### PR TITLE
swaps: report funded vHTLC script in OutSwapHtlcEvent to detect skew (#538 L2)

### DIFF
--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -264,6 +264,19 @@ type OutSwapHtlcEvent struct {
 
 	// VHTLCConfig contains the script parameters for the funded vHTLC.
 	VHTLCConfig VHTLCConfig
+
+	// VHTLCOutpoint is the funded vHTLC outpoint when the swap server knows
+	// it at notification time, in "txid:vout" format. Empty otherwise.
+	VHTLCOutpoint string
+
+	// VHTLCAmountSat is the funded vHTLC amount when known by the server.
+	VHTLCAmountSat int64
+
+	// VHTLCPkScript is the funded vHTLC P2TR script as computed by the swap
+	// server. The receiver compares it against the script it derives
+	// locally to detect a client/server vHTLC script disagreement. Empty
+	// for older servers that do not populate it.
+	VHTLCPkScript []byte
 }
 
 // OutSwapHtlcNotification carries one mailbox-delivered out-swap HTLC event

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -262,6 +262,10 @@ func outSwapHtlcEventFromProto(event *swaprpc.OutSwapHtlcEvent) (
 	if event.GetAmountSat() > math.MaxInt64 {
 		return nil, fmt.Errorf("out-swap event amount exceeds int64")
 	}
+	if event.GetVhtlcAmountSat() > math.MaxInt64 {
+		return nil, fmt.Errorf("out-swap event vHTLC amount exceeds " +
+			"int64")
+	}
 
 	var paymentHash lntypes.Hash
 	copy(paymentHash[:], event.GetPaymentHash())
@@ -277,7 +281,12 @@ func outSwapHtlcEventFromProto(event *swaprpc.OutSwapHtlcEvent) (
 		OnionBlob: append(
 			[]byte(nil), event.GetOnionBlob()...,
 		),
-		VHTLCConfig: *cfg,
+		VHTLCConfig:    *cfg,
+		VHTLCOutpoint:  event.GetVhtlcOutpoint(),
+		VHTLCAmountSat: int64(event.GetVhtlcAmountSat()),
+		VHTLCPkScript: append(
+			[]byte(nil), event.GetVhtlcPkScript()...,
+		),
 	}, nil
 }
 

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -968,6 +968,32 @@ func (s *ReceiveSession) acceptOutSwapHtlcEvent(ctx context.Context,
 		return fmt.Errorf("get vHTLC pkScript: %w", err)
 	}
 
+	// When the swap server reports the script it actually funded, compare
+	// it to the one derived here. A mismatch means the two sides disagree
+	// on the vHTLC script (for example a lib/arkscript version skew); the
+	// funded output then lives at an address this receiver would never
+	// query, so the poll would otherwise loop until the refund locktime.
+	// Fail fast with a clear reason instead. The check is skipped for older
+	// servers that do not populate the script.
+	if len(event.VHTLCPkScript) > 0 &&
+		!bytes.Equal(event.VHTLCPkScript, pkScript) {
+		return s.failTerminal(
+			ctx, fmt.Sprintf("swap server funded vHTLC script %x "+
+				"but receiver derived %x; client and server "+
+				"disagree on the vHTLC script (likely a "+
+				"lib/arkscript version skew)",
+				event.VHTLCPkScript, pkScript),
+			nil,
+			nil,
+		)
+	}
+
+	s.client.log.DebugS(ctx, "Accepted out-swap HTLC event",
+		btclog.Hex("hash", s.PaymentHash[:]),
+		slog.String("pk_script", hex.EncodeToString(pkScript)),
+		slog.String("server_vhtlc_outpoint", event.VHTLCOutpoint),
+	)
+
 	policyTemplate, err := encodeVHTLCPolicyTemplate(policy)
 	if err != nil {
 		return fmt.Errorf("encode vHTLC policy: %w", err)

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -324,6 +324,125 @@ func TestReceiveSessionSkipsServerAckForSameArkHTLCEvent(t *testing.T) {
 	require.Zero(t, session.pendingHTLCAckCursor)
 }
 
+// newOutSwapSkewTestSession builds a receive session at the invoice-created
+// state plus the matching out-swap HTLC event config, wired so
+// acceptOutSwapHtlcEvent can run its onion and script checks. It returns the
+// session, the event config, and the receive auth key the caller passes to
+// acceptOutSwapHtlcEvent.
+func newOutSwapSkewTestSession(t *testing.T) (*ReceiveSession, VHTLCConfig,
+	ReceiveAuthKey) {
+
+	t.Helper()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	authPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage := lntypes.Preimage{4, 5, 6}
+	hash := preimage.Hash()
+
+	daemonConn := &testDaemonConn{
+		identityKey:    clientPriv.PubKey(),
+		operatorKey:    operatorPriv.PubKey(),
+		receiveAuthKey: authPriv.Serialize(),
+	}
+	client := NewSwapClient(nil, daemonConn, nil, nil)
+	useTestOnionDecoder(client, 42_000)
+
+	session := &ReceiveSession{
+		client:         client,
+		amountSat:      btcutil.Amount(42_000),
+		state:          ReceiveStateInvoiceCreated,
+		PaymentHash:    hash,
+		clientPubKey:   clientPriv.PubKey(),
+		operatorPubKey: operatorPriv.PubKey(),
+	}
+
+	cfg := VHTLCConfig{
+		RefundLocktime:                       900,
+		UnilateralClaimDelay:                 5,
+		UnilateralRefundDelay:                6,
+		UnilateralRefundWithoutReceiverDelay: 7,
+		SwapServerPubkey: serverPriv.PubKey().
+			SerializeCompressed(),
+	}
+
+	authKey, err := client.receiveAuthKey(t.Context(), hash)
+	require.NoError(t, err)
+
+	return session, cfg, authKey
+}
+
+// TestAcceptOutSwapHtlcEventDetectsScriptSkew verifies that when the swap
+// server reports a funded vHTLC script that disagrees with the one the receiver
+// derives, the receive fails fast with a clear skew error instead of accepting
+// the event and polling an address that will never be funded.
+func TestAcceptOutSwapHtlcEventDetectsScriptSkew(t *testing.T) {
+	t.Parallel()
+
+	session, cfg, authKey := newOutSwapSkewTestSession(t)
+
+	// A non-empty script that cannot match the locally derived one forces
+	// the skew branch.
+	wrongScript := bytes.Repeat([]byte{0xab}, 34)
+
+	err := session.acceptOutSwapHtlcEvent(t.Context(), &OutSwapHtlcEvent{
+		PaymentHash:   session.PaymentHash,
+		AmountSat:     int64(session.amountSat),
+		VHTLCConfig:   cfg,
+		VHTLCPkScript: wrongScript,
+	}, authKey, 0)
+	require.Error(t, err)
+	require.Contains(t, failureReason(err), "disagree on the vHTLC script")
+	require.Equal(t, ReceiveStateFailed, session.State())
+}
+
+// TestAcceptOutSwapHtlcEventAcceptsMatchingScript verifies that a server-
+// reported funded script matching the locally derived script is accepted
+// normally, so the new skew guard never rejects a healthy receive.
+func TestAcceptOutSwapHtlcEventAcceptsMatchingScript(t *testing.T) {
+	t.Parallel()
+
+	session, cfg, authKey := newOutSwapSkewTestSession(t)
+
+	serverKey, err := btcec.ParsePubKey(cfg.SwapServerPubkey)
+	require.NoError(t, err)
+
+	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:                               serverKey,
+		Receiver:                             session.clientPubKey,
+		Server:                               session.operatorPubKey,
+		PreimageHash:                         session.PaymentHash,
+		RefundLocktime:                       cfg.RefundLocktime,
+		UnilateralClaimDelay:                 cfg.UnilateralClaimDelay,
+		UnilateralRefundDelay:                cfg.UnilateralRefundDelay,
+		UnilateralRefundWithoutReceiverDelay: cfg.UnilateralRefundWithoutReceiverDelay, //nolint:ll
+	})
+	require.NoError(t, err)
+
+	matchingScript, err := policy.PkScript()
+	require.NoError(t, err)
+
+	err = session.acceptOutSwapHtlcEvent(t.Context(), &OutSwapHtlcEvent{
+		PaymentHash:   session.PaymentHash,
+		AmountSat:     int64(session.amountSat),
+		VHTLCConfig:   cfg,
+		VHTLCOutpoint: "funded-txid:0",
+		VHTLCPkScript: matchingScript,
+	}, authKey, 0)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, session.State())
+	require.Equal(t, matchingScript, session.vhtlcPkScript)
+}
+
 type testSwapServerConn struct {
 	hint           *RouteHint
 	payerFeeMsat   uint64

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -324,7 +324,21 @@ type OutSwapHtlcEvent struct {
 	OnionBlob []byte `protobuf:"bytes,3,opt,name=onion_blob,json=onionBlob,proto3" json:"onion_blob,omitempty"`
 	// vhtlc_config contains the virtual HTLC parameters the client should use
 	// when constructing the expected output.
-	VhtlcConfig   *VHTLCConfig `protobuf:"bytes,4,opt,name=vhtlc_config,json=vhtlcConfig,proto3" json:"vhtlc_config,omitempty"`
+	VhtlcConfig *VHTLCConfig `protobuf:"bytes,4,opt,name=vhtlc_config,json=vhtlcConfig,proto3" json:"vhtlc_config,omitempty"`
+	// vhtlc_outpoint is the funded vHTLC outpoint in "txid:vout" format, when
+	// the swap server knows it at notification time. It lets the receiver
+	// cross-check the output it later observes against the one the server
+	// actually funded. Empty when the server has not recorded the outpoint.
+	VhtlcOutpoint string `protobuf:"bytes,5,opt,name=vhtlc_outpoint,json=vhtlcOutpoint,proto3" json:"vhtlc_outpoint,omitempty"`
+	// vhtlc_amount_sat is the funded vHTLC amount in satoshis, when known.
+	VhtlcAmountSat uint64 `protobuf:"varint,6,opt,name=vhtlc_amount_sat,json=vhtlcAmountSat,proto3" json:"vhtlc_amount_sat,omitempty"`
+	// vhtlc_pk_script is the P2TR script of the funded vHTLC as computed by
+	// the swap server from the same parameters in vhtlc_config. The receiver
+	// compares it against the script it derives locally; a mismatch means the
+	// two sides disagree on the vHTLC script (for example a lib/arkscript
+	// version skew) and the funded output lives at a different address than the
+	// receiver would ever query. Empty for older servers that do not set it.
+	VhtlcPkScript []byte `protobuf:"bytes,7,opt,name=vhtlc_pk_script,json=vhtlcPkScript,proto3" json:"vhtlc_pk_script,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -383,6 +397,27 @@ func (x *OutSwapHtlcEvent) GetOnionBlob() []byte {
 func (x *OutSwapHtlcEvent) GetVhtlcConfig() *VHTLCConfig {
 	if x != nil {
 		return x.VhtlcConfig
+	}
+	return nil
+}
+
+func (x *OutSwapHtlcEvent) GetVhtlcOutpoint() string {
+	if x != nil {
+		return x.VhtlcOutpoint
+	}
+	return ""
+}
+
+func (x *OutSwapHtlcEvent) GetVhtlcAmountSat() uint64 {
+	if x != nil {
+		return x.VhtlcAmountSat
+	}
+	return 0
+}
+
+func (x *OutSwapHtlcEvent) GetVhtlcPkScript() []byte {
+	if x != nil {
+		return x.VhtlcPkScript
 	}
 	return nil
 }
@@ -1145,14 +1180,17 @@ const file_swap_proto_rawDesc = "" +
 	"\x1dAcknowledgeOutSwapHtlcRequest\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12.\n" +
 	"\x13client_vhtlc_pubkey\x18\x02 \x01(\fR\x11clientVhtlcPubkey\" \n" +
-	"\x1eAcknowledgeOutSwapHtlcResponse\"\xac\x01\n" +
+	"\x1eAcknowledgeOutSwapHtlcResponse\"\xa5\x02\n" +
 	"\x10OutSwapHtlcEvent\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x1d\n" +
 	"\n" +
 	"amount_sat\x18\x02 \x01(\x04R\tamountSat\x12\x1d\n" +
 	"\n" +
 	"onion_blob\x18\x03 \x01(\fR\tonionBlob\x127\n" +
-	"\fvhtlc_config\x18\x04 \x01(\v2\x14.swaprpc.VHTLCConfigR\vvhtlcConfig\"\x97\x01\n" +
+	"\fvhtlc_config\x18\x04 \x01(\v2\x14.swaprpc.VHTLCConfigR\vvhtlcConfig\x12%\n" +
+	"\x0evhtlc_outpoint\x18\x05 \x01(\tR\rvhtlcOutpoint\x12(\n" +
+	"\x10vhtlc_amount_sat\x18\x06 \x01(\x04R\x0evhtlcAmountSat\x12&\n" +
+	"\x0fvhtlc_pk_script\x18\a \x01(\fR\rvhtlcPkScript\"\x97\x01\n" +
 	"\x10SwapMailboxEvent\x12?\n" +
 	"\rout_swap_htlc\x18\x01 \x01(\v2\x19.swaprpc.OutSwapHtlcEventH\x00R\voutSwapHtlc\x129\n" +
 	"\vin_ark_htlc\x18\x02 \x01(\v2\x17.swaprpc.InArkHtlcEventH\x00R\tinArkHtlcB\a\n" +

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -111,6 +111,23 @@ message OutSwapHtlcEvent {
     // vhtlc_config contains the virtual HTLC parameters the client should use
     // when constructing the expected output.
     VHTLCConfig vhtlc_config = 4;
+
+    // vhtlc_outpoint is the funded vHTLC outpoint in "txid:vout" format, when
+    // the swap server knows it at notification time. It lets the receiver
+    // cross-check the output it later observes against the one the server
+    // actually funded. Empty when the server has not recorded the outpoint.
+    string vhtlc_outpoint = 5;
+
+    // vhtlc_amount_sat is the funded vHTLC amount in satoshis, when known.
+    uint64 vhtlc_amount_sat = 6;
+
+    // vhtlc_pk_script is the P2TR script of the funded vHTLC as computed by
+    // the swap server from the same parameters in vhtlc_config. The receiver
+    // compares it against the script it derives locally; a mismatch means the
+    // two sides disagree on the vHTLC script (for example a lib/arkscript
+    // version skew) and the funded output lives at a different address than the
+    // receiver would ever query. Empty for older servers that do not set it.
+    bytes vhtlc_pk_script = 7;
 }
 
 // SwapMailboxEvent is the explicit event wrapper carried by swap mailbox


### PR DESCRIPTION
## Summary

Closes the remaining #538 failure mode that retrying alone cannot fix: a
**client/server `lib/arkscript` skew** where the swap server funds one vHTLC
pkScript while the receiver derives (and polls for) another. The poll never
resolves and only expires at the refund locktime.

This is the client (darepo-client) half of the fix. It adds optional fields to
the out-swap HTLC event so the swap server can report the vHTLC it actually
funded, and has the receiver fail fast on a script disagreement.

### Changes
- **`swaprpc/swap.proto`**: add `vhtlc_outpoint`, `vhtlc_amount_sat`, and
  `vhtlc_pk_script` to `OutSwapHtlcEvent` (mirrors `InArkHtlcEvent`; all
  optional). Regenerated `swap.pb.go` via `make rpc`.
- **`sdk/swaps`**: thread the new fields through the SDK `OutSwapHtlcEvent` and
  its proto converter; in `acceptOutSwapHtlcEvent`, compare the server-reported
  `vhtlc_pk_script` against the locally derived script and fail terminally with
  a clear "client and server disagree on the vHTLC script (likely a
  lib/arkscript version skew)" reason on mismatch. Skipped when the field is
  empty, so receives against older servers are unchanged.

### Tests
- `TestAcceptOutSwapHtlcEventDetectsScriptSkew` — mismatched server script →
  terminal failure with the skew reason.
- `TestAcceptOutSwapHtlcEventAcceptsMatchingScript` — matching script → normal
  acceptance (guard never rejects a healthy receive).

### Relationship to the other #538 work
- The **race** (pre-funded window) is already handled in main (PR #550) and
  covered by tests in #623. This PR handles the **skew** variant.
- The server half (populate the new fields from `swap.VHTLCOutpoint` /
  computed pkScript in `publishOutSwapHtlcEvent`) is a companion swapdk-server
  PR that bumps its `client` submodule to include this change.

## Validation
- `go test ./sdk/swaps/` (full package)
- `make fmt-changed-check`
- `make lint-changed-local` — 0 issues
- `make commitmsg-lint range="origin/main..HEAD"`