### PR TITLE
actor: add durable Read/Commit execution path (+ ledger)

### DIFF
--- a/baselib/actor/durable_actor.go
+++ b/baselib/actor/durable_actor.go
@@ -43,9 +43,22 @@ type DurableActorConfig[M TLVMessage, R any] struct {
 	// When unset, the runtime falls back to btclog.Disabled.
 	Log fn.Option[btclog.Logger]
 
-	// Behavior defines how the actor responds to messages.
-	// The runtime handles ack/nack automatically based on the result.
-	Behavior ActorBehavior[M, R]
+	// Behavior defines how the actor responds to messages. It is one of two
+	// shapes:
+	//
+	//   - Left: a classic ActorBehavior. The runtime wraps the whole
+	//     Receive in one transaction (processInTransaction) when the store
+	//     is tx-aware, else runs the short-slice path. This is the safe
+	//     default.
+	//
+	//   - Right: a BoundTxBehavior built via NewTxBehavior. The runtime
+	//     drives the behavior through the Read/Commit execution path
+	//     (processWithExec) so it can do side-effect IO outside the writer
+	//     transaction. This requires a TxAwareDeliveryStore.
+	//
+	// DefaultDurableActorConfig populates the Left case from its behavior
+	// argument; tx-aware actors overwrite this field with fn.NewRight.
+	Behavior fn.Either[ActorBehavior[M, R], BoundTxBehavior[M, R]]
 
 	// Store is the persistence layer for mailbox operations. If the store
 	// implements TxAwareDeliveryStore, message processing will be wrapped
@@ -99,6 +112,30 @@ type DurableActorConfig[M TLVMessage, R any] struct {
 	DeduplicationTTL time.Duration
 }
 
+// NewClassicBehavior wraps a classic ActorBehavior as the Left case of the
+// DurableActorConfig.Behavior either. DefaultDurableActorConfig applies it for
+// you; use it directly only when assigning Behavior on a hand-built config.
+func NewClassicBehavior[M TLVMessage, R any](
+	behavior ActorBehavior[M, R],
+) fn.Either[ActorBehavior[M, R], BoundTxBehavior[M, R]] {
+
+	return fn.NewLeft[ActorBehavior[M, R], BoundTxBehavior[M, R]](behavior)
+}
+
+// NewTxBehaviorEither binds a TxBehavior and its StoreFactory and wraps the
+// result as the Right case of the DurableActorConfig.Behavior either.
+// DefaultDurableTxActorConfig applies it for you; use it directly only when
+// assigning Behavior on a hand-built config.
+func NewTxBehaviorEither[M TLVMessage, R any, S any](
+	behavior TxBehavior[M, R, S],
+	factory StoreFactory[S],
+) fn.Either[ActorBehavior[M, R], BoundTxBehavior[M, R]] {
+
+	return fn.NewRight[ActorBehavior[M, R]](
+		NewTxBehavior(behavior, factory),
+	)
+}
+
 // DefaultDurableActorConfig returns a config with sensible defaults.
 func DefaultDurableActorConfig[M TLVMessage, R any](
 	id string,
@@ -112,7 +149,7 @@ func DefaultDurableActorConfig[M TLVMessage, R any](
 	return DurableActorConfig[M, R]{
 		ID:                id,
 		Log:               fn.None[btclog.Logger](),
-		Behavior:          behavior,
+		Behavior:          NewClassicBehavior(behavior),
 		Store:             store,
 		Codec:             codec,
 		TellRetryPolicy:   DefaultTellRetryPolicy,
@@ -123,6 +160,26 @@ func DefaultDurableActorConfig[M TLVMessage, R any](
 		CleanupTimeout:    5 * time.Second,
 		DeduplicationTTL:  24 * time.Hour,
 	}
+}
+
+// DefaultDurableTxActorConfig returns a config wired for the Read/Commit
+// execution path. It is the tx-aware counterpart to DefaultDurableActorConfig:
+// rather than taking a classic ActorBehavior, it takes a TxBehavior and its
+// StoreFactory and binds them into the config's Right case, hiding the
+// NewTxBehavior / fn.NewRight boilerplate from callers. The store must be a
+// TxAwareDeliveryStore (enforced by NewDurableActor).
+func DefaultDurableTxActorConfig[M TLVMessage, R any, S any](
+	id string,
+	behavior TxBehavior[M, R, S],
+	factory StoreFactory[S],
+	store DeliveryStore,
+	codec *MessageCodec,
+) DurableActorConfig[M, R] {
+
+	cfg := DefaultDurableActorConfig[M, R](id, nil, store, codec)
+	cfg.Behavior = NewTxBehaviorEither[M, R, S](behavior, factory)
+
+	return cfg
 }
 
 // DurableActor is an actor implementation that provides crash-resilient message
@@ -144,8 +201,11 @@ type DurableActor[M TLVMessage, R any] struct {
 	// id is the unique identifier for the actor.
 	id string
 
-	// behavior defines how the actor responds to messages.
-	behavior ActorBehavior[M, R]
+	// behavior selects how the actor processes messages. The Left case is a
+	// classic ActorBehavior the runtime wraps in a transaction; the Right
+	// case is a BoundTxBehavior driven through the Read/Commit execution
+	// path. It mirrors DurableActorConfig.Behavior directly.
+	behavior fn.Either[ActorBehavior[M, R], BoundTxBehavior[M, R]]
 
 	// mailbox is the durable incoming message queue.
 	mailbox *DurableMailbox[M, R]
@@ -200,10 +260,37 @@ type DurableActor[M TLVMessage, R any] struct {
 	ref ActorRef[M, R]
 }
 
-// NewDurableActor creates a new durable actor instance.
+// ErrTxBehaviorNeedsTxStore indicates that a config requested the Read/Commit
+// execution path (a Right BoundTxBehavior) without a TxAwareDeliveryStore,
+// which that path requires to open its short transactions.
+var ErrTxBehaviorNeedsTxStore = fmt.Errorf("durable actor: TxBehavior " +
+	"requires a TxAwareDeliveryStore")
+
+// ErrNoBehavior indicates that a config carries no usable behavior: either a
+// nil classic ActorBehavior (the fn.Either zero value is a Left holding nil, so
+// a forgotten Behavior field lands here) or a zero-value BoundTxBehavior whose
+// run hook was never bound (e.g. fn.NewRight(BoundTxBehavior{}) instead of
+// NewTxBehavior/DefaultDurableTxActorConfig). Surfacing it at construction
+// keeps the misconfiguration from panicking at first dispatch.
+var ErrNoBehavior = fmt.Errorf("durable actor: a behavior must be set (use " +
+	"DefaultDurableActorConfig or DefaultDurableTxActorConfig)")
+
+// ErrDurableAskUnsupported indicates that a DurableAsk was delivered to an
+// actor running on the Read/Commit (TxBehavior) execution path. On that path
+// the message is acked inside the behavior's own Commit, so the framework
+// cannot fold the crash-safe callback response into the consuming transaction
+// (it does not have the behavior's result at Commit time). The request is
+// rejected with this error delivered to the caller as the response. Full
+// DurableAsk support is planned alongside the OOR effect-actor adopter.
+var ErrDurableAskUnsupported = fmt.Errorf("durable actor: DurableAsk is not " +
+	"supported on the Read/Commit execution path")
+
+// NewDurableActor creates a new durable actor instance. It returns an error
+// result when the configuration is invalid -- currently when a TxBehavior is
+// paired with a store that is not transaction-aware.
 func NewDurableActor[M TLVMessage, R any](
 	cfg DurableActorConfig[M, R],
-) *DurableActor[M, R] {
+) fn.Result[*DurableActor[M, R]] {
 
 	baseCtx := build.ContextWithLogger(
 		context.Background(), cfg.Log.UnwrapOr(btclog.Disabled),
@@ -236,6 +323,35 @@ func NewDurableActor[M TLVMessage, R any](
 		txAwareStore = txStore
 	}
 
+	// Validate the configured behavior up front so a misconfigured actor
+	// fails closed at construction rather than panicking at first dispatch.
+	// The fn.Either zero value is a Left holding a nil ActorBehavior, so a
+	// forgotten Behavior field is caught here too.
+	if cfg.Behavior.IsRight() {
+		txb := cfg.Behavior.RightToSome().UnsafeFromSome()
+		switch {
+		// A zero-value BoundTxBehavior has no run hook and would panic
+		// at dispatch.
+		case !txb.isSet():
+			cancel()
+
+			return fn.Err[*DurableActor[M, R]](ErrNoBehavior)
+
+		// The Read/Commit execution path opens its own short
+		// transactions, so it requires a transaction-aware store.
+		case txAwareStore == nil:
+			cancel()
+
+			return fn.Err[*DurableActor[M, R]](
+				ErrTxBehaviorNeedsTxStore,
+			)
+		}
+	} else if cfg.Behavior.LeftToSome().UnwrapOr(nil) == nil {
+		cancel()
+
+		return fn.Err[*DurableActor[M, R]](ErrNoBehavior)
+	}
+
 	actor := &DurableActor[M, R]{
 		id:                cfg.ID,
 		behavior:          cfg.Behavior,
@@ -259,7 +375,7 @@ func NewDurableActor[M TLVMessage, R any](
 		actor: actor,
 	}
 
-	return actor
+	return fn.Ok(actor)
 }
 
 // Start initiates the actor's message processing loop.
@@ -313,8 +429,15 @@ func (a *DurableActor[M, R]) process() {
 	// For durable mailboxes, we don't drain to DLO since messages persist
 	// in the database and will be picked up on restart.
 
-	// If the behavior implements Stoppable, call OnStop.
-	if stoppable, ok := a.behavior.(Stoppable); ok {
+	// If a classic behavior implements Stoppable, call OnStop. The
+	// Read/Commit (Right) path has no Stoppable hook of its own; its owner
+	// manages cleanup.
+	a.behavior.WhenLeft(func(b ActorBehavior[M, R]) {
+		stoppable, ok := b.(Stoppable)
+		if !ok {
+			return
+		}
+
 		cleanupCtx, cancel := context.WithTimeout(
 			context.Background(), a.cleanupTimeout,
 		)
@@ -324,7 +447,7 @@ func (a *DurableActor[M, R]) process() {
 			logger(a.ctx).WarnS(a.ctx, "Durable actor cleanup error",
 				err, "actor_id", a.id)
 		}
-	}
+	})
 
 	logger(a.ctx).DebugS(a.ctx, "Durable actor terminated",
 		"actor_id", a.id,
@@ -396,6 +519,18 @@ func (a *DurableActor[M, R]) processDelivery(delivery *Delivery[M, R]) {
 				ErrLeaseExpired,
 				"delivery_id", delivery.ID)
 		}
+
+		return
+	}
+
+	// If the actor opted into the Read/Commit execution path (a Right
+	// behavior), drive it through the Exec handle. Construction guarantees
+	// a tx-aware store is present in this case.
+	if a.behavior.IsRight() {
+		a.processWithExec(
+			processCtx, delivery,
+			a.behavior.RightToSome().UnsafeFromSome(),
+		)
 
 		return
 	}
@@ -483,6 +618,18 @@ func (a *DurableActor[M, R]) processWithoutTransaction(ctx context.Context,
 	// Execute behavior with panic recovery.
 	result := a.executeBehaviorSafely(ctx, delivery)
 
+	// Hand the result to the shared non-transactional ack/nack bookkeeping.
+	a.finishNonTx(ctx, delivery, result)
+}
+
+// finishNonTx applies ack/nack/dead-letter bookkeeping for a result that was
+// produced outside a framework transaction (the processWithoutTransaction path
+// and the uncommitted tail of processWithExec). It runs the durable writes
+// under a detached, bounded context so they finish even if Stop cancels the
+// actor context mid-commit.
+func (a *DurableActor[M, R]) finishNonTx(ctx context.Context,
+	delivery *Delivery[M, R], result fn.Result[R]) {
+
 	// The message result is now known. Durable bookkeeping must be allowed
 	// to finish even if Stop cancels the actor context while ack/processed
 	// markers are being committed. In particular, SQLite's driver can race
@@ -552,6 +699,167 @@ func (a *DurableActor[M, R]) processWithoutTransaction(ctx context.Context,
 	a.handleResult(bookkeepingCtx, delivery, result)
 }
 
+// processWithExec drives a TxBehavior through its Read/Commit execution path.
+// The behavior does any slow side-effect IO without holding the writer, then
+// commits state plus the lease-fenced ack in one short transaction. A lease
+// heartbeat runs for the duration so a long IO middle does not let the lease
+// expire underneath an in-progress Commit.
+func (a *DurableActor[M, R]) processWithExec(ctx context.Context,
+	delivery *Delivery[M, R], tb BoundTxBehavior[M, R]) {
+
+	// The Read/Commit execution path does not yet support DurableAsk. On
+	// this path the message is acked inside the behavior's own Commit, so
+	// the framework cannot fold the crash-safe callback response into the
+	// consuming transaction (the behavior owns the tx and its result is not
+	// known until after Commit). Rather than silently consume the request
+	// and leave the caller hanging, reject it with an explicit error
+	// response. Full support is planned with the OOR effect-actor adopter.
+	if delivery.IsDurableAsk() {
+		a.rejectDurableAskOnExecPath(ctx, delivery)
+
+		return
+	}
+
+	// Extend the lease while the behavior does IO outside the writer tx.
+	heartbeatDone := make(chan struct{})
+	var stopHeartbeat sync.Once
+	stop := func() {
+		stopHeartbeat.Do(func() { close(heartbeatDone) })
+	}
+	go a.heartbeat(ctx, delivery, heartbeatDone)
+	defer stop()
+
+	core := &execCore{
+		store:      a.txAwareStore,
+		msgID:      delivery.ID,
+		leaseToken: delivery.LeaseToken,
+		actorID:    a.id,
+		dedupTTL:   a.deduplicationTTL,
+	}
+
+	result := a.runExecSafely(ctx, delivery, tb, core)
+
+	// Stop the heartbeat as soon as the behavior returns. On the committed
+	// path the message is already acked and deleted inside Commit, so a
+	// late heartbeat tick would try to extend a gone lease and log a
+	// spurious "Failed to extend lease" warning.
+	stop()
+
+	// If the behavior committed, the state write, dedup mark, and
+	// lease-fenced ack are already durable in a single transaction. Only
+	// the in-memory promise for an Ask caller remains.
+	if core.committed {
+		if delivery.IsAsk() && delivery.Promise != nil {
+			delivery.Promise.Complete(result)
+		}
+
+		return
+	}
+
+	// The behavior returned without committing: it either failed before
+	// Commit (e.g. the side-effect IO errored, so we nack for retry) or it
+	// intentionally consumed the message without persisting state (e.g. a
+	// RestartMessage). Either way, fall back to the framework's standard
+	// non-transactional ack/nack handling.
+	a.finishNonTx(ctx, delivery, result)
+}
+
+// rejectDurableAskOnExecPath fails a DurableAsk delivered to a Read/Commit
+// (TxBehavior) actor. It writes an error AskResponse to the outbox so the
+// caller receives a definitive failure instead of hanging, then consumes the
+// message under the lease fence -- the error response, dedup mark, and ack all
+// commit in one transaction. On any failure it nacks so the request is retried
+// (and re-rejected) rather than lost. See ErrDurableAskUnsupported.
+func (a *DurableActor[M, R]) rejectDurableAskOnExecPath(ctx context.Context,
+	delivery *Delivery[M, R]) {
+
+	// Use a detached, bounded context so the rejection bookkeeping finishes
+	// even if Stop cancels the actor context mid-commit.
+	bookkeepingCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx), a.cleanupTimeout,
+	)
+	defer cancel()
+
+	errResult := fn.Err[R](ErrDurableAskUnsupported)
+
+	err := a.txAwareStore.ExecTx(bookkeepingCtx, false, func(
+		txCtx context.Context, store DeliveryStore) error {
+
+		if err := a.writeAskResponseToOutbox(
+			txCtx, delivery, errResult, store,
+		); err != nil {
+			return err
+		}
+
+		if err := store.MarkProcessed(
+			txCtx, delivery.ID, a.id, a.deduplicationTTL,
+		); err != nil {
+			return err
+		}
+
+		rows, err := store.AckMessage(
+			txCtx, delivery.ID, delivery.LeaseToken,
+		)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return ErrLeaseLost
+		}
+
+		return nil
+	})
+	if err == nil {
+		logger(ctx).WarnS(ctx, "Rejected DurableAsk on Read/Commit "+
+			"path with error response",
+			ErrDurableAskUnsupported,
+			"actor_id", a.id,
+			"delivery_id", delivery.ID)
+
+		return
+	}
+
+	logger(ctx).WarnS(ctx, "Failed to reject DurableAsk on Read/Commit "+
+		"path, nacking for retry",
+		err,
+		"actor_id", a.id,
+		"delivery_id", delivery.ID)
+
+	if nackErr := delivery.Nack(
+		bookkeepingCtx, err, 10*time.Second,
+	); nackErr != nil {
+
+		logger(ctx).WarnS(ctx, "Failed to nack after DurableAsk "+
+			"reject failure",
+			nackErr,
+			"actor_id", a.id,
+			"delivery_id", delivery.ID)
+	}
+}
+
+// runExecSafely runs a TxBehavior with panic recovery, converting a panic into
+// an error result so the caller treats it as a non-committed failure.
+func (a *DurableActor[M, R]) runExecSafely(ctx context.Context,
+	delivery *Delivery[M, R], tb BoundTxBehavior[M, R], core *execCore) (
+	result fn.Result[R]) {
+
+	defer func() {
+		if r := recover(); r != nil {
+			err := fmt.Errorf("panic: %v", r)
+
+			logger(ctx).ErrorS(ctx, "Panic during tx message "+
+				"processing",
+				err,
+				"actor_id", a.id,
+				"delivery_id", delivery.ID)
+
+			result = fn.Err[R](err)
+		}
+	}()
+
+	return tb.run(ctx, core, delivery.Message)
+}
+
 // executeBehaviorSafely runs the behavior with panic recovery.
 func (a *DurableActor[M, R]) executeBehaviorSafely(ctx context.Context,
 	delivery *Delivery[M, R]) (result fn.Result[R]) {
@@ -570,7 +878,11 @@ func (a *DurableActor[M, R]) executeBehaviorSafely(ctx context.Context,
 		}
 	}()
 
-	return a.behavior.Receive(ctx, delivery.Message)
+	// This path only runs for a classic (Left) behavior; the Right path is
+	// handled by processWithExec.
+	classic := a.behavior.LeftToSome().UnwrapOr(nil)
+
+	return classic.Receive(ctx, delivery.Message)
 }
 
 // handleResultInTx handles the result within a transaction.

--- a/baselib/actor/durable_actor_test.go
+++ b/baselib/actor/durable_actor_test.go
@@ -236,7 +236,7 @@ func TestDurableActorCreation(t *testing.T) {
 	behavior := newMockBehavior(fn.Ok(42))
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	require.NotNil(t, actor)
 	require.Equal(t, "test-actor", actor.id)
@@ -255,7 +255,7 @@ func TestDurableActorStartStop(t *testing.T) {
 	behavior := newMockBehavior(fn.Ok(42))
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	// Start should be idempotent.
 	actor.Start()
@@ -282,7 +282,7 @@ func TestDurableActorTellProcessing(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.PollInterval = 10 * time.Millisecond
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	defer actor.Stop()
@@ -328,7 +328,7 @@ func TestDurableActorTellIgnoresCallerContextAfterEnqueue(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.PollInterval = 10 * time.Millisecond
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	msg := &actorTestMsg{
 		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(42)),
@@ -373,7 +373,7 @@ func TestDurableActorAskRespectsCallerContextAfterEnqueue(t *testing.T) {
 	}
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	askCtx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -421,7 +421,7 @@ func TestDurableActorAskProcessing(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.PollInterval = 10 * time.Millisecond
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	defer actor.Stop()
@@ -456,7 +456,7 @@ func TestDurableActorAskWithError(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.PollInterval = 10 * time.Millisecond
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	defer actor.Stop()
@@ -488,7 +488,7 @@ func TestDurableActorDeduplication(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.PollInterval = 10 * time.Millisecond
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	defer actor.Stop()
@@ -560,7 +560,7 @@ func TestDurableActorPanicRecovery(t *testing.T) {
 		return false, 0
 	}
 
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	defer actor.Stop()
@@ -607,7 +607,7 @@ func TestDurableActorTellRetryPolicy(t *testing.T) {
 		return true, 10 * time.Millisecond
 	}
 
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	defer actor.Stop()
@@ -645,7 +645,7 @@ func TestDurableActorTransactionWrapping(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.PollInterval = 10 * time.Millisecond
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	defer actor.Stop()
@@ -678,7 +678,7 @@ func TestDurableActorTransactionFailure(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.PollInterval = 10 * time.Millisecond
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	msg := &actorTestMsg{
 		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(42)),
@@ -742,7 +742,7 @@ func TestDurableActorStoppableBehavior(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.CleanupTimeout = 1 * time.Second
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	time.Sleep(10 * time.Millisecond)
@@ -763,7 +763,7 @@ func TestDurableActorRef(t *testing.T) {
 	behavior := newMockBehavior(fn.Ok(42))
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	ref := actor.Ref()
 	require.NotNil(t, ref)
@@ -783,7 +783,7 @@ func TestDurableActorTellToTerminatedActor(t *testing.T) {
 	behavior := newMockBehavior(fn.Ok(42))
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	actor.Stop()
@@ -812,7 +812,7 @@ func TestDurableActorTellPreservesMailboxError(t *testing.T) {
 	behavior := newMockBehavior(fn.Ok(42))
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	// Leave the actor stopped so Tell exercises only durable enqueue error
 	// propagation, not mailbox receive-loop processing.
@@ -839,7 +839,7 @@ func TestDurableActorAskToTerminatedActor(t *testing.T) {
 	behavior := newMockBehavior(fn.Ok(42))
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	actor.Stop()
@@ -871,7 +871,7 @@ func TestDurableActorWithWaitGroup(t *testing.T) {
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.Wg = &wg
 
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	actor.Stop()
@@ -978,7 +978,7 @@ func TestDurableActorRapid_DeduplicationIdempotent(t *testing.T) {
 			"test-actor", behavior, store, codec,
 		)
 		cfg.PollInterval = 1 * time.Millisecond
-		actor := NewDurableActor(cfg)
+		actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 		actor.Start()
 		defer actor.Stop()
@@ -990,23 +990,37 @@ func TestDurableActorRapid_DeduplicationIdempotent(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		err := actor.Ref().Tell(ctx, msg)
+		require.NoError(rt, actor.Ref().Tell(ctx, msg))
+
+		// Wait until the message is FULLY processed before reading the
+		// processed ID: the behavior ran (callCount==1), the dedup mark
+		// is recorded, and the original mailbox row is acked. Waiting
+		// on all three closes the race where the dedup mark is not yet
+		// written when we grab the ID -- reading too early yields an
+		// empty ID, re-enqueues a different message, and spuriously
+		// processes it twice (the source of the prior rapid flakiness).
+		var processedID string
+		require.Eventually(rt, func() bool {
+			store.mu.Lock()
+			defer store.mu.Unlock()
+
+			if callCount.Load() != 1 || len(store.processed) != 1 ||
+				len(store.messages) != 0 {
+				return false
+			}
+
+			for id := range store.processed {
+				processedID = id
+			}
+
+			return true
+		}, time.Second, 5*time.Millisecond)
+
+		// Re-enqueue a message reusing the already-processed ID.
+		payload, err := codec.Encode(msg)
 		require.NoError(rt, err)
 
-		// Wait for first processing.
-		require.Eventually(rt, func() bool {
-			return callCount.Load() == 1
-		}, 500*time.Millisecond, 5*time.Millisecond)
-
-		// Get processed ID.
 		store.mu.Lock()
-		var processedID string
-		for id := range store.processed {
-			processedID = id
-			break
-		}
-		payload, _ := codec.Encode(msg)
-		// Re-enqueue same ID.
 		store.messages[processedID] = &LeasedMessage{
 			ID:          processedID,
 			MailboxID:   "test-actor",
@@ -1024,12 +1038,11 @@ func TestDurableActorRapid_DeduplicationIdempotent(t *testing.T) {
 		default:
 		}
 
-		// Wait and verify still only 1 call.
-		time.Sleep(50 * time.Millisecond)
-		require.Equal(
-			rt, int32(1), callCount.Load(),
-			"duplicate message should be skipped",
-		)
+		// The duplicate must never be processed: dedup keeps callCount
+		// pinned at 1 across the whole window.
+		require.Never(rt, func() bool {
+			return callCount.Load() != 1
+		}, 200*time.Millisecond, 5*time.Millisecond)
 	})
 }
 
@@ -1047,7 +1060,7 @@ func TestDurableActorRapid_AckAfterSuccess(t *testing.T) {
 			"test-actor", behavior, store, codec,
 		)
 		cfg.PollInterval = 1 * time.Millisecond
-		actor := NewDurableActor(cfg)
+		actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 		actor.Start()
 		defer actor.Stop()
@@ -1110,7 +1123,7 @@ func TestDurableActorRapid_NackAfterFailure(t *testing.T) {
 			return true, 1 * time.Millisecond
 		}
 
-		actor := NewDurableActor(cfg)
+		actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 		actor.Start()
 		defer actor.Stop()
@@ -1164,7 +1177,7 @@ func TestDurableActorRapid_ConcurrentTellSafe(t *testing.T) {
 			"test-actor", behavior, store, codec,
 		)
 		cfg.PollInterval = 1 * time.Millisecond
-		actor := NewDurableActor(cfg)
+		actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 		actor.Start()
 		defer actor.Stop()
@@ -1214,7 +1227,7 @@ func TestDurableAskValidation(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.PollInterval = 10 * time.Millisecond
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	defer actor.Stop()
@@ -1283,7 +1296,7 @@ func TestDurableAskToStoppedActor(t *testing.T) {
 	behavior := newMockBehavior(fn.Ok(42))
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	actor.Stop()
@@ -1322,7 +1335,7 @@ func TestDurableActorWithTxAwareStore(t *testing.T) {
 			"test-actor", behavior, store, codec,
 		)
 		cfg.PollInterval = 10 * time.Millisecond
-		actor := NewDurableActor(cfg)
+		actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 		actor.Start()
 		defer actor.Stop()
@@ -1357,7 +1370,7 @@ func TestDurableActorWithTxAwareStore(t *testing.T) {
 			"test-actor", behavior, store, codec,
 		)
 		cfg.PollInterval = 10 * time.Millisecond
-		actor := NewDurableActor(cfg)
+		actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 		actor.Start()
 		defer actor.Stop()
@@ -1396,7 +1409,7 @@ func TestDurableActorWithTxAwareStore(t *testing.T) {
 			"test-actor", behavior, store, codec,
 		)
 		cfg.PollInterval = 10 * time.Millisecond
-		actor := NewDurableActor(cfg)
+		actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 		actor.Start()
 		defer actor.Stop()
@@ -1471,7 +1484,7 @@ func TestDurableAskNacksOnOutboxWriteFailure(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.PollInterval = 10 * time.Millisecond
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 
@@ -1629,7 +1642,7 @@ func TestPromiseCompletionDeferredInTxPath(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.PollInterval = 10 * time.Millisecond
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	defer actor.Stop()
@@ -1667,7 +1680,7 @@ func TestPromiseNotCompletedOnTxFailure(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.PollInterval = 10 * time.Millisecond
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	defer actor.Stop()
@@ -1854,7 +1867,7 @@ func TestDurableAskWithExpiredContext(t *testing.T) {
 	behavior.setDelay(5 * time.Second)
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	defer actor.Stop()
@@ -1939,7 +1952,7 @@ func TestTxPathDeferPromisePropagatedToTxDelivery(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.PollInterval = 10 * time.Millisecond
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	defer actor.Stop()
@@ -1995,7 +2008,7 @@ func TestTxDurableAskDoesNotRetryAfterOutboxWrite(t *testing.T) {
 
 	cfg := DefaultDurableActorConfig("test-actor", behavior, store, codec)
 	cfg.PollInterval = 10 * time.Millisecond
-	actor := NewDurableActor(cfg)
+	actor := NewDurableActor(cfg).UnwrapOrFail(t)
 
 	actor.Start()
 	defer actor.Stop()

--- a/baselib/actor/tx_exec.go
+++ b/baselib/actor/tx_exec.go
@@ -1,0 +1,248 @@
+package actor
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// ErrLeaseLost indicates that a fenced Commit aborted because the message's
+// lease was no longer held by this consumer. This happens when the behavior
+// stalled past its lease (e.g. a slow side-effect IO) and the message was
+// reclaimed and reprocessed elsewhere. The Commit transaction rolls back and
+// applies nothing; any duplicate effect the stale consumer would have emitted
+// is deduplicated downstream by the receiver's ON CONFLICT (id) DO NOTHING.
+var ErrLeaseLost = fmt.Errorf("lease lost: message reclaimed by another " +
+	"consumer")
+
+// Exec is the per-message execution handle handed to a TxBehavior. It lets a
+// behavior do slow side-effect IO without holding the SQLite writer, then group
+// several writes into a single short, fenced transaction.
+//
+// The type parameter S is the behavior's typed, transaction-scoped store,
+// produced by the StoreFactory passed to NewTxBehavior. Inside Read/Commit the
+// store joins the framework transaction (its DB calls run against the same
+// *sql.Tx via the context), so domain writes and the framework's
+// ack/dedup bookkeeping commit atomically together.
+type Exec[S any] interface {
+	// Read runs fn inside a short read-only transaction (a WAL snapshot)
+	// and acquires no writer lock. Use it to load inputs before doing IO.
+	Read(ctx context.Context,
+		fn func(ctx context.Context, store S) error) error
+
+	// Commit runs fn inside one short writer transaction. Every store call
+	// inside fn is atomic together. The framework folds the lease-fenced
+	// ack and the dedup mark into this same transaction, so the behavior's
+	// state advance and the message's consumption are one exactly-once
+	// unit. If the lease was lost while the behavior did IO, Commit returns
+	// ErrLeaseLost and the whole transaction is rolled back.
+	Commit(ctx context.Context,
+		fn func(ctx context.Context, store S) error) error
+}
+
+// StoreFactory builds the behavior's typed, transaction-scoped store S from the
+// framework's transaction-scoped DeliveryStore. The DeliveryStore exposes the
+// framework primitives (e.g. EnqueueOutbox) for effect emission; the supplied
+// context carries the *sql.Tx so domain stores join the same transaction. A
+// factory that only needs domain stores can ignore both arguments and return a
+// store value captured at construction (those stores join via the context that
+// Read/Commit pass to the closure).
+//
+// Atomicity contract: the returned store MUST perform its writes against the
+// per-call transaction. Domain stores do this by reading the *sql.Tx off the
+// context that Read/Commit hand to the closure (via actor.TxFromContext). Two
+// ways to silently break this -- both commit out-of-band with no error while
+// the framework's ack still fences, so state is NOT atomic with consumption:
+//
+//	// WRONG: captures an outer (non-tx) context, so writes do not join the
+//	// Commit transaction.
+//	factory := func(context.Context, actor.DeliveryStore) myStore {
+//	    return myStore{ctx: outerCtx, db: db}
+//	}
+//
+//	// WRONG: returns a store bound to the raw DB handle, bypassing the tx.
+//	factory := func(context.Context, actor.DeliveryStore) myStore {
+//	    return myStore{db: rawDB}
+//	}
+//
+//	// RIGHT: the store reads the tx from the closure's ctx at call time.
+//	factory := func(context.Context, actor.DeliveryStore) myStore {
+//	    return myStore{domain: domainStore} // joins via ctx in Commit's fn
+//	}
+//
+// In short: never capture a context in the factory; let the store pick up the
+// transaction from the ctx passed into the Read/Commit closure.
+type StoreFactory[S any] func(ctx context.Context, ds DeliveryStore) S
+
+// TxBehavior is an opt-in alternative to ActorBehavior for durable actors that
+// must do side-effect IO outside the writer transaction. Instead of the
+// framework wrapping the whole Receive in one transaction (the implicit
+// processInTransaction path), the behavior drives its own Read/Commit phases
+// via the Exec handle. The classic ActorBehavior path is unchanged and remains
+// the safe default for behaviors that do no IO.
+type TxBehavior[M TLVMessage, R any, S any] interface {
+	// Receive processes a message using the Exec handle for explicit
+	// Read/Commit phases. Side-effect IO runs between Read and Commit,
+	// while no transaction is held.
+	Receive(ctx context.Context, msg M, ax Exec[S]) fn.Result[R]
+}
+
+// execCore is the non-generic engine backing every Exec[S]. It is bound to a
+// single in-flight delivery and folds the lease fence, dedup mark, and ack into
+// the Commit transaction so the store type S can stay a free type parameter
+// without leaking into the DurableActor.
+type execCore struct {
+	// store is the transaction-aware delivery store used to open the short
+	// Read/Commit transactions.
+	store TxAwareDeliveryStore
+
+	// msgID is the delivery (mailbox message) ID being processed.
+	msgID string
+
+	// leaseToken is the lease this consumer holds on the message; Commit's
+	// ack is fenced on it.
+	leaseToken string
+
+	// actorID identifies the owning actor for the dedup mark.
+	actorID string
+
+	// dedupTTL is how long the processed-message marker is retained.
+	dedupTTL time.Duration
+
+	// committed records whether a Commit transaction succeeded. When true,
+	// the state write, dedup mark, and fenced ack are already durable, so
+	// the actor must not ack again.
+	committed bool
+}
+
+// read runs fn inside a short read-only transaction.
+func (e *execCore) read(ctx context.Context,
+	fn func(ctx context.Context, ds DeliveryStore) error) error {
+
+	return e.store.ExecTx(ctx, true, func(txCtx context.Context,
+		s DeliveryStore) error {
+
+		return fn(txCtx, s)
+	})
+}
+
+// commit runs fn inside one short writer transaction, then folds in the dedup
+// mark and the lease-fenced ack. A zero-row ack means the lease was reclaimed
+// while the behavior did IO, so the whole transaction is rolled back and
+// ErrLeaseLost is returned. On success it records that the delivery has been
+// consumed durably.
+func (e *execCore) commit(ctx context.Context,
+	fn func(ctx context.Context, ds DeliveryStore) error) error {
+
+	err := e.store.ExecTx(ctx, false, func(txCtx context.Context,
+		s DeliveryStore) error {
+
+		// Fence first: ack deletes the mailbox row only if our lease
+		// token still matches. Zero rows means the lease was reclaimed
+		// while the behavior did IO, so we abort and apply nothing --
+		// the whole transaction rolls back, including any writes the
+		// closure would make below. Fencing up front keeps the
+		// stale-lease path a true no-op rather than relying on rollback
+		// alone.
+		rows, err := s.AckMessage(txCtx, e.msgID, e.leaseToken)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return ErrLeaseLost
+		}
+
+		// The behavior's own writes (state advance, outbox effects)
+		// join this transaction via txCtx, so they commit atomically
+		// with the ack above.
+		if err := fn(txCtx, s); err != nil {
+			return err
+		}
+
+		// Mark the message processed for dedup within the same tx so
+		// the state advance and the dedup record are atomic with
+		// consumption.
+		return s.MarkProcessed(txCtx, e.msgID, e.actorID, e.dedupTTL)
+	})
+	if err != nil {
+		return err
+	}
+
+	e.committed = true
+
+	return nil
+}
+
+// execHandle is the generic Exec[S] adapter over the non-generic execCore. It
+// builds the typed store S from the transaction-scoped DeliveryStore on each
+// Read/Commit and hands it to the behavior's closure.
+type execHandle[S any] struct {
+	core    *execCore
+	factory StoreFactory[S]
+}
+
+// Read implements Exec by running the closure against a typed store inside a
+// read-only transaction.
+func (e execHandle[S]) Read(ctx context.Context,
+	fn func(ctx context.Context, store S) error) error {
+
+	return e.core.read(ctx, func(txCtx context.Context,
+		ds DeliveryStore) error {
+
+		return fn(txCtx, e.factory(txCtx, ds))
+	})
+}
+
+// Commit implements Exec by running the closure against a typed store inside
+// the fenced writer transaction.
+func (e execHandle[S]) Commit(ctx context.Context,
+	fn func(ctx context.Context, store S) error) error {
+
+	return e.core.commit(ctx, func(txCtx context.Context,
+		ds DeliveryStore) error {
+
+		return fn(txCtx, e.factory(txCtx, ds))
+	})
+}
+
+// BoundTxBehavior is a store-type-erased durable behavior produced by
+// NewTxBehavior. The store type parameter S is captured inside, so the value
+// fits in DurableActorConfig.TxBehavior without forcing the store type onto the
+// DurableActor itself. Construct one with NewTxBehavior and place it in the
+// config to run the actor on the Read/Commit execution path.
+type BoundTxBehavior[M TLVMessage, R any] struct {
+	// run drives one message through the behavior using an Exec[S] built
+	// over the supplied execCore. It is nil for the zero value.
+	run func(ctx context.Context, core *execCore, msg M) fn.Result[R]
+}
+
+// isSet reports whether this BoundTxBehavior carries a behavior.
+func (b BoundTxBehavior[M, R]) isSet() bool {
+	return b.run != nil
+}
+
+// NewTxBehavior binds a TxBehavior and its StoreFactory into a
+// store-type-erased BoundTxBehavior suitable for DurableActorConfig.TxBehavior.
+// The factory is the injection point for the behavior's typed store: it is
+// invoked inside each Read/Commit transaction to produce the store handed to
+// the behavior's closures.
+func NewTxBehavior[M TLVMessage, R any, S any](
+	behavior TxBehavior[M, R, S],
+	factory StoreFactory[S],
+) BoundTxBehavior[M, R] {
+
+	return BoundTxBehavior[M, R]{
+		run: func(ctx context.Context, core *execCore,
+			msg M) fn.Result[R] {
+
+			ax := execHandle[S]{
+				core:    core,
+				factory: factory,
+			}
+
+			return behavior.Receive(ctx, msg, ax)
+		},
+	}
+}

--- a/baselib/actor/tx_exec_test.go
+++ b/baselib/actor/tx_exec_test.go
@@ -1,0 +1,618 @@
+package actor
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// execTestBehavior is a TxBehavior whose per-message logic is supplied by a
+// closure. Its store type is the framework DeliveryStore, so the factory is the
+// identity on the tx-scoped store.
+type execTestBehavior struct {
+	onReceive func(ctx context.Context, msg *actorTestMsg,
+		ax Exec[DeliveryStore]) fn.Result[int]
+}
+
+// Receive implements TxBehavior.
+func (b *execTestBehavior) Receive(ctx context.Context, msg *actorTestMsg,
+	ax Exec[DeliveryStore]) fn.Result[int] {
+
+	return b.onReceive(ctx, msg, ax)
+}
+
+// identityStoreFactory hands the tx-scoped DeliveryStore straight through as
+// the behavior's typed store.
+func identityStoreFactory(_ context.Context, ds DeliveryStore) DeliveryStore {
+	return ds
+}
+
+// enqueueEffects returns a Commit closure that writes one outbox effect per id.
+// It is the canonical "several writes in one Commit" workload used to exercise
+// the atomic-grouping invariant.
+func enqueueEffects(ids ...string) func(context.Context, DeliveryStore) error {
+	return func(ctx context.Context, ds DeliveryStore) error {
+		for _, id := range ids {
+			err := ds.EnqueueOutbox(ctx, OutboxParams{
+				ID:            id,
+				SourceActorID: "actor-a",
+				TargetActorID: "actor-b",
+				MessageType:   "actor.TestMsg",
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+// execHarness bundles a tx-aware mock store and codec with helpers and
+// assertions for exercising the Read/Commit execution path. It keeps the tests
+// focused on behavior (what was consumed / committed) rather than mock
+// plumbing. All query helpers take the store lock internally.
+type execHarness struct {
+	store *mockTxAwareStore
+	codec *MessageCodec
+}
+
+// newExecHarness builds a harness over a fresh tx-aware store.
+func newExecHarness() *execHarness {
+	return &execHarness{
+		store: newMockTxAwareStore(),
+		codec: newActorTestCodec(),
+	}
+}
+
+// seedLeased enqueues msgID into mailboxID and leases it under leaseToken,
+// returning the harness as the consumer that now holds the lease.
+func (h *execHarness) seedLeased(t require.TestingT, mailboxID, msgID,
+	leaseToken string) {
+
+	ctx := context.Background()
+
+	require.NoError(
+		t,
+		h.store.EnqueueMessage(
+			ctx, EnqueueParams{
+				ID:          msgID,
+				MailboxID:   mailboxID,
+				MessageType: "actor.TestMsg",
+				MaxAttempts: 10,
+				AvailableAt: time.Now().Add(-time.Second),
+			},
+		),
+	)
+
+	leased, err := h.store.LeaseNextMessage(
+		ctx, mailboxID, leaseToken, time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leased)
+	require.Equal(t, msgID, leased.ID)
+	require.Equal(t, leaseToken, leased.LeaseToken)
+}
+
+// coreFor builds an execCore bound to msgID and holding leaseToken.
+func (h *execHarness) coreFor(msgID, leaseToken string) *execCore {
+	return &execCore{
+		store:      h.store,
+		msgID:      msgID,
+		leaseToken: leaseToken,
+		actorID:    "actor-a",
+		dedupTTL:   time.Hour,
+	}
+}
+
+// messageExists reports whether the mailbox row is still present.
+func (h *execHarness) messageExists(id string) bool {
+	h.store.mu.Lock()
+	defer h.store.mu.Unlock()
+
+	_, ok := h.store.messages[id]
+
+	return ok
+}
+
+// isProcessed reports whether the dedup mark is set.
+func (h *execHarness) isProcessed(id string) bool {
+	h.store.mu.Lock()
+	defer h.store.mu.Unlock()
+
+	return h.store.processed[id]
+}
+
+// outboxCount returns the number of committed outbox effects.
+func (h *execHarness) outboxCount() int {
+	h.store.mu.Lock()
+	defer h.store.mu.Unlock()
+
+	return len(h.store.outbox)
+}
+
+// outboxHas reports whether an outbox effect with the given id committed.
+func (h *execHarness) outboxHas(id string) bool {
+	h.store.mu.Lock()
+	defer h.store.mu.Unlock()
+
+	_, ok := h.store.outbox[id]
+
+	return ok
+}
+
+// requireConsumed asserts the message was fence-acked (row gone) and the dedup
+// mark was set -- the two halves of "the message was durably consumed".
+func (h *execHarness) requireConsumed(t require.TestingT, id string) {
+	require.False(t, h.messageExists(id), "message should be consumed")
+	require.True(t, h.isProcessed(id), "message should be marked processed")
+}
+
+// requireRetained asserts the message is still claimable and unconsumed: the
+// row is present and no dedup mark was written.
+func (h *execHarness) requireRetained(t require.TestingT, id string) {
+	require.True(t, h.messageExists(id), "message should be retained")
+	require.False(t, h.isProcessed(id), "message must not be processed")
+}
+
+// startTxActor wires beh into a durable actor on the Read/Commit path and
+// starts it. The caller is responsible for stopping it.
+func (h *execHarness) startTxActor(t *testing.T,
+	beh TxBehavior[*actorTestMsg, int, DeliveryStore],
+) *DurableActor[*actorTestMsg, int] {
+
+	cfg := DefaultDurableTxActorConfig[*actorTestMsg, int, DeliveryStore](
+		"test-actor", beh, identityStoreFactory, h.store, h.codec,
+	)
+	cfg.PollInterval = 10 * time.Millisecond
+
+	a := NewDurableActor(cfg).UnwrapOrFail(t)
+	a.Start()
+
+	return a
+}
+
+// tellTestMsg sends a value-carrying test message to the actor.
+func tellTestMsg(t *testing.T, a *DurableActor[*actorTestMsg, int],
+	value uint64) {
+
+	t.Helper()
+
+	msg := &actorTestMsg{
+		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](value),
+	}
+	require.NoError(t, a.Ref().Tell(context.Background(), msg))
+}
+
+// TestExecCommitFenceConsumesMessage verifies the happy path: a Commit with the
+// held lease token runs the user writes, marks the message processed, and
+// fence-acks it (deletes the mailbox row), all reported as committed.
+func TestExecCommitFenceConsumesMessage(t *testing.T) {
+	t.Parallel()
+
+	h := newExecHarness()
+	h.seedLeased(t, "mb", "m1", "tok-1")
+
+	core := h.coreFor("m1", "tok-1")
+	err := core.commit(context.Background(), enqueueEffects("out-1"))
+	require.NoError(t, err)
+
+	require.True(t, core.committed)
+	h.requireConsumed(t, "m1")
+	require.True(t, h.outboxHas("out-1"))
+}
+
+// TestExecCommitStaleLeaseNoOps verifies the fence: a Commit attempted with a
+// lease token that no longer matches (message reclaimed elsewhere) aborts with
+// ErrLeaseLost and applies nothing -- no user write, no dedup mark, message
+// retained.
+func TestExecCommitStaleLeaseNoOps(t *testing.T) {
+	t.Parallel()
+
+	h := newExecHarness()
+	h.seedLeased(t, "mb", "m1", "tok-1")
+
+	core := h.coreFor("m1", "stale-token")
+
+	var userWriteRan bool
+	err := core.commit(context.Background(), func(ctx context.Context,
+		ds DeliveryStore) error {
+
+		userWriteRan = true
+
+		return enqueueEffects("out-stale")(ctx, ds)
+	})
+	require.ErrorIs(t, err, ErrLeaseLost)
+
+	require.False(t, core.committed)
+	require.False(
+		t, userWriteRan,
+		"user closure must not run when the fence rejects the commit",
+	)
+	h.requireRetained(t, "m1")
+	require.Zero(t, h.outboxCount())
+}
+
+// TestExecCommitTwiceSecondFails verifies a successful Commit cannot be
+// double-applied: a second Commit on the same core finds the message already
+// consumed and fails the fence without adding further effects.
+func TestExecCommitTwiceSecondFails(t *testing.T) {
+	t.Parallel()
+
+	h := newExecHarness()
+	h.seedLeased(t, "mb", "m1", "tok-1")
+
+	core := h.coreFor("m1", "tok-1")
+	require.NoError(
+		t,
+		core.commit(
+			context.Background(), enqueueEffects("out-1"),
+		),
+	)
+
+	// A second commit hits the fence (the row is gone) and applies nothing.
+	err := core.commit(context.Background(), enqueueEffects("out-2"))
+	require.ErrorIs(t, err, ErrLeaseLost)
+
+	require.True(t, h.outboxHas("out-1"))
+	require.False(t, h.outboxHas("out-2"))
+	require.Equal(t, 1, h.outboxCount())
+}
+
+// TestDurableActorExecPathCommits drives a TxBehavior end-to-end through the
+// actor: a Tell is delivered, the behavior commits an outbox effect, and the
+// message is consumed.
+func TestDurableActorExecPathCommits(t *testing.T) {
+	t.Parallel()
+
+	h := newExecHarness()
+
+	committed := make(chan struct{}, 1)
+	behavior := &execTestBehavior{
+		onReceive: func(ctx context.Context, msg *actorTestMsg,
+			ax Exec[DeliveryStore]) fn.Result[int] {
+
+			err := ax.Commit(ctx, enqueueEffects("effect-1"))
+			if err != nil {
+				return fn.Err[int](err)
+			}
+
+			select {
+			case committed <- struct{}{}:
+			default:
+			}
+
+			return fn.Ok(7)
+		},
+	}
+
+	a := h.startTxActor(t, behavior)
+	defer a.Stop()
+
+	tellTestMsg(t, a, 1)
+
+	select {
+	case <-committed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("behavior never committed")
+	}
+
+	// The committed effect is durable and the mailbox drains to empty (the
+	// fence-ack consumed the message).
+	require.Eventually(t, func() bool {
+		return h.outboxHas("effect-1") && !h.anyMessages()
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// The Commit path was used (a tx ran).
+	require.True(t, h.store.txExecuted.Load())
+}
+
+// TestDurableActorExecPathRetriesOnError verifies that a behavior which fails
+// before committing (e.g. side-effect IO error) leaves the message for retry
+// rather than consuming it.
+func TestDurableActorExecPathRetriesOnError(t *testing.T) {
+	t.Parallel()
+
+	h := newExecHarness()
+
+	behavior := &execTestBehavior{
+		onReceive: func(ctx context.Context, msg *actorTestMsg,
+			_ Exec[DeliveryStore]) fn.Result[int] {
+
+			// Simulate IO failing before any Commit.
+			return fn.Err[int](context.DeadlineExceeded)
+		},
+	}
+
+	a := h.startTxActor(t, behavior)
+	defer a.Stop()
+
+	tellTestMsg(t, a, 1)
+
+	// The failure nacks for retry; no outbox effect is produced.
+	require.Eventually(t, func() bool {
+		return h.store.nackCalled.Load()
+	}, 2*time.Second, 10*time.Millisecond)
+
+	require.Zero(t, h.outboxCount())
+}
+
+// TestDurableActorExecPathConsumesWithoutCommit verifies that a behavior which
+// returns success without calling Commit (e.g. a RestartMessage handler) still
+// has its message consumed via the non-transactional ack path, with no Commit
+// transaction opened.
+func TestDurableActorExecPathConsumesWithoutCommit(t *testing.T) {
+	t.Parallel()
+
+	h := newExecHarness()
+
+	behavior := &execTestBehavior{
+		onReceive: func(ctx context.Context, msg *actorTestMsg,
+			_ Exec[DeliveryStore]) fn.Result[int] {
+
+			// No Commit: nothing to persist, just consume the
+			// message.
+			return fn.Ok(0)
+		},
+	}
+
+	a := h.startTxActor(t, behavior)
+	defer a.Stop()
+
+	tellTestMsg(t, a, 1)
+
+	require.Eventually(t, func() bool {
+		return !h.anyMessages()
+	}, 2*time.Second, 10*time.Millisecond)
+
+	require.False(
+		t, h.store.txExecuted.Load(),
+		"no Commit means no transaction should run",
+	)
+}
+
+// anyMessages reports whether any mailbox rows remain.
+func (h *execHarness) anyMessages() bool {
+	h.store.mu.Lock()
+	defer h.store.mu.Unlock()
+
+	return len(h.store.messages) > 0
+}
+
+// TestNewDurableActorTxBehaviorRequiresTxStore verifies that pairing a
+// TxBehavior with a store that is not transaction-aware is rejected at
+// construction.
+func TestNewDurableActorTxBehaviorRequiresTxStore(t *testing.T) {
+	t.Parallel()
+
+	// A plain (non-tx-aware) delivery store.
+	store := newMockDeliveryStore()
+	codec := newActorTestCodec()
+
+	behavior := &execTestBehavior{
+		onReceive: func(ctx context.Context, msg *actorTestMsg,
+			_ Exec[DeliveryStore]) fn.Result[int] {
+
+			return fn.Ok(0)
+		},
+	}
+
+	cfg := DefaultDurableTxActorConfig[*actorTestMsg, int, DeliveryStore](
+		"test-actor", behavior, identityStoreFactory, store, codec,
+	)
+
+	_, err := NewDurableActor(cfg).Unpack()
+	require.ErrorIs(t, err, ErrTxBehaviorNeedsTxStore)
+}
+
+// TestDurableActorExecPathRejectsDurableAsk verifies that a DurableAsk
+// delivered to a Read/Commit (TxBehavior) actor is not silently consumed: the
+// behavior never runs, an error response is written to the outbox so the caller
+// does not hang, and the message is consumed (acked + dedup-marked).
+func TestDurableActorExecPathRejectsDurableAsk(t *testing.T) {
+	t.Parallel()
+
+	h := newExecHarness()
+
+	var behaviorRan atomic.Bool
+	behavior := &execTestBehavior{
+		onReceive: func(ctx context.Context, msg *actorTestMsg,
+			ax Exec[DeliveryStore]) fn.Result[int] {
+
+			behaviorRan.Store(true)
+
+			return fn.Ok(0)
+		},
+	}
+
+	a := h.startTxActor(t, behavior)
+	defer a.Stop()
+
+	durableRef, ok := a.Ref().(DurableActorRef[*actorTestMsg, int])
+	require.True(t, ok, "durable actor ref must support DurableAsk")
+
+	msg := &actorTestMsg{
+		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(1)),
+	}
+	require.NoError(
+		t,
+		durableRef.DurableAsk(
+			context.Background(), msg, DurableAskParams{
+				CallbackActorID: "callback-actor",
+				CorrelationID:   "corr-1",
+			},
+		),
+	)
+
+	// The request is rejected: an error response lands in the outbox and
+	// the mailbox row is consumed, without the behavior ever running.
+	require.Eventually(t, func() bool {
+		h.store.mu.Lock()
+		defer h.store.mu.Unlock()
+
+		return len(h.store.outbox) == 1 && len(h.store.messages) == 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	require.False(
+		t, behaviorRan.Load(),
+		"behavior must not run for a rejected DurableAsk",
+	)
+}
+
+// TestNewDurableActorRejectsMissingBehavior verifies construction fails closed
+// when no usable behavior is configured: a zero-value config (forgotten
+// Behavior field, which the fn.Either zero value reports as a Left holding nil)
+// and a Right holding a zero-value BoundTxBehavior (run hook never bound) both
+// error with ErrNoBehavior instead of panicking at first dispatch.
+func TestNewDurableActorRejectsMissingBehavior(t *testing.T) {
+	t.Parallel()
+
+	store := newMockTxAwareStore()
+	codec := newActorTestCodec()
+
+	// Forgotten Behavior field: the either zero value is Left(nil).
+	missingCfg := DurableActorConfig[*actorTestMsg, int]{
+		ID:    "test-actor",
+		Store: store,
+		Codec: codec,
+	}
+	_, err := NewDurableActor(missingCfg).Unpack()
+	require.ErrorIs(t, err, ErrNoBehavior)
+
+	// Right holding a zero-value BoundTxBehavior (no run hook).
+	zeroTxCfg := DefaultDurableActorConfig[*actorTestMsg, int](
+		"test-actor",
+		newMockBehavior(
+			fn.Ok(1),
+		),
+		store,
+		codec,
+	)
+	zeroTxCfg.Behavior = fn.NewRight[ActorBehavior[*actorTestMsg, int]](
+		BoundTxBehavior[*actorTestMsg, int]{},
+	)
+	_, err = NewDurableActor(zeroTxCfg).Unpack()
+	require.ErrorIs(t, err, ErrNoBehavior)
+}
+
+// TestDurableActorConfigBehaviorEither verifies the two config constructors
+// populate the correct side of the Behavior either.
+func TestDurableActorConfigBehaviorEither(t *testing.T) {
+	t.Parallel()
+
+	store := newMockTxAwareStore()
+	codec := newActorTestCodec()
+
+	classic := newMockBehavior(fn.Ok(1))
+	classicCfg := DefaultDurableActorConfig[*actorTestMsg, int](
+		"a", classic, store, codec,
+	)
+	require.True(t, classicCfg.Behavior.IsLeft())
+	require.False(t, classicCfg.Behavior.IsRight())
+
+	tx := &execTestBehavior{
+		onReceive: func(ctx context.Context, msg *actorTestMsg,
+			_ Exec[DeliveryStore]) fn.Result[int] {
+
+			return fn.Ok(0)
+		},
+	}
+	txCfg := DefaultDurableTxActorConfig[*actorTestMsg, int, DeliveryStore](
+		"a", tx, identityStoreFactory, store, codec,
+	)
+	require.True(t, txCfg.Behavior.IsRight())
+	require.False(t, txCfg.Behavior.IsLeft())
+}
+
+// tokenGen draws non-empty lease tokens for property tests.
+var tokenGen = rapid.StringMatching(`[a-zA-Z0-9]{1,12}`)
+
+// TestExecCommitFenceProperty is the property form of the fence invariant:
+// across arbitrary held/attempted token pairs, a Commit consumes the message
+// and applies its effect exactly when the attempted token matches the held
+// lease, and otherwise applies nothing and returns ErrLeaseLost.
+func TestExecCommitFenceProperty(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		held := tokenGen.Draw(rt, "held")
+		sameLease := rapid.Bool().Draw(rt, "sameLease")
+
+		// Build an attempted token that is equal to or definitely
+		// different from the held token.
+		attempted := held
+		if !sameLease {
+			attempted = held + "-mismatch"
+		}
+
+		h := newExecHarness()
+		h.seedLeased(rt, "mb", "m1", held)
+
+		core := h.coreFor("m1", attempted)
+		err := core.commit(
+			context.Background(), enqueueEffects("eff"),
+		)
+
+		if sameLease {
+			// Matching lease: consumed exactly once, effect
+			// present.
+			require.NoError(rt, err)
+			require.True(rt, core.committed)
+			h.requireConsumed(rt, "m1")
+			require.True(rt, h.outboxHas("eff"))
+			require.Equal(rt, 1, h.outboxCount())
+
+			return
+		}
+
+		// Mismatched lease: nothing applied, message retained.
+		require.ErrorIs(rt, err, ErrLeaseLost)
+		require.False(rt, core.committed)
+		h.requireRetained(rt, "m1")
+		require.Zero(rt, h.outboxCount())
+	})
+}
+
+// TestExecCommitAtomicGroupingProperty is the property form of the
+// atomic-grouping invariant: whatever number of effects a single Commit writes
+// (including zero), on success every effect is present and the message is
+// consumed and marked processed -- all-or-nothing in one transaction.
+func TestExecCommitAtomicGroupingProperty(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		n := rapid.IntRange(0, 8).Draw(rt, "numEffects")
+
+		ids := make([]string, n)
+		for i := range ids {
+			ids[i] = fmt.Sprintf("eff-%d", i)
+		}
+
+		h := newExecHarness()
+		h.seedLeased(rt, "mb", "m1", "tok")
+
+		core := h.coreFor("m1", "tok")
+		require.NoError(
+			rt,
+			core.commit(
+				context.Background(), enqueueEffects(ids...),
+			),
+		)
+
+		require.True(rt, core.committed)
+		h.requireConsumed(rt, "m1")
+
+		// Exactly the n effects committed -- no more, no fewer.
+		require.Equal(rt, n, h.outboxCount())
+		for _, id := range ids {
+			require.True(rt, h.outboxHas(id))
+		}
+	})
+}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -305,6 +305,13 @@ type Server struct {
 	// the ledger actor; this field is for queries only.
 	ledgerStore *db.LedgerStoreDB
 
+	// ledgerActor is the durable client-side accounting actor. It is
+	// retained so the daemon can stop it during shutdown; the durable
+	// mailbox is the registered delivery path (producers Tell its ref via
+	// the ledger service key), so unlike the receptionist registration it
+	// is not managed by the actor system's stoppable set.
+	ledgerActor *ledger.LedgerActor
+
 	// boardingSweepStore exposes the boarding-sweep DB adapter for
 	// read-only RPC handlers (ListBoardingSweeps). All mutating writes
 	// happen inside the wallet actor; this field is for pure CRUD reads
@@ -921,6 +928,25 @@ func (s *Server) run(ctx context.Context, shutdownFn func()) error {
 			err := s.actorSystem.Shutdown(shutdownCtx)
 			if err != nil {
 				s.log.WarnS(ctx, "Actor system shutdown failed",
+					err,
+				)
+			}
+		}
+
+		// Stop the ledger actor only after the actor system has drained
+		// the producer actors (round, OOR, VTXO, wallet) above. The
+		// ledger is not in the actor system's stoppable set -- we
+		// register only its durable ref -- so it must be stopped here
+		// explicitly. Doing it after actorSystem.Shutdown closes the
+		// window where a still-running producer's best-effort
+		// accounting Tell would hit a cancelled ledger context and be
+		// dropped before it is persisted. It still runs before db.Close
+		// below so the actor's in-flight ledger writes drain first.
+		if s.ledgerActor != nil {
+			//nolint:contextcheck // bounded shutdown
+			err := s.ledgerActor.OnStop(shutdownCtx)
+			if err != nil {
+				s.log.WarnS(ctx, "Ledger actor shutdown failed",
 					err,
 				)
 			}
@@ -2971,11 +2997,22 @@ func (s *Server) initLedgerActor(ctx context.Context) error {
 	if err := ledgerActor.Start(ctx); err != nil {
 		return fmt.Errorf("start ledger actor: %w", err)
 	}
+	s.ledgerActor = ledgerActor
 
+	// Register the durable actor's ref with the receptionist so producers
+	// Tell the durable mailbox via the ledger service key (mirroring OOR
+	// and serverconn). The actor runs the Read/Commit execution path, so
+	// each accounting event commits its ledger legs and the mailbox ack in
+	// one lease-fenced transaction. Lifecycle is owned by the daemon: the
+	// actor is stopped explicitly during shutdown (it is not in the actor
+	// system's stoppable set, since we register only its ref, not an
+	// in-memory actor).
 	ledgerKey := ledger.NewServiceKey()
-	actor.RegisterWithSystem(
-		s.actorSystem, "ledger-accounting", ledgerKey, ledgerActor,
-	)
+	if err := actor.RegisterWithReceptionist(
+		s.actorSystem.Receptionist(), ledgerKey, ledgerActor.Ref(),
+	); err != nil {
+		return fmt.Errorf("register ledger actor: %w", err)
+	}
 
 	s.log.InfoS(ctx, "Ledger accounting actor started")
 

--- a/db/actordelivery/durable_actor_reorder_test.go
+++ b/db/actordelivery/durable_actor_reorder_test.go
@@ -259,7 +259,7 @@ func TestDurableActorPerKeyFIFOSurvivesTransientFailure(t *testing.T) {
 	cfg.LeaseDuration = 5 * time.Second
 	cfg.HeartbeatInterval = 2 * time.Second
 
-	a := actor.NewDurableActor(cfg)
+	a := actor.NewDurableActor(cfg).UnwrapOrFail(t)
 
 	a.Start()
 	defer func() {
@@ -335,7 +335,7 @@ func TestDurableActorCrossKeyIndependence(t *testing.T) {
 	cfg.LeaseDuration = 5 * time.Second
 	cfg.HeartbeatInterval = 2 * time.Second
 
-	a := actor.NewDurableActor(cfg)
+	a := actor.NewDurableActor(cfg).UnwrapOrFail(t)
 
 	a.Start()
 	defer func() {

--- a/internal/actortest/e2e_test.go
+++ b/internal/actortest/e2e_test.go
@@ -113,7 +113,7 @@ func (h *testHarness) newDurableCounter(id string) (
 	cfg.LeaseDuration = 5 * time.Second
 	cfg.HeartbeatInterval = 1 * time.Second
 
-	durableActor := actor.NewDurableActor(cfg)
+	durableActor := actor.NewDurableActor(cfg).UnwrapOrFail(h.t)
 
 	// Register with [Message, any] types so OutboxPublisher can find it.
 	// The OutboxPublisher looks up actors using ServiceKey[Message, any],

--- a/internal/actortest/ledger_e2e_test.go
+++ b/internal/actortest/ledger_e2e_test.go
@@ -1,0 +1,174 @@
+package actortest
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/db/actordelivery"
+	"github.com/lightninglabs/darepo-client/db/sqlc"
+	"github.com/lightninglabs/darepo-client/ledger"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// newLedgerActorForTest wires a real ledger.LedgerActor on the durable
+// Read/Commit execution path. The tx-aware delivery store and the ledger store
+// are backed by the SAME in-memory SQLite database, so a handler's
+// InsertLedgerEntry joins the actor's Commit transaction (via
+// actor.TxFromContext) exactly as it does in production. This exercises the
+// full stack -- durable mailbox lease/ack + fenced Commit + double-entry
+// writes -- rather than the mocks used in the ledger package's unit tests.
+func newLedgerActorForTest(t *testing.T) (*ledger.LedgerActor,
+	*db.LedgerStoreDB) {
+
+	t.Helper()
+
+	sqlDB := db.NewTestDB(t)
+
+	// Use a real-time clock so the delivery store's available_at/lease
+	// timestamps agree with the durable mailbox's default clock. Injecting
+	// a frozen test clock here would desync the two (the mailbox stamps
+	// available_at from its own default clock) and the message would never
+	// be claim-eligible.
+	clk := clock.NewDefaultClock()
+
+	txStore, err := actordelivery.NewTxAwareDeliveryStoreFromDB(
+		sqlDB.DB, sqlDB.Backend(), clk, btclog.Disabled,
+	)
+	require.NoError(t, err)
+
+	ledgerTxExec := db.NewTransactionExecutor(
+		sqlDB.BaseDB,
+		func(tx *sql.Tx) *sqlc.Queries {
+			return sqlDB.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+	ledgerStore := &db.LedgerStoreDB{TransactionExecutor: ledgerTxExec}
+
+	ledgerActor := ledger.NewLedgerActor(ledger.ActorConfig{
+		Log:           fn.None[btclog.Logger](),
+		DeliveryStore: txStore,
+		LedgerStore:   ledgerStore,
+		Clock:         fn.Some[clock.Clock](clk),
+	})
+	require.NoError(t, ledgerActor.Start(t.Context()))
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer cancel()
+
+		_ = ledgerActor.OnStop(ctx)
+	})
+
+	return ledgerActor, ledgerStore
+}
+
+// requireBalance asserts the net (debits minus credits) balance of an account.
+func requireBalance(t *testing.T, store *db.LedgerStoreDB, account string,
+	want int64) {
+
+	t.Helper()
+
+	got, err := store.GetAccountBalance(t.Context(), account)
+	require.NoError(t, err)
+	require.Equalf(t, want, got, "account %s balance", account)
+}
+
+// tryCount reads the total ledger row count, tolerating transient read errors
+// (e.g. SQLITE_BUSY while the actor holds the writer during a retry). Returns
+// ok=false when the count could not be read, so polling closures treat a
+// transient failure as "not yet / nothing observed" rather than a hard error.
+func tryCount(store *db.LedgerStoreDB) (int64, bool) {
+	n, err := store.CountLedgerEntries(context.Background())
+	if err != nil {
+		return 0, false
+	}
+
+	return n, true
+}
+
+// TestLedgerActorExitCostCommitsBothLegs drives a real ExitCostMsg through the
+// durable mailbox and asserts the two legs (send + fee) are booked atomically
+// in one fenced Commit, and that a replay is idempotent (the shared
+// outpoint-keyed legs dedup, so no double-booking through the real stack).
+func TestLedgerActorExitCostCommitsBothLegs(t *testing.T) {
+	t.Parallel()
+
+	ledgerActor, store := newLedgerActorForTest(t)
+
+	msg := &ledger.ExitCostMsg{
+		OutpointHash: [32]byte{
+			0xaa,
+			0x01,
+			0x02,
+		},
+		OutpointIndex: 3,
+		AmountSat:     10_000,
+		ExitCostSat:   1_500,
+		BlockHeight:   880_000,
+	}
+	require.NoError(t, ledgerActor.Ref().Tell(t.Context(), msg))
+
+	// Both legs commit: the message drains and exactly two rows land.
+	require.Eventually(t, func() bool {
+		n, ok := tryCount(store)
+
+		return ok && n == 2
+	}, 3*time.Second, 20*time.Millisecond)
+
+	// Send leg debits transfers_out by the net amount; fee leg debits
+	// onchain_fees by the exit cost; vtxo_balance is credited the gross.
+	net := msg.AmountSat - msg.ExitCostSat
+	requireBalance(t, store, ledger.AccountTransfersOut, net)
+	requireBalance(t, store, ledger.AccountOnchainFees, msg.ExitCostSat)
+	requireBalance(t, store, ledger.AccountVTXOBalance, -msg.AmountSat)
+
+	// Replaying the same event is a no-op: both legs share the
+	// outpoint-derived idempotency key and dedup via ON CONFLICT DO
+	// NOTHING, so the row count never grows past two.
+	require.NoError(t, ledgerActor.Ref().Tell(t.Context(), msg))
+	require.Never(t, func() bool {
+		n, ok := tryCount(store)
+
+		return ok && n != 2
+	}, 500*time.Millisecond, 50*time.Millisecond)
+}
+
+// TestLedgerActorRejectsInvalidExitCost confirms a handler validation failure
+// (exit cost >= VTXO amount) commits nothing: because the Commit closure
+// returns an error, the fenced transaction rolls back and no partial ledger
+// leg is left behind.
+func TestLedgerActorRejectsInvalidExitCost(t *testing.T) {
+	t.Parallel()
+
+	ledgerActor, store := newLedgerActorForTest(t)
+
+	// Fee consumes the whole VTXO: handleExitCost rejects with
+	// ErrInvalidMessage before any leg can be persisted.
+	msg := &ledger.ExitCostMsg{
+		OutpointHash: [32]byte{
+			0xbb,
+			0x09,
+		},
+		OutpointIndex: 1,
+		AmountSat:     2_000,
+		ExitCostSat:   2_000,
+		BlockHeight:   880_001,
+	}
+	require.NoError(t, ledgerActor.Ref().Tell(t.Context(), msg))
+
+	// No ledger rows are ever written, even as the message is retried.
+	require.Never(t, func() bool {
+		n, ok := tryCount(store)
+
+		return ok && n != 0
+	}, 500*time.Millisecond, 50*time.Millisecond)
+}

--- a/ledger/actor.go
+++ b/ledger/actor.go
@@ -282,6 +282,21 @@ type ActorConfig struct {
 	Clock fn.Option[clock.Clock]
 }
 
+// ledgerTx is the typed, transaction-scoped store handed to ledger handlers
+// inside a single Commit. Every write a handler issues through it joins that
+// one Commit transaction (the stores pick up the *sql.Tx from the handler's
+// context), so multi-leg events such as ExitCost book all legs atomically with
+// the mailbox ack. This is the store type the durable-actor Exec handle injects
+// per message via NewLedgerActor's StoreFactory.
+type ledgerTx struct {
+	// ledger persists double-entry ledger rows.
+	ledger LedgerStore
+
+	// audit persists wallet UTXO audit-log rows. Nil when the actor runs in
+	// log-only mode (no UTXOAuditStore configured).
+	audit UTXOAuditStore
+}
+
 // LedgerActor is a durable actor that serializes all client-side
 // accounting writes from rounds, OOR transfers, and on-chain
 // exits. It receives fire-and-forget Tell messages and persists
@@ -311,8 +326,8 @@ type LedgerActor struct {
 
 var (
 	// Compile-time check that LedgerActor implements the durable
-	// actor behavior interface.
-	_ actor.ActorBehavior[LedgerMsg, LedgerResp] = (*LedgerActor)(nil)
+	// transaction-aware behavior interface over its typed ledgerTx store.
+	_ actor.TxBehavior[LedgerMsg, LedgerResp, ledgerTx] = (*LedgerActor)(nil)
 
 	// Compile-time check that LedgerActor implements actor-system
 	// cleanup.
@@ -349,16 +364,25 @@ func (a *LedgerActor) Start(ctx context.Context) error {
 
 	codec := newLedgerCodec()
 
+	// Run on the durable actor's Read/Commit execution path: each handler
+	// books its ledger legs inside one short, lease-fenced Commit
+	// transaction rather than the framework holding a writer tx across the
+	// whole Receive. The StoreFactory injects the typed ledgerTx store
+	// bound to that Commit transaction.
+	//
 	// The durable actor should not see LedgerActor's OnStop hook, because
 	// that hook waits for the durable actor itself to exit. The
 	// actor-system wrapper owns that cleanup instead.
-	durableBehavior := actor.NewFunctionBehavior(a.Receive)
-	durableCfg := actor.DefaultDurableActorConfig[
-		LedgerMsg, LedgerResp,
+	durableCfg := actor.DefaultDurableTxActorConfig[
+		LedgerMsg, LedgerResp, ledgerTx,
 	](
-		a.actorID, durableBehavior, a.cfg.DeliveryStore, codec,
+		a.actorID, a, a.bindStores, a.cfg.DeliveryStore, codec,
 	)
-	a.durable = actor.NewDurableActor(durableCfg)
+	durable, err := actor.NewDurableActor(durableCfg).Unpack()
+	if err != nil {
+		return fmt.Errorf("build ledger durable actor: %w", err)
+	}
+	a.durable = durable
 	a.ref = a.durable.Ref()
 
 	checkpoint, err := a.cfg.DeliveryStore.LoadCheckpoint(
@@ -431,82 +455,52 @@ func (a *LedgerActor) logHandlerErr(ctx context.Context, msg string,
 	_ = errors.Is(err, ErrInvalidMessage)
 }
 
-// Receive processes one durable message. This is the
-// ActorBehavior implementation called by the durable runtime.
-func (a *LedgerActor) Receive(ctx context.Context,
-	msg LedgerMsg) fn.Result[LedgerResp] {
+// bindStores is the StoreFactory passed to the durable actor: it produces the
+// typed ledgerTx store the Exec handle hands to each handler inside a Commit.
+// The stores join the Commit transaction via the context passed to their
+// methods, so the factory itself ignores its arguments and just wires the
+// configured stores through.
+func (a *LedgerActor) bindStores(_ context.Context,
+	_ actor.DeliveryStore) ledgerTx {
+
+	return ledgerTx{
+		ledger: a.cfg.LedgerStore,
+		audit:  a.cfg.UTXOAuditStore,
+	}
+}
+
+// Receive processes one durable message. This is the TxBehavior implementation
+// called by the durable runtime: each handler that persists state runs inside a
+// single lease-fenced Commit transaction via the Exec handle, so the ledger
+// writes and the mailbox ack land atomically.
+func (a *LedgerActor) Receive(ctx context.Context, msg LedgerMsg,
+	ax actor.Exec[ledgerTx]) fn.Result[LedgerResp] {
 
 	switch m := msg.(type) {
 	case *actor.RestartMessage:
+		// Restart carries no state to persist, so it does not Commit;
+		// the framework consumes it via the non-transactional ack path.
 		a.log.InfoS(ctx, "Ledger actor restarted")
 
 		return fn.Ok[LedgerResp](nil)
 
 	case *FeePaidMsg:
-		if err := a.handleFeePaid(ctx, m); err != nil {
-			a.logHandlerErr(
-				ctx, "Failed to handle fee paid", err,
-			)
-
-			return fn.Err[LedgerResp](err)
-		}
-
-		return fn.Ok[LedgerResp](nil)
+		return a.handleFeePaid(ctx, m, ax)
 
 	case *VTXOReceivedMsg:
-		if err := a.handleVTXOReceived(ctx, m); err != nil {
-			a.logHandlerErr(
-				ctx, "Failed to handle VTXO received", err,
-			)
-
-			return fn.Err[LedgerResp](err)
-		}
-
-		return fn.Ok[LedgerResp](nil)
+		return a.handleVTXOReceived(ctx, m, ax)
 
 	case *VTXOSentMsg:
-		if err := a.handleVTXOSent(ctx, m); err != nil {
-			a.logHandlerErr(
-				ctx, "Failed to handle VTXO sent", err,
-			)
-
-			return fn.Err[LedgerResp](err)
-		}
-
-		return fn.Ok[LedgerResp](nil)
+		return a.handleVTXOSent(ctx, m, ax)
 
 	case *ExitCostMsg:
-		if err := a.handleExitCost(ctx, m); err != nil {
-			a.logHandlerErr(
-				ctx, "Failed to handle exit cost", err,
-			)
-
-			return fn.Err[LedgerResp](err)
-		}
-
-		return fn.Ok[LedgerResp](nil)
+		return a.handleExitCost(ctx, m, ax)
 
 	case *UTXOCreatedMsg:
-		if err := a.handleUTXOCreated(ctx, m); err != nil {
-			a.logHandlerErr(
-				ctx, "Failed to handle UTXO created", err,
-			)
-
-			return fn.Err[LedgerResp](err)
-		}
-
-		return fn.Ok[LedgerResp](nil)
+		return a.handleUTXOCreated(ctx, m, ax)
 
 	case *UTXOSpentMsg:
-		if err := a.handleUTXOSpent(ctx, m); err != nil {
-			a.logHandlerErr(
-				ctx, "Failed to handle UTXO spent", err,
-			)
-
-			return fn.Err[LedgerResp](err)
-		}
-
-		return fn.Ok[LedgerResp](nil)
+		return a.handleUTXOSpent(ctx, m, ax)
 
 	default:
 		return fn.Err[LedgerResp](
@@ -514,4 +508,40 @@ func (a *LedgerActor) Receive(ctx context.Context,
 				ErrInvalidMessage, msg),
 		)
 	}
+}
+
+// fail logs a pre-Commit handler failure (validation or message-building) and
+// returns it as the result. These failures happen before any Commit, so they
+// do not flow through commit's logging below; logging here keeps the operator
+// view uniform. ErrLeaseLost never originates from this path.
+func (a *LedgerActor) fail(ctx context.Context, errMsg string,
+	err error) fn.Result[LedgerResp] {
+
+	a.logHandlerErr(ctx, errMsg, err)
+
+	return fn.Err[LedgerResp](err)
+}
+
+// commit runs the write closure inside one lease-fenced Commit transaction and
+// maps the outcome to a LedgerResp result. Handlers do their validation and
+// entry construction BEFORE calling commit, so the closure passed here contains
+// only the persistence (InsertLedgerEntry / InsertUTXOAuditEntry) and the
+// writer lock is held for nothing else. Commit failures are logged at WarnS via
+// logHandlerErr. A lost lease (ErrLeaseLost) is not a handler fault -- the
+// message was reclaimed and reprocessed elsewhere -- so it is returned without
+// the handler-error log; the framework's retry path takes over.
+func (a *LedgerActor) commit(ctx context.Context, ax actor.Exec[ledgerTx],
+	errMsg string,
+	write func(ctx context.Context, q ledgerTx) error,
+) fn.Result[LedgerResp] {
+
+	if err := ax.Commit(ctx, write); err != nil {
+		if !errors.Is(err, actor.ErrLeaseLost) {
+			a.logHandlerErr(ctx, errMsg, err)
+		}
+
+		return fn.Err[LedgerResp](err)
+	}
+
+	return fn.Ok[LedgerResp](nil)
 }

--- a/ledger/handlers.go
+++ b/ledger/handlers.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
 // zeroRoundID is the zero value used to detect empty round IDs.
@@ -41,8 +43,14 @@ func sessionIDOrNil(id [32]byte) []byte {
 // during boarding or refresh are debited from fees_paid and
 // credited to vtxo_balance (the fee reduces the client's VTXO
 // balance).
-func (a *LedgerActor) handleFeePaid(ctx context.Context,
-	msg *FeePaidMsg) error {
+//
+// Validation and entry construction run before Commit, with no writer
+// lock held; only the single InsertLedgerEntry runs inside the
+// lease-fenced Commit transaction.
+func (a *LedgerActor) handleFeePaid(ctx context.Context, msg *FeePaidMsg,
+	ax actor.Exec[ledgerTx]) fn.Result[LedgerResp] {
+
+	const errMsg = "Failed to handle fee paid"
 
 	// Reject non-positive amounts up front so a malformed TLV
 	// (e.g. a zero payload or a uint64 that decoded past
@@ -50,8 +58,11 @@ func (a *LedgerActor) handleFeePaid(ctx context.Context,
 	// hitting the SQL CHECK constraint and driving a durable
 	// retry loop on a permanent failure.
 	if msg.AmountSat <= 0 {
-		return fmt.Errorf("%w: FeePaidMsg amount_sat must be positive "+
-			"(got %d)", ErrInvalidMessage, msg.AmountSat)
+		return a.fail(
+			ctx, errMsg, fmt.Errorf("%w: FeePaidMsg amount_sat "+
+				"must be positive (got %d)", ErrInvalidMessage,
+				msg.AmountSat),
+		)
 	}
 
 	roundID := roundIDOrNil(msg.RoundID)
@@ -99,8 +110,10 @@ func (a *LedgerActor) handleFeePaid(ctx context.Context,
 		description = "boarding-sweep on-chain miner fee"
 
 	default:
-		return fmt.Errorf("%w: unknown fee type %q", ErrInvalidMessage,
-			msg.FeeType)
+		return a.fail(
+			ctx, errMsg, fmt.Errorf("%w: unknown fee type %q",
+				ErrInvalidMessage, msg.FeeType),
+		)
 	}
 
 	a.log.InfoS(ctx, "Recording fee payment",
@@ -112,18 +125,22 @@ func (a *LedgerActor) handleFeePaid(ctx context.Context,
 			uint64(msg.BlockHeight)),
 	)
 
-	return a.cfg.LedgerStore.InsertLedgerEntry(
-		ctx, LedgerEntry{
-			DebitAccount:   debitAccount,
-			CreditAccount:  creditAccount,
-			AmountSat:      msg.AmountSat,
-			RoundID:        roundID,
-			IdempotencyKey: idempotency,
-			EventType:      eventType,
-			Description:    description,
-			CreatedAt:      a.clk.Now().Unix(),
-		},
-	)
+	entry := LedgerEntry{
+		DebitAccount:   debitAccount,
+		CreditAccount:  creditAccount,
+		AmountSat:      msg.AmountSat,
+		RoundID:        roundID,
+		IdempotencyKey: idempotency,
+		EventType:      eventType,
+		Description:    description,
+		CreatedAt:      a.clk.Now().Unix(),
+	}
+
+	return a.commit(ctx, ax, errMsg, func(ctx context.Context,
+		q ledgerTx) error {
+
+		return q.ledger.InsertLedgerEntry(ctx, entry)
+	})
 }
 
 // handleVTXOReceived records a VTXO received by the client.
@@ -132,13 +149,18 @@ func (a *LedgerActor) handleFeePaid(ctx context.Context,
 // round receipts, the balance moves from wallet_balance to
 // vtxo_balance.
 func (a *LedgerActor) handleVTXOReceived(ctx context.Context,
-	msg *VTXOReceivedMsg) error {
+	msg *VTXOReceivedMsg, ax actor.Exec[ledgerTx]) fn.Result[LedgerResp] {
+
+	const errMsg = "Failed to handle VTXO received"
 
 	// Reject non-positive amounts up front; see handleFeePaid
 	// for the rationale.
 	if msg.AmountSat <= 0 {
-		return fmt.Errorf("%w: VTXOReceivedMsg amount_sat must be "+
-			"positive (got %d)", ErrInvalidMessage, msg.AmountSat)
+		return a.fail(
+			ctx, errMsg, fmt.Errorf("%w: VTXOReceivedMsg "+
+				"amount_sat must be positive (got %d)",
+				ErrInvalidMessage, msg.AmountSat),
+		)
 	}
 
 	roundID := roundIDOrNil(msg.RoundID)
@@ -192,8 +214,10 @@ func (a *LedgerActor) handleVTXOReceived(ctx context.Context,
 		creditAccount = AccountTransfersOut
 
 	default:
-		return fmt.Errorf("%w: unknown vtxo source %q",
-			ErrInvalidMessage, msg.Source)
+		return a.fail(
+			ctx, errMsg, fmt.Errorf("%w: unknown vtxo source %q",
+				ErrInvalidMessage, msg.Source),
+		)
 	}
 
 	// Per-VTXO idempotency key so multiple owned receives in
@@ -213,24 +237,28 @@ func (a *LedgerActor) handleVTXOReceived(ctx context.Context,
 	// issue #504.
 	chainVout := int32(msg.OutpointIndex)
 
-	return a.cfg.LedgerStore.InsertLedgerEntry(
-		ctx, LedgerEntry{
-			DebitAccount:  debitAccount,
-			CreditAccount: creditAccount,
-			AmountSat:     msg.AmountSat,
-			RoundID:       roundID,
-			EventType:     EventVTXOReceived,
-			Description: fmt.Sprintf(
-				"VTXO received via %s: %x:%d",
-				msg.Source, msg.OutpointHash,
-				msg.OutpointIndex,
-			),
-			CreatedAt:      a.clk.Now().Unix(),
-			IdempotencyKey: idempotencyKey,
-			ChainTxid:      msg.OutpointHash[:],
-			ChainVout:      &chainVout,
-		},
-	)
+	entry := LedgerEntry{
+		DebitAccount:  debitAccount,
+		CreditAccount: creditAccount,
+		AmountSat:     msg.AmountSat,
+		RoundID:       roundID,
+		EventType:     EventVTXOReceived,
+		Description: fmt.Sprintf(
+			"VTXO received via %s: %x:%d",
+			msg.Source, msg.OutpointHash,
+			msg.OutpointIndex,
+		),
+		CreatedAt:      a.clk.Now().Unix(),
+		IdempotencyKey: idempotencyKey,
+		ChainTxid:      msg.OutpointHash[:],
+		ChainVout:      &chainVout,
+	}
+
+	return a.commit(ctx, ax, errMsg, func(ctx context.Context,
+		q ledgerTx) error {
+
+		return q.ledger.InsertLedgerEntry(ctx, entry)
+	})
 }
 
 // handleVTXOSent records a VTXO leaving the client's balance,
@@ -241,14 +269,19 @@ func (a *LedgerActor) handleVTXOReceived(ctx context.Context,
 // is contradictory ("cannot route to both"). The counterparty
 // side is debited to transfers_out so gross send flows are
 // tracked independently of received flows.
-func (a *LedgerActor) handleVTXOSent(ctx context.Context,
-	msg *VTXOSentMsg) error {
+func (a *LedgerActor) handleVTXOSent(ctx context.Context, msg *VTXOSentMsg,
+	ax actor.Exec[ledgerTx]) fn.Result[LedgerResp] {
+
+	const errMsg = "Failed to handle VTXO sent"
 
 	// Reject non-positive amounts up front; see handleFeePaid
 	// for the rationale.
 	if msg.AmountSat <= 0 {
-		return fmt.Errorf("%w: VTXOSentMsg amount_sat must be "+
-			"positive (got %d)", ErrInvalidMessage, msg.AmountSat)
+		return a.fail(
+			ctx, errMsg, fmt.Errorf("%w: VTXOSentMsg amount_sat "+
+				"must be positive (got %d)", ErrInvalidMessage,
+				msg.AmountSat),
+		)
 	}
 
 	sessionID := sessionIDOrNil(msg.SessionID)
@@ -256,12 +289,18 @@ func (a *LedgerActor) handleVTXOSent(ctx context.Context,
 
 	switch {
 	case sessionID == nil && roundID == nil:
-		return fmt.Errorf("%w: VTXOSentMsg requires one of SessionID "+
-			"or RoundID to be non-zero", ErrInvalidMessage)
+		return a.fail(
+			ctx, errMsg, fmt.Errorf("%w: VTXOSentMsg requires "+
+				"one of SessionID or RoundID to be non-zero",
+				ErrInvalidMessage),
+		)
 
 	case sessionID != nil && roundID != nil:
-		return fmt.Errorf("%w: VTXOSentMsg cannot set both SessionID "+
-			"and RoundID", ErrInvalidMessage)
+		return a.fail(
+			ctx, errMsg, fmt.Errorf("%w: VTXOSentMsg cannot set "+
+				"both SessionID and RoundID",
+				ErrInvalidMessage),
+		)
 	}
 
 	a.log.InfoS(ctx, "Recording VTXO sent",
@@ -294,19 +333,23 @@ func (a *LedgerActor) handleVTXOSent(ctx context.Context,
 		)
 	}
 
-	return a.cfg.LedgerStore.InsertLedgerEntry(
-		ctx, LedgerEntry{
-			DebitAccount:   AccountTransfersOut,
-			CreditAccount:  AccountVTXOBalance,
-			AmountSat:      msg.AmountSat,
-			SessionID:      sessionID,
-			RoundID:        roundID,
-			EventType:      EventVTXOSent,
-			Description:    description,
-			CreatedAt:      a.clk.Now().Unix(),
-			IdempotencyKey: idempotencyKey,
-		},
-	)
+	entry := LedgerEntry{
+		DebitAccount:   AccountTransfersOut,
+		CreditAccount:  AccountVTXOBalance,
+		AmountSat:      msg.AmountSat,
+		SessionID:      sessionID,
+		RoundID:        roundID,
+		EventType:      EventVTXOSent,
+		Description:    description,
+		CreatedAt:      a.clk.Now().Unix(),
+		IdempotencyKey: idempotencyKey,
+	}
+
+	return a.commit(ctx, ax, errMsg, func(ctx context.Context,
+		q ledgerTx) error {
+
+		return q.ledger.InsertLedgerEntry(ctx, entry)
+	})
 }
 
 // zeroHash is a convenience sentinel for detecting an absent
@@ -336,8 +379,10 @@ var zeroHash chainhash.Hash
 //
 // On-chain wallet side is intentionally not booked here: the
 // wallet_utxo_log audit trail covers wallet_balance changes.
-func (a *LedgerActor) handleExitCost(ctx context.Context,
-	msg *ExitCostMsg) error {
+func (a *LedgerActor) handleExitCost(ctx context.Context, msg *ExitCostMsg,
+	ax actor.Exec[ledgerTx]) fn.Result[LedgerResp] {
+
+	const errMsg = "Failed to handle exit cost"
 
 	a.log.InfoS(ctx, "Recording exit cost",
 		slog.String(
@@ -355,16 +400,22 @@ func (a *LedgerActor) handleExitCost(ctx context.Context,
 	// to record and the amount_sat > 0 CHECK would reject it
 	// anyway; fail fast with a clear error instead.
 	if msg.ExitCostSat <= 0 || msg.AmountSat <= 0 {
-		return fmt.Errorf("%w: exit cost requires positive amount_sat "+
-			"and exit_cost_sat (got %d, %d)", ErrInvalidMessage,
-			msg.AmountSat, msg.ExitCostSat)
+		return a.fail(
+			ctx, errMsg, fmt.Errorf("%w: exit cost requires "+
+				"positive amount_sat and exit_cost_sat "+
+				"(got %d, %d)", ErrInvalidMessage,
+				msg.AmountSat, msg.ExitCostSat),
+		)
 	}
 
 	if msg.ExitCostSat >= msg.AmountSat {
-		return fmt.Errorf("%w: exit cost %d exceeds or equals VTXO "+
-			"amount %d for %x:%d", ErrInvalidMessage,
-			msg.ExitCostSat, msg.AmountSat, msg.OutpointHash,
-			msg.OutpointIndex)
+		return a.fail(
+			ctx, errMsg, fmt.Errorf("%w: exit cost %d exceeds or "+
+				"equals VTXO amount %d for %x:%d",
+				ErrInvalidMessage, msg.ExitCostSat,
+				msg.AmountSat, msg.OutpointHash,
+				msg.OutpointIndex),
+		)
 	}
 
 	now := a.clk.Now().Unix()
@@ -403,29 +454,27 @@ func (a *LedgerActor) handleExitCost(ctx context.Context,
 		IdempotencyKey: idempotencyKey,
 	}
 
-	// Book the send leg and the fee leg via two separate
-	// InsertLedgerEntry calls. Both join the durable actor's
-	// outer delivery transaction (db.TransactionExecutor.ExecTx
-	// picks up the tx from ctx via actor.TxFromContext), so a
-	// crash or error between the two calls rolls back both
-	// writes and the mailbox ack together -- no partial-write
-	// window. The shared outpoint-derived IdempotencyKey makes
-	// an out-of-band replay resolve to a silent no-op via the
-	// partial unique index idx_client_ledger_idempotent_key and
-	// the ON CONFLICT DO NOTHING clause on the insert query.
-	if err := a.cfg.LedgerStore.InsertLedgerEntry(
-		ctx, sendLeg,
-	); err != nil {
-		return fmt.Errorf("exit send leg: %w", err)
-	}
+	// Book the send leg and the fee leg via two InsertLedgerEntry
+	// calls inside ONE Commit. Both join the same lease-fenced writer
+	// transaction, so a crash or error between them rolls back both
+	// writes and the mailbox ack together -- no partial-write window.
+	// The shared outpoint-derived IdempotencyKey makes an out-of-band
+	// replay resolve to a silent no-op via the partial unique index
+	// idx_client_ledger_idempotent_key and the ON CONFLICT DO NOTHING
+	// clause on the insert query.
+	return a.commit(ctx, ax, errMsg, func(ctx context.Context,
+		q ledgerTx) error {
 
-	if err := a.cfg.LedgerStore.InsertLedgerEntry(
-		ctx, feeLeg,
-	); err != nil {
-		return fmt.Errorf("exit fee leg: %w", err)
-	}
+		if err := q.ledger.InsertLedgerEntry(ctx, sendLeg); err != nil {
+			return fmt.Errorf("exit send leg: %w", err)
+		}
 
-	return nil
+		if err := q.ledger.InsertLedgerEntry(ctx, feeLeg); err != nil {
+			return fmt.Errorf("exit fee leg: %w", err)
+		}
+
+		return nil
+	})
 }
 
 // exitIdempotencyKey derives the outpoint-scoped dedup key used on
@@ -477,7 +526,9 @@ func exitIdempotencyKey(hash [32]byte, index uint32) []byte {
 // (wire enforces MaxSatoshi bounds on tx outputs) but the guard
 // closes the last corruption gap on the TLV decode path.
 func (a *LedgerActor) handleUTXOCreated(ctx context.Context,
-	msg *UTXOCreatedMsg) error {
+	msg *UTXOCreatedMsg, ax actor.Exec[ledgerTx]) fn.Result[LedgerResp] {
+
+	const errMsg = "Failed to handle UTXO created"
 
 	a.log.InfoS(ctx, "Recording UTXO created",
 		slog.String(
@@ -491,55 +542,65 @@ func (a *LedgerActor) handleUTXOCreated(ctx context.Context,
 			msg.Classification),
 	)
 
+	// UTXOAuditStore is optional: in log-only mode there is nothing to
+	// persist, so consume the message without opening a Commit.
 	if a.cfg.UTXOAuditStore == nil {
-		return nil
+		return fn.Ok[LedgerResp](nil)
 	}
 
 	if msg.AmountSat <= 0 {
-		return fmt.Errorf("%w: UTXOCreatedMsg amount_sat must be "+
-			"positive (got %d)", ErrInvalidMessage, msg.AmountSat)
+		return a.fail(
+			ctx, errMsg, fmt.Errorf("%w: UTXOCreatedMsg "+
+				"amount_sat must be positive (got %d)",
+				ErrInvalidMessage, msg.AmountSat),
+		)
 	}
 
 	now := a.clk.Now().Unix()
 	chainVout := int32(msg.OutpointIndex)
 	confirmationHeight := int32(msg.BlockHeight)
 
-	err := a.cfg.UTXOAuditStore.InsertUTXOAuditEntry(
-		ctx, UTXOAuditEntry{
-			OutpointHash:  msg.OutpointHash[:],
-			OutpointIndex: int32(msg.OutpointIndex),
-			AmountSat:     msg.AmountSat,
-			Event:         "created",
-			BlockHeight:   int32(msg.BlockHeight),
-			ClassifiedAs:  msg.Classification,
-			CreatedAt:     now,
-		},
-	)
-	if err != nil {
-		return err
+	audit := UTXOAuditEntry{
+		OutpointHash:  msg.OutpointHash[:],
+		OutpointIndex: int32(msg.OutpointIndex),
+		AmountSat:     msg.AmountSat,
+		Event:         "created",
+		BlockHeight:   int32(msg.BlockHeight),
+		ClassifiedAs:  msg.Classification,
+		CreatedAt:     now,
 	}
 
-	return a.cfg.LedgerStore.InsertLedgerEntry(
-		ctx, LedgerEntry{
-			DebitAccount:  AccountWalletBalance,
-			CreditAccount: AccountOpeningBalance,
-			AmountSat:     msg.AmountSat,
-			EventType:     EventWalletUTXOCreated,
-			Description: fmt.Sprintf(
-				"wallet UTXO confirmed at %x:%d "+
-					"(classification %s) at height %d",
-				msg.OutpointHash, msg.OutpointIndex,
-				msg.Classification, msg.BlockHeight,
-			),
-			CreatedAt: now,
-			IdempotencyKey: walletUTXOIdempotencyKey(
-				msg.OutpointHash, msg.OutpointIndex,
-			),
-			ChainTxid:          msg.OutpointHash[:],
-			ChainVout:          &chainVout,
-			ConfirmationHeight: &confirmationHeight,
-		},
-	)
+	entry := LedgerEntry{
+		DebitAccount:  AccountWalletBalance,
+		CreditAccount: AccountOpeningBalance,
+		AmountSat:     msg.AmountSat,
+		EventType:     EventWalletUTXOCreated,
+		Description: fmt.Sprintf(
+			"wallet UTXO confirmed at %x:%d "+
+				"(classification %s) at height %d",
+			msg.OutpointHash, msg.OutpointIndex,
+			msg.Classification, msg.BlockHeight,
+		),
+		CreatedAt: now,
+		IdempotencyKey: walletUTXOIdempotencyKey(
+			msg.OutpointHash, msg.OutpointIndex,
+		),
+		ChainTxid:          msg.OutpointHash[:],
+		ChainVout:          &chainVout,
+		ConfirmationHeight: &confirmationHeight,
+	}
+
+	// The audit row and the ledger deposit leg commit together in one
+	// lease-fenced transaction.
+	return a.commit(ctx, ax, errMsg, func(ctx context.Context,
+		q ledgerTx) error {
+
+		if err := q.audit.InsertUTXOAuditEntry(ctx, audit); err != nil {
+			return err
+		}
+
+		return q.ledger.InsertLedgerEntry(ctx, entry)
+	})
 }
 
 // walletUTXOIdempotencyKey derives the outpoint-scoped dedup key
@@ -561,8 +622,10 @@ func walletUTXOIdempotencyKey(hash [32]byte, index uint32) []byte {
 // handleUTXOSpent records a spent wallet UTXO in the audit log.
 // The classification is provided by the sending subsystem (e.g.
 // round actor classifies as "round_funding").
-func (a *LedgerActor) handleUTXOSpent(ctx context.Context,
-	msg *UTXOSpentMsg) error {
+func (a *LedgerActor) handleUTXOSpent(ctx context.Context, msg *UTXOSpentMsg,
+	ax actor.Exec[ledgerTx]) fn.Result[LedgerResp] {
+
+	const errMsg = "Failed to handle UTXO spent"
 
 	a.log.InfoS(ctx, "Recording UTXO spent",
 		slog.String(
@@ -576,19 +639,25 @@ func (a *LedgerActor) handleUTXOSpent(ctx context.Context,
 			msg.Classification),
 	)
 
+	// UTXOAuditStore is optional: in log-only mode there is nothing to
+	// persist, so consume the message without opening a Commit.
 	if a.cfg.UTXOAuditStore == nil {
-		return nil
+		return fn.Ok[LedgerResp](nil)
 	}
 
-	return a.cfg.UTXOAuditStore.InsertUTXOAuditEntry(
-		ctx, UTXOAuditEntry{
-			OutpointHash:  msg.OutpointHash[:],
-			OutpointIndex: int32(msg.OutpointIndex),
-			AmountSat:     msg.AmountSat,
-			Event:         "spent",
-			BlockHeight:   int32(msg.BlockHeight),
-			ClassifiedAs:  msg.Classification,
-			CreatedAt:     a.clk.Now().Unix(),
-		},
-	)
+	audit := UTXOAuditEntry{
+		OutpointHash:  msg.OutpointHash[:],
+		OutpointIndex: int32(msg.OutpointIndex),
+		AmountSat:     msg.AmountSat,
+		Event:         "spent",
+		BlockHeight:   int32(msg.BlockHeight),
+		ClassifiedAs:  msg.Classification,
+		CreatedAt:     a.clk.Now().Unix(),
+	}
+
+	return a.commit(ctx, ax, errMsg, func(ctx context.Context,
+		q ledgerTx) error {
+
+		return q.audit.InsertUTXOAuditEntry(ctx, audit)
+	})
 }

--- a/ledger/handlers_test.go
+++ b/ledger/handlers_test.go
@@ -130,6 +130,38 @@ func newTestActorWithAudit(t *testing.T) (*LedgerActor, *mockLedgerStore,
 	return a, ledgerStore, auditStore
 }
 
+// fakeExec is a synchronous Exec[ledgerTx] for handler unit tests. It runs
+// Read/Commit closures immediately against the actor's stores, with no real
+// transaction or lease fence, so a handler's build-then-Commit flow can be
+// exercised without standing up a durable mailbox.
+type fakeExec struct {
+	store ledgerTx
+}
+
+// Read runs fn against the actor's stores.
+func (e fakeExec) Read(ctx context.Context,
+	fn func(context.Context, ledgerTx) error) error {
+
+	return fn(ctx, e.store)
+}
+
+// Commit runs fn against the actor's stores.
+func (e fakeExec) Commit(ctx context.Context,
+	fn func(context.Context, ledgerTx) error) error {
+
+	return fn(ctx, e.store)
+}
+
+// run drives a message through the actor's Receive with a synchronous fake
+// Exec and returns the handler error. The insert closures execute against the
+// actor's mock stores, so the existing store-based assertions still hold while
+// the validation/build work runs (as in production) outside any transaction.
+func run(ctx context.Context, a *LedgerActor, msg LedgerMsg) error {
+	ax := fakeExec{store: a.bindStores(ctx, nil)}
+
+	return a.Receive(ctx, msg, ax).Err()
+}
+
 // TestHandleFeePaidBoarding verifies that a boarding fee is
 // recorded with the correct accounts and event type.
 func TestHandleFeePaidBoarding(t *testing.T) {
@@ -149,7 +181,7 @@ func TestHandleFeePaidBoarding(t *testing.T) {
 		BlockHeight: 800_000,
 	}
 
-	err := a.handleFeePaid(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 
 	entries := store.getEntries()
@@ -181,7 +213,7 @@ func TestHandleFeePaidRefresh(t *testing.T) {
 		BlockHeight: 800_100,
 	}
 
-	err := a.handleFeePaid(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 
 	entries := store.getEntries()
@@ -213,7 +245,7 @@ func TestHandleFeePaidOnchainSweep(t *testing.T) {
 		IdempotencyKey: append([]byte(nil), sweepTxid[:]...),
 	}
 
-	err := a.handleFeePaid(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 
 	entries := store.getEntries()
@@ -249,7 +281,7 @@ func TestHandleFeePaidOnchainSweepRejectsZeroAmount(t *testing.T) {
 		BlockHeight: 800_700,
 	}
 
-	err := a.handleFeePaid(ctx, msg)
+	err := run(ctx, a, msg)
 	require.ErrorIs(t, err, ErrInvalidMessage)
 }
 
@@ -277,7 +309,7 @@ func TestHandleVTXOReceivedRoundBoarding(t *testing.T) {
 		},
 	}
 
-	err := a.handleVTXOReceived(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 
 	entries := store.getEntries()
@@ -329,7 +361,7 @@ func TestHandleVTXOReceivedRoundTransfer(t *testing.T) {
 		},
 	}
 
-	err := a.handleVTXOReceived(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 
 	entries := store.getEntries()
@@ -369,7 +401,7 @@ func TestHandleVTXOReceivedRoundRefresh(t *testing.T) {
 		},
 	}
 
-	err := a.handleVTXOReceived(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 
 	entries := store.getEntries()
@@ -411,8 +443,8 @@ func TestRefreshRoundNetsToFeeOnVTXOBalance(t *testing.T) {
 	// RoundID set.
 	require.NoError(
 		t,
-		a.handleVTXOSent(
-			ctx, &VTXOSentMsg{
+		run(
+			ctx, a, &VTXOSentMsg{
 				RoundID:   roundID,
 				AmountSat: gross,
 			},
@@ -422,8 +454,8 @@ func TestRefreshRoundNetsToFeeOnVTXOBalance(t *testing.T) {
 	// Leg 2: new VTXO materializes with Source=SourceRoundRefresh.
 	require.NoError(
 		t,
-		a.handleVTXOReceived(
-			ctx, &VTXOReceivedMsg{
+		run(
+			ctx, a, &VTXOReceivedMsg{
 				OutpointHash:  [32]byte{0x01},
 				OutpointIndex: 0,
 				AmountSat:     gross,
@@ -436,8 +468,8 @@ func TestRefreshRoundNetsToFeeOnVTXOBalance(t *testing.T) {
 	// Leg 3: the operator fee for the refresh round.
 	require.NoError(
 		t,
-		a.handleFeePaid(
-			ctx, &FeePaidMsg{
+		run(
+			ctx, a, &FeePaidMsg{
 				RoundID:     roundID,
 				AmountSat:   fee,
 				FeeType:     FeeTypeRefresh,
@@ -499,7 +531,7 @@ func TestHandleVTXOReceivedOOR(t *testing.T) {
 		},
 	}
 
-	err := a.handleVTXOReceived(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 
 	entries := store.getEntries()
@@ -527,7 +559,7 @@ func TestHandleVTXOSent(t *testing.T) {
 		AmountSat: 10_000,
 	}
 
-	err := a.handleVTXOSent(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 
 	entries := store.getEntries()
@@ -566,7 +598,7 @@ func TestHandleVTXOSentInRound(t *testing.T) {
 		AmountSat: 25_000,
 	}
 
-	err := a.handleVTXOSent(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 
 	entries := store.getEntries()
@@ -595,7 +627,7 @@ func TestHandleVTXOSentNeitherSet(t *testing.T) {
 		AmountSat: 1,
 	}
 
-	err := a.handleVTXOSent(ctx, msg)
+	err := run(ctx, a, msg)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInvalidMessage)
 	require.Contains(t, err.Error(),
@@ -622,7 +654,7 @@ func TestHandleVTXOSentBothSet(t *testing.T) {
 		AmountSat: 1,
 	}
 
-	err := a.handleVTXOSent(ctx, msg)
+	err := run(ctx, a, msg)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInvalidMessage)
 	require.Contains(
@@ -653,7 +685,12 @@ func TestHandleVTXOSendReceiveAreGross(t *testing.T) {
 			1,
 		},
 	}
-	require.NoError(t, a.handleVTXOReceived(ctx, recv))
+	require.NoError(
+		t,
+		run(
+			ctx, a, recv,
+		),
+	)
 
 	sent := &VTXOSentMsg{
 		SessionID: [32]byte{
@@ -661,7 +698,7 @@ func TestHandleVTXOSendReceiveAreGross(t *testing.T) {
 		},
 		AmountSat: 10_000,
 	}
-	require.NoError(t, a.handleVTXOSent(ctx, sent))
+	require.NoError(t, run(ctx, a, sent))
 
 	entries := store.getEntries()
 	require.Len(t, entries, 2)
@@ -694,7 +731,7 @@ func TestHandleExitCost(t *testing.T) {
 		BlockHeight:   800_500,
 	}
 
-	err := a.handleExitCost(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 
 	entries := store.getEntries()
@@ -744,7 +781,7 @@ func TestHandleExitCostFeeExceedsValue(t *testing.T) {
 		BlockHeight:   800_600,
 	}
 
-	err := a.handleExitCost(ctx, msg)
+	err := run(ctx, a, msg)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInvalidMessage)
 	require.Contains(
@@ -828,7 +865,7 @@ func TestHandleExitCostWritesBothLegsWithSharedKey(t *testing.T) {
 		BlockHeight:   800_800,
 	}
 
-	err := a.handleExitCost(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 
 	entries := store.getEntries()
@@ -891,12 +928,12 @@ func TestHandleExitCostReplayIsIdempotent(t *testing.T) {
 	}
 
 	// First delivery persists both legs.
-	require.NoError(t, a.handleExitCost(ctx, msg))
+	require.NoError(t, run(ctx, a, msg))
 	require.Len(t, store.getEntries(), 2)
 
 	// Second delivery of the identical message is the
 	// at-least-once replay scenario. Row count must not grow.
-	require.NoError(t, a.handleExitCost(ctx, msg))
+	require.NoError(t, run(ctx, a, msg))
 	require.Len(
 		t, store.getEntries(), 2,
 		"replay must not double-book ledger entries",
@@ -908,7 +945,12 @@ func TestHandleExitCostReplayIsIdempotent(t *testing.T) {
 	// only on account pairs.
 	other := *msg
 	other.OutpointIndex = 8
-	require.NoError(t, a.handleExitCost(ctx, &other))
+	require.NoError(
+		t,
+		run(
+			ctx, a, &other,
+		),
+	)
 	require.Len(
 		t, store.getEntries(), 4,
 		"distinct outpoint must not be deduped",
@@ -983,7 +1025,9 @@ func TestHandleExitCostInvalidAmounts(t *testing.T) {
 				BlockHeight:   800_700,
 			}
 
-			err := a.handleExitCost(ctx, msg)
+			err := run(
+				ctx, a, msg,
+			)
 			require.Error(t, err)
 			require.ErrorIs(t, err, ErrInvalidMessage)
 			require.Contains(t, err.Error(), tc.contain)
@@ -1019,7 +1063,7 @@ func TestDBErrorDoesNotWrapErrInvalidMessage(t *testing.T) {
 		BlockHeight: 1,
 	}
 
-	err := a.handleFeePaid(t.Context(), msg)
+	err := run(t.Context(), a, msg)
 	require.Error(t, err)
 	require.ErrorIs(t, err, dbErr)
 	require.NotErrorIs(t, err, ErrInvalidMessage)
@@ -1061,11 +1105,13 @@ func TestHandleNonPositiveAmounts(t *testing.T) {
 			run: func(ctx context.Context, a *LedgerActor,
 				amt int64) error {
 
-				return a.handleFeePaid(ctx, &FeePaidMsg{
-					RoundID:   [16]byte{1},
-					AmountSat: amt,
-					FeeType:   FeeTypeBoarding,
-				})
+				return run(
+					ctx, a, &FeePaidMsg{
+						RoundID:   [16]byte{1},
+						AmountSat: amt,
+						FeeType:   FeeTypeBoarding,
+					},
+				)
 			},
 		},
 		{
@@ -1073,8 +1119,8 @@ func TestHandleNonPositiveAmounts(t *testing.T) {
 			run: func(ctx context.Context, a *LedgerActor,
 				amt int64) error {
 
-				return a.handleVTXOReceived(
-					ctx, &VTXOReceivedMsg{
+				return run(
+					ctx, a, &VTXOReceivedMsg{
 						OutpointHash: [32]byte{1},
 						AmountSat:    amt,
 						Source:       SourceOOR,
@@ -1087,8 +1133,8 @@ func TestHandleNonPositiveAmounts(t *testing.T) {
 			run: func(ctx context.Context, a *LedgerActor,
 				amt int64) error {
 
-				return a.handleVTXOSent(
-					ctx, &VTXOSentMsg{
+				return run(
+					ctx, a, &VTXOSentMsg{
 						SessionID: [32]byte{1},
 						AmountSat: amt,
 					},
@@ -1184,7 +1230,7 @@ func TestHandleFeePaidUnknownType(t *testing.T) {
 		BlockHeight: 800_000,
 	}
 
-	err := a.handleFeePaid(ctx, msg)
+	err := run(ctx, a, msg)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInvalidMessage)
 	require.Contains(t, err.Error(), "unknown fee type")
@@ -1216,7 +1262,7 @@ func TestHandleVTXOReceivedUnknownSource(t *testing.T) {
 		},
 	}
 
-	err := a.handleVTXOReceived(ctx, msg)
+	err := run(ctx, a, msg)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInvalidMessage)
 	require.Contains(t, err.Error(), "unknown vtxo source")
@@ -1248,7 +1294,7 @@ func TestHandleUTXOCreated(t *testing.T) {
 		Classification: ClassificationDeposit,
 	}
 
-	err := a.handleUTXOCreated(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 
 	// Audit-log side: the wallet_utxo_log row is still written.
@@ -1297,13 +1343,15 @@ func TestHandleUTXOCreatedRejectsNonPositive(t *testing.T) {
 	ctx := t.Context()
 
 	for _, amt := range []int64{0, -1, -50_000} {
-		err := a.handleUTXOCreated(ctx, &UTXOCreatedMsg{
-			OutpointHash:   [32]byte{0xde},
-			OutpointIndex:  0,
-			AmountSat:      amt,
-			BlockHeight:    800_000,
-			Classification: ClassificationDeposit,
-		})
+		err := run(
+			ctx, a, &UTXOCreatedMsg{
+				OutpointHash:   [32]byte{0xde},
+				OutpointIndex:  0,
+				AmountSat:      amt,
+				BlockHeight:    800_000,
+				Classification: ClassificationDeposit,
+			},
+		)
 		require.ErrorIs(t, err, ErrInvalidMessage)
 	}
 
@@ -1330,7 +1378,7 @@ func TestHandleUTXOSpent(t *testing.T) {
 		Classification: ClassificationRoundFunding,
 	}
 
-	err := a.handleUTXOSpent(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 
 	entries := auditStore.getEntries()
@@ -1372,8 +1420,8 @@ func TestBoardingRoundNetsToOpeningBalanceAndVTXO(t *testing.T) {
 	// Leg 1: wallet UTXO confirms.
 	require.NoError(
 		t,
-		a.handleUTXOCreated(
-			ctx, &UTXOCreatedMsg{
+		run(
+			ctx, a, &UTXOCreatedMsg{
 				OutpointHash:   outpoint,
 				OutpointIndex:  3,
 				AmountSat:      amount,
@@ -1387,8 +1435,8 @@ func TestBoardingRoundNetsToOpeningBalanceAndVTXO(t *testing.T) {
 	// VTXO with Source=SourceRoundBoarding.
 	require.NoError(
 		t,
-		a.handleVTXOReceived(
-			ctx, &VTXOReceivedMsg{
+		run(
+			ctx, a, &VTXOReceivedMsg{
 				OutpointHash:  [32]byte{0x22},
 				OutpointIndex: 0,
 				AmountSat:     amount,
@@ -1450,7 +1498,7 @@ func TestHandleUTXOCreatedNoAuditStore(t *testing.T) {
 	}
 
 	// Should not error even without UTXOAuditStore.
-	err := a.handleUTXOCreated(ctx, msg)
+	err := run(ctx, a, msg)
 	require.NoError(t, err)
 }
 

--- a/oor/actor.go
+++ b/oor/actor.go
@@ -253,7 +253,12 @@ func NewOORClientActor(cfg ClientActorCfg) *OORClientActor {
 	)
 	durableCfg.Log = cfg.Log
 
-	durable := actor.NewDurableActor(durableCfg)
+	durable, err := actor.NewDurableActor(durableCfg).Unpack()
+	if err != nil {
+		actorRef.startupErr = err
+
+		return actorRef
+	}
 	actorRef.durable = durable
 	actorRef.ref = durable.Ref()
 

--- a/oor/signing_effect_actor.go
+++ b/oor/signing_effect_actor.go
@@ -269,7 +269,11 @@ func NewSigningEffectActor(cfg SigningEffectActorConfig) (*SigningEffectActor,
 	)
 	durableCfg.Log = cfg.Log
 
-	effect.durable = actor.NewDurableActor(durableCfg)
+	durable, err := actor.NewDurableActor(durableCfg).Unpack()
+	if err != nil {
+		return nil, err
+	}
+	effect.durable = durable
 	effect.durable.Start()
 
 	if cfg.ActorSystem != nil {

--- a/p-models/durableactor/CLAUDE.md
+++ b/p-models/durableactor/CLAUDE.md
@@ -2,8 +2,9 @@
 
 This package models the durable actor mailbox from distributed-systems first
 principles: durable enqueue, lease ownership, retry scheduling, ack/nack token
-validation, dead-letter/removal, idempotent delivery identity, and
-per-correlation-key FIFO.
+validation, dead-letter/removal, idempotent delivery identity,
+per-correlation-key FIFO, and the Read/Commit consume step (lease-fenced
+exactly-once effect application under lease-expiry-during-IO).
 
 ## Files
 
@@ -22,7 +23,9 @@ per-correlation-key FIFO.
 | `./p-models/scripts/check.sh` | Full default check: P model plus Go bridge |
 | `p compile -pp p-models/durableactor/infra.pproj` | Compile this model |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxCorrelationKeyFIFO` | Run green durable mailbox tests |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxReadCommitFence` | Run the green Read/Commit exactly-once-effect test |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxLegacyReorderCounterexample` | Demonstrate the old ordering bug |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxUnfencedCommitCounterexample` | Demonstrate the unfenced-commit double-apply bug |
 | `go test ./p-models/durableactor/bridge` | Replay traces against Go |
 
 ## Modeling Guidance

--- a/p-models/durableactor/README.md
+++ b/p-models/durableactor/README.md
@@ -18,10 +18,25 @@ that matter for the bug:
 `src/mailbox_fifo.p` keeps both the old available-at ordering profile and the
 new per-correlation-key FIFO profile. It also includes a stateful
 `DurableMailboxSpec` machine with token ownership, lease expiry, nack retry,
-idempotent enqueue, ack deletion, and dead-letter removal semantics. The test
-suite proves that the legacy profile permits a same-key overtake after a
-nack/backoff, while the new profile blocks same-key overtakes without blocking
-other keys, other mailboxes, or unkeyed rows.
+idempotent enqueue, ack deletion, dead-letter removal, and the durable actor's
+Read/Commit consume step (`eDurableMailboxCommit`). The test suite proves that
+the legacy profile permits a same-key overtake after a nack/backoff, while the
+new profile blocks same-key overtakes without blocking other keys, other
+mailboxes, or unkeyed rows.
+
+### Read/Commit consume step
+
+`eDurableMailboxCommit` models the durable actor's Read/Commit execution path
+(`baselib/actor`): a behavior does its side-effect IO outside the writer
+transaction, then Commit folds the behavior effect, the dedup mark, and the
+lease-fenced ack into one atomic unit. The model exercises the scenario the
+fence exists for: a consumer leases a row and starts IO, its lease expires
+mid-IO, and a second consumer reclaims and reprocesses the same row. Under the
+fenced design the first consumer's stale Commit is an `ErrLeaseLost` no-op, so
+the behavior effect is applied exactly once. The `fenced` flag on the commit
+request also selects an unfenced profile for the counterexample, where the
+effect is applied regardless of the lease token and a stale consumer
+double-applies it under reclaim.
 
 ### Spec monitors
 
@@ -45,6 +60,17 @@ globally; each test case attaches the ones it wants with `assert <spec> in
   driver enqueues a same-key pair plus a cross-key row, then leases-and-acks in
   a loop; a model in which a row could never be claimed would leave the monitor
   hot forever. It is checked by `tcMailboxLiveness`.
+- `LeaseFencedCommitAppliesEffectAtMostOnce` is the safety contract for the
+  Read/Commit consume step: a row's behavior effect must be applied at most once
+  even when its lease expires mid-IO and the row is reclaimed and reprocessed.
+  `tcMailboxReadCommitFence` checks the fenced design holds it; the negative
+  `tcMailboxUnfencedCommitCounterexample` runs the unfenced profile with no
+  in-machine assertion, so the double-apply is raised solely by this monitor.
+  This monitor deliberately verifies the lease fence is sufficient *in
+  isolation*: it does not model the receiver-side `ON CONFLICT (id) DO NOTHING`
+  dedup that production also has as a downstream backstop. That omission is
+  intentional (it proves the fence alone enforces exactly-once at the source);
+  it is not a claim that the downstream dedup is unnecessary in every flow.
 
 The Go bridge in `bridge/` replays JSON model traces from `traces/` against the real
 `db/actordelivery` SQLite store. This keeps the P model tied to the SQL claim

--- a/p-models/durableactor/bridge/mailbox_trace.go
+++ b/p-models/durableactor/bridge/mailbox_trace.go
@@ -1,8 +1,10 @@
 package bridge
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +18,15 @@ import (
 	"github.com/lightninglabs/darepo-client/db/sqlc"
 	"github.com/lightningnetwork/lnd/clock"
 	_ "modernc.org/sqlite"
+)
+
+// commitActorID and commitDedupTTL are the dedup-mark identity and retention a
+// commit trace op writes via MarkProcessed inside the fenced commit
+// transaction. They live at package scope so any future trace op that also
+// records dedup state shares the same actor id and TTL as commit.
+const (
+	commitActorID  = "model.TraceActor"
+	commitDedupTTL = time.Hour
 )
 
 // MailboxTrace is a model trace that can be replayed against the real durable
@@ -53,6 +64,12 @@ type MailboxTraceEvent struct {
 	// assert that intent at the enqueue step itself, rather than relying
 	// solely on a downstream lease assertion to observe the no-op.
 	ExpectDuplicate bool `json:"expect_duplicate,omitempty"`
+
+	// ExpectProcessed asserts the dedup state of the row after a commit op.
+	// A fenced commit that consumes the row marks it processed; a stale
+	// (ErrLeaseLost) commit rolls the dedup mark back, leaving it
+	// unprocessed. Nil leaves the dedup state unchecked.
+	ExpectProcessed *bool `json:"expect_processed,omitempty"`
 }
 
 // ParseMailboxTrace parses one mailbox model trace from disk.
@@ -142,6 +159,9 @@ func ReplayMailboxTrace(t *testing.T, trace *MailboxTrace) {
 
 		case "ack":
 			replayAck(t, store, event)
+
+		case "commit":
+			replayCommit(t, store, event)
 
 		case "dead_letter":
 			replayDeadLetter(t, store, event)
@@ -264,6 +284,70 @@ func replayAck(t *testing.T, store actor.TxAwareDeliveryStore,
 	)
 	requireNoError(t, err)
 	requireExpectedRows(t, rows, event, "ack")
+}
+
+// replayCommit models the durable actor's Read/Commit consume step against the
+// real store, mirroring execCore.commit in baselib/actor: inside one writer
+// transaction it fence-acks the row (DELETE ... WHERE id AND lease_token) and,
+// only when that ack consumed a row, records the dedup mark. A zero-row ack
+// means the lease was reclaimed mid-IO, so the transaction is rolled back with
+// ErrLeaseLost and nothing (ack or dedup mark) is applied. This keeps the P
+// commit-fence model tied to the SQL exactly-once mechanism.
+func replayCommit(t *testing.T, store actor.TxAwareDeliveryStore,
+	event MailboxTraceEvent) {
+
+	t.Helper()
+
+	var rows int64
+	err := store.ExecTx(
+		t.Context(), false,
+		func(txCtx context.Context, s actor.DeliveryStore) error {
+			var ackErr error
+			rows, ackErr = s.AckMessage(
+				txCtx, event.ID, event.LeaseToken,
+			)
+			if ackErr != nil {
+				return ackErr
+			}
+
+			// Fence: a zero-row ack means the lease was lost. Abort
+			// so the dedup mark (and, in production, the behavior's
+			// domain writes) roll back atomically with the failed
+			// consume.
+			if rows == 0 {
+				return actor.ErrLeaseLost
+			}
+
+			return s.MarkProcessed(
+				txCtx, event.ID, commitActorID, commitDedupTTL,
+			)
+		},
+	)
+
+	// A fenced commit either consumes the row (rows == 1, no error) or is a
+	// lease-lost no-op (rows == 0, ErrLeaseLost, fully rolled back).
+	if rows == 0 {
+		if !errors.Is(err, actor.ErrLeaseLost) {
+			t.Fatalf("commit of %s with a stale lease expected "+
+				"ErrLeaseLost, got %v", event.ID, err)
+		}
+	} else {
+		requireNoError(t, err)
+	}
+
+	requireExpectedRows(t, rows, event, "commit")
+
+	// The dedup mark is the bridge's analog of the behavior effect: it is
+	// folded into the same transaction as the ack, so a stale commit leaves
+	// the row unprocessed while a successful commit marks it exactly once.
+	if event.ExpectProcessed != nil {
+		processed, perr := store.IsProcessed(t.Context(), event.ID)
+		requireNoError(t, perr)
+		if processed != *event.ExpectProcessed {
+			t.Fatalf("commit of %s: expected processed=%v, got %v",
+				event.ID, *event.ExpectProcessed, processed)
+		}
+	}
 }
 
 func replayDeadLetter(t *testing.T, store actor.TxAwareDeliveryStore,

--- a/p-models/durableactor/src/mailbox_fifo.p
+++ b/p-models/durableactor/src/mailbox_fifo.p
@@ -77,12 +77,36 @@ type DurableMailboxDeadLetterReq = (
     id: int
 );
 
+// DurableMailboxCommitReq models the durable actor's Read/Commit consume step.
+// A behavior does its side-effect IO outside the writer transaction (the gap
+// between leasing the row and committing here), then Commit folds the behavior
+// effect, the dedup mark, and the lease-fenced ack into one atomic unit.
+//
+// `fenced` distinguishes the two designs:
+//
+//   * LeaseFencedCommit (fenced = true): the production Read/Commit path. The
+//     effect is applied only when the lease token still matches, atomically
+//     with the ack. A consumer whose lease expired and whose row was reclaimed
+//     applies nothing (ErrLeaseLost is a no-op).
+//
+//   * Unfenced (fenced = false): the counterexample. The effect is applied
+//     regardless of the lease token -- modeling a behavior whose domain write
+//     is not bound to the fenced ack -- so a stale consumer double-applies the
+//     effect under reclaim.
+type DurableMailboxCommitReq = (
+    reply_to: machine,
+    id: int,
+    lease_token: int,
+    fenced: bool
+);
+
 event eDurableMailboxEnqueue: DurableMailboxEnqueueReq;
 event eDurableMailboxLeaseNext: DurableMailboxLeaseNextReq;
 event eDurableMailboxAck: DurableMailboxTokenReq;
 event eDurableMailboxNack: DurableMailboxNackReq;
 event eDurableMailboxExpireLeasesAt: int;
 event eDurableMailboxDeadLetter: DurableMailboxDeadLetterReq;
+event eDurableMailboxCommit: DurableMailboxCommitReq;
 
 event eDurableMailboxOpResp: (int, DurableMailboxOpResult);
 event eDurableMailboxLeaseResp: (int, DurableMailboxOpResult);
@@ -103,6 +127,14 @@ event eDurableMailboxLeaseResp: (int, DurableMailboxOpResult);
 event eDurableMailboxClaimed: (machine, int, int, int);
 event eDurableMailboxRowEnqueued: (machine, int, int, int, int, int);
 event eDurableMailboxRowRemoved: (machine, int);
+
+// eDurableMailboxEffectApplied is announced when a Read/Commit consumer's
+// behavior effect is durably applied during Commit. It carries the announcing
+// mailbox machine and the row id: (mbox, id). The
+// LeaseFencedCommitAppliesEffectAtMostOnce monitor uses it to assert the effect
+// for any one row is applied at most once across the run, even when the row's
+// lease expires mid-IO and the row is reclaimed and reprocessed.
+event eDurableMailboxEffectApplied: (machine, int);
 
 // eMailboxWorkArrived and eMailboxWorkDrained are emitted only by the liveness
 // driver to feed the non-starvation liveness monitor. Keeping them distinct
@@ -525,6 +557,59 @@ machine DurableMailboxSpec {
             send req.reply_to, eDurableMailboxOpResp,
                 (req.id, MailboxOpOk);
         }
+
+        // Commit models the durable actor's Read/Commit consume step: the
+        // behavior effect, the dedup mark, and the lease-fenced ack land as one
+        // atomic unit. The effect is announced (eDurableMailboxEffectApplied)
+        // and the row is consumed (removed) per the design selected by
+        // req.fenced.
+        //
+        // The ack itself ALWAYS validates the lease token, mirroring the
+        // production ack `DELETE ... WHERE id AND lease_token`: a stale owner
+        // can never consume the row. Under the fenced design the effect is gated
+        // on the same token check, so it commits atomically with the ack and a
+        // stale owner applies nothing. Under the unfenced (counterexample)
+        // design the effect is applied even when the token is stale, so a
+        // reclaimed-and-reprocessed row gets its effect applied twice -- the bug
+        // the lease fence exists to prevent.
+        on eDurableMailboxCommit do (req: DurableMailboxCommitReq) {
+            var row: MailboxRow;
+            var tokenOk: bool;
+
+            // A missing row means it was already consumed (e.g. a reclaimer
+            // committed first). The model deliberately reports this as
+            // MailboxOpNotFound rather than the MailboxOpTokenMismatch of the
+            // stale-but-present case below; the production ack collapses both
+            // into a single 0-row DELETE -> ErrLeaseLost. The distinction is
+            // cosmetic for safety: both are effect no-ops (neither reaches the
+            // effect announce), so the at-most-once contract holds identically.
+            if (!RowExists(rows, req.id)) {
+                send req.reply_to, eDurableMailboxOpResp,
+                    (req.id, MailboxOpNotFound);
+                return;
+            }
+
+            row = RowByID(rows, req.id);
+            tokenOk = TokenMatches(row, req.lease_token);
+
+            if (tokenOk || !req.fenced) {
+                announce eDurableMailboxEffectApplied, (this, req.id);
+            }
+
+            if (tokenOk) {
+                rows = RemoveMailboxRow(rows, req.id);
+                announce eDurableMailboxRowRemoved, (this, req.id);
+                send req.reply_to, eDurableMailboxOpResp,
+                    (req.id, MailboxOpOk);
+                return;
+            }
+
+            // Stale token: the ack fenced the consume out. Under the fenced
+            // design no effect was applied above; this is the ErrLeaseLost
+            // no-op.
+            send req.reply_to, eDurableMailboxOpResp,
+                (req.id, MailboxOpTokenMismatch);
+        }
     }
 }
 
@@ -634,6 +719,35 @@ spec MailboxKeyedWorkEventuallyDrains observes
             if (outstanding == 0) {
                 goto Idle;
             }
+        }
+    }
+}
+
+// LeaseFencedCommitAppliesEffectAtMostOnce is the safety contract for the
+// durable actor's Read/Commit consume step. The Read/Commit path lets a
+// behavior do side-effect IO outside the writer transaction, so the row's lease
+// can expire mid-IO and the row can be reclaimed and reprocessed by a second
+// consumer. The lease fence (the token-validated ack that the behavior effect
+// commits atomically with) must ensure the effect is applied at most once
+// across the whole run, regardless of how many consumers processed the row.
+//
+// The monitor namespaces state by (mbox, id) because one test case can spin up
+// several DurableMailboxSpec machines that reuse row ids. It catches the
+// unfenced design directly: a stale consumer that applies its effect after the
+// row was reclaimed announces a second eDurableMailboxEffectApplied for the same
+// (mbox, id), tripping the assertion with no in-machine check required.
+spec LeaseFencedCommitAppliesEffectAtMostOnce observes
+    eDurableMailboxEffectApplied {
+
+    var applied: map[(machine, int), bool];
+
+    start state Monitoring {
+        on eDurableMailboxEffectApplied do (effect: (machine, int)) {
+            assert !(effect in applied),
+                "lease-fenced commit applied a message effect more than "+
+                "once (a stale owner committed after the row was reclaimed)";
+
+            applied[effect] = true;
         }
     }
 }

--- a/p-models/durableactor/test/mailbox_fifo_test.p
+++ b/p-models/durableactor/test/mailbox_fifo_test.p
@@ -855,6 +855,180 @@ machine MailboxLivenessDriver {
     state Done {}
 }
 
+// TestDurableMailboxSpec_LeaseFencedCommitExactlyOnce drives the durable
+// actor's Read/Commit consume step under lease expiry mid-IO. Consumer A leases
+// the row and begins its side-effect IO; while it is off doing IO the lease
+// expires and consumer B reclaims and reprocesses the same row. A's stale
+// fenced Commit must be an ErrLeaseLost no-op (token mismatch, no effect), and
+// only B's fenced Commit applies the effect and consumes the row. The
+// LeaseFencedCommitAppliesEffectAtMostOnce monitor confirms the effect is
+// applied exactly once across both consumers.
+machine TestDurableMailboxSpec_LeaseFencedCommitExactlyOnce {
+    var mailbox: DurableMailboxSpec;
+
+    start state Init {
+        entry {
+            var op_resp: (int, DurableMailboxOpResult);
+            var lease_resp: (int, DurableMailboxOpResult);
+
+            mailbox = new DurableMailboxSpec(PerCorrelationKeyFIFO);
+
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    1, 10, 100, 0, 0, NoLease(), NoLeaseToken(), 0, 3, 0
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (r0: (int, DurableMailboxOpResult)) { op_resp = r0; }
+            }
+            assert op_resp.1 == MailboxOpOk, "enqueue succeeds";
+
+            // Consumer A leases the row (token 11), then begins IO.
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 11,
+                now = 0, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (r1: (int, DurableMailboxOpResult)) { lease_resp = r1; }
+            }
+            assert lease_resp.0 == 1 && lease_resp.1 == MailboxOpOk,
+                "consumer A leases the row";
+
+            // A's lease expires mid-IO; consumer B reclaims the same durable
+            // row and reprocesses it.
+            send mailbox, eDurableMailboxExpireLeasesAt, 6;
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 22,
+                now = 6, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (r2: (int, DurableMailboxOpResult)) { lease_resp = r2; }
+            }
+            assert lease_resp.0 == 1 && lease_resp.1 == MailboxOpOk,
+                "consumer B reclaims the same row after lease expiry";
+
+            // A finishes its IO and commits with its now-stale token: the lease
+            // fence rejects it and no effect is applied.
+            send mailbox, eDurableMailboxCommit, (
+                reply_to = this, id = 1, lease_token = 11, fenced = true
+            );
+            receive { case eDurableMailboxOpResp:
+                (r3: (int, DurableMailboxOpResult)) { op_resp = r3; }
+            }
+            assert op_resp.1 == MailboxOpTokenMismatch,
+                "stale consumer A commit is an ErrLeaseLost no-op";
+
+            // B commits with the current token: effect applied, row consumed.
+            send mailbox, eDurableMailboxCommit, (
+                reply_to = this, id = 1, lease_token = 22, fenced = true
+            );
+            receive { case eDurableMailboxOpResp:
+                (r4: (int, DurableMailboxOpResult)) { op_resp = r4; }
+            }
+            assert op_resp.1 == MailboxOpOk,
+                "current owner B commits and consumes the row";
+
+            // The committed row is terminal: no further redelivery.
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 33,
+                now = 6, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (r5: (int, DurableMailboxOpResult)) { lease_resp = r5; }
+            }
+            assert lease_resp.1 == MailboxOpNotFound,
+                "committed row is terminal";
+
+            // A late commit for the already-consumed row hits the missing-row
+            // branch: it must be a no-op (no second effect). This exercises the
+            // MailboxOpNotFound path the reclaim-after-consume case takes, and
+            // the LeaseFencedCommitAppliesEffectAtMostOnce monitor confirms it
+            // applies no effect.
+            send mailbox, eDurableMailboxCommit, (
+                reply_to = this, id = 1, lease_token = 22, fenced = true
+            );
+            receive { case eDurableMailboxOpResp:
+                (r6: (int, DurableMailboxOpResult)) { op_resp = r6; }
+            }
+            assert op_resp.1 == MailboxOpNotFound,
+                "commit of an already-consumed row is a not-found no-op";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// TestDurableMailboxSpec_UnfencedCommitDoubleApplyCounterexample drives the same
+// reclaim scenario but with UNFENCED commits, modeling a behavior whose domain
+// write is not bound to the lease-fenced ack. Consumer A's stale commit applies
+// its effect even though its lease expired, then consumer B applies the effect
+// again -- a double-apply. There is no in-machine assertion for the
+// double-apply: it is raised solely by LeaseFencedCommitAppliesEffectAtMostOnce,
+// proving the monitor catches the exact bug the lease fence prevents.
+machine TestDurableMailboxSpec_UnfencedCommitDoubleApplyCounterexample {
+    var mailbox: DurableMailboxSpec;
+
+    start state Init {
+        entry {
+            var op_resp: (int, DurableMailboxOpResult);
+            var lease_resp: (int, DurableMailboxOpResult);
+
+            mailbox = new DurableMailboxSpec(PerCorrelationKeyFIFO);
+
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    1, 10, 100, 0, 0, NoLease(), NoLeaseToken(), 0, 3, 0
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (r0: (int, DurableMailboxOpResult)) { op_resp = r0; }
+            }
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 11,
+                now = 0, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (r1: (int, DurableMailboxOpResult)) { lease_resp = r1; }
+            }
+
+            send mailbox, eDurableMailboxExpireLeasesAt, 6;
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 22,
+                now = 6, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (r2: (int, DurableMailboxOpResult)) { lease_resp = r2; }
+            }
+
+            // Stale consumer A commits unfenced: the effect is applied despite
+            // the expired-and-reclaimed lease.
+            send mailbox, eDurableMailboxCommit, (
+                reply_to = this, id = 1, lease_token = 11, fenced = false
+            );
+            receive { case eDurableMailboxOpResp:
+                (r3: (int, DurableMailboxOpResult)) { op_resp = r3; }
+            }
+
+            // Consumer B commits unfenced: the effect is applied a second time.
+            send mailbox, eDurableMailboxCommit, (
+                reply_to = this, id = 1, lease_token = 22, fenced = false
+            );
+            receive { case eDurableMailboxOpResp:
+                (r4: (int, DurableMailboxOpResult)) { op_resp = r4; }
+            }
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
 machine MailboxFIFOTestDriver {
     start state RunTests {
         entry {
@@ -916,3 +1090,21 @@ test tcMailboxMonitorCatchesLegacyReorder
     [main=TestMailboxFIFO_LegacyReorderNoInlineAssert]:
   assert SameKeyFIFOClaimsRespectLiveHead in
   { DurableMailboxSpec, TestMailboxFIFO_LegacyReorderNoInlineAssert };
+
+// tcMailboxReadCommitFence checks the durable actor Read/Commit exactly-once
+// effect contract: a row whose lease expires mid-IO is reclaimed and
+// reprocessed, the stale consumer's lease-fenced commit is an ErrLeaseLost
+// no-op, and the behavior effect is applied exactly once.
+test tcMailboxReadCommitFence
+    [main=TestDurableMailboxSpec_LeaseFencedCommitExactlyOnce]:
+  assert LeaseFencedCommitAppliesEffectAtMostOnce in
+  { DurableMailboxSpec, TestDurableMailboxSpec_LeaseFencedCommitExactlyOnce };
+
+// tcMailboxUnfencedCommitCounterexample runs the reclaim scenario with unfenced
+// commits and no in-machine assertion, so the double-apply is raised solely by
+// LeaseFencedCommitAppliesEffectAtMostOnce. It is expected to find a bug.
+test tcMailboxUnfencedCommitCounterexample
+    [main=TestDurableMailboxSpec_UnfencedCommitDoubleApplyCounterexample]:
+  assert LeaseFencedCommitAppliesEffectAtMostOnce in
+  { DurableMailboxSpec,
+    TestDurableMailboxSpec_UnfencedCommitDoubleApplyCounterexample };

--- a/p-models/durableactor/traces/mailbox_read_commit_fenced_exactly_once.json
+++ b/p-models/durableactor/traces/mailbox_read_commit_fenced_exactly_once.json
@@ -1,0 +1,45 @@
+{
+  "trace_id": "mailbox_read_commit_fenced_exactly_once",
+  "description": "Read/Commit consume under lease expiry mid-IO. Consumer A leases the row and begins IO; its lease expires and consumer B reclaims and reprocesses the same row. A's stale fenced commit is an ErrLeaseLost no-op (0 rows, dedup mark rolled back), and only B's fenced commit consumes the row and marks it processed, so the message is consumed exactly once.",
+  "events": [
+    {
+      "op": "enqueue",
+      "id": "1",
+      "mailbox_id": "mb-1",
+      "available_at": 0,
+      "max_attempts": 3
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "mb-1",
+      "lease_token": "tok-A",
+      "expect_id": "1",
+      "now": 0
+    },
+    {
+      "op": "expire_leases",
+      "now": 120
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "mb-1",
+      "lease_token": "tok-B",
+      "expect_id": "1",
+      "now": 120
+    },
+    {
+      "op": "commit",
+      "id": "1",
+      "lease_token": "tok-A",
+      "expect_rows": 0,
+      "expect_processed": false
+    },
+    {
+      "op": "commit",
+      "id": "1",
+      "lease_token": "tok-B",
+      "expect_rows": 1,
+      "expect_processed": true
+    }
+  ]
+}

--- a/p-models/scripts/check.sh
+++ b/p-models/scripts/check.sh
@@ -80,11 +80,22 @@ check_negative() {
 check_green tcMailboxCorrelationKeyFIFO
 check_green tcMailboxLiveness
 
+# The Read/Commit consume step must apply a message's behavior effect exactly
+# once even when the row's lease expires mid-IO and the row is reclaimed and
+# reprocessed: the stale consumer's lease-fenced commit must be an ErrLeaseLost
+# no-op.
+check_green tcMailboxReadCommitFence
+
 # The legacy reorder must still be caught two independent ways: once by the
 # in-machine assertion, and once by the SameKeyFIFOClaimsRespectLiveHead monitor
 # with no in-machine assertion. A single schedule is enough to surface it.
 check_negative tcMailboxLegacyReorderCounterexample 1
 check_negative tcMailboxMonitorCatchesLegacyReorder 1
+
+# The unfenced-commit counterexample must be caught by the
+# LeaseFencedCommitAppliesEffectAtMostOnce monitor: a stale consumer that
+# applies its effect after the row was reclaimed double-applies it.
+check_negative tcMailboxUnfencedCommitCounterexample 1
 
 echo ""
 echo "=== Go Bridge Conformance ==="

--- a/serverconn/actor_correlation_key_test.go
+++ b/serverconn/actor_correlation_key_test.go
@@ -246,7 +246,7 @@ func TestSendClientEventRequestPlumbsCorrelationKeyToStore(t *testing.T) {
 	cfg.Store = store
 	cfg.Codec = NewServerConnCodec()
 
-	durable := newDurableConnectorForTest(cfg, 50*time.Millisecond)
+	durable := newDurableConnectorForTest(t, cfg, 50*time.Millisecond)
 	durable.Start()
 	defer durable.Stop()
 

--- a/serverconn/restart_replay_test.go
+++ b/serverconn/restart_replay_test.go
@@ -68,6 +68,7 @@ func (e *failFirstSendEdge) Snapshot() (int, string, string) {
 // newDurableConnectorForTest creates a DurableActor wrapper around
 // ServerConnectionActor with an explicit Tell retry delay.
 func newDurableConnectorForTest(
+	t *testing.T,
 	cfg ConnectorConfig,
 	retryDelay time.Duration,
 ) *actor.DurableActor[ServerConnMsg, ServerConnResp] {
@@ -94,7 +95,7 @@ func newDurableConnectorForTest(
 		return true, retryDelay
 	}
 
-	return actor.NewDurableActor(durableCfg)
+	return actor.NewDurableActor(durableCfg).UnwrapOrFail(t)
 }
 
 // TestEgress_RestartReplayPreservesStableIDs verifies that a failed egress send
@@ -111,7 +112,7 @@ func TestEgress_RestartReplayPreservesStableIDs(t *testing.T) {
 	cfg.Codec = NewServerConnCodec()
 
 	// First actor instance fails once and nacks the message for retry.
-	durable1 := newDurableConnectorForTest(cfg, 500*time.Millisecond)
+	durable1 := newDurableConnectorForTest(t, cfg, 500*time.Millisecond)
 	durable1.Start()
 
 	err := durable1.TellRef().Tell(t.Context(), &SendClientEventRequest{
@@ -141,7 +142,7 @@ func TestEgress_RestartReplayPreservesStableIDs(t *testing.T) {
 
 	// Second actor instance replays from the same durable store and then
 	// succeeds.
-	durable2 := newDurableConnectorForTest(cfg, 20*time.Millisecond)
+	durable2 := newDurableConnectorForTest(t, cfg, 20*time.Millisecond)
 	durable2.Start()
 	defer durable2.Stop()
 
@@ -177,7 +178,7 @@ func TestDurableUnary_RestartReplayPreservesStableIDs(t *testing.T) {
 
 	// First actor instance fails once and leaves the durable unary
 	// send queued for replay.
-	durable1 := newDurableConnectorForTest(cfg, 500*time.Millisecond)
+	durable1 := newDurableConnectorForTest(t, cfg, 500*time.Millisecond)
 	durable1.Start()
 
 	err := durable1.TellRef().Tell(
@@ -214,7 +215,7 @@ func TestDurableUnary_RestartReplayPreservesStableIDs(t *testing.T) {
 
 	// Second actor instance replays from the same durable store and then
 	// succeeds.
-	durable2 := newDurableConnectorForTest(cfg, 20*time.Millisecond)
+	durable2 := newDurableConnectorForTest(t, cfg, 20*time.Millisecond)
 	durable2.Start()
 	defer durable2.Stop()
 

--- a/serverconn/runtime.go
+++ b/serverconn/runtime.go
@@ -57,7 +57,10 @@ func NewRuntime(cfg ConnectorConfig) (*Runtime, error) {
 	)
 	durableCfg.Log = cfg.Log
 
-	durable := actor.NewDurableActor(durableCfg)
+	durable, err := actor.NewDurableActor(durableCfg).Unpack()
+	if err != nil {
+		return nil, err
+	}
 	unary := NewUnaryFacade(connector)
 
 	return &Runtime{

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -119,7 +119,10 @@ func NewVTXOUnrollActor(cfg Config) (*VTXOUnrollActor, error) {
 	)
 	durableCfg.Log = cfg.Log
 
-	durable := actor.NewDurableActor(durableCfg)
+	durable, err := actor.NewDurableActor(durableCfg).Unpack()
+	if err != nil {
+		return nil, err
+	}
 	behavior.selfRef = durable.TellRef()
 	durable.Start()
 


### PR DESCRIPTION
In this PR, we add a new "Read/Commit" execution path to the durable actor
framework so a behavior can do its slow side-effect IO (signing RPCs, calls
out to the server, polling, etc) *without* holding the SQLite writer the whole
time, while still getting an atomic, exactly-once commit at the end. This is
the framework-level fix for the OOR/swap concurrency stalls tracked in
lightninglabs/darepo#313: today `DurableActor` wraps the entire `Receive` in
one `ExecTx`, so if a behavior does any IO inside that tx the single WAL writer
is held across the network round-trip and every other actor (plus the ingress
dispatch write) stalls behind it.

The design follows section 4 of the framework sketch. A behavior opts in by
implementing `TxBehavior[M, R, S]` and is driven through an `Exec[S]` handle
with two phases. `Read` runs a short read-only snapshot (no writer lock); the
behavior then does its IO with no tx held; finally `Commit` runs one short
writer tx. The trick that keeps this exactly-once is a lease fence: inside
`Commit` we ack the mailbox row first (`DELETE ... WHERE id = ? AND lease_token
= ?`), and if that deletes zero rows the lease was reclaimed while we were off
doing IO, so we abort with `ErrLeaseLost` and the whole tx rolls back, applying
nothing. On the happy path the behavior's own writes and the dedup mark fold
into that same tx, so the state advance and the message consumption commit
together. Any duplicate effect a stale consumer might have already emitted is
deduped downstream by the receiver's `ON CONFLICT (id) DO NOTHING`.

See each commit message for a detailed description w.r.t the incremental
changes.

## Framework

The store type `S` is a free type parameter injected via a `StoreFactory`, so
`DurableActor` itself stays `[M, R]` and the typed store is handed to the
behavior's `Commit` closure (it joins the tx via `actor.TxFromContext`). The
config's `Behavior` becomes an `fn.Either` of the classic `ActorBehavior`
(Left, the unchanged safe default) and the new `BoundTxBehavior` (Right).
`NewDurableActor` now returns an `fn.Result` and fails closed at construction:
a `TxBehavior` paired with a non-tx-aware store gets `ErrTxBehaviorNeedsTxStore`,
and a missing or zero-value behavior gets `ErrNoBehavior` instead of panicking
at first dispatch. `NewClassicBehavior`, `NewTxBehaviorEither`, and
`DefaultDurableTxActorConfig` keep the either-wrapping boilerplate out of
callers.

Property tests with rapid pin the two invariants that matter: the lease fence
(consume exactly when the token matches, else `ErrLeaseLost` with zero side
effects) and atomic grouping (any number of effects commit all-or-nothing
alongside consumption and the dedup mark).

## Ledger

We convert the client ledger actor as the first adopter. Each accounting
handler now books its ledger legs inside one fenced `Commit` via a typed
`ledgerTx` store, so multi-leg events like `ExitCost` commit every leg
atomically with the mailbox ack. We also fix the wiring: the ledger used to
register an in-memory actor via `RegisterWithSystem`, so producer `Tell`s were
handled synchronously and the durable mailbox went unused. We now register the
durable ref with the receptionist (the same shape OOR and serverconn already
use) and stop the actor explicitly during shutdown, after the producers drain
but before `db.Close`, so the Commit/fence path is actually exercised and
best-effort accounting Tells aren't dropped in the shutdown window. An
end-to-end test drives a real `ExitCostMsg` through the durable mailbox and
asserts two-leg atomicity, idempotent replay, and rollback-on-reject.

## Follow-ups

The OOR effect actors and serverconn egress are the next adopters (section 4.5
of the sketch) and aren't in this PR.

While reviewing we also turned up a pre-existing ledger dedup bug that's
orthogonal to this work: two in-round transfer receives in the same round can
collide on the `idx_client_ledger_idempotent_round` index (which doesn't
include the per-outpoint key) and the untargeted `ON CONFLICT DO NOTHING`
silently drops the second. Tracked separately in #661.

## Test plan

- [x] `make lint` (Docker) clean
- [x] `baselib/actor`, `ledger`, `internal/actortest`, `serverconn`, `oor`, `unroll`, `db/actordelivery` unit tests pass
- [x] rapid property tests for the lease fence + atomic grouping
- [x] end-to-end ledger test over a real SQLite-backed durable mailbox