### PR TITLE
serverconn: demote per-batch ingress pull log to trace

### DIFF
--- a/serverconn/ingress.go
+++ b/serverconn/ingress.go
@@ -122,7 +122,8 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 			continue
 		}
 
-		a.log.DebugS(ctx, "Pulled envelopes",
+		a.log.TraceS(
+			ctx, "Pulled envelopes",
 			slog.Int("count", len(envelopes)),
 			slog.Uint64("cursor", state.PullCursor),
 			slog.Uint64("next_cursor", nextCursor),


### PR DESCRIPTION
In this PR, we demote the per-batch "Pulled envelopes" log in the
serverconn ingress loop from debug to trace.

The ingress loop logs a line for every batch of envelopes it pulls from
the mailbox. Under a steady stream that fires roughly every 20ms, so the
debug log fills up with near-identical entries like:

```
[DBG] SVRC: Pulled envelopes count=1 cursor=40990663 next_cursor=40990665
[DBG] SVRC: Pulled envelopes count=1 cursor=40990665 next_cursor=40990667
[DBG] SVRC: Pulled envelopes count=1 cursor=40990667 next_cursor=40990669
```

This is routine per-envelope cursor bookkeeping, not a debug-worthy
event, so we move it to trace alongside the other low-level ingress
accounting (e.g. the unary facade already logs at trace). The line is
still there when you're tracing cursor movement; it just no longer
drowns out the rest of the debug output.
