### PR TITLE
darepod: guard custom spend locktime

### DIFF
--- a/darepod/rpc_oor_custom_input_test.go
+++ b/darepod/rpc_oor_custom_input_test.go
@@ -2,18 +2,23 @@ package darepod
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
+	"github.com/lightninglabs/darepo-client/oor"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/mock"
@@ -106,6 +111,96 @@ func newCustomOORRPCFixture(t *testing.T) *customOORRPCFixture {
 		claimPath:  claimPath,
 		clientPriv: receiverPriv,
 		outpoint:   outpoint,
+	}
+}
+
+type heightOnlyChainBackend struct {
+	chainsource.ChainBackend
+
+	height int32
+}
+
+func (b *heightOnlyChainBackend) BestBlock(ctx context.Context) (int32,
+	chainhash.Hash, error) {
+
+	return b.height, chainhash.Hash{}, nil
+}
+
+func (b *heightOnlyChainBackend) EstimateFee(ctx context.Context,
+	targetConf uint32) (btcutil.Amount, error) {
+
+	return 0, nil
+}
+
+// TestRequireCustomSpendsMature verifies the custom-input maturity preflight
+// admits height-locked spends at or past their absolute locktime, rejects
+// height-locked spends before that point with a retryable precondition error,
+// and fails closed for timestamp locktimes because this RPC path only compares
+// against the current block height.
+func TestRequireCustomSpendsMature(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		height       int32
+		lockTime     uint32
+		wantCode     codes.Code
+		wantContains string
+	}{{
+		name:     "mature height locktime",
+		height:   144,
+		lockTime: 144,
+		wantCode: codes.OK,
+	}, {
+		name:         "immature height locktime",
+		height:       143,
+		lockTime:     144,
+		wantCode:     codes.FailedPrecondition,
+		wantContains: "not mature",
+	}, {
+		name:   "timestamp locktime unsupported",
+		height: 144,
+		lockTime: uint32(
+			txscript.LockTimeThreshold,
+		),
+		wantCode:     codes.InvalidArgument,
+		wantContains: "timestamp locktime",
+	}}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			rpcServer := &RPCServer{
+				server: &Server{
+					chainBackend: &heightOnlyChainBackend{
+						height: test.height,
+					},
+				},
+			}
+			inputs := []oor.TransferInput{{
+				CustomSpend: &arkscript.SpendPath{
+					RequiredLockTime: test.lockTime,
+				},
+			}}
+
+			err := rpcServer.requireCustomSpendsMature(
+				t.Context(), inputs,
+			)
+
+			if test.wantCode == codes.OK {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Equal(t, test.wantCode, status.Code(err))
+			require.Contains(
+				t, status.Convert(err).Message(),
+				test.wantContains,
+			)
+		})
 	}
 }
 

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -2284,6 +2284,10 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 			return nil, status.Errorf(codes.Internal, "build "+
 				"custom inputs: %v", err)
 		}
+		err = r.requireCustomSpendsMature(ctx, selectedInputs)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		// Standard path: select and lock VTXOs from wallet.
 		phaseStart = time.Now()
@@ -2453,6 +2457,49 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 		SessionId:          resp.SessionID.String(),
 		RecipientOutpoints: recipientOutpoints,
 	}, nil
+}
+
+// requireCustomSpendsMature rejects custom OOR inputs whose absolute
+// block-height locktime is still in the future. Timestamp locktimes are not
+// currently supported at this RPC boundary because the daemon only has the
+// current best height in this path.
+func (r *RPCServer) requireCustomSpendsMature(ctx context.Context,
+	inputs []oor.TransferInput) error {
+
+	var requiredLockTime uint32
+	for _, input := range inputs {
+		if input.CustomSpend == nil {
+			continue
+		}
+
+		if input.CustomSpend.RequiredLockTime > requiredLockTime {
+			requiredLockTime = input.CustomSpend.RequiredLockTime
+		}
+	}
+
+	if requiredLockTime == 0 || r.server.chainBackend == nil {
+		return nil
+	}
+
+	if requiredLockTime >= txscript.LockTimeThreshold {
+		return status.Errorf(codes.InvalidArgument, "custom input "+
+			"timestamp locktime %d is not supported",
+			requiredLockTime)
+	}
+
+	height, _, err := r.server.chainBackend.BestBlock(ctx)
+	if err != nil {
+		return status.Errorf(codes.Unavailable, "fetch block "+
+			"height: %v", err)
+	}
+
+	if uint32(height) < requiredLockTime {
+		return status.Errorf(codes.FailedPrecondition, "custom input "+
+			"spend locktime %d is not mature at height %d",
+			requiredLockTime, height)
+	}
+
+	return nil
 }
 
 // PrepareOOR builds a deterministic OOR package without submitting it.


### PR DESCRIPTION
## Summary

Custom-input `SendOOR` now rejects spends before the encoded absolute locktime has matured. For custom spends, `darepod` scans the selected transfer inputs for the maximum `RequiredLockTime`, fetches the current chain height, and returns `FailedPrecondition` if the node is still below that height.

This prevents pre-locktime vHTLC refund spends from being submitted while leaving mature custom spends unchanged.

## Context

This is the darepo-client half of the split for lightninglabs/swapdk-server#119. The swapdk-server integration test branch uses this client commit as its submodule dependency to assert that pre-locktime refunds are rejected before maturity.

Original split commit: `1057a964` (`darepod: guard custom spend locktime`)
Rebased signed tip for this PR: `bf59ce4f`

## Validation

- `git diff --check origin/main..HEAD`
- `go test ./darepod`
- `make commitmsg-lint range="origin/main..HEAD"`