### PR TITLE
darepod: support multi-recipient SendOOR

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_ark_send.go
+++ b/cmd/darepocli/darepoclicommands/cmd_ark_send.go
@@ -210,7 +210,7 @@ func sendOOR(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 
-		req.Recipient = recipient
+		req.Recipients = []*daemonrpc.Output{recipient}
 		req.DryRun = dryRun
 		req.IdempotencyKey = idempotencyKey
 

--- a/cmd/darepocli/darepoclicommands/cmd_mcp.go
+++ b/cmd/darepocli/darepoclicommands/cmd_mcp.go
@@ -395,7 +395,7 @@ func registerMCPSendTools(s *mcp.Server, client daemonrpc.DaemonServiceClient) {
 
 		resp, err := client.SendOOR(
 			ctx, &daemonrpc.SendOORRequest{
-				Recipient:      recipient,
+				Recipients:     []*daemonrpc.Output{recipient},
 				DryRun:         args.DryRun,
 				IdempotencyKey: args.IdempotencyKey,
 			},

--- a/cmd/darepocli/darepoclicommands/devrpc/command_test.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/command_test.go
@@ -255,7 +255,7 @@ func TestDevCmdParsesHexBytesWithSpaces(t *testing.T) {
 	}
 }
 
-func TestDevCmdFlattensSingularNestedMessages(t *testing.T) {
+func TestDevCmdParsesSendOORRecipients(t *testing.T) {
 	server := &testDaemonServer{}
 	var out bytes.Buffer
 	cmd, cleanup := newTestDevCmd(t, server, &out)
@@ -263,8 +263,7 @@ func TestDevCmdFlattensSingularNestedMessages(t *testing.T) {
 
 	cmd.SetArgs([]string{
 		"daemon", "send-oor",
-		"--recipient.address", "bcrt1dest",
-		"--recipient.amount_sat", "7",
+		"--recipients-json", `[{"address":"bcrt1dest","amount_sat":7}]`,
 		"--dry_run",
 	})
 	if err := cmd.Execute(); err != nil {
@@ -277,14 +276,17 @@ func TestDevCmdFlattensSingularNestedMessages(t *testing.T) {
 	if !server.oorReq.DryRun {
 		t.Fatalf("expected dry_run to be set")
 	}
-	if server.oorReq.Recipient.AmountSat != 7 {
-		t.Fatalf("amount = %v", server.oorReq.Recipient.AmountSat)
+	if len(server.oorReq.Recipients) != 1 {
+		t.Fatalf("recipient count = %v", len(server.oorReq.Recipients))
+	}
+	if server.oorReq.Recipients[0].AmountSat != 7 {
+		t.Fatalf("amount = %v", server.oorReq.Recipients[0].AmountSat)
 	}
 
-	dest, ok := server.oorReq.Recipient.
+	dest, ok := server.oorReq.Recipients[0].
 		Destination.(*daemonrpc.Output_Address)
 	if !ok {
-		t.Fatalf("destination = %T", server.oorReq.Recipient.
+		t.Fatalf("destination = %T", server.oorReq.Recipients[0].
 			Destination)
 	}
 	if dest.Address != "bcrt1dest" {
@@ -299,7 +301,7 @@ func TestDevCmdRejectsNestedOneofConflicts(t *testing.T) {
 	defer cleanup()
 
 	cmd.SetArgs([]string{
-		"daemon", "send-oor",
+		"daemon", "prepare-oor",
 		"--recipient.address", "bcrt1dest",
 		"--recipient.pubkey", "00",
 	})

--- a/cmd/darepocli/darepoclicommands/devrpc/describe_test.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/describe_test.go
@@ -64,7 +64,7 @@ func TestDevDescribeRespectsOneofGroup(t *testing.T) {
 	stdout, restore := captureStdout(t)
 	defer restore()
 
-	cmd.SetArgs([]string{"daemon", "send-oor", "--describe"})
+	cmd.SetArgs([]string{"daemon", "prepare-oor", "--describe"})
 	require.NoError(t, cmd.Execute())
 
 	var desc methodDescription

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -2860,8 +2860,8 @@ func (x *SendVTXOResponse) GetSelectedCount() int32 {
 
 type SendOORRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// recipient is the output to create via the out-of-round transfer.
-	Recipient *Output `protobuf:"bytes,1,opt,name=recipient,proto3" json:"recipient,omitempty"`
+	// recipients are the outputs to create via one out-of-round transfer.
+	Recipients []*Output `protobuf:"bytes,1,rep,name=recipients,proto3" json:"recipients,omitempty"`
 	// dry_run validates the request without initiating the transfer.
 	DryRun bool `protobuf:"varint,2,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
 	// custom_inputs overrides wallet VTXO selection. When set, the
@@ -2908,9 +2908,9 @@ func (*SendOORRequest) Descriptor() ([]byte, []int) {
 	return file_daemon_proto_rawDescGZIP(), []int{33}
 }
 
-func (x *SendOORRequest) GetRecipient() *Output {
+func (x *SendOORRequest) GetRecipients() []*Output {
 	if x != nil {
-		return x.Recipient
+		return x.Recipients
 	}
 	return nil
 }
@@ -3117,12 +3117,15 @@ type SendOORResponse struct {
 	Status string `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
 	// session_id is the OOR session identifier. Empty on dry_run.
 	SessionId string `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	// recipient_outpoint is the Ark transaction outpoint created for the
-	// requested recipient. Empty on dry_run or when an older idempotent
-	// session is returned without enough local request context.
-	RecipientOutpoint string `protobuf:"bytes,3,opt,name=recipient_outpoint,json=recipientOutpoint,proto3" json:"recipient_outpoint,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// recipient_outpoints are the Ark transaction outpoints created for
+	// the requested recipients, in request-recipient order. The whole
+	// list is empty on dry_run or when an older idempotent session is
+	// returned without enough local request context. Individual entries
+	// may be empty when the daemon cannot resolve one recipient's
+	// outpoint from the finalized Ark transaction.
+	RecipientOutpoints []string `protobuf:"bytes,3,rep,name=recipient_outpoints,json=recipientOutpoints,proto3" json:"recipient_outpoints,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *SendOORResponse) Reset() {
@@ -3169,11 +3172,11 @@ func (x *SendOORResponse) GetSessionId() string {
 	return ""
 }
 
-func (x *SendOORResponse) GetRecipientOutpoint() string {
+func (x *SendOORResponse) GetRecipientOutpoints() []string {
 	if x != nil {
-		return x.RecipientOutpoint
+		return x.RecipientOutpoints
 	}
-	return ""
+	return nil
 }
 
 type PrepareOORRequest struct {
@@ -7971,9 +7974,11 @@ const file_daemon_proto_rawDesc = "" +
 	"\bround_id\x18\x02 \x01(\tR\aroundId\x12(\n" +
 	"\x10total_amount_sat\x18\x03 \x01(\x03R\x0etotalAmountSat\x12*\n" +
 	"\x11change_amount_sat\x18\x04 \x01(\x03R\x0fchangeAmountSat\x12%\n" +
-	"\x0eselected_count\x18\x05 \x01(\x05R\rselectedCount\"\xc3\x01\n" +
-	"\x0eSendOORRequest\x12/\n" +
-	"\trecipient\x18\x01 \x01(\v2\x11.daemonrpc.OutputR\trecipient\x12\x17\n" +
+	"\x0eselected_count\x18\x05 \x01(\x05R\rselectedCount\"\xc5\x01\n" +
+	"\x0eSendOORRequest\x121\n" +
+	"\n" +
+	"recipients\x18\x01 \x03(\v2\x11.daemonrpc.OutputR\n" +
+	"recipients\x12\x17\n" +
 	"\adry_run\x18\x02 \x01(\bR\x06dryRun\x12>\n" +
 	"\rcustom_inputs\x18\x03 \x03(\v2\x19.daemonrpc.CustomOORInputR\fcustomInputs\x12'\n" +
 	"\x0fidempotency_key\x18\x04 \x01(\tR\x0eidempotencyKey\"\x8d\x02\n" +
@@ -7990,12 +7995,12 @@ const file_daemon_proto_rawDesc = "" +
 	"\x06pubkey\x18\x01 \x01(\fR\x06pubkey\x12%\n" +
 	"\x0ewitness_script\x18\x02 \x01(\fR\rwitnessScript\x12\x1c\n" +
 	"\tsignature\x18\x03 \x01(\fR\tsignature\x12\x18\n" +
-	"\asighash\x18\x04 \x01(\rR\asighash\"w\n" +
+	"\asighash\x18\x04 \x01(\rR\asighash\"y\n" +
 	"\x0fSendOORResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x02 \x01(\tR\tsessionId\x12-\n" +
-	"\x12recipient_outpoint\x18\x03 \x01(\tR\x11recipientOutpoint\"\x84\x01\n" +
+	"session_id\x18\x02 \x01(\tR\tsessionId\x12/\n" +
+	"\x13recipient_outpoints\x18\x03 \x03(\tR\x12recipientOutpoints\"\x84\x01\n" +
 	"\x11PrepareOORRequest\x12/\n" +
 	"\trecipient\x18\x01 \x01(\v2\x11.daemonrpc.OutputR\trecipient\x12>\n" +
 	"\rcustom_inputs\x18\x02 \x03(\v2\x19.daemonrpc.CustomOORInputR\fcustomInputs\"\xad\x01\n" +
@@ -8603,7 +8608,7 @@ var file_daemon_proto_depIdxs = []int32{
 	1,   // 5: daemonrpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> daemonrpc.VTXOStatus
 	20,  // 6: daemonrpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> daemonrpc.VTXO
 	39,  // 7: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
-	39,  // 8: daemonrpc.SendOORRequest.recipient:type_name -> daemonrpc.Output
+	39,  // 8: daemonrpc.SendOORRequest.recipients:type_name -> daemonrpc.Output
 	43,  // 9: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
 	44,  // 10: daemonrpc.CustomOORInput.external_signatures:type_name -> daemonrpc.TaprootScriptSignature
 	39,  // 11: daemonrpc.PrepareOORRequest.recipient:type_name -> daemonrpc.Output

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -749,8 +749,8 @@ message SendVTXOResponse {
 }
 
 message SendOORRequest {
-    // recipient is the output to create via the out-of-round transfer.
-    Output recipient = 1;
+    // recipients are the outputs to create via one out-of-round transfer.
+    repeated Output recipients = 1;
 
     // dry_run validates the request without initiating the transfer.
     bool dry_run = 2;
@@ -822,10 +822,13 @@ message SendOORResponse {
     // session_id is the OOR session identifier. Empty on dry_run.
     string session_id = 2;
 
-    // recipient_outpoint is the Ark transaction outpoint created for the
-    // requested recipient. Empty on dry_run or when an older idempotent
-    // session is returned without enough local request context.
-    string recipient_outpoint = 3;
+    // recipient_outpoints are the Ark transaction outpoints created for
+    // the requested recipients, in request-recipient order. The whole
+    // list is empty on dry_run or when an older idempotent session is
+    // returned without enough local request context. Individual entries
+    // may be empty when the daemon cannot resolve one recipient's
+    // outpoint from the finalized Ark transaction.
+    repeated string recipient_outpoints = 3;
 }
 
 message PrepareOORRequest {

--- a/darepod/rpc_oor_idempotency_test.go
+++ b/darepod/rpc_oor_idempotency_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/db/actordelivery"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
 	"github.com/lightninglabs/darepo-client/oor"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightninglabs/darepo-client/wallet"
@@ -178,6 +179,53 @@ func (a *blockingSendOORActor) Receive(ctx context.Context,
 	}
 }
 
+type capturingSendOORActor struct {
+	mu       sync.Mutex
+	requests []*oor.StartTransferRequest
+	response *oor.StartTransferResponse
+}
+
+func (a *capturingSendOORActor) Receive(_ context.Context,
+	msg oor.OORDurableMsg) fn.Result[oor.ActorResp] {
+
+	req, ok := msg.(*oor.StartTransferRequest)
+	if !ok {
+		return fn.Err[oor.ActorResp](
+			fmt.Errorf("unexpected OOR message %T", msg),
+		)
+	}
+
+	reqCopy := *req
+	reqCopy.Inputs = append([]oor.TransferInput(nil), req.Inputs...)
+	reqCopy.Recipients = append(
+		[]oortx.RecipientOutput(nil), req.Recipients...,
+	)
+
+	a.mu.Lock()
+	a.requests = append(a.requests, &reqCopy)
+	resp := a.response
+	a.mu.Unlock()
+
+	return fn.Ok[oor.ActorResp](resp)
+}
+
+func (a *capturingSendOORActor) capturedRequests() []*oor.StartTransferRequest {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	requests := make([]*oor.StartTransferRequest, 0, len(a.requests))
+	for _, req := range a.requests {
+		reqCopy := *req
+		reqCopy.Inputs = append([]oor.TransferInput(nil), req.Inputs...)
+		reqCopy.Recipients = append(
+			[]oortx.RecipientOutput(nil), req.Recipients...,
+		)
+		requests = append(requests, &reqCopy)
+	}
+
+	return requests
+}
+
 // TestSendOORRejectsRecipientBelowDustBeforeWalletSelection verifies the
 // daemon enforces the operator's advertised dust limit before it selects wallet
 // inputs or submits work to the OOR actor. This is the daemon-side guard behind
@@ -225,11 +273,287 @@ func TestSendOORRejectsRecipientBelowDustBeforeWalletSelection(t *testing.T) {
 	)
 
 	_, err = rpcServer.SendOOR(t.Context(), &daemonrpc.SendOORRequest{
-		Recipient: recipient,
+		Recipients: []*daemonrpc.Output{recipient},
 	})
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 	require.ErrorContains(
 		t, err, "amount 999 below operator dust_limit 1000",
+	)
+}
+
+// TestSendOORSubmitsMultipleRecipients verifies the daemon maps one
+// multi-recipient RPC request into one OOR actor request. This pins the public
+// RPC surface that later batching code uses: wallet selection targets the sum
+// of all requested outputs, the actor receives every requested recipient in one
+// package, and the response reports outpoints in request-recipient order even
+// though the underlying Ark transaction uses canonical output ordering.
+func TestSendOORSubmitsMultipleRecipients(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	recipientKeyA, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	recipientKeyB, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	const (
+		amountA   = int64(11_000)
+		amountB   = int64(13_000)
+		exitDelay = uint32(10)
+	)
+	totalAmount := btcutil.Amount(amountA + amountB)
+
+	vtxoStore, _ := newSendOORTestStores(t)
+	desc := newSendOORTestVTXO(
+		t, operatorKey.PubKey(), 0x51, totalAmount,
+	)
+	require.NoError(t, vtxoStore.SaveVTXO(ctx, desc))
+
+	testWallet := &sendOORTestWallet{
+		selections: [][]wallet.SelectedVTXO{{
+			selectedVTXOFromDescriptor(desc),
+		}},
+	}
+
+	system := actor.NewActorSystem()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer cancel()
+
+		require.NoError(t, system.Shutdown(shutdownCtx))
+	})
+
+	walletKey := actor.NewServiceKey[
+		wallet.WalletMsg, wallet.WalletResp,
+	](
+		"send-oor-many-test-wallet",
+	)
+	walletRef := walletKey.Spawn(
+		system, "send-oor-many-test-wallet", testWallet,
+	)
+
+	sessionHash := chainhash.HashH([]byte("send-oor-many-session"))
+	oorActor := &capturingSendOORActor{
+		response: &oor.StartTransferResponse{
+			SessionID: oor.SessionID(sessionHash),
+		},
+	}
+	oorKey := oor.NewServiceKey()
+	oorKey.Spawn(system, "send-oor-many-test-actor", oorActor)
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+
+	server := &Server{
+		cfg:         &Config{},
+		log:         btclog.Disabled,
+		walletReady: walletReady,
+		chainParams: &chaincfg.RegressionNetParams,
+		serverConn: newBufconnClient(t, &fakeArkService{
+			getInfoResponse: &arkrpc.GetInfoResponse{
+				Pubkey: operatorKey.
+					PubKey().
+					SerializeCompressed(),
+				VtxoExitDelay: exitDelay,
+				DustLimit:     1,
+			},
+		}),
+		actorSystem: system,
+		vtxoStore:   vtxoStore,
+		walletRef:   fn.Some(walletRef),
+	}
+
+	rpcServer := NewRPCServer(server)
+	recipientA := sendOORPolicyRecipient(
+		t, recipientKeyA.PubKey(), operatorKey.PubKey(), exitDelay,
+		amountA,
+	)
+	recipientB := sendOORPolicyRecipient(
+		t, recipientKeyB.PubKey(), operatorKey.PubKey(), exitDelay,
+		amountB,
+	)
+
+	resp, err := rpcServer.SendOOR(ctx, &daemonrpc.SendOORRequest{
+		Recipients: []*daemonrpc.Output{
+			recipientA,
+			recipientB,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "submitted", resp.GetStatus())
+	require.Equal(t, sessionHash.String(), resp.GetSessionId())
+	require.Len(t, resp.GetRecipientOutpoints(), 2)
+
+	requests := oorActor.capturedRequests()
+	require.Len(t, requests, 1)
+	require.Len(t, requests[0].Recipients, 2)
+	require.Empty(t, requests[0].IdempotencyKey)
+	require.Len(t, requests[0].Inputs, 1)
+	require.Equal(t, desc.Outpoint, requests[0].Inputs[0].VTXO.Outpoint)
+
+	for i, recipient := range requests[0].Recipients {
+		outpoint, err := oortx.RecipientOutPoint(
+			sessionHash, requests[0].Recipients, recipient,
+		)
+		require.NoError(t, err)
+		require.Equal(t, outpoint.String(), resp.RecipientOutpoints[i])
+	}
+
+	selectReqs := testWallet.selectionRequests()
+	require.Len(t, selectReqs, 1)
+	require.Equal(t, totalAmount, selectReqs[0].TargetAmount)
+	require.Equal(t, btcutil.Amount(1), selectReqs[0].MinChangeAmount)
+	require.Empty(t, testWallet.unlockBatches())
+}
+
+// TestSendOORRejectsTooManyRecipients verifies the daemon rejects oversized
+// OOR fanout before resolving scripts or selecting wallet inputs. The OOR
+// actor also has request-size limits, but the RPC layer does enough per
+// recipient work that it needs its own cheap boundary guard.
+func TestSendOORRejectsTooManyRecipients(t *testing.T) {
+	t.Parallel()
+
+	recipients := make([]*daemonrpc.Output, maxOORRecipients+1)
+	for i := range recipients {
+		recipients[i] = &daemonrpc.Output{
+			AmountSat: 1,
+		}
+	}
+
+	_, err := sendOORRequestRecipients(&daemonrpc.SendOORRequest{
+		Recipients: recipients,
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.ErrorContains(t, err, "too many recipients")
+}
+
+// TestSendOORRejectsDuplicateRecipientOutputs verifies the daemon rejects
+// request entries that would map to the same canonical OOR output. Without
+// this guard the transaction builder cannot map request-order recipients back
+// to distinct outpoints after canonical output sorting.
+func TestSendOORRejectsDuplicateRecipientOutputs(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	recipientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	const (
+		amountSat = int64(10_000)
+		exitDelay = uint32(10)
+	)
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+
+	server := &Server{
+		cfg:         &Config{},
+		log:         btclog.Disabled,
+		walletReady: walletReady,
+		chainParams: &chaincfg.RegressionNetParams,
+		serverConn: newBufconnClient(t, &fakeArkService{
+			getInfoResponse: &arkrpc.GetInfoResponse{
+				Pubkey: operatorKey.
+					PubKey().
+					SerializeCompressed(),
+				VtxoExitDelay: exitDelay,
+				DustLimit:     1,
+			},
+		}),
+	}
+
+	recipient := sendOORPolicyRecipient(
+		t, recipientKey.PubKey(), operatorKey.PubKey(), exitDelay,
+		amountSat,
+	)
+
+	_, err = NewRPCServer(server).SendOOR(
+		t.Context(), &daemonrpc.SendOORRequest{
+			Recipients: []*daemonrpc.Output{
+				recipient,
+				recipient,
+			},
+			DryRun: true,
+		},
+	)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.ErrorContains(t, err, "recipient 1 duplicates recipient 0")
+}
+
+// TestSendOORRejectsCustomInputsWithMultipleRecipients verifies the daemon
+// keeps custom-input sends single-recipient. Custom inputs carry per-input
+// signing material for specialized spend paths, so widening them should happen
+// as a separate protocol change rather than accidentally piggybacking on
+// wallet-selected fanout.
+func TestSendOORRejectsCustomInputsWithMultipleRecipients(t *testing.T) {
+	t.Parallel()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	recipientKeyA, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	recipientKeyB, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	const (
+		amountSat = int64(10_000)
+		exitDelay = uint32(10)
+	)
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+
+	server := &Server{
+		cfg:         &Config{},
+		log:         btclog.Disabled,
+		walletReady: walletReady,
+		chainParams: &chaincfg.RegressionNetParams,
+		serverConn: newBufconnClient(t, &fakeArkService{
+			getInfoResponse: &arkrpc.GetInfoResponse{
+				Pubkey: operatorKey.
+					PubKey().
+					SerializeCompressed(),
+				VtxoExitDelay: exitDelay,
+				DustLimit:     1,
+			},
+		}),
+	}
+
+	recipientA := sendOORPolicyRecipient(
+		t, recipientKeyA.PubKey(), operatorKey.PubKey(), exitDelay,
+		amountSat,
+	)
+	recipientB := sendOORPolicyRecipient(
+		t, recipientKeyB.PubKey(), operatorKey.PubKey(), exitDelay,
+		amountSat,
+	)
+
+	_, err = NewRPCServer(server).SendOOR(
+		t.Context(), &daemonrpc.SendOORRequest{
+			Recipients: []*daemonrpc.Output{
+				recipientA,
+				recipientB,
+			},
+			DryRun: true,
+			CustomInputs: []*daemonrpc.CustomOORInput{{
+				Outpoint: "00:0",
+			}},
+		},
+	)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.ErrorContains(
+		t, err, "custom inputs require exactly one recipient",
 	)
 }
 
@@ -328,13 +652,18 @@ func TestSendOORReturnsExistingIdempotencyKeyBeforeWalletSelection(
 	)
 
 	firstResp, err := rpcServer.SendOOR(ctx, &daemonrpc.SendOORRequest{
-		Recipient:      recipient,
+		Recipients:     []*daemonrpc.Output{recipient},
 		IdempotencyKey: idempotencyKey,
 	})
 	require.NoError(t, err)
 	require.Equal(t, "submitted", firstResp.Status)
 	require.NotEmpty(t, firstResp.SessionId)
-	require.Equal(t, firstResp.SessionId+":0", firstResp.RecipientOutpoint)
+	require.Equal(
+		t, []string{
+			firstResp.SessionId + ":0",
+		},
+		firstResp.RecipientOutpoints,
+	)
 	require.Empty(t, testWallet.unlockBatches())
 	selectReqs := testWallet.selectionRequests()
 	require.Len(t, selectReqs, 1)
@@ -342,12 +671,12 @@ func TestSendOORReturnsExistingIdempotencyKeyBeforeWalletSelection(
 	require.Equal(t, btcutil.Amount(1), selectReqs[0].MinChangeAmount)
 
 	secondResp, err := rpcServer.SendOOR(ctx, &daemonrpc.SendOORRequest{
-		Recipient:      recipient,
+		Recipients:     []*daemonrpc.Output{recipient},
 		IdempotencyKey: idempotencyKey,
 	})
 	require.NoError(t, err)
 	require.Equal(t, firstResp.SessionId, secondResp.SessionId)
-	require.Empty(t, secondResp.RecipientOutpoint)
+	require.Empty(t, secondResp.RecipientOutpoints)
 	require.Equal(t, 1, testWallet.selectCount())
 	require.Empty(t, testWallet.unlockBatches())
 }
@@ -448,21 +777,26 @@ func TestSendOORUnlocksSelectedInputsForExistingSession(t *testing.T) {
 	)
 
 	firstResp, err := rpcServer.SendOOR(ctx, &daemonrpc.SendOORRequest{
-		Recipient: recipient,
+		Recipients: []*daemonrpc.Output{recipient},
 	})
 	require.NoError(t, err)
 	require.Equal(t, "submitted", firstResp.Status)
 	require.NotEmpty(t, firstResp.SessionId)
-	require.Equal(t, firstResp.SessionId+":0", firstResp.RecipientOutpoint)
+	require.Equal(
+		t, []string{
+			firstResp.SessionId + ":0",
+		},
+		firstResp.RecipientOutpoints,
+	)
 	require.Empty(t, testWallet.unlockBatches())
 
 	secondResp, err := rpcServer.SendOOR(ctx, &daemonrpc.SendOORRequest{
-		Recipient: recipient,
+		Recipients: []*daemonrpc.Output{recipient},
 	})
 	require.NoError(t, err)
 	require.Equal(t, firstResp.SessionId, secondResp.SessionId)
 	require.Equal(
-		t, firstResp.RecipientOutpoint, secondResp.RecipientOutpoint,
+		t, firstResp.RecipientOutpoints, secondResp.RecipientOutpoints,
 	)
 	require.Equal(t, 2, testWallet.selectCount())
 
@@ -477,10 +811,10 @@ func TestSendOORUnlocksSelectedInputsForExistingSession(t *testing.T) {
 	}, 5*time.Second, 50*time.Millisecond)
 }
 
-// TestSendOORWaitDeadlineDoesNotUnlockSubmittedInputs verifies that once a
-// detached OOR actor Ask has been submitted, a caller wait deadline does not
+// TestSendOORWaitCancelDoesNotUnlockSubmittedInputs verifies that once a
+// detached OOR actor Ask has been submitted, caller cancellation does not
 // release wallet-selected inputs while that actor work is still in flight.
-func TestSendOORWaitDeadlineDoesNotUnlockSubmittedInputs(t *testing.T) {
+func TestSendOORWaitCancelDoesNotUnlockSubmittedInputs(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -570,25 +904,37 @@ func TestSendOORWaitDeadlineDoesNotUnlockSubmittedInputs(t *testing.T) {
 		amountSat,
 	)
 
-	waitCtx, cancel := context.WithTimeout(
-		context.Background(), 50*time.Millisecond,
-	)
+	waitCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_, err = rpcServer.SendOOR(waitCtx, &daemonrpc.SendOORRequest{
-		Recipient: recipient,
-	})
-	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := rpcServer.SendOOR(
+			waitCtx, &daemonrpc.SendOORRequest{
+				Recipients: []*daemonrpc.Output{recipient},
+			},
+		)
+		errChan <- err
+	}()
 
-	require.Eventually(t, func() bool {
-		select {
-		case <-blockingActor.started:
-			return true
+	select {
+	case <-blockingActor.started:
+	case err := <-errChan:
+		require.NoError(t, err)
+		require.FailNow(t, "SendOOR returned before actor start")
 
-		default:
-			return false
-		}
-	}, time.Second, 10*time.Millisecond)
+	case <-time.After(time.Second):
+		require.FailNow(t, "OOR actor did not start")
+	}
+
+	cancel()
+	select {
+	case err = <-errChan:
+		require.Equal(t, codes.Canceled, status.Code(err))
+
+	case <-time.After(time.Second):
+		require.FailNow(t, "SendOOR did not observe caller cancel")
+	}
 	require.Empty(t, testWallet.unlockBatches())
 
 	close(blockingActor.release)

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -62,6 +62,12 @@ const (
 	// pending futures; this ceiling prevents a pathological actor stall
 	// from retaining wallet/custom input reservations forever.
 	submittedOORCleanupTimeout = 10 * time.Minute
+
+	// maxOORRecipients mirrors the in-round send cap at the daemon
+	// boundary. The OOR actor has its own package-size limits, but the
+	// RPC handler resolves scripts and policy templates before handing
+	// work to that actor, so it needs its own cheap request-size guard.
+	maxOORRecipients = 256
 )
 
 // RPCServer implements the daemon's gRPC DaemonService interface.
@@ -321,6 +327,142 @@ func validateOORRecipientDust(amountSat int64, dustLimit btcutil.Amount) error {
 
 	return status.Errorf(codes.InvalidArgument, "amount %d below operator "+
 		"dust_limit %d", amount, dustLimit)
+}
+
+// sendOORRequestRecipients returns the caller-requested OOR recipients in
+// request order.
+func sendOORRequestRecipients(req *daemonrpc.SendOORRequest) (
+	[]*daemonrpc.Output, error) {
+
+	if req == nil || len(req.GetRecipients()) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "recipient "+
+			"is required")
+	}
+
+	if len(req.GetRecipients()) > maxOORRecipients {
+		return nil, status.Errorf(codes.InvalidArgument, "too many "+
+			"recipients: %d (max %d)", len(req.GetRecipients()),
+			maxOORRecipients)
+	}
+
+	return req.GetRecipients(), nil
+}
+
+// sumSendOORRecipientAmounts validates every requested recipient amount and
+// returns the aggregate wallet-selection target.
+func sumSendOORRecipientAmounts(recipients []*daemonrpc.Output) (btcutil.Amount,
+	error) {
+
+	var total int64
+	for i, recipient := range recipients {
+		if recipient == nil {
+			return 0, status.Errorf(codes.InvalidArgument,
+				"recipient %d is required", i)
+		}
+
+		if recipient.AmountSat <= 0 {
+			return 0, status.Errorf(codes.InvalidArgument,
+				"recipient %d amount must be positive", i)
+		}
+
+		if recipient.AmountSat > int64(btcutil.MaxSatoshi) {
+			return 0, status.Errorf(codes.InvalidArgument,
+				"recipient %d amount must be <= %d", i,
+				int64(btcutil.MaxSatoshi))
+		}
+
+		if total > int64(btcutil.MaxSatoshi)-recipient.AmountSat {
+			return 0, status.Errorf(codes.InvalidArgument, "total "+
+				"recipient amount must be <= %d",
+				int64(btcutil.MaxSatoshi))
+		}
+
+		total += recipient.AmountSat
+	}
+
+	return btcutil.Amount(total), nil
+}
+
+// indexedSendOORRecipientError keeps the original gRPC code while adding the
+// recipient index to the user-facing error.
+func indexedSendOORRecipientError(index int, err error) error {
+	st := status.Convert(err)
+
+	return status.Errorf(st.Code(), "recipient %d: %s", index, st.Message())
+}
+
+// buildSendOORRecipients resolves the daemon RPC recipient descriptors into
+// the OOR actor's package-level recipient outputs.
+func (r *RPCServer) buildSendOORRecipients(ctx context.Context,
+	requestRecipients []*daemonrpc.Output, terms *types.OperatorTerms) (
+	[]oortx.RecipientOutput, error) {
+
+	seen := make(map[string]int, len(requestRecipients))
+	recipients := make(
+		[]oortx.RecipientOutput, 0, len(requestRecipients),
+	)
+	for i, out := range requestRecipients {
+		pkScript, err := r.resolveOutputPkScript(ctx, out)
+		if err != nil {
+			return nil, indexedSendOORRecipientError(i, err)
+		}
+
+		if err := validateOORRecipientDust(
+			out.AmountSat, terms.DustLimit,
+		); err != nil {
+			return nil, indexedSendOORRecipientError(i, err)
+		}
+
+		policyTemplate, err := r.resolveOutputPolicyTemplate(
+			ctx, out, pkScript, terms.PubKey, terms.VTXOExitDelay,
+		)
+		if err != nil {
+			return nil, indexedSendOORRecipientError(i, err)
+		}
+
+		key := fmt.Sprintf("%d:%x", out.AmountSat, pkScript)
+		if first, ok := seen[key]; ok {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"recipient %d duplicates recipient %d", i,
+				first)
+		}
+		seen[key] = i
+
+		recipients = append(recipients, oortx.RecipientOutput{
+			PkScript:           pkScript,
+			Value:              btcutil.Amount(out.AmountSat),
+			VTXOPolicyTemplate: policyTemplate,
+		})
+	}
+
+	return recipients, nil
+}
+
+// resolveOORRecipientOutpoints maps each requested recipient to the outpoint it
+// occupies after the canonical OOR output ordering is applied.
+func (r *RPCServer) resolveOORRecipientOutpoints(ctx context.Context,
+	sessionID oor.SessionID,
+	allRecipients, requestRecipients []oortx.RecipientOutput) []string {
+
+	sessionHash := chainhash.Hash(sessionID)
+	outpoints := make([]string, len(requestRecipients))
+	for i, recipient := range requestRecipients {
+		outpoint, err := oortx.RecipientOutPoint(
+			sessionHash, allRecipients, recipient,
+		)
+		if err != nil {
+			r.server.log.WarnS(ctx, "Unable to resolve OOR "+
+				"recipient outpoint", err,
+				slog.String("session_id", sessionID.String()),
+				slog.Int("recipient_index", i))
+
+			continue
+		}
+
+		outpoints[i] = outpoint.String()
+	}
+
+	return outpoints
 }
 
 // walletStateToProto maps the daemon's in-process WalletState enum to
@@ -1956,7 +2098,6 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		idempotencyDuration   time.Duration
 		resolveScriptDuration time.Duration
 		operatorTermsDuration time.Duration
-		policyResolveDuration time.Duration
 		inputSelectDuration   time.Duration
 		buildInputsDuration   time.Duration
 		changeOutputDuration  time.Duration
@@ -1967,14 +2108,14 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		return nil, err
 	}
 
-	if req.Recipient == nil {
-		return nil, status.Errorf(codes.InvalidArgument, "recipient "+
-			"is required")
+	requestRecipients, err := sendOORRequestRecipients(req)
+	if err != nil {
+		return nil, err
 	}
 
-	if req.Recipient.AmountSat <= 0 {
-		return nil, status.Errorf(codes.InvalidArgument, "amount "+
-			"must be positive")
+	targetAmt, err := sumSendOORRecipientAmounts(requestRecipients)
+	if err != nil {
+		return nil, err
 	}
 
 	if req.GetIdempotencyKey() != "" && !req.DryRun {
@@ -2005,18 +2146,8 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		}
 	}
 
-	// Resolve the recipient's pkScript from the destination
-	// oneof. Pubkey destinations need operator terms to derive
-	// VTXO-compatible taproot outputs, so we pass a lazy fetcher.
-	phaseStart := time.Now()
-	pkScript, err := r.resolveOutputPkScript(ctx, req.Recipient)
-	resolveScriptDuration = time.Since(phaseStart)
-	if err != nil {
-		return nil, err
-	}
-
 	// Fetch operator terms for the checkpoint policy.
-	phaseStart = time.Now()
+	phaseStart := time.Now()
 	terms, err := r.server.fetchOperatorTerms(ctx)
 	operatorTermsDuration = time.Since(phaseStart)
 	if err != nil {
@@ -2024,10 +2155,20 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 			"operator terms: %v", err)
 	}
 
-	if err := validateOORRecipientDust(
-		req.Recipient.AmountSat, terms.DustLimit,
-	); err != nil {
+	// Resolve the recipients' pkScripts from the destination oneofs
+	// and bind any supplied semantic policy templates to those scripts.
+	phaseStart = time.Now()
+	oorRecipients, err := r.buildSendOORRecipients(
+		ctx, requestRecipients, terms,
+	)
+	resolveScriptDuration = time.Since(phaseStart)
+	if err != nil {
 		return nil, err
+	}
+
+	if len(req.CustomInputs) > 0 && len(oorRecipients) != 1 {
+		return nil, status.Errorf(codes.InvalidArgument, "custom "+
+			"inputs require exactly one recipient")
 	}
 
 	// For dry_run, return a preview before selecting wallet inputs or
@@ -2057,15 +2198,6 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	policy := arkscript.CheckpointPolicy{
 		OperatorKey: terms.PubKey,
 		CSVDelay:    terms.VTXOExitDelay,
-	}
-
-	phaseStart = time.Now()
-	recipientPolicyTemplate, err := r.resolveOutputPolicyTemplate(
-		ctx, req.Recipient, pkScript, terms.PubKey, terms.VTXOExitDelay,
-	)
-	policyResolveDuration = time.Since(phaseStart)
-	if err != nil {
-		return nil, err
 	}
 
 	var (
@@ -2136,7 +2268,6 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	} else {
 		// Standard path: select and lock VTXOs from wallet.
 		phaseStart = time.Now()
-		targetAmt := btcutil.Amount(req.Recipient.AmountSat)
 		wRef := r.server.walletRef.UnsafeFromSome()
 
 		selectReq := &wallet.SelectAndLockVTXOsRequest{
@@ -2182,15 +2313,12 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		}
 	}
 
-	targetAmt := btcutil.Amount(req.Recipient.AmountSat)
-
-	// Build the recipient output for the OOR transfer.
-	recipient := oortx.RecipientOutput{
-		PkScript:           pkScript,
-		Value:              targetAmt,
-		VTXOPolicyTemplate: recipientPolicyTemplate,
-	}
-	recipients := []oortx.RecipientOutput{recipient}
+	requestOORRecipients := append(
+		[]oortx.RecipientOutput(nil), oorRecipients...,
+	)
+	// Keep the request copy change-free so response outpoint resolution
+	// maps only caller-requested recipients back into the finalized Ark tx.
+	recipients := requestOORRecipients
 
 	phaseStart = time.Now()
 	inputTotal, err := sumOORInputAmounts(selectedInputs)
@@ -2275,35 +2403,24 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		r.unlockSelectedVTXOsBestEffort(ctx, locked)
 	}
 
-	sessionHash := chainhash.Hash(resp.SessionID)
-	recipientOutpoint, err := oortx.RecipientOutPoint(
-		sessionHash, recipients, recipient,
+	recipientOutpoints := r.resolveOORRecipientOutpoints(
+		ctx, resp.SessionID, recipients, requestOORRecipients,
 	)
-	recipientOutpointString := ""
-	if err != nil {
-		r.server.log.WarnS(ctx, "Unable to resolve OOR recipient "+
-			"outpoint", err,
-			slog.String("session_id", resp.SessionID.String()))
-	} else {
-		recipientOutpointString = recipientOutpoint.String()
-	}
-
 	r.server.log.InfoS(ctx, "OOR transfer submitted",
 		slog.String("session_id", resp.SessionID.String()),
 		slog.Bool("existing_session", resp.Existing),
-		slog.String("recipient_outpoint", recipientOutpointString),
-		slog.Int64("amount_sat", req.Recipient.AmountSat),
+		slog.Int("recipient_outpoint_count", len(recipientOutpoints)),
+		slog.Int64("amount_sat", int64(targetAmt)),
 		slog.Int64("input_total_sat", int64(inputTotal)),
 		slog.Int64("change_sat", int64(changeAmt)),
-		slog.Int("recipient_count", len(recipients)),
+		slog.Int("recipient_count", len(requestOORRecipients)),
+		slog.Int("output_count", len(recipients)),
 		slog.Duration("duration", time.Since(startTime)),
 		slog.Duration("idempotency_duration", idempotencyDuration),
 		slog.Duration("resolve_script_duration",
 			resolveScriptDuration),
 		slog.Duration("operator_terms_duration",
 			operatorTermsDuration),
-		slog.Duration("policy_resolve_duration",
-			policyResolveDuration),
 		slog.Duration("input_select_duration",
 			inputSelectDuration),
 		slog.Duration("build_inputs_duration",
@@ -2313,9 +2430,9 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		slog.Duration("oor_actor_duration", oorActorDuration))
 
 	return &daemonrpc.SendOORResponse{
-		Status:            "submitted",
-		SessionId:         resp.SessionID.String(),
-		RecipientOutpoint: recipientOutpointString,
+		Status:             "submitted",
+		SessionId:          resp.SessionID.String(),
+		RecipientOutpoints: recipientOutpoints,
 	}, nil
 }
 

--- a/internal/actortest/e2e_test.go
+++ b/internal/actortest/e2e_test.go
@@ -180,8 +180,10 @@ const outboxForwardProcessingTimeout = 5 * time.Second
 
 // outboxDeliveryTimeout is the timeout budget for waiting on OutboxPublisher
 // delivery in end-to-end tests. The helper actively triggers publish attempts
-// during this window to reduce scheduler-induced flakiness under `-race`.
-const outboxDeliveryTimeout = 10 * time.Second
+// during this window to reduce scheduler-induced flakiness under `-race`, but
+// the full CI race suite can still starve these chained delivery tests while
+// other package tests are competing for CPU.
+const outboxDeliveryTimeout = 30 * time.Second
 
 // durableCounterRef is a shorthand alias for the generic durable ref used in
 // these end-to-end tests.

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -918,13 +918,16 @@ func (c *Client) SendOORWithPolicyAndKeyDetails(ctx context.Context,
 	idempotencyKey string) (*OORSendResult, error) {
 
 	resp, err := c.SendOOR(ctx, &daemonrpc.SendOORRequest{
-		Recipient: &daemonrpc.Output{
-			Destination: &daemonrpc.Output_PolicyTemplate{
-				PolicyTemplate: append(
-					[]byte(nil), recipientPolicyTemplate...,
-				),
+		Recipients: []*daemonrpc.Output{
+			{
+				Destination: &daemonrpc.Output_PolicyTemplate{
+					PolicyTemplate: append(
+						[]byte(nil),
+						recipientPolicyTemplate...,
+					),
+				},
+				AmountSat: amountSat,
 			},
-			AmountSat: amountSat,
 		},
 		IdempotencyKey: idempotencyKey,
 	})
@@ -932,9 +935,15 @@ func (c *Client) SendOORWithPolicyAndKeyDetails(ctx context.Context,
 		return nil, err
 	}
 
+	recipientOutpoints := resp.GetRecipientOutpoints()
+	recipientOutpoint := ""
+	if len(recipientOutpoints) > 0 {
+		recipientOutpoint = recipientOutpoints[0]
+	}
+
 	return &OORSendResult{
 		SessionID:         resp.GetSessionId(),
-		RecipientOutpoint: resp.GetRecipientOutpoint(),
+		RecipientOutpoint: recipientOutpoint,
 	}, nil
 }
 
@@ -945,11 +954,15 @@ func (c *Client) SendOORWithCustomInputs(ctx context.Context,
 	string, error) {
 
 	resp, err := c.SendOOR(ctx, &daemonrpc.SendOORRequest{
-		Recipient: &daemonrpc.Output{
-			Destination: &daemonrpc.Output_Pubkey{
-				Pubkey: append([]byte(nil), recipientPubKey...),
+		Recipients: []*daemonrpc.Output{
+			{
+				Destination: &daemonrpc.Output_Pubkey{
+					Pubkey: append(
+						[]byte(nil), recipientPubKey...,
+					),
+				},
+				AmountSat: amountSat,
 			},
-			AmountSat: amountSat,
 		},
 		CustomInputs: customOORInputsToRPC(inputs),
 	})

--- a/sdk/ark/client_test.go
+++ b/sdk/ark/client_test.go
@@ -163,8 +163,10 @@ func newFakeDaemonService() *fakeDaemonService {
 			},
 		},
 		sendOORResp: &daemonrpc.SendOORResponse{
-			SessionId:         "session-123",
-			RecipientOutpoint: "session-123:0",
+			SessionId: "session-123",
+			RecipientOutpoints: []string{
+				"session-123:0",
+			},
 		},
 	}
 }
@@ -656,10 +658,13 @@ func TestDialRemotePolicyHelpers(t *testing.T) {
 	service.mu.Unlock()
 
 	require.NotNil(t, policyReq)
-	require.Equal(t, int64(42_000), policyReq.GetRecipient().GetAmountSat())
+	require.Len(t, policyReq.GetRecipients(), 1)
+	require.Equal(
+		t, int64(42_000), policyReq.GetRecipients()[0].GetAmountSat(),
+	)
 	require.Equal(
 		t, []byte{0xaa, 0xbb},
-		policyReq.GetRecipient().GetPolicyTemplate(),
+		policyReq.GetRecipients()[0].GetPolicyTemplate(),
 	)
 
 	sessionID, err = client.SendOORWithCustomInputs(
@@ -682,8 +687,9 @@ func TestDialRemotePolicyHelpers(t *testing.T) {
 	service.mu.Unlock()
 
 	require.NotNil(t, customReq)
+	require.Len(t, customReq.GetRecipients(), 1)
 	require.Equal(
-		t, []byte{0x11, 0x22}, customReq.GetRecipient().GetPubkey(),
+		t, []byte{0x11, 0x22}, customReq.GetRecipients()[0].GetPubkey(),
 	)
 	require.Len(t, customReq.GetCustomInputs(), 1)
 	require.Equal(

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -25,10 +25,12 @@ import (
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/darepod"
 	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	"github.com/lightninglabs/darepo-client/round"
+	"github.com/lightninglabs/darepo-client/rpc/oorpb"
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
 	"github.com/lightninglabs/darepo-client/serverconn"
 	"github.com/lightninglabs/darepo-client/vtxo"
@@ -74,6 +76,8 @@ type fakeMailboxServer struct {
 	nextEventSeq    map[string]uint64
 	joinRoundReqs   []*roundpb.JoinRoundRequest
 	joinRoundEnvs   []*mailboxpb.Envelope
+	oorSubmitReqs   []*oorpb.SubmitPackageRequest
+	oorSubmitEnvs   []*mailboxpb.Envelope
 	inboxSignalChan chan struct{}
 }
 
@@ -247,6 +251,10 @@ func (s *fakeMailboxServer) handleOperatorEnvelope(ctx context.Context,
 		env.Rpc.Method == roundpb.MethodJoinRound:
 		return s.recordJoinRound(env)
 
+	case env.Rpc.Service == oorpb.ServiceName &&
+		env.Rpc.Method == oorpb.MethodSubmitPackage:
+		return s.recordOORSubmitPackage(env)
+
 	default:
 		return nil
 	}
@@ -277,6 +285,35 @@ func (s *fakeMailboxServer) replyWithOperatorInfo(ctx context.Context,
 	}
 
 	s.enqueueEnvelope(responseEnv)
+
+	return nil
+}
+
+// recordOORSubmitPackage decodes and stores an OOR submit-package envelope so
+// systests can assert on the real mailbox payload emitted by darepod.
+func (s *fakeMailboxServer) recordOORSubmitPackage(
+	env *mailboxpb.Envelope) error {
+
+	if env.Body == nil {
+		return fmt.Errorf("OOR submit envelope missing body")
+	}
+
+	var req oorpb.SubmitPackageRequest
+	if err := env.Body.UnmarshalTo(&req); err != nil {
+		return fmt.Errorf("decode OOR submit body: %w", err)
+	}
+
+	cloned, ok := proto.Clone(&req).(*oorpb.SubmitPackageRequest)
+	if !ok {
+		return fmt.Errorf("clone OOR submit body: unexpected type %T",
+			&req)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.oorSubmitReqs = append(s.oorSubmitReqs, cloned)
+	s.oorSubmitEnvs = append(s.oorSubmitEnvs, env)
 
 	return nil
 }
@@ -359,6 +396,24 @@ func (s *fakeMailboxServer) pullBatch(mailboxID string, cursor uint64,
 	return batch, nextCursor
 }
 
+// oorSubmitPackages returns a cloned snapshot of recorded OOR submit requests.
+func (s *fakeMailboxServer) oorSubmitPackages() []*oorpb.SubmitPackageRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	reqs := make([]*oorpb.SubmitPackageRequest, 0, len(s.oorSubmitReqs))
+	for _, req := range s.oorSubmitReqs {
+		cloned, ok := proto.Clone(req).(*oorpb.SubmitPackageRequest)
+		if !ok {
+			continue
+		}
+
+		reqs = append(reqs, cloned)
+	}
+
+	return reqs
+}
+
 // directedSendFixture owns the daemon under test, its fake operator edge, and
 // the gRPC client used by the systest.
 type directedSendFixture struct {
@@ -367,6 +422,7 @@ type directedSendFixture struct {
 	client         daemonrpc.DaemonServiceClient
 	conn           *grpc.ClientConn
 	mailboxServer  *fakeMailboxServer
+	operatorKey    *btcec.PublicKey
 	seededOutpoint wire.OutPoint
 }
 
@@ -483,6 +539,7 @@ func newDirectedSendFixture(t *testing.T,
 		client:         client,
 		conn:           conn,
 		mailboxServer:  mailboxServer,
+		operatorKey:    operatorPriv.PubKey(),
 		seededOutpoint: seededOutpoint,
 	}
 }
@@ -606,6 +663,11 @@ func seedLiveVTXO(t *testing.T, cfg *darepod.Config,
 	)
 	require.NoError(t, err)
 
+	tapScript, err := arkscript.VTXOTapScript(
+		clientPriv.PubKey(), operatorKey, 144,
+	)
+	require.NoError(t, err)
+
 	outpoint := wire.OutPoint{
 		Hash:  chainhash.HashH([]byte(t.Name() + "-seeded-vtxo")),
 		Index: 0,
@@ -659,9 +721,10 @@ func seedLiveVTXO(t *testing.T, cfg *darepod.Config,
 	require.NoError(t, err)
 
 	err = vtxoStore.SaveVTXO(t.Context(), &vtxo.Descriptor{
-		Outpoint: outpoint,
-		Amount:   amount,
-		PkScript: descriptor.PkScript,
+		Outpoint:       outpoint,
+		Amount:         amount,
+		PolicyTemplate: descriptor.PolicyTemplate,
+		PkScript:       descriptor.PkScript,
 		ClientKey: keychain.KeyDescriptor{
 			PubKey: clientPriv.PubKey(),
 			KeyLocator: keychain.KeyLocator{
@@ -670,6 +733,7 @@ func seedLiveVTXO(t *testing.T, cfg *darepod.Config,
 			},
 		},
 		OperatorKey: operatorKey,
+		TapScript:   tapScript,
 		Ancestry: []types.Ancestry{{
 			TreePath:       treePath,
 			CommitmentTxID: commitmentTxID,
@@ -733,6 +797,27 @@ func findVTXOByOutpoint(vtxos []*daemonrpc.VTXO,
 	}
 
 	return nil
+}
+
+// oorPolicyRecipient returns a policy-backed OOR recipient for systests that
+// need a standard Ark output shape without relying on address parsing.
+func oorPolicyRecipient(t *testing.T, ownerKey, operatorKey *btcec.PublicKey,
+	amountSat int64) *daemonrpc.Output {
+
+	t.Helper()
+
+	policyTemplate, err := arkscript.EncodeStandardVTXOTemplate(
+		ownerKey, operatorKey, 144,
+	)
+	require.NoError(t, err)
+
+	return &daemonrpc.Output{
+		Destination: &daemonrpc.Output_PolicyTemplate{
+			PolicyTemplate: policyTemplate,
+		},
+		AmountSat:          amountSat,
+		VtxoPolicyTemplate: policyTemplate,
+	}
 }
 
 // TestSendVTXOEndToEnd exercises directed send through the full daemon stack:
@@ -826,4 +911,76 @@ func TestSendVTXOEndToEnd(t *testing.T) {
 		200*time.Millisecond,
 		"round did not reach pending-assembly state",
 	)
+}
+
+// TestSendOORMultipleRecipientsEndToEnd exercises the public SendOOR RPC
+// through the full daemon stack with more than one requested recipient. The
+// assertion is intentionally made at the fake operator mailbox boundary: the
+// RPC handler must aggregate the requested amount, the wallet must lock one
+// input, the OOR actor must build one session, and the serialized
+// SubmitPackage request must carry both recipient outputs in the single OOR
+// package that future swap batching will rely on.
+func TestSendOORMultipleRecipientsEndToEnd(t *testing.T) {
+	ParallelN(t)
+
+	fixture := newDirectedSendFixture(t)
+
+	recipientPrivA, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	recipientPrivB, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	const (
+		amountA = int64(40_000)
+		amountB = int64(60_000)
+	)
+
+	ctx, cancel := context.WithTimeout(
+		t.Context(), 10*time.Second,
+	)
+	defer cancel()
+
+	resp, err := fixture.client.SendOOR(
+		ctx, &daemonrpc.SendOORRequest{
+			Recipients: []*daemonrpc.Output{
+				oorPolicyRecipient(
+					t, recipientPrivA.PubKey(),
+					fixture.operatorKey, amountA,
+				),
+				oorPolicyRecipient(
+					t, recipientPrivB.PubKey(),
+					fixture.operatorKey, amountB,
+				),
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "submitted", resp.GetStatus())
+	require.NotEmpty(t, resp.GetSessionId())
+	require.Len(t, resp.GetRecipientOutpoints(), 2)
+
+	require.Eventually(t, func() bool {
+		reqs := fixture.mailboxServer.oorSubmitPackages()
+		if len(reqs) != 1 {
+			return false
+		}
+
+		return len(reqs[0].GetRecipientOutputs()) == 2
+	}, 20*time.Second, 200*time.Millisecond)
+
+	reqs := fixture.mailboxServer.oorSubmitPackages()
+	require.Len(t, reqs, 1)
+
+	recipientAmounts := make(map[int64]int)
+	for _, recipient := range reqs[0].GetRecipientOutputs() {
+		recipientAmounts[recipient.GetValueSat()]++
+		require.NotEmpty(t, recipient.GetPkScript())
+		require.NotEmpty(t, recipient.GetVtxoPolicyTemplate())
+	}
+
+	require.Equal(t, map[int64]int{
+		amountA: 1,
+		amountB: 1,
+	}, recipientAmounts)
 }


### PR DESCRIPTION
## Summary

This extends the existing `SendOOR` RPC instead of adding a second OOR send method. The OOR actor already accepts a recipient slice, so the daemon now exposes that shape directly at the RPC boundary.

`SendOORRequest` now has one canonical `recipients` field. The daemon validates each recipient, selects wallet inputs for the aggregate amount, and submits one OOR transfer with all requested outputs. The response returns `recipient_outpoints` in request order so callers can map each requested recipient to the VTXO it received.

The SDK still keeps single-recipient convenience helpers for existing swap code. Those helpers now build a one-element `recipients` list and read the first returned outpoint.

Custom-input OOR sends stay single-recipient for now. That path carries specialized signing material, so widening it should be a separate protocol change with its own tests.

## Testing

- `make unit pkg=./darepod`
- `make unit pkg=./sdk/ark`
- `make unit pkg=./rpc/oorpb`
- `go test ./cmd/darepocli/darepoclicommands/devrpc ./cmd/darepocli/darepoclicommands`
- `go test -tags "systest" -v ./systest/... -run TestSendOORMultipleRecipientsEndToEnd -timeout 10m`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`
