### PR TITLE
chainsource: reconnect block epoch subscriptions

### DIFF
--- a/chainsource/block_epoch_actor.go
+++ b/chainsource/block_epoch_actor.go
@@ -5,11 +5,25 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/build"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+const (
+	// defaultBlockEpochReconnectBackoff is the initial delay before a
+	// long-lived block subscription tries to re-register after its backend
+	// stream closes. LND can close all chain notifier streams during
+	// restart or internal notifier churn; callers such as the boarding
+	// wallet need the subscription to heal without a daemon restart.
+	defaultBlockEpochReconnectBackoff = time.Second
+
+	// defaultBlockEpochMaxReconnectBackoff caps reconnect backoff so a
+	// backend outage does not spin, but recovery still happens promptly.
+	defaultBlockEpochMaxReconnectBackoff = 30 * time.Second
 )
 
 // BlockEpochConfig holds configuration for BlockEpochActor.
@@ -21,6 +35,15 @@ type BlockEpochConfig struct {
 	// falls back to extracting a logger from context via LoggerFromContext,
 	// or uses btclog.Disabled if no logger is found.
 	Log fn.Option[btclog.Logger]
+
+	// ReconnectBackoff is the initial delay before reconnecting a block
+	// epoch subscription whose backend stream closed after the initial
+	// registration succeeded. Zero uses defaultBlockEpochReconnectBackoff.
+	ReconnectBackoff time.Duration
+
+	// MaxReconnectBackoff caps the exponential reconnect delay. Zero uses
+	// defaultBlockEpochMaxReconnectBackoff.
+	MaxReconnectBackoff time.Duration
 }
 
 // WithLogger returns a new config with the given logger set.
@@ -177,6 +200,57 @@ func (a *BlockEpochActor) handleSubscribeBlocks(actorCtx context.Context,
 	return fn.Ok[EpochResp](resp)
 }
 
+// blockEpochReconnectBackoff returns the normalized reconnect delay bounds for
+// this actor. Tests can lower both values; production uses conservative
+// defaults that avoid log spam while still healing notifier restarts promptly.
+func (a *BlockEpochActor) blockEpochReconnectBackoff() (time.Duration,
+	time.Duration) {
+
+	initial := a.cfg.ReconnectBackoff
+	if initial <= 0 {
+		initial = defaultBlockEpochReconnectBackoff
+	}
+
+	maxBackoff := a.cfg.MaxReconnectBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = defaultBlockEpochMaxReconnectBackoff
+	}
+	if maxBackoff < initial {
+		maxBackoff = initial
+	}
+
+	return initial, maxBackoff
+}
+
+// waitForReconnect sleeps for the current backoff unless the actor is
+// stopping. It returns false when shutdown won the race.
+func (a *BlockEpochActor) waitForReconnect(backoff time.Duration) bool {
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return true
+
+	case <-a.ctx.Done():
+		return false
+	}
+}
+
+// nextReconnectBackoff doubles the reconnect delay and caps it at maxBackoff.
+func nextReconnectBackoff(backoff, maxBackoff time.Duration) time.Duration {
+	if backoff >= maxBackoff {
+		return maxBackoff
+	}
+
+	next := backoff * 2
+	if next > maxBackoff {
+		return maxBackoff
+	}
+
+	return next
+}
+
 // monitorBlocks runs in a background goroutine and forwards block events to
 // the subscriber (either channel or actor reference).
 func (a *BlockEpochActor) monitorBlocks() {
@@ -184,6 +258,11 @@ func (a *BlockEpochActor) monitorBlocks() {
 
 	log := a.logger(a.ctx)
 	log.InfoS(a.ctx, "BlockEpochActor monitoring started")
+
+	reconnectBackoff, maxReconnectBackoff :=
+		a.blockEpochReconnectBackoff()
+	currentBackoff := reconnectBackoff
+	registration := a.registration
 
 	// In iterator mode, the sender (this goroutine) is responsible for
 	// closing the channel to signal the receiver that no more values will
@@ -197,18 +276,50 @@ func (a *BlockEpochActor) monitorBlocks() {
 	// Make sure we clean up the registration on exit.
 	defer func() {
 		log.InfoS(a.ctx, "BlockEpochActor monitoring stopped")
-		if a.registration != nil {
-			a.registration.Cancel()
+		if registration != nil {
+			registration.Cancel()
 		}
 	}()
 
 	for {
-		select {
-		case epoch, ok := <-a.registration.Epochs:
-			if !ok {
-				log.InfoS(a.ctx, "Block epoch channel closed")
-
+		if registration == nil {
+			if !a.waitForReconnect(currentBackoff) {
 				return
+			}
+
+			var err error
+			registration, err = a.cfg.Backend.RegisterBlocks(a.ctx)
+			if err != nil {
+				log.WarnS(a.ctx, "Block epoch reconnect failed",
+					err,
+					slog.Duration("backoff",
+						currentBackoff),
+				)
+				currentBackoff = nextReconnectBackoff(
+					currentBackoff, maxReconnectBackoff,
+				)
+
+				continue
+			}
+
+			log.InfoS(a.ctx, "Block epoch subscription reconnected")
+			currentBackoff = reconnectBackoff
+		}
+
+		select {
+		case epoch, ok := <-registration.Epochs:
+			if !ok {
+				log.InfoS(
+					a.ctx,
+					"Block epoch channel closed, "+
+						"reconnecting",
+					slog.Duration("backoff",
+						currentBackoff),
+				)
+				registration.Cancel()
+				registration = nil
+
+				continue
 			}
 
 			log.InfoS(a.ctx, "Received block from backend",

--- a/chainsource/chainsource_test.go
+++ b/chainsource/chainsource_test.go
@@ -28,6 +28,17 @@ type mockBackend struct {
 	bestHash   chainhash.Hash
 }
 
+type blockEpochRegistration struct {
+	epochs chan *BlockEpoch
+	cancel chan struct{}
+}
+
+type reconnectBlockBackend struct {
+	*mockBackend
+
+	registrations chan *blockEpochRegistration
+}
+
 // newMockBackend creates a new mock backend for testing.
 func newMockBackend() *mockBackend {
 	return &mockBackend{
@@ -37,6 +48,78 @@ func newMockBackend() *mockBackend {
 		epochCancel: make(chan struct{}, 10),
 		feeRate:     1000,
 		bestHeight:  100,
+	}
+}
+
+func newReconnectBlockBackend() *reconnectBlockBackend {
+	return &reconnectBlockBackend{
+		mockBackend:   newMockBackend(),
+		registrations: make(chan *blockEpochRegistration, 10),
+	}
+}
+
+func (m *reconnectBlockBackend) RegisterBlocks(ctx context.Context) (
+	*BlockRegistration, error) {
+
+	reg := &blockEpochRegistration{
+		epochs: make(chan *BlockEpoch, 10),
+		cancel: make(chan struct{}, 1),
+	}
+
+	select {
+	case m.registrations <- reg:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	return &BlockRegistration{
+		Epochs: reg.epochs,
+		Cancel: func() {
+			select {
+			case reg.cancel <- struct{}{}:
+			default:
+			}
+		},
+	}, nil
+}
+
+func (m *reconnectBlockBackend) nextRegistration(
+	t *testing.T) *blockEpochRegistration {
+
+	t.Helper()
+
+	select {
+	case reg := <-m.registrations:
+		return reg
+
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for block registration")
+	}
+
+	return nil
+}
+
+func (r *blockEpochRegistration) send(height int32) chainhash.Hash {
+	hash := chainhash.Hash{}
+	hash[0] = byte(height)
+	hash[1] = byte(height >> 8)
+
+	r.epochs <- &BlockEpoch{
+		Height:    height,
+		Hash:      hash,
+		Timestamp: 0,
+	}
+
+	return hash
+}
+
+func (r *blockEpochRegistration) assertCanceled(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-r.cancel:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for registration cancel")
 	}
 }
 
@@ -1175,6 +1258,65 @@ func TestBlockEpochActorNotifyMode(t *testing.T) {
 	require.True(t, ok, "timeout waiting for notification")
 	require.Equal(t, int32(150), event.Height)
 	require.Equal(t, hash, event.Hash)
+}
+
+// TestBlockEpochActorReconnectsAfterBackendStreamCloses reproduces the
+// production failure mode where LND closes the long-lived block epoch stream
+// after the subscription was already established. The wallet relies on this
+// stream to process new tips, scan confirmed backing-wallet outputs, and
+// promote confirmed boarding UTXOs into boarding intents. If the actor treats
+// a closed backend stream as terminal, the daemon can keep serving RPCs while
+// silently missing later confirmations until it is restarted. This test closes
+// the first backend registration, verifies the actor cancels it, then asserts
+// the same subscriber receives a block from a fresh registration.
+func TestBlockEpochActorReconnectsAfterBackendStreamCloses(t *testing.T) {
+	t.Parallel()
+
+	backend := newReconnectBlockBackend()
+	ctx := t.Context()
+	epochActor := NewBlockEpochActor(BlockEpochConfig{
+		Backend:             backend,
+		ReconnectBackoff:    5 * time.Millisecond,
+		MaxReconnectBackoff: 5 * time.Millisecond,
+	})
+	defer epochActor.Stop()
+
+	notifier := actor.NewChannelTellOnlyRef[BlockEpoch](
+		"test-reconnect-notify", 10,
+	)
+
+	result := epochActor.Receive(ctx, &SubscribeBlocksRequest{
+		CallerID: "test-epoch-reconnect",
+		NotifyActor: fn.Some(
+			actor.TellOnlyRef[BlockEpoch](notifier),
+		),
+	})
+	require.True(t, result.IsOk())
+
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+	epochResp, ok := resp.(*SubscribeBlocksResponse)
+	require.True(t, ok)
+	require.NotNil(t, epochResp.Cancel)
+
+	firstReg := backend.nextRegistration(t)
+	firstHash := firstReg.send(150)
+
+	firstEvent, ok := notifier.AwaitMessage(time.Second)
+	require.True(t, ok, "timeout waiting for first block epoch")
+	require.Equal(t, int32(150), firstEvent.Height)
+	require.Equal(t, firstHash, firstEvent.Hash)
+
+	close(firstReg.epochs)
+	firstReg.assertCanceled(t)
+
+	secondReg := backend.nextRegistration(t)
+	secondHash := secondReg.send(151)
+
+	secondEvent, ok := notifier.AwaitMessage(time.Second)
+	require.True(t, ok, "timeout waiting for reconnected block epoch")
+	require.Equal(t, int32(151), secondEvent.Height)
+	require.Equal(t, secondHash, secondEvent.Hash)
 }
 
 // TestBlockEpochActorIteratorMode tests block subscription in Iterator mode.


### PR DESCRIPTION
## Summary

Fixes #714.

This PR keeps the block epoch actor alive when the backend epoch stream closes after the initial subscription succeeds. Instead of treating the closed stream as terminal, the actor now cancels the closed registration, waits with bounded backoff, and registers a fresh stream.

The production symptom was that darepod could keep serving RPCs after LND's chain notifier stream exited, but the wallet stopped processing new chain tips. A boarding address funded after that point could confirm on-chain without being promoted into a confirmed boarding intent, so `GetBalance` and `Board` still reported no boarding UTXOs until the daemon restarted.

## Test Coverage

Added a regression test that closes the first backend block epoch registration, verifies it is canceled, and then confirms the same subscriber receives a block from the replacement registration.

Local checks:

```bash
make unit pkg=./chainsource case=TestBlockEpochActorReconnectsAfterBackendStreamCloses timeout=30s
make unit pkg=./chainsource timeout=2m
make lint-changed-local
```