### PR TITLE
oor: reject sub-dust recipients

### DIFF
--- a/darepod/rpc_oor_custom_input_test.go
+++ b/darepod/rpc_oor_custom_input_test.go
@@ -56,7 +56,7 @@ func newCustomOORRPCFixture(t *testing.T) *customOORRPCFixture {
 		getInfoResponse: &arkrpc.GetInfoResponse{
 			Pubkey:        serverPubkey,
 			VtxoExitDelay: 144,
-			DustLimit:     1,
+			DustLimit:     1000,
 		},
 	}
 
@@ -107,6 +107,32 @@ func newCustomOORRPCFixture(t *testing.T) *customOORRPCFixture {
 		clientPriv: receiverPriv,
 		outpoint:   outpoint,
 	}
+}
+
+// TestPrepareOORRejectsRecipientBelowDust verifies prepared custom-input OOR
+// packages use the same recipient dust guard as submitted OOR sends. The swap
+// cooperative-refund flow asks PrepareOOR to build a deterministic package
+// before any operator authorization happens, so a sub-dust recipient amount
+// must be rejected at this boundary instead of producing checkpoint material
+// that would later create an unusable receiver VTXO.
+func TestPrepareOORRejectsRecipientBelowDust(t *testing.T) {
+	t.Parallel()
+
+	fixture := newCustomOORRPCFixture(t)
+	fixture.recipient.AmountSat = 999
+
+	_, err := fixture.rpcServer.PrepareOOR(
+		t.Context(), &daemonrpc.PrepareOORRequest{
+			Recipient: fixture.recipient,
+			CustomInputs: []*daemonrpc.CustomOORInput{
+				fixture.customIn,
+			},
+		},
+	)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.ErrorContains(
+		t, err, "amount 999 below operator dust_limit 1000",
+	)
 }
 
 // TestPrepareOORCustomInputMapsPreparedInput exercises the daemon-level

--- a/darepod/rpc_oor_idempotency_test.go
+++ b/darepod/rpc_oor_idempotency_test.go
@@ -158,6 +158,61 @@ func (a *blockingSendOORActor) Receive(ctx context.Context,
 	}
 }
 
+// TestSendOORRejectsRecipientBelowDustBeforeWalletSelection verifies the
+// daemon enforces the operator's advertised dust limit before it selects wallet
+// inputs or submits work to the OOR actor. This is the daemon-side guard behind
+// `darepocli ark send oor`: a caller that asks to create a sub-dust recipient
+// VTXO must fail synchronously instead of leaving the receiver with a live VTXO
+// they cannot later spend cooperatively.
+func TestSendOORRejectsRecipientBelowDustBeforeWalletSelection(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	recipientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	const (
+		dustLimit = int64(1000)
+		amountSat = int64(999)
+		exitDelay = uint32(10)
+	)
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+
+	server := &Server{
+		cfg:         &Config{},
+		log:         btclog.Disabled,
+		walletReady: walletReady,
+		chainParams: &chaincfg.RegressionNetParams,
+		serverConn: newBufconnClient(t, &fakeArkService{
+			getInfoResponse: &arkrpc.GetInfoResponse{
+				Pubkey: operatorKey.
+					PubKey().
+					SerializeCompressed(),
+				VtxoExitDelay: exitDelay,
+				DustLimit:     dustLimit,
+			},
+		}),
+	}
+
+	rpcServer := NewRPCServer(server)
+	recipient := sendOORPolicyRecipient(
+		t, recipientKey.PubKey(), operatorKey.PubKey(), exitDelay,
+		amountSat,
+	)
+
+	_, err = rpcServer.SendOOR(t.Context(), &daemonrpc.SendOORRequest{
+		Recipient: recipient,
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.ErrorContains(
+		t, err, "amount 999 below operator dust_limit 1000",
+	)
+}
+
 // TestSendOORReturnsExistingIdempotencyKeyBeforeWalletSelection verifies a
 // keyed retry returns the existing OOR session before acquiring fresh wallet
 // inputs.

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -284,6 +284,24 @@ func appendOORChangeRecipient(ctx context.Context,
 	return out, change, nil
 }
 
+// validateOORRecipientDust enforces the operator's advertised output floor for
+// caller-selected OOR recipients. Change outputs are checked later after input
+// selection; this guard prevents creating a receiver VTXO that the operator
+// would not accept in subsequent cooperative spends.
+func validateOORRecipientDust(amountSat int64, dustLimit btcutil.Amount) error {
+	if dustLimit <= 0 {
+		return nil
+	}
+
+	amount := btcutil.Amount(amountSat)
+	if amount >= dustLimit {
+		return nil
+	}
+
+	return status.Errorf(codes.InvalidArgument, "amount %d below operator "+
+		"dust_limit %d", amount, dustLimit)
+}
+
 // walletStateToProto maps the daemon's in-process WalletState enum to
 // the public daemonrpc.WalletState wire enum.
 func walletStateToProto(s WalletState) daemonrpc.WalletState {
@@ -1793,8 +1811,24 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		return nil, err
 	}
 
-	// For dry_run, validate inputs and return a preview without
-	// contacting the operator.
+	// Fetch operator terms for the checkpoint policy.
+	phaseStart = time.Now()
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	operatorTermsDuration = time.Since(phaseStart)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to fetch "+
+			"operator terms: %v", err)
+	}
+
+	if err := validateOORRecipientDust(
+		req.Recipient.AmountSat, terms.DustLimit,
+	); err != nil {
+		return nil, err
+	}
+
+	// For dry_run, return a preview before selecting wallet inputs or
+	// submitting to the actor. The operator is still queried above so the
+	// preview enforces the current dust limit.
 	if req.DryRun {
 		return &daemonrpc.SendOORResponse{
 			Status: "preview",
@@ -1814,15 +1848,6 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	if r.server.vtxoStore == nil {
 		return nil, status.Errorf(codes.Internal, "VTXO store not "+
 			"initialized")
-	}
-
-	// Fetch operator terms for the checkpoint policy.
-	phaseStart = time.Now()
-	terms, err := r.server.fetchOperatorTerms(ctx)
-	operatorTermsDuration = time.Since(phaseStart)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "unable to fetch "+
-			"operator terms: %v", err)
 	}
 
 	policy := arkscript.CheckpointPolicy{
@@ -2127,6 +2152,12 @@ func (r *RPCServer) PrepareOOR(ctx context.Context,
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to fetch "+
 			"operator terms: %v", err)
+	}
+
+	if err := validateOORRecipientDust(
+		req.GetRecipient().GetAmountSat(), terms.DustLimit,
+	); err != nil {
+		return nil, err
 	}
 
 	recipientPolicyTemplate, err := r.resolveOutputPolicyTemplate(

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/zpay32"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -101,6 +102,17 @@ type swapClientService struct {
 	// invoice to a payer. Production derives this from the daemon's cached
 	// operator terms; tests may leave it nil to disable this preflight.
 	receiveMinAmount func(context.Context) (uint64, error)
+
+	// payMinAmount returns the current minimum output amount that a
+	// pay-swap vHTLC must satisfy before sdk/swaps persists the pay
+	// session. This mirrors the receive guard so high-level wallet RPC
+	// callers fail before a background worker reaches the daemon's SendOOR
+	// dust check.
+	payMinAmount func(context.Context) (uint64, error)
+
+	// chainParams is used only for BOLT-11 pay invoice decoding. Tests that
+	// leave payMinAmount unset do not need to provide it.
+	chainParams *chaincfg.Params
 }
 
 // swapRuntimeClient is the narrow part of sdk/swaps that the daemon
@@ -406,24 +418,30 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 		),
 	)
 
+	dustLimit := func(ctx context.Context) (uint64, error) {
+		info, err := arkClient.GetInfo(ctx)
+		if err != nil {
+			return 0, err
+		}
+
+		return receiveSwapMinAmountSat(info.ServerInfo)
+	}
+
 	service := &swapClientService{
 		client: &swapClientAdapter{
 			client: swapClient,
 		},
-		store:       store,
-		log:         log,
-		rootCtx:     rootCtx,
-		cancel:      cancel,
-		active:      make(map[string]struct{}),
-		subscribers: make(map[chan *swapclientrpc.SwapSummary]struct{}),
-		receiveMinAmount: func(ctx context.Context) (uint64, error) {
-			info, err := arkClient.GetInfo(ctx)
-			if err != nil {
-				return 0, err
-			}
-
-			return receiveSwapMinAmountSat(info.ServerInfo)
-		},
+		store:   store,
+		log:     log,
+		rootCtx: rootCtx,
+		cancel:  cancel,
+		active:  make(map[string]struct{}),
+		subscribers: make(
+			map[chan *swapclientrpc.SwapSummary]struct{},
+		),
+		receiveMinAmount: dustLimit,
+		payMinAmount:     dustLimit,
+		chainParams:      chainParams,
 	}
 
 	cleanup := func() {
@@ -910,6 +928,71 @@ func (s *swapClientService) validateReceiveAmount(ctx context.Context,
 		amountSat, minAmountSat)
 }
 
+// payInvoiceAmountSat decodes the BOLT-11 invoice amount in whole satoshis.
+// The swap pay path funds one Ark vHTLC of this value, so a nil, zero, or
+// millisatoshi-only invoice cannot be admitted through the daemon subserver.
+func payInvoiceAmountSat(invoice string,
+	chainParams *chaincfg.Params) (uint64, error) {
+
+	decoded, err := zpay32.Decode(invoice, chainParams)
+	if err != nil {
+		return 0, err
+	}
+
+	if decoded.MilliSat == nil {
+		return 0, fmt.Errorf("invoice amount is required")
+	}
+
+	amountMSat := uint64(*decoded.MilliSat)
+	if amountMSat == 0 {
+		return 0, fmt.Errorf("invoice amount must be positive")
+	}
+	if amountMSat%1000 != 0 {
+		return 0, fmt.Errorf("invoice amount must be whole satoshis")
+	}
+
+	return amountMSat / 1000, nil
+}
+
+// validatePayInvoiceAmount rejects locally-impossible pay invoices before the
+// SDK persists a swap session and starts a background worker.
+func (s *swapClientService) validatePayInvoiceAmount(ctx context.Context,
+	invoice string) error {
+
+	if s.payMinAmount == nil {
+		return nil
+	}
+
+	if s.chainParams == nil {
+		return status.Error(
+			codes.Internal,
+			"chain params required for pay invoice validation",
+		)
+	}
+
+	amountSat, err := payInvoiceAmountSat(invoice, s.chainParams)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "invoice amount "+
+			"preflight failed: %v", err)
+	}
+
+	minAmountSat, err := s.payMinAmount(ctx)
+	if err != nil {
+		return status.Errorf(codes.Unavailable, "pay amount preflight "+
+			"failed: %v", err)
+	}
+	if minAmountSat == 0 {
+		return nil
+	}
+	if amountSat >= minAmountSat {
+		return nil
+	}
+
+	return status.Errorf(codes.InvalidArgument, "invoice amount_sat %d is "+
+		"below the %d sat minimum for pay swaps (operator dust limit)",
+		amountSat, minAmountSat)
+}
+
 // StartPay persists a pay swap through sdk/swaps, starts or reuses the daemon
 // background worker for the resulting payment hash, and returns the initial
 // durable summary to the RPC caller.
@@ -927,6 +1010,11 @@ func (s *swapClientService) StartPay(ctx context.Context,
 			codes.Unimplemented,
 			"idempotency_key is reserved for future use",
 		)
+	}
+	if err := s.validatePayInvoiceAmount(
+		ctx, req.GetInvoice(),
+	); err != nil {
+		return nil, err
 	}
 
 	session, err := s.client.StartPayViaLightning(

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -15,7 +15,9 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/darepod"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
@@ -24,6 +26,8 @@ import (
 	"github.com/lightninglabs/darepo-client/serverconn"
 	"github.com/lightninglabs/darepo-client/swaprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/zpay32"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -260,6 +264,62 @@ func TestStartPayPreservesRuntimeStatusCode(t *testing.T) {
 		t, status.Convert(err).Message(),
 		"receive intent already used",
 	)
+}
+
+// TestStartPayRejectsInvoiceBelowOperatorDust verifies the wallet RPC facade
+// applies the same operator dust limit as the underlying daemon OOR sender
+// before it persists a pay swap. Without this synchronous preflight, a
+// sub-dust BOLT-11 invoice could be admitted, then fail later in the
+// background worker after the user-facing Send RPC already returned.
+func TestStartPayRejectsInvoiceBelowOperatorDust(t *testing.T) {
+	t.Parallel()
+
+	fakeClient := newFakeSwapRuntime()
+	service := newTestSwapClientService(fakeClient)
+	service.chainParams = &chaincfg.RegressionNetParams
+	service.payMinAmount = func(context.Context) (uint64, error) {
+		return 1000, nil
+	}
+	defer service.cancel()
+
+	_, err := service.StartPay(
+		t.Context(), &swapclientrpc.StartPayRequest{
+			Invoice: testSwapPayInvoice(t, 999),
+		},
+	)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.ErrorContains(
+		t, err, "invoice amount_sat 999 is below the 1000 sat "+
+			"minimum for pay swaps",
+	)
+	require.Equal(t, 0, fakeClient.startPayCount())
+}
+
+// TestStartPayRejectsMissingChainParamsAsInternal verifies a daemon wiring
+// error is not reported as a caller invoice problem. Pay invoice dust
+// validation needs network parameters to parse BOLT-11 correctly; if the
+// service is missing them, the RPC should fail as an internal server error
+// before touching the swap runtime.
+func TestStartPayRejectsMissingChainParamsAsInternal(t *testing.T) {
+	t.Parallel()
+
+	fakeClient := newFakeSwapRuntime()
+	service := newTestSwapClientService(fakeClient)
+	service.payMinAmount = func(context.Context) (uint64, error) {
+		return 1000, nil
+	}
+	defer service.cancel()
+
+	_, err := service.StartPay(
+		t.Context(), &swapclientrpc.StartPayRequest{
+			Invoice: testSwapPayInvoice(t, 999),
+		},
+	)
+	require.Equal(t, codes.Internal, status.Code(err))
+	require.ErrorContains(
+		t, err, "chain params required for pay invoice validation",
+	)
+	require.Equal(t, 0, fakeClient.startPayCount())
 }
 
 // TestStartReceiveReturnsInvoiceAndStartsWorker verifies receive startup
@@ -675,6 +735,32 @@ func testHash(seed byte) lntypes.Hash {
 	}
 
 	return hash
+}
+
+func testSwapPayInvoice(t *testing.T, amountSat btcutil.Amount) string {
+	t.Helper()
+
+	invoiceKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage := lntypes.Preimage{0x60, 0x6, 0x60, 0x6}
+	invoice, err := zpay32.NewInvoice(
+		&chaincfg.RegressionNetParams, preimage.Hash(), time.Now(),
+		zpay32.Amount(
+			lnwire.NewMSatFromSatoshis(amountSat),
+		),
+		zpay32.Description("pay"),
+	)
+	require.NoError(t, err)
+
+	paymentRequest, err := invoice.Encode(zpay32.MessageSigner{
+		SignCompact: func(msg []byte) ([]byte, error) {
+			return ecdsa.SignCompact(invoiceKey, msg, true), nil
+		},
+	})
+	require.NoError(t, err)
+
+	return paymentRequest
 }
 
 type fakeSwapRuntime struct {


### PR DESCRIPTION
## Summary
- reject OOR recipient amounts below `server_info.dust_limit` in `SendOOR`, including dry-runs
- apply the same check to `PrepareOOR` so custom-input packages cannot be prepared for sub-dust recipients
- reject sub-dust pay invoices in the wallet RPC layer before a swap session is persisted

Fixes #606.

## Testing
- `go test ./darepod`
- `go test -tags 'swapruntime walletdkrpc' ./swapclientserver`\n- `make fmt-changed`\n- `make lint-changed-local`\n- `make commitmsg-lint range="origin/main..HEAD"`\n\n## Manual arktest\nReproduced before the fix with `/tmp/arktest-606-state`: Bob accepted `ark send oor --amount 999` while the operator advertised `dust_limit: 1000`, and Alice received a live `999 sat` VTXO.\n\nRetested with a fixed arktest build from `/tmp/arktest-606-fixed-state`:\n\n```\nbob-cli ark send oor --pubkey <alice_pubkey> --amount 999\n{\n  "error": {\n    "code": "INVALID_ARGUMENT",\n    "message": "amount 999 below operator dust_limit 1000",\n    "details": "SendOOR RPC failed"\n  }\n}\n```\n\n`--dry_run` returns the same `INVALID_ARGUMENT`. I also tested the wallet RPC send path with a `999 sat` BOLT-11 invoice and `bob-cli send --force`; it now fails before swap persistence with `invoice amount_sat 999 is below the 1000 sat minimum for pay swaps`.\n