### PR TITLE
docs: nightly doc-gardening sweep 2026-06-03

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,6 +50,7 @@ package may import from a higher layer.
 | [`db`](db/) | SQLite/PostgreSQL persistence: boarding, rounds, VTXOs, OOR artifacts, fee ledger |
 | [`mailbox`](mailbox/) | Mailbox protocol primitives across three sub-packages (pb, rpc, conn) |
 | [`serverconn`](serverconn/) | Unified server connector: durable egress, ingress polling, unary RPC facade |
+| [`serverconn/mailboxpull`](serverconn/mailboxpull/) | Shared retry-and-backoff primitives for mailbox pull loops; used by both `serverconn` ingress and `sdk/swaps` event consumers |
 
 ### Layer 3: Application & Orchestration
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -3,9 +3,11 @@
 ## Purpose
 
 Build, verification, and maintenance scripts including schema registry
-verification, commit message linting, and documentation cross-link validation.
+verification, commit message linting, documentation cross-link validation,
+and sample config consistency checking.
 
 ## Relationships
 
 - **Depends on**: nothing.
-- **Depended on by**: Makefile targets (`make doc-check`, `make commitmsg-lint`, `make schema-check`).
+- **Depended on by**: Makefile targets (`make doc-check`, `make commitmsg-lint`,
+  `make schema-check`, `make sample-conf-check`).

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -3,9 +3,11 @@
 ## Purpose
 
 Build, verification, and maintenance scripts including schema registry
-verification, commit message linting, and documentation cross-link validation.
+verification, commit message linting, documentation cross-link validation,
+and sample config consistency checking.
 
 ## Relationships
 
 - **Depends on**: nothing.
-- **Depended on by**: Makefile targets (`make doc-check`, `make commitmsg-lint`, `make schema-check`).
+- **Depended on by**: Makefile targets (`make doc-check`, `make commitmsg-lint`,
+  `make schema-check`, `make sample-conf-check`).

--- a/scripts/check-sample-darepod-conf/AGENTS.md
+++ b/scripts/check-sample-darepod-conf/AGENTS.md
@@ -1,0 +1,47 @@
+# check-sample-darepod-conf
+
+## Purpose
+
+CI tool (invoked via `make sample-conf-check`) that verifies
+`sample-darepod.conf` documents every daemon config option with the correct
+current default value. Fails if any key is missing, stale, or carries a
+wrong default, keeping the sample file in sync with `darepod.DefaultConfig`
+and the daemon CLI flags.
+
+## Key Types
+
+All symbols are package-private; the binary exposes only `main`.
+
+- `expectedConfigKeys` — Extracts config keys and default values from
+  `darepod.DefaultConfig()` by reflecting over `mapstructure` struct tags.
+- `addDaemonFlagKeys` — Augments the expected map with CLI-only flags
+  (e.g. `bitcoind.*`) by parsing `darepod --help` output and cross-checking
+  against flags registered in `cmd/darepod/main.go`.
+- `parseSampleConfig` — Reads commented `# key=value` lines from the sample
+  file; rejects any live (uncommented) config line.
+- `checkSampleConfig` — Reports three failure classes: missing keys, stale
+  keys, and default-value mismatches.
+- `daemonFlag` — Holds one CLI flag name and its default value as parsed from
+  help output.
+
+## Relationships
+
+- **Depends on**: `darepod` (`DefaultConfig()`).
+- **Depended on by**: Makefile target `make sample-conf-check`.
+- **Sends**: nothing.
+- **Receives**: nothing.
+
+## Invariants
+
+- All entries in `sample-darepod.conf` must remain commented; live config
+  lines cause `parseSampleConfig` to fail immediately.
+- Every flag registered in `cmd/darepod/main.go` must appear in
+  `darepod --help`; a mismatch causes `addDaemonFlagKeys` to return an error
+  so parser drift is caught early rather than silently producing a stale map.
+- The tool does not modify any files; it is read-only and exits non-zero on
+  any discrepancy.
+
+## Deep Docs
+
+- [scripts/CLAUDE.md](../CLAUDE.md) — Parent scripts package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/scripts/check-sample-darepod-conf/CLAUDE.md
+++ b/scripts/check-sample-darepod-conf/CLAUDE.md
@@ -1,0 +1,47 @@
+# check-sample-darepod-conf
+
+## Purpose
+
+CI tool (invoked via `make sample-conf-check`) that verifies
+`sample-darepod.conf` documents every daemon config option with the correct
+current default value. Fails if any key is missing, stale, or carries a
+wrong default, keeping the sample file in sync with `darepod.DefaultConfig`
+and the daemon CLI flags.
+
+## Key Types
+
+All symbols are package-private; the binary exposes only `main`.
+
+- `expectedConfigKeys` — Extracts config keys and default values from
+  `darepod.DefaultConfig()` by reflecting over `mapstructure` struct tags.
+- `addDaemonFlagKeys` — Augments the expected map with CLI-only flags
+  (e.g. `bitcoind.*`) by parsing `darepod --help` output and cross-checking
+  against flags registered in `cmd/darepod/main.go`.
+- `parseSampleConfig` — Reads commented `# key=value` lines from the sample
+  file; rejects any live (uncommented) config line.
+- `checkSampleConfig` — Reports three failure classes: missing keys, stale
+  keys, and default-value mismatches.
+- `daemonFlag` — Holds one CLI flag name and its default value as parsed from
+  help output.
+
+## Relationships
+
+- **Depends on**: `darepod` (`DefaultConfig()`).
+- **Depended on by**: Makefile target `make sample-conf-check`.
+- **Sends**: nothing.
+- **Receives**: nothing.
+
+## Invariants
+
+- All entries in `sample-darepod.conf` must remain commented; live config
+  lines cause `parseSampleConfig` to fail immediately.
+- Every flag registered in `cmd/darepod/main.go` must appear in
+  `darepod --help`; a mismatch causes `addDaemonFlagKeys` to return an error
+  so parser drift is caught early rather than silently producing a stale map.
+- The tool does not modify any files; it is read-only and exits non-zero on
+  any discrepancy.
+
+## Deep Docs
+
+- [scripts/CLAUDE.md](../CLAUDE.md) — Parent scripts package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/serverconn/mailboxpull/AGENTS.md
+++ b/serverconn/mailboxpull/AGENTS.md
@@ -1,0 +1,55 @@
+# mailboxpull
+
+## Purpose
+
+Shared retry-and-backoff primitives for mailbox pull loops. Factors out
+the common shape needed by the persistent identity-mailbox ingress loop in
+`serverconn` and by per-swap event consumers in `sdk/swaps`, so reliability
+semantics (delay schedule, jitter, context-cancel precedence) stay uniform
+across both consumers.
+
+## Key Types
+
+- `BackoffConfig` — Exponential backoff parameters (`BaseDelay`, `MaxDelay`);
+  zero value selects safe defaults (200 ms base, 30 s cap).
+- `RetryDelay(cfg, attempt)` — Returns an exponential backoff duration with
+  jitter in [0.5, 1.0), capped at `MaxDelay`.
+- `Sleep(ctx, cfg, attempt*)` — Increments the attempt counter and sleeps for
+  the next backoff interval, aborting on context cancellation.
+- `PullWithRetry(ctx, edge, req, cfg, log)` — Calls `MailboxServiceClient.Pull`
+  in a loop, retrying transport errors with exponential backoff until a
+  successful response or context done.
+- `DefaultBackoffConfig()` — Returns production defaults (200 ms / 30 s),
+  mirroring `serverconn.DefaultConnectorConfig` so both pull paths back off
+  identically when the shared mailbox endpoint is flapping.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (`MailboxServiceClient`, `PullRequest`,
+  `PullResponse`), `btclog` (structured warning on retry).
+- **Depended on by**: `serverconn` (ingress loop in `ingress.go`),
+  `sdk/swaps` (per-swap event consumer in `out_swap_mailbox.go`).
+- **Sends**: nothing — pure utility, no actor messages.
+- **Receives**: nothing — callers pass in a ready `MailboxServiceClient`.
+
+## Invariants
+
+- Only transport errors trigger retries; status-level failures
+  (`resp.Status` non-nil with `Ok=false`) are returned to the caller
+  unchanged — the caller decides whether to surface or retry.
+- On context cancellation, `PullWithRetry` returns `ctx.Err()`, not the
+  underlying transport error, even when the cancel arrives between a
+  failed Pull and the next sleep. This asymmetry is intentional: callers
+  further up the stack treat `context.Canceled` as a clean shutdown, not
+  a swap failure.
+- The attempt counter is owned and reset by the caller; a success should
+  reset it to 0 so the next failure starts from the base delay rather
+  than an already-accumulated exponent.
+
+## Deep Docs
+
+- [serverconn/README.md](../README.md) — Parent package architecture, ingress
+  loop design.
+- [docs/mailbox_architecture.md](../../docs/mailbox_architecture.md) —
+  Three-layer mailbox system.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/serverconn/mailboxpull/CLAUDE.md
+++ b/serverconn/mailboxpull/CLAUDE.md
@@ -1,0 +1,55 @@
+# mailboxpull
+
+## Purpose
+
+Shared retry-and-backoff primitives for mailbox pull loops. Factors out
+the common shape needed by the persistent identity-mailbox ingress loop in
+`serverconn` and by per-swap event consumers in `sdk/swaps`, so reliability
+semantics (delay schedule, jitter, context-cancel precedence) stay uniform
+across both consumers.
+
+## Key Types
+
+- `BackoffConfig` — Exponential backoff parameters (`BaseDelay`, `MaxDelay`);
+  zero value selects safe defaults (200 ms base, 30 s cap).
+- `RetryDelay(cfg, attempt)` — Returns an exponential backoff duration with
+  jitter in [0.5, 1.0), capped at `MaxDelay`.
+- `Sleep(ctx, cfg, attempt*)` — Increments the attempt counter and sleeps for
+  the next backoff interval, aborting on context cancellation.
+- `PullWithRetry(ctx, edge, req, cfg, log)` — Calls `MailboxServiceClient.Pull`
+  in a loop, retrying transport errors with exponential backoff until a
+  successful response or context done.
+- `DefaultBackoffConfig()` — Returns production defaults (200 ms / 30 s),
+  mirroring `serverconn.DefaultConnectorConfig` so both pull paths back off
+  identically when the shared mailbox endpoint is flapping.
+
+## Relationships
+
+- **Depends on**: `mailbox/pb` (`MailboxServiceClient`, `PullRequest`,
+  `PullResponse`), `btclog` (structured warning on retry).
+- **Depended on by**: `serverconn` (ingress loop in `ingress.go`),
+  `sdk/swaps` (per-swap event consumer in `out_swap_mailbox.go`).
+- **Sends**: nothing — pure utility, no actor messages.
+- **Receives**: nothing — callers pass in a ready `MailboxServiceClient`.
+
+## Invariants
+
+- Only transport errors trigger retries; status-level failures
+  (`resp.Status` non-nil with `Ok=false`) are returned to the caller
+  unchanged — the caller decides whether to surface or retry.
+- On context cancellation, `PullWithRetry` returns `ctx.Err()`, not the
+  underlying transport error, even when the cancel arrives between a
+  failed Pull and the next sleep. This asymmetry is intentional: callers
+  further up the stack treat `context.Canceled` as a clean shutdown, not
+  a swap failure.
+- The attempt counter is owned and reset by the caller; a success should
+  reset it to 0 so the next failure starts from the base delay rather
+  than an already-accumulated exponent.
+
+## Deep Docs
+
+- [serverconn/README.md](../README.md) — Parent package architecture, ingress
+  loop design.
+- [docs/mailbox_architecture.md](../../docs/mailbox_architecture.md) —
+  Three-layer mailbox system.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.


### PR DESCRIPTION
## Summary

Automated nightly documentation sweep for 2026-06-03.

- Added `serverconn/mailboxpull/CLAUDE.md` and `AGENTS.md`: new package
  providing shared retry-and-backoff primitives for mailbox pull loops,
  used by both `serverconn` ingress and `sdk/swaps` event consumers.
- Added `scripts/check-sample-darepod-conf/CLAUDE.md` and `AGENTS.md`:
  CI tool (`make sample-conf-check`) that verifies `sample-darepod.conf`
  matches daemon config defaults.
- Updated `scripts/CLAUDE.md` / `AGENTS.md` to mention `sample-conf-check`.
- Updated `ARCHITECTURE.md` to list `serverconn/mailboxpull` in Layer 2.

Please review the updated `CLAUDE.md`/`AGENTS.md` and `ARCHITECTURE.md` diffs.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)