### PR TITLE
darepod: report only spendable VTXOs in GetBalance vtxo_balance_sat

### DIFF
--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -502,19 +502,25 @@ func (r *RPCServer) GetBalance(ctx context.Context,
 			"balance: %v", err)
 	}
 
-	// Fetch VTXO balance by summing all live VTXOs using the
-	// package-level SumBalance helper. Propagate query errors rather
+	// Fetch the spendable VTXO balance. Propagate query errors rather
 	// than silently zeroing — a returned zero is functionally
 	// indistinguishable from "no VTXOs" and would mislead a UI that
 	// trusts the response, which is the same rationale that makes
 	// fetchBoardingBalance error-strict above.
 	if r.server.vtxoStore != nil {
+		// ListLiveVTXOs returns every non-terminal VTXO (Live,
+		// PendingForfeit, Forfeiting, Spending) because it backs
+		// actor recovery, not spendability. Sum only the spendable
+		// (Live) subset: counting PendingForfeit/Spending here would
+		// overstate vtxo_balance_sat, which consumers such as the
+		// auto-boarder read as spendable liquidity and would then
+		// stop replenishing.
 		liveVTXOs, err := r.server.vtxoStore.ListLiveVTXOs(ctx)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "fetch vtxo "+
 				"balance: %v", err)
 		}
-		resp.VtxoBalanceSat = int64(vtxo.SumBalance(liveVTXOs))
+		resp.VtxoBalanceSat = int64(vtxo.SumSpendableBalance(liveVTXOs))
 	}
 
 	// Fetch the confirmed balance of the backing on-chain wallet so

--- a/vtxo/filter.go
+++ b/vtxo/filter.go
@@ -54,3 +54,19 @@ func SumBalance(descs []*Descriptor) btcutil.Amount {
 
 	return total
 }
+
+// SumSpendableBalance computes the total balance across only the
+// spendable subset of descriptors. Only Live VTXOs can fund a spend;
+// the other non-terminal states (PendingForfeit, Forfeiting, Spending)
+// are still "live" for actor-recovery purposes but cannot back a spend,
+// so they are excluded here. Callers reporting a spendable balance must
+// use this rather than SumBalance over a recovery-oriented VTXO set,
+// otherwise the figure overstates spendable liquidity.
+func SumSpendableBalance(descs []*Descriptor) btcutil.Amount {
+	spendable := FilterDescriptors(descs, FilterOptions{
+		Status:    VTXOStatusLive,
+		StatusSet: true,
+	})
+
+	return SumBalance(spendable)
+}

--- a/vtxo/filter_test.go
+++ b/vtxo/filter_test.go
@@ -1,0 +1,81 @@
+package vtxo
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSumSpendableBalance verifies that SumSpendableBalance counts only
+// Live VTXOs, excluding the other non-terminal states that ListLiveVTXOs
+// returns for actor recovery (PendingForfeit, Forfeiting, Spending). This
+// is the regression behind darepo-client #584, where a stuck Spending
+// VTXO and a PendingForfeit VTXO were summed into vtxo_balance_sat and
+// made the spendable balance look non-zero when it was actually zero.
+func TestSumSpendableBalance(t *testing.T) {
+	t.Parallel()
+
+	descs := []*Descriptor{
+		{
+			Amount: 1_000,
+			Status: VTXOStatusLive,
+		},
+		{
+			Amount: 2_000,
+			Status: VTXOStatusLive,
+		},
+		{
+			Amount: 5_000,
+			Status: VTXOStatusPendingForfeit,
+		},
+		{
+			Amount: 7_000,
+			Status: VTXOStatusForfeiting,
+		},
+		{
+			Amount: 4_834_745,
+			Status: VTXOStatusSpending,
+		},
+	}
+
+	// Only the two Live VTXOs are spendable.
+	require.Equal(
+		t, btcutil.Amount(3_000), SumSpendableBalance(descs),
+	)
+
+	// SumBalance over the same set sums everything, demonstrating why
+	// GetBalance must not use it for the spendable figure.
+	require.Equal(
+		t, btcutil.Amount(4_849_745), SumBalance(descs),
+	)
+}
+
+// TestSumSpendableBalanceAllNonSpendable confirms the issue's pathological
+// case: a set containing no Live VTXOs (only a Spending + PendingForfeit
+// reservation) reports zero spendable balance, not the inflated total.
+func TestSumSpendableBalanceAllNonSpendable(t *testing.T) {
+	t.Parallel()
+
+	descs := []*Descriptor{
+		{
+			Amount: 4_834_745,
+			Status: VTXOStatusSpending,
+		},
+		{
+			Amount: 5_000,
+			Status: VTXOStatusPendingForfeit,
+		},
+	}
+
+	require.Zero(t, SumSpendableBalance(descs))
+	require.Equal(t, btcutil.Amount(4_839_745), SumBalance(descs))
+}
+
+// TestSumSpendableBalanceEmpty guards the empty-input case.
+func TestSumSpendableBalanceEmpty(t *testing.T) {
+	t.Parallel()
+
+	require.Zero(t, SumSpendableBalance(nil))
+	require.Zero(t, SumSpendableBalance([]*Descriptor{}))
+}


### PR DESCRIPTION
In this PR, we fix #584: `darepod`'s `GetBalance` reports a `vtxo_balance_sat`
that overstates the spendable Ark-side balance, because it sums VTXOs that
can't actually fund anything.

The handler summed `ListLiveVTXOs`, but that query backs actor recovery, not
spendability. By design it returns every non-terminal VTXO, i.e. `Live(0)`,
`PendingForfeit(1)`, `Forfeiting(2)`, and `Spending(7)`, since those actors all
have to be respawned on startup. Summing that set for a balance figure means a
VTXO pinned in `Spending`, or one parked in `PendingForfeit`, gets counted as
spendable when it isn't.

That mismeasure bites downstream. The swapdk-server auto-boarder reads
`vtxo_balance_sat` as spendable liquidity (`LiveVTXOSat`). On signet a single
4,834,745 sat VTXO stuck in `Spending` plus a 5,000 sat `PendingForfeit` made
the field read ~4.84M while real spendable balance was 0. With a pending 3M
board on top, effective liquidity looked like ~10.8M, above the 5M low-water
mark, so the auto-boarder boarded `amount_sat=0` on every tick and never
refilled the actual spendable pool. Out-swap funding stayed starved.

## The fix

We add `vtxo.SumSpendableBalance`, which filters a descriptor set to `Live` via
the existing `FilterDescriptors` and then sums it. `GetBalance` now uses that
over the recovered set. `ListLiveVTXOs` is left alone for its recovery callers
(queued-outpoint synthesis, recovery snapshots, manager startup), and
`SumBalance` stays for callers that want the total over an already-filtered set.

We do this as a Go-side filter over the set `GetBalance` already fetches, rather
than a dedicated `status = 0 AND spent = FALSE` SQL query. The reason is purely
mechanical: sqlc codegen here is Docker-based and Docker isn't available in this
environment, so a new query can't be regenerated and CI's `sqlc-check` would
reject hand-written generated code. The Go filter makes the field mean what its
name and consumers assume without touching the generated layer. A scalar DB sum
stays a clean follow-up if we'd rather not load the descriptors at all.

## Tests

`vtxo/filter_test.go` covers the helper directly. `TestSumSpendableBalance`
rebuilds the issue's exact mixed-status set (two `Live`, plus `PendingForfeit`,
`Forfeiting`, and a 4.8M `Spending`) and asserts only the `Live` amounts sum,
while `SumBalance` over the same set still totals everything (that contrast is
why `GetBalance` must not use it). `TestSumSpendableBalanceAllNonSpendable`
covers the all-stuck case reporting zero, and `TestSumSpendableBalanceEmpty`
guards empty input.

## Test plan

- [x] `go build ./vtxo/ ./darepod/`
- [x] `go vet ./vtxo/`
- [x] `go test ./vtxo/ -count=1`
- [x] `gofmt -l` clean on changed files
