### PR TITLE
unroll: retry failed critical exits

### DIFF
--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -120,6 +120,7 @@ type fakeTxConfirmRef struct {
 	responseStates map[chainhash.Hash]txconfirm.TxState
 	confirmHeights map[chainhash.Hash]int32
 	failureReasons map[chainhash.Hash]string
+	failOnce       map[chainhash.Hash]bool
 }
 
 // ID returns the fake actor ID.
@@ -153,6 +154,13 @@ func (f *fakeTxConfirmRef) Ask(_ context.Context,
 	f.requests = append(f.requests, req)
 	state := f.responseStates[req.Tx.TxHash()]
 	height := f.confirmHeights[req.Tx.TxHash()]
+	if state == txconfirm.TxStateFailed &&
+		f.failOnce[req.Tx.TxHash()] {
+
+		delete(f.responseStates, req.Tx.TxHash())
+		delete(f.failureReasons, req.Tx.TxHash())
+		delete(f.failOnce, req.Tx.TxHash())
+	}
 	f.mu.Unlock()
 
 	if state == 0 {
@@ -298,6 +306,22 @@ func (f *fakeTxConfirmRef) setImmediateFailed(txid chainhash.Hash,
 
 	f.responseStates[txid] = txconfirm.TxStateFailed
 	f.failureReasons[txid] = reason
+}
+
+// setImmediateFailedOnce configures one txid to fail only on the next ensure.
+func (f *fakeTxConfirmRef) setImmediateFailedOnce(txid chainhash.Hash,
+	reason string) {
+
+	f.setImmediateFailed(txid, reason)
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.failOnce == nil {
+		f.failOnce = make(map[chainhash.Hash]bool)
+	}
+
+	f.failOnce[txid] = true
 }
 
 // emitConfirmed delivers a txconfirm success notification to the subscriber.

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -33,6 +34,12 @@ const (
 	// terminalChildDrainTimeout bounds the cleanup probe used before
 	// stopping a terminal child actor.
 	terminalChildDrainTimeout = 30 * time.Second
+
+	// legacyProofTxConfirmFailure is the old terminal failure string used
+	// when txconfirm synchronously reported TxStateFailed for a proof tx.
+	// New txconfirm code keeps transient anchor-broadcast failures
+	// retryable, but legacy DBs can still carry this false-terminal latch.
+	legacyProofTxConfirmFailure = "txconfirm returned failed state"
 )
 
 // RegistryRecord stores the coarse control-plane view of one unroll target.
@@ -425,6 +432,15 @@ func (r *registryBehavior) handleEnsure(ctx context.Context,
 	// the durable store. Re-spawning a fresh actor on top of an existing
 	// record would clobber the recorded sweep txid or fail reason.
 	if record, ok := r.pending[req.Outpoint]; ok {
+		if shouldRetryFailedCriticalRecord(record) {
+			resp, err := r.retryFailedCriticalRecord(ctx, record)
+			if err != nil {
+				return fn.Err[RegistryResp](err)
+			}
+
+			return fn.Ok[RegistryResp](resp)
+		}
+
 		return fn.Ok[RegistryResp](&EnsureUnrollResp{
 			ActorID: record.ActorID,
 			Created: false,
@@ -438,67 +454,12 @@ func (r *registryBehavior) handleEnsure(ctx context.Context,
 		)
 	}
 	if existing != nil {
-		// A durable record exists but no child is live for it. Two
-		// sub-cases:
-		//
-		//   1. Terminal record (Completed/Failed) — return the
-		//      historical ActorID so callers see a stable identity
-		//      and do not clobber the recorded sweep txid or
-		//      failure reason.
-		//
-		//   2. Non-terminal record — the actor was admitted in a
-		//      previous boot but never resumed (e.g. RestoreNonTerminal
-		//      hit a transient ChainSource error). Attempt an inline
-		//      restore so a fresh Ensure from the chain resolver or
-		//      RPC layer can recover from a transient failure on the
-		//      previous boot. If restore fails again, surface the
-		//      error so the caller can retry; the durable record
-		//      stays non-terminal and will be retried on the next
-		//      Ensure / next daemon restart.
-		if !existing.IsTerminal() {
-			if err := r.validateRestorableRecords(
-				[]RegistryRecord{*existing},
-			); err != nil {
-				return fn.Err[RegistryResp](
-					fmt.Errorf("validate existing record "+
-						"for restore: %w", err),
-				)
-			}
-
-			height, err := r.queryBestHeight(ctx)
-			if err != nil {
-				return fn.Err[RegistryResp](
-					fmt.Errorf("best height for "+
-						"restore: %w", err),
-				)
-			}
-
-			child, err := r.tryRestoreOne(ctx, *existing, height)
-			if err != nil {
-				return fn.Err[RegistryResp](
-					fmt.Errorf("restore existing "+
-						"record: %w", err),
-				)
-			}
-
-			r.active[req.Outpoint] = child
-
-			// Mirror the historical record into r.pending so
-			// handleTerminated can carry over Trigger / ActorID
-			// without an extra store lookup, and so handleGetStatus
-			// answers from cache while the child runs.
-			r.pending[req.Outpoint] = cloneRegistryRecord(*existing)
-
-			return fn.Ok[RegistryResp](&EnsureUnrollResp{
-				ActorID: child.Ref().ID(),
-				Created: false,
-			})
+		resp, err := r.handleStoredEnsureRecord(ctx, *existing)
+		if err != nil {
+			return fn.Err[RegistryResp](err)
 		}
 
-		return fn.Ok[RegistryResp](&EnsureUnrollResp{
-			ActorID: existing.ActorID,
-			Created: false,
-		})
+		return fn.Ok[RegistryResp](resp)
 	}
 
 	height, err := r.queryBestHeight(ctx)
@@ -644,6 +605,55 @@ func (r *registryBehavior) handleEnsure(ctx context.Context,
 		ActorID: child.Ref().ID(),
 		Created: true,
 	})
+}
+
+// handleStoredEnsureRecord handles a durable record found during EnsureUnroll
+// after the active/pending in-memory checks missed. Terminal records normally
+// dedup to historical status, while non-terminal records are restored inline so
+// a fresh Ensure can recover a failed boot restore. The only terminal exception
+// is the narrow critical-expiry false-failure repair path.
+func (r *registryBehavior) handleStoredEnsureRecord(ctx context.Context,
+	record RegistryRecord) (*EnsureUnrollResp, error) {
+
+	if shouldRetryFailedCriticalRecord(record) {
+		return r.retryFailedCriticalRecord(ctx, record)
+	}
+
+	if record.IsTerminal() {
+		return &EnsureUnrollResp{
+			ActorID: record.ActorID,
+			Created: false,
+		}, nil
+	}
+
+	if err := r.validateRestorableRecords(
+		[]RegistryRecord{record},
+	); err != nil {
+		return nil, fmt.Errorf("validate existing record for "+
+			"restore: %w", err)
+	}
+
+	height, err := r.queryBestHeight(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("best height for restore: %w", err)
+	}
+
+	child, err := r.tryRestoreOne(ctx, record, height)
+	if err != nil {
+		return nil, fmt.Errorf("restore existing record: %w", err)
+	}
+
+	r.active[record.TargetOutpoint] = child
+
+	// Mirror the historical record into r.pending so handleTerminated can
+	// carry over Trigger / ActorID without an extra store lookup, and so
+	// handleGetStatus answers from cache while the child runs.
+	r.pending[record.TargetOutpoint] = cloneRegistryRecord(record)
+
+	return &EnsureUnrollResp{
+		ActorID: child.Ref().ID(),
+		Created: false,
+	}, nil
 }
 
 // watchChildAdmissionResult waits for a previously enqueued child start to
@@ -897,6 +907,31 @@ func (r *registryBehavior) handleTerminated(ctx context.Context,
 			record.ActorID = child.Ref().ID()
 		}
 
+		if shouldRetryFailedCriticalRecord(record) {
+			child.Stop()
+			delete(r.active, req.Outpoint)
+
+			resp, err := r.retryFailedCriticalRecord(ctx, record)
+			if err != nil {
+				r.log.WarnS(ctx, "Failed to retry critical "+
+					"unroll after terminal notification",
+					err,
+					slog.String(
+						"outpoint",
+						req.Outpoint.String(),
+					),
+					slog.String("actor_id", record.ActorID),
+				)
+
+				// Fall through to persist the terminal record
+				// so operators can see the failure instead of
+				// losing the only status signal for this
+				// target.
+			} else {
+				return fn.Ok[RegistryResp](resp)
+			}
+		}
+
 		// Terminal child drain uses its own bounded cleanup context.
 		//nolint:contextcheck
 		stopChildAfterDrain(child)
@@ -909,6 +944,179 @@ func (r *registryBehavior) handleTerminated(ctx context.Context,
 	r.requestPersist(req.Outpoint, 0)
 
 	return fn.Ok[RegistryResp](&RegistryAckResp{})
+}
+
+// shouldRetryFailedCriticalRecord reports whether a failed terminal record is
+// safe to turn back into an active recovery job. The scope is deliberately
+// narrow: only critical/restart recovery jobs that failed before any sweep tx
+// existed, and only for the legacy proof-tx txconfirm failure that current
+// txconfirm no longer treats as terminal for transient anchor-broadcast cases.
+func shouldRetryFailedCriticalRecord(record RegistryRecord) bool {
+	if record.Phase != PhaseFailed {
+		return false
+	}
+
+	switch record.Trigger {
+	case TriggerCriticalExpiry, TriggerRestart:
+	default:
+		return false
+	}
+
+	if record.SweepTxid != nil {
+		return false
+	}
+
+	return strings.Contains(record.FailReason, "proof tx") &&
+		strings.Contains(record.FailReason, legacyProofTxConfirmFailure)
+}
+
+// retryFailedCriticalRecord clears a stale failed checkpoint and starts a fresh
+// recovery actor for a critical-expiry target. The VTXO remains
+// recovery-owned: the control-plane row goes back to a non-terminal phase, but
+// the target is never returned to the spendable Live set.
+func (r *registryBehavior) retryFailedCriticalRecord(ctx context.Context,
+	record RegistryRecord) (*EnsureUnrollResp, error) {
+
+	if err := validateExitPolicyIdentity(
+		record.ExitPolicyKind, record.ExitPolicyRef,
+	); err != nil {
+		return nil, fmt.Errorf("validate retry record: %w", err)
+	}
+
+	if err := r.validateResolverCoversRecords(
+		[]RegistryRecord{record},
+	); err != nil {
+		return nil, fmt.Errorf("validate retry policy resolver: %w",
+			err)
+	}
+
+	if r.cfg.DeliveryStore == nil {
+		return nil, fmt.Errorf("delivery store must be provided")
+	}
+
+	actorID := record.ActorID
+	if actorID == "" {
+		actorID = actorIDForTarget(record.TargetOutpoint)
+	}
+
+	if err := r.cfg.DeliveryStore.DeleteCheckpoint(
+		ctx, actorID,
+	); err != nil {
+		return nil, fmt.Errorf("delete failed unroll checkpoint: %w",
+			err)
+	}
+
+	height, err := r.queryBestHeight(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("best height for retry: %w", err)
+	}
+
+	child, err := r.spawn(ctx, record.TargetOutpoint)
+	if err != nil {
+		return nil, fmt.Errorf("spawn retry child: %w", err)
+	}
+
+	retryRecord := cloneRegistryRecord(record)
+	retryRecord.ActorID = child.Ref().ID()
+	retryRecord.Phase = PhasePending
+	retryRecord.FailReason = ""
+	retryRecord.SweepTxid = nil
+
+	if err := r.cfg.Store.UpsertRecord(ctx, retryRecord); err != nil {
+		child.Stop()
+
+		return nil, fmt.Errorf("persist retry record: %w", err)
+	}
+
+	r.active[record.TargetOutpoint] = child
+	r.pending[record.TargetOutpoint] = cloneRegistryRecord(retryRecord)
+
+	startReq := &StartUnrollRequest{
+		Height:         height,
+		Trigger:        record.Trigger,
+		ExitPolicyKind: record.ExitPolicyKind,
+		ExitPolicyRef:  record.ExitPolicyRef,
+	}
+	startCtx, cancelStart := context.WithTimeout(
+		context.WithoutCancel(ctx), childAdmissionTimeout,
+	)
+	defer cancelStart()
+
+	startFuture := child.Ref().Ask(context.WithoutCancel(ctx), startReq)
+	_, err = startFuture.Await(startCtx).Unpack()
+	if err != nil {
+		if isCancellationRace(err) {
+			r.watchChildAdmissionResult(
+				context.WithoutCancel(ctx),
+				record.TargetOutpoint, child, startFuture,
+			)
+			r.log.WarnS(ctx, "Retried unroll child start did not "+
+				"respond before admission timeout; trusting "+
+				"durable enqueue", err,
+				slog.String(
+					"outpoint",
+					record.TargetOutpoint.String(),
+				),
+				slog.String("actor_id", child.Ref().ID()),
+			)
+
+			return &EnsureUnrollResp{
+				ActorID: child.Ref().ID(),
+				Created: true,
+			}, nil
+		}
+
+		r.failAdmittedChild(
+			ctx, record.TargetOutpoint, child,
+			fmt.Errorf("start retry child: %w", err),
+		)
+
+		return nil, fmt.Errorf("start retry child: %w", err)
+	}
+
+	state, err := r.childState(startCtx, child)
+	if err != nil {
+		if !isCancellationRace(err) {
+			r.failAdmittedChild(
+				ctx, record.TargetOutpoint, child,
+				fmt.Errorf("read retry child state: %w", err),
+			)
+
+			return nil, fmt.Errorf("read retry child state: %w",
+				err)
+		}
+
+		r.log.WarnS(ctx, "Failed to read retried unroll state "+
+			"after durable admission", err,
+			slog.String("outpoint", record.TargetOutpoint.String()),
+			slog.String("actor_id", child.Ref().ID()),
+		)
+
+		return &EnsureUnrollResp{
+			ActorID: child.Ref().ID(),
+			Created: true,
+		}, nil
+	}
+
+	retryRecord = recordFromChildState(
+		record.TargetOutpoint, child.Ref().ID(), state,
+	)
+	r.pending[record.TargetOutpoint] = cloneRegistryRecord(retryRecord)
+	if err := r.cfg.Store.UpsertRecord(startCtx, retryRecord); err != nil {
+		r.log.WarnS(ctx, "Failed to refine retried unroll "+
+			"admission record", err,
+			slog.String("outpoint", record.TargetOutpoint.String()),
+			slog.String("actor_id", child.Ref().ID()),
+		)
+		// Registry persistence retries are actor-owned follow-up work.
+		//nolint:contextcheck
+		r.requestPersist(record.TargetOutpoint, 0)
+	}
+
+	return &EnsureUnrollResp{
+		ActorID: child.Ref().ID(),
+		Created: true,
+	}, nil
 }
 
 // stopChildAfterDrain stops a terminal child only after a queued status probe

--- a/unroll/registry_test.go
+++ b/unroll/registry_test.go
@@ -656,6 +656,142 @@ func TestRegistryTerminalNotificationMarksStore(t *testing.T) {
 	require.Contains(t, after.FailReason, "proof tx")
 }
 
+// TestRegistryEnsureRepairsLegacyCriticalProofFailure verifies that a legacy
+// terminal critical-expiry row carrying the old txconfirm failed-state reason
+// is turned back into a running recovery job instead of staying stranded
+// forever.
+func TestRegistryEnsureRepairsLegacyCriticalProofFailure(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	registry, store, checkpoints, txconfirmRef := newRegistryHarness(
+		t, proof, desc,
+	)
+
+	target := proof.TargetOutpoint()
+	actorID := actorIDForTarget(target)
+	rootTxid := proof.RootTxids()[0]
+	failReason := "proof tx " + rootTxid.String() +
+		" failed: txconfirm returned failed state"
+
+	err := store.UpsertRecord(t.Context(), RegistryRecord{
+		TargetOutpoint: target,
+		ActorID:        actorID,
+		Trigger:        TriggerCriticalExpiry,
+		Phase:          PhaseFailed,
+		FailReason:     failReason,
+	})
+	require.NoError(t, err)
+
+	raw, err := encodeCheckpoint(&actorCheckpoint{
+		Version: checkpointVersion,
+		Height:  110,
+		Started: true,
+		Trigger: TriggerCriticalExpiry,
+		State: unrollplan.State{
+			InFlightTxids: []chainhash.Hash{rootTxid},
+		},
+		Fail: failReason,
+	})
+	require.NoError(t, err)
+	err = checkpoints.SaveCheckpoint(t.Context(), actor.CheckpointParams{
+		ActorID:   actorID,
+		StateType: checkpointStateType,
+		StateData: raw,
+		Version:   checkpointVersion,
+	})
+	require.NoError(t, err)
+
+	resp, err := registry.Ref().Ask(t.Context(), &EnsureUnrollRequest{
+		Outpoint: target,
+		Trigger:  TriggerRestart,
+	}).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	ensureResp, ok := resp.(*EnsureUnrollResp)
+	require.True(t, ok)
+	require.True(t, ensureResp.Created)
+	require.Equal(t, actorID, ensureResp.ActorID)
+
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(rootTxid) == 1
+	}, testTimeout, 10*time.Millisecond)
+
+	statusResp, err := registry.Ref().Ask(
+		t.Context(), &GetStatusRequest{
+			Outpoint: target,
+		},
+	).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	status, ok := statusResp.(*GetStatusResp)
+	require.True(t, ok)
+	require.True(t, status.Found)
+	require.True(t, status.Active)
+	require.Equal(t, PhaseMaterializing, status.Phase)
+	require.Empty(t, status.FailReason)
+
+	checkpoint := mustDecodeCheckpoint(t, checkpoints, actorID)
+	require.Empty(t, checkpoint.Fail)
+
+	record, err := store.GetRecord(t.Context(), target)
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	require.Equal(t, PhaseMaterializing, record.Phase)
+	require.Empty(t, record.FailReason)
+}
+
+// TestRegistryRetriesRuntimeCriticalProofFailure verifies the no-restart path:
+// when a critical-expiry child reaches the same old false-terminal proof
+// failure, the registry clears the failed checkpoint and re-drives recovery in
+// the same daemon process.
+func TestRegistryRetriesRuntimeCriticalProofFailure(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	registry, store, checkpoints, txconfirmRef := newRegistryHarness(
+		t, proof, desc,
+	)
+
+	target := proof.TargetOutpoint()
+	actorID := actorIDForTarget(target)
+	rootTxid := proof.RootTxids()[0]
+	txconfirmRef.setImmediateFailedOnce(rootTxid, "old failed state")
+
+	_, err := registry.Ref().Ask(t.Context(), &EnsureUnrollRequest{
+		Outpoint: target,
+		Trigger:  TriggerCriticalExpiry,
+	}).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(rootTxid) >= 2
+	}, testTimeout, 10*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		resp, err := registry.Ref().Ask(
+			t.Context(), &GetStatusRequest{
+				Outpoint: target,
+			},
+		).Await(t.Context()).Unpack()
+		require.NoError(t, err)
+
+		status, ok := resp.(*GetStatusResp)
+		require.True(t, ok)
+
+		return status.Found && status.Active &&
+			status.Phase == PhaseMaterializing &&
+			status.FailReason == ""
+	}, testTimeout, 10*time.Millisecond)
+
+	checkpoint := mustDecodeCheckpoint(t, checkpoints, actorID)
+	require.Empty(t, checkpoint.Fail)
+
+	record, err := store.GetRecord(t.Context(), target)
+	require.NoError(t, err)
+	require.NotNil(t, record)
+	require.Equal(t, PhaseMaterializing, record.Phase)
+	require.Empty(t, record.FailReason)
+}
+
 // TestRegistryTerminalNotificationDrainsChildBeforeStop verifies that the
 // registry does not cancel a child synchronously from the terminal-notification
 // handler. A child notifies the registry from its own message transaction, so


### PR DESCRIPTION
## Summary

Fixes lightninglabs/darepo-client#690.

This PR repairs a stuck unilateral-exit state where a critical-expiry VTXO can
be left in `VTXOStatusUnilateralExit` while its unroll job is terminal
`failed`. In that state the balance correctly shows zero spendable live VTXOs,
but the recovery subsystem also stops trying to recover the funds.

The fix keeps the VTXO recovery-owned. It does **not** move the VTXO back to
`Live`. Instead, for a narrow legacy false-terminal failure shape, it clears the
stale failed unroll checkpoint and starts the unroll actor again.

## Problem

A VTXO near critical expiry is handed from the normal VTXO manager to the
unilateral-exit subsystem. From that point on, normal coin selection should not
use it anymore; the unroll actor owns the on-chain recovery attempt.

The bad state is:

1. The VTXO has already moved to `UnilateralExit`.
2. The unroll actor asks `txconfirm` to materialize a proof transaction.
3. Legacy/current state can report that proof transaction as failed with:

   ```
   proof tx ... failed: txconfirm returned failed state
   ```

4. The unroll actor writes `FailReason` into its durable FSM checkpoint.
5. The registry writes the control-plane row as terminal `failed`.

After that, neither normal restart restore nor the orphaned-unroll scan can
recover it:

- `RestoreNonTerminal` intentionally skips terminal failed jobs.
- `EnsureUnroll` intentionally dedups terminal records so it does not clobber a
  real historical failure or sweep txid.
- The failed actor checkpoint restores directly back to `PhaseFailed`.

So the user sees no live balance, but recovery also does not continue.

## What Is Safe To Retry

This PR retries only a narrow class of failed records:

- phase is `failed`
- trigger is `critical_expiry` or `restart`
- no sweep txid exists yet
- the failure reason is the legacy proof-tx failed-state message

That shape means we failed before building or broadcasting a final sweep. There
is no sweep txid to preserve and no normal spendable VTXO to re-enable. The
safe action is to re-drive proof materialization from the local proof/OOR
artifacts.

The PR deliberately does **not** retry these cases:

- manual unroll failures
- completed/failed jobs that already have a sweep txid
- sweep failures
- external spend failures
- unrelated proof/proof-shape failures

Those keep the existing terminal semantics because they may represent a real
unrecoverable condition or an already-started on-chain spend path.

## Implementation

The registry now has an explicit repair path for retryable failed critical
records:

1. Detect the narrow failed-record shape in `EnsureUnroll` and in runtime child
   terminal notifications.
2. Delete the stale failed actor checkpoint for that target.
3. Persist the control-plane row back to a non-terminal pending/materializing
   state with the original trigger and policy identity.
4. Spawn the same target actor again and send a fresh `StartUnrollRequest`.
5. Keep all other terminal records on the existing dedup path.

This handles both important cases:

- legacy DB rows discovered by a later `EnsureUnroll`/startup orphan scan
- live daemon processes that hit the false-terminal failure without restart

## Tests

Added regression coverage for both paths:

- `TestRegistryEnsureRepairsLegacyCriticalProofFailure`
  - seeds a terminal failed critical-expiry registry row
  - seeds a failed actor checkpoint carrying the old txconfirm reason
  - calls `EnsureUnroll`
  - asserts the checkpoint failure latch is cleared and proof materialization is
    re-driven

- `TestRegistryRetriesRuntimeCriticalProofFailure`
  - starts a critical-expiry unroll
  - makes txconfirm fail the proof tx exactly once
  - asserts the registry clears the failed checkpoint and retries in the same
    daemon process

The existing terminal manual-failure test remains intact, proving ordinary
terminal failures still dedup and are not restarted.

## Validation

Ran locally:

- `go test ./unroll -count=1`
- `go test ./txconfirm ./vtxo ./darepod -count=1`
- `make lint-changed-local`
- `make fmt-changed-check`
- `make commitmsg-lint range=origin/main..HEAD`
