### PR TITLE
round: reap rounds that settle in the terminal failed state

### DIFF
--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -163,6 +163,15 @@ state transitions and validation rules live under [Invariants](#invariants).
   dedicated FSM per round handles confirmation monitoring.
 - The round actor does **not** mark VTXOs as `PendingForfeit` — the
   wallet/manager admits VTXOs before sending `RegisterIntentMsg`.
+- A round that settles in the terminal `ClientFailedState` (admission
+  timeout, server rejection, quote rejection, forfeit-collection timeout,
+  etc.) is reaped from the actor's `rounds` map by `reapIfFailed`, called
+  after every event in `askEventAndProcessOutbox`. This mirrors
+  `onRoundComplete` (success) and `handleCancelRound` (explicit cancel) so
+  failed/timed-out rounds don't accumulate in memory or `ListRounds`.
+  Nothing reuses a failed round — `findAssemblingRound` only returns
+  `Idle`/`PendingRoundAssembly` rounds, and the FSM's recovery transitions
+  have no production producer — so reaping the settled failed state is safe.
 - `ClientWallet` provides MuSig2 signing and key derivation; boarding
   address creation is handled by the wallet actor (not the round FSM).
 - Persisted VTXO ownership uses `OwnerKey` (not `SigningKey`). For

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -163,6 +163,15 @@ state transitions and validation rules live under [Invariants](#invariants).
   dedicated FSM per round handles confirmation monitoring.
 - The round actor does **not** mark VTXOs as `PendingForfeit` — the
   wallet/manager admits VTXOs before sending `RegisterIntentMsg`.
+- A round that settles in the terminal `ClientFailedState` (admission
+  timeout, server rejection, quote rejection, forfeit-collection timeout,
+  etc.) is reaped from the actor's `rounds` map by `reapIfFailed`, called
+  after every event in `askEventAndProcessOutbox`. This mirrors
+  `onRoundComplete` (success) and `handleCancelRound` (explicit cancel) so
+  failed/timed-out rounds don't accumulate in memory or `ListRounds`.
+  Nothing reuses a failed round — `findAssemblingRound` only returns
+  `Idle`/`PendingRoundAssembly` rounds, and the FSM's recovery transitions
+  have no production producer — so reaping the settled failed state is safe.
 - `ClientWallet` provides MuSig2 signing and key derivation; boarding
   address creation is handled by the wallet actor (not the round FSM).
 - Persisted VTXO ownership uses `OwnerKey` (not `SigningKey`). For

--- a/round/actor.go
+++ b/round/actor.go
@@ -1007,6 +1007,13 @@ func (a *RoundClientActor) askEventAndProcessOutbox(ctx context.Context,
 		}
 	}
 
+	// If the event settled the round in the terminal failed state, reap it
+	// so timed-out / failed rounds don't accumulate in the actor's map and
+	// ListRounds view. This runs unconditionally (not only when the outbox
+	// is non-empty) because some failure transitions — e.g. BoardingFailed
+	// in PendingRoundAssembly / IntentSentState — emit no outbox.
+	a.reapIfFailed(ctx, roundFSM)
+
 	return nil
 }
 
@@ -1932,9 +1939,17 @@ func (a *RoundClientActor) handleCancelRound(ctx context.Context,
 		})
 	}
 
-	// Remove the cancelled round from the map.
+	// Remove the cancelled round. When the injected BoardingFailed settles
+	// the round in ClientFailedState, the reap in askEventAndProcessOutbox
+	// has already stopped the FSM and removed it. But some states (e.g.
+	// QuoteReceivedState) self-loop on BoardingFailed, so the reap does not
+	// fire there — an explicit cancel must still drop the round. Guard on
+	// presence so we don't double-stop an FSM the reap already cleaned up.
 	keyStr := RoundKeyStr(targetFSM.Key.KeyString())
-	delete(a.rounds, keyStr)
+	if _, exists := a.rounds[keyStr]; exists {
+		targetFSM.FSM.Stop()
+		delete(a.rounds, keyStr)
+	}
 
 	a.log.InfoS(ctx, "Round participation cancelled successfully")
 
@@ -1962,6 +1977,57 @@ func (a *RoundClientActor) onRoundComplete(ctx context.Context, roundID RoundID,
 	delete(a.commitmentTxIndex, txid)
 
 	return a.cfg.RoundStore.FinalizeRound(ctx, roundID, txid, confInfo)
+}
+
+// reapIfFailed removes a round FSM from active tracking once an event has
+// settled it in the terminal ClientFailedState. Rounds that fail or time out
+// (registration/admission timeout, server rejection, quote rejection,
+// forfeit-collection timeout, etc.) would otherwise linger in the rounds map
+// for the lifetime of the daemon — and keep surfacing in ListRounds — because
+// only successful completion (onRoundComplete) and explicit cancellation
+// (handleCancelRound) removed rounds. Nothing reuses a failed round in
+// production: findAssemblingRound only returns Idle / PendingRoundAssembly
+// rounds, and the FSM's IntentPackage / RecoveryInitiated recovery transitions
+// have no production producer. This closes that gap for autonomous failures.
+//
+// Reaping only the *settled* terminal-failed state is safe even against the
+// recovery transition: a round that recovers within the same turn
+// (ClientFailed -> Idle -> PendingRoundAssembly via an internal IntentPackage)
+// does not end the turn in ClientFailedState, so it is left untouched.
+func (a *RoundClientActor) reapIfFailed(ctx context.Context,
+	roundFSM *RoundFSM) {
+
+	keyStr := RoundKeyStr(roundFSM.Key.KeyString())
+
+	// If the round was already removed during outbox processing (e.g. a
+	// successful round handled by onRoundComplete), there is nothing to do
+	// and the FSM may already be stopped.
+	if _, ok := a.rounds[keyStr]; !ok {
+		return
+	}
+
+	state, err := roundFSM.FSM.CurrentState()
+	if err != nil {
+		return
+	}
+
+	// Only the settled, truly-terminal ClientFailedState is reaped.
+	// RecoveryInitiatedState is deliberately NOT reaped: it is
+	// semi-terminal (states.go) and represents a round whose CSV-timeout
+	// sweep tx has been broadcast and is awaiting confirmation — in-flight
+	// work, not a settled failure. Dropping it on entry would stop tracking
+	// an active recovery.
+	if _, failed := state.(*ClientFailedState); !failed {
+		return
+	}
+
+	a.log.InfoS(ctx, "Reaping failed round",
+		slog.String("round_key", string(keyStr)),
+	)
+
+	roundFSM.FSM.Stop()
+	delete(a.rounds, keyStr)
+	delete(a.commitmentTxIndex, roundFSM.TxID)
 }
 
 // handleConfirmation processes a commitment transaction confirmation event

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -1036,7 +1036,11 @@ func TestActorLifecycle(t *testing.T) {
 			Recoverable: true,
 		})
 
-		h.assertFSMState("ClientFailedState")
+		// The failed round is reaped, leaving no rounds tracked.
+		require.Empty(
+			t, h.queryState(),
+			"failed round should be reaped",
+		)
 	})
 
 	t.Run("concurrent_rounds", func(t *testing.T) {
@@ -1277,6 +1281,10 @@ func TestActorServerMessageRouting(t *testing.T) {
 		expectedState string
 		expectOutbox  bool
 		outboxMsgType string
+
+		// expectReaped asserts the round is removed from tracking
+		// (e.g. it failed) rather than left in expectedState.
+		expectReaped bool
 	}{
 		{
 			name: "IntentRequested_from_PendingRoundAssembly",
@@ -1399,8 +1407,8 @@ func TestActorServerMessageRouting(t *testing.T) {
 					Recoverable: true,
 				}
 			},
-			expectedState: "ClientFailedState",
-			expectOutbox:  false,
+			expectOutbox: false,
+			expectReaped: true,
 		},
 	}
 
@@ -1415,7 +1423,14 @@ func TestActorServerMessageRouting(t *testing.T) {
 			event := tc.serverEvent(h)
 			h.sendServerMessage(event)
 
-			h.assertFSMState(tc.expectedState)
+			if tc.expectReaped {
+				require.Empty(
+					h.t, h.queryState(),
+					"failed round should be reaped",
+				)
+			} else {
+				h.assertFSMState(tc.expectedState)
+			}
 			if tc.expectOutbox {
 				h.assertServerMessageSent(tc.outboxMsgType)
 			}
@@ -2113,17 +2128,12 @@ func TestHandleForfeitCollectionTimeout(t *testing.T) {
 			"actor receive failed: %v", result.Err(),
 		)
 
+		// The failed round is reaped so it does not linger in the
+		// actor's map. The failure reason/recoverability is covered by
+		// the FSM-level forfeit-collection-timeout test.
 		states := h.queryState()
-		stateInfo, exists := states[string(keyStr)]
-		require.True(t, exists, "expected round state")
-		failedState, ok := stateInfo.State.(*ClientFailedState)
-		require.True(
-			t, ok, "expected ClientFailedState, got %T",
-			stateInfo.State,
-		)
-		require.Contains(t, failedState.Reason, "forfeit signature")
-		require.Contains(t, failedState.Reason, "timeout")
-		require.True(t, failedState.Recoverable)
+		_, exists := states[string(keyStr)]
+		require.False(t, exists, "failed round should be reaped")
 	})
 
 	t.Run("ignores_unknown_timeout_phase", func(t *testing.T) {
@@ -2218,17 +2228,11 @@ func TestHandleForfeitCollectionTimeout(t *testing.T) {
 			"timeout receive failed: %v", result.Err(),
 		)
 
-		// Confirm the first round is now failed.
+		// The first round failed on timeout and is reaped.
 		keyStr1 := RoundKeyStr(roundID1.KeyString())
 		states := h.queryState()
-		stateInfo, exists := states[string(keyStr1)]
-		require.True(t, exists)
-		failedState, ok := stateInfo.State.(*ClientFailedState)
-		require.True(
-			t, ok, "expected ClientFailedState, got %T",
-			stateInfo.State,
-		)
-		require.True(t, failedState.Recoverable)
+		_, exists := states[string(keyStr1)]
+		require.False(t, exists, "failed round should be reaped")
 
 		// Phase 2: Start a new round from a boarding confirmation,
 		// proving the actor is still healthy.
@@ -2242,6 +2246,49 @@ func TestHandleForfeitCollectionTimeout(t *testing.T) {
 		h.assertFSMState("IntentSentState")
 		h.assertServerMessageSent("SendClientEventRequest")
 	})
+}
+
+// TestActorReapsFailedRound verifies that a round driven into the terminal
+// failed state is removed from the actor's tracking rather than left to
+// accumulate. Here the round fails via a registration (admission) timeout
+// while parked in IntentSentState.
+func TestActorReapsFailedRound(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	h.setupMockRoundStoreForStart()
+	require.NoError(t, h.start())
+
+	// Drive a round to IntentSentState (join request sent, awaiting the
+	// server's admission watermark).
+	intent := h.newTestBoardingIntent()
+	h.sendWalletConfirmation(intent)
+	h.assertFSMState("PendingRoundAssembly")
+	h.sendVTXORequests(50000)
+	h.sendServerMessage(&IntentRequested{})
+	h.assertFSMState("IntentSentState")
+
+	// Grab the (temp) key of the in-flight round.
+	before := h.queryState()
+	require.Len(t, before, 1)
+	var keyStr string
+	for k := range before {
+		keyStr = k
+	}
+
+	// Fire the registration timeout for that round.
+	msg := &TimeoutMsg{
+		TimeoutID: makeTimeoutID(
+			RoundKeyStr(keyStr), TimeoutPhaseRegistration,
+		),
+	}
+	require.True(t, h.receive(msg).IsOk())
+
+	// The failed round is reaped, leaving no rounds tracked.
+	after := h.queryState()
+	_, exists := after[keyStr]
+	require.False(t, exists, "failed round should be reaped")
+	require.Empty(t, after, "no rounds should remain tracked")
 }
 
 // TestRealTimeoutActorForfeitExpiry exercises the full timeout flow with a
@@ -2305,18 +2352,11 @@ func TestRealTimeoutActorForfeitExpiry(t *testing.T) {
 	require.True(t, result.IsOk(), "actor receive failed: %v",
 		result.Err())
 
-	// Verify the round transitioned to failed.
+	// Verify the failed round is reaped after the real timeout fires.
 	keyStr := RoundKeyStr(roundID.KeyString())
 	states := h.queryState()
-	stateInfo, exists := states[string(keyStr)]
-	require.True(t, exists, "expected round state")
-	failedState, ok := stateInfo.State.(*ClientFailedState)
-	require.True(
-		t, ok, "expected ClientFailedState, got %T", stateInfo.State,
-	)
-	require.Contains(t, failedState.Reason, "forfeit signature")
-	require.Contains(t, failedState.Reason, "timeout")
-	require.True(t, failedState.Recoverable)
+	_, exists := states[string(keyStr)]
+	require.False(t, exists, "failed round should be reaped")
 
 	// Phase 2: Start a new round to prove actor recovery.
 	intent := h.newTestBoardingIntent()


### PR DESCRIPTION
Follow-up to #659 (Roasbeef's review note):

> Can follow up later with this, but I realized that we don't ever delete the rounds that we'd otherwise timeout or fail via other means (only on successful round, or explicit cancel, etc.).

## Problem

Only two paths removed a round from the round actor's in-memory `rounds` map:
- `onRoundComplete` — successful completion (`ConfirmedState`).
- `handleCancelRound` — explicit user cancellation.

Rounds that failed or timed out **autonomously** — registration/admission timeout (#653/#659), server rejection, quote rejection, forfeit-collection timeout, etc. — settled in `ClientFailedState` but were **never removed**. They lingered in memory and kept surfacing in `ListRounds` for the lifetime of the daemon.

## Fix

Add `reapIfFailed`, invoked after every event in `askEventAndProcessOutbox`: when an event settles a round in the terminal `ClientFailedState`, stop its FSM and drop it from the `rounds` (and `commitmentTxIndex`) maps — mirroring the success (`onRoundComplete`) and explicit-cancel (`handleCancelRound`) paths.

Notes:
- The reap runs **unconditionally** (not gated on a non-empty outbox) because some failure transitions — e.g. `BoardingFailed` in `PendingRoundAssembly`/`IntentSentState` — emit no outbox.
- Reaping only the **settled** failed state is safe:
  - Nothing reuses a failed round: `findAssemblingRound` only returns `Idle`/`PendingRoundAssembly` rounds, and the FSM's `IntentPackage`/`RecoveryInitiated` recovery transitions have **no production producer** (only constructed in the transition table and tests).
  - A round that recovers within the same turn (`ClientFailed → Idle → PendingRoundAssembly` via an internal `IntentPackage`) does not *end* the turn in `ClientFailedState`, so it is left untouched.
- This also fixes a minor pre-existing leak: `handleCancelRound` previously dropped the cancelled round from the map without stopping its FSM; the central reap now stops it.

## Testing

- New `TestActorReapsFailedRound` — drives a round to `IntentSentState`, fires the registration timeout, asserts the round is reaped (no rounds remain tracked).
- Updated the existing failure-path actor tests (forfeit-collection timeout, real-timer timeout, `timeout_then_new_round`, server-rejection routing, `registration_failure`) to assert the round is reaped rather than left lingering in `ClientFailedState`. The failure *reason* remains covered by the FSM-level transition tests.
- `go test ./round/...`, `make lint-changed-local` (0 issues), `make fmt-changed`, `make doc-check` all clean.

Per-package docs (`round/CLAUDE.md`, `round/AGENTS.md`) updated with the reaping invariant.