### PR TITLE
swapwallet: complete cooperative leave activity

### DIFF
--- a/swapwallet/doc.go
+++ b/swapwallet/doc.go
@@ -45,16 +45,17 @@
 // separate confirmed ledger row later, but the two rows do NOT share an
 // id in v1 because there is no daemon-side notification hook that links
 // (a) an exit's queued outpoints to its eventual sweep txid, or (b) a
-// deposit's boarding address to its eventual boarding txid. The earlier
-// in-process intent index was removed once it became clear it was an
-// identity-mapping ceremony for the SEND-invoice and RECV paths (the
-// swap subsystem already keys those by payment_hash). A v2 canonical-id
-// projection lands when the daemon exposes the missing hooks; the
-// right home for that link is the daemon-side persistence (leave job,
-// deposit address record), not a process-local map. Callers that need
-// to correlate EXIT/DEPOSIT pending → confirmed in v1 should track the
-// WalletEntry.Counterparty (truncated bech32 address or txid) and the
-// persisted ledger txid via separate queries.
+// deposit's boarding address to its eventual boarding txid. Cooperative
+// leave rows can still complete while the original runtime-local row is
+// alive: once the source VTXO is terminally forfeited, the pending EXIT
+// row is shown as COMPLETE. After restart, however, the daemon cannot
+// recreate the original counterparty/note from durable state alone. A v2
+// canonical-id projection lands when the daemon exposes the missing
+// hooks; the right home for that link is the daemon-side persistence
+// (leave job, deposit address record), not a process-local map. Callers
+// that need to correlate EXIT/DEPOSIT pending → confirmed across restart
+// in v1 should track the WalletEntry.Counterparty (truncated bech32
+// address or txid) and the persisted ledger txid via separate queries.
 //
 // Onchain SEND sweep semantics: the cooperative-leave path sweeps WHOLE
 // selected VTXOs to the destination, so the recipient may receive more

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -168,8 +168,17 @@ func (h *history) listActivity(ctx context.Context,
 		}
 		entries = append(entries, exitEntries...)
 
+		var forfeitedOutpoints map[string]struct{}
+		if h.hasWalletLocalExitEntries() {
+			forfeitedOutpoints, _ = h.collectForfeitedVTXOOutpoints(
+				ctx,
+			)
+		}
+
 		entries = append(
-			entries, h.collectWalletLocalPendingEntries(ctx)...,
+			entries, h.collectWalletLocalPendingEntries(
+				ctx, forfeitedOutpoints,
+			)...,
 		)
 	}
 
@@ -402,7 +411,7 @@ func (h *history) collectUnilateralExitEntries(ctx context.Context) (
 			}
 		}
 
-		if err := h.decorateExitEntry(ctx, entry); err != nil {
+		if err := h.decorateExitEntry(ctx, entry, nil); err != nil {
 			return nil, err
 		}
 
@@ -416,8 +425,8 @@ func (h *history) collectUnilateralExitEntries(ctx context.Context) (
 // calls before their durable terminal source is available. Cooperative leave
 // uses this path immediately after Send returns; unilateral exit uses it until
 // the unroll status/VTXO projection catches up.
-func (h *history) collectWalletLocalPendingEntries(
-	ctx context.Context) []*walletdkrpc.WalletEntry {
+func (h *history) collectWalletLocalPendingEntries(ctx context.Context,
+	forfeitedOutpoints map[string]struct{}) []*walletdkrpc.WalletEntry {
 
 	if h.runtime == nil {
 		return nil
@@ -432,10 +441,59 @@ func (h *history) collectWalletLocalPendingEntries(
 		// Status lookup is best-effort for wallet-local entries. A
 		// missing unroll job usually means this is a cooperative
 		// leave pending row, not a unilateral exit.
-		_ = h.decorateExitEntry(ctx, entry)
+		_ = h.decorateExitEntry(ctx, entry, forfeitedOutpoints)
 	}
 
 	return entries
+}
+
+// hasWalletLocalExitEntries returns true when the runtime has any local EXIT
+// row to decorate. It lets the activity list avoid querying terminal VTXOs when
+// no cooperative-leave row could use them.
+func (h *history) hasWalletLocalExitEntries() bool {
+	if h.runtime == nil {
+		return false
+	}
+
+	for _, entry := range h.runtime.pendingSnapshot() {
+		if entry.GetKind() == walletdkrpc.EntryKind_ENTRY_KIND_EXIT {
+			return true
+		}
+	}
+
+	return false
+}
+
+// collectForfeitedVTXOOutpoints returns the terminal VTXO outpoints used to
+// complete cooperative-leave rows. This remains a v1 best-effort scan until the
+// daemon exposes a direct VTXO-by-outpoint lookup.
+func (h *history) collectForfeitedVTXOOutpoints(
+	ctx context.Context) (map[string]struct{}, error) {
+
+	if h.deps.RPCServer == nil {
+		return nil, nil
+	}
+
+	resp, err := h.deps.RPCServer.ListVTXOs(
+		ctx, &daemonrpc.ListVTXOsRequest{
+			StatusFilter: daemonrpc.
+				VTXOStatus_VTXO_STATUS_FORFEITED,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list forfeited vtxos: %w", err)
+	}
+
+	outpoints := make(map[string]struct{}, len(resp.GetVtxos()))
+	for _, vtxo := range resp.GetVtxos() {
+		if vtxo.GetOutpoint() == "" {
+			continue
+		}
+
+		outpoints[vtxo.GetOutpoint()] = struct{}{}
+	}
+
+	return outpoints, nil
 }
 
 // unilateralExitEntryFromVTXO projects a VTXO in UNILATERAL_EXIT into a
@@ -465,11 +523,14 @@ func unilateralExitEntryFromVTXO(v *daemonrpc.VTXO) *walletdkrpc.WalletEntry {
 	}
 }
 
-// decorateExitEntry applies unroll status to an EXIT entry when the daemon has
-// a unilateral-exit job for the entry id. Cooperative leave entries do not have
-// unroll jobs, so Found=false leaves the original pending row untouched.
+// decorateExitEntry applies the best daemon-backed status available for an EXIT
+// entry. Unilateral exits are owned by the unroll job store. Cooperative leaves
+// have no unroll job, so when Found=false we fall back to the VTXO terminal
+// state for the entry id: a forfeited source VTXO means the leave round
+// confirmed and the wallet-local pending row can be shown as complete.
 func (h *history) decorateExitEntry(ctx context.Context,
-	entry *walletdkrpc.WalletEntry) error {
+	entry *walletdkrpc.WalletEntry,
+	forfeitedOutpoints map[string]struct{}) error {
 
 	if h.deps.RPCServer == nil || entry == nil || entry.GetId() == "" {
 		return nil
@@ -485,12 +546,63 @@ func (h *history) decorateExitEntry(ctx context.Context,
 			err)
 	}
 	if !resp.GetFound() {
+		decorateCooperativeLeaveEntry(entry, forfeitedOutpoints)
+
 		return nil
 	}
 
 	applyUnrollStatus(entry, resp)
 
 	return nil
+}
+
+// decorateCooperativeLeaveEntry completes a wallet-local cooperative leave row
+// once the source VTXO is terminally forfeited. This is intentionally
+// best-effort: until the daemon persists a leave job that links queued
+// outpoints to the commitment tx, a restarted daemon cannot recreate the
+// original counterparty/note from the runtime-local row.
+func decorateCooperativeLeaveEntry(entry *walletdkrpc.WalletEntry,
+	forfeitedOutpoints map[string]struct{}) {
+
+	if entry.GetStatus() != walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING {
+		return
+	}
+
+	if forfeitedOutpoints == nil {
+		return
+	}
+	if _, ok := forfeitedOutpoints[entry.GetId()]; !ok {
+		return
+	}
+
+	// Cooperative leave rows are process-local in v1, so the source
+	// outpoint is the only stable link to daemon state. A matching
+	// forfeited VTXO means the round that consumed the queued leave
+	// input confirmed.
+	applyCooperativeLeaveForfeited(entry)
+}
+
+// applyCooperativeLeaveForfeited projects a forfeited cooperative-leave source
+// VTXO onto the original wallet-local EXIT row.
+func applyCooperativeLeaveForfeited(entry *walletdkrpc.WalletEntry) {
+	if entry == nil {
+		return
+	}
+
+	entry.Status = walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE
+	entry.FailureReason = ""
+
+	progress := entry.GetProgress()
+	if progress == nil {
+		progress = &walletdkrpc.WalletEntryProgress{}
+		entry.Progress = progress
+	}
+	if progress.GetVtxoOutpoint() == "" {
+		progress.VtxoOutpoint = entry.GetId()
+	}
+	progress.Phase = walletdkrpc.
+		WalletEntryPhase_WALLET_ENTRY_PHASE_CONFIRMED
+	progress.PhaseLabel = "confirmed"
 }
 
 // collectLedgerEntries reads the daemon's unified ledger+sweep page and

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -1200,6 +1200,202 @@ func TestHistoryIncludesWalletLocalPendingExit(t *testing.T) {
 	require.Equal(t, "user note", entries[0].GetNote())
 }
 
+// TestHistoryCompletesWalletLocalExitWhenVTXOForfeited confirms a
+// cooperative-leave activity row stops showing as pending once the source VTXO
+// has been terminally forfeited in the confirmed leave round. This is the
+// issue #568 balance/activity edge: the VTXO state is authoritative for the
+// in-process pending row even though v1 does not yet persist a durable leave
+// job that links the original entry id to the commitment transaction.
+func TestHistoryCompletesWalletLocalExitWhenVTXOForfeited(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{}
+	rpc.unrollStatusResp = &daemonrpc.GetUnrollStatusResponse{
+		Found: false,
+	}
+	rpc.listVTXOsByStatus = map[daemonrpc.VTXOStatus]*daemonrpc.
+		ListVTXOsResponse{
+
+		daemonrpc.VTXOStatus_VTXO_STATUS_UNILATERAL_EXIT: {},
+		daemonrpc.VTXOStatus_VTXO_STATUS_FORFEITED: {
+			Vtxos: []*daemonrpc.VTXO{
+				{
+					Outpoint: "leave-outpoint:1",
+					Status: daemonrpc.
+						VTXOStatus_VTXO_STATUS_FORFEITED,
+				},
+			},
+		},
+	}
+
+	pending := leaveEntryStub(
+		[]string{
+			"leave-outpoint:1",
+		}, "bcrt1qdest",
+		50_000, "user note",
+	)
+	h.runtime.trackPendingEntryWithoutTimeout(pending)
+
+	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{})
+	require.NoError(t, err)
+
+	entries := resp.GetActivity().GetEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, "leave-outpoint:1", entries[0].GetId())
+	require.Equal(
+		t, walletdkrpc.EntryKind_ENTRY_KIND_EXIT, entries[0].GetKind(),
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		entries[0].GetStatus(),
+	)
+	require.Equal(
+		t, walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_CONFIRMED,
+		entries[0].GetProgress().GetPhase(),
+	)
+	require.Equal(t, "confirmed", entries[0].GetProgress().GetPhaseLabel())
+	require.Equal(
+		t, "leave-outpoint:1",
+		entries[0].GetProgress().GetVtxoOutpoint(),
+	)
+	require.Equal(t, int64(-50_000), entries[0].GetAmountSat())
+	require.Equal(t, "user note", entries[0].GetNote())
+
+	pendingResp, err := h.List(t.Context(), &walletdkrpc.ListRequest{
+		PendingOnly: true,
+	})
+	require.NoError(t, err)
+	require.Empty(t, pendingResp.GetActivity().GetEntries())
+}
+
+// TestHistoryKeepsWalletLocalExitPendingForUnmatchedForfeitedVTXO confirms the
+// cooperative-leave fallback only completes the wallet-local row when the
+// forfeited VTXO is the same source outpoint tracked by the row. This protects
+// the v1 heuristic from treating any terminal VTXO as proof that this specific
+// leave completed.
+func TestHistoryKeepsWalletLocalExitPendingForUnmatchedForfeitedVTXO(
+	t *testing.T) {
+
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{}
+	rpc.unrollStatusResp = &daemonrpc.GetUnrollStatusResponse{
+		Found: false,
+	}
+	rpc.listVTXOsByStatus = map[daemonrpc.VTXOStatus]*daemonrpc.
+		ListVTXOsResponse{
+
+		daemonrpc.VTXOStatus_VTXO_STATUS_UNILATERAL_EXIT: {},
+		daemonrpc.VTXOStatus_VTXO_STATUS_FORFEITED: {
+			Vtxos: []*daemonrpc.VTXO{
+				{
+					Outpoint: "other-leave-outpoint:0",
+					Status: daemonrpc.
+						VTXOStatus_VTXO_STATUS_FORFEITED,
+				},
+			},
+		},
+	}
+
+	pending := leaveEntryStub(
+		[]string{
+			"leave-outpoint:1",
+		}, "bcrt1qdest",
+		50_000, "user note",
+	)
+	h.runtime.trackPendingEntryWithoutTimeout(pending)
+
+	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{})
+	require.NoError(t, err)
+
+	entries := resp.GetActivity().GetEntries()
+	require.Len(t, entries, 1)
+	require.Equal(t, "leave-outpoint:1", entries[0].GetId())
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		entries[0].GetStatus(),
+	)
+	require.Equal(
+		t,
+		walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_REQUEST_CREATED,
+		entries[0].GetProgress().GetPhase(),
+	)
+	require.Equal(
+		t, "request_created", entries[0].GetProgress().GetPhaseLabel(),
+	)
+}
+
+// TestHistoryScansForfeitedVTXOsOnceForWalletLocalExits confirms activity list
+// batches the cooperative-leave terminal lookup. A wallet process can retain
+// multiple runtime-local EXIT rows until restart; history should not scan the
+// full forfeited VTXO set once per row.
+func TestHistoryScansForfeitedVTXOsOnceForWalletLocalExits(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{}
+	rpc.unrollStatusResp = &daemonrpc.GetUnrollStatusResponse{
+		Found: false,
+	}
+	rpc.listVTXOsByStatus = map[daemonrpc.VTXOStatus]*daemonrpc.
+		ListVTXOsResponse{
+
+		daemonrpc.VTXOStatus_VTXO_STATUS_UNILATERAL_EXIT: {},
+		daemonrpc.VTXOStatus_VTXO_STATUS_FORFEITED: {
+			Vtxos: []*daemonrpc.VTXO{
+				{
+					Outpoint: "leave-outpoint:1",
+					Status: daemonrpc.
+						VTXOStatus_VTXO_STATUS_FORFEITED,
+				},
+			},
+		},
+	}
+
+	h.runtime.trackPendingEntryWithoutTimeout(
+		leaveEntryStub(
+			[]string{
+				"leave-outpoint:1",
+			}, "bcrt1qdest",
+			50_000, "first note",
+		),
+	)
+	h.runtime.trackPendingEntryWithoutTimeout(
+		leaveEntryStub(
+			[]string{
+				"other-leave-outpoint:0",
+			}, "bcrt1qdest",
+			25_000, "second note",
+		),
+	)
+
+	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{})
+	require.NoError(t, err)
+
+	byID := make(map[string]*walletdkrpc.WalletEntry)
+	for _, entry := range resp.GetActivity().GetEntries() {
+		byID[entry.GetId()] = entry
+	}
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		byID["leave-outpoint:1"].GetStatus(),
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		byID["other-leave-outpoint:0"].GetStatus(),
+	)
+	require.Equal(t, 2, rpc.listVTXOsCalls)
+	require.Equal(
+		t, daemonrpc.VTXOStatus_VTXO_STATUS_FORFEITED,
+		rpc.listVTXOsLastReq.GetStatusFilter(),
+	)
+}
+
 // TestHistoryKeepsCSVPendingUnilateralExitPendingAfterDeadline confirms the
 // wallet-local timeout overlay cannot clobber the unroll subsystem's
 // authoritative non-terminal status. Unilateral exits normally wait through a

--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -38,6 +38,9 @@ type fakeRPCServer struct {
 	newAddressResp   *daemonrpc.NewAddressResponse
 	newAddressErr    error
 
+	listVTXOsByStatus map[daemonrpc.VTXOStatus]*daemonrpc.
+				ListVTXOsResponse
+
 	newWalletAddressResp string
 	newWalletAddressErr  error
 	listWalletUnspent    []*wallet.Utxo
@@ -98,6 +101,12 @@ func (f *fakeRPCServer) ListVTXOs(_ context.Context,
 
 	f.listVTXOsCalls++
 	f.listVTXOsLastReq = req
+
+	if f.listVTXOsByStatus != nil {
+		if resp, ok := f.listVTXOsByStatus[req.GetStatusFilter()]; ok {
+			return resp, f.listVTXOsErr
+		}
+	}
 
 	return f.listVTXOsResp, f.listVTXOsErr
 }


### PR DESCRIPTION
## Summary

This fixes the remaining cooperative-leave activity gap from #568.

The manual arktest run on latest `main` no longer reproduces the original
balance/VTXO bug: after a cooperative on-chain send confirms, the source VTXO
moves through `PENDING_FORFEIT` / `FORFEITING` to `FORFEITED`, the change VTXO is
live, and wallet balance reflects only the remaining Ark funds. The remaining
problem is the runtime-local EXIT activity row: it keeps showing as `PENDING`
because cooperative leaves do not have an unroll job for `GetUnrollStatus` to
use as a decorator.

This patch makes the history projection use the source VTXO's terminal state for
that runtime-local row. If a pending EXIT entry has no unroll job and its entry id
matches a `FORFEITED` VTXO, the row is shown as `COMPLETE` with the confirmed
phase and no longer appears in `activity --pending`.

## Manual Test Evidence

Using arktest against latest `main` plus the fixed `walletdkrpc` arktest tag:

- Alice boarded `200,000 sat`.
- Alice sent `50,000 sat` on-chain to Bob's LND wallet.
- Source VTXO:
  `5ba3ccd355453eb1d97847e9cd90c5435e3092336eff35360ab693d4f05dbc1c:0`.
- Source VTXO transitioned to `VTXO_STATUS_FORFEITED` after the leave round
  confirmed.
- Alice received a live change VTXO:
  `5bb86ae0b900fd5127a47642ea079063c224b96b0f3fb9959aaf1ccb412efd91:0`,
  amount `149,106 sat`.
- Alice wallet balance matched the live change amount: `149,106 sat`.
- Bob's LND wallet saw the `50,000 sat` confirmed output in tx
  `55af3668c74c082b46f78a799a726a9824349a08ee17c4e60c48024efc82761c`.
- Before this PR, `activity --pending` still showed the original EXIT row as
  pending after confirmation.

## Limits

This is a best-effort fix for the live runtime row. After a daemon restart, v1
still cannot recreate the original cooperative-leave counterparty/note from
persistent state alone. The durable v2 fix should persist a leave-job correlation
that links queued outpoints to the eventual commitment transaction.

## Tests

- `go test -tags 'walletdkrpc swapruntime' ./swapwallet`
- `go test ./vtxo ./wallet ./darepod`
- `make fmt-changed`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`

Fixes #568.
