### PR TITLE
darepod: unlock wallet VTXOs on OOR cleanup timeout

### DIFF
--- a/darepod/rpc_oor_idempotency_test.go
+++ b/darepod/rpc_oor_idempotency_test.go
@@ -1045,6 +1045,76 @@ func TestSubmittedOORCleanupTimeoutReleasesCustomInput(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+// TestSubmittedOORCleanupTimeoutReleasesSelectedVTXOs verifies that when the
+// detached OOR cleanup waiter times out, the wallet-selected VTXOs are still
+// unlocked. The cleanupCtx is expired by the timeout, so the unlock must run on
+// a fresh context or the wallet mailbox would reject the already-expired Tell
+// and leave the VTXOs pinned.
+func TestSubmittedOORCleanupTimeoutReleasesSelectedVTXOs(t *testing.T) {
+	t.Parallel()
+
+	testWallet := &sendOORTestWallet{}
+
+	system := actor.NewActorSystem()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer cancel()
+
+		require.NoError(t, system.Shutdown(shutdownCtx))
+	})
+
+	walletKey := actor.NewServiceKey[
+		wallet.WalletMsg, wallet.WalletResp,
+	](
+		"send-oor-vtxo-unlock-test-wallet",
+	)
+	walletRef := walletKey.Spawn(
+		system, "send-oor-vtxo-unlock-test-wallet", testWallet,
+	)
+
+	rpcServer := &RPCServer{
+		server: &Server{
+			log:       btclog.Disabled,
+			walletRef: fn.Some(walletRef),
+		},
+		customInputLocks: make(map[wire.OutPoint]struct{}),
+	}
+
+	locked := &wallet.SelectAndLockVTXOsResponse{
+		SelectedVTXOs: []wallet.SelectedVTXO{
+			{
+				Outpoint: wire.OutPoint{
+					Hash: chainhash.HashH(
+						[]byte("send-oor-vtxo-unlock"),
+					),
+					Index: 0,
+				},
+				Amount: 1000,
+			},
+		},
+	}
+
+	// The promise is never completed, forcing the cleanup waiter down the
+	// timeout branch where cleanupCtx expires.
+	promise := actor.NewPromise[oor.ActorResp]()
+	rpcServer.cleanupSubmittedOORStartWithTimeout(
+		context.Background(), promise.Future(), locked, nil,
+		10*time.Millisecond,
+	)
+
+	require.Eventually(t, func() bool {
+		return len(testWallet.unlockBatches()) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	batches := testWallet.unlockBatches()
+	require.Len(t, batches, 1)
+	require.Equal(
+		t, locked.SelectedVTXOs[0].Outpoint, batches[0][0],
+	)
+}
+
 func TestIsAwaitContextError(t *testing.T) {
 	t.Parallel()
 

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -63,6 +63,13 @@ const (
 	// from retaining wallet/custom input reservations forever.
 	submittedOORCleanupTimeout = 10 * time.Minute
 
+	// submittedOORUnlockTimeout bounds the fresh context used to unlock
+	// wallet-selected VTXOs when the detached OOR cleanup waiter itself
+	// timed out. The cleanupCtx is deliberately expired in that branch, so
+	// the unlock must run on a new bounded context to avoid the wallet
+	// mailbox rejecting an already-expired Tell.
+	submittedOORUnlockTimeout = 30 * time.Second
+
 	// maxOORRecipients mirrors the in-round send cap at the daemon
 	// boundary. The OOR actor has its own package-size limits, but the
 	// RPC handler resolves scripts and policy templates before handing
@@ -2818,6 +2825,15 @@ func (r *RPCServer) cleanupSubmittedOORStartWithTimeout(ctx context.Context,
 		oorResult := future.Await(cleanupCtx)
 		oorResp, err := oorResult.Unpack()
 		if err != nil {
+			// The unlock context defaults to cleanupCtx, which is
+			// still live on a real actor failure. If the await
+			// instead ended because cleanupCtx hit its deadline,
+			// that same context is now expired and the wallet
+			// actor's mailbox would reject the unlock Tell before
+			// enqueue, silently pinning the wallet-selected VTXOs.
+			// Derive a fresh bounded context from the detached base
+			// in that case so the unlock still lands.
+			unlockCtx := cleanupCtx
 			if cleanupCtx.Err() != nil {
 				r.server.log.ErrorS(
 					cleanupCtx,
@@ -2826,9 +2842,17 @@ func (r *RPCServer) cleanupSubmittedOORStartWithTimeout(ctx context.Context,
 					err,
 					slog.Duration("timeout", timeout),
 				)
+
+				freshCtx, freshCancel := context.WithTimeout(
+					context.WithoutCancel(ctx),
+					submittedOORUnlockTimeout,
+				)
+				defer freshCancel()
+
+				unlockCtx = freshCtx
 			}
 
-			r.unlockSelectedVTXOsBestEffort(cleanupCtx, locked)
+			r.unlockSelectedVTXOsBestEffort(unlockCtx, locked)
 			if releaseCustomInputs != nil {
 				releaseCustomInputs()
 			}


### PR DESCRIPTION
## The bug

`cleanupSubmittedOORStartWithTimeout` in `darepod/rpc_server.go` builds a
detached, bounded cleanup context:

```go
cleanupCtx, cancel := context.WithTimeout(
    context.WithoutCancel(ctx), timeout, // submittedOORCleanupTimeout (10m)
)
```

and then `future.Await(cleanupCtx)`. When the detached OOR start future never
completes, `Await` returns *because* `cleanupCtx` hit its deadline, so
`cleanupCtx` is now expired. The very next statement passed that same expired
`cleanupCtx` to `unlockSelectedVTXOsBestEffort`, which flows to
`walletRef.Tell(cleanupCtx, &wallet.UnlockVTXOsRequest{...})`.

`ChannelMailbox.Send` rejects an already-expired context before enqueue, so the
unlock was silently dropped and the wallet-selected VTXOs stayed pinned in
`SpendingState` — potentially indefinitely.

The custom-input release path was unaffected (its callback is a pure in-memory
map delete, context-independent). Only the wallet-selected VTXO unlock at
timeout was broken.

## The fix

In the timeout branch, derive a fresh bounded context from the detached base
(`context.WithTimeout(context.WithoutCancel(ctx), submittedOORUnlockTimeout)`,
30s, with its own `defer cancel()`) and use that for the unlock. The
completion and actor-failure branches keep using the still-live `cleanupCtx`,
and the custom-input release still happens in every branch. A name-prefixed
comment explains why the fresh context is required.

## The test

`TestSubmittedOORCleanupTimeoutReleasesCustomInput` passed `nil` for `locked`
and only checked the in-memory custom-input callback, which is why the gap went
unnoticed. This adds `TestSubmittedOORCleanupTimeoutReleasesSelectedVTXOs`,
which drives the timeout path with a non-nil `locked` set against a recording
wallet actor (`sendOORTestWallet`) and asserts an `UnlockVTXOsRequest` is
actually delivered on timeout. Verified that the new test fails on the
unpatched code (VTXOs never unlocked) and passes with the fix. The existing
test is unchanged.

Fixes #387