### PR TITLE
round: time out unanswered round registration to free stranded forfeits

### DIFF
--- a/darepod/config.go
+++ b/darepod/config.go
@@ -187,6 +187,12 @@ type Config struct {
 	//nolint:ll
 	ForfeitCollectionTimeout time.Duration `mapstructure:"forfeitcollectiontimeout"`
 
+	// RegistrationTimeout is the maximum wall-clock duration to
+	// wait for the server's RoundJoined admission watermark after
+	// sending a JoinRoundRequest. If zero, the round package
+	// default is used; a negative value disables the timeout.
+	RegistrationTimeout time.Duration `mapstructure:"registrationtimeout"`
+
 	// AllowMainnet must be set to true explicitly to run the daemon
 	// on mainnet. This guard prevents accidentally operating on
 	// mainnet during development, since DefaultNetwork is "mainnet".

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -3364,6 +3364,7 @@ func (s *Server) initRoundActor(ctx context.Context,
 		LedgerSink:           fn.Some(ledger.NewSink(s.actorSystem)),
 		ForfeitCollectionTimeout: s.cfg.
 			ForfeitCollectionTimeout,
+		RegistrationTimeout: s.cfg.RegistrationTimeout,
 	}
 
 	roundActor, err := round.NewRoundClientActor(
@@ -3720,6 +3721,11 @@ func (s *Server) initOORActor(ctx context.Context,
 // mapRoundVTXOManagerMsg infallible.
 var _ vtxo.ManagerMsg = (*round.VTXOCreatedNotification)(nil)
 var _ vtxo.ManagerMsg = (*round.VTXOTerminatedMsg)(nil)
+
+// The round actor releases forfeit-reserved inputs on registration timeout by
+// Telling an actormsg.ReleaseForfeitRequest through the same bridged
+// VTXOManager ref, so it too must satisfy vtxo.ManagerMsg.
+var _ vtxo.ManagerMsg = (*actormsg.ReleaseForfeitRequest)(nil)
 
 // mapRoundVTXOManagerMsg adapts round-owned manager notifications into the
 // concrete message type accepted by the VTXO manager actor.

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -92,8 +92,13 @@ state transitions and validation rules live under [Invariants](#invariants).
 
 ### Misc
 
-- `TimeoutPhase` (`fsm_timeouts.go`) — only value:
-  `TimeoutPhaseForfeitCollection`.
+- `TimeoutPhase` (`fsm_timeouts.go`) — `TimeoutPhaseForfeitCollection`
+  (forfeit-signature collection window) and `TimeoutPhaseRegistration`
+  (IntentSentState admission window; on expiry the FSM fails the round
+  recoverably and emits `ReleaseForfeitReservation` so forfeit-reserved
+  inputs are not stranded — darepo-client#653). Timeout outbox messages
+  (`StartTimeoutReq`/`CancelTimeoutReq`) key on `RoundKeyStr` so temp-keyed
+  rounds (pre-admission) can be timed.
 - `MaxQuoteEntriesPerClient = 1024` (`from_proto.go`) — bounds quote
   entry decoding to reject malformed envelopes before allocating slices.
 - `FromProto` methods on `JoinRoundQuoteReceived`, `RoundJoined`,

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -92,8 +92,13 @@ state transitions and validation rules live under [Invariants](#invariants).
 
 ### Misc
 
-- `TimeoutPhase` (`fsm_timeouts.go`) — only value:
-  `TimeoutPhaseForfeitCollection`.
+- `TimeoutPhase` (`fsm_timeouts.go`) — `TimeoutPhaseForfeitCollection`
+  (forfeit-signature collection window) and `TimeoutPhaseRegistration`
+  (IntentSentState admission window; on expiry the FSM fails the round
+  recoverably and emits `ReleaseForfeitReservation` so forfeit-reserved
+  inputs are not stranded — darepo-client#653). Timeout outbox messages
+  (`StartTimeoutReq`/`CancelTimeoutReq`) key on `RoundKeyStr` so temp-keyed
+  rounds (pre-admission) can be timed.
 - `MaxQuoteEntriesPerClient = 1024` (`from_proto.go`) — bounds quote
   entry decoding to reject malformed envelopes before allocating slices.
 - `FromProto` methods on `JoinRoundQuoteReceived`, `RoundJoined`,

--- a/round/actor.go
+++ b/round/actor.go
@@ -37,6 +37,17 @@ var _ actor.Stoppable = (*RoundClientActor)(nil)
 
 const defaultForfeitCollectionTimeout = 2 * time.Minute
 
+// defaultRegistrationTimeout bounds how long the client waits in
+// IntentSentState for the server to acknowledge a JoinRoundRequest with a
+// RoundJoined admission watermark. The ack is a lightweight reply (not the
+// seal-time quote), so it should arrive within a network round-trip plus brief
+// server-side queuing; 60s is generous enough to tolerate a slow server or
+// link while still bounding how long forfeit-reserved inputs sit stranded in
+// pending-forfeit when the server never responds (darepo-client#653). It is
+// configurable via RoundClientConfig.RegistrationTimeout for operators and
+// tests that need a different bound.
+const defaultRegistrationTimeout = 60 * time.Second
+
 // RefreshVTXORequest is sent from a VTXO actor when its VTXO is approaching
 // expiry and needs to be refreshed in a new round. The round actor should
 // queue this VTXO for inclusion in the next batch swap.
@@ -138,26 +149,25 @@ func buildVTXORequestFromRefresh(req *RefreshVTXORequest) types.VTXORequest {
 	}
 }
 
-// makeTimeoutID builds a composite timeout ID from round ID and phase.
-func makeTimeoutID(roundID RoundID, phase TimeoutPhase) timeout.ID {
-	return timeout.ID(fmt.Sprintf("%s:%s", roundID.String(), phase))
+// makeTimeoutID builds a composite timeout ID from a round map key and phase.
+// The key is used verbatim (it may itself contain ":" for temp keys, e.g.
+// "temp:<uuid>"), so parseTimeoutID splits on the final ":" to recover the
+// phase.
+func makeTimeoutID(key RoundKeyStr, phase TimeoutPhase) timeout.ID {
+	return timeout.ID(fmt.Sprintf("%s:%s", key, phase))
 }
 
-// parseTimeoutID extracts round ID and phase from a composite timeout ID.
-func parseTimeoutID(id timeout.ID) (RoundID, TimeoutPhase, error) {
-	parts := strings.SplitN(string(id), ":", 2)
-	if len(parts) != 2 {
-		return RoundID{}, "", fmt.Errorf("invalid timeout ID "+
-			"format: %s", id)
+// parseTimeoutID extracts the round map key and phase from a composite timeout
+// ID. The phase is the suffix after the final ":"; everything before it is the
+// round key (which may contain ":" itself for temp-keyed rounds).
+func parseTimeoutID(id timeout.ID) (RoundKeyStr, TimeoutPhase, error) {
+	s := string(id)
+	idx := strings.LastIndex(s, ":")
+	if idx < 0 {
+		return "", "", fmt.Errorf("invalid timeout ID format: %s", id)
 	}
 
-	roundID, err := ParseRoundID(parts[0])
-	if err != nil {
-		return RoundID{}, "", fmt.Errorf("invalid round ID in "+
-			"timeout ID: %w", err)
-	}
-
-	return roundID, TimeoutPhase(parts[1]), nil
+	return RoundKeyStr(s[:idx]), TimeoutPhase(s[idx+1:]), nil
 }
 
 // RoundFSM wraps a state machine instance for a specific round.
@@ -304,6 +314,14 @@ type RoundClientConfig struct {
 	// If zero, a conservative default is used.
 	ForfeitCollectionTimeout time.Duration
 
+	// RegistrationTimeout is the max wall-clock duration to wait in
+	// IntentSentState for the server's RoundJoined admission watermark
+	// before failing the round (recoverable) and releasing any
+	// forfeit-reserved inputs. If zero, defaultRegistrationTimeout is used.
+	// A negative value disables the timeout (rounds wait indefinitely for
+	// admission), which restores the pre-#653 behavior.
+	RegistrationTimeout time.Duration
+
 	// OwnedScriptChecker determines whether a VTXO pkScript belongs
 	// to the local wallet. When nil, all VTXOs pass the ownership
 	// check (backward-compatible default for tests).
@@ -372,6 +390,15 @@ func NewRoundClientActor(cfg *RoundClientConfig) fn.Result[*RoundClientActor] {
 		forfeitTimeout = defaultForfeitCollectionTimeout
 	}
 	env.ForfeitCollectionTimeout = forfeitTimeout
+
+	// A zero value selects the default; a negative value is an explicit
+	// opt-out (wait for admission indefinitely). Only the zero case is
+	// rewritten to the default.
+	registrationTimeout := cfg.RegistrationTimeout
+	if registrationTimeout == 0 {
+		registrationTimeout = defaultRegistrationTimeout
+	}
+	env.RegistrationTimeout = registrationTimeout
 
 	actor := &RoundClientActor{
 		cfg:               cfg,
@@ -652,7 +679,9 @@ func (a *RoundClientActor) createRoundFSMFromDB(ctx context.Context,
 		DisableJoinRequestAuth: a.cfg.DisableJoinRequestAuth,
 		ForfeitCollectionTimeout: a.
 			env.ForfeitCollectionTimeout,
-		OwnedScriptChecker: a.cfg.OwnedScriptChecker,
+		RegistrationTimeout: a.env.RegistrationTimeout,
+		RoundKey:            RoundKeyStr(roundID.KeyString()),
+		OwnedScriptChecker:  a.cfg.OwnedScriptChecker,
 	}
 	fsmCfg := ClientStateMachineCfg{
 		Logger:        fsmLogger,
@@ -715,7 +744,9 @@ func (a *RoundClientActor) createNewRound(ctx context.Context) (*RoundFSM,
 		DisableJoinRequestAuth: a.cfg.DisableJoinRequestAuth,
 		ForfeitCollectionTimeout: a.
 			env.ForfeitCollectionTimeout,
-		OwnedScriptChecker: a.cfg.OwnedScriptChecker,
+		RegistrationTimeout: a.env.RegistrationTimeout,
+		RoundKey:            RoundKeyStr(tempKey.KeyString()),
+		OwnedScriptChecker:  a.cfg.OwnedScriptChecker,
 	}
 	fsmCfg := ClientStateMachineCfg{
 		Logger:        fsmLogger,
@@ -1998,7 +2029,7 @@ func (a *RoundClientActor) handleConfirmation(ctx context.Context,
 func (a *RoundClientActor) handleTimeout(ctx context.Context,
 	msg *TimeoutMsg) fn.Result[actormsg.RoundActorResp] {
 
-	roundID, phase, err := parseTimeoutID(msg.TimeoutID)
+	keyStr, phase, err := parseTimeoutID(msg.TimeoutID)
 	if err != nil {
 		a.log.WarnS(ctx, "Failed to parse timeout ID",
 			err,
@@ -2008,11 +2039,10 @@ func (a *RoundClientActor) handleTimeout(ctx context.Context,
 		return fn.Ok[actormsg.RoundActorResp](nil)
 	}
 
-	keyStr := RoundKeyStr(roundID.KeyString())
 	roundFSM, exists := a.rounds[keyStr]
 	if !exists {
 		a.log.DebugS(ctx, "Ignoring timeout for unknown round",
-			slog.String("round_id", roundID.String()),
+			slog.String("round_key", string(keyStr)),
 			slog.String("phase", string(phase)),
 		)
 
@@ -2022,14 +2052,29 @@ func (a *RoundClientActor) handleTimeout(ctx context.Context,
 	var timeoutEvt ClientEvent
 	switch phase {
 	case TimeoutPhaseForfeitCollection:
+		// Forfeit collection only runs after the round has been
+		// re-keyed to its server-assigned RoundID, so the map key
+		// parses back to a RoundID.
+		roundID, perr := ParseRoundID(string(keyStr))
+		if perr != nil {
+			a.log.WarnS(ctx, "Forfeit timeout with non-RoundID key",
+				perr,
+				slog.String("round_key", string(keyStr)),
+			)
+
+			return fn.Ok[actormsg.RoundActorResp](nil)
+		}
 		timeoutEvt = &ForfeitCollectionTimedOut{
 			RoundID: roundID,
 		}
 
+	case TimeoutPhaseRegistration:
+		timeoutEvt = &RegistrationTimedOut{}
+
 	default:
 		a.log.WarnS(ctx, "Ignoring timeout with unknown phase",
 			nil,
-			slog.String("round_id", roundID.String()),
+			slog.String("round_key", string(keyStr)),
 			slog.String("phase", string(phase)),
 		)
 
@@ -2084,7 +2129,7 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 			}
 
 		case *StartTimeoutReq:
-			compositeID := makeTimeoutID(m.RoundID, m.Phase)
+			compositeID := makeTimeoutID(m.RoundKey, m.Phase)
 
 			mapFn := func(expired timeout.ExpiredMsg,
 			) actormsg.RoundReceivable {
@@ -2109,7 +2154,7 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 			}
 
 		case *CancelTimeoutReq:
-			compositeID := makeTimeoutID(m.RoundID, m.Phase)
+			compositeID := makeTimeoutID(m.RoundKey, m.Phase)
 			req := &timeout.CancelTimeoutRequest{
 				ID: compositeID,
 			}
@@ -2117,6 +2162,33 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 				ctx, req,
 			); err != nil {
 				return fmt.Errorf("cancel timeout: %w", err)
+			}
+
+		case *ReleaseForfeitReservation:
+			// Release forfeit-reserved VTXOs back to LiveState via
+			// the VTXO manager. Best-effort and fire-and-forget: a
+			// failed release is logged but must not halt outbox
+			// processing for the (already failed) round. Routing
+			// through the manager keeps its reservation set in sync
+			// so the released inputs can be re-selected for a
+			// retry.
+			if a.cfg.VTXOManager == nil || len(m.Outpoints) == 0 {
+				continue
+			}
+			if err := a.cfg.VTXOManager.Tell(
+				ctx, &actormsg.ReleaseForfeitRequest{
+					Outpoints: m.Outpoints,
+				},
+			); err != nil {
+
+				a.log.WarnS(
+					ctx,
+					"Failed to release forfeit reservation",
+					err,
+					slog.Int(
+						"outpoints", len(m.Outpoints),
+					),
+				)
 			}
 
 		case *VTXOCreatedNotification:

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -600,7 +600,7 @@ func TestActorProcessOutbox(t *testing.T) {
 		duration := 30 * time.Second
 		outbox := []ClientOutMsg{
 			&StartTimeoutReq{
-				RoundID:  roundID,
+				RoundKey: RoundKeyStr(roundID.KeyString()),
 				Phase:    TimeoutPhaseForfeitCollection,
 				Duration: duration,
 			},
@@ -610,7 +610,10 @@ func TestActorProcessOutbox(t *testing.T) {
 		require.NoError(t, err)
 
 		timeoutID := makeTimeoutID(
-			roundID, TimeoutPhaseForfeitCollection,
+			RoundKeyStr(
+				roundID.KeyString(),
+			),
+			TimeoutPhaseForfeitCollection,
 		)
 		h.timeoutActor.assertTimeoutScheduled(
 			t, timeoutID, duration,
@@ -628,7 +631,10 @@ func TestActorProcessOutbox(t *testing.T) {
 
 		roundID := testRoundID("timeout-round-cancel")
 		timeoutID := makeTimeoutID(
-			roundID, TimeoutPhaseForfeitCollection,
+			RoundKeyStr(
+				roundID.KeyString(),
+			),
+			TimeoutPhaseForfeitCollection,
 		)
 
 		schedReq := &timeout.ScheduleTimeoutRequest{
@@ -643,8 +649,8 @@ func TestActorProcessOutbox(t *testing.T) {
 
 		outbox := []ClientOutMsg{
 			&CancelTimeoutReq{
-				RoundID: roundID,
-				Phase:   TimeoutPhaseForfeitCollection,
+				RoundKey: RoundKeyStr(roundID.KeyString()),
+				Phase:    TimeoutPhaseForfeitCollection,
 			},
 		}
 
@@ -2095,7 +2101,10 @@ func TestHandleForfeitCollectionTimeout(t *testing.T) {
 		keyStr := RoundKeyStr(roundID.KeyString())
 		msg := &TimeoutMsg{
 			TimeoutID: makeTimeoutID(
-				roundID, TimeoutPhaseForfeitCollection,
+				RoundKeyStr(
+					roundID.KeyString(),
+				),
+				TimeoutPhaseForfeitCollection,
 			),
 		}
 		result := h.receive(msg)
@@ -2131,7 +2140,10 @@ func TestHandleForfeitCollectionTimeout(t *testing.T) {
 
 		keyStr := RoundKeyStr(roundID.KeyString())
 		tid := makeTimeoutID(
-			roundID, TimeoutPhase("unknown"),
+			RoundKeyStr(
+				roundID.KeyString(),
+			),
+			TimeoutPhase("unknown"),
 		)
 		msg := &TimeoutMsg{TimeoutID: tid}
 		result := h.receive(msg)
@@ -2165,7 +2177,10 @@ func TestHandleForfeitCollectionTimeout(t *testing.T) {
 		unknownID := testRoundID("nonexistent-round")
 		msg := &TimeoutMsg{
 			TimeoutID: makeTimeoutID(
-				unknownID, TimeoutPhaseForfeitCollection,
+				RoundKeyStr(
+					unknownID.KeyString(),
+				),
+				TimeoutPhaseForfeitCollection,
 			),
 		}
 		result := h.receive(msg)
@@ -2191,7 +2206,10 @@ func TestHandleForfeitCollectionTimeout(t *testing.T) {
 
 		timeoutMsg := &TimeoutMsg{
 			TimeoutID: makeTimeoutID(
-				roundID1, TimeoutPhaseForfeitCollection,
+				RoundKeyStr(
+					roundID1.KeyString(),
+				),
+				TimeoutPhaseForfeitCollection,
 			),
 		}
 		result := h.receive(timeoutMsg)
@@ -2254,7 +2272,7 @@ func TestRealTimeoutActorForfeitExpiry(t *testing.T) {
 	// when entering forfeit collection. This schedules the real timeout.
 	outbox := []ClientOutMsg{
 		&StartTimeoutReq{
-			RoundID:  roundID,
+			RoundKey: RoundKeyStr(roundID.KeyString()),
 			Phase:    TimeoutPhaseForfeitCollection,
 			Duration: 100 * time.Millisecond,
 		},
@@ -2271,7 +2289,13 @@ func TestRealTimeoutActorForfeitExpiry(t *testing.T) {
 	timeoutMsg, ok := rawMsg.(*TimeoutMsg)
 	require.True(t, ok, "expected *TimeoutMsg, got %T", rawMsg)
 	require.Equal(
-		t, makeTimeoutID(roundID, TimeoutPhaseForfeitCollection),
+		t,
+		makeTimeoutID(
+			RoundKeyStr(
+				roundID.KeyString(),
+			),
+			TimeoutPhaseForfeitCollection,
+		),
 		timeoutMsg.TimeoutID,
 	)
 

--- a/round/events.go
+++ b/round/events.go
@@ -413,3 +413,14 @@ type ForfeitCollectionTimedOut struct {
 }
 
 func (e *ForfeitCollectionTimedOut) clientEventSealed() {}
+
+// RegistrationTimedOut is emitted by the round actor when the registration
+// (admission) window expires while the FSM is still parked in IntentSentState,
+// i.e. the server never returned a RoundJoined admission watermark for the
+// JoinRoundRequest. The FSM consumes this in IntentSentState to fail the round
+// (recoverable) and release any forfeit-reserved inputs back to LiveState so
+// they are not stranded in pending-forfeit (darepo-client#653). The timeout is
+// armed when the FSM is still temp-keyed, so the event carries no RoundID.
+type RegistrationTimedOut struct{}
+
+func (e *RegistrationTimedOut) clientEventSealed() {}

--- a/round/fsm_environment.go
+++ b/round/fsm_environment.go
@@ -75,6 +75,19 @@ type ClientEnvironment struct {
 	// forfeit signatures from VTXO actors.
 	ForfeitCollectionTimeout time.Duration
 
+	// RegistrationTimeout is the timeout used while parked in
+	// IntentSentState waiting for the server's RoundJoined admission
+	// watermark. A non-positive value disables arming the registration
+	// timeout for the round.
+	RegistrationTimeout time.Duration
+
+	// RoundKey is the actor's map key for this round FSM (a TempRoundKey
+	// string before admission, a RoundID string after re-keying). The
+	// registration-timeout outbox messages carry it so the actor can
+	// schedule/cancel a timeout for a round that has not yet been assigned
+	// a server RoundID.
+	RoundKey RoundKeyStr
+
 	// OwnedScriptChecker determines whether a pkScript belongs to
 	// the local wallet. Used by buildOwnedClientVTXOs to filter
 	// VTXOs that should be persisted locally. This replaces the

--- a/round/fsm_timeouts.go
+++ b/round/fsm_timeouts.go
@@ -7,6 +7,14 @@ const (
 	// TimeoutPhaseForfeitCollection is the timeout phase for
 	// ForfeitSignaturesCollectingState.
 	TimeoutPhaseForfeitCollection TimeoutPhase = "forfeit-collection"
+
+	// TimeoutPhaseRegistration is the timeout phase for IntentSentState.
+	// It bounds how long the client waits for the server to acknowledge a
+	// JoinRoundRequest (the RoundJoined admission watermark). Without it a
+	// silent or unresponsive server would leave the round parked in
+	// IntentSentState forever, stranding any forfeit-reserved VTXOs in
+	// pending-forfeit (see darepo-client#653).
+	TimeoutPhaseRegistration TimeoutPhase = "registration"
 )
 
 // cancelForfeitTimeout builds a single-element outbox slice that
@@ -14,8 +22,8 @@ const (
 func cancelForfeitTimeout(roundID RoundID) []ClientOutMsg {
 	return []ClientOutMsg{
 		&CancelTimeoutReq{
-			RoundID: roundID,
-			Phase:   TimeoutPhaseForfeitCollection,
+			RoundKey: RoundKeyStr(roundID.KeyString()),
+			Phase:    TimeoutPhaseForfeitCollection,
 		},
 	}
 }

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -778,8 +778,12 @@ func (m *RoundCheckpointedNotification) clientOutMsgSealed() {}
 type StartTimeoutReq struct {
 	actor.BaseMessage
 
-	// RoundID identifies which round owns this timeout.
-	RoundID RoundID
+	// RoundKey identifies which round owns this timeout. It is the actor's
+	// map key for the round FSM (a RoundID for re-keyed rounds, or a
+	// TempRoundKey for rounds still awaiting admission), so timeouts can be
+	// scheduled for rounds that have not yet received a server-assigned
+	// RoundID.
+	RoundKey RoundKeyStr
 
 	// Phase identifies the round FSM phase that scheduled the timeout.
 	Phase TimeoutPhase
@@ -794,14 +798,31 @@ func (m *StartTimeoutReq) clientOutMsgSealed() {}
 type CancelTimeoutReq struct {
 	actor.BaseMessage
 
-	// RoundID identifies which round owns this timeout.
-	RoundID RoundID
+	// RoundKey identifies which round owns this timeout. See
+	// StartTimeoutReq.RoundKey for why this is a map key rather than a
+	// RoundID.
+	RoundKey RoundKeyStr
 
 	// Phase identifies the round FSM phase timeout to cancel.
 	Phase TimeoutPhase
 }
 
 func (m *CancelTimeoutReq) clientOutMsgSealed() {}
+
+// ReleaseForfeitReservation asks the actor to release the given VTXOs from
+// pending-forfeit back to LiveState via the VTXO manager. The FSM emits it when
+// a round fails before any forfeit signatures have been submitted to the
+// server (e.g. registration/admission timeout), so the forfeit-reserved inputs
+// are not stranded in pending-forfeit. Releasing is safe at that point because
+// nothing has been signed against the (non-existent) commitment transaction.
+type ReleaseForfeitReservation struct {
+	actor.BaseMessage
+
+	// Outpoints identifies the VTXOs to release from pending-forfeit.
+	Outpoints []wire.OutPoint
+}
+
+func (m *ReleaseForfeitReservation) clientOutMsgSealed() {}
 
 // RoundFailedNotification is emitted when a round FSM transitions to
 // ClientFailedState. This notifies higher layers (actor, wallet) of the

--- a/round/registration_timeout_test.go
+++ b/round/registration_timeout_test.go
@@ -1,0 +1,195 @@
+package round
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+// regTimeoutOutpoint builds a deterministic VTXO outpoint for the
+// registration-timeout tests.
+func regTimeoutOutpoint(seed byte, index uint32) wire.OutPoint {
+	return wire.OutPoint{
+		Hash: chainhash.Hash{
+			seed,
+		},
+		Index: index,
+	}
+}
+
+// mkForfeit builds a forfeit request for the given outpoint so the
+// IntentSentState carries something to release on timeout.
+func mkForfeit(op wire.OutPoint, amount btcutil.Amount) types.ForfeitRequest {
+	opCopy := op
+
+	return types.ForfeitRequest{
+		VTXOOutpoint: &opCopy,
+		Amount:       amount,
+	}
+}
+
+// findOutbox returns the first outbox message of type T, or false.
+func findOutbox[T ClientOutMsg](outbox []ClientOutMsg) (T, bool) {
+	for _, m := range outbox {
+		if typed, ok := m.(T); ok {
+			return typed, true
+		}
+	}
+
+	var zero T
+
+	return zero, false
+}
+
+// TestRegistrationTimeoutFailsAndReleasesForfeits is the core fix proof: when a
+// RegistrationTimedOut event reaches IntentSentState (the server never returned
+// a RoundJoined admission watermark), the FSM must fail the round as
+// recoverable AND emit a ReleaseForfeitReservation for every forfeit-reserved
+// input so they return to LiveState instead of being stranded in
+// pending-forfeit (darepo-client#653).
+func TestRegistrationTimeoutFailsAndReleasesForfeits(t *testing.T) {
+	t.Parallel()
+
+	op1 := regTimeoutOutpoint(0x01, 0)
+	op2 := regTimeoutOutpoint(0x02, 1)
+
+	s := &IntentSentState{
+		Intents: Intents{
+			Forfeits: []types.ForfeitRequest{
+				mkForfeit(op1, 10_000),
+				mkForfeit(op2, 20_000),
+			},
+		},
+	}
+	env := &ClientEnvironment{Log: btclog.Disabled}
+
+	tr, err := s.ProcessEvent(
+		context.Background(), &RegistrationTimedOut{}, env,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, tr.NextState)
+
+	// The round must fail, and the failure must be recoverable so the
+	// wallet/UI can offer a retry rather than a dead-end.
+	failed, ok := tr.NextState.(*ClientFailedState)
+	require.True(t, ok, "expected ClientFailedState, got %T", tr.NextState)
+	require.True(t, failed.Recoverable)
+
+	require.True(t, tr.NewEvents.IsSome())
+	outbox := tr.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+
+	// A failure notification is emitted for observability.
+	_, ok = findOutbox[*RoundFailedNotification](outbox)
+	require.True(t, ok, "expected RoundFailedNotification in outbox")
+
+	// The forfeit reservation is released for exactly the reserved inputs.
+	release, ok := findOutbox[*ReleaseForfeitReservation](outbox)
+	require.True(
+		t, ok, "expected ReleaseForfeitReservation in outbox",
+	)
+	require.ElementsMatch(
+		t, []wire.OutPoint{op1, op2}, release.Outpoints,
+	)
+}
+
+// TestRegistrationTimeoutIgnoredAfterAdmission verifies that a stale
+// RegistrationTimedOut arriving after the round has already been admitted
+// (AdmittedRoundID populated by RoundJoined) is ignored: the FSM stays in
+// IntentSentState and does NOT fail the round or release its forfeits. This
+// guards against a late timeout racing past the cancel and aborting a healthy,
+// admitted round.
+func TestRegistrationTimeoutIgnoredAfterAdmission(t *testing.T) {
+	t.Parallel()
+
+	op := regTimeoutOutpoint(0x03, 0)
+	s := &IntentSentState{
+		Intents: Intents{
+			Forfeits: []types.ForfeitRequest{
+				mkForfeit(op, 10_000),
+			},
+		},
+		AdmittedRoundID: testRoundIDTr("already-admitted"),
+	}
+	env := &ClientEnvironment{Log: btclog.Disabled}
+
+	tr, err := s.ProcessEvent(
+		context.Background(), &RegistrationTimedOut{}, env,
+	)
+	require.NoError(t, err)
+
+	// The round must remain parked in IntentSentState (a self-loop), not
+	// transition to a failed state.
+	_, ok := tr.NextState.(*IntentSentState)
+	require.True(t, ok, "expected IntentSentState, got %T", tr.NextState)
+
+	// No release and no failure notification: the admitted round is left
+	// untouched.
+	outbox := tr.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+	_, ok = findOutbox[*ReleaseForfeitReservation](outbox)
+	require.False(t, ok, "admitted round must not release forfeits")
+	_, ok = findOutbox[*RoundFailedNotification](outbox)
+	require.False(t, ok, "admitted round must not be failed")
+}
+
+// TestRegistrationTimeoutNoForfeitsStillFails verifies a boarding-only round
+// (no forfeit reservation) still fails recoverably on admission timeout, but
+// does not emit a forfeit release (there is nothing to release).
+func TestRegistrationTimeoutNoForfeitsStillFails(t *testing.T) {
+	t.Parallel()
+
+	s := &IntentSentState{Intents: Intents{}}
+	env := &ClientEnvironment{Log: btclog.Disabled}
+
+	tr, err := s.ProcessEvent(
+		context.Background(), &RegistrationTimedOut{}, env,
+	)
+	require.NoError(t, err)
+
+	failed, ok := tr.NextState.(*ClientFailedState)
+	require.True(t, ok, "expected ClientFailedState, got %T", tr.NextState)
+	require.True(t, failed.Recoverable)
+
+	outbox := tr.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+	_, ok = findOutbox[*RoundFailedNotification](outbox)
+	require.True(t, ok, "expected RoundFailedNotification in outbox")
+
+	_, ok = findOutbox[*ReleaseForfeitReservation](outbox)
+	require.False(
+		t, ok, "no forfeit reservation should be released for a "+
+			"boarding-only round",
+	)
+}
+
+// TestRoundJoinedCancelsRegistrationTimeout verifies that once the server's
+// RoundJoined admission watermark arrives, the FSM cancels the registration
+// timeout: the post-admission wait for the seal-time quote is governed by the
+// quote's own expiry, not the admission timer, so the timer must not fire and
+// tear down a healthy, admitted round.
+func TestRoundJoinedCancelsRegistrationTimeout(t *testing.T) {
+	t.Parallel()
+
+	const roundKey = RoundKeyStr("temp:round-joined-cancels")
+	s := &IntentSentState{Intents: Intents{}}
+	env := &ClientEnvironment{Log: btclog.Disabled, RoundKey: roundKey}
+
+	tr, err := s.ProcessEvent(context.Background(), &RoundJoined{
+		RoundID: testRoundIDTr("admitted-round"),
+	}, env)
+	require.NoError(t, err)
+
+	// The FSM stays parked in IntentSentState awaiting the quote.
+	_, ok := tr.NextState.(*IntentSentState)
+	require.True(t, ok, "expected IntentSentState, got %T", tr.NextState)
+
+	outbox := tr.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+	cancel, ok := findOutbox[*CancelTimeoutReq](outbox)
+	require.True(t, ok, "expected CancelTimeoutReq in outbox")
+	require.Equal(t, TimeoutPhaseRegistration, cancel.Phase)
+	require.Equal(t, roundKey, cancel.RoundKey)
+}

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -476,21 +476,36 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 
 		// With all this extracted, we'll now send the
 		// JoinRoundRequest to kick off the signing process.
+		outbox := []ClientOutMsg{
+			&JoinRoundRequest{
+				BoardingRequests: boardingReqs,
+				VTXORequests:     vtxoReqs,
+				ForfeitRequests:  forfeitReqs,
+				LeaveRequests:    leaveReqs,
+				Identifier:       idPub,
+				Auth:             joinAuth,
+			},
+		}
+
+		// Arm the registration (admission) timeout so a server that
+		// never returns a RoundJoined watermark cannot park us in
+		// IntentSentState forever. On expiry the FSM fails the round
+		// and releases any forfeit-reserved inputs (darepo-client#653).
+		// A non-positive timeout disables the safety net.
+		if env.RegistrationTimeout > 0 {
+			outbox = append(outbox, &StartTimeoutReq{
+				RoundKey: env.RoundKey,
+				Phase:    TimeoutPhaseRegistration,
+				Duration: env.RegistrationTimeout,
+			})
+		}
+
 		return &ClientStateTransition{
 			NextState: &IntentSentState{
 				Intents: intent,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
-				Outbox: []ClientOutMsg{
-					&JoinRoundRequest{
-						BoardingRequests: boardingReqs,
-						VTXORequests:     vtxoReqs,
-						ForfeitRequests:  forfeitReqs,
-						LeaveRequests:    leaveReqs,
-						Identifier:       idPub,
-						Auth:             joinAuth,
-					},
-				},
+				Outbox: outbox,
 			}),
 		}, nil
 
@@ -539,11 +554,89 @@ func (s *IntentSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 			slog.Int("vtxo_intent_count", len(s.Intents.VTXOs)),
 		)
 
+		// Admission arrived, so cancel the registration timeout. The
+		// post-admission wait for the seal-time quote is governed by
+		// the quote's own expiry, not this watermark timer.
+		cancelReg := []ClientOutMsg{
+			&CancelTimeoutReq{
+				RoundKey: env.RoundKey,
+				Phase:    TimeoutPhaseRegistration,
+			},
+		}
+
 		return &ClientStateTransition{
 			NextState: &IntentSentState{
 				Intents:         s.Intents.Clone(),
 				AdmittedRoundID: evt.RoundID,
 			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: cancelReg,
+			}),
+		}, nil
+
+	case *RegistrationTimedOut:
+		// Ignore a stale timeout once the round has been admitted.
+		// Admission (RoundJoined) cancels the timer and re-keys the
+		// round away from its temp key, so the actor layer already
+		// drops a late TimeoutMsg whose composite id carries the temp
+		// key. This guard is belt-and-suspenders for any in-flight
+		// RegistrationTimedOut that raced past the cancel, and keeps
+		// the invariant explicit at the FSM if the arming/re-key timing
+		// ever changes: never abort a round we know the server
+		// admitted.
+		if s.AdmittedRoundID != (RoundID{}) {
+			env.Log.DebugS(ctx, "Ignoring stale registration timeout; "+
+				"round already admitted",
+				slog.String(
+					"round_id", s.AdmittedRoundID.String(),
+				),
+			)
+
+			return selfLoop(s), nil
+		}
+
+		// The server never acknowledged our JoinRoundRequest within the
+		// admission window. Fail the round as recoverable (the client
+		// may retry) and release any forfeit-reserved inputs back to
+		// LiveState so they are not stranded in pending-forfeit
+		// (darepo-client#653). Releasing is safe here: at this phase no
+		// forfeit signatures have been produced or sent to the server,
+		// so there is nothing to double-spend.
+		const reason = "round admission timed out"
+		timeoutErr := fmt.Errorf("server did not acknowledge join " +
+			"request before registration timeout")
+
+		env.Log.WarnS(ctx, "Round admission timed out; failing round "+
+			"and releasing forfeit reservation", timeoutErr,
+			slog.Int("forfeit_count", len(s.Intents.Forfeits)),
+		)
+
+		outbox := []ClientOutMsg{
+			&RoundFailedNotification{
+				RoundID:       fn.None[RoundID](),
+				Reason:        reason,
+				Recoverable:   true,
+				OriginalError: timeoutErr,
+			},
+		}
+		if outpoints := forfeitOutpoints(s.Intents.Forfeits); len(
+			outpoints,
+		) > 0 {
+
+			outbox = append(outbox, &ReleaseForfeitReservation{
+				Outpoints: outpoints,
+			})
+		}
+
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      reason,
+				Error:       timeoutErr,
+				Recoverable: true,
+			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: outbox,
+			}),
 		}, nil
 
 	case *JoinRoundQuoteReceived:
@@ -1819,7 +1912,7 @@ func (s *CommitmentTxValidatedState) ProcessEvent(ctx context.Context,
 			}
 
 			outbox = append(outbox, &StartTimeoutReq{
-				RoundID:  s.RoundID,
+				RoundKey: RoundKeyStr(s.RoundID.KeyString()),
 				Phase:    TimeoutPhaseForfeitCollection,
 				Duration: env.ForfeitCollectionTimeout,
 			})
@@ -2152,8 +2245,8 @@ func (s *ForfeitSignaturesCollectingState) forfeitCollectionOutbox(
 
 	outboxMsgs := []ClientOutMsg{
 		&CancelTimeoutReq{
-			RoundID: s.RoundID,
-			Phase:   TimeoutPhaseForfeitCollection,
+			RoundKey: RoundKeyStr(s.RoundID.KeyString()),
+			Phase:    TimeoutPhaseForfeitCollection,
 		},
 		&SubmitVTXOForfeitSigsToServer{
 			RoundID:    s.RoundID,
@@ -2617,7 +2710,7 @@ func (s *PartialSigsSentState) transitionToForfeitCollection(
 	}
 
 	outbox = append(outbox, &StartTimeoutReq{
-		RoundID:  s.RoundID,
+		RoundKey: RoundKeyStr(s.RoundID.KeyString()),
 		Phase:    TimeoutPhaseForfeitCollection,
 		Duration: env.ForfeitCollectionTimeout,
 	})
@@ -2648,6 +2741,29 @@ func (s *PartialSigsSentState) transitionToForfeitCollection(
 			Outbox: outbox,
 		}),
 	}, nil
+}
+
+// forfeitOutpoints returns the deduplicated VTXO outpoints carried by the given
+// forfeit requests, skipping any request without an outpoint. Used to release a
+// round's forfeit reservation when the round fails before signing.
+func forfeitOutpoints(requests []types.ForfeitRequest) []wire.OutPoint {
+	seen := make(map[wire.OutPoint]struct{}, len(requests))
+	outpoints := make([]wire.OutPoint, 0, len(requests))
+	for i := range requests {
+		if requests[i].VTXOOutpoint == nil {
+			continue
+		}
+
+		op := *requests[i].VTXOOutpoint
+		if _, ok := seen[op]; ok {
+			continue
+		}
+
+		seen[op] = struct{}{}
+		outpoints = append(outpoints, op)
+	}
+
+	return outpoints
 }
 
 // forfeitRequestMap indexes local forfeit requests by outpoint so custom local

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -29,6 +29,12 @@
 # value uses the daemon default.
 # forfeitcollectiontimeout=0s
 
+# Maximum duration to wait for the server's round-admission watermark after
+# sending a join request before failing the round and releasing any
+# forfeit-reserved inputs. The zero value uses the daemon default; a negative
+# value disables the timeout.
+# registrationtimeout=0s
+
 # Explicit opt-in for mainnet operation.
 # allow-mainnet=false
 

--- a/systest/leave_strand_test.go
+++ b/systest/leave_strand_test.go
@@ -1,0 +1,229 @@
+//go:build systest
+
+package systest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/darepod"
+	"github.com/stretchr/testify/require"
+)
+
+// leaveAdmissionTimeout is the short registration (admission) timeout used by
+// the leave-stranding systest so the recovery path is exercised in seconds
+// rather than the production default. It is kept comfortably larger than
+// parkedObserveWindow so the transient pending-forfeit / REGISTRATION_SENT
+// state is reliably observable before the timeout fires it away, even when the
+// suite runs several Dockerized daemons in parallel.
+const leaveAdmissionTimeout = 15 * time.Second
+
+// parkedObserveWindow bounds how long we poll for the transient stranded state
+// (pending-forfeit + temp REGISTRATION_SENT). It must stay below
+// leaveAdmissionTimeout so the observation does not race the recovery.
+const parkedObserveWindow = 8 * time.Second
+
+// leaveRecoveryWindow bounds how long we wait for the admission timeout to fire
+// and the VTXO to be released back to LIVE. It is generous on top of the
+// admission timeout to tolerate actor/Docker scheduling latency under parallel
+// systest load (the release path is several async actor hops).
+const leaveRecoveryWindow = leaveAdmissionTimeout + 60*time.Second
+
+// TestLeaveStrandedVTXORecoversOnAdmissionTimeout reproduces darepo-client#653
+// and proves the fix: a cooperative leave reserves the VTXO into
+// pending-forfeit and parks the round in a temp REGISTRATION_SENT state, but
+// the fake operator never returns a RoundJoined admission watermark. Without
+// the registration-timeout safety net the VTXO would be stranded in
+// pending-forfeit forever (balance permanently zero). With it, the admission
+// timeout fires, the round fails recoverably, and the VTXO is released back to
+// LIVE with the spendable balance restored.
+//
+// The fake mailbox server gives the client zero cooperation after the
+// JoinRoundRequest, so a VTXO that returns to LIVE proves the daemon recovers
+// entirely on its own, with no help from the server.
+func TestLeaveStrandedVTXORecoversOnAdmissionTimeout(t *testing.T) {
+	ParallelN(t)
+
+	// EagerRoundJoin makes the leave drive the round FSM into
+	// IntentSentState immediately (matching the wallet/SDK hosts where the
+	// issue was observed); the short admission timeout keeps the test fast.
+	fixture := newDirectedSendFixture(t, func(c *darepod.Config) {
+		c.EagerRoundJoin = true
+		c.RegistrationTimeout = leaveAdmissionTimeout
+	})
+
+	// The seeded VTXO starts LIVE and is the entire spendable balance.
+	startVTXOs := listAllVTXOs(t, fixture.client)
+	require.Len(t, startVTXOs, 1)
+	require.Equal(
+		t, daemonrpc.VTXOStatus_VTXO_STATUS_LIVE, startVTXOs[0].Status,
+	)
+	require.Equal(
+		t, testSeededAmountSat, vtxoBalanceSat(t, fixture.client),
+	)
+
+	destAddr := newRegtestTaprootAddr(t)
+
+	// Issue the cooperative leave. The reservation into pending-forfeit is
+	// synchronous, so by the time this returns the VTXO is already
+	// reserved.
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	leaveResp, err := fixture.client.LeaveVTXOs(
+		ctx, &daemonrpc.LeaveVTXOsRequest{
+			Selection: &daemonrpc.LeaveVTXOsRequest_Outpoints{
+				Outpoints: &daemonrpc.OutpointSelection{
+					Outpoints: []string{
+						outpointString(
+							fixture.seededOutpoint,
+						),
+					},
+				},
+			},
+			DefaultDestination: &daemonrpc.LeaveDestination{
+				Target: &daemonrpc.LeaveDestination_Address{
+					Address: destAddr,
+				},
+			},
+		},
+	)
+	require.NoError(t, err, "LeaveVTXOs RPC failed")
+	require.Equal(t, "queued", leaveResp.Status)
+	require.Contains(
+		t, leaveResp.QueuedOutpoints,
+		outpointString(fixture.seededOutpoint),
+	)
+
+	// The stranded condition from the issue: the VTXO is reserved into
+	// pending-forfeit while the round parks in a temp REGISTRATION_SENT
+	// state with no round id. Both hold synchronously once LeaveVTXOs
+	// returns, so we capture them together well inside the admission
+	// window (the combined poll avoids racing the timeout that later
+	// clears the REGISTRATION_SENT round).
+	require.Eventuallyf(
+		t,
+		func() bool {
+			v := findVTXOByOutpoint(
+				listAllVTXOs(t, fixture.client),
+				fixture.seededOutpoint,
+			)
+			pendingForfeit := v != nil && v.Status ==
+				daemonrpc.VTXOStatus_VTXO_STATUS_PENDING_FORFEIT
+
+			return pendingForfeit &&
+				hasTempRegistrationSentRound(t, fixture.client)
+		},
+		parkedObserveWindow, 100*time.Millisecond,
+		"leave did not park the VTXO in pending-forfeit with a temp "+
+			"REGISTRATION_SENT round",
+	)
+
+	// The fix: the admission timeout fires, the round fails recoverably,
+	// and the VTXO is released back to LIVE rather than stranded. On the
+	// unfixed daemon this never happens and the assertion times out.
+	requireVTXOStatusEventually(
+		t, fixture.client, fixture.seededOutpoint,
+		daemonrpc.VTXOStatus_VTXO_STATUS_LIVE, leaveRecoveryWindow,
+	)
+
+	// The spendable balance is restored to its starting value.
+	require.Eventually(
+		t,
+		func() bool {
+			return vtxoBalanceSat(t, fixture.client) ==
+				testSeededAmountSat
+		},
+		20*time.Second, 100*time.Millisecond,
+		"vtxo balance not restored after leave recovery",
+	)
+}
+
+// vtxoBalanceSat returns the daemon's current off-chain (VTXO) balance.
+func vtxoBalanceSat(t *testing.T, client daemonrpc.DaemonServiceClient) int64 {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.GetBalance(ctx, &daemonrpc.GetBalanceRequest{})
+	require.NoError(t, err)
+
+	return resp.GetVtxoBalanceSat()
+}
+
+// requireVTXOStatusEventually polls until the VTXO at the given outpoint
+// reaches the expected status, failing the test if it does not within the
+// timeout.
+func requireVTXOStatusEventually(t *testing.T,
+	client daemonrpc.DaemonServiceClient, outpoint wire.OutPoint,
+	want daemonrpc.VTXOStatus, timeout time.Duration) {
+
+	t.Helper()
+
+	require.Eventuallyf(
+		t,
+		func() bool {
+			v := findVTXOByOutpoint(
+				listAllVTXOs(t, client), outpoint,
+			)
+
+			return v != nil && v.Status == want
+		},
+		timeout, 100*time.Millisecond,
+		"VTXO %s did not reach status %s within %s",
+		outpoint, want, timeout,
+	)
+}
+
+// hasTempRegistrationSentRound reports whether the daemon currently tracks a
+// temp-keyed round in REGISTRATION_SENT — the parked state a leave reaches
+// once its JoinRoundRequest is sent but unacknowledged.
+func hasTempRegistrationSentRound(t *testing.T,
+	client daemonrpc.DaemonServiceClient) bool {
+
+	t.Helper()
+
+	for _, r := range listRounds(t, client) {
+		if r.IsTemp && r.State ==
+			daemonrpc.RoundState_ROUND_STATE_REGISTRATION_SENT {
+			return true
+		}
+	}
+
+	return false
+}
+
+// outpointString renders an outpoint in the "txid:index" form the daemon RPC
+// uses for VTXO selection and reporting.
+func outpointString(op wire.OutPoint) string {
+	return fmt.Sprintf("%s:%d", op.Hash, op.Index)
+}
+
+// newRegtestTaprootAddr derives a fresh regtest P2TR address for use as a leave
+// destination. The round never completes in this test, so the address only
+// needs to be a valid on-chain destination the client can encode.
+func newRegtestTaprootAddr(t *testing.T) string {
+	t.Helper()
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	taprootKey := txscript.ComputeTaprootKeyNoScript(priv.PubKey())
+	addr, err := btcutil.NewAddressTaproot(
+		schnorr.SerializePubKey(taprootKey),
+		&chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	return addr.String()
+}

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -372,8 +372,12 @@ type directedSendFixture struct {
 
 // newDirectedSendFixture starts a full darepod instance against the systest
 // LND backend and a fake mailbox edge, then waits for the daemon RPC to become
-// ready.
-func newDirectedSendFixture(t *testing.T) *directedSendFixture {
+// ready. Optional cfgMutators are applied to the daemon Config after the base
+// setup (and before the DB is seeded / the server starts) so callers can tune
+// timeouts and feature flags for their scenario.
+func newDirectedSendFixture(t *testing.T,
+	cfgMutators ...func(*darepod.Config)) *directedSendFixture {
+
 	t.Helper()
 
 	h := NewSysTestHarness(t)
@@ -424,6 +428,10 @@ func newDirectedSendFixture(t *testing.T) *directedSendFixture {
 	cfg.Server.Host = mailboxAddr
 	cfg.Server.Insecure = true
 	cfg.RPC.ListenAddr = rpcAddr
+
+	for _, mutate := range cfgMutators {
+		mutate(cfg)
+	}
 
 	seededOutpoint := seedLiveVTXO(
 		t, cfg, operatorPriv.PubKey(),


### PR DESCRIPTION
Fixes #653

## The problem

A cooperative leave / unboard strands the VTXO in `VTXO_STATUS_PENDING_FORFEIT` with a zero wallet balance and no recovery path.

A leave happens in two client-side steps:

1. **Reserve** — the VTXO is moved into `PENDING_FORFEIT` (committed to being handed over, not spendable elsewhere) *before* registration.
2. **Register** — the client sends a `JoinRoundRequest` and parks in `IntentSentState`, waiting for the server's `RoundJoined` admission watermark.

There was **no timeout on step 2**. If the server never answers the `JoinRoundRequest` (it sealed the round without this client, dropped the request, flaky link, etc.), the round FSM waits forever. The result is exactly what was reported on signet in #653:

- the VTXO is stuck in `PENDING_FORFEIT` indefinitely,
- the round shows a temporary `ROUND_STATE_REGISTRATION_SENT` with no round id and no commitment tx,
- the wallet balance reads zero, and
- there is no automatic recovery and no retry path.

The funds aren't lost (the VTXO still exists), but they're frozen and invisible — a P0 fund-safety bug.

## The fix

Add a **registration (admission) timeout** to the client round FSM:

- Arm a timer when entering `IntentSentState`; **cancel it** as soon as `RoundJoined` (admission) arrives, so healthy rounds are completely unaffected.
- If the timer fires (server never acknowledged), the FSM:
  1. fails the round as **recoverable** (the user can simply retry), and
  2. emits `ReleaseForfeitReservation`, which the round actor forwards to the VTXO manager to move the VTXO from `PENDING_FORFEIT` back to `LiveState`, restoring the balance.

Releasing is safe at this phase because no forfeit signatures have been produced yet — there is no half-finished transaction that could double-spend. The timeout is intentionally scoped to the *pre-admission* window only; once admitted, the longer seal-time wait governs, so a healthy round is never torn down mid-flight.

The scope of the change is **entirely client-side** — the `JoinRoundRequest` sent to the operator is byte-identical, so there is no protocol or server change.

### Supporting changes

- Timeouts can now target a round that has no server-assigned `RoundID` yet (still temp-keyed), so timeout outbox messages key on the round's map key (`RoundKeyStr`) and the composite timeout ID splits the phase off the final `:`.
- `RegistrationTimeout` is configurable via `RoundClientConfig` and the `darepod` config (`registrationtimeout`), with a **60s default** (zero selects the default; a negative value disables the timeout).

## Testing

Verified red→green at two levels:

- **FSM unit tests** (`round/registration_timeout_test.go`): the timeout transitions the round to a recoverable `ClientFailedState` and emits the release for exactly the reserved inputs; `RoundJoined` cancels the timer. Confirmed the bug reproduces (FSM stays stuck) without the handler.
- **System test** (`systest/leave_strand_test.go`): drives the real daemon through a leave against a fake operator that never returns `RoundJoined`, and asserts the VTXO recovers from `PENDING_FORFEIT` back to `LIVE` with balance restored. With the timeout disabled, the same test shows the VTXO stays stranded — i.e. it reproduces #653.

Existing round/darepod tests and the existing `TestSendVTXOEndToEnd` systest still pass; the happy-path leave is unaffected.

## Known follow-up (UX, not fund-safety)

This restores the funds and balance, but does not yet mark the pending `EXIT` **activity row** failed directly from the round failure. Today that row self-fails within ≤30 min via the existing `swapwallet` deadline overlay (reason `timed_out`). Making it immediate (with the precise reason) requires teaching `swapwallet` to observe round outcomes and is tracked as a separate, also client-side follow-up.