### PR TITLE
serverconn: quiet ingress shutdown cancellation

### DIFF
--- a/serverconn/ingress.go
+++ b/serverconn/ingress.go
@@ -39,9 +39,7 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 	for {
 		select {
 		case <-ctx.Done():
-			a.log.InfoS(ctx, "Ingress loop exiting",
-				slog.String("mailbox_id",
-					a.cfg.LocalMailboxID))
+			a.logIngressExit(ctx)
 
 			return
 
@@ -55,6 +53,12 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 			if err := a.ackRemote(
 				ctx, state.AckTarget,
 			); err != nil {
+
+				if isIngressShutdownErr(ctx, err) {
+					a.logIngressExit(ctx)
+
+					return
+				}
 
 				a.log.WarnS(ctx, "AckUpTo failed, retrying",
 					err,
@@ -93,6 +97,12 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 			ctx, state.PullCursor,
 		)
 		if err != nil {
+			if isIngressShutdownErr(ctx, err) {
+				a.logIngressExit(ctx)
+
+				return
+			}
+
 			a.log.WarnS(ctx, "Pull failed, retrying",
 				err,
 				slog.Uint64("cursor", state.PullCursor),
@@ -179,6 +189,24 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 
 		failCount = 0
 	}
+}
+
+// logIngressExit emits the common ingress shutdown log line.
+func (a *ServerConnectionActor) logIngressExit(ctx context.Context) {
+	a.log.InfoS(ctx, "Ingress loop exiting",
+		slog.String("mailbox_id", a.cfg.LocalMailboxID),
+	)
+}
+
+// isIngressShutdownErr reports whether err is an expected result of shutting
+// down the ingress loop. Only local loop-context cancellation is terminal; a
+// remote transport cancellation can be transient and must stay retryable.
+func isIngressShutdownErr(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return ctx.Err() != nil
 }
 
 // pullBatch calls Edge.Pull and returns the envelopes and next cursor.

--- a/serverconn/ingress_error_test.go
+++ b/serverconn/ingress_error_test.go
@@ -2,6 +2,7 @@ package serverconn
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -9,6 +10,8 @@ import (
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // mailboxClientStub is a configurable MailboxServiceClient test double.
@@ -190,6 +193,66 @@ func TestAckRemote_StatusFailure(t *testing.T) {
 	require.ErrorAs(t, err, &stErr)
 	require.Equal(t, "AckUpTo", stErr.Op)
 	require.Contains(t, stErr.Error(), "ack failed")
+}
+
+// TestIsIngressShutdownErr verifies expected shutdown cancellation is
+// distinguished from retryable ingress failures.
+func TestIsIngressShutdownErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		cancel bool
+		err    error
+		want   bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name:   "local context canceled",
+			cancel: true,
+			err:    context.Canceled,
+			want:   true,
+		},
+		{
+			name: "grpc canceled",
+			err:  status.Error(codes.Canceled, "context canceled"),
+			want: false,
+		},
+		{
+			name:   "ctx canceled after transport error",
+			cancel: true,
+			err:    errors.New("transport closed"),
+			want:   true,
+		},
+		{
+			name: "retryable transport error",
+			err:  errors.New("temporary transport failure"),
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			if test.cancel {
+				cancel()
+			}
+
+			require.Equal(
+				t, test.want,
+				isIngressShutdownErr(ctx, test.err),
+			)
+		})
+	}
 }
 
 // TestLoadCheckpoint_Errors verifies loadCheckpoint surfaces store/decode


### PR DESCRIPTION
## Summary

- treat ingress pull/ack cancellation during shutdown as a normal loop exit
- keep retry warnings for real transient mailbox errors
- add coverage for local and gRPC cancellation classification

Closes #633.

## Validation

- `make fmt-changed`
- `go test ./serverconn -run 'Test(IsIngressShutdownErr|PullBatch_StatusFailure|AckRemote_StatusFailure)' -count=1`
- `go test ./serverconn -count=1`
- `make lint-changed-local`
- `make fmt-changed-check`
- `make commitmsg-lint range=origin/main..HEAD`
