### PR TITLE
darepod: recover Ark state from seed restore

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_create.go
+++ b/cmd/darepocli/darepoclicommands/cmd_create.go
@@ -68,15 +68,16 @@ func newCreateCmd() *cobra.Command {
 // walletCreate implements the top-level `create` verb.
 func walletCreate(cmd *cobra.Command, _ []string) error {
 	recoverWallet, _ := cmd.Flags().GetBool("recover")
-	mnemonicFile, err := aliasedStringFlag(
-		cmd, "mnemonic-file", "mnemonic_file",
+	mnemonicFile, err := aliasedFlag(
+		cmd, "mnemonic-file", "mnemonic_file", cmd.Flags().GetString,
 	)
 	if err != nil {
 		return err
 	}
 
-	recoveryWindow, err := aliasedUint32Flag(
+	recoveryWindow, err := aliasedFlag(
 		cmd, "recovery-window", "recovery_window",
+		cmd.Flags().GetUint32,
 	)
 	if err != nil {
 		return err
@@ -178,40 +179,22 @@ func readMnemonicFile(path string) ([]string, error) {
 	return words, nil
 }
 
-// aliasedStringFlag reads a string flag with a hidden compatibility alias.
-func aliasedStringFlag(cmd *cobra.Command, primary,
-	alias string) (string, error) {
+// aliasedFlag reads a flag with a hidden compatibility alias.
+func aliasedFlag[T any](cmd *cobra.Command, primary, alias string,
+	get func(string) (T, error)) (T, error) {
 
 	primaryChanged := cmd.Flags().Changed(primary)
 	aliasChanged := cmd.Flags().Changed(alias)
+	var zero T
 	switch {
 	case primaryChanged && aliasChanged:
-		return "", fmt.Errorf("--%s and --%s cannot both be set",
+		return zero, fmt.Errorf("--%s and --%s cannot both be set",
 			primary, alias)
 
 	case aliasChanged:
-		return cmd.Flags().GetString(alias)
+		return get(alias)
 
 	default:
-		return cmd.Flags().GetString(primary)
-	}
-}
-
-// aliasedUint32Flag reads a uint32 flag with a hidden compatibility alias.
-func aliasedUint32Flag(cmd *cobra.Command, primary,
-	alias string) (uint32, error) {
-
-	primaryChanged := cmd.Flags().Changed(primary)
-	aliasChanged := cmd.Flags().Changed(alias)
-	switch {
-	case primaryChanged && aliasChanged:
-		return 0, fmt.Errorf("--%s and --%s cannot both be set",
-			primary, alias)
-
-	case aliasChanged:
-		return cmd.Flags().GetUint32(alias)
-
-	default:
-		return cmd.Flags().GetUint32(primary)
+		return get(primary)
 	}
 }

--- a/cmd/darepocli/darepoclicommands/cmd_create.go
+++ b/cmd/darepocli/darepoclicommands/cmd_create.go
@@ -3,6 +3,7 @@ package darepoclicommands
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 	"github.com/spf13/cobra"
@@ -46,12 +47,52 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().Bool("print-mnemonic-json", false,
 		"include the mnemonic in the JSON response on stdout "+
 			"(default: stderr only)")
+	cmd.Flags().Bool("recover", false,
+		"import an existing mnemonic and recover Ark wallet state")
+	cmd.Flags().String("mnemonic-file", "",
+		"path to file containing an existing 24-word aezeed mnemonic")
+	cmd.Flags().String("mnemonic_file", "",
+		"path to file containing an existing 24-word aezeed mnemonic")
+	cmd.Flags().Uint32("recovery-window", 0,
+		"number of key indexes to scan per recovery family "+
+			"(default: daemon wallet.recoverywindow)")
+	cmd.Flags().Uint32("recovery_window", 0,
+		"number of key indexes to scan per recovery family "+
+			"(default: daemon wallet.recoverywindow)")
+	_ = cmd.Flags().MarkHidden("mnemonic_file")
+	_ = cmd.Flags().MarkHidden("recovery_window")
 
 	return cmd
 }
 
 // walletCreate implements the top-level `create` verb.
 func walletCreate(cmd *cobra.Command, _ []string) error {
+	recoverWallet, _ := cmd.Flags().GetBool("recover")
+	mnemonicFile, err := aliasedStringFlag(
+		cmd, "mnemonic-file", "mnemonic_file",
+	)
+	if err != nil {
+		return err
+	}
+
+	recoveryWindow, err := aliasedUint32Flag(
+		cmd, "recovery-window", "recovery_window",
+	)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case recoverWallet && mnemonicFile == "":
+		return fmt.Errorf("--recover requires --mnemonic-file")
+
+	case !recoverWallet && mnemonicFile != "":
+		return fmt.Errorf("--mnemonic-file requires --recover")
+
+	case !recoverWallet && recoveryWindow != 0:
+		return fmt.Errorf("--recovery-window requires --recover")
+	}
+
 	seedPassphrase, err := readSeedPassphrase(cmd)
 	if err != nil {
 		return err
@@ -66,31 +107,50 @@ func walletCreate(cmd *cobra.Command, _ []string) error {
 
 	printJSON, _ := cmd.Flags().GetBool("print-mnemonic-json")
 
+	var mnemonic []string
+	if recoverWallet {
+		mnemonic, err = readMnemonicFile(mnemonicFile)
+		if err != nil {
+			return err
+		}
+	}
+
 	return withWalletClient(
 		cmd, func(c walletdkrpc.WalletServiceClient) error {
 			resp, err := c.Create(
 				cmd.Context(), &walletdkrpc.CreateRequest{
 					WalletPassword: password,
 					SeedPassphrase: seedPassphrase,
+					Mnemonic:       mnemonic,
+					RecoverState:   recoverWallet,
+					RecoveryWindow: recoveryWindow,
 				},
 			)
 			if err != nil {
 				return fmt.Errorf("create wallet: %w", err)
 			}
 
-			// Print the mnemonic to stderr so it does not mix
-			// with structured JSON output on stdout. By default
-			// the mnemonic is REDACTED from the JSON response
-			// on stdout so a log aggregator or shell redirect
-			// cannot persist the master secret; callers that
-			// explicitly need the machine-readable form pass
-			// --print-mnemonic-json.
-			fmt.Fprintln(os.Stderr, "=== WRITE DOWN YOUR SEED ===")
-			for i, word := range resp.GetMnemonic() {
-				fmt.Fprintf(os.Stderr, "%2d. %s\n", i+1, word)
+			// Fresh-create prints the generated mnemonic to stderr
+			// so it does not mix with structured JSON output. A
+			// recovery import already read the mnemonic from disk,
+			// so do not re-print it by default.
+			if !recoverWallet {
+				fmt.Fprintln(
+					os.Stderr,
+					"=== WRITE DOWN YOUR SEED ===",
+				)
+				for i, word := range resp.GetMnemonic() {
+					fmt.Fprintf(
+						os.Stderr, "%2d. %s\n", i+1,
+						word,
+					)
+				}
+				fmt.Fprintln(
+					os.Stderr,
+					"============================",
+				)
+				fmt.Fprintln(os.Stderr)
 			}
-			fmt.Fprintln(os.Stderr, "============================")
-			fmt.Fprintln(os.Stderr)
 
 			if !printJSON {
 				resp.Mnemonic = nil
@@ -99,4 +159,59 @@ func walletCreate(cmd *cobra.Command, _ []string) error {
 			return printWalletProto(resp)
 		},
 	)
+}
+
+// readMnemonicFile reads mnemonic words from path. The file may contain words
+// separated by any whitespace, including one word per line.
+func readMnemonicFile(path string) ([]string, error) {
+	// The file path is explicitly provided by the CLI user.
+	data, err := os.ReadFile(path) //nolint:gosec // G304
+	if err != nil {
+		return nil, fmt.Errorf("unable to read mnemonic file: %w", err)
+	}
+
+	words := strings.Fields(string(data))
+	if len(words) == 0 {
+		return nil, fmt.Errorf("mnemonic file is empty")
+	}
+
+	return words, nil
+}
+
+// aliasedStringFlag reads a string flag with a hidden compatibility alias.
+func aliasedStringFlag(cmd *cobra.Command, primary,
+	alias string) (string, error) {
+
+	primaryChanged := cmd.Flags().Changed(primary)
+	aliasChanged := cmd.Flags().Changed(alias)
+	switch {
+	case primaryChanged && aliasChanged:
+		return "", fmt.Errorf("--%s and --%s cannot both be set",
+			primary, alias)
+
+	case aliasChanged:
+		return cmd.Flags().GetString(alias)
+
+	default:
+		return cmd.Flags().GetString(primary)
+	}
+}
+
+// aliasedUint32Flag reads a uint32 flag with a hidden compatibility alias.
+func aliasedUint32Flag(cmd *cobra.Command, primary,
+	alias string) (uint32, error) {
+
+	primaryChanged := cmd.Flags().Changed(primary)
+	aliasChanged := cmd.Flags().Changed(alias)
+	switch {
+	case primaryChanged && aliasChanged:
+		return 0, fmt.Errorf("--%s and --%s cannot both be set",
+			primary, alias)
+
+	case aliasChanged:
+		return cmd.Flags().GetUint32(alias)
+
+	default:
+		return cmd.Flags().GetUint32(primary)
+	}
 }

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -1116,6 +1116,13 @@ type InitWalletRequest struct {
 	// generating the aezeed mnemonic. Must match the value passed to
 	// GenSeed.
 	SeedPassphrase []byte `protobuf:"bytes,3,opt,name=seed_passphrase,json=seedPassphrase,proto3" json:"seed_passphrase,omitempty"`
+	// recover_state asks the daemon to scan deterministic Ark wallet keys
+	// after the seed is restored and rebuild local Ark state from chain and
+	// indexer data.
+	RecoverState bool `protobuf:"varint,4,opt,name=recover_state,json=recoverState,proto3" json:"recover_state,omitempty"`
+	// recovery_window is the number of key indexes to scan per recovery key
+	// family. Zero uses the daemon wallet.recoverywindow config value.
+	RecoveryWindow uint32 `protobuf:"varint,5,opt,name=recovery_window,json=recoveryWindow,proto3" json:"recovery_window,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -1171,6 +1178,20 @@ func (x *InitWalletRequest) GetSeedPassphrase() []byte {
 	return nil
 }
 
+func (x *InitWalletRequest) GetRecoverState() bool {
+	if x != nil {
+		return x.RecoverState
+	}
+	return false
+}
+
+func (x *InitWalletRequest) GetRecoveryWindow() uint32 {
+	if x != nil {
+		return x.RecoveryWindow
+	}
+	return 0
+}
+
 type InitWalletResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// identity_pubkey is the hex-encoded daemon wallet identity public key
@@ -1178,8 +1199,25 @@ type InitWalletResponse struct {
 	// reported by GetInfoResponse.identity_pubkey and used for Ark/OOR
 	// signing flows.
 	IdentityPubkey string `protobuf:"bytes,1,opt,name=identity_pubkey,json=identityPubkey,proto3" json:"identity_pubkey,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// recovery_ran is true when InitWallet attempted Ark-state recovery.
+	RecoveryRan bool `protobuf:"varint,2,opt,name=recovery_ran,json=recoveryRan,proto3" json:"recovery_ran,omitempty"`
+	// recovered_boarding_addresses is the number of boarding addresses
+	// rebuilt and persisted from deterministic keys.
+	RecoveredBoardingAddresses uint32 `protobuf:"varint,3,opt,name=recovered_boarding_addresses,json=recoveredBoardingAddresses,proto3" json:"recovered_boarding_addresses,omitempty"`
+	// recovered_boarding_utxos is the number of confirmed wallet UTXOs found
+	// at recovered boarding addresses during the recovery scan.
+	RecoveredBoardingUtxos uint32 `protobuf:"varint,4,opt,name=recovered_boarding_utxos,json=recoveredBoardingUtxos,proto3" json:"recovered_boarding_utxos,omitempty"`
+	// recovered_vtxos is the number of indexed VTXOs restored into local
+	// wallet state.
+	RecoveredVtxos uint32 `protobuf:"varint,5,opt,name=recovered_vtxos,json=recoveredVtxos,proto3" json:"recovered_vtxos,omitempty"`
+	// recovered_oor_receive_scripts is the number of registered OOR receive
+	// scripts matched and restored into local ownership metadata.
+	RecoveredOorReceiveScripts uint32 `protobuf:"varint,6,opt,name=recovered_oor_receive_scripts,json=recoveredOorReceiveScripts,proto3" json:"recovered_oor_receive_scripts,omitempty"`
+	// recovered_oor_events is the number of OOR recipient events processed
+	// during recovery.
+	RecoveredOorEvents uint32 `protobuf:"varint,7,opt,name=recovered_oor_events,json=recoveredOorEvents,proto3" json:"recovered_oor_events,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *InitWalletResponse) Reset() {
@@ -1217,6 +1255,48 @@ func (x *InitWalletResponse) GetIdentityPubkey() string {
 		return x.IdentityPubkey
 	}
 	return ""
+}
+
+func (x *InitWalletResponse) GetRecoveryRan() bool {
+	if x != nil {
+		return x.RecoveryRan
+	}
+	return false
+}
+
+func (x *InitWalletResponse) GetRecoveredBoardingAddresses() uint32 {
+	if x != nil {
+		return x.RecoveredBoardingAddresses
+	}
+	return 0
+}
+
+func (x *InitWalletResponse) GetRecoveredBoardingUtxos() uint32 {
+	if x != nil {
+		return x.RecoveredBoardingUtxos
+	}
+	return 0
+}
+
+func (x *InitWalletResponse) GetRecoveredVtxos() uint32 {
+	if x != nil {
+		return x.RecoveredVtxos
+	}
+	return 0
+}
+
+func (x *InitWalletResponse) GetRecoveredOorReceiveScripts() uint32 {
+	if x != nil {
+		return x.RecoveredOorReceiveScripts
+	}
+	return 0
+}
+
+func (x *InitWalletResponse) GetRecoveredOorEvents() uint32 {
+	if x != nil {
+		return x.RecoveredOorEvents
+	}
+	return 0
 }
 
 type UnlockWalletRequest struct {
@@ -7848,13 +7928,21 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0fseed_passphrase\x18\x01 \x01(\fR\x0eseedPassphrase\"V\n" +
 	"\x0fGenSeedResponse\x12\x1a\n" +
 	"\bmnemonic\x18\x01 \x03(\tR\bmnemonic\x12'\n" +
-	"\x0fenciphered_seed\x18\x02 \x01(\fR\x0eencipheredSeed\"\x81\x01\n" +
+	"\x0fenciphered_seed\x18\x02 \x01(\fR\x0eencipheredSeed\"\xcf\x01\n" +
 	"\x11InitWalletRequest\x12\x1a\n" +
 	"\bmnemonic\x18\x01 \x03(\tR\bmnemonic\x12'\n" +
 	"\x0fwallet_password\x18\x02 \x01(\fR\x0ewalletPassword\x12'\n" +
-	"\x0fseed_passphrase\x18\x03 \x01(\fR\x0eseedPassphrase\"=\n" +
+	"\x0fseed_passphrase\x18\x03 \x01(\fR\x0eseedPassphrase\x12#\n" +
+	"\rrecover_state\x18\x04 \x01(\bR\frecoverState\x12'\n" +
+	"\x0frecovery_window\x18\x05 \x01(\rR\x0erecoveryWindow\"\xfa\x02\n" +
 	"\x12InitWalletResponse\x12'\n" +
-	"\x0fidentity_pubkey\x18\x01 \x01(\tR\x0eidentityPubkey\">\n" +
+	"\x0fidentity_pubkey\x18\x01 \x01(\tR\x0eidentityPubkey\x12!\n" +
+	"\frecovery_ran\x18\x02 \x01(\bR\vrecoveryRan\x12@\n" +
+	"\x1crecovered_boarding_addresses\x18\x03 \x01(\rR\x1arecoveredBoardingAddresses\x128\n" +
+	"\x18recovered_boarding_utxos\x18\x04 \x01(\rR\x16recoveredBoardingUtxos\x12'\n" +
+	"\x0frecovered_vtxos\x18\x05 \x01(\rR\x0erecoveredVtxos\x12A\n" +
+	"\x1drecovered_oor_receive_scripts\x18\x06 \x01(\rR\x1arecoveredOorReceiveScripts\x120\n" +
+	"\x14recovered_oor_events\x18\a \x01(\rR\x12recoveredOorEvents\">\n" +
 	"\x13UnlockWalletRequest\x12'\n" +
 	"\x0fwallet_password\x18\x01 \x01(\fR\x0ewalletPassword\"?\n" +
 	"\x14UnlockWalletResponse\x12'\n" +

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -377,6 +377,15 @@ message InitWalletRequest {
     // generating the aezeed mnemonic. Must match the value passed to
     // GenSeed.
     bytes seed_passphrase = 3;
+
+    // recover_state asks the daemon to scan deterministic Ark wallet keys
+    // after the seed is restored and rebuild local Ark state from chain and
+    // indexer data.
+    bool recover_state = 4;
+
+    // recovery_window is the number of key indexes to scan per recovery key
+    // family. Zero uses the daemon wallet.recoverywindow config value.
+    uint32 recovery_window = 5;
 }
 
 message InitWalletResponse {
@@ -385,6 +394,29 @@ message InitWalletResponse {
     // reported by GetInfoResponse.identity_pubkey and used for Ark/OOR
     // signing flows.
     string identity_pubkey = 1;
+
+    // recovery_ran is true when InitWallet attempted Ark-state recovery.
+    bool recovery_ran = 2;
+
+    // recovered_boarding_addresses is the number of boarding addresses
+    // rebuilt and persisted from deterministic keys.
+    uint32 recovered_boarding_addresses = 3;
+
+    // recovered_boarding_utxos is the number of confirmed wallet UTXOs found
+    // at recovered boarding addresses during the recovery scan.
+    uint32 recovered_boarding_utxos = 4;
+
+    // recovered_vtxos is the number of indexed VTXOs restored into local
+    // wallet state.
+    uint32 recovered_vtxos = 5;
+
+    // recovered_oor_receive_scripts is the number of registered OOR receive
+    // scripts matched and restored into local ownership metadata.
+    uint32 recovered_oor_receive_scripts = 6;
+
+    // recovered_oor_events is the number of OOR recipient events processed
+    // during recovery.
+    uint32 recovered_oor_events = 7;
 }
 
 message UnlockWalletRequest {

--- a/darepod/rpc_wallet.go
+++ b/darepod/rpc_wallet.go
@@ -317,6 +317,17 @@ func (r *RPCServer) InitWallet(ctx context.Context,
 			"wallet: %v", err)
 	}
 
+	var recoveryResult *walletRecoveryResult
+	if req.GetRecoverState() {
+		recoveryResult, err = r.recoverWalletState(
+			ctx, req.GetRecoveryWindow(),
+		)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "unable to "+
+				"recover wallet state: %v", err)
+		}
+	}
+
 	// Derive identity pubkey for the response.
 	identityPubkey, err := r.deriveIdentityPubkey(ctx)
 	if err != nil {
@@ -324,9 +335,14 @@ func (r *RPCServer) InitWallet(ctx context.Context,
 			"identity pubkey: %v", err)
 	}
 
-	return &daemonrpc.InitWalletResponse{
+	resp := &daemonrpc.InitWalletResponse{
 		IdentityPubkey: identityPubkey,
-	}, nil
+	}
+	if recoveryResult != nil {
+		recoveryResult.apply(resp)
+	}
+
+	return resp, nil
 }
 
 // UnlockWallet decrypts an existing wallet seed using the provided

--- a/darepod/wallet_recovery.go
+++ b/darepod/wallet_recovery.go
@@ -1,0 +1,695 @@
+package darepod
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/build"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	libtypes "github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/oor"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightninglabs/darepo-client/wallet"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	recoveryVTXOPageSize = 128
+	recoveryOORPageSize  = 128
+)
+
+type walletRecoveryResult struct {
+	BoardingAddresses uint32
+	BoardingUTXOs     uint32
+	VTXOs             uint32
+	OORReceiveScripts uint32
+	OOREvents         uint32
+}
+
+func (r walletRecoveryResult) apply(resp *daemonrpc.InitWalletResponse) {
+	resp.RecoveryRan = true
+	resp.RecoveredBoardingAddresses = r.BoardingAddresses
+	resp.RecoveredBoardingUtxos = r.BoardingUTXOs
+	resp.RecoveredVtxos = r.VTXOs
+	resp.RecoveredOorReceiveScripts = r.OORReceiveScripts
+	resp.RecoveredOorEvents = r.OOREvents
+}
+
+func (r *RPCServer) recoverWalletState(ctx context.Context, window uint32) (
+	*walletRecoveryResult, error) {
+
+	if window == 0 {
+		window = r.server.cfg.Wallet.RecoveryWindow
+	}
+	if window == 0 {
+		window = DefaultRecoveryWindow
+	}
+
+	if r.server.proofKeyBackend == nil {
+		return nil, fmt.Errorf("wallet backend not initialized")
+	}
+
+	select {
+	case <-r.server.DaemonReady():
+	case <-ctx.Done():
+		return nil, fmt.Errorf("wait for wallet-ready services: %w",
+			ctx.Err())
+	}
+
+	if r.server.indexer == nil {
+		return nil, fmt.Errorf("indexer client not initialized")
+	}
+
+	terms, err := r.server.fetchOperatorTerms(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var result walletRecoveryResult
+	if err := r.recoverBoardingKeys(
+		ctx, terms, window, &result,
+	); err != nil {
+		return nil, fmt.Errorf("recover boarding keys: %w", err)
+	}
+	if err := r.recoverIndexedVTXOs(
+		ctx, terms, window, &result,
+	); err != nil {
+		return nil, fmt.Errorf("recover indexed VTXOs: %w", err)
+	}
+	if err := r.recoverOORReceiveScripts(
+		ctx, terms, window, &result,
+	); err != nil {
+		return nil, fmt.Errorf("recover OOR receive scripts: %w", err)
+	}
+
+	return &result, nil
+}
+
+func (r *RPCServer) recoverBoardingKeys(ctx context.Context,
+	terms *libtypes.OperatorTerms, window uint32,
+	result *walletRecoveryResult) error {
+
+	backend, err := r.server.recoveryBoardingBackend()
+	if err != nil {
+		return err
+	}
+
+	store := r.server.newBoardingStore()
+	recoveredScripts := make(map[string]struct{}, window)
+
+	for i := uint32(0); i < window; i++ {
+		keyDesc, err := r.server.proofKeyBackend.DeriveKey(
+			ctx, keychain.KeyLocator{
+				Family: wallet.BoardingKeyFamily,
+				Index:  i,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("derive boarding key %d: %w", i, err)
+		}
+
+		tapscript, err := arkscript.VTXOTapScript(
+			keyDesc.PubKey, terms.PubKey, terms.BoardingExitDelay,
+		)
+		if err != nil {
+			return fmt.Errorf("build boarding tapscript %d: %w", i,
+				err)
+		}
+
+		addr, err := backend.ImportTaprootScript(ctx, tapscript)
+		if err != nil {
+			return fmt.Errorf("import boarding script %d: %w", i,
+				err)
+		}
+
+		boardingAddr := &wallet.BoardingAddress{
+			Address:     addr,
+			Tapscript:   tapscript,
+			KeyDesc:     *keyDesc,
+			OperatorKey: terms.PubKey,
+			ExitDelay:   terms.BoardingExitDelay,
+		}
+		if err := store.InsertBoardingAddress(
+			ctx, boardingAddr,
+		); err != nil {
+			return fmt.Errorf("persist boarding address %d: %w", i,
+				err)
+		}
+
+		pkScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return fmt.Errorf("derive boarding pk script %d: %w", i,
+				err)
+		}
+		recoveredScripts[string(pkScript)] = struct{}{}
+		result.BoardingAddresses++
+	}
+
+	utxos, err := backend.ListUnspent(
+		ctx, wallet.MinBoardingConfs, wallet.MaxConfsForListUnspent,
+	)
+	if err != nil {
+		return fmt.Errorf("list boarding UTXOs: %w", err)
+	}
+
+	for _, utxo := range utxos {
+		if _, ok := recoveredScripts[string(utxo.PkScript)]; ok {
+			result.BoardingUTXOs++
+		}
+	}
+
+	return nil
+}
+
+func (s *Server) recoveryBoardingBackend() (wallet.BoardingBackend, error) {
+	switch s.cfg.Wallet.Type {
+	case WalletTypeLwwallet:
+		if !s.lwWallet.IsSome() {
+			return nil, fmt.Errorf("lwwallet not initialized")
+		}
+
+		return s.lwWallet.UnsafeFromSome().BoardingBackend(), nil
+
+	case WalletTypeBtcwallet:
+		if !s.btcwWallet.IsSome() {
+			return nil, fmt.Errorf("btcwallet not initialized")
+		}
+
+		return s.btcwWallet.UnsafeFromSome().BoardingBackend(), nil
+
+	default:
+		return nil, fmt.Errorf("wallet type %s does not support seed "+
+			"recovery", s.cfg.Wallet.Type)
+	}
+}
+
+func (r *RPCServer) recoverIndexedVTXOs(ctx context.Context,
+	terms *libtypes.OperatorTerms, window uint32,
+	result *walletRecoveryResult) error {
+
+	for i := uint32(0); i < window; i++ {
+		keyDesc, err := r.server.proofKeyBackend.DeriveKey(
+			ctx, keychain.KeyLocator{
+				Family: libtypes.VTXOOwnerKeyFamily,
+				Index:  i,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("derive VTXO key %d: %w", i, err)
+		}
+
+		pkScript, err := BuildPubKeyVTXOReceiveScript(
+			keyDesc.PubKey, terms.PubKey, terms.VTXOExitDelay,
+		)
+		if err != nil {
+			return fmt.Errorf("build VTXO script %d: %w", i, err)
+		}
+
+		idx := r.server.indexer.WithSigner(
+			r.server.proofKeyBackend.ProofSigner(*keyDesc),
+		)
+		expiresAt := r.server.clk.Now().Add(
+			defaultOORReceiveScriptRegistrationTTL,
+		)
+		_, err = idx.RegisterReceiveScriptTaproot(
+			ctx, pkScript, expiresAt, "seed-recovery-vtxo",
+		)
+		if err != nil && status.Code(err) != codes.AlreadyExists {
+			return fmt.Errorf("register VTXO script %d: %w", i, err)
+		}
+
+		cursor := []byte(nil)
+		for {
+			resp, err := idx.ListVTXOsByScriptsTaproot(
+				ctx,
+				[]indexer.TaprootScriptScope{{
+					PkScript: pkScript,
+				}},
+				cursor, recoveryVTXOPageSize,
+				nil,
+			)
+			if err != nil {
+				return fmt.Errorf("list VTXOs for key %d: %w",
+					i, err)
+			}
+
+			vtxos := vtxo.FlattenListVTXOsByScriptsResponse(
+				resp,
+			)
+			for _, indexed := range vtxos {
+				indexedScript := indexed.GetPkScript()
+				if !bytes.Equal(indexedScript, pkScript) {
+					continue
+				}
+
+				desc, ok, err := recoveryDescriptorFromIndexer(
+					indexed, *keyDesc, terms,
+				)
+				if err != nil {
+					return fmt.Errorf("convert VTXO for "+
+						"key %d: %w", i, err)
+				}
+				if !ok {
+					continue
+				}
+
+				saved, err := r.saveRecoveredVTXO(ctx, desc)
+				if err != nil {
+					return err
+				}
+				if saved {
+					result.VTXOs++
+				}
+			}
+
+			cursor = resp.GetNextCursor()
+			if len(cursor) == 0 {
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+func recoveryDescriptorFromIndexer(indexed *arkrpc.VTXO,
+	keyDesc keychain.KeyDescriptor, terms *libtypes.OperatorTerms) (
+	*vtxo.Descriptor, bool, error) {
+
+	status, ok := recoveryVTXOStatus(indexed.GetStatus())
+	if !ok {
+		return nil, false, nil
+	}
+
+	outpoint, err := recoveryOutpoint(indexed.GetOutpoint())
+	if err != nil {
+		return nil, false, err
+	}
+
+	operatorKey := terms.PubKey
+	if len(indexed.GetOperatorPubkey()) > 0 {
+		operatorKey, err = btcec.ParsePubKey(
+			indexed.GetOperatorPubkey(),
+		)
+		if err != nil {
+			return nil, false, fmt.Errorf("parse operator key: %w",
+				err)
+		}
+	}
+
+	exitDelay := indexed.GetRelativeExpiry()
+	if exitDelay == 0 {
+		exitDelay = terms.VTXOExitDelay
+	}
+
+	tapscript, err := arkscript.VTXOTapScript(
+		keyDesc.PubKey, operatorKey, exitDelay,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("build tapscript: %w", err)
+	}
+
+	policyTemplate, err := arkscript.EncodeStandardVTXOTemplate(
+		keyDesc.PubKey, operatorKey, exitDelay,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("encode policy: %w", err)
+	}
+
+	ancestry, err := vtxo.AncestryFromRPC(indexed.GetAncestryPaths())
+	if err != nil {
+		return nil, false, fmt.Errorf("convert ancestry: %w", err)
+	}
+
+	commitmentTxID, err := chainhash.NewHash(
+		indexed.GetCommitmentTxid(),
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("parse commitment txid: %w", err)
+	}
+
+	return &vtxo.Descriptor{
+		Outpoint:       outpoint,
+		Amount:         btcutil.Amount(indexed.GetValueSat()),
+		PolicyTemplate: policyTemplate,
+		PkScript:       append([]byte(nil), indexed.GetPkScript()...),
+		ClientKey:      keyDesc,
+		OperatorKey:    operatorKey,
+		TapScript:      tapscript,
+		Ancestry:       ancestry,
+		RoundID:        indexed.GetRoundId(),
+		CommitmentTxID: *commitmentTxID,
+		BatchExpiry:    indexed.GetBatchExpiryHeight(),
+		RelativeExpiry: exitDelay,
+		ChainDepth:     int(indexed.GetChainDepth()),
+		CreatedHeight:  indexed.GetCreatedHeight(),
+		Status:         status,
+	}, true, nil
+}
+
+func recoveryOutpoint(op *arkrpc.OutPoint) (wire.OutPoint, error) {
+	if op == nil {
+		return wire.OutPoint{}, fmt.Errorf("outpoint missing")
+	}
+
+	txid, err := chainhash.NewHash(op.GetTxid())
+	if err != nil {
+		return wire.OutPoint{}, fmt.Errorf("parse outpoint txid: %w",
+			err)
+	}
+
+	return wire.OutPoint{
+		Hash:  *txid,
+		Index: op.GetVout(),
+	}, nil
+}
+
+func recoveryVTXOStatus(status arkrpc.VTXOStatus) (vtxo.VTXOStatus, bool) {
+	switch status {
+	case arkrpc.VTXOStatus_VTXO_STATUS_UNCONFIRMED,
+		arkrpc.VTXOStatus_VTXO_STATUS_LIVE:
+		return vtxo.VTXOStatusLive, true
+
+	case arkrpc.VTXOStatus_VTXO_STATUS_PENDING_FORFEIT:
+		return vtxo.VTXOStatusPendingForfeit, true
+
+	case arkrpc.VTXOStatus_VTXO_STATUS_FORFEITING:
+		return vtxo.VTXOStatusForfeiting, true
+
+	case arkrpc.VTXOStatus_VTXO_STATUS_UNILATERAL_EXIT:
+		return vtxo.VTXOStatusUnilateralExit, true
+
+	default:
+		return vtxo.VTXOStatusLive, false
+	}
+}
+
+func (r *RPCServer) saveRecoveredVTXO(ctx context.Context,
+	desc *vtxo.Descriptor) (bool, error) {
+
+	if r.server.vtxoStore == nil {
+		return false, fmt.Errorf("VTXO store not initialized")
+	}
+
+	err := r.server.vtxoStore.SaveVTXO(ctx, desc)
+	if err == nil {
+		if err := r.notifyRecoveredVTXOs(
+			ctx, []*vtxo.Descriptor{desc},
+		); err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	existing, getErr := r.server.vtxoStore.GetVTXO(ctx, desc.Outpoint)
+	if getErr != nil {
+		if !errorsIsNoRows(getErr) {
+			return false, fmt.Errorf("check existing recovered "+
+				"VTXO: %w", getErr)
+		}
+
+		return false, err
+	}
+	if existing == nil || existing.Amount != desc.Amount ||
+		!bytes.Equal(existing.PkScript, desc.PkScript) {
+		return false, err
+	}
+
+	return false, nil
+}
+
+func (r *RPCServer) notifyRecoveredVTXOs(ctx context.Context,
+	descs []*vtxo.Descriptor) error {
+
+	if len(descs) == 0 || !r.server.vtxoMgrRef.IsSome() {
+		return nil
+	}
+
+	var notifyErr error
+	r.server.vtxoMgrRef.WhenSome(func(ref actor.ActorRef[
+		vtxo.ManagerMsg, vtxo.ManagerResp,
+	]) {
+
+		notifyErr = ref.Tell(
+			ctx, &vtxo.VTXOsMaterializedNotification{
+				VTXOs: descs,
+			},
+		)
+	})
+	if notifyErr != nil {
+		return fmt.Errorf("notify VTXO manager: %w", notifyErr)
+	}
+
+	return nil
+}
+
+func (r *RPCServer) recoverOORReceiveScripts(ctx context.Context,
+	terms *libtypes.OperatorTerms, window uint32,
+	result *walletRecoveryResult) error {
+
+	registered, err := r.server.indexer.ListMyReceiveScripts(ctx)
+	if err != nil {
+		return fmt.Errorf("list registered receive scripts: %w", err)
+	}
+
+	registeredScripts := make(
+		map[string]struct{},
+		len(
+			registered.GetScripts(),
+		),
+	)
+	for _, script := range registered.GetScripts() {
+		registeredScripts[string(script.GetPkScript())] = struct{}{}
+	}
+
+	packageStore := r.newLocalOORArtifactStore()
+	handler := r.recoveryOORHandler(terms, packageStore)
+
+	for i := uint32(0); i < window; i++ {
+		keyDesc, err := r.server.proofKeyBackend.DeriveKey(
+			ctx, keychain.KeyLocator{
+				Family: oorReceiveKeyFamily,
+				Index:  i,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("derive OOR key %d: %w", i, err)
+		}
+
+		pkScript, err := BuildPubKeyVTXOReceiveScript(
+			keyDesc.PubKey, terms.PubKey, terms.VTXOExitDelay,
+		)
+		if err != nil {
+			return fmt.Errorf("build OOR script %d: %w", i, err)
+		}
+
+		if _, ok := registeredScripts[string(pkScript)]; !ok {
+			continue
+		}
+
+		err = packageStore.UpsertOwnedReceiveScript(
+			ctx, db.OwnedReceiveScriptRecord{
+				PkScript:       pkScript,
+				ClientKey:      *keyDesc,
+				OperatorPubKey: terms.PubKey,
+				ExitDelay:      int64(terms.VTXOExitDelay),
+				Source:         db.OwnedReceiveScriptSourceSync,
+				CreatedAt:      r.server.clk.Now(),
+				LastUsedAt:     fn.None[time.Time](),
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("persist OOR script %d: %w", i, err)
+		}
+		result.OORReceiveScripts++
+
+		idx := r.server.indexer.WithSigner(
+			r.server.proofKeyBackend.ProofSigner(*keyDesc),
+		)
+		if err := r.recoverOOREventsForScript(
+			ctx, idx, pkScript, handler, result,
+		); err != nil {
+			return fmt.Errorf("recover OOR events for key %d: %w",
+				i, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *RPCServer) recoveryOORHandler(
+	terms *libtypes.OperatorTerms,
+	packageStore *db.OORArtifactPersistenceStore,
+) *oor.LocalPersistenceOutboxHandler {
+
+	return &oor.LocalPersistenceOutboxHandler{
+		Store:        r.server.vtxoStore,
+		PackageStore: packageStore,
+		OperatorKey:  terms.PubKey,
+		ExitDelay:    terms.VTXOExitDelay,
+		NotifyIncomingVTXOs: func(ctx context.Context,
+			descs []*vtxo.Descriptor) error {
+
+			return r.notifyRecoveredVTXOs(ctx, descs)
+		},
+		ResolveIncomingClientKey: func(ctx context.Context,
+			recipient oor.ArkRecipientOutput) (
+			keychain.KeyDescriptor, error) {
+
+			return ResolveOwnedReceiveScriptKey(
+				ctx, packageStore, recipient,
+			)
+		},
+		ResolveIncomingMetadata: func(ctx context.Context,
+			sessionID oor.SessionID,
+			recipient oor.ArkRecipientOutput, ark *psbt.Packet,
+			finalCheckpoints []*psbt.Packet) (
+			oor.IncomingVTXOMetadata, error) {
+
+			_ = ctx
+			_ = sessionID
+			_ = recipient
+			_ = ark
+			_ = finalCheckpoints
+
+			return oor.IncomingVTXOMetadata{}, fmt.Errorf(
+				"unexpected generic resolver call")
+		},
+	}
+}
+
+func (r *RPCServer) recoverOOREventsForScript(ctx context.Context,
+	idx *indexer.Client, pkScript []byte,
+	handler *oor.LocalPersistenceOutboxHandler,
+	result *walletRecoveryResult) error {
+
+	var afterEventID uint64
+	for {
+		resp, err := idx.ListOORRecipientEventsByScriptTaproot(
+			ctx, pkScript, afterEventID, recoveryOORPageSize,
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, event := range resp.GetEvents() {
+			if event == nil {
+				continue
+			}
+
+			err := r.materializeRecoveredOOREvent(
+				ctx, idx, event, handler,
+			)
+			if err != nil {
+				return err
+			}
+			result.OOREvents++
+		}
+
+		nextCursor := resp.GetNextCursor()
+		if nextCursor == 0 || nextCursor == afterEventID {
+			break
+		}
+
+		afterEventID = nextCursor
+	}
+
+	return nil
+}
+
+func (r *RPCServer) materializeRecoveredOOREvent(ctx context.Context,
+	idx *indexer.Client, event *arkrpc.OORRecipientEvent,
+	handler *oor.LocalPersistenceOutboxHandler) error {
+
+	sessionHash, err := chainhash.NewHash(event.GetSessionId())
+	if err != nil {
+		return fmt.Errorf("parse OOR session id: %w", err)
+	}
+	sessionID := oor.SessionID(*sessionHash)
+
+	incoming, err := oor.IncomingTransferEventFromResponse(
+		sessionID, event.GetEventId(),
+		&arkrpc.ListOORRecipientEventsByScriptResponse{
+			Events: []*arkrpc.OORRecipientEvent{event},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("decode incoming event: %w", err)
+	}
+
+	recipients, err := oor.ExtractArkRecipients(incoming.ArkPSBT)
+	if err != nil {
+		return fmt.Errorf("extract recipients: %w", err)
+	}
+
+	metadataMatches := make(
+		[]oor.IncomingMetadataMatch, 0, len(recipients),
+	)
+	for _, recipient := range recipients {
+		if !bytes.Equal(
+			recipient.PkScript, event.GetRecipientPkScript(),
+		) {
+
+			continue
+		}
+
+		metadata, err := ResolveIncomingMetadataFromIndexerWithLimits(
+			build.ContextWithLogger(
+				ctx, r.server.subLogger(Subsystem),
+			),
+			idx,
+			sessionID,
+			recipient,
+			r.server.cfg.OORReceiveLimits(),
+		)
+		if err != nil {
+			return err
+		}
+
+		metadataMatches = append(metadataMatches,
+			oor.IncomingMetadataMatch{
+				OutputIndex: recipient.OutputIndex,
+				Metadata:    metadata,
+			},
+		)
+	}
+
+	_, err = handler.Handle(
+		ctx, sessionID, &oor.MaterializeIncomingVTXOsRequest{
+			SessionID:            sessionID,
+			ArkPSBT:              incoming.ArkPSBT,
+			FinalCheckpointPSBTs: incoming.FinalCheckpointPSBTs,
+			Recipients:           recipients,
+			MetadataMatches:      metadataMatches,
+			AncestorPackages:     incoming.AncestorPackages,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("materialize incoming event: %w", err)
+	}
+
+	return nil
+}
+
+func errorsIsNoRows(err error) bool {
+	return errors.Is(err, sql.ErrNoRows)
+}

--- a/darepod/wallet_recovery.go
+++ b/darepod/wallet_recovery.go
@@ -67,6 +67,9 @@ func (r *RPCServer) recoverWalletState(ctx context.Context, window uint32) (
 		return nil, fmt.Errorf("wallet backend not initialized")
 	}
 
+	// InitWallet stores the seed before this point, which lets the daemon
+	// start wallet-backed services on a separate goroutine. Recovery needs
+	// those services, so wait for that async startup before scanning.
 	select {
 	case <-r.server.DaemonReady():
 	case <-ctx.Done():
@@ -502,31 +505,48 @@ func (r *RPCServer) recoverOORReceiveScripts(ctx context.Context,
 			return fmt.Errorf("build OOR script %d: %w", i, err)
 		}
 
-		if _, ok := registeredScripts[string(pkScript)]; !ok {
-			continue
+		scriptPersisted := false
+		persistScript := func() error {
+			if scriptPersisted {
+				return nil
+			}
+
+			source := db.OwnedReceiveScriptSourceSync
+			err := packageStore.UpsertOwnedReceiveScript(
+				ctx, db.OwnedReceiveScriptRecord{
+					PkScript:       pkScript,
+					ClientKey:      *keyDesc,
+					OperatorPubKey: terms.PubKey,
+					ExitDelay: int64(
+						terms.VTXOExitDelay,
+					),
+					Source:     source,
+					CreatedAt:  r.server.clk.Now(),
+					LastUsedAt: fn.None[time.Time](),
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("persist OOR script %d: %w",
+					i, err)
+			}
+
+			scriptPersisted = true
+			result.OORReceiveScripts++
+
+			return nil
 		}
 
-		err = packageStore.UpsertOwnedReceiveScript(
-			ctx, db.OwnedReceiveScriptRecord{
-				PkScript:       pkScript,
-				ClientKey:      *keyDesc,
-				OperatorPubKey: terms.PubKey,
-				ExitDelay:      int64(terms.VTXOExitDelay),
-				Source:         db.OwnedReceiveScriptSourceSync,
-				CreatedAt:      r.server.clk.Now(),
-				LastUsedAt:     fn.None[time.Time](),
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("persist OOR script %d: %w", i, err)
+		if _, ok := registeredScripts[string(pkScript)]; ok {
+			if err := persistScript(); err != nil {
+				return err
+			}
 		}
-		result.OORReceiveScripts++
 
 		idx := r.server.indexer.WithSigner(
 			r.server.proofKeyBackend.ProofSigner(*keyDesc),
 		)
 		if err := r.recoverOOREventsForScript(
-			ctx, idx, pkScript, handler, result,
+			ctx, idx, pkScript, persistScript, handler, result,
 		); err != nil {
 			return fmt.Errorf("recover OOR events for key %d: %w",
 				i, err)
@@ -578,7 +598,7 @@ func (r *RPCServer) recoveryOORHandler(
 }
 
 func (r *RPCServer) recoverOOREventsForScript(ctx context.Context,
-	idx *indexer.Client, pkScript []byte,
+	idx *indexer.Client, pkScript []byte, ensureScript func() error,
 	handler *oor.LocalPersistenceOutboxHandler,
 	result *walletRecoveryResult) error {
 
@@ -594,6 +614,10 @@ func (r *RPCServer) recoverOOREventsForScript(ctx context.Context,
 		for _, event := range resp.GetEvents() {
 			if event == nil {
 				continue
+			}
+
+			if err := ensureScript(); err != nil {
+				return err
 			}
 
 			err := r.materializeRecoveredOOREvent(
@@ -647,7 +671,8 @@ func (r *RPCServer) materializeRecoveredOOREvent(ctx context.Context,
 	for _, recipient := range recipients {
 		if !bytes.Equal(
 			recipient.PkScript, event.GetRecipientPkScript(),
-		) {
+		) ||
+			recipient.OutputIndex != event.GetOutputIndex() {
 
 			continue
 		}

--- a/darepod/wallet_recovery.go
+++ b/darepod/wallet_recovery.go
@@ -34,6 +34,9 @@ import (
 const (
 	recoveryVTXOPageSize = 128
 	recoveryOORPageSize  = 128
+
+	recoveryIndexerRetryAttempts = 8
+	recoveryIndexerRetryDelay    = 150 * time.Millisecond
 )
 
 type walletRecoveryResult struct {
@@ -42,6 +45,36 @@ type walletRecoveryResult struct {
 	VTXOs             uint32
 	OORReceiveScripts uint32
 	OOREvents         uint32
+}
+
+// retryRecoveryIndexerRPC retries recovery-local indexer calls that hit the
+// operator's per-client query limiter.
+func retryRecoveryIndexerRPC(ctx context.Context, call func() error) error {
+	var err error
+	for attempt := 0; attempt < recoveryIndexerRetryAttempts; attempt++ {
+		err = call()
+		if status.Code(err) != codes.ResourceExhausted {
+			return err
+		}
+
+		if attempt == recoveryIndexerRetryAttempts-1 {
+			break
+		}
+
+		timer := time.NewTimer(recoveryIndexerRetryDelay)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+
+			return fmt.Errorf("wait for indexer retry: %w",
+				ctx.Err())
+		}
+	}
+
+	return err
 }
 
 func (r walletRecoveryResult) apply(resp *daemonrpc.InitWalletResponse) {
@@ -232,23 +265,33 @@ func (r *RPCServer) recoverIndexedVTXOs(ctx context.Context,
 		expiresAt := r.server.clk.Now().Add(
 			defaultOORReceiveScriptRegistrationTTL,
 		)
-		_, err = idx.RegisterReceiveScriptTaproot(
-			ctx, pkScript, expiresAt, "seed-recovery-vtxo",
-		)
+		err = retryRecoveryIndexerRPC(ctx, func() error {
+			_, err := idx.RegisterReceiveScriptTaproot(
+				ctx, pkScript, expiresAt, "seed-recovery-vtxo",
+			)
+
+			return err
+		})
 		if err != nil && status.Code(err) != codes.AlreadyExists {
 			return fmt.Errorf("register VTXO script %d: %w", i, err)
 		}
 
 		cursor := []byte(nil)
 		for {
-			resp, err := idx.ListVTXOsByScriptsTaproot(
-				ctx,
-				[]indexer.TaprootScriptScope{{
-					PkScript: pkScript,
-				}},
-				cursor, recoveryVTXOPageSize,
-				nil,
-			)
+			var resp *arkrpc.ListVTXOsByScriptsResponse
+			err := retryRecoveryIndexerRPC(ctx, func() error {
+				var err error
+				resp, err = idx.ListVTXOsByScriptsTaproot(
+					ctx,
+					[]indexer.TaprootScriptScope{{
+						PkScript: pkScript,
+					}},
+					cursor, recoveryVTXOPageSize,
+					nil,
+				)
+
+				return err
+			})
 			if err != nil {
 				return fmt.Errorf("list VTXOs for key %d: %w",
 					i, err)
@@ -469,7 +512,13 @@ func (r *RPCServer) recoverOORReceiveScripts(ctx context.Context,
 	terms *libtypes.OperatorTerms, window uint32,
 	result *walletRecoveryResult) error {
 
-	registered, err := r.server.indexer.ListMyReceiveScripts(ctx)
+	var registered *arkrpc.ListMyReceiveScriptsResponse
+	err := retryRecoveryIndexerRPC(ctx, func() error {
+		var err error
+		registered, err = r.server.indexer.ListMyReceiveScripts(ctx)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("list registered receive scripts: %w", err)
 	}
@@ -604,9 +653,16 @@ func (r *RPCServer) recoverOOREventsForScript(ctx context.Context,
 
 	var afterEventID uint64
 	for {
-		resp, err := idx.ListOORRecipientEventsByScriptTaproot(
-			ctx, pkScript, afterEventID, recoveryOORPageSize,
-		)
+		var resp *arkrpc.ListOORRecipientEventsByScriptResponse
+		err := retryRecoveryIndexerRPC(ctx, func() error {
+			var err error
+			resp, err = idx.ListOORRecipientEventsByScriptTaproot(
+				ctx, pkScript, afterEventID,
+				recoveryOORPageSize,
+			)
+
+			return err
+		})
 		if err != nil {
 			return err
 		}

--- a/darepod/wallet_recovery_test.go
+++ b/darepod/wallet_recovery_test.go
@@ -1,0 +1,48 @@
+package darepod
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestRetryRecoveryIndexerRPCRetriesResourceExhausted verifies seed recovery
+// backs off and retries when the operator query limiter rejects a scan request.
+func TestRetryRecoveryIndexerRPCRetriesResourceExhausted(t *testing.T) {
+	t.Parallel()
+
+	var attempts int
+	err := retryRecoveryIndexerRPC(t.Context(), func() error {
+		attempts++
+		if attempts == 1 {
+			return status.Error(
+				codes.ResourceExhausted, "rate limited",
+			)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts)
+}
+
+// TestRetryRecoveryIndexerRPCStopsOnContextCancel verifies recovery does not
+// spin forever if the restore RPC is cancelled during rate-limit backoff.
+func TestRetryRecoveryIndexerRPCStopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	var attempts int
+	err := retryRecoveryIndexerRPC(ctx, func() error {
+		attempts++
+
+		return status.Error(codes.ResourceExhausted, "rate limited")
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, attempts)
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ into specific topics below.
 | [swap_system.md](swap_system.md) | End-to-end swap walkthrough: vHTLC tree (collaborative vs. unilateral-exit leaves), receive (out-swap) and pay (in-swap) flows, the off-chain-first cancellation/timeout recovery ladder, same-Ark p2p detection, swap-server RPCs, and proof-gated indexer authorization, with mermaid diagrams |
 | [walletdk_integration.md](walletdk_integration.md) | Basic `walletdk` integration flow, startup/config examples, swap accounting, and wrapper guidance |
 | [walletdkrpc_build.md](walletdkrpc_build.md) | How to build and install the daemon and CLI with the wallet RPC subserver enabled (`walletdkrpc` + `swapruntime` tags) |
+| [seed_restore_recovery.md](seed_restore_recovery.md) | Restore a self-managed seed and recover Ark state from chain/indexer data |
 | [swap_background_execution.md](swap_background_execution.md) | Optional build-tagged daemon executor for background swap progress and daemon-backed CLI control |
 | [mailbox_architecture.md](mailbox_architecture.md) | Three-layer mailbox system: pb, rpc, conn, serverconn |
 | [mailbox_durable_actor_layer.md](mailbox_durable_actor_layer.md) | The durable mailbox and durable actor: leases, dedup, transactional outbox, DurableAsk, and the classic vs. Read/Commit (`TxBehavior`/`Exec[S]`) execution paths |

--- a/docs/seed_restore_recovery.md
+++ b/docs/seed_restore_recovery.md
@@ -1,0 +1,168 @@
+# Seed Restore Recovery
+
+This guide covers restoring a self-managed `darepod` wallet from its mnemonic
+and asking the daemon to recover Ark state. It applies to embedded wallet
+backends such as `lwwallet` and `btcwallet`.
+
+## What Recovery Does
+
+`darepocli create --recover` imports an existing mnemonic into a fresh daemon
+data directory. With Ark-state recovery enabled, the daemon scans deterministic
+keys and reconstructs local wallet state from the chain, the backing wallet,
+and the operator indexer.
+
+The scan covers three key families:
+
+- Boarding keys: rebuilds boarding scripts, imports them into the backing
+  wallet, persists missing boarding addresses, and lets wallet balance
+  discovery find confirmed boarding UTXOs.
+- VTXO owner keys: rebuilds standard VTXO owner scripts and queries indexed
+  VTXOs from the operator indexer.
+- Out-of-round receive keys: rebuilds receive scripts, matches owned scripts
+  registered with the indexer, and fetches recipient events for those scripts.
+
+The recovery response reports how much state was materialized:
+
+- `recovery_ran`
+- `recovered_boarding_addresses`
+- `recovered_boarding_utxos`
+- `recovered_vtxos`
+- `recovered_oor_receive_scripts`
+- `recovered_oor_events`
+
+Recovery is idempotent. Re-running it against already persisted scripts or
+VTXOs should not fail because the state already exists.
+
+## Before You Restore
+
+Stop the original daemon before restoring the same mnemonic into another
+daemon. The seed controls the wallet identity used for mailbox and indexer
+requests. Running two daemons with the same seed at the same time can make
+responses arrive at the wrong process.
+
+Use a fresh daemon data directory for the restored wallet. The restore password
+protects the local seed file in that new directory; it does not have to match
+the password used by the original wallet. The optional aezeed seed passphrase,
+if one was used when the wallet was created, must match.
+
+Pick a recovery window large enough to include every key index you care about.
+`--recovery-window=N` scans indexes `0..N-1` in each recovery family. A value of
+`0` uses the daemon's configured `wallet.recoverywindow`.
+
+## CLI Restore
+
+Create a wallet and record the mnemonic:
+
+```sh
+export DAREPOD_WALLET_PASSWORD='replace-with-a-local-wallet-password'
+
+darepocli create --print-mnemonic-json > create.json
+jq -r '.mnemonic[]' create.json > wallet.mnemonic
+chmod 600 wallet.mnemonic
+```
+
+Generate receive surfaces as usual:
+
+```sh
+darepocli recv --onchain
+darepocli recv --offchain --amt 10000 --memo 'restore smoke'
+```
+
+After stopping the original daemon, start a fresh daemon with an empty data
+directory and restore the seed:
+
+```sh
+export DAREPOD_WALLET_PASSWORD='replace-with-a-new-local-wallet-password'
+
+darepocli create --recover \
+  --mnemonic-file wallet.mnemonic \
+  --recovery-window 100
+```
+
+Inspect the response counters. Then check the public wallet surface:
+
+```sh
+darepocli balance
+darepocli vtxos list
+```
+
+For unboarded boarding funds, top-level `darepocli balance` reports the amount
+under `pending_in_sat`. Once funds are boarded into VTXOs, they contribute to
+`confirmed_sat`.
+
+## Local arktest Smoke
+
+The root `darepo` repository contains the `arktest` manual harness. Use it when
+this client repo is checked out as the root repo's `client/` submodule.
+
+Build the manual harness and CLI binaries from the root repo:
+
+```sh
+make arktest
+```
+
+Start an embedded-wallet topology where `darepocli create` initializes the
+wallet:
+
+```sh
+./arktest --datadir /tmp/arktest-restore start \
+  --client-wallet=lwwallet \
+  --manual-wallet \
+  --client alice
+```
+
+In another terminal, load the generated aliases and create the source wallet:
+
+```sh
+eval "$(./arktest --datadir /tmp/arktest-restore aliases)"
+export DAREPOD_WALLET_PASSWORD=itest-wallet-password
+
+alice-cli create --print-mnemonic-json > alice-create.json
+jq -r '.mnemonic[]' alice-create.json > alice.mnemonic
+
+addr="$(alice-cli recv --onchain | jq -r '.onchain_address')"
+./arktest --datadir /tmp/arktest-restore faucet "$addr" 100000
+alice-cli balance
+```
+
+Do not restore `alice.mnemonic` into another live client in this same `arktest`
+process. `arktest start` runs client daemons in-process and has no shell command
+to stop only one client while keeping the chain, operator, and indexer alive.
+`arktest stop` stops the whole topology, which is fine for cleanup but does not
+leave the same regtest chain/indexer available for a manual restore.
+
+Use the root integration test for the full local CLI restore path. It keeps one
+operator/indexer topology alive, stops the source daemon in-process, restores the
+same mnemonic into fresh daemon data directories, and asserts both a too-small
+and a sufficient recovery window:
+
+```sh
+ARK_ITEST_CLIENT_WALLET=lwwallet \
+go test -tags='itest walletdkrpc swapruntime dev nolog' -v ./itest \
+  -run '^TestBoardingIntegrationRecoveryCLIFromSeedRestoresBoardingFunds$' \
+  -count=1 -timeout=60m
+```
+
+The test must be built with the same daemon-side `walletdkrpc` tag that the
+top-level `darepocli create`, `recv`, and `balance` commands require. Without
+that tag, the CLI can connect to the daemon but the wallet service returns:
+
+```sh
+daemon was not built with -tags walletdkrpc
+```
+
+## Troubleshooting
+
+`--recover requires --mnemonic-file` means the CLI rejected a restore command
+before it contacted the daemon. Supply a whitespace-separated 24-word mnemonic
+file.
+
+If recovery succeeds but funds are missing, first raise `--recovery-window`.
+For example, a window of `1` only scans index `0`.
+
+If restore hangs or mailbox/indexer responses look inconsistent, make sure no
+other daemon is running with the same seed.
+
+If `darepocli balance` shows zero after recovering unboarded boarding funds,
+check whether the funding transaction has enough confirmations for the
+operator's configured minimum confirmation count.

--- a/rpc/walletdkrpc/wallet.pb.go
+++ b/rpc/walletdkrpc/wallet.pb.go
@@ -542,9 +542,16 @@ type CreateRequest struct {
 	// "generate a fresh seed"; non-empty means "recover from this
 	// mnemonic". When non-empty the response echoes the same mnemonic
 	// back unchanged.
-	Mnemonic      []string `protobuf:"bytes,3,rep,name=mnemonic,proto3" json:"mnemonic,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Mnemonic []string `protobuf:"bytes,3,rep,name=mnemonic,proto3" json:"mnemonic,omitempty"`
+	// recover_state asks the daemon to scan deterministic Ark wallet keys
+	// after importing mnemonic and rebuild local Ark state from chain and
+	// indexer data.
+	RecoverState bool `protobuf:"varint,4,opt,name=recover_state,json=recoverState,proto3" json:"recover_state,omitempty"`
+	// recovery_window is the number of key indexes to scan per recovery key
+	// family. Zero uses the daemon wallet.recoverywindow config value.
+	RecoveryWindow uint32 `protobuf:"varint,5,opt,name=recovery_window,json=recoveryWindow,proto3" json:"recovery_window,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *CreateRequest) Reset() {
@@ -598,6 +605,20 @@ func (x *CreateRequest) GetMnemonic() []string {
 	return nil
 }
 
+func (x *CreateRequest) GetRecoverState() bool {
+	if x != nil {
+		return x.RecoverState
+	}
+	return false
+}
+
+func (x *CreateRequest) GetRecoveryWindow() uint32 {
+	if x != nil {
+		return x.RecoveryWindow
+	}
+	return 0
+}
+
 type CreateResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// mnemonic is the 24-word aezeed mnemonic for the wallet. For fresh
@@ -610,8 +631,25 @@ type CreateResponse struct {
 	// identity_pubkey is the hex-encoded daemon wallet identity public
 	// key derived from the newly created wallet.
 	IdentityPubkey string `protobuf:"bytes,2,opt,name=identity_pubkey,json=identityPubkey,proto3" json:"identity_pubkey,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// recovery_ran is true when Create attempted Ark-state recovery.
+	RecoveryRan bool `protobuf:"varint,3,opt,name=recovery_ran,json=recoveryRan,proto3" json:"recovery_ran,omitempty"`
+	// recovered_boarding_addresses is the number of boarding addresses
+	// rebuilt and persisted from deterministic keys.
+	RecoveredBoardingAddresses uint32 `protobuf:"varint,4,opt,name=recovered_boarding_addresses,json=recoveredBoardingAddresses,proto3" json:"recovered_boarding_addresses,omitempty"`
+	// recovered_boarding_utxos is the number of confirmed wallet UTXOs found
+	// at recovered boarding addresses during the recovery scan.
+	RecoveredBoardingUtxos uint32 `protobuf:"varint,5,opt,name=recovered_boarding_utxos,json=recoveredBoardingUtxos,proto3" json:"recovered_boarding_utxos,omitempty"`
+	// recovered_vtxos is the number of indexed VTXOs restored into local
+	// wallet state.
+	RecoveredVtxos uint32 `protobuf:"varint,6,opt,name=recovered_vtxos,json=recoveredVtxos,proto3" json:"recovered_vtxos,omitempty"`
+	// recovered_oor_receive_scripts is the number of registered OOR receive
+	// scripts matched and restored into local ownership metadata.
+	RecoveredOorReceiveScripts uint32 `protobuf:"varint,7,opt,name=recovered_oor_receive_scripts,json=recoveredOorReceiveScripts,proto3" json:"recovered_oor_receive_scripts,omitempty"`
+	// recovered_oor_events is the number of OOR recipient events processed
+	// during recovery.
+	RecoveredOorEvents uint32 `protobuf:"varint,8,opt,name=recovered_oor_events,json=recoveredOorEvents,proto3" json:"recovered_oor_events,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *CreateResponse) Reset() {
@@ -656,6 +694,48 @@ func (x *CreateResponse) GetIdentityPubkey() string {
 		return x.IdentityPubkey
 	}
 	return ""
+}
+
+func (x *CreateResponse) GetRecoveryRan() bool {
+	if x != nil {
+		return x.RecoveryRan
+	}
+	return false
+}
+
+func (x *CreateResponse) GetRecoveredBoardingAddresses() uint32 {
+	if x != nil {
+		return x.RecoveredBoardingAddresses
+	}
+	return 0
+}
+
+func (x *CreateResponse) GetRecoveredBoardingUtxos() uint32 {
+	if x != nil {
+		return x.RecoveredBoardingUtxos
+	}
+	return 0
+}
+
+func (x *CreateResponse) GetRecoveredVtxos() uint32 {
+	if x != nil {
+		return x.RecoveredVtxos
+	}
+	return 0
+}
+
+func (x *CreateResponse) GetRecoveredOorReceiveScripts() uint32 {
+	if x != nil {
+		return x.RecoveredOorReceiveScripts
+	}
+	return 0
+}
+
+func (x *CreateResponse) GetRecoveredOorEvents() uint32 {
+	if x != nil {
+		return x.RecoveredOorEvents
+	}
+	return 0
 }
 
 type UnlockRequest struct {
@@ -3709,14 +3789,22 @@ var File_wallet_proto protoreflect.FileDescriptor
 
 const file_wallet_proto_rawDesc = "" +
 	"\n" +
-	"\fwallet.proto\x12\vwalletdkrpc\"}\n" +
+	"\fwallet.proto\x12\vwalletdkrpc\"\xcb\x01\n" +
 	"\rCreateRequest\x12'\n" +
 	"\x0fwallet_password\x18\x01 \x01(\fR\x0ewalletPassword\x12'\n" +
 	"\x0fseed_passphrase\x18\x02 \x01(\fR\x0eseedPassphrase\x12\x1a\n" +
-	"\bmnemonic\x18\x03 \x03(\tR\bmnemonic\"U\n" +
+	"\bmnemonic\x18\x03 \x03(\tR\bmnemonic\x12#\n" +
+	"\rrecover_state\x18\x04 \x01(\bR\frecoverState\x12'\n" +
+	"\x0frecovery_window\x18\x05 \x01(\rR\x0erecoveryWindow\"\x92\x03\n" +
 	"\x0eCreateResponse\x12\x1a\n" +
 	"\bmnemonic\x18\x01 \x03(\tR\bmnemonic\x12'\n" +
-	"\x0fidentity_pubkey\x18\x02 \x01(\tR\x0eidentityPubkey\"8\n" +
+	"\x0fidentity_pubkey\x18\x02 \x01(\tR\x0eidentityPubkey\x12!\n" +
+	"\frecovery_ran\x18\x03 \x01(\bR\vrecoveryRan\x12@\n" +
+	"\x1crecovered_boarding_addresses\x18\x04 \x01(\rR\x1arecoveredBoardingAddresses\x128\n" +
+	"\x18recovered_boarding_utxos\x18\x05 \x01(\rR\x16recoveredBoardingUtxos\x12'\n" +
+	"\x0frecovered_vtxos\x18\x06 \x01(\rR\x0erecoveredVtxos\x12A\n" +
+	"\x1drecovered_oor_receive_scripts\x18\a \x01(\rR\x1arecoveredOorReceiveScripts\x120\n" +
+	"\x14recovered_oor_events\x18\b \x01(\rR\x12recoveredOorEvents\"8\n" +
 	"\rUnlockRequest\x12'\n" +
 	"\x0fwallet_password\x18\x01 \x01(\fR\x0ewalletPassword\"9\n" +
 	"\x0eUnlockResponse\x12'\n" +

--- a/rpc/walletdkrpc/wallet.proto
+++ b/rpc/walletdkrpc/wallet.proto
@@ -186,6 +186,15 @@ message CreateRequest {
     // mnemonic". When non-empty the response echoes the same mnemonic
     // back unchanged.
     repeated string mnemonic = 3;
+
+    // recover_state asks the daemon to scan deterministic Ark wallet keys
+    // after importing mnemonic and rebuild local Ark state from chain and
+    // indexer data.
+    bool recover_state = 4;
+
+    // recovery_window is the number of key indexes to scan per recovery key
+    // family. Zero uses the daemon wallet.recoverywindow config value.
+    uint32 recovery_window = 5;
 }
 
 message CreateResponse {
@@ -200,6 +209,29 @@ message CreateResponse {
     // identity_pubkey is the hex-encoded daemon wallet identity public
     // key derived from the newly created wallet.
     string identity_pubkey = 2;
+
+    // recovery_ran is true when Create attempted Ark-state recovery.
+    bool recovery_ran = 3;
+
+    // recovered_boarding_addresses is the number of boarding addresses
+    // rebuilt and persisted from deterministic keys.
+    uint32 recovered_boarding_addresses = 4;
+
+    // recovered_boarding_utxos is the number of confirmed wallet UTXOs found
+    // at recovered boarding addresses during the recovery scan.
+    uint32 recovered_boarding_utxos = 5;
+
+    // recovered_vtxos is the number of indexed VTXOs restored into local
+    // wallet state.
+    uint32 recovered_vtxos = 6;
+
+    // recovered_oor_receive_scripts is the number of registered OOR receive
+    // scripts matched and restored into local ownership metadata.
+    uint32 recovered_oor_receive_scripts = 7;
+
+    // recovered_oor_events is the number of OOR recipient events processed
+    // during recovery.
+    uint32 recovered_oor_events = 8;
 }
 
 message UnlockRequest {

--- a/sdk/walletdk/client.go
+++ b/sdk/walletdk/client.go
@@ -196,6 +196,8 @@ func (c *Client) CreateWallet(ctx context.Context, req CreateWalletRequest) (
 			Mnemonic:       mnemonic,
 			SeedPassphrase: bytes.Clone(req.SeedPassphrase),
 			WalletPassword: bytes.Clone(req.WalletPassword),
+			RecoverState:   req.RecoverState,
+			RecoveryWindow: req.RecoveryWindow,
 		},
 	)
 	if err != nil {
@@ -206,6 +208,15 @@ func (c *Client) CreateWallet(ctx context.Context, req CreateWalletRequest) (
 		Mnemonic:       mnemonic,
 		EncipheredSeed: encipheredSeed,
 		IdentityPubKey: initResp.GetIdentityPubkey(),
+		RecoveryRan:    initResp.GetRecoveryRan(),
+		RecoveredBoardingAddresses: initResp.
+			GetRecoveredBoardingAddresses(),
+		RecoveredBoardingUTXOs: initResp.
+			GetRecoveredBoardingUtxos(),
+		RecoveredVTXOs: initResp.GetRecoveredVtxos(),
+		RecoveredOORReceiveScripts: initResp.
+			GetRecoveredOorReceiveScripts(),
+		RecoveredOORRecipientEvents: initResp.GetRecoveredOorEvents(),
 	}, nil
 }
 

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -100,7 +100,8 @@ type CreateWalletRequest struct {
 	RecoveryWindow uint32
 }
 
-// CreateWalletResult returns the seed words and daemon identity.
+// CreateWalletResult returns the seed words, daemon identity, and optional
+// recovery counters.
 type CreateWalletResult struct {
 	Mnemonic                    []string
 	EncipheredSeed              []byte

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -96,13 +96,21 @@ type CreateWalletRequest struct {
 	Mnemonic       []string
 	SeedPassphrase []byte
 	WalletPassword []byte
+	RecoverState   bool
+	RecoveryWindow uint32
 }
 
 // CreateWalletResult returns the seed words and daemon identity.
 type CreateWalletResult struct {
-	Mnemonic       []string
-	EncipheredSeed []byte
-	IdentityPubKey string
+	Mnemonic                    []string
+	EncipheredSeed              []byte
+	IdentityPubKey              string
+	RecoveryRan                 bool
+	RecoveredBoardingAddresses  uint32
+	RecoveredBoardingUTXOs      uint32
+	RecoveredVTXOs              uint32
+	RecoveredOORReceiveScripts  uint32
+	RecoveredOORRecipientEvents uint32
 }
 
 // UnlockWalletRequest unlocks an existing embedded daemon wallet.

--- a/swapwallet/admin.go
+++ b/swapwallet/admin.go
@@ -65,6 +65,8 @@ func (s *Service) create(ctx context.Context, req *walletdkrpc.CreateRequest) (
 			Mnemonic:       mnemonic,
 			WalletPassword: req.GetWalletPassword(),
 			SeedPassphrase: req.GetSeedPassphrase(),
+			RecoverState:   req.GetRecoverState(),
+			RecoveryWindow: req.GetRecoveryWindow(),
 		},
 	)
 	if err != nil {
@@ -73,8 +75,14 @@ func (s *Service) create(ctx context.Context, req *walletdkrpc.CreateRequest) (
 	}
 
 	return &walletdkrpc.CreateResponse{
-		Mnemonic:       mnemonic,
-		IdentityPubkey: initResp.GetIdentityPubkey(),
+		Mnemonic:                   mnemonic,
+		IdentityPubkey:             initResp.GetIdentityPubkey(),
+		RecoveryRan:                initResp.GetRecoveryRan(),
+		RecoveredBoardingAddresses: initResp.GetRecoveredBoardingAddresses(),
+		RecoveredBoardingUtxos:     initResp.GetRecoveredBoardingUtxos(),
+		RecoveredVtxos:             initResp.GetRecoveredVtxos(),
+		RecoveredOorReceiveScripts: initResp.GetRecoveredOorReceiveScripts(),
+		RecoveredOorEvents:         initResp.GetRecoveredOorEvents(),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- add opt-in Ark-state recovery to seed restore via `recover_state` and `recovery_window` on daemon RPC and walletdk create
- scan deterministic boarding, VTXO-owner, and OOR receive key families during `InitWallet` restore
- rebuild local boarding metadata, recover indexed VTXOs, and materialize OOR recipient events through the existing storage paths
- add `darepocli create --recover --mnemonic-file <path> --recovery-window <n>` while keeping hidden underscore aliases for compatibility

## Review follow-up
- OOR recovery now queries every derived receive key in the recovery window, even if the indexer registration has expired
- OOR event materialization matches both recipient script and output index
- recovered OOR script metadata is persisted before event materialization, but unused expired keys are not written locally
- the CLI alias reader uses one generic helper, and the SDK create result comment mentions recovery counters
- recovery documents its dependency on async wallet-backed service startup before waiting on `DaemonReady()`

## Paired root coverage
- Root itests live in lightninglabs/darepo#545
- The root branch updates the client submodule to this PR and adds recovery tests for boarding funds, indexed VTXOs, and offline OOR receives

## Tests
- `make fmt-changed`
- `make lint-changed-local`
- `go test ./darepod ./sdk/walletdk ./cmd/darepocli/darepoclicommands -run TestNonExistent -count=0`
- `go test -tags='walletdkrpc swapruntime' ./swapwallet -run TestNonExistent -count=0`
- from the paired root branch: `make itest backend=lwwallet icase='TestOORIntegrationRecoveryFromSeedRestoresOfflineReceive'`
- earlier root coverage on this PR stack: boarding recovery, indexed-VTXO recovery, and shard coverage itests
