### PR TITLE
swapwallet: key boarding deposits by outpoint

### DIFF
--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -108,10 +108,10 @@ default builds avoid the swap executor's dependency graph.
   stuck row appears as FAILED even when the caller asks for
   `pending_only=false`.
 - **DEPOSIT rows backed by the `wallet_utxo_created` ledger event**
-  are pinned to `ENTRY_STATUS_PENDING` even after chain confirmation
-  (`statusForLedgerRow`), because a boarding UTXO landing on-chain
-  is not yet a spendable VTXO. Promotion to COMPLETE waits for a
-  follow-up `boarded-into-round` ledger event (issue #503).
+  mirror the ledger confirmation status. Confirmed on-chain boarding
+  deposits surface as `ENTRY_STATUS_COMPLETE`, while unconfirmed
+  boarding funds are represented by the synthetic
+  `boarding-unconfirmed` pending row from `GetBalance`.
 - **`Balance` projection** maps daemonrpc fields onto the walletdkrpc
   shape: `confirmed_sat` is VTXO-only (`vtxo_balance_sat`),
   `pending_in_sat` sums `boarding_confirmed_sat +

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -108,10 +108,10 @@ default builds avoid the swap executor's dependency graph.
   stuck row appears as FAILED even when the caller asks for
   `pending_only=false`.
 - **DEPOSIT rows backed by the `wallet_utxo_created` ledger event**
-  are pinned to `ENTRY_STATUS_PENDING` even after chain confirmation
-  (`statusForLedgerRow`), because a boarding UTXO landing on-chain
-  is not yet a spendable VTXO. Promotion to COMPLETE waits for a
-  follow-up `boarded-into-round` ledger event (issue #503).
+  mirror the ledger confirmation status. Confirmed on-chain boarding
+  deposits surface as `ENTRY_STATUS_COMPLETE`, while unconfirmed
+  boarding funds are represented by the synthetic
+  `boarding-unconfirmed` pending row from `GetBalance`.
 - **`Balance` projection** maps daemonrpc fields onto the walletdkrpc
   shape: `confirmed_sat` is VTXO-only (`vtxo_balance_sat`),
   `pending_in_sat` sums `boarding_confirmed_sat +

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -800,7 +800,7 @@ func walletEntryFromLedgerRow(t *daemonrpc.TransactionHistoryEntry) (
 		return nil, false
 	}
 
-	id := t.GetTxid()
+	id := ledgerActivityID(t, kind)
 	if id == "" {
 		// Fall back to entry_id for ledger-backed rows so every
 		// WalletEntry has a stable id.
@@ -820,6 +820,26 @@ func walletEntryFromLedgerRow(t *daemonrpc.TransactionHistoryEntry) (
 		UpdatedAtUnix: t.GetCreatedAtUnixS(),
 		Progress:      progressFromLedgerRow(t),
 	}, true
+}
+
+// ledgerActivityID returns the stable activity id for one ledger-backed row.
+// Boarding UTXO creation rows are identified by outpoint, not bare txid, so a
+// single Bitcoin transaction that pays multiple wallet-owned outputs surfaces
+// every deposit instead of collapsing them during activity de-duplication.
+func ledgerActivityID(t *daemonrpc.TransactionHistoryEntry,
+	kind walletdkrpc.EntryKind) string {
+
+	if t == nil || t.GetTxid() == "" {
+		return ""
+	}
+
+	if kind == walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT &&
+		t.GetSubtype() == ledger.EventWalletUTXOCreated &&
+		t.GetOutputIndex() >= 0 {
+		return fmt.Sprintf("%s:%d", t.GetTxid(), t.GetOutputIndex())
+	}
+
+	return t.GetTxid()
 }
 
 // statusForLedgerRow folds the ledger row's confirmation_status into the

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -1235,6 +1235,75 @@ func TestHistoryDedupesByID(t *testing.T) {
 	)
 }
 
+// TestHistoryKeepsSameTransactionBoardingOutputs confirms duplicate boarding
+// deposits from the same Bitcoin transaction are keyed by outpoint before
+// activity de-duplication. A funding transaction can pay the same boarding
+// address in multiple outputs; all wallet-owned UTXOs must remain visible so
+// activity totals match the raw transaction history.
+func TestHistoryKeepsSameTransactionBoardingOutputs(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+
+	const (
+		sharedTxid = "18983d5d6f9c2dbf5166174777162f97797bed3e59d5f63b80a58833ea5391a0"
+		otherTxid  = "c4411b5d45230b71335dad7f5a20772985facf9634280dc263063b1f9b87f034"
+	)
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:               "boarding",
+				Subtype:            ledger.EventWalletUTXOCreated,
+				ConfirmationStatus: "confirmed",
+				AmountSat:          990_064,
+				Txid:               sharedTxid,
+				OutputIndex:        127,
+				EntryId:            1,
+				CreatedAtUnixS:     300,
+			},
+			{
+				Type:               "boarding",
+				Subtype:            ledger.EventWalletUTXOCreated,
+				ConfirmationStatus: "confirmed",
+				AmountSat:          990_064,
+				Txid:               sharedTxid,
+				OutputIndex:        23,
+				EntryId:            2,
+				CreatedAtUnixS:     200,
+			},
+			{
+				Type:               "boarding",
+				Subtype:            ledger.EventWalletUTXOCreated,
+				ConfirmationStatus: "confirmed",
+				AmountSat:          283_605,
+				Txid:               otherTxid,
+				OutputIndex:        0,
+				EntryId:            3,
+				CreatedAtUnixS:     100,
+			},
+		},
+	}
+
+	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{})
+	require.NoError(t, err)
+
+	entries := resp.GetActivity().GetEntries()
+	require.Len(t, entries, 3)
+
+	amountsByID := make(map[string]int64, len(entries))
+	var total int64
+	for _, entry := range entries {
+		amountsByID[entry.GetId()] = entry.GetAmountSat()
+		total += entry.GetAmountSat()
+	}
+
+	require.Equal(t, int64(2_263_733), total)
+	require.Equal(t, int64(990_064), amountsByID[sharedTxid+":127"])
+	require.Equal(t, int64(990_064), amountsByID[sharedTxid+":23"])
+	require.Equal(t, int64(283_605), amountsByID[otherTxid+":0"])
+}
+
 // TestHistoryPaginationOffsetPlumbedToLedger confirms that requesting
 // page 2 (offset>=limit) of wallet history returns the expected ledger
 // rows. Prior to the fix, collectLedgerEntries passed only Limit (not

--- a/swapwallet/inspection.go
+++ b/swapwallet/inspection.go
@@ -271,6 +271,13 @@ func ledgerRowMatchesEntry(row *daemonrpc.TransactionHistoryEntry,
 		return false
 	}
 
+	if kind, _, ok := classifyLedgerRow(row); ok {
+		id := ledgerActivityID(row, kind)
+		if id != "" && id == entry.GetId() {
+			return true
+		}
+	}
+
 	if row.GetTxid() != "" && row.GetTxid() == entry.GetId() {
 		return true
 	}

--- a/swapwallet/inspection_test.go
+++ b/swapwallet/inspection_test.go
@@ -153,7 +153,7 @@ func TestInspectActivityOmitsIrrelevantNotes(t *testing.T) {
 
 	resp, err := inspection.InspectActivity(
 		t.Context(), &walletdkrpc.InspectActivityRequest{
-			Id: "deposit-txid",
+			Id: "deposit-txid:1",
 		},
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Fixes #566.

`activity` previously keyed ledger-backed deposit rows by bare txid. When one Bitcoin transaction paid the boarding address more than once, both `wallet_utxo_created` rows normalized to the same `WalletEntry.id`, and the activity merger's `dedupeByID` pass kept only one of them.

This changes confirmed boarding UTXO activity ids to the concrete outpoint form `txid:vout`. The raw transaction id still remains in `entry.progress.txid`, but the activity row id is now unique per wallet-owned output, so same-transaction deposits are no longer dropped.

Inspection matching was updated to understand the same outpoint-shaped id.

## Validation

- `go test -tags="walletdkrpc swapruntime nolog" ./swapwallet -run 'TestHistory(KeepsSameTransactionBoardingOutputs|DedupesByID|DepositCompletesOnChainConfirmation)|TestInspectActivityOmitsIrrelevantNotes'`
- `go test -tags="walletdkrpc swapruntime nolog" ./swapwallet`
- `git diff --check`
- `make lint-changed-local`
- `make fmt-changed-check`
- `make commitmsg-lint range="origin/main..HEAD"`
