### PR TITLE
round: prove forfeit connectors are rooted in the commitment tx

### DIFF
--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -31,7 +31,7 @@ server during round participation. These types are used across `round`, `vtxo`,
 - `MaxAncestryTreeDepth([]Ancestry) int` — Returns the largest `TreeDepth` across a slice; drives worst-case unilateral-exit timing calculations.
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
 - `BatchOutputInfo` — Batch output metadata (outpoint, value, tree root).
-- `ConnectorLeafInfo` — Connector output index and leaf info for forfeit construction.
+- `ConnectorLeafInfo` — Assigned connector leaf (outpoint + output) plus the connector-tree ancestry params (`RootOutputIndex`, `NumLeaves`, `Radix`, `LeafIndex`) the client uses to reconstruct the tree and prove the leaf descends from the commitment tx before signing the forfeit (darepo-client#681).
 - `BoardingInputSignature` — Signed boarding input for round commitment.
 - `ForfeitTxSig` — Forfeit transaction signature.
 - `OORPackageDirection` / `OORPackageLinkKind` — Enums for OOR package direction and link types.

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -31,7 +31,7 @@ server during round participation. These types are used across `round`, `vtxo`,
 - `MaxAncestryTreeDepth([]Ancestry) int` — Returns the largest `TreeDepth` across a slice; drives worst-case unilateral-exit timing calculations.
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
 - `BatchOutputInfo` — Batch output metadata (outpoint, value, tree root).
-- `ConnectorLeafInfo` — Connector output index and leaf info for forfeit construction.
+- `ConnectorLeafInfo` — Assigned connector leaf (outpoint + output) plus the connector-tree ancestry params (`RootOutputIndex`, `NumLeaves`, `Radix`, `LeafIndex`) the client uses to reconstruct the tree and prove the leaf descends from the commitment tx before signing the forfeit (darepo-client#681).
 - `BoardingInputSignature` — Signed boarding input for round commitment.
 - `ForfeitTxSig` — Forfeit transaction signature.
 - `OORPackageDirection` / `OORPackageLinkKind` — Enums for OOR package direction and link types.

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -362,6 +362,25 @@ type ConnectorLeafInfo struct {
 	// contains the value and pkScript needed to construct the forfeit
 	// transaction witness.
 	LeafOutput *wire.TxOut
+
+	// RootOutputIndex is the commitment-tx output index that this
+	// connector tree's root transaction spends. It lets the client bind
+	// the connector tree to the commitment tx it is about to sign into.
+	RootOutputIndex uint32
+
+	// NumLeaves is the total number of connector leaves in the tree this
+	// leaf belongs to. Connector trees have identical leaves, so this plus
+	// the radix and operator key fully determine the tree shape.
+	NumLeaves uint32
+
+	// Radix is the branching factor used to build the connector tree. It
+	// is not derivable from the commitment tx, so the operator must supply
+	// it for deterministic reconstruction.
+	Radix uint32
+
+	// LeafIndex is the position of this leaf within the connector tree's
+	// flattened leaf list. Zero is a valid index.
+	LeafIndex uint32
 }
 
 // BatchOutputInfo contains the information about a batch output in the

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -201,6 +201,17 @@ state transitions and validation rules live under [Invariants](#invariants).
 - `ConnectorLeafInfo.VTXOAmount` is populated from local VTXO state
   (not from the server's proto), so the forfeit penalty output equals
   the canonical local value rather than a server-supplied one.
+- **Connector ancestry is proven before any forfeit is signed**
+  (`validateConnectorAncestry`, darepo-client#681). In
+  `CommitmentTxReceivedState`, after VTXO-tree validation, each assigned
+  connector leaf is checked by deterministically reconstructing its
+  connector tree via `tree.BuildConnectorTree` from the commitment-tx
+  output at `ConnectorLeafInfo.RootOutputIndex`, the operator key, and
+  the server-supplied `NumLeaves`/`Radix`, then asserting the assigned
+  leaf is the one at `LeafIndex` (outpoint + output). Because the leaf is
+  rebuilt on top of a real commitment output, the connector is only
+  spendable once the commitment tx confirms, preserving round atomicity.
+  No connector transactions cross the wire — only the four scalars.
 - `MaxQuoteEntriesPerClient = 1024` is enforced in `FromProto` before
   allocating quote slices to prevent resource exhaustion.
 - `SubmitForfeitSigRequest` (boarding input signatures) is distinct

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -201,6 +201,17 @@ state transitions and validation rules live under [Invariants](#invariants).
 - `ConnectorLeafInfo.VTXOAmount` is populated from local VTXO state
   (not from the server's proto), so the forfeit penalty output equals
   the canonical local value rather than a server-supplied one.
+- **Connector ancestry is proven before any forfeit is signed**
+  (`validateConnectorAncestry`, darepo-client#681). In
+  `CommitmentTxReceivedState`, after VTXO-tree validation, each assigned
+  connector leaf is checked by deterministically reconstructing its
+  connector tree via `tree.BuildConnectorTree` from the commitment-tx
+  output at `ConnectorLeafInfo.RootOutputIndex`, the operator key, and
+  the server-supplied `NumLeaves`/`Radix`, then asserting the assigned
+  leaf is the one at `LeafIndex` (outpoint + output). Because the leaf is
+  rebuilt on top of a real commitment output, the connector is only
+  spendable once the commitment tx confirms, preserving round atomicity.
+  No connector transactions cross the wire — only the four scalars.
 - `MaxQuoteEntriesPerClient = 1024` is enforced in `FromProto` before
   allocating quote slices to prevent resource exhaustion.
 - `SubmitForfeitSigRequest` (boarding input signatures) is distinct

--- a/round/connector_validation_test.go
+++ b/round/connector_validation_test.go
@@ -1,0 +1,335 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/stretchr/testify/require"
+)
+
+// connectorLeafAmount is the per-leaf dust value used by the connector
+// fixtures. The exact value is irrelevant to the binding logic; it only has to
+// be positive and divide the root output value evenly.
+const connectorLeafAmount = int64(330)
+
+// newConnectorFixture builds a connector tree the way the operator would, plus
+// a commitment tx that funds its root output at rootIdx, and returns the
+// per-leaf ConnectorLeafInfo entries a client would receive over the wire. The
+// returned infos are fully valid; tests mutate copies to exercise the negative
+// paths.
+func newConnectorFixture(t *testing.T, operatorKey *btcec.PublicKey, numLeaves,
+	radix int, rootIdx uint32) (*wire.MsgTx, []*ConnectorLeafInfo) {
+
+	t.Helper()
+
+	// The connector root output script must be P2TR; derive one from a
+	// throwaway internal key.
+	internalPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	connScript, err := txscript.PayToTaprootScript(internalPriv.PubKey())
+	require.NoError(t, err)
+
+	rootOutput := &wire.TxOut{
+		Value:    int64(numLeaves) * connectorLeafAmount,
+		PkScript: connScript,
+	}
+
+	// Place the connector output at rootIdx, padding earlier indices with
+	// throwaway outputs so the index is meaningful.
+	commitmentTx := wire.NewMsgTx(3)
+	commitmentTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Index: 0},
+	})
+	for range rootIdx {
+		commitmentTx.AddTxOut(&wire.TxOut{
+			Value:    1000,
+			PkScript: []byte{txscript.OP_RETURN},
+		})
+	}
+	commitmentTx.AddTxOut(rootOutput)
+
+	rootOutpoint := wire.OutPoint{
+		Hash:  commitmentTx.TxHash(),
+		Index: rootIdx,
+	}
+
+	connTree, err := tree.BuildConnectorTree(
+		rootOutpoint, rootOutput, tree.ConnectorDescriptor{
+			PkScript:  connScript,
+			NumLeaves: numLeaves,
+			Amount:    btcutil.Amount(connectorLeafAmount),
+		}, operatorKey, radix,
+	)
+	require.NoError(t, err)
+
+	leaves := connTree.Root.GetLeafNodes()
+	require.Len(t, leaves, numLeaves)
+
+	infos := make([]*ConnectorLeafInfo, numLeaves)
+	for i, leaf := range leaves {
+		op, opErr := leaf.GetNonAnchorOutpoint()
+		require.NoError(t, opErr)
+
+		out, outErr := connectorLeafOutput(leaf)
+		require.NoError(t, outErr)
+
+		infos[i] = &ConnectorLeafInfo{
+			LeafIndex:         i,
+			ConnectorOutpoint: *op,
+			ConnectorPkScript: out.PkScript,
+			ConnectorAmount:   out.Value,
+			RootOutputIndex:   rootIdx,
+			NumLeaves:         uint32(numLeaves),
+			Radix:             uint32(radix),
+		}
+	}
+
+	return commitmentTx, infos
+}
+
+// mappingFrom wraps a single ConnectorLeafInfo in the forfeit-mapping shape
+// validateConnectorAncestry consumes, keyed by a dummy forfeited-VTXO outpoint.
+func mappingFrom(info *ConnectorLeafInfo) map[wire.OutPoint]*ConnectorLeafInfo {
+	return map[wire.OutPoint]*ConnectorLeafInfo{
+		{
+			Index: 7,
+		}: info,
+	}
+}
+
+// TestValidateConnectorAncestryAccepts verifies that connector leaves genuinely
+// rooted in the commitment tx pass validation, for both single-output and
+// multi-output (multi-leaf) rounds.
+func TestValidateConnectorAncestryAccepts(t *testing.T) {
+	t.Parallel()
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorKey := operatorPriv.PubKey()
+
+	t.Run("single leaf", func(t *testing.T) {
+		t.Parallel()
+
+		commitmentTx, infos := newConnectorFixture(
+			t, operatorKey, 1, 2, 0,
+		)
+		require.NoError(
+			t,
+			validateConnectorAncestry(
+				commitmentTx, operatorKey,
+				mappingFrom(infos[0]),
+			),
+		)
+	})
+
+	t.Run("multi leaf every index", func(t *testing.T) {
+		t.Parallel()
+
+		// Use a non-zero root index to also cover the padding path.
+		commitmentTx, infos := newConnectorFixture(
+			t, operatorKey, 5, 2, 3,
+		)
+
+		// Every assigned leaf must validate against the same tx.
+		mappings := make(map[wire.OutPoint]*ConnectorLeafInfo)
+		for i, info := range infos {
+			mappings[wire.OutPoint{Index: uint32(i)}] = info
+		}
+		require.NoError(
+			t, validateConnectorAncestry(
+				commitmentTx, operatorKey, mappings,
+			),
+		)
+	})
+
+	t.Run("no mappings is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, validateConnectorAncestry(
+			nil, nil, nil,
+		))
+	})
+}
+
+// TestValidateConnectorAncestryRejects verifies that connector leaves that do
+// not provably descend from the commitment tx — whether from an operator bug,
+// misconfiguration, or compromise — are rejected before the forfeit is signed.
+func TestValidateConnectorAncestryRejects(t *testing.T) {
+	t.Parallel()
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorKey := operatorPriv.PubKey()
+
+	// mutate returns a copy of a valid leaf info with fn applied.
+	mutate := func(info *ConnectorLeafInfo,
+		fn func(*ConnectorLeafInfo)) *ConnectorLeafInfo {
+
+		cp := *info
+		fn(&cp)
+
+		return &cp
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(info *ConnectorLeafInfo)
+	}{
+		{
+			name: "root output index out of range",
+			mutate: func(i *ConnectorLeafInfo) {
+				i.RootOutputIndex = 99
+			},
+		},
+		{
+			name: "leaf not reachable by tree",
+			mutate: func(i *ConnectorLeafInfo) {
+				i.ConnectorOutpoint.Hash[0] ^= 0xff
+			},
+		},
+		{
+			name: "wrong radix reshapes the tree",
+			mutate: func(i *ConnectorLeafInfo) {
+				i.Radix = 3
+			},
+		},
+		{
+			name: "num leaves mismatch",
+			mutate: func(i *ConnectorLeafInfo) {
+				i.NumLeaves = 4
+			},
+		},
+		{
+			name: "num leaves exceeds maximum",
+			mutate: func(i *ConnectorLeafInfo) {
+				i.NumLeaves = maxConnectorTreeLeaves + 1
+			},
+		},
+		{
+			name: "radix exceeds maximum",
+			mutate: func(i *ConnectorLeafInfo) {
+				i.Radix = maxConnectorTreeRadix + 1
+			},
+		},
+		{
+			name: "radix below minimum",
+			mutate: func(i *ConnectorLeafInfo) {
+				i.Radix = 1
+			},
+		},
+		{
+			name: "leaf index out of range",
+			mutate: func(i *ConnectorLeafInfo) {
+				i.LeafIndex = 10
+			},
+		},
+		{
+			name: "tampered connector script",
+			mutate: func(i *ConnectorLeafInfo) {
+				i.ConnectorPkScript = []byte{
+					0x51,
+					0x20,
+				}
+			},
+		},
+		{
+			name: "tampered connector amount",
+			mutate: func(i *ConnectorLeafInfo) {
+				i.ConnectorAmount = connectorLeafAmount + 1
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Rebuild against a multi-leaf tree so index/shape
+			// mutations are meaningful.
+			commitmentTx, infos := newConnectorFixture(
+				t, operatorKey, 5, 2, 0,
+			)
+			bad := mutate(infos[2], tc.mutate)
+
+			require.Error(
+				t,
+				validateConnectorAncestry(
+					commitmentTx, operatorKey,
+					mappingFrom(bad),
+				),
+			)
+		})
+	}
+
+	t.Run("leaf from a different commitment tx", func(t *testing.T) {
+		t.Parallel()
+
+		// A leaf info built against commitment A must not validate
+		// against a structurally identical commitment B with a
+		// different txid.
+		commitmentA, infosA := newConnectorFixture(
+			t, operatorKey, 3, 2, 0,
+		)
+		require.NoError(
+			t,
+			validateConnectorAncestry(
+				commitmentA, operatorKey,
+				mappingFrom(infosA[1]),
+			),
+		)
+
+		commitmentB := commitmentA.Copy()
+		commitmentB.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: wire.OutPoint{Index: 1},
+		})
+		require.NotEqual(t, commitmentA.TxHash(), commitmentB.TxHash())
+
+		require.Error(
+			t,
+			validateConnectorAncestry(
+				commitmentB, operatorKey,
+				mappingFrom(infosA[1]),
+			),
+		)
+	})
+
+	t.Run("wrong operator key reshapes the tree", func(t *testing.T) {
+		t.Parallel()
+
+		commitmentTx, infos := newConnectorFixture(
+			t, operatorKey, 3, 2, 0,
+		)
+
+		otherPriv, otherErr := btcec.NewPrivateKey()
+		require.NoError(t, otherErr)
+
+		require.Error(
+			t,
+			validateConnectorAncestry(
+				commitmentTx, otherPriv.PubKey(),
+				mappingFrom(infos[1]),
+			),
+		)
+	})
+
+	t.Run("nil connector info", func(t *testing.T) {
+		t.Parallel()
+
+		commitmentTx, _ := newConnectorFixture(
+			t, operatorKey, 1, 2, 0,
+		)
+		require.Error(
+			t,
+			validateConnectorAncestry(
+				commitmentTx, operatorKey,
+				map[wire.OutPoint]*ConnectorLeafInfo{
+					{Index: 0}: nil,
+				},
+			),
+		)
+	})
+}

--- a/round/events.go
+++ b/round/events.go
@@ -177,9 +177,8 @@ func (e *CommitmentTxBuilt) clientEventSealed() {}
 // connector output, paying the VTXO value to the operator's forfeit address.
 type ConnectorLeafInfo struct {
 	// LeafIndex is the position of this connector in the connector tree.
-	// Note that this field is NOT populated by FromProto since the
-	// server's ConnectorLeafInfo proto does not carry it. It is only
-	// set by local tree-building code. Zero is a valid index.
+	// Populated by FromProto from the server's ConnectorLeafInfo proto and
+	// also set by local tree-building code. Zero is a valid index.
 	LeafIndex int
 
 	// ConnectorOutpoint is the outpoint of the connector output in the
@@ -197,6 +196,21 @@ type ConnectorLeafInfo struct {
 	// combined with ConnectorAmount when validating that the zero-fee
 	// forfeit tx pays the full input value to the penalty output.
 	VTXOAmount btcutil.Amount
+
+	// RootOutputIndex is the commitment-tx output index that the connector
+	// tree's root transaction spends. It binds this connector leaf's tree
+	// to the commitment tx the client is about to sign into.
+	RootOutputIndex uint32
+
+	// NumLeaves is the total number of connector leaves in the tree this
+	// leaf belongs to. Together with Radix and the operator key it lets the
+	// client deterministically reconstruct the connector tree and prove the
+	// assigned leaf descends from the commitment tx (darepo-client#681).
+	NumLeaves uint32
+
+	// Radix is the branching factor used to build the connector tree. It is
+	// not derivable from the commitment tx, so the operator supplies it.
+	Radix uint32
 }
 
 // CommitmentTxValidated is emitted after the client successfully validates

--- a/round/from_proto.go
+++ b/round/from_proto.go
@@ -264,6 +264,10 @@ func (e *CommitmentTxBuilt) FromProto(p proto.Message) error {
 				ConnectorOutpoint: connOP,
 				ConnectorPkScript: leafOut.PkScript,
 				ConnectorAmount:   leafOut.Value,
+				RootOutputIndex:   info.GetRootOutputIndex(),
+				NumLeaves:         info.GetNumLeaves(),
+				Radix:             info.GetRadix(),
+				LeafIndex:         int(info.GetLeafIndex()),
 			}
 		}
 	}

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"math"
 	"slices"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
@@ -1719,6 +1722,33 @@ func (s *CommitmentTxReceivedState) ProcessEvent(ctx context.Context,
 			slog.Int("vtxo_tree_count", len(s.VTXOTreePaths)),
 		)
 
+		// Before carrying the forfeit mappings forward to signing,
+		// prove that each assigned connector leaf descends from this
+		// round's commitment tx. Without this an inconsistent or
+		// compromised operator could hand us a connector leaf that
+		// exists independently of the commitment tx; signing the
+		// forfeit over it would make the old VTXO claimable even if
+		// the replacement round never commits, breaking round
+		// atomicity (darepo-client#681).
+		//
+		//nolint:contextcheck // Connector-tree reconstruction is pure,
+		// deterministic CPU work (the lib/tree materializer ignores its
+		// context); there is no I/O to cancel, so no context to thread.
+		if err := validateConnectorAncestry(
+			s.CommitmentTx.UnsignedTx, env.OperatorTerms.PubKey,
+			evt.ForfeitMappings,
+		); err != nil {
+			// Error carried into failed state.
+			return &ClientStateTransition{ //nolint:nilerr
+				NextState: &ClientFailedState{
+					Reason: "connector ancestry " +
+						"validation failed",
+					Error:       err,
+					Recoverable: false,
+				},
+			}, nil
+		}
+
 		forfeitMappings, err := populateForfeitMappingAmounts(
 			evt.ForfeitMappings, s.Intents.Forfeits,
 		)
@@ -2703,6 +2733,231 @@ func populateForfeitMappingAmounts(
 	}
 
 	return populated, nil
+}
+
+const (
+	// maxConnectorTreeLeaves bounds the number of connector leaves the
+	// client will reconstruct from an operator-supplied NumLeaves. A
+	// connector tree carries one leaf per forfeited VTXO assigned to its
+	// connector output, so even very large rounds stay far below this.
+	// The cap exists only to bound reconstruction memory so a malformed or
+	// malicious leaf count cannot drive an out-of-memory DoS; 2^16 is far
+	// above any realistic round while keeping reconstruction cheap.
+	maxConnectorTreeLeaves = 1 << 16
+
+	// maxConnectorTreeRadix bounds the operator-supplied connector tree
+	// branching factor. Real connector trees use a small radix (binary by
+	// default); this generous ceiling rejects nonsensical values without
+	// constraining any plausible operator configuration.
+	maxConnectorTreeRadix = 1 << 10
+)
+
+// validateConnectorAncestry proves that every operator-supplied connector leaf
+// the client is about to forfeit against descends from an output of this
+// round's commitment tx. Connector trees have identical leaves and a
+// deterministic BFS layout, so the client reconstructs the exact tree from the
+// scalars the operator sent (root output index, leaf count, radix) plus the
+// committed connector output and the operator key — no tree transactions cross
+// the wire — and asserts the assigned leaf is the one at the claimed index.
+//
+// Binding the connector to the commitment tx is what preserves round
+// atomicity: a connector leaf is only ever spendable once the commitment tx
+// confirms, so the old VTXO cannot be forfeited unless the replacement round
+// also commits (darepo-client#681).
+func validateConnectorAncestry(commitmentTx *wire.MsgTx,
+	operatorKey *btcec.PublicKey,
+	mappings map[wire.OutPoint]*ConnectorLeafInfo) error {
+
+	if len(mappings) == 0 {
+		return nil
+	}
+
+	switch {
+	case commitmentTx == nil:
+		return fmt.Errorf("commitment tx is nil")
+
+	case operatorKey == nil:
+		return fmt.Errorf("operator key is nil")
+	}
+
+	commitmentTxID := commitmentTx.TxHash()
+
+	for vtxoOutpoint, info := range mappings {
+		if info == nil {
+			return fmt.Errorf("nil connector info for %s",
+				vtxoOutpoint)
+		}
+
+		if err := verifyConnectorLeaf(
+			commitmentTx, commitmentTxID, operatorKey, info,
+		); err != nil {
+			return fmt.Errorf("connector for forfeited VTXO %s: %w",
+				vtxoOutpoint, err)
+		}
+	}
+
+	return nil
+}
+
+// verifyConnectorLeaf reconstructs the connector tree rooted at the commitment
+// tx output named by info.RootOutputIndex and confirms that info's assigned
+// connector leaf (outpoint + output) is the leaf at info.LeafIndex of that
+// tree. Reconstruction uses the same deterministic builder as the operator, so
+// any divergence in the leaf data, root output, leaf count, radix, or operator
+// key is caught here, before the client signs the forfeit.
+func verifyConnectorLeaf(commitmentTx *wire.MsgTx,
+	commitmentTxID chainhash.Hash, operatorKey *btcec.PublicKey,
+	info *ConnectorLeafInfo) error {
+
+	// Compare as uint32 so a value that would overflow a signed 32-bit int
+	// cannot wrap past the bounds check on 32-bit architectures.
+	rootIdx := info.RootOutputIndex
+	if rootIdx >= uint32(len(commitmentTx.TxOut)) {
+		return fmt.Errorf("root output index %d out of range "+
+			"(commitment tx has %d outputs)", rootIdx,
+			len(commitmentTx.TxOut))
+	}
+
+	// NumLeaves and Radix are operator-supplied and drive tree
+	// reconstruction, so bound them before allocating anything: an
+	// unbounded leaf count is an out-of-memory DoS vector.
+	switch {
+	case info.NumLeaves == 0:
+		return fmt.Errorf("num leaves must be positive")
+
+	case info.NumLeaves > maxConnectorTreeLeaves:
+		return fmt.Errorf("num leaves %d exceeds maximum %d",
+			info.NumLeaves, maxConnectorTreeLeaves)
+
+	case info.Radix < 2:
+		return fmt.Errorf("radix must be at least 2, got %d",
+			info.Radix)
+
+	case info.Radix > maxConnectorTreeRadix:
+		return fmt.Errorf("radix %d exceeds maximum %d", info.Radix,
+			maxConnectorTreeRadix)
+	}
+	numLeaves := int(info.NumLeaves)
+	radix := int(info.Radix)
+
+	if info.LeafIndex < 0 || info.LeafIndex >= numLeaves {
+		return fmt.Errorf("leaf index %d out of range for %d leaves",
+			info.LeafIndex, numLeaves)
+	}
+
+	if info.ConnectorAmount <= 0 {
+		return fmt.Errorf("connector leaf amount must be "+
+			"positive, got %d", info.ConnectorAmount)
+	}
+
+	// The root output funds exactly numLeaves dust leaves; if its value
+	// does not divide cleanly the operator's parameters are inconsistent
+	// with the committed output and reconstruction would not match. Guard
+	// the multiplication against int64 overflow first so a huge leaf
+	// amount cannot wrap to a value that spuriously matches the output.
+	rootOutput := commitmentTx.TxOut[rootIdx]
+	if int64(numLeaves) > math.MaxInt64/info.ConnectorAmount {
+		return fmt.Errorf("num leaves %d and leaf amount %d "+
+			"overflow int64", numLeaves, info.ConnectorAmount)
+	}
+	if rootOutput.Value != int64(numLeaves)*info.ConnectorAmount {
+		return fmt.Errorf("root output value %d != num leaves %d * "+
+			"leaf amount %d", rootOutput.Value, numLeaves,
+			info.ConnectorAmount)
+	}
+
+	rootOutpoint := wire.OutPoint{
+		Hash:  commitmentTxID,
+		Index: rootIdx,
+	}
+
+	// Reconstruct the connector tree exactly as the operator built it.
+	connTree, err := tree.BuildConnectorTree(
+		rootOutpoint, rootOutput, tree.ConnectorDescriptor{
+			PkScript:  rootOutput.PkScript,
+			NumLeaves: numLeaves,
+			Amount:    btcutil.Amount(info.ConnectorAmount),
+		}, operatorKey, radix,
+	)
+	if err != nil {
+		return fmt.Errorf("reconstruct connector tree: %w", err)
+	}
+
+	// Verify the reconstructed structure: the root spends the commitment
+	// output and every child spends its parent at the claimed index.
+	if err := connTree.Verify(); err != nil {
+		return fmt.Errorf("connector tree structure invalid: %w", err)
+	}
+
+	leaves := connTree.Root.GetLeafNodes()
+	if len(leaves) != numLeaves {
+		return fmt.Errorf("reconstructed tree has %d leaves, "+
+			"expected %d", len(leaves), numLeaves)
+	}
+
+	// The assigned connector leaf must be the leaf at the claimed index.
+	// Matching the outpoint binds the entire leaf transaction (the
+	// outpoint hash is the leaf tx hash), proving it descends from the
+	// commitment tx.
+	leaf := leaves[info.LeafIndex]
+	if leaf == nil {
+		return fmt.Errorf("reconstructed leaf at index %d is nil",
+			info.LeafIndex)
+	}
+	gotOutpoint, err := leaf.GetNonAnchorOutpoint()
+	if err != nil {
+		return fmt.Errorf("connector leaf outpoint: %w", err)
+	}
+	if *gotOutpoint != info.ConnectorOutpoint {
+		return fmt.Errorf("assigned connector outpoint %s is not leaf "+
+			"%d of the reconstructed tree (%s)",
+			info.ConnectorOutpoint, info.LeafIndex, gotOutpoint)
+	}
+
+	// Cross-check the assigned connector output (the value and script the
+	// forfeit penalty is built against) against the reconstructed leaf so
+	// a leaf_output inconsistent with the proven outpoint cannot slip
+	// through.
+	gotOutput, err := connectorLeafOutput(leaf)
+	if err != nil {
+		return err
+	}
+	if gotOutput.Value != info.ConnectorAmount {
+		return fmt.Errorf("connector leaf value %d != assigned "+
+			"amount %d", gotOutput.Value, info.ConnectorAmount)
+	}
+	if !bytes.Equal(gotOutput.PkScript, info.ConnectorPkScript) {
+		return fmt.Errorf("connector leaf script does not match " +
+			"assigned connector script")
+	}
+
+	return nil
+}
+
+// connectorLeafOutput returns the single non-anchor output of a connector leaf
+// node.
+func connectorLeafOutput(leaf *tree.Node) (*wire.TxOut, error) {
+	if leaf == nil {
+		return nil, fmt.Errorf("connector leaf node is nil")
+	}
+
+	var found *wire.TxOut
+	for _, out := range leaf.Outputs {
+		if bytes.Equal(out.PkScript, arkscript.AnchorPkScript) {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf("connector leaf has multiple " +
+				"non-anchor outputs")
+		}
+		found = out
+	}
+	if found == nil {
+		return nil, fmt.Errorf("connector leaf has no non-anchor " +
+			"output")
+	}
+
+	return found, nil
 }
 
 // expectedForfeitSequence returns the tx sequence expected for a forfeit input.

--- a/rpc/roundpb/round.pb.go
+++ b/rpc/roundpb/round.pb.go
@@ -368,12 +368,30 @@ func (x *VTXOTree) GetSweepTapscriptRoot() []byte {
 
 // ConnectorLeafInfo contains information about a connector leaf assigned to a
 // forfeit request. Used in server-to-client batch info messages.
+//
+// Fields 3-6 carry the connector-tree ancestry parameters the client needs to
+// prove the assigned leaf descends from this round's commitment transaction.
+// Connector trees have identical leaves and a deterministic BFS layout, so the
+// client reconstructs the exact tree from these scalars plus the commitment tx
+// output at root_output_index and the operator key — no tree transactions are
+// shipped. The client then asserts leaf_outpoint/leaf_output is the leaf at
+// leaf_index of that reconstructed tree before signing the forfeit.
 type ConnectorLeafInfo struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// leaf_outpoint is the outpoint of the connector leaf.
 	LeafOutpoint *Outpoint `protobuf:"bytes,1,opt,name=leaf_outpoint,json=leafOutpoint,proto3" json:"leaf_outpoint,omitempty"`
 	// leaf_output is the connector leaf's transaction output.
-	LeafOutput    *TxOut `protobuf:"bytes,2,opt,name=leaf_output,json=leafOutput,proto3" json:"leaf_output,omitempty"`
+	LeafOutput *TxOut `protobuf:"bytes,2,opt,name=leaf_output,json=leafOutput,proto3" json:"leaf_output,omitempty"`
+	// root_output_index is the commitment-tx output index that this
+	// connector tree's root transaction spends (the tree's batch outpoint
+	// index). It binds the connector tree to the commitment tx.
+	RootOutputIndex uint32 `protobuf:"varint,3,opt,name=root_output_index,json=rootOutputIndex,proto3" json:"root_output_index,omitempty"`
+	// num_leaves is the total number of connector leaves in this tree.
+	NumLeaves uint32 `protobuf:"varint,4,opt,name=num_leaves,json=numLeaves,proto3" json:"num_leaves,omitempty"`
+	// radix is the connector tree branching factor used to build the tree.
+	Radix uint32 `protobuf:"varint,5,opt,name=radix,proto3" json:"radix,omitempty"`
+	// leaf_index is the position of this leaf within the connector tree.
+	LeafIndex     uint32 `protobuf:"varint,6,opt,name=leaf_index,json=leafIndex,proto3" json:"leaf_index,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -420,6 +438,34 @@ func (x *ConnectorLeafInfo) GetLeafOutput() *TxOut {
 		return x.LeafOutput
 	}
 	return nil
+}
+
+func (x *ConnectorLeafInfo) GetRootOutputIndex() uint32 {
+	if x != nil {
+		return x.RootOutputIndex
+	}
+	return 0
+}
+
+func (x *ConnectorLeafInfo) GetNumLeaves() uint32 {
+	if x != nil {
+		return x.NumLeaves
+	}
+	return 0
+}
+
+func (x *ConnectorLeafInfo) GetRadix() uint32 {
+	if x != nil {
+		return x.Radix
+	}
+	return 0
+}
+
+func (x *ConnectorLeafInfo) GetLeafIndex() uint32 {
+	if x != nil {
+		return x.LeafIndex
+	}
+	return 0
 }
 
 // ClientConnectorLeafInfo extends ConnectorLeafInfo with client-side fields
@@ -2354,11 +2400,17 @@ const file_round_proto_rawDesc = "" +
 	"\x05nodes\x18\x01 \x03(\v2\x12.round.v1.TreeNodeR\x05nodes\x129\n" +
 	"\x0ebatch_outpoint\x18\x02 \x01(\v2\x12.round.v1.OutpointR\rbatchOutpoint\x122\n" +
 	"\fbatch_output\x18\x03 \x01(\v2\x0f.round.v1.TxOutR\vbatchOutput\x120\n" +
-	"\x14sweep_tapscript_root\x18\x04 \x01(\fR\x12sweepTapscriptRoot\"~\n" +
+	"\x14sweep_tapscript_root\x18\x04 \x01(\fR\x12sweepTapscriptRoot\"\xfe\x01\n" +
 	"\x11ConnectorLeafInfo\x127\n" +
 	"\rleaf_outpoint\x18\x01 \x01(\v2\x12.round.v1.OutpointR\fleafOutpoint\x120\n" +
 	"\vleaf_output\x18\x02 \x01(\v2\x0f.round.v1.TxOutR\n" +
-	"leafOutput\"\xf7\x01\n" +
+	"leafOutput\x12*\n" +
+	"\x11root_output_index\x18\x03 \x01(\rR\x0frootOutputIndex\x12\x1d\n" +
+	"\n" +
+	"num_leaves\x18\x04 \x01(\rR\tnumLeaves\x12\x14\n" +
+	"\x05radix\x18\x05 \x01(\rR\x05radix\x12\x1d\n" +
+	"\n" +
+	"leaf_index\x18\x06 \x01(\rR\tleafIndex\"\xf7\x01\n" +
 	"\x17ClientConnectorLeafInfo\x12\x1d\n" +
 	"\n" +
 	"leaf_index\x18\x01 \x01(\x05R\tleafIndex\x12A\n" +

--- a/rpc/roundpb/round.proto
+++ b/rpc/roundpb/round.proto
@@ -81,12 +81,34 @@ message VTXOTree {
 
 // ConnectorLeafInfo contains information about a connector leaf assigned to a
 // forfeit request. Used in server-to-client batch info messages.
+//
+// Fields 3-6 carry the connector-tree ancestry parameters the client needs to
+// prove the assigned leaf descends from this round's commitment transaction.
+// Connector trees have identical leaves and a deterministic BFS layout, so the
+// client reconstructs the exact tree from these scalars plus the commitment tx
+// output at root_output_index and the operator key — no tree transactions are
+// shipped. The client then asserts leaf_outpoint/leaf_output is the leaf at
+// leaf_index of that reconstructed tree before signing the forfeit.
 message ConnectorLeafInfo {
     // leaf_outpoint is the outpoint of the connector leaf.
     Outpoint leaf_outpoint = 1;
 
     // leaf_output is the connector leaf's transaction output.
     TxOut leaf_output = 2;
+
+    // root_output_index is the commitment-tx output index that this
+    // connector tree's root transaction spends (the tree's batch outpoint
+    // index). It binds the connector tree to the commitment tx.
+    uint32 root_output_index = 3;
+
+    // num_leaves is the total number of connector leaves in this tree.
+    uint32 num_leaves = 4;
+
+    // radix is the connector tree branching factor used to build the tree.
+    uint32 radix = 5;
+
+    // leaf_index is the position of this leaf within the connector tree.
+    uint32 leaf_index = 6;
 }
 
 // ClientConnectorLeafInfo extends ConnectorLeafInfo with client-side fields


### PR DESCRIPTION
Fixes #681.

## Problem

The client signs forfeit transactions using flat, operator-supplied
connector leaf data, but never proves the connector leaf is part of a
connector tree rooted in the current round's commitment transaction. If
the operator emits inconsistent connector data (implementation bug,
serialization bug, misconfiguration, or compromise), the client signs a
forfeit over a connector that exists independently of the commitment tx.
Once that connector is spendable, the old VTXO can be claimed without the
replacement round ever committing — breaking round atomicity.

## Approach: reconstruct, don't ship the tree

Connector trees have identical leaves and a deterministic BFS layout, so
the client can rebuild the exact tree from a few scalars rather than
receiving the connector transactions over the wire. Pure-local
reconstruction is impossible (the client doesn't know the round-wide
forfeit count, the radix, or which commitment output is the connector
root), so the operator ships just those scalars.

`ConnectorLeafInfo` gains four fields: `root_output_index`, `num_leaves`,
`radix`, `leaf_index`.

Before signing any forfeit (in `CommitmentTxReceivedState`, after VTXO-tree
validation), `validateConnectorAncestry`:

- reconstructs each connector tree via `tree.BuildConnectorTree` from the
  commitment-tx output at `RootOutputIndex`, the operator key, and the
  supplied `NumLeaves`/`Radix`;
- verifies the tree structure (`tree.Verify()` — root spends the batch
  outpoint, every child spends its parent at the claimed index);
- asserts the assigned connector leaf is the leaf at `LeafIndex`
  (outpoint + output cross-check).

Any mismatch fails the round non-recoverably. Because the leaf is rebuilt
on top of a real commitment output, the connector is only ever spendable
once the commitment tx confirms — restoring atomicity.

## Commits

1. `roundpb:` add the four ancestry fields to `ConnectorLeafInfo` (proto +
   regenerated stubs).
2. `types:` carry the ancestry params on `types.ConnectorLeafInfo`.
3. `round:` reconstruct + validate connector ancestry before signing,
   decode the new fields in `FromProto`, with tests.

## Tests

`round/connector_validation_test.go` — positive single/multi-leaf
fixtures plus negatives (root index out of range, unreachable leaf, wrong
radix/num-leaves/operator-key, leaf from a different commitment tx,
tampered script/amount, out-of-range leaf index, nil info).

## Notes

- The server-side counterpart (populate + serialize the fields) is a
  separate PR against `lightninglabs/darepo`.
- This is the connector counterpart to #680 (binding the VTXO tree to the
  commitment tx), which remains open; both are needed for full atomicity.
- The issue's follow-up hardening (exporting connector terms, enforcing
  exact connector count/distinctness) is left as the tracked subtask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)