### PR TITLE
rpc: Add SendOnChain for exact-amount onchain sends (fixes #634)

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_send.go
+++ b/cmd/darepocli/darepoclicommands/cmd_send.go
@@ -28,12 +28,11 @@ func newSendCmd() *cobra.Command {
 			"subsystem (which transparently picks same-Ark p2p " +
 			"vs real Lightning). With --onchain the destination " +
 			"is a bech32 onchain address and the daemon submits " +
-			"a cooperative-leave (LeaveVTXOs) request.\n\n" +
-			"Onchain v1 has whole-VTXO sweep semantics: the " +
-			"actual outflow (echoed on stderr and in " +
-			"actual_amount_sat) may exceed --amt because " +
-			"selected VTXOs are swept in full. Set --sweep-all " +
-			"with --amt=0 to drain every live VTXO.\n\n" +
+			"an atomic onchain-send (SendOnChain) request that " +
+			"lands exactly --amt sats at the destination and " +
+			"returns the residual to the wallet as a change " +
+			"VTXO. Use --sweep-all with --amt=0 to drain every " +
+			"live VTXO instead.\n\n" +
 			"Examples:\n" +
 			"  darepocli send lnbcrt... --offchain\n" +
 			"  darepocli send bcrt1... --onchain --amt 1000\n" +
@@ -171,22 +170,6 @@ func walletSend(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return fmt.Errorf("send prepared intent: %w",
 					err)
-			}
-
-			// For onchain sends actual_amount_sat may exceed
-			// --amt under the v1 whole-VTXO sweep semantics.
-			// Surface it on stderr so a human reading the
-			// terminal sees the real outflow while shell
-			// pipelines can still consume the JSON body.
-			actual := resp.GetActualAmountSat()
-			if !offchain && !sweepAll && actual != int64(amt) {
-				fmt.Fprintf(
-					cmd.ErrOrStderr(),
-					"note: actual_amount_sat=%d exceeds "+
-						"--amt=%d due to whole-VTXO "+
-						"sweep semantics\n", actual,
-					amt,
-				)
 			}
 
 			return printWalletProto(resp)

--- a/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
@@ -156,6 +156,13 @@ func generatedRegistry() []serviceSpec {
 					Comments: "LeaveVTXOs queues one or more VTXOs for cooperative leave\n(offboard) in the next round. Each VTXO is forfeited and the\nforfeited amount (minus the quoted per-input operator fee)\nlands as an on-chain output at the specified destination.",
 				},
 				{
+					Name:     "SendOnChain",
+					Aliases:  []string{"send-on-chain"},
+					Input:    "daemonrpc.SendOnChainRequest",
+					Output:   "daemonrpc.SendOnChainResponse",
+					Comments: "SendOnChain is the wallet-shaped onchain payment primitive: it\npicks live VTXOs to cover the requested amount, forfeits them\nin the next round, produces one on-chain output of the exact\nrequested amount at the supplied destination, and returns any\nresidual to the caller as a change VTXO. The atomic\nforfeit + leave + change-VTXO intent registers immediately\n(TriggerRegistration=true) so the caller does not need to also\nissue JoinNextRound. sweep_all skips selection and drains every\nlive VTXO to the destination (no change VTXO produced).",
+				},
+				{
 					Name:     "Board",
 					Aliases:  []string{"board"},
 					Input:    "daemonrpc.BoardRequest",

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -3948,6 +3948,214 @@ func (x *LeaveVTXOsResponse) GetStatus() string {
 	return ""
 }
 
+type SendOnChainRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// destination is the on-chain recipient. Same shape (and standardness
+	// gating) as LeaveVTXOsRequest.default_destination.
+	Destination *LeaveDestination `protobuf:"bytes,1,opt,name=destination,proto3" json:"destination,omitempty"`
+	// amount picks the send mode. Exactly one variant must be set.
+	//
+	// Types that are valid to be assigned to Amount:
+	//
+	//	*SendOnChainRequest_AmountSat
+	//	*SendOnChainRequest_SweepAll
+	Amount isSendOnChainRequest_Amount `protobuf_oneof:"amount"`
+	// dry_run validates inputs and returns the planned selection
+	// without submitting the round intent.
+	DryRun        bool `protobuf:"varint,5,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SendOnChainRequest) Reset() {
+	*x = SendOnChainRequest{}
+	mi := &file_daemon_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SendOnChainRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SendOnChainRequest) ProtoMessage() {}
+
+func (x *SendOnChainRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SendOnChainRequest.ProtoReflect.Descriptor instead.
+func (*SendOnChainRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{48}
+}
+
+func (x *SendOnChainRequest) GetDestination() *LeaveDestination {
+	if x != nil {
+		return x.Destination
+	}
+	return nil
+}
+
+func (x *SendOnChainRequest) GetAmount() isSendOnChainRequest_Amount {
+	if x != nil {
+		return x.Amount
+	}
+	return nil
+}
+
+func (x *SendOnChainRequest) GetAmountSat() int64 {
+	if x != nil {
+		if x, ok := x.Amount.(*SendOnChainRequest_AmountSat); ok {
+			return x.AmountSat
+		}
+	}
+	return 0
+}
+
+func (x *SendOnChainRequest) GetSweepAll() bool {
+	if x != nil {
+		if x, ok := x.Amount.(*SendOnChainRequest_SweepAll); ok {
+			return x.SweepAll
+		}
+	}
+	return false
+}
+
+func (x *SendOnChainRequest) GetDryRun() bool {
+	if x != nil {
+		return x.DryRun
+	}
+	return false
+}
+
+type isSendOnChainRequest_Amount interface {
+	isSendOnChainRequest_Amount()
+}
+
+type SendOnChainRequest_AmountSat struct {
+	// amount_sat is the exact number of sats to send on-chain to
+	// destination. The daemon selects live VTXOs whose summed value
+	// covers amount_sat plus an operator-fee headroom plus dust,
+	// forfeits them, produces one on-chain output of exactly
+	// amount_sat, and returns the residual to the caller as a
+	// change VTXO. Must be > 0 and ≤ MaxSatoshi.
+	AmountSat int64 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3,oneof"`
+}
+
+type SendOnChainRequest_SweepAll struct {
+	// sweep_all, when true, drains every live VTXO into a single
+	// on-chain output at destination. No change VTXO is produced;
+	// the actual on-chain amount equals Σ(live VTXOs) − operator
+	// fee and is echoed back as actual_amount_sat.
+	SweepAll bool `protobuf:"varint,3,opt,name=sweep_all,json=sweepAll,proto3,oneof"`
+}
+
+func (*SendOnChainRequest_AmountSat) isSendOnChainRequest_Amount() {}
+
+func (*SendOnChainRequest_SweepAll) isSendOnChainRequest_Amount() {}
+
+type SendOnChainResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// actual_amount_sat is the exact value of the on-chain output
+	// that will land at destination. For amount_sat mode this echoes
+	// the requested amount. For sweep_all it is Σ(selected VTXOs) −
+	// operator fee.
+	ActualAmountSat int64 `protobuf:"varint,1,opt,name=actual_amount_sat,json=actualAmountSat,proto3" json:"actual_amount_sat,omitempty"`
+	// fee_sat is the operator fee deducted from the input set for
+	// this send. Under the #270 seal-time fee handshake this is the
+	// server-stamped figure, not a pre-flight estimate. Zero in
+	// dry_run mode.
+	FeeSat int64 `protobuf:"varint,2,opt,name=fee_sat,json=feeSat,proto3" json:"fee_sat,omitempty"`
+	// selected_outpoints lists the VTXOs the daemon picked to
+	// forfeit for this send, in the order they were chosen.
+	SelectedOutpoints []string `protobuf:"bytes,3,rep,name=selected_outpoints,json=selectedOutpoints,proto3" json:"selected_outpoints,omitempty"`
+	// change_outpoint is the outpoint of the change VTXO produced
+	// by an amount_sat send. Empty in dry_run, in sweep_all mode,
+	// or when no change is needed (input set exactly covers
+	// amount_sat + fee + dust). The outpoint is populated once the
+	// round seals and the new VTXO is persisted; in fast-path
+	// responses it may be empty pending the round.
+	ChangeOutpoint string `protobuf:"bytes,4,opt,name=change_outpoint,json=changeOutpoint,proto3" json:"change_outpoint,omitempty"`
+	// status is "submitted" on a successful intent registration,
+	// "preview" when dry_run is set.
+	Status        string `protobuf:"bytes,5,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SendOnChainResponse) Reset() {
+	*x = SendOnChainResponse{}
+	mi := &file_daemon_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SendOnChainResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SendOnChainResponse) ProtoMessage() {}
+
+func (x *SendOnChainResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SendOnChainResponse.ProtoReflect.Descriptor instead.
+func (*SendOnChainResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{49}
+}
+
+func (x *SendOnChainResponse) GetActualAmountSat() int64 {
+	if x != nil {
+		return x.ActualAmountSat
+	}
+	return 0
+}
+
+func (x *SendOnChainResponse) GetFeeSat() int64 {
+	if x != nil {
+		return x.FeeSat
+	}
+	return 0
+}
+
+func (x *SendOnChainResponse) GetSelectedOutpoints() []string {
+	if x != nil {
+		return x.SelectedOutpoints
+	}
+	return nil
+}
+
+func (x *SendOnChainResponse) GetChangeOutpoint() string {
+	if x != nil {
+		return x.ChangeOutpoint
+	}
+	return ""
+}
+
+func (x *SendOnChainResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
 type BoardRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// target_vtxo_count asks the daemon to fan the confirmed boarding
@@ -3969,7 +4177,7 @@ type BoardRequest struct {
 
 func (x *BoardRequest) Reset() {
 	*x = BoardRequest{}
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3981,7 +4189,7 @@ func (x *BoardRequest) String() string {
 func (*BoardRequest) ProtoMessage() {}
 
 func (x *BoardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3994,7 +4202,7 @@ func (x *BoardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardRequest.ProtoReflect.Descriptor instead.
 func (*BoardRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{48}
+	return file_daemon_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *BoardRequest) GetTargetVtxoCount() uint32 {
@@ -4025,7 +4233,7 @@ type BoardResponse struct {
 
 func (x *BoardResponse) Reset() {
 	*x = BoardResponse{}
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4037,7 +4245,7 @@ func (x *BoardResponse) String() string {
 func (*BoardResponse) ProtoMessage() {}
 
 func (x *BoardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4050,7 +4258,7 @@ func (x *BoardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardResponse.ProtoReflect.Descriptor instead.
 func (*BoardResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{49}
+	return file_daemon_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *BoardResponse) GetStatus() string {
@@ -4075,7 +4283,7 @@ type JoinNextRoundRequest struct {
 
 func (x *JoinNextRoundRequest) Reset() {
 	*x = JoinNextRoundRequest{}
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4087,7 +4295,7 @@ func (x *JoinNextRoundRequest) String() string {
 func (*JoinNextRoundRequest) ProtoMessage() {}
 
 func (x *JoinNextRoundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4100,7 +4308,7 @@ func (x *JoinNextRoundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinNextRoundRequest.ProtoReflect.Descriptor instead.
 func (*JoinNextRoundRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{50}
+	return file_daemon_proto_rawDescGZIP(), []int{52}
 }
 
 type JoinNextRoundResponse struct {
@@ -4115,7 +4323,7 @@ type JoinNextRoundResponse struct {
 
 func (x *JoinNextRoundResponse) Reset() {
 	*x = JoinNextRoundResponse{}
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4127,7 +4335,7 @@ func (x *JoinNextRoundResponse) String() string {
 func (*JoinNextRoundResponse) ProtoMessage() {}
 
 func (x *JoinNextRoundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4140,7 +4348,7 @@ func (x *JoinNextRoundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinNextRoundResponse.ProtoReflect.Descriptor instead.
 func (*JoinNextRoundResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{51}
+	return file_daemon_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *JoinNextRoundResponse) GetStatus() string {
@@ -4176,7 +4384,7 @@ type SweepBoardingUTXOsRequest struct {
 
 func (x *SweepBoardingUTXOsRequest) Reset() {
 	*x = SweepBoardingUTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4188,7 +4396,7 @@ func (x *SweepBoardingUTXOsRequest) String() string {
 func (*SweepBoardingUTXOsRequest) ProtoMessage() {}
 
 func (x *SweepBoardingUTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4201,7 +4409,7 @@ func (x *SweepBoardingUTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepBoardingUTXOsRequest.ProtoReflect.Descriptor instead.
 func (*SweepBoardingUTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{52}
+	return file_daemon_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *SweepBoardingUTXOsRequest) GetOutpoints() []string {
@@ -4254,7 +4462,7 @@ type BoardingSweepOutput struct {
 
 func (x *BoardingSweepOutput) Reset() {
 	*x = BoardingSweepOutput{}
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4266,7 +4474,7 @@ func (x *BoardingSweepOutput) String() string {
 func (*BoardingSweepOutput) ProtoMessage() {}
 
 func (x *BoardingSweepOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4279,7 +4487,7 @@ func (x *BoardingSweepOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweepOutput.ProtoReflect.Descriptor instead.
 func (*BoardingSweepOutput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{53}
+	return file_daemon_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *BoardingSweepOutput) GetOutpoint() string {
@@ -4345,7 +4553,7 @@ type SweepBoardingUTXOsResponse struct {
 
 func (x *SweepBoardingUTXOsResponse) Reset() {
 	*x = SweepBoardingUTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4357,7 +4565,7 @@ func (x *SweepBoardingUTXOsResponse) String() string {
 func (*SweepBoardingUTXOsResponse) ProtoMessage() {}
 
 func (x *SweepBoardingUTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4370,7 +4578,7 @@ func (x *SweepBoardingUTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepBoardingUTXOsResponse.ProtoReflect.Descriptor instead.
 func (*SweepBoardingUTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{54}
+	return file_daemon_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *SweepBoardingUTXOsResponse) GetStatus() string {
@@ -4474,7 +4682,7 @@ type ListBoardingSweepsRequest struct {
 
 func (x *ListBoardingSweepsRequest) Reset() {
 	*x = ListBoardingSweepsRequest{}
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4486,7 +4694,7 @@ func (x *ListBoardingSweepsRequest) String() string {
 func (*ListBoardingSweepsRequest) ProtoMessage() {}
 
 func (x *ListBoardingSweepsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4499,7 +4707,7 @@ func (x *ListBoardingSweepsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBoardingSweepsRequest.ProtoReflect.Descriptor instead.
 func (*ListBoardingSweepsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{55}
+	return file_daemon_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *ListBoardingSweepsRequest) GetStatus() string {
@@ -4542,7 +4750,7 @@ type BoardingSweepInput struct {
 
 func (x *BoardingSweepInput) Reset() {
 	*x = BoardingSweepInput{}
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4554,7 +4762,7 @@ func (x *BoardingSweepInput) String() string {
 func (*BoardingSweepInput) ProtoMessage() {}
 
 func (x *BoardingSweepInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4567,7 +4775,7 @@ func (x *BoardingSweepInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweepInput.ProtoReflect.Descriptor instead.
 func (*BoardingSweepInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{56}
+	return file_daemon_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *BoardingSweepInput) GetOutpoint() string {
@@ -4637,7 +4845,7 @@ type BoardingSweep struct {
 
 func (x *BoardingSweep) Reset() {
 	*x = BoardingSweep{}
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4649,7 +4857,7 @@ func (x *BoardingSweep) String() string {
 func (*BoardingSweep) ProtoMessage() {}
 
 func (x *BoardingSweep) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4662,7 +4870,7 @@ func (x *BoardingSweep) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweep.ProtoReflect.Descriptor instead.
 func (*BoardingSweep) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{57}
+	return file_daemon_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *BoardingSweep) GetTxid() string {
@@ -4754,7 +4962,7 @@ type ListBoardingSweepsResponse struct {
 
 func (x *ListBoardingSweepsResponse) Reset() {
 	*x = ListBoardingSweepsResponse{}
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4766,7 +4974,7 @@ func (x *ListBoardingSweepsResponse) String() string {
 func (*ListBoardingSweepsResponse) ProtoMessage() {}
 
 func (x *ListBoardingSweepsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4779,7 +4987,7 @@ func (x *ListBoardingSweepsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBoardingSweepsResponse.ProtoReflect.Descriptor instead.
 func (*ListBoardingSweepsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{58}
+	return file_daemon_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *ListBoardingSweepsResponse) GetSweeps() []*BoardingSweep {
@@ -4809,7 +5017,7 @@ type RoundVTXOInfo struct {
 
 func (x *RoundVTXOInfo) Reset() {
 	*x = RoundVTXOInfo{}
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4821,7 +5029,7 @@ func (x *RoundVTXOInfo) String() string {
 func (*RoundVTXOInfo) ProtoMessage() {}
 
 func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4834,7 +5042,7 @@ func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundVTXOInfo.ProtoReflect.Descriptor instead.
 func (*RoundVTXOInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{59}
+	return file_daemon_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *RoundVTXOInfo) GetOutpoint() string {
@@ -4902,7 +5110,7 @@ type RoundInfo struct {
 
 func (x *RoundInfo) Reset() {
 	*x = RoundInfo{}
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4914,7 +5122,7 @@ func (x *RoundInfo) String() string {
 func (*RoundInfo) ProtoMessage() {}
 
 func (x *RoundInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4927,7 +5135,7 @@ func (x *RoundInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundInfo.ProtoReflect.Descriptor instead.
 func (*RoundInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{60}
+	return file_daemon_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *RoundInfo) GetRoundId() string {
@@ -5039,7 +5247,7 @@ type ListRoundsRequest struct {
 
 func (x *ListRoundsRequest) Reset() {
 	*x = ListRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5051,7 +5259,7 @@ func (x *ListRoundsRequest) String() string {
 func (*ListRoundsRequest) ProtoMessage() {}
 
 func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5064,7 +5272,7 @@ func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{61}
+	return file_daemon_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ListRoundsRequest) GetPageSize() int32 {
@@ -5119,7 +5327,7 @@ type GetRoundRequest struct {
 
 func (x *GetRoundRequest) Reset() {
 	*x = GetRoundRequest{}
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5131,7 +5339,7 @@ func (x *GetRoundRequest) String() string {
 func (*GetRoundRequest) ProtoMessage() {}
 
 func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5144,7 +5352,7 @@ func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundRequest.ProtoReflect.Descriptor instead.
 func (*GetRoundRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{62}
+	return file_daemon_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *GetRoundRequest) GetRoundId() string {
@@ -5164,7 +5372,7 @@ type GetRoundResponse struct {
 
 func (x *GetRoundResponse) Reset() {
 	*x = GetRoundResponse{}
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5176,7 +5384,7 @@ func (x *GetRoundResponse) String() string {
 func (*GetRoundResponse) ProtoMessage() {}
 
 func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5189,7 +5397,7 @@ func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundResponse.ProtoReflect.Descriptor instead.
 func (*GetRoundResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{63}
+	return file_daemon_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *GetRoundResponse) GetRound() *RoundInfo {
@@ -5212,7 +5420,7 @@ type ListRoundsResponse struct {
 
 func (x *ListRoundsResponse) Reset() {
 	*x = ListRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5224,7 +5432,7 @@ func (x *ListRoundsResponse) String() string {
 func (*ListRoundsResponse) ProtoMessage() {}
 
 func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5237,7 +5445,7 @@ func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{64}
+	return file_daemon_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *ListRoundsResponse) GetRounds() []*RoundInfo {
@@ -5262,7 +5470,7 @@ type WatchRoundsRequest struct {
 
 func (x *WatchRoundsRequest) Reset() {
 	*x = WatchRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5274,7 +5482,7 @@ func (x *WatchRoundsRequest) String() string {
 func (*WatchRoundsRequest) ProtoMessage() {}
 
 func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5287,7 +5495,7 @@ func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsRequest.ProtoReflect.Descriptor instead.
 func (*WatchRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{65}
+	return file_daemon_proto_rawDescGZIP(), []int{67}
 }
 
 type WatchRoundsResponse struct {
@@ -5301,7 +5509,7 @@ type WatchRoundsResponse struct {
 
 func (x *WatchRoundsResponse) Reset() {
 	*x = WatchRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[66]
+	mi := &file_daemon_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5313,7 +5521,7 @@ func (x *WatchRoundsResponse) String() string {
 func (*WatchRoundsResponse) ProtoMessage() {}
 
 func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[66]
+	mi := &file_daemon_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5326,7 +5534,7 @@ func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsResponse.ProtoReflect.Descriptor instead.
 func (*WatchRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{66}
+	return file_daemon_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *WatchRoundsResponse) GetRound() *RoundInfo {
@@ -5364,7 +5572,7 @@ type OORSessionInfo struct {
 
 func (x *OORSessionInfo) Reset() {
 	*x = OORSessionInfo{}
-	mi := &file_daemon_proto_msgTypes[67]
+	mi := &file_daemon_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5376,7 +5584,7 @@ func (x *OORSessionInfo) String() string {
 func (*OORSessionInfo) ProtoMessage() {}
 
 func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[67]
+	mi := &file_daemon_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5389,7 +5597,7 @@ func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OORSessionInfo.ProtoReflect.Descriptor instead.
 func (*OORSessionInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{67}
+	return file_daemon_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *OORSessionInfo) GetSessionId() string {
@@ -5473,7 +5681,7 @@ type ListOORSessionsRequest struct {
 
 func (x *ListOORSessionsRequest) Reset() {
 	*x = ListOORSessionsRequest{}
-	mi := &file_daemon_proto_msgTypes[68]
+	mi := &file_daemon_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5485,7 +5693,7 @@ func (x *ListOORSessionsRequest) String() string {
 func (*ListOORSessionsRequest) ProtoMessage() {}
 
 func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[68]
+	mi := &file_daemon_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5498,7 +5706,7 @@ func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{68}
+	return file_daemon_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *ListOORSessionsRequest) GetPageSize() int32 {
@@ -5542,7 +5750,7 @@ type ListOORSessionsResponse struct {
 
 func (x *ListOORSessionsResponse) Reset() {
 	*x = ListOORSessionsResponse{}
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5554,7 +5762,7 @@ func (x *ListOORSessionsResponse) String() string {
 func (*ListOORSessionsResponse) ProtoMessage() {}
 
 func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5567,7 +5775,7 @@ func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{69}
+	return file_daemon_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *ListOORSessionsResponse) GetSessions() []*OORSessionInfo {
@@ -5594,7 +5802,7 @@ type GetOORSessionRequest struct {
 
 func (x *GetOORSessionRequest) Reset() {
 	*x = GetOORSessionRequest{}
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5606,7 +5814,7 @@ func (x *GetOORSessionRequest) String() string {
 func (*GetOORSessionRequest) ProtoMessage() {}
 
 func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5619,7 +5827,7 @@ func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionRequest.ProtoReflect.Descriptor instead.
 func (*GetOORSessionRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{70}
+	return file_daemon_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *GetOORSessionRequest) GetSessionId() string {
@@ -5639,7 +5847,7 @@ type GetOORSessionResponse struct {
 
 func (x *GetOORSessionResponse) Reset() {
 	*x = GetOORSessionResponse{}
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5651,7 +5859,7 @@ func (x *GetOORSessionResponse) String() string {
 func (*GetOORSessionResponse) ProtoMessage() {}
 
 func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5664,7 +5872,7 @@ func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionResponse.ProtoReflect.Descriptor instead.
 func (*GetOORSessionResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{71}
+	return file_daemon_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *GetOORSessionResponse) GetSession() *OORSessionInfo {
@@ -5692,7 +5900,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5704,7 +5912,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5717,7 +5925,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{72}
+	return file_daemon_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *EstimateFeeRequest) GetAmountSat() int64 {
@@ -5771,7 +5979,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_daemon_proto_msgTypes[73]
+	mi := &file_daemon_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5783,7 +5991,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[73]
+	mi := &file_daemon_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5796,7 +6004,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{73}
+	return file_daemon_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *EstimateFeeResponse) GetLiquidityFeeSat() int64 {
@@ -5866,7 +6074,7 @@ type GetFeeHistoryRequest struct {
 
 func (x *GetFeeHistoryRequest) Reset() {
 	*x = GetFeeHistoryRequest{}
-	mi := &file_daemon_proto_msgTypes[74]
+	mi := &file_daemon_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5878,7 +6086,7 @@ func (x *GetFeeHistoryRequest) String() string {
 func (*GetFeeHistoryRequest) ProtoMessage() {}
 
 func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[74]
+	mi := &file_daemon_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5891,7 +6099,7 @@ func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryRequest.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{74}
+	return file_daemon_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *GetFeeHistoryRequest) GetLimit() uint32 {
@@ -5966,7 +6174,7 @@ type FeeHistoryEntry struct {
 
 func (x *FeeHistoryEntry) Reset() {
 	*x = FeeHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[75]
+	mi := &file_daemon_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5978,7 +6186,7 @@ func (x *FeeHistoryEntry) String() string {
 func (*FeeHistoryEntry) ProtoMessage() {}
 
 func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[75]
+	mi := &file_daemon_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5991,7 +6199,7 @@ func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeHistoryEntry.ProtoReflect.Descriptor instead.
 func (*FeeHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{75}
+	return file_daemon_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *FeeHistoryEntry) GetEntryId() int64 {
@@ -6071,7 +6279,7 @@ type GetFeeHistoryResponse struct {
 
 func (x *GetFeeHistoryResponse) Reset() {
 	*x = GetFeeHistoryResponse{}
-	mi := &file_daemon_proto_msgTypes[76]
+	mi := &file_daemon_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6083,7 +6291,7 @@ func (x *GetFeeHistoryResponse) String() string {
 func (*GetFeeHistoryResponse) ProtoMessage() {}
 
 func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[76]
+	mi := &file_daemon_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6096,7 +6304,7 @@ func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryResponse.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{76}
+	return file_daemon_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *GetFeeHistoryResponse) GetEntries() []*FeeHistoryEntry {
@@ -6137,7 +6345,7 @@ type ListTransactionsRequest struct {
 
 func (x *ListTransactionsRequest) Reset() {
 	*x = ListTransactionsRequest{}
-	mi := &file_daemon_proto_msgTypes[77]
+	mi := &file_daemon_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6149,7 +6357,7 @@ func (x *ListTransactionsRequest) String() string {
 func (*ListTransactionsRequest) ProtoMessage() {}
 
 func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[77]
+	mi := &file_daemon_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6162,7 +6370,7 @@ func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsRequest.ProtoReflect.Descriptor instead.
 func (*ListTransactionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{77}
+	return file_daemon_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *ListTransactionsRequest) GetFromUnixS() int64 {
@@ -6248,7 +6456,7 @@ type TransactionHistoryEntry struct {
 
 func (x *TransactionHistoryEntry) Reset() {
 	*x = TransactionHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[78]
+	mi := &file_daemon_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6260,7 +6468,7 @@ func (x *TransactionHistoryEntry) String() string {
 func (*TransactionHistoryEntry) ProtoMessage() {}
 
 func (x *TransactionHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[78]
+	mi := &file_daemon_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6273,7 +6481,7 @@ func (x *TransactionHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionHistoryEntry.ProtoReflect.Descriptor instead.
 func (*TransactionHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{78}
+	return file_daemon_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *TransactionHistoryEntry) GetSource() string {
@@ -6403,7 +6611,7 @@ type ListTransactionsResponse struct {
 
 func (x *ListTransactionsResponse) Reset() {
 	*x = ListTransactionsResponse{}
-	mi := &file_daemon_proto_msgTypes[79]
+	mi := &file_daemon_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6415,7 +6623,7 @@ func (x *ListTransactionsResponse) String() string {
 func (*ListTransactionsResponse) ProtoMessage() {}
 
 func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[79]
+	mi := &file_daemon_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6428,7 +6636,7 @@ func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsResponse.ProtoReflect.Descriptor instead.
 func (*ListTransactionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{79}
+	return file_daemon_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *ListTransactionsResponse) GetTransactions() []*TransactionHistoryEntry {
@@ -6463,7 +6671,7 @@ type UnrollRequest struct {
 
 func (x *UnrollRequest) Reset() {
 	*x = UnrollRequest{}
-	mi := &file_daemon_proto_msgTypes[80]
+	mi := &file_daemon_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6475,7 +6683,7 @@ func (x *UnrollRequest) String() string {
 func (*UnrollRequest) ProtoMessage() {}
 
 func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[80]
+	mi := &file_daemon_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6488,7 +6696,7 @@ func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollRequest.ProtoReflect.Descriptor instead.
 func (*UnrollRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{80}
+	return file_daemon_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *UnrollRequest) GetOutpoint() string {
@@ -6511,7 +6719,7 @@ type UnrollResponse struct {
 
 func (x *UnrollResponse) Reset() {
 	*x = UnrollResponse{}
-	mi := &file_daemon_proto_msgTypes[81]
+	mi := &file_daemon_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6523,7 +6731,7 @@ func (x *UnrollResponse) String() string {
 func (*UnrollResponse) ProtoMessage() {}
 
 func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[81]
+	mi := &file_daemon_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6536,7 +6744,7 @@ func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollResponse.ProtoReflect.Descriptor instead.
 func (*UnrollResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{81}
+	return file_daemon_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *UnrollResponse) GetCreated() bool {
@@ -6563,7 +6771,7 @@ type GetUnrollStatusRequest struct {
 
 func (x *GetUnrollStatusRequest) Reset() {
 	*x = GetUnrollStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[82]
+	mi := &file_daemon_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6575,7 +6783,7 @@ func (x *GetUnrollStatusRequest) String() string {
 func (*GetUnrollStatusRequest) ProtoMessage() {}
 
 func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[82]
+	mi := &file_daemon_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6588,7 +6796,7 @@ func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{82}
+	return file_daemon_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *GetUnrollStatusRequest) GetOutpoint() string {
@@ -6616,7 +6824,7 @@ type GetUnrollStatusResponse struct {
 
 func (x *GetUnrollStatusResponse) Reset() {
 	*x = GetUnrollStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[83]
+	mi := &file_daemon_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6628,7 +6836,7 @@ func (x *GetUnrollStatusResponse) String() string {
 func (*GetUnrollStatusResponse) ProtoMessage() {}
 
 func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[83]
+	mi := &file_daemon_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6641,7 +6849,7 @@ func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{83}
+	return file_daemon_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *GetUnrollStatusResponse) GetFound() bool {
@@ -6723,7 +6931,7 @@ type ArmVHTLCRecoveryRequest struct {
 
 func (x *ArmVHTLCRecoveryRequest) Reset() {
 	*x = ArmVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[84]
+	mi := &file_daemon_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6735,7 +6943,7 @@ func (x *ArmVHTLCRecoveryRequest) String() string {
 func (*ArmVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[84]
+	mi := &file_daemon_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6748,7 +6956,7 @@ func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{84}
+	return file_daemon_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *ArmVHTLCRecoveryRequest) GetRequestId() string {
@@ -6891,7 +7099,7 @@ type ArmVHTLCRecoveryResponse struct {
 
 func (x *ArmVHTLCRecoveryResponse) Reset() {
 	*x = ArmVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[85]
+	mi := &file_daemon_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6903,7 +7111,7 @@ func (x *ArmVHTLCRecoveryResponse) String() string {
 func (*ArmVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[85]
+	mi := &file_daemon_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6916,7 +7124,7 @@ func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{85}
+	return file_daemon_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *ArmVHTLCRecoveryResponse) GetRecoveryId() string {
@@ -6956,7 +7164,7 @@ type EscalateVHTLCRecoveryRequest struct {
 
 func (x *EscalateVHTLCRecoveryRequest) Reset() {
 	*x = EscalateVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[86]
+	mi := &file_daemon_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6968,7 +7176,7 @@ func (x *EscalateVHTLCRecoveryRequest) String() string {
 func (*EscalateVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[86]
+	mi := &file_daemon_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6981,7 +7189,7 @@ func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{86}
+	return file_daemon_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *EscalateVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -7015,7 +7223,7 @@ type EscalateVHTLCRecoveryResponse struct {
 
 func (x *EscalateVHTLCRecoveryResponse) Reset() {
 	*x = EscalateVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[87]
+	mi := &file_daemon_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7027,7 +7235,7 @@ func (x *EscalateVHTLCRecoveryResponse) String() string {
 func (*EscalateVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[87]
+	mi := &file_daemon_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7040,7 +7248,7 @@ func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{87}
+	return file_daemon_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *EscalateVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -7064,7 +7272,7 @@ type CancelVHTLCRecoveryRequest struct {
 
 func (x *CancelVHTLCRecoveryRequest) Reset() {
 	*x = CancelVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[88]
+	mi := &file_daemon_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7076,7 +7284,7 @@ func (x *CancelVHTLCRecoveryRequest) String() string {
 func (*CancelVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[88]
+	mi := &file_daemon_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7089,7 +7297,7 @@ func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{88}
+	return file_daemon_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *CancelVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -7123,7 +7331,7 @@ type CancelVHTLCRecoveryResponse struct {
 
 func (x *CancelVHTLCRecoveryResponse) Reset() {
 	*x = CancelVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[89]
+	mi := &file_daemon_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7135,7 +7343,7 @@ func (x *CancelVHTLCRecoveryResponse) String() string {
 func (*CancelVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[89]
+	mi := &file_daemon_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7148,7 +7356,7 @@ func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{89}
+	return file_daemon_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *CancelVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -7168,7 +7376,7 @@ type GetVHTLCRecoveryStatusRequest struct {
 
 func (x *GetVHTLCRecoveryStatusRequest) Reset() {
 	*x = GetVHTLCRecoveryStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[90]
+	mi := &file_daemon_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7180,7 +7388,7 @@ func (x *GetVHTLCRecoveryStatusRequest) String() string {
 func (*GetVHTLCRecoveryStatusRequest) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[90]
+	mi := &file_daemon_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7193,7 +7401,7 @@ func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{90}
+	return file_daemon_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *GetVHTLCRecoveryStatusRequest) GetRecoveryId() string {
@@ -7215,7 +7423,7 @@ type GetVHTLCRecoveryStatusResponse struct {
 
 func (x *GetVHTLCRecoveryStatusResponse) Reset() {
 	*x = GetVHTLCRecoveryStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[91]
+	mi := &file_daemon_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7227,7 +7435,7 @@ func (x *GetVHTLCRecoveryStatusResponse) String() string {
 func (*GetVHTLCRecoveryStatusResponse) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[91]
+	mi := &file_daemon_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7240,7 +7448,7 @@ func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{91}
+	return file_daemon_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *GetVHTLCRecoveryStatusResponse) GetFound() bool {
@@ -7267,7 +7475,7 @@ type ListVHTLCRecoveriesRequest struct {
 
 func (x *ListVHTLCRecoveriesRequest) Reset() {
 	*x = ListVHTLCRecoveriesRequest{}
-	mi := &file_daemon_proto_msgTypes[92]
+	mi := &file_daemon_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7279,7 +7487,7 @@ func (x *ListVHTLCRecoveriesRequest) String() string {
 func (*ListVHTLCRecoveriesRequest) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[92]
+	mi := &file_daemon_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7292,7 +7500,7 @@ func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesRequest.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{92}
+	return file_daemon_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *ListVHTLCRecoveriesRequest) GetIncludeTerminal() bool {
@@ -7312,7 +7520,7 @@ type ListVHTLCRecoveriesResponse struct {
 
 func (x *ListVHTLCRecoveriesResponse) Reset() {
 	*x = ListVHTLCRecoveriesResponse{}
-	mi := &file_daemon_proto_msgTypes[93]
+	mi := &file_daemon_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7324,7 +7532,7 @@ func (x *ListVHTLCRecoveriesResponse) String() string {
 func (*ListVHTLCRecoveriesResponse) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[93]
+	mi := &file_daemon_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7337,7 +7545,7 @@ func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesResponse.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{93}
+	return file_daemon_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *ListVHTLCRecoveriesResponse) GetStatuses() []*VHTLCRecoveryStatus {
@@ -7412,7 +7620,7 @@ type VHTLCRecoveryStatus struct {
 
 func (x *VHTLCRecoveryStatus) Reset() {
 	*x = VHTLCRecoveryStatus{}
-	mi := &file_daemon_proto_msgTypes[94]
+	mi := &file_daemon_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7424,7 +7632,7 @@ func (x *VHTLCRecoveryStatus) String() string {
 func (*VHTLCRecoveryStatus) ProtoMessage() {}
 
 func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[94]
+	mi := &file_daemon_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7437,7 +7645,7 @@ func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VHTLCRecoveryStatus.ProtoReflect.Descriptor instead.
 func (*VHTLCRecoveryStatus) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{94}
+	return file_daemon_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *VHTLCRecoveryStatus) GetRecoveryId() string {
@@ -7833,7 +8041,20 @@ const file_daemon_proto_rawDesc = "" +
 	"\tselection\"W\n" +
 	"\x12LeaveVTXOsResponse\x12)\n" +
 	"\x10queued_outpoints\x18\x01 \x03(\tR\x0fqueuedOutpoints\x12\x16\n" +
-	"\x06status\x18\x02 \x01(\tR\x06status\"Y\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\"\xb6\x01\n" +
+	"\x12SendOnChainRequest\x12=\n" +
+	"\vdestination\x18\x01 \x01(\v2\x1b.daemonrpc.LeaveDestinationR\vdestination\x12\x1f\n" +
+	"\n" +
+	"amount_sat\x18\x02 \x01(\x03H\x00R\tamountSat\x12\x1d\n" +
+	"\tsweep_all\x18\x03 \x01(\bH\x00R\bsweepAll\x12\x17\n" +
+	"\adry_run\x18\x05 \x01(\bR\x06dryRunB\b\n" +
+	"\x06amount\"\xca\x01\n" +
+	"\x13SendOnChainResponse\x12*\n" +
+	"\x11actual_amount_sat\x18\x01 \x01(\x03R\x0factualAmountSat\x12\x17\n" +
+	"\afee_sat\x18\x02 \x01(\x03R\x06feeSat\x12-\n" +
+	"\x12selected_outpoints\x18\x03 \x03(\tR\x11selectedOutpoints\x12'\n" +
+	"\x0fchange_outpoint\x18\x04 \x01(\tR\x0echangeOutpoint\x12\x16\n" +
+	"\x06status\x18\x05 \x01(\tR\x06status\"Y\n" +
 	"\fBoardRequest\x12*\n" +
 	"\x11target_vtxo_count\x18\x01 \x01(\rR\x0ftargetVtxoCount\x12\x1d\n" +
 	"\n" +
@@ -8201,7 +8422,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1eVHTLC_RECOVERY_STATE_COMPLETED\x10\t\x12\"\n" +
 	"\x1eVHTLC_RECOVERY_STATE_CANCELLED\x10\n" +
 	"\x12\x1f\n" +
-	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\xd0\x1a\n" +
+	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\x9e\x1b\n" +
 	"\rDaemonService\x12@\n" +
 	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
 	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
@@ -8227,7 +8448,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\x12SignOORCustomInput\x12$.daemonrpc.SignOORCustomInputRequest\x1a%.daemonrpc.SignOORCustomInputResponse\x12O\n" +
 	"\fRefreshVTXOs\x12\x1e.daemonrpc.RefreshVTXOsRequest\x1a\x1f.daemonrpc.RefreshVTXOsResponse\x12I\n" +
 	"\n" +
-	"LeaveVTXOs\x12\x1c.daemonrpc.LeaveVTXOsRequest\x1a\x1d.daemonrpc.LeaveVTXOsResponse\x12:\n" +
+	"LeaveVTXOs\x12\x1c.daemonrpc.LeaveVTXOsRequest\x1a\x1d.daemonrpc.LeaveVTXOsResponse\x12L\n" +
+	"\vSendOnChain\x12\x1d.daemonrpc.SendOnChainRequest\x1a\x1e.daemonrpc.SendOnChainResponse\x12:\n" +
 	"\x05Board\x12\x17.daemonrpc.BoardRequest\x1a\x18.daemonrpc.BoardResponse\x12R\n" +
 	"\rJoinNextRound\x12\x1f.daemonrpc.JoinNextRoundRequest\x1a .daemonrpc.JoinNextRoundResponse\x12a\n" +
 	"\x12SweepBoardingUTXOs\x12$.daemonrpc.SweepBoardingUTXOsRequest\x1a%.daemonrpc.SweepBoardingUTXOsResponse\x12a\n" +
@@ -8262,7 +8484,7 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 96)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 98)
 var file_daemon_proto_goTypes = []any{
 	(WalletState)(0),                              // 0: daemonrpc.WalletState
 	(VTXOStatus)(0),                               // 1: daemonrpc.VTXOStatus
@@ -8321,54 +8543,56 @@ var file_daemon_proto_goTypes = []any{
 	(*LeaveDestination)(nil),                      // 54: daemonrpc.LeaveDestination
 	(*LeaveVTXOsRequest)(nil),                     // 55: daemonrpc.LeaveVTXOsRequest
 	(*LeaveVTXOsResponse)(nil),                    // 56: daemonrpc.LeaveVTXOsResponse
-	(*BoardRequest)(nil),                          // 57: daemonrpc.BoardRequest
-	(*BoardResponse)(nil),                         // 58: daemonrpc.BoardResponse
-	(*JoinNextRoundRequest)(nil),                  // 59: daemonrpc.JoinNextRoundRequest
-	(*JoinNextRoundResponse)(nil),                 // 60: daemonrpc.JoinNextRoundResponse
-	(*SweepBoardingUTXOsRequest)(nil),             // 61: daemonrpc.SweepBoardingUTXOsRequest
-	(*BoardingSweepOutput)(nil),                   // 62: daemonrpc.BoardingSweepOutput
-	(*SweepBoardingUTXOsResponse)(nil),            // 63: daemonrpc.SweepBoardingUTXOsResponse
-	(*ListBoardingSweepsRequest)(nil),             // 64: daemonrpc.ListBoardingSweepsRequest
-	(*BoardingSweepInput)(nil),                    // 65: daemonrpc.BoardingSweepInput
-	(*BoardingSweep)(nil),                         // 66: daemonrpc.BoardingSweep
-	(*ListBoardingSweepsResponse)(nil),            // 67: daemonrpc.ListBoardingSweepsResponse
-	(*RoundVTXOInfo)(nil),                         // 68: daemonrpc.RoundVTXOInfo
-	(*RoundInfo)(nil),                             // 69: daemonrpc.RoundInfo
-	(*ListRoundsRequest)(nil),                     // 70: daemonrpc.ListRoundsRequest
-	(*GetRoundRequest)(nil),                       // 71: daemonrpc.GetRoundRequest
-	(*GetRoundResponse)(nil),                      // 72: daemonrpc.GetRoundResponse
-	(*ListRoundsResponse)(nil),                    // 73: daemonrpc.ListRoundsResponse
-	(*WatchRoundsRequest)(nil),                    // 74: daemonrpc.WatchRoundsRequest
-	(*WatchRoundsResponse)(nil),                   // 75: daemonrpc.WatchRoundsResponse
-	(*OORSessionInfo)(nil),                        // 76: daemonrpc.OORSessionInfo
-	(*ListOORSessionsRequest)(nil),                // 77: daemonrpc.ListOORSessionsRequest
-	(*ListOORSessionsResponse)(nil),               // 78: daemonrpc.ListOORSessionsResponse
-	(*GetOORSessionRequest)(nil),                  // 79: daemonrpc.GetOORSessionRequest
-	(*GetOORSessionResponse)(nil),                 // 80: daemonrpc.GetOORSessionResponse
-	(*EstimateFeeRequest)(nil),                    // 81: daemonrpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil),                   // 82: daemonrpc.EstimateFeeResponse
-	(*GetFeeHistoryRequest)(nil),                  // 83: daemonrpc.GetFeeHistoryRequest
-	(*FeeHistoryEntry)(nil),                       // 84: daemonrpc.FeeHistoryEntry
-	(*GetFeeHistoryResponse)(nil),                 // 85: daemonrpc.GetFeeHistoryResponse
-	(*ListTransactionsRequest)(nil),               // 86: daemonrpc.ListTransactionsRequest
-	(*TransactionHistoryEntry)(nil),               // 87: daemonrpc.TransactionHistoryEntry
-	(*ListTransactionsResponse)(nil),              // 88: daemonrpc.ListTransactionsResponse
-	(*UnrollRequest)(nil),                         // 89: daemonrpc.UnrollRequest
-	(*UnrollResponse)(nil),                        // 90: daemonrpc.UnrollResponse
-	(*GetUnrollStatusRequest)(nil),                // 91: daemonrpc.GetUnrollStatusRequest
-	(*GetUnrollStatusResponse)(nil),               // 92: daemonrpc.GetUnrollStatusResponse
-	(*ArmVHTLCRecoveryRequest)(nil),               // 93: daemonrpc.ArmVHTLCRecoveryRequest
-	(*ArmVHTLCRecoveryResponse)(nil),              // 94: daemonrpc.ArmVHTLCRecoveryResponse
-	(*EscalateVHTLCRecoveryRequest)(nil),          // 95: daemonrpc.EscalateVHTLCRecoveryRequest
-	(*EscalateVHTLCRecoveryResponse)(nil),         // 96: daemonrpc.EscalateVHTLCRecoveryResponse
-	(*CancelVHTLCRecoveryRequest)(nil),            // 97: daemonrpc.CancelVHTLCRecoveryRequest
-	(*CancelVHTLCRecoveryResponse)(nil),           // 98: daemonrpc.CancelVHTLCRecoveryResponse
-	(*GetVHTLCRecoveryStatusRequest)(nil),         // 99: daemonrpc.GetVHTLCRecoveryStatusRequest
-	(*GetVHTLCRecoveryStatusResponse)(nil),        // 100: daemonrpc.GetVHTLCRecoveryStatusResponse
-	(*ListVHTLCRecoveriesRequest)(nil),            // 101: daemonrpc.ListVHTLCRecoveriesRequest
-	(*ListVHTLCRecoveriesResponse)(nil),           // 102: daemonrpc.ListVHTLCRecoveriesResponse
-	(*VHTLCRecoveryStatus)(nil),                   // 103: daemonrpc.VHTLCRecoveryStatus
-	nil,                                           // 104: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	(*SendOnChainRequest)(nil),                    // 57: daemonrpc.SendOnChainRequest
+	(*SendOnChainResponse)(nil),                   // 58: daemonrpc.SendOnChainResponse
+	(*BoardRequest)(nil),                          // 59: daemonrpc.BoardRequest
+	(*BoardResponse)(nil),                         // 60: daemonrpc.BoardResponse
+	(*JoinNextRoundRequest)(nil),                  // 61: daemonrpc.JoinNextRoundRequest
+	(*JoinNextRoundResponse)(nil),                 // 62: daemonrpc.JoinNextRoundResponse
+	(*SweepBoardingUTXOsRequest)(nil),             // 63: daemonrpc.SweepBoardingUTXOsRequest
+	(*BoardingSweepOutput)(nil),                   // 64: daemonrpc.BoardingSweepOutput
+	(*SweepBoardingUTXOsResponse)(nil),            // 65: daemonrpc.SweepBoardingUTXOsResponse
+	(*ListBoardingSweepsRequest)(nil),             // 66: daemonrpc.ListBoardingSweepsRequest
+	(*BoardingSweepInput)(nil),                    // 67: daemonrpc.BoardingSweepInput
+	(*BoardingSweep)(nil),                         // 68: daemonrpc.BoardingSweep
+	(*ListBoardingSweepsResponse)(nil),            // 69: daemonrpc.ListBoardingSweepsResponse
+	(*RoundVTXOInfo)(nil),                         // 70: daemonrpc.RoundVTXOInfo
+	(*RoundInfo)(nil),                             // 71: daemonrpc.RoundInfo
+	(*ListRoundsRequest)(nil),                     // 72: daemonrpc.ListRoundsRequest
+	(*GetRoundRequest)(nil),                       // 73: daemonrpc.GetRoundRequest
+	(*GetRoundResponse)(nil),                      // 74: daemonrpc.GetRoundResponse
+	(*ListRoundsResponse)(nil),                    // 75: daemonrpc.ListRoundsResponse
+	(*WatchRoundsRequest)(nil),                    // 76: daemonrpc.WatchRoundsRequest
+	(*WatchRoundsResponse)(nil),                   // 77: daemonrpc.WatchRoundsResponse
+	(*OORSessionInfo)(nil),                        // 78: daemonrpc.OORSessionInfo
+	(*ListOORSessionsRequest)(nil),                // 79: daemonrpc.ListOORSessionsRequest
+	(*ListOORSessionsResponse)(nil),               // 80: daemonrpc.ListOORSessionsResponse
+	(*GetOORSessionRequest)(nil),                  // 81: daemonrpc.GetOORSessionRequest
+	(*GetOORSessionResponse)(nil),                 // 82: daemonrpc.GetOORSessionResponse
+	(*EstimateFeeRequest)(nil),                    // 83: daemonrpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil),                   // 84: daemonrpc.EstimateFeeResponse
+	(*GetFeeHistoryRequest)(nil),                  // 85: daemonrpc.GetFeeHistoryRequest
+	(*FeeHistoryEntry)(nil),                       // 86: daemonrpc.FeeHistoryEntry
+	(*GetFeeHistoryResponse)(nil),                 // 87: daemonrpc.GetFeeHistoryResponse
+	(*ListTransactionsRequest)(nil),               // 88: daemonrpc.ListTransactionsRequest
+	(*TransactionHistoryEntry)(nil),               // 89: daemonrpc.TransactionHistoryEntry
+	(*ListTransactionsResponse)(nil),              // 90: daemonrpc.ListTransactionsResponse
+	(*UnrollRequest)(nil),                         // 91: daemonrpc.UnrollRequest
+	(*UnrollResponse)(nil),                        // 92: daemonrpc.UnrollResponse
+	(*GetUnrollStatusRequest)(nil),                // 93: daemonrpc.GetUnrollStatusRequest
+	(*GetUnrollStatusResponse)(nil),               // 94: daemonrpc.GetUnrollStatusResponse
+	(*ArmVHTLCRecoveryRequest)(nil),               // 95: daemonrpc.ArmVHTLCRecoveryRequest
+	(*ArmVHTLCRecoveryResponse)(nil),              // 96: daemonrpc.ArmVHTLCRecoveryResponse
+	(*EscalateVHTLCRecoveryRequest)(nil),          // 97: daemonrpc.EscalateVHTLCRecoveryRequest
+	(*EscalateVHTLCRecoveryResponse)(nil),         // 98: daemonrpc.EscalateVHTLCRecoveryResponse
+	(*CancelVHTLCRecoveryRequest)(nil),            // 99: daemonrpc.CancelVHTLCRecoveryRequest
+	(*CancelVHTLCRecoveryResponse)(nil),           // 100: daemonrpc.CancelVHTLCRecoveryResponse
+	(*GetVHTLCRecoveryStatusRequest)(nil),         // 101: daemonrpc.GetVHTLCRecoveryStatusRequest
+	(*GetVHTLCRecoveryStatusResponse)(nil),        // 102: daemonrpc.GetVHTLCRecoveryStatusResponse
+	(*ListVHTLCRecoveriesRequest)(nil),            // 103: daemonrpc.ListVHTLCRecoveriesRequest
+	(*ListVHTLCRecoveriesResponse)(nil),           // 104: daemonrpc.ListVHTLCRecoveriesResponse
+	(*VHTLCRecoveryStatus)(nil),                   // 105: daemonrpc.VHTLCRecoveryStatus
+	nil,                                           // 106: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
 	0,   // 0: daemonrpc.GetInfoResponse.wallet_state:type_name -> daemonrpc.WalletState
@@ -8390,120 +8614,123 @@ var file_daemon_proto_depIdxs = []int32{
 	51,  // 16: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
 	51,  // 17: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
 	54,  // 18: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
-	104, // 19: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
-	62,  // 20: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
-	65,  // 21: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
-	66,  // 22: daemonrpc.ListBoardingSweepsResponse.sweeps:type_name -> daemonrpc.BoardingSweep
-	2,   // 23: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
-	68,  // 24: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
-	2,   // 25: daemonrpc.ListRoundsRequest.state_filter:type_name -> daemonrpc.RoundState
-	69,  // 26: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
-	69,  // 27: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
-	69,  // 28: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
-	3,   // 29: daemonrpc.OORSessionInfo.direction:type_name -> daemonrpc.OORSessionDirection
-	4,   // 30: daemonrpc.OORSessionInfo.status:type_name -> daemonrpc.OORSessionStatus
-	3,   // 31: daemonrpc.ListOORSessionsRequest.direction_filter:type_name -> daemonrpc.OORSessionDirection
-	4,   // 32: daemonrpc.ListOORSessionsRequest.status_filter:type_name -> daemonrpc.OORSessionStatus
-	76,  // 33: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
-	76,  // 34: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
-	84,  // 35: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
-	87,  // 36: daemonrpc.ListTransactionsResponse.transactions:type_name -> daemonrpc.TransactionHistoryEntry
-	5,   // 37: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
-	6,   // 38: daemonrpc.ArmVHTLCRecoveryRequest.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
-	7,   // 39: daemonrpc.ArmVHTLCRecoveryRequest.action:type_name -> daemonrpc.VHTLCRecoveryAction
-	103, // 40: daemonrpc.ArmVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	103, // 41: daemonrpc.EscalateVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	103, // 42: daemonrpc.CancelVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	103, // 43: daemonrpc.GetVHTLCRecoveryStatusResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	103, // 44: daemonrpc.ListVHTLCRecoveriesResponse.statuses:type_name -> daemonrpc.VHTLCRecoveryStatus
-	6,   // 45: daemonrpc.VHTLCRecoveryStatus.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
-	7,   // 46: daemonrpc.VHTLCRecoveryStatus.action:type_name -> daemonrpc.VHTLCRecoveryAction
-	8,   // 47: daemonrpc.VHTLCRecoveryStatus.state:type_name -> daemonrpc.VHTLCRecoveryState
-	5,   // 48: daemonrpc.VHTLCRecoveryStatus.unroll_status:type_name -> daemonrpc.UnrollJobStatus
-	54,  // 49: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
-	9,   // 50: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
-	12,  // 51: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
-	14,  // 52: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
-	16,  // 53: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
-	18,  // 54: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
-	21,  // 55: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
-	23,  // 56: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
-	25,  // 57: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
-	27,  // 58: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
-	29,  // 59: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
-	31,  // 60: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
-	33,  // 61: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
-	35,  // 62: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
-	37,  // 63: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
-	40,  // 64: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
-	42,  // 65: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
-	46,  // 66: daemonrpc.DaemonService.PrepareOOR:input_type -> daemonrpc.PrepareOORRequest
-	49,  // 67: daemonrpc.DaemonService.SignOORCustomInput:input_type -> daemonrpc.SignOORCustomInputRequest
-	52,  // 68: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
-	55,  // 69: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
-	57,  // 70: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
-	59,  // 71: daemonrpc.DaemonService.JoinNextRound:input_type -> daemonrpc.JoinNextRoundRequest
-	61,  // 72: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
-	64,  // 73: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
-	70,  // 74: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
-	71,  // 75: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
-	74,  // 76: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
-	77,  // 77: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
-	79,  // 78: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
-	81,  // 79: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
-	83,  // 80: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
-	86,  // 81: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
-	89,  // 82: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
-	91,  // 83: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
-	93,  // 84: daemonrpc.DaemonService.ArmVHTLCRecovery:input_type -> daemonrpc.ArmVHTLCRecoveryRequest
-	95,  // 85: daemonrpc.DaemonService.EscalateVHTLCRecovery:input_type -> daemonrpc.EscalateVHTLCRecoveryRequest
-	97,  // 86: daemonrpc.DaemonService.CancelVHTLCRecovery:input_type -> daemonrpc.CancelVHTLCRecoveryRequest
-	99,  // 87: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> daemonrpc.GetVHTLCRecoveryStatusRequest
-	101, // 88: daemonrpc.DaemonService.ListVHTLCRecoveries:input_type -> daemonrpc.ListVHTLCRecoveriesRequest
-	10,  // 89: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	13,  // 90: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	15,  // 91: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	17,  // 92: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	19,  // 93: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	22,  // 94: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	24,  // 95: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	26,  // 96: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
-	28,  // 97: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
-	30,  // 98: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
-	32,  // 99: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
-	34,  // 100: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
-	36,  // 101: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
-	38,  // 102: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
-	41,  // 103: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	45,  // 104: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	48,  // 105: daemonrpc.DaemonService.PrepareOOR:output_type -> daemonrpc.PrepareOORResponse
-	50,  // 106: daemonrpc.DaemonService.SignOORCustomInput:output_type -> daemonrpc.SignOORCustomInputResponse
-	53,  // 107: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	56,  // 108: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
-	58,  // 109: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	60,  // 110: daemonrpc.DaemonService.JoinNextRound:output_type -> daemonrpc.JoinNextRoundResponse
-	63,  // 111: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
-	67,  // 112: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
-	73,  // 113: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	72,  // 114: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
-	75,  // 115: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	78,  // 116: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
-	80,  // 117: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
-	82,  // 118: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
-	85,  // 119: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
-	88,  // 120: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
-	90,  // 121: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
-	92,  // 122: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
-	94,  // 123: daemonrpc.DaemonService.ArmVHTLCRecovery:output_type -> daemonrpc.ArmVHTLCRecoveryResponse
-	96,  // 124: daemonrpc.DaemonService.EscalateVHTLCRecovery:output_type -> daemonrpc.EscalateVHTLCRecoveryResponse
-	98,  // 125: daemonrpc.DaemonService.CancelVHTLCRecovery:output_type -> daemonrpc.CancelVHTLCRecoveryResponse
-	100, // 126: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> daemonrpc.GetVHTLCRecoveryStatusResponse
-	102, // 127: daemonrpc.DaemonService.ListVHTLCRecoveries:output_type -> daemonrpc.ListVHTLCRecoveriesResponse
-	89,  // [89:128] is the sub-list for method output_type
-	50,  // [50:89] is the sub-list for method input_type
-	50,  // [50:50] is the sub-list for extension type_name
-	50,  // [50:50] is the sub-list for extension extendee
-	0,   // [0:50] is the sub-list for field type_name
+	106, // 19: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	54,  // 20: daemonrpc.SendOnChainRequest.destination:type_name -> daemonrpc.LeaveDestination
+	64,  // 21: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
+	67,  // 22: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
+	68,  // 23: daemonrpc.ListBoardingSweepsResponse.sweeps:type_name -> daemonrpc.BoardingSweep
+	2,   // 24: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
+	70,  // 25: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
+	2,   // 26: daemonrpc.ListRoundsRequest.state_filter:type_name -> daemonrpc.RoundState
+	71,  // 27: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
+	71,  // 28: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
+	71,  // 29: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
+	3,   // 30: daemonrpc.OORSessionInfo.direction:type_name -> daemonrpc.OORSessionDirection
+	4,   // 31: daemonrpc.OORSessionInfo.status:type_name -> daemonrpc.OORSessionStatus
+	3,   // 32: daemonrpc.ListOORSessionsRequest.direction_filter:type_name -> daemonrpc.OORSessionDirection
+	4,   // 33: daemonrpc.ListOORSessionsRequest.status_filter:type_name -> daemonrpc.OORSessionStatus
+	78,  // 34: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
+	78,  // 35: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
+	86,  // 36: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
+	89,  // 37: daemonrpc.ListTransactionsResponse.transactions:type_name -> daemonrpc.TransactionHistoryEntry
+	5,   // 38: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
+	6,   // 39: daemonrpc.ArmVHTLCRecoveryRequest.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
+	7,   // 40: daemonrpc.ArmVHTLCRecoveryRequest.action:type_name -> daemonrpc.VHTLCRecoveryAction
+	105, // 41: daemonrpc.ArmVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	105, // 42: daemonrpc.EscalateVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	105, // 43: daemonrpc.CancelVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	105, // 44: daemonrpc.GetVHTLCRecoveryStatusResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	105, // 45: daemonrpc.ListVHTLCRecoveriesResponse.statuses:type_name -> daemonrpc.VHTLCRecoveryStatus
+	6,   // 46: daemonrpc.VHTLCRecoveryStatus.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
+	7,   // 47: daemonrpc.VHTLCRecoveryStatus.action:type_name -> daemonrpc.VHTLCRecoveryAction
+	8,   // 48: daemonrpc.VHTLCRecoveryStatus.state:type_name -> daemonrpc.VHTLCRecoveryState
+	5,   // 49: daemonrpc.VHTLCRecoveryStatus.unroll_status:type_name -> daemonrpc.UnrollJobStatus
+	54,  // 50: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
+	9,   // 51: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
+	12,  // 52: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
+	14,  // 53: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
+	16,  // 54: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
+	18,  // 55: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
+	21,  // 56: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
+	23,  // 57: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
+	25,  // 58: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
+	27,  // 59: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
+	29,  // 60: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
+	31,  // 61: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
+	33,  // 62: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
+	35,  // 63: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
+	37,  // 64: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
+	40,  // 65: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	42,  // 66: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	46,  // 67: daemonrpc.DaemonService.PrepareOOR:input_type -> daemonrpc.PrepareOORRequest
+	49,  // 68: daemonrpc.DaemonService.SignOORCustomInput:input_type -> daemonrpc.SignOORCustomInputRequest
+	52,  // 69: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	55,  // 70: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
+	57,  // 71: daemonrpc.DaemonService.SendOnChain:input_type -> daemonrpc.SendOnChainRequest
+	59,  // 72: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
+	61,  // 73: daemonrpc.DaemonService.JoinNextRound:input_type -> daemonrpc.JoinNextRoundRequest
+	63,  // 74: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
+	66,  // 75: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
+	72,  // 76: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
+	73,  // 77: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
+	76,  // 78: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
+	79,  // 79: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
+	81,  // 80: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
+	83,  // 81: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
+	85,  // 82: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
+	88,  // 83: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
+	91,  // 84: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
+	93,  // 85: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
+	95,  // 86: daemonrpc.DaemonService.ArmVHTLCRecovery:input_type -> daemonrpc.ArmVHTLCRecoveryRequest
+	97,  // 87: daemonrpc.DaemonService.EscalateVHTLCRecovery:input_type -> daemonrpc.EscalateVHTLCRecoveryRequest
+	99,  // 88: daemonrpc.DaemonService.CancelVHTLCRecovery:input_type -> daemonrpc.CancelVHTLCRecoveryRequest
+	101, // 89: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> daemonrpc.GetVHTLCRecoveryStatusRequest
+	103, // 90: daemonrpc.DaemonService.ListVHTLCRecoveries:input_type -> daemonrpc.ListVHTLCRecoveriesRequest
+	10,  // 91: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	13,  // 92: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	15,  // 93: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	17,  // 94: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	19,  // 95: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	22,  // 96: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	24,  // 97: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	26,  // 98: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
+	28,  // 99: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
+	30,  // 100: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
+	32,  // 101: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
+	34,  // 102: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
+	36,  // 103: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
+	38,  // 104: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
+	41,  // 105: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	45,  // 106: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	48,  // 107: daemonrpc.DaemonService.PrepareOOR:output_type -> daemonrpc.PrepareOORResponse
+	50,  // 108: daemonrpc.DaemonService.SignOORCustomInput:output_type -> daemonrpc.SignOORCustomInputResponse
+	53,  // 109: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	56,  // 110: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
+	58,  // 111: daemonrpc.DaemonService.SendOnChain:output_type -> daemonrpc.SendOnChainResponse
+	60,  // 112: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	62,  // 113: daemonrpc.DaemonService.JoinNextRound:output_type -> daemonrpc.JoinNextRoundResponse
+	65,  // 114: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
+	69,  // 115: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
+	75,  // 116: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	74,  // 117: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
+	77,  // 118: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	80,  // 119: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
+	82,  // 120: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
+	84,  // 121: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
+	87,  // 122: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
+	90,  // 123: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
+	92,  // 124: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
+	94,  // 125: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
+	96,  // 126: daemonrpc.DaemonService.ArmVHTLCRecovery:output_type -> daemonrpc.ArmVHTLCRecoveryResponse
+	98,  // 127: daemonrpc.DaemonService.EscalateVHTLCRecovery:output_type -> daemonrpc.EscalateVHTLCRecoveryResponse
+	100, // 128: daemonrpc.DaemonService.CancelVHTLCRecovery:output_type -> daemonrpc.CancelVHTLCRecoveryResponse
+	102, // 129: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> daemonrpc.GetVHTLCRecoveryStatusResponse
+	104, // 130: daemonrpc.DaemonService.ListVHTLCRecoveries:output_type -> daemonrpc.ListVHTLCRecoveriesResponse
+	91,  // [91:131] is the sub-list for method output_type
+	51,  // [51:91] is the sub-list for method input_type
+	51,  // [51:51] is the sub-list for extension type_name
+	51,  // [51:51] is the sub-list for extension extendee
+	0,   // [0:51] is the sub-list for field type_name
 }
 
 func init() { file_daemon_proto_init() }
@@ -8528,13 +8755,17 @@ func file_daemon_proto_init() {
 		(*LeaveVTXOsRequest_Outpoints)(nil),
 		(*LeaveVTXOsRequest_All)(nil),
 	}
+	file_daemon_proto_msgTypes[48].OneofWrappers = []any{
+		(*SendOnChainRequest_AmountSat)(nil),
+		(*SendOnChainRequest_SweepAll)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      9,
-			NumMessages:   96,
+			NumMessages:   98,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.pb.gw.go
+++ b/daemonrpc/daemon.pb.gw.go
@@ -575,6 +575,33 @@ func local_request_DaemonService_LeaveVTXOs_0(ctx context.Context, marshaler run
 	return msg, metadata, err
 }
 
+func request_DaemonService_SendOnChain_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SendOnChainRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.SendOnChain(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_DaemonService_SendOnChain_0(ctx context.Context, marshaler runtime.Marshaler, server DaemonServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SendOnChainRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.SendOnChain(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_DaemonService_Board_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq BoardRequest
@@ -1490,6 +1517,26 @@ func RegisterDaemonServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_LeaveVTXOs_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_SendOnChain_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/daemonrpc.DaemonService/SendOnChain", runtime.WithHTTPPathPattern("/v1/daemon/send-onchain"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_DaemonService_SendOnChain_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_SendOnChain_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_DaemonService_Board_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2237,6 +2284,23 @@ func RegisterDaemonServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_LeaveVTXOs_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_SendOnChain_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/daemonrpc.DaemonService/SendOnChain", runtime.WithHTTPPathPattern("/v1/daemon/send-onchain"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_DaemonService_SendOnChain_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_SendOnChain_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_DaemonService_Board_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2584,6 +2648,7 @@ var (
 	pattern_DaemonService_SignOORCustomInput_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "sign-oor-custom-input"}, ""))
 	pattern_DaemonService_RefreshVTXOs_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "refresh-vtxos"}, ""))
 	pattern_DaemonService_LeaveVTXOs_0                    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "leave-vtxos"}, ""))
+	pattern_DaemonService_SendOnChain_0                   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "send-onchain"}, ""))
 	pattern_DaemonService_Board_0                         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "board"}, ""))
 	pattern_DaemonService_JoinNextRound_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "join-next-round"}, ""))
 	pattern_DaemonService_SweepBoardingUTXOs_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "sweep-boarding-utxos"}, ""))
@@ -2626,6 +2691,7 @@ var (
 	forward_DaemonService_SignOORCustomInput_0            = runtime.ForwardResponseMessage
 	forward_DaemonService_RefreshVTXOs_0                  = runtime.ForwardResponseMessage
 	forward_DaemonService_LeaveVTXOs_0                    = runtime.ForwardResponseMessage
+	forward_DaemonService_SendOnChain_0                   = runtime.ForwardResponseMessage
 	forward_DaemonService_Board_0                         = runtime.ForwardResponseMessage
 	forward_DaemonService_JoinNextRound_0                 = runtime.ForwardResponseMessage
 	forward_DaemonService_SweepBoardingUTXOs_0            = runtime.ForwardResponseMessage

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -104,6 +104,17 @@ service DaemonService {
     // lands as an on-chain output at the specified destination.
     rpc LeaveVTXOs (LeaveVTXOsRequest) returns (LeaveVTXOsResponse);
 
+    // SendOnChain is the wallet-shaped onchain payment primitive: it
+    // picks live VTXOs to cover the requested amount, forfeits them
+    // in the next round, produces one on-chain output of the exact
+    // requested amount at the supplied destination, and returns any
+    // residual to the caller as a change VTXO. The atomic
+    // forfeit + leave + change-VTXO intent registers immediately
+    // (TriggerRegistration=true) so the caller does not need to also
+    // issue JoinNextRound. sweep_all skips selection and drains every
+    // live VTXO to the destination (no change VTXO produced).
+    rpc SendOnChain (SendOnChainRequest) returns (SendOnChainResponse);
+
     // Board triggers the client to join the next round with any
     // confirmed boarding UTXOs. This sends IntentRequested to
     // the round FSM, which emits a JoinRoundRequest to the server.
@@ -961,6 +972,63 @@ message LeaveVTXOsResponse {
 
     // status is the result: "queued" on success, "preview" on dry_run.
     string status = 2;
+}
+
+message SendOnChainRequest {
+    // destination is the on-chain recipient. Same shape (and standardness
+    // gating) as LeaveVTXOsRequest.default_destination.
+    LeaveDestination destination = 1;
+
+    // amount picks the send mode. Exactly one variant must be set.
+    oneof amount {
+        // amount_sat is the exact number of sats to send on-chain to
+        // destination. The daemon selects live VTXOs whose summed value
+        // covers amount_sat plus an operator-fee headroom plus dust,
+        // forfeits them, produces one on-chain output of exactly
+        // amount_sat, and returns the residual to the caller as a
+        // change VTXO. Must be > 0 and ≤ MaxSatoshi.
+        int64 amount_sat = 2;
+
+        // sweep_all, when true, drains every live VTXO into a single
+        // on-chain output at destination. No change VTXO is produced;
+        // the actual on-chain amount equals Σ(live VTXOs) − operator
+        // fee and is echoed back as actual_amount_sat.
+        bool sweep_all = 3;
+    }
+
+    // dry_run validates inputs and returns the planned selection
+    // without submitting the round intent.
+    bool dry_run = 5;
+}
+
+message SendOnChainResponse {
+    // actual_amount_sat is the exact value of the on-chain output
+    // that will land at destination. For amount_sat mode this echoes
+    // the requested amount. For sweep_all it is Σ(selected VTXOs) −
+    // operator fee.
+    int64 actual_amount_sat = 1;
+
+    // fee_sat is the operator fee deducted from the input set for
+    // this send. Under the #270 seal-time fee handshake this is the
+    // server-stamped figure, not a pre-flight estimate. Zero in
+    // dry_run mode.
+    int64 fee_sat = 2;
+
+    // selected_outpoints lists the VTXOs the daemon picked to
+    // forfeit for this send, in the order they were chosen.
+    repeated string selected_outpoints = 3;
+
+    // change_outpoint is the outpoint of the change VTXO produced
+    // by an amount_sat send. Empty in dry_run, in sweep_all mode,
+    // or when no change is needed (input set exactly covers
+    // amount_sat + fee + dust). The outpoint is populated once the
+    // round seals and the new VTXO is persisted; in fast-path
+    // responses it may be empty pending the round.
+    string change_outpoint = 4;
+
+    // status is "submitted" on a successful intent registration,
+    // "preview" when dry_run is set.
+    string status = 5;
 }
 
 message BoardRequest {

--- a/daemonrpc/daemon.yaml
+++ b/daemonrpc/daemon.yaml
@@ -63,6 +63,9 @@ http:
     - selector: daemonrpc.DaemonService.LeaveVTXOs
       post: /v1/daemon/leave-vtxos
       body: "*"
+    - selector: daemonrpc.DaemonService.SendOnChain
+      post: /v1/daemon/send-onchain
+      body: "*"
     - selector: daemonrpc.DaemonService.Board
       post: /v1/daemon/board
       body: "*"

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -39,6 +39,7 @@ const (
 	DaemonService_SignOORCustomInput_FullMethodName            = "/daemonrpc.DaemonService/SignOORCustomInput"
 	DaemonService_RefreshVTXOs_FullMethodName                  = "/daemonrpc.DaemonService/RefreshVTXOs"
 	DaemonService_LeaveVTXOs_FullMethodName                    = "/daemonrpc.DaemonService/LeaveVTXOs"
+	DaemonService_SendOnChain_FullMethodName                   = "/daemonrpc.DaemonService/SendOnChain"
 	DaemonService_Board_FullMethodName                         = "/daemonrpc.DaemonService/Board"
 	DaemonService_JoinNextRound_FullMethodName                 = "/daemonrpc.DaemonService/JoinNextRound"
 	DaemonService_SweepBoardingUTXOs_FullMethodName            = "/daemonrpc.DaemonService/SweepBoardingUTXOs"
@@ -137,6 +138,16 @@ type DaemonServiceClient interface {
 	// forfeited amount (minus the quoted per-input operator fee)
 	// lands as an on-chain output at the specified destination.
 	LeaveVTXOs(ctx context.Context, in *LeaveVTXOsRequest, opts ...grpc.CallOption) (*LeaveVTXOsResponse, error)
+	// SendOnChain is the wallet-shaped onchain payment primitive: it
+	// picks live VTXOs to cover the requested amount, forfeits them
+	// in the next round, produces one on-chain output of the exact
+	// requested amount at the supplied destination, and returns any
+	// residual to the caller as a change VTXO. The atomic
+	// forfeit + leave + change-VTXO intent registers immediately
+	// (TriggerRegistration=true) so the caller does not need to also
+	// issue JoinNextRound. sweep_all skips selection and drains every
+	// live VTXO to the destination (no change VTXO produced).
+	SendOnChain(ctx context.Context, in *SendOnChainRequest, opts ...grpc.CallOption) (*SendOnChainResponse, error)
 	// Board triggers the client to join the next round with any
 	// confirmed boarding UTXOs. This sends IntentRequested to
 	// the round FSM, which emits a JoinRoundRequest to the server.
@@ -411,6 +422,16 @@ func (c *daemonServiceClient) LeaveVTXOs(ctx context.Context, in *LeaveVTXOsRequ
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(LeaveVTXOsResponse)
 	err := c.cc.Invoke(ctx, DaemonService_LeaveVTXOs_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) SendOnChain(ctx context.Context, in *SendOnChainRequest, opts ...grpc.CallOption) (*SendOnChainResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SendOnChainResponse)
+	err := c.cc.Invoke(ctx, DaemonService_SendOnChain_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -693,6 +714,16 @@ type DaemonServiceServer interface {
 	// forfeited amount (minus the quoted per-input operator fee)
 	// lands as an on-chain output at the specified destination.
 	LeaveVTXOs(context.Context, *LeaveVTXOsRequest) (*LeaveVTXOsResponse, error)
+	// SendOnChain is the wallet-shaped onchain payment primitive: it
+	// picks live VTXOs to cover the requested amount, forfeits them
+	// in the next round, produces one on-chain output of the exact
+	// requested amount at the supplied destination, and returns any
+	// residual to the caller as a change VTXO. The atomic
+	// forfeit + leave + change-VTXO intent registers immediately
+	// (TriggerRegistration=true) so the caller does not need to also
+	// issue JoinNextRound. sweep_all skips selection and drains every
+	// live VTXO to the destination (no change VTXO produced).
+	SendOnChain(context.Context, *SendOnChainRequest) (*SendOnChainResponse, error)
 	// Board triggers the client to join the next round with any
 	// confirmed boarding UTXOs. This sends IntentRequested to
 	// the round FSM, which emits a JoinRoundRequest to the server.
@@ -832,6 +863,9 @@ func (UnimplementedDaemonServiceServer) RefreshVTXOs(context.Context, *RefreshVT
 }
 func (UnimplementedDaemonServiceServer) LeaveVTXOs(context.Context, *LeaveVTXOsRequest) (*LeaveVTXOsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method LeaveVTXOs not implemented")
+}
+func (UnimplementedDaemonServiceServer) SendOnChain(context.Context, *SendOnChainRequest) (*SendOnChainResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SendOnChain not implemented")
 }
 func (UnimplementedDaemonServiceServer) Board(context.Context, *BoardRequest) (*BoardResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Board not implemented")
@@ -1271,6 +1305,24 @@ func _DaemonService_LeaveVTXOs_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_SendOnChain_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SendOnChainRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).SendOnChain(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_SendOnChain_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).SendOnChain(ctx, req.(*SendOnChainRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _DaemonService_Board_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(BoardRequest)
 	if err := dec(in); err != nil {
@@ -1692,6 +1744,10 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "LeaveVTXOs",
 			Handler:    _DaemonService_LeaveVTXOs_Handler,
+		},
+		{
+			MethodName: "SendOnChain",
+			Handler:    _DaemonService_SendOnChain_Handler,
 		},
 		{
 			MethodName: "Board",

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -64,6 +64,8 @@ type DaemonServiceMailboxServer interface {
 	RefreshVTXOs(ctx context.Context, req *RefreshVTXOsRequest) (*RefreshVTXOsResponse, error)
 	// LeaveVTXOs handles LeaveVTXOs.
 	LeaveVTXOs(ctx context.Context, req *LeaveVTXOsRequest) (*LeaveVTXOsResponse, error)
+	// SendOnChain handles SendOnChain.
+	SendOnChain(ctx context.Context, req *SendOnChainRequest) (*SendOnChainResponse, error)
 	// Board handles Board.
 	Board(ctx context.Context, req *BoardRequest) (*BoardResponse, error)
 	// JoinNextRound handles JoinNextRound.
@@ -305,6 +307,16 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.LeaveVTXOs(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "SendOnChain", func() proto.Message {
+		return &SendOnChainRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*SendOnChainRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.SendOnChain(ctx, req)
 	})
 	r.Handle("daemonrpc.DaemonService", "Board", func() proto.Message {
 		return &BoardRequest{}
@@ -951,6 +963,29 @@ func (c *DaemonServiceMailboxClient) LeaveVTXOs(ctx context.Context, req *LeaveV
 	}
 
 	resp := new(LeaveVTXOsResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// SendOnChain calls the SendOnChain RPC.
+func (c *DaemonServiceMailboxClient) SendOnChain(ctx context.Context, req *SendOnChainRequest, opts ...rpc.RPCOptions) (*SendOnChainResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "SendOnChain",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(SendOnChainResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -1507,6 +1507,189 @@ func (r *RPCServer) LeaveVTXOs(ctx context.Context,
 	}, nil
 }
 
+// SendOnChain plans and submits an atomic onchain payment from VTXOs.
+// The RPC enforces the wallet-API invariants on the request shape
+// (exactly one of amount_sat / sweep_all set, destination present,
+// destination resolves to a standard pkScript) and then dispatches to
+// the wallet actor's handleSendOnChain. For sweep_all the RPC layer
+// also enumerates the live VTXO set via vtxoStore so the wallet does
+// not have to bypass the manager's admission gate to drain the wallet.
+func (r *RPCServer) SendOnChain(ctx context.Context,
+	req *daemonrpc.SendOnChainRequest) (*daemonrpc.SendOnChainResponse,
+	error) {
+
+	// Pure-argument validation first so a malformed request surfaces
+	// InvalidArgument before any wallet-state check.
+	if req.GetDestination() == nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"destination is required")
+	}
+
+	pkScript, err := r.resolveLeaveDestination(req.GetDestination())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"destination: %v", err)
+	}
+
+	var (
+		targetAmount btcutil.Amount
+		sweepAll     bool
+	)
+	switch amt := req.Amount.(type) {
+	case *daemonrpc.SendOnChainRequest_AmountSat:
+		if amt.AmountSat <= 0 ||
+			amt.AmountSat > int64(btcutil.MaxSatoshi) {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"amount_sat must be between 1 and %d",
+				int64(btcutil.MaxSatoshi))
+		}
+		targetAmount = btcutil.Amount(amt.AmountSat)
+
+	case *daemonrpc.SendOnChainRequest_SweepAll:
+		if !amt.SweepAll {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"sweep_all must be true when selected")
+		}
+		sweepAll = true
+
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "amount "+
+			"mode is required (amount_sat or sweep_all)")
+	}
+
+	// Fetch operator terms for the change VTXO descriptor + the
+	// coin-selection headroom hint. Under #270 the binding fee is
+	// stamped server-side; MinOperatorFee is advisory only.
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "fetch operator "+
+			"terms: %v", err)
+	}
+
+	// For sweep_all, enumerate live VTXOs up front. We do this at
+	// the RPC layer (not in the wallet actor) so the dry_run path
+	// can echo the planned outpoint set without reserving anything,
+	// and so the wallet does not need its own live-set listing seam.
+	var sweepOutpoints []wire.OutPoint
+	if sweepAll {
+		if r.server.vtxoStore == nil {
+			return nil, status.Errorf(codes.Internal, "vtxo "+
+				"store not initialized")
+		}
+
+		liveVTXOs, err := r.server.vtxoStore.ListLiveVTXOs(ctx)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "list live "+
+				"VTXOs: %v", err)
+		}
+		if len(liveVTXOs) == 0 {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"no live VTXOs to sweep")
+		}
+
+		for _, v := range liveVTXOs {
+			sweepOutpoints = append(sweepOutpoints, v.Outpoint)
+		}
+	}
+
+	// Every path below touches the wallet, so gate on it now.
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if !r.server.walletRef.IsSome() {
+		return nil, status.Errorf(codes.Internal, "wallet actor not "+
+			"initialized")
+	}
+
+	wRef := r.server.walletRef.UnsafeFromSome()
+
+	sendReq := &wallet.SendOnChainRequest{
+		DestinationPkScript: pkScript,
+		TargetAmountSat:     targetAmount,
+		SweepOutpoints:      sweepOutpoints,
+		OperatorFee:         terms.MinOperatorFee,
+		DustLimit:           terms.DustLimit,
+		OperatorKey:         terms.PubKey,
+		VTXOExitDelay:       terms.VTXOExitDelay,
+		DryRun:              req.DryRun,
+	}
+
+	// Strip caller cancellation from the wallet Ask: SendOnChain is
+	// the wallet-shaped onchain-payment one-shot, and the CLI client
+	// typically disconnects as soon as this RPC returns "submitted".
+	// The downstream pipeline (wallet → client-side round actor →
+	// outbound mailbox publish → operator-side join validation →
+	// forfeit-VTXO lookup) all inherits the actor-system per-message
+	// ctx from this Ask; without WithoutCancel here the CLI exit
+	// races the operator's admission lookup and the round fails with
+	// "context canceled". The Await keeps the original ctx so the
+	// caller can still abort waiting for the wallet response. Mirrors
+	// JoinNextRound → TriggerRoundRegistration.
+	askCtx := context.WithoutCancel(ctx)
+	future := wRef.Ask(askCtx, sendReq)
+	result := future.Await(ctx)
+
+	resp, err := result.Unpack()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "send on-chain "+
+			"failed: %v", err)
+	}
+
+	sendResp, ok := resp.(*wallet.SendOnChainResponse)
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "unexpected "+
+			"response type: %T", resp)
+	}
+
+	// Trigger round registration on a fresh Ask boundary so the
+	// IntentRequested → outbound JoinRoundRequest publish → operator
+	// admission lookup chain runs under TriggerRoundRegistration's
+	// detached context. This mirrors the JoinNextRound RPC pattern:
+	// SendOnChain is a one-shot, so the wallet host must not be
+	// asked to also call JoinNextRound separately. Skip for dry_run
+	// since the wallet handler released the reservation rather than
+	// committing the intent.
+	if !req.DryRun {
+		if err := r.server.TriggerRoundRegistration(ctx); err != nil {
+			return nil, status.Errorf(codes.Internal, "trigger "+
+				"round registration: %v", err)
+		}
+	}
+
+	outpointStrs := make([]string, 0, len(sendResp.SelectedOutpoints))
+	for _, op := range sendResp.SelectedOutpoints {
+		outpointStrs = append(
+			outpointStrs, fmt.Sprintf("%s:%d", op.Hash, op.Index),
+		)
+	}
+
+	r.server.log.InfoS(ctx, "SendOnChain completed",
+		slog.String("status", sendResp.Status.String()),
+		slog.Bool("sweep_all", sweepAll),
+		slog.Int64("actual_amount_sat",
+			int64(sendResp.ActualAmountSat)),
+		slog.Int("selected_count",
+			len(sendResp.SelectedOutpoints)),
+		slog.Int64("change_amount",
+			int64(sendResp.ChangeAmount)),
+	)
+
+	return &daemonrpc.SendOnChainResponse{
+		ActualAmountSat:   int64(sendResp.ActualAmountSat),
+		SelectedOutpoints: outpointStrs,
+		Status:            sendResp.Status.String(),
+
+		// FeeSat and ChangeOutpoint are populated once the round
+		// seals and the seal-time quote becomes known. The fast-
+		// path response returns zero / empty here; callers that
+		// need the final values look them up via the wallet
+		// history once the round confirms.
+		FeeSat:         0,
+		ChangeOutpoint: "",
+	}, nil
+}
+
 // Board triggers the client to join the next round with any confirmed
 // boarding UTXOs. The RPC delegates the full flow to the wallet actor:
 // balance check, VTXO amount computation, and round registration. It

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -436,6 +436,17 @@ func (c *DaemonServiceClient) LeaveVTXOs(ctx context.Context,
 	return out, err
 }
 
+// SendOnChain plans and submits an atomic onchain payment from VTXOs.
+func (c *DaemonServiceClient) SendOnChain(ctx context.Context,
+	in *daemonrpc.SendOnChainRequest, _ ...grpc.CallOption) (
+	*daemonrpc.SendOnChainResponse, error) {
+
+	out := new(daemonrpc.SendOnChainResponse)
+	err := c.client.Post(ctx, "/v1/daemon/send-onchain", in, out)
+
+	return out, err
+}
+
 // Board queues confirmed boarding UTXOs for the next round.
 func (c *DaemonServiceClient) Board(ctx context.Context,
 	in *daemonrpc.BoardRequest, _ ...grpc.CallOption) (

--- a/swapwallet/deps.go
+++ b/swapwallet/deps.go
@@ -30,6 +30,10 @@ type RPCServer interface {
 		req *daemonrpc.LeaveVTXOsRequest) (
 		*daemonrpc.LeaveVTXOsResponse, error)
 
+	SendOnChain(ctx context.Context,
+		req *daemonrpc.SendOnChainRequest) (
+		*daemonrpc.SendOnChainResponse, error)
+
 	ListVTXOs(ctx context.Context,
 		req *daemonrpc.ListVTXOsRequest) (
 		*daemonrpc.ListVTXOsResponse,

--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -64,6 +64,11 @@ type fakeRPCServer struct {
 	joinNextRoundResp  *daemonrpc.JoinNextRoundResponse
 	joinNextRoundErr   error
 	joinNextRoundCalls int
+
+	sendOnChainResp    *daemonrpc.SendOnChainResponse
+	sendOnChainErr     error
+	sendOnChainCalls   int
+	sendOnChainLastReq *daemonrpc.SendOnChainRequest
 }
 
 func (f *fakeRPCServer) LeaveVTXOs(_ context.Context,
@@ -195,6 +200,19 @@ func (f *fakeRPCServer) JoinNextRound(_ context.Context,
 	f.joinNextRoundCalls++
 
 	return f.joinNextRoundResp, f.joinNextRoundErr
+}
+
+func (f *fakeRPCServer) SendOnChain(_ context.Context,
+	req *daemonrpc.SendOnChainRequest) (*daemonrpc.SendOnChainResponse,
+	error) {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.sendOnChainCalls++
+	f.sendOnChainLastReq = req
+
+	return f.sendOnChainResp, f.sendOnChainErr
 }
 
 // fakeSwapService is a minimal swapclientrpc.SwapClientServiceServer used

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -308,75 +308,66 @@ func (r *router) prepareOnchain(ctx context.Context, addr string,
 	), nil
 }
 
-// sendOnchainIntent routes a prepared onchain destination through the existing
-// LeaveVTXOs cooperative-exit RPC.
+// sendOnchainIntent routes a prepared onchain destination through the
+// daemon's SendOnChain RPC. The daemon owns VTXO selection, intent
+// composition (forfeits + one fixed leave output + one change VTXO in
+// bounded mode; forfeits + one fee-absorbing leave output in sweep-all
+// mode), and atomic round registration — the wallet layer is a thin
+// translator from the prepared intent to daemonrpc.SendOnChainRequest
+// plus the WalletEntry stub the deadline watcher needs.
+//
+// Exact-amount semantics: a bounded send (--amt N) lands exactly N
+// sats at the destination; any residual returns to the caller as a
+// change VTXO under the #270 seal-time fee handshake. The earlier
+// "whole-VTXO sweep semantics" overpay (issue #634) is gone.
 func (r *router) sendOnchainIntent(ctx context.Context,
 	intent *preparedSendIntent) (*walletdkrpc.SendResponse, error) {
 
 	if r.deps.RPCServer == nil {
 		return nil, ErrSwapBackendUnavailable
 	}
-	if len(intent.selectedOutpoints) == 0 {
-		return nil, ErrInvalidSendIntent
-	}
 
-	leaveReq := &daemonrpc.LeaveVTXOsRequest{
-		Selection: &daemonrpc.LeaveVTXOsRequest_Outpoints{
-			Outpoints: &daemonrpc.OutpointSelection{
-				Outpoints: append(
-					[]string(nil),
-					intent.selectedOutpoints...,
-				),
-			},
-		},
-		DefaultDestination: &daemonrpc.LeaveDestination{
+	sendReq := &daemonrpc.SendOnChainRequest{
+		Destination: &daemonrpc.LeaveDestination{
 			Target: &daemonrpc.LeaveDestination_Address{
 				Address: intent.onchainAddress,
 			},
 		},
 	}
+	if intent.sweepAll {
+		sendReq.Amount = &daemonrpc.SendOnChainRequest_SweepAll{
+			SweepAll: true,
+		}
+	} else {
+		sendReq.Amount = &daemonrpc.SendOnChainRequest_AmountSat{
+			AmountSat: int64(intent.amountSat),
+		}
+	}
 
-	resp, err := r.deps.RPCServer.LeaveVTXOs(ctx, leaveReq)
+	sendResp, err := r.deps.RPCServer.SendOnChain(ctx, sendReq)
 	if err != nil {
-		return nil, fmt.Errorf("leave vtxos: %w", err)
+		return nil, fmt.Errorf("send on-chain: %w", err)
 	}
 
-	// LeaveVTXOs only QUEUES the leave intent in the round actor's
-	// PendingAssembly state; the round does not actually seal until
-	// the daemon receives a JoinNextRound trigger. The everyday
-	// wallet verb is documented as a one-shot ("send onchain"), so
-	// we commit the intent here on the caller's behalf. The ark.*
-	// raw `vtxos refresh` / `vtxos leave` CLI exposes the
-	// queue-only mode via --no_join for batching use cases; that
-	// path is not reachable through walletdkrpc.Send and should not
-	// be — the higher-level Send verb has no batching contract.
-	//
-	// A join failure here leaves the leave intent queued in the
-	// round actor: LeaveVTXOs has already returned successfully and
-	// the intent persists in PendingAssembly. We surface the error
-	// (rather than swallowing it) so the caller is not silently
-	// stranded — but the recovery is a one-liner, and the wrapped
-	// message embeds the exact `ark rounds join` command the user
-	// needs to commit the queued intent.
-	if _, err := r.deps.RPCServer.JoinNextRound(
-		ctx, &daemonrpc.JoinNextRoundRequest{},
-	); err != nil {
-		return nil, fmt.Errorf("auto-join next round after leave: the "+
-			"leave intent is queued and can be committed manually "+
-			"with `ark rounds join`: %w", err)
-	}
+	// SendOnChain registers the intent atomically (TriggerRegistration
+	// is set inside the daemon handler), so there is no explicit
+	// JoinNextRound call to make here — that was an artifact of the
+	// previous LeaveVTXOs-based implementation that queued without
+	// committing.
 
-	// For sweep-all the caller's amt_sat is required to be zero, so
-	// recording int64(amtSat) on the pending entry would make the row
-	// show as a zero-sat exit in List/SubscribeWallet. The real outflow
-	// is the actualSat sum of selected VTXOs computed above.
+	// In sweep-all mode the caller's amount_sat is zero, so the
+	// pending entry must carry the daemon-reported actual amount
+	// rather than logging a zero-sat exit row in
+	// List/SubscribeWallet. In bounded mode actual_amount_sat equals
+	// the requested --amt exactly under the new exact-amount path.
+	actualSat := sendResp.GetActualAmountSat()
 	entryAmt := int64(intent.amountSat)
 	if intent.sweepAll {
-		entryAmt = intent.actualAmountSat
+		entryAmt = actualSat
 	}
 	entry := leaveEntryStub(
-		resp.GetQueuedOutpoints(), intent.onchainAddress, entryAmt,
-		intent.note,
+		sendResp.GetSelectedOutpoints(), intent.onchainAddress,
+		entryAmt, intent.note,
 	)
 
 	// v1 SCOPE: we track the pending row for the deadline watcher
@@ -389,7 +380,7 @@ func (r *router) sendOnchainIntent(ctx context.Context,
 
 	return &walletdkrpc.SendResponse{
 		Entry:           entry,
-		ActualAmountSat: intent.actualAmountSat,
+		ActualAmountSat: actualSat,
 	}, nil
 }
 

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -213,11 +213,12 @@ func TestRouterSendInvoiceDispatchesStartPay(t *testing.T) {
 }
 
 // TestRouterSendOnchainSelectsVTXOsAndCallsLeave confirms that an onchain
-// destination triggers VTXO selection via ListVTXOs and then a LeaveVTXOs
-// call with the selected outpoints. It also asserts the response carries
-// the actual amount that will leave the wallet (the sum of selected
-// VTXOs), which under v1 whole-VTXO sweep semantics may exceed the
-// caller's amt_sat.
+// destination triggers a local VTXO snapshot via ListVTXOs during prepare
+// (for the preview), and that the Send step then dispatches to the
+// daemon's SendOnChain RPC with the caller's --amt passed through
+// exactly. ActualAmountSat on the response equals --amt: the exact-
+// amount path (issue #634) replaces the previous whole-VTXO sweep where
+// the destination could receive significantly more than --amt.
 func TestRouterSendOnchainSelectsVTXOsAndCallsLeave(t *testing.T) {
 	t.Parallel()
 
@@ -238,12 +239,13 @@ func TestRouterSendOnchainSelectsVTXOsAndCallsLeave(t *testing.T) {
 			},
 		},
 	}
-	rpc.leaveResp = &daemonrpc.LeaveVTXOsResponse{
-		QueuedOutpoints: []string{
+	rpc.sendOnChainResp = &daemonrpc.SendOnChainResponse{
+		ActualAmountSat: 10_000,
+		SelectedOutpoints: []string{
 			"tx1:0",
 			"tx2:1",
 		},
-		Status: "queued",
+		Status: "submitted",
 	}
 
 	prepareResp, err := r.PrepareSend(
@@ -277,26 +279,30 @@ func TestRouterSendOnchainSelectsVTXOsAndCallsLeave(t *testing.T) {
 	resp, err := sendPrepared(t, r, prepareResp)
 	require.NoError(t, err)
 	require.Equal(t, 0, swap.startPayCalls)
-	require.Equal(t, 1, rpc.leaveCalls)
-	require.Equal(t, 1, rpc.listVTXOsCalls)
 	require.Equal(
-		t, 1, rpc.joinNextRoundCalls, "sendOnchain must "+
-			"auto-commit the leave intent so the top-level "+
-			"`send` verb is a one-shot",
+		t, 0, rpc.leaveCalls,
+		"new SendOnChain path must not fall back to LeaveVTXOs",
+	)
+	require.Equal(t, 1, rpc.sendOnChainCalls)
+	require.Equal(
+		t, 1, rpc.listVTXOsCalls,
+		"prepare-time preview still snapshots live VTXOs",
+	)
+	require.Equal(
+		t, 0, rpc.joinNextRoundCalls, "SendOnChain registers "+
+			"atomically; no JoinNextRound from the wallet layer",
 	)
 
-	got := rpc.leaveLastReq.GetOutpoints().GetOutpoints()
+	gotReq := rpc.sendOnChainLastReq
 	require.Equal(
-		t, []string{
-			"tx1:0",
-			"tx2:1",
-		},
-		got, "selected outpoints must cover the target amount and "+
-			"stop as soon as covered",
+		t, int64(10_000), gotReq.GetAmountSat(),
+		"--amt is passed to SendOnChain exactly under the new "+
+			"exact-amount semantics (issue #634)",
 	)
+	require.False(t, gotReq.GetSweepAll())
 	require.Equal(
 		t, "bcrt1qaddr",
-		rpc.leaveLastReq.GetDefaultDestination().GetAddress(),
+		gotReq.GetDestination().GetAddress(),
 	)
 	require.Equal(
 		t, walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
@@ -304,40 +310,39 @@ func TestRouterSendOnchainSelectsVTXOsAndCallsLeave(t *testing.T) {
 	)
 	require.Equal(
 		t, "tx1:0", resp.GetEntry().GetId(),
-		"the EXIT entry id is the first queued outpoint",
+		"the EXIT entry id is the first selected outpoint",
 	)
 	require.Equal(
-		t, int64(12_000), resp.GetActualAmountSat(),
-		"actual_amount_sat must be the SUM of selected VTXOs so "+
-			"the caller can see whole-VTXO overpay before "+
-			"treating the send as confirmed",
+		t, int64(10_000), resp.GetActualAmountSat(),
+		"actual_amount_sat must equal --amt exactly under the new "+
+			"change-VTXO semantics (issue #634)",
 	)
 
-	// Regression: darepo-client#577. The bounded-amount coin
-	// selector must ask the daemon for VTXO_STATUS_LIVE only,
-	// otherwise a VTXO in PendingForfeit/Forfeiting (from an
-	// in-flight earlier leave) leaks back into the selection and
-	// the subsequent LeaveVTXOs call fails at the manager's
-	// reservation gate.
+	// Regression: darepo-client#577. The prepare-time preview must
+	// still filter to live VTXOs only so a stuck Forfeiting VTXO
+	// from a prior leave doesn't inflate the preview's reported
+	// outflow.
 	require.Equal(
 		t, daemonrpc.VTXOStatus_VTXO_STATUS_LIVE,
 		rpc.listVTXOsLastReq.GetStatusFilter(),
-		"selectVTXOsForAmount must filter to live VTXOs only "+
-			"(darepo-client#577)",
+		"prepare must filter to live VTXOs only (darepo-client#577)",
 	)
 
 	_, err = sendPrepared(t, r, prepareResp)
 	require.ErrorIs(t, err, ErrInvalidSendIntent)
 	require.Equal(
-		t, 1, rpc.leaveCalls,
+		t, 1, rpc.sendOnChainCalls,
 		"prepared send intents must be consume-once",
 	)
 }
 
-// TestRouterSendOnchainSweepAllUsesPreparedOutpoints confirms that the
-// explicit sweep_all flag snapshots the live set during prepare and spends
-// those exact outpoints during send.
-func TestRouterSendOnchainSweepAllUsesPreparedOutpoints(t *testing.T) {
+// TestRouterSendOnchainSweepAllRoutesToSendOnChain confirms that the
+// explicit sweep_all flag snapshots the live set during prepare (for the
+// preview total) and dispatches to SendOnChain in sweep_all mode at
+// Send time. The daemon enumerates the live set again at execution
+// time, so the actual swept set may diverge from the prepare-time
+// snapshot if new VTXOs land between prepare and Send.
+func TestRouterSendOnchainSweepAllRoutesToSendOnChain(t *testing.T) {
 	t.Parallel()
 
 	r, _, rpc := newRouterFixture(t)
@@ -353,12 +358,13 @@ func TestRouterSendOnchainSweepAllUsesPreparedOutpoints(t *testing.T) {
 			},
 		},
 	}
-	rpc.leaveResp = &daemonrpc.LeaveVTXOsResponse{
-		QueuedOutpoints: []string{
+	rpc.sendOnChainResp = &daemonrpc.SendOnChainResponse{
+		ActualAmountSat: 12_000,
+		SelectedOutpoints: []string{
 			"tx1:0",
 			"tx2:1",
 		},
-		Status: "queued",
+		Status: "submitted",
 	}
 
 	prepareResp, err := r.PrepareSend(
@@ -378,21 +384,14 @@ func TestRouterSendOnchainSweepAllUsesPreparedOutpoints(t *testing.T) {
 	)
 	resp, err := sendPrepared(t, r, prepareResp)
 	require.NoError(t, err)
-	require.Equal(
-		t, []string{
-			"tx1:0",
-			"tx2:1",
-		},
-		rpc.leaveLastReq.GetOutpoints().GetOutpoints(),
-		"sweep_all must spend the exact prepared VTXO set",
+	require.Equal(t, 1, rpc.sendOnChainCalls)
+	require.True(
+		t, rpc.sendOnChainLastReq.GetSweepAll(),
+		"sweep_all must set the sweep_all variant on SendOnChain",
 	)
 	require.Equal(
 		t, int64(12_000), resp.GetActualAmountSat(),
-		"actual_amount_sat on sweep must echo the total live VTXO sum",
-	)
-	require.Equal(
-		t, 1, rpc.joinNextRoundCalls,
-		"sweep-all path must also auto-commit the leave intent",
+		"actual_amount_sat on sweep must echo the daemon response",
 	)
 
 	// Regression: darepo-client#577. Sweep-all prepare must also
@@ -406,14 +405,11 @@ func TestRouterSendOnchainSweepAllUsesPreparedOutpoints(t *testing.T) {
 	)
 }
 
-// TestRouterSendOnchainAutoJoinFailureSurfaced asserts that when the
-// implicit JoinNextRound after a successful LeaveVTXOs fails, the error
-// is propagated to the caller — silently swallowing it would leave the
-// caller thinking the leave dispatched while the queued intent rots in
-// the round actor's PendingAssembly state. The error message says
-// `ark rounds join` explicitly so the recovery path is discoverable
-// straight from the failure.
-func TestRouterSendOnchainAutoJoinFailureSurfaced(t *testing.T) {
+// TestRouterSendOnchainDaemonErrorBubblesUp asserts that when the
+// daemon's SendOnChain RPC fails (insufficient funds, round actor
+// rejection, selection shortfall, etc.) the error is surfaced to the
+// caller wrapped with the router's context.
+func TestRouterSendOnchainDaemonErrorBubblesUp(t *testing.T) {
 	t.Parallel()
 
 	r, _, rpc := newRouterFixture(t)
@@ -425,13 +421,7 @@ func TestRouterSendOnchainAutoJoinFailureSurfaced(t *testing.T) {
 			},
 		},
 	}
-	rpc.leaveResp = &daemonrpc.LeaveVTXOsResponse{
-		QueuedOutpoints: []string{
-			"tx1:0",
-		},
-		Status: "queued",
-	}
-	rpc.joinNextRoundErr = errors.New("round actor unavailable")
+	rpc.sendOnChainErr = errors.New("insufficient live VTXOs")
 
 	prepareResp, err := r.PrepareSend(
 		t.Context(), &walletdkrpc.PrepareSendRequest{
@@ -445,17 +435,9 @@ func TestRouterSendOnchainAutoJoinFailureSurfaced(t *testing.T) {
 	require.NoError(t, err)
 	_, err = sendPrepared(t, r, prepareResp)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "auto-join next round after leave")
-	require.ErrorContains(t, err, "round actor unavailable")
-	require.ErrorContains(t, err, "ark rounds join")
-	require.Equal(
-		t, 1, rpc.leaveCalls,
-		"the leave call must have happened before the join failure",
-	)
-	require.Equal(
-		t, 1, rpc.joinNextRoundCalls,
-		"the join must have been attempted",
-	)
+	require.ErrorContains(t, err, "send on-chain")
+	require.ErrorContains(t, err, "insufficient live VTXOs")
+	require.Equal(t, 1, rpc.sendOnChainCalls)
 }
 
 // TestRouterSendOnchainAmtZeroRejectedWithoutSweepAll asserts the

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -718,3 +718,147 @@ func (m *SendVTXOsResponse) MessageType() string {
 
 // walletRespSealed implements the sealed WalletResp interface.
 func (m *SendVTXOsResponse) walletRespSealed() {}
+
+// SendOnChainRequest asks the wallet actor to plan and submit an atomic
+// onchain payment from VTXOs: select the inputs, build one fixed leave
+// output and one change VTXO (bounded mode) or one fee-absorbing leave
+// output (sweep-all mode), and register the resulting intent with the
+// round actor with eager registration.
+//
+// The mode is implicit in the field set: a non-empty SweepOutpoints
+// means sweep-all (drain those VTXOs), otherwise it is a bounded send
+// for TargetAmountSat. The RPC layer enforces that exactly one shape is
+// populated before dispatching the request to the wallet.
+type SendOnChainRequest struct {
+	actor.BaseMessage
+
+	// DestinationPkScript is the on-chain destination script for the
+	// leave output. The script is validated and resolved by the RPC
+	// layer before dispatch; the wallet treats it as opaque.
+	DestinationPkScript []byte
+
+	// TargetAmountSat is the exact on-chain amount the caller wants
+	// to land at DestinationPkScript. Must be > 0 for a bounded send
+	// (empty SweepOutpoints). The wallet selects VTXOs whose summed
+	// value covers TargetAmountSat plus an OperatorFee + DustLimit
+	// headroom so a residual change VTXO can land above dust.
+	TargetAmountSat btcutil.Amount
+
+	// SweepOutpoints carries the live-VTXO outpoint set enumerated by
+	// the RPC server for sweep-all mode; a non-empty value selects
+	// sweep-all. Every live VTXO is drained to DestinationPkScript
+	// with no change VTXO; the single leave output absorbs the
+	// residual under the #270 fee handshake. Empty means a bounded
+	// send. The wallet does not enumerate live VTXOs itself; the RPC
+	// layer's vtxoStore listing is the single source of truth.
+	SweepOutpoints []wire.OutPoint
+
+	// OperatorFee is the daemon's current operator-fee hint
+	// (typically OperatorTerms.MinOperatorFee). Used as
+	// coin-selection headroom in bounded mode so the residual change
+	// VTXO does not land below dust. Advisory only under #270; the
+	// binding fee comes from the server's seal-time quote.
+	OperatorFee btcutil.Amount
+
+	// DustLimit is the change-VTXO dust floor (typically
+	// OperatorTerms.DustLimit). Added to OperatorFee when computing
+	// coin-selection headroom in bounded mode.
+	DustLimit btcutil.Amount
+
+	// OperatorKey is the operator's pubkey for the change-VTXO
+	// policy template. Required in bounded mode; unused in sweep-all.
+	OperatorKey *btcec.PublicKey
+
+	// VTXOExitDelay is the CSV delay for the change VTXO's exit
+	// path. Required in bounded mode; unused in sweep-all.
+	VTXOExitDelay uint32
+
+	// DryRun validates inputs and reserves a selection without
+	// submitting the round intent. The reservation is released
+	// immediately after the preview is built.
+	DryRun bool
+}
+
+// IsSweepAll reports whether the request drains the wallet (sweep-all)
+// rather than sending a bounded TargetAmountSat. Sweep-all is implied
+// by a non-empty SweepOutpoints set.
+func (m *SendOnChainRequest) IsSweepAll() bool {
+	return len(m.SweepOutpoints) > 0
+}
+
+// MessageType returns the message type identifier for logging.
+func (m *SendOnChainRequest) MessageType() string {
+	return "SendOnChainRequest"
+}
+
+// walletMsgSealed implements the sealed WalletMsg interface.
+func (m *SendOnChainRequest) walletMsgSealed() {}
+
+// SendOnChainStatus enumerates the terminal outcomes of a
+// SendOnChainRequest as surfaced to the caller.
+type SendOnChainStatus uint8
+
+const (
+	// SendOnChainStatusSubmitted indicates the onchain send intent
+	// was registered with the round actor for the next round.
+	SendOnChainStatusSubmitted SendOnChainStatus = iota
+
+	// SendOnChainStatusPreview indicates a dry-run: inputs were
+	// validated and a selection previewed without submitting an
+	// intent.
+	SendOnChainStatusPreview
+)
+
+// String returns the wire string form of the status, consumed by the
+// RPC layer when projecting onto the proto response.
+func (s SendOnChainStatus) String() string {
+	switch s {
+	case SendOnChainStatusSubmitted:
+		return "submitted"
+
+	case SendOnChainStatusPreview:
+		return "preview"
+
+	default:
+		return "unknown"
+	}
+}
+
+// SendOnChainResponse carries the outcome of a SendOnChainRequest.
+type SendOnChainResponse struct {
+	actor.BaseMessage
+
+	// Status is Submitted for a successfully registered intent or
+	// Preview for a dry-run.
+	Status SendOnChainStatus
+
+	// ActualAmountSat is the on-chain amount that will land at
+	// DestinationPkScript. In bounded mode this equals the
+	// TargetAmountSat the caller requested (the server stamps fee
+	// deviations onto the change VTXO). In SweepAll mode this is
+	// the pre-fee Σ(SelectedOutpoints); the actual landing amount
+	// is reduced by the server's seal-time operator fee.
+	ActualAmountSat btcutil.Amount
+
+	// SelectedOutpoints is the set of VTXOs forfeited for this send,
+	// in selection order.
+	SelectedOutpoints []wire.OutPoint
+
+	// TotalSelected is the sum of all SelectedOutpoints' VTXO
+	// amounts.
+	TotalSelected btcutil.Amount
+
+	// ChangeAmount is the projected change-VTXO value in bounded
+	// mode (TotalSelected − TargetAmountSat, before fee). Zero for
+	// SweepAll. The on-chain value is finalized by the server at
+	// seal time and may differ by the operator fee.
+	ChangeAmount btcutil.Amount
+}
+
+// MessageType returns the message type identifier for logging.
+func (m *SendOnChainResponse) MessageType() string {
+	return "SendOnChainResponse"
+}
+
+// walletRespSealed implements the sealed WalletResp interface.
+func (m *SendOnChainResponse) walletRespSealed() {}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -702,6 +702,9 @@ func (a *Ark) Receive(ctx context.Context,
 	case *SendVTXOsRequest:
 		return a.handleSendVTXOs(ctx, m)
 
+	case *SendOnChainRequest:
+		return a.handleSendOnChain(ctx, m)
+
 	case *SweepBoardingUTXOsRequest:
 		return a.handleSweepBoardingUTXOs(ctx, m)
 
@@ -2671,6 +2674,375 @@ func (a *Ark) buildSendVTXORequests(ctx context.Context, req *SendVTXOsRequest,
 	}
 
 	return vtxoRequests, nil
+}
+
+// handleSendOnChain plans and submits an atomic onchain payment from VTXOs.
+// The handler has two modes selected by the request:
+//
+//   - Bounded (TargetAmountSat > 0): the wallet asks the VTXO manager to
+//     select and reserve VTXOs covering TargetAmountSat plus an
+//     OperatorFee + DustLimit headroom, then builds an intent of
+//     {forfeit inputs, one fixed LeaveRequest of exactly TargetAmountSat,
+//     one change VTXORequest with IsChange=true} so the server's seal-time
+//     quote builder stamps the residual onto the change VTXO.
+//
+//   - SweepAll: the wallet reserves the outpoint set enumerated by the
+//     RPC layer (no in-wallet enumeration) and builds an intent of
+//     {forfeit inputs, one LeaveRequest with IsChange=true and zero
+//     target}, so the server stamps the full residual (Σinputs − fee)
+//     onto the single on-chain output.
+//
+// Both modes register with TriggerRegistration=true: the onchain send is
+// atomic by design and never composes with other queued intents.
+//
+//nolint:gocyclo,funlen
+func (a *Ark) handleSendOnChain(ctx context.Context,
+	req *SendOnChainRequest) fn.Result[WalletResp] {
+
+	// Pure input validation. The RPC layer already enforced these
+	// invariants; the duplicate is defense-in-depth so the wallet
+	// actor never builds a malformed intent. Sweep-all mode is
+	// implied by a non-empty SweepOutpoints set.
+	if len(req.DestinationPkScript) == 0 {
+		return fn.Err[WalletResp](
+			fmt.Errorf("destination pkScript required"),
+		)
+	}
+
+	sweepAll := req.IsSweepAll()
+
+	switch {
+	case sweepAll && req.TargetAmountSat != 0:
+		return fn.Err[WalletResp](
+			fmt.Errorf("sweep-all requires target_amount_sat == 0"),
+		)
+
+	case !sweepAll && req.TargetAmountSat <= 0:
+		return fn.Err[WalletResp](
+			fmt.Errorf("target_amount_sat must be positive for " +
+				"a bounded send"),
+		)
+
+	case !sweepAll && req.OperatorKey == nil:
+		return fn.Err[WalletResp](
+			fmt.Errorf("operator_key required to build the " +
+				"change VTXO"),
+		)
+	}
+
+	a.logger(ctx).InfoS(ctx, "Processing onchain send",
+		slog.Bool("sweep_all", sweepAll),
+		slog.Int64("target_amount_sat",
+			int64(req.TargetAmountSat)),
+		slog.Int("sweep_outpoints", len(req.SweepOutpoints)),
+		slog.Int64("operator_fee_hint",
+			int64(req.OperatorFee)),
+		slog.Bool("dry_run", req.DryRun),
+	)
+
+	// Reserve forfeit inputs. Bounded mode delegates selection to
+	// the VTXO manager (largest-first); sweep-all takes the outpoint
+	// list the RPC layer enumerated and reserves it explicitly. Both
+	// paths fill in selectedOutpoints / selectedAmounts / totalSelected.
+	var (
+		selectedOutpoints []wire.OutPoint
+		selectedAmounts   []btcutil.Amount
+		totalSelected     btcutil.Amount
+	)
+
+	if sweepAll {
+		_, err := a.askManager(
+			ctx, &actormsg.ReserveForfeitRequest{
+				Outpoints: req.SweepOutpoints,
+			},
+		)
+		if err != nil {
+			return fn.Err[WalletResp](
+				fmt.Errorf("reserve sweep outpoints: %w", err),
+			)
+		}
+
+		// Materialize amounts so the intent's ForfeitRequest set is
+		// complete. The reservation already gates concurrent
+		// consumers, so reading amounts via the descriptor here is
+		// race-free.
+		for _, op := range req.SweepOutpoints {
+			vtxo, err := a.vtxoReader.GetVTXO(ctx, op)
+			if err != nil {
+				// Release the full reserved set up front
+				// and clear selectedOutpoints so the
+				// deferred cleanup below does not attempt
+				// to release the (sub)set a second time.
+				releaseCtx := context.WithoutCancel(ctx)
+				_ = a.releaseManagerForfeitStrict(
+					releaseCtx, req.SweepOutpoints,
+				)
+				selectedOutpoints = nil
+
+				return fn.Err[WalletResp](
+					fmt.Errorf("load sweep vtxo %s: %w",
+						op, err),
+				)
+			}
+			selectedOutpoints = append(selectedOutpoints, op)
+			selectedAmounts = append(
+				selectedAmounts, vtxo.Amount,
+			)
+			totalSelected += vtxo.Amount
+		}
+	} else {
+		// Bounded: select via the manager with enough headroom so
+		// the residual change VTXO can clear dust under the
+		// seal-time fee handshake. The advisory OperatorFee hint
+		// over-selects under stale schedules; excess simply lands
+		// as a larger change VTXO.
+		target := req.TargetAmountSat + req.OperatorFee + req.DustLimit
+		resp, err := a.askManager(
+			ctx, &actormsg.SelectAndReserveForfeitRequest{
+				TargetAmount: target,
+			},
+		)
+		if err != nil {
+			return fn.Err[WalletResp](
+				fmt.Errorf("select and reserve forfeit: %w",
+					err),
+			)
+		}
+
+		//nolint:forcetypeassert
+		mgrResp := resp.(*actormsg.SelectAndReserveForfeitResponse)
+		for _, v := range mgrResp.SelectedVTXOs {
+			selectedOutpoints = append(
+				selectedOutpoints, v.Outpoint,
+			)
+			selectedAmounts = append(selectedAmounts, v.Amount)
+		}
+		totalSelected = mgrResp.TotalSelected
+	}
+
+	// Release reserved outpoints if we bail before successfully
+	// registering the intent. Same pattern as handleSendVTXOs:
+	// context.WithoutCancel survives client disconnect.
+	committed := false
+	defer func() {
+		if committed {
+			return
+		}
+
+		releaseCtx := context.WithoutCancel(ctx)
+		releaseErr := a.releaseManagerForfeitStrict(
+			releaseCtx, selectedOutpoints,
+		)
+		if releaseErr != nil {
+			a.logger(releaseCtx).WarnS(
+				releaseCtx,
+				"Failed to release reserved sweep outpoints",
+				releaseErr,
+			)
+		}
+	}()
+
+	// Defensive shortfall check in bounded mode. The manager's
+	// SelectAndReserveForfeit fails closed on insufficient funds,
+	// but we re-check here so a buggy selector or stale-cache race
+	// surfaces as a wallet error rather than as a server-side
+	// admission failure on a fee-deficient intent. The dust floor
+	// is enforced locally so a below-dust change projection fails
+	// fast here instead of late at operator admission with
+	// ErrVTXOAmountBelowMinimum.
+	var change btcutil.Amount
+	if !sweepAll {
+		if totalSelected <= req.TargetAmountSat {
+			return fn.Err[WalletResp](
+				fmt.Errorf("selection shortfall: selected "+
+					"%d, need >%d", totalSelected,
+					req.TargetAmountSat),
+			)
+		}
+		change = totalSelected - req.TargetAmountSat
+		if change < req.DustLimit {
+			return fn.Err[WalletResp](
+				fmt.Errorf("change amount %d is below dust "+
+					"limit %d", change, req.DustLimit),
+			)
+		}
+	}
+
+	if req.DryRun {
+
+		// Deferred release returns the reservation.
+		return fn.Ok[WalletResp](&SendOnChainResponse{
+			Status: SendOnChainStatusPreview,
+			ActualAmountSat: sendOnChainActualAmount(
+				req, totalSelected,
+			),
+			SelectedOutpoints: selectedOutpoints,
+			TotalSelected:     totalSelected,
+			ChangeAmount:      change,
+		})
+	}
+
+	// Build the round intent. Forfeit inputs come from the
+	// reservation; the leave output is the user's onchain payment;
+	// the change VTXO (bounded mode only) absorbs the seal-time fee
+	// residual.
+	forfeits := make(
+		[]types.ForfeitRequest, 0, len(selectedOutpoints),
+	)
+	for i, op := range selectedOutpoints {
+		forfeits = append(forfeits, types.ForfeitRequest{
+			VTXOOutpoint: &op,
+			Amount:       selectedAmounts[i],
+		})
+	}
+
+	var (
+		leaves []*types.LeaveRequest
+		vtxos  []types.VTXORequest
+	)
+
+	if sweepAll {
+		// One leave output, IsChange=true: server stamps the
+		// residual (Σinputs − fee) onto it at seal time.
+		leaves = []*types.LeaveRequest{
+			{
+				Output: &wire.TxOut{
+					PkScript: req.DestinationPkScript,
+				},
+				IsChange: true,
+			},
+		}
+	} else {
+		// One fixed leave + one change VTXO. The change VTXO uses
+		// the same arkscript pattern as the directed-send self-
+		// change at buildSendVTXORequests so confirmation-time
+		// ownership persistence works through the standard
+		// OwnedScriptRegistrar path.
+		leaves = []*types.LeaveRequest{
+			{
+				Output: &wire.TxOut{
+					PkScript: req.DestinationPkScript,
+					Value:    int64(req.TargetAmountSat),
+				},
+				IsChange: false,
+			},
+		}
+
+		changeClientKey, err := a.backend.DeriveNextKey(
+			ctx, types.VTXOOwnerKeyFamily,
+		)
+		if err != nil {
+			return fn.Err[WalletResp](
+				fmt.Errorf("derive change client key: %w", err),
+			)
+		}
+
+		policyTemplate, pkScript, err := arkscript.
+			EncodeStandardVTXOArtifacts(
+				changeClientKey.PubKey, req.OperatorKey,
+				req.VTXOExitDelay,
+			)
+		if err != nil {
+			return fn.Err[WalletResp](
+				fmt.Errorf("build change descriptor: %w", err),
+			)
+		}
+
+		vtxos = []types.VTXORequest{
+			{
+				// Amount is the caller's projected change
+				// (totalSelected − TargetAmountSat). The
+				// seal-time quote rewrites this slot with
+				// the residual (Σin − Σfixed − fee) because
+				// IsChange=true, but the value must already
+				// be above the operator's dust floor at
+				// admission time — the join-request
+				// validation runs before the seal-time
+				// builder, and a zero or sub-dust placeholder
+				// is rejected with ErrVTXOAmountBelowMinimum.
+				Amount:         change,
+				PolicyTemplate: policyTemplate,
+				PkScript:       pkScript,
+				Expiry:         req.VTXOExitDelay,
+				ClientKey:      changeClientKey.PubKey,
+				OwnerKey:       *changeClientKey,
+				OperatorKey:    req.OperatorKey,
+				Origin:         types.VTXOOriginRoundRefresh,
+				IsChange:       true,
+			},
+		}
+	}
+
+	// Register the intent with the round actor. TriggerRegistration is
+	// left false here so the wallet handler stops at the "intent
+	// queued" boundary; the RPC handler fires the IntentRequested
+	// step separately (via darepod.TriggerRoundRegistration), which
+	// mirrors the OLD LeaveVTXOs+JoinNextRound split that arktest
+	// exercises today. The eager-mode RegisterIntentMsg.TriggerRegistration
+	// path collapses both steps into a single Ask and has a latent ctx
+	// issue in arktest with EagerRoundJoin=false: the FSM transition
+	// inside the same Ask interleaves with the outbound publish in a
+	// way that leaves the operator's forfeit-VTXO lookup with a
+	// cancelled context. Splitting matches the proven-working pattern.
+	//
+	// Ask context is stripped of caller cancellation as defense in
+	// depth in case any caller invokes the wallet handler directly
+	// with a request-scoped ctx; the Await keeps the original ctx.
+	serviceKey := actormsg.RoundActorServiceKey()
+	roundRef := serviceKey.Ref(a.actorSystem)
+
+	askCtx := context.WithoutCancel(ctx)
+	future := roundRef.Ask(askCtx, &actormsg.RegisterIntentMsg{
+		Forfeits:            forfeits,
+		VTXOs:               vtxos,
+		Leaves:              leaves,
+		TriggerRegistration: false,
+	})
+	result := future.Await(ctx)
+	if result.IsErr() {
+		a.logger(ctx).WarnS(ctx, "Round rejected onchain send intent",
+			result.Err(),
+		)
+
+		return fn.Err[WalletResp](
+			fmt.Errorf(
+				"round rejected onchain send intent: %w",
+				result.Err(),
+			),
+		)
+	}
+
+	committed = true
+
+	a.logger(ctx).InfoS(ctx, "Onchain send intent registered",
+		slog.Int("forfeits", len(forfeits)),
+		slog.Int("leaves", len(leaves)),
+		slog.Int("change_vtxos", len(vtxos)),
+		slog.Int64("total_selected", int64(totalSelected)),
+		slog.Int64("change_projection", int64(change)),
+	)
+
+	return fn.Ok[WalletResp](&SendOnChainResponse{
+		Status:            SendOnChainStatusSubmitted,
+		ActualAmountSat:   sendOnChainActualAmount(req, totalSelected),
+		SelectedOutpoints: selectedOutpoints,
+		TotalSelected:     totalSelected,
+		ChangeAmount:      change,
+	})
+}
+
+// sendOnChainActualAmount returns the on-chain amount that will land at
+// the destination. In bounded mode this is the exact TargetAmountSat;
+// in sweep-all it is the pre-fee Σ(inputs), which the server reduces by
+// the seal-time operator fee.
+func sendOnChainActualAmount(req *SendOnChainRequest,
+	totalSelected btcutil.Amount) btcutil.Amount {
+
+	if req.IsSweepAll() {
+		return totalSelected
+	}
+
+	return req.TargetAmountSat
 }
 
 // releaseManagerForfeitStrict releases forfeit reservations and returns


### PR DESCRIPTION
## Summary

- Adds a new \`SendOnChain\` daemonrpc RPC that gives \`darepocli send --onchain --amt N\` exact-amount semantics: the destination receives EXACTLY N sats, and any residual returns to the caller as a change VTXO.
- The handler picks live VTXOs via the existing manager admission gate, emits a mixed intent (1 forfeit set + 1 fixed leave output + 1 IsChange=true VTXO), and registers it atomically.
- Rewires \`walletrpc.Send\` (the wallet-shaped multiplexed send verb) to dispatch onchain through \`SendOnChain\` instead of the old whole-VTXO \`LeaveVTXOs\` + \`JoinNextRound\` path. The \`ark vtxos leave\` raw CLI keeps using \`LeaveVTXOs\` unchanged for advanced batching.
- Drops the \"v1 whole-VTXO sweep semantics\" warning from the CLI; the overpay it warned about can no longer happen.

Fixes lightninglabs/darepo-client#634.

## Background

Before: \`darepocli send --onchain --amt 25000\` silently swept whole VTXOs to the destination because the underlying \`LeaveVTXOs\` primitive has no change output. Viktor reported sending 25,000 sats and the destination receiving ~905,000 sats — a 36× overpay. The CLI emitted a \`note:\` to stderr after the fact, but the round was already in flight.

After: the daemon emits one fixed leave output of exactly \`amount_sat\` and a change VTXO. The seal-time fee handshake (#270) stamps the operator fee onto the change VTXO via \`IsChange=true\`, so the destination still lands the exact requested amount.

## Commit order

The 7 commits split along natural seams so each one builds and tests cleanly:

1. \`rpc: Add SendOnChain RPC definition\` — proto + grpc-gateway route.
2. \`rpc: Regenerate stubs for SendOnChain\` — \`make rpc\`.
3. \`restclient: Implement SendOnChain over the REST gateway\` — handwritten REST stub.
4. \`wallet: Add SendOnChain handler for exact-amount onchain sends\` — wallet actor handler + actor message types.
5. \`darepod: Wire SendOnChain RPC handler\` — RPC server method with the split-Ask pattern (mirrors \`LeaveVTXOs + JoinNextRound\`).
6. \`swapwallet: Route onchain send through SendOnChain\` — router rewrite + test updates.
7. \`darepocli: Drop whole-VTXO overpay warning from send\` — CLI text cleanup.

## Test plan

- [x] \`go test -tags \"walletrpc swapruntime\" ./...\` — all client unit tests pass.
- [x] swapwallet router tests updated to assert the new exact-amount invariants.
- [x] End-to-end coverage in the parent darepo repo: new \`TestSendOnChainExactAmount\` itest boards alice with 120k sats, sends \`amount_sat=30000\`, confirms the round, asserts bitcoind destination receives exactly 30000 sats AND alice retains a change VTXO ≈ 90k − operator fee.
- [x] Manual reproduction via \`arktest\` (\`darepocli --no-tls send <addr> --onchain --amt 25000\`): bitcoind \`getreceivedbyaddress\` returns exactly 0.00025000 and alice's wallet shows a change VTXO of ~872k sats.

## Companion PR

The parent darepo repo needs (a) a submodule bump to pick up these commits and (b) an unrelated rounds-actor fix that arktest's reproduction exposed. Will link here once opened.