### PR TITLE
darepod: move OOR receive key family into lnd's provisioned range

### DIFF
--- a/darepod/receive_script.go
+++ b/darepod/receive_script.go
@@ -21,9 +21,20 @@ const (
 	defaultOORReceiveScriptRegistrationTTL = 30 * 24 * time.Hour
 
 	// oorReceiveKeyFamily is the key family used for OOR receive
-	// keys. Uses a custom family distinct from the identity key
-	// family to keep receive keys in their own derivation path.
-	oorReceiveKeyFamily = keychain.KeyFamily(987_200)
+	// keys. It is distinct from the identity key family (and the
+	// boarding/VTXO families) so receive keys live in their own
+	// derivation path.
+	//
+	// The value must stay within the range of key family accounts that
+	// lnd pre-provisions on a wallet (families 0..255, created via
+	// InitAccounts when the wallet is set up or converted to
+	// watch-only). Deriving from a family outside that range forces
+	// lnd to create the account on demand, which needs the master key
+	// and therefore fails on a watch-only + remote-signer wallet with
+	// "address manager is watching-only". 202 keeps us inside the
+	// pre-provisioned range and continues the ark operator block
+	// (sweep=200, operator=201) used on the server side.
+	oorReceiveKeyFamily = keychain.KeyFamily(202)
 )
 
 // DefaultOORReceiveKeyFamily returns the key family used for


### PR DESCRIPTION
In this PR, we move `oorReceiveKeyFamily` from `987_200` down to `202`, so
OOR receive key derivation stays inside the range of key family accounts
that lnd actually provisions on a wallet. This fixes the testnet swapdk Ark
client breeder, which could board a vTXO but then failed to split it with
`rpc error: code = Unknown desc = address manager is watching-only` (see
lightninglabs/lightning-infra#3392).

## Root cause

lnd only pre-creates key family accounts `0..255` up front. It does this via
`InitAccounts` both when a wallet is first set up and when a wallet is
converted to watch-only (`InitAccounts(scope, convertToWatchOnly, 255)` in
`lnwallet/btcwallet`). When you ask for a key from a family outside that
range, lnd's keyring falls through `createAccountIfNotExists` to
`NewRawAccount`, which has to derive a fresh account xpub from the master
key.

That on-the-fly account creation is exactly what a watch-only wallet can't
do. The testnet `swapdk-ark-client` is backed by `lnd-pool-gateway`, which
is a wallet converted to watch-only and paired with a remote signer, so the
master key is gone. The breeder's `NewReceiveScript` path hits
`DeriveNextKey(987_200)`, lnd tries to materialize account `987_200`, and
the address manager rejects it because it's watching-only. The whole thing
fails before a script is ever registered.

The reason this only showed up on testnet is that signet's client is wired
to a full-key lnd that happily creates account `987_200` on demand, so the
same code path works there. And arkd shares the same watch-only pool-gateway
without trouble because its own families sit under the line already
(`sweep=200`, `operator=201`).

## The fix

`202` keeps us inside the pre-provisioned `0..255` range and continues the
ark operator block already used on the server side (`sweep=200`,
`operator=201`). It also stays clear of the families this client already
uses, so receive keys keep their own derivation path: boarding is `42`, the
round-join identifier is `43`, and the VTXO owner/signing families are `44`
and `45`. With this, the OOR receive path derives cleanly from a watch-only
plus remote-signer lnd, and swapd and arkd can keep sharing the same backing
node instead of pinning the client to a hot wallet.

## Compatibility note

This changes the derivation path for OOR receive keys, so any receive
scripts already registered under family `987_200` (e.g. on signet, where the
old path worked) won't be re-derived under the new family. Given OOR receive
on testnet never got off the ground and signet is still early, that seems
fine, but worth a sanity check before this rolls anywhere with funds parked
on `987_200`-derived scripts.

Closes https://github.com/lightninglabs/lightning-infra/issues/3392