### PR TITLE
swapclientserver: return pending pay duplicates

### DIFF
--- a/mailbox/conn/response_registry_test.go
+++ b/mailbox/conn/response_registry_test.go
@@ -52,7 +52,7 @@ func TestResponseRegistry_RegisterThenDeliver(t *testing.T) {
 func TestResponseRegistry_TTLPrunesPending(t *testing.T) {
 	t.Parallel()
 
-	registry := NewResponseRegistry(5 * time.Millisecond)
+	registry := NewResponseRegistry(time.Minute)
 	id := CorrelationID("corr-3")
 
 	require.Equal(
@@ -64,7 +64,9 @@ func TestResponseRegistry_TTLPrunesPending(t *testing.T) {
 		),
 	)
 
-	time.Sleep(20 * time.Millisecond)
+	registry.mu.Lock()
+	registry.pending[id].Created = time.Now().Add(-2 * time.Minute)
+	registry.mu.Unlock()
 
 	// Register after the buffered response has expired. The future
 	// should not be immediately completed.

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -808,6 +808,23 @@ func (c *Client) GetIndexedOORSession(ctx context.Context, pkScript []byte,
 	return newIndexedOORSessionInfo(resp), nil
 }
 
+// GetOORSession returns the daemon's local durable status for one OOR
+// transfer session.
+func (c *Client) GetOORSession(ctx context.Context, sessionID string) (
+	*daemonrpc.OORSessionInfo, error) {
+
+	resp, err := c.daemon.GetOORSession(ctx,
+		&daemonrpc.GetOORSessionRequest{
+			SessionId: sessionID,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get oor session: %w", err)
+	}
+
+	return resp.GetSession(), nil
+}
+
 // SendVTXO submits an in-round send request through the daemon. Passing nil
 // uses an empty request.
 func (c *Client) SendVTXO(ctx context.Context, req *daemonrpc.SendVTXORequest) (

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -463,6 +463,11 @@ type DaemonConn interface {
 	GetIndexedOORSession(ctx context.Context, pkScript []byte,
 		sessionTxID string) (*OORPackageInfo, error)
 
+	// GetOORSession returns the daemon's local durable status for one OOR
+	// session.
+	GetOORSession(ctx context.Context,
+		sessionID string) (*daemonrpc.OORSessionInfo, error)
+
 	// AllocateReceiveScript allocates a fresh wallet-owned receive
 	// destination.
 	AllocateReceiveScript(ctx context.Context,

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	loopfsm "github.com/lightninglabs/loop/fsm"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -1056,6 +1057,14 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 		return nil
 	}
 
+	sessionHandled, err := s.reconcilePayRefundSession(ctx)
+	if err != nil {
+		return newRetryableActionError(err)
+	}
+	if sessionHandled {
+		return nil
+	}
+
 	funded, err := s.observeRefundableVHTLC(ctx)
 	if err != nil {
 		return newRetryableActionError(
@@ -1065,10 +1074,6 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 	}
 	if !funded {
 		return waitForFixedPoll(ctx, s.client.waitPollInterval)
-	}
-
-	if s.refundSessionID != "" {
-		return s.markRefundAccepted(ctx)
 	}
 
 	height, err := s.client.daemon.BlockHeight(ctx)
@@ -1145,7 +1150,7 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 		slog.String("refund_session_id", refundSessionID),
 	)
 
-	return s.markRefundAccepted(ctx)
+	return waitForFixedPoll(ctx, s.client.waitPollInterval)
 }
 
 // refundLocktimePollInterval returns a slower timeout-refund poll interval when
@@ -1389,8 +1394,31 @@ func (s *paySession) observeRefundableVHTLC(ctx context.Context) (bool, error) {
 	vtxo, err := s.client.daemon.FindLiveVTXOByPkScript(
 		ctx, s.vhtlcPkScript,
 	)
-	if err != nil || vtxo == nil {
+	if err != nil {
+		if isUnregisteredScriptErr(err) && s.vhtlcOutpoint != "" &&
+			s.vhtlcAmount > 0 {
+
+			s.client.log.DebugS(
+				ctx,
+				"Using local in-swap vHTLC metadata for refund",
+				slog.String("err", err.Error()),
+				btclog.Hex("hash", s.cfg.PaymentHash[:]),
+				slog.String("outpoint", s.vhtlcOutpoint),
+			)
+
+			if err := s.ensurePayRefundRecoveryArmed(
+				ctx,
+			); err != nil {
+				return false, err
+			}
+
+			return true, nil
+		}
+
 		return false, err
+	}
+	if vtxo == nil {
+		return false, nil
 	}
 
 	err = s.mutateAndPersist(ctx, func() error {
@@ -1408,6 +1436,84 @@ func (s *paySession) observeRefundableVHTLC(ctx context.Context) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// reconcilePayRefundSession checks whether the daemon has durable local OOR
+// status for an accepted cooperative refund. This avoids depending solely on
+// refund output indexing while still keeping retry blocked until the daemon
+// reports a terminal refund session.
+func (s *paySession) reconcilePayRefundSession(ctx context.Context) (bool,
+	error) {
+
+	if s.refundSessionID == "" {
+		return false, nil
+	}
+
+	session, err := s.client.daemon.GetOORSession(ctx, s.refundSessionID)
+	if err != nil {
+		return true, err
+	}
+	if session == nil {
+		s.client.log.DebugS(ctx, "Pay refund OOR session not found",
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+			slog.String("refund_session_id", s.refundSessionID),
+		)
+
+		return true, waitForFixedPoll(ctx, s.client.waitPollInterval)
+	}
+
+	switch session.GetStatus() {
+	case daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_COMPLETED:
+		return true, s.markRefundSessionCompleted(ctx, session)
+
+	case daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_FAILED:
+		reason := session.GetFailureReason()
+		s.client.log.WarnS(ctx, "Pay refund OOR session failed",
+			nil,
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+			slog.String("refund_session_id", s.refundSessionID),
+			slog.String("phase", session.GetPhase()),
+			slog.String("reason", reason),
+		)
+
+		return false, s.mutateAndPersist(ctx, func() error {
+			s.refundSessionID = ""
+
+			return nil
+		})
+
+	default:
+		s.client.log.DebugS(ctx, "Pay refund OOR session pending",
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+			slog.String("refund_session_id", s.refundSessionID),
+			slog.String("phase", session.GetPhase()),
+			slog.String("status", session.GetStatus().String()),
+		)
+
+		return true, waitForFixedPoll(ctx, s.client.waitPollInterval)
+	}
+}
+
+// markRefundSessionCompleted persists terminal recovery after the daemon's
+// durable OOR session state confirms cooperative refund completion.
+func (s *paySession) markRefundSessionCompleted(ctx context.Context,
+	session *daemonrpc.OORSessionInfo) error {
+
+	s.client.log.InfoS(ctx, "Pay swap refund session completed",
+		btclog.Hex("hash", s.cfg.PaymentHash[:]),
+		slog.String("refund_session_id", s.refundSessionID),
+		slog.String("phase", session.GetPhase()),
+	)
+	if err := cancelVHTLCRecovery(
+		ctx, s.client.daemon, s.refundRecoveryID,
+		recoveryReasonRefundSessionCompleted, "",
+	); err != nil {
+		return err
+	}
+
+	return s.mutateAndPersist(ctx, func() error {
+		return s.transition(payEventRefunded)
+	})
 }
 
 // markRefundOutputIndexed persists terminal recovery after the refund output
@@ -1463,29 +1569,6 @@ func (s *paySession) markRefunded(ctx context.Context,
 			s.refundSessionID = spentVHTLC.SpentByTxID
 		}
 
-		return s.transition(payEventRefunded)
-	})
-}
-
-// markRefundAccepted persists terminal recovery after the daemon accepts the
-// custom-input OOR refund. The indexed refund output can lag behind the OOR
-// acceptance, but the accepted session is the durable point where the vHTLC has
-// been reassigned back to the client wallet.
-func (s *paySession) markRefundAccepted(ctx context.Context) error {
-	if s.state == PayStateRefunded {
-		return nil
-	}
-	if s.refundSessionID == "" {
-		return fmt.Errorf("missing refund session id")
-	}
-	if err := cancelVHTLCRecovery(
-		ctx, s.client.daemon, s.refundRecoveryID,
-		recoveryReasonRefundAccepted, "",
-	); err != nil {
-		return newRetryableActionError(err)
-	}
-
-	return s.mutateAndPersist(ctx, func() error {
 		return s.transition(payEventRefunded)
 	})
 }

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
 	swapsqlc "github.com/lightninglabs/darepo-client/sdk/swaps/sqlc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/zpay32"
@@ -719,6 +720,230 @@ func TestPaySessionCooperativeRefundsBeforeTimeout(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, PayStateRefunded, resumed.State())
 	require.Equal(t, "refund-session", resumed.refundSessionID)
+}
+
+// TestPaySessionCooperativeRefundUsesLocalFundingMetadata asserts the refund
+// path can proceed from the persisted funding response when the authoritative
+// indexer rejects the vHTLC script lookup for the client's principal.
+func TestPaySessionCooperativeRefundUsesLocalFundingMetadata(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	refundScript, err := txscript.PayToTaprootScript(clientPriv.PubKey())
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:  preimage.Hash(),
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
+			ServerPubkey: serverPriv.PubKey(),
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime:                       100,
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			Expiry: time.Now().Add(time.Minute),
+		},
+		refundAuthorization: &InSwapRefundAuthorization{
+			Signature: TaprootScriptSignature{
+				PubKey: serverPriv.
+					PubKey().
+					SerializeCompressed(),
+				WitnessScript: []byte("witness"),
+				Signature:     []byte("server-sig"),
+			},
+			FailureReason: "payment failed",
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey:   clientPriv.PubKey(),
+		operatorKey:   operatorPriv.PubKey(),
+		blockHeight:   50,
+		sendSessionID: "refund-session",
+		sendOutpoint:  "funding:0",
+		receiveInfo: &ReceiveInfo{
+			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+			PkScript:    refundScript,
+		},
+		spendOnCustom: true,
+	}
+	daemonConn.liveLookupHook = func(call int) (*VTXOInfo, error) {
+		if call <= 2 {
+			return nil, unregisteredScriptIndexerErr()
+		}
+
+		scriptKey := hex.EncodeToString(refundScript)
+		if vtxo := daemonConn.liveByPkScript[scriptKey]; vtxo != nil {
+			return vtxo, nil
+		}
+
+		return nil, nil
+	}
+
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	client.waitPollInterval = time.Millisecond
+	client.refundLocktimeBuffer = 0
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	_, err = session.Wait(t.Context())
+	require.ErrorIs(t, err, ErrSwapRefunded)
+	require.Equal(t, 1, daemonConn.sendPolicyCalls)
+	require.GreaterOrEqual(t, daemonConn.liveLookupCalls, 1)
+	require.Equal(t, 1, daemonConn.sendCustomCalls)
+	require.NotNil(t, serverConn.refundAuthorizeReq)
+	require.Equal(
+		t, "funding:0", serverConn.refundAuthorizeReq.vhtlcOutpoint,
+	)
+	require.EqualValues(
+		t, testInSwapAmountSat,
+		serverConn.refundAuthorizeReq.vhtlcAmountSat,
+	)
+	require.Equal(t, "funding:0", session.vhtlcOutpoint)
+	require.EqualValues(t, testInSwapAmountSat, session.vhtlcAmount)
+}
+
+// TestPaySessionCooperativeRefundWaitsForOutputBeforeTerminal verifies the
+// client does not make a refund-accepted swap terminal before wallet recovery
+// is visible. A caller retrying the same invoice should still see this swap as
+// pending until the refund output or spent vHTLC is indexed.
+func TestPaySessionCooperativeRefundWaitsForOutputBeforeTerminal(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	refundScript, err := txscript.PayToTaprootScript(clientPriv.PubKey())
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:  preimage.Hash(),
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
+			ServerPubkey: serverPriv.PubKey(),
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime:                       100,
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			Expiry: time.Now().Add(time.Minute),
+		},
+		refundAuthorization: &InSwapRefundAuthorization{
+			Signature: TaprootScriptSignature{
+				PubKey: serverPriv.
+					PubKey().
+					SerializeCompressed(),
+				WitnessScript: []byte("witness"),
+				Signature:     []byte("server-sig"),
+			},
+			FailureReason: "payment failed",
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey:   clientPriv.PubKey(),
+		operatorKey:   operatorPriv.PubKey(),
+		blockHeight:   50,
+		sendSessionID: "refund-session",
+		sendOutpoint:  "funding:0",
+		receiveInfo: &ReceiveInfo{
+			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+			PkScript:    refundScript,
+		},
+	}
+	daemonConn.liveLookupHook = func(call int) (*VTXOInfo, error) {
+		if daemonConn.sendCustomCalls == 0 {
+			return nil, unregisteredScriptIndexerErr()
+		}
+
+		return nil, nil
+	}
+
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	client.waitPollInterval = 5 * time.Millisecond
+	client.refundLocktimeBuffer = 0
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	err = session.runUntil(t.Context(), PayStateWaitingForClaim)
+	require.NoError(t, err)
+	require.Equal(t, PayStateWaitingForClaim, session.State())
+
+	refunded, err := session.tryCooperativeRefund(t.Context())
+	require.NoError(t, err)
+	require.True(t, refunded)
+	require.Equal(t, PayStateRefundInitiated, session.State())
+	require.Equal(t, "refund-session", session.refundSessionID)
+	require.Equal(t, 1, daemonConn.sendCustomCalls)
+	require.NotNil(t, serverConn.refundAuthorizeReq)
+
+	waitCtx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+
+	err = session.completeRefund(waitCtx)
+	require.NoError(t, err)
+	require.Equal(t, PayStateRefundInitiated, session.State())
+	require.Equal(t, 1, daemonConn.oorSessionCalls)
+	require.Equal(t, "refund-session", daemonConn.lastOORSessionID)
+
+	daemonConn.oorSession = &daemonrpc.OORSessionInfo{
+		SessionId: "refund-session",
+		Status: daemonrpc.
+			OORSessionStatus_OOR_SESSION_STATUS_COMPLETED,
+		Phase: "completed",
+	}
+
+	err = session.completeRefund(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, PayStateRefunded, session.State())
+	require.Equal(t, 1, daemonConn.cancelCalls)
+	require.Equal(
+		t, recoveryReasonRefundSessionCompleted,
+		daemonConn.lastCancel.GetReason(),
+	)
 }
 
 // TestPaySessionCooperativeRefundIgnoresServerUnavailable asserts a pay

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -624,6 +624,8 @@ type testDaemonConn struct {
 	prepareOOREErr    error
 	sendPolicyErr     error
 	sendCustomErr     error
+	oorSession        *daemonrpc.OORSessionInfo
+	oorSessionErr     error
 	listSpentErr      error
 	liveLookupErr     error
 	liveLookupHook    func(call int) (*VTXOInfo, error)
@@ -632,11 +634,13 @@ type testDaemonConn struct {
 	spendOnCustom     bool
 	sendPolicyCalls   int
 	sendCustomCalls   int
+	oorSessionCalls   int
 	liveLookupCalls   int
 	spentLookupCalls  int
 	lastSendPolicy    []byte
 	lastClaimPubKey   []byte
 	lastClaimInput    []CustomInput
+	lastOORSessionID  string
 	armRecoveryResp   *daemonrpc.ArmVHTLCRecoveryResponse
 	armRecoveryErr    error
 	escalateResp      *daemonrpc.EscalateVHTLCRecoveryResponse
@@ -715,9 +719,34 @@ func (d *testDaemonConn) SendOORWithCustomInputs(_ context.Context,
 					}
 			}
 		}
+
+		d.oorSession = &daemonrpc.OORSessionInfo{
+			SessionId: d.sendSessionID,
+			Status: daemonrpc.
+				OORSessionStatus_OOR_SESSION_STATUS_COMPLETED,
+			ConsumedOutpoints: []string{
+				inputs[0].Outpoint,
+			},
+			CreatedOutpoints: []string{
+				d.sendSessionID + ":0",
+			},
+		}
 	}
 
 	return d.sendSessionID, d.sendCustomErr
+}
+
+// GetOORSession returns the configured local OOR session status.
+func (d *testDaemonConn) GetOORSession(_ context.Context, sessionID string) (
+	*daemonrpc.OORSessionInfo, error) {
+
+	d.oorSessionCalls++
+	d.lastOORSessionID = sessionID
+	if d.oorSessionErr != nil {
+		return nil, d.oorSessionErr
+	}
+
+	return d.oorSession, nil
 }
 
 // ArmVHTLCRecovery records the daemon recovery arm request.

--- a/sdk/swaps/recovery.go
+++ b/sdk/swaps/recovery.go
@@ -76,9 +76,11 @@ const (
 	// cooperative refund output is already indexed.
 	recoveryReasonRefundOutputIndexed = "cooperative refund output indexed"
 
-	// recoveryReasonRefundAccepted explains cancellation when the daemon
-	// accepted the cooperative refund OOR.
-	recoveryReasonRefundAccepted = "cooperative refund accepted"
+	// recoveryReasonRefundSessionCompleted explains cancellation when the
+	// daemon's durable OOR session status confirms cooperative refund
+	// completion before refund output indexing catches up.
+	recoveryReasonRefundSessionCompleted = "cooperative refund session " +
+		"completed"
 
 	// recoveryReasonClaimAccepted explains cancellation when the daemon
 	// accepted the cooperative claim OOR.

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -110,8 +110,9 @@ type swapClientService struct {
 	// dust check.
 	payMinAmount func(context.Context) (uint64, error)
 
-	// chainParams is used only for BOLT-11 pay invoice decoding. Tests that
-	// leave payMinAmount unset do not need to provide it.
+	// chainParams decodes BOLT-11 pay invoices for local amount preflight
+	// and duplicate in-flight checks before swap creation mutates remote
+	// swapdk-server state.
 	chainParams *chaincfg.Params
 }
 
@@ -1017,6 +1018,14 @@ func (s *swapClientService) StartPay(ctx context.Context,
 		return nil, err
 	}
 
+	existing, ok, err := s.pendingSwapForInvoice(ctx, req.GetInvoice())
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return existing, nil
+	}
+
 	session, err := s.client.StartPayViaLightning(
 		ctx, req.GetInvoice(), req.GetMaxFeeSat(),
 	)
@@ -1085,6 +1094,52 @@ func (s *swapClientService) StartReceive(ctx context.Context,
 		Invoice:     session.Invoice(),
 		Swap:        summary,
 	}, nil
+}
+
+// pendingSwapForInvoice decodes a real BOLT-11 invoice and checks whether the
+// daemon already has a pending swap for its payment hash. Placeholder invoices
+// used by tests, or malformed invoices that sdk/swaps must reject later, skip
+// this best-effort preflight so the existing validation path is preserved.
+func (s *swapClientService) pendingSwapForInvoice(ctx context.Context,
+	invoice string) (*swapclientrpc.StartPayResponse, bool, error) {
+
+	if s.chainParams == nil {
+		return nil, false, nil
+	}
+
+	decoded, err := zpay32.Decode(
+		strings.TrimSpace(invoice), s.chainParams,
+	)
+	if err != nil || decoded.PaymentHash == nil {
+		return nil, false, nil
+	}
+
+	var hash lntypes.Hash
+	copy(hash[:], decoded.PaymentHash[:])
+
+	summary, err := s.client.GetSwapSummary(ctx, hash)
+	if err != nil {
+		if errors.Is(err, swaps.ErrSwapSummaryNotFound) {
+			return nil, false, nil
+		}
+
+		return nil, false, status.Errorf(codes.Internal, "get "+
+			"existing swap: %v", err)
+	}
+	if !summary.Pending {
+		return nil, false, nil
+	}
+
+	if summary.Direction != swaps.SwapDirectionPay {
+		return nil, false, nil
+	}
+
+	s.startPayWorker(hash)
+
+	return &swapclientrpc.StartPayResponse{
+		PaymentHash: hex.EncodeToString(hash[:]),
+		Swap:        swapSummaryToProto(summary),
+	}, true, nil
 }
 
 // ResumeSwap is a manual wake-up path for a persisted swap. It does not create

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -4,6 +4,7 @@ package swapclientserver
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"net/http"
@@ -236,6 +237,102 @@ func TestStartPayReturnsSummaryAndStartsWorker(t *testing.T) {
 	fakeClient.awaitPayResume(t, payHash)
 	require.Equal(t, 1, fakeClient.startPayCount())
 	require.Equal(t, 1, fakeClient.payResumeCount(payHash))
+}
+
+// TestStartPayReturnsPendingDuplicateInvoice verifies a repeated StartPay for
+// an invoice with a pending local swap returns that durable swap summary before
+// it can create another server-side in-swap.
+func TestStartPayReturnsPendingDuplicateInvoice(t *testing.T) {
+	t.Parallel()
+
+	payHash := testHash(33)
+	invoice := testStartPayInvoice(t, payHash, 10_000)
+	fakeClient := newFakeSwapRuntime(
+		swaps.SwapSummary{
+			Direction:   swaps.SwapDirectionPay,
+			PaymentHash: payHash,
+			Invoice:     invoice,
+			State:       "FundingInitiated",
+			Pending:     true,
+			AmountSat:   10_000,
+			MaxFeeSat:   25,
+		},
+	)
+	service := newTestSwapClientService(fakeClient)
+	service.chainParams = &chaincfg.RegressionNetParams
+	defer service.cancel()
+
+	resp, err := service.StartPay(
+		t.Context(), &swapclientrpc.StartPayRequest{
+			Invoice:   invoice,
+			MaxFeeSat: 25,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, hex.EncodeToString(payHash[:]), resp.GetPaymentHash())
+	require.True(t, resp.GetSwap().GetPending())
+	require.Equal(
+		t, swapclientrpc.SwapDirection_SWAP_DIRECTION_PAY,
+		resp.GetSwap().GetDirection(),
+	)
+	require.Equal(
+		t, swapclientrpc.SwapState_SWAP_STATE_FUNDING_INITIATED,
+		resp.GetSwap().GetState(),
+	)
+
+	fakeClient.awaitPayResume(t, payHash)
+	require.Equal(t, 0, fakeClient.startPayCount())
+	require.Equal(t, 1, fakeClient.payResumeCount(payHash))
+}
+
+// TestStartPayIgnoresPendingReceiveDuplicate verifies a receive swap with the
+// invoice payment hash does not satisfy the duplicate-pay preflight.
+func TestStartPayIgnoresPendingReceiveDuplicate(t *testing.T) {
+	t.Parallel()
+
+	receiveHash := testHash(34)
+	payHash := testHash(35)
+	invoice := testStartPayInvoice(t, receiveHash, 10_000)
+	fakeClient := newFakeSwapRuntime(
+		swaps.SwapSummary{
+			Direction:   swaps.SwapDirectionReceive,
+			PaymentHash: receiveHash,
+			Invoice:     invoice,
+			State:       "VHTLCAccepted",
+			Pending:     true,
+			AmountSat:   10_000,
+		},
+		swaps.SwapSummary{
+			Direction:   swaps.SwapDirectionPay,
+			PaymentHash: payHash,
+			Invoice:     invoice,
+			State:       "SwapCreated",
+			Pending:     true,
+			AmountSat:   10_000,
+		},
+	)
+	fakeClient.startPaySession = &fakePaySession{hash: payHash}
+	service := newTestSwapClientService(fakeClient)
+	service.chainParams = &chaincfg.RegressionNetParams
+	defer service.cancel()
+
+	resp, err := service.StartPay(
+		t.Context(), &swapclientrpc.StartPayRequest{
+			Invoice:   invoice,
+			MaxFeeSat: 25,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, hex.EncodeToString(payHash[:]), resp.GetPaymentHash())
+	require.Equal(
+		t, swapclientrpc.SwapDirection_SWAP_DIRECTION_PAY,
+		resp.GetSwap().GetDirection(),
+	)
+
+	fakeClient.awaitPayResume(t, payHash)
+	require.Equal(t, 1, fakeClient.startPayCount())
+	require.Equal(t, 1, fakeClient.payResumeCount(payHash))
+	require.Equal(t, 0, fakeClient.receiveResumeCount(receiveHash))
 }
 
 // TestStartPayPreservesRuntimeStatusCode verifies startup failures keep the
@@ -738,6 +835,35 @@ func newTestSwapClientService(client swapRuntimeClient) *swapClientService {
 		active:      make(map[string]struct{}),
 		subscribers: make(map[chan *swapclientrpc.SwapSummary]struct{}),
 	}
+}
+
+// testStartPayInvoice returns a signed regtest invoice for StartPay tests that
+// need the subserver's local payment-hash preflight to decode a real BOLT-11.
+func testStartPayInvoice(t *testing.T, hash lntypes.Hash,
+	amountSat int64) string {
+
+	t.Helper()
+
+	invoice, err := zpay32.NewInvoice(
+		&chaincfg.RegressionNetParams, hash, time.Now(),
+		zpay32.Amount(
+			lnwire.MilliSatoshi(amountSat*1000),
+		),
+		zpay32.Description("swapclientserver test invoice"),
+	)
+	require.NoError(t, err)
+
+	privKey, _ := btcec.PrivKeyFromBytes([]byte{77})
+	encoded, err := invoice.Encode(zpay32.MessageSigner{
+		SignCompact: func(msg []byte) ([]byte, error) {
+			digest := sha256.Sum256(msg)
+
+			return ecdsa.SignCompact(privKey, digest[:], true), nil
+		},
+	})
+	require.NoError(t, err)
+
+	return encoded
 }
 
 func testHash(seed byte) lntypes.Hash {


### PR DESCRIPTION
## Summary
- decode StartPay invoices locally before creating a new pay swap
- return the existing pending swap summary when the payment hash is already in flight
- re-arm the pay worker for duplicate pending starts

## Testing
- go test -tags="dev nolog swapruntime" -timeout=5m ./swapclientserver
- make commitmsg-lint commit=HEAD
- git diff --check