### PR TITLE
swapwallet: hide exact-input funding rows

### DIFF
--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -568,10 +568,9 @@ type swapOORCorrelations struct {
 }
 
 // swapOORCorrelationsFromSwaps indexes swap session ids by the internal OOR leg
-// they explain. Pay swaps hide their funding input only when the same funding
-// session returns change and the delta equals the swap amount. Receive swaps
-// hide their claim input only when the same claim session materializes a wallet
-// VTXO.
+// they explain. Pay swaps hide their funding input when the session plus net
+// outgoing amount matches the swap amount. Receive swaps hide their claim input
+// only when the same claim session materializes a wallet VTXO.
 func swapOORCorrelationsFromSwaps(
 	swaps []*swapclientrpc.SwapSummary) swapOORCorrelations {
 
@@ -667,8 +666,13 @@ func projectOORLedgerActivity(rows []*daemonrpc.TransactionHistoryEntry,
 			continue
 		}
 
+		amounts := correlations.payAmountsByFundingSession[session]
 		received := receivedBySession[session]
 		if received == 0 {
+			if consumePayFundingAmount(amounts, row.GetAmountSat()) {
+				projection.hidden[row.GetEntryId()] = struct{}{}
+			}
+
 			continue
 		}
 
@@ -684,19 +688,30 @@ func projectOORLedgerActivity(rows []*daemonrpc.TransactionHistoryEntry,
 			projection.hidden[row.GetEntryId()] = struct{}{}
 
 		case delta > 0:
-			amounts := correlations.payAmountsByFundingSession[session]
-			if amounts == nil || amounts[delta] == 0 {
+			if !consumePayFundingAmount(amounts, delta) {
 				projection.displayAmountByEntryID[row.GetEntryId()] =
 					-delta
 
 				continue
 			}
 			projection.hidden[row.GetEntryId()] = struct{}{}
-			amounts[delta]--
 		}
 	}
 
 	return projection
+}
+
+// consumePayFundingAmount matches one pay-swap amount against an OOR send leg.
+// The amount can be either the net send delta after wallet change, or the full
+// send amount when the selected input produced no change.
+func consumePayFundingAmount(amounts map[int64]int, amount int64) bool {
+	if amounts[amount] == 0 {
+		return false
+	}
+
+	amounts[amount]--
+
+	return true
 }
 
 // internalZeroDeltaSession reports whether a balanced same-session OOR

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -530,6 +530,62 @@ func TestHistoryHidesPayFundingOORInput(t *testing.T) {
 	require.Equal(t, int64(-1_234), entries[0].GetAmountSat())
 }
 
+// TestHistoryHidesPayFundingOORInputWithoutChange confirms wallet activity
+// hides a pay-swap funding send even when the selected input exactly matches
+// the vHTLC amount and therefore produces no wallet change row.
+func TestHistoryHidesPayFundingOORInputWithoutChange(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+
+	sessionID := testBytes(32, 0x22)
+	sessionHex := testSessionString(t, sessionID)
+
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{
+		Swaps: []*swapclientrpc.SwapSummary{
+			{
+				PaymentHash: "payment-hash",
+				Direction: swapclientrpc.
+					SwapDirection_SWAP_DIRECTION_PAY,
+				State: swapclientrpc.
+					SwapState_SWAP_STATE_REFUNDED,
+				AmountSat:        42_000,
+				UpdatedAtUnix:    200,
+				FundingSessionId: sessionHex,
+			},
+		},
+	}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:           "oor",
+				Subtype:        ledger.EventVTXOSent,
+				AmountSat:      42_000,
+				DebitAccount:   ledger.AccountTransfersOut,
+				CreditAccount:  ledger.AccountVTXOBalance,
+				SessionId:      sessionID,
+				EntryId:        15,
+				CreatedAtUnixS: 100,
+			},
+		},
+	}
+
+	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{})
+	require.NoError(t, err)
+
+	entries := resp.GetActivity().GetEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, "payment-hash", entries[0].GetId())
+	require.Equal(
+		t, walletdkrpc.EntryKind_ENTRY_KIND_SEND, entries[0].GetKind(),
+	)
+	require.Equal(t, int64(-42_000), entries[0].GetAmountSat())
+	require.Equal(
+		t, walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_REFUNDED,
+		entries[0].GetProgress().GetPhase(),
+	)
+}
+
 // TestHistoryHidesPayRefundOORSession confirms the cooperative refund OOR
 // created for a failed pay swap stays internal to the swap row. The wallet
 // activity entry should be the refunded payment hash, not a synthetic


### PR DESCRIPTION
## Summary

Fixes #669 by hiding pay-swap funding OOR ledger rows when the selected input exactly matches the vHTLC amount and therefore produces no wallet change row.

The issue screenshot already has the correct user-facing swap rows: the payment attempts are represented by `SEND ... refunded` entries. We do not need to add a separate refund/receive activity row. The confusing part was the extra `ledger-*` rows leaking through as pending sends.

## Root Cause

The existing activity-feed filter hid pay-swap funding OOR rows when the same OOR session also had a wallet receive/change row. That works for the usual case:

- OOR send spends a larger VTXO.
- OOR receive returns wallet change.
- The net outgoing delta equals the swap amount.
- The internal funding row is hidden.

But exact-input funding has no wallet change row:

- OOR send amount equals the swap amount.
- No paired receive/change row exists.
- The old filter skipped the session because `received == 0`.
- The internal funding row leaked into activity as `ledger-N` / `payment_detected`.

## Fix

When there is no receive/change row, still hide the OOR send row if structured swap metadata proves that:

- the row's OOR session matches a pay swap funding session, and
- the row amount matches that swap amount.

Ordinary user OOR sends remain visible because this path still requires the swap funding session correlation; it does not hide by amount alone.

## Validation

- Added a regression test that first reproduced the leaked shape: one refunded swap row plus a pending `ledger-*` send for the same amount.
- Verified the activity feed now shows only the refunded swap row.

Commands run locally:

```bash
make fmt-changed-check base=origin/main
make commitmsg-lint commit=HEAD
go test -tags='dev walletdkrpc swapruntime nolog' ./swapwallet -count=1
```
