### PR TITLE
docs: document the durable actor layer and mailbox transport

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ into specific topics below.
 | [walletdkrpc_build.md](walletdkrpc_build.md) | How to build and install the daemon and CLI with the wallet RPC subserver enabled (`walletdkrpc` + `swapruntime` tags) |
 | [swap_background_execution.md](swap_background_execution.md) | Optional build-tagged daemon executor for background swap progress and daemon-backed CLI control |
 | [mailbox_architecture.md](mailbox_architecture.md) | Three-layer mailbox system: pb, rpc, conn, serverconn |
+| [mailbox_durable_actor_layer.md](mailbox_durable_actor_layer.md) | The durable mailbox and durable actor: leases, dedup, transactional outbox, DurableAsk, and the classic vs. Read/Commit (`TxBehavior`/`Exec[S]`) execution paths |
 | [RPC_MAILBOX_CONTRACT.md](RPC_MAILBOX_CONTRACT.md) | Envelope semantics, at-least-once delivery, ack watermarks |
 
 ## Development

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ into specific topics below.
 | [swap_background_execution.md](swap_background_execution.md) | Optional build-tagged daemon executor for background swap progress and daemon-backed CLI control |
 | [mailbox_architecture.md](mailbox_architecture.md) | Three-layer mailbox system: pb, rpc, conn, serverconn |
 | [mailbox_durable_actor_layer.md](mailbox_durable_actor_layer.md) | The durable mailbox and durable actor: leases, dedup, transactional outbox, DurableAsk, and the classic vs. Read/Commit (`TxBehavior`/`Exec[S]`) execution paths |
+| [mailbox_transport_serverconn_clientconn.md](mailbox_transport_serverconn_clientconn.md) | The RPC-over-mailbox transport relating this client's `serverconn` to the operator's `clientconn`: envelope, edge API, shared `mailbox/conn` primitives, ack watermark, identity/auth/liveness, and the wire contract |
 | [RPC_MAILBOX_CONTRACT.md](RPC_MAILBOX_CONTRACT.md) | Envelope semantics, at-least-once delivery, ack watermarks |
 
 ## Development

--- a/docs/mailbox_durable_actor_layer.md
+++ b/docs/mailbox_durable_actor_layer.md
@@ -1,0 +1,637 @@
+# The Mailbox and Durable Actor Layer
+
+An actor reads a message, does some work, writes new state, and reports that it
+is done. A crash can land between any two of those steps. If the actor drops the
+message the moment it reads it and then crashes, the message is gone. If it
+writes the new state but crashes before recording that the message was handled,
+a restart runs the message again and writes the state twice.
+
+This layer closes those gaps. It persists a message to the database before
+anyone processes it, and it records that the message was handled in the same
+transaction that commits the work, so either both land or neither does. The
+transport underneath may deliver a message more than once, which is called
+at-least-once delivery. On top of it, this layer gives the application
+exactly-once processing: the effect of a message lands once, however many times
+the message arrives.
+
+The code lives in `baselib/actor`. The connection runtime that carries traffic
+to and from the remote Ark server is built on top of this layer; for how a
+server connection becomes a durable actor and how inbound events reach durable
+mailboxes, see
+[`mailbox_transport_serverconn_clientconn.md`](mailbox_transport_serverconn_clientconn.md).
+
+## Contents
+
+1. [The three mechanisms](#the-three-mechanisms)
+2. [The pieces](#the-pieces)
+3. [The durable mailbox](#the-durable-mailbox)
+4. [Leases](#leases)
+5. [The durable actor and its execution paths](#the-durable-actor-and-its-execution-paths)
+6. [The classic path](#the-classic-path)
+7. [The Read/Commit path](#the-readcommit-path)
+8. [Deduplication](#deduplication)
+9. [The transactional outbox and DurableAsk](#the-transactional-outbox-and-durableask)
+10. [Crash recovery and restart](#crash-recovery-and-restart)
+11. [Choosing a path](#choosing-a-path)
+
+---
+
+## The three mechanisms
+
+Three mechanisms do most of the work.
+
+Durability persists a message to the database before it is delivered, so a crash
+before processing redelivers the message instead of losing it.
+
+A lease gives one consumer time-boxed ownership of a message. When that consumer
+crashes, its lease expires and the message becomes available to another consumer
+or to the same consumer after it restarts.
+
+Deduplication records each handled message identifier with a time-to-live (TTL).
+When a message is redelivered but was already handled, the actor recognizes the
+identifier and skips it. This is what turns at-least-once delivery into
+exactly-once processing.
+
+---
+
+## The pieces
+
+```mermaid
+flowchart TB
+    subgraph App["Your code"]
+        BEH["ActorBehavior / TxBehavior"]
+    end
+
+    subgraph Runtime["Durable actor runtime"]
+        DA["DurableActor"]
+        DM["DurableMailbox"]
+        DEL["Delivery (one leased message)"]
+        EX["Exec[S] (Read/Commit handle)"]
+    end
+
+    subgraph Store["Persistence: DeliveryStore / TxAwareDeliveryStore"]
+        MM[("mailbox_messages")]
+        PM[("processed_messages")]
+        OM[("outbox_messages")]
+        CP[("fsm_checkpoints")]
+        DL[("dead_letters")]
+    end
+
+    BEH -->|you implement| DA
+    DA -->|owns| DM
+    DM -->|yields| DEL
+    DA -->|drives| EX
+    DM --> MM
+    DA --> PM
+    DA --> OM
+    DA --> CP
+    DA --> DL
+```
+
+| Piece | What it is |
+|-------|------------|
+| `DurableActor[M, R]` | The runtime. It drains the mailbox, runs your behavior, and books the resulting ack, dedup mark, and retry. |
+| `ActorBehavior[M, R]` | The classic behavior you implement: `Receive(ctx, msg) fn.Result[R]`. |
+| `TxBehavior[M, R, S]` | The Read/Commit behavior: `Receive(ctx, msg, Exec[S]) fn.Result[R]`. |
+| `DurableMailbox[M, R]` | The per-actor message queue backed by the `mailbox_messages` table. |
+| `Delivery[M, R]` | One leased message together with its lease operations (`Ack`, `Nack`, `Extend`). |
+| `Exec[S]` | The per-message handle the Read/Commit path hands to a `TxBehavior`. |
+| `DeliveryStore` | The persistence interface: enqueue, lease, ack, nack, dead-letter, dedup, checkpoint, outbox. |
+| `TxAwareDeliveryStore` | `DeliveryStore` plus `ExecTx`, which runs several operations in one database transaction. |
+| `MessageCodec` | The type-length-value (TLV) codec that serializes a message for storage. |
+
+The message type `M` must implement `TLVMessage`, so it can encode and decode
+itself as a TLV stream and the mailbox can persist it. The response type `R` is
+whatever an `Ask` caller expects back.
+
+---
+
+## The durable mailbox
+
+A `DurableMailbox` is a persistent queue scoped to one actor. Sending a message
+writes a row to `mailbox_messages`; the actor's processing loop reads those rows
+back out. Because the queue lives in the database, it survives a restart of the
+process on either end.
+
+A message moves through a small state machine.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Available: Send() (available_at = now)
+    Available --> Leased: LeaseNextMessage() (sets lease_token, lease_until)
+    Leased --> Acked: Ack() (lease_token matches)
+    Leased --> Available: Nack() or lease expires
+    Leased --> DeadLettered: max attempts exceeded
+    Acked --> [*]
+    DeadLettered --> [*]
+```
+
+The store behind the mailbox is `DeliveryStore`. Its core methods:
+
+```go
+type DeliveryStore interface {
+    // Mailbox queue.
+    EnqueueMessage(ctx context.Context, params EnqueueParams) error
+    LeaseNextMessage(ctx context.Context, mailboxID, leaseToken string,
+        leaseDuration time.Duration) (*LeasedMessage, error)
+    AckMessage(ctx context.Context, id, leaseToken string) (int64, error)
+    NackMessage(ctx context.Context, id, leaseToken string,
+        retryAfter time.Duration) (int64, error)
+    MoveToDeadLetter(ctx context.Context, id, reason string) error
+    DeleteMessage(ctx context.Context, id string) error
+    ExpireLeases(ctx context.Context) error
+
+    // Deduplication.
+    IsProcessed(ctx context.Context, id string) (bool, error)
+    MarkProcessed(ctx context.Context, id, actorID string,
+        ttl time.Duration) error
+
+    // Transactional outbox.
+    EnqueueOutbox(ctx context.Context, params OutboxParams) error
+    ClaimOutboxBatch(ctx context.Context, ...) (...)
+
+    // FSM checkpoints.
+    SaveCheckpoint(ctx context.Context, params CheckpointParams) error
+    LoadCheckpoint(ctx context.Context, actorID string) (*Checkpoint, error)
+}
+```
+
+`AckMessage` returns the number of rows it deleted. That row count carries the
+crash-safety guarantee, as the [Leases](#leases) and
+[Read/Commit](#the-readcommit-path) sections both rely on it.
+
+### Same-transaction enqueue
+
+`DurableMailbox.Send` keeps the sender's database transaction in the context.
+When the sender and the target actor share a database, the send joins the
+sender's transaction, so enqueuing the message commits atomically with whatever
+the sender was already writing. An actor that updates its own state and notifies
+another actor in one step therefore never leaves a gap where the state changed
+but the notification was lost.
+
+### Per-correlation-key FIFO
+
+By default the mailbox claims messages in global `available_at` order. A message
+type can override `CorrelationKey() string` to opt into per-key first-in,
+first-out (FIFO) ordering. Two messages in the same mailbox that share a
+non-empty correlation key are then handled in emission order regardless of retry
+backoff.
+
+This order matters because of an overtaking bug it prevents. Suppose message 1
+fails transiently and is nacked with a backoff that pushes its `available_at`
+into the future. Message 2, enqueued later in the same logical stream with an
+earlier `available_at`, would otherwise be claimed first and overtake message 1.
+The claim path blocks this with an anti-join on the message identifier, a
+UUIDv7 that sorts by creation time at millisecond granularity: the head of each
+correlation key must drain before any later same-key row becomes claim-eligible.
+Unkeyed messages keep the global order and do not interfere, and head-of-line
+blocking stays bounded to the correlation key rather than the whole mailbox.
+
+The override lives on the concrete message struct, such as the round and
+out-of-round message types, not in the framework. The framework only carries the
+value from `msg.CorrelationKey()` through `EnqueueParams.CorrelationKey` into the
+`mailbox_messages.correlation_key` column.
+
+---
+
+## Leases
+
+A lease answers one question: which consumer is allowed to finish this message?
+When a consumer claims a message, the store stamps it with a unique `lease_token`
+and a `lease_until` expiry. To acknowledge the message, the consumer must present
+the same token.
+
+Without a token, a slow consumer could acknowledge a message that a second
+consumer already reprocessed after the first consumer's lease expired. That stale
+ack would double-count the work or corrupt state.
+
+```mermaid
+sequenceDiagram
+    participant C1 as Consumer 1
+    participant DB as Store
+    participant C2 as Consumer 2
+
+    C1->>DB: Lease message, get token=ABC
+    Note over C1: starts slow work
+    Note over DB: lease expires, token cleared
+    C2->>DB: Lease same message, get token=XYZ
+    C2->>DB: Ack(token=XYZ) deletes 1 row, success
+    Note over C1: finishes work
+    C1->>DB: Ack(token=ABC) deletes 0 rows
+    Note over C1: 0 rows means the lease was lost
+```
+
+`AckMessage` deletes the row only where the token matches, so a return of zero
+rows says something precise: this consumer no longer owns the message. The
+Read/Commit path turns that signal into a transaction rollback (see
+[the lease fence](#the-lease-fence)).
+
+### Heartbeating
+
+A long operation would outlive its lease if nothing extended it. The
+`DurableActor` runtime runs a background heartbeat that calls `Delivery.Extend`
+every `HeartbeatInterval`, which defaults to a third of the lease duration, so a
+30-second lease is extended every 10 seconds. You do not extend leases by hand;
+the runtime keeps the lease alive for as long as your behavior runs.
+
+---
+
+## The durable actor and its execution paths
+
+`DurableActor` owns the mailbox and runs your behavior. You construct one from a
+`DurableActorConfig` and a behavior:
+
+```go
+res := actor.NewDurableActor(
+    actor.DefaultDurableActorConfig(id, behavior, store, codec),
+)
+da, err := res.Unpack()
+```
+
+`NewDurableActor` returns an `fn.Result` rather than a bare pointer because it
+validates the configuration and fails at construction instead of panicking on
+the first message. A missing behavior returns `ErrNoBehavior`. (The behavior
+field is an `fn.Either` whose zero value is a `Left` holding a nil classic
+behavior, so a forgotten field lands here too.) A Read/Commit behavior paired
+with a store that cannot run transactions returns `ErrTxBehaviorNeedsTxStore`.
+
+When a message arrives, the actor first checks deduplication, then picks one of
+three paths from the configured behavior and store.
+
+```mermaid
+flowchart TD
+    MSG["message leased from mailbox"] --> DEDUP{"already processed?"}
+    DEDUP -->|yes| ACKDUP["ack the duplicate, skip the behavior"]
+    DEDUP -->|no| KIND{"behavior kind?"}
+
+    KIND -->|"Read/Commit (TxBehavior)"| EXEC["processWithExec"]
+    KIND -->|"classic + tx-aware store"| INTX["processInTransaction"]
+    KIND -->|"classic + plain store"| NOTX["processWithoutTransaction"]
+```
+
+The behavior is stored as an `fn.Either[ActorBehavior, BoundTxBehavior]`. The
+`Left` case is the classic behavior, and the `Right` case is the Read/Commit
+behavior. The constructors `DefaultDurableActorConfig` (classic) and
+`DefaultDurableTxActorConfig` (Read/Commit) wrap the either for you.
+
+The next two sections cover the transactional paths. The third path,
+`processWithoutTransaction`, serves stores that cannot run transactions: it runs
+the behavior and then books the ack and dedup mark as separate operations. Use a
+transaction-aware store whenever atomicity matters.
+
+---
+
+## The classic path
+
+The classic path is the default and the right choice for any behavior that does
+no slow IO. The runtime opens one database transaction, runs your whole `Receive`
+inside it, and books the result in that same transaction: the state writes, any
+outbox writes, the dedup mark, and the ack.
+
+```mermaid
+sequenceDiagram
+    participant DA as DurableActor
+    participant TX as one writer transaction
+    participant B as Behavior.Receive
+    participant DB as Store
+
+    DA->>TX: ExecTx(begin)
+    TX->>B: Receive(ctx, msg)
+    B-->>TX: fn.Result[R] (writes via the ctx tx)
+    TX->>DB: MarkProcessed
+    TX->>DB: Ack (delete the mailbox row)
+    DA->>TX: commit
+    Note over DA,TX: state, dedup, and ack commit together
+```
+
+Your behavior implements one method:
+
+```go
+type ActorBehavior[M TLVMessage, R any] interface {
+    Receive(ctx context.Context, msg M) fn.Result[R]
+}
+```
+
+Any domain store your behavior writes through joins the framework transaction by
+reading the `*sql.Tx` off the context with `actor.TxFromContext`. The result then
+decides the bookkeeping. A successful `Tell` marks the message processed and acks
+it. A failed `Tell` consults the `TellRetryPolicy`: if the policy retries, the
+runtime nacks with a delay and does not mark the message processed, so the
+redelivery is not skipped; if the policy gives up, the runtime dead-letters the
+message. An `Ask` always acks, because the error is part of the persisted result,
+and its in-memory promise completes only after the transaction commits, so a
+caller never sees success for work that did not durably land.
+
+This path holds the single write-ahead-log (WAL) writer for the whole `Receive`.
+A behavior that does a network round-trip in the middle, such as signing,
+calling the server, or polling, holds the writer across that round-trip, and
+every other actor that needs the writer waits behind it. The Read/Commit path
+removes that cost.
+
+---
+
+## The Read/Commit path
+
+A behavior that must do slow side-effect IO opts into the Read/Commit path. It
+splits one `Receive` into three phases: a short read, the IO with no transaction
+held, and one short fenced commit. The writer lock is held only for the reads and
+the final write, never across the network.
+
+The behavior implements `TxBehavior` and works through an `Exec[S]` handle:
+
+```go
+type TxBehavior[M TLVMessage, R any, S any] interface {
+    Receive(ctx context.Context, msg M, ax Exec[S]) fn.Result[R]
+}
+
+type Exec[S any] interface {
+    // Read runs fn inside a short read-only snapshot. No writer lock.
+    Read(ctx context.Context, fn func(ctx context.Context, store S) error) error
+
+    // Commit runs fn inside one short writer transaction, then folds in
+    // the lease-fenced ack and the dedup mark.
+    Commit(ctx context.Context, fn func(ctx context.Context, store S) error) error
+}
+```
+
+A handler reads its inputs, drops the transaction, does the IO, and then commits
+the result.
+
+```mermaid
+sequenceDiagram
+    participant B as TxBehavior.Receive
+    participant AX as Exec[S]
+    participant DB as Store
+
+    B->>AX: Read(loadInputs)
+    AX->>DB: short read-only snapshot (no writer lock)
+    Note over B: no transaction held
+    B->>B: slow IO: sign, call the server, poll
+    B->>AX: Commit(writeState)
+    AX->>DB: ack, fenced on lease_token, returns row count
+    alt rows == 0
+        AX-->>B: ErrLeaseLost (whole tx rolls back)
+    else rows == 1
+        AX->>DB: writeState (joins this tx)
+        AX->>DB: MarkProcessed (joins this tx)
+        Note over AX,DB: ack, state, and dedup commit together
+    end
+```
+
+### The lease fence
+
+The exactly-once guarantee survives the IO window because of the order of
+operations inside `Commit`. The runtime acks first:
+
+```go
+// Inside Commit, before running the behavior's write closure:
+rows, err := s.AckMessage(txCtx, msgID, leaseToken)
+if err != nil {
+    return err
+}
+if rows == 0 {
+    return ErrLeaseLost
+}
+// The behavior's writes and the dedup mark run next, in this same tx.
+```
+
+If the behavior stalled past its lease during the IO, another consumer may have
+already reclaimed and reprocessed the message. The token then no longer matches,
+`AckMessage` deletes zero rows, `Commit` returns `ErrLeaseLost`, and the whole
+transaction rolls back, applying nothing. Acking first keeps the stale-lease case
+a true no-op rather than relying on rollback to undo work that already ran. Any
+duplicate effect the stale consumer emitted is absorbed downstream by the
+receiver's `ON CONFLICT (id) DO NOTHING`.
+
+On the happy path, the behavior's writes, the dedup mark, and the ack commit in
+one transaction, so the state advance and the message's consumption are a single
+exactly-once unit. A lease heartbeat runs for the whole `processWithExec`
+duration, so a long IO middle cannot let the lease expire underneath an
+in-progress commit. The heartbeat stops the moment the behavior returns, because
+a committed message is already deleted and a late heartbeat tick would log a
+spurious failure trying to extend a gone lease.
+
+### The store factory and the atomicity contract
+
+A `StoreFactory` you supply builds the behavior's typed, transaction-scoped store
+`S` once per message:
+
+```go
+type StoreFactory[S any] func(ctx context.Context, ds DeliveryStore) S
+```
+
+The factory runs inside each `Read` and `Commit` transaction and returns the
+store handed to your closure. One rule governs it: the returned store must write
+against the per-call transaction. Domain stores satisfy the rule by reading the
+`*sql.Tx` from the closure's context (via `actor.TxFromContext`) at call time.
+
+Two mistakes break the rule silently. Both commit out-of-band with no error while
+the framework's ack still fences, so the state is not atomic with consumption.
+
+```go
+// WRONG: captures an outer (non-tx) context, so writes skip the Commit tx.
+factory := func(context.Context, actor.DeliveryStore) myStore {
+    return myStore{ctx: outerCtx, db: db}
+}
+
+// WRONG: binds to the raw DB handle, bypassing the tx entirely.
+factory := func(context.Context, actor.DeliveryStore) myStore {
+    return myStore{db: rawDB}
+}
+
+// RIGHT: the store reads the tx from the closure's ctx at call time.
+factory := func(context.Context, actor.DeliveryStore) myStore {
+    return myStore{domain: domainStore}
+}
+```
+
+Never capture a context in the factory. Let the store pick up the transaction
+from the context passed into the `Read` or `Commit` closure.
+
+### A worked example: the client ledger
+
+The client-side ledger actor is the first adopter. It wires onto the Read/Commit
+path with `DefaultDurableTxActorConfig` and injects a typed `ledgerTx` store:
+
+```go
+durableCfg := actor.DefaultDurableTxActorConfig[LedgerMsg, LedgerResp, ledgerTx](
+    a.actorID, a, a.bindStores, a.cfg.DeliveryStore, codec,
+)
+durable, err := actor.NewDurableActor(durableCfg).Unpack()
+```
+
+Its handler for a unilateral-exit cost books two ledger legs, a send leg and a
+fee leg, through two `InsertLedgerEntry` calls inside one `Commit`:
+
+```go
+return a.commit(ctx, ax, "Failed to handle exit cost",
+    func(ctx context.Context, q ledgerTx) error {
+        if err := q.ledger.InsertLedgerEntry(ctx, sendLeg); err != nil {
+            return err
+        }
+        return q.ledger.InsertLedgerEntry(ctx, feeLeg)
+    },
+)
+```
+
+Both legs join the same fenced transaction, so a crash or error between them
+rolls back both writes and the mailbox ack together. There is no window where
+only the send leg landed. A returned `ErrLeaseLost` means the message was
+reclaimed and reprocessed elsewhere, not that the handler failed, so the ledger
+does not log it as a handler error and the framework's retry path takes over.
+
+### What this path does not support yet
+
+`DurableAsk` (see [the next section](#the-transactional-outbox-and-durableask))
+does not work on this path yet. On the Read/Commit path, the behavior acks the
+message inside its own `Commit`, so the framework cannot fold the crash-safe
+callback response into the consuming transaction; it does not have the behavior's
+result at commit time. A `DurableAsk` delivered to a Read/Commit actor is
+rejected with `ErrDurableAskUnsupported`: the runtime writes an error response to
+the caller under the same lease fence rather than leaving the caller to hang.
+Full support is planned alongside the effect actors in the out-of-round
+subsystem, the next part of the codebase to adopt this path.
+
+---
+
+## Deduplication
+
+Before it runs your behavior, the actor calls `IsProcessed(id)`. If the message
+was already handled, for example because it ran before a crash but the ack was
+lost, the actor skips the behavior and acks the redelivered copy. After a
+successful run, `MarkProcessed(id, actorID, ttl)` records the identifier so a
+later redelivery is recognized.
+
+On both transactional paths the dedup mark is written inside the same transaction
+as the work and the ack, so the record that a message was handled can never drift
+out of sync with the effect of handling it. The TTL should comfortably exceed the
+longest possible redelivery window; it defaults to 24 hours.
+
+Marking is skipped on purpose when the actor intends to retry. A failed `Tell`
+that the retry policy will redeliver must not be marked processed, or the
+redelivery would be wrongly skipped as a duplicate.
+
+---
+
+## The transactional outbox and DurableAsk
+
+An actor often needs to send a message to another actor while handling its own.
+Sending that message in a separate step after the state change reopens the crash
+gap: state updated, message never sent. The transactional outbox closes it.
+
+### Change data capture through the outbox
+
+To emit a message, a behavior writes it to the `outbox_messages` table inside its
+own transaction, via `EnqueueOutbox`. The outgoing message and the state change
+then commit together or not at all. A background `OutboxPublisher` polls the
+outbox, decodes each message, looks up the target actor through the
+`Receptionist` service registry, and delivers it. This is the change data capture
+(CDC) pattern: the durable outbox row is the captured intent, and the publisher
+turns it into a real delivery.
+
+```mermaid
+sequenceDiagram
+    participant A as Actor A (in tx)
+    participant DB as Store
+    participant P as OutboxPublisher
+    participant B as Actor B mailbox
+
+    A->>DB: write state + EnqueueOutbox(msg) in one tx
+    Note over A,DB: both commit together
+    loop poll
+        P->>DB: ClaimOutboxBatch()
+        DB-->>P: pending messages
+    end
+    P->>B: Tell(decoded msg)
+    P->>DB: CompleteOutbox(id) on success
+```
+
+When delivery fails, the publisher leaves the row for the next poll to retry.
+
+### DurableAsk: request-response that survives a crash
+
+A normal `Ask` returns an in-memory promise, which a crash destroys. `DurableAsk`
+routes the response through the durable outbox instead, so it survives a restart
+on either side. The caller supplies two parameters. `CallbackActorID` is the
+caller's own actor identifier: the target writes its response to the outbox
+addressed to this actor, and the publisher delivers it to the caller's mailbox.
+`CorrelationID` is a unique identifier the caller generates so it can match a
+response to the request it answers, since responses arrive later as separate
+messages.
+
+```mermaid
+flowchart LR
+    subgraph "Standard Ask (lost on crash)"
+        A1[Caller] -->|Ask| T1[Target]
+        T1 -->|complete| P1["in-memory promise"]
+    end
+    subgraph "DurableAsk (survives a crash)"
+        A2[Caller] -->|DurableAsk| T2[Target]
+        T2 -->|write to outbox| O2[("outbox_messages")]
+        O2 -->|publisher| M2[("caller's mailbox")]
+        M2 -->|Receive| A2
+    end
+```
+
+---
+
+## Crash recovery and restart
+
+When an actor restarts, it must restore its state before it processes anything
+that depends on that state. Checkpoints and the `RestartMessage` make this work.
+
+On each message, a behavior can checkpoint its finite-state-machine (FSM) state
+to `fsm_checkpoints`. On startup, the actor loads the latest checkpoint and
+prepends a `RestartMessage` to its own mailbox. That message carries
+`RestartPriority`, the maximum 32-bit integer, so it always sorts to the front of
+the queue and runs before any regular message. The behavior restores its state
+from the `RestartMessage`, and only then does normal processing resume.
+
+```mermaid
+flowchart TD
+    START["actor start"] --> LOAD{"checkpoint exists?"}
+    LOAD -->|yes| PRE["prepend RestartMessage (priority=MAX)"]
+    LOAD -->|no| LOOP
+    PRE --> LOOP["processing loop"]
+    LOOP --> NEXT["LeaseNextMessage"]
+    NEXT --> ISR{"RestartMessage?"}
+    ISR -->|yes| RESTORE["restore FSM state"]
+    ISR -->|no| RUN["run behavior"]
+    RESTORE --> NEXT
+    RUN --> NEXT
+```
+
+A message that was leased but never acked before a crash is redelivered once its
+lease expires. `ExpireLeases` clears stale leases by setting `lease_token` and
+`lease_until` back to null, the message becomes available again, the restarted
+actor leases it, and deduplication decides whether the behavior runs or the
+message is acked as an already-handled duplicate.
+
+---
+
+## Choosing a path
+
+| Situation | Path |
+|-----------|------|
+| Behavior does only fast in-memory work and database writes | Classic (`ActorBehavior` with a tx-aware store) |
+| Behavior must do slow IO (signing, calling the server, polling) before it can commit | Read/Commit (`TxBehavior` with `Exec[S]`) |
+| Several writes must land atomically with consumption | Either transactional path; both fold the dedup mark and ack into one transaction |
+| Fire-and-forget, no response needed | `Tell` |
+| Request-response, caller stays alive | `Ask` |
+| Request-response that must survive a caller crash | `DurableAsk` (classic path only, for now) |
+| Notify another actor while handling a message | Transactional outbox (`EnqueueOutbox` inside the tx) |
+
+The classic path is the default. Reach for Read/Commit when holding the writer
+across IO would stall other actors.
+
+---
+
+## Related documents
+
+- [`mailbox_transport_serverconn_clientconn.md`](mailbox_transport_serverconn_clientconn.md)
+  builds on this layer: it shows how the connection runtime to the remote Ark
+  server is itself a durable actor, and how the wire transport relates this
+  client's `serverconn` to the operator's `clientconn`.
+- [`fee_ledger.md`](fee_ledger.md) covers the client ledger, the first adopter of
+  the Read/Commit path, with its full chart of accounts and per-flow
+  walkthroughs.

--- a/docs/mailbox_transport_serverconn_clientconn.md
+++ b/docs/mailbox_transport_serverconn_clientconn.md
@@ -1,0 +1,616 @@
+# The Mailbox Transport: serverconn and clientconn
+
+The client and the remote Ark server never share a process or a TCP connection.
+They talk by appending messages to each other's mailboxes and pulling them back
+out. The client's end of that arrangement is the `serverconn` package in this
+repository. The server operator's end is its `clientconn` ingress loop, which
+lives in the server repository.
+
+This document stands on its own, but it builds on the durable actor layer. The
+client's outbound side is itself a durable actor, and inbound events land in
+durable actor mailboxes. For how durable actors, leases, the transactional
+outbox, and exactly-once processing work, see
+[`mailbox_durable_actor_layer.md`](mailbox_durable_actor_layer.md).
+
+## Contents
+
+1. [Why a mailbox instead of a gRPC stream](#why-a-mailbox-instead-of-a-grpc-stream)
+2. [The two ends and the edge between them](#the-two-ends-and-the-edge-between-them)
+3. [The envelope](#the-envelope)
+4. [The edge API: Send, Pull, AckUpTo](#the-edge-api-send-pull-ackupto)
+5. [The shared connection primitives](#the-shared-connection-primitives)
+6. [serverconn: the client end](#serverconn-the-client-end)
+7. [clientconn: the operator end](#clientconn-the-operator-end)
+8. [The ack watermark](#the-ack-watermark)
+9. [Identity, authentication, and liveness](#identity-authentication-and-liveness)
+10. [Worked flows](#worked-flows)
+11. [Crash recovery on each end](#crash-recovery-on-each-end)
+12. [The wire contract](#the-wire-contract)
+
+---
+
+## Why a mailbox instead of a gRPC stream
+
+A plain gRPC stream ties message delivery to the life of a TCP connection. If
+the connection drops mid-request, the request fails with no retry. If the process
+crashes after receiving a message but before acting on it, the message is gone.
+
+The mailbox transport replaces the stream with store-and-forward. The sender
+appends a message to the recipient's mailbox, where the message is persisted
+before the recipient ever sees it. The recipient pulls the message, processes it
+durably, and only then acknowledges it. A crash between pull and acknowledgment
+causes redelivery, not loss. This buys three properties a raw stream lacks.
+
+A message is durable: it survives a restart of either process. Delivery is
+at-least-once: an unacknowledged message is redelivered on reconnect. And the
+transport is unified: request-response remote procedure calls (RPCs) and
+fire-and-forget events share one envelope format and one edge API.
+
+The price is that a message may arrive more than once, so both ends must be
+idempotent. The durable actor layer on the client and the deduplication logic on
+the server are what make at-least-once delivery safe.
+
+---
+
+## The two ends and the edge between them
+
+Three parts are in play: the client, the server, and the edge between them. The
+edge is a gRPC service, hosted at the server, that owns the mailbox storage.
+
+```mermaid
+flowchart LR
+    subgraph Client["Client process (this repo)"]
+        APP["round / out-of-round actors, RPC callers"]
+        SC["serverconn.Runtime<br/>(egress DurableActor + ingress loop)"]
+    end
+
+    subgraph Edge["Mailbox edge (gRPC at the server)"]
+        CMB[("client's mailbox")]
+        OMB[("operator's mailbox")]
+    end
+
+    subgraph Operator["Operator process (server repo)"]
+        CC["clientconn ingress loop"]
+        SRV["Ark services + handlers"]
+    end
+
+    APP <--> SC
+    SC -->|"Send to operator's mailbox"| OMB
+    SC -->|"Pull/AckUpTo from client's mailbox"| CMB
+    CC -->|"Send to client's mailbox"| CMB
+    CC -->|"Pull/AckUpTo from operator's mailbox"| OMB
+    CC <--> SRV
+```
+
+Each side sends by appending to the other side's mailbox and receives by pulling
+from its own. The arrows are symmetric, because `serverconn` and `clientconn` are
+mirror images: they run the same connection primitives over the same envelope
+format. That symmetry is by design. The reusable primitives in `mailbox/conn`
+were factored out of `serverconn` so the operator's `clientconn` could mirror
+this client's ack-watermark logic, response correlation, and codec without
+importing any client-specific code.
+
+The client-side code is layered.
+
+| Layer | Packages | Responsibility |
+|-------|----------|----------------|
+| 1 | `mailbox/pb` | Generated protobuf: the `Envelope`, `RpcMeta`, `Status`, and the `MailboxService` edge API. |
+| 2 | `mailbox/rpc`, `mailbox/conn` | The runtime contracts generated stubs depend on, plus the shared connection primitives (ack watermark, response registry, deterministic identifiers, and a bridge between protobuf and the type-length-value (TLV) records the durable mailbox stores). |
+| 3 | `serverconn` | The client's connection runtime: an egress durable actor, an ingress loop, an event router, a unary facade, and the `Runtime` that composes them. |
+
+Layer 1 is pure generated code. Layer 2 is shared by both ends of the wire. Layer
+3 wires the client into its actor system.
+
+---
+
+## The envelope
+
+Every message, whether request, response, or event, travels inside an `Envelope`.
+
+```mermaid
+classDiagram
+    class Envelope {
+        +string msg_id
+        +string idempotency_key
+        +string sender
+        +string recipient
+        +Any body
+        +RpcMeta rpc
+        +uint64 event_seq
+        +map~string,string~ headers
+    }
+    class RpcMeta {
+        +Kind kind
+        +string service
+        +string method
+        +string correlation_id
+        +string reply_to
+    }
+    class Kind {
+        <<enumeration>>
+        KIND_REQUEST
+        KIND_RESPONSE
+        KIND_EVENT
+    }
+    Envelope *-- RpcMeta
+    RpcMeta --> Kind
+```
+
+A few fields carry the contract. `msg_id` identifies a single message; do not
+assume it is unique per send attempt. The durable egress derives it from the
+payload (`StableEventMsgID`), so a replayed event keeps the same `msg_id` on
+every retry rather than getting a fresh one. `idempotency_key` is likewise stable
+per semantic operation and stays the same across retries of the same logical
+request, and it is the key the receiver deduplicates on, never `msg_id`. `body`
+is a `google.protobuf.Any` holding the typed payload, which receivers unmarshal
+in forward-compatible mode, discarding unknown fields.
+
+The `rpc` field is the optional RPC overlay. Its `Kind` says what the envelope
+is: a `KIND_REQUEST` is a unary request from client to server, a `KIND_RESPONSE`
+is a unary response from server to client, and a `KIND_EVENT` is a
+fire-and-forget message in either direction. `service` and `method` name the
+destination, and `correlation_id` pairs a response with its request.
+
+`event_seq` is assigned by the edge. It defines per-mailbox ordering and serves
+as the cursor for `Pull` and `AckUpTo`. `headers` carries extensible metadata,
+including application errors (see
+[error transport](#error-transport-through-headers)).
+
+The routing keys come straight from the protobuf service definition: `service` is
+the fully-qualified service name, such as `"arkrpc.v1.RoundService"`, and
+`method` is the method name, such as `"JoinRound"`.
+
+---
+
+## The edge API: Send, Pull, AckUpTo
+
+The edge is an ordinary gRPC service with three RPCs. Everything above it, namely
+request correlation, idempotency, and dispatch routing, is an application-level
+protocol built on these three primitives.
+
+```protobuf
+service MailboxService {
+    rpc Send    (SendRequest)    returns (SendResponse);
+    rpc Pull    (PullRequest)    returns (PullResponse);
+    rpc AckUpTo (AckUpToRequest) returns (AckUpToResponse);
+}
+```
+
+`Send` appends an envelope to the recipient's mailbox and returns a `Status`,
+which can report a protocol-version mismatch among other things. `Pull` fetches
+envelopes from the caller's own mailbox starting at a cursor; it long-polls,
+blocking up to a bounded timeout and returning promptly when new envelopes
+arrive, with a `next_cursor` set to the highest `event_seq` seen plus one.
+`AckUpTo` advances the caller's ack watermark, after which the server may
+garbage-collect envelopes older than the watermark. The call is monotonic, never
+moving the watermark backward, and safe to retry.
+
+---
+
+## The shared connection primitives
+
+`mailbox/rpc` and `mailbox/conn` hold the building blocks both ends use. They
+carry no transport implementation and no actor dependency, so a generated stub or
+an operator-side connector can import them freely.
+
+`RPCClient` and `Router` in `mailbox/rpc` are the two contracts generated stubs
+depend on. `RPCClient` is the client side:
+
+```go
+type RPCClient interface {
+    SendRPC(ctx context.Context, method ServiceMethod,
+        req proto.Message, opts RPCOptions) (SendResult, error)
+    AwaitRPC(ctx context.Context, correlationID string,
+        resp proto.Message) error
+}
+```
+
+Splitting the call into `SendRPC` then `AwaitRPC` lets a caller register a
+response waiter before the send, which closes the race where a fast server
+replies before the caller is listening. `Router` is the server side:
+`Handle(service, method, newReq, fn)` registers a typed handler, and the
+generated `RegisterXxxMailboxServer` calls it once per method. `ServeMux` is the
+concrete `Router`, a small thread-safe map from a `(service, method)` pair to a
+typed handler.
+
+### Error transport through headers
+
+Application errors travel in an envelope header, not in the body, so the body
+stays reserved for successful payloads. The header is
+`mailboxrpc.grpc_status_b64`, a base64-encoded `google.rpc.Status`.
+`EncodeErrorHeaders` turns a Go error into that header, and `DecodeErrorHeaders`
+reconstructs it. On receipt, the client checks the error header before it reads
+the body.
+
+### The other primitives
+
+`AckState` in `mailbox/conn` is the four-cursor watermark machine described in
+[its own section](#the-ack-watermark).
+
+`ResponseRegistry` maps a correlation identifier to an in-memory waiter and
+buffers a response that arrives before its waiter is registered. It is in-memory
+only: on a crash, callers' contexts are cancelled and they retry, because the
+edge still holds the unacked envelopes.
+
+`EnvelopeIdentity` derives stable identifiers from payload content.
+`StableEventMsgID(payload)` and `StableEventIdempotencyKey(payload)` each return
+a prefix plus the first 16 bytes of the payload's SHA-256 digest. When a durable
+event is replayed from the actor mailbox after a crash, the same identifiers
+reappear from the same stored bytes, so a retry carries the same idempotency key
+and the server deduplicates it with no extra state.
+
+`WrappedProto[T]` bridges a protobuf message into the `TLVMessage` interface the
+durable actor mailbox requires, by marshaling to and from bytes. This is how a
+proto payload becomes storable in a durable actor mailbox.
+
+---
+
+## serverconn: the client end
+
+`serverconn` is the single boundary for all mailbox traffic between this client
+and the remote server. It plays two roles at once, an outbound durable actor and
+an inbound polling loop, composed by a `Runtime`.
+
+```mermaid
+flowchart TB
+    subgraph Runtime["serverconn.Runtime"]
+        subgraph Egress["Egress: ServerConnectionActor as a DurableActor"]
+            INBOX["durable mailbox"]
+            RECV["Receive()"]
+        end
+        subgraph Ingress["Ingress: background loop"]
+            PULL["Edge.Pull"]
+            DISP["dispatchBatch"]
+            ACK["Edge.AckUpTo"]
+            CKPT["saveCheckpoint"]
+        end
+        UF["UnaryFacade"]
+        RR["ResponseRegistry"]
+    end
+
+    ROUND["round / out-of-round actors"] -->|"Tell(SendClientEventRequest)"| INBOX
+    INBOX --> RECV -->|"Edge.Send"| EDGE["edge"]
+    UF -->|"Edge.Send (direct)"| EDGE
+    EDGE -->|"Pull"| PULL --> DISP
+    DISP -->|"KIND_RESPONSE"| RR
+    DISP -->|"KIND_REQUEST / KIND_EVENT"| ACTORS["local durable actors"]
+    DISP --> ACK --> CKPT
+    UF -.->|"RegisterWaiter / AwaitRPC"| RR
+```
+
+### Egress: two paths for two needs
+
+Outbound traffic takes one of two paths, chosen by whether the message must
+survive a crash.
+
+The durable path carries finite-state-machine (FSM) events, the messages a round
+or out-of-round actor must not lose. The producer calls
+`Tell(SendClientEventRequest)` on the
+connection runtime, which is a durable actor, so the event is TLV-encoded and
+persisted to the durable mailbox before the call returns. The actor's `Receive`
+later converts the event to a proto, derives a stable `msg_id` and
+`idempotency_key` from the payload hash, builds a `KIND_EVENT` envelope, and
+calls `Edge.Send`. On a crash, the durable mailbox replays the persisted event,
+the same identifiers are derived again, and the server deduplicates the retry.
+The `SendClientEventRequest` forwards its inner message's `CorrelationKey()`, so
+the durable mailbox enqueues the event into the correct per-key first-in,
+first-out (FIFO) lane, such as `round/<id>` or `oor/<session>`, and a cached key
+populated during TLV decode preserves that lane even after the message is decoded
+again on crash-replay.
+
+The fast path carries unary RPCs, where the caller can retry. The
+`UnaryFacade` builds a `KIND_REQUEST` envelope and calls `Edge.Send` directly,
+with no durable mailbox in the way. It trades crash durability for lower latency,
+which suits a request the caller will reissue if it fails.
+
+### Ingress: the pull-dispatch-ack loop
+
+A background goroutine runs one cycle continuously.
+
+```mermaid
+flowchart TD
+    LOAD["load AckState checkpoint"] --> NEEDACK{"NeedsAck()?"}
+    NEEDACK -->|yes| ACK["Edge.AckUpTo(AckTarget)"]
+    ACK -->|ok| ADVA["AdvanceAck() + checkpoint"]
+    ADVA --> PULL
+    NEEDACK -->|no| PULL["Edge.Pull(PullCursor, long-poll)"]
+    PULL -->|empty| NEEDACK
+    PULL -->|batch| DISP["dispatchBatch()"]
+    DISP -->|all dispatched| ADVD["AdvanceDispatch(nextCursor) + checkpoint"]
+    ADVD --> NEEDACK
+    DISP -->|partial fail| PART["AdvanceDispatch(lastCommitted+1) + checkpoint"]
+    PART --> BACK["backoff"] --> NEEDACK
+    ACK -->|fail| BACK
+```
+
+Dispatch routes each envelope by its `Kind`. A `KIND_RESPONSE` goes to the
+`ResponseRegistry`, completing the in-memory waiter for a unary RPC; this is not
+durable, since the response is consumed immediately, and if no waiter exists
+because the caller crashed and is gone, the ingress can fall back to durable
+route dispatch. A `KIND_REQUEST` or `KIND_EVENT` is looked up in a dispatch table
+keyed by `(service, method)`; the matched dispatcher unmarshals the body, adapts
+it to a local actor's message type, and calls `Tell` on that durable actor, which
+persists the message before returning. A nil return means the envelope is
+durably committed locally.
+
+When dispatch fails partway through a batch, for instance because a target
+actor's store is briefly down, the loop advances its watermark only past the last
+successfully-committed envelope, and the failed one is re-pulled next cycle.
+Transient failures back off exponentially with jitter.
+
+### The event router and the unary facade
+
+The `EventRouter` is where inbound routes are declared at wiring time. Each route
+binds a `(service, method)` pair to a target actor's `ServiceKey` and an adapter
+that turns the decoded proto into the actor's message type. A new server-pushed
+event needs only a new route registration, with no change to the loop.
+
+The `UnaryFacade` implements `RPCClient` for the generated stubs. `SendRPC`
+registers a response waiter, builds the request envelope, and sends it directly.
+`AwaitRPC` blocks on that waiter until the ingress loop delivers the matching
+`KIND_RESPONSE`, then checks the error header before unmarshaling the body.
+
+### The runtime
+
+`Runtime` embeds the egress `DurableActor`, so it registers directly with the
+actor system and promotes `Ref` and `TellRef` without wrappers. `Start` starts
+the durable actor (egress) and then the ingress loop, which loads the ack
+checkpoint and begins pulling; `Stop` reverses the order. Higher layers reach
+egress through `TellRef` and typed RPCs through `Unary()`.
+
+---
+
+## clientconn: the operator end
+
+On the operator's side, the mirror of `serverconn` is its `clientconn` ingress
+loop, in the server repository. It is the operator's view of one connected
+client. The name is from the operator's perspective: `clientconn` is the
+connection to a client, just as this repo's `serverconn` is the connection to the
+server.
+
+Because the connection primitives are shared, `clientconn` runs the same
+machinery in mirror image.
+
+| Concern | serverconn (this client) | clientconn (the operator) |
+|---------|--------------------------|---------------------------|
+| Sends to | the operator's mailbox | the client's mailbox |
+| Pulls from | the client's own mailbox | the operator's mailbox |
+| Ack watermark | `AckState`, four cursors, checkpointed | the same `AckState` logic, mirrored |
+| Inbound dispatch | route to a local durable actor via `Tell` | route to the operator's request handlers |
+| Idempotency | derives stable keys, retries safely | deduplicates on the request's idempotency key |
+
+This repository does not contain `clientconn`, but it pins down the parts of the
+contract the operator must honor, because the client sends envelopes the operator
+interprets:
+
+- The client sends a heartbeat to the well-known service
+  `clientconn.v1.HeartbeatService`, method `Heartbeat`, and the operator
+  recognizes that service and refreshes the client's liveness status (see
+  [liveness](#identity-authentication-and-liveness)).
+- The client sets a stable idempotency key on any request it may retry, and the
+  operator deduplicates on that key without assuming it sees the key only once.
+- The operator echoes the request's `correlation_id` on its response. A client
+  with several requests in flight demultiplexes pulled responses by correlation
+  id before it advances any ack watermark, because a client that acked too far
+  would drop responses for its concurrent requests.
+- Ordering holds only within a single mailbox stream, so neither side assumes an
+  order between different mailboxes or a request-to-response order beyond
+  correlation. The client tolerates out-of-order delivery: a seal-time fee quote
+  that arrives before the round event that keys the FSM waits in a buffer until
+  that event lands.
+
+---
+
+## The ack watermark
+
+The ack watermark turns at-least-once delivery into no-loss delivery. Each end
+tracks four monotonic cursors.
+
+```go
+type AckState struct {
+    PullCursor          uint64 // cursor for the next Pull
+    DispatchCommittedTo uint64 // max cursor durably dispatched locally
+    AckTarget           uint64 // max cursor that should be acked remotely
+    AckCommittedTo      uint64 // last cursor successfully acked remotely
+}
+```
+
+One invariant governs them:
+
+> `AckCommittedTo` must never exceed `DispatchCommittedTo`.
+
+Never acknowledge past work that is not yet durable locally. If the loop acked an
+envelope before durably dispatching it, a crash in that gap would lose the
+envelope for good: the server, seeing the ack, garbage-collects it, while the
+client has no record of it.
+
+The cursors advance in order. `AdvanceDispatch(nextCursor)` bumps
+`DispatchCommittedTo` and `AckTarget` after `dispatchBatch` durably persists a
+batch. `AdvanceAck()` sets `AckCommittedTo` to `AckTarget` after `AckUpTo`
+succeeds. `NeedsAck()` reports whether `AckTarget > AckCommittedTo`. The state is
+serialized with LND's TLV codec as four `uint64` records and checkpointed after
+every change, so a restart resumes from `PullCursor`.
+
+```mermaid
+sequenceDiagram
+    participant IL as ingress loop
+    participant DB as local store
+    participant E as edge
+
+    Note over IL: Pull returns 5,6,7,8
+    IL->>DB: dispatch 5,6,7,8 (Tell, persisted)
+    IL->>DB: checkpoint DispatchCommittedTo=9
+    Note over IL: CRASH before AckUpTo
+    Note over IL: restart, loadCheckpoint: AckCommittedTo=5, DispatchCommittedTo=9
+    IL->>E: AckUpTo(9)
+    Note over E: GC 5..8, already durable locally
+    IL->>E: Pull(cursor=9)
+    Note over IL: no loss
+```
+
+Had the crash struck between dispatching envelope 6 and envelope 7, before the
+checkpoint, the checkpoint would still show the old position; the loop would
+re-pull and re-dispatch 7 and 8, and the durable actor's deduplication would
+absorb the repeats.
+
+---
+
+## Identity, authentication, and liveness
+
+A mailbox is named by the public key of its owner. `PubKeyMailboxID` derives the
+canonical mailbox identifier from a compressed public key in hex, so the client's
+and operator's mailbox names are deterministic and need no separate registration.
+
+Two layers protect the connection. At the transport layer, mutual TLS (mTLS)
+binds the session to the mailbox identity: `GenerateClientTLSCert` mints an
+ephemeral P-256 client certificate whose subject common name is the client's
+secp256k1 identity public key in hex. At the application layer, every outbound
+envelope carries a BIP-340 Schnorr signature in the `x-mailbox-auth-sig` header
+(`AuthHeaderKey`). The signed digest is a tagged hash, `MailboxAuthDigest`, built
+with the `MailboxAuthTagStr` domain separator. The connection's configured
+`AuthSignature` is merged into every envelope, and the auth header always wins
+over any caller-provided header. `SignMailboxAuth`, `VerifyMailboxAuth`, and
+`ParseMailboxPubKey` are the sign-and-verify helpers the two ends share.
+
+The heartbeat keeps liveness current. The client sends a heartbeat every
+`DefaultHeartbeatInterval` (30 seconds), but skips it when real traffic went out
+within the interval, since the operator's ingress already sees that activity. The
+operator's default staleness threshold is twice the interval, so one missed
+heartbeat is grace rather than a disconnect. If heartbeats stop, the operator
+marks the client offline after the threshold.
+
+---
+
+## Worked flows
+
+### A unary RPC round-trip
+
+```mermaid
+sequenceDiagram
+    participant C as caller
+    participant S as generated stub
+    participant UF as UnaryFacade
+    participant RR as ResponseRegistry
+    participant E as edge
+    participant SRV as operator handler
+    participant IL as ingress loop
+
+    C->>S: SayHello(ctx, req)
+    S->>UF: SendRPC(method, req)
+    UF->>RR: RegisterWaiter(corrID)
+    UF->>E: Send(KIND_REQUEST)
+    E->>SRV: deliver request
+    SRV->>E: Send(KIND_RESPONSE, corrID)
+    IL->>E: Pull
+    E-->>IL: KIND_RESPONSE
+    IL->>RR: DeliverResponse(corrID, env)
+    S->>UF: AwaitRPC(corrID, resp)
+    RR-->>UF: future completes
+    UF->>UF: check error header, else unmarshal body
+    UF-->>S: resp
+    S-->>C: (resp, nil)
+```
+
+### A durable event, egressed
+
+```mermaid
+sequenceDiagram
+    participant RA as round actor
+    participant DM as durable mailbox
+    participant SCA as ServerConnectionActor
+    participant E as edge
+    participant SRV as operator
+
+    RA->>DM: Tell(SendClientEventRequest)
+    DM->>DM: persist (TLV) before returning
+    DM->>SCA: Receive(...)
+    SCA->>SCA: toProto + derive stable msg_id / idempotency_key
+    SCA->>E: Send(KIND_EVENT)
+    E->>SRV: deliver event
+    Note over DM: on crash, replay yields the same IDs, so the server dedups
+```
+
+### A server-pushed event, ingressed
+
+```mermaid
+sequenceDiagram
+    participant SRV as operator
+    participant E as edge
+    participant IL as ingress loop
+    participant D as dispatcher closure
+    participant TA as target durable actor
+    participant DB as local store
+
+    SRV->>E: Send(KIND_EVENT, service, method)
+    IL->>E: Pull
+    E-->>IL: KIND_EVENT
+    IL->>D: dispatcher(ctx, env)
+    D->>D: unmarshal body to proto, adapt to actor msg
+    D->>TA: Tell(actorMsg)
+    TA->>DB: persist to durable mailbox
+    D-->>IL: nil (committed)
+    IL->>IL: AdvanceDispatch(nextCursor)
+    IL->>E: AckUpTo(cursor)
+    IL->>DB: checkpoint AckState
+```
+
+---
+
+## Crash recovery on each end
+
+Three recovery paths run independently when the client restarts.
+
+Egress is the durable actor replaying its inbox. Each persisted
+`SendClientEventRequest` reproduces the same stable identifiers from its stored
+payload, so the operator deduplicates the retries.
+
+Ingress restores the four-cursor `AckState` from its checkpoint and resumes
+pulling from `PullCursor`. If an ack was pending at crash time, it acks first. Any
+envelopes re-pulled in the gap are handled idempotently by the durable actors
+they dispatch into.
+
+Unary RPCs keep their waiters in memory only, so a crash cancels every waiting
+caller's context. Callers retry with a fresh correlation id, or reuse a stable
+idempotency key so the operator deduplicates.
+
+The operator's `clientconn` recovers symmetrically: it persists its own ack
+watermark and resumes pulling from the client's mailbox, redelivering anything
+the client had not yet acked.
+
+---
+
+## The wire contract
+
+Both ends must uphold these properties, independent of either implementation:
+
+- Delivery is at-least-once, so a send may be retried and a pull may return
+  duplicates. Both ends are idempotent.
+- The sender sets a stable idempotency key on any retriable request, and the
+  receiver deduplicates on it without assuming uniqueness.
+- A response echoes the request's correlation id, and a caller with concurrent
+  requests demultiplexes by correlation id before it advances any ack watermark.
+- Ordering is stable only within a single mailbox stream. Neither side assumes a
+  cross-mailbox order or a request-to-response order beyond correlation.
+- The ack watermark is monotonic and safe to retry. A side acks only after it
+  persists whatever it needs to keep in-flight work, never past work that is not
+  yet durable locally.
+- A pull blocks up to a bounded timeout, returns promptly on new data, and
+  returns before the timeout elapses.
+- Payloads are protobuf-encoded, and receivers unmarshal forward-compatibly,
+  discarding unknown fields. The generated stubs are a convenience over the
+  transport, not a constraint on it.
+- Application errors ride in an envelope header as an encoded gRPC status,
+  separate from the transport's own failure domain.
+
+For the normative, implementation-ready version of this contract, see
+[`RPC_MAILBOX_CONTRACT.md`](RPC_MAILBOX_CONTRACT.md).
+
+---
+
+## Related documents
+
+- [`mailbox_durable_actor_layer.md`](mailbox_durable_actor_layer.md) covers the
+  durable actor layer this transport stands on: leases, deduplication, the
+  transactional outbox, and the classic and Read/Commit execution paths.
+- [`RPC_MAILBOX_CONTRACT.md`](RPC_MAILBOX_CONTRACT.md) records the non-normative
+  protocol contract notes on ordering, idempotency, and ack semantics.


### PR DESCRIPTION
In this PR, we add two self-contained docs for the durable actor + mailbox
machinery. They're written to be read on their own rather than leaning on
the existing `mailbox_architecture.md` / `durable_actor_architecture.md`,
and they cross-link each other. We base this off #662 because the first
doc covers the new Read/Commit execution path that lands there, and the
pre-existing docs predate it.

The split is by altitude. The first doc is the foundation (how one actor
processes one message without losing it), and the second sits on top of it
(how that machinery carries traffic to and from the operator). See each
commit message for a detailed description w.r.t the incremental changes.

## Durable mailbox + actor layer

`docs/mailbox_durable_actor_layer.md` starts from the crash windows the
layer exists to close, then walks the durable mailbox, leases, and dedup
that turn at-least-once delivery into exactly-once processing. The reason
this doc is new rather than an edit to `durable_actor_architecture.md` is
the Read/Commit path: that older doc only knows the classic
whole-`Receive` transaction, so there's no map for when to reach for
`TxBehavior` / `Exec[S]`, how the lease fence keeps the commit
exactly-once if the behavior stalls past its lease during IO, or what the
`StoreFactory` atomicity contract requires (and the two ways to break it).
We document the classic path and the Read/Commit path side by side, ground
the latter in the client ledger's two-leg `ExitCost` handler, and end with
a checklist for picking one.

## Mailbox transport: serverconn and clientconn

`docs/mailbox_transport_serverconn_clientconn.md` relates this client's
`serverconn` to the operator's `clientconn` ingress loop (which lives in
the server repo). The framing the current mailbox doc lacks is the wire
relationship between the two ends: they never share a process or a
connection, they're mirror images talking through each other's mailboxes,
which is exactly why the connection primitives were factored out into
`mailbox/conn`. We make that symmetry the spine, work up from the envelope
through the `Send`/`Pull`/`AckUpTo` edge API and the shared primitives, and
pin down the parts of the contract the operator has to honor (heartbeat via
`clientconn.v1.HeartbeatService`, idempotency, correlation, ordering). It
also covers pubkey-derived mailbox identity, the BIP-340 Schnorr auth
header, mTLS, and liveness.

## Notes for review

These are docs only, no code changes. The diagrams are mermaid, so they
render inline on GitHub. The prose was run through a clarity pass (classic
style: concrete nouns, active verbs, given-before-new ordering, acronyms
spelled out on first use), so it should read cleanly top to bottom.

Targeting `durable-actor-read-commit-path` rather than `main` so the
Read/Commit references resolve against code that exists. Happy to retarget
to `main` once #662 merges.

## Test plan

- [x] `make commitmsg-lint` clean on both commits
- [x] all intra-doc and cross-doc links resolve to real files
- [x] mermaid blocks render