### PR TITLE
darepod: expand ~ in config paths during Validate

### DIFF
--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -526,11 +526,7 @@ func configureDaemonLogWriter(cfg *darepod.Config,
 		return nil, nil
 	}
 
-	logDir, err := cfg.LogDir()
-	if err != nil {
-		return nil, err
-	}
-
+	logDir := cfg.LogDir()
 	if err := os.MkdirAll(logDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create log directory %q: %w", logDir,
 			err)

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -719,6 +719,10 @@ func DefaultConfig() *Config {
 // Validate checks the config for internal consistency and returns an error
 // if any required fields are missing or invalid.
 func (c *Config) Validate() error {
+	if err := c.expandPaths(); err != nil {
+		return err
+	}
+
 	switch c.Network {
 	case "mainnet", "testnet", "regtest", "simnet", "signet":
 	default:
@@ -954,28 +958,74 @@ func networkToChainParams(network string) (*chaincfg.Params, error) {
 }
 
 // NetworkDir returns the network-scoped data directory (e.g.,
-// ~/.darepod/data/regtest).
-func (c *Config) NetworkDir() (string, error) {
-	dataDir, err := expandTilde(c.DataDir)
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(dataDir, "data", c.Network), nil
+// /home/user/.darepod/data/regtest). Path fields are normalized by
+// Validate via expandPaths, so callers must validate before reaching
+// this helper.
+func (c *Config) NetworkDir() string {
+	return filepath.Join(c.DataDir, "data", c.Network)
 }
 
-// LogDir returns the network-scoped log directory.
-func (c *Config) LogDir() (string, error) {
+// LogDir returns the network-scoped log directory. Path fields are
+// normalized by Validate via expandPaths, so callers must validate
+// before reaching this helper.
+func (c *Config) LogDir() string {
 	if c.LogDirPath != "" {
-		return expandTilde(c.LogDirPath)
+		return c.LogDirPath
 	}
 
-	dataDir, err := expandTilde(c.DataDir)
-	if err != nil {
-		return "", err
+	return filepath.Join(c.DataDir, "logs", c.Network)
+}
+
+// expandPaths normalizes filesystem path fields by expanding a leading tilde to
+// the user's home directory. expandTilde is a no-op on empty strings and on
+// paths that don't start with "~", so URL-or-path fields (e.g. BtcwBlockSource,
+// BtcwFilterSource) pass through unchanged.
+func (c *Config) expandPaths() error {
+	fields := []*string{
+		&c.DataDir,
+		&c.LogDirPath,
 	}
 
-	return filepath.Join(dataDir, "logs", c.Network), nil
+	if c.Lnd != nil {
+		fields = append(fields,
+			&c.Lnd.TLSPath, &c.Lnd.MacaroonPath,
+		)
+	}
+
+	if c.Server != nil {
+		fields = append(fields, &c.Server.TLSCertPath)
+	}
+
+	if c.RPC != nil {
+		fields = append(
+			fields, &c.RPC.TLSCertPath, &c.RPC.TLSKeyPath,
+		)
+	}
+
+	if c.Wallet != nil {
+		fields = append(
+			fields, &c.Wallet.PasswordFile,
+			&c.Wallet.BtcwalletDataDir, &c.Wallet.BtcwBlockSource,
+			&c.Wallet.BtcwFilterSource,
+		)
+	}
+
+	if c.Swap != nil {
+		fields = append(
+			fields, &c.Swap.DatabaseFileName,
+			&c.Swap.ServerTLSCertPath,
+		)
+	}
+
+	for _, p := range fields {
+		expanded, err := expandTilde(*p)
+		if err != nil {
+			return fmt.Errorf("expand path %q: %w", *p, err)
+		}
+		*p = expanded
+	}
+
+	return nil
 }
 
 // expandTilde replaces a leading ~ or ~/ with the user's home

--- a/darepod/config_expand_paths_test.go
+++ b/darepod/config_expand_paths_test.go
@@ -1,0 +1,103 @@
+package darepod
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateExpandsTildePaths verifies Validate normalizes the leading
+// tilde on filesystem path fields so downstream consumers can read them
+// as absolute strings without repeating the expansion.
+func TestValidateExpandsTildePaths(t *testing.T) {
+	t.Parallel()
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	cfg := DefaultConfig()
+	cfg.Network = "regtest"
+	cfg.DataDir = "~/.darepod"
+	cfg.LogDirPath = "~/.darepod/logs-override"
+	cfg.Wallet.EsploraURL = "https://esplora.example/api"
+	cfg.Lnd.TLSPath = "~/.lnd/tls.cert"
+	cfg.Lnd.MacaroonPath = "~/.lnd/admin.macaroon"
+	cfg.Server.TLSCertPath = "~/ark/tls.cert"
+	cfg.RPC.TLSCertPath = "~/.darepod/rpc-tls.cert"
+	cfg.RPC.TLSKeyPath = "~/.darepod/rpc-tls.key"
+	cfg.Wallet.PasswordFile = "~/secrets/pw"
+	cfg.Wallet.BtcwalletDataDir = "~/.darepod/neutrino"
+	cfg.Swap.DatabaseFileName = "~/.darepod/custom-swaps.db"
+	cfg.Swap.ServerTLSCertPath = "~/.darepod/swap-tls.cert"
+
+	require.NoError(t, cfg.Validate())
+
+	require.Equal(t, filepath.Join(home, ".darepod"), cfg.DataDir)
+	require.Equal(
+		t, filepath.Join(home, ".darepod", "logs-override"),
+		cfg.LogDirPath,
+	)
+	require.Equal(
+		t, filepath.Join(home, ".lnd", "tls.cert"), cfg.Lnd.TLSPath,
+	)
+	require.Equal(
+		t, filepath.Join(home, ".lnd", "admin.macaroon"),
+		cfg.Lnd.MacaroonPath,
+	)
+	require.Equal(
+		t, filepath.Join(home, "ark", "tls.cert"),
+		cfg.Server.TLSCertPath,
+	)
+	require.Equal(
+		t, filepath.Join(home, ".darepod", "rpc-tls.cert"),
+		cfg.RPC.TLSCertPath,
+	)
+	require.Equal(
+		t, filepath.Join(home, ".darepod", "rpc-tls.key"),
+		cfg.RPC.TLSKeyPath,
+	)
+	require.Equal(
+		t, filepath.Join(home, "secrets", "pw"),
+		cfg.Wallet.PasswordFile,
+	)
+	require.Equal(
+		t, filepath.Join(home, ".darepod", "neutrino"),
+		cfg.Wallet.BtcwalletDataDir,
+	)
+	require.Equal(
+		t, filepath.Join(home, ".darepod", "custom-swaps.db"),
+		cfg.Swap.DatabaseFileName,
+	)
+	require.Equal(
+		t, filepath.Join(home, ".darepod", "swap-tls.cert"),
+		cfg.Swap.ServerTLSCertPath,
+	)
+
+	// NetworkDir and LogDir read the already-expanded values without
+	// re-expanding, so the result is a clean absolute path.
+	require.Equal(
+		t, filepath.Join(home, ".darepod", "data", "regtest"),
+		cfg.NetworkDir(),
+	)
+	require.Equal(
+		t, filepath.Join(home, ".darepod", "logs-override"),
+		cfg.LogDir(),
+	)
+}
+
+// TestValidateLeavesAbsolutePathsUntouched verifies the expansion step is a
+// no-op for callers that already pass absolute paths.
+func TestValidateLeavesAbsolutePathsUntouched(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.Network = "regtest"
+	cfg.DataDir = dataDir
+	cfg.Wallet.EsploraURL = "https://esplora.example/api"
+
+	require.NoError(t, cfg.Validate())
+	require.Equal(t, dataDir, cfg.DataDir)
+}

--- a/darepod/config_logdir_test.go
+++ b/darepod/config_logdir_test.go
@@ -17,9 +17,9 @@ func TestConfigLogDirUsesNetworkScopedDefault(t *testing.T) {
 	cfg.DataDir = dataDir
 	cfg.Network = "regtest"
 
-	logDir, err := cfg.LogDir()
-	require.NoError(t, err)
-	require.Equal(t, filepath.Join(dataDir, "logs", "regtest"), logDir)
+	require.Equal(
+		t, filepath.Join(dataDir, "logs", "regtest"), cfg.LogDir(),
+	)
 }
 
 // TestConfigLogDirUsesExplicitLogDir verifies an explicit log directory
@@ -33,7 +33,5 @@ func TestConfigLogDirUsesExplicitLogDir(t *testing.T) {
 	cfg.Network = "regtest"
 	cfg.LogDirPath = explicitLogDir
 
-	logDir, err := cfg.LogDir()
-	require.NoError(t, err)
-	require.Equal(t, explicitLogDir, logDir)
+	require.Equal(t, explicitLogDir, cfg.LogDir())
 }

--- a/darepod/rpc_wallet.go
+++ b/darepod/rpc_wallet.go
@@ -288,13 +288,7 @@ func (r *RPCServer) InitWallet(ctx context.Context,
 	}
 
 	// Resolve the network directory for seed storage.
-	networkDir, err := r.server.cfg.NetworkDir()
-	if err != nil {
-		rollbackState()
-
-		return nil, status.Errorf(codes.Internal, "unable to resolve "+
-			"network directory: %v", err)
-	}
+	networkDir := r.server.cfg.NetworkDir()
 
 	// Delegate to the package-level function that validates the
 	// mnemonic, derives the seed, encrypts it, and saves it to
@@ -367,13 +361,7 @@ func (r *RPCServer) UnlockWallet(ctx context.Context,
 	}
 
 	// Resolve the network directory for seed lookup.
-	networkDir, err := r.server.cfg.NetworkDir()
-	if err != nil {
-		rollbackState()
-
-		return nil, status.Errorf(codes.Internal, "unable to resolve "+
-			"network directory: %v", err)
-	}
+	networkDir := r.server.cfg.NetworkDir()
 
 	// Delegate to the package-level function that loads the
 	// encrypted seed from disk and decrypts it. This logic is

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1288,13 +1288,7 @@ func (s *Server) tryAutoUnlockLwwallet(ctx context.Context) {
 		return
 	}
 
-	networkDir, err := s.cfg.NetworkDir()
-	if err != nil {
-		s.log.ErrorS(ctx, "Unable to resolve network directory",
-			err)
-
-		return
-	}
+	networkDir := s.cfg.NetworkDir()
 
 	// Check for an encrypted seed file on disk.
 	if !SeedFileExists(networkDir) {
@@ -1371,10 +1365,7 @@ func (s *Server) tryAutoUnlockLwwallet(ctx context.Context) {
 func (s *Server) startLwwallet(ctx context.Context,
 	seed [rawSeedLen]byte) error {
 
-	networkDir, err := s.cfg.NetworkDir()
-	if err != nil {
-		return fmt.Errorf("resolve network directory: %w", err)
-	}
+	networkDir := s.cfg.NetworkDir()
 
 	pollInterval := s.cfg.Wallet.PollInterval
 	if pollInterval == 0 {
@@ -1481,13 +1472,7 @@ func (s *Server) tryAutoUnlockBtcwallet(ctx context.Context) {
 		return
 	}
 
-	networkDir, err := s.cfg.NetworkDir()
-	if err != nil {
-		s.log.ErrorS(ctx,
-			"Unable to resolve network directory", err)
-
-		return
-	}
+	networkDir := s.cfg.NetworkDir()
 
 	// Check for an encrypted seed file on disk.
 	if !SeedFileExists(networkDir) {
@@ -1568,12 +1553,7 @@ func (s *Server) preStartNeutrino(ctx context.Context) error {
 
 	neutrinoDataDir := s.cfg.Wallet.BtcwalletDataDir
 	if neutrinoDataDir == "" {
-		networkDir, err := s.cfg.NetworkDir()
-		if err != nil {
-			return fmt.Errorf("resolve network directory: %w", err)
-		}
-
-		neutrinoDataDir = networkDir
+		neutrinoDataDir = s.cfg.NetworkDir()
 	}
 
 	var neutrinoOpts []btcwbackend.NeutrinoServiceOption
@@ -1615,10 +1595,7 @@ func (s *Server) preStartNeutrino(ctx context.Context) error {
 func (s *Server) startBtcwallet(ctx context.Context,
 	seed [rawSeedLen]byte) error {
 
-	networkDir, err := s.cfg.NetworkDir()
-	if err != nil {
-		return fmt.Errorf("resolve network directory: %w", err)
-	}
+	networkDir := s.cfg.NetworkDir()
 
 	recoveryWindow := s.cfg.Wallet.RecoveryWindow
 	if recoveryWindow == 0 {
@@ -1649,7 +1626,10 @@ func (s *Server) startBtcwallet(ctx context.Context,
 	// Reuse the pre-started neutrino service if available.
 	// Otherwise, create a new one (fallback for callers that
 	// skip preStartNeutrino).
-	var w *btcwbackend.Wallet
+	var (
+		w   *btcwbackend.Wallet
+		err error
+	)
 	if s.neutrinoSvc.IsSome() {
 		svc := s.neutrinoSvc.UnsafeFromSome()
 		w, err = btcwbackend.NewWithNeutrino(cfg, svc)
@@ -2854,10 +2834,7 @@ func (s *Server) handleInboundRPC(ctx context.Context,
 //
 //nolint:contextcheck // database constructor owns migration startup context
 func (s *Server) initDatabase(ctx context.Context) error {
-	networkDir, err := s.cfg.NetworkDir()
-	if err != nil {
-		return fmt.Errorf("resolve network directory: %w", err)
-	}
+	networkDir := s.cfg.NetworkDir()
 
 	if err := os.MkdirAll(networkDir, 0700); err != nil {
 		return fmt.Errorf("unable to create data dir: %w", err)
@@ -2865,6 +2842,7 @@ func (s *Server) initDatabase(ctx context.Context) error {
 
 	sqliteCfg := db.DefaultSqliteConfig(networkDir)
 
+	var err error
 	s.db, err = db.NewSqliteStore(
 		sqliteCfg, s.subLogger(db.Subsystem),
 	)

--- a/sdk/ark/embedded.go
+++ b/sdk/ark/embedded.go
@@ -58,6 +58,16 @@ func StartEmbedded(ctx context.Context, cfg EmbeddedConfig) (*Client, error) {
 	}
 	daemonCfg.RPC.Listener = listener
 
+	// Validate normalizes path fields (e.g. tilde expansion) and fills
+	// in subsystem defaults that NewServer assumes are present, so the
+	// embedded path matches the standalone daemon's contract.
+	if err := daemonCfg.Validate(); err != nil {
+		_ = listener.Close()
+
+		return nil, fmt.Errorf("validate embedded daemon config: %w",
+			err)
+	}
+
 	server, err := darepod.NewServer(daemonCfg)
 	if err != nil {
 		_ = listener.Close()
@@ -146,12 +156,22 @@ func StartEmbedded(ctx context.Context, cfg EmbeddedConfig) (*Client, error) {
 	}, nil
 }
 
-// cloneDaemonConfig copies the daemon config deeply enough that embedded
-// startup can inject a listener without mutating the caller's config. This is
-// intentionally a passthrough clone of darepod.Config and must be updated if
-// new reference-typed fields are added there.
+// cloneDaemonConfig deep-copies the daemon config so embedded startup can
+// inject a listener and run Validate without mutating the caller's config.
+// This must be updated if new reference-typed fields are added to
+// darepod.Config or to any sub-config reachable from it.
 func cloneDaemonConfig(cfg *darepod.Config) *darepod.Config {
 	clone := *cfg
+
+	clone.RPCServiceRegistrars = append(
+		[]darepod.RPCServiceRegistrar(nil), cfg.RPCServiceRegistrars...,
+	)
+	clone.RPCGatewayRegistrars = append(
+		[]darepod.RPCGatewayRegistrar(nil), cfg.RPCGatewayRegistrars...,
+	)
+	clone.WalletReadyHooks = append(
+		[]darepod.WalletReadyHook(nil), cfg.WalletReadyHooks...,
+	)
 
 	if cfg.Lnd != nil {
 		lndCfg := *cfg.Lnd
@@ -165,6 +185,14 @@ func cloneDaemonConfig(cfg *darepod.Config) *darepod.Config {
 
 	if cfg.RPC != nil {
 		rpcCfg := *cfg.RPC
+		if cfg.RPC.Gateway != nil {
+			gw := *cfg.RPC.Gateway
+			gw.AllowedOrigins = append(
+				[]string(nil),
+				cfg.RPC.Gateway.AllowedOrigins...,
+			)
+			rpcCfg.Gateway = &gw
+		}
 		clone.RPC = &rpcCfg
 	}
 
@@ -177,6 +205,30 @@ func cloneDaemonConfig(cfg *darepod.Config) *darepod.Config {
 			[]string(nil), cfg.Wallet.BtcwalletAddPeers...,
 		)
 		clone.Wallet = &walletCfg
+	}
+
+	if cfg.Unroll != nil {
+		unrollCfg := *cfg.Unroll
+		clone.Unroll = &unrollCfg
+	}
+
+	if cfg.OOR != nil {
+		oorCfg := *cfg.OOR
+		if cfg.OOR.Limits != nil {
+			limits := *cfg.OOR.Limits
+			oorCfg.Limits = &limits
+		}
+		clone.OOR = &oorCfg
+	}
+
+	if cfg.Swap != nil {
+		swapCfg := *cfg.Swap
+		clone.Swap = &swapCfg
+	}
+
+	if cfg.SwapWallet != nil {
+		swapWalletCfg := *cfg.SwapWallet
+		clone.SwapWallet = &swapWalletCfg
 	}
 
 	return &clone

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -567,8 +567,7 @@ func seedLiveVTXO(t *testing.T, cfg *darepod.Config,
 
 	t.Helper()
 
-	networkDir, err := cfg.NetworkDir()
-	require.NoError(t, err)
+	networkDir := cfg.NetworkDir()
 	require.NoError(t, os.MkdirAll(networkDir, 0o700))
 
 	sqliteStore, err := db.NewSqliteStore(


### PR DESCRIPTION
Related to https://github.com/lightninglabs/darepo-client/issues/553. Tilde-prefixed paths set via the config file or CLI flags (e.g. `datadir: ~/.darepod`) were only expanded inside NetworkDir() and LogDir(); every other DataDir consumer read the literal string. As a result, e.g. the swap subserver default `filepath.Join(DataDir, "swaps.db")` produced a directory named "~" in the daemon CWD.

Centralize expansion in a new Config.expandPaths() called at the top of Validate so downstream code can treat path fields as absolute. Covers DataDir, LogDirPath, Lnd TLS/macaroon, wallet password and btcwallet sources, and the swap DB / TLS cert paths. NetworkDir and LogDir drop their per-call expandTilde now that DataDir is normalized upfront.

Users will probably need to migrate from the `~` folder to the intended folder.