### PR TITLE
vtxo+darepod: reconcile orphaned spending reservations on startup

### DIFF
--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1965,7 +1965,98 @@ func (s *Server) startWalletDependentActors(ctx context.Context,
 		return err
 	}
 
+	// -------------------------------------------------------
+	// 15. Reconcile orphaned spending reservations.
+	// -------------------------------------------------------
+	// With the VTXO manager and OOR subsystem both recovered, release any
+	// VTXO left stranded in SpendingState by a spend that died without
+	// emitting SpendReleasedEvent (see issue #587). Non-fatal: a failure
+	// here just leaves those VTXOs reserved until the next restart.
+	if err := s.reconcileOrphanedSpendingReservations(
+		ctx, vtxoManagerRef,
+	); err != nil {
+		s.log.WarnS(ctx, "Failed to reconcile orphaned spending "+
+			"reservations", err)
+	}
+
 	s.log.InfoS(ctx, "Wallet-dependent actors started")
+
+	return nil
+}
+
+// reconcileOrphanedSpendingReservations releases VTXOs stranded in
+// SpendingState that no live OOR session still claims. A VTXO enters
+// SpendingState only via the OOR send path, which reserves the selected
+// VTXOs as inputs; if that spend dies without emitting SpendReleasedEvent,
+// the reservation outlives its owner and the VTXO is unspendable until batch
+// expiry forces an on-chain unilateral exit.
+//
+// We build the claimed set from the OOR actor's live (pending) outgoing
+// sessions and hand it to the VTXO manager, which releases any Spending VTXO
+// not in that set. If the OOR set can't be determined we abort rather than
+// release, since an incomplete claimed set would free VTXOs a live spend
+// legitimately holds. The OOR actor processes its restart message before this
+// query (the mailbox is FIFO and the restart is prepended), so its in-memory
+// session set is fully restored by the time we read it.
+//
+// Forfeit-state reservations (PendingForfeit/Forfeiting) from round
+// registration are a separate lifecycle and are intentionally out of scope:
+// only the OOR SpendingState path is reconciled here.
+func (s *Server) reconcileOrphanedSpendingReservations(ctx context.Context,
+	vtxoManagerRef actor.ActorRef[vtxo.ManagerMsg, vtxo.ManagerResp]) error {
+
+	if s.actorSystem == nil {
+		return nil
+	}
+
+	// Gather the input outpoints still held by live outgoing OOR sessions.
+	oorRef := oor.NewServiceKey().Ref(s.actorSystem)
+	listResult := oorRef.Ask(ctx, &oor.ListSessionsRequest{
+		Direction:   oor.SessionDirectionOutgoing,
+		PendingOnly: true,
+	}).Await(ctx)
+
+	actorResp, err := listResult.Unpack()
+	if err != nil {
+		return fmt.Errorf("query live OOR sessions: %w", err)
+	}
+
+	listResp, ok := actorResp.(*oor.ListSessionsResponse)
+	if !ok {
+		return fmt.Errorf("unexpected OOR list response type: %T",
+			actorResp)
+	}
+
+	var claimed []wire.OutPoint
+	for _, summary := range listResp.Sessions {
+		claimed = append(claimed, summary.InputOutpoints...)
+	}
+
+	// Hand the claimed set to the manager, which releases any Spending VTXO
+	// not present in it.
+	reconcileResult := vtxoManagerRef.Ask(ctx,
+		&vtxo.ReconcileSpendingReservationsRequest{
+			ClaimedInputs: claimed,
+		},
+	).Await(ctx)
+
+	resp, err := reconcileResult.Unpack()
+	if err != nil {
+		return fmt.Errorf("reconcile spending reservations: %w", err)
+	}
+
+	reconcileResp, ok := resp.(*vtxo.ReconcileSpendingReservationsResponse)
+	if !ok {
+		return fmt.Errorf("unexpected reconcile response type: %T", resp)
+	}
+
+	if reconcileResp.ReleasedCount > 0 {
+		s.log.InfoS(ctx, "Released orphaned spending reservations",
+			slog.Int("released", reconcileResp.ReleasedCount),
+			slog.Int("scanned", reconcileResp.ScannedCount),
+			slog.Int("claimed", reconcileResp.ClaimedCount),
+		)
+	}
 
 	return nil
 }

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -274,6 +274,9 @@ func (m *Manager) Receive(ctx context.Context,
 	case *CompleteSpendRequest:
 		return m.handleCompleteSpend(ctx, req)
 
+	case *ReconcileSpendingReservationsRequest:
+		return m.handleReconcileSpendingReservations(ctx, req)
+
 	case *ReserveForfeitRequest:
 		return m.handleReserveForfeit(ctx, req)
 
@@ -787,6 +790,99 @@ func (m *Manager) handleReleaseSpend(ctx context.Context,
 	return fn.Ok[ManagerResp](&ReleaseSpendResponse{
 		ReleasedCount: released,
 	})
+}
+
+// handleReconcileSpendingReservations releases VTXOs stranded in SpendingState
+// that no live spend still claims. It is meant to run once at startup, after
+// the OOR subsystem has recovered, to undo orphaned reservations left behind
+// when a spend died without emitting SpendReleasedEvent. Without this, such a
+// VTXO stays unspendable until batch expiry forces an on-chain unilateral exit.
+func (m *Manager) handleReconcileSpendingReservations(ctx context.Context,
+	req *ReconcileSpendingReservationsRequest) fn.Result[ManagerResp] {
+
+	// Read the authoritative current Spending set from the store rather than
+	// the Start-time descriptor snapshot. A spend that completed or released
+	// during recovery has already updated its persisted status, so reading
+	// fresh here avoids treating an already-resolved VTXO as an orphan.
+	spending, err := m.cfg.Store.ListVTXOsByStatus(ctx, VTXOStatusSpending)
+	if err != nil {
+		return fn.Err[ManagerResp](
+			fmt.Errorf("list spending vtxos: %w", err),
+		)
+	}
+
+	orphans := orphanedReservations(spending, req.ClaimedInputs)
+
+	var (
+		released int
+		errs     []error
+	)
+	for _, op := range orphans {
+		ref, ok := m.actors[op]
+		if !ok {
+			// No live actor for this outpoint means it was already
+			// cleaned up to a terminal state; nothing to release.
+			continue
+		}
+
+		result := m.askVTXOActor(ctx, ref, &SpendReleasedEvent{})
+		if _, err := result.Unpack(); err != nil {
+			m.logger(ctx).WarnS(ctx,
+				"Orphaned spend release failed", err,
+				slog.String("outpoint", op.String()),
+			)
+			errs = append(
+				errs, fmt.Errorf("release %s: %w", op, err),
+			)
+
+			continue
+		}
+
+		m.logger(ctx).InfoS(ctx,
+			"Released orphaned spending reservation",
+			slog.String("outpoint", op.String()),
+		)
+		released++
+	}
+
+	if len(errs) > 0 {
+		return fn.Err[ManagerResp](
+			fmt.Errorf("reconcile spending: %d/%d release(s) "+
+				"failed: %w", len(errs), len(orphans),
+				errors.Join(errs...)),
+		)
+	}
+
+	return fn.Ok[ManagerResp](&ReconcileSpendingReservationsResponse{
+		ScannedCount:  len(spending),
+		ClaimedCount:  len(req.ClaimedInputs),
+		ReleasedCount: released,
+	})
+}
+
+// orphanedReservations returns the outpoints of Spending VTXOs that no live
+// spend still claims. A reservation is an orphan when the VTXO sits in
+// SpendingState yet no live OOR session lists it among its inputs, which is
+// exactly the state left behind when the reserving spend dies without
+// releasing it.
+func orphanedReservations(spending []*Descriptor,
+	claimed []wire.OutPoint) []wire.OutPoint {
+
+	claimedSet := make(map[wire.OutPoint]struct{}, len(claimed))
+	for _, op := range claimed {
+		claimedSet[op] = struct{}{}
+	}
+
+	var orphans []wire.OutPoint
+	for _, d := range spending {
+		if _, ok := claimedSet[d.Outpoint]; ok {
+			continue
+		}
+
+		orphans = append(orphans, d.Outpoint)
+	}
+
+	return orphans
 }
 
 // handleCompleteSpend marks VTXOs as fully spent via SpendCompletedEvent.

--- a/vtxo/messages.go
+++ b/vtxo/messages.go
@@ -1,6 +1,7 @@
 package vtxo
 
 import (
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/round"
@@ -113,6 +114,52 @@ type ListLiveDescriptorsResponse struct {
 
 // VTXOManagerResp implements actormsg.VTXOManagerResp marker interface.
 func (r *ListLiveDescriptorsResponse) VTXOManagerResp() {}
+
+// ReconcileSpendingReservationsRequest asks the manager to release VTXOs
+// stranded in SpendingState that no live spend still claims. A VTXO enters
+// SpendingState when an OOR send reserves it; if that spend dies without
+// emitting SpendReleasedEvent (crash, abandoned funding attempt), the
+// reservation outlives its owner and the VTXO is stuck until batch expiry.
+//
+// ClaimedInputs is the set of VTXO input outpoints that live/resumable OOR
+// sessions still hold after recovery. Any Spending VTXO not in this set is an
+// orphan and is returned to LiveState.
+//
+// The caller must assemble a COMPLETE claimed set before sending this. If the
+// set can't be determined (e.g. the OOR actor is unreachable), the caller must
+// not send the request at all: an incomplete set would release VTXOs that a
+// live spend legitimately holds.
+type ReconcileSpendingReservationsRequest struct {
+	actor.BaseMessage
+
+	// ClaimedInputs are the input outpoints still held by live spends.
+	ClaimedInputs []wire.OutPoint
+}
+
+// MessageType returns the message type identifier.
+func (r *ReconcileSpendingReservationsRequest) MessageType() string {
+	return "ReconcileSpendingReservationsRequest"
+}
+
+// VTXOManagerMsg implements actormsg.VTXOManagerMsg marker interface.
+func (r *ReconcileSpendingReservationsRequest) VTXOManagerMsg() {}
+
+// ReconcileSpendingReservationsResponse reports the outcome of a reconcile
+// pass: how many Spending VTXOs were scanned, how many inputs the caller
+// reported as still claimed, and how many orphans were released back to Live.
+type ReconcileSpendingReservationsResponse struct {
+	// ScannedCount is the number of VTXOs found in SpendingState.
+	ScannedCount int
+
+	// ClaimedCount is the size of the claimed-input set the caller passed.
+	ClaimedCount int
+
+	// ReleasedCount is the number of orphaned reservations released.
+	ReleasedCount int
+}
+
+// VTXOManagerResp implements actormsg.VTXOManagerResp marker interface.
+func (r *ReconcileSpendingReservationsResponse) VTXOManagerResp() {}
 
 // =============================================================================
 // Relay messages: VTXO actor → Manager → external actor

--- a/vtxo/reconcile_test.go
+++ b/vtxo/reconcile_test.go
@@ -1,0 +1,169 @@
+package vtxo
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// newSpendingTestManager builds a Manager whose actors all start in
+// SpendingState, mirroring the post-restart recovery of VTXOs that were
+// reserved for an OOR spend. The store reports the same set as Spending.
+func newSpendingTestManager(t *testing.T,
+	descriptors []*Descriptor) (*Manager, *MockVTXOStore) {
+
+	t.Helper()
+
+	store := &MockVTXOStore{}
+	mgr := &Manager{
+		cfg: &ManagerConfig{
+			Store:      store,
+			RoundActor: newMockRoundActorRef(t),
+		},
+		actors: make(map[wire.OutPoint]VTXOActorRef),
+	}
+
+	for _, d := range descriptors {
+		d.Status = VTXOStatusSpending
+		mgr.actors[d.Outpoint] = newMockVTXOActorRef(
+			d.Outpoint.String(),
+			&SpendingState{
+				VTXO:              d,
+				LastCheckedHeight: d.CreatedHeight,
+			},
+		)
+	}
+
+	return mgr, store
+}
+
+// requireActorState asserts the mock actor for outpoint is in state T.
+func requireActorState[T VTXOState](t *testing.T, mgr *Manager,
+	op wire.OutPoint) {
+
+	t.Helper()
+
+	ref, ok := mgr.actors[op].(*mockVTXOActorRef)
+	require.True(t, ok, "expected *mockVTXOActorRef, got %T", mgr.actors[op])
+
+	_, ok = ref.state.(T)
+	require.Truef(t, ok, "expected state %T, got %T", *new(T), ref.state)
+}
+
+// TestReconcileSpendingReservationsReleasesOrphans verifies the core #587 fix:
+// a Spending VTXO that no live OOR session claims is released back to Live,
+// while a Spending VTXO a live session still holds is left untouched.
+func TestReconcileSpendingReservationsReleasesOrphans(t *testing.T) {
+	t.Parallel()
+
+	claimed := makeDescriptor(t, 10000, 0)
+	orphanA := makeDescriptor(t, 20000, 1)
+	orphanB := makeDescriptor(t, 30000, 2)
+
+	mgr, store := newSpendingTestManager(t, []*Descriptor{
+		claimed, orphanA, orphanB,
+	})
+
+	store.On(
+		"ListVTXOsByStatus", mock.Anything, VTXOStatusSpending,
+	).Return([]*Descriptor{claimed, orphanA, orphanB}, nil)
+
+	// Only `claimed` is still held by a live outgoing OOR session.
+	result := mgr.Receive(t.Context(),
+		&ReconcileSpendingReservationsRequest{
+			ClaimedInputs: []wire.OutPoint{claimed.Outpoint},
+		},
+	)
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	reconcileResp, ok := resp.(*ReconcileSpendingReservationsResponse)
+	require.True(t, ok)
+	require.Equal(t, 3, reconcileResp.ScannedCount)
+	require.Equal(t, 1, reconcileResp.ClaimedCount)
+	require.Equal(t, 2, reconcileResp.ReleasedCount)
+
+	// Orphans are back in LiveState; the claimed reservation is untouched.
+	requireActorState[*LiveState](t, mgr, orphanA.Outpoint)
+	requireActorState[*LiveState](t, mgr, orphanB.Outpoint)
+	requireActorState[*SpendingState](t, mgr, claimed.Outpoint)
+}
+
+// TestReconcileSpendingReservationsNoOrphans verifies that when every Spending
+// VTXO is still claimed by a live session, nothing is released.
+func TestReconcileSpendingReservationsNoOrphans(t *testing.T) {
+	t.Parallel()
+
+	v1 := makeDescriptor(t, 10000, 0)
+	v2 := makeDescriptor(t, 20000, 1)
+
+	mgr, store := newSpendingTestManager(t, []*Descriptor{v1, v2})
+
+	store.On(
+		"ListVTXOsByStatus", mock.Anything, VTXOStatusSpending,
+	).Return([]*Descriptor{v1, v2}, nil)
+
+	result := mgr.Receive(t.Context(),
+		&ReconcileSpendingReservationsRequest{
+			ClaimedInputs: []wire.OutPoint{v1.Outpoint, v2.Outpoint},
+		},
+	)
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	reconcileResp := resp.(*ReconcileSpendingReservationsResponse)
+	require.Equal(t, 0, reconcileResp.ReleasedCount)
+	requireActorState[*SpendingState](t, mgr, v1.Outpoint)
+	requireActorState[*SpendingState](t, mgr, v2.Outpoint)
+}
+
+// TestReconcileSpendingReservationsEmptyClaimedReleasesAll verifies that with
+// no live sessions at all (empty claimed set), every Spending VTXO is treated
+// as an orphan and released. This is the full-starvation recovery case.
+func TestReconcileSpendingReservationsEmptyClaimedReleasesAll(t *testing.T) {
+	t.Parallel()
+
+	v1 := makeDescriptor(t, 10000, 0)
+	v2 := makeDescriptor(t, 20000, 1)
+
+	mgr, store := newSpendingTestManager(t, []*Descriptor{v1, v2})
+
+	store.On(
+		"ListVTXOsByStatus", mock.Anything, VTXOStatusSpending,
+	).Return([]*Descriptor{v1, v2}, nil)
+
+	result := mgr.Receive(t.Context(),
+		&ReconcileSpendingReservationsRequest{ClaimedInputs: nil},
+	)
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	reconcileResp := resp.(*ReconcileSpendingReservationsResponse)
+	require.Equal(t, 2, reconcileResp.ReleasedCount)
+	requireActorState[*LiveState](t, mgr, v1.Outpoint)
+	requireActorState[*LiveState](t, mgr, v2.Outpoint)
+}
+
+// TestOrphanedReservations covers the pure set-difference helper.
+func TestOrphanedReservations(t *testing.T) {
+	t.Parallel()
+
+	a := wire.OutPoint{Index: 1}
+	b := wire.OutPoint{Index: 2}
+	c := wire.OutPoint{Index: 3}
+	spending := []*Descriptor{{Outpoint: a}, {Outpoint: b}, {Outpoint: c}}
+
+	require.ElementsMatch(t, []wire.OutPoint{a, c},
+		orphanedReservations(spending, []wire.OutPoint{b}))
+
+	require.ElementsMatch(t, []wire.OutPoint{a, b, c},
+		orphanedReservations(spending, nil))
+
+	require.Empty(t, orphanedReservations(
+		spending, []wire.OutPoint{a, b, c},
+	))
+
+	require.Empty(t, orphanedReservations(nil, []wire.OutPoint{a}))
+}


### PR DESCRIPTION
In this PR, we fix #587: a VTXO reserved for an OOR spend can get stuck in
`SpendingState` (DB `status = 7`) forever. The reservation is meant to be
short-lived: the spend either completes the VTXO or emits `SpendReleasedEvent`
to free it. But if the spend dies without releasing (a crash, an abandoned
vHTLC-funding attempt), the reservation is orphaned. On restart the VTXO actor
reloads straight into `SpendingState` and only ever sees `BlockEpochEvent`s, so
nothing releases it, and the VTXO is unspendable until batch expiry forces an
on-chain unilateral exit. On signet this was the root of the out-swap liquidity
starvation: a 4,834,745 sat VTXO pinned in `Spending`, never coming back.

## Approach (option A): startup reconciliation against live OOR sessions

A VTXO only ever enters `SpendingState` through one path: the OOR send flow,
which reserves the selected VTXOs as inputs (`SelectAndReserveSpendRequest` ->
`SpendReserveEvent`). Round registration reserves via the *forfeit* path
(`PendingForfeit`/`Forfeiting`), a separate lifecycle, so it's out of scope
here. That means the complete set of legitimate `Spending` holders after a
restart is exactly the set of input outpoints held by live, resumable outgoing
OOR sessions. Anything in `Spending` that isn't in that set is an orphan.

So at startup, once the VTXO manager and the OOR subsystem have both recovered,
we run one reconcile pass:

- The server asks the OOR actor for the input outpoints of its live (pending)
  outgoing sessions via `ListSessionsRequest`, which the actor already supports.
  The OOR actor processes its prepended restart message before this Ask (the
  mailbox is FIFO), so its in-memory session set is fully restored from the
  durable checkpoint by the time we read it.
- The server hands that claimed set to the VTXO manager via
  `ReconcileSpendingReservationsRequest`. The manager reads the authoritative
  current `Spending` set from the store (not the Start-time snapshot, so a spend
  that resolved during recovery isn't mistaken for an orphan) and releases every
  Spending VTXO not in the claimed set, reusing the same `SpendReleasedEvent`
  path as a normal release.

Safety: if the OOR query fails we abort rather than release, since an incomplete
claimed set would free a VTXO a live spend still holds. The pass is non-fatal to
startup; a failure just leaves the VTXOs reserved until the next restart, same
as today.

The claimed set is gathered in the server and passed into the manager rather
than queried from inside the VTXO actor. The manager has no handle on the OOR
session store, and keeping the query in the server avoids a `vtxo -> oor` import
cycle.

## Why not option B (durable reservation index)

The more thorough fix is to make the reservation itself durable: persist
`(owner_id, input_outpoint)` atomically with the `-> Spending` transition,
delete it on release/complete, and on startup release any Spending VTXO whose
owner record is absent or resolves to a terminal/nonexistent owner. That closes
the gap deterministically instead of leaning on startup ordering, and it
generalizes cleanly to the forfeit path too.

We didn't take that here because it costs a schema migration plus write-path
hooks at every reserve/release/complete site, and option A already recovers the
stuck VTXOs using state we already persist (the OOR durable checkpoint plus the
VTXO status). Option B is the natural follow-up if we want crash-proof
reservation accounting across both the spend and forfeit paths. The keys are: a
`spending_reservations(owner_kind, owner_id, outpoint)` table, atomic
insert/delete on the status transitions, and a startup sweep that releases rows
with no live owner.

## Operator escape-hatch (pending)

The issue also asks for an operator CLI/RPC to force-release an orphaned
`Spending` reservation without waiting for the automatic pass. That needs a new
gRPC method, and proto generation in this repo is Docker-based (`make rpc` ->
`scripts/gen_protos_docker.sh`), which isn't available in my environment, so I
can't generate or verify the stubs here. With the automatic reconciliation in
place a restart already unsticks orphans, so this is a convenience rather than
the critical path. I'll fold it in once proto regen is available, or it can land
as a fast follow-up.

## Tests

`vtxo/reconcile_test.go` covers the manager handler.
`TestReconcileSpendingReservationsReleasesOrphans` builds three reserved VTXOs,
marks one as still claimed by a live session, and asserts the other two are
released back to Live while the claimed one is untouched.
`TestReconcileSpendingReservationsNoOrphans` confirms a fully-claimed set
releases nothing, and `TestReconcileSpendingReservationsEmptyClaimedReleasesAll`
covers the no-live-sessions case. `TestOrphanedReservations` exercises the pure
set-difference helper.

## Test plan

- [x] `go build ./vtxo/... ./darepod/... ./oor/... ./wallet/... ./round/...`
- [x] `go vet ./vtxo/ ./darepod/`
- [x] `go test ./vtxo/ -count=1`
- [x] `gofmt -l` clean on changed files
- [ ] operator escape-hatch CLI/RPC (blocked on proto regen, see above)
