### PR TITLE
daemonrpc+darepod: ReleaseSpendingVTXO operator RPC + CLI

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_vtxos.go
+++ b/cmd/darepocli/darepoclicommands/cmd_vtxos.go
@@ -24,9 +24,55 @@ func newVTXOsCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		newVTXOsListCmd(), newVTXOsRefreshCmd(), newVTXOsLeaveCmd(),
+		newVTXOsReleaseSpendingCmd(),
 	)
 
 	return cmd
+}
+
+// newVTXOsReleaseSpendingCmd creates the vtxos release-spending
+// subcommand. It is an operator escape-hatch that force-releases a VTXO
+// stuck in spending state (an orphaned spend reservation) back to Live;
+// the daemon rejects the call if the VTXO is not actually spending.
+func newVTXOsReleaseSpendingCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "release-spending [outpoint]",
+		Short: "Force-release a VTXO stuck in spending state",
+		Long: "Operator escape-hatch for a VTXO whose spend " +
+			"reservation was orphaned (the owning spend died " +
+			"without releasing it). Releases the outpoint " +
+			"(txid:index) back to Live. The daemon rejects the " +
+			"call unless the VTXO is currently in spending " +
+			"state.\n\n" +
+			"Example:\n" +
+			"  darepocli ark vtxos release-spending TXID:VOUT",
+		Args: cobra.ExactArgs(1),
+		RunE: vtxosReleaseSpending,
+	}
+}
+
+// vtxosReleaseSpending executes the ReleaseSpendingVTXO RPC.
+func vtxosReleaseSpending(cmd *cobra.Command, args []string) error {
+	if err := validateOutpointString(args[0]); err != nil {
+		return PrintError("INVALID_ARGS", err.Error())
+	}
+
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	resp, err := client.ReleaseSpendingVTXO(
+		cmd.Context(), &daemonrpc.ReleaseSpendingVTXORequest{
+			Outpoint: args[0],
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("ReleaseSpendingVTXO RPC failed: %w", err)
+	}
+
+	return printJSON(resp)
 }
 
 // validStatuses lists the valid VTXO status filter values for input

--- a/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
@@ -288,6 +288,13 @@ func generatedRegistry() []serviceSpec {
 					Output:   "daemonrpc.ListVHTLCRecoveriesResponse",
 					Comments: "ListVHTLCRecoveries returns all durable recovery rows for operator\ninspection. Armed rows are dormant; callers must use\nEscalateVHTLCRecovery to start costly on-chain recovery.",
 				},
+				{
+					Name:     "ReleaseSpendingVTXO",
+					Aliases:  []string{"release-spending-vtxo"},
+					Input:    "daemonrpc.ReleaseSpendingVTXORequest",
+					Output:   "daemonrpc.ReleaseSpendingVTXOResponse",
+					Comments: "ReleaseSpendingVTXO force-releases a VTXO stuck in SpendingState back to\nLive. This is an operator escape-hatch for an orphaned spend reservation\n(issue #587) whose owning spend died without releasing it; normal clients\nnever need it. The release is rejected if the VTXO is not currently in\nSpendingState.",
+				},
 			},
 		},
 		{

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -6542,6 +6542,96 @@ func (x *UnrollResponse) GetActorId() string {
 	return ""
 }
 
+type ReleaseSpendingVTXORequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// outpoint is the VTXO outpoint to release, formatted as "txid:index".
+	Outpoint      string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReleaseSpendingVTXORequest) Reset() {
+	*x = ReleaseSpendingVTXORequest{}
+	mi := &file_daemon_proto_msgTypes[82]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReleaseSpendingVTXORequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReleaseSpendingVTXORequest) ProtoMessage() {}
+
+func (x *ReleaseSpendingVTXORequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[82]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReleaseSpendingVTXORequest.ProtoReflect.Descriptor instead.
+func (*ReleaseSpendingVTXORequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{82}
+}
+
+func (x *ReleaseSpendingVTXORequest) GetOutpoint() string {
+	if x != nil {
+		return x.Outpoint
+	}
+	return ""
+}
+
+type ReleaseSpendingVTXOResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// released is true if the reservation was released back to Live.
+	Released      bool `protobuf:"varint,1,opt,name=released,proto3" json:"released,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReleaseSpendingVTXOResponse) Reset() {
+	*x = ReleaseSpendingVTXOResponse{}
+	mi := &file_daemon_proto_msgTypes[83]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReleaseSpendingVTXOResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReleaseSpendingVTXOResponse) ProtoMessage() {}
+
+func (x *ReleaseSpendingVTXOResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[83]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReleaseSpendingVTXOResponse.ProtoReflect.Descriptor instead.
+func (*ReleaseSpendingVTXOResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{83}
+}
+
+func (x *ReleaseSpendingVTXOResponse) GetReleased() bool {
+	if x != nil {
+		return x.Released
+	}
+	return false
+}
+
 type GetUnrollStatusRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// outpoint is the VTXO outpoint to query, formatted as "txid:index".
@@ -6552,7 +6642,7 @@ type GetUnrollStatusRequest struct {
 
 func (x *GetUnrollStatusRequest) Reset() {
 	*x = GetUnrollStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[82]
+	mi := &file_daemon_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6564,7 +6654,7 @@ func (x *GetUnrollStatusRequest) String() string {
 func (*GetUnrollStatusRequest) ProtoMessage() {}
 
 func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[82]
+	mi := &file_daemon_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6577,7 +6667,7 @@ func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{82}
+	return file_daemon_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *GetUnrollStatusRequest) GetOutpoint() string {
@@ -6605,7 +6695,7 @@ type GetUnrollStatusResponse struct {
 
 func (x *GetUnrollStatusResponse) Reset() {
 	*x = GetUnrollStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[83]
+	mi := &file_daemon_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6617,7 +6707,7 @@ func (x *GetUnrollStatusResponse) String() string {
 func (*GetUnrollStatusResponse) ProtoMessage() {}
 
 func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[83]
+	mi := &file_daemon_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6630,7 +6720,7 @@ func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{83}
+	return file_daemon_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *GetUnrollStatusResponse) GetFound() bool {
@@ -6712,7 +6802,7 @@ type ArmVHTLCRecoveryRequest struct {
 
 func (x *ArmVHTLCRecoveryRequest) Reset() {
 	*x = ArmVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[84]
+	mi := &file_daemon_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6724,7 +6814,7 @@ func (x *ArmVHTLCRecoveryRequest) String() string {
 func (*ArmVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[84]
+	mi := &file_daemon_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6737,7 +6827,7 @@ func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{84}
+	return file_daemon_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *ArmVHTLCRecoveryRequest) GetRequestId() string {
@@ -6880,7 +6970,7 @@ type ArmVHTLCRecoveryResponse struct {
 
 func (x *ArmVHTLCRecoveryResponse) Reset() {
 	*x = ArmVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[85]
+	mi := &file_daemon_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6892,7 +6982,7 @@ func (x *ArmVHTLCRecoveryResponse) String() string {
 func (*ArmVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[85]
+	mi := &file_daemon_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6905,7 +6995,7 @@ func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{85}
+	return file_daemon_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *ArmVHTLCRecoveryResponse) GetRecoveryId() string {
@@ -6945,7 +7035,7 @@ type EscalateVHTLCRecoveryRequest struct {
 
 func (x *EscalateVHTLCRecoveryRequest) Reset() {
 	*x = EscalateVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[86]
+	mi := &file_daemon_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6957,7 +7047,7 @@ func (x *EscalateVHTLCRecoveryRequest) String() string {
 func (*EscalateVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[86]
+	mi := &file_daemon_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6970,7 +7060,7 @@ func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{86}
+	return file_daemon_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *EscalateVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -7004,7 +7094,7 @@ type EscalateVHTLCRecoveryResponse struct {
 
 func (x *EscalateVHTLCRecoveryResponse) Reset() {
 	*x = EscalateVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[87]
+	mi := &file_daemon_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7016,7 +7106,7 @@ func (x *EscalateVHTLCRecoveryResponse) String() string {
 func (*EscalateVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[87]
+	mi := &file_daemon_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7029,7 +7119,7 @@ func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{87}
+	return file_daemon_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *EscalateVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -7053,7 +7143,7 @@ type CancelVHTLCRecoveryRequest struct {
 
 func (x *CancelVHTLCRecoveryRequest) Reset() {
 	*x = CancelVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[88]
+	mi := &file_daemon_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7065,7 +7155,7 @@ func (x *CancelVHTLCRecoveryRequest) String() string {
 func (*CancelVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[88]
+	mi := &file_daemon_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7078,7 +7168,7 @@ func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{88}
+	return file_daemon_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *CancelVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -7112,7 +7202,7 @@ type CancelVHTLCRecoveryResponse struct {
 
 func (x *CancelVHTLCRecoveryResponse) Reset() {
 	*x = CancelVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[89]
+	mi := &file_daemon_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7124,7 +7214,7 @@ func (x *CancelVHTLCRecoveryResponse) String() string {
 func (*CancelVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[89]
+	mi := &file_daemon_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7137,7 +7227,7 @@ func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{89}
+	return file_daemon_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *CancelVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -7157,7 +7247,7 @@ type GetVHTLCRecoveryStatusRequest struct {
 
 func (x *GetVHTLCRecoveryStatusRequest) Reset() {
 	*x = GetVHTLCRecoveryStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[90]
+	mi := &file_daemon_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7169,7 +7259,7 @@ func (x *GetVHTLCRecoveryStatusRequest) String() string {
 func (*GetVHTLCRecoveryStatusRequest) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[90]
+	mi := &file_daemon_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7182,7 +7272,7 @@ func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{90}
+	return file_daemon_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *GetVHTLCRecoveryStatusRequest) GetRecoveryId() string {
@@ -7204,7 +7294,7 @@ type GetVHTLCRecoveryStatusResponse struct {
 
 func (x *GetVHTLCRecoveryStatusResponse) Reset() {
 	*x = GetVHTLCRecoveryStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[91]
+	mi := &file_daemon_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7216,7 +7306,7 @@ func (x *GetVHTLCRecoveryStatusResponse) String() string {
 func (*GetVHTLCRecoveryStatusResponse) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[91]
+	mi := &file_daemon_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7229,7 +7319,7 @@ func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{91}
+	return file_daemon_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *GetVHTLCRecoveryStatusResponse) GetFound() bool {
@@ -7256,7 +7346,7 @@ type ListVHTLCRecoveriesRequest struct {
 
 func (x *ListVHTLCRecoveriesRequest) Reset() {
 	*x = ListVHTLCRecoveriesRequest{}
-	mi := &file_daemon_proto_msgTypes[92]
+	mi := &file_daemon_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7268,7 +7358,7 @@ func (x *ListVHTLCRecoveriesRequest) String() string {
 func (*ListVHTLCRecoveriesRequest) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[92]
+	mi := &file_daemon_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7281,7 +7371,7 @@ func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesRequest.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{92}
+	return file_daemon_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *ListVHTLCRecoveriesRequest) GetIncludeTerminal() bool {
@@ -7301,7 +7391,7 @@ type ListVHTLCRecoveriesResponse struct {
 
 func (x *ListVHTLCRecoveriesResponse) Reset() {
 	*x = ListVHTLCRecoveriesResponse{}
-	mi := &file_daemon_proto_msgTypes[93]
+	mi := &file_daemon_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7313,7 +7403,7 @@ func (x *ListVHTLCRecoveriesResponse) String() string {
 func (*ListVHTLCRecoveriesResponse) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[93]
+	mi := &file_daemon_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7326,7 +7416,7 @@ func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesResponse.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{93}
+	return file_daemon_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *ListVHTLCRecoveriesResponse) GetStatuses() []*VHTLCRecoveryStatus {
@@ -7401,7 +7491,7 @@ type VHTLCRecoveryStatus struct {
 
 func (x *VHTLCRecoveryStatus) Reset() {
 	*x = VHTLCRecoveryStatus{}
-	mi := &file_daemon_proto_msgTypes[94]
+	mi := &file_daemon_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7413,7 +7503,7 @@ func (x *VHTLCRecoveryStatus) String() string {
 func (*VHTLCRecoveryStatus) ProtoMessage() {}
 
 func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[94]
+	mi := &file_daemon_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7426,7 +7516,7 @@ func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VHTLCRecoveryStatus.ProtoReflect.Descriptor instead.
 func (*VHTLCRecoveryStatus) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{94}
+	return file_daemon_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *VHTLCRecoveryStatus) GetRecoveryId() string {
@@ -8021,7 +8111,11 @@ const file_daemon_proto_rawDesc = "" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\"E\n" +
 	"\x0eUnrollResponse\x12\x18\n" +
 	"\acreated\x18\x01 \x01(\bR\acreated\x12\x19\n" +
-	"\bactor_id\x18\x02 \x01(\tR\aactorId\"4\n" +
+	"\bactor_id\x18\x02 \x01(\tR\aactorId\"8\n" +
+	"\x1aReleaseSpendingVTXORequest\x12\x1a\n" +
+	"\boutpoint\x18\x01 \x01(\tR\boutpoint\"9\n" +
+	"\x1bReleaseSpendingVTXOResponse\x12\x1a\n" +
+	"\breleased\x18\x01 \x01(\bR\breleased\"4\n" +
 	"\x16GetUnrollStatusRequest\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\"\xa1\x01\n" +
 	"\x17GetUnrollStatusResponse\x12\x14\n" +
@@ -8189,7 +8283,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1eVHTLC_RECOVERY_STATE_COMPLETED\x10\t\x12\"\n" +
 	"\x1eVHTLC_RECOVERY_STATE_CANCELLED\x10\n" +
 	"\x12\x1f\n" +
-	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\xd0\x1a\n" +
+	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\xb6\x1b\n" +
 	"\rDaemonService\x12@\n" +
 	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
 	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
@@ -8235,7 +8329,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\x15EscalateVHTLCRecovery\x12'.daemonrpc.EscalateVHTLCRecoveryRequest\x1a(.daemonrpc.EscalateVHTLCRecoveryResponse\x12d\n" +
 	"\x13CancelVHTLCRecovery\x12%.daemonrpc.CancelVHTLCRecoveryRequest\x1a&.daemonrpc.CancelVHTLCRecoveryResponse\x12m\n" +
 	"\x16GetVHTLCRecoveryStatus\x12(.daemonrpc.GetVHTLCRecoveryStatusRequest\x1a).daemonrpc.GetVHTLCRecoveryStatusResponse\x12d\n" +
-	"\x13ListVHTLCRecoveries\x12%.daemonrpc.ListVHTLCRecoveriesRequest\x1a&.daemonrpc.ListVHTLCRecoveriesResponseB2Z0github.com/lightninglabs/darepo-client/daemonrpcb\x06proto3"
+	"\x13ListVHTLCRecoveries\x12%.daemonrpc.ListVHTLCRecoveriesRequest\x1a&.daemonrpc.ListVHTLCRecoveriesResponse\x12d\n" +
+	"\x13ReleaseSpendingVTXO\x12%.daemonrpc.ReleaseSpendingVTXORequest\x1a&.daemonrpc.ReleaseSpendingVTXOResponseB2Z0github.com/lightninglabs/darepo-client/daemonrpcb\x06proto3"
 
 var (
 	file_daemon_proto_rawDescOnce sync.Once
@@ -8250,7 +8345,7 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 96)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 98)
 var file_daemon_proto_goTypes = []any{
 	(WalletState)(0),                              // 0: daemonrpc.WalletState
 	(VTXOStatus)(0),                               // 1: daemonrpc.VTXOStatus
@@ -8343,20 +8438,22 @@ var file_daemon_proto_goTypes = []any{
 	(*ListTransactionsResponse)(nil),              // 88: daemonrpc.ListTransactionsResponse
 	(*UnrollRequest)(nil),                         // 89: daemonrpc.UnrollRequest
 	(*UnrollResponse)(nil),                        // 90: daemonrpc.UnrollResponse
-	(*GetUnrollStatusRequest)(nil),                // 91: daemonrpc.GetUnrollStatusRequest
-	(*GetUnrollStatusResponse)(nil),               // 92: daemonrpc.GetUnrollStatusResponse
-	(*ArmVHTLCRecoveryRequest)(nil),               // 93: daemonrpc.ArmVHTLCRecoveryRequest
-	(*ArmVHTLCRecoveryResponse)(nil),              // 94: daemonrpc.ArmVHTLCRecoveryResponse
-	(*EscalateVHTLCRecoveryRequest)(nil),          // 95: daemonrpc.EscalateVHTLCRecoveryRequest
-	(*EscalateVHTLCRecoveryResponse)(nil),         // 96: daemonrpc.EscalateVHTLCRecoveryResponse
-	(*CancelVHTLCRecoveryRequest)(nil),            // 97: daemonrpc.CancelVHTLCRecoveryRequest
-	(*CancelVHTLCRecoveryResponse)(nil),           // 98: daemonrpc.CancelVHTLCRecoveryResponse
-	(*GetVHTLCRecoveryStatusRequest)(nil),         // 99: daemonrpc.GetVHTLCRecoveryStatusRequest
-	(*GetVHTLCRecoveryStatusResponse)(nil),        // 100: daemonrpc.GetVHTLCRecoveryStatusResponse
-	(*ListVHTLCRecoveriesRequest)(nil),            // 101: daemonrpc.ListVHTLCRecoveriesRequest
-	(*ListVHTLCRecoveriesResponse)(nil),           // 102: daemonrpc.ListVHTLCRecoveriesResponse
-	(*VHTLCRecoveryStatus)(nil),                   // 103: daemonrpc.VHTLCRecoveryStatus
-	nil,                                           // 104: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	(*ReleaseSpendingVTXORequest)(nil),            // 91: daemonrpc.ReleaseSpendingVTXORequest
+	(*ReleaseSpendingVTXOResponse)(nil),           // 92: daemonrpc.ReleaseSpendingVTXOResponse
+	(*GetUnrollStatusRequest)(nil),                // 93: daemonrpc.GetUnrollStatusRequest
+	(*GetUnrollStatusResponse)(nil),               // 94: daemonrpc.GetUnrollStatusResponse
+	(*ArmVHTLCRecoveryRequest)(nil),               // 95: daemonrpc.ArmVHTLCRecoveryRequest
+	(*ArmVHTLCRecoveryResponse)(nil),              // 96: daemonrpc.ArmVHTLCRecoveryResponse
+	(*EscalateVHTLCRecoveryRequest)(nil),          // 97: daemonrpc.EscalateVHTLCRecoveryRequest
+	(*EscalateVHTLCRecoveryResponse)(nil),         // 98: daemonrpc.EscalateVHTLCRecoveryResponse
+	(*CancelVHTLCRecoveryRequest)(nil),            // 99: daemonrpc.CancelVHTLCRecoveryRequest
+	(*CancelVHTLCRecoveryResponse)(nil),           // 100: daemonrpc.CancelVHTLCRecoveryResponse
+	(*GetVHTLCRecoveryStatusRequest)(nil),         // 101: daemonrpc.GetVHTLCRecoveryStatusRequest
+	(*GetVHTLCRecoveryStatusResponse)(nil),        // 102: daemonrpc.GetVHTLCRecoveryStatusResponse
+	(*ListVHTLCRecoveriesRequest)(nil),            // 103: daemonrpc.ListVHTLCRecoveriesRequest
+	(*ListVHTLCRecoveriesResponse)(nil),           // 104: daemonrpc.ListVHTLCRecoveriesResponse
+	(*VHTLCRecoveryStatus)(nil),                   // 105: daemonrpc.VHTLCRecoveryStatus
+	nil,                                           // 106: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
 	0,   // 0: daemonrpc.GetInfoResponse.wallet_state:type_name -> daemonrpc.WalletState
@@ -8378,7 +8475,7 @@ var file_daemon_proto_depIdxs = []int32{
 	51,  // 16: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
 	51,  // 17: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
 	54,  // 18: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
-	104, // 19: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	106, // 19: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 	62,  // 20: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
 	65,  // 21: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
 	66,  // 22: daemonrpc.ListBoardingSweepsResponse.sweeps:type_name -> daemonrpc.BoardingSweep
@@ -8399,11 +8496,11 @@ var file_daemon_proto_depIdxs = []int32{
 	5,   // 37: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
 	6,   // 38: daemonrpc.ArmVHTLCRecoveryRequest.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
 	7,   // 39: daemonrpc.ArmVHTLCRecoveryRequest.action:type_name -> daemonrpc.VHTLCRecoveryAction
-	103, // 40: daemonrpc.ArmVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	103, // 41: daemonrpc.EscalateVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	103, // 42: daemonrpc.CancelVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	103, // 43: daemonrpc.GetVHTLCRecoveryStatusResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	103, // 44: daemonrpc.ListVHTLCRecoveriesResponse.statuses:type_name -> daemonrpc.VHTLCRecoveryStatus
+	105, // 40: daemonrpc.ArmVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	105, // 41: daemonrpc.EscalateVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	105, // 42: daemonrpc.CancelVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	105, // 43: daemonrpc.GetVHTLCRecoveryStatusResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	105, // 44: daemonrpc.ListVHTLCRecoveriesResponse.statuses:type_name -> daemonrpc.VHTLCRecoveryStatus
 	6,   // 45: daemonrpc.VHTLCRecoveryStatus.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
 	7,   // 46: daemonrpc.VHTLCRecoveryStatus.action:type_name -> daemonrpc.VHTLCRecoveryAction
 	8,   // 47: daemonrpc.VHTLCRecoveryStatus.state:type_name -> daemonrpc.VHTLCRecoveryState
@@ -8442,53 +8539,55 @@ var file_daemon_proto_depIdxs = []int32{
 	83,  // 80: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
 	86,  // 81: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
 	89,  // 82: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
-	91,  // 83: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
-	93,  // 84: daemonrpc.DaemonService.ArmVHTLCRecovery:input_type -> daemonrpc.ArmVHTLCRecoveryRequest
-	95,  // 85: daemonrpc.DaemonService.EscalateVHTLCRecovery:input_type -> daemonrpc.EscalateVHTLCRecoveryRequest
-	97,  // 86: daemonrpc.DaemonService.CancelVHTLCRecovery:input_type -> daemonrpc.CancelVHTLCRecoveryRequest
-	99,  // 87: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> daemonrpc.GetVHTLCRecoveryStatusRequest
-	101, // 88: daemonrpc.DaemonService.ListVHTLCRecoveries:input_type -> daemonrpc.ListVHTLCRecoveriesRequest
-	10,  // 89: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	13,  // 90: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	15,  // 91: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	17,  // 92: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	19,  // 93: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	22,  // 94: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	24,  // 95: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	26,  // 96: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
-	28,  // 97: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
-	30,  // 98: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
-	32,  // 99: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
-	34,  // 100: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
-	36,  // 101: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
-	38,  // 102: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
-	41,  // 103: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	45,  // 104: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	48,  // 105: daemonrpc.DaemonService.PrepareOOR:output_type -> daemonrpc.PrepareOORResponse
-	50,  // 106: daemonrpc.DaemonService.SignOORCustomInput:output_type -> daemonrpc.SignOORCustomInputResponse
-	53,  // 107: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	56,  // 108: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
-	58,  // 109: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	60,  // 110: daemonrpc.DaemonService.JoinNextRound:output_type -> daemonrpc.JoinNextRoundResponse
-	63,  // 111: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
-	67,  // 112: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
-	73,  // 113: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	72,  // 114: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
-	75,  // 115: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	78,  // 116: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
-	80,  // 117: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
-	82,  // 118: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
-	85,  // 119: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
-	88,  // 120: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
-	90,  // 121: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
-	92,  // 122: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
-	94,  // 123: daemonrpc.DaemonService.ArmVHTLCRecovery:output_type -> daemonrpc.ArmVHTLCRecoveryResponse
-	96,  // 124: daemonrpc.DaemonService.EscalateVHTLCRecovery:output_type -> daemonrpc.EscalateVHTLCRecoveryResponse
-	98,  // 125: daemonrpc.DaemonService.CancelVHTLCRecovery:output_type -> daemonrpc.CancelVHTLCRecoveryResponse
-	100, // 126: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> daemonrpc.GetVHTLCRecoveryStatusResponse
-	102, // 127: daemonrpc.DaemonService.ListVHTLCRecoveries:output_type -> daemonrpc.ListVHTLCRecoveriesResponse
-	89,  // [89:128] is the sub-list for method output_type
-	50,  // [50:89] is the sub-list for method input_type
+	93,  // 83: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
+	95,  // 84: daemonrpc.DaemonService.ArmVHTLCRecovery:input_type -> daemonrpc.ArmVHTLCRecoveryRequest
+	97,  // 85: daemonrpc.DaemonService.EscalateVHTLCRecovery:input_type -> daemonrpc.EscalateVHTLCRecoveryRequest
+	99,  // 86: daemonrpc.DaemonService.CancelVHTLCRecovery:input_type -> daemonrpc.CancelVHTLCRecoveryRequest
+	101, // 87: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> daemonrpc.GetVHTLCRecoveryStatusRequest
+	103, // 88: daemonrpc.DaemonService.ListVHTLCRecoveries:input_type -> daemonrpc.ListVHTLCRecoveriesRequest
+	91,  // 89: daemonrpc.DaemonService.ReleaseSpendingVTXO:input_type -> daemonrpc.ReleaseSpendingVTXORequest
+	10,  // 90: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	13,  // 91: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	15,  // 92: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	17,  // 93: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	19,  // 94: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	22,  // 95: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	24,  // 96: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	26,  // 97: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
+	28,  // 98: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
+	30,  // 99: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
+	32,  // 100: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
+	34,  // 101: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
+	36,  // 102: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
+	38,  // 103: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
+	41,  // 104: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	45,  // 105: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	48,  // 106: daemonrpc.DaemonService.PrepareOOR:output_type -> daemonrpc.PrepareOORResponse
+	50,  // 107: daemonrpc.DaemonService.SignOORCustomInput:output_type -> daemonrpc.SignOORCustomInputResponse
+	53,  // 108: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	56,  // 109: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
+	58,  // 110: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	60,  // 111: daemonrpc.DaemonService.JoinNextRound:output_type -> daemonrpc.JoinNextRoundResponse
+	63,  // 112: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
+	67,  // 113: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
+	73,  // 114: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	72,  // 115: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
+	75,  // 116: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	78,  // 117: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
+	80,  // 118: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
+	82,  // 119: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
+	85,  // 120: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
+	88,  // 121: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
+	90,  // 122: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
+	94,  // 123: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
+	96,  // 124: daemonrpc.DaemonService.ArmVHTLCRecovery:output_type -> daemonrpc.ArmVHTLCRecoveryResponse
+	98,  // 125: daemonrpc.DaemonService.EscalateVHTLCRecovery:output_type -> daemonrpc.EscalateVHTLCRecoveryResponse
+	100, // 126: daemonrpc.DaemonService.CancelVHTLCRecovery:output_type -> daemonrpc.CancelVHTLCRecoveryResponse
+	102, // 127: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> daemonrpc.GetVHTLCRecoveryStatusResponse
+	104, // 128: daemonrpc.DaemonService.ListVHTLCRecoveries:output_type -> daemonrpc.ListVHTLCRecoveriesResponse
+	92,  // 129: daemonrpc.DaemonService.ReleaseSpendingVTXO:output_type -> daemonrpc.ReleaseSpendingVTXOResponse
+	90,  // [90:130] is the sub-list for method output_type
+	50,  // [50:90] is the sub-list for method input_type
 	50,  // [50:50] is the sub-list for extension type_name
 	50,  // [50:50] is the sub-list for extension extendee
 	0,   // [0:50] is the sub-list for field type_name
@@ -8522,7 +8621,7 @@ func file_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      9,
-			NumMessages:   96,
+			NumMessages:   98,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.pb.gw.go
+++ b/daemonrpc/daemon.pb.gw.go
@@ -1084,6 +1084,33 @@ func local_request_DaemonService_ListVHTLCRecoveries_0(ctx context.Context, mars
 	return msg, metadata, err
 }
 
+func request_DaemonService_ReleaseSpendingVTXO_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ReleaseSpendingVTXORequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ReleaseSpendingVTXO(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_DaemonService_ReleaseSpendingVTXO_0(ctx context.Context, marshaler runtime.Marshaler, server DaemonServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ReleaseSpendingVTXORequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ReleaseSpendingVTXO(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterDaemonServiceHandlerServer registers the http handlers for service DaemonService to "mux".
 // UnaryRPC     :call DaemonServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -1857,6 +1884,26 @@ func RegisterDaemonServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_ListVHTLCRecoveries_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_ReleaseSpendingVTXO_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/daemonrpc.DaemonService/ReleaseSpendingVTXO", runtime.WithHTTPPathPattern("/v1/daemon/release-spending-vtxo"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_DaemonService_ReleaseSpendingVTXO_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_ReleaseSpendingVTXO_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	return nil
 }
@@ -2560,6 +2607,23 @@ func RegisterDaemonServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_ListVHTLCRecoveries_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_ReleaseSpendingVTXO_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/daemonrpc.DaemonService/ReleaseSpendingVTXO", runtime.WithHTTPPathPattern("/v1/daemon/release-spending-vtxo"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_DaemonService_ReleaseSpendingVTXO_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_ReleaseSpendingVTXO_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -2603,6 +2667,7 @@ var (
 	pattern_DaemonService_CancelVHTLCRecovery_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "cancel-vhtlc-recovery"}, ""))
 	pattern_DaemonService_GetVHTLCRecoveryStatus_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "get-vhtlc-recovery-status"}, ""))
 	pattern_DaemonService_ListVHTLCRecoveries_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "list-vhtlc-recoveries"}, ""))
+	pattern_DaemonService_ReleaseSpendingVTXO_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "release-spending-vtxo"}, ""))
 )
 
 var (
@@ -2645,4 +2710,5 @@ var (
 	forward_DaemonService_CancelVHTLCRecovery_0           = runtime.ForwardResponseMessage
 	forward_DaemonService_GetVHTLCRecoveryStatus_0        = runtime.ForwardResponseMessage
 	forward_DaemonService_ListVHTLCRecoveries_0           = runtime.ForwardResponseMessage
+	forward_DaemonService_ReleaseSpendingVTXO_0           = runtime.ForwardResponseMessage
 )

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -202,6 +202,14 @@ service DaemonService {
     // EscalateVHTLCRecovery to start costly on-chain recovery.
     rpc ListVHTLCRecoveries (ListVHTLCRecoveriesRequest)
         returns (ListVHTLCRecoveriesResponse);
+
+    // ReleaseSpendingVTXO force-releases a VTXO stuck in SpendingState back to
+    // Live. This is an operator escape-hatch for an orphaned spend reservation
+    // (issue #587) whose owning spend died without releasing it; normal clients
+    // never need it. The release is rejected if the VTXO is not currently in
+    // SpendingState.
+    rpc ReleaseSpendingVTXO (ReleaseSpendingVTXORequest)
+        returns (ReleaseSpendingVTXOResponse);
 }
 
 // WalletState mirrors the daemon's in-process wallet lifecycle enum:
@@ -1665,6 +1673,16 @@ message UnrollResponse {
 
     // actor_id is the identifier of the durable unroll job actor.
     string actor_id = 2;
+}
+
+message ReleaseSpendingVTXORequest {
+    // outpoint is the VTXO outpoint to release, formatted as "txid:index".
+    string outpoint = 1;
+}
+
+message ReleaseSpendingVTXOResponse {
+    // released is true if the reservation was released back to Live.
+    bool released = 1;
 }
 
 message GetUnrollStatusRequest {

--- a/daemonrpc/daemon.yaml
+++ b/daemonrpc/daemon.yaml
@@ -120,3 +120,6 @@ http:
     - selector: daemonrpc.DaemonService.ListVHTLCRecoveries
       post: /v1/daemon/list-vhtlc-recoveries
       body: "*"
+    - selector: daemonrpc.DaemonService.ReleaseSpendingVTXO
+      post: /v1/daemon/release-spending-vtxo
+      body: "*"

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -58,6 +58,7 @@ const (
 	DaemonService_CancelVHTLCRecovery_FullMethodName           = "/daemonrpc.DaemonService/CancelVHTLCRecovery"
 	DaemonService_GetVHTLCRecoveryStatus_FullMethodName        = "/daemonrpc.DaemonService/GetVHTLCRecoveryStatus"
 	DaemonService_ListVHTLCRecoveries_FullMethodName           = "/daemonrpc.DaemonService/ListVHTLCRecoveries"
+	DaemonService_ReleaseSpendingVTXO_FullMethodName           = "/daemonrpc.DaemonService/ReleaseSpendingVTXO"
 )
 
 // DaemonServiceClient is the client API for DaemonService service.
@@ -207,6 +208,12 @@ type DaemonServiceClient interface {
 	// inspection. Armed rows are dormant; callers must use
 	// EscalateVHTLCRecovery to start costly on-chain recovery.
 	ListVHTLCRecoveries(ctx context.Context, in *ListVHTLCRecoveriesRequest, opts ...grpc.CallOption) (*ListVHTLCRecoveriesResponse, error)
+	// ReleaseSpendingVTXO force-releases a VTXO stuck in SpendingState back to
+	// Live. This is an operator escape-hatch for an orphaned spend reservation
+	// (issue #587) whose owning spend died without releasing it; normal clients
+	// never need it. The release is rejected if the VTXO is not currently in
+	// SpendingState.
+	ReleaseSpendingVTXO(ctx context.Context, in *ReleaseSpendingVTXORequest, opts ...grpc.CallOption) (*ReleaseSpendingVTXOResponse, error)
 }
 
 type daemonServiceClient struct {
@@ -616,6 +623,16 @@ func (c *daemonServiceClient) ListVHTLCRecoveries(ctx context.Context, in *ListV
 	return out, nil
 }
 
+func (c *daemonServiceClient) ReleaseSpendingVTXO(ctx context.Context, in *ReleaseSpendingVTXORequest, opts ...grpc.CallOption) (*ReleaseSpendingVTXOResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ReleaseSpendingVTXOResponse)
+	err := c.cc.Invoke(ctx, DaemonService_ReleaseSpendingVTXO_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // DaemonServiceServer is the server API for DaemonService service.
 // All implementations must embed UnimplementedDaemonServiceServer
 // for forward compatibility.
@@ -763,6 +780,12 @@ type DaemonServiceServer interface {
 	// inspection. Armed rows are dormant; callers must use
 	// EscalateVHTLCRecovery to start costly on-chain recovery.
 	ListVHTLCRecoveries(context.Context, *ListVHTLCRecoveriesRequest) (*ListVHTLCRecoveriesResponse, error)
+	// ReleaseSpendingVTXO force-releases a VTXO stuck in SpendingState back to
+	// Live. This is an operator escape-hatch for an orphaned spend reservation
+	// (issue #587) whose owning spend died without releasing it; normal clients
+	// never need it. The release is rejected if the VTXO is not currently in
+	// SpendingState.
+	ReleaseSpendingVTXO(context.Context, *ReleaseSpendingVTXORequest) (*ReleaseSpendingVTXOResponse, error)
 	mustEmbedUnimplementedDaemonServiceServer()
 }
 
@@ -889,6 +912,9 @@ func (UnimplementedDaemonServiceServer) GetVHTLCRecoveryStatus(context.Context, 
 }
 func (UnimplementedDaemonServiceServer) ListVHTLCRecoveries(context.Context, *ListVHTLCRecoveriesRequest) (*ListVHTLCRecoveriesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListVHTLCRecoveries not implemented")
+}
+func (UnimplementedDaemonServiceServer) ReleaseSpendingVTXO(context.Context, *ReleaseSpendingVTXORequest) (*ReleaseSpendingVTXOResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReleaseSpendingVTXO not implemented")
 }
 func (UnimplementedDaemonServiceServer) mustEmbedUnimplementedDaemonServiceServer() {}
 func (UnimplementedDaemonServiceServer) testEmbeddedByValue()                       {}
@@ -1606,6 +1632,24 @@ func _DaemonService_ListVHTLCRecoveries_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_ReleaseSpendingVTXO_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReleaseSpendingVTXORequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).ReleaseSpendingVTXO(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_ReleaseSpendingVTXO_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).ReleaseSpendingVTXO(ctx, req.(*ReleaseSpendingVTXORequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // DaemonService_ServiceDesc is the grpc.ServiceDesc for DaemonService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -1764,6 +1808,10 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListVHTLCRecoveries",
 			Handler:    _DaemonService_ListVHTLCRecoveries_Handler,
+		},
+		{
+			MethodName: "ReleaseSpendingVTXO",
+			Handler:    _DaemonService_ReleaseSpendingVTXO_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -102,6 +102,8 @@ type DaemonServiceMailboxServer interface {
 	GetVHTLCRecoveryStatus(ctx context.Context, req *GetVHTLCRecoveryStatusRequest) (*GetVHTLCRecoveryStatusResponse, error)
 	// ListVHTLCRecoveries handles ListVHTLCRecoveries.
 	ListVHTLCRecoveries(ctx context.Context, req *ListVHTLCRecoveriesRequest) (*ListVHTLCRecoveriesResponse, error)
+	// ReleaseSpendingVTXO handles ReleaseSpendingVTXO.
+	ReleaseSpendingVTXO(ctx context.Context, req *ReleaseSpendingVTXORequest) (*ReleaseSpendingVTXOResponse, error)
 }
 
 // RegisterDaemonServiceMailboxServer registers handlers for DaemonService.
@@ -495,6 +497,16 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.ListVHTLCRecoveries(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "ReleaseSpendingVTXO", func() proto.Message {
+		return &ReleaseSpendingVTXORequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ReleaseSpendingVTXORequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ReleaseSpendingVTXO(ctx, req)
 	})
 }
 
@@ -1388,6 +1400,29 @@ func (c *DaemonServiceMailboxClient) ListVHTLCRecoveries(ctx context.Context, re
 	}
 
 	resp := new(ListVHTLCRecoveriesResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ReleaseSpendingVTXO calls the ReleaseSpendingVTXO RPC.
+func (c *DaemonServiceMailboxClient) ReleaseSpendingVTXO(ctx context.Context, req *ReleaseSpendingVTXORequest, opts ...rpc.RPCOptions) (*ReleaseSpendingVTXOResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "ReleaseSpendingVTXO",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ReleaseSpendingVTXOResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -3141,6 +3141,80 @@ func (r *RPCServer) Unroll(ctx context.Context, req *daemonrpc.UnrollRequest) (
 	}, nil
 }
 
+// ReleaseSpendingVTXO force-releases a VTXO stuck in SpendingState back
+// to LiveState. It is an operator escape-hatch for an orphaned spend
+// reservation (issue #587) whose owning spend died without releasing
+// it; the request is rejected unless the VTXO is currently Spending so
+// the hatch can't be misused on a healthy VTXO.
+func (r *RPCServer) ReleaseSpendingVTXO(ctx context.Context,
+	req *daemonrpc.ReleaseSpendingVTXORequest) (
+	*daemonrpc.ReleaseSpendingVTXOResponse, error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if !r.server.vtxoMgrRef.IsSome() {
+		return nil, status.Errorf(codes.Unavailable, "VTXO manager "+
+			"not initialized")
+	}
+
+	outpoint, err := parseOutpointString(req.Outpoint)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid "+
+			"outpoint: %v", err)
+	}
+
+	var vtxoMgrRef actor.ActorRef[
+		vtxo.ManagerMsg, vtxo.ManagerResp,
+	]
+	r.server.vtxoMgrRef.WhenSome(
+		func(ref actor.ActorRef[
+			vtxo.ManagerMsg, vtxo.ManagerResp,
+		]) {
+
+			vtxoMgrRef = ref
+		},
+	)
+
+	// Guard the hatch: only a VTXO actually parked in SpendingState is
+	// eligible. Loading the descriptor first means a typo or a healthy
+	// VTXO is rejected before we touch the manager.
+	if r.server.vtxoStore != nil {
+		desc, err := r.server.vtxoStore.GetVTXO(ctx, outpoint)
+		if err == nil && desc != nil &&
+			desc.Status != vtxo.VTXOStatusSpending {
+
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"vtxo %s is not in spending state", outpoint)
+		}
+		if err == nil && desc == nil {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"vtxo %s is not in spending state", outpoint)
+		}
+	}
+
+	resp, askErr := vtxoMgrRef.Ask(
+		ctx, &actormsg.ReleaseSpendRequest{
+			Outpoints: []wire.OutPoint{outpoint},
+		},
+	).Await(ctx).Unpack()
+	if askErr != nil {
+		return nil, status.Errorf(codes.Internal, "release spend: %v",
+			askErr)
+	}
+
+	relResp, ok := resp.(*actormsg.ReleaseSpendResponse)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "unexpected "+
+			"response type %T", resp)
+	}
+
+	return &daemonrpc.ReleaseSpendingVTXOResponse{
+		Released: relResp.ReleasedCount == 1,
+	}, nil
+}
+
 // preflightUnrollMinUTXOSat is the soft floor used by the unroll fee-
 // input pre-check. Confirmed wallet UTXOs below this threshold are
 // counted as unavailable because they're too small to plausibly cover

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -657,6 +657,17 @@ func (c *DaemonServiceClient) ListVHTLCRecoveries(ctx context.Context,
 	return out, err
 }
 
+// ReleaseSpendingVTXO force-releases a VTXO stuck in spending state.
+func (c *DaemonServiceClient) ReleaseSpendingVTXO(ctx context.Context,
+	in *daemonrpc.ReleaseSpendingVTXORequest, _ ...grpc.CallOption) (
+	*daemonrpc.ReleaseSpendingVTXOResponse, error) {
+
+	out := new(daemonrpc.ReleaseSpendingVTXOResponse)
+	err := c.client.Post(ctx, "/v1/daemon/release-spending-vtxo", in, out)
+
+	return out, err
+}
+
 // NewSwapClientServiceClient creates a SwapClientService REST client.
 func NewSwapClientServiceClient(addr string,
 	opts ...Option) swapclientrpc.SwapClientServiceClient {


### PR DESCRIPTION
In this PR, we add an operator escape-hatch to force-release a VTXO stuck in
`SpendingState` back to Live. It's the manual companion to the automatic #587
recovery (#593 / #597): when a spend reservation is orphaned (the owning OOR send
died without releasing it), the VTXO is unspendable until batch expiry, and an
operator can recover it on demand.

## The RPC

`ReleaseSpendingVTXO(outpoint)` on the daemon service. The handler routes through
the VTXO manager: it parses the outpoint and, to keep the hatch from being
misused on a healthy VTXO, refuses the call unless the VTXO is currently in
`SpendingState`. It then asks the manager to release it through the same
`SpendReleasedEvent` path a normal release uses, and reports whether the release
happened.

## CLI

`darepocli ark vtxos release-spending <outpoint>` gives operators a direct verb.
Because the RPC also lands in the regenerated dev registry, it's reachable
through the generated `dev` command too (alias `release-spending-vtxo`), but the
dedicated verb is the ergonomic path.

## Notes

The proto stubs were regenerated with the repo's pinned toolchain (protoc
3.21.12 plus the go.mod-pinned plugins); the diff is limited to the daemonrpc
generated files and the dev RPC registry. The hand-rolled REST client gains the
matching method to stay in step with the `DaemonServiceClient` interface it
implements.

## Test plan

- [x] `go build ./daemonrpc/... ./darepod/... ./cmd/darepocli/... ./rpc/restclient/...`
- [x] `go vet ./daemonrpc/ ./darepod/ ./cmd/darepocli/darepoclicommands/...`
- [x] `go test ./daemonrpc/ ./darepod/ ./cmd/darepocli/darepoclicommands/... -count=1`
- [x] `gofmt -l` clean on changed files
- [x] proto regen scoped to daemonrpc + dev registry (pinned protoc 3.21.12)
