### PR TITLE
swaps: support immediate failed in-swap refunds

### DIFF
--- a/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
@@ -127,6 +127,20 @@ func generatedRegistry() []serviceSpec {
 					Comments: "SendOOR initiates an out-of-round transfer directly between the\nclient and operator, without waiting for a round.",
 				},
 				{
+					Name:     "PrepareOOR",
+					Aliases:  []string{"prepare-oor"},
+					Input:    "daemonrpc.PrepareOORRequest",
+					Output:   "daemonrpc.PrepareOORResponse",
+					Comments: "PrepareOOR builds the deterministic OOR package without submitting it.\nThis lets callers collect signatures from external custom-input\nparticipants before calling SendOOR with the same parameters.",
+				},
+				{
+					Name:     "SignOORCustomInput",
+					Aliases:  []string{"sign-oor-custom-input"},
+					Input:    "daemonrpc.SignOORCustomInputRequest",
+					Output:   "daemonrpc.SignOORCustomInputResponse",
+					Comments: "SignOORCustomInput signs one prepared custom OOR checkpoint input with\nthe daemon identity key.",
+				},
+				{
 					Name:     "RefreshVTXOs",
 					Aliases:  []string{"refresh-vtxos"},
 					Input:    "daemonrpc.RefreshVTXOsRequest",

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -2952,9 +2952,14 @@ type CustomOORInput struct {
 	// amount_sat is the VTXO value in satoshis.
 	AmountSat int64 `protobuf:"varint,4,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
 	// pk_script is the VTXO taproot output script.
-	PkScript      []byte `protobuf:"bytes,5,opt,name=pk_script,json=pkScript,proto3" json:"pk_script,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	PkScript []byte `protobuf:"bytes,5,opt,name=pk_script,json=pkScript,proto3" json:"pk_script,omitempty"`
+	// external_signatures are taproot script-spend signatures produced by
+	// other parties required by the selected spend path. The local daemon still
+	// validates the policy/spend-path binding and adds its own signature before
+	// assembling the final witness.
+	ExternalSignatures []*TaprootScriptSignature `protobuf:"bytes,6,rep,name=external_signatures,json=externalSignatures,proto3" json:"external_signatures,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *CustomOORInput) Reset() {
@@ -3022,6 +3027,89 @@ func (x *CustomOORInput) GetPkScript() []byte {
 	return nil
 }
 
+func (x *CustomOORInput) GetExternalSignatures() []*TaprootScriptSignature {
+	if x != nil {
+		return x.ExternalSignatures
+	}
+	return nil
+}
+
+// TaprootScriptSignature carries one externally produced tapscript signature
+// for a custom OOR input. Keep this in sync with
+// swaprpc.TaprootScriptSignature.
+type TaprootScriptSignature struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// pubkey is the compressed public key that produced the signature.
+	Pubkey []byte `protobuf:"bytes,1,opt,name=pubkey,proto3" json:"pubkey,omitempty"`
+	// witness_script is the tapscript leaf this signature commits to.
+	WitnessScript []byte `protobuf:"bytes,2,opt,name=witness_script,json=witnessScript,proto3" json:"witness_script,omitempty"`
+	// signature is the raw Schnorr signature, optionally followed by a one-byte
+	// sighash type when the sighash is not SIGHASH_DEFAULT.
+	Signature []byte `protobuf:"bytes,3,opt,name=signature,proto3" json:"signature,omitempty"`
+	// sighash is the tapscript sighash type. Zero means SIGHASH_DEFAULT.
+	Sighash       uint32 `protobuf:"varint,4,opt,name=sighash,proto3" json:"sighash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TaprootScriptSignature) Reset() {
+	*x = TaprootScriptSignature{}
+	mi := &file_daemon_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TaprootScriptSignature) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TaprootScriptSignature) ProtoMessage() {}
+
+func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TaprootScriptSignature.ProtoReflect.Descriptor instead.
+func (*TaprootScriptSignature) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *TaprootScriptSignature) GetPubkey() []byte {
+	if x != nil {
+		return x.Pubkey
+	}
+	return nil
+}
+
+func (x *TaprootScriptSignature) GetWitnessScript() []byte {
+	if x != nil {
+		return x.WitnessScript
+	}
+	return nil
+}
+
+func (x *TaprootScriptSignature) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
+func (x *TaprootScriptSignature) GetSighash() uint32 {
+	if x != nil {
+		return x.Sighash
+	}
+	return 0
+}
+
 type SendOORResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// status is the result: "submitted" on success, "preview" on
@@ -3035,7 +3123,7 @@ type SendOORResponse struct {
 
 func (x *SendOORResponse) Reset() {
 	*x = SendOORResponse{}
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3047,7 +3135,7 @@ func (x *SendOORResponse) String() string {
 func (*SendOORResponse) ProtoMessage() {}
 
 func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3060,7 +3148,7 @@ func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORResponse.ProtoReflect.Descriptor instead.
 func (*SendOORResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{35}
+	return file_daemon_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *SendOORResponse) GetStatus() string {
@@ -3077,6 +3165,308 @@ func (x *SendOORResponse) GetSessionId() string {
 	return ""
 }
 
+type PrepareOORRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// recipient is the output to create via the out-of-round transfer.
+	Recipient *Output `protobuf:"bytes,1,opt,name=recipient,proto3" json:"recipient,omitempty"`
+	// custom_inputs are caller-specified inputs. PrepareOOR currently only
+	// supports custom inputs because wallet-selected inputs would need wallet
+	// locks and therefore would not be side-effect free.
+	CustomInputs  []*CustomOORInput `protobuf:"bytes,2,rep,name=custom_inputs,json=customInputs,proto3" json:"custom_inputs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareOORRequest) Reset() {
+	*x = PrepareOORRequest{}
+	mi := &file_daemon_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareOORRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareOORRequest) ProtoMessage() {}
+
+func (x *PrepareOORRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareOORRequest.ProtoReflect.Descriptor instead.
+func (*PrepareOORRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *PrepareOORRequest) GetRecipient() *Output {
+	if x != nil {
+		return x.Recipient
+	}
+	return nil
+}
+
+func (x *PrepareOORRequest) GetCustomInputs() []*CustomOORInput {
+	if x != nil {
+		return x.CustomInputs
+	}
+	return nil
+}
+
+type PreparedOORCustomInput struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// outpoint identifies the custom input this signing data belongs to.
+	Outpoint string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	// checkpoint_psbt is the serialized unsigned checkpoint PSBT whose input
+	// spends the custom VTXO.
+	CheckpointPsbt []byte `protobuf:"bytes,2,opt,name=checkpoint_psbt,json=checkpointPsbt,proto3" json:"checkpoint_psbt,omitempty"`
+	// witness_script is the tapscript leaf external parties must sign.
+	WitnessScript []byte `protobuf:"bytes,3,opt,name=witness_script,json=witnessScript,proto3" json:"witness_script,omitempty"`
+	// signing_pubkeys are the compressed public keys required by the spend
+	// path in script order.
+	SigningPubkeys [][]byte `protobuf:"bytes,4,rep,name=signing_pubkeys,json=signingPubkeys,proto3" json:"signing_pubkeys,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *PreparedOORCustomInput) Reset() {
+	*x = PreparedOORCustomInput{}
+	mi := &file_daemon_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PreparedOORCustomInput) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PreparedOORCustomInput) ProtoMessage() {}
+
+func (x *PreparedOORCustomInput) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PreparedOORCustomInput.ProtoReflect.Descriptor instead.
+func (*PreparedOORCustomInput) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *PreparedOORCustomInput) GetOutpoint() string {
+	if x != nil {
+		return x.Outpoint
+	}
+	return ""
+}
+
+func (x *PreparedOORCustomInput) GetCheckpointPsbt() []byte {
+	if x != nil {
+		return x.CheckpointPsbt
+	}
+	return nil
+}
+
+func (x *PreparedOORCustomInput) GetWitnessScript() []byte {
+	if x != nil {
+		return x.WitnessScript
+	}
+	return nil
+}
+
+func (x *PreparedOORCustomInput) GetSigningPubkeys() [][]byte {
+	if x != nil {
+		return x.SigningPubkeys
+	}
+	return nil
+}
+
+type PrepareOORResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ark_psbt is the serialized unsigned Ark PSBT that would be submitted.
+	ArkPsbt []byte `protobuf:"bytes,1,opt,name=ark_psbt,json=arkPsbt,proto3" json:"ark_psbt,omitempty"`
+	// checkpoint_psbts are the serialized unsigned checkpoint PSBTs that would
+	// be submitted.
+	CheckpointPsbts [][]byte `protobuf:"bytes,2,rep,name=checkpoint_psbts,json=checkpointPsbts,proto3" json:"checkpoint_psbts,omitempty"`
+	// custom_inputs contains signing data for each prepared custom input.
+	CustomInputs []*PreparedOORCustomInput `protobuf:"bytes,3,rep,name=custom_inputs,json=customInputs,proto3" json:"custom_inputs,omitempty"`
+	// session_id is the deterministic OOR session id derived from ark_psbt.
+	SessionId     string `protobuf:"bytes,4,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareOORResponse) Reset() {
+	*x = PrepareOORResponse{}
+	mi := &file_daemon_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareOORResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareOORResponse) ProtoMessage() {}
+
+func (x *PrepareOORResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareOORResponse.ProtoReflect.Descriptor instead.
+func (*PrepareOORResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *PrepareOORResponse) GetArkPsbt() []byte {
+	if x != nil {
+		return x.ArkPsbt
+	}
+	return nil
+}
+
+func (x *PrepareOORResponse) GetCheckpointPsbts() [][]byte {
+	if x != nil {
+		return x.CheckpointPsbts
+	}
+	return nil
+}
+
+func (x *PrepareOORResponse) GetCustomInputs() []*PreparedOORCustomInput {
+	if x != nil {
+		return x.CustomInputs
+	}
+	return nil
+}
+
+func (x *PrepareOORResponse) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+type SignOORCustomInputRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// custom_input describes the vHTLC/custom VTXO and selected spend path.
+	CustomInput *CustomOORInput `protobuf:"bytes,1,opt,name=custom_input,json=customInput,proto3" json:"custom_input,omitempty"`
+	// checkpoint_psbt is the prepared checkpoint PSBT to sign.
+	CheckpointPsbt []byte `protobuf:"bytes,2,opt,name=checkpoint_psbt,json=checkpointPsbt,proto3" json:"checkpoint_psbt,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *SignOORCustomInputRequest) Reset() {
+	*x = SignOORCustomInputRequest{}
+	mi := &file_daemon_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignOORCustomInputRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignOORCustomInputRequest) ProtoMessage() {}
+
+func (x *SignOORCustomInputRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignOORCustomInputRequest.ProtoReflect.Descriptor instead.
+func (*SignOORCustomInputRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *SignOORCustomInputRequest) GetCustomInput() *CustomOORInput {
+	if x != nil {
+		return x.CustomInput
+	}
+	return nil
+}
+
+func (x *SignOORCustomInputRequest) GetCheckpointPsbt() []byte {
+	if x != nil {
+		return x.CheckpointPsbt
+	}
+	return nil
+}
+
+type SignOORCustomInputResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// signature is the daemon identity key's tapscript signature.
+	Signature     *TaprootScriptSignature `protobuf:"bytes,1,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignOORCustomInputResponse) Reset() {
+	*x = SignOORCustomInputResponse{}
+	mi := &file_daemon_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignOORCustomInputResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignOORCustomInputResponse) ProtoMessage() {}
+
+func (x *SignOORCustomInputResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignOORCustomInputResponse.ProtoReflect.Descriptor instead.
+func (*SignOORCustomInputResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *SignOORCustomInputResponse) GetSignature() *TaprootScriptSignature {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
 // OutpointSelection wraps a list of outpoint strings for use inside a
 // oneof field, since proto3 does not allow repeated fields directly in
 // a oneof.
@@ -3090,7 +3480,7 @@ type OutpointSelection struct {
 
 func (x *OutpointSelection) Reset() {
 	*x = OutpointSelection{}
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3102,7 +3492,7 @@ func (x *OutpointSelection) String() string {
 func (*OutpointSelection) ProtoMessage() {}
 
 func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3115,7 +3505,7 @@ func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutpointSelection.ProtoReflect.Descriptor instead.
 func (*OutpointSelection) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{36}
+	return file_daemon_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *OutpointSelection) GetOutpoints() []string {
@@ -3140,7 +3530,7 @@ type RefreshVTXOsRequest struct {
 
 func (x *RefreshVTXOsRequest) Reset() {
 	*x = RefreshVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3152,7 +3542,7 @@ func (x *RefreshVTXOsRequest) String() string {
 func (*RefreshVTXOsRequest) ProtoMessage() {}
 
 func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3165,7 +3555,7 @@ func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{37}
+	return file_daemon_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *RefreshVTXOsRequest) GetSelection() isRefreshVTXOsRequest_Selection {
@@ -3232,7 +3622,7 @@ type RefreshVTXOsResponse struct {
 
 func (x *RefreshVTXOsResponse) Reset() {
 	*x = RefreshVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3244,7 +3634,7 @@ func (x *RefreshVTXOsResponse) String() string {
 func (*RefreshVTXOsResponse) ProtoMessage() {}
 
 func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3257,7 +3647,7 @@ func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{38}
+	return file_daemon_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *RefreshVTXOsResponse) GetQueuedOutpoints() []string {
@@ -3291,7 +3681,7 @@ type LeaveDestination struct {
 
 func (x *LeaveDestination) Reset() {
 	*x = LeaveDestination{}
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3303,7 +3693,7 @@ func (x *LeaveDestination) String() string {
 func (*LeaveDestination) ProtoMessage() {}
 
 func (x *LeaveDestination) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3316,7 +3706,7 @@ func (x *LeaveDestination) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveDestination.ProtoReflect.Descriptor instead.
 func (*LeaveDestination) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{39}
+	return file_daemon_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *LeaveDestination) GetTarget() isLeaveDestination_Target {
@@ -3397,7 +3787,7 @@ type LeaveVTXOsRequest struct {
 
 func (x *LeaveVTXOsRequest) Reset() {
 	*x = LeaveVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3409,7 +3799,7 @@ func (x *LeaveVTXOsRequest) String() string {
 func (*LeaveVTXOsRequest) ProtoMessage() {}
 
 func (x *LeaveVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3422,7 +3812,7 @@ func (x *LeaveVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*LeaveVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{40}
+	return file_daemon_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *LeaveVTXOsRequest) GetSelection() isLeaveVTXOsRequest_Selection {
@@ -3505,7 +3895,7 @@ type LeaveVTXOsResponse struct {
 
 func (x *LeaveVTXOsResponse) Reset() {
 	*x = LeaveVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3517,7 +3907,7 @@ func (x *LeaveVTXOsResponse) String() string {
 func (*LeaveVTXOsResponse) ProtoMessage() {}
 
 func (x *LeaveVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3530,7 +3920,7 @@ func (x *LeaveVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*LeaveVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{41}
+	return file_daemon_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *LeaveVTXOsResponse) GetQueuedOutpoints() []string {
@@ -3568,7 +3958,7 @@ type BoardRequest struct {
 
 func (x *BoardRequest) Reset() {
 	*x = BoardRequest{}
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3580,7 +3970,7 @@ func (x *BoardRequest) String() string {
 func (*BoardRequest) ProtoMessage() {}
 
 func (x *BoardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3593,7 +3983,7 @@ func (x *BoardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardRequest.ProtoReflect.Descriptor instead.
 func (*BoardRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{42}
+	return file_daemon_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *BoardRequest) GetTargetVtxoCount() uint32 {
@@ -3624,7 +4014,7 @@ type BoardResponse struct {
 
 func (x *BoardResponse) Reset() {
 	*x = BoardResponse{}
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3636,7 +4026,7 @@ func (x *BoardResponse) String() string {
 func (*BoardResponse) ProtoMessage() {}
 
 func (x *BoardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3649,7 +4039,7 @@ func (x *BoardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardResponse.ProtoReflect.Descriptor instead.
 func (*BoardResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{43}
+	return file_daemon_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *BoardResponse) GetStatus() string {
@@ -3674,7 +4064,7 @@ type JoinNextRoundRequest struct {
 
 func (x *JoinNextRoundRequest) Reset() {
 	*x = JoinNextRoundRequest{}
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3686,7 +4076,7 @@ func (x *JoinNextRoundRequest) String() string {
 func (*JoinNextRoundRequest) ProtoMessage() {}
 
 func (x *JoinNextRoundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3699,7 +4089,7 @@ func (x *JoinNextRoundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinNextRoundRequest.ProtoReflect.Descriptor instead.
 func (*JoinNextRoundRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{44}
+	return file_daemon_proto_rawDescGZIP(), []int{50}
 }
 
 type JoinNextRoundResponse struct {
@@ -3714,7 +4104,7 @@ type JoinNextRoundResponse struct {
 
 func (x *JoinNextRoundResponse) Reset() {
 	*x = JoinNextRoundResponse{}
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3726,7 +4116,7 @@ func (x *JoinNextRoundResponse) String() string {
 func (*JoinNextRoundResponse) ProtoMessage() {}
 
 func (x *JoinNextRoundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3739,7 +4129,7 @@ func (x *JoinNextRoundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinNextRoundResponse.ProtoReflect.Descriptor instead.
 func (*JoinNextRoundResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{45}
+	return file_daemon_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *JoinNextRoundResponse) GetStatus() string {
@@ -3775,7 +4165,7 @@ type SweepBoardingUTXOsRequest struct {
 
 func (x *SweepBoardingUTXOsRequest) Reset() {
 	*x = SweepBoardingUTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3787,7 +4177,7 @@ func (x *SweepBoardingUTXOsRequest) String() string {
 func (*SweepBoardingUTXOsRequest) ProtoMessage() {}
 
 func (x *SweepBoardingUTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3800,7 +4190,7 @@ func (x *SweepBoardingUTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepBoardingUTXOsRequest.ProtoReflect.Descriptor instead.
 func (*SweepBoardingUTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{46}
+	return file_daemon_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *SweepBoardingUTXOsRequest) GetOutpoints() []string {
@@ -3853,7 +4243,7 @@ type BoardingSweepOutput struct {
 
 func (x *BoardingSweepOutput) Reset() {
 	*x = BoardingSweepOutput{}
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3865,7 +4255,7 @@ func (x *BoardingSweepOutput) String() string {
 func (*BoardingSweepOutput) ProtoMessage() {}
 
 func (x *BoardingSweepOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3878,7 +4268,7 @@ func (x *BoardingSweepOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweepOutput.ProtoReflect.Descriptor instead.
 func (*BoardingSweepOutput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{47}
+	return file_daemon_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *BoardingSweepOutput) GetOutpoint() string {
@@ -3944,7 +4334,7 @@ type SweepBoardingUTXOsResponse struct {
 
 func (x *SweepBoardingUTXOsResponse) Reset() {
 	*x = SweepBoardingUTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3956,7 +4346,7 @@ func (x *SweepBoardingUTXOsResponse) String() string {
 func (*SweepBoardingUTXOsResponse) ProtoMessage() {}
 
 func (x *SweepBoardingUTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3969,7 +4359,7 @@ func (x *SweepBoardingUTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepBoardingUTXOsResponse.ProtoReflect.Descriptor instead.
 func (*SweepBoardingUTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{48}
+	return file_daemon_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *SweepBoardingUTXOsResponse) GetStatus() string {
@@ -4073,7 +4463,7 @@ type ListBoardingSweepsRequest struct {
 
 func (x *ListBoardingSweepsRequest) Reset() {
 	*x = ListBoardingSweepsRequest{}
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4085,7 +4475,7 @@ func (x *ListBoardingSweepsRequest) String() string {
 func (*ListBoardingSweepsRequest) ProtoMessage() {}
 
 func (x *ListBoardingSweepsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4098,7 +4488,7 @@ func (x *ListBoardingSweepsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBoardingSweepsRequest.ProtoReflect.Descriptor instead.
 func (*ListBoardingSweepsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{49}
+	return file_daemon_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *ListBoardingSweepsRequest) GetStatus() string {
@@ -4141,7 +4531,7 @@ type BoardingSweepInput struct {
 
 func (x *BoardingSweepInput) Reset() {
 	*x = BoardingSweepInput{}
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4153,7 +4543,7 @@ func (x *BoardingSweepInput) String() string {
 func (*BoardingSweepInput) ProtoMessage() {}
 
 func (x *BoardingSweepInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4166,7 +4556,7 @@ func (x *BoardingSweepInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweepInput.ProtoReflect.Descriptor instead.
 func (*BoardingSweepInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{50}
+	return file_daemon_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *BoardingSweepInput) GetOutpoint() string {
@@ -4236,7 +4626,7 @@ type BoardingSweep struct {
 
 func (x *BoardingSweep) Reset() {
 	*x = BoardingSweep{}
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4248,7 +4638,7 @@ func (x *BoardingSweep) String() string {
 func (*BoardingSweep) ProtoMessage() {}
 
 func (x *BoardingSweep) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4261,7 +4651,7 @@ func (x *BoardingSweep) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweep.ProtoReflect.Descriptor instead.
 func (*BoardingSweep) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{51}
+	return file_daemon_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *BoardingSweep) GetTxid() string {
@@ -4353,7 +4743,7 @@ type ListBoardingSweepsResponse struct {
 
 func (x *ListBoardingSweepsResponse) Reset() {
 	*x = ListBoardingSweepsResponse{}
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4365,7 +4755,7 @@ func (x *ListBoardingSweepsResponse) String() string {
 func (*ListBoardingSweepsResponse) ProtoMessage() {}
 
 func (x *ListBoardingSweepsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4378,7 +4768,7 @@ func (x *ListBoardingSweepsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBoardingSweepsResponse.ProtoReflect.Descriptor instead.
 func (*ListBoardingSweepsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{52}
+	return file_daemon_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *ListBoardingSweepsResponse) GetSweeps() []*BoardingSweep {
@@ -4408,7 +4798,7 @@ type RoundVTXOInfo struct {
 
 func (x *RoundVTXOInfo) Reset() {
 	*x = RoundVTXOInfo{}
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4420,7 +4810,7 @@ func (x *RoundVTXOInfo) String() string {
 func (*RoundVTXOInfo) ProtoMessage() {}
 
 func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4433,7 +4823,7 @@ func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundVTXOInfo.ProtoReflect.Descriptor instead.
 func (*RoundVTXOInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{53}
+	return file_daemon_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *RoundVTXOInfo) GetOutpoint() string {
@@ -4501,7 +4891,7 @@ type RoundInfo struct {
 
 func (x *RoundInfo) Reset() {
 	*x = RoundInfo{}
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4513,7 +4903,7 @@ func (x *RoundInfo) String() string {
 func (*RoundInfo) ProtoMessage() {}
 
 func (x *RoundInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4526,7 +4916,7 @@ func (x *RoundInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundInfo.ProtoReflect.Descriptor instead.
 func (*RoundInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{54}
+	return file_daemon_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *RoundInfo) GetRoundId() string {
@@ -4638,7 +5028,7 @@ type ListRoundsRequest struct {
 
 func (x *ListRoundsRequest) Reset() {
 	*x = ListRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4650,7 +5040,7 @@ func (x *ListRoundsRequest) String() string {
 func (*ListRoundsRequest) ProtoMessage() {}
 
 func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4663,7 +5053,7 @@ func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{55}
+	return file_daemon_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *ListRoundsRequest) GetPageSize() int32 {
@@ -4718,7 +5108,7 @@ type GetRoundRequest struct {
 
 func (x *GetRoundRequest) Reset() {
 	*x = GetRoundRequest{}
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4730,7 +5120,7 @@ func (x *GetRoundRequest) String() string {
 func (*GetRoundRequest) ProtoMessage() {}
 
 func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4743,7 +5133,7 @@ func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundRequest.ProtoReflect.Descriptor instead.
 func (*GetRoundRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{56}
+	return file_daemon_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *GetRoundRequest) GetRoundId() string {
@@ -4763,7 +5153,7 @@ type GetRoundResponse struct {
 
 func (x *GetRoundResponse) Reset() {
 	*x = GetRoundResponse{}
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4775,7 +5165,7 @@ func (x *GetRoundResponse) String() string {
 func (*GetRoundResponse) ProtoMessage() {}
 
 func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4788,7 +5178,7 @@ func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundResponse.ProtoReflect.Descriptor instead.
 func (*GetRoundResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{57}
+	return file_daemon_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *GetRoundResponse) GetRound() *RoundInfo {
@@ -4811,7 +5201,7 @@ type ListRoundsResponse struct {
 
 func (x *ListRoundsResponse) Reset() {
 	*x = ListRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4823,7 +5213,7 @@ func (x *ListRoundsResponse) String() string {
 func (*ListRoundsResponse) ProtoMessage() {}
 
 func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4836,7 +5226,7 @@ func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{58}
+	return file_daemon_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *ListRoundsResponse) GetRounds() []*RoundInfo {
@@ -4861,7 +5251,7 @@ type WatchRoundsRequest struct {
 
 func (x *WatchRoundsRequest) Reset() {
 	*x = WatchRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4873,7 +5263,7 @@ func (x *WatchRoundsRequest) String() string {
 func (*WatchRoundsRequest) ProtoMessage() {}
 
 func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4886,7 +5276,7 @@ func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsRequest.ProtoReflect.Descriptor instead.
 func (*WatchRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{59}
+	return file_daemon_proto_rawDescGZIP(), []int{65}
 }
 
 type WatchRoundsResponse struct {
@@ -4900,7 +5290,7 @@ type WatchRoundsResponse struct {
 
 func (x *WatchRoundsResponse) Reset() {
 	*x = WatchRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4912,7 +5302,7 @@ func (x *WatchRoundsResponse) String() string {
 func (*WatchRoundsResponse) ProtoMessage() {}
 
 func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4925,7 +5315,7 @@ func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsResponse.ProtoReflect.Descriptor instead.
 func (*WatchRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{60}
+	return file_daemon_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *WatchRoundsResponse) GetRound() *RoundInfo {
@@ -4963,7 +5353,7 @@ type OORSessionInfo struct {
 
 func (x *OORSessionInfo) Reset() {
 	*x = OORSessionInfo{}
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4975,7 +5365,7 @@ func (x *OORSessionInfo) String() string {
 func (*OORSessionInfo) ProtoMessage() {}
 
 func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4988,7 +5378,7 @@ func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OORSessionInfo.ProtoReflect.Descriptor instead.
 func (*OORSessionInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{61}
+	return file_daemon_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *OORSessionInfo) GetSessionId() string {
@@ -5072,7 +5462,7 @@ type ListOORSessionsRequest struct {
 
 func (x *ListOORSessionsRequest) Reset() {
 	*x = ListOORSessionsRequest{}
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5084,7 +5474,7 @@ func (x *ListOORSessionsRequest) String() string {
 func (*ListOORSessionsRequest) ProtoMessage() {}
 
 func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5097,7 +5487,7 @@ func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{62}
+	return file_daemon_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *ListOORSessionsRequest) GetPageSize() int32 {
@@ -5141,7 +5531,7 @@ type ListOORSessionsResponse struct {
 
 func (x *ListOORSessionsResponse) Reset() {
 	*x = ListOORSessionsResponse{}
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5153,7 +5543,7 @@ func (x *ListOORSessionsResponse) String() string {
 func (*ListOORSessionsResponse) ProtoMessage() {}
 
 func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5166,7 +5556,7 @@ func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{63}
+	return file_daemon_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *ListOORSessionsResponse) GetSessions() []*OORSessionInfo {
@@ -5193,7 +5583,7 @@ type GetOORSessionRequest struct {
 
 func (x *GetOORSessionRequest) Reset() {
 	*x = GetOORSessionRequest{}
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5205,7 +5595,7 @@ func (x *GetOORSessionRequest) String() string {
 func (*GetOORSessionRequest) ProtoMessage() {}
 
 func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5218,7 +5608,7 @@ func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionRequest.ProtoReflect.Descriptor instead.
 func (*GetOORSessionRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{64}
+	return file_daemon_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *GetOORSessionRequest) GetSessionId() string {
@@ -5238,7 +5628,7 @@ type GetOORSessionResponse struct {
 
 func (x *GetOORSessionResponse) Reset() {
 	*x = GetOORSessionResponse{}
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5250,7 +5640,7 @@ func (x *GetOORSessionResponse) String() string {
 func (*GetOORSessionResponse) ProtoMessage() {}
 
 func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5263,7 +5653,7 @@ func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionResponse.ProtoReflect.Descriptor instead.
 func (*GetOORSessionResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{65}
+	return file_daemon_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *GetOORSessionResponse) GetSession() *OORSessionInfo {
@@ -5291,7 +5681,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_daemon_proto_msgTypes[66]
+	mi := &file_daemon_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5303,7 +5693,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[66]
+	mi := &file_daemon_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5316,7 +5706,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{66}
+	return file_daemon_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *EstimateFeeRequest) GetAmountSat() int64 {
@@ -5370,7 +5760,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_daemon_proto_msgTypes[67]
+	mi := &file_daemon_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5382,7 +5772,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[67]
+	mi := &file_daemon_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5395,7 +5785,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{67}
+	return file_daemon_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *EstimateFeeResponse) GetLiquidityFeeSat() int64 {
@@ -5465,7 +5855,7 @@ type GetFeeHistoryRequest struct {
 
 func (x *GetFeeHistoryRequest) Reset() {
 	*x = GetFeeHistoryRequest{}
-	mi := &file_daemon_proto_msgTypes[68]
+	mi := &file_daemon_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5477,7 +5867,7 @@ func (x *GetFeeHistoryRequest) String() string {
 func (*GetFeeHistoryRequest) ProtoMessage() {}
 
 func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[68]
+	mi := &file_daemon_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5490,7 +5880,7 @@ func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryRequest.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{68}
+	return file_daemon_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *GetFeeHistoryRequest) GetLimit() uint32 {
@@ -5565,7 +5955,7 @@ type FeeHistoryEntry struct {
 
 func (x *FeeHistoryEntry) Reset() {
 	*x = FeeHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5577,7 +5967,7 @@ func (x *FeeHistoryEntry) String() string {
 func (*FeeHistoryEntry) ProtoMessage() {}
 
 func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5590,7 +5980,7 @@ func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeHistoryEntry.ProtoReflect.Descriptor instead.
 func (*FeeHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{69}
+	return file_daemon_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *FeeHistoryEntry) GetEntryId() int64 {
@@ -5670,7 +6060,7 @@ type GetFeeHistoryResponse struct {
 
 func (x *GetFeeHistoryResponse) Reset() {
 	*x = GetFeeHistoryResponse{}
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5682,7 +6072,7 @@ func (x *GetFeeHistoryResponse) String() string {
 func (*GetFeeHistoryResponse) ProtoMessage() {}
 
 func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5695,7 +6085,7 @@ func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryResponse.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{70}
+	return file_daemon_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *GetFeeHistoryResponse) GetEntries() []*FeeHistoryEntry {
@@ -5736,7 +6126,7 @@ type ListTransactionsRequest struct {
 
 func (x *ListTransactionsRequest) Reset() {
 	*x = ListTransactionsRequest{}
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5748,7 +6138,7 @@ func (x *ListTransactionsRequest) String() string {
 func (*ListTransactionsRequest) ProtoMessage() {}
 
 func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5761,7 +6151,7 @@ func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsRequest.ProtoReflect.Descriptor instead.
 func (*ListTransactionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{71}
+	return file_daemon_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *ListTransactionsRequest) GetFromUnixS() int64 {
@@ -5847,7 +6237,7 @@ type TransactionHistoryEntry struct {
 
 func (x *TransactionHistoryEntry) Reset() {
 	*x = TransactionHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5859,7 +6249,7 @@ func (x *TransactionHistoryEntry) String() string {
 func (*TransactionHistoryEntry) ProtoMessage() {}
 
 func (x *TransactionHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5872,7 +6262,7 @@ func (x *TransactionHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionHistoryEntry.ProtoReflect.Descriptor instead.
 func (*TransactionHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{72}
+	return file_daemon_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *TransactionHistoryEntry) GetSource() string {
@@ -6002,7 +6392,7 @@ type ListTransactionsResponse struct {
 
 func (x *ListTransactionsResponse) Reset() {
 	*x = ListTransactionsResponse{}
-	mi := &file_daemon_proto_msgTypes[73]
+	mi := &file_daemon_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6014,7 +6404,7 @@ func (x *ListTransactionsResponse) String() string {
 func (*ListTransactionsResponse) ProtoMessage() {}
 
 func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[73]
+	mi := &file_daemon_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6027,7 +6417,7 @@ func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsResponse.ProtoReflect.Descriptor instead.
 func (*ListTransactionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{73}
+	return file_daemon_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *ListTransactionsResponse) GetTransactions() []*TransactionHistoryEntry {
@@ -6062,7 +6452,7 @@ type UnrollRequest struct {
 
 func (x *UnrollRequest) Reset() {
 	*x = UnrollRequest{}
-	mi := &file_daemon_proto_msgTypes[74]
+	mi := &file_daemon_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6074,7 +6464,7 @@ func (x *UnrollRequest) String() string {
 func (*UnrollRequest) ProtoMessage() {}
 
 func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[74]
+	mi := &file_daemon_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6087,7 +6477,7 @@ func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollRequest.ProtoReflect.Descriptor instead.
 func (*UnrollRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{74}
+	return file_daemon_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *UnrollRequest) GetOutpoint() string {
@@ -6110,7 +6500,7 @@ type UnrollResponse struct {
 
 func (x *UnrollResponse) Reset() {
 	*x = UnrollResponse{}
-	mi := &file_daemon_proto_msgTypes[75]
+	mi := &file_daemon_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6122,7 +6512,7 @@ func (x *UnrollResponse) String() string {
 func (*UnrollResponse) ProtoMessage() {}
 
 func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[75]
+	mi := &file_daemon_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6135,7 +6525,7 @@ func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollResponse.ProtoReflect.Descriptor instead.
 func (*UnrollResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{75}
+	return file_daemon_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *UnrollResponse) GetCreated() bool {
@@ -6162,7 +6552,7 @@ type GetUnrollStatusRequest struct {
 
 func (x *GetUnrollStatusRequest) Reset() {
 	*x = GetUnrollStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[76]
+	mi := &file_daemon_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6174,7 +6564,7 @@ func (x *GetUnrollStatusRequest) String() string {
 func (*GetUnrollStatusRequest) ProtoMessage() {}
 
 func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[76]
+	mi := &file_daemon_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6187,7 +6577,7 @@ func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{76}
+	return file_daemon_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *GetUnrollStatusRequest) GetOutpoint() string {
@@ -6215,7 +6605,7 @@ type GetUnrollStatusResponse struct {
 
 func (x *GetUnrollStatusResponse) Reset() {
 	*x = GetUnrollStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[77]
+	mi := &file_daemon_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6227,7 +6617,7 @@ func (x *GetUnrollStatusResponse) String() string {
 func (*GetUnrollStatusResponse) ProtoMessage() {}
 
 func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[77]
+	mi := &file_daemon_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6240,7 +6630,7 @@ func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{77}
+	return file_daemon_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *GetUnrollStatusResponse) GetFound() bool {
@@ -6322,7 +6712,7 @@ type ArmVHTLCRecoveryRequest struct {
 
 func (x *ArmVHTLCRecoveryRequest) Reset() {
 	*x = ArmVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[78]
+	mi := &file_daemon_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6334,7 +6724,7 @@ func (x *ArmVHTLCRecoveryRequest) String() string {
 func (*ArmVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[78]
+	mi := &file_daemon_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6347,7 +6737,7 @@ func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{78}
+	return file_daemon_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *ArmVHTLCRecoveryRequest) GetRequestId() string {
@@ -6490,7 +6880,7 @@ type ArmVHTLCRecoveryResponse struct {
 
 func (x *ArmVHTLCRecoveryResponse) Reset() {
 	*x = ArmVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[79]
+	mi := &file_daemon_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6502,7 +6892,7 @@ func (x *ArmVHTLCRecoveryResponse) String() string {
 func (*ArmVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[79]
+	mi := &file_daemon_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6515,7 +6905,7 @@ func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{79}
+	return file_daemon_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *ArmVHTLCRecoveryResponse) GetRecoveryId() string {
@@ -6555,7 +6945,7 @@ type EscalateVHTLCRecoveryRequest struct {
 
 func (x *EscalateVHTLCRecoveryRequest) Reset() {
 	*x = EscalateVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[80]
+	mi := &file_daemon_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6567,7 +6957,7 @@ func (x *EscalateVHTLCRecoveryRequest) String() string {
 func (*EscalateVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[80]
+	mi := &file_daemon_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6580,7 +6970,7 @@ func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{80}
+	return file_daemon_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *EscalateVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -6614,7 +7004,7 @@ type EscalateVHTLCRecoveryResponse struct {
 
 func (x *EscalateVHTLCRecoveryResponse) Reset() {
 	*x = EscalateVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[81]
+	mi := &file_daemon_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6626,7 +7016,7 @@ func (x *EscalateVHTLCRecoveryResponse) String() string {
 func (*EscalateVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[81]
+	mi := &file_daemon_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6639,7 +7029,7 @@ func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{81}
+	return file_daemon_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *EscalateVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -6663,7 +7053,7 @@ type CancelVHTLCRecoveryRequest struct {
 
 func (x *CancelVHTLCRecoveryRequest) Reset() {
 	*x = CancelVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[82]
+	mi := &file_daemon_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6675,7 +7065,7 @@ func (x *CancelVHTLCRecoveryRequest) String() string {
 func (*CancelVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[82]
+	mi := &file_daemon_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6688,7 +7078,7 @@ func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{82}
+	return file_daemon_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *CancelVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -6722,7 +7112,7 @@ type CancelVHTLCRecoveryResponse struct {
 
 func (x *CancelVHTLCRecoveryResponse) Reset() {
 	*x = CancelVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[83]
+	mi := &file_daemon_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6734,7 +7124,7 @@ func (x *CancelVHTLCRecoveryResponse) String() string {
 func (*CancelVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[83]
+	mi := &file_daemon_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6747,7 +7137,7 @@ func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{83}
+	return file_daemon_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *CancelVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -6767,7 +7157,7 @@ type GetVHTLCRecoveryStatusRequest struct {
 
 func (x *GetVHTLCRecoveryStatusRequest) Reset() {
 	*x = GetVHTLCRecoveryStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[84]
+	mi := &file_daemon_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6779,7 +7169,7 @@ func (x *GetVHTLCRecoveryStatusRequest) String() string {
 func (*GetVHTLCRecoveryStatusRequest) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[84]
+	mi := &file_daemon_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6792,7 +7182,7 @@ func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{84}
+	return file_daemon_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *GetVHTLCRecoveryStatusRequest) GetRecoveryId() string {
@@ -6814,7 +7204,7 @@ type GetVHTLCRecoveryStatusResponse struct {
 
 func (x *GetVHTLCRecoveryStatusResponse) Reset() {
 	*x = GetVHTLCRecoveryStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[85]
+	mi := &file_daemon_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6826,7 +7216,7 @@ func (x *GetVHTLCRecoveryStatusResponse) String() string {
 func (*GetVHTLCRecoveryStatusResponse) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[85]
+	mi := &file_daemon_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6839,7 +7229,7 @@ func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{85}
+	return file_daemon_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *GetVHTLCRecoveryStatusResponse) GetFound() bool {
@@ -6866,7 +7256,7 @@ type ListVHTLCRecoveriesRequest struct {
 
 func (x *ListVHTLCRecoveriesRequest) Reset() {
 	*x = ListVHTLCRecoveriesRequest{}
-	mi := &file_daemon_proto_msgTypes[86]
+	mi := &file_daemon_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6878,7 +7268,7 @@ func (x *ListVHTLCRecoveriesRequest) String() string {
 func (*ListVHTLCRecoveriesRequest) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[86]
+	mi := &file_daemon_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6891,7 +7281,7 @@ func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesRequest.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{86}
+	return file_daemon_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *ListVHTLCRecoveriesRequest) GetIncludeTerminal() bool {
@@ -6911,7 +7301,7 @@ type ListVHTLCRecoveriesResponse struct {
 
 func (x *ListVHTLCRecoveriesResponse) Reset() {
 	*x = ListVHTLCRecoveriesResponse{}
-	mi := &file_daemon_proto_msgTypes[87]
+	mi := &file_daemon_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6923,7 +7313,7 @@ func (x *ListVHTLCRecoveriesResponse) String() string {
 func (*ListVHTLCRecoveriesResponse) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[87]
+	mi := &file_daemon_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6936,7 +7326,7 @@ func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesResponse.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{87}
+	return file_daemon_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *ListVHTLCRecoveriesResponse) GetStatuses() []*VHTLCRecoveryStatus {
@@ -7011,7 +7401,7 @@ type VHTLCRecoveryStatus struct {
 
 func (x *VHTLCRecoveryStatus) Reset() {
 	*x = VHTLCRecoveryStatus{}
-	mi := &file_daemon_proto_msgTypes[88]
+	mi := &file_daemon_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7023,7 +7413,7 @@ func (x *VHTLCRecoveryStatus) String() string {
 func (*VHTLCRecoveryStatus) ProtoMessage() {}
 
 func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[88]
+	mi := &file_daemon_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7036,7 +7426,7 @@ func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VHTLCRecoveryStatus.ProtoReflect.Descriptor instead.
 func (*VHTLCRecoveryStatus) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{88}
+	return file_daemon_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *VHTLCRecoveryStatus) GetRecoveryId() string {
@@ -7367,7 +7757,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\trecipient\x18\x01 \x01(\v2\x11.daemonrpc.OutputR\trecipient\x12\x17\n" +
 	"\adry_run\x18\x02 \x01(\bR\x06dryRun\x12>\n" +
 	"\rcustom_inputs\x18\x03 \x03(\v2\x19.daemonrpc.CustomOORInputR\fcustomInputs\x12'\n" +
-	"\x0fidempotency_key\x18\x04 \x01(\tR\x0eidempotencyKey\"\xb9\x01\n" +
+	"\x0fidempotency_key\x18\x04 \x01(\tR\x0eidempotencyKey\"\x8d\x02\n" +
 	"\x0eCustomOORInput\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x120\n" +
 	"\x14vtxo_policy_template\x18\x02 \x01(\fR\x12vtxoPolicyTemplate\x12\x1d\n" +
@@ -7375,11 +7765,36 @@ const file_daemon_proto_rawDesc = "" +
 	"spend_path\x18\x03 \x01(\fR\tspendPath\x12\x1d\n" +
 	"\n" +
 	"amount_sat\x18\x04 \x01(\x03R\tamountSat\x12\x1b\n" +
-	"\tpk_script\x18\x05 \x01(\fR\bpkScript\"H\n" +
+	"\tpk_script\x18\x05 \x01(\fR\bpkScript\x12R\n" +
+	"\x13external_signatures\x18\x06 \x03(\v2!.daemonrpc.TaprootScriptSignatureR\x12externalSignatures\"\x8f\x01\n" +
+	"\x16TaprootScriptSignature\x12\x16\n" +
+	"\x06pubkey\x18\x01 \x01(\fR\x06pubkey\x12%\n" +
+	"\x0ewitness_script\x18\x02 \x01(\fR\rwitnessScript\x12\x1c\n" +
+	"\tsignature\x18\x03 \x01(\fR\tsignature\x12\x18\n" +
+	"\asighash\x18\x04 \x01(\rR\asighash\"H\n" +
 	"\x0fSendOORResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x02 \x01(\tR\tsessionId\"1\n" +
+	"session_id\x18\x02 \x01(\tR\tsessionId\"\x84\x01\n" +
+	"\x11PrepareOORRequest\x12/\n" +
+	"\trecipient\x18\x01 \x01(\v2\x11.daemonrpc.OutputR\trecipient\x12>\n" +
+	"\rcustom_inputs\x18\x02 \x03(\v2\x19.daemonrpc.CustomOORInputR\fcustomInputs\"\xad\x01\n" +
+	"\x16PreparedOORCustomInput\x12\x1a\n" +
+	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12'\n" +
+	"\x0fcheckpoint_psbt\x18\x02 \x01(\fR\x0echeckpointPsbt\x12%\n" +
+	"\x0ewitness_script\x18\x03 \x01(\fR\rwitnessScript\x12'\n" +
+	"\x0fsigning_pubkeys\x18\x04 \x03(\fR\x0esigningPubkeys\"\xc1\x01\n" +
+	"\x12PrepareOORResponse\x12\x19\n" +
+	"\bark_psbt\x18\x01 \x01(\fR\aarkPsbt\x12)\n" +
+	"\x10checkpoint_psbts\x18\x02 \x03(\fR\x0fcheckpointPsbts\x12F\n" +
+	"\rcustom_inputs\x18\x03 \x03(\v2!.daemonrpc.PreparedOORCustomInputR\fcustomInputs\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x04 \x01(\tR\tsessionId\"\x82\x01\n" +
+	"\x19SignOORCustomInputRequest\x12<\n" +
+	"\fcustom_input\x18\x01 \x01(\v2\x19.daemonrpc.CustomOORInputR\vcustomInput\x12'\n" +
+	"\x0fcheckpoint_psbt\x18\x02 \x01(\fR\x0echeckpointPsbt\"]\n" +
+	"\x1aSignOORCustomInputResponse\x12?\n" +
+	"\tsignature\x18\x01 \x01(\v2!.daemonrpc.TaprootScriptSignatureR\tsignature\"1\n" +
 	"\x11OutpointSelection\x12\x1c\n" +
 	"\toutpoints\x18\x01 \x03(\tR\toutpoints\"\x8d\x01\n" +
 	"\x13RefreshVTXOsRequest\x12<\n" +
@@ -7774,7 +8189,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1eVHTLC_RECOVERY_STATE_COMPLETED\x10\t\x12\"\n" +
 	"\x1eVHTLC_RECOVERY_STATE_CANCELLED\x10\n" +
 	"\x12\x1f\n" +
-	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\xa2\x19\n" +
+	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\xd0\x1a\n" +
 	"\rDaemonService\x12@\n" +
 	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
 	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
@@ -7794,7 +8209,10 @@ const file_daemon_proto_rawDesc = "" +
 	"\x18GetIndexedVTXOByPkScript\x12*.daemonrpc.GetIndexedVTXOByPkScriptRequest\x1a+.daemonrpc.GetIndexedVTXOByPkScriptResponse\x12y\n" +
 	"\x1aGetIndexedOORSessionByTxid\x12,.daemonrpc.GetIndexedOORSessionByTxidRequest\x1a-.daemonrpc.GetIndexedOORSessionByTxidResponse\x12C\n" +
 	"\bSendVTXO\x12\x1a.daemonrpc.SendVTXORequest\x1a\x1b.daemonrpc.SendVTXOResponse\x12@\n" +
-	"\aSendOOR\x12\x19.daemonrpc.SendOORRequest\x1a\x1a.daemonrpc.SendOORResponse\x12O\n" +
+	"\aSendOOR\x12\x19.daemonrpc.SendOORRequest\x1a\x1a.daemonrpc.SendOORResponse\x12I\n" +
+	"\n" +
+	"PrepareOOR\x12\x1c.daemonrpc.PrepareOORRequest\x1a\x1d.daemonrpc.PrepareOORResponse\x12a\n" +
+	"\x12SignOORCustomInput\x12$.daemonrpc.SignOORCustomInputRequest\x1a%.daemonrpc.SignOORCustomInputResponse\x12O\n" +
 	"\fRefreshVTXOs\x12\x1e.daemonrpc.RefreshVTXOsRequest\x1a\x1f.daemonrpc.RefreshVTXOsResponse\x12I\n" +
 	"\n" +
 	"LeaveVTXOs\x12\x1c.daemonrpc.LeaveVTXOsRequest\x1a\x1d.daemonrpc.LeaveVTXOsResponse\x12:\n" +
@@ -7832,7 +8250,7 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 90)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 96)
 var file_daemon_proto_goTypes = []any{
 	(WalletState)(0),                              // 0: daemonrpc.WalletState
 	(VTXOStatus)(0),                               // 1: daemonrpc.VTXOStatus
@@ -7878,186 +8296,202 @@ var file_daemon_proto_goTypes = []any{
 	(*SendVTXOResponse)(nil),                      // 41: daemonrpc.SendVTXOResponse
 	(*SendOORRequest)(nil),                        // 42: daemonrpc.SendOORRequest
 	(*CustomOORInput)(nil),                        // 43: daemonrpc.CustomOORInput
-	(*SendOORResponse)(nil),                       // 44: daemonrpc.SendOORResponse
-	(*OutpointSelection)(nil),                     // 45: daemonrpc.OutpointSelection
-	(*RefreshVTXOsRequest)(nil),                   // 46: daemonrpc.RefreshVTXOsRequest
-	(*RefreshVTXOsResponse)(nil),                  // 47: daemonrpc.RefreshVTXOsResponse
-	(*LeaveDestination)(nil),                      // 48: daemonrpc.LeaveDestination
-	(*LeaveVTXOsRequest)(nil),                     // 49: daemonrpc.LeaveVTXOsRequest
-	(*LeaveVTXOsResponse)(nil),                    // 50: daemonrpc.LeaveVTXOsResponse
-	(*BoardRequest)(nil),                          // 51: daemonrpc.BoardRequest
-	(*BoardResponse)(nil),                         // 52: daemonrpc.BoardResponse
-	(*JoinNextRoundRequest)(nil),                  // 53: daemonrpc.JoinNextRoundRequest
-	(*JoinNextRoundResponse)(nil),                 // 54: daemonrpc.JoinNextRoundResponse
-	(*SweepBoardingUTXOsRequest)(nil),             // 55: daemonrpc.SweepBoardingUTXOsRequest
-	(*BoardingSweepOutput)(nil),                   // 56: daemonrpc.BoardingSweepOutput
-	(*SweepBoardingUTXOsResponse)(nil),            // 57: daemonrpc.SweepBoardingUTXOsResponse
-	(*ListBoardingSweepsRequest)(nil),             // 58: daemonrpc.ListBoardingSweepsRequest
-	(*BoardingSweepInput)(nil),                    // 59: daemonrpc.BoardingSweepInput
-	(*BoardingSweep)(nil),                         // 60: daemonrpc.BoardingSweep
-	(*ListBoardingSweepsResponse)(nil),            // 61: daemonrpc.ListBoardingSweepsResponse
-	(*RoundVTXOInfo)(nil),                         // 62: daemonrpc.RoundVTXOInfo
-	(*RoundInfo)(nil),                             // 63: daemonrpc.RoundInfo
-	(*ListRoundsRequest)(nil),                     // 64: daemonrpc.ListRoundsRequest
-	(*GetRoundRequest)(nil),                       // 65: daemonrpc.GetRoundRequest
-	(*GetRoundResponse)(nil),                      // 66: daemonrpc.GetRoundResponse
-	(*ListRoundsResponse)(nil),                    // 67: daemonrpc.ListRoundsResponse
-	(*WatchRoundsRequest)(nil),                    // 68: daemonrpc.WatchRoundsRequest
-	(*WatchRoundsResponse)(nil),                   // 69: daemonrpc.WatchRoundsResponse
-	(*OORSessionInfo)(nil),                        // 70: daemonrpc.OORSessionInfo
-	(*ListOORSessionsRequest)(nil),                // 71: daemonrpc.ListOORSessionsRequest
-	(*ListOORSessionsResponse)(nil),               // 72: daemonrpc.ListOORSessionsResponse
-	(*GetOORSessionRequest)(nil),                  // 73: daemonrpc.GetOORSessionRequest
-	(*GetOORSessionResponse)(nil),                 // 74: daemonrpc.GetOORSessionResponse
-	(*EstimateFeeRequest)(nil),                    // 75: daemonrpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil),                   // 76: daemonrpc.EstimateFeeResponse
-	(*GetFeeHistoryRequest)(nil),                  // 77: daemonrpc.GetFeeHistoryRequest
-	(*FeeHistoryEntry)(nil),                       // 78: daemonrpc.FeeHistoryEntry
-	(*GetFeeHistoryResponse)(nil),                 // 79: daemonrpc.GetFeeHistoryResponse
-	(*ListTransactionsRequest)(nil),               // 80: daemonrpc.ListTransactionsRequest
-	(*TransactionHistoryEntry)(nil),               // 81: daemonrpc.TransactionHistoryEntry
-	(*ListTransactionsResponse)(nil),              // 82: daemonrpc.ListTransactionsResponse
-	(*UnrollRequest)(nil),                         // 83: daemonrpc.UnrollRequest
-	(*UnrollResponse)(nil),                        // 84: daemonrpc.UnrollResponse
-	(*GetUnrollStatusRequest)(nil),                // 85: daemonrpc.GetUnrollStatusRequest
-	(*GetUnrollStatusResponse)(nil),               // 86: daemonrpc.GetUnrollStatusResponse
-	(*ArmVHTLCRecoveryRequest)(nil),               // 87: daemonrpc.ArmVHTLCRecoveryRequest
-	(*ArmVHTLCRecoveryResponse)(nil),              // 88: daemonrpc.ArmVHTLCRecoveryResponse
-	(*EscalateVHTLCRecoveryRequest)(nil),          // 89: daemonrpc.EscalateVHTLCRecoveryRequest
-	(*EscalateVHTLCRecoveryResponse)(nil),         // 90: daemonrpc.EscalateVHTLCRecoveryResponse
-	(*CancelVHTLCRecoveryRequest)(nil),            // 91: daemonrpc.CancelVHTLCRecoveryRequest
-	(*CancelVHTLCRecoveryResponse)(nil),           // 92: daemonrpc.CancelVHTLCRecoveryResponse
-	(*GetVHTLCRecoveryStatusRequest)(nil),         // 93: daemonrpc.GetVHTLCRecoveryStatusRequest
-	(*GetVHTLCRecoveryStatusResponse)(nil),        // 94: daemonrpc.GetVHTLCRecoveryStatusResponse
-	(*ListVHTLCRecoveriesRequest)(nil),            // 95: daemonrpc.ListVHTLCRecoveriesRequest
-	(*ListVHTLCRecoveriesResponse)(nil),           // 96: daemonrpc.ListVHTLCRecoveriesResponse
-	(*VHTLCRecoveryStatus)(nil),                   // 97: daemonrpc.VHTLCRecoveryStatus
-	nil,                                           // 98: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	(*TaprootScriptSignature)(nil),                // 44: daemonrpc.TaprootScriptSignature
+	(*SendOORResponse)(nil),                       // 45: daemonrpc.SendOORResponse
+	(*PrepareOORRequest)(nil),                     // 46: daemonrpc.PrepareOORRequest
+	(*PreparedOORCustomInput)(nil),                // 47: daemonrpc.PreparedOORCustomInput
+	(*PrepareOORResponse)(nil),                    // 48: daemonrpc.PrepareOORResponse
+	(*SignOORCustomInputRequest)(nil),             // 49: daemonrpc.SignOORCustomInputRequest
+	(*SignOORCustomInputResponse)(nil),            // 50: daemonrpc.SignOORCustomInputResponse
+	(*OutpointSelection)(nil),                     // 51: daemonrpc.OutpointSelection
+	(*RefreshVTXOsRequest)(nil),                   // 52: daemonrpc.RefreshVTXOsRequest
+	(*RefreshVTXOsResponse)(nil),                  // 53: daemonrpc.RefreshVTXOsResponse
+	(*LeaveDestination)(nil),                      // 54: daemonrpc.LeaveDestination
+	(*LeaveVTXOsRequest)(nil),                     // 55: daemonrpc.LeaveVTXOsRequest
+	(*LeaveVTXOsResponse)(nil),                    // 56: daemonrpc.LeaveVTXOsResponse
+	(*BoardRequest)(nil),                          // 57: daemonrpc.BoardRequest
+	(*BoardResponse)(nil),                         // 58: daemonrpc.BoardResponse
+	(*JoinNextRoundRequest)(nil),                  // 59: daemonrpc.JoinNextRoundRequest
+	(*JoinNextRoundResponse)(nil),                 // 60: daemonrpc.JoinNextRoundResponse
+	(*SweepBoardingUTXOsRequest)(nil),             // 61: daemonrpc.SweepBoardingUTXOsRequest
+	(*BoardingSweepOutput)(nil),                   // 62: daemonrpc.BoardingSweepOutput
+	(*SweepBoardingUTXOsResponse)(nil),            // 63: daemonrpc.SweepBoardingUTXOsResponse
+	(*ListBoardingSweepsRequest)(nil),             // 64: daemonrpc.ListBoardingSweepsRequest
+	(*BoardingSweepInput)(nil),                    // 65: daemonrpc.BoardingSweepInput
+	(*BoardingSweep)(nil),                         // 66: daemonrpc.BoardingSweep
+	(*ListBoardingSweepsResponse)(nil),            // 67: daemonrpc.ListBoardingSweepsResponse
+	(*RoundVTXOInfo)(nil),                         // 68: daemonrpc.RoundVTXOInfo
+	(*RoundInfo)(nil),                             // 69: daemonrpc.RoundInfo
+	(*ListRoundsRequest)(nil),                     // 70: daemonrpc.ListRoundsRequest
+	(*GetRoundRequest)(nil),                       // 71: daemonrpc.GetRoundRequest
+	(*GetRoundResponse)(nil),                      // 72: daemonrpc.GetRoundResponse
+	(*ListRoundsResponse)(nil),                    // 73: daemonrpc.ListRoundsResponse
+	(*WatchRoundsRequest)(nil),                    // 74: daemonrpc.WatchRoundsRequest
+	(*WatchRoundsResponse)(nil),                   // 75: daemonrpc.WatchRoundsResponse
+	(*OORSessionInfo)(nil),                        // 76: daemonrpc.OORSessionInfo
+	(*ListOORSessionsRequest)(nil),                // 77: daemonrpc.ListOORSessionsRequest
+	(*ListOORSessionsResponse)(nil),               // 78: daemonrpc.ListOORSessionsResponse
+	(*GetOORSessionRequest)(nil),                  // 79: daemonrpc.GetOORSessionRequest
+	(*GetOORSessionResponse)(nil),                 // 80: daemonrpc.GetOORSessionResponse
+	(*EstimateFeeRequest)(nil),                    // 81: daemonrpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil),                   // 82: daemonrpc.EstimateFeeResponse
+	(*GetFeeHistoryRequest)(nil),                  // 83: daemonrpc.GetFeeHistoryRequest
+	(*FeeHistoryEntry)(nil),                       // 84: daemonrpc.FeeHistoryEntry
+	(*GetFeeHistoryResponse)(nil),                 // 85: daemonrpc.GetFeeHistoryResponse
+	(*ListTransactionsRequest)(nil),               // 86: daemonrpc.ListTransactionsRequest
+	(*TransactionHistoryEntry)(nil),               // 87: daemonrpc.TransactionHistoryEntry
+	(*ListTransactionsResponse)(nil),              // 88: daemonrpc.ListTransactionsResponse
+	(*UnrollRequest)(nil),                         // 89: daemonrpc.UnrollRequest
+	(*UnrollResponse)(nil),                        // 90: daemonrpc.UnrollResponse
+	(*GetUnrollStatusRequest)(nil),                // 91: daemonrpc.GetUnrollStatusRequest
+	(*GetUnrollStatusResponse)(nil),               // 92: daemonrpc.GetUnrollStatusResponse
+	(*ArmVHTLCRecoveryRequest)(nil),               // 93: daemonrpc.ArmVHTLCRecoveryRequest
+	(*ArmVHTLCRecoveryResponse)(nil),              // 94: daemonrpc.ArmVHTLCRecoveryResponse
+	(*EscalateVHTLCRecoveryRequest)(nil),          // 95: daemonrpc.EscalateVHTLCRecoveryRequest
+	(*EscalateVHTLCRecoveryResponse)(nil),         // 96: daemonrpc.EscalateVHTLCRecoveryResponse
+	(*CancelVHTLCRecoveryRequest)(nil),            // 97: daemonrpc.CancelVHTLCRecoveryRequest
+	(*CancelVHTLCRecoveryResponse)(nil),           // 98: daemonrpc.CancelVHTLCRecoveryResponse
+	(*GetVHTLCRecoveryStatusRequest)(nil),         // 99: daemonrpc.GetVHTLCRecoveryStatusRequest
+	(*GetVHTLCRecoveryStatusResponse)(nil),        // 100: daemonrpc.GetVHTLCRecoveryStatusResponse
+	(*ListVHTLCRecoveriesRequest)(nil),            // 101: daemonrpc.ListVHTLCRecoveriesRequest
+	(*ListVHTLCRecoveriesResponse)(nil),           // 102: daemonrpc.ListVHTLCRecoveriesResponse
+	(*VHTLCRecoveryStatus)(nil),                   // 103: daemonrpc.VHTLCRecoveryStatus
+	nil,                                           // 104: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
-	0,  // 0: daemonrpc.GetInfoResponse.wallet_state:type_name -> daemonrpc.WalletState
-	11, // 1: daemonrpc.GetInfoResponse.server_info:type_name -> daemonrpc.ServerInfo
-	1,  // 2: daemonrpc.VTXO.status:type_name -> daemonrpc.VTXOStatus
-	1,  // 3: daemonrpc.ListVTXOsRequest.status_filter:type_name -> daemonrpc.VTXOStatus
-	20, // 4: daemonrpc.ListVTXOsResponse.vtxos:type_name -> daemonrpc.VTXO
-	1,  // 5: daemonrpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> daemonrpc.VTXOStatus
-	20, // 6: daemonrpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> daemonrpc.VTXO
-	39, // 7: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
-	39, // 8: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
-	43, // 9: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
-	45, // 10: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
-	45, // 11: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
-	48, // 12: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
-	98, // 13: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
-	56, // 14: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
-	59, // 15: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
-	60, // 16: daemonrpc.ListBoardingSweepsResponse.sweeps:type_name -> daemonrpc.BoardingSweep
-	2,  // 17: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
-	62, // 18: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
-	2,  // 19: daemonrpc.ListRoundsRequest.state_filter:type_name -> daemonrpc.RoundState
-	63, // 20: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
-	63, // 21: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
-	63, // 22: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
-	3,  // 23: daemonrpc.OORSessionInfo.direction:type_name -> daemonrpc.OORSessionDirection
-	4,  // 24: daemonrpc.OORSessionInfo.status:type_name -> daemonrpc.OORSessionStatus
-	3,  // 25: daemonrpc.ListOORSessionsRequest.direction_filter:type_name -> daemonrpc.OORSessionDirection
-	4,  // 26: daemonrpc.ListOORSessionsRequest.status_filter:type_name -> daemonrpc.OORSessionStatus
-	70, // 27: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
-	70, // 28: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
-	78, // 29: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
-	81, // 30: daemonrpc.ListTransactionsResponse.transactions:type_name -> daemonrpc.TransactionHistoryEntry
-	5,  // 31: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
-	6,  // 32: daemonrpc.ArmVHTLCRecoveryRequest.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
-	7,  // 33: daemonrpc.ArmVHTLCRecoveryRequest.action:type_name -> daemonrpc.VHTLCRecoveryAction
-	97, // 34: daemonrpc.ArmVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	97, // 35: daemonrpc.EscalateVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	97, // 36: daemonrpc.CancelVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	97, // 37: daemonrpc.GetVHTLCRecoveryStatusResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	97, // 38: daemonrpc.ListVHTLCRecoveriesResponse.statuses:type_name -> daemonrpc.VHTLCRecoveryStatus
-	6,  // 39: daemonrpc.VHTLCRecoveryStatus.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
-	7,  // 40: daemonrpc.VHTLCRecoveryStatus.action:type_name -> daemonrpc.VHTLCRecoveryAction
-	8,  // 41: daemonrpc.VHTLCRecoveryStatus.state:type_name -> daemonrpc.VHTLCRecoveryState
-	5,  // 42: daemonrpc.VHTLCRecoveryStatus.unroll_status:type_name -> daemonrpc.UnrollJobStatus
-	48, // 43: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
-	9,  // 44: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
-	12, // 45: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
-	14, // 46: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
-	16, // 47: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
-	18, // 48: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
-	21, // 49: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
-	23, // 50: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
-	25, // 51: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
-	27, // 52: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
-	29, // 53: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
-	31, // 54: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
-	33, // 55: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
-	35, // 56: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
-	37, // 57: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
-	40, // 58: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
-	42, // 59: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
-	46, // 60: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
-	49, // 61: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
-	51, // 62: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
-	53, // 63: daemonrpc.DaemonService.JoinNextRound:input_type -> daemonrpc.JoinNextRoundRequest
-	55, // 64: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
-	58, // 65: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
-	64, // 66: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
-	65, // 67: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
-	68, // 68: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
-	71, // 69: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
-	73, // 70: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
-	75, // 71: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
-	77, // 72: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
-	80, // 73: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
-	83, // 74: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
-	85, // 75: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
-	87, // 76: daemonrpc.DaemonService.ArmVHTLCRecovery:input_type -> daemonrpc.ArmVHTLCRecoveryRequest
-	89, // 77: daemonrpc.DaemonService.EscalateVHTLCRecovery:input_type -> daemonrpc.EscalateVHTLCRecoveryRequest
-	91, // 78: daemonrpc.DaemonService.CancelVHTLCRecovery:input_type -> daemonrpc.CancelVHTLCRecoveryRequest
-	93, // 79: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> daemonrpc.GetVHTLCRecoveryStatusRequest
-	95, // 80: daemonrpc.DaemonService.ListVHTLCRecoveries:input_type -> daemonrpc.ListVHTLCRecoveriesRequest
-	10, // 81: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	13, // 82: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	15, // 83: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	17, // 84: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	19, // 85: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	22, // 86: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	24, // 87: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	26, // 88: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
-	28, // 89: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
-	30, // 90: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
-	32, // 91: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
-	34, // 92: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
-	36, // 93: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
-	38, // 94: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
-	41, // 95: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	44, // 96: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	47, // 97: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	50, // 98: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
-	52, // 99: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	54, // 100: daemonrpc.DaemonService.JoinNextRound:output_type -> daemonrpc.JoinNextRoundResponse
-	57, // 101: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
-	61, // 102: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
-	67, // 103: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	66, // 104: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
-	69, // 105: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	72, // 106: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
-	74, // 107: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
-	76, // 108: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
-	79, // 109: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
-	82, // 110: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
-	84, // 111: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
-	86, // 112: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
-	88, // 113: daemonrpc.DaemonService.ArmVHTLCRecovery:output_type -> daemonrpc.ArmVHTLCRecoveryResponse
-	90, // 114: daemonrpc.DaemonService.EscalateVHTLCRecovery:output_type -> daemonrpc.EscalateVHTLCRecoveryResponse
-	92, // 115: daemonrpc.DaemonService.CancelVHTLCRecovery:output_type -> daemonrpc.CancelVHTLCRecoveryResponse
-	94, // 116: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> daemonrpc.GetVHTLCRecoveryStatusResponse
-	96, // 117: daemonrpc.DaemonService.ListVHTLCRecoveries:output_type -> daemonrpc.ListVHTLCRecoveriesResponse
-	81, // [81:118] is the sub-list for method output_type
-	44, // [44:81] is the sub-list for method input_type
-	44, // [44:44] is the sub-list for extension type_name
-	44, // [44:44] is the sub-list for extension extendee
-	0,  // [0:44] is the sub-list for field type_name
+	0,   // 0: daemonrpc.GetInfoResponse.wallet_state:type_name -> daemonrpc.WalletState
+	11,  // 1: daemonrpc.GetInfoResponse.server_info:type_name -> daemonrpc.ServerInfo
+	1,   // 2: daemonrpc.VTXO.status:type_name -> daemonrpc.VTXOStatus
+	1,   // 3: daemonrpc.ListVTXOsRequest.status_filter:type_name -> daemonrpc.VTXOStatus
+	20,  // 4: daemonrpc.ListVTXOsResponse.vtxos:type_name -> daemonrpc.VTXO
+	1,   // 5: daemonrpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> daemonrpc.VTXOStatus
+	20,  // 6: daemonrpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> daemonrpc.VTXO
+	39,  // 7: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
+	39,  // 8: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
+	43,  // 9: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
+	44,  // 10: daemonrpc.CustomOORInput.external_signatures:type_name -> daemonrpc.TaprootScriptSignature
+	39,  // 11: daemonrpc.PrepareOORRequest.recipient:type_name -> daemonrpc.Output
+	43,  // 12: daemonrpc.PrepareOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
+	47,  // 13: daemonrpc.PrepareOORResponse.custom_inputs:type_name -> daemonrpc.PreparedOORCustomInput
+	43,  // 14: daemonrpc.SignOORCustomInputRequest.custom_input:type_name -> daemonrpc.CustomOORInput
+	44,  // 15: daemonrpc.SignOORCustomInputResponse.signature:type_name -> daemonrpc.TaprootScriptSignature
+	51,  // 16: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	51,  // 17: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	54,  // 18: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
+	104, // 19: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	62,  // 20: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
+	65,  // 21: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
+	66,  // 22: daemonrpc.ListBoardingSweepsResponse.sweeps:type_name -> daemonrpc.BoardingSweep
+	2,   // 23: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
+	68,  // 24: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
+	2,   // 25: daemonrpc.ListRoundsRequest.state_filter:type_name -> daemonrpc.RoundState
+	69,  // 26: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
+	69,  // 27: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
+	69,  // 28: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
+	3,   // 29: daemonrpc.OORSessionInfo.direction:type_name -> daemonrpc.OORSessionDirection
+	4,   // 30: daemonrpc.OORSessionInfo.status:type_name -> daemonrpc.OORSessionStatus
+	3,   // 31: daemonrpc.ListOORSessionsRequest.direction_filter:type_name -> daemonrpc.OORSessionDirection
+	4,   // 32: daemonrpc.ListOORSessionsRequest.status_filter:type_name -> daemonrpc.OORSessionStatus
+	76,  // 33: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
+	76,  // 34: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
+	84,  // 35: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
+	87,  // 36: daemonrpc.ListTransactionsResponse.transactions:type_name -> daemonrpc.TransactionHistoryEntry
+	5,   // 37: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
+	6,   // 38: daemonrpc.ArmVHTLCRecoveryRequest.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
+	7,   // 39: daemonrpc.ArmVHTLCRecoveryRequest.action:type_name -> daemonrpc.VHTLCRecoveryAction
+	103, // 40: daemonrpc.ArmVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	103, // 41: daemonrpc.EscalateVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	103, // 42: daemonrpc.CancelVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	103, // 43: daemonrpc.GetVHTLCRecoveryStatusResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	103, // 44: daemonrpc.ListVHTLCRecoveriesResponse.statuses:type_name -> daemonrpc.VHTLCRecoveryStatus
+	6,   // 45: daemonrpc.VHTLCRecoveryStatus.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
+	7,   // 46: daemonrpc.VHTLCRecoveryStatus.action:type_name -> daemonrpc.VHTLCRecoveryAction
+	8,   // 47: daemonrpc.VHTLCRecoveryStatus.state:type_name -> daemonrpc.VHTLCRecoveryState
+	5,   // 48: daemonrpc.VHTLCRecoveryStatus.unroll_status:type_name -> daemonrpc.UnrollJobStatus
+	54,  // 49: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
+	9,   // 50: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
+	12,  // 51: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
+	14,  // 52: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
+	16,  // 53: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
+	18,  // 54: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
+	21,  // 55: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
+	23,  // 56: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
+	25,  // 57: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
+	27,  // 58: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
+	29,  // 59: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
+	31,  // 60: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
+	33,  // 61: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
+	35,  // 62: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
+	37,  // 63: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
+	40,  // 64: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	42,  // 65: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	46,  // 66: daemonrpc.DaemonService.PrepareOOR:input_type -> daemonrpc.PrepareOORRequest
+	49,  // 67: daemonrpc.DaemonService.SignOORCustomInput:input_type -> daemonrpc.SignOORCustomInputRequest
+	52,  // 68: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	55,  // 69: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
+	57,  // 70: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
+	59,  // 71: daemonrpc.DaemonService.JoinNextRound:input_type -> daemonrpc.JoinNextRoundRequest
+	61,  // 72: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
+	64,  // 73: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
+	70,  // 74: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
+	71,  // 75: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
+	74,  // 76: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
+	77,  // 77: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
+	79,  // 78: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
+	81,  // 79: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
+	83,  // 80: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
+	86,  // 81: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
+	89,  // 82: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
+	91,  // 83: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
+	93,  // 84: daemonrpc.DaemonService.ArmVHTLCRecovery:input_type -> daemonrpc.ArmVHTLCRecoveryRequest
+	95,  // 85: daemonrpc.DaemonService.EscalateVHTLCRecovery:input_type -> daemonrpc.EscalateVHTLCRecoveryRequest
+	97,  // 86: daemonrpc.DaemonService.CancelVHTLCRecovery:input_type -> daemonrpc.CancelVHTLCRecoveryRequest
+	99,  // 87: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> daemonrpc.GetVHTLCRecoveryStatusRequest
+	101, // 88: daemonrpc.DaemonService.ListVHTLCRecoveries:input_type -> daemonrpc.ListVHTLCRecoveriesRequest
+	10,  // 89: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	13,  // 90: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	15,  // 91: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	17,  // 92: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	19,  // 93: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	22,  // 94: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	24,  // 95: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	26,  // 96: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
+	28,  // 97: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
+	30,  // 98: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
+	32,  // 99: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
+	34,  // 100: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
+	36,  // 101: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
+	38,  // 102: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
+	41,  // 103: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	45,  // 104: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	48,  // 105: daemonrpc.DaemonService.PrepareOOR:output_type -> daemonrpc.PrepareOORResponse
+	50,  // 106: daemonrpc.DaemonService.SignOORCustomInput:output_type -> daemonrpc.SignOORCustomInputResponse
+	53,  // 107: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	56,  // 108: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
+	58,  // 109: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	60,  // 110: daemonrpc.DaemonService.JoinNextRound:output_type -> daemonrpc.JoinNextRoundResponse
+	63,  // 111: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
+	67,  // 112: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
+	73,  // 113: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	72,  // 114: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
+	75,  // 115: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	78,  // 116: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
+	80,  // 117: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
+	82,  // 118: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
+	85,  // 119: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
+	88,  // 120: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
+	90,  // 121: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
+	92,  // 122: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
+	94,  // 123: daemonrpc.DaemonService.ArmVHTLCRecovery:output_type -> daemonrpc.ArmVHTLCRecoveryResponse
+	96,  // 124: daemonrpc.DaemonService.EscalateVHTLCRecovery:output_type -> daemonrpc.EscalateVHTLCRecoveryResponse
+	98,  // 125: daemonrpc.DaemonService.CancelVHTLCRecovery:output_type -> daemonrpc.CancelVHTLCRecoveryResponse
+	100, // 126: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> daemonrpc.GetVHTLCRecoveryStatusResponse
+	102, // 127: daemonrpc.DaemonService.ListVHTLCRecoveries:output_type -> daemonrpc.ListVHTLCRecoveriesResponse
+	89,  // [89:128] is the sub-list for method output_type
+	50,  // [50:89] is the sub-list for method input_type
+	50,  // [50:50] is the sub-list for extension type_name
+	50,  // [50:50] is the sub-list for extension extendee
+	0,   // [0:50] is the sub-list for field type_name
 }
 
 func init() { file_daemon_proto_init() }
@@ -8070,15 +8504,15 @@ func file_daemon_proto_init() {
 		(*Output_Pubkey)(nil),
 		(*Output_PolicyTemplate)(nil),
 	}
-	file_daemon_proto_msgTypes[37].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[43].OneofWrappers = []any{
 		(*RefreshVTXOsRequest_Outpoints)(nil),
 		(*RefreshVTXOsRequest_All)(nil),
 	}
-	file_daemon_proto_msgTypes[39].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[45].OneofWrappers = []any{
 		(*LeaveDestination_Address)(nil),
 		(*LeaveDestination_PkScript)(nil),
 	}
-	file_daemon_proto_msgTypes[40].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[46].OneofWrappers = []any{
 		(*LeaveVTXOsRequest_Outpoints)(nil),
 		(*LeaveVTXOsRequest_All)(nil),
 	}
@@ -8088,7 +8522,7 @@ func file_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      9,
-			NumMessages:   90,
+			NumMessages:   96,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.pb.gw.go
+++ b/daemonrpc/daemon.pb.gw.go
@@ -467,6 +467,60 @@ func local_request_DaemonService_SendOOR_0(ctx context.Context, marshaler runtim
 	return msg, metadata, err
 }
 
+func request_DaemonService_PrepareOOR_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PrepareOORRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.PrepareOOR(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_DaemonService_PrepareOOR_0(ctx context.Context, marshaler runtime.Marshaler, server DaemonServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PrepareOORRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.PrepareOOR(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_DaemonService_SignOORCustomInput_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SignOORCustomInputRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.SignOORCustomInput(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_DaemonService_SignOORCustomInput_0(ctx context.Context, marshaler runtime.Marshaler, server DaemonServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SignOORCustomInputRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.SignOORCustomInput(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_DaemonService_RefreshVTXOs_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq RefreshVTXOsRequest
@@ -1356,6 +1410,46 @@ func RegisterDaemonServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_SendOOR_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_PrepareOOR_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/daemonrpc.DaemonService/PrepareOOR", runtime.WithHTTPPathPattern("/v1/daemon/prepare-oor"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_DaemonService_PrepareOOR_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_PrepareOOR_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_SignOORCustomInput_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/daemonrpc.DaemonService/SignOORCustomInput", runtime.WithHTTPPathPattern("/v1/daemon/sign-oor-custom-input"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_DaemonService_SignOORCustomInput_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_SignOORCustomInput_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_DaemonService_RefreshVTXOs_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2075,6 +2169,40 @@ func RegisterDaemonServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_SendOOR_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_PrepareOOR_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/daemonrpc.DaemonService/PrepareOOR", runtime.WithHTTPPathPattern("/v1/daemon/prepare-oor"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_DaemonService_PrepareOOR_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_PrepareOOR_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_SignOORCustomInput_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/daemonrpc.DaemonService/SignOORCustomInput", runtime.WithHTTPPathPattern("/v1/daemon/sign-oor-custom-input"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_DaemonService_SignOORCustomInput_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_SignOORCustomInput_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_DaemonService_RefreshVTXOs_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2452,6 +2580,8 @@ var (
 	pattern_DaemonService_GetIndexedOORSessionByTxid_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "get-indexed-oor-session-by-txid"}, ""))
 	pattern_DaemonService_SendVTXO_0                      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "send-vtxo"}, ""))
 	pattern_DaemonService_SendOOR_0                       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "send-oor"}, ""))
+	pattern_DaemonService_PrepareOOR_0                    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "prepare-oor"}, ""))
+	pattern_DaemonService_SignOORCustomInput_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "sign-oor-custom-input"}, ""))
 	pattern_DaemonService_RefreshVTXOs_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "refresh-vtxos"}, ""))
 	pattern_DaemonService_LeaveVTXOs_0                    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "leave-vtxos"}, ""))
 	pattern_DaemonService_Board_0                         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "board"}, ""))
@@ -2492,6 +2622,8 @@ var (
 	forward_DaemonService_GetIndexedOORSessionByTxid_0    = runtime.ForwardResponseMessage
 	forward_DaemonService_SendVTXO_0                      = runtime.ForwardResponseMessage
 	forward_DaemonService_SendOOR_0                       = runtime.ForwardResponseMessage
+	forward_DaemonService_PrepareOOR_0                    = runtime.ForwardResponseMessage
+	forward_DaemonService_SignOORCustomInput_0            = runtime.ForwardResponseMessage
 	forward_DaemonService_RefreshVTXOs_0                  = runtime.ForwardResponseMessage
 	forward_DaemonService_LeaveVTXOs_0                    = runtime.ForwardResponseMessage
 	forward_DaemonService_Board_0                         = runtime.ForwardResponseMessage

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -84,6 +84,16 @@ service DaemonService {
     // client and operator, without waiting for a round.
     rpc SendOOR (SendOORRequest) returns (SendOORResponse);
 
+    // PrepareOOR builds the deterministic OOR package without submitting it.
+    // This lets callers collect signatures from external custom-input
+    // participants before calling SendOOR with the same parameters.
+    rpc PrepareOOR (PrepareOORRequest) returns (PrepareOORResponse);
+
+    // SignOORCustomInput signs one prepared custom OOR checkpoint input with
+    // the daemon identity key.
+    rpc SignOORCustomInput (SignOORCustomInputRequest)
+        returns (SignOORCustomInputResponse);
+
     // RefreshVTXOs queues one or more VTXOs for refresh in the next
     // round. This extends their expiry without changing ownership.
     rpc RefreshVTXOs (RefreshVTXOsRequest) returns (RefreshVTXOsResponse);
@@ -767,6 +777,30 @@ message CustomOORInput {
 
     // pk_script is the VTXO taproot output script.
     bytes pk_script = 5;
+
+    // external_signatures are taproot script-spend signatures produced by
+    // other parties required by the selected spend path. The local daemon still
+    // validates the policy/spend-path binding and adds its own signature before
+    // assembling the final witness.
+    repeated TaprootScriptSignature external_signatures = 6;
+}
+
+// TaprootScriptSignature carries one externally produced tapscript signature
+// for a custom OOR input. Keep this in sync with
+// swaprpc.TaprootScriptSignature.
+message TaprootScriptSignature {
+    // pubkey is the compressed public key that produced the signature.
+    bytes pubkey = 1;
+
+    // witness_script is the tapscript leaf this signature commits to.
+    bytes witness_script = 2;
+
+    // signature is the raw Schnorr signature, optionally followed by a one-byte
+    // sighash type when the sighash is not SIGHASH_DEFAULT.
+    bytes signature = 3;
+
+    // sighash is the tapscript sighash type. Zero means SIGHASH_DEFAULT.
+    uint32 sighash = 4;
 }
 
 message SendOORResponse {
@@ -776,6 +810,60 @@ message SendOORResponse {
 
     // session_id is the OOR session identifier. Empty on dry_run.
     string session_id = 2;
+}
+
+message PrepareOORRequest {
+    // recipient is the output to create via the out-of-round transfer.
+    Output recipient = 1;
+
+    // custom_inputs are caller-specified inputs. PrepareOOR currently only
+    // supports custom inputs because wallet-selected inputs would need wallet
+    // locks and therefore would not be side-effect free.
+    repeated CustomOORInput custom_inputs = 2;
+}
+
+message PreparedOORCustomInput {
+    // outpoint identifies the custom input this signing data belongs to.
+    string outpoint = 1;
+
+    // checkpoint_psbt is the serialized unsigned checkpoint PSBT whose input
+    // spends the custom VTXO.
+    bytes checkpoint_psbt = 2;
+
+    // witness_script is the tapscript leaf external parties must sign.
+    bytes witness_script = 3;
+
+    // signing_pubkeys are the compressed public keys required by the spend
+    // path in script order.
+    repeated bytes signing_pubkeys = 4;
+}
+
+message PrepareOORResponse {
+    // ark_psbt is the serialized unsigned Ark PSBT that would be submitted.
+    bytes ark_psbt = 1;
+
+    // checkpoint_psbts are the serialized unsigned checkpoint PSBTs that would
+    // be submitted.
+    repeated bytes checkpoint_psbts = 2;
+
+    // custom_inputs contains signing data for each prepared custom input.
+    repeated PreparedOORCustomInput custom_inputs = 3;
+
+    // session_id is the deterministic OOR session id derived from ark_psbt.
+    string session_id = 4;
+}
+
+message SignOORCustomInputRequest {
+    // custom_input describes the vHTLC/custom VTXO and selected spend path.
+    CustomOORInput custom_input = 1;
+
+    // checkpoint_psbt is the prepared checkpoint PSBT to sign.
+    bytes checkpoint_psbt = 2;
+}
+
+message SignOORCustomInputResponse {
+    // signature is the daemon identity key's tapscript signature.
+    TaprootScriptSignature signature = 1;
 }
 
 // OutpointSelection wraps a list of outpoint strings for use inside a

--- a/daemonrpc/daemon.yaml
+++ b/daemonrpc/daemon.yaml
@@ -51,6 +51,12 @@ http:
     - selector: daemonrpc.DaemonService.SendOOR
       post: /v1/daemon/send-oor
       body: "*"
+    - selector: daemonrpc.DaemonService.PrepareOOR
+      post: /v1/daemon/prepare-oor
+      body: "*"
+    - selector: daemonrpc.DaemonService.SignOORCustomInput
+      post: /v1/daemon/sign-oor-custom-input
+      body: "*"
     - selector: daemonrpc.DaemonService.RefreshVTXOs
       post: /v1/daemon/refresh-vtxos
       body: "*"

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -35,6 +35,8 @@ const (
 	DaemonService_GetIndexedOORSessionByTxid_FullMethodName    = "/daemonrpc.DaemonService/GetIndexedOORSessionByTxid"
 	DaemonService_SendVTXO_FullMethodName                      = "/daemonrpc.DaemonService/SendVTXO"
 	DaemonService_SendOOR_FullMethodName                       = "/daemonrpc.DaemonService/SendOOR"
+	DaemonService_PrepareOOR_FullMethodName                    = "/daemonrpc.DaemonService/PrepareOOR"
+	DaemonService_SignOORCustomInput_FullMethodName            = "/daemonrpc.DaemonService/SignOORCustomInput"
 	DaemonService_RefreshVTXOs_FullMethodName                  = "/daemonrpc.DaemonService/RefreshVTXOs"
 	DaemonService_LeaveVTXOs_FullMethodName                    = "/daemonrpc.DaemonService/LeaveVTXOs"
 	DaemonService_Board_FullMethodName                         = "/daemonrpc.DaemonService/Board"
@@ -120,6 +122,13 @@ type DaemonServiceClient interface {
 	// SendOOR initiates an out-of-round transfer directly between the
 	// client and operator, without waiting for a round.
 	SendOOR(ctx context.Context, in *SendOORRequest, opts ...grpc.CallOption) (*SendOORResponse, error)
+	// PrepareOOR builds the deterministic OOR package without submitting it.
+	// This lets callers collect signatures from external custom-input
+	// participants before calling SendOOR with the same parameters.
+	PrepareOOR(ctx context.Context, in *PrepareOORRequest, opts ...grpc.CallOption) (*PrepareOORResponse, error)
+	// SignOORCustomInput signs one prepared custom OOR checkpoint input with
+	// the daemon identity key.
+	SignOORCustomInput(ctx context.Context, in *SignOORCustomInputRequest, opts ...grpc.CallOption) (*SignOORCustomInputResponse, error)
 	// RefreshVTXOs queues one or more VTXOs for refresh in the next
 	// round. This extends their expiry without changing ownership.
 	RefreshVTXOs(ctx context.Context, in *RefreshVTXOsRequest, opts ...grpc.CallOption) (*RefreshVTXOsResponse, error)
@@ -362,6 +371,26 @@ func (c *daemonServiceClient) SendOOR(ctx context.Context, in *SendOORRequest, o
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(SendOORResponse)
 	err := c.cc.Invoke(ctx, DaemonService_SendOOR_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) PrepareOOR(ctx context.Context, in *PrepareOORRequest, opts ...grpc.CallOption) (*PrepareOORResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PrepareOORResponse)
+	err := c.cc.Invoke(ctx, DaemonService_PrepareOOR_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) SignOORCustomInput(ctx context.Context, in *SignOORCustomInputRequest, opts ...grpc.CallOption) (*SignOORCustomInputResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SignOORCustomInputResponse)
+	err := c.cc.Invoke(ctx, DaemonService_SignOORCustomInput_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -649,6 +678,13 @@ type DaemonServiceServer interface {
 	// SendOOR initiates an out-of-round transfer directly between the
 	// client and operator, without waiting for a round.
 	SendOOR(context.Context, *SendOORRequest) (*SendOORResponse, error)
+	// PrepareOOR builds the deterministic OOR package without submitting it.
+	// This lets callers collect signatures from external custom-input
+	// participants before calling SendOOR with the same parameters.
+	PrepareOOR(context.Context, *PrepareOORRequest) (*PrepareOORResponse, error)
+	// SignOORCustomInput signs one prepared custom OOR checkpoint input with
+	// the daemon identity key.
+	SignOORCustomInput(context.Context, *SignOORCustomInputRequest) (*SignOORCustomInputResponse, error)
 	// RefreshVTXOs queues one or more VTXOs for refresh in the next
 	// round. This extends their expiry without changing ownership.
 	RefreshVTXOs(context.Context, *RefreshVTXOsRequest) (*RefreshVTXOsResponse, error)
@@ -784,6 +820,12 @@ func (UnimplementedDaemonServiceServer) SendVTXO(context.Context, *SendVTXOReque
 }
 func (UnimplementedDaemonServiceServer) SendOOR(context.Context, *SendOORRequest) (*SendOORResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SendOOR not implemented")
+}
+func (UnimplementedDaemonServiceServer) PrepareOOR(context.Context, *PrepareOORRequest) (*PrepareOORResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PrepareOOR not implemented")
+}
+func (UnimplementedDaemonServiceServer) SignOORCustomInput(context.Context, *SignOORCustomInputRequest) (*SignOORCustomInputResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SignOORCustomInput not implemented")
 }
 func (UnimplementedDaemonServiceServer) RefreshVTXOs(context.Context, *RefreshVTXOsRequest) (*RefreshVTXOsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RefreshVTXOs not implemented")
@@ -1153,6 +1195,42 @@ func _DaemonService_SendOOR_Handler(srv interface{}, ctx context.Context, dec fu
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(DaemonServiceServer).SendOOR(ctx, req.(*SendOORRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_PrepareOOR_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PrepareOORRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).PrepareOOR(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_PrepareOOR_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).PrepareOOR(ctx, req.(*PrepareOORRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_SignOORCustomInput_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SignOORCustomInputRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).SignOORCustomInput(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_SignOORCustomInput_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).SignOORCustomInput(ctx, req.(*SignOORCustomInputRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1598,6 +1676,14 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SendOOR",
 			Handler:    _DaemonService_SendOOR_Handler,
+		},
+		{
+			MethodName: "PrepareOOR",
+			Handler:    _DaemonService_PrepareOOR_Handler,
+		},
+		{
+			MethodName: "SignOORCustomInput",
+			Handler:    _DaemonService_SignOORCustomInput_Handler,
 		},
 		{
 			MethodName: "RefreshVTXOs",

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -56,6 +56,10 @@ type DaemonServiceMailboxServer interface {
 	SendVTXO(ctx context.Context, req *SendVTXORequest) (*SendVTXOResponse, error)
 	// SendOOR handles SendOOR.
 	SendOOR(ctx context.Context, req *SendOORRequest) (*SendOORResponse, error)
+	// PrepareOOR handles PrepareOOR.
+	PrepareOOR(ctx context.Context, req *PrepareOORRequest) (*PrepareOORResponse, error)
+	// SignOORCustomInput handles SignOORCustomInput.
+	SignOORCustomInput(ctx context.Context, req *SignOORCustomInputRequest) (*SignOORCustomInputResponse, error)
 	// RefreshVTXOs handles RefreshVTXOs.
 	RefreshVTXOs(ctx context.Context, req *RefreshVTXOsRequest) (*RefreshVTXOsResponse, error)
 	// LeaveVTXOs handles LeaveVTXOs.
@@ -261,6 +265,26 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.SendOOR(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "PrepareOOR", func() proto.Message {
+		return &PrepareOORRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*PrepareOORRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.PrepareOOR(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "SignOORCustomInput", func() proto.Message {
+		return &SignOORCustomInputRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*SignOORCustomInputRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.SignOORCustomInput(ctx, req)
 	})
 	r.Handle("daemonrpc.DaemonService", "RefreshVTXOs", func() proto.Message {
 		return &RefreshVTXOsRequest{}
@@ -835,6 +859,52 @@ func (c *DaemonServiceMailboxClient) SendOOR(ctx context.Context, req *SendOORRe
 	}
 
 	resp := new(SendOORResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// PrepareOOR calls the PrepareOOR RPC.
+func (c *DaemonServiceMailboxClient) PrepareOOR(ctx context.Context, req *PrepareOORRequest, opts ...rpc.RPCOptions) (*PrepareOORResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "PrepareOOR",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(PrepareOORResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// SignOORCustomInput calls the SignOORCustomInput RPC.
+func (c *DaemonServiceMailboxClient) SignOORCustomInput(ctx context.Context, req *SignOORCustomInputRequest, opts ...rpc.RPCOptions) (*SignOORCustomInputResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "SignOORCustomInput",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(SignOORCustomInputResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -2059,6 +2059,231 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	}, nil
 }
 
+// PrepareOOR builds a deterministic OOR package without submitting it.
+func (r *RPCServer) PrepareOOR(ctx context.Context,
+	req *daemonrpc.PrepareOORRequest) (*daemonrpc.PrepareOORResponse,
+	error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if req.GetRecipient() == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "recipient "+
+			"is required")
+	}
+
+	if req.GetRecipient().GetAmountSat() <= 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "amount "+
+			"must be positive")
+	}
+
+	if len(req.GetCustomInputs()) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "custom "+
+			"inputs are required")
+	}
+
+	if r.server.vtxoStore == nil {
+		return nil, status.Errorf(codes.Internal, "VTXO store not "+
+			"initialized")
+	}
+
+	pkScript, err := r.resolveOutputPkScript(ctx, req.GetRecipient())
+	if err != nil {
+		return nil, err
+	}
+
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to fetch "+
+			"operator terms: %v", err)
+	}
+
+	recipientPolicyTemplate, err := r.resolveOutputPolicyTemplate(
+		ctx, req.GetRecipient(), pkScript, terms.PubKey,
+		terms.VTXOExitDelay,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	selectedInputs, err := BuildCustomTransferInputs(
+		ctx, r.server.vtxoStore, req.GetCustomInputs(),
+		r.server.clientKeyDesc, terms.PubKey, terms.VTXOExitDelay,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "build custom "+
+			"inputs: %v", err)
+	}
+
+	inputTotal, err := sumOORInputAmounts(selectedInputs)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "sum OOR input "+
+			"amounts: %v", err)
+	}
+
+	recipients := []oortx.RecipientOutput{{
+		PkScript: pkScript,
+		Value: btcutil.Amount(
+			req.GetRecipient().GetAmountSat(),
+		),
+		VTXOPolicyTemplate: recipientPolicyTemplate,
+	}}
+
+	recipients, _, err = appendOORChangeRecipient(
+		ctx, recipients, inputTotal, terms.DustLimit,
+		func(ctx context.Context, change btcutil.Amount) (
+			oortx.RecipientOutput, error) {
+
+			return r.buildOORChangeRecipient(
+				ctx, terms.PubKey, terms.VTXOExitDelay, change,
+			)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: terms.PubKey,
+		CSVDelay:    terms.VTXOExitDelay,
+	}
+	arkPSBT, checkpointPSBTs, err := oor.BuildSubmitPackage(
+		policy, selectedInputs, recipients,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "build OOR "+
+			"package: %v", err)
+	}
+
+	arkRaw, err := psbtutil.Serialize(arkPSBT)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "serialize ark "+
+			"psbt: %v", err)
+	}
+
+	checkpointRaw := make([][]byte, 0, len(checkpointPSBTs))
+	preparedInputs := make(
+		[]*daemonrpc.PreparedOORCustomInput, 0, len(selectedInputs),
+	)
+	for i := range checkpointPSBTs {
+		raw, err := psbtutil.Serialize(checkpointPSBTs[i])
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "serialize "+
+				"checkpoint psbt %d: %v", i, err)
+		}
+		checkpointRaw = append(checkpointRaw, raw)
+
+		input := selectedInputs[i]
+		if input.CustomSpend == nil {
+			continue
+		}
+
+		signingPubKeys := make([][]byte, 0, len(input.CustomSpendKeys))
+		for _, key := range input.CustomSpendKeys {
+			if key == nil {
+				return nil, status.Errorf(codes.Internal,
+					"custom spend key is nil")
+			}
+
+			signingPubKeys = append(
+				signingPubKeys, key.SerializeCompressed(),
+			)
+		}
+
+		preparedInputs = append(
+			preparedInputs, &daemonrpc.PreparedOORCustomInput{
+				Outpoint:       input.VTXO.Outpoint.String(),
+				CheckpointPsbt: raw,
+				WitnessScript: input.CustomSpend.SpendInfo.
+					WitnessScript,
+				SigningPubkeys: signingPubKeys,
+			},
+		)
+	}
+
+	return &daemonrpc.PrepareOORResponse{
+		ArkPsbt:         arkRaw,
+		CheckpointPsbts: checkpointRaw,
+		CustomInputs:    preparedInputs,
+		SessionId:       arkPSBT.UnsignedTx.TxHash().String(),
+	}, nil
+}
+
+// SignOORCustomInput signs one prepared custom OOR checkpoint input.
+func (r *RPCServer) SignOORCustomInput(ctx context.Context,
+	req *daemonrpc.SignOORCustomInputRequest) (
+	*daemonrpc.SignOORCustomInputResponse, error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if req.GetCustomInput() == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "custom "+
+			"input is required")
+	}
+
+	if r.server.vtxoStore == nil {
+		return nil, status.Errorf(codes.Internal, "VTXO store not "+
+			"initialized")
+	}
+
+	checkpoint, err := psbtutil.Parse(req.GetCheckpointPsbt())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "parse "+
+			"checkpoint psbt: %v", err)
+	}
+
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to fetch "+
+			"operator terms: %v", err)
+	}
+
+	inputs, err := BuildCustomTransferInputs(
+		ctx, r.server.vtxoStore,
+		[]*daemonrpc.CustomOORInput{req.GetCustomInput()},
+		r.server.clientKeyDesc, terms.PubKey, terms.VTXOExitDelay,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "build custom "+
+			"input: %v", err)
+	}
+	if len(inputs) != 1 {
+		return nil, status.Errorf(codes.Internal, "expected one "+
+			"custom input, got %d", len(inputs))
+	}
+
+	signer, err := r.server.oorSigner()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "resolve signer: %v",
+			err)
+	}
+
+	sig, err := oor.SignCustomCheckpointInput(
+		signer, &inputs[0], checkpoint,
+	)
+	if err != nil {
+		if errors.Is(err, oor.ErrCustomCheckpointInputSigning) {
+			return nil, status.Errorf(codes.Internal, "sign "+
+				"custom input: %v", err)
+		}
+
+		return nil, status.Errorf(codes.InvalidArgument, "sign custom "+
+			"input: %v", err)
+	}
+
+	return &daemonrpc.SignOORCustomInputResponse{
+		Signature: &daemonrpc.TaprootScriptSignature{
+			Pubkey:        sig.PubKey.SerializeCompressed(),
+			WitnessScript: sig.WitnessScript,
+			Signature:     sig.Signature,
+			Sighash:       uint32(sig.SigHash),
+		},
+	}, nil
+}
+
 // findOutgoingOORSessionByIdempotencyKey asks the OOR actor whether the daemon
 // already knows a keyed outgoing session before acquiring wallet or custom
 // inputs for the retry.

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -3572,24 +3572,9 @@ func (s *Server) initOORActor(ctx context.Context,
 		s.subLogger(db.Subsystem),
 	)
 
-	// Select the OOR signer based on wallet type. The
-	// SigningOutboxHandler only needs input.Signer for signing
-	// checkpoint PSBTs.
-	var oorSigner input.Signer
-	switch s.cfg.Wallet.Type {
-	case WalletTypeLnd:
-		lndSvc := s.lnd.UnsafeFromSome()
-		lndWallet := lndbackend.NewClientWallet(
-			lndSvc.Signer, lndSvc.WalletKit,
-		)
-		lndWallet.Log = fn.Some(s.subLogger(lndbackend.Subsystem))
-		oorSigner = lndWallet
-
-	case WalletTypeLwwallet:
-		oorSigner = s.lwWallet.UnsafeFromSome()
-
-	case WalletTypeBtcwallet:
-		oorSigner = s.btcwWallet.UnsafeFromSome()
+	oorSigner, err := s.oorSigner()
+	if err != nil {
+		return err
 	}
 
 	vtxoStore := dbStore.NewVTXOStore(s.clk)
@@ -3626,7 +3611,6 @@ func (s *Server) initOORActor(ctx context.Context,
 	}
 	oorKey := oor.NewServiceKey()
 
-	var err error
 	s.oorSigningEffect, err = oor.NewSigningEffectActor(
 		oor.SigningEffectActorConfig{
 			ActorID:       oor.SigningEffectActorID,
@@ -3798,6 +3782,30 @@ func (s *Server) initOORActor(ctx context.Context,
 	s.log.InfoS(ctx, "Incoming VTXO handler started")
 
 	return nil
+}
+
+// oorSigner returns the wallet signer used for OOR checkpoint inputs.
+func (s *Server) oorSigner() (input.Signer, error) {
+	switch s.cfg.Wallet.Type {
+	case WalletTypeLnd:
+		lndSvc := s.lnd.UnsafeFromSome()
+		lndWallet := lndbackend.NewClientWallet(
+			lndSvc.Signer, lndSvc.WalletKit,
+		)
+		lndWallet.Log = fn.Some(s.subLogger(lndbackend.Subsystem))
+
+		return lndWallet, nil
+
+	case WalletTypeLwwallet:
+		return s.lwWallet.UnsafeFromSome(), nil
+
+	case WalletTypeBtcwallet:
+		return s.btcwWallet.UnsafeFromSome(), nil
+
+	default:
+		return nil, fmt.Errorf("unsupported wallet type %v",
+			s.cfg.Wallet.Type)
+	}
 }
 
 // Compile-time assertions: every round.VTXOManagerMsg implementor must

--- a/darepod/wallet_ops.go
+++ b/darepod/wallet_ops.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
@@ -279,10 +281,57 @@ func BuildCustomTransferInputs(ctx context.Context, store vtxo.VTXOStore,
 			input.CustomSpend = spendPath
 		}
 
+		input.ExternalSignatures, err = customTaprootScriptSignatures(
+			ci.ExternalSignatures,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("decode external signatures "+
+				"for %s: %w", outpoint, err)
+		}
+
 		inputs = append(inputs, input)
 	}
 
 	return inputs, nil
+}
+
+// customTaprootScriptSignatures decodes RPC external signature records into
+// the OOR domain representation.
+func customTaprootScriptSignatures(
+	rpcSigs []*daemonrpc.TaprootScriptSignature) (
+	[]oor.ExternalTaprootScriptSignature, error) {
+
+	result := make([]oor.ExternalTaprootScriptSignature, 0, len(rpcSigs))
+	for i, rpcSig := range rpcSigs {
+		if rpcSig == nil {
+			return nil, fmt.Errorf("signature %d is nil", i)
+		}
+
+		pubKey, err := btcec.ParsePubKey(rpcSig.GetPubkey())
+		if err != nil {
+			return nil, fmt.Errorf("parse pubkey %d: %w", i, err)
+		}
+
+		if len(rpcSig.GetWitnessScript()) == 0 {
+			return nil, fmt.Errorf("signature %d witness script "+
+				"is required", i)
+		}
+
+		if len(rpcSig.GetSignature()) == 0 {
+			return nil, fmt.Errorf("signature %d is required", i)
+		}
+
+		result = append(result, oor.ExternalTaprootScriptSignature{
+			PubKey:        pubKey,
+			WitnessScript: bytes.Clone(rpcSig.GetWitnessScript()),
+			Signature:     bytes.Clone(rpcSig.GetSignature()),
+			SigHash: txscript.SigHashType(
+				rpcSig.GetSighash(),
+			),
+		})
+	}
+
+	return result, nil
 }
 
 // findSettlementOwnerLeaf maps a custom auth spend path to the
@@ -321,6 +370,12 @@ func findSettlementOwnerLeaf(template *arkscript.PolicyTemplate,
 
 		if !bytes.Equal(script, spendPath.WitnessScript) {
 			continue
+		}
+
+		if !localOperatorOnlyLeaf(
+			leaf.Node, participant, operator,
+		) {
+			return nil, nil, nil
 		}
 
 		encodedLeaf, err := leaf.Encode()
@@ -365,6 +420,12 @@ func findSettlementOwnerLeaf(template *arkscript.PolicyTemplate,
 				continue
 			}
 
+			if !localOperatorOnlyLeaf(
+				leaf.Node, participant, operator,
+			) {
+				return nil, nil, nil
+			}
+
 			encodedLeaf, err := leaf.Encode()
 			if err != nil {
 				return nil, nil, fmt.Errorf("encode "+
@@ -378,6 +439,50 @@ func findSettlementOwnerLeaf(template *arkscript.PolicyTemplate,
 	}
 
 	return nil, nil, fmt.Errorf("no settlement pair matches spend path")
+}
+
+// localOperatorOnlyLeaf reports whether the leaf's signing keys are exactly
+// the local participant and Ark operator. Other custom policy leaves still
+// remain valid as the checkpoint input spend, but the checkpoint output owner
+// path must be signable by the local OOR actor plus the operator cosigner.
+func localOperatorOnlyLeaf(node arkscript.Node,
+	participant, operator *btcec.PublicKey) bool {
+
+	keys := firstMultisigKeys(node)
+	if len(keys) != 2 {
+		return false
+	}
+
+	return sameXOnlyPubKey(keys[0], participant) &&
+		sameXOnlyPubKey(keys[1], operator)
+}
+
+// firstMultisigKeys extracts the signing key set from the first multisig node.
+func firstMultisigKeys(node arkscript.Node) []*btcec.PublicKey {
+	switch n := node.(type) {
+	case *arkscript.Multisig:
+		return append([]*btcec.PublicKey(nil), n.Keys...)
+
+	case *arkscript.Condition:
+		return firstMultisigKeys(n.Inner)
+
+	case *arkscript.CSV:
+		return firstMultisigKeys(n.Inner)
+
+	default:
+		return nil
+	}
+}
+
+// sameXOnlyPubKey compares pubkeys by their x-only taproot encoding.
+func sameXOnlyPubKey(a, b *btcec.PublicKey) bool {
+	if a == nil || b == nil {
+		return false
+	}
+
+	return bytes.Equal(
+		schnorr.SerializePubKey(a), schnorr.SerializePubKey(b),
+	)
 }
 
 // spendPathsMatch reports whether two semantic spend paths describe the same

--- a/darepod/wallet_ops_test.go
+++ b/darepod/wallet_ops_test.go
@@ -362,10 +362,10 @@ func TestReserveCustomInputsAtomicOnCollision(t *testing.T) {
 	release2()
 }
 
-// TestBuildCustomTransferInputsUsesPolicyLeaf verifies that a policy-backed
-// custom spend preserves the exact semantic policy leaf for the checkpoint
-// owner path instead of defaulting to a generic collab leaf.
-func TestBuildCustomTransferInputsUsesPolicyLeaf(t *testing.T) {
+// TestBuildCustomTransferInputsUsesLocalOperatorPolicyLeaf verifies that a
+// policy-backed custom spend preserves an exact semantic policy leaf when the
+// checkpoint owner path remains signable by the local client and operator.
+func TestBuildCustomTransferInputsUsesLocalOperatorPolicyLeaf(t *testing.T) {
 	t.Parallel()
 
 	policy, preimage, _, receiverPriv, serverPriv :=
@@ -415,6 +415,63 @@ func TestBuildCustomTransferInputsUsesPolicyLeaf(t *testing.T) {
 	ownerLeafScript, err := ownerLeaf.Script()
 	require.NoError(t, err)
 	require.Equal(t, claimPath.WitnessScript, ownerLeafScript)
+}
+
+// TestBuildCustomTransferInputsDefaultsMultiPartyRefundOwnerLeaf verifies that
+// a custom spend which needs an extra participant signature uses a standard
+// local/operator checkpoint owner leaf after the custom input spend itself.
+func TestBuildCustomTransferInputsDefaultsMultiPartyRefundOwnerLeaf(
+	t *testing.T) {
+
+	t.Parallel()
+
+	policy, _, senderPriv, _, serverPriv := testVHTLCPolicyFixture(t)
+
+	policyTemplate, err := policy.Template.Encode()
+	require.NoError(t, err)
+
+	pkScript, err := policy.PkScript()
+	require.NoError(t, err)
+
+	refundPath, err := policy.RefundPath()
+	require.NoError(t, err)
+
+	spendPath, err := refundPath.Encode()
+	require.NoError(t, err)
+
+	outpoint := testWalletOpsOutpoint(4)
+	clientKey := keychain.KeyDescriptor{
+		PubKey: senderPriv.PubKey(),
+		KeyLocator: keychain.KeyLocator{
+			Family: 7,
+			Index:  8,
+		},
+	}
+
+	inputs, err := BuildCustomTransferInputs(
+		t.Context(), &testCustomInputStore{},
+		[]*daemonrpc.CustomOORInput{{
+			Outpoint:           outpoint.String(),
+			VtxoPolicyTemplate: policyTemplate,
+			SpendPath:          spendPath,
+			AmountSat:          42_000,
+			PkScript:           pkScript,
+		}}, clientKey, serverPriv.PubKey(), 144,
+	)
+	require.NoError(t, err)
+	require.Len(t, inputs, 1)
+
+	input := inputs[0]
+	require.Empty(t, input.OwnerLeafScript)
+	require.Empty(t, input.OwnerLeafPolicy)
+	require.NoError(t, input.Validate())
+
+	defaultLeaf, err := arkscript.MultiSigCollabTapLeaf(
+		senderPriv.PubKey(), serverPriv.PubKey(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, defaultLeaf.Script, input.OwnerLeafScript)
+	require.NotEqual(t, refundPath.WitnessScript, input.OwnerLeafScript)
 }
 
 // TestFindSettlementOwnerLeafWithConditions verifies that a caller's

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	clientdb "github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/lib/tree"
@@ -106,6 +107,7 @@ const (
 	transferInputVTXOPolicyRecordType         tlv.Type = 14
 	transferInputRequiredSequenceRecordType   tlv.Type = 15
 	transferInputRequiredLockTimeRecordType   tlv.Type = 16
+	transferInputExternalSignaturesRecordType tlv.Type = 17
 )
 
 const (
@@ -1022,6 +1024,22 @@ func encodeTransferInputSnapshot(input *TransferInputSnapshot) ([]byte, error) {
 		)
 	}
 
+	if len(input.ExternalSignatures) > 0 {
+		sigBlob, sigErr := encodeExternalSignatures(
+			input.ExternalSignatures,
+		)
+		if sigErr != nil {
+			return nil, sigErr
+		}
+
+		records = append(
+			records, tlv.MakePrimitiveRecord(
+				transferInputExternalSignaturesRecordType,
+				&sigBlob,
+			),
+		)
+	}
+
 	stream, err := tlv.NewStream(records...)
 	if err != nil {
 		return nil, err
@@ -1051,6 +1069,7 @@ func decodeTransferInputSnapshot(raw []byte) (*TransferInputSnapshot, error) {
 		witnessScript      []byte
 		controlBlock       []byte
 		condBlob           []byte
+		externalSigBlob    []byte
 		requiredSequence   uint32
 		requiredLockTime   uint32
 	)
@@ -1109,6 +1128,10 @@ func decodeTransferInputSnapshot(raw []byte) (*TransferInputSnapshot, error) {
 			transferInputRequiredLockTimeRecordType,
 			&requiredLockTime,
 		),
+		tlv.MakePrimitiveRecord(
+			transferInputExternalSignaturesRecordType,
+			&externalSigBlob,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -1165,6 +1188,15 @@ func decodeTransferInputSnapshot(raw []byte) (*TransferInputSnapshot, error) {
 		snap.ConditionWitness = items
 	}
 
+	if len(externalSigBlob) > 0 {
+		sigs, sigErr := decodeExternalSignatures(externalSigBlob)
+		if sigErr != nil {
+			return nil, sigErr
+		}
+
+		snap.ExternalSignatures = sigs
+	}
+
 	return snap, nil
 }
 
@@ -1184,6 +1216,19 @@ const (
 	// cannot hold any value that could not actually make it onto
 	// the chain.
 	maxConditionWitnessItemBytes = 520
+
+	// maxExternalSignatures caps additional signatures carried by one
+	// custom input. Current vHTLC refunds need one external swap-server
+	// signature.
+	maxExternalSignatures = 8
+
+	// maxExternalSignatureScriptBytes caps the witness script copied into
+	// each external signature record.
+	maxExternalSignatureScriptBytes = 520
+
+	// maxExternalSignatureBytes caps Schnorr signatures plus optional
+	// sighash byte.
+	maxExternalSignatureBytes = 65
 )
 
 // encodeConditionWitness serializes a list of witness items as
@@ -1247,6 +1292,138 @@ func decodeConditionWitness(raw []byte) ([][]byte, error) {
 	}
 
 	return items, nil
+}
+
+// encodeExternalSignatures serializes pre-collected tapscript signatures into a
+// bounded durable blob.
+func encodeExternalSignatures(sigs []ExternalTaprootScriptSignature) ([]byte,
+	error) {
+
+	if len(sigs) > maxExternalSignatures {
+		return nil, fmt.Errorf("external signature count %d exceeds "+
+			"maximum %d", len(sigs), maxExternalSignatures)
+	}
+
+	var buf bytes.Buffer
+	if err := wire.WriteVarInt(&buf, 0, uint64(len(sigs))); err != nil {
+		return nil, err
+	}
+
+	for i := range sigs {
+		sig := sigs[i]
+		if sig.PubKey == nil {
+			return nil, fmt.Errorf("external signature %d pubkey "+
+				"is required", i)
+		}
+
+		if len(sig.WitnessScript) > maxExternalSignatureScriptBytes {
+			return nil, fmt.Errorf("external signature %d witness "+
+				"script size %d exceeds maximum %d", i,
+				len(sig.WitnessScript),
+				maxExternalSignatureScriptBytes)
+		}
+
+		if len(sig.Signature) > maxExternalSignatureBytes {
+			return nil, fmt.Errorf("external signature %d size %d "+
+				"exceeds maximum %d", i, len(sig.Signature),
+				maxExternalSignatureBytes)
+		}
+
+		if err := wire.WriteVarBytes(
+			&buf, 0, sig.PubKey.SerializeCompressed(),
+		); err != nil {
+			return nil, err
+		}
+
+		if err := wire.WriteVarBytes(
+			&buf, 0, sig.WitnessScript,
+		); err != nil {
+			return nil, err
+		}
+
+		if err := wire.WriteVarBytes(
+			&buf, 0, sig.Signature,
+		); err != nil {
+			return nil, err
+		}
+
+		if err := binary.Write(
+			&buf, binary.BigEndian, uint32(sig.SigHash),
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// decodeExternalSignatures deserializes the bounded durable external signature
+// blob.
+func decodeExternalSignatures(raw []byte) ([]ExternalTaprootScriptSignature,
+	error) {
+
+	r := bytes.NewReader(raw)
+	count, err := wire.ReadVarInt(r, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	if count > maxExternalSignatures {
+		return nil, fmt.Errorf("external signature count %d exceeds "+
+			"maximum %d", count, maxExternalSignatures)
+	}
+
+	result := make([]ExternalTaprootScriptSignature, 0, count)
+	for i := uint64(0); i < count; i++ {
+		pubKeyBytes, err := wire.ReadVarBytes(
+			r, 0, 33, "external signature pubkey",
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		pubKey, err := btcec.ParsePubKey(pubKeyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse external signature "+
+				"pubkey %d: %w", i, err)
+		}
+
+		witnessScript, err := wire.ReadVarBytes(
+			r, 0, maxExternalSignatureScriptBytes,
+			"external signature witness script",
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		signature, err := wire.ReadVarBytes(
+			r, 0, maxExternalSignatureBytes, "external signature",
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		var sigHash uint32
+		if err := binary.Read(
+			r, binary.BigEndian, &sigHash,
+		); err != nil {
+			return nil, err
+		}
+
+		result = append(result, ExternalTaprootScriptSignature{
+			PubKey:        pubKey,
+			WitnessScript: witnessScript,
+			Signature:     signature,
+			SigHash:       txscript.SigHashType(sigHash),
+		})
+	}
+
+	if r.Len() != 0 {
+		return nil, fmt.Errorf("external signatures contain trailing " +
+			"bytes")
+	}
+
+	return result, nil
 }
 
 func encodeSessionPayload(sessionID SessionID) ([]byte, error) {

--- a/oor/checkpoint_sign.go
+++ b/oor/checkpoint_sign.go
@@ -2,6 +2,7 @@ package oor
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -15,6 +16,11 @@ import (
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 )
+
+// ErrCustomCheckpointInputSigning means the prepared checkpoint input passed
+// validation, but the local signer failed to produce a signature.
+var ErrCustomCheckpointInputSigning = errors.New("custom checkpoint input " +
+	"signing failed")
 
 // SignCheckpointPSBTs attaches the client-side collaborative VTXO spend
 // signatures to each checkpoint PSBT.
@@ -453,48 +459,9 @@ func signCustomCheckpointPSBT(signer input.Signer, in *TransferInput,
 			len(checkpoint.UnsignedTx.TxIn), len(checkpoint.Inputs))
 	}
 
-	// Defense-in-depth binding check: the caller-supplied witness script
-	// and control block must commit to a taproot output whose P2TR script
-	// is exactly the VTXO's pkScript. Without this, a malformed control
-	// block would coerce the signer into producing a Schnorr signature
-	// over an attacker-chosen tapscript. BuildCustomTransferInputs
-	// performs the same check at the RPC boundary; we re-verify here so
-	// downstream paths that bypass that constructor (e.g. persisted
-	// TransferInputSnapshots resumed from disk) are still covered.
-	if err := in.CustomSpend.VerifyBindsToPkScript(
-		in.VTXO.PkScript,
-	); err != nil {
-		return fmt.Errorf("custom spend path does not bind to VTXO "+
-			"pkScript: %w", err)
-	}
-
-	prevOut := &wire.TxOut{
-		Value:    int64(in.VTXO.Amount),
-		PkScript: in.VTXO.PkScript,
-	}
-
-	prevFetcher := txscript.NewCannedPrevOutputFetcher(
-		prevOut.PkScript, prevOut.Value,
-	)
-
-	sigHashes := txscript.NewTxSigHashes(
-		checkpoint.UnsignedTx, prevFetcher,
-	)
-
-	// Build the sign descriptor directly from the custom SpendInfo
-	// rather than deriving it from the VTXO's collaborative leaf.
-	signDesc := in.CustomSpend.SpendInfo.BuildSignDescriptor(
-		in.VTXO.ClientKey, prevOut, sigHashes, prevFetcher, 0,
-	)
-
-	sig, err := signer.SignOutputRaw(checkpoint.UnsignedTx, signDesc)
+	localSig, err := SignCustomCheckpointInput(signer, in, checkpoint)
 	if err != nil {
-		return fmt.Errorf("sign output: %w", err)
-	}
-
-	sigBytes := sig.Serialize()
-	if len(sigBytes) == 0 {
-		return fmt.Errorf("signer returned empty signature")
+		return err
 	}
 
 	// Attach the custom leaf script and client signature to the PSBT.
@@ -510,17 +477,24 @@ func signCustomCheckpointPSBT(signer input.Signer, in *TransferInput,
 
 	err = psbtutil.AddTaprootScriptSpendSig(
 		&checkpoint.Inputs[0], in.VTXO.ClientKey.PubKey,
-		in.CustomSpend.SpendInfo.WitnessScript, sigBytes,
-		signDesc.HashType,
+		in.CustomSpend.SpendInfo.WitnessScript, localSig.Signature,
+		localSig.SigHash,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = attachExternalTaprootScriptSignatures(
+		in, &checkpoint.Inputs[0],
 	)
 	if err != nil {
 		return err
 	}
 
 	// If condition witness items are provided (e.g., hashlock
-	// preimage), assemble and set the final script witness. This
-	// combines the operator sig, client sig, condition items,
-	// witness script, and control block into BIP-174
+	// preimage), or if all custom-spend keys are known, assemble and set
+	// the final script witness. This combines all required signatures,
+	// condition items, witness script, and control block into BIP-174
 	// FinalScriptWitness format.
 	if len(in.CustomSpend.Conditions) > 0 {
 		err = arkscript.PutConditionWitnessPSBTInput(
@@ -529,7 +503,9 @@ func signCustomCheckpointPSBT(signer input.Signer, in *TransferInput,
 		if err != nil {
 			return err
 		}
+	}
 
+	if len(in.CustomSpendKeys) > 0 || len(in.CustomSpend.Conditions) > 0 {
 		err = assembleCustomFinalWitness(
 			in, &checkpoint.Inputs[0],
 		)
@@ -541,24 +517,156 @@ func signCustomCheckpointPSBT(signer input.Signer, in *TransferInput,
 	return nil
 }
 
+// SignCustomCheckpointInput signs a checkpoint input using the transfer
+// input's custom spend path and returns the raw tapscript signature.
+func SignCustomCheckpointInput(signer input.Signer, in *TransferInput,
+	checkpoint *psbt.Packet) (*ExternalTaprootScriptSignature, error) {
+
+	if signer == nil {
+		return nil, fmt.Errorf("signer must be provided")
+	}
+
+	if in == nil || in.VTXO == nil || in.CustomSpend == nil {
+		return nil, fmt.Errorf("custom transfer input is required")
+	}
+
+	if checkpoint == nil || checkpoint.UnsignedTx == nil {
+		return nil, fmt.Errorf("checkpoint psbt must include " +
+			"unsigned tx")
+	}
+
+	if len(checkpoint.UnsignedTx.TxIn) != 1 ||
+		len(checkpoint.Inputs) != 1 {
+		return nil, fmt.Errorf("checkpoint psbt must have exactly one "+
+			"input, got tx=%d psbt=%d",
+			len(checkpoint.UnsignedTx.TxIn), len(checkpoint.Inputs))
+	}
+
+	if err := in.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Defense-in-depth binding check: the caller-supplied witness script
+	// and control block must commit to a taproot output whose P2TR script
+	// is exactly the VTXO's pkScript. Without this, a malformed control
+	// block would coerce the signer into producing a Schnorr signature
+	// over an attacker-chosen tapscript.
+	if err := in.CustomSpend.VerifyBindsToPkScript(
+		in.VTXO.PkScript,
+	); err != nil {
+		return nil, fmt.Errorf("custom spend path does not bind to "+
+			"VTXO pkScript: %w", err)
+	}
+
+	prevOut := &wire.TxOut{
+		Value:    int64(in.VTXO.Amount),
+		PkScript: in.VTXO.PkScript,
+	}
+
+	prevFetcher := txscript.NewCannedPrevOutputFetcher(
+		prevOut.PkScript, prevOut.Value,
+	)
+	sigHashes := txscript.NewTxSigHashes(
+		checkpoint.UnsignedTx, prevFetcher,
+	)
+
+	signDesc := in.CustomSpend.SpendInfo.BuildSignDescriptor(
+		in.VTXO.ClientKey, prevOut, sigHashes, prevFetcher, 0,
+	)
+
+	sig, err := signer.SignOutputRaw(checkpoint.UnsignedTx, signDesc)
+	if err != nil {
+		return nil, fmt.Errorf("%w: sign output: %w",
+			ErrCustomCheckpointInputSigning, err)
+	}
+
+	sigBytes := sig.Serialize()
+	if len(sigBytes) == 0 {
+		return nil, fmt.Errorf("%w: signer returned empty signature",
+			ErrCustomCheckpointInputSigning)
+	}
+
+	return &ExternalTaprootScriptSignature{
+		PubKey:        in.VTXO.ClientKey.PubKey,
+		WitnessScript: in.CustomSpend.SpendInfo.WitnessScript,
+		Signature:     sigBytes,
+		SigHash:       signDesc.HashType,
+	}, nil
+}
+
+// attachExternalTaprootScriptSignatures copies externally produced custom
+// spend signatures into the checkpoint PSBT input.
+func attachExternalTaprootScriptSignatures(in *TransferInput,
+	pIn *psbt.PInput) error {
+
+	if len(in.ExternalSignatures) == 0 {
+		return nil
+	}
+
+	for i := range in.ExternalSignatures {
+		externalSig := in.ExternalSignatures[i]
+		if externalSig.PubKey == nil {
+			return fmt.Errorf("external signature %d pubkey is "+
+				"required", i)
+		}
+
+		if !bytes.Equal(
+			externalSig.WitnessScript,
+			in.CustomSpend.SpendInfo.WitnessScript,
+		) {
+			return fmt.Errorf("external signature %d witness "+
+				"script mismatch", i)
+		}
+
+		required := false
+		for _, spendKey := range in.CustomSpendKeys {
+			if spendKey == nil {
+				continue
+			}
+
+			if bytes.Equal(
+				schnorr.SerializePubKey(externalSig.PubKey),
+				schnorr.SerializePubKey(spendKey),
+			) {
+
+				required = true
+				break
+			}
+		}
+		if !required {
+			return fmt.Errorf("external signature %d pubkey is "+
+				"not required by custom spend path", i)
+		}
+
+		err := psbtutil.AddTaprootScriptSpendSig(
+			pIn, externalSig.PubKey, externalSig.WitnessScript,
+			externalSig.Signature, externalSig.SigHash,
+		)
+		if err != nil {
+			return fmt.Errorf("add external signature %d: %w", i,
+				err)
+		}
+	}
+
+	return nil
+}
+
 // assembleCustomFinalWitness builds the FinalScriptWitness for a custom
 // spend path that requires condition witness elements beyond signatures.
 //
-// The witness stack is: [op_sig, client_sig, ...conditionItems,
-// witnessScript, controlBlock].
+// The witness stack is: [signatures in reverse script-key order,
+// ...conditionItems, witnessScript, controlBlock].
 func assembleCustomFinalWitness(in *TransferInput, pIn *psbt.PInput) error {
-	clientKeyBytes := schnorr.SerializePubKey(
-		in.VTXO.ClientKey.PubKey,
-	)
 	leafHash := txscript.NewBaseTapLeaf(
 		in.CustomSpend.SpendInfo.WitnessScript,
 	).TapHash()
 	leafHashBytes := leafHash[:]
 
-	// Find the operator sig: any TaprootScriptSpendSig that is NOT
-	// the client key on the same leaf.
-	var opSigBytes []byte
-	var clientSigBytes []byte
+	if len(in.CustomSpendKeys) == 0 {
+		return fmt.Errorf("custom spend key order is required")
+	}
+
+	sigsByPubKey := make(map[string][]byte, len(pIn.TaprootScriptSpendSig))
 
 	for _, sigRec := range pIn.TaprootScriptSpendSig {
 		if sigRec == nil {
@@ -569,28 +677,29 @@ func assembleCustomFinalWitness(in *TransferInput, pIn *psbt.PInput) error {
 			continue
 		}
 
-		if bytes.Equal(sigRec.XOnlyPubKey, clientKeyBytes) {
-			clientSigBytes = sigRec.Signature
-		} else {
-			opSigBytes = sigRec.Signature
-		}
+		sigsByPubKey[string(sigRec.XOnlyPubKey)] = sigRec.Signature
 	}
 
-	if len(opSigBytes) == 0 {
-		return fmt.Errorf("operator signature not found in psbt input")
-	}
-
-	if len(clientSigBytes) == 0 {
-		return fmt.Errorf("client signature not found in psbt input")
-	}
-
-	// Build the witness stack: op_sig, client_sig,
-	// ...conditionItems, witnessScript, controlBlock.
-	witnessItems := make([][]byte, 0,
-		2+len(in.CustomSpend.Conditions)+2,
+	witnessItems := make(
+		[][]byte, 0,
+		len(in.CustomSpendKeys)+len(in.CustomSpend.Conditions)+2,
 	)
-	witnessItems = append(witnessItems, opSigBytes)
-	witnessItems = append(witnessItems, clientSigBytes)
+	for i := len(in.CustomSpendKeys) - 1; i >= 0; i-- {
+		pubKey := in.CustomSpendKeys[i]
+		if pubKey == nil {
+			return fmt.Errorf("custom spend key %d is nil", i)
+		}
+
+		pubKeyBytes := schnorr.SerializePubKey(pubKey)
+		sigBytes := sigsByPubKey[string(pubKeyBytes)]
+		if len(sigBytes) == 0 {
+			return fmt.Errorf("signature for custom spend key %x "+
+				"not found in psbt input", pubKeyBytes)
+		}
+
+		witnessItems = append(witnessItems, sigBytes)
+	}
+
 	witnessItems = append(witnessItems, in.CustomSpend.Conditions...)
 	witnessItems = append(
 		witnessItems, in.CustomSpend.SpendInfo.WitnessScript,

--- a/oor/checkpoint_sign_test.go
+++ b/oor/checkpoint_sign_test.go
@@ -1,0 +1,50 @@
+package oor
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttachExternalTaprootScriptSignaturesRejectsUnexpectedPubKey verifies an
+// external signature must come from a key required by the custom spend path.
+func TestAttachExternalTaprootScriptSignaturesRejectsUnexpectedPubKey(
+	t *testing.T) {
+
+	t.Parallel()
+
+	_, requiredKey := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x01}, 32))
+	_, unexpectedKey := btcec.PrivKeyFromBytes(
+		bytes.Repeat(
+			[]byte{0x02}, 32,
+		),
+	)
+	witnessScript := []byte{0x51}
+
+	input := &TransferInput{
+		CustomSpend: &arkscript.SpendPath{
+			SpendInfo: &arkscript.SpendInfo{
+				WitnessScript: witnessScript,
+			},
+		},
+		CustomSpendKeys: []*btcec.PublicKey{
+			requiredKey,
+		},
+		ExternalSignatures: []ExternalTaprootScriptSignature{
+			{
+				PubKey:        unexpectedKey,
+				WitnessScript: witnessScript,
+				Signature: []byte{
+					0x01,
+				},
+			},
+		},
+	}
+
+	err := attachExternalTaprootScriptSignatures(input, &psbt.PInput{})
+	require.ErrorContains(t, err, "pubkey is not required")
+}

--- a/oor/transfer_input_snapshot.go
+++ b/oor/transfer_input_snapshot.go
@@ -75,6 +75,10 @@ type TransferInputSnapshot struct {
 	// path. It must survive snapshots together with RequiredSequence for
 	// CLTV-gated leaves such as vHTLC refunds.
 	RequiredLockTime uint32
+
+	// ExternalSignatures are pre-collected tapscript signatures needed to
+	// resume custom OOR spends after restart.
+	ExternalSignatures []ExternalTaprootScriptSignature
 }
 
 // ToSnapshot converts the transfer input into a portable snapshot.
@@ -125,6 +129,7 @@ func (i *TransferInput) ToSnapshot() (*TransferInputSnapshot, error) {
 		snap.RequiredSequence = i.CustomSpend.RequiredSequence
 		snap.RequiredLockTime = i.CustomSpend.RequiredLockTime
 	}
+	snap.ExternalSignatures = cloneExternalSignatures(i.ExternalSignatures)
 
 	return snap, nil
 }
@@ -227,6 +232,9 @@ func TransferInputFromSnapshot(snap *TransferInputSnapshot) (TransferInput,
 			RequiredLockTime: snap.RequiredLockTime,
 		}
 	}
+	result.ExternalSignatures = cloneExternalSignatures(
+		snap.ExternalSignatures,
+	)
 
 	// For custom spend paths, use the stored PkScript instead of
 	// deriving from keys.
@@ -235,4 +243,28 @@ func TransferInputFromSnapshot(snap *TransferInputSnapshot) (TransferInput,
 	}
 
 	return result, nil
+}
+
+// cloneExternalSignatures deep-copies custom input external signatures.
+func cloneExternalSignatures(
+	sigs []ExternalTaprootScriptSignature,
+) []ExternalTaprootScriptSignature {
+
+	if len(sigs) == 0 {
+		return nil
+	}
+
+	result := make([]ExternalTaprootScriptSignature, len(sigs))
+	for i := range sigs {
+		// btcec.PublicKey is treated as immutable; clone the mutable
+		// byte slices while sharing the parsed key object.
+		result[i] = ExternalTaprootScriptSignature{
+			PubKey:        sigs[i].PubKey,
+			WitnessScript: bytes.Clone(sigs[i].WitnessScript),
+			Signature:     bytes.Clone(sigs[i].Signature),
+			SigHash:       sigs[i].SigHash,
+		}
+	}
+
+	return result
 }

--- a/oor/transfer_inputs.go
+++ b/oor/transfer_inputs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
@@ -42,6 +43,32 @@ type TransferInput struct {
 	// for non-standard VTXOs (e.g., vHTLC Claim path). When set,
 	// checkpoint signing uses this spend path directly.
 	CustomSpend *arkscript.SpendPath
+
+	// CustomSpendKeys are the public keys required by CustomSpend in script
+	// evaluation order. Witness assembly reverses this order because
+	// CHECKSIGVERIFY consumes signatures from the top of the stack.
+	CustomSpendKeys []*btcec.PublicKey
+
+	// ExternalSignatures are tapscript signatures produced by additional
+	// custom-spend participants before the local daemon adds its signature.
+	ExternalSignatures []ExternalTaprootScriptSignature
+}
+
+// ExternalTaprootScriptSignature carries one externally produced tapscript
+// signature for a custom OOR input.
+type ExternalTaprootScriptSignature struct {
+	// PubKey is the compressed public key that produced the signature.
+	PubKey *btcec.PublicKey
+
+	// WitnessScript is the tapscript leaf this signature commits to.
+	WitnessScript []byte
+
+	// Signature is the raw Schnorr signature, optionally followed by a
+	// one-byte sighash type when SigHash is not SIGHASH_DEFAULT.
+	Signature []byte
+
+	// SigHash is the tapscript sighash type. Zero means SIGHASH_DEFAULT.
+	SigHash txscript.SigHashType
 }
 
 // InputOutpoints returns the VTXO outpoints for the transfer inputs.
@@ -133,6 +160,19 @@ func (i *TransferInput) Validate() error {
 		return fmt.Errorf("owner leaf policy must be provided")
 	}
 
+	if i.CustomSpend != nil && len(i.CustomSpendKeys) == 0 &&
+		len(i.VTXOPolicyTemplate) > 0 {
+
+		keys, err := customSpendKeys(
+			i.VTXOPolicyTemplate, i.CustomSpend,
+		)
+		if err != nil {
+			return err
+		}
+
+		i.CustomSpendKeys = keys
+	}
+
 	return nil
 }
 
@@ -193,6 +233,60 @@ func (i *TransferInput) EffectiveSpendPath() (*arkscript.SpendPath, error) {
 // leaf.
 func (i *TransferInput) IsCustomSpend() bool {
 	return i.CustomSpend != nil
+}
+
+// customSpendKeys returns the signing keys required by spendPath in script
+// order by matching the spend path witness script to the semantic policy leaf.
+func customSpendKeys(policyTemplate []byte,
+	spendPath *arkscript.SpendPath) ([]*btcec.PublicKey, error) {
+
+	if spendPath == nil {
+		return nil, fmt.Errorf("custom spend path must be provided")
+	}
+
+	template, err := arkscript.DecodePolicyTemplate(policyTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("decode custom spend policy: %w", err)
+	}
+
+	for _, leaf := range template.Leaves {
+		script, err := leaf.Script()
+		if err != nil {
+			return nil, fmt.Errorf("compile custom spend leaf: %w",
+				err)
+		}
+
+		if !bytes.Equal(script, spendPath.WitnessScript) {
+			continue
+		}
+
+		keys := multisigKeys(leaf.Node)
+		if len(keys) == 0 {
+			return nil, fmt.Errorf("custom spend leaf has no " +
+				"multisig keys")
+		}
+
+		return keys, nil
+	}
+
+	return nil, fmt.Errorf("custom spend leaf not found in policy")
+}
+
+// multisigKeys extracts the first multisig key set from a semantic node.
+func multisigKeys(node arkscript.Node) []*btcec.PublicKey {
+	switch n := node.(type) {
+	case *arkscript.Multisig:
+		return append([]*btcec.PublicKey(nil), n.Keys...)
+
+	case *arkscript.Condition:
+		return multisigKeys(n.Inner)
+
+	case *arkscript.CSV:
+		return multisigKeys(n.Inner)
+
+	default:
+		return nil
+	}
 }
 
 // defaultVTXOPolicyTemplate derives the standard semantic policy for inputs

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -509,6 +509,17 @@ func buildSubmitPackage(policy arkscript.CheckpointPolicy,
 	inputs []TransferInput, outputs []oortx.RecipientOutput) (*psbt.Packet,
 	[]*psbt.Packet, error) {
 
+	return BuildSubmitPackage(policy, inputs, outputs)
+}
+
+// BuildSubmitPackage constructs a v0 OOR submit package using the shared
+// darepo-client lib/tx/oor primitives. It only builds deterministic PSBTs from
+// caller-provided inputs and outputs; it does not acquire wallet locks, select
+// wallet inputs, or persist OOR session state.
+func BuildSubmitPackage(policy arkscript.CheckpointPolicy,
+	inputs []TransferInput, outputs []oortx.RecipientOutput) (*psbt.Packet,
+	[]*psbt.Packet, error) {
+
 	if len(inputs) == 0 {
 		return nil, nil, fmt.Errorf("checkpoint inputs required")
 	}

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -175,6 +175,19 @@ func (c *SwapServiceClient) CreateInSwap(ctx context.Context,
 	return out, err
 }
 
+// AuthorizeInSwapRefund asks the swap server to sign a failed in-swap refund.
+func (c *SwapServiceClient) AuthorizeInSwapRefund(ctx context.Context,
+	in *swaprpc.AuthorizeInSwapRefundRequest, _ ...grpc.CallOption) (
+	*swaprpc.AuthorizeInSwapRefundResponse, error) {
+
+	out := new(swaprpc.AuthorizeInSwapRefundResponse)
+	err := c.client.Post(
+		ctx, "/v1/swap/authorize-in-swap-refund", in, out,
+	)
+
+	return out, err
+}
+
 // NewDaemonServiceClient creates a DaemonService REST client.
 func NewDaemonServiceClient(addr string,
 	opts ...Option) daemonrpc.DaemonServiceClient {
@@ -375,6 +388,28 @@ func (c *DaemonServiceClient) SendOOR(ctx context.Context,
 
 	out := new(daemonrpc.SendOORResponse)
 	err := c.client.Post(ctx, "/v1/daemon/send-oor", in, out)
+
+	return out, err
+}
+
+// PrepareOOR builds an out-of-round transfer package without submitting it.
+func (c *DaemonServiceClient) PrepareOOR(ctx context.Context,
+	in *daemonrpc.PrepareOORRequest, _ ...grpc.CallOption) (
+	*daemonrpc.PrepareOORResponse, error) {
+
+	out := new(daemonrpc.PrepareOORResponse)
+	err := c.client.Post(ctx, "/v1/daemon/prepare-oor", in, out)
+
+	return out, err
+}
+
+// SignOORCustomInput signs one prepared custom OOR input.
+func (c *DaemonServiceClient) SignOORCustomInput(ctx context.Context,
+	in *daemonrpc.SignOORCustomInputRequest, _ ...grpc.CallOption) (
+	*daemonrpc.SignOORCustomInputResponse, error) {
+
+	out := new(daemonrpc.SignOORCustomInputResponse)
+	err := c.client.Post(ctx, "/v1/daemon/sign-oor-custom-input", in, out)
 
 	return out, err
 }

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -277,6 +277,58 @@ type CustomOORInput struct {
 
 	// PkScript is the raw taproot output script of the spent VTXO.
 	PkScript []byte
+
+	// ExternalSignatures are tapscript signatures produced by additional
+	// parties required by the selected spend path.
+	ExternalSignatures []TaprootScriptSignature
+}
+
+// TaprootScriptSignature carries one externally produced tapscript signature
+// for a custom OOR input.
+type TaprootScriptSignature struct {
+	// PubKey is the compressed public key that produced the signature.
+	PubKey []byte
+
+	// WitnessScript is the tapscript leaf this signature commits to.
+	WitnessScript []byte
+
+	// Signature is the raw Schnorr signature, optionally followed by a
+	// one-byte sighash type when the sighash is not SIGHASH_DEFAULT.
+	Signature []byte
+
+	// SigHash is the tapscript sighash type. Zero means SIGHASH_DEFAULT.
+	SigHash uint32
+}
+
+// PreparedOORCustomInput carries signing data for one prepared custom input.
+type PreparedOORCustomInput struct {
+	// Outpoint identifies the custom input.
+	Outpoint string
+
+	// CheckpointPSBT is the serialized unsigned checkpoint PSBT to sign.
+	CheckpointPSBT []byte
+
+	// WitnessScript is the tapscript leaf external parties must sign.
+	WitnessScript []byte
+
+	// SigningPubKeys are the compressed public keys required by the spend
+	// path in script order.
+	SigningPubKeys [][]byte
+}
+
+// PreparedOOR describes the deterministic package returned by PrepareOOR.
+type PreparedOOR struct {
+	// ArkPSBT is the serialized unsigned Ark PSBT.
+	ArkPSBT []byte
+
+	// CheckpointPSBTs are the serialized unsigned checkpoint PSBTs.
+	CheckpointPSBTs [][]byte
+
+	// CustomInputs carries signing data for each prepared custom input.
+	CustomInputs []PreparedOORCustomInput
+
+	// SessionID is the deterministic OOR session id.
+	SessionID string
 }
 
 // WrapDaemonClient creates an Ark SDK facade from an already-connected daemon
@@ -830,19 +882,6 @@ func (c *Client) SendOORWithCustomInputs(ctx context.Context,
 	recipientPubKey []byte, amountSat int64, inputs []CustomOORInput) (
 	string, error) {
 
-	rpcInputs := make([]*daemonrpc.CustomOORInput, len(inputs))
-	for i := range inputs {
-		rpcInputs[i] = &daemonrpc.CustomOORInput{
-			Outpoint: inputs[i].Outpoint,
-			VtxoPolicyTemplate: append(
-				[]byte(nil), inputs[i].VTXOPolicyTemplate...,
-			),
-			SpendPath: append([]byte(nil), inputs[i].SpendPath...),
-			AmountSat: inputs[i].AmountSat,
-			PkScript:  append([]byte(nil), inputs[i].PkScript...),
-		}
-	}
-
 	resp, err := c.SendOOR(ctx, &daemonrpc.SendOORRequest{
 		Recipient: &daemonrpc.Output{
 			Destination: &daemonrpc.Output_Pubkey{
@@ -850,7 +889,7 @@ func (c *Client) SendOORWithCustomInputs(ctx context.Context,
 			},
 			AmountSat: amountSat,
 		},
-		CustomInputs: rpcInputs,
+		CustomInputs: customOORInputsToRPC(inputs),
 	})
 	if err != nil {
 		return "", err
@@ -930,6 +969,155 @@ func (c *Client) GetVHTLCRecoveryStatus(ctx context.Context,
 	}
 
 	return resp, nil
+}
+
+// PrepareOORWithCustomInputs builds a deterministic custom-input OOR package
+// without submitting it.
+func (c *Client) PrepareOORWithCustomInputs(ctx context.Context,
+	recipientPubKey []byte, amountSat int64, inputs []CustomOORInput) (
+	*PreparedOOR, error) {
+
+	rpcInputs := customOORInputsToRPC(inputs)
+	resp, err := c.daemon.PrepareOOR(
+		ctx, &daemonrpc.PrepareOORRequest{
+			Recipient: &daemonrpc.Output{
+				Destination: &daemonrpc.Output_Pubkey{
+					Pubkey: append(
+						[]byte(nil), recipientPubKey...,
+					),
+				},
+				AmountSat: amountSat,
+			},
+			CustomInputs: rpcInputs,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	preparedInputs := make(
+		[]PreparedOORCustomInput, 0,
+		len(
+			resp.GetCustomInputs(),
+		),
+	)
+	for _, input := range resp.GetCustomInputs() {
+		signingPubKeys := make(
+			[][]byte, 0,
+			len(
+				input.GetSigningPubkeys(),
+			),
+		)
+		for _, key := range input.GetSigningPubkeys() {
+			signingPubKeys = append(
+				signingPubKeys,
+				append(
+					[]byte(nil), key...,
+				),
+			)
+		}
+
+		preparedInputs = append(preparedInputs, PreparedOORCustomInput{
+			Outpoint: input.GetOutpoint(),
+			CheckpointPSBT: append(
+				[]byte(nil), input.GetCheckpointPsbt()...,
+			),
+			WitnessScript: append(
+				[]byte(nil), input.GetWitnessScript()...,
+			),
+			SigningPubKeys: signingPubKeys,
+		})
+	}
+
+	checkpoints := make([][]byte, 0, len(resp.GetCheckpointPsbts()))
+	for _, checkpoint := range resp.GetCheckpointPsbts() {
+		checkpoints = append(
+			checkpoints,
+			append(
+				[]byte(nil), checkpoint...,
+			),
+		)
+	}
+
+	return &PreparedOOR{
+		ArkPSBT:         append([]byte(nil), resp.GetArkPsbt()...),
+		CheckpointPSBTs: checkpoints,
+		CustomInputs:    preparedInputs,
+		SessionID:       resp.GetSessionId(),
+	}, nil
+}
+
+// SignOORCustomInput asks the daemon identity key to sign one prepared custom
+// OOR input.
+func (c *Client) SignOORCustomInput(ctx context.Context, input CustomOORInput,
+	checkpointPSBT []byte) (*TaprootScriptSignature, error) {
+
+	resp, err := c.daemon.SignOORCustomInput(
+		ctx, &daemonrpc.SignOORCustomInputRequest{
+			CustomInput:    customOORInputToRPC(input),
+			CheckpointPsbt: append([]byte(nil), checkpointPSBT...),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	sig := resp.GetSignature()
+	if sig == nil {
+		return nil, fmt.Errorf("daemon returned empty custom input " +
+			"signature")
+	}
+
+	return &TaprootScriptSignature{
+		PubKey:        append([]byte(nil), sig.GetPubkey()...),
+		WitnessScript: append([]byte(nil), sig.GetWitnessScript()...),
+		Signature:     append([]byte(nil), sig.GetSignature()...),
+		SigHash:       sig.GetSighash(),
+	}, nil
+}
+
+// customOORInputsToRPC converts SDK custom input structs to RPC messages.
+func customOORInputsToRPC(inputs []CustomOORInput) []*daemonrpc.CustomOORInput {
+	rpcInputs := make([]*daemonrpc.CustomOORInput, len(inputs))
+	for i := range inputs {
+		rpcInputs[i] = customOORInputToRPC(inputs[i])
+	}
+
+	return rpcInputs
+}
+
+// customOORInputToRPC converts one SDK custom input struct to an RPC message.
+func customOORInputToRPC(input CustomOORInput) *daemonrpc.CustomOORInput {
+	externalSigs := make(
+		[]*daemonrpc.TaprootScriptSignature, 0,
+		len(input.ExternalSignatures),
+	)
+	for j := range input.ExternalSignatures {
+		sig := input.ExternalSignatures[j]
+		externalSigs = append(
+			externalSigs, &daemonrpc.TaprootScriptSignature{
+				Pubkey: append([]byte(nil), sig.PubKey...),
+				WitnessScript: append(
+					[]byte(nil), sig.WitnessScript...,
+				),
+				Signature: append(
+					[]byte(nil), sig.Signature...,
+				),
+				Sighash: sig.SigHash,
+			},
+		)
+	}
+
+	return &daemonrpc.CustomOORInput{
+		Outpoint: input.Outpoint,
+		VtxoPolicyTemplate: append(
+			[]byte(nil), input.VTXOPolicyTemplate...,
+		),
+		SpendPath:          append([]byte(nil), input.SpendPath...),
+		AmountSat:          input.AmountSat,
+		PkScript:           append([]byte(nil), input.PkScript...),
+		ExternalSignatures: externalSigs,
+	}
 }
 
 // ListLiveVTXOs returns the daemon's live spendable VTXOs as typed SDK-owned

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -363,6 +363,14 @@ type SwapServerConn interface {
 	CreateInSwap(ctx context.Context, invoice string, maxFeeSat uint64,
 		clientVhtlcPubkey *btcec.PublicKey) (*InSwapConfig, error)
 
+	// AuthorizeInSwapRefund asks the swap server to sign one exact
+	// cooperative refund spend after it has safely failed the Lightning
+	// payment.
+	AuthorizeInSwapRefund(ctx context.Context, paymentHash lntypes.Hash,
+		vhtlcOutpoint string, vhtlcAmountSat int64, vhtlcPolicyTemplate,
+		refundSpendPath,
+		checkpointPSBT []byte) (*InSwapRefundAuthorization, error)
+
 	// Close closes the connection.
 	Close() error
 }
@@ -410,6 +418,11 @@ type DaemonConn interface {
 	GetVHTLCRecoveryStatus(ctx context.Context,
 		req *daemonrpc.GetVHTLCRecoveryStatusRequest) (
 		*daemonrpc.GetVHTLCRecoveryStatusResponse, error)
+
+	// PrepareOORWithCustomInputs builds a deterministic custom-input OOR
+	// package without submitting it.
+	PrepareOORWithCustomInputs(ctx context.Context, recipientPubKey []byte,
+		amountSat int64, inputs []CustomInput) (*PreparedOOR, error)
 
 	// IdentityPubKey returns the client's identity pubkey.
 	IdentityPubKey(ctx context.Context) (*btcec.PublicKey, error)
@@ -467,11 +480,32 @@ type DaemonConn interface {
 // CustomInput aliases the Ark SDK's typed custom OOR input.
 type CustomInput = sdkark.CustomOORInput
 
+// PreparedOOR aliases the Ark SDK's deterministic prepared OOR view.
+type PreparedOOR = sdkark.PreparedOOR
+
+// PreparedOORCustomInput aliases the Ark SDK's prepared custom input view.
+type PreparedOORCustomInput = sdkark.PreparedOORCustomInput
+
+// TaprootScriptSignature aliases the Ark SDK's external tapscript signature.
+type TaprootScriptSignature = sdkark.TaprootScriptSignature
+
 // VTXOInfo aliases the Ark SDK's typed VTXO metadata.
 type VTXOInfo = sdkark.VTXOInfo
 
 // OORPackageInfo aliases the Ark SDK's typed indexed OOR session view.
 type OORPackageInfo = sdkark.IndexedOORSessionInfo
+
+// InSwapRefundAuthorization carries the swap server's cooperative refund
+// signature and the terminal Lightning failure reason that made it safe.
+type InSwapRefundAuthorization struct {
+	// Signature is the server's tapscript signature for the prepared
+	// refund checkpoint input.
+	Signature TaprootScriptSignature
+
+	// FailureReason describes why the swap server considers the Lightning
+	// payment terminal and therefore safe to refund immediately.
+	FailureReason string
+}
 
 // SwapClient is the high-level client API for Lightning<->Ark
 // swaps.

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -103,6 +103,57 @@ func (g *GRPCSwapServerConn) CreateInSwap(ctx context.Context, invoice string,
 	return inSwapConfigFromProto(resp)
 }
 
+// AuthorizeInSwapRefund asks the swap server to sign one prepared cooperative
+// in-swap refund.
+func (g *GRPCSwapServerConn) AuthorizeInSwapRefund(ctx context.Context,
+	paymentHash lntypes.Hash, vhtlcOutpoint string, vhtlcAmountSat int64,
+	vhtlcPolicyTemplate, refundSpendPath, checkpointPSBT []byte) (
+	*InSwapRefundAuthorization, error) {
+
+	if vhtlcOutpoint == "" {
+		return nil, fmt.Errorf("vHTLC outpoint must be provided")
+	}
+	if vhtlcAmountSat <= 0 {
+		return nil, fmt.Errorf("vHTLC amount must be positive")
+	}
+
+	resp, err := g.client.AuthorizeInSwapRefund(
+		ctx, &swaprpc.AuthorizeInSwapRefundRequest{
+			PaymentHash:    append([]byte(nil), paymentHash[:]...),
+			VhtlcOutpoint:  vhtlcOutpoint,
+			VhtlcAmountSat: uint64(vhtlcAmountSat),
+			VhtlcPolicyTemplate: append(
+				[]byte(nil), vhtlcPolicyTemplate...,
+			),
+			RefundSpendPath: append(
+				[]byte(nil), refundSpendPath...,
+			),
+			CheckpointPsbt: append([]byte(nil), checkpointPSBT...),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	sig := resp.GetSignature()
+	if sig == nil {
+		return nil, fmt.Errorf("AuthorizeInSwapRefund RPC returned " +
+			"empty signature")
+	}
+
+	return &InSwapRefundAuthorization{
+		Signature: TaprootScriptSignature{
+			PubKey: append([]byte(nil), sig.GetPubkey()...),
+			WitnessScript: append(
+				[]byte(nil), sig.GetWitnessScript()...,
+			),
+			Signature: append([]byte(nil), sig.GetSignature()...),
+			SigHash:   sig.GetSighash(),
+		},
+		FailureReason: resp.GetFailureReason(),
+	}, nil
+}
+
 // Close is a no-op because the caller owns the underlying grpc.ClientConn.
 func (g *GRPCSwapServerConn) Close() error {
 	return nil

--- a/sdk/swaps/grpc_conn_test.go
+++ b/sdk/swaps/grpc_conn_test.go
@@ -1,0 +1,47 @@
+package swaps
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/swaprpc"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type testSwapServiceClient struct {
+	swaprpc.SwapServiceClient
+
+	authorizeErr error
+}
+
+func (c testSwapServiceClient) AuthorizeInSwapRefund(context.Context,
+	*swaprpc.AuthorizeInSwapRefundRequest, ...grpc.CallOption) (
+	*swaprpc.AuthorizeInSwapRefundResponse, error) {
+
+	return nil, c.authorizeErr
+}
+
+// TestAuthorizeInSwapRefundPreservesStatusCode verifies the pay session can
+// still distinguish retryable "not ready" authorization responses.
+func TestAuthorizeInSwapRefundPreservesStatusCode(t *testing.T) {
+	t.Parallel()
+
+	conn := &GRPCSwapServerConn{
+		client: testSwapServiceClient{
+			authorizeErr: status.Error(
+				codes.FailedPrecondition, "refund unavailable",
+			),
+		},
+	}
+
+	_, err := conn.AuthorizeInSwapRefund(
+		context.Background(), lntypes.Hash{}, "txid:0", 1, nil, nil,
+		nil,
+	)
+	require.Error(t, err)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -13,6 +13,8 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	loopfsm "github.com/lightninglabs/loop/fsm"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // PayState identifies the client-side lifecycle state of an Ark-to-Lightning
@@ -888,6 +890,14 @@ func (s *paySession) waitForClaimPreimage(ctx context.Context) error {
 			)
 		}
 
+		refunded, err := s.tryCooperativeRefund(ctx)
+		if err != nil {
+			return err
+		}
+		if refunded {
+			return nil
+		}
+
 		height, err := s.client.daemon.BlockHeight(ctx)
 		if err != nil {
 			return fmt.Errorf("get block height: %w", err)
@@ -972,6 +982,10 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 		return waitForFixedPoll(ctx, s.client.waitPollInterval)
 	}
 
+	if s.refundSessionID != "" {
+		return s.markRefundAccepted(ctx)
+	}
+
 	height, err := s.client.daemon.BlockHeight(ctx)
 	if err != nil {
 		return fmt.Errorf("get block height: %w", err)
@@ -987,10 +1001,6 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 		)
 
 		return waitForFixedPoll(ctx, s.client.waitPollInterval)
-	}
-
-	if s.refundSessionID != "" {
-		return s.markRefundAccepted(ctx)
 	}
 
 	refundPubKey, err := s.refundPubKey(ctx)
@@ -1049,6 +1059,171 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 	)
 
 	return s.markRefundAccepted(ctx)
+}
+
+// tryCooperativeRefund attempts an immediate refund before the timeout branch
+// matures. The swap server only authorizes this after its Lightning payment
+// attempt is terminal and no preimage is known, so an unavailable response just
+// means the SDK should keep waiting for either claim or timeout.
+func (s *paySession) tryCooperativeRefund(ctx context.Context) (bool, error) {
+	if s.refundSessionID != "" {
+		return true, s.initiateRefund(
+			ctx, "cooperative refund already submitted",
+		)
+	}
+
+	funded, err := s.observeRefundableVHTLC(ctx)
+	if err != nil {
+		return false, newRetryableActionError(
+			fmt.Errorf("query in-swap vHTLC before cooperative "+
+				"refund: %w", err),
+		)
+	}
+	if !funded {
+		return false, nil
+	}
+
+	refundPubKey, err := s.refundPubKey(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	refundPath, err := s.vhtlcPolicy.RefundPath()
+	if err != nil {
+		return false, fmt.Errorf("build cooperative refund path: %w",
+			err)
+	}
+
+	spendPath, err := refundPath.Encode()
+	if err != nil {
+		return false, fmt.Errorf("encode cooperative refund path: %w",
+			err)
+	}
+
+	input := CustomInput{
+		Outpoint:           s.vhtlcOutpoint,
+		VTXOPolicyTemplate: s.vhtlcPolicyTemplate,
+		SpendPath:          spendPath,
+		AmountSat:          s.vhtlcAmount,
+		PkScript:           s.vhtlcPkScript,
+	}
+
+	prepared, err := s.client.daemon.PrepareOORWithCustomInputs(
+		ctx, refundPubKey, s.vhtlcAmount, []CustomInput{input},
+	)
+	if err != nil {
+		return false, newRetryableActionError(
+			fmt.Errorf("prepare cooperative in-swap refund: %w",
+				err),
+		)
+	}
+
+	preparedInput, err := preparedCustomInput(prepared, s.vhtlcOutpoint)
+	if err != nil {
+		return false, err
+	}
+
+	authorization, err := s.client.server.AuthorizeInSwapRefund(
+		ctx, s.cfg.PaymentHash, s.vhtlcOutpoint, s.vhtlcAmount,
+		s.vhtlcPolicyTemplate, spendPath, preparedInput.CheckpointPSBT,
+	)
+	if err != nil {
+		code := status.Code(err)
+		if code == codes.FailedPrecondition ||
+			code == codes.Unavailable ||
+			code == codes.Unimplemented {
+
+			s.client.log.DebugS(
+				ctx,
+				"Cooperative in-swap refund not yet available",
+				btclog.Hex("hash", s.cfg.PaymentHash[:]),
+				slog.String("outpoint", s.vhtlcOutpoint),
+			)
+
+			return false, nil
+		}
+
+		return false, newRetryableActionError(
+			fmt.Errorf("authorize cooperative in-swap refund: %w",
+				err),
+		)
+	}
+	if authorization == nil {
+		return false, newRetryableActionError(
+			fmt.Errorf("authorize cooperative in-swap refund: " +
+				"empty response"),
+		)
+	}
+
+	input.ExternalSignatures = []TaprootScriptSignature{
+		authorization.Signature,
+	}
+
+	refundSessionID, err := s.client.daemon.SendOORWithCustomInputs(
+		ctx, refundPubKey, s.vhtlcAmount, []CustomInput{input},
+	)
+	if err != nil {
+		return false, newRetryableActionError(
+			fmt.Errorf("submit cooperative in-swap refund: %w",
+				err),
+		)
+	}
+	if refundSessionID == "" {
+		return false, fmt.Errorf("cooperative in-swap refund " +
+			"returned empty session id")
+	}
+
+	reason := authorization.FailureReason
+	if reason == "" {
+		reason = "swap server safely failed Lightning payment"
+	}
+
+	s.client.log.InfoS(ctx, "Cooperative in-swap refund submitted",
+		btclog.Hex("hash", s.cfg.PaymentHash[:]),
+		slog.String("outpoint", s.vhtlcOutpoint),
+		slog.String("refund_session_id", refundSessionID),
+		slog.String("reason", reason),
+	)
+
+	if err := s.persistRefundSessionID(
+		ctx, refundSessionID, reason,
+	); err != nil {
+		return false, newRetryableActionError(
+			fmt.Errorf("persist cooperative refund session id: %w",
+				err),
+		)
+	}
+	if err := s.initiateRefund(ctx, reason); err != nil {
+		return false, newRetryableActionError(err)
+	}
+
+	return true, nil
+}
+
+// preparedCustomInput returns the prepared checkpoint signing data for one
+// custom input outpoint.
+func preparedCustomInput(prepared *PreparedOOR,
+	outpoint string) (*PreparedOORCustomInput, error) {
+
+	if prepared == nil {
+		return nil, fmt.Errorf("prepared OOR package is required")
+	}
+
+	for i := range prepared.CustomInputs {
+		input := &prepared.CustomInputs[i]
+		if input.Outpoint != outpoint {
+			continue
+		}
+		if len(input.CheckpointPSBT) == 0 {
+			return nil, fmt.Errorf("prepared custom input %s "+
+				"missing checkpoint PSBT", outpoint)
+		}
+
+		return input, nil
+	}
+
+	return nil, fmt.Errorf("prepared OOR package missing custom input %s",
+		outpoint)
 }
 
 // observeRefundOutput returns the wallet output created by the timeout refund

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -3,6 +3,7 @@ package swaps
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -14,9 +15,12 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	swapsqlc "github.com/lightninglabs/darepo-client/sdk/swaps/sqlc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/zpay32"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -33,7 +37,55 @@ const (
 )
 
 type testInSwapServerConn struct {
-	cfg *InSwapConfig
+	cfg                 *InSwapConfig
+	refundAuthorization *InSwapRefundAuthorization
+	refundAuthorizeErr  error
+	refundAuthorizeReq  *testRefundAuthorizeReq
+}
+
+type testRefundAuthorizeReq struct {
+	paymentHash     lntypes.Hash
+	vhtlcOutpoint   string
+	vhtlcAmountSat  int64
+	vhtlcPolicy     []byte
+	refundSpendPath []byte
+	checkpointPSBT  []byte
+}
+
+type failAtExecDBTX struct {
+	db     *sql.DB
+	err    error
+	failAt int
+	calls  int
+}
+
+func (f *failAtExecDBTX) ExecContext(ctx context.Context, query string,
+	args ...interface{}) (sql.Result, error) {
+
+	f.calls++
+	if f.calls == f.failAt {
+		return nil, f.err
+	}
+
+	return f.db.ExecContext(ctx, query, args...)
+}
+
+func (f *failAtExecDBTX) PrepareContext(ctx context.Context, query string) (
+	*sql.Stmt, error) {
+
+	return f.db.PrepareContext(ctx, query)
+}
+
+func (f *failAtExecDBTX) QueryContext(ctx context.Context, query string,
+	args ...interface{}) (*sql.Rows, error) {
+
+	return f.db.QueryContext(ctx, query, args...)
+}
+
+func (f *failAtExecDBTX) QueryRowContext(ctx context.Context, query string,
+	args ...interface{}) *sql.Row {
+
+	return f.db.QueryRowContext(ctx, query, args...)
 }
 
 // RequestChannelID is unused in these tests.
@@ -49,6 +101,31 @@ func (c *testInSwapServerConn) CreateInSwap(context.Context, string, uint64,
 	*btcec.PublicKey) (*InSwapConfig, error) {
 
 	return c.cfg, nil
+}
+
+// AuthorizeInSwapRefund records and returns the preconfigured refund
+// authorization.
+func (c *testInSwapServerConn) AuthorizeInSwapRefund(_ context.Context,
+	paymentHash lntypes.Hash, vhtlcOutpoint string, vhtlcAmountSat int64,
+	vhtlcPolicyTemplate, refundSpendPath, checkpointPSBT []byte) (
+	*InSwapRefundAuthorization, error) {
+
+	c.refundAuthorizeReq = &testRefundAuthorizeReq{
+		paymentHash:     paymentHash,
+		vhtlcOutpoint:   vhtlcOutpoint,
+		vhtlcAmountSat:  vhtlcAmountSat,
+		vhtlcPolicy:     append([]byte(nil), vhtlcPolicyTemplate...),
+		refundSpendPath: append([]byte(nil), refundSpendPath...),
+		checkpointPSBT:  append([]byte(nil), checkpointPSBT...),
+	}
+	if c.refundAuthorizeErr != nil {
+		return nil, c.refundAuthorizeErr
+	}
+	if c.refundAuthorization != nil {
+		return c.refundAuthorization, nil
+	}
+
+	return nil, status.Error(codes.FailedPrecondition, "refund unavailable")
 }
 
 // Close closes the server connection.
@@ -533,6 +610,314 @@ func TestPaySessionRefundsFundedVHTLCOnTimeout(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, PayStateRefunded, resumed.State())
 	require.Equal(t, "refund-session", resumed.refundSessionID)
+}
+
+// TestPaySessionCooperativeRefundsBeforeTimeout asserts a pay session can
+// sweep a funded vHTLC immediately once the swap server has safely failed the
+// Lightning payment and signs the exact prepared refund checkpoint.
+func TestPaySessionCooperativeRefundsBeforeTimeout(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	refundScript, err := txscript.PayToTaprootScript(clientPriv.PubKey())
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:  preimage.Hash(),
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
+			ServerPubkey: serverPriv.PubKey(),
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime:                       100,
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			Expiry: time.Now().Add(time.Minute),
+		},
+		refundAuthorization: &InSwapRefundAuthorization{
+			Signature: TaprootScriptSignature{
+				PubKey: serverPriv.
+					PubKey().
+					SerializeCompressed(),
+				WitnessScript: []byte("witness"),
+				Signature:     []byte("server-sig"),
+			},
+			FailureReason: "payment failed",
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey:   clientPriv.PubKey(),
+		operatorKey:   operatorPriv.PubKey(),
+		blockHeight:   50,
+		sendSessionID: "refund-session",
+		vhtlc: &VTXOInfo{
+			Outpoint:  "funding:0",
+			AmountSat: testInSwapAmountSat,
+		},
+		receiveInfo: &ReceiveInfo{
+			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+			PkScript:    refundScript,
+		},
+		spendOnCustom: true,
+	}
+
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	client.waitPollInterval = time.Millisecond
+	client.refundLocktimeBuffer = 0
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	_, err = session.Wait(t.Context())
+	require.ErrorIs(t, err, ErrSwapRefunded)
+	require.Equal(t, 1, daemonConn.sendCustomCalls)
+	require.NotNil(t, serverConn.refundAuthorizeReq)
+	require.Equal(
+		t, "funding:0", serverConn.refundAuthorizeReq.vhtlcOutpoint,
+	)
+	require.EqualValues(
+		t, testInSwapAmountSat,
+		serverConn.refundAuthorizeReq.vhtlcAmountSat,
+	)
+	require.Equal(
+		t, []byte("checkpoint"),
+		serverConn.refundAuthorizeReq.checkpointPSBT,
+	)
+	require.Len(t, daemonConn.lastClaimInput, 1)
+	require.Len(t, daemonConn.lastClaimInput[0].ExternalSignatures, 1)
+	require.Equal(
+		t, []byte("server-sig"),
+		daemonConn.lastClaimInput[0].ExternalSignatures[0].Signature,
+	)
+
+	resumed, err := client.ResumePayViaLightning(
+		t.Context(), preimage.Hash(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, PayStateRefunded, resumed.State())
+	require.Equal(t, "refund-session", resumed.refundSessionID)
+}
+
+// TestPaySessionCooperativeRefundIgnoresServerUnavailable asserts a pay
+// session keeps waiting when refund authorization is not available from the
+// swap server, such as while the swap daemon is restarting or when talking to
+// an older server that does not implement the RPC.
+func TestPaySessionCooperativeRefundIgnoresServerUnavailable(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	refundScript, err := txscript.PayToTaprootScript(clientPriv.PubKey())
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:  preimage.Hash(),
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
+			ServerPubkey: serverPriv.PubKey(),
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime:                       100,
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			Expiry: time.Now().Add(time.Minute),
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+		blockHeight: 50,
+		vhtlc: &VTXOInfo{
+			Outpoint:  "funding:0",
+			AmountSat: testInSwapAmountSat,
+		},
+		receiveInfo: &ReceiveInfo{
+			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+			PkScript:    refundScript,
+		},
+	}
+
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	client.waitPollInterval = time.Millisecond
+	client.refundLocktimeBuffer = 0
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	err = session.runUntil(t.Context(), PayStateWaitingForClaim)
+	require.NoError(t, err)
+
+	for _, code := range []codes.Code{
+		codes.Unavailable,
+		codes.Unimplemented,
+	} {
+		serverConn.refundAuthorizeErr = status.Error(
+			code, "refund authorization unavailable",
+		)
+
+		refunded, err := session.tryCooperativeRefund(t.Context())
+		require.NoError(t, err)
+		require.False(t, refunded)
+		require.Equal(t, PayStateWaitingForClaim, session.State())
+		require.Zero(t, daemonConn.sendCustomCalls)
+	}
+}
+
+// TestPaySessionCooperativeRefundKeepsAcceptedSessionOnPersistFailure asserts
+// the accepted daemon OOR session id stays in memory if the following swap DB
+// write fails. The next tick must advance from the remembered accepted session
+// instead of submitting a second custom-input refund spend.
+func TestPaySessionCooperativeRefundKeepsAcceptedSessionOnPersistFailure(
+	t *testing.T) {
+
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	refundScript, err := txscript.PayToTaprootScript(clientPriv.PubKey())
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:  preimage.Hash(),
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
+			ServerPubkey: serverPriv.PubKey(),
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime:                       100,
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			Expiry: time.Now().Add(time.Minute),
+		},
+		refundAuthorization: &InSwapRefundAuthorization{
+			Signature: TaprootScriptSignature{
+				PubKey: serverPriv.
+					PubKey().
+					SerializeCompressed(),
+				WitnessScript: []byte("witness"),
+				Signature:     []byte("server-sig"),
+			},
+			FailureReason: "payment failed",
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey:   clientPriv.PubKey(),
+		operatorKey:   operatorPriv.PubKey(),
+		blockHeight:   50,
+		sendSessionID: "refund-session",
+		vhtlc: &VTXOInfo{
+			Outpoint:  "funding:0",
+			AmountSat: testInSwapAmountSat,
+		},
+		receiveInfo: &ReceiveInfo{
+			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+			PkScript:    refundScript,
+		},
+	}
+
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	client.waitPollInterval = time.Millisecond
+	client.refundLocktimeBuffer = 0
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	err = session.runUntil(t.Context(), PayStateWaitingForClaim)
+	require.NoError(t, err)
+
+	_, err = session.refundPubKey(t.Context())
+	require.NoError(t, err)
+	funded, err := session.observeRefundableVHTLC(t.Context())
+	require.NoError(t, err)
+	require.True(t, funded)
+
+	persistErr := errors.New("persist failed")
+	failingDB := &failAtExecDBTX{
+		db:     store.db,
+		err:    persistErr,
+		failAt: 2,
+	}
+	store.queries = swapsqlc.New(failingDB)
+
+	refunded, err := session.tryCooperativeRefund(t.Context())
+	require.ErrorContains(t, err, "persist failed")
+	require.False(t, refunded)
+	require.Equal(t, "refund-session", session.refundSessionID)
+	require.Equal(t, "payment failed", session.interventionReason)
+	require.Equal(t, PayStateWaitingForClaim, session.State())
+	require.Equal(t, 1, daemonConn.sendCustomCalls)
+	require.Equal(t, 2, failingDB.calls)
+
+	refunded, err = session.tryCooperativeRefund(t.Context())
+	require.NoError(t, err)
+	require.True(t, refunded)
+	require.Equal(t, "refund-session", session.refundSessionID)
+	require.Equal(t, PayStateRefundInitiated, session.State())
+	require.Equal(t, 1, daemonConn.sendCustomCalls)
 }
 
 // TestPaySessionRefundsWhenRefundLocktimePassesBeforeClaim asserts that a

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -1651,11 +1651,11 @@ func encodeVHTLCPolicyTemplate(policy *arkscript.VHTLCPolicy) ([]byte, error) {
 // live, then returns its outpoint and amount.
 //
 // The polled pkScript is derived locally from the vHTLC policy parameters
-// supplied by the swap server. A persistent loop where the indexer keeps
-// rejecting the query because the script is not registered to the current
-// principal is terminal for this receive attempt: either the local and remote
-// script derivation disagree, or stale local swap metadata survived a daemon
-// reset while the corresponding server-side script registration did not.
+// supplied by the swap server. Some receive paths, such as same-Ark p2p OOR,
+// can materialize the vHTLC in the local daemon before the proof-gated indexer
+// lookup is registered for this principal. In that case the local live VTXO set
+// is authoritative enough to proceed, while complete absence remains retryable
+// until the refund-locktime guard expires.
 func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 	deadline time.Time, keepWaiting func(context.Context) error) (string,
 	int64, error) {
@@ -1673,12 +1673,44 @@ func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 				slog.String("pk_script", pkScriptHex),
 			)
 			if isUnregisteredScriptErr(err) {
-				return "", 0, newFailureError(
-					fmt.Sprintf("vHTLC script %s is not "+
-						"registered for current "+
-						"principal", pkScriptHex),
-					err,
-				)
+				localVTXO, localErr :=
+					c.localLiveVTXOByPkScript(
+						ctx, pkScript,
+					)
+				if localErr != nil {
+					c.log.DebugS(
+						ctx,
+						"Unable to query local vHTLC "+
+							"state",
+						slog.String(
+							"err", localErr.Error(),
+						),
+						slog.String(
+							"pk_script",
+							pkScriptHex,
+						),
+					)
+				}
+				if localVTXO != nil {
+					c.log.InfoS(ctx,
+						"Found local funded vHTLC",
+						slog.String(
+							"pk_script",
+							pkScriptHex,
+						),
+						slog.String(
+							"outpoint",
+							localVTXO.Outpoint,
+						),
+						slog.Int64(
+							"amount_sat",
+							localVTXO.AmountSat,
+						),
+					)
+
+					return localVTXO.Outpoint,
+						localVTXO.AmountSat, nil
+				}
 			}
 		}
 		if vtxo != nil {
@@ -1721,4 +1753,24 @@ func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 		case <-timer.C:
 		}
 	}
+}
+
+// localLiveVTXOByPkScript returns a daemon-local live VTXO matching pkScript.
+// This is a fallback for OOR-delivered vHTLCs that are locally known before a
+// proof-gated indexed lookup can be made under the receiver's principal.
+func (c *SwapClient) localLiveVTXOByPkScript(ctx context.Context,
+	pkScript []byte) (*VTXOInfo, error) {
+
+	vtxos, err := c.daemon.ListLiveVTXOs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range vtxos {
+		if bytes.Equal(vtxos[i].PkScript, pkScript) {
+			return &vtxos[i], nil
+		}
+	}
+
+	return nil, nil
 }

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -374,6 +374,14 @@ func (c *testSwapServerConn) CreateInSwap(context.Context, string, uint64,
 	return nil, nil
 }
 
+// AuthorizeInSwapRefund is unused in these tests.
+func (c *testSwapServerConn) AuthorizeInSwapRefund(context.Context,
+	lntypes.Hash, string, int64, []byte, []byte, []byte) (
+	*InSwapRefundAuthorization, error) {
+
+	return nil, fmt.Errorf("unexpected in-swap refund authorization")
+}
+
 // Close closes the server connection.
 func (c *testSwapServerConn) Close() error {
 	return nil
@@ -472,14 +480,22 @@ func TestCancelVHTLCRecoveryIgnoresNotFound(t *testing.T) {
 	)
 }
 
-// TestWaitForVHTLCFailsOnUnregisteredScript verifies stale accepted receive
-// events stop retrying once the current principal can no longer query the
-// expected script.
-func TestWaitForVHTLCFailsOnUnregisteredScript(t *testing.T) {
+// TestWaitForVHTLCFallsBackToLocalVTXOOnUnregisteredScript verifies same-Ark
+// p2p receives can proceed from the daemon-local OOR materialization path when
+// the proof-gated indexer lookup is not registered for the receiver principal.
+func TestWaitForVHTLCFallsBackToLocalVTXOOnUnregisteredScript(t *testing.T) {
 	t.Parallel()
 
 	pkScript := bytes.Repeat([]byte{0x02}, 34)
+	localVTXO := VTXOInfo{
+		Outpoint:  "local-vhtlc:0",
+		AmountSat: 42_000,
+		PkScript:  pkScript,
+	}
 	daemonConn := &testDaemonConn{
+		liveVTXOs: []VTXOInfo{
+			localVTXO,
+		},
 		liveLookupErr: status.Error(
 			codes.Internal, "indexer query failed: rpc error: "+
 				"code = Unauthenticated desc = script not "+
@@ -488,14 +504,12 @@ func TestWaitForVHTLCFailsOnUnregisteredScript(t *testing.T) {
 	}
 	client := NewSwapClient(nil, daemonConn, nil, nil)
 
-	_, _, err := client.waitForVHTLC(
+	outpoint, amount, err := client.waitForVHTLC(
 		t.Context(), pkScript, time.Time{}, nil,
 	)
-	require.Error(t, err)
-	require.Contains(
-		t, failureReason(err),
-		"not registered for current principal",
-	)
+	require.NoError(t, err)
+	require.Equal(t, localVTXO.Outpoint, outpoint)
+	require.Equal(t, localVTXO.AmountSat, amount)
 	require.Equal(t, 1, daemonConn.liveLookupCalls)
 }
 
@@ -515,6 +529,8 @@ type testDaemonConn struct {
 	receiveAuthErr    error
 	receiveAllocCalls int
 	sendSessionID     string
+	preparedOOR       *PreparedOOR
+	prepareOOREErr    error
 	sendPolicyErr     error
 	sendCustomErr     error
 	listSpentErr      error
@@ -694,6 +710,35 @@ func (d *testDaemonConn) GetVHTLCRecoveryStatus(_ context.Context,
 	}, nil
 }
 
+// PrepareOORWithCustomInputs records the requested package and returns
+// deterministic signing material for tests.
+func (d *testDaemonConn) PrepareOORWithCustomInputs(_ context.Context,
+	recipientPubKey []byte, _ int64, inputs []CustomInput) (*PreparedOOR,
+	error) {
+
+	if d.prepareOOREErr != nil {
+		return nil, d.prepareOOREErr
+	}
+	if d.preparedOOR != nil {
+		return d.preparedOOR, nil
+	}
+	if len(inputs) == 0 {
+		return nil, fmt.Errorf("custom input is required")
+	}
+
+	return &PreparedOOR{
+		CustomInputs: []PreparedOORCustomInput{{
+			Outpoint:       inputs[0].Outpoint,
+			CheckpointPSBT: []byte("checkpoint"),
+			WitnessScript:  []byte("witness"),
+			SigningPubKeys: [][]byte{
+				append([]byte(nil), recipientPubKey...),
+			},
+		}},
+		SessionID: d.sendSessionID,
+	}, nil
+}
+
 // IdentityPubKey returns the configured client key.
 func (d *testDaemonConn) IdentityPubKey(context.Context) (*btcec.PublicKey,
 	error) {
@@ -800,7 +845,7 @@ func (d *testDaemonConn) ReceiveAuthECDH(_ context.Context,
 	return sha256.Sum256(ecdhPubKey.SerializeCompressed()), nil
 }
 
-// ListLiveVTXOs is unused in these tests.
+// ListLiveVTXOs returns configured daemon-local live VTXOs.
 func (d *testDaemonConn) ListLiveVTXOs(context.Context) ([]VTXOInfo, error) {
 	return append([]VTXOInfo(nil), d.liveVTXOs...), nil
 }
@@ -824,6 +869,14 @@ func (d *testDaemonConn) FindLiveVTXOByPkScript(_ context.Context,
 		if vtxo := d.liveByPkScript[scriptKey]; vtxo != nil {
 			return vtxo, nil
 		}
+	}
+	if d.receiveInfo != nil &&
+		bytes.Equal(d.receiveInfo.PkScript, pkScript) {
+		return nil, nil
+	}
+	if d.vhtlc != nil && len(d.vhtlc.PkScript) != 0 &&
+		!bytes.Equal(d.vhtlc.PkScript, pkScript) {
+		return nil, nil
 	}
 
 	return d.vhtlc, nil

--- a/sdk/swaps/store_sessions.go
+++ b/sdk/swaps/store_sessions.go
@@ -555,6 +555,22 @@ func (s *paySession) persistFundingSessionID(ctx context.Context,
 	return nil
 }
 
+// persistRefundSessionID stores the accepted refund session id without
+// rolling back the in-memory id on persistence failure. Custom-input OOR
+// submission is a daemon-side side effect, so retries must remember that an
+// accepted refund already exists even if the swap DB write fails afterwards.
+func (s *paySession) persistRefundSessionID(ctx context.Context,
+	refundSessionID, reason string) error {
+
+	s.refundSessionID = refundSessionID
+	s.interventionReason = reason
+	if err := s.persist(ctx); err != nil {
+		return fmt.Errorf("persist pay refund session id: %w", err)
+	}
+
+	return nil
+}
+
 // persist writes the full pay session snapshot into the isolated swap store
 // when one is configured.
 func (s *paySession) persist(ctx context.Context) error {

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -809,6 +809,226 @@ func (x *CreateInSwapResponse) GetSettlementType() SettlementType {
 	return SettlementType_SETTLEMENT_TYPE_UNSPECIFIED
 }
 
+type AuthorizeInSwapRefundRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// payment_hash identifies the in-swap.
+	PaymentHash []byte `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// vhtlc_outpoint is the funded vHTLC outpoint in "txid:vout" format.
+	VhtlcOutpoint string `protobuf:"bytes,2,opt,name=vhtlc_outpoint,json=vhtlcOutpoint,proto3" json:"vhtlc_outpoint,omitempty"`
+	// vhtlc_amount_sat is the funded vHTLC amount.
+	VhtlcAmountSat uint64 `protobuf:"varint,3,opt,name=vhtlc_amount_sat,json=vhtlcAmountSat,proto3" json:"vhtlc_amount_sat,omitempty"`
+	// vhtlc_policy_template is the serialized vHTLC policy template.
+	VhtlcPolicyTemplate []byte `protobuf:"bytes,4,opt,name=vhtlc_policy_template,json=vhtlcPolicyTemplate,proto3" json:"vhtlc_policy_template,omitempty"`
+	// refund_spend_path is the serialized vHTLC Refund spend path.
+	RefundSpendPath []byte `protobuf:"bytes,5,opt,name=refund_spend_path,json=refundSpendPath,proto3" json:"refund_spend_path,omitempty"`
+	// checkpoint_psbt is the prepared custom OOR checkpoint PSBT to sign.
+	CheckpointPsbt []byte `protobuf:"bytes,6,opt,name=checkpoint_psbt,json=checkpointPsbt,proto3" json:"checkpoint_psbt,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *AuthorizeInSwapRefundRequest) Reset() {
+	*x = AuthorizeInSwapRefundRequest{}
+	mi := &file_swap_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuthorizeInSwapRefundRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuthorizeInSwapRefundRequest) ProtoMessage() {}
+
+func (x *AuthorizeInSwapRefundRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AuthorizeInSwapRefundRequest.ProtoReflect.Descriptor instead.
+func (*AuthorizeInSwapRefundRequest) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *AuthorizeInSwapRefundRequest) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+func (x *AuthorizeInSwapRefundRequest) GetVhtlcOutpoint() string {
+	if x != nil {
+		return x.VhtlcOutpoint
+	}
+	return ""
+}
+
+func (x *AuthorizeInSwapRefundRequest) GetVhtlcAmountSat() uint64 {
+	if x != nil {
+		return x.VhtlcAmountSat
+	}
+	return 0
+}
+
+func (x *AuthorizeInSwapRefundRequest) GetVhtlcPolicyTemplate() []byte {
+	if x != nil {
+		return x.VhtlcPolicyTemplate
+	}
+	return nil
+}
+
+func (x *AuthorizeInSwapRefundRequest) GetRefundSpendPath() []byte {
+	if x != nil {
+		return x.RefundSpendPath
+	}
+	return nil
+}
+
+func (x *AuthorizeInSwapRefundRequest) GetCheckpointPsbt() []byte {
+	if x != nil {
+		return x.CheckpointPsbt
+	}
+	return nil
+}
+
+type AuthorizeInSwapRefundResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// signature is the swap server receiver key's tapscript signature.
+	Signature *TaprootScriptSignature `protobuf:"bytes,1,opt,name=signature,proto3" json:"signature,omitempty"`
+	// failure_reason is the terminal Lightning payment failure that made the
+	// refund safe to authorize.
+	FailureReason string `protobuf:"bytes,2,opt,name=failure_reason,json=failureReason,proto3" json:"failure_reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AuthorizeInSwapRefundResponse) Reset() {
+	*x = AuthorizeInSwapRefundResponse{}
+	mi := &file_swap_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuthorizeInSwapRefundResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuthorizeInSwapRefundResponse) ProtoMessage() {}
+
+func (x *AuthorizeInSwapRefundResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AuthorizeInSwapRefundResponse.ProtoReflect.Descriptor instead.
+func (*AuthorizeInSwapRefundResponse) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *AuthorizeInSwapRefundResponse) GetSignature() *TaprootScriptSignature {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
+func (x *AuthorizeInSwapRefundResponse) GetFailureReason() string {
+	if x != nil {
+		return x.FailureReason
+	}
+	return ""
+}
+
+// TaprootScriptSignature carries one externally produced tapscript signature.
+// Keep this in sync with daemonrpc.TaprootScriptSignature.
+type TaprootScriptSignature struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// pubkey is the compressed public key that produced the signature.
+	Pubkey []byte `protobuf:"bytes,1,opt,name=pubkey,proto3" json:"pubkey,omitempty"`
+	// witness_script is the tapscript leaf this signature commits to.
+	WitnessScript []byte `protobuf:"bytes,2,opt,name=witness_script,json=witnessScript,proto3" json:"witness_script,omitempty"`
+	// signature is the raw Schnorr signature, optionally followed by a one-byte
+	// sighash type when the sighash is not SIGHASH_DEFAULT.
+	Signature []byte `protobuf:"bytes,3,opt,name=signature,proto3" json:"signature,omitempty"`
+	// sighash is the tapscript sighash type. Zero means SIGHASH_DEFAULT.
+	Sighash       uint32 `protobuf:"varint,4,opt,name=sighash,proto3" json:"sighash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TaprootScriptSignature) Reset() {
+	*x = TaprootScriptSignature{}
+	mi := &file_swap_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TaprootScriptSignature) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TaprootScriptSignature) ProtoMessage() {}
+
+func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TaprootScriptSignature.ProtoReflect.Descriptor instead.
+func (*TaprootScriptSignature) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *TaprootScriptSignature) GetPubkey() []byte {
+	if x != nil {
+		return x.Pubkey
+	}
+	return nil
+}
+
+func (x *TaprootScriptSignature) GetWitnessScript() []byte {
+	if x != nil {
+		return x.WitnessScript
+	}
+	return nil
+}
+
+func (x *TaprootScriptSignature) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
+func (x *TaprootScriptSignature) GetSighash() uint32 {
+	if x != nil {
+		return x.Sighash
+	}
+	return 0
+}
+
 var File_swap_proto protoreflect.FileDescriptor
 
 const file_swap_proto_rawDesc = "" +
@@ -869,14 +1089,30 @@ const file_swap_proto_rawDesc = "" +
 	"\rserver_pubkey\x18\x04 \x01(\fR\fserverPubkey\x127\n" +
 	"\fvhtlc_config\x18\x05 \x01(\v2\x14.swaprpc.VHTLCConfigR\vvhtlcConfig\x122\n" +
 	"\x06expiry\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x06expiry\x12@\n" +
-	"\x0fsettlement_type\x18\a \x01(\x0e2\x17.swaprpc.SettlementTypeR\x0esettlementType*l\n" +
+	"\x0fsettlement_type\x18\a \x01(\x0e2\x17.swaprpc.SettlementTypeR\x0esettlementType\"\x9b\x02\n" +
+	"\x1cAuthorizeInSwapRefundRequest\x12!\n" +
+	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12%\n" +
+	"\x0evhtlc_outpoint\x18\x02 \x01(\tR\rvhtlcOutpoint\x12(\n" +
+	"\x10vhtlc_amount_sat\x18\x03 \x01(\x04R\x0evhtlcAmountSat\x122\n" +
+	"\x15vhtlc_policy_template\x18\x04 \x01(\fR\x13vhtlcPolicyTemplate\x12*\n" +
+	"\x11refund_spend_path\x18\x05 \x01(\fR\x0frefundSpendPath\x12'\n" +
+	"\x0fcheckpoint_psbt\x18\x06 \x01(\fR\x0echeckpointPsbt\"\x85\x01\n" +
+	"\x1dAuthorizeInSwapRefundResponse\x12=\n" +
+	"\tsignature\x18\x01 \x01(\v2\x1f.swaprpc.TaprootScriptSignatureR\tsignature\x12%\n" +
+	"\x0efailure_reason\x18\x02 \x01(\tR\rfailureReason\"\x8f\x01\n" +
+	"\x16TaprootScriptSignature\x12\x16\n" +
+	"\x06pubkey\x18\x01 \x01(\fR\x06pubkey\x12%\n" +
+	"\x0ewitness_script\x18\x02 \x01(\fR\rwitnessScript\x12\x1c\n" +
+	"\tsignature\x18\x03 \x01(\fR\tsignature\x12\x18\n" +
+	"\asighash\x18\x04 \x01(\rR\asighash*l\n" +
 	"\x0eSettlementType\x12\x1f\n" +
 	"\x1bSETTLEMENT_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19SETTLEMENT_TYPE_LIGHTNING\x10\x01\x12\x1a\n" +
-	"\x16SETTLEMENT_TYPE_IN_ARK\x10\x022\xb3\x01\n" +
+	"\x16SETTLEMENT_TYPE_IN_ARK\x10\x022\x9b\x02\n" +
 	"\vSwapService\x12W\n" +
 	"\x10RequestChannelId\x12 .swaprpc.RequestChannelIdRequest\x1a!.swaprpc.RequestChannelIdResponse\x12K\n" +
-	"\fCreateInSwap\x12\x1c.swaprpc.CreateInSwapRequest\x1a\x1d.swaprpc.CreateInSwapResponseB0Z.github.com/lightninglabs/darepo-client/swaprpcb\x06proto3"
+	"\fCreateInSwap\x12\x1c.swaprpc.CreateInSwapRequest\x1a\x1d.swaprpc.CreateInSwapResponse\x12f\n" +
+	"\x15AuthorizeInSwapRefund\x12%.swaprpc.AuthorizeInSwapRefundRequest\x1a&.swaprpc.AuthorizeInSwapRefundResponseB0Z.github.com/lightninglabs/darepo-client/swaprpcb\x06proto3"
 
 var (
 	file_swap_proto_rawDescOnce sync.Once
@@ -891,19 +1127,22 @@ func file_swap_proto_rawDescGZIP() []byte {
 }
 
 var file_swap_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_swap_proto_goTypes = []any{
-	(SettlementType)(0),              // 0: swaprpc.SettlementType
-	(*RequestChannelIdRequest)(nil),  // 1: swaprpc.RequestChannelIdRequest
-	(*RequestChannelIdResponse)(nil), // 2: swaprpc.RequestChannelIdResponse
-	(*OutSwapHtlcEvent)(nil),         // 3: swaprpc.OutSwapHtlcEvent
-	(*SwapMailboxEvent)(nil),         // 4: swaprpc.SwapMailboxEvent
-	(*InArkHtlcEvent)(nil),           // 5: swaprpc.InArkHtlcEvent
-	(*RouteHint)(nil),                // 6: swaprpc.RouteHint
-	(*VHTLCConfig)(nil),              // 7: swaprpc.VHTLCConfig
-	(*CreateInSwapRequest)(nil),      // 8: swaprpc.CreateInSwapRequest
-	(*CreateInSwapResponse)(nil),     // 9: swaprpc.CreateInSwapResponse
-	(*timestamppb.Timestamp)(nil),    // 10: google.protobuf.Timestamp
+	(SettlementType)(0),                   // 0: swaprpc.SettlementType
+	(*RequestChannelIdRequest)(nil),       // 1: swaprpc.RequestChannelIdRequest
+	(*RequestChannelIdResponse)(nil),      // 2: swaprpc.RequestChannelIdResponse
+	(*OutSwapHtlcEvent)(nil),              // 3: swaprpc.OutSwapHtlcEvent
+	(*SwapMailboxEvent)(nil),              // 4: swaprpc.SwapMailboxEvent
+	(*InArkHtlcEvent)(nil),                // 5: swaprpc.InArkHtlcEvent
+	(*RouteHint)(nil),                     // 6: swaprpc.RouteHint
+	(*VHTLCConfig)(nil),                   // 7: swaprpc.VHTLCConfig
+	(*CreateInSwapRequest)(nil),           // 8: swaprpc.CreateInSwapRequest
+	(*CreateInSwapResponse)(nil),          // 9: swaprpc.CreateInSwapResponse
+	(*AuthorizeInSwapRefundRequest)(nil),  // 10: swaprpc.AuthorizeInSwapRefundRequest
+	(*AuthorizeInSwapRefundResponse)(nil), // 11: swaprpc.AuthorizeInSwapRefundResponse
+	(*TaprootScriptSignature)(nil),        // 12: swaprpc.TaprootScriptSignature
+	(*timestamppb.Timestamp)(nil),         // 13: google.protobuf.Timestamp
 }
 var file_swap_proto_depIdxs = []int32{
 	6,  // 0: swaprpc.RequestChannelIdResponse.route_hint:type_name -> swaprpc.RouteHint
@@ -912,17 +1151,20 @@ var file_swap_proto_depIdxs = []int32{
 	5,  // 3: swaprpc.SwapMailboxEvent.in_ark_htlc:type_name -> swaprpc.InArkHtlcEvent
 	7,  // 4: swaprpc.InArkHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
 	7,  // 5: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	10, // 6: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
+	13, // 6: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
 	0,  // 7: swaprpc.CreateInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
-	1,  // 8: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
-	8,  // 9: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
-	2,  // 10: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
-	9,  // 11: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
-	10, // [10:12] is the sub-list for method output_type
-	8,  // [8:10] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	12, // 8: swaprpc.AuthorizeInSwapRefundResponse.signature:type_name -> swaprpc.TaprootScriptSignature
+	1,  // 9: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
+	8,  // 10: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
+	10, // 11: swaprpc.SwapService.AuthorizeInSwapRefund:input_type -> swaprpc.AuthorizeInSwapRefundRequest
+	2,  // 12: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
+	9,  // 13: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
+	11, // 14: swaprpc.SwapService.AuthorizeInSwapRefund:output_type -> swaprpc.AuthorizeInSwapRefundResponse
+	12, // [12:15] is the sub-list for method output_type
+	9,  // [9:12] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_swap_proto_init() }
@@ -940,7 +1182,7 @@ func file_swap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_swap_proto_rawDesc), len(file_swap_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   9,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/swaprpc/swap.pb.gw.go
+++ b/swaprpc/swap.pb.gw.go
@@ -89,6 +89,33 @@ func local_request_SwapService_CreateInSwap_0(ctx context.Context, marshaler run
 	return msg, metadata, err
 }
 
+func request_SwapService_AuthorizeInSwapRefund_0(ctx context.Context, marshaler runtime.Marshaler, client SwapServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AuthorizeInSwapRefundRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.AuthorizeInSwapRefund(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SwapService_AuthorizeInSwapRefund_0(ctx context.Context, marshaler runtime.Marshaler, server SwapServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AuthorizeInSwapRefundRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.AuthorizeInSwapRefund(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterSwapServiceHandlerServer registers the http handlers for service SwapService to "mux".
 // UnaryRPC     :call SwapServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -134,6 +161,26 @@ func RegisterSwapServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux
 			return
 		}
 		forward_SwapService_CreateInSwap_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SwapService_AuthorizeInSwapRefund_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/swaprpc.SwapService/AuthorizeInSwapRefund", runtime.WithHTTPPathPattern("/v1/swap/authorize-in-swap-refund"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SwapService_AuthorizeInSwapRefund_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_AuthorizeInSwapRefund_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -209,15 +256,34 @@ func RegisterSwapServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_SwapService_CreateInSwap_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_SwapService_AuthorizeInSwapRefund_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/swaprpc.SwapService/AuthorizeInSwapRefund", runtime.WithHTTPPathPattern("/v1/swap/authorize-in-swap-refund"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SwapService_AuthorizeInSwapRefund_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_AuthorizeInSwapRefund_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_SwapService_RequestChannelId_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "request-channel-id"}, ""))
-	pattern_SwapService_CreateInSwap_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "create-in-swap"}, ""))
+	pattern_SwapService_RequestChannelId_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "request-channel-id"}, ""))
+	pattern_SwapService_CreateInSwap_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "create-in-swap"}, ""))
+	pattern_SwapService_AuthorizeInSwapRefund_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "authorize-in-swap-refund"}, ""))
 )
 
 var (
-	forward_SwapService_RequestChannelId_0 = runtime.ForwardResponseMessage
-	forward_SwapService_CreateInSwap_0     = runtime.ForwardResponseMessage
+	forward_SwapService_RequestChannelId_0      = runtime.ForwardResponseMessage
+	forward_SwapService_CreateInSwap_0          = runtime.ForwardResponseMessage
+	forward_SwapService_AuthorizeInSwapRefund_0 = runtime.ForwardResponseMessage
 )

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -31,6 +31,11 @@ service SwapService {
     // CreateInSwap initiates an Ark-to-Lightning swap for the given invoice and
     // returns the negotiated vHTLC parameters.
     rpc CreateInSwap (CreateInSwapRequest) returns (CreateInSwapResponse);
+
+    // AuthorizeInSwapRefund signs a prepared cooperative refund spend for a
+    // funded in-swap whose Lightning payment attempt has terminally failed.
+    rpc AuthorizeInSwapRefund (AuthorizeInSwapRefundRequest)
+        returns (AuthorizeInSwapRefundResponse);
 }
 
 // RequestChannelIdRequest starts one Lightning-to-Ark receive negotiation.
@@ -201,4 +206,50 @@ message CreateInSwapResponse {
     // settlement_type identifies whether this negotiation should be completed
     // through Lightning or directly inside the Ark instance.
     SettlementType settlement_type = 7;
+}
+
+message AuthorizeInSwapRefundRequest {
+    // payment_hash identifies the in-swap.
+    bytes payment_hash = 1;
+
+    // vhtlc_outpoint is the funded vHTLC outpoint in "txid:vout" format.
+    string vhtlc_outpoint = 2;
+
+    // vhtlc_amount_sat is the funded vHTLC amount.
+    uint64 vhtlc_amount_sat = 3;
+
+    // vhtlc_policy_template is the serialized vHTLC policy template.
+    bytes vhtlc_policy_template = 4;
+
+    // refund_spend_path is the serialized vHTLC Refund spend path.
+    bytes refund_spend_path = 5;
+
+    // checkpoint_psbt is the prepared custom OOR checkpoint PSBT to sign.
+    bytes checkpoint_psbt = 6;
+}
+
+message AuthorizeInSwapRefundResponse {
+    // signature is the swap server receiver key's tapscript signature.
+    TaprootScriptSignature signature = 1;
+
+    // failure_reason is the terminal Lightning payment failure that made the
+    // refund safe to authorize.
+    string failure_reason = 2;
+}
+
+// TaprootScriptSignature carries one externally produced tapscript signature.
+// Keep this in sync with daemonrpc.TaprootScriptSignature.
+message TaprootScriptSignature {
+    // pubkey is the compressed public key that produced the signature.
+    bytes pubkey = 1;
+
+    // witness_script is the tapscript leaf this signature commits to.
+    bytes witness_script = 2;
+
+    // signature is the raw Schnorr signature, optionally followed by a one-byte
+    // sighash type when the sighash is not SIGHASH_DEFAULT.
+    bytes signature = 3;
+
+    // sighash is the tapscript sighash type. Zero means SIGHASH_DEFAULT.
+    uint32 sighash = 4;
 }

--- a/swaprpc/swap.yaml
+++ b/swaprpc/swap.yaml
@@ -9,3 +9,6 @@ http:
     - selector: swaprpc.SwapService.CreateInSwap
       post: /v1/swap/create-in-swap
       body: "*"
+    - selector: swaprpc.SwapService.AuthorizeInSwapRefund
+      post: /v1/swap/authorize-in-swap-refund
+      body: "*"

--- a/swaprpc/swap_grpc.pb.go
+++ b/swaprpc/swap_grpc.pb.go
@@ -19,8 +19,9 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	SwapService_RequestChannelId_FullMethodName = "/swaprpc.SwapService/RequestChannelId"
-	SwapService_CreateInSwap_FullMethodName     = "/swaprpc.SwapService/CreateInSwap"
+	SwapService_RequestChannelId_FullMethodName      = "/swaprpc.SwapService/RequestChannelId"
+	SwapService_CreateInSwap_FullMethodName          = "/swaprpc.SwapService/CreateInSwap"
+	SwapService_AuthorizeInSwapRefund_FullMethodName = "/swaprpc.SwapService/AuthorizeInSwapRefund"
 )
 
 // SwapServiceClient is the client API for SwapService service.
@@ -36,6 +37,9 @@ type SwapServiceClient interface {
 	// CreateInSwap initiates an Ark-to-Lightning swap for the given invoice and
 	// returns the negotiated vHTLC parameters.
 	CreateInSwap(ctx context.Context, in *CreateInSwapRequest, opts ...grpc.CallOption) (*CreateInSwapResponse, error)
+	// AuthorizeInSwapRefund signs a prepared cooperative refund spend for a
+	// funded in-swap whose Lightning payment attempt has terminally failed.
+	AuthorizeInSwapRefund(ctx context.Context, in *AuthorizeInSwapRefundRequest, opts ...grpc.CallOption) (*AuthorizeInSwapRefundResponse, error)
 }
 
 type swapServiceClient struct {
@@ -66,6 +70,16 @@ func (c *swapServiceClient) CreateInSwap(ctx context.Context, in *CreateInSwapRe
 	return out, nil
 }
 
+func (c *swapServiceClient) AuthorizeInSwapRefund(ctx context.Context, in *AuthorizeInSwapRefundRequest, opts ...grpc.CallOption) (*AuthorizeInSwapRefundResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AuthorizeInSwapRefundResponse)
+	err := c.cc.Invoke(ctx, SwapService_AuthorizeInSwapRefund_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SwapServiceServer is the server API for SwapService service.
 // All implementations must embed UnimplementedSwapServiceServer
 // for forward compatibility.
@@ -79,6 +93,9 @@ type SwapServiceServer interface {
 	// CreateInSwap initiates an Ark-to-Lightning swap for the given invoice and
 	// returns the negotiated vHTLC parameters.
 	CreateInSwap(context.Context, *CreateInSwapRequest) (*CreateInSwapResponse, error)
+	// AuthorizeInSwapRefund signs a prepared cooperative refund spend for a
+	// funded in-swap whose Lightning payment attempt has terminally failed.
+	AuthorizeInSwapRefund(context.Context, *AuthorizeInSwapRefundRequest) (*AuthorizeInSwapRefundResponse, error)
 	mustEmbedUnimplementedSwapServiceServer()
 }
 
@@ -94,6 +111,9 @@ func (UnimplementedSwapServiceServer) RequestChannelId(context.Context, *Request
 }
 func (UnimplementedSwapServiceServer) CreateInSwap(context.Context, *CreateInSwapRequest) (*CreateInSwapResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateInSwap not implemented")
+}
+func (UnimplementedSwapServiceServer) AuthorizeInSwapRefund(context.Context, *AuthorizeInSwapRefundRequest) (*AuthorizeInSwapRefundResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AuthorizeInSwapRefund not implemented")
 }
 func (UnimplementedSwapServiceServer) mustEmbedUnimplementedSwapServiceServer() {}
 func (UnimplementedSwapServiceServer) testEmbeddedByValue()                     {}
@@ -152,6 +172,24 @@ func _SwapService_CreateInSwap_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SwapService_AuthorizeInSwapRefund_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AuthorizeInSwapRefundRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SwapServiceServer).AuthorizeInSwapRefund(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SwapService_AuthorizeInSwapRefund_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SwapServiceServer).AuthorizeInSwapRefund(ctx, req.(*AuthorizeInSwapRefundRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SwapService_ServiceDesc is the grpc.ServiceDesc for SwapService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -166,6 +204,10 @@ var SwapService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CreateInSwap",
 			Handler:    _SwapService_CreateInSwap_Handler,
+		},
+		{
+			MethodName: "AuthorizeInSwapRefund",
+			Handler:    _SwapService_AuthorizeInSwapRefund_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/swaprpc/swap_mailboxrpc.pb.go
+++ b/swaprpc/swap_mailboxrpc.pb.go
@@ -28,6 +28,8 @@ type SwapServiceMailboxServer interface {
 	RequestChannelId(ctx context.Context, req *RequestChannelIdRequest) (*RequestChannelIdResponse, error)
 	// CreateInSwap handles CreateInSwap.
 	CreateInSwap(ctx context.Context, req *CreateInSwapRequest) (*CreateInSwapResponse, error)
+	// AuthorizeInSwapRefund handles AuthorizeInSwapRefund.
+	AuthorizeInSwapRefund(ctx context.Context, req *AuthorizeInSwapRefundRequest) (*AuthorizeInSwapRefundResponse, error)
 }
 
 // RegisterSwapServiceMailboxServer registers handlers for SwapService.
@@ -51,6 +53,16 @@ func RegisterSwapServiceMailboxServer(r rpc.Router, impl SwapServiceMailboxServe
 		}
 
 		return impl.CreateInSwap(ctx, req)
+	})
+	r.Handle("swaprpc.SwapService", "AuthorizeInSwapRefund", func() proto.Message {
+		return &AuthorizeInSwapRefundRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*AuthorizeInSwapRefundRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.AuthorizeInSwapRefund(ctx, req)
 	})
 }
 
@@ -93,6 +105,29 @@ func (c *SwapServiceMailboxClient) CreateInSwap(ctx context.Context, req *Create
 	}
 
 	resp := new(CreateInSwapResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// AuthorizeInSwapRefund calls the AuthorizeInSwapRefund RPC.
+func (c *SwapServiceMailboxClient) AuthorizeInSwapRefund(ctx context.Context, req *AuthorizeInSwapRefundRequest, opts ...rpc.RPCOptions) (*AuthorizeInSwapRefundResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "swaprpc.SwapService",
+		Method:  "AuthorizeInSwapRefund",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(AuthorizeInSwapRefundResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -119,9 +119,7 @@ func (h *history) listActivity(ctx context.Context,
 			walletrpc.EntryKind_ENTRY_KIND_RECV) {
 
 		var err error
-		swapEntries, swapCorrelations, err = h.collectSwapEntries(
-			ctx, req.GetPendingOnly(),
-		)
+		swapEntries, swapCorrelations, err = h.collectSwapEntries(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("collect swap entries: %w", err)
 		}
@@ -269,8 +267,9 @@ func (h *history) listOnchain(ctx context.Context, req *walletrpc.ListRequest) (
 // collectSwapEntries pulls the latest swap summaries from the swap
 // subserver and normalizes them into WalletEntry rows. Pay rows become
 // SEND, receive rows become RECV; the underlying SwapDirection enum drives
-// the mapping.
-func (h *history) collectSwapEntries(ctx context.Context, pendingOnly bool) (
+// the mapping. The full swap set is always queried so terminal swaps can
+// still hide their internal OOR ledger rows when callers request --pending.
+func (h *history) collectSwapEntries(ctx context.Context) (
 	[]*walletrpc.WalletEntry, swapOORCorrelations, error) {
 
 	if h.deps.SwapService == nil {
@@ -278,9 +277,7 @@ func (h *history) collectSwapEntries(ctx context.Context, pendingOnly bool) (
 	}
 
 	resp, err := h.deps.SwapService.ListSwaps(
-		ctx, &swapclientrpc.ListSwapsRequest{
-			PendingOnly: pendingOnly,
-		},
+		ctx, &swapclientrpc.ListSwapsRequest{},
 	)
 	if err != nil {
 		return nil, swapOORCorrelations{}, err
@@ -409,6 +406,7 @@ func (h *history) collectLedgerEntries(ctx context.Context, offset,
 type swapOORCorrelations struct {
 	payAmountsByFundingSession map[string]map[int64]int
 	claimSessions              map[string]struct{}
+	refundSessions             map[string]struct{}
 }
 
 // swapOORCorrelationsFromSwaps indexes swap session ids by the internal OOR leg
@@ -422,6 +420,7 @@ func swapOORCorrelationsFromSwaps(
 	out := swapOORCorrelations{
 		payAmountsByFundingSession: make(map[string]map[int64]int),
 		claimSessions:              make(map[string]struct{}),
+		refundSessions:             make(map[string]struct{}),
 	}
 
 	for _, swap := range swaps {
@@ -429,15 +428,20 @@ func swapOORCorrelationsFromSwaps(
 		case swapclientrpc.SwapDirection_SWAP_DIRECTION_PAY:
 			session := strings.ToLower(swap.GetFundingSessionId())
 			amount := swap.GetAmountSat()
-			if session == "" || amount <= 0 {
-				continue
+			if session != "" && amount > 0 {
+				if out.payAmountsByFundingSession[session] == nil {
+					out.payAmountsByFundingSession[session] =
+						make(map[int64]int)
+				}
+				out.payAmountsByFundingSession[session][amount]++
 			}
-			if out.payAmountsByFundingSession[session] == nil {
-				out.payAmountsByFundingSession[session] = make(
-					map[int64]int,
-				)
+
+			refundSession := strings.ToLower(
+				swap.GetRefundSessionId(),
+			)
+			if refundSession != "" {
+				out.refundSessions[refundSession] = struct{}{}
 			}
-			out.payAmountsByFundingSession[session][amount]++
 
 		case swapclientrpc.SwapDirection_SWAP_DIRECTION_RECEIVE:
 			session := strings.ToLower(swap.GetClaimSessionId())
@@ -492,8 +496,8 @@ func internalOORLedgerEntries(rows []*daemonrpc.TransactionHistoryEntry,
 		}
 
 		switch delta := row.GetAmountSat() - received; {
-		case delta == 0 && sessionInSet(
-			correlations.claimSessions, session,
+		case delta == 0 && internalZeroDeltaSession(
+			correlations, session,
 		):
 
 			hidden[row.GetEntryId()] = struct{}{}
@@ -509,6 +513,16 @@ func internalOORLedgerEntries(rows []*daemonrpc.TransactionHistoryEntry,
 	}
 
 	return hidden
+}
+
+// internalZeroDeltaSession reports whether a balanced same-session OOR
+// send+receive pair belongs to a swap-internal claim or refund. Those rows
+// are already represented by the swap entry itself.
+func internalZeroDeltaSession(correlations swapOORCorrelations,
+	session string) bool {
+
+	return sessionInSet(correlations.claimSessions, session) ||
+		sessionInSet(correlations.refundSessions, session)
 }
 
 // sessionInSet reports whether a normalized OOR session id appears in set.

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -426,6 +426,174 @@ func TestHistoryHidesPayFundingOORInput(t *testing.T) {
 	require.Equal(t, int64(-1_234), entries[0].GetAmountSat())
 }
 
+// TestHistoryHidesPayRefundOORSession confirms the cooperative refund OOR
+// created for a failed pay swap stays internal to the swap row. The wallet
+// activity entry should be the refunded payment hash, not a synthetic
+// ledger-N SEND for the refund self-transfer.
+func TestHistoryHidesPayRefundOORSession(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+
+	refundSession := testBytes(32, 0x61)
+	refundHex := testSessionString(t, refundSession)
+
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{
+		Swaps: []*swapclientrpc.SwapSummary{
+			{
+				PaymentHash: "payment-hash",
+				Direction: swapclientrpc.
+					SwapDirection_SWAP_DIRECTION_PAY,
+				State: swapclientrpc.
+					SwapState_SWAP_STATE_REFUNDED,
+				AmountSat:       1_000,
+				UpdatedAtUnix:   200,
+				RefundSessionId: refundHex,
+			},
+		},
+	}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:           "oor",
+				Subtype:        ledger.EventVTXOSent,
+				AmountSat:      1_000,
+				DebitAccount:   ledger.AccountTransfersOut,
+				CreditAccount:  ledger.AccountVTXOBalance,
+				SessionId:      refundSession,
+				EntryId:        17,
+				CreatedAtUnixS: 100,
+			},
+			{
+				Type:           "oor",
+				Subtype:        ledger.EventVTXOReceived,
+				AmountSat:      1_000,
+				DebitAccount:   ledger.AccountVTXOBalance,
+				CreditAccount:  ledger.AccountTransfersIn,
+				Txid:           refundHex,
+				OutputIndex:    0,
+				EntryId:        18,
+				CreatedAtUnixS: 101,
+			},
+		},
+	}
+
+	resp, err := h.List(t.Context(), &walletrpc.ListRequest{})
+	require.NoError(t, err)
+
+	entries := resp.GetActivity().GetEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, "payment-hash", entries[0].GetId())
+	require.Equal(
+		t, walletrpc.EntryKind_ENTRY_KIND_SEND, entries[0].GetKind(),
+	)
+	require.Equal(
+		t, walletrpc.EntryStatus_ENTRY_STATUS_FAILED,
+		entries[0].GetStatus(),
+	)
+	require.Equal(
+		t, walletrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_REFUNDED,
+		entries[0].GetProgress().GetPhase(),
+	)
+}
+
+// TestHistoryPendingFilterKeepsTerminalSwapCorrelations confirms --pending
+// still uses terminal swap metadata to hide internal OOR funding and refund
+// ledger legs before filtering terminal swap rows out of the response.
+func TestHistoryPendingFilterKeepsTerminalSwapCorrelations(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+
+	fundingSession := testBytes(32, 0x71)
+	fundingHex := testSessionString(t, fundingSession)
+	refundSession := testBytes(32, 0x81)
+	refundHex := testSessionString(t, refundSession)
+
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{
+		Swaps: []*swapclientrpc.SwapSummary{
+			{
+				PaymentHash: "completed-payment",
+				Direction: swapclientrpc.
+					SwapDirection_SWAP_DIRECTION_PAY,
+				State: swapclientrpc.
+					SwapState_SWAP_STATE_COMPLETED,
+				AmountSat:        1_000,
+				UpdatedAtUnix:    200,
+				FundingSessionId: fundingHex,
+			},
+			{
+				PaymentHash: "refunded-payment",
+				Direction: swapclientrpc.
+					SwapDirection_SWAP_DIRECTION_PAY,
+				State: swapclientrpc.
+					SwapState_SWAP_STATE_REFUNDED,
+				AmountSat:       1_000,
+				UpdatedAtUnix:   300,
+				RefundSessionId: refundHex,
+			},
+		},
+	}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:           "oor",
+				Subtype:        ledger.EventVTXOSent,
+				AmountSat:      9_000,
+				DebitAccount:   ledger.AccountTransfersOut,
+				CreditAccount:  ledger.AccountVTXOBalance,
+				SessionId:      fundingSession,
+				EntryId:        21,
+				CreatedAtUnixS: 100,
+			},
+			{
+				Type:           "oor",
+				Subtype:        ledger.EventVTXOReceived,
+				AmountSat:      8_000,
+				DebitAccount:   ledger.AccountVTXOBalance,
+				CreditAccount:  ledger.AccountTransfersIn,
+				Txid:           fundingHex,
+				OutputIndex:    1,
+				EntryId:        22,
+				CreatedAtUnixS: 101,
+			},
+			{
+				Type:           "oor",
+				Subtype:        ledger.EventVTXOSent,
+				AmountSat:      1_000,
+				DebitAccount:   ledger.AccountTransfersOut,
+				CreditAccount:  ledger.AccountVTXOBalance,
+				SessionId:      refundSession,
+				EntryId:        23,
+				CreatedAtUnixS: 102,
+			},
+			{
+				Type:           "oor",
+				Subtype:        ledger.EventVTXOReceived,
+				AmountSat:      1_000,
+				DebitAccount:   ledger.AccountVTXOBalance,
+				CreditAccount:  ledger.AccountTransfersIn,
+				Txid:           refundHex,
+				OutputIndex:    0,
+				EntryId:        24,
+				CreatedAtUnixS: 103,
+			},
+		},
+	}
+
+	resp, err := h.List(t.Context(), &walletrpc.ListRequest{
+		PendingOnly: true,
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.GetActivity().GetEntries())
+	require.False(
+		t, swap.listSwapsLast.GetPendingOnly(),
+		"history must fetch all swaps so terminal rows can hide "+
+			"their internal OOR ledger legs before --pending "+
+			"filters the visible rows",
+	)
+}
+
 // TestHistoryKeepsSameAmountUnmatchedFundingInput confirms pay-swap funding
 // legs are hidden by funding session, not by amount alone.
 func TestHistoryKeepsSameAmountUnmatchedFundingInput(t *testing.T) {

--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -216,6 +216,7 @@ type fakeSwapService struct {
 	listSwapsResp  *swapclientrpc.ListSwapsResponse
 	listSwapsErr   error
 	listSwapsCalls int
+	listSwapsLast  *swapclientrpc.ListSwapsRequest
 }
 
 func (f *fakeSwapService) StartPay(_ context.Context,
@@ -239,12 +240,31 @@ func (f *fakeSwapService) StartReceive(_ context.Context,
 }
 
 func (f *fakeSwapService) ListSwaps(_ context.Context,
-	_ *swapclientrpc.ListSwapsRequest) (*swapclientrpc.ListSwapsResponse,
+	req *swapclientrpc.ListSwapsRequest) (*swapclientrpc.ListSwapsResponse,
 	error) {
 
 	f.listSwapsCalls++
+	f.listSwapsLast = req
 
-	return f.listSwapsResp, f.listSwapsErr
+	if !req.GetPendingOnly() || f.listSwapsResp == nil {
+		return f.listSwapsResp, f.listSwapsErr
+	}
+
+	filtered := &swapclientrpc.ListSwapsResponse{
+		Swaps: make(
+			[]*swapclientrpc.SwapSummary, 0,
+			len(
+				f.listSwapsResp.GetSwaps(),
+			),
+		),
+	}
+	for _, swap := range f.listSwapsResp.GetSwaps() {
+		if swap.GetPending() {
+			filtered.Swaps = append(filtered.Swaps, swap)
+		}
+	}
+
+	return filtered, f.listSwapsErr
 }
 
 // errFakeStreamClosed is the canonical error returned by streaming-aware

--- a/swapwallet/normalize.go
+++ b/swapwallet/normalize.go
@@ -219,7 +219,9 @@ func kindFromSwapDirection(dir swapclientrpc.SwapDirection,
 // statusFromSwapState collapses every backing SwapState plus the pending
 // flag into the three user-facing wallet states. Pending governs PENDING
 // vs COMPLETE / FAILED; terminal states pick between COMPLETE and FAILED
-// based on whether the run reached the happy path.
+// based on whether the run reached the happy path. REFUNDED is a terminal
+// failure from the payment perspective; the phase carries the extra context
+// that funds returned.
 func statusFromSwapState(state swapclientrpc.SwapState,
 	pending bool) walletrpc.EntryStatus {
 
@@ -228,13 +230,13 @@ func statusFromSwapState(state swapclientrpc.SwapState,
 	}
 
 	switch state {
-	case swapclientrpc.SwapState_SWAP_STATE_COMPLETED,
-		swapclientrpc.SwapState_SWAP_STATE_REFUNDED:
+	case swapclientrpc.SwapState_SWAP_STATE_COMPLETED:
 		return walletrpc.EntryStatus_ENTRY_STATUS_COMPLETE
 
 	case swapclientrpc.SwapState_SWAP_STATE_FAILED,
 		swapclientrpc.SwapState_SWAP_STATE_EXPIRED,
-		swapclientrpc.SwapState_SWAP_STATE_NEEDS_INTERVENTION:
+		swapclientrpc.SwapState_SWAP_STATE_NEEDS_INTERVENTION,
+		swapclientrpc.SwapState_SWAP_STATE_REFUNDED:
 		return walletrpc.EntryStatus_ENTRY_STATUS_FAILED
 
 	default:

--- a/swapwallet/normalize_test.go
+++ b/swapwallet/normalize_test.go
@@ -89,9 +89,9 @@ func TestKindFromSwapDirection(t *testing.T) {
 }
 
 // TestStatusFromSwapState covers every branch: pending always wins,
-// terminal happy states map to COMPLETE, terminal failure states map
-// to FAILED, and any other non-pending state is treated as PENDING so
-// callers keep polling.
+// completed maps to COMPLETE, terminal failure states map to FAILED,
+// and any other non-pending state is treated as PENDING so callers keep
+// polling.
 func TestStatusFromSwapState(t *testing.T) {
 	t.Parallel()
 
@@ -102,26 +102,27 @@ func TestStatusFromSwapState(t *testing.T) {
 			swapclientrpc.SwapState_SWAP_STATE_COMPLETED, true,
 		),
 	)
+	require.Equal(
+		t, walletrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		statusFromSwapState(
+			swapclientrpc.SwapState_SWAP_STATE_REFUNDED, true,
+		),
+	)
 
-	// Terminal completed / refunded → COMPLETE.
+	// Terminal completed -> COMPLETE.
 	require.Equal(
 		t, walletrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
 		statusFromSwapState(
 			swapclientrpc.SwapState_SWAP_STATE_COMPLETED, false,
 		),
 	)
-	require.Equal(
-		t, walletrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
-		statusFromSwapState(
-			swapclientrpc.SwapState_SWAP_STATE_REFUNDED, false,
-		),
-	)
 
-	// Terminal failed states → FAILED.
+	// Terminal failed states, including refunded payments, -> FAILED.
 	for _, s := range []swapclientrpc.SwapState{
 		swapclientrpc.SwapState_SWAP_STATE_FAILED,
 		swapclientrpc.SwapState_SWAP_STATE_EXPIRED,
 		swapclientrpc.SwapState_SWAP_STATE_NEEDS_INTERVENTION,
+		swapclientrpc.SwapState_SWAP_STATE_REFUNDED,
 	} {
 		require.Equal(
 			t, walletrpc.EntryStatus_ENTRY_STATUS_FAILED,


### PR DESCRIPTION
## Problem

When an Ark-to-Lightning pay-side in-swap funds its vHTLC and the swap server later hits a terminal Lightning payment failure, the payer's Ark funds stay locked until the timeout refund path matures. That is safe, but unnecessarily slow: the server already knows the Lightning payment failed and no preimage was learned.

## Proposed design

This PR adds the client/daemon pieces for a cooperative immediate refund:

- add daemon RPCs to prepare a deterministic custom-input OOR and to sign one prepared custom input;
- carry externally produced tapscript signatures through custom OOR inputs and durable OOR snapshots;
- assemble custom input witnesses in script-key order with externally supplied signatures;
- add the swap RPC client surface for in-swap refund authorization;
- have pay sessions ask the swap server to sign the exact prepared cooperative refund spend after safe terminal failure, then submit the signed custom OOR before `refund_locktime`.

The timeout `RefundWithoutReceiver` path remains the fallback when the server has not safely failed yet, is unavailable, or is an older implementation.

## Tests

- `make fmt-changed`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`
- `make unit pkg=./sdk/swaps timeout=5m`
