### PR TITLE
txconfirm: keep never-broadcast checkpoints retrying with operator escalation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6
 	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.41.0
+	golang.org/x/time v0.11.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
@@ -206,7 +207,6 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
-	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -46,9 +46,15 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - `TxConfirmed` / `TxFailed` — terminal `Notification` types delivered
   to each subscriber.
 - `TxState` — `New`, `Broadcasting`, `AwaitingConfirmation`,
-  `FeeBumping`, `Confirmed`, `Failed`.
+  `FeeBumping`, `Confirmed`, `Failed`. `Broadcasting` covers BOTH the
+  initial attempt and the "reached no mempool, retrying" case;
+  `AwaitingConfirmation` is reported only once the tx (or a redundant
+  parent) is actually in a mempool.
 - Sentinels: `ErrNonTRUCParent`, `ErrCPFPFeeInputUnavailable`,
   `ErrEnsureParamsMismatch`, `ErrFeeInputProducesDust`.
+- `Config.BroadcastFailureAlertThreshold` — consecutive no-mempool
+  failures before the operator escalation fires (default 3). Time to
+  first alert ≈ threshold × `FeeBumpIntervalBlocks` blocks.
 
 ## Relationships
 
@@ -73,6 +79,19 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 
 ## Invariants
 
+- **Never give up on a no-mempool tx**: a tx whose broadcast reached no
+  mempool stays in `Broadcasting` and is re-attempted every
+  `FeeBumpIntervalBlocks`, never transitioning to terminal `Failed`. This
+  covers `ErrCPFPFeeInputUnavailable` and transient package-relay
+  rejections (min-relay-fee on the zero-fee anchor parent, mempool-full,
+  fee input spent mid-submit) — the conditions CPFP retry exists to
+  overcome. Only a structurally permanent error
+  (`isPermanentBroadcastError`, currently `ErrNonTRUCParent`) fails
+  terminally; `ErrParentAlreadyBroadcast` advances to
+  `AwaitingConfirmation` (a live parent exists on another path). Rationale:
+  a fraud-response checkpoint must land before the counterparty's
+  CSV-timeout path, so the actor escalates to operators rather than
+  silently aborting.
 - **Strict dedup check**: two `EnsureConfirmedReq` for the same txid
   must agree on `TargetConfs` and `ConfirmationPkScript`; mismatches
   return `ErrEnsureParamsMismatch` rather than silently reusing the

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/chainsource"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"golang.org/x/time/rate"
 )
 
 const (
@@ -27,7 +28,21 @@ const (
 	// at all) after which the actor emits an operator-visible escalation.
 	// The tx keeps being re-attempted regardless; this only controls when
 	// the actor starts asking for operator attention.
-	DefaultBroadcastFailureAlertThreshold = 5
+	//
+	// Note the effective time to first alert is roughly this threshold
+	// times FeeBumpIntervalBlocks blocks, because re-attempts are
+	// interval-paced. The default is kept small so a fund-risk tx (e.g. a
+	// fraud-response checkpoint) surfaces to operators quickly rather than
+	// after a long silent window.
+	DefaultBroadcastFailureAlertThreshold = 3
+
+	// broadcastEscalationReminder bounds how often the operator-facing
+	// "repeatedly failing" escalation repeats once the alert threshold has
+	// been crossed. The first crossing always logs; subsequent reminders
+	// are emitted at most once per this interval, decoupling the reminder
+	// cadence from the (block-driven) retry interval so a permanently stuck
+	// tx does not flood the log.
+	broadcastEscalationReminder = 10 * time.Minute
 )
 
 var (
@@ -78,6 +93,11 @@ type Config struct {
 	// dashboards and alerts can distinguish "cannot broadcast" from a tx
 	// that is genuinely awaiting confirmation. Zero falls back to
 	// DefaultBroadcastFailureAlertThreshold.
+	//
+	// Because re-attempts are interval-paced, the effective time to the
+	// first alert is roughly BroadcastFailureAlertThreshold *
+	// FeeBumpIntervalBlocks blocks. Tune both together when changing how
+	// quickly a stuck fund-risk tx should surface to operators.
 	BroadcastFailureAlertThreshold int
 
 	// MaxFeeRateSatPerVByte caps fee estimates used by the internal CPFP
@@ -162,6 +182,14 @@ type trackedTx struct {
 	fsm  *trackedTxStateMachine
 
 	subscribers map[string]actor.TellOnlyRef[Notification]
+
+	// escalateLog rate-limits the operator-facing escalation that fires
+	// once a tx has failed to reach any mempool repeatedly. It
+	// edge-triggers on the first crossing of the alert threshold and then
+	// emits at most one reminder per broadcastEscalationReminder, so a
+	// persistently stuck tx stays visible without flooding the log on every
+	// retry interval.
+	escalateLog rate.Sometimes
 
 	// confWatchRegistered reports whether a chainsource confirmation
 	// watch is currently active for this txid. It is flipped true by
@@ -451,22 +479,31 @@ func (a *TxBroadcasterActor) handleEnsure(ctx context.Context,
 //     broadcast). The conf watch is already registered, so advance to
 //     AwaitingConfirmation and let it ride.
 //
-//   - ErrCPFPFeeInputUnavailable: a total broadcast failure — both the CPFP
-//     child sign and the direct-parent fallback failed, so nothing reached any
-//     mempool. The tx stays in Broadcasting (it must NOT report
-//     AwaitingConfirmation) and is re-attempted on the next interval. The
-//     consecutive-failure counter is bumped and, past the configured
-//     threshold, the operator is alerted. The actor never gives up.
+//   - a permanent/structural error (see isPermanentBroadcastError): the tx can
+//     never be accepted as submitted, so retrying is pointless. Fail it
+//     terminally and notify subscribers.
 //
-//   - any other error: a genuine terminal broadcast failure.
+//   - any other error on an anchor (CPFP) parent: the tx reached no mempool but
+//     the failure is plausibly transient — a missing confirmed fee input
+//     (ErrCPFPFeeInputUnavailable), a min-relay-fee rejection of the zero-fee
+//     anchor parent, a mempool-full condition, or a fee input spent out from
+//     under us. These are exactly the conditions CPFP retry exists to overcome,
+//     so the tx stays in Broadcasting (it must NOT report
+//     AwaitingConfirmation), is re-attempted on the next interval, and
+//     escalates to the operator past the configured threshold. The actor never
+//     gives up on such a tx: a fraud-response checkpoint must land before the
+//     counterparty's CSV-timeout path can win.
+//
+//   - any other error on a non-anchor parent: a plain direct broadcast with no
+//     CPFP retry machinery. There is nothing to fee-bump and no fund-risk
+//     retry contract, so fail it terminally as before.
 func (a *TxBroadcasterActor) recordInitialBroadcastOutcome(ctx context.Context,
 	entry *trackedTx, err error) {
 
-	if err == nil {
-		return
-	}
-
 	switch {
+	case err == nil:
+		return
+
 	case errors.Is(err, ErrParentAlreadyBroadcast):
 		// A live parent exists on another path, so the conf watch can
 		// ride to confirmation. Advance to AwaitingConfirmation.
@@ -485,16 +522,40 @@ func (a *TxBroadcasterActor) recordInitialBroadcastOutcome(ctx context.Context,
 			},
 		)
 
-	case errors.Is(err, ErrCPFPFeeInputUnavailable):
-		// Nothing reached any mempool. Stay in Broadcasting so the next
-		// interval re-attempts, and track the failure for escalation.
+	case isPermanentBroadcastError(err):
+		// The tx is structurally unacceptable (e.g. a non-TRUC parent);
+		// no amount of retrying will land it, so fail terminally.
+		a.failTrackedTx(
+			ctx, entry, fmt.Sprintf("broadcast: %v", err),
+		)
+
+	case findAnchorOutput(entry.data.Tx) >= 0:
+		// An anchor (CPFP) parent reached no mempool. The failure is
+		// plausibly transient and this is the fund-risk path, so stay
+		// in Broadcasting, re-attempt next interval, and escalate
+		// rather than give up.
 		a.recordBroadcastFailure(ctx, entry, err)
 
 	default:
+		// A non-anchor direct broadcast failed and has no CPFP retry
+		// contract; fail terminally.
 		a.failTrackedTx(
 			ctx, entry, fmt.Sprintf("broadcast: %v", err),
 		)
 	}
+}
+
+// isPermanentBroadcastError reports whether a broadcast error is structural and
+// can never succeed on retry, so an anchor-bearing tracked tx should fail
+// terminally rather than spin in the Broadcasting retry loop. Transient
+// conditions on an anchor parent are kept retryable, because on a fund-risk
+// path (e.g. a fraud-response checkpoint) it is safer to keep trying and alert
+// an operator than to silently abort a tx that must confirm.
+func isPermanentBroadcastError(err error) bool {
+
+	// A non-TRUC (non-v3) parent is a caller/programming error: the version
+	// gate rejects it identically on every attempt, so retrying only spams.
+	return errors.Is(err, ErrNonTRUCParent)
 }
 
 // recordBroadcastFailure keeps a never-broadcast tx in the Broadcasting state,
@@ -516,12 +577,15 @@ func (a *TxBroadcasterActor) recordBroadcastFailure(ctx context.Context,
 
 	failures := trackedTxBroadcastFailures(currentState) + 1
 
-	a.log.WarnS(ctx,
+	// The per-attempt record is routine (one line per retry interval), so
+	// it logs at debug; the operator-facing signal is the throttled
+	// escalation below.
+	a.log.DebugS(ctx,
 		"Initial broadcast reached no mempool; will retry",
-		cause,
 		"txid", entry.data.Txid,
 		slog.String("label", entry.data.Label),
 		slog.Int("consecutive_failures", failures),
+		slog.Any("cause", cause),
 	)
 
 	_ = a.advanceTrackedTxFSM(
@@ -533,19 +597,22 @@ func (a *TxBroadcasterActor) recordBroadcastFailure(ctx context.Context,
 		},
 	)
 
-	// Escalate once the failure count reaches the threshold and on every
-	// subsequent attempt, so a persistent deterministic failure stays
-	// visible to operators without giving up. The message is intentionally
-	// static so alerting can key on it.
+	// Escalate once the failure count reaches the threshold. escalateLog
+	// edge-triggers on the first crossing and then emits at most one
+	// reminder per broadcastEscalationReminder, so a persistently stuck tx
+	// stays visible without a warning on every retry interval. The message
+	// is intentionally static so alerting can key on it.
 	if failures >= a.cfg.BroadcastFailureAlertThreshold {
-		a.log.WarnS(ctx,
-			"Tx broadcast repeatedly failing; operator "+
-				"intervention may be required",
-			cause,
-			"txid", entry.data.Txid,
-			slog.String("label", entry.data.Label),
-			slog.Int("consecutive_failures", failures),
-		)
+		entry.escalateLog.Do(func() {
+			a.log.WarnS(ctx,
+				"Tx broadcast repeatedly failing; operator "+
+					"intervention may be required",
+				cause,
+				"txid", entry.data.Txid,
+				slog.String("label", entry.data.Label),
+				slog.Int("consecutive_failures", failures),
+			)
+		})
 	}
 }
 
@@ -835,6 +902,10 @@ func (a *TxBroadcasterActor) newTrackedTx(ctx context.Context,
 		fsm:  fsm,
 		subscribers: map[string]actor.TellOnlyRef[Notification]{
 			req.Subscriber.ID(): req.Subscriber,
+		},
+		escalateLog: rate.Sometimes{
+			First:    1,
+			Interval: broadcastEscalationReminder,
 		},
 	}, nil
 }

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -20,6 +21,13 @@ const (
 	// blocks to wait before retrying a still-unconfirmed transaction
 	// with a fresh CPFP child.
 	DefaultFeeBumpIntervalBlocks int32 = 2
+
+	// DefaultBroadcastFailureAlertThreshold is the default number of
+	// consecutive initial-broadcast failures (a tx that reached no mempool
+	// at all) after which the actor emits an operator-visible escalation.
+	// The tx keeps being re-attempted regardless; this only controls when
+	// the actor starts asking for operator attention.
+	DefaultBroadcastFailureAlertThreshold = 5
 )
 
 var (
@@ -62,6 +70,15 @@ type Config struct {
 	// before retrying an unconfirmed transaction. Zero falls back to
 	// DefaultFeeBumpIntervalBlocks.
 	FeeBumpIntervalBlocks int32
+
+	// BroadcastFailureAlertThreshold is the number of consecutive
+	// initial-broadcast failures (a tx that reached no mempool at all)
+	// after which the actor escalates with an operator-visible warning.
+	// The actor never gives up on the tx — escalation is informational so
+	// dashboards and alerts can distinguish "cannot broadcast" from a tx
+	// that is genuinely awaiting confirmation. Zero falls back to
+	// DefaultBroadcastFailureAlertThreshold.
+	BroadcastFailureAlertThreshold int
 
 	// MaxFeeRateSatPerVByte caps fee estimates used by the internal CPFP
 	// broadcaster. Zero falls back to DefaultMaxFeeRateSatPerVByte.
@@ -213,6 +230,11 @@ func (m *blockEpochObservedMsg) txConfirmMsgSealed() {}
 func NewTxBroadcasterActor(cfg Config) *TxBroadcasterActor {
 	if cfg.FeeBumpIntervalBlocks <= 0 {
 		cfg.FeeBumpIntervalBlocks = DefaultFeeBumpIntervalBlocks
+	}
+
+	if cfg.BroadcastFailureAlertThreshold <= 0 {
+		cfg.BroadcastFailureAlertThreshold =
+			DefaultBroadcastFailureAlertThreshold
 	}
 
 	return &TxBroadcasterActor{
@@ -407,49 +429,124 @@ func (a *TxBroadcasterActor) handleEnsure(ctx context.Context,
 		return a.ensureResp(entry, true), nil
 	}
 
-	if err := a.broadcastTrackedTx(
-		ctx, entry, TxStateBroadcasting,
-	); err != nil {
-
-		switch {
-		case errors.Is(err, ErrCPFPFeeInputUnavailable):
-			a.log.WarnS(ctx,
-				"Initial anchor broadcast waiting for CPFP "+
-					"fee input",
-				err, "txid", entry.data.Txid,
-			)
-
-		case errors.Is(err, ErrParentAlreadyBroadcast):
-			// Parent is already broadcast by another path
-			// (typically the operator's redundant CPFP racing the
-			// client's own broadcast). The conf watch is already
-			// registered on the parent, so let it ride to
-			// confirmation rather than failing the tracked tx.
-			a.log.WarnS(ctx,
-				"Initial anchor broadcast deferring to "+
-					"existing path",
-				err, "txid", entry.data.Txid,
-			)
-
-		default:
-			a.failTrackedTx(
-				ctx, entry, fmt.Sprintf("broadcast: %v", err),
-			)
-
-			return a.ensureResp(entry, true), nil
-		}
-
-		progress := trackedTxProgress{
-			LastBroadcastHeight: a.bestHeight,
-		}
-		_ = a.advanceTrackedTxFSM(
-			ctx, entry, &trackedTxBroadcastAccepted{
-				Progress: progress,
-			},
-		)
-	}
+	err = a.broadcastTrackedTx(ctx, entry, TxStateBroadcasting)
+	a.recordInitialBroadcastOutcome(ctx, entry, err)
 
 	return a.ensureResp(entry, true), nil
+}
+
+// recordInitialBroadcastOutcome advances the FSM based on the result of an
+// initial (or retried) broadcast for a tracked tx that had not yet reached any
+// mempool. It is shared by the initial submit in handleEnsure and the
+// interval-driven re-attempt in handleBlockObserved so both apply identical
+// state semantics.
+//
+// The outcome is routed by error class:
+//
+//   - nil: broadcastTrackedTx already advanced the FSM to
+//     AwaitingConfirmation, so there is nothing left to do.
+//
+//   - ErrParentAlreadyBroadcast: a live parent genuinely exists on another
+//     path (typically the operator's redundant CPFP racing the client's own
+//     broadcast). The conf watch is already registered, so advance to
+//     AwaitingConfirmation and let it ride.
+//
+//   - ErrCPFPFeeInputUnavailable: a total broadcast failure — both the CPFP
+//     child sign and the direct-parent fallback failed, so nothing reached any
+//     mempool. The tx stays in Broadcasting (it must NOT report
+//     AwaitingConfirmation) and is re-attempted on the next interval. The
+//     consecutive-failure counter is bumped and, past the configured
+//     threshold, the operator is alerted. The actor never gives up.
+//
+//   - any other error: a genuine terminal broadcast failure.
+func (a *TxBroadcasterActor) recordInitialBroadcastOutcome(ctx context.Context,
+	entry *trackedTx, err error) {
+
+	if err == nil {
+		return
+	}
+
+	switch {
+	case errors.Is(err, ErrParentAlreadyBroadcast):
+		// A live parent exists on another path, so the conf watch can
+		// ride to confirmation. Advance to AwaitingConfirmation.
+		a.log.WarnS(ctx,
+			"Initial anchor broadcast deferring to existing path",
+			err, "txid", entry.data.Txid,
+		)
+
+		_ = a.advanceTrackedTxFSM(
+			ctx, entry, &trackedTxBroadcastAccepted{
+				Progress: trackedTxProgress{
+					LastBroadcastHeight: fn.Some(
+						a.bestHeight,
+					),
+				},
+			},
+		)
+
+	case errors.Is(err, ErrCPFPFeeInputUnavailable):
+		// Nothing reached any mempool. Stay in Broadcasting so the next
+		// interval re-attempts, and track the failure for escalation.
+		a.recordBroadcastFailure(ctx, entry, err)
+
+	default:
+		a.failTrackedTx(
+			ctx, entry, fmt.Sprintf("broadcast: %v", err),
+		)
+	}
+}
+
+// recordBroadcastFailure keeps a never-broadcast tx in the Broadcasting state,
+// increments its consecutive-failure counter, and escalates to the operator
+// once the counter crosses the configured threshold. It never transitions the
+// tx to a terminal state: a fraud-response checkpoint (and similar fund-risk
+// txs) must keep retrying until it lands, so the escalation is informational
+// rather than a give-up.
+func (a *TxBroadcasterActor) recordBroadcastFailure(ctx context.Context,
+	entry *trackedTx, cause error) {
+
+	currentState, stateErr := entry.currentFSMState()
+	if stateErr != nil {
+		a.log.WarnS(ctx, "Failed to read tracked tx state",
+			stateErr, "txid", entry.data.Txid)
+
+		return
+	}
+
+	failures := trackedTxBroadcastFailures(currentState) + 1
+
+	a.log.WarnS(ctx,
+		"Initial broadcast reached no mempool; will retry",
+		cause,
+		"txid", entry.data.Txid,
+		slog.String("label", entry.data.Label),
+		slog.Int("consecutive_failures", failures),
+	)
+
+	_ = a.advanceTrackedTxFSM(
+		ctx, entry, &trackedTxBroadcastFailed{
+			Progress: trackedTxProgress{
+				LastBroadcastHeight: fn.Some(a.bestHeight),
+				BroadcastFailures:   failures,
+			},
+		},
+	)
+
+	// Escalate once the failure count reaches the threshold and on every
+	// subsequent attempt, so a persistent deterministic failure stays
+	// visible to operators without giving up. The message is intentionally
+	// static so alerting can key on it.
+	if failures >= a.cfg.BroadcastFailureAlertThreshold {
+		a.log.WarnS(ctx,
+			"Tx broadcast repeatedly failing; operator "+
+				"intervention may be required",
+			cause,
+			"txid", entry.data.Txid,
+			slog.String("label", entry.data.Label),
+			slog.Int("consecutive_failures", failures),
+		)
+	}
 }
 
 // handleCancel removes one subscriber from one tracked txid.
@@ -559,16 +656,23 @@ func (a *TxBroadcasterActor) handleConfirmationObserved(ctx context.Context,
 	}
 }
 
-// handleBlockObserved records a new best height and fee-bumps any
-// eligible pending transactions.
+// handleBlockObserved records a new best height and drives interval-paced
+// retries for eligible pending transactions. Two distinct retry paths exist:
 //
-// Fee-bump failures are intentionally non-terminal: the original
-// broadcast is still live on the network and the confirmation watch
-// remains active, so the tracked tx may still confirm on its own. We
-// recover the FSM back to AwaitingConfirmation with the new height so
-// the next block observation evaluates shouldFeeBump freshly — a bump
-// attempt that failed at height H is not retried until at least
-// FeeBumpIntervalBlocks have elapsed since H.
+//   - A tx still in Broadcasting reached no mempool on its initial attempt.
+//     It is re-broadcast from scratch and the result routed through
+//     recordInitialBroadcastOutcome, so a continued failure stays in
+//     Broadcasting (and escalates) while a success advances to
+//     AwaitingConfirmation.
+//
+//   - A tx in AwaitingConfirmation already reached a mempool and is
+//     fee-bumped. Fee-bump failures are intentionally non-terminal: the
+//     original broadcast is still live and the confirmation watch remains
+//     active, so the tx may still confirm on its own. We recover the FSM back
+//     to AwaitingConfirmation with the new height so the next block
+//     observation evaluates eligibility freshly — an attempt that failed at
+//     height H is not retried until at least FeeBumpIntervalBlocks have
+//     elapsed since H.
 func (a *TxBroadcasterActor) handleBlockObserved(ctx context.Context,
 	msg *blockEpochObservedMsg) {
 
@@ -593,31 +697,42 @@ func (a *TxBroadcasterActor) handleBlockObserved(ctx context.Context,
 			continue
 		}
 
-		if !a.shouldFeeBump(entry) {
-			continue
-		}
-
-		if err := a.broadcastTrackedTx(
-			ctx, entry, TxStateFeeBumping,
-		); err != nil {
-
-			// Fee-bump failures are non-terminal. The original
-			// broadcast is still live and the confirmation watch
-			// remains active, so the tx may still confirm without
-			// the bump. Recover the FSM back to
-			// AwaitingConfirmation with an updated broadcast
-			// height so the next bump waits the full interval.
-			a.log.WarnS(ctx, "Fee bump failed, will retry",
-				err, "txid", entry.data.Txid)
-
-			progress := trackedTxProgress{
-				LastBroadcastHeight: a.bestHeight,
-			}
-			_ = a.advanceTrackedTxFSM(
-				ctx, entry, &trackedTxBroadcastAccepted{
-					Progress: progress,
-				},
+		switch {
+		// A tx that never reached any mempool is re-attempted from
+		// scratch and routed through the shared outcome handler.
+		case a.shouldRetryBroadcast(entry):
+			err := a.broadcastTrackedTx(
+				ctx, entry, TxStateBroadcasting,
 			)
+			a.recordInitialBroadcastOutcome(ctx, entry, err)
+
+		// A tx already in a mempool is fee-bumped.
+		case a.shouldFeeBump(entry):
+			if err := a.broadcastTrackedTx(
+				ctx, entry, TxStateFeeBumping,
+			); err != nil {
+
+				// Fee-bump failures are non-terminal. The
+				// original broadcast is still live and the
+				// confirmation watch remains active, so the tx
+				// may still confirm without the bump. Recover
+				// the FSM back to AwaitingConfirmation with an
+				// updated broadcast height so the next bump
+				// waits the full interval.
+				a.log.WarnS(ctx, "Fee bump failed, will retry",
+					err, "txid", entry.data.Txid)
+
+				progress := trackedTxProgress{
+					LastBroadcastHeight: fn.Some(
+						a.bestHeight,
+					),
+				}
+				_ = a.advanceTrackedTxFSM(
+					ctx, entry, &trackedTxBroadcastAccepted{
+						Progress: progress,
+					},
+				)
+			}
 		}
 	}
 }
@@ -956,7 +1071,7 @@ func (a *TxBroadcasterActor) broadcastTrackedTx(ctx context.Context,
 	if err := a.advanceTrackedTxFSM(
 		ctx, entry, &trackedTxBroadcastAccepted{
 			Progress: trackedTxProgress{
-				LastBroadcastHeight: a.bestHeight,
+				LastBroadcastHeight: fn.Some(a.bestHeight),
 				CurrentFeeRate:      result.FeeRate,
 				ChildTxid:           copyHash(result.ChildTxid),
 			},
@@ -968,15 +1083,30 @@ func (a *TxBroadcasterActor) broadcastTrackedTx(ctx context.Context,
 	return nil
 }
 
-// shouldFeeBump reports whether a tracked transaction is eligible for another
-// broadcast attempt at the current height.
+// shouldFeeBump reports whether a tracked transaction that already reached a
+// mempool is eligible for another fee-bump attempt at the current height.
 func (a *TxBroadcasterActor) shouldFeeBump(entry *trackedTx) bool {
+	return a.broadcastIntervalElapsed(entry, TxStateAwaitingConfirmation)
+}
+
+// shouldRetryBroadcast reports whether a tracked transaction that has not yet
+// reached any mempool (still in Broadcasting after a total broadcast failure)
+// is due for another initial-broadcast attempt at the current height.
+func (a *TxBroadcasterActor) shouldRetryBroadcast(entry *trackedTx) bool {
+	return a.broadcastIntervalElapsed(entry, TxStateBroadcasting)
+}
+
+// broadcastIntervalElapsed reports whether the tracked tx is in wantState and
+// at least FeeBumpIntervalBlocks have elapsed since its last broadcast attempt.
+func (a *TxBroadcasterActor) broadcastIntervalElapsed(entry *trackedTx,
+	wantState TxState) bool {
+
 	state, err := entry.currentTxState()
 	if err != nil {
 		return false
 	}
 
-	if state != TxStateAwaitingConfirmation {
+	if state != wantState {
 		return false
 	}
 
@@ -985,13 +1115,19 @@ func (a *TxBroadcasterActor) shouldFeeBump(entry *trackedTx) bool {
 		return false
 	}
 
-	lastBroadcastHeight := trackedTxLastBroadcastHeight(currentState)
-	if lastBroadcastHeight == 0 {
-		return false
-	}
-
-	return a.bestHeight-lastBroadcastHeight >=
-		a.cfg.FeeBumpIntervalBlocks
+	// A tx with no recorded broadcast height has not been submitted yet, so
+	// it is not due for a re-attempt. MapOptionZ yields the bool zero value
+	// (false) for the None case, which is exactly that. Keying on the
+	// Option presence rather than a zero height means a genuine attempt at
+	// height zero (fresh chain / early sync) is still paced correctly
+	// instead of being wedged forever.
+	return fn.MapOptionZ(
+		trackedTxLastBroadcastHeight(currentState),
+		func(lastBroadcastHeight int32) bool {
+			return a.bestHeight-lastBroadcastHeight >=
+				a.cfg.FeeBumpIntervalBlocks
+		},
+	)
 }
 
 // failTrackedTx moves one tracked txid into terminal failure and notifies all

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -1733,3 +1733,75 @@ func TestEnsureConfirmedEscalatesAfterRepeatedFailures(t *testing.T) {
 		"repeated failures must escalate to the operator",
 	)
 }
+
+// TestEnsureConfirmedRetriesTransientPackageRejection verifies that an anchor
+// (CPFP) parent whose package submission is rejected for a transient reason
+// (e.g. min relay fee not met on the zero-fee anchor parent) stays in
+// Broadcasting and is re-attempted, rather than failing terminally. This is the
+// fund-risk retry contract: such a checkpoint must keep trying until it lands.
+func TestEnsureConfirmedRetriesTransientPackageRejection(t *testing.T) {
+	chain := newFakeChainSourceRef(100)
+	chain.packageErr = fmt.Errorf("transaction rejected by the mempool " +
+		"because of low fees: min relay fee not met")
+	walletRef := &fakeWallet{
+		utxos: []*walletcore.Utxo{
+			makeWalletUTXO(t),
+		},
+	}
+	ref, _ := newTestActor(t, Config{
+		ChainSource:           chain,
+		Wallet:                walletRef,
+		FeeBumpIntervalBlocks: 1,
+	})
+
+	tx := makeTestTx(true)
+	sub := actor.NewChannelTellOnlyRef[Notification]("sub-a", 4)
+	resp := mustEnsure(t, ref.Ref(), &EnsureConfirmedReq{
+		Tx:         tx,
+		Subscriber: sub,
+	})
+
+	// A transient package rejection must NOT fail the fund-risk tx; it
+	// stays in Broadcasting for re-attempt.
+	require.Equal(t, TxStateBroadcasting, resp.State)
+	require.Equal(t, 1, chain.packageCallCount())
+	mustHaveNoNotification(t, sub)
+
+	// The next interval re-attempts (hitting the same rejection) and the tx
+	// remains non-terminal.
+	chain.emitBlock(t, 101)
+	require.Equal(
+		t, TxStateBroadcasting,
+		mustTrackedState(
+			t, ref.Ref(), tx, sub,
+		),
+	)
+	require.Equal(t, 2, chain.packageCallCount())
+	mustHaveNoNotification(t, sub)
+}
+
+// TestEnsureConfirmedFailsPermanentBroadcastError verifies that a structurally
+// permanent broadcast error (a non-TRUC parent) fails terminally instead of
+// spinning in the Broadcasting retry loop.
+func TestEnsureConfirmedFailsPermanentBroadcastError(t *testing.T) {
+	chain := newFakeChainSourceRef(100)
+	ref, _ := newTestActor(t, Config{
+		ChainSource: chain,
+		Wallet:      &fakeWallet{},
+	})
+
+	// A v2 (non-TRUC) parent is rejected by the broadcaster's version gate
+	// with ErrNonTRUCParent on every attempt.
+	tx := makeTestTx(true)
+	tx.Version = 2
+
+	sub := actor.NewChannelTellOnlyRef[Notification]("sub-a", 4)
+	resp := mustEnsure(t, ref.Ref(), &EnsureConfirmedReq{
+		Tx:         tx,
+		Subscriber: sub,
+	})
+	require.Equal(t, TxStateFailed, resp.State)
+
+	failed := mustAwaitNotification(t, sub)
+	require.IsType(t, &TxFailed{}, failed)
+}

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,7 +16,9 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/chainbackends"
 	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightninglabs/darepo-client/walletcore"
@@ -571,6 +575,24 @@ func mustEnsure(t *testing.T, ref actor.ActorRef[Msg, Resp],
 	require.True(t, ok)
 
 	return typed
+}
+
+// mustTrackedState returns the current public state of a tracked tx by
+// re-issuing an idempotent ensure for the same subscriber. Re-ensuring an
+// existing txid attaches without re-broadcasting, so it is a side-effect-free
+// way to observe FSM state from the test goroutine.
+func mustTrackedState(t *testing.T, ref actor.ActorRef[Msg, Resp],
+	tx *wire.MsgTx, sub actor.TellOnlyRef[Notification]) TxState {
+
+	t.Helper()
+
+	resp := mustEnsure(t, ref, &EnsureConfirmedReq{
+		Tx:         tx,
+		Subscriber: sub,
+	})
+	require.False(t, resp.Created)
+
+	return resp.State
 }
 
 // mustCancel sends a CancelInterestReq and returns the typed response.
@@ -1188,8 +1210,9 @@ func TestFeeBumpOnNewBlocks(t *testing.T) {
 }
 
 // TestEnsureConfirmedWaitsForInitialCPFPInput verifies that an anchor parent
-// stays retryable when its first broadcast attempt lacks a confirmed fee
-// input.
+// whose first broadcast attempt reaches no mempool (no confirmed fee input)
+// stays in the Broadcasting state — not AwaitingConfirmation — and is
+// re-attempted on each interval without ever advancing to a terminal state.
 func TestEnsureConfirmedWaitsForInitialCPFPInput(t *testing.T) {
 	chain := newFakeChainSourceRef(100)
 	walletRef := &fakeWallet{
@@ -1207,16 +1230,36 @@ func TestEnsureConfirmedWaitsForInitialCPFPInput(t *testing.T) {
 		Tx:         tx,
 		Subscriber: sub,
 	})
-	require.Equal(t, TxStateAwaitingConfirmation, resp.State)
+
+	// A tx that reached no mempool must report Broadcasting, not the
+	// misleading AwaitingConfirmation that #509 flagged.
+	require.Equal(t, TxStateBroadcasting, resp.State)
 	require.Equal(t, 0, chain.packageCallCount())
 	require.Equal(t, 0, chain.broadcastCallCount())
 	mustHaveNoNotification(t, sub)
 
+	// One block short of the interval: no re-attempt yet.
 	chain.emitBlock(t, 101)
 	require.Equal(t, 0, chain.packageCallCount())
+	require.Equal(
+		t, TxStateBroadcasting,
+		mustTrackedState(
+			t, ref.Ref(), tx, sub,
+		),
+	)
 
+	// Interval elapsed: a re-attempt fires but still fails (wallet broken),
+	// so the tx stays in Broadcasting and never reaches a mempool or a
+	// terminal state.
 	chain.emitBlock(t, 102)
 	require.Equal(t, 0, chain.packageCallCount())
+	require.Equal(
+		t, TxStateBroadcasting,
+		mustTrackedState(
+			t, ref.Ref(), tx, sub,
+		),
+	)
+	mustHaveNoNotification(t, sub)
 }
 
 // TestEnsureConfirmedRepeatedEnsureIsIdempotent verifies that repeating the
@@ -1459,5 +1502,234 @@ func TestTerminalEntryEvictedAfterFailure(t *testing.T) {
 	require.False(
 		t, cancelResp.Removed,
 		"failed entry should have been evicted before cancel",
+	)
+}
+
+// flakyListWallet wraps a fakeWallet and makes ListUnspent fail a fixed number
+// of times before succeeding, simulating a wallet whose confirmed fee inputs
+// only become available after some delay.
+type flakyListWallet struct {
+	*fakeWallet
+
+	// remaining is the number of ListUnspent calls that still fail before
+	// the wallet starts returning its UTXOs.
+	remaining atomic.Int32
+}
+
+// ListUnspent fails while remaining calls are budgeted, then delegates to the
+// embedded fakeWallet.
+func (w *flakyListWallet) ListUnspent(ctx context.Context, minConfs,
+	maxConfs int32) ([]*walletcore.Utxo, error) {
+
+	if w.remaining.Add(-1) >= 0 {
+		return nil, fmt.Errorf("list temporarily unavailable")
+	}
+
+	return w.fakeWallet.ListUnspent(ctx, minConfs, maxConfs)
+}
+
+// TestEnsureConfirmedRetriesUntilBroadcastSucceeds verifies that a tx whose
+// initial broadcast reaches no mempool stays in Broadcasting, is re-attempted
+// on each interval, and finally advances to AwaitingConfirmation once the
+// broadcast succeeds — with the package submitted exactly once.
+func TestEnsureConfirmedRetriesUntilBroadcastSucceeds(t *testing.T) {
+	chain := newFakeChainSourceRef(100)
+	walletRef := &flakyListWallet{
+		fakeWallet: &fakeWallet{
+			utxos: []*walletcore.Utxo{
+				makeWalletUTXO(t),
+			},
+		},
+	}
+
+	// Fail the initial attempt and the first retry; succeed on the second
+	// retry.
+	walletRef.remaining.Store(2)
+
+	ref, _ := newTestActor(t, Config{
+		ChainSource:           chain,
+		Wallet:                walletRef,
+		FeeBumpIntervalBlocks: 1,
+	})
+
+	tx := makeTestTx(true)
+	sub := actor.NewChannelTellOnlyRef[Notification]("sub-a", 4)
+	resp := mustEnsure(t, ref.Ref(), &EnsureConfirmedReq{
+		Tx:         tx,
+		Subscriber: sub,
+	})
+	require.Equal(t, TxStateBroadcasting, resp.State)
+	require.Equal(t, 0, chain.packageCallCount())
+
+	// First retry still fails: tx stays in Broadcasting.
+	chain.emitBlock(t, 101)
+	require.Equal(
+		t, TxStateBroadcasting,
+		mustTrackedState(
+			t, ref.Ref(), tx, sub,
+		),
+	)
+	require.Equal(t, 0, chain.packageCallCount())
+
+	// Second retry succeeds: tx advances to AwaitingConfirmation and the
+	// package is submitted once.
+	chain.emitBlock(t, 102)
+	require.Equal(
+		t, TxStateAwaitingConfirmation,
+		mustTrackedState(
+			t, ref.Ref(), tx, sub,
+		),
+	)
+	require.Equal(t, 1, chain.packageCallCount())
+	mustHaveNoNotification(t, sub)
+}
+
+// TestEnsureConfirmedRetriesWhenFirstAttemptFailsAtHeightZero verifies that a
+// tx whose initial broadcast fails while the actor's best height is still zero
+// (a fresh chain or very early sync) is not wedged in Broadcasting forever. The
+// failed attempt records LastBroadcastHeight=Some(0), and because the retry
+// pacing keys on the recorded-height Option rather than overloading a zero
+// height as "never broadcast", the next interval re-attempts and the heal
+// advances the tx to AwaitingConfirmation. Before the fix this never re-armed.
+func TestEnsureConfirmedRetriesWhenFirstAttemptFailsAtHeightZero(t *testing.T) {
+	chain := newFakeChainSourceRef(0)
+	walletRef := &flakyListWallet{
+		fakeWallet: &fakeWallet{
+			utxos: []*walletcore.Utxo{
+				makeWalletUTXO(t),
+			},
+		},
+	}
+
+	// Fail only the initial attempt (recorded at height zero); the first
+	// retry succeeds.
+	walletRef.remaining.Store(1)
+
+	ref, _ := newTestActor(t, Config{
+		ChainSource:           chain,
+		Wallet:                walletRef,
+		FeeBumpIntervalBlocks: 1,
+	})
+
+	tx := makeTestTx(true)
+	sub := actor.NewChannelTellOnlyRef[Notification]("sub-a", 4)
+	resp := mustEnsure(t, ref.Ref(), &EnsureConfirmedReq{
+		Tx:         tx,
+		Subscriber: sub,
+	})
+
+	// The initial broadcast failed at best-height zero, so the tx stays in
+	// Broadcasting with a recorded height of zero.
+	require.Equal(t, TxStateBroadcasting, resp.State)
+	require.Equal(t, 0, chain.packageCallCount())
+
+	// One block elapses the interval (1 - 0 >= 1): the retry must fire and
+	// succeed, advancing the tx to AwaitingConfirmation rather than leaving
+	// it wedged at height zero.
+	chain.emitBlock(t, 1)
+	require.Equal(
+		t, TxStateAwaitingConfirmation,
+		mustTrackedState(
+			t, ref.Ref(), tx, sub,
+		),
+	)
+	require.Equal(t, 1, chain.packageCallCount())
+	mustHaveNoNotification(t, sub)
+}
+
+// TestEnsureConfirmedDefersToExistingParentBroadcast verifies that when the
+// package submission reports the parent is already known on another path (and
+// only the child failed), the tx advances to AwaitingConfirmation rather than
+// staying in Broadcasting — the conf watch rides the existing parent to
+// confirmation.
+func TestEnsureConfirmedDefersToExistingParentBroadcast(t *testing.T) {
+	chain := newFakeChainSourceRef(100)
+
+	tx := makeTestTx(true)
+	chain.packageErr = errors.Join(
+		chainbackends.NewPackageTxError(
+			"W1", tx.TxHash(),
+			"txn-already-known",
+		),
+		chainbackends.NewPackageTxError(
+			"W2", chainhash.Hash{0xab},
+			"bad-txns-inputs-missingorspent",
+		),
+	)
+
+	walletRef := &fakeWallet{
+		utxos: []*walletcore.Utxo{
+			makeWalletUTXO(t),
+		},
+	}
+	ref, _ := newTestActor(t, Config{
+		ChainSource: chain,
+		Wallet:      walletRef,
+	})
+
+	tx2 := tx
+	sub := actor.NewChannelTellOnlyRef[Notification]("sub-a", 4)
+	resp := mustEnsure(t, ref.Ref(), &EnsureConfirmedReq{
+		Tx:         tx2,
+		Subscriber: sub,
+	})
+
+	// A live parent exists on another path, so we await confirmation rather
+	// than retrying as a never-broadcast tx.
+	require.Equal(t, TxStateAwaitingConfirmation, resp.State)
+	require.Equal(t, 1, chain.packageCallCount())
+	mustHaveNoNotification(t, sub)
+}
+
+// TestEnsureConfirmedEscalatesAfterRepeatedFailures verifies that repeated
+// total broadcast failures escalate to an operator-visible warning once the
+// configured threshold is crossed, while the tx keeps retrying and never
+// advances to a terminal state.
+func TestEnsureConfirmedEscalatesAfterRepeatedFailures(t *testing.T) {
+	var buf bytes.Buffer
+	logger := btclog.NewSLogger(btclog.NewDefaultHandler(&buf))
+	logger.SetLevel(btclog.LevelTrace)
+
+	chain := newFakeChainSourceRef(100)
+	walletRef := &fakeWallet{
+		listErr: fmt.Errorf("list failed"),
+	}
+	ref, _ := newTestActor(t, Config{
+		ChainSource:                    chain,
+		Wallet:                         walletRef,
+		FeeBumpIntervalBlocks:          1,
+		BroadcastFailureAlertThreshold: 3,
+		Log:                            fn.Some[btclog.Logger](logger),
+	})
+
+	tx := makeTestTx(true)
+	sub := actor.NewChannelTellOnlyRef[Notification]("sub-a", 4)
+	resp := mustEnsure(t, ref.Ref(), &EnsureConfirmedReq{
+		Tx:         tx,
+		Subscriber: sub,
+	})
+	require.Equal(t, TxStateBroadcasting, resp.State)
+
+	// Drive enough interval-paced retries to cross the alert threshold.
+	chain.emitBlock(t, 101)
+	chain.emitBlock(t, 102)
+	chain.emitBlock(t, 103)
+
+	// A synchronous round-trip flushes the actor mailbox, so all retry
+	// handling (and its logging) has completed before we inspect state and
+	// captured logs.
+	require.Equal(
+		t, TxStateBroadcasting,
+		mustTrackedState(
+			t, ref.Ref(), tx, sub,
+		),
+	)
+	require.Equal(t, 0, chain.packageCallCount())
+	mustHaveNoNotification(t, sub)
+
+	require.Contains(
+		t, buf.String(),
+		"operator intervention",
+		"repeated failures must escalate to the operator",
 	)
 }

--- a/txconfirm/broadcaster_test.go
+++ b/txconfirm/broadcaster_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
 	"github.com/lightninglabs/darepo-client/chainbackends"
 	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightninglabs/darepo-client/walletcore"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
@@ -895,6 +896,165 @@ func TestCPFPReselectsAfterPreciseFeeGrowth(t *testing.T) {
 	require.False(
 		t, spendsSmall, "child must not spend the abandoned UTXO",
 	)
+}
+
+// makeCheckpointShapedParent builds a v3/TRUC parent that mirrors a finalized
+// OOR checkpoint / fraud-response tx: its sole non-anchor input already carries
+// a real (pre-signed) taproot key-spend witness, it has a taproot checkpoint
+// output, and the canonical P2A anchor is the last output. This differs from a
+// round commitment tx only in the parent's own input witness — the trait
+// issue #509 hypothesised would break the CPFP child finalize path.
+func makeCheckpointShapedParent() (*wire.MsgTx, wire.TxWitness) {
+	tx := wire.NewMsgTx(3)
+
+	// A pre-signed taproot key-spend witness (single 64-byte schnorr sig),
+	// as a finalized OOR checkpoint input would carry.
+	signedWitness := wire.TxWitness{bytes.Repeat([]byte{0x07}, 64)}
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{0xcc},
+			Index: 1,
+		},
+		Witness: signedWitness,
+	})
+
+	// A P2TR checkpoint output (OP_1 <32-byte key>).
+	checkpointPkScript := append(
+		[]byte{txscript.OP_1, txscript.OP_DATA_32},
+		bytes.Repeat([]byte{0x02}, 32)...,
+	)
+	tx.AddTxOut(&wire.TxOut{
+		Value:    50_000,
+		PkScript: checkpointPkScript,
+	})
+
+	// The canonical P2A anchor, always last.
+	tx.AddTxOut(arkscript.AnchorOutput())
+
+	return tx, signedWitness
+}
+
+// TestCPFPChildFinalizesCheckpointShapedParent is a regression test for
+// issue #509. It proves the CPFP child finalize path is agnostic to the
+// parent's input type: a checkpoint / fraud-response parent — whose own input
+// is a pre-signed taproot key-spend, unlike a round commitment tx — still
+// yields a CPFP child whose canonical P2A anchor input is pre-finalized with an
+// empty witness, so LND FinalizePsbt only has to sign the wallet fee input. The
+// parent's signed input is preserved byte-for-byte; the broadcaster never
+// re-finalizes it.
+func TestCPFPChildFinalizesCheckpointShapedParent(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	chain.feeRate = 5
+
+	parent, parentWitness := makeCheckpointShapedParent()
+	parentTxid := parent.TxHash()
+
+	anchorIdx := findAnchorOutput(parent)
+	require.GreaterOrEqual(t, anchorIdx, 0, "parent must carry an anchor")
+	anchorOutpoint := wire.OutPoint{
+		Hash:  parentTxid,
+		Index: uint32(anchorIdx),
+	}
+
+	feeUtxo := &walletcore.Utxo{
+		Outpoint: wire.OutPoint{
+			Hash: chainhash.Hash{
+				0xfe,
+			},
+			Index: 0,
+		},
+		Amount:   200_000,
+		PkScript: p2pkhTestPkScript(t),
+	}
+
+	// inspect runs on the child PSBT before the wallet attaches dummy
+	// witnesses. It directly asserts the mechanism #509 claimed was
+	// missing: signCPFPChild pre-finalizes the anchor input (empty witness)
+	// and leaves the wallet fee input for FinalizePsbt to sign.
+	var inspected bool
+	wlt := &rewritingWallet{
+		utxos: []*walletcore.Utxo{
+			feeUtxo,
+		},
+		changeScript: []byte{
+			txscript.OP_TRUE,
+		},
+		inspect: func(p *psbt.Packet) {
+			inspected = true
+			for i, in := range p.UnsignedTx.TxIn {
+				switch in.PreviousOutPoint {
+				case anchorOutpoint:
+					require.Equal(
+						t, []byte{0x00},
+						p.Inputs[i].FinalScriptWitness,
+						"anchor input must be "+
+							"pre-finalized empty",
+					)
+
+				case feeUtxo.Outpoint:
+					require.Empty(
+						t,
+						p.Inputs[i].FinalScriptWitness,
+						"fee input must be left "+
+							"for the wallet to "+
+							"sign",
+					)
+					require.NotNil(
+						t, p.Inputs[i].WitnessUtxo,
+					)
+				}
+			}
+		},
+	}
+
+	b := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource: chain,
+		Wallet:      wlt,
+	})
+
+	_, err := b.Submit(t.Context(), 100, &BroadcastRequest{
+		Tx: parent, Label: "fraud-spent_leaf",
+	})
+	require.NoError(t, err)
+	require.True(t, inspected, "FinalizePsbt inspect hook must have run")
+
+	// A CPFP package — not a direct-broadcast fallback — must have been
+	// submitted.
+	require.Equal(t, 1, chain.packageCallCount())
+	require.Zero(t, chain.broadcastCallCount())
+
+	child := chain.packageCalls[0].Child
+	require.NotNil(t, child)
+
+	// The child's anchor input is spent with an empty witness (P2A is
+	// anyone-can-spend), while the wallet fee input carries a signature.
+	var sawAnchor, sawFee bool
+	for _, in := range child.TxIn {
+		switch in.PreviousOutPoint {
+		case anchorOutpoint:
+			sawAnchor = true
+			require.Empty(
+				t, in.Witness,
+				"anchor input witness must be empty",
+			)
+
+		case feeUtxo.Outpoint:
+			sawFee = true
+			require.NotEmpty(
+				t, in.Witness,
+				"fee input must be signed by the wallet",
+			)
+		}
+	}
+	require.True(t, sawAnchor, "child must spend the parent anchor")
+	require.True(t, sawFee, "child must spend the wallet fee input")
+
+	// The parent in the submitted package is untouched: its pre-signed
+	// checkpoint input witness is preserved byte-for-byte.
+	submittedParent := chain.packageCalls[0].Parents[0]
+	require.Equal(t, parentWitness, submittedParent.TxIn[0].Witness)
 }
 
 // TestCPFPBroadcasterFallbackAndErrors covers the lower-level generic

--- a/txconfirm/broadcaster_test.go
+++ b/txconfirm/broadcaster_test.go
@@ -1351,7 +1351,7 @@ func TestActorValidationAndCleanup(t *testing.T) {
 				},
 			},
 			trackedTxProgress: trackedTxProgress{
-				LastBroadcastHeight: 99,
+				LastBroadcastHeight: fn.Some[int32](99),
 			},
 		}
 		entry := newTrackedTxForState(t, awaitState)
@@ -1364,7 +1364,7 @@ func TestActorValidationAndCleanup(t *testing.T) {
 				},
 			},
 			trackedTxProgress: trackedTxProgress{
-				LastBroadcastHeight: 98,
+				LastBroadcastHeight: fn.Some[int32](98),
 			},
 		}
 		entry = newTrackedTxForState(t, awaitState2)
@@ -1375,7 +1375,7 @@ func TestActorValidationAndCleanup(t *testing.T) {
 				Txid: chainhash.Hash{7},
 			},
 			trackedTxProgress: trackedTxProgress{
-				LastBroadcastHeight: 98,
+				LastBroadcastHeight: fn.Some[int32](98),
 			},
 			ConfirmHeight: 100,
 		})
@@ -1397,7 +1397,7 @@ func TestActorValidationAndCleanup(t *testing.T) {
 				TargetConfs: 1,
 			},
 			trackedTxProgress: trackedTxProgress{
-				LastBroadcastHeight: 99,
+				LastBroadcastHeight: fn.Some[int32](99),
 			},
 		}
 		entry := newTrackedTxForState(t, awaitConf)

--- a/txconfirm/doc.go
+++ b/txconfirm/doc.go
@@ -50,6 +50,18 @@
 // tracked entry only while a terminal notification still needs retry
 // delivery.
 //
+// A broadcast that reaches no mempool at all does NOT advance to
+// AwaitingConfirmation. It stays in Broadcasting and self-loops there,
+// re-attempting every fee-bump interval, and is never failed
+// automatically — only a structurally permanent error (a non-TRUC
+// parent) is terminal. Transient conditions such as a missing confirmed
+// fee input, a min-relay-fee rejection of the zero-fee anchor parent, or
+// a mempool-full backend keep retrying. After
+// Config.BroadcastFailureAlertThreshold consecutive failures the actor
+// emits a rate-limited operator escalation, because a fund-risk tx (e.g.
+// a fraud-response checkpoint) must eventually land rather than be
+// silently abandoned.
+//
 // # CPFP correctness
 //
 // For transactions containing an ephemeral anchor output (BIP 431), the

--- a/txconfirm/fsm_test.go
+++ b/txconfirm/fsm_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btclog/v2"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,7 +52,7 @@ func TestTrackedTxFSMInitialBroadcastFlow(t *testing.T) {
 	require.Equal(t, data.TargetConfs, broadcasting.TargetConfs)
 
 	progress := trackedTxProgress{
-		LastBroadcastHeight: 100,
+		LastBroadcastHeight: fn.Some[int32](100),
 		CurrentFeeRate:      7,
 		ChildTxid:           copyHash(&data.Txid),
 	}
@@ -76,7 +77,9 @@ func TestTrackedTxFSMInitialBroadcastFlow(t *testing.T) {
 		t, TxStateAwaitingConfirmation,
 		txStateFromTrackedState(awaiting),
 	)
-	require.Equal(t, int32(100), trackedTxLastBroadcastHeight(awaiting))
+	require.Equal(
+		t, fn.Some[int32](100), trackedTxLastBroadcastHeight(awaiting),
+	)
 
 	_, err = fsm.AskEvent(
 		t.Context(), &trackedTxConfirmed{
@@ -121,7 +124,7 @@ func TestTrackedTxFSMFeeBumpFlow(t *testing.T) {
 	_, err = fsm.AskEvent(
 		t.Context(), &trackedTxBroadcastAccepted{
 			Progress: trackedTxProgress{
-				LastBroadcastHeight: 100,
+				LastBroadcastHeight: fn.Some[int32](100),
 				CurrentFeeRate:      5,
 			},
 		},
@@ -137,13 +140,13 @@ func TestTrackedTxFSMFeeBumpFlow(t *testing.T) {
 		t, fsm,
 	).(*trackedTxStateFeeBumping)
 	require.True(t, ok)
-	require.Equal(t, int32(100), feeBumping.LastBroadcastHeight)
+	require.Equal(t, fn.Some[int32](100), feeBumping.LastBroadcastHeight)
 	require.Equal(t, 0, feeBumping.BumpCount)
 
 	_, err = fsm.AskEvent(
 		t.Context(), &trackedTxBroadcastAccepted{
 			Progress: trackedTxProgress{
-				LastBroadcastHeight: 103,
+				LastBroadcastHeight: fn.Some[int32](103),
 				CurrentFeeRate:      11,
 			},
 		},
@@ -154,7 +157,7 @@ func TestTrackedTxFSMFeeBumpFlow(t *testing.T) {
 		t, fsm,
 	).(*trackedTxStateAwaitingConfirmation)
 	require.True(t, ok)
-	require.Equal(t, int32(103), awaiting.LastBroadcastHeight)
+	require.Equal(t, fn.Some[int32](103), awaiting.LastBroadcastHeight)
 	require.Equal(t, int64(11), awaiting.CurrentFeeRate)
 	require.Equal(t, 1, awaiting.BumpCount)
 }
@@ -188,7 +191,7 @@ func TestTrackedTxFSMFailureAndInvalidTransitions(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "broadcast rejected", reason)
 	require.Equal(t, TxStateFailed, txStateFromTrackedState(failed))
-	require.Zero(t, trackedTxLastBroadcastHeight(failed))
+	require.True(t, trackedTxLastBroadcastHeight(failed).IsNone())
 
 	_, err = failed.ProcessEvent(
 		t.Context(), &trackedTxBroadcastStarted{},
@@ -205,4 +208,101 @@ func TestTrackedTxFSMFailureAndInvalidTransitions(t *testing.T) {
 		}, &trackedTxEnvironment{Txid: data.Txid},
 	)
 	require.Error(t, err)
+}
+
+// TestTrackedTxFSMBroadcastFailureStaysBroadcasting verifies that a total
+// broadcast failure self-loops the Broadcasting state, accumulating the
+// consecutive-failure counter and last attempt height, and that a later
+// success advances to AwaitingConfirmation with a reset failure counter.
+func TestTrackedTxFSMBroadcastFailureStaysBroadcasting(t *testing.T) {
+	tx := makeTestTx(true)
+	data := trackedTxData{
+		Tx:          tx,
+		Txid:        tx.TxHash(),
+		TargetConfs: 1,
+	}
+
+	fsm := newTrackedTxStateMachine(btclog.Disabled, data)
+	fsm.Start(t.Context())
+	t.Cleanup(fsm.Stop)
+
+	_, err := fsm.AskEvent(
+		t.Context(), &trackedTxBroadcastStarted{},
+	).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	// First total failure: stay in Broadcasting, counter at 1.
+	_, err = fsm.AskEvent(
+		t.Context(), &trackedTxBroadcastFailed{
+			Progress: trackedTxProgress{
+				LastBroadcastHeight: fn.Some[int32](100),
+				BroadcastFailures:   1,
+			},
+		},
+	).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	broadcasting, ok := mustCurrentTrackedTxState(
+		t, fsm,
+	).(*trackedTxStateBroadcasting)
+	require.True(t, ok)
+	require.Equal(
+		t, TxStateBroadcasting, txStateFromTrackedState(broadcasting),
+	)
+	require.Equal(t, fn.Some[int32](100), broadcasting.LastBroadcastHeight)
+	require.Equal(t, 1, broadcasting.BroadcastFailures)
+	require.Equal(t, 1, trackedTxBroadcastFailures(broadcasting))
+	require.Equal(
+		t, fn.Some[int32](100),
+		trackedTxLastBroadcastHeight(broadcasting),
+	)
+
+	// A re-attempt self-loops Broadcasting, preserving accumulated
+	// progress until it resolves.
+	_, err = fsm.AskEvent(
+		t.Context(), &trackedTxBroadcastStarted{},
+	).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	stillBroadcasting, ok := mustCurrentTrackedTxState(
+		t, fsm,
+	).(*trackedTxStateBroadcasting)
+	require.True(t, ok)
+	require.Equal(t, 1, stillBroadcasting.BroadcastFailures)
+
+	// Second total failure: counter advances to 2.
+	_, err = fsm.AskEvent(
+		t.Context(), &trackedTxBroadcastFailed{
+			Progress: trackedTxProgress{
+				LastBroadcastHeight: fn.Some[int32](102),
+				BroadcastFailures:   2,
+			},
+		},
+	).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	broadcasting, ok = mustCurrentTrackedTxState(
+		t, fsm,
+	).(*trackedTxStateBroadcasting)
+	require.True(t, ok)
+	require.Equal(t, 2, broadcasting.BroadcastFailures)
+
+	// Eventual success advances to AwaitingConfirmation and resets the
+	// failure counter (the accepted progress carries no failures).
+	_, err = fsm.AskEvent(
+		t.Context(), &trackedTxBroadcastAccepted{
+			Progress: trackedTxProgress{
+				LastBroadcastHeight: fn.Some[int32](104),
+				CurrentFeeRate:      9,
+			},
+		},
+	).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	awaiting, ok := mustCurrentTrackedTxState(
+		t, fsm,
+	).(*trackedTxStateAwaitingConfirmation)
+	require.True(t, ok)
+	require.Equal(t, fn.Some[int32](104), awaiting.LastBroadcastHeight)
+	require.Equal(t, 0, trackedTxBroadcastFailures(awaiting))
 }

--- a/txconfirm/fsm_types.go
+++ b/txconfirm/fsm_types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/protofsm"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
 // trackedTxStateMachine is the protofsm instance used for one tracked txid.
@@ -75,8 +76,12 @@ type trackedTxData struct {
 // states after the transaction has been submitted at least once.
 type trackedTxProgress struct {
 	// LastBroadcastHeight is the chain height at which the last submission
-	// attempt completed.
-	LastBroadcastHeight int32
+	// attempt completed. It is None until the tx has been submitted at
+	// least once, so the retry/fee-bump interval check can distinguish "no
+	// attempt yet" from a genuine attempt at height zero (e.g. on a fresh
+	// chain or during early sync) rather than overloading a zero height as
+	// the sentinel.
+	LastBroadcastHeight fn.Option[int32]
 
 	// CurrentFeeRate is the fee rate used by the latest submission attempt.
 	CurrentFeeRate int64
@@ -84,6 +89,14 @@ type trackedTxProgress struct {
 	// BumpCount counts successful fee-bump rebroadcasts after the initial
 	// submission.
 	BumpCount int
+
+	// BroadcastFailures counts consecutive initial-broadcast attempts that
+	// reached no mempool at all (both the CPFP child sign and the
+	// direct-parent fallback failed). It is reset to zero once a broadcast
+	// succeeds and the tx advances to AwaitingConfirmation. The actor uses
+	// it to escalate to the operator after repeated deterministic failures
+	// without ever giving up on a tx that must still confirm.
+	BroadcastFailures int
 
 	// ChildTxid is the latest CPFP child txid when an anchor package was
 	// built.
@@ -106,6 +119,20 @@ type trackedTxBroadcastAccepted struct {
 
 // trackedTxEventSealed marks trackedTxBroadcastAccepted as a tracked-tx event.
 func (e *trackedTxBroadcastAccepted) trackedTxEventSealed() {}
+
+// trackedTxBroadcastFailed records that an initial broadcast attempt reached
+// no mempool at all. It keeps the tx in the Broadcasting state (rather than
+// falsely advancing to AwaitingConfirmation) so it is re-attempted on the
+// next interval, and carries the updated progress including the incremented
+// consecutive-failure counter.
+type trackedTxBroadcastFailed struct {
+	// Progress captures the broadcast metadata for the failed attempt,
+	// including the bumped BroadcastFailures counter.
+	Progress trackedTxProgress
+}
+
+// trackedTxEventSealed marks trackedTxBroadcastFailed as a tracked-tx event.
+func (e *trackedTxBroadcastFailed) trackedTxEventSealed() {}
 
 // trackedTxFeeBumpStarted records the start of a fee-bump rebroadcast
 // attempt.
@@ -227,9 +254,13 @@ func (t *trackedTx) currentFSMState() (trackedTxState, error) {
 	return state, nil
 }
 
-// trackedTxLastBroadcastHeight returns the state's latest broadcast height.
-func trackedTxLastBroadcastHeight(state trackedTxState) int32 {
+// trackedTxLastBroadcastHeight returns the state's latest broadcast height, or
+// None if the tx has not been submitted yet.
+func trackedTxLastBroadcastHeight(state trackedTxState) fn.Option[int32] {
 	switch s := state.(type) {
+	case *trackedTxStateBroadcasting:
+		return s.LastBroadcastHeight
+
 	case *trackedTxStateAwaitingConfirmation:
 		return s.LastBroadcastHeight
 
@@ -243,8 +274,20 @@ func trackedTxLastBroadcastHeight(state trackedTxState) int32 {
 		return s.LastBroadcastHeight
 
 	default:
-		return 0
+		return fn.None[int32]()
 	}
+}
+
+// trackedTxBroadcastFailures returns the state's consecutive failed-broadcast
+// count. Only the Broadcasting state tracks failures; every other state has
+// either not started broadcasting or already reached a mempool, so the count
+// is zero there.
+func trackedTxBroadcastFailures(state trackedTxState) int {
+	if s, ok := state.(*trackedTxStateBroadcasting); ok {
+		return s.BroadcastFailures
+	}
+
+	return 0
 }
 
 // trackedTxConfirmHeight returns the state's confirmation height if the

--- a/txconfirm/messages.go
+++ b/txconfirm/messages.go
@@ -38,11 +38,18 @@ const (
 	TxStateNew TxState = iota
 
 	// TxStateBroadcasting indicates the initial broadcast attempt is in
-	// progress.
+	// progress, or that it failed to reach any mempool and is being
+	// re-attempted on each fee-bump interval. A tx in this state has NOT
+	// yet been accepted anywhere; it is distinct from
+	// TxStateAwaitingConfirmation, which is reported only once the tx (or a
+	// redundant parent on another path) has actually reached a mempool. A
+	// tx that cannot broadcast is never failed automatically — it retries
+	// until it lands and escalates to the operator after
+	// BroadcastFailureAlertThreshold consecutive failures.
 	TxStateBroadcasting
 
-	// TxStateAwaitingConfirmation indicates the transaction has been
-	// submitted and is waiting for chain confirmation.
+	// TxStateAwaitingConfirmation indicates the transaction has reached a
+	// mempool and is waiting for chain confirmation.
 	TxStateAwaitingConfirmation
 
 	// TxStateFeeBumping indicates a replacement or rebroadcast attempt is

--- a/txconfirm/states.go
+++ b/txconfirm/states.go
@@ -50,9 +50,12 @@ func (s *trackedTxStateNew) ProcessEvent(_ context.Context,
 }
 
 // trackedTxStateBroadcasting indicates the initial broadcast attempt is in
-// progress.
+// progress, or has failed to reach any mempool and is awaiting re-attempt.
+// The embedded progress carries the last attempt height and the consecutive
+// failure counter so the actor can pace retries and escalate to the operator.
 type trackedTxStateBroadcasting struct {
 	trackedTxData
+	trackedTxProgress
 }
 
 // String returns a human-readable representation of the broadcasting state.
@@ -74,6 +77,29 @@ func (s *trackedTxStateBroadcasting) ProcessEvent(_ context.Context,
 	*trackedTxStateTransition, error) {
 
 	switch e := event.(type) {
+	case *trackedTxBroadcastStarted:
+		// A re-attempt of the initial broadcast self-loops the
+		// Broadcasting state, preserving the accumulated progress
+		// (last attempt height and failure counter) until the attempt
+		// resolves to acceptance or another failure.
+		return &trackedTxStateTransition{
+			NextState: &trackedTxStateBroadcasting{
+				trackedTxData:     s.trackedTxData,
+				trackedTxProgress: s.trackedTxProgress,
+			},
+		}, nil
+
+	case *trackedTxBroadcastFailed:
+		// The attempt reached no mempool. Stay in Broadcasting with
+		// the updated progress so the next interval re-attempts rather
+		// than falsely reporting AwaitingConfirmation.
+		return &trackedTxStateTransition{
+			NextState: &trackedTxStateBroadcasting{
+				trackedTxData:     s.trackedTxData,
+				trackedTxProgress: e.Progress,
+			},
+		}, nil
+
 	case *trackedTxBroadcastAccepted:
 		return &trackedTxStateTransition{
 			NextState: &trackedTxStateAwaitingConfirmation{
@@ -85,16 +111,18 @@ func (s *trackedTxStateBroadcasting) ProcessEvent(_ context.Context,
 	case *trackedTxConfirmed:
 		return &trackedTxStateTransition{
 			NextState: &trackedTxStateConfirmed{
-				trackedTxData: s.trackedTxData,
-				ConfirmHeight: e.BlockHeight,
+				trackedTxData:     s.trackedTxData,
+				trackedTxProgress: s.trackedTxProgress,
+				ConfirmHeight:     e.BlockHeight,
 			},
 		}, nil
 
 	case *trackedTxFailed:
 		return &trackedTxStateTransition{
 			NextState: &trackedTxStateFailed{
-				trackedTxData: s.trackedTxData,
-				Reason:        e.Reason,
+				trackedTxData:     s.trackedTxData,
+				trackedTxProgress: s.trackedTxProgress,
+				Reason:            e.Reason,
 			},
 		}, nil
 


### PR DESCRIPTION
## Summary

Addresses [issue #509](https://github.com/lightninglabs/darepo/issues/509) on the client side. A fraud-response checkpoint whose initial broadcast reached no mempool (CPFP child sign **and** direct-parent fallback both failing, surfaced as `ErrCPFPFeeInputUnavailable`) was advanced straight to `AwaitingConfirmation` and then retried forever with no escalation — a tracked tx silently "awaiting confirmation" that was never actually sent. On a fund-risk path this is dangerous: the checkpoint must confirm before the client's unilateral-exit CSV matures.

This PR:

1. **Keeps never-broadcast txs in `Broadcasting`** (item 2). The `Broadcasting` state now carries progress (last attempt height + a consecutive-failure counter) and self-loops on re-attempt. A total broadcast failure stays in `Broadcasting` and is re-attempted every `FeeBumpIntervalBlocks` from the block observer, sharing the broadcast-outcome handling with the initial submit. `ErrParentAlreadyBroadcast` still advances to `AwaitingConfirmation` (a live parent genuinely exists on another path).
2. **Escalates on repeated deterministic failure, never auto-fails** (item 3). After `BroadcastFailureAlertThreshold` (default 5) consecutive failures, the actor emits a distinct operator-visible `WARN`. It never transitions to terminal `Failed` — a tx that must land keeps retrying.
3. **Pins the CPFP-child finalize contract** (item 1). Investigation showed item 1's stated root cause does **not** reproduce on current `main`: `signCPFPChild` already pre-finalizes the canonical P2A anchor (empty witness) for *every* anchor-bearing TRUC parent, so LND `FinalizePsbt` only signs the wallet fee input. The original report predates this code. Rather than re-fix a non-bug, a regression test builds a checkpoint-shaped parent (pre-signed taproot key-spend input, unlike a round commitment tx) and asserts the child's anchor input is pre-finalized empty, the fee input is left for the wallet, the package is submitted, and the parent's signed input is preserved byte-for-byte.

## Test plan

- [x] `make unit pkg=./txconfirm/...` — all green, including new FSM, actor, and regression tests
- [x] `go test -race ./txconfirm/...` — race-clean
- [x] `go vet ./txconfirm/...`, `gofmt`, gopls diagnostics clean
- [ ] CI lint (local `custom-gcl` blocked by a `GOROOT==GOPATH` env issue in the dev sandbox)

## Notes

- New `Config.BroadcastFailureAlertThreshold` is additive (zero falls back to the default); no caller changes required.
- Server-side observability for the #508-amplified fund-risk window lands in the parent `darepo` repo.