### PR TITLE
swaprpc: ack accepted out-swap HTLC events

### DIFF
--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -188,6 +188,20 @@ func (c *SwapServiceClient) AuthorizeInSwapRefund(ctx context.Context,
 	return out, err
 }
 
+// AcknowledgeOutSwapHtlc tells the swap server an out-swap receiver durably
+// accepted the HTLC event.
+func (c *SwapServiceClient) AcknowledgeOutSwapHtlc(ctx context.Context,
+	in *swaprpc.AcknowledgeOutSwapHtlcRequest, _ ...grpc.CallOption) (
+	*swaprpc.AcknowledgeOutSwapHtlcResponse, error) {
+
+	out := new(swaprpc.AcknowledgeOutSwapHtlcResponse)
+	err := c.client.Post(
+		ctx, "/v1/swap/acknowledge-out-swap-htlc", in, out,
+	)
+
+	return out, err
+}
+
 // NewDaemonServiceClient creates a DaemonService REST client.
 func NewDaemonServiceClient(addr string,
 	opts ...Option) daemonrpc.DaemonServiceClient {

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -371,6 +371,11 @@ type SwapServerConn interface {
 		paymentHash lntypes.Hash, amountSat btcutil.Amount,
 		expirySeconds uint32) (*OutSwapQuote, error)
 
+	// AcknowledgeOutSwapHTLC tells the server this receiver validated and
+	// durably accepted the out-swap HTLC event.
+	AcknowledgeOutSwapHTLC(ctx context.Context, paymentHash lntypes.Hash,
+		vhtlcPubkey *btcec.PublicKey) error
+
 	// CreateInSwap initiates an Ark->LN swap on the server.
 	CreateInSwap(ctx context.Context, invoice string, maxFeeSat uint64,
 		clientVhtlcPubkey *btcec.PublicKey) (*InSwapConfig, error)

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -79,6 +79,30 @@ func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 	}, nil
 }
 
+// AcknowledgeOutSwapHTLC tells the swap server this receiver validated and
+// durably accepted the out-swap HTLC event.
+func (g *GRPCSwapServerConn) AcknowledgeOutSwapHTLC(ctx context.Context,
+	paymentHash lntypes.Hash, vhtlcPubkey *btcec.PublicKey) error {
+
+	if vhtlcPubkey == nil {
+		return fmt.Errorf("vHTLC pubkey must be provided")
+	}
+
+	_, err := g.client.AcknowledgeOutSwapHtlc(
+		ctx, &swaprpc.AcknowledgeOutSwapHtlcRequest{
+			PaymentHash: append(
+				[]byte(nil), paymentHash[:]...,
+			),
+			ClientVhtlcPubkey: vhtlcPubkey.SerializeCompressed(),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("AcknowledgeOutSwapHtlc RPC: %w", err)
+	}
+
+	return nil
+}
+
 // CreateInSwap initiates one Ark-to-Lightning swap on the swap server.
 func (g *GRPCSwapServerConn) CreateInSwap(ctx context.Context, invoice string,
 	maxFeeSat uint64, clientVhtlcPubkey *btcec.PublicKey) (*InSwapConfig,

--- a/sdk/swaps/grpc_conn_test.go
+++ b/sdk/swaps/grpc_conn_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/darepo-client/swaprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
@@ -16,13 +17,24 @@ type testSwapServiceClient struct {
 	swaprpc.SwapServiceClient
 
 	authorizeErr error
+	ackErr       error
+	lastAckReq   *swaprpc.AcknowledgeOutSwapHtlcRequest
 }
 
-func (c testSwapServiceClient) AuthorizeInSwapRefund(context.Context,
+func (c *testSwapServiceClient) AuthorizeInSwapRefund(context.Context,
 	*swaprpc.AuthorizeInSwapRefundRequest, ...grpc.CallOption) (
 	*swaprpc.AuthorizeInSwapRefundResponse, error) {
 
 	return nil, c.authorizeErr
+}
+
+func (c *testSwapServiceClient) AcknowledgeOutSwapHtlc(_ context.Context,
+	req *swaprpc.AcknowledgeOutSwapHtlcRequest, _ ...grpc.CallOption) (
+	*swaprpc.AcknowledgeOutSwapHtlcResponse, error) {
+
+	c.lastAckReq = req
+
+	return nil, c.ackErr
 }
 
 // TestAuthorizeInSwapRefundPreservesStatusCode verifies the pay session can
@@ -31,7 +43,7 @@ func TestAuthorizeInSwapRefundPreservesStatusCode(t *testing.T) {
 	t.Parallel()
 
 	conn := &GRPCSwapServerConn{
-		client: testSwapServiceClient{
+		client: &testSwapServiceClient{
 			authorizeErr: status.Error(
 				codes.FailedPrecondition, "refund unavailable",
 			),
@@ -44,4 +56,50 @@ func TestAuthorizeInSwapRefundPreservesStatusCode(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+// TestAcknowledgeOutSwapHTLCPreservesStatusCode verifies the receive session
+// can distinguish retryable or terminal server ACK failures by their original
+// gRPC status code.
+func TestAcknowledgeOutSwapHTLCPreservesStatusCode(t *testing.T) {
+	t.Parallel()
+
+	client := &testSwapServiceClient{
+		ackErr: status.Error(codes.FailedPrecondition, "not ready"),
+	}
+	conn := &GRPCSwapServerConn{
+		client: client,
+	}
+
+	pubkey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	hash := lntypes.Hash{1, 2, 3}
+	err = conn.AcknowledgeOutSwapHTLC(
+		context.Background(), hash, pubkey.PubKey(),
+	)
+	require.Error(t, err)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.Equal(t, hash[:], client.lastAckReq.GetPaymentHash())
+	require.Equal(
+		t, pubkey.PubKey().SerializeCompressed(),
+		client.lastAckReq.GetClientVhtlcPubkey(),
+	)
+}
+
+// TestAcknowledgeOutSwapHTLCRejectsMissingPubkey verifies malformed local
+// state is rejected before an invalid request can reach the swap server.
+func TestAcknowledgeOutSwapHTLCRejectsMissingPubkey(t *testing.T) {
+	t.Parallel()
+
+	client := &testSwapServiceClient{}
+	conn := &GRPCSwapServerConn{
+		client: client,
+	}
+
+	err := conn.AcknowledgeOutSwapHTLC(
+		context.Background(), lntypes.Hash{}, nil,
+	)
+	require.ErrorContains(t, err, "vHTLC pubkey must be provided")
+	require.Nil(t, client.lastAckReq)
 }

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -98,6 +98,13 @@ func (c *testInSwapServerConn) RequestChannelID(_ context.Context,
 	return nil, nil
 }
 
+// AcknowledgeOutSwapHTLC is unused in these tests.
+func (c *testInSwapServerConn) AcknowledgeOutSwapHTLC(context.Context,
+	lntypes.Hash, *btcec.PublicKey) error {
+
+	return nil
+}
+
 // CreateInSwap returns the preconfigured in-swap config.
 func (c *testInSwapServerConn) CreateInSwap(context.Context, string, uint64,
 	*btcec.PublicKey) (*InSwapConfig, error) {

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -18,6 +18,8 @@ import (
 	"github.com/lightningnetwork/lnd/htlcswitch/hop"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/lnwire"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -1013,11 +1015,60 @@ func (s *ReceiveSession) ackAcceptedHTLCEvent(ctx context.Context,
 		)
 	}
 
+	if err := s.acknowledgeOutSwapHTLC(ctx); err != nil {
+		return err
+	}
+
 	if err := s.clearPendingHTLCAck(ctx); err != nil {
 		return newRetryableActionError(err)
 	}
 
 	return nil
+}
+
+// acknowledgeOutSwapHTLC records the receiver's durable event acceptance with
+// the swap server before clearing the local pending ACK marker.
+func (s *ReceiveSession) acknowledgeOutSwapHTLC(ctx context.Context) error {
+	if s.settlementType != "" &&
+		s.settlementType != SettlementTypeLightning {
+		return nil
+	}
+	if s.client == nil || s.client.server == nil {
+		return fmt.Errorf("swap server connection is not configured")
+	}
+	if s.clientPubKey == nil {
+		return fmt.Errorf("client vHTLC pubkey is not configured")
+	}
+
+	if err := s.client.server.AcknowledgeOutSwapHTLC(
+		ctx, s.PaymentHash, s.clientPubKey,
+	); err != nil {
+
+		err = fmt.Errorf("acknowledge out-swap HTLC: %w", err)
+		if isTerminalOutSwapHTLCAckError(err) {
+			return newFailureError(
+				"swap server rejected out-swap HTLC ack", err,
+			)
+		}
+
+		return newRetryableActionError(err)
+	}
+
+	return nil
+}
+
+// isTerminalOutSwapHTLCAckError reports authoritative server ACK rejections
+// that cannot be fixed by retrying the durable pending cursor. The server uses
+// FailedPrecondition for the transient "not published yet" state, so that code
+// deliberately remains retryable.
+func isTerminalOutSwapHTLCAckError(err error) bool {
+	switch status.Code(err) {
+	case codes.InvalidArgument, codes.NotFound, codes.PermissionDenied:
+		return true
+
+	default:
+		return false
+	}
 }
 
 // clearPendingHTLCAck records that the accepted HTLC event's mailbox cursor

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -244,21 +244,106 @@ func TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy(t *testing.T) {
 	require.True(t, session.swapServerPubKey.IsEqual(senderPriv.PubKey()))
 }
 
-type testSwapServerConn struct {
-	hint          *RouteHint
-	payerFeeMsat  uint64
-	cfg           *VHTLCConfig
-	htlcAmountSat uint64
-	waitErr       error
-	ackErr        error
-	ackErrs       []error
-	ackCursor     uint64
-	waitCalls     int
-	ackCalls      int
-	lastAckCursor uint64
+// TestReceiveSessionSkipsServerAckForSameArkHTLCEvent verifies the server ACK
+// is only sent for Lightning-backed out-swaps. Same-Ark receives use the same
+// durable mailbox cursor machinery, but the swap server does not fund those
+// vHTLCs and must not receive an out-swap funding ACK.
+func TestReceiveSessionSkipsServerAckForSameArkHTLCEvent(t *testing.T) {
+	t.Parallel()
 
-	lastVhtlcPubkey *btcec.PublicKey
-	lastAmountSat   btcutil.Amount
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	senderPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := &testInvoiceCreator{
+		invoice: &invoices.Invoice{
+			PaymentRequest: []byte("lnrtest1swap"),
+		},
+	}
+	serverPubKey := senderPriv.PubKey().SerializeCompressed()
+	serverConn := &testSwapServerConn{
+		hint: &RouteHint{
+			NodeID:          serverPubKey,
+			ChannelID:       99,
+			FeeBaseMsat:     1,
+			FeePropPpm:      2,
+			CltvExpiryDelta: 40,
+		},
+		cfg: &VHTLCConfig{
+			RefundLocktime:                       144,
+			UnilateralClaimDelay:                 12,
+			UnilateralRefundDelay:                24,
+			UnilateralRefundWithoutReceiverDelay: 36,
+			SwapServerPubkey:                     serverPubKey,
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+		blockHeight: 100,
+	}
+
+	client := NewSwapClient(serverConn, daemonConn, nil, creator)
+	useTestOnionDecoder(client, 42_000)
+
+	session, err := client.StartReceiveViaLightning(
+		t.Context(), btcutil.Amount(42_000),
+	)
+	require.NoError(t, err)
+
+	ackCalls := 0
+	client.outEvents = &testIncomingEventReceiver{
+		notification: &IncomingVHTLCNotification{
+			InArk: &InArkHtlcEvent{
+				PaymentHash:  session.PaymentHash,
+				AmountSat:    42_000,
+				SenderPubkey: senderPriv.PubKey(),
+				VHTLCConfig:  *serverConn.cfg,
+			},
+			AckCursor: 23,
+			Ack: func(context.Context) error {
+				ackCalls++
+
+				return nil
+			},
+		},
+	}
+
+	err = session.waitForHTLCEvent(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, session.State())
+	require.Equal(t, SettlementTypeInArk, session.settlementType)
+	require.Equal(t, 1, ackCalls)
+	require.Zero(t, serverConn.serverAckCalls)
+	require.Zero(t, session.pendingHTLCAckCursor)
+}
+
+type testSwapServerConn struct {
+	hint           *RouteHint
+	payerFeeMsat   uint64
+	cfg            *VHTLCConfig
+	htlcAmountSat  uint64
+	waitErr        error
+	ackErr         error
+	ackErrs        []error
+	serverAckErr   error
+	serverAckErrs  []error
+	ackCursor      uint64
+	waitCalls      int
+	ackCalls       int
+	serverAckCalls int
+	lastAckCursor  uint64
+
+	lastVhtlcPubkey     *btcec.PublicKey
+	lastAmountSat       btcutil.Amount
+	lastServerAckHash   lntypes.Hash
+	lastServerAckPubkey *btcec.PublicKey
 }
 
 type testIncomingEventReceiver struct {
@@ -365,6 +450,23 @@ func (c *testSwapServerConn) AckOutSwapHtlc(_ context.Context, _ lntypes.Hash,
 	}
 
 	return c.ackErr
+}
+
+// AcknowledgeOutSwapHTLC records the server-side durable acceptance ACK.
+func (c *testSwapServerConn) AcknowledgeOutSwapHTLC(_ context.Context,
+	paymentHash lntypes.Hash, vhtlcPubkey *btcec.PublicKey) error {
+
+	c.serverAckCalls++
+	c.lastServerAckHash = paymentHash
+	c.lastServerAckPubkey = vhtlcPubkey
+	if len(c.serverAckErrs) > 0 {
+		err := c.serverAckErrs[0]
+		c.serverAckErrs = c.serverAckErrs[1:]
+
+		return err
+	}
+
+	return c.serverAckErr
 }
 
 // CreateInSwap is unused in these tests.
@@ -1546,6 +1648,11 @@ func TestReceiveSessionResumesAfterAckedHTLCEvent(t *testing.T) {
 	require.Equal(t, 1, serverConn.waitCalls)
 	require.Equal(t, 1, serverConn.ackCalls)
 	require.Equal(t, uint64(8), serverConn.lastAckCursor)
+	require.Equal(t, 1, serverConn.serverAckCalls)
+	require.Equal(t, session.PaymentHash, serverConn.lastServerAckHash)
+	require.True(
+		t, session.clientPubKey.IsEqual(serverConn.lastServerAckPubkey),
+	)
 	require.Zero(t, session.pendingHTLCAckCursor)
 
 	resumeServer := &testSwapServerConn{
@@ -1572,6 +1679,8 @@ func TestReceiveSessionResumesAfterAckedHTLCEvent(t *testing.T) {
 	require.Equal(t, "resume-txid:1", outpoint)
 	require.EqualValues(t, 42_000, amount)
 	require.Zero(t, resumeServer.waitCalls)
+	require.Zero(t, resumeServer.ackCalls)
+	require.Zero(t, resumeServer.serverAckCalls)
 }
 
 // TestReceiveSessionWaitForFundingSurvivesIndexerRowLag is the end-to-end #538
@@ -1725,6 +1834,7 @@ func TestReceiveSessionRetriesAcceptedHTLCAckOnResume(t *testing.T) {
 	require.Equal(t, 1, serverConn.waitCalls)
 	require.Equal(t, 1, serverConn.ackCalls)
 	require.Equal(t, uint64(12), serverConn.lastAckCursor)
+	require.Zero(t, serverConn.serverAckCalls)
 
 	resumeServer := &testSwapServerConn{
 		waitErr: errors.New("unexpected mailbox wait"),
@@ -1753,6 +1863,12 @@ func TestReceiveSessionRetriesAcceptedHTLCAckOnResume(t *testing.T) {
 	require.Zero(t, resumeServer.waitCalls)
 	require.Equal(t, 1, resumeServer.ackCalls)
 	require.Equal(t, uint64(12), resumeServer.lastAckCursor)
+	require.Equal(t, 1, resumeServer.serverAckCalls)
+	require.Equal(t, session.PaymentHash, resumeServer.lastServerAckHash)
+	require.True(
+		t,
+		resumed.clientPubKey.IsEqual(resumeServer.lastServerAckPubkey),
+	)
 	require.Zero(t, resumed.pendingHTLCAckCursor)
 
 	reloaded, err := resumedClient.ResumeReceiveViaLightning(
@@ -1760,6 +1876,207 @@ func TestReceiveSessionRetriesAcceptedHTLCAckOnResume(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Zero(t, reloaded.pendingHTLCAckCursor)
+}
+
+// TestReceiveSessionRetriesAcceptedHTLCServerAckOnResume asserts server-side
+// ACK errors after mailbox cursor ACK are retried from the durable accepted
+// event state. This is the client's crash-safe boundary for telling the swap
+// server it can now fund the vHTLC.
+func TestReceiveSessionRetriesAcceptedHTLCServerAckOnResume(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := &testInvoiceCreator{
+		invoice: &invoices.Invoice{
+			PaymentRequest: []byte("lnrtest1swap"),
+		},
+	}
+	serverPubKey := serverPriv.PubKey().SerializeCompressed()
+	cfg := &VHTLCConfig{
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+		SwapServerPubkey:                     serverPubKey,
+	}
+	serverAckErr := errors.New("temporary server ack failure")
+	serverConn := &testSwapServerConn{
+		hint: &RouteHint{
+			NodeID:          serverPubKey,
+			ChannelID:       99,
+			FeeBaseMsat:     1,
+			FeePropPpm:      2,
+			CltvExpiryDelta: 40,
+		},
+		cfg: cfg,
+		serverAckErrs: []error{
+			serverAckErr,
+		},
+		ackCursor: 12,
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+		blockHeight: 100,
+	}
+
+	client := NewSwapClientWithStore(
+		serverConn, daemonConn, nil, creator, store,
+	)
+	useTestOnionDecoder(client, 42_000)
+	client.waitPollInterval = time.Millisecond
+
+	session, err := client.StartReceiveViaLightning(
+		t.Context(), btcutil.Amount(42_000),
+	)
+	require.NoError(t, err)
+
+	err = session.waitForHTLCEvent(t.Context())
+	require.ErrorIs(t, err, serverAckErr)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, session.State())
+	require.EqualValues(t, 12, session.pendingHTLCAckCursor)
+	require.Equal(t, 1, serverConn.waitCalls)
+	require.Equal(t, 1, serverConn.ackCalls)
+	require.Equal(t, 1, serverConn.serverAckCalls)
+	require.Equal(t, session.PaymentHash, serverConn.lastServerAckHash)
+	require.True(
+		t, session.clientPubKey.IsEqual(serverConn.lastServerAckPubkey),
+	)
+
+	resumeServer := &testSwapServerConn{
+		waitErr: errors.New("unexpected mailbox wait"),
+	}
+	resumedClient := NewSwapClientWithStore(
+		resumeServer, daemonConn, nil, creator, store,
+	)
+	resumedClient.waitPollInterval = time.Millisecond
+
+	resumed, err := resumedClient.ResumeReceiveViaLightning(
+		t.Context(), session.PaymentHash,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, resumed.State())
+	require.EqualValues(t, 12, resumed.pendingHTLCAckCursor)
+
+	daemonConn.vhtlc = &VTXOInfo{
+		Outpoint:  "resume-txid:1",
+		AmountSat: 42_000,
+	}
+
+	outpoint, amount, err := resumed.WaitForFunding(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "resume-txid:1", outpoint)
+	require.EqualValues(t, 42_000, amount)
+	require.Zero(t, resumeServer.waitCalls)
+	require.Equal(t, 1, resumeServer.ackCalls)
+	require.Equal(t, 1, resumeServer.serverAckCalls)
+	require.Zero(t, resumed.pendingHTLCAckCursor)
+}
+
+// TestReceiveSessionClassifiesOutSwapServerAckStatus verifies the receiver
+// keeps retrying server ACK statuses that mean "not ready yet", but stops when
+// the swap server authoritatively rejects the ACK for a permanent reason.
+func TestReceiveSessionClassifiesOutSwapServerAckStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		code      codes.Code
+		wantState ReceiveState
+	}{
+		{
+			name:      "not published retryable",
+			code:      codes.FailedPrecondition,
+			wantState: ReceiveStateHTLCEventAccepted,
+		},
+		{
+			name:      "missing swap terminal",
+			code:      codes.NotFound,
+			wantState: ReceiveStateFailed,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newTestSwapStore(t)
+
+			clientPriv, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			operatorPriv, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			serverPriv, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			creator := &testInvoiceCreator{
+				invoice: &invoices.Invoice{
+					PaymentRequest: []byte("lnrtest1swap"),
+				},
+			}
+			serverPubKey := serverPriv.
+				PubKey().
+				SerializeCompressed()
+			cfg := &VHTLCConfig{
+				RefundLocktime:        144,
+				UnilateralClaimDelay:  12,
+				UnilateralRefundDelay: 24,
+			}
+			cfg.UnilateralRefundWithoutReceiverDelay = 36
+			cfg.SwapServerPubkey = serverPubKey
+			serverConn := &testSwapServerConn{
+				hint: &RouteHint{
+					NodeID:          serverPubKey,
+					ChannelID:       99,
+					FeeBaseMsat:     1,
+					FeePropPpm:      2,
+					CltvExpiryDelta: 40,
+				},
+				cfg: cfg,
+				serverAckErr: status.Error(
+					test.code, "ack rejected",
+				),
+				ackCursor: 12,
+			}
+			daemonConn := &testDaemonConn{
+				identityKey: clientPriv.PubKey(),
+				operatorKey: operatorPriv.PubKey(),
+				blockHeight: 100,
+			}
+
+			client := NewSwapClientWithStore(
+				serverConn, daemonConn, nil, creator, store,
+			)
+			useTestOnionDecoder(client, 42_000)
+			client.waitPollInterval = time.Millisecond
+
+			session, err := client.StartReceiveViaLightning(
+				t.Context(), btcutil.Amount(42_000),
+			)
+			require.NoError(t, err)
+
+			_, _, err = session.WaitForFunding(t.Context())
+			require.Error(t, err)
+			require.ErrorContains(t, err, "ack rejected")
+			require.Equal(t, test.wantState, session.State())
+			require.Equal(t, 1, serverConn.serverAckCalls)
+		})
+	}
 }
 
 // TestReceiveSessionExpiresAtRefundLocktimeWithoutFunding asserts a resumed

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -214,9 +214,106 @@ func (x *RequestChannelIdResponse) GetPayerFeeMsat() uint64 {
 	return 0
 }
 
-// OutSwapHtlcEvent describes one server-funded intercepted HTLC. The event is
-// intentionally raw from the Lightning side: the client must decode onion_blob
-// with the invoice/auth private key before it claims the Ark vHTLC.
+// AcknowledgeOutSwapHtlcRequest confirms that the receiver has validated and
+// durably accepted the out-swap HTLC notification for one receive invoice.
+type AcknowledgeOutSwapHtlcRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// payment_hash identifies the intercepted HTLC.
+	PaymentHash []byte `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// client_vhtlc_pubkey is the receiver key used when the route was
+	// registered. The server checks it against the persisted out-swap before
+	// treating the acknowledgement as valid.
+	ClientVhtlcPubkey []byte `protobuf:"bytes,2,opt,name=client_vhtlc_pubkey,json=clientVhtlcPubkey,proto3" json:"client_vhtlc_pubkey,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *AcknowledgeOutSwapHtlcRequest) Reset() {
+	*x = AcknowledgeOutSwapHtlcRequest{}
+	mi := &file_swap_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AcknowledgeOutSwapHtlcRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AcknowledgeOutSwapHtlcRequest) ProtoMessage() {}
+
+func (x *AcknowledgeOutSwapHtlcRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AcknowledgeOutSwapHtlcRequest.ProtoReflect.Descriptor instead.
+func (*AcknowledgeOutSwapHtlcRequest) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *AcknowledgeOutSwapHtlcRequest) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+func (x *AcknowledgeOutSwapHtlcRequest) GetClientVhtlcPubkey() []byte {
+	if x != nil {
+		return x.ClientVhtlcPubkey
+	}
+	return nil
+}
+
+// AcknowledgeOutSwapHtlcResponse is empty on success.
+type AcknowledgeOutSwapHtlcResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AcknowledgeOutSwapHtlcResponse) Reset() {
+	*x = AcknowledgeOutSwapHtlcResponse{}
+	mi := &file_swap_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AcknowledgeOutSwapHtlcResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AcknowledgeOutSwapHtlcResponse) ProtoMessage() {}
+
+func (x *AcknowledgeOutSwapHtlcResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AcknowledgeOutSwapHtlcResponse.ProtoReflect.Descriptor instead.
+func (*AcknowledgeOutSwapHtlcResponse) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{3}
+}
+
+// OutSwapHtlcEvent describes one intercepted HTLC and the vHTLC terms the swap
+// server will fund after the receiver acknowledges durable event acceptance.
+// The event is intentionally raw from the Lightning side: the client must
+// decode onion_blob with the invoice/auth private key before it claims the Ark
+// vHTLC.
 type OutSwapHtlcEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// payment_hash is the intercepted HTLC hash.
@@ -234,7 +331,7 @@ type OutSwapHtlcEvent struct {
 
 func (x *OutSwapHtlcEvent) Reset() {
 	*x = OutSwapHtlcEvent{}
-	mi := &file_swap_proto_msgTypes[2]
+	mi := &file_swap_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -246,7 +343,7 @@ func (x *OutSwapHtlcEvent) String() string {
 func (*OutSwapHtlcEvent) ProtoMessage() {}
 
 func (x *OutSwapHtlcEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[2]
+	mi := &file_swap_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -259,7 +356,7 @@ func (x *OutSwapHtlcEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutSwapHtlcEvent.ProtoReflect.Descriptor instead.
 func (*OutSwapHtlcEvent) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{2}
+	return file_swap_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *OutSwapHtlcEvent) GetPaymentHash() []byte {
@@ -305,7 +402,7 @@ type SwapMailboxEvent struct {
 
 func (x *SwapMailboxEvent) Reset() {
 	*x = SwapMailboxEvent{}
-	mi := &file_swap_proto_msgTypes[3]
+	mi := &file_swap_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -317,7 +414,7 @@ func (x *SwapMailboxEvent) String() string {
 func (*SwapMailboxEvent) ProtoMessage() {}
 
 func (x *SwapMailboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[3]
+	mi := &file_swap_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -330,7 +427,7 @@ func (x *SwapMailboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SwapMailboxEvent.ProtoReflect.Descriptor instead.
 func (*SwapMailboxEvent) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{3}
+	return file_swap_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *SwapMailboxEvent) GetEvent() isSwapMailboxEvent_Event {
@@ -363,8 +460,8 @@ type isSwapMailboxEvent_Event interface {
 }
 
 type SwapMailboxEvent_OutSwapHtlc struct {
-	// out_swap_htlc is emitted when the server has funded or accepted
-	// funding for an out-swap HTLC.
+	// out_swap_htlc is emitted when the server has accepted funding
+	// responsibility for an out-swap HTLC.
 	OutSwapHtlc *OutSwapHtlcEvent `protobuf:"bytes,1,opt,name=out_swap_htlc,json=outSwapHtlc,proto3,oneof"`
 }
 
@@ -404,7 +501,7 @@ type InArkHtlcEvent struct {
 
 func (x *InArkHtlcEvent) Reset() {
 	*x = InArkHtlcEvent{}
-	mi := &file_swap_proto_msgTypes[4]
+	mi := &file_swap_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -416,7 +513,7 @@ func (x *InArkHtlcEvent) String() string {
 func (*InArkHtlcEvent) ProtoMessage() {}
 
 func (x *InArkHtlcEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[4]
+	mi := &file_swap_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -429,7 +526,7 @@ func (x *InArkHtlcEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InArkHtlcEvent.ProtoReflect.Descriptor instead.
 func (*InArkHtlcEvent) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{4}
+	return file_swap_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *InArkHtlcEvent) GetPaymentHash() []byte {
@@ -493,7 +590,7 @@ type RouteHint struct {
 
 func (x *RouteHint) Reset() {
 	*x = RouteHint{}
-	mi := &file_swap_proto_msgTypes[5]
+	mi := &file_swap_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -505,7 +602,7 @@ func (x *RouteHint) String() string {
 func (*RouteHint) ProtoMessage() {}
 
 func (x *RouteHint) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[5]
+	mi := &file_swap_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -518,7 +615,7 @@ func (x *RouteHint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteHint.ProtoReflect.Descriptor instead.
 func (*RouteHint) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{5}
+	return file_swap_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *RouteHint) GetNodeId() []byte {
@@ -580,7 +677,7 @@ type VHTLCConfig struct {
 
 func (x *VHTLCConfig) Reset() {
 	*x = VHTLCConfig{}
-	mi := &file_swap_proto_msgTypes[6]
+	mi := &file_swap_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -592,7 +689,7 @@ func (x *VHTLCConfig) String() string {
 func (*VHTLCConfig) ProtoMessage() {}
 
 func (x *VHTLCConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[6]
+	mi := &file_swap_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -605,7 +702,7 @@ func (x *VHTLCConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VHTLCConfig.ProtoReflect.Descriptor instead.
 func (*VHTLCConfig) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{6}
+	return file_swap_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *VHTLCConfig) GetRefundLocktime() uint32 {
@@ -659,7 +756,7 @@ type CreateInSwapRequest struct {
 
 func (x *CreateInSwapRequest) Reset() {
 	*x = CreateInSwapRequest{}
-	mi := &file_swap_proto_msgTypes[7]
+	mi := &file_swap_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -671,7 +768,7 @@ func (x *CreateInSwapRequest) String() string {
 func (*CreateInSwapRequest) ProtoMessage() {}
 
 func (x *CreateInSwapRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[7]
+	mi := &file_swap_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -684,7 +781,7 @@ func (x *CreateInSwapRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateInSwapRequest.ProtoReflect.Descriptor instead.
 func (*CreateInSwapRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{7}
+	return file_swap_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *CreateInSwapRequest) GetInvoice() string {
@@ -732,7 +829,7 @@ type CreateInSwapResponse struct {
 
 func (x *CreateInSwapResponse) Reset() {
 	*x = CreateInSwapResponse{}
-	mi := &file_swap_proto_msgTypes[8]
+	mi := &file_swap_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -744,7 +841,7 @@ func (x *CreateInSwapResponse) String() string {
 func (*CreateInSwapResponse) ProtoMessage() {}
 
 func (x *CreateInSwapResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[8]
+	mi := &file_swap_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -757,7 +854,7 @@ func (x *CreateInSwapResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateInSwapResponse.ProtoReflect.Descriptor instead.
 func (*CreateInSwapResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{8}
+	return file_swap_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *CreateInSwapResponse) GetPaymentHash() []byte {
@@ -829,7 +926,7 @@ type AuthorizeInSwapRefundRequest struct {
 
 func (x *AuthorizeInSwapRefundRequest) Reset() {
 	*x = AuthorizeInSwapRefundRequest{}
-	mi := &file_swap_proto_msgTypes[9]
+	mi := &file_swap_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -841,7 +938,7 @@ func (x *AuthorizeInSwapRefundRequest) String() string {
 func (*AuthorizeInSwapRefundRequest) ProtoMessage() {}
 
 func (x *AuthorizeInSwapRefundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[9]
+	mi := &file_swap_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -854,7 +951,7 @@ func (x *AuthorizeInSwapRefundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthorizeInSwapRefundRequest.ProtoReflect.Descriptor instead.
 func (*AuthorizeInSwapRefundRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{9}
+	return file_swap_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *AuthorizeInSwapRefundRequest) GetPaymentHash() []byte {
@@ -912,7 +1009,7 @@ type AuthorizeInSwapRefundResponse struct {
 
 func (x *AuthorizeInSwapRefundResponse) Reset() {
 	*x = AuthorizeInSwapRefundResponse{}
-	mi := &file_swap_proto_msgTypes[10]
+	mi := &file_swap_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -924,7 +1021,7 @@ func (x *AuthorizeInSwapRefundResponse) String() string {
 func (*AuthorizeInSwapRefundResponse) ProtoMessage() {}
 
 func (x *AuthorizeInSwapRefundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[10]
+	mi := &file_swap_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -937,7 +1034,7 @@ func (x *AuthorizeInSwapRefundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthorizeInSwapRefundResponse.ProtoReflect.Descriptor instead.
 func (*AuthorizeInSwapRefundResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{10}
+	return file_swap_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *AuthorizeInSwapRefundResponse) GetSignature() *TaprootScriptSignature {
@@ -973,7 +1070,7 @@ type TaprootScriptSignature struct {
 
 func (x *TaprootScriptSignature) Reset() {
 	*x = TaprootScriptSignature{}
-	mi := &file_swap_proto_msgTypes[11]
+	mi := &file_swap_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -985,7 +1082,7 @@ func (x *TaprootScriptSignature) String() string {
 func (*TaprootScriptSignature) ProtoMessage() {}
 
 func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[11]
+	mi := &file_swap_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -998,7 +1095,7 @@ func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaprootScriptSignature.ProtoReflect.Descriptor instead.
 func (*TaprootScriptSignature) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{11}
+	return file_swap_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *TaprootScriptSignature) GetPubkey() []byte {
@@ -1044,7 +1141,11 @@ const file_swap_proto_rawDesc = "" +
 	"\x18RequestChannelIdResponse\x121\n" +
 	"\n" +
 	"route_hint\x18\x01 \x01(\v2\x12.swaprpc.RouteHintR\trouteHint\x12$\n" +
-	"\x0epayer_fee_msat\x18\x02 \x01(\x04R\fpayerFeeMsat\"\xac\x01\n" +
+	"\x0epayer_fee_msat\x18\x02 \x01(\x04R\fpayerFeeMsat\"r\n" +
+	"\x1dAcknowledgeOutSwapHtlcRequest\x12!\n" +
+	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12.\n" +
+	"\x13client_vhtlc_pubkey\x18\x02 \x01(\fR\x11clientVhtlcPubkey\" \n" +
+	"\x1eAcknowledgeOutSwapHtlcResponse\"\xac\x01\n" +
 	"\x10OutSwapHtlcEvent\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x1d\n" +
 	"\n" +
@@ -1108,11 +1209,12 @@ const file_swap_proto_rawDesc = "" +
 	"\x0eSettlementType\x12\x1f\n" +
 	"\x1bSETTLEMENT_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19SETTLEMENT_TYPE_LIGHTNING\x10\x01\x12\x1a\n" +
-	"\x16SETTLEMENT_TYPE_IN_ARK\x10\x022\x9b\x02\n" +
+	"\x16SETTLEMENT_TYPE_IN_ARK\x10\x022\x86\x03\n" +
 	"\vSwapService\x12W\n" +
 	"\x10RequestChannelId\x12 .swaprpc.RequestChannelIdRequest\x1a!.swaprpc.RequestChannelIdResponse\x12K\n" +
 	"\fCreateInSwap\x12\x1c.swaprpc.CreateInSwapRequest\x1a\x1d.swaprpc.CreateInSwapResponse\x12f\n" +
-	"\x15AuthorizeInSwapRefund\x12%.swaprpc.AuthorizeInSwapRefundRequest\x1a&.swaprpc.AuthorizeInSwapRefundResponseB0Z.github.com/lightninglabs/darepo-client/swaprpcb\x06proto3"
+	"\x15AuthorizeInSwapRefund\x12%.swaprpc.AuthorizeInSwapRefundRequest\x1a&.swaprpc.AuthorizeInSwapRefundResponse\x12i\n" +
+	"\x16AcknowledgeOutSwapHtlc\x12&.swaprpc.AcknowledgeOutSwapHtlcRequest\x1a'.swaprpc.AcknowledgeOutSwapHtlcResponseB0Z.github.com/lightninglabs/darepo-client/swaprpcb\x06proto3"
 
 var (
 	file_swap_proto_rawDescOnce sync.Once
@@ -1127,41 +1229,45 @@ func file_swap_proto_rawDescGZIP() []byte {
 }
 
 var file_swap_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_swap_proto_goTypes = []any{
-	(SettlementType)(0),                   // 0: swaprpc.SettlementType
-	(*RequestChannelIdRequest)(nil),       // 1: swaprpc.RequestChannelIdRequest
-	(*RequestChannelIdResponse)(nil),      // 2: swaprpc.RequestChannelIdResponse
-	(*OutSwapHtlcEvent)(nil),              // 3: swaprpc.OutSwapHtlcEvent
-	(*SwapMailboxEvent)(nil),              // 4: swaprpc.SwapMailboxEvent
-	(*InArkHtlcEvent)(nil),                // 5: swaprpc.InArkHtlcEvent
-	(*RouteHint)(nil),                     // 6: swaprpc.RouteHint
-	(*VHTLCConfig)(nil),                   // 7: swaprpc.VHTLCConfig
-	(*CreateInSwapRequest)(nil),           // 8: swaprpc.CreateInSwapRequest
-	(*CreateInSwapResponse)(nil),          // 9: swaprpc.CreateInSwapResponse
-	(*AuthorizeInSwapRefundRequest)(nil),  // 10: swaprpc.AuthorizeInSwapRefundRequest
-	(*AuthorizeInSwapRefundResponse)(nil), // 11: swaprpc.AuthorizeInSwapRefundResponse
-	(*TaprootScriptSignature)(nil),        // 12: swaprpc.TaprootScriptSignature
-	(*timestamppb.Timestamp)(nil),         // 13: google.protobuf.Timestamp
+	(SettlementType)(0),                    // 0: swaprpc.SettlementType
+	(*RequestChannelIdRequest)(nil),        // 1: swaprpc.RequestChannelIdRequest
+	(*RequestChannelIdResponse)(nil),       // 2: swaprpc.RequestChannelIdResponse
+	(*AcknowledgeOutSwapHtlcRequest)(nil),  // 3: swaprpc.AcknowledgeOutSwapHtlcRequest
+	(*AcknowledgeOutSwapHtlcResponse)(nil), // 4: swaprpc.AcknowledgeOutSwapHtlcResponse
+	(*OutSwapHtlcEvent)(nil),               // 5: swaprpc.OutSwapHtlcEvent
+	(*SwapMailboxEvent)(nil),               // 6: swaprpc.SwapMailboxEvent
+	(*InArkHtlcEvent)(nil),                 // 7: swaprpc.InArkHtlcEvent
+	(*RouteHint)(nil),                      // 8: swaprpc.RouteHint
+	(*VHTLCConfig)(nil),                    // 9: swaprpc.VHTLCConfig
+	(*CreateInSwapRequest)(nil),            // 10: swaprpc.CreateInSwapRequest
+	(*CreateInSwapResponse)(nil),           // 11: swaprpc.CreateInSwapResponse
+	(*AuthorizeInSwapRefundRequest)(nil),   // 12: swaprpc.AuthorizeInSwapRefundRequest
+	(*AuthorizeInSwapRefundResponse)(nil),  // 13: swaprpc.AuthorizeInSwapRefundResponse
+	(*TaprootScriptSignature)(nil),         // 14: swaprpc.TaprootScriptSignature
+	(*timestamppb.Timestamp)(nil),          // 15: google.protobuf.Timestamp
 }
 var file_swap_proto_depIdxs = []int32{
-	6,  // 0: swaprpc.RequestChannelIdResponse.route_hint:type_name -> swaprpc.RouteHint
-	7,  // 1: swaprpc.OutSwapHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	3,  // 2: swaprpc.SwapMailboxEvent.out_swap_htlc:type_name -> swaprpc.OutSwapHtlcEvent
-	5,  // 3: swaprpc.SwapMailboxEvent.in_ark_htlc:type_name -> swaprpc.InArkHtlcEvent
-	7,  // 4: swaprpc.InArkHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	7,  // 5: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	13, // 6: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
+	8,  // 0: swaprpc.RequestChannelIdResponse.route_hint:type_name -> swaprpc.RouteHint
+	9,  // 1: swaprpc.OutSwapHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	5,  // 2: swaprpc.SwapMailboxEvent.out_swap_htlc:type_name -> swaprpc.OutSwapHtlcEvent
+	7,  // 3: swaprpc.SwapMailboxEvent.in_ark_htlc:type_name -> swaprpc.InArkHtlcEvent
+	9,  // 4: swaprpc.InArkHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	9,  // 5: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	15, // 6: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
 	0,  // 7: swaprpc.CreateInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
-	12, // 8: swaprpc.AuthorizeInSwapRefundResponse.signature:type_name -> swaprpc.TaprootScriptSignature
+	14, // 8: swaprpc.AuthorizeInSwapRefundResponse.signature:type_name -> swaprpc.TaprootScriptSignature
 	1,  // 9: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
-	8,  // 10: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
-	10, // 11: swaprpc.SwapService.AuthorizeInSwapRefund:input_type -> swaprpc.AuthorizeInSwapRefundRequest
-	2,  // 12: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
-	9,  // 13: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
-	11, // 14: swaprpc.SwapService.AuthorizeInSwapRefund:output_type -> swaprpc.AuthorizeInSwapRefundResponse
-	12, // [12:15] is the sub-list for method output_type
-	9,  // [9:12] is the sub-list for method input_type
+	10, // 10: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
+	12, // 11: swaprpc.SwapService.AuthorizeInSwapRefund:input_type -> swaprpc.AuthorizeInSwapRefundRequest
+	3,  // 12: swaprpc.SwapService.AcknowledgeOutSwapHtlc:input_type -> swaprpc.AcknowledgeOutSwapHtlcRequest
+	2,  // 13: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
+	11, // 14: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
+	13, // 15: swaprpc.SwapService.AuthorizeInSwapRefund:output_type -> swaprpc.AuthorizeInSwapRefundResponse
+	4,  // 16: swaprpc.SwapService.AcknowledgeOutSwapHtlc:output_type -> swaprpc.AcknowledgeOutSwapHtlcResponse
+	13, // [13:17] is the sub-list for method output_type
+	9,  // [9:13] is the sub-list for method input_type
 	9,  // [9:9] is the sub-list for extension type_name
 	9,  // [9:9] is the sub-list for extension extendee
 	0,  // [0:9] is the sub-list for field type_name
@@ -1172,7 +1278,7 @@ func file_swap_proto_init() {
 	if File_swap_proto != nil {
 		return
 	}
-	file_swap_proto_msgTypes[3].OneofWrappers = []any{
+	file_swap_proto_msgTypes[5].OneofWrappers = []any{
 		(*SwapMailboxEvent_OutSwapHtlc)(nil),
 		(*SwapMailboxEvent_InArkHtlc)(nil),
 	}
@@ -1182,7 +1288,7 @@ func file_swap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_swap_proto_rawDesc), len(file_swap_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   12,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/swaprpc/swap.pb.gw.go
+++ b/swaprpc/swap.pb.gw.go
@@ -116,6 +116,33 @@ func local_request_SwapService_AuthorizeInSwapRefund_0(ctx context.Context, mars
 	return msg, metadata, err
 }
 
+func request_SwapService_AcknowledgeOutSwapHtlc_0(ctx context.Context, marshaler runtime.Marshaler, client SwapServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AcknowledgeOutSwapHtlcRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.AcknowledgeOutSwapHtlc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SwapService_AcknowledgeOutSwapHtlc_0(ctx context.Context, marshaler runtime.Marshaler, server SwapServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AcknowledgeOutSwapHtlcRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.AcknowledgeOutSwapHtlc(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterSwapServiceHandlerServer registers the http handlers for service SwapService to "mux".
 // UnaryRPC     :call SwapServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -181,6 +208,26 @@ func RegisterSwapServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux
 			return
 		}
 		forward_SwapService_AuthorizeInSwapRefund_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SwapService_AcknowledgeOutSwapHtlc_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/swaprpc.SwapService/AcknowledgeOutSwapHtlc", runtime.WithHTTPPathPattern("/v1/swap/acknowledge-out-swap-htlc"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SwapService_AcknowledgeOutSwapHtlc_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_AcknowledgeOutSwapHtlc_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -273,17 +320,36 @@ func RegisterSwapServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_SwapService_AuthorizeInSwapRefund_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_SwapService_AcknowledgeOutSwapHtlc_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/swaprpc.SwapService/AcknowledgeOutSwapHtlc", runtime.WithHTTPPathPattern("/v1/swap/acknowledge-out-swap-htlc"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SwapService_AcknowledgeOutSwapHtlc_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_AcknowledgeOutSwapHtlc_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_SwapService_RequestChannelId_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "request-channel-id"}, ""))
-	pattern_SwapService_CreateInSwap_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "create-in-swap"}, ""))
-	pattern_SwapService_AuthorizeInSwapRefund_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "authorize-in-swap-refund"}, ""))
+	pattern_SwapService_RequestChannelId_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "request-channel-id"}, ""))
+	pattern_SwapService_CreateInSwap_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "create-in-swap"}, ""))
+	pattern_SwapService_AuthorizeInSwapRefund_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "authorize-in-swap-refund"}, ""))
+	pattern_SwapService_AcknowledgeOutSwapHtlc_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "acknowledge-out-swap-htlc"}, ""))
 )
 
 var (
-	forward_SwapService_RequestChannelId_0      = runtime.ForwardResponseMessage
-	forward_SwapService_CreateInSwap_0          = runtime.ForwardResponseMessage
-	forward_SwapService_AuthorizeInSwapRefund_0 = runtime.ForwardResponseMessage
+	forward_SwapService_RequestChannelId_0       = runtime.ForwardResponseMessage
+	forward_SwapService_CreateInSwap_0           = runtime.ForwardResponseMessage
+	forward_SwapService_AuthorizeInSwapRefund_0  = runtime.ForwardResponseMessage
+	forward_SwapService_AcknowledgeOutSwapHtlc_0 = runtime.ForwardResponseMessage
 )

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -36,6 +36,12 @@ service SwapService {
     // funded in-swap whose Lightning payment attempt has terminally failed.
     rpc AuthorizeInSwapRefund (AuthorizeInSwapRefundRequest)
         returns (AuthorizeInSwapRefundResponse);
+
+    // AcknowledgeOutSwapHtlc records that the receiver validated and durably
+    // accepted the out-swap HTLC mailbox event. The swap server waits for this
+    // acknowledgement before funding the Ark vHTLC.
+    rpc AcknowledgeOutSwapHtlc (AcknowledgeOutSwapHtlcRequest)
+        returns (AcknowledgeOutSwapHtlcResponse);
 }
 
 // RequestChannelIdRequest starts one Lightning-to-Ark receive negotiation.
@@ -71,9 +77,27 @@ message RequestChannelIdResponse {
     uint64 payer_fee_msat = 2;
 }
 
-// OutSwapHtlcEvent describes one server-funded intercepted HTLC. The event is
-// intentionally raw from the Lightning side: the client must decode onion_blob
-// with the invoice/auth private key before it claims the Ark vHTLC.
+// AcknowledgeOutSwapHtlcRequest confirms that the receiver has validated and
+// durably accepted the out-swap HTLC notification for one receive invoice.
+message AcknowledgeOutSwapHtlcRequest {
+    // payment_hash identifies the intercepted HTLC.
+    bytes payment_hash = 1;
+
+    // client_vhtlc_pubkey is the receiver key used when the route was
+    // registered. The server checks it against the persisted out-swap before
+    // treating the acknowledgement as valid.
+    bytes client_vhtlc_pubkey = 2;
+}
+
+// AcknowledgeOutSwapHtlcResponse is empty on success.
+message AcknowledgeOutSwapHtlcResponse {
+}
+
+// OutSwapHtlcEvent describes one intercepted HTLC and the vHTLC terms the swap
+// server will fund after the receiver acknowledges durable event acceptance.
+// The event is intentionally raw from the Lightning side: the client must
+// decode onion_blob with the invoice/auth private key before it claims the Ark
+// vHTLC.
 message OutSwapHtlcEvent {
     // payment_hash is the intercepted HTLC hash.
     bytes payment_hash = 1;
@@ -93,8 +117,8 @@ message OutSwapHtlcEvent {
 // envelopes.
 message SwapMailboxEvent {
     oneof event {
-        // out_swap_htlc is emitted when the server has funded or accepted
-        // funding for an out-swap HTLC.
+        // out_swap_htlc is emitted when the server has accepted funding
+        // responsibility for an out-swap HTLC.
         OutSwapHtlcEvent out_swap_htlc = 1;
 
         // in_ark_htlc is emitted when a same-Ark sender has funded or

--- a/swaprpc/swap.yaml
+++ b/swaprpc/swap.yaml
@@ -12,3 +12,6 @@ http:
     - selector: swaprpc.SwapService.AuthorizeInSwapRefund
       post: /v1/swap/authorize-in-swap-refund
       body: "*"
+    - selector: swaprpc.SwapService.AcknowledgeOutSwapHtlc
+      post: /v1/swap/acknowledge-out-swap-htlc
+      body: "*"

--- a/swaprpc/swap_grpc.pb.go
+++ b/swaprpc/swap_grpc.pb.go
@@ -19,9 +19,10 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	SwapService_RequestChannelId_FullMethodName      = "/swaprpc.SwapService/RequestChannelId"
-	SwapService_CreateInSwap_FullMethodName          = "/swaprpc.SwapService/CreateInSwap"
-	SwapService_AuthorizeInSwapRefund_FullMethodName = "/swaprpc.SwapService/AuthorizeInSwapRefund"
+	SwapService_RequestChannelId_FullMethodName       = "/swaprpc.SwapService/RequestChannelId"
+	SwapService_CreateInSwap_FullMethodName           = "/swaprpc.SwapService/CreateInSwap"
+	SwapService_AuthorizeInSwapRefund_FullMethodName  = "/swaprpc.SwapService/AuthorizeInSwapRefund"
+	SwapService_AcknowledgeOutSwapHtlc_FullMethodName = "/swaprpc.SwapService/AcknowledgeOutSwapHtlc"
 )
 
 // SwapServiceClient is the client API for SwapService service.
@@ -40,6 +41,10 @@ type SwapServiceClient interface {
 	// AuthorizeInSwapRefund signs a prepared cooperative refund spend for a
 	// funded in-swap whose Lightning payment attempt has terminally failed.
 	AuthorizeInSwapRefund(ctx context.Context, in *AuthorizeInSwapRefundRequest, opts ...grpc.CallOption) (*AuthorizeInSwapRefundResponse, error)
+	// AcknowledgeOutSwapHtlc records that the receiver validated and durably
+	// accepted the out-swap HTLC mailbox event. The swap server waits for this
+	// acknowledgement before funding the Ark vHTLC.
+	AcknowledgeOutSwapHtlc(ctx context.Context, in *AcknowledgeOutSwapHtlcRequest, opts ...grpc.CallOption) (*AcknowledgeOutSwapHtlcResponse, error)
 }
 
 type swapServiceClient struct {
@@ -80,6 +85,16 @@ func (c *swapServiceClient) AuthorizeInSwapRefund(ctx context.Context, in *Autho
 	return out, nil
 }
 
+func (c *swapServiceClient) AcknowledgeOutSwapHtlc(ctx context.Context, in *AcknowledgeOutSwapHtlcRequest, opts ...grpc.CallOption) (*AcknowledgeOutSwapHtlcResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AcknowledgeOutSwapHtlcResponse)
+	err := c.cc.Invoke(ctx, SwapService_AcknowledgeOutSwapHtlc_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SwapServiceServer is the server API for SwapService service.
 // All implementations must embed UnimplementedSwapServiceServer
 // for forward compatibility.
@@ -96,6 +111,10 @@ type SwapServiceServer interface {
 	// AuthorizeInSwapRefund signs a prepared cooperative refund spend for a
 	// funded in-swap whose Lightning payment attempt has terminally failed.
 	AuthorizeInSwapRefund(context.Context, *AuthorizeInSwapRefundRequest) (*AuthorizeInSwapRefundResponse, error)
+	// AcknowledgeOutSwapHtlc records that the receiver validated and durably
+	// accepted the out-swap HTLC mailbox event. The swap server waits for this
+	// acknowledgement before funding the Ark vHTLC.
+	AcknowledgeOutSwapHtlc(context.Context, *AcknowledgeOutSwapHtlcRequest) (*AcknowledgeOutSwapHtlcResponse, error)
 	mustEmbedUnimplementedSwapServiceServer()
 }
 
@@ -114,6 +133,9 @@ func (UnimplementedSwapServiceServer) CreateInSwap(context.Context, *CreateInSwa
 }
 func (UnimplementedSwapServiceServer) AuthorizeInSwapRefund(context.Context, *AuthorizeInSwapRefundRequest) (*AuthorizeInSwapRefundResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AuthorizeInSwapRefund not implemented")
+}
+func (UnimplementedSwapServiceServer) AcknowledgeOutSwapHtlc(context.Context, *AcknowledgeOutSwapHtlcRequest) (*AcknowledgeOutSwapHtlcResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AcknowledgeOutSwapHtlc not implemented")
 }
 func (UnimplementedSwapServiceServer) mustEmbedUnimplementedSwapServiceServer() {}
 func (UnimplementedSwapServiceServer) testEmbeddedByValue()                     {}
@@ -190,6 +212,24 @@ func _SwapService_AuthorizeInSwapRefund_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SwapService_AcknowledgeOutSwapHtlc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AcknowledgeOutSwapHtlcRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SwapServiceServer).AcknowledgeOutSwapHtlc(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SwapService_AcknowledgeOutSwapHtlc_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SwapServiceServer).AcknowledgeOutSwapHtlc(ctx, req.(*AcknowledgeOutSwapHtlcRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SwapService_ServiceDesc is the grpc.ServiceDesc for SwapService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -208,6 +248,10 @@ var SwapService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AuthorizeInSwapRefund",
 			Handler:    _SwapService_AuthorizeInSwapRefund_Handler,
+		},
+		{
+			MethodName: "AcknowledgeOutSwapHtlc",
+			Handler:    _SwapService_AcknowledgeOutSwapHtlc_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/swaprpc/swap_mailboxrpc.pb.go
+++ b/swaprpc/swap_mailboxrpc.pb.go
@@ -30,6 +30,8 @@ type SwapServiceMailboxServer interface {
 	CreateInSwap(ctx context.Context, req *CreateInSwapRequest) (*CreateInSwapResponse, error)
 	// AuthorizeInSwapRefund handles AuthorizeInSwapRefund.
 	AuthorizeInSwapRefund(ctx context.Context, req *AuthorizeInSwapRefundRequest) (*AuthorizeInSwapRefundResponse, error)
+	// AcknowledgeOutSwapHtlc handles AcknowledgeOutSwapHtlc.
+	AcknowledgeOutSwapHtlc(ctx context.Context, req *AcknowledgeOutSwapHtlcRequest) (*AcknowledgeOutSwapHtlcResponse, error)
 }
 
 // RegisterSwapServiceMailboxServer registers handlers for SwapService.
@@ -63,6 +65,16 @@ func RegisterSwapServiceMailboxServer(r rpc.Router, impl SwapServiceMailboxServe
 		}
 
 		return impl.AuthorizeInSwapRefund(ctx, req)
+	})
+	r.Handle("swaprpc.SwapService", "AcknowledgeOutSwapHtlc", func() proto.Message {
+		return &AcknowledgeOutSwapHtlcRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*AcknowledgeOutSwapHtlcRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.AcknowledgeOutSwapHtlc(ctx, req)
 	})
 }
 
@@ -128,6 +140,29 @@ func (c *SwapServiceMailboxClient) AuthorizeInSwapRefund(ctx context.Context, re
 	}
 
 	resp := new(AuthorizeInSwapRefundResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// AcknowledgeOutSwapHtlc calls the AcknowledgeOutSwapHtlc RPC.
+func (c *SwapServiceMailboxClient) AcknowledgeOutSwapHtlc(ctx context.Context, req *AcknowledgeOutSwapHtlcRequest, opts ...rpc.RPCOptions) (*AcknowledgeOutSwapHtlcResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "swaprpc.SwapService",
+		Method:  "AcknowledgeOutSwapHtlc",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(AcknowledgeOutSwapHtlcResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

This adds an explicit receiver ACK for out-swap HTLC events.

Before this change, the receive side only ACKed the mailbox cursor after it accepted an HTLC event. That proved the message was consumed, but it did not give the swap server a durable signal that the receiver had validated and persisted the event before the server funded the Ark vHTLC.

The new `AcknowledgeOutSwapHtlc` RPC lets the receiver ACK the event back to the swap server after the mailbox ACK succeeds. The receive session keeps the existing retry boundary: if the mailbox ACK or server ACK fails, the pending cursor remains and resume retries the missing acknowledgement. Same-Ark receives skip the server ACK because the swap server does not fund those vHTLCs.

This PR is the client-side half of the fix for lightninglabs/swapdk-server#29. The matching swapdk-server PR updates the server state machine to wait for this ACK before funding.

## Stack

This PR is based on lightninglabs/darepo-client#717 (`max-vtxo-amt`). The server currently needs the newer darepo/client API surface from that stack, so keeping this PR stacked avoids reintroducing the stale submodule baseline that swapdk-server was pinned to.

## Tests

- `go test ./sdk/swaps -count=1`
- `go test ./rpc/restclient -count=1`
