### PR TITLE
Retry unregistered vHTLC poll window

### DIFF
--- a/sdk/swaps/errors.go
+++ b/sdk/swaps/errors.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	loopfsm "github.com/lightninglabs/loop/fsm"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
-
-const unregisteredScriptErrText = "script not registered for principal"
 
 var (
 	// ErrSwapExpired is returned when a client-side swap reaches its
@@ -191,25 +188,6 @@ func isDeadlineExceededErr(err error) bool {
 	}
 
 	return status.Code(err) == codes.DeadlineExceeded
-}
-
-// isUnregisteredScriptErr reports an authoritative indexer rejection for a
-// script that is no longer bound to the caller's current mailbox principal.
-func isUnregisteredScriptErr(err error) bool {
-	if err == nil || !strings.Contains(
-		err.Error(), unregisteredScriptErrText,
-	) {
-		return false
-	}
-
-	switch status.Code(err) {
-	case codes.Unauthenticated, codes.PermissionDenied, codes.Internal,
-		codes.Unknown:
-		return true
-
-	default:
-		return false
-	}
 }
 
 // handleFailure persists the terminal swap state associated with err and

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -1652,10 +1652,12 @@ func encodeVHTLCPolicyTemplate(policy *arkscript.VHTLCPolicy) ([]byte, error) {
 //
 // The polled pkScript is derived locally from the vHTLC policy parameters
 // supplied by the swap server. A persistent loop where the indexer keeps
-// rejecting the query because the script is not registered to the current
-// principal is terminal for this receive attempt: either the local and remote
-// script derivation disagree, or stale local swap metadata survived a daemon
-// reset while the corresponding server-side script registration did not.
+// rejecting the query (e.g. "Unauthenticated: script not registered for
+// principal") usually means the local and remote `lib/arkscript` packages
+// disagree on the vHTLC script structure, so the funded output is at a
+// different pkScript than this side derives. The bundled log includes the
+// indexer's error wording and the queried pkScript so the operator can match it
+// against the on-chain output for diagnosis.
 func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 	deadline time.Time, keepWaiting func(context.Context) error) (string,
 	int64, error) {
@@ -1672,14 +1674,6 @@ func (c *SwapClient) waitForVHTLC(ctx context.Context, pkScript []byte,
 				slog.String("err", err.Error()),
 				slog.String("pk_script", pkScriptHex),
 			)
-			if isUnregisteredScriptErr(err) {
-				return "", 0, newFailureError(
-					fmt.Sprintf("vHTLC script %s is not "+
-						"registered for current "+
-						"principal", pkScriptHex),
-					err,
-				)
-			}
 		}
 		if vtxo != nil {
 			c.log.InfoS(ctx, "Found funded vHTLC",

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -472,31 +472,37 @@ func TestCancelVHTLCRecoveryIgnoresNotFound(t *testing.T) {
 	)
 }
 
-// TestWaitForVHTLCFailsOnUnregisteredScript verifies stale accepted receive
-// events stop retrying once the current principal can no longer query the
-// expected script.
-func TestWaitForVHTLCFailsOnUnregisteredScript(t *testing.T) {
+// TestWaitForVHTLCRetriesUnregisteredScriptUntilFunded verifies the expected
+// pre-funded window does not fail a receive before the vHTLC row is indexed.
+func TestWaitForVHTLCRetriesUnregisteredScriptUntilFunded(t *testing.T) {
 	t.Parallel()
 
 	pkScript := bytes.Repeat([]byte{0x02}, 34)
+	expected := &VTXOInfo{
+		Outpoint:  "funding:0",
+		AmountSat: 5000,
+	}
 	daemonConn := &testDaemonConn{
-		liveLookupErr: status.Error(
-			codes.Internal, "indexer query failed: rpc error: "+
-				"code = Unauthenticated desc = script not "+
-				"registered for principal",
-		),
+		liveLookupErrs: []error{
+			status.Error(
+				codes.Internal, "indexer query failed: rpc "+
+					"error: code = Unauthenticated "+
+					"desc = script not registered for "+
+					"principal",
+			),
+		},
+		vhtlc: expected,
 	}
 	client := NewSwapClient(nil, daemonConn, nil, nil)
+	client.waitPollInterval = time.Millisecond
 
-	_, _, err := client.waitForVHTLC(
-		t.Context(), pkScript, time.Time{}, nil,
+	outpoint, amount, err := client.waitForVHTLC(
+		t.Context(), pkScript, time.Now().Add(time.Second), nil,
 	)
-	require.Error(t, err)
-	require.Contains(
-		t, failureReason(err),
-		"not registered for current principal",
-	)
-	require.Equal(t, 1, daemonConn.liveLookupCalls)
+	require.NoError(t, err)
+	require.Equal(t, expected.Outpoint, outpoint)
+	require.Equal(t, expected.AmountSat, amount)
+	require.Equal(t, 2, daemonConn.liveLookupCalls)
 }
 
 type testDaemonConn struct {
@@ -518,6 +524,7 @@ type testDaemonConn struct {
 	sendPolicyErr     error
 	sendCustomErr     error
 	listSpentErr      error
+	liveLookupErrs    []error
 	liveLookupErr     error
 	spentLookupErr    error
 	spentLookupBlock  time.Duration
@@ -815,6 +822,12 @@ func (d *testDaemonConn) FindLiveVTXOByPkScript(_ context.Context,
 	pkScript []byte) (*VTXOInfo, error) {
 
 	d.liveLookupCalls++
+	if len(d.liveLookupErrs) > 0 {
+		err := d.liveLookupErrs[0]
+		d.liveLookupErrs = d.liveLookupErrs[1:]
+
+		return nil, err
+	}
 	if d.liveLookupErr != nil {
 		return nil, d.liveLookupErr
 	}


### PR DESCRIPTION
## Summary

Updates #538.

A `script not registered for principal` response from the indexer can be a transient pre-funded state: the receiver has accepted the swap server's HTLC event and derived the vHTLC pkScript, but the swap server has not yet materialized the matching vHTLC row in arkd's indexer.

The current code treats that response as terminal immediately, which can fail fresh offchain receives during that normal window. This changes the poller back to retrying the indexer error and lets the existing refund-locktime guard decide when funding is no longer possible. Permanent script mismatches still leave the diagnostic log with the queried pkScript, and stale receives still expire once the refund locktime is imminent or reached.

## Validation

- `make fmt-changed`
- `make unit pkg=./sdk/swaps case=TestWaitForVHTLCRetriesUnregisteredScriptUntilFunded`
- `make unit pkg=./sdk/swaps`
- `make lint-changed-local`
- `git diff --check`
- `make commitmsg-lint range="HEAD~1..HEAD"`
