### PR TITLE
ci: pin Claude Code action to Opus 4.8

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,5 +42,5 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-opus-4-8 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--model claude-opus-4-8'
 


### PR DESCRIPTION
In this PR, we pin the model used by our two Claude GitHub workflows to Opus 4.8. The `claude-code-review.yml` job that fires on the `claude-review` label, and the `claude.yml` `@claude` assistant, both run `anthropics/claude-code-action@v1` and neither one set a model. That meant they fell back to the action's built-in default, a Sonnet-class model, so our PR reviews were running on Sonnet rather than the strongest model we have.

The v1 action dropped the old dedicated `model:` input, so the model now has to ride in through `claude_args` as `--model claude-opus-4-8`. For the review workflow we prepend it to the existing `claude_args` (next to the `--allowed-tools` list); for the assistant workflow we uncomment the `claude_args` line and set it there.

A matching change goes up in `lightninglabs/darepo` so both repos review on the same model.