### PR TITLE
db: configurable commit durability and fullfsync, pg test-DB reuse

### DIFF
--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -214,6 +214,23 @@ func newRootCmd() *cobra.Command {
 			"otherwise",
 	)
 
+	// SQLite database durability knobs (db.sqlite.* namespace). The
+	// db.postgres.* namespace is reserved for a future Postgres-tuning
+	// change; the daemon always opens SQLite.
+	f.String(
+		"db.sqlite.synchronous", cfg.DB.Sqlite.Synchronous, "the "+
+			"SQLite synchronous (commit durability) level: one "+
+			"of full, normal, off; empty defaults to normal, "+
+			"which under WAL mode omits the per-commit fsync "+
+			"of full for higher write throughput",
+	)
+	f.Bool(
+		"db.sqlite.nofullfsync", cfg.DB.Sqlite.NoFullfsync, "disable"+
+			" the SQLite fullfsync pragma (macOS only); trades "+
+			"power-loss flush guarantees for higher sustained "+
+			"write throughput",
+	)
+
 	// OOR safety limits. These are advanced knobs; most operators
 	// should keep the defaults unless a limit-exceeded error says
 	// otherwise after a protocol upgrade or operator/indexer change.

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -275,12 +275,57 @@ type Config struct {
 	// sdk/walletdk embedded path).
 	EagerRoundJoin bool `mapstructure:"eagerroundjoin"`
 
+	// DB groups the per-backend database tuning knobs under the db.sqlite.*
+	// and db.postgres.* namespaces. A value type so a zero-value Config can
+	// never carry a nil sub-config into the start path.
+	DB DBConfig `mapstructure:"db"`
+
 	// Pprof configures the optional net/http/pprof debug server. It is
 	// disabled by default and must be explicitly opted into via a
 	// non-empty listen address. A value type so a zero-value Config can
 	// never carry a nil pprof config into the start path.
 	Pprof PprofConfig `mapstructure:"pprof"`
 }
+
+// DBConfig groups the per-backend database tuning knobs. Only the SQLite
+// knobs are wired today; the daemon always opens SQLite, so the Postgres
+// namespace is reserved for a future Postgres-tuning change.
+type DBConfig struct {
+	// Sqlite holds the SQLite-backend durability knobs, exposed on the
+	// daemon under the db.sqlite.* namespace.
+	Sqlite DBSqliteConfig `mapstructure:"sqlite"`
+
+	// Postgres is reserved for future Postgres-backend tuning knobs. It is
+	// intentionally empty today: the daemon always opens SQLite, and
+	// Postgres durability tuning is deferred to a separate change.
+	Postgres DBPostgresConfig `mapstructure:"postgres"`
+}
+
+// DBSqliteConfig holds the SQLite-backend durability knobs exposed on the
+// daemon under the db.sqlite.* namespace.
+type DBSqliteConfig struct {
+	// Synchronous selects the SQLite synchronous (commit durability)
+	// level. One of "full", "normal", or "off"; an empty value resolves to
+	// the safe default ("normal"). Under WAL mode "normal" omits the
+	// per-commit WAL fsync of "full" for substantially higher write
+	// throughput, replaying any tail dropped on power loss via the
+	// idempotent persistence stack. See db.SqliteConfig.Synchronous.
+	Synchronous string `mapstructure:"synchronous"`
+
+	// NoFullfsync disables the SQLite fullfsync pragma. The pragma only
+	// matters on macOS, where it makes flushes wait on a full hardware
+	// cache flush; with the default synchronous=normal level it governs
+	// the WAL checkpoint sync, which recurs continuously under sustained
+	// write load. Write-heavy macOS deployments that accept the weaker
+	// flush guarantee can disable it for substantially higher throughput.
+	// No effect on other platforms. See db.SqliteConfig.NoFullfsync.
+	NoFullfsync bool `mapstructure:"nofullfsync"`
+}
+
+// DBPostgresConfig is reserved for future Postgres-backend tuning knobs. It
+// is intentionally empty: the daemon always opens SQLite, and Postgres
+// durability tuning is deferred to a separate change.
+type DBPostgresConfig struct{}
 
 // RPCServiceRegistrar registers one optional daemon gRPC subserver on the
 // daemon's existing listener.

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -2943,6 +2943,13 @@ func (s *Server) initDatabase(ctx context.Context) error {
 	}
 
 	sqliteCfg := db.DefaultSqliteConfig(networkDir)
+	sqliteCfg.NoFullfsync = s.cfg.DB.Sqlite.NoFullfsync
+
+	// An empty level keeps the DefaultSqliteConfig default ("normal"); a
+	// non-empty operator override is validated in NewSqliteStore.
+	if s.cfg.DB.Sqlite.Synchronous != "" {
+		sqliteCfg.Synchronous = s.cfg.DB.Sqlite.Synchronous
+	}
 
 	var err error
 	s.db, err = db.NewSqliteStore(

--- a/db/actordelivery/migrations_test.go
+++ b/db/actordelivery/migrations_test.go
@@ -27,7 +27,8 @@ func newSQLiteDB(t *testing.T) *sql.DB {
 
 // newConcurrentSQLiteDB opens a sqlite test database configured exactly like
 // the production store (see db/sqlite.go): WAL journaling, a 30s busy_timeout,
-// synchronous=full, and _txlock=immediate, with the same multi-connection pool.
+// synchronous=normal, and _txlock=immediate, with the same multi-connection
+// pool.
 // Tests that drive concurrent writers (e.g. a multi-worker durable actor) must
 // use this rather than the bare newSQLiteDB: _txlock=immediate plus
 // busy_timeout is what lets concurrent write transactions serialize by waiting
@@ -41,7 +42,7 @@ func newConcurrentSQLiteDB(t testing.TB) *sql.DB {
 		"foreign_keys=on",
 		"journal_mode=WAL",
 		"busy_timeout=30000",
-		"synchronous=full",
+		"synchronous=normal",
 		"fullfsync=true",
 	}
 	opts := make(url.Values)

--- a/db/sqlite.go
+++ b/db/sqlite.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"net/url"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,6 +42,36 @@ const (
 	// defaultConnMaxLifetime is the maximum amount of time a connection can
 	// be reused for before it is closed.
 	defaultConnMaxLifetime = 10 * time.Minute
+
+	// defaultSqliteSynchronous is the default value for the SQLite
+	// synchronous pragma. We default to "normal" rather than "full"
+	// because, under WAL mode, "normal" omits the per-commit WAL fsync
+	// entirely (the WAL is synced only before a checkpoint), which is
+	// exactly what makes it faster than "full". A committed transaction is
+	// still durable across an application/process crash, but a power loss
+	// or OS crash can roll back the recently committed tail still sitting
+	// in the un-synced WAL. The at-least-once, idempotent, deterministic
+	// OOR/outbox/serverconn stack recovers from a process crash with zero
+	// loss and replays that dropped tail after power loss, so the
+	// per-commit fsync of "full" is an unneeded throughput ceiling.
+	// "normal" never corrupts the database ("off" is not corruption-safe).
+	defaultSqliteSynchronous = SqliteSynchronousNormal
+
+	// SqliteSynchronousFull is the strictest SQLite synchronous level. It
+	// fsyncs on every commit, trading throughput for the strongest
+	// per-commit durability guarantee.
+	SqliteSynchronousFull = "full"
+
+	// SqliteSynchronousNormal relaxes the synchronous pragma to "normal".
+	// Under WAL mode this omits the per-commit WAL fsync (syncing the WAL
+	// only before a checkpoint), which is safe given our recoverable,
+	// idempotent persistence stack.
+	SqliteSynchronousNormal = "normal"
+
+	// SqliteSynchronousOff disables synchronous flushing entirely. This is
+	// the most aggressive (and least durable) level; a power loss may lose
+	// recently committed transactions, but it never corrupts the database.
+	SqliteSynchronousOff = "off"
 )
 
 // SqliteConfig holds all the config arguments needed to interact with our
@@ -58,6 +90,23 @@ type SqliteConfig struct {
 	// DatabaseFileName is the full file path where the database file can be
 	// found.
 	DatabaseFileName string `long:"dbfile" description:"The full path to the database."`
+
+	// Synchronous controls the SQLite synchronous pragma, which governs
+	// commit durability. Valid values are "full", "normal", and "off".
+	// When empty it defaults to "normal", which under WAL mode omits the
+	// per-commit WAL fsync of "full" (the WAL is synced only before a
+	// checkpoint).
+	Synchronous string `long:"synchronous" description:"The SQLite synchronous (commit durability) level. One of: full, normal, off."`
+
+	// NoFullfsync disables the SQLite fullfsync pragma. The pragma only
+	// matters on macOS, where a regular fsync does not guarantee the data
+	// reached stable storage; with synchronous=normal it governs the WAL
+	// checkpoint sync. Checkpoints fire continuously under a sustained
+	// write load and F_FULLFSYNC waits on a full hardware cache flush, so
+	// write-heavy deployments that accept the weaker flush guarantee can
+	// disable it for substantially better throughput. The default keeps
+	// fullfsync enabled.
+	NoFullfsync bool `long:"nofullfsync" description:"Disable the macOS fullfsync pragma; trades power-loss flush guarantees on macOS for higher sustained write throughput. No effect on other platforms."`
 
 	// Log is an optional logger for the SQLite store. When None, the store
 	// falls back to the explicit constructor logger.
@@ -82,6 +131,13 @@ func NewSqliteStore(cfg *SqliteConfig,
 	// Resolve the effective logger: prefer the config option, then fall
 	// back to the explicitly provided logger parameter.
 	storeLog := cfg.Log.UnwrapOr(explicitLog)
+
+	// Resolve and validate the configured synchronous level before we build
+	// the DSN, normalizing an empty value to the safe default.
+	synchronous, err := resolveSqliteSynchronous(cfg.Synchronous)
+	if err != nil {
+		return nil, err
+	}
 
 	// The set of pragma options are accepted using query options. For now
 	// we only want to ensure that foreign key constraints are properly
@@ -115,19 +171,29 @@ func NewSqliteStore(cfg *SqliteConfig,
 			value: "30000",
 		},
 		{
-			// With the WAL mode, this ensures that we also do an
-			// extra WAL sync after each transaction. The normal
-			// sync mode skips this and gives better performance,
-			// but risks durability.
+			// The synchronous pragma governs commit durability.
+			// Under WAL mode, "full" fsyncs the WAL on every
+			// commit; "normal" (our default) omits that per-commit
+			// fsync and syncs the WAL only before a checkpoint, for
+			// substantially better throughput at the cost of the
+			// recently committed tail on power loss. The value is
+			// configurable so operators can trade durability for
+			// performance. See resolveSqliteSynchronous for the
+			// accepted values.
 			name:  "synchronous",
-			value: "full",
+			value: synchronous,
 		},
 		{
-			// This is used to ensure proper durability for users
-			// running on Mac OS. It uses the correct fsync system
-			// call to ensure items are fully flushed to disk.
+			// fullfsync uses the correct fsync system call on macOS
+			// so that flushed data is genuinely durable. Under
+			// "normal" it governs the WAL checkpoint sync rather
+			// than a per-commit fsync, but checkpoints recur
+			// continuously under sustained write load and each
+			// F_FULLFSYNC waits on a full hardware cache flush, so
+			// the config exposes an opt-out for write-heavy
+			// deployments. Enabled by default.
 			name:  "fullfsync",
-			value: "true",
+			value: strconv.FormatBool(!cfg.NoFullfsync),
 		},
 	}
 	sqliteOptions := make(url.Values)
@@ -148,6 +214,8 @@ func NewSqliteStore(cfg *SqliteConfig,
 
 	storeLog.InfoS(ctx, "Opening SQLite database",
 		slog.String("db_file", cfg.DatabaseFileName),
+		slog.String("synchronous", synchronous),
+		slog.Bool("fullfsync", !cfg.NoFullfsync),
 		slog.Int("max_conns", defaultMaxConns),
 		slog.Duration("conn_max_lifetime", defaultConnMaxLifetime),
 	)
@@ -211,6 +279,35 @@ func NewSqliteStore(cfg *SqliteConfig,
 	}
 
 	return s, nil
+}
+
+// resolveSqliteSynchronous normalizes and validates a configured SQLite
+// synchronous level. An empty value resolves to the package default
+// (defaultSqliteSynchronous); any other value must be one of "full",
+// "normal", or "off". Unknown values are rejected with a descriptive error so
+// a typo surfaces at startup rather than silently weakening durability.
+func resolveSqliteSynchronous(value string) (string, error) {
+	if value == "" {
+		return defaultSqliteSynchronous, nil
+	}
+
+	// Normalize case before validating so an operator can spell the level
+	// in any case (e.g. "NORMAL"), matching the uppercase form used in the
+	// durability docs and prose. The resolved value is returned lowercased
+	// so it feeds the pragma as SQLite expects.
+	level := strings.ToLower(value)
+
+	switch level {
+	case SqliteSynchronousFull, SqliteSynchronousNormal,
+		SqliteSynchronousOff:
+		return level, nil
+
+	default:
+		return "", fmt.Errorf("invalid sqlite synchronous level %q: "+
+			"must be one of %q, %q, or %q", value,
+			SqliteSynchronousFull, SqliteSynchronousNormal,
+			SqliteSynchronousOff)
+	}
 }
 
 // backupSqliteDatabase creates a backup of the given SQLite database. The

--- a/db/sqlite_test.go
+++ b/db/sqlite_test.go
@@ -1,0 +1,117 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// queryFullfsync reads back the effective fullfsync pragma on a store.
+func queryFullfsync(t *testing.T, store *SqliteStore) int {
+	t.Helper()
+
+	var value int
+	err := store.DB.QueryRow("PRAGMA fullfsync;").Scan(&value)
+	require.NoError(t, err)
+
+	return value
+}
+
+// TestSqliteFullfsyncKnob verifies that the NoFullfsync config field controls
+// the fullfsync pragma on new connections, and that the default keeps it
+// enabled.
+func TestSqliteFullfsyncKnob(t *testing.T) {
+	t.Parallel()
+
+	newStore := func(t *testing.T, noFullfsync bool) *SqliteStore {
+		store, err := NewSqliteStore(&SqliteConfig{
+			DatabaseFileName: filepath.Join(
+				t.TempDir(),
+				"test.db",
+			),
+			SkipMigrations: true,
+			NoFullfsync:    noFullfsync,
+		}, btclog.Disabled)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, store.DB.Close())
+		})
+
+		return store
+	}
+
+	defaultStore := newStore(t, false)
+	require.Equal(t, 1, queryFullfsync(t, defaultStore))
+
+	disabledStore := newStore(t, true)
+	require.Equal(t, 0, queryFullfsync(t, disabledStore))
+}
+
+// TestResolveSqliteSynchronous verifies that the configured synchronous level
+// is normalized and validated: an empty value resolves to the safe default,
+// each valid level passes through unchanged, and an unknown value is rejected
+// so a typo surfaces at startup rather than silently weakening durability.
+func TestResolveSqliteSynchronous(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "empty resolves to default normal",
+			value: "",
+			want:  defaultSqliteSynchronous,
+		},
+		{
+			name:  "full passes through",
+			value: SqliteSynchronousFull,
+			want:  SqliteSynchronousFull,
+		},
+		{
+			name:  "normal passes through",
+			value: SqliteSynchronousNormal,
+			want:  SqliteSynchronousNormal,
+		},
+		{
+			name:  "off passes through",
+			value: SqliteSynchronousOff,
+			want:  SqliteSynchronousOff,
+		},
+		{
+			name:  "uppercase normalizes to lowercase",
+			value: "NORMAL",
+			want:  SqliteSynchronousNormal,
+		},
+		{
+			name:  "mixed case normalizes to lowercase",
+			value: "Full",
+			want:  SqliteSynchronousFull,
+		},
+		{
+			name:    "unknown value is rejected",
+			value:   "fsync",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveSqliteSynchronous(tc.value)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/db/store.go
+++ b/db/store.go
@@ -111,6 +111,7 @@ func DefaultConfig(dataDir string) *Config {
 func DefaultSqliteConfig(dataDir string) *SqliteConfig {
 	return &SqliteConfig{
 		DatabaseFileName: fmt.Sprintf("%s/arkd.db", dataDir),
+		Synchronous:      defaultSqliteSynchronous,
 	}
 }
 

--- a/db/test_postgres.go
+++ b/db/test_postgres.go
@@ -3,8 +3,26 @@
 package db
 
 import (
+	"sync"
 	"testing"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/stretchr/testify/require"
 )
+
+// testPgFixtureMtx guards testPgFixturesByPath. Tests may restart a client
+// concurrently with others, so the path-keyed cache must be safe to read and
+// write from multiple goroutines.
+var testPgFixtureMtx sync.Mutex
+
+// testPgFixturesByPath memoizes the Postgres fixture (the docker container and
+// its underlying database) created for a given dbPath. The systest restart
+// harness reopens the SAME dbPath to model a daemon restart and expects the
+// previously persisted state to survive. The sqlite backend gets this for free
+// because it reopens the file at dbPath; Postgres has no such file, so we
+// retain the same underlying database across calls and hand out a fresh store
+// (connection pool) over it each time.
+var testPgFixturesByPath = make(map[string]*TestPgFixture)
 
 // NewTestDB is a helper function that creates a Postgres database for testing.
 func NewTestDB(t testing.TB) *PostgresStore {
@@ -12,9 +30,88 @@ func NewTestDB(t testing.TB) *PostgresStore {
 }
 
 // NewTestDBHandleFromPath is a helper function that creates a new handle to an
-// existing SQLite database for testing.
+// existing Postgres database for testing, keyed by dbPath.
+//
+// On sqlite, reopening dbPath reattaches to the same on-disk file, so state
+// survives a simulated daemon restart. Postgres has no such file: a naive
+// implementation would spin up a brand-new empty database on every call,
+// silently dropping all persisted state (OOR sessions, wallet, boarding) the
+// moment a test restarts a client. The restart path also closes the previous
+// store's connection pool on shutdown, so we cannot simply hand back the same
+// store either; the reopened handle must be a fresh, open pool.
+//
+// To match the sqlite semantics we memoize the fixture (the docker container
+// and its database) per dbPath, and open a NEW store over it on every call:
+// the first call for a path creates the database, runs migrations, and
+// registers teardown; later calls with the same path reuse that same database
+// (so the state carries across the restart) but open a fresh connection pool
+// and skip migrations, since the schema already exists. dbPaths are unique per
+// client per test (temp dirs), so reuse only ever happens within a single test
+// (the original handle plus its restart).
+//
+// Invariant: the fixture teardown and cache eviction are registered against the
+// testing.TB of the FIRST call for a path, so a given dbPath must only ever be
+// reused within the lifetime of the test that first opened it. The unique
+// per-client temp-dir paths guarantee this; callers must not share a dbPath
+// across independent tests.
 func NewTestDBHandleFromPath(t testing.TB, dbPath string) *PostgresStore {
-	return NewTestPostgresDB(t)
+	t.Helper()
+
+	// For tests, use a simple logger that outputs to the test log.
+	log := btclog.Disabled
+
+	testPgFixtureMtx.Lock()
+	defer testPgFixtureMtx.Unlock()
+
+	sqlFixture, ok := testPgFixturesByPath[dbPath]
+	if !ok {
+		// First handle for this path: stand up the database, run
+		// migrations via the default store path, and register teardown.
+		sqlFixture = NewTestPgFixture(
+			t, DefaultPostgresFixtureLifetime, true,
+		)
+
+		store, err := NewPostgresStore(sqlFixture.GetConfig(), log)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			sqlFixture.TearDown(t)
+
+			testPgFixtureMtx.Lock()
+			delete(testPgFixturesByPath, dbPath)
+			testPgFixtureMtx.Unlock()
+		})
+
+		// Close this pool at test end even if the caller's restart
+		// shutdown already closed it (sql.DB.Close is idempotent), so a
+		// test that never restarts does not leak the pool. Registered
+		// after TearDown so it runs first (cleanups are LIFO).
+		t.Cleanup(func() {
+			_ = store.DB.Close()
+		})
+
+		testPgFixturesByPath[dbPath] = sqlFixture
+
+		return store
+	}
+
+	// Subsequent handle for this path (a restart): reuse the existing
+	// database but open a fresh connection pool over it. The schema and
+	// data already exist, so migrations are skipped.
+	storeCfg := sqlFixture.GetConfig()
+	storeCfg.SkipMigrations = true
+
+	store, err := NewPostgresStore(storeCfg, log)
+	require.NoError(t, err)
+
+	// The caller closes this pool on its restart-shutdown, but register a
+	// cleanup too (sql.DB.Close is idempotent) so the per-restart pool is
+	// released even if the test ends without a further restart.
+	t.Cleanup(func() {
+		_ = store.DB.Close()
+	})
+
+	return store
 }
 
 // NewTestDBWithVersion is a helper function that creates a Postgres database

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -50,6 +50,18 @@
 # end-to-end.
 # eagerroundjoin=false
 
+# SQLite commit durability level: one of full, normal, off. Empty defaults
+# to normal, which under WAL mode omits the per-commit WAL fsync of full
+# (the WAL is synced only before a checkpoint) for substantially higher
+# write throughput while staying safe against corruption. Values are
+# case-insensitive.
+# db.sqlite.synchronous=
+
+# Disable the SQLite fullfsync pragma (macOS only); trades power-loss flush
+# guarantees for higher sustained write throughput. No effect on other
+# platforms.
+# db.sqlite.nofullfsync=false
+
 # Address for the pprof debug HTTP server, for example 127.0.0.1:6060. Empty
 # disables pprof entirely. When set, a dedicated HTTP server exposes the
 # standard net/http/pprof endpoints. The server is plain HTTP (no TLS) and


### PR DESCRIPTION
In this PR, we expose the SQLite storage durability levers that the OOR
benchmarking campaign showed were the first two ceilings on payment
throughput, and we make the postgres test harness reuse its database across
daemon restarts so restart-style systests work on both backends.

The headline knob is commit durability: `synchronous` is now configurable,
defaulting to NORMAL on the client (was FULL). Under WAL, NORMAL omits the
per-commit WAL fsync (the WAL is synced only before a checkpoint), so a power
loss can roll back the last few commits but can never corrupt the database; an
OS or app crash loses nothing. That contract composes cleanly with the durable
mailbox model, where every cross-actor message is redelivered until acked, so a
dropped tail commit replays rather than strands. On the high-contention stress
shape this single default was worth 1.3-2.3x throughput with p50 falling from
~6s to ~700ms: the per-commit fsync was the latency tail.

The second knob is macOS specific: sqlite on darwin issues F_FULLFSYNC (a full
disk-barrier flush), a hidden second fsync tax that profiling showed cost ~35%
throughput on the bench host. Under NORMAL it governs the WAL checkpoint sync
rather than a per-commit fsync, but checkpoints recur continuously under
sustained write load, so the `fullfsync` pragma is now configurable. The
default is unchanged.

Both knobs are exposed on the daemon under the `db.sqlite.*` namespace
(`db.sqlite.synchronous`, `db.sqlite.nofullfsync`), matching the dotted config
convention used elsewhere; the `db.postgres.*` namespace is reserved.
Postgres-side durability tuning (`synchronous_commit`) is deliberately deferred
to a separate change, and the operator-side default is a separate decision that
stays FULL over there (darepo#553).

The test-infra commit keys the postgres test database off the dbPath so a
restarted daemon lands on the same database rather than a fresh one, which the
restart-recovery systests depend on.

This PR builds on #693 and is part of the OOR optimization train.
