### PR TITLE
swapwallet: require unlock before wallet verbs

### DIFF
--- a/cmd/darepocli/darepoclicommands/error_format.go
+++ b/cmd/darepocli/darepoclicommands/error_format.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -12,6 +13,7 @@ import (
 const (
 	defaultErrorCode = "EXECUTION_FAILED"
 	invalidArgsCode  = "INVALID_ARGS"
+	walletLockedCode = "WALLET_LOCKED"
 )
 
 type commandError struct {
@@ -54,6 +56,10 @@ func formatCommandError(err error) commandError {
 		}
 	}
 
+	if daemonrpc.IsWalletNotReadyError(err) {
+		return formatWalletNotReadyError(err)
+	}
+
 	if rpcErr, ok := parseRPCErrorChain(err.Error()); ok {
 		return commandError{
 			code:    grpcCodeNameToCLI(rpcErr.code),
@@ -72,6 +78,28 @@ func formatCommandError(err error) commandError {
 	return commandError{
 		code:    defaultErrorCode,
 		message: err.Error(),
+	}
+}
+
+// formatWalletNotReadyError gives wallet lifecycle preconditions the
+// actionable CLI wording users need instead of a raw gRPC status string.
+func formatWalletNotReadyError(err error) commandError {
+	msg := "wallet is not ready; check `darepocli getinfo`"
+	state, _ := daemonrpc.WalletNotReadyState(err)
+	switch state {
+	case daemonrpc.WalletNotReadyStateNone:
+		msg = "wallet is not created; run `darepocli create`"
+
+	case daemonrpc.WalletNotReadyStateLocked:
+		msg = "wallet is locked; run `darepocli unlock`"
+
+	case daemonrpc.WalletNotReadyStateSyncing:
+		msg = "wallet is syncing; try again once sync completes"
+	}
+
+	return commandError{
+		code:    walletLockedCode,
+		message: msg,
 	}
 }
 

--- a/cmd/darepocli/darepoclicommands/root_test.go
+++ b/cmd/darepocli/darepoclicommands/root_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -79,6 +80,53 @@ func TestPrintCommandErrorAddsStatusWrapperDetails(t *testing.T) {
 		}
 	}`
 	require.JSONEq(t, expected, buf.String())
+}
+
+func TestPrintCommandErrorMapsWalletNotReadyToStateHint(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		state string
+		msg   string
+	}{
+		{
+			name:  "none",
+			state: daemonrpc.WalletNotReadyStateNone,
+			msg:   "wallet is not created; run `darepocli create`",
+		},
+		{
+			name:  "locked",
+			state: daemonrpc.WalletNotReadyStateLocked,
+			msg:   "wallet is locked; run `darepocli unlock`",
+		},
+		{
+			name:  "syncing",
+			state: daemonrpc.WalletNotReadyStateSyncing,
+			msg: "wallet is syncing; try again once sync " +
+				"completes",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := fmt.Errorf("recv invoice: %w",
+				daemonrpc.WalletNotReadyStateError(
+					"wallet is not ready", tc.state,
+				))
+
+			var buf bytes.Buffer
+			require.NoError(t, printCommandError(&buf, err))
+
+			const expectedTemplate = `{"error":{"code":` +
+				`"WALLET_LOCKED","message":%q}}`
+			expected := fmt.Sprintf(expectedTemplate, tc.msg)
+			require.JSONEq(t, expected, buf.String())
+		})
+	}
 }
 
 func TestPrintCommandErrorHandlesBareGRPCStatus(t *testing.T) {

--- a/daemonrpc/errors.go
+++ b/daemonrpc/errors.go
@@ -12,16 +12,48 @@ const (
 	// WalletNotReadyReason identifies gRPC FailedPrecondition errors
 	// caused by a daemon wallet lifecycle state that is not yet usable.
 	WalletNotReadyReason = "WALLET_NOT_READY"
+
+	// WalletNotReadyStateKey is the ErrorInfo metadata key carrying
+	// the specific daemon wallet lifecycle state when the caller needs
+	// a more precise user-facing hint.
+	WalletNotReadyStateKey = "wallet_state"
+
+	// WalletNotReadyStateNone indicates no wallet has been created.
+	WalletNotReadyStateNone = "none"
+
+	// WalletNotReadyStateLocked indicates an encrypted wallet exists
+	// but has not been unlocked.
+	WalletNotReadyStateLocked = "locked"
+
+	// WalletNotReadyStateSyncing indicates the wallet has been
+	// unlocked but is not yet ready to sign.
+	WalletNotReadyStateSyncing = "syncing"
+
+	// WalletNotReadyStateUnknown indicates the daemon reported an
+	// unrecognized or unspecified wallet lifecycle state.
+	WalletNotReadyStateUnknown = "unknown"
 )
 
 // WalletNotReadyError returns a structured gRPC error for wallet lifecycle
 // preconditions. The human message may change, but callers should match the
 // stable ErrorInfo reason with IsWalletNotReadyError.
 func WalletNotReadyError(msg string) error {
+	return WalletNotReadyStateError(msg, "")
+}
+
+// WalletNotReadyStateError returns a structured wallet lifecycle precondition
+// and includes the stable wallet_state metadata when state is non-empty.
+func WalletNotReadyStateError(msg string, state string) error {
 	st := status.New(codes.FailedPrecondition, msg)
+	metadata := map[string]string{}
+	if state != "" {
+		metadata[WalletNotReadyStateKey] = state
+	}
+
 	st, err := st.WithDetails(&errdetails.ErrorInfo{
-		Reason: WalletNotReadyReason,
-		Domain: walletNotReadyDomain,
+		Reason:   WalletNotReadyReason,
+		Domain:   walletNotReadyDomain,
+		Metadata: metadata,
 	})
 	if err != nil {
 		return status.Error(codes.FailedPrecondition, msg)
@@ -33,9 +65,28 @@ func WalletNotReadyError(msg string) error {
 // IsWalletNotReadyError reports whether err is the structured wallet lifecycle
 // precondition returned by WalletNotReadyError.
 func IsWalletNotReadyError(err error) bool {
+	_, ok := walletNotReadyInfo(err)
+
+	return ok
+}
+
+// WalletNotReadyState returns the stable wallet_state metadata carried by a
+// structured wallet lifecycle precondition, when present.
+func WalletNotReadyState(err error) (string, bool) {
+	info, ok := walletNotReadyInfo(err)
+	if !ok {
+		return "", false
+	}
+
+	state, ok := info.GetMetadata()[WalletNotReadyStateKey]
+
+	return state, ok
+}
+
+func walletNotReadyInfo(err error) (*errdetails.ErrorInfo, bool) {
 	st, ok := status.FromError(err)
 	if !ok || st.Code() != codes.FailedPrecondition {
-		return false
+		return nil, false
 	}
 
 	for _, detail := range st.Details() {
@@ -46,9 +97,9 @@ func IsWalletNotReadyError(err error) bool {
 
 		if info.GetDomain() == walletNotReadyDomain &&
 			info.GetReason() == WalletNotReadyReason {
-			return true
+			return info, true
 		}
 	}
 
-	return false
+	return nil, false
 }

--- a/daemonrpc/errors_test.go
+++ b/daemonrpc/errors_test.go
@@ -13,11 +13,30 @@ import (
 func TestWalletNotReadyErrorMatchesStructuredReason(t *testing.T) {
 	t.Parallel()
 
-	err := WalletNotReadyError("custom readiness wording")
+	err := WalletNotReadyStateError(
+		"custom readiness wording", WalletNotReadyStateLocked,
+	)
 
 	require.True(t, IsWalletNotReadyError(err))
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
 	require.Contains(t, err.Error(), "custom readiness wording")
+
+	state, ok := WalletNotReadyState(err)
+	require.True(t, ok)
+	require.Equal(t, WalletNotReadyStateLocked, state)
+}
+
+// TestWalletNotReadyErrorAllowsMissingState verifies older callers can still
+// emit the coarse wallet-not-ready reason without state metadata.
+func TestWalletNotReadyErrorAllowsMissingState(t *testing.T) {
+	t.Parallel()
+
+	err := WalletNotReadyError("custom readiness wording")
+
+	require.True(t, IsWalletNotReadyError(err))
+
+	_, ok := WalletNotReadyState(err)
+	require.False(t, ok)
 }
 
 // TestIsWalletNotReadyErrorRejectsPlainFailedPrecondition verifies unrelated

--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -118,6 +118,12 @@ func (f *fakeRPCServer) ListTransactions(_ context.Context,
 func (f *fakeRPCServer) GetInfo(_ context.Context,
 	_ *daemonrpc.GetInfoRequest) (*daemonrpc.GetInfoResponse, error) {
 
+	if f.getInfoResp == nil && f.getInfoErr == nil {
+		return &daemonrpc.GetInfoResponse{
+			WalletState: daemonrpc.WalletState_WALLET_STATE_READY,
+		}, nil
+	}
+
 	return f.getInfoResp, f.getInfoErr
 }
 

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -132,12 +132,6 @@ func (s *Service) Deposit(ctx context.Context,
 		return nil, err
 	}
 
-	if s.deps.RPCServer == nil {
-		return nil, status.Error(
-			codes.Unavailable, ErrSwapBackendUnavailable.Error(),
-		)
-	}
-
 	addrResp, err := s.deps.RPCServer.NewAddress(
 		ctx, &daemonrpc.NewAddressRequest{},
 	)

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -63,6 +63,10 @@ func (s *Service) PrepareSend(ctx context.Context,
 	req *walletdkrpc.PrepareSendRequest) (*walletdkrpc.PrepareSendResponse,
 	error) {
 
+	if err := s.requireWalletReady(ctx); err != nil {
+		return nil, err
+	}
+
 	return s.router.PrepareSend(ctx, req)
 }
 
@@ -71,6 +75,10 @@ func (s *Service) PrepareSend(ctx context.Context,
 // the existing LeaveVTXOs cooperative-exit RPC.
 func (s *Service) Send(ctx context.Context, req *walletdkrpc.SendRequest) (
 	*walletdkrpc.SendResponse, error) {
+
+	if err := s.requireWalletReady(ctx); err != nil {
+		return nil, err
+	}
 
 	return s.router.Send(ctx, req)
 }
@@ -99,6 +107,10 @@ func (s *Service) ExitStatus(ctx context.Context,
 func (s *Service) Recv(ctx context.Context, req *walletdkrpc.RecvRequest) (
 	*walletdkrpc.RecvResponse, error) {
 
+	if err := s.requireWalletReady(ctx); err != nil {
+		return nil, err
+	}
+
 	return s.recv.Recv(ctx, req)
 }
 
@@ -115,6 +127,10 @@ func (s *Service) List(ctx context.Context, req *walletdkrpc.ListRequest) (
 // constructs scripts itself.
 func (s *Service) Deposit(ctx context.Context,
 	req *walletdkrpc.DepositRequest) (*walletdkrpc.DepositResponse, error) {
+
+	if err := s.requireWalletReady(ctx); err != nil {
+		return nil, err
+	}
 
 	if s.deps.RPCServer == nil {
 		return nil, status.Error(
@@ -158,6 +174,52 @@ func (s *Service) Deposit(ctx context.Context,
 		OnchainAddress: addrResp.GetAddress(),
 		Entry:          entry,
 	}, nil
+}
+
+// requireWalletReady rejects wallet verbs that need unlocked key material
+// before they can reach swap or address-generation code paths.
+func (s *Service) requireWalletReady(ctx context.Context) error {
+	if s == nil || s.deps == nil || s.deps.RPCServer == nil {
+		return status.Error(
+			codes.Unavailable, ErrSwapBackendUnavailable.Error(),
+		)
+	}
+
+	info, err := s.deps.RPCServer.GetInfo(
+		ctx, &daemonrpc.GetInfoRequest{},
+	)
+	if err != nil {
+		return fmt.Errorf("get info: %w", err)
+	}
+
+	switch info.GetWalletState() {
+	case daemonrpc.WalletState_WALLET_STATE_READY:
+		return nil
+
+	case daemonrpc.WalletState_WALLET_STATE_NONE:
+		return daemonrpc.WalletNotReadyStateError(
+			"wallet is not ready",
+			daemonrpc.WalletNotReadyStateNone,
+		)
+
+	case daemonrpc.WalletState_WALLET_STATE_LOCKED:
+		return daemonrpc.WalletNotReadyStateError(
+			"wallet is not ready",
+			daemonrpc.WalletNotReadyStateLocked,
+		)
+
+	case daemonrpc.WalletState_WALLET_STATE_SYNCING:
+		return daemonrpc.WalletNotReadyStateError(
+			"wallet is not ready",
+			daemonrpc.WalletNotReadyStateSyncing,
+		)
+
+	default:
+		return daemonrpc.WalletNotReadyStateError(
+			"wallet is not ready",
+			daemonrpc.WalletNotReadyStateUnknown,
+		)
+	}
 }
 
 // Balance composes the unified balance summary by reading the daemon's

--- a/swapwallet/service_test.go
+++ b/swapwallet/service_test.go
@@ -3,12 +3,15 @@
 package swapwallet
 
 import (
+	"context"
 	"testing"
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // newServiceFixture builds a Service with fake deps so each gRPC handler
@@ -67,6 +70,110 @@ func TestServiceDepositReturnsAddress(t *testing.T) {
 		t, "address_issued",
 		resp.GetEntry().GetProgress().GetPhaseLabel(),
 	)
+}
+
+// TestServiceWalletVerbsRejectLockedWalletBeforeWork confirms wallet verbs
+// fail with an actionable wallet-readiness status before reaching swap or
+// address-generation work that requires unlocked key material.
+func TestServiceWalletVerbsRejectLockedWalletBeforeWork(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		call func(context.Context, *Service) error
+	}{
+		{
+			name: "prepare send",
+			call: func(ctx context.Context, svc *Service) error {
+				_, err := svc.PrepareSend(
+					ctx, &walletdkrpc.PrepareSendRequest{},
+				)
+
+				return err
+			},
+		},
+		{
+			name: "send",
+			call: func(ctx context.Context, svc *Service) error {
+				_, err := svc.Send(
+					ctx, &walletdkrpc.SendRequest{},
+				)
+
+				return err
+			},
+		},
+		{
+			name: "recv",
+			call: func(ctx context.Context, svc *Service) error {
+				_, err := svc.Recv(
+					ctx, &walletdkrpc.RecvRequest{
+						AmtSat: 50_000,
+					},
+				)
+
+				return err
+			},
+		},
+		{
+			name: "deposit",
+			call: func(ctx context.Context, svc *Service) error {
+				_, err := svc.Deposit(
+					ctx, &walletdkrpc.DepositRequest{},
+				)
+
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, swap, rpc := newServiceFixture(t)
+			rpc.getInfoResp = &daemonrpc.GetInfoResponse{
+				WalletState: daemonrpc.WalletState_WALLET_STATE_LOCKED,
+			}
+
+			err := tc.call(t.Context(), svc)
+			require.Error(t, err)
+			require.True(t, daemonrpc.IsWalletNotReadyError(err))
+			require.Equal(
+				t, codes.FailedPrecondition, status.Code(err),
+			)
+
+			state, ok := daemonrpc.WalletNotReadyState(err)
+			require.True(t, ok)
+			require.Equal(
+				t, daemonrpc.WalletNotReadyStateLocked, state,
+			)
+			require.Equal(t, 0, swap.startReceiveCalls)
+		})
+	}
+}
+
+// TestServiceRecvWithoutRPCServerReturnsUnavailable confirms the shared
+// readiness gate preserves a stable wire code for missing backend plumbing.
+func TestServiceRecvWithoutRPCServerReturnsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	swap := &fakeSwapService{}
+	deps := &Deps{
+		SwapService: swap,
+	}
+	runtime := newRuntime(t.Context(), deps)
+	t.Cleanup(runtime.stop)
+
+	svc := newService(deps, runtime)
+	_, err := svc.Recv(
+		t.Context(), &walletdkrpc.RecvRequest{
+			AmtSat: 50_000,
+		},
+	)
+	require.Error(t, err)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+	require.Equal(t, 0, swap.startReceiveCalls)
 }
 
 // TestServiceBalanceProjectsDaemonGetBalance confirms Balance pulls


### PR DESCRIPTION
## Summary

- reject wallet-facing send/recv/deposit verbs before swap/address setup when the daemon wallet is not ready
- reuse the structured daemonrpc wallet-not-ready precondition so callers can match the stable reason
- render wallet-not-ready errors in darepocli as `WALLET_LOCKED` with an actionable unlock hint

Closes #649.

## Testing

- `go test -tags='dev walletdkrpc swapruntime nolog' ./cmd/darepocli/darepoclicommands ./swapwallet -count=1`
- `make lint-changed-local`
- `make fmt-changed-check base=origin/main`
- `make commitmsg-lint range=origin/main..HEAD`
