### PR TITLE
docs: nightly doc-gardening sweep 2026-06-11

### DIFF
--- a/chainsource/AGENTS.md
+++ b/chainsource/AGENTS.md
@@ -15,6 +15,12 @@ communication alongside the raw registration API.
   request. Registered under `ChainSourceKey`.
 - `ChainSourceConfig` — Config struct: `Backend ChainBackend`, `System
   *actor.ActorSystem`, `Log fn.Option[btclog.Logger]`.
+- `BlockEpochConfig` — Config for `BlockEpochActor`. Fields:
+  `Backend ChainBackend`, `Log fn.Option[btclog.Logger]`,
+  `ReconnectBackoff time.Duration` (initial delay before re-subscribing
+  after backend stream closes; zero uses 1s default),
+  `MaxReconnectBackoff time.Duration` (exponential cap; zero uses 30s
+  default).
 - `ChainSourceMsg` / `ChainSourceResp` — Sealed actor message interfaces for
   requests and responses sent to the `ChainSourceActor`.
 - `FeeEstimateRequest/Response`, `BestHeightRequest/Response`,
@@ -56,6 +62,10 @@ communication alongside the raw registration API.
 - Confirmation sub-actors support two notification modes: Future-based (blocking
   await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
   mode when blocking inside a durable actor transaction is unsafe.
+- `BlockEpochActor` automatically re-subscribes with exponential backoff when
+  the backend stream closes after an initial successful registration (e.g. LND
+  notifier restart). Tests can lower both backoff bounds via `BlockEpochConfig`;
+  the actor returns `false` from `waitForReconnect` on shutdown.
 
 ## Deep Docs
 

--- a/chainsource/CLAUDE.md
+++ b/chainsource/CLAUDE.md
@@ -15,6 +15,12 @@ communication alongside the raw registration API.
   request. Registered under `ChainSourceKey`.
 - `ChainSourceConfig` — Config struct: `Backend ChainBackend`, `System
   *actor.ActorSystem`, `Log fn.Option[btclog.Logger]`.
+- `BlockEpochConfig` — Config for `BlockEpochActor`. Fields:
+  `Backend ChainBackend`, `Log fn.Option[btclog.Logger]`,
+  `ReconnectBackoff time.Duration` (initial delay before re-subscribing
+  after backend stream closes; zero uses 1s default),
+  `MaxReconnectBackoff time.Duration` (exponential cap; zero uses 30s
+  default).
 - `ChainSourceMsg` / `ChainSourceResp` — Sealed actor message interfaces for
   requests and responses sent to the `ChainSourceActor`.
 - `FeeEstimateRequest/Response`, `BestHeightRequest/Response`,
@@ -56,6 +62,10 @@ communication alongside the raw registration API.
 - Confirmation sub-actors support two notification modes: Future-based (blocking
   await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
   mode when blocking inside a durable actor transaction is unsafe.
+- `BlockEpochActor` automatically re-subscribes with exponential backoff when
+  the backend stream closes after an initial successful registration (e.g. LND
+  notifier restart). Tests can lower both backoff bounds via `BlockEpochConfig`;
+  the actor returns `false` from `waitForReconnect` on shutdown.
 
 ## Deep Docs
 

--- a/cmd/darepocli/darepoclicommands/AGENTS.md
+++ b/cmd/darepocli/darepoclicommands/AGENTS.md
@@ -54,7 +54,7 @@ who want direct access.
 | `ark sweep [list]` | `SweepBoardingUTXOs` / `ListBoardingSweeps` | Boarding-timeout sweeps |
 | `ark fees {estimate,history}` | `EstimateFee` / `GetFeeHistory` | Fee estimation and history |
 | `ark listtransactions` | `ListTransactions` | Raw paginated transaction history |
-| `ark send {inround,oor}` | `SendVTXO` / `SendOOR` | Raw in-round / OOR send (superseded by `send` for the wallet shape) |
+| `ark send {inround,oor}` | `SendVTXO` / `SendOOR` | Raw in-round / OOR send (superseded by `send` for the wallet shape). OOR send uses `--recipients-json '[{"address":"...","amount_sat":N}]'` (plural) |
 
 ### `swap.*` advanced commands (swapruntime build tag)
 
@@ -115,6 +115,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/cmd/d
   mutually exclusive; if neither is set, offchain is the default. The
   CLI does NOT sniff the destination string — the daemon performs
   the authoritative parse.
+- `ark send oor` populates `SendOORRequest.Recipients` (a repeated field)
+  with one element built from the `--recipient.*` flags. The MCP tool also
+  uses `Recipients` (plural). The proto dropped `Recipient` (singular).
 - The wallet password is NEVER read from argv. The supported sources
   are `DAREPOD_WALLET_PASSWORD` (highest priority), then
   `--wallet_password_file`, then piped stdin, then interactive prompt.

--- a/cmd/darepocli/darepoclicommands/CLAUDE.md
+++ b/cmd/darepocli/darepoclicommands/CLAUDE.md
@@ -54,7 +54,7 @@ who want direct access.
 | `ark sweep [list]` | `SweepBoardingUTXOs` / `ListBoardingSweeps` | Boarding-timeout sweeps |
 | `ark fees {estimate,history}` | `EstimateFee` / `GetFeeHistory` | Fee estimation and history |
 | `ark listtransactions` | `ListTransactions` | Raw paginated transaction history |
-| `ark send {inround,oor}` | `SendVTXO` / `SendOOR` | Raw in-round / OOR send (superseded by `send` for the wallet shape) |
+| `ark send {inround,oor}` | `SendVTXO` / `SendOOR` | Raw in-round / OOR send (superseded by `send` for the wallet shape). OOR send uses `--recipients-json '[{"address":"...","amount_sat":N}]'` (plural) |
 
 ### `swap.*` advanced commands (swapruntime build tag)
 
@@ -115,6 +115,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/cmd/d
   mutually exclusive; if neither is set, offchain is the default. The
   CLI does NOT sniff the destination string — the daemon performs
   the authoritative parse.
+- `ark send oor` populates `SendOORRequest.Recipients` (a repeated field)
+  with one element built from the `--recipient.*` flags. The MCP tool also
+  uses `Recipients` (plural). The proto dropped `Recipient` (singular).
 - The wallet password is NEVER read from argv. The supported sources
   are `DAREPOD_WALLET_PASSWORD` (highest priority), then
   `--wallet_password_file`, then piped stdin, then interactive prompt.

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -19,7 +19,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
 - `RPCServer` — implements gRPC `DaemonService`. Holds an in-memory
   `customInputLocks` map (guarded by `customInputLocksMu`) that
   reserves custom OOR input outpoints for the duration of a `SendOOR`
-  call.
+  call. `SendOOR` now accepts multiple recipients via `req.Recipients`
+  (up to `maxOORRecipients = 256`); `sendOORRequestRecipients`,
+  `sumSendOORRecipientAmounts`, and `buildSendOORRecipients` helpers
+  validate and resolve the list before handing it to the OOR actor.
 - `Config` — daemon configuration. Notable fields:
   `MailboxEdgeFactory` (test transport interception),
   `PackageSubmitter chainbackends.PackageSubmitter` (v3 CPFP submitter
@@ -265,6 +268,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   per-recipient amounts outside `(0, MaxSatoshi]`, uses
   overflow-safe accumulation. Wallet-side `handleSendVTXOs` repeats
   these checks as defense-in-depth.
+- `SendOOR` accepts multiple recipients via `req.Recipients` (replaces
+  the singular `req.Recipient`). The RPC boundary enforces
+  `maxOORRecipients = 256` before script resolution. `buildSendOORRecipients`
+  resolves scripts, validates per-recipient dust, and resolves policy templates.
+  When the cleanup waiter times out (`submittedOORCleanupTimeout = 10 min`),
+  unlocks run on a fresh 30s context (`submittedOORUnlockTimeout`) because the
+  cleanup context is already cancelled.
 - `SendOOR` with custom inputs serializes concurrent calls on the
   same outpoints via `reserveCustomInputs`. Custom inputs lock for
   the RPC lifetime; release is deferred on both success and failure.

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -19,7 +19,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
 - `RPCServer` — implements gRPC `DaemonService`. Holds an in-memory
   `customInputLocks` map (guarded by `customInputLocksMu`) that
   reserves custom OOR input outpoints for the duration of a `SendOOR`
-  call.
+  call. `SendOOR` now accepts multiple recipients via `req.Recipients`
+  (up to `maxOORRecipients = 256`); `sendOORRequestRecipients`,
+  `sumSendOORRecipientAmounts`, and `buildSendOORRecipients` helpers
+  validate and resolve the list before handing it to the OOR actor.
 - `Config` — daemon configuration. Notable fields:
   `MailboxEdgeFactory` (test transport interception),
   `PackageSubmitter chainbackends.PackageSubmitter` (v3 CPFP submitter
@@ -265,6 +268,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   per-recipient amounts outside `(0, MaxSatoshi]`, uses
   overflow-safe accumulation. Wallet-side `handleSendVTXOs` repeats
   these checks as defense-in-depth.
+- `SendOOR` accepts multiple recipients via `req.Recipients` (replaces
+  the singular `req.Recipient`). The RPC boundary enforces
+  `maxOORRecipients = 256` before script resolution. `buildSendOORRecipients`
+  resolves scripts, validates per-recipient dust, and resolves policy templates.
+  When the cleanup waiter times out (`submittedOORCleanupTimeout = 10 min`),
+  unlocks run on a fresh 30s context (`submittedOORUnlockTimeout`) because the
+  cleanup context is already cancelled.
 - `SendOOR` with custom inputs serializes concurrent calls on the
   same outpoints via `reserveCustomInputs`. Custom inputs lock for
   the RPC lifetime; release is deferred on both success and failure.

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -11,19 +11,31 @@ PostgreSQL backends.
 
 For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<Symbol>`.
 
+- `InternalKeyQuerier` — Minimal interface over the shared `internal_keys`
+  registry: `UpsertInternalKey` + `GetInternalKeyByID`. Embedded by
+  `BoardingStore`, `RoundStore`, and `OORArtifactStore` so each store can
+  register-then-reference a client wallet key within the same transaction.
+- `RegisterInternalKeyTx(ctx, q, now, keychain.KeyDescriptor) (int64, error)` —
+  Idempotently records a key descriptor in `internal_keys` and returns its
+  surrogate id. Safe to call multiple times for the same triple.
+- `InternalKeyDescByIDTx(ctx, q, id) (keychain.KeyDescriptor, error)` —
+  Hydrates a full `KeyDescriptor` (pubkey + locator) from the registry by id.
 - `BatchedTx[Q]` — generic interface for atomic transactions (`ExecTx`,
   `Backend`).
-- `BoardingStore` / `BoardingWalletStore` — interface + concrete
-  sqlc-backed store for boarding addresses, intents, and the aggregate
-  sweep lifecycle (consumed by `wallet.BoardingStore`). Sweep ops:
+- `BoardingStore` / `BoardingWalletStore` — interface (embeds
+  `InternalKeyQuerier`) + concrete sqlc-backed store for boarding
+  addresses, intents, and the aggregate sweep lifecycle (consumed by
+  `wallet.BoardingStore`). Client wallet keys are stored by `client_key_id`
+  FK referencing `internal_keys` rather than inlined columns. Sweep ops:
   `Create/MarkPublished/MarkFailed/List/ListPending/MarkInputSpent`.
 - `NewBoardingSweep` / `BoardingSweepRecord` /
   `BoardingSweepInputRecord` — control-plane domain types. Sweep
   statuses: `pending`, `published`, `confirmed`, `external_resolved`,
   `failed`. Input statuses: `pending`, `published`, `spent`,
   `external_spent`, `failed`.
-- `RoundStore` / `RoundPersistenceStore` — round-state interface +
-  concrete `BatchedTx[RoundStore]`-backed store
+- `RoundStore` / `RoundPersistenceStore` — round-state interface
+  (embeds `InternalKeyQuerier`) + concrete `BatchedTx[RoundStore]`-backed
+  store
   (`InsertRound`/`Get`/`GetByCommitmentTxid`/`ListActive`/`ListByStatus`/
   `UpdateStatus`/`Finalize` plus boarding-intent / VTXO-request /
   client-tree queries).
@@ -31,8 +43,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   paginated listing (avoids deserializing full trees).
 - `VTXOPersistenceStore` — VTXO descriptor store
   (`InsertClientVTXO`, `FetchByOutpoint`). Persists `ChainDepth`.
-- `OORArtifactStore`, `OwnedReceiveScriptStore` — OOR session state
-  and locally owned receive-script metadata.
+- `OORArtifactStore` (embeds `InternalKeyQuerier`), `OwnedReceiveScriptStore`
+  — OOR session state and locally owned receive-script metadata. Client
+  keys stored via `client_key_id` FK in `owned_receive_scripts`.
 - `LedgerStoreDB` — implements `ledger.LedgerStore`. Wraps
   `sqlc.InsertClientLedgerEntry` (ON CONFLICT DO NOTHING for replay
   idempotency). Joins the outer actor transaction via
@@ -125,6 +138,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 
 ### Migration notes
 
+- `000002_boarding_tables` — now also creates the `internal_keys` table
+  (surrogate key, 33-byte pubkey BLOB, key_family BIGINT, key_index BIGINT,
+  created_at; UNIQUE on `(pubkey, key_family, key_index)`) before the
+  boarding tables it introduced, so FKs declared in those tables have a
+  target. `boarding_addresses`, `round_vtxo_requests`, `vtxos`, and
+  `owned_receive_scripts` reference `internal_keys.id` via a `*_key_id`
+  nullable FK instead of inlining the (pubkey, family, index) triple.
 - `000017_spending_reservations` — adds `spending_reservations` table with
   `(outpoint_hash, outpoint_index)` PK, `owner_kind`, `owner_id`, and
   `created_at`. A row exists IFF the owning spend session was durably

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -11,19 +11,31 @@ PostgreSQL backends.
 
 For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<Symbol>`.
 
+- `InternalKeyQuerier` — Minimal interface over the shared `internal_keys`
+  registry: `UpsertInternalKey` + `GetInternalKeyByID`. Embedded by
+  `BoardingStore`, `RoundStore`, and `OORArtifactStore` so each store can
+  register-then-reference a client wallet key within the same transaction.
+- `RegisterInternalKeyTx(ctx, q, now, keychain.KeyDescriptor) (int64, error)` —
+  Idempotently records a key descriptor in `internal_keys` and returns its
+  surrogate id. Safe to call multiple times for the same triple.
+- `InternalKeyDescByIDTx(ctx, q, id) (keychain.KeyDescriptor, error)` —
+  Hydrates a full `KeyDescriptor` (pubkey + locator) from the registry by id.
 - `BatchedTx[Q]` — generic interface for atomic transactions (`ExecTx`,
   `Backend`).
-- `BoardingStore` / `BoardingWalletStore` — interface + concrete
-  sqlc-backed store for boarding addresses, intents, and the aggregate
-  sweep lifecycle (consumed by `wallet.BoardingStore`). Sweep ops:
+- `BoardingStore` / `BoardingWalletStore` — interface (embeds
+  `InternalKeyQuerier`) + concrete sqlc-backed store for boarding
+  addresses, intents, and the aggregate sweep lifecycle (consumed by
+  `wallet.BoardingStore`). Client wallet keys are stored by `client_key_id`
+  FK referencing `internal_keys` rather than inlined columns. Sweep ops:
   `Create/MarkPublished/MarkFailed/List/ListPending/MarkInputSpent`.
 - `NewBoardingSweep` / `BoardingSweepRecord` /
   `BoardingSweepInputRecord` — control-plane domain types. Sweep
   statuses: `pending`, `published`, `confirmed`, `external_resolved`,
   `failed`. Input statuses: `pending`, `published`, `spent`,
   `external_spent`, `failed`.
-- `RoundStore` / `RoundPersistenceStore` — round-state interface +
-  concrete `BatchedTx[RoundStore]`-backed store
+- `RoundStore` / `RoundPersistenceStore` — round-state interface
+  (embeds `InternalKeyQuerier`) + concrete `BatchedTx[RoundStore]`-backed
+  store
   (`InsertRound`/`Get`/`GetByCommitmentTxid`/`ListActive`/`ListByStatus`/
   `UpdateStatus`/`Finalize` plus boarding-intent / VTXO-request /
   client-tree queries).
@@ -31,8 +43,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   paginated listing (avoids deserializing full trees).
 - `VTXOPersistenceStore` — VTXO descriptor store
   (`InsertClientVTXO`, `FetchByOutpoint`). Persists `ChainDepth`.
-- `OORArtifactStore`, `OwnedReceiveScriptStore` — OOR session state
-  and locally owned receive-script metadata.
+- `OORArtifactStore` (embeds `InternalKeyQuerier`), `OwnedReceiveScriptStore`
+  — OOR session state and locally owned receive-script metadata. Client
+  keys stored via `client_key_id` FK in `owned_receive_scripts`.
 - `LedgerStoreDB` — implements `ledger.LedgerStore`. Wraps
   `sqlc.InsertClientLedgerEntry` (ON CONFLICT DO NOTHING for replay
   idempotency). Joins the outer actor transaction via
@@ -125,6 +138,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 
 ### Migration notes
 
+- `000002_boarding_tables` — now also creates the `internal_keys` table
+  (surrogate key, 33-byte pubkey BLOB, key_family BIGINT, key_index BIGINT,
+  created_at; UNIQUE on `(pubkey, key_family, key_index)`) before the
+  boarding tables it introduced, so FKs declared in those tables have a
+  target. `boarding_addresses`, `round_vtxo_requests`, `vtxos`, and
+  `owned_receive_scripts` reference `internal_keys.id` via a `*_key_id`
+  nullable FK instead of inlining the (pubkey, family, index) triple.
 - `000017_spending_reservations` — adds `spending_reservations` table with
   `(outpoint_hash, outpoint_index)` PK, `owner_kind`, `owner_id`, and
   `created_at`. A row exists IFF the owning spend session was durably

--- a/internal/actortest/AGENTS.md
+++ b/internal/actortest/AGENTS.md
@@ -12,7 +12,7 @@ state+outbox checkpointing.
 
 - `testHarness` / `newTestHarness` — Central test scaffolding: sets up real DB, actor system, delivery store, and outbox publisher.
 - `eventuallyWithOutboxPublish` — Helper that actively triggers `OutboxPublisher.PublishPending()` on every polling iteration, making outbox delivery assertions robust under the race detector and CI scheduler pressure.
-- Timeout constants: `outboxForwardProcessingTimeout` (5s), `outboxDeliveryTimeout` (10s), `durableAskResponseTimeout` (10s).
+- Timeout constants: `outboxForwardProcessingTimeout` (5s), `outboxDeliveryTimeout` (30s — raised from 10s to tolerate CPU starvation under the race detector in CI), `durableAskResponseTimeout` (10s).
 
 ## Relationships
 

--- a/internal/actortest/CLAUDE.md
+++ b/internal/actortest/CLAUDE.md
@@ -12,7 +12,7 @@ state+outbox checkpointing.
 
 - `testHarness` / `newTestHarness` — Central test scaffolding: sets up real DB, actor system, delivery store, and outbox publisher.
 - `eventuallyWithOutboxPublish` — Helper that actively triggers `OutboxPublisher.PublishPending()` on every polling iteration, making outbox delivery assertions robust under the race detector and CI scheduler pressure.
-- Timeout constants: `outboxForwardProcessingTimeout` (5s), `outboxDeliveryTimeout` (10s), `durableAskResponseTimeout` (10s).
+- Timeout constants: `outboxForwardProcessingTimeout` (5s), `outboxDeliveryTimeout` (30s — raised from 10s to tolerate CPU starvation under the race detector in CI), `durableAskResponseTimeout` (10s).
 
 ## Relationships
 

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -26,7 +26,7 @@ server during round participation. These types are used across `round`, `vtxo`,
   `TxProof fn.Option[proof.TxProof]` carries an optional SPV merkle
   inclusion proof for server-side verification of boarding UTXOs without
   requiring the server's own chain source.
-- `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount). `MaxOORLineageVBytes uint32` carries the operator-published cap on the cumulative on-chain vbytes a recipient must publish to claim a VTXO produced by an OOR submit unilaterally. Zero means no cap enforced server-side (clients fall back to a conservative local default).
+- `OperatorTerms` — Server-published round parameters: `PubKey`, `BoardingExitDelay`, `VTXOExitDelay`, `DustLimit`, `MinBoardingAmount`, `MaxBoardingAmount`, `MaxOORLineageVBytes`. Note: `ForfeitScript`, `SweepKey`, and `SweepDelay` were removed — these are now delivered per-round via `round.CommitmentTxBuilt` (`ForfeitKey`, `SweepKey`, `SweepDelay`) so clients agree with the server across operator key rotations. `MaxOORLineageVBytes uint32` carries the operator-published cap on cumulative on-chain vbytes a recipient must publish to claim a VTXO from an OOR submit unilaterally; zero means no cap enforced server-side.
 - `Ancestry` — One rooted commitment-tree fragment contributing ancestry to a VTXO (defined in `lib/types/ancestry.go`). Fields: `TreePath *tree.Tree` (extracted root-to-leaf path), `CommitmentTxID chainhash.Hash`, `InputIndices []uint32` (Ark tx input indices this fragment serves; empty for round-direct VTXOs), `TreeDepth uint32`. Round-direct VTXOs carry a single-element slice; cross-round multi-input OOR VTXOs carry one entry per distinct commitment tx.
 - `MaxAncestryTreeDepth([]Ancestry) int` — Returns the largest `TreeDepth` across a slice; drives worst-case unilateral-exit timing calculations.
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
@@ -50,6 +50,7 @@ server during round participation. These types are used across `round`, `vtxo`,
 - `VTXOOwnerKeyFamily` (44) is the HD key family used for deriving VTXO owner signing keys.
 - `VTXOSigningKeyFamily` (45) is the HD key family used for per-round VTXO MuSig2 signing keys.
 - `JoinRoundAuthMessage` produces a deterministic byte encoding for Schnorr signature verification.
+- `OperatorTerms` does NOT carry `ForfeitScript`, `SweepKey`, or `SweepDelay` — those are per-round values delivered in `round.CommitmentTxBuilt`. Any code constructing VTXOs or forfeit transactions must use the round-delivered keys, not `OperatorTerms`.
 
 ## Deep Docs
 

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -26,7 +26,7 @@ server during round participation. These types are used across `round`, `vtxo`,
   `TxProof fn.Option[proof.TxProof]` carries an optional SPV merkle
   inclusion proof for server-side verification of boarding UTXOs without
   requiring the server's own chain source.
-- `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount). `MaxOORLineageVBytes uint32` carries the operator-published cap on the cumulative on-chain vbytes a recipient must publish to claim a VTXO produced by an OOR submit unilaterally. Zero means no cap enforced server-side (clients fall back to a conservative local default).
+- `OperatorTerms` — Server-published round parameters: `PubKey`, `BoardingExitDelay`, `VTXOExitDelay`, `DustLimit`, `MinBoardingAmount`, `MaxBoardingAmount`, `MaxOORLineageVBytes`. Note: `ForfeitScript`, `SweepKey`, and `SweepDelay` were removed — these are now delivered per-round via `round.CommitmentTxBuilt` (`ForfeitKey`, `SweepKey`, `SweepDelay`) so clients agree with the server across operator key rotations. `MaxOORLineageVBytes uint32` carries the operator-published cap on cumulative on-chain vbytes a recipient must publish to claim a VTXO from an OOR submit unilaterally; zero means no cap enforced server-side.
 - `Ancestry` — One rooted commitment-tree fragment contributing ancestry to a VTXO (defined in `lib/types/ancestry.go`). Fields: `TreePath *tree.Tree` (extracted root-to-leaf path), `CommitmentTxID chainhash.Hash`, `InputIndices []uint32` (Ark tx input indices this fragment serves; empty for round-direct VTXOs), `TreeDepth uint32`. Round-direct VTXOs carry a single-element slice; cross-round multi-input OOR VTXOs carry one entry per distinct commitment tx.
 - `MaxAncestryTreeDepth([]Ancestry) int` — Returns the largest `TreeDepth` across a slice; drives worst-case unilateral-exit timing calculations.
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
@@ -50,6 +50,7 @@ server during round participation. These types are used across `round`, `vtxo`,
 - `VTXOOwnerKeyFamily` (44) is the HD key family used for deriving VTXO owner signing keys.
 - `VTXOSigningKeyFamily` (45) is the HD key family used for per-round VTXO MuSig2 signing keys.
 - `JoinRoundAuthMessage` produces a deterministic byte encoding for Schnorr signature verification.
+- `OperatorTerms` does NOT carry `ForfeitScript`, `SweepKey`, or `SweepDelay` — those are per-round values delivered in `round.CommitmentTxBuilt`. Any code constructing VTXOs or forfeit transactions must use the round-delivered keys, not `OperatorTerms`.
 
 ## Deep Docs
 

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -53,6 +53,13 @@ State transitions and validation rules live under [Invariants](#invariants).
   `MaxMailboxItems=10000`, `MaxMailboxScriptBytes=10000`). Zero fields
   are normalized; codec factories capture limits so deserialization
   enforces them.
+- `normalizeCheckpointOwnerLeaves(policy, inputs)` — rewrites each
+  standard input's checkpoint output owner collaborative leaf to commit to
+  the session checkpoint policy's operator key rather than the spent input
+  VTXO's (potentially older) operator key. Required when the operator
+  rotated keys between VTXO creation and OOR session start; custom-spend
+  inputs are left untouched. Called before building a submit package in
+  `Idle.ProcessEvent`.
 - `emitVTXOSent` / `emitVTXOsReceived` — internal ledger emitters
   (gated on `fn.Some(LedgerSink)`).
 - `NewRetryCallbackRef` — bridges timeout-actor expiry notifications
@@ -263,6 +270,12 @@ State transitions and validation rules live under [Invariants](#invariants).
   with an active outgoing session errors until the outgoing session
   terminates; then the outgoing entry is deleted and an incoming
   session is created in its place.
+- Checkpoint output owner leaf is normalized to the **session** operator
+  key at submit time via `normalizeCheckpointOwnerLeaves`. The spent VTXO
+  may have been created under an older operator key; the checkpoint output
+  and the Ark co-signature are both governed by the session (current)
+  operator key. Custom spend inputs carry their own owner leaf and are
+  untouched.
 - `SigningEffectActor` requests are durable: OOR persists FSM state
   and enqueues the request before signing runs. A restart-duplicate
   that reaches OOR after the FSM has advanced is silently discarded

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -53,6 +53,13 @@ State transitions and validation rules live under [Invariants](#invariants).
   `MaxMailboxItems=10000`, `MaxMailboxScriptBytes=10000`). Zero fields
   are normalized; codec factories capture limits so deserialization
   enforces them.
+- `normalizeCheckpointOwnerLeaves(policy, inputs)` — rewrites each
+  standard input's checkpoint output owner collaborative leaf to commit to
+  the session checkpoint policy's operator key rather than the spent input
+  VTXO's (potentially older) operator key. Required when the operator
+  rotated keys between VTXO creation and OOR session start; custom-spend
+  inputs are left untouched. Called before building a submit package in
+  `Idle.ProcessEvent`.
 - `emitVTXOSent` / `emitVTXOsReceived` — internal ledger emitters
   (gated on `fn.Some(LedgerSink)`).
 - `NewRetryCallbackRef` — bridges timeout-actor expiry notifications
@@ -263,6 +270,12 @@ State transitions and validation rules live under [Invariants](#invariants).
   with an active outgoing session errors until the outgoing session
   terminates; then the outgoing entry is deleted and an incoming
   session is created in its place.
+- Checkpoint output owner leaf is normalized to the **session** operator
+  key at submit time via `normalizeCheckpointOwnerLeaves`. The spent VTXO
+  may have been created under an older operator key; the checkpoint output
+  and the Ark co-signature are both governed by the session (current)
+  operator key. Custom spend inputs carry their own owner leaf and are
+  untouched.
 - `SigningEffectActor` requests are durable: OOR persists FSM state
   and enqueues the request before signing runs. A restart-duplicate
   that reaches OOR after the FSM has advanced is silently discarded

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -25,7 +25,9 @@ state transitions and validation rules live under [Invariants](#invariants).
   `JoinRoundQuoteReceived` (carries reseal `SealPass`), `QuoteAccepted`,
   `QuoteRejected`, `ForfeitCollectionTimedOut`, `ForfeitSignatureResponse`,
   `ConnectorLeafInfo`, `IntentPackage` (atomic delivery of all intent
-  types).
+  types), `CommitmentTxBuilt` (carries per-round operator signing keys
+  `TreeCosignKey`, `ConnectorOperatorKey`, `SweepKey`, `SweepDelay`,
+  `ForfeitKey` that replace global `OperatorTerms` fields).
 - `ClientOutMsg` — sealed outbox interface. Members:
   `JoinRoundAcceptOutbox`, `JoinRoundRejectOutbox`,
   `SubmitForfeitSigRequest`, `StartTimeoutReq`, `CancelTimeoutReq`,
@@ -92,6 +94,15 @@ state transitions and validation rules live under [Invariants](#invariants).
 
 ### Misc
 
+- `validateVTXOTreeBinding(unsignedTx, vtxoTrees)` — proves that each
+  operator-supplied VTXO tree is rooted in the round's commitment tx outputs
+  BEFORE any path validation or co-signing (darepo-client#680). A
+  self-consistent but mis-rooted tree transitions to `ClientFailedState`
+  (non-recoverable).
+- `confirmationWatchScript(tx, vtxoTrees)` — selects the commitment tx
+  output pkScript to watch for confirmation: uses the validated batch output
+  that carries this client's funds, falling back to output 0 when no VTXO
+  trees exist.
 - `TimeoutPhase` (`fsm_timeouts.go`) — `TimeoutPhaseForfeitCollection`
   (forfeit-signature collection window) and `TimeoutPhaseRegistration`
   (IntentSentState admission window; on expiry the FSM fails the round
@@ -153,6 +164,20 @@ state transitions and validation rules live under [Invariants](#invariants).
 
 ## Invariants
 
+- Per-round operator keys: `CommitmentTxBuilt` delivers `TreeCosignKey`
+  (VTXO tree MuSig2 cosigner), `ConnectorOperatorKey` (connector tree
+  builder), `SweepKey` (VTXO tree sweep leaf), `SweepDelay`
+  (batch-wide timelock), and `ForfeitKey` (forfeit penalty output BIP-86
+  key-spend target) alongside the commitment tx. These replace the
+  corresponding global `OperatorTerms` fields and ensure agreement across
+  operator key rotations. Nil fields fall back to the global operator key
+  for backwards compatibility with older servers.
+- `ValidateDelayParameters` (sweep delay vs VTXO exit delay security check)
+  runs per round in `CommitmentTxReceivedState.ProcessEvent` using the
+  round's `SweepDelay`, not at actor construction.
+- VTXO tree path validation uses `TreeCosignKey` (round-local) not the
+  global operator pubkey. Connector ancestry validation uses
+  `ConnectorOperatorKey`.
 - Tree signatures are validated **before** boarding input signatures
   are released (security checkpoint at `InputSigSent`).
 - Forfeit signatures are collected **after** VTXO tree signing

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -25,7 +25,9 @@ state transitions and validation rules live under [Invariants](#invariants).
   `JoinRoundQuoteReceived` (carries reseal `SealPass`), `QuoteAccepted`,
   `QuoteRejected`, `ForfeitCollectionTimedOut`, `ForfeitSignatureResponse`,
   `ConnectorLeafInfo`, `IntentPackage` (atomic delivery of all intent
-  types).
+  types), `CommitmentTxBuilt` (carries per-round operator signing keys
+  `TreeCosignKey`, `ConnectorOperatorKey`, `SweepKey`, `SweepDelay`,
+  `ForfeitKey` that replace global `OperatorTerms` fields).
 - `ClientOutMsg` — sealed outbox interface. Members:
   `JoinRoundAcceptOutbox`, `JoinRoundRejectOutbox`,
   `SubmitForfeitSigRequest`, `StartTimeoutReq`, `CancelTimeoutReq`,
@@ -92,6 +94,15 @@ state transitions and validation rules live under [Invariants](#invariants).
 
 ### Misc
 
+- `validateVTXOTreeBinding(unsignedTx, vtxoTrees)` — proves that each
+  operator-supplied VTXO tree is rooted in the round's commitment tx outputs
+  BEFORE any path validation or co-signing (darepo-client#680). A
+  self-consistent but mis-rooted tree transitions to `ClientFailedState`
+  (non-recoverable).
+- `confirmationWatchScript(tx, vtxoTrees)` — selects the commitment tx
+  output pkScript to watch for confirmation: uses the validated batch output
+  that carries this client's funds, falling back to output 0 when no VTXO
+  trees exist.
 - `TimeoutPhase` (`fsm_timeouts.go`) — `TimeoutPhaseForfeitCollection`
   (forfeit-signature collection window) and `TimeoutPhaseRegistration`
   (IntentSentState admission window; on expiry the FSM fails the round
@@ -153,6 +164,20 @@ state transitions and validation rules live under [Invariants](#invariants).
 
 ## Invariants
 
+- Per-round operator keys: `CommitmentTxBuilt` delivers `TreeCosignKey`
+  (VTXO tree MuSig2 cosigner), `ConnectorOperatorKey` (connector tree
+  builder), `SweepKey` (VTXO tree sweep leaf), `SweepDelay`
+  (batch-wide timelock), and `ForfeitKey` (forfeit penalty output BIP-86
+  key-spend target) alongside the commitment tx. These replace the
+  corresponding global `OperatorTerms` fields and ensure agreement across
+  operator key rotations. Nil fields fall back to the global operator key
+  for backwards compatibility with older servers.
+- `ValidateDelayParameters` (sweep delay vs VTXO exit delay security check)
+  runs per round in `CommitmentTxReceivedState.ProcessEvent` using the
+  round's `SweepDelay`, not at actor construction.
+- VTXO tree path validation uses `TreeCosignKey` (round-local) not the
+  global operator pubkey. Connector ancestry validation uses
+  `ConnectorOperatorKey`.
 - Tree signatures are validated **before** boarding input signatures
   are released (security checkpoint at `InputSigSent`).
 - Forfeit signatures are collected **after** VTXO tree signing

--- a/sdk/ark/AGENTS.md
+++ b/sdk/ark/AGENTS.md
@@ -32,7 +32,11 @@ transport, without duplicating Ark runtime behavior.
   already-connected `daemonrpc.DaemonServiceClient` and a caller-supplied
   `closeFn`.
 - `Info` / `ServerInfo` / `Seed` / `WalletInitResult` — SDK-owned typed
-  models for daemon status and wallet bootstrap flows.
+  models for daemon status and wallet bootstrap flows. `ServerInfo` carries
+  `PubKey`, `BoardingExitDelay`, `VTXOExitDelay`, `DustLimit`,
+  `MinBoardingAmount`, `MaxBoardingAmount`; `ForfeitScript`, `SweepKey`,
+  and `SweepDelay` were removed — those are now per-round values delivered
+  via `CommitmentTxBuilt`.
 - `VTXOInfo` — Typed VTXO view (Outpoint, AmountSat, Status, BatchExpiry,
   RoundID, CreatedHeight, etc.) returned by `ListLiveVTXOs` /
   `ListSpentVTXOs`.
@@ -89,7 +93,13 @@ transport, without duplicating Ark runtime behavior.
   it does not own the caller's `DaemonServer` runtime. `Close()` tears down
   only the private transport.
 - `ServerInfo` is a bootstrap-time operator-terms snapshot; refresh after
-  reconnect is not wired through yet.
+  reconnect is not wired through yet. It does NOT carry `ForfeitScript`,
+  `SweepKey`, or `SweepDelay` — callers must not assume those are global
+  constants; they arrive per-round from the daemon.
+- `SendOORWithPolicyAndKeyDetails` and `SendOORWithCustomInputs` use
+  `req.Recipients` (a list with one element) rather than the former
+  singular `req.Recipient`. `OORSendResult.RecipientOutpoint` is taken
+  from `resp.RecipientOutpoints[0]`.
 - Pre-1.0, some methods intentionally return `daemonrpc` protobuf types
   directly. Those passthrough APIs are not yet treated as stable SDK-owned
   models.

--- a/sdk/ark/CLAUDE.md
+++ b/sdk/ark/CLAUDE.md
@@ -32,7 +32,11 @@ transport, without duplicating Ark runtime behavior.
   already-connected `daemonrpc.DaemonServiceClient` and a caller-supplied
   `closeFn`.
 - `Info` / `ServerInfo` / `Seed` / `WalletInitResult` — SDK-owned typed
-  models for daemon status and wallet bootstrap flows.
+  models for daemon status and wallet bootstrap flows. `ServerInfo` carries
+  `PubKey`, `BoardingExitDelay`, `VTXOExitDelay`, `DustLimit`,
+  `MinBoardingAmount`, `MaxBoardingAmount`; `ForfeitScript`, `SweepKey`,
+  and `SweepDelay` were removed — those are now per-round values delivered
+  via `CommitmentTxBuilt`.
 - `VTXOInfo` — Typed VTXO view (Outpoint, AmountSat, Status, BatchExpiry,
   RoundID, CreatedHeight, etc.) returned by `ListLiveVTXOs` /
   `ListSpentVTXOs`.
@@ -89,7 +93,13 @@ transport, without duplicating Ark runtime behavior.
   it does not own the caller's `DaemonServer` runtime. `Close()` tears down
   only the private transport.
 - `ServerInfo` is a bootstrap-time operator-terms snapshot; refresh after
-  reconnect is not wired through yet.
+  reconnect is not wired through yet. It does NOT carry `ForfeitScript`,
+  `SweepKey`, or `SweepDelay` — callers must not assume those are global
+  constants; they arrive per-round from the daemon.
+- `SendOORWithPolicyAndKeyDetails` and `SendOORWithCustomInputs` use
+  `req.Recipients` (a list with one element) rather than the former
+  singular `req.Recipient`. `OORSendResult.RecipientOutpoint` is taken
+  from `resp.RecipientOutpoints[0]`.
 - Pre-1.0, some methods intentionally return `daemonrpc` protobuf types
   directly. Those passthrough APIs are not yet treated as stable SDK-owned
   models.

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -85,7 +85,10 @@ default builds avoid the swap executor's dependency graph.
 - `WalletEntry.id` is the stable canonical id for SEND-invoice and
   RECV (Lightning payment_hash) across the entire pending → terminal
   lifecycle. EXIT and DEPOSIT rows do not yet share an id between
-  pending and confirmed in v1; see `doc.go`.
+  pending and confirmed in v1; see `doc.go`. Cooperative leave EXIT rows
+  are shown as COMPLETE once the source VTXO is terminally forfeited —
+  detected via `collectForfeitedVTXOOutpoints` during `listActivity`. After
+  daemon restart the counterparty/note field cannot be reconstructed.
 - Onchain SEND is routed through `RPCServer.SendOnChain` which delegates to
   `wallet.SendOnChainRequest`. Two modes: **sweep-all** (non-empty
   `SweepOutpoints` — drains those VTXOs exactly, no change, leave output

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -85,7 +85,10 @@ default builds avoid the swap executor's dependency graph.
 - `WalletEntry.id` is the stable canonical id for SEND-invoice and
   RECV (Lightning payment_hash) across the entire pending → terminal
   lifecycle. EXIT and DEPOSIT rows do not yet share an id between
-  pending and confirmed in v1; see `doc.go`.
+  pending and confirmed in v1; see `doc.go`. Cooperative leave EXIT rows
+  are shown as COMPLETE once the source VTXO is terminally forfeited —
+  detected via `collectForfeitedVTXOOutpoints` during `listActivity`. After
+  daemon restart the counterparty/note field cannot be reconstructed.
 - Onchain SEND is routed through `RPCServer.SendOnChain` which delegates to
   `wallet.SendOnChainRequest`. Two modes: **sweep-all** (non-empty
   `SweepOutpoints` — drains those VTXOs exactly, no change, leave output

--- a/systest/AGENTS.md
+++ b/systest/AGENTS.md
@@ -5,6 +5,14 @@
 System-level end-to-end integration tests exercising the full daemon with real
 Bitcoin/LND backends via the test harness.
 
+## Key Test Infrastructure
+
+- `fakeMailboxServer` — in-process mailbox stub capturing envelopes for
+  assertion. Captures both `roundpb.JoinRoundRequest` envelopes and, since
+  darepo-client#708, `oorpb.SubmitPackageRequest` envelopes via
+  `recordOORSubmitPackage`. Tests can assert on the real mailbox payloads
+  darepod emits without a live server.
+
 ## Relationships
 
 - **Depends on**: `harness` (test environment), `darepod` (daemon under test).

--- a/systest/CLAUDE.md
+++ b/systest/CLAUDE.md
@@ -5,6 +5,14 @@
 System-level end-to-end integration tests exercising the full daemon with real
 Bitcoin/LND backends via the test harness.
 
+## Key Test Infrastructure
+
+- `fakeMailboxServer` — in-process mailbox stub capturing envelopes for
+  assertion. Captures both `roundpb.JoinRoundRequest` envelopes and, since
+  darepo-client#708, `oorpb.SubmitPackageRequest` envelopes via
+  `recordOORSubmitPackage`. Tests can assert on the real mailbox payloads
+  darepod emits without a live server.
+
 ## Relationships
 
 - **Depends on**: `harness` (test environment), `darepod` (daemon under test).


### PR DESCRIPTION
Automated nightly doc-gardening sweep for 2026-06-11.

## Summary

Updated 11 per-package CLAUDE.md/AGENTS.md pairs to reflect Go source changes since the last merged sweep (9ceba73).

Key areas:
- **db**: New `InternalKeyQuerier` interface + `internal_keys` registry table normalizes wallet key storage — `boarding_addresses`, `vtxos`, `round_vtxo_requests`, and `owned_receive_scripts` now reference `internal_keys.id` via FK instead of inlining the pubkey/family/index triple.
- **round**: Per-round operator keys (`TreeCosignKey`, `SweepKey`, `SweepDelay`, `ForfeitKey`, `ConnectorOperatorKey`) delivered with each `CommitmentTxBuilt` event, replacing global `OperatorTerms` fields. VTXO tree binding validated before co-signing.
- **lib/types**: `OperatorTerms` drops `ForfeitScript`, `SweepKey`, `SweepDelay` — these are now per-round.
- **oor**: `normalizeCheckpointOwnerLeaves` fixes checkpoint output owner leaf for operator key rotations.
- **darepod/sdk/ark/cli**: `SendOOR` API migrated from singular `Recipient` to plural `Recipients`.
- **chainsource**: `BlockEpochActor` auto-reconnect backoff configuration.
- **swapwallet**: Cooperative leave EXIT rows shown as COMPLETE once source VTXO is terminally forfeited.

## Review

Please review the updated `CLAUDE.md`/`AGENTS.md` diffs in each package directory listed above, and the `ARCHITECTURE.md` (no changes needed this sweep).

Generated by `.claude/skills/doc-gardening` — see workflow run for full log.