### PR TITLE
swapwallet: surface exit activity rows

### DIFF
--- a/swapwallet/admin.go
+++ b/swapwallet/admin.go
@@ -103,8 +103,9 @@ func (s *Service) unlock(ctx context.Context, req *walletdkrpc.UnlockRequest) (
 	}, nil
 }
 
-// exit proxies daemonrpc.Unroll. The wallet layer doesn't track the exit
-// job locally; the daemon's unroll registry is the authoritative store.
+// exit proxies daemonrpc.Unroll. The daemon's unroll registry remains the
+// authoritative store; the wallet layer tracks only the friendly pending row
+// so activity can show the user's exit attempt immediately.
 func (s *Service) exit(ctx context.Context, req *walletdkrpc.ExitRequest) (
 	*walletdkrpc.ExitResponse, error) {
 
@@ -128,6 +129,10 @@ func (s *Service) exit(ctx context.Context, req *walletdkrpc.ExitRequest) (
 	if err != nil {
 		return nil, status.Errorf(status.Code(err), "exit: %v", err)
 	}
+
+	entry := unilateralExitEntryStub(req.GetOutpoint())
+	s.runtime.trackPendingEntryWithoutTimeout(entry)
+	s.runtime.emit(entry)
 
 	return &walletdkrpc.ExitResponse{
 		Created: resp.GetCreated(),

--- a/swapwallet/admin_test.go
+++ b/swapwallet/admin_test.go
@@ -168,6 +168,17 @@ func TestExitProxiesUnroll(t *testing.T) {
 	require.True(t, resp.GetCreated())
 	require.Equal(t, "exit-job-42", resp.GetActorId())
 	require.Equal(t, "abc:0", rpc.unrollLast.GetOutpoint())
+
+	entries := svc.runtime.pendingSnapshot()
+	require.Len(t, entries, 1)
+	require.Equal(t, "abc:0", entries[0].GetId())
+	require.Equal(
+		t, walletdkrpc.EntryKind_ENTRY_KIND_EXIT, entries[0].GetKind(),
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		entries[0].GetStatus(),
+	)
 }
 
 // TestExitRejectsEmptyOutpoint confirms a missing outpoint is rejected

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -160,6 +160,19 @@ func (h *history) listActivity(ctx context.Context,
 		entries = append(entries, pendingBoarding...)
 	}
 
+	if h.shouldInclude(kindFilter, walletdkrpc.EntryKind_ENTRY_KIND_EXIT) {
+		exitEntries, err := h.collectUnilateralExitEntries(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("collect unilateral exit "+
+				"entries: %w", err)
+		}
+		entries = append(entries, exitEntries...)
+
+		entries = append(
+			entries, h.collectWalletLocalPendingEntries(ctx)...,
+		)
+	}
+
 	// Apply wallet-level overlay (deadline timeout) BEFORE filtering so
 	// a stuck entry appears as FAILED in the wallet view even when the
 	// caller asked for pending_only=false.
@@ -338,11 +351,146 @@ func (h *history) collectPendingBoardingEntries(ctx context.Context) (
 			CreatedAtUnix: now,
 			UpdatedAtUnix: now,
 			Progress: &walletdkrpc.WalletEntryProgress{
-				Phase:      walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_WAITING_FOR_CONFIRMATION,
+				Phase: walletdkrpc.
+					WalletEntryPhase_WALLET_ENTRY_PHASE_WAITING_FOR_CONFIRMATION,
 				PhaseLabel: "waiting_for_confirmation",
 			},
 		},
 	}, nil
+}
+
+// collectUnilateralExitEntries synthesizes activity rows for VTXOs already
+// handed to the unroll subsystem. The unroll job store is the durable source
+// of truth for unilateral exits; activity consumes it through the existing
+// VTXO inventory plus per-outpoint ExitStatus surface.
+func (h *history) collectUnilateralExitEntries(ctx context.Context) (
+	[]*walletdkrpc.WalletEntry, error) {
+
+	if h.deps.RPCServer == nil {
+		return nil, nil
+	}
+
+	resp, err := h.deps.RPCServer.ListVTXOs(
+		ctx, &daemonrpc.ListVTXOsRequest{
+			StatusFilter: daemonrpc.
+				VTXOStatus_VTXO_STATUS_UNILATERAL_EXIT,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list unilateral-exit vtxos: %w", err)
+	}
+
+	pendingByID := make(map[string]*walletdkrpc.WalletEntry)
+	if h.runtime != nil {
+		for _, entry := range h.runtime.pendingSnapshot() {
+			pendingByID[entry.GetId()] = entry
+		}
+	}
+
+	out := make([]*walletdkrpc.WalletEntry, 0, len(resp.GetVtxos()))
+	for _, vtxo := range resp.GetVtxos() {
+		entry := unilateralExitEntryFromVTXO(vtxo)
+		if entry.GetId() == "" {
+			continue
+		}
+		if pending := pendingByID[entry.GetId()]; pending != nil {
+			if pending.GetCreatedAtUnix() != 0 {
+				entry.CreatedAtUnix = pending.GetCreatedAtUnix()
+			}
+			if pending.GetUpdatedAtUnix() != 0 {
+				entry.UpdatedAtUnix = pending.GetUpdatedAtUnix()
+			}
+		}
+
+		if err := h.decorateExitEntry(ctx, entry); err != nil {
+			return nil, err
+		}
+
+		out = append(out, entry)
+	}
+
+	return out, nil
+}
+
+// collectWalletLocalPendingEntries returns pending rows created by wallet RPC
+// calls before their durable terminal source is available. Cooperative leave
+// uses this path immediately after Send returns; unilateral exit uses it until
+// the unroll status/VTXO projection catches up.
+func (h *history) collectWalletLocalPendingEntries(
+	ctx context.Context) []*walletdkrpc.WalletEntry {
+
+	if h.runtime == nil {
+		return nil
+	}
+
+	entries := h.runtime.pendingSnapshot()
+	for _, entry := range entries {
+		if entry.GetKind() != walletdkrpc.EntryKind_ENTRY_KIND_EXIT {
+			continue
+		}
+
+		// Status lookup is best-effort for wallet-local entries. A
+		// missing unroll job usually means this is a cooperative
+		// leave pending row, not a unilateral exit.
+		_ = h.decorateExitEntry(ctx, entry)
+	}
+
+	return entries
+}
+
+// unilateralExitEntryFromVTXO projects a VTXO in UNILATERAL_EXIT into a
+// wallet-facing EXIT activity row. The amount is negative because value is
+// leaving Ark custody.
+func unilateralExitEntryFromVTXO(v *daemonrpc.VTXO) *walletdkrpc.WalletEntry {
+	if v == nil {
+		return nil
+	}
+
+	now := nowUnix()
+
+	return &walletdkrpc.WalletEntry{
+		Id:            v.GetOutpoint(),
+		Kind:          walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+		Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		AmountSat:     -v.GetAmountSat(),
+		Counterparty:  "unilateral",
+		CreatedAtUnix: now,
+		UpdatedAtUnix: now,
+		Progress: &walletdkrpc.WalletEntryProgress{
+			Phase: walletdkrpc.
+				WalletEntryPhase_WALLET_ENTRY_PHASE_SETTLING,
+			PhaseLabel:   "unilateral_exit",
+			VtxoOutpoint: v.GetOutpoint(),
+		},
+	}
+}
+
+// decorateExitEntry applies unroll status to an EXIT entry when the daemon has
+// a unilateral-exit job for the entry id. Cooperative leave entries do not have
+// unroll jobs, so Found=false leaves the original pending row untouched.
+func (h *history) decorateExitEntry(ctx context.Context,
+	entry *walletdkrpc.WalletEntry) error {
+
+	if h.deps.RPCServer == nil || entry == nil || entry.GetId() == "" {
+		return nil
+	}
+
+	resp, err := h.deps.RPCServer.GetUnrollStatus(
+		ctx, &daemonrpc.GetUnrollStatusRequest{
+			Outpoint: entry.GetId(),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("get unroll status %s: %w", entry.GetId(),
+			err)
+	}
+	if !resp.GetFound() {
+		return nil
+	}
+
+	applyUnrollStatus(entry, resp)
+
+	return nil
 }
 
 // collectLedgerEntries reads the daemon's unified ledger+sweep page and

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
@@ -1101,6 +1102,178 @@ func TestHistoryWalletRowsApplyTimedOutOverlay(t *testing.T) {
 		t, "timed_out",
 		resp.GetActivity().GetEntries()[0].GetFailureReason(),
 	)
+}
+
+// TestHistoryIncludesWalletLocalPendingExit confirms a cooperative leave row
+// returned by Send remains visible in activity before any terminal ledger row
+// exists. The regression in issue #612 was that Send returned an EXIT entry,
+// but ListActivity only read swap/ledger sources and therefore dropped the
+// wallet-local pending row immediately.
+func TestHistoryIncludesWalletLocalPendingExit(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{}
+	rpc.unrollStatusResp = &daemonrpc.GetUnrollStatusResponse{
+		Found: false,
+	}
+
+	pending := leaveEntryStub(
+		[]string{
+			"leave-outpoint:1",
+		}, "bcrt1qdest",
+		50_000, "user note",
+	)
+	h.runtime.trackPendingEntry(pending)
+
+	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{})
+	require.NoError(t, err)
+
+	entries := resp.GetActivity().GetEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, "leave-outpoint:1", entries[0].GetId())
+	require.Equal(
+		t, walletdkrpc.EntryKind_ENTRY_KIND_EXIT, entries[0].GetKind(),
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		entries[0].GetStatus(),
+	)
+	require.Equal(t, int64(-50_000), entries[0].GetAmountSat())
+	require.Equal(t, "user note", entries[0].GetNote())
+}
+
+// TestHistoryKeepsCSVPendingUnilateralExitPendingAfterDeadline confirms the
+// wallet-local timeout overlay cannot clobber the unroll subsystem's
+// authoritative non-terminal status. Unilateral exits normally wait through a
+// CSV delay that exceeds the generic wallet deadline, so a CSV_PENDING job must
+// remain PENDING instead of being projected to FAILED.
+func TestHistoryKeepsCSVPendingUnilateralExitPendingAfterDeadline(
+	t *testing.T) {
+
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{}
+	rpc.listVTXOsResp = &daemonrpc.ListVTXOsResponse{
+		Vtxos: []*daemonrpc.VTXO{
+			{
+				Outpoint:  "exit-outpoint:0",
+				AmountSat: 7_000,
+				Status: daemonrpc.
+					VTXOStatus_VTXO_STATUS_UNILATERAL_EXIT,
+			},
+		},
+	}
+	rpc.unrollStatusResp = &daemonrpc.GetUnrollStatusResponse{
+		Found:  true,
+		Status: daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_CSV_PENDING,
+	}
+
+	pending := unilateralExitEntryStub("exit-outpoint:0")
+	pending.CreatedAtUnix = 123
+	pending.UpdatedAtUnix = 124
+	h.runtime.trackPendingEntryWithoutTimeout(pending)
+	h.runtime.applyDeadlines(time.Now().Add(2 * defaultWalletDeadline))
+
+	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{})
+	require.NoError(t, err)
+
+	entries := resp.GetActivity().GetEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, "exit-outpoint:0", entries[0].GetId())
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		entries[0].GetStatus(),
+	)
+	require.Equal(
+		t, "csv_pending", entries[0].GetProgress().GetPhaseLabel(),
+	)
+	require.Equal(t, int64(123), entries[0].GetCreatedAtUnix())
+	require.Equal(t, int64(124), entries[0].GetUpdatedAtUnix())
+	require.Empty(t, entries[0].GetFailureReason())
+}
+
+// TestHistoryExitKindFilterGatesWalletLocalPendingRows confirms filtering out
+// EXIT also skips wallet-local pending rows before they issue per-row
+// ExitStatus lookups. The filterEntries pass would drop them eventually, but
+// gating at collection avoids useless unroll-status RPCs for other views.
+func TestHistoryExitKindFilterGatesWalletLocalPendingRows(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{}
+
+	h.runtime.trackPendingEntryWithoutTimeout(
+		leaveEntryStub(
+			[]string{
+				"leave-outpoint:1",
+			}, "bcrt1qdest",
+			50_000, "",
+		),
+	)
+
+	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{
+		Kinds: []walletdkrpc.EntryKind{
+			walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT,
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.GetActivity().GetEntries())
+	require.Zero(t, rpc.unrollStatusCalls)
+	require.Zero(t, rpc.listVTXOsCalls)
+}
+
+// TestHistoryIncludesUnilateralExitVTXO confirms a VTXO that has already been
+// handed to the unroll subsystem appears as EXIT activity even after the
+// original Exit RPC response is gone. The row is decorated from ExitStatus so
+// terminal unroll failures surface as FAILED rather than staying invisible or
+// permanently pending.
+func TestHistoryIncludesUnilateralExitVTXO(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{}
+	rpc.listVTXOsResp = &daemonrpc.ListVTXOsResponse{
+		Vtxos: []*daemonrpc.VTXO{
+			{
+				Outpoint:  "exit-outpoint:0",
+				AmountSat: 7_000,
+				Status: daemonrpc.
+					VTXOStatus_VTXO_STATUS_UNILATERAL_EXIT,
+			},
+		},
+	}
+	rpc.unrollStatusResp = &daemonrpc.GetUnrollStatusResponse{
+		Found:     true,
+		Status:    daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_FAILED,
+		LastError: "broadcast failed",
+	}
+
+	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{})
+	require.NoError(t, err)
+
+	entries := resp.GetActivity().GetEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, "exit-outpoint:0", entries[0].GetId())
+	require.Equal(
+		t, walletdkrpc.EntryKind_ENTRY_KIND_EXIT, entries[0].GetKind(),
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_FAILED,
+		entries[0].GetStatus(),
+	)
+	require.Equal(t, int64(-7_000), entries[0].GetAmountSat())
+	require.Equal(t, "broadcast failed", entries[0].GetFailureReason())
+	require.Equal(
+		t, daemonrpc.VTXOStatus_VTXO_STATUS_UNILATERAL_EXIT,
+		rpc.listVTXOsLastReq.GetStatusFilter(),
+	)
+	require.Equal(t, "exit-outpoint:0", rpc.unrollStatusLast.GetOutpoint())
 }
 
 // TestHistorySwapRowIdIsPaymentHash confirms that a swap-side row

--- a/swapwallet/normalize.go
+++ b/swapwallet/normalize.go
@@ -469,3 +469,78 @@ func leaveEntryStub(queuedOutpoints []string, destination string, amtSat int64,
 		},
 	}
 }
+
+// unilateralExitEntryStub builds the initial WalletEntry tracked after the
+// user explicitly requests a unilateral exit.
+func unilateralExitEntryStub(outpoint string) *walletdkrpc.WalletEntry {
+	createdAt := nowUnix()
+
+	return &walletdkrpc.WalletEntry{
+		Id:            outpoint,
+		Kind:          walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+		Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		Counterparty:  "unilateral",
+		CreatedAtUnix: createdAt,
+		UpdatedAtUnix: createdAt,
+		Progress: &walletdkrpc.WalletEntryProgress{
+			Phase: walletdkrpc.
+				WalletEntryPhase_WALLET_ENTRY_PHASE_REQUEST_CREATED,
+			PhaseLabel:   "request_created",
+			VtxoOutpoint: outpoint,
+		},
+	}
+}
+
+// applyUnrollStatus projects daemon unroll status onto an EXIT activity row.
+func applyUnrollStatus(entry *walletdkrpc.WalletEntry,
+	resp *daemonrpc.GetUnrollStatusResponse) {
+
+	if entry == nil || resp == nil || !resp.GetFound() {
+		return
+	}
+
+	progress := entry.GetProgress()
+	if progress == nil {
+		progress = &walletdkrpc.WalletEntryProgress{}
+		entry.Progress = progress
+	}
+	if progress.GetVtxoOutpoint() == "" {
+		progress.VtxoOutpoint = entry.GetId()
+	}
+	progress.Txid = resp.GetSweepTxid()
+
+	switch resp.GetStatus() {
+	case daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_COMPLETED:
+		entry.Status = walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE
+		progress.Phase = walletdkrpc.
+			WalletEntryPhase_WALLET_ENTRY_PHASE_CONFIRMED
+		progress.PhaseLabel = "confirmed"
+
+	case daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_FAILED:
+		entry.Status = walletdkrpc.EntryStatus_ENTRY_STATUS_FAILED
+		entry.FailureReason = resp.GetLastError()
+		progress.Phase = walletdkrpc.
+			WalletEntryPhase_WALLET_ENTRY_PHASE_FAILED
+		progress.PhaseLabel = "failed"
+
+	case daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_CSV_PENDING:
+		entry.Status = walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING
+		progress.Phase = walletdkrpc.
+			WalletEntryPhase_WALLET_ENTRY_PHASE_WAITING_FOR_CONFIRMATION
+		progress.PhaseLabel = "csv_pending"
+
+	case daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_SWEEPING:
+		entry.Status = walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING
+		progress.Phase = walletdkrpc.
+			WalletEntryPhase_WALLET_ENTRY_PHASE_SETTLING
+		progress.PhaseLabel = "sweeping"
+
+	case daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_PENDING,
+		daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_MATERIALIZING:
+
+		entry.Status = walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING
+		progress.Phase = walletdkrpc.
+			WalletEntryPhase_WALLET_ENTRY_PHASE_SETTLING
+		progress.PhaseLabel = "unilateral_exit"
+	}
+}

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -384,12 +384,8 @@ func (r *router) sendOnchainIntent(ctx context.Context,
 	// correlation between the pending row and the eventual sweep
 	// ledger row is deferred to v2 — see swapwallet/doc.go for the
 	// limitation note.
-	r.runtime.trackPending(
-		entry.GetId(), entry.GetKind(),
-		unixToTime(
-			entry.GetCreatedAtUnix(),
-		),
-	)
+	r.runtime.trackPendingEntryWithoutTimeout(entry)
+	r.runtime.emit(entry)
 
 	return &walletdkrpc.SendResponse{
 		Entry:           entry,

--- a/swapwallet/runtime.go
+++ b/swapwallet/runtime.go
@@ -26,6 +26,8 @@ type pendingEntry struct {
 	kind      walletdkrpc.EntryKind
 	createdAt time.Time
 	deadline  time.Time
+	noTimeout bool
+	entry     *walletdkrpc.WalletEntry
 }
 
 // Runtime owns the swapwallet package's background lifecycle: the unified
@@ -159,15 +161,98 @@ func (r *Runtime) resumeAll(ctx context.Context) {
 func (r *Runtime) trackPending(id string, kind walletdkrpc.EntryKind,
 	createdAt time.Time) {
 
+	r.trackPendingEntryAt(&walletdkrpc.WalletEntry{
+		Id:            id,
+		Kind:          kind,
+		Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		CreatedAtUnix: createdAt.Unix(),
+		UpdatedAtUnix: createdAt.Unix(),
+	}, createdAt, false)
+}
+
+// trackPendingEntry records a wallet-local pending activity row. Unlike swap
+// rows, these entries do not have a durable swap FSM feeding List/Subscribe
+// updates, so the runtime keeps the friendly WalletEntry snapshot that should
+// appear in activity until a backing ledger or status source supersedes it.
+func (r *Runtime) trackPendingEntry(entry *walletdkrpc.WalletEntry) {
+	if entry == nil || entry.GetId() == "" {
+		return
+	}
+
+	r.trackPendingEntryAt(
+		entry,
+		unixToTime(
+			entry.GetCreatedAtUnix(),
+		),
+		false,
+	)
+}
+
+// trackPendingEntryWithoutTimeout records a wallet-local pending activity row
+// that should remain pending until a source of truth supersedes it. Cooperative
+// leave uses this because a successful on-chain round can take longer than the
+// generic wallet deadline, and the v1 activity layer cannot yet correlate the
+// pending outpoint id to the later confirmed sweep txid.
+func (r *Runtime) trackPendingEntryWithoutTimeout(
+	entry *walletdkrpc.WalletEntry) {
+
+	if entry == nil || entry.GetId() == "" {
+		return
+	}
+
+	r.trackPendingEntryAt(
+		entry,
+		unixToTime(
+			entry.GetCreatedAtUnix(),
+		),
+		true,
+	)
+}
+
+// trackPendingEntryAt is the shared implementation for callers that already
+// have a precise submit time and callers that only have a WalletEntry unix
+// timestamp.
+func (r *Runtime) trackPendingEntryAt(entry *walletdkrpc.WalletEntry,
+	createdAt time.Time, noTimeout bool) {
+
+	if entry == nil || entry.GetId() == "" {
+		return
+	}
+
 	r.pendingMu.Lock()
 	defer r.pendingMu.Unlock()
 
-	if existing, ok := r.pending[id]; ok {
+	entryCopy := cloneWalletEntry(entry)
+	if entryCopy.Status == walletdkrpc.EntryStatus_ENTRY_STATUS_UNSPECIFIED {
+		entryCopy.Status = walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING
+	}
+
+	if entryCopy.GetCreatedAtUnix() == 0 {
+		entryCopy.CreatedAtUnix = createdAt.Unix()
+	}
+	if entryCopy.GetUpdatedAtUnix() == 0 {
+		entryCopy.UpdatedAtUnix = entryCopy.GetCreatedAtUnix()
+	}
+
+	if existing, ok := r.pending[entryCopy.GetId()]; ok {
 		// Already tracked: preserve the original first-observed
-		// createdAt and deadline. Only refresh the kind in case
-		// the source row's direction was lazily populated.
-		existing.kind = kind
-		r.pending[id] = existing
+		// timestamps and deadline. Refresh the rest of the snapshot
+		// in case the source row's direction or metadata was lazily
+		// populated.
+		existing.kind = entryCopy.GetKind()
+		if existing.entry != nil {
+			if existing.entry.GetCreatedAtUnix() != 0 {
+				entryCopy.CreatedAtUnix = existing.entry.
+					GetCreatedAtUnix()
+			}
+			if existing.entry.GetUpdatedAtUnix() != 0 {
+				entryCopy.UpdatedAtUnix = existing.entry.
+					GetUpdatedAtUnix()
+			}
+		}
+		existing.entry = entryCopy
+		existing.noTimeout = noTimeout
+		r.pending[entryCopy.GetId()] = existing
 
 		return
 	}
@@ -176,12 +261,38 @@ func (r *Runtime) trackPending(id string, kind walletdkrpc.EntryKind,
 	// createdAt. This is the load-bearing fix for the
 	// restart-resume-and-immediately-time-out failure mode.
 	now := time.Now()
-	r.pending[id] = pendingEntry{
-		id:        id,
-		kind:      kind,
+	r.pending[entryCopy.GetId()] = pendingEntry{
+		id:        entryCopy.GetId(),
+		kind:      entryCopy.GetKind(),
 		createdAt: createdAt,
 		deadline:  now.Add(r.deps.resolveDeadline()),
+		noTimeout: noTimeout,
+		entry:     entryCopy,
 	}
+}
+
+// pendingSnapshot returns copies of the wallet-local pending entries that
+// should be included in List/Subscribe snapshots.
+func (r *Runtime) pendingSnapshot() []*walletdkrpc.WalletEntry {
+	r.pendingMu.Lock()
+	defer r.pendingMu.Unlock()
+
+	out := make([]*walletdkrpc.WalletEntry, 0, len(r.pending))
+	for _, pending := range r.pending {
+		entry := cloneWalletEntry(pending.entry)
+		if entry == nil {
+			entry = &walletdkrpc.WalletEntry{
+				Id:            pending.id,
+				Kind:          pending.kind,
+				Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+				CreatedAtUnix: pending.createdAt.Unix(),
+				UpdatedAtUnix: pending.createdAt.Unix(),
+			}
+		}
+		out = append(out, entry)
+	}
+
+	return out
 }
 
 // clearPending removes the runtime record for an entry that has reached a
@@ -258,6 +369,9 @@ func (r *Runtime) markTimedOut(now time.Time) []*walletdkrpc.WalletEntry {
 		if _, alreadyTimedOut := r.overlay[id]; alreadyTimedOut {
 			continue
 		}
+		if entry.noTimeout {
+			continue
+		}
 		if now.Before(entry.deadline) {
 			continue
 		}
@@ -267,17 +381,38 @@ func (r *Runtime) markTimedOut(now time.Time) []*walletdkrpc.WalletEntry {
 			failureReason: "timed_out",
 		}
 		r.overlay[id] = ov
-		notify = append(notify, &walletdkrpc.WalletEntry{
-			Id:            id,
-			Kind:          entry.kind,
-			Status:        ov.status,
-			FailureReason: ov.failureReason,
-			CreatedAtUnix: entry.createdAt.Unix(),
-			UpdatedAtUnix: now.Unix(),
-		})
+		notifyEntry := cloneWalletEntry(entry.entry)
+		if notifyEntry == nil {
+			notifyEntry = &walletdkrpc.WalletEntry{
+				Id:            id,
+				Kind:          entry.kind,
+				CreatedAtUnix: entry.createdAt.Unix(),
+			}
+		}
+		notifyEntry.Status = ov.status
+		notifyEntry.FailureReason = ov.failureReason
+		notifyEntry.UpdatedAtUnix = now.Unix()
+		notify = append(notify, notifyEntry)
 	}
 
 	return notify
+}
+
+// cloneWalletEntry returns a shallow copy with mutable nested fields copied
+// where the runtime updates them. Request oneofs are immutable after entry
+// creation in this package, so a shallow copy is sufficient for those.
+func cloneWalletEntry(entry *walletdkrpc.WalletEntry) *walletdkrpc.WalletEntry {
+	if entry == nil {
+		return nil
+	}
+
+	entryCopy := *entry
+	if entry.GetProgress() != nil {
+		progress := *entry.GetProgress()
+		entryCopy.Progress = &progress
+	}
+
+	return &entryCopy
 }
 
 // isSwapKind reports pinned SEND/RECV rows whose lifecycle is backed by the

--- a/swapwallet/runtime_test.go
+++ b/swapwallet/runtime_test.go
@@ -273,6 +273,44 @@ func TestDeadlineWatcherEmitsTimeoutToSubscribers(t *testing.T) {
 	}
 }
 
+// TestTrackPendingEntryPreservesTimestampsOnRefresh confirms that refreshing a
+// wallet-local pending row cannot make an existing activity row look new again.
+// Some later sources rebuild entries with fallback timestamps, so the runtime
+// keeps the original created/updated values while still accepting refreshed
+// metadata like amount and counterparty.
+func TestTrackPendingEntryPreservesTimestampsOnRefresh(t *testing.T) {
+	t.Parallel()
+
+	r := newRuntime(t.Context(), &Deps{})
+	defer r.stop()
+
+	r.trackPendingEntry(&walletdkrpc.WalletEntry{
+		Id:            "exit-outpoint:0",
+		Kind:          walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+		Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		AmountSat:     -1_000,
+		Counterparty:  "first",
+		CreatedAtUnix: 100,
+		UpdatedAtUnix: 100,
+	})
+	r.trackPendingEntry(&walletdkrpc.WalletEntry{
+		Id:            "exit-outpoint:0",
+		Kind:          walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+		Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		AmountSat:     -2_000,
+		Counterparty:  "refreshed",
+		CreatedAtUnix: 200,
+		UpdatedAtUnix: 250,
+	})
+
+	entries := r.pendingSnapshot()
+	require.Len(t, entries, 1)
+	require.Equal(t, int64(100), entries[0].GetCreatedAtUnix())
+	require.Equal(t, int64(100), entries[0].GetUpdatedAtUnix())
+	require.Equal(t, int64(-2_000), entries[0].GetAmountSat())
+	require.Equal(t, "refreshed", entries[0].GetCounterparty())
+}
+
 // TestDeadlineWatcherDoesNotReEmitAlreadyTimedOut asserts that running
 // applyDeadlines again on the same tick does not re-emit; the watcher
 // only emits on the elevation edge.
@@ -302,6 +340,39 @@ func TestDeadlineWatcherDoesNotReEmitAlreadyTimedOut(t *testing.T) {
 			"watcher must not re-emit on an already-timed-out " +
 				"entry",
 		)
+
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// TestDeadlineWatcherSkipsNoTimeoutEntries asserts that wallet-local rows
+// explicitly marked as source-owned stay pending instead of receiving a
+// synthetic FAILED overlay from the generic wallet deadline. Cooperative
+// leave uses this mode because the confirmed sweep row has a different v1 id,
+// so timing out the pending stub would create a false failed exit beside the
+// later successful on-chain row.
+func TestDeadlineWatcherSkipsNoTimeoutEntries(t *testing.T) {
+	t.Parallel()
+
+	deadline := 50 * time.Millisecond
+	deps := &Deps{
+		WalletDeadline: deadline,
+	}
+	r := newRuntime(t.Context(), deps)
+	defer r.stop()
+
+	sub := r.subscribe()
+	entry := leaveEntryStub([]string{"exit:0"}, "bcrt1qdest", 1_000, "")
+	r.trackPendingEntryWithoutTimeout(entry)
+
+	r.applyDeadlines(time.Now().Add(2 * deadline))
+
+	_, ok := r.overlayFor("exit:0")
+	require.False(t, ok, "no-timeout row must not receive overlay")
+
+	select {
+	case got := <-sub:
+		t.Fatalf("no-timeout row must not emit timeout update: %v", got)
 
 	case <-time.After(50 * time.Millisecond):
 	}


### PR DESCRIPTION
## Summary

- include wallet-local pending EXIT rows in activity snapshots so cooperative leave appears after `send --onchain`
- track unilateral `exit` requests as pending activity rows and emit them to subscribers
- synthesize restart-safe unilateral EXIT rows from VTXOs in `UNILATERAL_EXIT`, decorating them from `ExitStatus` so terminal failures show as FAILED

Fixes #612

## Test

- go test -tags 'walletdkrpc swapruntime' ./swapwallet
- make fmt-changed
- make lint-changed-local
- make commitmsg-lint range="origin/main..HEAD"
