### PR TITLE
Require refund proof before terminalizing a pay swap

### DIFF
--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -244,8 +244,7 @@ type paySession struct {
 	refundReceivePubKey []byte
 	refundReceiveScript []byte
 	// refundSessionID stores the daemon OOR session id when this process
-	// submitted the refund, or the observed spender txid when a resume
-	// adopts an already-indexed refund spend.
+	// submitted the refund.
 	refundSessionID         string
 	refundRecoveryID        string
 	refundRecoveryFailureAt time.Time
@@ -1551,12 +1550,60 @@ func (s *paySession) markRefunded(ctx context.Context,
 	if spentVHTLC == nil {
 		return nil
 	}
+	if s.refundSessionID == "" {
+		reason := "funded vHTLC spent before refund session was " +
+			"accepted"
+		if spentVHTLC.SpentByTxID != "" {
+			reason = fmt.Sprintf("%s (spender %s)", reason,
+				spentVHTLC.SpentByTxID)
+		}
+
+		return s.needsIntervention(ctx, reason, nil, func() {
+			if spentVHTLC.Outpoint != "" {
+				s.vhtlcOutpoint = spentVHTLC.Outpoint
+			}
+			if spentVHTLC.AmountSat != 0 {
+				s.vhtlcAmount = spentVHTLC.AmountSat
+			}
+		})
+	}
+	if spentVHTLC.SpentByTxID == "" {
+		s.client.log.InfoS(
+			ctx,
+			"Pay swap refund spend lacks spender txid",
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+			slog.String("outpoint", spentVHTLC.Outpoint),
+			slog.String("refund_session_id", s.refundSessionID),
+		)
+
+		return waitForFixedPoll(ctx, s.client.waitPollInterval)
+	}
+	if spentVHTLC.SpentByTxID != s.refundSessionID {
+		reason := fmt.Sprintf("funded vHTLC spent by unexpected txid "+
+			"%s before refund session %s completed",
+			spentVHTLC.SpentByTxID, s.refundSessionID)
+
+		return s.needsIntervention(ctx, reason, nil, func() {
+			if spentVHTLC.Outpoint != "" {
+				s.vhtlcOutpoint = spentVHTLC.Outpoint
+			}
+			if spentVHTLC.AmountSat != 0 {
+				s.vhtlcAmount = spentVHTLC.AmountSat
+			}
+		})
+	}
 
 	s.client.log.InfoS(ctx, "Pay swap refunded",
 		btclog.Hex("hash", s.cfg.PaymentHash[:]),
 		slog.String("outpoint", spentVHTLC.Outpoint),
 		slog.String("spender", spentVHTLC.SpentByTxID),
 	)
+	if err := cancelVHTLCRecovery(
+		ctx, s.client.daemon, s.refundRecoveryID,
+		recoveryReasonRefundSessionCompleted, s.refundSessionID,
+	); err != nil {
+		return newRetryableActionError(err)
+	}
 
 	return s.mutateAndPersist(ctx, func() error {
 		if spentVHTLC.Outpoint != "" {
@@ -1564,9 +1611,6 @@ func (s *paySession) markRefunded(ctx context.Context,
 		}
 		if spentVHTLC.AmountSat != 0 {
 			s.vhtlcAmount = spentVHTLC.AmountSat
-		}
-		if s.refundSessionID == "" && spentVHTLC.SpentByTxID != "" {
-			s.refundSessionID = spentVHTLC.SpentByTxID
 		}
 
 		return s.transition(payEventRefunded)

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -1286,17 +1286,14 @@ func TestPaySessionResumeAfterAcceptedRefundFindsOutput(t *testing.T) {
 	require.Equal(t, PayStateRefunded, reloaded.State())
 }
 
-// TestPaySessionResumeAfterAcceptedRefundUsesSpentVHTLCFallback exercises the
-// same accepted-refund restart window as
+// TestPaySessionResumeAfterAcceptedRefundRejectsSpentVHTLCFallback exercises
+// the same accepted-refund restart window as
 // TestPaySessionResumeAfterAcceptedRefundFindsOutput, but with the wallet
-// indexer lagging on the newly-created refund output. In that case the funded
-// vHTLC spend is already visible without a claim preimage, while the refund
-// destination script returns no live output yet. The session must still treat
-// the spend as a successful cooperative refund, because the pre-locktime refund
-// path requires the client, operator, and server signatures. This pins the
-// fallback that prevents a recovered refund from being misclassified as
-// NeedsIntervention during restart reconciliation.
-func TestPaySessionResumeAfterAcceptedRefundUsesSpentVHTLCFallback(
+// indexer lagging on the newly-created refund output. A bare spent-vHTLC
+// spender txid is not durable proof that the client-owned refund session was
+// accepted before the refund session id was persisted, so the session must stop
+// for intervention instead of adopting the observed spender as its refund.
+func TestPaySessionResumeAfterAcceptedRefundRejectsSpentVHTLCFallback(
 	t *testing.T) {
 
 	t.Parallel()
@@ -1420,16 +1417,20 @@ func TestPaySessionResumeAfterAcceptedRefundUsesSpentVHTLCFallback(
 	require.Nil(t, refundOutput)
 
 	_, err = resumed.Wait(t.Context())
-	require.ErrorIs(t, err, ErrSwapRefunded)
-	require.Equal(t, PayStateRefunded, resumed.State())
-	require.Equal(t, "refund-session", resumed.refundSessionID)
+	require.ErrorContains(
+		t, err, "funded vHTLC spent before refund session was accepted",
+	)
+	require.Equal(t, PayStateNeedsIntervention, resumed.State())
+	require.Empty(t, resumed.refundSessionID)
+	require.Contains(t, resumed.InterventionReason(), "refund-session")
 	require.Equal(t, 1, daemonConn.sendCustomCalls)
 
 	reloaded, err := resumedClient.ResumePayViaLightning(
 		t.Context(), preimage.Hash(),
 	)
 	require.NoError(t, err)
-	require.Equal(t, PayStateRefunded, reloaded.State())
+	require.Equal(t, PayStateNeedsIntervention, reloaded.State())
+	require.Contains(t, reloaded.InterventionReason(), "refund-session")
 }
 
 // TestPaySessionObserveRefundOutputIgnoresWrongAmount verifies that a live VTXO
@@ -2347,6 +2348,133 @@ func TestPaySessionNeedsInterventionOnSpentWithoutPreimage(t *testing.T) {
 	)
 	require.Equal(t, "funding:0", resumed.vhtlcOutpoint)
 	require.EqualValues(t, testInSwapAmountSat, resumed.vhtlcAmount)
+}
+
+// TestPaySessionRejectsUnknownRefundSpend asserts refund reconciliation does
+// not adopt an arbitrary vHTLC spender as the client's own refund session.
+func TestPaySessionRejectsUnknownRefundSpend(t *testing.T) {
+	t.Parallel()
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	daemonConn := &testDaemonConn{
+		spentVTXO: &VTXOInfo{
+			Outpoint:    "funding:0",
+			AmountSat:   testInSwapAmountSat,
+			SpentByTxID: "server-claim-session",
+		},
+		indexedPackage: &OORPackageInfo{},
+	}
+
+	client := configureTestPayClient(
+		NewSwapClient(nil, daemonConn, nil, nil),
+	)
+	client.waitPollInterval = time.Millisecond
+
+	session := &paySession{
+		client: client,
+		state:  PayStateRefundInitiated,
+		cfg: &InSwapConfig{
+			PaymentHash: preimage.Hash(),
+			AmountSat:   testInSwapAmountSat,
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime: 200,
+			},
+		},
+		vhtlcPkScript: []byte{
+			0x51,
+			0x20,
+			0x99,
+		},
+		vhtlcOutpoint: "funding:0",
+		vhtlcAmount:   testInSwapAmountSat,
+		refundReceiveScript: []byte{
+			0x51,
+			0x20,
+			0xaa,
+		},
+	}
+
+	err = session.completeRefund(t.Context())
+	require.ErrorContains(
+		t, err, "funded vHTLC spent before refund session was accepted",
+	)
+	require.Equal(t, PayStateNeedsIntervention, session.State())
+	require.Contains(
+		t, session.InterventionReason(),
+		"funded vHTLC spent before refund session was accepted",
+	)
+	require.Contains(
+		t, session.InterventionReason(),
+		"server-claim-session",
+	)
+	require.Empty(t, session.refundSessionID)
+	require.Equal(t, "funding:0", session.vhtlcOutpoint)
+	require.EqualValues(t, testInSwapAmountSat, session.vhtlcAmount)
+}
+
+// TestPaySessionAcceptsKnownRefundSpend asserts refund reconciliation still
+// terminalizes when the observed vHTLC spender matches the persisted refund
+// session.
+func TestPaySessionAcceptsKnownRefundSpend(t *testing.T) {
+	t.Parallel()
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	daemonConn := &testDaemonConn{
+		spentVTXO: &VTXOInfo{
+			Outpoint:    "funding:0",
+			AmountSat:   testInSwapAmountSat,
+			SpentByTxID: "refund-session",
+		},
+		indexedPackage: &OORPackageInfo{},
+	}
+
+	client := configureTestPayClient(
+		NewSwapClient(nil, daemonConn, nil, nil),
+	)
+	client.waitPollInterval = time.Millisecond
+
+	session := &paySession{
+		client: client,
+		state:  PayStateRefundInitiated,
+		cfg: &InSwapConfig{
+			PaymentHash: preimage.Hash(),
+			AmountSat:   testInSwapAmountSat,
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime: 200,
+			},
+		},
+		vhtlcPkScript: []byte{
+			0x51,
+			0x20,
+			0x99,
+		},
+		vhtlcOutpoint: "funding:0",
+		vhtlcAmount:   testInSwapAmountSat,
+		refundReceiveScript: []byte{
+			0x51,
+			0x20,
+			0xaa,
+		},
+		refundSessionID:  "refund-session",
+		refundRecoveryID: "recovery",
+	}
+
+	err = session.completeRefund(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, PayStateRefunded, session.State())
+	require.Equal(t, "refund-session", session.refundSessionID)
+	require.Equal(t, 1, daemonConn.cancelCalls)
+	require.Equal(
+		t, recoveryReasonRefundSessionCompleted,
+		daemonConn.lastCancel.GetReason(),
+	)
+	require.Equal(
+		t, "refund-session", daemonConn.lastCancel.GetCooperativeTxid(),
+	)
 }
 
 // TestWaitForInSwapClaimObservationToleratesPreimageLag asserts an indexed


### PR DESCRIPTION
## Summary

The pay-side refund reconciler (`markRefunded` in `sdk/swaps/in_swap.go`) could mark an Ark-to-Lightning pay swap as `Refunded` without any proof that the client actually recovered its funds. This PR requires real proof before terminalizing, and adds positive and negative regression tests.

## Background

When reconciling a funded vHTLC during the timeout-refund phase, `markRefunded` used to adopt any observed vHTLC spender txid as the client's own refund session whenever no refund session id had been persisted yet, and then transition the swap to `Refunded`:

```go
if s.refundSessionID == "" && spentVHTLC.SpentByTxID != "" {
    s.refundSessionID = spentVHTLC.SpentByTxID
}
```

This fallback dates back to the original pay lifecycle implementation. It was meant to let a client that broadcast a refund but crashed before persisting the session id still terminalize on resume. The problem: a bare spender txid is not proof that the client received the refund. Nothing distinguishes the client's own refund spend from any other spend of the vHTLC, so an arbitrary spender (or a crash/indexer-lag window) could be misread as a completed client refund.

## Fix

`markRefunded` now terminalizes as `Refunded` only when there is durable proof, which is one of:

- an indexed refund output is found (`markRefundOutputIndexed`), or
- the local OOR refund session reports completed (`markRefundSessionCompleted`), or
- the observed spender txid matches the persisted `refundSessionID`.

The spender txid and the OOR session id share one identifier space (the session/ark txid), so a genuine self-submitted refund still matches and terminalizes normally. When the spender txid is not visible yet, the reconciler keeps polling to tolerate indexer lag. When no session id was ever persisted, or the spender does not match the persisted session, the swap stops for operator intervention instead of guessing. On the matching-spender path it also cancels the armed vHTLC recovery job, consistent with the other terminalization paths.

## Worst case prevented

Previously the client could mark a pay swap as `Refunded` when the vHTLC was merely spent, with no known claim preimage and no proof that the client received the refund. That would hide a loss of the full vHTLC amount, park the swap in a terminal "refunded" state that stops normal swap handling, and make the wallet and operator believe recovery succeeded when the client's funds may never have been recovered.

## Testing

- `make unit pkg=./sdk/swaps/` — full package passes.
- New `TestPaySessionAcceptsKnownRefundSpend` (positive): a spender txid matching the persisted refund session still terminalizes as `Refunded` and cancels the armed recovery job.
- New `TestPaySessionRejectsUnknownRefundSpend` (negative): an arbitrary spender txid that does not match the persisted refund session is not treated as the client's own refund.
- Renamed `TestPaySessionResumeAfterAcceptedRefundUsesSpentVHTLCFallback` to `...RejectsSpentVHTLCFallback` and flipped its expectation: in the crash-after-broadcast, indexer-lag restart window where the vHTLC spend is visible but neither a refund output nor a persisted session id is, the swap now stops for intervention.
- Existing `TestPaySessionResumeAfterAcceptedRefundFindsOutput` is unchanged and still pins that an indexed refund output terminalizes, keeping all three proof-based paths covered.

## Notes for reviewers

In the narrow window where a client crashes between broadcasting the refund and persisting the session id, and the indexer is also lagging on the refund output, the swap now stops at `NeedsIntervention` instead of auto-terminalizing. This is the intended conservative direction: a safe, operator-clearable stop is preferable to a false success that hides a potential loss, and the primary path still auto-recovers as soon as the refund output is indexed.

---

Found this initially using https://github.com/lightninglabs/darepo/issues/543 as prompt.