### PR TITLE
docs: nightly doc-gardening sweep 2026-06-12

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -73,6 +73,7 @@ package may import from a higher layer.
 | [`rpc/walletdkrpc`](rpc/walletdkrpc/) | Highest-level gRPC surface: `WalletService` with the seven core wallet verbs. Composes `daemonrpc` and `rpc/swapclientrpc` server-side via `swapwallet` |
 | [`rpc/restclient`](rpc/restclient/) | HTTP/protoJSON transport adapter: `Client`, `StreamClient[T]`, and per-service factory functions implementing the same gRPC stub interfaces over REST |
 | [`daemonrpc`](daemonrpc/) | Daemon gRPC API definitions |
+| [`swaprpc`](swaprpc/) | External swap-server gRPC API definitions (`SwapService`): channel allocation, in-swap creation, refund authorization, and out-swap HTLC acknowledgement |
 
 ### Layer 4: Testing & Tooling
 

--- a/arkrpc/AGENTS.md
+++ b/arkrpc/AGENTS.md
@@ -36,3 +36,6 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
   reproduce the original tree (excluding derived `FinalKey` fields).
 - Child iteration during flattening is sorted by output index for
   deterministic serialization.
+- `GetInfoResponse.ServerInfo` no longer carries `ForfeitScript`,
+  `SweepKey`, or `SweepDelay` (field numbers 4-6 are unused). These
+  values are now delivered per-round in `round.v1.ClientBatchInfo`.

--- a/arkrpc/CLAUDE.md
+++ b/arkrpc/CLAUDE.md
@@ -36,3 +36,6 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
   reproduce the original tree (excluding derived `FinalKey` fields).
 - Child iteration during flattening is sorted by output index for
   deterministic serialization.
+- `GetInfoResponse.ServerInfo` no longer carries `ForfeitScript`,
+  `SweepKey`, or `SweepDelay` (field numbers 4-6 are unused). These
+  values are now delivered per-round in `round.v1.ClientBatchInfo`.

--- a/chainsource/AGENTS.md
+++ b/chainsource/AGENTS.md
@@ -32,6 +32,9 @@ communication alongside the raw registration API.
 - `EpochMsg` / `EpochResp` — Sealed interfaces for block-epoch sub-actor.
 - `SubscribeBlocksRequest/Response`, `UnsubscribeBlocksRequest/Response` —
   Block subscription lifecycle.
+- `BlockEpochConfig` — Config for block epoch monitoring. `ReconnectBackoff`
+  and `MaxReconnectBackoff` control exponential backoff delays when the
+  backend stream closes unexpectedly (e.g., after an LND restart).
 - `ConfRegistration` / `SpendRegistration` / `BlockRegistration` — Structs with
   buffered notification channels and a `Cancel()` function.
 - `ConfirmationEvent`, `SpendEvent`, `BlockEpoch` — Notification payload types.
@@ -56,6 +59,10 @@ communication alongside the raw registration API.
 - Confirmation sub-actors support two notification modes: Future-based (blocking
   await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
   mode when blocking inside a durable actor transaction is unsafe.
+- Block epoch sub-actors reconnect automatically when the backend stream closes
+  (e.g., after a remote node restart). Reconnection uses exponential backoff
+  configured via `BlockEpochConfig.ReconnectBackoff` and `MaxReconnectBackoff`
+  so the daemon never silently misses confirmations after a stream drop.
 
 ## Deep Docs
 

--- a/chainsource/CLAUDE.md
+++ b/chainsource/CLAUDE.md
@@ -32,6 +32,9 @@ communication alongside the raw registration API.
 - `EpochMsg` / `EpochResp` — Sealed interfaces for block-epoch sub-actor.
 - `SubscribeBlocksRequest/Response`, `UnsubscribeBlocksRequest/Response` —
   Block subscription lifecycle.
+- `BlockEpochConfig` — Config for block epoch monitoring. `ReconnectBackoff`
+  and `MaxReconnectBackoff` control exponential backoff delays when the
+  backend stream closes unexpectedly (e.g., after an LND restart).
 - `ConfRegistration` / `SpendRegistration` / `BlockRegistration` — Structs with
   buffered notification channels and a `Cancel()` function.
 - `ConfirmationEvent`, `SpendEvent`, `BlockEpoch` — Notification payload types.
@@ -56,6 +59,10 @@ communication alongside the raw registration API.
 - Confirmation sub-actors support two notification modes: Future-based (blocking
   await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
   mode when blocking inside a durable actor transaction is unsafe.
+- Block epoch sub-actors reconnect automatically when the backend stream closes
+  (e.g., after a remote node restart). Reconnection uses exponential backoff
+  configured via `BlockEpochConfig.ReconnectBackoff` and `MaxReconnectBackoff`
+  so the daemon never silently misses confirmations after a stream drop.
 
 ## Deep Docs
 

--- a/daemonrpc/AGENTS.md
+++ b/daemonrpc/AGENTS.md
@@ -5,10 +5,27 @@
 Daemon gRPC API definitions for wallet operations and round queries. Proto
 source: `daemonrpc/daemon.proto`.
 
+## Key Types
+
+- `ServerInfo` — Operator terms snapshot: `OperatorPubkey`,
+  `BoardingExitDelay`, `VtxoExitDelay`, `DustLimit`, `FeeRate`,
+  `MinBoardingAmount`, `MaxBoardingAmount`, `MinConfirmations`,
+  `MinOperatorFee`. Note: `ForfeitScript`, `SweepKey`, and `SweepDelay`
+  (field numbers 4-6) were removed; these values are now delivered
+  per-round in `round.v1.ClientBatchInfo`.
+- `SendOORRequest` — OOR transfer request. `Recipients` is a repeated
+  `Output` field supporting multiple recipients in a single transfer.
+  `DryRun`, `CustomInputs`, and `IdempotencyKey` remain unchanged.
+- `SendOORResponse` — OOR transfer response. `RecipientOutpoints` is a
+  repeated string (one per requested recipient, in order). Individual
+  entries may be empty if the daemon cannot resolve the outpoint from
+  the finalized Ark transaction.
+
 ## Relationships
 
 - **Depends on**: nothing (proto definitions).
-- **Depended on by**: `darepod` (implements services), `cmd/darepocli` (uses generated clients).
+- **Depended on by**: `darepod` (implements services), `cmd/darepocli`
+  (uses generated clients), `sdk/ark` (SDK facade).
 
 ## Invariants
 

--- a/daemonrpc/CLAUDE.md
+++ b/daemonrpc/CLAUDE.md
@@ -5,10 +5,27 @@
 Daemon gRPC API definitions for wallet operations and round queries. Proto
 source: `daemonrpc/daemon.proto`.
 
+## Key Types
+
+- `ServerInfo` — Operator terms snapshot: `OperatorPubkey`,
+  `BoardingExitDelay`, `VtxoExitDelay`, `DustLimit`, `FeeRate`,
+  `MinBoardingAmount`, `MaxBoardingAmount`, `MinConfirmations`,
+  `MinOperatorFee`. Note: `ForfeitScript`, `SweepKey`, and `SweepDelay`
+  (field numbers 4-6) were removed; these values are now delivered
+  per-round in `round.v1.ClientBatchInfo`.
+- `SendOORRequest` — OOR transfer request. `Recipients` is a repeated
+  `Output` field supporting multiple recipients in a single transfer.
+  `DryRun`, `CustomInputs`, and `IdempotencyKey` remain unchanged.
+- `SendOORResponse` — OOR transfer response. `RecipientOutpoints` is a
+  repeated string (one per requested recipient, in order). Individual
+  entries may be empty if the daemon cannot resolve the outpoint from
+  the finalized Ark transaction.
+
 ## Relationships
 
 - **Depends on**: nothing (proto definitions).
-- **Depended on by**: `darepod` (implements services), `cmd/darepocli` (uses generated clients).
+- **Depended on by**: `darepod` (implements services), `cmd/darepocli`
+  (uses generated clients), `sdk/ark` (SDK facade).
 
 ## Invariants
 

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -15,7 +15,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   `Backend`).
 - `BoardingStore` / `BoardingWalletStore` — interface + concrete
   sqlc-backed store for boarding addresses, intents, and the aggregate
-  sweep lifecycle (consumed by `wallet.BoardingStore`). Sweep ops:
+  sweep lifecycle (consumed by `wallet.BoardingStore`). Embeds
+  `InternalKeyQuerier` so boarding address inserts register the client
+  wallet key in the shared `internal_keys` registry within the same
+  transaction. Sweep ops:
   `Create/MarkPublished/MarkFailed/List/ListPending/MarkInputSpent`.
 - `NewBoardingSweep` / `BoardingSweepRecord` /
   `BoardingSweepInputRecord` — control-plane domain types. Sweep

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -15,7 +15,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   `Backend`).
 - `BoardingStore` / `BoardingWalletStore` — interface + concrete
   sqlc-backed store for boarding addresses, intents, and the aggregate
-  sweep lifecycle (consumed by `wallet.BoardingStore`). Sweep ops:
+  sweep lifecycle (consumed by `wallet.BoardingStore`). Embeds
+  `InternalKeyQuerier` so boarding address inserts register the client
+  wallet key in the shared `internal_keys` registry within the same
+  transaction. Sweep ops:
   `Create/MarkPublished/MarkFailed/List/ListPending/MarkInputSpent`.
 - `NewBoardingSweep` / `BoardingSweepRecord` /
   `BoardingSweepInputRecord` — control-plane domain types. Sweep

--- a/db/actordelivery/sqlc/AGENTS.md
+++ b/db/actordelivery/sqlc/AGENTS.md
@@ -1,0 +1,34 @@
+# db/actordelivery/sqlc
+
+## Purpose
+
+Generated type-safe SQL query layer for durable actor mailbox persistence.
+Produced by `make sqlc` from query files under `db/actordelivery/`. Uses a
+dedicated migration table separate from the main client schema to allow
+independent versioning.
+
+## Key Generated Types
+
+- `ActorDeliveryQueries` interface — All actor-delivery SQL operations:
+  mailbox message enqueue/lease/ack/nack/extend/expire; ask-result
+  insert/fetch; outbox claim/complete/fail; deduplication; FSM
+  checkpoint persist/fetch; dead-letter queue insert/list; cleanup.
+- Row types: `MailboxMessage`, `AskResult`, `OutboxMessage`,
+  `FsmCheckpoint`, `DeadLetterMessage`.
+
+## Relationships
+
+- **Depends on**: SQLite / PostgreSQL drivers; standard library only.
+- **Depended on by**: `db/actordelivery` (wraps in `TxActorDeliveryStore`
+  and `TxAwareActorDeliveryStore`).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make sqlc`.
+- Query files and migration SQL live in `db/actordelivery/`.
+
+## Deep Docs
+
+- [db/actordelivery/CLAUDE.md](../CLAUDE.md) — Parent package overview.
+- [docs/durable_actor_architecture.md](../../../docs/durable_actor_architecture.md)
+  — Durable actor internals.

--- a/db/actordelivery/sqlc/CLAUDE.md
+++ b/db/actordelivery/sqlc/CLAUDE.md
@@ -1,0 +1,34 @@
+# db/actordelivery/sqlc
+
+## Purpose
+
+Generated type-safe SQL query layer for durable actor mailbox persistence.
+Produced by `make sqlc` from query files under `db/actordelivery/`. Uses a
+dedicated migration table separate from the main client schema to allow
+independent versioning.
+
+## Key Generated Types
+
+- `ActorDeliveryQueries` interface — All actor-delivery SQL operations:
+  mailbox message enqueue/lease/ack/nack/extend/expire; ask-result
+  insert/fetch; outbox claim/complete/fail; deduplication; FSM
+  checkpoint persist/fetch; dead-letter queue insert/list; cleanup.
+- Row types: `MailboxMessage`, `AskResult`, `OutboxMessage`,
+  `FsmCheckpoint`, `DeadLetterMessage`.
+
+## Relationships
+
+- **Depends on**: SQLite / PostgreSQL drivers; standard library only.
+- **Depended on by**: `db/actordelivery` (wraps in `TxActorDeliveryStore`
+  and `TxAwareActorDeliveryStore`).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make sqlc`.
+- Query files and migration SQL live in `db/actordelivery/`.
+
+## Deep Docs
+
+- [db/actordelivery/CLAUDE.md](../CLAUDE.md) — Parent package overview.
+- [docs/durable_actor_architecture.md](../../../docs/durable_actor_architecture.md)
+  — Durable actor internals.

--- a/db/sqlc/AGENTS.md
+++ b/db/sqlc/AGENTS.md
@@ -1,0 +1,76 @@
+# db/sqlc
+
+## Purpose
+
+Generated type-safe SQL query layer for darepo-client's main persistent
+store. Produced by `make sqlc` from query files in `db/sqlc/queries/` and
+schema files in `db/sqlc/schemas/`. Supports both SQLite and PostgreSQL.
+Never edit generated `*.go` files directly.
+
+## Key Generated Types
+
+- `Querier` interface — Top-level generated interface with all query methods
+  grouped by domain.
+- **Boarding**: `BoardingAddress`, `BoardingIntent`, `BoardingAddrRow`,
+  `BoardingIntentRow`, `BoardingSweep`, `BoardingSweepInput`,
+  `NewAddrParams`, `NewIntentParams`, `InsertBoardingSweepParams`.
+- **Rounds**: `Round`, `RoundRow`, `UpdateRoundStatusParams`.
+- **VTXOs**: `Vtxo`, `VtxoRow`, `VtxoAncestryPath`.
+- **OOR Artifacts**: `OorPackage`, `OorVtxo`, `OwnedReceiveScript`.
+- **Fee Accounting**: `LedgerEntry`, `Account`,
+  `InsertClientLedgerEntryParams`.
+- **Unilateral Exit**: `UnilateralExitJob`, `UpsertUnilateralExitJobParams`.
+- **vHTLC Recovery**: `VhtlcRecoveryJob`.
+- **Spending Reservations**: `SpendingReservation`,
+  `UpsertSpendingReservationParams`.
+- **Internal Keys**: `InternalKey`, `InsertInternalKeyParams` — shared
+  registry for client wallet keys referenced by FK from boarding, VTXO,
+  OOR, and round tables.
+- **Chain Info**: `ChainInfo`.
+
+## Migration History (17 versions)
+
+| Version | Table(s) Added |
+|---------|----------------|
+| 000001 | `chain_info` |
+| 000002 | `boarding_addresses`, `boarding_intents`, `boarding_statuses` |
+| 000003 | `rounds`, `round_statuses` |
+| 000004 | `oor_packages`, `oor_vtxos`, `owned_receive_scripts` + enum tables |
+| 000005 | `chain_depth` column on `vtxos` |
+| 000006 | `accounts`, `account_types`, `ledger_entries` |
+| 000007 | `wallet_utxo_log` |
+| 000008 | `unilateral_exit_jobs` |
+| 000009 | `vtxo_ancestry_paths` (replaces scalar tree_path) |
+| 000010 | `tx_proof` BLOB on `boarding_intents` |
+| 000011 | `boarding_sweeps`, `boarding_sweep_inputs` |
+| 000012 | `boarding_sweep_fee_paid` ledger event type |
+| 000013 | `pending_board_requests` |
+| 000014 | `chain_txid`/`chain_vout`/`confirmation_height` on `ledger_entries` |
+| 000015 | `vhtlc_recovery_jobs` |
+| 000016 | `exit_policy_kind`/`exit_policy_ref` on `unilateral_exit_jobs` |
+| 000017 | `spending_reservations` |
+
+`LatestMigrationVersion = 17`.
+
+## Relationships
+
+- **Depends on**: SQLite (`modernc.org/sqlite`) and PostgreSQL (`lib/pq`)
+  drivers; standard library only.
+- **Depended on by**: `db` (wraps generated queries in domain stores),
+  `db/actordelivery/sqlc` (separate migration table, same pattern).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make sqlc`.
+- Query files live in `db/sqlc/queries/`; schema in `db/sqlc/schemas/`;
+  migrations in `db/sqlc/migrations/`.
+- `spending_reservations` uses `(outpoint_hash, outpoint_index)` as PK;
+  a row's existence signals a durably checkpointed spend owner.
+- `ledger_entries.entry_id` uses `AUTOINCREMENT` (SQLite) / `SERIAL`
+  (PostgreSQL) to prevent rowid reuse after deletion.
+
+## Deep Docs
+
+- [db/CLAUDE.md](../CLAUDE.md) — Parent db package overview with domain
+  store types and migration notes.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/db/sqlc/CLAUDE.md
+++ b/db/sqlc/CLAUDE.md
@@ -1,0 +1,76 @@
+# db/sqlc
+
+## Purpose
+
+Generated type-safe SQL query layer for darepo-client's main persistent
+store. Produced by `make sqlc` from query files in `db/sqlc/queries/` and
+schema files in `db/sqlc/schemas/`. Supports both SQLite and PostgreSQL.
+Never edit generated `*.go` files directly.
+
+## Key Generated Types
+
+- `Querier` interface — Top-level generated interface with all query methods
+  grouped by domain.
+- **Boarding**: `BoardingAddress`, `BoardingIntent`, `BoardingAddrRow`,
+  `BoardingIntentRow`, `BoardingSweep`, `BoardingSweepInput`,
+  `NewAddrParams`, `NewIntentParams`, `InsertBoardingSweepParams`.
+- **Rounds**: `Round`, `RoundRow`, `UpdateRoundStatusParams`.
+- **VTXOs**: `Vtxo`, `VtxoRow`, `VtxoAncestryPath`.
+- **OOR Artifacts**: `OorPackage`, `OorVtxo`, `OwnedReceiveScript`.
+- **Fee Accounting**: `LedgerEntry`, `Account`,
+  `InsertClientLedgerEntryParams`.
+- **Unilateral Exit**: `UnilateralExitJob`, `UpsertUnilateralExitJobParams`.
+- **vHTLC Recovery**: `VhtlcRecoveryJob`.
+- **Spending Reservations**: `SpendingReservation`,
+  `UpsertSpendingReservationParams`.
+- **Internal Keys**: `InternalKey`, `InsertInternalKeyParams` — shared
+  registry for client wallet keys referenced by FK from boarding, VTXO,
+  OOR, and round tables.
+- **Chain Info**: `ChainInfo`.
+
+## Migration History (17 versions)
+
+| Version | Table(s) Added |
+|---------|----------------|
+| 000001 | `chain_info` |
+| 000002 | `boarding_addresses`, `boarding_intents`, `boarding_statuses` |
+| 000003 | `rounds`, `round_statuses` |
+| 000004 | `oor_packages`, `oor_vtxos`, `owned_receive_scripts` + enum tables |
+| 000005 | `chain_depth` column on `vtxos` |
+| 000006 | `accounts`, `account_types`, `ledger_entries` |
+| 000007 | `wallet_utxo_log` |
+| 000008 | `unilateral_exit_jobs` |
+| 000009 | `vtxo_ancestry_paths` (replaces scalar tree_path) |
+| 000010 | `tx_proof` BLOB on `boarding_intents` |
+| 000011 | `boarding_sweeps`, `boarding_sweep_inputs` |
+| 000012 | `boarding_sweep_fee_paid` ledger event type |
+| 000013 | `pending_board_requests` |
+| 000014 | `chain_txid`/`chain_vout`/`confirmation_height` on `ledger_entries` |
+| 000015 | `vhtlc_recovery_jobs` |
+| 000016 | `exit_policy_kind`/`exit_policy_ref` on `unilateral_exit_jobs` |
+| 000017 | `spending_reservations` |
+
+`LatestMigrationVersion = 17`.
+
+## Relationships
+
+- **Depends on**: SQLite (`modernc.org/sqlite`) and PostgreSQL (`lib/pq`)
+  drivers; standard library only.
+- **Depended on by**: `db` (wraps generated queries in domain stores),
+  `db/actordelivery/sqlc` (separate migration table, same pattern).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make sqlc`.
+- Query files live in `db/sqlc/queries/`; schema in `db/sqlc/schemas/`;
+  migrations in `db/sqlc/migrations/`.
+- `spending_reservations` uses `(outpoint_hash, outpoint_index)` as PK;
+  a row's existence signals a durably checkpointed spend owner.
+- `ledger_entries.entry_id` uses `AUTOINCREMENT` (SQLite) / `SERIAL`
+  (PostgreSQL) to prevent rowid reuse after deletion.
+
+## Deep Docs
+
+- [db/CLAUDE.md](../CLAUDE.md) — Parent db package overview with domain
+  store types and migration notes.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/internal/actortest/AGENTS.md
+++ b/internal/actortest/AGENTS.md
@@ -12,7 +12,10 @@ state+outbox checkpointing.
 
 - `testHarness` / `newTestHarness` — Central test scaffolding: sets up real DB, actor system, delivery store, and outbox publisher.
 - `eventuallyWithOutboxPublish` — Helper that actively triggers `OutboxPublisher.PublishPending()` on every polling iteration, making outbox delivery assertions robust under the race detector and CI scheduler pressure.
-- Timeout constants: `outboxForwardProcessingTimeout` (5s), `outboxDeliveryTimeout` (10s), `durableAskResponseTimeout` (10s).
+- Timeout constants: `outboxForwardProcessingTimeout` (5s),
+  `outboxDeliveryTimeout` (30s — extended to reduce flakiness under the
+  race detector when CI scheduler pressure starves chained delivery),
+  `durableAskResponseTimeout` (10s).
 
 ## Relationships
 

--- a/internal/actortest/CLAUDE.md
+++ b/internal/actortest/CLAUDE.md
@@ -12,7 +12,10 @@ state+outbox checkpointing.
 
 - `testHarness` / `newTestHarness` — Central test scaffolding: sets up real DB, actor system, delivery store, and outbox publisher.
 - `eventuallyWithOutboxPublish` — Helper that actively triggers `OutboxPublisher.PublishPending()` on every polling iteration, making outbox delivery assertions robust under the race detector and CI scheduler pressure.
-- Timeout constants: `outboxForwardProcessingTimeout` (5s), `outboxDeliveryTimeout` (10s), `durableAskResponseTimeout` (10s).
+- Timeout constants: `outboxForwardProcessingTimeout` (5s),
+  `outboxDeliveryTimeout` (30s — extended to reduce flakiness under the
+  race detector when CI scheduler pressure starves chained delivery),
+  `durableAskResponseTimeout` (10s).
 
 ## Relationships
 

--- a/mailbox/pb/AGENTS.md
+++ b/mailbox/pb/AGENTS.md
@@ -1,0 +1,47 @@
+# mailbox/pb
+
+## Purpose
+
+Generated protobuf/gRPC stubs for the mailbox wire protocol. Defines the
+`Envelope` format and `MailboxService` edge API used by all durable
+client-server transport in this project.
+
+## Key Types
+
+- `Envelope` — Durable transport unit. Fields: `ProtocolVersion`, `MsgId`
+  (unique per retry), `IdempotencyKey` (stable across retries for server
+  deduplication), `Sender`, `Recipient`, `Body` (google.protobuf.Any),
+  `Rpc` (RpcMeta overlay), `EventSeq` (server-assigned monotonic cursor),
+  `Headers`, `Checksum`.
+- `RpcMeta` — RPC overlay: `Kind` (REQUEST/RESPONSE/EVENT), `Service`,
+  `Method`, `CorrelationId`, `ReplyTo`.
+- `Header` — Key-value pair for optional envelope headers.
+- `MailboxService` — Edge API with three methods:
+  - `Send(Envelope) → Envelope` — Deliver an envelope to a recipient.
+  - `Pull(PullRequest) → PullResponse` — Long-poll for new envelopes
+    (default 5 s timeout).
+  - `AckUpTo(AckRequest) → AckResponse` — Acknowledge all envelopes up
+    to and including a given `EventSeq` cursor.
+
+## Relationships
+
+- **Depends on**: nothing (pure proto-generated types, google.protobuf.Any).
+- **Depended on by**: `serverconn` (constructs envelopes, drives Pull/AckUpTo),
+  `darepod` (server-side mailbox), `sdk/swaps` (swap mailbox pull).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- `MsgId` differs on each retry; `IdempotencyKey` is stable across retries —
+  do not confuse the two.
+- `EventSeq` is server-assigned; clients treat it as an opaque monotonic
+  cursor for `AckUpTo`.
+- Proto source: `mailbox/pb/mailbox.proto`.
+
+## Deep Docs
+
+- [mailbox/CLAUDE.md](../CLAUDE.md) — Parent mailbox package overview.
+- [docs/mailbox_architecture.md](../../docs/mailbox_architecture.md) — Full
+  three-layer mailbox architecture.
+- [docs/RPC_MAILBOX_CONTRACT.md](../../docs/RPC_MAILBOX_CONTRACT.md) —
+  Envelope semantics and ack watermark contract.

--- a/mailbox/pb/CLAUDE.md
+++ b/mailbox/pb/CLAUDE.md
@@ -1,0 +1,47 @@
+# mailbox/pb
+
+## Purpose
+
+Generated protobuf/gRPC stubs for the mailbox wire protocol. Defines the
+`Envelope` format and `MailboxService` edge API used by all durable
+client-server transport in this project.
+
+## Key Types
+
+- `Envelope` — Durable transport unit. Fields: `ProtocolVersion`, `MsgId`
+  (unique per retry), `IdempotencyKey` (stable across retries for server
+  deduplication), `Sender`, `Recipient`, `Body` (google.protobuf.Any),
+  `Rpc` (RpcMeta overlay), `EventSeq` (server-assigned monotonic cursor),
+  `Headers`, `Checksum`.
+- `RpcMeta` — RPC overlay: `Kind` (REQUEST/RESPONSE/EVENT), `Service`,
+  `Method`, `CorrelationId`, `ReplyTo`.
+- `Header` — Key-value pair for optional envelope headers.
+- `MailboxService` — Edge API with three methods:
+  - `Send(Envelope) → Envelope` — Deliver an envelope to a recipient.
+  - `Pull(PullRequest) → PullResponse` — Long-poll for new envelopes
+    (default 5 s timeout).
+  - `AckUpTo(AckRequest) → AckResponse` — Acknowledge all envelopes up
+    to and including a given `EventSeq` cursor.
+
+## Relationships
+
+- **Depends on**: nothing (pure proto-generated types, google.protobuf.Any).
+- **Depended on by**: `serverconn` (constructs envelopes, drives Pull/AckUpTo),
+  `darepod` (server-side mailbox), `sdk/swaps` (swap mailbox pull).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- `MsgId` differs on each retry; `IdempotencyKey` is stable across retries —
+  do not confuse the two.
+- `EventSeq` is server-assigned; clients treat it as an opaque monotonic
+  cursor for `AckUpTo`.
+- Proto source: `mailbox/pb/mailbox.proto`.
+
+## Deep Docs
+
+- [mailbox/CLAUDE.md](../CLAUDE.md) — Parent mailbox package overview.
+- [docs/mailbox_architecture.md](../../docs/mailbox_architecture.md) — Full
+  three-layer mailbox architecture.
+- [docs/RPC_MAILBOX_CONTRACT.md](../../docs/RPC_MAILBOX_CONTRACT.md) —
+  Envelope semantics and ack watermark contract.

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -21,6 +21,14 @@ State transitions and validation rules live under [Invariants](#invariants).
 - `SignArkPSBT` — signs Ark PSBT inputs on the checkpoint 2-of-2 collab
   leaf using `MultiPrevOutFetcher` for BIP-341 sighashes across
   multi-input transfers.
+- `normalizeCheckpointOwnerLeaves(policy, inputs)` — rebuilds each
+  standard transfer input's checkpoint OUTPUT owner leaf to commit to
+  the current session operator key. Resolves the operator-key-rotation
+  bug where a VTXO created under an old operator key would produce a
+  checkpoint output whose owner leaf referenced that stale key and be
+  rejected by the server. Called inside the `StartTransferEvent` handler
+  before building the submit package. Custom-spend inputs (vHTLC) and
+  inputs without a VTXO policy are left untouched.
 - `ClientActorCfg` — configuration for `OORClientActor`. Notable fields:
   `OutboxHandler`, `ServerConn`, `PackageStore`, `DeliveryStore`,
   `VTXOManager`, `VTXOStore`, optional `LedgerSink fn.Option[ledger.Sink]`
@@ -207,6 +215,10 @@ State transitions and validation rules live under [Invariants](#invariants).
 
 - Checkpoint output collab path is 2-of-2
   `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig.
+- Checkpoint OUTPUT owner leaf is always bound to the current session
+  operator key (via `normalizeCheckpointOwnerLeaves`) regardless of which
+  operator key epoch the source VTXO was created under. The checkpoint INPUT
+  spend path retains the VTXO's original historical operator key unchanged.
 - `signCustomCheckpointPSBT` re-verifies that the custom spend path
   binds to the VTXO pkScript via `SpendPath.VerifyBindsToPkScript`
   before signing — covers persisted `TransferInputSnapshot`s resumed

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -21,6 +21,14 @@ State transitions and validation rules live under [Invariants](#invariants).
 - `SignArkPSBT` — signs Ark PSBT inputs on the checkpoint 2-of-2 collab
   leaf using `MultiPrevOutFetcher` for BIP-341 sighashes across
   multi-input transfers.
+- `normalizeCheckpointOwnerLeaves(policy, inputs)` — rebuilds each
+  standard transfer input's checkpoint OUTPUT owner leaf to commit to
+  the current session operator key. Resolves the operator-key-rotation
+  bug where a VTXO created under an old operator key would produce a
+  checkpoint output whose owner leaf referenced that stale key and be
+  rejected by the server. Called inside the `StartTransferEvent` handler
+  before building the submit package. Custom-spend inputs (vHTLC) and
+  inputs without a VTXO policy are left untouched.
 - `ClientActorCfg` — configuration for `OORClientActor`. Notable fields:
   `OutboxHandler`, `ServerConn`, `PackageStore`, `DeliveryStore`,
   `VTXOManager`, `VTXOStore`, optional `LedgerSink fn.Option[ledger.Sink]`
@@ -207,6 +215,10 @@ State transitions and validation rules live under [Invariants](#invariants).
 
 - Checkpoint output collab path is 2-of-2
   `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig.
+- Checkpoint OUTPUT owner leaf is always bound to the current session
+  operator key (via `normalizeCheckpointOwnerLeaves`) regardless of which
+  operator key epoch the source VTXO was created under. The checkpoint INPUT
+  spend path retains the VTXO's original historical operator key unchanged.
 - `signCustomCheckpointPSBT` re-verifies that the custom spend path
   binds to the VTXO pkScript via `SpendPath.VerifyBindsToPkScript`
   before signing — covers persisted `TransferInputSnapshot`s resumed

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -201,6 +201,11 @@ state transitions and validation rules live under [Invariants](#invariants).
 - Each client sub-tree in the commitment tree must contain exactly one
   non-anchor leaf; `buildOwnedClientVTXOs` fails the transition
   otherwise.
+- **Sweep delay is validated per-round** in `CommitmentTxReceivedState`
+  (against `ClientBatchInfo.SweepDelay`), not once at actor construction.
+  The sweep delay is now a per-batch parameter delivered in
+  `ClientBatchInfo` rather than a global `OperatorTerms` field; this
+  enables per-round sweep-delay configuration and operator key rotation.
 - **Seal-time fee handshake (#270)**: the server is the amount
   authority. When `QuoteReceivedState.Quote` is non-nil, it threads
   through `RoundJoinedState` → `CommitmentTxReceivedState`, which

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -201,6 +201,11 @@ state transitions and validation rules live under [Invariants](#invariants).
 - Each client sub-tree in the commitment tree must contain exactly one
   non-anchor leaf; `buildOwnedClientVTXOs` fails the transition
   otherwise.
+- **Sweep delay is validated per-round** in `CommitmentTxReceivedState`
+  (against `ClientBatchInfo.SweepDelay`), not once at actor construction.
+  The sweep delay is now a per-batch parameter delivered in
+  `ClientBatchInfo` rather than a global `OperatorTerms` field; this
+  enables per-round sweep-delay configuration and operator key rotation.
 - **Seal-time fee handshake (#270)**: the server is the amount
   authority. When `QuoteReceivedState.Quote` is non-nil, it threads
   through `RoundJoinedState` → `CommitmentTxReceivedState`, which

--- a/rpc/oorpb/AGENTS.md
+++ b/rpc/oorpb/AGENTS.md
@@ -1,0 +1,51 @@
+# rpc/oorpb
+
+## Purpose
+
+Generated protobuf/gRPC stubs for the out-of-round (OOR) transfer mailbox
+protocol. Carries Ark PSBTs, signing descriptors, recipient outputs, and
+server co-signed checkpoint responses between client and server for OOR
+transfers.
+
+## Key Types
+
+- `OORMailboxService` — Two mailbox methods:
+  - `SubmitPackage` — Client submits an OOR package (inputs, recipients,
+    policies, fee rate, session/idempotency keys). Server responds with
+    co-signed checkpoint PSBTs and a server-assigned session ID.
+  - `FinalizePackage` — Client submits finalized checkpoint PSBTs;
+    server confirms the session.
+- `SubmitPackageRequest` — Carries: `ArkPsbt`, `SigningDescriptors`,
+  `RecipientOutputs`, `FeeRateSatPerVbyte`, `SessionId` (optional resume),
+  `IsDryRun`, `IdempotencyKey`.
+- `SubmitPackageResponse` — Carries: `CheckpointPsbts` (one per recipient),
+  `SessionId` (server-assigned).
+- `OORSigningDescriptor` — Per-input signing metadata: `Outpoint`,
+  `VtxoPolicyTemplate`, `SpendPath`, `OwnerLeafPolicy`.
+- `OORRecipientOutput` — Recipient output spec: `PkScript`, `VhtlcPolicy`,
+  `AmountSat`.
+- `OOROutPoint` — Protobuf representation of a Bitcoin outpoint (txid bytes
+  + vout index).
+- `SubmitRejectedError` — Server-side rejection with a rejection code
+  (e.g., `OOR_REJECT_LINEAGE_TOO_LARGE`).
+- `FinalizePackageRequest/Response` — Finalize the OOR session after
+  client fully signs checkpoint PSBTs.
+
+## Relationships
+
+- **Depends on**: nothing (pure proto-generated types).
+- **Depended on by**: `oor` (OOR FSM uses these types for message marshaling),
+  `darepod` (OOR orchestration), `systest` (fake operator mailbox).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- Proto source: `rpc/oorpb/oorwire.proto`.
+- `IdempotencyKey` is stable across retries; `SessionId` is the server's
+  durable identifier assigned on first successful submit.
+
+## Deep Docs
+
+- [oor/CLAUDE.md](../../oor/CLAUDE.md) — OOR FSM package using these types.
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent rpc package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/rpc/oorpb/CLAUDE.md
+++ b/rpc/oorpb/CLAUDE.md
@@ -1,0 +1,51 @@
+# rpc/oorpb
+
+## Purpose
+
+Generated protobuf/gRPC stubs for the out-of-round (OOR) transfer mailbox
+protocol. Carries Ark PSBTs, signing descriptors, recipient outputs, and
+server co-signed checkpoint responses between client and server for OOR
+transfers.
+
+## Key Types
+
+- `OORMailboxService` — Two mailbox methods:
+  - `SubmitPackage` — Client submits an OOR package (inputs, recipients,
+    policies, fee rate, session/idempotency keys). Server responds with
+    co-signed checkpoint PSBTs and a server-assigned session ID.
+  - `FinalizePackage` — Client submits finalized checkpoint PSBTs;
+    server confirms the session.
+- `SubmitPackageRequest` — Carries: `ArkPsbt`, `SigningDescriptors`,
+  `RecipientOutputs`, `FeeRateSatPerVbyte`, `SessionId` (optional resume),
+  `IsDryRun`, `IdempotencyKey`.
+- `SubmitPackageResponse` — Carries: `CheckpointPsbts` (one per recipient),
+  `SessionId` (server-assigned).
+- `OORSigningDescriptor` — Per-input signing metadata: `Outpoint`,
+  `VtxoPolicyTemplate`, `SpendPath`, `OwnerLeafPolicy`.
+- `OORRecipientOutput` — Recipient output spec: `PkScript`, `VhtlcPolicy`,
+  `AmountSat`.
+- `OOROutPoint` — Protobuf representation of a Bitcoin outpoint (txid bytes
+  + vout index).
+- `SubmitRejectedError` — Server-side rejection with a rejection code
+  (e.g., `OOR_REJECT_LINEAGE_TOO_LARGE`).
+- `FinalizePackageRequest/Response` — Finalize the OOR session after
+  client fully signs checkpoint PSBTs.
+
+## Relationships
+
+- **Depends on**: nothing (pure proto-generated types).
+- **Depended on by**: `oor` (OOR FSM uses these types for message marshaling),
+  `darepod` (OOR orchestration), `systest` (fake operator mailbox).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- Proto source: `rpc/oorpb/oorwire.proto`.
+- `IdempotencyKey` is stable across retries; `SessionId` is the server's
+  durable identifier assigned on first successful submit.
+
+## Deep Docs
+
+- [oor/CLAUDE.md](../../oor/CLAUDE.md) — OOR FSM package using these types.
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent rpc package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/rpc/roundpb/AGENTS.md
+++ b/rpc/roundpb/AGENTS.md
@@ -12,6 +12,25 @@ layer.
 All `*.pb.go` files are generated — never edit directly; regenerate with
 `make rpc`. The manually-maintained `service.go` defines:
 
+`ClientBatchInfo` carries five per-round cryptographic keys (fields 5-9)
+alongside existing `vtxo_tree_paths` and `connector_leaf_map`, enabling
+operator key rotation without breaking in-flight round agreements:
+
+- `TreeCosignKey` (bytes, field 5) — VTXO-tree MuSig2 cosigner key for
+  this round; derived fresh per round, independent of the persistent
+  identity key.
+- `ConnectorOperatorKey` (bytes, field 6) — operator key used to build this
+  round's connector tree; clients reconstruct connector outpoints from this
+  key rather than global operator terms.
+- `SweepKey` (bytes, field 7) — operator sweep key for this round's
+  VTXO-tree sweep leaf.
+- `SweepDelay` (uint32, field 8) — batch-wide absolute-timelock in blocks
+  for the VTXO-tree sweep leaf; clients use this for batch expiry
+  calculations, not global operator terms.
+- `ForfeitKey` (bytes, field 9) — dedicated forfeit penalty key for this
+  round; clients derive the forfeit-tx penalty output via BIP-86 key-spend
+  to this key.
+
 - `ServiceName` — Fully-qualified protobuf service name
   (`"round.v1.RoundService"`) used for mailbox event routing.
 - Server→client push method names: `MethodJoinAck`, `MethodBatchInfo`,

--- a/rpc/roundpb/CLAUDE.md
+++ b/rpc/roundpb/CLAUDE.md
@@ -12,6 +12,25 @@ layer.
 All `*.pb.go` files are generated — never edit directly; regenerate with
 `make rpc`. The manually-maintained `service.go` defines:
 
+`ClientBatchInfo` carries five per-round cryptographic keys (fields 5-9)
+alongside existing `vtxo_tree_paths` and `connector_leaf_map`, enabling
+operator key rotation without breaking in-flight round agreements:
+
+- `TreeCosignKey` (bytes, field 5) — VTXO-tree MuSig2 cosigner key for
+  this round; derived fresh per round, independent of the persistent
+  identity key.
+- `ConnectorOperatorKey` (bytes, field 6) — operator key used to build this
+  round's connector tree; clients reconstruct connector outpoints from this
+  key rather than global operator terms.
+- `SweepKey` (bytes, field 7) — operator sweep key for this round's
+  VTXO-tree sweep leaf.
+- `SweepDelay` (uint32, field 8) — batch-wide absolute-timelock in blocks
+  for the VTXO-tree sweep leaf; clients use this for batch expiry
+  calculations, not global operator terms.
+- `ForfeitKey` (bytes, field 9) — dedicated forfeit penalty key for this
+  round; clients derive the forfeit-tx penalty output via BIP-86 key-spend
+  to this key.
+
 - `ServiceName` — Fully-qualified protobuf service name
   (`"round.v1.RoundService"`) used for mailbox event routing.
 - Server→client push method names: `MethodJoinAck`, `MethodBatchInfo`,

--- a/rpc/swapclientrpc/AGENTS.md
+++ b/rpc/swapclientrpc/AGENTS.md
@@ -1,0 +1,55 @@
+# rpc/swapclientrpc
+
+## Purpose
+
+Generated protobuf/gRPC service and message definitions for the daemon-side
+swap client service (`SwapClientService`). Exposes the swap subsystem — start,
+resume, list, get, and subscribe to swap execution state — to local SDK/CLI
+clients.
+
+## Key Types
+
+- `SwapClientService` — Six methods:
+  - `StartPay` — Start an Ark-to-Lightning payment swap (daemon continues in
+    background after returning the swap handle).
+  - `StartReceive` — Start a Lightning-to-Ark receive swap (daemon continues
+    the claim after the invoice is paid).
+  - `ResumeSwap` — Resume one persisted pending swap by payment hash.
+  - `ListSwaps` — List persisted swap sessions from daemon-owned store.
+  - `GetSwap` — Fetch one swap summary by payment hash.
+  - `SubscribeSwaps` — Stream swap summary updates, with optional snapshot
+    of existing swaps.
+- `SwapDirection` — `SWAP_DIRECTION_PAY` / `SWAP_DIRECTION_RECEIVE`.
+- `SwapSettlementType` — `SWAP_SETTLEMENT_TYPE_LIGHTNING` /
+  `SWAP_SETTLEMENT_TYPE_IN_ARK`.
+- `SwapState` — 15+ states: `CREATED`, `SWAP_CREATED`, `INVOICE_CREATED`,
+  `HTLC_EVENT_ACCEPTED`, `VHTLC_FUNDED`, `CLAIM_INITIATED`, `COMPLETED`,
+  `EXPIRED`, `FAILED`, `NEEDS_INTERVENTION`, `REFUND_INITIATED`, `REFUNDED`,
+  `CANCELED`, `FUNDING_INITIATED`, `WAITING_FOR_CLAIM`.
+- `SwapSummary` — Flat summary row: `PaymentHash`, `State`, `Direction`,
+  `SettlementType`, `CreatedAt`, `UpdatedAt`, `ErrorMessage`.
+- `StartPayRequest/Response` — Pay request: `Invoice`, `MaxFeeSat`.
+  Response: `PaymentHash`.
+- `StartReceiveRequest/Response` — Receive request: `AmountMsat`,
+  `Memo`. Response: `Invoice`, `PaymentHash`.
+- `SubscribeSwapsRequest/Response` — Optional `IncludeExisting` flag for
+  initial snapshot.
+
+## Relationships
+
+- **Depends on**: nothing (pure proto-generated types).
+- **Depended on by**: `sdk/swaps` (client-side swap orchestration),
+  `swapwallet` (daemon-side RPC handler), `cmd/darepocli/darepoclicommands`
+  (swap CLI commands), `devrpc` (dynamic CLI).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- Proto source: `rpc/swapclientrpc/swap_client.proto`.
+
+## Deep Docs
+
+- [sdk/swaps/CLAUDE.md](../../sdk/swaps/CLAUDE.md) — High-level swap SDK.
+- [swapwallet/CLAUDE.md](../../swapwallet/CLAUDE.md) — Daemon-side handler.
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent rpc package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/rpc/swapclientrpc/CLAUDE.md
+++ b/rpc/swapclientrpc/CLAUDE.md
@@ -1,0 +1,55 @@
+# rpc/swapclientrpc
+
+## Purpose
+
+Generated protobuf/gRPC service and message definitions for the daemon-side
+swap client service (`SwapClientService`). Exposes the swap subsystem — start,
+resume, list, get, and subscribe to swap execution state — to local SDK/CLI
+clients.
+
+## Key Types
+
+- `SwapClientService` — Six methods:
+  - `StartPay` — Start an Ark-to-Lightning payment swap (daemon continues in
+    background after returning the swap handle).
+  - `StartReceive` — Start a Lightning-to-Ark receive swap (daemon continues
+    the claim after the invoice is paid).
+  - `ResumeSwap` — Resume one persisted pending swap by payment hash.
+  - `ListSwaps` — List persisted swap sessions from daemon-owned store.
+  - `GetSwap` — Fetch one swap summary by payment hash.
+  - `SubscribeSwaps` — Stream swap summary updates, with optional snapshot
+    of existing swaps.
+- `SwapDirection` — `SWAP_DIRECTION_PAY` / `SWAP_DIRECTION_RECEIVE`.
+- `SwapSettlementType` — `SWAP_SETTLEMENT_TYPE_LIGHTNING` /
+  `SWAP_SETTLEMENT_TYPE_IN_ARK`.
+- `SwapState` — 15+ states: `CREATED`, `SWAP_CREATED`, `INVOICE_CREATED`,
+  `HTLC_EVENT_ACCEPTED`, `VHTLC_FUNDED`, `CLAIM_INITIATED`, `COMPLETED`,
+  `EXPIRED`, `FAILED`, `NEEDS_INTERVENTION`, `REFUND_INITIATED`, `REFUNDED`,
+  `CANCELED`, `FUNDING_INITIATED`, `WAITING_FOR_CLAIM`.
+- `SwapSummary` — Flat summary row: `PaymentHash`, `State`, `Direction`,
+  `SettlementType`, `CreatedAt`, `UpdatedAt`, `ErrorMessage`.
+- `StartPayRequest/Response` — Pay request: `Invoice`, `MaxFeeSat`.
+  Response: `PaymentHash`.
+- `StartReceiveRequest/Response` — Receive request: `AmountMsat`,
+  `Memo`. Response: `Invoice`, `PaymentHash`.
+- `SubscribeSwapsRequest/Response` — Optional `IncludeExisting` flag for
+  initial snapshot.
+
+## Relationships
+
+- **Depends on**: nothing (pure proto-generated types).
+- **Depended on by**: `sdk/swaps` (client-side swap orchestration),
+  `swapwallet` (daemon-side RPC handler), `cmd/darepocli/darepoclicommands`
+  (swap CLI commands), `devrpc` (dynamic CLI).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- Proto source: `rpc/swapclientrpc/swap_client.proto`.
+
+## Deep Docs
+
+- [sdk/swaps/CLAUDE.md](../../sdk/swaps/CLAUDE.md) — High-level swap SDK.
+- [swapwallet/CLAUDE.md](../../swapwallet/CLAUDE.md) — Daemon-side handler.
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent rpc package overview.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/swaps/AGENTS.md
+++ b/sdk/swaps/AGENTS.md
@@ -56,7 +56,11 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
 - `Store` — isolated SQLite persistence. Runs its own migration table
   (`swap_client_schema_migrations`) separate from the main daemon DB.
 - `SwapServerConn` / `GRPCSwapServerConn` — remote swap-server gRPC
-  (`RequestChannelID`, `CreateInSwap`).
+  (`RequestChannelID`, `CreateInSwap`, `AcknowledgeOutSwapHTLC`).
+  `AcknowledgeOutSwapHTLC` notifies the server that the receiver has
+  durably accepted the out-swap HTLC mailbox event; the server waits for
+  this acknowledgement before funding the Ark vHTLC, ensuring
+  crash-safe receive semantics.
 - `DaemonConn` — wallet operations (OOR sends, VTXO lookups, key
   queries, receive-auth signing/ECDH) provided by the Ark daemon.
   Includes `ReceiveAuthKey`, `SignReceiveAuthMessage[Compact]`, and

--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -56,7 +56,11 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
 - `Store` — isolated SQLite persistence. Runs its own migration table
   (`swap_client_schema_migrations`) separate from the main daemon DB.
 - `SwapServerConn` / `GRPCSwapServerConn` — remote swap-server gRPC
-  (`RequestChannelID`, `CreateInSwap`).
+  (`RequestChannelID`, `CreateInSwap`, `AcknowledgeOutSwapHTLC`).
+  `AcknowledgeOutSwapHTLC` notifies the server that the receiver has
+  durably accepted the out-swap HTLC mailbox event; the server waits for
+  this acknowledgement before funding the Ark vHTLC, ensuring
+  crash-safe receive semantics.
 - `DaemonConn` — wallet operations (OOR sends, VTXO lookups, key
   queries, receive-auth signing/ECDH) provided by the Ark daemon.
   Includes `ReceiveAuthKey`, `SignReceiveAuthMessage[Compact]`, and

--- a/sdk/swaps/sqlc/AGENTS.md
+++ b/sdk/swaps/sqlc/AGENTS.md
@@ -1,0 +1,37 @@
+# sdk/swaps/sqlc
+
+## Purpose
+
+Generated type-safe SQL query layer for the swap client's isolated
+persistence store. Produced by `make sqlc` from query files in
+`sdk/swaps/sqlc/queries/`. Uses a separate migration table
+(`swap_client_schema_migrations`) so it is completely independent from
+the main daemon DB.
+
+## Key Generated Types
+
+- `PaySwap` — Ark-to-Lightning swap row: `PaymentHash`, `Invoice`, `State`,
+  `AmountMsat`, `FeeMsat`, `ExpiresAt`, client/operator/server pubkeys,
+  vHTLC parameters (`RefundLocktime`, `UnilateralClaimDelay`, etc.),
+  `RefundSessionId`, `RecoveryId`, `Preimage`, `InterventionReason`.
+- `ReceiveSwap` — Lightning-to-Ark swap row: `PaymentHash`, `AmountMsat`,
+  `State`, `Invoice`, `Preimage`, `DeadlineBlockHeight`, client/operator/
+  server pubkeys, vHTLC parameters, optional `VhtlcOutpoint`/`VhtlcAmount`,
+  `SettlementType`.
+
+## Relationships
+
+- **Depends on**: SQLite driver (`modernc.org/sqlite`); standard library only.
+- **Depended on by**: `sdk/swaps` (consumes via `Store` type with optional
+  persistence).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make sqlc`.
+- Swap persistence is optional; `sdk/swaps.NewSwapClient` (no store) and
+  `NewSwapClientWithStore` (SQLite-backed) are both valid.
+
+## Deep Docs
+
+- [sdk/swaps/CLAUDE.md](../CLAUDE.md) — Parent swap SDK overview.
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/swaps/sqlc/CLAUDE.md
+++ b/sdk/swaps/sqlc/CLAUDE.md
@@ -1,0 +1,37 @@
+# sdk/swaps/sqlc
+
+## Purpose
+
+Generated type-safe SQL query layer for the swap client's isolated
+persistence store. Produced by `make sqlc` from query files in
+`sdk/swaps/sqlc/queries/`. Uses a separate migration table
+(`swap_client_schema_migrations`) so it is completely independent from
+the main daemon DB.
+
+## Key Generated Types
+
+- `PaySwap` — Ark-to-Lightning swap row: `PaymentHash`, `Invoice`, `State`,
+  `AmountMsat`, `FeeMsat`, `ExpiresAt`, client/operator/server pubkeys,
+  vHTLC parameters (`RefundLocktime`, `UnilateralClaimDelay`, etc.),
+  `RefundSessionId`, `RecoveryId`, `Preimage`, `InterventionReason`.
+- `ReceiveSwap` — Lightning-to-Ark swap row: `PaymentHash`, `AmountMsat`,
+  `State`, `Invoice`, `Preimage`, `DeadlineBlockHeight`, client/operator/
+  server pubkeys, vHTLC parameters, optional `VhtlcOutpoint`/`VhtlcAmount`,
+  `SettlementType`.
+
+## Relationships
+
+- **Depends on**: SQLite driver (`modernc.org/sqlite`); standard library only.
+- **Depended on by**: `sdk/swaps` (consumes via `Store` type with optional
+  persistence).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make sqlc`.
+- Swap persistence is optional; `sdk/swaps.NewSwapClient` (no store) and
+  `NewSwapClientWithStore` (SQLite-backed) are both valid.
+
+## Deep Docs
+
+- [sdk/swaps/CLAUDE.md](../CLAUDE.md) — Parent swap SDK overview.
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/serverconn/hellotestpb/AGENTS.md
+++ b/serverconn/hellotestpb/AGENTS.md
@@ -1,0 +1,28 @@
+# serverconn/hellotestpb
+
+## Purpose
+
+Test-only protobuf package providing a minimal `HelloService` RPC for
+exercising `serverconn` mailbox infrastructure (routing, method dispatch,
+crash recovery) without pulling in full round or OOR protocol logic.
+
+## Key Types
+
+- `HelloService` — Single RPC: `SayHello(HelloRequest) → HelloResponse`.
+- `HelloRequest` — `Name string` field echoed back in the response.
+- `HelloResponse` — `Message string` echo response.
+
+## Relationships
+
+- **Depends on**: nothing (pure proto-generated types).
+- **Depended on by**: `serverconn` test files only; not imported by
+  production code.
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- Test-only: must not be imported outside `serverconn` tests.
+
+## Deep Docs
+
+- [serverconn/CLAUDE.md](../CLAUDE.md) — Parent serverconn package overview.

--- a/serverconn/hellotestpb/CLAUDE.md
+++ b/serverconn/hellotestpb/CLAUDE.md
@@ -1,0 +1,28 @@
+# serverconn/hellotestpb
+
+## Purpose
+
+Test-only protobuf package providing a minimal `HelloService` RPC for
+exercising `serverconn` mailbox infrastructure (routing, method dispatch,
+crash recovery) without pulling in full round or OOR protocol logic.
+
+## Key Types
+
+- `HelloService` — Single RPC: `SayHello(HelloRequest) → HelloResponse`.
+- `HelloRequest` — `Name string` field echoed back in the response.
+- `HelloResponse` — `Message string` echo response.
+
+## Relationships
+
+- **Depends on**: nothing (pure proto-generated types).
+- **Depended on by**: `serverconn` test files only; not imported by
+  production code.
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- Test-only: must not be imported outside `serverconn` tests.
+
+## Deep Docs
+
+- [serverconn/CLAUDE.md](../CLAUDE.md) — Parent serverconn package overview.

--- a/swaprpc/AGENTS.md
+++ b/swaprpc/AGENTS.md
@@ -1,0 +1,58 @@
+# swaprpc
+
+## Purpose
+
+Generated protobuf/gRPC service and message definitions for Lightning-to-Ark
+(receive) and Ark-to-Lightning (pay) atomic swap negotiations via virtual HTLCs
+(vHTLCs). This is the external swap-server API: clients open channels, create
+swaps, and handle acknowledgements through this service.
+
+## Key Types
+
+- `SwapService` — gRPC service with four methods:
+  - `RequestChannelId` — Allocates a short channel ID and route hint for a
+    Lightning-to-Ark receive; returns the vHTLC pubkey and invoice hints.
+  - `CreateInSwap` — Initiates an Ark-to-Lightning pay swap against a BOLT-11
+    invoice; returns negotiated amounts, fees, server pubkey, vHTLC config,
+    expiry, and settlement type.
+  - `AuthorizeInSwapRefund` — Signs a cooperative refund spend for a failed
+    Ark-to-Lightning swap.
+  - `AcknowledgeOutSwapHtlc` — Records that the receiver has durably accepted
+    an out-swap HTLC mailbox event; the server does not fund the Ark vHTLC
+    until this acknowledgement arrives.
+- `SettlementType` — Enum: `SETTLEMENT_TYPE_LIGHTNING` (swap server bridges to
+  Lightning network) or `SETTLEMENT_TYPE_IN_ARK` (same-Ark vHTLC settlement
+  without bridging to Lightning).
+- `VHTLCConfig` — vHTLC timelocks and keys: `RefundLocktime`,
+  `UnilateralClaimDelay`, `UnilateralRefundDelay`,
+  `UnilateralRefundWithoutReceiverDelay`, `SwapserverPubkey`.
+- `SwapMailboxEvent` — Envelope for HTLC events delivered via mailbox; carries
+  either an `OutSwapHtlcEvent` (Lightning-backed intercepted HTLC) or an
+  `InArkHtlcEvent` (same-Ark vHTLC payment).
+- `OutSwapHtlcEvent` — Lightning-backed intercepted HTLC: payment hash, raw
+  onion blob, vHTLC config. Delivered after receiver acknowledges durable
+  acceptance via `AcknowledgeOutSwapHtlc`.
+- `InArkHtlcEvent` — Same-Ark vHTLC event: payment hash, sender pubkey, vHTLC
+  config, optional indexed outpoint and amount.
+- `RouteHint` — Lightning invoice hop hint (node_id, channel_id, fee rates,
+  cltv_expiry_delta).
+- `TaprootScriptSignature` — Taproot signature carrier (pubkey, witness_script,
+  signature bytes, sighash type).
+
+## Relationships
+
+- **Depends on**: nothing (pure proto-generated types).
+- **Depended on by**: `sdk/swaps` (client-side swap orchestration),
+  `swapclientserver` (daemon-side swap server connection),
+  `rpc/restclient` (HTTP transport).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- Proto source: `swaprpc/swap.proto`.
+
+## Deep Docs
+
+- [sdk/swaps/CLAUDE.md](../sdk/swaps/CLAUDE.md) — High-level swap SDK using
+  this package.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/swaprpc/CLAUDE.md
+++ b/swaprpc/CLAUDE.md
@@ -1,0 +1,58 @@
+# swaprpc
+
+## Purpose
+
+Generated protobuf/gRPC service and message definitions for Lightning-to-Ark
+(receive) and Ark-to-Lightning (pay) atomic swap negotiations via virtual HTLCs
+(vHTLCs). This is the external swap-server API: clients open channels, create
+swaps, and handle acknowledgements through this service.
+
+## Key Types
+
+- `SwapService` — gRPC service with four methods:
+  - `RequestChannelId` — Allocates a short channel ID and route hint for a
+    Lightning-to-Ark receive; returns the vHTLC pubkey and invoice hints.
+  - `CreateInSwap` — Initiates an Ark-to-Lightning pay swap against a BOLT-11
+    invoice; returns negotiated amounts, fees, server pubkey, vHTLC config,
+    expiry, and settlement type.
+  - `AuthorizeInSwapRefund` — Signs a cooperative refund spend for a failed
+    Ark-to-Lightning swap.
+  - `AcknowledgeOutSwapHtlc` — Records that the receiver has durably accepted
+    an out-swap HTLC mailbox event; the server does not fund the Ark vHTLC
+    until this acknowledgement arrives.
+- `SettlementType` — Enum: `SETTLEMENT_TYPE_LIGHTNING` (swap server bridges to
+  Lightning network) or `SETTLEMENT_TYPE_IN_ARK` (same-Ark vHTLC settlement
+  without bridging to Lightning).
+- `VHTLCConfig` — vHTLC timelocks and keys: `RefundLocktime`,
+  `UnilateralClaimDelay`, `UnilateralRefundDelay`,
+  `UnilateralRefundWithoutReceiverDelay`, `SwapserverPubkey`.
+- `SwapMailboxEvent` — Envelope for HTLC events delivered via mailbox; carries
+  either an `OutSwapHtlcEvent` (Lightning-backed intercepted HTLC) or an
+  `InArkHtlcEvent` (same-Ark vHTLC payment).
+- `OutSwapHtlcEvent` — Lightning-backed intercepted HTLC: payment hash, raw
+  onion blob, vHTLC config. Delivered after receiver acknowledges durable
+  acceptance via `AcknowledgeOutSwapHtlc`.
+- `InArkHtlcEvent` — Same-Ark vHTLC event: payment hash, sender pubkey, vHTLC
+  config, optional indexed outpoint and amount.
+- `RouteHint` — Lightning invoice hop hint (node_id, channel_id, fee rates,
+  cltv_expiry_delta).
+- `TaprootScriptSignature` — Taproot signature carrier (pubkey, witness_script,
+  signature bytes, sighash type).
+
+## Relationships
+
+- **Depends on**: nothing (pure proto-generated types).
+- **Depended on by**: `sdk/swaps` (client-side swap orchestration),
+  `swapclientserver` (daemon-side swap server connection),
+  `rpc/restclient` (HTTP transport).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- Proto source: `swaprpc/swap.proto`.
+
+## Deep Docs
+
+- [sdk/swaps/CLAUDE.md](../sdk/swaps/CLAUDE.md) — High-level swap SDK using
+  this package.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -99,6 +99,12 @@ default builds avoid the swap executor's dependency graph.
   to the next round without a separate CLI step. If the implicit join fails,
   the error carries the explicit recovery hint (`ark rounds join`) so the
   leave intent — already queued in the round actor — is not stranded silently.
+- Wallet-local EXIT rows are decorated as COMPLETE when their source VTXO
+  appears in the terminally forfeited VTXO list
+  (`decorateCooperativeLeaveEntry`). This is a best-effort v1 heuristic that
+  lets cooperative-leave rows complete without durable leave-job linkage.
+  Forfeited VTXO outpoints are fetched once per `listActivity` call (not per
+  row) when any EXIT row exists (`hasWalletLocalExitEntries`).
 - `ListView` defaults to Activity. Only Activity honors
   `pending_only` and `kinds`; those filters are ignored for VTXOs
   and Onchain.

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -99,6 +99,12 @@ default builds avoid the swap executor's dependency graph.
   to the next round without a separate CLI step. If the implicit join fails,
   the error carries the explicit recovery hint (`ark rounds join`) so the
   leave intent — already queued in the round actor — is not stranded silently.
+- Wallet-local EXIT rows are decorated as COMPLETE when their source VTXO
+  appears in the terminally forfeited VTXO list
+  (`decorateCooperativeLeaveEntry`). This is a best-effort v1 heuristic that
+  lets cooperative-leave rows complete without durable leave-job linkage.
+  Forfeited VTXO outpoints are fetched once per `listActivity` call (not per
+  row) when any EXIT row exists (`hasWalletLocalExitEntries`).
 - `ListView` defaults to Activity. Only Activity honors
   `pending_only` and `kinds`; those filters are ignored for VTXOs
   and Onchain.


### PR DESCRIPTION
Nightly automated doc-gardening sweep for 2026-06-12.

Workflow run: https://github.com/lightninglabs/darepo-client/actions/runs/0

## What changed

**New CLAUDE.md/AGENTS.md** (packages previously missing docs):
- `swaprpc` — External swap-server gRPC service definitions
- `mailbox/pb` — Mailbox wire protocol protobuf stubs
- `rpc/oorpb` — OOR transfer mailbox protocol stubs
- `rpc/swapclientrpc` — Daemon-side swap client service stubs
- `db/sqlc` — Main database type-safe query layer (17 migrations)
- `db/actordelivery/sqlc` — Actor delivery query layer
- `sdk/swaps/sqlc` — Swap client persistence query layer
- `serverconn/hellotestpb` — Test-only HelloService proto package

**Updated CLAUDE.md/AGENTS.md** (stale docs reflecting recent changes):
- `arkrpc`, `daemonrpc`, `rpc/roundpb` — Proto changes: removed global
  ForfeitScript/SweepKey/SweepDelay from ServerInfo; added 5 per-round
  keys to ClientBatchInfo (TreeCosignKey, ConnectorOperatorKey, SweepKey,
  SweepDelay, ForfeitKey)
- `chainsource` — Block epoch actor auto-reconnect with exponential backoff
- `oor` — New `normalizeCheckpointOwnerLeaves` operator-key-rotation fix
- `round` — Per-round sweep delay validation (moved from global init)
- `sdk/ark` — Multi-recipient OOR send (Recipients array)
- `sdk/swaps` — New `AcknowledgeOutSwapHTLC` swap server method
- `swapwallet` — Cooperative-leave EXIT row completion heuristic
- `db` — BoardingStore now embeds InternalKeyQuerier
- `internal/actortest` — outboxDeliveryTimeout increased to 30s

**ARCHITECTURE.md** — Added `swaprpc` to Layer 3 package table.

Please review the updated CLAUDE.md/AGENTS.md and ARCHITECTURE.md diffs.
