### PR TITLE
docs: fix stale `list --view` and `walletrpc` references

### DIFF
--- a/.claude/skills/darepod.md
+++ b/.claude/skills/darepod.md
@@ -105,11 +105,14 @@ darepocli send lnbcrt... --offchain --no-tls
 darepocli send bcrt1... --onchain --amt 1000 --no-tls
 darepocli send bcrt1... --onchain --sweep-all --no-tls
 
-# List: pick a view (activity = default).
-darepocli list --no-tls                            # activity
-darepocli list --view vtxos --no-tls               # VTXO inventory
-darepocli list --view onchain --limit 100 --no-tls # on-chain history
-darepocli list --pending --kind send,recv --no-tls # filter (activity)
+# Activity: merged send/recv/deposit/exit feed.
+darepocli activity --no-tls                            # all activity
+darepocli activity --pending --kind send,recv --no-tls # filter
+darepocli activity --format json --no-tls              # JSON output
+# VTXO inventory and on-chain history are not part of the activity feed;
+# use the `ark` subtree: `ark vtxos list` (live VTXOs),
+# `ark listtransactions` (raw tx / onchain history),
+# `ark sweep list` (boarding-timeout sweep records).
 
 # Exit: trigger and query a unilateral exit (unroll).
 darepocli exit --outpoint TXID:VOUT --no-tls
@@ -127,8 +130,7 @@ darepocli ark vtxos list --no-tls
 darepocli ark vtxos list --status live --min_amount 10000 --no-tls
 darepocli ark vtxos refresh --all --no-tls
 
-# Raw transaction history (superseded for the wallet shape by
-# `list --view onchain`)
+# Raw transaction history (the wallet-shaped feed is `activity`)
 darepocli ark listtransactions --no-tls
 
 # Raw send paths
@@ -183,7 +185,7 @@ echo -n 'pass' | darepocli unlock --no-tls
 6. Mine a block: `bitcoin-cli generatetoaddress 1 <miner_addr>`
 7. Check balance: `darepocli balance --no-tls`
 8. List VTXOs (once boarding completes):
-   `darepocli list --view vtxos --no-tls`
+   `darepocli ark vtxos list --no-tls`
 
 ## Environment Variables
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,11 +38,11 @@ export PATH="$(go env GOPATH)/bin:$PATH"
 ```bash
 git clone https://github.com/lightninglabs/darepo-client.git
 cd darepo-client
-make install-walletrpc
+make install-walletdkrpc
 ```
 
 That single target builds and installs both `darepod` and `darepocli` to
-`$GOPATH/bin` with the optional `walletrpc` + `swapruntime` subsystems
+`$GOPATH/bin` with the optional `walletdkrpc` + `swapruntime` subsystems
 enabled. After it completes you have access to:
 
 - The top-level wallet verbs: `darepocli {create, unlock, balance, recv,
@@ -59,9 +59,9 @@ darepod   --version
 darepocli --help
 ```
 
-If `darepocli balance` reports `daemon was not built with -tags walletrpc`,
+If `darepocli balance` reports `daemon was not built with -tags walletdkrpc`,
 the binary on `PATH` came from a default build. Re-run
-`make install-walletrpc` and ensure `$GOPATH/bin` precedes any older copy.
+`make install-walletdkrpc` and ensure `$GOPATH/bin` precedes any older copy.
 
 ---
 
@@ -74,10 +74,10 @@ the variant that matches your needs.
 |----------------------------------|----------------------------|-------------------------|--------------------------------------------------------|
 | Core (default)                   | _(none)_                   | `darepod`, `darepocli`  | Headless Ark client; no swaps; power-user CLI only.    |
 | With Lightning swaps             | `swapruntime`              | `darepod`, `darepocli`  | Use Lightning-to-Ark / Ark-to-Lightning swaps.         |
-| With wallet RPC (recommended)    | `walletrpc swapruntime`    | `darepod`, `darepocli`  | Use the top-level wallet verbs and host-app SDK.       |
+| With wallet RPC (recommended)    | `walletdkrpc swapruntime`  | `darepod`, `darepocli`  | Use the top-level wallet verbs and host-app SDK.       |
 
-`walletrpc` is a strict superset of `swapruntime`; you cannot enable
-`walletrpc` without `swapruntime` (the combination is enforced at compile
+`walletdkrpc` is a strict superset of `swapruntime`; you cannot enable
+`walletdkrpc` without `swapruntime` (the combination is enforced at compile
 time).
 
 ### Local debug builds (output to `./bin/`)
@@ -85,7 +85,7 @@ time).
 ```bash
 make build                       # core
 make build-swapruntime           # + swap subsystem
-make build-walletrpc             # + walletrpc and swap subsystem  (recommended)
+make build-walletdkrpc             # + walletdkrpc and swap subsystem  (recommended)
 ```
 
 After any of these, the binaries are at:
@@ -98,11 +98,11 @@ After any of these, the binaries are at:
 ```bash
 make install                     # core
 make install-swapruntime         # + swap subsystem
-make install-walletrpc           # + walletrpc and swap subsystem  (recommended)
+make install-walletdkrpc           # + walletdkrpc and swap subsystem  (recommended)
 ```
 
 For more on what each tag turns on, see
-[`docs/walletrpc_build.md`](docs/walletrpc_build.md).
+[`docs/walletdkrpc_build.md`](docs/walletdkrpc_build.md).
 
 ---
 
@@ -122,11 +122,11 @@ go version
 #    workspace (see docs/go_workspace.md); this is normally automatic.
 go mod download
 
-# 4. Build the recommended (walletrpc) variant into ./bin.
-make build-walletrpc
+# 4. Build the recommended (walletdkrpc) variant into ./bin.
+make build-walletdkrpc
 
 # 5. Or install the same variant to $GOPATH/bin.
-make install-walletrpc
+make install-walletdkrpc
 
 # 6. Confirm the binaries.
 ./bin/darepod   --help
@@ -190,7 +190,7 @@ darepod \
 After starting the daemon, the wallet must be created and unlocked before
 any operation can proceed.
 
-With a `walletrpc`-enabled build (`make install-walletrpc`):
+With a `walletdkrpc`-enabled build (`make install-walletdkrpc`):
 
 ```bash
 # Create a wallet (prints the seed mnemonic on stderr; write it down!).
@@ -203,7 +203,7 @@ DAREPOD_WALLET_PASSWORD=your_password darepocli unlock --no-tls
 To skip manual unlock entirely, pass `--wallet.password_file=/path/to/file`
 to `darepod` at startup; the daemon will auto-unlock from the file.
 
-Without `walletrpc`, the only supported path is the password-file auto-unlock
+Without `walletdkrpc`, the only supported path is the password-file auto-unlock
 above. The `create` / `unlock` CLI commands are not present in the default
 build. Full password-handling rules:
 [`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md#password-handling).
@@ -216,7 +216,7 @@ build. Full password-handling rules:
 # 1. Daemon answers basic status.
 darepocli getinfo --no-tls
 
-# 2. (walletrpc only) wallet verbs work.
+# 2. (walletdkrpc only) wallet verbs work.
 darepocli balance --no-tls
 darepocli activity --no-tls
 
@@ -227,9 +227,9 @@ darepocli ark vtxos list --no-tls
 darepocli schema --no-tls
 ```
 
-If you see `daemon was not built with -tags walletrpc` for the wallet
+If you see `daemon was not built with -tags walletdkrpc` for the wallet
 verbs, your `darepod` binary is the default (untagged) build. Reinstall
-with `make install-walletrpc`.
+with `make install-walletdkrpc`.
 
 ---
 
@@ -239,7 +239,7 @@ Pull the latest source and reinstall the same variant you previously used:
 
 ```bash
 git pull --rebase
-make install-walletrpc       # or whichever variant you run
+make install-walletdkrpc       # or whichever variant you run
 ```
 
 ---
@@ -262,9 +262,9 @@ Deleting `~/.darepod` is irreversible without the recorded mnemonic.
 
 | Symptom                                                | Fix                                                                                  |
 |--------------------------------------------------------|--------------------------------------------------------------------------------------|
-| `daemon was not built with -tags walletrpc`            | Reinstall with `make install-walletrpc`.                                             |
+| `daemon was not built with -tags walletdkrpc`            | Reinstall with `make install-walletdkrpc`.                                             |
 | `connection refused` on `darepocli`                    | Daemon not running, or wrong `--rpcserver` address.                                  |
-| `wallet not ready`                                     | Run `darepocli unlock` (walletrpc), or restart `darepod` with `--wallet.password_file`. |
+| `wallet not ready`                                     | Run `darepocli unlock` (walletdkrpc), or restart `darepod` with `--wallet.password_file`. |
 | `wallet already exists`                                | Use `darepocli unlock` instead of `create`.                                          |
 | TLS / x509 errors against the daemon                   | Use `--no-tls` on regtest, or pass `--tlscertpath` to `darepocli`.                   |
 | `go: module ... requires go 1.25.5` or similar         | Upgrade to Go 1.25.5+ (see Prerequisites).                                           |
@@ -278,7 +278,7 @@ Deeper troubleshooting (per-flag and per-backend) is in
 ## Next Steps
 
 - **Run the daemon:** [`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md)
-- **Build-tag deep dive:** [`docs/walletrpc_build.md`](docs/walletrpc_build.md)
+- **Build-tag deep dive:** [`docs/walletdkrpc_build.md`](docs/walletdkrpc_build.md)
 - **Embed the daemon in a host app:** [`docs/walletdk_integration.md`](docs/walletdk_integration.md)
 - **Codebase map:** [`ARCHITECTURE.md`](ARCHITECTURE.md)
 - **Contribute:** style guide and pre-commit checklist in

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and exposes a typed gRPC + REST API for host applications.
 - **Lightning swaps.** Optional swap subsystem (`swapruntime`) provides
   Lightning-to-Ark and Ark-to-Lightning atomic swaps with a durable FSM.
 - **Wallet RPC facade.** Optional flat, swap-vocabulary-free wallet API
-  (`walletrpc`) exposes seven core verbs: `create`, `unlock`, `send`,
+  (`walletdkrpc`) exposes seven core verbs: `create`, `unlock`, `send`,
   `recv`, `activity`, `balance`, `exit`.
 - **Host-app SDK.** `sdk/ark`, `sdk/swaps`, and `sdk/walletdk` embed the
   daemon in-process and expose typed Go APIs over a private transport.
@@ -42,7 +42,7 @@ and exposes a typed gRPC + REST API for host applications.
 # enabled (recommended; gives you the top-level wallet verbs).
 git clone https://github.com/lightninglabs/darepo-client.git
 cd darepo-client
-make install-walletrpc
+make install-walletdkrpc
 
 # Start the daemon against a local regtest Ark operator + Esplora. The local
 # and remote mailbox IDs are derived from the client and operator pubkeys, so
@@ -81,15 +81,15 @@ nothing in binary size or surface area.
 |----------------------------|-----------------------------|-----------------------------------------------------------|
 | `make build`               | _(none)_                    | Core Ark client. Power-user `ark *` and `dev *` CLI only. |
 | `make build-swapruntime`   | `swapruntime`               | + Lightning swap subsystem (`sdk/swaps`, swap CLI).       |
-| `make build-walletrpc`     | `walletrpc swapruntime`     | + Wallet RPC subserver and top-level wallet verbs.        |
+| `make build-walletdkrpc`   | `walletdkrpc swapruntime`   | + Wallet RPC subserver and top-level wallet verbs.        |
 | `make install`             | _(none)_                    | Installs the core build to `$GOPATH/bin`.                 |
 | `make install-swapruntime` | `swapruntime`               | Installs the swap-enabled build.                          |
-| `make install-walletrpc`   | `walletrpc swapruntime`     | Installs the full walletrpc-enabled build (recommended).  |
+| `make install-walletdkrpc` | `walletdkrpc swapruntime`   | Installs the full walletdkrpc-enabled build (recommended).|
 
-The `walletrpc` build is a strict superset of `swapruntime`. Most users
-want `make install-walletrpc`.
+The `walletdkrpc` build is a strict superset of `swapruntime`. Most users
+want `make install-walletdkrpc`.
 
-See [`docs/walletrpc_build.md`](docs/walletrpc_build.md) for the full
+See [`docs/walletdkrpc_build.md`](docs/walletdkrpc_build.md) for the full
 matrix, what each tag enables, and what the CLI surface looks like in each
 mode.
 
@@ -100,11 +100,11 @@ mode.
 ```
 darepocli
 ├── getinfo                   daemon status                          (all builds)
-├── balance / recv / send     unified wallet verbs                   (walletrpc)
-├── create / unlock           wallet bring-up                        (walletrpc)
-├── activity                  unified wallet activity history        (walletrpc)
+├── balance / recv / send     unified wallet verbs                   (walletdkrpc)
+├── create / unlock           wallet bring-up                        (walletdkrpc)
+├── activity                  unified wallet activity history        (walletdkrpc)
 ├── exit [status]             unilateral exit a VTXO                 (all builds)
-├── mcp serve                 MCP server for AI agents               (walletrpc)
+├── mcp serve                 MCP server for AI agents               (walletdkrpc)
 ├── schema                    JSON dump of all CLI methods           (all builds)
 ├── ark ...                   power-user Ark RPCs                    (all builds)
 │   ├── board                 board confirmed boarding UTXOs
@@ -173,7 +173,7 @@ own `CLAUDE.md` / `AGENTS.md` with package-local context.
 |----------------------------------|-----------------------------------------------------------------------|
 | System architecture              | [`ARCHITECTURE.md`](ARCHITECTURE.md)                                  |
 | Install, configure, operate      | [`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md)                |
-| Build-tag matrix                 | [`docs/walletrpc_build.md`](docs/walletrpc_build.md)                  |
+| Build-tag matrix                 | [`docs/walletdkrpc_build.md`](docs/walletdkrpc_build.md)                  |
 | Durable actor pattern            | [`docs/durable_actor_architecture.md`](docs/durable_actor_architecture.md) |
 | Mailbox transport                | [`docs/mailbox_architecture.md`](docs/mailbox_architecture.md)        |
 | SDK layering                     | [`docs/sdk_layered_architecture.md`](docs/sdk_layered_architecture.md)|

--- a/cmd/darepocli/darepoclicommands/cmd_create.go
+++ b/cmd/darepocli/darepoclicommands/cmd_create.go
@@ -9,7 +9,7 @@ import (
 )
 
 // newCreateCmd builds the top-level `create` verb. It is one of the
-// seven core wallet verbs (create, unlock, send, recv, list, balance,
+// seven core wallet verbs (create, unlock, send, recv, activity, balance,
 // exit) and dials walletdkrpc.WalletService.Create which proxies
 // daemonrpc.GenSeed + daemonrpc.InitWallet under the hood. Both the
 // wallet password and the optional seed passphrase are read from

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -60,7 +60,7 @@ type schemaMethod struct {
 // methodRegistry returns the full schema for all darepocli commands.
 // The body is split across helper functions to stay under the funlen
 // linter cap. The top-level wallet verbs (create, unlock, send, recv,
-// list, balance, exit) are the day-to-day surface; advanced commands
+// activity, balance, exit) are the day-to-day surface; advanced commands
 // live under the `ark.*` and `swap.*` namespaces.
 //
 // The swap.* entries are listed unconditionally regardless of the

--- a/cmd/darepocli/darepoclicommands/wallet_client.go
+++ b/cmd/darepocli/darepoclicommands/wallet_client.go
@@ -168,26 +168,6 @@ func parseEntryKind(s string) (walletdkrpc.EntryKind, error) {
 	}
 }
 
-// parseListView maps a user-facing view string to the proto enum used in
-// ListRequest.View. Empty/default falls back to ACTIVITY.
-func parseListView(s string) (walletdkrpc.ListView, error) {
-	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", "activity":
-		return walletdkrpc.ListView_LIST_VIEW_ACTIVITY, nil
-
-	case "vtxos", "vtxo":
-		return walletdkrpc.ListView_LIST_VIEW_VTXOS, nil
-
-	case "onchain", "on-chain":
-		return walletdkrpc.ListView_LIST_VIEW_ONCHAIN, nil
-
-	default:
-		return walletdkrpc.ListView_LIST_VIEW_UNSPECIFIED,
-			fmt.Errorf("unknown view %q (activity|vtxos|onchain)",
-				s)
-	}
-}
-
 // resolveOffchainFlag enforces the --offchain / --onchain invariant: at
 // most one may be set, and absence implies offchain (the default for
 // send and recv).

--- a/cmd/darepocli/darepoclicommands/wallet_client_test.go
+++ b/cmd/darepocli/darepoclicommands/wallet_client_test.go
@@ -192,69 +192,6 @@ func TestResolveOffchainFlagRejectsConflict(t *testing.T) {
 	require.ErrorIs(t, err, errOffchainOnchainConflict)
 }
 
-// TestParseListView confirms each accepted view string maps cleanly
-// onto the proto enum and unknown values are rejected.
-func TestParseListView(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		in   string
-		want walletdkrpc.ListView
-		bad  bool
-	}{
-		{
-			"",
-			walletdkrpc.ListView_LIST_VIEW_ACTIVITY,
-			false,
-		},
-		{
-			"activity",
-			walletdkrpc.ListView_LIST_VIEW_ACTIVITY,
-			false,
-		},
-		{
-			"ACTIVITY",
-			walletdkrpc.ListView_LIST_VIEW_ACTIVITY,
-			false,
-		},
-		{
-			"vtxos",
-			walletdkrpc.ListView_LIST_VIEW_VTXOS,
-			false,
-		},
-		{
-			"vtxo",
-			walletdkrpc.ListView_LIST_VIEW_VTXOS,
-			false,
-		},
-		{
-			"onchain",
-			walletdkrpc.ListView_LIST_VIEW_ONCHAIN,
-			false,
-		},
-		{
-			"on-chain",
-			walletdkrpc.ListView_LIST_VIEW_ONCHAIN,
-			false,
-		},
-		{
-			"junk",
-			walletdkrpc.ListView_LIST_VIEW_UNSPECIFIED,
-			true,
-		},
-	}
-	for _, tc := range cases {
-		v, err := parseListView(tc.in)
-		if tc.bad {
-			require.Error(t, err, "in=%q", tc.in)
-
-			continue
-		}
-		require.NoError(t, err, "in=%q", tc.in)
-		require.Equal(t, tc.want, v, "in=%q", tc.in)
-	}
-}
-
 // TestParseEntryKindAcceptsCanonicalForms confirms the kind parser
 // accepts the canonical names plus the obvious aliases ("receive" for
 // "recv").

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -27,7 +27,7 @@ After building, two binaries are produced:
 
 ### Optional: walletdkrpc
 
-The "user-facing" verbs in the CLI (`balance`, `recv`, `send`, `list`,
+The "user-facing" verbs in the CLI (`balance`, `recv`, `send`, `activity`,
 `create`, `unlock`) route through the `walletdkrpc` subserver. That code
 is gated behind the `walletdkrpc` build tag; the default `make build` does
 **not** enable it. Without the tag, those verbs return:
@@ -205,7 +205,7 @@ darepocli
 ├── create / unlock           — wallet bring-up (walletdkrpc)
 ├── recv                      — boarding address / Lightning invoice (walletdkrpc)
 ├── send                      — Lightning invoice / onchain leave (walletdkrpc)
-├── list                      — unified activity / VTXOs / onchain (walletdkrpc)
+├── activity                  — unified wallet activity feed (walletdkrpc)
 ├── exit [status]             — unilateral exit a VTXO
 ├── mcp serve                 — MCP server for AI agents (walletdkrpc)
 ├── schema                    — JSON dump of CLI methods
@@ -452,24 +452,32 @@ darepocli ark listtransactions \
   --no-tls
 ```
 
-### `list` (walletdkrpc)
+### `activity` (walletdkrpc)
 
-Unified wallet view selected by `--view`:
+The merged wallet activity feed: send / recv / deposit / exit history.
 
-| `--view` | Returns |
-|----------|---------|
-| `activity` (default) | Merged send / recv / deposit / exit history |
-| `vtxos` | Live VTXO inventory |
-| `onchain` | Boarding deposits, sweeps, leave outputs |
-
-`--pending` and `--kind` apply within the activity view and are ignored
-for the others.
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--pending` | | Only entries still in flight |
+| `--kind` | | Filter by kind (`send,recv,deposit,exit`); repeatable |
+| `--limit` | daemon default | Page size |
+| `--offset` | `0` | Pagination offset |
+| `--format` | `table` | Output format (`table`, `expanded`/`x`, `json`) |
 
 ```bash
-darepocli list --no-tls
-darepocli list --view vtxos --no-tls
-darepocli list --view onchain --limit 100 --no-tls
-darepocli list --pending --kind send,recv --no-tls
+darepocli activity --no-tls
+darepocli activity --pending --kind send,recv --no-tls
+darepocli activity --format json --no-tls
+darepocli activity inspect <id> --no-tls
+```
+
+The VTXO inventory and onchain history are not part of the activity feed.
+Use the `ark` subtree for those:
+
+```bash
+darepocli ark vtxos list --no-tls          # live VTXO inventory
+darepocli ark listtransactions --no-tls    # raw transaction / onchain history
+darepocli ark sweep list --no-tls          # boarding-timeout sweep records
 ```
 
 ### `schema`

--- a/docs/walletdkrpc_build.md
+++ b/docs/walletdkrpc_build.md
@@ -19,7 +19,7 @@ The wallet RPC subserver lives behind paired build tags:
 
 - `walletdkrpc` — registers the wallet RPC gRPC service in the daemon and
   enables the top-level `darepocli` wallet verbs (`balance`, `recv`,
-  `send`, `list`, `create`, `unlock`, `mcp`).
+  `send`, `activity`, `create`, `unlock`, `mcp`).
 - `swapruntime` — the underlying swap subsystem the wallet RPC layer
   composes against. Required transitively: building with `walletdkrpc` but
   without `swapruntime` is a deliberate compile error.
@@ -67,10 +67,12 @@ When the daemon is started from a `walletdkrpc`-tagged build:
   calls, enforces a wallet-level deadline watcher that transitions stuck
   entries to FAILED, and runs a monitor loop that fans normalized updates
   to `SubscribeWallet` subscribers.
-- The CLI exposes top-level wallet verbs: `send`, `recv`, `list`,
-  `balance`, `create`, `unlock`, and `mcp serve`. Boarding deposits and
-  onchain sweeps appear via `list --view onchain`. Subscriptions are
-  available from the `walletdkrpc.WalletService.SubscribeWallet` RPC.
+- The CLI exposes top-level wallet verbs: `send`, `recv`, `activity`,
+  `balance`, `create`, `unlock`, and `mcp serve`. Raw transaction / onchain
+  history is available via `ark listtransactions`, the live VTXO set via
+  `ark vtxos list`, and boarding-timeout sweep records via `ark sweep list`.
+  Subscriptions are available from the
+  `walletdkrpc.WalletService.SubscribeWallet` RPC.
 - The `sdk/walletdk` facade can route through wallet RPC instead of the
   raw swap RPCs.
 
@@ -105,12 +107,12 @@ authoritative constants.
 make build-walletdkrpc
 
 # Confirm the top-level wallet verbs appear in `darepocli --help`
-# (balance, recv, send, list, create, unlock, mcp).
+# (balance, recv, send, activity, create, unlock, mcp).
 ./bin/darepocli --help
 
 # After starting the daemon and creating/unlocking a wallet:
 ./bin/darepocli balance
-./bin/darepocli list --view vtxos
+./bin/darepocli ark vtxos list
 ```
 
 If `darepocli balance` returns `daemon was not built with -tags walletdkrpc`,


### PR DESCRIPTION
## Summary

Cleans up stale CLI/build references that no longer match the code:

- **`list --view` → `activity`**: the top-level `list --view vtxos|onchain`
  verb was removed (renamed to `activity`, `--view` flag dropped, hardcoded
  to `LIST_VIEW_ACTIVITY`). Docs and the darepod skill still documented it.
  Now document the real `activity` command and point VTXO/onchain views at
  the `ark` subtree (`ark vtxos list`, `ark sweep list`).
- **Dead code**: removed the now-unreachable `parseListView` helper and its
  unit test (only the test referenced it after the `list`→`activity` rename).
- **`walletrpc` → `walletdkrpc`**: the build tag was renamed but `INSTALL.md`
  and `README.md` still referenced the old name, breaking the documented make
  targets (`install-walletrpc`, `build-walletrpc`), `-tags` strings, and
  `docs/walletrpc_build.md` links. Renamed all occurrences. The btcsuite
  `walletrpc.WalletService` references in `docs/walletdk_integration.md` are a
  different upstream package and left unchanged.
