### PR TITLE
swapwallet: hide receive claim OOR rows by output

### DIFF
--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -467,6 +467,7 @@ func internalOORLedgerEntries(rows []*daemonrpc.TransactionHistoryEntry,
 	receiveRowsBySession := make(
 		map[string][]*daemonrpc.TransactionHistoryEntry,
 	)
+	var claimOutputSessions map[string]struct{}
 	for _, row := range rows {
 		session, ok := oorReceiveSessionID(row)
 		if !ok {
@@ -477,6 +478,13 @@ func internalOORLedgerEntries(rows []*daemonrpc.TransactionHistoryEntry,
 		receiveRowsBySession[session] = append(
 			receiveRowsBySession[session], row,
 		)
+
+		if receiveMatchesClaimOutput(row, correlations.claimSessions) {
+			if claimOutputSessions == nil {
+				claimOutputSessions = make(map[string]struct{})
+			}
+			claimOutputSessions[session] = struct{}{}
+		}
 	}
 
 	hidden := make(map[int64]struct{})
@@ -497,7 +505,7 @@ func internalOORLedgerEntries(rows []*daemonrpc.TransactionHistoryEntry,
 
 		switch delta := row.GetAmountSat() - received; {
 		case delta == 0 && internalZeroDeltaSession(
-			correlations, session,
+			correlations, claimOutputSessions, session,
 		):
 
 			hidden[row.GetEntryId()] = struct{}{}
@@ -519,10 +527,35 @@ func internalOORLedgerEntries(rows []*daemonrpc.TransactionHistoryEntry,
 // send+receive pair belongs to a swap-internal claim or refund. Those rows
 // are already represented by the swap entry itself.
 func internalZeroDeltaSession(correlations swapOORCorrelations,
-	session string) bool {
+	claimOutputSessions map[string]struct{}, session string) bool {
 
 	return sessionInSet(correlations.claimSessions, session) ||
-		sessionInSet(correlations.refundSessions, session)
+		sessionInSet(correlations.refundSessions, session) ||
+		sessionInSet(claimOutputSessions, session)
+}
+
+// receiveMatchesClaimOutput reports whether an OOR receive row materialized
+// the output produced by a receive-swap claim. Some ledgers record the OOR
+// session id separately from the materialized output txid, while the swap
+// summary stores the claim id as the output txid. Matching both keeps the
+// internal send leg hidden in either shape.
+func receiveMatchesClaimOutput(row *daemonrpc.TransactionHistoryEntry,
+	claimSessions map[string]struct{}) bool {
+
+	if len(claimSessions) == 0 {
+		return false
+	}
+
+	if row == nil {
+		return false
+	}
+
+	txid := strings.ToLower(row.GetTxid())
+	if txid == "" {
+		return false
+	}
+
+	return sessionInSet(claimSessions, txid)
 }
 
 // sessionInSet reports whether a normalized OOR session id appears in set.

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -54,6 +54,59 @@ func testSessionString(t *testing.T, raw []byte) string {
 	return hash.String()
 }
 
+// setReceiveClaimByOutputTxidFixture wires the receive-claim shape where the
+// ledger OOR session differs from the materialized claim output txid.
+func setReceiveClaimByOutputTxidFixture(t *testing.T, swap *fakeSwapService,
+	rpc *fakeRPCServer) {
+
+	t.Helper()
+
+	oorSession := testBytes(32, 0x19)
+	claimSession := testBytes(32, 0x29)
+	claimHex := testSessionString(t, claimSession)
+
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{
+		Swaps: []*swapclientrpc.SwapSummary{
+			{
+				PaymentHash: "receive-payment",
+				Direction: swapclientrpc.
+					SwapDirection_SWAP_DIRECTION_RECEIVE,
+				State: swapclientrpc.
+					SwapState_SWAP_STATE_COMPLETED,
+				AmountSat:      5_000,
+				UpdatedAtUnix:  200,
+				ClaimSessionId: claimHex,
+			},
+		},
+	}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:           "oor",
+				Subtype:        ledger.EventVTXOSent,
+				AmountSat:      5_000,
+				DebitAccount:   ledger.AccountTransfersOut,
+				CreditAccount:  ledger.AccountVTXOBalance,
+				SessionId:      oorSession,
+				EntryId:        13,
+				CreatedAtUnixS: 100,
+			},
+			{
+				Type:           "oor",
+				Subtype:        ledger.EventVTXOReceived,
+				AmountSat:      5_000,
+				DebitAccount:   ledger.AccountVTXOBalance,
+				CreditAccount:  ledger.AccountTransfersIn,
+				SessionId:      oorSession,
+				Txid:           claimHex,
+				OutputIndex:    0,
+				EntryId:        14,
+				CreatedAtUnixS: 101,
+			},
+		},
+	}
+}
+
 // TestHistoryListMergesSwapAndLedgerSources confirms the merger combines
 // rows from both backends and normalizes them into the flat WalletEntry
 // shape.
@@ -276,6 +329,53 @@ func TestHistoryHidesReceiveClaimOORSend(t *testing.T) {
 	require.Equal(
 		t, walletrpc.EntryKind_ENTRY_KIND_RECV, entries[0].GetKind(),
 	)
+}
+
+// TestHistoryPendingFilterHidesReceiveClaimByOutputTxid confirms --pending
+// hides completed receive-swap OOR rows even when the ledger OOR session id is
+// different from the materialized claim output txid stored in the swap summary.
+func TestHistoryPendingFilterHidesReceiveClaimByOutputTxid(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	setReceiveClaimByOutputTxidFixture(t, swap, rpc)
+
+	resp, err := h.List(t.Context(), &walletrpc.ListRequest{
+		PendingOnly: true,
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.GetActivity().GetEntries())
+	require.False(
+		t, swap.listSwapsLast.GetPendingOnly(),
+		"history must fetch all swaps so terminal receive swaps "+
+			"can hide their internal OOR ledger legs before "+
+			"--pending filters the visible rows",
+	)
+}
+
+// TestHistoryHidesReceiveClaimByOutputTxid confirms normal activity shows the
+// receive swap while hiding its internal OOR rows when the OOR session differs
+// from the materialized claim output txid.
+func TestHistoryHidesReceiveClaimByOutputTxid(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	setReceiveClaimByOutputTxidFixture(t, swap, rpc)
+
+	resp, err := h.List(t.Context(), &walletrpc.ListRequest{})
+	require.NoError(t, err)
+
+	entries := resp.GetActivity().GetEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, "receive-payment", entries[0].GetId())
+	require.Equal(
+		t, walletrpc.EntryKind_ENTRY_KIND_RECV, entries[0].GetKind(),
+	)
+	require.Equal(
+		t, walletrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		entries[0].GetStatus(),
+	)
+	require.Equal(t, int64(5_000), entries[0].GetAmountSat())
 }
 
 // TestHistoryKeepsUnpairedOORSend confirms ordinary OOR sends remain visible


### PR DESCRIPTION
## Problem

Issue #572 reports that a completed Lightning receive can still leave an internal OOR send row visible in `darepocli --no-tls activity --pending`.

PR #550 fixed the first half of this class of bug by making pending activity fetch all swap summaries before hiding internal OOR rows. The remaining issue is that some receive-claim ledger rows use one value for the OOR `session_id`, while the completed receive swap stores the claim id as the materialized receive row `txid`.

In that shape, the wallet sees a balanced OOR send/receive pair, but does not recognize the OOR session as belonging to the completed receive swap, so the outgoing internal send leg can leak as pending activity.

Fixes #572.

## Fix

- Track OOR sessions whose receive row `txid` matches a receive swap `claim_session_id`.
- Treat those sessions as internal zero-delta claim sessions when hiding paired OOR rows.
- Avoid allocating the claim-output session map unless the edge case is actually present.
- Add regression coverage for both normal activity and `--pending`: completed receive swap, different ledger OOR `session_id`, and materialized claim output `txid` matching the swap `claim_session_id`.

## Tests

- `go test -tags='dev walletrpc swapruntime nolog' ./swapwallet -run 'TestHistory(PendingFilterHidesReceiveClaimByOutputTxid|HidesReceiveClaimByOutputTxid|HidesReceiveClaimOORSend|PendingFilterKeepsTerminalSwapCorrelations)' -count=1 -timeout=5m`
- `go test -tags='dev walletrpc swapruntime nolog' ./sdk/swaps ./swapwallet -count=1 -timeout=5m`
- `make fmt-changed-check base=origin/main`
- `make lint-changed-local`
- `make commitmsg-lint range=origin/main..HEAD`