### PR TITLE
swapwallet: skip in-flight VTXOs in onchain-send coin selection

### DIFF
--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -18,23 +18,24 @@ import (
 type fakeRPCServer struct {
 	mu sync.Mutex
 
-	listVTXOsResp  *daemonrpc.ListVTXOsResponse
-	listVTXOsErr   error
-	listVTXOsCalls int
-	leaveResp      *daemonrpc.LeaveVTXOsResponse
-	leaveErr       error
-	leaveCalls     int
-	leaveLastReq   *daemonrpc.LeaveVTXOsRequest
-	listTxResp     *daemonrpc.ListTransactionsResponse
-	listTxErr      error
-	listTxCalls    int
-	listTxLastReq  *daemonrpc.ListTransactionsRequest
-	getInfoResp    *daemonrpc.GetInfoResponse
-	getInfoErr     error
-	getBalanceResp *daemonrpc.GetBalanceResponse
-	getBalanceErr  error
-	newAddressResp *daemonrpc.NewAddressResponse
-	newAddressErr  error
+	listVTXOsResp    *daemonrpc.ListVTXOsResponse
+	listVTXOsErr     error
+	listVTXOsCalls   int
+	listVTXOsLastReq *daemonrpc.ListVTXOsRequest
+	leaveResp        *daemonrpc.LeaveVTXOsResponse
+	leaveErr         error
+	leaveCalls       int
+	leaveLastReq     *daemonrpc.LeaveVTXOsRequest
+	listTxResp       *daemonrpc.ListTransactionsResponse
+	listTxErr        error
+	listTxCalls      int
+	listTxLastReq    *daemonrpc.ListTransactionsRequest
+	getInfoResp      *daemonrpc.GetInfoResponse
+	getInfoErr       error
+	getBalanceResp   *daemonrpc.GetBalanceResponse
+	getBalanceErr    error
+	newAddressResp   *daemonrpc.NewAddressResponse
+	newAddressErr    error
 
 	genSeedResp     *daemonrpc.GenSeedResponse
 	genSeedErr      error
@@ -79,12 +80,13 @@ func (f *fakeRPCServer) LeaveVTXOs(_ context.Context,
 }
 
 func (f *fakeRPCServer) ListVTXOs(_ context.Context,
-	_ *daemonrpc.ListVTXOsRequest) (*daemonrpc.ListVTXOsResponse, error) {
+	req *daemonrpc.ListVTXOsRequest) (*daemonrpc.ListVTXOsResponse, error) {
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	f.listVTXOsCalls++
+	f.listVTXOsLastReq = req
 
 	return f.listVTXOsResp, f.listVTXOsErr
 }

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -244,19 +244,43 @@ func (r *router) sendOnchain(ctx context.Context, addr string,
 	}, nil
 }
 
+// listLiveVTXOsForLeave returns the daemon's view of VTXOs that are
+// safe to feed into a fresh LeaveVTXOs call. The default ListVTXOs
+// response also includes VTXOs in PendingForfeit / Forfeiting /
+// Spending — those are "not yet terminal" but already committed to
+// another in-flight operation, and reselecting them races into the
+// VTXO manager's reservation gate (issue darepo-client#577: a second
+// onchain send while the first leave round is still unconfirmed
+// fails with "forfeiting: bad event: *round.PendingForfeitEvent").
+// Filtering to VTXO_STATUS_LIVE at the source closes that race for
+// every caller — both `--sweep-all` totalling and bounded-amount
+// coin selection.
+func (r *router) listLiveVTXOsForLeave(ctx context.Context) ([]*daemonrpc.VTXO,
+	error) {
+
+	listResp, err := r.deps.RPCServer.ListVTXOs(
+		ctx, &daemonrpc.ListVTXOsRequest{
+			StatusFilter: daemonrpc.VTXOStatus_VTXO_STATUS_LIVE,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list vtxos: %w", err)
+	}
+
+	return listResp.GetVtxos(), nil
+}
+
 // totalLiveVTXOAmount sums every live VTXO so a sweep-all caller can be
 // told how much will actually leave the wallet before the daemon hands
 // the operation off to LeaveVTXOs.
 func (r *router) totalLiveVTXOAmount(ctx context.Context) (int64, error) {
-	listResp, err := r.deps.RPCServer.ListVTXOs(
-		ctx, &daemonrpc.ListVTXOsRequest{},
-	)
+	vtxos, err := r.listLiveVTXOsForLeave(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("list vtxos: %w", err)
+		return 0, err
 	}
 
 	var total int64
-	for _, v := range listResp.GetVtxos() {
+	for _, v := range vtxos {
 		if v.GetAmountSat() <= 0 {
 			continue
 		}
@@ -283,18 +307,16 @@ func (r *router) selectVTXOsForAmount(ctx context.Context, target int64) (
 		return nil, 0, ErrAmountInvalid
 	}
 
-	listResp, err := r.deps.RPCServer.ListVTXOs(
-		ctx, &daemonrpc.ListVTXOsRequest{},
-	)
+	vtxos, err := r.listLiveVTXOsForLeave(ctx)
 	if err != nil {
-		return nil, 0, fmt.Errorf("list vtxos: %w", err)
+		return nil, 0, err
 	}
 
 	var (
 		selected []string
 		covered  int64
 	)
-	for _, v := range listResp.GetVtxos() {
+	for _, v := range vtxos {
 		if v.GetAmountSat() <= 0 {
 			continue
 		}

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -415,8 +415,8 @@ func TestRouterSendInvoicePreservesStartPayStatusCode(t *testing.T) {
 	)
 	swap.startPayErr = startPayErr
 
-	_, err := r.Send(t.Context(), &walletrpc.SendRequest{
-		Destination: &walletrpc.SendRequest_Invoice{
+	_, err := r.Send(t.Context(), &walletdkrpc.SendRequest{
+		Destination: &walletdkrpc.SendRequest_Invoice{
 			Invoice: "lnbc1example",
 		},
 	})

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -145,6 +145,19 @@ func TestRouterSendOnchainSelectsVTXOsAndCallsLeave(t *testing.T) {
 			"the caller can see whole-VTXO overpay before "+
 			"treating the send as confirmed",
 	)
+
+	// Regression: darepo-client#577. The bounded-amount coin
+	// selector must ask the daemon for VTXO_STATUS_LIVE only,
+	// otherwise a VTXO in PendingForfeit/Forfeiting (from an
+	// in-flight earlier leave) leaks back into the selection and
+	// the subsequent LeaveVTXOs call fails at the manager's
+	// reservation gate.
+	require.Equal(
+		t, daemonrpc.VTXOStatus_VTXO_STATUS_LIVE,
+		rpc.listVTXOsLastReq.GetStatusFilter(),
+		"selectVTXOsForAmount must filter to live VTXOs only "+
+			"(darepo-client#577)",
+	)
 }
 
 // TestRouterSendOnchainSweepAllRoutesToAllSelection confirms that the
@@ -193,6 +206,16 @@ func TestRouterSendOnchainSweepAllRoutesToAllSelection(t *testing.T) {
 	require.Equal(
 		t, 1, rpc.joinNextRoundCalls,
 		"sweep-all path must also auto-commit the leave intent",
+	)
+
+	// Regression: darepo-client#577. totalLiveVTXOAmount must also
+	// filter to VTXO_STATUS_LIVE so a stuck Forfeiting VTXO from a
+	// prior leave doesn't inflate the reported sweep total.
+	require.Equal(
+		t, daemonrpc.VTXOStatus_VTXO_STATUS_LIVE,
+		rpc.listVTXOsLastReq.GetStatusFilter(),
+		"totalLiveVTXOAmount must filter to live VTXOs only "+
+			"(darepo-client#577)",
 	)
 }
 


### PR DESCRIPTION
## Summary

Fixes #577. The onchain-send router's coin selector fed every result from `ListVTXOs` to `LeaveVTXOs` — including VTXOs in `PendingForfeit` / `Forfeiting` / `Spending` state. A user sending onchain twice in quick succession hit:

```
send: rpc error: code = Internal desc = leave vtxos:
  rpc error: code = Internal desc = leave request failed:
    reserve leave inputs: reserve forfeit <outpoint>:
      process event: forfeiting: bad event: *round.PendingForfeitEvent
```

The second Send re-selected the same outpoint as the first, the VTXO manager rejected the duplicate `PendingForfeitEvent` against a VTXO already in `ForfeitingState`, and the error bubbled up to the CLI.

This change routes both the bounded-amount and sweep-all selectors through a shared `listLiveVTXOsForLeave` helper that calls `ListVTXOs` with `StatusFilter: VTXO_STATUS_LIVE`. In-flight VTXOs are excluded at the daemon RPC, closing the race for every caller.

## Test plan

- [x] Unit: `go test -tags 'walletrpc swapruntime' -run TestRouterSendOnchain ./swapwallet/...` — both bounded-amount and sweep-all paths now assert `StatusFilter == VTXO_STATUS_LIVE` on the captured `ListVTXOs` request.
- [x] Itest (server-side): `make itest icase=TestLeaveIntegrationMultiVTXOSequentialSends` — two sequential onchain leaves on different VTXOs, both bitcoind destinations receive their fee-adjusted slice.
- [x] Itest (regression pin, server-side): `make itest icase=TestLeaveIntegrationDoubleSendBeforeConfirmation` — direct `LeaveVTXOs` on a Forfeiting VTXO still surfaces the structured admission error so the daemon's defense-in-depth is preserved.