### PR TITLE
oor: Widen Eventually budget for durable signing chain tests

### DIFF
--- a/oor/actor_resume_test.go
+++ b/oor/actor_resume_test.go
@@ -774,7 +774,7 @@ func TestOORClientActorResumeAfterServerCoSignedFromStore(t *testing.T) {
 		_, ok = finalStateMsg.State.(*Completed)
 
 		return ok
-	}, 5*time.Second, 50*time.Millisecond)
+	}, signingChainEventuallyTimeout, 50*time.Millisecond)
 }
 
 // TestOORClientActorResumeFromSnapshotSubmitSent verifies the client can resume
@@ -1146,7 +1146,7 @@ func TestOORClientActorDurableRestartWithRetryMetadata(t *testing.T) {
 		})
 
 		return resp.IsOk()
-	}, 5*time.Second, 50*time.Millisecond)
+	}, signingChainEventuallyTimeout, 50*time.Millisecond)
 
 	// The restarted actor should have emitted ScheduleRetryRequest
 	// (not SendSubmitPackageRequest) because the checkpoint had
@@ -1354,7 +1354,7 @@ func TestOORClientActorDurableRestartAutoResume(t *testing.T) {
 		default:
 			return false
 		}
-	}, 5*time.Second, 50*time.Millisecond)
+	}, signingChainEventuallyTimeout, 50*time.Millisecond)
 }
 
 // TestOORClientActorDurableRestartRetriesMarkInputsSpent asserts that a
@@ -1503,7 +1503,7 @@ func TestOORClientActorDurableRestartRetriesMarkInputsSpent(t *testing.T) {
 		_, awaitingLocalUpdate := got.State.(*AwaitingLocalVTXOUpdate)
 
 		return awaitingLocalUpdate
-	}, 5*time.Second, 50*time.Millisecond)
+	}, signingChainEventuallyTimeout, 50*time.Millisecond)
 
 	require.True(
 		t, handler2.sawScheduleRetry.Load(),
@@ -1540,7 +1540,7 @@ func TestOORClientActorDurableRestartRetriesMarkInputsSpent(t *testing.T) {
 		_, completed := got.State.(*Completed)
 
 		return completed
-	}, 5*time.Second, 50*time.Millisecond)
+	}, signingChainEventuallyTimeout, 50*time.Millisecond)
 
 	require.EqualValues(t, 2, completeSpendAttempts.Load())
 }

--- a/oor/actor_test.go
+++ b/oor/actor_test.go
@@ -24,6 +24,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// signingChainEventuallyTimeout bounds how long a test waits for the
+// asynchronous signing chain (StartTransfer -> durable signing-effect outbox ->
+// OutboxPublisher delivery -> SigningEffectActor signs -> ArkSignedEvent driven
+// back -> SubmitPackage emitted) to complete. Every hop commits a separate
+// durable SQLite transaction, each fsync'd (synchronous=full, fullfsync=true),
+// so the critical path is a sequence of disk syncs plus ECDSA/Schnorr signing.
+// Idle the chain finishes in well under a second, but under the race detector
+// on a loaded, slow CI runner it is ~10x slower and was overrunning the
+// previous 5s budget, surfacing as a spurious "Condition never satisfied"
+// flake. 30s matches the DB busy_timeout rationale (multi-actor contention
+// "can comfortably exceed 5s") and gives generous headroom without masking a
+// genuine hang — a real stall still fails the test, just later.
+const signingChainEventuallyTimeout = 30 * time.Second
+
 // testOutboxHandler is a minimal in-process outbox handler for client actor
 // tests. It simulates a server and wallet by returning follow-up events that
 // drive the FSM forward.
@@ -536,7 +550,7 @@ func TestOORClientActorStartTransferIdempotencyKeySurvivesRestart(
 		})
 
 		return resp.IsOk()
-	}, 5*time.Second, 50*time.Millisecond)
+	}, signingChainEventuallyTimeout, 50*time.Millisecond)
 
 	serverConn.mu.Lock()
 	messagesBeforeRetry := len(serverConn.messages)
@@ -1799,7 +1813,7 @@ func TestOORClientActorSigningViaEffectActor(t *testing.T) {
 
 		return req.Service == oorpb.ServiceName &&
 			req.Method == oorpb.MethodSubmitPackage
-	}, 5*time.Second, 10*time.Millisecond)
+	}, signingChainEventuallyTimeout, 10*time.Millisecond)
 }
 
 // TestIsTransportEventClassification verifies that isTransportEvent correctly


### PR DESCRIPTION
### Problem

`TestOORClientActorSigningViaEffectActor` flakes on the `make unit-race` CI step with:

```
actor_test.go:1786: Condition never satisfied
```

The assertion waits (5s budget) for an asynchronous chain to reach `SubmitPackage`:

```
StartTransfer -> durable signing-effect outbox write -> OutboxPublisher delivery
-> SigningEffectActor signs -> ArkSignedEvent driven back -> SubmitPackage emitted
```

Every hop commits its own durable SQLite transaction, each fsync'd (`synchronous=full`, `fullfsync=true`), so the critical path is a sequence of disk syncs plus ECDSA/Schnorr signing.

### Root cause

This is a too-tight timeout, **not** a logic bug. Idle the chain completes in ~0.37s. Under the race detector on a loaded, slow CI runner it is ~10x slower and overruns 5s — the observed CI failure took 22s total, i.e. the chain blew past the budget.

Instrumented stress runs (race detector, `GOMAXPROCS=1`, load avg ~280, many concurrent processes) reproduced the time scaling: the chain still completed in **0.5–1.9s with zero nack/backoff or poll-fallback events** — confirming the work is correct, just slow under contention.

### Fix

Replace the per-call 5s timeouts with a documented `signingChainEventuallyTimeout` constant (30s, matching the existing DB `busy_timeout` rationale that multi-actor contention "can comfortably exceed 5s"). A larger `Eventually` budget is purely protective: it returns the instant the condition holds, so fast runs are unaffected, and a genuine hang still fails the test, just later. The same constant is applied to the resume/restart assertions in `actor_resume_test.go`, which exercise the same durable-actor chain and share the flake risk.

### Testing

- `go vet ./oor/` — clean
- `make lint-changed-local` — 0 issues
- Affected tests pass under `-race` on latest `main`
