### PR TITLE
swaps: adopt in-swap funding outpoint locally

### DIFF
--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -3116,9 +3116,13 @@ type SendOORResponse struct {
 	// dry_run.
 	Status string `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
 	// session_id is the OOR session identifier. Empty on dry_run.
-	SessionId     string `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	SessionId string `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	// recipient_outpoint is the Ark transaction outpoint created for the
+	// requested recipient. Empty on dry_run or when an older idempotent
+	// session is returned without enough local request context.
+	RecipientOutpoint string `protobuf:"bytes,3,opt,name=recipient_outpoint,json=recipientOutpoint,proto3" json:"recipient_outpoint,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *SendOORResponse) Reset() {
@@ -3161,6 +3165,13 @@ func (x *SendOORResponse) GetStatus() string {
 func (x *SendOORResponse) GetSessionId() string {
 	if x != nil {
 		return x.SessionId
+	}
+	return ""
+}
+
+func (x *SendOORResponse) GetRecipientOutpoint() string {
+	if x != nil {
+		return x.RecipientOutpoint
 	}
 	return ""
 }
@@ -7771,11 +7782,12 @@ const file_daemon_proto_rawDesc = "" +
 	"\x06pubkey\x18\x01 \x01(\fR\x06pubkey\x12%\n" +
 	"\x0ewitness_script\x18\x02 \x01(\fR\rwitnessScript\x12\x1c\n" +
 	"\tsignature\x18\x03 \x01(\fR\tsignature\x12\x18\n" +
-	"\asighash\x18\x04 \x01(\rR\asighash\"H\n" +
+	"\asighash\x18\x04 \x01(\rR\asighash\"w\n" +
 	"\x0fSendOORResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x02 \x01(\tR\tsessionId\"\x84\x01\n" +
+	"session_id\x18\x02 \x01(\tR\tsessionId\x12-\n" +
+	"\x12recipient_outpoint\x18\x03 \x01(\tR\x11recipientOutpoint\"\x84\x01\n" +
 	"\x11PrepareOORRequest\x12/\n" +
 	"\trecipient\x18\x01 \x01(\v2\x11.daemonrpc.OutputR\trecipient\x12>\n" +
 	"\rcustom_inputs\x18\x02 \x03(\v2\x19.daemonrpc.CustomOORInputR\fcustomInputs\"\xad\x01\n" +

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -810,6 +810,11 @@ message SendOORResponse {
 
     // session_id is the OOR session identifier. Empty on dry_run.
     string session_id = 2;
+
+    // recipient_outpoint is the Ark transaction outpoint created for the
+    // requested recipient. Empty on dry_run or when an older idempotent
+    // session is returned without enough local request context.
+    string recipient_outpoint = 3;
 }
 
 message PrepareOORRequest {

--- a/darepod/rpc_oor_idempotency_test.go
+++ b/darepod/rpc_oor_idempotency_test.go
@@ -259,6 +259,7 @@ func TestSendOORReturnsExistingIdempotencyKeyBeforeWalletSelection(
 	require.NoError(t, err)
 	require.Equal(t, "submitted", firstResp.Status)
 	require.NotEmpty(t, firstResp.SessionId)
+	require.Equal(t, firstResp.SessionId+":0", firstResp.RecipientOutpoint)
 	require.Empty(t, testWallet.unlockBatches())
 
 	secondResp, err := rpcServer.SendOOR(ctx, &daemonrpc.SendOORRequest{
@@ -267,6 +268,7 @@ func TestSendOORReturnsExistingIdempotencyKeyBeforeWalletSelection(
 	})
 	require.NoError(t, err)
 	require.Equal(t, firstResp.SessionId, secondResp.SessionId)
+	require.Empty(t, secondResp.RecipientOutpoint)
 	require.Equal(t, 1, testWallet.selectCount())
 	require.Empty(t, testWallet.unlockBatches())
 }
@@ -372,6 +374,7 @@ func TestSendOORUnlocksSelectedInputsForExistingSession(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "submitted", firstResp.Status)
 	require.NotEmpty(t, firstResp.SessionId)
+	require.Equal(t, firstResp.SessionId+":0", firstResp.RecipientOutpoint)
 	require.Empty(t, testWallet.unlockBatches())
 
 	secondResp, err := rpcServer.SendOOR(ctx, &daemonrpc.SendOORRequest{
@@ -379,6 +382,9 @@ func TestSendOORUnlocksSelectedInputsForExistingSession(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, firstResp.SessionId, secondResp.SessionId)
+	require.Equal(
+		t, firstResp.RecipientOutpoint, secondResp.RecipientOutpoint,
+	)
 	require.Equal(t, 2, testWallet.selectCount())
 
 	require.Eventually(t, func() bool {

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -1773,6 +1773,9 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 				slog.String("idempotency_key", key),
 			)
 
+			// This fast path returns before resolving the current
+			// request, so the recipient outpoint is intentionally
+			// omitted. Full request replay below can recompute it.
 			return &daemonrpc.SendOORResponse{
 				Status:    "submitted",
 				SessionId: sessionID.String(),
@@ -1952,11 +1955,12 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	targetAmt := btcutil.Amount(req.Recipient.AmountSat)
 
 	// Build the recipient output for the OOR transfer.
-	recipients := []oortx.RecipientOutput{{
+	recipient := oortx.RecipientOutput{
 		PkScript:           pkScript,
 		Value:              targetAmt,
 		VTXOPolicyTemplate: recipientPolicyTemplate,
-	}}
+	}
+	recipients := []oortx.RecipientOutput{recipient}
 
 	phaseStart = time.Now()
 	inputTotal, err := sumOORInputAmounts(selectedInputs)
@@ -2041,9 +2045,23 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		r.unlockSelectedVTXOsBestEffort(ctx, locked)
 	}
 
+	sessionHash := chainhash.Hash(resp.SessionID)
+	recipientOutpoint, err := oortx.RecipientOutPoint(
+		sessionHash, recipients, recipient,
+	)
+	recipientOutpointString := ""
+	if err != nil {
+		r.server.log.WarnS(ctx, "Unable to resolve OOR recipient "+
+			"outpoint", err,
+			slog.String("session_id", resp.SessionID.String()))
+	} else {
+		recipientOutpointString = recipientOutpoint.String()
+	}
+
 	r.server.log.InfoS(ctx, "OOR transfer submitted",
 		slog.String("session_id", resp.SessionID.String()),
 		slog.Bool("existing_session", resp.Existing),
+		slog.String("recipient_outpoint", recipientOutpointString),
 		slog.Int64("amount_sat", req.Recipient.AmountSat),
 		slog.Int64("input_total_sat", int64(inputTotal)),
 		slog.Int64("change_sat", int64(changeAmt)),
@@ -2065,8 +2083,9 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		slog.Duration("oor_actor_duration", oorActorDuration))
 
 	return &daemonrpc.SendOORResponse{
-		Status:    "submitted",
-		SessionId: resp.SessionID.String(),
+		Status:            "submitted",
+		SessionId:         resp.SessionID.String(),
+		RecipientOutpoint: recipientOutpointString,
 	}, nil
 }
 

--- a/lib/tx/oor/build.go
+++ b/lib/tx/oor/build.go
@@ -101,6 +101,54 @@ func CanonicalRecipientOutputs(recipients []RecipientOutput) []RecipientOutput {
 	return out
 }
 
+// RecipientOutputIndex returns the tx output index for target after applying
+// the same canonical recipient ordering used by BuildArkPSBT.
+func RecipientOutputIndex(recipients []RecipientOutput,
+	target RecipientOutput) (uint32, error) {
+
+	var (
+		found bool
+		index uint32
+	)
+
+	for i, recipient := range CanonicalRecipientOutputs(recipients) {
+		if recipient.Value != target.Value ||
+			!bytes.Equal(recipient.PkScript, target.PkScript) {
+
+			continue
+		}
+
+		if found {
+			return 0, fmt.Errorf("recipient output is ambiguous")
+		}
+
+		found = true
+		index = uint32(i)
+	}
+
+	if !found {
+		return 0, fmt.Errorf("recipient output not found")
+	}
+
+	return index, nil
+}
+
+// RecipientOutPoint returns the resolved Ark tx outpoint for target after
+// applying BuildArkPSBT recipient ordering.
+func RecipientOutPoint(txid chainhash.Hash, recipients []RecipientOutput,
+	target RecipientOutput) (wire.OutPoint, error) {
+
+	index, err := RecipientOutputIndex(recipients, target)
+	if err != nil {
+		return wire.OutPoint{}, err
+	}
+
+	return wire.OutPoint{
+		Hash:  txid,
+		Index: index,
+	}, nil
+}
+
 // BuildCheckpointPSBT constructs an unsigned checkpoint PSBT that spends a
 // VTXO input, pays the entire input value to a checkpoint P2TR output, and
 // appends a zero-value anchor output.

--- a/lib/tx/oor/build_test.go
+++ b/lib/tx/oor/build_test.go
@@ -2,9 +2,11 @@ package oor
 
 import (
 	"crypto/rand"
+	"encoding/hex"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
@@ -145,4 +147,53 @@ func TestBuildCheckpointPSBTPreservesOwnerLeafPolicy(t *testing.T) {
 		t, cpResult.TapTreeEncoded,
 		cpResult.PSBT.Outputs[0].TaprootTapTree,
 	)
+}
+
+func TestRecipientOutPointUsesCanonicalRecipientOrder(t *testing.T) {
+	t.Parallel()
+
+	txid := chainhash.Hash{1, 2, 3}
+	target := RecipientOutput{
+		PkScript: hexBytes(t, "5120bbbb"),
+		Value:    btcutil.Amount(500),
+	}
+	recipients := []RecipientOutput{
+		{
+			PkScript: hexBytes(t, "5120aaaa"),
+			Value:    btcutil.Amount(2_000),
+		},
+		target,
+		{
+			PkScript: hexBytes(t, "5120cccc"),
+			Value:    btcutil.Amount(1_000),
+		},
+	}
+
+	outpoint, err := RecipientOutPoint(txid, recipients, target)
+	require.NoError(t, err)
+	require.Equal(t, txid, outpoint.Hash)
+	require.EqualValues(t, 0, outpoint.Index)
+}
+
+func TestRecipientOutputIndexRejectsAmbiguousTarget(t *testing.T) {
+	t.Parallel()
+
+	target := RecipientOutput{
+		PkScript: hexBytes(t, "5120bbbb"),
+		Value:    btcutil.Amount(500),
+	}
+
+	_, err := RecipientOutputIndex(
+		[]RecipientOutput{target, target}, target,
+	)
+	require.ErrorContains(t, err, "ambiguous")
+}
+
+func hexBytes(t *testing.T, value string) []byte {
+	t.Helper()
+
+	decoded, err := hex.DecodeString(value)
+	require.NoError(t, err)
+
+	return decoded
 }

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -842,14 +842,29 @@ func (c *Client) SendOOR(ctx context.Context, req *daemonrpc.SendOORRequest) (
 	return resp, nil
 }
 
+// OORSendResult contains daemon metadata for an accepted OOR transfer.
+type OORSendResult struct {
+	// SessionID is the OOR session identifier.
+	SessionID string
+
+	// RecipientOutpoint is the Ark tx outpoint created for the requested
+	// recipient when the daemon can resolve it locally.
+	RecipientOutpoint string
+}
+
 // SendOORWithPolicy sends one OOR transfer to a semantic policy-backed
 // destination and returns the resulting OOR session id.
 func (c *Client) SendOORWithPolicy(ctx context.Context, amountSat int64,
 	recipientPolicyTemplate []byte) (string, error) {
 
-	return c.SendOORWithPolicyAndKey(
+	result, err := c.SendOORWithPolicyAndKeyDetails(
 		ctx, amountSat, recipientPolicyTemplate, "",
 	)
+	if err != nil {
+		return "", err
+	}
+
+	return result.SessionID, nil
 }
 
 // SendOORWithPolicyAndKey sends one OOR transfer to a semantic policy-backed
@@ -857,6 +872,33 @@ func (c *Client) SendOORWithPolicy(ctx context.Context, amountSat int64,
 // session id.
 func (c *Client) SendOORWithPolicyAndKey(ctx context.Context, amountSat int64,
 	recipientPolicyTemplate []byte, idempotencyKey string) (string, error) {
+
+	result, err := c.SendOORWithPolicyAndKeyDetails(
+		ctx, amountSat, recipientPolicyTemplate, idempotencyKey,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return result.SessionID, nil
+}
+
+// SendOORWithPolicyDetails sends one OOR transfer to a semantic policy-backed
+// destination and returns the accepted OOR metadata.
+func (c *Client) SendOORWithPolicyDetails(ctx context.Context, amountSat int64,
+	recipientPolicyTemplate []byte) (*OORSendResult, error) {
+
+	return c.SendOORWithPolicyAndKeyDetails(
+		ctx, amountSat, recipientPolicyTemplate, "",
+	)
+}
+
+// SendOORWithPolicyAndKeyDetails sends one OOR transfer to a semantic
+// policy-backed destination using the supplied idempotency key and returns the
+// accepted OOR metadata.
+func (c *Client) SendOORWithPolicyAndKeyDetails(ctx context.Context,
+	amountSat int64, recipientPolicyTemplate []byte,
+	idempotencyKey string) (*OORSendResult, error) {
 
 	resp, err := c.SendOOR(ctx, &daemonrpc.SendOORRequest{
 		Recipient: &daemonrpc.Output{
@@ -870,10 +912,13 @@ func (c *Client) SendOORWithPolicyAndKey(ctx context.Context, amountSat int64,
 		IdempotencyKey: idempotencyKey,
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return resp.GetSessionId(), nil
+	return &OORSendResult{
+		SessionID:         resp.GetSessionId(),
+		RecipientOutpoint: resp.GetRecipientOutpoint(),
+	}, nil
 }
 
 // SendOORWithCustomInputs sends one OOR transfer using caller-specified

--- a/sdk/ark/client_test.go
+++ b/sdk/ark/client_test.go
@@ -163,7 +163,8 @@ func newFakeDaemonService() *fakeDaemonService {
 			},
 		},
 		sendOORResp: &daemonrpc.SendOORResponse{
-			SessionId: "session-123",
+			SessionId:         "session-123",
+			RecipientOutpoint: "session-123:0",
 		},
 	}
 }
@@ -643,6 +644,13 @@ func TestDialRemotePolicyHelpers(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "session-123", sessionID)
 
+	oorResult, err := client.SendOORWithPolicyDetails(
+		context.Background(), 42_000, []byte{0xaa, 0xbb},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "session-123", oorResult.SessionID)
+	require.Equal(t, "session-123:0", oorResult.RecipientOutpoint)
+
 	service.mu.Lock()
 	policyReq := service.lastSendOORReq
 	service.mu.Unlock()
@@ -841,6 +849,7 @@ func TestStartEmbeddedUsesBufconnTransport(t *testing.T) {
 	cfg.Wallet.Type = darepod.WalletTypeBtcwallet
 	cfg.Wallet.FeeURL = "http://127.0.0.1:3001"
 	cfg.Wallet.EsploraURL = ""
+	cfg.RPC.Gateway.ListenAddr = "127.0.0.1:0"
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -43,6 +43,9 @@ const (
 	SettlementTypeInArk SettlementType = "in_ark"
 )
 
+// OORSendResult contains daemon metadata for an accepted OOR transfer.
+type OORSendResult = sdkark.OORSendResult
+
 // SwapSummary is the stable list view for one persisted swap session.
 type SwapSummary struct {
 	// Direction identifies whether this is a pay or receive session.
@@ -386,10 +389,10 @@ type DaemonConn interface {
 	// BlockHeight returns the daemon's best known chain height.
 	BlockHeight(ctx context.Context) (uint32, error)
 
-	// SendOORWithPolicy sends an OOR transfer to a semantic policy-backed
-	// destination.
-	SendOORWithPolicy(ctx context.Context, amountSat int64,
-		recipientPolicyTemplate []byte) (string, error)
+	// SendOORWithPolicyDetails sends an OOR transfer to a semantic
+	// policy-backed destination.
+	SendOORWithPolicyDetails(ctx context.Context, amountSat int64,
+		recipientPolicyTemplate []byte) (*OORSendResult, error)
 
 	// SendOORWithCustomInputs sends an OOR with custom inputs into one
 	// standard pubkey-backed Ark receive destination.

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -804,6 +804,10 @@ func (s *paySession) ensureFundingSubmitted(ctx context.Context,
 	allowImmediate bool) error {
 
 	if s.fundingSessionID != "" {
+		if s.vhtlcOutpoint != "" && s.vhtlcAmount > 0 {
+			return s.markVHTLCFundedFromLocalMetadata(ctx)
+		}
+
 		return nil
 	}
 
@@ -816,7 +820,7 @@ func (s *paySession) ensureFundingSubmitted(ctx context.Context,
 		}
 	}
 
-	txid, err := s.client.daemon.SendOORWithPolicy(
+	result, err := s.client.daemon.SendOORWithPolicyDetails(
 		ctx, s.cfg.AmountSat, s.vhtlcPolicyTemplate,
 	)
 	if err != nil {
@@ -844,17 +848,62 @@ func (s *paySession) ensureFundingSubmitted(ctx context.Context,
 
 		return fmt.Errorf("fund vHTLC: %w", err)
 	}
+	if result == nil || result.SessionID == "" {
+		return fmt.Errorf("fund vHTLC: daemon returned empty OOR " +
+			"session id")
+	}
 
 	s.client.log.InfoS(ctx, "In-swap vHTLC funding submitted",
 		btclog.Hex("hash", s.cfg.PaymentHash[:]),
-		slog.String("txid", txid),
+		slog.String("txid", result.SessionID),
+		slog.String("outpoint", result.RecipientOutpoint),
 	)
 
-	if err := s.persistFundingSessionID(ctx, txid); err != nil {
+	if err := s.persistFundingResult(
+		ctx, result.SessionID, result.RecipientOutpoint,
+		s.cfg.AmountSat,
+	); err != nil {
+		return newRetryableActionError(err)
+	}
+	if result.RecipientOutpoint == "" {
+		return nil
+	}
+
+	return s.markVHTLCFundedFromLocalMetadata(ctx)
+}
+
+// markVHTLCFundedFromLocalMetadata records progress from a locally known
+// funding outpoint. This lets retries recover even if the OOR metadata was
+// persisted but the subsequent state transition did not make it to the swap
+// DB.
+func (s *paySession) markVHTLCFundedFromLocalMetadata(
+	ctx context.Context) error {
+
+	s.client.log.InfoS(ctx, "In-swap vHTLC funded from local OOR metadata",
+		btclog.Hex("hash", s.cfg.PaymentHash[:]),
+		slog.String("outpoint", s.vhtlcOutpoint),
+		slog.Int64("amount_sat", s.vhtlcAmount),
+	)
+
+	if err := s.ensurePayRefundRecoveryArmed(ctx); err != nil {
 		return newRetryableActionError(err)
 	}
 
-	return nil
+	return s.mutateAndPersist(ctx, func() error {
+		switch s.state {
+		case PayStateVHTLCFunded, PayStateWaitingForClaim:
+			return nil
+
+		case PayStateSwapCreated, PayStateFundingInitiated:
+			return s.transition(payEventVHTLCFunded)
+
+		default:
+			// The funding paths only call this helper before claim
+			// handling starts. Leave any unexpected later state
+			// alone instead of manufacturing a stale transition.
+			return nil
+		}
+	})
 }
 
 // waitForClaimPreimage waits until the server claim spend is indexed and the

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -1554,6 +1554,91 @@ func TestPaySessionCancelDoesNotPersistFailed(t *testing.T) {
 	require.NotEqual(t, PayStateNeedsIntervention, resumed.State())
 }
 
+// TestPaySessionUsesFundingResponseOutpointWhenIndexerRejectsLiveLookup
+// asserts the pay FSM can adopt its funded vHTLC from local OOR metadata
+// instead of depending on the remote pkScript indexer to reveal the outpoint.
+func TestPaySessionUsesFundingResponseOutpointWhenIndexerRejectsLiveLookup(
+	t *testing.T) {
+
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:  preimage.Hash(),
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
+			ServerPubkey: serverPriv.PubKey(),
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime:                       144,
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			Expiry: time.Now().Add(time.Minute),
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey:   clientPriv.PubKey(),
+		operatorKey:   operatorPriv.PubKey(),
+		blockHeight:   100,
+		sendSessionID: "funding-session",
+		sendOutpoint:  "funding-session:0",
+		liveLookupErr: status.Error(
+			codes.Unauthenticated,
+			"script not registered for principal",
+		),
+	}
+
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	client.waitPollInterval = time.Millisecond
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	err = session.runUntil(t.Context(), PayStateWaitingForClaim)
+	require.NoError(t, err)
+	require.Equal(t, PayStateWaitingForClaim, session.State())
+	require.Equal(t, "funding-session", session.fundingSessionID)
+	require.Equal(t, "funding-session:0", session.vhtlcOutpoint)
+	require.EqualValues(t, testInSwapAmountSat, session.vhtlcAmount)
+	require.Equal(t, 1, daemonConn.sendPolicyCalls)
+	require.Equal(t, 1, daemonConn.liveLookupCalls)
+	require.Equal(t, 1, daemonConn.armRecoveryCalls)
+	require.Equal(
+		t, "funding-session:0",
+		daemonConn.lastArmRecovery.GetVtxoOutpoint(),
+	)
+
+	reloaded, err := client.ResumePayViaLightning(
+		t.Context(), preimage.Hash(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, PayStateWaitingForClaim, reloaded.State())
+	require.Equal(t, "funding-session:0", reloaded.vhtlcOutpoint)
+}
+
 // TestPaySessionResumeFundingGraceSkipsImmediateResend asserts a resumed pay
 // session in the accepted-but-not-yet-persisted funding window does not
 // immediately resend funding while the ambiguity grace period is still active.

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -529,6 +529,7 @@ type testDaemonConn struct {
 	receiveAuthErr    error
 	receiveAllocCalls int
 	sendSessionID     string
+	sendOutpoint      string
 	preparedOOR       *PreparedOOR
 	prepareOOREErr    error
 	sendPolicyErr     error
@@ -568,16 +569,23 @@ func (d *testDaemonConn) BlockHeight(context.Context) (uint32, error) {
 	return d.blockHeight, nil
 }
 
-// SendOORWithPolicy records the requested output policy template.
-func (d *testDaemonConn) SendOORWithPolicy(_ context.Context, _ int64,
-	recipientPolicyTemplate []byte) (string, error) {
+// SendOORWithPolicyDetails records the requested output policy template.
+func (d *testDaemonConn) SendOORWithPolicyDetails(_ context.Context, _ int64,
+	recipientPolicyTemplate []byte) (*OORSendResult, error) {
 
 	d.sendPolicyCalls++
 	d.lastSendPolicy = append(
 		[]byte(nil), recipientPolicyTemplate...,
 	)
 
-	return d.sendSessionID, d.sendPolicyErr
+	if d.sendPolicyErr != nil {
+		return nil, d.sendPolicyErr
+	}
+
+	return &OORSendResult{
+		SessionID:         d.sendSessionID,
+		RecipientOutpoint: d.sendOutpoint,
+	}, nil
 }
 
 // SendOORWithCustomInputs records the claim request.

--- a/sdk/swaps/store_sessions.go
+++ b/sdk/swaps/store_sessions.go
@@ -542,14 +542,21 @@ func (s *paySession) mutateAndPersist(ctx context.Context,
 	return nil
 }
 
-// persistFundingSessionID stores the accepted funding session id without
-// rolling back the in-memory id on persistence failure.
-func (s *paySession) persistFundingSessionID(ctx context.Context,
-	fundingSessionID string) error {
+// persistFundingResult stores the accepted funding session metadata without
+// rolling back in-memory fields on persistence failure. The funding OOR is a
+// daemon-side side effect, so retries must remember the accepted session and
+// resolved vHTLC outpoint when they are known.
+func (s *paySession) persistFundingResult(ctx context.Context, fundingSessionID,
+	vhtlcOutpoint string, vhtlcAmount int64) error {
 
 	s.fundingSessionID = fundingSessionID
+	if vhtlcOutpoint != "" {
+		s.vhtlcOutpoint = vhtlcOutpoint
+		s.vhtlcAmount = vhtlcAmount
+	}
+
 	if err := s.persist(ctx); err != nil {
-		return fmt.Errorf("persist pay funding session id: %w", err)
+		return fmt.Errorf("persist pay funding result: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Closes #621.

This makes the pay-swap funding step use the local OOR submit result as the authoritative source for the funded vHTLC outpoint.

The daemon already knows the final recipient outpoint after canonical OOR output ordering. This PR returns that outpoint in `SendOORResponse`, exposes it through a detailed SDK helper, and has the pay swap FSM persist it together with the funding session id. Once that metadata is durable, the client can advance past `FundingInitiated` without depending on a remote `FindLiveVTXOByPkScript` lookup to discover its own vHTLC vout.

## Details

- Add `recipient_outpoint` to `SendOORResponse`.
- Derive the recipient outpoint from the same canonical recipient ordering used by `BuildArkPSBT` instead of assuming a fixed vout.
- Keep the old SDK `SendOORWithPolicy` / `SendOORWithPolicyAndKey` helpers returning only the session id, and add detailed variants for callers that need the outpoint.
- Update the pay swap daemon boundary to use the detailed helper.
- Persist `fundingSessionID`, `vhtlcOutpoint`, and `vhtlcAmount` together when the daemon accepts the funding OOR.
- Allow retries/resumes to drive `VHTLCFunded` from already-persisted local OOR metadata.
- Keep the existing indexer-based claim/preimage observation path unchanged.
- Make the embedded SDK test bind its HTTP gateway to an ephemeral port so a local daemon on the default gateway port does not make the suite fail spuriously.

## Tests

- `make rpc`
- `make fmt-changed`
- `go test ./lib/tx/oor -run 'TestBuildCheckpoint|TestRecipient|TestSubmitPackageValidateHappyPath' -count=1`
- `go test ./darepod -run 'TestSendOORReturnsExistingIdempotencyKeyBeforeWalletSelection|TestSendOORUnlocksSelectedInputsForExistingSession' -count=1`
- `go test ./sdk/ark -run 'TestClient' -count=1`
- `go test ./sdk/swaps -run 'TestPaySessionUsesFundingResponseOutpointWhenIndexerRejectsLiveLookup|TestPaySessionResumeFundingGrace|TestPayViaLightningRequiresClaimPreimage' -count=1`
- `go test ./lib/tx/oor ./darepod ./sdk/swaps -count=1`
- `go test ./sdk/ark/... -count=1`
- `make lint-changed-local`
- `make commitmsg-lint range=origin/main..HEAD`
