### PR TITLE
multi: demote high-frequency ark-client logs to trace

### DIFF
--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -658,7 +658,21 @@ func (s *paySession) ensureFundingStillSafe(ctx context.Context) error {
 // then records funding intent once the daemon accepts the OOR transfer.
 func (s *paySession) fundOrAdoptVHTLC(ctx context.Context) error {
 	funded, err := s.observeLiveVHTLC(ctx)
-	if err != nil {
+	switch {
+	// A fresh in-swap has not funded its vHTLC yet, so the script is not
+	// registered with the authoritative indexer and the pre-funding adopt
+	// query is expected to be rejected on the first pass. Log it at debug
+	// so it is not mistaken for the genuine receive-side registration loop
+	// tracked in #538; only real query failures warrant a warning.
+	case err != nil && isUnregisteredScriptErr(err):
+		s.client.log.DebugS(
+			ctx,
+			"In-swap vHTLC not yet registered before funding",
+			slog.String("err", err.Error()),
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+		)
+
+	case err != nil:
 		s.client.log.WarnS(
 			ctx,
 			"Unable to query in-swap vHTLC before funding",
@@ -706,7 +720,7 @@ func (s *paySession) waitForFundedVHTLC(ctx context.Context) error {
 			s.client.log.DebugS(
 				ctx,
 				"Unable to query in-swap claim preimage",
-				err,
+				slog.String("err", err.Error()),
 				btclog.Hex("hash", s.cfg.PaymentHash[:]),
 			)
 		}
@@ -742,7 +756,7 @@ func (s *paySession) waitForFundedVHTLC(ctx context.Context) error {
 			s.client.log.DebugS(
 				ctx,
 				"Unable to query in-swap vHTLC",
-				err,
+				slog.String("err", err.Error()),
 				btclog.Hex("hash", s.cfg.PaymentHash[:]),
 			)
 		}
@@ -815,7 +829,7 @@ func (s *paySession) ensureFundingSubmitted(ctx context.Context,
 				ctx,
 				"Unable to reconcile in-swap vHTLC after "+
 					"funding error",
-				reconcileErr,
+				slog.String("err", reconcileErr.Error()),
 				btclog.Hex("hash", s.cfg.PaymentHash[:]),
 			)
 		}
@@ -859,7 +873,7 @@ func (s *paySession) waitForClaimPreimage(ctx context.Context) error {
 			s.client.log.DebugS(
 				ctx,
 				"Unable to query in-swap claim preimage",
-				err,
+				slog.String("err", err.Error()),
 				btclog.Hex("hash", s.cfg.PaymentHash[:]),
 			)
 		}

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -1190,7 +1190,7 @@ func (s *ReceiveSession) ensureReceiveFundingStillPossible(
 		s.client.log.DebugS(
 			ctx,
 			"Unable to query receive refund locktime height",
-			err,
+			slog.String("err", err.Error()),
 			btclog.Hex("hash", s.PaymentHash[:]),
 		)
 
@@ -1537,7 +1537,7 @@ func (c *SwapClient) receiveClaimAlreadyIndexedBounded(ctx context.Context,
 			c.log.DebugS(
 				ctx,
 				"Timed out checking indexed receive claim",
-				err,
+				slog.String("err", err.Error()),
 				btclog.Hex("hash", paymentHash[:]),
 			)
 

--- a/serverconn/unary_facade.go
+++ b/serverconn/unary_facade.go
@@ -138,7 +138,8 @@ func (f *UnaryFacade) SendRPC(ctx context.Context,
 		return mailboxrpc.SendResult{}, sendErr
 	}
 
-	f.connector.log.DebugS(ctx, "Sent unary RPC request",
+	f.connector.log.TraceS(
+		ctx, "Sent unary RPC request",
 		slog.String("service", method.Service),
 		slog.String("method", method.Method),
 		slog.String("correlation_id", correlationID),

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2276,7 +2276,7 @@ func (a *Ark) releaseManagerForfeit(ctx context.Context,
 func (a *Ark) handleSelectAndLockVTXOs(ctx context.Context,
 	req *SelectAndLockVTXOsRequest) fn.Result[WalletResp] {
 
-	a.logger(ctx).InfoS(ctx, "Selecting and locking VTXOs for spend",
+	a.logger(ctx).TraceS(ctx, "Selecting and locking VTXOs for spend",
 		slog.Int64("target", int64(req.TargetAmount)),
 	)
 


### PR DESCRIPTION
## Summary

Two log lines on the hot path of a swap-attached ark client (the `swapdk-ark-client` darepod) dominate the daemon log at default verbosity. Demote both to `TraceS`.

| Site | Was | Now |
|---|---|---|
| `serverconn/unary_facade.go` — "Sent unary RPC request" | `DebugS` | `TraceS` |
| `wallet/wallet.go` — "Selecting and locking VTXOs for spend" | `InfoS` | `TraceS` |

## Why

- **"Sent unary RPC request"** fires on every unary call the client makes to the operator, including the ~2/sec indexer polls that a swap receive runs while waiting for a vHTLC to be funded. At `DebugS` it produced thousands of lines an hour on an otherwise-idle signet client — e.g. on our signet `swapdk-ark-client`:
  ```
  [DBG] SVRC: Sent unary RPC request service=arkrpc.IndexerService method=ListVTXOsByScripts correlation_id=...
  ```
- **"Selecting and locking VTXOs for spend"** was logged at `InfoS`, so it showed up even at default info verbosity on every OOR coin-selection attempt. A retrying vHTLC funding loop reprints it every couple of seconds.

Neither line describes a state change — they're routine per-call mechanics. Operators who want the firehose can still opt in with trace logging.

## Test plan

- [x] `go build ./serverconn/... ./wallet/...`
- [ ] Run a swapd-attached ark client at default debug and confirm the indexer-poll + coin-selection spam is gone; confirm both lines reappear under `--debuglevel=trace`.