### PR TITLE
chainbackends: add Esplora package submitter for lnd/neutrino unroll broadcast

### DIFF
--- a/chainbackends/esplorarpc/CLAUDE.md
+++ b/chainbackends/esplorarpc/CLAUDE.md
@@ -1,0 +1,59 @@
+# esplorarpc
+
+## Purpose
+
+Esplora-backed implementation of `chainbackends.PackageSubmitter`. POSTs a
+v3/TRUC parent+child package to an Esplora/electrs `/txs/package` endpoint so
+chain backends that cannot relay packages themselves — lnd's `WalletKit` and
+the neutrino SPV backend — can still broadcast the zero-fee ephemeral-anchor
+parents that unilateral exit / fraud response produce (darepo-client#590).
+
+Sibling to `chainbackends/bitcoindrpc`: one concrete `PackageSubmitter` per
+relay source. The lwwallet backend does **not** use this — it relays packages
+through its own Esplora chain backend (`lwwallet.EsploraClient.SubmitPackage`).
+
+## Key Types
+
+- `PackageSubmitter` — HTTP client that POSTs a JSON array of raw tx hex
+  (parents-first, child-last) to `<baseURL>/txs/package`. Dedicated
+  `*http.Client` with a 30s backstop timeout. Constructed via
+  `New(baseURL, ...Option)`.
+- `New(baseURL, opts...)` — normalizes `baseURL` (bare host → `https://`,
+  trailing slash trimmed, scheme validated). `Option`s: `WithHTTPClient`
+  (tests / custom TLS / proxy), `WithLog` (debug-logs the raw endpoint
+  response — the only place an Esplora-side reject reason is visible).
+
+## Relationships
+
+- **Depends on**: `btcd/btcjson` (`SubmitPackageResult`), `btcd/wire`
+  (`MsgTx`), `btclog/v2` + `lnd/fn/v2` (optional logger), standard library
+  `net/http`. Deliberately does **not** import `chainbackends` (mirrors
+  `bitcoindrpc`): the interface is satisfied structurally, asserted only in
+  the test.
+- **Depended on by**: `cmd/darepod` (wires via `package.esploraurl`, falling
+  back to `wallet.esploraurl`, when `bitcoind.host` is unset).
+
+## Invariants
+
+- Returns the parsed `*btcjson.SubmitPackageResult` even when it reports
+  per-tx rejections; the caller's backend classifies `PackageMsg` /
+  `TxResults` (same contract as `bitcoindrpc`). A Go error is returned only
+  for transport failures or an unparseable non-2xx body (e.g. an HTML proxy
+  error page).
+- Esplora returns bitcoind's **bare** submitpackage result object (no
+  JSON-RPC `{result, error}` envelope), unmarshaled directly into
+  `btcjson.SubmitPackageResult` (whose `UnmarshalJSON` reads `package_msg` /
+  `tx-results`).
+- The `maxFeeRate` argument is accepted for interface compatibility but
+  **ignored**: `/txs/package` exposes no per-call maxfeerate override, so the
+  server default governs (matches the lwwallet path). bitcoind-direct callers
+  pass `maxfeerate=0` to avoid the default 0.10 BTC/kvB cap rejecting a CPFP
+  child's high standalone feerate; if a server enforces that cap this endpoint
+  would need a query-param escape hatch.
+- Trust: routing a package through a third-party Esplora reveals it to that
+  server — a privacy regression for an otherwise-trustless SPV wallet, hence
+  opt-in.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/chainbackends/esplorarpc/package_submitter.go
+++ b/chainbackends/esplorarpc/package_submitter.go
@@ -1,0 +1,241 @@
+// Package esplorarpc provides an Esplora-backed implementation of
+// chainbackends.PackageSubmitter. It POSTs a v3/TRUC parent+child package to
+// an Esplora/electrs `/txs/package` endpoint, letting chain backends that
+// cannot do package relay themselves (lnd's WalletKit, neutrino SPV) still
+// broadcast the zero-fee ephemeral-anchor parents that unilateral exit /
+// fraud response produce.
+//
+// Sibling to chainbackends/bitcoindrpc: one concrete PackageSubmitter per
+// relay source. Esplora differs from a direct bitcoind connection in two
+// ways this implementation accounts for: the endpoint is a plain REST POST
+// of a JSON array of raw tx hex (not a JSON-RPC envelope), and it returns
+// bitcoind's bare submitpackage result object directly rather than wrapped
+// in a `{result, error}` envelope.
+//
+// Trust note: routing a package through a third-party Esplora server reveals
+// those transactions to that server. For an otherwise-trustless SPV wallet
+// this is a privacy regression, so this submitter is intended to be opt-in.
+package esplorarpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// submitTimeout bounds the package POST so a wedged or slow Esplora server
+// cannot stall the caller for the full parent context timeout. It matches
+// the bitcoindrpc submitter's backstop so both relay sources behave the
+// same under a hung endpoint.
+const submitTimeout = 30 * time.Second
+
+// packagePath is the Esplora REST path for atomic v3 package relay.
+const packagePath = "/txs/package"
+
+// PackageSubmitter implements chainbackends.PackageSubmitter by POSTing a
+// parent+child package to an Esplora/electrs `/txs/package` endpoint.
+type PackageSubmitter struct {
+	// url is the normalized Esplora REST root (no trailing slash); the
+	// package path is appended per request.
+	url string
+
+	// client is a dedicated HTTP client so we never share state with
+	// http.DefaultClient, and it carries a timeout as a backstop for
+	// callers that pass a never-cancelled context.
+	client *http.Client
+
+	// log is optional; without it the submitter logs nothing.
+	log fn.Option[btclog.Logger]
+}
+
+// Option configures a PackageSubmitter.
+type Option func(*PackageSubmitter)
+
+// WithHTTPClient overrides the default HTTP client. Intended for tests and
+// for operators that need custom TLS, proxy, or timeout behaviour.
+func WithHTTPClient(client *http.Client) Option {
+	return func(s *PackageSubmitter) {
+		s.client = client
+	}
+}
+
+// WithLog attaches a logger used to emit the raw endpoint response at debug
+// level, which is the only place an Esplora-side package reject reason is
+// visible. Without it the submitter logs nothing.
+func WithLog(log btclog.Logger) Option {
+	return func(s *PackageSubmitter) {
+		s.log = fn.Some(log)
+	}
+}
+
+// New creates a submitter that POSTs packages to the Esplora REST API rooted
+// at baseURL (e.g. "https://blockstream.info/api" or a bare host). A base URL
+// without a scheme defaults to https:// since public Esplora servers speak
+// TLS; a trailing slash is trimmed so the package path joins cleanly.
+func New(baseURL string, opts ...Option) (*PackageSubmitter, error) {
+	endpoint, err := normalizeBaseURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &PackageSubmitter{
+		url: endpoint,
+		client: &http.Client{
+			Timeout: submitTimeout,
+		},
+		log: fn.None[btclog.Logger](),
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s, nil
+}
+
+// normalizeBaseURL validates and canonicalizes the operator-supplied Esplora
+// base URL into a concrete http:// or https:// root without a trailing slash.
+func normalizeBaseURL(baseURL string) (string, error) {
+	if strings.TrimSpace(baseURL) == "" {
+		return "", fmt.Errorf("esplora base URL is required")
+	}
+
+	raw := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+
+	endpoint, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse esplora base URL %q: %w", baseURL,
+			err)
+	}
+	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
+		return "", fmt.Errorf("unsupported esplora URL scheme %q",
+			endpoint.Scheme)
+	}
+	if endpoint.Host == "" {
+		return "", fmt.Errorf("esplora base URL %q has no host",
+			baseURL)
+	}
+
+	return strings.TrimRight(endpoint.String(), "/"), nil
+}
+
+// SubmitPackage implements chainbackends.PackageSubmitter by POSTing the
+// serialized parent(s) and child to the Esplora `/txs/package` endpoint.
+// Transactions are ordered parents-first, child-last, matching the
+// dependency order Esplora (and bitcoind's submitpackage) require.
+//
+// The maxFeeRate argument is accepted for interface compatibility but
+// ignored: the Esplora `/txs/package` endpoint exposes no per-call
+// maxfeerate override, so the server's own default governs. This mirrors the
+// lwwallet ChainBackend Esplora path. If a CPFP child's high standalone
+// feerate is ever rejected by a server enforcing the default 0.10 BTC/kvB
+// cap, the endpoint would need a query-param escape hatch; bitcoind-direct
+// callers sidestep this by passing maxfeerate=0 (see chainbackends/
+// bitcoindrpc).
+func (s *PackageSubmitter) SubmitPackage(ctx context.Context,
+	parents []*wire.MsgTx, child *wire.MsgTx, _ *float64) (
+	*btcjson.SubmitPackageResult, error) {
+
+	if child == nil {
+		return nil, fmt.Errorf("child transaction is required")
+	}
+
+	txHexes := make([]string, 0, len(parents)+1)
+	for i, tx := range parents {
+		raw, err := serializeTx(tx)
+		if err != nil {
+			return nil, fmt.Errorf("serialize parent %d: %w", i,
+				err)
+		}
+
+		txHexes = append(txHexes, raw)
+	}
+
+	childHex, err := serializeTx(child)
+	if err != nil {
+		return nil, fmt.Errorf("serialize child: %w", err)
+	}
+	txHexes = append(txHexes, childHex)
+
+	body, err := json.Marshal(txHexes)
+	if err != nil {
+		return nil, fmt.Errorf("marshal package txs: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, s.url+packagePath, bytes.NewReader(body),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create http request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	// URL is the operator-configured Esplora endpoint, not caller-
+	// controlled input.
+	resp, err := s.client.Do(httpReq) //nolint:gosec // G704: trusted URL
+	if err != nil {
+		return nil, fmt.Errorf("submit package: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read package response: %w", err)
+	}
+
+	s.log.WhenSome(func(l btclog.Logger) {
+		l.DebugS(ctx, "Esplora package response",
+			slog.Int("status", resp.StatusCode),
+			slog.String("body", string(respBody)),
+		)
+	})
+
+	// Esplora returns bitcoind's bare submitpackage result object (no
+	// JSON-RPC envelope). A response with a parseable body is the normal
+	// path even when the body reports per-tx rejections: the caller's
+	// backend interprets PackageMsg / TxResults (mirroring bitcoindrpc,
+	// which likewise returns the result and lets the backend classify
+	// it). Only fall back to an HTTP-level error when the body is missing
+	// or unparseable, e.g. an HTML 4xx/5xx page from a proxy.
+	var result btcjson.SubmitPackageResult
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("submit package HTTP %d: %s",
+				resp.StatusCode, string(respBody))
+		}
+
+		return nil, fmt.Errorf("decode package response: %w (body: %s)",
+			err, string(respBody))
+	}
+
+	return &result, nil
+}
+
+// serializeTx returns the hex-encoded wire serialization of tx.
+func serializeTx(tx *wire.MsgTx) (string, error) {
+	if tx == nil {
+		return "", fmt.Errorf("transaction is nil")
+	}
+
+	var buf bytes.Buffer
+	if err := tx.Serialize(&buf); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(buf.Bytes()), nil
+}

--- a/chainbackends/esplorarpc/package_submitter_test.go
+++ b/chainbackends/esplorarpc/package_submitter_test.go
@@ -1,0 +1,201 @@
+package esplorarpc
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/chainbackends"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time assertion that the Esplora submitter satisfies the shared
+// chainbackends.PackageSubmitter interface so it drops into the lnd and
+// neutrino chain backends without adapter glue.
+var _ chainbackends.PackageSubmitter = (*PackageSubmitter)(nil)
+
+// zeroHash is a valid 64-hex-character txid/wtxid placeholder for the
+// per-tx result map in canned Esplora responses.
+const zeroHash = "0000000000000000000000000000000000000000000000000000" +
+	"000000000000"
+
+// newTestTx builds a minimal v3 transaction. The lockTime is used to make
+// the parent and child serialize to distinct hex so ordering can be
+// asserted from the request body.
+func newTestTx(lockTime uint32) *wire.MsgTx {
+	tx := wire.NewMsgTx(3)
+	tx.LockTime = lockTime
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Index: 0},
+		Sequence:         wire.MaxTxInSequenceNum,
+	})
+	tx.AddTxOut(&wire.TxOut{
+		Value:    1000,
+		PkScript: []byte{0x51},
+	})
+
+	return tx
+}
+
+// txHex returns the hex-encoded wire serialization of tx.
+func txHex(t *testing.T, tx *wire.MsgTx) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	require.NoError(t, tx.Serialize(&buf))
+
+	return hex.EncodeToString(buf.Bytes())
+}
+
+// TestSubmitPackageSuccess verifies that parents and child are POSTed to
+// /txs/package in dependency order and a success result is returned.
+func TestSubmitPackageSuccess(t *testing.T) {
+	parent := newTestTx(1)
+	child := newTestTx(2)
+	wantHexes := []string{txHex(t, parent), txHex(t, child)}
+
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodPost, r.Method)
+			require.Equal(t, packagePath, r.URL.Path)
+			require.Equal(
+				t, "application/json",
+				r.Header.Get("Content-Type"),
+			)
+
+			var got []string
+			require.NoError(
+				t, json.NewDecoder(r.Body).Decode(&got),
+			)
+			require.Equal(t, wantHexes, got)
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"package_msg":"success",`+
+				`"tx-results":{"`+zeroHash+`":{"txid":"`+
+				zeroHash+`"}}}`)
+		},
+	))
+	defer srv.Close()
+
+	submitter, err := New(srv.URL)
+	require.NoError(t, err)
+
+	result, err := submitter.SubmitPackage(
+		t.Context(), []*wire.MsgTx{parent}, child, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "success", result.PackageMsg)
+	require.Len(t, result.TxResults, 1)
+}
+
+// TestSubmitPackageRejection verifies that a package-relay rejection is
+// returned as a populated result (not a Go error): the caller's backend
+// classifies PackageMsg / per-tx errors, exactly as for bitcoindrpc.
+func TestSubmitPackageRejection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w,
+				`{"package_msg":"transaction failed",`+
+					`"tx-results":{"`+zeroHash+
+					`":{"txid":"`+zeroHash+
+					`","error":"min relay fee not met"}}}`)
+		},
+	))
+	defer srv.Close()
+
+	submitter, err := New(srv.URL)
+	require.NoError(t, err)
+
+	result, err := submitter.SubmitPackage(
+		t.Context(), []*wire.MsgTx{newTestTx(1)}, newTestTx(2), nil,
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, "success", result.PackageMsg)
+
+	txResult, ok := result.TxResults[zeroHash]
+	require.True(t, ok)
+	require.NotNil(t, txResult.Error)
+	require.Equal(t, "min relay fee not met", *txResult.Error)
+}
+
+// TestSubmitPackageHTTPError verifies that a non-2xx response carrying a
+// non-JSON body surfaces an HTTP-level error rather than a decode error.
+func TestSubmitPackageHTTPError(t *testing.T) {
+	srv := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, "bad request")
+			},
+		),
+	)
+	defer srv.Close()
+
+	submitter, err := New(srv.URL)
+	require.NoError(t, err)
+
+	_, err = submitter.SubmitPackage(
+		t.Context(), []*wire.MsgTx{newTestTx(1)}, newTestTx(2), nil,
+	)
+	require.ErrorContains(t, err, "HTTP 400")
+}
+
+// TestSubmitPackageNilChild verifies the child is required.
+func TestSubmitPackageNilChild(t *testing.T) {
+	submitter, err := New("https://example.com/api")
+	require.NoError(t, err)
+
+	_, err = submitter.SubmitPackage(t.Context(), nil, nil, nil)
+	require.ErrorContains(t, err, "child")
+}
+
+// TestNewBaseURLNormalization covers scheme defaulting, trailing-slash
+// trimming, and rejection of empty / unsupported inputs.
+func TestNewBaseURLNormalization(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr string
+	}{{
+		name:  "bare host defaults to https",
+		input: "blockstream.info/api",
+		want:  "https://blockstream.info/api",
+	}, {
+		name:  "trailing slash trimmed",
+		input: "https://mempool.space/api/",
+		want:  "https://mempool.space/api",
+	}, {
+		name:  "explicit http preserved",
+		input: "http://127.0.0.1:3002",
+		want:  "http://127.0.0.1:3002",
+	}, {
+		name:    "empty rejected",
+		input:   "  ",
+		wantErr: "required",
+	}, {
+		name:    "unsupported scheme rejected",
+		input:   "ftp://example.com",
+		wantErr: "unsupported",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			submitter, err := New(tc.input)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, submitter.url)
+		})
+	}
+}

--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -691,7 +691,9 @@ func configurePackageRelayFallback(v *viper.Viper, cfg *darepod.Config) error {
 		esploraURL = v.GetString("wallet.esploraurl")
 	}
 	if esploraURL == "" {
-		warnIfNoPackagePath(cfg)
+		if w := packageRelayWarning(cfg); w != "" {
+			fmt.Fprintf(os.Stderr, "WARNING: %s\n", w)
+		}
 
 		return nil
 	}
@@ -707,25 +709,42 @@ func configurePackageRelayFallback(v *viper.Viper, cfg *darepod.Config) error {
 	return nil
 }
 
-// warnIfNoPackagePath prints a startup warning when the configured wallet
-// backend cannot relay v3 ephemeral-anchor packages on its own and no package
-// submitter was wired. Without a package path, unilateral exit and fraud
-// response cannot broadcast their zero-fee parents (darepo-client#590). The
-// lwwallet backend is exempt: it relays packages through its own Esplora
-// chain backend.
-func warnIfNoPackagePath(cfg *darepod.Config) {
-	switch cfg.Wallet.Type {
-	case darepod.WalletTypeLnd, darepod.WalletTypeBtcwallet:
-		fmt.Fprintf(
-			os.Stderr, "WARNING: wallet.type %q has no v3 "+
-				"package relay path configured: set "+
-				"bitcoind.host for direct submitpackage, or "+
-				"package.esploraurl for Esplora relay. "+
-				"Without one, unilateral exit (darepocli "+
-				"exit) cannot broadcast and will fail.\n",
-			cfg.Wallet.Type,
-		)
+// packageRelayWarning returns a startup warning when the configured wallet
+// backend may be unable to relay v3 ephemeral-anchor packages and no package
+// submitter was wired, or the empty string when no warning is warranted.
+// Without a package path, unilateral exit and fraud response cannot broadcast
+// their zero-fee parents (darepo-client#590).
+//
+// The scope is deliberately narrow (darepo-client#678): only the lnd backend
+// can warrant a warning, because the other backends relay natively —
+//
+//   - lwwallet relays packages through its own Esplora chain backend, so it
+//     never needs a submitter.
+//   - btcwallet (neutrino SPV) relays the zero-fee parent + CPFP child over
+//     P2P 1p1c package relay with no submitter, confirmed by the
+//     neutrino_p2p_1p1c case of TestUnilateralExitPackageRelayMatrix. Warning
+//     it would be a false alarm, so it is exempt.
+//   - lnd relays natively only when backed by neutrino (the same P2P 1p1c
+//     path, confirmed by lnd_neutrino_1p1c); when backed by bitcoind it
+//     submits the zero-fee parent standalone and bitcoind rejects it ("min
+//     relay fee not met"), so the exit fails (the darepo-client#590 bug).
+//     lnd's RPC does not expose its chain backend, so darepod cannot tell the
+//     two apart at startup — hence a conditional warning that names the
+//     bitcoind-backed case rather than a blanket claim that every lnd exit
+//     fails.
+func packageRelayWarning(cfg *darepod.Config) string {
+	if cfg.Wallet.Type != darepod.WalletTypeLnd {
+		return ""
 	}
+
+	return fmt.Sprintf("wallet.type %q has no v3 package relay submitter "+
+		"configured. If this lnd is backed by bitcoind, unilateral "+
+		"exit (darepocli exit) cannot broadcast its zero-fee package "+
+		"and will fail; set bitcoind.host for direct submitpackage "+
+		"(pointing at the same bitcoind your lnd uses) or "+
+		"package.esploraurl for Esplora relay. If this lnd is backed "+
+		"by neutrino, relay works via P2P 1p1c and no submitter "+
+		"is needed.", cfg.Wallet.Type)
 }
 
 // isLoopbackHost reports whether the given bitcoind RPC address points

--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/chainbackends/bitcoindrpc"
+	"github.com/lightninglabs/darepo-client/chainbackends/esplorarpc"
 	"github.com/lightninglabs/darepo-client/darepod"
 	"github.com/lightningnetwork/lnd/signal"
 	"github.com/spf13/cobra"
@@ -71,6 +72,14 @@ func newRootCmd() *cobra.Command {
 			// Wire bitcoind package submitter for V3
 			// ephemeral anchor package relay (unroll).
 			err := configureBitcoindSubmitter(v, cfg)
+			if err != nil {
+				return err
+			}
+
+			// Fall back to an Esplora-backed package submitter when
+			// no direct bitcoind path was configured, so the lnd
+			// and neutrino backends can still relay v3 packages.
+			err = configurePackageRelayFallback(v, cfg)
 			if err != nil {
 				return err
 			}
@@ -560,12 +569,24 @@ func configureDaemonLogWriter(cfg *darepod.Config,
 	return logFile, nil
 }
 
-// registerBitcoindFlags registers optional direct bitcoind package relay
-// flags. Direct bitcoind relay is used for V3 ephemeral anchor transactions.
+// registerBitcoindFlags registers the optional v3 ephemeral-anchor package
+// relay flags. Two relay sources are supported: a direct bitcoind JSON-RPC
+// connection (bitcoind.*) and an Esplora/electrs `/txs/package` endpoint
+// (package.esploraurl). A bitcoind source takes precedence; see
+// configurePackageRelayFallback.
 func registerBitcoindFlags(f *pflag.FlagSet) {
 	f.String(
 		"bitcoind.host", "",
 		"bitcoind RPC address (host:port) for submitpackage support",
+	)
+	f.String(
+		"package.esploraurl", "", "Esplora/electrs REST base URL "+
+			"whose /txs/package endpoint relays v3 "+
+			"ephemeral-anchor packages for the lnd and "+
+			"neutrino backends. Falls back to "+
+			"wallet.esploraurl when unset; ignored when "+
+			"bitcoind.host is set. Routing packages through a "+
+			"third-party Esplora reveals them to that server",
 	)
 	f.String("bitcoind.user", "",
 		"bitcoind RPC username",
@@ -640,6 +661,71 @@ func configureBitcoindSubmitter(v *viper.Viper, cfg *darepod.Config) error {
 	cfg.PackageSubmitter = submitter
 
 	return nil
+}
+
+// configurePackageRelayFallback wires an Esplora-backed package submitter
+// onto cfg when no direct bitcoind submitter was configured. This gives the
+// lnd and neutrino chain backends — which cannot relay v3 ephemeral-anchor
+// packages themselves — a working submitpackage path via an Esplora/electrs
+// `/txs/package` endpoint, which unilateral exit and fraud response need to
+// broadcast their zero-fee parents (darepo-client#590).
+//
+// Precedence: a bitcoind submitter always wins (it is configured first and
+// this returns early when one is set); otherwise an explicit
+// package.esploraurl wins; otherwise the lwwallet wallet.esploraurl is reused.
+// The lwwallet backend does not need this — it relays packages through its
+// own Esplora chain backend — but reusing its URL is harmless and covers
+// operators who switch wallet types.
+//
+// Trust note: broadcasting through a third-party Esplora reveals the package
+// to that server, a privacy regression for an otherwise-trustless SPV wallet.
+// It is therefore opt-in: absent any URL the daemon runs without a package
+// path and warns when the active backend needs one.
+func configurePackageRelayFallback(v *viper.Viper, cfg *darepod.Config) error {
+	if cfg.PackageSubmitter != nil {
+		return nil
+	}
+
+	esploraURL := v.GetString("package.esploraurl")
+	if esploraURL == "" {
+		esploraURL = v.GetString("wallet.esploraurl")
+	}
+	if esploraURL == "" {
+		warnIfNoPackagePath(cfg)
+
+		return nil
+	}
+
+	submitter, err := esplorarpc.New(esploraURL)
+	if err != nil {
+		return fmt.Errorf("configure esplora package submitter: %w",
+			err)
+	}
+
+	cfg.PackageSubmitter = submitter
+
+	return nil
+}
+
+// warnIfNoPackagePath prints a startup warning when the configured wallet
+// backend cannot relay v3 ephemeral-anchor packages on its own and no package
+// submitter was wired. Without a package path, unilateral exit and fraud
+// response cannot broadcast their zero-fee parents (darepo-client#590). The
+// lwwallet backend is exempt: it relays packages through its own Esplora
+// chain backend.
+func warnIfNoPackagePath(cfg *darepod.Config) {
+	switch cfg.Wallet.Type {
+	case darepod.WalletTypeLnd, darepod.WalletTypeBtcwallet:
+		fmt.Fprintf(
+			os.Stderr, "WARNING: wallet.type %q has no v3 "+
+				"package relay path configured: set "+
+				"bitcoind.host for direct submitpackage, or "+
+				"package.esploraurl for Esplora relay. "+
+				"Without one, unilateral exit (darepocli "+
+				"exit) cannot broadcast and will fail.\n",
+			cfg.Wallet.Type,
+		)
+	}
 }
 
 // isLoopbackHost reports whether the given bitcoind RPC address points

--- a/cmd/darepod/main_test.go
+++ b/cmd/darepod/main_test.go
@@ -411,3 +411,56 @@ func TestResolveBitcoindAuth(t *testing.T) {
 		})
 	}
 }
+
+// TestPackageRelayWarning checks that the startup package-relay warning is
+// scoped to the lnd backend. lwwallet relays via its own Esplora chain
+// backend and btcwallet (neutrino) relays via P2P 1p1c, so warning either
+// would be a false alarm (darepo-client#678).
+func TestPackageRelayWarning(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		walletType string
+		wantWarn   bool
+	}{
+		{
+			name:       "lnd warns (may be bitcoind-backed)",
+			walletType: darepod.WalletTypeLnd,
+			wantWarn:   true,
+		},
+		{
+			name:       "btcwallet exempt (neutrino 1p1c)",
+			walletType: darepod.WalletTypeBtcwallet,
+			wantWarn:   false,
+		},
+		{
+			name:       "lwwallet exempt (native esplora)",
+			walletType: darepod.WalletTypeLwwallet,
+			wantWarn:   false,
+		},
+		{
+			name:       "unset wallet type does not warn",
+			walletType: "",
+			wantWarn:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &darepod.Config{
+				Wallet: &darepod.WalletConfig{
+					Type: tc.walletType,
+				},
+			}
+
+			warn := packageRelayWarning(cfg)
+			if (warn != "") != tc.wantWarn {
+				t.Fatalf("walletType %q: wantWarn=%v, got %q",
+					tc.walletType, tc.wantWarn, warn)
+			}
+		})
+	}
+}

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -242,3 +242,12 @@
 # https://. Use this when bitcoind RPC is fronted by a TLS reverse
 # proxy.
 # bitcoind.tlscertpath=
+
+# Optional Esplora/electrs REST base URL whose /txs/package endpoint
+# relays v3 ephemeral-anchor packages (unilateral exit, fraud response)
+# for the lnd and neutrino backends, so they need no bitcoind RPC of
+# their own. Falls back to wallet.esploraurl when unset, and is ignored
+# when bitcoind.host is set (a bitcoind submitter takes precedence).
+# Routing packages through a third-party Esplora reveals them to that
+# server, so this is opt-in.
+# package.esploraurl=

--- a/systest/unroll_esplora_package_test.go
+++ b/systest/unroll_esplora_package_test.go
@@ -1,0 +1,233 @@
+//go:build systest
+
+package systest
+
+import (
+	"bytes"
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/chainbackends"
+	"github.com/lightninglabs/darepo-client/chainbackends/esplorarpc"
+	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/lib/tx/arktx"
+	"github.com/lightninglabs/darepo-client/lndbackend"
+	"github.com/lightninglabs/darepo-client/txconfirm"
+	"github.com/lightninglabs/darepo-client/walletcore"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/stretchr/testify/require"
+)
+
+// fundedUTXOAmount is the value funded into each LND wallet UTXO used by the
+// package-relay test. It is comfortably larger than any plausible CPFP child
+// fee so the broadcaster's fee-input selection always succeeds.
+const fundedUTXOAmount = btcutil.Amount(1_000_000)
+
+// lndPackageWallet adapts the harness LND services to txconfirm.Wallet. It
+// mirrors the production lndUnrollWallet (darepod/server.go): UTXO
+// enumeration and leasing come from the boarding backend, fresh change
+// scripts and PSBT finalization from the WalletKit.
+type lndPackageWallet struct {
+	*lndbackend.BoardingBackend
+}
+
+// NewWalletPkScript returns a fresh wallet-managed taproot pkScript.
+func (w *lndPackageWallet) NewWalletPkScript(ctx context.Context) ([]byte,
+	error) {
+
+	addr, err := w.WalletKit().NextAddr(
+		ctx, lnwallet.DefaultAccountName,
+		walletrpc.AddressType_TAPROOT_PUBKEY, true,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return txscript.PayToAddrScript(addr)
+}
+
+// FinalizePsbt signs and finalizes a PSBT via LND's WalletKit.
+func (w *lndPackageWallet) FinalizePsbt(ctx context.Context,
+	packetBytes []byte) (*wire.MsgTx, error) {
+
+	packet, err := psbt.NewFromRawBytes(bytes.NewReader(packetBytes), false)
+	if err != nil {
+		return nil, err
+	}
+
+	_, finalTx, err := w.WalletKit().FinalizePsbt(ctx, packet, "")
+
+	return finalTx, err
+}
+
+// TestEsploraPackageRelayUnrollBroadcast proves that the Esplora-backed
+// package submitter can broadcast the kind of transaction a unilateral exit
+// produces — a zero-fee v3 (TRUC) parent carrying an ephemeral anchor — by
+// driving the real txconfirm.CPFPBroadcaster against the harness's electrs
+// `/txs/package` endpoint. This is the end-to-end confidence check for using
+// the Esplora relay path for unroll on the lnd / neutrino backends, which
+// cannot relay such packages on their own (darepo-client#590).
+//
+// The parent pays zero fee (its outputs sum to its single input), so it can
+// only confirm via a CPFP child carried in a package. If the package confirms,
+// Esplora package relay worked.
+func TestEsploraPackageRelayUnrollBroadcast(t *testing.T) {
+	h := NewSysTestHarness(t)
+	ctx := h.Context()
+
+	// Fund two confirmed LND UTXOs: one to build the zero-fee anchor
+	// parent, one for the broadcaster to select as the CPFP child fee
+	// input.
+	h.Harness.FundOperatorLND(fundedUTXOAmount)
+	h.Harness.FundOperatorLND(fundedUTXOAmount)
+	h.WaitForLNDSync()
+
+	lnd := h.Harness.LND
+	wlt := &lndPackageWallet{
+		BoardingBackend: lndbackend.NewBoardingBackend(
+			lnd.WalletKit, lnd.ChainKit,
+		),
+	}
+
+	// Build the LND chain backend with the Esplora package submitter wired
+	// in, exactly as cmd/darepod does via package.esploraurl.
+	backendCfg := chainbackends.LNDBackendFromLndClientConfig{LND: lnd}
+	backend := chainbackends.NewLNDBackendFromLndClient(
+		backendCfg.WithLogger(
+			h.SubLogger(chainbackends.LndClientSubsystem),
+		),
+	)
+	submitter, err := esplorarpc.New(
+		h.Harness.EsploraURL,
+		esplorarpc.WithLog(
+			h.SubLogger("ESPL"),
+		),
+	)
+	require.NoError(t, err)
+	backend.SetPackageSubmitter(submitter)
+
+	require.NoError(t, backend.Start())
+	t.Cleanup(func() { _ = backend.Stop() })
+
+	chainActor := chainsource.NewChainSourceActor(
+		chainsource.ChainSourceConfig{
+			Backend: backend,
+			System:  h.ActorSystem(),
+		}.WithLogger(h.SubLogger(chainsource.Subsystem)),
+	)
+	chainRef := actor.RegisterWithSystem(
+		h.ActorSystem(),
+		"chain-source", actor.NewServiceKey[
+			chainsource.ChainSourceMsg, chainsource.ChainSourceResp,
+		](
+			"chain-source",
+		),
+		chainActor,
+	)
+
+	// Pick the parent-input UTXO and lease it so the broadcaster's
+	// fee-input selection picks the other UTXO rather than double-spending
+	// the parent's input.
+	utxos, err := wlt.ListUnspent(ctx, 1, math.MaxInt32)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(utxos), 2, "need >=2 confirmed UTXOs")
+
+	parentInput := utxos[0]
+
+	var lockID walletcore.LockID
+	copy(lockID[:], "systest-esplora-package-relay")
+	_, err = wlt.LeaseOutput(ctx, lockID, parentInput.Outpoint, time.Hour)
+	require.NoError(t, err)
+
+	// Build a zero-fee v3 parent with an ephemeral anchor: the exact shape
+	// of an unroll proof/sweep parent. The single non-anchor output equals
+	// the input value, so the parent pays zero fee and cannot relay alone.
+	changeScript, err := wlt.NewWalletPkScript(ctx)
+	require.NoError(t, err)
+
+	parent := wire.NewMsgTx(arktx.TxVersion)
+	parent.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: parentInput.Outpoint,
+		Sequence:         wire.MaxTxInSequenceNum,
+	})
+	parent.AddTxOut(&wire.TxOut{
+		Value:    int64(parentInput.Amount),
+		PkScript: changeScript,
+	})
+	parent.AddTxOut(arkscript.AnchorOutput())
+
+	signedParent := signWalletInput(ctx, t, wlt, parent, parentInput)
+	parentTxid := signedParent.TxHash()
+
+	// Submit via the real CPFP broadcaster, which builds and signs the
+	// fee-paying child and submits the parent+child package through the
+	// chain source → LNDBackend.SubmitPackage → Esplora /txs/package.
+	broadcaster := txconfirm.NewCPFPBroadcaster(txconfirm.BroadcasterConfig{
+		ChainSource: chainRef,
+		Wallet:      wlt,
+		Log:         fn.Some(h.SubLogger("TXCF")),
+	})
+
+	result, err := broadcaster.Submit(ctx, 0, &txconfirm.BroadcastRequest{
+		Tx:    signedParent,
+		Label: "systest-esplora-unroll",
+	})
+	require.NoError(t, err, "Esplora package submission failed")
+	require.NotNil(t, result.ChildTxid, "expected a CPFP child")
+
+	// Both parent and child must reach bitcoind's mempool, proving electrs
+	// accepted the package and relayed it, then confirm in the next block.
+	h.Harness.WaitMempoolTx(parentTxid.String())
+	h.Harness.WaitMempoolTx(result.ChildTxid.String())
+	h.Harness.Generate(1)
+
+	require.Empty(
+		t, h.Harness.MempoolTxIDs(),
+		"package should have confirmed and drained the mempool",
+	)
+}
+
+// signWalletInput finalizes the single wallet input of tx via the wallet's
+// PSBT signer, returning the fully signed transaction.
+func signWalletInput(ctx context.Context, t *testing.T, w *lndPackageWallet,
+	tx *wire.MsgTx, in *walletcore.Utxo) *wire.MsgTx {
+
+	t.Helper()
+
+	op := tx.TxIn[0].PreviousOutPoint
+	packet, err := psbt.New(
+		[]*wire.OutPoint{&op}, tx.TxOut, tx.Version, tx.LockTime,
+		[]uint32{tx.TxIn[0].Sequence},
+	)
+	require.NoError(t, err)
+
+	packet.Inputs[0].WitnessUtxo = &wire.TxOut{
+		Value:    int64(in.Amount),
+		PkScript: in.PkScript,
+	}
+
+	// FundOperatorLND hands out P2WPKH (SegWit v0) outputs, so the witness
+	// signature must carry an explicit SIGHASH_ALL byte. Without setting
+	// the PSBT sighash type, LND finalizes a witness bitcoind rejects with
+	// "Signature hash type missing or not understood". The production CPFP
+	// path sets it the same way via cpfpFeeInputSighash.
+	packet.Inputs[0].SighashType = txscript.SigHashAll
+
+	var buf bytes.Buffer
+	require.NoError(t, packet.Serialize(&buf))
+
+	signed, err := w.FinalizePsbt(ctx, buf.Bytes())
+	require.NoError(t, err)
+
+	return signed
+}


### PR DESCRIPTION


## Update: scope the startup warning to lnd (addresses #678)

Folded in a follow-up commit (`cmd/darepod: Scope no-package-relay warning to lnd backend`) that narrows the missing-submitter startup warning. It previously fired for both `lnd` and `btcwallet`; the `btcwallet` (neutrino SPV) backend relays the zero-fee parent + CPFP child over P2P 1p1c with no submitter, so warning it was a false alarm. The warning now only fires for the `lnd` backend (the one config that can actually strand an exit when backed by bitcoind), and `warnIfNoPackagePath` was refactored into a unit-tested `packageRelayWarning` helper.
