### PR TITLE
cmd: Confirm wallet password on create

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_create.go
+++ b/cmd/darepocli/darepoclicommands/cmd_create.go
@@ -56,13 +56,13 @@ func walletCreate(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	defer zeroBytes(seedPassphrase)
 
 	password, err := readPasswordConfirmed(cmd)
 	if err != nil {
 		return err
 	}
 	defer zeroBytes(password)
-	defer zeroBytes(seedPassphrase)
 
 	printJSON, _ := cmd.Flags().GetBool("print-mnemonic-json")
 

--- a/cmd/darepocli/darepoclicommands/cmd_create.go
+++ b/cmd/darepocli/darepoclicommands/cmd_create.go
@@ -25,7 +25,8 @@ func newCreateCmd() *cobra.Command {
 			"The wallet password is read from stdin / " +
 			"DAREPOD_WALLET_PASSWORD env / " +
 			"--wallet_password_file (never CLI args). The " +
-			"optional seed passphrase is read from " +
+			"interactive password prompt asks for confirmation. " +
+			"The optional seed passphrase is read from " +
 			"DAREPOD_SEED_PASSPHRASE env / " +
 			"--seed_passphrase_file. The mnemonic is shown " +
 			"on stderr ONCE and is NOT included in the JSON " +
@@ -56,7 +57,7 @@ func walletCreate(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	password, err := readPassword(cmd)
+	password, err := readPasswordConfirmed(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/darepocli/darepoclicommands/wallet_password.go
+++ b/cmd/darepocli/darepoclicommands/wallet_password.go
@@ -2,6 +2,7 @@ package darepoclicommands
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +13,10 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
+
+// errPasswordConfirmationMismatch is returned when the create-wallet
+// password confirmation does not match the first interactive entry.
+var errPasswordConfirmationMismatch = errors.New("passwords do not match")
 
 // zeroBytes overwrites every byte of b with zero. Best-effort
 // scrubbing of cryptographic material before it falls out of scope —
@@ -56,6 +61,22 @@ func readSeedPassphrase(cmd *cobra.Command) ([]byte, error) {
 // so that automated environments (such as the darepotest REPL) can set
 // it without stdin races. The CLI never accepts passwords via argv.
 func readPassword(cmd *cobra.Command) ([]byte, error) {
+	return readWalletPassword(cmd, false)
+}
+
+// readPasswordConfirmed reads the wallet password with interactive
+// confirmation. Non-interactive sources (env, file, stdin pipe) stay
+// single-read so automated callers can continue to provide exactly one
+// secret.
+func readPasswordConfirmed(cmd *cobra.Command) ([]byte, error) {
+	return readWalletPassword(cmd, true)
+}
+
+// readWalletPassword reads the wallet password from one of the supported
+// sources, optionally confirming only the interactive prompt path.
+func readWalletPassword(cmd *cobra.Command,
+	confirmInteractive bool) ([]byte, error) {
+
 	// Check environment variable first — takes priority so that
 	// callers with piped stdin (e.g. REPL, CI) can override without
 	// fighting over stdin.
@@ -92,9 +113,19 @@ func readPassword(cmd *cobra.Command) ([]byte, error) {
 		return nil, fmt.Errorf("unable to read password from stdin")
 	}
 
-	// Interactive prompt (TTY).
-	fmt.Fprint(os.Stderr, "Enter wallet password: ")
+	if confirmInteractive {
+		return readConfirmedPassword(readInteractivePassword)
+	}
 
+	return readInteractivePassword("Enter wallet password: ")
+}
+
+// readInteractivePassword reads one password from the controlling TTY
+// using the supplied prompt.
+func readInteractivePassword(prompt string) ([]byte, error) {
+	fmt.Fprint(os.Stderr, prompt)
+
+	// Interactive prompt (TTY).
 	fd := int(os.Stdin.Fd())
 	oldState, err := term.MakeRaw(fd)
 	if err != nil {
@@ -120,6 +151,31 @@ func readPassword(cmd *cobra.Command) ([]byte, error) {
 	if printErr != nil {
 		return nil, fmt.Errorf("unable to finalize password prompt: %w",
 			printErr)
+	}
+
+	return password, nil
+}
+
+// readConfirmedPassword reads the password twice and rejects mismatches
+// before the daemon sees the secret.
+func readConfirmedPassword(read func(string) ([]byte, error)) ([]byte, error) {
+	password, err := read("Enter wallet password: ")
+	if err != nil {
+		return nil, err
+	}
+
+	confirmation, err := read("Confirm wallet password: ")
+	if err != nil {
+		zeroBytes(password)
+
+		return nil, err
+	}
+	defer zeroBytes(confirmation)
+
+	if !bytes.Equal(password, confirmation) {
+		zeroBytes(password)
+
+		return nil, errPasswordConfirmationMismatch
 	}
 
 	return password, nil

--- a/cmd/darepocli/darepoclicommands/wallet_password_test.go
+++ b/cmd/darepocli/darepoclicommands/wallet_password_test.go
@@ -102,6 +102,85 @@ func TestReadMaskedPasswordCtrlDEmpty(t *testing.T) {
 	require.ErrorContains(t, err, "unable to read password")
 }
 
+// TestReadConfirmedPasswordAcceptsMatch confirms the interactive
+// confirmation flow returns the first password when both entries match.
+func TestReadConfirmedPasswordAcceptsMatch(t *testing.T) {
+	t.Parallel()
+
+	var prompts []string
+	values := [][]byte{
+		[]byte("secret"),
+		[]byte("secret"),
+	}
+	password, err := readConfirmedPassword(
+		func(prompt string) ([]byte, error) {
+			prompts = append(prompts, prompt)
+			value := values[0]
+			values = values[1:]
+
+			return value, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secret"), password)
+	require.Equal(
+		t, []string{
+			"Enter wallet password: ",
+			"Confirm wallet password: ",
+		}, prompts,
+	)
+}
+
+// TestReadConfirmedPasswordRejectsMismatch confirms a mistyped
+// confirmation fails locally and scrubs both entered secrets.
+func TestReadConfirmedPasswordRejectsMismatch(t *testing.T) {
+	t.Parallel()
+
+	passwordBytes := []byte("secret")
+	confirmationBytes := []byte("secrex")
+	values := [][]byte{
+		passwordBytes,
+		confirmationBytes,
+	}
+
+	password, err := readConfirmedPassword(
+		func(_ string) ([]byte, error) {
+			value := values[0]
+			values = values[1:]
+
+			return value, nil
+		},
+	)
+	require.Nil(t, password)
+	require.ErrorIs(t, err, errPasswordConfirmationMismatch)
+	require.Equal(t, []byte{0, 0, 0, 0, 0, 0}, passwordBytes)
+	require.Equal(t, []byte{0, 0, 0, 0, 0, 0}, confirmationBytes)
+}
+
+// TestReadConfirmedPasswordZerosOnConfirmError confirms the first
+// password entry is scrubbed if the confirmation prompt fails.
+func TestReadConfirmedPasswordZerosOnConfirmError(t *testing.T) {
+	t.Parallel()
+
+	passwordBytes := []byte("secret")
+	confirmErr := errors.New("confirmation failed")
+	reads := 0
+
+	password, err := readConfirmedPassword(
+		func(_ string) ([]byte, error) {
+			reads++
+			if reads == 1 {
+				return passwordBytes, nil
+			}
+
+			return nil, confirmErr
+		},
+	)
+	require.Nil(t, password)
+	require.ErrorIs(t, err, confirmErr)
+	require.Equal(t, []byte{0, 0, 0, 0, 0, 0}, passwordBytes)
+}
+
 // TestReadMaskedPasswordWrapsReadError confirms an underlying read
 // error is wrapped (not swallowed) and surfaces with the
 // "unable to read password" prefix.


### PR DESCRIPTION
Prompt twice when darepocli create reads the wallet password from an interactive terminal. This prevents a typo from silently initializing a wallet with an unintended password.

Keep environment, password-file, and piped-stdin inputs single-read so scripted setup remains non-interactive.