### PR TITLE
sdk/swaps: fix swap-store schema upgrade via migration 000002

### DIFF
--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -126,6 +126,21 @@ result into an `IncomingVHTLCNotification`.
 - Error sentinels (`ErrSwapExpired`, `ErrSwapRefunded`,
   `ErrSwapSummaryNotFound`) are exported; callers use `errors.Is`.
 
+### Migration notes
+
+- **Never add columns to an already-applied migration.** golang-migrate
+  records the version in `swap_client_schema_migrations` and never
+  re-runs it, so editing `000001` in place leaves every pre-existing
+  store without the new columns (it boots fine, then fails queries with
+  `no such column`). Always author a new forward-only `0000NN_*.up.sql`
+  with `ALTER TABLE ADD COLUMN` (backward-compatible defaults) and bump
+  `LatestMigrationVersion` in `store.go`.
+- `000002_swap_recovery_and_fee_columns` — adds `payer_fee_msat`
+  (BIGINT, default 0) and `claim_recovery_id` (TEXT, default '') to
+  `receive_swaps`, and `refund_recovery_id` (TEXT, default '') to
+  `pay_swaps`. These were originally mis-appended to `000001`.
+- `000001_swap_sessions` — base `receive_swaps` / `pay_swaps` schema.
+
 ## Deep Docs
 
 - [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/swaps/migrations/000001_swap_sessions.up.sql
+++ b/sdk/swaps/migrations/000001_swap_sessions.up.sql
@@ -14,10 +14,6 @@ CREATE TABLE IF NOT EXISTS receive_swaps (
     -- amount_sat is the requested invoice amount in satoshis.
     amount_sat BIGINT NOT NULL,
 
-    -- payer_fee_msat is the payer-paid route fee quoted by the swap server.
-    -- The fee is not deducted from amount_sat.
-    payer_fee_msat BIGINT NOT NULL,
-
     -- state is the current client-side receive FSM state name.
     state TEXT NOT NULL,
 
@@ -89,10 +85,6 @@ CREATE TABLE IF NOT EXISTS receive_swaps (
     -- claim_session_id is the deterministic OOR session identifier returned
     -- by the daemon when the client submits the receive-side claim.
     claim_session_id TEXT NOT NULL DEFAULT '',
-
-    -- claim_recovery_id is the daemon-owned vHTLC recovery row armed for
-    -- unilateral claim fallback. Empty means recovery has not been armed yet.
-    claim_recovery_id TEXT NOT NULL DEFAULT '',
 
     -- intervention_reason is the durable terminal explanation stored when a
     -- receive session fails or stops in NeedsIntervention.
@@ -192,11 +184,6 @@ CREATE TABLE IF NOT EXISTS pay_swaps (
     -- by the daemon when the client submits the timeout refund, or the
     -- observed spender txid when resume adopts an already-indexed refund.
     refund_session_id TEXT NOT NULL DEFAULT '',
-
-    -- refund_recovery_id is the daemon-owned vHTLC recovery row armed for
-    -- unilateral refund-without-receiver fallback. Empty means recovery has not
-    -- been armed yet.
-    refund_recovery_id TEXT NOT NULL DEFAULT '',
 
     -- preimage is the claim preimage once the swap server's spend is
     -- authoritatively observed.

--- a/sdk/swaps/migrations/000002_swap_recovery_and_fee_columns.down.sql
+++ b/sdk/swaps/migrations/000002_swap_recovery_and_fee_columns.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE pay_swaps DROP COLUMN refund_recovery_id;
+
+ALTER TABLE receive_swaps DROP COLUMN claim_recovery_id;
+ALTER TABLE receive_swaps DROP COLUMN payer_fee_msat;

--- a/sdk/swaps/migrations/000002_swap_recovery_and_fee_columns.up.sql
+++ b/sdk/swaps/migrations/000002_swap_recovery_and_fee_columns.up.sql
@@ -1,0 +1,24 @@
+-- 000002_swap_recovery_and_fee_columns reintroduces three columns that were
+-- appended to the already-applied 000001 migration by PRs #486 and #521.
+-- golang-migrate never re-runs a version already recorded in
+-- swap_client_schema_migrations, so swap stores created before those PRs booted
+-- without the columns and failed swap listing with "no such column". Moving the
+-- additions into this forward-only migration upgrades every existing swap store
+-- on first boot; the backward-compatible defaults backfill legacy rows.
+
+-- payer_fee_msat is the payer-paid route fee quoted by the swap server. The fee
+-- is not deducted from amount_sat. Legacy receive rows backfill to 0.
+ALTER TABLE receive_swaps
+    ADD COLUMN payer_fee_msat BIGINT NOT NULL DEFAULT 0;
+
+-- claim_recovery_id is the daemon-owned vHTLC recovery row armed for the
+-- receive-side unilateral claim fallback. Empty means recovery has not been
+-- armed yet.
+ALTER TABLE receive_swaps
+    ADD COLUMN claim_recovery_id TEXT NOT NULL DEFAULT '';
+
+-- refund_recovery_id is the daemon-owned vHTLC recovery row armed for the
+-- pay-side unilateral refund-without-receiver fallback. Empty means recovery
+-- has not been armed yet.
+ALTER TABLE pay_swaps
+    ADD COLUMN refund_recovery_id TEXT NOT NULL DEFAULT '';

--- a/sdk/swaps/sqlc/models.go
+++ b/sdk/swaps/sqlc/models.go
@@ -27,17 +27,16 @@ type PaySwap struct {
 	RefundReceivePubkey                  []byte
 	RefundReceivePkscript                []byte
 	RefundSessionID                      string
-	RefundRecoveryID                     string
 	Preimage                             []byte
 	InterventionReason                   string
 	CreatedAtUnix                        int64
 	UpdatedAtUnix                        int64
+	RefundRecoveryID                     string
 }
 
 type ReceiveSwap struct {
 	PaymentHash                          []byte
 	AmountSat                            int64
-	PayerFeeMsat                         int64
 	State                                string
 	Invoice                              string
 	Preimage                             []byte
@@ -58,8 +57,9 @@ type ReceiveSwap struct {
 	ClaimReceivePubkey                   []byte
 	ClaimReceivePkscript                 []byte
 	ClaimSessionID                       string
-	ClaimRecoveryID                      string
 	InterventionReason                   string
 	CreatedAtUnix                        int64
 	UpdatedAtUnix                        int64
+	PayerFeeMsat                         int64
+	ClaimRecoveryID                      string
 }

--- a/sdk/swaps/sqlc/swaps.sql.go
+++ b/sdk/swaps/sqlc/swaps.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const GetPaySwap = `-- name: GetPaySwap :one
-SELECT payment_hash, invoice, max_fee_sat, state, amount_sat, fee_sat, expiry_unix, client_pubkey, operator_pubkey, server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, funding_session_id, refund_receive_pubkey, refund_receive_pkscript, refund_session_id, refund_recovery_id, preimage, intervention_reason, created_at_unix, updated_at_unix FROM pay_swaps
+SELECT payment_hash, invoice, max_fee_sat, state, amount_sat, fee_sat, expiry_unix, client_pubkey, operator_pubkey, server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, funding_session_id, refund_receive_pubkey, refund_receive_pkscript, refund_session_id, preimage, intervention_reason, created_at_unix, updated_at_unix, refund_recovery_id FROM pay_swaps
 WHERE payment_hash = $1
 LIMIT 1
 `
@@ -41,17 +41,17 @@ func (q *Queries) GetPaySwap(ctx context.Context, paymentHash []byte) (PaySwap, 
 		&i.RefundReceivePubkey,
 		&i.RefundReceivePkscript,
 		&i.RefundSessionID,
-		&i.RefundRecoveryID,
 		&i.Preimage,
 		&i.InterventionReason,
 		&i.CreatedAtUnix,
 		&i.UpdatedAtUnix,
+		&i.RefundRecoveryID,
 	)
 	return i, err
 }
 
 const GetReceiveSwap = `-- name: GetReceiveSwap :one
-SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, claim_recovery_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
+SELECT payment_hash, amount_sat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix, payer_fee_msat, claim_recovery_id FROM receive_swaps
 WHERE payment_hash = $1
 LIMIT 1
 `
@@ -62,7 +62,6 @@ func (q *Queries) GetReceiveSwap(ctx context.Context, paymentHash []byte) (Recei
 	err := row.Scan(
 		&i.PaymentHash,
 		&i.AmountSat,
-		&i.PayerFeeMsat,
 		&i.State,
 		&i.Invoice,
 		&i.Preimage,
@@ -83,16 +82,17 @@ func (q *Queries) GetReceiveSwap(ctx context.Context, paymentHash []byte) (Recei
 		&i.ClaimReceivePubkey,
 		&i.ClaimReceivePkscript,
 		&i.ClaimSessionID,
-		&i.ClaimRecoveryID,
 		&i.InterventionReason,
 		&i.CreatedAtUnix,
 		&i.UpdatedAtUnix,
+		&i.PayerFeeMsat,
+		&i.ClaimRecoveryID,
 	)
 	return i, err
 }
 
 const ListPaySwaps = `-- name: ListPaySwaps :many
-SELECT payment_hash, invoice, max_fee_sat, state, amount_sat, fee_sat, expiry_unix, client_pubkey, operator_pubkey, server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, funding_session_id, refund_receive_pubkey, refund_receive_pkscript, refund_session_id, refund_recovery_id, preimage, intervention_reason, created_at_unix, updated_at_unix FROM pay_swaps
+SELECT payment_hash, invoice, max_fee_sat, state, amount_sat, fee_sat, expiry_unix, client_pubkey, operator_pubkey, server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, funding_session_id, refund_receive_pubkey, refund_receive_pkscript, refund_session_id, preimage, intervention_reason, created_at_unix, updated_at_unix, refund_recovery_id FROM pay_swaps
 ORDER BY created_at_unix ASC
 `
 
@@ -128,11 +128,11 @@ func (q *Queries) ListPaySwaps(ctx context.Context) ([]PaySwap, error) {
 			&i.RefundReceivePubkey,
 			&i.RefundReceivePkscript,
 			&i.RefundSessionID,
-			&i.RefundRecoveryID,
 			&i.Preimage,
 			&i.InterventionReason,
 			&i.CreatedAtUnix,
 			&i.UpdatedAtUnix,
+			&i.RefundRecoveryID,
 		); err != nil {
 			return nil, err
 		}
@@ -148,7 +148,7 @@ func (q *Queries) ListPaySwaps(ctx context.Context) ([]PaySwap, error) {
 }
 
 const ListPendingPaySwaps = `-- name: ListPendingPaySwaps :many
-SELECT payment_hash, invoice, max_fee_sat, state, amount_sat, fee_sat, expiry_unix, client_pubkey, operator_pubkey, server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, funding_session_id, refund_receive_pubkey, refund_receive_pkscript, refund_session_id, refund_recovery_id, preimage, intervention_reason, created_at_unix, updated_at_unix FROM pay_swaps
+SELECT payment_hash, invoice, max_fee_sat, state, amount_sat, fee_sat, expiry_unix, client_pubkey, operator_pubkey, server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, funding_session_id, refund_receive_pubkey, refund_receive_pkscript, refund_session_id, preimage, intervention_reason, created_at_unix, updated_at_unix, refund_recovery_id FROM pay_swaps
 WHERE state NOT IN (
     'Completed', 'Expired', 'Refunded', 'NeedsIntervention', 'Failed'
 )
@@ -187,11 +187,11 @@ func (q *Queries) ListPendingPaySwaps(ctx context.Context) ([]PaySwap, error) {
 			&i.RefundReceivePubkey,
 			&i.RefundReceivePkscript,
 			&i.RefundSessionID,
-			&i.RefundRecoveryID,
 			&i.Preimage,
 			&i.InterventionReason,
 			&i.CreatedAtUnix,
 			&i.UpdatedAtUnix,
+			&i.RefundRecoveryID,
 		); err != nil {
 			return nil, err
 		}
@@ -207,7 +207,7 @@ func (q *Queries) ListPendingPaySwaps(ctx context.Context) ([]PaySwap, error) {
 }
 
 const ListPendingReceiveSwaps = `-- name: ListPendingReceiveSwaps :many
-SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, claim_recovery_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
+SELECT payment_hash, amount_sat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix, payer_fee_msat, claim_recovery_id FROM receive_swaps
 WHERE state NOT IN ('Completed', 'Expired', 'NeedsIntervention', 'Failed')
 ORDER BY created_at_unix ASC
 `
@@ -224,7 +224,6 @@ func (q *Queries) ListPendingReceiveSwaps(ctx context.Context) ([]ReceiveSwap, e
 		if err := rows.Scan(
 			&i.PaymentHash,
 			&i.AmountSat,
-			&i.PayerFeeMsat,
 			&i.State,
 			&i.Invoice,
 			&i.Preimage,
@@ -245,10 +244,11 @@ func (q *Queries) ListPendingReceiveSwaps(ctx context.Context) ([]ReceiveSwap, e
 			&i.ClaimReceivePubkey,
 			&i.ClaimReceivePkscript,
 			&i.ClaimSessionID,
-			&i.ClaimRecoveryID,
 			&i.InterventionReason,
 			&i.CreatedAtUnix,
 			&i.UpdatedAtUnix,
+			&i.PayerFeeMsat,
+			&i.ClaimRecoveryID,
 		); err != nil {
 			return nil, err
 		}
@@ -264,7 +264,7 @@ func (q *Queries) ListPendingReceiveSwaps(ctx context.Context) ([]ReceiveSwap, e
 }
 
 const ListReceiveSwaps = `-- name: ListReceiveSwaps :many
-SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, claim_recovery_id, intervention_reason, created_at_unix, updated_at_unix FROM receive_swaps
+SELECT payment_hash, amount_sat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, intervention_reason, created_at_unix, updated_at_unix, payer_fee_msat, claim_recovery_id FROM receive_swaps
 ORDER BY created_at_unix ASC
 `
 
@@ -280,7 +280,6 @@ func (q *Queries) ListReceiveSwaps(ctx context.Context) ([]ReceiveSwap, error) {
 		if err := rows.Scan(
 			&i.PaymentHash,
 			&i.AmountSat,
-			&i.PayerFeeMsat,
 			&i.State,
 			&i.Invoice,
 			&i.Preimage,
@@ -301,10 +300,11 @@ func (q *Queries) ListReceiveSwaps(ctx context.Context) ([]ReceiveSwap, error) {
 			&i.ClaimReceivePubkey,
 			&i.ClaimReceivePkscript,
 			&i.ClaimSessionID,
-			&i.ClaimRecoveryID,
 			&i.InterventionReason,
 			&i.CreatedAtUnix,
 			&i.UpdatedAtUnix,
+			&i.PayerFeeMsat,
+			&i.ClaimRecoveryID,
 		); err != nil {
 			return nil, err
 		}

--- a/sdk/swaps/store.go
+++ b/sdk/swaps/store.go
@@ -48,7 +48,9 @@ const (
 	defaultConnMaxLifetime = 10 * time.Minute
 
 	// LatestMigrationVersion is the latest swap-client schema migration.
-	LatestMigrationVersion uint = 1
+	//
+	// NOTE: This MUST be updated when a new migration is added.
+	LatestMigrationVersion uint = 2
 )
 
 //go:embed migrations/*.sql


### PR DESCRIPTION
In this PR, we fix a schema upgrade bug in the isolated swap-client
store. PRs #486 and #521 each appended a new `NOT NULL` column to the
already-applied `000001_swap_sessions` migration: `refund_recovery_id`
on `pay_swaps`, and `claim_recovery_id` + `payer_fee_msat` on
`receive_swaps`. golang-migrate records the applied version in
`swap_client_schema_migrations` and never re-runs a version it's already
seen, so any swap store created before those PRs comes up at version 1
without the new columns. The store boots fine, then the first `list
pending swaps` on startup blows up with `SQL logic error: no such
column: refund_recovery_id`, which knocks the whole swap subsystem
offline (`Swap subscribe failed; backing off`).

This is the same footgun we already fixed for the main daemon DB in
`936fdd2d` and `7b553dc7` (moving columns into `000015`/`000016`). That
fix only covered `db/sqlc/migrations` though; the swap store lives in
its own migration tree under `sdk/swaps/migrations` and never got the
same treatment.

## The fix

We revert the three columns back out of `000001` and reintroduce them in
a forward-only `000002` migration that issues `ALTER TABLE ADD COLUMN`
with backward-compatible defaults (`payer_fee_msat` backfills to 0, the
recovery ids to `''`), then bump `LatestMigrationVersion` to 2 in
`store.go`. A pre-existing store applies the new shape on first boot, and
a fresh store reaches the same end state by running 000001 then 000002.
The sqlc regen is split into its own commit: since the columns move to
the tail of each table, their model fields and generated `SELECT` lists
shift to the end. No behavioral change.

## Testing

`TestSwapSqliteStoreRunsMigrations` and the fee-summary store test pass,
`make build` is clean, and the up/down migration round-trips on a fresh
sqlite db. `make sqlc-check` passes with the regenerated models committed.