### PR TITLE
walletdk: default exit to cooperative

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_exit.go
+++ b/cmd/darepocli/darepoclicommands/cmd_exit.go
@@ -7,25 +7,33 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const forceUnrollAck = "I_KNOW_WHAT_I_AM_DOING"
+
 // newExitCmd builds the top-level `exit` verb. It dials
-// walletdkrpc.WalletService.Exit which proxies daemonrpc.Unroll to spawn
-// a durable unilateral-exit job. The `exit status` subcommand reads the
-// job status via walletdkrpc.WalletService.ExitStatus.
+// walletdkrpc.WalletService.Exit, which queues a cooperative leave by default
+// and starts unilateral unroll only when the caller supplies the exact force
+// acknowledgement. The `exit status` subcommand reads the forced-unroll job
+// status via walletdkrpc.WalletService.ExitStatus.
 //
 // `exit` replaces the legacy `unroll` verb at the user surface; the
-// underlying daemon actor/registry pathway is unchanged.
+// underlying daemon actor/registry pathway is only used for acknowledged
+// forced exits.
 func newExitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "exit",
-		Short: "Trigger a unilateral exit for a VTXO",
-		Long: "Starts the on-chain recovery process for the " +
-			"specified VTXO outpoint. The daemon assembles a " +
-			"recovery proof, spawns a durable exit (unroll) " +
-			"job, and drives the on-chain recovery to " +
-			"completion. The job survives daemon restarts; " +
-			"this command only submits the request.\n\n" +
+		Short: "Cooperatively exit a VTXO",
+		Long: "Queues the specified VTXO outpoint for cooperative " +
+			"leave. If --onchain-address is omitted, the daemon " +
+			"generates a fresh backing-wallet destination. " +
+			"Unilateral unroll is only started when " +
+			"--force-unroll-ack is exactly " +
+			forceUnrollAck + ".\n\n" +
 			"Example:\n" +
 			"  darepocli exit --outpoint TXID:VOUT\n" +
+			"  darepocli exit --outpoint TXID:VOUT " +
+			"--onchain-address bcrt1...\n" +
+			"  darepocli exit --outpoint TXID:VOUT " +
+			"--force-unroll-ack " + forceUnrollAck + "\n" +
 			"  darepocli exit status --outpoint TXID:VOUT",
 		Args: cobra.NoArgs,
 		RunE: walletExit,
@@ -34,6 +42,11 @@ func newExitCmd() *cobra.Command {
 	cmd.Flags().String("outpoint", "",
 		"VTXO outpoint to exit (txid:vout)")
 	_ = cmd.MarkFlagRequired("outpoint")
+	cmd.Flags().String("onchain-address", "",
+		"cooperative leave destination; omitted means a fresh "+
+			"wallet-owned address")
+	cmd.Flags().String("force-unroll-ack", "",
+		"exact acknowledgement required to force unilateral unroll")
 	cmd.Flags().Bool("dry-run", false,
 		"validate inputs locally and print the preview without "+
 			"dispatching to the daemon; exits 10 on a valid "+
@@ -51,7 +64,34 @@ func walletExit(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	req := &walletdkrpc.ExitRequest{Outpoint: outpoint}
+	onchainAddress, _ := cmd.Flags().GetString("onchain-address")
+	if onchainAddress != "" {
+		if err := invalidArgs(
+			validateDestination(onchainAddress),
+		); err != nil {
+			return err
+		}
+	}
+
+	forceAck, _ := cmd.Flags().GetString("force-unroll-ack")
+	if forceAck != "" && forceAck != forceUnrollAck {
+		return invalidArgs(
+			fmt.Errorf("--force-unroll-ack must be exactly %q",
+				forceUnrollAck),
+		)
+	}
+	if forceAck != "" && onchainAddress != "" {
+		return invalidArgs(
+			fmt.Errorf("--onchain-address cannot be combined " +
+				"with --force-unroll-ack"),
+		)
+	}
+
+	req := &walletdkrpc.ExitRequest{
+		Outpoint:       outpoint,
+		OnchainAddress: onchainAddress,
+		ForceUnrollAck: forceAck,
+	}
 
 	if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
 		return walletDryRunPreview(

--- a/cmd/darepocli/darepoclicommands/mcp_wallet.go
+++ b/cmd/darepocli/darepoclicommands/mcp_wallet.go
@@ -216,21 +216,42 @@ func registerMCPWalletMutateTools(s *mcp.Server,
 	})
 
 	type exitArgs struct {
-		Outpoint string `json:"outpoint" jsonschema:"VTXO outpoint to exit (txid:vout)"` //nolint:ll
+		Outpoint       string `json:"outpoint" jsonschema:"VTXO outpoint to exit (txid:vout)"`                                 //nolint:ll
+		OnchainAddress string `json:"onchain_address,omitempty" jsonschema:"cooperative leave destination; empty uses wallet"` //nolint:ll
+		ForceUnrollAck string `json:"force_unroll_ack,omitempty" jsonschema:"exact acknowledgement required for unroll"`       //nolint:ll
 	}
 	mcp.AddTool(s, &mcp.Tool{
 		Name: "exit",
-		Description: "Trigger a unilateral exit for a VTXO " +
-			"(spawns a durable on-chain recovery job)",
+		Description: "Cooperatively exit a VTXO by default; forced " +
+			"unroll requires the exact acknowledgement string",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, args exitArgs) (
 		*mcp.CallToolResult, any, error) {
 
 		if err := validateOutpoint(args.Outpoint); err != nil {
 			return nil, nil, err
 		}
+		if args.OnchainAddress != "" {
+			if err := validateDestination(
+				args.OnchainAddress,
+			); err != nil {
+				return nil, nil, err
+			}
+		}
+		if args.ForceUnrollAck != "" &&
+			args.ForceUnrollAck != forceUnrollAck {
+			return nil, nil, fmt.Errorf("force_unroll_ack must be "+
+				"exactly %q", forceUnrollAck)
+		}
+		if args.ForceUnrollAck != "" && args.OnchainAddress != "" {
+			return nil, nil, fmt.Errorf("onchain_address cannot " +
+				"be combined with force_unroll_ack")
+		}
+
 		resp, err := client.Exit(
 			ctx, &walletdkrpc.ExitRequest{
-				Outpoint: args.Outpoint,
+				Outpoint:       args.Outpoint,
+				OnchainAddress: args.OnchainAddress,
+				ForceUnrollAck: args.ForceUnrollAck,
 			},
 		)
 		if err != nil {

--- a/darepod/rpc_wallet_helpers.go
+++ b/darepod/rpc_wallet_helpers.go
@@ -1,0 +1,21 @@
+package darepod
+
+import (
+	"context"
+
+	"github.com/lightninglabs/darepo-client/wallet"
+)
+
+// NewWalletAddress returns a fresh backing-wallet receive address for wallet
+// RPC facade code that needs an internal cooperative-exit destination.
+func (r *RPCServer) NewWalletAddress(ctx context.Context) (string, error) {
+	return r.server.NewWalletAddress(ctx)
+}
+
+// ListWalletUnspent returns confirmed backing-wallet UTXOs for wallet RPC
+// facade preflight checks.
+func (r *RPCServer) ListWalletUnspent(ctx context.Context, minConfs,
+	maxConfs int32) ([]*wallet.Utxo, error) {
+
+	return r.server.ListWalletUnspent(ctx, minConfs, maxConfs)
+}

--- a/rpc/walletdkrpc/wallet.pb.go
+++ b/rpc/walletdkrpc/wallet.pb.go
@@ -311,6 +311,57 @@ func (SendQuoteStatus) EnumDescriptor() ([]byte, []int) {
 	return file_wallet_proto_rawDescGZIP(), []int{4}
 }
 
+// ExitMode identifies whether Exit queued a cooperative leave or started a
+// forced unilateral unroll.
+type ExitMode int32
+
+const (
+	ExitMode_EXIT_MODE_UNSPECIFIED ExitMode = 0
+	ExitMode_EXIT_MODE_COOPERATIVE ExitMode = 1
+	ExitMode_EXIT_MODE_UNILATERAL  ExitMode = 2
+)
+
+// Enum value maps for ExitMode.
+var (
+	ExitMode_name = map[int32]string{
+		0: "EXIT_MODE_UNSPECIFIED",
+		1: "EXIT_MODE_COOPERATIVE",
+		2: "EXIT_MODE_UNILATERAL",
+	}
+	ExitMode_value = map[string]int32{
+		"EXIT_MODE_UNSPECIFIED": 0,
+		"EXIT_MODE_COOPERATIVE": 1,
+		"EXIT_MODE_UNILATERAL":  2,
+	}
+)
+
+func (x ExitMode) Enum() *ExitMode {
+	p := new(ExitMode)
+	*p = x
+	return p
+}
+
+func (x ExitMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ExitMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_wallet_proto_enumTypes[5].Descriptor()
+}
+
+func (ExitMode) Type() protoreflect.EnumType {
+	return &file_wallet_proto_enumTypes[5]
+}
+
+func (x ExitMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ExitMode.Descriptor instead.
+func (ExitMode) EnumDescriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{5}
+}
+
 // ExitJobStatus collapses the underlying unroll job phases to a short
 // wallet-facing string set.
 type ExitJobStatus int32
@@ -370,11 +421,11 @@ func (x ExitJobStatus) String() string {
 }
 
 func (ExitJobStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_wallet_proto_enumTypes[5].Descriptor()
+	return file_wallet_proto_enumTypes[6].Descriptor()
 }
 
 func (ExitJobStatus) Type() protoreflect.EnumType {
-	return &file_wallet_proto_enumTypes[5]
+	return &file_wallet_proto_enumTypes[6]
 }
 
 func (x ExitJobStatus) Number() protoreflect.EnumNumber {
@@ -383,7 +434,7 @@ func (x ExitJobStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ExitJobStatus.Descriptor instead.
 func (ExitJobStatus) EnumDescriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{5}
+	return file_wallet_proto_rawDescGZIP(), []int{6}
 }
 
 // WalletEntryPhase is a coarse, wallet-facing lifecycle phase. It is not a
@@ -461,11 +512,11 @@ func (x WalletEntryPhase) String() string {
 }
 
 func (WalletEntryPhase) Descriptor() protoreflect.EnumDescriptor {
-	return file_wallet_proto_enumTypes[6].Descriptor()
+	return file_wallet_proto_enumTypes[7].Descriptor()
 }
 
 func (WalletEntryPhase) Type() protoreflect.EnumType {
-	return &file_wallet_proto_enumTypes[6]
+	return &file_wallet_proto_enumTypes[7]
 }
 
 func (x WalletEntryPhase) Number() protoreflect.EnumNumber {
@@ -474,7 +525,7 @@ func (x WalletEntryPhase) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use WalletEntryPhase.Descriptor instead.
 func (WalletEntryPhase) EnumDescriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{6}
+	return file_wallet_proto_rawDescGZIP(), []int{7}
 }
 
 type CreateRequest struct {
@@ -2814,11 +2865,18 @@ func (x *StatusResponse) GetPendingCount() uint32 {
 
 type ExitRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// outpoint is the VTXO outpoint to unilaterally exit, formatted as
-	// "txid:index".
-	Outpoint      string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// outpoint is the VTXO outpoint to exit, formatted as "txid:index".
+	Outpoint string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	// onchain_address is the cooperative leave destination. Empty asks the
+	// daemon to generate a fresh backing-wallet address internally.
+	OnchainAddress string `protobuf:"bytes,2,opt,name=onchain_address,json=onchainAddress,proto3" json:"onchain_address,omitempty"`
+	// force_unroll_ack must be exactly "I_KNOW_WHAT_I_AM_DOING" to bypass
+	// cooperative leave and start unilateral unroll. It cannot be combined
+	// with onchain_address, and the server requires at least one confirmed
+	// local backing-wallet UTXO before admitting forced unroll.
+	ForceUnrollAck string `protobuf:"bytes,3,opt,name=force_unroll_ack,json=forceUnrollAck,proto3" json:"force_unroll_ack,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *ExitRequest) Reset() {
@@ -2858,15 +2916,37 @@ func (x *ExitRequest) GetOutpoint() string {
 	return ""
 }
 
+func (x *ExitRequest) GetOnchainAddress() string {
+	if x != nil {
+		return x.OnchainAddress
+	}
+	return ""
+}
+
+func (x *ExitRequest) GetForceUnrollAck() string {
+	if x != nil {
+		return x.ForceUnrollAck
+	}
+	return ""
+}
+
 type ExitResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// created indicates whether a new exit job was spawned. False if
-	// an existing job already covers this target.
+	// created indicates whether a new unilateral exit job was spawned.
+	// False if an existing job already covers this target. Cooperative
+	// exits leave this unset.
 	Created bool `protobuf:"varint,1,opt,name=created,proto3" json:"created,omitempty"`
-	// actor_id is the identifier of the durable exit job actor.
-	ActorId       string `protobuf:"bytes,2,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// actor_id is the identifier of the durable unilateral exit job actor.
+	ActorId string `protobuf:"bytes,2,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
+	// mode identifies the branch the daemon took.
+	Mode ExitMode `protobuf:"varint,3,opt,name=mode,proto3,enum=walletdkrpc.ExitMode" json:"mode,omitempty"`
+	// queued_outpoints lists the outpoints accepted into cooperative leave.
+	QueuedOutpoints []string `protobuf:"bytes,4,rep,name=queued_outpoints,json=queuedOutpoints,proto3" json:"queued_outpoints,omitempty"`
+	// onchain_address is the cooperative leave destination used by the
+	// daemon. It may be caller-supplied or daemon-generated.
+	OnchainAddress string `protobuf:"bytes,5,opt,name=onchain_address,json=onchainAddress,proto3" json:"onchain_address,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *ExitResponse) Reset() {
@@ -2909,6 +2989,27 @@ func (x *ExitResponse) GetCreated() bool {
 func (x *ExitResponse) GetActorId() string {
 	if x != nil {
 		return x.ActorId
+	}
+	return ""
+}
+
+func (x *ExitResponse) GetMode() ExitMode {
+	if x != nil {
+		return x.Mode
+	}
+	return ExitMode_EXIT_MODE_UNSPECIFIED
+}
+
+func (x *ExitResponse) GetQueuedOutpoints() []string {
+	if x != nil {
+		return x.QueuedOutpoints
+	}
+	return nil
+}
+
+func (x *ExitResponse) GetOnchainAddress() string {
+	if x != nil {
+		return x.OnchainAddress
 	}
 	return ""
 }
@@ -3777,12 +3878,17 @@ const file_wallet_proto_rawDesc = "" +
 	"\bunlocked\x18\x02 \x01(\bR\bunlocked\x12\x18\n" +
 	"\anetwork\x18\x03 \x01(\tR\anetwork\x126\n" +
 	"\abalance\x18\x04 \x01(\v2\x1c.walletdkrpc.BalanceResponseR\abalance\x12#\n" +
-	"\rpending_count\x18\x05 \x01(\rR\fpendingCount\")\n" +
+	"\rpending_count\x18\x05 \x01(\rR\fpendingCount\"|\n" +
 	"\vExitRequest\x12\x1a\n" +
-	"\boutpoint\x18\x01 \x01(\tR\boutpoint\"C\n" +
+	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12'\n" +
+	"\x0fonchain_address\x18\x02 \x01(\tR\x0eonchainAddress\x12(\n" +
+	"\x10force_unroll_ack\x18\x03 \x01(\tR\x0eforceUnrollAck\"\xc2\x01\n" +
 	"\fExitResponse\x12\x18\n" +
 	"\acreated\x18\x01 \x01(\bR\acreated\x12\x19\n" +
-	"\bactor_id\x18\x02 \x01(\tR\aactorId\"/\n" +
+	"\bactor_id\x18\x02 \x01(\tR\aactorId\x12)\n" +
+	"\x04mode\x18\x03 \x01(\x0e2\x15.walletdkrpc.ExitModeR\x04mode\x12)\n" +
+	"\x10queued_outpoints\x18\x04 \x03(\tR\x0fqueuedOutpoints\x12'\n" +
+	"\x0fonchain_address\x18\x05 \x01(\tR\x0eonchainAddress\"/\n" +
 	"\x11ExitStatusRequest\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\"\x9c\x01\n" +
 	"\x12ExitStatusResponse\x12\x14\n" +
@@ -3856,7 +3962,11 @@ const file_wallet_proto_rawDesc = "" +
 	"\x0fSendQuoteStatus\x12!\n" +
 	"\x1dSEND_QUOTE_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aSEND_QUOTE_STATUS_COMPLETE\x10\x01\x12 \n" +
-	"\x1cSEND_QUOTE_STATUS_LOCAL_ONLY\x10\x02*\xea\x01\n" +
+	"\x1cSEND_QUOTE_STATUS_LOCAL_ONLY\x10\x02*Z\n" +
+	"\bExitMode\x12\x19\n" +
+	"\x15EXIT_MODE_UNSPECIFIED\x10\x00\x12\x19\n" +
+	"\x15EXIT_MODE_COOPERATIVE\x10\x01\x12\x18\n" +
+	"\x14EXIT_MODE_UNILATERAL\x10\x02*\xea\x01\n" +
 	"\rExitJobStatus\x12\x1f\n" +
 	"\x1bEXIT_JOB_STATUS_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17EXIT_JOB_STATUS_PENDING\x10\x01\x12!\n" +
@@ -3905,7 +4015,7 @@ func file_wallet_proto_rawDescGZIP() []byte {
 	return file_wallet_proto_rawDescData
 }
 
-var file_wallet_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
+var file_wallet_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
 var file_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_wallet_proto_goTypes = []any{
 	(EntryKind)(0),                  // 0: walletdkrpc.EntryKind
@@ -3913,108 +4023,110 @@ var file_wallet_proto_goTypes = []any{
 	(ListView)(0),                   // 2: walletdkrpc.ListView
 	(SendRail)(0),                   // 3: walletdkrpc.SendRail
 	(SendQuoteStatus)(0),            // 4: walletdkrpc.SendQuoteStatus
-	(ExitJobStatus)(0),              // 5: walletdkrpc.ExitJobStatus
-	(WalletEntryPhase)(0),           // 6: walletdkrpc.WalletEntryPhase
-	(*CreateRequest)(nil),           // 7: walletdkrpc.CreateRequest
-	(*CreateResponse)(nil),          // 8: walletdkrpc.CreateResponse
-	(*UnlockRequest)(nil),           // 9: walletdkrpc.UnlockRequest
-	(*UnlockResponse)(nil),          // 10: walletdkrpc.UnlockResponse
-	(*PrepareSendRequest)(nil),      // 11: walletdkrpc.PrepareSendRequest
-	(*PrepareSendResponse)(nil),     // 12: walletdkrpc.PrepareSendResponse
-	(*SendRequest)(nil),             // 13: walletdkrpc.SendRequest
-	(*SendResponse)(nil),            // 14: walletdkrpc.SendResponse
-	(*RecvRequest)(nil),             // 15: walletdkrpc.RecvRequest
-	(*RecvResponse)(nil),            // 16: walletdkrpc.RecvResponse
-	(*ListRequest)(nil),             // 17: walletdkrpc.ListRequest
-	(*ListResponse)(nil),            // 18: walletdkrpc.ListResponse
-	(*ActivityList)(nil),            // 19: walletdkrpc.ActivityList
-	(*VTXOInventory)(nil),           // 20: walletdkrpc.VTXOInventory
-	(*WalletVTXO)(nil),              // 21: walletdkrpc.WalletVTXO
-	(*OnchainHistory)(nil),          // 22: walletdkrpc.OnchainHistory
-	(*OnchainTx)(nil),               // 23: walletdkrpc.OnchainTx
-	(*InspectActivityRequest)(nil),  // 24: walletdkrpc.InspectActivityRequest
-	(*InspectActivityResponse)(nil), // 25: walletdkrpc.InspectActivityResponse
-	(*ActivitySwapTrace)(nil),       // 26: walletdkrpc.ActivitySwapTrace
-	(*ActivityVTXOTrace)(nil),       // 27: walletdkrpc.ActivityVTXOTrace
-	(*ActivityLedgerTrace)(nil),     // 28: walletdkrpc.ActivityLedgerTrace
-	(*DepositRequest)(nil),          // 29: walletdkrpc.DepositRequest
-	(*DepositResponse)(nil),         // 30: walletdkrpc.DepositResponse
-	(*BalanceRequest)(nil),          // 31: walletdkrpc.BalanceRequest
-	(*BalanceResponse)(nil),         // 32: walletdkrpc.BalanceResponse
-	(*StatusRequest)(nil),           // 33: walletdkrpc.StatusRequest
-	(*StatusResponse)(nil),          // 34: walletdkrpc.StatusResponse
-	(*ExitRequest)(nil),             // 35: walletdkrpc.ExitRequest
-	(*ExitResponse)(nil),            // 36: walletdkrpc.ExitResponse
-	(*ExitStatusRequest)(nil),       // 37: walletdkrpc.ExitStatusRequest
-	(*ExitStatusResponse)(nil),      // 38: walletdkrpc.ExitStatusResponse
-	(*SubscribeWalletRequest)(nil),  // 39: walletdkrpc.SubscribeWalletRequest
-	(*WalletEntry)(nil),             // 40: walletdkrpc.WalletEntry
-	(*WalletEntryRequest)(nil),      // 41: walletdkrpc.WalletEntryRequest
-	(*LightningInvoiceRequest)(nil), // 42: walletdkrpc.LightningInvoiceRequest
-	(*OnchainAddressRequest)(nil),   // 43: walletdkrpc.OnchainAddressRequest
-	(*ArkAddressRequest)(nil),       // 44: walletdkrpc.ArkAddressRequest
-	(*WalletEntryProgress)(nil),     // 45: walletdkrpc.WalletEntryProgress
+	(ExitMode)(0),                   // 5: walletdkrpc.ExitMode
+	(ExitJobStatus)(0),              // 6: walletdkrpc.ExitJobStatus
+	(WalletEntryPhase)(0),           // 7: walletdkrpc.WalletEntryPhase
+	(*CreateRequest)(nil),           // 8: walletdkrpc.CreateRequest
+	(*CreateResponse)(nil),          // 9: walletdkrpc.CreateResponse
+	(*UnlockRequest)(nil),           // 10: walletdkrpc.UnlockRequest
+	(*UnlockResponse)(nil),          // 11: walletdkrpc.UnlockResponse
+	(*PrepareSendRequest)(nil),      // 12: walletdkrpc.PrepareSendRequest
+	(*PrepareSendResponse)(nil),     // 13: walletdkrpc.PrepareSendResponse
+	(*SendRequest)(nil),             // 14: walletdkrpc.SendRequest
+	(*SendResponse)(nil),            // 15: walletdkrpc.SendResponse
+	(*RecvRequest)(nil),             // 16: walletdkrpc.RecvRequest
+	(*RecvResponse)(nil),            // 17: walletdkrpc.RecvResponse
+	(*ListRequest)(nil),             // 18: walletdkrpc.ListRequest
+	(*ListResponse)(nil),            // 19: walletdkrpc.ListResponse
+	(*ActivityList)(nil),            // 20: walletdkrpc.ActivityList
+	(*VTXOInventory)(nil),           // 21: walletdkrpc.VTXOInventory
+	(*WalletVTXO)(nil),              // 22: walletdkrpc.WalletVTXO
+	(*OnchainHistory)(nil),          // 23: walletdkrpc.OnchainHistory
+	(*OnchainTx)(nil),               // 24: walletdkrpc.OnchainTx
+	(*InspectActivityRequest)(nil),  // 25: walletdkrpc.InspectActivityRequest
+	(*InspectActivityResponse)(nil), // 26: walletdkrpc.InspectActivityResponse
+	(*ActivitySwapTrace)(nil),       // 27: walletdkrpc.ActivitySwapTrace
+	(*ActivityVTXOTrace)(nil),       // 28: walletdkrpc.ActivityVTXOTrace
+	(*ActivityLedgerTrace)(nil),     // 29: walletdkrpc.ActivityLedgerTrace
+	(*DepositRequest)(nil),          // 30: walletdkrpc.DepositRequest
+	(*DepositResponse)(nil),         // 31: walletdkrpc.DepositResponse
+	(*BalanceRequest)(nil),          // 32: walletdkrpc.BalanceRequest
+	(*BalanceResponse)(nil),         // 33: walletdkrpc.BalanceResponse
+	(*StatusRequest)(nil),           // 34: walletdkrpc.StatusRequest
+	(*StatusResponse)(nil),          // 35: walletdkrpc.StatusResponse
+	(*ExitRequest)(nil),             // 36: walletdkrpc.ExitRequest
+	(*ExitResponse)(nil),            // 37: walletdkrpc.ExitResponse
+	(*ExitStatusRequest)(nil),       // 38: walletdkrpc.ExitStatusRequest
+	(*ExitStatusResponse)(nil),      // 39: walletdkrpc.ExitStatusResponse
+	(*SubscribeWalletRequest)(nil),  // 40: walletdkrpc.SubscribeWalletRequest
+	(*WalletEntry)(nil),             // 41: walletdkrpc.WalletEntry
+	(*WalletEntryRequest)(nil),      // 42: walletdkrpc.WalletEntryRequest
+	(*LightningInvoiceRequest)(nil), // 43: walletdkrpc.LightningInvoiceRequest
+	(*OnchainAddressRequest)(nil),   // 44: walletdkrpc.OnchainAddressRequest
+	(*ArkAddressRequest)(nil),       // 45: walletdkrpc.ArkAddressRequest
+	(*WalletEntryProgress)(nil),     // 46: walletdkrpc.WalletEntryProgress
 }
 var file_wallet_proto_depIdxs = []int32{
 	3,  // 0: walletdkrpc.PrepareSendResponse.rail:type_name -> walletdkrpc.SendRail
 	4,  // 1: walletdkrpc.PrepareSendResponse.quote_status:type_name -> walletdkrpc.SendQuoteStatus
-	40, // 2: walletdkrpc.SendResponse.entry:type_name -> walletdkrpc.WalletEntry
-	40, // 3: walletdkrpc.RecvResponse.entry:type_name -> walletdkrpc.WalletEntry
+	41, // 2: walletdkrpc.SendResponse.entry:type_name -> walletdkrpc.WalletEntry
+	41, // 3: walletdkrpc.RecvResponse.entry:type_name -> walletdkrpc.WalletEntry
 	2,  // 4: walletdkrpc.ListRequest.view:type_name -> walletdkrpc.ListView
 	0,  // 5: walletdkrpc.ListRequest.kinds:type_name -> walletdkrpc.EntryKind
-	19, // 6: walletdkrpc.ListResponse.activity:type_name -> walletdkrpc.ActivityList
-	20, // 7: walletdkrpc.ListResponse.vtxos:type_name -> walletdkrpc.VTXOInventory
-	22, // 8: walletdkrpc.ListResponse.onchain:type_name -> walletdkrpc.OnchainHistory
-	40, // 9: walletdkrpc.ActivityList.entries:type_name -> walletdkrpc.WalletEntry
-	21, // 10: walletdkrpc.VTXOInventory.vtxos:type_name -> walletdkrpc.WalletVTXO
-	23, // 11: walletdkrpc.OnchainHistory.txs:type_name -> walletdkrpc.OnchainTx
-	40, // 12: walletdkrpc.InspectActivityResponse.entry:type_name -> walletdkrpc.WalletEntry
-	26, // 13: walletdkrpc.InspectActivityResponse.swap:type_name -> walletdkrpc.ActivitySwapTrace
-	27, // 14: walletdkrpc.InspectActivityResponse.vtxos:type_name -> walletdkrpc.ActivityVTXOTrace
-	28, // 15: walletdkrpc.InspectActivityResponse.ledger_rows:type_name -> walletdkrpc.ActivityLedgerTrace
-	40, // 16: walletdkrpc.DepositResponse.entry:type_name -> walletdkrpc.WalletEntry
-	32, // 17: walletdkrpc.StatusResponse.balance:type_name -> walletdkrpc.BalanceResponse
-	5,  // 18: walletdkrpc.ExitStatusResponse.status:type_name -> walletdkrpc.ExitJobStatus
-	0,  // 19: walletdkrpc.SubscribeWalletRequest.kinds:type_name -> walletdkrpc.EntryKind
-	0,  // 20: walletdkrpc.WalletEntry.kind:type_name -> walletdkrpc.EntryKind
-	1,  // 21: walletdkrpc.WalletEntry.status:type_name -> walletdkrpc.EntryStatus
-	41, // 22: walletdkrpc.WalletEntry.request:type_name -> walletdkrpc.WalletEntryRequest
-	45, // 23: walletdkrpc.WalletEntry.progress:type_name -> walletdkrpc.WalletEntryProgress
-	42, // 24: walletdkrpc.WalletEntryRequest.lightning_invoice:type_name -> walletdkrpc.LightningInvoiceRequest
-	43, // 25: walletdkrpc.WalletEntryRequest.onchain_address:type_name -> walletdkrpc.OnchainAddressRequest
-	44, // 26: walletdkrpc.WalletEntryRequest.ark_address:type_name -> walletdkrpc.ArkAddressRequest
-	6,  // 27: walletdkrpc.WalletEntryProgress.phase:type_name -> walletdkrpc.WalletEntryPhase
-	7,  // 28: walletdkrpc.WalletService.Create:input_type -> walletdkrpc.CreateRequest
-	9,  // 29: walletdkrpc.WalletService.Unlock:input_type -> walletdkrpc.UnlockRequest
-	11, // 30: walletdkrpc.WalletService.PrepareSend:input_type -> walletdkrpc.PrepareSendRequest
-	13, // 31: walletdkrpc.WalletService.Send:input_type -> walletdkrpc.SendRequest
-	15, // 32: walletdkrpc.WalletService.Recv:input_type -> walletdkrpc.RecvRequest
-	17, // 33: walletdkrpc.WalletService.List:input_type -> walletdkrpc.ListRequest
-	29, // 34: walletdkrpc.WalletService.Deposit:input_type -> walletdkrpc.DepositRequest
-	31, // 35: walletdkrpc.WalletService.Balance:input_type -> walletdkrpc.BalanceRequest
-	33, // 36: walletdkrpc.WalletService.Status:input_type -> walletdkrpc.StatusRequest
-	35, // 37: walletdkrpc.WalletService.Exit:input_type -> walletdkrpc.ExitRequest
-	37, // 38: walletdkrpc.WalletService.ExitStatus:input_type -> walletdkrpc.ExitStatusRequest
-	39, // 39: walletdkrpc.WalletService.SubscribeWallet:input_type -> walletdkrpc.SubscribeWalletRequest
-	24, // 40: walletdkrpc.WalletInspectionService.InspectActivity:input_type -> walletdkrpc.InspectActivityRequest
-	8,  // 41: walletdkrpc.WalletService.Create:output_type -> walletdkrpc.CreateResponse
-	10, // 42: walletdkrpc.WalletService.Unlock:output_type -> walletdkrpc.UnlockResponse
-	12, // 43: walletdkrpc.WalletService.PrepareSend:output_type -> walletdkrpc.PrepareSendResponse
-	14, // 44: walletdkrpc.WalletService.Send:output_type -> walletdkrpc.SendResponse
-	16, // 45: walletdkrpc.WalletService.Recv:output_type -> walletdkrpc.RecvResponse
-	18, // 46: walletdkrpc.WalletService.List:output_type -> walletdkrpc.ListResponse
-	30, // 47: walletdkrpc.WalletService.Deposit:output_type -> walletdkrpc.DepositResponse
-	32, // 48: walletdkrpc.WalletService.Balance:output_type -> walletdkrpc.BalanceResponse
-	34, // 49: walletdkrpc.WalletService.Status:output_type -> walletdkrpc.StatusResponse
-	36, // 50: walletdkrpc.WalletService.Exit:output_type -> walletdkrpc.ExitResponse
-	38, // 51: walletdkrpc.WalletService.ExitStatus:output_type -> walletdkrpc.ExitStatusResponse
-	40, // 52: walletdkrpc.WalletService.SubscribeWallet:output_type -> walletdkrpc.WalletEntry
-	25, // 53: walletdkrpc.WalletInspectionService.InspectActivity:output_type -> walletdkrpc.InspectActivityResponse
-	41, // [41:54] is the sub-list for method output_type
-	28, // [28:41] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	20, // 6: walletdkrpc.ListResponse.activity:type_name -> walletdkrpc.ActivityList
+	21, // 7: walletdkrpc.ListResponse.vtxos:type_name -> walletdkrpc.VTXOInventory
+	23, // 8: walletdkrpc.ListResponse.onchain:type_name -> walletdkrpc.OnchainHistory
+	41, // 9: walletdkrpc.ActivityList.entries:type_name -> walletdkrpc.WalletEntry
+	22, // 10: walletdkrpc.VTXOInventory.vtxos:type_name -> walletdkrpc.WalletVTXO
+	24, // 11: walletdkrpc.OnchainHistory.txs:type_name -> walletdkrpc.OnchainTx
+	41, // 12: walletdkrpc.InspectActivityResponse.entry:type_name -> walletdkrpc.WalletEntry
+	27, // 13: walletdkrpc.InspectActivityResponse.swap:type_name -> walletdkrpc.ActivitySwapTrace
+	28, // 14: walletdkrpc.InspectActivityResponse.vtxos:type_name -> walletdkrpc.ActivityVTXOTrace
+	29, // 15: walletdkrpc.InspectActivityResponse.ledger_rows:type_name -> walletdkrpc.ActivityLedgerTrace
+	41, // 16: walletdkrpc.DepositResponse.entry:type_name -> walletdkrpc.WalletEntry
+	33, // 17: walletdkrpc.StatusResponse.balance:type_name -> walletdkrpc.BalanceResponse
+	5,  // 18: walletdkrpc.ExitResponse.mode:type_name -> walletdkrpc.ExitMode
+	6,  // 19: walletdkrpc.ExitStatusResponse.status:type_name -> walletdkrpc.ExitJobStatus
+	0,  // 20: walletdkrpc.SubscribeWalletRequest.kinds:type_name -> walletdkrpc.EntryKind
+	0,  // 21: walletdkrpc.WalletEntry.kind:type_name -> walletdkrpc.EntryKind
+	1,  // 22: walletdkrpc.WalletEntry.status:type_name -> walletdkrpc.EntryStatus
+	42, // 23: walletdkrpc.WalletEntry.request:type_name -> walletdkrpc.WalletEntryRequest
+	46, // 24: walletdkrpc.WalletEntry.progress:type_name -> walletdkrpc.WalletEntryProgress
+	43, // 25: walletdkrpc.WalletEntryRequest.lightning_invoice:type_name -> walletdkrpc.LightningInvoiceRequest
+	44, // 26: walletdkrpc.WalletEntryRequest.onchain_address:type_name -> walletdkrpc.OnchainAddressRequest
+	45, // 27: walletdkrpc.WalletEntryRequest.ark_address:type_name -> walletdkrpc.ArkAddressRequest
+	7,  // 28: walletdkrpc.WalletEntryProgress.phase:type_name -> walletdkrpc.WalletEntryPhase
+	8,  // 29: walletdkrpc.WalletService.Create:input_type -> walletdkrpc.CreateRequest
+	10, // 30: walletdkrpc.WalletService.Unlock:input_type -> walletdkrpc.UnlockRequest
+	12, // 31: walletdkrpc.WalletService.PrepareSend:input_type -> walletdkrpc.PrepareSendRequest
+	14, // 32: walletdkrpc.WalletService.Send:input_type -> walletdkrpc.SendRequest
+	16, // 33: walletdkrpc.WalletService.Recv:input_type -> walletdkrpc.RecvRequest
+	18, // 34: walletdkrpc.WalletService.List:input_type -> walletdkrpc.ListRequest
+	30, // 35: walletdkrpc.WalletService.Deposit:input_type -> walletdkrpc.DepositRequest
+	32, // 36: walletdkrpc.WalletService.Balance:input_type -> walletdkrpc.BalanceRequest
+	34, // 37: walletdkrpc.WalletService.Status:input_type -> walletdkrpc.StatusRequest
+	36, // 38: walletdkrpc.WalletService.Exit:input_type -> walletdkrpc.ExitRequest
+	38, // 39: walletdkrpc.WalletService.ExitStatus:input_type -> walletdkrpc.ExitStatusRequest
+	40, // 40: walletdkrpc.WalletService.SubscribeWallet:input_type -> walletdkrpc.SubscribeWalletRequest
+	25, // 41: walletdkrpc.WalletInspectionService.InspectActivity:input_type -> walletdkrpc.InspectActivityRequest
+	9,  // 42: walletdkrpc.WalletService.Create:output_type -> walletdkrpc.CreateResponse
+	11, // 43: walletdkrpc.WalletService.Unlock:output_type -> walletdkrpc.UnlockResponse
+	13, // 44: walletdkrpc.WalletService.PrepareSend:output_type -> walletdkrpc.PrepareSendResponse
+	15, // 45: walletdkrpc.WalletService.Send:output_type -> walletdkrpc.SendResponse
+	17, // 46: walletdkrpc.WalletService.Recv:output_type -> walletdkrpc.RecvResponse
+	19, // 47: walletdkrpc.WalletService.List:output_type -> walletdkrpc.ListResponse
+	31, // 48: walletdkrpc.WalletService.Deposit:output_type -> walletdkrpc.DepositResponse
+	33, // 49: walletdkrpc.WalletService.Balance:output_type -> walletdkrpc.BalanceResponse
+	35, // 50: walletdkrpc.WalletService.Status:output_type -> walletdkrpc.StatusResponse
+	37, // 51: walletdkrpc.WalletService.Exit:output_type -> walletdkrpc.ExitResponse
+	39, // 52: walletdkrpc.WalletService.ExitStatus:output_type -> walletdkrpc.ExitStatusResponse
+	41, // 53: walletdkrpc.WalletService.SubscribeWallet:output_type -> walletdkrpc.WalletEntry
+	26, // 54: walletdkrpc.WalletInspectionService.InspectActivity:output_type -> walletdkrpc.InspectActivityResponse
+	42, // [42:55] is the sub-list for method output_type
+	29, // [29:42] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_wallet_proto_init() }
@@ -4041,7 +4153,7 @@ func file_wallet_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wallet_proto_rawDesc), len(file_wallet_proto_rawDesc)),
-			NumEnums:      7,
+			NumEnums:      8,
 			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   2,

--- a/rpc/walletdkrpc/wallet.proto
+++ b/rpc/walletdkrpc/wallet.proto
@@ -66,10 +66,10 @@ service WalletService {
     // `getinfo` CLI verb covers the human-facing readiness view).
     rpc Status (StatusRequest) returns (StatusResponse);
 
-    // Exit triggers a unilateral exit (unroll) for the specified VTXO
-    // outpoint. The daemon assembles the recovery proof, spawns a durable
-    // unroll job, and drives the on-chain recovery process to completion.
-    // Proxies daemonrpc.Unroll.
+    // Exit queues a cooperative leave for the specified VTXO outpoint by
+    // default. When the caller supplies force_unroll_ack exactly, the daemon
+    // starts a unilateral unroll instead after checking that the outpoint is
+    // present in the local backing wallet's UTXO set.
     rpc Exit (ExitRequest) returns (ExitResponse);
 
     // ExitStatus reports the current phase of an unroll job for the
@@ -160,6 +160,14 @@ enum SendQuoteStatus {
     // validation and selection but one or more remote quote APIs are not
     // available yet.
     SEND_QUOTE_STATUS_LOCAL_ONLY = 2;
+}
+
+// ExitMode identifies whether Exit queued a cooperative leave or started a
+// forced unilateral unroll.
+enum ExitMode {
+    EXIT_MODE_UNSPECIFIED = 0;
+    EXIT_MODE_COOPERATIVE = 1;
+    EXIT_MODE_UNILATERAL = 2;
 }
 
 message CreateRequest {
@@ -729,18 +737,38 @@ message StatusResponse {
 }
 
 message ExitRequest {
-    // outpoint is the VTXO outpoint to unilaterally exit, formatted as
-    // "txid:index".
+    // outpoint is the VTXO outpoint to exit, formatted as "txid:index".
     string outpoint = 1;
+
+    // onchain_address is the cooperative leave destination. Empty asks the
+    // daemon to generate a fresh backing-wallet address internally.
+    string onchain_address = 2;
+
+    // force_unroll_ack must be exactly "I_KNOW_WHAT_I_AM_DOING" to bypass
+    // cooperative leave and start unilateral unroll. It cannot be combined
+    // with onchain_address, and the server requires at least one confirmed
+    // local backing-wallet UTXO before admitting forced unroll.
+    string force_unroll_ack = 3;
 }
 
 message ExitResponse {
-    // created indicates whether a new exit job was spawned. False if
-    // an existing job already covers this target.
+    // created indicates whether a new unilateral exit job was spawned.
+    // False if an existing job already covers this target. Cooperative
+    // exits leave this unset.
     bool created = 1;
 
-    // actor_id is the identifier of the durable exit job actor.
+    // actor_id is the identifier of the durable unilateral exit job actor.
     string actor_id = 2;
+
+    // mode identifies the branch the daemon took.
+    ExitMode mode = 3;
+
+    // queued_outpoints lists the outpoints accepted into cooperative leave.
+    repeated string queued_outpoints = 4;
+
+    // onchain_address is the cooperative leave destination used by the
+    // daemon. It may be caller-supplied or daemon-generated.
+    string onchain_address = 5;
 }
 
 message ExitStatusRequest {

--- a/rpc/walletdkrpc/wallet_grpc.pb.go
+++ b/rpc/walletdkrpc/wallet_grpc.pb.go
@@ -90,10 +90,10 @@ type WalletServiceClient interface {
 	// the proto for programmatic callers; not surfaced as a CLI verb (the
 	// `getinfo` CLI verb covers the human-facing readiness view).
 	Status(ctx context.Context, in *StatusRequest, opts ...grpc.CallOption) (*StatusResponse, error)
-	// Exit triggers a unilateral exit (unroll) for the specified VTXO
-	// outpoint. The daemon assembles the recovery proof, spawns a durable
-	// unroll job, and drives the on-chain recovery process to completion.
-	// Proxies daemonrpc.Unroll.
+	// Exit queues a cooperative leave for the specified VTXO outpoint by
+	// default. When the caller supplies force_unroll_ack exactly, the daemon
+	// starts a unilateral unroll instead after checking that the outpoint is
+	// present in the local backing wallet's UTXO set.
 	Exit(ctx context.Context, in *ExitRequest, opts ...grpc.CallOption) (*ExitResponse, error)
 	// ExitStatus reports the current phase of an unroll job for the
 	// specified VTXO outpoint, including recovery chain progress and
@@ -299,10 +299,10 @@ type WalletServiceServer interface {
 	// the proto for programmatic callers; not surfaced as a CLI verb (the
 	// `getinfo` CLI verb covers the human-facing readiness view).
 	Status(context.Context, *StatusRequest) (*StatusResponse, error)
-	// Exit triggers a unilateral exit (unroll) for the specified VTXO
-	// outpoint. The daemon assembles the recovery proof, spawns a durable
-	// unroll job, and drives the on-chain recovery process to completion.
-	// Proxies daemonrpc.Unroll.
+	// Exit queues a cooperative leave for the specified VTXO outpoint by
+	// default. When the caller supplies force_unroll_ack exactly, the daemon
+	// starts a unilateral unroll instead after checking that the outpoint is
+	// present in the local backing wallet's UTXO set.
 	Exit(context.Context, *ExitRequest) (*ExitResponse, error)
 	// ExitStatus reports the current phase of an unroll job for the
 	// specified VTXO outpoint, including recovery chain progress and

--- a/sdk/walletdk/AGENTS.md
+++ b/sdk/walletdk/AGENTS.md
@@ -50,16 +50,18 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   `WalletVTXO`, `OnchainTx`.
 - `ExitRequest` / `ExitResult` / `ExitStatusRequest` /
   `ExitStatusResult` / `ExitJobStatus` — exit DTOs. `ExitRequest`
-  carries the target outpoint plus an optional on-chain `Destination`:
-  when set, `Exit` first attempts a cooperative leave
-  (`daemonrpc.LeaveVTXOs`) so the VTXO is unwound via the next round
-  with the leave output landing on the caller-supplied address; the
-  SDK transparently falls back to `walletdkrpc.Exit` (unilateral
-  unroll) on any cooperative failure. `ExitResult.Cooperative`
+  carries the target outpoint plus an optional on-chain `Destination`
+  for cooperative leave; when omitted, the daemon generates an
+  internal backing-wallet address. The SDK delegates exit policy to
+  `walletdkrpc.Exit`, which queues cooperative leave by default and
+  starts unilateral unroll only when `ForceUnrollAck` carries the
+  daemon's exact acknowledgement string. `Destination` and
+  `ForceUnrollAck` are mutually exclusive. `ExitResult.Cooperative`
   reports the path taken; `QueuedOutpoints` echoes cooperative
-  selection; `Created`/`ActorID` describe the unilateral fallback
-  job; `CooperativeError` carries the original cooperative failure
-  when fallback occurred. Status strings are the wrapper-owned
+  selection; `Created`/`ActorID` describe a forced unilateral job.
+  `CooperativeError` and `ExitPathUnilateralFallback` are retained for
+  source compatibility with the old fallback result shape but are not
+  populated by current behavior. Status strings are the wrapper-owned
   lowercase set
   (`pending`/`materializing`/`csv_pending`/`sweeping`/`completed`/`failed`/`unspecified`).
 - `ErrWalletRPCUnavailable` — sentinel returned by every wallet method

--- a/sdk/walletdk/CLAUDE.md
+++ b/sdk/walletdk/CLAUDE.md
@@ -50,16 +50,18 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   `WalletVTXO`, `OnchainTx`.
 - `ExitRequest` / `ExitResult` / `ExitStatusRequest` /
   `ExitStatusResult` / `ExitJobStatus` — exit DTOs. `ExitRequest`
-  carries the target outpoint plus an optional on-chain `Destination`:
-  when set, `Exit` first attempts a cooperative leave
-  (`daemonrpc.LeaveVTXOs`) so the VTXO is unwound via the next round
-  with the leave output landing on the caller-supplied address; the
-  SDK transparently falls back to `walletdkrpc.Exit` (unilateral
-  unroll) on any cooperative failure. `ExitResult.Cooperative`
+  carries the target outpoint plus an optional on-chain `Destination`
+  for cooperative leave; when omitted, the daemon generates an
+  internal backing-wallet address. The SDK delegates exit policy to
+  `walletdkrpc.Exit`, which queues cooperative leave by default and
+  starts unilateral unroll only when `ForceUnrollAck` carries the
+  daemon's exact acknowledgement string. `Destination` and
+  `ForceUnrollAck` are mutually exclusive. `ExitResult.Cooperative`
   reports the path taken; `QueuedOutpoints` echoes cooperative
-  selection; `Created`/`ActorID` describe the unilateral fallback
-  job; `CooperativeError` carries the original cooperative failure
-  when fallback occurred. Status strings are the wrapper-owned
+  selection; `Created`/`ActorID` describe a forced unilateral job.
+  `CooperativeError` and `ExitPathUnilateralFallback` are retained for
+  source compatibility with the old fallback result shape but are not
+  populated by current behavior. Status strings are the wrapper-owned
   lowercase set
   (`pending`/`materializing`/`csv_pending`/`sweeping`/`completed`/`failed`/`unspecified`).
 - `ErrWalletRPCUnavailable` — sentinel returned by every wallet method

--- a/sdk/walletdk/client.go
+++ b/sdk/walletdk/client.go
@@ -16,8 +16,6 @@ import (
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const defaultCloseTimeout = 5 * time.Second
@@ -398,32 +396,10 @@ func (c *Client) List(ctx context.Context, req ListRequest) (*ListResult,
 	return listResultFromProto(view, resp), nil
 }
 
-// Exit drives the SDK's two-track exit policy for a single VTXO
-// outpoint. When req.Destination is set, Exit first attempts a
-// server-cooperative leave (LeaveVTXOs RPC) so the VTXO is unwound
-// through the next assembling round and the leave output lands on
-// the caller-supplied on-chain address. The SDK only falls back to
-// unilateral unroll on transport-class errors (operator unreachable
-// or the caller's ctx fired); caller-side errors such as
-// InvalidArgument are returned verbatim so a typo on Destination is
-// loud rather than silently routed to a wallet-derived script. A
-// nil-error LeaveVTXOs response that does not echo req.Outpoint in
-// QueuedOutpoints (H-2) is treated as a per-outpoint cooperative
-// failure and routed through the same fallback pipeline. When
-// req.Destination is empty the cooperative path is skipped and Exit
-// goes straight to unilateral unroll.
-//
-// Before falling back, Exit cross-checks via ListVTXOs that the
-// daemon did not already admit the cooperative leave server-side
-// (which can happen when the caller's ctx cancels mid-handler but
-// the wallet actor keeps processing on its own root-anchored ctx).
-// The fallback is refused if the VTXO is in PendingForfeit /
-// Forfeiting, since racing an Unroll in either state risks a
-// double-claim of the same VTXO.
-//
-// Read ExitResult.Path to dispatch on which branch the daemon took;
-// the remaining fields are zero-valued for paths they do not apply
-// to.
+// Exit requests wallet-facing exit for a single VTXO outpoint. The daemon
+// queues cooperative leave by default, generating an internal destination when
+// req.Destination is empty. Unilateral unroll is reachable only when
+// req.ForceUnrollAck carries the daemon's exact acknowledgement string.
 func (c *Client) Exit(ctx context.Context, req ExitRequest) (*ExitResult,
 	error) {
 
@@ -435,207 +411,40 @@ func (c *Client) Exit(ctx context.Context, req ExitRequest) (*ExitResult,
 	}
 
 	dest := strings.TrimSpace(req.Destination)
-	if dest == "" {
-		res, err := c.unilateralExit(ctx, req.Outpoint)
-		if err != nil {
-			return nil, err
-		}
-		res.Path = ExitPathUnilateral
-
-		return res, nil
+	ack := strings.TrimSpace(req.ForceUnrollAck)
+	if dest != "" && ack != "" {
+		return nil, fmt.Errorf("destination cannot be combined with " +
+			"force_unroll_ack")
 	}
-
-	leaveResp, leaveErr := c.cooperativeLeave(ctx, req.Outpoint, dest)
-	if leaveErr == nil {
-		// H-2 guard: the daemon's LeaveVTXOs surfaces per-outpoint
-		// wallet failures as log lines rather than as a top-level
-		// error, returning a (possibly empty) queued set. Treat a
-		// queued list that does not echo our outpoint as cooperative
-		// failure and fall through to the fallback decision tree.
-		queued := leaveResp.GetQueuedOutpoints()
-		if outpointInList(req.Outpoint, queued) {
-			return &ExitResult{
-				Path:            ExitPathCooperative,
-				Cooperative:     true,
-				QueuedOutpoints: queued,
-			}, nil
-		}
-		leaveErr = fmt.Errorf("%w for %s", errCooperativeEmptyQueued,
-			req.Outpoint)
-	}
-
-	// H-1 triage: caller-class errors are not eligible for
-	// silent fallback. Returning them verbatim keeps caller bugs
-	// (typo'd address, wrong-network destination, malformed
-	// outpoint) loud rather than rerouting funds to a wallet
-	// script via the unilateral path.
-	if !isCooperativeRetryable(leaveErr) {
-		return nil, fmt.Errorf("exit: cooperative leave failed: %w",
-			leaveErr)
-	}
-
-	// M-6 short-circuit: if the caller's ctx already fired,
-	// the fallback would also fail against the same ctx. Return
-	// the cooperative error wrapped in the ctx error so the
-	// caller sees what happened without a misleading
-	// "fallback failed" suffix.
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		return nil, fmt.Errorf("exit: cooperative leave failed (%w) "+
-			"and ctx cancelled: %v", ctxErr, leaveErr)
-	}
-
-	// H-3 ListVTXOs guard: the wallet actor processes the leave
-	// against its own root-anchored ctx, so a caller-side ctx
-	// cancel can race the daemon's admission to completion. If
-	// the VTXO is already PendingForfeit / Forfeiting the
-	// cooperative leave is in flight on the operator; firing
-	// Unroll on top would risk a double-claim.
-	if admitted, err := c.cooperativeAttemptAdmitted(
-		ctx, req.Outpoint,
-	); err != nil {
-		// Lookup failure is itself a transport-class problem;
-		// surface it alongside the cooperative error rather
-		// than silently choosing for the caller.
-		return nil, fmt.Errorf("exit: cooperative leave failed (%w) "+
-			"and admission probe failed: %v", leaveErr, err)
-	} else if admitted {
-		return nil, fmt.Errorf("exit: cooperative leave failed at the "+
-			"RPC boundary but the daemon already admitted the "+
-			"intent; retry the cooperative path or wait for the "+
-			"round to settle: %w", leaveErr)
-	}
-
-	fallback, err := c.unilateralExit(ctx, req.Outpoint)
-	if err != nil {
-		return nil, fmt.Errorf("exit: cooperative leave failed (%v) "+
-			"and unilateral fallback failed: %w", leaveErr, err)
-	}
-	fallback.Path = ExitPathUnilateralFallback
-	fallback.CooperativeError = leaveErr.Error()
-
-	return fallback, nil
-}
-
-// cooperativeLeave builds the single-outpoint LeaveVTXOs request and
-// dispatches it. Factored out of Exit so the cooperative dispatch and
-// the post-call triage logic read cleanly.
-func (c *Client) cooperativeLeave(ctx context.Context, outpoint,
-	destination string) (*daemonrpc.LeaveVTXOsResponse, error) {
-
-	leaveReq := &daemonrpc.LeaveVTXOsRequest{
-		Selection: &daemonrpc.LeaveVTXOsRequest_Outpoints{
-			Outpoints: &daemonrpc.OutpointSelection{
-				Outpoints: []string{
-					outpoint,
-				},
-			},
-		},
-		DefaultDestination: &daemonrpc.LeaveDestination{
-			Target: &daemonrpc.LeaveDestination_Address{
-				Address: destination,
-			},
-		},
-	}
-
-	return c.daemon.LeaveVTXOs(ctx, leaveReq)
-}
-
-// cooperativeAttemptAdmitted reports whether the daemon's wallet
-// state shows the supplied outpoint already locked into a
-// cooperative leave (PendingForfeit / Forfeiting). The probe is used
-// by Exit to guard the unilateral fallback against a double-claim
-// race when a caller-side ctx cancel returned an error from
-// LeaveVTXOs but the wallet actor kept processing on its root ctx.
-func (c *Client) cooperativeAttemptAdmitted(ctx context.Context,
-	outpoint string) (bool, error) {
-
-	for _, st := range []daemonrpc.VTXOStatus{
-		daemonrpc.VTXOStatus_VTXO_STATUS_PENDING_FORFEIT,
-		daemonrpc.VTXOStatus_VTXO_STATUS_FORFEITING,
-	} {
-		resp, err := c.daemon.ListVTXOs(
-			ctx, &daemonrpc.ListVTXOsRequest{
-				StatusFilter: st,
-			},
-		)
-		if err != nil {
-			return false, err
-		}
-		for _, vtxo := range resp.GetVtxos() {
-			if vtxo.GetOutpoint() == outpoint {
-				return true, nil
-			}
-		}
-	}
-
-	return false, nil
-}
-
-// errCooperativeEmptyQueued sentinels the H-2 case where the
-// daemon's LeaveVTXOs accepted the request but returned no queued
-// outpoint for the caller's target — typically a per-outpoint
-// wallet failure that LeaveVTXOs logs and swallows. We treat this
-// like a transport-class failure so the SDK falls back to
-// unilateral exit.
-var errCooperativeEmptyQueued = errors.New("cooperative leave returned no " +
-	"queued outpoint")
-
-// isCooperativeRetryable reports whether an error from the
-// cooperative LeaveVTXOs RPC is eligible for the unilateral
-// fallback. Only transport- or operator-availability-class codes
-// qualify, plus the empty-queued sentinel; caller-side errors
-// (InvalidArgument, FailedPrecondition, NotFound, PermissionDenied)
-// are returned verbatim so callers see their mistakes directly
-// instead of having the SDK silently route the funds via the
-// unilateral path.
-func isCooperativeRetryable(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, errCooperativeEmptyQueued) {
-		return true
-	}
-	switch status.Code(err) {
-	case codes.Unavailable, codes.DeadlineExceeded,
-		codes.Canceled, codes.Aborted, codes.ResourceExhausted:
-
-		return true
-
-	default:
-		return false
-	}
-}
-
-// outpointInList reports whether target is contained in the supplied
-// outpoint string slice. Used by Exit's H-2 guard against the
-// daemon's "queued nothing but no error" failure mode.
-func outpointInList(target string, list []string) bool {
-	for _, op := range list {
-		if op == target {
-			return true
-		}
-	}
-
-	return false
-}
-
-// unilateralExit calls walletdkrpc.Exit (which proxies
-// daemonrpc.Unroll). The caller sets Path to ExitPathUnilateral or
-// ExitPathUnilateralFallback depending on the branch.
-func (c *Client) unilateralExit(ctx context.Context, outpoint string) (
-	*ExitResult, error) {
 
 	resp, err := c.wallet.Exit(ctx, &walletdkrpc.ExitRequest{
-		Outpoint: outpoint,
+		Outpoint:       req.Outpoint,
+		OnchainAddress: dest,
+		ForceUnrollAck: ack,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("exit: %w", err)
 	}
 
-	return &ExitResult{
-		Created: resp.GetCreated(),
-		ActorID: resp.GetActorId(),
-	}, nil
+	switch resp.GetMode() {
+	case walletdkrpc.ExitMode_EXIT_MODE_COOPERATIVE:
+		return &ExitResult{
+			Path:            ExitPathCooperative,
+			Cooperative:     true,
+			QueuedOutpoints: resp.GetQueuedOutpoints(),
+		}, nil
+
+	case walletdkrpc.ExitMode_EXIT_MODE_UNILATERAL:
+		return &ExitResult{
+			Path:    ExitPathUnilateral,
+			Created: resp.GetCreated(),
+			ActorID: resp.GetActorId(),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("exit: daemon returned unknown mode %v",
+			resp.GetMode())
+	}
 }
 
 // ExitStatus reports the current phase of an exit job for the

--- a/sdk/walletdk/client_exit_test.go
+++ b/sdk/walletdk/client_exit_test.go
@@ -5,59 +5,20 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
-// stubDaemonClient embeds the gRPC interface (left nil) so calls to
-// any method other than the ones we explicitly stub trip a nil-deref
-// panic — the desired behavior for a test that should only exercise
-// the methods Exit actually depends on.
-type stubDaemonClient struct {
-	daemonrpc.DaemonServiceClient
-
-	leaveVTXOs func(ctx context.Context,
-		req *daemonrpc.LeaveVTXOsRequest) (
-		*daemonrpc.LeaveVTXOsResponse, error)
-
-	listVTXOs func(ctx context.Context,
-		req *daemonrpc.ListVTXOsRequest) (
-		*daemonrpc.ListVTXOsResponse, error)
-
-	leaveCalls int
-	listCalls  int
-}
-
-func (s *stubDaemonClient) LeaveVTXOs(ctx context.Context,
-	req *daemonrpc.LeaveVTXOsRequest, _ ...grpc.CallOption) (
-	*daemonrpc.LeaveVTXOsResponse, error) {
-
-	s.leaveCalls++
-
-	return s.leaveVTXOs(ctx, req)
-}
-
-func (s *stubDaemonClient) ListVTXOs(ctx context.Context,
-	req *daemonrpc.ListVTXOsRequest, _ ...grpc.CallOption) (
-	*daemonrpc.ListVTXOsResponse, error) {
-
-	s.listCalls++
-
-	return s.listVTXOs(ctx, req)
-}
-
-// stubWalletClient mirrors stubDaemonClient for the wallet RPC
-// surface; only Exit is needed.
+// stubWalletClient embeds the gRPC interface so calls to any method other
+// than the ones explicitly stubbed fail loudly in tests.
 type stubWalletClient struct {
 	walletdkrpc.WalletServiceClient
 
-	exit func(ctx context.Context, req *walletdkrpc.ExitRequest) (
+	exit func(context.Context, *walletdkrpc.ExitRequest) (
 		*walletdkrpc.ExitResponse, error)
 
+	lastExit  *walletdkrpc.ExitRequest
 	exitCalls int
 }
 
@@ -66,6 +27,7 @@ func (s *stubWalletClient) Exit(ctx context.Context,
 	*walletdkrpc.ExitResponse, error) {
 
 	s.exitCalls++
+	s.lastExit = req
 
 	return s.exit(ctx, req)
 }
@@ -74,112 +36,69 @@ const (
 	testExitOutpoint    = "abcdef0123456789:0"
 	testExitDestination = "bcrt1qexample"
 	testActorID         = "actor-xyz"
+	testForceUnrollAck  = "I_KNOW_WHAT_I_AM_DOING"
 )
 
-// newExitTestClient assembles a walletdk.Client backed by stub gRPC
-// clients so the Exit decision tree can be exercised without
-// standing up a real daemon.
-func newExitTestClient(daemon daemonrpc.DaemonServiceClient,
-	wallet walletdkrpc.WalletServiceClient) *Client {
-
+// newExitTestClient assembles a walletdk.Client backed by a stub wallet RPC
+// client so Exit can be exercised without standing up a real daemon.
+func newExitTestClient(wallet walletdkrpc.WalletServiceClient) *Client {
 	return &Client{
-		daemon:    daemon,
 		wallet:    wallet,
 		canWallet: true,
 	}
 }
 
-// listVTXOsStub is the signature of a stub for daemonrpc.ListVTXOs
-// used by the H-3 ListVTXOs-guard tests. Aliased so callers can
-// declare it without an 80-column-busting inline function literal
-// type.
-type listVTXOsStub = func(context.Context, *daemonrpc.ListVTXOsRequest) (
-	*daemonrpc.ListVTXOsResponse, error)
-
-// listVTXOsHit returns a ListVTXOs stub that echoes the supplied
-// outpoint when queried for the supplied status filter, and an empty
-// response otherwise. Used by the H-3 ListVTXOs-guard tests to
-// model "the daemon already admitted the cooperative leave".
-func listVTXOsHit(want daemonrpc.VTXOStatus, outpoint string) listVTXOsStub {
-	hit := &daemonrpc.ListVTXOsResponse{
-		Vtxos: []*daemonrpc.VTXO{{
-			Outpoint: outpoint,
-			Status:   want,
-		}},
-	}
-
-	return func(_ context.Context, req *daemonrpc.ListVTXOsRequest) (
-		*daemonrpc.ListVTXOsResponse, error) {
-
-		if req.GetStatusFilter() == want {
-			return hit, nil
-		}
-
-		return &daemonrpc.ListVTXOsResponse{}, nil
-	}
-}
-
-// TestExitNoDestinationGoesStraightToUnilateral pins down the
-// no-cooperative-attempt branch: when ExitRequest.Destination is
-// empty the SDK calls walletdkrpc.Exit directly and reports
-// ExitPathUnilateral without ever touching LeaveVTXOs / ListVTXOs.
-func TestExitNoDestinationGoesStraightToUnilateral(t *testing.T) {
+// TestExitDefaultUsesWalletRPCCooperative verifies that an empty destination
+// still calls walletdkrpc.Exit and reports the daemon's cooperative mode.
+func TestExitDefaultUsesWalletRPCCooperative(t *testing.T) {
 	t.Parallel()
 
 	wallet := &stubWalletClient{
 		exit: func(_ context.Context, _ *walletdkrpc.ExitRequest) (
 			*walletdkrpc.ExitResponse, error) {
 
+			mode := walletdkrpc.ExitMode_EXIT_MODE_COOPERATIVE
+
 			return &walletdkrpc.ExitResponse{
-				Created: true,
-				ActorId: testActorID,
+				Mode: mode,
+				QueuedOutpoints: []string{
+					testExitOutpoint,
+				},
 			}, nil
 		},
 	}
-	daemon := &stubDaemonClient{}
-
-	client := newExitTestClient(daemon, wallet)
+	client := newExitTestClient(wallet)
 
 	res, err := client.Exit(t.Context(), ExitRequest{
 		Outpoint: testExitOutpoint,
 	})
 	require.NoError(t, err)
-	require.Equal(t, ExitPathUnilateral, res.Path)
-	require.True(t, res.Created)
-	require.Equal(t, testActorID, res.ActorID)
-	require.Empty(t, res.CooperativeError)
-	require.Zero(
-		t, daemon.leaveCalls,
-		"no Destination must not invoke LeaveVTXOs",
-	)
-	require.Zero(
-		t, daemon.listCalls, "no Destination must not invoke ListVTXOs",
-	)
+	require.Equal(t, ExitPathCooperative, res.Path)
+	require.True(t, res.Cooperative)
+	require.Equal(t, []string{testExitOutpoint}, res.QueuedOutpoints)
 	require.Equal(t, 1, wallet.exitCalls)
+	require.Equal(t, testExitOutpoint, wallet.lastExit.GetOutpoint())
+	require.Empty(t, wallet.lastExit.GetOnchainAddress())
+	require.Empty(t, wallet.lastExit.GetForceUnrollAck())
 }
 
-// TestExitCooperativeSuccess covers the happy path: the daemon
-// queues the outpoint, the SDK reports ExitPathCooperative and
-// never falls through to Unroll.
-func TestExitCooperativeSuccess(t *testing.T) {
+// TestExitCooperativeDestinationPassesThrough confirms a caller-supplied
+// destination is forwarded to the wallet RPC surface.
+func TestExitCooperativeDestinationPassesThrough(t *testing.T) {
 	t.Parallel()
 
-	daemon := &stubDaemonClient{
-		leaveVTXOs: func(_ context.Context,
-			_ *daemonrpc.LeaveVTXOsRequest) (
-			*daemonrpc.LeaveVTXOsResponse, error) {
+	wallet := &stubWalletClient{
+		exit: func(_ context.Context, _ *walletdkrpc.ExitRequest) (
+			*walletdkrpc.ExitResponse, error) {
 
-			return &daemonrpc.LeaveVTXOsResponse{
-				QueuedOutpoints: []string{
-					testExitOutpoint,
-				},
-				Status: "queued",
+			mode := walletdkrpc.ExitMode_EXIT_MODE_COOPERATIVE
+
+			return &walletdkrpc.ExitResponse{
+				Mode: mode,
 			}, nil
 		},
 	}
-	wallet := &stubWalletClient{}
-
-	client := newExitTestClient(daemon, wallet)
+	client := newExitTestClient(wallet)
 
 	res, err := client.Exit(t.Context(), ExitRequest{
 		Outpoint:    testExitOutpoint,
@@ -187,321 +106,111 @@ func TestExitCooperativeSuccess(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, ExitPathCooperative, res.Path)
-	require.True(t, res.Cooperative)
-	require.Equal(t, []string{testExitOutpoint}, res.QueuedOutpoints)
-	require.Equal(t, 1, daemon.leaveCalls)
-	require.Zero(
-		t, daemon.listCalls,
-		"cooperative success must not probe ListVTXOs",
+	require.Equal(
+		t, testExitDestination, wallet.lastExit.GetOnchainAddress(),
 	)
-	require.Zero(
-		t, wallet.exitCalls,
-		"cooperative success must not invoke unilateral Exit",
-	)
+	require.Empty(t, wallet.lastExit.GetForceUnrollAck())
 }
 
-// TestExitCooperativeEmptyQueuedFallsThrough pins down the H-2 fix:
-// when the daemon returns nil error but an empty (or
-// outpoint-missing) QueuedOutpoints set, the SDK treats the
-// cooperative call as a failure and runs the full fallback
-// pipeline.
-func TestExitCooperativeEmptyQueuedFallsThrough(t *testing.T) {
+// TestExitForcedUnrollPassesAck confirms the SDK does not hide forced unroll:
+// the acknowledgement is forwarded and unilateral mode is projected.
+func TestExitForcedUnrollPassesAck(t *testing.T) {
 	t.Parallel()
 
-	daemon := &stubDaemonClient{
-		leaveVTXOs: func(_ context.Context,
-			_ *daemonrpc.LeaveVTXOsRequest) (
-			*daemonrpc.LeaveVTXOsResponse, error) {
-
-			// LeaveVTXOs surfaces per-outpoint wallet errors as
-			// log lines rather than as a top-level error,
-			// returning the partial QueuedOutpoints set. An
-			// empty list signals our outpoint was dropped.
-			return &daemonrpc.LeaveVTXOsResponse{
-				QueuedOutpoints: nil,
-				Status:          "queued",
-			}, nil
-		},
-		listVTXOs: func(_ context.Context,
-			_ *daemonrpc.ListVTXOsRequest) (
-			*daemonrpc.ListVTXOsResponse, error) {
-
-			return &daemonrpc.ListVTXOsResponse{}, nil
-		},
-	}
 	wallet := &stubWalletClient{
 		exit: func(_ context.Context, _ *walletdkrpc.ExitRequest) (
 			*walletdkrpc.ExitResponse, error) {
 
+			mode := walletdkrpc.ExitMode_EXIT_MODE_UNILATERAL
+
 			return &walletdkrpc.ExitResponse{
+				Mode:    mode,
 				Created: true,
 				ActorId: testActorID,
 			}, nil
 		},
 	}
-
-	client := newExitTestClient(daemon, wallet)
+	client := newExitTestClient(wallet)
 
 	res, err := client.Exit(t.Context(), ExitRequest{
-		Outpoint:    testExitOutpoint,
-		Destination: testExitDestination,
+		Outpoint:       testExitOutpoint,
+		ForceUnrollAck: testForceUnrollAck,
 	})
 	require.NoError(t, err)
-	require.Equal(t, ExitPathUnilateralFallback, res.Path)
+	require.Equal(t, ExitPathUnilateral, res.Path)
 	require.True(t, res.Created)
 	require.Equal(t, testActorID, res.ActorID)
-	require.Contains(
-		t, res.CooperativeError, errCooperativeEmptyQueued.Error(),
-		"H-2 empty-queued failure must carry the sentinel error",
+	require.Equal(
+		t, testForceUnrollAck, wallet.lastExit.GetForceUnrollAck(),
 	)
 }
 
-// TestExitCooperativeTerminalErrorNoFallback pins down the H-1 fix:
-// caller-class gRPC errors (InvalidArgument, FailedPrecondition,
-// NotFound, PermissionDenied) are returned verbatim instead of
-// silently rerouting funds via the unilateral fallback path.
-func TestExitCooperativeTerminalErrorNoFallback(t *testing.T) {
+// TestExitRejectsDestinationWithForcedUnroll mirrors the wallet RPC's
+// mutual-exclusion rule before spending a round trip.
+func TestExitRejectsDestinationWithForcedUnroll(t *testing.T) {
 	t.Parallel()
 
-	for _, code := range []codes.Code{
-		codes.InvalidArgument,
-		codes.FailedPrecondition,
-		codes.NotFound,
-		codes.PermissionDenied,
-		codes.Unauthenticated,
-	} {
-		t.Run(code.String(), func(t *testing.T) {
-			daemon := &stubDaemonClient{
-				leaveVTXOs: func(_ context.Context,
-					_ *daemonrpc.LeaveVTXOsRequest) (
-					*daemonrpc.LeaveVTXOsResponse, error) {
+	wallet := &stubWalletClient{
+		exit: func(context.Context, *walletdkrpc.ExitRequest) (
+			*walletdkrpc.ExitResponse, error) {
 
-					return nil, status.Error(
-						code, "synthetic",
-					)
-				},
-			}
-			wallet := &stubWalletClient{}
+			t.Fatal("wallet RPC must not be called")
 
-			client := newExitTestClient(daemon, wallet)
-
-			res, err := client.Exit(t.Context(), ExitRequest{
-				Outpoint:    testExitOutpoint,
-				Destination: testExitDestination,
-			})
-			require.Error(t, err)
-			require.Nil(t, res)
-			require.Equal(
-				t, code, status.Code(err),
-				"terminal codes must surface verbatim",
-			)
-			require.Zero(
-				t, wallet.exitCalls, "terminal cooperative "+
-					"error must NOT fall through to "+
-					"unilateral",
-			)
-			require.Zero(
-				t, daemon.listCalls, "terminal cooperative "+
-					"error must NOT probe ListVTXOs",
-			)
-		})
-	}
-}
-
-// TestExitCooperativeTransientErrorFallsBack covers the happy
-// fallback path: a transport-class gRPC error from LeaveVTXOs +
-// clean ListVTXOs probe → unilateral Unroll succeeds →
-// ExitPathUnilateralFallback with the cooperative error attached.
-func TestExitCooperativeTransientErrorFallsBack(t *testing.T) {
-	t.Parallel()
-
-	for _, code := range []codes.Code{
-		codes.Unavailable,
-		codes.DeadlineExceeded,
-		codes.Aborted,
-		codes.ResourceExhausted,
-	} {
-		t.Run(code.String(), func(t *testing.T) {
-			cooperativeErr := status.Error(code, "synthetic")
-			daemon := &stubDaemonClient{
-				leaveVTXOs: func(_ context.Context,
-					_ *daemonrpc.LeaveVTXOsRequest) (
-					*daemonrpc.LeaveVTXOsResponse, error) {
-
-					return nil, cooperativeErr
-				},
-				listVTXOs: func(_ context.Context,
-					_ *daemonrpc.ListVTXOsRequest) (
-					*daemonrpc.ListVTXOsResponse, error) {
-
-					empty := &daemonrpc.ListVTXOsResponse{}
-
-					return empty, nil
-				},
-			}
-			wallet := &stubWalletClient{
-				exit: func(_ context.Context,
-					_ *walletdkrpc.ExitRequest) (
-					*walletdkrpc.ExitResponse, error) {
-
-					return &walletdkrpc.ExitResponse{
-						Created: true,
-						ActorId: testActorID,
-					}, nil
-				},
-			}
-
-			client := newExitTestClient(daemon, wallet)
-
-			res, err := client.Exit(t.Context(), ExitRequest{
-				Outpoint:    testExitOutpoint,
-				Destination: testExitDestination,
-			})
-			require.NoError(t, err)
-			require.Equal(
-				t, ExitPathUnilateralFallback, res.Path,
-			)
-			require.True(t, res.Created)
-			require.Equal(
-				t, cooperativeErr.Error(), res.CooperativeError,
-			)
-			require.Equal(
-				t, 2, daemon.listCalls, "H-3 guard must "+
-					"probe both PendingForfeit and "+
-					"Forfeiting before falling back",
-			)
-		})
-	}
-}
-
-// TestExitListVTXOsGuardRefusesFallback pins down the H-3 fix: even
-// when the cooperative gRPC call returned a retryable error, if
-// ListVTXOs shows the outpoint already in PendingForfeit /
-// Forfeiting the SDK refuses to fall back rather than racing the
-// daemon's in-flight cooperative leave with an Unroll.
-func TestExitListVTXOsGuardRefusesFallback(t *testing.T) {
-	t.Parallel()
-
-	for _, st := range []daemonrpc.VTXOStatus{
-		daemonrpc.VTXOStatus_VTXO_STATUS_PENDING_FORFEIT,
-		daemonrpc.VTXOStatus_VTXO_STATUS_FORFEITING,
-	} {
-		t.Run(st.String(), func(t *testing.T) {
-			daemon := &stubDaemonClient{
-				leaveVTXOs: func(_ context.Context,
-					_ *daemonrpc.LeaveVTXOsRequest) (
-					*daemonrpc.LeaveVTXOsResponse, error) {
-
-					return nil, status.Error(
-						codes.Canceled,
-						"client gave up",
-					)
-				},
-				listVTXOs: listVTXOsHit(st, testExitOutpoint),
-			}
-			wallet := &stubWalletClient{}
-
-			client := newExitTestClient(daemon, wallet)
-
-			// We use t.Context() here even though LeaveVTXOs
-			// returned codes.Canceled: the synthetic error is
-			// not driven by an actually-cancelled ctx, so the
-			// M-6 short-circuit will not fire and the H-3
-			// guard's ListVTXOs probe runs to completion.
-			res, err := client.Exit(t.Context(), ExitRequest{
-				Outpoint:    testExitOutpoint,
-				Destination: testExitDestination,
-			})
-			require.Error(t, err)
-			require.Nil(t, res)
-			require.Contains(
-				t, err.Error(),
-				"daemon already admitted",
-			)
-			require.Zero(
-				t, wallet.exitCalls, "H-3 guard must NOT "+
-					"issue Unroll when the cooperative "+
-					"attempt is in flight",
-			)
-		})
-	}
-}
-
-// TestExitCtxCancelShortCircuits pins down the M-6 fix: if the
-// caller's ctx is already cancelled by the time the cooperative
-// attempt fails, the fallback is short-circuited rather than
-// wasting another RPC against an expired ctx.
-func TestExitCtxCancelShortCircuits(t *testing.T) {
-	t.Parallel()
-
-	daemon := &stubDaemonClient{
-		leaveVTXOs: func(_ context.Context,
-			_ *daemonrpc.LeaveVTXOsRequest) (
-			*daemonrpc.LeaveVTXOsResponse, error) {
-
-			return nil, status.Error(
-				codes.Canceled, "client gave up",
-			)
+			return nil, nil
 		},
 	}
-	wallet := &stubWalletClient{}
-
-	client := newExitTestClient(daemon, wallet)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	res, err := client.Exit(ctx, ExitRequest{
-		Outpoint:    testExitOutpoint,
-		Destination: testExitDestination,
-	})
-	require.Error(t, err)
-	require.Nil(t, res)
-	require.ErrorIs(t, err, context.Canceled)
-	require.Zero(
-		t, daemon.listCalls,
-		"ctx-cancelled short-circuit must not probe ListVTXOs",
-	)
-	require.Zero(
-		t, wallet.exitCalls,
-		"ctx-cancelled short-circuit must not call Unroll",
-	)
-}
-
-// TestExitListVTXOsLookupFailureSurfaces verifies that a ListVTXOs
-// probe failure is returned to the caller wrapped alongside the
-// cooperative error rather than silently choosing the fallback
-// path. This keeps the SDK from making a decision on stale state.
-func TestExitListVTXOsLookupFailureSurfaces(t *testing.T) {
-	t.Parallel()
-
-	probeErr := errors.New("backend offline")
-	daemon := &stubDaemonClient{
-		leaveVTXOs: func(_ context.Context,
-			_ *daemonrpc.LeaveVTXOsRequest) (
-			*daemonrpc.LeaveVTXOsResponse, error) {
-
-			return nil, status.Error(codes.Unavailable, "transport")
-		},
-		listVTXOs: func(_ context.Context,
-			_ *daemonrpc.ListVTXOsRequest) (
-			*daemonrpc.ListVTXOsResponse, error) {
-
-			return nil, probeErr
-		},
-	}
-	wallet := &stubWalletClient{}
-
-	client := newExitTestClient(daemon, wallet)
+	client := newExitTestClient(wallet)
 
 	res, err := client.Exit(t.Context(), ExitRequest{
-		Outpoint:    testExitOutpoint,
-		Destination: testExitDestination,
+		Outpoint:       testExitOutpoint,
+		Destination:    testExitDestination,
+		ForceUnrollAck: testForceUnrollAck,
 	})
-	require.Error(t, err)
+	require.ErrorContains(t, err, "destination cannot be combined")
 	require.Nil(t, res)
-	require.Contains(t, err.Error(), "admission probe failed")
-	require.Zero(
-		t, wallet.exitCalls, "probe failure must NOT proceed to Unroll",
-	)
+	require.Zero(t, wallet.exitCalls)
+}
+
+// TestExitSurfacesWalletRPCError verifies wallet RPC failures are returned
+// without client-side fallback.
+func TestExitSurfacesWalletRPCError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("wallet rpc failed")
+	wallet := &stubWalletClient{
+		exit: func(_ context.Context, _ *walletdkrpc.ExitRequest) (
+			*walletdkrpc.ExitResponse, error) {
+
+			return nil, sentinel
+		},
+	}
+	client := newExitTestClient(wallet)
+
+	res, err := client.Exit(t.Context(), ExitRequest{
+		Outpoint: testExitOutpoint,
+	})
+	require.ErrorIs(t, err, sentinel)
+	require.Nil(t, res)
+}
+
+// TestExitRejectsEmptyOutpoint confirms local validation still rejects an
+// unusable request before any RPC is attempted.
+func TestExitRejectsEmptyOutpoint(t *testing.T) {
+	t.Parallel()
+
+	wallet := &stubWalletClient{
+		exit: func(context.Context, *walletdkrpc.ExitRequest) (
+			*walletdkrpc.ExitResponse, error) {
+
+			t.Fatal("wallet RPC must not be called")
+
+			return nil, nil
+		},
+	}
+	client := newExitTestClient(wallet)
+
+	res, err := client.Exit(t.Context(), ExitRequest{})
+	require.ErrorContains(t, err, "outpoint is required")
+	require.Nil(t, res)
+	require.Zero(t, wallet.exitCalls)
 }

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -322,19 +322,23 @@ type OnchainTx struct {
 // ExitRequest triggers an exit for a VTXO outpoint. When Destination is
 // set, the SDK first attempts a cooperative leave (LeaveVTXOs RPC) with
 // the leave output bound for the supplied on-chain address; if that path
-// fails the SDK falls back to a unilateral unroll. When Destination is
-// empty, the SDK skips the cooperative attempt and goes straight to
-// unilateral unroll.
+// succeeds, the SDK returns a cooperative result. Unilateral unroll is
+// reachable only when ForceUnrollAck carries the daemon's exact
+// acknowledgement string.
 type ExitRequest struct {
 	// Outpoint identifies the VTXO to exit in "txid:index" format.
 	Outpoint string
 
 	// Destination is the on-chain address that receives the leave
 	// output when the cooperative path succeeds. The address must be
-	// valid for the daemon's configured network. Empty disables the
-	// cooperative attempt and falls straight through to unilateral
-	// unroll, which always lands on a wallet-derived script.
+	// valid for the daemon's configured network. Empty asks the daemon
+	// to generate a fresh backing-wallet destination internally.
 	Destination string
+
+	// ForceUnrollAck must be exactly "I_KNOW_WHAT_I_AM_DOING" to bypass
+	// cooperative leave and start unilateral unroll. Cannot be combined
+	// with Destination; the server rejects the pair with InvalidArgument.
+	ForceUnrollAck string
 }
 
 // ExitPath identifies which branch of the Exit decision tree the
@@ -349,15 +353,15 @@ const (
 	// via walletdkrpc.SubscribeWallet to confirm terminal state.
 	ExitPathCooperative ExitPath = "cooperative"
 
-	// ExitPathUnilateral means the caller did not supply a Destination
-	// so the SDK skipped the cooperative attempt entirely. Created
+	// ExitPathUnilateral means the caller supplied the exact force
+	// acknowledgement and the daemon started unilateral unroll. Created
 	// and ActorID describe the unilateral unroll job.
 	ExitPathUnilateral ExitPath = "unilateral"
 
-	// ExitPathUnilateralFallback means the cooperative attempt failed
-	// and the SDK fell back to unilateral unroll. CooperativeError
-	// carries the original failure; Created and ActorID describe the
-	// fallback job.
+	// ExitPathUnilateralFallback is retained for source compatibility
+	// with the prior SDK result shape. New forced unrolls return
+	// ExitPathUnilateral; current wallet RPC behavior never returns this
+	// path because cooperative failures are surfaced directly.
 	ExitPathUnilateralFallback ExitPath = "unilateral_fallback"
 )
 
@@ -389,12 +393,10 @@ type ExitResult struct {
 	// ExitPathUnilateralFallback.
 	ActorID string
 
-	// CooperativeError holds the rendered error string returned by
-	// the cooperative attempt when the SDK fell back to unilateral.
-	// A string (rather than the error interface) keeps the field
-	// stable across gomobile / React Native / WASM bridges, which
-	// cannot marshal an opaque interface value. Populated only when
-	// Path == ExitPathUnilateralFallback; empty otherwise.
+	// CooperativeError is retained for source compatibility with the
+	// prior SDK fallback result shape. Current wallet RPC behavior never
+	// populates it because cooperative failures are returned directly
+	// instead of falling back to unilateral unroll.
 	CooperativeError string
 }
 

--- a/swapwallet/admin.go
+++ b/swapwallet/admin.go
@@ -4,12 +4,19 @@ package swapwallet
 
 import (
 	"context"
+	"strings"
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+const forceUnrollAck = "I_KNOW_WHAT_I_AM_DOING"
+
+// walletUnspentMaxConfs is intentionally high enough to behave as unbounded
+// for a local wallet UTXO fee-input preflight.
+const walletUnspentMaxConfs int32 = 9999999
 
 // create is the implementation of WalletService.Create. It proxies the
 // daemonrpc admin surface: if the caller supplied a mnemonic, we treat the
@@ -103,9 +110,8 @@ func (s *Service) unlock(ctx context.Context, req *walletdkrpc.UnlockRequest) (
 	}, nil
 }
 
-// exit proxies daemonrpc.Unroll. The daemon's unroll registry remains the
-// authoritative store; the wallet layer tracks only the friendly pending row
-// so activity can show the user's exit attempt immediately.
+// exit queues cooperative leave by default. Forced unilateral unroll is gated
+// by an exact acknowledgement string and a local backing-wallet UTXO preflight.
 func (s *Service) exit(ctx context.Context, req *walletdkrpc.ExitRequest) (
 	*walletdkrpc.ExitResponse, error) {
 
@@ -119,6 +125,84 @@ func (s *Service) exit(ctx context.Context, req *walletdkrpc.ExitRequest) (
 		return nil, status.Error(
 			codes.InvalidArgument, "outpoint is required",
 		)
+	}
+
+	ack := strings.TrimSpace(req.GetForceUnrollAck())
+	if ack != "" {
+		return s.forceUnroll(ctx, req, ack)
+	}
+
+	return s.cooperativeExit(ctx, req)
+}
+
+// cooperativeExit routes wallet-facing Exit through LeaveVTXOs. If the caller
+// did not supply a destination, the daemon generates a fresh backing-wallet
+// address so the default path stays cooperative without asking the user for
+// an on-chain address.
+func (s *Service) cooperativeExit(ctx context.Context,
+	req *walletdkrpc.ExitRequest) (*walletdkrpc.ExitResponse, error) {
+
+	destination := strings.TrimSpace(req.GetOnchainAddress())
+	if destination == "" {
+		addr, err := s.deps.RPCServer.NewWalletAddress(ctx)
+		if err != nil {
+			return nil, status.Errorf(status.Code(err), "new "+
+				"wallet address: %v", err)
+		}
+		destination = addr
+	}
+
+	resp, err := s.deps.RPCServer.LeaveVTXOs(
+		ctx, &daemonrpc.LeaveVTXOsRequest{
+			Selection: &daemonrpc.LeaveVTXOsRequest_Outpoints{
+				Outpoints: &daemonrpc.OutpointSelection{
+					Outpoints: []string{
+						req.GetOutpoint(),
+					},
+				},
+			},
+			DefaultDestination: &daemonrpc.LeaveDestination{
+				Target: &daemonrpc.LeaveDestination_Address{
+					Address: destination,
+				},
+			},
+		},
+	)
+	if err != nil {
+		return nil, status.Errorf(status.Code(err), "exit: %v", err)
+	}
+
+	queued := resp.GetQueuedOutpoints()
+	if !outpointQueued(req.GetOutpoint(), queued) {
+		return nil, status.Errorf(codes.Internal, "exit: cooperative "+
+			"leave did not echo outpoint %s", req.GetOutpoint())
+	}
+
+	return &walletdkrpc.ExitResponse{
+		Mode:            walletdkrpc.ExitMode_EXIT_MODE_COOPERATIVE,
+		QueuedOutpoints: queued,
+		OnchainAddress:  destination,
+	}, nil
+}
+
+// forceUnroll runs the legacy unilateral path only after the caller opts in
+// with the exact acknowledgement string and the local backing wallet has at
+// least one confirmed UTXO available for sweep fees.
+func (s *Service) forceUnroll(ctx context.Context, req *walletdkrpc.ExitRequest,
+	ack string) (*walletdkrpc.ExitResponse, error) {
+
+	if req.GetOnchainAddress() != "" {
+		return nil, status.Error(
+			codes.InvalidArgument,
+			"onchain_address cannot be set with force_unroll_ack",
+		)
+	}
+	if ack != forceUnrollAck {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"force_unroll_ack must be exactly %q", forceUnrollAck)
+	}
+	if err := s.requireLocalUnrollBalance(ctx); err != nil {
+		return nil, err
 	}
 
 	resp, err := s.deps.RPCServer.Unroll(
@@ -137,7 +221,41 @@ func (s *Service) exit(ctx context.Context, req *walletdkrpc.ExitRequest) (
 	return &walletdkrpc.ExitResponse{
 		Created: resp.GetCreated(),
 		ActorId: resp.GetActorId(),
+		Mode:    walletdkrpc.ExitMode_EXIT_MODE_UNILATERAL,
 	}, nil
+}
+
+// requireLocalUnrollBalance checks that the local backing wallet has at least
+// one confirmed UTXO before unilateral unroll starts. The lower-level unroll
+// path still owns target-specific recovery validation; this wallet-facing gate
+// rejects the obvious no-fee-input case before entering the emergency path.
+func (s *Service) requireLocalUnrollBalance(ctx context.Context) error {
+	utxos, err := s.deps.RPCServer.ListWalletUnspent(
+		ctx, 1, walletUnspentMaxConfs,
+	)
+	if err != nil {
+		return status.Errorf(status.Code(err), "list wallet "+
+			"unspent: %v", err)
+	}
+	if len(utxos) > 0 {
+		return nil
+	}
+
+	return status.Errorf(codes.FailedPrecondition, "no confirmed local "+
+		"wallet UTXOs available for forced unroll")
+}
+
+// outpointQueued reports whether the daemon echoed target in a cooperative
+// leave response. A missing echo means the daemon accepted the RPC but did not
+// admit this outpoint into the round.
+func outpointQueued(target string, queued []string) bool {
+	for _, outpoint := range queued {
+		if outpoint == target {
+			return true
+		}
+	}
+
+	return false
 }
 
 // exitStatus proxies daemonrpc.GetUnrollStatus and projects the daemon's

--- a/swapwallet/admin_test.go
+++ b/swapwallet/admin_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"github.com/lightninglabs/darepo-client/wallet"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -150,24 +151,109 @@ func TestUnlockRejectsEmptyPassword(t *testing.T) {
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
-// TestExitProxiesUnroll confirms Exit plumbs the outpoint and surfaces
-// the created flag plus actor id.
-func TestExitProxiesUnroll(t *testing.T) {
+// TestExitDefaultsToCooperativeLeave confirms Exit queues LeaveVTXOs by
+// default and generates a fresh backing-wallet destination when omitted.
+func TestExitDefaultsToCooperativeLeave(t *testing.T) {
 	t.Parallel()
 
 	svc, rpc := newAdminFixture(t)
-	rpc.unrollResp = &daemonrpc.UnrollResponse{
-		Created: true,
-		ActorId: "exit-job-42",
+	rpc.newWalletAddressResp = "bcrt1qwallet"
+	rpc.leaveResp = &daemonrpc.LeaveVTXOsResponse{
+		QueuedOutpoints: []string{
+			"abc:0",
+		},
 	}
 
 	resp, err := svc.Exit(t.Context(), &walletdkrpc.ExitRequest{
 		Outpoint: "abc:0",
 	})
 	require.NoError(t, err)
+	require.Equal(
+		t, walletdkrpc.ExitMode_EXIT_MODE_COOPERATIVE, resp.GetMode(),
+	)
+	require.Equal(t, []string{"abc:0"}, resp.GetQueuedOutpoints())
+	require.Equal(t, "bcrt1qwallet", resp.GetOnchainAddress())
+	require.Equal(t, 1, rpc.leaveCalls)
+	require.Equal(t, 0, rpc.unrollCalls)
+
+	sel := rpc.leaveLastReq.GetOutpoints()
+	require.NotNil(t, sel)
+	require.Equal(t, []string{"abc:0"}, sel.GetOutpoints())
+	dest := rpc.leaveLastReq.GetDefaultDestination().GetAddress()
+	require.Equal(t, "bcrt1qwallet", dest)
+}
+
+// TestExitUsesProvidedCooperativeDestination confirms callers can provide the
+// cooperative leave destination explicitly.
+func TestExitUsesProvidedCooperativeDestination(t *testing.T) {
+	t.Parallel()
+
+	svc, rpc := newAdminFixture(t)
+	rpc.leaveResp = &daemonrpc.LeaveVTXOsResponse{
+		QueuedOutpoints: []string{
+			"abc:0",
+		},
+	}
+
+	resp, err := svc.Exit(t.Context(), &walletdkrpc.ExitRequest{
+		Outpoint:       "abc:0",
+		OnchainAddress: "bcrt1qexternal",
+	})
+	require.NoError(t, err)
+	require.Equal(
+		t, walletdkrpc.ExitMode_EXIT_MODE_COOPERATIVE, resp.GetMode(),
+	)
+	require.Equal(t, "bcrt1qexternal", resp.GetOnchainAddress())
+	require.Empty(t, rpc.newWalletAddressResp)
+
+	dest := rpc.leaveLastReq.GetDefaultDestination().GetAddress()
+	require.Equal(t, "bcrt1qexternal", dest)
+}
+
+// TestExitCooperativeRequiresQueuedOutpoint prevents a false cooperative
+// success when LeaveVTXOs returns nil error but drops the requested outpoint.
+func TestExitCooperativeRequiresQueuedOutpoint(t *testing.T) {
+	t.Parallel()
+
+	svc, rpc := newAdminFixture(t)
+	rpc.leaveResp = &daemonrpc.LeaveVTXOsResponse{
+		QueuedOutpoints: []string{
+			"other:0",
+		},
+	}
+
+	_, err := svc.Exit(t.Context(), &walletdkrpc.ExitRequest{
+		Outpoint:       "abc:0",
+		OnchainAddress: "bcrt1qexternal",
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
+}
+
+// TestExitForcedUnrollProxiesUnroll confirms the forced branch plumbs the
+// outpoint and surfaces the created flag plus actor id.
+func TestExitForcedUnrollProxiesUnroll(t *testing.T) {
+	t.Parallel()
+
+	svc, rpc := newAdminFixture(t)
+	rpc.listWalletUnspent = []*wallet.Utxo{{}}
+	rpc.unrollResp = &daemonrpc.UnrollResponse{
+		Created: true,
+		ActorId: "exit-job-42",
+	}
+
+	resp, err := svc.Exit(t.Context(), &walletdkrpc.ExitRequest{
+		Outpoint:       "abc:0",
+		ForceUnrollAck: forceUnrollAck,
+	})
+	require.NoError(t, err)
+	require.Equal(
+		t, walletdkrpc.ExitMode_EXIT_MODE_UNILATERAL, resp.GetMode(),
+	)
 	require.True(t, resp.GetCreated())
 	require.Equal(t, "exit-job-42", resp.GetActorId())
 	require.Equal(t, "abc:0", rpc.unrollLast.GetOutpoint())
+	require.Equal(t, 0, rpc.leaveCalls)
 
 	entries := svc.runtime.pendingSnapshot()
 	require.Len(t, entries, 1)
@@ -179,6 +265,53 @@ func TestExitProxiesUnroll(t *testing.T) {
 		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
 		entries[0].GetStatus(),
 	)
+}
+
+// TestExitForcedUnrollRequiresAck verifies a partial acknowledgement does not
+// start unroll.
+func TestExitForcedUnrollRequiresAck(t *testing.T) {
+	t.Parallel()
+
+	svc, rpc := newAdminFixture(t)
+	_, err := svc.Exit(t.Context(), &walletdkrpc.ExitRequest{
+		Outpoint:       "abc:0",
+		ForceUnrollAck: "sure",
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Equal(t, 0, rpc.unrollCalls)
+	require.Equal(t, 0, rpc.leaveCalls)
+}
+
+// TestExitForcedUnrollRejectsDestination verifies the force branch cannot
+// silently ignore a cooperative destination.
+func TestExitForcedUnrollRejectsDestination(t *testing.T) {
+	t.Parallel()
+
+	svc, rpc := newAdminFixture(t)
+	_, err := svc.Exit(t.Context(), &walletdkrpc.ExitRequest{
+		Outpoint:       "abc:0",
+		OnchainAddress: "bcrt1qexternal",
+		ForceUnrollAck: forceUnrollAck,
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Equal(t, 0, rpc.unrollCalls)
+}
+
+// TestExitForcedUnrollRequiresLocalUTXO verifies unilateral unroll is refused
+// unless the target outpoint is in the local backing-wallet UTXO set.
+func TestExitForcedUnrollRequiresLocalUTXO(t *testing.T) {
+	t.Parallel()
+
+	svc, rpc := newAdminFixture(t)
+	_, err := svc.Exit(t.Context(), &walletdkrpc.ExitRequest{
+		Outpoint:       "abc:0",
+		ForceUnrollAck: forceUnrollAck,
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.Equal(t, 0, rpc.unrollCalls)
 }
 
 // TestExitRejectsEmptyOutpoint confirms a missing outpoint is rejected
@@ -283,7 +416,8 @@ func TestAdminHandlersSurfaceDaemonErrors(t *testing.T) {
 	})
 	require.ErrorContains(t, err, sentinel.Error())
 
-	rpc.unrollErr = sentinel
+	rpc.newWalletAddressResp = "bcrt1qwallet"
+	rpc.leaveErr = sentinel
 	_, err = svc.Exit(t.Context(), &walletdkrpc.ExitRequest{
 		Outpoint: "abc:0",
 	})
@@ -322,8 +456,9 @@ func TestAdminHandlersPreserveGRPCCode(t *testing.T) {
 	})
 	require.Equal(t, codes.PermissionDenied, status.Code(err))
 
-	rpc.unrollErr = status.Error(
-		codes.FailedPrecondition, "not unlocked",
+	rpc.newWalletAddressResp = "bcrt1qwallet"
+	rpc.leaveErr = status.Error(
+		codes.FailedPrecondition, "not enough funds",
 	)
 	_, err = svc.Exit(t.Context(), &walletdkrpc.ExitRequest{
 		Outpoint: "abc:0",

--- a/swapwallet/deps.go
+++ b/swapwallet/deps.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/darepod"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
+	"github.com/lightninglabs/darepo-client/wallet"
 )
 
 // RPCServer is the narrow contract swapwallet composes against from the
@@ -57,6 +58,11 @@ type RPCServer interface {
 	NewAddress(ctx context.Context,
 		req *daemonrpc.NewAddressRequest) (
 		*daemonrpc.NewAddressResponse, error)
+
+	NewWalletAddress(ctx context.Context) (string, error)
+
+	ListWalletUnspent(ctx context.Context, minConfs,
+		maxConfs int32) ([]*wallet.Utxo, error)
 
 	GenSeed(ctx context.Context,
 		req *daemonrpc.GenSeedRequest) (

--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
+	"github.com/lightninglabs/darepo-client/wallet"
 )
 
 // fakeRPCServer is a hand-written implementation of swapwallet.RPCServer
@@ -36,6 +37,11 @@ type fakeRPCServer struct {
 	getBalanceErr    error
 	newAddressResp   *daemonrpc.NewAddressResponse
 	newAddressErr    error
+
+	newWalletAddressResp string
+	newWalletAddressErr  error
+	listWalletUnspent    []*wallet.Utxo
+	listWalletUnspentErr error
 
 	genSeedResp     *daemonrpc.GenSeedResponse
 	genSeedErr      error
@@ -125,6 +131,16 @@ func (f *fakeRPCServer) NewAddress(_ context.Context,
 	_ *daemonrpc.NewAddressRequest) (*daemonrpc.NewAddressResponse, error) {
 
 	return f.newAddressResp, f.newAddressErr
+}
+
+func (f *fakeRPCServer) NewWalletAddress(_ context.Context) (string, error) {
+	return f.newWalletAddressResp, f.newWalletAddressErr
+}
+
+func (f *fakeRPCServer) ListWalletUnspent(_ context.Context, _ int32, _ int32) (
+	[]*wallet.Utxo, error) {
+
+	return f.listWalletUnspent, f.listWalletUnspentErr
 }
 
 func (f *fakeRPCServer) GenSeed(_ context.Context,

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -75,9 +75,8 @@ func (s *Service) Send(ctx context.Context, req *walletdkrpc.SendRequest) (
 	return s.router.Send(ctx, req)
 }
 
-// Exit triggers a unilateral exit (unroll) for the specified VTXO
-// outpoint by proxying daemonrpc.Unroll. The wallet layer does not track
-// the exit job locally.
+// Exit queues cooperative leave by default, or starts forced unroll when the
+// request carries the exact acknowledgement string.
 func (s *Service) Exit(ctx context.Context, req *walletdkrpc.ExitRequest) (
 	*walletdkrpc.ExitResponse, error) {
 


### PR DESCRIPTION
Fixes #465

## Summary
- make wallet-facing Exit queue cooperative LeaveVTXOs by default
- add onchain_address, force_unroll_ack, mode, and queued_outpoints to walletrpc Exit
- require I_KNOW_WHAT_I_AM_DOING plus confirmed local wallet UTXOs before forced unroll
- update darepocli, MCP, and walletdk behavior/tests for the new policy

## Test Plan
- make unit pkg=./swapwallet tags="walletrpc swapruntime" timeout=5m
- make unit pkg=./cmd/darepocli/darepoclicommands tags="walletrpc swapruntime" timeout=5m
- make unit pkg=./sdk/walletdk tags="walletrpc swapruntime" timeout=5m
- make lint-changed-local base=bb2a982dcb5c73602196b42b31a5e143a1d0bb85
- make build tags="walletrpc swapruntime"
- make commitmsg-lint commit=HEAD

Note: Docker-backed make rpc could not run because Docker is unavailable locally; protos were regenerated with the repo script using local protoc and generated version comments were normalized back to the Docker protoc version.