### PR TITLE
multi: Add Ark protocol version negotiation and enforcement

### DIFF
--- a/arkrpc/ark.pb.go
+++ b/arkrpc/ark.pb.go
@@ -21,10 +21,75 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// State is the lifecycle state of an Ark protocol version.
+type ArkVersionPolicy_State int32
+
+const (
+	// STATE_UNSPECIFIED is the zero value and must not be used as a real
+	// policy state.
+	ArkVersionPolicy_STATE_UNSPECIFIED ArkVersionPolicy_State = 0
+	// STATE_ACTIVE means the version may be selected without warning.
+	ArkVersionPolicy_STATE_ACTIVE ArkVersionPolicy_State = 1
+	// STATE_DEPRECATING means the version may still be selected, but the
+	// client must surface the disable deadline and upgrade URL.
+	ArkVersionPolicy_STATE_DEPRECATING ArkVersionPolicy_State = 2
+	// STATE_DISABLED means the version must never be selected or accepted.
+	ArkVersionPolicy_STATE_DISABLED ArkVersionPolicy_State = 3
+)
+
+// Enum value maps for ArkVersionPolicy_State.
+var (
+	ArkVersionPolicy_State_name = map[int32]string{
+		0: "STATE_UNSPECIFIED",
+		1: "STATE_ACTIVE",
+		2: "STATE_DEPRECATING",
+		3: "STATE_DISABLED",
+	}
+	ArkVersionPolicy_State_value = map[string]int32{
+		"STATE_UNSPECIFIED": 0,
+		"STATE_ACTIVE":      1,
+		"STATE_DEPRECATING": 2,
+		"STATE_DISABLED":    3,
+	}
+)
+
+func (x ArkVersionPolicy_State) Enum() *ArkVersionPolicy_State {
+	p := new(ArkVersionPolicy_State)
+	*p = x
+	return p
+}
+
+func (x ArkVersionPolicy_State) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ArkVersionPolicy_State) Descriptor() protoreflect.EnumDescriptor {
+	return file_ark_proto_enumTypes[0].Descriptor()
+}
+
+func (ArkVersionPolicy_State) Type() protoreflect.EnumType {
+	return &file_ark_proto_enumTypes[0]
+}
+
+func (x ArkVersionPolicy_State) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ArkVersionPolicy_State.Descriptor instead.
+func (ArkVersionPolicy_State) EnumDescriptor() ([]byte, []int) {
+	return file_ark_proto_rawDescGZIP(), []int{1, 0}
+}
+
 type GetInfoRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// supported_ark_versions lists the Ark protocol versions this client can
+	// use, ordered by client preference (most preferred first). The operator
+	// selects the first operator-preferred version present in this list. An
+	// empty list is interpreted as support for Ark v1 only during the
+	// documented legacy rollout window.
+	SupportedArkVersions []uint32 `protobuf:"varint,1,rep,packed,name=supported_ark_versions,json=supportedArkVersions,proto3" json:"supported_ark_versions,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *GetInfoRequest) Reset() {
@@ -55,6 +120,90 @@ func (x *GetInfoRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use GetInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetInfoRequest) Descriptor() ([]byte, []int) {
 	return file_ark_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *GetInfoRequest) GetSupportedArkVersions() []uint32 {
+	if x != nil {
+		return x.SupportedArkVersions
+	}
+	return nil
+}
+
+// ArkVersionPolicy advertises the operator's deprecation policy for a single
+// Ark protocol version. It lets a client surface upgrade deadlines and URLs
+// for the version it negotiates.
+type ArkVersionPolicy struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// version is the Ark protocol version this policy describes.
+	Version uint32 `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
+	// state is the lifecycle state of the version.
+	State ArkVersionPolicy_State `protobuf:"varint,2,opt,name=state,proto3,enum=arkrpc.ArkVersionPolicy_State" json:"state,omitempty"`
+	// disable_after_unix_s is the advertised planned cutoff (wall-clock unix
+	// seconds) after which the operator intends to disable this version. It is
+	// an advertised deadline, not an automatic timer.
+	DisableAfterUnixS int64 `protobuf:"varint,3,opt,name=disable_after_unix_s,json=disableAfterUnixS,proto3" json:"disable_after_unix_s,omitempty"`
+	// upgrade_url points the client at upgrade instructions for this version.
+	UpgradeUrl    string `protobuf:"bytes,4,opt,name=upgrade_url,json=upgradeUrl,proto3" json:"upgrade_url,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ArkVersionPolicy) Reset() {
+	*x = ArkVersionPolicy{}
+	mi := &file_ark_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ArkVersionPolicy) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ArkVersionPolicy) ProtoMessage() {}
+
+func (x *ArkVersionPolicy) ProtoReflect() protoreflect.Message {
+	mi := &file_ark_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ArkVersionPolicy.ProtoReflect.Descriptor instead.
+func (*ArkVersionPolicy) Descriptor() ([]byte, []int) {
+	return file_ark_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *ArkVersionPolicy) GetVersion() uint32 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+func (x *ArkVersionPolicy) GetState() ArkVersionPolicy_State {
+	if x != nil {
+		return x.State
+	}
+	return ArkVersionPolicy_STATE_UNSPECIFIED
+}
+
+func (x *ArkVersionPolicy) GetDisableAfterUnixS() int64 {
+	if x != nil {
+		return x.DisableAfterUnixS
+	}
+	return 0
+}
+
+func (x *ArkVersionPolicy) GetUpgradeUrl() string {
+	if x != nil {
+		return x.UpgradeUrl
+	}
+	return ""
 }
 
 type GetInfoResponse struct {
@@ -111,13 +260,23 @@ type GetInfoResponse struct {
 	// cap pre-submit to avoid round-trip rejections; a value of 0 means
 	// the operator does not enforce a cap.
 	MaxOorLineageVbytes uint32 `protobuf:"varint,18,opt,name=max_oor_lineage_vbytes,json=maxOorLineageVbytes,proto3" json:"max_oor_lineage_vbytes,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// selected_ark_version is the Ark protocol version the operator selected
+	// for this client from its supported_ark_versions request. Zero means no
+	// common version exists; the client must not start its mailbox runtime.
+	SelectedArkVersion uint32 `protobuf:"varint,19,opt,name=selected_ark_version,json=selectedArkVersion,proto3" json:"selected_ark_version,omitempty"`
+	// supported_ark_versions lists the Ark protocol versions the operator
+	// currently has enabled, in operator-preference order.
+	SupportedArkVersions []uint32 `protobuf:"varint,20,rep,packed,name=supported_ark_versions,json=supportedArkVersions,proto3" json:"supported_ark_versions,omitempty"`
+	// ark_version_policies carries upgrade and deprecation information for the
+	// operator's known Ark protocol versions.
+	ArkVersionPolicies []*ArkVersionPolicy `protobuf:"bytes,21,rep,name=ark_version_policies,json=arkVersionPolicies,proto3" json:"ark_version_policies,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *GetInfoResponse) Reset() {
 	*x = GetInfoResponse{}
-	mi := &file_ark_proto_msgTypes[1]
+	mi := &file_ark_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -129,7 +288,7 @@ func (x *GetInfoResponse) String() string {
 func (*GetInfoResponse) ProtoMessage() {}
 
 func (x *GetInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ark_proto_msgTypes[1]
+	mi := &file_ark_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -142,7 +301,7 @@ func (x *GetInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetInfoResponse) Descriptor() ([]byte, []int) {
-	return file_ark_proto_rawDescGZIP(), []int{1}
+	return file_ark_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *GetInfoResponse) GetVersion() string {
@@ -271,6 +430,27 @@ func (x *GetInfoResponse) GetMaxOorLineageVbytes() uint32 {
 	return 0
 }
 
+func (x *GetInfoResponse) GetSelectedArkVersion() uint32 {
+	if x != nil {
+		return x.SelectedArkVersion
+	}
+	return 0
+}
+
+func (x *GetInfoResponse) GetSupportedArkVersions() []uint32 {
+	if x != nil {
+		return x.SupportedArkVersions
+	}
+	return nil
+}
+
+func (x *GetInfoResponse) GetArkVersionPolicies() []*ArkVersionPolicy {
+	if x != nil {
+		return x.ArkVersionPolicies
+	}
+	return nil
+}
+
 // EstimateFeeRequest asks the server to estimate the fee for a
 // VTXO operation at current rates and utilization.
 type EstimateFeeRequest struct {
@@ -289,7 +469,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_ark_proto_msgTypes[2]
+	mi := &file_ark_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -301,7 +481,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ark_proto_msgTypes[2]
+	mi := &file_ark_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -314,7 +494,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_ark_proto_rawDescGZIP(), []int{2}
+	return file_ark_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *EstimateFeeRequest) GetAmountSat() int64 {
@@ -367,7 +547,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_ark_proto_msgTypes[3]
+	mi := &file_ark_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -379,7 +559,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ark_proto_msgTypes[3]
+	mi := &file_ark_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -392,7 +572,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_ark_proto_rawDescGZIP(), []int{3}
+	return file_ark_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *EstimateFeeResponse) GetLiquidityFeeSat() int64 {
@@ -448,8 +628,20 @@ var File_ark_proto protoreflect.FileDescriptor
 
 const file_ark_proto_rawDesc = "" +
 	"\n" +
-	"\tark.proto\x12\x06arkrpc\"\x10\n" +
-	"\x0eGetInfoRequest\"\xac\x05\n" +
+	"\tark.proto\x12\x06arkrpc\"F\n" +
+	"\x0eGetInfoRequest\x124\n" +
+	"\x16supported_ark_versions\x18\x01 \x03(\rR\x14supportedArkVersions\"\x91\x02\n" +
+	"\x10ArkVersionPolicy\x12\x18\n" +
+	"\aversion\x18\x01 \x01(\rR\aversion\x124\n" +
+	"\x05state\x18\x02 \x01(\x0e2\x1e.arkrpc.ArkVersionPolicy.StateR\x05state\x12/\n" +
+	"\x14disable_after_unix_s\x18\x03 \x01(\x03R\x11disableAfterUnixS\x12\x1f\n" +
+	"\vupgrade_url\x18\x04 \x01(\tR\n" +
+	"upgradeUrl\"[\n" +
+	"\x05State\x12\x15\n" +
+	"\x11STATE_UNSPECIFIED\x10\x00\x12\x10\n" +
+	"\fSTATE_ACTIVE\x10\x01\x12\x15\n" +
+	"\x11STATE_DEPRECATING\x10\x02\x12\x12\n" +
+	"\x0eSTATE_DISABLED\x10\x03\"\xe0\x06\n" +
 	"\x0fGetInfoResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x16\n" +
 	"\x06pubkey\x18\x02 \x01(\fR\x06pubkey\x12\x18\n" +
@@ -472,7 +664,10 @@ const file_ark_proto_rawDesc = "" +
 	"\vannual_rate\x18\x10 \x01(\x01R\n" +
 	"annualRate\x12&\n" +
 	"\x0fbase_margin_sat\x18\x11 \x01(\x03R\rbaseMarginSat\x123\n" +
-	"\x16max_oor_lineage_vbytes\x18\x12 \x01(\rR\x13maxOorLineageVbytes\"\x7f\n" +
+	"\x16max_oor_lineage_vbytes\x18\x12 \x01(\rR\x13maxOorLineageVbytes\x120\n" +
+	"\x14selected_ark_version\x18\x13 \x01(\rR\x12selectedArkVersion\x124\n" +
+	"\x16supported_ark_versions\x18\x14 \x03(\rR\x14supportedArkVersions\x12J\n" +
+	"\x14ark_version_policies\x18\x15 \x03(\v2\x18.arkrpc.ArkVersionPolicyR\x12arkVersionPolicies\"\x7f\n" +
 	"\x12EstimateFeeRequest\x12\x1d\n" +
 	"\n" +
 	"amount_sat\x18\x01 \x01(\x03R\tamountSat\x12\x1f\n" +
@@ -505,23 +700,28 @@ func file_ark_proto_rawDescGZIP() []byte {
 	return file_ark_proto_rawDescData
 }
 
-var file_ark_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_ark_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_ark_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_ark_proto_goTypes = []any{
-	(*GetInfoRequest)(nil),      // 0: arkrpc.GetInfoRequest
-	(*GetInfoResponse)(nil),     // 1: arkrpc.GetInfoResponse
-	(*EstimateFeeRequest)(nil),  // 2: arkrpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil), // 3: arkrpc.EstimateFeeResponse
+	(ArkVersionPolicy_State)(0), // 0: arkrpc.ArkVersionPolicy.State
+	(*GetInfoRequest)(nil),      // 1: arkrpc.GetInfoRequest
+	(*ArkVersionPolicy)(nil),    // 2: arkrpc.ArkVersionPolicy
+	(*GetInfoResponse)(nil),     // 3: arkrpc.GetInfoResponse
+	(*EstimateFeeRequest)(nil),  // 4: arkrpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil), // 5: arkrpc.EstimateFeeResponse
 }
 var file_ark_proto_depIdxs = []int32{
-	0, // 0: arkrpc.ArkService.GetInfo:input_type -> arkrpc.GetInfoRequest
-	2, // 1: arkrpc.ArkService.EstimateFee:input_type -> arkrpc.EstimateFeeRequest
-	1, // 2: arkrpc.ArkService.GetInfo:output_type -> arkrpc.GetInfoResponse
-	3, // 3: arkrpc.ArkService.EstimateFee:output_type -> arkrpc.EstimateFeeResponse
-	2, // [2:4] is the sub-list for method output_type
-	0, // [0:2] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	0, // 0: arkrpc.ArkVersionPolicy.state:type_name -> arkrpc.ArkVersionPolicy.State
+	2, // 1: arkrpc.GetInfoResponse.ark_version_policies:type_name -> arkrpc.ArkVersionPolicy
+	1, // 2: arkrpc.ArkService.GetInfo:input_type -> arkrpc.GetInfoRequest
+	4, // 3: arkrpc.ArkService.EstimateFee:input_type -> arkrpc.EstimateFeeRequest
+	3, // 4: arkrpc.ArkService.GetInfo:output_type -> arkrpc.GetInfoResponse
+	5, // 5: arkrpc.ArkService.EstimateFee:output_type -> arkrpc.EstimateFeeResponse
+	4, // [4:6] is the sub-list for method output_type
+	2, // [2:4] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_ark_proto_init() }
@@ -534,13 +734,14 @@ func file_ark_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ark_proto_rawDesc), len(file_ark_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   4,
+			NumEnums:      1,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_ark_proto_goTypes,
 		DependencyIndexes: file_ark_proto_depIdxs,
+		EnumInfos:         file_ark_proto_enumTypes,
 		MessageInfos:      file_ark_proto_msgTypes,
 	}.Build()
 	File_ark_proto = out.File

--- a/arkrpc/ark.proto
+++ b/arkrpc/ark.proto
@@ -15,6 +15,48 @@ service ArkService {
 }
 
 message GetInfoRequest {
+    // supported_ark_versions lists the Ark protocol versions this client can
+    // use, ordered by client preference (most preferred first). The operator
+    // selects the first operator-preferred version present in this list. An
+    // empty list is interpreted as support for Ark v1 only during the
+    // documented legacy rollout window.
+    repeated uint32 supported_ark_versions = 1;
+}
+
+// ArkVersionPolicy advertises the operator's deprecation policy for a single
+// Ark protocol version. It lets a client surface upgrade deadlines and URLs
+// for the version it negotiates.
+message ArkVersionPolicy {
+    // State is the lifecycle state of an Ark protocol version.
+    enum State {
+        // STATE_UNSPECIFIED is the zero value and must not be used as a real
+        // policy state.
+        STATE_UNSPECIFIED = 0;
+
+        // STATE_ACTIVE means the version may be selected without warning.
+        STATE_ACTIVE = 1;
+
+        // STATE_DEPRECATING means the version may still be selected, but the
+        // client must surface the disable deadline and upgrade URL.
+        STATE_DEPRECATING = 2;
+
+        // STATE_DISABLED means the version must never be selected or accepted.
+        STATE_DISABLED = 3;
+    }
+
+    // version is the Ark protocol version this policy describes.
+    uint32 version = 1;
+
+    // state is the lifecycle state of the version.
+    State state = 2;
+
+    // disable_after_unix_s is the advertised planned cutoff (wall-clock unix
+    // seconds) after which the operator intends to disable this version. It is
+    // an advertised deadline, not an automatic timer.
+    int64 disable_after_unix_s = 3;
+
+    // upgrade_url points the client at upgrade instructions for this version.
+    string upgrade_url = 4;
 }
 
 message GetInfoResponse {
@@ -87,6 +129,19 @@ message GetInfoResponse {
     // cap pre-submit to avoid round-trip rejections; a value of 0 means
     // the operator does not enforce a cap.
     uint32 max_oor_lineage_vbytes = 18;
+
+    // selected_ark_version is the Ark protocol version the operator selected
+    // for this client from its supported_ark_versions request. Zero means no
+    // common version exists; the client must not start its mailbox runtime.
+    uint32 selected_ark_version = 19;
+
+    // supported_ark_versions lists the Ark protocol versions the operator
+    // currently has enabled, in operator-preference order.
+    repeated uint32 supported_ark_versions = 20;
+
+    // ark_version_policies carries upgrade and deprecation information for the
+    // operator's known Ark protocol versions.
+    repeated ArkVersionPolicy ark_version_policies = 21;
 }
 
 // EstimateFeeRequest asks the server to estimate the fee for a

--- a/arkrpc/version.go
+++ b/arkrpc/version.go
@@ -1,0 +1,15 @@
+package arkrpc
+
+// ArkProtocolVersionV1 is the initial Ark protocol version. The Ark protocol
+// version defines how the client and operator communicate over a decodable
+// mailbox transport: Ark RPC request and response shapes, round and OOR
+// choreography, application-level validation, and service/method routing
+// expectations.
+//
+// It is negotiated through the direct GetInfo bootstrap RPC and bound to a
+// client runtime for its lifetime. Production currently supports only v1; a
+// synthetic v2 may be configured in tests to exercise selection, binding, and
+// rejection behavior, but no production default advertises a version beyond
+// v1. This constant is deliberately separate from the mailbox transport
+// version and the VTXO construction version, which evolve independently.
+const ArkProtocolVersionV1 uint32 = 1

--- a/arkrpc/version_compat_test.go
+++ b/arkrpc/version_compat_test.go
@@ -1,0 +1,136 @@
+package arkrpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestGetInfoRequestOldShapeDecodesZero proves that a GetInfoRequest encoded
+// without the new supported_ark_versions field (the pre-versioning "old
+// shape") decodes under the new generated code with the new field left at its
+// zero value. This is the additive-compatibility guarantee that lets an
+// updated server decode a request from a pre-versioning client.
+func TestGetInfoRequestOldShapeDecodesZero(t *testing.T) {
+	t.Parallel()
+
+	// The old shape is an empty request: the pre-versioning GetInfoRequest
+	// carried no fields at all.
+	oldShape := &GetInfoRequest{}
+
+	raw, err := proto.Marshal(oldShape)
+	require.NoError(t, err)
+
+	decoded := &GetInfoRequest{}
+	require.NoError(t, proto.Unmarshal(raw, decoded))
+
+	// The newly added repeated field must be empty after decoding an old
+	// message.
+	require.Empty(t, decoded.SupportedArkVersions)
+}
+
+// TestGetInfoResponseOldShapeDecodesZero proves that a GetInfoResponse
+// populated only with pre-versioning fields decodes under the new code with
+// every newly added version field at its zero value. This mirrors the
+// legacy-server response that the updated client must interpret as v1.
+func TestGetInfoResponseOldShapeDecodesZero(t *testing.T) {
+	t.Parallel()
+
+	// Populate only fields that existed before versioning was introduced.
+	oldShape := &GetInfoResponse{
+		Version: "0.1.0",
+		Pubkey: []byte{
+			0x02,
+			0x03,
+			0x04,
+		},
+		Network:           "regtest",
+		BlockHeight:       100,
+		BoardingExitDelay: 144,
+		VtxoExitDelay:     144,
+		DustLimit:         330,
+	}
+
+	raw, err := proto.Marshal(oldShape)
+	require.NoError(t, err)
+
+	decoded := &GetInfoResponse{}
+	require.NoError(t, proto.Unmarshal(raw, decoded))
+
+	// Existing fields round-trip unchanged.
+	require.Equal(t, "0.1.0", decoded.Version)
+	require.Equal(t, []byte{0x02, 0x03, 0x04}, decoded.Pubkey)
+	require.Equal(t, "regtest", decoded.Network)
+
+	// The newly added version fields must all be zero/empty because the
+	// old shape never set them.
+	require.Zero(t, decoded.SelectedArkVersion)
+	require.Empty(t, decoded.SupportedArkVersions)
+	require.Empty(t, decoded.ArkVersionPolicies)
+}
+
+// TestGetInfoVersionFieldsRoundTrip proves that the new versioning fields are
+// preserved across a marshal/unmarshal cycle, including the nested
+// ArkVersionPolicy message and its State enum and deadline/URL fields.
+func TestGetInfoVersionFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	req := &GetInfoRequest{
+		SupportedArkVersions: []uint32{
+			2,
+			1,
+		},
+	}
+
+	reqRaw, err := proto.Marshal(req)
+	require.NoError(t, err)
+
+	reqDecoded := &GetInfoRequest{}
+	require.NoError(t, proto.Unmarshal(reqRaw, reqDecoded))
+	require.Equal(t, []uint32{2, 1}, reqDecoded.SupportedArkVersions)
+
+	v1Policy := &ArkVersionPolicy{
+		Version:           1,
+		State:             ArkVersionPolicy_STATE_DEPRECATING,
+		DisableAfterUnixS: 1893456000,
+		UpgradeUrl:        "https://upgrade.example",
+	}
+	v2Policy := &ArkVersionPolicy{
+		Version: 2,
+		State:   ArkVersionPolicy_STATE_ACTIVE,
+	}
+
+	resp := &GetInfoResponse{
+		Version:            "1.0.0",
+		SelectedArkVersion: 2,
+		SupportedArkVersions: []uint32{
+			2,
+			1,
+		},
+		ArkVersionPolicies: []*ArkVersionPolicy{
+			v1Policy,
+			v2Policy,
+		},
+	}
+
+	respRaw, err := proto.Marshal(resp)
+	require.NoError(t, err)
+
+	respDecoded := &GetInfoResponse{}
+	require.NoError(t, proto.Unmarshal(respRaw, respDecoded))
+
+	require.Equal(t, uint32(2), respDecoded.SelectedArkVersion)
+	require.Equal(t, []uint32{2, 1}, respDecoded.SupportedArkVersions)
+	require.Len(t, respDecoded.ArkVersionPolicies, 2)
+
+	first := respDecoded.ArkVersionPolicies[0]
+	require.Equal(t, uint32(1), first.Version)
+	require.Equal(t, ArkVersionPolicy_STATE_DEPRECATING, first.State)
+	require.Equal(t, int64(1893456000), first.DisableAfterUnixS)
+	require.Equal(t, "https://upgrade.example", first.UpgradeUrl)
+
+	second := respDecoded.ArkVersionPolicies[1]
+	require.Equal(t, uint32(2), second.Version)
+	require.Equal(t, ArkVersionPolicy_STATE_ACTIVE, second.State)
+}

--- a/darepod/mailbox_ingress_compat_test.go
+++ b/darepod/mailbox_ingress_compat_test.go
@@ -1,0 +1,154 @@
+package darepod
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/lightninglabs/darepo-client/serverconn"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// permanentPullEdge is a mailbox edge whose Pull returns a permanent version
+// status, so an ingress loop transitions the connector to its incompatible
+// state on its first poll. Send and AckUpTo succeed.
+type permanentPullEdge struct{}
+
+func (permanentPullEdge) Send(_ context.Context, _ *mailboxpb.SendRequest,
+	_ ...grpc.CallOption) (*mailboxpb.SendResponse, error) {
+
+	return &mailboxpb.SendResponse{
+		Status: &mailboxpb.Status{
+			Ok: true,
+		},
+	}, nil
+}
+
+func (permanentPullEdge) Pull(_ context.Context, _ *mailboxpb.PullRequest,
+	_ ...grpc.CallOption) (*mailboxpb.PullResponse, error) {
+
+	return &mailboxpb.PullResponse{
+		Status: &mailboxpb.Status{
+			Ok:   false,
+			Code: mailboxconn.StatusUpgradeRequired,
+		},
+	}, nil
+}
+
+func (permanentPullEdge) AckUpTo(_ context.Context, _ *mailboxpb.AckUpToRequest,
+	_ ...grpc.CallOption) (*mailboxpb.AckUpToResponse, error) {
+
+	return &mailboxpb.AckUpToResponse{
+		Status: &mailboxpb.Status{
+			Ok: true,
+		},
+	}, nil
+}
+
+// okPullEdge is a mailbox edge that succeeds on every operation, returning
+// empty long-poll results. Used when the runtime is pre-marked incompatible so
+// the edge behavior is irrelevant.
+type okPullEdge struct{}
+
+func (okPullEdge) Send(_ context.Context, _ *mailboxpb.SendRequest,
+	_ ...grpc.CallOption) (*mailboxpb.SendResponse, error) {
+
+	return &mailboxpb.SendResponse{Status: &mailboxpb.Status{Ok: true}}, nil
+}
+
+func (okPullEdge) Pull(_ context.Context, _ *mailboxpb.PullRequest,
+	_ ...grpc.CallOption) (*mailboxpb.PullResponse, error) {
+
+	return &mailboxpb.PullResponse{Status: &mailboxpb.Status{Ok: true}}, nil
+}
+
+func (okPullEdge) AckUpTo(_ context.Context, _ *mailboxpb.AckUpToRequest,
+	_ ...grpc.CallOption) (*mailboxpb.AckUpToResponse, error) {
+
+	return &mailboxpb.AckUpToResponse{
+		Status: &mailboxpb.Status{
+			Ok: true,
+		},
+	}, nil
+}
+
+// newCompatTestServer wires a Server with a real serverconn.Runtime built from
+// the given edge and a DB-backed delivery store, with the incompatibility
+// callback routed to onServerIncompatible (which clears server_connected).
+func newCompatTestServer(t *testing.T,
+	edge mailboxpb.MailboxServiceClient) *Server {
+
+	t.Helper()
+
+	_, deliveryStore := newSendOORTestStores(t)
+
+	s := &Server{log: btclog.Disabled}
+
+	cfg := serverconn.DefaultConnectorConfig()
+	cfg.Edge = edge
+	cfg.Store = deliveryStore
+	cfg.LocalMailboxID = "client-1"
+	cfg.RemoteMailboxID = "server-1"
+	cfg.ArkProtocolVersion = 1
+	cfg.OnIncompatible = s.onServerIncompatible
+
+	rt, err := serverconn.NewRuntime(cfg)
+	require.NoError(t, err)
+
+	s.runtime = rt
+
+	return s
+}
+
+// TestStartMailboxIngressConcurrentIncompatible proves that an incompatibility
+// landing while ingress starts (here, the ingress loop's first Pull returns a
+// permanent version status) always wins over the startup "connected" write:
+// server_connected ends false. This is the concurrent-start race the fix
+// closes by setting connected=true before StartIngress so any callback's false
+// is written afterward.
+func TestStartMailboxIngressConcurrentIncompatible(t *testing.T) {
+	t.Parallel()
+
+	s := newCompatTestServer(t, permanentPullEdge{})
+
+	s.runtime.StartEgress()
+	defer s.runtime.Stop()
+
+	// StartIngress itself succeeds; the ingress goroutine then transitions.
+	require.NoError(t, s.startMailboxIngress(t.Context()))
+
+	require.Eventually(t, func() bool {
+		return !s.isServerConnected()
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestStartMailboxIngressAlreadyIncompatible proves that when the runtime is
+// already incompatible, startMailboxIngress returns an error and leaves
+// server_connected false rather than reporting a healthy connection.
+func TestStartMailboxIngressAlreadyIncompatible(t *testing.T) {
+	t.Parallel()
+
+	s := newCompatTestServer(t, okPullEdge{})
+
+	s.runtime.StartEgress()
+	defer s.runtime.Stop()
+
+	// Mark incompatible up front; the callback clears server_connected.
+	s.runtime.MarkIncompatible(
+		t.Context(),
+		mailboxconn.NewStatusError(
+			"refresh", &mailboxpb.Status{
+				Ok:   false,
+				Code: mailboxconn.StatusArkVersionMismatch,
+			},
+		),
+	)
+
+	err := s.startMailboxIngress(t.Context())
+	require.Error(t, err)
+	require.False(t, s.isServerConnected())
+}

--- a/darepod/operator_negotiation.go
+++ b/darepod/operator_negotiation.go
@@ -1,0 +1,246 @@
+package darepod
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+)
+
+// arkVersionNegotiation is the outcome of the bootstrap GetInfo negotiation.
+// connectAndBootstrapMailbox is the sole owner of this negotiation: it caches
+// every value below before constructing the mailbox runtime, so the later
+// round-actor initialization and refresh-only GetInfo calls never renegotiate.
+type arkVersionNegotiation struct {
+	// operatorPubKey is the operator's main public key.
+	operatorPubKey *btcec.PublicKey
+
+	// selectedArkVersion is the Ark protocol version to bind to the
+	// runtime. It is always non-zero on a successful negotiation.
+	selectedArkVersion uint32
+
+	// terms is the initial operator terms parsed from the same response, so
+	// the round actor does not need a second negotiating call.
+	terms *types.OperatorTerms
+
+	// selectedPolicy is the deprecation policy advertised for the selected
+	// version, or nil when the operator advertised none.
+	selectedPolicy *arkrpc.ArkVersionPolicy
+}
+
+// arkVersionSupported reports whether version is present in the client's
+// supported list.
+func arkVersionSupported(supported []uint32, version uint32) bool {
+	for _, v := range supported {
+		if v == version {
+			return true
+		}
+	}
+
+	return false
+}
+
+// resolveArkVersionSelection interprets a bootstrap GetInfo response against
+// the client's supported Ark protocol versions. It returns the version to bind
+// or an error when no compatible version exists. It is the single decision
+// point for runtime-version selection and is deliberately pure so it can be
+// unit-tested with fake responses.
+//
+// A non-zero selection is honored as long as the client supports it. A zero
+// selection always means no compatible version exists and is fatal — the
+// runtime must not be created. There is no legacy-server fallback: the client
+// and operator are deployed together, so the operator always returns an
+// explicit selection.
+func resolveArkVersionSelection(resp *arkrpc.GetInfoResponse,
+	clientSupported []uint32) (uint32, error) {
+
+	if resp == nil {
+		return 0, fmt.Errorf("nil GetInfo response")
+	}
+
+	// A zero selection means the operator advertised no common version (or
+	// is a pre-versioning server that cannot stamp the field). Either way
+	// it is fatal: the runtime must not be created.
+	if resp.SelectedArkVersion == 0 {
+		return 0, fmt.Errorf("no compatible ark protocol version "+
+			"(operator supports %v, client supports %v)",
+			resp.SupportedArkVersions, clientSupported)
+	}
+
+	// Honor the operator's selection as long as this client supports it.
+	if !arkVersionSupported(clientSupported, resp.SelectedArkVersion) {
+		return 0, fmt.Errorf("operator selected unsupported ark "+
+			"protocol version %d (client supports %v)",
+			resp.SelectedArkVersion, clientSupported)
+	}
+
+	return resp.SelectedArkVersion, nil
+}
+
+// selectedArkPolicy returns the policy advertised for the given version, or
+// nil if the operator advertised none.
+func selectedArkPolicy(resp *arkrpc.GetInfoResponse,
+	version uint32) *arkrpc.ArkVersionPolicy {
+
+	if resp == nil {
+		return nil
+	}
+
+	for _, policy := range resp.ArkVersionPolicies {
+		if policy != nil && policy.Version == version {
+			return policy
+		}
+	}
+
+	return nil
+}
+
+// operatorTermsFromResponse parses operator terms from a GetInfo response. It
+// is shared by the bootstrap negotiation and the refresh-only path so both
+// produce identical terms from the same fields.
+func operatorTermsFromResponse(resp *arkrpc.GetInfoResponse) (
+	*types.OperatorTerms, error) {
+
+	if resp == nil {
+		return nil, fmt.Errorf("nil GetInfo response")
+	}
+
+	if len(resp.Pubkey) == 0 {
+		return nil, fmt.Errorf("operator pubkey is missing")
+	}
+
+	pubKey, err := btcec.ParsePubKey(resp.Pubkey)
+	if err != nil {
+		return nil, fmt.Errorf("parse operator pubkey: %w", err)
+	}
+
+	var sweepKey *btcec.PublicKey
+	if len(resp.SweepKey) > 0 {
+		sweepKey, err = btcec.ParsePubKey(resp.SweepKey)
+		if err != nil {
+			return nil, fmt.Errorf("parse sweep key: %w", err)
+		}
+	}
+
+	return &types.OperatorTerms{
+		PubKey:              pubKey,
+		BoardingExitDelay:   resp.BoardingExitDelay,
+		VTXOExitDelay:       resp.VtxoExitDelay,
+		ForfeitScript:       resp.ForfeitScript,
+		SweepKey:            sweepKey,
+		SweepDelay:          resp.SweepDelay,
+		DustLimit:           btcutil.Amount(resp.DustLimit),
+		MinBoardingAmount:   btcutil.Amount(resp.MinBoardingAmount),
+		MaxBoardingAmount:   btcutil.Amount(resp.MaxBoardingAmount),
+		FeeRate:             btcutil.Amount(resp.FeeRate),
+		MinOperatorFee:      btcutil.Amount(resp.MinOperatorFee),
+		MinConfirmations:    resp.MinConfirmations,
+		MaxOORLineageVBytes: resp.MaxOorLineageVbytes,
+	}, nil
+}
+
+// clientSupportedArkVersions returns the Ark protocol versions this client
+// advertises during bootstrap, ordered by preference. Production supports only
+// v1; no production default advertises a higher version. Tests negotiate
+// against this same default unless they call resolveArkVersionSelection or
+// negotiateArkBootstrap with an explicit list.
+func clientSupportedArkVersions() []uint32 {
+	return []uint32{arkrpc.ArkProtocolVersionV1}
+}
+
+// logArkVersionDeprecation surfaces the disable deadline and upgrade URL when
+// the negotiated Ark protocol version is deprecating. Deprecation is an
+// external operational condition rather than an internal bug, so it is logged
+// below error level.
+func (s *Server) logArkVersionDeprecation(ctx context.Context,
+	policy *arkrpc.ArkVersionPolicy) {
+
+	if policy == nil ||
+		policy.State != arkrpc.ArkVersionPolicy_STATE_DEPRECATING {
+		return
+	}
+
+	s.log.WarnS(ctx, "Negotiated ark protocol version is deprecating",
+		nil,
+		slog.Uint64("ark_protocol_version", uint64(policy.Version)),
+		slog.Int64("disable_after_unix_s", policy.DisableAfterUnixS),
+		slog.String("upgrade_url", policy.UpgradeUrl),
+	)
+}
+
+// onServerIncompatible is the connector compatibility callback. When the
+// mailbox connector hits its first permanent version error it transitions to a
+// terminal incompatible state and invokes this once. We mark the daemon
+// disconnected and log the actionable upgrade information. This is an external
+// compatibility condition rather than an internal bug, so it logs below error
+// level.
+func (s *Server) onServerIncompatible(statusErr *mailboxconn.StatusError) {
+	s.serverConnected.Store(false)
+
+	ctx := context.Background()
+
+	if statusErr == nil {
+		s.log.WarnS(ctx, "Server connection became incompatible", nil)
+
+		return
+	}
+
+	s.log.WarnS(ctx, "Server connection became incompatible", statusErr,
+		slog.String("code", statusErr.Code()),
+		slog.Any(
+			"supported_mailbox_versions",
+			statusErr.SupportedMailboxVersions(),
+		),
+		slog.Any(
+			"supported_ark_versions",
+			statusErr.SupportedArkVersions(),
+		),
+		slog.String("upgrade_url", statusErr.UpgradeURL()),
+	)
+}
+
+// negotiateArkBootstrap performs the single bootstrap GetInfo call that owns
+// Ark protocol version selection. It sends the client's complete supported
+// version list and parses everything needed before the mailbox runtime is
+// created: the operator public key, the selected version, the initial
+// operator terms, and the selected version's deprecation policy.
+//
+// It returns an error without selecting a version when no compatible version
+// exists, so the caller can refuse to create the runtime.
+func (s *Server) negotiateArkBootstrap(ctx context.Context,
+	clientSupported []uint32) (*arkVersionNegotiation, error) {
+
+	client := s.operatorArkClient()
+	if client == nil {
+		return nil, fmt.Errorf("operator connection not initialized")
+	}
+
+	resp, err := client.GetInfo(ctx, &arkrpc.GetInfoRequest{
+		SupportedArkVersions: clientSupported,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("GetInfo RPC: %w", err)
+	}
+
+	terms, err := operatorTermsFromResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	selected, err := resolveArkVersionSelection(resp, clientSupported)
+	if err != nil {
+		return nil, err
+	}
+
+	return &arkVersionNegotiation{
+		operatorPubKey:     terms.PubKey,
+		selectedArkVersion: selected,
+		terms:              terms,
+		selectedPolicy:     selectedArkPolicy(resp, selected),
+	}, nil
+}

--- a/darepod/operator_negotiation.go
+++ b/darepod/operator_negotiation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lightninglabs/darepo-client/arkrpc"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 )
 
 // arkVersionNegotiation is the outcome of the bootstrap GetInfo negotiation.
@@ -79,7 +80,41 @@ func resolveArkVersionSelection(resp *arkrpc.GetInfoResponse,
 			resp.SelectedArkVersion, clientSupported)
 	}
 
+	// A contradictory operator response selects a version it simultaneously
+	// advertises as DISABLED. Fail closed: refuse to bind a runtime to a
+	// version the operator says is retired. Surface it as a permanent
+	// UPGRADE_REQUIRED status error carrying the advertised upgrade URL so
+	// the daemon can point the user at the upgrade. An absent policy for
+	// the selected version is allowed (no contradiction), preserving
+	// compatibility with operators that advertise no policy for it.
+	policy := selectedArkPolicy(resp, resp.SelectedArkVersion)
+	if policy != nil &&
+		policy.State == arkrpc.ArkVersionPolicy_STATE_DISABLED {
+		return 0, disabledSelectionStatus(
+			"bootstrap", resp.SelectedArkVersion, resp, policy,
+		)
+	}
+
 	return resp.SelectedArkVersion, nil
+}
+
+// disabledSelectionStatus builds the permanent UPGRADE_REQUIRED status error
+// returned when the operator selects an Ark protocol version it simultaneously
+// advertises as DISABLED. op names the originating path ("bootstrap" or
+// "refresh"); the advertised upgrade URL and the operator's enabled versions
+// are preserved so the daemon can surface actionable upgrade guidance.
+func disabledSelectionStatus(op string, version uint32,
+	resp *arkrpc.GetInfoResponse,
+	policy *arkrpc.ArkVersionPolicy) *mailboxconn.StatusError {
+
+	return mailboxconn.NewStatusError(op, &mailboxpb.Status{
+		Ok:   false,
+		Code: mailboxconn.StatusUpgradeRequired,
+		Message: fmt.Sprintf("operator selected ark protocol version "+
+			"%d but advertises it as disabled", version),
+		SupportedArkVersions: resp.SupportedArkVersions,
+		UpgradeUrl:           policy.UpgradeUrl,
+	})
 }
 
 // selectedArkPolicy returns the policy advertised for the given version, or

--- a/darepod/operator_negotiation_test.go
+++ b/darepod/operator_negotiation_test.go
@@ -398,3 +398,137 @@ func TestFetchOperatorTermsRefreshProcessesDeprecation(t *testing.T) {
 	)
 	require.Equal(t, "https://up.example", cached.UpgradeUrl)
 }
+
+// TestNegotiateArkBootstrapSelectedButDisabled proves the client refuses to
+// bootstrap a runtime when the operator selects the client's supported version
+// but simultaneously advertises that version as DISABLED. The refusal is a
+// permanent UPGRADE_REQUIRED status error carrying the advertised upgrade URL.
+func TestNegotiateArkBootstrapSelectedButDisabled(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubArkServiceClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             testOperatorPubKeyBytes(t),
+			SelectedArkVersion: 1,
+			ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+				{
+					Version: 1,
+					State: arkrpc.
+						ArkVersionPolicy_STATE_DISABLED,
+					UpgradeUrl: "https://up.example",
+				},
+			},
+		},
+	}
+	srv := &Server{arkClient: stub}
+
+	neg, err := srv.negotiateArkBootstrap(t.Context(), []uint32{1})
+	require.Error(t, err)
+	require.Nil(t, neg)
+
+	require.True(t, mailboxconn.IsPermanentVersionError(err))
+
+	var statusErr *mailboxconn.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	require.Equal(
+		t, mailboxconn.StatusUpgradeRequired, statusErr.Code(),
+	)
+	require.Equal(t, "https://up.example", statusErr.UpgradeURL())
+}
+
+// TestValidateRefreshSelectionSelectedButDisabled proves a refresh that
+// re-selects the bound version but advertises it as DISABLED is a terminal,
+// mandatory-upgrade failure: a permanent UPGRADE_REQUIRED status error carrying
+// the advertised upgrade URL, distinct from the renegotiation mismatch path.
+func TestValidateRefreshSelectionSelectedButDisabled(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{arkProtocolVersion: 1}
+
+	resp := &arkrpc.GetInfoResponse{
+		SelectedArkVersion: 1,
+		ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+			{
+				Version: 1,
+				State: arkrpc.
+					ArkVersionPolicy_STATE_DISABLED,
+				UpgradeUrl: "https://up.example",
+			},
+		},
+	}
+
+	statusErr := srv.validateRefreshSelection(resp)
+	require.NotNil(t, statusErr)
+	require.Equal(
+		t, mailboxconn.StatusUpgradeRequired, statusErr.Code(),
+	)
+	require.Equal(t, "https://up.example", statusErr.UpgradeURL())
+}
+
+// TestValidateRefreshSelectionActivePolicyOk proves a matching selection with a
+// non-disabled (here ACTIVE) policy for the bound version is a normal, accepted
+// refresh — an advertised policy alone does not make a refresh fail.
+func TestValidateRefreshSelectionActivePolicyOk(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{arkProtocolVersion: 1}
+
+	resp := &arkrpc.GetInfoResponse{
+		SelectedArkVersion: 1,
+		ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+			{
+				Version: 1,
+				State: arkrpc.
+					ArkVersionPolicy_STATE_ACTIVE,
+			},
+		},
+	}
+
+	require.Nil(t, srv.validateRefreshSelection(resp))
+}
+
+// TestFetchOperatorTermsRefreshSelectedButDisabledMarksIncompatible proves the
+// refresh path drives an existing runtime to INCOMPATIBLE when the operator
+// re-selects the bound version but advertises it as DISABLED.
+// fetchOperatorTerms returns the permanent UPGRADE_REQUIRED error and calls
+// MarkIncompatible, whose OnIncompatible callback clears server_connected.
+func TestFetchOperatorTermsRefreshSelectedButDisabledMarksIncompatible(
+	t *testing.T) {
+
+	t.Parallel()
+
+	s := newCompatTestServer(t, okPullEdge{})
+
+	// Model a healthy, connected client bound to v1 before the refresh.
+	s.serverConnected.Store(true)
+	s.arkProtocolVersion = 1
+	s.arkClient = &stubArkServiceClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             testOperatorPubKeyBytes(t),
+			SelectedArkVersion: 1,
+			ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+				{
+					Version: 1,
+					State: arkrpc.
+						ArkVersionPolicy_STATE_DISABLED,
+					UpgradeUrl: "https://up.example",
+				},
+			},
+		},
+	}
+
+	_, err := s.fetchOperatorTerms(t.Context())
+	require.Error(t, err)
+	require.True(t, mailboxconn.IsPermanentVersionError(err))
+
+	var statusErr *mailboxconn.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	require.Equal(
+		t, mailboxconn.StatusUpgradeRequired, statusErr.Code(),
+	)
+	require.Equal(t, "https://up.example", statusErr.UpgradeURL())
+
+	// The refresh transitioned the runtime to INCOMPATIBLE, firing the
+	// OnIncompatible callback that clears server_connected.
+	require.False(t, s.isServerConnected())
+}

--- a/darepod/operator_negotiation_test.go
+++ b/darepod/operator_negotiation_test.go
@@ -1,0 +1,400 @@
+package darepod
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// stubArkServiceClient is a minimal arkrpc.ArkServiceClient that returns a
+// canned GetInfo response, used to drive the bootstrap negotiation without a
+// real transport.
+type stubArkServiceClient struct {
+	resp *arkrpc.GetInfoResponse
+	err  error
+}
+
+// GetInfo returns the canned response.
+func (s *stubArkServiceClient) GetInfo(_ context.Context,
+	_ *arkrpc.GetInfoRequest, _ ...grpc.CallOption) (
+	*arkrpc.GetInfoResponse, error) {
+
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	return s.resp, nil
+}
+
+// EstimateFee is unused by these tests.
+func (s *stubArkServiceClient) EstimateFee(_ context.Context,
+	_ *arkrpc.EstimateFeeRequest, _ ...grpc.CallOption) (
+	*arkrpc.EstimateFeeResponse, error) {
+
+	return &arkrpc.EstimateFeeResponse{}, nil
+}
+
+// testOperatorPubKeyBytes returns a valid compressed secp256k1 public key for
+// populating a fake GetInfo response.
+func testOperatorPubKeyBytes(t *testing.T) []byte {
+	t.Helper()
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return priv.PubKey().SerializeCompressed()
+}
+
+// TestResolveArkVersionSelection covers the pure selection decision: normal
+// preference selection, an operator selecting an unsupported version, a zero
+// selection (no overlap or pre-versioning server) which is always fatal, and
+// a no-overlap response with a non-empty list.
+func TestResolveArkVersionSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		resp         *arkrpc.GetInfoResponse
+		client       []uint32
+		wantSelected uint32
+		wantErr      bool
+	}{
+		{
+			name: "normal v1 selection",
+			resp: &arkrpc.GetInfoResponse{
+				SelectedArkVersion: 1,
+			},
+			client: []uint32{
+				1,
+			},
+			wantSelected: 1,
+		},
+		{
+			name: "operator selects v2 client supports it",
+			resp: &arkrpc.GetInfoResponse{
+				SelectedArkVersion: 2,
+			},
+			client: []uint32{
+				1,
+				2,
+			},
+			wantSelected: 2,
+		},
+		{
+			name: "operator selects unsupported version",
+			resp: &arkrpc.GetInfoResponse{
+				SelectedArkVersion: 2,
+			},
+			client: []uint32{
+				1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero selection is fatal",
+			resp: &arkrpc.GetInfoResponse{},
+			client: []uint32{
+				1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "no overlap is fatal",
+			resp: &arkrpc.GetInfoResponse{
+				SupportedArkVersions: []uint32{
+					2,
+					3,
+				},
+			},
+			client: []uint32{
+				1,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			selected, err := resolveArkVersionSelection(
+				tc.resp, tc.client,
+			)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantSelected, selected)
+		})
+	}
+}
+
+// TestNegotiateArkBootstrapZeroSelection proves the client refuses to bootstrap
+// when the operator returns a zero selection (no common version, or a
+// pre-versioning server). There is no legacy fallback.
+func TestNegotiateArkBootstrapZeroSelection(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{
+		arkClient: &stubArkServiceClient{
+			resp: &arkrpc.GetInfoResponse{
+				Pubkey: testOperatorPubKeyBytes(t),
+			},
+		},
+	}
+
+	neg, err := srv.negotiateArkBootstrap(
+		t.Context(), []uint32{arkrpc.ArkProtocolVersionV1},
+	)
+	require.Error(t, err)
+	require.Nil(t, neg)
+}
+
+// TestNegotiateArkBootstrapNoOverlap proves a no-overlap response yields an
+// error so connectAndBootstrapMailbox refuses to create the runtime.
+func TestNegotiateArkBootstrapNoOverlap(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{
+		arkClient: &stubArkServiceClient{
+			resp: &arkrpc.GetInfoResponse{
+				Pubkey: testOperatorPubKeyBytes(t),
+				SupportedArkVersions: []uint32{
+					2,
+				},
+			},
+		},
+	}
+
+	neg, err := srv.negotiateArkBootstrap(
+		t.Context(), []uint32{arkrpc.ArkProtocolVersionV1},
+	)
+	require.Error(t, err)
+	require.Nil(t, neg)
+}
+
+// TestNegotiateArkBootstrapDeprecating proves a deprecating selection returns
+// the advertised deadline and upgrade URL on the cached policy.
+func TestNegotiateArkBootstrapDeprecating(t *testing.T) {
+	t.Parallel()
+
+	policy := &arkrpc.ArkVersionPolicy{
+		Version:           1,
+		State:             arkrpc.ArkVersionPolicy_STATE_DEPRECATING,
+		DisableAfterUnixS: 1893456000,
+		UpgradeUrl:        "https://up.example",
+	}
+	srv := &Server{
+		arkClient: &stubArkServiceClient{
+			resp: &arkrpc.GetInfoResponse{
+				Pubkey:             testOperatorPubKeyBytes(t),
+				SelectedArkVersion: 1,
+				ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+					policy,
+				},
+			},
+		},
+	}
+
+	neg, err := srv.negotiateArkBootstrap(
+		t.Context(), []uint32{1},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, neg.selectedPolicy)
+	require.Equal(
+		t, arkrpc.ArkVersionPolicy_STATE_DEPRECATING,
+		neg.selectedPolicy.State,
+	)
+	require.Equal(
+		t, int64(1893456000), neg.selectedPolicy.DisableAfterUnixS,
+	)
+	require.Equal(
+		t, "https://up.example", neg.selectedPolicy.UpgradeUrl,
+	)
+}
+
+// TestValidateRefreshSelection proves a refresh cannot renegotiate: it accepts
+// only a matching selection and treats any zero or different selection as a
+// terminal ARK_VERSION_MISMATCH. There is no legacy fallback.
+func TestValidateRefreshSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		boundArk uint32
+		resp     *arkrpc.GetInfoResponse
+		wantErr  bool
+	}{
+		{
+			name:     "matching v1",
+			boundArk: 1,
+			resp: &arkrpc.GetInfoResponse{
+				SelectedArkVersion: 1,
+			},
+		},
+		{
+			name:     "matching v2",
+			boundArk: 2,
+			resp: &arkrpc.GetInfoResponse{
+				SelectedArkVersion: 2,
+			},
+		},
+		{
+			name:     "v1 rejects zero selection",
+			boundArk: 1,
+			resp:     &arkrpc.GetInfoResponse{},
+			wantErr:  true,
+		},
+		{
+			name:     "v1 rejects different selection",
+			boundArk: 1,
+			resp: &arkrpc.GetInfoResponse{
+				SelectedArkVersion: 2,
+			},
+			wantErr: true,
+		},
+		{
+			name:     "v2 rejects zero selection",
+			boundArk: 2,
+			resp:     &arkrpc.GetInfoResponse{},
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := &Server{arkProtocolVersion: tc.boundArk}
+
+			// validateRefreshSelection returns a typed pointer;
+			// compare the pointer directly to avoid the
+			// nil-interface pitfall.
+			statusErr := srv.validateRefreshSelection(tc.resp)
+			if tc.wantErr {
+				require.NotNil(t, statusErr)
+				require.Equal(
+					t, mailboxconn.StatusArkVersionMismatch,
+					statusErr.Code(),
+				)
+
+				return
+			}
+
+			require.Nil(t, statusErr)
+		})
+	}
+}
+
+// TestFetchOperatorTermsRefreshPinsVersion proves fetchOperatorTerms is
+// refresh-only: it sends the runtime-bound version as the singleton supported
+// list and leaves the bound version unchanged on success.
+func TestFetchOperatorTermsRefreshPinsVersion(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubArkServiceClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             testOperatorPubKeyBytes(t),
+			SelectedArkVersion: 1,
+		},
+	}
+	srv := &Server{arkClient: stub, arkProtocolVersion: 1}
+
+	terms, err := srv.fetchOperatorTerms(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, terms)
+
+	// The runtime version must be unchanged by a refresh.
+	require.Equal(t, uint32(1), srv.arkProtocolVersion)
+}
+
+// TestFetchOperatorTermsRefreshRejectsRenegotiation proves a refresh that
+// selects a different version fails with a terminal ARK_VERSION_MISMATCH and
+// does not change the bound version.
+func TestFetchOperatorTermsRefreshRejectsRenegotiation(t *testing.T) {
+	t.Parallel()
+
+	// The operator now prefers v2 and advertises a disabled policy for the
+	// bound v1, carrying an upgrade URL the client must surface.
+	stub := &stubArkServiceClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             testOperatorPubKeyBytes(t),
+			SelectedArkVersion: 2,
+			ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+				{
+					Version: 1,
+					State: arkrpc.
+						ArkVersionPolicy_STATE_DISABLED,
+					UpgradeUrl: "https://up.example",
+				},
+			},
+		},
+	}
+	srv := &Server{arkClient: stub, arkProtocolVersion: 1}
+
+	_, err := srv.fetchOperatorTerms(t.Context())
+	require.Error(t, err)
+	require.True(t, mailboxconn.IsPermanentVersionError(err))
+
+	var statusErr *mailboxconn.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	require.Equal(
+		t, mailboxconn.StatusArkVersionMismatch, statusErr.Code(),
+	)
+
+	// The mismatch carries actionable upgrade guidance from the bound
+	// version's advertised policy.
+	require.Equal(t, "https://up.example", statusErr.UpgradeURL())
+
+	// The runtime version must be unchanged by a failed refresh.
+	require.Equal(t, uint32(1), srv.arkProtocolVersion)
+}
+
+// TestFetchOperatorTermsRefreshProcessesDeprecation proves a successful refresh
+// updates the cached deprecation policy for the bound version, so a
+// long-running client learns about a newly deprecating version without a
+// restart.
+func TestFetchOperatorTermsRefreshProcessesDeprecation(t *testing.T) {
+	t.Parallel()
+
+	policy := &arkrpc.ArkVersionPolicy{
+		Version:           1,
+		State:             arkrpc.ArkVersionPolicy_STATE_DEPRECATING,
+		DisableAfterUnixS: 1893456000,
+		UpgradeUrl:        "https://up.example",
+	}
+	stub := &stubArkServiceClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             testOperatorPubKeyBytes(t),
+			SelectedArkVersion: 1,
+			ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+				policy,
+			},
+		},
+	}
+	srv := &Server{
+		arkClient:          stub,
+		arkProtocolVersion: 1,
+		log:                btclog.Disabled,
+	}
+
+	terms, err := srv.fetchOperatorTerms(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, terms)
+
+	cached := srv.selectedArkPolicy.Load()
+	require.NotNil(t, cached)
+	require.Equal(
+		t, arkrpc.ArkVersionPolicy_STATE_DEPRECATING, cached.State,
+	)
+	require.Equal(t, "https://up.example", cached.UpgradeUrl)
+}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
@@ -4043,6 +4044,22 @@ func (s *Server) validateRefreshSelection(
 	boundVersion := s.arkProtocolVersion
 
 	if resp.SelectedArkVersion == boundVersion {
+		// The operator re-selected the bound version, which is normally
+		// a successful refresh. But a contradictory response also
+		// advertises that same selected version as DISABLED. Fail
+		// closed: this is a terminal, mandatory-upgrade condition, so
+		// return a permanent UPGRADE_REQUIRED error carrying the
+		// advertised upgrade URL. An absent policy is allowed (no
+		// contradiction), preserving compatibility with operators that
+		// advertise no policy for the bound version.
+		policy := selectedArkPolicy(resp, boundVersion)
+		if policy != nil &&
+			policy.State == arkrpc.ArkVersionPolicy_STATE_DISABLED {
+			return disabledSelectionStatus(
+				"refresh", boundVersion, resp, policy,
+			)
+		}
+
 		return nil
 	}
 

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -16,7 +16,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
@@ -42,6 +41,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/lndbackend"
 	"github.com/lightninglabs/darepo-client/lwwallet"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	"github.com/lightninglabs/darepo-client/oor"
@@ -283,6 +283,19 @@ type Server struct {
 	// terms. It is stored atomically because startup writes race with
 	// concurrent GetInfo RPC reads.
 	operatorTerms atomic.Pointer[types.OperatorTerms]
+
+	// arkProtocolVersion is the Ark protocol version negotiated during
+	// bootstrap and bound to the mailbox runtime for its lifetime. Later
+	// refresh-only GetInfo calls pin this version and never change it; a
+	// fresh negotiation only happens on a daemon restart.
+	arkProtocolVersion uint32
+
+	// selectedArkPolicy caches the deprecation policy advertised for the
+	// negotiated Ark protocol version, if the operator advertised one. It
+	// is nil when the operator returned no matching policy (e.g. an old
+	// server). Stored atomically because startup writes race with RPC
+	// reads.
+	selectedArkPolicy atomic.Pointer[arkrpc.ArkVersionPolicy]
 
 	// serverConnected reports whether mailbox ingress is currently
 	// running against the Ark operator. It flips true once ingress
@@ -2074,11 +2087,20 @@ func (s *Server) resumeBoardingSweeps(ctx context.Context,
 // startMailboxIngress starts mailbox ingress once all actor dispatch targets
 // have been registered.
 func (s *Server) startMailboxIngress(ctx context.Context) error {
+	// Mark connected BEFORE starting ingress. An incompatibility that lands
+	// concurrently (e.g. the ingress loop immediately hits a permanent
+	// version error) invokes the compatibility callback, which writes
+	// server_connected=false. Because that write necessarily happens after
+	// this unconditional true, the false always wins and we never leave a
+	// stale "connected" after an incompatibility. On a synchronous start
+	// failure we clear it back to false ourselves.
+	s.setServerConnected(true)
+
 	if err := s.runtime.StartIngress(ctx); err != nil {
+		s.setServerConnected(false)
+
 		return fmt.Errorf("start serverconn ingress: %w", err)
 	}
-
-	s.setServerConnected(true)
 
 	return nil
 }
@@ -2907,11 +2929,10 @@ func (s *Server) handleInboundRPC(ctx context.Context,
 	}
 
 	responseEnv := &mailboxpb.Envelope{
-		ProtocolVersion: env.ProtocolVersion,
-		Sender:          s.localMailboxID,
-		Recipient:       env.Rpc.ReplyTo,
-		Headers:         headers,
-		Body:            body,
+		Sender:    s.localMailboxID,
+		Recipient: env.Rpc.ReplyTo,
+		Headers:   headers,
+		Body:      body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			CorrelationId: env.Rpc.CorrelationId,
@@ -2919,6 +2940,11 @@ func (s *Server) handleInboundRPC(ctx context.Context,
 			Method:        env.Rpc.Method,
 		},
 	}
+
+	// Stamp the runtime-bound version pair rather than copying the
+	// caller-controlled inbound versions, so responses always carry this
+	// client's negotiated mailbox transport and Ark protocol versions.
+	s.runtime.StampEnvelope(responseEnv)
 
 	_, err = edge.Send(ctx, &mailboxpb.SendRequest{
 		Envelope: responseEnv,
@@ -3172,14 +3198,37 @@ func (s *Server) connectAndBootstrapMailbox(ctx context.Context) error {
 
 	s.log.InfoS(ctx, "Connected to ark server")
 
-	// Fetch the operator's public key via direct ArkService before
-	// wiring the mailbox transport.
-	operatorPubKey, err := s.fetchOperatorPubKeyDirect(ctx)
+	// Negotiate the Ark protocol version via direct ArkService before
+	// wiring the mailbox transport. This is the sole negotiation owner: it
+	// selects the runtime version and caches the initial operator terms so
+	// the round actor never renegotiates.
+	negotiation, err := s.negotiateArkBootstrap(
+		ctx, clientSupportedArkVersions(),
+	)
 	if err != nil {
-		return fmt.Errorf("fetch operator pubkey: %w", err)
+		return fmt.Errorf("negotiate ark protocol version: %w", err)
 	}
 
-	s.log.InfoS(ctx, "Fetched operator pubkey via direct ArkService",
+	operatorPubKey := negotiation.operatorPubKey
+
+	// Cache the negotiation outcome before constructing the runtime so
+	// every later consumer reads the bound version and initial terms
+	// instead of issuing a second negotiating call.
+	s.arkProtocolVersion = negotiation.selectedArkVersion
+	s.storeOperatorTerms(negotiation.terms)
+	s.selectedArkPolicy.Store(negotiation.selectedPolicy)
+
+	// Surface a deprecation warning if the negotiated version is being
+	// retired, so the operator sees the deadline and upgrade URL. This is
+	// an external compatibility condition, not an internal bug, so it logs
+	// below error level.
+	s.logArkVersionDeprecation(ctx, negotiation.selectedPolicy)
+
+	s.log.InfoS(ctx, "Negotiated ark protocol version",
+		slog.Uint64(
+			"ark_protocol_version",
+			uint64(negotiation.selectedArkVersion),
+		),
 		slog.String(
 			"operator_mailbox_id",
 			serverconn.PubKeyMailboxID(operatorPubKey),
@@ -3230,7 +3279,10 @@ func (s *Server) connectAndBootstrapMailbox(ctx context.Context) error {
 	connCfg.Edge = edge
 	connCfg.LocalMailboxID = s.localMailboxID
 	connCfg.RemoteMailboxID = remoteMailboxID
-	connCfg.ProtocolVersion = 1
+
+	// Bind the runtime to the negotiated Ark protocol version.
+	// DefaultConnectorConfig already binds mailbox transport v1.
+	connCfg.ArkProtocolVersion = s.arkProtocolVersion
 	connCfg.Store = s.deliveryStore
 	connCfg.Dispatchers = dispatchers
 	connCfg.AuthSignature = authSig
@@ -3240,6 +3292,7 @@ func (s *Server) connectAndBootstrapMailbox(ctx context.Context) error {
 		server: s,
 	}
 	connCfg.Log = fn.Some(s.subLogger(serverconn.Subsystem))
+	connCfg.OnIncompatible = s.onServerIncompatible
 
 	s.runtime, err = serverconn.NewRuntime(connCfg)
 	if err != nil {
@@ -3429,16 +3482,14 @@ func (s *Server) initRoundActor(ctx context.Context,
 	roundStore := dbStore.NewRoundStore(s.chainParams, s.clk)
 	s.roundStore = roundStore
 
-	// Fetch the operator's terms from the server. These include
-	// the operator pubkey, sweep delay, exit delay, dust limit,
-	// and other round parameters.
-	operatorTerms, err := s.fetchOperatorTerms(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("unable to fetch operator terms: %w",
-			err)
+	// Consume the operator terms cached by the bootstrap negotiation
+	// instead of issuing a second negotiating GetInfo call. The bootstrap
+	// is the sole version owner, so the round actor must not renegotiate.
+	operatorTerms := s.loadOperatorTerms()
+	if operatorTerms == nil {
+		return nil, fmt.Errorf("operator terms not cached: bootstrap " +
+			"negotiation must run before the round actor starts")
 	}
-
-	s.storeOperatorTerms(operatorTerms)
 
 	// Maximum operator fee the client is willing to pay per
 	// round, sourced from the daemon config. Config.Validate
@@ -3920,19 +3971,20 @@ func mapRoundVTXOManagerMsg(msg round.VTXOManagerMsg) vtxo.ManagerMsg {
 	return mapped
 }
 
-// fetchOperatorTerms retrieves the operator's terms from the Ark
-// server via a direct ArkService.GetInfo RPC on the configured
-// transport. This must not depend on mailbox ingress during startup:
-// a restarted client can already have queued server-push envelopes in
-// its mailbox, and those envelopes may target actors that have not yet
-// been registered. Using the mailbox transport here can therefore
-// deadlock round/OOR bootstrap behind redelivery of those pending
-// events.
+// fetchOperatorTerms refreshes the operator's terms from the Ark server via a
+// direct ArkService.GetInfo RPC. It is refresh-only: it is NOT a negotiation.
+// connectAndBootstrapMailbox is the sole owner of Ark protocol version
+// selection, so this call pins the runtime-bound version by sending it as the
+// singleton supported list and rejects any response that selects a different
+// or zero version. It never mutates the runtime version.
+//
+// This must not depend on mailbox ingress: a restarted client can already have
+// queued server-push envelopes in its mailbox targeting actors that have not
+// yet been registered, so using the mailbox transport here can deadlock
+// round/OOR bootstrap behind redelivery of those pending events.
 //
 // The terms include the operator pubkey, sweep delay, VTXO exit delay,
-// forfeit script, dust limit, and fee rate. These are required before
-// the round actor can start, as they govern all round signing and
-// validation parameters.
+// forfeit script, dust limit, and fee rate.
 func (s *Server) fetchOperatorTerms(ctx context.Context) (*types.OperatorTerms,
 	error) {
 
@@ -3941,45 +3993,75 @@ func (s *Server) fetchOperatorTerms(ctx context.Context) (*types.OperatorTerms,
 		return nil, fmt.Errorf("operator connection not initialized")
 	}
 
-	resp, err := client.GetInfo(ctx, &arkrpc.GetInfoRequest{})
+	// Pin the runtime-bound version: send it as the singleton supported
+	// list so a conforming operator re-selects exactly this version.
+	boundVersion := s.arkProtocolVersion
+
+	resp, err := client.GetInfo(ctx, &arkrpc.GetInfoRequest{
+		SupportedArkVersions: []uint32{boundVersion},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("GetInfo RPC: %w", err)
 	}
 
-	if len(resp.Pubkey) == 0 {
-		return nil, fmt.Errorf("operator pubkey is missing")
-	}
-
-	pubKey, err := btcec.ParsePubKey(resp.Pubkey)
-	if err != nil {
-		return nil, fmt.Errorf("parse operator pubkey: %w", err)
-	}
-
-	var sweepKey *btcec.PublicKey
-	if len(resp.SweepKey) > 0 {
-		sweepKey, err = btcec.ParsePubKey(resp.SweepKey)
-		if err != nil {
-			return nil, fmt.Errorf("parse sweep key: %w", err)
+	// A refresh that selects a different version is a terminal
+	// compatibility failure: the runtime is bound for its lifetime, so the
+	// runtime must be torn down and renegotiated. Drive the connector to
+	// its incompatible state and surface the typed error.
+	if statusErr := s.validateRefreshSelection(resp); statusErr != nil {
+		if s.runtime != nil {
+			s.runtime.MarkIncompatible(ctx, statusErr)
 		}
+
+		return nil, statusErr
 	}
 
-	terms := &types.OperatorTerms{
-		PubKey:              pubKey,
-		BoardingExitDelay:   resp.BoardingExitDelay,
-		VTXOExitDelay:       resp.VtxoExitDelay,
-		ForfeitScript:       resp.ForfeitScript,
-		SweepKey:            sweepKey,
-		SweepDelay:          resp.SweepDelay,
-		DustLimit:           btcutil.Amount(resp.DustLimit),
-		MinBoardingAmount:   btcutil.Amount(resp.MinBoardingAmount),
-		MaxBoardingAmount:   btcutil.Amount(resp.MaxBoardingAmount),
-		FeeRate:             btcutil.Amount(resp.FeeRate),
-		MinOperatorFee:      btcutil.Amount(resp.MinOperatorFee),
-		MinConfirmations:    resp.MinConfirmations,
-		MaxOORLineageVBytes: resp.MaxOorLineageVbytes,
+	// On a successful refresh, update the cached deprecation policy for the
+	// bound version and surface any deprecation warning so a long-running
+	// client learns about a newly deprecating version without a restart.
+	policy := selectedArkPolicy(resp, boundVersion)
+	s.selectedArkPolicy.Store(policy)
+	s.logArkVersionDeprecation(ctx, policy)
+
+	return operatorTermsFromResponse(resp)
+}
+
+// validateRefreshSelection enforces that a refresh-only GetInfo response keeps
+// the runtime bound to its negotiated Ark protocol version. A matching
+// selection passes (returns nil). Any other selection — zero, or a different
+// non-zero version — is a terminal compatibility failure, returned as a typed
+// ARK_VERSION_MISMATCH StatusError so callers can both classify it as
+// permanent and surface actionable guidance. There is no legacy fallback: the
+// client and operator are deployed together.
+//
+// The status carries the operator's currently enabled versions and, when the
+// operator advertised a policy for the bound version (e.g. it is now disabled),
+// that version's upgrade URL so the client can point the user at the upgrade.
+func (s *Server) validateRefreshSelection(
+	resp *arkrpc.GetInfoResponse) *mailboxconn.StatusError {
+
+	boundVersion := s.arkProtocolVersion
+
+	if resp.SelectedArkVersion == boundVersion {
+		return nil
 	}
 
-	return terms, nil
+	// Extract upgrade guidance from the bound version's advertised policy,
+	// if any, so the mismatch error is actionable rather than bare.
+	var upgradeURL string
+	if policy := selectedArkPolicy(resp, boundVersion); policy != nil {
+		upgradeURL = policy.UpgradeUrl
+	}
+
+	return mailboxconn.NewStatusError("refresh", &mailboxpb.Status{
+		Ok:   false,
+		Code: mailboxconn.StatusArkVersionMismatch,
+		Message: fmt.Sprintf("operator refresh selected ark version "+
+			"%d, runtime bound to %d", resp.SelectedArkVersion,
+			boundVersion),
+		SupportedArkVersions: resp.SupportedArkVersions,
+		UpgradeUrl:           upgradeURL,
+	})
 }
 
 // deriveIdentityKeyEarly derives the client's identity key before the
@@ -4091,35 +4173,6 @@ func (s *Server) deriveIdentityKeyEarly(ctx context.Context) error {
 		))
 
 	return nil
-}
-
-// fetchOperatorPubKeyDirect fetches the operator's public key via a direct
-// ArkService.GetInfo call, bypassing the mailbox
-// transport. This is needed before the mailbox runtime starts because
-// the remote mailbox ID is derived from the operator's pubkey.
-func (s *Server) fetchOperatorPubKeyDirect(ctx context.Context) (
-	*btcec.PublicKey, error) {
-
-	client := s.operatorArkClient()
-	if client == nil {
-		return nil, fmt.Errorf("operator connection not initialized")
-	}
-
-	resp, err := client.GetInfo(ctx, &arkrpc.GetInfoRequest{})
-	if err != nil {
-		return nil, fmt.Errorf("GetInfo RPC: %w", err)
-	}
-
-	if len(resp.Pubkey) == 0 {
-		return nil, fmt.Errorf("operator pubkey is missing")
-	}
-
-	pubKey, err := btcec.ParsePubKey(resp.Pubkey)
-	if err != nil {
-		return nil, fmt.Errorf("parse operator pubkey: %w", err)
-	}
-
-	return pubKey, nil
 }
 
 // signMailboxAuth computes the Schnorr auth signature for the

--- a/mailbox/conn/response_registry.go
+++ b/mailbox/conn/response_registry.go
@@ -147,6 +147,21 @@ func (r *ResponseRegistry) RemoveWaiter(id CorrelationID) {
 	}
 }
 
+// FailAll completes every registered waiter's promise with err and clears the
+// waiter set. It is used to fail all in-flight unary callers at once when the
+// connector transitions to a terminal incompatible state, so no caller blocks
+// on a response that will never arrive.
+func (r *ResponseRegistry) FailAll(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for id, waiter := range r.waiters {
+		waiter.Promise.Complete(fn.Err[*mailboxpb.Envelope](err))
+
+		delete(r.waiters, id)
+	}
+}
+
 // RemovePending drops any buffered early response for the correlation ID.
 func (r *ResponseRegistry) RemovePending(id CorrelationID) {
 	r.mu.Lock()

--- a/mailbox/conn/status_error.go
+++ b/mailbox/conn/status_error.go
@@ -1,0 +1,146 @@
+package conn
+
+import (
+	"errors"
+	"fmt"
+
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+)
+
+// Permanent mailbox status codes. These classify a non-OK mailbox edge
+// response as an expected, non-retryable version-compatibility failure rather
+// than a transient transport hiccup or an internal bug. They are the
+// machine-readable values carried in mailboxpb.Status.Code.
+const (
+	// StatusMailboxVersionUnsupported indicates the envelope's mailbox
+	// transport framing version is not supported by the responder. The
+	// sender must use a compatible endpoint or client.
+	StatusMailboxVersionUnsupported = "MAILBOX_VERSION_UNSUPPORTED"
+
+	// StatusArkVersionUnsupported indicates the envelope's Ark protocol
+	// version is not currently enabled by the responder. The sender must
+	// renegotiate or upgrade.
+	StatusArkVersionUnsupported = "ARK_VERSION_UNSUPPORTED"
+
+	// StatusArkVersionMismatch indicates the envelope's Ark protocol
+	// version differs from the version already bound to the responder's
+	// runtime for this client. The sender must stop the runtime and
+	// renegotiate.
+	StatusArkVersionMismatch = "ARK_VERSION_MISMATCH"
+
+	// StatusUpgradeRequired indicates the client software must upgrade
+	// before continuing. The sender must stop retrying and surface the
+	// upgrade information.
+	StatusUpgradeRequired = "UPGRADE_REQUIRED"
+)
+
+// permanentVersionCodes is the set of status codes that represent permanent,
+// non-retryable version-compatibility failures. It is the single source of
+// truth for permanent-error classification so unary, durable event,
+// heartbeat, pull, and ack paths all agree.
+var permanentVersionCodes = map[string]struct{}{
+	StatusMailboxVersionUnsupported: {},
+	StatusArkVersionUnsupported:     {},
+	StatusArkVersionMismatch:        {},
+	StatusUpgradeRequired:           {},
+}
+
+// StatusError wraps a non-OK mailbox edge Status so callers can classify the
+// failure and recover the full structured payload (supported versions and
+// upgrade URL) without flattening it into a generic error string. It is the
+// shared status type used by every client Send, Pull, and AckUpTo path,
+// replacing previously duplicated unexported status handling.
+type StatusError struct {
+	// Op is the mailbox operation that failed (e.g. "Send", "Pull",
+	// "AckUpTo").
+	Op string
+
+	// Status is the complete status returned by the mailbox edge. It is
+	// retained verbatim so callers can read every field, including the
+	// supported-version lists and upgrade URL.
+	Status *mailboxpb.Status
+}
+
+// NewStatusError builds a StatusError for the given operation and edge status.
+// The status is retained as-is; callers should only construct this for a
+// non-OK status.
+func NewStatusError(op string, status *mailboxpb.Status) *StatusError {
+	return &StatusError{
+		Op:     op,
+		Status: status,
+	}
+}
+
+// Error returns a human-readable description that preserves the operation,
+// message, and code so logs remain diagnosable.
+func (e *StatusError) Error() string {
+	if e.Status == nil {
+		return e.Op + ": nil status"
+	}
+
+	return fmt.Sprintf("%s: %s (%s)", e.Op, e.Status.Message, e.Status.Code)
+}
+
+// Code returns the machine-readable status code, or the empty string when no
+// status is present.
+func (e *StatusError) Code() string {
+	if e.Status == nil {
+		return ""
+	}
+
+	return e.Status.Code
+}
+
+// IsPermanentVersion reports whether this status is one of the four permanent
+// version-compatibility codes. Every other status (transient transport or
+// internal failure) is left to the existing retry policy.
+func (e *StatusError) IsPermanentVersion() bool {
+	if e.Status == nil {
+		return false
+	}
+
+	_, ok := permanentVersionCodes[e.Status.Code]
+
+	return ok
+}
+
+// SupportedMailboxVersions returns the mailbox transport versions the
+// responder advertised, if any.
+func (e *StatusError) SupportedMailboxVersions() []uint32 {
+	if e.Status == nil {
+		return nil
+	}
+
+	return e.Status.SupportedMailboxVersions
+}
+
+// SupportedArkVersions returns the Ark protocol versions the responder
+// advertised, if any.
+func (e *StatusError) SupportedArkVersions() []uint32 {
+	if e.Status == nil {
+		return nil
+	}
+
+	return e.Status.SupportedArkVersions
+}
+
+// UpgradeURL returns the upgrade URL the responder advertised, if any.
+func (e *StatusError) UpgradeURL() string {
+	if e.Status == nil {
+		return ""
+	}
+
+	return e.Status.UpgradeUrl
+}
+
+// IsPermanentVersionError reports whether err is, or wraps, a StatusError
+// carrying one of the permanent version-compatibility codes. Durable senders
+// use this to stop retrying and to dead-letter the failing message.
+func IsPermanentVersionError(err error) bool {
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+
+	return statusErr.IsPermanentVersion()
+}

--- a/mailbox/conn/status_error_test.go
+++ b/mailbox/conn/status_error_test.go
@@ -1,0 +1,173 @@
+package conn
+
+import (
+	"fmt"
+	"testing"
+
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatusErrorClassification is a table-driven test proving that every
+// permanent version code is classified as permanent while transient transport
+// and internal failures are not, and that the full structured status payload
+// (supported versions and upgrade URL) remains available on the typed error.
+func TestStatusErrorClassification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		code        string
+		permanent   bool
+		mailboxVers []uint32
+		arkVers     []uint32
+		upgradeURL  string
+	}{
+		{
+			name:      "mailbox version unsupported",
+			code:      StatusMailboxVersionUnsupported,
+			permanent: true,
+			mailboxVers: []uint32{
+				1,
+			},
+			upgradeURL: "https://upgrade.example/mbx",
+		},
+		{
+			name:      "ark version unsupported",
+			code:      StatusArkVersionUnsupported,
+			permanent: true,
+			arkVers: []uint32{
+				1,
+				2,
+			},
+			upgradeURL: "https://upgrade.example/ark",
+		},
+		{
+			name:      "ark version mismatch",
+			code:      StatusArkVersionMismatch,
+			permanent: true,
+			arkVers: []uint32{
+				1,
+			},
+		},
+		{
+			name:      "upgrade required",
+			code:      StatusUpgradeRequired,
+			permanent: true,
+			arkVers: []uint32{
+				2,
+			},
+			upgradeURL: "https://upgrade.example/req",
+		},
+		{
+			name:      "transient unavailable",
+			code:      "UNAVAILABLE",
+			permanent: false,
+		},
+		{
+			name:      "internal failure",
+			code:      "INTERNAL",
+			permanent: false,
+		},
+		{
+			name:      "empty code",
+			code:      "",
+			permanent: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			status := &mailboxpb.Status{
+				Ok:                       false,
+				Code:                     tc.code,
+				Message:                  "boom",
+				SupportedMailboxVersions: tc.mailboxVers,
+				SupportedArkVersions:     tc.arkVers,
+				UpgradeUrl:               tc.upgradeURL,
+			}
+
+			statusErr := NewStatusError("Send", status)
+
+			// Classification matches the permanent-code table.
+			require.Equal(
+				t, tc.permanent, statusErr.IsPermanentVersion(),
+			)
+			require.Equal(
+				t, tc.permanent,
+				IsPermanentVersionError(statusErr),
+			)
+
+			// The code and full payload remain available.
+			require.Equal(t, tc.code, statusErr.Code())
+			require.Equal(
+				t, tc.mailboxVers,
+				statusErr.SupportedMailboxVersions(),
+			)
+			require.Equal(
+				t, tc.arkVers, statusErr.SupportedArkVersions(),
+			)
+			require.Equal(t, tc.upgradeURL, statusErr.UpgradeURL())
+
+			// The error string preserves operation, message, and
+			// code for diagnosability.
+			require.Contains(t, statusErr.Error(), "Send")
+			require.Contains(t, statusErr.Error(), "boom")
+			if tc.code != "" {
+				require.Contains(
+					t, statusErr.Error(), tc.code,
+				)
+			}
+		})
+	}
+}
+
+// TestStatusErrorNilStatus proves the typed error degrades gracefully when no
+// status is present rather than panicking.
+func TestStatusErrorNilStatus(t *testing.T) {
+	t.Parallel()
+
+	statusErr := NewStatusError("AckUpTo", nil)
+
+	require.False(t, statusErr.IsPermanentVersion())
+	require.Empty(t, statusErr.Code())
+	require.Nil(t, statusErr.SupportedMailboxVersions())
+	require.Nil(t, statusErr.SupportedArkVersions())
+	require.Empty(t, statusErr.UpgradeURL())
+	require.Contains(t, statusErr.Error(), "nil status")
+}
+
+// TestIsPermanentVersionErrorWrapped proves the free helper unwraps a wrapped
+// StatusError, so durable senders can classify deeply nested errors.
+func TestIsPermanentVersionErrorWrapped(t *testing.T) {
+	t.Parallel()
+
+	permErr := NewStatusError("Send", &mailboxpb.Status{
+		Ok:   false,
+		Code: StatusUpgradeRequired,
+	})
+	wrapped := fmt.Errorf("send failed: %w", permErr)
+	require.True(t, IsPermanentVersionError(wrapped))
+
+	transientErr := NewStatusError("Send", &mailboxpb.Status{
+		Ok:   false,
+		Code: "UNAVAILABLE",
+	})
+	require.False(
+		t,
+		IsPermanentVersionError(
+			fmt.Errorf("send failed: %w", transientErr),
+		),
+	)
+
+	// A non-StatusError is never a permanent version error.
+	require.False(
+		t,
+		IsPermanentVersionError(
+			fmt.Errorf("some other error"),
+		),
+	)
+}

--- a/mailbox/pb/mailbox.pb.go
+++ b/mailbox/pb/mailbox.pb.go
@@ -184,9 +184,14 @@ type Envelope struct {
 	// rpc carries optional RPC overlay metadata.
 	Rpc *RpcMeta `protobuf:"bytes,11,opt,name=rpc,proto3" json:"rpc,omitempty"`
 	// event_seq is assigned by the mailbox edge to define per-mailbox ordering.
-	EventSeq      uint64 `protobuf:"varint,12,opt,name=event_seq,json=eventSeq,proto3" json:"event_seq,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	EventSeq uint64 `protobuf:"varint,12,opt,name=event_seq,json=eventSeq,proto3" json:"event_seq,omitempty"`
+	// ark_protocol_version is the negotiated Ark protocol version selected
+	// through the direct GetInfo bootstrap RPC. It is distinct from
+	// protocol_version, which is the mailbox transport version. Every envelope
+	// sent after negotiation carries the runtime-bound Ark protocol version.
+	ArkProtocolVersion uint32 `protobuf:"varint,13,opt,name=ark_protocol_version,json=arkProtocolVersion,proto3" json:"ark_protocol_version,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *Envelope) Reset() {
@@ -303,6 +308,13 @@ func (x *Envelope) GetEventSeq() uint64 {
 	return 0
 }
 
+func (x *Envelope) GetArkProtocolVersion() uint32 {
+	if x != nil {
+		return x.ArkProtocolVersion
+	}
+	return 0
+}
+
 // Status describes the result of a mailbox edge operation.
 type Status struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -317,9 +329,18 @@ type Status struct {
 	// server_protocol_version is populated for upgrade-required errors.
 	ServerProtocolVersion uint32 `protobuf:"varint,5,opt,name=server_protocol_version,json=serverProtocolVersion,proto3" json:"server_protocol_version,omitempty"`
 	// upgrade_url is populated for upgrade-required errors.
-	UpgradeUrl    string `protobuf:"bytes,6,opt,name=upgrade_url,json=upgradeUrl,proto3" json:"upgrade_url,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	UpgradeUrl string `protobuf:"bytes,6,opt,name=upgrade_url,json=upgradeUrl,proto3" json:"upgrade_url,omitempty"`
+	// supported_mailbox_versions lists the mailbox transport versions the
+	// responder supports. It is populated for permanent version errors so the
+	// sender can surface actionable guidance without parsing gRPC status
+	// details.
+	SupportedMailboxVersions []uint32 `protobuf:"varint,7,rep,packed,name=supported_mailbox_versions,json=supportedMailboxVersions,proto3" json:"supported_mailbox_versions,omitempty"`
+	// supported_ark_versions lists the Ark protocol versions the responder has
+	// enabled. It is populated for permanent version errors so the sender can
+	// surface actionable guidance without parsing gRPC status details.
+	SupportedArkVersions []uint32 `protobuf:"varint,8,rep,packed,name=supported_ark_versions,json=supportedArkVersions,proto3" json:"supported_ark_versions,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Status) Reset() {
@@ -392,6 +413,20 @@ func (x *Status) GetUpgradeUrl() string {
 		return x.UpgradeUrl
 	}
 	return ""
+}
+
+func (x *Status) GetSupportedMailboxVersions() []uint32 {
+	if x != nil {
+		return x.SupportedMailboxVersions
+	}
+	return nil
+}
+
+func (x *Status) GetSupportedArkVersions() []uint32 {
+	if x != nil {
+		return x.SupportedArkVersions
+	}
+	return nil
 }
 
 // SendRequest sends a single envelope.
@@ -733,7 +768,7 @@ const file_mailbox_proto_rawDesc = "" +
 	"\fKIND_REQUEST\x10\x01\x12\x11\n" +
 	"\rKIND_RESPONSE\x10\x02\x12\x0e\n" +
 	"\n" +
-	"KIND_EVENT\x10\x03\"\x80\x04\n" +
+	"KIND_EVENT\x10\x03\"\xb2\x04\n" +
 	"\bEnvelope\x12)\n" +
 	"\x10protocol_version\x18\x01 \x01(\rR\x0fprotocolVersion\x12\x15\n" +
 	"\x06msg_id\x18\x02 \x01(\tR\x05msgId\x12'\n" +
@@ -747,10 +782,11 @@ const file_mailbox_proto_rawDesc = "" +
 	"\x04body\x18\n" +
 	" \x01(\v2\x14.google.protobuf.AnyR\x04body\x12%\n" +
 	"\x03rpc\x18\v \x01(\v2\x13.mailbox.v1.RpcMetaR\x03rpc\x12\x1b\n" +
-	"\tevent_seq\x18\f \x01(\x04R\beventSeq\x1a:\n" +
+	"\tevent_seq\x18\f \x01(\x04R\beventSeq\x120\n" +
+	"\x14ark_protocol_version\x18\r \x01(\rR\x12arkProtocolVersion\x1a:\n" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe4\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xd8\x02\n" +
 	"\x06Status\x12\x0e\n" +
 	"\x02ok\x18\x01 \x01(\bR\x02ok\x12\x12\n" +
 	"\x04code\x18\x02 \x01(\tR\x04code\x12\x18\n" +
@@ -758,7 +794,9 @@ const file_mailbox_proto_rawDesc = "" +
 	"\x1emin_supported_protocol_version\x18\x04 \x01(\rR\x1bminSupportedProtocolVersion\x126\n" +
 	"\x17server_protocol_version\x18\x05 \x01(\rR\x15serverProtocolVersion\x12\x1f\n" +
 	"\vupgrade_url\x18\x06 \x01(\tR\n" +
-	"upgradeUrl\"?\n" +
+	"upgradeUrl\x12<\n" +
+	"\x1asupported_mailbox_versions\x18\a \x03(\rR\x18supportedMailboxVersions\x124\n" +
+	"\x16supported_ark_versions\x18\b \x03(\rR\x14supportedArkVersions\"?\n" +
 	"\vSendRequest\x120\n" +
 	"\benvelope\x18\x01 \x01(\v2\x14.mailbox.v1.EnvelopeR\benvelope\":\n" +
 	"\fSendResponse\x12*\n" +

--- a/mailbox/pb/mailbox.proto
+++ b/mailbox/pb/mailbox.proto
@@ -70,6 +70,12 @@ message Envelope {
 
     // event_seq is assigned by the mailbox edge to define per-mailbox ordering.
     uint64 event_seq = 12;
+
+    // ark_protocol_version is the negotiated Ark protocol version selected
+    // through the direct GetInfo bootstrap RPC. It is distinct from
+    // protocol_version, which is the mailbox transport version. Every envelope
+    // sent after negotiation carries the runtime-bound Ark protocol version.
+    uint32 ark_protocol_version = 13;
 }
 
 // Status describes the result of a mailbox edge operation.
@@ -91,6 +97,17 @@ message Status {
 
     // upgrade_url is populated for upgrade-required errors.
     string upgrade_url = 6;
+
+    // supported_mailbox_versions lists the mailbox transport versions the
+    // responder supports. It is populated for permanent version errors so the
+    // sender can surface actionable guidance without parsing gRPC status
+    // details.
+    repeated uint32 supported_mailbox_versions = 7;
+
+    // supported_ark_versions lists the Ark protocol versions the responder has
+    // enabled. It is populated for permanent version errors so the sender can
+    // surface actionable guidance without parsing gRPC status details.
+    repeated uint32 supported_ark_versions = 8;
 }
 
 // SendRequest sends a single envelope.

--- a/mailbox/pb/version.go
+++ b/mailbox/pb/version.go
@@ -1,0 +1,14 @@
+package mailboxpb
+
+// MailboxProtocolVersionV1 is the stable mailbox transport version. The
+// mailbox transport version defines how an envelope is framed, routed, and
+// delivered: Envelope framing, RpcMeta routing, Send/Pull/AckUpTo behavior,
+// and cursor, acknowledgement, and durable replay semantics.
+//
+// It is intentionally a code constant rather than operator configuration
+// because mailbox v1 is the stable bootstrap endpoint that every client must
+// be able to decode. A future breaking mailbox transport must run on a new
+// endpoint or protobuf service package (such as mailbox.v2); it cannot depend
+// on a v1 envelope to negotiate a format that v1 cannot decode. This value is
+// therefore not a normal rolling configuration choice.
+const MailboxProtocolVersionV1 uint32 = 1

--- a/mailbox/pb/version_compat_test.go
+++ b/mailbox/pb/version_compat_test.go
@@ -1,0 +1,125 @@
+package mailboxpb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestEnvelopeOldShapeDecodesZero proves that an Envelope encoded without the
+// new ark_protocol_version field decodes under the new generated code with
+// that field left at its zero value, while the existing mailbox transport
+// protocol_version is preserved. This is the additive-compatibility guarantee
+// that lets the updated code decode envelopes produced before the Ark
+// protocol version field existed.
+func TestEnvelopeOldShapeDecodesZero(t *testing.T) {
+	t.Parallel()
+
+	// Populate only fields that existed before ark_protocol_version was
+	// added.
+	oldShape := &Envelope{
+		ProtocolVersion: uint32(1),
+		MsgId:           "msg-1",
+		IdempotencyKey:  "idem-1",
+		Sender:          "alice",
+		Recipient:       "bob",
+		EventSeq:        7,
+	}
+
+	raw, err := proto.Marshal(oldShape)
+	require.NoError(t, err)
+
+	decoded := &Envelope{}
+	require.NoError(t, proto.Unmarshal(raw, decoded))
+
+	// The mailbox transport version round-trips unchanged.
+	require.Equal(t, uint32(1), decoded.ProtocolVersion)
+	require.Equal(t, "msg-1", decoded.MsgId)
+	require.Equal(t, uint64(7), decoded.EventSeq)
+
+	// The newly added Ark protocol version must be zero after decoding an
+	// old-shape envelope.
+	require.Zero(t, decoded.ArkProtocolVersion)
+}
+
+// TestStatusOldShapeDecodesZero proves that a Status encoded with only the
+// pre-versioning fields decodes under the new code with the newly added
+// supported-version lists empty.
+func TestStatusOldShapeDecodesZero(t *testing.T) {
+	t.Parallel()
+
+	oldShape := &Status{
+		Ok:      false,
+		Code:    "SOME_CODE",
+		Message: "human readable",
+	}
+
+	raw, err := proto.Marshal(oldShape)
+	require.NoError(t, err)
+
+	decoded := &Status{}
+	require.NoError(t, proto.Unmarshal(raw, decoded))
+
+	require.Equal(t, "SOME_CODE", decoded.Code)
+	require.Equal(t, "human readable", decoded.Message)
+
+	require.Empty(t, decoded.SupportedMailboxVersions)
+	require.Empty(t, decoded.SupportedArkVersions)
+}
+
+// TestEnvelopeVersionFieldsRoundTrip proves that both version axes on the
+// Envelope are independently preserved across a marshal/unmarshal cycle.
+func TestEnvelopeVersionFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	env := &Envelope{
+		ProtocolVersion:    uint32(1),
+		ArkProtocolVersion: 2,
+		MsgId:              "msg-2",
+	}
+
+	raw, err := proto.Marshal(env)
+	require.NoError(t, err)
+
+	decoded := &Envelope{}
+	require.NoError(t, proto.Unmarshal(raw, decoded))
+
+	require.Equal(t, uint32(1), decoded.ProtocolVersion)
+	require.Equal(t, uint32(2), decoded.ArkProtocolVersion)
+	require.Equal(t, "msg-2", decoded.MsgId)
+}
+
+// TestStatusVersionFieldsRoundTrip proves that the new supported-version lists
+// on Status are preserved across a marshal/unmarshal cycle so callers can
+// surface actionable upgrade guidance from a permanent version error.
+func TestStatusVersionFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	status := &Status{
+		Ok:         false,
+		Code:       "ARK_VERSION_UNSUPPORTED",
+		Message:    "unsupported",
+		UpgradeUrl: "https://upgrade.example",
+		SupportedMailboxVersions: []uint32{
+			uint32(1),
+		},
+		SupportedArkVersions: []uint32{
+			1,
+			2,
+		},
+	}
+
+	raw, err := proto.Marshal(status)
+	require.NoError(t, err)
+
+	decoded := &Status{}
+	require.NoError(t, proto.Unmarshal(raw, decoded))
+
+	require.Equal(t, "ARK_VERSION_UNSUPPORTED", decoded.Code)
+	require.Equal(t, "https://upgrade.example", decoded.UpgradeUrl)
+	require.Equal(
+		t, []uint32{uint32(1)}, decoded.SupportedMailboxVersions,
+	)
+	require.Equal(t, []uint32{1, 2}, decoded.SupportedArkVersions)
+}

--- a/serverconn/README.md
+++ b/serverconn/README.md
@@ -263,7 +263,8 @@ watermark.
 | `Edge` | `MailboxServiceClient` | *required* | gRPC client for the remote mailbox edge. |
 | `LocalMailboxID` | `string` | *required* | This client's mailbox identifier. |
 | `RemoteMailboxID` | `string` | *required* | Remote server's mailbox identifier. |
-| `ProtocolVersion` | `uint32` | `0` | Protocol version stamped on outbound envelopes. |
+| `MailboxProtocolVersion` | `uint32` | `MailboxProtocolVersionV1` | Immutable mailbox transport version stamped on outbound envelopes. Defaults to the v1 code constant. |
+| `ArkProtocolVersion` | `uint32` | `0` | Immutable negotiated Ark protocol version stamped on outbound envelopes and validated on inbound ones. Must be non-zero; `NewRuntime` rejects zero. |
 | `Dispatchers` | `map[ServiceMethod]EnvelopeDispatcher` | `nil` | Inbound envelope routing table. |
 | `Store` | `actor.DeliveryStore` | *required* | Durability store for inbox, outbox, and checkpoints. |
 | `Codec` | `*actor.MessageCodec` | `NewServerConnCodec()` | TLV codec for ServerConnMsg serialization. |

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -661,6 +661,23 @@ type ServerConnectionActor struct {
 	// checks this to skip sending when real traffic already
 	// proves liveness.
 	lastSendNano atomic.Int64
+
+	// compatErr caches the first permanent version error that moved the
+	// connector to the terminal INCOMPATIBLE state. A nil pointer means the
+	// connector is still COMPATIBLE. Once set, new sends return this error
+	// without contacting the edge.
+	compatErr atomic.Pointer[mailboxconn.StatusError]
+
+	// compatOnce guarantees the incompatibility transition (cache, cancel,
+	// fail waiters, callback) runs exactly once even under concurrent
+	// permanent failures.
+	compatOnce sync.Once
+
+	// ingressCancel holds the ingress/heartbeat context cancel function so
+	// the incompatibility transition can stop them asynchronously without
+	// joining its own goroutine. CancelFunc is idempotent, so StopIngress
+	// may also invoke it.
+	ingressCancel atomic.Pointer[context.CancelFunc]
 }
 
 // NewServerConnectionActor creates a new server connection actor with the
@@ -715,6 +732,10 @@ func (a *ServerConnectionActor) Receive(ctx context.Context,
 func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 	req *SendClientEventRequest) fn.Result[ServerConnResp] {
 
+	if ce := a.compatibilityError(); ce != nil {
+		return fn.Err[ServerConnResp](ce)
+	}
+
 	protoMsg, err := req.Message.ToProto().Unpack()
 	if err != nil {
 		a.log.WarnS(ctx, "Failed to convert to proto", err)
@@ -763,7 +784,6 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 	service, method := eventRoutingMetadata(req)
 
 	envelope := &mailboxpb.Envelope{
-		ProtocolVersion: a.cfg.ProtocolVersion,
 		MsgId:           msgID,
 		IdempotencyKey:  idempotencyKey,
 		Sender:          a.cfg.LocalMailboxID,
@@ -778,6 +798,10 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 			ReplyTo: a.cfg.LocalMailboxID,
 		},
 	}
+
+	// Stamp the immutable version pair immediately before sending so the
+	// outbound envelope never relies on a caller-provided Ark version.
+	a.cfg.stampEnvelope(envelope)
 
 	// Use a detached context for the gRPC call so that parent
 	// cancellation does not abort the outbound send, while
@@ -797,10 +821,12 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 	}
 
 	if resp.Status != nil && !resp.Status.Ok {
-		return fn.Err[ServerConnResp](
-			fmt.Errorf("send client event: %s (%s)",
-				resp.Status.Message, resp.Status.Code),
+		sErr := mailboxconn.NewStatusError(
+			"send client event", resp.Status,
 		)
+		a.checkPermanentStatus(ctx, sErr)
+
+		return fn.Err[ServerConnResp](sErr)
 	}
 
 	a.lastSendNano.Store(time.Now().UnixNano())
@@ -926,8 +952,11 @@ func (a *ServerConnectionActor) sendUnaryEnvelope(ctx context.Context,
 	body *anypb.Any, service string, method string, correlationID string,
 	msgID string, idempotencyKey string) fn.Result[ServerConnResp] {
 
+	if ce := a.compatibilityError(); ce != nil {
+		return fn.Err[ServerConnResp](ce)
+	}
+
 	envelope := &mailboxpb.Envelope{
-		ProtocolVersion: a.cfg.ProtocolVersion,
 		MsgId:           msgID,
 		IdempotencyKey:  idempotencyKey,
 		Sender:          a.cfg.LocalMailboxID,
@@ -944,6 +973,10 @@ func (a *ServerConnectionActor) sendUnaryEnvelope(ctx context.Context,
 		},
 	}
 
+	// Stamp the immutable version pair immediately before sending so the
+	// outbound envelope never relies on a caller-provided Ark version.
+	a.cfg.stampEnvelope(envelope)
+
 	sendCtx, sendCancel := context.WithTimeout(
 		context.WithoutCancel(ctx), defaultSendEventTimeout,
 	)
@@ -959,10 +992,12 @@ func (a *ServerConnectionActor) sendUnaryEnvelope(ctx context.Context,
 	}
 
 	if resp.Status != nil && !resp.Status.Ok {
-		return fn.Err[ServerConnResp](
-			fmt.Errorf("send unary request: %s (%s)",
-				resp.Status.Message, resp.Status.Code),
+		sErr := mailboxconn.NewStatusError(
+			"send unary request", resp.Status,
 		)
+		a.checkPermanentStatus(ctx, sErr)
+
+		return fn.Err[ServerConnResp](sErr)
 	}
 
 	return fn.Ok[ServerConnResp](&SendRPCResponse{
@@ -1005,6 +1040,17 @@ func eventRoutingMetadata(req *SendClientEventRequest) (string, string) {
 func (a *ServerConnectionActor) handleSendRPCRequest(ctx context.Context,
 	req *SendRPCRequest) fn.Result[ServerConnResp] {
 
+	if ce := a.compatibilityError(); ce != nil {
+		return fn.Err[ServerConnResp](ce)
+	}
+
+	// Re-stamp the pre-built (and possibly replayed) envelope with the
+	// runtime-bound version pair so a persisted caller-provided Ark version
+	// can never be sent. The bound pair is immutable, so re-stamping a
+	// replayed envelope reproduces the value it was originally stamped
+	// with.
+	a.cfg.stampEnvelope(req.Envelope)
+
 	resp, err := a.cfg.Edge.Send(ctx, &mailboxpb.SendRequest{
 		Envelope: req.Envelope,
 	})
@@ -1015,10 +1061,12 @@ func (a *ServerConnectionActor) handleSendRPCRequest(ctx context.Context,
 	}
 
 	if resp.Status != nil && !resp.Status.Ok {
-		return fn.Err[ServerConnResp](
-			fmt.Errorf("send rpc request: %s (%s)",
-				resp.Status.Message, resp.Status.Code),
+		sErr := mailboxconn.NewStatusError(
+			"send rpc request", resp.Status,
 		)
+		a.checkPermanentStatus(ctx, sErr)
+
+		return fn.Err[ServerConnResp](sErr)
 	}
 
 	a.lastSendNano.Store(time.Now().UnixNano())
@@ -1070,12 +1118,39 @@ func (a *ServerConnectionActor) StartIngress(
 	ctx context.Context,
 ) error {
 
+	// Fast path: if the connector already transitioned to the terminal
+	// incompatible state (e.g. a durable egress replay hit a permanent
+	// version error before ingress started), refuse to start polling or
+	// load checkpoints. Returning the cached error keeps the caller from
+	// marking the connection healthy.
+	if ce := a.compatibilityError(); ce != nil {
+		return ce
+	}
+
 	state, err := a.loadCheckpoint(ctx)
 	if err != nil {
 		return fmt.Errorf("load ingress checkpoint: %w", err)
 	}
 
 	ingressCtx, cancel := context.WithCancel(ctx)
+
+	// Publish the cancel func so the incompatibility transition can stop
+	// ingress and heartbeat asynchronously. CancelFunc is idempotent, so
+	// StopIngress invoking it again via cancelCh is harmless.
+	a.ingressCancel.Store(&cancel)
+
+	// Recheck after publishing the cancel func to close the race with a
+	// concurrent markIncompatible. The two transitions touch the compat
+	// error and the cancel pointer in opposite orders: markIncompatible
+	// stores the compat error then loads the cancel; we store the cancel
+	// then load the compat error. So at least one of us observes the
+	// other — either we see the incompatible state here and abort, or
+	// markIncompatible sees our published cancel and stops the goroutines.
+	if ce := a.compatibilityError(); ce != nil {
+		cancel()
+
+		return ce
+	}
 
 	a.wg.Add(2)
 	a.cancelCh <- cancel

--- a/serverconn/compatibility.go
+++ b/serverconn/compatibility.go
@@ -1,0 +1,73 @@
+package serverconn
+
+import (
+	"context"
+	"errors"
+
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+)
+
+// compatibilityError returns the cached permanent version error if the
+// connector has transitioned to the terminal INCOMPATIBLE state, or nil while
+// it is still COMPATIBLE. Send paths consult this before contacting the edge.
+func (a *ServerConnectionActor) compatibilityError() *mailboxconn.StatusError {
+	return a.compatErr.Load()
+}
+
+// checkPermanentStatus inspects an error returned by an edge operation. If it
+// is a permanent version StatusError, it drives the terminal incompatibility
+// transition and returns true. Transient and non-status errors return false so
+// the existing retry policy still applies.
+func (a *ServerConnectionActor) checkPermanentStatus(ctx context.Context,
+	err error) bool {
+
+	if err == nil {
+		return false
+	}
+
+	var statusErr *mailboxconn.StatusError
+	if !errors.As(err, &statusErr) || !statusErr.IsPermanentVersion() {
+		return false
+	}
+
+	a.markIncompatible(ctx, statusErr)
+
+	return true
+}
+
+// markIncompatible performs the one-shot transition to the terminal
+// INCOMPATIBLE state. It caches the typed error, cancels ingress and heartbeat
+// processing asynchronously (so a calling ingress or heartbeat goroutine never
+// waits for itself), fails all pending unary waiters with the same error, and
+// invokes the optional compatibility callback exactly once. Subsequent calls
+// are no-ops.
+func (a *ServerConnectionActor) markIncompatible(ctx context.Context,
+	statusErr *mailboxconn.StatusError) {
+
+	if statusErr == nil {
+		return
+	}
+
+	a.compatOnce.Do(func() {
+		// Cache the error first so any concurrent send observes the
+		// terminal state immediately.
+		a.compatErr.Store(statusErr)
+
+		a.log.WarnS(ctx, "Connector became incompatible", statusErr)
+
+		// Cancel ingress and heartbeat without joining: this may run on
+		// the ingress goroutine itself. CancelFunc is idempotent.
+		if cancel := a.ingressCancel.Load(); cancel != nil {
+			(*cancel)()
+		}
+
+		// Fail every in-flight unary waiter so no caller blocks on a
+		// response that will never arrive.
+		a.responseRegistry.FailAll(statusErr)
+
+		// Notify the owner exactly once.
+		if a.cfg.OnIncompatible != nil {
+			a.cfg.OnIncompatible(statusErr)
+		}
+	})
+}

--- a/serverconn/compatibility_test.go
+++ b/serverconn/compatibility_test.go
@@ -1,0 +1,326 @@
+package serverconn
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// recordingEdge is a MailboxServiceClient that counts Send calls and returns a
+// configurable status, used to prove permanent-error handling without a real
+// transport.
+type recordingEdge struct {
+	sendCount  atomic.Int64
+	sendStatus *mailboxpb.Status
+}
+
+func (e *recordingEdge) Send(_ context.Context, _ *mailboxpb.SendRequest,
+	_ ...grpc.CallOption) (*mailboxpb.SendResponse, error) {
+
+	e.sendCount.Add(1)
+
+	return &mailboxpb.SendResponse{Status: e.sendStatus}, nil
+}
+
+func (e *recordingEdge) Pull(_ context.Context, _ *mailboxpb.PullRequest,
+	_ ...grpc.CallOption) (*mailboxpb.PullResponse, error) {
+
+	return &mailboxpb.PullResponse{Status: okStatus()}, nil
+}
+
+func (e *recordingEdge) AckUpTo(_ context.Context, _ *mailboxpb.AckUpToRequest,
+	_ ...grpc.CallOption) (*mailboxpb.AckUpToResponse, error) {
+
+	return &mailboxpb.AckUpToResponse{Status: okStatus()}, nil
+}
+
+// permanentStatus builds a permanent version status for tests.
+func permanentStatus() *mailboxpb.Status {
+	return &mailboxpb.Status{
+		Ok:      false,
+		Code:    mailboxconn.StatusUpgradeRequired,
+		Message: "client must upgrade",
+		SupportedArkVersions: []uint32{
+			2,
+		},
+		UpgradeUrl: "https://upgrade.example",
+	}
+}
+
+// TestMarkIncompatibleOnce proves that concurrent permanent failures cause
+// exactly one state transition and one callback, cache the typed error, and
+// fail pending unary waiters with that error.
+func TestMarkIncompatibleOnce(t *testing.T) {
+	t.Parallel()
+
+	var callbackCount atomic.Int64
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	cfg.OnIncompatible = func(*mailboxconn.StatusError) {
+		callbackCount.Add(1)
+	}
+
+	conn := NewServerConnectionActor(cfg)
+
+	// Register a unary waiter that must be failed by the transition.
+	corrID := CorrelationID("corr-1")
+	fut := conn.RegisterWaiter(corrID)
+
+	statusErr := mailboxconn.NewStatusError("Send", permanentStatus())
+
+	// Fire many concurrent permanent failures.
+	const racers = 16
+	var wg sync.WaitGroup
+	wg.Add(racers)
+	for i := 0; i < racers; i++ {
+		go func() {
+			defer wg.Done()
+
+			require.True(
+				t,
+				conn.checkPermanentStatus(
+					t.Context(), statusErr,
+				),
+			)
+		}()
+	}
+	wg.Wait()
+
+	// Exactly one transition and one callback.
+	require.Equal(t, int64(1), callbackCount.Load())
+	require.NotNil(t, conn.compatibilityError())
+	require.Equal(
+		t, mailboxconn.StatusUpgradeRequired,
+		conn.compatibilityError().Code(),
+	)
+
+	// The pending waiter received the same typed error.
+	res := fut.Await(t.Context())
+	require.Error(t, res.Err())
+	require.True(t, mailboxconn.IsPermanentVersionError(res.Err()))
+}
+
+// TestTransientStatusDoesNotMarkIncompatible proves a transient status does not
+// transition the connector, so the existing retry policy still applies.
+func TestTransientStatusDoesNotMarkIncompatible(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	conn := NewServerConnectionActor(cfg)
+
+	transient := mailboxconn.NewStatusError("Pull", &mailboxpb.Status{
+		Ok:   false,
+		Code: "UNAVAILABLE",
+	})
+	require.False(t, conn.checkPermanentStatus(t.Context(), transient))
+	require.Nil(t, conn.compatibilityError())
+}
+
+// TestSendShortCircuitsAfterIncompatible proves future sends return the cached
+// error without contacting the edge once the connector is incompatible.
+func TestSendShortCircuitsAfterIncompatible(t *testing.T) {
+	t.Parallel()
+
+	edge := &recordingEdge{sendStatus: okStatus()}
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	cfg.Edge = edge
+
+	conn := NewServerConnectionActor(cfg)
+
+	// Transition to incompatible directly.
+	conn.markIncompatible(
+		t.Context(),
+		mailboxconn.NewStatusError(
+			"Send", permanentStatus(),
+		),
+	)
+
+	// An event send must not contact the edge and must return the cached
+	// error.
+	res := conn.Receive(t.Context(), &SendClientEventRequest{
+		Message: &testServerMessage{value: "after-incompat"},
+	})
+	require.Error(t, res.Err())
+	require.True(t, mailboxconn.IsPermanentVersionError(res.Err()))
+
+	// The unary facade and heartbeat paths must also avoid the edge.
+	conn.sendHeartbeat(t.Context())
+
+	require.Equal(t, int64(0), edge.sendCount.Load())
+}
+
+// TestPermanentStatusFromEdgeMarksIncompatible proves that a permanent status
+// returned by the edge transitions the connector and invokes the callback
+// once, while the edge is contacted exactly once.
+func TestPermanentStatusFromEdgeMarksIncompatible(t *testing.T) {
+	t.Parallel()
+
+	var callbackCount atomic.Int64
+
+	edge := &recordingEdge{sendStatus: permanentStatus()}
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	cfg.Edge = edge
+	cfg.OnIncompatible = func(*mailboxconn.StatusError) {
+		callbackCount.Add(1)
+	}
+
+	conn := NewServerConnectionActor(cfg)
+
+	res := conn.Receive(t.Context(), &SendClientEventRequest{
+		Message: &testServerMessage{value: "permanent"},
+	})
+	require.Error(t, res.Err())
+	require.True(t, mailboxconn.IsPermanentVersionError(res.Err()))
+
+	require.Equal(t, int64(1), edge.sendCount.Load())
+	require.Equal(t, int64(1), callbackCount.Load())
+	require.NotNil(t, conn.compatibilityError())
+}
+
+// TestStartIngressRefusesWhenIncompatible proves that if the connector became
+// incompatible before ingress starts (e.g. a durable egress replay hit a
+// permanent error between StartEgress and StartIngress), StartIngress returns
+// the cached error and never starts polling — so the caller cannot mark the
+// connection healthy.
+func TestStartIngressRefusesWhenIncompatible(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	conn := NewServerConnectionActor(cfg)
+
+	conn.markIncompatible(
+		t.Context(),
+		mailboxconn.NewStatusError(
+			"Send", permanentStatus(),
+		),
+	)
+
+	err := conn.StartIngress(t.Context())
+	require.Error(t, err)
+	require.True(t, mailboxconn.IsPermanentVersionError(err))
+}
+
+// TestAwaitRPCShortCircuitsAfterIncompatible proves AwaitRPC returns the cached
+// error instead of blocking when incompatibility lands after a waiter was
+// pre-registered (by SendRPC) but before AwaitRPC runs.
+func TestAwaitRPCShortCircuitsAfterIncompatible(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	conn := NewServerConnectionActor(cfg)
+	facade := NewUnaryFacade(conn)
+
+	// Simulate SendRPC pre-registering the waiter, then incompatibility
+	// landing (which drains waiters via FailAll).
+	conn.RegisterWaiter(CorrelationID("corr-1"))
+	conn.markIncompatible(
+		t.Context(),
+		mailboxconn.NewStatusError(
+			"Send", permanentStatus(),
+		),
+	)
+
+	// A bounded context ensures a regression (blocking) fails fast instead
+	// of hanging the suite.
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	err := facade.AwaitRPC(ctx, "corr-1", &mailboxpb.Status{})
+	require.Error(t, err)
+	require.True(t, mailboxconn.IsPermanentVersionError(err))
+}
+
+// TestRuntimeMarkIncompatible proves the exported Runtime.MarkIncompatible
+// entry point drives the connector to its terminal state and fires the
+// callback, so side-channel detectors (such as a refresh-only GetInfo) can
+// transition the runtime.
+func TestRuntimeMarkIncompatible(t *testing.T) {
+	t.Parallel()
+
+	var callbackCount atomic.Int64
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	cfg.OnIncompatible = func(*mailboxconn.StatusError) {
+		callbackCount.Add(1)
+	}
+
+	rt, err := NewRuntime(cfg)
+	require.NoError(t, err)
+
+	rt.MarkIncompatible(
+		t.Context(),
+		mailboxconn.NewStatusError(
+			"refresh", permanentStatus(),
+		),
+	)
+
+	require.Equal(t, int64(1), callbackCount.Load())
+	require.NotNil(t, rt.Connector().compatibilityError())
+}
+
+// TestPermanentAwareTellRetryPolicy proves the durable retry policy treats a
+// permanent version error as non-retryable (dead-letter) while a transient
+// error keeps the default retry behavior.
+func TestPermanentAwareTellRetryPolicy(t *testing.T) {
+	t.Parallel()
+
+	permErr := mailboxconn.NewStatusError("Send", permanentStatus())
+	retry, _ := permanentAwareTellRetryPolicy(permErr, 0)
+	require.False(t, retry, "permanent error must not be retried")
+
+	transient := mailboxconn.NewStatusError("Send", &mailboxpb.Status{
+		Ok:   false,
+		Code: "UNAVAILABLE",
+	})
+	retry, _ = permanentAwareTellRetryPolicy(transient, 0)
+	require.True(t, retry, "transient error must still retry")
+}
+
+// TestDurableSendDeadLettersPermanentError proves a durable event whose send
+// returns a permanent version error is dead-lettered immediately rather than
+// retried.
+func TestDurableSendDeadLettersPermanentError(t *testing.T) {
+	t.Parallel()
+
+	edge := &recordingEdge{sendStatus: permanentStatus()}
+	mb := newInMemoryMailbox()
+	store := newMemCheckpointStore()
+	cfg := newTestConnectorConfig(mb, store)
+	cfg.Edge = edge
+
+	rt, err := NewRuntime(cfg)
+	require.NoError(t, err)
+
+	rt.StartEgress()
+	defer rt.Stop()
+
+	err = rt.TellRef().Tell(t.Context(), &SendClientEventRequest{
+		Message: &testServerMessage{value: "dead-letter"},
+	})
+	require.NoError(t, err)
+
+	actorID := DurableActorID(cfg.LocalMailboxID)
+	require.Eventually(t, func() bool {
+		letters, lErr := store.ListDeadLetters(t.Context(), actorID, 10)
+		require.NoError(t, lErr)
+
+		return len(letters) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// The edge was contacted at most once: there was no retry storm.
+	require.LessOrEqual(t, edge.sendCount.Load(), int64(1))
+}

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -462,10 +462,11 @@ func TestIngressAckHandledResponseWithoutActorDelivery(t *testing.T) {
 	require.NoError(t, err)
 
 	status := mb.send(&mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          "server-1",
-		Recipient:       "client-1",
-		Body:            body,
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             "server-1",
+		Recipient:          "client-1",
+		Body:               body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			CorrelationId: "stale-corr",

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -100,10 +101,11 @@ func sendResponseToMailbox(t *testing.T, mb *inMemoryMailbox, recipientID,
 	}
 
 	env := &mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          "server-1",
-		Recipient:       recipientID,
-		Body:            body,
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             "server-1",
+		Recipient:          recipientID,
+		Body:               body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			CorrelationId: correlationID,
@@ -129,10 +131,11 @@ func sendRoutedResponseToMailbox(t *testing.T, mb *inMemoryMailbox, recipientID,
 	}
 
 	env := &mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          "server-1",
-		Recipient:       recipientID,
-		Body:            body,
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             "server-1",
+		Recipient:          recipientID,
+		Body:               body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			CorrelationId: correlationID,
@@ -157,10 +160,11 @@ func sendRoutedErrorResponseToMailbox(t *testing.T, mb *inMemoryMailbox,
 	t.Helper()
 
 	env := &mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          "server-1",
-		Recipient:       recipientID,
-		Headers:         mailboxrpc.EncodeErrorHeaders(err),
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             "server-1",
+		Recipient:          recipientID,
+		Headers:            mailboxrpc.EncodeErrorHeaders(err),
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			CorrelationId: correlationID,
@@ -188,10 +192,11 @@ func sendEventToMailbox(t *testing.T, mb *inMemoryMailbox, recipientID, service,
 	require.NoError(t, err)
 
 	env := &mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          "server-1",
-		Recipient:       recipientID,
-		Body:            body,
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             "server-1",
+		Recipient:          recipientID,
+		Body:               body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:    mailboxpb.RpcMeta_KIND_EVENT,
 			Service: service,
@@ -549,7 +554,7 @@ func TestIngress_NoAckOnDispatchFailure(t *testing.T) {
 
 			// Fail the first attempt, succeed thereafter.
 			if count == 1 {
-				return &statusError{
+				return &mailboxconn.StatusError{
 					Op: "dispatch",
 					Status: &mailboxpb.Status{
 						Ok:      false,
@@ -785,7 +790,7 @@ func TestIngress_PartialDispatch_NoDuplicateRedelivery(t *testing.T) {
 			// second to be dispatched (count==3) but NOT the
 			// first again.
 			if count == 2 {
-				return &statusError{
+				return &mailboxconn.StatusError{
 					Op: "dispatch",
 					Status: &mailboxpb.Status{
 						Ok:      false,

--- a/serverconn/e2e_test.go
+++ b/serverconn/e2e_test.go
@@ -202,11 +202,12 @@ func (s *testServer) handleRequest(ctx context.Context,
 	}
 
 	responseEnv := &mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          s.serverMailboxID,
-		Recipient:       env.Rpc.ReplyTo,
-		Headers:         headers,
-		Body:            body,
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             s.serverMailboxID,
+		Recipient:          env.Rpc.ReplyTo,
+		Headers:            headers,
+		Body:               body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			CorrelationId: env.Rpc.CorrelationId,
@@ -228,10 +229,11 @@ func (s *testServer) pushEvent(t *testing.T, recipientID, service,
 	require.NoError(t, err)
 
 	env := &mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          s.serverMailboxID,
-		Recipient:       recipientID,
-		Body:            body,
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             s.serverMailboxID,
+		Recipient:          recipientID,
+		Body:               body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:    mailboxpb.RpcMeta_KIND_EVENT,
 			Service: service,

--- a/serverconn/heartbeat.go
+++ b/serverconn/heartbeat.go
@@ -77,6 +77,13 @@ func (a *ServerConnectionActor) startHeartbeat(ctx context.Context) {
 // envelope has no body — the service/method metadata is sufficient for
 // the server to recognise it as a liveness signal.
 func (a *ServerConnectionActor) sendHeartbeat(ctx context.Context) {
+	// Skip heartbeats once the connector is incompatible: the transition
+	// already cancelled this goroutine's context, but guard defensively so
+	// we never contact the edge after the terminal state.
+	if a.compatibilityError() != nil {
+		return
+	}
+
 	now := time.Now()
 
 	// Each heartbeat needs a unique MsgId to avoid deduplication
@@ -91,7 +98,6 @@ func (a *ServerConnectionActor) sendHeartbeat(ctx context.Context) {
 	)
 
 	envelope := &mailboxpb.Envelope{
-		ProtocolVersion: a.cfg.ProtocolVersion,
 		MsgId:           msgID,
 		Sender:          a.cfg.LocalMailboxID,
 		Recipient:       a.cfg.RemoteMailboxID,
@@ -105,13 +111,28 @@ func (a *ServerConnectionActor) sendHeartbeat(ctx context.Context) {
 		},
 	}
 
+	// Stamp the immutable version pair so heartbeats carry both versions
+	// like every other outbound envelope.
+	a.cfg.stampEnvelope(envelope)
+
 	// Best-effort: log but don't fail. The server will mark us
 	// offline after the staleness threshold if heartbeats stop
 	// arriving.
-	_, err := a.cfg.Edge.Send(ctx, &mailboxpb.SendRequest{
+	resp, err := a.cfg.Edge.Send(ctx, &mailboxpb.SendRequest{
 		Envelope: envelope,
 	})
 	if err != nil {
 		a.log.WarnS(ctx, "Heartbeat send failed", err)
+
+		return
+	}
+
+	// A permanent version status on a heartbeat is terminal, just like on
+	// any other send path: drive the incompatibility transition.
+	if resp.Status != nil && !resp.Status.Ok {
+		a.checkPermanentStatus(
+			ctx,
+			mailboxconn.NewStatusError("heartbeat", resp.Status),
+		)
 	}
 }

--- a/serverconn/inbound_version.go
+++ b/serverconn/inbound_version.go
@@ -1,0 +1,66 @@
+package serverconn
+
+import (
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+)
+
+// validateInboundEnvelope checks that an inbound server envelope carries the
+// mailbox transport and Ark protocol versions bound to this runtime. It
+// returns a typed permanent version StatusError on mismatch so the ingress
+// loop refuses to acknowledge or dispatch the envelope and the connector can
+// classify the failure as permanent. A nil return means the envelope is
+// compatible and may be delivered.
+//
+// There is no legacy fallback: an inbound Ark version of zero is treated as a
+// mismatch like any other wrong version. The client and operator are deployed
+// together, so every authentic server envelope carries the negotiated version.
+func (a *ServerConnectionActor) validateInboundEnvelope(
+	env *mailboxpb.Envelope) error {
+
+	if env == nil {
+		return nil
+	}
+
+	// The mailbox transport version must match the bound transport version
+	// exactly. The transport is a stable code constant, so any difference
+	// means the envelope cannot be safely framed for this runtime.
+	if env.ProtocolVersion != a.cfg.MailboxProtocolVersion {
+		return mailboxconn.NewStatusError(
+			"inbound", a.inboundMismatchStatus(
+				mailboxconn.StatusMailboxVersionUnsupported,
+			),
+		)
+	}
+
+	// The Ark protocol version must match the bound version exactly.
+	if env.ArkProtocolVersion != a.cfg.ArkProtocolVersion {
+		return mailboxconn.NewStatusError(
+			"inbound", a.inboundMismatchStatus(
+				mailboxconn.StatusArkVersionMismatch,
+			),
+		)
+	}
+
+	return nil
+}
+
+// inboundMismatchStatus synthesizes the structured status carried by an
+// inbound version mismatch. It advertises the runtime's bound versions so the
+// failure is diagnosable and classifiable as permanent by the shared status
+// helper.
+func (a *ServerConnectionActor) inboundMismatchStatus(
+	code string) *mailboxpb.Status {
+
+	return &mailboxpb.Status{
+		Ok:      false,
+		Code:    code,
+		Message: "inbound envelope version mismatch",
+		SupportedMailboxVersions: []uint32{
+			a.cfg.MailboxProtocolVersion,
+		},
+		SupportedArkVersions: []uint32{
+			a.cfg.ArkProtocolVersion,
+		},
+	}
+}

--- a/serverconn/ingress.go
+++ b/serverconn/ingress.go
@@ -60,6 +60,12 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 					return
 				}
 
+				// A permanent version error is terminal: stop
+				// the loop rather than retrying forever.
+				if a.checkPermanentStatus(ctx, err) {
+					return
+				}
+
 				a.log.WarnS(ctx, "AckUpTo failed, retrying",
 					err,
 					slog.Uint64(
@@ -103,6 +109,12 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 				return
 			}
 
+			// A permanent version error is terminal: stop the loop
+			// rather than retrying forever.
+			if a.checkPermanentStatus(ctx, err) {
+				return
+			}
+
 			a.log.WarnS(ctx, "Pull failed, retrying",
 				err,
 				slog.Uint64("cursor", state.PullCursor),
@@ -136,6 +148,14 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 			ctx, envelopes, nextCursor,
 		)
 		if dispatchErr != nil {
+			// A permanent inbound version mismatch is terminal:
+			// stop the loop WITHOUT advancing the cursor so the
+			// offending envelope is preserved for a future
+			// compatible restart, and never acknowledged.
+			if a.checkPermanentStatus(ctx, dispatchErr) {
+				return
+			}
+
 			a.log.WarnS(ctx, "Dispatch failed",
 				dispatchErr,
 				slog.Uint64("committed_to", committedCursor),
@@ -227,10 +247,7 @@ func (a *ServerConnectionActor) pullBatch(ctx context.Context, cursor uint64) (
 	}
 
 	if resp.Status != nil && !resp.Status.Ok {
-		return nil, 0, &statusError{
-			Op:     "Pull",
-			Status: resp.Status,
-		}
+		return nil, 0, mailboxconn.NewStatusError("Pull", resp.Status)
 	}
 
 	return resp.Envelopes, resp.NextCursor, nil
@@ -258,6 +275,16 @@ func (a *ServerConnectionActor) dispatchBatch(ctx context.Context,
 	lastCommitted := uint64(0)
 
 	for _, env := range envelopes {
+		// Validate the envelope's version pair against the runtime
+		// binding before delivering it to any waiter or dispatcher. A
+		// mismatch is a permanent compatibility failure: stop the batch
+		// without advancing the ack cursor so the envelope is preserved
+		// for a future compatible restart, and never acknowledge or
+		// dispatch it.
+		if err := a.validateInboundEnvelope(env); err != nil {
+			return lastCommitted, err
+		}
+
 		if env.Rpc == nil {
 			a.log.WarnS(
 				ctx,
@@ -406,10 +433,7 @@ func (a *ServerConnectionActor) ackRemote(
 	}
 
 	if resp.Status != nil && !resp.Status.Ok {
-		return &statusError{
-			Op:     "AckUpTo",
-			Status: resp.Status,
-		}
+		return mailboxconn.NewStatusError("AckUpTo", resp.Status)
 	}
 
 	return nil
@@ -484,22 +508,4 @@ func (a *ServerConnectionActor) backoffConfig() mailboxpull.BackoffConfig {
 		BaseDelay: a.cfg.RetryBaseDelay,
 		MaxDelay:  a.cfg.RetryMaxDelay,
 	}
-}
-
-// statusError wraps a mailbox status failure for error reporting.
-type statusError struct {
-	// Op is the operation that failed (e.g., "Pull", "AckUpTo").
-	Op string
-
-	// Status is the status returned by the mailbox edge.
-	Status *mailboxpb.Status
-}
-
-// Error returns a human-readable error string.
-func (e *statusError) Error() string {
-	if e.Status == nil {
-		return e.Op + ": nil status"
-	}
-
-	return e.Op + ": " + e.Status.Message + " (" + e.Status.Code + ")"
 }

--- a/serverconn/ingress_error_test.go
+++ b/serverconn/ingress_error_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -130,7 +131,7 @@ func newErrorPathActor(
 	cfg.Store = store
 	cfg.LocalMailboxID = "client-1"
 	cfg.RemoteMailboxID = "server-1"
-	cfg.ProtocolVersion = 1
+	cfg.ArkProtocolVersion = 1
 
 	return NewServerConnectionActor(cfg)
 }
@@ -159,7 +160,7 @@ func TestPullBatch_StatusFailure(t *testing.T) {
 	_, _, err := actor.pullBatch(t.Context(), 0)
 	require.Error(t, err)
 
-	var stErr *statusError
+	var stErr *mailboxconn.StatusError
 	require.ErrorAs(t, err, &stErr)
 	require.Equal(t, "Pull", stErr.Op)
 	require.Contains(t, stErr.Error(), "TEMPORARY")
@@ -189,7 +190,7 @@ func TestAckRemote_StatusFailure(t *testing.T) {
 	err := actor.ackRemote(t.Context(), 1)
 	require.Error(t, err)
 
-	var stErr *statusError
+	var stErr *mailboxconn.StatusError
 	require.ErrorAs(t, err, &stErr)
 	require.Equal(t, "AckUpTo", stErr.Op)
 	require.Contains(t, stErr.Error(), "ack failed")
@@ -307,12 +308,12 @@ func TestSaveCheckpoint_Error(t *testing.T) {
 func TestStatusError_ErrorString(t *testing.T) {
 	t.Parallel()
 
-	errNil := (&statusError{
+	errNil := (&mailboxconn.StatusError{
 		Op: "AckUpTo",
 	}).Error()
 	require.Contains(t, errNil, "nil status")
 
-	errStatus := (&statusError{
+	errStatus := (&mailboxconn.StatusError{
 		Op: "Pull",
 		Status: &mailboxpb.Status{
 			Ok:      false,

--- a/serverconn/runtime.go
+++ b/serverconn/runtime.go
@@ -3,8 +3,11 @@ package serverconn
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 )
 
 // DurableActorID returns the durable actor mailbox ID used for serverconn
@@ -43,6 +46,22 @@ func NewRuntime(cfg ConnectorConfig) (*Runtime, error) {
 		return nil, fmt.Errorf("remote mailbox id is required")
 	}
 
+	// Mailbox transport v1 is the stable bootstrap endpoint represented by
+	// a code constant. Default it when unset so callers cannot accidentally
+	// start a runtime with a zero transport version.
+	if cfg.MailboxProtocolVersion == 0 {
+		cfg.MailboxProtocolVersion = mailboxpb.MailboxProtocolVersionV1
+	}
+
+	// The Ark protocol version is negotiated before the runtime exists and
+	// is bound here for the runtime's lifetime. A zero value means no
+	// version was selected, so refuse to construct the runtime. Legacy
+	// server mode still binds an explicit Ark v1; it only changes how an
+	// inbound zero is interpreted, not the bound version.
+	if cfg.ArkProtocolVersion == 0 {
+		return nil, fmt.Errorf("ark protocol version must be non-zero")
+	}
+
 	if cfg.Codec == nil {
 		cfg.Codec = NewServerConnCodec()
 	}
@@ -57,6 +76,11 @@ func NewRuntime(cfg ConnectorConfig) (*Runtime, error) {
 	)
 	durableCfg.Log = cfg.Log
 
+	// A permanent version error is not retryable: dead-letter the failing
+	// durable message immediately instead of retrying it forever. All other
+	// (transient) failures keep the default exponential-backoff policy.
+	durableCfg.TellRetryPolicy = permanentAwareTellRetryPolicy
+
 	durable, err := actor.NewDurableActor(durableCfg).Unpack()
 	if err != nil {
 		return nil, err
@@ -68,6 +92,21 @@ func NewRuntime(cfg ConnectorConfig) (*Runtime, error) {
 		connector:    connector,
 		unary:        unary,
 	}, nil
+}
+
+// permanentAwareTellRetryPolicy is the durable actor's retry policy for
+// serverconn egress. A permanent version error is non-retryable, so the
+// failing durable message is dead-lettered immediately rather than retried
+// forever; every other (transient) failure keeps the default
+// exponential-backoff schedule.
+func permanentAwareTellRetryPolicy(err error,
+	attempts int) (bool, time.Duration) {
+
+	if mailboxconn.IsPermanentVersionError(err) {
+		return false, 0
+	}
+
+	return actor.DefaultTellRetryPolicy(err, attempts)
 }
 
 // Start launches durable egress processing and ingress pulling. Returns an
@@ -119,4 +158,24 @@ func (r *Runtime) Unary() *UnaryFacade {
 // Connector returns the underlying connector behavior.
 func (r *Runtime) Connector() *ServerConnectionActor {
 	return r.connector
+}
+
+// MarkIncompatible drives the runtime to its terminal incompatible state. It
+// is the exported entry point for callers outside the connector (such as a
+// refresh-only GetInfo that observes a changed selection) that detect a
+// permanent version failure on a side channel rather than on the mailbox edge.
+func (r *Runtime) MarkIncompatible(ctx context.Context,
+	statusErr *mailboxconn.StatusError) {
+
+	r.connector.markIncompatible(ctx, statusErr)
+}
+
+// StampEnvelope stamps the runtime's immutable mailbox transport and Ark
+// protocol versions onto a locally constructed envelope immediately before it
+// is sent. It is the shared stamping entry point for callers outside the
+// connector (such as the darepod mailbox response path) so every client send
+// path carries the runtime-bound version pair rather than copying a
+// caller-controlled value.
+func (r *Runtime) StampEnvelope(env *mailboxpb.Envelope) {
+	r.connector.cfg.stampEnvelope(env)
 }

--- a/serverconn/runtime_test.go
+++ b/serverconn/runtime_test.go
@@ -49,6 +49,56 @@ func TestNewRuntime_ValidateConfig(t *testing.T) {
 	)
 }
 
+// TestNewRuntimeArkVersionBinding verifies runtime construction rejects a zero
+// Ark protocol version and accepts an explicit v1 as well as a synthetic v2.
+// The synthetic v2 case proves selection and binding work without adding v2 to
+// any production default.
+func TestNewRuntimeArkVersionBinding(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+
+	baseCfg := func() ConnectorConfig {
+		cfg := DefaultConnectorConfig()
+		cfg.Store = newMemCheckpointStore()
+		cfg.Edge = &fakeMailboxServiceClient{mb: mb}
+		cfg.LocalMailboxID = "client-1"
+		cfg.RemoteMailboxID = "server-1"
+
+		return cfg
+	}
+
+	// A zero Ark protocol version is rejected: a runtime must always carry
+	// an explicit bound version.
+	zeroCfg := baseCfg()
+	zeroCfg.ArkProtocolVersion = 0
+	_, err := NewRuntime(zeroCfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ark protocol version")
+
+	// An explicit Ark v1 is accepted, and the default mailbox transport
+	// version is bound.
+	v1Cfg := baseCfg()
+	v1Cfg.ArkProtocolVersion = 1
+	rt, err := NewRuntime(v1Cfg)
+	require.NoError(t, err)
+	require.NotNil(t, rt)
+	require.Equal(
+		t, uint32(1), rt.Connector().cfg.ArkProtocolVersion,
+	)
+	require.NotZero(t, rt.Connector().cfg.MailboxProtocolVersion)
+
+	// A synthetic Ark v2 is accepted too, proving binding is not pinned to
+	// v1 even though no production default advertises v2.
+	v2Cfg := baseCfg()
+	v2Cfg.ArkProtocolVersion = 2
+	rt2, err := NewRuntime(v2Cfg)
+	require.NoError(t, err)
+	require.Equal(
+		t, uint32(2), rt2.Connector().cfg.ArkProtocolVersion,
+	)
+}
+
 // TestNewRuntime_DefaultCodec verifies runtime construction fills a default
 // codec when one is not supplied.
 func TestNewRuntime_DefaultCodec(t *testing.T) {

--- a/serverconn/testutil_test.go
+++ b/serverconn/testutil_test.go
@@ -857,7 +857,7 @@ func newTestConnectorConfig(
 	cfg.Store = store
 	cfg.LocalMailboxID = "client-1"
 	cfg.RemoteMailboxID = "server-1"
-	cfg.ProtocolVersion = 1
+	cfg.ArkProtocolVersion = 1
 	cfg.PullWaitTimeout = 50 * time.Millisecond
 
 	return cfg

--- a/serverconn/types.go
+++ b/serverconn/types.go
@@ -121,9 +121,18 @@ type ConnectorConfig struct {
 	// envelopes are addressed to this mailbox.
 	RemoteMailboxID string
 
-	// ProtocolVersion is the protocol version stamped on outbound
-	// envelopes.
-	ProtocolVersion uint32
+	// MailboxProtocolVersion is the immutable mailbox transport version
+	// stamped on every outbound envelope. It defines envelope framing and
+	// delivery semantics and is a stable code constant
+	// (mailboxpb.MailboxProtocolVersionV1), not a negotiated value.
+	MailboxProtocolVersion uint32
+
+	// ArkProtocolVersion is the immutable Ark protocol version negotiated
+	// through the direct GetInfo bootstrap RPC and bound to this runtime
+	// for its lifetime. It is stamped on every outbound envelope and
+	// validated on every inbound envelope. Runtime construction rejects a
+	// zero value: a runtime must always carry an explicit Ark version.
+	ArkProtocolVersion uint32
 
 	// Dispatchers maps (service, method) pairs to envelope dispatchers.
 	// The ingress loop uses this table to route KIND_REQUEST and
@@ -146,6 +155,14 @@ type ConnectorConfig struct {
 
 	// Log is an optional logger for this connector instance.
 	Log fn.Option[btclog.Logger]
+
+	// OnIncompatible is an optional callback invoked exactly once when the
+	// connector transitions to a terminal incompatible state after the
+	// first permanent version error. It receives the typed status error so
+	// the caller can surface supported versions, the disable deadline, and
+	// the upgrade URL. It must not block; the connector invokes it inline
+	// on the transition.
+	OnIncompatible func(*mailboxconn.StatusError)
 
 	// PullMaxEnvelopes bounds the number of envelopes returned per Pull
 	// call.
@@ -272,15 +289,37 @@ func (c *ConnectorConfig) mergeAuthHeaders(
 	return merged
 }
 
+// stampEnvelope stamps the runtime's immutable mailbox transport and Ark
+// protocol versions onto an envelope immediately before it is sent. It
+// overwrites any pre-existing version values so no send path — including a
+// pre-built or replayed envelope — can rely on a caller-provided Ark version.
+// The bound version pair is immutable for the runtime's lifetime, so
+// re-stamping a replayed envelope is always correct.
+func (c *ConnectorConfig) stampEnvelope(env *mailboxpb.Envelope) {
+	if env == nil {
+		return
+	}
+
+	env.ProtocolVersion = c.MailboxProtocolVersion
+	env.ArkProtocolVersion = c.ArkProtocolVersion
+}
+
 // DefaultConnectorConfig returns a ConnectorConfig with sensible defaults for
 // polling and retry behavior. The caller must still set Edge, mailbox IDs,
 // and Store. Codec is optional — NewRuntime fills a default.
 func DefaultConnectorConfig() ConnectorConfig {
 	return ConnectorConfig{
-		PullMaxEnvelopes:  50,
-		PullWaitTimeout:   5 * time.Second,
-		RetryBaseDelay:    200 * time.Millisecond,
-		RetryMaxDelay:     30 * time.Second,
-		ResponseWaiterTTL: mailboxconn.DefaultResponseWaiterTTL,
+		// Mailbox transport v1 is the stable bootstrap endpoint, so the
+		// default is a code constant rather than a negotiated value.
+		// ArkProtocolVersion is intentionally left zero: the caller
+		// must set the negotiated Ark version, and NewRuntime rejects a
+		// zero value so a runtime can never start without an explicit
+		// Ark version binding.
+		MailboxProtocolVersion: mailboxpb.MailboxProtocolVersionV1,
+		PullMaxEnvelopes:       50,
+		PullWaitTimeout:        5 * time.Second,
+		RetryBaseDelay:         200 * time.Millisecond,
+		RetryMaxDelay:          30 * time.Second,
+		ResponseWaiterTTL:      mailboxconn.DefaultResponseWaiterTTL,
 	}
 }

--- a/serverconn/unary_facade.go
+++ b/serverconn/unary_facade.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"time"
 
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	"google.golang.org/protobuf/proto"
@@ -50,6 +51,12 @@ func (f *UnaryFacade) SendRPC(ctx context.Context,
 	method mailboxrpc.ServiceMethod, req proto.Message,
 	opts mailboxrpc.RPCOptions) (mailboxrpc.SendResult, error) {
 
+	// Once the connector is incompatible, fail new unary sends with the
+	// cached error without contacting the edge.
+	if ce := f.connector.compatibilityError(); ce != nil {
+		return mailboxrpc.SendResult{}, ce
+	}
+
 	cfg := f.connector.cfg
 
 	msgID, err := randomID(16)
@@ -88,7 +95,6 @@ func (f *UnaryFacade) SendRPC(ctx context.Context,
 	}
 
 	envelope := &mailboxpb.Envelope{
-		ProtocolVersion: cfg.ProtocolVersion,
 		MsgId:           msgID,
 		IdempotencyKey:  idempotencyKey,
 		Sender:          cfg.LocalMailboxID,
@@ -104,6 +110,10 @@ func (f *UnaryFacade) SendRPC(ctx context.Context,
 			ReplyTo:       cfg.LocalMailboxID,
 		},
 	}
+
+	// Stamp the immutable version pair immediately before sending so the
+	// outbound envelope never relies on a caller-provided Ark version.
+	cfg.stampEnvelope(envelope)
 
 	resp, err := cfg.Edge.Send(ctx, &mailboxpb.SendRequest{
 		Envelope: envelope,
@@ -124,10 +134,8 @@ func (f *UnaryFacade) SendRPC(ctx context.Context,
 	if resp.Status != nil && !resp.Status.Ok {
 		f.connector.removeWaiter(corrID)
 
-		sendErr := &statusError{
-			Op:     "Send",
-			Status: resp.Status,
-		}
+		sendErr := mailboxconn.NewStatusError("Send", resp.Status)
+		f.connector.checkPermanentStatus(ctx, sendErr)
 
 		f.connector.log.WarnS(ctx, "Unary send returned non-OK status",
 			sendErr,
@@ -164,6 +172,16 @@ func (f *UnaryFacade) AwaitRPC(ctx context.Context, correlationID string,
 	// ID, we get back the same (possibly already completed) Future.
 	future := f.connector.RegisterWaiter(corrID)
 	defer f.connector.removeWaiter(corrID)
+
+	// Recheck after registering to close the race with a concurrent
+	// markIncompatible: if incompatibility was cached before this register,
+	// we observe it here and return without blocking; if it lands after,
+	// the waiter is already in the registry and FailAll completes it.
+	// Either ordering returns the cached error rather than blocking
+	// forever.
+	if ce := f.connector.compatibilityError(); ce != nil {
+		return ce
+	}
 
 	result := future.Await(ctx)
 	if result.IsErr() {

--- a/serverconn/version_stamp_test.go
+++ b/serverconn/version_stamp_test.go
@@ -1,0 +1,298 @@
+package serverconn
+
+import (
+	"context"
+	"testing"
+
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// sentEnvelopes returns a snapshot of the envelopes delivered to the given
+// recipient mailbox.
+func sentEnvelopes(mb *inMemoryMailbox,
+	recipient string) []*mailboxpb.Envelope {
+
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	out := make([]*mailboxpb.Envelope, len(mb.mailboxes[recipient]))
+	copy(out, mb.mailboxes[recipient])
+
+	return out
+}
+
+// TestStampEnvelopeOverwrites proves the shared stamping helper writes the
+// bound version pair onto an envelope and overwrites any pre-existing
+// caller-provided version values, so no send path can rely on a caller version.
+func TestStampEnvelopeOverwrites(t *testing.T) {
+	t.Parallel()
+
+	cfg := ConnectorConfig{
+		MailboxProtocolVersion: 1,
+		ArkProtocolVersion:     2,
+	}
+
+	// A caller-provided envelope with bogus versions must be overwritten.
+	env := &mailboxpb.Envelope{
+		ProtocolVersion:    99,
+		ArkProtocolVersion: 99,
+	}
+	cfg.stampEnvelope(env)
+	require.Equal(t, uint32(1), env.ProtocolVersion)
+	require.Equal(t, uint32(2), env.ArkProtocolVersion)
+
+	// A nil envelope must not panic.
+	cfg.stampEnvelope(nil)
+}
+
+// TestOutboundEnvelopesCarryBothVersions drives every client send path through
+// the actor with a synthetic Ark v2 binding and proves each emitted envelope
+// carries both the mailbox transport version and the Ark protocol version.
+// Covers event, durable unary request, pre-built replay, and heartbeat
+// envelopes. Synthetic v2 is configured only on this test connector, never in
+// a production default.
+func TestOutboundEnvelopesCarryBothVersions(t *testing.T) {
+	t.Parallel()
+
+	const (
+		wantMailboxVersion = uint32(1)
+		wantArkVersion     = uint32(2)
+	)
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+
+	// Bind a synthetic Ark v2 to prove stamping is not pinned to v1.
+	cfg.ArkProtocolVersion = wantArkVersion
+	cfg.MailboxProtocolVersion = wantMailboxVersion
+
+	conn := NewServerConnectionActor(cfg)
+	ctx := t.Context()
+
+	// Event envelope (durable client FSM outbox message).
+	res := conn.Receive(ctx, &SendClientEventRequest{
+		Message: &testServerMessage{value: "event"},
+	})
+	require.NoError(t, res.Err())
+
+	// Durable unary request envelope.
+	unaryReq, err := NewSendUnaryRequest(
+		mailboxrpc.ServiceMethod{
+			Service: testEventService,
+			Method:  testEventMethod,
+		},
+		wrapperspb.String("unary"), "corr-1",
+	)
+	require.NoError(t, err)
+	require.NoError(t, conn.Receive(ctx, unaryReq).Err())
+
+	// Pre-built (replay) envelope: deliberately constructed with zero
+	// versions to prove the re-stamp path overwrites a persisted value.
+	body, err := anypb.New(wrapperspb.String("replay"))
+	require.NoError(t, err)
+	prebuilt := &SendRPCRequest{
+		Envelope: &mailboxpb.Envelope{
+			ProtocolVersion:    0,
+			ArkProtocolVersion: 0,
+			Recipient:          cfg.RemoteMailboxID,
+			Body:               body,
+			Rpc: &mailboxpb.RpcMeta{
+				Kind:    mailboxpb.RpcMeta_KIND_REQUEST,
+				Service: testEventService,
+				Method:  testEventMethod,
+			},
+		},
+	}
+	require.NoError(t, conn.Receive(ctx, prebuilt).Err())
+
+	// Heartbeat envelope.
+	conn.sendHeartbeat(ctx)
+
+	// Every envelope delivered to the remote mailbox must carry both
+	// versions.
+	envs := sentEnvelopes(mb, cfg.RemoteMailboxID)
+	require.Len(t, envs, 4)
+	for i, env := range envs {
+		require.Equalf(
+			t, wantMailboxVersion, env.ProtocolVersion, "mailbox"+
+				" version on envelope %d", i,
+		)
+		require.Equalf(
+			t, wantArkVersion, env.ArkProtocolVersion, "ark "+
+				"version on envelope %d", i,
+		)
+	}
+}
+
+// TestRuntimeStampEnvelopeResponse proves the exported Runtime.StampEnvelope
+// entry point (used by the darepod mailbox response path) stamps a response
+// envelope with the runtime-bound pair rather than any caller value.
+func TestRuntimeStampEnvelopeResponse(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	cfg.ArkProtocolVersion = 2
+
+	rt, err := NewRuntime(cfg)
+	require.NoError(t, err)
+
+	responseEnv := &mailboxpb.Envelope{
+		ProtocolVersion:    7,
+		ArkProtocolVersion: 7,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind: mailboxpb.RpcMeta_KIND_RESPONSE,
+		},
+	}
+	rt.StampEnvelope(responseEnv)
+	require.Equal(t, uint32(1), responseEnv.ProtocolVersion)
+	require.Equal(t, uint32(2), responseEnv.ArkProtocolVersion)
+}
+
+// TestValidateInboundEnvelope covers the inbound validation matrix: a matching
+// pair passes; a transport mismatch, a non-zero Ark mismatch, and a zero Ark
+// version (no legacy fallback) all fail. There is no legacy mode.
+func TestValidateInboundEnvelope(t *testing.T) {
+	t.Parallel()
+
+	const (
+		codeMbx = mailboxconn.StatusMailboxVersionUnsupported
+		codeArk = mailboxconn.StatusArkVersionMismatch
+	)
+
+	tests := []struct {
+		name        string
+		boundArk    uint32
+		envMailbox  uint32
+		envArk      uint32
+		wantErr     bool
+		wantErrCode string
+	}{
+		{
+			name:       "matching v1",
+			boundArk:   1,
+			envMailbox: 1,
+			envArk:     1,
+		},
+		{
+			name:        "transport mismatch",
+			boundArk:    1,
+			envMailbox:  2,
+			envArk:      1,
+			wantErr:     true,
+			wantErrCode: codeMbx,
+		},
+		{
+			name:        "ark mismatch nonzero",
+			boundArk:    1,
+			envMailbox:  1,
+			envArk:      2,
+			wantErr:     true,
+			wantErrCode: codeArk,
+		},
+		{
+			name:        "ark zero is mismatch",
+			boundArk:    1,
+			envMailbox:  1,
+			envArk:      0,
+			wantErr:     true,
+			wantErrCode: codeArk,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mb := newInMemoryMailbox()
+			cfg := newTestConnectorConfig(
+				mb, newMemCheckpointStore(),
+			)
+			cfg.ArkProtocolVersion = tc.boundArk
+			cfg.MailboxProtocolVersion = 1
+
+			conn := NewServerConnectionActor(cfg)
+			env := &mailboxpb.Envelope{
+				ProtocolVersion:    tc.envMailbox,
+				ArkProtocolVersion: tc.envArk,
+			}
+
+			err := conn.validateInboundEnvelope(env)
+			if !tc.wantErr {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			require.True(
+				t, mailboxconn.IsPermanentVersionError(err),
+			)
+
+			var statusErr *mailboxconn.StatusError
+			require.ErrorAs(t, err, &statusErr)
+			require.Equal(t, tc.wantErrCode, statusErr.Code())
+		})
+	}
+}
+
+// TestDispatchBatchRejectsMismatchedEnvelope proves a mismatched inbound
+// envelope is neither dispatched nor acknowledged: dispatchBatch returns an
+// error, the dispatcher is never invoked, and the committed cursor does not
+// advance past the rejected envelope.
+func TestDispatchBatchRejectsMismatchedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	cfg.ArkProtocolVersion = 1
+	cfg.MailboxProtocolVersion = 1
+
+	dispatched := false
+	svcMethod := mailboxrpc.ServiceMethod{
+		Service: testEventService,
+		Method:  testEventMethod,
+	}
+	var disp EnvelopeDispatcher = func(context.Context,
+		*mailboxpb.Envelope) error {
+
+		dispatched = true
+
+		return nil
+	}
+	cfg.Dispatchers = map[mailboxrpc.ServiceMethod]EnvelopeDispatcher{
+		svcMethod: disp,
+	}
+
+	conn := NewServerConnectionActor(cfg)
+
+	// An envelope bound for the dispatcher but carrying a mismatched Ark
+	// version must be rejected before dispatch.
+	env := &mailboxpb.Envelope{
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 2,
+		EventSeq:           5,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:    mailboxpb.RpcMeta_KIND_EVENT,
+			Service: testEventService,
+			Method:  testEventMethod,
+		},
+	}
+
+	committed, err := conn.dispatchBatch(
+		t.Context(), []*mailboxpb.Envelope{env}, 6,
+	)
+	require.Error(t, err)
+	require.True(t, mailboxconn.IsPermanentVersionError(err))
+	require.False(t, dispatched, "mismatched envelope was dispatched")
+
+	// The committed cursor must not advance past the rejected envelope, so
+	// the ack watermark cannot move and the envelope is preserved.
+	require.Less(t, committed, uint64(5))
+}


### PR DESCRIPTION
## Summary

This is PR A of the protocol-versioning work tracked by
https://github.com/lightninglabs/darepo/issues/526.

It adds the client-side control plane and transport enforcement needed to roll
Ark protocol versions forward safely. Production behavior remains Ark v1; this
PR does not implement Ark v2 semantics.

The client now:

- advertises its supported Ark protocol versions during the direct `GetInfo`
  bootstrap;
- refuses startup unless the operator explicitly selects a compatible,
  non-disabled version;
- binds the selected Ark version and mailbox transport version immutably to the
  mailbox runtime;
- stamps that bound pair on every outbound envelope, including durable replay,
  unary calls, events, heartbeats, and locally built responses;
- validates every inbound envelope before dispatch or acknowledgement;
- treats version failures as permanent, stopping retries and ingress, failing
  pending callers, dead-lettering the failed durable send, and reporting the
  daemon disconnected;
- pins later `GetInfo` refreshes to the bound version while still learning
  deprecation policy and upgrade guidance.

## Why

Without an explicit version contract, a rolling upgrade can silently mix
incompatible Ark semantics in durable mailbox queues. Retrying those messages
cannot make them compatible and may leave a client appearing healthy while it
cannot communicate safely.

This PR establishes the client invariants required before a second real Ark
protocol version can exist:

```text
bootstrap negotiation -> immutable runtime binding
                      -> stamp every outbound envelope
                      -> validate every inbound envelope
                      -> terminal failure on incompatibility
```

Mailbox transport version, Ark protocol version, and persisted VTXO
construction version remain separate axes. Construction-version routing is
future work.

## Rollout Contract

This deliberately has **no new-client-to-old-server fallback**. An updated
client talking to a server that does not explicitly select a version receives
selection zero and refuses to start.

The paired server PR
https://github.com/lightninglabs/darepo/pull/569 must therefore ship with this
PR. The server retains a temporary old-client-to-new-server v1 fallback while
Ark v1 remains enabled.

Final client SHA consumed by the server submodule:
`18f789e42460b97e59839e14717c78ed536eb533`.

## Wire Contract

- Adds supported/selected Ark version fields and lifecycle policy to `GetInfo`.
- Adds Ark protocol version to mailbox envelopes.
- Adds supported-version and upgrade guidance to structured mailbox statuses.
- Defines permanent compatibility statuses:
  - `MAILBOX_VERSION_UNSUPPORTED`
  - `ARK_VERSION_UNSUPPORTED`
  - `ARK_VERSION_MISMATCH`
  - `UPGRADE_REQUIRED`

All protobuf changes are additive and generated code was regenerated with
`make rpc`.

## Important Behaviors Covered

- A zero or unsupported bootstrap selection refuses runtime creation.
- A selected version advertised as `DISABLED` fails with permanent
  `UPGRADE_REQUIRED` while preserving the upgrade URL.
- Refresh calls cannot renegotiate a live runtime.
- A refresh that changes selection or disables the bound version transitions
  the runtime to `INCOMPATIBLE`.
- Permanent statuses stop durable retries and fail in-flight unary waiters.
- Wrong-version inbound envelopes are neither dispatched nor acknowledged.
- All production send paths stamp the immutable bound pair.

## Validation

- `make build`
- focused bootstrap, refresh, compatibility, ingress, and stamping tests under
  `-race`
- `make fmt-changed`
- `make fmt-changed-check`
- `make lint-changed-local`
- `make tidy-module-check`
- `make doc-check`
- `make commitmsg-lint`
- protobuf compatibility and generation checks

## Dependency

This PR should land before paired server PR
https://github.com/lightninglabs/darepo/pull/569 so the server's `client/`
submodule commit resolves from the upstream repository.
