### PR TITLE
darepod: fix OOR pubkey fixture width

### DIFF
--- a/darepod/rpc_oor_custom_input_test.go
+++ b/darepod/rpc_oor_custom_input_test.go
@@ -98,7 +98,9 @@ func newCustomOORRPCFixture(t *testing.T) *customOORRPCFixture {
 		recipient: &daemonrpc.Output{
 			AmountSat: 42_000,
 			Destination: &daemonrpc.Output_Pubkey{
-				Pubkey: receiverPriv.PubKey().X().Bytes(),
+				Pubkey: schnorr.SerializePubKey(
+					receiverPriv.PubKey(),
+				),
 			},
 		},
 		claimPath:  claimPath,


### PR DESCRIPTION
## Summary

- serialize the custom OOR RPC test recipient key with the fixed-width Schnorr x-only encoder
- prevent the fixture from occasionally passing a 31-byte pubkey when a generated x-coordinate has a leading zero

Fixes #592.

## Testing

- `go test -tags="walletdkrpc swapruntime nolog" ./darepod -run TestPrepareOORCustomInputMapsPreparedInput -count=100`
- `go test -tags="walletdkrpc swapruntime nolog" ./darepod -run 'TestPrepareOORCustomInputMapsPreparedInput|TestSignOORCustomInputMapsSignatureAndErrorCodes' -count=1`
- `make lint-changed-local`
- `make fmt-changed-check`
- `make commitmsg-lint range="origin/main..HEAD"`
