### PR TITLE
unroll: run VTXOUnrollActor on the durable Read/Commit path

### DIFF
--- a/baselib/actor/durable_actor.go
+++ b/baselib/actor/durable_actor.go
@@ -730,11 +730,12 @@ func (a *DurableActor[M, R]) processWithExec(ctx context.Context,
 	defer stop()
 
 	core := &execCore{
-		store:      a.txAwareStore,
-		msgID:      delivery.ID,
-		leaseToken: delivery.LeaseToken,
-		actorID:    a.id,
-		dedupTTL:   a.deduplicationTTL,
+		store:         a.txAwareStore,
+		msgID:         delivery.ID,
+		leaseToken:    delivery.LeaseToken,
+		actorID:       a.id,
+		dedupTTL:      a.deduplicationTTL,
+		leaseDuration: a.leaseDuration,
 	}
 
 	result := a.runExecSafely(ctx, delivery, tb, core)

--- a/baselib/actor/tx_exec.go
+++ b/baselib/actor/tx_exec.go
@@ -32,6 +32,26 @@ type Exec[S any] interface {
 	Read(ctx context.Context,
 		fn func(ctx context.Context, store S) error) error
 
+	// Stage runs fn inside one short, lease-fenced writer transaction with
+	// no dedup mark and no ack. Use it to durably advance behavior state
+	// (e.g. a checkpoint) BEFORE doing side-effect IO, when the behavior
+	// must preserve a persist-before-effect invariant but the message is
+	// only consumed once at the end via Commit. A Stage write is its own
+	// atomic unit; it is NOT atomic with the eventual Commit. Because the
+	// writer lock is released the moment Stage returns, the following IO
+	// never holds it -- that is the whole point of staging ahead of a slow
+	// side effect.
+	//
+	// Stage is fenced on the lease token: if this consumer's lease was
+	// reclaimed during the IO window, Stage returns ErrLeaseLost and
+	// applies nothing, so a stale consumer cannot regress a newer owner's
+	// checkpoint. Behaviors that Stage must still be replay-safe: a crash
+	// after a Stage but before Commit redelivers the message and re-applies
+	// it against the already-advanced state, so each staged advance must be
+	// idempotent (monotonic state, dedup'd downstream effects).
+	Stage(ctx context.Context,
+		fn func(ctx context.Context, store S) error) error
+
 	// Commit runs fn inside one short writer transaction. Every store call
 	// inside fn is atomic together. The framework folds the lease-fenced
 	// ack and the dedup mark into this same transaction, so the behavior's
@@ -111,6 +131,12 @@ type execCore struct {
 	// dedupTTL is how long the processed-message marker is retained.
 	dedupTTL time.Duration
 
+	// leaseDuration is how long Stage extends the lease by when it fences.
+	// Stage reuses ExtendLease as its token fence, so the fenced lease
+	// check and a heartbeat-style extension happen in the same transaction
+	// as the staged write.
+	leaseDuration time.Duration
+
 	// committed records whether a Commit transaction succeeded. When true,
 	// the state write, dedup mark, and fenced ack are already durable, so
 	// the actor must not ack again.
@@ -123,6 +149,64 @@ func (e *execCore) read(ctx context.Context,
 
 	return e.store.ExecTx(ctx, true, func(txCtx context.Context,
 		s DeliveryStore) error {
+
+		return fn(txCtx, s)
+	})
+}
+
+// stage runs fn inside one short writer transaction that is lease-fenced but
+// does NOT ack the message or write a dedup mark. It durably advances behavior
+// state ahead of side-effect IO without consuming the message and without
+// setting committed; the message is consumed later by commit. The staged write
+// commits in its own transaction, independent of that eventual commit, so it
+// survives even a commit that rolls back with ErrLeaseLost.
+//
+// The fence matters once an actor can have more than one consumer. If this
+// consumer's lease expired during the IO window and another consumer reclaimed
+// and advanced (or consumed) the same mailbox row, an unfenced stage would let
+// this now-stale consumer overwrite the newer owner's checkpoint -- a lost
+// update / checkpoint regression. So stage fences first by extending its own
+// lease (ExtendLease validates the token): zero rows means the lease was
+// reclaimed, so we return ErrLeaseLost and roll back without running fn,
+// applying nothing. The extension doubles as a heartbeat folded into the write.
+// In a single-consumer deployment the fence always passes; it is defense for
+// the multi-consumer case.
+//
+// stage still never acks, so how the message is finally consumed depends on
+// what the behavior returns:
+//
+//   - Behavior errors before/at commit: processWithExec finds committed unset
+//     and falls to finishNonTx, which nacks for redelivery. The redelivered
+//     message replays the staged advance against the already-persisted state,
+//     so the behavior MUST be idempotent under replay.
+//
+//   - Behavior returns success without ever calling commit: finishNonTx acks
+//     the message anyway (the same tail that consumes a RestartMessage), so it
+//     is NOT redelivered -- but it is consumed WITHOUT the lease-fenced,
+//     co-transactional dedup that commit folds in. A behavior that staged
+//     domain state and then needs exactly-once consumption must therefore call
+//     commit; returning success without it silently downgrades to an at-least-
+//     once consume.
+func (e *execCore) stage(ctx context.Context,
+	fn func(ctx context.Context, ds DeliveryStore) error) error {
+
+	return e.store.ExecTx(ctx, false, func(txCtx context.Context,
+		s DeliveryStore) error {
+
+		// Fence first: extending our lease validates the token. Zero
+		// rows means the lease was reclaimed while the behavior did IO,
+		// so a now-stale consumer must not advance durable state --
+		// abort and roll back without running fn, so it cannot regress
+		// a newer owner's checkpoint.
+		rows, err := s.ExtendLease(
+			txCtx, e.msgID, e.leaseToken, e.leaseDuration,
+		)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return ErrLeaseLost
+		}
 
 		return fn(txCtx, s)
 	})
@@ -189,6 +273,18 @@ func (e execHandle[S]) Read(ctx context.Context,
 	fn func(ctx context.Context, store S) error) error {
 
 	return e.core.read(ctx, func(txCtx context.Context,
+		ds DeliveryStore) error {
+
+		return fn(txCtx, e.factory(txCtx, ds))
+	})
+}
+
+// Stage implements Exec by running the closure against a typed store inside an
+// unfenced writer transaction that neither acks nor dedups the message.
+func (e execHandle[S]) Stage(ctx context.Context,
+	fn func(ctx context.Context, store S) error) error {
+
+	return e.core.stage(ctx, func(txCtx context.Context,
 		ds DeliveryStore) error {
 
 		return fn(txCtx, e.factory(txCtx, ds))

--- a/baselib/actor/tx_exec_test.go
+++ b/baselib/actor/tx_exec_test.go
@@ -104,11 +104,12 @@ func (h *execHarness) seedLeased(t require.TestingT, mailboxID, msgID,
 // coreFor builds an execCore bound to msgID and holding leaseToken.
 func (h *execHarness) coreFor(msgID, leaseToken string) *execCore {
 	return &execCore{
-		store:      h.store,
-		msgID:      msgID,
-		leaseToken: leaseToken,
-		actorID:    "actor-a",
-		dedupTTL:   time.Hour,
+		store:         h.store,
+		msgID:         msgID,
+		leaseToken:    leaseToken,
+		actorID:       "actor-a",
+		dedupTTL:      time.Hour,
+		leaseDuration: time.Minute,
 	}
 }
 
@@ -614,5 +615,199 @@ func TestExecCommitAtomicGroupingProperty(t *testing.T) {
 		for _, id := range ids {
 			require.True(rt, h.outboxHas(id))
 		}
+	})
+}
+
+// TestExecStageWritesIndependentOfAck verifies the core Stage contract: a Stage
+// commits its writes in their own transaction but does NOT ack or dedup the
+// message and does NOT mark the core committed. The write is durable while the
+// message remains claimable for a later Commit.
+func TestExecStageWritesIndependentOfAck(t *testing.T) {
+	t.Parallel()
+
+	h := newExecHarness()
+	h.seedLeased(t, "mb", "m1", "tok-1")
+
+	core := h.coreFor("m1", "tok-1")
+	err := core.stage(context.Background(), enqueueEffects("staged-1"))
+	require.NoError(t, err)
+
+	// The staged write is durable, but the message is neither consumed nor
+	// marked processed, and the core is not committed.
+	require.True(t, h.outboxHas("staged-1"))
+	require.False(t, core.committed)
+	h.requireRetained(t, "m1")
+}
+
+// TestExecStageFencesStaleToken verifies that Stage is lease-fenced: a Stage
+// attempted with a lease token that no longer matches the held lease (the
+// message was reclaimed by another consumer) returns ErrLeaseLost and applies
+// nothing, so a stale consumer cannot regress a newer owner's checkpoint.
+func TestExecStageFencesStaleToken(t *testing.T) {
+	t.Parallel()
+
+	h := newExecHarness()
+	h.seedLeased(t, "mb", "m1", "tok-1")
+
+	// A core holding a stale token: the lease fence rejects the staged
+	// write just as it would reject a commit.
+	core := h.coreFor("m1", "stale-token")
+
+	var stageWriteRan bool
+	err := core.stage(context.Background(), func(ctx context.Context,
+		ds DeliveryStore) error {
+
+		stageWriteRan = true
+
+		return enqueueEffects("staged-1")(ctx, ds)
+	})
+	require.ErrorIs(t, err, ErrLeaseLost)
+
+	require.False(
+		t, stageWriteRan,
+		"stage closure must not run when the fence rejects the stage",
+	)
+	require.False(t, h.outboxHas("staged-1"))
+	require.False(t, core.committed)
+	h.requireRetained(t, "m1")
+}
+
+// TestExecStageSurvivesLeaseLostCommit verifies the central early-durable-write
+// property: a Staged write persists even when a later Commit loses the fence.
+// The Commit's transaction (the ack + dedup) rolls back, but the earlier
+// Stage's transaction already committed, so the staged effect remains and the
+// message is retained for an idempotent replay.
+func TestExecStageSurvivesLeaseLostCommit(t *testing.T) {
+	t.Parallel()
+
+	h := newExecHarness()
+	h.seedLeased(t, "mb", "m1", "tok-1")
+
+	// Stage durably under the held lease.
+	staged := h.coreFor("m1", "tok-1")
+	require.NoError(
+		t,
+		staged.stage(
+			context.Background(), enqueueEffects("staged-1"),
+		),
+	)
+
+	// Now a Commit with a stale token loses the fence and rolls back.
+	stale := h.coreFor("m1", "stale-token")
+	var commitWriteRan bool
+	err := stale.commit(context.Background(), func(ctx context.Context,
+		ds DeliveryStore) error {
+
+		commitWriteRan = true
+
+		return enqueueEffects("commit-1")(ctx, ds)
+	})
+	require.ErrorIs(t, err, ErrLeaseLost)
+
+	// The staged write survived; the commit write never ran; the message is
+	// retained for redelivery.
+	require.True(t, h.outboxHas("staged-1"))
+	require.False(t, h.outboxHas("commit-1"))
+	require.False(t, commitWriteRan)
+	require.False(t, stale.committed)
+	h.requireRetained(t, "m1")
+}
+
+// TestExecStageThenCommitConsumesTogether verifies the normal sequence: one or
+// more Stage writes ahead of the IO, then a single fenced Commit that consumes
+// the message. After Commit every staged effect and the commit effect are
+// durable, and the message is consumed and marked processed.
+func TestExecStageThenCommitConsumesTogether(t *testing.T) {
+	t.Parallel()
+
+	h := newExecHarness()
+	h.seedLeased(t, "mb", "m1", "tok-1")
+
+	core := h.coreFor("m1", "tok-1")
+	require.NoError(
+		t,
+		core.stage(
+			context.Background(), enqueueEffects("staged-1"),
+		),
+	)
+	require.NoError(
+		t,
+		core.commit(
+			context.Background(), enqueueEffects("commit-1"),
+		),
+	)
+
+	require.True(t, core.committed)
+	require.True(t, h.outboxHas("staged-1"))
+	require.True(t, h.outboxHas("commit-1"))
+	h.requireConsumed(t, "m1")
+}
+
+// TestExecStageThenCommitAtomicGroupingProperty is the property form of the
+// staged-write durability invariant: across an arbitrary number of Stage writes
+// and a final Commit under a matching-or-stale lease, every staged effect is
+// always durable (each Stage is its own committed transaction), while the
+// consume step (ack + dedup + the commit effect) lands exactly when the lease
+// still matches and is otherwise a no-op that leaves the message for replay.
+func TestExecStageThenCommitAtomicGroupingProperty(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		n := rapid.IntRange(0, 6).Draw(rt, "numStaged")
+		sameLease := rapid.Bool().Draw(rt, "sameLease")
+
+		held := "tok"
+		attempted := held
+		if !sameLease {
+			attempted = held + "-mismatch"
+		}
+
+		h := newExecHarness()
+		h.seedLeased(rt, "mb", "m1", held)
+
+		// Stage n effects, each in its own non-fenced transaction. The
+		// staging core always holds the real lease.
+		stager := h.coreFor("m1", held)
+		staged := make([]string, n)
+		for i := range staged {
+			staged[i] = fmt.Sprintf("staged-%d", i)
+			require.NoError(
+				rt,
+				stager.stage(
+					context.Background(),
+					enqueueEffects(staged[i]),
+				),
+			)
+		}
+
+		// Every staged effect is durable regardless of the fence below.
+		for _, id := range staged {
+			require.True(rt, h.outboxHas(id))
+		}
+
+		// The single Commit consumes the message iff the lease matches.
+		core := h.coreFor("m1", attempted)
+		err := core.commit(
+			context.Background(), enqueueEffects("commit"),
+		)
+
+		if sameLease {
+			require.NoError(rt, err)
+			require.True(rt, core.committed)
+			h.requireConsumed(rt, "m1")
+			require.True(rt, h.outboxHas("commit"))
+			require.Equal(rt, n+1, h.outboxCount())
+
+			return
+		}
+
+		// Stale lease: the consume step is a no-op, the commit effect
+		// is absent, and the staged effects remain -- the message is
+		// held for an idempotent replay.
+		require.ErrorIs(rt, err, ErrLeaseLost)
+		require.False(rt, core.committed)
+		require.False(rt, h.outboxHas("commit"))
+		require.Equal(rt, n, h.outboxCount())
+		h.requireRetained(rt, "m1")
 	})
 }

--- a/ledger/handlers_test.go
+++ b/ledger/handlers_test.go
@@ -145,6 +145,14 @@ func (e fakeExec) Read(ctx context.Context,
 	return fn(ctx, e.store)
 }
 
+// Stage runs fn against the actor's stores. The ledger handlers do not stage
+// (they validate then Commit), but the Exec interface requires it.
+func (e fakeExec) Stage(ctx context.Context,
+	fn func(context.Context, ledgerTx) error) error {
+
+	return fn(ctx, e.store)
+}
+
 // Commit runs fn against the actor's stores.
 func (e fakeExec) Commit(ctx context.Context,
 	fn func(context.Context, ledgerTx) error) error {

--- a/p-models/durableactor/CLAUDE.md
+++ b/p-models/durableactor/CLAUDE.md
@@ -26,6 +26,9 @@ exactly-once effect application under lease-expiry-during-IO).
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxReadCommitFence` | Run the green Read/Commit exactly-once-effect test |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxLegacyReorderCounterexample` | Demonstrate the old ordering bug |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxUnfencedCommitCounterexample` | Demonstrate the unfenced-commit double-apply bug |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStageCommitExactlyOnce` | Run the green Stage-then-Commit replay-safety test |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStagedDoubleBroadcastCounterexample` | Demonstrate the unstable-broadcast double-broadcast bug |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStaleStageRegressesCounterexample` | Demonstrate the unfenced-stage checkpoint regression bug |
 | `go test ./p-models/durableactor/bridge` | Replay traces against Go |
 
 ## Modeling Guidance

--- a/p-models/durableactor/README.md
+++ b/p-models/durableactor/README.md
@@ -38,11 +38,39 @@ request also selects an unfenced profile for the counterexample, where the
 effect is applied regardless of the lease token and a stale consumer
 double-applies it under reclaim.
 
+### Stage (early durable write)
+
+`eDurableMailboxStage` models the durable actor's Stage primitive
+(`baselib/actor` `Exec.Stage`): a short, **lease-fenced** writer transaction that
+advances behavior state *before* the side-effect IO, while the message is only
+consumed later by Commit. The unroll actor uses it to persist a sweep
+transaction before handing it to txconfirm (persist-before-broadcast). Because
+the staged write commits in its own transaction, it survives a later
+lease-lost Commit — in the model `checkpoint`/`sweepId` are spec-machine state
+that the fenced Commit (which only touches `rows`) never rolls back.
+
+The stage request carries two design knobs. `stable` selects how the broadcast
+id is chosen on replay (persisted-and-reused vs freshly-derived). `fenced`
+selects whether the checkpoint write validates the lease token first, mirroring
+the production Stage that fences on `ExtendLease`. A checkpoint write is an
+overwrite (`SaveCheckpoint` replaces the row), so under the fence only the live
+lease holder, which holds the newest state, writes, and the checkpoint stays
+monotone. An unfenced stale consumer would overwrite a newer checkpoint with an
+older level: the lost-update / checkpoint regression the fence prevents.
+
+The scenario the Stage path is checked against is a crash between the Stage and
+the Commit: a consumer leases a row, Stages its checkpoint and broadcasts, then
+crashes; a second consumer reclaims the same durable row and replays the same
+event. The green case also has the stale consumer wake up and try to Stage with
+its now-reclaimed token, which the fence rejects. Two counterexamples drive the
+two ways it can go wrong: the unstable profile re-derives a fresh broadcast id
+on replay (a second distinct broadcast), and the unfenced profile lets the stale
+consumer overwrite a newer checkpoint with an older level (a regression).
+
 ### Spec monitors
 
-The model carries two spec monitors. P does **not** activate spec monitors
-globally; each test case attaches the ones it wants with `assert <spec> in
-{ ... }`.
+P does **not** activate spec monitors globally; each test case attaches the
+ones it wants with `assert <spec> in { ... }`.
 
 - `SameKeyFIFOClaimsRespectLiveHead` is the global safety contract. It
   reconstructs the live per-lane row set from the enqueue/claim/removal stream
@@ -71,6 +99,21 @@ globally; each test case attaches the ones it wants with `assert <spec> in
   dedup that production also has as a downstream backstop. That omission is
   intentional (it proves the fence alone enforces exactly-once at the source);
   it is not a claim that the downstream dedup is unnecessary in every flow.
+- `StagedEffectAppliedAtMostOnceUnderReplay` is the safety contract for the
+  Stage path: across a Stage'd-but-unacked crash and replay, a row must never
+  broadcast two *distinct* downstream effects. `tcMailboxStageCommitExactlyOnce`
+  checks the stable design holds it; the negative
+  `tcMailboxStagedDoubleBroadcastCounterexample` runs the unstable profile with
+  no in-machine assertion, so the double-broadcast is raised solely by this
+  monitor — the exact failure the persist-before-broadcast / sweep-reuse rule
+  prevents.
+- `CheckpointAdvancesMonotonically` guards the other half of the Stage
+  contract: a staged checkpoint never moves backward. Because every stage write
+  is an overwrite, the fence is what keeps it monotone (only the live owner
+  writes). `tcMailboxStageCommitExactlyOnce` checks the fenced design holds it;
+  the negative `tcMailboxStaleStageRegressesCounterexample` runs the unfenced
+  profile with no in-machine assertion, so the checkpoint regression is raised
+  solely by this monitor — the lost-update the lease fence prevents.
 
 The Go bridge in `bridge/` replays JSON model traces from `traces/` against the real
 `db/actordelivery` SQLite store. This keeps the P model tied to the SQL claim

--- a/p-models/durableactor/src/mailbox_fifo.p
+++ b/p-models/durableactor/src/mailbox_fifo.p
@@ -100,6 +100,50 @@ type DurableMailboxCommitReq = (
     fenced: bool
 );
 
+// DurableMailboxStageReq models the durable actor's early-durable-write (Stage)
+// primitive: a short, non-fenced writer transaction that advances behavior
+// state BEFORE the side-effect IO, while the message is only consumed later by
+// Commit. A behavior that must persist-before-broadcast (e.g. the unroll actor
+// persisting a sweep transaction before handing it to txconfirm) stages here.
+//
+//   * effect_seq is the monotone checkpoint level the stage advances to (the
+//     FSM transition index). A replay of an already-staged level is a no-op.
+//
+//   * sweep_seq identifies the downstream broadcast (e.g. the sweep txid) the
+//     behavior will emit after this stage. `stable` selects the two designs:
+//
+//       - stable = true (production): the broadcast id is derived from the
+//         staged checkpoint and persisted with it, so a replay reuses the same
+//         id and the downstream (txconfirm) dedups it. At most one distinct
+//         broadcast occurs per row.
+//
+//       - stable = false (counterexample): the behavior derives a fresh
+//         broadcast id on every attempt (e.g. a sweep rebuilt with a new wallet
+//         address), so a replay broadcasts a new distinct id -- the
+//         double-broadcast the persist-before-broadcast / sweep-reuse rule
+//         exists to prevent.
+//
+//   * lease_token / fenced select whether the stage validates the lease before
+//     writing, mirroring the production Stage that fences on ExtendLease:
+//
+//       - fenced = true (production): the checkpoint write happens only when the
+//         lease token still matches. A consumer whose lease was reclaimed
+//         applies nothing, so it cannot regress a newer owner's checkpoint.
+//
+//       - fenced = false (counterexample): the write happens regardless of the
+//         token, modeling the original unfenced Stage where a stale consumer
+//         overwrites the checkpoint with its older state -- the lost-update /
+//         checkpoint regression the fence prevents.
+type DurableMailboxStageReq = (
+    reply_to: machine,
+    id: int,
+    lease_token: int,
+    effect_seq: int,
+    sweep_seq: int,
+    stable: bool,
+    fenced: bool
+);
+
 event eDurableMailboxEnqueue: DurableMailboxEnqueueReq;
 event eDurableMailboxLeaseNext: DurableMailboxLeaseNextReq;
 event eDurableMailboxAck: DurableMailboxTokenReq;
@@ -107,6 +151,7 @@ event eDurableMailboxNack: DurableMailboxNackReq;
 event eDurableMailboxExpireLeasesAt: int;
 event eDurableMailboxDeadLetter: DurableMailboxDeadLetterReq;
 event eDurableMailboxCommit: DurableMailboxCommitReq;
+event eDurableMailboxStage: DurableMailboxStageReq;
 
 event eDurableMailboxOpResp: (int, DurableMailboxOpResult);
 event eDurableMailboxLeaseResp: (int, DurableMailboxOpResult);
@@ -135,6 +180,22 @@ event eDurableMailboxRowRemoved: (machine, int);
 // for any one row is applied at most once across the run, even when the row's
 // lease expires mid-IO and the row is reclaimed and reprocessed.
 event eDurableMailboxEffectApplied: (machine, int);
+
+// eDurableMailboxCheckpointStaged is announced whenever a Stage advances a
+// row's durable checkpoint to a strictly higher level. It carries
+// (mbox, id, effect_seq). CheckpointAdvancesMonotonically uses it to assert a
+// staged checkpoint never moves backward and a replay never re-stages a stale
+// level as if it were new.
+event eDurableMailboxCheckpointStaged: (machine, int, int);
+
+// eDurableMailboxBroadcast is announced when a behavior performs the downstream
+// broadcast IO that follows a Stage (e.g. handing the sweep tx to txconfirm).
+// It carries (mbox, id, sweep_id) where sweep_id is the broadcast identity
+// (e.g. the sweep txid). StagedEffectAppliedAtMostOnceUnderReplay asserts that
+// across a Stage'd-but-unacked crash and replay, a row never broadcasts two
+// DISTINCT ids -- the production design reuses the persisted id, so the replay
+// re-broadcasts the same id and the downstream dedups it.
+event eDurableMailboxBroadcast: (machine, int, int);
 
 // eMailboxWorkArrived and eMailboxWorkDrained are emitted only by the liveness
 // driver to feed the non-starvation liveness monitor. Keeping them distinct
@@ -445,6 +506,16 @@ machine DurableMailboxSpec {
     var rows: seq[MailboxRow];
     var mode: MailboxClaimMode;
 
+    // checkpoint and sweepId model the behavior's durable, non-fenced staged
+    // state, written by Stage ahead of the side-effect IO. checkpoint[id] is
+    // the monotone FSM level; sweepId[id] is the persisted broadcast identity.
+    // Both are spec-machine state, so a failed (lease-lost) Commit -- which only
+    // touches rows -- never rolls them back: a staged write survives the
+    // rolled-back ack, exactly as a Stage transaction commits independently of
+    // the later fenced Commit.
+    var checkpoint: map[int, int];
+    var sweepId: map[int, int];
+
     start state Active {
         entry (claim_mode: MailboxClaimMode) {
             mode = claim_mode;
@@ -539,6 +610,73 @@ machine DurableMailboxSpec {
 
         on eDurableMailboxExpireLeasesAt do (now: int) {
             rows = ExpireMailboxLeases(rows, now);
+        }
+
+        // Stage models the durable actor's early-durable-write: a short,
+        // lease-fenced writer transaction that advances the behavior checkpoint
+        // and records the upcoming broadcast identity BEFORE the side-effect IO,
+        // without acking the message. A staged row stays claimable until a later
+        // Commit consumes it.
+        //
+        // The fence (production: fenced = true) validates the lease token before
+        // writing, mirroring the production Stage that fences on ExtendLease. A
+        // checkpoint write is an OVERWRITE (SaveCheckpoint replaces the row), so
+        // a stale consumer that wrote its older state would regress the
+        // checkpoint. The fence is what keeps the write monotone: only the live
+        // lease holder, which holds the newest state, writes. The unfenced
+        // profile (fenced = false) writes regardless of the token, so a stale
+        // consumer overwrites a newer checkpoint with an older level -- the
+        // lost-update regression the fence prevents.
+        on eDurableMailboxStage do (req: DurableMailboxStageReq) {
+            var row: MailboxRow;
+            var bcast: int;
+
+            // Stage advances state only for a row that still exists. Once a
+            // fenced Commit has removed the row, a stale consumer cannot stage
+            // or broadcast against it.
+            if (!RowExists(rows, req.id)) {
+                send req.reply_to, eDurableMailboxOpResp,
+                    (req.id, MailboxOpNotFound);
+                return;
+            }
+
+            // Fence: under the production design the write happens only when the
+            // lease token still matches. A reclaimed consumer applies nothing,
+            // so it cannot regress the checkpoint. The unfenced profile skips
+            // this gate to expose the regression.
+            row = RowByID(rows, req.id);
+            if (req.fenced && !TokenMatches(row, req.lease_token)) {
+                send req.reply_to, eDurableMailboxOpResp,
+                    (req.id, MailboxOpTokenMismatch);
+                return;
+            }
+
+            // The checkpoint write is an overwrite. Under the fence only the
+            // live owner reaches here, so the level is non-decreasing; an
+            // unfenced stale writer can lower it, which the monotonicity monitor
+            // catches.
+            checkpoint[req.id] = req.effect_seq;
+            announce eDurableMailboxCheckpointStaged,
+                (this, req.id, req.effect_seq);
+
+            // Record the broadcast identity. The production design persists it
+            // with the checkpoint and reuses it on replay (stable); the
+            // counterexample re-derives a fresh id every attempt.
+            if (req.stable) {
+                if (!(req.id in sweepId)) {
+                    sweepId[req.id] = req.sweep_seq;
+                }
+            } else {
+                sweepId[req.id] = req.sweep_seq;
+            }
+
+            // Emit the downstream broadcast. The receiver dedups by id, so a
+            // replay that reuses the persisted id is collapsed; a replay that
+            // derives a fresh id is a distinct, second broadcast.
+            bcast = sweepId[req.id];
+            announce eDurableMailboxBroadcast, (this, req.id, bcast);
+            send req.reply_to, eDurableMailboxOpResp,
+                (req.id, MailboxOpOk);
         }
 
         // Dead-letter removes a row by id, with no lease-token check, matching
@@ -748,6 +886,72 @@ spec LeaseFencedCommitAppliesEffectAtMostOnce observes
                 "once (a stale owner committed after the row was reclaimed)";
 
             applied[effect] = true;
+        }
+    }
+}
+
+// StagedEffectAppliedAtMostOnceUnderReplay is the headline safety contract for
+// the early-durable-write (Stage) path. Because a Stage advances durable state
+// ahead of the IO but the message is acked only later by Commit, a crash
+// between the Stage and the Commit redelivers the message and replays the same
+// event against the already-advanced state. The contract is that this replay
+// must not produce a second DISTINCT downstream broadcast: the production design
+// reuses the broadcast id persisted with the checkpoint, so the replay
+// re-broadcasts the same id and the receiver (txconfirm) dedups it.
+//
+// The monitor namespaces state by (mbox, id). It catches the counterexample
+// design directly: a behavior that re-derives a fresh broadcast id on replay
+// announces a second, different eDurableMailboxBroadcast for the same (mbox,
+// id), tripping the assertion with no in-machine check -- the double-broadcast
+// the persist-before-broadcast / sweep-reuse rule prevents.
+spec StagedEffectAppliedAtMostOnceUnderReplay observes
+    eDurableMailboxBroadcast {
+
+    var seen: map[(machine, int), bool];
+    var broadcastId: map[(machine, int), int];
+
+    start state Monitoring {
+        on eDurableMailboxBroadcast do (b: (machine, int, int)) {
+            var key: (machine, int);
+
+            key = (b.0, b.1);
+
+            if (key in seen) {
+                assert broadcastId[key] == b.2,
+                    "a row broadcast two distinct downstream effects across "+
+                    "a Stage'd-but-unacked replay (double-broadcast)";
+            } else {
+                seen[key] = true;
+                broadcastId[key] = b.2;
+            }
+        }
+    }
+}
+
+// CheckpointAdvancesMonotonically guards the other half of the Stage contract:
+// a staged checkpoint never moves backward. Every Stage write is an overwrite
+// that announces its level, so a replayed (equal) level is fine but a lower
+// level is a regression. Under the fence only the live lease holder writes, so
+// the level is non-decreasing; an unfenced stale consumer that overwrites with
+// its older level trips this directly -- the lost-update the fence prevents.
+spec CheckpointAdvancesMonotonically observes
+    eDurableMailboxCheckpointStaged {
+
+    var high: map[(machine, int), int];
+
+    start state Monitoring {
+        on eDurableMailboxCheckpointStaged do (s: (machine, int, int)) {
+            var key: (machine, int);
+
+            key = (s.0, s.1);
+
+            if (key in high) {
+                assert s.2 >= high[key],
+                    "a staged checkpoint regressed (a stale consumer "+
+                    "overwrote a newer checkpoint with an older level)";
+            }
+
+            high[key] = s.2;
         }
     }
 }

--- a/p-models/durableactor/test/mailbox_fifo_test.p
+++ b/p-models/durableactor/test/mailbox_fifo_test.p
@@ -1029,6 +1029,281 @@ machine TestDurableMailboxSpec_UnfencedCommitDoubleApplyCounterexample {
     state Done {}
 }
 
+// TestDurableMailboxSpec_StageThenFencedCommitExactlyOnce drives the
+// early-durable-write path under a crash between the Stage and the Commit.
+// Consumer A leases the row, Stages its checkpoint and broadcasts a sweep, then
+// crashes before committing (its lease expires mid-IO). Consumer B reclaims the
+// same durable row, replays the Stage -- which must reuse the persisted sweep id
+// (a monotone no-op on the checkpoint) -- and commits under the fence. A's stale
+// commit is an ErrLeaseLost no-op. The StagedEffectAppliedAtMostOnceUnderReplay
+// and CheckpointAdvancesMonotonically monitors confirm the replay neither
+// double-broadcasts nor regresses the checkpoint, while
+// LeaseFencedCommitAppliesEffectAtMostOnce confirms the consume is exactly once.
+machine TestDurableMailboxSpec_StageThenFencedCommitExactlyOnce {
+    var mailbox: DurableMailboxSpec;
+
+    start state Init {
+        entry {
+            var op_resp: (int, DurableMailboxOpResult);
+            var lease_resp: (int, DurableMailboxOpResult);
+
+            mailbox = new DurableMailboxSpec(PerCorrelationKeyFIFO);
+
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    1, 10, 100, 0, 0, NoLease(), NoLeaseToken(), 0, 3, 0
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (r0: (int, DurableMailboxOpResult)) { op_resp = r0; }
+            }
+            assert op_resp.1 == MailboxOpOk, "enqueue succeeds";
+
+            // Consumer A leases the row (token 11) and begins its work.
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 11,
+                now = 0, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (r1: (int, DurableMailboxOpResult)) { lease_resp = r1; }
+            }
+            assert lease_resp.0 == 1 && lease_resp.1 == MailboxOpOk,
+                "consumer A leases the row";
+
+            // A stages its checkpoint (level 1) and the sweep id (7) it is
+            // about to broadcast, then would do its IO. stable = true: the sweep
+            // id is persisted with the checkpoint. fenced = true: the write is
+            // gated on A's lease token (which it holds here).
+            send mailbox, eDurableMailboxStage, (
+                reply_to = this, id = 1, lease_token = 11, effect_seq = 1,
+                sweep_seq = 7, stable = true, fenced = true
+            );
+            receive { case eDurableMailboxOpResp:
+                (r2: (int, DurableMailboxOpResult)) { op_resp = r2; }
+            }
+            assert op_resp.1 == MailboxOpOk, "consumer A stages its checkpoint";
+
+            // A crashes before committing: its lease expires and consumer B
+            // reclaims the same durable row (the staged checkpoint survives).
+            send mailbox, eDurableMailboxExpireLeasesAt, 6;
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 22,
+                now = 6, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (r3: (int, DurableMailboxOpResult)) { lease_resp = r3; }
+            }
+            assert lease_resp.0 == 1 && lease_resp.1 == MailboxOpOk,
+                "consumer B reclaims the row after lease expiry";
+
+            // B replays the same event under its own token. It re-stages level
+            // 1 and, because the design is stable, reuses the persisted sweep id
+            // 7 even though it offers a freshly-derived 9 -- so the re-broadcast
+            // is the same id and the receiver dedups it.
+            send mailbox, eDurableMailboxStage, (
+                reply_to = this, id = 1, lease_token = 22, effect_seq = 1,
+                sweep_seq = 9, stable = true, fenced = true
+            );
+            receive { case eDurableMailboxOpResp:
+                (r4: (int, DurableMailboxOpResult)) { op_resp = r4; }
+            }
+            assert op_resp.1 == MailboxOpOk, "consumer B replays the stage";
+
+            // A wakes up stale and tries to stage its older view with its
+            // now-reclaimed token. The Stage fence rejects it, so it cannot
+            // regress B's checkpoint -- the multi-consumer lost-update guard.
+            send mailbox, eDurableMailboxStage, (
+                reply_to = this, id = 1, lease_token = 11, effect_seq = 1,
+                sweep_seq = 7, stable = true, fenced = true
+            );
+            receive { case eDurableMailboxOpResp:
+                (rStale: (int, DurableMailboxOpResult)) { op_resp = rStale; }
+            }
+            assert op_resp.1 == MailboxOpTokenMismatch,
+                "stale consumer A stage is fenced out (no regression)";
+
+            // A finishes its IO and commits with its now-stale token: fenced
+            // out, no effect.
+            send mailbox, eDurableMailboxCommit, (
+                reply_to = this, id = 1, lease_token = 11, fenced = true
+            );
+            receive { case eDurableMailboxOpResp:
+                (r5: (int, DurableMailboxOpResult)) { op_resp = r5; }
+            }
+            assert op_resp.1 == MailboxOpTokenMismatch,
+                "stale consumer A commit is an ErrLeaseLost no-op";
+
+            // B commits under the current token: the message is consumed once.
+            send mailbox, eDurableMailboxCommit, (
+                reply_to = this, id = 1, lease_token = 22, fenced = true
+            );
+            receive { case eDurableMailboxOpResp:
+                (r6: (int, DurableMailboxOpResult)) { op_resp = r6; }
+            }
+            assert op_resp.1 == MailboxOpOk,
+                "current owner B commits and consumes the row";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// TestDurableMailboxSpec_StagedDoubleBroadcastCounterexample drives the same
+// crash-and-replay scenario with the UNSTABLE design: the behavior re-derives a
+// fresh broadcast id (a sweep rebuilt with a new wallet address) on the replay
+// instead of reusing the one persisted with the checkpoint. The replay therefore
+// emits a second, distinct broadcast for the same row -- a double-broadcast.
+// There is no in-machine assertion for it: it is raised solely by
+// StagedEffectAppliedAtMostOnceUnderReplay, proving the monitor catches the
+// exact failure the persist-before-broadcast / sweep-reuse rule prevents.
+machine TestDurableMailboxSpec_StagedDoubleBroadcastCounterexample {
+    var mailbox: DurableMailboxSpec;
+
+    start state Init {
+        entry {
+            var op_resp: (int, DurableMailboxOpResult);
+            var lease_resp: (int, DurableMailboxOpResult);
+
+            mailbox = new DurableMailboxSpec(PerCorrelationKeyFIFO);
+
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    1, 10, 100, 0, 0, NoLease(), NoLeaseToken(), 0, 3, 0
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (r0: (int, DurableMailboxOpResult)) { op_resp = r0; }
+            }
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 11,
+                now = 0, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (r1: (int, DurableMailboxOpResult)) { lease_resp = r1; }
+            }
+
+            // A stages and broadcasts sweep id 7 (unstable design). A holds the
+            // lease here, so the fence passes; the bug is the broadcast id.
+            send mailbox, eDurableMailboxStage, (
+                reply_to = this, id = 1, lease_token = 11, effect_seq = 1,
+                sweep_seq = 7, stable = false, fenced = true
+            );
+            receive { case eDurableMailboxOpResp:
+                (r2: (int, DurableMailboxOpResult)) { op_resp = r2; }
+            }
+
+            // A crashes; B reclaims the same row.
+            send mailbox, eDurableMailboxExpireLeasesAt, 6;
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 22,
+                now = 6, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (r3: (int, DurableMailboxOpResult)) { lease_resp = r3; }
+            }
+
+            // B replays under its own token, but the unstable design derives a
+            // FRESH sweep id 9 and broadcasts it -- a second, distinct broadcast
+            // for the same row.
+            send mailbox, eDurableMailboxStage, (
+                reply_to = this, id = 1, lease_token = 22, effect_seq = 1,
+                sweep_seq = 9, stable = false, fenced = true
+            );
+            receive { case eDurableMailboxOpResp:
+                (r4: (int, DurableMailboxOpResult)) { op_resp = r4; }
+            }
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// TestDurableMailboxSpec_StaleStageRegressesCheckpointCounterexample drives the
+// multi-consumer lost-update scenario with an UNFENCED stage. Consumer A stages
+// level 2, its lease expires, consumer B reclaims and advances the checkpoint to
+// level 3, then stale A wakes up and stages its older level 2 with the fence
+// disabled. Because the unfenced write overwrites regardless of the token, it
+// regresses the checkpoint from 3 back to 2. There is no in-machine assertion
+// for it: the regression is raised solely by CheckpointAdvancesMonotonically,
+// proving the monitor catches the exact lost-update the Stage fence prevents.
+machine TestDurableMailboxSpec_StaleStageRegressesCheckpointCounterexample {
+    var mailbox: DurableMailboxSpec;
+
+    start state Init {
+        entry {
+            var op_resp: (int, DurableMailboxOpResult);
+            var lease_resp: (int, DurableMailboxOpResult);
+
+            mailbox = new DurableMailboxSpec(PerCorrelationKeyFIFO);
+
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    1, 10, 100, 0, 0, NoLease(), NoLeaseToken(), 0, 3, 0
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (r0: (int, DurableMailboxOpResult)) { op_resp = r0; }
+            }
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 11,
+                now = 0, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (r1: (int, DurableMailboxOpResult)) { lease_resp = r1; }
+            }
+
+            // A stages level 2 under its lease.
+            send mailbox, eDurableMailboxStage, (
+                reply_to = this, id = 1, lease_token = 11, effect_seq = 2,
+                sweep_seq = 7, stable = true, fenced = true
+            );
+            receive { case eDurableMailboxOpResp:
+                (r2: (int, DurableMailboxOpResult)) { op_resp = r2; }
+            }
+
+            // A's lease expires; B reclaims and advances the checkpoint to 3.
+            send mailbox, eDurableMailboxExpireLeasesAt, 6;
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 22,
+                now = 6, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (r3: (int, DurableMailboxOpResult)) { lease_resp = r3; }
+            }
+            send mailbox, eDurableMailboxStage, (
+                reply_to = this, id = 1, lease_token = 22, effect_seq = 3,
+                sweep_seq = 7, stable = true, fenced = true
+            );
+            receive { case eDurableMailboxOpResp:
+                (r4: (int, DurableMailboxOpResult)) { op_resp = r4; }
+            }
+
+            // Stale A wakes up and stages its older level 2 UNFENCED, so the
+            // overwrite regresses the checkpoint from 3 back to 2.
+            send mailbox, eDurableMailboxStage, (
+                reply_to = this, id = 1, lease_token = 11, effect_seq = 2,
+                sweep_seq = 7, stable = true, fenced = false
+            );
+            receive { case eDurableMailboxOpResp:
+                (r5: (int, DurableMailboxOpResult)) { op_resp = r5; }
+            }
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
 machine MailboxFIFOTestDriver {
     start state RunTests {
         entry {
@@ -1108,3 +1383,35 @@ test tcMailboxUnfencedCommitCounterexample
   assert LeaseFencedCommitAppliesEffectAtMostOnce in
   { DurableMailboxSpec,
     TestDurableMailboxSpec_UnfencedCommitDoubleApplyCounterexample };
+
+// tcMailboxStageCommitExactlyOnce checks the early-durable-write contract: a
+// row whose checkpoint is Staged and broadcast, then crashes before the Commit,
+// is reclaimed and replayed without double-broadcasting or regressing the
+// checkpoint, and is consumed exactly once under the fence.
+test tcMailboxStageCommitExactlyOnce
+    [main=TestDurableMailboxSpec_StageThenFencedCommitExactlyOnce]:
+  assert StagedEffectAppliedAtMostOnceUnderReplay,
+         CheckpointAdvancesMonotonically,
+         LeaseFencedCommitAppliesEffectAtMostOnce in
+  { DurableMailboxSpec,
+    TestDurableMailboxSpec_StageThenFencedCommitExactlyOnce };
+
+// tcMailboxStagedDoubleBroadcastCounterexample runs the crash-and-replay
+// scenario with the unstable design (a fresh broadcast id on replay) and no
+// in-machine assertion, so the double-broadcast is raised solely by
+// StagedEffectAppliedAtMostOnceUnderReplay. It is expected to find a bug.
+test tcMailboxStagedDoubleBroadcastCounterexample
+    [main=TestDurableMailboxSpec_StagedDoubleBroadcastCounterexample]:
+  assert StagedEffectAppliedAtMostOnceUnderReplay in
+  { DurableMailboxSpec,
+    TestDurableMailboxSpec_StagedDoubleBroadcastCounterexample };
+
+// tcMailboxStaleStageRegressesCounterexample runs the multi-consumer lost-update
+// scenario with an unfenced stage and no in-machine assertion, so the checkpoint
+// regression is raised solely by CheckpointAdvancesMonotonically. It is expected
+// to find a bug.
+test tcMailboxStaleStageRegressesCounterexample
+    [main=TestDurableMailboxSpec_StaleStageRegressesCheckpointCounterexample]:
+  assert CheckpointAdvancesMonotonically in
+  { DurableMailboxSpec,
+    TestDurableMailboxSpec_StaleStageRegressesCheckpointCounterexample };

--- a/p-models/scripts/check.sh
+++ b/p-models/scripts/check.sh
@@ -97,6 +97,21 @@ check_negative tcMailboxMonitorCatchesLegacyReorder 1
 # applies its effect after the row was reclaimed double-applies it.
 check_negative tcMailboxUnfencedCommitCounterexample 1
 
+# The early-durable-write (Stage) path must replay safely: a checkpoint Staged
+# and broadcast, then crashed before Commit, is reclaimed and replayed without
+# double-broadcasting or regressing the checkpoint, and consumed exactly once.
+check_green tcMailboxStageCommitExactlyOnce
+
+# The unstable-broadcast counterexample must be caught by the
+# StagedEffectAppliedAtMostOnceUnderReplay monitor: a behavior that re-derives a
+# fresh broadcast id on replay double-broadcasts.
+check_negative tcMailboxStagedDoubleBroadcastCounterexample 1
+
+# The unfenced-stage counterexample must be caught by the
+# CheckpointAdvancesMonotonically monitor: a stale consumer whose stage is not
+# lease-fenced overwrites a newer owner's checkpoint with an older level.
+check_negative tcMailboxStaleStageRegressesCounterexample 1
+
 echo ""
 echo "=== Go Bridge Conformance ==="
 go test ./p-models/durableactor/bridge

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -114,8 +114,9 @@ func NewVTXOUnrollActor(cfg Config) (*VTXOUnrollActor, error) {
 		return nil, err
 	}
 
-	durableCfg := actor.DefaultDurableActorConfig[Msg, Resp](
-		cfg.ActorID, behavior, cfg.DeliveryStore, newCodec(),
+	durableCfg := actor.DefaultDurableTxActorConfig[Msg, Resp, unrollTx](
+		cfg.ActorID, behavior, behavior.bindStores, cfg.DeliveryStore,
+		newCodec(),
 	)
 	durableCfg.Log = cfg.Log
 
@@ -152,6 +153,35 @@ type behavior struct {
 	terminalNotified  bool
 }
 
+// unrollTx is the transaction-scoped store handed to the unroll behavior inside
+// each Read/Stage/Commit phase. The unroll actor's only durable write is its
+// checkpoint, so the store is thin: it carries the actor ID plus the per-call
+// DeliveryStore whose SaveCheckpoint/LoadCheckpoint join the framework
+// transaction via the closure context.
+type unrollTx struct {
+	store   actor.DeliveryStore
+	actorID string
+}
+
+// bindStores is the StoreFactory for the unroll Read/Stage/Commit path. It must
+// thread the per-call DeliveryStore -- the handle SaveCheckpoint reads the
+// active *sql.Tx off of -- rather than a captured one, so every checkpoint
+// write lands in the transaction the framework opened for that phase.
+func (b *behavior) bindStores(_ context.Context,
+	ds actor.DeliveryStore) unrollTx {
+
+	return unrollTx{
+		store:   ds,
+		actorID: b.cfg.ActorID,
+	}
+}
+
+// behavior runs on the durable actor Read/Commit execution path: it persists
+// each checkpoint with a short, lock-releasing Stage ahead of the txconfirm IO
+// and consumes the message with one lease-fenced Commit, so the SQLite writer
+// is never held across a cross-actor Ask.
+var _ actor.TxBehavior[Msg, Resp, unrollTx] = (*behavior)(nil)
+
 // Receive processes one durable actor message. It is the single entry
 // point for every input that drives the unroll FSM: admission, restart,
 // chain events, txconfirm notifications, external spends, and status
@@ -177,10 +207,52 @@ type behavior struct {
 //
 // Unknown messages are rejected with a typed error rather than silently
 // dropped so codec/dispatch mismatches are loud.
-func (b *behavior) Receive(ctx context.Context, msg Msg) fn.Result[Resp] {
+func (b *behavior) Receive(ctx context.Context, msg Msg,
+	ax actor.Exec[unrollTx]) fn.Result[Resp] {
+
+	// GetStateRequest is a read-only status probe: it drives no FSM
+	// transition and writes nothing, so it returns directly without a Stage
+	// or a Commit. The framework's non-transactional tail acks the Ask once
+	// the behavior returns.
+	if _, ok := msg.(*GetStateRequest); ok {
+		return fn.Ok[Resp](b.stateResponse())
+	}
+
+	// Run the FSM pipeline. Every checkpoint write inside is a short,
+	// lock-releasing Stage and the slow txconfirm IO runs with no writer
+	// transaction held; dispatch never commits.
+	res := b.dispatch(ctx, ax, msg)
+	if res.IsErr() {
+
+		// The behavior did not commit, so the framework nacks the
+		// message; it is redelivered and replayed against the durably
+		// Staged state.
+		return res
+	}
+
+	// Single consume point: fold the lease-fenced ack, the dedup mark, and
+	// a final checkpoint re-persist into one short writer transaction. A
+	// lost lease surfaces here as actor.ErrLeaseLost and the Staged
+	// checkpoints survive for an idempotent replay.
+	if err := b.commitAck(ctx, ax); err != nil {
+		return fn.Err[Resp](err)
+	}
+
+	return res
+}
+
+// dispatch maps one durable message onto the FSM event surface and runs the
+// apply-stage-route pipeline (possibly recursively). It performs every Stage
+// write and all IO but never commits: Receive owns the single lease-fenced
+// Commit so the message is consumed exactly once after the whole pipeline
+// settles. Unknown messages are rejected with a typed error rather than
+// silently dropped so codec/dispatch mismatches are loud.
+func (b *behavior) dispatch(ctx context.Context, ax actor.Exec[unrollTx],
+	msg Msg) fn.Result[Resp] {
+
 	switch m := msg.(type) {
 	case *StartUnrollRequest:
-		return b.handleEvent(ctx, &StartEvent{
+		return b.handleEvent(ctx, ax, &StartEvent{
 			Height:         m.Height,
 			Trigger:        m.Trigger,
 			ExitPolicyKind: m.ExitPolicyKind,
@@ -188,32 +260,29 @@ func (b *behavior) Receive(ctx context.Context, msg Msg) fn.Result[Resp] {
 		})
 
 	case *ResumeUnrollRequest:
-		return b.handleEvent(ctx, &ResumeEvent{
+		return b.handleEvent(ctx, ax, &ResumeEvent{
 			Height: m.Height,
 		})
 
 	case *HeightObservedMsg:
-		return b.handleEvent(ctx, &HeightUpdatedEvent{
+		return b.handleEvent(ctx, ax, &HeightUpdatedEvent{
 			Height: m.Height,
 		})
 
 	case *TxConfirmedMsg:
-		return b.handleEvent(ctx, &TxConfirmedEvent{
+		return b.handleEvent(ctx, ax, &TxConfirmedEvent{
 			Txid:   m.Txid,
 			Height: m.Height,
 		})
 
 	case *TxFailedMsg:
-		return b.handleEvent(ctx, &TxFailedEvent{
+		return b.handleEvent(ctx, ax, &TxFailedEvent{
 			Txid:   m.Txid,
 			Reason: b.failureReasonForTx(m.Txid, m.Reason),
 		})
 
 	case *SpendObservedMsg:
-		return b.handleSpendObserved(ctx, m)
-
-	case *GetStateRequest:
-		return fn.Ok[Resp](b.stateResponse())
+		return b.handleSpendObserved(ctx, ax, m)
 
 	default:
 		return fn.Err[Resp](
@@ -240,7 +309,7 @@ func (b *behavior) OnStop(ctx context.Context) error {
 // load of proof / descriptor / planner / session / subscriptions happens
 // exactly once per actor lifetime regardless of which event kind arrives
 // first, and so the caller sees a uniform AckResp on success.
-func (b *behavior) handleEvent(ctx context.Context,
+func (b *behavior) handleEvent(ctx context.Context, ax actor.Exec[unrollTx],
 	event Event) fn.Result[Resp] {
 
 	if err := b.ensureLoaded(ctx); err != nil {
@@ -265,7 +334,7 @@ func (b *behavior) handleEvent(ctx context.Context,
 		return fn.Ok[Resp](&AckResp{})
 	}
 
-	if err := b.driveEvent(ctx, event); err != nil {
+	if err := b.driveEvent(ctx, ax, event); err != nil {
 		return fn.Err[Resp](err)
 	}
 
@@ -280,12 +349,16 @@ func (b *behavior) handleEvent(ctx context.Context,
 //     IO; this call returns synchronously with the new state persisted
 //     in the FSM session.
 //
-//  2. Persist: write the resulting checkpoint to the delivery store
-//     BEFORE doing any IO on the outbox. If the process crashes between
-//     the FSM transition and the outbox routing, restart restores the
-//     exact same state that was in memory and re-emits the outbox via
+//  2. Stage: write the resulting checkpoint to the delivery store in a
+//     short, non-fenced writer transaction (ax.Stage) BEFORE doing any IO
+//     on the outbox. The writer lock is released the moment Stage returns,
+//     so the txconfirm IO that follows never holds it. If the process
+//     crashes between the Stage and the outbox routing, restart restores
+//     the exact same state that was in memory and re-emits the outbox via
 //     the reissue path, so no work is lost and no work is duplicated
-//     beyond what txconfirm's txid-keyed dedup already collapses.
+//     beyond what txconfirm's txid-keyed dedup already collapses. The
+//     message itself is acked only once, by the single lease-fenced Commit
+//     in Receive after the whole (possibly recursive) pipeline settles.
 //
 //  3. Route: interpret each OutboxEvent as a real IO effect — submit
 //     ready proof nodes to txconfirm, re-arm in-flight subscriptions,
@@ -300,10 +373,13 @@ func (b *behavior) handleEvent(ctx context.Context,
 //     late TxConfirmed after we already failed) are suppressed by
 //     terminalNotified.
 //
-// Persist-before-route is the invariant that lets the actor lose its
+// Stage-before-route is the invariant that lets the actor lose its
 // process mid-operation without corrupting on-chain state — every side
-// effect is driven by a checkpoint that is already on disk.
-func (b *behavior) driveEvent(ctx context.Context, event Event) error {
+// effect is driven by a checkpoint that is already on disk, durably Staged
+// in its own short transaction ahead of the IO.
+func (b *behavior) driveEvent(ctx context.Context, ax actor.Exec[unrollTx],
+	event Event) error {
+
 	if b.session == nil || b.session.FSM == nil {
 		return fmt.Errorf("session not initialized")
 	}
@@ -313,11 +389,11 @@ func (b *behavior) driveEvent(ctx context.Context, event Event) error {
 		return err
 	}
 
-	if err := b.persistCheckpoint(ctx); err != nil {
+	if err := b.persistCheckpoint(ctx, ax); err != nil {
 		return err
 	}
 
-	if err := b.routeOutbox(ctx, outbox); err != nil {
+	if err := b.routeOutbox(ctx, ax, outbox); err != nil {
 		return err
 	}
 
@@ -358,14 +434,33 @@ func (b *behavior) driveEvent(ctx context.Context, event Event) error {
 // descriptor), we drive a SweepBuildFailedEvent through the FSM so the
 // retry budget is accounted for and we reach terminal Failed after
 // maxSweepAttempts.
-func (b *behavior) startSweep(ctx context.Context) error {
+func (b *behavior) startSweep(ctx context.Context,
+	ax actor.Exec[unrollTx]) error {
+
+	// Idempotency guard against a lost-in-memory sweep. Before deriving a
+	// fresh sweep -- which burns a new BIP32 wallet address and yields a
+	// new txid -- reconcile against the durably Staged checkpoint via a
+	// short read-only snapshot. If a previous processing attempt already
+	// Staged a sweepTx but crashed before its Commit acked, the message is
+	// being replayed; adopting the Staged sweepTx keeps us on a single
+	// sweep txid / pkScript instead of racing a freshly-derived sweep on
+	// chain. restoreCheckpoint repopulates b.sweepTx at boot, so this only
+	// fires on an in-memory/durable desync, but it makes the
+	// persist-before-broadcast guarantee robust to in-memory state loss
+	// rather than dependent on the boot path alone.
+	if b.sweepTx == nil {
+		if err := b.adoptStagedSweep(ctx, ax); err != nil {
+			return err
+		}
+	}
+
 	// Reuse the sweep tx restored from the checkpoint (or built on a
 	// prior attempt inside this actor lifetime) so we converge on a
 	// single sweep txid / wallet pkScript across retries.
 	if b.sweepTx == nil {
 		policy, err := b.resolveExitSpendPolicy(ctx)
 		if err != nil {
-			return b.driveEvent(ctx, &SweepBuildFailedEvent{
+			return b.driveEvent(ctx, ax, &SweepBuildFailedEvent{
 				Reason: err.Error(),
 			})
 		}
@@ -391,7 +486,7 @@ func (b *behavior) startSweep(ctx context.Context) error {
 		// invalid tx.
 		if b.proof != nil &&
 			policy.CSVDelay() > b.proof.CSVDelay() {
-			return b.driveEvent(ctx, &SweepBuildFailedEvent{
+			return b.driveEvent(ctx, ax, &SweepBuildFailedEvent{
 				Reason: fmt.Sprintf("policy csv delay %d "+
 					"exceeds proof csv delay %d",
 					policy.CSVDelay(),
@@ -458,7 +553,7 @@ func (b *behavior) startSweep(ctx context.Context) error {
 				return nil
 			}
 
-			return b.driveEvent(ctx, &SweepBuildFailedEvent{
+			return b.driveEvent(ctx, ax, &SweepBuildFailedEvent{
 				Reason: err.Error(),
 			})
 		}
@@ -478,10 +573,12 @@ func (b *behavior) startSweep(ctx context.Context) error {
 		)
 	}
 
-	// Persist the built sweep before asking txconfirm to broadcast, so
-	// on any retry the same sweepTx is restored and re-submitted under
-	// txconfirm's dedup rather than a freshly-derived sweep racing it.
-	if err := b.persistCheckpoint(ctx); err != nil {
+	// Stage the built sweep before asking txconfirm to broadcast, so on any
+	// retry the same sweepTx is restored and re-submitted under txconfirm's
+	// dedup rather than a freshly-derived sweep racing it. Stage commits
+	// this in its own short writer transaction and releases the lock, so
+	// the EnsureConfirmedReq Ask below runs with no writer held.
+	if err := b.persistCheckpoint(ctx, ax); err != nil {
 		return err
 	}
 
@@ -511,7 +608,7 @@ func (b *behavior) startSweep(ctx context.Context) error {
 		return err
 	}
 
-	return b.driveEvent(ctx, &SweepBroadcastedEvent{Txid: sweepTxid})
+	return b.driveEvent(ctx, ax, &SweepBroadcastedEvent{Txid: sweepTxid})
 }
 
 // exitPolicyKind returns the durable policy kind for the current job.
@@ -606,7 +703,8 @@ const proofNodeHeightHint uint32 = 1
 // FSM so the usual terminal path runs, rather than propagating the error
 // up and leaving the actor waiting on a subscription that will never
 // fire.
-func (b *behavior) ensureNodeConfirmed(ctx context.Context, txid chainhash.Hash,
+func (b *behavior) ensureNodeConfirmed(ctx context.Context,
+	ax actor.Exec[unrollTx], txid chainhash.Hash,
 	node *recovery.Node) error {
 
 	if node == nil {
@@ -639,7 +737,7 @@ func (b *behavior) ensureNodeConfirmed(ctx context.Context, txid chainhash.Hash,
 	}
 
 	if ensureResp.State == txconfirm.TxStateFailed {
-		return b.driveEvent(ctx, &TxFailedEvent{
+		return b.driveEvent(ctx, ax, &TxFailedEvent{
 			Txid: txid,
 			Reason: b.failureReasonForTx(
 				txid, "txconfirm returned failed state",
@@ -1189,7 +1287,7 @@ func (b *behavior) proofSpendCallerID(outpoint wire.OutPoint) string {
 //     with a reason that identifies the spending txid and height so
 //     operators can triage the cause off-line.
 func (b *behavior) handleSpendObserved(ctx context.Context,
-	msg *SpendObservedMsg) fn.Result[Resp] {
+	ax actor.Exec[unrollTx], msg *SpendObservedMsg) fn.Result[Resp] {
 
 	if err := b.ensureLoaded(ctx); err != nil {
 		return fn.Err[Resp](err)
@@ -1200,7 +1298,7 @@ func (b *behavior) handleSpendObserved(ctx context.Context,
 	}
 
 	if b.proof != nil {
-		acked, err := b.ackProofOutputSpend(ctx, msg)
+		acked, err := b.ackProofOutputSpend(ctx, ax, msg)
 		if err != nil {
 			return fn.Err[Resp](err)
 		}
@@ -1211,7 +1309,7 @@ func (b *behavior) handleSpendObserved(ctx context.Context,
 		// Case 2: the spender is a proof-graph node. That means an
 		// ancestor of our target just confirmed on chain.
 		if _, ok := b.proof.Node(msg.SpendingTxid); ok {
-			return b.handleEvent(ctx, &TxConfirmedEvent{
+			return b.handleEvent(ctx, ax, &TxConfirmedEvent{
 				Txid:   msg.SpendingTxid,
 				Height: msg.SpendingHeight,
 			})
@@ -1230,7 +1328,7 @@ func (b *behavior) handleSpendObserved(ctx context.Context,
 		if job.PlannerState.Sweep.Txid.IsSome() &&
 			job.PlannerState.Sweep.Txid.UnsafeFromSome() ==
 				msg.SpendingTxid {
-			return b.handleEvent(ctx, &HeightUpdatedEvent{
+			return b.handleEvent(ctx, ax, &HeightUpdatedEvent{
 				Height: msg.SpendingHeight,
 			})
 		}
@@ -1250,7 +1348,7 @@ func (b *behavior) handleSpendObserved(ctx context.Context,
 		"at height %d", spentOutpoint, msg.SpendingTxid,
 		msg.SpendingHeight)
 
-	return b.handleEvent(ctx, &FailEvent{Reason: reason})
+	return b.handleEvent(ctx, ax, &FailEvent{Reason: reason})
 }
 
 // ackProofOutputSpend records proof-output spend evidence and reports whether
@@ -1258,7 +1356,7 @@ func (b *behavior) handleSpendObserved(ctx context.Context,
 // transaction, the parent proof tx is still confirmed, but the caller must
 // continue into the external-spend failure path.
 func (b *behavior) ackProofOutputSpend(ctx context.Context,
-	msg *SpendObservedMsg) (bool, error) {
+	ax actor.Exec[unrollTx], msg *SpendObservedMsg) (bool, error) {
 
 	if msg.Outpoint == (wire.OutPoint{}) ||
 		msg.Outpoint == b.cfg.TargetOutpoint {
@@ -1269,7 +1367,7 @@ func (b *behavior) ackProofOutputSpend(ctx context.Context,
 		return false, nil
 	}
 
-	err := b.driveEvent(ctx, &TxConfirmedEvent{
+	err := b.driveEvent(ctx, ax, &TxConfirmedEvent{
 		Txid:   msg.Outpoint.Hash,
 		Height: msg.SpendingHeight,
 	})
@@ -1290,7 +1388,7 @@ func (b *behavior) ackProofOutputSpend(ctx context.Context,
 		Height: msg.SpendingHeight,
 	}
 
-	return true, b.driveEvent(ctx, event)
+	return true, b.driveEvent(ctx, ax, event)
 }
 
 // inTerminalState reports whether the FSM has already reached a terminal
@@ -1306,32 +1404,120 @@ func (b *behavior) inTerminalState() bool {
 	return state.IsTerminal()
 }
 
-// persistCheckpoint writes the current durable actor checkpoint.
-func (b *behavior) persistCheckpoint(ctx context.Context) error {
+// checkpointWrite snapshots the current FSM state into a durable checkpoint and
+// returns it alongside a closure that persists it through a transaction-scoped
+// store. The closure is shared verbatim by the Stage path (persistCheckpoint)
+// and the lease-fenced Commit path (commitAck) so both write identical bytes;
+// only the transaction they run in differs.
+func (b *behavior) checkpointWrite() (*actorCheckpoint,
+	func(context.Context, unrollTx) error, error) {
+
 	state, err := b.currentState()
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	checkpoint := checkpointFromState(state, b.sweepTx)
 	raw, err := encodeCheckpoint(checkpoint)
 	if err != nil {
+		return nil, nil, err
+	}
+
+	write := func(txCtx context.Context, tx unrollTx) error {
+		return tx.store.SaveCheckpoint(txCtx, actor.CheckpointParams{
+			ActorID:   tx.actorID,
+			StateType: checkpointStateType,
+			StateData: raw,
+			Version:   checkpointVersion,
+		})
+	}
+
+	return checkpoint, write, nil
+}
+
+// persistCheckpoint durably advances the actor checkpoint with a short,
+// non-fenced Stage write ahead of the outbox IO. Stage runs the write in its
+// own writer transaction and releases the SQLite writer the moment it returns,
+// so the txconfirm round-trips that follow never hold the lock. The message is
+// not consumed here -- it is acked once, later, by commitAck.
+func (b *behavior) persistCheckpoint(ctx context.Context,
+	ax actor.Exec[unrollTx]) error {
+
+	checkpoint, write, err := b.checkpointWrite()
+	if err != nil {
 		return err
 	}
 
-	err = b.cfg.DeliveryStore.SaveCheckpoint(ctx, actor.CheckpointParams{
-		ActorID:   b.cfg.ActorID,
-		StateType: checkpointStateType,
-		StateData: raw,
-		Version:   checkpointVersion,
-	})
-	if err != nil {
+	if err := ax.Stage(ctx, write); err != nil {
 		return err
 	}
 
 	b.pending = checkpoint
 
 	return nil
+}
+
+// commitAck is the single consume point for a message. It folds the
+// lease-fenced ack and the dedup mark into one short writer transaction and
+// re-persists the final checkpoint so the last state advance is atomic with
+// consumption. Every intermediate checkpoint was already durably Staged ahead
+// of the IO, so this Commit is short and never wraps a txconfirm round-trip. A
+// lost lease surfaces here as actor.ErrLeaseLost: the ack rolls back, the
+// Staged checkpoints survive, and the framework redelivers the message for an
+// idempotent replay against the advanced state.
+func (b *behavior) commitAck(ctx context.Context,
+	ax actor.Exec[unrollTx]) error {
+
+	checkpoint, write, err := b.checkpointWrite()
+	if err != nil {
+		return err
+	}
+
+	if err := ax.Commit(ctx, write); err != nil {
+		return err
+	}
+
+	b.pending = checkpoint
+
+	return nil
+}
+
+// adoptStagedSweep reconciles the in-memory sweep cache with the durable
+// checkpoint through a short read-only snapshot (ax.Read). It exists so a
+// replay after a Staged-but-uncommitted sweep build reuses the persisted sweep
+// transaction instead of building -- and broadcasting -- a second one with a
+// fresh wallet address and a new txid. It only adopts the sweep transaction,
+// never b.pending, so it cannot regress the FSM-derived state; it is a no-op
+// when no sweep has been staged yet.
+func (b *behavior) adoptStagedSweep(ctx context.Context,
+	ax actor.Exec[unrollTx]) error {
+
+	return ax.Read(ctx, func(rCtx context.Context, tx unrollTx) error {
+		checkpoint, err := tx.store.LoadCheckpoint(rCtx, tx.actorID)
+		if err != nil {
+			return err
+		}
+
+		if checkpoint == nil {
+			return nil
+		}
+
+		decoded, err := decodeCheckpoint(checkpoint.StateData)
+		if err != nil {
+			return err
+		}
+
+		if decoded.Version != checkpointVersion {
+			return fmt.Errorf("unknown checkpoint version %d",
+				decoded.Version)
+		}
+
+		if decoded.SweepTx != nil {
+			b.sweepTx = copyTx(decoded.SweepTx)
+		}
+
+		return nil
+	})
 }
 
 // routeOutbox interprets each [OutboxEvent] emitted by the FSM as a real
@@ -1363,7 +1549,7 @@ func (b *behavior) persistCheckpoint(ctx context.Context) error {
 //     to re-attach the confirmation subscription. A nil sweepTx here
 //     means the checkpoint is corrupt and we fail loudly rather than
 //     silently losing the job.
-func (b *behavior) routeOutbox(ctx context.Context,
+func (b *behavior) routeOutbox(ctx context.Context, ax actor.Exec[unrollTx],
 	outbox []OutboxEvent) error {
 
 	for i := range outbox {
@@ -1387,7 +1573,9 @@ func (b *behavior) routeOutbox(ctx context.Context,
 						"%s missing", txid)
 				}
 
-				err := b.ensureNodeConfirmed(ctx, txid, node)
+				err := b.ensureNodeConfirmed(
+					ctx, ax, txid, node,
+				)
 				if err != nil {
 					return err
 				}
@@ -1410,7 +1598,9 @@ func (b *behavior) routeOutbox(ctx context.Context,
 						"missing on reissue", txid)
 				}
 
-				err := b.ensureNodeConfirmed(ctx, txid, node)
+				err := b.ensureNodeConfirmed(
+					ctx, ax, txid, node,
+				)
 				if err != nil {
 					return err
 				}
@@ -1434,7 +1624,7 @@ func (b *behavior) routeOutbox(ctx context.Context,
 			}
 
 		case *RequestSweepBuild:
-			if err := b.startSweep(ctx); err != nil {
+			if err := b.startSweep(ctx, ax); err != nil {
 				return err
 			}
 

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -120,6 +121,12 @@ type fakeTxConfirmRef struct {
 	responseStates map[chainhash.Hash]txconfirm.TxState
 	confirmHeights map[chainhash.Hash]int32
 	failureReasons map[chainhash.Hash]string
+
+	// onAsk, when set, is invoked with each EnsureConfirmedReq as it is
+	// recorded (outside the store lock). Tests use it to assert ordering
+	// and locking invariants at the exact moment of the txconfirm broadcast
+	// IO.
+	onAsk func(*txconfirm.EnsureConfirmedReq)
 }
 
 // ID returns the fake actor ID.
@@ -153,7 +160,15 @@ func (f *fakeTxConfirmRef) Ask(_ context.Context,
 	f.requests = append(f.requests, req)
 	state := f.responseStates[req.Tx.TxHash()]
 	height := f.confirmHeights[req.Tx.TxHash()]
+	onAsk := f.onAsk
 	f.mu.Unlock()
+
+	// Fire the ordering hook outside the store lock, after recording the
+	// request but before the response resolves, so a test observes the
+	// exact moment the unroll actor is doing its txconfirm IO.
+	if onAsk != nil {
+		onAsk(req)
+	}
 
 	if state == 0 {
 		state = txconfirm.TxStateAwaitingConfirmation
@@ -889,11 +904,144 @@ func (s *memCheckpointStore) CleanupExpired(context.Context) error {
 	return nil
 }
 
+// memExec is an in-memory actor.Exec[unrollTx] for unroll tests. Read, Stage,
+// and Commit each run their closure directly against the shared checkpoint
+// store; there is no real lease fence, so Commit ordinarily "consumes" by just
+// running its write. Hooks let tests observe Stage/Commit ordering relative to
+// the txconfirm IO and inject a lost-lease failure.
+type memExec struct {
+	store   actor.DeliveryStore
+	actorID string
+
+	// inWriteTxn is set while a Stage or Commit closure runs and cleared
+	// once it returns, so a test can assert no writer transaction is held
+	// across an outbox Ask (the contention win this migration targets).
+	inWriteTxn atomic.Bool
+
+	// stageCount and commitCount record how many Stage/Commit transactions
+	// ran, for ordering and "exactly one consume" assertions.
+	stageCount  atomic.Int64
+	commitCount atomic.Int64
+
+	// commitLeaseLost, when set, makes Commit fail with actor.ErrLeaseLost
+	// without running its closure (and without acking), simulating a lost
+	// lease at the consume step. The Staged writes that already ran are
+	// unaffected. It is an atomic so a test can flip it between messages
+	// without racing the actor goroutine.
+	commitLeaseLost atomic.Bool
+}
+
+// newMemExec builds an in-memory Exec writing through the given store under the
+// given actor ID.
+func newMemExec(store actor.DeliveryStore, actorID string) *memExec {
+	return &memExec{store: store, actorID: actorID}
+}
+
+// newMemExecFor builds an in-memory Exec for a behavior from its own config, so
+// the test Exec writes through the same DeliveryStore and actor ID the behavior
+// would use in production.
+func newMemExecFor(b *behavior) *memExec {
+	return newMemExec(b.cfg.DeliveryStore, b.cfg.ActorID)
+}
+
+// tx returns the transaction-scoped store handed to each closure.
+func (e *memExec) tx() unrollTx {
+	return unrollTx{store: e.store, actorID: e.actorID}
+}
+
+// Read implements actor.Exec by running fn against the store with no writer.
+func (e *memExec) Read(ctx context.Context,
+	fn func(context.Context, unrollTx) error) error {
+
+	return fn(ctx, e.tx())
+}
+
+// Stage implements actor.Exec by running fn in a (simulated) short writer
+// transaction that neither acks nor dedups the message.
+func (e *memExec) Stage(ctx context.Context,
+	fn func(context.Context, unrollTx) error) error {
+
+	e.inWriteTxn.Store(true)
+	defer e.inWriteTxn.Store(false)
+
+	if err := fn(ctx, e.tx()); err != nil {
+		return err
+	}
+
+	e.stageCount.Add(1)
+
+	return nil
+}
+
+// Commit implements actor.Exec by folding the (simulated) lease-fenced ack into
+// fn's writer transaction. When commitLeaseLost is set it models a lost lease:
+// the closure never runs and nothing is consumed.
+func (e *memExec) Commit(ctx context.Context,
+	fn func(context.Context, unrollTx) error) error {
+
+	if e.commitLeaseLost.Load() {
+		return actor.ErrLeaseLost
+	}
+
+	e.inWriteTxn.Store(true)
+	defer e.inWriteTxn.Store(false)
+
+	if err := fn(ctx, e.tx()); err != nil {
+		return err
+	}
+
+	e.commitCount.Add(1)
+
+	return nil
+}
+
+// txExecAdapter drives a TxBehavior behind a plain in-memory actor for tests.
+// It implements the classic actor.ActorBehavior surface by handing the behavior
+// a memExec, so the existing ref-driven tests keep working while the behavior
+// exercises its real Read/Stage/Commit code paths.
+type txExecAdapter struct {
+	b  *behavior
+	ax *memExec
+}
+
+// Receive implements actor.ActorBehavior by delegating to the TxBehavior with
+// the in-memory Exec handle.
+func (a *txExecAdapter) Receive(ctx context.Context, msg Msg) fn.Result[Resp] {
+	return a.b.Receive(ctx, msg, a.ax)
+}
+
+// OnStop forwards to the behavior's cleanup so subscription teardown still runs
+// when the test actor stops.
+func (a *txExecAdapter) OnStop(ctx context.Context) error {
+	return a.b.OnStop(ctx)
+}
+
+// adaptTx wraps a TxBehavior behind the classic ActorBehavior surface for
+// tests, using an Exec derived from the behavior's own config.
+func adaptTx(b *behavior) *txExecAdapter {
+	return &txExecAdapter{b: b, ax: newMemExecFor(b)}
+}
+
 // newActorHarness creates a new unroll actor behavior behind a regular
 // in-memory actor while still persisting checkpoints to the fake store.
 func newActorHarness(t *testing.T, proof *recovery.Proof,
 	desc *vtxo.Descriptor) (*actor.Actor[Msg, Resp], *behavior,
 	*fakeTxConfirmRef, *memCheckpointStore) {
+
+	t.Helper()
+
+	inst, b, ref, store, _ := newActorHarnessExec(t, proof, desc)
+
+	return inst, b, ref, store
+}
+
+// newActorHarnessExec is newActorHarness plus the in-memory Exec the behavior
+// runs on, so a test can observe Stage/Commit ordering, assert no writer
+// transaction is held across the txconfirm IO, and inject a lost lease at the
+// consume step.
+func newActorHarnessExec(t *testing.T, proof *recovery.Proof,
+	desc *vtxo.Descriptor) (*actor.Actor[Msg, Resp], *behavior,
+	*fakeTxConfirmRef, *memCheckpointStore, *memExec) {
 
 	t.Helper()
 
@@ -921,16 +1069,17 @@ func newActorHarness(t *testing.T, proof *recovery.Proof,
 	err := behavior.restoreCheckpoint(t.Context())
 	require.NoError(t, err)
 
+	exec := newMemExecFor(behavior)
 	actorInstance := actor.NewActor(actor.ActorConfig[Msg, Resp]{
 		ID:          "unroll-test",
-		Behavior:    behavior,
+		Behavior:    &txExecAdapter{b: behavior, ax: exec},
 		MailboxSize: 64,
 	})
 	behavior.selfRef = actorInstance.TellRef()
 	actorInstance.Start()
 	t.Cleanup(actorInstance.Stop)
 
-	return actorInstance, behavior, txconfirmRef, store
+	return actorInstance, behavior, txconfirmRef, store, exec
 }
 
 // mustAsk asks the actor and unwraps the response.
@@ -1729,7 +1878,7 @@ func TestResumeReissuesDeferredCheckpointWatch(t *testing.T) {
 
 	resumedActor := actor.NewActor(actor.ActorConfig[Msg, Resp]{
 		ID:          "resume-deferred-test",
-		Behavior:    resumeBehavior,
+		Behavior:    adaptTx(resumeBehavior),
 		MailboxSize: 64,
 	})
 	resumeBehavior.selfRef = resumedActor.TellRef()
@@ -1814,7 +1963,7 @@ func TestResumeReissuesInFlightArk(t *testing.T) {
 
 	resumedActor := actor.NewActor(actor.ActorConfig[Msg, Resp]{
 		ID:          "resume-ark-test",
-		Behavior:    resumeBehavior,
+		Behavior:    adaptTx(resumeBehavior),
 		MailboxSize: 64,
 	})
 	resumeBehavior.selfRef = resumedActor.TellRef()
@@ -2136,7 +2285,7 @@ func TestResumeReissuesInflightWork(t *testing.T) {
 	require.NoError(t, err)
 	resumedActor := actor.NewActor(actor.ActorConfig[Msg, Resp]{
 		ID:          "resume-test",
-		Behavior:    resumeBehavior,
+		Behavior:    adaptTx(resumeBehavior),
 		MailboxSize: 64,
 	})
 	resumeBehavior.selfRef = resumedActor.TellRef()
@@ -2340,7 +2489,7 @@ func TestResumeReissuesSweepConfirmation(t *testing.T) {
 
 	resumedActor := actor.NewActor(actor.ActorConfig[Msg, Resp]{
 		ID:          "resume-sweep-test",
-		Behavior:    resumeBehavior,
+		Behavior:    adaptTx(resumeBehavior),
 		MailboxSize: 64,
 	})
 	resumeBehavior.selfRef = resumedActor.TellRef()
@@ -2675,7 +2824,7 @@ func TestResumeMultiParentPartialConfirmation(t *testing.T) {
 
 	resumedActor := actor.NewActor(actor.ActorConfig[Msg, Resp]{
 		ID:          "resume-partial-merge",
-		Behavior:    resumeBehavior,
+		Behavior:    adaptTx(resumeBehavior),
 		MailboxSize: 64,
 	})
 	resumeBehavior.selfRef = resumedActor.TellRef()
@@ -2756,7 +2905,7 @@ func TestResumeCSVWaitDoesNotSweepUntilMature(t *testing.T) {
 
 	resumedActor := actor.NewActor(actor.ActorConfig[Msg, Resp]{
 		ID:          "resume-csv-test",
-		Behavior:    resumeBehavior,
+		Behavior:    adaptTx(resumeBehavior),
 		MailboxSize: 64,
 	})
 	resumeBehavior.selfRef = resumedActor.TellRef()
@@ -2950,3 +3099,367 @@ var _ actor.ActorRef[
 var _ *waddrmgr.Tapscript
 var _ = btcutil.Amount(0)
 var _ = psbt.Packet{}
+
+// driveLinearToSweep drives a linear-proof unroll actor from admission through
+// the proof-graph confirmations and CSV maturation until the final sweep is
+// built and broadcast. It mirrors TestConfirmedNodesAdvanceToSweep and returns
+// the broadcast sweep txid (read back from the durable checkpoint).
+func driveLinearToSweep(t *testing.T, ref actor.ActorRef[Msg, Resp],
+	txconfirmRef *fakeTxConfirmRef, store *memCheckpointStore,
+	proof *recovery.Proof) chainhash.Hash {
+
+	t.Helper()
+
+	mustAsk(t, ref, &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+	require.Equal(t, 1, txconfirmRef.requestCount())
+
+	txconfirmRef.emitConfirmed(t, 0, proof.RootTxids()[0], 101)
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCount() >= 2
+	}, testTimeout, 10*time.Millisecond)
+
+	txconfirmRef.emitConfirmed(t, 1, proof.TargetOutpoint().Hash, 102)
+
+	mustAsk(t, ref, &HeightObservedMsg{Height: 103})
+	mustAsk(t, ref, &HeightObservedMsg{Height: 104})
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCount() >= 3
+	}, testTimeout, 10*time.Millisecond)
+
+	cp, err := store.LoadCheckpoint(context.Background(), "unroll-test")
+	require.NoError(t, err)
+	require.NotNil(t, cp)
+	decoded, err := decodeCheckpoint(cp.StateData)
+	require.NoError(t, err)
+	require.NotNil(t, decoded.SweepTx)
+
+	return decoded.SweepTx.TxHash()
+}
+
+// TestUnrollStageBeforeBroadcast verifies the persist-before-broadcast
+// invariant survives the Read/Commit migration: the checkpoint carrying the
+// sweep transaction is durably Staged BEFORE txconfirm is asked to broadcast
+// it. The ordering is observed at the exact moment of the broadcast Ask.
+func TestUnrollStageBeforeBroadcast(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, _, txconfirmRef, store, _ := newActorHarnessExec(
+		t, proof, desc,
+	)
+
+	// At each broadcast Ask, record whether a checkpoint carrying that
+	// exact tx was already durably staged.
+	var mu sync.Mutex
+	stagedBeforeAsk := make(map[chainhash.Hash]bool)
+	txconfirmRef.onAsk = func(req *txconfirm.EnsureConfirmedReq) {
+		staged := false
+		cp, err := store.LoadCheckpoint(
+			context.Background(),
+			"unroll-test",
+		)
+		if err == nil && cp != nil {
+			decoded, derr := decodeCheckpoint(cp.StateData)
+			if derr == nil && decoded.SweepTx != nil &&
+				decoded.SweepTx.TxHash() == req.Tx.TxHash() {
+
+				staged = true
+			}
+		}
+
+		mu.Lock()
+		stagedBeforeAsk[req.Tx.TxHash()] = staged
+		mu.Unlock()
+	}
+
+	sweepTxid := driveLinearToSweep(
+		t, unrollActor.Ref(), txconfirmRef, store, proof,
+	)
+
+	// The sweep checkpoint was on disk before its broadcast crossed the
+	// actor boundary.
+	mu.Lock()
+	defer mu.Unlock()
+	require.True(
+		t, stagedBeforeAsk[sweepTxid], "sweep tx must be durably "+
+			"staged before the txconfirm broadcast",
+	)
+}
+
+// TestUnrollNoWriterTxnHeldAcrossTxConfirmAsk verifies the contention win the
+// migration targets: no SQLite writer transaction is ever held while the actor
+// performs a txconfirm Ask. Under the old classic path the entire Receive --
+// including this blocking cross-actor Ask -- ran inside one writer transaction.
+func TestUnrollNoWriterTxnHeldAcrossTxConfirmAsk(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, _, txconfirmRef, store, exec := newActorHarnessExec(
+		t, proof, desc,
+	)
+
+	var sawOpenWriteTxn atomic.Bool
+	txconfirmRef.onAsk = func(_ *txconfirm.EnsureConfirmedReq) {
+		if exec.inWriteTxn.Load() {
+			sawOpenWriteTxn.Store(true)
+		}
+	}
+
+	driveLinearToSweep(t, unrollActor.Ref(), txconfirmRef, store, proof)
+
+	require.False(
+		t, sawOpenWriteTxn.Load(),
+		"no writer transaction may be held across a txconfirm Ask",
+	)
+	require.GreaterOrEqual(t, txconfirmRef.requestCount(), 3)
+}
+
+// TestUnrollSweepStagedSurvivesLeaseLostReplay verifies the early-durable-write
+// guarantee end to end on the money path. A sweep is built, Staged, and
+// broadcast, but the consuming Commit loses its lease (a crash window between
+// the broadcast and the ack). The staged sweep must survive the rolled-back
+// Commit, and a fresh actor that restores from the same store must reuse the
+// SAME sweep txid -- never deriving a second sweep that would race the first on
+// chain.
+func TestUnrollSweepStagedSurvivesLeaseLostReplay(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, _, txconfirmRef, store, exec := newActorHarnessExec(
+		t, proof, desc,
+	)
+
+	// Drive up to the brink of the sweep: roots and target confirmed, one
+	// height tick shy of the build.
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+	txconfirmRef.emitConfirmed(t, 0, proof.RootTxids()[0], 101)
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCount() >= 2
+	}, testTimeout, 10*time.Millisecond)
+	txconfirmRef.emitConfirmed(t, 1, proof.TargetOutpoint().Hash, 102)
+	mustAsk(t, unrollActor.Ref(), &HeightObservedMsg{Height: 103})
+	require.Equal(t, 2, txconfirmRef.requestCount())
+
+	// Lose the lease at Commit. The next height tick builds + Stages + and
+	// broadcasts the sweep, then the fenced consume fails: the message is
+	// not acked, but the Staged sweep is already durable.
+	exec.commitLeaseLost.Store(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
+	defer cancel()
+	_, err := unrollActor.Ref().Ask(
+		ctx, &HeightObservedMsg{Height: 104},
+	).Await(ctx).Unpack()
+	require.ErrorIs(t, err, actor.ErrLeaseLost)
+
+	// The sweep was broadcast even though the Commit rolled back.
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCount() >= 3
+	}, testTimeout, 10*time.Millisecond)
+
+	// The staged sweep survived the lost-lease Commit.
+	cp, err := store.LoadCheckpoint(context.Background(), "unroll-test")
+	require.NoError(t, err)
+	require.NotNil(t, cp)
+	decoded, err := decodeCheckpoint(cp.StateData)
+	require.NoError(t, err)
+	require.NotNil(
+		t, decoded.SweepTx,
+		"staged sweep must survive the rolled-back Commit",
+	)
+	sweepTxid := decoded.SweepTx.TxHash()
+	require.Equal(t, 1, txconfirmRef.requestCountForTxid(sweepTxid))
+
+	// Simulate redelivery to a fresh process: a brand-new behavior restores
+	// from the same store (its in-memory sweep cache starts empty) and must
+	// reuse the persisted sweep rather than build a new one.
+	replayCfg := Config{
+		TargetOutpoint: proof.TargetOutpoint(),
+		ActorID:        "unroll-test",
+		DeliveryStore:  store,
+		ProofAssembler: &mockProofAssembler{
+			proof: proof,
+		},
+		VTXOStore: &mockVTXOStore{
+			desc: desc,
+		},
+		TxConfirmRef: txconfirmRef,
+		ChainSource:  &fakeChainSourceRef{},
+		Wallet:       &fakeSweepWallet{},
+		Log:          fn.Some(btclog.Disabled),
+	}
+	replayBehavior := &behavior{cfg: replayCfg, log: btclog.Disabled}
+	require.NoError(t, replayBehavior.restoreCheckpoint(t.Context()))
+	require.NotNil(
+		t, replayBehavior.sweepTx,
+		"sanity: fresh behavior loads the staged sweep from checkpoint",
+	)
+	require.Equal(t, sweepTxid, replayBehavior.sweepTx.TxHash())
+
+	replayActor := actor.NewActor(actor.ActorConfig[Msg, Resp]{
+		ID:          "unroll-test",
+		Behavior:    adaptTx(replayBehavior),
+		MailboxSize: 64,
+	})
+	replayBehavior.selfRef = replayActor.TellRef()
+	replayActor.Start()
+	t.Cleanup(replayActor.Stop)
+
+	mustAsk(t, replayActor.Ref(), &ResumeUnrollRequest{Height: 105})
+
+	// The reissued sweep is the SAME txid -- reused from the checkpoint --
+	// so txconfirm dedups it and no second distinct sweep is ever
+	// broadcast.
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(sweepTxid) == 2
+	}, testTimeout, 10*time.Millisecond)
+
+	sweepTxids := make(map[chainhash.Hash]struct{})
+	for _, txid := range txconfirmRef.requestedTxids() {
+		if _, ok := proof.Node(txid); ok {
+			continue
+		}
+		if txid == proof.TargetOutpoint().Hash {
+			continue
+		}
+		sweepTxids[txid] = struct{}{}
+	}
+	require.Len(
+		t, sweepTxids, 1,
+		"replay must not derive a second sweep transaction",
+	)
+}
+
+// TestUnrollAdoptStagedSweepReusesPersisted verifies the Read-based idempotency
+// guard in isolation: when a sweep was durably Staged but the in-memory cache
+// is empty (the desync window the guard exists for), adoptStagedSweep reads the
+// checkpoint snapshot and reuses the persisted sweep instead of leaving the
+// behavior to derive a fresh one.
+func TestUnrollAdoptStagedSweepReusesPersisted(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	sweepTx, err := buildSweepTx(
+		t.Context(), &fakeSweepWallet{}, &fakeChainSourceRef{}, proof,
+		desc, 0, 110, NewStandardVTXOExitSpendPolicy(desc),
+	)
+	require.NoError(t, err)
+	sweepTxid := sweepTx.TxHash()
+
+	store := newMemCheckpointStore()
+	raw, err := encodeCheckpoint(&actorCheckpoint{
+		Version: checkpointVersion,
+		Height:  110,
+		Started: true,
+		State: unrollplan.State{
+			Sweep: unrollplan.SweepState{
+				Status: unrollplan.SweepStatusBroadcasted,
+				Txid:   fn.Some(sweepTxid),
+			},
+		},
+		SweepTx: sweepTx,
+	})
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		store.SaveCheckpoint(
+			t.Context(), actor.CheckpointParams{
+				ActorID:   "unroll-test",
+				StateType: checkpointStateType,
+				StateData: raw,
+				Version:   checkpointVersion,
+			},
+		),
+	)
+
+	// A behavior with an empty in-memory sweep cache (no
+	// restoreCheckpoint).
+	b := &behavior{
+		cfg: Config{
+			ActorID:       "unroll-test",
+			DeliveryStore: store,
+			Log:           fn.Some(btclog.Disabled),
+		},
+		log: btclog.Disabled,
+	}
+	require.Nil(t, b.sweepTx)
+
+	exec := newMemExec(store, "unroll-test")
+	require.NoError(t, b.adoptStagedSweep(t.Context(), exec))
+
+	// The persisted sweep is now reused in memory: a subsequent build would
+	// take the reuse branch rather than derive a new address/txid.
+	require.NotNil(t, b.sweepTx)
+	require.Equal(t, sweepTxid, b.sweepTx.TxHash())
+	require.Equal(
+		t, int64(0), exec.stageCount.Load(),
+		"adoptStagedSweep must only Read, never Stage",
+	)
+	require.Equal(t, int64(0), exec.commitCount.Load())
+}
+
+// TestUnrollStartSweepReusesStagedSweepOnLiveDesync drives a live actor to a
+// broadcast sweep, then simulates the in-memory cache being lost WITHOUT a
+// reboot (b.sweepTx cleared) and re-enters startSweep. The adoptStagedSweep
+// Read guard inside startSweep must reload the persisted sweep so the reuse
+// branch fires and no second, freshly-derived sweep txid is ever broadcast.
+// This exercises the guard through startSweep on a loaded behavior,
+// complementing the isolated adoptStagedSweep unit test and the reboot-path
+// replay test.
+func TestUnrollStartSweepReusesStagedSweepOnLiveDesync(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, behavior, txconfirmRef, store, exec := newActorHarnessExec(
+		t, proof, desc,
+	)
+
+	sweepTxid := driveLinearToSweep(
+		t, unrollActor.Ref(), txconfirmRef, store, proof,
+	)
+	requestsBefore := txconfirmRef.requestCount()
+
+	// Simulate losing the in-memory sweep cache on a live instance (no
+	// reboot, so restoreCheckpoint does not run): the durable checkpoint
+	// still carries the sweep, but b.sweepTx is now nil.
+	behavior.sweepTx = nil
+
+	// Re-enter startSweep directly. With the cache empty, the only safe
+	// outcome is to adopt the persisted sweep via the Read guard; deriving
+	// a fresh sweep here would burn a new wallet address and a new txid.
+	ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
+	defer cancel()
+	_ = behavior.startSweep(ctx, exec)
+
+	// The persisted sweep was reloaded into the in-memory cache.
+	require.NotNil(
+		t, behavior.sweepTx, "startSweep must adopt the staged "+
+			"sweep when the cache is empty",
+	)
+	require.Equal(t, sweepTxid, behavior.sweepTx.TxHash())
+
+	// Every txconfirm request that followed reused the SAME sweep txid; no
+	// second, freshly-derived sweep was broadcast.
+	for _, txid := range txconfirmRef.requestedTxids()[requestsBefore:] {
+		require.Equal(
+			t, sweepTxid, txid, "re-entered startSweep must "+
+				"reuse the staged sweep txid",
+		)
+	}
+
+	sweepTxids := make(map[chainhash.Hash]struct{})
+	for _, txid := range txconfirmRef.requestedTxids() {
+		if _, ok := proof.Node(txid); ok {
+			continue
+		}
+		if txid == proof.TargetOutpoint().Hash {
+			continue
+		}
+		sweepTxids[txid] = struct{}{}
+	}
+	require.Len(
+		t, sweepTxids, 1,
+		"a live-desync re-entry must not derive a second sweep",
+	)
+}

--- a/unroll/fsm_logic.go
+++ b/unroll/fsm_logic.go
@@ -456,6 +456,24 @@ func applyFailedEvent(job *JobState, event *TxFailedEvent) {
 // failure cause is persistent (fee-rate too low, double-spend of the
 // input) the retry will simply rediscover the same rejection, and we
 // rely on maxSweepAttempts to bound the loop.
+//
+// Replay caveat (durable actor Read/Commit path): SweepAttempts++ is the
+// only non-monotone mutation in this FSM, so it is not idempotent under
+// message replay. On the Read/Commit path the failure event is Staged in
+// its own short transaction ahead of the lease-fenced Commit; if the
+// process crashes (or the lease is lost) in the window between that Stage
+// and the Commit, the un-acked failure message is redelivered and applied
+// again, incrementing the counter a second time for one logical failure.
+// The pre-migration whole-Receive-in-one-transaction path did not have this
+// edge because the increment and the ack rolled back together on a nack.
+// The impact is bounded and loses no funds: the sweep itself is never
+// double-broadcast (b.sweepTx is reused under a stable txid), only the retry
+// counter is inflated, so the worst case is a unilateral-exit job reaching
+// terminal Failed up to maxSweepAttempts retries early, which the client can
+// re-initiate. A fully idempotent retry accounting (deduping the failure per
+// build attempt rather than per event arrival) is tracked as a follow-up; it
+// is a standalone FSM change, not part of the Read/Commit migration that
+// merely exposed this latent non-idempotency.
 func applySweepBuildFailed(job *JobState, reason string) {
 	job.SweepAttempts++
 

--- a/unroll/registry_test.go
+++ b/unroll/registry_test.go
@@ -437,7 +437,7 @@ func newRegistryHarnessWithSpawn(t *testing.T,
 		//nolint:contextcheck // test child actor owns its own lifecycle
 		childActor := actor.NewActor(actor.ActorConfig[Msg, Resp]{
 			ID:          actorIDForTarget(target),
-			Behavior:    childBehavior,
+			Behavior:    adaptTx(childBehavior),
 			MailboxSize: 64,
 		})
 		childBehavior.selfRef = childActor.TellRef()

--- a/unroll/sweep_attempts_replay_test.go
+++ b/unroll/sweep_attempts_replay_test.go
@@ -1,0 +1,110 @@
+package unroll
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUnrollSweepAttemptsOverCountUnderReplayIsBounded is a characterization
+// test that pins the KNOWN, documented over-count of the sweep retry budget
+// under a Stage-then-lost-Commit replay. See the replay caveat on
+// applySweepBuildFailed: SweepAttempts++ is the one non-monotone FSM mutation,
+// so a failure message that is Staged but whose Commit loses its lease is
+// redelivered and re-applied, advancing the counter twice for one logical
+// failure.
+//
+// This is a bounded, no-fund-loss divergence (the sweep is never
+// double-broadcast; only the counter inflates, terminating a job at most
+// maxSweepAttempts retries early). The test asserts the current behavior so the
+// divergence is on record and any future change to it is caught; the fully
+// idempotent retry accounting is tracked as a follow-up FSM change. If that
+// follow-up lands, the final assertion should flip from 2 to 1.
+func TestUnrollSweepAttemptsOverCountUnderReplayIsBounded(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+
+	// Drive a real harness all the way to a broadcast sweep so the behavior
+	// holds a started FSM session in AwaitingSweepConfirmation with
+	// b.sweepTx set and Sweep.Txid recorded.
+	unrollActor, b, txconfirmRef, _, _ := newActorHarnessExec(
+		t, proof, desc,
+	)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+	txconfirmRef.emitConfirmed(t, 0, proof.RootTxids()[0], 101)
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(
+			proof.TargetOutpoint().Hash,
+		) == 1
+	}, testTimeout, 10*time.Millisecond)
+	txconfirmRef.emitConfirmed(t, 1, proof.TargetOutpoint().Hash, 102)
+	mustAsk(t, unrollActor.Ref(), &HeightObservedMsg{Height: 104})
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCount() == 3
+	}, testTimeout, 10*time.Millisecond)
+
+	// Capture the broadcast sweep txid and confirm the budget is untouched.
+	sweepTxid := txconfirmRef.lastRequest(t).Tx.TxHash()
+	require.Equal(t, 0, currentSweepAttempts(t, b))
+
+	// Build a TxFailedMsg for the sweep txid -- exactly what txconfirm
+	// would deliver on a mempool rejection / fee-spike eviction. This is
+	// the SINGLE logical failure we will see replayed.
+	failMsg := &TxFailedMsg{
+		Txid:   sweepTxid,
+		Reason: "sweep rejected (fee too low)",
+	}
+
+	// First delivery: the consume Commit loses its lease. Stage writes
+	// (including the SweepAttempts++ inside applySweepBuildFailed) already
+	// ran and are durable; the message is NOT acked, so the framework
+	// redelivers it.
+	exec1 := newMemExecFor(b)
+	exec1.commitLeaseLost.Store(true)
+	res1 := b.Receive(t.Context(), failMsg, exec1)
+	require.True(t, res1.IsErr())
+	require.ErrorIs(t, res1.Err(), actor.ErrLeaseLost)
+
+	attemptsAfterFirst := currentSweepAttempts(t, b)
+	require.Equal(
+		t, 1, attemptsAfterFirst,
+		"first delivery records exactly one sweep attempt",
+	)
+
+	// Redelivery of the SAME message (lease reacquired, Commit now
+	// succeeds). The replay re-applies the failure against the already
+	// advanced state because applySweepBuildFailed reset the sweep back to
+	// Pending under the same txid, so the txid still matches and the
+	// counter advances again.
+	exec2 := newMemExecFor(b)
+	res2 := b.Receive(t.Context(), failMsg, exec2)
+	require.True(t, res2.IsOk(), "redelivery should consume cleanly")
+
+	attemptsAfterReplay := currentSweepAttempts(t, b)
+
+	// Known bounded behavior: a single logical failure advanced the retry
+	// budget by two. When the idempotent-retry follow-up lands this becomes
+	// 1.
+	require.Equal(
+		t, 2, attemptsAfterReplay, "known bounded over-count: one "+
+			"logical sweep failure advances the retry budget "+
+			"twice under lease-lost replay",
+	)
+}
+
+// currentSweepAttempts reads the SweepAttempts counter off the behavior's
+// current FSM state.
+func currentSweepAttempts(t *testing.T, b *behavior) int {
+	t.Helper()
+
+	state, err := b.currentState()
+	require.NoError(t, err)
+
+	return stateJob(state).SweepAttempts
+}


### PR DESCRIPTION
In this PR, we move the `VTXOUnrollActor` onto the durable actor Read/Commit
execution path, and add a `Stage` primitive to `baselib/actor` to make that
possible without giving up the actor's persist-before-broadcast invariant.

The unroll registry already spawns one actor per target outpoint, so unilateral
exits run concurrently across VTXOs. What was actually serializing them was the
SQLite single-writer lock. On the classic durable path the whole `Receive` runs
inside one writer transaction, and `Receive` does its work by Asking `txconfirm`
to broadcast and confirm each proof-graph node and the final sweep. So we'd hold
the writer across those blocking cross-actor round trips, and every other VTXO
actor (plus the registry, the ledger, receive scripts, etc, etc) would queue up
behind that one lock. Worth stating plainly: `txconfirm` is a plain, non-durable
actor, so holding the writer across the Ask bought us no atomicity at all, it was
pure contention.

The Read/Commit path (added for the ledger actor) lets a behavior do its
side-effect IO with no transaction held, then fold its state advance and the
lease-fenced ack into one short Commit. The trouble is the unroll actor has an
invariant the ledger migration didn't: it must persist the sweep transaction
_before_ it hands it to txconfirm, so that a retry or a restart reuses the same
sweep txid and the same wallet address instead of racing a freshly-derived sweep
on chain (a second sweep burns a new BIP32 address and, if both land, leaks
something about the wallet's key derivation). The existing `Exec` only had `Read`
(a read-only snapshot) and `Commit`, and `Commit` lands at the _end_, after the
IO. That's the wrong side of the broadcast.

See each commit message for the detailed description w.r.t the incremental
changes.

## The Stage primitive

So in the first commit we add `Stage` to the `Exec` interface. `Stage` runs its
closure inside one short, non-fenced writer transaction with no ack and no dedup
mark, and it does not set the `committed` flag. The writer lock is released the
moment `Stage` returns, so any IO that follows never holds it, which is the whole
point of staging ahead of a slow side effect. The message is still consumed
exactly once, later, by the single lease-fenced `Commit`. A staged write commits
in its own transaction, independent of that eventual `Commit`, so it survives
even a `Commit` that rolls back with `ErrLeaseLost`.

The flip side of that independence is that the behavior now owns an idempotency
obligation: a crash between a `Stage` and the `Commit` redelivers the message and
replays the same event against the already-advanced state, so every staged
advance has to be replay-safe (monotonic state, downstream effects deduped). The
interface doc spells this out.

## Converting the unroll actor

With `Stage` in hand, the conversion is mostly mechanical. `persistCheckpoint`
becomes a `Stage`, so each FSM transition durably advances the checkpoint and
then releases the lock before the txconfirm IO. `driveEvent` recurses (a routed
event can re-enter the pipeline), and each level stages its own checkpoint, but
the message is consumed by a _single_ `commitAck` at the top of `Receive` after
the whole pipeline settles. There is exactly one `Commit` per message, never one
buried inside the recursion.

The persist-before-broadcast money path is preserved and, honestly, hardened. The
sweep is still staged before it crosses the actor boundary, and `startSweep` now
also reconciles against the durable checkpoint with a `Read` snapshot
(`adoptStagedSweep`) before it ever derives a fresh sweep. So even if the
in-memory `b.sweepTx` cache is lost without a reboot, we reload the persisted
sweep and stay on a single txid/address rather than building a second one.

## Modeling it

The third commit extends the `p-models/durableactor` P model. The model captured
the fenced `Commit` as one atomic consume; `Stage` deliberately breaks that
atomicity, so we add an `eDurableMailboxStage` event (a non-fenced write that
advances a monotone checkpoint and records the broadcast id), plus two monitors:
`StagedEffectAppliedAtMostOnceUnderReplay` asserts that a staged-but-unacked crash
and replay never double-broadcasts, and `CheckpointAdvancesMonotonically` guards
that a crash never rolls a checkpoint backward. There's a green driver for the
stable design and a counterexample driver that re-derives a fresh broadcast id on
replay, which the monitor catches on its own. `./p-models/scripts/check.sh` runs
all of it green plus the Go bridge.

## One known caveat

There's one edge the split exposes, called out here and documented inline on
`applySweepBuildFailed`. `SweepAttempts++` is the only non-monotone mutation in
the unroll FSM, so it is not idempotent under replay. On the old whole-`Receive`
path the increment and the ack rolled back together on a nack; on the Read/Commit
path the failure is staged in its own transaction, so a crash in the window
between that stage and the consuming `Commit` redelivers the failure and counts it
twice. The impact is bounded and loses no funds: the sweep itself is never
double-broadcast (we reuse the staged txid), only the retry counter inflates, so
the worst case is a unilateral-exit job reaching terminal `Failed` up to
`maxSweepAttempts` retries early, which the client can re-initiate. A fully
idempotent retry accounting (deduping per build attempt rather than per event
arrival) is a standalone FSM change, tracked as a follow-up; a characterization
test pins the current behavior so the divergence is on record.

## Testing

`baselib/actor` gets unit + property tests for the `Stage` primitive (stage
writes commit independent of the ack, stage is not lease-fenced, a staged write
survives a lost-lease `Commit`). The unroll side adds tests for the load-bearing
properties: the sweep is staged before the broadcast Ask, no writer transaction is
ever held across a txconfirm Ask, a staged sweep survives a lost-lease `Commit` and
a fresh actor reuses it on replay, and `adoptStagedSweep` reuses the persisted
sweep both in isolation and on a live-instance desync.
