### PR TITLE
round: arm forfeit timeout before dispatching forfeit requests

### DIFF
--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -892,6 +892,69 @@ func TestActorProcessOutbox(t *testing.T) {
 
 		h.assertServerMessageSent("SendClientEventRequest")
 	})
+
+	// This is the regression test for issue #386. The forfeit-collection
+	// transitions emit StartTimeoutReq BEFORE the per-VTXO
+	// ForfeitRequestToVTXO messages so that a failed forfeit Tell cannot
+	// strand the round without a timeout. processOutbox aborts on the
+	// first send error, so if the timeout were emitted last it would be
+	// skipped when a forfeit Tell fails, and the round would wait forever
+	// for signatures with no timeout armed.
+	t.Run("forfeit_send_failure_still_arms_timeout", func(t *testing.T) {
+		t.Parallel()
+
+		h := newActorTestHarness(t)
+		h.setupMockRoundStoreForStart()
+
+		// Wire up a real but empty actor system so the forfeit
+		// request fails its service-key lookup (no VTXO actor is
+		// registered), mirroring the ErrNoActorsAvailable trigger.
+		system := actor.NewActorSystem()
+		t.Cleanup(func() {
+			_ = system.Shutdown(t.Context())
+		})
+		h.actor.cfg.ActorSystem = system
+
+		err := h.start()
+		require.NoError(t, err)
+
+		roundID := testRoundID("forfeit-send-failure")
+		duration := 30 * time.Second
+		vtxoOutpoint := wire.OutPoint{
+			Hash:  chainhash.HashH([]byte("vtxo-386")),
+			Index: 0,
+		}
+
+		// The outbox mirrors what the forfeit-collection transitions
+		// now emit: the timeout first, then the per-VTXO forfeit
+		// request whose Tell will fail.
+		outbox := []ClientOutMsg{
+			&StartTimeoutReq{
+				RoundKey: RoundKeyStr(roundID.KeyString()),
+				Phase:    TimeoutPhaseForfeitCollection,
+				Duration: duration,
+			},
+			&ForfeitRequestToVTXO{
+				VTXOOutpoint: vtxoOutpoint,
+				RoundID:      roundID.String(),
+			},
+		}
+
+		// The forfeit Tell fails, so processOutbox returns an error.
+		err = h.actor.processOutbox(h.ctx, outbox)
+		require.Error(t, err)
+
+		// Despite the forfeit failure, the timeout must already be
+		// armed because it was emitted first. This is the property
+		// that keeps the round recoverable.
+		timeoutID := makeTimeoutID(
+			RoundKeyStr(
+				roundID.KeyString(),
+			),
+			TimeoutPhaseForfeitCollection,
+		)
+		h.timeoutActor.assertTimeoutScheduled(t, timeoutID, duration)
+	})
 }
 
 // TestActorGetStateWithActiveRounds validates that the actor correctly reports

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -1490,6 +1490,22 @@ func (h *boardingTestHarness) assertOutboxLen(expected int) {
 	)
 }
 
+// assertOutboxFirstType asserts that the first outbox message has the given
+// concrete type. This is used to pin ordering invariants where a message must
+// be emitted before any others (e.g. arming a timeout before dispatching
+// forfeit requests).
+func (h *boardingTestHarness) assertOutboxFirstType(msgType string) {
+	h.t.Helper()
+
+	require.NotEmpty(h.t, h.outboxMessages, "outbox is empty")
+
+	typeName := fmt.Sprintf("%T", h.outboxMessages[0])
+	require.Truef(
+		h.t, typeName == msgType || typeName == "*round."+msgType,
+		"first outbox message is %s, expected %s", typeName, msgType,
+	)
+}
+
 func (h *boardingTestHarness) clearOutbox() {
 	h.outboxMessages = nil
 }

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -2016,12 +2016,30 @@ func (s *CommitmentTxValidatedState) ProcessEvent(ctx context.Context,
 				}, nil
 			}
 
+			// Arm the forfeit-collection timeout FIRST, before
+			// dispatching any per-VTXO forfeit requests. This
+			// transition advances the in-memory FSM to
+			// ForfeitSignaturesCollectingState without
+			// checkpointing, so a restart cannot recover it. If a
+			// later ForfeitRequestToVTXO Tell fails, processOutbox
+			// aborts on that error and never reaches a trailing
+			// timeout, leaving the round wedged waiting for forfeit
+			// signatures forever. Emitting StartTimeoutReq first
+			// guarantees the timeout is scheduled regardless of any
+			// subsequent per-VTXO send failure, so the round can
+			// still time out into a recoverable failed state.
+			var outbox []ClientOutMsg
+			outbox = append(outbox, &StartTimeoutReq{
+				RoundKey: RoundKeyStr(s.RoundID.KeyString()),
+				Phase:    TimeoutPhaseForfeitCollection,
+				Duration: env.ForfeitCollectionTimeout,
+			})
+
 			// Build forfeit request messages for each VTXO being
 			// forfeited.
 			forfeitReqs := forfeitRequestMap(
 				s.Intents.Forfeits,
 			)
-			var outbox []ClientOutMsg
 			for vtxoOutpoint, info := range s.ForfeitMappings {
 				connOut := info.ConnectorOutpoint
 				connScript := info.ConnectorPkScript
@@ -2040,12 +2058,6 @@ func (s *CommitmentTxValidatedState) ProcessEvent(ctx context.Context,
 				}
 				outbox = append(outbox, msg)
 			}
-
-			outbox = append(outbox, &StartTimeoutReq{
-				RoundKey: RoundKeyStr(s.RoundID.KeyString()),
-				Phase:    TimeoutPhaseForfeitCollection,
-				Duration: env.ForfeitCollectionTimeout,
-			})
 
 			// Transition directly to forfeit collection.
 			collectedForfeits := make(
@@ -2892,9 +2904,25 @@ func (s *PartialSigsSentState) transitionToForfeitCollection(
 		}, nil
 	}
 
+	// Arm the forfeit-collection timeout FIRST, before dispatching any
+	// per-VTXO forfeit requests. This transition advances the in-memory
+	// FSM to ForfeitSignaturesCollectingState without checkpointing, so a
+	// restart cannot recover it. If a later ForfeitRequestToVTXO Tell
+	// fails, processOutbox aborts on that error and never reaches a
+	// trailing timeout, leaving the round wedged waiting for forfeit
+	// signatures forever. Emitting StartTimeoutReq first guarantees the
+	// timeout is scheduled regardless of any subsequent per-VTXO send
+	// failure, so the round can still time out into a recoverable failed
+	// state.
+	var outbox []ClientOutMsg
+	outbox = append(outbox, &StartTimeoutReq{
+		RoundKey: RoundKeyStr(s.RoundID.KeyString()),
+		Phase:    TimeoutPhaseForfeitCollection,
+		Duration: env.ForfeitCollectionTimeout,
+	})
+
 	// Build forfeit request messages for each VTXO being refreshed.
 	forfeitReqs := forfeitRequestMap(s.Intents.Forfeits)
-	var outbox []ClientOutMsg
 	for vtxoOutpoint, info := range s.ForfeitMappings {
 		req := forfeitReqs[vtxoOutpoint]
 		msg := &ForfeitRequestToVTXO{
@@ -2908,12 +2936,6 @@ func (s *PartialSigsSentState) transitionToForfeitCollection(
 		}
 		outbox = append(outbox, msg)
 	}
-
-	outbox = append(outbox, &StartTimeoutReq{
-		RoundKey: RoundKeyStr(s.RoundID.KeyString()),
-		Phase:    TimeoutPhaseForfeitCollection,
-		Duration: env.ForfeitCollectionTimeout,
-	})
 
 	env.Log.InfoS(ctx, "Transitioning to forfeit collection",
 		slog.String("round_id", s.RoundID.String()),

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -1696,6 +1696,13 @@ func TestCommitmentTxValidatedState(t *testing.T) {
 
 		h.assertOutboxContainsType("*round.ForfeitRequestToVTXO")
 		h.assertOutboxContainsType("*round.StartTimeoutReq")
+
+		// The collection timeout must be armed BEFORE any forfeit
+		// request is dispatched. processOutbox aborts on the first
+		// send error, so a trailing timeout would be skipped if a
+		// per-VTXO forfeit Tell fails, stranding the round with no
+		// timeout. See issue #386.
+		h.assertOutboxFirstType("*round.StartTimeoutReq")
 	})
 }
 
@@ -1991,6 +1998,13 @@ func TestPartialSigsSentState(t *testing.T) {
 
 		h.assertOutboxContainsType("*round.ForfeitRequestToVTXO")
 		h.assertOutboxContainsType("*round.StartTimeoutReq")
+
+		// The collection timeout must be armed BEFORE any forfeit
+		// request is dispatched. processOutbox aborts on the first
+		// send error, so a trailing timeout would be skipped if a
+		// per-VTXO forfeit Tell fails, stranding the round with no
+		// timeout. See issue #386.
+		h.assertOutboxFirstType("*round.StartTimeoutReq")
 	})
 
 	t.Run("empty_signatures_error", func(t *testing.T) {


### PR DESCRIPTION
## The bug (#386)

Both forfeit-collection entry transitions in `round/transitions.go` built
an outbox slice that emitted one or more `ForfeitRequestToVTXO` messages
**first** and appended the trailing `StartTimeoutReq` **last**, then
advanced the in-memory FSM into `ForfeitSignaturesCollectingState`:

- the boarding/leave path in `CommitmentTxValidatedState.ProcessEvent`
- `PartialSigsSentState.transitionToForfeitCollection` (refresh path)

In `round/actor.go`, `processOutbox` returns on the **first** error, and
the `ForfeitRequestToVTXO` handler now **returns an error** when the
non-durable VTXO actor `Tell` fails (changed from log-and-continue in
e7c50b8a). So if a `ForfeitRequestToVTXO` Tell failed, the remaining
outbox messages — including the trailing `StartTimeoutReq` — were never
processed.

This transition does **not** call `CommitState`; the advanced state is
in-memory only and is not recovered on restart (`ListActiveRounds` only
restores broadcast rounds). The result was a round waiting indefinitely
for forfeit signatures with **no timeout armed**, instead of timing out
into a recoverable failed state.

The only triggers are first-party invariant breaks: a missing VTXO actor
registration (`ErrNoActorsAvailable`) or an in-memory mailbox send
failure at shutdown. This is a robustness/liveness fix, not a security
fix.

## The fix

Emit `StartTimeoutReq` **before** any `ForfeitRequestToVTXO` in the
outbox slice, in both transitions. `StartTimeoutReq` is handled by
scheduling a timeout via the timeout actor, fully independent of forfeit
dispatch, so arming it slightly earlier is safe and guarantees the
collection timeout fires regardless of whether a later per-VTXO Tell
fails. Name-prefixed comments explain why the timeout must be armed
first.

## Tests

- Added `TestActorProcessOutbox/forfeit_send_failure_still_arms_timeout`:
  wires a real but empty actor system so the `ForfeitRequestToVTXO` Tell
  fails its service-key lookup, then asserts `processOutbox` returns an
  error **and** the timeout was still scheduled.
- Added an `assertOutboxFirstType` harness helper and used it to assert
  `StartTimeoutReq` is the **first** outbox message in both the leave-only
  (`TestCommitmentTxValidatedState`) and refresh
  (`TestNoncesSentState`) transition tests.
- No existing tests were weakened or removed; the previous
  order-independent `assertOutboxContainsType` checks still hold.

## Validation

- `make fmt-changed`: clean
- `make lint-changed-local`: 0 issues
- `make build`: ok
- `go test ./round/` (full package): ok

Fixes #386