### PR TITLE
docs: nightly doc-gardening sweep 2026-06-10

### DIFF
--- a/chainsource/AGENTS.md
+++ b/chainsource/AGENTS.md
@@ -30,6 +30,10 @@ communication alongside the raw registration API.
 - `RegisterSpendRequest/Response`, `UnregisterSpendRequest/Response` — Spend
   monitoring lifecycle.
 - `EpochMsg` / `EpochResp` — Sealed interfaces for block-epoch sub-actor.
+- `BlockEpochConfig` — Config for `BlockEpochActor`. `ReconnectBackoff` and
+  `MaxReconnectBackoff` control exponential reconnect delay when the backend
+  stream closes mid-subscription (defaults: 1 s initial, 30 s cap). Zero
+  values use the defaults; tests lower both to speed up reconnect assertions.
 - `SubscribeBlocksRequest/Response`, `UnsubscribeBlocksRequest/Response` —
   Block subscription lifecycle.
 - `ConfRegistration` / `SpendRegistration` / `BlockRegistration` — Structs with
@@ -56,6 +60,13 @@ communication alongside the raw registration API.
 - Confirmation sub-actors support two notification modes: Future-based (blocking
   await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
   mode when blocking inside a durable actor transaction is unsafe.
+- `BlockEpochActor` auto-reconnects with exponential backoff when the backend
+  stream closes mid-subscription. LND can close all chain-notifier streams
+  during restart; callers such as the boarding wallet need healing without a
+  full daemon restart. The actor does NOT return on a closed epoch channel;
+  instead it cancels the old registration, waits for the current backoff, and
+  re-calls `RegisterBlocks`. Backoff resets to initial on a successful
+  reconnection.
 
 ## Deep Docs
 

--- a/chainsource/CLAUDE.md
+++ b/chainsource/CLAUDE.md
@@ -30,6 +30,10 @@ communication alongside the raw registration API.
 - `RegisterSpendRequest/Response`, `UnregisterSpendRequest/Response` — Spend
   monitoring lifecycle.
 - `EpochMsg` / `EpochResp` — Sealed interfaces for block-epoch sub-actor.
+- `BlockEpochConfig` — Config for `BlockEpochActor`. `ReconnectBackoff` and
+  `MaxReconnectBackoff` control exponential reconnect delay when the backend
+  stream closes mid-subscription (defaults: 1 s initial, 30 s cap). Zero
+  values use the defaults; tests lower both to speed up reconnect assertions.
 - `SubscribeBlocksRequest/Response`, `UnsubscribeBlocksRequest/Response` —
   Block subscription lifecycle.
 - `ConfRegistration` / `SpendRegistration` / `BlockRegistration` — Structs with
@@ -56,6 +60,13 @@ communication alongside the raw registration API.
 - Confirmation sub-actors support two notification modes: Future-based (blocking
   await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
   mode when blocking inside a durable actor transaction is unsafe.
+- `BlockEpochActor` auto-reconnects with exponential backoff when the backend
+  stream closes mid-subscription. LND can close all chain-notifier streams
+  during restart; callers such as the boarding wallet need healing without a
+  full daemon restart. The actor does NOT return on a closed epoch channel;
+  instead it cancels the old registration, waits for the current backoff, and
+  re-calls `RegisterBlocks`. Backoff resets to initial on a successful
+  reconnection.
 
 ## Deep Docs
 

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -253,6 +253,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   `serverconn.PubKeyMailboxID`), not config strings. The operator's
   remote mailbox ID is fetched via direct gRPC before the mailbox
   runtime starts.
+- `OperatorTerms` no longer carries `ForfeitScript`, `SweepKey`, or
+  `SweepDelay`; these are delivered per round in the batch info and are not
+  surfaced in the daemon-level `ServerInfo` RPC response.
 - Auth headers (Schnorr signature) are injected into all outbound
   envelopes including response envelopes in `handleInboundRPC`.
 - TLS client cert generation is skipped in insecure mode.
@@ -265,9 +268,21 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   per-recipient amounts outside `(0, MaxSatoshi]`, uses
   overflow-safe accumulation. Wallet-side `handleSendVTXOs` repeats
   these checks as defense-in-depth.
+- `SendOOR` supports multiple recipients (up to `maxOORRecipients = 256`).
+  Request validation (`sendOORRequestRecipients`, `sumSendOORRecipientAmounts`)
+  runs before operator terms are fetched; per-recipient script resolution and
+  dust validation run in `buildSendOORRecipients`. Custom inputs still require
+  exactly one recipient. The response now carries `RecipientOutpoints` (plural)
+  instead of a single `RecipientOutpoint`.
 - `SendOOR` with custom inputs serializes concurrent calls on the
   same outpoints via `reserveCustomInputs`. Custom inputs lock for
   the RPC lifetime; release is deferred on both success and failure.
+- `cleanupSubmittedOORStartWithTimeout`: when the cleanup context deadline
+  expires before the OOR actor responds, the wallet-unlock call runs on a
+  fresh `submittedOORUnlockTimeout`-bounded context (derived from the
+  request's cancel-free base), not the already-expired cleanup context.
+  Without this, the wallet actor's mailbox rejects the expired Tell and
+  wallet-selected VTXOs are silently pinned.
 - `BuildCustomTransferInputs` validates (a) the caller-supplied
   policy template compiles to the provided pkScript
   (`PolicyTemplate.MatchesPkScript`), and (b) the spend path's

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -253,6 +253,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   `serverconn.PubKeyMailboxID`), not config strings. The operator's
   remote mailbox ID is fetched via direct gRPC before the mailbox
   runtime starts.
+- `OperatorTerms` no longer carries `ForfeitScript`, `SweepKey`, or
+  `SweepDelay`; these are delivered per round in the batch info and are not
+  surfaced in the daemon-level `ServerInfo` RPC response.
 - Auth headers (Schnorr signature) are injected into all outbound
   envelopes including response envelopes in `handleInboundRPC`.
 - TLS client cert generation is skipped in insecure mode.
@@ -265,9 +268,21 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   per-recipient amounts outside `(0, MaxSatoshi]`, uses
   overflow-safe accumulation. Wallet-side `handleSendVTXOs` repeats
   these checks as defense-in-depth.
+- `SendOOR` supports multiple recipients (up to `maxOORRecipients = 256`).
+  Request validation (`sendOORRequestRecipients`, `sumSendOORRecipientAmounts`)
+  runs before operator terms are fetched; per-recipient script resolution and
+  dust validation run in `buildSendOORRecipients`. Custom inputs still require
+  exactly one recipient. The response now carries `RecipientOutpoints` (plural)
+  instead of a single `RecipientOutpoint`.
 - `SendOOR` with custom inputs serializes concurrent calls on the
   same outpoints via `reserveCustomInputs`. Custom inputs lock for
   the RPC lifetime; release is deferred on both success and failure.
+- `cleanupSubmittedOORStartWithTimeout`: when the cleanup context deadline
+  expires before the OOR actor responds, the wallet-unlock call runs on a
+  fresh `submittedOORUnlockTimeout`-bounded context (derived from the
+  request's cancel-free base), not the already-expired cleanup context.
+  Without this, the wallet actor's mailbox rejects the expired Tell and
+  wallet-selected VTXOs are silently pinned.
 - `BuildCustomTransferInputs` validates (a) the caller-supplied
   policy template compiles to the provided pkScript
   (`PolicyTemplate.MatchesPkScript`), and (b) the spend path's

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -205,6 +205,13 @@ State transitions and validation rules live under [Invariants](#invariants).
 
 ## Invariants
 
+- Before dispatching a standard `StartTransferEvent`, `Idle.ProcessEvent`
+  calls `normalizeCheckpointOwnerLeaves` to rebind each input's checkpoint
+  OUTPUT owner leaf to the session operator key (not the spent VTXO's
+  historical operator key). A VTXO created before an operator key rotation
+  would otherwise produce a checkpoint output the current operator cannot
+  co-sign, causing a server-side submit rejection. Custom-spend inputs (e.g.
+  vHTLC) carry their own explicit owner leaf and are left untouched.
 - Checkpoint output collab path is 2-of-2
   `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig.
 - `signCustomCheckpointPSBT` re-verifies that the custom spend path

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -205,6 +205,13 @@ State transitions and validation rules live under [Invariants](#invariants).
 
 ## Invariants
 
+- Before dispatching a standard `StartTransferEvent`, `Idle.ProcessEvent`
+  calls `normalizeCheckpointOwnerLeaves` to rebind each input's checkpoint
+  OUTPUT owner leaf to the session operator key (not the spent VTXO's
+  historical operator key). A VTXO created before an operator key rotation
+  would otherwise produce a checkpoint output the current operator cannot
+  co-sign, causing a server-side submit rejection. Custom-spend inputs (e.g.
+  vHTLC) carry their own explicit owner leaf and are left untouched.
 - Checkpoint output collab path is 2-of-2
   `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig.
 - `signCustomCheckpointPSBT` re-verifies that the custom spend path

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -24,8 +24,14 @@ state transitions and validation rules live under [Invariants](#invariants).
 - `ClientEvent` — sealed inbound event interface. Notable members:
   `JoinRoundQuoteReceived` (carries reseal `SealPass`), `QuoteAccepted`,
   `QuoteRejected`, `ForfeitCollectionTimedOut`, `ForfeitSignatureResponse`,
-  `ConnectorLeafInfo`, `IntentPackage` (atomic delivery of all intent
-  types).
+  `ConnectorLeafInfo`, `IntentPackage` (atomic delivery of all intent types).
+  `CommitmentTxBuilt` carries five per-round operator keys in addition to the
+  VTXO tree: `TreeCosignKey` (MuSig2 cosigner for VTXO output tree),
+  `ConnectorOperatorKey` (connector tree operator key), `SweepKey` (sweep-leaf
+  key), `SweepDelay` (batch-wide absolute timelock), and `ForfeitKey` (forfeit
+  penalty output key). All are per-round deliveries replacing the removed
+  global `OperatorTerms` sweep/forfeit fields; nil values fall back to the
+  global operator key for older servers.
 - `ClientOutMsg` — sealed outbox interface. Members:
   `JoinRoundAcceptOutbox`, `JoinRoundRejectOutbox`,
   `SubmitForfeitSigRequest`, `StartTimeoutReq`, `CancelTimeoutReq`,
@@ -161,6 +167,15 @@ state transitions and validation rules live under [Invariants](#invariants).
 - Aggregated signatures validated on `VTXOTreePaths` are propagated to
   extracted `ClientTrees` via `SubmitTreeSigs` + `VerifySigned`, so
   persisted client trees carry valid signatures for unilateral exit.
+- Sweep key, sweep delay, and forfeit key are now delivered per round in
+  `CommitmentTxBuilt` (not from global `OperatorTerms`). The
+  sweep-vs-exit-delay security check runs in `CommitmentTxReceivedState` rather
+  than at actor construction, because the delay is not known until the round's
+  batch info arrives.
+- `registerCommitmentConfirmation` watches the validated batch output (the
+  output that receives this client's funds) via `confirmationWatchScript`,
+  rather than always assuming output 0. Falls back to output 0 when the round
+  carries no VTXO trees.
 - Round state is checkpointed atomically after tree validation — a
   crash before checkpoint means the client has no record of sent
   signatures.

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -24,8 +24,14 @@ state transitions and validation rules live under [Invariants](#invariants).
 - `ClientEvent` — sealed inbound event interface. Notable members:
   `JoinRoundQuoteReceived` (carries reseal `SealPass`), `QuoteAccepted`,
   `QuoteRejected`, `ForfeitCollectionTimedOut`, `ForfeitSignatureResponse`,
-  `ConnectorLeafInfo`, `IntentPackage` (atomic delivery of all intent
-  types).
+  `ConnectorLeafInfo`, `IntentPackage` (atomic delivery of all intent types).
+  `CommitmentTxBuilt` carries five per-round operator keys in addition to the
+  VTXO tree: `TreeCosignKey` (MuSig2 cosigner for VTXO output tree),
+  `ConnectorOperatorKey` (connector tree operator key), `SweepKey` (sweep-leaf
+  key), `SweepDelay` (batch-wide absolute timelock), and `ForfeitKey` (forfeit
+  penalty output key). All are per-round deliveries replacing the removed
+  global `OperatorTerms` sweep/forfeit fields; nil values fall back to the
+  global operator key for older servers.
 - `ClientOutMsg` — sealed outbox interface. Members:
   `JoinRoundAcceptOutbox`, `JoinRoundRejectOutbox`,
   `SubmitForfeitSigRequest`, `StartTimeoutReq`, `CancelTimeoutReq`,
@@ -161,6 +167,15 @@ state transitions and validation rules live under [Invariants](#invariants).
 - Aggregated signatures validated on `VTXOTreePaths` are propagated to
   extracted `ClientTrees` via `SubmitTreeSigs` + `VerifySigned`, so
   persisted client trees carry valid signatures for unilateral exit.
+- Sweep key, sweep delay, and forfeit key are now delivered per round in
+  `CommitmentTxBuilt` (not from global `OperatorTerms`). The
+  sweep-vs-exit-delay security check runs in `CommitmentTxReceivedState` rather
+  than at actor construction, because the delay is not known until the round's
+  batch info arrives.
+- `registerCommitmentConfirmation` watches the validated batch output (the
+  output that receives this client's funds) via `confirmationWatchScript`,
+  rather than always assuming output 0. Falls back to output 0 when the round
+  carries no VTXO trees.
 - Round state is checkpointed atomically after tree validation — a
   crash before checkpoint means the client has no record of sent
   signatures.


### PR DESCRIPTION
Automated nightly doc-gardening sweep for 2026-06-10.

## Summary

- **chainsource**: Added `BlockEpochConfig.ReconnectBackoff`/`MaxReconnectBackoff` fields and auto-reconnect invariant (PR #715).
- **round**: Documented per-round operator keys in `CommitmentTxBuilt` (`TreeCosignKey`, `ConnectorOperatorKey`, `SweepKey`, `SweepDelay`, `ForfeitKey`); sweep-vs-exit-delay check moved to `CommitmentTxReceivedState`; confirmation tracker now watches the validated batch output (PRs #698, #699, #712).
- **oor**: Added `normalizeCheckpointOwnerLeaves` invariant — rebinds checkpoint output owner leaf to session operator key before transfer to handle operator key rotation (PR #699).
- **darepod**: Multi-recipient `SendOOR` support (`maxOORRecipients=256`, plural `RecipientOutpoints`); `cleanupSubmittedOORStartWithTimeout` unlock-context fix; `OperatorTerms` no longer carries `ForfeitScript`/`SweepKey`/`SweepDelay` (PRs #696, #707, #698).

## Review notes

Please review the diffs in `chainsource/CLAUDE.md`, `round/CLAUDE.md`, `oor/CLAUDE.md`, and `darepod/CLAUDE.md` (plus their `AGENTS.md` mirrors). `make doc-check` passes on this branch.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)