### PR TITLE
baselib/actor+db: leaseless single-worker consume, transactional outbox

### DIFF
--- a/baselib/actor/CLAUDE.md
+++ b/baselib/actor/CLAUDE.md
@@ -26,7 +26,7 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `Receptionist` — Service locator mapping `ServiceKey` → `ActorRef` for decoupled actor wiring.
 - `Message` — Sealed interface for all actor messages (must embed `BaseMessage`).
 - `MessageCodec` — TLV-based codec for message serialization/deserialization.
-- `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter).
+- `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter). The leaseless single-worker fast path adds `PeekNextMessage` (read-only claim, no lease, no attempts bump; yields an empty lease token), `AckMessageByID` (unfenced delete), and `NackMessageByID` (unfenced release that increments attempts). A `DurableActor` enables it (via `DurableMailboxConfig.SingleWorkerLeaseless`) strictly when `NumWorkers == 1` AND the behavior is the Read/Commit (Right/`TxBehavior`) path, eliminating the per-message lease write transaction. The multi-worker pool and the classic path are byte-for-byte unchanged: they keep `LeaseNextMessage` and the lease-fenced ack. Ack/nack route to the by-ID ops automatically whenever the delivery's lease token is empty; `Delivery.ShouldDeadLetter` counts the in-flight attempt as `Attempts + 1` on the leaseless path so the dead-letter boundary matches the leased path (where attempts is pre-incremented at lease).
 - `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence. Provides `Wait(ctx)` to block until the actor stops and `StopAndWait(ctx)` to request a graceful shutdown and then wait.
 - `DurableActorConfig[M, R]` — Configuration struct for `DurableActor`: behavior, store, codec, clock, DLO, WaitGroup, `TellRetryPolicy`, lease/heartbeat/poll durations, max attempts, cleanup timeout, deduplication TTL, and `NumWorkers`.
 - `DurableActorConfig.NumWorkers` — How many concurrent worker loops drain the actor's single mailbox. Default and any value `<= 1` is one worker (strictly-sequential processing). A value `> 1` turns the actor into a competing-consumer pool: that many goroutines each lease distinct messages via `LeaseNextMailboxMessage`, so independent messages run in parallel while per-correlation-key FIFO still keeps same-key messages ordered. Only for behaviors whose handlers are concurrency-safe and hold no writer across their side effects (e.g. the serverconn egress sender on the Read/Commit path). `NewDurableActor` **fails closed** with `ErrConcurrentClassicBehavior` when `NumWorkers > 1` is paired with a classic (`Left`) `ActorBehavior`, since the classic path wraps the whole `Receive` in one write transaction and assumes sequential delivery; pools are only valid on the Read/Commit (`TxBehavior`) path. The test-only `DurableActorConfig.AllowConcurrentClassicBehavior()` escape hatch bypasses the guard for the egress benchmark that measures the forbidden config; production code must never call it.
@@ -62,6 +62,16 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 ## Invariants
 
 - Messages are processed sequentially per actor by default (one worker, no concurrent `Receive` calls). Opting into `DurableActorConfig.NumWorkers > 1` relaxes this: that many worker loops drain the one mailbox concurrently, so `Receive` may run in parallel across distinct messages. The competing-consumer lease guarantees each message is still processed by exactly one worker, and per-correlation-key FIFO holds across workers; only behaviors with concurrency-safe handlers should set it. The combination is structurally restricted to the Read/Commit path: `NewDurableActor` rejects `NumWorkers > 1` on a classic `ActorBehavior` with `ErrConcurrentClassicBehavior` so a stateful, sequentially-assumed actor can never be silently fanned out.
+- **Leaseless consume ownership model.** `SingleWorkerLeaseless` removes the
+  lease-token fence, so its safety argument is "one live runtime owner for this
+  mailbox", not merely "one goroutine in this process". Do not enable it for a
+  mailbox that can be drained by another daemon/process at the same time unless
+  an external singleton/ownership fence already exists. A peeked delivery always
+  carries an empty lease token, even when the persisted row still has stale
+  expired lease metadata from an older leased claim; that empty token is the
+  p-model edge that routes ack/nack to the by-ID operations. Retry-policy
+  decisions must use `Delivery.EffectiveAttempts()` so the in-flight peeked
+  attempt is counted before a nack can raise the row to `max_attempts`.
 - `Tell` with a `DurableActor` persists the message before returning (crash-safe enqueue).
 - Outbox messages are dispatched only after state is persisted (outbox pattern).
 - `ServiceKey` lookup via `Receptionist` is type-safe: mismatched types return `ErrServiceKeyTypeMismatch`.

--- a/baselib/actor/CLAUDE.md
+++ b/baselib/actor/CLAUDE.md
@@ -74,6 +74,12 @@ crash-safe at-least-once delivery with exactly-once deduplication.
   attempt is counted before a nack can raise the row to `max_attempts`.
 - `Tell` with a `DurableActor` persists the message before returning (crash-safe enqueue).
 - Outbox messages are dispatched only after state is persisted (outbox pattern).
+- **Outbox fold p-model.** For tx-aware stores, outbox delivery is
+  `claim -> (target mailbox enqueue + CompleteOutbox) in one write tx`. If the
+  transaction fails before commit, both the enqueue and completion roll back and
+  the claim expiry is the retry mechanism; the publisher must log the
+  transaction failure even when the inner Tell/Complete operations returned nil,
+  because begin/commit failures happen outside those operation-level logs.
 - `ServiceKey` lookup via `Receptionist` is type-safe: mismatched types return `ErrServiceKeyTypeMismatch`.
 - `RestartMessage` has `RestartPriority` (MaxInt32) ensuring it is processed before all other messages on recovery.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.

--- a/baselib/actor/delivery.go
+++ b/baselib/actor/delivery.go
@@ -64,6 +64,14 @@ type Delivery[M TLVMessage, R any] struct {
 	// store is the backing store for persisting ack/nack operations.
 	store DeliveryStore
 
+	// leaseless reports that this delivery was peeked, not leased: it holds
+	// no lease token and its attempts count was NOT pre-incremented at
+	// claim time. The nack path increments attempts by ID, so the
+	// dead-letter boundary must count this in-flight attempt (Attempts + 1)
+	// to match the leased path, where attempts was already bumped at lease.
+	// See ShouldDeadLetter.
+	leaseless bool
+
 	// mu guards mutable fields (acked, LeaseUntil) that may be accessed
 	// concurrently by the heartbeat goroutine (Extend) and the main
 	// processing goroutine (Ack/Nack).
@@ -76,6 +84,35 @@ type Delivery[M TLVMessage, R any] struct {
 	// is used by the transaction path to defer promise completion until
 	// after the transaction commits successfully.
 	deferPromise bool
+
+	// mutationFailed records that a Nack store write (release, attempts
+	// bump, or dead-letter) returned an error, leaving the underlying row
+	// physically unchanged. The leaseless (peeked) path has no lease fence
+	// to throttle a re-peek of the same eligible row, so the worker loop
+	// inspects this flag after processing and backs off for a poll interval
+	// before the next claim, matching the implicit lease-expiry backoff of
+	// the fenced path instead of tight-spinning against a wedged DB.
+	mutationFailed bool
+}
+
+// MutationFailed reports whether the last Nack on this delivery failed to
+// persist its row mutation. The worker loop uses this to back off before
+// re-claiming, since a failed leaseless nack leaves the row unchanged and
+// immediately re-eligible.
+func (d *Delivery[M, R]) MutationFailed() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.mutationFailed
+}
+
+// setMutationFailed marks that a Nack store write failed to persist its row
+// mutation, so the worker loop should back off before re-claiming.
+func (d *Delivery[M, R]) setMutationFailed() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.mutationFailed = true
 }
 
 // IsAsk returns true if this delivery is for an Ask message (has a promise).
@@ -113,8 +150,27 @@ func (d *Delivery[M, R]) IsLeaseExpired() bool {
 
 // ShouldDeadLetter returns true if this message should be moved to the dead
 // letter queue (max attempts reached).
+//
+// The leased path pre-increments attempts at claim time, so Attempts already
+// counts the in-flight delivery and the boundary is Attempts >= MaxAttempts.
+// The leaseless (peeked) path does NOT pre-increment -- the nack increments by
+// ID -- so the in-flight attempt is counted as Attempts + 1, matching the
+// leased boundary and ensuring a message still dead-letters before it becomes
+// peek-ineligible (attempts == max_attempts).
 func (d *Delivery[M, R]) ShouldDeadLetter() bool {
-	return d.Attempts >= d.MaxAttempts
+	return d.EffectiveAttempts() >= d.MaxAttempts
+}
+
+// EffectiveAttempts returns the retry-policy attempt count for this delivery.
+// Leased deliveries are pre-incremented at claim time; leaseless peeked
+// deliveries are not, so the current in-flight attempt is counted here.
+func (d *Delivery[M, R]) EffectiveAttempts() int {
+	effectiveAttempts := d.Attempts
+	if d.leaseless {
+		effectiveAttempts++
+	}
+
+	return effectiveAttempts
 }
 
 // Ack marks the message as successfully processed.
@@ -141,8 +197,9 @@ func (d *Delivery[M, R]) Ack(ctx context.Context, result fn.Result[R]) error {
 	// This must happen before SaveAskResult to prevent stale lease
 	// holders from persisting results: ask_results uses ON CONFLICT
 	// DO NOTHING, so a stale write would silently block the valid
-	// worker's result.
-	rowsAffected, err := d.store.AckMessage(ctx, d.ID, d.LeaseToken)
+	// worker's result. A leaseless (peeked) delivery has an empty lease
+	// token and acks by ID; ackMessage routes to the unfenced op then.
+	rowsAffected, err := ackMessage(ctx, d.store, d.ID, d.LeaseToken)
 	if err != nil {
 		return fmt.Errorf("ack message: %w", err)
 	}
@@ -223,10 +280,15 @@ func (d *Delivery[M, R]) Nack(
 		if dlErr := d.store.MoveToDeadLetter(
 			ctx, d.ID, reason,
 		); dlErr != nil {
+
+			d.setMutationFailed()
+
 			return fmt.Errorf("move to dead letter: %w", dlErr)
 		}
 
 		if delErr := d.store.DeleteMessage(ctx, d.ID); delErr != nil {
+			d.setMutationFailed()
+
 			return fmt.Errorf("delete message after dead "+
 				"letter: %w", delErr)
 		}
@@ -238,11 +300,15 @@ func (d *Delivery[M, R]) Nack(
 		return nil
 	}
 
-	// Release the message for redelivery.
-	rowsAffected, nackErr := d.store.NackMessage(
-		ctx, d.ID, d.LeaseToken, retryAfter,
+	// Release the message for redelivery. A leaseless (peeked) delivery has
+	// an empty lease token and nacks by ID, which also increments attempts
+	// (the peek did not), preserving dead-lettering on max attempts.
+	rowsAffected, nackErr := nackMessage(
+		ctx, d.store, d.ID, d.LeaseToken, retryAfter,
 	)
 	if nackErr != nil {
+		d.setMutationFailed()
+
 		return fmt.Errorf("nack message: %w", nackErr)
 	}
 
@@ -313,5 +379,9 @@ func newDelivery[M TLVMessage, R any](
 		MaxAttempts:     msg.MaxAttempts,
 		store:           store,
 		acked:           false,
+
+		// A peeked (leaseless) message carries an empty lease token and
+		// its attempts were not pre-incremented at claim time.
+		leaseless: msg.LeaseToken == "",
 	}
 }

--- a/baselib/actor/delivery_store.go
+++ b/baselib/actor/delivery_store.go
@@ -185,6 +185,34 @@ type OutboxWakeRegistrar interface {
 	RegisterOutboxWake(func())
 }
 
+// MailboxWakeRegistrar is optionally implemented by stores that can notify a
+// same-process mailbox receive loop after an enqueue commits. It exists for the
+// folded outbox-delivery path: when EnqueueMessage runs inside an ambient
+// transaction (the OutboxPublisher folds the target enqueue and CompleteOutbox
+// into one write tx), the enqueued row is invisible to the target consumer
+// until the outer tx commits, so the pre-commit in-process wake fired by
+// DurableMailbox.Send races ahead of visibility and finds nothing. The store
+// fires the registered wakes only after the tx commits, so consumers re-poll
+// against a now-visible row instead of waiting out a full poll interval.
+// Polling remains the cross-process and restart fallback.
+type MailboxWakeRegistrar interface {
+	// RegisterMailboxWake registers a callback fired after any enqueue
+	// commits inside an ExecTx, and returns a cancel function that
+	// deregisters it. A DurableMailbox registers its Wake on construction
+	// and calls the returned cancel on Close, so a stopped mailbox leaves
+	// no closure behind.
+	//
+	// The wake is COARSE: after a folded enqueue commits, every registered
+	// mailbox is woken, so a non-target mailbox does one empty re-poll.
+	// This deliberately trades a precise per-mailbox wake for not tracking
+	// which mailbox received the message -- the store keeps a flat list of
+	// wakes rather than a per-mailbox registry plus a per-transaction
+	// target set, which removes the registry's restart-clobber races. The
+	// empty re-poll is cheap and bounded; the poll ticker remains the
+	// durable fallback.
+	RegisterMailboxWake(wake func()) (cancel func())
+}
+
 // EnqueueParams contains parameters for enqueueing a mailbox message.
 type EnqueueParams struct {
 	// ID is the unique message identifier (ULID recommended).

--- a/baselib/actor/delivery_store.go
+++ b/baselib/actor/delivery_store.go
@@ -22,15 +22,42 @@ type DeliveryStore interface {
 		leaseToken string,
 		leaseDuration time.Duration) (*LeasedMessage, error)
 
+	// PeekNextMessage claims the next available message with a READ-only
+	// query and takes NO lease: it does not set a lease token or expiry and
+	// does not increment attempts. It is the leaseless fast path for
+	// single-worker (NumWorkers == 1) actors, which have no competing
+	// consumer to fence the ack against. The returned LeasedMessage carries
+	// an EMPTY LeaseToken, which signals the consume path to ack/nack via
+	// the unfenced by-ID operations. Eligibility and ordering match
+	// LeaseNextMessage exactly. Returns nil if no messages are available.
+	PeekNextMessage(ctx context.Context,
+		mailboxID string) (*LeasedMessage, error)
+
 	// AckMessage acknowledges successful processing of a message.
 	// Validates the lease token to prevent stale acks. Returns the number
 	// of rows affected (0 if token mismatch, 1 if success).
 	AckMessage(ctx context.Context, id, leaseToken string) (int64, error)
 
+	// AckMessageByID acknowledges successful processing of a message by ID
+	// WITHOUT validating a lease token. It is the leaseless single-worker
+	// counterpart to AckMessage. Returns the number of rows affected (1 on
+	// success, 0 if the row was already gone). MUST NOT be used by the
+	// multi-worker path, which relies on lease-token fencing.
+	AckMessageByID(ctx context.Context, id string) (int64, error)
+
 	// NackMessage releases a message for redelivery after the specified
 	// delay. Clears the lease and sets a new available_at time.
 	// Validates the lease token to prevent stale nacks.
 	NackMessage(ctx context.Context, id, leaseToken string,
+		retryAfter time.Duration) (int64, error)
+
+	// NackMessageByID releases a message for redelivery by ID WITHOUT
+	// validating a lease token, and increments attempts. It is the
+	// leaseless single-worker counterpart to NackMessage. The attempts bump
+	// is required because the leaseless peek does not increment attempts,
+	// so the failure path must, to preserve dead-lettering on max attempts.
+	// Returns the number of rows affected.
+	NackMessageByID(ctx context.Context, id string,
 		retryAfter time.Duration) (int64, error)
 
 	// ExtendLease extends the lease for long-running message processing.
@@ -119,6 +146,36 @@ type DeliveryStore interface {
 
 	// CleanupExpired removes expired deduplication entries and ask results.
 	CleanupExpired(ctx context.Context) error
+}
+
+// ackMessage acknowledges a delivery, picking the fenced or unfenced store
+// operation by whether a lease token is present. A leaseless (peeked) delivery
+// carries an empty token and acks by ID; a leased delivery acks under its lease
+// fence. Centralizing the choice here keeps every ack call site -- the commit
+// fold, the non-tx tail, the classic tx path, and the duplicate-skip path --
+// consistent without each branching on the token.
+func ackMessage(ctx context.Context, store DeliveryStore, id,
+	leaseToken string) (int64, error) {
+
+	if leaseToken == "" {
+		return store.AckMessageByID(ctx, id)
+	}
+
+	return store.AckMessage(ctx, id, leaseToken)
+}
+
+// nackMessage releases a delivery for redelivery, picking the fenced or
+// unfenced store operation by whether a lease token is present. The unfenced
+// by-ID path additionally increments attempts, which the leaseless peek does
+// not do, so dead-lettering on max attempts is preserved.
+func nackMessage(ctx context.Context, store DeliveryStore, id,
+	leaseToken string, retryAfter time.Duration) (int64, error) {
+
+	if leaseToken == "" {
+		return store.NackMessageByID(ctx, id, retryAfter)
+	}
+
+	return store.NackMessage(ctx, id, leaseToken, retryAfter)
 }
 
 // OutboxWakeRegistrar is optionally implemented by stores that can notify a

--- a/baselib/actor/delivery_test.go
+++ b/baselib/actor/delivery_test.go
@@ -39,6 +39,13 @@ type mockDeliveryStore struct {
 	// outboxWakes stores callbacks invoked after outbox enqueue.
 	outboxWakes []func()
 
+	// mailboxWakes stores the live post-commit wakes registered via
+	// RegisterMailboxWake, keyed by an opaque handle. The real store fires
+	// every one of them after a folded enqueue commits (a coarse
+	// broadcast), and the returned cancel removes exactly its own entry.
+	mailboxWakes      map[uint64]func()
+	mailboxWakeNextID uint64
+
 	// Error injection for testing.
 	injectError error
 
@@ -61,12 +68,13 @@ type mockDeliveryStore struct {
 
 func newMockDeliveryStore() *mockDeliveryStore {
 	return &mockDeliveryStore{
-		messages:    make(map[string]*LeasedMessage),
-		askResults:  make(map[string]*AskResult),
-		processed:   make(map[string]bool),
-		checkpoints: make(map[string]*Checkpoint),
-		deadLetters: make(map[string]*DeadLetter),
-		outbox:      make(map[string]*OutboxMessage),
+		messages:     make(map[string]*LeasedMessage),
+		askResults:   make(map[string]*AskResult),
+		processed:    make(map[string]bool),
+		checkpoints:  make(map[string]*Checkpoint),
+		deadLetters:  make(map[string]*DeadLetter),
+		outbox:       make(map[string]*OutboxMessage),
+		mailboxWakes: make(map[uint64]func()),
 	}
 }
 
@@ -447,6 +455,41 @@ func (m *mockDeliveryStore) RegisterOutboxWake(wake func()) {
 	defer m.mu.Unlock()
 
 	m.outboxWakes = append(m.outboxWakes, wake)
+}
+
+func (m *mockDeliveryStore) RegisterMailboxWake(wake func()) func() {
+	if wake == nil {
+		return func() {}
+	}
+
+	m.mu.Lock()
+	id := m.mailboxWakeNextID
+	m.mailboxWakeNextID++
+	m.mailboxWakes[id] = wake
+	m.mu.Unlock()
+
+	// The cancel removes exactly this registration, mirroring the
+	// production store so a closed mailbox leaves no closure behind.
+	return func() {
+		m.mu.Lock()
+		delete(m.mailboxWakes, id)
+		m.mu.Unlock()
+	}
+}
+
+// fireMailboxWakes invokes every registered post-commit wake, standing in for
+// the real store firing the coarse broadcast after a folded enqueue commits.
+func (m *mockDeliveryStore) fireMailboxWakes() {
+	m.mu.Lock()
+	wakes := make([]func(), 0, len(m.mailboxWakes))
+	for _, wake := range m.mailboxWakes {
+		wakes = append(wakes, wake)
+	}
+	m.mu.Unlock()
+
+	for _, wake := range wakes {
+		wake()
+	}
 }
 
 func (m *mockDeliveryStore) ClaimOutboxBatch(ctx context.Context,

--- a/baselib/actor/delivery_test.go
+++ b/baselib/actor/delivery_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -46,6 +47,16 @@ type mockDeliveryStore struct {
 
 	// injectEnqueueError causes only EnqueueMessage to fail.
 	injectEnqueueError error
+
+	// injectNackError causes the by-ID nack to fail without affecting the
+	// peek/claim path. It models a wedged write txn on the leaseless nack
+	// edge while leaving the message peek-eligible.
+	injectNackError error
+
+	// peekCount counts PeekNextMessage calls. Used to assert that the
+	// receive loop backs off after a failed leaseless nack instead of
+	// tight-spinning re-peeks of the same eligible row.
+	peekCount atomic.Int64
 }
 
 func newMockDeliveryStore() *mockDeliveryStore {
@@ -131,6 +142,50 @@ func (m *mockDeliveryStore) LeaseNextMessage(ctx context.Context,
 	return nil, nil
 }
 
+// PeekNextMessage claims the next available message without taking a lease.
+// It mirrors LeaseNextMessage's eligibility but does not set a lease token,
+// does not set lease_until, and does NOT increment attempts. The returned
+// message carries an empty lease token.
+func (m *mockDeliveryStore) PeekNextMessage(ctx context.Context,
+	mailboxID string) (*LeasedMessage, error) {
+
+	m.peekCount.Add(1)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.injectError != nil {
+		return nil, m.injectError
+	}
+
+	now := time.Now()
+
+	for _, msg := range m.messages {
+		if msg.MailboxID != mailboxID {
+			continue
+		}
+
+		// Skip if leased and not expired.
+		if msg.LeaseToken != "" && msg.LeaseUntil.After(now) {
+			continue
+		}
+
+		// Skip if attempts exhausted, matching the SQL eligibility.
+		if msg.Attempts >= msg.MaxAttempts {
+			continue
+		}
+
+		// Return without mutating: no lease, no attempts bump.
+		peeked := *msg
+		peeked.LeaseToken = ""
+		peeked.LeaseUntil = time.Time{}
+
+		return &peeked, nil
+	}
+
+	return nil, nil
+}
+
 func (m *mockDeliveryStore) AckMessage(ctx context.Context, id,
 	leaseToken string) (int64, error) {
 
@@ -147,6 +202,27 @@ func (m *mockDeliveryStore) AckMessage(ctx context.Context, id,
 	}
 
 	if msg.LeaseToken != leaseToken {
+		return 0, nil
+	}
+
+	delete(m.messages, id)
+
+	return 1, nil
+}
+
+// AckMessageByID acknowledges a message by ID without lease-token validation,
+// mirroring the unfenced leaseless SQL ack.
+func (m *mockDeliveryStore) AckMessageByID(ctx context.Context, id string) (
+	int64, error) {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.injectError != nil {
+		return 0, m.injectError
+	}
+
+	if _, ok := m.messages[id]; !ok {
 		return 0, nil
 	}
 
@@ -177,6 +253,36 @@ func (m *mockDeliveryStore) NackMessage(ctx context.Context, id,
 	// Release the lease.
 	msg.LeaseToken = ""
 	msg.LeaseUntil = time.Time{}
+
+	return 1, nil
+}
+
+// NackMessageByID releases a message by ID without lease-token validation and
+// increments attempts, mirroring the unfenced leaseless SQL nack.
+func (m *mockDeliveryStore) NackMessageByID(ctx context.Context, id string,
+	retryAfter time.Duration) (int64, error) {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.injectError != nil {
+		return 0, m.injectError
+	}
+
+	if m.injectNackError != nil {
+		return 0, m.injectNackError
+	}
+
+	msg, ok := m.messages[id]
+	if !ok {
+		return 0, nil
+	}
+
+	// Release any lease and increment attempts. The attempts bump is the
+	// behavior the leaseless path relies on for dead-lettering.
+	msg.LeaseToken = ""
+	msg.LeaseUntil = time.Time{}
+	msg.Attempts++
 
 	return 1, nil
 }
@@ -707,6 +813,73 @@ func TestDeliveryNackPoisonPill(t *testing.T) {
 	require.Contains(t, dl.FailureReason, "max attempts reached")
 }
 
+// TestDeliveryNackMutationFailed verifies that a failed leaseless nack store
+// write sets the mutationFailed flag so the worker loop can back off, while a
+// successful nack leaves the flag clear. Without the flag, a leaseless row
+// whose nack write fails stays physically unchanged and immediately
+// re-eligible, and the receive loop would tight-spin re-peeking it against a
+// wedged DB.
+func TestDeliveryNackMutationFailed(t *testing.T) {
+	t.Parallel()
+
+	msgID := "test-msg-1"
+
+	newLeaselessDelivery := func(
+		store *mockDeliveryStore) *Delivery[*testTLVMsg, string] {
+
+		return &Delivery[*testTLVMsg, string]{
+			ID: msgID,
+			Message: &testTLVMsg{
+				Value: tlv.NewPrimitiveRecord[tlv.TlvType1](
+					uint64(42),
+				),
+			},
+			// Empty lease token routes nack through the unfenced
+			// by-ID op and marks this delivery leaseless.
+			LeaseToken:  "",
+			Attempts:    1,
+			MaxAttempts: 10,
+			leaseless:   true,
+		}
+	}
+
+	// A successful nack must not flag the delivery.
+	okStore := newMockDeliveryStore()
+	okStore.messages[msgID] = &LeasedMessage{
+		ID:          msgID,
+		MailboxID:   "test-actor",
+		Attempts:    1,
+		MaxAttempts: 10,
+	}
+	okDelivery := newLeaselessDelivery(okStore)
+	okDelivery.store = okStore
+
+	err := okDelivery.Nack(
+		context.Background(), errors.New("transient"), 5*time.Second,
+	)
+	require.NoError(t, err)
+	require.False(t, okDelivery.MutationFailed())
+
+	// A failed nack store write must flag the delivery so the receive loop
+	// throttles its re-peek.
+	failStore := newMockDeliveryStore()
+	failStore.messages[msgID] = &LeasedMessage{
+		ID:          msgID,
+		MailboxID:   "test-actor",
+		Attempts:    1,
+		MaxAttempts: 10,
+	}
+	failStore.injectNackError = errors.New("database is locked")
+	failDelivery := newLeaselessDelivery(failStore)
+	failDelivery.store = failStore
+
+	err = failDelivery.Nack(
+		context.Background(), errors.New("transient"), 5*time.Second,
+	)
+	require.Error(t, err)
+	require.True(t, failDelivery.MutationFailed())
+}
+
 // TestDeliveryExtend tests lease extension.
 func TestDeliveryExtend(t *testing.T) {
 	t.Parallel()
@@ -838,6 +1011,28 @@ func TestDeliveryHelperMethods(t *testing.T) {
 	require.True(t, askDelivery.IsLeaseExpired())
 	require.True(t, askDelivery.ShouldDeadLetter())
 	require.True(t, askDelivery.LeaseRemaining() < 0)
+}
+
+// TestDeliveryEffectiveAttempts verifies that retry policy accounting counts
+// the current in-flight delivery on the leaseless path, where peek did not
+// increment attempts at claim time.
+func TestDeliveryEffectiveAttempts(t *testing.T) {
+	t.Parallel()
+
+	leased := &Delivery[*testTLVMsg, string]{
+		Attempts:    4,
+		MaxAttempts: 5,
+	}
+	require.Equal(t, 4, leased.EffectiveAttempts())
+	require.False(t, leased.ShouldDeadLetter())
+
+	leaseless := &Delivery[*testTLVMsg, string]{
+		Attempts:    4,
+		MaxAttempts: 5,
+		leaseless:   true,
+	}
+	require.Equal(t, 5, leaseless.EffectiveAttempts())
+	require.True(t, leaseless.ShouldDeadLetter())
 }
 
 // TestDeliveryRapidAckNack is a property-based test for Ack/Nack behavior.

--- a/baselib/actor/durable_actor.go
+++ b/baselib/actor/durable_actor.go
@@ -440,6 +440,21 @@ func NewDurableActor[M TLVMessage, R any](
 		return fn.Err[*DurableActor[M, R]](ErrConcurrentClassicBehavior)
 	}
 
+	// Enable the leaseless peek consume path strictly for a single-worker
+	// Read/Commit (Right / TxBehavior) actor. A single worker has no
+	// competing consumer, so the lease token's only purpose -- fencing the
+	// ack -- is unnecessary, and peeking with a read-only query eliminates
+	// one write transaction per consumed message. We additionally require
+	// the Read/Commit path because that is where the consume ack is folded
+	// into the behavior's own short transaction (where the by-ID ack
+	// belongs atomically); the classic path keeps the lease so its
+	// lease-bound attempts and retry-budget semantics are unchanged. With
+	// numWorkers > 1 the flag stays false, so the multi-worker
+	// competing-consumer path keeps LeaseNextMessage and the lease-fenced
+	// ack byte-for-byte.
+	mailboxCfg.SingleWorkerLeaseless = numWorkers == 1 &&
+		cfg.Behavior.IsRight()
+
 	actor := &DurableActor[M, R]{
 		id:                cfg.ID,
 		behavior:          cfg.Behavior,
@@ -620,8 +635,11 @@ func (a *DurableActor[M, R]) processDelivery(delivery *Delivery[M, R]) {
 
 		// Already processed - attempt to ack the mailbox message
 		// without re-running behavior or re-persisting any Ask results.
-		rows, err := delivery.store.AckMessage(
-			processCtx, delivery.ID, delivery.LeaseToken,
+		// ackMessage routes a leaseless (empty-token) delivery to the
+		// unfenced by-ID ack.
+		rows, err := ackMessage(
+			processCtx, delivery.store, delivery.ID,
+			delivery.LeaseToken,
 		)
 		if err != nil {
 			logger(processCtx).WarnS(processCtx, "Failed to ack "+
@@ -631,10 +649,25 @@ func (a *DurableActor[M, R]) processDelivery(delivery *Delivery[M, R]) {
 			return
 		}
 		if rows == 0 {
-			logger(processCtx).WarnS(processCtx, "Duplicate ack "+
-				"failed (lease expired)",
-				ErrLeaseExpired,
-				"delivery_id", delivery.ID)
+			// A zero-row ack means the row was not deleted. On the
+			// leased path that signals the lease expired or was
+			// claimed by another consumer. On the leaseless
+			// (empty-token) path there is no fence: the row is
+			// simply already gone (the original processing consumed
+			// it and this is a benign duplicate redelivery), so it
+			// is not a lease failure and warrants no warning.
+			if delivery.LeaseToken == "" {
+				logger(processCtx).DebugS(
+					processCtx,
+					"Duplicate ack found row already gone",
+					"delivery_id", delivery.ID,
+				)
+			} else {
+				logger(processCtx).WarnS(processCtx,
+					"Duplicate ack failed (lease expired)",
+					ErrLeaseExpired,
+					"delivery_id", delivery.ID)
+			}
 		}
 
 		return
@@ -794,7 +827,9 @@ func (a *DurableActor[M, R]) finishNonTx(ctx context.Context,
 		// handleResult.
 		shouldMarkProcessed = false
 	} else if delivery.IsTell() && result.Err() != nil {
-		retry, _ := a.tellRetryPolicy(result.Err(), delivery.Attempts)
+		retry, _ := a.tellRetryPolicy(
+			result.Err(), delivery.EffectiveAttempts(),
+		)
 		if retry {
 			shouldMarkProcessed = false
 		}
@@ -838,12 +873,17 @@ func (a *DurableActor[M, R]) processWithExec(ctx context.Context,
 	}
 
 	// Extend the lease while the behavior does IO outside the writer tx.
+	// A leaseless (peeked) delivery holds no lease, so there is nothing to
+	// heartbeat -- skip it to avoid a spurious "Failed to extend lease"
+	// warning loop against an empty token. stop stays a safe no-op then.
 	heartbeatDone := make(chan struct{})
 	var stopHeartbeat sync.Once
 	stop := func() {
 		stopHeartbeat.Do(func() { close(heartbeatDone) })
 	}
-	go a.heartbeat(ctx, delivery, heartbeatDone)
+	if !delivery.leaseless {
+		go a.heartbeat(ctx, delivery, heartbeatDone)
+	}
 	defer stop()
 
 	core := &execCore{
@@ -926,8 +966,8 @@ func (a *DurableActor[M, R]) rejectDurableAskOnExecPath(ctx context.Context,
 			return err
 		}
 
-		rows, err := store.AckMessage(
-			txCtx, delivery.ID, delivery.LeaseToken,
+		rows, err := ackMessage(
+			txCtx, store, delivery.ID, delivery.LeaseToken,
 		)
 		if err != nil {
 			return err
@@ -1079,6 +1119,7 @@ func (a *DurableActor[M, R]) handleResultInTx(
 
 	// For Tell messages, handle based on success/error.
 	if err := result.Err(); err != nil {
+		effectiveAttempts := delivery.EffectiveAttempts()
 		logger(ctx).WarnS(ctx,
 			"Durable actor Tell message failed",
 			err,
@@ -1086,14 +1127,18 @@ func (a *DurableActor[M, R]) handleResultInTx(
 			"delivery_id", delivery.ID,
 			"msg_type", delivery.Message.MessageType(),
 			"attempts", delivery.Attempts,
+			"effective_attempts", effectiveAttempts,
 		)
 
 		// Apply Tell retry policy.
-		retry, delay := a.tellRetryPolicy(err, delivery.Attempts)
+		retry, delay := a.tellRetryPolicy(err, effectiveAttempts)
 		if retry {
 			// Don't mark as processed - we want retry to work.
-			_, nackErr := store.NackMessage(
-				ctx, delivery.ID, delivery.LeaseToken, delay,
+			// nackMessage routes a leaseless (empty-token) delivery
+			// to the by-ID nack, which increments attempts.
+			_, nackErr := nackMessage(
+				ctx, store, delivery.ID, delivery.LeaseToken,
+				delay,
 			)
 
 			return nackErr
@@ -1192,6 +1237,7 @@ func (a *DurableActor[M, R]) handleResult(ctx context.Context,
 
 	// For Tell messages, handle based on success/error.
 	if err := result.Err(); err != nil {
+		effectiveAttempts := delivery.EffectiveAttempts()
 		logger(ctx).WarnS(ctx,
 			"Durable actor Tell message failed",
 			err,
@@ -1199,10 +1245,11 @@ func (a *DurableActor[M, R]) handleResult(ctx context.Context,
 			"delivery_id", delivery.ID,
 			"msg_type", delivery.Message.MessageType(),
 			"attempts", delivery.Attempts,
+			"effective_attempts", effectiveAttempts,
 		)
 
 		// Apply Tell retry policy.
-		retry, delay := a.tellRetryPolicy(err, delivery.Attempts)
+		retry, delay := a.tellRetryPolicy(err, effectiveAttempts)
 		if retry {
 			if nackErr := delivery.Nack(
 				ctx, err, delay,

--- a/baselib/actor/durable_actor_test.go
+++ b/baselib/actor/durable_actor_test.go
@@ -174,7 +174,8 @@ type mockTxAwareStore struct {
 	// txShouldFail causes ExecTx to fail.
 	txShouldFail bool
 
-	// nackCalled tracks whether NackMessage was called after tx failure.
+	// nackCalled tracks whether a nack (fenced NackMessage or the leaseless
+	// unfenced NackMessageByID) was called after a failure.
 	nackCalled atomic.Bool
 
 	// txPostCallbackHook runs after fn() succeeds but before ExecTx
@@ -225,6 +226,17 @@ func (m *mockTxAwareStore) NackMessage(ctx context.Context, id,
 	m.nackCalled.Store(true)
 
 	return m.mockDeliveryStore.NackMessage(ctx, id, leaseToken, retryAfter)
+}
+
+// Override NackMessageByID to track calls. The leaseless single-worker
+// Read/Commit path nacks via the unfenced by-ID variant, so the test's
+// nackCalled flag must observe it too.
+func (m *mockTxAwareStore) NackMessageByID(ctx context.Context, id string,
+	retryAfter time.Duration) (int64, error) {
+
+	m.nackCalled.Store(true)
+
+	return m.mockDeliveryStore.NackMessageByID(ctx, id, retryAfter)
 }
 
 // TestDurableActorCreation tests actor creation with various configs.
@@ -2058,4 +2070,58 @@ func TestTxDurableAskDoesNotRetryAfterOutboxWrite(t *testing.T) {
 		t, 1, outboxCount,
 		"exactly one outbox response should be written",
 	)
+}
+
+// TestFinishNonTxLeaselessTerminalTellMarksProcessed verifies that the
+// uncommitted TxBehavior tail counts the current leaseless attempt before
+// consulting the retry policy. Without that effective-attempt accounting, the
+// fifth failure would be treated as retryable, then Delivery.Nack would
+// dead-letter/delete the row without a processed marker.
+func TestFinishNonTxLeaselessTerminalTellMarksProcessed(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	msgID := "leaseless-terminal-tell"
+	msg := &actorTestMsg{
+		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(42)),
+	}
+
+	store.messages[msgID] = &LeasedMessage{
+		ID:          msgID,
+		MailboxID:   "test-actor",
+		MessageType: msg.MessageType(),
+		Attempts:    4,
+		MaxAttempts: 5,
+	}
+
+	delivery := &Delivery[*actorTestMsg, int]{
+		ID:          msgID,
+		Message:     msg,
+		Attempts:    4,
+		MaxAttempts: 5,
+		store:       store,
+		leaseless:   true,
+	}
+
+	actor := &DurableActor[*actorTestMsg, int]{
+		id:               "test-actor",
+		store:            store,
+		tellRetryPolicy:  DefaultTellRetryPolicy,
+		cleanupTimeout:   time.Second,
+		deduplicationTTL: time.Hour,
+	}
+
+	actor.finishNonTx(
+		context.Background(), delivery,
+		fn.Err[int](
+			errors.New("terminal failure"),
+		),
+	)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	require.True(t, store.processed[msgID])
+	require.Contains(t, store.deadLetters, msgID)
+	require.NotContains(t, store.messages, msgID)
 }

--- a/baselib/actor/durable_mailbox.go
+++ b/baselib/actor/durable_mailbox.go
@@ -94,6 +94,34 @@ type DurableMailboxConfig struct {
 	// poll interval. It is purely a latency optimization: correctness never
 	// depends on a wake because the poll ticker is the fallback.
 	WakeBuffer int
+
+	// SingleWorkerLeaseless enables the leaseless peek consume path. When
+	// set, Receive claims the next message with a READ-only PeekNextMessage
+	// instead of the write-transaction LeaseNextMessage, and yields a
+	// delivery with an EMPTY lease token. The empty token routes ack/nack
+	// through the unfenced by-ID store operations. This eliminates one
+	// write transaction per consumed message. It is sound ONLY when the
+	// actor runs exactly one worker (no competing consumer to fence
+	// against), so the owning DurableActor sets it strictly when NumWorkers
+	// == 1. A crash between peek and the consuming commit leaves the
+	// message untouched (it was never written), so it is simply re-peeked
+	// on restart -- identical at-least-once behavior to a lease that
+	// expires.
+	//
+	// Because the peek is a pure READ, attempts is bumped only on the nack
+	// (failure) path, never at claim. A message that returns an error nacks
+	// and climbs toward dead-lettering normally; but a message that crashes
+	// the worker PROCESS on every attempt skips the nack each time and so
+	// re-peeks indefinitely without ever dead-lettering. This is a
+	// deliberate tradeoff, NOT a gap to "fix" by bumping attempts at claim:
+	// bumping at claim turns every poll -- including the empty polls that
+	// dominate under contention -- back into a writer-lock-grabbing write
+	// transaction, which is the exact cross-actor serialization the
+	// leaseless read exists to avoid. The single-worker actors that use
+	// this path carry their own higher-level retry/backoff and treat the
+	// dead-letter table as a manual sink, so indefinite redelivery of a
+	// process-poisoning message is preferable to silently dropping it.
+	SingleWorkerLeaseless bool
 }
 
 // DefaultDurableMailboxConfig returns a config with sensible defaults.
@@ -318,12 +346,27 @@ func (m *DurableMailbox[M, R]) Receive(
 				return
 			}
 
-			// Try to lease a message.
-			leaseToken := generateID()
-			leased, err := m.cfg.Store.LeaseNextMessage(
-				ctx, m.cfg.MailboxID, leaseToken,
-				m.cfg.LeaseDuration,
+			// Claim the next message. The single-worker leaseless
+			// path peeks with a read-only query and takes no lease
+			// (the yielded delivery carries an empty lease token,
+			// which routes ack/nack through the unfenced by-ID
+			// store ops). The default path leases under a write
+			// transaction so a competing consumer is fenced out.
+			var (
+				leased *LeasedMessage
+				err    error
 			)
+			if m.cfg.SingleWorkerLeaseless {
+				leased, err = m.cfg.Store.PeekNextMessage(
+					ctx, m.cfg.MailboxID,
+				)
+			} else {
+				leaseToken := generateID()
+				leased, err = m.cfg.Store.LeaseNextMessage(
+					ctx, m.cfg.MailboxID, leaseToken,
+					m.cfg.LeaseDuration,
+				)
+			}
 
 			if err != nil {
 				// During teardown, the durable store is closed
@@ -468,6 +511,30 @@ func (m *DurableMailbox[M, R]) Receive(
 			if !yield(env) {
 				return
 			}
+
+			// A leaseless delivery whose nack write failed left
+			// its row physically unchanged and immediately
+			// re-eligible. Unlike the leased path, there is no
+			// lease fence whose expiry throttles the next claim,
+			// so re-peeking right away would tight-spin against a
+			// wedged DB. Back off for a poll interval (or until a
+			// wake) before the next claim, matching the implicit
+			// lease-expiry backoff of the fenced path.
+			if delivery.MutationFailed() {
+				select {
+				case <-ticker.C:
+					continue
+
+				case <-m.wake:
+					continue
+
+				case <-ctx.Done():
+					return
+
+				case <-m.actorCtx.Done():
+					return
+				}
+			}
 		}
 	}
 }
@@ -480,7 +547,19 @@ func (m *DurableMailbox[M, R]) Receive(
 func (m *DurableMailbox[M, R]) handlePoisonMessage(ctx context.Context,
 	leased *LeasedMessage, reason string) {
 
-	if leased.Attempts >= leased.MaxAttempts {
+	// A peeked (leaseless) message carries an empty lease token and was not
+	// attempts-bumped at claim time, so the in-flight attempt is counted as
+	// Attempts + 1 to match the leased dead-letter boundary. Otherwise a
+	// poison message would reach attempts == max_attempts via the by-ID
+	// nack below and become peek-ineligible before it could be
+	// dead-lettered.
+	leaseless := leased.LeaseToken == ""
+	effectiveAttempts := leased.Attempts
+	if leaseless {
+		effectiveAttempts++
+	}
+
+	if effectiveAttempts >= leased.MaxAttempts {
 		// Exhausted attempts -- dead-letter the message so it
 		// doesn't stay stranded in the mailbox forever.
 		dlReason := fmt.Sprintf("poison message (attempts %d/%d): %s",
@@ -522,9 +601,11 @@ func (m *DurableMailbox[M, R]) handlePoisonMessage(ctx context.Context,
 		return
 	}
 
-	// Not yet exhausted -- nack for retry with backoff.
-	_, _ = m.cfg.Store.NackMessage(
-		ctx, leased.ID, leased.LeaseToken, 60*time.Second,
+	// Not yet exhausted -- nack for retry with backoff. nackMessage routes
+	// the leaseless (empty-token) case to the by-ID nack, which increments
+	// attempts so the poison message still climbs toward dead-lettering.
+	_, _ = nackMessage(
+		ctx, m.cfg.Store, leased.ID, leased.LeaseToken, 60*time.Second,
 	)
 }
 

--- a/baselib/actor/durable_mailbox.go
+++ b/baselib/actor/durable_mailbox.go
@@ -157,6 +157,11 @@ type DurableMailbox[M TLVMessage, R any] struct {
 	// wake signals the receive loop to poll immediately.
 	wake chan struct{}
 
+	// cancelWake deregisters this mailbox's post-commit wake from a
+	// MailboxWakeRegistrar store. It is nil when the store does not support
+	// wakes. Close calls it so a stopped mailbox leaves no closure behind.
+	cancelWake func()
+
 	// actorCtx is the actor's lifecycle context.
 	actorCtx context.Context
 
@@ -178,12 +183,46 @@ func NewDurableMailbox[M TLVMessage, R any](
 		wakeBuffer = 1
 	}
 
-	return &DurableMailbox[M, R]{
+	m := &DurableMailbox[M, R]{
 		cfg:             cfg,
 		clock:           cfg.Clock.UnwrapOr(clock.NewDefaultClock()),
 		wake:            make(chan struct{}, wakeBuffer),
 		actorCtx:        actorCtx,
 		promiseRegistry: make(map[string]any),
+	}
+
+	// Register a post-commit wake for this mailbox when the store supports
+	// it. The folded outbox-delivery path enqueues into this mailbox inside
+	// the publisher's write transaction, so the pre-commit wake fired by
+	// Send races ahead of the row becoming visible. The store fires the
+	// registered wakes only after the tx commits, restoring same-process
+	// delivery latency that would otherwise wait out a full poll interval.
+	// The wake is coarse (every registered mailbox is roused), so an idle
+	// mailbox may do one empty re-poll per unrelated folded enqueue.
+	if registrar, ok := cfg.Store.(MailboxWakeRegistrar); ok {
+		m.cancelWake = registrar.RegisterMailboxWake(m.Wake)
+	}
+
+	return m
+}
+
+// Wake nudges the receive loop to poll immediately. The signal is best-effort
+// because the poll ticker remains the durability fallback; a dropped wake (the
+// channel already holds a pending signal) only defers delivery to the next
+// loop iteration, never loses it.
+func (m *DurableMailbox[M, R]) Wake() {
+	// Hold the close lock so we never send on a closed wake channel: Close
+	// takes the write lock before closing it.
+	m.closeMu.RLock()
+	defer m.closeMu.RUnlock()
+
+	if m.closed.Load() {
+		return
+	}
+
+	select {
+	case m.wake <- struct{}{}:
+	default:
 	}
 }
 
@@ -287,7 +326,13 @@ func (m *DurableMailbox[M, R]) Send(ctx context.Context,
 		return fmt.Errorf("enqueue mailbox message: %w", err)
 	}
 
-	// Signal the receive loop to wake up.
+	// Signal the receive loop to wake up. This is the immediate-visibility
+	// path for non-transactional enqueues. When Send runs inside an ambient
+	// tx (the folded outbox-delivery path), the row is not yet visible, so
+	// this wake is a harmless empty poll and the store's post-commit
+	// RegisterMailboxWake callback is what actually rouses the consumer.
+	// We already hold closeMu.RLock here, so signal the channel directly
+	// rather than re-entering Wake and its RLock.
 	select {
 	case m.wake <- struct{}{}:
 	default:
@@ -617,6 +662,14 @@ func (m *DurableMailbox[M, R]) Close() {
 
 	if m.closed.CompareAndSwap(false, true) {
 		close(m.wake)
+
+		// Remove our post-commit wake from the store so a stopped
+		// mailbox leaves no closure behind. A stable durable ID reused
+		// across restarts would otherwise leave an inert closure that
+		// notifyMailboxWake walks on each folded enqueue commit.
+		if m.cancelWake != nil {
+			m.cancelWake()
+		}
 	}
 }
 

--- a/baselib/actor/durable_mailbox_test.go
+++ b/baselib/actor/durable_mailbox_test.go
@@ -343,6 +343,83 @@ func TestDurableMailboxReceive(t *testing.T) {
 	require.Equal(t, []byte("test"), received.Payload.Val)
 }
 
+// TestDurableMailboxReceiveLeaselessNackBackoff verifies that when a leaseless
+// delivery's nack store write fails, the receive loop backs off for a poll
+// interval before re-peeking instead of tight-spinning. The failed nack leaves
+// the row physically unchanged and immediately re-eligible, and without the
+// backoff the loop would re-peek the same row in an unbounded CPU-bound tight
+// loop. We assert that the number of peeks over a fixed window stays bounded by
+// the poll cadence rather than growing without bound.
+func TestDurableMailboxReceiveLeaselessNackBackoff(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newDurableTestCodec()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const pollInterval = 25 * time.Millisecond
+
+	cfg := DefaultDurableMailboxConfig("test-mailbox", store, codec)
+	cfg.PollInterval = pollInterval
+	cfg.SingleWorkerLeaseless = true
+	mailbox := NewDurableMailbox[*durableTestMsg, int](ctx, cfg)
+
+	// Seed one eligible message directly so the peek path returns it.
+	msg := &durableTestMsg{
+		Value:   tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(7)),
+		Payload: tlv.NewPrimitiveRecord[tlv.TlvType2]([]byte("x")),
+	}
+	payload, err := codec.Encode(msg)
+	require.NoError(t, err)
+
+	store.messages["leaseless-msg"] = &LeasedMessage{
+		ID:          "leaseless-msg",
+		MailboxID:   "test-mailbox",
+		MessageType: msg.MessageType(),
+		Payload:     payload,
+		Attempts:    0,
+		MaxAttempts: 10,
+	}
+
+	// Make every leaseless nack store write fail while leaving the message
+	// peek-eligible, so each delivery is flagged mutationFailed and the
+	// loop must throttle before re-peeking the same unchanged row.
+	store.injectNackError = errors.New("database is locked")
+
+	receiveCtx, receiveCancel := context.WithTimeout(
+		ctx, 5*pollInterval,
+	)
+	defer receiveCancel()
+
+	deliveries := 0
+	for receivedEnv := range mailbox.Receive(receiveCtx) {
+		deliveries++
+
+		delivery, ok :=
+			receivedEnv.delivery.(*Delivery[*durableTestMsg, int])
+		require.True(t, ok)
+
+		// Nack fails against the wedged store, setting mutationFailed.
+		nackErr := delivery.Nack(
+			receiveCtx, errors.New("transient"), pollInterval,
+		)
+		require.Error(t, nackErr)
+		require.True(t, delivery.MutationFailed())
+	}
+
+	// Over a ~5 poll-interval window, a throttled loop peeks on the order
+	// of the poll count, not thousands of times. A generous ceiling still
+	// distinguishes bounded backoff from an unbounded tight spin.
+	peeks := store.peekCount.Load()
+	require.Less(
+		t, peeks, int64(50),
+		"receive loop tight-spun instead of backing off: %d peeks",
+		peeks,
+	)
+	require.Positive(t, deliveries)
+}
+
 // TestDurableMailboxReceiveContextCancelled tests that Receive respects
 // context.
 func TestDurableMailboxReceiveContextCancelled(t *testing.T) {

--- a/baselib/actor/durable_mailbox_test.go
+++ b/baselib/actor/durable_mailbox_test.go
@@ -583,6 +583,139 @@ func TestDurableMailboxWakeSignal(t *testing.T) {
 	}
 }
 
+// TestDurableMailboxRegistersMailboxWake verifies that NewDurableMailbox
+// registers its Wake with a store that implements MailboxWakeRegistrar, and
+// that firing the registered wake rouses the receive loop. This stands in for
+// the folded outbox-delivery path: the publisher's ExecTx enqueues into this
+// mailbox inside its write tx (so Send's pre-commit wake races ahead of the
+// row becoming visible), then fires the registered wake after commit. Without
+// it the consumer would idle until its poll interval.
+func TestDurableMailboxRegistersMailboxWake(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newDurableTestCodec()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// A long poll interval ensures only the registered wake can deliver in
+	// time, isolating the post-commit wake path from the poll fallback.
+	cfg := DefaultDurableMailboxConfig("wake-mailbox", store, codec)
+	cfg.PollInterval = time.Hour
+	mailbox := NewDurableMailbox[*durableTestMsg, int](ctx, cfg)
+
+	// The mailbox must have registered exactly one post-commit wake.
+	store.mu.Lock()
+	registered := len(store.mailboxWakes)
+	store.mu.Unlock()
+	require.Equal(
+		t, 1, registered, "mailbox did not register a wake callback",
+	)
+
+	received := make(chan *durableTestMsg, 1)
+	go func() {
+		for env := range mailbox.Receive(ctx) {
+			received <- env.message
+
+			return
+		}
+	}()
+
+	// Let the receive loop settle into its long poll wait.
+	time.Sleep(50 * time.Millisecond)
+
+	// Enqueue the row directly (bypassing Send's pre-commit wake) to model
+	// a row that only becomes visible at commit, then fire the registered
+	// post-commit wake the way the store does after ExecTx commits.
+	msg := &durableTestMsg{
+		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(7)),
+	}
+	payload, err := codec.Encode(msg)
+	require.NoError(t, err)
+
+	require.NoError(
+		t,
+		store.EnqueueMessage(
+			ctx, EnqueueParams{
+				ID:          "wake-msg",
+				MailboxID:   "wake-mailbox",
+				MessageType: msg.MessageType(),
+				Payload:     payload,
+				AvailableAt: time.Now().Add(-time.Minute),
+				MaxAttempts: 3,
+			},
+		),
+	)
+
+	store.fireMailboxWakes()
+
+	select {
+	case m := <-received:
+		require.Equal(t, uint64(7), m.Value.Val)
+
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal(
+			"registered mailbox wake did not rouse the receive " +
+				"loop",
+		)
+	}
+}
+
+// TestDurableMailboxWakeRestartNoAccumulation verifies that constructing a
+// fresh DurableMailbox for the same durable ID against a shared store (the
+// actor-restart pattern) does not accumulate stale wake closures: each
+// construction registers one wake and Close cancels it, so at any time the
+// store holds only the live mailboxes' wakes. Without the cancel-on-Close
+// contract, every restart would leave another inert closure that
+// notifyMailboxWake walks on each folded enqueue commit, an unbounded leak on
+// the feature's primary execution path.
+func TestDurableMailboxWakeRestartNoAccumulation(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	codec := newDurableTestCodec()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const mailboxID = "restart-mailbox"
+
+	// Simulate many actor restarts that each reuse the same durable ID and
+	// the same store. Each constructed mailbox registers, then Close
+	// cancels it, leaving the store with no live wake between restarts.
+	const restarts = 50
+	for i := 0; i < restarts; i++ {
+		cfg := DefaultDurableMailboxConfig(mailboxID, store, codec)
+		mailbox := NewDurableMailbox[*durableTestMsg, int](ctx, cfg)
+
+		// While live, exactly one wake is registered.
+		store.mu.Lock()
+		liveCount := len(store.mailboxWakes)
+		store.mu.Unlock()
+		require.Equal(
+			t, 1, liveCount,
+			"wake map grew beyond the single live mailbox",
+		)
+
+		mailbox.Close()
+
+		// After Close, the entry is gone entirely.
+		store.mu.Lock()
+		afterClose := len(store.mailboxWakes)
+		store.mu.Unlock()
+		require.Equal(
+			t, 0, afterClose,
+			"Close left a stale wake closure behind",
+		)
+	}
+
+	// The map must not have grown with the restart count.
+	store.mu.Lock()
+	final := len(store.mailboxWakes)
+	store.mu.Unlock()
+	require.Equal(t, 0, final,
+		"wake closures accumulated across restarts")
+}
+
 // TestDurableMailboxConcurrentSends tests concurrent send operations.
 func TestDurableMailboxConcurrentSends(t *testing.T) {
 	t.Parallel()

--- a/baselib/actor/outbox_publisher.go
+++ b/baselib/actor/outbox_publisher.go
@@ -258,27 +258,67 @@ func (p *OutboxPublisher) deliverMessage(msg OutboxMessage) {
 	// ON CONFLICT clause makes it a no-op.
 	deliverCtx := WithOutboxID(p.ctx, msg.ID)
 
-	// Deliver the message. Tell now returns an error if the message could
-	// not be durably enqueued to the target's mailbox.
-	if err := ref.Tell(deliverCtx, decoded); err != nil {
-		logger(p.ctx).WarnS(p.ctx, "Failed to deliver outbox message", err,
-			"message_id", msg.ID,
-			"target", msg.TargetActorID,
-			"attempts", msg.DeliveryAttempts)
+	// deliver performs the durable handoff: Tell enqueues into the
+	// target's mailbox (returning an error if the message could not be
+	// durably enqueued), then the outbox row is marked complete.
+	deliver := func(ctx context.Context, store DeliveryStore) error {
+		if err := ref.Tell(ctx, decoded); err != nil {
+			logger(p.ctx).WarnS(p.ctx,
+				"Failed to deliver outbox message", err,
+				"message_id", msg.ID,
+				"target", msg.TargetActorID,
+				"attempts", msg.DeliveryAttempts)
 
-		// Don't mark as complete - leave for retry on next poll. The
-		// message will be dead-lettered when DeliveryAttempts exceeds
-		// MaxDeliveryAttempts (checked at the start of this function).
-		return
+			// Don't mark as complete - leave for retry on next
+			// poll. The message will be dead-lettered when
+			// DeliveryAttempts exceeds MaxDeliveryAttempts
+			// (checked at the start of this function).
+			return err
+		}
+
+		// Mark as complete after successful durable send.
+		completeErr := store.CompleteOutbox(
+			ctx, msg.ID, msg.ClaimToken,
+		)
+		if completeErr != nil {
+			logger(p.ctx).WarnS(p.ctx,
+				"Failed to complete outbox message",
+				completeErr, "message_id", msg.ID)
+
+			return completeErr
+		}
+
+		return nil
 	}
 
-	// Mark as complete after successful durable send.
-	completeErr := p.cfg.Store.CompleteOutbox(
-		p.ctx, msg.ID, msg.ClaimToken,
-	)
-	if completeErr != nil {
-		logger(p.ctx).WarnS(p.ctx, "Failed to complete outbox message",
-			completeErr, "message_id", msg.ID)
+	// When the store supports transactions, fold the target enqueue and
+	// the outbox completion into ONE write transaction: the Tell joins
+	// the ambient tx via the context (DurableMailbox.Send preserves it
+	// into EnqueueMessage), and CompleteOutbox runs on the tx-scoped
+	// store. This halves the per-delivery commit count (enqueue+complete
+	// were two write txs) and closes the enqueue-without-complete
+	// redelivery window. Outbox targets are durable same-DB actors by
+	// design (the CDC premise), so the enqueue always shares our DB.
+	// On any error the tx rolls back and the claimed row is retried
+	// after claim expiry, exactly like the non-transactional path.
+	if txStore, ok := p.cfg.Store.(TxAwareDeliveryStore); ok {
+		if err := txStore.ExecTx(
+			deliverCtx, false, deliver,
+		); err != nil {
+
+			logger(p.ctx).WarnS(p.ctx,
+				"Failed to execute outbox delivery transaction",
+				err,
+				"message_id", msg.ID,
+				"target", msg.TargetActorID,
+				"attempts", msg.DeliveryAttempts,
+				"claim_token", msg.ClaimToken,
+			)
+
+			return
+		}
+	} else if err := deliver(deliverCtx, p.cfg.Store); err != nil {
+		return
 	}
 
 	logger(p.ctx).TraceS(p.ctx, "Delivered outbox message",

--- a/baselib/actor/outbox_publisher_test.go
+++ b/baselib/actor/outbox_publisher_test.go
@@ -1,6 +1,7 @@
 package actor
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -9,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
@@ -236,6 +239,86 @@ func TestOutboxPublisherDelivery(t *testing.T) {
 
 		return ok && msg.Status == "completed"
 	}, 500*time.Millisecond, 10*time.Millisecond)
+}
+
+var errPostDeliveryTxFailure = errors.New("post-delivery tx failure")
+
+type postDeliveryFailTxStore struct {
+	*mockDeliveryStore
+
+	execCalled atomic.Bool
+}
+
+func (s *postDeliveryFailTxStore) ExecTx(ctx context.Context, readOnly bool,
+	fn TxFunc) error {
+
+	s.execCalled.Store(true)
+
+	if err := fn(ctx, s.mockDeliveryStore); err != nil {
+		return err
+	}
+
+	return errPostDeliveryTxFailure
+}
+
+// TestOutboxPublisherLogsExecTxFailure verifies commit-level transaction
+// failures are visible even when the inner delivery closure completed
+// successfully and therefore emitted no delivery-specific warning.
+func TestOutboxPublisherLogsExecTxFailure(t *testing.T) {
+	t.Parallel()
+
+	baseStore := newMockDeliveryStore()
+	store := &postDeliveryFailTxStore{
+		mockDeliveryStore: baseStore,
+	}
+	codec := newOutboxTestCodec()
+	system := newMockSystem()
+
+	msg := &outboxTestMsg{
+		Value: tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(42)),
+	}
+	payload, err := codec.Encode(msg)
+	require.NoError(t, err)
+
+	baseStore.mu.Lock()
+	baseStore.outbox["outbox-tx-fail"] = &OutboxMessage{
+		ID:            "outbox-tx-fail",
+		SourceActorID: "source-actor",
+		TargetActorID: "target-actor",
+		MessageType:   msg.MessageType(),
+		Payload:       payload,
+		Status:        "pending",
+	}
+	baseStore.mu.Unlock()
+
+	cfg := DefaultOutboxPublisherConfig(store, codec, system)
+	cfg.PollInterval = time.Hour
+	publisher := NewOutboxPublisher(cfg)
+
+	var logBuf bytes.Buffer
+	handler := btclog.NewDefaultHandler(&logBuf)
+	log := btclog.NewSLogger(handler.SubSystem("TEST"))
+	log.SetLevel(btclog.LevelWarn)
+	publisher.ctx = build.ContextWithLogger(publisher.ctx, log)
+
+	publisher.PublishPending()
+
+	require.True(t, store.execCalled.Load())
+	require.Contains(
+		t, logBuf.String(),
+		"Failed to execute outbox delivery transaction",
+	)
+	require.Contains(t, logBuf.String(), errPostDeliveryTxFailure.Error())
+	require.Contains(t, logBuf.String(), "outbox-tx-fail")
+
+	system.mu.Lock()
+	require.Len(t, system.tellCalls, 1)
+	system.mu.Unlock()
+
+	baseStore.mu.Lock()
+	status := baseStore.outbox["outbox-tx-fail"].Status
+	baseStore.mu.Unlock()
+	require.Equal(t, "completed", status)
 }
 
 // TestOutboxPublisherDecodeError tests poison pill handling.

--- a/baselib/actor/tx_exec.go
+++ b/baselib/actor/tx_exec.go
@@ -193,6 +193,15 @@ func (e *execCore) stage(ctx context.Context,
 	return e.store.ExecTx(ctx, false, func(txCtx context.Context,
 		s DeliveryStore) error {
 
+		// On the leaseless (single-worker) path there is no lease token
+		// to fence and no competing consumer that could reclaim the
+		// message, so skip the ExtendLease fence (which would
+		// spuriously return zero rows for an empty token) and stage
+		// directly.
+		if e.leaseToken == "" {
+			return fn(txCtx, s)
+		}
+
 		// Fence first: extending our lease validates the token. Zero
 		// rows means the lease was reclaimed while the behavior did IO,
 		// so a now-stale consumer must not advance durable state --
@@ -230,7 +239,15 @@ func (e *execCore) commit(ctx context.Context,
 		// closure would make below. Fencing up front keeps the
 		// stale-lease path a true no-op rather than relying on rollback
 		// alone.
-		rows, err := s.AckMessage(txCtx, e.msgID, e.leaseToken)
+		//
+		// On the leaseless (single-worker) path the token is empty, so
+		// ackMessage deletes by ID without a fence: there is no
+		// competing consumer, and a crash before this commit leaves the
+		// peeked row untouched for re-peek. A zero-row by-ID ack means
+		// the row is already gone (e.g. a redelivery of an
+		// already-consumed message racing dedup), which is likewise a
+		// no-op to roll back.
+		rows, err := ackMessage(txCtx, s, e.msgID, e.leaseToken)
 		if err != nil {
 			return err
 		}

--- a/db/actordelivery/CLAUDE.md
+++ b/db/actordelivery/CLAUDE.md
@@ -30,9 +30,20 @@ other services can reuse durable actor storage without pulling unrelated tables.
   a `TxActorDeliveryStore` scoped to that transaction, and on successful commit
   fires outbox-wake callbacks when outbox messages were enqueued inside the tx.
 - `ActorDeliveryQueries` — Interface for all actor delivery SQL operations:
-  mailbox enqueue/lease/ack/nack/extend/expire, ask results, outbox
+  mailbox enqueue/lease/peek/ack/nack/extend/expire, ask results, outbox
   claim/complete/fail, deduplication, FSM checkpoints, dead letters, and
   cleanup. Implemented by the SQLC-generated query set.
+- **Leaseless single-worker consume path** — `PeekNextMailboxMessage` (a
+  READ-only claim that mirrors `LeaseNextMailboxMessage`'s eligibility and
+  ordering but takes no lease and does NOT bump attempts),
+  `AckMailboxMessageByID` (unfenced delete by id), and
+  `NackMailboxMessageByID` (unfenced release that increments attempts).
+  Exposed on both `Store` and `TxActorDeliveryStore` as `PeekNextMessage`
+  (read tx), `AckMessageByID`, and `NackMessageByID`. Used only by
+  `NumWorkers == 1` Read/Commit actors, which have no competing consumer to
+  fence; the multi-worker pool keeps lease + fenced ack. The by-ID nack
+  increments attempts because the peek does not, preserving dead-lettering
+  on max attempts.
 - `BatchedActorDeliveryQueries` — Batched transaction wrapper for
   `ActorDeliveryQueries`.
 - `MigrationOption` — Functional options for migration configuration
@@ -65,6 +76,12 @@ other services can reuse durable actor storage without pulling unrelated tables.
   goroutines.
 - `TxAwareActorDeliveryStore.ExecTx` always defers `tx.Rollback()` so partial
   writes cannot survive a function error; commit is the only success path.
+- `PeekNextMessage` is a read-only eligibility check, not an ownership write.
+  The store adapter must map every peeked row to an empty lease token before it
+  reaches the actor layer, including rows that still carry stale expired lease
+  metadata from a previous leased claim. The by-ID nack path clears that stale
+  metadata while incrementing attempts, preserving the leaseless p-model:
+  `peek -> empty-token delivery -> by-ID ack/nack`.
 
 ## Deep Docs
 

--- a/db/actordelivery/mailbox_wake_context.go
+++ b/db/actordelivery/mailbox_wake_context.go
@@ -1,0 +1,38 @@
+package actordelivery
+
+import (
+	"context"
+)
+
+// mailboxEnqueueFlagKey is the context key for the per-transaction flag that
+// records whether ANY mailbox received a message inside an ExecTx. ExecTx reads
+// it after commit to decide whether to fire the coarse mailbox wake. The wake
+// is coarse -- it rouses every registered mailbox, not a specific one -- so a
+// single boolean is all the transaction needs to track; it does not record
+// which mailbox was enqueued.
+type mailboxEnqueueFlagKey struct{}
+
+// withMailboxEnqueueFlag returns a context carrying a fresh per-transaction
+// mailbox-enqueue flag alongside a pointer to it. ExecTx installs the flag so
+// any enqueue executed within the transaction can mark it, regardless of which
+// store path the enqueue takes: the tx-scoped TxActorDeliveryStore and the
+// folded outbox path's (*Store).EnqueueMessage (which joins the ambient tx via
+// TransactionExecutor.ExecTx) both call noteMailboxEnqueued on the same ctx.
+func withMailboxEnqueueFlag(ctx context.Context) (context.Context, *bool) {
+	enqueued := new(bool)
+
+	return context.WithValue(
+		ctx, mailboxEnqueueFlagKey{}, enqueued,
+	), enqueued
+}
+
+// noteMailboxEnqueued records that some mailbox received a message in the
+// transaction carried by ctx, if a flag is present. A transaction body runs on
+// a single goroutine, so the unsynchronized write is safe. It is a no-op
+// outside an ExecTx (no flag in context), so the non-transactional enqueue path
+// is unaffected.
+func noteMailboxEnqueued(ctx context.Context) {
+	if enqueued, ok := ctx.Value(mailboxEnqueueFlagKey{}).(*bool); ok {
+		*enqueued = true
+	}
+}

--- a/db/actordelivery/queries/mailbox.sql
+++ b/db/actordelivery/queries/mailbox.sql
@@ -88,11 +88,80 @@ WHERE mailbox_messages.id = (
 )
 RETURNING *;
 
+-- name: PeekNextMailboxMessage :one
+-- Read-only claim of the next available message WITHOUT taking a lease.
+-- This is the leaseless fast path for single-worker (NumWorkers == 1) actors:
+-- with no competing consumer, the lease_token's only purpose -- fencing the
+-- ack against another worker -- is unnecessary, so the extra write transaction
+-- that LeaseNextMailboxMessage performs (set lease_token/lease_until, bump
+-- attempts) is pure overhead. Peek runs as a pure SELECT, so a crash between
+-- peek and the consuming Commit leaves the message untouched and it is simply
+-- re-peeked on restart (at-least-once preserved, identical to today's
+-- lease-expiry redelivery).
+--
+-- The eligibility predicate and ORDER BY mirror LeaseNextMailboxMessage's inner
+-- SELECT EXACTLY so the leaseless path observes the same per-correlation-key
+-- FIFO and priority/available_at/created_at ordering. See that query for the
+-- full rationale on the correlation-key anti-join and the m2.attempts <
+-- m2.max_attempts predicate.
+--
+-- Because peek takes no lease, attempts is NOT incremented here. The store
+-- adapter maps the returned row to an empty-token delivery even if the
+-- persisted row has stale metadata from an expired lease. That empty token is
+-- part of the framework contract: it routes the actor layer to the by-ID
+-- ack/nack path. The single-worker consume path increments attempts on its
+-- failure (nack) path via NackMailboxMessageByID so a repeatedly-failing
+-- message still climbs to max_attempts and dead-letters.
+SELECT m.* FROM mailbox_messages m
+WHERE m.mailbox_id = $1
+  AND m.available_at <= $2
+  AND (m.lease_until IS NULL OR m.lease_until < $2)
+  AND m.attempts < m.max_attempts
+  AND (
+      m.correlation_key IS NULL
+      OR NOT EXISTS (
+          SELECT 1 FROM mailbox_messages m2
+          WHERE m2.mailbox_id = m.mailbox_id
+            AND m2.correlation_key = m.correlation_key
+            AND m2.id < m.id
+            AND m2.attempts < m2.max_attempts
+      )
+  )
+ORDER BY m.priority DESC, m.available_at ASC, m.created_at ASC
+LIMIT 1;
+
 -- name: AckMailboxMessage :execrows
 -- Acknowledge successful processing. Deletes the message.
 -- Validates lease_token to prevent stale acks.
 DELETE FROM mailbox_messages
 WHERE id = $1 AND lease_token = $2;
+
+-- name: AckMailboxMessageByID :execrows
+-- Unfenced acknowledgment used by the leaseless single-worker consume path.
+-- Deletes the message by ID without validating a lease_token, because a
+-- single-worker actor has no competing consumer to fence against. Folded into
+-- the behavior's Commit transaction, so a crash before commit leaves the row
+-- intact for re-peek. MUST NOT be used by the multi-worker (NumWorkers > 1)
+-- path, which relies on lease_token fencing via AckMailboxMessage.
+DELETE FROM mailbox_messages
+WHERE id = $1;
+
+-- name: NackMailboxMessageByID :execrows
+-- Unfenced redelivery release for the leaseless single-worker consume path.
+-- Sets a new available_at and increments attempts. The attempts bump is
+-- essential: the leaseless peek does not increment attempts (unlike a lease),
+-- so the failure path must do it here, otherwise a repeatedly-failing message
+-- would never climb to max_attempts and dead-letter. No lease_token clause,
+-- because a single-worker actor has no competing consumer to fence against.
+-- Any stale expired lease metadata is cleared so the persisted row matches the
+-- leaseless state machine after a retry decision.
+UPDATE mailbox_messages
+SET
+    lease_token = NULL,
+    lease_until = NULL,
+    available_at = $2,
+    attempts = attempts + 1
+WHERE id = $1;
 
 -- name: NackMailboxMessage :execrows
 -- Release message for redelivery after retry delay.

--- a/db/actordelivery/sqlc/mailbox.sql.go
+++ b/db/actordelivery/sqlc/mailbox.sql.go
@@ -30,6 +30,25 @@ func (q *Queries) AckMailboxMessage(ctx context.Context, arg AckMailboxMessagePa
 	return result.RowsAffected()
 }
 
+const AckMailboxMessageByID = `-- name: AckMailboxMessageByID :execrows
+DELETE FROM mailbox_messages
+WHERE id = $1
+`
+
+// Unfenced acknowledgment used by the leaseless single-worker consume path.
+// Deletes the message by ID without validating a lease_token, because a
+// single-worker actor has no competing consumer to fence against. Folded into
+// the behavior's Commit transaction, so a crash before commit leaves the row
+// intact for re-peek. MUST NOT be used by the multi-worker (NumWorkers > 1)
+// path, which relies on lease_token fencing via AckMailboxMessage.
+func (q *Queries) AckMailboxMessageByID(ctx context.Context, id string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, AckMailboxMessageByID, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const ClaimOutboxBatch = `-- name: ClaimOutboxBatch :many
 UPDATE outbox_messages
 SET delivery_attempts = delivery_attempts + 1,
@@ -955,6 +974,108 @@ func (q *Queries) NackMailboxMessage(ctx context.Context, arg NackMailboxMessage
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+const NackMailboxMessageByID = `-- name: NackMailboxMessageByID :execrows
+UPDATE mailbox_messages
+SET
+    lease_token = NULL,
+    lease_until = NULL,
+    available_at = $2,
+    attempts = attempts + 1
+WHERE id = $1
+`
+
+type NackMailboxMessageByIDParams struct {
+	ID          string
+	AvailableAt int64
+}
+
+// Unfenced redelivery release for the leaseless single-worker consume path.
+// Sets a new available_at and increments attempts. The attempts bump is
+// essential: the leaseless peek does not increment attempts (unlike a lease),
+// so the failure path must do it here, otherwise a repeatedly-failing message
+// would never climb to max_attempts and dead-letter. No lease_token clause,
+// because a single-worker actor has no competing consumer to fence against.
+// Any stale expired lease metadata is cleared so the persisted row matches the
+// leaseless state machine after a retry decision.
+func (q *Queries) NackMailboxMessageByID(ctx context.Context, arg NackMailboxMessageByIDParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, NackMailboxMessageByID, arg.ID, arg.AvailableAt)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const PeekNextMailboxMessage = `-- name: PeekNextMailboxMessage :one
+SELECT m.id, m.mailbox_id, m.message_type, m.payload, m.promise_id, m.callback_actor_id, m.correlation_id, m.priority, m.lease_token, m.lease_until, m.available_at, m.attempts, m.max_attempts, m.created_at, m.correlation_key FROM mailbox_messages m
+WHERE m.mailbox_id = $1
+  AND m.available_at <= $2
+  AND (m.lease_until IS NULL OR m.lease_until < $2)
+  AND m.attempts < m.max_attempts
+  AND (
+      m.correlation_key IS NULL
+      OR NOT EXISTS (
+          SELECT 1 FROM mailbox_messages m2
+          WHERE m2.mailbox_id = m.mailbox_id
+            AND m2.correlation_key = m.correlation_key
+            AND m2.id < m.id
+            AND m2.attempts < m2.max_attempts
+      )
+  )
+ORDER BY m.priority DESC, m.available_at ASC, m.created_at ASC
+LIMIT 1
+`
+
+type PeekNextMailboxMessageParams struct {
+	MailboxID   string
+	AvailableAt int64
+}
+
+// Read-only claim of the next available message WITHOUT taking a lease.
+// This is the leaseless fast path for single-worker (NumWorkers == 1) actors:
+// with no competing consumer, the lease_token's only purpose -- fencing the
+// ack against another worker -- is unnecessary, so the extra write transaction
+// that LeaseNextMailboxMessage performs (set lease_token/lease_until, bump
+// attempts) is pure overhead. Peek runs as a pure SELECT, so a crash between
+// peek and the consuming Commit leaves the message untouched and it is simply
+// re-peeked on restart (at-least-once preserved, identical to today's
+// lease-expiry redelivery).
+//
+// The eligibility predicate and ORDER BY mirror LeaseNextMailboxMessage's inner
+// SELECT EXACTLY so the leaseless path observes the same per-correlation-key
+// FIFO and priority/available_at/created_at ordering. See that query for the
+// full rationale on the correlation-key anti-join and the m2.attempts <
+// m2.max_attempts predicate.
+//
+// Because peek takes no lease, attempts is NOT incremented here. The store
+// adapter maps the returned row to an empty-token delivery even if the
+// persisted row has stale metadata from an expired lease. That empty token is
+// part of the framework contract: it routes the actor layer to the by-ID
+// ack/nack path. The single-worker consume path increments attempts on its
+// failure (nack) path via NackMailboxMessageByID so a repeatedly-failing
+// message still climbs to max_attempts and dead-letters.
+func (q *Queries) PeekNextMailboxMessage(ctx context.Context, arg PeekNextMailboxMessageParams) (MailboxMessage, error) {
+	row := q.db.QueryRowContext(ctx, PeekNextMailboxMessage, arg.MailboxID, arg.AvailableAt)
+	var i MailboxMessage
+	err := row.Scan(
+		&i.ID,
+		&i.MailboxID,
+		&i.MessageType,
+		&i.Payload,
+		&i.PromiseID,
+		&i.CallbackActorID,
+		&i.CorrelationID,
+		&i.Priority,
+		&i.LeaseToken,
+		&i.LeaseUntil,
+		&i.AvailableAt,
+		&i.Attempts,
+		&i.MaxAttempts,
+		&i.CreatedAt,
+		&i.CorrelationKey,
+	)
+	return i, err
 }
 
 const SaveFSMCheckpoint = `-- name: SaveFSMCheckpoint :exec

--- a/db/actordelivery/sqlc/querier.go
+++ b/db/actordelivery/sqlc/querier.go
@@ -13,6 +13,13 @@ type Querier interface {
 	// Acknowledge successful processing. Deletes the message.
 	// Validates lease_token to prevent stale acks.
 	AckMailboxMessage(ctx context.Context, arg AckMailboxMessageParams) (int64, error)
+	// Unfenced acknowledgment used by the leaseless single-worker consume path.
+	// Deletes the message by ID without validating a lease_token, because a
+	// single-worker actor has no competing consumer to fence against. Folded into
+	// the behavior's Commit transaction, so a crash before commit leaves the row
+	// intact for re-peek. MUST NOT be used by the multi-worker (NumWorkers > 1)
+	// path, which relies on lease_token fencing via AckMailboxMessage.
+	AckMailboxMessageByID(ctx context.Context, id string) (int64, error)
 	// Claim a batch of pending outbox messages for delivery. Sets a claim token
 	// and expiry to prevent concurrent publishers from processing the same messages.
 	// Only selects rows that are unclaimed or whose claim has expired.
@@ -148,6 +155,39 @@ type Querier interface {
 	// Clears lease and sets new available_at.
 	// Validates lease_token to prevent stale nacks.
 	NackMailboxMessage(ctx context.Context, arg NackMailboxMessageParams) (int64, error)
+	// Unfenced redelivery release for the leaseless single-worker consume path.
+	// Sets a new available_at and increments attempts. The attempts bump is
+	// essential: the leaseless peek does not increment attempts (unlike a lease),
+	// so the failure path must do it here, otherwise a repeatedly-failing message
+	// would never climb to max_attempts and dead-letter. No lease_token clause,
+	// because a single-worker actor has no competing consumer to fence against.
+	// Any stale expired lease metadata is cleared so the persisted row matches the
+	// leaseless state machine after a retry decision.
+	NackMailboxMessageByID(ctx context.Context, arg NackMailboxMessageByIDParams) (int64, error)
+	// Read-only claim of the next available message WITHOUT taking a lease.
+	// This is the leaseless fast path for single-worker (NumWorkers == 1) actors:
+	// with no competing consumer, the lease_token's only purpose -- fencing the
+	// ack against another worker -- is unnecessary, so the extra write transaction
+	// that LeaseNextMailboxMessage performs (set lease_token/lease_until, bump
+	// attempts) is pure overhead. Peek runs as a pure SELECT, so a crash between
+	// peek and the consuming Commit leaves the message untouched and it is simply
+	// re-peeked on restart (at-least-once preserved, identical to today's
+	// lease-expiry redelivery).
+	//
+	// The eligibility predicate and ORDER BY mirror LeaseNextMailboxMessage's inner
+	// SELECT EXACTLY so the leaseless path observes the same per-correlation-key
+	// FIFO and priority/available_at/created_at ordering. See that query for the
+	// full rationale on the correlation-key anti-join and the m2.attempts <
+	// m2.max_attempts predicate.
+	//
+	// Because peek takes no lease, attempts is NOT incremented here. The store
+	// adapter maps the returned row to an empty-token delivery even if the
+	// persisted row has stale metadata from an expired lease. That empty token is
+	// part of the framework contract: it routes the actor layer to the by-ID
+	// ack/nack path. The single-worker consume path increments attempts on its
+	// failure (nack) path via NackMailboxMessageByID so a repeatedly-failing
+	// message still climbs to max_attempts and dead-letters.
+	PeekNextMailboxMessage(ctx context.Context, arg PeekNextMailboxMessageParams) (MailboxMessage, error)
 	// =============================================================================
 	// FSM Checkpoints
 	// =============================================================================

--- a/db/actordelivery/store_bench_test.go
+++ b/db/actordelivery/store_bench_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -108,5 +109,72 @@ func BenchmarkDeliveryMailboxRoundTrip(b *testing.B) {
 		rows, err := store.AckMessage(ctx, leased.ID, leaseToken)
 		require.NoError(b, err)
 		require.Equal(b, int64(1), rows)
+	}
+}
+
+// benchMailboxTrip runs one full durable mailbox trip (enqueue, lease, ack) on
+// the given mailbox. It is a free function to keep the concurrent benchmark's
+// worker body shallow.
+func benchMailboxTrip(ctx context.Context, store *Store, mailbox, id string,
+	payload []byte) {
+
+	token := "lease-" + id
+	_ = store.EnqueueMessage(ctx, actor.EnqueueParams{
+		ID:          id,
+		MailboxID:   mailbox,
+		MessageType: "BenchMsg",
+		Payload:     payload,
+		AvailableAt: time.Now().Add(-time.Minute),
+		MaxAttempts: 3,
+	})
+
+	leased, err := store.LeaseNextMessage(
+		ctx, mailbox, token, 30*time.Second,
+	)
+	if err != nil || leased == nil {
+		return
+	}
+
+	_, _ = store.AckMessage(ctx, leased.ID, token)
+}
+
+// BenchmarkDeliveryConcurrentActors measures durable mailbox throughput as the
+// number of independent mailboxes processing in parallel grows. This is the
+// per-session sharding shape: the old global OOR actor funneled every session
+// through one mailbox, so unrelated sessions queued behind each other; the
+// per-session refactor gives each session its own mailbox. Each worker runs a
+// full enqueue/lease/ack trip on its own mailbox concurrently. The SQLite
+// writer is still a shared floor, but no session blocks behind its queue.
+func BenchmarkDeliveryConcurrentActors(b *testing.B) {
+	for _, mailboxes := range []int{1, 4, 16, 64} {
+		b.Run(fmt.Sprintf("mailboxes=%d",
+			mailboxes), func(b *testing.B) {
+			ctx := context.Background()
+			store := newBenchStore(b)
+			payload := make([]byte, 256)
+			perWorker := (b.N + mailboxes - 1) / mailboxes
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			var wg sync.WaitGroup
+			for w := 0; w < mailboxes; w++ {
+				wg.Add(1)
+				go func(worker int) {
+					defer wg.Done()
+
+					mailbox := fmt.Sprintf("mb-%d", worker)
+					for i := 0; i < perWorker; i++ {
+						id := fmt.Sprintf("m-%d-%d",
+							worker, i)
+						benchMailboxTrip(
+							ctx, store, mailbox, id,
+							payload,
+						)
+					}
+				}(w)
+			}
+			wg.Wait()
+		})
 	}
 }

--- a/db/actordelivery/store_bench_test.go
+++ b/db/actordelivery/store_bench_test.go
@@ -1,0 +1,112 @@
+package actordelivery
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/db"
+	adsqlc "github.com/lightninglabs/darepo-client/db/actordelivery/sqlc"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/stretchr/testify/require"
+)
+
+// newBenchStore builds an actor delivery store backed by a fresh test database
+// for benchmarking the durable mailbox and checkpoint write paths -- the "drip
+// box" the OOR refactor reshapes.
+func newBenchStore(b *testing.B) *Store {
+	b.Helper()
+
+	testDB := db.NewTestDB(b)
+	actorQueries := adsqlc.New(testDB.DB)
+
+	actorDB := db.NewTransactionExecutor(
+		testDB.BaseDB,
+		func(tx *sql.Tx) ActorDeliveryQueries {
+			return actorQueries.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+
+	return NewStore(actorDB, clock.NewDefaultClock())
+}
+
+// BenchmarkDeliveryCheckpointWrite measures the cost of one FSM checkpoint
+// write as the persisted state blob grows. It isolates exactly the write the
+// old global OOR actor paid on every mutation: it serialized ALL sessions into
+// one blob, so the per-mutation cost grew with the number of in-flight
+// sessions. The per-session refactor replaces this with one small fixed-size
+// row per session, so this benchmark is the "before" curve the refactor
+// flattens.
+func BenchmarkDeliveryCheckpointWrite(b *testing.B) {
+	sizes := []int{
+		1 << 10, // 1 KiB  -- a handful of sessions.
+		1 << 14, // 16 KiB -- dozens of sessions.
+		1 << 18, // 256 KiB -- a saturated whole-map blob.
+	}
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("blob=%dB", size), func(b *testing.B) {
+			ctx := context.Background()
+			store := newBenchStore(b)
+			blob := make([]byte, size)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				err := store.SaveCheckpoint(
+					ctx, actor.CheckpointParams{
+						ActorID:   "bench-actor",
+						StateType: "oor.sessions",
+						StateData: blob,
+						Version:   int64(i),
+					},
+				)
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
+// BenchmarkDeliveryMailboxRoundTrip measures one message's full durable trip
+// through a single mailbox: enqueue, lease, ack. A single global actor funnels
+// every session's messages through one such serial trip; the per-session
+// refactor spreads them across independent mailboxes, so this is the
+// per-message floor each shard pays in parallel rather than in series.
+func BenchmarkDeliveryMailboxRoundTrip(b *testing.B) {
+	ctx := context.Background()
+	store := newBenchStore(b)
+	payload := make([]byte, 256)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		id := fmt.Sprintf("bench-msg-%d", i)
+		err := store.EnqueueMessage(ctx, actor.EnqueueParams{
+			ID:          id,
+			MailboxID:   "bench-mailbox",
+			MessageType: "BenchMsg",
+			Payload:     payload,
+			AvailableAt: time.Now().Add(-time.Minute),
+			MaxAttempts: 3,
+		})
+		require.NoError(b, err)
+
+		leaseToken := fmt.Sprintf("lease-%d", i)
+		leased, err := store.LeaseNextMessage(
+			ctx, "bench-mailbox", leaseToken, 30*time.Second,
+		)
+		require.NoError(b, err)
+		require.NotNil(b, leased)
+
+		rows, err := store.AckMessage(ctx, leased.ID, leaseToken)
+		require.NoError(b, err)
+		require.Equal(b, int64(1), rows)
+	}
+}

--- a/db/actordelivery/store_impl.go
+++ b/db/actordelivery/store_impl.go
@@ -23,8 +23,10 @@ type (
 	EnqueueMailboxParams   = adsqlc.EnqueueMailboxMessageParams
 	EnqueueOutboxParams    = adsqlc.EnqueueOutboxMessageParams
 	LeaseMailboxParams     = adsqlc.LeaseNextMailboxMessageParams
+	PeekMailboxParams      = adsqlc.PeekNextMailboxMessageParams
 	AckMailboxParams       = adsqlc.AckMailboxMessageParams
 	NackMailboxParams      = adsqlc.NackMailboxMessageParams
+	NackMailboxByIDParams  = adsqlc.NackMailboxMessageByIDParams
 	ExtendMailboxParams    = adsqlc.ExtendMailboxLeaseParams
 	InsertAskResultParams  = adsqlc.InsertAskResultParams
 	ClaimOutboxBatchParams = adsqlc.ClaimOutboxBatchParams
@@ -52,11 +54,19 @@ type ActorDeliveryQueries interface {
 	LeaseNextMailboxMessage(ctx context.Context,
 		arg LeaseMailboxParams) (MailboxMsgRow, error)
 
+	PeekNextMailboxMessage(ctx context.Context,
+		arg PeekMailboxParams) (MailboxMsgRow, error)
+
 	AckMailboxMessage(ctx context.Context,
 		arg AckMailboxParams) (int64, error)
 
+	AckMailboxMessageByID(ctx context.Context, id string) (int64, error)
+
 	NackMailboxMessage(ctx context.Context,
 		arg NackMailboxParams) (int64, error)
+
+	NackMailboxMessageByID(ctx context.Context,
+		arg NackMailboxByIDParams) (int64, error)
 
 	ExtendMailboxLease(ctx context.Context,
 		arg ExtendMailboxParams) (int64, error)
@@ -246,6 +256,76 @@ func (s *Store) LeaseNextMessage(ctx context.Context, mailboxID string,
 	return result, err
 }
 
+// leasedMessageFromRow maps a SQLC mailbox row to an actor.LeasedMessage.
+func leasedMessageFromRow(msg MailboxMsgRow) *actor.LeasedMessage {
+	return &actor.LeasedMessage{
+		ID:              msg.ID,
+		MailboxID:       msg.MailboxID,
+		MessageType:     msg.MessageType,
+		Payload:         msg.Payload,
+		PromiseID:       fromNullString(msg.PromiseID),
+		CallbackActorID: fromNullString(msg.CallbackActorID),
+		CorrelationID:   fromNullString(msg.CorrelationID),
+		Priority:        int(msg.Priority),
+		LeaseToken:      fromNullString(msg.LeaseToken),
+		LeaseUntil:      fromNullInt64Time(msg.LeaseUntil),
+		Attempts:        int(msg.Attempts),
+		MaxAttempts:     int(msg.MaxAttempts),
+		CreatedAt:       time.Unix(msg.CreatedAt, 0),
+	}
+}
+
+// leaselessMessageFromRow maps a SQLC mailbox row to a peeked delivery. A
+// peeked row may still carry stale, expired lease metadata from an older leased
+// claim; the actor-layer contract for PeekNextMessage is always an empty token,
+// which routes ack/nack to the by-ID leaseless operations.
+func leaselessMessageFromRow(msg MailboxMsgRow) *actor.LeasedMessage {
+	leased := leasedMessageFromRow(msg)
+	leased.LeaseToken = ""
+	leased.LeaseUntil = time.Time{}
+
+	return leased
+}
+
+// PeekNextMessage claims the next available message with a read-only query and
+// takes no lease. The returned LeasedMessage carries an empty LeaseToken, which
+// signals the single-worker consume path to ack/nack via the unfenced by-ID
+// operations. It runs under a read transaction (no fsync), eliminating the
+// write transaction that LeaseNextMessage performs.
+func (s *Store) PeekNextMessage(ctx context.Context, mailboxID string) (
+	*actor.LeasedMessage, error) {
+
+	readTxOpts := db.ReadTxOption()
+
+	var result *actor.LeasedMessage
+
+	err := s.db.ExecTx(ctx, readTxOpts,
+		func(q ActorDeliveryQueries) error {
+			now := s.clock.Now()
+
+			msg, err := q.PeekNextMailboxMessage(
+				ctx,
+				PeekMailboxParams{
+					MailboxID:   mailboxID,
+					AvailableAt: now.Unix(),
+				},
+			)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return nil
+				}
+
+				return err
+			}
+
+			result = leaselessMessageFromRow(msg)
+
+			return nil
+		})
+
+	return result, err
+}
+
 // AckMessage acknowledges successful processing of a message.
 func (s *Store) AckMessage(ctx context.Context, id, leaseToken string) (int64,
 	error) {
@@ -263,6 +343,28 @@ func (s *Store) AckMessage(ctx context.Context, id, leaseToken string) (int64,
 				ID:         id,
 				LeaseToken: toNullString(leaseToken),
 			})
+
+			return err
+		},
+	)
+
+	return rows, err
+}
+
+// AckMessageByID acknowledges successful processing of a message by ID without
+// validating a lease token. It is the leaseless single-worker counterpart to
+// AckMessage.
+func (s *Store) AckMessageByID(ctx context.Context, id string) (int64, error) {
+	writeTxOpts := db.WriteTxOption()
+
+	var rows int64
+
+	err := s.db.ExecTx(
+		ctx,
+		writeTxOpts,
+		func(q ActorDeliveryQueries) error {
+			var err error
+			rows, err = q.AckMailboxMessageByID(ctx, id)
 
 			return err
 		},
@@ -291,6 +393,39 @@ func (s *Store) NackMessage(ctx context.Context, id, leaseToken string,
 				LeaseToken:  toNullString(leaseToken),
 				AvailableAt: availableAt.Unix(),
 			})
+
+			return err
+		},
+	)
+
+	return rows, err
+}
+
+// NackMessageByID releases a message for redelivery by ID without validating a
+// lease token, and increments attempts. It is the leaseless single-worker
+// counterpart to NackMessage. The attempts bump preserves dead-lettering on
+// max attempts because the leaseless peek does not increment attempts.
+func (s *Store) NackMessageByID(ctx context.Context, id string,
+	retryAfter time.Duration) (int64, error) {
+
+	writeTxOpts := db.WriteTxOption()
+
+	var rows int64
+
+	err := s.db.ExecTx(
+		ctx,
+		writeTxOpts,
+		func(q ActorDeliveryQueries) error {
+			availableAt := s.clock.Now().Add(retryAfter)
+
+			var err error
+			rows, err = q.NackMailboxMessageByID(
+				ctx,
+				NackMailboxByIDParams{
+					ID:          id,
+					AvailableAt: availableAt.Unix(),
+				},
+			)
 
 			return err
 		},
@@ -991,6 +1126,29 @@ func (s *TxActorDeliveryStore) LeaseNextMessage(ctx context.Context,
 	}, nil
 }
 
+// PeekNextMessage claims the next available message with a read-only query and
+// takes no lease, within the current transaction. The returned LeasedMessage
+// carries an empty LeaseToken, signalling the unfenced by-ID ack/nack path.
+func (s *TxActorDeliveryStore) PeekNextMessage(ctx context.Context,
+	mailboxID string) (*actor.LeasedMessage, error) {
+
+	now := s.clock.Now()
+
+	msg, err := s.querier.PeekNextMailboxMessage(ctx, PeekMailboxParams{
+		MailboxID:   mailboxID,
+		AvailableAt: now.Unix(),
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return leaselessMessageFromRow(msg), nil
+}
+
 // AckMessage acknowledges successful processing of a message.
 func (s *TxActorDeliveryStore) AckMessage(ctx context.Context, id,
 	leaseToken string) (int64, error) {
@@ -999,6 +1157,15 @@ func (s *TxActorDeliveryStore) AckMessage(ctx context.Context, id,
 		ID:         id,
 		LeaseToken: toNullString(leaseToken),
 	})
+}
+
+// AckMessageByID acknowledges successful processing of a message by ID without
+// validating a lease token, within the current transaction. It is the leaseless
+// single-worker counterpart to AckMessage.
+func (s *TxActorDeliveryStore) AckMessageByID(ctx context.Context, id string) (
+	int64, error) {
+
+	return s.querier.AckMailboxMessageByID(ctx, id)
 }
 
 // NackMessage releases a message for redelivery after the specified delay.
@@ -1010,6 +1177,20 @@ func (s *TxActorDeliveryStore) NackMessage(ctx context.Context, id,
 	return s.querier.NackMailboxMessage(ctx, NackMailboxParams{
 		ID:          id,
 		LeaseToken:  toNullString(leaseToken),
+		AvailableAt: availableAt.Unix(),
+	})
+}
+
+// NackMessageByID releases a message for redelivery by ID without validating a
+// lease token, and increments attempts, within the current transaction. It is
+// the leaseless single-worker counterpart to NackMessage.
+func (s *TxActorDeliveryStore) NackMessageByID(ctx context.Context, id string,
+	retryAfter time.Duration) (int64, error) {
+
+	availableAt := s.clock.Now().Add(retryAfter)
+
+	return s.querier.NackMailboxMessageByID(ctx, NackMailboxByIDParams{
+		ID:          id,
 		AvailableAt: availableAt.Unix(),
 	})
 }

--- a/db/actordelivery/store_impl.go
+++ b/db/actordelivery/store_impl.go
@@ -141,6 +141,20 @@ type Store struct {
 
 	outboxWakeMu sync.Mutex
 	outboxWakes  []func()
+
+	mailboxWakeMu     sync.Mutex
+	mailboxWakeNextID uint64
+
+	// mailboxWakes holds the live post-commit mailbox wakes, keyed by a
+	// unique registration handle (NOT a mailbox ID). The wake is coarse:
+	// notifyMailboxWake fires every entry after any folded enqueue commits,
+	// so the store never needs to know which mailbox received the message.
+	// Keying by an opaque handle (rather than mailbox ID) means a restart
+	// that reuses a durable mailbox ID gets a fresh entry instead of
+	// clobbering a still-live one, and the cancel returned by
+	// RegisterMailboxWake deletes exactly that entry, so a stopped mailbox
+	// leaves nothing behind.
+	mailboxWakes map[uint64]func()
 }
 
 // NewStore creates a new actor delivery store using the
@@ -150,8 +164,9 @@ func NewStore(
 ) *Store {
 
 	return &Store{
-		db:    db,
-		clock: clock,
+		db:           db,
+		clock:        clock,
+		mailboxWakes: make(map[uint64]func()),
 	}
 }
 
@@ -162,7 +177,7 @@ func (s *Store) EnqueueMessage(
 
 	writeTxOpts := db.WriteTxOption()
 
-	return s.db.ExecTx(ctx, writeTxOpts,
+	err := s.db.ExecTx(ctx, writeTxOpts,
 		func(q ActorDeliveryQueries) error {
 			createdAt := s.clock.Now().Unix()
 
@@ -192,6 +207,20 @@ func (s *Store) EnqueueMessage(
 				},
 			)
 		})
+	if err != nil {
+		return err
+	}
+
+	// When this enqueue joined an ambient ExecTx transaction (the folded
+	// outbox-delivery path, where the target actor's store enqueues through
+	// the shared tx via TransactionExecutor.ExecTx), mark the transaction's
+	// enqueue flag so ExecTx fires its post-commit coarse mailbox wake. The
+	// tx-scoped TxActorDeliveryStore marks the same flag directly; this
+	// covers the join path that bypasses it. Outside an ExecTx this is a
+	// no-op.
+	noteMailboxEnqueued(ctx)
+
+	return nil
 }
 
 // LeaseNextMessage atomically claims the next available message for processing.
@@ -640,6 +669,47 @@ func (s *Store) notifyOutboxWake() {
 	}
 }
 
+// RegisterMailboxWake registers a same-process callback that runs after any
+// enqueue commits inside an ExecTx, and returns a cancel function that
+// deregisters it. It restores immediate delivery for the folded outbox path,
+// where the enqueued row is invisible to a consumer until the publisher's
+// transaction commits. The wake is coarse -- every registered mailbox is woken,
+// so a non-target re-polls once and finds nothing -- and the mailbox still
+// polls as the durable fallback.
+func (s *Store) RegisterMailboxWake(wake func()) func() {
+	if wake == nil {
+		return func() {}
+	}
+
+	s.mailboxWakeMu.Lock()
+	id := s.mailboxWakeNextID
+	s.mailboxWakeNextID++
+	s.mailboxWakes[id] = wake
+	s.mailboxWakeMu.Unlock()
+
+	// The cancel deletes exactly this registration's entry, so a stopped
+	// mailbox (DurableMailbox.Close) leaves no closure behind even when a
+	// later mailbox reuses the same durable ID.
+	return func() {
+		s.mailboxWakeMu.Lock()
+		delete(s.mailboxWakes, id)
+		s.mailboxWakeMu.Unlock()
+	}
+}
+
+func (s *Store) notifyMailboxWake() {
+	s.mailboxWakeMu.Lock()
+	wakes := make([]func(), 0, len(s.mailboxWakes))
+	for _, wake := range s.mailboxWakes {
+		wakes = append(wakes, wake)
+	}
+	s.mailboxWakeMu.Unlock()
+
+	for _, wake := range wakes {
+		wake()
+	}
+}
+
 // ClaimOutboxBatch claims a batch of pending outbox messages for delivery.
 func (s *Store) ClaimOutboxBatch(ctx context.Context,
 	params actor.OutboxClaimParams) ([]actor.OutboxMessage, error) {
@@ -1071,7 +1141,7 @@ func (s *TxActorDeliveryStore) EnqueueMessage(
 	ctx context.Context, params actor.EnqueueParams,
 ) error {
 
-	return s.querier.EnqueueMailboxMessage(ctx, EnqueueMailboxParams{
+	if err := s.querier.EnqueueMailboxMessage(ctx, EnqueueMailboxParams{
 		ID:              params.ID,
 		MailboxID:       params.MailboxID,
 		MessageType:     params.MessageType,
@@ -1084,7 +1154,18 @@ func (s *TxActorDeliveryStore) EnqueueMessage(
 		MaxAttempts:     int32(params.MaxAttempts),
 		CreatedAt:       s.clock.Now().Unix(),
 		CorrelationKey:  toNullString(params.CorrelationKey),
-	})
+	}); err != nil {
+		return err
+	}
+
+	// Mark the transaction's enqueue flag so ExecTx fires its post-commit
+	// coarse mailbox wake. The enqueued row is invisible to the consumer
+	// until commit, so the in-process wake from DurableMailbox.Send cannot
+	// rouse it; this is the signal that restores immediate same-process
+	// delivery.
+	noteMailboxEnqueued(ctx)
+
+	return nil
 }
 
 // LeaseNextMessage atomically claims the next available message for processing.
@@ -1577,8 +1658,14 @@ func (s *TxAwareActorDeliveryStore) ExecTx(
 		txQuerier, s.clock, tx, &outboxEnqueued,
 	)
 
-	// Attach transaction to context.
+	// Attach the transaction and a fresh mailbox-enqueue flag to the
+	// context. The flag captures enqueues regardless of store path,
+	// including those that join the ambient tx via
+	// TransactionExecutor.ExecTx (the folded outbox-delivery path, where
+	// the target actor's store enqueues through (*Store).EnqueueMessage
+	// rather than the tx-scoped TxActorDeliveryStore).
 	txCtx := actor.WithTx(ctx, tx)
+	txCtx, mailboxEnqueued := withMailboxEnqueueFlag(txCtx)
 
 	// Execute the function with the transaction-scoped store.
 	if err := fn(txCtx, txStore); err != nil {
@@ -1593,6 +1680,18 @@ func (s *TxAwareActorDeliveryStore) ExecTx(
 		s.notifyOutboxWake()
 	}
 
+	// Fire the coarse post-commit mailbox wake if any mailbox received a
+	// message in this transaction. The enqueued rows only became visible at
+	// commit, so this rouses local consumers immediately instead of leaving
+	// them to wait out a poll interval. It is coarse -- every registered
+	// mailbox re-polls, and a non-target does one empty poll -- which is
+	// why the transaction only tracks whether an enqueue happened, not
+	// which mailbox. This restores the same-process delivery latency that
+	// the folded outbox path otherwise regresses.
+	if *mailboxEnqueued {
+		s.notifyMailboxWake()
+	}
+
 	return nil
 }
 
@@ -1601,6 +1700,10 @@ var _ actor.DeliveryStore = (*Store)(nil)
 
 // Compile-time check that Store can wake same-process outbox publishers.
 var _ actor.OutboxWakeRegistrar = (*Store)(nil)
+
+// Compile-time check that Store can wake same-process mailbox receive loops
+// after a folded outbox enqueue commits.
+var _ actor.MailboxWakeRegistrar = (*Store)(nil)
 
 // Compile-time check that TxAwareActorDeliveryStore implements
 // actor.TxAwareDeliveryStore.

--- a/db/actordelivery/store_impl_test.go
+++ b/db/actordelivery/store_impl_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -678,6 +679,213 @@ func TestTxAwareActorDeliveryStoreOutboxWake(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("commit did not wake outbox publisher")
 	}
+}
+
+// TestTxAwareActorDeliveryStoreMailboxWake verifies that an enqueue folded into
+// a write transaction wakes registered mailbox receive loops after the
+// transaction commits, and that a rolled-back enqueue wakes nobody. The wake is
+// coarse: every registered mailbox is roused (a non-target does one empty
+// re-poll), so the test asserts that two independent registered wakes BOTH fire
+// on commit, via both the join path and the tx-scoped store. This pins the
+// folded outbox-delivery path: the enqueued row is invisible to the consumer
+// until commit, so without a post-commit wake the target would idle until its
+// poll interval fired.
+func TestTxAwareActorDeliveryStoreMailboxWake(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newTxAwareActorDeliveryStoreForTest(t)
+
+	wakeA := make(chan struct{}, 1)
+	cancelA := store.RegisterMailboxWake(func() {
+		select {
+		case wakeA <- struct{}{}:
+		default:
+		}
+	})
+	defer cancelA()
+
+	wakeB := make(chan struct{}, 1)
+	cancelB := store.RegisterMailboxWake(func() {
+		select {
+		case wakeB <- struct{}{}:
+		default:
+		}
+	})
+	defer cancelB()
+
+	enqueueParams := func(id string) actor.EnqueueParams {
+		return actor.EnqueueParams{
+			ID:          id,
+			MailboxID:   "target-actor",
+			MessageType: "test.Message",
+			Payload: []byte{
+				1,
+			},
+			AvailableAt: time.Now().Add(-time.Minute),
+			MaxAttempts: 3,
+		}
+	}
+
+	// Drive the enqueue through the outer store's EnqueueMessage with the
+	// ambient tx in context, exactly as the folded outbox-delivery path
+	// does: DurableMailbox.Send calls EnqueueMessage on the target actor's
+	// (*Store)-backed store, which joins the ambient tx via
+	// TransactionExecutor.ExecTx rather than the tx-scoped store. The wake
+	// must fire even though the tx-scoped TxActorDeliveryStore is never
+	// touched.
+
+	// A rolled-back enqueue must not wake the target: the row never became
+	// visible.
+	rollbackErr := errors.New("rollback")
+	err := store.ExecTx(ctx, false, func(
+		txCtx context.Context, _ actor.DeliveryStore,
+	) error {
+
+		require.NoError(
+			t,
+			store.EnqueueMessage(
+				txCtx,
+				enqueueParams(
+					generateTestID(),
+				),
+			),
+		)
+
+		return rollbackErr
+	})
+	require.ErrorIs(t, err, rollbackErr)
+
+	// A rolled-back enqueue wakes nobody: the row never became visible.
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-wakeA:
+		t.Fatal("rollback should not wake a mailbox")
+
+	default:
+	}
+	select {
+	case <-wakeB:
+		t.Fatal("rollback should not wake a mailbox")
+
+	default:
+	}
+
+	// A committed enqueue through the join path wakes every registered
+	// mailbox (coarse broadcast), so both wakes must fire.
+	err = store.ExecTx(ctx, false, func(
+		txCtx context.Context, _ actor.DeliveryStore,
+	) error {
+
+		return store.EnqueueMessage(
+			txCtx,
+			enqueueParams(
+				generateTestID(),
+			),
+		)
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-wakeA:
+	case <-time.After(time.Second):
+		t.Fatal("commit did not wake registered mailbox A")
+	}
+	select {
+	case <-wakeB:
+	case <-time.After(time.Second):
+		t.Fatal("commit did not wake registered mailbox B")
+	}
+
+	// An enqueue through the tx-scoped store must also fire the coarse
+	// post-commit wake, so callers that hold the TxActorDeliveryStore
+	// directly are covered too.
+	err = store.ExecTx(ctx, false, func(
+		txCtx context.Context, txStore actor.DeliveryStore,
+	) error {
+
+		return txStore.EnqueueMessage(
+			txCtx,
+			enqueueParams(
+				generateTestID(),
+			),
+		)
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-wakeA:
+	case <-time.After(time.Second):
+		t.Fatal("tx-scoped enqueue did not wake registered mailbox A")
+	}
+	select {
+	case <-wakeB:
+	case <-time.After(time.Second):
+		t.Fatal("tx-scoped enqueue did not wake registered mailbox B")
+	}
+}
+
+// TestStoreMailboxWakeCancelRemovesEntry verifies the coarse mailbox-wake
+// registry: each RegisterMailboxWake adds an independent entry keyed by an
+// opaque handle (so a restart reusing a durable mailbox ID never clobbers a
+// still-live registration), notifyMailboxWake fires every registered closure,
+// and the cancel returned by RegisterMailboxWake removes exactly its own entry.
+// The cancel-on-Close contract is what bounds map growth to the set of live
+// mailboxes rather than the lifetime count of mailbox constructions.
+func TestStoreMailboxWakeCancelRemovesEntry(t *testing.T) {
+	t.Parallel()
+
+	store := newActorDeliveryStoreForTest(t)
+
+	// Register many wakes, mirroring repeated actor restarts that each
+	// construct a fresh mailbox against the shared store.
+	var fired atomic.Int64
+	const registrations = 25
+	cancels := make([]func(), 0, registrations)
+	for i := 0; i < registrations; i++ {
+		cancels = append(
+			cancels, store.RegisterMailboxWake(func() {
+				fired.Add(1)
+			}),
+		)
+	}
+
+	// Each registration is an independent live entry: the coarse broadcast
+	// does no ID-keyed dedup, so all of them land.
+	store.mailboxWakeMu.Lock()
+	count := len(store.mailboxWakes)
+	store.mailboxWakeMu.Unlock()
+	require.Equal(
+		t, registrations, count, "registrations did not all land",
+	)
+
+	// notifyMailboxWake fires every registered closure.
+	store.notifyMailboxWake()
+	require.Equal(
+		t, int64(registrations), fired.Load(),
+		"notifyMailboxWake did not fire every registration",
+	)
+
+	// Cancelling every registration drains the registry, so stopped
+	// mailboxes leave nothing behind.
+	for _, cancel := range cancels {
+		cancel()
+	}
+
+	store.mailboxWakeMu.Lock()
+	count = len(store.mailboxWakes)
+	store.mailboxWakeMu.Unlock()
+	require.Equal(
+		t, 0, count, "cancel left stale closures behind",
+	)
+
+	// A wake after cancel fires nothing.
+	fired.Store(0)
+	store.notifyMailboxWake()
+	require.Equal(
+		t, int64(0), fired.Load(),
+		"notifyMailboxWake fired after cancel",
+	)
 }
 
 // TestActorDeliveryStoreDeduplication tests deduplication operations.

--- a/db/actordelivery/store_impl_test.go
+++ b/db/actordelivery/store_impl_test.go
@@ -121,6 +121,193 @@ func TestActorDeliveryStoreEnqueueAndLease(t *testing.T) {
 	require.Nil(t, leased2)
 }
 
+// TestActorDeliveryStorePeekIsPureRead verifies that PeekNextMessage claims
+// the next message without taking a lease: it sets no lease token, no lease
+// expiry, and does NOT increment attempts, so the same message is returned on a
+// repeated peek. This is the at-least-once invariant of the leaseless path: a
+// crash between peek and commit leaves the row untouched for re-peek.
+func TestActorDeliveryStorePeekIsPureRead(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActorDeliveryStoreForTest(t)
+
+	err := store.EnqueueMessage(ctx, actor.EnqueueParams{
+		ID:          "msg-peek",
+		MailboxID:   "actor-1",
+		MessageType: "test.Message",
+		Payload:     []byte{1, 2, 3},
+		Priority:    5,
+		AvailableAt: time.Now().Add(-time.Minute),
+		MaxAttempts: 3,
+	})
+	require.NoError(t, err)
+
+	peeked, err := store.PeekNextMessage(ctx, "actor-1")
+	require.NoError(t, err)
+	require.NotNil(t, peeked)
+
+	require.Equal(t, "msg-peek", peeked.ID)
+	require.Equal(t, []byte{1, 2, 3}, peeked.Payload)
+
+	// No lease was taken and attempts was not incremented.
+	require.Empty(t, peeked.LeaseToken)
+	require.Equal(t, 0, peeked.Attempts)
+
+	// A second peek returns the same message: peek is a pure read, so the
+	// message stays claimable (unlike a lease, which would hide it).
+	peeked2, err := store.PeekNextMessage(ctx, "actor-1")
+	require.NoError(t, err)
+	require.NotNil(t, peeked2)
+	require.Equal(t, "msg-peek", peeked2.ID)
+	require.Equal(t, 0, peeked2.Attempts)
+}
+
+// TestActorDeliveryStorePeekMasksExpiredLease verifies that the leaseless peek
+// contract is independent of stale persisted lease metadata. A row can carry an
+// expired lease token from a pre-upgrade leased consumer or a crash; once peek
+// selects it, the actor-layer delivery must still have an empty token so
+// ack/nack route to the by-ID leaseless operations.
+func TestActorDeliveryStorePeekMasksExpiredLease(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	ts := newActorDeliveryStoreForTest(t)
+
+	err := ts.EnqueueMessage(ctx, actor.EnqueueParams{
+		ID:          "msg-expired-lease-peek",
+		MailboxID:   "actor-1",
+		MessageType: "test.Message",
+		Payload:     []byte{1, 2, 3},
+		Priority:    5,
+		AvailableAt: ts.clock.Now().Add(-time.Minute),
+		MaxAttempts: 3,
+	})
+	require.NoError(t, err)
+
+	leased, err := ts.LeaseNextMessage(
+		ctx, "actor-1", "stale-token", 10*time.Second,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, leased)
+	require.Equal(t, "stale-token", leased.LeaseToken)
+	require.Equal(t, 1, leased.Attempts)
+
+	ts.clock.SetTime(ts.clock.Now().Add(11 * time.Second))
+
+	peeked, err := ts.PeekNextMessage(ctx, "actor-1")
+	require.NoError(t, err)
+	require.NotNil(t, peeked)
+	require.Equal(t, "msg-expired-lease-peek", peeked.ID)
+	require.Empty(t, peeked.LeaseToken)
+	require.True(t, peeked.LeaseUntil.IsZero())
+	require.Equal(t, 1, peeked.Attempts)
+
+	rows, err := ts.NackMessageByID(ctx, peeked.ID, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows)
+
+	peeked, err = ts.PeekNextMessage(ctx, "actor-1")
+	require.NoError(t, err)
+	require.NotNil(t, peeked)
+	require.Empty(t, peeked.LeaseToken)
+	require.True(t, peeked.LeaseUntil.IsZero())
+	require.Equal(t, 2, peeked.Attempts)
+}
+
+// TestActorDeliveryStoreAckByID verifies the unfenced by-ID ack deletes the
+// message regardless of any lease token, then becomes a no-op.
+func TestActorDeliveryStoreAckByID(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActorDeliveryStoreForTest(t)
+
+	err := store.EnqueueMessage(ctx, actor.EnqueueParams{
+		ID:          "msg-ackid",
+		MailboxID:   "actor-1",
+		MessageType: "test.Message",
+		Payload:     []byte{1},
+		AvailableAt: time.Now().Add(-time.Minute),
+		MaxAttempts: 3,
+	})
+	require.NoError(t, err)
+
+	// Peek (no lease), then ack by ID without any token.
+	peeked, err := store.PeekNextMessage(ctx, "actor-1")
+	require.NoError(t, err)
+	require.NotNil(t, peeked)
+	require.Empty(t, peeked.LeaseToken)
+
+	rows, err := store.AckMessageByID(ctx, "msg-ackid")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows)
+
+	// The message is gone; a repeat ack is a no-op.
+	rows, err = store.AckMessageByID(ctx, "msg-ackid")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), rows)
+
+	peeked2, err := store.PeekNextMessage(ctx, "actor-1")
+	require.NoError(t, err)
+	require.Nil(t, peeked2)
+}
+
+// TestActorDeliveryStoreNackByIDIncrementsAttempts verifies the unfenced by-ID
+// nack increments attempts (the peek did not) and applies the retry backoff.
+// The attempts bump is what preserves dead-lettering on the leaseless path: the
+// message climbs to max_attempts and then becomes peek-ineligible.
+func TestActorDeliveryStoreNackByIDIncrementsAttempts(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	ts := newActorDeliveryStoreForTest(t)
+
+	err := ts.EnqueueMessage(ctx, actor.EnqueueParams{
+		ID:          "msg-nackid",
+		MailboxID:   "actor-1",
+		MessageType: "test.Message",
+		Payload:     []byte{1},
+		AvailableAt: ts.clock.Now().Add(-time.Minute),
+		MaxAttempts: 2,
+	})
+	require.NoError(t, err)
+
+	// First peek: attempts is still 0 (peek does not bump).
+	peeked, err := ts.PeekNextMessage(ctx, "actor-1")
+	require.NoError(t, err)
+	require.NotNil(t, peeked)
+	require.Equal(t, 0, peeked.Attempts)
+
+	// Nack by ID: attempts -> 1, available_at pushed into the future.
+	rows, err := ts.NackMessageByID(ctx, "msg-nackid", 5*time.Minute)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows)
+
+	// Still in backoff, so not yet peekable.
+	peeked, err = ts.PeekNextMessage(ctx, "actor-1")
+	require.NoError(t, err)
+	require.Nil(t, peeked)
+
+	// Advance past the backoff; the message is peekable with attempts == 1.
+	ts.clock.SetTime(ts.clock.Now().Add(6 * time.Minute))
+	peeked, err = ts.PeekNextMessage(ctx, "actor-1")
+	require.NoError(t, err)
+	require.NotNil(t, peeked)
+	require.Equal(t, 1, peeked.Attempts)
+
+	// Nack again with no backoff: attempts -> 2 == max_attempts, so the
+	// message is no longer peek-eligible and would be dead-lettered by the
+	// consume path's ShouldDeadLetter check.
+	rows, err = ts.NackMessageByID(ctx, "msg-nackid", 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows)
+
+	peeked, err = ts.PeekNextMessage(ctx, "actor-1")
+	require.NoError(t, err)
+	require.Nil(t, peeked)
+}
+
 // TestActorDeliveryStoreAck tests message acknowledgement.
 func TestActorDeliveryStoreAck(t *testing.T) {
 	t.Parallel()

--- a/internal/actortest/e2e_test.go
+++ b/internal/actortest/e2e_test.go
@@ -3,6 +3,7 @@ package actortest
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -31,7 +32,7 @@ type testHarness struct {
 	ctx context.Context //nolint:containedctx
 
 	cancel      context.CancelFunc
-	store       *actordelivery.Store
+	store       *actordelivery.TxAwareActorDeliveryStore
 	codec       *actor.MessageCodec
 	clock       *clock.TestClock
 	actorSystem *actor.ActorSystem
@@ -59,8 +60,13 @@ func newTestHarness(t *testing.T) *testHarness {
 	// Create a test clock for time manipulation.
 	testClock := clock.NewTestClock(time.Now())
 
-	// Create the actor delivery store.
-	store := actordelivery.NewStore(actorDB, testClock)
+	// Create the actor delivery store. The transaction-aware variant
+	// matches production wiring (darepod hands the OutboxPublisher a
+	// TxAwareDeliveryStore), so the publisher e2e tests exercise the
+	// folded Tell+CompleteOutbox single-transaction delivery path.
+	store := actordelivery.NewTxAwareActorDeliveryStore(
+		actorDB, sqlDB.BaseDB, testClock,
+	)
 
 	// Create the message codec with counter messages registered.
 	codec := NewCounterCodec()
@@ -406,6 +412,136 @@ func TestOutboxPublisher_DeliversToTarget(t *testing.T) {
 	})
 
 	// Wait for target to receive the increment via OutboxPublisher.
+	eventuallyWithOutboxPublish(
+		t, publisher, outboxDeliveryTimeout,
+		func() bool {
+			return targetBehavior.Count() == 25
+		},
+	)
+
+	require.Equal(t, int64(25), targetBehavior.Count())
+}
+
+// completeFailDeliveryStore wraps a transaction-scoped DeliveryStore and fails
+// CompleteOutbox on demand. It lets the rollback test force the folded
+// Tell+CompleteOutbox delivery transaction to fail AFTER the target enqueue
+// succeeded, which is the interesting atomicity window.
+type completeFailDeliveryStore struct {
+	actor.DeliveryStore
+
+	fail *atomic.Bool
+}
+
+// CompleteOutbox fails with an injected error while the flag is set, and
+// otherwise delegates to the wrapped transaction-scoped store.
+func (s *completeFailDeliveryStore) CompleteOutbox(ctx context.Context, id,
+	claimToken string) error {
+
+	if s.fail.Load() {
+		return errInjectedCompleteFailure
+	}
+
+	return s.DeliveryStore.CompleteOutbox(ctx, id, claimToken)
+}
+
+// errInjectedCompleteFailure is the sentinel injected by
+// completeFailDeliveryStore.
+var errInjectedCompleteFailure = errors.New("injected complete failure")
+
+// completeFailTxStore wraps the real TxAwareActorDeliveryStore so the
+// OutboxPublisher still detects transaction support, while the TxFunc receives
+// a transaction-scoped store whose CompleteOutbox can be forced to fail.
+type completeFailTxStore struct {
+	*actordelivery.TxAwareActorDeliveryStore
+
+	fail atomic.Bool
+}
+
+// ExecTx delegates to the real transactional executor but interposes the
+// failure-injecting store in front of the transaction-scoped DeliveryStore.
+func (s *completeFailTxStore) ExecTx(ctx context.Context, readOnly bool,
+	fn actor.TxFunc) error {
+
+	return s.TxAwareActorDeliveryStore.ExecTx(
+		ctx, readOnly,
+		func(txCtx context.Context, store actor.DeliveryStore) error {
+			return fn(txCtx, &completeFailDeliveryStore{
+				DeliveryStore: store,
+				fail:          &s.fail,
+			})
+		},
+	)
+}
+
+// TestOutboxPublisherAtomicDeliveryRollback verifies the folded delivery
+// transaction is atomic: when CompleteOutbox fails after a successful Tell,
+// the rollback must also undo the target mailbox enqueue, leaving the outbox
+// row claimed-but-pending so a later cycle redelivers exactly once.
+func TestOutboxPublisherAtomicDeliveryRollback(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+
+	sourceID := uniqueID("counter-src")
+	targetID := uniqueID("counter-tgt")
+
+	sourceActor, sourceBehavior := h.newDurableCounter(sourceID)
+	sourceActor.Start()
+	defer sourceActor.Stop()
+
+	targetActor, targetBehavior := h.newDurableCounter(targetID)
+	targetActor.Start()
+	defer targetActor.Stop()
+
+	// The publisher sees the failure-injecting wrapper, which still
+	// satisfies TxAwareDeliveryStore, so deliveries run on the folded
+	// single-transaction path.
+	failStore := &completeFailTxStore{
+		TxAwareActorDeliveryStore: h.store,
+	}
+	failStore.fail.Store(true)
+
+	publisherCfg := actor.DefaultOutboxPublisherConfig(
+		failStore, h.codec, h.actorSystem,
+	)
+
+	// Manual publish cycles only: a long poll interval plus never calling
+	// Start keeps every claim attempt under test control.
+	publisherCfg.PollInterval = time.Hour
+	publisher := actor.NewOutboxPublisher(publisherCfg)
+
+	// Source forwards to target, parking one message in the outbox.
+	payload, err := h.codec.Encode(&IncrementMsg{Amount: 25})
+	require.NoError(t, err)
+
+	err = sourceActor.Ref().Tell(h.ctx, &ForwardMsg{
+		Target:  targetID,
+		MsgType: IncrementMsgType,
+		Payload: payload,
+	})
+	require.NoError(t, err)
+
+	eventually(t, outboxForwardProcessingTimeout, func() bool {
+		return sourceBehavior.ForwardCount() == 1
+	})
+
+	// First publish cycle: the Tell enqueues into the target mailbox
+	// inside the delivery transaction, then the injected CompleteOutbox
+	// failure rolls the whole transaction back.
+	publisher.PublishPending()
+
+	// The rollback must have erased the target enqueue: a leaked row
+	// would be drained by the running target actor and bump its counter.
+	peeked, err := h.store.PeekNextMessage(h.ctx, targetID)
+	require.NoError(t, err)
+	require.Nil(t, peeked, "enqueue leaked from rolled-back delivery tx")
+	require.Equal(t, int64(0), targetBehavior.Count())
+
+	// Heal the store and expire the claim so the row is reclaimable.
+	failStore.fail.Store(false)
+	h.clock.SetTime(h.clock.Now().Add(time.Minute))
+
+	// The retry cycle must deliver exactly once.
 	eventuallyWithOutboxPublish(
 		t, publisher, outboxDeliveryTimeout,
 		func() bool {

--- a/p-models/README.md
+++ b/p-models/README.md
@@ -38,6 +38,7 @@ correlation-key ordering fix:
 - per-correlation-key FIFO blocking
 - ack, nack, lease expiry, and dead-letter removal
 - lease token ownership
+- leaseless single-worker peek with by-ID ack/nack
 - retry exhaustion
 - independence between different mailboxes and different correlation keys
 

--- a/p-models/durableactor/CLAUDE.md
+++ b/p-models/durableactor/CLAUDE.md
@@ -3,8 +3,10 @@
 This package models the durable actor mailbox from distributed-systems first
 principles: durable enqueue, lease ownership, retry scheduling, ack/nack token
 validation, dead-letter/removal, idempotent delivery identity,
-per-correlation-key FIFO, and the Read/Commit consume step (lease-fenced
-exactly-once effect application under lease-expiry-during-IO).
+per-correlation-key FIFO, the Read/Commit consume step (lease-fenced
+exactly-once effect application under lease-expiry-during-IO), and the CDC
+outbox fold (the target enqueue and the outbox completion committing as one
+transaction, with no-lost-message and exactly-once-delivery guarantees).
 
 ## Files
 
@@ -39,7 +41,9 @@ exactly-once effect application under lease-expiry-during-IO).
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressFoldNoLoss` | Run the green transactional ingress-fold no-loss test |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressEagerCursorCounterexample` | Demonstrate the eager-cursor-after-rollback message loss |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressCheckpointFirstCounterexample` | Demonstrate the checkpoint-before-enqueue message loss |
-| `go test ./p-models/durableactor/bridge` | Replay traces against Go |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcOutboxFold` | Run the green transactional outbox-fold test |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcOutboxSplitWriteCounterexample` | Demonstrate the split-write lost-message bug |
+| `go test ./p-models/durableactor/bridge` | Replay traces and the outbox-fold/crash-restart bridge tests against Go |
 
 ## Modeling Guidance
 

--- a/p-models/durableactor/README.md
+++ b/p-models/durableactor/README.md
@@ -18,11 +18,29 @@ that matter for the bug:
 `src/mailbox_fifo.p` keeps both the old available-at ordering profile and the
 new per-correlation-key FIFO profile. It also includes a stateful
 `DurableMailboxSpec` machine with token ownership, lease expiry, nack retry,
-idempotent enqueue, ack deletion, dead-letter removal, and the durable actor's
-Read/Commit consume step (`eDurableMailboxCommit`). The test suite proves that
-the legacy profile permits a same-key overtake after a nack/backoff, while the
-new profile blocks same-key overtakes without blocking other keys, other
-mailboxes, or unkeyed rows.
+idempotent enqueue, ack deletion, dead-letter removal, the leaseless
+single-worker peek path, and the durable actor's Read/Commit consume step
+(`eDurableMailboxCommit`). The test suite proves that the legacy profile
+permits a same-key overtake after a nack/backoff, while the new profile blocks
+same-key overtakes without blocking other keys, other mailboxes, or unkeyed
+rows.
+
+### Leaseless peek consume
+
+`eDurableMailboxPeekNext`, `eDurableMailboxAckByID`, and
+`eDurableMailboxNackByID` model `SingleWorkerLeaseless`: one runtime owner
+drains a mailbox with a read-only peek instead of a lease-grant write. Peek
+uses the same eligibility and ordering rule as `LeaseNext`, but it does not
+write a lease token, deadline, or attempt increment. The actor-layer delivery
+must therefore carry `NoLeaseToken()` even if the persisted row still has stale
+expired lease metadata from an older leased claim.
+
+The by-ID nack is the matching failure edge: because peek did not pre-increment
+attempts, nack increments attempts while clearing any stale lease metadata. The
+green `TestDurableMailboxSpec_LeaselessPeekMasksStaleLease` scenario exercises
+the case that caught the review bug: a row is leased once, its lease deadline
+passes without a maintenance cleanup, then the leaseless path peeks it as an
+empty-token delivery and nacks it by ID.
 
 ### Read/Commit consume step
 
@@ -129,6 +147,10 @@ Two representational details matter when writing P scenarios or bridge traces:
   clock). The two express the same backoff; they are not interchangeable field
   values, so port a scenario by recomputing the delay, not by copying the
   number.
+- **Peek always expects an empty token.** Bridge `peek` events assert the
+  production `PeekNextMessage` adapter surface, not the raw DB row. Omitting
+  `expect_token` means the expected token is empty, matching the actor-layer
+  contract even when the row still has stale expired lease metadata.
 - **Keep `created_at` unique within a lane.** The claim order mirrors the SQL
   `ORDER BY m.priority DESC, m.available_at ASC, m.created_at ASC`. The model
   adds a final `id` tie-breaker only for determinism (the SQL leaves

--- a/p-models/durableactor/bridge/CLAUDE.md
+++ b/p-models/durableactor/bridge/CLAUDE.md
@@ -23,9 +23,34 @@ than the P checker.
   sorted by `TraceID`.
 - `ReplayMailboxTrace(t, trace)` — Replays a trace against a fresh SQLite
   `actordelivery` store in a temp dir. The `commit` op models the Read/Commit
-  fenced-ack pattern exactly: it runs `AckMessage` + `MarkProcessed` inside one
-  writer transaction, rolling back with `actor.ErrLeaseLost` when the ack row
-  count is zero.
+  consume step exactly: it runs the ack + `MarkProcessed` inside one writer
+  transaction, rolling back with `actor.ErrLeaseLost` when the ack row count is
+  zero. The ack op is chosen by lease token exactly as production `ackMessage`
+  routes it: a leased commit (`lease_token` set) acks under the lease fence via
+  `AckMessage`, while a leaseless commit (empty `lease_token`, the single-worker
+  peek path) acks via `AckMessageByID`. Both halves are trace-covered
+  (`mailbox_read_commit_fenced_exactly_once` and
+  `mailbox_leaseless_commit_fold`).
+
+## Direct bridge tests (not JSON-trace driven)
+
+Some contracts span a transaction boundary or a process restart and do not fit
+the per-op JSON replay model, so they are written as direct Go tests that drive
+the real store:
+
+- `outbox_fold_test.go` — the Go analog of the `tcOutboxFold` P scenario. It
+  runs `deliverMessage`'s fold (`EnqueueMessage` + `CompleteOutbox` inside one
+  `ExecTx`) against the real store and asserts the SQL-level contract: a fold
+  that fails after the enqueue rolls back with no orphan in the target mailbox
+  and the outbox row stays pending until claim expiry; a redelivery lands
+  exactly once; and a stale-token completion is a fenced 0-row no-op while the
+  idempotent (`ON CONFLICT id`) enqueue collapses a concurrent reclaim's
+  duplicate.
+- `crash_restart_test.go` — reopens a fresh `*sql.DB` and store against the same
+  on-disk SQLite file to model a process restart. It asserts a peeked-but-unacked
+  message survives a crash with attempts unchanged (peek is read-only), and a
+  leased-but-unacked message survives with its attempt bump durable and becomes
+  re-leasable after `ExpireLeases`.
 
 ## Relationships
 
@@ -38,9 +63,12 @@ than the P checker.
 
 - Every trace op that can fail hard uses `t.Fatal`; partial replays are not
   allowed to proceed silently.
-- The `commit` op is the sole site where `ExecTx`/`AckMessage`/`MarkProcessed`
-  are combined — it deliberately mirrors `execCore.commit` in `baselib/actor`
-  so the P model's commit-fence scenario stays tied to the real SQL path.
+- The `commit` op is the sole site where `ExecTx`/ack/`MarkProcessed` are
+  combined — it deliberately mirrors `execCore.commit` in `baselib/actor`,
+  routing the ack to `AckMessage` (leased) or `AckMessageByID` (leaseless,
+  empty token) exactly as production `ackMessage` does, so the P model's
+  commit-fence scenario stays tied to the real SQL path on both the leased and
+  leaseless single-worker consume.
 - Duplicate enqueue ops (`ExpectDuplicate: true`) must complete without error;
   a future rejection would fail here explicitly rather than at a later lease
   step.

--- a/p-models/durableactor/bridge/crash_restart_test.go
+++ b/p-models/durableactor/bridge/crash_restart_test.go
@@ -1,0 +1,231 @@
+package bridge
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/db/actordelivery"
+	"github.com/lightninglabs/darepo-client/db/sqlc"
+	"github.com/lightningnetwork/lnd/clock"
+)
+
+// openStoreAt opens (or reopens) an actor-delivery store backed by the SQLite
+// file at path. runMigrations applies the schema, which the first open must do
+// and a restart open must not (the schema is already durable in the file). The
+// returned closer drops the underlying *sql.DB connection, modeling a process
+// exit that leaves the on-disk database intact.
+func openStoreAt(t *testing.T, path string, clk clock.Clock,
+	runMigrations bool) (actor.TxAwareDeliveryStore, func()) {
+
+	t.Helper()
+
+	rawDB, err := sql.Open("sqlite", path)
+	requireNoError(t, err)
+
+	if runMigrations {
+		requireNoError(
+			t, actordelivery.RunMigrations(
+				rawDB, sqlc.BackendTypeSqlite,
+			),
+		)
+	}
+
+	store, err := actordelivery.NewTxAwareDeliveryStoreFromDB(
+		rawDB, sqlc.BackendTypeSqlite, clk, btclog.Disabled,
+	)
+	requireNoError(t, err)
+
+	return store, func() {
+		requireNoError(t, rawDB.Close())
+	}
+}
+
+// TestPeekSurvivesCrashBeforeAck models a single-worker actor that peeks a
+// durable message (the leaseless fast path), then the process dies before it
+// can ack or nack. After a restart against the same on-disk database the same
+// row must still be peekable, byte-for-byte, with its attempt count unchanged:
+// peek is read-only, so a crash mid-processing cannot lose the message or
+// inflate its retry budget. The restart is real — a fresh *sql.DB and a fresh
+// store are constructed against the same file — so this exercises durability,
+// not in-memory state.
+func TestPeekSurvivesCrashBeforeAck(t *testing.T) {
+	t.Parallel()
+
+	const (
+		msgID   = "crash-peek-1"
+		mailbox = "single-worker"
+	)
+
+	path := filepath.Join(t.TempDir(), "crash-restart.db")
+	clk := clock.NewTestClock(traceTime(0))
+
+	// First boot: enqueue a message and peek it without acking.
+	store, closeStore := openStoreAt(t, path, clk, true)
+
+	requireNoError(
+		t,
+		store.EnqueueMessage(
+			t.Context(), actor.EnqueueParams{
+				ID:          msgID,
+				MailboxID:   mailbox,
+				MessageType: "model.TraceMsg",
+				Payload:     []byte("crash-payload"),
+				AvailableAt: clk.Now(),
+				MaxAttempts: 3,
+			},
+		),
+	)
+
+	peeked, err := store.PeekNextMessage(t.Context(), mailbox)
+	requireNoError(t, err)
+	if peeked == nil || peeked.ID != msgID {
+		t.Fatalf("expected to peek %s before crash, got %v", msgID,
+			peeked)
+	}
+	if peeked.LeaseToken != "" {
+		t.Fatalf("leaseless peek must surface an empty token, got %q",
+			peeked.LeaseToken)
+	}
+	if peeked.Attempts != 0 {
+		t.Fatalf("peek must not increment attempts, got %d",
+			peeked.Attempts)
+	}
+
+	// Crash: drop the connection with the message peeked but neither acked
+	// nor nacked.
+	closeStore()
+
+	// Restart: a fresh store against the same on-disk database.
+	clk2 := clock.NewTestClock(traceTime(5))
+	store2, closeStore2 := openStoreAt(t, path, clk2, false)
+	defer closeStore2()
+
+	// The same row is still peekable, intact, with attempts unchanged: the
+	// pre-crash peek neither consumed it nor charged it a retry.
+	rePeeked, err := store2.PeekNextMessage(t.Context(), mailbox)
+	requireNoError(t, err)
+	if rePeeked == nil || rePeeked.ID != msgID {
+		t.Fatalf("expected %s to survive the restart, got %v", msgID,
+			rePeeked)
+	}
+	if rePeeked.LeaseToken != "" {
+		t.Fatalf("post-restart peek must still be leaseless, got %q",
+			rePeeked.LeaseToken)
+	}
+	if rePeeked.Attempts != 0 {
+		t.Fatalf("attempts must be unchanged across the crash, got %d",
+			rePeeked.Attempts)
+	}
+	if string(rePeeked.Payload) != "crash-payload" {
+		t.Fatalf("payload corrupted across restart: %q",
+			string(rePeeked.Payload))
+	}
+
+	// The recovered worker can now consume it via the leaseless by-id ack.
+	rows, err := store2.AckMessageByID(t.Context(), msgID)
+	requireNoError(t, err)
+	if rows != 1 {
+		t.Fatalf("expected to ack exactly 1 recovered row, got %d",
+			rows)
+	}
+	if drained, err := store2.PeekNextMessage(
+		t.Context(), mailbox,
+	); err != nil || drained != nil {
+
+		t.Fatalf("expected the mailbox to be drained after ack, got "+
+			"(%v, %v)", drained, err)
+	}
+}
+
+// TestLeaseSurvivesCrashBeforeAck is the leased-path counterpart: a worker
+// leases a message (which sets a lease token and increments attempts), then the
+// process dies mid-IO before acking. After a restart the row must still exist
+// with its incremented attempt count durable; once the original lease deadline
+// passes, ExpireLeases returns it to the available set and it can be re-leased
+// for at-least-once redelivery — the durable-redelivery contract under a crash.
+func TestLeaseSurvivesCrashBeforeAck(t *testing.T) {
+	t.Parallel()
+
+	const (
+		msgID   = "crash-lease-1"
+		mailbox = "multi-worker"
+	)
+
+	path := filepath.Join(t.TempDir(), "crash-lease.db")
+	clk := clock.NewTestClock(traceTime(0))
+
+	// First boot: enqueue and lease (token + attempts++), then crash.
+	store, closeStore := openStoreAt(t, path, clk, true)
+
+	requireNoError(
+		t,
+		store.EnqueueMessage(
+			t.Context(), actor.EnqueueParams{
+				ID:          msgID,
+				MailboxID:   mailbox,
+				MessageType: "model.TraceMsg",
+				Payload:     []byte("lease-payload"),
+				AvailableAt: clk.Now(),
+				MaxAttempts: 3,
+			},
+		),
+	)
+
+	leased, err := store.LeaseNextMessage(
+		t.Context(), mailbox, "worker-A", 10*time.Second,
+	)
+	requireNoError(t, err)
+	if leased == nil || leased.ID != msgID {
+		t.Fatalf("expected to lease %s before crash, got %v", msgID,
+			leased)
+	}
+	if leased.Attempts != 1 {
+		t.Fatalf("lease must increment attempts to 1, got %d",
+			leased.Attempts)
+	}
+
+	// Crash mid-IO: the lease is held but never acked.
+	closeStore()
+
+	// Restart at a time still within the original lease window: the row is
+	// durably present, the attempt bump survived, and the stale lease still
+	// fences a peek out until it expires.
+	clk2 := clock.NewTestClock(traceTime(5))
+	store2, closeStore2 := openStoreAt(t, path, clk2, false)
+	defer closeStore2()
+
+	if peeked, err := store2.PeekNextMessage(
+		t.Context(), mailbox,
+	); err != nil || peeked != nil {
+
+		t.Fatalf("a still-live lease must fence the row out "+
+			"post-restart, got (%v, %v)", peeked, err)
+	}
+
+	// Once the lease deadline passes, expiry returns the row to the
+	// available set and a new worker re-leases it — the attempt count
+	// carries forward, so dead-lettering accounting is preserved.
+	clk2.SetTime(traceTime(20))
+	requireNoError(t, store2.ExpireLeases(t.Context()))
+
+	released, err := store2.LeaseNextMessage(
+		t.Context(), mailbox, "worker-B", 10*time.Second,
+	)
+	requireNoError(t, err)
+	if released == nil || released.ID != msgID {
+		t.Fatalf("expected %s to be re-leasable after expiry, got %v",
+			msgID, released)
+	}
+	if released.Attempts != 2 {
+		t.Fatalf("expected attempts to carry forward to 2 across the "+
+			"crash, got %d", released.Attempts)
+	}
+	if string(released.Payload) != "lease-payload" {
+		t.Fatalf("payload corrupted across restart: %q",
+			string(released.Payload))
+	}
+}

--- a/p-models/durableactor/bridge/mailbox_trace.go
+++ b/p-models/durableactor/bridge/mailbox_trace.go
@@ -57,6 +57,8 @@ type MailboxTraceEvent struct {
 	MaxAttempts    int    `json:"max_attempts,omitempty"`
 	Priority       int    `json:"priority,omitempty"`
 	ExpectRows     *int64 `json:"expect_rows,omitempty"`
+	ExpectAttempts *int   `json:"expect_attempts,omitempty"`
+	ExpectToken    string `json:"expect_token,omitempty"`
 
 	// ExpectDuplicate marks an enqueue op whose id already exists.
 	// Production EnqueueMessage is idempotent by durable id, so a duplicate
@@ -154,11 +156,20 @@ func ReplayMailboxTrace(t *testing.T, trace *MailboxTrace) {
 		case "lease":
 			replayLease(t, store, event)
 
+		case "peek":
+			replayPeek(t, store, event)
+
 		case "nack":
 			replayNack(t, store, event)
 
+		case "nack_by_id":
+			replayNackByID(t, store, event)
+
 		case "ack":
 			replayAck(t, store, event)
+
+		case "ack_by_id":
+			replayAckByID(t, store, event)
 
 		case "commit":
 			replayCommit(t, store, event)
@@ -259,6 +270,63 @@ func replayLease(t *testing.T, store actor.TxAwareDeliveryStore,
 		t.Fatalf("expected leased payload %q, got %q",
 			event.ExpectPayload, string(leased.Payload))
 	}
+
+	if event.ExpectAttempts != nil &&
+		leased.Attempts != *event.ExpectAttempts {
+
+		t.Fatalf("expected leased attempts %d, got %d",
+			*event.ExpectAttempts, leased.Attempts)
+	}
+
+	if event.ExpectToken != "" && leased.LeaseToken != event.ExpectToken {
+		t.Fatalf("expected lease token %q, got %q", event.ExpectToken,
+			leased.LeaseToken)
+	}
+}
+
+func replayPeek(t *testing.T, store actor.TxAwareDeliveryStore,
+	event MailboxTraceEvent) {
+
+	t.Helper()
+
+	peeked, err := store.PeekNextMessage(t.Context(), event.MailboxID)
+	requireNoError(t, err)
+
+	if event.ExpectID == "" {
+		if peeked != nil {
+			t.Fatalf("expected no peeked row, got %s", peeked.ID)
+		}
+
+		return
+	}
+
+	if peeked == nil {
+		t.Fatalf("expected peeked row %s, got nil", event.ExpectID)
+	}
+
+	if peeked.ID != event.ExpectID {
+		t.Fatalf("expected peeked row %s, got %s", event.ExpectID,
+			peeked.ID)
+	}
+
+	if event.ExpectPayload != "" &&
+		string(peeked.Payload) != event.ExpectPayload {
+
+		t.Fatalf("expected peeked payload %q, got %q",
+			event.ExpectPayload, string(peeked.Payload))
+	}
+
+	if event.ExpectAttempts != nil &&
+		peeked.Attempts != *event.ExpectAttempts {
+
+		t.Fatalf("expected peeked attempts %d, got %d",
+			*event.ExpectAttempts, peeked.Attempts)
+	}
+
+	if peeked.LeaseToken != event.ExpectToken {
+		t.Fatalf("expected peek token %q, got %q", event.ExpectToken,
+			peeked.LeaseToken)
+	}
 }
 
 func replayNack(t *testing.T, store actor.TxAwareDeliveryStore,
@@ -274,6 +342,19 @@ func replayNack(t *testing.T, store actor.TxAwareDeliveryStore,
 	requireExpectedRows(t, rows, event, "nack")
 }
 
+func replayNackByID(t *testing.T, store actor.TxAwareDeliveryStore,
+	event MailboxTraceEvent) {
+
+	t.Helper()
+
+	rows, err := store.NackMessageByID(
+		t.Context(), event.ID,
+		time.Duration(event.RetryAfter)*time.Second,
+	)
+	requireNoError(t, err)
+	requireExpectedRows(t, rows, event, "nack_by_id")
+}
+
 func replayAck(t *testing.T, store actor.TxAwareDeliveryStore,
 	event MailboxTraceEvent) {
 
@@ -286,11 +367,26 @@ func replayAck(t *testing.T, store actor.TxAwareDeliveryStore,
 	requireExpectedRows(t, rows, event, "ack")
 }
 
+func replayAckByID(t *testing.T, store actor.TxAwareDeliveryStore,
+	event MailboxTraceEvent) {
+
+	t.Helper()
+
+	rows, err := store.AckMessageByID(t.Context(), event.ID)
+	requireNoError(t, err)
+	requireExpectedRows(t, rows, event, "ack_by_id")
+}
+
 // replayCommit models the durable actor's Read/Commit consume step against the
 // real store, mirroring execCore.commit in baselib/actor: inside one writer
-// transaction it fence-acks the row (DELETE ... WHERE id AND lease_token) and,
-// only when that ack consumed a row, records the dedup mark. A zero-row ack
-// means the lease was reclaimed mid-IO, so the transaction is rolled back with
+// transaction it acks the row and, only when that ack consumed a row, records
+// the dedup mark. The ack op is chosen by lease token exactly as production
+// ackMessage routes it -- a leased delivery acks under its lease fence
+// (DELETE ... WHERE id AND lease_token) while a leaseless (empty-token,
+// single-worker peek) delivery acks by ID (DELETE ... WHERE id) -- so the
+// bridge exercises both halves of the fold. A zero-row ack means the row is
+// already gone (the lease was reclaimed mid-IO, or, on the leaseless path, the
+// row was already consumed), so the transaction is rolled back with
 // ErrLeaseLost and nothing (ack or dedup mark) is applied. This keeps the P
 // commit-fence model tied to the SQL exactly-once mechanism.
 func replayCommit(t *testing.T, store actor.TxAwareDeliveryStore,
@@ -303,9 +399,15 @@ func replayCommit(t *testing.T, store actor.TxAwareDeliveryStore,
 		t.Context(), false,
 		func(txCtx context.Context, s actor.DeliveryStore) error {
 			var ackErr error
-			rows, ackErr = s.AckMessage(
-				txCtx, event.ID, event.LeaseToken,
-			)
+			if event.LeaseToken == "" {
+				rows, ackErr = s.AckMessageByID(
+					txCtx, event.ID,
+				)
+			} else {
+				rows, ackErr = s.AckMessage(
+					txCtx, event.ID, event.LeaseToken,
+				)
+			}
 			if ackErr != nil {
 				return ackErr
 			}

--- a/p-models/durableactor/bridge/outbox_fold_test.go
+++ b/p-models/durableactor/bridge/outbox_fold_test.go
@@ -1,0 +1,327 @@
+package bridge
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/db/actordelivery"
+	"github.com/lightninglabs/darepo-client/db/sqlc"
+	"github.com/lightningnetwork/lnd/clock"
+)
+
+// foldClaimDuration is the outbox claim lease the fold bridge tests hold. It is
+// long enough that a re-claim inside the window is rejected and short enough
+// that advancing the test clock past it makes the row reclaimable.
+const foldClaimDuration = 30 * time.Second
+
+// errFoldInjected simulates a CompleteOutbox failure (or a crash) AFTER the
+// target enqueue inside the folded delivery transaction. Returning it from the
+// ExecTx closure rolls the whole transaction back, exactly as a real
+// CompleteOutbox error would in deliverMessage.
+var errFoldInjected = errors.New("injected outbox fold failure")
+
+// newFoldStore builds a transaction-aware actor-delivery store backed by a
+// fresh migrated SQLite database, matching the production wiring the outbox
+// publisher uses (NewTxAwareDeliveryStoreFromDB + the same backend type).
+func newFoldStore(t *testing.T, clk clock.Clock) actor.TxAwareDeliveryStore {
+	t.Helper()
+
+	rawDB := newSQLiteDB(t)
+	requireNoError(
+		t, actordelivery.RunMigrations(rawDB, sqlc.BackendTypeSqlite),
+	)
+
+	store, err := actordelivery.NewTxAwareDeliveryStoreFromDB(
+		rawDB, sqlc.BackendTypeSqlite, clk, btclog.Disabled,
+	)
+	requireNoError(t, err)
+
+	return store
+}
+
+// foldDelivery replays deliverMessage's transactional fold against the real
+// store: inside ONE ExecTx it durably enqueues the message into the target
+// mailbox (the "Tell") and then completes the outbox row. The enqueue is keyed
+// by the outbox id so a redelivery is an idempotent ON CONFLICT no-op, exactly
+// as WithOutboxID arranges in production. When failAfterEnqueue is set the
+// closure returns errFoldInjected after the enqueue, modeling a CompleteOutbox
+// error or a crash mid-fold; ExecTx then rolls the enqueue back atomically.
+func foldDelivery(t *testing.T, store actor.TxAwareDeliveryStore,
+	clk clock.Clock, outboxID, target, completeToken string,
+	failAfterEnqueue bool) error {
+
+	t.Helper()
+
+	return store.ExecTx(
+		t.Context(), false,
+		func(txCtx context.Context, s actor.DeliveryStore) error {
+			err := s.EnqueueMessage(txCtx, actor.EnqueueParams{
+				ID:          outboxID,
+				MailboxID:   target,
+				MessageType: "model.TraceMsg",
+				Payload:     []byte("fold-payload"),
+				AvailableAt: clk.Now(),
+				MaxAttempts: 3,
+			})
+			if err != nil {
+				return err
+			}
+
+			// Model the failure window between the durable enqueue
+			// and the completion: the fold must roll the enqueue
+			// back rather than leave an orphan in the target
+			// mailbox.
+			if failAfterEnqueue {
+				return errFoldInjected
+			}
+
+			return s.CompleteOutbox(txCtx, outboxID, completeToken)
+		},
+	)
+}
+
+// claimOutbox claims up to ten pending outbox rows under the given token,
+// mirroring publishBatch's per-poll claim.
+func claimOutbox(t *testing.T, store actor.TxAwareDeliveryStore,
+	token string) []actor.OutboxMessage {
+
+	t.Helper()
+
+	msgs, err := store.ClaimOutboxBatch(
+		t.Context(), actor.OutboxClaimParams{
+			Limit:         10,
+			ClaimToken:    token,
+			ClaimDuration: foldClaimDuration,
+		},
+	)
+	requireNoError(t, err)
+
+	return msgs
+}
+
+// leaseTarget leases the next message from the target mailbox, returning nil
+// when the mailbox is empty.
+func leaseTarget(t *testing.T, store actor.TxAwareDeliveryStore, target,
+	token string) *actor.LeasedMessage {
+
+	t.Helper()
+
+	leased, err := store.LeaseNextMessage(
+		t.Context(), target, token, time.Minute,
+	)
+	requireNoError(t, err)
+
+	return leased
+}
+
+// TestOutboxFoldRollbackErasesEnqueueAndRetries is the bridge analog of the P
+// outbox-fold contract and of deliverMessage's transactional path. A folded
+// delivery that fails after the target enqueue must leave NO orphan in the
+// target mailbox, must leave the outbox row pending (and unclaimable until the
+// claim expires), and must redeliver exactly once after the claim expires. It
+// drives the real SQLite store so the ExecTx rollback, the claim-expiry reclaim
+// SQL, and the token-fenced completion are all exercised, not modeled.
+func TestOutboxFoldRollbackErasesEnqueueAndRetries(t *testing.T) {
+	t.Parallel()
+
+	const (
+		outboxID = "outbox-fold-1"
+		target   = "target-actor"
+	)
+
+	clk := clock.NewTestClock(traceTime(0))
+	store := newFoldStore(t, clk)
+
+	requireNoError(
+		t,
+		store.EnqueueOutbox(
+			t.Context(), actor.OutboxParams{
+				ID:            outboxID,
+				SourceActorID: "source-actor",
+				TargetActorID: target,
+				MessageType:   "model.TraceMsg",
+				Payload:       []byte("fold-payload"),
+			},
+		),
+	)
+
+	// Publisher claims the row (token-1): delivery_attempts goes to 1.
+	claimed := claimOutbox(t, store, "token-1")
+	if len(claimed) != 1 {
+		t.Fatalf("expected 1 claimed outbox row, got %d", len(claimed))
+	}
+	if claimed[0].ID != outboxID {
+		t.Fatalf("expected claimed outbox id %s, got %s", outboxID,
+			claimed[0].ID)
+	}
+	if claimed[0].DeliveryAttempts != 1 {
+		t.Fatalf("expected delivery_attempts 1 after first "+
+			"claim, got %d", claimed[0].DeliveryAttempts)
+	}
+
+	// The folded delivery fails after the enqueue, so the whole tx rolls
+	// back.
+	err := foldDelivery(t, store, clk, outboxID, target, "token-1", true)
+	if !errors.Is(err, errFoldInjected) {
+		t.Fatalf("expected injected fold failure, got %v", err)
+	}
+
+	// Rollback erased the target enqueue: the target mailbox is empty.
+	if leased := leaseTarget(t, store, target, "probe"); leased != nil {
+		t.Fatalf("rolled-back fold left an orphan enqueue %s in the "+
+			"target mailbox", leased.ID)
+	}
+
+	// The outbox row is still pending but NOT reclaimable while the first
+	// claim is live: a re-claim inside the claim window returns nothing.
+	clk.SetTime(traceTime(10))
+	if held := claimOutbox(t, store, "token-early"); len(held) != 0 {
+		t.Fatalf("outbox row reclaimed inside its live claim "+
+			"window: %d rows", len(held))
+	}
+
+	// After the claim expires the row is reclaimable again, and the
+	// delivery_attempts bump from the first claim survived the rolled-back
+	// fold (the claim commits in its own tx, separate from the fold).
+	clk.SetTime(traceTime(40))
+	reclaimed := claimOutbox(t, store, "token-2")
+	if len(reclaimed) != 1 {
+		t.Fatalf("expected the row to be reclaimable after claim "+
+			"expiry, got %d rows", len(reclaimed))
+	}
+	if reclaimed[0].DeliveryAttempts != 2 {
+		t.Fatalf("expected delivery_attempts 2 after reclaim, got %d",
+			reclaimed[0].DeliveryAttempts)
+	}
+
+	// Redelivery commits the fold: target enqueue and completion land
+	// atomically.
+	requireNoError(
+		t,
+		foldDelivery(t, store, clk, outboxID, target, "token-2", false),
+	)
+
+	// The target mailbox now holds exactly one copy of the message.
+	leased := leaseTarget(t, store, target, "consumer")
+	if leased == nil || leased.ID != outboxID {
+		t.Fatalf("expected the redelivered row %s in the target "+
+			"mailbox, got %v", outboxID, leased)
+	}
+	rows, err := store.AckMessage(t.Context(), outboxID, leased.LeaseToken)
+	requireNoError(t, err)
+	if rows != 1 {
+		t.Fatalf("expected to ack exactly 1 target row, got %d", rows)
+	}
+	if dup := leaseTarget(t, store, target, "consumer-2"); dup != nil {
+		t.Fatalf("target mailbox held a duplicate row %s after the "+
+			"fold redelivery", dup.ID)
+	}
+
+	// The outbox row is completed: no further claim returns it, even past a
+	// later claim expiry.
+	clk.SetTime(traceTime(100))
+	if done := claimOutbox(t, store, "token-3"); len(done) != 0 {
+		t.Fatalf("completed outbox row was reclaimed: %d rows",
+			len(done))
+	}
+}
+
+// TestOutboxFoldConcurrentReclaimDeliversExactlyOnce drives the cross-publisher
+// reclaim race the claim token exists to fence. A slow publisher's claim
+// expires and a second publisher reclaims the row; the stale publisher then
+// commits its fold with its OLD token. Its enqueue commits (idempotent by id)
+// but its CompleteOutbox is a zero-row no-op because the row is now owned by
+// the new token, so the outbox stays pending. The current owner's fold then
+// finds the enqueue already present (ON CONFLICT no-op) and completes under its
+// matching token. The target mailbox must end with exactly one copy of the
+// message: receiver-side dedup collapses the duplicate enqueue and the
+// token-fenced completion admits only the current owner.
+func TestOutboxFoldConcurrentReclaimDeliversExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	const (
+		outboxID = "outbox-fold-2"
+		target   = "target-actor"
+	)
+
+	clk := clock.NewTestClock(traceTime(0))
+	store := newFoldStore(t, clk)
+
+	requireNoError(
+		t,
+		store.EnqueueOutbox(
+			t.Context(), actor.OutboxParams{
+				ID:            outboxID,
+				SourceActorID: "source-actor",
+				TargetActorID: target,
+				MessageType:   "model.TraceMsg",
+				Payload:       []byte("fold-payload"),
+			},
+		),
+	)
+
+	// Publisher P1 claims at t=0 (token-1).
+	first := claimOutbox(t, store, "token-1")
+	if len(first) != 1 || first[0].DeliveryAttempts != 1 {
+		t.Fatalf("expected 1 row at attempts 1 for P1, got %+v", first)
+	}
+
+	// P1 stalls past its claim; P2 reclaims the same row at t=40 (token-2).
+	clk.SetTime(traceTime(40))
+	second := claimOutbox(t, store, "token-2")
+	if len(second) != 1 || second[0].DeliveryAttempts != 2 {
+		t.Fatalf("expected 1 row at attempts 2 for P2, got %+v", second)
+	}
+
+	// Stale P1 finishes first with its now-superseded token. The enqueue
+	// commits, but CompleteOutbox(token-1) matches zero rows (the row is
+	// owned by token-2), so the tx commits with the outbox still pending.
+	requireNoError(
+		t,
+		foldDelivery(t, store, clk, outboxID, target, "token-1", false),
+	)
+
+	// The outbox row is still pending: P1's stale completion was fenced
+	// out. (It is owned by token-2 until that claim expires, so a fresh
+	// claim inside the window sees nothing.)
+	if held := claimOutbox(t, store, "token-peek"); len(held) != 0 {
+		t.Fatalf("expected the row to stay owned by token-2, got %d "+
+			"reclaimable rows", len(held))
+	}
+
+	// Current owner P2 runs its fold: the enqueue is an idempotent no-op
+	// (the id already exists from P1) and CompleteOutbox(token-2) matches,
+	// so the row is completed.
+	requireNoError(
+		t,
+		foldDelivery(t, store, clk, outboxID, target, "token-2", false),
+	)
+
+	// Despite two folds enqueuing, the target mailbox holds exactly one
+	// row.
+	leased := leaseTarget(t, store, target, "consumer")
+	if leased == nil || leased.ID != outboxID {
+		t.Fatalf("expected exactly the delivered row %s, got %v",
+			outboxID, leased)
+	}
+	rows, err := store.AckMessage(t.Context(), outboxID, leased.LeaseToken)
+	requireNoError(t, err)
+	if rows != 1 {
+		t.Fatalf("expected to ack exactly 1 target row, got %d", rows)
+	}
+	if dup := leaseTarget(t, store, target, "consumer-2"); dup != nil {
+		t.Fatalf("concurrent reclaim double-delivered to the target "+
+			"mailbox: duplicate %s", dup.ID)
+	}
+
+	// The outbox row is completed: no further claim returns it.
+	clk.SetTime(traceTime(200))
+	if done := claimOutbox(t, store, "token-3"); len(done) != 0 {
+		t.Fatalf("completed outbox row was reclaimed: %d rows",
+			len(done))
+	}
+}

--- a/p-models/durableactor/src/mailbox_fifo.p
+++ b/p-models/durableactor/src/mailbox_fifo.p
@@ -53,16 +53,33 @@ type DurableMailboxLeaseNextReq = (
     lease_duration: int
 );
 
+type DurableMailboxPeekNextReq = (
+    reply_to: machine,
+    mailbox_id: int,
+    now: int
+);
+
 type DurableMailboxTokenReq = (
     reply_to: machine,
     id: int,
     lease_token: int
 );
 
+type DurableMailboxByIDReq = (
+    reply_to: machine,
+    id: int
+);
+
 type DurableMailboxNackReq = (
     reply_to: machine,
     id: int,
     lease_token: int,
+    available_at: int
+);
+
+type DurableMailboxNackByIDReq = (
+    reply_to: machine,
+    id: int,
     available_at: int
 );
 
@@ -146,8 +163,11 @@ type DurableMailboxStageReq = (
 
 event eDurableMailboxEnqueue: DurableMailboxEnqueueReq;
 event eDurableMailboxLeaseNext: DurableMailboxLeaseNextReq;
+event eDurableMailboxPeekNext: DurableMailboxPeekNextReq;
 event eDurableMailboxAck: DurableMailboxTokenReq;
+event eDurableMailboxAckByID: DurableMailboxByIDReq;
 event eDurableMailboxNack: DurableMailboxNackReq;
+event eDurableMailboxNackByID: DurableMailboxNackByIDReq;
 event eDurableMailboxExpireLeasesAt: int;
 event eDurableMailboxDeadLetter: DurableMailboxDeadLetterReq;
 event eDurableMailboxCommit: DurableMailboxCommitReq;
@@ -155,6 +175,7 @@ event eDurableMailboxStage: DurableMailboxStageReq;
 
 event eDurableMailboxOpResp: (int, DurableMailboxOpResult);
 event eDurableMailboxLeaseResp: (int, DurableMailboxOpResult);
+event eDurableMailboxPeekResp: (int, int, int, DurableMailboxOpResult);
 
 // eDurableMailboxClaimed is announced on every successful lease.
 // eDurableMailboxRowEnqueued and eDurableMailboxRowRemoved let the FIFO monitor
@@ -470,6 +491,26 @@ fun NackMailboxRow(rows: seq[MailboxRow], id: int, available_at: int):
     return ReplaceMailboxRow(rows, row);
 }
 
+// NackMailboxRowByID is the leaseless failure path. Peek does not write a
+// lease or pre-increment attempts, so the by-ID nack increments attempts here.
+// It also clears any stale expired lease metadata left by an older leased
+// claim; otherwise the persisted row no longer matches the empty-token
+// leaseless state machine the actor layer observed.
+fun NackMailboxRowByID(rows: seq[MailboxRow], id: int, available_at: int):
+    seq[MailboxRow] {
+
+    var row: MailboxRow;
+
+    row = RowByID(rows, id);
+    row = NewMailboxRow(
+        row.id, row.mailbox_id, row.correlation_key, row.priority,
+        available_at, NoLease(), NoLeaseToken(), row.attempts + 1,
+        row.max_attempts, row.created_at
+    );
+
+    return ReplaceMailboxRow(rows, row);
+}
+
 fun ExpireMailboxLeases(rows: seq[MailboxRow], now: int): seq[MailboxRow] {
     var result: seq[MailboxRow];
     var i: int;
@@ -565,6 +606,34 @@ machine DurableMailboxSpec {
                 (id, MailboxOpOk);
         }
 
+        on eDurableMailboxPeekNext do (
+            req: DurableMailboxPeekNextReq
+        ) {
+            var id: int;
+            var row: MailboxRow;
+
+            id = ClaimNextMailboxRow(
+                rows, req.mailbox_id, req.now, mode
+            );
+            if (id == NoMailboxRow()) {
+                send req.reply_to, eDurableMailboxPeekResp,
+                    (
+                        NoMailboxRow(), NoLeaseToken(), 0,
+                        MailboxOpNotFound
+                    );
+                return;
+            }
+
+            // Peek is read-only: it selects the same eligible row as LeaseNext
+            // but does not mutate lease metadata or attempts. The actor-layer
+            // contract is nevertheless an empty token, even if the persisted
+            // row still has stale expired lease metadata from an older leased
+            // claim.
+            row = RowByID(rows, id);
+            send req.reply_to, eDurableMailboxPeekResp,
+                (id, NoLeaseToken(), row.attempts, MailboxOpOk);
+        }
+
         on eDurableMailboxAck do (req: DurableMailboxTokenReq) {
             var row: MailboxRow;
 
@@ -578,6 +647,19 @@ machine DurableMailboxSpec {
             if (!TokenMatches(row, req.lease_token)) {
                 send req.reply_to, eDurableMailboxOpResp,
                     (req.id, MailboxOpTokenMismatch);
+                return;
+            }
+
+            rows = RemoveMailboxRow(rows, req.id);
+            announce eDurableMailboxRowRemoved, (this, req.id);
+            send req.reply_to, eDurableMailboxOpResp,
+                (req.id, MailboxOpOk);
+        }
+
+        on eDurableMailboxAckByID do (req: DurableMailboxByIDReq) {
+            if (!RowExists(rows, req.id)) {
+                send req.reply_to, eDurableMailboxOpResp,
+                    (req.id, MailboxOpNotFound);
                 return;
             }
 
@@ -604,6 +686,18 @@ machine DurableMailboxSpec {
             }
 
             rows = NackMailboxRow(rows, req.id, req.available_at);
+            send req.reply_to, eDurableMailboxOpResp,
+                (req.id, MailboxOpOk);
+        }
+
+        on eDurableMailboxNackByID do (req: DurableMailboxNackByIDReq) {
+            if (!RowExists(rows, req.id)) {
+                send req.reply_to, eDurableMailboxOpResp,
+                    (req.id, MailboxOpNotFound);
+                return;
+            }
+
+            rows = NackMailboxRowByID(rows, req.id, req.available_at);
             send req.reply_to, eDurableMailboxOpResp,
                 (req.id, MailboxOpOk);
         }

--- a/p-models/durableactor/src/mailbox_fifo.p
+++ b/p-models/durableactor/src/mailbox_fifo.p
@@ -1049,3 +1049,234 @@ spec CheckpointAdvancesMonotonically observes
         }
     }
 }
+
+// =============================================================================
+// Outbox fold model
+// =============================================================================
+//
+// The CDC outbox publisher's per-message delivery step folds two writes -- the
+// target-mailbox enqueue (the "Tell") and the outbox-row completion -- into a
+// single write transaction (deliverMessage's ExecTx in baselib/actor). The
+// contract this model pins down:
+//
+//   * Atomicity: the enqueue and the completion commit together or not at all.
+//     A failure mid-fold rolls BOTH back, so the outbox row stays pending and
+//     no orphan is left in the target mailbox; the row is redelivered after the
+//     claim expires.
+//
+//   * Idempotent delivery: the target enqueue is keyed by the outbox id
+//     (WithOutboxID -> ON CONFLICT (id) DO NOTHING), so a redelivery or a
+//     concurrent-publisher reclaim never produces a second distinct delivery.
+//
+//   * Token-fenced completion: only the current claim owner completes the row.
+//     A stale publisher's completion matches zero rows (it is a no-op, not a
+//     failure), so the row stays pending for the live owner.
+//
+// The headline safety property is no lost messages: an outbox row must never be
+// marked completed unless the target enqueue is durable. The two profiles:
+//
+//   * AtomicFold (production): one transaction. The completion can only be
+//     observed together with a durable enqueue.
+//
+//   * SplitWrite (counterexample): the completion and the enqueue are
+//     independent writes. A crash after the completion lands but before the
+//     enqueue is durable leaves the outbox completed with the message never
+//     delivered -- the lost message the fold's single transaction prevents.
+
+enum OutboxFoldMode {
+    AtomicFold,
+    SplitWrite
+}
+
+type OutboxFoldIDReq = (
+    reply_to: machine,
+    id: int
+);
+
+type OutboxFoldClaimReq = (
+    reply_to: machine,
+    id: int,
+    token: int
+);
+
+// OutboxFoldDeliverReq models the folded delivery transaction for one row.
+// `token` is the publisher's claim token; completion is gated on it matching
+// the row's current owner. `enqueue_ok` models whether the target enqueue step
+// succeeds: false is the failure/crash that, under AtomicFold, must roll the
+// whole transaction back.
+type OutboxFoldDeliverReq = (
+    reply_to: machine,
+    id: int,
+    token: int,
+    enqueue_ok: bool
+);
+
+event eOutboxFoldEnqueue: OutboxFoldIDReq;
+event eOutboxFoldClaim: OutboxFoldClaimReq;
+event eOutboxFoldDeliver: OutboxFoldDeliverReq;
+event eOutboxFoldResp: (int, DurableMailboxOpResult);
+
+// eOutboxTargetEnqueued is announced when a delivery durably enqueues the
+// message into the target mailbox; eOutboxCompleted when the outbox row is
+// marked completed. Both carry (mbox, id). The monitors reconstruct the
+// completed-implies-delivered and delivered-at-most-once contracts from this
+// stream, namespaced by the announcing OutboxFoldSpec instance.
+event eOutboxTargetEnqueued: (machine, int);
+event eOutboxCompleted: (machine, int);
+
+// OutboxFoldSpec is the idealized transactional outbox + target mailbox for the
+// CDC delivery step. It is single-table per (outbox row, target enqueue) and
+// scoped by id; the safety contract is independent of how many rows coexist.
+machine OutboxFoldSpec {
+    var mode: OutboxFoldMode;
+    var present: map[int, bool];
+    var completed: map[int, bool];
+    var enqueued: map[int, bool];
+    var token: map[int, int];
+
+    start state Active {
+        entry (fold_mode: OutboxFoldMode) {
+            mode = fold_mode;
+        }
+
+        on eOutboxFoldEnqueue do (req: OutboxFoldIDReq) {
+            if (req.id in present && present[req.id]) {
+                send req.reply_to, eOutboxFoldResp,
+                    (req.id, MailboxOpDuplicate);
+                return;
+            }
+
+            present[req.id] = true;
+            completed[req.id] = false;
+            enqueued[req.id] = false;
+            token[req.id] = NoLeaseToken();
+            send req.reply_to, eOutboxFoldResp, (req.id, MailboxOpOk);
+        }
+
+        // Claim assigns the row's current owner token, mirroring
+        // ClaimOutboxBatch. Only a pending row is claimable; a completed row is
+        // terminal. A reclaim (after the prior claim expires) simply overwrites
+        // the owner token, which is what fences a stale publisher out.
+        on eOutboxFoldClaim do (req: OutboxFoldClaimReq) {
+            if (!(req.id in present) || !present[req.id]) {
+                send req.reply_to, eOutboxFoldResp,
+                    (req.id, MailboxOpNotFound);
+                return;
+            }
+
+            if (completed[req.id]) {
+                send req.reply_to, eOutboxFoldResp,
+                    (req.id, MailboxOpNotFound);
+                return;
+            }
+
+            token[req.id] = req.token;
+            send req.reply_to, eOutboxFoldResp, (req.id, MailboxOpOk);
+        }
+
+        on eOutboxFoldDeliver do (req: OutboxFoldDeliverReq) {
+            var tokenOk: bool;
+
+            if (!(req.id in present) || !present[req.id]) {
+                send req.reply_to, eOutboxFoldResp,
+                    (req.id, MailboxOpNotFound);
+                return;
+            }
+
+            // Completion is token-fenced: it lands only for the current owner.
+            tokenOk = token[req.id] == req.token &&
+                req.token != NoLeaseToken();
+
+            if (mode == AtomicFold) {
+                // One transaction. If the enqueue step fails the whole tx
+                // rolls back: nothing is applied and the row stays pending for
+                // redelivery after the claim expires.
+                if (!req.enqueue_ok) {
+                    send req.reply_to, eOutboxFoldResp,
+                        (req.id, MailboxOpOk);
+                    return;
+                }
+
+                // The enqueue committed: durable and idempotent by id, so a
+                // redelivery or reclaim re-run announces no second delivery.
+                if (!enqueued[req.id]) {
+                    enqueued[req.id] = true;
+                    announce eOutboxTargetEnqueued, (this, req.id);
+                }
+
+                // The completion is folded into the same commit. A stale token
+                // matches zero rows -- a no-op, not a failure -- so the row
+                // stays pending, exactly like CompleteOutbox's token-gated
+                // UPDATE.
+                if (tokenOk && !completed[req.id]) {
+                    completed[req.id] = true;
+                    announce eOutboxCompleted, (this, req.id);
+                }
+
+                send req.reply_to, eOutboxFoldResp, (req.id, MailboxOpOk);
+                return;
+            }
+
+            // SplitWrite (counterexample): the completion and the enqueue are
+            // independent, unsynchronized writes. The dangerous interleaving
+            // commits the completion even though the enqueue did not durably
+            // land (enqueue_ok = false), leaving the row completed with the
+            // message never delivered -- a lost message.
+            if (tokenOk && !completed[req.id]) {
+                completed[req.id] = true;
+                announce eOutboxCompleted, (this, req.id);
+            }
+
+            if (req.enqueue_ok && !enqueued[req.id]) {
+                enqueued[req.id] = true;
+                announce eOutboxTargetEnqueued, (this, req.id);
+            }
+
+            send req.reply_to, eOutboxFoldResp, (req.id, MailboxOpOk);
+        }
+    }
+}
+
+// OutboxCompletionImpliesDelivery is the no-lost-messages safety contract for
+// the outbox fold: an outbox row may be marked completed only if the target
+// enqueue is already durable. It reconstructs the durable-enqueue set from the
+// announcement stream and, on every completion, asserts the row was delivered.
+// The AtomicFold profile upholds it by construction (a completion is only
+// observable together with the same transaction's durable enqueue); the
+// SplitWrite counterexample trips it directly when a completion lands without a
+// delivery, with no in-machine assertion required.
+spec OutboxCompletionImpliesDelivery observes
+    eOutboxTargetEnqueued, eOutboxCompleted {
+
+    var enqueued: map[(machine, int), bool];
+
+    start state Monitoring {
+        on eOutboxTargetEnqueued do (e: (machine, int)) {
+            enqueued[e] = true;
+        }
+
+        on eOutboxCompleted do (c: (machine, int)) {
+            assert c in enqueued && enqueued[c],
+                "outbox row marked completed without a durable target "+
+                "enqueue (lost message)";
+        }
+    }
+}
+
+// OutboxTargetDeliveredAtMostOnce is the exactly-once half of the contract: the
+// idempotent (ON CONFLICT id) target enqueue means a row is delivered to the
+// target mailbox at most once, no matter how many times it is redelivered or
+// reclaimed by concurrent publishers. A second distinct delivery for the same
+// (mbox, id) trips the assertion.
+spec OutboxTargetDeliveredAtMostOnce observes eOutboxTargetEnqueued {
+    var seen: map[(machine, int), bool];
+
+    start state Monitoring {
+        on eOutboxTargetEnqueued do (e: (machine, int)) {
+            assert !(e in seen),
+                "outbox fold delivered two distinct copies to the target "+
+                "mailbox for one row";
+            seen[e] = true;
+        }
+    }
+}

--- a/p-models/durableactor/test/mailbox_fifo_test.p
+++ b/p-models/durableactor/test/mailbox_fifo_test.p
@@ -1401,6 +1401,210 @@ machine TestDurableMailboxSpec_StaleStageRegressesCheckpointCounterexample {
     state Done {}
 }
 
+// TestOutboxFold_AtomicRollbackThenRedeliver drives the production AtomicFold
+// path of the CDC delivery step. A folded delivery fails after the target
+// enqueue, so the whole transaction rolls back: no delivery is announced and
+// the outbox row stays pending. The publisher reclaims the row under a new
+// token and redelivers successfully -- the enqueue and the completion land
+// together -- after which the completed row is terminal and no longer
+// claimable. The OutboxCompletionImpliesDelivery and
+// OutboxTargetDeliveredAtMostOnce monitors confirm no lost message and exactly
+// one delivery.
+machine TestOutboxFold_AtomicRollbackThenRedeliver {
+    var outbox: OutboxFoldSpec;
+
+    start state Init {
+        entry {
+            var resp: (int, DurableMailboxOpResult);
+
+            outbox = new OutboxFoldSpec(AtomicFold);
+
+            send outbox, eOutboxFoldEnqueue, (reply_to = this, id = 1);
+            receive { case eOutboxFoldResp:
+                (r0: (int, DurableMailboxOpResult)) { resp = r0; }
+            }
+            assert resp.1 == MailboxOpOk, "outbox enqueue succeeds";
+
+            send outbox, eOutboxFoldClaim, (
+                reply_to = this, id = 1, token = 11
+            );
+            receive { case eOutboxFoldResp:
+                (r1: (int, DurableMailboxOpResult)) { resp = r1; }
+            }
+            assert resp.1 == MailboxOpOk, "first claim sets the owner token";
+
+            // The fold fails after the enqueue step: AtomicFold rolls the whole
+            // transaction back, so nothing is delivered and the row is pending.
+            send outbox, eOutboxFoldDeliver, (
+                reply_to = this, id = 1, token = 11, enqueue_ok = false
+            );
+            receive { case eOutboxFoldResp:
+                (r2: (int, DurableMailboxOpResult)) { resp = r2; }
+            }
+            assert resp.1 == MailboxOpOk, "failed fold rolls back cleanly";
+
+            // Reclaim after the prior claim expires (new owner token), then
+            // redeliver successfully: the enqueue and the completion commit
+            // together.
+            send outbox, eOutboxFoldClaim, (
+                reply_to = this, id = 1, token = 22
+            );
+            receive { case eOutboxFoldResp:
+                (r3: (int, DurableMailboxOpResult)) { resp = r3; }
+            }
+            assert resp.1 == MailboxOpOk, "reclaim assigns a new owner token";
+
+            send outbox, eOutboxFoldDeliver, (
+                reply_to = this, id = 1, token = 22, enqueue_ok = true
+            );
+            receive { case eOutboxFoldResp:
+                (r4: (int, DurableMailboxOpResult)) { resp = r4; }
+            }
+            assert resp.1 == MailboxOpOk, "redelivery commits the fold";
+
+            // A completed row is terminal: no further claim returns it.
+            send outbox, eOutboxFoldClaim, (
+                reply_to = this, id = 1, token = 33
+            );
+            receive { case eOutboxFoldResp:
+                (r5: (int, DurableMailboxOpResult)) { resp = r5; }
+            }
+            assert resp.1 == MailboxOpNotFound,
+                "completed outbox row is terminal";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// TestOutboxFold_StaleClaimCannotComplete drives the cross-publisher reclaim
+// race. A slow publisher's claim expires and a second publisher reclaims the
+// row; the stale publisher then folds with its OLD token. Its enqueue commits
+// (idempotent by id) but its completion is fenced out (token mismatch), so the
+// row stays pending. The current owner then folds: the enqueue is an idempotent
+// no-op and the completion lands. The target is delivered exactly once
+// (OutboxTargetDeliveredAtMostOnce) and never completed without a delivery
+// (OutboxCompletionImpliesDelivery).
+machine TestOutboxFold_StaleClaimCannotComplete {
+    var outbox: OutboxFoldSpec;
+
+    start state Init {
+        entry {
+            var resp: (int, DurableMailboxOpResult);
+
+            outbox = new OutboxFoldSpec(AtomicFold);
+
+            send outbox, eOutboxFoldEnqueue, (reply_to = this, id = 1);
+            receive { case eOutboxFoldResp:
+                (r0: (int, DurableMailboxOpResult)) { resp = r0; }
+            }
+            assert resp.1 == MailboxOpOk, "outbox enqueue succeeds";
+
+            // Publisher P1 claims (token 11); then P1 stalls and P2 reclaims
+            // the same row (token 22) after the claim expires.
+            send outbox, eOutboxFoldClaim, (
+                reply_to = this, id = 1, token = 11
+            );
+            receive { case eOutboxFoldResp:
+                (r1: (int, DurableMailboxOpResult)) { resp = r1; }
+            }
+            assert resp.1 == MailboxOpOk, "P1 claims the row";
+
+            send outbox, eOutboxFoldClaim, (
+                reply_to = this, id = 1, token = 22
+            );
+            receive { case eOutboxFoldResp:
+                (r2: (int, DurableMailboxOpResult)) { resp = r2; }
+            }
+            assert resp.1 == MailboxOpOk, "P2 reclaims the row";
+
+            // Stale P1 folds with its now-superseded token: the enqueue
+            // commits, but the completion matches no row and is a no-op.
+            send outbox, eOutboxFoldDeliver, (
+                reply_to = this, id = 1, token = 11, enqueue_ok = true
+            );
+            receive { case eOutboxFoldResp:
+                (r3: (int, DurableMailboxOpResult)) { resp = r3; }
+            }
+            assert resp.1 == MailboxOpOk, "stale P1 fold commits its enqueue";
+
+            // Current owner P2 folds: the enqueue is an idempotent no-op and
+            // the completion lands under the matching token.
+            send outbox, eOutboxFoldDeliver, (
+                reply_to = this, id = 1, token = 22, enqueue_ok = true
+            );
+            receive { case eOutboxFoldResp:
+                (r4: (int, DurableMailboxOpResult)) { resp = r4; }
+            }
+            assert resp.1 == MailboxOpOk, "current P2 fold completes the row";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// TestOutboxFold_SplitWriteLosesMessageCounterexample drives the same delivery
+// with the SplitWrite (non-transactional two-step) design and NO in-machine
+// assertion. The completion write lands even though the enqueue did not durably
+// happen, so the outbox row is completed with the message never delivered. The
+// lost message is raised solely by OutboxCompletionImpliesDelivery, proving the
+// monitor catches the exact failure the single fold transaction prevents.
+machine TestOutboxFold_SplitWriteLosesMessageCounterexample {
+    var outbox: OutboxFoldSpec;
+
+    start state Init {
+        entry {
+            var resp: (int, DurableMailboxOpResult);
+
+            outbox = new OutboxFoldSpec(SplitWrite);
+
+            send outbox, eOutboxFoldEnqueue, (reply_to = this, id = 1);
+            receive { case eOutboxFoldResp:
+                (r0: (int, DurableMailboxOpResult)) { resp = r0; }
+            }
+
+            send outbox, eOutboxFoldClaim, (
+                reply_to = this, id = 1, token = 11
+            );
+            receive { case eOutboxFoldResp:
+                (r1: (int, DurableMailboxOpResult)) { resp = r1; }
+            }
+
+            // The completion lands but the enqueue did not durably happen: a
+            // lost message under the split-write design.
+            send outbox, eOutboxFoldDeliver, (
+                reply_to = this, id = 1, token = 11, enqueue_ok = false
+            );
+            receive { case eOutboxFoldResp:
+                (r2: (int, DurableMailboxOpResult)) { resp = r2; }
+            }
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// OutboxFoldGreenDriver spawns the green outbox-fold scenarios under the
+// no-lost-message and exactly-once monitors.
+machine OutboxFoldGreenDriver {
+    start state RunTests {
+        entry {
+            new TestOutboxFold_AtomicRollbackThenRedeliver();
+            new TestOutboxFold_StaleClaimCannotComplete();
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
 machine MailboxFIFOTestDriver {
     start state RunTests {
         entry {
@@ -1514,3 +1718,26 @@ test tcMailboxStaleStageRegressesCounterexample
   assert CheckpointAdvancesMonotonically in
   { DurableMailboxSpec,
     TestDurableMailboxSpec_StaleStageRegressesCheckpointCounterexample };
+
+// tcOutboxFold checks the transactional outbox fold contract: a folded delivery
+// commits the target enqueue and the outbox completion together or not at all,
+// a failed fold rolls back with no orphan and redelivers after claim expiry,
+// completion is token-fenced against stale publishers, and the target is
+// delivered exactly once. No outbox row is ever completed without a durable
+// delivery.
+test tcOutboxFold [main=OutboxFoldGreenDriver]:
+  assert OutboxCompletionImpliesDelivery,
+         OutboxTargetDeliveredAtMostOnce in
+  { OutboxFoldSpec,
+    TestOutboxFold_AtomicRollbackThenRedeliver,
+    TestOutboxFold_StaleClaimCannotComplete,
+    OutboxFoldGreenDriver };
+
+// tcOutboxSplitWriteCounterexample runs the delivery with the non-transactional
+// split-write design and no in-machine assertion, so the lost message is raised
+// solely by OutboxCompletionImpliesDelivery. It is expected to find a bug.
+test tcOutboxSplitWriteCounterexample
+    [main=TestOutboxFold_SplitWriteLosesMessageCounterexample]:
+  assert OutboxCompletionImpliesDelivery in
+  { OutboxFoldSpec,
+    TestOutboxFold_SplitWriteLosesMessageCounterexample };

--- a/p-models/durableactor/test/mailbox_fifo_test.p
+++ b/p-models/durableactor/test/mailbox_fifo_test.p
@@ -681,6 +681,103 @@ machine TestDurableMailboxSpec_DeadLetterByIdRemovesExhaustedRow {
     state Done {}
 }
 
+// TestDurableMailboxSpec_LeaselessPeekMasksStaleLease exercises the
+// SingleWorkerLeaseless mailbox edge: a row that was previously leased can
+// become peek-eligible after the lease deadline passes, even if no maintenance
+// worker has cleared the stale lease metadata. Peek must surface an empty token
+// and leave attempts untouched; the by-ID nack then increments attempts and
+// clears the stale metadata.
+machine TestDurableMailboxSpec_LeaselessPeekMasksStaleLease {
+    var mailbox: DurableMailboxSpec;
+
+    start state Init {
+        entry {
+            var op_resp: (int, DurableMailboxOpResult);
+            var lease_resp: (int, DurableMailboxOpResult);
+            var peek_resp: (int, int, int, DurableMailboxOpResult);
+
+            mailbox = new DurableMailboxSpec(PerCorrelationKeyFIFO);
+
+            send mailbox, eDurableMailboxEnqueue, (
+                reply_to = this,
+                row = NewMailboxRow(
+                    1, 10, 100, 0, 0, NoLease(), NoLeaseToken(),
+                    0, 3, 0
+                )
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp0: (int, DurableMailboxOpResult)) { op_resp = resp0; }
+            }
+            assert op_resp.1 == MailboxOpOk, "enqueue succeeds";
+
+            send mailbox, eDurableMailboxLeaseNext, (
+                reply_to = this, mailbox_id = 10, lease_token = 11,
+                now = 0, lease_duration = 5
+            );
+            receive { case eDurableMailboxLeaseResp:
+                (resp1: (int, DurableMailboxOpResult)) {
+                    lease_resp = resp1;
+                }
+            }
+            assert lease_resp.0 == 1 && lease_resp.1 == MailboxOpOk,
+                "leased path sets stale metadata and increments attempts";
+
+            // No eDurableMailboxExpireLeasesAt here: production PeekNextMessage
+            // treats lease_until < now as eligible even when the persisted row
+            // still carries the old token/deadline.
+            send mailbox, eDurableMailboxPeekNext, (
+                reply_to = this, mailbox_id = 10, now = 6
+            );
+            receive { case eDurableMailboxPeekResp:
+                (resp2: (int, int, int, DurableMailboxOpResult)) {
+                    peek_resp = resp2;
+                }
+            }
+            assert peek_resp.0 == 1 && peek_resp.3 == MailboxOpOk,
+                "peek selects the expired-lease row";
+            assert peek_resp.1 == NoLeaseToken(),
+                "peek surfaces an empty actor-layer token";
+            assert peek_resp.2 == 1,
+                "peek is read-only and does not increment attempts";
+
+            send mailbox, eDurableMailboxNackByID, (
+                reply_to = this, id = 1, available_at = 7
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp3: (int, DurableMailboxOpResult)) { op_resp = resp3; }
+            }
+            assert op_resp.1 == MailboxOpOk,
+                "by-ID nack succeeds without validating the stale token";
+
+            send mailbox, eDurableMailboxPeekNext, (
+                reply_to = this, mailbox_id = 10, now = 7
+            );
+            receive { case eDurableMailboxPeekResp:
+                (resp4: (int, int, int, DurableMailboxOpResult)) {
+                    peek_resp = resp4;
+                }
+            }
+            assert peek_resp.0 == 1 && peek_resp.1 == NoLeaseToken(),
+                "row remains on the empty-token leaseless path";
+            assert peek_resp.2 == 2,
+                "by-ID nack increments attempts for retry accounting";
+
+            send mailbox, eDurableMailboxAckByID, (
+                reply_to = this, id = 1
+            );
+            receive { case eDurableMailboxOpResp:
+                (resp5: (int, DurableMailboxOpResult)) { op_resp = resp5; }
+            }
+            assert op_resp.1 == MailboxOpOk,
+                "by-ID ack consumes the peeked row";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
 // TestMailboxFIFO_LegacyReorderNoInlineAssert replays the production reorder
 // against the legacy claim mode but, unlike
 // TestMailboxFIFO_LegacyCounterexampleToIdealFIFO, contains NO in-machine
@@ -1319,6 +1416,7 @@ machine MailboxFIFOTestDriver {
             new TestDurableMailboxSpec_DuplicateEnqueuePreservesFirstRow();
             new TestDurableMailboxSpec_PriorityDoesNotPierceSameKeyFIFO();
             new TestDurableMailboxSpec_DeadLetterByIdRemovesExhaustedRow();
+            new TestDurableMailboxSpec_LeaselessPeekMasksStaleLease();
 
             goto Done;
         }
@@ -1345,6 +1443,7 @@ test tcMailboxCorrelationKeyFIFO [main=MailboxFIFOTestDriver]:
     TestDurableMailboxSpec_DuplicateEnqueuePreservesFirstRow,
     TestDurableMailboxSpec_PriorityDoesNotPierceSameKeyFIFO,
     TestDurableMailboxSpec_DeadLetterByIdRemovesExhaustedRow,
+    TestDurableMailboxSpec_LeaselessPeekMasksStaleLease,
     MailboxFIFOTestDriver };
 
 // tcMailboxLiveness checks the non-starvation liveness property: every enqueued

--- a/p-models/durableactor/traces/mailbox_leaseless_commit_fold.json
+++ b/p-models/durableactor/traces/mailbox_leaseless_commit_fold.json
@@ -1,0 +1,37 @@
+{
+  "trace_id": "mailbox_leaseless_commit_fold",
+  "description": "Leaseless single-worker Read/Commit consume. The row is peeked as an empty-token delivery and committed via the by-ID fold (AckMessageByID + MarkProcessed in one tx), consuming it exactly once and marking it processed. A second by-ID commit of the same id is a fenced 0-row no-op (ErrLeaseLost, dedup mark untouched), so the leaseless path consumes exactly once just like the leased fence.",
+  "events": [
+    {
+      "op": "enqueue",
+      "id": "1",
+      "mailbox_id": "mb-1",
+      "available_at": 0,
+      "max_attempts": 3
+    },
+    {
+      "op": "peek",
+      "mailbox_id": "mb-1",
+      "expect_id": "1"
+    },
+    {
+      "op": "commit",
+      "id": "1",
+      "lease_token": "",
+      "expect_rows": 1,
+      "expect_processed": true
+    },
+    {
+      "op": "peek",
+      "mailbox_id": "mb-1",
+      "expect_id": ""
+    },
+    {
+      "op": "commit",
+      "id": "1",
+      "lease_token": "",
+      "expect_rows": 0,
+      "expect_processed": true
+    }
+  ]
+}

--- a/p-models/durableactor/traces/mailbox_leaseless_peek_stale_lease.json
+++ b/p-models/durableactor/traces/mailbox_leaseless_peek_stale_lease.json
@@ -1,0 +1,54 @@
+{
+  "trace_id": "mailbox_leaseless_peek_stale_lease",
+  "description": "A row with stale expired lease metadata is peeked as an empty-token leaseless delivery; by-ID nack clears metadata and increments attempts.",
+  "events": [
+    {
+      "op": "enqueue",
+      "id": "msg-1",
+      "mailbox_id": "actor-A",
+      "correlation_key": "session-1",
+      "payload": "payload-1",
+      "max_attempts": 3
+    },
+    {
+      "op": "lease",
+      "mailbox_id": "actor-A",
+      "lease_token": "stale-lease",
+      "lease_duration": 5,
+      "expect_id": "msg-1",
+      "expect_payload": "payload-1",
+      "expect_attempts": 1,
+      "expect_token": "stale-lease"
+    },
+    {
+      "op": "peek",
+      "mailbox_id": "actor-A",
+      "now": 6,
+      "expect_id": "msg-1",
+      "expect_payload": "payload-1",
+      "expect_attempts": 1
+    },
+    {
+      "op": "nack_by_id",
+      "id": "msg-1",
+      "retry_after": 1
+    },
+    {
+      "op": "peek",
+      "mailbox_id": "actor-A",
+      "now": 7,
+      "expect_id": "msg-1",
+      "expect_payload": "payload-1",
+      "expect_attempts": 2
+    },
+    {
+      "op": "ack_by_id",
+      "id": "msg-1"
+    },
+    {
+      "op": "peek",
+      "mailbox_id": "actor-A",
+      "expect_id": ""
+    }
+  ]
+}

--- a/p-models/scripts/check.sh
+++ b/p-models/scripts/check.sh
@@ -112,6 +112,16 @@ check_negative tcMailboxStagedDoubleBroadcastCounterexample 1
 # lease-fenced overwrites a newer owner's checkpoint with an older level.
 check_negative tcMailboxStaleStageRegressesCounterexample 1
 
+# The CDC outbox fold must commit the target enqueue and the outbox completion
+# atomically: a failed fold rolls back with no orphan and redelivers after claim
+# expiry, completion is token-fenced, and the target is delivered exactly once.
+check_green tcOutboxFold
+
+# The split-write counterexample must be caught by the
+# OutboxCompletionImpliesDelivery monitor: a non-transactional two-step that
+# completes the outbox without a durable enqueue loses the message.
+check_negative tcOutboxSplitWriteCounterexample 1
+
 echo ""
 echo "=== Go Bridge Conformance ==="
 go test ./p-models/durableactor/bridge

--- a/serverconn/testutil_test.go
+++ b/serverconn/testutil_test.go
@@ -446,6 +446,57 @@ func (s *memCheckpointStore) LeaseNextMessage(ctx context.Context,
 	return &leasedCopy, nil
 }
 
+// PeekNextMessage claims the next available message without taking a lease,
+// mirroring LeaseNextMessage's eligibility/ordering but without mutating the
+// lease token, lease expiry, or attempts. The returned message carries an
+// empty lease token.
+func (s *memCheckpointStore) PeekNextMessage(ctx context.Context,
+	mailboxID string) (*actor.LeasedMessage, error) {
+
+	_ = ctx
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+
+	var selected *storeMessage
+	for _, msg := range s.messages {
+		if msg.leased.MailboxID != mailboxID {
+			continue
+		}
+
+		if msg.availableAt.After(now) {
+			continue
+		}
+
+		if msg.leased.LeaseToken != "" &&
+			msg.leased.LeaseUntil.After(now) {
+
+			continue
+		}
+
+		if selected == nil ||
+			msg.availableAt.Before(selected.availableAt) {
+
+			selected = msg
+		}
+	}
+
+	if selected == nil {
+		return nil, nil
+	}
+
+	leasedCopy := selected.leased
+	leasedCopy.LeaseToken = ""
+	leasedCopy.LeaseUntil = time.Time{}
+	leasedCopy.Payload = append(
+		[]byte(nil), selected.leased.Payload...,
+	)
+
+	return &leasedCopy, nil
+}
+
 // AckMessage acknowledges a leased message by ID and lease token.
 func (s *memCheckpointStore) AckMessage(ctx context.Context, id,
 	leaseToken string) (int64, error) {
@@ -461,6 +512,25 @@ func (s *memCheckpointStore) AckMessage(ctx context.Context, id,
 	}
 
 	if msg.leased.LeaseToken != leaseToken {
+		return 0, nil
+	}
+
+	delete(s.messages, id)
+
+	return 1, nil
+}
+
+// AckMessageByID acknowledges a message by ID without lease-token validation,
+// mirroring the unfenced leaseless ack.
+func (s *memCheckpointStore) AckMessageByID(ctx context.Context, id string) (
+	int64, error) {
+
+	_ = ctx
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.messages[id]; !ok {
 		return 0, nil
 	}
 
@@ -489,6 +559,29 @@ func (s *memCheckpointStore) NackMessage(ctx context.Context, id,
 
 	msg.leased.LeaseToken = ""
 	msg.leased.LeaseUntil = time.Time{}
+	msg.availableAt = time.Now().Add(retryAfter)
+
+	return 1, nil
+}
+
+// NackMessageByID releases a message by ID without lease-token validation and
+// increments attempts, mirroring the unfenced leaseless nack.
+func (s *memCheckpointStore) NackMessageByID(ctx context.Context, id string,
+	retryAfter time.Duration) (int64, error) {
+
+	_ = ctx
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	msg, ok := s.messages[id]
+	if !ok {
+		return 0, nil
+	}
+
+	msg.leased.LeaseToken = ""
+	msg.leased.LeaseUntil = time.Time{}
+	msg.leased.Attempts++
 	msg.availableAt = time.Now().Add(retryAfter)
 
 	return 1, nil

--- a/systest/oor_vtxo_manager_test.go
+++ b/systest/oor_vtxo_manager_test.go
@@ -338,6 +338,13 @@ func driveIncomingOutbox(ctx context.Context, session *oor.ReceiveSession,
 		case *oor.IncomingTransferNotification:
 			continue
 
+		case *oor.ScheduleRetryRequest:
+			// The incoming metadata path arms a give-up/backoff
+			// retry timer alongside its query (see fab1754c). This
+			// synchronous driver resolves metadata immediately, so
+			// the timer never needs to fire; ignore it.
+			continue
+
 		case *oor.MaterializeIncomingVTXOsRequest:
 			followUps, err := handler.Handle(
 				ctx, sessionID, typedMsg,

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -789,6 +789,13 @@ func (s *memCheckpointStore) LeaseNextMessage(context.Context, string, string,
 	return nil, nil
 }
 
+// PeekNextMessage is unused in these tests.
+func (s *memCheckpointStore) PeekNextMessage(context.Context, string) (
+	*actor.LeasedMessage, error) {
+
+	return nil, nil
+}
+
 // AckMessage is unused in these tests.
 func (s *memCheckpointStore) AckMessage(context.Context, string, string) (int64,
 	error) {
@@ -796,8 +803,22 @@ func (s *memCheckpointStore) AckMessage(context.Context, string, string) (int64,
 	return 1, nil
 }
 
+// AckMessageByID is unused in these tests.
+func (s *memCheckpointStore) AckMessageByID(context.Context, string) (int64,
+	error) {
+
+	return 1, nil
+}
+
 // NackMessage is unused in these tests.
 func (s *memCheckpointStore) NackMessage(context.Context, string, string,
+	time.Duration) (int64, error) {
+
+	return 1, nil
+}
+
+// NackMessageByID is unused in these tests.
+func (s *memCheckpointStore) NackMessageByID(context.Context, string,
 	time.Duration) (int64, error) {
 
 	return 1, nil


### PR DESCRIPTION
In this PR, we extend the durable actor runtime with two framework-layer
optimizations that came straight out of profiling the OOR payment path: a
leaseless consume path for single-worker actors, and a transactional fold for
outbox delivery.

The leaseless path attacks transaction #1 on every consume. The classic path
opens a write transaction just to lease the next mailbox message
(`LeaseNextMessage` is an UPDATE under BEGIN IMMEDIATE), then a second one to
commit the turn's effects. For an actor with `numWorkers == 1` there is no
competing consumer, so the lease buys nothing: we add a read-only
`PeekNextMailboxMessage` plus by-id ack/nack variants and gate them strictly on
the single-worker case via a mailbox flag. Routing is keyed on the empty lease
token, so the multi-worker path is byte-for-byte unchanged. At its point in the
optimization chain this was worth ~1.6x: the peek is a pure read, so idle polls
go from one write transaction to zero and stop grabbing the single sqlite writer
under BEGIN IMMEDIATE, which is exactly what was serializing all the concurrent
session pollers. The head-to-head lives in lightninglabs/darepo#538's Experiment
6.

Because the peek takes no lease, it also doesn't pre-bump attempts; that bump
moves to nack-by-id, so a message that fails by returning an error still climbs
toward dead-lettering just like the leased path. The one case it doesn't cover
is a message that crashes the worker *process* on every attempt: it skips the
nack each time and so re-peeks forever instead of dead-lettering. That's
deliberate, not a gap to "fix" by bumping attempts at claim, which would put
every poll (including the empty ones that dominate under contention) back under
BEGIN IMMEDIATE and hand the 1.6x right back. The single-worker actors on this
path carry their own higher-level retry/backoff and treat the dead-letter table
as a manual sink, so retrying a process-poisoning message beats silently
dropping it. A wedged-DB nack now also backs off on the poll ticker instead of
tight-spinning re-peeks of the same row.

The outbox fold introduces `TxAwareDeliveryStore` and folds outbox delivery
(enqueue into the destination mailbox + mark-complete) into one write
transaction. Before the fold those were two commits ordered for safety, which
left a crash window where an enqueued message could be redelivered because its
completion never landed; the fold closes that window structurally. Folding the
enqueue inside the publisher's tx means the row isn't visible to the target
until commit, so the in-process wake from `Send` races ahead of visibility and
finds nothing. We restore the snappy same-process handoff with a post-commit
wake: once a folded enqueue commits, we rouse the local mailbox receive loops to
re-poll. It's a coarse broadcast (every local mailbox re-polls, a non-target
does one empty poll) with the poll ticker as the correctness fallback, so a
missed wake only ever costs a poll interval, never a message. The same `TxAware`
mechanism is what the serverconn ingress fold builds on.

Rounding things out: drip-box and concurrent-mailbox throughput benchmarks for
the delivery store, and a systest driver fix so the incoming outbox driver
handles `ScheduleRetryRequest`.

This is part of the OOR optimization train; see each commit message for a
detailed description w.r.t the incremental changes.
