### PR TITLE
docs: nightly doc-gardening sweep 2026-06-15

### DIFF
--- a/chainsource/AGENTS.md
+++ b/chainsource/AGENTS.md
@@ -15,6 +15,12 @@ communication alongside the raw registration API.
   request. Registered under `ChainSourceKey`.
 - `ChainSourceConfig` — Config struct: `Backend ChainBackend`, `System
   *actor.ActorSystem`, `Log fn.Option[btclog.Logger]`.
+- `BlockEpochConfig` — Config for `BlockEpochActor`. Fields:
+  `Backend ChainBackend`, `Log fn.Option[btclog.Logger]`,
+  `ReconnectBackoff time.Duration` (initial reconnect delay when the
+  backend stream closes; zero → 1s default),
+  `MaxReconnectBackoff time.Duration` (exponential cap; zero → 30s
+  default). Tests may lower both to speed up reconnect cycles.
 - `ChainSourceMsg` / `ChainSourceResp` — Sealed actor message interfaces for
   requests and responses sent to the `ChainSourceActor`.
 - `FeeEstimateRequest/Response`, `BestHeightRequest/Response`,
@@ -56,6 +62,12 @@ communication alongside the raw registration API.
 - Confirmation sub-actors support two notification modes: Future-based (blocking
   await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
   mode when blocking inside a durable actor transaction is unsafe.
+- `BlockEpochActor.monitorBlocks()` auto-reconnects when the backend
+  stream closes (e.g. LND notifier restart). On channel close it
+  cancels the old registration, waits for `currentBackoff`, then calls
+  `RegisterBlocks` again. Backoff doubles on each failed re-registration
+  and resets to `ReconnectBackoff` on success. The actor stops cleanly
+  when its context is cancelled during a reconnect wait.
 
 ## Deep Docs
 

--- a/chainsource/CLAUDE.md
+++ b/chainsource/CLAUDE.md
@@ -15,6 +15,12 @@ communication alongside the raw registration API.
   request. Registered under `ChainSourceKey`.
 - `ChainSourceConfig` — Config struct: `Backend ChainBackend`, `System
   *actor.ActorSystem`, `Log fn.Option[btclog.Logger]`.
+- `BlockEpochConfig` — Config for `BlockEpochActor`. Fields:
+  `Backend ChainBackend`, `Log fn.Option[btclog.Logger]`,
+  `ReconnectBackoff time.Duration` (initial reconnect delay when the
+  backend stream closes; zero → 1s default),
+  `MaxReconnectBackoff time.Duration` (exponential cap; zero → 30s
+  default). Tests may lower both to speed up reconnect cycles.
 - `ChainSourceMsg` / `ChainSourceResp` — Sealed actor message interfaces for
   requests and responses sent to the `ChainSourceActor`.
 - `FeeEstimateRequest/Response`, `BestHeightRequest/Response`,
@@ -56,6 +62,12 @@ communication alongside the raw registration API.
 - Confirmation sub-actors support two notification modes: Future-based (blocking
   await) and actor-based (async `Tell` via `NotifyActor`). Callers use the actor
   mode when blocking inside a durable actor transaction is unsafe.
+- `BlockEpochActor.monitorBlocks()` auto-reconnects when the backend
+  stream closes (e.g. LND notifier restart). On channel close it
+  cancels the old registration, waits for `currentBackoff`, then calls
+  `RegisterBlocks` again. Backoff doubles on each failed re-registration
+  and resets to `ReconnectBackoff` on success. The actor stops cleanly
+  when its context is cancelled during a reconnect wait.
 
 ## Deep Docs
 

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -92,6 +92,12 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   (cap 1000), `offset` (clamped to `math.MaxInt32`). Delegates to
   `ledgerStore.ListTransactionHistory` and projects via
   `transactionHistoryRowToProto`.
+- `OperatorPubKey(ctx)` — `RPCServer` method that fetches the current
+  Ark operator pubkey directly from the server and refreshes the
+  daemon's cached operator terms snapshot. Subservers that construct
+  new vHTLC policy scripts call this instead of `GetInfo` so
+  operator-key rotations are observed before the policy reaches the
+  wallet or OOR layer.
 - `proxyUpstreamError(err, msg)` — gRPC-safety helper preserving
   upstream codes while stripping operator-side text. Errors without a
   status map to `codes.Unavailable`.
@@ -265,6 +271,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   per-recipient amounts outside `(0, MaxSatoshi]`, uses
   overflow-safe accumulation. Wallet-side `handleSendVTXOs` repeats
   these checks as defense-in-depth.
+- `SendOOR` enforces `maxOORRecipients = 256` at the RPC handler
+  boundary via `sendOORRequestRecipients`. Mirrors the in-round send
+  cap and provides a cheap request-size guard before script resolution
+  and policy template compilation run.
 - `SendOOR` with custom inputs serializes concurrent calls on the
   same outpoints via `reserveCustomInputs`. Custom inputs lock for
   the RPC lifetime; release is deferred on both success and failure.

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -92,6 +92,12 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   (cap 1000), `offset` (clamped to `math.MaxInt32`). Delegates to
   `ledgerStore.ListTransactionHistory` and projects via
   `transactionHistoryRowToProto`.
+- `OperatorPubKey(ctx)` — `RPCServer` method that fetches the current
+  Ark operator pubkey directly from the server and refreshes the
+  daemon's cached operator terms snapshot. Subservers that construct
+  new vHTLC policy scripts call this instead of `GetInfo` so
+  operator-key rotations are observed before the policy reaches the
+  wallet or OOR layer.
 - `proxyUpstreamError(err, msg)` — gRPC-safety helper preserving
   upstream codes while stripping operator-side text. Errors without a
   status map to `codes.Unavailable`.
@@ -265,6 +271,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   per-recipient amounts outside `(0, MaxSatoshi]`, uses
   overflow-safe accumulation. Wallet-side `handleSendVTXOs` repeats
   these checks as defense-in-depth.
+- `SendOOR` enforces `maxOORRecipients = 256` at the RPC handler
+  boundary via `sendOORRequestRecipients`. Mirrors the in-round send
+  cap and provides a cheap request-size guard before script resolution
+  and policy template compilation run.
 - `SendOOR` with custom inputs serializes concurrent calls on the
   same outpoints via `reserveCustomInputs`. Custom inputs lock for
   the RPC lifetime; release is deferred on both success and failure.

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -13,9 +13,26 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 
 - `BatchedTx[Q]` — generic interface for atomic transactions (`ExecTx`,
   `Backend`).
+- `InternalKeyQuerier` — two-method interface (`UpsertInternalKey`,
+  `GetInternalKeyByID`) for the shared internal-key registry. Embedded
+  by `BoardingStore`, `RoundStore`, and `OORArtifactPersistenceStore`
+  so consumer stores can register-then-reference a key within the same
+  transaction that writes the referencing row.
+- `RegisterInternalKeyTx(ctx, qtx, now, desc)` — idempotently records
+  a `keychain.KeyDescriptor` in the registry and returns its surrogate
+  id; re-registering the same `(pubkey, family, index)` triple returns
+  the existing id. Entry point for all consumer stores.
+- `InternalKeyDescByIDTx(ctx, qtx, id)` — reconstructs a
+  `keychain.KeyDescriptor` from a registry id; used on load to hydrate
+  key fields from the referencing row's FK.
+- `ErrInternalKeyPubKeyMissing` / `ErrInternalKeyNotFound` — error
+  sentinels returned by the two helpers above.
 - `BoardingStore` / `BoardingWalletStore` — interface + concrete
   sqlc-backed store for boarding addresses, intents, and the aggregate
-  sweep lifecycle (consumed by `wallet.BoardingStore`). Sweep ops:
+  sweep lifecycle (consumed by `wallet.BoardingStore`). `BoardingStore`
+  embeds `InternalKeyQuerier` so the boarding store can register the
+  client wallet key via the shared internal_keys registry within its
+  own transaction. Sweep ops:
   `Create/MarkPublished/MarkFailed/List/ListPending/MarkInputSpent`.
 - `NewBoardingSweep` / `BoardingSweepRecord` /
   `BoardingSweepInputRecord` — control-plane domain types. Sweep
@@ -125,6 +142,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 
 ### Migration notes
 
+- `internal_keys` shared registry — adds an `internal_keys` table with a
+  `(pubkey, key_family, key_index)` unique triple and a surrogate
+  integer PK. The boarding, round vtxo request, and OOR artifact store
+  rows that previously inlined `(client_pubkey, client_key_family,
+  client_key_index)` columns now carry a `*_key_id` FK referencing this
+  table. Existing SQL migration files (000002, 000003, 000004) were
+  updated; `LatestMigrationVersion` remains 17.
 - `000017_spending_reservations` — adds `spending_reservations` table with
   `(outpoint_hash, outpoint_index)` PK, `owner_kind`, `owner_id`, and
   `created_at`. A row exists IFF the owning spend session was durably

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -13,9 +13,26 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 
 - `BatchedTx[Q]` — generic interface for atomic transactions (`ExecTx`,
   `Backend`).
+- `InternalKeyQuerier` — two-method interface (`UpsertInternalKey`,
+  `GetInternalKeyByID`) for the shared internal-key registry. Embedded
+  by `BoardingStore`, `RoundStore`, and `OORArtifactPersistenceStore`
+  so consumer stores can register-then-reference a key within the same
+  transaction that writes the referencing row.
+- `RegisterInternalKeyTx(ctx, qtx, now, desc)` — idempotently records
+  a `keychain.KeyDescriptor` in the registry and returns its surrogate
+  id; re-registering the same `(pubkey, family, index)` triple returns
+  the existing id. Entry point for all consumer stores.
+- `InternalKeyDescByIDTx(ctx, qtx, id)` — reconstructs a
+  `keychain.KeyDescriptor` from a registry id; used on load to hydrate
+  key fields from the referencing row's FK.
+- `ErrInternalKeyPubKeyMissing` / `ErrInternalKeyNotFound` — error
+  sentinels returned by the two helpers above.
 - `BoardingStore` / `BoardingWalletStore` — interface + concrete
   sqlc-backed store for boarding addresses, intents, and the aggregate
-  sweep lifecycle (consumed by `wallet.BoardingStore`). Sweep ops:
+  sweep lifecycle (consumed by `wallet.BoardingStore`). `BoardingStore`
+  embeds `InternalKeyQuerier` so the boarding store can register the
+  client wallet key via the shared internal_keys registry within its
+  own transaction. Sweep ops:
   `Create/MarkPublished/MarkFailed/List/ListPending/MarkInputSpent`.
 - `NewBoardingSweep` / `BoardingSweepRecord` /
   `BoardingSweepInputRecord` — control-plane domain types. Sweep
@@ -125,6 +142,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 
 ### Migration notes
 
+- `internal_keys` shared registry — adds an `internal_keys` table with a
+  `(pubkey, key_family, key_index)` unique triple and a surrogate
+  integer PK. The boarding, round vtxo request, and OOR artifact store
+  rows that previously inlined `(client_pubkey, client_key_family,
+  client_key_index)` columns now carry a `*_key_id` FK referencing this
+  table. Existing SQL migration files (000002, 000003, 000004) were
+  updated; `LatestMigrationVersion` remains 17.
 - `000017_spending_reservations` — adds `spending_reservations` table with
   `(outpoint_hash, outpoint_index)` PK, `owner_kind`, `owner_id`, and
   `created_at`. A row exists IFF the owning spend session was durably

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -26,7 +26,13 @@ server during round participation. These types are used across `round`, `vtxo`,
   `TxProof fn.Option[proof.TxProof]` carries an optional SPV merkle
   inclusion proof for server-side verification of boarding UTXOs without
   requiring the server's own chain source.
-- `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount). `MaxOORLineageVBytes uint32` carries the operator-published cap on the cumulative on-chain vbytes a recipient must publish to claim a VTXO produced by an OOR submit unilaterally. Zero means no cap enforced server-side (clients fall back to a conservative local default).
+- `OperatorTerms` — Server-published global round parameters (fee rates,
+  expiry config, connector dust amount). `MaxOORLineageVBytes uint32`
+  carries the operator-published cap on cumulative on-chain vbytes a
+  recipient must publish to claim a VTXO unilaterally. Note:
+  `ForfeitScript`, `SweepKey`, and `SweepDelay` were removed — these
+  are now delivered per-round in `CommitmentTxBuilt` rather than as
+  global operator terms.
 - `Ancestry` — One rooted commitment-tree fragment contributing ancestry to a VTXO (defined in `lib/types/ancestry.go`). Fields: `TreePath *tree.Tree` (extracted root-to-leaf path), `CommitmentTxID chainhash.Hash`, `InputIndices []uint32` (Ark tx input indices this fragment serves; empty for round-direct VTXOs), `TreeDepth uint32`. Round-direct VTXOs carry a single-element slice; cross-round multi-input OOR VTXOs carry one entry per distinct commitment tx.
 - `MaxAncestryTreeDepth([]Ancestry) int` — Returns the largest `TreeDepth` across a slice; drives worst-case unilateral-exit timing calculations.
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -26,7 +26,13 @@ server during round participation. These types are used across `round`, `vtxo`,
   `TxProof fn.Option[proof.TxProof]` carries an optional SPV merkle
   inclusion proof for server-side verification of boarding UTXOs without
   requiring the server's own chain source.
-- `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount). `MaxOORLineageVBytes uint32` carries the operator-published cap on the cumulative on-chain vbytes a recipient must publish to claim a VTXO produced by an OOR submit unilaterally. Zero means no cap enforced server-side (clients fall back to a conservative local default).
+- `OperatorTerms` — Server-published global round parameters (fee rates,
+  expiry config, connector dust amount). `MaxOORLineageVBytes uint32`
+  carries the operator-published cap on cumulative on-chain vbytes a
+  recipient must publish to claim a VTXO unilaterally. Note:
+  `ForfeitScript`, `SweepKey`, and `SweepDelay` were removed — these
+  are now delivered per-round in `CommitmentTxBuilt` rather than as
+  global operator terms.
 - `Ancestry` — One rooted commitment-tree fragment contributing ancestry to a VTXO (defined in `lib/types/ancestry.go`). Fields: `TreePath *tree.Tree` (extracted root-to-leaf path), `CommitmentTxID chainhash.Hash`, `InputIndices []uint32` (Ark tx input indices this fragment serves; empty for round-direct VTXOs), `TreeDepth uint32`. Round-direct VTXOs carry a single-element slice; cross-round multi-input OOR VTXOs carry one entry per distinct commitment tx.
 - `MaxAncestryTreeDepth([]Ancestry) int` — Returns the largest `TreeDepth` across a slice; drives worst-case unilateral-exit timing calculations.
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.

--- a/oor/AGENTS.md
+++ b/oor/AGENTS.md
@@ -205,6 +205,14 @@ State transitions and validation rules live under [Invariants](#invariants).
 
 ## Invariants
 
+- **Checkpoint owner-leaf normalization**: before building an outgoing
+  package, `normalizeCheckpointOwnerLeaves` rebuilds each standard
+  input's checkpoint output owner collaborative leaf to commit to the
+  *session* operator key (from `CheckpointPolicy.OperatorKey`) rather
+  than the spent input VTXO's operator key. A VTXO created under a
+  pre-rotation operator key would otherwise produce a checkpoint output
+  that the rotated operator cannot co-sign. Custom-spend inputs (e.g.
+  vHTLC) carry their own owner leaf and are left untouched.
 - Checkpoint output collab path is 2-of-2
   `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig.
 - `signCustomCheckpointPSBT` re-verifies that the custom spend path

--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -205,6 +205,14 @@ State transitions and validation rules live under [Invariants](#invariants).
 
 ## Invariants
 
+- **Checkpoint owner-leaf normalization**: before building an outgoing
+  package, `normalizeCheckpointOwnerLeaves` rebuilds each standard
+  input's checkpoint output owner collaborative leaf to commit to the
+  *session* operator key (from `CheckpointPolicy.OperatorKey`) rather
+  than the spent input VTXO's operator key. A VTXO created under a
+  pre-rotation operator key would otherwise produce a checkpoint output
+  that the rotated operator cannot co-sign. Custom-spend inputs (e.g.
+  vHTLC) carry their own owner leaf and are left untouched.
 - Checkpoint output collab path is 2-of-2
   `MultiSigCollabTapLeaf(clientKey, operatorKey)`, not single-sig.
 - `signCustomCheckpointPSBT` re-verifies that the custom spend path

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -101,6 +101,16 @@ state transitions and validation rules live under [Invariants](#invariants).
   rounds (pre-admission) can be timed.
 - `MaxQuoteEntriesPerClient = 1024` (`from_proto.go`) — bounds quote
   entry decoding to reject malformed envelopes before allocating slices.
+- `CommitmentTxBuilt` per-round operator keys (added alongside the base
+  fields): `TreeCosignKey` (operator MuSig2 cosigner key for VTXO tree,
+  derived fresh per round so tree validation is independent of global
+  GetInfo key), `ConnectorOperatorKey` (operator key used to build the
+  connector tree for this round), `SweepKey` (operator sweep key for the
+  VTXO-tree sweep leaf), `SweepDelay` (batch-wide absolute-timelock in
+  blocks for the sweep leaf), `ForfeitKey` (dedicated forfeit penalty
+  key; forfeit-tx penalty output is BIP-86 key-spend to this key). All
+  four keys replace the global GetInfo equivalents on well-formed
+  rounds; nil means server predates the field (fallback to global key).
 - `FromProto` methods on `JoinRoundQuoteReceived`, `RoundJoined`,
   `CommitmentTxBuilt`, `AwaitingBoardingSigs`, `NoncesAggregated`,
   `OperatorSigned`, `BoardingFailed`, `JoinRoundRequest` — all
@@ -153,14 +163,30 @@ state transitions and validation rules live under [Invariants](#invariants).
 
 ## Invariants
 
+- **Per-round operator keys** (`SweepKey`, `SweepDelay`, `ForfeitKey`,
+  `TreeCosignKey`, `ConnectorOperatorKey`) are captured in
+  `CommitmentTxReceivedState` and carried through all subsequent signing
+  states. Sweep-vs-exit-delay security validation runs per-round in
+  `CommitmentTxReceivedState`; it was removed from actor construction
+  (`ValidateDelayParameters`) so a single round's parameters do not
+  block unrelated rounds.
 - Tree signatures are validated **before** boarding input signatures
   are released (security checkpoint at `InputSigSent`).
+- Forfeit timeout is **armed before** forfeit-signature requests are
+  dispatched to individual VTXO actors. This ensures the
+  `ForfeitSignaturesCollecting` window starts before any request is in
+  flight, so a late or stalled response is bounded by the timer rather
+  than accumulating unbounded.
 - Forfeit signatures are collected **after** VTXO tree signing
   completes — clients only forfeit old VTXOs after verifying the new
   VTXOs are properly signed.
 - Aggregated signatures validated on `VTXOTreePaths` are propagated to
   extracted `ClientTrees` via `SubmitTreeSigs` + `VerifySigned`, so
   persisted client trees carry valid signatures for unilateral exit.
+- Commitment-tx confirmation monitoring watches the **validated batch
+  output** (the output that receives this client's funds), selected by
+  `confirmationWatchScript` from the VTXO tree paths. Falls back to
+  output 0 when no trees are available (pre-checkpoint restarts).
 - Round state is checkpointed atomically after tree validation — a
   crash before checkpoint means the client has no record of sent
   signatures.

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -101,6 +101,16 @@ state transitions and validation rules live under [Invariants](#invariants).
   rounds (pre-admission) can be timed.
 - `MaxQuoteEntriesPerClient = 1024` (`from_proto.go`) — bounds quote
   entry decoding to reject malformed envelopes before allocating slices.
+- `CommitmentTxBuilt` per-round operator keys (added alongside the base
+  fields): `TreeCosignKey` (operator MuSig2 cosigner key for VTXO tree,
+  derived fresh per round so tree validation is independent of global
+  GetInfo key), `ConnectorOperatorKey` (operator key used to build the
+  connector tree for this round), `SweepKey` (operator sweep key for the
+  VTXO-tree sweep leaf), `SweepDelay` (batch-wide absolute-timelock in
+  blocks for the sweep leaf), `ForfeitKey` (dedicated forfeit penalty
+  key; forfeit-tx penalty output is BIP-86 key-spend to this key). All
+  four keys replace the global GetInfo equivalents on well-formed
+  rounds; nil means server predates the field (fallback to global key).
 - `FromProto` methods on `JoinRoundQuoteReceived`, `RoundJoined`,
   `CommitmentTxBuilt`, `AwaitingBoardingSigs`, `NoncesAggregated`,
   `OperatorSigned`, `BoardingFailed`, `JoinRoundRequest` — all
@@ -153,14 +163,30 @@ state transitions and validation rules live under [Invariants](#invariants).
 
 ## Invariants
 
+- **Per-round operator keys** (`SweepKey`, `SweepDelay`, `ForfeitKey`,
+  `TreeCosignKey`, `ConnectorOperatorKey`) are captured in
+  `CommitmentTxReceivedState` and carried through all subsequent signing
+  states. Sweep-vs-exit-delay security validation runs per-round in
+  `CommitmentTxReceivedState`; it was removed from actor construction
+  (`ValidateDelayParameters`) so a single round's parameters do not
+  block unrelated rounds.
 - Tree signatures are validated **before** boarding input signatures
   are released (security checkpoint at `InputSigSent`).
+- Forfeit timeout is **armed before** forfeit-signature requests are
+  dispatched to individual VTXO actors. This ensures the
+  `ForfeitSignaturesCollecting` window starts before any request is in
+  flight, so a late or stalled response is bounded by the timer rather
+  than accumulating unbounded.
 - Forfeit signatures are collected **after** VTXO tree signing
   completes — clients only forfeit old VTXOs after verifying the new
   VTXOs are properly signed.
 - Aggregated signatures validated on `VTXOTreePaths` are propagated to
   extracted `ClientTrees` via `SubmitTreeSigs` + `VerifySigned`, so
   persisted client trees carry valid signatures for unilateral exit.
+- Commitment-tx confirmation monitoring watches the **validated batch
+  output** (the output that receives this client's funds), selected by
+  `confirmationWatchScript` from the VTXO tree paths. Falls back to
+  output 0 when no trees are available (pre-checkpoint restarts).
 - Round state is checkpointed atomically after tree validation — a
   crash before checkpoint means the client has no record of sent
   signatures.

--- a/sdk/swaps/AGENTS.md
+++ b/sdk/swaps/AGENTS.md
@@ -56,7 +56,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
 - `Store` — isolated SQLite persistence. Runs its own migration table
   (`swap_client_schema_migrations`) separate from the main daemon DB.
 - `SwapServerConn` / `GRPCSwapServerConn` — remote swap-server gRPC
-  (`RequestChannelID`, `CreateInSwap`).
+  (`RequestChannelID`, `AcknowledgeOutSwapHTLC`, `CreateInSwap`).
+  `AcknowledgeOutSwapHTLC(ctx, paymentHash, vhtlcPubkey)` tells the
+  server this receiver validated and durably accepted the out-swap HTLC
+  event; must be called after the caller has checkpointed the event.
 - `DaemonConn` — wallet operations (OOR sends, VTXO lookups, key
   queries, receive-auth signing/ECDH) provided by the Ark daemon.
   Includes `ReceiveAuthKey`, `SignReceiveAuthMessage[Compact]`, and

--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -56,7 +56,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
 - `Store` — isolated SQLite persistence. Runs its own migration table
   (`swap_client_schema_migrations`) separate from the main daemon DB.
 - `SwapServerConn` / `GRPCSwapServerConn` — remote swap-server gRPC
-  (`RequestChannelID`, `CreateInSwap`).
+  (`RequestChannelID`, `AcknowledgeOutSwapHTLC`, `CreateInSwap`).
+  `AcknowledgeOutSwapHTLC(ctx, paymentHash, vhtlcPubkey)` tells the
+  server this receiver validated and durably accepted the out-swap HTLC
+  event; must be called after the caller has checkpointed the event.
 - `DaemonConn` — wallet operations (OOR sends, VTXO lookups, key
   queries, receive-auth signing/ECDH) provided by the Ark daemon.
   Includes `ReceiveAuthKey`, `SignReceiveAuthMessage[Compact]`, and

--- a/swapclientserver/AGENTS.md
+++ b/swapclientserver/AGENTS.md
@@ -22,6 +22,15 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
   the subserver unit-testable without running real swap FSMs.
 - `swapClientAdapter` — Thin production adapter that forwards calls to
   `*swaps.SwapClient`.
+- `operatorPubKeyFetcher` — `func(context.Context) (*btcec.PublicKey, error)`;
+  fetches the current Ark operator pubkey live (bypassing GetInfo cache).
+- `liveOperatorDaemonConn` — wraps a `swaps.DaemonConn`, overriding
+  `OperatorPubKey` to call the live fetcher. All other methods delegate
+  to the embedded connection.
+- `daemonWithLiveOperatorKey(daemon, fetch)` — factory returning a
+  `liveOperatorDaemonConn` when `fetch` is non-nil, or the original
+  `daemon` otherwise. Used so swap vHTLC policies see operator-key
+  rotations before OOR funding is submitted.
 - `paySwapSession` / `receiveSwapSession` — Minimal session interfaces
   (`PaymentHash`, `Wait`, and `Invoice` for receive) that the daemon
   goroutines drive. Production implementations are `sdk/swaps.PaySession` and
@@ -86,6 +95,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `idempotency_key` on `StartPay` / `StartReceive` is explicitly reserved and
   returns `Unimplemented` to guard against accidental duplicate-start
   assumptions.
+- **Live operator key**: `Register` wraps `arkClient` with
+  `daemonWithLiveOperatorKey` so `SwapClient` calls
+  `RPCServer.OperatorPubKey` (direct Ark transport) rather than the
+  cached GetInfo snapshot when constructing new vHTLC policies. This
+  ensures operator-key rotations are observed before OOR funding is
+  submitted.
 - `SetOutSwapEventReceiver` must run before any receive worker is started:
   `SwapClient` captures the receiver into the per-swap worker at start time,
   so a late install would leave already-running workers using whatever

--- a/swapclientserver/CLAUDE.md
+++ b/swapclientserver/CLAUDE.md
@@ -22,6 +22,15 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
   the subserver unit-testable without running real swap FSMs.
 - `swapClientAdapter` — Thin production adapter that forwards calls to
   `*swaps.SwapClient`.
+- `operatorPubKeyFetcher` — `func(context.Context) (*btcec.PublicKey, error)`;
+  fetches the current Ark operator pubkey live (bypassing GetInfo cache).
+- `liveOperatorDaemonConn` — wraps a `swaps.DaemonConn`, overriding
+  `OperatorPubKey` to call the live fetcher. All other methods delegate
+  to the embedded connection.
+- `daemonWithLiveOperatorKey(daemon, fetch)` — factory returning a
+  `liveOperatorDaemonConn` when `fetch` is non-nil, or the original
+  `daemon` otherwise. Used so swap vHTLC policies see operator-key
+  rotations before OOR funding is submitted.
 - `paySwapSession` / `receiveSwapSession` — Minimal session interfaces
   (`PaymentHash`, `Wait`, and `Invoice` for receive) that the daemon
   goroutines drive. Production implementations are `sdk/swaps.PaySession` and
@@ -86,6 +95,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `idempotency_key` on `StartPay` / `StartReceive` is explicitly reserved and
   returns `Unimplemented` to guard against accidental duplicate-start
   assumptions.
+- **Live operator key**: `Register` wraps `arkClient` with
+  `daemonWithLiveOperatorKey` so `SwapClient` calls
+  `RPCServer.OperatorPubKey` (direct Ark transport) rather than the
+  cached GetInfo snapshot when constructing new vHTLC policies. This
+  ensures operator-key rotations are observed before OOR funding is
+  submitted.
 - `SetOutSwapEventReceiver` must run before any receive worker is started:
   `SwapClient` captures the receiver into the per-swap worker at start time,
   so a late install would leave already-running workers using whatever

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -86,6 +86,15 @@ default builds avoid the swap executor's dependency graph.
   RECV (Lightning payment_hash) across the entire pending → terminal
   lifecycle. EXIT and DEPOSIT rows do not yet share an id between
   pending and confirmed in v1; see `doc.go`.
+- **Cooperative leave completion**: a wallet-local EXIT row transitions
+  to COMPLETE when its source VTXO is terminally forfeited. The
+  activity list collects forfeited VTXO outpoints via
+  `collectForfeitedVTXOOutpoints` (only when local EXIT entries exist)
+  and passes them to `collectWalletLocalPendingEntries` so the
+  decorator can mark the EXIT as complete without waiting for a durable
+  ledger row. After daemon restart, the pending EXIT row cannot be
+  recreated from durable state alone; callers should use the ledger
+  history to correlate.
 - Onchain SEND is routed through `RPCServer.SendOnChain` which delegates to
   `wallet.SendOnChainRequest`. Two modes: **sweep-all** (non-empty
   `SweepOutpoints` — drains those VTXOs exactly, no change, leave output

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -86,6 +86,15 @@ default builds avoid the swap executor's dependency graph.
   RECV (Lightning payment_hash) across the entire pending → terminal
   lifecycle. EXIT and DEPOSIT rows do not yet share an id between
   pending and confirmed in v1; see `doc.go`.
+- **Cooperative leave completion**: a wallet-local EXIT row transitions
+  to COMPLETE when its source VTXO is terminally forfeited. The
+  activity list collects forfeited VTXO outpoints via
+  `collectForfeitedVTXOOutpoints` (only when local EXIT entries exist)
+  and passes them to `collectWalletLocalPendingEntries` so the
+  decorator can mark the EXIT as complete without waiting for a durable
+  ledger row. After daemon restart, the pending EXIT row cannot be
+  recreated from durable state alone; callers should use the ledger
+  history to correlate.
 - Onchain SEND is routed through `RPCServer.SendOnChain` which delegates to
   `wallet.SendOnChainRequest`. Two modes: **sweep-all** (non-empty
   `SweepOutpoints` — drains those VTXOs exactly, no change, leave output


### PR DESCRIPTION
Automated nightly doc-gardening sweep for 2026-06-15.

Workflow run: ${SERVER_URL:-https://github.com/lightninglabs/darepo-client}/actions/runs/${RUN_ID:-nightly}

## What changed

Updated CLAUDE.md and AGENTS.md for 9 packages (18 files) to reflect
Go source changes since the last merged sweep (base: 9ceba73fb9).

Key changes documented:

- **db**: new `InternalKeyQuerier` interface and `RegisterInternalKeyTx`
  / `InternalKeyDescByIDTx` helpers; `BoardingStore` now embeds
  `InternalKeyQuerier`; client keys stored via FK to shared
  `internal_keys` registry instead of inlined columns.
- **round**: per-round operator key delivery (`TreeCosignKey`,
  `ConnectorOperatorKey`, `SweepKey`, `SweepDelay`, `ForfeitKey`) via
  `CommitmentTxBuilt`; forfeit timeout armed before forfeit requests are
  dispatched; confirmation monitoring watches batch output not output 0.
- **lib/types**: `ForfeitScript`, `SweepKey`, `SweepDelay` removed from
  `OperatorTerms` — now delivered per-round.
- **chainsource**: `BlockEpochConfig` gains `ReconnectBackoff` /
  `MaxReconnectBackoff`; `BlockEpochActor` auto-reconnects on stream close.
- **sdk/swaps**: `AcknowledgeOutSwapHTLC` added to `SwapServerConn`.
- **oor**: `normalizeCheckpointOwnerLeaves` invariant for operator key
  rotation handling on checkpoint owner leaf.
- **swapwallet**: cooperative leave EXIT rows complete when source VTXO
  is terminally forfeited.
- **swapclientserver**: `liveOperatorDaemonConn` wraps `DaemonConn` to
  fetch operator pubkey live for vHTLC policy construction.
- **darepod**: `RPCServer.OperatorPubKey` method; `maxOORRecipients = 256`.

## Review

Please review the diffs in the updated `CLAUDE.md` / `AGENTS.md` files
and `ARCHITECTURE.md` (no architecture changes this sweep) for accuracy
against the Go source changes in the listed packages.
