### PR TITLE
Move default swap DB under network dir

### DIFF
--- a/darepod/config.go
+++ b/darepod/config.go
@@ -378,8 +378,9 @@ type SwapConfig struct {
 	ServerInsecure bool `mapstructure:"serverinsecure"`
 
 	// DatabaseFileName is the daemon-owned swap SQLite database path. When
-	// empty, the daemon stores swaps under DataDir/swaps.db so restart
-	// resume can discover pending sessions without CLI state.
+	// empty, the daemon stores swaps under NetworkDir()/swaps.db so a
+	// network DB reset clears persisted swap activity with the main daemon
+	// DB.
 	DatabaseFileName string `mapstructure:"databasefilename"`
 
 	// VHTLCRecovery controls when the daemon-owned swap runtime escalates

--- a/docs/swap_background_execution.md
+++ b/docs/swap_background_execution.md
@@ -119,7 +119,8 @@ swaprpc -> swapdk-server
 
 The executor owns:
 
-- swap store lifecycle (`~/.darepod/swaps.db` by default, configurable);
+- swap store lifecycle (`~/.darepod/data/<network>/swaps.db` by default,
+  configurable);
 - swap-server transport config;
 - construction of `sdk/swaps.SwapClient`;
 - a per-payment-hash worker registry;

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -276,14 +276,18 @@ func RegisterGateway(ctx context.Context, mux *runtime.ServeMux,
 func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 	daemonCfg *darepod.Config) (*swapClientService, func(), error) {
 
+	if daemonCfg == nil {
+		return nil, nil, fmt.Errorf("daemon config is required")
+	}
+
 	cfg := daemonCfg.Swap
 	if cfg == nil {
 		cfg = darepod.DefaultConfig().Swap
 	}
 
-	dbPath := cfg.DatabaseFileName
-	if dbPath == "" {
-		dbPath = filepath.Join(daemonCfg.DataDir, "swaps.db")
+	dbPath, err := swapStoreDatabasePath(daemonCfg, cfg)
+	if err != nil {
+		return nil, nil, err
 	}
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
 		return nil, nil, fmt.Errorf("create swap db dir: %w", err)
@@ -417,6 +421,24 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 	}
 
 	return service, cleanup, nil
+}
+
+// swapStoreDatabasePath returns the daemon-owned swap store path. By default it
+// follows the network-scoped daemon DB directory so a network DB reset also
+// clears wallet activity derived from persisted swap sessions.
+func swapStoreDatabasePath(daemonCfg *darepod.Config,
+	cfg *darepod.SwapConfig) (string, error) {
+
+	if daemonCfg == nil {
+		return "", fmt.Errorf("daemon config is required")
+	}
+	if cfg != nil && cfg.DatabaseFileName != "" {
+		return cfg.DatabaseFileName, nil
+	}
+
+	return filepath.Join(
+		daemonCfg.NetworkDir(), swaps.DefaultSqliteDatabaseFileName,
+	), nil
 }
 
 // newSwapServerClients builds the swapdk-server clients for the configured

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -64,6 +66,79 @@ func TestResumePendingStartsWorkersAndDedupes(t *testing.T) {
 	require.Equal(t, 1, fakeClient.payResumeCount(payHash))
 	require.Equal(t, 1, fakeClient.receiveResumeCount(receiveHash))
 	require.True(t, fakeClient.sawPendingOnlyList())
+}
+
+// TestSwapStoreDatabasePathDefaultsToNetworkDir verifies a default swap store
+// is reset together with the network-scoped daemon DB directory.
+func TestSwapStoreDatabasePathDefaultsToNetworkDir(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	path, err := swapStoreDatabasePath(&darepod.Config{
+		DataDir: dataDir,
+		Network: "signet",
+	}, &darepod.SwapConfig{})
+	require.NoError(t, err)
+	require.Equal(
+		t, filepath.Join(dataDir, "data", "signet", "swaps.db"), path,
+	)
+}
+
+// TestSwapStoreDatabasePathUsesValidatedDataDir verifies the default swap store
+// follows the daemon's validated data directory, including config-level tilde
+// expansion.
+func TestSwapStoreDatabasePathUsesValidatedDataDir(t *testing.T) {
+	t.Parallel()
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	daemonCfg := darepod.DefaultConfig()
+	daemonCfg.Network = "regtest"
+	daemonCfg.Wallet.EsploraURL = "https://esplora.example/api"
+	require.NoError(t, daemonCfg.Validate())
+
+	path, err := swapStoreDatabasePath(daemonCfg, &darepod.SwapConfig{})
+	require.NoError(t, err)
+	require.Equal(
+		t, filepath.Join(
+			home, ".darepod", "data", "regtest", "swaps.db",
+		),
+		path,
+	)
+}
+
+// TestSwapStoreDatabasePathExpandsConfiguredHome verifies explicit operator
+// paths follow the same leading-tilde behavior as the daemon datadir.
+func TestSwapStoreDatabasePathExpandsConfiguredHome(t *testing.T) {
+	t.Parallel()
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	daemonCfg := darepod.DefaultConfig()
+	daemonCfg.DataDir = t.TempDir()
+	daemonCfg.Network = "signet"
+	daemonCfg.AllowMainnet = false
+	daemonCfg.Wallet.EsploraURL = "https://esplora.example/api"
+	daemonCfg.Swap.DatabaseFileName = "~/.darepod/custom-swaps.db"
+	require.NoError(t, daemonCfg.Validate())
+
+	path, err := swapStoreDatabasePath(daemonCfg, daemonCfg.Swap)
+	require.NoError(t, err)
+	require.Equal(
+		t, filepath.Join(home, ".darepod", "custom-swaps.db"), path,
+	)
+}
+
+// TestSwapStoreDatabasePathRequiresDaemonConfig verifies the helper fails
+// explicitly if a future call site reaches it without daemon config.
+func TestSwapStoreDatabasePathRequiresDaemonConfig(t *testing.T) {
+	t.Parallel()
+
+	path, err := swapStoreDatabasePath(nil, &darepod.SwapConfig{})
+	require.ErrorContains(t, err, "daemon config is required")
+	require.Empty(t, path)
 }
 
 func TestStartPayReturnsSummaryAndStartsWorker(t *testing.T) {


### PR DESCRIPTION
## Summary

Related to #553.

Manual arktest repro with the same LND wallet and a fresh daemon data dir did not reproduce server-keyed activity rehydration: the fresh daemon returned an empty `activity` list and had zero local ledger, VTXO, boarding, and swap rows. That means this change should not be treated as a complete fix for the mixed activity table shown in #553.

This still moves the default daemon-owned swap DB from `DataDir/swaps.db` to `NetworkDir()/swaps.db`, so wiping `~/.darepod/data/<network>` also clears persisted swap summaries. That closes one real persistence mismatch for swap rows, but ledger-backed activity such as `DEPOSIT` or `ledger-*` rows must come from the local daemon DB or from activity created after the wipe.

Explicit `swap.databasefilename` values still work, and leading `~` is expanded so configured paths do not accidentally create a literal `~` directory.

## Manual Repro Notes

Fresh arktest setup:

- Started a one-client regtest topology with alice.
- Created and confirmed one boarding deposit.
- Verified alice's original daemon showed one `DEPOSIT` activity row.
- Started a second `darepod` against the same alice LND wallet and same local arkd, but with a brand-new data dir.
- The fresh daemon returned `activity.entries=[]`.
- The fresh daemon DB contained zero `ledger_entries`, zero `vtxos`, zero `boarding_addresses`, zero `boarding_intents`, and the swap DB had zero pay/receive rows.

Conclusion: same LND identity alone does not cause the activity table to be rebuilt from server state.

## Validation

- `make fmt-changed`
- `make unit tags="swapruntime" pkg=./swapclientserver case=TestSwapStoreDatabasePath`
- `make unit tags="swapruntime" pkg=./swapclientserver`
- `make lint-changed-local`
- `git diff --check`
- `make commitmsg-lint range="HEAD~1..HEAD"`
