### PR TITLE
harness: add neutrino chain-backend option for lnd nodes

### DIFF
--- a/harness/harness.go
+++ b/harness/harness.go
@@ -76,6 +76,16 @@ const (
 	// for each harness instance to ensure isolation between test runs.
 	networkPrefix = "ark-harness-"
 
+	// LNDChainBackendBitcoind backs a harness lnd node with the regtest
+	// bitcoind over RPC + ZMQ. This is the default.
+	LNDChainBackendBitcoind = "bitcoind"
+
+	// LNDChainBackendNeutrino backs a harness lnd node with neutrino,
+	// syncing and broadcasting over the regtest bitcoind's P2P interface
+	// (which serves compact block filters). Used to exercise lnd's native
+	// SPV / 1p1c broadcast path.
+	LNDChainBackendNeutrino = "neutrino"
+
 	// BitcoindRPCUser is the RPC username for bitcoind in regtest mode.
 	BitcoindRPCUser = "admin1"
 
@@ -2155,7 +2165,7 @@ func (h *Harness) bitcoindSendToAddress(address string, amount float64) string {
 // startLND launches an lnd container and waits until its gRPC is responsive
 // and TLS cert and admin macaroon are available.
 func (h *Harness) startLND() *LndInstance {
-	inst := h.startLNDInstance("lnd", h.lndDataDir)
+	inst := h.startLNDInstance("lnd", h.lndDataDir, LNDChainBackendBitcoind)
 	h.lnd = inst.Resource
 	h.LNDGRPCPort = inst.GRPCPort
 	h.LNDRestPort = inst.RESTPort
@@ -2165,7 +2175,9 @@ func (h *Harness) startLND() *LndInstance {
 	return inst
 }
 
-func (h *Harness) startLNDInstance(name, dataDir string) *LndInstance {
+func (h *Harness) startLNDInstance(name, dataDir,
+	chainBackend string) *LndInstance {
+
 	h.T.Helper()
 
 	require.NoError(h.T, os.MkdirAll(dataDir, 0o755))
@@ -2178,6 +2190,7 @@ func (h *Harness) startLNDInstance(name, dataDir string) *LndInstance {
 		group:        h.group,
 		image:        imageRepo(h.opts.LNDImage),
 		tag:          imageTag(h.opts.LNDImage),
+		chainBackend: chainBackend,
 	})
 
 	inst := &LndInstance{
@@ -2325,6 +2338,15 @@ func loadClientTLSCredentials(tlsPath string) (credentials.TransportCredentials,
 // StartAdditionalLND launches an extra LND instance with the given name and
 // returns its handle.
 func (h *Harness) StartAdditionalLND(name string) *LndInstance {
+	return h.StartAdditionalLNDWithBackend(name, LNDChainBackendBitcoind)
+}
+
+// StartAdditionalLNDWithBackend launches an extra LND instance with the given
+// name and chain backend (LNDChainBackendBitcoind or LNDChainBackendNeutrino)
+// and returns its handle.
+func (h *Harness) StartAdditionalLNDWithBackend(name,
+	chainBackend string) *LndInstance {
+
 	h.T.Helper()
 
 	if name == "" {
@@ -2336,7 +2358,7 @@ func (h *Harness) StartAdditionalLND(name string) *LndInstance {
 	}
 
 	dataDir := filepath.Join(h.artifactsDir, name)
-	inst := h.startLNDInstance(name, dataDir)
+	inst := h.startLNDInstance(name, dataDir, chainBackend)
 	h.initAndWaitLNDInstance(inst)
 	h.extraLNDs[name] = inst
 

--- a/harness/tapd_harness.go
+++ b/harness/tapd_harness.go
@@ -74,6 +74,12 @@ type lndConfig struct {
 	group        string
 	image        string
 	tag          string
+
+	// chainBackend selects lnd's chain backend: LNDChainBackendBitcoind
+	// (default) or LNDChainBackendNeutrino. Neutrino backs lnd via SPV over
+	// the regtest bitcoind's P2P + compact filters, exercising lnd's native
+	// 1p1c broadcast path instead of bitcoind's synchronous mempool checks.
+	chainBackend string
 }
 
 // tapdConfig holds the configuration for starting a tapd container.
@@ -151,14 +157,6 @@ func (h *Harness) startLNDContainer(cfg lndConfig) *dockertest.Resource {
 		fmt.Sprintf("--lnddir=%s", lndDirInContainer),
 		"--bitcoin.active",
 		"--bitcoin.regtest",
-		"--bitcoin.node=bitcoind",
-		fmt.Sprintf("--bitcoind.rpchost=%s:18443", cfg.bitcoindName),
-		fmt.Sprintf("--bitcoind.rpcuser=%s", BitcoindRPCUser),
-		fmt.Sprintf("--bitcoind.rpcpass=%s", BitcoindRPCPass),
-		fmt.Sprintf("--bitcoind.zmqpubrawblock=tcp://%s:28332",
-			cfg.bitcoindName),
-		fmt.Sprintf("--bitcoind.zmqpubrawtx=tcp://%s:28333",
-			cfg.bitcoindName),
 		"--rpclisten=0.0.0.0:10009",
 		"--restlisten=0.0.0.0:8080",
 		"--listen=0.0.0.0:9735",
@@ -169,6 +167,33 @@ func (h *Harness) startLNDContainer(cfg lndConfig) *dockertest.Resource {
 		"--accept-keysend",
 		"--protocol.option-scid-alias",
 		"--protocol.zero-conf",
+	}
+
+	// Append the chain-backend-specific flags. Neutrino syncs and
+	// broadcasts over the regtest bitcoind's P2P interface (which serves
+	// compact block filters), so lnd uses its SPV broadcast path; this is
+	// what lets us observe whether an lnd-backed daemon can relay zero-fee
+	// v3 anchor packages via 1p1c instead of a direct bitcoind submitter.
+	switch cfg.chainBackend {
+	case LNDChainBackendNeutrino:
+		cmd = append(
+			cmd, "--bitcoin.node=neutrino",
+			fmt.Sprintf("--neutrino.connect=%s:18444",
+				cfg.bitcoindName),
+		)
+
+	default:
+		cmd = append(
+			cmd, "--bitcoin.node=bitcoind",
+			fmt.Sprintf("--bitcoind.rpchost=%s:18443",
+				cfg.bitcoindName),
+			fmt.Sprintf("--bitcoind.rpcuser=%s", BitcoindRPCUser),
+			fmt.Sprintf("--bitcoind.rpcpass=%s", BitcoindRPCPass),
+			fmt.Sprintf("--bitcoind.zmqpubrawblock=tcp://%s:28332",
+				cfg.bitcoindName),
+			fmt.Sprintf("--bitcoind.zmqpubrawtx=tcp://%s:28333",
+				cfg.bitcoindName),
+		)
 	}
 
 	lndHostDir, err := filepath.Abs(cfg.dataDir)


### PR DESCRIPTION
## Summary

Adds a neutrino chain-backend option for the harness's lnd nodes, so the
unilateral-exit package-relay itests can exercise an **lnd-on-neutrino**
client (P2P 1p1c relay) in addition to the existing bitcoind-backed setup.

## Background / scope change

This PR previously also carried the lnd `WalletKit.SubmitPackage` consumer
(`lndsubmitter`) plus fork pins for lnd/lndclient/btcwallet. That approach
has been **descoped**: only an lnd-on-bitcoind daemon ever needed package
*submission*, and that case is already served by the existing `bitcoindrpc`
package submitter (point darepod at the same bitcoind lnd uses). Every other
backend relays via the existing individual-broadcast **1p1c** fallback, which
needs no new code:

- **lnd-on-neutrino / embedded neutrino** — broadcast parent + CPFP child
  individually; Core v28+ 1p1c P2P relay carries the zero-fee parent.
- **lnd-on-bitcoind** — `bitcoindrpc` `PackageSubmitter` → bitcoind
  `submitpackage` (already on `main`, wired by the harness and `cmd/darepod`).

So the lnd `SubmitPackage` RPC stack (btcd / btcwallet / lnd / lndclient PRs)
becomes a *later, purely-additive ergonomic upgrade* (a pure-lnd operator
wouldn't configure a separate bitcoind endpoint) rather than a correctness
requirement. The lwwallet `/txs/package` relay method that was also bundled
here belongs with the Esplora work, not this PR.

What remains here is just the harness enabler for the lnd-on-neutrino test
matrix row.