### PR TITLE
swaps: harden immediate refund follow-ups

### DIFF
--- a/darepod/rpc_oor_custom_input_test.go
+++ b/darepod/rpc_oor_custom_input_test.go
@@ -1,0 +1,264 @@
+package darepod
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type customOORRPCFixture struct {
+	rpcServer  *RPCServer
+	customIn   *daemonrpc.CustomOORInput
+	recipient  *daemonrpc.Output
+	claimPath  *arkscript.SpendPath
+	clientPriv *btcec.PrivateKey
+	outpoint   wire.OutPoint
+}
+
+func newCustomOORRPCFixture(t *testing.T) *customOORRPCFixture {
+	t.Helper()
+
+	policy, preimage, _, receiverPriv, serverPriv :=
+		testVHTLCPolicyFixture(t)
+	policyTemplate, err := policy.Template.Encode()
+	require.NoError(t, err)
+
+	pkScript, err := policy.PkScript()
+	require.NoError(t, err)
+
+	claimPath, err := policy.ClaimPath(preimage)
+	require.NoError(t, err)
+
+	spendPath, err := claimPath.Encode()
+	require.NoError(t, err)
+
+	ready := make(chan struct{})
+	close(ready)
+
+	serverPubkey := serverPriv.PubKey().SerializeCompressed()
+	svc := &fakeArkService{
+		getInfoResponse: &arkrpc.GetInfoResponse{
+			Pubkey:        serverPubkey,
+			VtxoExitDelay: 144,
+			DustLimit:     1,
+		},
+	}
+
+	server := &Server{
+		cfg: &Config{
+			Wallet: &WalletConfig{
+				Type: WalletTypeLwwallet,
+			},
+		},
+		walletReady: ready,
+		vtxoStore:   &db.VTXOPersistenceStore{},
+		clientKeyDesc: keychain.KeyDescriptor{
+			PubKey: receiverPriv.PubKey(),
+			KeyLocator: keychain.KeyLocator{
+				Family: 1,
+				Index:  2,
+			},
+		},
+		chainParams: &chaincfg.RegressionNetParams,
+		arkClient: arkrpc.NewArkServiceClient(
+			newBufconnClient(t, svc),
+		),
+	}
+
+	outpoint := testWalletOpsOutpoint(6)
+
+	return &customOORRPCFixture{
+		rpcServer: &RPCServer{
+			server:           server,
+			customInputLocks: make(map[wire.OutPoint]struct{}),
+		},
+		customIn: &daemonrpc.CustomOORInput{
+			Outpoint:           outpoint.String(),
+			VtxoPolicyTemplate: policyTemplate,
+			SpendPath:          spendPath,
+			AmountSat:          42_000,
+			PkScript:           pkScript,
+		},
+		recipient: &daemonrpc.Output{
+			AmountSat: 42_000,
+			Destination: &daemonrpc.Output_Pubkey{
+				Pubkey: receiverPriv.PubKey().X().Bytes(),
+			},
+		},
+		claimPath:  claimPath,
+		clientPriv: receiverPriv,
+		outpoint:   outpoint,
+	}
+}
+
+// TestPrepareOORCustomInputMapsPreparedInput exercises the daemon-level
+// PrepareOOR RPC for an externally described custom input rather than the SDK
+// mock seam. A cooperative refund first asks the daemon to build the exact OOR
+// checkpoint that the server will authorize, so the response must map the
+// selected custom input back to its outpoint, return the matching checkpoint
+// PSBT bytes, expose the custom witness script, and preserve the signing key
+// list required for final witness assembly.
+func TestPrepareOORCustomInputMapsPreparedInput(t *testing.T) {
+	t.Parallel()
+
+	fixture := newCustomOORRPCFixture(t)
+
+	resp, err := fixture.rpcServer.PrepareOOR(
+		t.Context(), &daemonrpc.PrepareOORRequest{
+			Recipient: fixture.recipient,
+			CustomInputs: []*daemonrpc.CustomOORInput{
+				fixture.customIn,
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.GetSessionId())
+	require.NotEmpty(t, resp.GetArkPsbt())
+	require.Len(t, resp.GetCheckpointPsbts(), 1)
+	require.Len(t, resp.GetCustomInputs(), 1)
+
+	arkPacket, err := psbtutil.Parse(resp.GetArkPsbt())
+	require.NoError(t, err)
+	require.Len(t, arkPacket.UnsignedTx.TxIn, 1)
+	require.Len(t, arkPacket.UnsignedTx.TxOut, 2)
+
+	prepared := resp.GetCustomInputs()[0]
+	require.Equal(t, fixture.outpoint.String(), prepared.GetOutpoint())
+	require.Equal(
+		t, resp.GetCheckpointPsbts()[0], prepared.GetCheckpointPsbt(),
+	)
+	require.Equal(
+		t, fixture.claimPath.SpendInfo.WitnessScript,
+		prepared.GetWitnessScript(),
+	)
+	wantKey := schnorr.SerializePubKey(fixture.clientPriv.PubKey())
+	gotKeys := xOnlyPubkeys(t, prepared.GetSigningPubkeys())
+	require.Contains(t, gotKeys, wantKey)
+}
+
+// TestSignOORCustomInputMapsSignatureAndErrorCodes exercises the daemon-level
+// SignOORCustomInput RPC using a real checkpoint PSBT produced by PrepareOOR.
+// The happy path verifies the RPC response preserves the signer pubkey, witness
+// script, signature bytes, and sighash fields. The negative subcases pin the
+// wire contract for malformed caller data: invalid PSBT bytes are caller
+// InvalidArgument, while a wallet signing failure is Internal because the
+// request passed structural validation and failed inside the daemon signer.
+func TestSignOORCustomInputMapsSignatureAndErrorCodes(t *testing.T) {
+	t.Parallel()
+
+	fixture := newCustomOORRPCFixture(t)
+	prepared, err := fixture.rpcServer.PrepareOOR(
+		t.Context(), &daemonrpc.PrepareOORRequest{
+			Recipient: fixture.recipient,
+			CustomInputs: []*daemonrpc.CustomOORInput{
+				fixture.customIn,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	checkpoint := prepared.GetCustomInputs()[0].GetCheckpointPsbt()
+	wantScript := fixture.claimPath.SpendInfo.WitnessScript
+
+	sig, err := schnorr.Sign(
+		fixture.clientPriv,
+		bytes.Repeat(
+			[]byte{0x01}, 32,
+		),
+	)
+	require.NoError(t, err)
+
+	signer := &input.MockInputSigner{}
+	signer.On(
+		"SignOutputRaw", mock.Anything,
+		mock.MatchedBy(func(desc *input.SignDescriptor) bool {
+			signMethod := input.TaprootScriptSpendSignMethod
+			if desc.SignMethod != signMethod {
+				return false
+			}
+
+			return bytes.Equal(desc.WitnessScript, wantScript)
+		}),
+	).Return(sig, nil).Once()
+	fixture.rpcServer.oorSignerOverride = signer
+
+	resp, err := fixture.rpcServer.SignOORCustomInput(
+		t.Context(), &daemonrpc.SignOORCustomInputRequest{
+			CustomInput:    fixture.customIn,
+			CheckpointPsbt: checkpoint,
+		},
+	)
+	require.NoError(t, err)
+	signer.AssertExpectations(t)
+
+	require.Equal(
+		t, fixture.clientPriv.PubKey().SerializeCompressed(),
+		resp.GetSignature().GetPubkey(),
+	)
+	require.Equal(
+		t, wantScript, resp.GetSignature().GetWitnessScript(),
+	)
+	require.Equal(t, sig.Serialize(), resp.GetSignature().GetSignature())
+	require.EqualValues(
+		t, txscript.SigHashDefault, resp.GetSignature().GetSighash(),
+	)
+
+	_, err = fixture.rpcServer.SignOORCustomInput(
+		t.Context(), &daemonrpc.SignOORCustomInputRequest{
+			CustomInput:    fixture.customIn,
+			CheckpointPsbt: []byte("not a psbt"),
+		},
+	)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	signErr := &input.MockInputSigner{}
+	signErr.On(
+		"SignOutputRaw", mock.Anything, mock.Anything,
+	).Return(nil, assertErr("signer unavailable")).Once()
+	fixture.rpcServer.oorSignerOverride = signErr
+
+	_, err = fixture.rpcServer.SignOORCustomInput(
+		t.Context(), &daemonrpc.SignOORCustomInputRequest{
+			CustomInput:    fixture.customIn,
+			CheckpointPsbt: checkpoint,
+		},
+	)
+	require.Equal(t, codes.Internal, status.Code(err))
+	signErr.AssertExpectations(t)
+}
+
+type assertErr string
+
+func (e assertErr) Error() string {
+	return string(e)
+}
+
+func xOnlyPubkeys(t *testing.T, pubkeys [][]byte) [][]byte {
+	t.Helper()
+
+	xOnly := make([][]byte, 0, len(pubkeys))
+	for _, pubkey := range pubkeys {
+		parsed, err := btcec.ParsePubKey(pubkey)
+		require.NoError(t, err)
+
+		xOnly = append(xOnly, schnorr.SerializePubKey(parsed))
+	}
+
+	return xOnly
+}

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/input"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -83,6 +84,10 @@ type RPCServer struct {
 	// customInputLocks is the set of custom OOR input outpoints
 	// currently reserved by an in-flight SendOOR call.
 	customInputLocks map[wire.OutPoint]struct{}
+
+	// oorSignerOverride lets focused RPC tests exercise custom-input
+	// signing without booting a full wallet backend.
+	oorSignerOverride input.Signer
 }
 
 // NewRPCServer creates a new RPCServer backed by the given Server.
@@ -2255,7 +2260,7 @@ func (r *RPCServer) SignOORCustomInput(ctx context.Context,
 			"custom input, got %d", len(inputs))
 	}
 
-	signer, err := r.server.oorSigner()
+	signer, err := r.oorSigner()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "resolve signer: %v",
 			err)
@@ -2282,6 +2287,15 @@ func (r *RPCServer) SignOORCustomInput(ctx context.Context,
 			Sighash:       uint32(sig.SigHash),
 		},
 	}, nil
+}
+
+// oorSigner returns the wallet signer used for OOR checkpoint inputs.
+func (r *RPCServer) oorSigner() (input.Signer, error) {
+	if r.oorSignerOverride != nil {
+		return r.oorSignerOverride, nil
+	}
+
+	return r.server.oorSigner()
 }
 
 // findOutgoingOORSessionByIdempotencyKey asks the OOR actor whether the daemon

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/stretchr/testify/require"
@@ -235,6 +236,102 @@ func TestDecodeLengthPrefixedBlobListRejectsTrailingBytes(t *testing.T) {
 	raw = append(raw, 0xff)
 	_, err = decodeLengthPrefixedBlobList(raw)
 	require.ErrorContains(t, err, "trailing payload bytes")
+}
+
+// TestExternalSignaturesTLVRoundTrip verifies the durable encoding used for
+// custom-input signatures preserves each signature's signer key, witness
+// script, raw Schnorr signature bytes, and sighash flag. Cooperative refunds
+// rely on these records when a client restarts after obtaining a server
+// signature but before finalizing the custom OOR spend; a field swap or missing
+// sighash would only surface later as an invalid checkpoint witness.
+func TestExternalSignaturesTLVRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	_, key1 := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x01}, 32))
+	_, key2 := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x02}, 32))
+	sigs := []ExternalTaprootScriptSignature{
+		{
+			PubKey: key1,
+			WitnessScript: []byte{
+				0x51,
+				0x20,
+				0x01,
+			},
+			Signature: []byte{
+				0x11,
+				0x12,
+			},
+			SigHash: txscript.SigHashDefault,
+		},
+		{
+			PubKey: key2,
+			WitnessScript: []byte{
+				0x20,
+				0x02,
+				0xac,
+			},
+			Signature: []byte{
+				0x21,
+				0x22,
+				0x23,
+			},
+			SigHash: txscript.SigHashAll,
+		},
+	}
+
+	raw, err := encodeExternalSignatures(sigs)
+	require.NoError(t, err)
+
+	decoded, err := decodeExternalSignatures(raw)
+	require.NoError(t, err)
+	require.Len(t, decoded, len(sigs))
+	for i := range sigs {
+		require.Equal(
+			t, sigs[i].PubKey.SerializeCompressed(),
+			decoded[i].PubKey.SerializeCompressed(),
+		)
+		require.Equal(
+			t, sigs[i].WitnessScript, decoded[i].WitnessScript,
+		)
+		require.Equal(t, sigs[i].Signature, decoded[i].Signature)
+		require.Equal(t, sigs[i].SigHash, decoded[i].SigHash)
+	}
+}
+
+// TestExternalSignaturesTLVRejectsMalformedPayloads pins the defensive decode
+// rules around the external-signature durable blob. The decoder must reject
+// oversize signature lists before allocation, corrupted public keys before they
+// enter signing state, and trailing bytes that could otherwise mask partially
+// parsed data from a future or corrupt format.
+func TestExternalSignaturesTLVRejectsMalformedPayloads(t *testing.T) {
+	t.Parallel()
+
+	tooMany := make(
+		[]ExternalTaprootScriptSignature, maxExternalSignatures+1,
+	)
+	_, err := encodeExternalSignatures(tooMany)
+	require.ErrorContains(t, err, "external signature count")
+
+	var corruptKey bytes.Buffer
+	require.NoError(t, wire.WriteVarInt(&corruptKey, 0, 1))
+	require.NoError(t, wire.WriteVarBytes(&corruptKey, 0, []byte{0x02}))
+	_, err = decodeExternalSignatures(corruptKey.Bytes())
+	require.ErrorContains(t, err, "parse external signature pubkey")
+
+	_, key := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x03}, 32))
+	raw, err := encodeExternalSignatures([]ExternalTaprootScriptSignature{
+		{
+			PubKey:        key,
+			WitnessScript: []byte{0x51},
+			Signature:     []byte{0x01},
+			SigHash:       txscript.SigHashDefault,
+		},
+	})
+	require.NoError(t, err)
+
+	raw = append(raw, 0xff)
+	_, err = decodeExternalSignatures(raw)
+	require.ErrorContains(t, err, "trailing bytes")
 }
 
 // TestDriveEventRequestRoundTripFailEvent asserts DriveEventRequest TLV

--- a/oor/checkpoint_sign_test.go
+++ b/oor/checkpoint_sign_test.go
@@ -6,7 +6,10 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,4 +50,100 @@ func TestAttachExternalTaprootScriptSignaturesRejectsUnexpectedPubKey(
 
 	err := attachExternalTaprootScriptSignatures(input, &psbt.PInput{})
 	require.ErrorContains(t, err, "pubkey is not required")
+}
+
+// TestAssembleCustomFinalWitnessOrdersSignatures locks down the final witness
+// layout for custom-spend checkpoints that use more than two signing keys. The
+// tapscript multisig helper consumes signatures in reverse key order, so a
+// forward-ordered witness would fail script evaluation even if every signature
+// is individually present and valid. The test builds a three-key custom spend,
+// attaches distinct PSBT signature records for each key, assembles the final
+// witness, and verifies the stack is [key3 sig, key2 sig, key1 sig,
+// conditions..., witness script, control block].
+func TestAssembleCustomFinalWitnessOrdersSignatures(t *testing.T) {
+	t.Parallel()
+
+	_, key1 := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x01}, 32))
+	_, key2 := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x02}, 32))
+	_, key3 := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x03}, 32))
+
+	witnessScript := []byte{0x51}
+	controlBlock := []byte{0xc0}
+	conditions := [][]byte{
+		{
+			0xaa,
+		},
+		{
+			0xbb,
+		},
+	}
+	input := &TransferInput{
+		CustomSpend: &arkscript.SpendPath{
+			SpendInfo: &arkscript.SpendInfo{
+				WitnessScript: witnessScript,
+				ControlBlock:  controlBlock,
+			},
+			Conditions: conditions,
+		},
+		CustomSpendKeys: []*btcec.PublicKey{
+			key1,
+			key2,
+			key3,
+		},
+	}
+
+	signatures := [][]byte{
+		{
+			0x11,
+		},
+		{
+			0x22,
+		},
+		{
+			0x33,
+		},
+	}
+	pIn := &psbt.PInput{}
+	for i, key := range input.CustomSpendKeys {
+		err := psbtutil.AddTaprootScriptSpendSig(
+			pIn, key, witnessScript, signatures[i],
+			txscript.SigHashDefault,
+		)
+		require.NoError(t, err)
+	}
+
+	err := assembleCustomFinalWitness(input, pIn)
+	require.NoError(t, err)
+
+	witness := decodeFinalScriptWitness(t, pIn.FinalScriptWitness)
+	require.Equal(t, wire.TxWitness{
+		signatures[2],
+		signatures[1],
+		signatures[0],
+		conditions[0],
+		conditions[1],
+		witnessScript,
+		controlBlock,
+	}, witness)
+}
+
+func decodeFinalScriptWitness(t *testing.T, raw []byte) wire.TxWitness {
+	t.Helper()
+
+	reader := bytes.NewReader(raw)
+	count, err := wire.ReadVarInt(reader, 0)
+	require.NoError(t, err)
+
+	witness := make(wire.TxWitness, count)
+	for i := uint64(0); i < count; i++ {
+		item, err := wire.ReadVarBytes(
+			reader, 0, txscript.MaxScriptSize, "witness",
+		)
+		require.NoError(t, err)
+
+		witness[i] = item
+	}
+	require.Zero(t, reader.Len())
+
+	return witness
 }

--- a/oor/transfer_input_snapshot_test.go
+++ b/oor/transfer_input_snapshot_test.go
@@ -13,8 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestTransferInputSnapshotRoundTrip asserts that transfer input snapshots
-// contain enough information to rebuild the VTXO signing descriptor.
+// TestTransferInputSnapshotRoundTrip verifies a durable TransferInputSnapshot
+// contains enough information to rebuild the VTXO signing descriptor for a
+// custom spend after process restart. The round trip covers the custom
+// spend-path script, control block, condition witness, required sequence and
+// locktime, and externally supplied tapscript signatures. Those fields are the
+// resume-critical material for cooperative refunds, where the client may
+// already hold a server signature and must reconstruct the same custom OOR
+// input before final witness assembly.
 func TestTransferInputSnapshotRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -103,6 +109,17 @@ func TestTransferInputSnapshotRoundTrip(t *testing.T) {
 			},
 		},
 	}
+	in.ExternalSignatures = []ExternalTaprootScriptSignature{
+		{
+			PubKey:        operatorKey.PubKey(),
+			WitnessScript: ownerLeaf.Script,
+			Signature: []byte{
+				0x30,
+				0x31,
+			},
+			SigHash: txscript.SigHashDefault,
+		},
+	}
 
 	snap, err := in.ToSnapshot()
 	require.NoError(t, err)
@@ -132,6 +149,9 @@ func TestTransferInputSnapshotRoundTrip(t *testing.T) {
 		snap.RequiredSequence)
 	require.Equal(t, in.CustomSpend.RequiredLockTime,
 		snap.RequiredLockTime)
+	requireExternalSignatureEqual(
+		t, in.ExternalSignatures[0], snap.ExternalSignatures[0],
+	)
 
 	rebuilt, err := TransferInputFromSnapshot(snap)
 	require.NoError(t, err)
@@ -168,6 +188,48 @@ func TestTransferInputSnapshotRoundTrip(t *testing.T) {
 	require.Equal(
 		t, in.CustomSpend.Conditions, rebuilt.CustomSpend.Conditions,
 	)
+	requireExternalSignatureEqual(
+		t, in.ExternalSignatures[0], rebuilt.ExternalSignatures[0],
+	)
+}
+
+// TestCloneExternalSignaturesDeepCopiesMutableBytes verifies persisted custom
+// signature snapshots do not alias the mutable witness-script or signature
+// slices held by a live TransferInput. Restart recovery depends on these
+// snapshots being immutable once captured; otherwise a later signing attempt
+// could mutate the in-memory transfer input and silently corrupt the durable
+// external signature material used to resume a cooperative refund.
+func TestCloneExternalSignaturesDeepCopiesMutableBytes(t *testing.T) {
+	t.Parallel()
+
+	_, key := btcec.PrivKeyFromBytes([]byte{
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+	})
+	original := []ExternalTaprootScriptSignature{
+		{
+			PubKey: key,
+			WitnessScript: []byte{
+				0x51,
+				0x20,
+			},
+			Signature: []byte{
+				0xaa,
+				0xbb,
+			},
+			SigHash: txscript.SigHashDefault,
+		},
+	}
+
+	clone := cloneExternalSignatures(original)
+	requireExternalSignatureEqual(t, original[0], clone[0])
+
+	clone[0].WitnessScript[0] = 0x00
+	clone[0].Signature[0] = 0x00
+
+	require.Equal(t, []byte{0x51, 0x20}, original[0].WitnessScript)
+	require.Equal(t, []byte{0xaa, 0xbb}, original[0].Signature)
+	require.Same(t, original[0].PubKey, clone[0].PubKey)
 }
 
 // TestTransferInputValidateRejectsNil asserts nil receivers are rejected.
@@ -203,6 +265,21 @@ func TestTransferInputFromSnapshotRejectsMissingFields(t *testing.T) {
 		OwnerLeafScript: []byte{0x51},
 	})
 	require.Error(t, err)
+}
+
+func requireExternalSignatureEqual(t *testing.T,
+	want ExternalTaprootScriptSignature,
+	got ExternalTaprootScriptSignature) {
+
+	t.Helper()
+
+	require.Equal(
+		t, want.PubKey.SerializeCompressed(),
+		got.PubKey.SerializeCompressed(),
+	)
+	require.Equal(t, want.WitnessScript, got.WitnessScript)
+	require.Equal(t, want.Signature, got.Signature)
+	require.Equal(t, want.SigHash, got.SigHash)
 }
 
 // TestTransferInputToSnapshotRejectsMissingVTXO asserts we require a full VTXO

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -876,6 +876,22 @@ func (s *paySession) waitForClaimPreimage(ctx context.Context) error {
 			})
 		}
 		if spentVHTLC != nil {
+			refundOutput, err := s.observeRefundOutput(ctx)
+			if err != nil {
+				return newRetryableActionError(
+					fmt.Errorf("query in-swap refund "+
+						"output after spend: %w", err),
+				)
+			}
+			if refundOutput != nil {
+				return s.markRefundOutputIndexed(
+					ctx, refundOutput,
+				)
+			}
+			if len(s.refundReceiveScript) > 0 {
+				return s.markRefunded(ctx, spentVHTLC)
+			}
+
 			reason := "funded vHTLC spent without claim preimage"
 			if spentVHTLC.SpentByTxID != "" {
 				reason = fmt.Sprintf("%s (spender %s)", reason,
@@ -1226,10 +1242,10 @@ func preparedCustomInput(prepared *PreparedOOR,
 		outpoint)
 }
 
-// observeRefundOutput returns the wallet output created by the timeout refund
-// once the daemon indexes the persisted refund destination. The refund output
-// is the most direct proof that the client recovered funds, while the spent
-// vHTLC record can lag behind or be unavailable depending on indexer timing.
+// observeRefundOutput returns the wallet output created by a refund once the
+// daemon indexes the persisted refund destination. The refund output is the
+// most direct proof that the client recovered funds, while the spent vHTLC
+// record can lag behind or be unavailable depending on indexer timing.
 func (s *paySession) observeRefundOutput(ctx context.Context) (*VTXOInfo,
 	error) {
 
@@ -1248,9 +1264,17 @@ func (s *paySession) observeRefundOutput(ctx context.Context) (*VTXOInfo,
 	}
 
 	if s.vhtlcAmount != 0 && refundOutput.AmountSat != s.vhtlcAmount {
-		return nil, fmt.Errorf("refund output amount %d does not "+
-			"match vHTLC amount %d", refundOutput.AmountSat,
-			s.vhtlcAmount)
+		s.client.log.WarnS(
+			ctx,
+			"Ignoring refund output with unexpected amount",
+			nil,
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+			slog.String("outpoint", refundOutput.Outpoint),
+			slog.Int64("amount", refundOutput.AmountSat),
+			slog.Int64("want_amount", s.vhtlcAmount),
+		)
+
+		return nil, nil
 	}
 
 	return refundOutput, nil

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -17,6 +17,12 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const (
+	refundLocktimeNearBlocks      = uint32(3)
+	refundLocktimeMaxPollMultiple = uint32(30)
+	refundLocktimeMaxPollInterval = time.Minute
+)
+
 // PayState identifies the client-side lifecycle state of an Ark-to-Lightning
 // pay flow.
 type PayState uint8
@@ -1007,6 +1013,7 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 		return fmt.Errorf("get block height: %w", err)
 	}
 	if height < s.cfg.VHTLCConfig.RefundLocktime {
+		wait := s.refundLocktimePollInterval(height)
 		s.client.log.DebugS(ctx, "Pay swap refund not yet mature",
 			btclog.Hex("hash", s.cfg.PaymentHash[:]),
 			slog.Uint64("height", uint64(height)),
@@ -1014,9 +1021,10 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 				"refund_locktime",
 				uint64(s.cfg.VHTLCConfig.RefundLocktime),
 			),
+			slog.Duration("next_poll", wait),
 		)
 
-		return waitForFixedPoll(ctx, s.client.waitPollInterval)
+		return waitForFixedPoll(ctx, wait)
 	}
 
 	refundPubKey, err := s.refundPubKey(ctx)
@@ -1075,6 +1083,38 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 	)
 
 	return s.markRefundAccepted(ctx)
+}
+
+// refundLocktimePollInterval returns a slower timeout-refund poll interval when
+// the refund branch is still many blocks away from maturity. The final few
+// blocks keep the normal SDK interval so the client remains responsive near the
+// first spendable height.
+func (s *paySession) refundLocktimePollInterval(height uint32) time.Duration {
+	wait := s.client.waitPollInterval
+	locktime := s.cfg.VHTLCConfig.RefundLocktime
+	if wait <= 0 || height >= locktime {
+		return wait
+	}
+
+	remaining := locktime - height
+	if remaining <= refundLocktimeNearBlocks {
+		return wait
+	}
+
+	multiple := remaining / 2
+	if multiple < 2 {
+		multiple = 2
+	}
+	if multiple > refundLocktimeMaxPollMultiple {
+		multiple = refundLocktimeMaxPollMultiple
+	}
+
+	backoff := wait * time.Duration(multiple)
+	if backoff > refundLocktimeMaxPollInterval {
+		return refundLocktimeMaxPollInterval
+	}
+
+	return backoff
 }
 
 // tryCooperativeRefund attempts an immediate refund before the timeout branch

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"testing"
 	"time"
@@ -918,6 +919,333 @@ func TestPaySessionCooperativeRefundKeepsAcceptedSessionOnPersistFailure(
 	require.Equal(t, "refund-session", session.refundSessionID)
 	require.Equal(t, PayStateRefundInitiated, session.State())
 	require.Equal(t, 1, daemonConn.sendCustomCalls)
+}
+
+// TestPaySessionResumeAfterAcceptedRefundFindsOutput exercises the crash window
+// after the daemon has accepted a cooperative refund OOR but before the swap DB
+// write records the refund session id. A restarted client in that window
+// reloads the pay session with an empty refundSessionID, while the
+// wallet/indexer may already report the vHTLC as spent by the accepted refund.
+// The important invariant is that this spent-without-preimage observation must
+// not force NeedsIntervention if the persisted refund destination output is
+// live; instead the client should reconcile the refund as terminally recovered
+// and avoid submitting a second custom-input spend.
+func TestPaySessionResumeAfterAcceptedRefundFindsOutput(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	refundScript, err := txscript.PayToTaprootScript(clientPriv.PubKey())
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:  preimage.Hash(),
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
+			ServerPubkey: serverPriv.PubKey(),
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime:                       100,
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			Expiry: time.Now().Add(time.Minute),
+		},
+		refundAuthorization: &InSwapRefundAuthorization{
+			Signature: TaprootScriptSignature{
+				PubKey: serverPriv.
+					PubKey().
+					SerializeCompressed(),
+				WitnessScript: []byte("witness"),
+				Signature:     []byte("server-sig"),
+			},
+			FailureReason: "payment failed",
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey:   clientPriv.PubKey(),
+		operatorKey:   operatorPriv.PubKey(),
+		blockHeight:   50,
+		sendSessionID: "refund-session",
+		vhtlc: &VTXOInfo{
+			Outpoint:  "funding:0",
+			AmountSat: testInSwapAmountSat,
+		},
+		receiveInfo: &ReceiveInfo{
+			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+			PkScript:    refundScript,
+		},
+		spendOnCustom: true,
+	}
+
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	client.waitPollInterval = time.Millisecond
+	client.refundLocktimeBuffer = 0
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	err = session.runUntil(t.Context(), PayStateWaitingForClaim)
+	require.NoError(t, err)
+
+	_, err = session.refundPubKey(t.Context())
+	require.NoError(t, err)
+	funded, err := session.observeRefundableVHTLC(t.Context())
+	require.NoError(t, err)
+	require.True(t, funded)
+
+	persistErr := errors.New("persist failed")
+	failingDB := &failAtExecDBTX{
+		db:     store.db,
+		err:    persistErr,
+		failAt: 2,
+	}
+	store.queries = swapsqlc.New(failingDB)
+
+	refunded, err := session.tryCooperativeRefund(t.Context())
+	require.ErrorContains(t, err, "persist failed")
+	require.False(t, refunded)
+	require.Equal(t, 1, daemonConn.sendCustomCalls)
+	require.Equal(t, PayStateWaitingForClaim, session.State())
+
+	store.queries = swapsqlc.New(store.db)
+	resumedClient := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	resumedClient.waitPollInterval = time.Millisecond
+	resumedClient.refundLocktimeBuffer = 0
+
+	resumed, err := resumedClient.ResumePayViaLightning(
+		t.Context(), preimage.Hash(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, PayStateWaitingForClaim, resumed.State())
+	require.Empty(t, resumed.refundSessionID)
+	require.NotEmpty(t, resumed.refundReceiveScript)
+
+	refundOutput, err := resumed.observeRefundOutput(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, refundOutput)
+
+	_, err = resumed.Wait(t.Context())
+	require.ErrorIs(t, err, ErrSwapRefunded)
+	require.Equal(t, PayStateRefunded, resumed.State())
+	require.Equal(t, 1, daemonConn.sendCustomCalls)
+
+	reloaded, err := resumedClient.ResumePayViaLightning(
+		t.Context(), preimage.Hash(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, PayStateRefunded, reloaded.State())
+}
+
+// TestPaySessionResumeAfterAcceptedRefundUsesSpentVHTLCFallback exercises the
+// same accepted-refund restart window as
+// TestPaySessionResumeAfterAcceptedRefundFindsOutput, but with the wallet
+// indexer lagging on the newly-created refund output. In that case the funded
+// vHTLC spend is already visible without a claim preimage, while the refund
+// destination script returns no live output yet. The session must still treat
+// the spend as a successful cooperative refund, because the pre-locktime refund
+// path requires the client, operator, and server signatures. This pins the
+// fallback that prevents a recovered refund from being misclassified as
+// NeedsIntervention during restart reconciliation.
+func TestPaySessionResumeAfterAcceptedRefundUsesSpentVHTLCFallback(
+	t *testing.T) {
+
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	refundScript, err := txscript.PayToTaprootScript(clientPriv.PubKey())
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:  preimage.Hash(),
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
+			ServerPubkey: serverPriv.PubKey(),
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime:                       100,
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			Expiry: time.Now().Add(time.Minute),
+		},
+		refundAuthorization: &InSwapRefundAuthorization{
+			Signature: TaprootScriptSignature{
+				PubKey: serverPriv.
+					PubKey().
+					SerializeCompressed(),
+				WitnessScript: []byte("witness"),
+				Signature:     []byte("server-sig"),
+			},
+			FailureReason: "payment failed",
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey:   clientPriv.PubKey(),
+		operatorKey:   operatorPriv.PubKey(),
+		blockHeight:   50,
+		sendSessionID: "refund-session",
+		vhtlc: &VTXOInfo{
+			Outpoint:  "funding:0",
+			AmountSat: testInSwapAmountSat,
+		},
+		receiveInfo: &ReceiveInfo{
+			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+			PkScript:    refundScript,
+		},
+		spendOnCustom: true,
+	}
+
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	client.waitPollInterval = time.Millisecond
+	client.refundLocktimeBuffer = 0
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	err = session.runUntil(t.Context(), PayStateWaitingForClaim)
+	require.NoError(t, err)
+
+	_, err = session.refundPubKey(t.Context())
+	require.NoError(t, err)
+	funded, err := session.observeRefundableVHTLC(t.Context())
+	require.NoError(t, err)
+	require.True(t, funded)
+
+	persistErr := errors.New("persist failed")
+	failingDB := &failAtExecDBTX{
+		db:     store.db,
+		err:    persistErr,
+		failAt: 2,
+	}
+	store.queries = swapsqlc.New(failingDB)
+
+	refunded, err := session.tryCooperativeRefund(t.Context())
+	require.ErrorContains(t, err, "persist failed")
+	require.False(t, refunded)
+	require.Equal(t, 1, daemonConn.sendCustomCalls)
+	require.Equal(t, PayStateWaitingForClaim, session.State())
+
+	daemonConn.liveByPkScript = nil
+
+	store.queries = swapsqlc.New(store.db)
+	resumedClient := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	resumedClient.waitPollInterval = time.Millisecond
+	resumedClient.refundLocktimeBuffer = 0
+
+	resumed, err := resumedClient.ResumePayViaLightning(
+		t.Context(), preimage.Hash(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, PayStateWaitingForClaim, resumed.State())
+	require.Empty(t, resumed.refundSessionID)
+	require.NotEmpty(t, resumed.refundReceiveScript)
+
+	refundOutput, err := resumed.observeRefundOutput(t.Context())
+	require.NoError(t, err)
+	require.Nil(t, refundOutput)
+
+	_, err = resumed.Wait(t.Context())
+	require.ErrorIs(t, err, ErrSwapRefunded)
+	require.Equal(t, PayStateRefunded, resumed.State())
+	require.Equal(t, "refund-session", resumed.refundSessionID)
+	require.Equal(t, 1, daemonConn.sendCustomCalls)
+
+	reloaded, err := resumedClient.ResumePayViaLightning(
+		t.Context(), preimage.Hash(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, PayStateRefunded, reloaded.State())
+}
+
+// TestPaySessionObserveRefundOutputIgnoresWrongAmount verifies that a live VTXO
+// at the persisted refund destination script is treated as "not our refund
+// output" when its amount does not match the funded vHTLC amount. The lookup
+// can race unrelated wallet state or future same-script activity. Retrying a
+// permanent amount-mismatch error would wedge the pay FSM forever, while
+// returning nil lets the caller keep reconciling through the spent-vHTLC
+// fallback or normal polling instead.
+func TestPaySessionObserveRefundOutputIgnoresWrongAmount(t *testing.T) {
+	t.Parallel()
+
+	refundScript := []byte{0x51, 0x20, 0x99}
+	daemonConn := &testDaemonConn{
+		liveByPkScript: map[string]*VTXOInfo{
+			hex.EncodeToString(refundScript): {
+				Outpoint:  "refund:0",
+				AmountSat: testInSwapAmountSat - 1,
+				PkScript:  refundScript,
+			},
+		},
+	}
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	session := &paySession{
+		client: configureTestPayClient(
+			NewSwapClient(nil, daemonConn, nil, nil),
+		),
+		cfg: &InSwapConfig{
+			PaymentHash: preimage.Hash(),
+		},
+		refundReceiveScript: refundScript,
+		vhtlcOutpoint:       "funding:0",
+		vhtlcAmount:         testInSwapAmountSat,
+	}
+
+	refundOutput, err := session.observeRefundOutput(t.Context())
+	require.NoError(t, err)
+	require.Nil(t, refundOutput)
+	require.Equal(t, 1, daemonConn.liveLookupCalls)
 }
 
 // TestPaySessionRefundsWhenRefundLocktimePassesBeforeClaim asserts that a

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -1248,6 +1248,41 @@ func TestPaySessionObserveRefundOutputIgnoresWrongAmount(t *testing.T) {
 	require.Equal(t, 1, daemonConn.liveLookupCalls)
 }
 
+// TestPaySessionRefundLocktimePollInterval documents the timeout-refund polling
+// schedule used while a vHTLC is known but the refund branch is not yet
+// spendable. Far from the refund locktime, the client should reduce noisy
+// wallet and indexer polling by backing off from the normal SDK interval. Near
+// the locktime, and once the locktime is reached, the helper must return the
+// normal poll interval so the client remains responsive around the first height
+// where a timeout refund can be submitted.
+func TestPaySessionRefundLocktimePollInterval(t *testing.T) {
+	t.Parallel()
+
+	session := &paySession{
+		client: &SwapClient{
+			waitPollInterval: 2 * time.Second,
+		},
+		cfg: &InSwapConfig{
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime: 200,
+			},
+		},
+	}
+
+	require.Equal(
+		t, time.Minute, session.refundLocktimePollInterval(50),
+	)
+	require.Equal(
+		t, 20*time.Second, session.refundLocktimePollInterval(180),
+	)
+	require.Equal(
+		t, 2*time.Second, session.refundLocktimePollInterval(197),
+	)
+	require.Equal(
+		t, 2*time.Second, session.refundLocktimePollInterval(200),
+	)
+}
+
 // TestPaySessionRefundsWhenRefundLocktimePassesBeforeClaim asserts that a
 // funded pay session does not wait for the wall-clock swap deadline after the
 // Ark refund locktime matures. The client should durably enter the refund path

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -68,6 +68,64 @@ func TestResumePendingStartsWorkersAndDedupes(t *testing.T) {
 	require.True(t, fakeClient.sawPendingOnlyList())
 }
 
+// TestResumeSwapConcurrentCallsStartOnePayWorker drives many manual resume RPCs
+// for the same pay swap at the same time. ResumeSwap is allowed to be retried
+// by clients, but it must not create parallel FSM drivers for one payment hash.
+// The test starts all callers from the same barrier, verifies every RPC still
+// returns successfully with the current summary, and then asserts exactly one
+// ResumePayViaLightning call was admitted through the active-worker gate.
+func TestResumeSwapConcurrentCallsStartOnePayWorker(t *testing.T) {
+	t.Parallel()
+
+	payHash := testHash(9)
+	fakeClient := newFakeSwapRuntime(swaps.SwapSummary{
+		Direction:   swaps.SwapDirectionPay,
+		PaymentHash: payHash,
+		State:       "waiting_for_claim",
+		Pending:     true,
+	})
+	service := newTestSwapClientService(fakeClient)
+	defer service.cancel()
+
+	req := &swapclientrpc.ResumeSwapRequest{
+		PaymentHash: hex.EncodeToString(payHash[:]),
+		Direction:   swapclientrpc.SwapDirection_SWAP_DIRECTION_PAY,
+	}
+
+	const callers = 16
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			<-start
+			_, err := service.ResumeSwap(t.Context(), req)
+			errs <- err
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	fakeClient.awaitPayResume(t, payHash)
+	require.Equal(t, 1, fakeClient.payResumeCount(payHash))
+
+	select {
+	case got := <-fakeClient.payResumeCh:
+		t.Fatalf("unexpected duplicate pay resume for %x", got[:])
+
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 // TestSwapStoreDatabasePathDefaultsToNetworkDir verifies a default swap store
 // is reset together with the network-scoped daemon DB directory.
 func TestSwapStoreDatabasePathDefaultsToNetworkDir(t *testing.T) {

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -723,6 +723,60 @@ func TestHistoryKeepsOORSendWithChangeWithoutSwap(t *testing.T) {
 	require.Equal(t, int64(-999_745), entries[0].GetAmountSat())
 }
 
+// TestHistoryKeepsZeroDeltaOORSendWithoutSwap covers a balanced OOR session
+// that sends funds out and receives the same amount back to this wallet without
+// any swap summary referencing the session. This shape is expected for ordinary
+// wallet-local OOR activity and must not be mistaken for a swap refund or claim
+// just because the net delta is zero. The history merger may hide the paired
+// receive leg as same-session change, but it must keep the outgoing SEND row so
+// user-initiated OOR activity remains visible in the wallet activity stream.
+func TestHistoryKeepsZeroDeltaOORSendWithoutSwap(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+
+	sessionID := testBytes(32, 0x35)
+	sessionHex := testSessionString(t, sessionID)
+
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:           "oor",
+				Subtype:        ledger.EventVTXOSent,
+				AmountSat:      1_000,
+				DebitAccount:   ledger.AccountTransfersOut,
+				CreditAccount:  ledger.AccountVTXOBalance,
+				SessionId:      sessionID,
+				EntryId:        31,
+				CreatedAtUnixS: 100,
+			},
+			{
+				Type:           "oor",
+				Subtype:        ledger.EventVTXOReceived,
+				AmountSat:      1_000,
+				DebitAccount:   ledger.AccountVTXOBalance,
+				CreditAccount:  ledger.AccountTransfersIn,
+				Txid:           sessionHex,
+				OutputIndex:    0,
+				EntryId:        32,
+				CreatedAtUnixS: 101,
+			},
+		},
+	}
+
+	resp, err := h.List(t.Context(), &walletrpc.ListRequest{})
+	require.NoError(t, err)
+
+	entries := resp.GetActivity().GetEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, "ledger-31", entries[0].GetId())
+	require.Equal(
+		t, walletrpc.EntryKind_ENTRY_KIND_SEND, entries[0].GetKind(),
+	)
+	require.Equal(t, int64(-1_000), entries[0].GetAmountSat())
+}
+
 // TestHistoryPendingFilterIncludesPendingBoarding confirms --pending includes
 // the synthetic unconfirmed boarding row.
 func TestHistoryPendingFilterIncludesPendingBoarding(t *testing.T) {


### PR DESCRIPTION
## Summary

This covers the client-side follow-ups from lightninglabs/swapdk-server#57:

- reconcile an accepted cooperative refund after restart by observing the refund output, or by adopting the indexed vHTLC spend when the refund output has not indexed yet
- ignore wrong-amount VTXOs at the refund destination as "not our refund output" instead of retrying a permanent amount-mismatch error
- back off timeout-refund polling while the refund locktime is still far away
- pin concurrent `ResumeSwap` calls so only one pay worker starts for a swap
- add a low-level custom OOR witness-ordering test
- keep ordinary zero-delta OOR sends visible in wallet history
- add TLV/snapshot round-trip coverage for durable external signatures
- add direct daemon RPC coverage for custom-input `PrepareOOR` and `SignOORCustomInput`

Each test includes an expanded comment describing the behavior and regression boundary it protects.

## Tests

- `make commitmsg-lint range="origin/main..HEAD"`
- `make lint-changed-local`
- `make unit pkg=./sdk/swaps case='TestPaySessionResumeAfterAcceptedRefundFindsOutput\|TestPaySessionResumeAfterAcceptedRefundUsesSpentVHTLCFallback\|TestPaySessionObserveRefundOutputIgnoresWrongAmount\|TestPaySessionCooperativeRefundKeepsAcceptedSessionOnPersistFailure\|TestPaySessionRefundLocktimePollInterval' timeout=2m`
- `make unit pkg=./oor case='TestAssembleCustomFinalWitnessOrdersSignatures\|TestExternalSignaturesTLVRoundTrip\|TestExternalSignaturesTLVRejectsMalformedPayloads\|TestTransferInputSnapshotRoundTrip\|TestCloneExternalSignaturesDeepCopiesMutableBytes' timeout=2m`
- `go test -tags="dev nolog swapruntime" ./swapclientserver -run TestResumeSwapConcurrentCallsStartOnePayWorker -count=1`
- `go test -tags="dev nolog walletrpc swapruntime" ./swapwallet -run TestHistoryKeepsZeroDeltaOORSendWithoutSwap -count=1`
- `make unit pkg=./darepod case='TestPrepareOORCustomInputMapsPreparedInput\|TestSignOORCustomInputMapsSignatureAndErrorCodes' timeout=2m`
