### PR TITLE
docs: nightly doc-gardening sweep 2026-06-09

### DIFF
--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -58,6 +58,14 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   cap, positive and `MaxSatoshi`-bounded amounts, overflow-safe sum),
   resolves destinations via `resolveRecipientOutput`, delegates to
   the wallet actor.
+- `SendOOR` — out-of-round transfer. Accepts one or more recipients
+  in one atomic session (up to `maxOORRecipients = 256`). Validates
+  recipient count, then calls `sendOORRequestRecipients` +
+  `sumSendOORRecipientAmounts` for early rejection before touching
+  the wallet. Resolves all recipient pkScripts and policy templates
+  via `buildSendOORRecipients` (deduplication guard included). Wallet
+  selection targets the aggregate amount. Returns per-recipient
+  outpoints via `resolveOORRecipientOutpoints` in request order.
 - `resolveRecipientOutput` — extracts pkScript and client pubkey from
   an `Output` proto oneof (pubkey or address). Taproot-only.
 - `ListVTXOs` — paginated VTXO inventory. When called with
@@ -158,6 +166,16 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   `BoardingBackend`; lwwallet/btcwallet paths reach into `BtcWallet`
   directly, reinterpreting `wallet.LockID` as `wtxmgr.LockID` via
   direct `[32]byte` cast so leases round-trip across restart.
+- `sendOORRequestRecipients` — validates the `Recipients` slice in a
+  `SendOORRequest` (non-nil, within `maxOORRecipients`).
+- `sumSendOORRecipientAmounts` — per-recipient dust/overflow validation,
+  returns the aggregate wallet-selection target.
+- `buildSendOORRecipients` — resolves pkScripts + policy templates for
+  every requested recipient and rejects duplicate `(amount, pkScript)`
+  pairs that would map to the same canonical OOR output.
+- `resolveOORRecipientOutpoints` — maps each requested recipient back
+  to the outpoint it occupies after canonical OOR output sorting,
+  returning results in request-recipient order.
 - `reserveCustomInputs` (on `RPCServer`) — atomically claims every
   custom OOR outpoint for a `SendOOR` call. Returns a release
   function (typically deferred).
@@ -265,6 +283,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   per-recipient amounts outside `(0, MaxSatoshi]`, uses
   overflow-safe accumulation. Wallet-side `handleSendVTXOs` repeats
   these checks as defense-in-depth.
+- `SendOOR` supports multiple recipients in one atomic OOR session.
+  `maxOORRecipients = 256` mirrors the in-round cap and is enforced
+  before any script resolution. Custom inputs require exactly one
+  recipient (reject at RPC layer, not in the OOR actor).
 - `SendOOR` with custom inputs serializes concurrent calls on the
   same outpoints via `reserveCustomInputs`. Custom inputs lock for
   the RPC lifetime; release is deferred on both success and failure.

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -58,6 +58,14 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   cap, positive and `MaxSatoshi`-bounded amounts, overflow-safe sum),
   resolves destinations via `resolveRecipientOutput`, delegates to
   the wallet actor.
+- `SendOOR` — out-of-round transfer. Accepts one or more recipients
+  in one atomic session (up to `maxOORRecipients = 256`). Validates
+  recipient count, then calls `sendOORRequestRecipients` +
+  `sumSendOORRecipientAmounts` for early rejection before touching
+  the wallet. Resolves all recipient pkScripts and policy templates
+  via `buildSendOORRecipients` (deduplication guard included). Wallet
+  selection targets the aggregate amount. Returns per-recipient
+  outpoints via `resolveOORRecipientOutpoints` in request order.
 - `resolveRecipientOutput` — extracts pkScript and client pubkey from
   an `Output` proto oneof (pubkey or address). Taproot-only.
 - `ListVTXOs` — paginated VTXO inventory. When called with
@@ -158,6 +166,16 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   `BoardingBackend`; lwwallet/btcwallet paths reach into `BtcWallet`
   directly, reinterpreting `wallet.LockID` as `wtxmgr.LockID` via
   direct `[32]byte` cast so leases round-trip across restart.
+- `sendOORRequestRecipients` — validates the `Recipients` slice in a
+  `SendOORRequest` (non-nil, within `maxOORRecipients`).
+- `sumSendOORRecipientAmounts` — per-recipient dust/overflow validation,
+  returns the aggregate wallet-selection target.
+- `buildSendOORRecipients` — resolves pkScripts + policy templates for
+  every requested recipient and rejects duplicate `(amount, pkScript)`
+  pairs that would map to the same canonical OOR output.
+- `resolveOORRecipientOutpoints` — maps each requested recipient back
+  to the outpoint it occupies after canonical OOR output sorting,
+  returning results in request-recipient order.
 - `reserveCustomInputs` (on `RPCServer`) — atomically claims every
   custom OOR outpoint for a `SendOOR` call. Returns a release
   function (typically deferred).
@@ -265,6 +283,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   per-recipient amounts outside `(0, MaxSatoshi]`, uses
   overflow-safe accumulation. Wallet-side `handleSendVTXOs` repeats
   these checks as defense-in-depth.
+- `SendOOR` supports multiple recipients in one atomic OOR session.
+  `maxOORRecipients = 256` mirrors the in-round cap and is enforced
+  before any script resolution. Custom inputs require exactly one
+  recipient (reject at RPC layer, not in the OOR actor).
 - `SendOOR` with custom inputs serializes concurrent calls on the
   same outpoints via `reserveCustomInputs`. Custom inputs lock for
   the RPC lifetime; release is deferred on both success and failure.

--- a/internal/actortest/AGENTS.md
+++ b/internal/actortest/AGENTS.md
@@ -12,7 +12,7 @@ state+outbox checkpointing.
 
 - `testHarness` / `newTestHarness` — Central test scaffolding: sets up real DB, actor system, delivery store, and outbox publisher.
 - `eventuallyWithOutboxPublish` — Helper that actively triggers `OutboxPublisher.PublishPending()` on every polling iteration, making outbox delivery assertions robust under the race detector and CI scheduler pressure.
-- Timeout constants: `outboxForwardProcessingTimeout` (5s), `outboxDeliveryTimeout` (10s), `durableAskResponseTimeout` (10s).
+- Timeout constants: `outboxForwardProcessingTimeout` (5s), `outboxDeliveryTimeout` (30s), `durableAskResponseTimeout` (10s). `outboxDeliveryTimeout` is generous to absorb CPU contention from the race detector when other packages run concurrently.
 
 ## Relationships
 

--- a/internal/actortest/CLAUDE.md
+++ b/internal/actortest/CLAUDE.md
@@ -12,7 +12,7 @@ state+outbox checkpointing.
 
 - `testHarness` / `newTestHarness` — Central test scaffolding: sets up real DB, actor system, delivery store, and outbox publisher.
 - `eventuallyWithOutboxPublish` — Helper that actively triggers `OutboxPublisher.PublishPending()` on every polling iteration, making outbox delivery assertions robust under the race detector and CI scheduler pressure.
-- Timeout constants: `outboxForwardProcessingTimeout` (5s), `outboxDeliveryTimeout` (10s), `durableAskResponseTimeout` (10s).
+- Timeout constants: `outboxForwardProcessingTimeout` (5s), `outboxDeliveryTimeout` (30s), `durableAskResponseTimeout` (10s). `outboxDeliveryTimeout` is generous to absorb CPU contention from the race detector when other packages run concurrently.
 
 ## Relationships
 

--- a/systest/AGENTS.md
+++ b/systest/AGENTS.md
@@ -5,7 +5,17 @@
 System-level end-to-end integration tests exercising the full daemon with real
 Bitcoin/LND backends via the test harness.
 
+## Key Tests
+
+- `TestSendVTXOEndToEnd` — exercises directed in-round send through the full
+  stack: gRPC, wallet, VTXO manager, round FSM, and mailbox JoinRound egress.
+- `TestSendOORMultipleRecipientsEndToEnd` — exercises multi-recipient `SendOOR`
+  through the full daemon stack, asserting at the fake-operator mailbox
+  boundary that one session is built with both recipient outputs in the
+  SubmitPackage payload.
+
 ## Relationships
 
-- **Depends on**: `harness` (test environment), `darepod` (daemon under test).
+- **Depends on**: `harness` (test environment), `darepod` (daemon under test),
+  `rpc/oorpb` (OOR mailbox payload decoding).
 - **Depended on by**: nothing (test-only).

--- a/systest/CLAUDE.md
+++ b/systest/CLAUDE.md
@@ -5,7 +5,17 @@
 System-level end-to-end integration tests exercising the full daemon with real
 Bitcoin/LND backends via the test harness.
 
+## Key Tests
+
+- `TestSendVTXOEndToEnd` — exercises directed in-round send through the full
+  stack: gRPC, wallet, VTXO manager, round FSM, and mailbox JoinRound egress.
+- `TestSendOORMultipleRecipientsEndToEnd` — exercises multi-recipient `SendOOR`
+  through the full daemon stack, asserting at the fake-operator mailbox
+  boundary that one session is built with both recipient outputs in the
+  SubmitPackage payload.
+
 ## Relationships
 
-- **Depends on**: `harness` (test environment), `darepod` (daemon under test).
+- **Depends on**: `harness` (test environment), `darepod` (daemon under test),
+  `rpc/oorpb` (OOR mailbox payload decoding).
 - **Depended on by**: nothing (test-only).


### PR DESCRIPTION
Automated nightly doc-gardening sweep for 2026-06-09.

**Changes since last sweep** (multi-recipient SendOOR — PR #696):

- `darepod/CLAUDE.md` + `AGENTS.md` — document multi-recipient `SendOOR`
  handler, new helper functions (`sendOORRequestRecipients`,
  `sumSendOORRecipientAmounts`, `buildSendOORRecipients`,
  `resolveOORRecipientOutpoints`), and updated `maxOORRecipients = 256`
  invariant.
- `internal/actortest/CLAUDE.md` + `AGENTS.md` — correct
  `outboxDeliveryTimeout` from 10s to 30s with context.
- `systest/CLAUDE.md` + `AGENTS.md` — add `TestSendOORMultipleRecipientsEndToEnd`
  and `TestSendVTXOEndToEnd` to the Key Tests section; add `rpc/oorpb`
  dependency.

Please review the updated CLAUDE.md/AGENTS.md diffs for accuracy.
