### PR TITLE
oor: Bind OOR checkpoint outputs to the session operator key

### DIFF
--- a/oor/checkpoint_owner_leaf_test.go
+++ b/oor/checkpoint_owner_leaf_test.go
@@ -1,0 +1,196 @@
+package oor
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNormalizeCheckpointOwnerLeavesBindsSessionKey proves that for a standard
+// collaborative input the checkpoint OUTPUT owner leaf is rebound to the
+// session operator key rather than the spent input VTXO's (possibly
+// pre-rotation) operator key. This is the client half of the
+// operator-key-rotation OOR fix: the server rebuilds + co-signs the checkpoint
+// output under the session key, so the client must commit the output owner leaf
+// to that same key.
+func TestNormalizeCheckpointOwnerLeavesBindsSessionKey(t *testing.T) {
+	t.Parallel()
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// X: the operator key the input VTXO was created under (historical).
+	inputOperatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// Y: the operator's current key, carried by the session policy.
+	sessionOperatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	inputs := []TransferInput{{
+		VTXO: &vtxo.Descriptor{
+			Outpoint: wire.OutPoint{
+				Hash: chainhash.Hash{
+					1,
+				},
+			},
+			Amount: btcutil.Amount(50_000),
+			ClientKey: keychain.KeyDescriptor{
+				PubKey: clientKey.PubKey(),
+			},
+			OperatorKey: inputOperatorKey.PubKey(),
+		},
+	}}
+
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: sessionOperatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	require.NoError(t, normalizeCheckpointOwnerLeaves(policy, inputs))
+
+	leaf, err := arkscript.DecodeLeafTemplate(inputs[0].OwnerLeafPolicy)
+	require.NoError(t, err)
+
+	// The owner leaf commits to the session key + the client key, and NOT
+	// to the spent input's historical operator key.
+	require.True(
+		t,
+		arkscript.ContainsKey(
+			leaf.Node, sessionOperatorKey.PubKey(),
+		),
+		"owner leaf must commit to the session operator key",
+	)
+	require.True(t, arkscript.ContainsKey(leaf.Node, clientKey.PubKey()))
+	require.False(
+		t,
+		arkscript.ContainsKey(
+			leaf.Node, inputOperatorKey.PubKey(),
+		),
+		"owner leaf must not commit to the input's historical key",
+	)
+
+	// Script and policy are a consistent pair derived from the session key.
+	wantLeaf, _, err := defaultOwnerLeaf(
+		clientKey.PubKey(), sessionOperatorKey.PubKey(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, wantLeaf, inputs[0].OwnerLeafScript)
+
+	// The spend side is untouched: the input VTXO's operator key, from
+	// which the historical collaborative spend path is derived, still
+	// equals X. Only the checkpoint OUTPUT owner leaf was rebound.
+	require.Equal(
+		t, inputOperatorKey.PubKey(), inputs[0].VTXO.OperatorKey,
+		"normalization must not touch the input's spend-side key",
+	)
+}
+
+// TestNormalizeCheckpointOwnerLeavesSkipsIncompleteInput asserts that an input
+// without a VTXO or without a client pubkey is skipped (not an error and not a
+// keyless leaf), since its owner leaf cannot be derived.
+func TestNormalizeCheckpointOwnerLeavesSkipsIncompleteInput(t *testing.T) {
+	t.Parallel()
+
+	sessionOperatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: sessionOperatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	inputs := []TransferInput{
+		// No VTXO at all.
+		{},
+		// VTXO present but no client pubkey (operator key set just to
+		// show it is the missing client key, not a missing VTXO, that
+		// triggers the skip).
+		{VTXO: &vtxo.Descriptor{
+			Outpoint: wire.OutPoint{
+				Hash: chainhash.Hash{
+					3,
+				},
+			},
+			Amount:      btcutil.Amount(50_000),
+			OperatorKey: clientKey.PubKey(),
+		}},
+	}
+
+	require.NoError(t, normalizeCheckpointOwnerLeaves(policy, inputs))
+
+	for i := range inputs {
+		require.Empty(t, inputs[i].OwnerLeafScript)
+		require.Empty(t, inputs[i].OwnerLeafPolicy)
+	}
+}
+
+// TestNormalizeCheckpointOwnerLeavesSkipsCustomSpend asserts that a custom
+// spend input (e.g. vHTLC), which carries its own explicit owner leaf, is left
+// untouched by the session-key normalization.
+func TestNormalizeCheckpointOwnerLeavesSkipsCustomSpend(t *testing.T) {
+	t.Parallel()
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	inputOperatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	sessionOperatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	customLeaf := []byte{0xde, 0xad, 0xbe, 0xef}
+	customPolicy := []byte{0xca, 0xfe}
+
+	inputs := []TransferInput{{
+		VTXO: &vtxo.Descriptor{
+			Outpoint: wire.OutPoint{
+				Hash: chainhash.Hash{
+					2,
+				},
+			},
+			Amount: btcutil.Amount(50_000),
+			ClientKey: keychain.KeyDescriptor{
+				PubKey: clientKey.PubKey(),
+			},
+			OperatorKey: inputOperatorKey.PubKey(),
+		},
+		OwnerLeafScript: customLeaf,
+		OwnerLeafPolicy: customPolicy,
+		CustomSpend:     &arkscript.SpendPath{},
+	}}
+
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: sessionOperatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	require.NoError(t, normalizeCheckpointOwnerLeaves(policy, inputs))
+
+	require.Equal(t, customLeaf, inputs[0].OwnerLeafScript)
+	require.Equal(t, customPolicy, inputs[0].OwnerLeafPolicy)
+}
+
+// TestNormalizeCheckpointOwnerLeavesRequiresPolicyKey asserts a nil session
+// operator key is rejected rather than silently producing a keyless leaf.
+func TestNormalizeCheckpointOwnerLeavesRequiresPolicyKey(t *testing.T) {
+	t.Parallel()
+
+	require.Error(
+		t,
+		normalizeCheckpointOwnerLeaves(
+			arkscript.CheckpointPolicy{
+				CSVDelay: 10,
+			},
+			nil,
+		),
+	)
+}

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -95,6 +95,18 @@ func (s *Idle) ProcessEvent(ctx context.Context, event Event,
 
 	switch evt := event.(type) {
 	case *StartTransferEvent:
+		// Bind each standard checkpoint output's owner leaf to the
+		// session operator key before building. A VTXO created under a
+		// pre-rotation operator key would otherwise produce a
+		// checkpoint output the rotated operator cannot co-sign and the
+		// server rejects at submit. See normalizeCheckpointOwnerLeaves.
+		err := normalizeCheckpointOwnerLeaves(
+			evt.Policy, evt.VTXOInputs,
+		)
+		if err != nil {
+			return nil, err
+		}
+
 		canonicalRecipients := oortx.CanonicalRecipientOutputs(
 			evt.RecipientOutputs,
 		)
@@ -529,6 +541,63 @@ func buildSubmitPackage(policy arkscript.CheckpointPolicy,
 	[]*psbt.Packet, error) {
 
 	return BuildSubmitPackage(policy, inputs, outputs)
+}
+
+// normalizeCheckpointOwnerLeaves rebuilds each standard input's checkpoint
+// OUTPUT owner collaborative leaf so it commits to the session operator key
+// rather than the spent input VTXO's operator key.
+//
+// The checkpoint output -- and the Ark tx that spends it cooperatively -- is
+// governed by the session checkpoint policy, whose operator key is the
+// operator's current key at session-creation time. The spent input VTXO may
+// instead have been created under an older operator key, after the operator
+// rotated. Deriving the output owner leaf from the input's operator key would
+// make the server's submit-rebuild reject the checkpoint ("owner leaf policy
+// does not contain operator key") and make the operator's Ark co-signature,
+// produced with the session key, fail the leaf's key-membership check.
+//
+// The input SPEND path is untouched: spending the VTXO still uses its own
+// tapscript, committed to the historical operator key (resolved server-side
+// per input). Custom spends (e.g. vHTLC) carry their own owner leaf and are
+// left untouched. Before any rotation the input and session keys are equal, so
+// this is a no-op then.
+func normalizeCheckpointOwnerLeaves(policy arkscript.CheckpointPolicy,
+	inputs []TransferInput) error {
+
+	if policy.OperatorKey == nil {
+		return fmt.Errorf("checkpoint policy operator key required")
+	}
+
+	for i := range inputs {
+		input := &inputs[i]
+
+		if input.IsCustomSpend() {
+			continue
+		}
+
+		if input.VTXO == nil || input.VTXO.ClientKey.PubKey == nil {
+			continue
+		}
+
+		leaf, leafPolicy, err := defaultOwnerLeaf(
+			input.VTXO.ClientKey.PubKey, policy.OperatorKey,
+		)
+		if err != nil {
+			return err
+		}
+
+		// defaultOwnerLeaf only returns an empty leaf when one of its
+		// key args is nil; both are non-nil here, so this is a
+		// belt-and-suspenders guard rather than a reachable branch.
+		if len(leaf) == 0 {
+			continue
+		}
+
+		input.OwnerLeafScript = leaf
+		input.OwnerLeafPolicy = leafPolicy
+	}
+
+	return nil
 }
 
 // BuildSubmitPackage constructs a v0 OOR submit package using the shared


### PR DESCRIPTION
## What

When building an OOR transfer, the client derived the checkpoint **output's** owner collaborative leaf from the *spent input VTXO's* operator key. But the checkpoint output — and the Ark tx that spends it cooperatively — is governed by the **session checkpoint policy**, whose operator key is the operator's *current* key at session-creation time.

After the operator rotates its key, a VTXO created under an older key (X) would produce a checkpoint output committed to X, while the server (correctly) rebuilds and co-signs that output under the current/session key (Y). The post-rotation submit was rejected at `AwaitingSubmitValidationState` with `"owner leaf policy does not contain operator key"`, before the server's per-input co-sign path even ran — so **any** OOR spend of a pre-rotation VTXO failed. Before a rotation X == Y, so this was invisible.

## Fix

Rebind each standard input's checkpoint-output owner leaf to the **session** operator key (`StartTransferEvent.Policy.OperatorKey`) in the `StartTransfer` transition, before the deterministic build and before the inputs flow into signing/persistence (`normalizeCheckpointOwnerLeaves`).

The input **spend** path is untouched — spending the VTXO still uses its own tapscript, committed to the historical key, which the server resolves and co-signs per input. Custom spends (e.g. vHTLC) carry their own owner leaf and are skipped.

This is the **client half** of the operator-key-rotation OOR work. The server half (per-input historical co-sign + session-bound checkpoint policy persistence + indexer surfacing) is in darepo (stacked on #525 work).

## Testing

- New unit tests (`oor/checkpoint_owner_leaf_test.go`): owner leaf rebinds to the session key (and not the input's historical key); custom spends untouched; nil policy key rejected.
- End-to-end (server repo itests, now un-skipped): `TestOORSendAfterOperatorKeyRotation` (single rotated-key OOR send) and `TestOORSendMixedHistoricalOperatorKeys` (one transfer spending inputs under two different historical keys) both pass.

Part of the operator-key-rotation epic (#525).

🤖 Generated with [Claude Code](https://claude.com/claude-code)