### PR TITLE
db: Keep boarded intents out of pending balance

### DIFF
--- a/db/boarding_wallet_test.go
+++ b/db/boarding_wallet_test.go
@@ -150,6 +150,39 @@ func createSweepStoreIntentWithSeed(t *testing.T, store *BoardingWalletStore,
 	return intent
 }
 
+// insertRoundBoardingIntentForTest links an intent to a persisted round.
+func insertRoundBoardingIntentForTest(t *testing.T, db *BaseDB, roundID,
+	roundStatus string, intent wallet.BoardingIntent) {
+
+	t.Helper()
+
+	ctx := t.Context()
+	require.NoError(
+		t,
+		db.InsertRound(
+			ctx, sqlc.InsertRoundParams{
+				RoundID:        roundID,
+				Status:         roundStatus,
+				CreationTime:   100,
+				LastUpdateTime: 100,
+			},
+		),
+	)
+	require.NoError(
+		t,
+		db.InsertRoundBoardingIntent(
+			ctx, sqlc.InsertRoundBoardingIntentParams{
+				RoundID:       roundID,
+				OutpointHash:  intent.Outpoint.Hash[:],
+				OutpointIndex: int32(intent.Outpoint.Index),
+				ClientKey:     testBytes(33, 0x11),
+				OperatorKey:   testBytes(33, 0x22),
+				ExitDelay:     144,
+			},
+		),
+	)
+}
+
 // dbSweepInputStatus returns the only input status in a one-input sweep test.
 func dbSweepInputStatus(t *testing.T,
 	inputs []wallet.BoardingSweepInputRecord) string {
@@ -350,6 +383,150 @@ func TestBoardingIntentLifecycle(t *testing.T) {
 	retrievedIntent, err = store.GetIntent(ctx, outpoint)
 	require.NoError(t, err)
 	require.Equal(t, wallet.BoardingStatusAdopted, retrievedIntent.Status)
+}
+
+// TestBoardingIntentConfirmedReplayDoesNotRegressStatus verifies that repeated
+// boarding UTXO detection cannot move an already-adopted intent back to
+// confirmed.
+func TestBoardingIntentConfirmedReplayDoesNotRegressStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, _ := newBoardingStoreForTest(t)
+	intent := createSweepStoreIntent(t, store)
+
+	require.NoError(
+		t, store.UpdateBoardingIntentStatus(
+			ctx, intent.Outpoint, wallet.BoardingStatusAdopted,
+		),
+	)
+
+	intent.Status = wallet.BoardingStatusConfirmed
+	require.NoError(t, store.InsertBoardingIntents(ctx, intent))
+
+	retrievedIntent, err := store.GetIntent(ctx, intent.Outpoint)
+	require.NoError(t, err)
+	require.Equal(t, wallet.BoardingStatusAdopted, retrievedIntent.Status)
+}
+
+// TestConfirmedBoardingIntentQueriesIgnoreRoundAdoptedRows verifies stale
+// confirmed rows that already have round boarding metadata cannot contribute to
+// pending boarding balance or board replay.
+func TestConfirmedBoardingIntentQueriesIgnoreRoundAdoptedRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, db := newBoardingStoreForTest(t)
+	intent := createSweepStoreIntent(t, store)
+
+	insertRoundBoardingIntentForTest(
+		t, db, "round-issue-564", "confirmed", intent,
+	)
+
+	confirmed, err := store.FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusConfirmed,
+	)
+	require.NoError(t, err)
+	require.Empty(t, confirmed)
+
+	backlog, err := store.FetchBoardingIntentsByStatusAndMinHeight(
+		ctx, wallet.BoardingStatusConfirmed, 0,
+	)
+	require.NoError(t, err)
+	require.Empty(t, backlog)
+
+	sweepable, err := store.FetchBoardingIntentsBySweepableStatuses(
+		ctx, []wallet.BoardingStatus{
+			wallet.BoardingStatusConfirmed,
+			wallet.BoardingStatusFailed,
+			wallet.BoardingStatusExpired,
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, sweepable)
+}
+
+// TestConfirmedBoardingIntentQueriesKeepFailedRoundRows verifies confirmed
+// intents linked only to failed rounds remain visible for retry/recovery.
+func TestConfirmedBoardingIntentQueriesKeepFailedRoundRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, db := newBoardingStoreForTest(t)
+	intent := createSweepStoreIntent(t, store)
+
+	insertRoundBoardingIntentForTest(
+		t, db, "round-failed", "failed", intent,
+	)
+
+	confirmed, err := store.FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusConfirmed,
+	)
+	require.NoError(t, err)
+	require.Len(t, confirmed, 1)
+	require.Equal(t, intent.Outpoint, confirmed[0].Outpoint)
+
+	backlog, err := store.FetchBoardingIntentsByStatusAndMinHeight(
+		ctx, wallet.BoardingStatusConfirmed, 0,
+	)
+	require.NoError(t, err)
+	require.Len(t, backlog, 1)
+	require.Equal(t, intent.Outpoint, backlog[0].Outpoint)
+
+	sweepable, err := store.FetchBoardingIntentsBySweepableStatuses(
+		ctx, []wallet.BoardingStatus{
+			wallet.BoardingStatusConfirmed,
+			wallet.BoardingStatusFailed,
+			wallet.BoardingStatusExpired,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, sweepable, 1)
+	require.Equal(t, intent.Outpoint, sweepable[0].Outpoint)
+}
+
+// TestAdoptedBoardingIntentQueriesIgnoreConfirmedRoundRows verifies adopted
+// boarding intents stop contributing to pending boarding balance once their
+// linked commitment round is confirmed.
+func TestAdoptedBoardingIntentQueriesIgnoreConfirmedRoundRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, db := newBoardingStoreForTest(t)
+	intent := createSweepStoreIntent(t, store)
+
+	require.NoError(
+		t, store.UpdateBoardingIntentStatus(
+			ctx, intent.Outpoint, wallet.BoardingStatusAdopted,
+		),
+	)
+
+	insertRoundBoardingIntentForTest(
+		t, db, "round-input-sig", "input_sig_sent", intent,
+	)
+
+	adopted, err := store.FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusAdopted,
+	)
+	require.NoError(t, err)
+	require.Len(t, adopted, 1)
+
+	require.NoError(
+		t,
+		db.UpdateRoundStatus(
+			ctx, sqlc.UpdateRoundStatusParams{
+				RoundID:        "round-input-sig",
+				Status:         "confirmed",
+				LastUpdateTime: 200,
+			},
+		),
+	)
+
+	adopted, err = store.FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusAdopted,
+	)
+	require.NoError(t, err)
+	require.Empty(t, adopted)
 }
 
 // TestUpdateBoardingIntentStatus verifies the narrow status update helper used

--- a/db/sqlc/boarding.sql.go
+++ b/db/sqlc/boarding.sql.go
@@ -229,7 +229,16 @@ INSERT INTO boarding_intents (
 ON CONFLICT (outpoint_hash, outpoint_index) DO UPDATE
 SET
     amount = COALESCE(excluded.amount, boarding_intents.amount),
-    status = excluded.status,
+    -- Re-detecting a boarding UTXO can replay the original confirmed
+    -- intent after the round store has already moved the row to adopted
+    -- or a sweep status. Such replays must refresh metadata without
+    -- regressing the lifecycle back to confirmed.
+    status = CASE
+        WHEN excluded.status = 'confirmed'
+            AND boarding_intents.status != 'confirmed'
+        THEN boarding_intents.status
+        ELSE excluded.status
+    END,
     conf_height = COALESCE(excluded.conf_height, boarding_intents.conf_height),
     conf_hash = COALESCE(excluded.conf_hash, boarding_intents.conf_hash),
     conf_tx = COALESCE(excluded.conf_tx, boarding_intents.conf_tx),
@@ -239,9 +248,7 @@ SET
     -- (domainIntentToInsertParams) normalises a zero-length proof
     -- slice to nil before the row is built, so excluded.tx_proof is
     -- either a populated blob or SQL NULL — plain COALESCE suffices
-    -- and is portable across SQLite and Postgres BYTEA. Status, by
-    -- contrast, is always authoritative on update so it overwrites
-    -- without COALESCE.
+    -- and is portable across SQLite and Postgres BYTEA.
     tx_proof = COALESCE(excluded.tx_proof, boarding_intents.tx_proof),
     last_update_time = excluded.last_update_time
 `
@@ -587,7 +594,29 @@ func (q *Queries) ListBoardingIntentsByPkScript(ctx context.Context, pkScript []
 
 const ListBoardingIntentsByStatus = `-- name: ListBoardingIntentsByStatus :many
 SELECT outpoint_hash, outpoint_index, pk_script, amount, conf_height, conf_hash, conf_tx, status, creation_time, last_update_time, tx_proof FROM boarding_intents
-WHERE status = $1
+WHERE boarding_intents.status = $1
+  AND (
+    $1 != 'confirmed' OR NOT EXISTS (
+      SELECT 1 FROM round_boarding_intents
+      JOIN rounds ON rounds.round_id = round_boarding_intents.round_id
+      WHERE round_boarding_intents.outpoint_hash =
+        boarding_intents.outpoint_hash
+        AND round_boarding_intents.outpoint_index =
+          boarding_intents.outpoint_index
+        AND rounds.status != 'failed'
+    )
+  )
+  AND (
+    $1 != 'adopted' OR NOT EXISTS (
+      SELECT 1 FROM round_boarding_intents
+      JOIN rounds ON rounds.round_id = round_boarding_intents.round_id
+      WHERE round_boarding_intents.outpoint_hash =
+        boarding_intents.outpoint_hash
+        AND round_boarding_intents.outpoint_index =
+          boarding_intents.outpoint_index
+        AND rounds.status = 'confirmed'
+    )
+  )
 ORDER BY creation_time DESC
 `
 
@@ -628,7 +657,18 @@ func (q *Queries) ListBoardingIntentsByStatus(ctx context.Context, status string
 
 const ListBoardingIntentsByStatusAndMinHeight = `-- name: ListBoardingIntentsByStatusAndMinHeight :many
 SELECT outpoint_hash, outpoint_index, pk_script, amount, conf_height, conf_hash, conf_tx, status, creation_time, last_update_time, tx_proof FROM boarding_intents
-WHERE status = $1 AND conf_height >= $2
+WHERE boarding_intents.status = $1 AND conf_height >= $2
+  AND (
+    $1 != 'confirmed' OR NOT EXISTS (
+      SELECT 1 FROM round_boarding_intents
+      JOIN rounds ON rounds.round_id = round_boarding_intents.round_id
+      WHERE round_boarding_intents.outpoint_hash =
+        boarding_intents.outpoint_hash
+        AND round_boarding_intents.outpoint_index =
+          boarding_intents.outpoint_index
+        AND rounds.status != 'failed'
+    )
+  )
 ORDER BY conf_height ASC
 `
 
@@ -674,7 +714,18 @@ func (q *Queries) ListBoardingIntentsByStatusAndMinHeight(ctx context.Context, a
 
 const ListBoardingIntentsBySweepableStatuses = `-- name: ListBoardingIntentsBySweepableStatuses :many
 SELECT outpoint_hash, outpoint_index, pk_script, amount, conf_height, conf_hash, conf_tx, status, creation_time, last_update_time, tx_proof FROM boarding_intents
-WHERE status IN ($1, $2, $3)
+WHERE boarding_intents.status IN ($1, $2, $3)
+  AND (
+    boarding_intents.status != 'confirmed' OR NOT EXISTS (
+      SELECT 1 FROM round_boarding_intents
+      JOIN rounds ON rounds.round_id = round_boarding_intents.round_id
+      WHERE round_boarding_intents.outpoint_hash =
+        boarding_intents.outpoint_hash
+        AND round_boarding_intents.outpoint_index =
+          boarding_intents.outpoint_index
+        AND rounds.status != 'failed'
+    )
+  )
 ORDER BY creation_time DESC
 `
 

--- a/db/sqlc/queries/boarding.sql
+++ b/db/sqlc/queries/boarding.sql
@@ -38,7 +38,16 @@ INSERT INTO boarding_intents (
 ON CONFLICT (outpoint_hash, outpoint_index) DO UPDATE
 SET
     amount = COALESCE(excluded.amount, boarding_intents.amount),
-    status = excluded.status,
+    -- Re-detecting a boarding UTXO can replay the original confirmed
+    -- intent after the round store has already moved the row to adopted
+    -- or a sweep status. Such replays must refresh metadata without
+    -- regressing the lifecycle back to confirmed.
+    status = CASE
+        WHEN excluded.status = 'confirmed'
+            AND boarding_intents.status != 'confirmed'
+        THEN boarding_intents.status
+        ELSE excluded.status
+    END,
     conf_height = COALESCE(excluded.conf_height, boarding_intents.conf_height),
     conf_hash = COALESCE(excluded.conf_hash, boarding_intents.conf_hash),
     conf_tx = COALESCE(excluded.conf_tx, boarding_intents.conf_tx),
@@ -48,9 +57,7 @@ SET
     -- (domainIntentToInsertParams) normalises a zero-length proof
     -- slice to nil before the row is built, so excluded.tx_proof is
     -- either a populated blob or SQL NULL — plain COALESCE suffices
-    -- and is portable across SQLite and Postgres BYTEA. Status, by
-    -- contrast, is always authoritative on update so it overwrites
-    -- without COALESCE.
+    -- and is portable across SQLite and Postgres BYTEA.
     tx_proof = COALESCE(excluded.tx_proof, boarding_intents.tx_proof),
     last_update_time = excluded.last_update_time;
 
@@ -60,12 +67,45 @@ WHERE outpoint_hash = $1 AND outpoint_index = $2;
 
 -- name: ListBoardingIntentsByStatus :many
 SELECT * FROM boarding_intents
-WHERE status = $1
+WHERE boarding_intents.status = $1
+  AND (
+    $1 != 'confirmed' OR NOT EXISTS (
+      SELECT 1 FROM round_boarding_intents
+      JOIN rounds ON rounds.round_id = round_boarding_intents.round_id
+      WHERE round_boarding_intents.outpoint_hash =
+        boarding_intents.outpoint_hash
+        AND round_boarding_intents.outpoint_index =
+          boarding_intents.outpoint_index
+        AND rounds.status != 'failed'
+    )
+  )
+  AND (
+    $1 != 'adopted' OR NOT EXISTS (
+      SELECT 1 FROM round_boarding_intents
+      JOIN rounds ON rounds.round_id = round_boarding_intents.round_id
+      WHERE round_boarding_intents.outpoint_hash =
+        boarding_intents.outpoint_hash
+        AND round_boarding_intents.outpoint_index =
+          boarding_intents.outpoint_index
+        AND rounds.status = 'confirmed'
+    )
+  )
 ORDER BY creation_time DESC;
 
 -- name: ListBoardingIntentsBySweepableStatuses :many
 SELECT * FROM boarding_intents
-WHERE status IN ($1, $2, $3)
+WHERE boarding_intents.status IN ($1, $2, $3)
+  AND (
+    boarding_intents.status != 'confirmed' OR NOT EXISTS (
+      SELECT 1 FROM round_boarding_intents
+      JOIN rounds ON rounds.round_id = round_boarding_intents.round_id
+      WHERE round_boarding_intents.outpoint_hash =
+        boarding_intents.outpoint_hash
+        AND round_boarding_intents.outpoint_index =
+          boarding_intents.outpoint_index
+        AND rounds.status != 'failed'
+    )
+  )
 ORDER BY creation_time DESC;
 
 -- name: ListAllBoardingIntents :many
@@ -226,7 +266,18 @@ SELECT outpoint_hash, outpoint_index FROM boarding_intents;
 
 -- name: ListBoardingIntentsByStatusAndMinHeight :many
 SELECT * FROM boarding_intents
-WHERE status = $1 AND conf_height >= $2
+WHERE boarding_intents.status = $1 AND conf_height >= $2
+  AND (
+    $1 != 'confirmed' OR NOT EXISTS (
+      SELECT 1 FROM round_boarding_intents
+      JOIN rounds ON rounds.round_id = round_boarding_intents.round_id
+      WHERE round_boarding_intents.outpoint_hash =
+        boarding_intents.outpoint_hash
+        AND round_boarding_intents.outpoint_index =
+          boarding_intents.outpoint_index
+        AND rounds.status != 'failed'
+    )
+  )
 ORDER BY conf_height ASC;
 
 -- Pending board request queries.


### PR DESCRIPTION
Fixes #564.

## Problem

After a boarding deposit is confirmed and adopted into a round, the wallet can
end up showing the same funds twice:

- the live VTXO, counted in `confirmed_sat`
- the original boarding amount, still counted in `pending_in_sat`

The live arktest reproduction showed this shape after the round confirmed:

```json
{
  "confirmed_sat": "999745",
  "pending_in_sat": "1000000",
  "pending_out_sat": "0"
}
```

The local DB row was not actually stuck at `confirmed`; it was correctly marked
`adopted`. The missing piece was that `adopted` rows were still being included
in pending boarding balance even after their linked round was confirmed and the
resulting VTXO was already live.

## Fix

- Keep adopted boarding intents visible while their linked round is still
  in-flight.
- Stop returning adopted boarding intents from pending-balance queries once
  their linked round has status `confirmed`.
- Preserve a later boarding lifecycle status when the same outpoint is replayed
  as `confirmed`.
- Exclude `confirmed` rows that already have `round_boarding_intents` metadata
  from confirmed/backlog/sweepable queries. This repairs stale local DBs where
  the row has already regressed.
- Add regression tests for replay regression, stale round-linked confirmed rows,
  and adopted rows aging out of pending balance after round confirmation.

## Tests

- `go test -tags='dev walletrpc swapruntime nolog' ./db -run 'Test(BoardingIntentConfirmedReplayDoesNotRegressStatus|ConfirmedBoardingIntentQueriesIgnoreRoundAdoptedRows|AdoptedBoardingIntentQueriesIgnoreConfirmedRoundRows|BoardingIntentLifecycle|FetchBoardingIntentsByStatus)' -count=1 -timeout=5m`
- `go test -tags='dev walletrpc swapruntime nolog' ./db ./wallet ./darepod ./swapwallet -count=1 -timeout=10m`
- `make lint-changed-local`
- `make fmt-changed-check base=origin/main`
- `make commitmsg-lint range=origin/main..HEAD`

## Manual arktest evidence

Built a private arktest binary with a temporary Go workspace that replaced
`github.com/lightninglabs/darepo-client` with this PR checkout:

```text
replace github.com/lightninglabs/darepo-client => /Users/bhandras/work/ark-testing/swapdk-server/client
```

Run:

```text
/tmp/arktest-564-bin/arktest --datadir /tmp/arktest-564-state start \
  --artifacts-dir /tmp/arktest-564-artifacts \
  --group-name issue564b \
  --client alice \
  --operator-funds 200000000 \
  --client-lnd-funds 100000000 \
  --logstdout
```

Commands exercised:

```text
alice-cli balance
/tmp/arktest-564-bin/arktest --datadir /tmp/arktest-564-state board alice 1000000
alice-cli activity
alice-cli ark board
arkcli trigger-batch
/tmp/arktest-564-bin/arktest --datadir /tmp/arktest-564-state mine 6
alice-cli balance
alice-cli ark vtxos list
```

Observed after funding the boarding address, before boarding:

```json
{
  "confirmed_sat": "0",
  "pending_in_sat": "1000000",
  "pending_out_sat": "0"
}
```

Activity at that point:

```text
DEPOSIT  COMPLETE  1000000  0  confirmed  605f57966e07aaf18ac28947484cce1708554e8e747f5c3e26bcc0b1385a48de
```

Observed round after `ark board`/`trigger-batch`:

```json
{
  "status": "ROUND_STATUS_BROADCAST",
  "num_participants": 1,
  "total_value_sat": "999745"
}
```

Observed after mining the commitment confirmation:

```json
{
  "confirmed_sat": "999745",
  "pending_in_sat": "0",
  "pending_out_sat": "0"
}
```

Final VTXO was live:

```text
amount_sat=999745 status=VTXO_STATUS_LIVE
```

DB sanity check from the same run:

```text
boarding_intents: amount=1000000 status=adopted
linked round: status=confirmed
adopted balance query result: empty
```
