### PR TITLE
oor: bound incoming metadata retries with backoff and give-up

### DIFF
--- a/oor/actor.go
+++ b/oor/actor.go
@@ -2432,6 +2432,26 @@ func (b *oorDurableBehavior) resumeOutboxForHandle(handle *sessionHandle,
 		return OutboxForState(outgoingState)
 
 	case sessionKindIncoming:
+		// An incoming session mid-backoff on metadata resolution must
+		// resume by re-scheduling the retry rather than firing the
+		// query immediately. Otherwise a restart during one of the
+		// capped backoff windows resets the wait to zero, and repeated
+		// restarts could burn through maxMetadataRetries far faster
+		// than the intended backoff schedule. The persisted attempt
+		// count reproduces the same deterministic delay.
+		if notified, ok := state.(*ReceiveNotified); ok &&
+			notified.MetadataAttempts > 0 {
+			return []OutboxEvent{
+				&ScheduleRetryRequest{
+					After: metadataRetryBackoff(
+						notified.MetadataAttempts,
+					),
+					Reason: "incoming metadata retry " +
+						"resumed after restart",
+				},
+			}, nil
+		}
+
 		return OutboxForIncomingState(state)
 
 	default:

--- a/oor/actor_drive_event_integration_test.go
+++ b/oor/actor_drive_event_integration_test.go
@@ -479,3 +479,95 @@ func TestOORDurableBehaviorResumeRestoredSessionsResolvePending(t *testing.T) {
 	require.NoError(t, stateErr)
 	require.IsType(t, &ReceiveResolving{}, state)
 }
+
+// TestOORDurableBehaviorResumeIncomingMetadataBackoff verifies an incoming
+// session interrupted mid-backoff on metadata resolution resumes by
+// re-scheduling the retry with the persisted backoff rather than firing the
+// query immediately. This keeps a restart from collapsing a capped backoff
+// window to zero and burning the retry budget faster than intended.
+func TestOORDurableBehaviorResumeIncomingMetadataBackoff(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	arkPSBT, finalCheckpoints, _, _, _, _ :=
+		buildTestIncomingMaterialization(t)
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+
+	const attempts = 3
+	session, err := newReceiveSessionWithState(
+		ctx, sessionID, &ReceiveNotified{
+			SessionID:            sessionID,
+			ArkPSBT:              arkPSBT,
+			FinalCheckpointPSBTs: finalCheckpoints,
+			MetadataAttempts:     attempts,
+		},
+	)
+	require.NoError(t, err)
+
+	behavior := &oorDurableBehavior{
+		cfg: ClientActorCfg{
+			DeliveryStore: newTestDeliveryStore(t),
+			ActorID:       "oor-resume-incoming-backoff",
+			OutboxHandler: &noopOutboxHandler{},
+		},
+	}
+
+	handle := &sessionHandle{
+		FSM:  session.FSM,
+		kind: sessionKindIncoming,
+	}
+
+	state, err := handle.currentSessionState()
+	require.NoError(t, err)
+
+	outbox, err := behavior.resumeOutboxForHandle(handle, state)
+	require.NoError(t, err)
+	require.Len(t, outbox, 1)
+
+	schedule, ok := outbox[0].(*ScheduleRetryRequest)
+	require.True(t, ok)
+	require.Equal(t, metadataRetryBackoff(attempts), schedule.After)
+}
+
+// TestOORDurableBehaviorResumeIncomingNoBackoff verifies a freshly notified
+// incoming session that has not yet retried metadata resolution resumes by
+// re-emitting the metadata query immediately.
+func TestOORDurableBehaviorResumeIncomingNoBackoff(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	arkPSBT, finalCheckpoints, _, _, _, _ :=
+		buildTestIncomingMaterialization(t)
+	sessionID := SessionID(arkPSBT.UnsignedTx.TxHash())
+
+	session, _, err := DriveIncomingTransferWithCheckpoints(
+		ctx, sessionID, arkPSBT, finalCheckpoints, nil,
+	)
+	require.NoError(t, err)
+
+	behavior := &oorDurableBehavior{
+		cfg: ClientActorCfg{
+			DeliveryStore: newTestDeliveryStore(t),
+			ActorID:       "oor-resume-incoming-fresh",
+			OutboxHandler: &noopOutboxHandler{},
+		},
+	}
+
+	handle := &sessionHandle{
+		FSM:  session.FSM,
+		kind: sessionKindIncoming,
+	}
+
+	state, err := handle.currentSessionState()
+	require.NoError(t, err)
+	require.IsType(t, &ReceiveNotified{}, state)
+
+	outbox, err := behavior.resumeOutboxForHandle(handle, state)
+	require.NoError(t, err)
+	require.Len(t, outbox, 1)
+
+	_, ok := outbox[0].(*QueryIncomingMetadataRequest)
+	require.True(t, ok)
+}

--- a/oor/outbox_error_test.go
+++ b/oor/outbox_error_test.go
@@ -1,6 +1,7 @@
 package oor
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -101,6 +102,143 @@ func TestHandleOutboxError(t *testing.T) {
 	require.Equal(t, "boom", schedule.Reason)
 }
 
+// TestReceiveNotifiedMetadataRetryBackoff asserts that retryable metadata
+// failures in the notified state grow the backoff exponentially, cap it, and
+// carry the attempt counter on the returned state so it persists.
+func TestReceiveNotifiedMetadataRetryBackoff(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		startAttempts uint32
+		wantAttempts  uint32
+		wantAfter     time.Duration
+	}{
+		{
+			startAttempts: 0,
+			wantAttempts:  1,
+			wantAfter:     1 * time.Second,
+		},
+		{
+			startAttempts: 1,
+			wantAttempts:  2,
+			wantAfter:     2 * time.Second,
+		},
+		{
+			startAttempts: 2,
+			wantAttempts:  3,
+			wantAfter:     4 * time.Second,
+		},
+		{
+			startAttempts: 8,
+			wantAttempts:  9,
+			wantAfter:     256 * time.Second,
+		},
+
+		// 2^9 = 512s exceeds the 5m cap, so it clamps.
+		{
+			startAttempts: 9,
+			wantAttempts:  10,
+			wantAfter:     metadataRetryMaxDelay,
+		},
+	}
+
+	for _, tc := range cases {
+		state := &ReceiveNotified{
+			SessionID: SessionID{
+				0x01,
+			},
+			MetadataAttempts: tc.startAttempts,
+		}
+
+		transition, err := handleReceiveOutboxError(
+			state, &OutboxErrorEvent{
+				Retryable:   true,
+				RetryAfter:  defaultRetryDelay,
+				ErrorReason: "metadata missing",
+			},
+		)
+		require.NoError(t, err)
+
+		next, ok := transition.NextState.(*ReceiveNotified)
+		require.True(t, ok)
+		require.Equal(t, tc.wantAttempts, next.MetadataAttempts)
+
+		// The original state must not be mutated in place.
+		require.Equal(t, tc.startAttempts, state.MetadataAttempts)
+
+		emitted := transition.NewEvents.UnwrapOr(EmittedEvent{})
+		require.Len(t, emitted.Outbox, 1)
+		schedule, ok := emitted.Outbox[0].(*ScheduleRetryRequest)
+		require.True(t, ok)
+		require.Equal(t, tc.wantAfter, schedule.After)
+	}
+}
+
+// TestReceiveNotifiedMetadataRetryGivesUp asserts that once the retry bound is
+// exceeded the notified state fails terminally instead of scheduling another
+// metadata query.
+func TestReceiveNotifiedMetadataRetryGivesUp(t *testing.T) {
+	t.Parallel()
+
+	state := &ReceiveNotified{
+		SessionID: SessionID{
+			0x02,
+		},
+		MetadataAttempts: maxMetadataRetries,
+	}
+
+	transition, err := handleReceiveOutboxError(state, &OutboxErrorEvent{
+		Retryable:   true,
+		RetryAfter:  defaultRetryDelay,
+		ErrorReason: "metadata missing",
+	})
+	require.NoError(t, err)
+
+	failed, ok := transition.NextState.(*Failed)
+	require.True(t, ok)
+	require.Contains(t, failed.Reason, "metadata missing")
+	require.True(t, transition.NewEvents.IsNone())
+}
+
+// TestMetadataRetryBackoff covers the backoff helper bounds directly.
+func TestMetadataRetryBackoff(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, metadataRetryBaseDelay, metadataRetryBackoff(0))
+	require.Equal(t, metadataRetryBaseDelay, metadataRetryBackoff(1))
+	require.Equal(t, 2*time.Second, metadataRetryBackoff(2))
+	require.Equal(t, metadataRetryMaxDelay, metadataRetryBackoff(100))
+}
+
+// TestIncomingSnapshotMetadataAttemptsRoundTrip asserts the persisted retry
+// counter survives a snapshot encode/decode cycle so the give-up bound holds
+// across restarts.
+func TestIncomingSnapshotMetadataAttemptsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	snap := &IncomingSnapshot{
+		Version: 1,
+		SessionID: SessionID{
+			0x03,
+		},
+		Phase: IncomingPhaseMaterializePending,
+		ArkPSBT: []byte{
+			0xaa,
+			0xbb,
+		},
+		MetadataAttempts: 7,
+	}
+
+	raw, err := encodeIncomingSnapshot(snap)
+	require.NoError(t, err)
+
+	decoded, err := decodeIncomingSnapshotWithLimits(
+		raw, DefaultReceiveLimits(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint32(7), decoded.MetadataAttempts)
+}
+
 // TestAwaitingFinalizeAcceptedOutboxError verifies that retryable outbox
 // failures in the finalize-ack wait state stay in the current state while
 // scheduling retry.
@@ -162,4 +300,31 @@ func TestAwaitingFinalizeAcceptedOutboxError(t *testing.T) {
 	schedule, ok := emitted.Outbox[0].(*ScheduleRetryRequest)
 	require.True(t, ok)
 	require.Equal(t, defaultRetryDelay, schedule.After)
+}
+
+// TestReceiveNotifiedMetadataRetryOverflowGivesUp ensures a corrupted snapshot
+// whose attempt counter sits at the uint32 maximum still terminates terminally
+// rather than wrapping past the bound when incremented. Checking the persisted
+// counter before the increment keeps the give-up reachable.
+func TestReceiveNotifiedMetadataRetryOverflowGivesUp(t *testing.T) {
+	t.Parallel()
+
+	state := &ReceiveNotified{
+		SessionID: SessionID{
+			0x03,
+		},
+		MetadataAttempts: math.MaxUint32,
+	}
+
+	transition, err := handleReceiveOutboxError(state, &OutboxErrorEvent{
+		Retryable:   true,
+		RetryAfter:  defaultRetryDelay,
+		ErrorReason: "metadata missing",
+	})
+	require.NoError(t, err)
+
+	failed, ok := transition.NextState.(*Failed)
+	require.True(t, ok)
+	require.Contains(t, failed.Reason, "metadata missing")
+	require.True(t, transition.NewEvents.IsNone())
 }

--- a/oor/receive_snapshot.go
+++ b/oor/receive_snapshot.go
@@ -20,6 +20,7 @@ const (
 	incomingSnapshotRecipientPkScriptType     tlv.Type = 13
 	incomingSnapshotRecipientEventIDType      tlv.Type = 15
 	incomingSnapshotAncestorPackagesType      tlv.Type = 17
+	incomingSnapshotMetadataAttemptsType      tlv.Type = 19
 )
 
 // IncomingPhase identifies the coarse stage of an incoming OOR receive
@@ -84,6 +85,11 @@ type IncomingSnapshot struct {
 	// RecipientEventID is the per-script cursor hint paired with
 	// RecipientPkScript during resolve-pending restart.
 	RecipientEventID uint64
+
+	// MetadataAttempts is the persisted retry count for the authoritative
+	// metadata resolution, used to bound backoff and the terminal give-up
+	// across restarts. Only meaningful in the materialize-pending phase.
+	MetadataAttempts uint32
 }
 
 // NewIncomingSnapshot exports an incoming receive session state into a
@@ -131,6 +137,7 @@ func NewIncomingSnapshot(sessionID SessionID,
 		snap.AncestorPackages = append(
 			[]PackageArtifact(nil), s.AncestorPackages...,
 		)
+		snap.MetadataAttempts = s.MetadataAttempts
 
 	case *ReceiveAwaitingAck:
 		snap.Phase = IncomingPhaseAckPending
@@ -217,6 +224,7 @@ func IncomingStateFromSnapshot(snapshot *IncomingSnapshot) (SessionState,
 				[]PackageArtifact(nil),
 				snapshot.AncestorPackages...,
 			),
+			MetadataAttempts: snapshot.MetadataAttempts,
 		}, nil
 
 	case IncomingPhaseAckPending:
@@ -262,6 +270,7 @@ func encodeIncomingSnapshot(snapshot *IncomingSnapshot) ([]byte, error) {
 		return nil, err
 	}
 
+	metadataAttempts := uint64(snapshot.MetadataAttempts)
 	version := uint64(snapshot.Version)
 
 	records := []tlv.Record{
@@ -293,6 +302,9 @@ func encodeIncomingSnapshot(snapshot *IncomingSnapshot) ([]byte, error) {
 		tlv.MakePrimitiveRecord(
 			incomingSnapshotAncestorPackagesType, &ancestorPackages,
 		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotMetadataAttemptsType, &metadataAttempts,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -323,6 +335,7 @@ func decodeIncomingSnapshotWithLimits(raw []byte,
 		recipientPkScript []byte
 		recipientEventID  uint64
 		ancestorPackages  []byte
+		metadataAttempts  uint64
 	)
 
 	records := []tlv.Record{
@@ -354,6 +367,9 @@ func decodeIncomingSnapshotWithLimits(raw []byte,
 		),
 		tlv.MakePrimitiveRecord(
 			incomingSnapshotAncestorPackagesType, &ancestorPackages,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingSnapshotMetadataAttemptsType, &metadataAttempts,
 		),
 	}
 
@@ -414,6 +430,7 @@ func decodeIncomingSnapshotWithLimits(raw []byte,
 			[]byte(nil), recipientPkScript...,
 		),
 		RecipientEventID: recipientEventID,
+		MetadataAttempts: uint32(metadataAttempts),
 	}, nil
 }
 

--- a/oor/receive_states.go
+++ b/oor/receive_states.go
@@ -66,6 +66,12 @@ type ReceiveNotified struct {
 	FinalCheckpointPSBTs []*psbt.Packet
 
 	AncestorPackages []PackageArtifact
+
+	// MetadataAttempts counts how many times the authoritative metadata
+	// resolution has failed retryably for this session. It drives the
+	// exponential backoff and terminal give-up in handleReceiveOutboxError
+	// and is persisted in the snapshot so the bound survives restarts.
+	MetadataAttempts uint32
 }
 
 // String returns a human-readable representation of ReceiveNotified.

--- a/oor/receive_transitions.go
+++ b/oor/receive_transitions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -72,6 +73,14 @@ func handleReceiveOutboxError(state ReceiveState,
 		}, nil
 	}
 
+	// The notified state retries the authoritative metadata resolution.
+	// Apply bounded exponential backoff and a terminal give-up so a
+	// session whose VTXO never lands in the indexer stops re-querying the
+	// mailbox forever instead of spinning at a flat cadence.
+	if notified, ok := state.(*ReceiveNotified); ok {
+		return handleNotifiedRetry(notified, evt), nil
+	}
+
 	after := evt.RetryAfter
 	if after == 0 {
 		after = defaultRetryDelay
@@ -88,6 +97,71 @@ func handleReceiveOutboxError(state ReceiveState,
 			},
 		}),
 	}, nil
+}
+
+// handleNotifiedRetry derives the backoff-or-give-up transition for a
+// retryable metadata resolution failure in the notified state. The attempt
+// counter rides on the returned state so it is persisted across restarts.
+func handleNotifiedRetry(state *ReceiveNotified,
+	evt *OutboxErrorEvent) *StateTransition {
+
+	// Give up once the bound is reached. The session can no longer make
+	// progress, so failing it terminally removes it from the retry
+	// population rather than re-querying indefinitely. The bound is
+	// checked against the persisted counter before incrementing so a
+	// corrupted snapshot at math.MaxUint32 cannot wrap past the limit and
+	// bypass the give-up.
+	if state.MetadataAttempts >= maxMetadataRetries {
+		return &StateTransition{
+			NextState: &Failed{
+				Reason: fmt.Sprintf("incoming metadata "+
+					"unresolved after %d retries: %s",
+					maxMetadataRetries, evt.ErrorReason),
+			},
+			NewEvents: fn.None[EmittedEvent](),
+		}
+	}
+
+	attempts := state.MetadataAttempts + 1
+
+	next := *state
+	next.MetadataAttempts = attempts
+
+	return &StateTransition{
+		NextState: &next,
+		NewEvents: fn.Some(EmittedEvent{
+			Outbox: []OutboxEvent{
+				&ScheduleRetryRequest{
+					After:  metadataRetryBackoff(attempts),
+					Reason: evt.ErrorReason,
+				},
+			},
+		}),
+	}
+}
+
+// metadataRetryBackoff returns the delay before the next metadata retry. It
+// grows exponentially with the attempt count, capped at metadataRetryMaxDelay.
+// It is deterministic (no jitter) so FSM replay and snapshot round-trips stay
+// reproducible.
+func metadataRetryBackoff(attempt uint32) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+
+	// Cap the shift well below the int64 overflow point; the delay is
+	// clamped to the max below long before this matters.
+	shift := attempt - 1
+	if shift > 30 {
+		shift = 30
+	}
+
+	delay := metadataRetryBaseDelay << shift
+	if delay <= 0 || delay > metadataRetryMaxDelay {
+		return metadataRetryMaxDelay
+	}
+
+	return delay
 }
 
 // retryReceiveState re-emits the outbox implied by the current receive state

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -18,6 +18,25 @@ import (
 // specify an explicit backoff.
 const defaultRetryDelay = 1 * time.Second
 
+const (
+	// metadataRetryBaseDelay is the initial backoff before re-issuing the
+	// authoritative incoming metadata query after a retryable failure.
+	metadataRetryBaseDelay = 1 * time.Second
+
+	// metadataRetryMaxDelay caps the exponential backoff between incoming
+	// metadata retries. Without a cap a long-lived stuck session would
+	// still re-query, just less often; the cap bounds the steady-state
+	// rate.
+	metadataRetryMaxDelay = 5 * time.Minute
+
+	// maxMetadataRetries bounds how many times the incoming receive FSM
+	// re-issues the metadata query before failing the session terminally.
+	// A VTXO that never lands in the indexer must stop being re-queried so
+	// one stuck session cannot spin the mailbox forever. With the base and
+	// cap above this is on the order of an hour of attempts.
+	maxMetadataRetries = 20
+)
+
 // unexpectedEvent returns a transition that stays in the current state and
 // emits no outbox work for an unexpected event.
 //


### PR DESCRIPTION
## Motivation

On signet the `swapdk-ark-client` was issuing `arkrpc.IndexerService/ListVTXOsByScripts` queries at ~77/sec, nonstop, each with a distinct msg_id. The backing mailbox held only a handful of rows at any instant — the queries were answered and acked instantly, so it was a live hot loop, not a backlog.

Root cause: the OOR incoming-receive phase-2 metadata resolution has no convergence guard. When materialization reports the VTXO is not yet in the indexer, it returns a *retryable* error with a flat **1s** delay (`oor/transitions.go` `defaultRetryDelay`) and **no attempt cap**. A session whose VTXO never lands re-issues the query once per second forever; many such sessions stuck at once sum to the observed rate. (Upstream those stuck sessions came from a swapd in-swap retry storm — fixed separately in swapdk-server.)

## Changes

- **`oor`** — `handleReceiveOutboxError` now routes `ReceiveNotified` retries through bounded **exponential backoff** (1s base, 5m cap) keyed off a new `MetadataAttempts` counter, and **gives up terminally** (→ `Failed`) after `maxMetadataRetries` (20) instead of scheduling another query. The counter rides on the `ReceiveNotified` state and is persisted in the incoming snapshot (new TLV record type 19) so the bound survives restarts — the resume path clears *volatile* retry metadata, so it must live in persisted FSM state.
- **`serverconn`** — demote the per-pull "Pulled envelopes" log from debug to trace. The ingress success path has no delay, so a continuously-fed mailbox spins the loop at RTT speed and floods debug logs with one line per single-envelope pull.

## Tests

New `oor` tests cover the backoff progression + cap, the terminal give-up, the backoff helper bounds, and the snapshot round-trip of the attempt counter. Full `oor` package passes; `make lint-changed-local` reports 0 issues.

Behavior change to call out: an incoming receive session that cannot resolve its metadata now fails terminally after ~an hour of attempts rather than retrying indefinitely. The terminal `Failed` reason carries the underlying error.