### PR TITLE
txconfirm: fix zero-output CPFP child when fee-input change is sub-dust

### DIFF
--- a/serverconn/unary_facade.go
+++ b/serverconn/unary_facade.go
@@ -138,7 +138,8 @@ func (f *UnaryFacade) SendRPC(ctx context.Context,
 		return mailboxrpc.SendResult{}, sendErr
 	}
 
-	f.connector.log.DebugS(ctx, "Sent unary RPC request",
+	f.connector.log.TraceS(
+		ctx, "Sent unary RPC request",
 		slog.String("service", method.Service),
 		slog.String("method", method.Method),
 		slog.String("correlation_id", correlationID),

--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -48,7 +48,7 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - `TxState` — `New`, `Broadcasting`, `AwaitingConfirmation`,
   `FeeBumping`, `Confirmed`, `Failed`.
 - Sentinels: `ErrNonTRUCParent`, `ErrCPFPFeeInputUnavailable`,
-  `ErrEnsureParamsMismatch`.
+  `ErrEnsureParamsMismatch`, `ErrFeeInputProducesDust`.
 
 ## Relationships
 

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -48,7 +48,7 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - `TxState` — `New`, `Broadcasting`, `AwaitingConfirmation`,
   `FeeBumping`, `Confirmed`, `Failed`.
 - Sentinels: `ErrNonTRUCParent`, `ErrCPFPFeeInputUnavailable`,
-  `ErrEnsureParamsMismatch`.
+  `ErrEnsureParamsMismatch`, `ErrFeeInputProducesDust`.
 
 ## Relationships
 

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -682,6 +682,30 @@ func p2trTestPkScript(t *testing.T) []byte {
 	return script
 }
 
+// p2pkhTestPkScript returns a fixed, canonical legacy P2PKH pkScript
+// (OP_DUP OP_HASH160 <20-byte hash> OP_EQUALVERIFY OP_CHECKSIG). A
+// P2PKH input is heavier than the P2WKH fallback used for unrecognised
+// change scripts, so it forces the precise per-input vsize
+// recalculation to grow the package fee.
+func p2pkhTestPkScript(t *testing.T) []byte {
+	t.Helper()
+
+	var hash [20]byte
+	for i := range hash {
+		hash[i] = byte(i + 1)
+	}
+	script, err := txscript.NewScriptBuilder().
+		AddOp(txscript.OP_DUP).
+		AddOp(txscript.OP_HASH160).
+		AddData(hash[:]).
+		AddOp(txscript.OP_EQUALVERIFY).
+		AddOp(txscript.OP_CHECKSIG).
+		Script()
+	require.NoError(t, err)
+
+	return script
+}
+
 // TestEnsureConfirmedDedupesTwoSubscribers verifies that the actor deduplicates
 // by txid while notifying all subscribers on confirmation.
 func TestEnsureConfirmedDedupesTwoSubscribers(t *testing.T) {

--- a/txconfirm/broadcaster.go
+++ b/txconfirm/broadcaster.go
@@ -57,6 +57,15 @@ var (
 	// it can be broadcast safely.
 	ErrCPFPFeeInputUnavailable = errors.New("cpfp fee input unavailable")
 
+	// ErrFeeInputProducesDust indicates that the selected fee input
+	// covers the package fee but leaves a change output below the dust
+	// limit. The CPFP child's only non-anchor output is that change, so a
+	// sub-dust remainder would yield a zero-output transaction that the
+	// wallet cannot finalize. Callers should select a larger fee input,
+	// one covering totalFee + DustLimit, instead.
+	ErrFeeInputProducesDust = errors.New("cpfp fee input leaves sub-dust " +
+		"change")
+
 	// ErrNonTRUCParent indicates that the caller submitted a parent
 	// transaction whose version is not v3 (TRUC). txconfirm relies on
 	// BIP-431 ephemeral-anchor and TRUC-package semantics for its
@@ -684,7 +693,14 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 		req.Tx, txid, feeRate, totalFee, childVSize,
 	)
 
-	feeInput, err := b.selectFeeInput(ctx, txid, totalFee)
+	// Select a fee input that covers the package fee *plus* a spendable
+	// (non-dust) change output. Selecting for totalFee alone can pick a
+	// UTXO whose post-fee remainder is below the dust limit, which would
+	// force BuildCPFPChild to drop its only output and produce a
+	// zero-output child that FinalizePsbt rejects. Requiring the dust
+	// buffer up front skips near-dust UTXOs and lands on one that always
+	// yields a valid change output.
+	feeInput, err := b.selectFeeInput(ctx, txid, totalFee+DustLimit)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrCPFPFeeInputUnavailable,
 			err)
@@ -707,6 +723,28 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 		)
 		if feeErr == nil && preciseFee > totalFee {
 			totalFee = preciseFee
+
+			// Growing the fee can push the already-selected
+			// input's change below the dust limit. Reselect
+			// against the precise threshold so we still land
+			// on an input that yields a spendable change
+			// output rather than tripping the dust guard and
+			// re-picking the same too-small input on every
+			// retry. The reservation cache keeps the current
+			// input when it already covers the larger fee.
+			reselected, selErr := b.selectFeeInput(
+				ctx, txid, totalFee+DustLimit,
+			)
+			if selErr != nil {
+				return b.fallbackDirectBroadcast(
+					ctx, req, txid, feeInput.Outpoint,
+					"reselect_fee_input", selErr,
+				)
+			}
+			if reselected.Outpoint != feeInput.Outpoint {
+				feeInput = reselected
+				b.reserveFeeInput(ctx, txid, feeInput)
+			}
 		}
 	}
 
@@ -1404,12 +1442,25 @@ func BuildCPFPChild(parentVersion int32, anchorOutpoint wire.OutPoint,
 			"for fee %d", feeInput.Output.Value, int64(totalFee))
 	}
 
-	if changeValue >= DustLimit {
-		childTx.AddTxOut(&wire.TxOut{
-			Value:    int64(changeValue),
-			PkScript: append([]byte(nil), changePkScript...),
-		})
+	// The CPFP child's only spendable output is this change output: the
+	// other input is the parent's zero-value ephemeral anchor. If the
+	// remainder after fees is below the dust limit we cannot emit a valid
+	// output, so refuse here rather than return a zero-output transaction
+	// that the wallet's FinalizePsbt rejects ("PSBT packet must contain at
+	// least one output"). Callers select fee inputs covering totalFee +
+	// DustLimit, so this is a defensive backstop against a post-selection
+	// fee top-up (mixed-type wallets) eroding the dust margin.
+	if changeValue < DustLimit {
+		return nil, fmt.Errorf("%w: fee input %d leaves %d change "+
+			"below dust limit %d", ErrFeeInputProducesDust,
+			feeInput.Output.Value, int64(changeValue),
+			int64(DustLimit))
 	}
+
+	childTx.AddTxOut(&wire.TxOut{
+		Value:    int64(changeValue),
+		PkScript: append([]byte(nil), changePkScript...),
+	})
 
 	return childTx, nil
 }

--- a/txconfirm/broadcaster_test.go
+++ b/txconfirm/broadcaster_test.go
@@ -441,7 +441,12 @@ func TestBroadcasterHelperFunctions(t *testing.T) {
 			t, wire.MaxTxInSequenceNum-2, child.TxIn[1].Sequence,
 		)
 
-		dustChild, err := BuildCPFPChild(
+		// A fee input whose entire value is consumed by the fee
+		// leaves no room for a change output. Since the child's only
+		// non-anchor output is that change, BuildCPFPChild must refuse
+		// rather than emit a zero-output transaction that FinalizePsbt
+		// would reject.
+		_, err = BuildCPFPChild(
 			tx.Version, wire.OutPoint{
 				Hash:  tx.TxHash(),
 				Index: 1,
@@ -451,8 +456,39 @@ func TestBroadcasterHelperFunctions(t *testing.T) {
 			[]byte{txscript.OP_TRUE},
 			btcutil.Amount(feeInput.Output.Value),
 		)
+		require.ErrorIs(t, err, ErrFeeInputProducesDust)
+
+		// A fee input leaving change one sat below the dust limit must
+		// also be refused: a sub-dust change output is not relayable.
+		_, err = BuildCPFPChild(
+			tx.Version, wire.OutPoint{
+				Hash:  tx.TxHash(),
+				Index: 1,
+			},
+			tx.TxOut[1],
+			feeInput,
+			[]byte{txscript.OP_TRUE},
+			btcutil.Amount(feeInput.Output.Value)-DustLimit+1,
+		)
+		require.ErrorIs(t, err, ErrFeeInputProducesDust)
+
+		// Change of exactly the dust limit is the boundary that is
+		// still acceptable: the child gets its single change output.
+		boundaryChild, err := BuildCPFPChild(
+			tx.Version, wire.OutPoint{
+				Hash:  tx.TxHash(),
+				Index: 1,
+			},
+			tx.TxOut[1],
+			feeInput,
+			[]byte{txscript.OP_TRUE},
+			btcutil.Amount(feeInput.Output.Value)-DustLimit,
+		)
 		require.NoError(t, err)
-		require.Empty(t, dustChild.TxOut)
+		require.Len(t, boundaryChild.TxOut, 1)
+		require.Equal(
+			t, int64(DustLimit), boundaryChild.TxOut[0].Value,
+		)
 
 		_, err = BuildCPFPChild(
 			tx.Version, wire.OutPoint{}, tx.TxOut[1], &FeeInput{
@@ -678,6 +714,187 @@ func p2wkhTestPkScript(t *testing.T) []byte {
 	require.NoError(t, err)
 
 	return script
+}
+
+// TestCPFPChildSelectionAvoidsDustOutput is a regression test for the
+// zero-output CPFP child bug. A wallet littered with near-dust UTXOs caused
+// SelectFeeInput (which picks the smallest UTXO covering the fee) to choose an
+// input whose post-fee remainder fell below the dust limit, so BuildCPFPChild
+// dropped its only output and produced a transaction with no outputs that the
+// wallet's FinalizePsbt rejected. The fix selects for totalFee + DustLimit so a
+// spendable change output is always emitted, and BuildCPFPChild now refuses a
+// sub-dust remainder rather than silently emitting a zero-output child.
+func TestCPFPChildSelectionAvoidsDustOutput(t *testing.T) {
+	t.Parallel()
+
+	const totalFee = btcutil.Amount(500)
+
+	// A wallet mirroring the production litter: a near-dust "poison" UTXO
+	// that covers the fee but leaves one sat below dust as change, next to
+	// a large UTXO that yields ample change.
+	poison := FeeInput{
+		Outpoint: wire.OutPoint{
+			Hash: chainhash.Hash{
+				0xaa,
+			}, Index: 0,
+		},
+		Output: &wire.TxOut{
+			Value: int64(totalFee + DustLimit - 1),
+		},
+		Confirmed: true,
+	}
+	large := FeeInput{
+		Outpoint: wire.OutPoint{
+			Hash: chainhash.Hash{
+				0xbb,
+			}, Index: 0,
+		},
+		Output: &wire.TxOut{
+			Value: 5_000_000,
+		},
+		Confirmed: true,
+	}
+	inputs := []FeeInput{poison, large}
+
+	parent := wire.NewMsgTx(3)
+	parent.AddTxOut(&wire.TxOut{
+		Value: 0, PkScript: []byte{txscript.OP_TRUE},
+	})
+	anchorOutpoint := wire.OutPoint{Hash: parent.TxHash(), Index: 0}
+	changePkScript := []byte{txscript.OP_TRUE}
+
+	// Selecting for the bare fee reproduces the original selection: the
+	// smallest covering UTXO is the poison input, and building a child with
+	// it now yields a sub-dust change that is refused (previously this
+	// silently produced a zero-output transaction).
+	buggy, err := SelectFeeInput(inputs, totalFee, nil)
+	require.NoError(t, err)
+	require.Equal(t, poison.Outpoint, buggy.Outpoint)
+
+	_, err = BuildCPFPChild(
+		parent.Version, anchorOutpoint, parent.TxOut[0], buggy,
+		changePkScript, totalFee,
+	)
+	require.ErrorIs(t, err, ErrFeeInputProducesDust)
+
+	// Selecting with the dust buffer skips the poison UTXO and lands on the
+	// large input, so the child always carries a valid change output.
+	fixed, err := SelectFeeInput(inputs, totalFee+DustLimit, nil)
+	require.NoError(t, err)
+	require.Equal(t, large.Outpoint, fixed.Outpoint)
+
+	child, err := BuildCPFPChild(
+		parent.Version, anchorOutpoint, parent.TxOut[0], fixed,
+		changePkScript, totalFee,
+	)
+	require.NoError(t, err)
+	require.Len(t, child.TxOut, 1)
+	require.Equal(
+		t, int64(btcutil.Amount(large.Output.Value)-totalFee),
+		child.TxOut[0].Value,
+	)
+}
+
+// TestCPFPReselectsAfterPreciseFeeGrowth verifies that when the precise
+// per-input vsize recalculation grows the package fee enough to push the
+// originally selected fee input's change below the dust limit, the
+// broadcaster reselects a larger fee input instead of tripping
+// ErrFeeInputProducesDust and re-picking the same too-small input on every
+// retry.
+func TestCPFPReselectsAfterPreciseFeeGrowth(t *testing.T) {
+	t.Parallel()
+
+	const feeRate = 5
+
+	chain := newFakeChainSourceRef(100)
+	chain.feeRate = feeRate
+
+	parent := makeTestTx(true)
+
+	// The change script the wallet hands out is OP_TRUE, which fee
+	// estimation treats as the P2WKH fallback class. A P2PKH fee input is
+	// heavier than that proxy, so selecting it forces the precise vsize
+	// recalculation to grow the package fee.
+	opTrue := []byte{txscript.OP_TRUE}
+	changeVSize := estimateChildVSize(opTrue, opTrue)
+	p2pkhScript := p2pkhTestPkScript(t)
+	preciseVSize := estimateChildVSize(p2pkhScript, opTrue)
+	require.Greater(
+		t, preciseVSize, changeVSize,
+		"P2PKH fee input must be heavier than the change proxy",
+	)
+
+	baseFee, err := computePackageFee(parent, feeRate, changeVSize)
+	require.NoError(t, err)
+	preciseFee, err := computePackageFee(parent, feeRate, preciseVSize)
+	require.NoError(t, err)
+	require.Greater(t, preciseFee, baseFee)
+
+	// The small P2PKH UTXO clears the initial totalFee + DustLimit
+	// threshold but not the grown preciseFee + DustLimit one, so it is
+	// selected first and then must be abandoned.
+	small := &walletcore.Utxo{
+		Outpoint: wire.OutPoint{
+			Hash: chainhash.Hash{
+				0xaa,
+			},
+			Index: 0,
+		},
+		Amount:   baseFee + DustLimit,
+		PkScript: p2pkhScript,
+	}
+	require.Less(
+		t, small.Amount, preciseFee+DustLimit,
+		"small UTXO must fail the precise threshold",
+	)
+
+	// A larger UTXO that comfortably covers the precise threshold.
+	large := &walletcore.Utxo{
+		Outpoint: wire.OutPoint{
+			Hash: chainhash.Hash{
+				0xbb,
+			},
+			Index: 0,
+		},
+		Amount:   preciseFee + DustLimit + 1000,
+		PkScript: p2pkhScript,
+	}
+
+	b := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource: chain,
+		Wallet: &fakeWallet{
+			utxos: []*walletcore.Utxo{small, large},
+		},
+	})
+
+	_, err = b.Submit(t.Context(), 100, &BroadcastRequest{
+		Tx: parent, Label: "reselect",
+	})
+	require.NoError(t, err)
+
+	// A CPFP package must have been submitted (not a direct-broadcast
+	// fallback), and its child must spend the large UTXO, not the
+	// abandoned small one.
+	require.Equal(t, 1, chain.packageCallCount())
+	require.Zero(t, chain.broadcastCallCount())
+
+	child := chain.packageCalls[0].Child
+	require.NotNil(t, child)
+
+	var spendsLarge, spendsSmall bool
+	for _, in := range child.TxIn {
+		switch in.PreviousOutPoint {
+		case large.Outpoint:
+			spendsLarge = true
+
+		case small.Outpoint:
+			spendsSmall = true
+		}
+	}
+	require.True(t, spendsLarge, "child must spend the reselected UTXO")
+	require.False(
+		t, spendsSmall, "child must not spend the abandoned UTXO",
+	)
 }
 
 // TestCPFPBroadcasterFallbackAndErrors covers the lower-level generic

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2276,7 +2276,7 @@ func (a *Ark) releaseManagerForfeit(ctx context.Context,
 func (a *Ark) handleSelectAndLockVTXOs(ctx context.Context,
 	req *SelectAndLockVTXOsRequest) fn.Result[WalletResp] {
 
-	a.logger(ctx).InfoS(ctx, "Selecting and locking VTXOs for spend",
+	a.logger(ctx).TraceS(ctx, "Selecting and locking VTXOs for spend",
 		slog.Int64("target", int64(req.TargetAmount)),
 	)
 


### PR DESCRIPTION
## Summary

Fixes #580.

`selectFeeInput` picks the **smallest** confirmed UTXO with `value >= totalFee`,
but `BuildCPFPChild` only emits a change output when `value - totalFee >=
DustLimit` (330). A fee input whose value lands in the window `[totalFee,
totalFee + DustLimit)` therefore passes selection yet yields a CPFP child with
**no outputs** — its only other input is the parent's zero-value ephemeral
anchor — which LND's `FinalizePsbt` rejects (`PSBT packet must contain at least
one output`). The 0-fee TRUC parent then can't relay on its own (`min relay fee
not met`), so on-chain unrolls wedge indefinitely.

Observed on signet: the wallet had ~97M sat across 18 UTXOs, but was littered
with near-dust outputs (`357 / 798 / 944`, plus five `294`s). For a few-hundred-sat
unroll-node fee, the selector grabbed one of the tiny ones, leaving sub-dust
change → zero-output child. The large UTXOs (78M / 12M / 3M) were never reached
because a tiny one already "qualified".

## Fix (two layers)

1. **Selection threshold** — select for `totalFee + DustLimit` so the chosen fee
   input always leaves a spendable change output. Near-dust UTXOs are skipped and
   selection lands on one that yields valid change.
2. **Builder guard** — `BuildCPFPChild` now returns `ErrFeeInputProducesDust`
   when the remainder is below dust, instead of silently constructing a
   zero-output transaction. Defense-in-depth against a post-selection fee top-up
   (mixed-type wallets) eroding the dust margin.

## Tests

- Updated `TestBroadcasterHelperFunctions` "build cpfp child": the sub-dust case
  now expects `ErrFeeInputProducesDust`; added a boundary case where change ==
  `DustLimit` is still accepted (one output emitted).
- Added `TestCPFPChildSelectionAvoidsDustOutput`: with a poison near-dust UTXO
  next to a large one, selecting for `totalFee` reproduces the bad pick (now
  refused at build), while selecting for `totalFee + DustLimit` lands on the
  large input and yields a valid single-output child.

## Test plan

- [x] `go build ./txconfirm/`
- [x] `go test ./txconfirm/ -count=1`
- [x] `go vet ./txconfirm/`
- [x] `sg scan` — no new style warnings introduced