### PR TITLE
docs: nightly doc-gardening sweep 2026-06-14

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,6 +70,7 @@ package may import from a higher layer.
 | [`arkrpc`](arkrpc/) | Server-side gRPC service definitions (ArkService, IndexerService) |
 | [`arkrpc/treeconv`](arkrpc/treeconv/) | Narrow re-export of tree-path conversion helpers without the full gRPC surface |
 | [`rpc`](rpc/) | Client-side RPC message definitions (roundpb, oorpb, swapclientrpc, walletdkrpc) and HTTP transport (`rpc/restclient`) |
+| [`swaprpc`](swaprpc/) | Generated gRPC stubs for the swap server protocol: `SwapService` (out-swap HTLC events, in-swap creation, refund auth, HTLC acknowledgement) |
 | [`rpc/walletdkrpc`](rpc/walletdkrpc/) | Highest-level gRPC surface: `WalletService` with the seven core wallet verbs. Composes `daemonrpc` and `rpc/swapclientrpc` server-side via `swapwallet` |
 | [`rpc/restclient`](rpc/restclient/) | HTTP/protoJSON transport adapter: `Client`, `StreamClient[T]`, and per-service factory functions implementing the same gRPC stub interfaces over REST |
 | [`daemonrpc`](daemonrpc/) | Daemon gRPC API definitions |

--- a/chainsource/AGENTS.md
+++ b/chainsource/AGENTS.md
@@ -14,7 +14,12 @@ communication alongside the raw registration API.
 - `ChainSourceActor` — Factory actor spawning sub-actors for each monitoring
   request. Registered under `ChainSourceKey`.
 - `ChainSourceConfig` — Config struct: `Backend ChainBackend`, `System
-  *actor.ActorSystem`, `Log fn.Option[btclog.Logger]`.
+  *actor.ActorSystem`, `Log fn.Option[btclog.Logger]`
+- `BlockEpochConfig` — Config for `BlockEpochActor`: `Backend ChainBackend`,
+  `Log fn.Option[btclog.Logger]`, `ReconnectBackoff time.Duration` (initial
+  delay before reconnecting a closed epoch stream; zero → 1 s default),
+  `MaxReconnectBackoff time.Duration` (caps exponential reconnect; zero →
+  30 s default).
 - `ChainSourceMsg` / `ChainSourceResp` — Sealed actor message interfaces for
   requests and responses sent to the `ChainSourceActor`.
 - `FeeEstimateRequest/Response`, `BestHeightRequest/Response`,
@@ -56,6 +61,11 @@ communication alongside the raw registration API.
 - Confirmation sub-actors support two notification modes: Future-based (blocking
   await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
   mode when blocking inside a durable actor transaction is unsafe.
+- `BlockEpochActor` auto-reconnects when its backend stream closes: it calls
+  `Backend.RegisterBlocks` again with exponential backoff (initial 1 s, cap 30 s
+  by default, overridable via `BlockEpochConfig`). This allows the boarding
+  wallet's block subscription to survive LND notifier restarts without a daemon
+  restart.
 
 ## Deep Docs
 

--- a/chainsource/CLAUDE.md
+++ b/chainsource/CLAUDE.md
@@ -14,7 +14,12 @@ communication alongside the raw registration API.
 - `ChainSourceActor` — Factory actor spawning sub-actors for each monitoring
   request. Registered under `ChainSourceKey`.
 - `ChainSourceConfig` — Config struct: `Backend ChainBackend`, `System
-  *actor.ActorSystem`, `Log fn.Option[btclog.Logger]`.
+  *actor.ActorSystem`, `Log fn.Option[btclog.Logger]`
+- `BlockEpochConfig` — Config for `BlockEpochActor`: `Backend ChainBackend`,
+  `Log fn.Option[btclog.Logger]`, `ReconnectBackoff time.Duration` (initial
+  delay before reconnecting a closed epoch stream; zero → 1 s default),
+  `MaxReconnectBackoff time.Duration` (caps exponential reconnect; zero →
+  30 s default).
 - `ChainSourceMsg` / `ChainSourceResp` — Sealed actor message interfaces for
   requests and responses sent to the `ChainSourceActor`.
 - `FeeEstimateRequest/Response`, `BestHeightRequest/Response`,
@@ -56,6 +61,11 @@ communication alongside the raw registration API.
 - Confirmation sub-actors support two notification modes: Future-based (blocking
   await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
   mode when blocking inside a durable actor transaction is unsafe.
+- `BlockEpochActor` auto-reconnects when its backend stream closes: it calls
+  `Backend.RegisterBlocks` again with exponential backoff (initial 1 s, cap 30 s
+  by default, overridable via `BlockEpochConfig`). This allows the boarding
+  wallet's block subscription to survive LND notifier restarts without a daemon
+  restart.
 
 ## Deep Docs
 

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -58,8 +58,18 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   cap, positive and `MaxSatoshi`-bounded amounts, overflow-safe sum),
   resolves destinations via `resolveRecipientOutput`, delegates to
   the wallet actor.
+- `OperatorPubKey(ctx) (*btcec.PublicKey, error)` on `RPCServer` — fetches
+  the live operator public key by calling `GetInfo` via the server connection.
+  Used by `swapclientserver` to provide vHTLC policy scripts with a fresh
+  key after an operator key rotation rather than a stale cached value.
 - `resolveRecipientOutput` — extracts pkScript and client pubkey from
   an `Output` proto oneof (pubkey or address). Taproot-only.
+- `SendOOR` now accepts `daemonrpc.SendOORRequest.Recipients` (plural) in
+  addition to the legacy single-recipient path. `sendOORRequestRecipients`
+  normalises the request, `buildSendOORRecipients` resolves them, and
+  `resolveOORRecipientOutpoints` maps indexed outpoints back to caller.
+  Limit: same count cap as `SendVTXO`; custom inputs require exactly one
+  recipient.
 - `ListVTXOs` — paginated VTXO inventory. When called with
   `VTXO_STATUS_PENDING_ROUND`, branches to `listPendingRoundVTXOs`
   which bypasses `s.vtxoStore` and projects synthetic VTXOs (amount

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -58,8 +58,18 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   cap, positive and `MaxSatoshi`-bounded amounts, overflow-safe sum),
   resolves destinations via `resolveRecipientOutput`, delegates to
   the wallet actor.
+- `OperatorPubKey(ctx) (*btcec.PublicKey, error)` on `RPCServer` — fetches
+  the live operator public key by calling `GetInfo` via the server connection.
+  Used by `swapclientserver` to provide vHTLC policy scripts with a fresh
+  key after an operator key rotation rather than a stale cached value.
 - `resolveRecipientOutput` — extracts pkScript and client pubkey from
   an `Output` proto oneof (pubkey or address). Taproot-only.
+- `SendOOR` now accepts `daemonrpc.SendOORRequest.Recipients` (plural) in
+  addition to the legacy single-recipient path. `sendOORRequestRecipients`
+  normalises the request, `buildSendOORRecipients` resolves them, and
+  `resolveOORRecipientOutpoints` maps indexed outpoints back to caller.
+  Limit: same count cap as `SendVTXO`; custom inputs require exactly one
+  recipient.
 - `ListVTXOs` — paginated VTXO inventory. When called with
   `VTXO_STATUS_PENDING_ROUND`, branches to `listPendingRoundVTXOs`
   which bypasses `s.vtxoStore` and projects synthetic VTXOs (amount

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -15,7 +15,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   `Backend`).
 - `BoardingStore` / `BoardingWalletStore` — interface + concrete
   sqlc-backed store for boarding addresses, intents, and the aggregate
-  sweep lifecycle (consumed by `wallet.BoardingStore`). Sweep ops:
+  sweep lifecycle (consumed by `wallet.BoardingStore`). `BoardingStore` embeds
+  `InternalKeyQuerier` so boarding-address writes can register the client wallet
+  key in the shared `internal_keys` registry within the same transaction. Sweep ops:
   `Create/MarkPublished/MarkFailed/List/ListPending/MarkInputSpent`.
 - `NewBoardingSweep` / `BoardingSweepRecord` /
   `BoardingSweepInputRecord` — control-plane domain types. Sweep
@@ -82,6 +84,18 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   `vtxo.SpendingReservationStore`.
 - `SpendingReservationStore` / `BatchedSpendingReservationStore` — Internal
   sqlc-backed query interfaces for the reservation table.
+- `InternalKeyQuerier` — Minimal interface for the internal-key registry helpers
+  (`UpsertInternalKey`, `GetInternalKeyByID`). Satisfied by `*sqlc.Queries` and
+  by every consumer store interface that embeds these two methods, allowing
+  register-then-reference of an internal key inside the same transaction.
+- `RegisterInternalKeyTx(ctx, qtx, now, desc)` — Idempotently records a
+  `keychain.KeyDescriptor` in the `internal_keys` table and returns its surrogate
+  id. Re-registering an identical (pubkey, key_family, key_index) triple returns
+  the existing id.
+- `InternalKeyDescByIDTx(ctx, qtx, id)` — Hydrates a `keychain.KeyDescriptor`
+  from its registry id within the caller's transaction context.
+- `ErrInternalKeyPubKeyMissing` / `ErrInternalKeyNotFound` — Sentinel errors for
+  missing public key on registration or unknown id on lookup.
 
 ## Relationships
 
@@ -125,6 +139,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 
 ### Migration notes
 
+- `000002_boarding_tables` (amended) — adds `internal_keys` table: surrogate-id
+  registry of client wallet `KeyDescriptor` values (pubkey + key_family +
+  key_index). Consumer tables reference keys by a `*_key_id` FK instead of
+  inlining the three-column triple. `boarding_addresses.client_key_id` was the
+  first consumer; it replaces the previously inlined
+  `client_pubkey`/`client_key_family`/`client_key_index` columns. Keyed by
+  `(pubkey, key_family, key_index)` unique constraint; upsert is idempotent.
 - `000017_spending_reservations` — adds `spending_reservations` table with
   `(outpoint_hash, outpoint_index)` PK, `owner_kind`, `owner_id`, and
   `created_at`. A row exists IFF the owning spend session was durably

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -15,7 +15,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   `Backend`).
 - `BoardingStore` / `BoardingWalletStore` — interface + concrete
   sqlc-backed store for boarding addresses, intents, and the aggregate
-  sweep lifecycle (consumed by `wallet.BoardingStore`). Sweep ops:
+  sweep lifecycle (consumed by `wallet.BoardingStore`). `BoardingStore` embeds
+  `InternalKeyQuerier` so boarding-address writes can register the client wallet
+  key in the shared `internal_keys` registry within the same transaction. Sweep ops:
   `Create/MarkPublished/MarkFailed/List/ListPending/MarkInputSpent`.
 - `NewBoardingSweep` / `BoardingSweepRecord` /
   `BoardingSweepInputRecord` — control-plane domain types. Sweep
@@ -82,6 +84,18 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   `vtxo.SpendingReservationStore`.
 - `SpendingReservationStore` / `BatchedSpendingReservationStore` — Internal
   sqlc-backed query interfaces for the reservation table.
+- `InternalKeyQuerier` — Minimal interface for the internal-key registry helpers
+  (`UpsertInternalKey`, `GetInternalKeyByID`). Satisfied by `*sqlc.Queries` and
+  by every consumer store interface that embeds these two methods, allowing
+  register-then-reference of an internal key inside the same transaction.
+- `RegisterInternalKeyTx(ctx, qtx, now, desc)` — Idempotently records a
+  `keychain.KeyDescriptor` in the `internal_keys` table and returns its surrogate
+  id. Re-registering an identical (pubkey, key_family, key_index) triple returns
+  the existing id.
+- `InternalKeyDescByIDTx(ctx, qtx, id)` — Hydrates a `keychain.KeyDescriptor`
+  from its registry id within the caller's transaction context.
+- `ErrInternalKeyPubKeyMissing` / `ErrInternalKeyNotFound` — Sentinel errors for
+  missing public key on registration or unknown id on lookup.
 
 ## Relationships
 
@@ -125,6 +139,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 
 ### Migration notes
 
+- `000002_boarding_tables` (amended) — adds `internal_keys` table: surrogate-id
+  registry of client wallet `KeyDescriptor` values (pubkey + key_family +
+  key_index). Consumer tables reference keys by a `*_key_id` FK instead of
+  inlining the three-column triple. `boarding_addresses.client_key_id` was the
+  first consumer; it replaces the previously inlined
+  `client_pubkey`/`client_key_family`/`client_key_index` columns. Keyed by
+  `(pubkey, key_family, key_index)` unique constraint; upsert is idempotent.
 - `000017_spending_reservations` — adds `spending_reservations` table with
   `(outpoint_hash, outpoint_index)` PK, `owner_kind`, `owner_id`, and
   `created_at`. A row exists IFF the owning spend session was durably

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -30,7 +30,10 @@ server during round participation. These types are used across `round`, `vtxo`,
 - `Ancestry` — One rooted commitment-tree fragment contributing ancestry to a VTXO (defined in `lib/types/ancestry.go`). Fields: `TreePath *tree.Tree` (extracted root-to-leaf path), `CommitmentTxID chainhash.Hash`, `InputIndices []uint32` (Ark tx input indices this fragment serves; empty for round-direct VTXOs), `TreeDepth uint32`. Round-direct VTXOs carry a single-element slice; cross-round multi-input OOR VTXOs carry one entry per distinct commitment tx.
 - `MaxAncestryTreeDepth([]Ancestry) int` — Returns the largest `TreeDepth` across a slice; drives worst-case unilateral-exit timing calculations.
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
-- `BatchOutputInfo` — Batch output metadata (outpoint, value, tree root).
+- `BatchOutputInfo` — Batch output metadata: outpoint, value, and the VTXO tree
+  (`Tree`). The tree embeds the per-round sweep key, sweep delay, and PrevOut.
+  `ForfeitScript`, `SweepKey`, and `SweepDelay` were removed from this type;
+  they are now delivered per-round in `round.CommitmentTxBuilt`.
 - `ConnectorLeafInfo` — Assigned connector leaf (outpoint + output) plus the connector-tree ancestry params (`RootOutputIndex`, `NumLeaves`, `Radix`, `LeafIndex`) the client uses to reconstruct the tree and prove the leaf descends from the commitment tx before signing the forfeit (darepo-client#681).
 - `BoardingInputSignature` — Signed boarding input for round commitment.
 - `ForfeitTxSig` — Forfeit transaction signature.

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -30,7 +30,10 @@ server during round participation. These types are used across `round`, `vtxo`,
 - `Ancestry` — One rooted commitment-tree fragment contributing ancestry to a VTXO (defined in `lib/types/ancestry.go`). Fields: `TreePath *tree.Tree` (extracted root-to-leaf path), `CommitmentTxID chainhash.Hash`, `InputIndices []uint32` (Ark tx input indices this fragment serves; empty for round-direct VTXOs), `TreeDepth uint32`. Round-direct VTXOs carry a single-element slice; cross-round multi-input OOR VTXOs carry one entry per distinct commitment tx.
 - `MaxAncestryTreeDepth([]Ancestry) int` — Returns the largest `TreeDepth` across a slice; drives worst-case unilateral-exit timing calculations.
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.
-- `BatchOutputInfo` — Batch output metadata (outpoint, value, tree root).
+- `BatchOutputInfo` — Batch output metadata: outpoint, value, and the VTXO tree
+  (`Tree`). The tree embeds the per-round sweep key, sweep delay, and PrevOut.
+  `ForfeitScript`, `SweepKey`, and `SweepDelay` were removed from this type;
+  they are now delivered per-round in `round.CommitmentTxBuilt`.
 - `ConnectorLeafInfo` — Assigned connector leaf (outpoint + output) plus the connector-tree ancestry params (`RootOutputIndex`, `NumLeaves`, `Radix`, `LeafIndex`) the client uses to reconstruct the tree and prove the leaf descends from the commitment tx before signing the forfeit (darepo-client#681).
 - `BoardingInputSignature` — Signed boarding input for round commitment.
 - `ForfeitTxSig` — Forfeit transaction signature.

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -101,6 +101,33 @@ state transitions and validation rules live under [Invariants](#invariants).
   rounds (pre-admission) can be timed.
 - `MaxQuoteEntriesPerClient = 1024` (`from_proto.go`) — bounds quote
   entry decoding to reject malformed envelopes before allocating slices.
+
+### Per-round operator key fields
+
+`CommitmentTxBuilt` and the FSM states that carry it
+(`CommitmentTxReceivedState`, `CommitmentTxValidatedState`,
+`ForfeitSignaturesCollectingState`, `NoncesSentState`,
+`NoncesAggregatedState`, `PartialSigsSentState`) each carry a set of
+**per-round operator key fields** delivered by the server with the
+commitment tx. These replace the global `GetInfo` operator keys for that
+round so an operator key rotation does not invalidate the client's tree
+view:
+
+- `TreeCosignKey *btcec.PublicKey` — server's per-round MuSig2 cosigner
+  key for the VTXO output tree. Used to validate and sign the tree. Nil
+  for servers that predate this field; callers fall back to the global
+  operator key.
+- `ConnectorOperatorKey *btcec.PublicKey` — operator key used to build
+  the connector tree for this round. Nil for older servers (fallback).
+- `SweepKey *btcec.PublicKey` — operator sweep key for this round's
+  VTXO-tree sweep leaf. Replaces the global `GetInfo` sweep key entirely.
+- `SweepDelay uint32` — batch-wide absolute-timelock in blocks for the
+  VTXO-tree sweep leaf; replaces the global `GetInfo` sweep delay. Used
+  to compute batch expiry for VTXOs created in this round.
+- `ForfeitKey *btcec.PublicKey` — operator's dedicated forfeit penalty
+  key for this round; the forfeit-tx penalty output is a BIP-86 key-spend
+  to this key. Replaces the global `GetInfo` forfeit script entirely.
+
 - `FromProto` methods on `JoinRoundQuoteReceived`, `RoundJoined`,
   `CommitmentTxBuilt`, `AwaitingBoardingSigs`, `NoncesAggregated`,
   `OperatorSigned`, `BoardingFailed`, `JoinRoundRequest` — all
@@ -225,6 +252,12 @@ state transitions and validation rules live under [Invariants](#invariants).
 - `ConnectorLeafInfo.VTXOAmount` is populated from local VTXO state
   (not from the server's proto), so the forfeit penalty output equals
   the canonical local value rather than a server-supplied one.
+- Per-round operator keys (`TreeCosignKey`, `ConnectorOperatorKey`,
+  `SweepKey`, `SweepDelay`, `ForfeitKey`) delivered in `CommitmentTxBuilt`
+  always take precedence over the global `GetInfo` operator terms for the
+  duration of that round. A well-formed server always provides them. Nil
+  means the server predates this feature; callers fall back to global terms
+  only in that case.
 - **Connector ancestry is proven before any forfeit is signed**
   (`validateConnectorAncestry`, darepo-client#681). In
   `CommitmentTxReceivedState`, after VTXO-tree validation, each assigned

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -101,6 +101,33 @@ state transitions and validation rules live under [Invariants](#invariants).
   rounds (pre-admission) can be timed.
 - `MaxQuoteEntriesPerClient = 1024` (`from_proto.go`) — bounds quote
   entry decoding to reject malformed envelopes before allocating slices.
+
+### Per-round operator key fields
+
+`CommitmentTxBuilt` and the FSM states that carry it
+(`CommitmentTxReceivedState`, `CommitmentTxValidatedState`,
+`ForfeitSignaturesCollectingState`, `NoncesSentState`,
+`NoncesAggregatedState`, `PartialSigsSentState`) each carry a set of
+**per-round operator key fields** delivered by the server with the
+commitment tx. These replace the global `GetInfo` operator keys for that
+round so an operator key rotation does not invalidate the client's tree
+view:
+
+- `TreeCosignKey *btcec.PublicKey` — server's per-round MuSig2 cosigner
+  key for the VTXO output tree. Used to validate and sign the tree. Nil
+  for servers that predate this field; callers fall back to the global
+  operator key.
+- `ConnectorOperatorKey *btcec.PublicKey` — operator key used to build
+  the connector tree for this round. Nil for older servers (fallback).
+- `SweepKey *btcec.PublicKey` — operator sweep key for this round's
+  VTXO-tree sweep leaf. Replaces the global `GetInfo` sweep key entirely.
+- `SweepDelay uint32` — batch-wide absolute-timelock in blocks for the
+  VTXO-tree sweep leaf; replaces the global `GetInfo` sweep delay. Used
+  to compute batch expiry for VTXOs created in this round.
+- `ForfeitKey *btcec.PublicKey` — operator's dedicated forfeit penalty
+  key for this round; the forfeit-tx penalty output is a BIP-86 key-spend
+  to this key. Replaces the global `GetInfo` forfeit script entirely.
+
 - `FromProto` methods on `JoinRoundQuoteReceived`, `RoundJoined`,
   `CommitmentTxBuilt`, `AwaitingBoardingSigs`, `NoncesAggregated`,
   `OperatorSigned`, `BoardingFailed`, `JoinRoundRequest` — all
@@ -225,6 +252,12 @@ state transitions and validation rules live under [Invariants](#invariants).
 - `ConnectorLeafInfo.VTXOAmount` is populated from local VTXO state
   (not from the server's proto), so the forfeit penalty output equals
   the canonical local value rather than a server-supplied one.
+- Per-round operator keys (`TreeCosignKey`, `ConnectorOperatorKey`,
+  `SweepKey`, `SweepDelay`, `ForfeitKey`) delivered in `CommitmentTxBuilt`
+  always take precedence over the global `GetInfo` operator terms for the
+  duration of that round. A well-formed server always provides them. Nil
+  means the server predates this feature; callers fall back to global terms
+  only in that case.
 - **Connector ancestry is proven before any forfeit is signed**
   (`validateConnectorAncestry`, darepo-client#681). In
   `CommitmentTxReceivedState`, after VTXO-tree validation, each assigned

--- a/rpc/restclient/AGENTS.md
+++ b/rpc/restclient/AGENTS.md
@@ -47,6 +47,8 @@ interface, and per-service factory functions so callers are channel-agnostic
   (`-bin`-suffixed) keys are skipped.
 - `WatchRounds`, `SubscribeSwaps`, and `SubscribeWallet` are the only
   server-streaming methods; all other methods are unary.
+- `SwapServiceClient.AcknowledgeOutSwapHtlc` is implemented as a REST POST to
+  `/v1/swap/acknowledge-out-swap-htlc`, mirroring the gRPC stub interface.
 - Generated service clients implement the same gRPC-generated interfaces
   as the generated gRPC stubs, so callers do not branch on transport type.
 

--- a/rpc/restclient/CLAUDE.md
+++ b/rpc/restclient/CLAUDE.md
@@ -47,6 +47,8 @@ interface, and per-service factory functions so callers are channel-agnostic
   (`-bin`-suffixed) keys are skipped.
 - `WatchRounds`, `SubscribeSwaps`, and `SubscribeWallet` are the only
   server-streaming methods; all other methods are unary.
+- `SwapServiceClient.AcknowledgeOutSwapHtlc` is implemented as a REST POST to
+  `/v1/swap/acknowledge-out-swap-htlc`, mirroring the gRPC stub interface.
 - Generated service clients implement the same gRPC-generated interfaces
   as the generated gRPC stubs, so callers do not branch on transport type.
 

--- a/sdk/ark/AGENTS.md
+++ b/sdk/ark/AGENTS.md
@@ -32,7 +32,10 @@ transport, without duplicating Ark runtime behavior.
   already-connected `daemonrpc.DaemonServiceClient` and a caller-supplied
   `closeFn`.
 - `Info` / `ServerInfo` / `Seed` / `WalletInitResult` — SDK-owned typed
-  models for daemon status and wallet bootstrap flows.
+  models for daemon status and wallet bootstrap flows. `ServerInfo` no longer
+  carries `ForfeitScript`, `SweepKey`, or `SweepDelay`; those fields are now
+  delivered per-round via `round.CommitmentTxBuilt` and the live operator key
+  fetch path.
 - `VTXOInfo` — Typed VTXO view (Outpoint, AmountSat, Status, BatchExpiry,
   RoundID, CreatedHeight, etc.) returned by `ListLiveVTXOs` /
   `ListSpentVTXOs`.
@@ -44,7 +47,10 @@ transport, without duplicating Ark runtime behavior.
   spend path, and UTXO info for `SendOORWithCustomInputs`.
 - Policy/OOR helpers such as `SendOORWithPolicy`, `SendOORWithCustomInputs`,
   typed indexed VTXO lookups, and typed receive-script decoding belong here
-  so higher-level packages do not rebuild daemonrpc adapters.
+  so higher-level packages do not rebuild daemonrpc adapters. `SendOORWithPolicy`
+  and `SendOnChainWithPolicy` now use `Recipients []*daemonrpc.Output` (plural)
+  rather than a single `Recipient`; `RecipientOutpoints []string` replaces
+  `RecipientOutpoint` in the response.
 - Receive-auth helpers: `ReceiveAuthKey`, `SignReceiveAuthMessage`,
   `SignReceiveAuthMessageCompact`, `ReceiveAuthECDH` — delegate payment-scoped
   signing and Sphinx ECDH operations to the daemon wallet without exposing the

--- a/sdk/ark/CLAUDE.md
+++ b/sdk/ark/CLAUDE.md
@@ -32,7 +32,10 @@ transport, without duplicating Ark runtime behavior.
   already-connected `daemonrpc.DaemonServiceClient` and a caller-supplied
   `closeFn`.
 - `Info` / `ServerInfo` / `Seed` / `WalletInitResult` — SDK-owned typed
-  models for daemon status and wallet bootstrap flows.
+  models for daemon status and wallet bootstrap flows. `ServerInfo` no longer
+  carries `ForfeitScript`, `SweepKey`, or `SweepDelay`; those fields are now
+  delivered per-round via `round.CommitmentTxBuilt` and the live operator key
+  fetch path.
 - `VTXOInfo` — Typed VTXO view (Outpoint, AmountSat, Status, BatchExpiry,
   RoundID, CreatedHeight, etc.) returned by `ListLiveVTXOs` /
   `ListSpentVTXOs`.
@@ -44,7 +47,10 @@ transport, without duplicating Ark runtime behavior.
   spend path, and UTXO info for `SendOORWithCustomInputs`.
 - Policy/OOR helpers such as `SendOORWithPolicy`, `SendOORWithCustomInputs`,
   typed indexed VTXO lookups, and typed receive-script decoding belong here
-  so higher-level packages do not rebuild daemonrpc adapters.
+  so higher-level packages do not rebuild daemonrpc adapters. `SendOORWithPolicy`
+  and `SendOnChainWithPolicy` now use `Recipients []*daemonrpc.Output` (plural)
+  rather than a single `Recipient`; `RecipientOutpoints []string` replaces
+  `RecipientOutpoint` in the response.
 - Receive-auth helpers: `ReceiveAuthKey`, `SignReceiveAuthMessage`,
   `SignReceiveAuthMessageCompact`, `ReceiveAuthECDH` — delegate payment-scoped
   signing and Sphinx ECDH operations to the daemon wallet without exposing the

--- a/sdk/swaps/AGENTS.md
+++ b/sdk/swaps/AGENTS.md
@@ -55,8 +55,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
   payment).
 - `Store` — isolated SQLite persistence. Runs its own migration table
   (`swap_client_schema_migrations`) separate from the main daemon DB.
-- `SwapServerConn` / `GRPCSwapServerConn` — remote swap-server gRPC
-  (`RequestChannelID`, `CreateInSwap`).
+- `SwapServerConn` / `GRPCSwapServerConn` — remote swap-server gRPC.
+  Methods: `RequestChannelID`, `AcknowledgeOutSwapHTLC` (records the
+  receiver's durable acceptance of an out-swap HTLC event with the server
+  before the local ACK cursor is cleared), `CreateInSwap`.
 - `DaemonConn` — wallet operations (OOR sends, VTXO lookups, key
   queries, receive-auth signing/ECDH) provided by the Ark daemon.
   Includes `ReceiveAuthKey`, `SignReceiveAuthMessage[Compact]`, and
@@ -121,6 +123,11 @@ result into an `IncomingVHTLCNotification`.
   `SHA256(preimage) == paymentHash`.
 - Mailbox `Ack` must be called only after the caller has validated
   and durably persisted the event. `AckCursor` is `eventSeq + 1`.
+- `ReceiveSession.ackAcceptedHTLCEvent` calls `SwapServerConn.AcknowledgeOutSwapHTLC`
+  **before** clearing the local pending ACK cursor. Skipped for same-Ark
+  (`SettlementTypeInArk`) sessions — the swap server does not fund those vHTLCs.
+  `FailedPrecondition` (server not yet published) is retryable; `InvalidArgument`,
+  `NotFound`, `PermissionDenied` are terminal failures.
 - `ReceiveAuthKey` signing/ECDH is always delegated to the daemon;
   the SDK never holds the raw private key for receive-auth.
 - Error sentinels (`ErrSwapExpired`, `ErrSwapRefunded`,

--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -55,8 +55,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
   payment).
 - `Store` — isolated SQLite persistence. Runs its own migration table
   (`swap_client_schema_migrations`) separate from the main daemon DB.
-- `SwapServerConn` / `GRPCSwapServerConn` — remote swap-server gRPC
-  (`RequestChannelID`, `CreateInSwap`).
+- `SwapServerConn` / `GRPCSwapServerConn` — remote swap-server gRPC.
+  Methods: `RequestChannelID`, `AcknowledgeOutSwapHTLC` (records the
+  receiver's durable acceptance of an out-swap HTLC event with the server
+  before the local ACK cursor is cleared), `CreateInSwap`.
 - `DaemonConn` — wallet operations (OOR sends, VTXO lookups, key
   queries, receive-auth signing/ECDH) provided by the Ark daemon.
   Includes `ReceiveAuthKey`, `SignReceiveAuthMessage[Compact]`, and
@@ -121,6 +123,11 @@ result into an `IncomingVHTLCNotification`.
   `SHA256(preimage) == paymentHash`.
 - Mailbox `Ack` must be called only after the caller has validated
   and durably persisted the event. `AckCursor` is `eventSeq + 1`.
+- `ReceiveSession.ackAcceptedHTLCEvent` calls `SwapServerConn.AcknowledgeOutSwapHTLC`
+  **before** clearing the local pending ACK cursor. Skipped for same-Ark
+  (`SettlementTypeInArk`) sessions — the swap server does not fund those vHTLCs.
+  `FailedPrecondition` (server not yet published) is retryable; `InvalidArgument`,
+  `NotFound`, `PermissionDenied` are terminal failures.
 - `ReceiveAuthKey` signing/ECDH is always delegated to the daemon;
   the SDK never holds the raw private key for receive-auth.
 - Error sentinels (`ErrSwapExpired`, `ErrSwapRefunded`,

--- a/swapclientserver/AGENTS.md
+++ b/swapclientserver/AGENTS.md
@@ -29,6 +29,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `receiveSessionAdapter` — Adds method accessors over
   `sdk/swaps.ReceiveSession` so both production code and tests share the same
   interface without exposing struct fields.
+- `operatorPubKeyFetcher` — `func(context.Context) (*btcec.PublicKey, error)`;
+  function type for fetching the live operator public key from the daemon.
+- `liveOperatorDaemonConn` — wraps a `swaps.DaemonConn` and replaces the static
+  `OperatorPubKey` with a live fetcher so vHTLC policy scripts use the current
+  operator key even after a key rotation. Constructed via
+  `daemonWithLiveOperatorKey(daemon, fetcher)`.
 - `Register(ctx, grpcServer, rpcServer, cfg)` — Top-level entry point called
   by a `swapruntime`-tagged `darepod` binary. Opens the daemon-owned SQLite
   swap store, dials `swapdk-server`, creates an in-process Ark SDK facade over
@@ -86,6 +92,9 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `idempotency_key` on `StartPay` / `StartReceive` is explicitly reserved and
   returns `Unimplemented` to guard against accidental duplicate-start
   assumptions.
+- The `DaemonConn` passed to `sdk/swaps` is wrapped with
+  `daemonWithLiveOperatorKey` so every vHTLC policy build fetches the live
+  operator key via `RPCServer.OperatorPubKey` rather than a stale cached value.
 - `SetOutSwapEventReceiver` must run before any receive worker is started:
   `SwapClient` captures the receiver into the per-swap worker at start time,
   so a late install would leave already-running workers using whatever

--- a/swapclientserver/CLAUDE.md
+++ b/swapclientserver/CLAUDE.md
@@ -29,6 +29,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `receiveSessionAdapter` — Adds method accessors over
   `sdk/swaps.ReceiveSession` so both production code and tests share the same
   interface without exposing struct fields.
+- `operatorPubKeyFetcher` — `func(context.Context) (*btcec.PublicKey, error)`;
+  function type for fetching the live operator public key from the daemon.
+- `liveOperatorDaemonConn` — wraps a `swaps.DaemonConn` and replaces the static
+  `OperatorPubKey` with a live fetcher so vHTLC policy scripts use the current
+  operator key even after a key rotation. Constructed via
+  `daemonWithLiveOperatorKey(daemon, fetcher)`.
 - `Register(ctx, grpcServer, rpcServer, cfg)` — Top-level entry point called
   by a `swapruntime`-tagged `darepod` binary. Opens the daemon-owned SQLite
   swap store, dials `swapdk-server`, creates an in-process Ark SDK facade over
@@ -86,6 +92,9 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `idempotency_key` on `StartPay` / `StartReceive` is explicitly reserved and
   returns `Unimplemented` to guard against accidental duplicate-start
   assumptions.
+- The `DaemonConn` passed to `sdk/swaps` is wrapped with
+  `daemonWithLiveOperatorKey` so every vHTLC policy build fetches the live
+  operator key via `RPCServer.OperatorPubKey` rather than a stale cached value.
 - `SetOutSwapEventReceiver` must run before any receive worker is started:
   `SwapClient` captures the receiver into the per-swap worker at start time,
   so a late install would leave already-running workers using whatever

--- a/swaprpc/AGENTS.md
+++ b/swaprpc/AGENTS.md
@@ -1,0 +1,62 @@
+# swaprpc
+
+## Purpose
+
+Generated gRPC stub package for the swap server protocol. Defines the
+`SwapService` RPC interface and all message types used by clients to initiate
+Lightning-to-Ark (out-swap) and Ark-to-Lightning (in-swap) atomic swaps via
+virtual HTLCs (vHTLCs). Proto source: `swap.proto`.
+
+## Key Types
+
+- `SwapServiceClient` / `SwapServiceServer` — gRPC stub interfaces for
+  `SwapService`. Implemented by `rpc/restclient.SwapServiceClient` (REST) and
+  the remote swap server.
+- `SettlementType` — enum: `SETTLEMENT_TYPE_UNSPECIFIED` (0),
+  `SETTLEMENT_TYPE_LIGHTNING` (1), `SETTLEMENT_TYPE_IN_ARK` (2).
+- `RequestChannelIdRequest/Response` — allocates a short channel ID used as a
+  route hint in Lightning invoices for out-swap receives.
+- `CreateInSwapRequest/Response` — initiates an Ark-to-Lightning swap: client
+  provides invoice + max-fee + vHTLC pubkey; server returns vHTLC config and
+  routing info.
+- `AuthorizeInSwapRefundRequest/Response` — requests a cooperative refund
+  authorization for a failed in-swap, signed by the server with a
+  `TaprootScriptSignature`.
+- `AcknowledgeOutSwapHtlcRequest/Response` — records the receiver's durable
+  acceptance of an out-swap HTLC event. The client sends this after validating
+  the event, allowing the server to confirm delivery. Added alongside the
+  `ReceiveSession.acknowledgeOutSwapHTLC` flow in `sdk/swaps`.
+- `SwapMailboxEvent` — envelope wrapping either an `OutSwapHtlcEvent` (server
+  intercepted a Lightning HTLC for this receiver) or an `InArkHtlcEvent`
+  (same-Ark vHTLC payment).
+- `OutSwapHtlcEvent` — Lightning-backed out-swap: intercepted HTLC parameters
+  (payment hash, amount, expiry, onion, vHTLC config).
+- `InArkHtlcEvent` — same-Ark vHTLC: direct validation without bridging through
+  Lightning (payment hash, amount, sender pubkey, vHTLC config).
+- `VHTLCConfig` — vHTLC timelocks and keys: `RefundLocktime`,
+  `UnilateralClaimDelay`, `UnilateralRefundDelay`,
+  `UnilateralRefundWithoutReceiverDelay`, `SwapServerPubkey`.
+- `RouteHint` — Lightning hop hint for invoices (NodeID, ChannelID, fees,
+  CLTV expiry delta).
+- `TaprootScriptSignature` — externally produced tapscript signature for refund
+  authorization.
+
+## Relationships
+
+- **Depends on**: `google/protobuf/timestamp.proto` (generated).
+- **Depended on by**: `sdk/swaps` (client stubs), `rpc/restclient`
+  (HTTP adapter), `swapclientserver` (via `sdk/swaps`).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- `AcknowledgeOutSwapHtlc` is only called for `SETTLEMENT_TYPE_LIGHTNING`
+  sessions; same-Ark (`IN_ARK`) sessions skip the server ACK.
+- Proto source: `swaprpc/swap.proto`. Generated files: `swap.pb.go`,
+  `swap_grpc.pb.go`, `swap.pb.gw.go`, `swap_mailboxrpc.pb.go`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.
+- [sdk/swaps/CLAUDE.md](../sdk/swaps/CLAUDE.md) — Client SDK consuming this
+  protocol.

--- a/swaprpc/CLAUDE.md
+++ b/swaprpc/CLAUDE.md
@@ -1,0 +1,62 @@
+# swaprpc
+
+## Purpose
+
+Generated gRPC stub package for the swap server protocol. Defines the
+`SwapService` RPC interface and all message types used by clients to initiate
+Lightning-to-Ark (out-swap) and Ark-to-Lightning (in-swap) atomic swaps via
+virtual HTLCs (vHTLCs). Proto source: `swap.proto`.
+
+## Key Types
+
+- `SwapServiceClient` / `SwapServiceServer` — gRPC stub interfaces for
+  `SwapService`. Implemented by `rpc/restclient.SwapServiceClient` (REST) and
+  the remote swap server.
+- `SettlementType` — enum: `SETTLEMENT_TYPE_UNSPECIFIED` (0),
+  `SETTLEMENT_TYPE_LIGHTNING` (1), `SETTLEMENT_TYPE_IN_ARK` (2).
+- `RequestChannelIdRequest/Response` — allocates a short channel ID used as a
+  route hint in Lightning invoices for out-swap receives.
+- `CreateInSwapRequest/Response` — initiates an Ark-to-Lightning swap: client
+  provides invoice + max-fee + vHTLC pubkey; server returns vHTLC config and
+  routing info.
+- `AuthorizeInSwapRefundRequest/Response` — requests a cooperative refund
+  authorization for a failed in-swap, signed by the server with a
+  `TaprootScriptSignature`.
+- `AcknowledgeOutSwapHtlcRequest/Response` — records the receiver's durable
+  acceptance of an out-swap HTLC event. The client sends this after validating
+  the event, allowing the server to confirm delivery. Added alongside the
+  `ReceiveSession.acknowledgeOutSwapHTLC` flow in `sdk/swaps`.
+- `SwapMailboxEvent` — envelope wrapping either an `OutSwapHtlcEvent` (server
+  intercepted a Lightning HTLC for this receiver) or an `InArkHtlcEvent`
+  (same-Ark vHTLC payment).
+- `OutSwapHtlcEvent` — Lightning-backed out-swap: intercepted HTLC parameters
+  (payment hash, amount, expiry, onion, vHTLC config).
+- `InArkHtlcEvent` — same-Ark vHTLC: direct validation without bridging through
+  Lightning (payment hash, amount, sender pubkey, vHTLC config).
+- `VHTLCConfig` — vHTLC timelocks and keys: `RefundLocktime`,
+  `UnilateralClaimDelay`, `UnilateralRefundDelay`,
+  `UnilateralRefundWithoutReceiverDelay`, `SwapServerPubkey`.
+- `RouteHint` — Lightning hop hint for invoices (NodeID, ChannelID, fees,
+  CLTV expiry delta).
+- `TaprootScriptSignature` — externally produced tapscript signature for refund
+  authorization.
+
+## Relationships
+
+- **Depends on**: `google/protobuf/timestamp.proto` (generated).
+- **Depended on by**: `sdk/swaps` (client stubs), `rpc/restclient`
+  (HTTP adapter), `swapclientserver` (via `sdk/swaps`).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- `AcknowledgeOutSwapHtlc` is only called for `SETTLEMENT_TYPE_LIGHTNING`
+  sessions; same-Ark (`IN_ARK`) sessions skip the server ACK.
+- Proto source: `swaprpc/swap.proto`. Generated files: `swap.pb.go`,
+  `swap_grpc.pb.go`, `swap.pb.gw.go`, `swap_mailboxrpc.pb.go`.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.
+- [sdk/swaps/CLAUDE.md](../sdk/swaps/CLAUDE.md) — Client SDK consuming this
+  protocol.

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -108,6 +108,12 @@ default builds avoid the swap executor's dependency graph.
   FAILED with `failure_reason="timed_out"` BEFORE filtering, so a
   stuck row appears as FAILED even when the caller asks for
   `pending_only=false`.
+- **Cooperative-leave FORFEITED decoration**: `collectForfeitedVTXOOutpoints`
+  gathers forfeited VTXO outpoints from the ledger for the current wallet
+  session. `decorateCooperativeLeaveEntry` annotates pending wallet-local
+  cooperative-leave entries whose matched VTXO was forfeited, promoting them
+  from PENDING to a FORFEITED-decorated state so the wallet history correctly
+  reflects leave outcomes.
 - **DEPOSIT rows backed by the `wallet_utxo_created` ledger event**
   mirror the ledger confirmation status. Confirmed on-chain boarding
   deposits surface as `ENTRY_STATUS_COMPLETE`, while unconfirmed

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -108,6 +108,12 @@ default builds avoid the swap executor's dependency graph.
   FAILED with `failure_reason="timed_out"` BEFORE filtering, so a
   stuck row appears as FAILED even when the caller asks for
   `pending_only=false`.
+- **Cooperative-leave FORFEITED decoration**: `collectForfeitedVTXOOutpoints`
+  gathers forfeited VTXO outpoints from the ledger for the current wallet
+  session. `decorateCooperativeLeaveEntry` annotates pending wallet-local
+  cooperative-leave entries whose matched VTXO was forfeited, promoting them
+  from PENDING to a FORFEITED-decorated state so the wallet history correctly
+  reflects leave outcomes.
 - **DEPOSIT rows backed by the `wallet_utxo_created` ledger event**
   mirror the ledger confirmation status. Confirmed on-chain boarding
   deposits surface as `ENTRY_STATUS_COMPLETE`, while unconfirmed


### PR DESCRIPTION
Automated nightly doc-gardening sweep for 2026-06-14. Review updated CLAUDE.md/AGENTS.md diffs and ARCHITECTURE.md changes. 11 packages updated, 1 new (swaprpc). Key: chainsource reconnect, db InternalKeyQuerier, round per-round operator keys, lib/types BatchOutputInfo cleanup, sdk/ark multi-recipient OOR, sdk/swaps AcknowledgeOutSwapHTLC, rpc/restclient, swapclientserver live operator key, swapwallet forfeit history, darepod OperatorPubKey + multi-recipient SendOOR, ARCHITECTURE.md swaprpc row.