### PR TITLE
round: Bind VTXO trees to the commitment tx before signing

### DIFF
--- a/round/actor.go
+++ b/round/actor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lightninglabs/darepo-client/ledger"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/serverconn"
 	"github.com/lightninglabs/darepo-client/timeout"
@@ -911,9 +912,11 @@ func forfeitsMatch(forfeits []types.ForfeitRequest,
 
 // registerCommitmentConfirmation registers for confirmation monitoring of a
 // commitment transaction with the chainsource actor. The commitmentTx is used
-// to extract the pkScript for LND's confirmation tracking.
+// to extract the pkScript for LND's confirmation tracking, and vtxoTrees (the
+// round's validated VTXO trees, possibly nil) selects which output to watch.
 func (a *RoundClientActor) registerCommitmentConfirmation(ctx context.Context,
-	txid chainhash.Hash, commitmentTx fn.Option[*psbt.Packet]) {
+	txid chainhash.Hash, commitmentTx fn.Option[*psbt.Packet],
+	vtxoTrees map[int]*tree.Tree) {
 
 	callerID := fmt.Sprintf("commitment-tx-%s", txid.String())
 
@@ -929,12 +932,16 @@ func (a *RoundClientActor) registerCommitmentConfirmation(ctx context.Context,
 		},
 	)
 
-	// Extract pkScript from the commitment transaction's first output.
-	// LND requires a pkScript for confirmation tracking.
+	// Extract the pkScript LND needs for confirmation tracking. Watch the
+	// validated batch output (the output that receives this client's
+	// funds) rather than assuming output 0; confirmationWatchScript falls
+	// back to output 0 when the round carries no VTXO trees.
 	var pkScript []byte
 	commitmentTx.WhenSome(func(packet *psbt.Packet) {
-		if packet.UnsignedTx != nil && len(packet.UnsignedTx.TxOut) > 0 {
-			pkScript = packet.UnsignedTx.TxOut[0].PkScript
+		if packet.UnsignedTx != nil {
+			pkScript = confirmationWatchScript(
+				packet.UnsignedTx, vtxoTrees,
+			)
 		}
 	})
 
@@ -1164,6 +1171,7 @@ func (a *RoundClientActor) Start(ctx context.Context) error {
 			a.commitmentTxIndex[roundFSM.TxID] = keyStr
 			a.registerCommitmentConfirmation(
 				ctx, roundFSM.TxID, round.CommitmentTx,
+				round.VTXOTreePaths.UnwrapOr(nil),
 			)
 
 			a.log.InfoS(ctx, "Resumed round awaiting confirmation",
@@ -2331,6 +2339,7 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 			a.commitmentTxIndex[txid] = keyStr
 			a.registerCommitmentConfirmation(
 				ctx, txid, roundFSM.CommitmentTx,
+				inputSigState.VTXOTreePaths,
 			)
 
 			a.log.InfoS(ctx, "Round checkpoint processed",

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -781,55 +781,144 @@ func (h *boardingTestHarness) newTestVTXOTreeForIntents(
 	return vtxtTree
 }
 
-// newCommitmentTxBuiltEvent creates a CommitmentTxBuilt event simulating what
-// the server sends after building the commitment transaction with all boarding
-// inputs and the batch VTXT tree output. The transaction is returned as a PSBT
-// with WitnessUtxo populated for all inputs, which is required for correct
-// Taproot sighash computation.
-func (h *boardingTestHarness) newCommitmentTxBuiltEvent(roundID RoundID,
-	intents []BoardingIntent, vtxtTree *tree.Tree) *CommitmentTxBuilt {
+// leafDescriptorsFromTree reconstructs the leaf descriptors of a VTXO tree
+// from its leaf nodes. bindTreeToCommitment uses it to rebuild a tree rooted
+// at a different batch outpoint: each leaf's non-anchor output supplies the
+// script and amount, and the single non-operator cosigner is the leaf owner
+// (signing) key.
+func (h *boardingTestHarness) leafDescriptorsFromTree(
+	t *tree.Tree) []tree.LeafDescriptor {
 
 	h.t.Helper()
 
-	// Build the unsigned transaction.
+	leafNodes := t.Root.GetLeafNodes()
+	leaves := make([]tree.LeafDescriptor, 0, len(leafNodes))
+	for _, leaf := range leafNodes {
+		require.GreaterOrEqual(h.t, len(leaf.Outputs), 1)
+		out := leaf.Outputs[0]
+
+		var coSigner *btcec.PublicKey
+		for _, cs := range leaf.CoSigners {
+			if !cs.IsEqual(h.operatorPubKey) {
+				coSigner = cs
+
+				break
+			}
+		}
+		require.NotNil(
+			h.t, coSigner, "leaf has no non-operator cosigner",
+		)
+
+		leaves = append(leaves, tree.LeafDescriptor{
+			PkScript:    out.PkScript,
+			Amount:      btcutil.Amount(out.Value),
+			CoSignerKey: coSigner,
+		})
+	}
+
+	return leaves
+}
+
+// bindTreeToCommitment makes vtxtTree commitment-bound, mirroring how the
+// honest operator constructs a round: it builds a commitment tx over the given
+// boarding intents whose first output is the tree's batch output (the canonical
+// tree-root taproot script plus the summed leaf value), then rebuilds vtxtTree
+// in place so its root spends that exact output. After it returns, the returned
+// PSBT and the (now bound) vtxtTree satisfy validateVTXOTreeBinding. The
+// returned PSBT carries WitnessUtxo for every input, which is required for
+// correct Taproot sighash computation in downstream signing fixtures.
+//
+// Replacing the batch outpoint changes the root tx hash and cascades to every
+// child input, so the tree is rebuilt from its leaves rather than patched in
+// place — the caller's *tree.Tree pointer is updated via assignment so events
+// generated afterwards (nonces, signatures) use the bound tree.
+//
+// extraOutputs are appended after the batch output and the anchor (e.g. leave
+// outputs). They must be supplied here rather than appended to the returned
+// PSBT, because appending after the fact would change the commitment txid and
+// break the binding the tree was just rebuilt against.
+func (h *boardingTestHarness) bindTreeToCommitment(intents []BoardingIntent,
+	vtxtTree *tree.Tree, extraOutputs ...*wire.TxOut) *psbt.Packet {
+
+	h.t.Helper()
+
+	// The batch output script depends only on the tree's cosigner set and
+	// sweep root, not on the outpoint, so it can be computed before the
+	// commitment txid is known. Recompute it exactly as the binding
+	// validation does.
+	finalKey, err := tree.ComputeFinalKey(
+		vtxtTree.Root.CoSigners, vtxtTree.SweepTapscriptRoot,
+	)
+	require.NoError(h.t, err)
+	rootScript, err := txscript.PayToTaprootScript(finalKey)
+	require.NoError(h.t, err)
+	batchOutput := &wire.TxOut{
+		Value:    vtxtTree.BatchOutput.Value,
+		PkScript: rootScript,
+	}
+
+	// Build the unsigned commitment tx: boarding inputs, the batch output
+	// at index 0, and the ephemeral anchor.
 	tx := wire.NewMsgTx(3)
 	for _, intent := range intents {
 		tx.AddTxIn(&wire.TxIn{
 			PreviousOutPoint: intent.Outpoint,
 		})
 	}
-
-	tx.AddTxOut(vtxtTree.BatchOutput)
-
+	tx.AddTxOut(batchOutput)
 	tx.AddTxOut(&wire.TxOut{
 		Value:    0,
 		PkScript: []byte{txscript.OP_TRUE, txscript.OP_RETURN},
 	})
+	for _, out := range extraOutputs {
+		tx.AddTxOut(out)
+	}
 
-	// Create PSBT inputs with WitnessUtxo for each boarding input.
-	pInputs := make([]psbt.PInput, len(intents))
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(h.t, err)
 	for i, intent := range intents {
 		addr := intent.Address.Address
-		pkScript := addr.ScriptAddress()
-		amt := intent.ChainInfo.Amount
-
-		pInputs[i] = psbt.PInput{
+		packet.Inputs[i] = psbt.PInput{
 			WitnessUtxo: &wire.TxOut{
-				Value:    int64(amt),
-				PkScript: pkScript,
+				Value:    int64(intent.ChainInfo.Amount),
+				PkScript: addr.ScriptAddress(),
 			},
 		}
 	}
 
-	// Create PSBT outputs (empty for now).
-	pOutputs := make([]psbt.POutput, len(tx.TxOut))
-
-	packet, err := psbt.NewFromUnsignedTx(tx)
+	// Rebuild the tree rooted at the real commitment output and adopt it
+	// into the caller's pointer.
+	txid := tx.TxHash()
+	leaves := h.leafDescriptorsFromTree(vtxtTree)
+	rebuilt, err := tree.NewTree(
+		wire.OutPoint{
+			Hash:  txid,
+			Index: 0,
+		},
+		batchOutput,
+		leaves,
+		h.operatorPubKey,
+		vtxtTree.SweepTapscriptRoot,
+		2,
+	)
 	require.NoError(h.t, err)
+	*vtxtTree = *rebuilt
 
-	// Populate the inputs with WitnessUtxo.
-	packet.Inputs = pInputs
-	packet.Outputs = pOutputs
+	return packet
+}
+
+// newCommitmentTxBuiltEvent creates a CommitmentTxBuilt event simulating what
+// the server sends after building the commitment transaction with all boarding
+// inputs and the batch VTXT tree output. The transaction is returned as a PSBT
+// with WitnessUtxo populated for all inputs, which is required for correct
+// Taproot sighash computation. The tree is bound to the commitment tx so it
+// passes the round's VTXO-tree commitment-binding validation.
+func (h *boardingTestHarness) newCommitmentTxBuiltEvent(roundID RoundID,
+	intents []BoardingIntent, vtxtTree *tree.Tree) *CommitmentTxBuilt {
+
+	h.t.Helper()
+
+	packet := h.bindTreeToCommitment(intents, vtxtTree)
 
 	return &CommitmentTxBuilt{
 		RoundID: roundID,
@@ -2108,41 +2197,6 @@ func (h *boardingTestHarness) forfeitScript() []byte {
 	require.NoError(h.t, err)
 
 	return script
-}
-
-// newTestCommitmentTxWithInputs creates a test commitment tx with the
-// specified number of inputs. Used for testing refresh-only rounds where there
-// are no boarding inputs.
-func (h *boardingTestHarness) newTestCommitmentTxWithInputs(
-	numInputs int) *psbt.Packet {
-
-	h.t.Helper()
-
-	tx := wire.NewMsgTx(3)
-
-	// Add the specified number of inputs.
-	for i := 0; i < numInputs; i++ {
-		tx.AddTxIn(&wire.TxIn{
-			PreviousOutPoint: h.newTestOutpoint(),
-		})
-	}
-
-	// Add a standard output.
-	tx.AddTxOut(&wire.TxOut{
-		Value:    100000,
-		PkScript: make([]byte, 34),
-	})
-
-	// Add OP_RETURN output.
-	tx.AddTxOut(&wire.TxOut{
-		Value:    0,
-		PkScript: []byte{txscript.OP_TRUE, txscript.OP_RETURN},
-	})
-
-	packet, err := psbt.NewFromUnsignedTx(tx)
-	require.NoError(h.t, err)
-
-	return packet
 }
 
 // newMinimalVTXOTree creates a minimal valid VTXO tree for testing. This is

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -2374,6 +2374,42 @@ func (s *ForfeitSignaturesCollectingState) finishForfeitCollection(
 	}, nil
 }
 
+// confirmationWatchScript returns the commitment-tx output script the client
+// asks the chain backend to watch for round confirmation. It prefers the
+// lowest VTXO batch-output index: every VTXOTreePaths key has been proven by
+// validateVTXOTreeBinding to equal its tree's BatchOutpoint.Index and to be in
+// range, so watching that output tracks the output that actually receives the
+// client's funds rather than assuming output 0. It falls back to the first
+// output when the round carries no VTXO trees (refresh-less / harness paths),
+// and returns nil only when the tx has no outputs. Confirmation detection is
+// by txid; the script matters for script-filtering backends (e.g. Neutrino).
+func confirmationWatchScript(commitmentTx *wire.MsgTx,
+	vtxoTrees map[int]*tree.Tree) []byte {
+
+	if commitmentTx == nil || len(commitmentTx.TxOut) == 0 {
+		return nil
+	}
+
+	idx := 0
+	if len(vtxoTrees) > 0 {
+		idx = -1
+		for k := range vtxoTrees {
+			if idx == -1 || k < idx {
+				idx = k
+			}
+		}
+	}
+
+	// Guard the index even though binding already proved it in range, so a
+	// future caller that reaches here on an unvalidated path degrades to
+	// watching output 0 rather than panicking.
+	if idx < 0 || idx >= len(commitmentTx.TxOut) {
+		return commitmentTx.TxOut[0].PkScript
+	}
+
+	return commitmentTx.TxOut[idx].PkScript
+}
+
 func (s *ForfeitSignaturesCollectingState) forfeitCollectionOutbox(
 	env *ClientEnvironment,
 	forfeitTxs map[wire.OutPoint]*types.ForfeitTxSig,
@@ -2383,10 +2419,9 @@ func (s *ForfeitSignaturesCollectingState) forfeitCollectionOutbox(
 	txid := s.CommitmentTx.UnsignedTx.TxHash()
 	callerID := fmt.Sprintf("commitment-%s", txid.String())
 
-	var pkScript []byte
-	if len(s.CommitmentTx.UnsignedTx.TxOut) > 0 {
-		pkScript = s.CommitmentTx.UnsignedTx.TxOut[0].PkScript
-	}
+	pkScript := confirmationWatchScript(
+		s.CommitmentTx.UnsignedTx, s.VTXOTreePaths,
+	)
 
 	outboxMsgs := []ClientOutMsg{
 		&CancelTimeoutReq{
@@ -2724,13 +2759,11 @@ func (s *PartialSigsSentState) ProcessEvent(ctx context.Context,
 		txid := s.CommitmentTx.UnsignedTx.TxHash()
 		callerID := fmt.Sprintf("commitment-%s", txid.String())
 
-		// Get pkScript from the first output for LND confirmation
-		// tracking.
+		// Watch the validated batch output (the output that receives
+		// this client's funds) for confirmation tracking, falling back
+		// to output 0 for rounds with no VTXO trees.
 		commitTx := s.CommitmentTx.UnsignedTx
-		var pkScript []byte
-		if len(commitTx.TxOut) > 0 {
-			pkScript = commitTx.TxOut[0].PkScript
-		}
+		pkScript := confirmationWatchScript(commitTx, s.VTXOTreePaths)
 
 		env.Log.InfoS(ctx, "Building RegisterConfirmationRequest",
 			slog.String("round_id", s.RoundID.String()),

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1750,6 +1750,38 @@ func (s *CommitmentTxReceivedState) ProcessEvent(ctx context.Context,
 			)
 		}
 
+		// Before trusting any tree's contents, prove that each
+		// operator-supplied VTXO tree is rooted in this round's
+		// commitment tx. The per-VTXO ValidatePath check below only
+		// proves internal self-consistency; without this binding a
+		// self-consistent tree rooted at the wrong commitment output
+		// would be co-signed, after which the client's new VTXOs are
+		// unrecoverable (darepo-client#680).
+		if err := validateVTXOTreeBinding(
+			s.CommitmentTx.UnsignedTx, s.VTXOTreePaths,
+		); err != nil {
+
+			env.Log.WarnS(
+				ctx,
+				"VTXO tree commitment binding failed",
+				err,
+				slog.String("round_id", s.RoundID.String()),
+			)
+
+			// The binding error is surfaced through the failed
+			// state, not raised as a Go error. A mis-rooted tree
+			// is a structural defect of the round, not a transient
+			// condition, so the failure is non-recoverable.
+			return &ClientStateTransition{
+				NextState: &ClientFailedState{
+					Reason: "VTXO tree commitment " +
+						"binding failed",
+					Error:       err,
+					Recoverable: false,
+				},
+			}, nil
+		}
+
 		clientTrees := make(map[SignerKey]*tree.Tree)
 
 		// Next, we'll make sure that each of the VTXO requests that we
@@ -3181,6 +3213,137 @@ func connectorLeafOutput(leaf *tree.Node) (*wire.TxOut, error) {
 	}
 
 	return found, nil
+}
+
+// validateVTXOTreeBinding proves that every operator-supplied VTXO tree is
+// rooted in this round's commitment tx. Internal tree self-consistency is not
+// enough: a tree's BatchOutpoint and BatchOutput come from the same untrusted
+// source as the rest of the tree, so a self-consistent tree rooted at the
+// wrong commitment output can pass ValidatePath/ValidateAnchors and still be
+// co-signed. Once the commitment tx confirms, such a tree does not spend the
+// real batch output, so the client's new VTXOs (whose outpoints are derived
+// from the tree root) are unrecoverable. This is the VTXO-tree counterpart to
+// validateConnectorAncestry; together they restore round atomicity
+// (darepo-client#680, companion to #681).
+//
+// For each (outputIdx, tree) pair it asserts that the tree's BatchOutpoint
+// names this commitment tx, that outputIdx agrees with BatchOutpoint.Index,
+// that the index is in range, that the committed output byte-matches the
+// tree's BatchOutput, and that the committed script equals the taproot script
+// recomputed from the tree root's cosigner set and sweep tapscript root (so a
+// substituted-but-self-consistent script is rejected).
+func validateVTXOTreeBinding(commitmentTx *wire.MsgTx,
+	vtxoTrees map[int]*tree.Tree) error {
+
+	if len(vtxoTrees) == 0 {
+		return nil
+	}
+
+	if commitmentTx == nil {
+		return fmt.Errorf("commitment tx is nil")
+	}
+
+	commitmentTxID := commitmentTx.TxHash()
+
+	for outputIdx, vtxoTree := range vtxoTrees {
+		if err := verifyVTXOTreeRoot(
+			commitmentTx, commitmentTxID, outputIdx, vtxoTree,
+		); err != nil {
+			return fmt.Errorf("vtxo tree at output %d: %w",
+				outputIdx, err)
+		}
+	}
+
+	return nil
+}
+
+// verifyVTXOTreeRoot checks that a single VTXO tree's root spends the
+// commitment output named by outputIdx and that the committed output matches
+// both the tree's claimed BatchOutput and the taproot script recomputed from
+// the tree's declared cosigner set and sweep tapscript root.
+func verifyVTXOTreeRoot(commitmentTx *wire.MsgTx, commitmentTxID chainhash.Hash,
+	outputIdx int, vtxoTree *tree.Tree) error {
+
+	switch {
+	case vtxoTree == nil:
+		return fmt.Errorf("nil tree")
+
+	case vtxoTree.Root == nil:
+		return fmt.Errorf("nil tree root")
+
+	case vtxoTree.BatchOutput == nil:
+		return fmt.Errorf("nil batch output")
+
+	case len(vtxoTree.Root.CoSigners) == 0:
+		return fmt.Errorf("tree root has no cosigners")
+	}
+
+	// The map is keyed by commitment-tx output index, so a tree filed under
+	// a key that disagrees with its own BatchOutpoint.Index is internally
+	// inconsistent about which output it spends. Reject before trusting
+	// either value. Compare as int64 so the check is lossless for any int
+	// outputIdx (no uint32 truncation) and naturally rejects negative keys.
+	if int64(outputIdx) != int64(vtxoTree.BatchOutpoint.Index) {
+		return fmt.Errorf("map key %d does not match batch outpoint "+
+			"index %d", outputIdx, vtxoTree.BatchOutpoint.Index)
+	}
+
+	// Bind the tree to this commitment tx: the root must spend an output of
+	// the tx we are about to sign into, not some other transaction.
+	if vtxoTree.BatchOutpoint.Hash != commitmentTxID {
+		return fmt.Errorf("batch outpoint hash %s does not match "+
+			"commitment txid %s", vtxoTree.BatchOutpoint.Hash,
+			commitmentTxID)
+	}
+
+	// Compare as uint32 so a value that would overflow a signed int cannot
+	// wrap past the bounds check on 32-bit architectures.
+	idx := vtxoTree.BatchOutpoint.Index
+	if idx >= uint32(len(commitmentTx.TxOut)) {
+		return fmt.Errorf("batch outpoint index %d out of range "+
+			"(commitment tx has %d outputs)", idx,
+			len(commitmentTx.TxOut))
+	}
+	committed := commitmentTx.TxOut[idx]
+
+	// The trusted BatchOutput (used as the MuSig2 prevout when signing the
+	// tree) must byte-match the real on-chain output, so the signature the
+	// client contributes binds to the output that actually receives its
+	// funds.
+	if committed.Value != vtxoTree.BatchOutput.Value {
+		return fmt.Errorf("committed output value %d != batch output "+
+			"value %d", committed.Value, vtxoTree.BatchOutput.Value)
+	}
+	if !bytes.Equal(committed.PkScript, vtxoTree.BatchOutput.PkScript) {
+		return fmt.Errorf("committed output script does not match " +
+			"batch output script")
+	}
+
+	// Finally, recompute the root taproot script from the tree's declared
+	// cosigner set and sweep tapscript root and require it to equal the
+	// committed script. BatchOutput.PkScript is operator-supplied, so the
+	// byte-match above only proves the operator put the same bytes on-chain
+	// and in the tree; without this an operator could commit a taproot
+	// output whose key is not the aggregate of the declared cosigners,
+	// leaving the co-signed tree unable to ever spend it. We recompute from
+	// the declared parameters rather than trusting Root.FinalKey, which is
+	// itself operator-supplied.
+	finalKey, err := tree.ComputeFinalKey(
+		vtxoTree.Root.CoSigners, vtxoTree.SweepTapscriptRoot,
+	)
+	if err != nil {
+		return fmt.Errorf("recompute tree root key: %w", err)
+	}
+	rootScript, err := txscript.PayToTaprootScript(finalKey)
+	if err != nil {
+		return fmt.Errorf("recompute tree root script: %w", err)
+	}
+	if !bytes.Equal(rootScript, committed.PkScript) {
+		return fmt.Errorf("committed output script does not match " +
+			"script recomputed from tree cosigners and sweep root")
+	}
+
+	return nil
 }
 
 // expectedForfeitSequence returns the tx sequence expected for a forfeit input.

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
-	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -1261,7 +1260,7 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 		intents := []BoardingIntent{intent}
 		vtxos := []types.VTXORequest{vtxoReq}
 		vtxtTree := h.newTestVTXOTreeForIntents(vtxos)
-		commitmentTx := h.newTestCommitmentTx(intents)
+		commitmentTx := h.bindTreeToCommitment(intents, vtxtTree)
 
 		state := &CommitmentTxReceivedState{
 			RoundID:      testRoundIDTr("round-001"),
@@ -1316,7 +1315,9 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 		// with a different outpoint for the commitment tx.
 		differentIntent := h.newTestBoardingIntent()
 		differentIntents := []BoardingIntent{differentIntent}
-		commitmentTx := h.newTestCommitmentTx(differentIntents)
+		commitmentTx := h.bindTreeToCommitment(
+			differentIntents, vtxtTree,
+		)
 
 		state := &CommitmentTxReceivedState{
 			RoundID:      testRoundIDTr("round-001"),
@@ -1386,7 +1387,7 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 
 		intents := []BoardingIntent{intent}
 		vtxos := []types.VTXORequest{vtxoReq}
-		commitmentTx := h.newTestCommitmentTx(intents)
+		commitmentTx := h.bindTreeToCommitment(intents, vtxtTree)
 
 		intentScript, err := vtxoReq.EffectivePkScript()
 		require.NoError(t, err)
@@ -1464,7 +1465,7 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 
 		intents := []BoardingIntent{intent}
 		vtxos := []types.VTXORequest{vtxoReq}
-		commitmentTx := h.newTestCommitmentTx(intents)
+		commitmentTx := h.bindTreeToCommitment(intents, vtxtTree)
 
 		intentScript, err := vtxoReq.EffectivePkScript()
 		require.NoError(t, err)
@@ -1543,13 +1544,11 @@ func TestCommitmentTxReceivedState(t *testing.T) {
 		// quoted (post-fee) amount, not the intent target. The
 		// stock helper hard-codes a single 100k output so we
 		// stitch the leave output in by hand below.
-		commitmentTx := h.newTestCommitmentTx(intents)
-		commitmentTx.UnsignedTx.AddTxOut(&wire.TxOut{
-			Value:    quotedLeaveValue,
-			PkScript: leavePkScript,
-		})
-		commitmentTx.Outputs = append(
-			commitmentTx.Outputs, psbt.POutput{},
+		commitmentTx := h.bindTreeToCommitment(
+			intents, vtxtTree, &wire.TxOut{
+				Value:    quotedLeaveValue,
+				PkScript: leavePkScript,
+			},
 		)
 
 		leaves := []*types.LeaveRequest{{
@@ -3499,12 +3498,12 @@ func TestRefreshOnlyRoundValidation(t *testing.T) {
 	emptyIntents := Intents{Boarding: []BoardingIntent{}}
 	roundID := testRoundIDTr("round-refresh-001")
 
-	// Create a minimal commitment tx with no boarding inputs.
-	commitmentTx := h.newTestCommitmentTxWithInputs(0)
-
 	// Create a VTXT tree. For refresh-only rounds, this would contain
 	// VTXOs for the refreshed amounts, but we need a minimal valid tree.
 	vtxtTree := h.newMinimalVTXOTree()
+
+	// Bind the tree to a commitment tx with no boarding inputs.
+	commitmentTx := h.bindTreeToCommitment(nil, vtxtTree)
 
 	state := &CommitmentTxReceivedState{
 		RoundID:      roundID,

--- a/round/vtxo_tree_binding_test.go
+++ b/round/vtxo_tree_binding_test.go
@@ -1,0 +1,247 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+// newBoundVTXOFixture builds a single-output commitment tx and a VTXO tree
+// rooted in it, exactly as the honest operator would. The returned tx and tree
+// satisfy validateVTXOTreeBinding; tests corrupt one aspect at a time to prove
+// the binding rejects it. The harness is returned so cases can mint extra
+// valid scripts/keys.
+func newBoundVTXOFixture(t *testing.T) (*wire.MsgTx, *tree.Tree,
+	*boardingTestHarness) {
+
+	t.Helper()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+	vtxoReq := h.newTestVTXORequestForIntent(intent)
+	vtxtTree := h.newTestVTXOTreeForIntents([]types.VTXORequest{vtxoReq})
+
+	// bindTreeToCommitment rebuilds vtxtTree in place so its root spends
+	// output 0 of the commitment tx it builds.
+	packet := h.bindTreeToCommitment([]BoardingIntent{intent}, vtxtTree)
+
+	return packet.UnsignedTx, vtxtTree, h
+}
+
+// TestValidateVTXOTreeBindingAccepts confirms an honest single-output round
+// (tree rooted in the commitment tx) passes the binding validation.
+func TestValidateVTXOTreeBindingAccepts(t *testing.T) {
+	t.Parallel()
+
+	commitmentTx, vtxtTree, _ := newBoundVTXOFixture(t)
+
+	err := validateVTXOTreeBinding(
+		commitmentTx, map[int]*tree.Tree{
+			0: vtxtTree,
+		},
+	)
+	require.NoError(t, err)
+}
+
+// TestValidateVTXOTreeBindingRejects walks each way an operator-supplied tree
+// can fail to bind to the commitment tx the client is about to sign into. Each
+// case starts from an honest fixture and corrupts exactly one aspect, proving
+// the corruption is what the binding catches.
+func TestValidateVTXOTreeBindingRejects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+
+		// corrupt mutates an otherwise-valid (commitmentTx, trees)
+		// fixture to introduce exactly one binding defect, returning
+		// the tree map to validate.
+		corrupt func(*testing.T, *wire.MsgTx, *tree.Tree,
+			*boardingTestHarness) map[int]*tree.Tree
+	}{{
+		// The root claims to spend some other transaction's output.
+		name: "batch outpoint hash mismatch",
+		corrupt: func(t *testing.T, _ *wire.MsgTx, vtxtTree *tree.Tree,
+			_ *boardingTestHarness) map[int]*tree.Tree {
+
+			vtxtTree.BatchOutpoint.Hash = chainhash.Hash{
+				0xff,
+			}
+
+			return map[int]*tree.Tree{
+				0: vtxtTree,
+			}
+		},
+	}, {
+		// The map key (the commitment output index this tree is filed
+		// under) disagrees with the tree's own BatchOutpoint.Index.
+		name: "map key disagrees with outpoint index",
+		corrupt: func(t *testing.T, _ *wire.MsgTx, vtxtTree *tree.Tree,
+			_ *boardingTestHarness) map[int]*tree.Tree {
+
+			// Tree's BatchOutpoint.Index is 0; file it under 1.
+			return map[int]*tree.Tree{
+				1: vtxtTree,
+			}
+		},
+	}, {
+		// The claimed batch output index is past the end of the
+		// commitment tx's outputs.
+		name: "batch outpoint index out of range",
+		corrupt: func(t *testing.T, commitmentTx *wire.MsgTx,
+			vtxtTree *tree.Tree,
+			_ *boardingTestHarness) map[int]*tree.Tree {
+
+			idx := uint32(len(commitmentTx.TxOut) + 5)
+			vtxtTree.BatchOutpoint.Index = idx
+
+			// Keep the map key in step so the earlier key-vs-index
+			// check passes and we exercise the range check.
+			return map[int]*tree.Tree{
+				int(idx): vtxtTree,
+			}
+		},
+	}, {
+		// The trusted BatchOutput value (the MuSig2 prevout amount)
+		// does not match the real committed output.
+		name: "batch output value mismatch",
+		corrupt: func(t *testing.T, _ *wire.MsgTx, vtxtTree *tree.Tree,
+			_ *boardingTestHarness) map[int]*tree.Tree {
+
+			vtxtTree.BatchOutput.Value++
+
+			return map[int]*tree.Tree{
+				0: vtxtTree,
+			}
+		},
+	}, {
+		// The trusted BatchOutput script does not match the real
+		// committed output script.
+		name: "batch output script mismatch",
+		corrupt: func(t *testing.T, _ *wire.MsgTx, vtxtTree *tree.Tree,
+			h *boardingTestHarness) map[int]*tree.Tree {
+
+			other, err := txscript.PayToTaprootScript(
+				h.operatorPubKey,
+			)
+			require.NoError(t, err)
+			vtxtTree.BatchOutput.PkScript = other
+
+			return map[int]*tree.Tree{
+				0: vtxtTree,
+			}
+		},
+	}, {
+		// The committed output and the tree's BatchOutput agree on a
+		// script byte-for-byte, but that script is NOT the taproot
+		// output of the tree's declared cosigner set + sweep root. The
+		// value/script-equality checks pass; only the recomputation
+		// check catches this substituted-but-self-consistent script.
+		name: "committed script not the recomputed tree root",
+		corrupt: func(t *testing.T, commitmentTx *wire.MsgTx,
+			vtxtTree *tree.Tree,
+			h *boardingTestHarness) map[int]*tree.Tree {
+
+			substituted, err := txscript.PayToTaprootScript(
+				h.operatorPubKey,
+			)
+			require.NoError(t, err)
+
+			idx := vtxtTree.BatchOutpoint.Index
+			commitmentTx.TxOut[idx].PkScript = substituted
+			vtxtTree.BatchOutput.PkScript = substituted
+
+			return map[int]*tree.Tree{
+				int(idx): vtxtTree,
+			}
+		},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			commitmentTx, vtxtTree, h := newBoundVTXOFixture(t)
+
+			// Sanity check: the fixture must bind before
+			// corruption, so a failure below is attributable to the
+			// corruption.
+			require.NoError(
+				t,
+				validateVTXOTreeBinding(
+					commitmentTx, map[int]*tree.Tree{
+						0: vtxtTree,
+					},
+				),
+			)
+
+			trees := tc.corrupt(t, commitmentTx, vtxtTree, h)
+			require.Error(
+				t, validateVTXOTreeBinding(
+					commitmentTx, trees,
+				),
+			)
+		})
+	}
+}
+
+// TestCommitmentTxReceivedRejectsUnboundTree confirms the binding is wired into
+// the round FSM: a commitment-tx event carrying a tree that is not rooted in
+// the commitment tx fails the round into ClientFailedState before any nonce is
+// generated, rather than being co-signed.
+func TestCommitmentTxReceivedRejectsUnboundTree(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	intent := h.newTestBoardingIntent()
+	vtxoReq := h.newTestVTXORequestForIntent(intent)
+	intents := []BoardingIntent{intent}
+	vtxos := []types.VTXORequest{vtxoReq}
+	vtxtTree := h.newTestVTXOTreeForIntents(vtxos)
+	commitmentTx := h.bindTreeToCommitment(intents, vtxtTree)
+
+	// Re-root the tree at an unrelated transaction after binding: the FSM
+	// must reject it rather than sign into it.
+	vtxtTree.BatchOutpoint.Hash = chainhash.Hash{0xab}
+
+	roundID := testRoundIDTr("round-unbound")
+	state := &CommitmentTxReceivedState{
+		RoundID:      roundID,
+		CommitmentTx: commitmentTx,
+		TxID:         commitmentTx.UnsignedTx.TxHash(),
+		SweepDelay:   1008,
+		VTXOTreePaths: map[int]*tree.Tree{
+			0: vtxtTree,
+		},
+		Intents: Intents{
+			Boarding: intents,
+			VTXOs:    vtxos,
+		},
+		ClientTrees: make(map[SignerKey]*tree.Tree),
+	}
+	h.withState(state)
+
+	event := &CommitmentTxBuilt{
+		RoundID: roundID,
+		Tx:      commitmentTx,
+		VTXOTreePaths: map[int]*tree.Tree{
+			0: vtxtTree,
+		},
+	}
+
+	transition, err := h.sendEvent(event)
+	require.NoError(t, err)
+	require.NotNil(t, transition)
+
+	failedState := assertStateType[*ClientFailedState](h)
+	require.Contains(t, failedState.Reason, "binding")
+
+	// The round must NOT have advanced toward signing.
+	require.NotContains(t, failedState.Reason, "validation failed")
+}

--- a/round/vtxo_tree_binding_test.go
+++ b/round/vtxo_tree_binding_test.go
@@ -190,6 +190,72 @@ func TestValidateVTXOTreeBindingRejects(t *testing.T) {
 	}
 }
 
+// TestConfirmationWatchScriptUsesBatchOutput builds a multi-output round whose
+// batch output is NOT at index 0 and confirms two things: the tree still binds
+// to the commitment tx, and the confirmation watch script tracks the validated
+// batch output rather than blindly watching output 0.
+func TestConfirmationWatchScriptUsesBatchOutput(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+	vtxoReq := h.newTestVTXORequestForIntent(intent)
+	vtxtTree := h.newTestVTXOTreeForIntents([]types.VTXORequest{vtxoReq})
+
+	// Canonical batch output: the taproot script of the tree's cosigner
+	// set tweaked by the sweep root, valued at the summed leaf amount.
+	finalKey, err := tree.ComputeFinalKey(
+		vtxtTree.Root.CoSigners, vtxtTree.SweepTapscriptRoot,
+	)
+	require.NoError(t, err)
+	batchScript, err := txscript.PayToTaprootScript(finalKey)
+	require.NoError(t, err)
+
+	// A distinct, non-batch output to sit at index 0 (e.g. a leave
+	// output), so the batch output lands at index 1.
+	fillerScript, err := txscript.PayToTaprootScript(h.operatorPubKey)
+	require.NoError(t, err)
+	require.NotEqual(t, fillerScript, batchScript)
+
+	const batchIdx = 1
+	tx := wire.NewMsgTx(3)
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: intent.Outpoint})
+	tx.AddTxOut(&wire.TxOut{Value: 12345, PkScript: fillerScript})
+	tx.AddTxOut(&wire.TxOut{
+		Value:    vtxtTree.BatchOutput.Value,
+		PkScript: batchScript,
+	})
+	tx.AddTxOut(&wire.TxOut{
+		Value:    0,
+		PkScript: []byte{txscript.OP_TRUE, txscript.OP_RETURN},
+	})
+
+	// Rebuild the tree rooted at the real batch output (index 1).
+	txid := tx.TxHash()
+	rebuilt, err := tree.NewTree(
+		wire.OutPoint{
+			Hash:  txid,
+			Index: batchIdx,
+		},
+		tx.TxOut[batchIdx],
+		h.leafDescriptorsFromTree(vtxtTree),
+		h.operatorPubKey,
+		vtxtTree.SweepTapscriptRoot,
+		2,
+	)
+	require.NoError(t, err)
+
+	trees := map[int]*tree.Tree{batchIdx: rebuilt}
+
+	// The non-index-0 tree must still bind.
+	require.NoError(t, validateVTXOTreeBinding(tx, trees))
+
+	// The watch script must be the batch output, not output 0.
+	watch := confirmationWatchScript(tx, trees)
+	require.Equal(t, batchScript, watch)
+	require.NotEqual(t, fillerScript, watch)
+}
+
 // TestCommitmentTxReceivedRejectsUnboundTree confirms the binding is wired into
 // the round FSM: a commitment-tx event carrying a tree that is not rooted in
 // the commitment tx fails the round into ClientFailedState before any nonce is


### PR DESCRIPTION
Fixes #680.

## Problem

The round path validated each operator-supplied VTXO tree for internal
self-consistency (leaf script present, client signing key on the path, anchors
well-formed) but **never checked that the tree's `BatchOutpoint` and
`BatchOutput` matched the commitment-transaction output the client was about to
sign into**. Every field the client trusted came from the same operator-supplied
blob as the rest of the tree, so a self-consistent tree rooted at the *wrong*
outpoint — or describing a batch output that did not match the real commitment
output — passed validation and was co-signed.

Once the commitment tx confirms, such a tree does not spend the real batch
output, and the client's new VTXOs (whose outpoints derive from the tree root)
are unrecoverable through it. Under an honest operator this is a fail-unsafe gap
on a construction/serialization bug or misconfiguration; under an untrusted
operator it is a fund-redirect path.

The OOR receive path already closes the analogous gap (`validateIncomingAncestry`),
and the connector counterpart landed in #681 (`validateConnectorAncestry`). This
PR brings the round VTXO-tree path to parity. Together #680 and #681 restore the
round atomicity invariant.

## Changes

**`round: Bind VTXO trees to the commitment tx before signing`**
- New `validateVTXOTreeBinding`, called in `CommitmentTxReceivedState` before
  the per-VTXO `ValidatePath` loop (so trees are bound before their contents are
  trusted) and before nonce generation. For each `(outputIdx, tree)` it asserts:
  - the tree's `BatchOutpoint` names this commitment tx,
  - the map key agrees with `BatchOutpoint.Index`,
  - the index is in range,
  - the committed output byte-matches the tree's `BatchOutput`, and
  - the committed script equals the taproot script **recomputed** from the tree
    root's cosigner set and sweep tapscript root (rejecting a substituted but
    self-consistent script, since `BatchOutput.PkScript` is itself
    operator-supplied).
- A mis-rooted tree fails the round into `ClientFailedState{Recoverable:false}`.
- Test harness now builds commitment-bound fixtures (`bindTreeToCommitment`),
  mirroring how the honest operator constructs a round.

**`round: Watch the validated batch output for confirmation`**
- The confirmation-registration paths assumed `TxOut[0]`. New
  `confirmationWatchScript` watches the validated batch-output index instead
  (falling back to output 0 for rounds with no VTXO trees), wired into both FSM
  outbox registrations and the actor resume/checkpoint registration. Not the
  core safety fix — `TxOut[0]` still works for txid-based detection — but
  correct for multi-output rounds and script-filtering backends (Neutrino).

## Testing

New `round/vtxo_tree_binding_test.go`:
- Six negative cases (outpoint-hash mismatch, map-key/index disagreement,
  out-of-range index, batch-output value mismatch, batch-output script mismatch,
  substituted-but-self-consistent script). Red-before/green-after confirmed by
  neutering the helper.
- Positive single-output case.
- Multi-output case (batch at index 1) asserting both that binding passes and
  that the confirmation watch script tracks the batch output, not output 0.
- An FSM-level test confirming an unbound tree fails the round with a binding
  reason rather than being co-signed.

`go test ./round/` green; `make fmt-changed` + `make lint-changed-local` clean;
`make commitmsg-lint` OK.