### PR TITLE
vtxo: avoid dust change in OOR selection

### DIFF
--- a/darepod/rpc_oor_idempotency_test.go
+++ b/darepod/rpc_oor_idempotency_test.go
@@ -32,11 +32,14 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type selectionReq = wallet.SelectAndLockVTXOsRequest
+
 type sendOORTestWallet struct {
 	mu sync.Mutex
 
 	selections [][]wallet.SelectedVTXO
 	unlocks    [][]wire.OutPoint
+	selectReqs []*selectionReq
 	selects    int
 }
 
@@ -49,6 +52,8 @@ func (w *sendOORTestWallet) Receive(_ context.Context,
 	switch msg := msg.(type) {
 	case *wallet.SelectAndLockVTXOsRequest:
 		w.selects++
+		reqCopy := *msg
+		w.selectReqs = append(w.selectReqs, &reqCopy)
 
 		if len(w.selections) == 0 {
 			return fn.Err[wallet.WalletResp](
@@ -117,6 +122,21 @@ func (w *sendOORTestWallet) selectCount() int {
 	defer w.mu.Unlock()
 
 	return w.selects
+}
+
+func (w *sendOORTestWallet) selectionRequests() []*selectionReq {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	requests := make(
+		[]*selectionReq, 0, len(w.selectReqs),
+	)
+	for _, req := range w.selectReqs {
+		reqCopy := *req
+		requests = append(requests, &reqCopy)
+	}
+
+	return requests
 }
 
 type sendOORNoopOutboxHandler struct{}
@@ -261,6 +281,10 @@ func TestSendOORReturnsExistingIdempotencyKeyBeforeWalletSelection(
 	require.NotEmpty(t, firstResp.SessionId)
 	require.Equal(t, firstResp.SessionId+":0", firstResp.RecipientOutpoint)
 	require.Empty(t, testWallet.unlockBatches())
+	selectReqs := testWallet.selectionRequests()
+	require.Len(t, selectReqs, 1)
+	require.Equal(t, btcutil.Amount(amountSat), selectReqs[0].TargetAmount)
+	require.Equal(t, btcutil.Amount(1), selectReqs[0].MinChangeAmount)
 
 	secondResp, err := rpcServer.SendOOR(ctx, &daemonrpc.SendOORRequest{
 		Recipient:      recipient,

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -1932,7 +1932,8 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		wRef := r.server.walletRef.UnsafeFromSome()
 
 		selectReq := &wallet.SelectAndLockVTXOsRequest{
-			TargetAmount: targetAmt,
+			TargetAmount:    targetAmt,
+			MinChangeAmount: terms.DustLimit,
 		}
 		selectFuture := wRef.Ask(ctx, selectReq)
 		selectResult := selectFuture.Await(ctx)

--- a/lib/actormsg/vtxo_admission.go
+++ b/lib/actormsg/vtxo_admission.go
@@ -25,6 +25,10 @@ type SelectAndReserveSpendRequest struct {
 	// TargetAmount is the minimum total value the selected VTXOs must
 	// cover.
 	TargetAmount btcutil.Amount
+
+	// MinChangeAmount, when positive, asks selection to avoid a
+	// non-zero residual below this amount. Exact spends are still valid.
+	MinChangeAmount btcutil.Amount
 }
 
 // VTXOManagerMsg implements VTXOManagerMsg marker interface.

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -598,10 +598,11 @@ func (m *Manager) spawnVTXOActor(ctx context.Context, vtxo *Descriptor) (
 // selectAndReserveVTXOs so the shared coin-selection + reservation
 // logic does not need to be duplicated.
 type reserveParams struct {
-	targetAmount btcutil.Amount
-	reserveEvent actormsg.VTXOActorMsg
-	rollback     func(ctx context.Context, ops []wire.OutPoint)
-	ask          func(context.Context, VTXOActorRef,
+	targetAmount    btcutil.Amount
+	minChangeAmount btcutil.Amount
+	reserveEvent    actormsg.VTXOActorMsg
+	rollback        func(ctx context.Context, ops []wire.OutPoint)
+	ask             func(context.Context, VTXOActorRef,
 		actormsg.VTXOActorMsg) fn.Result[actormsg.VTXOActorResp]
 	label string
 }
@@ -627,8 +628,17 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context, p reserveParams) (
 	}
 
 	// Run largest-first selection.
-	selected := selectLargestFirst(candidates, p.targetAmount)
+	selected, selectedTotal := selectLargestFirstWithMinChange(
+		candidates, p.targetAmount, p.minChangeAmount,
+	)
 	if selected == nil {
+		if selectedTotal >= p.targetAmount && p.minChangeAmount > 0 {
+			change := selectedTotal - p.targetAmount
+
+			return nil, 0, fmt.Errorf("change %d is below minimum "+
+				"change amount %d", change, p.minChangeAmount)
+		}
+
 		err := m.insufficientLiquidityError(ctx, candidates, p)
 
 		return nil, 0, err
@@ -737,11 +747,12 @@ func (m *Manager) handleSelectAndReserveSpend(ctx context.Context,
 	req *SelectAndReserveSpendRequest) fn.Result[ManagerResp] {
 
 	vtxos, total, err := m.selectAndReserveVTXOs(ctx, reserveParams{
-		targetAmount: req.TargetAmount,
-		reserveEvent: &SpendReserveEvent{},
-		rollback:     m.rollbackSpend,
-		ask:          m.askVTXOActor,
-		label:        "spend",
+		targetAmount:    req.TargetAmount,
+		minChangeAmount: req.MinChangeAmount,
+		reserveEvent:    &SpendReserveEvent{},
+		rollback:        m.rollbackSpend,
+		ask:             m.askVTXOActor,
+		label:           "spend",
 	})
 	if err != nil {
 		return fn.Err[ManagerResp](err)
@@ -1079,6 +1090,17 @@ func (m *Manager) handleSelectAndReserveForfeit(ctx context.Context,
 func selectLargestFirst(candidates []*Descriptor,
 	target btcutil.Amount) []*Descriptor {
 
+	selected, _ := selectLargestFirstWithMinChange(candidates, target, 0)
+
+	return selected
+}
+
+// selectLargestFirstWithMinChange implements largest-first coin selection
+// while avoiding non-zero change below minChange. Exact spends remain valid,
+// because no change output is produced in that case.
+func selectLargestFirstWithMinChange(candidates []*Descriptor,
+	target, minChange btcutil.Amount) ([]*Descriptor, btcutil.Amount) {
+
 	// Sort by amount descending.
 	sorted := make([]*Descriptor, len(candidates))
 	copy(sorted, candidates)
@@ -1087,20 +1109,35 @@ func selectLargestFirst(candidates []*Descriptor,
 	})
 
 	var (
-		selected []*Descriptor
-		total    btcutil.Amount
+		selected        []*Descriptor
+		total           btcutil.Amount
+		rejectedTotal   btcutil.Amount
+		rejectedForDust bool
 	)
 	for _, vtxo := range sorted {
 		selected = append(selected, vtxo)
 		total += vtxo.Amount
 
-		if total >= target {
-			return selected
+		if total < target {
+			continue
+		}
+
+		change := total - target
+		if change == 0 || minChange == 0 || change >= minChange {
+			return selected, total
+		}
+
+		if !rejectedForDust {
+			rejectedTotal = total
+			rejectedForDust = true
 		}
 	}
 
-	// Not enough funds.
-	return nil
+	if rejectedForDust {
+		return nil, rejectedTotal
+	}
+
+	return nil, total
 }
 
 // dedupOutpoints returns a copy of the slice with duplicate outpoints

--- a/vtxo/manager_admission_test.go
+++ b/vtxo/manager_admission_test.go
@@ -242,6 +242,114 @@ func TestSelectAndReserveSpendMultipleVTXOs(t *testing.T) {
 	require.Equal(t, btcutil.Amount(55000), spendResp.TotalSelected)
 }
 
+// TestSelectAndReserveSpendCoalescesDustChange verifies that OOR spend
+// selection keeps adding inputs when the first covering input would require a
+// non-zero change output below the operator dust limit. This avoids opening an
+// OOR package that the daemon later rejects for dust change.
+func TestSelectAndReserveSpendCoalescesDustChange(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(t, 1500, 0)
+	vtxo2 := makeDescriptor(t, 1500, 1)
+	vtxo3 := makeDescriptor(t, 1000, 2)
+	vtxo4 := makeDescriptor(t, 999, 3)
+
+	mgr, store := newTestManager(t, []*Descriptor{
+		vtxo1, vtxo2, vtxo3, vtxo4,
+	})
+
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusLive,
+	).Return([]*Descriptor{vtxo1, vtxo2, vtxo3, vtxo4}, nil)
+
+	result := mgr.Receive(t.Context(), &SelectAndReserveSpendRequest{
+		TargetAmount:    600,
+		MinChangeAmount: 1000,
+	})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	spendResp, ok := resp.(*SelectAndReserveSpendResponse)
+	require.True(t, ok, "expected *SelectAndReserveSpendResponse")
+
+	require.Len(t, spendResp.SelectedVTXOs, 2)
+	require.Equal(t, btcutil.Amount(3000), spendResp.TotalSelected)
+	require.Equal(t, vtxo1.Outpoint, spendResp.SelectedVTXOs[0].Outpoint)
+	require.Equal(t, vtxo2.Outpoint, spendResp.SelectedVTXOs[1].Outpoint)
+}
+
+// TestSelectAndReserveSpendAllowsExactDustlessSpend asserts that the
+// min-change guard does not force callers to select extra inputs when the
+// selected VTXO set exactly matches the spend amount. Exact spends have no
+// change output, so the operator dust limit is irrelevant.
+func TestSelectAndReserveSpendAllowsExactDustlessSpend(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(t, 600, 0)
+	vtxo2 := makeDescriptor(t, 1500, 1)
+
+	mgr, store := newTestManager(t, []*Descriptor{
+		vtxo1, vtxo2,
+	})
+
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusLive,
+	).Return([]*Descriptor{vtxo1, vtxo2}, nil)
+
+	result := mgr.Receive(t.Context(), &SelectAndReserveSpendRequest{
+		TargetAmount:    1500,
+		MinChangeAmount: 1000,
+	})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	spendResp, ok := resp.(*SelectAndReserveSpendResponse)
+	require.True(t, ok, "expected *SelectAndReserveSpendResponse")
+
+	require.Len(t, spendResp.SelectedVTXOs, 1)
+	require.Equal(t, btcutil.Amount(1500), spendResp.TotalSelected)
+	require.Equal(t, vtxo2.Outpoint, spendResp.SelectedVTXOs[0].Outpoint)
+}
+
+// TestSelectAndReserveSpendRejectsUnavoidableDustChange verifies that a
+// wallet with enough value but no exact-or-dust-safe combination fails before
+// reserving any VTXO. This leaves the caller with a local admission error
+// instead of an OOR package rejected after partial reservation.
+func TestSelectAndReserveSpendRejectsUnavoidableDustChange(t *testing.T) {
+	t.Parallel()
+
+	vtxo1 := makeDescriptor(t, 2000, 0)
+	vtxo2 := makeDescriptor(t, 1000, 1)
+
+	mgr, store := newTestManager(t, []*Descriptor{vtxo1, vtxo2})
+
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusLive,
+	).Return([]*Descriptor{vtxo1, vtxo2}, nil)
+
+	result := mgr.Receive(t.Context(), &SelectAndReserveSpendRequest{
+		TargetAmount:    600,
+		MinChangeAmount: 5000,
+	})
+	_, err := result.Unpack()
+	require.Error(t, err)
+	require.Contains(
+		t, err.Error(),
+		"change 1400 is below minimum change amount 5000",
+	)
+
+	for _, vtxo := range []*Descriptor{vtxo1, vtxo2} {
+		refAny := mgr.actors[vtxo.Outpoint]
+		ref, ok := refAny.(*mockVTXOActorRef)
+		require.True(
+			t, ok, "expected *mockVTXOActorRef, got %T", refAny,
+		)
+
+		_, ok = ref.state.(*LiveState)
+		require.True(t, ok, "expected LiveState, got %T", ref.state)
+	}
+}
+
 // TestSelectAndReserveSpendInsufficientFunds verifies that selection fails
 // when candidates cannot cover the target.
 func TestSelectAndReserveSpendInsufficientFunds(t *testing.T) {

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -399,6 +399,10 @@ type SelectAndLockVTXOsRequest struct {
 	// TargetAmount is the minimum total value the selected VTXOs must
 	// cover.
 	TargetAmount btcutil.Amount
+
+	// MinChangeAmount, when positive, asks selection to avoid a
+	// non-zero residual below this amount. Exact spends are still valid.
+	MinChangeAmount btcutil.Amount
 }
 
 // MessageType returns the message type identifier for logging and debugging.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2282,7 +2282,8 @@ func (a *Ark) handleSelectAndLockVTXOs(ctx context.Context,
 
 	resp, err := a.askManager(
 		ctx, &actormsg.SelectAndReserveSpendRequest{
-			TargetAmount: req.TargetAmount,
+			TargetAmount:    req.TargetAmount,
+			MinChangeAmount: req.MinChangeAmount,
 		},
 	)
 	if err != nil {

--- a/wallet/wallet_admission_test.go
+++ b/wallet/wallet_admission_test.go
@@ -25,6 +25,9 @@ import (
 // service key type. It responds to admission messages with configurable
 // results, enabling wallet handler tests without a real VTXO manager.
 type mockVTXOManagerBehavior struct {
+	// selectReq is the last SelectAndReserveSpendRequest received.
+	selectReq *actormsg.SelectAndReserveSpendRequest
+
 	// selectResp is returned for SelectAndReserveSpendRequest.
 	selectResp *actormsg.SelectAndReserveSpendResponse
 
@@ -72,8 +75,10 @@ type mockVTXOManagerBehavior struct {
 func (m *mockVTXOManagerBehavior) Receive(_ context.Context,
 	msg actormsg.VTXOManagerMsg) fn.Result[actormsg.VTXOManagerResp] {
 
-	switch msg.(type) {
+	switch msg := msg.(type) {
 	case *actormsg.SelectAndReserveSpendRequest:
+		m.selectReq = msg
+
 		if m.selectErr != nil {
 			return fn.Err[actormsg.VTXOManagerResp](
 				m.selectErr,
@@ -213,7 +218,8 @@ func TestSelectAndLockVTXOs(t *testing.T) {
 	w := newTestWalletWithManager(t, mgr)
 
 	req := &SelectAndLockVTXOsRequest{
-		TargetAmount: 70000,
+		TargetAmount:    70000,
+		MinChangeAmount: 1000,
 	}
 	result := w.Receive(t.Context(), req)
 	require.True(t, result.IsOk(), "expected ok, got: %v",
@@ -228,6 +234,8 @@ func TestSelectAndLockVTXOs(t *testing.T) {
 	require.Equal(t, testOutpoint(0), resp.SelectedVTXOs[0].Outpoint)
 	require.Equal(t, btcutil.Amount(50000),
 		resp.SelectedVTXOs[0].Amount)
+	require.Equal(t, btcutil.Amount(70000), mgr.selectReq.TargetAmount)
+	require.Equal(t, btcutil.Amount(1000), mgr.selectReq.MinChangeAmount)
 }
 
 // TestSelectAndLockVTXOsInsufficientFunds verifies that the wallet surfaces


### PR DESCRIPTION
## Summary

- thread the operator dust limit into OOR spend input selection
- keep selecting VTXOs when the first covering set would leave sub-dust change
- preserve exact-drain spends where no change output is produced

Fixes #603

## Test

- go test ./vtxo ./wallet ./darepod
- make lint-changed-local
- make commitmsg-lint range="origin/main..HEAD"
