### PR TITLE
darepocli: surface nested RPC errors

### DIFF
--- a/cmd/darepocli/darepoclicommands/error_format.go
+++ b/cmd/darepocli/darepoclicommands/error_format.go
@@ -1,0 +1,208 @@
+package darepoclicommands
+
+import (
+	"io"
+	"strconv"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	defaultErrorCode = "EXECUTION_FAILED"
+	invalidArgsCode  = "INVALID_ARGS"
+)
+
+type commandError struct {
+	code    string
+	message string
+	details string
+}
+
+// PrintCommandError writes err as the CLI's structured JSON error envelope.
+func PrintCommandError(err error) error {
+	formatted := formatCommandError(err)
+
+	return PrintErrorDetails(
+		formatted.code, formatted.message, formatted.details,
+	)
+}
+
+// printCommandError writes the formatted error envelope to the supplied writer.
+func printCommandError(w io.Writer, err error) error {
+	formatted := formatCommandError(err)
+
+	return printErrorDetails(
+		w, formatted.code, formatted.message, formatted.details,
+	)
+}
+
+// formatCommandError converts an execution error into the public CLI envelope.
+func formatCommandError(err error) commandError {
+	if err == nil {
+		return commandError{
+			code:    defaultErrorCode,
+			message: "unknown error",
+		}
+	}
+
+	if IsCobraArgError(err) {
+		return commandError{
+			code:    invalidArgsCode,
+			message: err.Error(),
+		}
+	}
+
+	if rpcErr, ok := parseRPCErrorChain(err.Error()); ok {
+		return commandError{
+			code:    grpcCodeNameToCLI(rpcErr.code),
+			message: rpcErr.message,
+			details: rpcErr.details,
+		}
+	}
+
+	if st, ok := status.FromError(err); ok {
+		return commandError{
+			code:    grpcCodeToCLI(st.Code()),
+			message: st.Message(),
+		}
+	}
+
+	return commandError{
+		code:    defaultErrorCode,
+		message: err.Error(),
+	}
+}
+
+type rpcErrorChain struct {
+	code    string
+	message string
+	details string
+}
+
+// parseRPCErrorChain extracts the deepest gRPC status from nested error text.
+func parseRPCErrorChain(msg string) (rpcErrorChain, bool) {
+	const (
+		rpcPrefix = "rpc error: code = "
+		descSep   = " desc = "
+	)
+
+	// This intentionally depends on grpc-go's long-standing status error
+	// string format. Keeping the recovery here lets the CLI improve errors
+	// that have already crossed process boundaries as text.
+	var contexts []string
+	var code string
+	rest := msg
+	for {
+		idx := strings.Index(rest, rpcPrefix)
+		if idx < 0 {
+			break
+		}
+
+		if context := cleanRPCContext(rest[:idx]); context != "" {
+			contexts = append(contexts, context)
+		}
+
+		afterCode := rest[idx+len(rpcPrefix):]
+		codeEnd := strings.Index(afterCode, descSep)
+		if codeEnd < 0 {
+			return rpcErrorChain{}, false
+		}
+
+		code = strings.TrimSpace(afterCode[:codeEnd])
+		rest = afterCode[codeEnd+len(descSep):]
+	}
+
+	if code == "" {
+		return rpcErrorChain{}, false
+	}
+
+	return rpcErrorChain{
+		code:    code,
+		message: cleanRPCDescription(rest),
+		details: strings.Join(contexts, ": "),
+	}, true
+}
+
+// cleanRPCContext normalizes one wrapper segment from a nested gRPC error.
+func cleanRPCContext(context string) string {
+	context = strings.TrimSpace(context)
+	context = strings.TrimSuffix(context, ":")
+
+	return strings.TrimSpace(context)
+}
+
+// cleanRPCDescription normalizes the deepest gRPC status description.
+func cleanRPCDescription(desc string) string {
+	desc = strings.TrimSpace(desc)
+	if unquoted, err := strconv.Unquote(desc); err == nil {
+		return unquoted
+	}
+
+	return desc
+}
+
+// grpcCodeToCLI maps a gRPC code to the CLI's uppercase code convention.
+func grpcCodeToCLI(code codes.Code) string {
+	return grpcCodeNameToCLI(code.String())
+}
+
+// grpcCodeNameToCLI maps a gRPC code name to the CLI's uppercase convention.
+func grpcCodeNameToCLI(name string) string {
+	switch name {
+	case "OK":
+		return "OK"
+
+	case "Canceled":
+		return "CANCELED"
+
+	case "Unknown":
+		return "UNKNOWN"
+
+	case "InvalidArgument":
+		return "INVALID_ARGUMENT"
+
+	case "DeadlineExceeded":
+		return "DEADLINE_EXCEEDED"
+
+	case "NotFound":
+		return "NOT_FOUND"
+
+	case "AlreadyExists":
+		return "ALREADY_EXISTS"
+
+	case "PermissionDenied":
+		return "PERMISSION_DENIED"
+
+	case "ResourceExhausted":
+		return "RESOURCE_EXHAUSTED"
+
+	case "FailedPrecondition":
+		return "FAILED_PRECONDITION"
+
+	case "Aborted":
+		return "ABORTED"
+
+	case "OutOfRange":
+		return "OUT_OF_RANGE"
+
+	case "Unimplemented":
+		return "UNIMPLEMENTED"
+
+	case "Internal":
+		return "INTERNAL"
+
+	case "Unavailable":
+		return "UNAVAILABLE"
+
+	case "DataLoss":
+		return "DATA_LOSS"
+
+	case "Unauthenticated":
+		return "UNAUTHENTICATED"
+
+	default:
+		return strings.ToUpper(name)
+	}
+}

--- a/cmd/darepocli/darepoclicommands/root.go
+++ b/cmd/darepocli/darepoclicommands/root.go
@@ -101,6 +101,7 @@ type errorEnvelope struct {
 type errorPayload struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
+	Details string `json:"details,omitempty"`
 }
 
 // PrintError writes a structured error to stderr in JSON format and
@@ -110,18 +111,35 @@ type errorPayload struct {
 // surface keeps signalling failure to the harness while stderr stays
 // machine-readable.
 func PrintError(code string, msg string) error {
-	if err := printError(os.Stderr, code, msg); err != nil {
+	if err := printErrorDetails(os.Stderr, code, msg, ""); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %s\n", msg)
 	}
 
 	return &printedError{code: code, msg: msg}
 }
 
+// PrintErrorDetails writes a structured error to stderr with optional
+// diagnostic context for the message.
+func PrintErrorDetails(code string, msg string, details string) error {
+	if err := printErrorDetails(os.Stderr, code, msg, details); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", msg)
+	}
+
+	return &printedError{code: code, msg: msg, details: details}
+}
+
 func printError(w io.Writer, code string, msg string) error {
+	return printErrorDetails(w, code, msg, "")
+}
+
+func printErrorDetails(w io.Writer, code string, msg string,
+	details string) error {
+
 	data, err := json.MarshalIndent(errorEnvelope{
 		Error: errorPayload{
 			Code:    code,
 			Message: msg,
+			Details: details,
 		},
 	}, "", "  ")
 	if err != nil {
@@ -138,8 +156,9 @@ func printError(w io.Writer, code string, msg string) error {
 // surfaces validation / auth / not-found failures distinctly without
 // callers needing to thread codes manually.
 type printedError struct {
-	code string
-	msg  string
+	code    string
+	msg     string
+	details string
 }
 
 // Error returns the underlying message for cobra's RunE plumbing.

--- a/cmd/darepocli/darepoclicommands/root_test.go
+++ b/cmd/darepocli/darepoclicommands/root_test.go
@@ -3,9 +3,13 @@ package darepoclicommands
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestPrintErrorFormatsIndentedJSON(t *testing.T) {
@@ -30,4 +34,96 @@ func TestPrintErrorFormatsIndentedJSON(t *testing.T) {
 		"\n    \"code\": \"EXECUTION_FAILED\"",
 	)
 	require.Contains(t, buf.String(), "\n    \"message\": ")
+}
+
+func TestPrintCommandErrorPromotesNestedGRPCStatus(t *testing.T) {
+	t.Parallel()
+
+	const msg = "send: rpc error: code = Internal desc = start pay: " +
+		"rpc error: code = Internal desc = start pay swap: " +
+		"create in-swap: CreateInSwap RPC: rpc error: code = " +
+		"AlreadyExists desc = receive intent already used"
+	const details = "send: start pay: start pay swap: create in-swap: " +
+		"CreateInSwap RPC"
+
+	var buf bytes.Buffer
+	err := printCommandError(&buf, errors.New(msg))
+	require.NoError(t, err)
+
+	expected := `{
+		"error": {
+			"code": "ALREADY_EXISTS",
+			"message": "receive intent already used",
+			"details": "` + details + `"
+		}
+	}`
+	require.JSONEq(t, expected, buf.String())
+}
+
+func TestPrintCommandErrorAddsStatusWrapperDetails(t *testing.T) {
+	t.Parallel()
+
+	statusErr := status.Error(
+		codes.AlreadyExists, "receive intent already used",
+	)
+	err := fmt.Errorf("send: %w", statusErr)
+
+	var buf bytes.Buffer
+	require.NoError(t, printCommandError(&buf, err))
+
+	expected := `{
+		"error": {
+			"code": "ALREADY_EXISTS",
+			"message": "receive intent already used",
+			"details": "send"
+		}
+	}`
+	require.JSONEq(t, expected, buf.String())
+}
+
+func TestPrintCommandErrorHandlesBareGRPCStatus(t *testing.T) {
+	t.Parallel()
+
+	err := status.Error(codes.AlreadyExists, "receive intent already used")
+
+	var buf bytes.Buffer
+	require.NoError(t, printCommandError(&buf, err))
+
+	expected := `{
+		"error": {
+			"code": "ALREADY_EXISTS",
+			"message": "receive intent already used"
+		}
+	}`
+	require.JSONEq(t, expected, buf.String())
+}
+
+func TestPrintCommandErrorLeavesPlainErrorsGeneric(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	require.NoError(t, printCommandError(&buf, errors.New("boom")))
+
+	expected := `{
+		"error": {
+			"code": "EXECUTION_FAILED",
+			"message": "boom"
+		}
+	}`
+	require.JSONEq(t, expected, buf.String())
+}
+
+func TestPrintCommandErrorHandlesNilError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	require.NoError(t, printCommandError(&buf, nil))
+
+	expected := `{
+		"error": {
+			"code": "EXECUTION_FAILED",
+			"message": "unknown error"
+		}
+	}`
+	require.JSONEq(t, expected, buf.String())
 }

--- a/cmd/darepocli/main.go
+++ b/cmd/darepocli/main.go
@@ -12,8 +12,8 @@ import (
 // for the full table (2=invalid args, 3=auth, 4=not found, 10=dry-run
 // passed). Any error that already carries the structured envelope set
 // by helpers like PrintError is treated as already-rendered; otherwise
-// we emit a generic EXECUTION_FAILED envelope so stderr stays
-// machine-readable in every failure path.
+// we emit a normalized error envelope so stderr stays machine-readable
+// in every failure path.
 func main() {
 	root := darepoclicommands.NewRootCmd()
 
@@ -23,18 +23,7 @@ func main() {
 	}
 
 	if !darepoclicommands.ErrorWasPrinted(err) {
-		// Cobra and pflag pre-RunE failures (missing required
-		// flag, wrong arg count, unknown flag) come through here
-		// as bare errors that should map onto the agent-cli
-		// INVALID_ARGS envelope, not the generic EXECUTION_FAILED
-		// one. The matching exit-code-2 mapping lives in
-		// ExitCodeFor via IsCobraArgError, so the stderr code and
-		// the exit code stay in lockstep.
-		code := "EXECUTION_FAILED"
-		if darepoclicommands.IsCobraArgError(err) {
-			code = "INVALID_ARGS"
-		}
-		_ = darepoclicommands.PrintError(code, err.Error())
+		_ = darepoclicommands.PrintCommandError(err)
 	}
 
 	os.Exit(darepoclicommands.ExitCodeFor(err))

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -880,8 +880,7 @@ func (s *swapClientService) StartPay(ctx context.Context,
 		ctx, req.GetInvoice(), req.GetMaxFeeSat(),
 	)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "start pay swap: %v",
-			err)
+		return nil, fmt.Errorf("start pay swap: %w", err)
 	}
 
 	hash := session.PaymentHash()

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/lightninglabs/darepo-client/swaprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -230,6 +232,34 @@ func TestStartPayReturnsSummaryAndStartsWorker(t *testing.T) {
 	fakeClient.awaitPayResume(t, payHash)
 	require.Equal(t, 1, fakeClient.startPayCount())
 	require.Equal(t, 1, fakeClient.payResumeCount(payHash))
+}
+
+// TestStartPayPreservesRuntimeStatusCode verifies startup failures keep the
+// lower-level gRPC code instead of flattening every error to Internal.
+func TestStartPayPreservesRuntimeStatusCode(t *testing.T) {
+	t.Parallel()
+
+	fakeClient := newFakeSwapRuntime()
+	startPayErr := status.Error(
+		codes.AlreadyExists, "receive intent already used",
+	)
+	fakeClient.startPayErr = startPayErr
+	service := newTestSwapClientService(fakeClient)
+	defer service.cancel()
+
+	_, err := service.StartPay(
+		t.Context(), &swapclientrpc.StartPayRequest{
+			Invoice: "lnbc1test",
+		},
+	)
+	require.Error(t, err)
+	require.Equal(t, codes.AlreadyExists, status.Code(err))
+	require.ErrorIs(t, err, startPayErr)
+	require.Contains(t, status.Convert(err).Message(), "start pay swap")
+	require.Contains(
+		t, status.Convert(err).Message(),
+		"receive intent already used",
+	)
 }
 
 // TestStartReceiveReturnsInvoiceAndStartsWorker verifies receive startup
@@ -625,6 +655,7 @@ type fakeSwapRuntime struct {
 
 	startPaySession     paySwapSession
 	startReceiveSession receiveSwapSession
+	startPayErr         error
 
 	startPayCalls      int
 	startReceiveCalls  int
@@ -655,6 +686,9 @@ func (f *fakeSwapRuntime) StartPayViaLightning(context.Context, string,
 	defer f.mu.Unlock()
 
 	f.startPayCalls++
+	if f.startPayErr != nil {
+		return nil, f.startPayErr
+	}
 	if f.startPaySession == nil {
 		return nil, errors.New("start pay session not configured")
 	}

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletrpc"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // newRouterFixture wires a router with the given fake deps, returning the
@@ -377,4 +379,30 @@ func TestRouterSendInvoiceErrorBubblesUp(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "swap server unavailable")
+}
+
+// TestRouterSendInvoicePreservesStartPayStatusCode verifies StartPay status
+// errors keep their gRPC code as they move through the wallet router.
+func TestRouterSendInvoicePreservesStartPayStatusCode(t *testing.T) {
+	t.Parallel()
+
+	r, swap, _ := newRouterFixture(t)
+	startPayErr := status.Error(
+		codes.AlreadyExists, "receive intent already used",
+	)
+	swap.startPayErr = startPayErr
+
+	_, err := r.Send(t.Context(), &walletrpc.SendRequest{
+		Destination: &walletrpc.SendRequest_Invoice{
+			Invoice: "lnbc1example",
+		},
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.AlreadyExists, status.Code(err))
+	require.ErrorIs(t, err, startPayErr)
+	require.Contains(t, status.Convert(err).Message(), "start pay")
+	require.Contains(
+		t, status.Convert(err).Message(),
+		"receive intent already used",
+	)
 }


### PR DESCRIPTION
## Summary

Improve the generic `darepocli` error envelope so nested gRPC failures expose the deepest status code/message and keep wrapper context in an optional `details` field.

This turns errors like:

```json
{
  "error": {
    "code": "EXECUTION_FAILED",
    "message": "send: rpc error: code = Internal desc = start pay: rpc error: code = Internal desc = start pay swap: create in-swap: CreateInSwap RPC: rpc error: code = AlreadyExists desc = receive intent already used"
  }
}
```

into:

```json
{
  "error": {
    "code": "ALREADY_EXISTS",
    "message": "receive intent already used",
    "details": "send: start pay: start pay swap: create in-swap: CreateInSwap RPC"
  }
}
```

Also preserve lower-level gRPC status codes through the wallet send and swap-client `StartPay` boundaries instead of flattening every pay-start failure to `Internal`.

## Validation

- `make fmt-changed`
- `go test -tags="dev nolog" ./cmd/darepocli/darepoclicommands`
- `go test -tags="walletrpc swapruntime nolog" ./swapwallet -run 'TestRouterSendInvoice'`
- `go test -tags="swapruntime nolog" ./swapclientserver -run 'TestStartPay'`
- `make lint-changed-local`
- `git diff --check`
- `make fmt-changed-check`
- `make commitmsg-lint range="origin/main..HEAD"`
