### PR TITLE
darepod: Gate unilateral exit on economic feasibility

### DIFF
--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -3349,23 +3349,15 @@ func (r *RPCServer) Unroll(ctx context.Context, req *daemonrpc.UnrollRequest) (
 		}
 	}
 
-	// Pre-flight the wallet's CPFP fee budget against the VTXO's
-	// ancestry shape. Each independent ancestry path (cross-
-	// commitment multi-input OOR VTXOs may have several; a round-
-	// direct VTXO has exactly one) corresponds to a distinct CPFP
-	// parent that the unroll needs to fee-bump on chain. TRUC RBF
-	// lets a single parent reuse its own fee input across bumps,
-	// but distinct parents each require their own confirmed wallet
-	// UTXO at child-construction time. If the wallet has fewer
-	// usable UTXOs than ancestry paths, the unroll will admit, the
-	// VTXO actor will transition to UnilateralExitState, but the
-	// chain layer will then thrash forever on
-	// `cpfp fee input unavailable: no confirmed wallet UTXOs
-	// available`. That leaves the VTXO in an exit state the user
-	// can't easily back out of. Fail closed here instead: refuse
-	// admission with InvalidArgument so the caller can fund the
-	// wallet and retry without contaminating state.
-	if err := r.preflightUnrollFeeInputs(
+	// Pre-flight the whole-picture feasibility of the exit before
+	// committing the VTXO to UnilateralExitState. This refuses an exit
+	// that can never succeed (the swept output would be dust and the
+	// sweep tx unrelayable — darepo-client #608), that is economically
+	// irrational (it burns more in fees than the coin is worth), or
+	// that the wallet cannot fund (insufficient balance or too few
+	// distinct CPFP fee inputs). Failing closed here keeps the VTXO out
+	// of an exit state the user can't easily back out of.
+	if err := r.preflightUnrollFeasibility(
 		admissionCtx, desc,
 	); err != nil {
 		return nil, err
@@ -3402,47 +3394,57 @@ func (r *RPCServer) Unroll(ctx context.Context, req *daemonrpc.UnrollRequest) (
 	}, nil
 }
 
-// preflightUnrollMinUTXOSat is the soft floor used by the unroll fee-
-// input pre-check. Confirmed wallet UTXOs below this threshold are
-// counted as unavailable because they're too small to plausibly cover
-// a v3/TRUC CPFP child fee. The exact required amount is determined
-// per-package at broadcast time in `txconfirm.CPFPBroadcaster`; this
-// constant is intentionally conservative so the pre-check rejects
-// only obviously-dust wallets, not borderline cases the run-time
-// fee bumper might still handle. Empirical floor observed during
-// itest (BUGS_FOUND.md bug-8): ~32k sat per package.
+// preflightUnrollMinUTXOSat is the soft floor that decides which
+// confirmed wallet UTXOs count as a "usable" CPFP fee input in the
+// unroll feasibility pre-flight. UTXOs below this threshold are too small
+// to plausibly cover a v3/TRUC CPFP child fee on their own, so they don't
+// count toward the one-input-per-ancestry-path requirement. The exact
+// required amount is determined per-package at broadcast time in
+// `txconfirm.CPFPBroadcaster`; this floor is intentionally conservative
+// so the pre-check rejects only obviously-dust wallets, not borderline
+// cases the run-time fee bumper might still handle. Empirical floor
+// observed during itest (BUGS_FOUND.md bug-8): ~32k sat per package.
 const preflightUnrollMinUTXOSat = btcutil.Amount(10_000)
 
-// preflightUnrollFeeInputs checks that the wallet has enough confirmed
-// UTXOs to cover the CPFP fee inputs the unroll will need. Returns a
-// codes.FailedPrecondition gRPC error with an actionable message when
-// the wallet is short. Returns nil (allow admission) when the
-// descriptor is unavailable, since we can't compute the required
-// count without it.
-func (r *RPCServer) preflightUnrollFeeInputs(ctx context.Context,
+const (
+	// unrollFeeConfTarget is the confirmation target used to estimate
+	// the fee rate for the unroll feasibility pre-flight. Six blocks
+	// matches the sweep estimator so the pre-check and the sweep the
+	// unroll actor later builds agree on the rate.
+	unrollFeeConfTarget = 6
+
+	// unrollFallbackFeeRateSatPerVByte is used when fee estimation is
+	// temporarily unavailable (cold backend, regtest) so the pre-flight
+	// can still produce a plausible estimate rather than blocking. Two
+	// sat/vB matches the sweep estimator's fallback.
+	unrollFallbackFeeRateSatPerVByte = btcutil.Amount(2)
+
+	// unrollMaxFeeRateSatPerVByte clamps a pathological fee estimate so
+	// a transient spike can't make every exit look uneconomical. Matches
+	// the sweep estimator's clamp.
+	unrollMaxFeeRateSatPerVByte = btcutil.Amount(100)
+)
+
+// preflightUnrollFeasibility assesses the whole-picture feasibility of a
+// unilateral exit before admission and returns a gRPC error when it is
+// infeasible. It gathers the recovery-transaction count from the VTXO
+// descriptor, the current fee rate from the chain backend, and the
+// wallet's confirmed UTXO set, then defers the verdict to the pure
+// unroll.AssessExitFeasibility model. Returns nil (allow admission) when
+// the descriptor is unavailable, since we can't assess without it and the
+// downstream admission path will surface its own error.
+func (r *RPCServer) preflightUnrollFeasibility(ctx context.Context,
 	desc *vtxo.Descriptor) error {
 
 	if desc == nil {
 
 		// The descriptor lookup failed earlier — let the existing
-		// admission path produce its own error rather than guess
-		// at the required count here.
+		// admission path produce its own error rather than guess at
+		// the feasibility here.
 		return nil
 	}
 
-	// Number of independent CPFP packages the unroll will produce
-	// is the count of ancestry paths: each path is a chain of
-	// commitment txs rooted at a distinct on-chain batch tx, and
-	// the chain layer needs one confirmed wallet UTXO per chain
-	// to fund the v3 child.
-	required := len(desc.Ancestry)
-	if required == 0 {
-
-		// A descriptor with no ancestry path is malformed in
-		// production but should not block admission — defer to
-		// the chain layer's own error handling.
-		return nil
-	}
+	numTxs, numPaths := unroll.RecoveryTxCount(desc)
 
 	utxos, err := r.server.ListWalletUnspent(ctx, 1, 9999999)
 	if err != nil {
@@ -3450,23 +3452,104 @@ func (r *RPCServer) preflightUnrollFeeInputs(ctx context.Context,
 			"unspent: %v", err)
 	}
 
+	// Derive both wallet inputs the model needs from a single snapshot:
+	// the total confirmed balance (can it fund the CPFP fees at all?)
+	// and the count of UTXOs large enough to each fund a CPFP child (are
+	// there enough distinct fee inputs for the concurrent packages?).
+	var confirmed btcutil.Amount
 	usable := 0
 	for _, utxo := range utxos {
+		confirmed += utxo.Amount
 		if utxo.Amount >= preflightUnrollMinUTXOSat {
 			usable++
 		}
 	}
 
-	if usable >= required {
+	verdict := unroll.AssessExitFeasibility(unroll.ExitFeasibilityInput{
+		NumRecoveryTxs:     numTxs,
+		NumAncestryPaths:   numPaths,
+		VTXOAmountSat:      desc.Amount,
+		FeeRateSatPerVByte: r.estimateUnrollFeeRate(ctx),
+		WalletConfirmedSat: confirmed,
+		WalletUsableInputs: usable,
+	})
+	if verdict.Feasible {
 		return nil
 	}
 
-	return status.Errorf(codes.FailedPrecondition, "insufficient wallet "+
-		"UTXOs to fund unroll CPFP: need at least %d confirmed wallet "+
-		"UTXO(s) of >= %d sat each (one per ancestry path), have %d "+
-		"usable. Fund the wallet's onchain address with more inputs "+
-		"and retry.", required, int64(preflightUnrollMinUTXOSat),
-		usable)
+	return unrollInfeasibleError(verdict)
+}
+
+// estimateUnrollFeeRate returns the current fee rate (sat/vByte) for the
+// unroll feasibility estimate, clamped to a sane range. It falls back to
+// a small fixed rate when the chain backend is missing or estimation
+// fails, so a cold backend never blocks an otherwise-viable exit.
+func (r *RPCServer) estimateUnrollFeeRate(ctx context.Context) btcutil.Amount {
+	if r.server.chainBackend == nil {
+		return unrollFallbackFeeRateSatPerVByte
+	}
+
+	feeRate, err := r.server.chainBackend.EstimateFee(
+		ctx, unrollFeeConfTarget,
+	)
+	if err != nil || feeRate <= 0 {
+		return unrollFallbackFeeRateSatPerVByte
+	}
+
+	if feeRate > unrollMaxFeeRateSatPerVByte {
+		return unrollMaxFeeRateSatPerVByte
+	}
+
+	return feeRate
+}
+
+// unrollInfeasibleError maps an infeasible exit verdict to an actionable
+// gRPC error. Every case is codes.FailedPrecondition: the request is
+// well-formed but the current VTXO/wallet/fee state forbids it. The
+// messages name the concrete numbers (cost, value, dust floor) so the
+// caller can act without re-deriving them, and point at cooperative leave
+// where unilateral exit is not the right tool.
+func unrollInfeasibleError(f unroll.ExitFeasibility) error {
+	switch f.Reason {
+	case unroll.ExitSweepBelowDust:
+		return status.Errorf(codes.FailedPrecondition, "unilateral "+
+			"exit not viable: VTXO is worth %d sat but after the "+
+			"~%d sat sweep fee (at %d sat/vB) only %d sat would "+
+			"remain, below the %d sat dust limit, so the exit "+
+			"transaction cannot be broadcast. Use a cooperative "+
+			"leave instead.", int64(f.VTXOAmountSat),
+			int64(f.SweepFeeSat), int64(f.FeeRateSatPerVByte),
+			int64(f.NetRecoveredSat), int64(f.DustLimitSat))
+
+	case unroll.ExitUneconomical:
+		return status.Errorf(codes.FailedPrecondition, "unilateral "+
+			"exit uneconomical: recovering this VTXO requires "+
+			"broadcasting %d transaction(s) costing ~%d sat in "+
+			"on-chain fees, but the VTXO is only worth %d sat. "+
+			"Use a cooperative leave instead.", f.NumRecoveryTxs,
+			int64(f.TotalRecoveryCostSat), int64(f.VTXOAmountSat))
+
+	case unroll.ExitWalletUnderfunded:
+		return status.Errorf(codes.FailedPrecondition, "on-chain "+
+			"wallet balance too low for unroll: need ~%d sat to "+
+			"fund CPFP fees for %d recovery transaction(s), but "+
+			"only %d sat confirmed. Deposit more and retry.",
+			int64(f.CPFPFeeTotalSat), f.NumRecoveryTxs,
+			int64(f.WalletConfirmedSat))
+
+	case unroll.ExitWalletTooFewInputs:
+		return status.Errorf(codes.FailedPrecondition, "insufficient "+
+			"wallet UTXOs to fund unroll CPFP: need at least %d "+
+			"confirmed wallet UTXO(s) of >= %d sat each (one per "+
+			"ancestry path), have %d usable. Fund the wallet's "+
+			"onchain address with more inputs and retry.",
+			f.RequiredWalletInputs,
+			int64(preflightUnrollMinUTXOSat), f.WalletUsableInputs)
+
+	default:
+		return status.Errorf(codes.FailedPrecondition, "unilateral "+
+			"exit infeasible: %s", f.Reason)
+	}
 }
 
 // GetUnrollStatus returns the current status of an unroll job for the

--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/oor"
 	"github.com/lightninglabs/darepo-client/round"
+	"github.com/lightninglabs/darepo-client/unroll"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -1384,4 +1385,84 @@ func TestQueryRoundStatesEarlyStateOmitsCommitmentTxid(t *testing.T) {
 	require.Empty(t, got.CommitmentTxid)
 	require.Len(t, got.Vtxos, 1)
 	require.Equal(t, int64(42_000), got.Vtxos[0].AmountSat)
+}
+
+// TestUnrollInfeasibleError verifies each infeasibility reason maps to a
+// codes.FailedPrecondition gRPC error whose message names the concrete
+// figures the caller needs to act on.
+func TestUnrollInfeasibleError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		verdict  unroll.ExitFeasibility
+		contains []string
+	}{
+		{
+			name: "sweep below dust names value, fee, and floor",
+			verdict: unroll.ExitFeasibility{
+				Reason:             unroll.ExitSweepBelowDust,
+				VTXOAmountSat:      1,
+				SweepFeeSat:        200,
+				FeeRateSatPerVByte: 1,
+				NetRecoveredSat:    -199,
+				DustLimitSat:       330,
+			},
+			contains: []string{
+				"not viable", "cooperative leave", "330 sat",
+			},
+		},
+		{
+			name: "uneconomical names tx count and total cost",
+			verdict: unroll.ExitFeasibility{
+				Reason:               unroll.ExitUneconomical,
+				NumRecoveryTxs:       50,
+				TotalRecoveryCostSat: 30_000,
+				VTXOAmountSat:        20_000,
+			},
+			contains: []string{
+				"uneconomical", "50 transaction",
+				"cooperative leave",
+			},
+		},
+		{
+			name: "underfunded names required and confirmed sats",
+			verdict: unroll.ExitFeasibility{
+				Reason: unroll.ExitWalletUnderfunded,
+
+				CPFPFeeTotalSat:    6_200,
+				NumRecoveryTxs:     4,
+				WalletConfirmedSat: 100,
+			},
+			contains: []string{
+				"wallet balance too low", "Deposit more",
+			},
+		},
+		{
+			name: "too few inputs names required and usable count",
+			verdict: unroll.ExitFeasibility{
+				Reason: unroll.ExitWalletTooFewInputs,
+
+				RequiredWalletInputs: 2,
+				WalletUsableInputs:   1,
+			},
+			contains: []string{
+				"insufficient", "one per ancestry path",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := unrollInfeasibleError(tc.verdict)
+			require.Equal(
+				t, codes.FailedPrecondition, status.Code(err),
+			)
+			for _, sub := range tc.contains {
+				require.Contains(t, err.Error(), sub)
+			}
+		})
+	}
 }

--- a/unroll/feasibility.go
+++ b/unroll/feasibility.go
@@ -1,0 +1,381 @@
+package unroll
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightninglabs/darepo-client/vtxo"
+)
+
+// A unilateral exit is the trust-minimized escape hatch a client uses to
+// reclaim a VTXO entirely on-chain, without the operator's cooperation.
+// Driving it to completion is not free: the client must broadcast (and
+// fee-bump, via CPFP) every ancestor transaction in the VTXO's proof
+// graph, then broadcast a final timeout-path sweep. Those fees come from
+// two distinct purses:
+//
+//   - Wallet-funded: each recovery transaction is a zero-fee / anchor
+//     parent driven on-chain by a CPFP child paid from a confirmed
+//     on-chain wallet UTXO. This cost never touches the VTXO value.
+//
+//   - VTXO-funded: the final sweep spends the target output and pays its
+//     own fee out of the VTXO value, so the amount that actually lands
+//     back in the wallet is `vtxo.Amount - sweepFee`.
+//
+// AssessExitFeasibility folds both purses into a single up-front verdict
+// so the admission path can refuse an exit that can never succeed (the
+// swept output would be dust and the sweep tx unrelayable) or that is
+// economically irrational (it burns more in fees than the coin is worth)
+// before the VTXO is committed to UnilateralExitState. The alternative —
+// admitting blindly — strands the VTXO in an exit state after the
+// broadcast fails "min relay fee not met", per darepo-client #608.
+
+const (
+	// defaultCPFPChildVBytes is a conservative virtual-size estimate
+	// for the CPFP child the txconfirm broadcaster builds per recovery
+	// transaction: it spends the ephemeral P2A anchor (tiny witness),
+	// one confirmed wallet fee input (taproot key-spend), and creates
+	// one P2TR change output. Taproot is the dominant path and 155 vB
+	// gives comfortable headroom over the exact size.
+	defaultCPFPChildVBytes int64 = 155
+
+	// defaultSweepOutputDustSat is the floor the swept output must clear
+	// for the sweep transaction to relay. 330 sat is the standard
+	// Bitcoin Core / btcwallet dust limit for a P2TR output at the
+	// 1 sat/vB default minimum relay fee (the sweep always pays to a
+	// P2TR wallet address). Configurable so a tighter or looser relay
+	// policy can be tracked, but the default matches stock policy.
+	defaultSweepOutputDustSat = btcutil.Amount(330)
+
+	// defaultMaxRecoveryCostFractionBP bounds how much of the VTXO's
+	// value the total on-chain recovery cost (CPFP fees + sweep fee)
+	// may consume before the exit is judged uneconomical, expressed in
+	// basis points of the VTXO value. The default of 10_000 bp (100%)
+	// blocks only exits that are outright loss-making — recovering the
+	// coin would cost at least as much as the coin holds. It is set at
+	// 100% rather than lower on purpose: a unilateral exit is the
+	// last-resort path used precisely when the operator is unreachable
+	// or uncooperative, so the daemon must not paternalistically refuse
+	// a merely-expensive (but still net-positive) recovery. Operators
+	// who want a stricter "don't bother below X% efficiency" policy can
+	// lower this.
+	defaultMaxRecoveryCostFractionBP int64 = 10_000
+)
+
+// ExitFeasibilityConfig parameterizes the economic pre-flight. The zero
+// value is valid: withDefaults fills every unset field with the
+// documented default, so callers that don't care can pass an empty
+// struct.
+type ExitFeasibilityConfig struct {
+	// CPFPChildVBytes is the estimated vsize of the CPFP fee-bump child
+	// built per recovery transaction. Zero falls back to
+	// defaultCPFPChildVBytes.
+	CPFPChildVBytes int64
+
+	// SweepVBytes is the estimated vsize of the timeout-path sweep.
+	// Zero falls back to the package-wide estimatedSweepVBytes so the
+	// pre-flight stays consistent with the sweep the unroll actor
+	// actually builds.
+	SweepVBytes int64
+
+	// SweepOutputDustSat is the minimum value the swept output must have
+	// to relay. Zero falls back to defaultSweepOutputDustSat.
+	SweepOutputDustSat btcutil.Amount
+
+	// MaxRecoveryCostFractionBP bounds the total recovery cost as a
+	// fraction (in basis points) of the VTXO value. Zero falls back to
+	// defaultMaxRecoveryCostFractionBP.
+	MaxRecoveryCostFractionBP int64
+}
+
+// withDefaults returns a copy of the config with every unset field
+// replaced by its documented default.
+func (c ExitFeasibilityConfig) withDefaults() ExitFeasibilityConfig {
+	if c.CPFPChildVBytes <= 0 {
+		c.CPFPChildVBytes = defaultCPFPChildVBytes
+	}
+	if c.SweepVBytes <= 0 {
+		c.SweepVBytes = estimatedSweepVBytes
+	}
+	if c.SweepOutputDustSat <= 0 {
+		c.SweepOutputDustSat = defaultSweepOutputDustSat
+	}
+	if c.MaxRecoveryCostFractionBP <= 0 {
+		c.MaxRecoveryCostFractionBP = defaultMaxRecoveryCostFractionBP
+	}
+
+	return c
+}
+
+// ExitInfeasibilityReason enumerates why a unilateral exit was judged
+// infeasible. ExitFeasible is the zero value (no problem).
+type ExitInfeasibilityReason uint8
+
+const (
+	// ExitFeasible means the exit passed every check.
+	ExitFeasible ExitInfeasibilityReason = iota
+
+	// ExitSweepBelowDust means the swept output, after deducting the
+	// sweep fee from the VTXO value, would fall at or below the dust
+	// limit. The sweep transaction could never be relayed, so the exit
+	// is impossible — no amount of wallet funding fixes it.
+	ExitSweepBelowDust
+
+	// ExitUneconomical means the total on-chain cost to recover the
+	// VTXO (wallet-funded CPFP fees plus the VTXO-funded sweep fee)
+	// exceeds the configured fraction of the VTXO value. The exit could
+	// technically complete but burns more than it returns.
+	ExitUneconomical
+
+	// ExitWalletUnderfunded means the confirmed on-chain wallet balance
+	// is too small to cover the CPFP fees for the recovery
+	// transactions. Funding the wallet and retrying resolves it.
+	ExitWalletUnderfunded
+
+	// ExitWalletTooFewInputs means the wallet has fewer usable confirmed
+	// UTXOs than the VTXO has independent ancestry paths. Each path is a
+	// distinct CPFP parent needing its own fee input at child-
+	// construction time, so distinct inputs — not just total balance —
+	// are required.
+	ExitWalletTooFewInputs
+)
+
+// String renders the reason for logs and error messages.
+func (r ExitInfeasibilityReason) String() string {
+	switch r {
+	case ExitFeasible:
+		return "feasible"
+
+	case ExitSweepBelowDust:
+		return "sweep_below_dust"
+
+	case ExitUneconomical:
+		return "uneconomical"
+
+	case ExitWalletUnderfunded:
+		return "wallet_underfunded"
+
+	case ExitWalletTooFewInputs:
+		return "wallet_too_few_inputs"
+
+	default:
+		return fmt.Sprintf("unknown(%d)", uint8(r))
+	}
+}
+
+// Impossible reports whether the reason describes an exit that can never
+// succeed regardless of wallet state or user override (the swept output
+// is unrelayable). Callers that offer a force-override should still
+// honor an Impossible verdict.
+func (r ExitInfeasibilityReason) Impossible() bool {
+	return r == ExitSweepBelowDust
+}
+
+// ExitFeasibilityInput carries everything the pure assessment needs. The
+// caller resolves these from the VTXO descriptor (RecoveryTxCount), the
+// chain fee estimator, and the wallet's confirmed UTXO set.
+type ExitFeasibilityInput struct {
+	// NumRecoveryTxs is the count of ancestor transactions that must be
+	// broadcast (and CPFP-bumped) to materialize the target output.
+	NumRecoveryTxs int
+
+	// NumAncestryPaths is the number of independent commitment-tree
+	// roots in the VTXO's ancestry — one concurrent CPFP parent each.
+	NumAncestryPaths int
+
+	// VTXOAmountSat is the value of the VTXO being exited.
+	VTXOAmountSat btcutil.Amount
+
+	// FeeRateSatPerVByte is the current estimated fee rate.
+	FeeRateSatPerVByte btcutil.Amount
+
+	// WalletConfirmedSat is the total confirmed on-chain wallet balance
+	// available to fund CPFP children.
+	WalletConfirmedSat btcutil.Amount
+
+	// WalletUsableInputs is the number of confirmed wallet UTXOs large
+	// enough to plausibly fund a CPFP child on their own.
+	WalletUsableInputs int
+
+	// Config tunes the cost model. The zero value uses all defaults.
+	Config ExitFeasibilityConfig
+}
+
+// ExitFeasibility is the structured verdict plus the full cost breakdown
+// that produced it, so callers can build actionable error messages and
+// UX previews without recomputing anything.
+type ExitFeasibility struct {
+	// Feasible is true when every check passed.
+	Feasible bool
+
+	// Reason is ExitFeasible when Feasible, else the first failing
+	// check.
+	Reason ExitInfeasibilityReason
+
+	// NumRecoveryTxs echoes the input recovery-transaction count.
+	NumRecoveryTxs int
+
+	// FeeRateSatPerVByte echoes the fee rate the estimate used.
+	FeeRateSatPerVByte btcutil.Amount
+
+	// CPFPFeeTotalSat is the wallet-funded cost: the summed CPFP child
+	// fees across every recovery transaction.
+	CPFPFeeTotalSat btcutil.Amount
+
+	// SweepFeeSat is the VTXO-funded cost: the fee the final sweep pays
+	// out of the VTXO value.
+	SweepFeeSat btcutil.Amount
+
+	// TotalRecoveryCostSat is CPFPFeeTotalSat + SweepFeeSat — the whole
+	// on-chain cost to recover the coin.
+	TotalRecoveryCostSat btcutil.Amount
+
+	// NetRecoveredSat is VTXOAmountSat - SweepFeeSat: the value that
+	// actually lands back in the wallet from the sweep.
+	NetRecoveredSat btcutil.Amount
+
+	// VTXOAmountSat echoes the input VTXO value.
+	VTXOAmountSat btcutil.Amount
+
+	// DustLimitSat is the resolved sweep-output dust floor used.
+	DustLimitSat btcutil.Amount
+
+	// RequiredWalletInputs is the number of distinct confirmed wallet
+	// UTXOs the exit needs (one per ancestry path).
+	RequiredWalletInputs int
+
+	// WalletConfirmedSat / WalletUsableInputs echo the wallet inputs.
+	WalletConfirmedSat btcutil.Amount
+	WalletUsableInputs int
+}
+
+// AssessExitFeasibility runs the pure economic model over the supplied
+// inputs and returns a verdict. It performs no IO and is the single
+// source of truth for whether a unilateral exit should be admitted.
+//
+// Checks are evaluated most-fundamental first, and the first failure is
+// reported:
+//
+//  1. ExitSweepBelowDust — the exit is impossible (unrelayable sweep).
+//  2. ExitUneconomical — the exit is not worth doing.
+//  3. ExitWalletUnderfunded — the wallet can't pay the CPFP fees.
+//  4. ExitWalletTooFewInputs — the wallet lacks distinct fee inputs.
+func AssessExitFeasibility(in ExitFeasibilityInput) ExitFeasibility {
+	cfg := in.Config.withDefaults()
+
+	sweepFee := btcutil.Amount(
+		int64(in.FeeRateSatPerVByte) * cfg.SweepVBytes,
+	)
+	cpfpTotal := btcutil.Amount(
+		int64(in.FeeRateSatPerVByte) * cfg.CPFPChildVBytes *
+			int64(in.NumRecoveryTxs),
+	)
+	totalCost := cpfpTotal + sweepFee
+	net := in.VTXOAmountSat - sweepFee
+
+	f := ExitFeasibility{
+		Feasible:             true,
+		Reason:               ExitFeasible,
+		NumRecoveryTxs:       in.NumRecoveryTxs,
+		FeeRateSatPerVByte:   in.FeeRateSatPerVByte,
+		CPFPFeeTotalSat:      cpfpTotal,
+		SweepFeeSat:          sweepFee,
+		TotalRecoveryCostSat: totalCost,
+		NetRecoveredSat:      net,
+		VTXOAmountSat:        in.VTXOAmountSat,
+		DustLimitSat:         cfg.SweepOutputDustSat,
+		RequiredWalletInputs: in.NumAncestryPaths,
+		WalletConfirmedSat:   in.WalletConfirmedSat,
+		WalletUsableInputs:   in.WalletUsableInputs,
+	}
+
+	// 1. Impossible: after the sweep pays its own fee, the output left
+	//    for the wallet is below the dust limit and the sweep tx cannot
+	//    be relayed. An output exactly at the dust limit is relayable
+	//    (standard dust semantics reject only strictly-below), so the
+	//    comparison is strict.
+	if net < cfg.SweepOutputDustSat {
+		f.Feasible = false
+		f.Reason = ExitSweepBelowDust
+
+		return f
+	}
+
+	// 2. Uneconomical: the whole-picture cost to recover the coin
+	//    (wallet-funded CPFP + VTXO-funded sweep) exceeds the configured
+	//    fraction of the coin's value. float64 keeps the basis-point
+	//    math overflow-free; sat-level precision is irrelevant for a
+	//    policy gate.
+	maxCost := float64(in.VTXOAmountSat) *
+		float64(cfg.MaxRecoveryCostFractionBP) / 10_000.0
+	if float64(totalCost) >= maxCost {
+		f.Feasible = false
+		f.Reason = ExitUneconomical
+
+		return f
+	}
+
+	// 3. Wallet can't fund the CPFP children at all.
+	if in.WalletConfirmedSat < cpfpTotal {
+		f.Feasible = false
+		f.Reason = ExitWalletUnderfunded
+
+		return f
+	}
+
+	// 4. Wallet has the balance but not enough distinct inputs: each
+	//    independent ancestry path is a separate CPFP parent that needs
+	//    its own confirmed fee input at child-construction time.
+	if in.WalletUsableInputs < in.NumAncestryPaths {
+		f.Feasible = false
+		f.Reason = ExitWalletTooFewInputs
+
+		return f
+	}
+
+	return f
+}
+
+// RecoveryTxCount derives, from a VTXO descriptor, two counts: the number
+// of ancestor transactions that must be broadcast to materialize the
+// target output, and the number of independent commitment-tree roots in
+// its ancestry (returned in that order). Each ancestry fragment
+// contributes its tree-path transactions; OOR VTXOs add one checkpoint
+// transaction per hop in the OOR chain (ChainDepth). A nil descriptor
+// yields (0, 0).
+func RecoveryTxCount(desc *vtxo.Descriptor) (int, int) {
+	if desc == nil {
+		return 0, 0
+	}
+
+	var numTxs, numPaths int
+	for _, a := range desc.Ancestry {
+		numPaths++
+
+		pathTxs := 0
+		switch {
+		case a.TreePath != nil:
+			pathTxs = a.TreePath.NumTx()
+
+		case a.TreeDepth > 0:
+			// Tree pruned but depth persisted: use it as a rough
+			// lower bound on the transactions in this fragment.
+			pathTxs = int(a.TreeDepth)
+		}
+
+		// An ancestry path that exists always has at least one
+		// commitment transaction. Floor at 1 so a malformed fragment
+		// (nil TreePath and zero TreeDepth) still contributes to the
+		// CPFP-fee estimate rather than silently costing nothing,
+		// which would let a wallet-underfunded exit slip through.
+		if pathTxs < 1 {
+			pathTxs = 1
+		}
+
+		numTxs += pathTxs
+	}
+
+	numTxs += desc.ChainDepth
+
+	return numTxs, numPaths
+}

--- a/unroll/feasibility_test.go
+++ b/unroll/feasibility_test.go
@@ -1,0 +1,328 @@
+package unroll
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAssessExitFeasibility exercises the pure economic model across the
+// feasible path and every infeasibility reason, asserting both the
+// verdict and the cost breakdown it reports.
+func TestAssessExitFeasibility(t *testing.T) {
+	t.Parallel()
+
+	// A healthy baseline: a 1M-sat VTXO, one shallow ancestry path, a
+	// well-funded wallet, 1 sat/vB. Individual cases mutate one axis.
+	baseline := func() ExitFeasibilityInput {
+		return ExitFeasibilityInput{
+			NumRecoveryTxs:     2,
+			NumAncestryPaths:   1,
+			VTXOAmountSat:      1_000_000,
+			FeeRateSatPerVByte: 1,
+			WalletConfirmedSat: 1_000_000,
+			WalletUsableInputs: 4,
+		}
+	}
+
+	tests := []struct {
+		name       string
+		mutate     func(*ExitFeasibilityInput)
+		wantReason ExitInfeasibilityReason
+		// assert lets a case make extra breakdown assertions.
+		assert func(t *testing.T, f ExitFeasibility)
+	}{
+		{
+			name:       "healthy exit is feasible",
+			mutate:     func(*ExitFeasibilityInput) {},
+			wantReason: ExitFeasible,
+			assert: func(t *testing.T, f ExitFeasibility) {
+				require.True(t, f.Feasible)
+
+				// 2 recovery txs * 155 vB * 1 sat/vB.
+				require.EqualValues(
+					t, 310, f.CPFPFeeTotalSat,
+				)
+				// 200 vB * 1 sat/vB.
+				require.EqualValues(t, 200, f.SweepFeeSat)
+				require.EqualValues(
+					t, 510, f.TotalRecoveryCostSat,
+				)
+				require.EqualValues(
+					t, 999_800, f.NetRecoveredSat,
+				)
+			},
+		},
+		{
+			name: "sub-dust VTXO cannot be swept",
+			mutate: func(in *ExitFeasibilityInput) {
+				// The #608 case: a 1-sat VTXO. After any sweep
+				// fee the net is negative, well below dust.
+				in.VTXOAmountSat = 1
+			},
+			wantReason: ExitSweepBelowDust,
+			assert: func(t *testing.T, f ExitFeasibility) {
+				require.False(t, f.Feasible)
+				require.True(t, f.Reason.Impossible())
+			},
+		},
+		{
+			name: "net one sat below dust is infeasible",
+			mutate: func(in *ExitFeasibilityInput) {
+				// sweepFee=200; net = dust-1 must fail.
+				// Keep recovery trivial so it's the only
+				// failure.
+				in.NumRecoveryTxs = 0
+				in.NumAncestryPaths = 0
+				in.FeeRateSatPerVByte = 1
+				in.VTXOAmountSat = 200 +
+					defaultSweepOutputDustSat - 1
+			},
+			wantReason: ExitSweepBelowDust,
+		},
+		{
+			name: "net exactly at dust clears the floor",
+			mutate: func(in *ExitFeasibilityInput) {
+				// net = vtxo-200 = dust. An output at the
+				// dust limit is relayable, so feasible.
+				// Keep recovery trivial.
+				in.NumRecoveryTxs = 0
+				in.NumAncestryPaths = 0
+				in.VTXOAmountSat = 200 +
+					defaultSweepOutputDustSat
+			},
+			wantReason: ExitFeasible,
+		},
+		{
+			name: "loss-making exit is uneconomical",
+			mutate: func(in *ExitFeasibilityInput) {
+				// Deep lineage on a small (but above-dust-net)
+				// VTXO: CPFP fees dwarf the coin's value at a
+				// high fee rate.
+				in.NumRecoveryTxs = 50
+				in.FeeRateSatPerVByte = 50
+				in.VTXOAmountSat = 20_000
+			},
+			wantReason: ExitUneconomical,
+			assert: func(t *testing.T, f ExitFeasibility) {
+				require.False(t, f.Reason.Impossible())
+				require.GreaterOrEqual(
+					t, int64(f.TotalRecoveryCostSat),
+					int64(f.VTXOAmountSat),
+				)
+			},
+		},
+		{
+			name: "wallet cannot fund CPFP fees",
+			mutate: func(in *ExitFeasibilityInput) {
+				// Plenty of value, but the on-chain wallet is
+				// nearly empty so the CPFP children can't be
+				// funded.
+				in.NumRecoveryTxs = 4
+				in.FeeRateSatPerVByte = 10
+				in.WalletConfirmedSat = 100
+			},
+			wantReason: ExitWalletUnderfunded,
+		},
+		{
+			name: "wallet has balance but too few inputs",
+			mutate: func(in *ExitFeasibilityInput) {
+				// Two independent ancestry paths need two
+				// distinct fee inputs; the wallet has balance
+				// in only one usable UTXO.
+				in.NumAncestryPaths = 2
+				in.WalletUsableInputs = 1
+			},
+			wantReason: ExitWalletTooFewInputs,
+		},
+		{
+			name: "dust check precedes wallet checks",
+			mutate: func(in *ExitFeasibilityInput) {
+				// Both sub-dust and underfunded: the impossible
+				// reason must win so the user isn't told to
+				// fund a wallet for an exit that can't work.
+				in.VTXOAmountSat = 1
+				in.WalletConfirmedSat = 0
+			},
+			wantReason: ExitSweepBelowDust,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			in := baseline()
+			tc.mutate(&in)
+
+			f := AssessExitFeasibility(in)
+
+			require.Equal(
+				t, tc.wantReason, f.Reason, "reason %s",
+				f.Reason,
+			)
+			require.Equal(
+				t, tc.wantReason == ExitFeasible, f.Feasible,
+			)
+
+			if tc.assert != nil {
+				tc.assert(t, f)
+			}
+		})
+	}
+}
+
+// TestExitFeasibilityConfigDefaults verifies that the zero-value config
+// resolves to the documented defaults and that explicit overrides win.
+func TestExitFeasibilityConfigDefaults(t *testing.T) {
+	t.Parallel()
+
+	got := ExitFeasibilityConfig{}.withDefaults()
+	require.Equal(t, defaultCPFPChildVBytes, got.CPFPChildVBytes)
+	require.EqualValues(t, estimatedSweepVBytes, got.SweepVBytes)
+	require.Equal(t, defaultSweepOutputDustSat, got.SweepOutputDustSat)
+	require.Equal(
+		t, defaultMaxRecoveryCostFractionBP,
+		got.MaxRecoveryCostFractionBP,
+	)
+
+	override := ExitFeasibilityConfig{
+		CPFPChildVBytes:           200,
+		SweepVBytes:               300,
+		SweepOutputDustSat:        546,
+		MaxRecoveryCostFractionBP: 5_000,
+	}.withDefaults()
+	require.Equal(t, int64(200), override.CPFPChildVBytes)
+	require.Equal(t, int64(300), override.SweepVBytes)
+	require.Equal(t, btcutil.Amount(546), override.SweepOutputDustSat)
+	require.Equal(t, int64(5_000), override.MaxRecoveryCostFractionBP)
+}
+
+// TestExitFeasibilityStricterFraction shows a lower cost-fraction policy
+// blocks an exit the default 100% threshold would allow.
+func TestExitFeasibilityStricterFraction(t *testing.T) {
+	t.Parallel()
+
+	in := ExitFeasibilityInput{
+		NumRecoveryTxs:     10,
+		NumAncestryPaths:   1,
+		VTXOAmountSat:      100_000,
+		FeeRateSatPerVByte: 10,
+		WalletConfirmedSat: 1_000_000,
+		WalletUsableInputs: 4,
+	}
+
+	// Total cost = 10*155*10 + 200*10 = 15_500 + 2_000 = 17_500 sat,
+	// which is 17.5% of the 100k VTXO: feasible under the 100% default.
+	require.True(t, AssessExitFeasibility(in).Feasible)
+
+	// Under a 10% (1_000 bp) policy the same exit is uneconomical.
+	in.Config.MaxRecoveryCostFractionBP = 1_000
+	f := AssessExitFeasibility(in)
+	require.False(t, f.Feasible)
+	require.Equal(t, ExitUneconomical, f.Reason)
+}
+
+// TestRecoveryTxCount checks the descriptor-derived recovery-transaction
+// and ancestry-path counts, including the OOR ChainDepth contribution and
+// the pruned-tree fallback.
+func TestRecoveryTxCount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil descriptor", func(t *testing.T) {
+		t.Parallel()
+
+		numTxs, numPaths := RecoveryTxCount(nil)
+		require.Zero(t, numTxs)
+		require.Zero(t, numPaths)
+	})
+
+	t.Run("pruned tree uses depth fallback plus chain depth", func(
+		t *testing.T) {
+
+		t.Parallel()
+
+		desc := &vtxo.Descriptor{
+			ChainDepth: 2,
+			Ancestry: []types.Ancestry{
+				{
+					CommitmentTxID: chainhash.Hash{
+						0x01,
+					},
+					TreePath:  nil,
+					TreeDepth: 3,
+				},
+				{
+					CommitmentTxID: chainhash.Hash{
+						0x02,
+					},
+					TreePath:  nil,
+					TreeDepth: 1,
+				},
+			},
+		}
+
+		numTxs, numPaths := RecoveryTxCount(desc)
+		require.Equal(t, 2, numPaths)
+		// 3 + 1 (depth fallback) + 2 (chain depth).
+		require.Equal(t, 6, numTxs)
+	})
+
+	t.Run("tree path contributes its NumTx", func(t *testing.T) {
+		t.Parallel()
+
+		// A root with two leaf children is three transactions.
+		treePath := &tree.Tree{
+			Root: &tree.Node{
+				Children: map[uint32]*tree.Node{
+					0: {},
+					1: {},
+				},
+			},
+		}
+		require.Equal(t, 3, treePath.NumTx())
+
+		desc := &vtxo.Descriptor{
+			Ancestry: []types.Ancestry{
+				{
+					CommitmentTxID: chainhash.Hash{
+						0x01,
+					},
+					TreePath: treePath,
+				},
+			},
+		}
+
+		numTxs, numPaths := RecoveryTxCount(desc)
+		require.Equal(t, 1, numPaths)
+		require.Equal(t, 3, numTxs)
+	})
+
+	t.Run("malformed path floors at one tx", func(t *testing.T) {
+		t.Parallel()
+
+		// An ancestry entry with neither a tree path nor a depth
+		// must still contribute at least one transaction so the
+		// CPFP-fee estimate is never zeroed out for a real path.
+		desc := &vtxo.Descriptor{
+			Ancestry: []types.Ancestry{
+				{
+					CommitmentTxID: chainhash.Hash{
+						0x01,
+					},
+					TreePath:  nil,
+					TreeDepth: 0,
+				},
+			},
+		}
+
+		numTxs, numPaths := RecoveryTxCount(desc)
+		require.Equal(t, 1, numPaths)
+		require.Equal(t, 1, numTxs)
+	})
+}


### PR DESCRIPTION
## Issue

Fixes #608.

`darepocli exit --outpoint …` admitted a unilateral exit after only
checking that the wallet held one confirmed UTXO per ancestry path. It
never looked at the target VTXO's own value, so a sub-dust VTXO was
admitted, transitioned to `UnilateralExitState`, and then failed
downstream with `min relay fee not met` when the proof/sweep tx could
not be broadcast — stranding the VTXO in an exit state the user can't
easily back out of.

## Background

A holistic fee check was proposed in #450 (`checkUnrollFeeBalance` /
`unrollFeeShortfall`, deriving `numRecoveryTxs` from the ancestry) but
was never merged — it was superseded by the coarse UTXO-count heuristic
`preflightUnrollFeeInputs` that ships today, which compares only against
the *wallet's* fee budget and never the VTXO's own value vs. dust. This
PR resurrects that idea and extends it with the dust / net-recovered and
economical checks it never had.

## Approach

Driving an exit to completion draws fees from two distinct purses:

- **Wallet-funded** — a CPFP child per recovery transaction, paid from a
  confirmed on-chain wallet UTXO. Never touches the VTXO value.
- **VTXO-funded** — the final sweep pays its own fee out of the VTXO
  value, so the amount that lands back in the wallet is
  `vtxo.Amount - sweepFee`.

A new pure, IO-free model (`unroll/feasibility.go`) folds both into one
verdict via `AssessExitFeasibility`, with four ordered checks:

1. **`ExitSweepBelowDust`** (impossible) — `net = vtxo - sweepFee` falls
   below the **network** P2TR dust limit, so the sweep tx can't relay.
   This is the #608 case and subsumes the plain dust check. The floor is
   network policy, **not** an operator-advertised value, so the verdict
   does not depend on the operator being reachable — a unilateral exit is
   precisely the path used when it isn't.
2. **`ExitUneconomical`** — total recovery cost (CPFP + sweep) exceeds a
   configurable fraction of the VTXO value. Default 100%, i.e. block only
   outright loss-making exits; merely-expensive-but-net-positive
   recoveries are left to the user.
3. **`ExitWalletUnderfunded`** — wallet can't cover the CPFP fees.
4. **`ExitWalletTooFewInputs`** — too few distinct fee inputs (one per
   ancestry path).

`RecoveryTxCount(desc)` derives the recovery-transaction and ancestry-
path counts from the descriptor (tree-path tx count + OOR `ChainDepth`).

`darepod`'s `preflightUnrollFeeInputs` is replaced by
`preflightUnrollFeasibility`, which gathers the inputs and maps each
infeasible verdict to a `FailedPrecondition` error naming the concrete
figures and pointing at cooperative leave.

All cost-model sizes, the dust floor, and the economical threshold are
configurable with documented defaults.

## Relationship to other work

Complementary to #658 (recover a VTXO after a failed no-broadcast unroll
— the #602 cascade): this PR is the admission gate that stops the doomed
exit from being admitted in the first place; #658 is the safety net if
one slips through.

## Reproduction note

The issue's original recipe (OOR-send 1 sat to self) is now blocked by
#606 (`validateOORRecipientDust`), so a full itest would need a sub-dust
VTXO seeded another way. The logic is covered by unit tests instead:
table-driven coverage of the pure model (`unroll/feasibility_test.go`)
and the verdict→gRPC mapping (`TestUnrollInfeasibleError`).

## Test Plan

- `make unit pkg=./unroll timeout=5m`
- `make unit pkg=./darepod case=TestUnrollInfeasibleError timeout=5m`
- `make lint-changed-local` (0 issues)