### PR TITLE
darepod: add opt-in pprof debug HTTP server

### DIFF
--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -194,6 +194,8 @@ func newRootCmd() *cobra.Command {
 
 	registerSwapRuntimeFlags(f, cfg)
 
+	registerPprofFlags(f, cfg)
+
 	// Safety flag for mainnet operation.
 	f.Bool(
 		"allow-mainnet", cfg.AllowMainnet, "allow the daemon to "+
@@ -332,6 +334,32 @@ func registerSwapRuntimeFlags(f *pflag.FlagSet, cfg *darepod.Config) {
 		cfg.Swap.VHTLCRecovery.MaxFeeRateSatPerKW, "maximum fee "+
 			"rate in sat/kw for swapruntime vHTLC recovery "+
 			"exit spends",
+	)
+}
+
+// registerPprofFlags registers the optional pprof debug-server flags. pprof is
+// disabled by default and only starts when pprof.listen is set to a non-empty
+// address. The flag names match the mapstructure config keys, so viper binds
+// them without explicit aliases.
+func registerPprofFlags(f *pflag.FlagSet, cfg *darepod.Config) {
+	f.String(
+		"pprof.listen", cfg.Pprof.ListenAddr, "address for the "+
+			"pprof debug HTTP server (e.g. 127.0.0.1:6060); "+
+			"empty disables pprof. Exposes sensitive runtime "+
+			"data, so bind to a loopback or firewalled address "+
+			"only",
+	)
+	f.Int(
+		"pprof.blockprofilerate", cfg.Pprof.BlockProfileRate, "value"+
+			" passed to runtime.SetBlockProfileRate at startup "+
+			"when greater than zero; zero leaves block "+
+			"profiling off",
+	)
+	f.Int(
+		"pprof.mutexprofilefraction", cfg.Pprof.MutexProfileFraction,
+		"value passed to runtime.SetMutexProfileFraction at "+
+			"startup when greater than zero; zero leaves mutex "+
+			"profiling off",
 	)
 }
 

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -258,6 +258,12 @@ type Config struct {
 	// build tag (both the standalone cmd/darepod binary and the
 	// sdk/walletdk embedded path).
 	EagerRoundJoin bool `mapstructure:"eagerroundjoin"`
+
+	// Pprof configures the optional net/http/pprof debug server. It is
+	// disabled by default and must be explicitly opted into via a
+	// non-empty listen address. A value type so a zero-value Config can
+	// never carry a nil pprof config into the start path.
+	Pprof PprofConfig `mapstructure:"pprof"`
 }
 
 // RPCServiceRegistrar registers one optional daemon gRPC subserver on the
@@ -602,6 +608,33 @@ func DefaultGatewayConfig() *GatewayConfig {
 		Enabled:    true,
 		ListenAddr: DefaultRPCGatewayHost,
 	}
+}
+
+// PprofConfig configures the optional net/http/pprof debug server.
+//
+// SECURITY: pprof exposes sensitive runtime and debug data — goroutine
+// stacks, heap and CPU profiles, the command line, and the symbol table —
+// any of which can leak internal state or enable denial-of-service. It is
+// opt-in (disabled by default) and is served on its own private HTTP mux
+// that is never attached to the daemon's gRPC/gateway listeners. Operators
+// who enable it should bind ListenAddr to a loopback or firewalled address
+// (e.g. "127.0.0.1:6060") and never expose it to untrusted networks.
+type PprofConfig struct {
+	// ListenAddr is the network address the pprof HTTP server binds to.
+	// An empty value (the default) disables pprof entirely. A non-empty
+	// value such as "127.0.0.1:6060" starts a dedicated HTTP server
+	// exposing the standard net/http/pprof endpoints.
+	ListenAddr string `mapstructure:"listen"`
+
+	// BlockProfileRate, when greater than zero, is passed to
+	// runtime.SetBlockProfileRate at startup to enable blocking-profile
+	// collection. Zero (the default) leaves block profiling disabled.
+	BlockProfileRate int `mapstructure:"blockprofilerate"`
+
+	// MutexProfileFraction, when greater than zero, is passed to
+	// runtime.SetMutexProfileFraction at startup to enable mutex-contention
+	// profiling. Zero (the default) leaves mutex profiling disabled.
+	MutexProfileFraction int `mapstructure:"mutexprofilefraction"`
 }
 
 // WalletConfig selects and configures the wallet backend.

--- a/darepod/logging.go
+++ b/darepod/logging.go
@@ -39,6 +39,7 @@ var allSubsystems = []string{
 	db.Subsystem,
 	SwapSubsystem,
 	WalletRPCSubsystem,
+	PprofSubsystem,
 	"TXCF",
 	"UNRL",
 	VHTLCRecoverySubsystem,
@@ -59,6 +60,11 @@ const (
 	// VHTLCRecoverySubsystem is the subsystem tag used for vHTLC
 	// on-chain recovery coordination logs.
 	VHTLCRecoverySubsystem = "VREC"
+
+	// PprofSubsystem is the subsystem tag used for the optional pprof
+	// debug server so its logs can be level-tuned independently of the
+	// main daemon logs.
+	PprofSubsystem = "PPRF"
 )
 
 // SetupLoggersWithShutdownFn registers all subsystem loggers using a plain

--- a/darepod/pprof.go
+++ b/darepod/pprof.go
@@ -1,0 +1,184 @@
+package darepod
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+)
+
+const (
+	// defaultPprofReadHeaderTimeout bounds request-line/header reads so a
+	// slow client cannot hold the local debug listener open indefinitely.
+	defaultPprofReadHeaderTimeout = 5 * time.Second
+
+	// defaultPprofReadTimeout bounds the full request read. It is larger
+	// than the header timeout because /debug/pprof/symbol accepts a POST
+	// body (a list of program counters) that must be read fully.
+	defaultPprofReadTimeout = 30 * time.Second
+
+	// CPU and trace profiles intentionally hold the response open for the
+	// caller-requested sampling window, so no fixed write deadline applies.
+	defaultPprofWriteTimeout = 0
+
+	// defaultPprofIdleTimeout bounds how long an idle keep-alive connection
+	// can sit around between debug requests.
+	defaultPprofIdleTimeout = 60 * time.Second
+)
+
+// newPprofMux builds a private HTTP mux exposing the standard
+// net/http/pprof endpoints. The mux is deliberately constructed here rather
+// than reusing http.DefaultServeMux: importing net/http/pprof registers its
+// handlers on the default mux as a side effect, and serving that mux would
+// leak the sensitive debug surface onto any other server that happens to use
+// the default mux. Routing through a private mux keeps pprof confined to its
+// own opt-in listener.
+func newPprofMux() *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// The Index handler also dispatches the named profile sub-paths
+	// (/debug/pprof/goroutine, /heap, /block, /mutex, /allocs,
+	// /threadcreate), so a single "/debug/pprof/" registration covers
+	// them along with the index page itself.
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	return mux
+}
+
+// pprofServer serves the standard net/http/pprof endpoints on a dedicated,
+// opt-in HTTP listener.
+//
+// SECURITY: this server exposes sensitive runtime and debug data and is only
+// started when PprofConfig.ListenAddr is non-empty. Operators are responsible
+// for binding it to a loopback or firewalled address.
+//
+// The daemon owns this server's lifecycle; Start and Stop are called
+// sequentially from the daemon run loop.
+type pprofServer struct {
+	cfg *PprofConfig
+	log btclog.Logger
+
+	listener net.Listener
+	httpSrv  *http.Server
+	wg       sync.WaitGroup
+}
+
+// newPprofServer constructs the daemon pprof debug server.
+func newPprofServer(cfg *PprofConfig, log btclog.Logger) *pprofServer {
+	return &pprofServer{
+		cfg: cfg,
+		log: log,
+	}
+}
+
+// Start starts the pprof debug server when a listen address is configured. An
+// empty listen address disables pprof entirely and Start is a no-op. When
+// enabled, it also applies the configured block and mutex profiling rates.
+func (p *pprofServer) Start(ctx context.Context) error {
+	if p.cfg.ListenAddr == "" {
+		p.log.DebugS(ctx, "pprof server disabled")
+
+		return nil
+	}
+
+	listener, err := net.Listen("tcp", p.cfg.ListenAddr)
+	if err != nil {
+		return fmt.Errorf("pprof listen: %w", err)
+	}
+
+	// Enable the optional sampling profilers after the listener is bound so
+	// a startup failure cannot leave process-global profiling turned on.
+	if p.cfg.BlockProfileRate > 0 {
+		runtime.SetBlockProfileRate(p.cfg.BlockProfileRate)
+	}
+	if p.cfg.MutexProfileFraction > 0 {
+		runtime.SetMutexProfileFraction(p.cfg.MutexProfileFraction)
+	}
+
+	p.listener = listener
+	p.httpSrv = &http.Server{
+		Handler:           newPprofMux(),
+		ReadTimeout:       defaultPprofReadTimeout,
+		ReadHeaderTimeout: defaultPprofReadHeaderTimeout,
+		// 0 means no deadline, keeping streaming CPU/trace profiles
+		// alive for their requested sampling window.
+		WriteTimeout: defaultPprofWriteTimeout,
+		IdleTimeout:  defaultPprofIdleTimeout,
+	}
+
+	srvCtx := context.WithoutCancel(ctx)
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+
+		p.log.InfoS(srvCtx, "pprof server listening",
+			slog.String("addr", listener.Addr().String()),
+		)
+
+		// http.ErrServerClosed is the expected signal from a graceful
+		// Shutdown, so it is not logged as an error. A mid-run listener
+		// failure is an external trigger, so it warrants WarnS, not the
+		// error level reserved for internal bugs.
+		err := p.httpSrv.Serve(listener)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			p.log.WarnS(srvCtx, "pprof server error", err)
+		}
+	}()
+
+	return nil
+}
+
+// Stop gracefully shuts down the pprof debug server using the caller-provided
+// (bounded) context, mirroring the daemon's other listener shutdowns. It is a
+// no-op when the server was never started.
+func (p *pprofServer) Stop(ctx context.Context) error {
+	if p.httpSrv == nil {
+		return nil
+	}
+
+	// Mirror the single-lifecycle Start conditions: only reset the
+	// process-global profiling rates this server enabled.
+	if p.cfg.BlockProfileRate > 0 {
+		runtime.SetBlockProfileRate(0)
+	}
+	if p.cfg.MutexProfileFraction > 0 {
+		runtime.SetMutexProfileFraction(0)
+	}
+
+	err := p.httpSrv.Shutdown(ctx)
+
+	// Shutdown closes the listener before draining connections, so Serve
+	// has already returned ErrServerClosed by now; wg.Wait only joins the
+	// serve goroutine and cannot block beyond the shutdown deadline.
+	p.wg.Wait()
+
+	// Clear the listener so Addr reports the server as no longer active
+	// once it has been stopped. Clear the HTTP server as well so Stop is
+	// idempotent.
+	p.listener = nil
+	p.httpSrv = nil
+
+	return err
+}
+
+// Addr returns the address the pprof server is listening on, or nil when the
+// server is disabled, not yet started, or already stopped.
+func (p *pprofServer) Addr() net.Addr {
+	if p.listener == nil {
+		return nil
+	}
+
+	return p.listener.Addr()
+}

--- a/darepod/pprof_test.go
+++ b/darepod/pprof_test.go
@@ -1,0 +1,178 @@
+package darepod
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewPprofMuxServesStandardEndpoints verifies the private pprof mux serves
+// the standard net/http/pprof endpoints, including the named profiles the
+// Index handler dispatches, without registering them on the default mux.
+func TestNewPprofMuxServesStandardEndpoints(t *testing.T) {
+	t.Parallel()
+
+	mux := newPprofMux()
+
+	// Each path should resolve to a pprof handler rather than the
+	// net/http 404 handler. The named profiles (goroutine, heap, ...) are
+	// dispatched by the Index handler under the "/debug/pprof/" prefix.
+	// The streaming profile/trace endpoints are covered by pattern lookup
+	// below so this test does not trigger a live capture.
+	paths := []string{
+		"/debug/pprof/",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/symbol",
+		"/debug/pprof/goroutine",
+		"/debug/pprof/heap",
+		"/debug/pprof/block",
+		"/debug/pprof/mutex",
+		"/debug/pprof/allocs",
+		"/debug/pprof/threadcreate",
+	}
+
+	for _, path := range paths {
+		// Slashes delimit subtest hierarchy in `go test -run`, so the
+		// raw path can't be the subtest name; use a sanitized key.
+		name := strings.ReplaceAll(
+			strings.TrimPrefix(path, "/"),
+			"/", "_",
+		)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			require.NotEqual(
+				t, http.StatusNotFound, rec.Code, "pprof "+
+					"endpoint %q should be registered",
+				path,
+			)
+		})
+	}
+}
+
+// TestNewPprofMuxRejectsUnknownPaths verifies the private pprof mux does not
+// serve paths outside the pprof surface, confirming it is a confined mux and
+// not the catch-all default mux.
+func TestNewPprofMuxRejectsUnknownPaths(t *testing.T) {
+	t.Parallel()
+
+	mux := newPprofMux()
+
+	req := httptest.NewRequest(http.MethodGet, "/not-pprof", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestNewPprofMuxRegistersProfileAndTrace asserts the streaming profile and
+// trace endpoints have their own explicit routes on the private mux. They are
+// checked via the mux's pattern lookup rather than served, so the test does
+// not trigger an actual (slow) CPU/trace capture. The assertion requires the
+// matched pattern to equal the exact path: a prefix-only match against
+// "/debug/pprof/" (i.e. the explicit registration removed) would fail.
+func TestNewPprofMuxRegistersProfileAndTrace(t *testing.T) {
+	t.Parallel()
+
+	mux := newPprofMux()
+
+	for _, path := range []string{
+		"/debug/pprof/profile",
+		"/debug/pprof/trace",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		_, pattern := mux.Handler(req)
+		require.Equalf(
+			t, path, pattern, "endpoint %q must have its own "+
+				"explicit route", path,
+		)
+	}
+}
+
+// TestPprofServerStartStop exercises the server lifecycle: Start binds an
+// OS-assigned loopback port and serves a pprof endpoint, and Stop releases
+// the listener and lets the serving goroutine exit.
+func TestPprofServerStartStop(t *testing.T) {
+	t.Parallel()
+
+	srv := newPprofServer(
+		&PprofConfig{
+			ListenAddr: "127.0.0.1:0",
+		},
+		btclog.Disabled,
+	)
+
+	require.NoError(t, srv.Start(context.Background()))
+
+	addr := srv.Addr()
+	require.NotNil(t, addr, "server must be listening after Start")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get("http://" + addr.String() + "/debug/pprof/")
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.NoError(t, srv.Stop(context.Background()))
+	require.NoError(t, srv.Stop(context.Background()))
+
+	// After Stop the listener is released, so a fresh request fails.
+	resp, err = client.Get("http://" + addr.String() + "/debug/pprof/")
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err, "request after Stop should fail")
+}
+
+// TestPprofServerStartDisabledIsNoOp asserts Start is a no-op when the
+// listen address is empty (pprof disabled).
+func TestPprofServerStartDisabledIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	srv := newPprofServer(&PprofConfig{}, btclog.Disabled)
+
+	require.NoError(t, srv.Start(context.Background()))
+	require.Nil(t, srv.Addr(), "disabled server must not listen")
+	require.NoError(t, srv.Stop(context.Background()))
+}
+
+// TestPprofServerAppliesProfilingRates exercises the block/mutex profiling
+// rate paths in Start and the reset in Stop. The rates are process-global
+// with no public getter, so this guards the wiring rather than the runtime
+// values. Not parallel: it mutates process-global runtime state.
+func TestPprofServerAppliesProfilingRates(t *testing.T) {
+	// Reset the process-global rates even if the test fails before Stop
+	// resets them, so other tests are not affected.
+	t.Cleanup(func() {
+		runtime.SetBlockProfileRate(0)
+		runtime.SetMutexProfileFraction(0)
+	})
+
+	srv := newPprofServer(
+		&PprofConfig{
+			ListenAddr:           "127.0.0.1:0",
+			BlockProfileRate:     1,
+			MutexProfileFraction: 1,
+		},
+		btclog.Disabled,
+	)
+
+	require.NoError(t, srv.Start(context.Background()))
+	require.NotNil(t, srv.Addr())
+	require.NoError(t, srv.Stop(context.Background()))
+
+	// After Stop the listener is cleared, so Addr reports inactive.
+	require.Nil(t, srv.Addr())
+	require.NoError(t, srv.Stop(context.Background()))
+}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -762,6 +762,32 @@ func (s *Server) run(ctx context.Context, shutdownFn func()) error {
 		slog.String("wallet_type", s.cfg.Wallet.Type),
 	)
 
+	// -------------------------------------------------------
+	// Optional pprof debug server (disabled by default).
+	// -------------------------------------------------------
+	// pprof exposes sensitive runtime/debug data, so it only starts when
+	// the operator sets an explicit listen address. It runs on its own
+	// private HTTP mux/listener — never on the gRPC/gateway servers — and
+	// is torn down with a bounded graceful shutdown like the other
+	// long-running listeners.
+	pprofSrv := newPprofServer(&s.cfg.Pprof, s.subLogger(PprofSubsystem))
+	if err := pprofSrv.Start(ctx); err != nil {
+		return fmt.Errorf("start pprof server: %w", err)
+	}
+	//nolint:contextcheck // shutdown uses bounded process-root context
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), DefaultShutdownTimeout,
+		)
+		defer cancel()
+
+		if err := pprofSrv.Stop(shutdownCtx); err != nil {
+			s.log.WarnS(shutdownCtx, "pprof server shutdown failed",
+				err,
+			)
+		}
+	}()
+
 	// Derive chain params from the config network string. In lnd
 	// mode this is overwritten by the lnd connection's chain
 	// params, but we need it early for lwwallet mode.

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -44,6 +44,21 @@
 # end-to-end.
 # eagerroundjoin=false
 
+# Address for the pprof debug HTTP server, for example 127.0.0.1:6060. Empty
+# disables pprof entirely. When set, a dedicated HTTP server exposes the
+# standard net/http/pprof endpoints. The server is plain HTTP (no TLS) and
+# unauthenticated, and pprof reveals sensitive runtime and debug data, so bind
+# it to a loopback or firewalled address only.
+# pprof.listen=
+
+# Value passed to runtime.SetBlockProfileRate at startup when greater than zero.
+# Zero leaves block profiling disabled.
+# pprof.blockprofilerate=0
+
+# Value passed to runtime.SetMutexProfileFraction at startup when greater than
+# zero. Zero leaves mutex profiling disabled.
+# pprof.mutexprofilefraction=0
+
 # lnd gRPC address.
 # lnd.host=localhost:10009
 


### PR DESCRIPTION
## Summary

Adds disabled-by-default pprof support to `darepod` (issue #635).

- New `pprof` config group, served on a **dedicated, private `http.ServeMux`** so the `net/http/pprof` endpoints are never attached to the gRPC or gateway listeners.
- `pprof.listen` — listen address; **empty (default) disables pprof entirely**.
- `pprof.blockprofilerate` — `runtime.SetBlockProfileRate` value, applied at startup when `> 0` (default `0`).
- `pprof.mutexprofilefraction` — `runtime.SetMutexProfileFraction` value, applied at startup when `> 0` (default `0`).
- Started in the daemon lifecycle only when a listen address is set, with a bounded graceful shutdown mirroring the other listeners. `http.ErrServerClosed` is treated as a clean shutdown. `WriteTimeout` is unset so streaming CPU/trace profiles (`?seconds=N`) are not cut off.

### Endpoints (when enabled)
`/debug/pprof/` (index → goroutine, heap, block, mutex, allocs, threadcreate), `/debug/pprof/cmdline`, `/debug/pprof/profile`, `/debug/pprof/symbol`, `/debug/pprof/trace`.

### Security
pprof exposes sensitive runtime/debug data and is opt-in. Operators must bind `pprof.listen` to a loopback (e.g. `127.0.0.1:6060`) or otherwise firewalled address. Documented in `sample-darepod.conf` and config GoDoc.

## Testing
- `make build`
- `go test ./darepod/ -run TestNewPprofMux` (new unit tests: endpoint registration + private-mux confinement)
- `make lint-changed-local` (0 issues)
- `make fmt-changed`
- sample-conf check (`check-sample-darepod-conf`) — passes
- `make commitmsg-lint` — passes
- `darepod --help` lists the three `--pprof.*` flags

Verify manually:
```
darepod --pprof.listen=127.0.0.1:6060
curl http://127.0.0.1:6060/debug/pprof/
curl -o cpu.prof 'http://127.0.0.1:6060/debug/pprof/profile?seconds=30'
```

Draft pending full CI (unit/itest/systest).

Closes #635.
