### PR TITLE
docs: add a real README and an INSTALL guide

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,286 @@
+# Installing darepo-client
+
+This document covers everything needed to get `darepod` (the daemon) and
+`darepocli` (the CLI) built, installed, and running. For day-to-day daemon
+operation, configuration flags, and the full CLI reference, see
+[`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md).
+
+---
+
+## Prerequisites
+
+| Requirement | Version            | Notes                                                       |
+|-------------|--------------------|-------------------------------------------------------------|
+| Go          | **1.25.5** or later| The reference version (used by CI and release builds).      |
+| Git         | any recent         | For cloning and submodule resolution.                       |
+| make        | GNU make           | All build/test/lint targets are driven through the Makefile.|
+| C toolchain | optional           | Only needed for `make unit-race` (requires `CGO_ENABLED=1`).|
+
+Verify your toolchain:
+
+```bash
+go version       # expect: go1.25.5+
+make --version
+git --version
+```
+
+Make sure `$GOPATH/bin` (or `$(go env GOBIN)`) is on your `PATH` so the
+installed binaries are reachable:
+
+```bash
+export PATH="$(go env GOPATH)/bin:$PATH"
+```
+
+---
+
+## TL;DR: Install With Wallet RPC (Recommended)
+
+```bash
+git clone https://github.com/lightninglabs/darepo-client.git
+cd darepo-client
+make install-walletrpc
+```
+
+That single target builds and installs both `darepod` and `darepocli` to
+`$GOPATH/bin` with the optional `walletrpc` + `swapruntime` subsystems
+enabled. After it completes you have access to:
+
+- The top-level wallet verbs: `darepocli {create, unlock, balance, recv,
+  send, activity, exit, mcp serve}`.
+- The Lightning swap subsystem (in-process swap FSM).
+- The full power-user surface: `darepocli ark *` and `darepocli dev *`.
+- The MCP server for AI-agent integration.
+
+Confirm the install:
+
+```bash
+which darepod darepocli
+darepod   --version
+darepocli --help
+```
+
+If `darepocli balance` reports `daemon was not built with -tags walletrpc`,
+the binary on `PATH` came from a default build. Re-run
+`make install-walletrpc` and ensure `$GOPATH/bin` precedes any older copy.
+
+---
+
+## Build Variants
+
+`darepod` ships with optional subsystems gated behind Go build tags. Pick
+the variant that matches your needs.
+
+| Variant                          | Tags                       | Binaries                | When to use                                            |
+|----------------------------------|----------------------------|-------------------------|--------------------------------------------------------|
+| Core (default)                   | _(none)_                   | `darepod`, `darepocli`  | Headless Ark client; no swaps; power-user CLI only.    |
+| With Lightning swaps             | `swapruntime`              | `darepod`, `darepocli`  | Use Lightning-to-Ark / Ark-to-Lightning swaps.         |
+| With wallet RPC (recommended)    | `walletrpc swapruntime`    | `darepod`, `darepocli`  | Use the top-level wallet verbs and host-app SDK.       |
+
+`walletrpc` is a strict superset of `swapruntime`; you cannot enable
+`walletrpc` without `swapruntime` (the combination is enforced at compile
+time).
+
+### Local debug builds (output to `./bin/`)
+
+```bash
+make build                       # core
+make build-swapruntime           # + swap subsystem
+make build-walletrpc             # + walletrpc and swap subsystem  (recommended)
+```
+
+After any of these, the binaries are at:
+
+- `./bin/darepod`
+- `./bin/darepocli`
+
+### Install to `$GOPATH/bin`
+
+```bash
+make install                     # core
+make install-swapruntime         # + swap subsystem
+make install-walletrpc           # + walletrpc and swap subsystem  (recommended)
+```
+
+For more on what each tag turns on, see
+[`docs/walletrpc_build.md`](docs/walletrpc_build.md).
+
+---
+
+## Step-By-Step From Source
+
+If you want the long form (e.g. for CI or reproducible-build setups):
+
+```bash
+# 1. Clone.
+git clone https://github.com/lightninglabs/darepo-client.git
+cd darepo-client
+
+# 2. Verify Go version (1.25.5+).
+go version
+
+# 3. Fetch and tidy dependencies. The repo uses a multi-module Go
+#    workspace (see docs/go_workspace.md); this is normally automatic.
+go mod download
+
+# 4. Build the recommended (walletrpc) variant into ./bin.
+make build-walletrpc
+
+# 5. Or install the same variant to $GOPATH/bin.
+make install-walletrpc
+
+# 6. Confirm the binaries.
+./bin/darepod   --help
+./bin/darepocli --help
+```
+
+---
+
+## Backend Prerequisites
+
+`darepod` supports three wallet/chain backends, selected at runtime via
+`--wallet.type`. Each has its own external dependencies.
+
+### `lwwallet` (default, standalone)
+
+Lightweight in-process wallet backed by an Esplora REST endpoint. No
+external Bitcoin node or lnd required.
+
+```bash
+darepod \
+  --network=regtest \
+  --wallet.type=lwwallet \
+  --wallet.esploraurl=http://localhost:3000
+```
+
+For local development the easiest Esplora is [Nigiri](https://nigiri.vulpem.com/):
+
+```bash
+nigiri start                 # spins up bitcoind + Esplora on regtest
+```
+
+### `btcwallet` (Neutrino)
+
+In-process btcwallet using Neutrino compact block filters. No external
+node required, but initial sync downloads block/filter headers.
+
+```bash
+darepod \
+  --network=signet \
+  --wallet.type=btcwallet \
+  --wallet.feeurl=https://mempool.space/signet/api/v1/fees/recommended
+```
+
+### `lnd`
+
+Uses an existing lnd node for signing and chain access. The node must be
+reachable over gRPC with a TLS cert and admin macaroon.
+
+```bash
+darepod \
+  --wallet.type=lnd \
+  --lnd.host=localhost:10009 \
+  --lnd.tlspath=~/.lnd/tls.cert \
+  --lnd.macaroonpath=~/.lnd/data/chain/bitcoin/regtest/admin.macaroon
+```
+
+---
+
+## Initial Wallet Setup
+
+After starting the daemon, the wallet must be created and unlocked before
+any operation can proceed.
+
+With a `walletrpc`-enabled build (`make install-walletrpc`):
+
+```bash
+# Create a wallet (prints the seed mnemonic on stderr; write it down!).
+DAREPOD_WALLET_PASSWORD=your_password darepocli create --no-tls
+
+# Unlock the wallet after every restart.
+DAREPOD_WALLET_PASSWORD=your_password darepocli unlock --no-tls
+```
+
+To skip manual unlock entirely, pass `--wallet.password_file=/path/to/file`
+to `darepod` at startup; the daemon will auto-unlock from the file.
+
+Without `walletrpc`, the only supported path is the password-file auto-unlock
+above. The `create` / `unlock` CLI commands are not present in the default
+build. Full password-handling rules:
+[`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md#password-handling).
+
+---
+
+## Verifying the Install
+
+```bash
+# 1. Daemon answers basic status.
+darepocli getinfo --no-tls
+
+# 2. (walletrpc only) wallet verbs work.
+darepocli balance --no-tls
+darepocli activity --no-tls
+
+# VTXO inventory lives under the ark subtree (available in every build).
+darepocli ark vtxos list --no-tls
+
+# 3. Schema dump (useful for tooling and AI agents).
+darepocli schema --no-tls
+```
+
+If you see `daemon was not built with -tags walletrpc` for the wallet
+verbs, your `darepod` binary is the default (untagged) build. Reinstall
+with `make install-walletrpc`.
+
+---
+
+## Updating
+
+Pull the latest source and reinstall the same variant you previously used:
+
+```bash
+git pull --rebase
+make install-walletrpc       # or whichever variant you run
+```
+
+---
+
+## Uninstalling
+
+```bash
+rm "$(go env GOPATH)/bin/darepod"
+rm "$(go env GOPATH)/bin/darepocli"
+# (Optional) wipe daemon state. This destroys the wallet seed!
+# rm -rf ~/.darepod
+```
+
+The wallet seed is stored encrypted under `~/.darepod/<network>/wallet_seed.enc`.
+Deleting `~/.darepod` is irreversible without the recorded mnemonic.
+
+---
+
+## Troubleshooting
+
+| Symptom                                                | Fix                                                                                  |
+|--------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `daemon was not built with -tags walletrpc`            | Reinstall with `make install-walletrpc`.                                             |
+| `connection refused` on `darepocli`                    | Daemon not running, or wrong `--rpcserver` address.                                  |
+| `wallet not ready`                                     | Run `darepocli unlock` (walletrpc), or restart `darepod` with `--wallet.password_file`. |
+| `wallet already exists`                                | Use `darepocli unlock` instead of `create`.                                          |
+| TLS / x509 errors against the daemon                   | Use `--no-tls` on regtest, or pass `--tlscertpath` to `darepocli`.                   |
+| `go: module ... requires go 1.25.5` or similar         | Upgrade to Go 1.25.5+ (see Prerequisites).                                           |
+| `make: command not found` / build fails inside Docker  | The `lint` and `rpc` targets need Docker; the `*-local` variants do not.             |
+
+Deeper troubleshooting (per-flag and per-backend) is in
+[`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md#troubleshooting).
+
+---
+
+## Next Steps
+
+- **Run the daemon:** [`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md)
+- **Build-tag deep dive:** [`docs/walletrpc_build.md`](docs/walletrpc_build.md)
+- **Embed the daemon in a host app:** [`docs/walletdk_integration.md`](docs/walletdk_integration.md)
+- **Codebase map:** [`ARCHITECTURE.md`](ARCHITECTURE.md)
+- **Contribute:** style guide and pre-commit checklist in
+  [`docs/development_guidelines.md`](docs/development_guidelines.md) and
+  [`docs/testing-guide.md`](docs/testing-guide.md).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,226 @@
 # darepo-client
+
+`darepo-client` is the reference [Ark protocol](https://arkdev.info/) client
+implementation in Go. It ships a long-running daemon (`darepod`) and a
+companion CLI (`darepocli`) that together let a Bitcoin user board into Ark
+rounds, hold and transfer VTXOs, swap into and out of the Lightning Network,
+and unilaterally exit to the chain at any time.
+
+The daemon is a self-contained, restart-safe process that talks to an Ark
+operator over a durable mailbox transport, manages its own on-chain wallet,
+and exposes a typed gRPC + REST API for host applications.
+
+---
+
+## Highlights
+
+- **Self-contained daemon.** One binary, embedded wallet, durable state.
+  Crash-safe across restarts via durable actor mailboxes.
+- **Three wallet backends.**
+  - `lwwallet`: in-process btcwallet + Esplora REST (no external node).
+  - `btcwallet`: in-process btcwallet + Neutrino (compact block filters).
+  - `lnd`: uses an existing lnd node for signing and chain access.
+- **Full Ark client surface.** Boarding, in-round transfers, out-of-round
+  transfers, refresh, cooperative leave, and unilateral exit.
+- **Lightning swaps.** Optional swap subsystem (`swapruntime`) provides
+  Lightning-to-Ark and Ark-to-Lightning atomic swaps with a durable FSM.
+- **Wallet RPC facade.** Optional flat, swap-vocabulary-free wallet API
+  (`walletrpc`) exposes seven core verbs: `create`, `unlock`, `send`,
+  `recv`, `activity`, `balance`, `exit`.
+- **Host-app SDK.** `sdk/ark`, `sdk/swaps`, and `sdk/walletdk` embed the
+  daemon in-process and expose typed Go APIs over a private transport.
+- **gRPC + REST.** Every RPC is reachable over gRPC or via grpc-gateway HTTP.
+- **MCP integration.** `darepocli mcp serve` exposes the daemon to AI agents
+  as typed tool calls.
+
+---
+
+## Quick Start
+
+```bash
+# Clone, build, and install darepod + darepocli with the wallet RPC surface
+# enabled (recommended; gives you the top-level wallet verbs).
+git clone https://github.com/lightninglabs/darepo-client.git
+cd darepo-client
+make install-walletrpc
+
+# Start the daemon against a local regtest Ark operator + Esplora. The local
+# and remote mailbox IDs are derived from the client and operator pubkeys, so
+# there are no mailbox-id flags to set.
+darepod \
+  --network=regtest \
+  --wallet.type=lwwallet \
+  --wallet.esploraurl=http://localhost:3000 \
+  --wallet.password_file=/path/to/password_file \
+  --server.host=localhost:10010 \
+  --server.insecure \
+  --rpc.listenaddr=localhost:10029
+
+# In another shell: create the wallet, get a boarding address, board.
+darepocli create --no-tls
+darepocli recv   --onchain --no-tls
+darepocli balance --no-tls
+darepocli ark board --no-tls
+```
+
+For a full end-to-end regtest walkthrough (with `nigiri` and a funded
+boarding UTXO), see [`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md).
+
+Detailed installation instructions (prerequisites, build variants, backend
+requirements, troubleshooting) live in [`INSTALL.md`](INSTALL.md).
+
+---
+
+## Build Variants
+
+`darepod` is intentionally modular. The default build is minimal; optional
+subsystems are gated behind build tags so hosts that do not need them pay
+nothing in binary size or surface area.
+
+| Target                     | Build tags                  | What it adds                                              |
+|----------------------------|-----------------------------|-----------------------------------------------------------|
+| `make build`               | _(none)_                    | Core Ark client. Power-user `ark *` and `dev *` CLI only. |
+| `make build-swapruntime`   | `swapruntime`               | + Lightning swap subsystem (`sdk/swaps`, swap CLI).       |
+| `make build-walletrpc`     | `walletrpc swapruntime`     | + Wallet RPC subserver and top-level wallet verbs.        |
+| `make install`             | _(none)_                    | Installs the core build to `$GOPATH/bin`.                 |
+| `make install-swapruntime` | `swapruntime`               | Installs the swap-enabled build.                          |
+| `make install-walletrpc`   | `walletrpc swapruntime`     | Installs the full walletrpc-enabled build (recommended).  |
+
+The `walletrpc` build is a strict superset of `swapruntime`. Most users
+want `make install-walletrpc`.
+
+See [`docs/walletrpc_build.md`](docs/walletrpc_build.md) for the full
+matrix, what each tag enables, and what the CLI surface looks like in each
+mode.
+
+---
+
+## CLI at a Glance
+
+```
+darepocli
+├── getinfo                   daemon status                          (all builds)
+├── balance / recv / send     unified wallet verbs                   (walletrpc)
+├── create / unlock           wallet bring-up                        (walletrpc)
+├── activity                  unified wallet activity history        (walletrpc)
+├── exit [status]             unilateral exit a VTXO                 (all builds)
+├── mcp serve                 MCP server for AI agents               (walletrpc)
+├── schema                    JSON dump of all CLI methods           (all builds)
+├── ark ...                   power-user Ark RPCs                    (all builds)
+│   ├── board                 board confirmed boarding UTXOs
+│   ├── vtxos {list|refresh|leave}
+│   ├── oor   {receive|get|list}
+│   ├── send  {oor|inround}
+│   ├── rounds {get|list|watch|join}
+│   ├── sweep [list]
+│   ├── fees   {estimate|history}
+│   └── listtransactions
+├── swap {list|show|receive|pay|resume|watch}                        (swapruntime)
+├── recovery {list|status|escalate|cancel}                           (swapruntime)
+└── dev <service> <Method>    raw gRPC, e.g. dev daemon GetBalance   (all builds)
+```
+
+Full CLI reference: [`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md).
+
+---
+
+## Configuration
+
+All daemon flags can also be set in `~/.darepod/darepod.conf` or via
+environment variables (`DAREPOD_*`). The canonical sample is
+[`sample-darepod.conf`](sample-darepod.conf), and the full flag reference
+is in [`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md#daemon-flags-reference).
+
+Common knobs:
+
+| Flag                       | Default            | Purpose                                  |
+|----------------------------|--------------------|------------------------------------------|
+| `--datadir`                | `~/.darepod`       | Root data directory.                     |
+| `--network`                | `mainnet`          | `mainnet`, `testnet`, `signet`, `regtest`, `simnet`. |
+| `--wallet.type`            | `lwwallet`         | `lwwallet`, `btcwallet`, or `lnd`.       |
+| `--wallet.esploraurl`      |                    | Esplora REST URL (`lwwallet`).           |
+| `--lnd.host`               | `localhost:10009`  | lnd gRPC (`lnd` backend).                |
+| `--server.host`            | `localhost:10010`  | Ark operator mailbox address.            |
+| `--rpc.listenaddr`         | `localhost:10029`  | Daemon gRPC listen address.              |
+
+---
+
+## Architecture
+
+```
+darepod (orchestrator)
+├── round       Ark round participation FSM
+├── vtxo        VTXO lifecycle FSM
+├── oor         Out-of-round transfer coordination
+├── wallet      Boarding wallet actor
+├── ledger      Double-entry fee accounting
+├── unroll      Per-target unilateral-exit actor
+├── txconfirm   Broadcast + CPFP + confirmation actor
+├── serverconn  Durable mailbox transport to the operator
+├── chainsource Pluggable chain backend (lnd | lwwallet | btcwbackend)
+└── db          SQLite or PostgreSQL persistence
+```
+
+The full system map, dependency graph, key types, and FSM diagrams live in
+[`ARCHITECTURE.md`](ARCHITECTURE.md). Each major package additionally has its
+own `CLAUDE.md` / `AGENTS.md` with package-local context.
+
+---
+
+## Documentation
+
+| Topic                            | Document                                                              |
+|----------------------------------|-----------------------------------------------------------------------|
+| System architecture              | [`ARCHITECTURE.md`](ARCHITECTURE.md)                                  |
+| Install, configure, operate      | [`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md)                |
+| Build-tag matrix                 | [`docs/walletrpc_build.md`](docs/walletrpc_build.md)                  |
+| Durable actor pattern            | [`docs/durable_actor_architecture.md`](docs/durable_actor_architecture.md) |
+| Mailbox transport                | [`docs/mailbox_architecture.md`](docs/mailbox_architecture.md)        |
+| SDK layering                     | [`docs/sdk_layered_architecture.md`](docs/sdk_layered_architecture.md)|
+| Wallet SDK (`sdk/walletdk`)      | [`docs/walletdk_integration.md`](docs/walletdk_integration.md)        |
+| Fee ledger                       | [`docs/fee_ledger.md`](docs/fee_ledger.md)                            |
+| arkscript spec                   | [`docs/arkscript_spec.md`](docs/arkscript_spec.md)                    |
+| Full doc index                   | [`docs/index.md`](docs/index.md)                                      |
+
+---
+
+## Development
+
+Prerequisites and build setup: [`INSTALL.md`](INSTALL.md).
+
+Common workflows:
+
+```bash
+make fmt-changed              # format changed Go files (goimports + llformat)
+make lint-changed-local       # fast local linter against origin/main
+make unit                     # run all unit tests
+make unit pkg=round case=TestFoo
+make systest                  # system integration tests (sqlite)
+make systest db=postgres      # system integration tests (postgres)
+make rpc                      # regenerate protobuf stubs
+make sqlc                     # regenerate type-safe DB queries
+make help                     # list every make target
+```
+
+Style guide, commit format, generated-code rules, and the pre-commit
+checklist are documented in:
+
+- [`docs/development_guidelines.md`](docs/development_guidelines.md)
+- [`docs/testing-guide.md`](docs/testing-guide.md)
+- [`docs/commit-tooling.md`](docs/commit-tooling.md)
+- [`CLAUDE.md`](CLAUDE.md): quick map for agent-assisted development.
+
+---
+
+## Project Status
+
+`darepo-client` is under active development. Mainnet operation requires the
+explicit `--allow-mainnet` flag; the default network is treated as a safety
+guard. RPC surfaces, on-disk schema, and CLI commands may still change
+across minor versions.
+
+## License
+
+A `LICENSE` file has not yet been published in this repository. Until one is
+added, treat the code as all-rights-reserved and contact the maintainers
+before redistributing.


### PR DESCRIPTION
In this PR, we replace the one-line placeholder `README.md` with a
proper top-level overview of darepo-client, and add a dedicated
`INSTALL.md` to give new users (and host-app integrators) a clean
on-ramp from clone to running daemon.

The README's job here is to be a map, not a manual. It names the
project for what it is (the reference Ark protocol client daemon plus
CLI), enumerates what `darepod` and `darepocli` actually do, gives a
copy-pasteable quick start that lands on `make install-walletrpc` as
the recommended install command, and then hands off to the existing
canonical docs (`docs/daemon_cli_guide.md`, `docs/walletrpc_build.md`,
`ARCHITECTURE.md`) for everything deeper. We deliberately don't
duplicate content from those docs, so the README stays accurate as
they evolve.

`INSTALL.md` is the other half. It walks through Go/toolchain
prerequisites, the full build-tag variant matrix (`build` vs
`build-swapruntime` vs `build-walletrpc`), backend-specific setup for
`lwwallet` / `btcwallet` / `lnd`, initial wallet bring-up, how to
verify the install actually picked up the `walletrpc` tag, plus a
small troubleshooting table for the failure modes that show up most
often (the classic `daemon was not built with -tags walletrpc`, TLS
errors on regtest, etc, etc). The recommended path stays the same
throughout: `make install-walletrpc`.

## Commits

- `docs: flesh out top-level README` — README rewrite.
- `docs: add INSTALL.md` — new install guide.

See each commit message for a bit more context.

## Test plan

- [x] `make commitmsg-lint range="origin/main..HEAD"` passes.
- [ ] Skim both files rendered on GitHub to confirm the cross-links
      resolve (relative links to `docs/`, `ARCHITECTURE.md`,
      `sample-darepod.conf`, `CLAUDE.md`).
- [ ] Confirm there's nothing in here that contradicts
      `docs/daemon_cli_guide.md` or `docs/walletrpc_build.md` (they
      stay authoritative).