### PR TITLE
swapwallet: show unboarded deposits as boarding

### DIFF
--- a/db/ledger_store_test.go
+++ b/db/ledger_store_test.go
@@ -546,6 +546,146 @@ func TestLedgerStoreTransactionHistoryWalletUTXOCreatedChainFields(
 	require.Equal(t, depositAmount-vtxoAmount, row.FeeSat)
 }
 
+// TestLedgerStoreTransactionHistoryWalletUTXOCreatedBoardingStatus confirms
+// a chain-confirmed deposit is not reported as complete until its boarding
+// outpoint has moved through a confirmed round and produced a spendable VTXO.
+func TestLedgerStoreTransactionHistoryWalletUTXOCreatedBoardingStatus(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+	store, db := newLedgerStoreAndDBForTest(t)
+
+	outpointHash := testHash32(0x52)
+	const (
+		outpointIndex      = uint32(1)
+		confirmationHeight = int32(304_091)
+		depositAmount      = int64(75_000)
+		createdAt          = int64(1_700_000_601)
+	)
+	pkScript := testBytes(34, 0x09)
+
+	require.NoError(
+		t,
+		store.InsertLedgerEntry(
+			ctx, ledger.LedgerEntry{
+				DebitAccount:   ledger.AccountWalletBalance,
+				CreditAccount:  ledger.AccountOpeningBalance,
+				AmountSat:      depositAmount,
+				EventType:      ledger.EventWalletUTXOCreated,
+				Description:    "boarding deposit",
+				CreatedAt:      createdAt,
+				IdempotencyKey: testBytes(36, 0x61),
+				ChainTxid:      outpointHash[:],
+				ChainVout: testInt32Ptr(
+					int32(outpointIndex),
+				),
+				ConfirmationHeight: testInt32Ptr(
+					confirmationHeight,
+				),
+			},
+		),
+	)
+
+	require.NoError(
+		t,
+		db.InsertBoardingAddress(
+			ctx, sqlc.InsertBoardingAddressParams{
+				PkScript:       pkScript,
+				AddressString:  "bcrt1pboarding",
+				ClientPubkey:   testBytes(33, 0x12),
+				OperatorPubkey: testBytes(33, 0x23),
+				ExitDelay:      144,
+				CreationTime:   createdAt,
+			},
+		),
+	)
+	require.NoError(
+		t,
+		db.InsertBoardingIntent(
+			ctx, sqlc.InsertBoardingIntentParams{
+				OutpointHash:   outpointHash[:],
+				OutpointIndex:  int32(outpointIndex),
+				PkScript:       pkScript,
+				Amount:         depositAmount,
+				ConfHeight:     confirmationHeight,
+				ConfHash:       testBytes(32, 0x03),
+				ConfTx:         testBytes(64, 0x04),
+				TxProof:        testBytes(64, 0x05),
+				Status:         "confirmed",
+				CreationTime:   createdAt,
+				LastUpdateTime: createdAt,
+			},
+		),
+	)
+
+	rows, err := store.ListTransactionHistory(ctx, "boarding", 0, 0, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	row := rows[0]
+	require.Equal(t, ledger.EventWalletUTXOCreated, row.Subtype)
+	require.Equal(t, "boarding", row.Status)
+	require.Equal(t, outpointHash[:], row.Txid)
+	require.Equal(t, confirmationHeight, row.ConfirmationHeight)
+	require.Zero(t, row.FeeSat)
+}
+
+// TestLedgerStoreTransactionHistoryWalletUTXOCreatedNonBoardingStatus confirms
+// a chain-confirmed wallet UTXO that is not backed by a boarding intent stays
+// confirmed. Sweep returns and future non-deposit wallet UTXOs should not be
+// shown as boarding forever just because they have wallet_utxo_created rows.
+func TestLedgerStoreTransactionHistoryWalletUTXOCreatedNonBoardingStatus(
+	t *testing.T) {
+
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newLedgerStoreForTest(t)
+
+	outpointHash := testHash32(0x53)
+	const (
+		outpointIndex      = uint32(0)
+		confirmationHeight = int32(304_101)
+		amount             = int64(50_000)
+		createdAt          = int64(1_700_000_602)
+	)
+
+	require.NoError(
+		t,
+		store.InsertLedgerEntry(
+			ctx, ledger.LedgerEntry{
+				DebitAccount:   ledger.AccountWalletBalance,
+				CreditAccount:  ledger.AccountOpeningBalance,
+				AmountSat:      amount,
+				EventType:      ledger.EventWalletUTXOCreated,
+				Description:    "boarding sweep return",
+				CreatedAt:      createdAt,
+				IdempotencyKey: testBytes(36, 0x62),
+				ChainTxid:      outpointHash[:],
+				ChainVout: testInt32Ptr(
+					int32(outpointIndex),
+				),
+				ConfirmationHeight: testInt32Ptr(
+					confirmationHeight,
+				),
+			},
+		),
+	)
+
+	rows, err := store.ListTransactionHistory(ctx, "boarding", 0, 0, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	row := rows[0]
+	require.Equal(t, ledger.EventWalletUTXOCreated, row.Subtype)
+	require.Equal(t, "confirmed", row.Status)
+	require.Equal(t, outpointHash[:], row.Txid)
+	require.Equal(t, int32(outpointIndex), row.OutputIndex)
+	require.Equal(t, confirmationHeight, row.ConfirmationHeight)
+}
+
 // TestLedgerStoreTransactionHistoryWalletUTXOCreatedMultiInputFee verifies
 // multi-input boarding rounds allocate the aggregate round fee across input
 // deposit rows proportionally for display.

--- a/db/sqlc/fee_accounting.sql.go
+++ b/db/sqlc/fee_accounting.sql.go
@@ -285,7 +285,21 @@ FROM (
            END AS fee_sat,
            le.created_at,
            CASE
-               WHEN le.event_type = 'wallet_utxo_created' THEN 'confirmed'
+               WHEN le.event_type = 'wallet_utxo_created'
+                    AND boarding_round.confirmed
+               THEN 'confirmed'
+               WHEN le.event_type = 'wallet_utxo_created'
+                    AND (le.chain_txid IS NULL OR le.chain_vout IS NULL)
+               THEN 'confirmed'
+               WHEN le.event_type = 'wallet_utxo_created'
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM boarding_intents AS status_bi
+                        WHERE status_bi.outpoint_hash = le.chain_txid
+                          AND status_bi.outpoint_index = le.chain_vout
+                    )
+               THEN 'confirmed'
+               WHEN le.event_type = 'wallet_utxo_created' THEN 'boarding'
                ELSE 'recorded'
            END AS status,
            le.description,
@@ -304,6 +318,7 @@ FROM (
     LEFT JOIN (
         SELECT allocated.outpoint_hash,
                allocated.outpoint_index,
+               allocated.confirmed,
                allocated.base_fee_sat +
                    CASE
                        WHEN allocated.remainder_rank <=
@@ -314,6 +329,7 @@ FROM (
         FROM (
             SELECT proportional.outpoint_hash,
                    proportional.outpoint_index,
+                   proportional.confirmed,
                    proportional.base_fee_sat,
                    proportional.round_fee_sat -
                        SUM(proportional.base_fee_sat) OVER (
@@ -329,6 +345,7 @@ FROM (
                 SELECT rbi.round_id,
                        rbi.outpoint_hash,
                        rbi.outpoint_index,
+                       r.status = 'confirmed' AS confirmed,
                        CASE
                            WHEN stats.round_fee_sat > 0
                                 AND stats.input_amount_sat > 0
@@ -347,6 +364,8 @@ FROM (
                 FROM round_boarding_intents AS rbi
                 JOIN boarding_intents AS bi
                     USING (outpoint_hash, outpoint_index)
+                JOIN rounds AS r
+                    ON r.round_id = rbi.round_id
                 JOIN (
                     SELECT intent_sums.round_id,
                            CAST(CASE

--- a/db/sqlc/queries/fee_accounting.sql
+++ b/db/sqlc/queries/fee_accounting.sql
@@ -83,7 +83,21 @@ FROM (
            END AS fee_sat,
            le.created_at,
            CASE
-               WHEN le.event_type = 'wallet_utxo_created' THEN 'confirmed'
+               WHEN le.event_type = 'wallet_utxo_created'
+                    AND boarding_round.confirmed
+               THEN 'confirmed'
+               WHEN le.event_type = 'wallet_utxo_created'
+                    AND (le.chain_txid IS NULL OR le.chain_vout IS NULL)
+               THEN 'confirmed'
+               WHEN le.event_type = 'wallet_utxo_created'
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM boarding_intents AS status_bi
+                        WHERE status_bi.outpoint_hash = le.chain_txid
+                          AND status_bi.outpoint_index = le.chain_vout
+                    )
+               THEN 'confirmed'
+               WHEN le.event_type = 'wallet_utxo_created' THEN 'boarding'
                ELSE 'recorded'
            END AS status,
            le.description,
@@ -102,6 +116,7 @@ FROM (
     LEFT JOIN (
         SELECT allocated.outpoint_hash,
                allocated.outpoint_index,
+               allocated.confirmed,
                allocated.base_fee_sat +
                    CASE
                        WHEN allocated.remainder_rank <=
@@ -112,6 +127,7 @@ FROM (
         FROM (
             SELECT proportional.outpoint_hash,
                    proportional.outpoint_index,
+                   proportional.confirmed,
                    proportional.base_fee_sat,
                    proportional.round_fee_sat -
                        SUM(proportional.base_fee_sat) OVER (
@@ -127,6 +143,7 @@ FROM (
                 SELECT rbi.round_id,
                        rbi.outpoint_hash,
                        rbi.outpoint_index,
+                       r.status = 'confirmed' AS confirmed,
                        CASE
                            WHEN stats.round_fee_sat > 0
                                 AND stats.input_amount_sat > 0
@@ -145,6 +162,8 @@ FROM (
                 FROM round_boarding_intents AS rbi
                 JOIN boarding_intents AS bi
                     USING (outpoint_hash, outpoint_index)
+                JOIN rounds AS r
+                    ON r.round_id = rbi.round_id
                 JOIN (
                     SELECT intent_sums.round_id,
                            CAST(CASE

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -869,8 +869,8 @@ func ledgerActivityID(t *daemonrpc.TransactionHistoryEntry,
 
 // statusForLedgerRow folds the ledger row's confirmation_status into the
 // flat EntryStatus the API surfaces. Detailed lifecycle context stays in
-// WalletEntry.progress and InspectActivity; the activity table should not
-// reinterpret confirmed ledger rows as pending.
+// WalletEntry.progress and InspectActivity; confirmed on-chain deposits stay
+// pending while they are still waiting to board into a confirmed round.
 func statusForLedgerRow(
 	t *daemonrpc.TransactionHistoryEntry) walletdkrpc.EntryStatus {
 
@@ -965,6 +965,10 @@ func phaseFromLedgerConfirmation(s string) (walletdkrpc.WalletEntryPhase,
 	string) {
 
 	switch s {
+	case "boarding":
+		return walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_SETTLING,
+			"boarding"
+
 	case "confirmed", "swept":
 		return walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_CONFIRMED,
 			"confirmed"

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -1412,11 +1412,47 @@ func TestHistoryPaginationOffsetPlumbedToLedger(t *testing.T) {
 	)
 }
 
-// TestHistoryDepositCompletesOnChainConfirmation confirms that a DEPOSIT row
-// mirrors the ledger confirmation status. More detailed boarding lifecycle
-// information belongs in progress/inspection rather than an activity-table
-// status override.
-func TestHistoryDepositCompletesOnChainConfirmation(t *testing.T) {
+// TestHistoryDepositBoardsBeforeCompletion confirms that a chain-confirmed
+// DEPOSIT row stays pending while the ledger reports the intermediate boarding
+// state. The user has seen the on-chain deposit, but it is not spendable until
+// the boarding round confirms and creates a live VTXO.
+func TestHistoryDepositBoardsBeforeCompletion(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:               "boarding",
+				Subtype:            ledger.EventWalletUTXOCreated,
+				ConfirmationStatus: "boarding",
+				AmountSat:          100_000,
+				Txid:               "boarding-txid",
+				CreatedAtUnixS:     100,
+			},
+		},
+	}
+
+	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.GetActivity().GetEntries(), 1)
+
+	entry := resp.GetActivity().GetEntries()[0]
+	require.Equal(
+		t, walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT, entry.GetKind(),
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		entry.GetStatus(),
+	)
+	require.Equal(t, "boarding", entry.GetProgress().GetPhaseLabel())
+}
+
+// TestHistoryDepositCompletesAfterBoarding confirms that a DEPOSIT row only
+// appears complete once the ledger reports that the boarding flow reached the
+// confirmed round state.
+func TestHistoryDepositCompletesAfterBoarding(t *testing.T) {
 	t.Parallel()
 
 	h, swap, rpc := newHistoryFixture(t)


### PR DESCRIPTION
## Summary

- report chain-confirmed wallet UTXO deposits as `boarding` until the matching boarding input is part of a confirmed round
- map that intermediate ledger status to a pending wallet activity entry with `phase_label="boarding"`
- keep legacy wallet UTXO rows without full outpoint metadata on the old confirmed path
- keep full-metadata `wallet_utxo_created` rows without a matching boarding intent confirmed, so sweep returns and future non-deposit wallet UTXOs do not remain pending forever

Fixes #629.

## Testing

- `go test ./db -run 'TestLedgerStoreTransactionHistoryWalletUTXOCreated'`
- `go test -tags="walletdkrpc swapruntime nolog" ./swapwallet -run 'TestHistoryDeposit|TestHistoryPendingFilterIncludesPendingBoarding|TestHistorySurfacesPendingBoardingBalance'`
- `go test ./db`
- `go test -tags="walletdkrpc swapruntime nolog" ./swapwallet`
- `make lint-changed-local`
- `make fmt-changed-check`
- `make commitmsg-lint range="origin/main..HEAD"`
