### PR TITLE
walletdk: add prepare-send flow

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_send.go
+++ b/cmd/darepocli/darepoclicommands/cmd_send.go
@@ -1,7 +1,9 @@
 package darepoclicommands
 
 import (
+	"bufio"
 	"fmt"
+	"strings"
 
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 	"github.com/spf13/cobra"
@@ -56,9 +58,11 @@ func newSendCmd() *cobra.Command {
 		"onchain only: drain the wallet to the destination. "+
 			"--amt MUST be 0 when set.")
 	cmd.Flags().Bool("dry-run", false,
-		"validate inputs locally and print the preview without "+
-			"dispatching to the daemon; exits 10 on a valid "+
-			"preview, non-zero on validation failure")
+		"prepare and print the preview without dispatching funds")
+	cmd.Flags().Bool("force", false,
+		"skip interactive confirmation after prepare")
+	cmd.Flags().Bool("yes", false,
+		"alias for --force")
 
 	return cmd
 }
@@ -115,38 +119,58 @@ func walletSend(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	req := &walletdkrpc.SendRequest{
+	req := &walletdkrpc.PrepareSendRequest{
 		AmtSat:    amt,
 		MaxFeeSat: maxFee,
 		Note:      note,
 		SweepAll:  sweepAll,
 	}
 	if offchain {
-		req.Destination = &walletdkrpc.SendRequest_Invoice{
+		req.Destination = &walletdkrpc.PrepareSendRequest_Invoice{
 			Invoice: dest,
 		}
 	} else {
-		req.Destination = &walletdkrpc.SendRequest_OnchainAddress{
+		req.Destination = &walletdkrpc.
+			PrepareSendRequest_OnchainAddress{
 			OnchainAddress: dest,
 		}
 	}
 
-	// --dry-run validates every invariant we just enforced and prints
-	// the proto-JSON preview without dispatching. Returning a code-10
-	// printedError lets main.go signal "dry-run passed" distinctly
-	// from a real send so an agent can stage a payment without
-	// risking a duplicate dispatch.
-	if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
-		return walletDryRunPreview(
-			"walletdkrpc.WalletService/Send", req,
-		)
-	}
-
 	return withWalletClient(
 		cmd, func(c walletdkrpc.WalletServiceClient) error {
-			resp, err := c.Send(cmd.Context(), req)
+			prepareResp, err := c.PrepareSend(cmd.Context(), req)
 			if err != nil {
-				return fmt.Errorf("send: %w", err)
+				return fmt.Errorf("prepare send: %w", err)
+			}
+
+			if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
+				if err := printWalletProto(
+					prepareResp,
+				); err != nil {
+					return err
+				}
+
+				return PrintError(
+					"DRY_RUN_OK", "dry-run validation "+
+						"passed; no funds were "+
+						"dispatched",
+				)
+			}
+
+			err = confirmSendIfNeeded(cmd, prepareResp)
+			if err != nil {
+				return err
+			}
+
+			intentID := prepareResp.GetSendIntentId()
+			resp, err := c.Send(
+				cmd.Context(), &walletdkrpc.SendRequest{
+					SendIntentId: intentID,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("send prepared intent: %w",
+					err)
 			}
 
 			// For onchain sends actual_amount_sat may exceed
@@ -168,4 +192,114 @@ func walletSend(cmd *cobra.Command, args []string) error {
 			return printWalletProto(resp)
 		},
 	)
+}
+
+func confirmSendIfNeeded(cmd *cobra.Command,
+	resp *walletdkrpc.PrepareSendResponse) error {
+
+	force, _ := cmd.Flags().GetBool("force")
+	yes, _ := cmd.Flags().GetBool("yes")
+	if force || yes {
+		return nil
+	}
+
+	if !stdinIsTTY(cmd) {
+		return PrintError(
+			"INVALID_ARGS", "send requires --force or --yes on "+
+				"non-interactive stdin; refusing to prompt "+
+				"because an agent cannot respond to y/N",
+		)
+	}
+
+	return promptSendConfirmation(cmd, resp)
+}
+
+func promptSendConfirmation(cmd *cobra.Command,
+	resp *walletdkrpc.PrepareSendResponse) error {
+
+	out := cmd.ErrOrStderr()
+
+	fmt.Fprintf(out, "Send %d sats\n", sendPreviewHeadlineAmount(resp))
+	fmt.Fprintf(out, "Rail: %s\n", sendRailLabel(resp.GetRail()))
+	if resp.GetFeeKnown() {
+		fmt.Fprintf(
+			out, "Expected fee: %d sats\n",
+			resp.GetExpectedFeeSat(),
+		)
+	} else {
+		fmt.Fprintln(out, "Expected fee: unknown")
+	}
+	if resp.GetTotalOutflowKnown() {
+		fmt.Fprintf(
+			out, "Expected total outflow: %d sats\n",
+			resp.GetExpectedTotalOutflowSat(),
+		)
+	} else {
+		fmt.Fprintln(out, "Expected total outflow: unknown")
+	}
+	if dest := resp.GetDestinationSummary(); dest != "" {
+		fmt.Fprintf(out, "Destination: %s\n", dest)
+	}
+	if desc := resp.GetInvoiceDescription(); desc != "" {
+		fmt.Fprintf(out, "Invoice: %s\n", desc)
+	}
+	if hash := resp.GetPaymentHash(); hash != "" {
+		fmt.Fprintf(out, "Payment hash: %s\n", hash)
+	}
+	if warning := resp.GetWarning(); warning != "" {
+		fmt.Fprintf(out, "Warning: %s\n", warning)
+	}
+	fmt.Fprint(out, "\nProceed? [y/N]: ")
+
+	reader := bufio.NewReader(cmd.InOrStdin())
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read confirmation: %w", err)
+	}
+
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer != "y" && answer != "yes" {
+		return fmt.Errorf("aborted by user")
+	}
+
+	return nil
+}
+
+func sendPreviewHeadlineAmount(resp *walletdkrpc.PrepareSendResponse) int64 {
+	if resp == nil {
+		return 0
+	}
+
+	amountSat := resp.GetAmountSat()
+	if amountSat != 0 {
+		return amountSat
+	}
+
+	if resp.GetRail() != walletdkrpc.SendRail_SEND_RAIL_ONCHAIN {
+		return amountSat
+	}
+	if !resp.GetTotalOutflowKnown() {
+		return amountSat
+	}
+
+	return resp.GetExpectedTotalOutflowSat()
+}
+
+func sendRailLabel(rail walletdkrpc.SendRail) string {
+	switch rail {
+	case walletdkrpc.SendRail_SEND_RAIL_IN_ARK:
+		return "in-Ark"
+
+	case walletdkrpc.SendRail_SEND_RAIL_LIGHTNING:
+		return "Lightning"
+
+	case walletdkrpc.SendRail_SEND_RAIL_ONCHAIN:
+		return "onchain"
+
+	case walletdkrpc.SendRail_SEND_RAIL_OFFCHAIN_UNKNOWN:
+		return "offchain"
+
+	default:
+		return "unknown"
+	}
 }

--- a/cmd/darepocli/darepoclicommands/cmd_send_test.go
+++ b/cmd/darepocli/darepoclicommands/cmd_send_test.go
@@ -1,0 +1,88 @@
+package darepoclicommands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfirmSendIfNeededRefusesNonTTY(t *testing.T) {
+	prev := stdinIsTTY
+	stdinIsTTY = func(*cobra.Command) bool { return false }
+	t.Cleanup(func() {
+		stdinIsTTY = prev
+	})
+
+	cmd := newSendCmd()
+	err := confirmSendIfNeeded(cmd, &walletdkrpc.PrepareSendResponse{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-interactive stdin")
+}
+
+func TestConfirmSendIfNeededForceSkipsPrompt(t *testing.T) {
+	prev := stdinIsTTY
+	stdinIsTTY = func(*cobra.Command) bool { return false }
+	t.Cleanup(func() {
+		stdinIsTTY = prev
+	})
+
+	cmd := newSendCmd()
+	require.NoError(t, cmd.Flags().Set("force", "true"))
+
+	err := confirmSendIfNeeded(cmd, &walletdkrpc.PrepareSendResponse{})
+	require.NoError(t, err)
+}
+
+func TestPromptSendConfirmationAcceptsYes(t *testing.T) {
+	cmd := newSendCmd()
+	cmd.SetIn(strings.NewReader("yes\n"))
+
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	err := promptSendConfirmation(cmd, &walletdkrpc.PrepareSendResponse{
+		AmountSat:               50_000,
+		ExpectedFeeSat:          123,
+		FeeKnown:                true,
+		ExpectedTotalOutflowSat: 50_123,
+		TotalOutflowKnown:       true,
+		Rail: walletdkrpc.
+			SendRail_SEND_RAIL_LIGHTNING,
+		DestinationSummary: "lnbc...",
+		PaymentHash:        "abcd",
+	})
+	require.NoError(t, err)
+	require.Contains(t, stderr.String(), "Send 50000 sats")
+	require.Contains(t, stderr.String(), "Proceed? [y/N]:")
+}
+
+func TestPromptSendConfirmationUsesSweepOutflow(t *testing.T) {
+	cmd := newSendCmd()
+	cmd.SetIn(strings.NewReader("yes\n"))
+
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	err := promptSendConfirmation(cmd, &walletdkrpc.PrepareSendResponse{
+		AmountSat:               0,
+		ExpectedTotalOutflowSat: 12_000,
+		TotalOutflowKnown:       true,
+		Rail: walletdkrpc.
+			SendRail_SEND_RAIL_ONCHAIN,
+	})
+	require.NoError(t, err)
+	require.Contains(t, stderr.String(), "Send 12000 sats")
+	require.NotContains(t, stderr.String(), "Send 0 sats")
+}
+
+func TestPromptSendConfirmationDefaultsNo(t *testing.T) {
+	cmd := newSendCmd()
+	cmd.SetIn(strings.NewReader("\n"))
+
+	err := promptSendConfirmation(cmd, &walletdkrpc.PrepareSendResponse{})
+	require.ErrorContains(t, err, "aborted by user")
+}

--- a/cmd/darepocli/darepoclicommands/mcp_wallet.go
+++ b/cmd/darepocli/darepoclicommands/mcp_wallet.go
@@ -136,14 +136,20 @@ func registerMCPWalletMutateTools(s *mcp.Server,
 		if err != nil {
 			return nil, nil, err
 		}
-		req, err := buildWalletSendRequest(
+		req, err := buildWalletPrepareSendRequest(
 			args.Destination, offchain, args.AmtSat, args.MaxFeeSat,
 			args.Note, args.SweepAll,
 		)
 		if err != nil {
 			return nil, nil, err
 		}
-		resp, err := client.Send(ctx, req)
+		prepareResp, err := client.PrepareSend(ctx, req)
+		if err != nil {
+			return nil, nil, mapWalletRPCError(err)
+		}
+		resp, err := client.Send(ctx, &walletdkrpc.SendRequest{
+			SendIntentId: prepareResp.GetSendIntentId(),
+		})
 		if err != nil {
 			return nil, nil, mapWalletRPCError(err)
 		}
@@ -261,12 +267,14 @@ func buildWalletActivityRequest(pendingOnly bool, kinds []string, limit,
 	return req, nil
 }
 
-// buildWalletSendRequest assembles a SendRequest while running the
+// buildWalletPrepareSendRequest assembles a PrepareSendRequest while running
+// the
 // CLI's input hardening (validateDestination, validateFreeText) and
 // the offchain/onchain invariants so MCP can't construct a shape the
 // CLI would reject.
-func buildWalletSendRequest(dest string, offchain bool, amt, maxFee uint64,
-	note string, sweepAll bool) (*walletdkrpc.SendRequest, error) {
+func buildWalletPrepareSendRequest(dest string, offchain bool, amt,
+	maxFee uint64, note string,
+	sweepAll bool) (*walletdkrpc.PrepareSendRequest, error) {
 
 	if err := validateDestination(dest); err != nil {
 		return nil, err
@@ -290,18 +298,19 @@ func buildWalletSendRequest(dest string, offchain bool, amt, maxFee uint64,
 		}
 	}
 
-	req := &walletdkrpc.SendRequest{
+	req := &walletdkrpc.PrepareSendRequest{
 		AmtSat:    amt,
 		MaxFeeSat: maxFee,
 		Note:      note,
 		SweepAll:  sweepAll,
 	}
 	if offchain {
-		req.Destination = &walletdkrpc.SendRequest_Invoice{
+		req.Destination = &walletdkrpc.PrepareSendRequest_Invoice{
 			Invoice: dest,
 		}
 	} else {
-		req.Destination = &walletdkrpc.SendRequest_OnchainAddress{
+		req.Destination = &walletdkrpc.
+			PrepareSendRequest_OnchainAddress{
 			OnchainAddress: dest,
 		}
 	}

--- a/cmd/darepocli/darepoclicommands/mcp_wallet_test.go
+++ b/cmd/darepocli/darepoclicommands/mcp_wallet_test.go
@@ -30,11 +30,11 @@ func TestParseDirectionFieldRejectsUnknown(t *testing.T) {
 	require.Contains(t, err.Error(), "unknown direction")
 }
 
-// TestBuildWalletSendRequestHardensAgentInput exercises the shared
+// TestBuildWalletPrepareSendRequestHardensAgentInput exercises the shared
 // builder used by both the CLI send verb and the MCP send tool. The
 // MCP path can't drift past the same input-hardening checks as the
 // CLI, so the rejections are exhaustive.
-func TestBuildWalletSendRequestHardensAgentInput(t *testing.T) {
+func TestBuildWalletPrepareSendRequestHardensAgentInput(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -94,7 +94,7 @@ func TestBuildWalletSendRequestHardensAgentInput(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := buildWalletSendRequest(
+			_, err := buildWalletPrepareSendRequest(
 				tc.dest, tc.offchain, tc.amt, 0, tc.note,
 				tc.sweepAll,
 			)
@@ -104,12 +104,12 @@ func TestBuildWalletSendRequestHardensAgentInput(t *testing.T) {
 	}
 }
 
-// TestBuildWalletSendRequestHappyPath confirms a valid invoice send
+// TestBuildWalletPrepareSendRequestHappyPath confirms a valid invoice send
 // produces the expected oneof and scalar fields.
-func TestBuildWalletSendRequestHappyPath(t *testing.T) {
+func TestBuildWalletPrepareSendRequestHappyPath(t *testing.T) {
 	t.Parallel()
 
-	req, err := buildWalletSendRequest(
+	req, err := buildWalletPrepareSendRequest(
 		"lnbcrt100u1pwlqxyz", true, 0, 250, "coffee", false,
 	)
 	require.NoError(t, err)

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -36,6 +36,10 @@ type schemaMethod struct {
 	// ResponseType is the proto response message name.
 	ResponseType string `json:"response_type"`
 
+	// DryRunResponseType is the proto response message name emitted in
+	// dry-run mode when it differs from ResponseType.
+	DryRunResponseType string `json:"dry_run_response_type,omitempty"`
+
 	// DryRun indicates whether the command supports --dry-run /
 	// --dry_run. Top-level wallet verbs use --dry-run (CLI-only
 	// validation, exits 10); ark.* commands use --dry_run that
@@ -208,17 +212,28 @@ func walletPaymentMethodRegistry() []schemaMethod {
 				{
 					Name: "dry-run",
 					Type: "bool",
-					Description: "CLI-side validation " +
-						"only; print the proto-JSON " +
-						"preview and exit 10 without " +
+					Description: "prepare and print the " +
+						"proto-JSON preview without " +
 						"dispatching",
 				},
+				{
+					Name: "force",
+					Type: "bool",
+					Description: "skip interactive " +
+						"confirmation",
+				},
+				{
+					Name:        "yes",
+					Type:        "bool",
+					Description: "alias for force",
+				},
 			},
-			RequestType:  "SendRequest",
-			ResponseType: "SendResponse",
-			DryRun:       true,
-			JSONInput:    false,
-			MCPTool:      true,
+			RequestType:        "PrepareSendRequest",
+			ResponseType:       "SendResponse",
+			DryRunResponseType: "PrepareSendResponse",
+			DryRun:             true,
+			JSONInput:          false,
+			MCPTool:            true,
 		},
 		{
 			Method:      "recv",

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -797,6 +797,17 @@ func (c *WalletServiceClient) Unlock(ctx context.Context,
 	return out, err
 }
 
+// PrepareSend validates and previews a wallet send.
+func (c *WalletServiceClient) PrepareSend(ctx context.Context,
+	in *walletdkrpc.PrepareSendRequest, _ ...grpc.CallOption) (
+	*walletdkrpc.PrepareSendResponse, error) {
+
+	out := new(walletdkrpc.PrepareSendResponse)
+	err := c.client.Post(ctx, "/v1/wallet/prepare-send", in, out)
+
+	return out, err
+}
+
 // Send dispatches a wallet send.
 func (c *WalletServiceClient) Send(ctx context.Context,
 	in *walletdkrpc.SendRequest, _ ...grpc.CallOption) (

--- a/rpc/walletdkrpc/wallet.pb.go
+++ b/rpc/walletdkrpc/wallet.pb.go
@@ -197,6 +197,120 @@ func (ListView) EnumDescriptor() ([]byte, []int) {
 	return file_wallet_proto_rawDescGZIP(), []int{2}
 }
 
+// SendRail identifies the expected settlement rail for a prepared send.
+type SendRail int32
+
+const (
+	SendRail_SEND_RAIL_UNSPECIFIED SendRail = 0
+	// SEND_RAIL_OFFCHAIN_UNKNOWN is used when the wallet can parse the
+	// invoice locally but the swapserver has not supplied a quote that
+	// distinguishes same-Ark settlement from Lightning settlement.
+	SendRail_SEND_RAIL_OFFCHAIN_UNKNOWN SendRail = 1
+	SendRail_SEND_RAIL_IN_ARK           SendRail = 2
+	SendRail_SEND_RAIL_LIGHTNING        SendRail = 3
+	SendRail_SEND_RAIL_ONCHAIN          SendRail = 4
+)
+
+// Enum value maps for SendRail.
+var (
+	SendRail_name = map[int32]string{
+		0: "SEND_RAIL_UNSPECIFIED",
+		1: "SEND_RAIL_OFFCHAIN_UNKNOWN",
+		2: "SEND_RAIL_IN_ARK",
+		3: "SEND_RAIL_LIGHTNING",
+		4: "SEND_RAIL_ONCHAIN",
+	}
+	SendRail_value = map[string]int32{
+		"SEND_RAIL_UNSPECIFIED":      0,
+		"SEND_RAIL_OFFCHAIN_UNKNOWN": 1,
+		"SEND_RAIL_IN_ARK":           2,
+		"SEND_RAIL_LIGHTNING":        3,
+		"SEND_RAIL_ONCHAIN":          4,
+	}
+)
+
+func (x SendRail) Enum() *SendRail {
+	p := new(SendRail)
+	*p = x
+	return p
+}
+
+func (x SendRail) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SendRail) Descriptor() protoreflect.EnumDescriptor {
+	return file_wallet_proto_enumTypes[3].Descriptor()
+}
+
+func (SendRail) Type() protoreflect.EnumType {
+	return &file_wallet_proto_enumTypes[3]
+}
+
+func (x SendRail) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SendRail.Descriptor instead.
+func (SendRail) EnumDescriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{3}
+}
+
+// SendQuoteStatus describes how complete the prepare-time quote is.
+type SendQuoteStatus int32
+
+const (
+	SendQuoteStatus_SEND_QUOTE_STATUS_UNSPECIFIED SendQuoteStatus = 0
+	// SEND_QUOTE_STATUS_COMPLETE means every user-visible amount and fee
+	// field is backed by a remote quote.
+	SendQuoteStatus_SEND_QUOTE_STATUS_COMPLETE SendQuoteStatus = 1
+	// SEND_QUOTE_STATUS_LOCAL_ONLY means the wallet performed local
+	// validation and selection but one or more remote quote APIs are not
+	// available yet.
+	SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY SendQuoteStatus = 2
+)
+
+// Enum value maps for SendQuoteStatus.
+var (
+	SendQuoteStatus_name = map[int32]string{
+		0: "SEND_QUOTE_STATUS_UNSPECIFIED",
+		1: "SEND_QUOTE_STATUS_COMPLETE",
+		2: "SEND_QUOTE_STATUS_LOCAL_ONLY",
+	}
+	SendQuoteStatus_value = map[string]int32{
+		"SEND_QUOTE_STATUS_UNSPECIFIED": 0,
+		"SEND_QUOTE_STATUS_COMPLETE":    1,
+		"SEND_QUOTE_STATUS_LOCAL_ONLY":  2,
+	}
+)
+
+func (x SendQuoteStatus) Enum() *SendQuoteStatus {
+	p := new(SendQuoteStatus)
+	*p = x
+	return p
+}
+
+func (x SendQuoteStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SendQuoteStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_wallet_proto_enumTypes[4].Descriptor()
+}
+
+func (SendQuoteStatus) Type() protoreflect.EnumType {
+	return &file_wallet_proto_enumTypes[4]
+}
+
+func (x SendQuoteStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SendQuoteStatus.Descriptor instead.
+func (SendQuoteStatus) EnumDescriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{4}
+}
+
 // ExitJobStatus collapses the underlying unroll job phases to a short
 // wallet-facing string set.
 type ExitJobStatus int32
@@ -256,11 +370,11 @@ func (x ExitJobStatus) String() string {
 }
 
 func (ExitJobStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_wallet_proto_enumTypes[3].Descriptor()
+	return file_wallet_proto_enumTypes[5].Descriptor()
 }
 
 func (ExitJobStatus) Type() protoreflect.EnumType {
-	return &file_wallet_proto_enumTypes[3]
+	return &file_wallet_proto_enumTypes[5]
 }
 
 func (x ExitJobStatus) Number() protoreflect.EnumNumber {
@@ -269,7 +383,7 @@ func (x ExitJobStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ExitJobStatus.Descriptor instead.
 func (ExitJobStatus) EnumDescriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{3}
+	return file_wallet_proto_rawDescGZIP(), []int{5}
 }
 
 // WalletEntryPhase is a coarse, wallet-facing lifecycle phase. It is not a
@@ -347,11 +461,11 @@ func (x WalletEntryPhase) String() string {
 }
 
 func (WalletEntryPhase) Descriptor() protoreflect.EnumDescriptor {
-	return file_wallet_proto_enumTypes[4].Descriptor()
+	return file_wallet_proto_enumTypes[6].Descriptor()
 }
 
 func (WalletEntryPhase) Type() protoreflect.EnumType {
-	return &file_wallet_proto_enumTypes[4]
+	return &file_wallet_proto_enumTypes[6]
 }
 
 func (x WalletEntryPhase) Number() protoreflect.EnumNumber {
@@ -360,7 +474,7 @@ func (x WalletEntryPhase) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WalletEntryPhase.Descriptor instead.
 func (WalletEntryPhase) EnumDescriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{4}
+	return file_wallet_proto_rawDescGZIP(), []int{6}
 }
 
 type CreateRequest struct {
@@ -584,16 +698,16 @@ func (x *UnlockResponse) GetIdentityPubkey() string {
 	return ""
 }
 
-type SendRequest struct {
+type PrepareSendRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// destination selects the outbound payment target. Exactly one
 	// variant must be set.
 	//
 	// Types that are valid to be assigned to Destination:
 	//
-	//	*SendRequest_Invoice
-	//	*SendRequest_OnchainAddress
-	Destination isSendRequest_Destination `protobuf_oneof:"destination"`
+	//	*PrepareSendRequest_Invoice
+	//	*PrepareSendRequest_OnchainAddress
+	Destination isPrepareSendRequest_Destination `protobuf_oneof:"destination"`
 	// amt_sat is required for onchain sends. For onchain sends amt_sat
 	// must be strictly positive unless sweep_all is set, in which case
 	// it must be zero. For invoice sends amt_sat is ignored: v1 requires
@@ -618,9 +732,287 @@ type SendRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
+func (x *PrepareSendRequest) Reset() {
+	*x = PrepareSendRequest{}
+	mi := &file_wallet_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareSendRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareSendRequest) ProtoMessage() {}
+
+func (x *PrepareSendRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareSendRequest.ProtoReflect.Descriptor instead.
+func (*PrepareSendRequest) Descriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *PrepareSendRequest) GetDestination() isPrepareSendRequest_Destination {
+	if x != nil {
+		return x.Destination
+	}
+	return nil
+}
+
+func (x *PrepareSendRequest) GetInvoice() string {
+	if x != nil {
+		if x, ok := x.Destination.(*PrepareSendRequest_Invoice); ok {
+			return x.Invoice
+		}
+	}
+	return ""
+}
+
+func (x *PrepareSendRequest) GetOnchainAddress() string {
+	if x != nil {
+		if x, ok := x.Destination.(*PrepareSendRequest_OnchainAddress); ok {
+			return x.OnchainAddress
+		}
+	}
+	return ""
+}
+
+func (x *PrepareSendRequest) GetAmtSat() uint64 {
+	if x != nil {
+		return x.AmtSat
+	}
+	return 0
+}
+
+func (x *PrepareSendRequest) GetNote() string {
+	if x != nil {
+		return x.Note
+	}
+	return ""
+}
+
+func (x *PrepareSendRequest) GetMaxFeeSat() uint64 {
+	if x != nil {
+		return x.MaxFeeSat
+	}
+	return 0
+}
+
+func (x *PrepareSendRequest) GetSweepAll() bool {
+	if x != nil {
+		return x.SweepAll
+	}
+	return false
+}
+
+type isPrepareSendRequest_Destination interface {
+	isPrepareSendRequest_Destination()
+}
+
+type PrepareSendRequest_Invoice struct {
+	// invoice is a BOLT-11 Lightning invoice. The daemon opens an
+	// out-swap; the swap server picks same-Ark p2p vs real Lightning
+	// transparently.
+	Invoice string `protobuf:"bytes,1,opt,name=invoice,proto3,oneof"`
+}
+
+type PrepareSendRequest_OnchainAddress struct {
+	// onchain_address is a bech32 onchain destination. The daemon
+	// submits a LeaveVTXOs request covering amt_sat plus fees.
+	OnchainAddress string `protobuf:"bytes,2,opt,name=onchain_address,json=onchainAddress,proto3,oneof"`
+}
+
+func (*PrepareSendRequest_Invoice) isPrepareSendRequest_Destination() {}
+
+func (*PrepareSendRequest_OnchainAddress) isPrepareSendRequest_Destination() {}
+
+type PrepareSendResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// send_intent_id is a short-lived, single-use token consumed by Send.
+	SendIntentId string `protobuf:"bytes,1,opt,name=send_intent_id,json=sendIntentId,proto3" json:"send_intent_id,omitempty"`
+	// amount_sat is the destination principal amount.
+	AmountSat int64 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// expected_fee_sat is meaningful only when fee_known is true.
+	ExpectedFeeSat int64 `protobuf:"varint,3,opt,name=expected_fee_sat,json=expectedFeeSat,proto3" json:"expected_fee_sat,omitempty"`
+	// fee_known is false when a required remote quote API is missing.
+	FeeKnown bool `protobuf:"varint,4,opt,name=fee_known,json=feeKnown,proto3" json:"fee_known,omitempty"`
+	// expected_total_outflow_sat is meaningful only when
+	// total_outflow_known is true.
+	ExpectedTotalOutflowSat int64 `protobuf:"varint,5,opt,name=expected_total_outflow_sat,json=expectedTotalOutflowSat,proto3" json:"expected_total_outflow_sat,omitempty"`
+	// total_outflow_known is false when the final outflow depends on a
+	// remote quote that is not available yet.
+	TotalOutflowKnown bool            `protobuf:"varint,6,opt,name=total_outflow_known,json=totalOutflowKnown,proto3" json:"total_outflow_known,omitempty"`
+	Rail              SendRail        `protobuf:"varint,7,opt,name=rail,proto3,enum=walletdkrpc.SendRail" json:"rail,omitempty"`
+	QuoteStatus       SendQuoteStatus `protobuf:"varint,8,opt,name=quote_status,json=quoteStatus,proto3,enum=walletdkrpc.SendQuoteStatus" json:"quote_status,omitempty"`
+	// destination_summary is a short display string suitable for CLI and
+	// UI confirmation prompts.
+	DestinationSummary string `protobuf:"bytes,9,opt,name=destination_summary,json=destinationSummary,proto3" json:"destination_summary,omitempty"`
+	// invoice_description is the BOLT-11 description when present.
+	InvoiceDescription string `protobuf:"bytes,10,opt,name=invoice_description,json=invoiceDescription,proto3" json:"invoice_description,omitempty"`
+	// payment_hash is the invoice payment hash when available.
+	PaymentHash string `protobuf:"bytes,11,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// expires_at_unix is the unix timestamp after which Send rejects the
+	// prepared intent.
+	ExpiresAtUnix int64 `protobuf:"varint,12,opt,name=expires_at_unix,json=expiresAtUnix,proto3" json:"expires_at_unix,omitempty"`
+	// selected_outpoints is populated for onchain sends so Send can spend
+	// exactly the VTXO set previewed to the user.
+	SelectedOutpoints []string `protobuf:"bytes,13,rep,name=selected_outpoints,json=selectedOutpoints,proto3" json:"selected_outpoints,omitempty"`
+	// warning carries a concise human-facing caveat for local-only
+	// previews.
+	Warning       string `protobuf:"bytes,14,opt,name=warning,proto3" json:"warning,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareSendResponse) Reset() {
+	*x = PrepareSendResponse{}
+	mi := &file_wallet_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareSendResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareSendResponse) ProtoMessage() {}
+
+func (x *PrepareSendResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareSendResponse.ProtoReflect.Descriptor instead.
+func (*PrepareSendResponse) Descriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *PrepareSendResponse) GetSendIntentId() string {
+	if x != nil {
+		return x.SendIntentId
+	}
+	return ""
+}
+
+func (x *PrepareSendResponse) GetAmountSat() int64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *PrepareSendResponse) GetExpectedFeeSat() int64 {
+	if x != nil {
+		return x.ExpectedFeeSat
+	}
+	return 0
+}
+
+func (x *PrepareSendResponse) GetFeeKnown() bool {
+	if x != nil {
+		return x.FeeKnown
+	}
+	return false
+}
+
+func (x *PrepareSendResponse) GetExpectedTotalOutflowSat() int64 {
+	if x != nil {
+		return x.ExpectedTotalOutflowSat
+	}
+	return 0
+}
+
+func (x *PrepareSendResponse) GetTotalOutflowKnown() bool {
+	if x != nil {
+		return x.TotalOutflowKnown
+	}
+	return false
+}
+
+func (x *PrepareSendResponse) GetRail() SendRail {
+	if x != nil {
+		return x.Rail
+	}
+	return SendRail_SEND_RAIL_UNSPECIFIED
+}
+
+func (x *PrepareSendResponse) GetQuoteStatus() SendQuoteStatus {
+	if x != nil {
+		return x.QuoteStatus
+	}
+	return SendQuoteStatus_SEND_QUOTE_STATUS_UNSPECIFIED
+}
+
+func (x *PrepareSendResponse) GetDestinationSummary() string {
+	if x != nil {
+		return x.DestinationSummary
+	}
+	return ""
+}
+
+func (x *PrepareSendResponse) GetInvoiceDescription() string {
+	if x != nil {
+		return x.InvoiceDescription
+	}
+	return ""
+}
+
+func (x *PrepareSendResponse) GetPaymentHash() string {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return ""
+}
+
+func (x *PrepareSendResponse) GetExpiresAtUnix() int64 {
+	if x != nil {
+		return x.ExpiresAtUnix
+	}
+	return 0
+}
+
+func (x *PrepareSendResponse) GetSelectedOutpoints() []string {
+	if x != nil {
+		return x.SelectedOutpoints
+	}
+	return nil
+}
+
+func (x *PrepareSendResponse) GetWarning() string {
+	if x != nil {
+		return x.Warning
+	}
+	return ""
+}
+
+type SendRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// send_intent_id is returned by PrepareSend and may be consumed once.
+	SendIntentId  string `protobuf:"bytes,1,opt,name=send_intent_id,json=sendIntentId,proto3" json:"send_intent_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
 func (x *SendRequest) Reset() {
 	*x = SendRequest{}
-	mi := &file_wallet_proto_msgTypes[4]
+	mi := &file_wallet_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -632,7 +1024,7 @@ func (x *SendRequest) String() string {
 func (*SendRequest) ProtoMessage() {}
 
 func (x *SendRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[4]
+	mi := &file_wallet_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -645,82 +1037,15 @@ func (x *SendRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendRequest.ProtoReflect.Descriptor instead.
 func (*SendRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{4}
+	return file_wallet_proto_rawDescGZIP(), []int{6}
 }
 
-func (x *SendRequest) GetDestination() isSendRequest_Destination {
+func (x *SendRequest) GetSendIntentId() string {
 	if x != nil {
-		return x.Destination
-	}
-	return nil
-}
-
-func (x *SendRequest) GetInvoice() string {
-	if x != nil {
-		if x, ok := x.Destination.(*SendRequest_Invoice); ok {
-			return x.Invoice
-		}
+		return x.SendIntentId
 	}
 	return ""
 }
-
-func (x *SendRequest) GetOnchainAddress() string {
-	if x != nil {
-		if x, ok := x.Destination.(*SendRequest_OnchainAddress); ok {
-			return x.OnchainAddress
-		}
-	}
-	return ""
-}
-
-func (x *SendRequest) GetAmtSat() uint64 {
-	if x != nil {
-		return x.AmtSat
-	}
-	return 0
-}
-
-func (x *SendRequest) GetNote() string {
-	if x != nil {
-		return x.Note
-	}
-	return ""
-}
-
-func (x *SendRequest) GetMaxFeeSat() uint64 {
-	if x != nil {
-		return x.MaxFeeSat
-	}
-	return 0
-}
-
-func (x *SendRequest) GetSweepAll() bool {
-	if x != nil {
-		return x.SweepAll
-	}
-	return false
-}
-
-type isSendRequest_Destination interface {
-	isSendRequest_Destination()
-}
-
-type SendRequest_Invoice struct {
-	// invoice is a BOLT-11 Lightning invoice. The daemon opens an
-	// out-swap; the swap server picks same-Ark p2p vs real Lightning
-	// transparently.
-	Invoice string `protobuf:"bytes,1,opt,name=invoice,proto3,oneof"`
-}
-
-type SendRequest_OnchainAddress struct {
-	// onchain_address is a bech32 onchain destination. The daemon
-	// submits a LeaveVTXOs request covering amt_sat plus fees.
-	OnchainAddress string `protobuf:"bytes,2,opt,name=onchain_address,json=onchainAddress,proto3,oneof"`
-}
-
-func (*SendRequest_Invoice) isSendRequest_Destination() {}
-
-func (*SendRequest_OnchainAddress) isSendRequest_Destination() {}
 
 type SendResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -742,7 +1067,7 @@ type SendResponse struct {
 
 func (x *SendResponse) Reset() {
 	*x = SendResponse{}
-	mi := &file_wallet_proto_msgTypes[5]
+	mi := &file_wallet_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -754,7 +1079,7 @@ func (x *SendResponse) String() string {
 func (*SendResponse) ProtoMessage() {}
 
 func (x *SendResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[5]
+	mi := &file_wallet_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -767,7 +1092,7 @@ func (x *SendResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendResponse.ProtoReflect.Descriptor instead.
 func (*SendResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{5}
+	return file_wallet_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *SendResponse) GetEntry() *WalletEntry {
@@ -796,7 +1121,7 @@ type RecvRequest struct {
 
 func (x *RecvRequest) Reset() {
 	*x = RecvRequest{}
-	mi := &file_wallet_proto_msgTypes[6]
+	mi := &file_wallet_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -808,7 +1133,7 @@ func (x *RecvRequest) String() string {
 func (*RecvRequest) ProtoMessage() {}
 
 func (x *RecvRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[6]
+	mi := &file_wallet_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -821,7 +1146,7 @@ func (x *RecvRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RecvRequest.ProtoReflect.Descriptor instead.
 func (*RecvRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{6}
+	return file_wallet_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *RecvRequest) GetAmtSat() uint64 {
@@ -851,7 +1176,7 @@ type RecvResponse struct {
 
 func (x *RecvResponse) Reset() {
 	*x = RecvResponse{}
-	mi := &file_wallet_proto_msgTypes[7]
+	mi := &file_wallet_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -863,7 +1188,7 @@ func (x *RecvResponse) String() string {
 func (*RecvResponse) ProtoMessage() {}
 
 func (x *RecvResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[7]
+	mi := &file_wallet_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -876,7 +1201,7 @@ func (x *RecvResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RecvResponse.ProtoReflect.Descriptor instead.
 func (*RecvResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{7}
+	return file_wallet_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *RecvResponse) GetInvoice() string {
@@ -923,7 +1248,7 @@ type ListRequest struct {
 
 func (x *ListRequest) Reset() {
 	*x = ListRequest{}
-	mi := &file_wallet_proto_msgTypes[8]
+	mi := &file_wallet_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -935,7 +1260,7 @@ func (x *ListRequest) String() string {
 func (*ListRequest) ProtoMessage() {}
 
 func (x *ListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[8]
+	mi := &file_wallet_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -948,7 +1273,7 @@ func (x *ListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRequest.ProtoReflect.Descriptor instead.
 func (*ListRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{8}
+	return file_wallet_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ListRequest) GetView() ListView {
@@ -1011,7 +1336,7 @@ type ListResponse struct {
 
 func (x *ListResponse) Reset() {
 	*x = ListResponse{}
-	mi := &file_wallet_proto_msgTypes[9]
+	mi := &file_wallet_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1023,7 +1348,7 @@ func (x *ListResponse) String() string {
 func (*ListResponse) ProtoMessage() {}
 
 func (x *ListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[9]
+	mi := &file_wallet_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1036,7 +1361,7 @@ func (x *ListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListResponse.ProtoReflect.Descriptor instead.
 func (*ListResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{9}
+	return file_wallet_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ListResponse) GetBody() isListResponse_Body {
@@ -1108,7 +1433,7 @@ type ActivityList struct {
 
 func (x *ActivityList) Reset() {
 	*x = ActivityList{}
-	mi := &file_wallet_proto_msgTypes[10]
+	mi := &file_wallet_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1120,7 +1445,7 @@ func (x *ActivityList) String() string {
 func (*ActivityList) ProtoMessage() {}
 
 func (x *ActivityList) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[10]
+	mi := &file_wallet_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1133,7 +1458,7 @@ func (x *ActivityList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActivityList.ProtoReflect.Descriptor instead.
 func (*ActivityList) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{10}
+	return file_wallet_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ActivityList) GetEntries() []*WalletEntry {
@@ -1163,7 +1488,7 @@ type VTXOInventory struct {
 
 func (x *VTXOInventory) Reset() {
 	*x = VTXOInventory{}
-	mi := &file_wallet_proto_msgTypes[11]
+	mi := &file_wallet_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1175,7 +1500,7 @@ func (x *VTXOInventory) String() string {
 func (*VTXOInventory) ProtoMessage() {}
 
 func (x *VTXOInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[11]
+	mi := &file_wallet_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1188,7 +1513,7 @@ func (x *VTXOInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VTXOInventory.ProtoReflect.Descriptor instead.
 func (*VTXOInventory) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{11}
+	return file_wallet_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *VTXOInventory) GetVtxos() []*WalletVTXO {
@@ -1234,7 +1559,7 @@ type WalletVTXO struct {
 
 func (x *WalletVTXO) Reset() {
 	*x = WalletVTXO{}
-	mi := &file_wallet_proto_msgTypes[12]
+	mi := &file_wallet_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1246,7 +1571,7 @@ func (x *WalletVTXO) String() string {
 func (*WalletVTXO) ProtoMessage() {}
 
 func (x *WalletVTXO) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[12]
+	mi := &file_wallet_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1259,7 +1584,7 @@ func (x *WalletVTXO) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletVTXO.ProtoReflect.Descriptor instead.
 func (*WalletVTXO) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{12}
+	return file_wallet_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *WalletVTXO) GetOutpoint() string {
@@ -1320,7 +1645,7 @@ type OnchainHistory struct {
 
 func (x *OnchainHistory) Reset() {
 	*x = OnchainHistory{}
-	mi := &file_wallet_proto_msgTypes[13]
+	mi := &file_wallet_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1332,7 +1657,7 @@ func (x *OnchainHistory) String() string {
 func (*OnchainHistory) ProtoMessage() {}
 
 func (x *OnchainHistory) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[13]
+	mi := &file_wallet_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1345,7 +1670,7 @@ func (x *OnchainHistory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnchainHistory.ProtoReflect.Descriptor instead.
 func (*OnchainHistory) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{13}
+	return file_wallet_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *OnchainHistory) GetTxs() []*OnchainTx {
@@ -1403,7 +1728,7 @@ type OnchainTx struct {
 
 func (x *OnchainTx) Reset() {
 	*x = OnchainTx{}
-	mi := &file_wallet_proto_msgTypes[14]
+	mi := &file_wallet_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1415,7 +1740,7 @@ func (x *OnchainTx) String() string {
 func (*OnchainTx) ProtoMessage() {}
 
 func (x *OnchainTx) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[14]
+	mi := &file_wallet_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1428,7 +1753,7 @@ func (x *OnchainTx) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnchainTx.ProtoReflect.Descriptor instead.
 func (*OnchainTx) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{14}
+	return file_wallet_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *OnchainTx) GetTxid() string {
@@ -1503,7 +1828,7 @@ type InspectActivityRequest struct {
 
 func (x *InspectActivityRequest) Reset() {
 	*x = InspectActivityRequest{}
-	mi := &file_wallet_proto_msgTypes[15]
+	mi := &file_wallet_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1515,7 +1840,7 @@ func (x *InspectActivityRequest) String() string {
 func (*InspectActivityRequest) ProtoMessage() {}
 
 func (x *InspectActivityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[15]
+	mi := &file_wallet_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1528,7 +1853,7 @@ func (x *InspectActivityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectActivityRequest.ProtoReflect.Descriptor instead.
 func (*InspectActivityRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{15}
+	return file_wallet_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *InspectActivityRequest) GetId() string {
@@ -1569,7 +1894,7 @@ type InspectActivityResponse struct {
 
 func (x *InspectActivityResponse) Reset() {
 	*x = InspectActivityResponse{}
-	mi := &file_wallet_proto_msgTypes[16]
+	mi := &file_wallet_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1581,7 +1906,7 @@ func (x *InspectActivityResponse) String() string {
 func (*InspectActivityResponse) ProtoMessage() {}
 
 func (x *InspectActivityResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[16]
+	mi := &file_wallet_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1594,7 +1919,7 @@ func (x *InspectActivityResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectActivityResponse.ProtoReflect.Descriptor instead.
 func (*InspectActivityResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{16}
+	return file_wallet_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *InspectActivityResponse) GetEntry() *WalletEntry {
@@ -1683,7 +2008,7 @@ type ActivitySwapTrace struct {
 
 func (x *ActivitySwapTrace) Reset() {
 	*x = ActivitySwapTrace{}
-	mi := &file_wallet_proto_msgTypes[17]
+	mi := &file_wallet_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1695,7 +2020,7 @@ func (x *ActivitySwapTrace) String() string {
 func (*ActivitySwapTrace) ProtoMessage() {}
 
 func (x *ActivitySwapTrace) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[17]
+	mi := &file_wallet_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1708,7 +2033,7 @@ func (x *ActivitySwapTrace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActivitySwapTrace.ProtoReflect.Descriptor instead.
 func (*ActivitySwapTrace) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{17}
+	return file_wallet_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ActivitySwapTrace) GetPaymentHash() string {
@@ -1858,7 +2183,7 @@ type ActivityVTXOTrace struct {
 
 func (x *ActivityVTXOTrace) Reset() {
 	*x = ActivityVTXOTrace{}
-	mi := &file_wallet_proto_msgTypes[18]
+	mi := &file_wallet_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1870,7 +2195,7 @@ func (x *ActivityVTXOTrace) String() string {
 func (*ActivityVTXOTrace) ProtoMessage() {}
 
 func (x *ActivityVTXOTrace) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[18]
+	mi := &file_wallet_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1883,7 +2208,7 @@ func (x *ActivityVTXOTrace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActivityVTXOTrace.ProtoReflect.Descriptor instead.
 func (*ActivityVTXOTrace) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{18}
+	return file_wallet_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ActivityVTXOTrace) GetId() string {
@@ -1988,7 +2313,7 @@ type ActivityLedgerTrace struct {
 
 func (x *ActivityLedgerTrace) Reset() {
 	*x = ActivityLedgerTrace{}
-	mi := &file_wallet_proto_msgTypes[19]
+	mi := &file_wallet_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2000,7 +2325,7 @@ func (x *ActivityLedgerTrace) String() string {
 func (*ActivityLedgerTrace) ProtoMessage() {}
 
 func (x *ActivityLedgerTrace) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[19]
+	mi := &file_wallet_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2013,7 +2338,7 @@ func (x *ActivityLedgerTrace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActivityLedgerTrace.ProtoReflect.Descriptor instead.
 func (*ActivityLedgerTrace) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{19}
+	return file_wallet_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ActivityLedgerTrace) GetSource() string {
@@ -2154,7 +2479,7 @@ type DepositRequest struct {
 
 func (x *DepositRequest) Reset() {
 	*x = DepositRequest{}
-	mi := &file_wallet_proto_msgTypes[20]
+	mi := &file_wallet_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2166,7 +2491,7 @@ func (x *DepositRequest) String() string {
 func (*DepositRequest) ProtoMessage() {}
 
 func (x *DepositRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[20]
+	mi := &file_wallet_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2179,7 +2504,7 @@ func (x *DepositRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DepositRequest.ProtoReflect.Descriptor instead.
 func (*DepositRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{20}
+	return file_wallet_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *DepositRequest) GetAmtSatHint() uint64 {
@@ -2204,7 +2529,7 @@ type DepositResponse struct {
 
 func (x *DepositResponse) Reset() {
 	*x = DepositResponse{}
-	mi := &file_wallet_proto_msgTypes[21]
+	mi := &file_wallet_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2216,7 +2541,7 @@ func (x *DepositResponse) String() string {
 func (*DepositResponse) ProtoMessage() {}
 
 func (x *DepositResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[21]
+	mi := &file_wallet_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2229,7 +2554,7 @@ func (x *DepositResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DepositResponse.ProtoReflect.Descriptor instead.
 func (*DepositResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{21}
+	return file_wallet_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *DepositResponse) GetOnchainAddress() string {
@@ -2254,7 +2579,7 @@ type BalanceRequest struct {
 
 func (x *BalanceRequest) Reset() {
 	*x = BalanceRequest{}
-	mi := &file_wallet_proto_msgTypes[22]
+	mi := &file_wallet_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2266,7 +2591,7 @@ func (x *BalanceRequest) String() string {
 func (*BalanceRequest) ProtoMessage() {}
 
 func (x *BalanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[22]
+	mi := &file_wallet_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2279,7 +2604,7 @@ func (x *BalanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BalanceRequest.ProtoReflect.Descriptor instead.
 func (*BalanceRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{22}
+	return file_wallet_proto_rawDescGZIP(), []int{24}
 }
 
 type BalanceResponse struct {
@@ -2298,7 +2623,7 @@ type BalanceResponse struct {
 
 func (x *BalanceResponse) Reset() {
 	*x = BalanceResponse{}
-	mi := &file_wallet_proto_msgTypes[23]
+	mi := &file_wallet_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2310,7 +2635,7 @@ func (x *BalanceResponse) String() string {
 func (*BalanceResponse) ProtoMessage() {}
 
 func (x *BalanceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[23]
+	mi := &file_wallet_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2323,7 +2648,7 @@ func (x *BalanceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BalanceResponse.ProtoReflect.Descriptor instead.
 func (*BalanceResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{23}
+	return file_wallet_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *BalanceResponse) GetConfirmedSat() int64 {
@@ -2355,7 +2680,7 @@ type StatusRequest struct {
 
 func (x *StatusRequest) Reset() {
 	*x = StatusRequest{}
-	mi := &file_wallet_proto_msgTypes[24]
+	mi := &file_wallet_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2367,7 +2692,7 @@ func (x *StatusRequest) String() string {
 func (*StatusRequest) ProtoMessage() {}
 
 func (x *StatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[24]
+	mi := &file_wallet_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2380,7 +2705,7 @@ func (x *StatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusRequest.ProtoReflect.Descriptor instead.
 func (*StatusRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{24}
+	return file_wallet_proto_rawDescGZIP(), []int{26}
 }
 
 type StatusResponse struct {
@@ -2405,7 +2730,7 @@ type StatusResponse struct {
 
 func (x *StatusResponse) Reset() {
 	*x = StatusResponse{}
-	mi := &file_wallet_proto_msgTypes[25]
+	mi := &file_wallet_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2417,7 +2742,7 @@ func (x *StatusResponse) String() string {
 func (*StatusResponse) ProtoMessage() {}
 
 func (x *StatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[25]
+	mi := &file_wallet_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2430,7 +2755,7 @@ func (x *StatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusResponse.ProtoReflect.Descriptor instead.
 func (*StatusResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{25}
+	return file_wallet_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *StatusResponse) GetReady() bool {
@@ -2479,7 +2804,7 @@ type ExitRequest struct {
 
 func (x *ExitRequest) Reset() {
 	*x = ExitRequest{}
-	mi := &file_wallet_proto_msgTypes[26]
+	mi := &file_wallet_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2491,7 +2816,7 @@ func (x *ExitRequest) String() string {
 func (*ExitRequest) ProtoMessage() {}
 
 func (x *ExitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[26]
+	mi := &file_wallet_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2504,7 +2829,7 @@ func (x *ExitRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExitRequest.ProtoReflect.Descriptor instead.
 func (*ExitRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{26}
+	return file_wallet_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ExitRequest) GetOutpoint() string {
@@ -2527,7 +2852,7 @@ type ExitResponse struct {
 
 func (x *ExitResponse) Reset() {
 	*x = ExitResponse{}
-	mi := &file_wallet_proto_msgTypes[27]
+	mi := &file_wallet_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2539,7 +2864,7 @@ func (x *ExitResponse) String() string {
 func (*ExitResponse) ProtoMessage() {}
 
 func (x *ExitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[27]
+	mi := &file_wallet_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2552,7 +2877,7 @@ func (x *ExitResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExitResponse.ProtoReflect.Descriptor instead.
 func (*ExitResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{27}
+	return file_wallet_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ExitResponse) GetCreated() bool {
@@ -2580,7 +2905,7 @@ type ExitStatusRequest struct {
 
 func (x *ExitStatusRequest) Reset() {
 	*x = ExitStatusRequest{}
-	mi := &file_wallet_proto_msgTypes[28]
+	mi := &file_wallet_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2592,7 +2917,7 @@ func (x *ExitStatusRequest) String() string {
 func (*ExitStatusRequest) ProtoMessage() {}
 
 func (x *ExitStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[28]
+	mi := &file_wallet_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2605,7 +2930,7 @@ func (x *ExitStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExitStatusRequest.ProtoReflect.Descriptor instead.
 func (*ExitStatusRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{28}
+	return file_wallet_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ExitStatusRequest) GetOutpoint() string {
@@ -2633,7 +2958,7 @@ type ExitStatusResponse struct {
 
 func (x *ExitStatusResponse) Reset() {
 	*x = ExitStatusResponse{}
-	mi := &file_wallet_proto_msgTypes[29]
+	mi := &file_wallet_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2645,7 +2970,7 @@ func (x *ExitStatusResponse) String() string {
 func (*ExitStatusResponse) ProtoMessage() {}
 
 func (x *ExitStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[29]
+	mi := &file_wallet_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2658,7 +2983,7 @@ func (x *ExitStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExitStatusResponse.ProtoReflect.Descriptor instead.
 func (*ExitStatusResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{29}
+	return file_wallet_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ExitStatusResponse) GetFound() bool {
@@ -2703,7 +3028,7 @@ type SubscribeWalletRequest struct {
 
 func (x *SubscribeWalletRequest) Reset() {
 	*x = SubscribeWalletRequest{}
-	mi := &file_wallet_proto_msgTypes[30]
+	mi := &file_wallet_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2715,7 +3040,7 @@ func (x *SubscribeWalletRequest) String() string {
 func (*SubscribeWalletRequest) ProtoMessage() {}
 
 func (x *SubscribeWalletRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[30]
+	mi := &file_wallet_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2728,7 +3053,7 @@ func (x *SubscribeWalletRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeWalletRequest.ProtoReflect.Descriptor instead.
 func (*SubscribeWalletRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{30}
+	return file_wallet_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *SubscribeWalletRequest) GetIncludeExisting() bool {
@@ -2800,7 +3125,7 @@ type WalletEntry struct {
 
 func (x *WalletEntry) Reset() {
 	*x = WalletEntry{}
-	mi := &file_wallet_proto_msgTypes[31]
+	mi := &file_wallet_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2812,7 +3137,7 @@ func (x *WalletEntry) String() string {
 func (*WalletEntry) ProtoMessage() {}
 
 func (x *WalletEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[31]
+	mi := &file_wallet_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2825,7 +3150,7 @@ func (x *WalletEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletEntry.ProtoReflect.Descriptor instead.
 func (*WalletEntry) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{31}
+	return file_wallet_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *WalletEntry) GetId() string {
@@ -2929,7 +3254,7 @@ type WalletEntryRequest struct {
 
 func (x *WalletEntryRequest) Reset() {
 	*x = WalletEntryRequest{}
-	mi := &file_wallet_proto_msgTypes[32]
+	mi := &file_wallet_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2941,7 +3266,7 @@ func (x *WalletEntryRequest) String() string {
 func (*WalletEntryRequest) ProtoMessage() {}
 
 func (x *WalletEntryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[32]
+	mi := &file_wallet_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2954,7 +3279,7 @@ func (x *WalletEntryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletEntryRequest.ProtoReflect.Descriptor instead.
 func (*WalletEntryRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{32}
+	return file_wallet_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *WalletEntryRequest) GetRequest() isWalletEntryRequest_Request {
@@ -3032,7 +3357,7 @@ type LightningInvoiceRequest struct {
 
 func (x *LightningInvoiceRequest) Reset() {
 	*x = LightningInvoiceRequest{}
-	mi := &file_wallet_proto_msgTypes[33]
+	mi := &file_wallet_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3044,7 +3369,7 @@ func (x *LightningInvoiceRequest) String() string {
 func (*LightningInvoiceRequest) ProtoMessage() {}
 
 func (x *LightningInvoiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[33]
+	mi := &file_wallet_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3057,7 +3382,7 @@ func (x *LightningInvoiceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LightningInvoiceRequest.ProtoReflect.Descriptor instead.
 func (*LightningInvoiceRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{33}
+	return file_wallet_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *LightningInvoiceRequest) GetInvoice() string {
@@ -3086,7 +3411,7 @@ type OnchainAddressRequest struct {
 
 func (x *OnchainAddressRequest) Reset() {
 	*x = OnchainAddressRequest{}
-	mi := &file_wallet_proto_msgTypes[34]
+	mi := &file_wallet_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3098,7 +3423,7 @@ func (x *OnchainAddressRequest) String() string {
 func (*OnchainAddressRequest) ProtoMessage() {}
 
 func (x *OnchainAddressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[34]
+	mi := &file_wallet_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3111,7 +3436,7 @@ func (x *OnchainAddressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnchainAddressRequest.ProtoReflect.Descriptor instead.
 func (*OnchainAddressRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{34}
+	return file_wallet_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *OnchainAddressRequest) GetAddress() string {
@@ -3132,7 +3457,7 @@ type ArkAddressRequest struct {
 
 func (x *ArkAddressRequest) Reset() {
 	*x = ArkAddressRequest{}
-	mi := &file_wallet_proto_msgTypes[35]
+	mi := &file_wallet_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3144,7 +3469,7 @@ func (x *ArkAddressRequest) String() string {
 func (*ArkAddressRequest) ProtoMessage() {}
 
 func (x *ArkAddressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[35]
+	mi := &file_wallet_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3157,7 +3482,7 @@ func (x *ArkAddressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArkAddressRequest.ProtoReflect.Descriptor instead.
 func (*ArkAddressRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{35}
+	return file_wallet_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ArkAddressRequest) GetAddress() string {
@@ -3190,7 +3515,7 @@ type WalletEntryProgress struct {
 
 func (x *WalletEntryProgress) Reset() {
 	*x = WalletEntryProgress{}
-	mi := &file_wallet_proto_msgTypes[36]
+	mi := &file_wallet_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3202,7 +3527,7 @@ func (x *WalletEntryProgress) String() string {
 func (*WalletEntryProgress) ProtoMessage() {}
 
 func (x *WalletEntryProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[36]
+	mi := &file_wallet_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3215,7 +3540,7 @@ func (x *WalletEntryProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletEntryProgress.ProtoReflect.Descriptor instead.
 func (*WalletEntryProgress) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{36}
+	return file_wallet_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *WalletEntryProgress) GetPhase() WalletEntryPhase {
@@ -3275,15 +3600,34 @@ const file_wallet_proto_rawDesc = "" +
 	"\rUnlockRequest\x12'\n" +
 	"\x0fwallet_password\x18\x01 \x01(\fR\x0ewalletPassword\"9\n" +
 	"\x0eUnlockResponse\x12'\n" +
-	"\x0fidentity_pubkey\x18\x01 \x01(\tR\x0eidentityPubkey\"\xcd\x01\n" +
-	"\vSendRequest\x12\x1a\n" +
+	"\x0fidentity_pubkey\x18\x01 \x01(\tR\x0eidentityPubkey\"\xd4\x01\n" +
+	"\x12PrepareSendRequest\x12\x1a\n" +
 	"\ainvoice\x18\x01 \x01(\tH\x00R\ainvoice\x12)\n" +
 	"\x0fonchain_address\x18\x02 \x01(\tH\x00R\x0eonchainAddress\x12\x17\n" +
 	"\aamt_sat\x18\x03 \x01(\x04R\x06amtSat\x12\x12\n" +
 	"\x04note\x18\x04 \x01(\tR\x04note\x12\x1e\n" +
 	"\vmax_fee_sat\x18\x05 \x01(\x04R\tmaxFeeSat\x12\x1b\n" +
 	"\tsweep_all\x18\x06 \x01(\bR\bsweepAllB\r\n" +
-	"\vdestination\"j\n" +
+	"\vdestination\"\xf0\x04\n" +
+	"\x13PrepareSendResponse\x12$\n" +
+	"\x0esend_intent_id\x18\x01 \x01(\tR\fsendIntentId\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x02 \x01(\x03R\tamountSat\x12(\n" +
+	"\x10expected_fee_sat\x18\x03 \x01(\x03R\x0eexpectedFeeSat\x12\x1b\n" +
+	"\tfee_known\x18\x04 \x01(\bR\bfeeKnown\x12;\n" +
+	"\x1aexpected_total_outflow_sat\x18\x05 \x01(\x03R\x17expectedTotalOutflowSat\x12.\n" +
+	"\x13total_outflow_known\x18\x06 \x01(\bR\x11totalOutflowKnown\x12)\n" +
+	"\x04rail\x18\a \x01(\x0e2\x15.walletdkrpc.SendRailR\x04rail\x12?\n" +
+	"\fquote_status\x18\b \x01(\x0e2\x1c.walletdkrpc.SendQuoteStatusR\vquoteStatus\x12/\n" +
+	"\x13destination_summary\x18\t \x01(\tR\x12destinationSummary\x12/\n" +
+	"\x13invoice_description\x18\n" +
+	" \x01(\tR\x12invoiceDescription\x12!\n" +
+	"\fpayment_hash\x18\v \x01(\tR\vpaymentHash\x12&\n" +
+	"\x0fexpires_at_unix\x18\f \x01(\x03R\rexpiresAtUnix\x12-\n" +
+	"\x12selected_outpoints\x18\r \x03(\tR\x11selectedOutpoints\x12\x18\n" +
+	"\awarning\x18\x0e \x01(\tR\awarning\"3\n" +
+	"\vSendRequest\x12$\n" +
+	"\x0esend_intent_id\x18\x01 \x01(\tR\fsendIntentId\"j\n" +
 	"\fSendResponse\x12.\n" +
 	"\x05entry\x18\x01 \x01(\v2\x18.walletdkrpc.WalletEntryR\x05entry\x12*\n" +
 	"\x11actual_amount_sat\x18\x02 \x01(\x03R\x0factualAmountSat\":\n" +
@@ -3481,7 +3825,17 @@ const file_wallet_proto_rawDesc = "" +
 	"\x15LIST_VIEW_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12LIST_VIEW_ACTIVITY\x10\x01\x12\x13\n" +
 	"\x0fLIST_VIEW_VTXOS\x10\x02\x12\x15\n" +
-	"\x11LIST_VIEW_ONCHAIN\x10\x03*\xea\x01\n" +
+	"\x11LIST_VIEW_ONCHAIN\x10\x03*\x8b\x01\n" +
+	"\bSendRail\x12\x19\n" +
+	"\x15SEND_RAIL_UNSPECIFIED\x10\x00\x12\x1e\n" +
+	"\x1aSEND_RAIL_OFFCHAIN_UNKNOWN\x10\x01\x12\x14\n" +
+	"\x10SEND_RAIL_IN_ARK\x10\x02\x12\x17\n" +
+	"\x13SEND_RAIL_LIGHTNING\x10\x03\x12\x15\n" +
+	"\x11SEND_RAIL_ONCHAIN\x10\x04*v\n" +
+	"\x0fSendQuoteStatus\x12!\n" +
+	"\x1dSEND_QUOTE_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
+	"\x1aSEND_QUOTE_STATUS_COMPLETE\x10\x01\x12 \n" +
+	"\x1cSEND_QUOTE_STATUS_LOCAL_ONLY\x10\x02*\xea\x01\n" +
 	"\rExitJobStatus\x12\x1f\n" +
 	"\x1bEXIT_JOB_STATUS_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17EXIT_JOB_STATUS_PENDING\x10\x01\x12!\n" +
@@ -3500,10 +3854,11 @@ const file_wallet_proto_rawDesc = "" +
 	"\x1cWALLET_ENTRY_PHASE_REFUNDING\x10\x06\x12\x1f\n" +
 	"\x1bWALLET_ENTRY_PHASE_REFUNDED\x10\a\x12\x1d\n" +
 	"\x19WALLET_ENTRY_PHASE_FAILED\x10\b\x12/\n" +
-	"+WALLET_ENTRY_PHASE_WAITING_FOR_CONFIRMATION\x10\t2\xfb\x05\n" +
+	"+WALLET_ENTRY_PHASE_WAITING_FOR_CONFIRMATION\x10\t2\xcd\x06\n" +
 	"\rWalletService\x12A\n" +
 	"\x06Create\x12\x1a.walletdkrpc.CreateRequest\x1a\x1b.walletdkrpc.CreateResponse\x12A\n" +
-	"\x06Unlock\x12\x1a.walletdkrpc.UnlockRequest\x1a\x1b.walletdkrpc.UnlockResponse\x12;\n" +
+	"\x06Unlock\x12\x1a.walletdkrpc.UnlockRequest\x1a\x1b.walletdkrpc.UnlockResponse\x12P\n" +
+	"\vPrepareSend\x12\x1f.walletdkrpc.PrepareSendRequest\x1a .walletdkrpc.PrepareSendResponse\x12;\n" +
 	"\x04Send\x12\x18.walletdkrpc.SendRequest\x1a\x19.walletdkrpc.SendResponse\x12;\n" +
 	"\x04Recv\x12\x18.walletdkrpc.RecvRequest\x1a\x19.walletdkrpc.RecvResponse\x12;\n" +
 	"\x04List\x12\x18.walletdkrpc.ListRequest\x1a\x19.walletdkrpc.ListResponse\x12D\n" +
@@ -3529,108 +3884,116 @@ func file_wallet_proto_rawDescGZIP() []byte {
 	return file_wallet_proto_rawDescData
 }
 
-var file_wallet_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
+var file_wallet_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
+var file_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_wallet_proto_goTypes = []any{
 	(EntryKind)(0),                  // 0: walletdkrpc.EntryKind
 	(EntryStatus)(0),                // 1: walletdkrpc.EntryStatus
 	(ListView)(0),                   // 2: walletdkrpc.ListView
-	(ExitJobStatus)(0),              // 3: walletdkrpc.ExitJobStatus
-	(WalletEntryPhase)(0),           // 4: walletdkrpc.WalletEntryPhase
-	(*CreateRequest)(nil),           // 5: walletdkrpc.CreateRequest
-	(*CreateResponse)(nil),          // 6: walletdkrpc.CreateResponse
-	(*UnlockRequest)(nil),           // 7: walletdkrpc.UnlockRequest
-	(*UnlockResponse)(nil),          // 8: walletdkrpc.UnlockResponse
-	(*SendRequest)(nil),             // 9: walletdkrpc.SendRequest
-	(*SendResponse)(nil),            // 10: walletdkrpc.SendResponse
-	(*RecvRequest)(nil),             // 11: walletdkrpc.RecvRequest
-	(*RecvResponse)(nil),            // 12: walletdkrpc.RecvResponse
-	(*ListRequest)(nil),             // 13: walletdkrpc.ListRequest
-	(*ListResponse)(nil),            // 14: walletdkrpc.ListResponse
-	(*ActivityList)(nil),            // 15: walletdkrpc.ActivityList
-	(*VTXOInventory)(nil),           // 16: walletdkrpc.VTXOInventory
-	(*WalletVTXO)(nil),              // 17: walletdkrpc.WalletVTXO
-	(*OnchainHistory)(nil),          // 18: walletdkrpc.OnchainHistory
-	(*OnchainTx)(nil),               // 19: walletdkrpc.OnchainTx
-	(*InspectActivityRequest)(nil),  // 20: walletdkrpc.InspectActivityRequest
-	(*InspectActivityResponse)(nil), // 21: walletdkrpc.InspectActivityResponse
-	(*ActivitySwapTrace)(nil),       // 22: walletdkrpc.ActivitySwapTrace
-	(*ActivityVTXOTrace)(nil),       // 23: walletdkrpc.ActivityVTXOTrace
-	(*ActivityLedgerTrace)(nil),     // 24: walletdkrpc.ActivityLedgerTrace
-	(*DepositRequest)(nil),          // 25: walletdkrpc.DepositRequest
-	(*DepositResponse)(nil),         // 26: walletdkrpc.DepositResponse
-	(*BalanceRequest)(nil),          // 27: walletdkrpc.BalanceRequest
-	(*BalanceResponse)(nil),         // 28: walletdkrpc.BalanceResponse
-	(*StatusRequest)(nil),           // 29: walletdkrpc.StatusRequest
-	(*StatusResponse)(nil),          // 30: walletdkrpc.StatusResponse
-	(*ExitRequest)(nil),             // 31: walletdkrpc.ExitRequest
-	(*ExitResponse)(nil),            // 32: walletdkrpc.ExitResponse
-	(*ExitStatusRequest)(nil),       // 33: walletdkrpc.ExitStatusRequest
-	(*ExitStatusResponse)(nil),      // 34: walletdkrpc.ExitStatusResponse
-	(*SubscribeWalletRequest)(nil),  // 35: walletdkrpc.SubscribeWalletRequest
-	(*WalletEntry)(nil),             // 36: walletdkrpc.WalletEntry
-	(*WalletEntryRequest)(nil),      // 37: walletdkrpc.WalletEntryRequest
-	(*LightningInvoiceRequest)(nil), // 38: walletdkrpc.LightningInvoiceRequest
-	(*OnchainAddressRequest)(nil),   // 39: walletdkrpc.OnchainAddressRequest
-	(*ArkAddressRequest)(nil),       // 40: walletdkrpc.ArkAddressRequest
-	(*WalletEntryProgress)(nil),     // 41: walletdkrpc.WalletEntryProgress
+	(SendRail)(0),                   // 3: walletdkrpc.SendRail
+	(SendQuoteStatus)(0),            // 4: walletdkrpc.SendQuoteStatus
+	(ExitJobStatus)(0),              // 5: walletdkrpc.ExitJobStatus
+	(WalletEntryPhase)(0),           // 6: walletdkrpc.WalletEntryPhase
+	(*CreateRequest)(nil),           // 7: walletdkrpc.CreateRequest
+	(*CreateResponse)(nil),          // 8: walletdkrpc.CreateResponse
+	(*UnlockRequest)(nil),           // 9: walletdkrpc.UnlockRequest
+	(*UnlockResponse)(nil),          // 10: walletdkrpc.UnlockResponse
+	(*PrepareSendRequest)(nil),      // 11: walletdkrpc.PrepareSendRequest
+	(*PrepareSendResponse)(nil),     // 12: walletdkrpc.PrepareSendResponse
+	(*SendRequest)(nil),             // 13: walletdkrpc.SendRequest
+	(*SendResponse)(nil),            // 14: walletdkrpc.SendResponse
+	(*RecvRequest)(nil),             // 15: walletdkrpc.RecvRequest
+	(*RecvResponse)(nil),            // 16: walletdkrpc.RecvResponse
+	(*ListRequest)(nil),             // 17: walletdkrpc.ListRequest
+	(*ListResponse)(nil),            // 18: walletdkrpc.ListResponse
+	(*ActivityList)(nil),            // 19: walletdkrpc.ActivityList
+	(*VTXOInventory)(nil),           // 20: walletdkrpc.VTXOInventory
+	(*WalletVTXO)(nil),              // 21: walletdkrpc.WalletVTXO
+	(*OnchainHistory)(nil),          // 22: walletdkrpc.OnchainHistory
+	(*OnchainTx)(nil),               // 23: walletdkrpc.OnchainTx
+	(*InspectActivityRequest)(nil),  // 24: walletdkrpc.InspectActivityRequest
+	(*InspectActivityResponse)(nil), // 25: walletdkrpc.InspectActivityResponse
+	(*ActivitySwapTrace)(nil),       // 26: walletdkrpc.ActivitySwapTrace
+	(*ActivityVTXOTrace)(nil),       // 27: walletdkrpc.ActivityVTXOTrace
+	(*ActivityLedgerTrace)(nil),     // 28: walletdkrpc.ActivityLedgerTrace
+	(*DepositRequest)(nil),          // 29: walletdkrpc.DepositRequest
+	(*DepositResponse)(nil),         // 30: walletdkrpc.DepositResponse
+	(*BalanceRequest)(nil),          // 31: walletdkrpc.BalanceRequest
+	(*BalanceResponse)(nil),         // 32: walletdkrpc.BalanceResponse
+	(*StatusRequest)(nil),           // 33: walletdkrpc.StatusRequest
+	(*StatusResponse)(nil),          // 34: walletdkrpc.StatusResponse
+	(*ExitRequest)(nil),             // 35: walletdkrpc.ExitRequest
+	(*ExitResponse)(nil),            // 36: walletdkrpc.ExitResponse
+	(*ExitStatusRequest)(nil),       // 37: walletdkrpc.ExitStatusRequest
+	(*ExitStatusResponse)(nil),      // 38: walletdkrpc.ExitStatusResponse
+	(*SubscribeWalletRequest)(nil),  // 39: walletdkrpc.SubscribeWalletRequest
+	(*WalletEntry)(nil),             // 40: walletdkrpc.WalletEntry
+	(*WalletEntryRequest)(nil),      // 41: walletdkrpc.WalletEntryRequest
+	(*LightningInvoiceRequest)(nil), // 42: walletdkrpc.LightningInvoiceRequest
+	(*OnchainAddressRequest)(nil),   // 43: walletdkrpc.OnchainAddressRequest
+	(*ArkAddressRequest)(nil),       // 44: walletdkrpc.ArkAddressRequest
+	(*WalletEntryProgress)(nil),     // 45: walletdkrpc.WalletEntryProgress
 }
 var file_wallet_proto_depIdxs = []int32{
-	36, // 0: walletdkrpc.SendResponse.entry:type_name -> walletdkrpc.WalletEntry
-	36, // 1: walletdkrpc.RecvResponse.entry:type_name -> walletdkrpc.WalletEntry
-	2,  // 2: walletdkrpc.ListRequest.view:type_name -> walletdkrpc.ListView
-	0,  // 3: walletdkrpc.ListRequest.kinds:type_name -> walletdkrpc.EntryKind
-	15, // 4: walletdkrpc.ListResponse.activity:type_name -> walletdkrpc.ActivityList
-	16, // 5: walletdkrpc.ListResponse.vtxos:type_name -> walletdkrpc.VTXOInventory
-	18, // 6: walletdkrpc.ListResponse.onchain:type_name -> walletdkrpc.OnchainHistory
-	36, // 7: walletdkrpc.ActivityList.entries:type_name -> walletdkrpc.WalletEntry
-	17, // 8: walletdkrpc.VTXOInventory.vtxos:type_name -> walletdkrpc.WalletVTXO
-	19, // 9: walletdkrpc.OnchainHistory.txs:type_name -> walletdkrpc.OnchainTx
-	36, // 10: walletdkrpc.InspectActivityResponse.entry:type_name -> walletdkrpc.WalletEntry
-	22, // 11: walletdkrpc.InspectActivityResponse.swap:type_name -> walletdkrpc.ActivitySwapTrace
-	23, // 12: walletdkrpc.InspectActivityResponse.vtxos:type_name -> walletdkrpc.ActivityVTXOTrace
-	24, // 13: walletdkrpc.InspectActivityResponse.ledger_rows:type_name -> walletdkrpc.ActivityLedgerTrace
-	36, // 14: walletdkrpc.DepositResponse.entry:type_name -> walletdkrpc.WalletEntry
-	28, // 15: walletdkrpc.StatusResponse.balance:type_name -> walletdkrpc.BalanceResponse
-	3,  // 16: walletdkrpc.ExitStatusResponse.status:type_name -> walletdkrpc.ExitJobStatus
-	0,  // 17: walletdkrpc.SubscribeWalletRequest.kinds:type_name -> walletdkrpc.EntryKind
-	0,  // 18: walletdkrpc.WalletEntry.kind:type_name -> walletdkrpc.EntryKind
-	1,  // 19: walletdkrpc.WalletEntry.status:type_name -> walletdkrpc.EntryStatus
-	37, // 20: walletdkrpc.WalletEntry.request:type_name -> walletdkrpc.WalletEntryRequest
-	41, // 21: walletdkrpc.WalletEntry.progress:type_name -> walletdkrpc.WalletEntryProgress
-	38, // 22: walletdkrpc.WalletEntryRequest.lightning_invoice:type_name -> walletdkrpc.LightningInvoiceRequest
-	39, // 23: walletdkrpc.WalletEntryRequest.onchain_address:type_name -> walletdkrpc.OnchainAddressRequest
-	40, // 24: walletdkrpc.WalletEntryRequest.ark_address:type_name -> walletdkrpc.ArkAddressRequest
-	4,  // 25: walletdkrpc.WalletEntryProgress.phase:type_name -> walletdkrpc.WalletEntryPhase
-	5,  // 26: walletdkrpc.WalletService.Create:input_type -> walletdkrpc.CreateRequest
-	7,  // 27: walletdkrpc.WalletService.Unlock:input_type -> walletdkrpc.UnlockRequest
-	9,  // 28: walletdkrpc.WalletService.Send:input_type -> walletdkrpc.SendRequest
-	11, // 29: walletdkrpc.WalletService.Recv:input_type -> walletdkrpc.RecvRequest
-	13, // 30: walletdkrpc.WalletService.List:input_type -> walletdkrpc.ListRequest
-	25, // 31: walletdkrpc.WalletService.Deposit:input_type -> walletdkrpc.DepositRequest
-	27, // 32: walletdkrpc.WalletService.Balance:input_type -> walletdkrpc.BalanceRequest
-	29, // 33: walletdkrpc.WalletService.Status:input_type -> walletdkrpc.StatusRequest
-	31, // 34: walletdkrpc.WalletService.Exit:input_type -> walletdkrpc.ExitRequest
-	33, // 35: walletdkrpc.WalletService.ExitStatus:input_type -> walletdkrpc.ExitStatusRequest
-	35, // 36: walletdkrpc.WalletService.SubscribeWallet:input_type -> walletdkrpc.SubscribeWalletRequest
-	20, // 37: walletdkrpc.WalletInspectionService.InspectActivity:input_type -> walletdkrpc.InspectActivityRequest
-	6,  // 38: walletdkrpc.WalletService.Create:output_type -> walletdkrpc.CreateResponse
-	8,  // 39: walletdkrpc.WalletService.Unlock:output_type -> walletdkrpc.UnlockResponse
-	10, // 40: walletdkrpc.WalletService.Send:output_type -> walletdkrpc.SendResponse
-	12, // 41: walletdkrpc.WalletService.Recv:output_type -> walletdkrpc.RecvResponse
-	14, // 42: walletdkrpc.WalletService.List:output_type -> walletdkrpc.ListResponse
-	26, // 43: walletdkrpc.WalletService.Deposit:output_type -> walletdkrpc.DepositResponse
-	28, // 44: walletdkrpc.WalletService.Balance:output_type -> walletdkrpc.BalanceResponse
-	30, // 45: walletdkrpc.WalletService.Status:output_type -> walletdkrpc.StatusResponse
-	32, // 46: walletdkrpc.WalletService.Exit:output_type -> walletdkrpc.ExitResponse
-	34, // 47: walletdkrpc.WalletService.ExitStatus:output_type -> walletdkrpc.ExitStatusResponse
-	36, // 48: walletdkrpc.WalletService.SubscribeWallet:output_type -> walletdkrpc.WalletEntry
-	21, // 49: walletdkrpc.WalletInspectionService.InspectActivity:output_type -> walletdkrpc.InspectActivityResponse
-	38, // [38:50] is the sub-list for method output_type
-	26, // [26:38] is the sub-list for method input_type
-	26, // [26:26] is the sub-list for extension type_name
-	26, // [26:26] is the sub-list for extension extendee
-	0,  // [0:26] is the sub-list for field type_name
+	3,  // 0: walletdkrpc.PrepareSendResponse.rail:type_name -> walletdkrpc.SendRail
+	4,  // 1: walletdkrpc.PrepareSendResponse.quote_status:type_name -> walletdkrpc.SendQuoteStatus
+	40, // 2: walletdkrpc.SendResponse.entry:type_name -> walletdkrpc.WalletEntry
+	40, // 3: walletdkrpc.RecvResponse.entry:type_name -> walletdkrpc.WalletEntry
+	2,  // 4: walletdkrpc.ListRequest.view:type_name -> walletdkrpc.ListView
+	0,  // 5: walletdkrpc.ListRequest.kinds:type_name -> walletdkrpc.EntryKind
+	19, // 6: walletdkrpc.ListResponse.activity:type_name -> walletdkrpc.ActivityList
+	20, // 7: walletdkrpc.ListResponse.vtxos:type_name -> walletdkrpc.VTXOInventory
+	22, // 8: walletdkrpc.ListResponse.onchain:type_name -> walletdkrpc.OnchainHistory
+	40, // 9: walletdkrpc.ActivityList.entries:type_name -> walletdkrpc.WalletEntry
+	21, // 10: walletdkrpc.VTXOInventory.vtxos:type_name -> walletdkrpc.WalletVTXO
+	23, // 11: walletdkrpc.OnchainHistory.txs:type_name -> walletdkrpc.OnchainTx
+	40, // 12: walletdkrpc.InspectActivityResponse.entry:type_name -> walletdkrpc.WalletEntry
+	26, // 13: walletdkrpc.InspectActivityResponse.swap:type_name -> walletdkrpc.ActivitySwapTrace
+	27, // 14: walletdkrpc.InspectActivityResponse.vtxos:type_name -> walletdkrpc.ActivityVTXOTrace
+	28, // 15: walletdkrpc.InspectActivityResponse.ledger_rows:type_name -> walletdkrpc.ActivityLedgerTrace
+	40, // 16: walletdkrpc.DepositResponse.entry:type_name -> walletdkrpc.WalletEntry
+	32, // 17: walletdkrpc.StatusResponse.balance:type_name -> walletdkrpc.BalanceResponse
+	5,  // 18: walletdkrpc.ExitStatusResponse.status:type_name -> walletdkrpc.ExitJobStatus
+	0,  // 19: walletdkrpc.SubscribeWalletRequest.kinds:type_name -> walletdkrpc.EntryKind
+	0,  // 20: walletdkrpc.WalletEntry.kind:type_name -> walletdkrpc.EntryKind
+	1,  // 21: walletdkrpc.WalletEntry.status:type_name -> walletdkrpc.EntryStatus
+	41, // 22: walletdkrpc.WalletEntry.request:type_name -> walletdkrpc.WalletEntryRequest
+	45, // 23: walletdkrpc.WalletEntry.progress:type_name -> walletdkrpc.WalletEntryProgress
+	42, // 24: walletdkrpc.WalletEntryRequest.lightning_invoice:type_name -> walletdkrpc.LightningInvoiceRequest
+	43, // 25: walletdkrpc.WalletEntryRequest.onchain_address:type_name -> walletdkrpc.OnchainAddressRequest
+	44, // 26: walletdkrpc.WalletEntryRequest.ark_address:type_name -> walletdkrpc.ArkAddressRequest
+	6,  // 27: walletdkrpc.WalletEntryProgress.phase:type_name -> walletdkrpc.WalletEntryPhase
+	7,  // 28: walletdkrpc.WalletService.Create:input_type -> walletdkrpc.CreateRequest
+	9,  // 29: walletdkrpc.WalletService.Unlock:input_type -> walletdkrpc.UnlockRequest
+	11, // 30: walletdkrpc.WalletService.PrepareSend:input_type -> walletdkrpc.PrepareSendRequest
+	13, // 31: walletdkrpc.WalletService.Send:input_type -> walletdkrpc.SendRequest
+	15, // 32: walletdkrpc.WalletService.Recv:input_type -> walletdkrpc.RecvRequest
+	17, // 33: walletdkrpc.WalletService.List:input_type -> walletdkrpc.ListRequest
+	29, // 34: walletdkrpc.WalletService.Deposit:input_type -> walletdkrpc.DepositRequest
+	31, // 35: walletdkrpc.WalletService.Balance:input_type -> walletdkrpc.BalanceRequest
+	33, // 36: walletdkrpc.WalletService.Status:input_type -> walletdkrpc.StatusRequest
+	35, // 37: walletdkrpc.WalletService.Exit:input_type -> walletdkrpc.ExitRequest
+	37, // 38: walletdkrpc.WalletService.ExitStatus:input_type -> walletdkrpc.ExitStatusRequest
+	39, // 39: walletdkrpc.WalletService.SubscribeWallet:input_type -> walletdkrpc.SubscribeWalletRequest
+	24, // 40: walletdkrpc.WalletInspectionService.InspectActivity:input_type -> walletdkrpc.InspectActivityRequest
+	8,  // 41: walletdkrpc.WalletService.Create:output_type -> walletdkrpc.CreateResponse
+	10, // 42: walletdkrpc.WalletService.Unlock:output_type -> walletdkrpc.UnlockResponse
+	12, // 43: walletdkrpc.WalletService.PrepareSend:output_type -> walletdkrpc.PrepareSendResponse
+	14, // 44: walletdkrpc.WalletService.Send:output_type -> walletdkrpc.SendResponse
+	16, // 45: walletdkrpc.WalletService.Recv:output_type -> walletdkrpc.RecvResponse
+	18, // 46: walletdkrpc.WalletService.List:output_type -> walletdkrpc.ListResponse
+	30, // 47: walletdkrpc.WalletService.Deposit:output_type -> walletdkrpc.DepositResponse
+	32, // 48: walletdkrpc.WalletService.Balance:output_type -> walletdkrpc.BalanceResponse
+	34, // 49: walletdkrpc.WalletService.Status:output_type -> walletdkrpc.StatusResponse
+	36, // 50: walletdkrpc.WalletService.Exit:output_type -> walletdkrpc.ExitResponse
+	38, // 51: walletdkrpc.WalletService.ExitStatus:output_type -> walletdkrpc.ExitStatusResponse
+	40, // 52: walletdkrpc.WalletService.SubscribeWallet:output_type -> walletdkrpc.WalletEntry
+	25, // 53: walletdkrpc.WalletInspectionService.InspectActivity:output_type -> walletdkrpc.InspectActivityResponse
+	41, // [41:54] is the sub-list for method output_type
+	28, // [28:41] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_wallet_proto_init() }
@@ -3639,15 +4002,15 @@ func file_wallet_proto_init() {
 		return
 	}
 	file_wallet_proto_msgTypes[4].OneofWrappers = []any{
-		(*SendRequest_Invoice)(nil),
-		(*SendRequest_OnchainAddress)(nil),
+		(*PrepareSendRequest_Invoice)(nil),
+		(*PrepareSendRequest_OnchainAddress)(nil),
 	}
-	file_wallet_proto_msgTypes[9].OneofWrappers = []any{
+	file_wallet_proto_msgTypes[11].OneofWrappers = []any{
 		(*ListResponse_Activity)(nil),
 		(*ListResponse_Vtxos)(nil),
 		(*ListResponse_Onchain)(nil),
 	}
-	file_wallet_proto_msgTypes[32].OneofWrappers = []any{
+	file_wallet_proto_msgTypes[34].OneofWrappers = []any{
 		(*WalletEntryRequest_LightningInvoice)(nil),
 		(*WalletEntryRequest_OnchainAddress)(nil),
 		(*WalletEntryRequest_ArkAddress)(nil),
@@ -3657,8 +4020,8 @@ func file_wallet_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wallet_proto_rawDesc), len(file_wallet_proto_rawDesc)),
-			NumEnums:      5,
-			NumMessages:   37,
+			NumEnums:      7,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/rpc/walletdkrpc/wallet.pb.gw.go
+++ b/rpc/walletdkrpc/wallet.pb.gw.go
@@ -89,6 +89,33 @@ func local_request_WalletService_Unlock_0(ctx context.Context, marshaler runtime
 	return msg, metadata, err
 }
 
+func request_WalletService_PrepareSend_0(ctx context.Context, marshaler runtime.Marshaler, client WalletServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PrepareSendRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.PrepareSend(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_WalletService_PrepareSend_0(ctx context.Context, marshaler runtime.Marshaler, server WalletServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PrepareSendRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.PrepareSend(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_WalletService_Send_0(ctx context.Context, marshaler runtime.Marshaler, client WalletServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq SendRequest
@@ -401,6 +428,26 @@ func RegisterWalletServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_WalletService_Unlock_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_WalletService_PrepareSend_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/walletdkrpc.WalletService/PrepareSend", runtime.WithHTTPPathPattern("/v1/wallet/prepare-send"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_WalletService_PrepareSend_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_WalletService_PrepareSend_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_WalletService_Send_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -672,6 +719,23 @@ func RegisterWalletServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_WalletService_Unlock_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_WalletService_PrepareSend_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/walletdkrpc.WalletService/PrepareSend", runtime.WithHTTPPathPattern("/v1/wallet/prepare-send"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_WalletService_PrepareSend_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_WalletService_PrepareSend_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_WalletService_Send_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -831,6 +895,7 @@ func RegisterWalletServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 var (
 	pattern_WalletService_Create_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "wallet", "create"}, ""))
 	pattern_WalletService_Unlock_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "wallet", "unlock"}, ""))
+	pattern_WalletService_PrepareSend_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "wallet", "prepare-send"}, ""))
 	pattern_WalletService_Send_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "wallet", "send"}, ""))
 	pattern_WalletService_Recv_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "wallet", "recv"}, ""))
 	pattern_WalletService_List_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "wallet", "list"}, ""))
@@ -845,6 +910,7 @@ var (
 var (
 	forward_WalletService_Create_0          = runtime.ForwardResponseMessage
 	forward_WalletService_Unlock_0          = runtime.ForwardResponseMessage
+	forward_WalletService_PrepareSend_0     = runtime.ForwardResponseMessage
 	forward_WalletService_Send_0            = runtime.ForwardResponseMessage
 	forward_WalletService_Recv_0            = runtime.ForwardResponseMessage
 	forward_WalletService_List_0            = runtime.ForwardResponseMessage

--- a/rpc/walletdkrpc/wallet.proto
+++ b/rpc/walletdkrpc/wallet.proto
@@ -26,11 +26,15 @@ service WalletService {
     // and starts the wallet subsystem. Proxies daemonrpc.UnlockWallet.
     rpc Unlock (UnlockRequest) returns (UnlockResponse);
 
-    // Send dispatches an outbound payment. The destination oneof selects
-    // between paying a BOLT-11 Lightning invoice (routed via an out-swap;
-    // the swap server transparently picks same-Ark p2p or real Lightning)
-    // and sending to an onchain address (routed via LeaveVTXOs cooperative
-    // exit). The daemon owns all downstream lifecycle.
+    // PrepareSend validates and previews an outbound payment without
+    // moving funds. The response carries a short-lived send_intent_id
+    // that must be consumed by Send.
+    rpc PrepareSend (PrepareSendRequest) returns (PrepareSendResponse);
+
+    // Send dispatches a previously prepared outbound payment. The
+    // request is intentionally intent-only: callers must use
+    // PrepareSend first so they can present amount, rail, fee, and
+    // total-outflow details before funds move.
     rpc Send (SendRequest) returns (SendResponse);
 
     // Recv asks the daemon for a Lightning invoice the caller can hand
@@ -130,6 +134,34 @@ enum ListView {
     LIST_VIEW_ONCHAIN = 3;
 }
 
+// SendRail identifies the expected settlement rail for a prepared send.
+enum SendRail {
+    SEND_RAIL_UNSPECIFIED = 0;
+
+    // SEND_RAIL_OFFCHAIN_UNKNOWN is used when the wallet can parse the
+    // invoice locally but the swapserver has not supplied a quote that
+    // distinguishes same-Ark settlement from Lightning settlement.
+    SEND_RAIL_OFFCHAIN_UNKNOWN = 1;
+
+    SEND_RAIL_IN_ARK = 2;
+    SEND_RAIL_LIGHTNING = 3;
+    SEND_RAIL_ONCHAIN = 4;
+}
+
+// SendQuoteStatus describes how complete the prepare-time quote is.
+enum SendQuoteStatus {
+    SEND_QUOTE_STATUS_UNSPECIFIED = 0;
+
+    // SEND_QUOTE_STATUS_COMPLETE means every user-visible amount and fee
+    // field is backed by a remote quote.
+    SEND_QUOTE_STATUS_COMPLETE = 1;
+
+    // SEND_QUOTE_STATUS_LOCAL_ONLY means the wallet performed local
+    // validation and selection but one or more remote quote APIs are not
+    // available yet.
+    SEND_QUOTE_STATUS_LOCAL_ONLY = 2;
+}
+
 message CreateRequest {
     // wallet_password is the password used to encrypt the on-disk seed.
     // Must be at least 8 bytes. The password is consumed and zeroed by
@@ -173,7 +205,7 @@ message UnlockResponse {
     string identity_pubkey = 1;
 }
 
-message SendRequest {
+message PrepareSendRequest {
     // destination selects the outbound payment target. Exactly one
     // variant must be set.
     oneof destination {
@@ -210,6 +242,58 @@ message SendRequest {
     // distinct from "amt_sat defaulted to zero" so a typo cannot empty
     // the wallet by accident. Ignored on the invoice path.
     bool sweep_all = 6;
+}
+
+message PrepareSendResponse {
+    // send_intent_id is a short-lived, single-use token consumed by Send.
+    string send_intent_id = 1;
+
+    // amount_sat is the destination principal amount.
+    int64 amount_sat = 2;
+
+    // expected_fee_sat is meaningful only when fee_known is true.
+    int64 expected_fee_sat = 3;
+
+    // fee_known is false when a required remote quote API is missing.
+    bool fee_known = 4;
+
+    // expected_total_outflow_sat is meaningful only when
+    // total_outflow_known is true.
+    int64 expected_total_outflow_sat = 5;
+
+    // total_outflow_known is false when the final outflow depends on a
+    // remote quote that is not available yet.
+    bool total_outflow_known = 6;
+
+    SendRail rail = 7;
+    SendQuoteStatus quote_status = 8;
+
+    // destination_summary is a short display string suitable for CLI and
+    // UI confirmation prompts.
+    string destination_summary = 9;
+
+    // invoice_description is the BOLT-11 description when present.
+    string invoice_description = 10;
+
+    // payment_hash is the invoice payment hash when available.
+    string payment_hash = 11;
+
+    // expires_at_unix is the unix timestamp after which Send rejects the
+    // prepared intent.
+    int64 expires_at_unix = 12;
+
+    // selected_outpoints is populated for onchain sends so Send can spend
+    // exactly the VTXO set previewed to the user.
+    repeated string selected_outpoints = 13;
+
+    // warning carries a concise human-facing caveat for local-only
+    // previews.
+    string warning = 14;
+}
+
+message SendRequest {
+    // send_intent_id is returned by PrepareSend and may be consumed once.
+    string send_intent_id = 1;
 }
 
 message SendResponse {

--- a/rpc/walletdkrpc/wallet.yaml
+++ b/rpc/walletdkrpc/wallet.yaml
@@ -9,6 +9,9 @@ http:
     - selector: walletdkrpc.WalletService.Unlock
       post: /v1/wallet/unlock
       body: "*"
+    - selector: walletdkrpc.WalletService.PrepareSend
+      post: /v1/wallet/prepare-send
+      body: "*"
     - selector: walletdkrpc.WalletService.Send
       post: /v1/wallet/send
       body: "*"

--- a/rpc/walletdkrpc/wallet_grpc.pb.go
+++ b/rpc/walletdkrpc/wallet_grpc.pb.go
@@ -21,6 +21,7 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	WalletService_Create_FullMethodName          = "/walletdkrpc.WalletService/Create"
 	WalletService_Unlock_FullMethodName          = "/walletdkrpc.WalletService/Unlock"
+	WalletService_PrepareSend_FullMethodName     = "/walletdkrpc.WalletService/PrepareSend"
 	WalletService_Send_FullMethodName            = "/walletdkrpc.WalletService/Send"
 	WalletService_Recv_FullMethodName            = "/walletdkrpc.WalletService/Recv"
 	WalletService_List_FullMethodName            = "/walletdkrpc.WalletService/List"
@@ -56,11 +57,14 @@ type WalletServiceClient interface {
 	// Unlock decrypts the on-disk wallet seed using the supplied password
 	// and starts the wallet subsystem. Proxies daemonrpc.UnlockWallet.
 	Unlock(ctx context.Context, in *UnlockRequest, opts ...grpc.CallOption) (*UnlockResponse, error)
-	// Send dispatches an outbound payment. The destination oneof selects
-	// between paying a BOLT-11 Lightning invoice (routed via an out-swap;
-	// the swap server transparently picks same-Ark p2p or real Lightning)
-	// and sending to an onchain address (routed via LeaveVTXOs cooperative
-	// exit). The daemon owns all downstream lifecycle.
+	// PrepareSend validates and previews an outbound payment without
+	// moving funds. The response carries a short-lived send_intent_id
+	// that must be consumed by Send.
+	PrepareSend(ctx context.Context, in *PrepareSendRequest, opts ...grpc.CallOption) (*PrepareSendResponse, error)
+	// Send dispatches a previously prepared outbound payment. The
+	// request is intentionally intent-only: callers must use
+	// PrepareSend first so they can present amount, rail, fee, and
+	// total-outflow details before funds move.
 	Send(ctx context.Context, in *SendRequest, opts ...grpc.CallOption) (*SendResponse, error)
 	// Recv asks the daemon for a Lightning invoice the caller can hand
 	// out. Internally this opens a swap-in via the daemon-owned swap
@@ -123,6 +127,16 @@ func (c *walletServiceClient) Unlock(ctx context.Context, in *UnlockRequest, opt
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(UnlockResponse)
 	err := c.cc.Invoke(ctx, WalletService_Unlock_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *walletServiceClient) PrepareSend(ctx context.Context, in *PrepareSendRequest, opts ...grpc.CallOption) (*PrepareSendResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PrepareSendResponse)
+	err := c.cc.Invoke(ctx, WalletService_PrepareSend_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -252,11 +266,14 @@ type WalletServiceServer interface {
 	// Unlock decrypts the on-disk wallet seed using the supplied password
 	// and starts the wallet subsystem. Proxies daemonrpc.UnlockWallet.
 	Unlock(context.Context, *UnlockRequest) (*UnlockResponse, error)
-	// Send dispatches an outbound payment. The destination oneof selects
-	// between paying a BOLT-11 Lightning invoice (routed via an out-swap;
-	// the swap server transparently picks same-Ark p2p or real Lightning)
-	// and sending to an onchain address (routed via LeaveVTXOs cooperative
-	// exit). The daemon owns all downstream lifecycle.
+	// PrepareSend validates and previews an outbound payment without
+	// moving funds. The response carries a short-lived send_intent_id
+	// that must be consumed by Send.
+	PrepareSend(context.Context, *PrepareSendRequest) (*PrepareSendResponse, error)
+	// Send dispatches a previously prepared outbound payment. The
+	// request is intentionally intent-only: callers must use
+	// PrepareSend first so they can present amount, rail, fee, and
+	// total-outflow details before funds move.
 	Send(context.Context, *SendRequest) (*SendResponse, error)
 	// Recv asks the daemon for a Lightning invoice the caller can hand
 	// out. Internally this opens a swap-in via the daemon-owned swap
@@ -310,6 +327,9 @@ func (UnimplementedWalletServiceServer) Create(context.Context, *CreateRequest) 
 }
 func (UnimplementedWalletServiceServer) Unlock(context.Context, *UnlockRequest) (*UnlockResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Unlock not implemented")
+}
+func (UnimplementedWalletServiceServer) PrepareSend(context.Context, *PrepareSendRequest) (*PrepareSendResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PrepareSend not implemented")
 }
 func (UnimplementedWalletServiceServer) Send(context.Context, *SendRequest) (*SendResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Send not implemented")
@@ -391,6 +411,24 @@ func _WalletService_Unlock_Handler(srv interface{}, ctx context.Context, dec fun
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(WalletServiceServer).Unlock(ctx, req.(*UnlockRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WalletService_PrepareSend_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PrepareSendRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WalletServiceServer).PrepareSend(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WalletService_PrepareSend_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WalletServiceServer).PrepareSend(ctx, req.(*PrepareSendRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -564,6 +602,10 @@ var WalletService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Unlock",
 			Handler:    _WalletService_Unlock_Handler,
+		},
+		{
+			MethodName: "PrepareSend",
+			Handler:    _WalletService_PrepareSend_Handler,
 		},
 		{
 			MethodName: "Send",

--- a/rpc/walletdkrpc/wallet_mailboxrpc.pb.go
+++ b/rpc/walletdkrpc/wallet_mailboxrpc.pb.go
@@ -28,6 +28,8 @@ type WalletServiceMailboxServer interface {
 	Create(ctx context.Context, req *CreateRequest) (*CreateResponse, error)
 	// Unlock handles Unlock.
 	Unlock(ctx context.Context, req *UnlockRequest) (*UnlockResponse, error)
+	// PrepareSend handles PrepareSend.
+	PrepareSend(ctx context.Context, req *PrepareSendRequest) (*PrepareSendResponse, error)
 	// Send handles Send.
 	Send(ctx context.Context, req *SendRequest) (*SendResponse, error)
 	// Recv handles Recv.
@@ -69,6 +71,16 @@ func RegisterWalletServiceMailboxServer(r rpc.Router, impl WalletServiceMailboxS
 		}
 
 		return impl.Unlock(ctx, req)
+	})
+	r.Handle("walletdkrpc.WalletService", "PrepareSend", func() proto.Message {
+		return &PrepareSendRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*PrepareSendRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.PrepareSend(ctx, req)
 	})
 	r.Handle("walletdkrpc.WalletService", "Send", func() proto.Message {
 		return &SendRequest{}
@@ -201,6 +213,29 @@ func (c *WalletServiceMailboxClient) Unlock(ctx context.Context, req *UnlockRequ
 	}
 
 	resp := new(UnlockResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// PrepareSend calls the PrepareSend RPC.
+func (c *WalletServiceMailboxClient) PrepareSend(ctx context.Context, req *PrepareSendRequest, opts ...rpc.RPCOptions) (*PrepareSendResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "walletdkrpc.WalletService",
+		Method:  "PrepareSend",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(PrepareSendResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/sdk/walletdk/client.go
+++ b/sdk/walletdk/client.go
@@ -291,15 +291,15 @@ func (c *Client) Receive(ctx context.Context, req ReceiveRequest) (
 	}, nil
 }
 
-// Send dispatches an outbound wallet payment.
-func (c *Client) Send(ctx context.Context, req SendRequest) (*SendResult,
-	error) {
+// PrepareSend validates and previews an outbound wallet payment.
+func (c *Client) PrepareSend(ctx context.Context, req PrepareSendRequest) (
+	*PrepareSendResult, error) {
 
 	if err := c.requireWalletRPC(); err != nil {
 		return nil, err
 	}
 
-	protoReq := &walletdkrpc.SendRequest{
+	protoReq := &walletdkrpc.PrepareSendRequest{
 		AmtSat:    req.AmountSat,
 		Note:      req.Note,
 		MaxFeeSat: req.MaxFeeSat,
@@ -313,12 +313,13 @@ func (c *Client) Send(ctx context.Context, req SendRequest) (*SendResult,
 			"both")
 
 	case invoice != "":
-		protoReq.Destination = &walletdkrpc.SendRequest_Invoice{
+		protoReq.Destination = &walletdkrpc.PrepareSendRequest_Invoice{
 			Invoice: invoice,
 		}
 
 	case onchainAddress != "":
-		protoReq.Destination = &walletdkrpc.SendRequest_OnchainAddress{
+		protoReq.Destination = &walletdkrpc.
+			PrepareSendRequest_OnchainAddress{
 			OnchainAddress: onchainAddress,
 		}
 
@@ -326,7 +327,28 @@ func (c *Client) Send(ctx context.Context, req SendRequest) (*SendResult,
 		return nil, fmt.Errorf("invoice or onchain_address is required")
 	}
 
-	resp, err := c.wallet.Send(ctx, protoReq)
+	resp, err := c.wallet.PrepareSend(ctx, protoReq)
+	if err != nil {
+		return nil, fmt.Errorf("prepare wallet payment: %w", err)
+	}
+
+	return prepareSendResultFromProto(resp), nil
+}
+
+// SendPrepared dispatches a previously prepared outbound wallet payment.
+func (c *Client) SendPrepared(ctx context.Context, req SendPreparedRequest) (
+	*SendResult, error) {
+
+	if err := c.requireWalletRPC(); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(req.SendIntentID) == "" {
+		return nil, fmt.Errorf("send_intent_id is required")
+	}
+
+	resp, err := c.wallet.Send(ctx, &walletdkrpc.SendRequest{
+		SendIntentId: strings.TrimSpace(req.SendIntentID),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("send wallet payment: %w", err)
 	}

--- a/sdk/walletdk/client_test.go
+++ b/sdk/walletdk/client_test.go
@@ -75,14 +75,14 @@ func TestBtcwalletRPCUsesClientBufconn(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestSendRejectsAmbiguousDestination ensures wrappers cannot accidentally set
-// both destination fields and have walletdk pick one.
-func TestSendRejectsAmbiguousDestination(t *testing.T) {
+// TestPrepareSendRejectsAmbiguousDestination ensures wrappers cannot
+// accidentally set both destination fields and have walletdk pick one.
+func TestPrepareSendRejectsAmbiguousDestination(t *testing.T) {
 	t.Parallel()
 
 	client := &Client{canWallet: true}
 
-	_, err := client.Send(context.Background(), SendRequest{
+	_, err := client.PrepareSend(context.Background(), PrepareSendRequest{
 		Invoice:        "lnbcrt...",
 		OnchainAddress: "bcrt1...",
 	})

--- a/sdk/walletdk/convert.go
+++ b/sdk/walletdk/convert.go
@@ -106,6 +106,67 @@ func listResultFromProto(view ListView,
 	return out
 }
 
+func prepareSendResultFromProto(
+	resp *walletdkrpc.PrepareSendResponse) *PrepareSendResult {
+
+	if resp == nil {
+		return &PrepareSendResult{}
+	}
+
+	return &PrepareSendResult{
+		SendIntentID:            resp.GetSendIntentId(),
+		AmountSat:               resp.GetAmountSat(),
+		ExpectedFeeSat:          resp.GetExpectedFeeSat(),
+		FeeKnown:                resp.GetFeeKnown(),
+		ExpectedTotalOutflowSat: resp.GetExpectedTotalOutflowSat(),
+		TotalOutflowKnown:       resp.GetTotalOutflowKnown(),
+		Rail:                    sendRailFromProto(resp.GetRail()),
+		QuoteStatus: quoteStatusFromProto(
+			resp.GetQuoteStatus(),
+		),
+		DestinationSummary: resp.GetDestinationSummary(),
+		InvoiceDescription: resp.GetInvoiceDescription(),
+		PaymentHash:        resp.GetPaymentHash(),
+		ExpiresAtUnix:      resp.GetExpiresAtUnix(),
+		SelectedOutpoints: append(
+			[]string(nil), resp.GetSelectedOutpoints()...,
+		),
+		Warning: resp.GetWarning(),
+	}
+}
+
+func sendRailFromProto(rail walletdkrpc.SendRail) SendRail {
+	switch rail {
+	case walletdkrpc.SendRail_SEND_RAIL_OFFCHAIN_UNKNOWN:
+		return SendRailOffchainUnknown
+
+	case walletdkrpc.SendRail_SEND_RAIL_IN_ARK:
+		return SendRailInArk
+
+	case walletdkrpc.SendRail_SEND_RAIL_LIGHTNING:
+		return SendRailLightning
+
+	case walletdkrpc.SendRail_SEND_RAIL_ONCHAIN:
+		return SendRailOnchain
+
+	default:
+		return SendRailUnspecified
+	}
+}
+
+func quoteStatusFromProto(status walletdkrpc.SendQuoteStatus) SendQuoteStatus {
+	switch status {
+	case walletdkrpc.SendQuoteStatus_SEND_QUOTE_STATUS_COMPLETE:
+		return SendQuoteStatusComplete
+
+	case walletdkrpc.SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY:
+		return SendQuoteStatusLocalOnly
+
+	default:
+		return SendQuoteStatusUnspecified
+	}
+}
+
 // exitJobStatusFromProto maps the walletdkrpc ExitJobStatus enum onto the
 // SDK string set.
 func exitJobStatusFromProto(s walletdkrpc.ExitJobStatus) ExitJobStatus {

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -145,19 +145,64 @@ type ReceiveResult struct {
 	Entry   Entry
 }
 
-// SendRequest dispatches an outbound payment.
-type SendRequest struct {
+// PrepareSendRequest validates and previews an outbound payment without
+// moving funds.
+type PrepareSendRequest struct {
 	Invoice        string
 	OnchainAddress string
 	AmountSat      uint64
 	Note           string
 	MaxFeeSat      uint64
 
-	// SweepAll drains every live VTXO to OnchainAddress. When set the
-	// daemon ignores AmountSat (which must be zero) and the host SHOULD
-	// echo SendResult.ActualAmountSat back to the user before treating
-	// the send as confirmed. Ignored on the invoice path.
+	// SweepAll drains every live VTXO to OnchainAddress. PrepareSend
+	// snapshots the live VTXO set and SendPrepared later spends that
+	// exact set. Ignored on the invoice path.
 	SweepAll bool
+}
+
+// SendRail identifies the expected settlement rail for a prepared send.
+type SendRail string
+
+const (
+	SendRailUnspecified     SendRail = "unspecified"
+	SendRailOffchainUnknown SendRail = "offchain_unknown"
+	SendRailInArk           SendRail = "in_ark"
+	SendRailLightning       SendRail = "lightning"
+	SendRailOnchain         SendRail = "onchain"
+)
+
+// SendQuoteStatus describes how complete the prepare-time quote is.
+type SendQuoteStatus string
+
+const (
+	SendQuoteStatusUnspecified SendQuoteStatus = "unspecified"
+	SendQuoteStatusComplete    SendQuoteStatus = "complete"
+	SendQuoteStatusLocalOnly   SendQuoteStatus = "local_only"
+)
+
+// PrepareSendResult contains the preview and intent id for a send.
+type PrepareSendResult struct {
+	SendIntentID            string
+	AmountSat               int64
+	ExpectedFeeSat          int64
+	FeeKnown                bool
+	ExpectedTotalOutflowSat int64
+	TotalOutflowKnown       bool
+	Rail                    SendRail
+	QuoteStatus             SendQuoteStatus
+	DestinationSummary      string
+	InvoiceDescription      string
+	PaymentHash             string
+	ExpiresAtUnix           int64
+	SelectedOutpoints       []string
+	Warning                 string
+}
+
+// SendPreparedRequest dispatches a prepared outbound payment.
+type SendPreparedRequest struct {
+	// SendIntentID is consumed before dispatch. If dispatch returns an
+	// error, callers should prepare a fresh send before retrying.
+	SendIntentID string
 }
 
 // SendResult contains the initial wallet entry for an outbound payment.

--- a/sdk/walletdk/walletdkrpc_stub_test.go
+++ b/sdk/walletdk/walletdkrpc_stub_test.go
@@ -19,7 +19,7 @@ func TestWalletMethodsRequireWalletRPC(t *testing.T) {
 	})
 	require.ErrorIs(t, err, ErrWalletRPCUnavailable)
 
-	_, err = client.Send(context.Background(), SendRequest{
+	_, err = client.PrepareSend(context.Background(), PrepareSendRequest{
 		Invoice: "invoice",
 	})
 	require.ErrorIs(t, err, ErrWalletRPCUnavailable)

--- a/swapwallet/deps.go
+++ b/swapwallet/deps.go
@@ -4,8 +4,10 @@ package swapwallet
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/darepod"
@@ -126,6 +128,11 @@ type Deps struct {
 	// (deposit), ListVTXOs (coin selection for onchain sends).
 	RPCServer RPCServer
 
+	// ChainParams is the daemon's configured Bitcoin network. Invoice
+	// prepare must decode against this exact network so a cross-network
+	// BOLT-11 invoice is rejected before a send intent is issued.
+	ChainParams *chaincfg.Params
+
 	// Log is the swapwallet subsystem logger; falls back to btclog.Disabled
 	// when nil.
 	Log btclog.Logger
@@ -209,4 +216,28 @@ func (d *Deps) resolveLog() btclog.Logger {
 	}
 
 	return btclog.Disabled
+}
+
+// chainParamsForWalletNetwork converts the daemon network string into the
+// btcd chain parameters used by wallet-layer invoice validation.
+func chainParamsForWalletNetwork(network string) (*chaincfg.Params, error) {
+	switch network {
+	case "mainnet", "bitcoin":
+		return &chaincfg.MainNetParams, nil
+
+	case "testnet", "testnet3":
+		return &chaincfg.TestNet3Params, nil
+
+	case "regtest":
+		return &chaincfg.RegressionNetParams, nil
+
+	case "simnet":
+		return &chaincfg.SimNetParams, nil
+
+	case "signet":
+		return &chaincfg.SigNetParams, nil
+
+	default:
+		return nil, fmt.Errorf("unknown network %q", network)
+	}
 }

--- a/swapwallet/errors.go
+++ b/swapwallet/errors.go
@@ -21,6 +21,11 @@ var (
 	ErrInvalidDestination = errors.New("send destination must set " +
 		"invoice or onchain_address")
 
+	// ErrInvalidSendIntent is returned when Send is invoked without a
+	// live prepared send intent.
+	ErrInvalidSendIntent = errors.New("send intent is missing, expired, " +
+		"or already consumed")
+
 	// ErrAmountRequired is returned when Send is invoked with an onchain
 	// destination but no amount, or with an invoice that does not encode
 	// an amount and no caller-supplied amount.

--- a/swapwallet/register.go
+++ b/swapwallet/register.go
@@ -73,10 +73,18 @@ func Register(ctx context.Context, grpcServer *grpc.Server,
 		coreRPC = rpcServer
 	}
 
+	chainParams, err := chainParamsForWalletNetwork(cfg.Network)
+	if err != nil {
+		failoverResume()
+
+		return nil, fmt.Errorf("swapwallet: %w", err)
+	}
+
 	deps := &Deps{
 		SwapBackend: cfg.Swap.Backend,
 		SwapService: swapService,
 		RPCServer:   coreRPC,
+		ChainParams: chainParams,
 	}
 	if rpcServer != nil {
 		deps.Log = rpcServer.SubLogger(darepod.WalletRPCSubsystem)

--- a/swapwallet/register_test.go
+++ b/swapwallet/register_test.go
@@ -45,6 +45,7 @@ func TestRegisterDefersResumeUntilWalletReadyHook(t *testing.T) {
 
 	backend := &fakeWalletBackend{}
 	cfg := &darepod.Config{
+		Network: "regtest",
 		Swap: &darepod.SwapConfig{
 			Backend:        backend,
 			SuppressResume: true,

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -4,13 +4,16 @@ package swapwallet
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"strings"
 
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"github.com/lightningnetwork/lnd/zpay32"
 )
 
 // router dispatches outbound Send requests to the appropriate daemon
@@ -22,54 +25,150 @@ import (
 type router struct {
 	deps    *Deps
 	runtime *Runtime
+	intents *preparedSendStore
 }
 
 // newRouter constructs a router bound to the shared wallet runtime.
 func newRouter(deps *Deps, runtime *Runtime) *router {
-	return &router{deps: deps, runtime: runtime}
+	return &router{
+		deps:    deps,
+		runtime: runtime,
+		intents: newPreparedSendStore(),
+	}
 }
 
-// Send dispatches a SendRequest to the right backend and returns the
-// initial WalletEntry that callers can poll or subscribe to for status
-// transitions.
-func (r *router) Send(ctx context.Context, req *walletdkrpc.SendRequest) (
-	*walletdkrpc.SendResponse, error) {
+// PrepareSend validates an outbound payment and records the exact intent that
+// a later Send call may consume.
+func (r *router) PrepareSend(ctx context.Context,
+	req *walletdkrpc.PrepareSendRequest) (*walletdkrpc.PrepareSendResponse,
+	error) {
 
 	if r == nil || r.deps == nil {
 		return nil, ErrSwapBackendUnavailable
 	}
+	if req == nil {
+		return nil, ErrInvalidDestination
+	}
 
 	switch dest := req.GetDestination().(type) {
-	case *walletdkrpc.SendRequest_Invoice:
-		return r.sendInvoice(ctx, dest.Invoice, req)
+	case *walletdkrpc.PrepareSendRequest_Invoice:
+		return r.prepareInvoice(ctx, dest.Invoice, req)
 
-	case *walletdkrpc.SendRequest_OnchainAddress:
-		return r.sendOnchain(ctx, dest.OnchainAddress, req)
+	case *walletdkrpc.PrepareSendRequest_OnchainAddress:
+		return r.prepareOnchain(ctx, dest.OnchainAddress, req)
 
 	default:
 		return nil, ErrInvalidDestination
 	}
 }
 
-// sendInvoice routes a BOLT-11 invoice through the daemon-owned swap
-// subserver. PR #339 lets the swap server transparently settle same-Ark
-// p2p when both parties are co-located, so the caller never sees that
-// distinction at the wallet layer.
-func (r *router) sendInvoice(ctx context.Context, invoice string,
-	req *walletdkrpc.SendRequest) (*walletdkrpc.SendResponse, error) {
+// Send consumes a prepared send intent and dispatches it to the right backend.
+func (r *router) Send(ctx context.Context, req *walletdkrpc.SendRequest) (
+	*walletdkrpc.SendResponse, error) {
+
+	if r == nil || r.deps == nil {
+		return nil, ErrSwapBackendUnavailable
+	}
+	if req == nil {
+		return nil, ErrInvalidSendIntent
+	}
+
+	intent, err := r.intents.consume(
+		strings.TrimSpace(
+			req.GetSendIntentId(),
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	switch intent.kind {
+	case preparedSendInvoice:
+		return r.sendInvoiceIntent(ctx, intent)
+
+	case preparedSendOnchain:
+		return r.sendOnchainIntent(ctx, intent)
+
+	default:
+		return nil, ErrInvalidSendIntent
+	}
+}
+
+func (r *router) prepareInvoice(ctx context.Context, invoice string,
+	req *walletdkrpc.PrepareSendRequest) (*walletdkrpc.PrepareSendResponse,
+	error) {
 
 	invoice = strings.TrimSpace(invoice)
 	if invoice == "" {
 		return nil, ErrInvalidDestination
 	}
+
+	decoded, err := decodePreparedInvoice(invoice, r.deps.ChainParams)
+	if err != nil {
+		return nil, err
+	}
+
+	amountSat, err := extractPreparedInvoiceAmountSat(decoded)
+	if err != nil {
+		return nil, err
+	}
+	if amountSat > math.MaxInt64 {
+		return nil, fmt.Errorf("%w: invoice amount exceeds int64 range",
+			ErrAmountInvalid)
+	}
+
+	paymentHash := ""
+	if decoded.PaymentHash != nil {
+		paymentHash = hex.EncodeToString(decoded.PaymentHash[:])
+	}
+
+	description := ""
+	if decoded.Description != nil {
+		description = strings.TrimSpace(*decoded.Description)
+	}
+
+	intent := &preparedSendIntent{
+		kind:      preparedSendInvoice,
+		invoice:   invoice,
+		amountSat: amountSat,
+		note:      req.GetNote(),
+		maxFeeSat: req.GetMaxFeeSat(),
+	}
+
+	if _, err := r.intents.put(intent); err != nil {
+		return nil, err
+	}
+
+	return prepareResponseFromIntent(
+		intent, prepareSendPreview{
+			rail: walletdkrpc.SendRail_SEND_RAIL_OFFCHAIN_UNKNOWN,
+			quoteStatus: walletdkrpc.
+				SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY,
+			amountSat:          int64(amountSat),
+			feeKnown:           false,
+			totalOutflowKnown:  false,
+			destinationSummary: truncate(invoice, 32),
+			invoiceDescription: description,
+			paymentHash:        paymentHash,
+			warning: "swapserver quote support is not available " +
+				"yet",
+		},
+	), nil
+}
+
+// sendInvoiceIntent routes a prepared BOLT-11 invoice through the
+// daemon-owned swap subserver.
+func (r *router) sendInvoiceIntent(ctx context.Context,
+	intent *preparedSendIntent) (*walletdkrpc.SendResponse, error) {
+
 	if r.deps.SwapService == nil {
 		return nil, ErrSwapBackendUnavailable
 	}
 
 	startResp, err := r.deps.SwapService.StartPay(
 		ctx, &swapclientrpc.StartPayRequest{
-			Invoice:   invoice,
-			MaxFeeSat: req.GetMaxFeeSat(),
+			Invoice:   intent.invoice,
+			MaxFeeSat: intent.maxFeeSat,
 		},
 	)
 	if err != nil {
@@ -77,7 +176,7 @@ func (r *router) sendInvoice(ctx context.Context, invoice string,
 	}
 
 	entry := swapEntryFromSummary(
-		startResp.GetSwap(), req.GetNote(), invoice,
+		startResp.GetSwap(), intent.note, intent.invoice,
 		walletdkrpc.EntryKind_ENTRY_KIND_SEND,
 	)
 
@@ -90,8 +189,8 @@ func (r *router) sendInvoice(ctx context.Context, invoice string,
 	}, nil
 }
 
-// sendOnchain routes an onchain destination through the existing
-// LeaveVTXOs cooperative-exit RPC. The router selects VTXOs covering the
+// prepareOnchain validates an onchain destination through local VTXO
+// selection. The router selects VTXOs covering the
 // requested amount using the existing wallet listing surface — no new
 // coin-selection primitive is introduced here.
 //
@@ -103,13 +202,15 @@ func (r *router) sendInvoice(ctx context.Context, invoice string,
 // pre-split a VTXO via OOR for exact amounts; that work is intentionally
 // out of scope here.
 //
-// Sweep semantics are gated on the explicit SendRequest.sweep_all flag:
+// Sweep semantics are gated on the explicit PrepareSendRequest.sweep_all flag:
 // amt_sat = 0 with sweep_all = false is rejected (the most common typo)
 // and amt_sat > 0 with sweep_all = true is rejected (contradictory).
 // This keeps "drain the wallet" structurally distinct from a defaulted
-// zero amount.
-func (r *router) sendOnchain(ctx context.Context, addr string,
-	req *walletdkrpc.SendRequest) (*walletdkrpc.SendResponse, error) {
+// zero amount. PrepareSend snapshots sweep_all as an explicit outpoint list;
+// VTXOs arriving after prepare are not included in the subsequent Send.
+func (r *router) prepareOnchain(ctx context.Context, addr string,
+	req *walletdkrpc.PrepareSendRequest) (*walletdkrpc.PrepareSendResponse,
+	error) {
 
 	addr = strings.TrimSpace(addr)
 	if addr == "" {
@@ -137,32 +238,21 @@ func (r *router) sendOnchain(ctx context.Context, addr string,
 			ErrAmountInvalid)
 	}
 
-	leaveReq := &daemonrpc.LeaveVTXOsRequest{
-		DefaultDestination: &daemonrpc.LeaveDestination{
-			Target: &daemonrpc.LeaveDestination_Address{
-				Address: addr,
-			},
-		},
-	}
-
-	var actualSat int64
+	var (
+		actualSat int64
+		selected  []string
+	)
 	switch {
 	case sweepAll:
-		// Sweep every live VTXO. LeaveVTXOs rejects non-empty
-		// per-outpoint overrides under selection=all, so the
-		// caller's address is applied uniformly.
-		leaveReq.Selection = &daemonrpc.LeaveVTXOsRequest_All{
-			All: true,
-		}
-
-		// Total in flight is the sum of every live VTXO so the
-		// caller's UI can echo it back before the user treats the
-		// send as confirmed.
-		total, err := r.totalLiveVTXOAmount(ctx)
+		vtxos, err := r.listLiveVTXOsForLeave(ctx)
 		if err != nil {
 			return nil, err
 		}
-		actualSat = total
+		selected, actualSat = outpointsAndSum(vtxos)
+		if actualSat == 0 {
+			return nil, fmt.Errorf("%w: no live VTXOs to sweep",
+				ErrAmountRequired)
+		}
 
 	default:
 		// Caller-bounded send: select live VTXOs whose total covers
@@ -170,18 +260,80 @@ func (r *router) sendOnchain(ctx context.Context, addr string,
 		// is the input to LeaveVTXOs; per-outpoint destinations are
 		// omitted so DefaultDestination applies to every selected
 		// outpoint.
-		selected, selectedSum, err := r.selectVTXOsForAmount(
+		selectedSet, selectedSum, err := r.selectVTXOsForAmount(
 			ctx, int64(amtSat),
 		)
 		if err != nil {
 			return nil, err
 		}
-		leaveReq.Selection = &daemonrpc.LeaveVTXOsRequest_Outpoints{
-			Outpoints: &daemonrpc.OutpointSelection{
-				Outpoints: selected,
-			},
-		}
+		selected = selectedSet
 		actualSat = selectedSum
+	}
+
+	intent := &preparedSendIntent{
+		kind:              preparedSendOnchain,
+		onchainAddress:    addr,
+		amountSat:         amtSat,
+		note:              req.GetNote(),
+		maxFeeSat:         req.GetMaxFeeSat(),
+		sweepAll:          sweepAll,
+		selectedOutpoints: append([]string(nil), selected...),
+		actualAmountSat:   actualSat,
+	}
+
+	if _, err := r.intents.put(intent); err != nil {
+		return nil, err
+	}
+
+	warning := "operator cooperative-leave quote support is not " +
+		"available yet"
+
+	previewAmount := int64(amtSat)
+	if sweepAll {
+		previewAmount = actualSat
+	}
+
+	return prepareResponseFromIntent(
+		intent, prepareSendPreview{
+			rail: walletdkrpc.SendRail_SEND_RAIL_ONCHAIN,
+			quoteStatus: walletdkrpc.
+				SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY,
+			amountSat:               previewAmount,
+			feeKnown:                false,
+			expectedTotalOutflowSat: actualSat,
+			totalOutflowKnown:       true,
+			destinationSummary:      addr,
+			warning:                 warning,
+		},
+	), nil
+}
+
+// sendOnchainIntent routes a prepared onchain destination through the existing
+// LeaveVTXOs cooperative-exit RPC.
+func (r *router) sendOnchainIntent(ctx context.Context,
+	intent *preparedSendIntent) (*walletdkrpc.SendResponse, error) {
+
+	if r.deps.RPCServer == nil {
+		return nil, ErrSwapBackendUnavailable
+	}
+	if len(intent.selectedOutpoints) == 0 {
+		return nil, ErrInvalidSendIntent
+	}
+
+	leaveReq := &daemonrpc.LeaveVTXOsRequest{
+		Selection: &daemonrpc.LeaveVTXOsRequest_Outpoints{
+			Outpoints: &daemonrpc.OutpointSelection{
+				Outpoints: append(
+					[]string(nil),
+					intent.selectedOutpoints...,
+				),
+			},
+		},
+		DefaultDestination: &daemonrpc.LeaveDestination{
+			Target: &daemonrpc.LeaveDestination_Address{
+				Address: intent.onchainAddress,
+			},
+		},
 	}
 
 	resp, err := r.deps.RPCServer.LeaveVTXOs(ctx, leaveReq)
@@ -218,12 +370,13 @@ func (r *router) sendOnchain(ctx context.Context, addr string,
 	// recording int64(amtSat) on the pending entry would make the row
 	// show as a zero-sat exit in List/SubscribeWallet. The real outflow
 	// is the actualSat sum of selected VTXOs computed above.
-	entryAmt := int64(amtSat)
-	if sweepAll {
-		entryAmt = actualSat
+	entryAmt := int64(intent.amountSat)
+	if intent.sweepAll {
+		entryAmt = intent.actualAmountSat
 	}
 	entry := leaveEntryStub(
-		resp.GetQueuedOutpoints(), addr, entryAmt, req.GetNote(),
+		resp.GetQueuedOutpoints(), intent.onchainAddress, entryAmt,
+		intent.note,
 	)
 
 	// v1 SCOPE: we track the pending row for the deadline watcher
@@ -240,7 +393,7 @@ func (r *router) sendOnchain(ctx context.Context, addr string,
 
 	return &walletdkrpc.SendResponse{
 		Entry:           entry,
-		ActualAmountSat: actualSat,
+		ActualAmountSat: intent.actualAmountSat,
 	}, nil
 }
 
@@ -268,26 +421,6 @@ func (r *router) listLiveVTXOsForLeave(ctx context.Context) ([]*daemonrpc.VTXO,
 	}
 
 	return listResp.GetVtxos(), nil
-}
-
-// totalLiveVTXOAmount sums every live VTXO so a sweep-all caller can be
-// told how much will actually leave the wallet before the daemon hands
-// the operation off to LeaveVTXOs.
-func (r *router) totalLiveVTXOAmount(ctx context.Context) (int64, error) {
-	vtxos, err := r.listLiveVTXOsForLeave(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	var total int64
-	for _, v := range vtxos {
-		if v.GetAmountSat() <= 0 {
-			continue
-		}
-		total += v.GetAmountSat()
-	}
-
-	return total, nil
 }
 
 // selectVTXOsForAmount returns the smallest-sufficient set of live VTXO
@@ -329,4 +462,56 @@ func (r *router) selectVTXOsForAmount(ctx context.Context, target int64) (
 
 	return nil, 0, fmt.Errorf("%w: insufficient live VTXOs cover %d sat "+
 		"(covered=%d)", ErrAmountRequired, target, covered)
+}
+
+func outpointsAndSum(vtxos []*daemonrpc.VTXO) ([]string, int64) {
+	var (
+		outpoints []string
+		total     int64
+	)
+	for _, v := range vtxos {
+		if v.GetAmountSat() <= 0 {
+			continue
+		}
+		outpoints = append(outpoints, v.GetOutpoint())
+		total += v.GetAmountSat()
+	}
+
+	return outpoints, total
+}
+
+func decodePreparedInvoice(invoice string,
+	chainParams *chaincfg.Params) (*zpay32.Invoice, error) {
+
+	if chainParams == nil {
+		return nil, fmt.Errorf("%w: invoice chain params are required",
+			ErrSwapBackendUnavailable)
+	}
+
+	decoded, err := zpay32.Decode(invoice, chainParams)
+	if err != nil {
+		return nil, fmt.Errorf("%w: decode invoice: %v",
+			ErrInvalidDestination, err)
+	}
+
+	return decoded, nil
+}
+
+func extractPreparedInvoiceAmountSat(decoded *zpay32.Invoice) (uint64, error) {
+	if decoded == nil || decoded.MilliSat == nil {
+		return 0, fmt.Errorf("%w: invoice amount is required",
+			ErrAmountRequired)
+	}
+
+	amountMSat := uint64(*decoded.MilliSat)
+	if amountMSat == 0 {
+		return 0, fmt.Errorf("%w: invoice amount must be positive",
+			ErrAmountInvalid)
+	}
+	if amountMSat%1000 != 0 {
+		return 0, fmt.Errorf("%w: invoice amount must be whole "+
+			"satoshis", ErrAmountInvalid)
+	}
+
+	return amountMSat / 1000, nil
 }

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -5,10 +5,18 @@ package swapwallet
 import (
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/zpay32"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -27,11 +35,152 @@ func newRouterFixture(t *testing.T) (*router, *fakeSwapService,
 		SwapBackend: nil, // not used by router paths
 		SwapService: swap,
 		RPCServer:   rpc,
+		ChainParams: &chaincfg.RegressionNetParams,
 	}
 	runtime := newRuntime(t.Context(), deps)
 	t.Cleanup(runtime.stop)
 
 	return newRouter(deps, runtime), swap, rpc
+}
+
+func sendPrepared(t *testing.T, r *router,
+	resp *walletdkrpc.PrepareSendResponse) (*walletdkrpc.SendResponse,
+	error) {
+
+	t.Helper()
+
+	return r.Send(t.Context(), &walletdkrpc.SendRequest{
+		SendIntentId: resp.GetSendIntentId(),
+	})
+}
+
+func sendPreparedInvoice(t *testing.T, r *router, invoice string,
+	maxFeeSat uint64) (*walletdkrpc.SendResponse, error) {
+
+	t.Helper()
+
+	intent := &preparedSendIntent{
+		kind:      preparedSendInvoice,
+		invoice:   invoice,
+		maxFeeSat: maxFeeSat,
+	}
+	id, err := r.intents.put(intent)
+	require.NoError(t, err)
+
+	return r.Send(t.Context(), &walletdkrpc.SendRequest{
+		SendIntentId: id,
+	})
+}
+
+func testPreparedInvoice(t *testing.T, amountSat btcutil.Amount,
+	description string) (string, string) {
+
+	t.Helper()
+
+	return testPreparedInvoiceOnNet(
+		t, &chaincfg.RegressionNetParams, amountSat, description,
+	)
+}
+
+func testPreparedInvoiceOnNet(t *testing.T, params *chaincfg.Params,
+	amountSat btcutil.Amount, description string) (string, string) {
+
+	t.Helper()
+
+	invoiceKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage := lntypes.Preimage{
+		0x01, 0x02, 0x03, 0x04,
+	}
+	paymentHash := preimage.Hash()
+
+	invoice, err := zpay32.NewInvoice(
+		params, paymentHash, time.Now(),
+		zpay32.Amount(
+			lnwire.NewMSatFromSatoshis(amountSat),
+		),
+		zpay32.Description(description),
+	)
+	require.NoError(t, err)
+
+	paymentRequest, err := invoice.Encode(zpay32.MessageSigner{
+		SignCompact: func(msg []byte) ([]byte, error) {
+			return ecdsa.SignCompact(invoiceKey, msg, true), nil
+		},
+	})
+	require.NoError(t, err)
+
+	return paymentRequest, paymentHash.String()
+}
+
+// TestRouterPrepareSendInvoiceRejectsWrongNetwork confirms prepare decodes
+// BOLT-11 invoices against the daemon network before issuing an intent.
+func TestRouterPrepareSendInvoiceRejectsWrongNetwork(t *testing.T) {
+	t.Parallel()
+
+	r, swap, rpc := newRouterFixture(t)
+	invoice, _ := testPreparedInvoiceOnNet(
+		t, &chaincfg.MainNetParams, 12_345, "wrong network",
+	)
+
+	_, err := r.PrepareSend(
+		t.Context(), &walletdkrpc.PrepareSendRequest{
+			Destination: &walletdkrpc.PrepareSendRequest_Invoice{
+				Invoice: invoice,
+			},
+		},
+	)
+	require.ErrorIs(t, err, ErrInvalidDestination)
+	require.Equal(t, 0, swap.startPayCalls)
+	require.Equal(t, 0, rpc.leaveCalls)
+
+	r.intents.mu.Lock()
+	intentCount := len(r.intents.intents)
+	r.intents.mu.Unlock()
+	require.Zero(t, intentCount, "wrong-network invoices create no intent")
+}
+
+// TestRouterPrepareSendInvoiceReturnsLocalPreview confirms the invoice
+// prepare path decodes the BOLT-11 metadata locally, produces a short-lived
+// intent, and honestly marks fee/rail details as local-only until remote quote
+// APIs exist.
+func TestRouterPrepareSendInvoiceReturnsLocalPreview(t *testing.T) {
+	t.Parallel()
+
+	r, swap, rpc := newRouterFixture(t)
+	invoice, paymentHash := testPreparedInvoice(t, 12_345, "coffee")
+
+	resp, err := r.PrepareSend(
+		t.Context(), &walletdkrpc.PrepareSendRequest{
+			Destination: &walletdkrpc.PrepareSendRequest_Invoice{
+				Invoice: invoice,
+			},
+			AmtSat:    99_999,
+			MaxFeeSat: 25,
+		},
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.GetSendIntentId())
+	require.Equal(t, int64(12_345), resp.GetAmountSat())
+	require.Equal(
+		t, walletdkrpc.SendRail_SEND_RAIL_OFFCHAIN_UNKNOWN,
+		resp.GetRail(),
+	)
+	require.Equal(
+		t, walletdkrpc.SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY,
+		resp.GetQuoteStatus(),
+	)
+	require.False(t, resp.GetFeeKnown())
+	require.False(t, resp.GetTotalOutflowKnown())
+	require.Equal(t, int64(0), resp.GetExpectedFeeSat())
+	require.Equal(t, int64(0), resp.GetExpectedTotalOutflowSat())
+	require.Equal(t, "coffee", resp.GetInvoiceDescription())
+	require.Equal(t, paymentHash, resp.GetPaymentHash())
+	require.Contains(t, resp.GetDestinationSummary(), "lnbcrt")
+	require.Contains(t, resp.GetWarning(), "swapserver quote support")
+	require.Equal(t, 0, swap.startPayCalls)
+	require.Equal(t, 0, rpc.leaveCalls)
 }
 
 // TestRouterSendInvoiceDispatchesStartPay confirms an invoice destination
@@ -50,12 +199,7 @@ func TestRouterSendInvoiceDispatchesStartPay(t *testing.T) {
 		},
 	}
 
-	resp, err := r.Send(t.Context(), &walletdkrpc.SendRequest{
-		Destination: &walletdkrpc.SendRequest_Invoice{
-			Invoice: "lnbc1example",
-		},
-		MaxFeeSat: 25,
-	})
+	resp, err := sendPreparedInvoice(t, r, "lnbc1example", 25)
 	require.NoError(t, err)
 	require.Equal(t, 1, swap.startPayCalls)
 	require.Equal(t, 0, rpc.leaveCalls)
@@ -102,12 +246,35 @@ func TestRouterSendOnchainSelectsVTXOsAndCallsLeave(t *testing.T) {
 		Status: "queued",
 	}
 
-	resp, err := r.Send(t.Context(), &walletdkrpc.SendRequest{
-		Destination: &walletdkrpc.SendRequest_OnchainAddress{
-			OnchainAddress: "bcrt1qaddr",
+	prepareResp, err := r.PrepareSend(
+		t.Context(), &walletdkrpc.PrepareSendRequest{
+			Destination: &walletdkrpc.
+				PrepareSendRequest_OnchainAddress{
+				OnchainAddress: "bcrt1qaddr",
+			},
+			AmtSat: 10000,
 		},
-		AmtSat: 10000,
-	})
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, walletdkrpc.SendRail_SEND_RAIL_ONCHAIN,
+		prepareResp.GetRail(),
+	)
+	require.Equal(
+		t, walletdkrpc.SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY,
+		prepareResp.GetQuoteStatus(),
+	)
+	require.Equal(
+		t, int64(12_000), prepareResp.GetExpectedTotalOutflowSat(),
+	)
+	require.Equal(
+		t, []string{
+			"tx1:0",
+			"tx2:1",
+		},
+		prepareResp.GetSelectedOutpoints(),
+	)
+	resp, err := sendPrepared(t, r, prepareResp)
 	require.NoError(t, err)
 	require.Equal(t, 0, swap.startPayCalls)
 	require.Equal(t, 1, rpc.leaveCalls)
@@ -158,12 +325,19 @@ func TestRouterSendOnchainSelectsVTXOsAndCallsLeave(t *testing.T) {
 		"selectVTXOsForAmount must filter to live VTXOs only "+
 			"(darepo-client#577)",
 	)
+
+	_, err = sendPrepared(t, r, prepareResp)
+	require.ErrorIs(t, err, ErrInvalidSendIntent)
+	require.Equal(
+		t, 1, rpc.leaveCalls,
+		"prepared send intents must be consume-once",
+	)
 }
 
-// TestRouterSendOnchainSweepAllRoutesToAllSelection confirms that the
-// explicit sweep_all flag routes through Selection.All and surfaces the
-// total live VTXO sum on actual_amount_sat.
-func TestRouterSendOnchainSweepAllRoutesToAllSelection(t *testing.T) {
+// TestRouterSendOnchainSweepAllUsesPreparedOutpoints confirms that the
+// explicit sweep_all flag snapshots the live set during prepare and spends
+// those exact outpoints during send.
+func TestRouterSendOnchainSweepAllUsesPreparedOutpoints(t *testing.T) {
 	t.Parallel()
 
 	r, _, rpc := newRouterFixture(t)
@@ -187,17 +361,30 @@ func TestRouterSendOnchainSweepAllRoutesToAllSelection(t *testing.T) {
 		Status: "queued",
 	}
 
-	resp, err := r.Send(t.Context(), &walletdkrpc.SendRequest{
-		Destination: &walletdkrpc.SendRequest_OnchainAddress{
-			OnchainAddress: "bcrt1qaddr",
+	prepareResp, err := r.PrepareSend(
+		t.Context(), &walletdkrpc.PrepareSendRequest{
+			Destination: &walletdkrpc.
+				PrepareSendRequest_OnchainAddress{
+				OnchainAddress: "bcrt1qaddr",
+			},
+			AmtSat:   0,
+			SweepAll: true,
 		},
-		AmtSat:   0,
-		SweepAll: true,
-	})
+	)
 	require.NoError(t, err)
-	require.True(
-		t, rpc.leaveLastReq.GetAll(),
-		"sweep_all must trigger Selection.All",
+	require.Equal(t, int64(12_000), prepareResp.GetAmountSat())
+	require.Equal(
+		t, int64(12_000), prepareResp.GetExpectedTotalOutflowSat(),
+	)
+	resp, err := sendPrepared(t, r, prepareResp)
+	require.NoError(t, err)
+	require.Equal(
+		t, []string{
+			"tx1:0",
+			"tx2:1",
+		},
+		rpc.leaveLastReq.GetOutpoints().GetOutpoints(),
+		"sweep_all must spend the exact prepared VTXO set",
 	)
 	require.Equal(
 		t, int64(12_000), resp.GetActualAmountSat(),
@@ -208,13 +395,13 @@ func TestRouterSendOnchainSweepAllRoutesToAllSelection(t *testing.T) {
 		"sweep-all path must also auto-commit the leave intent",
 	)
 
-	// Regression: darepo-client#577. totalLiveVTXOAmount must also
+	// Regression: darepo-client#577. Sweep-all prepare must also
 	// filter to VTXO_STATUS_LIVE so a stuck Forfeiting VTXO from a
 	// prior leave doesn't inflate the reported sweep total.
 	require.Equal(
 		t, daemonrpc.VTXOStatus_VTXO_STATUS_LIVE,
 		rpc.listVTXOsLastReq.GetStatusFilter(),
-		"totalLiveVTXOAmount must filter to live VTXOs only "+
+		"sweep-all prepare must filter to live VTXOs only "+
 			"(darepo-client#577)",
 	)
 }
@@ -246,12 +433,17 @@ func TestRouterSendOnchainAutoJoinFailureSurfaced(t *testing.T) {
 	}
 	rpc.joinNextRoundErr = errors.New("round actor unavailable")
 
-	_, err := r.Send(t.Context(), &walletdkrpc.SendRequest{
-		Destination: &walletdkrpc.SendRequest_OnchainAddress{
-			OnchainAddress: "bcrt1qaddr",
+	prepareResp, err := r.PrepareSend(
+		t.Context(), &walletdkrpc.PrepareSendRequest{
+			Destination: &walletdkrpc.
+				PrepareSendRequest_OnchainAddress{
+				OnchainAddress: "bcrt1qaddr",
+			},
+			AmtSat: 5_000,
 		},
-		AmtSat: 5_000,
-	})
+	)
+	require.NoError(t, err)
+	_, err = sendPrepared(t, r, prepareResp)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "auto-join next round after leave")
 	require.ErrorContains(t, err, "round actor unavailable")
@@ -274,8 +466,8 @@ func TestRouterSendOnchainAmtZeroRejectedWithoutSweepAll(t *testing.T) {
 
 	r, _, rpc := newRouterFixture(t)
 
-	_, err := r.Send(t.Context(), &walletdkrpc.SendRequest{
-		Destination: &walletdkrpc.SendRequest_OnchainAddress{
+	_, err := r.PrepareSend(t.Context(), &walletdkrpc.PrepareSendRequest{
+		Destination: &walletdkrpc.PrepareSendRequest_OnchainAddress{
 			OnchainAddress: "bcrt1qaddr",
 		},
 		AmtSat: 0,
@@ -295,8 +487,8 @@ func TestRouterSendOnchainSweepAllRequiresZeroAmt(t *testing.T) {
 
 	r, _, rpc := newRouterFixture(t)
 
-	_, err := r.Send(t.Context(), &walletdkrpc.SendRequest{
-		Destination: &walletdkrpc.SendRequest_OnchainAddress{
+	_, err := r.PrepareSend(t.Context(), &walletdkrpc.PrepareSendRequest{
+		Destination: &walletdkrpc.PrepareSendRequest_OnchainAddress{
 			OnchainAddress: "bcrt1qaddr",
 		},
 		AmtSat:   1_000,
@@ -324,8 +516,8 @@ func TestRouterSendOnchainInsufficientFunds(t *testing.T) {
 		},
 	}
 
-	_, err := r.Send(t.Context(), &walletdkrpc.SendRequest{
-		Destination: &walletdkrpc.SendRequest_OnchainAddress{
+	_, err := r.PrepareSend(t.Context(), &walletdkrpc.PrepareSendRequest{
+		Destination: &walletdkrpc.PrepareSendRequest_OnchainAddress{
 			OnchainAddress: "bcrt1qaddr",
 		},
 		AmtSat: 10_000,
@@ -337,15 +529,39 @@ func TestRouterSendOnchainInsufficientFunds(t *testing.T) {
 	)
 }
 
-// TestRouterSendUnsetDestinationRejected asserts both invoice and onchain
-// being unset returns ErrInvalidDestination cleanly.
-func TestRouterSendUnsetDestinationRejected(t *testing.T) {
+// TestRouterPrepareSendUnsetDestinationRejected asserts both invoice and
+// onchain being unset returns ErrInvalidDestination cleanly.
+func TestRouterPrepareSendUnsetDestinationRejected(t *testing.T) {
 	t.Parallel()
 
 	r, _, _ := newRouterFixture(t)
 
-	_, err := r.Send(t.Context(), &walletdkrpc.SendRequest{})
+	_, err := r.PrepareSend(
+		t.Context(), &walletdkrpc.PrepareSendRequest{},
+	)
 	require.ErrorIs(t, err, ErrInvalidDestination)
+}
+
+// TestRouterPrepareSendNilRequestRejected confirms direct in-process callers
+// get the same validation error as an empty request rather than a panic.
+func TestRouterPrepareSendNilRequestRejected(t *testing.T) {
+	t.Parallel()
+
+	r, _, _ := newRouterFixture(t)
+
+	_, err := r.PrepareSend(t.Context(), nil)
+	require.ErrorIs(t, err, ErrInvalidDestination)
+}
+
+// TestRouterSendNilRequestRejected confirms a missing prepared intent id is
+// rejected before the store path can dereference a nil request.
+func TestRouterSendNilRequestRejected(t *testing.T) {
+	t.Parallel()
+
+	r, _, _ := newRouterFixture(t)
+
+	_, err := r.Send(t.Context(), nil)
+	require.ErrorIs(t, err, ErrInvalidSendIntent)
 }
 
 // TestRouterSendInvoiceAmountSignedFromCallerKind asserts that an
@@ -370,11 +586,7 @@ func TestRouterSendInvoiceAmountSignedFromCallerKind(t *testing.T) {
 		},
 	}
 
-	resp, err := r.Send(t.Context(), &walletdkrpc.SendRequest{
-		Destination: &walletdkrpc.SendRequest_Invoice{
-			Invoice: "lnbc1example",
-		},
-	})
+	resp, err := sendPreparedInvoice(t, r, "lnbc1example", 0)
 	require.NoError(t, err)
 	require.Equal(
 		t, walletdkrpc.EntryKind_ENTRY_KIND_SEND,
@@ -395,11 +607,7 @@ func TestRouterSendInvoiceErrorBubblesUp(t *testing.T) {
 	r, swap, _ := newRouterFixture(t)
 	swap.startPayErr = errors.New("swap server unavailable")
 
-	_, err := r.Send(t.Context(), &walletdkrpc.SendRequest{
-		Destination: &walletdkrpc.SendRequest_Invoice{
-			Invoice: "lnbc1example",
-		},
-	})
+	_, err := sendPreparedInvoice(t, r, "lnbc1example", 0)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "swap server unavailable")
 }
@@ -415,11 +623,7 @@ func TestRouterSendInvoicePreservesStartPayStatusCode(t *testing.T) {
 	)
 	swap.startPayErr = startPayErr
 
-	_, err := r.Send(t.Context(), &walletdkrpc.SendRequest{
-		Destination: &walletdkrpc.SendRequest_Invoice{
-			Invoice: "lnbc1example",
-		},
-	})
+	_, err := sendPreparedInvoice(t, r, "lnbc1example", 0)
 	require.Error(t, err)
 	require.Equal(t, codes.AlreadyExists, status.Code(err))
 	require.ErrorIs(t, err, startPayErr)

--- a/swapwallet/send_intents.go
+++ b/swapwallet/send_intents.go
@@ -1,0 +1,153 @@
+//go:build walletdkrpc && swapruntime
+
+package swapwallet
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+)
+
+const sendIntentTTL = 5 * time.Minute
+
+type preparedSendKind uint8
+
+const (
+	preparedSendInvoice preparedSendKind = iota + 1
+	preparedSendOnchain
+)
+
+type preparedSendIntent struct {
+	id        string
+	kind      preparedSendKind
+	expiresAt time.Time
+
+	invoice        string
+	onchainAddress string
+	amountSat      uint64
+	note           string
+	maxFeeSat      uint64
+	sweepAll       bool
+
+	selectedOutpoints []string
+	actualAmountSat   int64
+}
+
+type prepareSendPreview struct {
+	rail                    walletdkrpc.SendRail
+	quoteStatus             walletdkrpc.SendQuoteStatus
+	amountSat               int64
+	expectedFeeSat          int64
+	feeKnown                bool
+	expectedTotalOutflowSat int64
+	totalOutflowKnown       bool
+	destinationSummary      string
+	invoiceDescription      string
+	paymentHash             string
+	warning                 string
+}
+
+type preparedSendStore struct {
+	mu      sync.Mutex
+	intents map[string]*preparedSendIntent
+}
+
+func newPreparedSendStore() *preparedSendStore {
+	return &preparedSendStore{
+		intents: make(map[string]*preparedSendIntent),
+	}
+}
+
+// put stores a prepared intent and returns the generated id.
+func (s *preparedSendStore) put(intent *preparedSendIntent) (string, error) {
+	if s == nil || intent == nil {
+		return "", ErrInvalidSendIntent
+	}
+
+	id, err := newSendIntentID()
+	if err != nil {
+		return "", err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	s.pruneExpiredLocked(now)
+
+	intent.id = id
+	intent.expiresAt = now.Add(sendIntentTTL)
+	s.intents[id] = intent
+
+	return id, nil
+}
+
+// consume returns and removes one live prepared intent. Send calls this before
+// dispatching to the backend, so any dispatch failure intentionally burns the
+// intent and requires the caller to prepare again.
+func (s *preparedSendStore) consume(id string) (*preparedSendIntent, error) {
+	if s == nil || id == "" {
+		return nil, ErrInvalidSendIntent
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	s.pruneExpiredLocked(now)
+
+	intent, ok := s.intents[id]
+	if !ok || now.After(intent.expiresAt) {
+		delete(s.intents, id)
+
+		return nil, ErrInvalidSendIntent
+	}
+
+	delete(s.intents, id)
+
+	return intent, nil
+}
+
+func (s *preparedSendStore) pruneExpiredLocked(now time.Time) {
+	for id, intent := range s.intents {
+		if now.After(intent.expiresAt) {
+			delete(s.intents, id)
+		}
+	}
+}
+
+func newSendIntentID() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("generate send intent id: %w", err)
+	}
+
+	return hex.EncodeToString(buf[:]), nil
+}
+
+func prepareResponseFromIntent(intent *preparedSendIntent,
+	preview prepareSendPreview) *walletdkrpc.PrepareSendResponse {
+
+	return &walletdkrpc.PrepareSendResponse{
+		SendIntentId:            intent.id,
+		AmountSat:               preview.amountSat,
+		ExpectedFeeSat:          preview.expectedFeeSat,
+		FeeKnown:                preview.feeKnown,
+		ExpectedTotalOutflowSat: preview.expectedTotalOutflowSat,
+		TotalOutflowKnown:       preview.totalOutflowKnown,
+		Rail:                    preview.rail,
+		QuoteStatus:             preview.quoteStatus,
+		DestinationSummary:      preview.destinationSummary,
+		InvoiceDescription:      preview.invoiceDescription,
+		PaymentHash:             preview.paymentHash,
+		ExpiresAtUnix:           intent.expiresAt.Unix(),
+		SelectedOutpoints: append(
+			[]string(nil), intent.selectedOutpoints...,
+		),
+		Warning: preview.warning,
+	}
+}

--- a/swapwallet/send_intents_test.go
+++ b/swapwallet/send_intents_test.go
@@ -1,0 +1,44 @@
+//go:build walletdkrpc && swapruntime
+
+package swapwallet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreparedSendStoreRejectsExpiredIntent(t *testing.T) {
+	t.Parallel()
+
+	store := newPreparedSendStore()
+	intent := &preparedSendIntent{
+		kind: preparedSendInvoice,
+	}
+
+	id, err := store.put(intent)
+	require.NoError(t, err)
+
+	store.mu.Lock()
+	store.intents[id].expiresAt = time.Now().Add(-time.Second)
+	store.mu.Unlock()
+
+	_, err = store.consume(id)
+	require.ErrorIs(t, err, ErrInvalidSendIntent)
+
+	store.mu.Lock()
+	_, ok := store.intents[id]
+	store.mu.Unlock()
+	require.False(t, ok, "expired intents must be pruned on consume")
+}
+
+func TestPreparedSendStoreRejectsNilIntent(t *testing.T) {
+	t.Parallel()
+
+	store := newPreparedSendStore()
+
+	id, err := store.put(nil)
+	require.ErrorIs(t, err, ErrInvalidSendIntent)
+	require.Empty(t, id)
+}

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -57,9 +57,17 @@ func (s *Service) Unlock(ctx context.Context, req *walletdkrpc.UnlockRequest) (
 	return s.unlock(ctx, req)
 }
 
-// Send dispatches an outbound payment. Invoice destinations route through
-// the daemon-owned swap subserver (which transparently picks same-Ark p2p
-// vHTLC vs real Lightning per PR #339); onchain destinations route through
+// PrepareSend validates and previews an outbound payment, returning a
+// short-lived intent that Send can consume.
+func (s *Service) PrepareSend(ctx context.Context,
+	req *walletdkrpc.PrepareSendRequest) (*walletdkrpc.PrepareSendResponse,
+	error) {
+
+	return s.router.PrepareSend(ctx, req)
+}
+
+// Send dispatches a previously prepared outbound payment. Invoice intents
+// route through the daemon-owned swap subserver; onchain intents route through
 // the existing LeaveVTXOs cooperative-exit RPC.
 func (s *Service) Send(ctx context.Context, req *walletdkrpc.SendRequest) (
 	*walletdkrpc.SendResponse, error) {


### PR DESCRIPTION
## Summary

Adds the walletdk prepare -> send split:

- `PrepareSend` validates a destination, builds a short-lived single-use send intent, and returns preview fields for amount, rail, fee, total outflow, expiry, selected outpoints, and warnings.
- `Send` is now intent-only and consumes the prepared intent before dispatching.
- The SDK, CLI, and MCP wallet tool use the new flow.
- `darepocli send` now prompts by default, with `--force` / `--yes` for non-interactive confirmation and `--dry-run` for preview-only output.

Remote quote APIs that do not exist yet are intentionally not implemented here. Those paths return `LOCAL_ONLY` quote status and warnings instead of pretending fees or offchain rail selection are known.

## Tests

- `go test -tags="dev nolog walletdkrpc swapruntime" ./swapwallet ./sdk/walletdk ./cmd/darepocli/darepoclicommands`
- `make lint-local`
- `make commitmsg-lint commit=HEAD`
- `git diff --check`

## Notes

This is phase 1 of the prepare/send work and should not be treated as fully closing #509 until swapserver and operator quote integration is added.

closes #604
