### PR TITLE
oor: Fix completed transfer activity

### DIFF
--- a/darepod/rpc_operation_status.go
+++ b/darepod/rpc_operation_status.go
@@ -148,15 +148,14 @@ func (r *RPCServer) listOORSessions(ctx context.Context,
 	req *daemonrpc.ListOORSessionsRequest) ([]*daemonrpc.OORSessionInfo,
 	error) {
 
-	merged := make(map[string]*daemonrpc.OORSessionInfo)
-
-	live, err := r.queryOORSessionSummaries(ctx, req)
-	if err != nil {
-		return nil, err
+	if req == nil {
+		req = &daemonrpc.ListOORSessionsRequest{}
 	}
 
-	for _, session := range live {
-		merged[session.GetSessionId()] = session
+	allReq := &daemonrpc.ListOORSessionsRequest{}
+	live, err := r.queryOORSessionSummaries(ctx, allReq)
+	if err != nil {
+		return nil, err
 	}
 
 	persisted, err := r.queryPersistedOORSessions(ctx, req)
@@ -164,7 +163,33 @@ func (r *RPCServer) listOORSessions(ctx context.Context,
 		return nil, err
 	}
 
+	if shouldQueryPersistedOORLiveOverlay(req) {
+		overlay, err := r.queryPersistedOORSessionsForLive(ctx, live)
+		if err != nil {
+			return nil, err
+		}
+
+		persisted = append(persisted, overlay...)
+	}
+
+	return mergeOORSessionLists(live, persisted, req), nil
+}
+
+// mergeOORSessionLists combines actor and package-store views for OOR status.
+func mergeOORSessionLists(live, persisted []*daemonrpc.OORSessionInfo,
+	req *daemonrpc.ListOORSessionsRequest) []*daemonrpc.OORSessionInfo {
+
+	if req == nil {
+		req = &daemonrpc.ListOORSessionsRequest{}
+	}
+
+	merged := make(map[string]*daemonrpc.OORSessionInfo)
+
 	for _, session := range persisted {
+		merged[session.GetSessionId()] = session
+	}
+
+	for _, session := range live {
 		if existing, ok := merged[session.GetSessionId()]; ok {
 			mergeOORSessionInfo(existing, session)
 			continue
@@ -175,6 +200,10 @@ func (r *RPCServer) listOORSessions(ctx context.Context,
 
 	sessions := make([]*daemonrpc.OORSessionInfo, 0, len(merged))
 	for _, session := range merged {
+		if !oorSessionMatchesFilters(session, req) {
+			continue
+		}
+
 		sessions = append(sessions, session)
 	}
 
@@ -182,7 +211,7 @@ func (r *RPCServer) listOORSessions(ctx context.Context,
 		return sessions[i].GetSessionId() < sessions[j].GetSessionId()
 	})
 
-	return sessions, nil
+	return sessions
 }
 
 // mergeOORSessionInfo fills artifact-backed fields missing from live state.
@@ -271,8 +300,7 @@ func (r *RPCServer) queryPersistedOORSessions(ctx context.Context,
 	req *daemonrpc.ListOORSessionsRequest) ([]*daemonrpc.OORSessionInfo,
 	error) {
 
-	if req.GetStatusFilter() ==
-		daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_PENDING {
+	if !shouldListPersistedOORPackages(req) {
 		return nil, nil
 	}
 
@@ -299,6 +327,87 @@ func (r *RPCServer) queryPersistedOORSessions(ctx context.Context,
 	}
 
 	return out, nil
+}
+
+// queryPersistedOORSessionsForLive fetches persisted package entries only for
+// live actor sessions. This preserves artifact-backed corrections for filtered
+// list calls without forcing every pending or failed query to materialize the
+// full package store.
+func (r *RPCServer) queryPersistedOORSessionsForLive(ctx context.Context,
+	live []*daemonrpc.OORSessionInfo) ([]*daemonrpc.OORSessionInfo, error) {
+
+	if len(live) == 0 {
+		return nil, nil
+	}
+
+	store := r.newLocalOORArtifactStore()
+	if store == nil {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{}, len(live))
+	out := make([]*daemonrpc.OORSessionInfo, 0, len(live))
+	for _, session := range live {
+		sessionID := session.GetSessionId()
+		if _, ok := seen[sessionID]; ok {
+			continue
+		}
+		seen[sessionID] = struct{}{}
+
+		hash, err := parseOORSessionID(sessionID)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "parse live "+
+				"OOR session id: %v", err)
+		}
+
+		pkg, err := store.GetPackage(ctx, hash)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to "+
+				"get persisted OOR package: %v", err)
+		}
+
+		out = append(out, oorPackageToProto(pkg))
+	}
+
+	return out, nil
+}
+
+// shouldListPersistedOORPackages reports whether a list request can include
+// completed package entries from a bounded store scan.
+func shouldListPersistedOORPackages(
+	req *daemonrpc.ListOORSessionsRequest) bool {
+
+	switch req.GetStatusFilter() {
+	case daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_PENDING,
+		daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_FAILED:
+		return false
+
+	default:
+		return true
+	}
+}
+
+// shouldQueryPersistedOORLiveOverlay reports whether live summaries need
+// targeted package lookups before final filter evaluation.
+func shouldQueryPersistedOORLiveOverlay(
+	req *daemonrpc.ListOORSessionsRequest) bool {
+
+	if req.GetDirectionFilter() != daemonrpc.
+		OORSessionDirection_OOR_SESSION_DIRECTION_UNSPECIFIED {
+		return true
+	}
+
+	switch req.GetStatusFilter() {
+	case daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_PENDING,
+		daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_FAILED:
+		return true
+
+	default:
+		return false
+	}
 }
 
 // roundSummaryToProto converts one persisted round summary to daemonrpc.

--- a/darepod/rpc_operation_status_test.go
+++ b/darepod/rpc_operation_status_test.go
@@ -78,6 +78,148 @@ func TestOORSessionMatchesFilters(t *testing.T) {
 	)
 }
 
+// TestMergeOORSessionListsPrefersPersistedDirection verifies that completed
+// package artifacts are the user-facing authority when a sender later observes
+// its own OOR change output as an incoming live actor session.
+func TestMergeOORSessionListsPrefersPersistedDirection(t *testing.T) {
+	t.Parallel()
+
+	outgoing := daemonrpc.
+		OORSessionDirection_OOR_SESSION_DIRECTION_OUTGOING
+	incoming := daemonrpc.
+		OORSessionDirection_OOR_SESSION_DIRECTION_INCOMING
+	pending := daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_PENDING
+	completed := daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_COMPLETED
+
+	live := []*daemonrpc.OORSessionInfo{
+		{
+			SessionId: "session-a",
+			Direction: incoming,
+			Status:    pending,
+		},
+	}
+	persisted := []*daemonrpc.OORSessionInfo{
+		{
+			SessionId: "session-a",
+			Direction: outgoing,
+			Status:    completed,
+			Phase:     "completed",
+			ConsumedOutpoints: []string{
+				"input:0",
+			},
+		},
+	}
+
+	all := mergeOORSessionLists(
+		live, persisted, &daemonrpc.ListOORSessionsRequest{},
+	)
+	require.Len(t, all, 1)
+	require.Equal(t, outgoing, all[0].GetDirection())
+	require.Equal(t, completed, all[0].GetStatus())
+	require.Equal(t, "completed", all[0].GetPhase())
+	require.Equal(t, []string{"input:0"}, all[0].GetConsumedOutpoints())
+
+	outgoingOnly := mergeOORSessionLists(
+		live, persisted, &daemonrpc.ListOORSessionsRequest{
+			DirectionFilter: outgoing,
+		},
+	)
+	require.Len(t, outgoingOnly, 1)
+
+	incomingOnly := mergeOORSessionLists(
+		live, persisted, &daemonrpc.ListOORSessionsRequest{
+			DirectionFilter: incoming,
+		},
+	)
+	require.Empty(t, incomingOnly)
+
+	pendingOnly := mergeOORSessionLists(
+		live, persisted, &daemonrpc.ListOORSessionsRequest{
+			StatusFilter: pending,
+		},
+	)
+	require.Empty(t, pendingOnly)
+}
+
+// TestPersistedOORPackageQueryPlanning verifies filtered OOR list requests
+// only perform package-store scans when completed artifacts can be returned.
+func TestPersistedOORPackageQueryPlanning(t *testing.T) {
+	t.Parallel()
+
+	pending := daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_PENDING
+	failed := daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_FAILED
+	completed := daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_COMPLETED
+	incoming := daemonrpc.
+		OORSessionDirection_OOR_SESSION_DIRECTION_INCOMING
+
+	tests := []struct {
+		name        string
+		req         *daemonrpc.ListOORSessionsRequest
+		wantList    bool
+		wantOverlay bool
+	}{
+		{
+			name:     "unfiltered",
+			req:      &daemonrpc.ListOORSessionsRequest{},
+			wantList: true,
+		},
+		{
+			name: "completed",
+			req: &daemonrpc.ListOORSessionsRequest{
+				StatusFilter: completed,
+			},
+			wantList: true,
+		},
+		{
+			name: "pending",
+			req: &daemonrpc.ListOORSessionsRequest{
+				StatusFilter: pending,
+			},
+			wantOverlay: true,
+		},
+		{
+			name: "failed",
+			req: &daemonrpc.ListOORSessionsRequest{
+				StatusFilter: failed,
+			},
+			wantOverlay: true,
+		},
+		{
+			name: "direction",
+			req: &daemonrpc.ListOORSessionsRequest{
+				DirectionFilter: incoming,
+			},
+			wantList:    true,
+			wantOverlay: true,
+		},
+		{
+			name: "completed direction",
+			req: &daemonrpc.ListOORSessionsRequest{
+				DirectionFilter: incoming,
+				StatusFilter:    completed,
+			},
+			wantList:    true,
+			wantOverlay: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(
+				t, test.wantList,
+				shouldListPersistedOORPackages(test.req),
+			)
+			require.Equal(
+				t, test.wantOverlay,
+				shouldQueryPersistedOORLiveOverlay(test.req),
+			)
+		})
+	}
+}
+
 // TestParseOORSessionIDNormalizesCase verifies uppercase session ids are
 // accepted and normalized to the canonical chainhash string form.
 func TestParseOORSessionIDNormalizesCase(t *testing.T) {

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -383,10 +383,12 @@ func (h *history) collectLedgerEntries(ctx context.Context, offset,
 		return nil, err
 	}
 
-	hidden := internalOORLedgerEntries(resp.GetTransactions(), correlations)
+	oorProjection := projectOORLedgerActivity(
+		resp.GetTransactions(), correlations,
+	)
 	out := make([]*walletdkrpc.WalletEntry, 0, len(resp.GetTransactions()))
 	for _, t := range resp.GetTransactions() {
-		if _, ok := hidden[t.GetEntryId()]; ok {
+		if _, ok := oorProjection.hidden[t.GetEntryId()]; ok {
 			continue
 		}
 
@@ -394,6 +396,11 @@ func (h *history) collectLedgerEntries(ctx context.Context, offset,
 		if !ok {
 			continue
 		}
+		entryID := t.GetEntryId()
+		if amount, ok := oorProjection.displayAmountByEntryID[entryID]; ok {
+			entry.AmountSat = amount
+		}
+
 		// v1 SCOPE: EXIT and DEPOSIT ledger rows carry txid but no
 		// link back to the original pending intent, so they
 		// surface under their synthetic id (the ledger txid or
@@ -458,13 +465,25 @@ func swapOORCorrelationsFromSwaps(
 	return out
 }
 
+type oorLedgerActivityProjection struct {
+	hidden                 map[int64]struct{}
+	displayAmountByEntryID map[int64]int64
+}
+
 // internalOORLedgerEntries returns ledger entry IDs for OOR legs that are
-// internal to swap execution or represent wallet-local OOR change. Send legs
-// are hidden only when structured swap metadata proves the external payment
-// amount. Receive legs paired with a send in the same session are change and
-// stay out of activity list noise; inspection still exposes the ledger rows.
+// internal to swap execution or represent wallet-local OOR change. Inspection
+// uses this compact view because it only needs to mark hidden rows.
 func internalOORLedgerEntries(rows []*daemonrpc.TransactionHistoryEntry,
 	correlations swapOORCorrelations) map[int64]struct{} {
+
+	return projectOORLedgerActivity(rows, correlations).hidden
+}
+
+// projectOORLedgerActivity returns the wallet-facing projection for OOR ledger
+// rows. Accounting rows stay gross; this helper only hides internal rows and
+// computes display amounts for activity.
+func projectOORLedgerActivity(rows []*daemonrpc.TransactionHistoryEntry,
+	correlations swapOORCorrelations) oorLedgerActivityProjection {
 
 	receivedBySession := make(map[string]int64)
 	receiveRowsBySession := make(
@@ -490,7 +509,10 @@ func internalOORLedgerEntries(rows []*daemonrpc.TransactionHistoryEntry,
 		}
 	}
 
-	hidden := make(map[int64]struct{})
+	projection := oorLedgerActivityProjection{
+		hidden:                 make(map[int64]struct{}),
+		displayAmountByEntryID: make(map[int64]int64),
+	}
 	for _, row := range rows {
 		session, ok := oorSendSessionID(row)
 		if !ok {
@@ -503,7 +525,7 @@ func internalOORLedgerEntries(rows []*daemonrpc.TransactionHistoryEntry,
 		}
 
 		for _, receiveRow := range receiveRowsBySession[session] {
-			hidden[receiveRow.GetEntryId()] = struct{}{}
+			projection.hidden[receiveRow.GetEntryId()] = struct{}{}
 		}
 
 		switch delta := row.GetAmountSat() - received; {
@@ -511,19 +533,22 @@ func internalOORLedgerEntries(rows []*daemonrpc.TransactionHistoryEntry,
 			correlations, claimOutputSessions, session,
 		):
 
-			hidden[row.GetEntryId()] = struct{}{}
+			projection.hidden[row.GetEntryId()] = struct{}{}
 
 		case delta > 0:
 			amounts := correlations.payAmountsByFundingSession[session]
-			if amounts[delta] == 0 {
+			if amounts == nil || amounts[delta] == 0 {
+				projection.displayAmountByEntryID[row.GetEntryId()] =
+					-delta
+
 				continue
 			}
-			hidden[row.GetEntryId()] = struct{}{}
+			projection.hidden[row.GetEntryId()] = struct{}{}
 			amounts[delta]--
 		}
 	}
 
-	return hidden
+	return projection
 }
 
 // internalZeroDeltaSession reports whether a balanced same-session OOR
@@ -829,6 +854,10 @@ func walletEntryFromLedgerRow(t *daemonrpc.TransactionHistoryEntry) (
 func statusForLedgerRow(
 	t *daemonrpc.TransactionHistoryEntry) walletdkrpc.EntryStatus {
 
+	if t.GetType() == "oor" && t.GetConfirmationStatus() == "recorded" {
+		return walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE
+	}
+
 	return statusFromLedgerConfirmation(t.GetConfirmationStatus())
 }
 
@@ -842,6 +871,10 @@ func progressFromLedgerRow(
 	}
 
 	phase, label := phaseFromLedgerConfirmation(t.GetConfirmationStatus())
+	if t.GetType() == "oor" && t.GetConfirmationStatus() == "recorded" {
+		phase = walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_CONFIRMED
+		label = "confirmed"
+	}
 
 	return &walletdkrpc.WalletEntryProgress{
 		Phase:              phase,

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -492,25 +492,27 @@ func TestHistoryHidesPayFundingOORInput(t *testing.T) {
 	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
 		Transactions: []*daemonrpc.TransactionHistoryEntry{
 			{
-				Type:           "oor",
-				Subtype:        ledger.EventVTXOSent,
-				AmountSat:      999_745,
-				DebitAccount:   ledger.AccountTransfersOut,
-				CreditAccount:  ledger.AccountVTXOBalance,
-				SessionId:      sessionID,
-				EntryId:        13,
-				CreatedAtUnixS: 100,
+				Type:               "oor",
+				Subtype:            ledger.EventVTXOSent,
+				ConfirmationStatus: "recorded",
+				AmountSat:          999_745,
+				DebitAccount:       ledger.AccountTransfersOut,
+				CreditAccount:      ledger.AccountVTXOBalance,
+				SessionId:          sessionID,
+				EntryId:            13,
+				CreatedAtUnixS:     100,
 			},
 			{
-				Type:           "oor",
-				Subtype:        ledger.EventVTXOReceived,
-				AmountSat:      998_511,
-				DebitAccount:   ledger.AccountVTXOBalance,
-				CreditAccount:  ledger.AccountTransfersIn,
-				Txid:           sessionHex,
-				OutputIndex:    1,
-				EntryId:        14,
-				CreatedAtUnixS: 101,
+				Type:               "oor",
+				Subtype:            ledger.EventVTXOReceived,
+				ConfirmationStatus: "recorded",
+				AmountSat:          998_511,
+				DebitAccount:       ledger.AccountVTXOBalance,
+				CreditAccount:      ledger.AccountTransfersIn,
+				Txid:               sessionHex,
+				OutputIndex:        1,
+				EntryId:            14,
+				CreatedAtUnixS:     101,
 			},
 		},
 	}
@@ -696,7 +698,8 @@ func TestHistoryPendingFilterKeepsTerminalSwapCorrelations(t *testing.T) {
 }
 
 // TestHistoryKeepsSameAmountUnmatchedFundingInput confirms pay-swap funding
-// legs are hidden by funding session, not by amount alone.
+// legs are hidden by funding session, not by amount alone. The unrelated raw
+// OOR send remains visible with its net external-send amount.
 func TestHistoryKeepsSameAmountUnmatchedFundingInput(t *testing.T) {
 	t.Parallel()
 
@@ -772,7 +775,7 @@ func TestHistoryKeepsSameAmountUnmatchedFundingInput(t *testing.T) {
 	require.Len(t, entries, 2)
 	require.Equal(t, "payment-hash", entries[0].GetId())
 	require.Equal(t, "ledger-15", entries[1].GetId())
-	require.Equal(t, int64(-999_745), entries[1].GetAmountSat())
+	require.Equal(t, int64(-1_234), entries[1].GetAmountSat())
 }
 
 // TestHistoryKeepsOORSendWithChangeWithoutSwap confirms the change-pairing
@@ -790,25 +793,27 @@ func TestHistoryKeepsOORSendWithChangeWithoutSwap(t *testing.T) {
 	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
 		Transactions: []*daemonrpc.TransactionHistoryEntry{
 			{
-				Type:           "oor",
-				Subtype:        ledger.EventVTXOSent,
-				AmountSat:      999_745,
-				DebitAccount:   ledger.AccountTransfersOut,
-				CreditAccount:  ledger.AccountVTXOBalance,
-				SessionId:      sessionID,
-				EntryId:        13,
-				CreatedAtUnixS: 100,
+				Type:               "oor",
+				Subtype:            ledger.EventVTXOSent,
+				ConfirmationStatus: "recorded",
+				AmountSat:          999_745,
+				DebitAccount:       ledger.AccountTransfersOut,
+				CreditAccount:      ledger.AccountVTXOBalance,
+				SessionId:          sessionID,
+				EntryId:            13,
+				CreatedAtUnixS:     100,
 			},
 			{
-				Type:           "oor",
-				Subtype:        ledger.EventVTXOReceived,
-				AmountSat:      998_511,
-				DebitAccount:   ledger.AccountVTXOBalance,
-				CreditAccount:  ledger.AccountTransfersIn,
-				Txid:           sessionHex,
-				OutputIndex:    1,
-				EntryId:        14,
-				CreatedAtUnixS: 101,
+				Type:               "oor",
+				Subtype:            ledger.EventVTXOReceived,
+				ConfirmationStatus: "recorded",
+				AmountSat:          998_511,
+				DebitAccount:       ledger.AccountVTXOBalance,
+				CreditAccount:      ledger.AccountTransfersIn,
+				Txid:               sessionHex,
+				OutputIndex:        1,
+				EntryId:            14,
+				CreatedAtUnixS:     101,
 			},
 		},
 	}
@@ -821,7 +826,11 @@ func TestHistoryKeepsOORSendWithChangeWithoutSwap(t *testing.T) {
 	require.Equal(
 		t, walletdkrpc.EntryKind_ENTRY_KIND_SEND, entries[0].GetKind(),
 	)
-	require.Equal(t, int64(-999_745), entries[0].GetAmountSat())
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		entries[0].GetStatus(),
+	)
+	require.Equal(t, int64(-1_234), entries[0].GetAmountSat())
 }
 
 // TestHistoryKeepsZeroDeltaOORSendWithoutSwap covers a balanced OOR session
@@ -843,25 +852,27 @@ func TestHistoryKeepsZeroDeltaOORSendWithoutSwap(t *testing.T) {
 	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
 		Transactions: []*daemonrpc.TransactionHistoryEntry{
 			{
-				Type:           "oor",
-				Subtype:        ledger.EventVTXOSent,
-				AmountSat:      1_000,
-				DebitAccount:   ledger.AccountTransfersOut,
-				CreditAccount:  ledger.AccountVTXOBalance,
-				SessionId:      sessionID,
-				EntryId:        31,
-				CreatedAtUnixS: 100,
+				Type:               "oor",
+				Subtype:            ledger.EventVTXOSent,
+				ConfirmationStatus: "recorded",
+				AmountSat:          1_000,
+				DebitAccount:       ledger.AccountTransfersOut,
+				CreditAccount:      ledger.AccountVTXOBalance,
+				SessionId:          sessionID,
+				EntryId:            31,
+				CreatedAtUnixS:     100,
 			},
 			{
-				Type:           "oor",
-				Subtype:        ledger.EventVTXOReceived,
-				AmountSat:      1_000,
-				DebitAccount:   ledger.AccountVTXOBalance,
-				CreditAccount:  ledger.AccountTransfersIn,
-				Txid:           sessionHex,
-				OutputIndex:    0,
-				EntryId:        32,
-				CreatedAtUnixS: 101,
+				Type:               "oor",
+				Subtype:            ledger.EventVTXOReceived,
+				ConfirmationStatus: "recorded",
+				AmountSat:          1_000,
+				DebitAccount:       ledger.AccountVTXOBalance,
+				CreditAccount:      ledger.AccountTransfersIn,
+				Txid:               sessionHex,
+				OutputIndex:        0,
+				EntryId:            32,
+				CreatedAtUnixS:     101,
 			},
 		},
 	}
@@ -875,7 +886,54 @@ func TestHistoryKeepsZeroDeltaOORSendWithoutSwap(t *testing.T) {
 	require.Equal(
 		t, walletdkrpc.EntryKind_ENTRY_KIND_SEND, entries[0].GetKind(),
 	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		entries[0].GetStatus(),
+	)
 	require.Equal(t, int64(-1_000), entries[0].GetAmountSat())
+}
+
+// TestHistoryCompletesRecordedOORReceive confirms materialized OOR receive
+// rows are terminal in the user-facing wallet activity stream. The ledger uses
+// "recorded" for durable local accounting rows, but an OOR receive row only
+// appears after the VTXO is live in the wallet.
+func TestHistoryCompletesRecordedOORReceive(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:               "oor",
+				Subtype:            ledger.EventVTXOReceived,
+				ConfirmationStatus: "recorded",
+				AmountSat:          7_000,
+				Txid:               "oor-recv-txid",
+				CreatedAtUnixS:     100,
+				DebitAccount:       ledger.AccountVTXOBalance,
+				CreditAccount:      ledger.AccountTransfersIn,
+			},
+		},
+	}
+
+	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{})
+	require.NoError(t, err)
+
+	entries := resp.GetActivity().GetEntries()
+	require.Len(t, entries, 1)
+	require.Equal(
+		t, walletdkrpc.EntryKind_ENTRY_KIND_RECV, entries[0].GetKind(),
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		entries[0].GetStatus(),
+	)
+	require.Equal(t, int64(7_000), entries[0].GetAmountSat())
+	require.Equal(
+		t, walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_CONFIRMED,
+		entries[0].GetProgress().GetPhase(),
+	)
 }
 
 // TestHistoryPendingFilterIncludesPendingBoarding confirms --pending includes


### PR DESCRIPTION
## Summary

- prefer persisted completed OOR package artifacts over live self-change summaries when listing sessions
- project recorded OOR ledger rows as complete in wallet activity
- show raw OOR sends with wallet-owned change as the net external-send amount

Fixes #569.

## Test Plan

- go test -tags='dev walletdkrpc swapruntime nolog' ./swapwallet ./darepod -timeout=5m
- go test -tags='dev nolog' ./oor ./ledger -run 'TestEmitVTXO|TestHandleVTXO' -timeout=5m
- make lint-changed-local
- git diff --check
