### PR TITLE
vtxo: classify locked OOR liquidity

### DIFF
--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -132,6 +132,27 @@ func (r *RPCServer) SignMailboxAuth(ctx context.Context,
 	return hex.EncodeToString(sig.Serialize()), nil
 }
 
+// vtxoAdmissionCode maps typed VTXO admission failures to caller-actionable
+// gRPC codes while preserving Internal for unexpected selection failures.
+func vtxoAdmissionCode(err error) codes.Code {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return codes.Canceled
+
+	case errors.Is(err, context.DeadlineExceeded):
+		return codes.DeadlineExceeded
+
+	case errors.Is(err, vtxo.ErrVTXOLiquidityLocked):
+		return codes.Aborted
+
+	case errors.Is(err, vtxo.ErrInsufficientSpendableFunds):
+		return codes.ResourceExhausted
+
+	default:
+		return codes.Internal
+	}
+}
+
 // ClientTLSCerts returns the daemon identity client certificate used when
 // optional subservers dial mTLS-protected mailbox edges.
 func (r *RPCServer) ClientTLSCerts() ([]tls.Certificate, error) {
@@ -1695,8 +1716,8 @@ func (r *RPCServer) SendVTXO(ctx context.Context,
 
 	resp, err := result.Unpack()
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "send failed: %v",
-			err)
+		return nil, status.Errorf(vtxoAdmissionCode(err), "send "+
+			"failed: %v", err)
 	}
 
 	sendResp, ok := resp.(*wallet.SendVTXOsResponse)
@@ -1918,8 +1939,8 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 
 		selectResp, err := selectResult.Unpack()
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "VTXO "+
-				"selection failed: %v", err)
+			return nil, status.Errorf(vtxoAdmissionCode(err),
+				"VTXO selection failed: %v", err)
 		}
 
 		var ok bool

--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -3,6 +3,7 @@ package darepod
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -39,6 +40,46 @@ func newTestRPCServer() *RPCServer {
 			chainParams: &chaincfg.RegressionNetParams,
 		},
 	}
+}
+
+// TestVTXOAdmissionCode verifies wallet admission errors surface as
+// caller-actionable gRPC codes instead of being collapsed into Internal.
+func TestVTXOAdmissionCode(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t, codes.Canceled,
+		vtxoAdmissionCode(
+			fmt.Errorf("select and reserve: %w", context.Canceled),
+		),
+	)
+	require.Equal(
+		t, codes.DeadlineExceeded,
+		vtxoAdmissionCode(
+			fmt.Errorf("select and reserve: %w",
+				context.DeadlineExceeded),
+		),
+	)
+	require.Equal(
+		t, codes.Aborted,
+		vtxoAdmissionCode(
+			fmt.Errorf("select and reserve: %w",
+				vtxo.ErrVTXOLiquidityLocked),
+		),
+	)
+	require.Equal(
+		t, codes.ResourceExhausted,
+		vtxoAdmissionCode(
+			fmt.Errorf("select and reserve: %w",
+				vtxo.ErrInsufficientSpendableFunds),
+		),
+	)
+	require.Equal(
+		t, codes.Internal,
+		vtxoAdmissionCode(
+			errors.New("actor system unavailable"),
+		),
+	)
 }
 
 // TestUnrollAdmissionSurvivesCallerCancellation verifies that a caller

--- a/vtxo/admission_errors.go
+++ b/vtxo/admission_errors.go
@@ -1,0 +1,14 @@
+package vtxo
+
+import "errors"
+
+var (
+	// ErrInsufficientSpendableFunds means live VTXOs cannot cover the
+	// requested amount.
+	ErrInsufficientSpendableFunds = errors.New("insufficient spendable " +
+		"funds")
+
+	// ErrVTXOLiquidityLocked means enough non-terminal liquidity exists,
+	// but some of it is currently reserved by another in-flight operation.
+	ErrVTXOLiquidityLocked = errors.New("vtxo liquidity temporarily locked")
+)

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -629,8 +629,9 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context, p reserveParams) (
 	// Run largest-first selection.
 	selected := selectLargestFirst(candidates, p.targetAmount)
 	if selected == nil {
-		return nil, 0, fmt.Errorf("insufficient funds: need %d",
-			p.targetAmount)
+		err := m.insufficientLiquidityError(ctx, candidates, p)
+
+		return nil, 0, err
 	}
 
 	// Reserve each selected VTXO via its actor. Track successfully
@@ -655,8 +656,15 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context, p reserveParams) (
 			)
 			p.rollback(ctx, reserved)
 
-			return nil, 0, fmt.Errorf("reserve %s %s: %w", p.label,
-				vtxo.Outpoint, err)
+			// The common post-selection failure is that another
+			// actor turn already moved this candidate out of
+			// LiveState while the store view was stale. Treat it as
+			// locked liquidity so callers can retry; unexpected
+			// actor/infrastructure errors remain wrapped inside the
+			// returned error for logs.
+			return nil, 0, fmt.Errorf("%w: reserve %s %s: %w",
+				ErrVTXOLiquidityLocked, p.label, vtxo.Outpoint,
+				err)
 		}
 
 		reserved = append(reserved, vtxo.Outpoint)
@@ -683,6 +691,42 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context, p reserveParams) (
 	)
 
 	return selectedVTXOs, totalSelected, nil
+}
+
+// insufficientLiquidityError distinguishes a true spendable-funds shortfall
+// from liquidity that is present but unavailable because another operation has
+// already moved it out of LiveState.
+func (m *Manager) insufficientLiquidityError(ctx context.Context,
+	liveCandidates []*Descriptor, p reserveParams) error {
+
+	liveTotal := SumBalance(liveCandidates)
+
+	nonTerminal, err := m.cfg.Store.ListLiveVTXOs(ctx)
+	if err != nil {
+		return fmt.Errorf("classify liquidity: %w", err)
+	}
+
+	var lockedTotal btcutil.Amount
+	for _, desc := range nonTerminal {
+		if desc == nil {
+			continue
+		}
+
+		if desc.Status == VTXOStatusLive {
+			continue
+		}
+
+		lockedTotal += desc.Amount
+	}
+
+	if lockedTotal > 0 && liveTotal+lockedTotal >= p.targetAmount {
+		return fmt.Errorf("%w: need %d, spendable %d, locked %d",
+			ErrVTXOLiquidityLocked, p.targetAmount, liveTotal,
+			lockedTotal)
+	}
+
+	return fmt.Errorf("%w: need %d, spendable %d",
+		ErrInsufficientSpendableFunds, p.targetAmount, liveTotal)
 }
 
 // handleSelectAndReserveSpend selects VTXOs covering the target amount using

--- a/vtxo/manager_admission_test.go
+++ b/vtxo/manager_admission_test.go
@@ -254,13 +254,17 @@ func TestSelectAndReserveSpendInsufficientFunds(t *testing.T) {
 	store.On(
 		"ListVTXOsByStatus", t.Context(), VTXOStatusLive,
 	).Return([]*Descriptor{vtxo1}, nil)
+	store.On("ListLiveVTXOs", t.Context()).Return(
+		[]*Descriptor{vtxo1}, nil,
+	)
 
 	result := mgr.Receive(t.Context(), &SelectAndReserveSpendRequest{
 		TargetAmount: 50000,
 	})
 	_, err := result.Unpack()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "insufficient funds")
+	require.ErrorIs(t, err, ErrInsufficientSpendableFunds)
+	require.NotErrorIs(t, err, ErrVTXOLiquidityLocked)
 }
 
 // TestSelectAndReserveSpendDoubleExclusion verifies that a second selection
@@ -290,13 +294,19 @@ func TestSelectAndReserveSpendDoubleExclusion(t *testing.T) {
 	store.On(
 		"ListVTXOsByStatus", t.Context(), VTXOStatusLive,
 	).Return([]*Descriptor{vtxo2}, nil).Once()
+	spendingVTXO := *vtxo1
+	spendingVTXO.Status = VTXOStatusSpending
+	store.On("ListLiveVTXOs", t.Context()).Return(
+		[]*Descriptor{nil, &spendingVTXO, vtxo2}, nil,
+	).Once()
 
 	result = mgr.Receive(t.Context(), &SelectAndReserveSpendRequest{
 		TargetAmount: 40000,
 	})
 	_, err = result.Unpack()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "insufficient funds")
+	require.ErrorIs(t, err, ErrVTXOLiquidityLocked)
+	require.NotErrorIs(t, err, ErrInsufficientSpendableFunds)
 }
 
 // =============================================================================
@@ -667,6 +677,7 @@ func TestSpendReserveRejectedWhenPendingForfeit(t *testing.T) {
 	})
 	_, err = result.Unpack()
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrVTXOLiquidityLocked)
 	require.Contains(t, err.Error(), "cannot reserve for spend")
 }
 
@@ -992,6 +1003,7 @@ func TestRollbackOnPartialSpendFailure(t *testing.T) {
 	})
 	_, err := result.Unpack()
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrVTXOLiquidityLocked)
 
 	// vtxo1 should be rolled back to LiveState.
 	refAny1, ok := mgr.actors[vtxo1.Outpoint]
@@ -1342,6 +1354,9 @@ func TestSelectAndReserveForfeitInsufficientFunds(t *testing.T) {
 	store.On(
 		"ListVTXOsByStatus", t.Context(), VTXOStatusLive,
 	).Return([]*Descriptor{vtxo1}, nil)
+	store.On("ListLiveVTXOs", t.Context()).Return(
+		[]*Descriptor{vtxo1}, nil,
+	)
 
 	result := mgr.Receive(
 		t.Context(), &SelectAndReserveForfeitRequest{
@@ -1350,7 +1365,7 @@ func TestSelectAndReserveForfeitInsufficientFunds(t *testing.T) {
 	)
 	_, err := result.Unpack()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "insufficient funds")
+	require.ErrorIs(t, err, ErrInsufficientSpendableFunds)
 }
 
 // TestSelectAndReserveForfeitSkipsNonLive verifies that VTXOs already


### PR DESCRIPTION
## Summary

Fixes #607.

Concurrent OOR sends that race on the same spendable liquidity now distinguish the two important failure modes:

- true spendable-funds shortfall returns a typed insufficient-funds admission error
- liquidity present but locked by an in-flight VTXO operation returns a typed locked-liquidity admission error

The daemon maps those typed errors to caller-actionable gRPC codes instead of collapsing all wallet-selection failures into `Internal`:

- locked liquidity -> `Aborted`, so callers know retrying later is reasonable
- true insufficient spendable funds -> `ResourceExhausted`
- unexpected selection failures still -> `Internal`

This also keeps stale-store/actor-state races covered: if selection sees an apparently live VTXO but the actor rejects the reserve because it is already pending/spending, that path is treated as locked-liquidity contention too.

## Testing

- `go test ./vtxo -run 'TestSelectAndReserveSpend(InsufficientFunds|DoubleExclusion|ReserveRejectedWhenPendingForfeit)|TestRollbackOnPartialSpendFailure|TestSelectAndReserveForfeitInsufficientFunds' -count=1`\n- `go test ./darepod -run TestVTXOAdmissionCode -count=1`\n- `go test ./vtxo ./darepod ./wallet -count=1`\n- `make fmt-changed`\n- `make lint-changed-local`\n- `make fmt-changed-check`\n- `make commitmsg-lint range=origin/main..HEAD`