### PR TITLE
round: Keep failed rounds observable; wallet: stop tip-tick loop on termination

### DIFF
--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -165,13 +165,18 @@ state transitions and validation rules live under [Invariants](#invariants).
   wallet/manager admits VTXOs before sending `RegisterIntentMsg`.
 - A round that settles in the terminal `ClientFailedState` (admission
   timeout, server rejection, quote rejection, forfeit-collection timeout,
-  etc.) is reaped from the actor's `rounds` map by `reapIfFailed`, called
-  after every event in `askEventAndProcessOutbox`. This mirrors
-  `onRoundComplete` (success) and `handleCancelRound` (explicit cancel) so
-  failed/timed-out rounds don't accumulate in memory or `ListRounds`.
+  etc.) is reaped from the actor's `rounds` map by `reapFailedRounds`,
+  swept at the start of the next assembly (`createNewRound`) rather than on
+  entry. Deferring the reap keeps the failure observable: `GetClientState`
+  (and the `ListRounds` RPC it backs) must be able to report a round as
+  FAILED until the client moves on to a fresh round — reaping on entry made
+  the terminal state vanish within the same actor turn, so a poller could
+  never see it (darepo-client#602). Sweeping at the next assembly still
+  bounds accumulation to the failures since the last new round, mirroring
+  `onRoundComplete` (success) and `handleCancelRound` (explicit cancel).
   Nothing reuses a failed round — `findAssemblingRound` only returns
   `Idle`/`PendingRoundAssembly` rounds, and the FSM's recovery transitions
-  have no production producer — so reaping the settled failed state is safe.
+  have no production producer — so deferred reaping is safe.
 - `ClientWallet` provides MuSig2 signing and key derivation; boarding
   address creation is handled by the wallet actor (not the round FSM).
 - Persisted VTXO ownership uses `OwnerKey` (not `SigningKey`). For

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -165,13 +165,18 @@ state transitions and validation rules live under [Invariants](#invariants).
   wallet/manager admits VTXOs before sending `RegisterIntentMsg`.
 - A round that settles in the terminal `ClientFailedState` (admission
   timeout, server rejection, quote rejection, forfeit-collection timeout,
-  etc.) is reaped from the actor's `rounds` map by `reapIfFailed`, called
-  after every event in `askEventAndProcessOutbox`. This mirrors
-  `onRoundComplete` (success) and `handleCancelRound` (explicit cancel) so
-  failed/timed-out rounds don't accumulate in memory or `ListRounds`.
+  etc.) is reaped from the actor's `rounds` map by `reapFailedRounds`,
+  swept at the start of the next assembly (`createNewRound`) rather than on
+  entry. Deferring the reap keeps the failure observable: `GetClientState`
+  (and the `ListRounds` RPC it backs) must be able to report a round as
+  FAILED until the client moves on to a fresh round — reaping on entry made
+  the terminal state vanish within the same actor turn, so a poller could
+  never see it (darepo-client#602). Sweeping at the next assembly still
+  bounds accumulation to the failures since the last new round, mirroring
+  `onRoundComplete` (success) and `handleCancelRound` (explicit cancel).
   Nothing reuses a failed round — `findAssemblingRound` only returns
   `Idle`/`PendingRoundAssembly` rounds, and the FSM's recovery transitions
-  have no production producer — so reaping the settled failed state is safe.
+  have no production producer — so deferred reaping is safe.
 - `ClientWallet` provides MuSig2 signing and key derivation; boarding
   address creation is handled by the wallet actor (not the round FSM).
 - Persisted VTXO ownership uses `OwnerKey` (not `SigningKey`). For

--- a/round/actor.go
+++ b/round/actor.go
@@ -718,6 +718,11 @@ func (a *RoundClientActor) createRoundFSMFromDB(ctx context.Context,
 func (a *RoundClientActor) createNewRound(ctx context.Context) (*RoundFSM,
 	error) {
 
+	// The client is starting a fresh round, so any rounds that previously
+	// settled in the terminal failed state have served their observability
+	// purpose and can be swept now (see reapFailedRounds).
+	a.reapFailedRounds(ctx)
+
 	tempKey, err := NewTempRoundKey()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate temp key: %w", err)
@@ -1006,13 +1011,6 @@ func (a *RoundClientActor) askEventAndProcessOutbox(ctx context.Context,
 			return fmt.Errorf("failed to process outbox: %w", err)
 		}
 	}
-
-	// If the event settled the round in the terminal failed state, reap it
-	// so timed-out / failed rounds don't accumulate in the actor's map and
-	// ListRounds view. This runs unconditionally (not only when the outbox
-	// is non-empty) because some failure transitions — e.g. BoardingFailed
-	// in PendingRoundAssembly / IntentSentState — emit no outbox.
-	a.reapIfFailed(ctx, roundFSM)
 
 	return nil
 }
@@ -1939,12 +1937,10 @@ func (a *RoundClientActor) handleCancelRound(ctx context.Context,
 		})
 	}
 
-	// Remove the cancelled round. When the injected BoardingFailed settles
-	// the round in ClientFailedState, the reap in askEventAndProcessOutbox
-	// has already stopped the FSM and removed it. But some states (e.g.
-	// QuoteReceivedState) self-loop on BoardingFailed, so the reap does not
-	// fire there — an explicit cancel must still drop the round. Guard on
-	// presence so we don't double-stop an FSM the reap already cleaned up.
+	// Remove the cancelled round. Failed rounds are now reaped lazily at
+	// the next assembly (reapFailedRounds), not on entry, so an explicit
+	// cancel must still stop and drop the round here. Guard on presence so
+	// we don't double-stop an FSM a concurrent path already cleaned up.
 	keyStr := RoundKeyStr(targetFSM.Key.KeyString())
 	if _, exists := a.rounds[keyStr]; exists {
 		targetFSM.FSM.Stop()
@@ -1979,8 +1975,8 @@ func (a *RoundClientActor) onRoundComplete(ctx context.Context, roundID RoundID,
 	return a.cfg.RoundStore.FinalizeRound(ctx, roundID, txid, confInfo)
 }
 
-// reapIfFailed removes a round FSM from active tracking once an event has
-// settled it in the terminal ClientFailedState. Rounds that fail or time out
+// reapFailedRounds drops every round FSM that has settled in the terminal
+// ClientFailedState from active tracking. Rounds that fail or time out
 // (registration/admission timeout, server rejection, quote rejection,
 // forfeit-collection timeout, etc.) would otherwise linger in the rounds map
 // for the lifetime of the daemon — and keep surfacing in ListRounds — because
@@ -1988,46 +1984,42 @@ func (a *RoundClientActor) onRoundComplete(ctx context.Context, roundID RoundID,
 // (handleCancelRound) removed rounds. Nothing reuses a failed round in
 // production: findAssemblingRound only returns Idle / PendingRoundAssembly
 // rounds, and the FSM's IntentPackage / RecoveryInitiated recovery transitions
-// have no production producer. This closes that gap for autonomous failures.
+// have no production producer.
 //
-// Reaping only the *settled* terminal-failed state is safe even against the
-// recovery transition: a round that recovers within the same turn
-// (ClientFailed -> Idle -> PendingRoundAssembly via an internal IntentPackage)
-// does not end the turn in ClientFailedState, so it is left untouched.
-func (a *RoundClientActor) reapIfFailed(ctx context.Context,
-	roundFSM *RoundFSM) {
+// Reaping is deliberately deferred to the next round assembly (createNewRound)
+// rather than fired the instant a round enters ClientFailedState. A failure is
+// only useful if a consumer can observe it: GetClientState (and the RPC
+// ListRounds surface it backs) must be able to report a round as FAILED at
+// least until the client moves on to a fresh round. Reaping on entry made the
+// terminal state vanish within the same actor turn, so a poller could never
+// see it (darepo-client#602 systests). Sweeping at the start of the next
+// assembly keeps the window open while still bounding accumulation to the
+// failures since the last new round.
+//
+// Only the *settled* terminal ClientFailedState is reaped.
+// RecoveryInitiatedState is deliberately NOT reaped: it is semi-terminal
+// (states.go) and represents a round whose CSV-timeout sweep tx has been
+// broadcast and is awaiting confirmation — in-flight work, not a settled
+// failure.
+func (a *RoundClientActor) reapFailedRounds(ctx context.Context) {
+	for keyStr, roundFSM := range a.rounds {
+		state, err := roundFSM.FSM.CurrentState()
+		if err != nil {
+			continue
+		}
 
-	keyStr := RoundKeyStr(roundFSM.Key.KeyString())
+		if _, failed := state.(*ClientFailedState); !failed {
+			continue
+		}
 
-	// If the round was already removed during outbox processing (e.g. a
-	// successful round handled by onRoundComplete), there is nothing to do
-	// and the FSM may already be stopped.
-	if _, ok := a.rounds[keyStr]; !ok {
-		return
+		a.log.InfoS(ctx, "Reaping failed round",
+			slog.String("round_key", string(keyStr)),
+		)
+
+		roundFSM.FSM.Stop()
+		delete(a.rounds, keyStr)
+		delete(a.commitmentTxIndex, roundFSM.TxID)
 	}
-
-	state, err := roundFSM.FSM.CurrentState()
-	if err != nil {
-		return
-	}
-
-	// Only the settled, truly-terminal ClientFailedState is reaped.
-	// RecoveryInitiatedState is deliberately NOT reaped: it is
-	// semi-terminal (states.go) and represents a round whose CSV-timeout
-	// sweep tx has been broadcast and is awaiting confirmation — in-flight
-	// work, not a settled failure. Dropping it on entry would stop tracking
-	// an active recovery.
-	if _, failed := state.(*ClientFailedState); !failed {
-		return
-	}
-
-	a.log.InfoS(ctx, "Reaping failed round",
-		slog.String("round_key", string(keyStr)),
-	)
-
-	roundFSM.FSM.Stop()
-	delete(a.rounds, keyStr)
-	delete(a.commitmentTxIndex, roundFSM.TxID)
 }
 
 // handleConfirmation processes a commitment transaction confirmation event

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -1036,11 +1036,16 @@ func TestActorLifecycle(t *testing.T) {
 			Recoverable: true,
 		})
 
-		// The failed round is reaped, leaving no rounds tracked.
-		require.Empty(
-			t, h.queryState(),
-			"failed round should be reaped",
+		// The failed round stays observable in ClientFailedState — it
+		// is reaped lazily at the next assembly, not on entry, so a
+		// consumer can still see the failure (darepo-client#602).
+		state := h.queryState()
+		require.Len(
+			t, state, 1, "failed round should remain observable",
 		)
+		for _, info := range state {
+			require.IsType(t, &ClientFailedState{}, info.State)
+		}
 	})
 
 	t.Run("concurrent_rounds", func(t *testing.T) {
@@ -1424,10 +1429,21 @@ func TestActorServerMessageRouting(t *testing.T) {
 			h.sendServerMessage(event)
 
 			if tc.expectReaped {
-				require.Empty(
-					h.t, h.queryState(),
-					"failed round should be reaped",
+				// Failed rounds are reaped lazily at the next
+				// assembly, not on entry, so the round remains
+				// observable in ClientFailedState here
+				// (darepo-client#602).
+				state := h.queryState()
+				require.Len(
+					h.t, state, 1,
+					"failed round should remain observable",
 				)
+				for _, info := range state {
+					require.IsType(
+						h.t, &ClientFailedState{},
+						info.State,
+					)
+				}
 			} else {
 				h.assertFSMState(tc.expectedState)
 			}
@@ -2128,12 +2144,14 @@ func TestHandleForfeitCollectionTimeout(t *testing.T) {
 			"actor receive failed: %v", result.Err(),
 		)
 
-		// The failed round is reaped so it does not linger in the
-		// actor's map. The failure reason/recoverability is covered by
-		// the FSM-level forfeit-collection-timeout test.
+		// The failed round stays observable in ClientFailedState; it is
+		// reaped lazily at the next assembly, not on entry
+		// (darepo-client#602). The failure reason/recoverability is
+		// covered by the FSM-level forfeit-collection-timeout test.
 		states := h.queryState()
-		_, exists := states[string(keyStr)]
-		require.False(t, exists, "failed round should be reaped")
+		info, exists := states[string(keyStr)]
+		require.True(t, exists, "failed round should remain observable")
+		require.IsType(t, &ClientFailedState{}, info.State)
 	})
 
 	t.Run("ignores_unknown_timeout_phase", func(t *testing.T) {
@@ -2228,17 +2246,28 @@ func TestHandleForfeitCollectionTimeout(t *testing.T) {
 			"timeout receive failed: %v", result.Err(),
 		)
 
-		// The first round failed on timeout and is reaped.
+		// The first round failed on timeout but stays observable in
+		// ClientFailedState — reaping is deferred to the next assembly
+		// (darepo-client#602).
 		keyStr1 := RoundKeyStr(roundID1.KeyString())
 		states := h.queryState()
-		_, exists := states[string(keyStr1)]
-		require.False(t, exists, "failed round should be reaped")
+		info, exists := states[string(keyStr1)]
+		require.True(t, exists, "failed round should remain observable")
+		require.IsType(t, &ClientFailedState{}, info.State)
 
 		// Phase 2: Start a new round from a boarding confirmation,
-		// proving the actor is still healthy.
+		// proving the actor is still healthy. Assembling the new round
+		// also sweeps the stale failed round.
 		intent := h.newTestBoardingIntent()
 		h.sendWalletConfirmation(intent)
 		h.assertFSMState("PendingRoundAssembly")
+
+		states = h.queryState()
+		_, stillThere := states[string(keyStr1)]
+		require.False(
+			t, stillThere,
+			"failed round should be reaped at next assembly",
+		)
 
 		h.sendVTXORequests(50000)
 		h.clearServerMessages()
@@ -2284,11 +2313,27 @@ func TestActorReapsFailedRound(t *testing.T) {
 	}
 	require.True(t, h.receive(msg).IsOk())
 
-	// The failed round is reaped, leaving no rounds tracked.
+	// The round settled in ClientFailedState but is NOT reaped on entry: it
+	// stays observable so a consumer can see the failure. Reaping is
+	// deferred to the next assembly (darepo-client#602).
+	failed := h.queryState()
+	failedFSM, exists := failed[keyStr]
+	require.True(t, exists, "failed round should remain observable")
+	require.IsType(
+		t, &ClientFailedState{}, failedFSM.State,
+		"round should be observable in ClientFailedState",
+	)
+
+	// Starting a fresh round sweeps the stale failed round.
+	intent2 := h.newTestBoardingIntent()
+	h.sendWalletConfirmation(intent2)
+	h.assertFSMState("PendingRoundAssembly")
+
 	after := h.queryState()
-	_, exists := after[keyStr]
-	require.False(t, exists, "failed round should be reaped")
-	require.Empty(t, after, "no rounds should remain tracked")
+	_, stillThere := after[keyStr]
+	require.False(
+		t, stillThere, "failed round should be reaped at next assembly",
+	)
 }
 
 // TestRealTimeoutActorForfeitExpiry exercises the full timeout flow with a
@@ -2352,16 +2397,26 @@ func TestRealTimeoutActorForfeitExpiry(t *testing.T) {
 	require.True(t, result.IsOk(), "actor receive failed: %v",
 		result.Err())
 
-	// Verify the failed round is reaped after the real timeout fires.
+	// The failed round stays observable after the timeout fires — reaping
+	// is deferred to the next assembly, not done on entry
+	// (darepo-client#602).
 	keyStr := RoundKeyStr(roundID.KeyString())
 	states := h.queryState()
-	_, exists := states[string(keyStr)]
-	require.False(t, exists, "failed round should be reaped")
+	failedInfo, exists := states[string(keyStr)]
+	require.True(t, exists, "failed round should remain observable")
+	require.IsType(t, &ClientFailedState{}, failedInfo.State)
 
-	// Phase 2: Start a new round to prove actor recovery.
+	// Phase 2: Start a new round to prove actor recovery. Assembling the
+	// new round also sweeps the stale failed round.
 	intent := h.newTestBoardingIntent()
 	h.sendWalletConfirmation(intent)
 	h.assertFSMState("PendingRoundAssembly")
+
+	states = h.queryState()
+	_, stillThere := states[string(keyStr)]
+	require.False(
+		t, stillThere, "failed round should be reaped at next assembly",
+	)
 }
 
 // TestVTXOCreatedNotificationForwarding verifies that VTXOCreatedNotification

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -584,10 +584,13 @@ func (a *Ark) Start(ctx context.Context,
 // tick: a tick handler that takes longer than the interval (a few
 // seconds is common when ListUnspent races against retries) would
 // otherwise let ticker.C events accumulate and drown out self-Tells
-// the handler makes for boarding-sweep resume kicks. Errors from the
-// Tell are debug-logged but never escalated: the next tick will
-// retry, and any backlog the actor is processing will catch up on
-// its own.
+// the handler makes for boarding-sweep resume kicks. Transient errors
+// from the Tell are debug-logged but never escalated: the next tick
+// will retry, and any backlog the actor is processing will catch up on
+// its own. A terminated-actor error is the one exception — the mailbox
+// is gone for good, so the loop returns instead of spinning, because
+// the actor system can terminate the actor without invoking Stop()
+// (which is what cancels a.ctx), and a dead ref will never recover.
 func (a *Ark) runTipTickLoop(interval time.Duration) {
 	defer a.wg.Done()
 
@@ -612,10 +615,18 @@ func (a *Ark) runTipTickLoop(interval time.Duration) {
 			)
 			if err != nil {
 				a.tickInflight.Store(false)
+
+				// A terminated actor never recovers, so stop
+				// the loop rather than respin and re-log every
+				// tick against a dead mailbox.
+				if errors.Is(err, actor.ErrActorTerminated) {
+					return
+				}
+
 				a.logger(a.ctx).DebugS(
 					a.ctx,
 					"Failed to schedule tip tick",
-					err,
+					slog.String("err", err.Error()),
 				)
 			}
 		}


### PR DESCRIPTION
## Summary

Two fixes surfaced while bumping darepo's client submodule forward (the
darepo-client#602 systest coverage in darepo#510 began exercising client
`main` for the first time, against a server on `master`).

### 1. `round`: failed rounds were reaped before they could be observed

darepo-client#686 added `reapIfFailed`, which stopped a round FSM and
deleted it from the actor's `rounds` map **the instant** an event settled
it in the terminal `ClientFailedState`. That made the failure
unobservable — `GetClientState` (and the `ListRounds` RPC it backs) could
never report a round as `FAILED`, because the state vanished within the
same actor turn that produced it.

Concretely, this broke the boarding seal-time-rejection systests
(`TestBoardingE2EInsufficientOperatorFee`, `TestBoardingE2ETimeoutThenRejoin`)
on **all three backends**: the rounds *did* fail and reap (confirmed via
`Reaping failed round` logs), but `WaitForFSMState("ClientFailedState")`
always raced the synchronous reap and timed out.

**Fix:** replace the on-entry `reapIfFailed` with `reapFailedRounds`, swept
at the start of the next assembly (`createNewRound`). A failed round now
lingers in `ClientFailedState` — observable to any consumer — until the
client starts a fresh round, at which point stale failures are dropped.
This preserves #686's goal (failed rounds don't accumulate for the daemon
lifetime) while bounding accumulation to the failures since the last new
round, and restores observability.

### 2. `wallet`: tip-tick loop spun forever after actor termination

`runTipTickLoop` exits only on `a.ctx.Done()`, cancelled by `Stop()`. But
the actor system can terminate the wallet actor without invoking `Stop()`,
leaving `a.ctx` live — the loop then spun forever, every self-`Tell`
returning `ErrActorTerminated` and emitting a debug log (tens of thousands
of lines per systest run). It now returns from the loop on
`ErrActorTerminated`. Also fixes the malformed log line that rendered as
`!BADKEY="actor terminated"` (bare error arg to `DebugS`) → proper
`slog.String("err", ...)`.

## Testing

- Updated the `round` actor reap unit tests to assert the new
  observable-then-swept-at-assembly behavior; full `round` + `wallet`
  unit suites pass, `lint-changed` clean.
- The companion darepo#510 submodule bump picks this up; the two boarding
  systests should go green on all backends.
