### PR TITLE
multi: Add Ark protocol version negotiation and enforcement

### DIFF
--- a/arkrpc/ark.pb.go
+++ b/arkrpc/ark.pb.go
@@ -21,10 +21,71 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// State is the lifecycle state of an Ark protocol version.
+type ArkVersionPolicy_State int32
+
+const (
+	// STATE_UNSPECIFIED is the zero value and must not be used as a real
+	// policy state.
+	ArkVersionPolicy_STATE_UNSPECIFIED ArkVersionPolicy_State = 0
+	// STATE_ACTIVE means the version may be selected and admitted.
+	ArkVersionPolicy_STATE_ACTIVE ArkVersionPolicy_State = 1
+	// STATE_DISABLED means the version must never be selected or accepted;
+	// it is advertised only so clients learn the version was retired.
+	ArkVersionPolicy_STATE_DISABLED ArkVersionPolicy_State = 2
+)
+
+// Enum value maps for ArkVersionPolicy_State.
+var (
+	ArkVersionPolicy_State_name = map[int32]string{
+		0: "STATE_UNSPECIFIED",
+		1: "STATE_ACTIVE",
+		2: "STATE_DISABLED",
+	}
+	ArkVersionPolicy_State_value = map[string]int32{
+		"STATE_UNSPECIFIED": 0,
+		"STATE_ACTIVE":      1,
+		"STATE_DISABLED":    2,
+	}
+)
+
+func (x ArkVersionPolicy_State) Enum() *ArkVersionPolicy_State {
+	p := new(ArkVersionPolicy_State)
+	*p = x
+	return p
+}
+
+func (x ArkVersionPolicy_State) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ArkVersionPolicy_State) Descriptor() protoreflect.EnumDescriptor {
+	return file_ark_proto_enumTypes[0].Descriptor()
+}
+
+func (ArkVersionPolicy_State) Type() protoreflect.EnumType {
+	return &file_ark_proto_enumTypes[0]
+}
+
+func (x ArkVersionPolicy_State) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ArkVersionPolicy_State.Descriptor instead.
+func (ArkVersionPolicy_State) EnumDescriptor() ([]byte, []int) {
+	return file_ark_proto_rawDescGZIP(), []int{1, 0}
+}
+
 type GetInfoRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// supported_ark_versions lists the Ark protocol versions this client can
+	// use, ordered by client preference (most preferred first). The operator
+	// selects the first operator-preferred version present in this list. An
+	// empty list means the client advertises no Ark version support, so it
+	// overlaps with nothing and the operator selects zero.
+	SupportedArkVersions []uint32 `protobuf:"varint,1,rep,packed,name=supported_ark_versions,json=supportedArkVersions,proto3" json:"supported_ark_versions,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *GetInfoRequest) Reset() {
@@ -55,6 +116,70 @@ func (x *GetInfoRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use GetInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetInfoRequest) Descriptor() ([]byte, []int) {
 	return file_ark_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *GetInfoRequest) GetSupportedArkVersions() []uint32 {
+	if x != nil {
+		return x.SupportedArkVersions
+	}
+	return nil
+}
+
+// ArkVersionPolicy advertises the operator's lifecycle policy for a single Ark
+// protocol version: whether it is ACTIVE (selectable) or DISABLED (advertised
+// so clients learn it was retired, but never selected or accepted).
+type ArkVersionPolicy struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// version is the Ark protocol version this policy describes.
+	Version uint32 `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
+	// state is the lifecycle state of the version.
+	State         ArkVersionPolicy_State `protobuf:"varint,2,opt,name=state,proto3,enum=arkrpc.ArkVersionPolicy_State" json:"state,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ArkVersionPolicy) Reset() {
+	*x = ArkVersionPolicy{}
+	mi := &file_ark_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ArkVersionPolicy) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ArkVersionPolicy) ProtoMessage() {}
+
+func (x *ArkVersionPolicy) ProtoReflect() protoreflect.Message {
+	mi := &file_ark_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ArkVersionPolicy.ProtoReflect.Descriptor instead.
+func (*ArkVersionPolicy) Descriptor() ([]byte, []int) {
+	return file_ark_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *ArkVersionPolicy) GetVersion() uint32 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+func (x *ArkVersionPolicy) GetState() ArkVersionPolicy_State {
+	if x != nil {
+		return x.State
+	}
+	return ArkVersionPolicy_STATE_UNSPECIFIED
 }
 
 type GetInfoResponse struct {
@@ -114,13 +239,22 @@ type GetInfoResponse struct {
 	// receive and boarding flows before funds enter the system. Zero
 	// means no cap.
 	MaxUserBalance int64 `protobuf:"varint,20,opt,name=max_user_balance,json=maxUserBalance,proto3" json:"max_user_balance,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// selected_ark_version is the Ark protocol version the operator selected
+	// for this client from its supported_ark_versions request. Zero means no
+	// common version exists; the client must not start its mailbox runtime.
+	SelectedArkVersion uint32 `protobuf:"varint,21,opt,name=selected_ark_version,json=selectedArkVersion,proto3" json:"selected_ark_version,omitempty"`
+	// ark_version_policies carries the lifecycle policy (ACTIVE or DISABLED)
+	// for each of the operator's known Ark protocol versions. The ACTIVE
+	// entries are the operator's enabled, selectable versions; DISABLED
+	// entries are advertised only so clients learn a version was retired.
+	ArkVersionPolicies []*ArkVersionPolicy `protobuf:"bytes,22,rep,name=ark_version_policies,json=arkVersionPolicies,proto3" json:"ark_version_policies,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *GetInfoResponse) Reset() {
 	*x = GetInfoResponse{}
-	mi := &file_ark_proto_msgTypes[1]
+	mi := &file_ark_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -132,7 +266,7 @@ func (x *GetInfoResponse) String() string {
 func (*GetInfoResponse) ProtoMessage() {}
 
 func (x *GetInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ark_proto_msgTypes[1]
+	mi := &file_ark_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -145,7 +279,7 @@ func (x *GetInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetInfoResponse) Descriptor() ([]byte, []int) {
-	return file_ark_proto_rawDescGZIP(), []int{1}
+	return file_ark_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *GetInfoResponse) GetVersion() string {
@@ -267,6 +401,20 @@ func (x *GetInfoResponse) GetMaxUserBalance() int64 {
 	return 0
 }
 
+func (x *GetInfoResponse) GetSelectedArkVersion() uint32 {
+	if x != nil {
+		return x.SelectedArkVersion
+	}
+	return 0
+}
+
+func (x *GetInfoResponse) GetArkVersionPolicies() []*ArkVersionPolicy {
+	if x != nil {
+		return x.ArkVersionPolicies
+	}
+	return nil
+}
+
 // EstimateFeeRequest asks the server to estimate the fee for a
 // VTXO operation at current rates and utilization.
 type EstimateFeeRequest struct {
@@ -285,7 +433,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_ark_proto_msgTypes[2]
+	mi := &file_ark_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -297,7 +445,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ark_proto_msgTypes[2]
+	mi := &file_ark_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -310,7 +458,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_ark_proto_rawDescGZIP(), []int{2}
+	return file_ark_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *EstimateFeeRequest) GetAmountSat() int64 {
@@ -363,7 +511,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_ark_proto_msgTypes[3]
+	mi := &file_ark_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -375,7 +523,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ark_proto_msgTypes[3]
+	mi := &file_ark_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -388,7 +536,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_ark_proto_rawDescGZIP(), []int{3}
+	return file_ark_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *EstimateFeeResponse) GetLiquidityFeeSat() int64 {
@@ -444,8 +592,16 @@ var File_ark_proto protoreflect.FileDescriptor
 
 const file_ark_proto_rawDesc = "" +
 	"\n" +
-	"\tark.proto\x12\x06arkrpc\"\x10\n" +
-	"\x0eGetInfoRequest\"\x98\x05\n" +
+	"\tark.proto\x12\x06arkrpc\"F\n" +
+	"\x0eGetInfoRequest\x124\n" +
+	"\x16supported_ark_versions\x18\x01 \x03(\rR\x14supportedArkVersions\"\xa8\x01\n" +
+	"\x10ArkVersionPolicy\x12\x18\n" +
+	"\aversion\x18\x01 \x01(\rR\aversion\x124\n" +
+	"\x05state\x18\x02 \x01(\x0e2\x1e.arkrpc.ArkVersionPolicy.StateR\x05state\"D\n" +
+	"\x05State\x12\x15\n" +
+	"\x11STATE_UNSPECIFIED\x10\x00\x12\x10\n" +
+	"\fSTATE_ACTIVE\x10\x01\x12\x12\n" +
+	"\x0eSTATE_DISABLED\x10\x02\"\x96\x06\n" +
 	"\x0fGetInfoResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x16\n" +
 	"\x06pubkey\x18\x02 \x01(\fR\x06pubkey\x12\x18\n" +
@@ -466,7 +622,9 @@ const file_ark_proto_rawDesc = "" +
 	"\x0fbase_margin_sat\x18\x11 \x01(\x03R\rbaseMarginSat\x123\n" +
 	"\x16max_oor_lineage_vbytes\x18\x12 \x01(\rR\x13maxOorLineageVbytes\x12-\n" +
 	"\x13min_vtxo_amount_sat\x18\x13 \x01(\x03R\x10minVtxoAmountSat\x12(\n" +
-	"\x10max_user_balance\x18\x14 \x01(\x03R\x0emaxUserBalance\"\x7f\n" +
+	"\x10max_user_balance\x18\x14 \x01(\x03R\x0emaxUserBalance\x120\n" +
+	"\x14selected_ark_version\x18\x15 \x01(\rR\x12selectedArkVersion\x12J\n" +
+	"\x14ark_version_policies\x18\x16 \x03(\v2\x18.arkrpc.ArkVersionPolicyR\x12arkVersionPolicies\"\x7f\n" +
 	"\x12EstimateFeeRequest\x12\x1d\n" +
 	"\n" +
 	"amount_sat\x18\x01 \x01(\x03R\tamountSat\x12\x1f\n" +
@@ -499,23 +657,28 @@ func file_ark_proto_rawDescGZIP() []byte {
 	return file_ark_proto_rawDescData
 }
 
-var file_ark_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_ark_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_ark_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_ark_proto_goTypes = []any{
-	(*GetInfoRequest)(nil),      // 0: arkrpc.GetInfoRequest
-	(*GetInfoResponse)(nil),     // 1: arkrpc.GetInfoResponse
-	(*EstimateFeeRequest)(nil),  // 2: arkrpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil), // 3: arkrpc.EstimateFeeResponse
+	(ArkVersionPolicy_State)(0), // 0: arkrpc.ArkVersionPolicy.State
+	(*GetInfoRequest)(nil),      // 1: arkrpc.GetInfoRequest
+	(*ArkVersionPolicy)(nil),    // 2: arkrpc.ArkVersionPolicy
+	(*GetInfoResponse)(nil),     // 3: arkrpc.GetInfoResponse
+	(*EstimateFeeRequest)(nil),  // 4: arkrpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil), // 5: arkrpc.EstimateFeeResponse
 }
 var file_ark_proto_depIdxs = []int32{
-	0, // 0: arkrpc.ArkService.GetInfo:input_type -> arkrpc.GetInfoRequest
-	2, // 1: arkrpc.ArkService.EstimateFee:input_type -> arkrpc.EstimateFeeRequest
-	1, // 2: arkrpc.ArkService.GetInfo:output_type -> arkrpc.GetInfoResponse
-	3, // 3: arkrpc.ArkService.EstimateFee:output_type -> arkrpc.EstimateFeeResponse
-	2, // [2:4] is the sub-list for method output_type
-	0, // [0:2] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	0, // 0: arkrpc.ArkVersionPolicy.state:type_name -> arkrpc.ArkVersionPolicy.State
+	2, // 1: arkrpc.GetInfoResponse.ark_version_policies:type_name -> arkrpc.ArkVersionPolicy
+	1, // 2: arkrpc.ArkService.GetInfo:input_type -> arkrpc.GetInfoRequest
+	4, // 3: arkrpc.ArkService.EstimateFee:input_type -> arkrpc.EstimateFeeRequest
+	3, // 4: arkrpc.ArkService.GetInfo:output_type -> arkrpc.GetInfoResponse
+	5, // 5: arkrpc.ArkService.EstimateFee:output_type -> arkrpc.EstimateFeeResponse
+	4, // [4:6] is the sub-list for method output_type
+	2, // [2:4] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_ark_proto_init() }
@@ -528,13 +691,14 @@ func file_ark_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ark_proto_rawDesc), len(file_ark_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   4,
+			NumEnums:      1,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_ark_proto_goTypes,
 		DependencyIndexes: file_ark_proto_depIdxs,
+		EnumInfos:         file_ark_proto_enumTypes,
 		MessageInfos:      file_ark_proto_msgTypes,
 	}.Build()
 	File_ark_proto = out.File

--- a/arkrpc/ark.proto
+++ b/arkrpc/ark.proto
@@ -15,6 +15,37 @@ service ArkService {
 }
 
 message GetInfoRequest {
+    // supported_ark_versions lists the Ark protocol versions this client can
+    // use, ordered by client preference (most preferred first). The operator
+    // selects the first operator-preferred version present in this list. An
+    // empty list means the client advertises no Ark version support, so it
+    // overlaps with nothing and the operator selects zero.
+    repeated uint32 supported_ark_versions = 1;
+}
+
+// ArkVersionPolicy advertises the operator's lifecycle policy for a single Ark
+// protocol version: whether it is ACTIVE (selectable) or DISABLED (advertised
+// so clients learn it was retired, but never selected or accepted).
+message ArkVersionPolicy {
+    // State is the lifecycle state of an Ark protocol version.
+    enum State {
+        // STATE_UNSPECIFIED is the zero value and must not be used as a real
+        // policy state.
+        STATE_UNSPECIFIED = 0;
+
+        // STATE_ACTIVE means the version may be selected and admitted.
+        STATE_ACTIVE = 1;
+
+        // STATE_DISABLED means the version must never be selected or accepted;
+        // it is advertised only so clients learn the version was retired.
+        STATE_DISABLED = 2;
+    }
+
+    // version is the Ark protocol version this policy describes.
+    uint32 version = 1;
+
+    // state is the lifecycle state of the version.
+    State state = 2;
 }
 
 message GetInfoResponse {
@@ -93,6 +124,17 @@ message GetInfoResponse {
     // receive and boarding flows before funds enter the system. Zero
     // means no cap.
     int64 max_user_balance = 20;
+
+    // selected_ark_version is the Ark protocol version the operator selected
+    // for this client from its supported_ark_versions request. Zero means no
+    // common version exists; the client must not start its mailbox runtime.
+    uint32 selected_ark_version = 21;
+
+    // ark_version_policies carries the lifecycle policy (ACTIVE or DISABLED)
+    // for each of the operator's known Ark protocol versions. The ACTIVE
+    // entries are the operator's enabled, selectable versions; DISABLED
+    // entries are advertised only so clients learn a version was retired.
+    repeated ArkVersionPolicy ark_version_policies = 22;
 }
 
 // EstimateFeeRequest asks the server to estimate the fee for a

--- a/arkrpc/version.go
+++ b/arkrpc/version.go
@@ -1,0 +1,15 @@
+package arkrpc
+
+// ArkProtocolVersionV1 is the initial Ark protocol version. The Ark protocol
+// version defines how the client and operator communicate over a decodable
+// mailbox transport: Ark RPC request and response shapes, round and OOR
+// choreography, application-level validation, and service/method routing
+// expectations.
+//
+// It is negotiated through the direct GetInfo bootstrap RPC and bound to a
+// client runtime for its lifetime. Production currently supports only v1; a
+// synthetic v2 may be configured in tests to exercise selection, binding, and
+// rejection behavior, but no production default advertises a version beyond
+// v1. This constant is deliberately separate from the mailbox transport
+// version and the VTXO construction version, which evolve independently.
+const ArkProtocolVersionV1 uint32 = 1

--- a/arkrpc/version_compat_test.go
+++ b/arkrpc/version_compat_test.go
@@ -1,0 +1,126 @@
+package arkrpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestGetInfoRequestOldShapeDecodesZero proves that a GetInfoRequest encoded
+// without the new supported_ark_versions field (the pre-versioning "old
+// shape") decodes under the new generated code with the new field left at its
+// zero value. This is the additive-compatibility guarantee that lets an
+// updated server decode a request from a pre-versioning client.
+func TestGetInfoRequestOldShapeDecodesZero(t *testing.T) {
+	t.Parallel()
+
+	// The old shape is an empty request: the pre-versioning GetInfoRequest
+	// carried no fields at all.
+	oldShape := &GetInfoRequest{}
+
+	raw, err := proto.Marshal(oldShape)
+	require.NoError(t, err)
+
+	decoded := &GetInfoRequest{}
+	require.NoError(t, proto.Unmarshal(raw, decoded))
+
+	// The newly added repeated field must be empty after decoding an old
+	// message.
+	require.Empty(t, decoded.SupportedArkVersions)
+}
+
+// TestGetInfoResponseOldShapeDecodesZero proves that a GetInfoResponse
+// populated only with pre-versioning fields decodes under the new code with
+// every newly added version field at its zero value. The updated client treats
+// a zero selected version as incompatible and refuses startup.
+func TestGetInfoResponseOldShapeDecodesZero(t *testing.T) {
+	t.Parallel()
+
+	// Populate only fields that existed before versioning was introduced.
+	oldShape := &GetInfoResponse{
+		Version: "0.1.0",
+		Pubkey: []byte{
+			0x02,
+			0x03,
+			0x04,
+		},
+		Network:           "regtest",
+		BlockHeight:       100,
+		BoardingExitDelay: 144,
+		VtxoExitDelay:     144,
+		DustLimit:         330,
+	}
+
+	raw, err := proto.Marshal(oldShape)
+	require.NoError(t, err)
+
+	decoded := &GetInfoResponse{}
+	require.NoError(t, proto.Unmarshal(raw, decoded))
+
+	// Existing fields round-trip unchanged.
+	require.Equal(t, "0.1.0", decoded.Version)
+	require.Equal(t, []byte{0x02, 0x03, 0x04}, decoded.Pubkey)
+	require.Equal(t, "regtest", decoded.Network)
+
+	// The newly added version fields must all be zero/empty because the
+	// old shape never set them.
+	require.Zero(t, decoded.SelectedArkVersion)
+	require.Empty(t, decoded.ArkVersionPolicies)
+}
+
+// TestGetInfoVersionFieldsRoundTrip proves that the new versioning fields are
+// preserved across a marshal/unmarshal cycle, including the nested
+// ArkVersionPolicy message and its State enum.
+func TestGetInfoVersionFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	req := &GetInfoRequest{
+		SupportedArkVersions: []uint32{
+			2,
+			1,
+		},
+	}
+
+	reqRaw, err := proto.Marshal(req)
+	require.NoError(t, err)
+
+	reqDecoded := &GetInfoRequest{}
+	require.NoError(t, proto.Unmarshal(reqRaw, reqDecoded))
+	require.Equal(t, []uint32{2, 1}, reqDecoded.SupportedArkVersions)
+
+	v1Policy := &ArkVersionPolicy{
+		Version: 1,
+		State:   ArkVersionPolicy_STATE_DISABLED,
+	}
+	v2Policy := &ArkVersionPolicy{
+		Version: 2,
+		State:   ArkVersionPolicy_STATE_ACTIVE,
+	}
+
+	resp := &GetInfoResponse{
+		Version:            "1.0.0",
+		SelectedArkVersion: 2,
+		ArkVersionPolicies: []*ArkVersionPolicy{
+			v1Policy,
+			v2Policy,
+		},
+	}
+
+	respRaw, err := proto.Marshal(resp)
+	require.NoError(t, err)
+
+	respDecoded := &GetInfoResponse{}
+	require.NoError(t, proto.Unmarshal(respRaw, respDecoded))
+
+	require.Equal(t, uint32(2), respDecoded.SelectedArkVersion)
+	require.Len(t, respDecoded.ArkVersionPolicies, 2)
+
+	first := respDecoded.ArkVersionPolicies[0]
+	require.Equal(t, uint32(1), first.Version)
+	require.Equal(t, ArkVersionPolicy_STATE_DISABLED, first.State)
+
+	second := respDecoded.ArkVersionPolicies[1]
+	require.Equal(t, uint32(2), second.Version)
+	require.Equal(t, ArkVersionPolicy_STATE_ACTIVE, second.State)
+}

--- a/darepod/mailbox_ingress_compat_test.go
+++ b/darepod/mailbox_ingress_compat_test.go
@@ -1,0 +1,154 @@
+package darepod
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/lightninglabs/darepo-client/serverconn"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// permanentPullEdge is a mailbox edge whose Pull returns a permanent version
+// status, so an ingress loop transitions the connector to its incompatible
+// state on its first poll. Send and AckUpTo succeed.
+type permanentPullEdge struct{}
+
+func (permanentPullEdge) Send(_ context.Context, _ *mailboxpb.SendRequest,
+	_ ...grpc.CallOption) (*mailboxpb.SendResponse, error) {
+
+	return &mailboxpb.SendResponse{
+		Status: &mailboxpb.Status{
+			Ok: true,
+		},
+	}, nil
+}
+
+func (permanentPullEdge) Pull(_ context.Context, _ *mailboxpb.PullRequest,
+	_ ...grpc.CallOption) (*mailboxpb.PullResponse, error) {
+
+	return &mailboxpb.PullResponse{
+		Status: &mailboxpb.Status{
+			Ok:   false,
+			Code: mailboxconn.StatusUpgradeRequired,
+		},
+	}, nil
+}
+
+func (permanentPullEdge) AckUpTo(_ context.Context, _ *mailboxpb.AckUpToRequest,
+	_ ...grpc.CallOption) (*mailboxpb.AckUpToResponse, error) {
+
+	return &mailboxpb.AckUpToResponse{
+		Status: &mailboxpb.Status{
+			Ok: true,
+		},
+	}, nil
+}
+
+// okPullEdge is a mailbox edge that succeeds on every operation, returning
+// empty long-poll results. Used when the runtime is pre-marked incompatible so
+// the edge behavior is irrelevant.
+type okPullEdge struct{}
+
+func (okPullEdge) Send(_ context.Context, _ *mailboxpb.SendRequest,
+	_ ...grpc.CallOption) (*mailboxpb.SendResponse, error) {
+
+	return &mailboxpb.SendResponse{Status: &mailboxpb.Status{Ok: true}}, nil
+}
+
+func (okPullEdge) Pull(_ context.Context, _ *mailboxpb.PullRequest,
+	_ ...grpc.CallOption) (*mailboxpb.PullResponse, error) {
+
+	return &mailboxpb.PullResponse{Status: &mailboxpb.Status{Ok: true}}, nil
+}
+
+func (okPullEdge) AckUpTo(_ context.Context, _ *mailboxpb.AckUpToRequest,
+	_ ...grpc.CallOption) (*mailboxpb.AckUpToResponse, error) {
+
+	return &mailboxpb.AckUpToResponse{
+		Status: &mailboxpb.Status{
+			Ok: true,
+		},
+	}, nil
+}
+
+// newCompatTestServer wires a Server with a real serverconn.Runtime built from
+// the given edge and a DB-backed delivery store, with the incompatibility
+// callback routed to onServerIncompatible (which clears server_connected).
+func newCompatTestServer(t *testing.T,
+	edge mailboxpb.MailboxServiceClient) *Server {
+
+	t.Helper()
+
+	_, deliveryStore, _ := newSendOORTestStores(t)
+
+	s := &Server{log: btclog.Disabled}
+
+	cfg := serverconn.DefaultConnectorConfig()
+	cfg.Edge = edge
+	cfg.Store = deliveryStore
+	cfg.LocalMailboxID = "client-1"
+	cfg.RemoteMailboxID = "server-1"
+	cfg.ArkProtocolVersion = 1
+	cfg.OnIncompatible = s.onServerIncompatible
+
+	rt, err := serverconn.NewRuntime(cfg)
+	require.NoError(t, err)
+
+	s.runtime = rt
+
+	return s
+}
+
+// TestStartMailboxIngressConcurrentIncompatible proves that an incompatibility
+// landing while ingress starts (here, the ingress loop's first Pull returns a
+// permanent version status) always wins over the startup "connected" write:
+// server_connected ends false. This is the concurrent-start race the fix
+// closes by setting connected=true before StartIngress so any callback's false
+// is written afterward.
+func TestStartMailboxIngressConcurrentIncompatible(t *testing.T) {
+	t.Parallel()
+
+	s := newCompatTestServer(t, permanentPullEdge{})
+
+	s.runtime.StartEgress()
+	defer s.runtime.Stop()
+
+	// StartIngress itself succeeds; the ingress goroutine then transitions.
+	require.NoError(t, s.startMailboxIngress(t.Context()))
+
+	require.Eventually(t, func() bool {
+		return !s.isServerConnected()
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestStartMailboxIngressAlreadyIncompatible proves that when the runtime is
+// already incompatible, startMailboxIngress returns an error and leaves
+// server_connected false rather than reporting a healthy connection.
+func TestStartMailboxIngressAlreadyIncompatible(t *testing.T) {
+	t.Parallel()
+
+	s := newCompatTestServer(t, okPullEdge{})
+
+	s.runtime.StartEgress()
+	defer s.runtime.Stop()
+
+	// Mark incompatible up front; the callback clears server_connected.
+	s.runtime.MarkIncompatible(
+		t.Context(),
+		mailboxconn.NewStatusError(
+			"refresh", &mailboxpb.Status{
+				Ok:   false,
+				Code: mailboxconn.StatusArkVersionMismatch,
+			},
+		),
+	)
+
+	err := s.startMailboxIngress(t.Context())
+	require.Error(t, err)
+	require.False(t, s.isServerConnected())
+}

--- a/darepod/operator_negotiation.go
+++ b/darepod/operator_negotiation.go
@@ -1,0 +1,148 @@
+package darepod
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	"github.com/lightninglabs/darepo-client/serverconn"
+)
+
+// arkVersionNegotiation is the outcome of the bootstrap GetInfo negotiation.
+// connectAndBootstrapMailbox is the sole owner of this negotiation: it caches
+// every value below before constructing the mailbox runtime, so the later
+// round-actor initialization and refresh-only GetInfo calls never renegotiate.
+type arkVersionNegotiation struct {
+	// operatorPubKey is the operator's main public key.
+	operatorPubKey *btcec.PublicKey
+
+	// selectedArkVersion is the Ark protocol version to bind to the
+	// runtime. It is always non-zero on a successful negotiation.
+	selectedArkVersion uint32
+
+	// terms is the initial operator terms parsed from the same response, so
+	// the round actor does not need a second negotiating call.
+	terms *types.OperatorTerms
+}
+
+// operatorTermsFromResponse parses operator terms from a GetInfo response. It
+// is shared by the bootstrap negotiation and the refresh-only path so both
+// produce identical terms from the same fields.
+func operatorTermsFromResponse(resp *arkrpc.GetInfoResponse) (
+	*types.OperatorTerms, error) {
+
+	if resp == nil {
+		return nil, fmt.Errorf("nil GetInfo response")
+	}
+
+	if len(resp.Pubkey) == 0 {
+		return nil, fmt.Errorf("operator pubkey is missing")
+	}
+
+	pubKey, err := btcec.ParsePubKey(resp.Pubkey)
+	if err != nil {
+		return nil, fmt.Errorf("parse operator pubkey: %w", err)
+	}
+
+	minVTXOAmount := resp.MinVtxoAmountSat
+	if minVTXOAmount < resp.DustLimit {
+		minVTXOAmount = resp.DustLimit
+	}
+
+	// The forfeit penalty key, sweep key and sweep delay are no longer
+	// global operator terms; they are delivered per round in the batch
+	// info, so GetInfo no longer carries them.
+	return &types.OperatorTerms{
+		PubKey:              pubKey,
+		BoardingExitDelay:   resp.BoardingExitDelay,
+		VTXOExitDelay:       resp.VtxoExitDelay,
+		DustLimit:           btcutil.Amount(resp.DustLimit),
+		MinVTXOAmount:       btcutil.Amount(minVTXOAmount),
+		MinBoardingAmount:   btcutil.Amount(resp.MinBoardingAmount),
+		MaxVTXOAmount:       btcutil.Amount(resp.MaxVtxoAmount),
+		FeeRate:             btcutil.Amount(resp.FeeRate),
+		MinOperatorFee:      btcutil.Amount(resp.MinOperatorFee),
+		MinConfirmations:    resp.MinConfirmations,
+		MaxOORLineageVBytes: resp.MaxOorLineageVbytes,
+		MaxUserBalance:      btcutil.Amount(resp.MaxUserBalance),
+	}, nil
+}
+
+// clientSupportedArkVersions returns the Ark protocol versions this client
+// advertises during bootstrap, ordered by preference. Production supports only
+// v1; no production default advertises a higher version.
+func clientSupportedArkVersions() []uint32 {
+	return []uint32{arkrpc.ArkProtocolVersionV1}
+}
+
+// onServerIncompatible is the connector compatibility callback. When the
+// mailbox connector hits its first permanent version error it transitions to a
+// terminal incompatible state and invokes this once. We mark the daemon
+// disconnected and log the actionable upgrade information. This is an external
+// compatibility condition rather than an internal bug, so it logs below error
+// level.
+func (s *Server) onServerIncompatible(statusErr *mailboxconn.StatusError) {
+	s.serverConnected.Store(false)
+
+	ctx := context.Background()
+
+	if statusErr == nil {
+		s.log.WarnS(ctx, "Server connection became incompatible", nil)
+
+		return
+	}
+
+	s.log.WarnS(ctx, "Server connection became incompatible", statusErr,
+		slog.String("code", statusErr.Code()),
+		slog.Any(
+			"supported_mailbox_versions",
+			statusErr.SupportedMailboxVersions(),
+		),
+		slog.Any(
+			"supported_ark_versions",
+			statusErr.SupportedArkVersions(),
+		),
+	)
+}
+
+// negotiateArkBootstrap performs the single bootstrap GetInfo call that owns
+// Ark protocol version selection. It delegates the version decision to a
+// serverconn.ArkVersionNegotiator over the direct ArkService connection, then
+// parses the initial operator terms from the same response so the round actor
+// never renegotiates.
+//
+// It returns an error without selecting a version when no compatible version
+// exists, so the caller can refuse to create the runtime.
+func (s *Server) negotiateArkBootstrap(ctx context.Context,
+	clientSupported []uint32) (*arkVersionNegotiation, error) {
+
+	client := s.operatorArkClient()
+	if client == nil {
+		return nil, fmt.Errorf("operator connection not initialized")
+	}
+
+	negotiator := serverconn.NewArkVersionNegotiator(
+		client, clientSupported,
+	)
+
+	resp, selected, err := negotiator.Bootstrap(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	terms, err := operatorTermsFromResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &arkVersionNegotiation{
+		operatorPubKey:     terms.PubKey,
+		selectedArkVersion: selected,
+		terms:              terms,
+	}, nil
+}

--- a/darepod/operator_negotiation_test.go
+++ b/darepod/operator_negotiation_test.go
@@ -1,0 +1,242 @@
+package darepod
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// activeArkPolicy builds an ACTIVE policy for the given version, used to
+// populate the operator's advertised policy list in fake GetInfo responses.
+func activeArkPolicy(version uint32) *arkrpc.ArkVersionPolicy {
+	return &arkrpc.ArkVersionPolicy{
+		Version: version,
+		State:   arkrpc.ArkVersionPolicy_STATE_ACTIVE,
+	}
+}
+
+// stubArkServiceClient is a minimal arkrpc.ArkServiceClient that returns a
+// canned GetInfo response, used to drive the bootstrap negotiation without a
+// real transport.
+type stubArkServiceClient struct {
+	resp *arkrpc.GetInfoResponse
+	err  error
+}
+
+// GetInfo returns the canned response.
+func (s *stubArkServiceClient) GetInfo(_ context.Context,
+	_ *arkrpc.GetInfoRequest, _ ...grpc.CallOption) (
+	*arkrpc.GetInfoResponse, error) {
+
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	return s.resp, nil
+}
+
+// EstimateFee is unused by these tests.
+func (s *stubArkServiceClient) EstimateFee(_ context.Context,
+	_ *arkrpc.EstimateFeeRequest, _ ...grpc.CallOption) (
+	*arkrpc.EstimateFeeResponse, error) {
+
+	return &arkrpc.EstimateFeeResponse{}, nil
+}
+
+// testOperatorPubKeyBytes returns a valid compressed secp256k1 public key for
+// populating a fake GetInfo response.
+func testOperatorPubKeyBytes(t *testing.T) []byte {
+	t.Helper()
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return priv.PubKey().SerializeCompressed()
+}
+
+// TestNegotiateArkBootstrapZeroSelection proves the client refuses to bootstrap
+// when the operator returns a zero selection (no common version, or a
+// pre-versioning server). There is no legacy fallback.
+func TestNegotiateArkBootstrapZeroSelection(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{
+		arkClient: &stubArkServiceClient{
+			resp: &arkrpc.GetInfoResponse{
+				Pubkey: testOperatorPubKeyBytes(t),
+			},
+		},
+	}
+
+	neg, err := srv.negotiateArkBootstrap(
+		t.Context(), []uint32{arkrpc.ArkProtocolVersionV1},
+	)
+	require.Error(t, err)
+	require.Nil(t, neg)
+}
+
+// TestNegotiateArkBootstrapNoOverlap proves a no-overlap response yields an
+// error so connectAndBootstrapMailbox refuses to create the runtime.
+func TestNegotiateArkBootstrapNoOverlap(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{
+		arkClient: &stubArkServiceClient{
+			resp: &arkrpc.GetInfoResponse{
+				Pubkey: testOperatorPubKeyBytes(t),
+				ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+					activeArkPolicy(2),
+				},
+			},
+		},
+	}
+
+	neg, err := srv.negotiateArkBootstrap(
+		t.Context(), []uint32{arkrpc.ArkProtocolVersionV1},
+	)
+	require.Error(t, err)
+	require.Nil(t, neg)
+}
+
+// TestFetchOperatorTermsRefreshPinsVersion proves fetchOperatorTerms is
+// refresh-only: it sends the runtime-bound version as the singleton supported
+// list and leaves the bound version unchanged on success.
+func TestFetchOperatorTermsRefreshPinsVersion(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubArkServiceClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             testOperatorPubKeyBytes(t),
+			SelectedArkVersion: 1,
+		},
+	}
+	srv := &Server{arkClient: stub, arkProtocolVersion: 1}
+
+	terms, err := srv.fetchOperatorTerms(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, terms)
+
+	// The runtime version must be unchanged by a refresh.
+	require.Equal(t, uint32(1), srv.arkProtocolVersion)
+}
+
+// TestFetchOperatorTermsRefreshRejectsRenegotiation proves a refresh that
+// selects a different version fails with a terminal ARK_VERSION_MISMATCH and
+// does not change the bound version.
+func TestFetchOperatorTermsRefreshRejectsRenegotiation(t *testing.T) {
+	t.Parallel()
+
+	// The operator now prefers v2 and advertises a disabled policy for the
+	// bound v1.
+	stub := &stubArkServiceClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             testOperatorPubKeyBytes(t),
+			SelectedArkVersion: 2,
+			ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+				{
+					Version: 1,
+					State: arkrpc.
+						ArkVersionPolicy_STATE_DISABLED,
+				},
+			},
+		},
+	}
+	srv := &Server{arkClient: stub, arkProtocolVersion: 1}
+
+	_, err := srv.fetchOperatorTerms(t.Context())
+	require.Error(t, err)
+	require.True(t, mailboxconn.IsPermanentVersionError(err))
+
+	var statusErr *mailboxconn.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	require.Equal(
+		t, mailboxconn.StatusArkVersionMismatch, statusErr.Code(),
+	)
+
+	// The runtime version must be unchanged by a failed refresh.
+	require.Equal(t, uint32(1), srv.arkProtocolVersion)
+}
+
+// TestNegotiateArkBootstrapSelectedButDisabled proves the client refuses to
+// bootstrap a runtime when the operator selects the client's supported version
+// but simultaneously advertises that version as DISABLED. The refusal is a
+// permanent UPGRADE_REQUIRED status error.
+func TestNegotiateArkBootstrapSelectedButDisabled(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubArkServiceClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             testOperatorPubKeyBytes(t),
+			SelectedArkVersion: 1,
+			ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+				{
+					Version: 1,
+					State: arkrpc.
+						ArkVersionPolicy_STATE_DISABLED,
+				},
+			},
+		},
+	}
+	srv := &Server{arkClient: stub}
+
+	neg, err := srv.negotiateArkBootstrap(t.Context(), []uint32{1})
+	require.Error(t, err)
+	require.Nil(t, neg)
+
+	require.True(t, mailboxconn.IsPermanentVersionError(err))
+
+	var statusErr *mailboxconn.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	require.Equal(
+		t, mailboxconn.StatusUpgradeRequired, statusErr.Code(),
+	)
+}
+
+// TestFetchOperatorTermsRefreshSelectedButDisabledMarksIncompatible proves the
+// refresh path drives an existing runtime to INCOMPATIBLE when the operator
+// re-selects the bound version but advertises it as DISABLED.
+// fetchOperatorTerms returns the permanent UPGRADE_REQUIRED error and calls
+// MarkIncompatible, whose OnIncompatible callback clears server_connected.
+func TestFetchOperatorTermsRefreshSelectedButDisabledMarksIncompatible(
+	t *testing.T) {
+
+	t.Parallel()
+
+	s := newCompatTestServer(t, okPullEdge{})
+
+	// Model a healthy, connected client bound to v1 before the refresh.
+	s.serverConnected.Store(true)
+	s.arkProtocolVersion = 1
+	s.arkClient = &stubArkServiceClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             testOperatorPubKeyBytes(t),
+			SelectedArkVersion: 1,
+			ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+				{
+					Version: 1,
+					State: arkrpc.
+						ArkVersionPolicy_STATE_DISABLED,
+				},
+			},
+		},
+	}
+
+	_, err := s.fetchOperatorTerms(t.Context())
+	require.Error(t, err)
+	require.True(t, mailboxconn.IsPermanentVersionError(err))
+
+	var statusErr *mailboxconn.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	require.Equal(
+		t, mailboxconn.StatusUpgradeRequired, statusErr.Code(),
+	)
+
+	// The refresh transitioned the runtime to INCOMPATIBLE, firing the
+	// OnIncompatible callback that clears server_connected.
+	require.False(t, s.isServerConnected())
+}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -310,6 +310,12 @@ type Server struct {
 	// concurrent GetInfo RPC reads.
 	operatorTerms atomic.Pointer[types.OperatorTerms]
 
+	// arkProtocolVersion is the Ark protocol version negotiated during
+	// bootstrap and bound to the mailbox runtime for its lifetime. Later
+	// refresh-only GetInfo calls pin this version and never change it; a
+	// fresh negotiation only happens on a daemon restart.
+	arkProtocolVersion uint32
+
 	// serverConnected reports whether mailbox ingress is currently
 	// running against the Ark operator. It flips true once ingress
 	// starts successfully and flips false again during shutdown.
@@ -2273,11 +2279,20 @@ func (s *Server) resumeBoardingSweeps(ctx context.Context,
 // startMailboxIngress starts mailbox ingress once all actor dispatch targets
 // have been registered.
 func (s *Server) startMailboxIngress(ctx context.Context) error {
+	// Mark connected BEFORE starting ingress. An incompatibility that lands
+	// concurrently (e.g. the ingress loop immediately hits a permanent
+	// version error) invokes the compatibility callback, which writes
+	// server_connected=false. Because that write necessarily happens after
+	// this unconditional true, the false always wins and we never leave a
+	// stale "connected" after an incompatibility. On a synchronous start
+	// failure we clear it back to false ourselves.
+	s.setServerConnected(true)
+
 	if err := s.runtime.StartIngress(ctx); err != nil {
+		s.setServerConnected(false)
+
 		return fmt.Errorf("start serverconn ingress: %w", err)
 	}
-
-	s.setServerConnected(true)
 
 	return nil
 }
@@ -3200,11 +3215,10 @@ func (s *Server) handleInboundRPC(ctx context.Context,
 	}
 
 	responseEnv := &mailboxpb.Envelope{
-		ProtocolVersion: env.ProtocolVersion,
-		Sender:          s.localMailboxID,
-		Recipient:       env.Rpc.ReplyTo,
-		Headers:         headers,
-		Body:            body,
+		Sender:    s.localMailboxID,
+		Recipient: env.Rpc.ReplyTo,
+		Headers:   headers,
+		Body:      body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			CorrelationId: env.Rpc.CorrelationId,
@@ -3212,6 +3226,11 @@ func (s *Server) handleInboundRPC(ctx context.Context,
 			Method:        env.Rpc.Method,
 		},
 	}
+
+	// Stamp the runtime-bound version pair rather than copying the
+	// caller-controlled inbound versions, so responses always carry this
+	// client's negotiated mailbox transport and Ark protocol versions.
+	s.runtime.StampEnvelope(responseEnv)
 
 	_, err = edge.Send(ctx, &mailboxpb.SendRequest{
 		Envelope: responseEnv,
@@ -3473,14 +3492,30 @@ func (s *Server) connectAndBootstrapMailbox(ctx context.Context) error {
 
 	s.log.InfoS(ctx, "Connected to ark server")
 
-	// Fetch the operator's public key via direct ArkService before
-	// wiring the mailbox transport.
-	operatorPubKey, err := s.fetchOperatorPubKeyDirect(ctx)
+	// Negotiate the Ark protocol version via direct ArkService before
+	// wiring the mailbox transport. This is the sole negotiation owner: it
+	// selects the runtime version and caches the initial operator terms so
+	// the round actor never renegotiates.
+	negotiation, err := s.negotiateArkBootstrap(
+		ctx, clientSupportedArkVersions(),
+	)
 	if err != nil {
-		return fmt.Errorf("fetch operator pubkey: %w", err)
+		return fmt.Errorf("negotiate ark protocol version: %w", err)
 	}
 
-	s.log.InfoS(ctx, "Fetched operator pubkey via direct ArkService",
+	operatorPubKey := negotiation.operatorPubKey
+
+	// Cache the negotiation outcome before constructing the runtime so
+	// every later consumer reads the bound version and initial terms
+	// instead of issuing a second negotiating call.
+	s.arkProtocolVersion = negotiation.selectedArkVersion
+	s.storeOperatorTerms(negotiation.terms)
+
+	s.log.InfoS(ctx, "Negotiated ark protocol version",
+		slog.Uint64(
+			"ark_protocol_version",
+			uint64(negotiation.selectedArkVersion),
+		),
 		slog.String(
 			"operator_mailbox_id",
 			serverconn.PubKeyMailboxID(operatorPubKey),
@@ -3551,7 +3586,10 @@ func (s *Server) connectAndBootstrapMailbox(ctx context.Context) error {
 	connCfg.Edge = edge
 	connCfg.LocalMailboxID = s.localMailboxID
 	connCfg.RemoteMailboxID = remoteMailboxID
-	connCfg.ProtocolVersion = 1
+
+	// Bind the runtime to the negotiated Ark protocol version.
+	// DefaultConnectorConfig already binds mailbox transport v1.
+	connCfg.ArkProtocolVersion = s.arkProtocolVersion
 	connCfg.Store = s.deliveryStore
 	connCfg.Dispatchers = dispatchers
 	connCfg.AuthSignature = authSig
@@ -3561,6 +3599,7 @@ func (s *Server) connectAndBootstrapMailbox(ctx context.Context) error {
 		server: s,
 	}
 	connCfg.Log = fn.Some(s.subLogger(serverconn.Subsystem))
+	connCfg.OnIncompatible = s.onServerIncompatible
 
 	s.runtime, err = serverconn.NewRuntime(connCfg)
 	if err != nil {
@@ -3772,16 +3811,14 @@ func (s *Server) initRoundActor(ctx context.Context,
 	roundStore := dbStore.NewRoundStore(s.chainParams, s.clk)
 	s.roundStore = roundStore
 
-	// Fetch the operator's terms from the server. These include
-	// the operator pubkey, sweep delay, exit delay, dust limit,
-	// and other round parameters.
-	operatorTerms, err := s.fetchOperatorTerms(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("unable to fetch operator terms: %w",
-			err)
+	// Consume the operator terms cached by the bootstrap negotiation
+	// instead of issuing a second negotiating GetInfo call. The bootstrap
+	// is the sole version owner, so the round actor must not renegotiate.
+	operatorTerms := s.loadOperatorTerms()
+	if operatorTerms == nil {
+		return nil, fmt.Errorf("operator terms not cached: bootstrap " +
+			"negotiation must run before the round actor starts")
 	}
-
-	s.storeOperatorTerms(operatorTerms)
 
 	// Maximum operator fee the client is willing to pay per
 	// round, sourced from the daemon config. Config.Validate
@@ -4274,19 +4311,20 @@ func mapRoundVTXOManagerMsg(msg round.VTXOManagerMsg) vtxo.ManagerMsg {
 	return mapped
 }
 
-// fetchOperatorTerms retrieves the operator's terms from the Ark
-// server via a direct ArkService.GetInfo RPC on the configured
-// transport. This must not depend on mailbox ingress during startup:
-// a restarted client can already have queued server-push envelopes in
-// its mailbox, and those envelopes may target actors that have not yet
-// been registered. Using the mailbox transport here can therefore
-// deadlock round/OOR bootstrap behind redelivery of those pending
-// events.
+// fetchOperatorTerms refreshes the operator's terms from the Ark server via a
+// direct ArkService.GetInfo RPC. It is refresh-only: it is NOT a negotiation.
+// connectAndBootstrapMailbox is the sole owner of Ark protocol version
+// selection, so this call pins the runtime-bound version by sending it as the
+// singleton supported list and rejects any response that selects a different
+// or zero version. It never mutates the runtime version.
+//
+// This must not depend on mailbox ingress: a restarted client can already have
+// queued server-push envelopes in its mailbox targeting actors that have not
+// yet been registered, so using the mailbox transport here can deadlock
+// round/OOR bootstrap behind redelivery of those pending events.
 //
 // The terms include the operator pubkey, sweep delay, VTXO exit delay,
-// forfeit script, dust limit, and fee rate. These are required before
-// the round actor can start, as they govern all round signing and
-// validation parameters.
+// forfeit script, dust limit, and fee rate.
 func (s *Server) fetchOperatorTerms(ctx context.Context) (*types.OperatorTerms,
 	error) {
 
@@ -4295,44 +4333,33 @@ func (s *Server) fetchOperatorTerms(ctx context.Context) (*types.OperatorTerms,
 		return nil, fmt.Errorf("operator connection not initialized")
 	}
 
-	resp, err := client.GetInfo(ctx, &arkrpc.GetInfoRequest{})
+	// Pin the runtime-bound version: send it as the singleton supported
+	// list so a conforming operator re-selects exactly this version.
+	boundVersion := s.arkProtocolVersion
+
+	resp, err := client.GetInfo(ctx, &arkrpc.GetInfoRequest{
+		SupportedArkVersions: []uint32{boundVersion},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("GetInfo RPC: %w", err)
 	}
 
-	if len(resp.Pubkey) == 0 {
-		return nil, fmt.Errorf("operator pubkey is missing")
+	// A refresh that selects a different version is a terminal
+	// compatibility failure: the runtime is bound for its lifetime, so the
+	// runtime must be torn down and renegotiated. Drive the connector to
+	// its incompatible state and surface the typed error.
+	if statusErr := serverconn.ValidateRefreshSelection(
+		resp, boundVersion,
+	); statusErr != nil {
+
+		if s.runtime != nil {
+			s.runtime.MarkIncompatible(ctx, statusErr)
+		}
+
+		return nil, statusErr
 	}
 
-	pubKey, err := btcec.ParsePubKey(resp.Pubkey)
-	if err != nil {
-		return nil, fmt.Errorf("parse operator pubkey: %w", err)
-	}
-
-	minVTXOAmount := resp.MinVtxoAmountSat
-	if minVTXOAmount < resp.DustLimit {
-		minVTXOAmount = resp.DustLimit
-	}
-
-	// The forfeit penalty key, sweep key and sweep delay are no longer
-	// global operator terms; they are delivered per round in the batch
-	// info, so GetInfo no longer carries them.
-	terms := &types.OperatorTerms{
-		PubKey:              pubKey,
-		BoardingExitDelay:   resp.BoardingExitDelay,
-		VTXOExitDelay:       resp.VtxoExitDelay,
-		DustLimit:           btcutil.Amount(resp.DustLimit),
-		MinVTXOAmount:       btcutil.Amount(minVTXOAmount),
-		MinBoardingAmount:   btcutil.Amount(resp.MinBoardingAmount),
-		MaxVTXOAmount:       btcutil.Amount(resp.MaxVtxoAmount),
-		FeeRate:             btcutil.Amount(resp.FeeRate),
-		MinOperatorFee:      btcutil.Amount(resp.MinOperatorFee),
-		MinConfirmations:    resp.MinConfirmations,
-		MaxOORLineageVBytes: resp.MaxOorLineageVbytes,
-		MaxUserBalance:      btcutil.Amount(resp.MaxUserBalance),
-	}
-
-	return terms, nil
+	return operatorTermsFromResponse(resp)
 }
 
 // deriveIdentityKeyEarly derives the client's identity key before the
@@ -4444,35 +4471,6 @@ func (s *Server) deriveIdentityKeyEarly(ctx context.Context) error {
 		))
 
 	return nil
-}
-
-// fetchOperatorPubKeyDirect fetches the operator's public key via a direct
-// ArkService.GetInfo call, bypassing the mailbox
-// transport. This is needed before the mailbox runtime starts because
-// the remote mailbox ID is derived from the operator's pubkey.
-func (s *Server) fetchOperatorPubKeyDirect(ctx context.Context) (
-	*btcec.PublicKey, error) {
-
-	client := s.operatorArkClient()
-	if client == nil {
-		return nil, fmt.Errorf("operator connection not initialized")
-	}
-
-	resp, err := client.GetInfo(ctx, &arkrpc.GetInfoRequest{})
-	if err != nil {
-		return nil, fmt.Errorf("GetInfo RPC: %w", err)
-	}
-
-	if len(resp.Pubkey) == 0 {
-		return nil, fmt.Errorf("operator pubkey is missing")
-	}
-
-	pubKey, err := btcec.ParsePubKey(resp.Pubkey)
-	if err != nil {
-		return nil, fmt.Errorf("parse operator pubkey: %w", err)
-	}
-
-	return pubKey, nil
 }
 
 // signMailboxAuth computes the Schnorr auth signature for the

--- a/docs/mailbox_architecture.md
+++ b/docs/mailbox_architecture.md
@@ -170,9 +170,8 @@ classDiagram
         +bool ok
         +string code
         +string message
-        +uint32 min_supported_protocol_version
-        +uint32 server_protocol_version
-        +string upgrade_url
+        +uint32[] supported_mailbox_versions
+        +uint32[] supported_ark_versions
     }
 
     Envelope *-- RpcMeta : rpc

--- a/mailbox/conn/response_registry.go
+++ b/mailbox/conn/response_registry.go
@@ -165,6 +165,21 @@ func (r *ResponseRegistry) HasWaiter(id CorrelationID) bool {
 	return ok
 }
 
+// FailAll completes every registered waiter's promise with err and clears the
+// waiter set. It is used to fail all in-flight unary callers at once when the
+// connector transitions to a terminal incompatible state, so no caller blocks
+// on a response that will never arrive.
+func (r *ResponseRegistry) FailAll(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for id, waiter := range r.waiters {
+		waiter.Promise.Complete(fn.Err[*mailboxpb.Envelope](err))
+
+		delete(r.waiters, id)
+	}
+}
+
 // RemovePending drops any buffered early response for the correlation ID.
 func (r *ResponseRegistry) RemovePending(id CorrelationID) {
 	r.mu.Lock()

--- a/mailbox/conn/status_error.go
+++ b/mailbox/conn/status_error.go
@@ -1,0 +1,136 @@
+package conn
+
+import (
+	"errors"
+	"fmt"
+
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+)
+
+// Permanent mailbox status codes. These classify a non-OK mailbox edge
+// response as an expected, non-retryable version-compatibility failure rather
+// than a transient transport hiccup or an internal bug. They are the
+// machine-readable values carried in mailboxpb.Status.Code.
+const (
+	// StatusMailboxVersionUnsupported indicates the envelope's mailbox
+	// transport framing version is not supported by the responder. The
+	// sender must use a compatible endpoint or client.
+	StatusMailboxVersionUnsupported = "MAILBOX_VERSION_UNSUPPORTED"
+
+	// StatusArkVersionUnsupported indicates the envelope's Ark protocol
+	// version is not currently enabled by the responder. The sender must
+	// renegotiate or upgrade.
+	StatusArkVersionUnsupported = "ARK_VERSION_UNSUPPORTED"
+
+	// StatusArkVersionMismatch indicates the envelope's Ark protocol
+	// version differs from the version already bound to the responder's
+	// runtime for this client. The sender must stop the runtime and
+	// renegotiate.
+	StatusArkVersionMismatch = "ARK_VERSION_MISMATCH"
+
+	// StatusUpgradeRequired indicates the client software must upgrade
+	// before continuing. The sender must stop retrying and surface the
+	// upgrade information.
+	StatusUpgradeRequired = "UPGRADE_REQUIRED"
+)
+
+// permanentVersionCodes is the set of status codes that represent permanent,
+// non-retryable version-compatibility failures. It is the single source of
+// truth for permanent-error classification so unary, durable event,
+// heartbeat, pull, and ack paths all agree.
+var permanentVersionCodes = map[string]struct{}{
+	StatusMailboxVersionUnsupported: {},
+	StatusArkVersionUnsupported:     {},
+	StatusArkVersionMismatch:        {},
+	StatusUpgradeRequired:           {},
+}
+
+// StatusError wraps a non-OK mailbox edge Status so callers can classify the
+// failure and recover the full structured payload without flattening it into a
+// generic error string. It is the shared status type used by every client Send,
+// Pull, and AckUpTo path, replacing previously duplicated unexported status
+// handling.
+type StatusError struct {
+	// Op is the mailbox operation that failed (e.g. "Send", "Pull",
+	// "AckUpTo").
+	Op string
+
+	// Status is the complete status returned by the mailbox edge. It is
+	// retained verbatim so callers can read every structured field.
+	Status *mailboxpb.Status
+}
+
+// NewStatusError builds a StatusError for the given operation and edge status.
+// The status is retained as-is; callers should only construct this for a
+// non-OK status.
+func NewStatusError(op string, status *mailboxpb.Status) *StatusError {
+	return &StatusError{
+		Op:     op,
+		Status: status,
+	}
+}
+
+// Error returns a human-readable description that preserves the operation,
+// message, and code so logs remain diagnosable.
+func (e *StatusError) Error() string {
+	if e.Status == nil {
+		return e.Op + ": nil status"
+	}
+
+	return fmt.Sprintf("%s: %s (%s)", e.Op, e.Status.Message, e.Status.Code)
+}
+
+// Code returns the machine-readable status code, or the empty string when no
+// status is present.
+func (e *StatusError) Code() string {
+	if e.Status == nil {
+		return ""
+	}
+
+	return e.Status.Code
+}
+
+// IsPermanentVersion reports whether this status is one of the four permanent
+// version-compatibility codes. Every other status (transient transport or
+// internal failure) is left to the existing retry policy.
+func (e *StatusError) IsPermanentVersion() bool {
+	if e.Status == nil {
+		return false
+	}
+
+	_, ok := permanentVersionCodes[e.Status.Code]
+
+	return ok
+}
+
+// SupportedMailboxVersions returns the mailbox transport versions the
+// responder advertised, if any.
+func (e *StatusError) SupportedMailboxVersions() []uint32 {
+	if e.Status == nil {
+		return nil
+	}
+
+	return e.Status.SupportedMailboxVersions
+}
+
+// SupportedArkVersions returns the Ark protocol versions the responder
+// advertised, if any.
+func (e *StatusError) SupportedArkVersions() []uint32 {
+	if e.Status == nil {
+		return nil
+	}
+
+	return e.Status.SupportedArkVersions
+}
+
+// IsPermanentVersionError reports whether err is, or wraps, a StatusError
+// carrying one of the permanent version-compatibility codes. Durable senders
+// use this to stop retrying and to dead-letter the failing message.
+func IsPermanentVersionError(err error) bool {
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+
+	return statusErr.IsPermanentVersion()
+}

--- a/mailbox/conn/status_error_test.go
+++ b/mailbox/conn/status_error_test.go
@@ -1,0 +1,165 @@
+package conn
+
+import (
+	"fmt"
+	"testing"
+
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatusErrorClassification is a table-driven test proving that every
+// permanent version code is classified as permanent while transient transport
+// and internal failures are not, and that the full structured status payload
+// (supported versions) remains available on the typed error.
+func TestStatusErrorClassification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		code        string
+		permanent   bool
+		mailboxVers []uint32
+		arkVers     []uint32
+	}{
+		{
+			name:      "mailbox version unsupported",
+			code:      StatusMailboxVersionUnsupported,
+			permanent: true,
+			mailboxVers: []uint32{
+				1,
+			},
+		},
+		{
+			name:      "ark version unsupported",
+			code:      StatusArkVersionUnsupported,
+			permanent: true,
+			arkVers: []uint32{
+				1,
+				2,
+			},
+		},
+		{
+			name:      "ark version mismatch",
+			code:      StatusArkVersionMismatch,
+			permanent: true,
+			arkVers: []uint32{
+				1,
+			},
+		},
+		{
+			name:      "upgrade required",
+			code:      StatusUpgradeRequired,
+			permanent: true,
+			arkVers: []uint32{
+				2,
+			},
+		},
+		{
+			name:      "transient unavailable",
+			code:      "UNAVAILABLE",
+			permanent: false,
+		},
+		{
+			name:      "internal failure",
+			code:      "INTERNAL",
+			permanent: false,
+		},
+		{
+			name:      "empty code",
+			code:      "",
+			permanent: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			status := &mailboxpb.Status{
+				Ok:                       false,
+				Code:                     tc.code,
+				Message:                  "boom",
+				SupportedMailboxVersions: tc.mailboxVers,
+				SupportedArkVersions:     tc.arkVers,
+			}
+
+			statusErr := NewStatusError("Send", status)
+
+			// Classification matches the permanent-code table.
+			require.Equal(
+				t, tc.permanent, statusErr.IsPermanentVersion(),
+			)
+			require.Equal(
+				t, tc.permanent,
+				IsPermanentVersionError(statusErr),
+			)
+
+			// The code and full payload remain available.
+			require.Equal(t, tc.code, statusErr.Code())
+			require.Equal(
+				t, tc.mailboxVers,
+				statusErr.SupportedMailboxVersions(),
+			)
+			require.Equal(
+				t, tc.arkVers, statusErr.SupportedArkVersions(),
+			)
+
+			// The error string preserves operation, message, and
+			// code for diagnosability.
+			require.Contains(t, statusErr.Error(), "Send")
+			require.Contains(t, statusErr.Error(), "boom")
+			if tc.code != "" {
+				require.Contains(
+					t, statusErr.Error(), tc.code,
+				)
+			}
+		})
+	}
+}
+
+// TestStatusErrorNilStatus proves the typed error degrades gracefully when no
+// status is present rather than panicking.
+func TestStatusErrorNilStatus(t *testing.T) {
+	t.Parallel()
+
+	statusErr := NewStatusError("AckUpTo", nil)
+
+	require.False(t, statusErr.IsPermanentVersion())
+	require.Empty(t, statusErr.Code())
+	require.Nil(t, statusErr.SupportedMailboxVersions())
+	require.Nil(t, statusErr.SupportedArkVersions())
+	require.Contains(t, statusErr.Error(), "nil status")
+}
+
+// TestIsPermanentVersionErrorWrapped proves the free helper unwraps a wrapped
+// StatusError, so durable senders can classify deeply nested errors.
+func TestIsPermanentVersionErrorWrapped(t *testing.T) {
+	t.Parallel()
+
+	permErr := NewStatusError("Send", &mailboxpb.Status{
+		Ok:   false,
+		Code: StatusUpgradeRequired,
+	})
+	wrapped := fmt.Errorf("send failed: %w", permErr)
+	require.True(t, IsPermanentVersionError(wrapped))
+
+	transientErr := NewStatusError("Send", &mailboxpb.Status{
+		Ok:   false,
+		Code: "UNAVAILABLE",
+	})
+	require.False(
+		t,
+		IsPermanentVersionError(
+			fmt.Errorf("send failed: %w", transientErr),
+		),
+	)
+
+	// A non-StatusError is never a permanent version error.
+	require.False(
+		t,
+		IsPermanentVersionError(
+			fmt.Errorf("some other error"),
+		),
+	)
+}

--- a/mailbox/pb/mailbox.pb.go
+++ b/mailbox/pb/mailbox.pb.go
@@ -184,9 +184,14 @@ type Envelope struct {
 	// rpc carries optional RPC overlay metadata.
 	Rpc *RpcMeta `protobuf:"bytes,11,opt,name=rpc,proto3" json:"rpc,omitempty"`
 	// event_seq is assigned by the mailbox edge to define per-mailbox ordering.
-	EventSeq      uint64 `protobuf:"varint,12,opt,name=event_seq,json=eventSeq,proto3" json:"event_seq,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	EventSeq uint64 `protobuf:"varint,12,opt,name=event_seq,json=eventSeq,proto3" json:"event_seq,omitempty"`
+	// ark_protocol_version is the negotiated Ark protocol version selected
+	// through the direct GetInfo bootstrap RPC. It is distinct from
+	// protocol_version, which is the mailbox transport version. Every envelope
+	// sent after negotiation carries the runtime-bound Ark protocol version.
+	ArkProtocolVersion uint32 `protobuf:"varint,13,opt,name=ark_protocol_version,json=arkProtocolVersion,proto3" json:"ark_protocol_version,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *Envelope) Reset() {
@@ -303,6 +308,13 @@ func (x *Envelope) GetEventSeq() uint64 {
 	return 0
 }
 
+func (x *Envelope) GetArkProtocolVersion() uint32 {
+	if x != nil {
+		return x.ArkProtocolVersion
+	}
+	return 0
+}
+
 // Status describes the result of a mailbox edge operation.
 type Status struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -316,10 +328,17 @@ type Status struct {
 	MinSupportedProtocolVersion uint32 `protobuf:"varint,4,opt,name=min_supported_protocol_version,json=minSupportedProtocolVersion,proto3" json:"min_supported_protocol_version,omitempty"`
 	// server_protocol_version is populated for upgrade-required errors.
 	ServerProtocolVersion uint32 `protobuf:"varint,5,opt,name=server_protocol_version,json=serverProtocolVersion,proto3" json:"server_protocol_version,omitempty"`
-	// upgrade_url is populated for upgrade-required errors.
-	UpgradeUrl    string `protobuf:"bytes,6,opt,name=upgrade_url,json=upgradeUrl,proto3" json:"upgrade_url,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// supported_mailbox_versions lists the mailbox transport versions the
+	// responder supports. It is populated for permanent version errors so the
+	// sender can surface actionable guidance without parsing gRPC status
+	// details.
+	SupportedMailboxVersions []uint32 `protobuf:"varint,7,rep,packed,name=supported_mailbox_versions,json=supportedMailboxVersions,proto3" json:"supported_mailbox_versions,omitempty"`
+	// supported_ark_versions lists the Ark protocol versions the responder has
+	// enabled. It is populated for permanent version errors so the sender can
+	// surface actionable guidance without parsing gRPC status details.
+	SupportedArkVersions []uint32 `protobuf:"varint,8,rep,packed,name=supported_ark_versions,json=supportedArkVersions,proto3" json:"supported_ark_versions,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Status) Reset() {
@@ -387,11 +406,18 @@ func (x *Status) GetServerProtocolVersion() uint32 {
 	return 0
 }
 
-func (x *Status) GetUpgradeUrl() string {
+func (x *Status) GetSupportedMailboxVersions() []uint32 {
 	if x != nil {
-		return x.UpgradeUrl
+		return x.SupportedMailboxVersions
 	}
-	return ""
+	return nil
+}
+
+func (x *Status) GetSupportedArkVersions() []uint32 {
+	if x != nil {
+		return x.SupportedArkVersions
+	}
+	return nil
 }
 
 // SendRequest sends a single envelope.
@@ -733,7 +759,7 @@ const file_mailbox_proto_rawDesc = "" +
 	"\fKIND_REQUEST\x10\x01\x12\x11\n" +
 	"\rKIND_RESPONSE\x10\x02\x12\x0e\n" +
 	"\n" +
-	"KIND_EVENT\x10\x03\"\x80\x04\n" +
+	"KIND_EVENT\x10\x03\"\xb2\x04\n" +
 	"\bEnvelope\x12)\n" +
 	"\x10protocol_version\x18\x01 \x01(\rR\x0fprotocolVersion\x12\x15\n" +
 	"\x06msg_id\x18\x02 \x01(\tR\x05msgId\x12'\n" +
@@ -747,18 +773,19 @@ const file_mailbox_proto_rawDesc = "" +
 	"\x04body\x18\n" +
 	" \x01(\v2\x14.google.protobuf.AnyR\x04body\x12%\n" +
 	"\x03rpc\x18\v \x01(\v2\x13.mailbox.v1.RpcMetaR\x03rpc\x12\x1b\n" +
-	"\tevent_seq\x18\f \x01(\x04R\beventSeq\x1a:\n" +
+	"\tevent_seq\x18\f \x01(\x04R\beventSeq\x120\n" +
+	"\x14ark_protocol_version\x18\r \x01(\rR\x12arkProtocolVersion\x1a:\n" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe4\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xca\x02\n" +
 	"\x06Status\x12\x0e\n" +
 	"\x02ok\x18\x01 \x01(\bR\x02ok\x12\x12\n" +
 	"\x04code\x18\x02 \x01(\tR\x04code\x12\x18\n" +
 	"\amessage\x18\x03 \x01(\tR\amessage\x12C\n" +
 	"\x1emin_supported_protocol_version\x18\x04 \x01(\rR\x1bminSupportedProtocolVersion\x126\n" +
-	"\x17server_protocol_version\x18\x05 \x01(\rR\x15serverProtocolVersion\x12\x1f\n" +
-	"\vupgrade_url\x18\x06 \x01(\tR\n" +
-	"upgradeUrl\"?\n" +
+	"\x17server_protocol_version\x18\x05 \x01(\rR\x15serverProtocolVersion\x12<\n" +
+	"\x1asupported_mailbox_versions\x18\a \x03(\rR\x18supportedMailboxVersions\x124\n" +
+	"\x16supported_ark_versions\x18\b \x03(\rR\x14supportedArkVersionsJ\x04\b\x06\x10\aR\vupgrade_url\"?\n" +
 	"\vSendRequest\x120\n" +
 	"\benvelope\x18\x01 \x01(\v2\x14.mailbox.v1.EnvelopeR\benvelope\":\n" +
 	"\fSendResponse\x12*\n" +

--- a/mailbox/pb/mailbox.proto
+++ b/mailbox/pb/mailbox.proto
@@ -70,6 +70,12 @@ message Envelope {
 
     // event_seq is assigned by the mailbox edge to define per-mailbox ordering.
     uint64 event_seq = 12;
+
+    // ark_protocol_version is the negotiated Ark protocol version selected
+    // through the direct GetInfo bootstrap RPC. It is distinct from
+    // protocol_version, which is the mailbox transport version. Every envelope
+    // sent after negotiation carries the runtime-bound Ark protocol version.
+    uint32 ark_protocol_version = 13;
 }
 
 // Status describes the result of a mailbox edge operation.
@@ -89,8 +95,22 @@ message Status {
     // server_protocol_version is populated for upgrade-required errors.
     uint32 server_protocol_version = 5;
 
-    // upgrade_url is populated for upgrade-required errors.
-    string upgrade_url = 6;
+    // Field 6 previously held upgrade_url, which was removed. Keep the tag and
+    // name reserved so a future field can never silently reuse it and collide
+    // on the wire with a peer still emitting the old value.
+    reserved 6;
+    reserved "upgrade_url";
+
+    // supported_mailbox_versions lists the mailbox transport versions the
+    // responder supports. It is populated for permanent version errors so the
+    // sender can surface actionable guidance without parsing gRPC status
+    // details.
+    repeated uint32 supported_mailbox_versions = 7;
+
+    // supported_ark_versions lists the Ark protocol versions the responder has
+    // enabled. It is populated for permanent version errors so the sender can
+    // surface actionable guidance without parsing gRPC status details.
+    repeated uint32 supported_ark_versions = 8;
 }
 
 // SendRequest sends a single envelope.

--- a/mailbox/pb/version.go
+++ b/mailbox/pb/version.go
@@ -1,0 +1,14 @@
+package mailboxpb
+
+// MailboxProtocolVersionV1 is the stable mailbox transport version. The
+// mailbox transport version defines how an envelope is framed, routed, and
+// delivered: Envelope framing, RpcMeta routing, Send/Pull/AckUpTo behavior,
+// and cursor, acknowledgement, and durable replay semantics.
+//
+// It is intentionally a code constant rather than operator configuration
+// because mailbox v1 is the stable bootstrap endpoint that every client must
+// be able to decode. A future breaking mailbox transport must run on a new
+// endpoint or protobuf service package (such as mailbox.v2); it cannot depend
+// on a v1 envelope to negotiate a format that v1 cannot decode. This value is
+// therefore not a normal rolling configuration choice.
+const MailboxProtocolVersionV1 uint32 = 1

--- a/mailbox/pb/version_compat_test.go
+++ b/mailbox/pb/version_compat_test.go
@@ -1,0 +1,123 @@
+package mailboxpb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestEnvelopeOldShapeDecodesZero proves that an Envelope encoded without the
+// new ark_protocol_version field decodes under the new generated code with
+// that field left at its zero value, while the existing mailbox transport
+// protocol_version is preserved. This is the additive-compatibility guarantee
+// that lets the updated code decode envelopes produced before the Ark
+// protocol version field existed.
+func TestEnvelopeOldShapeDecodesZero(t *testing.T) {
+	t.Parallel()
+
+	// Populate only fields that existed before ark_protocol_version was
+	// added.
+	oldShape := &Envelope{
+		ProtocolVersion: uint32(1),
+		MsgId:           "msg-1",
+		IdempotencyKey:  "idem-1",
+		Sender:          "alice",
+		Recipient:       "bob",
+		EventSeq:        7,
+	}
+
+	raw, err := proto.Marshal(oldShape)
+	require.NoError(t, err)
+
+	decoded := &Envelope{}
+	require.NoError(t, proto.Unmarshal(raw, decoded))
+
+	// The mailbox transport version round-trips unchanged.
+	require.Equal(t, uint32(1), decoded.ProtocolVersion)
+	require.Equal(t, "msg-1", decoded.MsgId)
+	require.Equal(t, uint64(7), decoded.EventSeq)
+
+	// The newly added Ark protocol version must be zero after decoding an
+	// old-shape envelope.
+	require.Zero(t, decoded.ArkProtocolVersion)
+}
+
+// TestStatusOldShapeDecodesZero proves that a Status encoded with only the
+// pre-versioning fields decodes under the new code with the newly added
+// supported-version lists empty.
+func TestStatusOldShapeDecodesZero(t *testing.T) {
+	t.Parallel()
+
+	oldShape := &Status{
+		Ok:      false,
+		Code:    "SOME_CODE",
+		Message: "human readable",
+	}
+
+	raw, err := proto.Marshal(oldShape)
+	require.NoError(t, err)
+
+	decoded := &Status{}
+	require.NoError(t, proto.Unmarshal(raw, decoded))
+
+	require.Equal(t, "SOME_CODE", decoded.Code)
+	require.Equal(t, "human readable", decoded.Message)
+
+	require.Empty(t, decoded.SupportedMailboxVersions)
+	require.Empty(t, decoded.SupportedArkVersions)
+}
+
+// TestEnvelopeVersionFieldsRoundTrip proves that both version axes on the
+// Envelope are independently preserved across a marshal/unmarshal cycle.
+func TestEnvelopeVersionFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	env := &Envelope{
+		ProtocolVersion:    uint32(1),
+		ArkProtocolVersion: 2,
+		MsgId:              "msg-2",
+	}
+
+	raw, err := proto.Marshal(env)
+	require.NoError(t, err)
+
+	decoded := &Envelope{}
+	require.NoError(t, proto.Unmarshal(raw, decoded))
+
+	require.Equal(t, uint32(1), decoded.ProtocolVersion)
+	require.Equal(t, uint32(2), decoded.ArkProtocolVersion)
+	require.Equal(t, "msg-2", decoded.MsgId)
+}
+
+// TestStatusVersionFieldsRoundTrip proves that the new supported-version lists
+// on Status are preserved across a marshal/unmarshal cycle so callers can
+// surface actionable guidance from a permanent version error.
+func TestStatusVersionFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	status := &Status{
+		Ok:      false,
+		Code:    "ARK_VERSION_UNSUPPORTED",
+		Message: "unsupported",
+		SupportedMailboxVersions: []uint32{
+			uint32(1),
+		},
+		SupportedArkVersions: []uint32{
+			1,
+			2,
+		},
+	}
+
+	raw, err := proto.Marshal(status)
+	require.NoError(t, err)
+
+	decoded := &Status{}
+	require.NoError(t, proto.Unmarshal(raw, decoded))
+
+	require.Equal(t, "ARK_VERSION_UNSUPPORTED", decoded.Code)
+	require.Equal(
+		t, []uint32{uint32(1)}, decoded.SupportedMailboxVersions,
+	)
+	require.Equal(t, []uint32{1, 2}, decoded.SupportedArkVersions)
+}

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -10,6 +10,7 @@ background ingress polling with event routing.
 
 - `Runtime` — Main entry point wrapping DurableActor, ServerConnectionActor, and UnaryFacade. The egress DurableActor runs on the Read/Commit (`TxBehavior`) path: each handler builds its envelope and calls `Edge.Send` with NO SQLite writer held, then a short lease-fenced Commit folds the ack + dedup. It runs as a competing-consumer pool of `ConnectorConfig.EgressWorkers` worker loops, so the round and out-of-round actors' sends proceed concurrently; the single ingress puller is separate and unaffected.
 - `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop. Dispatches `DurableUnaryQuery` values generically via `buildDurableUnary`.
+- `ArkVersionNegotiator` — Single home for Ark protocol version selection (`ark_version.go`). `Bootstrap` performs the one bootstrap `GetInfo` over the operator's **direct** ArkService connection (`ArkVersionGetInfoClient`, never the mailbox edge) and returns the response + selected version; the daemon parses domain terms from the same response. The free function `ValidateRefreshSelection(resp, boundVersion)` enforces that a refresh-only `GetInfo` keeps the runtime bound (returns a permanent `*StatusError` on drift/disable). Enabled versions are derived from the response's ACTIVE `ArkVersionPolicy` entries.
 - `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path). Also provides `AwaitRPCTimeout` for bounded waits.
 - `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store, durable unary builder, `EgressWorkers`). `EgressWorkers` sizes the egress worker pool (default `DefaultEgressWorkers` = 4); `<= 1` keeps the legacy single sender. The `DurableUnaryBuilder` field must be set to handle `DurableUnaryQuery` message types; otherwise those messages are rejected. The `AuthSignature` field holds the Schnorr auth sig injected into every outbound envelope via `mergeAuthHeaders` (auth header always wins over caller-provided headers).
 - `PubKeyMailboxID` — Derives canonical mailbox ID from a public key (hex-encoded compressed SEC). Panics on nil.
@@ -34,7 +35,7 @@ background ingress polling with event routing.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (DurableActor infrastructure), `mailbox/*` (Envelope, RpcMeta, MailboxServiceClient).
+- **Depends on**: `baselib/actor` (DurableActor infrastructure), `mailbox/*` (Envelope, RpcMeta, MailboxServiceClient), `arkrpc` (`GetInfo` request/response + `ArkVersionPolicy` for version negotiation).
 - **Depended on by**: `round` (outbound RPCs), `oor` (durable transport), `darepod` (wiring).
 - **Sends (egress → remote mailbox)**:
   - `SendClientEventRequest` (durable): wraps `JoinRoundRequest`, `JoinRoundAccept`, `JoinRoundReject`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`. `JoinRoundAccept` / `JoinRoundReject` are the explicit responses to a server-issued seal-time `JoinRoundQuote` (#270); both echo the `quote_id` so the server can drop stale responses after a reseal.

--- a/serverconn/README.md
+++ b/serverconn/README.md
@@ -263,7 +263,8 @@ watermark.
 | `Edge` | `MailboxServiceClient` | *required* | gRPC client for the remote mailbox edge. |
 | `LocalMailboxID` | `string` | *required* | This client's mailbox identifier. |
 | `RemoteMailboxID` | `string` | *required* | Remote server's mailbox identifier. |
-| `ProtocolVersion` | `uint32` | `0` | Protocol version stamped on outbound envelopes. |
+| `MailboxProtocolVersion` | `uint32` | `MailboxProtocolVersionV1` | Immutable mailbox transport version stamped on outbound envelopes. Defaults to the v1 code constant. |
+| `ArkProtocolVersion` | `uint32` | `0` | Immutable negotiated Ark protocol version stamped on outbound envelopes and validated on inbound ones. Must be non-zero; `NewRuntime` rejects zero. |
 | `Dispatchers` | `map[ServiceMethod]EnvelopeDispatcher` | `nil` | Inbound envelope routing table. |
 | `Store` | `actor.DeliveryStore` | *required* | Durability store for inbox, outbox, and checkpoints. |
 | `Codec` | `*actor.MessageCodec` | `NewServerConnCodec()` | TLV codec for ServerConnMsg serialization. |

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -682,6 +682,23 @@ type ServerConnectionActor struct {
 	// checks this to skip sending when real traffic already
 	// proves liveness.
 	lastSendNano atomic.Int64
+
+	// compatErr caches the first permanent version error that moved the
+	// connector to the terminal INCOMPATIBLE state. A nil pointer means the
+	// connector is still COMPATIBLE. Once set, new sends return this error
+	// without contacting the edge.
+	compatErr atomic.Pointer[mailboxconn.StatusError]
+
+	// compatOnce guarantees the incompatibility transition (cache, cancel,
+	// fail waiters, callback) runs exactly once even under concurrent
+	// permanent failures.
+	compatOnce sync.Once
+
+	// ingressCancel holds the ingress/heartbeat context cancel function so
+	// the incompatibility transition can stop them asynchronously without
+	// joining its own goroutine. CancelFunc is idempotent, so StopIngress
+	// may also invoke it.
+	ingressCancel atomic.Pointer[context.CancelFunc]
 }
 
 // NewServerConnectionActor creates a new server connection actor with the
@@ -690,6 +707,14 @@ type ServerConnectionActor struct {
 func NewServerConnectionActor(
 	cfg ConnectorConfig,
 ) *ServerConnectionActor {
+
+	// Stamp the runtime-bound version pair onto every outbound envelope in
+	// one place by wrapping the edge, so no individual send path has to
+	// remember to stamp. This mirrors the auth decorator layered over the
+	// same edge.
+	cfg.Edge = newVersionStampingMailboxClient(
+		cfg.Edge, cfg.MailboxProtocolVersion, cfg.ArkProtocolVersion,
+	)
 
 	return &ServerConnectionActor{
 		cfg: cfg,
@@ -776,6 +801,10 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 	req *SendClientEventRequest,
 	ax actor.Exec[egressTx]) fn.Result[ServerConnResp] {
 
+	if ce := a.compatibilityError(); ce != nil {
+		return fn.Err[ServerConnResp](ce)
+	}
+
 	protoMsg, err := req.Message.ToProto().Unpack()
 	if err != nil {
 		a.log.WarnS(ctx, "Failed to convert to proto", err)
@@ -824,7 +853,6 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 	service, method := eventRoutingMetadata(req)
 
 	envelope := &mailboxpb.Envelope{
-		ProtocolVersion: a.cfg.ProtocolVersion,
 		MsgId:           msgID,
 		IdempotencyKey:  idempotencyKey,
 		Sender:          a.cfg.LocalMailboxID,
@@ -851,17 +879,13 @@ func (a *ServerConnectionActor) handleSendClientEvent(ctx context.Context,
 	resp, err := a.cfg.Edge.Send(sendCtx, &mailboxpb.SendRequest{
 		Envelope: envelope,
 	})
-	if err != nil {
-		return fn.Err[ServerConnResp](
-			fmt.Errorf("send client event: %w", err),
-		)
-	}
+	if sErr := edgeResponseError(
+		"send client event", resp, err,
+	); sErr != nil {
 
-	if resp.Status != nil && !resp.Status.Ok {
-		return fn.Err[ServerConnResp](
-			fmt.Errorf("send client event: %s (%s)",
-				resp.Status.Message, resp.Status.Code),
-		)
+		a.checkPermanentStatus(ctx, sErr)
+
+		return fn.Err[ServerConnResp](sErr)
 	}
 
 	a.lastSendNano.Store(time.Now().UnixNano())
@@ -993,8 +1017,11 @@ func (a *ServerConnectionActor) sendUnaryEnvelope(ctx context.Context,
 	correlationID string, msgID string,
 	idempotencyKey string) fn.Result[ServerConnResp] {
 
+	if ce := a.compatibilityError(); ce != nil {
+		return fn.Err[ServerConnResp](ce)
+	}
+
 	envelope := &mailboxpb.Envelope{
-		ProtocolVersion: a.cfg.ProtocolVersion,
 		MsgId:           msgID,
 		IdempotencyKey:  idempotencyKey,
 		Sender:          a.cfg.LocalMailboxID,
@@ -1019,17 +1046,13 @@ func (a *ServerConnectionActor) sendUnaryEnvelope(ctx context.Context,
 	resp, err := a.cfg.Edge.Send(sendCtx, &mailboxpb.SendRequest{
 		Envelope: envelope,
 	})
-	if err != nil {
-		return fn.Err[ServerConnResp](
-			fmt.Errorf("send unary request: %w", err),
-		)
-	}
+	if sErr := edgeResponseError(
+		"send unary request", resp, err,
+	); sErr != nil {
 
-	if resp.Status != nil && !resp.Status.Ok {
-		return fn.Err[ServerConnResp](
-			fmt.Errorf("send unary request: %s (%s)",
-				resp.Status.Message, resp.Status.Code),
-		)
+		a.checkPermanentStatus(ctx, sErr)
+
+		return fn.Err[ServerConnResp](sErr)
 	}
 
 	if err := a.commitSend(ctx, ax); err != nil {
@@ -1077,20 +1100,20 @@ func (a *ServerConnectionActor) handleSendRPCRequest(ctx context.Context,
 	req *SendRPCRequest,
 	ax actor.Exec[egressTx]) fn.Result[ServerConnResp] {
 
+	if ce := a.compatibilityError(); ce != nil {
+		return fn.Err[ServerConnResp](ce)
+	}
+
 	resp, err := a.cfg.Edge.Send(ctx, &mailboxpb.SendRequest{
 		Envelope: req.Envelope,
 	})
-	if err != nil {
-		return fn.Err[ServerConnResp](
-			fmt.Errorf("send rpc request: %w", err),
-		)
-	}
+	if sErr := edgeResponseError(
+		"send rpc request", resp, err,
+	); sErr != nil {
 
-	if resp.Status != nil && !resp.Status.Ok {
-		return fn.Err[ServerConnResp](
-			fmt.Errorf("send rpc request: %s (%s)",
-				resp.Status.Message, resp.Status.Code),
-		)
+		a.checkPermanentStatus(ctx, sErr)
+
+		return fn.Err[ServerConnResp](sErr)
 	}
 
 	a.lastSendNano.Store(time.Now().UnixNano())
@@ -1155,12 +1178,39 @@ func (a *ServerConnectionActor) StartIngress(
 	ctx context.Context,
 ) error {
 
+	// Fast path: if the connector already transitioned to the terminal
+	// incompatible state (e.g. a durable egress replay hit a permanent
+	// version error before ingress started), refuse to start polling or
+	// load checkpoints. Returning the cached error keeps the caller from
+	// marking the connection healthy.
+	if ce := a.compatibilityError(); ce != nil {
+		return ce
+	}
+
 	state, err := a.loadCheckpoint(ctx)
 	if err != nil {
 		return fmt.Errorf("load ingress checkpoint: %w", err)
 	}
 
 	ingressCtx, cancel := context.WithCancel(ctx)
+
+	// Publish the cancel func so the incompatibility transition can stop
+	// ingress and heartbeat asynchronously. CancelFunc is idempotent, so
+	// StopIngress invoking it again via cancelCh is harmless.
+	a.ingressCancel.Store(&cancel)
+
+	// Recheck after publishing the cancel func to close the race with a
+	// concurrent markIncompatible. The two transitions touch the compat
+	// error and the cancel pointer in opposite orders: markIncompatible
+	// stores the compat error then loads the cancel; we store the cancel
+	// then load the compat error. So at least one of us observes the
+	// other — either we see the incompatible state here and abort, or
+	// markIncompatible sees our published cancel and stops the goroutines.
+	if ce := a.compatibilityError(); ce != nil {
+		cancel()
+
+		return ce
+	}
 
 	a.wg.Add(2)
 	a.cancelCh <- cancel

--- a/serverconn/ark_version.go
+++ b/serverconn/ark_version.go
@@ -1,0 +1,238 @@
+package serverconn
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"google.golang.org/grpc"
+)
+
+// ArkVersionGetInfoClient is the minimal direct-gRPC surface the negotiator
+// needs. Negotiation deliberately uses the operator's direct ArkService
+// connection, NOT the mailbox edge: a restarted client can have queued
+// server-push envelopes for not-yet-registered actors, so routing negotiation
+// over the mailbox could deadlock bootstrap behind redelivery.
+type ArkVersionGetInfoClient interface {
+	// GetInfo returns the operator's info, including its Ark protocol
+	// version selection and policies.
+	GetInfo(ctx context.Context, in *arkrpc.GetInfoRequest,
+		opts ...grpc.CallOption) (*arkrpc.GetInfoResponse, error)
+}
+
+// ArkVersionNegotiator owns Ark protocol version selection against an operator
+// over its direct ArkService connection. It is the single home for the
+// version-compatibility decision logic; the daemon supplies the transport
+// client and parses domain terms out of the returned response.
+type ArkVersionNegotiator struct {
+	// client is the direct ArkService connection used for GetInfo.
+	client ArkVersionGetInfoClient
+
+	// clientSupported is the client's Ark protocol versions, ordered by
+	// preference, advertised to the operator during bootstrap.
+	clientSupported []uint32
+}
+
+// NewArkVersionNegotiator builds a negotiator over the given direct ArkService
+// client and the client's supported Ark protocol versions.
+func NewArkVersionNegotiator(client ArkVersionGetInfoClient,
+	clientSupported []uint32) *ArkVersionNegotiator {
+
+	return &ArkVersionNegotiator{
+		client:          client,
+		clientSupported: clientSupported,
+	}
+}
+
+// Bootstrap performs the single bootstrap GetInfo call that owns Ark protocol
+// version selection. It returns the operator's full response (so the caller
+// can parse domain terms from the same response without a second call) and the
+// selected version to bind to the runtime. It returns an error without
+// selecting a version when no compatible version exists, so the caller can
+// refuse to create the runtime.
+func (n *ArkVersionNegotiator) Bootstrap(ctx context.Context) (
+	*arkrpc.GetInfoResponse, uint32, error) {
+
+	if n.client == nil {
+		return nil, 0, fmt.Errorf("operator connection not initialized")
+	}
+
+	resp, err := n.client.GetInfo(ctx, &arkrpc.GetInfoRequest{
+		SupportedArkVersions: n.clientSupported,
+	})
+	if err != nil {
+		return nil, 0, fmt.Errorf("GetInfo RPC: %w", err)
+	}
+
+	selected, err := resolveArkVersionSelection(resp, n.clientSupported)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return resp, selected, nil
+}
+
+// resolveArkVersionSelection interprets a bootstrap GetInfo response against
+// the client's supported Ark protocol versions. It returns the version to bind
+// or an error when no compatible version exists. It is the single decision
+// point for runtime-version selection and is deliberately pure so it can be
+// unit-tested with fake responses.
+//
+// A non-zero selection is honored as long as the client supports it. A zero
+// selection always means no compatible version exists and is fatal — the
+// runtime must not be created. There is no legacy-server fallback: the client
+// and operator are deployed together, so the operator always returns an
+// explicit selection.
+func resolveArkVersionSelection(resp *arkrpc.GetInfoResponse,
+	clientSupported []uint32) (uint32, error) {
+
+	if resp == nil {
+		return 0, fmt.Errorf("nil GetInfo response")
+	}
+
+	// A zero selection means the operator advertised no common version (or
+	// is a pre-versioning server that cannot stamp the field). Either way
+	// it is fatal: the runtime must not be created.
+	if resp.SelectedArkVersion == 0 {
+		return 0, fmt.Errorf("no compatible ark protocol version "+
+			"(operator supports %v, client supports %v)",
+			activeArkVersions(resp), clientSupported)
+	}
+
+	// Honor the operator's selection as long as this client supports it.
+	if !slices.Contains(clientSupported, resp.SelectedArkVersion) {
+		return 0, fmt.Errorf("operator selected unsupported ark "+
+			"protocol version %d (client supports %v)",
+			resp.SelectedArkVersion, clientSupported)
+	}
+
+	// A contradictory operator response selects a version it simultaneously
+	// advertises as DISABLED. Fail closed: refuse to bind a runtime to a
+	// version the operator says is retired. Surface it as a permanent
+	// UPGRADE_REQUIRED status error carrying the operator's advertised
+	// enabled versions. An absent policy for the selected version is
+	// allowed (no contradiction), preserving compatibility with operators
+	// that advertise no policy for it.
+	policy := selectedArkPolicy(resp, resp.SelectedArkVersion)
+	if policy != nil &&
+		policy.State == arkrpc.ArkVersionPolicy_STATE_DISABLED {
+		return 0, disabledSelectionStatus(
+			"bootstrap", resp.SelectedArkVersion, resp,
+		)
+	}
+
+	return resp.SelectedArkVersion, nil
+}
+
+// ValidateRefreshSelection enforces that a refresh-only GetInfo response keeps
+// the runtime bound to boundVersion. A matching selection passes (returns nil).
+// Any other selection — zero, or a different non-zero version — is a terminal
+// compatibility failure, returned as a typed ARK_VERSION_MISMATCH StatusError
+// so callers can both classify it as permanent and surface actionable guidance.
+// There is no legacy fallback: the client and operator are deployed together.
+//
+// The status carries the operator's currently enabled versions.
+func ValidateRefreshSelection(resp *arkrpc.GetInfoResponse,
+	boundVersion uint32) *mailboxconn.StatusError {
+
+	if resp == nil {
+		return mailboxconn.NewStatusError("refresh", &mailboxpb.Status{
+			Ok:   false,
+			Code: mailboxconn.StatusArkVersionMismatch,
+			Message: fmt.Sprintf("operator refresh returned nil "+
+				"GetInfo response, runtime bound to %d",
+				boundVersion),
+		})
+	}
+
+	if resp.SelectedArkVersion == boundVersion {
+		// The operator re-selected the bound version, which is normally
+		// a successful refresh. But a contradictory response also
+		// advertises that same selected version as DISABLED. Fail
+		// closed: this is a terminal, mandatory-upgrade condition, so
+		// return a permanent UPGRADE_REQUIRED error. An absent policy
+		// is allowed (no contradiction), preserving compatibility with
+		// operators that advertise no policy for the bound version.
+		policy := selectedArkPolicy(resp, boundVersion)
+		if policy != nil &&
+			policy.State == arkrpc.ArkVersionPolicy_STATE_DISABLED {
+			return disabledSelectionStatus(
+				"refresh", boundVersion, resp,
+			)
+		}
+
+		return nil
+	}
+
+	return mailboxconn.NewStatusError("refresh", &mailboxpb.Status{
+		Ok:   false,
+		Code: mailboxconn.StatusArkVersionMismatch,
+		Message: fmt.Sprintf("operator refresh selected ark version "+
+			"%d, runtime bound to %d", resp.SelectedArkVersion,
+			boundVersion),
+		SupportedArkVersions: activeArkVersions(resp),
+	})
+}
+
+// disabledSelectionStatus builds the permanent UPGRADE_REQUIRED status error
+// returned when the operator selects an Ark protocol version it simultaneously
+// advertises as DISABLED. op names the originating path ("bootstrap" or
+// "refresh"); the operator's enabled versions are preserved so the daemon can
+// surface actionable guidance.
+func disabledSelectionStatus(op string, version uint32,
+	resp *arkrpc.GetInfoResponse) *mailboxconn.StatusError {
+
+	return mailboxconn.NewStatusError(op, &mailboxpb.Status{
+		Ok:   false,
+		Code: mailboxconn.StatusUpgradeRequired,
+		Message: fmt.Sprintf("operator selected ark protocol version "+
+			"%d but advertises it as disabled", version),
+		SupportedArkVersions: activeArkVersions(resp),
+	})
+}
+
+// selectedArkPolicy returns the policy advertised for the given version, or
+// nil if the operator advertised none.
+func selectedArkPolicy(resp *arkrpc.GetInfoResponse,
+	version uint32) *arkrpc.ArkVersionPolicy {
+
+	if resp == nil {
+		return nil
+	}
+
+	for _, policy := range resp.ArkVersionPolicies {
+		if policy != nil && policy.Version == version {
+			return policy
+		}
+	}
+
+	return nil
+}
+
+// activeArkVersions returns the operator's enabled (ACTIVE) Ark protocol
+// versions, read from the response's per-version policy list. The enabled set
+// is derived from the policies because every ACTIVE policy is an enabled
+// version. The result is used only for diagnostic messages and status errors,
+// never for selection, so policy order (version-sorted) rather than operator
+// preference order is acceptable here.
+func activeArkVersions(resp *arkrpc.GetInfoResponse) []uint32 {
+	if resp == nil {
+		return nil
+	}
+
+	var versions []uint32
+	for _, policy := range resp.ArkVersionPolicies {
+		if policy == nil {
+			continue
+		}
+
+		if policy.State == arkrpc.ArkVersionPolicy_STATE_ACTIVE {
+			versions = append(versions, policy.Version)
+		}
+	}
+
+	return versions
+}

--- a/serverconn/ark_version_test.go
+++ b/serverconn/ark_version_test.go
@@ -1,0 +1,229 @@
+package serverconn
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	"github.com/stretchr/testify/require"
+)
+
+// activeArkPolicy builds an ACTIVE policy for the given version, used to
+// populate the operator's advertised policy list in fake GetInfo responses.
+func activeArkPolicy(version uint32) *arkrpc.ArkVersionPolicy {
+	return &arkrpc.ArkVersionPolicy{
+		Version: version,
+		State:   arkrpc.ArkVersionPolicy_STATE_ACTIVE,
+	}
+}
+
+// disabledArkPolicy builds a DISABLED policy for the given version.
+func disabledArkPolicy(version uint32) *arkrpc.ArkVersionPolicy {
+	return &arkrpc.ArkVersionPolicy{
+		Version: version,
+		State:   arkrpc.ArkVersionPolicy_STATE_DISABLED,
+	}
+}
+
+// TestResolveArkVersionSelection covers the pure selection decision: normal
+// preference selection, an operator selecting an unsupported version, a zero
+// selection (no overlap or pre-versioning server) which is always fatal, and
+// a no-overlap response with a non-empty list.
+func TestResolveArkVersionSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		resp         *arkrpc.GetInfoResponse
+		client       []uint32
+		wantSelected uint32
+		wantErr      bool
+	}{
+		{
+			name: "normal v1 selection",
+			resp: &arkrpc.GetInfoResponse{
+				SelectedArkVersion: 1,
+			},
+			client: []uint32{
+				1,
+			},
+			wantSelected: 1,
+		},
+		{
+			name: "operator selects v2 client supports it",
+			resp: &arkrpc.GetInfoResponse{
+				SelectedArkVersion: 2,
+			},
+			client: []uint32{
+				1,
+				2,
+			},
+			wantSelected: 2,
+		},
+		{
+			name: "operator selects unsupported version",
+			resp: &arkrpc.GetInfoResponse{
+				SelectedArkVersion: 2,
+			},
+			client: []uint32{
+				1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero selection is fatal",
+			resp: &arkrpc.GetInfoResponse{},
+			client: []uint32{
+				1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "no overlap is fatal",
+			resp: &arkrpc.GetInfoResponse{
+				ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+					activeArkPolicy(2),
+					activeArkPolicy(3),
+				},
+			},
+			client: []uint32{
+				1,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			selected, err := resolveArkVersionSelection(
+				tc.resp, tc.client,
+			)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantSelected, selected)
+		})
+	}
+}
+
+// TestValidateRefreshSelection proves a refresh cannot renegotiate: it accepts
+// only a matching selection and treats any zero or different selection as a
+// terminal ARK_VERSION_MISMATCH. There is no legacy fallback.
+func TestValidateRefreshSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		boundArk uint32
+		resp     *arkrpc.GetInfoResponse
+		wantErr  bool
+	}{
+		{
+			name:     "matching v1",
+			boundArk: 1,
+			resp: &arkrpc.GetInfoResponse{
+				SelectedArkVersion: 1,
+			},
+		},
+		{
+			name:     "matching v2",
+			boundArk: 2,
+			resp: &arkrpc.GetInfoResponse{
+				SelectedArkVersion: 2,
+			},
+		},
+		{
+			name:     "v1 rejects zero selection",
+			boundArk: 1,
+			resp:     &arkrpc.GetInfoResponse{},
+			wantErr:  true,
+		},
+		{
+			name:     "v1 rejects nil response",
+			boundArk: 1,
+			resp:     nil,
+			wantErr:  true,
+		},
+		{
+			name:     "v1 rejects different selection",
+			boundArk: 1,
+			resp: &arkrpc.GetInfoResponse{
+				SelectedArkVersion: 2,
+			},
+			wantErr: true,
+		},
+		{
+			name:     "v2 rejects zero selection",
+			boundArk: 2,
+			resp:     &arkrpc.GetInfoResponse{},
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// ValidateRefreshSelection returns a typed pointer;
+			// compare the pointer directly to avoid the
+			// nil-interface pitfall.
+			statusErr := ValidateRefreshSelection(
+				tc.resp, tc.boundArk,
+			)
+			if tc.wantErr {
+				require.NotNil(t, statusErr)
+				require.Equal(
+					t, mailboxconn.StatusArkVersionMismatch,
+					statusErr.Code(),
+				)
+
+				return
+			}
+
+			require.Nil(t, statusErr)
+		})
+	}
+}
+
+// TestValidateRefreshSelectionSelectedButDisabled proves a refresh that
+// re-selects the bound version but advertises it as DISABLED is a terminal,
+// mandatory-upgrade failure: a permanent UPGRADE_REQUIRED status error,
+// distinct from the renegotiation mismatch path.
+func TestValidateRefreshSelectionSelectedButDisabled(t *testing.T) {
+	t.Parallel()
+
+	resp := &arkrpc.GetInfoResponse{
+		SelectedArkVersion: 1,
+		ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+			disabledArkPolicy(1),
+		},
+	}
+
+	statusErr := ValidateRefreshSelection(resp, 1)
+	require.NotNil(t, statusErr)
+	require.Equal(
+		t, mailboxconn.StatusUpgradeRequired, statusErr.Code(),
+	)
+}
+
+// TestValidateRefreshSelectionActivePolicyOk proves a matching selection with a
+// non-disabled (here ACTIVE) policy for the bound version is a normal, accepted
+// refresh — an advertised policy alone does not make a refresh fail.
+func TestValidateRefreshSelectionActivePolicyOk(t *testing.T) {
+	t.Parallel()
+
+	resp := &arkrpc.GetInfoResponse{
+		SelectedArkVersion: 1,
+		ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+			activeArkPolicy(1),
+		},
+	}
+
+	require.Nil(t, ValidateRefreshSelection(resp, 1))
+}

--- a/serverconn/compatibility.go
+++ b/serverconn/compatibility.go
@@ -1,0 +1,117 @@
+package serverconn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+)
+
+// edgeStatusCarrier is implemented by every mailbox edge RPC response
+// (SendResponse, PullResponse, AckUpToResponse). Its generated GetStatus
+// accessor is nil-safe, but callers dereference other response fields, so
+// edgeResponseError also guards against a nil response.
+type edgeStatusCarrier interface {
+	comparable
+
+	GetStatus() *mailboxpb.Status
+}
+
+// edgeResponseError centralizes the version/compatibility check that every edge
+// send and receive path would otherwise repeat. It maps an edge RPC outcome to
+// the single error a caller should return, or nil when resp is usable:
+//
+//   - a transport error is wrapped with op;
+//   - a nil response (e.g. from a mock edge) is reported as a transport error;
+//   - a non-OK mailbox Status becomes a *mailboxconn.StatusError tagged with
+//     op, so a permanent version status classifies and surfaces upstream.
+//
+// It deliberately does not drive the incompatibility transition itself: callers
+// pass the returned error to checkPermanentStatus wherever a permanent failure
+// must shed the client, so the send paths and the ingress loop keep their
+// existing transition points.
+func edgeResponseError[T edgeStatusCarrier](op string, resp T,
+	err error) error {
+
+	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+
+	var nilResp T
+	if resp == nilResp {
+		return fmt.Errorf("%s: nil response", op)
+	}
+
+	if st := resp.GetStatus(); st != nil && !st.Ok {
+		return mailboxconn.NewStatusError(op, st)
+	}
+
+	return nil
+}
+
+// compatibilityError returns the cached permanent version error if the
+// connector has transitioned to the terminal INCOMPATIBLE state, or nil while
+// it is still COMPATIBLE. Send paths consult this before contacting the edge.
+func (a *ServerConnectionActor) compatibilityError() *mailboxconn.StatusError {
+	return a.compatErr.Load()
+}
+
+// checkPermanentStatus inspects an error returned by an edge operation. If it
+// is a permanent version StatusError, it drives the terminal incompatibility
+// transition and returns true. Transient and non-status errors return false so
+// the existing retry policy still applies.
+func (a *ServerConnectionActor) checkPermanentStatus(ctx context.Context,
+	err error) bool {
+
+	if err == nil {
+		return false
+	}
+
+	var statusErr *mailboxconn.StatusError
+	if !errors.As(err, &statusErr) || !statusErr.IsPermanentVersion() {
+		return false
+	}
+
+	a.markIncompatible(ctx, statusErr)
+
+	return true
+}
+
+// markIncompatible performs the one-shot transition to the terminal
+// INCOMPATIBLE state. It caches the typed error, cancels ingress and heartbeat
+// processing asynchronously (so a calling ingress or heartbeat goroutine never
+// waits for itself), fails all pending unary waiters with the same error, and
+// invokes the optional compatibility callback exactly once. Subsequent calls
+// are no-ops.
+func (a *ServerConnectionActor) markIncompatible(ctx context.Context,
+	statusErr *mailboxconn.StatusError) {
+
+	if statusErr == nil {
+		return
+	}
+
+	a.compatOnce.Do(func() {
+		// Cache the error first so any concurrent send observes the
+		// terminal state immediately.
+		a.compatErr.Store(statusErr)
+
+		a.log.WarnS(ctx, "Connector became incompatible", statusErr)
+
+		// Cancel ingress and heartbeat without joining: this may run on
+		// the ingress goroutine itself. CancelFunc is idempotent.
+		if cancel := a.ingressCancel.Load(); cancel != nil {
+			(*cancel)()
+		}
+
+		// Fail every in-flight unary waiter so no caller blocks on a
+		// response that will never arrive.
+		a.responseRegistry.FailAll(statusErr)
+
+		// Notify the owner exactly once.
+		if a.cfg.OnIncompatible != nil {
+			a.cfg.OnIncompatible(statusErr)
+		}
+	})
+}

--- a/serverconn/compatibility_test.go
+++ b/serverconn/compatibility_test.go
@@ -1,0 +1,325 @@
+package serverconn
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// recordingEdge is a MailboxServiceClient that counts Send calls and returns a
+// configurable status, used to prove permanent-error handling without a real
+// transport.
+type recordingEdge struct {
+	sendCount  atomic.Int64
+	sendStatus *mailboxpb.Status
+}
+
+func (e *recordingEdge) Send(_ context.Context, _ *mailboxpb.SendRequest,
+	_ ...grpc.CallOption) (*mailboxpb.SendResponse, error) {
+
+	e.sendCount.Add(1)
+
+	return &mailboxpb.SendResponse{Status: e.sendStatus}, nil
+}
+
+func (e *recordingEdge) Pull(_ context.Context, _ *mailboxpb.PullRequest,
+	_ ...grpc.CallOption) (*mailboxpb.PullResponse, error) {
+
+	return &mailboxpb.PullResponse{Status: okStatus()}, nil
+}
+
+func (e *recordingEdge) AckUpTo(_ context.Context, _ *mailboxpb.AckUpToRequest,
+	_ ...grpc.CallOption) (*mailboxpb.AckUpToResponse, error) {
+
+	return &mailboxpb.AckUpToResponse{Status: okStatus()}, nil
+}
+
+// permanentStatus builds a permanent version status for tests.
+func permanentStatus() *mailboxpb.Status {
+	return &mailboxpb.Status{
+		Ok:      false,
+		Code:    mailboxconn.StatusUpgradeRequired,
+		Message: "client must upgrade",
+		SupportedArkVersions: []uint32{
+			2,
+		},
+	}
+}
+
+// TestMarkIncompatibleOnce proves that concurrent permanent failures cause
+// exactly one state transition and one callback, cache the typed error, and
+// fail pending unary waiters with that error.
+func TestMarkIncompatibleOnce(t *testing.T) {
+	t.Parallel()
+
+	var callbackCount atomic.Int64
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	cfg.OnIncompatible = func(*mailboxconn.StatusError) {
+		callbackCount.Add(1)
+	}
+
+	conn := NewServerConnectionActor(cfg)
+
+	// Register a unary waiter that must be failed by the transition.
+	corrID := CorrelationID("corr-1")
+	fut := conn.RegisterWaiter(corrID)
+
+	statusErr := mailboxconn.NewStatusError("Send", permanentStatus())
+
+	// Fire many concurrent permanent failures.
+	const racers = 16
+	var wg sync.WaitGroup
+	wg.Add(racers)
+	for i := 0; i < racers; i++ {
+		go func() {
+			defer wg.Done()
+
+			require.True(
+				t,
+				conn.checkPermanentStatus(
+					t.Context(), statusErr,
+				),
+			)
+		}()
+	}
+	wg.Wait()
+
+	// Exactly one transition and one callback.
+	require.Equal(t, int64(1), callbackCount.Load())
+	require.NotNil(t, conn.compatibilityError())
+	require.Equal(
+		t, mailboxconn.StatusUpgradeRequired,
+		conn.compatibilityError().Code(),
+	)
+
+	// The pending waiter received the same typed error.
+	res := fut.Await(t.Context())
+	require.Error(t, res.Err())
+	require.True(t, mailboxconn.IsPermanentVersionError(res.Err()))
+}
+
+// TestTransientStatusDoesNotMarkIncompatible proves a transient status does not
+// transition the connector, so the existing retry policy still applies.
+func TestTransientStatusDoesNotMarkIncompatible(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	conn := NewServerConnectionActor(cfg)
+
+	transient := mailboxconn.NewStatusError("Pull", &mailboxpb.Status{
+		Ok:   false,
+		Code: "UNAVAILABLE",
+	})
+	require.False(t, conn.checkPermanentStatus(t.Context(), transient))
+	require.Nil(t, conn.compatibilityError())
+}
+
+// TestSendShortCircuitsAfterIncompatible proves future sends return the cached
+// error without contacting the edge once the connector is incompatible.
+func TestSendShortCircuitsAfterIncompatible(t *testing.T) {
+	t.Parallel()
+
+	edge := &recordingEdge{sendStatus: okStatus()}
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	cfg.Edge = edge
+
+	conn := NewServerConnectionActor(cfg)
+
+	// Transition to incompatible directly.
+	conn.markIncompatible(
+		t.Context(),
+		mailboxconn.NewStatusError(
+			"Send", permanentStatus(),
+		),
+	)
+
+	// An event send must not contact the edge and must return the cached
+	// error.
+	res := conn.Receive(t.Context(), &SendClientEventRequest{
+		Message: &testServerMessage{value: "after-incompat"},
+	}, &fakeEgressExec{})
+	require.Error(t, res.Err())
+	require.True(t, mailboxconn.IsPermanentVersionError(res.Err()))
+
+	// The unary facade and heartbeat paths must also avoid the edge.
+	conn.sendHeartbeat(t.Context())
+
+	require.Equal(t, int64(0), edge.sendCount.Load())
+}
+
+// TestPermanentStatusFromEdgeMarksIncompatible proves that a permanent status
+// returned by the edge transitions the connector and invokes the callback
+// once, while the edge is contacted exactly once.
+func TestPermanentStatusFromEdgeMarksIncompatible(t *testing.T) {
+	t.Parallel()
+
+	var callbackCount atomic.Int64
+
+	edge := &recordingEdge{sendStatus: permanentStatus()}
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	cfg.Edge = edge
+	cfg.OnIncompatible = func(*mailboxconn.StatusError) {
+		callbackCount.Add(1)
+	}
+
+	conn := NewServerConnectionActor(cfg)
+
+	res := conn.Receive(t.Context(), &SendClientEventRequest{
+		Message: &testServerMessage{value: "permanent"},
+	}, &fakeEgressExec{})
+	require.Error(t, res.Err())
+	require.True(t, mailboxconn.IsPermanentVersionError(res.Err()))
+
+	require.Equal(t, int64(1), edge.sendCount.Load())
+	require.Equal(t, int64(1), callbackCount.Load())
+	require.NotNil(t, conn.compatibilityError())
+}
+
+// TestStartIngressRefusesWhenIncompatible proves that if the connector became
+// incompatible before ingress starts (e.g. a durable egress replay hit a
+// permanent error between StartEgress and StartIngress), StartIngress returns
+// the cached error and never starts polling — so the caller cannot mark the
+// connection healthy.
+func TestStartIngressRefusesWhenIncompatible(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	conn := NewServerConnectionActor(cfg)
+
+	conn.markIncompatible(
+		t.Context(),
+		mailboxconn.NewStatusError(
+			"Send", permanentStatus(),
+		),
+	)
+
+	err := conn.StartIngress(t.Context())
+	require.Error(t, err)
+	require.True(t, mailboxconn.IsPermanentVersionError(err))
+}
+
+// TestAwaitRPCShortCircuitsAfterIncompatible proves AwaitRPC returns the cached
+// error instead of blocking when incompatibility lands after a waiter was
+// pre-registered (by SendRPC) but before AwaitRPC runs.
+func TestAwaitRPCShortCircuitsAfterIncompatible(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	conn := NewServerConnectionActor(cfg)
+	facade := NewUnaryFacade(conn)
+
+	// Simulate SendRPC pre-registering the waiter, then incompatibility
+	// landing (which drains waiters via FailAll).
+	conn.RegisterWaiter(CorrelationID("corr-1"))
+	conn.markIncompatible(
+		t.Context(),
+		mailboxconn.NewStatusError(
+			"Send", permanentStatus(),
+		),
+	)
+
+	// A bounded context ensures a regression (blocking) fails fast instead
+	// of hanging the suite.
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	err := facade.AwaitRPC(ctx, "corr-1", &mailboxpb.Status{})
+	require.Error(t, err)
+	require.True(t, mailboxconn.IsPermanentVersionError(err))
+}
+
+// TestRuntimeMarkIncompatible proves the exported Runtime.MarkIncompatible
+// entry point drives the connector to its terminal state and fires the
+// callback, so side-channel detectors (such as a refresh-only GetInfo) can
+// transition the runtime.
+func TestRuntimeMarkIncompatible(t *testing.T) {
+	t.Parallel()
+
+	var callbackCount atomic.Int64
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	cfg.OnIncompatible = func(*mailboxconn.StatusError) {
+		callbackCount.Add(1)
+	}
+
+	rt, err := NewRuntime(cfg)
+	require.NoError(t, err)
+
+	rt.MarkIncompatible(
+		t.Context(),
+		mailboxconn.NewStatusError(
+			"refresh", permanentStatus(),
+		),
+	)
+
+	require.Equal(t, int64(1), callbackCount.Load())
+	require.NotNil(t, rt.Connector().compatibilityError())
+}
+
+// TestPermanentAwareTellRetryPolicy proves the durable retry policy treats a
+// permanent version error as non-retryable (dead-letter) while a transient
+// error keeps the default retry behavior.
+func TestPermanentAwareTellRetryPolicy(t *testing.T) {
+	t.Parallel()
+
+	permErr := mailboxconn.NewStatusError("Send", permanentStatus())
+	retry, _ := permanentAwareTellRetryPolicy(permErr, 0)
+	require.False(t, retry, "permanent error must not be retried")
+
+	transient := mailboxconn.NewStatusError("Send", &mailboxpb.Status{
+		Ok:   false,
+		Code: "UNAVAILABLE",
+	})
+	retry, _ = permanentAwareTellRetryPolicy(transient, 0)
+	require.True(t, retry, "transient error must still retry")
+}
+
+// TestDurableSendDeadLettersPermanentError proves a durable event whose send
+// returns a permanent version error is dead-lettered immediately rather than
+// retried.
+func TestDurableSendDeadLettersPermanentError(t *testing.T) {
+	t.Parallel()
+
+	edge := &recordingEdge{sendStatus: permanentStatus()}
+	mb := newInMemoryMailbox()
+	store := newMemCheckpointStore()
+	cfg := newTestConnectorConfig(mb, store)
+	cfg.Edge = edge
+
+	rt, err := NewRuntime(cfg)
+	require.NoError(t, err)
+
+	rt.StartEgress()
+	defer rt.Stop()
+
+	err = rt.TellRef().Tell(t.Context(), &SendClientEventRequest{
+		Message: &testServerMessage{value: "dead-letter"},
+	})
+	require.NoError(t, err)
+
+	actorID := DurableActorID(cfg.LocalMailboxID)
+	require.Eventually(t, func() bool {
+		letters, lErr := store.ListDeadLetters(t.Context(), actorID, 10)
+		require.NoError(t, lErr)
+
+		return len(letters) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// The edge was contacted at most once: there was no retry storm.
+	require.LessOrEqual(t, edge.sendCount.Load(), int64(1))
+}

--- a/serverconn/connector_test.go
+++ b/serverconn/connector_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -101,10 +102,11 @@ func sendResponseToMailbox(t *testing.T, mb *inMemoryMailbox, recipientID,
 	}
 
 	env := &mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          "server-1",
-		Recipient:       recipientID,
-		Body:            body,
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             "server-1",
+		Recipient:          recipientID,
+		Body:               body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			CorrelationId: correlationID,
@@ -130,10 +132,11 @@ func sendRoutedResponseToMailbox(t *testing.T, mb *inMemoryMailbox, recipientID,
 	}
 
 	env := &mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          "server-1",
-		Recipient:       recipientID,
-		Body:            body,
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             "server-1",
+		Recipient:          recipientID,
+		Body:               body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			CorrelationId: correlationID,
@@ -158,10 +161,11 @@ func sendRoutedErrorResponseToMailbox(t *testing.T, mb *inMemoryMailbox,
 	t.Helper()
 
 	env := &mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          "server-1",
-		Recipient:       recipientID,
-		Headers:         mailboxrpc.EncodeErrorHeaders(err),
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             "server-1",
+		Recipient:          recipientID,
+		Headers:            mailboxrpc.EncodeErrorHeaders(err),
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			CorrelationId: correlationID,
@@ -189,10 +193,11 @@ func sendEventToMailbox(t *testing.T, mb *inMemoryMailbox, recipientID, service,
 	require.NoError(t, err)
 
 	env := &mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          "server-1",
-		Recipient:       recipientID,
-		Body:            body,
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             "server-1",
+		Recipient:          recipientID,
+		Body:               body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:    mailboxpb.RpcMeta_KIND_EVENT,
 			Service: service,
@@ -459,10 +464,11 @@ func TestIngressAckHandledResponseWithoutActorDelivery(t *testing.T) {
 	require.NoError(t, err)
 
 	status := mb.send(&mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          "server-1",
-		Recipient:       "client-1",
-		Body:            body,
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             "server-1",
+		Recipient:          "client-1",
+		Body:               body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			CorrelationId: "stale-corr",
@@ -551,7 +557,7 @@ func TestIngress_NoAckOnDispatchFailure(t *testing.T) {
 
 			// Fail the first attempt, succeed thereafter.
 			if count == 1 {
-				return &statusError{
+				return &mailboxconn.StatusError{
 					Op: "dispatch",
 					Status: &mailboxpb.Status{
 						Ok:      false,
@@ -804,7 +810,7 @@ func TestIngress_PartialDispatch_NoDuplicateRedelivery(t *testing.T) {
 			// batch. The retry re-dispatches both envelopes
 			// (counts 3 and 4) and commits.
 			if count == 2 {
-				return &statusError{
+				return &mailboxconn.StatusError{
 					Op: "dispatch",
 					Status: &mailboxpb.Status{
 						Ok:      false,

--- a/serverconn/e2e_test.go
+++ b/serverconn/e2e_test.go
@@ -202,11 +202,12 @@ func (s *testServer) handleRequest(ctx context.Context,
 	}
 
 	responseEnv := &mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          s.serverMailboxID,
-		Recipient:       env.Rpc.ReplyTo,
-		Headers:         headers,
-		Body:            body,
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             s.serverMailboxID,
+		Recipient:          env.Rpc.ReplyTo,
+		Headers:            headers,
+		Body:               body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			CorrelationId: env.Rpc.CorrelationId,
@@ -228,10 +229,11 @@ func (s *testServer) pushEvent(t *testing.T, recipientID, service,
 	require.NoError(t, err)
 
 	env := &mailboxpb.Envelope{
-		ProtocolVersion: 1,
-		Sender:          s.serverMailboxID,
-		Recipient:       recipientID,
-		Body:            body,
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 1,
+		Sender:             s.serverMailboxID,
+		Recipient:          recipientID,
+		Body:               body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:    mailboxpb.RpcMeta_KIND_EVENT,
 			Service: service,

--- a/serverconn/heartbeat.go
+++ b/serverconn/heartbeat.go
@@ -77,6 +77,13 @@ func (a *ServerConnectionActor) startHeartbeat(ctx context.Context) {
 // envelope has no body — the service/method metadata is sufficient for
 // the server to recognise it as a liveness signal.
 func (a *ServerConnectionActor) sendHeartbeat(ctx context.Context) {
+	// Skip heartbeats once the connector is incompatible: the transition
+	// already cancelled this goroutine's context, but guard defensively so
+	// we never contact the edge after the terminal state.
+	if a.compatibilityError() != nil {
+		return
+	}
+
 	now := time.Now()
 
 	// Each heartbeat needs a unique MsgId to avoid deduplication
@@ -91,7 +98,6 @@ func (a *ServerConnectionActor) sendHeartbeat(ctx context.Context) {
 	)
 
 	envelope := &mailboxpb.Envelope{
-		ProtocolVersion: a.cfg.ProtocolVersion,
 		MsgId:           msgID,
 		Sender:          a.cfg.LocalMailboxID,
 		Recipient:       a.cfg.RemoteMailboxID,
@@ -108,10 +114,15 @@ func (a *ServerConnectionActor) sendHeartbeat(ctx context.Context) {
 	// Best-effort: log but don't fail. The server will mark us
 	// offline after the staleness threshold if heartbeats stop
 	// arriving.
-	_, err := a.cfg.Edge.Send(ctx, &mailboxpb.SendRequest{
+	resp, err := a.cfg.Edge.Send(ctx, &mailboxpb.SendRequest{
 		Envelope: envelope,
 	})
-	if err != nil {
-		a.log.WarnS(ctx, "Heartbeat send failed", err)
+
+	// Best-effort: log on any failure. A permanent version status on a
+	// heartbeat is terminal, just like on any other send path, so drive the
+	// incompatibility transition (a no-op for a plain transport error).
+	if sErr := edgeResponseError("heartbeat", resp, err); sErr != nil {
+		a.log.WarnS(ctx, "Heartbeat send failed", sErr)
+		a.checkPermanentStatus(ctx, sErr)
 	}
 }

--- a/serverconn/inbound_version.go
+++ b/serverconn/inbound_version.go
@@ -1,0 +1,66 @@
+package serverconn
+
+import (
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+)
+
+// validateInboundEnvelope checks that an inbound server envelope carries the
+// mailbox transport and Ark protocol versions bound to this runtime. It
+// returns a typed permanent version StatusError on mismatch so the ingress
+// loop refuses to acknowledge or dispatch the envelope and the connector can
+// classify the failure as permanent. A nil return means the envelope is
+// compatible and may be delivered.
+//
+// There is no legacy fallback: an inbound Ark version of zero is treated as a
+// mismatch like any other wrong version. The client and operator are deployed
+// together, so every authentic server envelope carries the negotiated version.
+func (a *ServerConnectionActor) validateInboundEnvelope(
+	env *mailboxpb.Envelope) error {
+
+	if env == nil {
+		return nil
+	}
+
+	// The mailbox transport version must match the bound transport version
+	// exactly. The transport is a stable code constant, so any difference
+	// means the envelope cannot be safely framed for this runtime.
+	if env.ProtocolVersion != a.cfg.MailboxProtocolVersion {
+		return mailboxconn.NewStatusError(
+			"inbound", a.inboundMismatchStatus(
+				mailboxconn.StatusMailboxVersionUnsupported,
+			),
+		)
+	}
+
+	// The Ark protocol version must match the bound version exactly.
+	if env.ArkProtocolVersion != a.cfg.ArkProtocolVersion {
+		return mailboxconn.NewStatusError(
+			"inbound", a.inboundMismatchStatus(
+				mailboxconn.StatusArkVersionMismatch,
+			),
+		)
+	}
+
+	return nil
+}
+
+// inboundMismatchStatus synthesizes the structured status carried by an
+// inbound version mismatch. It advertises the runtime's bound versions so the
+// failure is diagnosable and classifiable as permanent by the shared status
+// helper.
+func (a *ServerConnectionActor) inboundMismatchStatus(
+	code string) *mailboxpb.Status {
+
+	return &mailboxpb.Status{
+		Ok:      false,
+		Code:    code,
+		Message: "inbound envelope version mismatch",
+		SupportedMailboxVersions: []uint32{
+			a.cfg.MailboxProtocolVersion,
+		},
+		SupportedArkVersions: []uint32{
+			a.cfg.ArkProtocolVersion,
+		},
+	}
+}

--- a/serverconn/ingress.go
+++ b/serverconn/ingress.go
@@ -54,61 +54,14 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 		default:
 		}
 
-		// Step 1: Ack pending dispatches before pulling more. This
-		// allows the remote mailbox to garbage-collect already
-		// committed envelopes.
-		if state.NeedsAck() {
-			if err := a.ackRemote(
-				ctx, state.AckTarget,
-			); err != nil {
-
-				if isIngressShutdownErr(ctx, err) {
-					a.logIngressExit(ctx)
-
-					return
-				}
-
-				a.log.WarnS(ctx, "AckUpTo failed, retrying",
-					err,
-					slog.Uint64(
-						"ack_target", state.AckTarget,
-					))
-
-				a.sleepBackoff(ctx, &failCount)
-
-				continue
-			}
-
-			state.AdvanceAck()
-
-			// On the transactional path the advanced watermark is
-			// persisted by the next dispatch checkpoint (or the
-			// idle flush below); losing it to a crash only costs
-			// one redundant idempotent AckUpTo on restart. The
-			// legacy path keeps the immediate checkpoint.
-			if txOK {
-				ackDirty = true
-				failCount = 0
-			} else if err := a.saveCheckpoint(
-				ctx, state,
-			); err != nil {
-
-				a.log.WarnS(
-					ctx,
-					"Failed to save checkpoint after ack",
-					err,
-				)
-
-				// Don't reset failCount — if the checkpoint
-				// store is persistently down, we want backoff
-				// to apply on subsequent iterations rather
-				// than spinning at full speed.
-				a.sleepBackoff(ctx, &failCount)
-
-				continue
-			} else {
-				failCount = 0
-			}
+		// Step 1: Ack pending dispatches before pulling more so the
+		// remote mailbox can garbage-collect committed envelopes.
+		if exit, retry := a.ackPhase(
+			ctx, &state, &ackDirty, &failCount, txOK,
+		); exit {
+			return
+		} else if retry {
+			continue
 		}
 
 		// Step 2: Pull a batch of envelopes from the remote mailbox.
@@ -119,6 +72,12 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 			if isIngressShutdownErr(ctx, err) {
 				a.logIngressExit(ctx)
 
+				return
+			}
+
+			// A permanent version error is terminal: stop the loop
+			// rather than retrying forever.
+			if a.checkPermanentStatus(ctx, err) {
 				return
 			}
 
@@ -181,6 +140,17 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 				ctx, txStore, envelopes, nextCursor, state,
 			)
 			if foldErr != nil {
+				// A permanent inbound version mismatch is
+				// terminal: stop the loop WITHOUT advancing the
+				// cursor so the offending envelope is preserved
+				// and never acknowledged, matching the legacy
+				// dispatch path below. The production store is
+				// transactional, so this is the path a real
+				// daemon takes.
+				if a.checkPermanentStatus(ctx, foldErr) {
+					return
+				}
+
 				a.log.WarnS(ctx,
 					"Transactional dispatch failed",
 					foldErr,
@@ -209,6 +179,14 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 			ctx, envelopes, nextCursor,
 		)
 		if dispatchErr != nil {
+			// A permanent inbound version mismatch is terminal:
+			// stop the loop WITHOUT advancing the cursor so the
+			// offending envelope is preserved for a future
+			// compatible restart, and never acknowledged.
+			if a.checkPermanentStatus(ctx, dispatchErr) {
+				return
+			}
+
 			a.log.WarnS(ctx, "Dispatch failed",
 				dispatchErr,
 				slog.Uint64("committed_to", committedCursor),
@@ -265,6 +243,75 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 	}
 }
 
+// ackPhase acks any pending dispatches before the next pull so the remote
+// mailbox can garbage-collect committed envelopes. It mutates state, ackDirty,
+// and failCount in place and returns two loop-control booleans, (exit, retry):
+// exit is true when the loop must stop (local shutdown or a permanent version
+// error), and retry is true when the caller should back off and continue. On
+// the transactional path the advanced watermark is left dirty for the next
+// dispatch checkpoint (or idle flush) to persist; the legacy path checkpoints
+// inline.
+func (a *ServerConnectionActor) ackPhase(ctx context.Context, state *AckState,
+	ackDirty *bool, failCount *int, txOK bool) (bool, bool) {
+
+	if !state.NeedsAck() {
+		return false, false
+	}
+
+	if err := a.ackRemote(ctx, state.AckTarget); err != nil {
+		if isIngressShutdownErr(ctx, err) {
+			a.logIngressExit(ctx)
+
+			return true, false
+		}
+
+		// A permanent version error is terminal: stop the loop rather
+		// than retrying forever.
+		if a.checkPermanentStatus(ctx, err) {
+			return true, false
+		}
+
+		a.log.WarnS(ctx, "AckUpTo failed, retrying",
+			err,
+			slog.Uint64("ack_target", state.AckTarget),
+		)
+
+		a.sleepBackoff(ctx, failCount)
+
+		return false, true
+	}
+
+	state.AdvanceAck()
+
+	// On the transactional path the advanced watermark is persisted by the
+	// next dispatch checkpoint (or the idle flush); losing it to a crash
+	// only costs one redundant idempotent AckUpTo on restart. The legacy
+	// path keeps the immediate checkpoint.
+	if txOK {
+		*ackDirty = true
+		*failCount = 0
+
+		return false, false
+	}
+
+	if err := a.saveCheckpoint(ctx, *state); err != nil {
+		a.log.WarnS(
+			ctx, "Failed to save checkpoint after ack", err,
+		)
+
+		// Don't reset failCount — if the checkpoint store is
+		// persistently down, we want backoff to apply on subsequent
+		// iterations rather than spinning at full speed.
+		a.sleepBackoff(ctx, failCount)
+
+		return false, true
+	}
+
+	*failCount = 0
+
+	return false, false
+}
+
 // logIngressExit emits the common ingress shutdown log line.
 func (a *ServerConnectionActor) logIngressExit(ctx context.Context) {
 	a.log.InfoS(ctx, "Ingress loop exiting",
@@ -295,15 +342,8 @@ func (a *ServerConnectionActor) pullBatch(ctx context.Context, cursor uint64) (
 		WaitTimeoutMs: waitMs,
 		Cursor:        cursor,
 	})
-	if err != nil {
-		return nil, 0, err
-	}
-
-	if resp.Status != nil && !resp.Status.Ok {
-		return nil, 0, &statusError{
-			Op:     "Pull",
-			Status: resp.Status,
-		}
+	if sErr := edgeResponseError("Pull", resp, err); sErr != nil {
+		return nil, 0, sErr
 	}
 
 	return resp.Envelopes, resp.NextCursor, nil
@@ -331,6 +371,16 @@ func (a *ServerConnectionActor) dispatchBatch(ctx context.Context,
 	lastCommitted := uint64(0)
 
 	for _, env := range envelopes {
+		// Validate the envelope's version pair against the runtime
+		// binding before delivering it to any waiter or dispatcher. A
+		// mismatch is a permanent compatibility failure: stop the batch
+		// without advancing the ack cursor so the envelope is preserved
+		// for a future compatible restart, and never acknowledge or
+		// dispatch it.
+		if err := a.validateInboundEnvelope(env); err != nil {
+			return lastCommitted, err
+		}
+
 		if env.Rpc == nil {
 			a.log.WarnS(
 				ctx,
@@ -474,18 +524,8 @@ func (a *ServerConnectionActor) ackRemote(
 		MailboxId: a.cfg.LocalMailboxID,
 		Cursor:    cursor,
 	})
-	if err != nil {
-		return err
-	}
 
-	if resp.Status != nil && !resp.Status.Ok {
-		return &statusError{
-			Op:     "AckUpTo",
-			Status: resp.Status,
-		}
-	}
-
-	return nil
+	return edgeResponseError("AckUpTo", resp, err)
 }
 
 // loadCheckpoint restores the AckState from the checkpoint store on startup.
@@ -546,6 +586,18 @@ func (a *ServerConnectionActor) runFoldedDispatch(ctx context.Context,
 	responses, durables := splitIngressEnvelopes(
 		envelopes, a.hasResponseWaiter,
 	)
+
+	// Waiter-backed responses deliver in-memory BEFORE the transaction and
+	// so bypass dispatchBatch, which is where the durable partition is
+	// validated. Validate them against the bound version pair here so every
+	// inbound envelope is checked before dispatch, just like the legacy
+	// path. A mismatch is permanent and surfaces to the caller, which
+	// drives the terminal incompatibility transition.
+	for _, resp := range responses {
+		if err := a.validateInboundEnvelope(resp); err != nil {
+			return state, err
+		}
+	}
 
 	// Deliver the waiter-backed responses to their live waiters outside
 	// the transaction. Any whose waiter vanished since the split peek come
@@ -733,22 +785,4 @@ func (a *ServerConnectionActor) backoffConfig() mailboxpull.BackoffConfig {
 		BaseDelay: a.cfg.RetryBaseDelay,
 		MaxDelay:  a.cfg.RetryMaxDelay,
 	}
-}
-
-// statusError wraps a mailbox status failure for error reporting.
-type statusError struct {
-	// Op is the operation that failed (e.g., "Pull", "AckUpTo").
-	Op string
-
-	// Status is the status returned by the mailbox edge.
-	Status *mailboxpb.Status
-}
-
-// Error returns a human-readable error string.
-func (e *statusError) Error() string {
-	if e.Status == nil {
-		return e.Op + ": nil status"
-	}
-
-	return e.Op + ": " + e.Status.Message + " (" + e.Status.Code + ")"
 }

--- a/serverconn/ingress_error_test.go
+++ b/serverconn/ingress_error_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -130,7 +131,7 @@ func newErrorPathActor(
 	cfg.Store = store
 	cfg.LocalMailboxID = "client-1"
 	cfg.RemoteMailboxID = "server-1"
-	cfg.ProtocolVersion = 1
+	cfg.ArkProtocolVersion = 1
 
 	return NewServerConnectionActor(cfg)
 }
@@ -159,7 +160,7 @@ func TestPullBatch_StatusFailure(t *testing.T) {
 	_, _, err := actor.pullBatch(t.Context(), 0)
 	require.Error(t, err)
 
-	var stErr *statusError
+	var stErr *mailboxconn.StatusError
 	require.ErrorAs(t, err, &stErr)
 	require.Equal(t, "Pull", stErr.Op)
 	require.Contains(t, stErr.Error(), "TEMPORARY")
@@ -189,7 +190,7 @@ func TestAckRemote_StatusFailure(t *testing.T) {
 	err := actor.ackRemote(t.Context(), 1)
 	require.Error(t, err)
 
-	var stErr *statusError
+	var stErr *mailboxconn.StatusError
 	require.ErrorAs(t, err, &stErr)
 	require.Equal(t, "AckUpTo", stErr.Op)
 	require.Contains(t, stErr.Error(), "ack failed")
@@ -307,12 +308,12 @@ func TestSaveCheckpoint_Error(t *testing.T) {
 func TestStatusError_ErrorString(t *testing.T) {
 	t.Parallel()
 
-	errNil := (&statusError{
+	errNil := (&mailboxconn.StatusError{
 		Op: "AckUpTo",
 	}).Error()
 	require.Contains(t, errNil, "nil status")
 
-	errStatus := (&statusError{
+	errStatus := (&mailboxconn.StatusError{
 		Op: "Pull",
 		Status: &mailboxpb.Status{
 			Ok:      false,

--- a/serverconn/runtime.go
+++ b/serverconn/runtime.go
@@ -3,8 +3,11 @@ package serverconn
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 )
 
 // DurableActorID returns the durable actor mailbox ID used for serverconn
@@ -43,6 +46,20 @@ func NewRuntime(cfg ConnectorConfig) (*Runtime, error) {
 		return nil, fmt.Errorf("remote mailbox id is required")
 	}
 
+	// Mailbox transport v1 is the stable bootstrap endpoint represented by
+	// a code constant. Default it when unset so callers cannot accidentally
+	// start a runtime with a zero transport version.
+	if cfg.MailboxProtocolVersion == 0 {
+		cfg.MailboxProtocolVersion = mailboxpb.MailboxProtocolVersionV1
+	}
+
+	// The Ark protocol version is negotiated before the runtime exists and
+	// is bound here for the runtime's lifetime. A zero value means no
+	// version was selected, so refuse to construct the runtime.
+	if cfg.ArkProtocolVersion == 0 {
+		return nil, fmt.Errorf("ark protocol version must be non-zero")
+	}
+
 	if cfg.Codec == nil {
 		cfg.Codec = NewServerConnCodec()
 	}
@@ -62,6 +79,11 @@ func NewRuntime(cfg ConnectorConfig) (*Runtime, error) {
 	// historical single-sender behavior for callers that leave it unset.
 	durableCfg.NumWorkers = cfg.EgressWorkers
 
+	// A permanent version error is not retryable: dead-letter the failing
+	// durable message immediately instead of retrying it forever. All other
+	// (transient) failures keep the default exponential-backoff policy.
+	durableCfg.TellRetryPolicy = permanentAwareTellRetryPolicy
+
 	durable, err := actor.NewDurableActor(durableCfg).Unpack()
 	if err != nil {
 		return nil, err
@@ -73,6 +95,21 @@ func NewRuntime(cfg ConnectorConfig) (*Runtime, error) {
 		connector:    connector,
 		unary:        unary,
 	}, nil
+}
+
+// permanentAwareTellRetryPolicy is the durable actor's retry policy for
+// serverconn egress. A permanent version error is non-retryable, so the
+// failing durable message is dead-lettered immediately rather than retried
+// forever; every other (transient) failure keeps the default
+// exponential-backoff schedule.
+func permanentAwareTellRetryPolicy(err error,
+	attempts int) (bool, time.Duration) {
+
+	if mailboxconn.IsPermanentVersionError(err) {
+		return false, 0
+	}
+
+	return actor.DefaultTellRetryPolicy(err, attempts)
 }
 
 // Start launches durable egress processing and ingress pulling. Returns an
@@ -124,4 +161,24 @@ func (r *Runtime) Unary() *UnaryFacade {
 // Connector returns the underlying connector behavior.
 func (r *Runtime) Connector() *ServerConnectionActor {
 	return r.connector
+}
+
+// MarkIncompatible drives the runtime to its terminal incompatible state. It
+// is the exported entry point for callers outside the connector (such as a
+// refresh-only GetInfo that observes a changed selection) that detect a
+// permanent version failure on a side channel rather than on the mailbox edge.
+func (r *Runtime) MarkIncompatible(ctx context.Context,
+	statusErr *mailboxconn.StatusError) {
+
+	r.connector.markIncompatible(ctx, statusErr)
+}
+
+// StampEnvelope stamps the runtime's immutable mailbox transport and Ark
+// protocol versions onto a locally constructed envelope immediately before it
+// is sent. It is the shared stamping entry point for callers outside the
+// connector (such as the darepod mailbox response path) so every client send
+// path carries the runtime-bound version pair rather than copying a
+// caller-controlled value.
+func (r *Runtime) StampEnvelope(env *mailboxpb.Envelope) {
+	r.connector.cfg.stampEnvelope(env)
 }

--- a/serverconn/runtime_test.go
+++ b/serverconn/runtime_test.go
@@ -49,6 +49,56 @@ func TestNewRuntime_ValidateConfig(t *testing.T) {
 	)
 }
 
+// TestNewRuntimeArkVersionBinding verifies runtime construction rejects a zero
+// Ark protocol version and accepts an explicit v1 as well as a synthetic v2.
+// The synthetic v2 case proves selection and binding work without adding v2 to
+// any production default.
+func TestNewRuntimeArkVersionBinding(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+
+	baseCfg := func() ConnectorConfig {
+		cfg := DefaultConnectorConfig()
+		cfg.Store = newMemCheckpointStore()
+		cfg.Edge = &fakeMailboxServiceClient{mb: mb}
+		cfg.LocalMailboxID = "client-1"
+		cfg.RemoteMailboxID = "server-1"
+
+		return cfg
+	}
+
+	// A zero Ark protocol version is rejected: a runtime must always carry
+	// an explicit bound version.
+	zeroCfg := baseCfg()
+	zeroCfg.ArkProtocolVersion = 0
+	_, err := NewRuntime(zeroCfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ark protocol version")
+
+	// An explicit Ark v1 is accepted, and the default mailbox transport
+	// version is bound.
+	v1Cfg := baseCfg()
+	v1Cfg.ArkProtocolVersion = 1
+	rt, err := NewRuntime(v1Cfg)
+	require.NoError(t, err)
+	require.NotNil(t, rt)
+	require.Equal(
+		t, uint32(1), rt.Connector().cfg.ArkProtocolVersion,
+	)
+	require.NotZero(t, rt.Connector().cfg.MailboxProtocolVersion)
+
+	// A synthetic Ark v2 is accepted too, proving binding is not pinned to
+	// v1 even though no production default advertises v2.
+	v2Cfg := baseCfg()
+	v2Cfg.ArkProtocolVersion = 2
+	rt2, err := NewRuntime(v2Cfg)
+	require.NoError(t, err)
+	require.Equal(
+		t, uint32(2), rt2.Connector().cfg.ArkProtocolVersion,
+	)
+}
+
 // TestNewRuntime_DefaultCodec verifies runtime construction fills a default
 // codec when one is not supplied.
 func TestNewRuntime_DefaultCodec(t *testing.T) {

--- a/serverconn/testutil_test.go
+++ b/serverconn/testutil_test.go
@@ -1004,7 +1004,7 @@ func newTestConnectorConfig(
 	cfg.Store = store
 	cfg.LocalMailboxID = "client-1"
 	cfg.RemoteMailboxID = "server-1"
-	cfg.ProtocolVersion = 1
+	cfg.ArkProtocolVersion = 1
 	cfg.PullWaitTimeout = 50 * time.Millisecond
 
 	return cfg

--- a/serverconn/types.go
+++ b/serverconn/types.go
@@ -121,9 +121,18 @@ type ConnectorConfig struct {
 	// envelopes are addressed to this mailbox.
 	RemoteMailboxID string
 
-	// ProtocolVersion is the protocol version stamped on outbound
-	// envelopes.
-	ProtocolVersion uint32
+	// MailboxProtocolVersion is the immutable mailbox transport version
+	// stamped on every outbound envelope. It defines envelope framing and
+	// delivery semantics and is a stable code constant
+	// (mailboxpb.MailboxProtocolVersionV1), not a negotiated value.
+	MailboxProtocolVersion uint32
+
+	// ArkProtocolVersion is the immutable Ark protocol version negotiated
+	// through the direct GetInfo bootstrap RPC and bound to this runtime
+	// for its lifetime. It is stamped on every outbound envelope and
+	// validated on every inbound envelope. Runtime construction rejects a
+	// zero value: a runtime must always carry an explicit Ark version.
+	ArkProtocolVersion uint32
 
 	// Dispatchers maps (service, method) pairs to envelope dispatchers.
 	// The ingress loop uses this table to route KIND_REQUEST and
@@ -157,6 +166,13 @@ type ConnectorConfig struct {
 
 	// Log is an optional logger for this connector instance.
 	Log fn.Option[btclog.Logger]
+
+	// OnIncompatible is an optional callback invoked exactly once when the
+	// connector transitions to a terminal incompatible state after the
+	// first permanent version error. It receives the typed status error so
+	// the caller can surface structured compatibility details. It must not
+	// block; the connector invokes it inline on the transition.
+	OnIncompatible func(*mailboxconn.StatusError)
 
 	// PullMaxEnvelopes bounds the number of envelopes returned per Pull
 	// call.
@@ -289,16 +305,35 @@ func (c *ConnectorConfig) mergeAuthHeaders(
 // per-correlation-key FIFO claim.
 const DefaultEgressWorkers = 4
 
+// stampEnvelope stamps the runtime's immutable mailbox transport and Ark
+// protocol versions onto an envelope immediately before it is sent. It
+// overwrites any pre-existing version values so no send path — including a
+// pre-built or replayed envelope — can rely on a caller-provided Ark version.
+// The bound version pair is immutable for the runtime's lifetime, so
+// re-stamping a replayed envelope is always correct.
+func (c *ConnectorConfig) stampEnvelope(env *mailboxpb.Envelope) {
+	stampEnvelopeVersions(
+		env, c.MailboxProtocolVersion, c.ArkProtocolVersion,
+	)
+}
+
 // DefaultConnectorConfig returns a ConnectorConfig with sensible defaults for
 // polling and retry behavior. The caller must still set Edge, mailbox IDs,
 // and Store. Codec is optional — NewRuntime fills a default.
 func DefaultConnectorConfig() ConnectorConfig {
 	return ConnectorConfig{
-		PullMaxEnvelopes:  50,
-		PullWaitTimeout:   5 * time.Second,
-		RetryBaseDelay:    200 * time.Millisecond,
-		RetryMaxDelay:     30 * time.Second,
-		ResponseWaiterTTL: mailboxconn.DefaultResponseWaiterTTL,
-		EgressWorkers:     DefaultEgressWorkers,
+		// Mailbox transport v1 is the stable bootstrap endpoint, so the
+		// default is a code constant rather than a negotiated value.
+		// ArkProtocolVersion is intentionally left zero: the caller
+		// must set the negotiated Ark version, and NewRuntime rejects a
+		// zero value so a runtime can never start without an explicit
+		// Ark version binding.
+		MailboxProtocolVersion: mailboxpb.MailboxProtocolVersionV1,
+		PullMaxEnvelopes:       50,
+		PullWaitTimeout:        5 * time.Second,
+		RetryBaseDelay:         200 * time.Millisecond,
+		RetryMaxDelay:          30 * time.Second,
+		ResponseWaiterTTL:      mailboxconn.DefaultResponseWaiterTTL,
+		EgressWorkers:          DefaultEgressWorkers,
 	}
 }

--- a/serverconn/unary_facade.go
+++ b/serverconn/unary_facade.go
@@ -50,6 +50,12 @@ func (f *UnaryFacade) SendRPC(ctx context.Context,
 	method mailboxrpc.ServiceMethod, req proto.Message,
 	opts mailboxrpc.RPCOptions) (mailboxrpc.SendResult, error) {
 
+	// Once the connector is incompatible, fail new unary sends with the
+	// cached error without contacting the edge.
+	if ce := f.connector.compatibilityError(); ce != nil {
+		return mailboxrpc.SendResult{}, ce
+	}
+
 	cfg := f.connector.cfg
 
 	msgID, err := randomID(16)
@@ -88,7 +94,6 @@ func (f *UnaryFacade) SendRPC(ctx context.Context,
 	}
 
 	envelope := &mailboxpb.Envelope{
-		ProtocolVersion: cfg.ProtocolVersion,
 		MsgId:           msgID,
 		IdempotencyKey:  idempotencyKey,
 		Sender:          cfg.LocalMailboxID,
@@ -108,28 +113,14 @@ func (f *UnaryFacade) SendRPC(ctx context.Context,
 	resp, err := cfg.Edge.Send(ctx, &mailboxpb.SendRequest{
 		Envelope: envelope,
 	})
-	if err != nil {
+	if sendErr := edgeResponseError(
+		"send rpc request", resp, err,
+	); sendErr != nil {
+
 		f.connector.removeWaiter(corrID)
+		f.connector.checkPermanentStatus(ctx, sendErr)
 
 		f.connector.log.WarnS(ctx, "Unary send failed",
-			err,
-			slog.String("service", method.Service),
-			slog.String("method", method.Method),
-		)
-
-		return mailboxrpc.SendResult{}, fmt.Errorf("send rpc "+
-			"request: %w", err)
-	}
-
-	if resp.Status != nil && !resp.Status.Ok {
-		f.connector.removeWaiter(corrID)
-
-		sendErr := &statusError{
-			Op:     "Send",
-			Status: resp.Status,
-		}
-
-		f.connector.log.WarnS(ctx, "Unary send returned non-OK status",
 			sendErr,
 			slog.String("service", method.Service),
 			slog.String("method", method.Method),
@@ -164,6 +155,16 @@ func (f *UnaryFacade) AwaitRPC(ctx context.Context, correlationID string,
 	// ID, we get back the same (possibly already completed) Future.
 	future := f.connector.RegisterWaiter(corrID)
 	defer f.connector.removeWaiter(corrID)
+
+	// Recheck after registering to close the race with a concurrent
+	// markIncompatible: if incompatibility was cached before this register,
+	// we observe it here and return without blocking; if it lands after,
+	// the waiter is already in the registry and FailAll completes it.
+	// Either ordering returns the cached error rather than blocking
+	// forever.
+	if ce := f.connector.compatibilityError(); ce != nil {
+		return ce
+	}
 
 	result := future.Await(ctx)
 	if result.IsErr() {

--- a/serverconn/version_stamp.go
+++ b/serverconn/version_stamp.go
@@ -1,0 +1,84 @@
+package serverconn
+
+import (
+	"context"
+
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"google.golang.org/grpc"
+)
+
+// stampEnvelopeVersions writes the immutable mailbox transport and Ark protocol
+// version pair onto an envelope, overwriting any pre-existing values so no send
+// path can rely on a caller-provided version. A nil envelope is a no-op. It is
+// the single stamping implementation shared by the edge decorator and the
+// exported response-path entry point.
+func stampEnvelopeVersions(env *mailboxpb.Envelope, mailboxVersion,
+	arkVersion uint32) {
+
+	if env == nil {
+		return
+	}
+
+	env.ProtocolVersion = mailboxVersion
+	env.ArkProtocolVersion = arkVersion
+}
+
+// versionStampingMailboxClient is a MailboxServiceClient decorator that stamps
+// the runtime-bound version pair onto every outbound envelope before forwarding
+// to the wrapped edge. It centralizes stamping in one interceptor-style
+// location so no individual send path has to remember to stamp; only Send
+// carries an envelope, so Pull and AckUpTo forward unchanged. It mirrors the
+// auth decorator (authenticatedMailboxClient) layered over the same edge.
+type versionStampingMailboxClient struct {
+	next           mailboxpb.MailboxServiceClient
+	mailboxVersion uint32
+	arkVersion     uint32
+}
+
+// newVersionStampingMailboxClient wraps next so every Send stamps the given
+// immutable version pair. A nil next is returned unchanged so a connector built
+// without an edge (rejected later by NewRuntime) does not gain a non-nil
+// wrapper around a nil client.
+func newVersionStampingMailboxClient(next mailboxpb.MailboxServiceClient,
+	mailboxVersion, arkVersion uint32) mailboxpb.MailboxServiceClient {
+
+	if next == nil {
+		return nil
+	}
+
+	return &versionStampingMailboxClient{
+		next:           next,
+		mailboxVersion: mailboxVersion,
+		arkVersion:     arkVersion,
+	}
+}
+
+// Send stamps the envelope's version pair, then forwards to the wrapped edge.
+func (c *versionStampingMailboxClient) Send(ctx context.Context,
+	req *mailboxpb.SendRequest, opts ...grpc.CallOption) (
+	*mailboxpb.SendResponse, error) {
+
+	if req != nil {
+		stampEnvelopeVersions(
+			req.Envelope, c.mailboxVersion, c.arkVersion,
+		)
+	}
+
+	return c.next.Send(ctx, req, opts...)
+}
+
+// Pull forwards unchanged: a pull request carries no envelope to stamp.
+func (c *versionStampingMailboxClient) Pull(ctx context.Context,
+	req *mailboxpb.PullRequest, opts ...grpc.CallOption) (
+	*mailboxpb.PullResponse, error) {
+
+	return c.next.Pull(ctx, req, opts...)
+}
+
+// AckUpTo forwards unchanged: an ack request carries no envelope to stamp.
+func (c *versionStampingMailboxClient) AckUpTo(ctx context.Context,
+	req *mailboxpb.AckUpToRequest, opts ...grpc.CallOption) (
+	*mailboxpb.AckUpToResponse, error) {
+
+	return c.next.AckUpTo(ctx, req, opts...)
+}

--- a/serverconn/version_stamp_test.go
+++ b/serverconn/version_stamp_test.go
@@ -1,0 +1,470 @@
+package serverconn
+
+import (
+	"context"
+	"testing"
+
+	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// sentEnvelopes returns a snapshot of the envelopes delivered to the given
+// recipient mailbox.
+func sentEnvelopes(mb *inMemoryMailbox,
+	recipient string) []*mailboxpb.Envelope {
+
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	out := make([]*mailboxpb.Envelope, len(mb.mailboxes[recipient]))
+	copy(out, mb.mailboxes[recipient])
+
+	return out
+}
+
+// TestStampEnvelopeOverwrites proves the shared stamping helper writes the
+// bound version pair onto an envelope and overwrites any pre-existing
+// caller-provided version values, so no send path can rely on a caller version.
+func TestStampEnvelopeOverwrites(t *testing.T) {
+	t.Parallel()
+
+	cfg := ConnectorConfig{
+		MailboxProtocolVersion: 1,
+		ArkProtocolVersion:     2,
+	}
+
+	// A caller-provided envelope with bogus versions must be overwritten.
+	env := &mailboxpb.Envelope{
+		ProtocolVersion:    99,
+		ArkProtocolVersion: 99,
+	}
+	cfg.stampEnvelope(env)
+	require.Equal(t, uint32(1), env.ProtocolVersion)
+	require.Equal(t, uint32(2), env.ArkProtocolVersion)
+
+	// A nil envelope must not panic.
+	cfg.stampEnvelope(nil)
+}
+
+// capturingEdge records the last SendRequest it received and otherwise returns
+// empty OK responses. It is used to assert the stamping decorator's behavior in
+// isolation.
+type capturingEdge struct {
+	lastSend *mailboxpb.SendRequest
+	pulls    int
+	acks     int
+}
+
+func (e *capturingEdge) Send(_ context.Context, req *mailboxpb.SendRequest,
+	_ ...grpc.CallOption) (*mailboxpb.SendResponse, error) {
+
+	e.lastSend = req
+
+	return &mailboxpb.SendResponse{}, nil
+}
+
+func (e *capturingEdge) Pull(_ context.Context, _ *mailboxpb.PullRequest,
+	_ ...grpc.CallOption) (*mailboxpb.PullResponse, error) {
+
+	e.pulls++
+
+	return &mailboxpb.PullResponse{}, nil
+}
+
+func (e *capturingEdge) AckUpTo(_ context.Context, _ *mailboxpb.AckUpToRequest,
+	_ ...grpc.CallOption) (*mailboxpb.AckUpToResponse, error) {
+
+	e.acks++
+
+	return &mailboxpb.AckUpToResponse{}, nil
+}
+
+// TestVersionStampingMailboxClient proves the edge decorator overwrites any
+// caller-provided versions on Send, tolerates nil requests/envelopes, forwards
+// Pull and AckUpTo unchanged, and returns a nil next unwrapped.
+func TestVersionStampingMailboxClient(t *testing.T) {
+	t.Parallel()
+
+	const (
+		wantMailboxVersion = uint32(1)
+		wantArkVersion     = uint32(2)
+	)
+
+	edge := &capturingEdge{}
+	wrapped := newVersionStampingMailboxClient(
+		edge, wantMailboxVersion, wantArkVersion,
+	)
+
+	// A send with bogus caller versions must be overwritten and forwarded.
+	_, err := wrapped.Send(t.Context(), &mailboxpb.SendRequest{
+		Envelope: &mailboxpb.Envelope{
+			ProtocolVersion:    99,
+			ArkProtocolVersion: 99,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, edge.lastSend)
+	require.Equal(
+		t, wantMailboxVersion, edge.lastSend.Envelope.ProtocolVersion,
+	)
+	require.Equal(
+		t, wantArkVersion, edge.lastSend.Envelope.ArkProtocolVersion,
+	)
+
+	// A nil request must not panic and must still forward.
+	_, err = wrapped.Send(t.Context(), nil)
+	require.NoError(t, err)
+
+	// Pull and AckUpTo forward unchanged.
+	_, err = wrapped.Pull(t.Context(), &mailboxpb.PullRequest{})
+	require.NoError(t, err)
+	_, err = wrapped.AckUpTo(t.Context(), &mailboxpb.AckUpToRequest{})
+	require.NoError(t, err)
+	require.Equal(t, 1, edge.pulls)
+	require.Equal(t, 1, edge.acks)
+
+	// A nil next is returned unwrapped so a connector built without an edge
+	// does not gain a non-nil wrapper around a nil client.
+	require.Nil(t, newVersionStampingMailboxClient(nil, 1, 2))
+}
+
+// TestOutboundEnvelopesCarryBothVersions drives every client send path through
+// the actor with a synthetic Ark v2 binding and proves each emitted envelope
+// carries both the mailbox transport version and the Ark protocol version.
+// Covers event, durable unary request, pre-built replay, and heartbeat
+// envelopes. Synthetic v2 is configured only on this test connector, never in
+// a production default.
+func TestOutboundEnvelopesCarryBothVersions(t *testing.T) {
+	t.Parallel()
+
+	const (
+		wantMailboxVersion = uint32(1)
+		wantArkVersion     = uint32(2)
+	)
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+
+	// Bind a synthetic Ark v2 to prove stamping is not pinned to v1.
+	cfg.ArkProtocolVersion = wantArkVersion
+	cfg.MailboxProtocolVersion = wantMailboxVersion
+
+	conn := NewServerConnectionActor(cfg)
+	ctx := t.Context()
+
+	// Event envelope (durable client FSM outbox message).
+	res := conn.Receive(ctx, &SendClientEventRequest{
+		Message: &testServerMessage{value: "event"},
+	}, &fakeEgressExec{})
+	require.NoError(t, res.Err())
+
+	// Durable unary request envelope.
+	unaryReq, err := NewSendUnaryRequest(
+		mailboxrpc.ServiceMethod{
+			Service: testEventService,
+			Method:  testEventMethod,
+		},
+		wrapperspb.String("unary"), "corr-1",
+	)
+	require.NoError(t, err)
+	require.NoError(t, conn.Receive(ctx, unaryReq, &fakeEgressExec{}).Err())
+
+	// Pre-built (replay) envelope: deliberately constructed with zero
+	// versions to prove the re-stamp path overwrites a persisted value.
+	body, err := anypb.New(wrapperspb.String("replay"))
+	require.NoError(t, err)
+	prebuilt := &SendRPCRequest{
+		Envelope: &mailboxpb.Envelope{
+			ProtocolVersion:    0,
+			ArkProtocolVersion: 0,
+			Recipient:          cfg.RemoteMailboxID,
+			Body:               body,
+			Rpc: &mailboxpb.RpcMeta{
+				Kind:    mailboxpb.RpcMeta_KIND_REQUEST,
+				Service: testEventService,
+				Method:  testEventMethod,
+			},
+		},
+	}
+	require.NoError(t, conn.Receive(ctx, prebuilt, &fakeEgressExec{}).Err())
+
+	// Heartbeat envelope.
+	conn.sendHeartbeat(ctx)
+
+	// Every envelope delivered to the remote mailbox must carry both
+	// versions.
+	envs := sentEnvelopes(mb, cfg.RemoteMailboxID)
+	require.Len(t, envs, 4)
+	for i, env := range envs {
+		require.Equalf(
+			t, wantMailboxVersion, env.ProtocolVersion, "mailbox"+
+				" version on envelope %d", i,
+		)
+		require.Equalf(
+			t, wantArkVersion, env.ArkProtocolVersion, "ark "+
+				"version on envelope %d", i,
+		)
+	}
+}
+
+// TestRuntimeStampEnvelopeResponse proves the exported Runtime.StampEnvelope
+// entry point (used by the darepod mailbox response path) stamps a response
+// envelope with the runtime-bound pair rather than any caller value.
+func TestRuntimeStampEnvelopeResponse(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	cfg.ArkProtocolVersion = 2
+
+	rt, err := NewRuntime(cfg)
+	require.NoError(t, err)
+
+	responseEnv := &mailboxpb.Envelope{
+		ProtocolVersion:    7,
+		ArkProtocolVersion: 7,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind: mailboxpb.RpcMeta_KIND_RESPONSE,
+		},
+	}
+	rt.StampEnvelope(responseEnv)
+	require.Equal(t, uint32(1), responseEnv.ProtocolVersion)
+	require.Equal(t, uint32(2), responseEnv.ArkProtocolVersion)
+}
+
+// TestValidateInboundEnvelope covers the inbound validation matrix: a matching
+// pair passes; a transport mismatch, a non-zero Ark mismatch, and a zero Ark
+// version all fail.
+func TestValidateInboundEnvelope(t *testing.T) {
+	t.Parallel()
+
+	const (
+		codeMbx = mailboxconn.StatusMailboxVersionUnsupported
+		codeArk = mailboxconn.StatusArkVersionMismatch
+	)
+
+	tests := []struct {
+		name        string
+		boundArk    uint32
+		envMailbox  uint32
+		envArk      uint32
+		wantErr     bool
+		wantErrCode string
+	}{
+		{
+			name:       "matching v1",
+			boundArk:   1,
+			envMailbox: 1,
+			envArk:     1,
+		},
+		{
+			name:        "transport mismatch",
+			boundArk:    1,
+			envMailbox:  2,
+			envArk:      1,
+			wantErr:     true,
+			wantErrCode: codeMbx,
+		},
+		{
+			name:        "ark mismatch nonzero",
+			boundArk:    1,
+			envMailbox:  1,
+			envArk:      2,
+			wantErr:     true,
+			wantErrCode: codeArk,
+		},
+		{
+			name:        "ark zero is mismatch",
+			boundArk:    1,
+			envMailbox:  1,
+			envArk:      0,
+			wantErr:     true,
+			wantErrCode: codeArk,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mb := newInMemoryMailbox()
+			cfg := newTestConnectorConfig(
+				mb, newMemCheckpointStore(),
+			)
+			cfg.ArkProtocolVersion = tc.boundArk
+			cfg.MailboxProtocolVersion = 1
+
+			conn := NewServerConnectionActor(cfg)
+			env := &mailboxpb.Envelope{
+				ProtocolVersion:    tc.envMailbox,
+				ArkProtocolVersion: tc.envArk,
+			}
+
+			err := conn.validateInboundEnvelope(env)
+			if !tc.wantErr {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			require.True(
+				t, mailboxconn.IsPermanentVersionError(err),
+			)
+
+			var statusErr *mailboxconn.StatusError
+			require.ErrorAs(t, err, &statusErr)
+			require.Equal(t, tc.wantErrCode, statusErr.Code())
+		})
+	}
+}
+
+// TestDispatchBatchRejectsMismatchedEnvelope proves a mismatched inbound
+// envelope is neither dispatched nor acknowledged: dispatchBatch returns an
+// error, the dispatcher is never invoked, and the committed cursor does not
+// advance past the rejected envelope.
+func TestDispatchBatchRejectsMismatchedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	mb := newInMemoryMailbox()
+	cfg := newTestConnectorConfig(mb, newMemCheckpointStore())
+	cfg.ArkProtocolVersion = 1
+	cfg.MailboxProtocolVersion = 1
+
+	dispatched := false
+	svcMethod := mailboxrpc.ServiceMethod{
+		Service: testEventService,
+		Method:  testEventMethod,
+	}
+	var disp EnvelopeDispatcher = func(context.Context,
+		*mailboxpb.Envelope) error {
+
+		dispatched = true
+
+		return nil
+	}
+	cfg.Dispatchers = map[mailboxrpc.ServiceMethod]EnvelopeDispatcher{
+		svcMethod: disp,
+	}
+
+	conn := NewServerConnectionActor(cfg)
+
+	// An envelope bound for the dispatcher but carrying a mismatched Ark
+	// version must be rejected before dispatch.
+	env := &mailboxpb.Envelope{
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 2,
+		EventSeq:           5,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:    mailboxpb.RpcMeta_KIND_EVENT,
+			Service: testEventService,
+			Method:  testEventMethod,
+		},
+	}
+
+	committed, err := conn.dispatchBatch(
+		t.Context(), []*mailboxpb.Envelope{env}, 6,
+	)
+	require.Error(t, err)
+	require.True(t, mailboxconn.IsPermanentVersionError(err))
+	require.False(t, dispatched, "mismatched envelope was dispatched")
+
+	// The committed cursor must not advance past the rejected envelope, so
+	// the ack watermark cannot move and the envelope is preserved.
+	require.Less(t, committed, uint64(5))
+}
+
+// TestRunFoldedDispatchRejectsMismatchedEnvelope proves the transactional
+// ingress path (the production path: the delivery store is tx-aware) treats an
+// inbound version mismatch as a permanent error for BOTH a durable envelope and
+// a waiter-backed response, and that the returned error drives the terminal
+// incompatibility transition. This guards the gap where the folded path
+// previously surfaced the mismatch only as a transient fold error and looped
+// forever instead of shedding the connection.
+func TestRunFoldedDispatchRejectsMismatchedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	// A mismatched envelope carries the bound mailbox version but a wrong
+	// Ark version, so validateInboundEnvelope rejects it as permanent.
+	durableEnv := &mailboxpb.Envelope{
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 2,
+		EventSeq:           5,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:    mailboxpb.RpcMeta_KIND_EVENT,
+			Service: testEventService,
+			Method:  testEventMethod,
+		},
+	}
+	responseEnv := &mailboxpb.Envelope{
+		ProtocolVersion:    1,
+		ArkProtocolVersion: 2,
+		EventSeq:           5,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
+			CorrelationId: "corr-1",
+		},
+	}
+
+	tests := []struct {
+		name string
+		env  *mailboxpb.Envelope
+	}{
+		{
+			name: "durable event mismatch",
+			env:  durableEnv,
+		},
+		{
+			name: "waiter-backed response mismatch",
+			env:  responseEnv,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mb := newInMemoryMailbox()
+			store := newMemCheckpointStore()
+			cfg := newTestConnectorConfig(mb, store)
+			cfg.ArkProtocolVersion = 1
+			cfg.MailboxProtocolVersion = 1
+
+			conn := NewServerConnectionActor(cfg)
+
+			// Register a live waiter so a KIND_RESPONSE takes the
+			// fast pre-transaction path (the gap fix #2 closes).
+			if tc.env.Rpc.CorrelationId != "" {
+				conn.RegisterWaiter(
+					CorrelationID(tc.env.Rpc.CorrelationId),
+				)
+			}
+
+			_, err := conn.runFoldedDispatch(
+				t.Context(), store,
+				[]*mailboxpb.Envelope{tc.env},
+				tc.env.EventSeq+1, AckState{},
+			)
+			require.Error(t, err)
+			require.True(
+				t, mailboxconn.IsPermanentVersionError(err),
+			)
+
+			// The returned error must drive the terminal transition
+			// rather than being retried forever.
+			require.True(
+				t,
+				conn.checkPermanentStatus(
+					t.Context(), err,
+				),
+			)
+			require.NotNil(t, conn.compatibilityError())
+		})
+	}
+}

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -450,6 +450,18 @@ func newDirectedSendFixture(t *testing.T,
 		DustLimit:         testDustLimitSat,
 		MinOperatorFee:    testOperatorFeeSat,
 		MinConfirmations:  1,
+
+		// The operator must advertise and select an Ark protocol
+		// version, otherwise the client's bootstrap negotiation fails
+		// closed with "no compatible ark protocol version". The enabled
+		// versions are carried as ACTIVE policies.
+		SelectedArkVersion: arkrpc.ArkProtocolVersionV1,
+		ArkVersionPolicies: []*arkrpc.ArkVersionPolicy{
+			{
+				Version: arkrpc.ArkProtocolVersionV1,
+				State:   arkrpc.ArkVersionPolicy_STATE_ACTIVE,
+			},
+		},
 	}
 
 	operatorMailbox := serverconn.PubKeyMailboxID(


### PR DESCRIPTION
## Summary

PR A of the protocol-versioning work tracked by
https://github.com/lightninglabs/darepo/issues/526. It owns the protobuf
contract and all client-side behavior for the **Ark session protocol** version.
Production behavior remains Ark v1; this PR does not implement Ark v2 semantics.

## Scope

Ark **session protocol** negotiation and admission **only**. It does **not**
implement VTXO construction-version or script-version semantics (how a specific
VTXO is built and spent) — that is a separate, out-of-scope future concern.
There is no deprecation lifecycle, disable deadline, upgrade-URL signalling,
mailbox transport v2, or old-server fallback.

## What the client does

- advertises its supported Ark protocol versions during the direct `GetInfo`
  bootstrap;
- refuses startup unless the operator selects a compatible, non-disabled,
  non-zero version (an empty or no-overlap response is fatal — there is no
  fallback to v1);
- binds the selected Ark version and the mailbox transport version immutably to
  the mailbox runtime;
- stamps that bound pair onto every outbound envelope (durable replay, unary
  calls, events, heartbeats, and locally built responses);
- validates every inbound envelope against the bound pair before dispatch or
  acknowledgement;
- treats version failures as permanent: stops retries and ingress, fails
  pending callers, dead-letters the failed durable send, and reports the daemon
  disconnected;
- pins later `GetInfo` refreshes to the bound version and never renegotiates.

## Approach / structure

All version/compatibility logic is centralized in `serverconn`, the mailbox
connector, rather than spread across the daemon and the individual send/recv
paths:

- **Negotiation lives in `serverconn`.** `ArkVersionNegotiator` owns bootstrap
  version selection over the operator's direct `GetInfo`, and
  `ValidateRefreshSelection` owns the refresh-only check. The decision logic is
  pure and unit-tested; the daemon only supplies the gRPC client and parses
  domain terms from the response.
- **One response/status check.** Every dispatch/recv path funnels its edge
  outcome through a single `edgeResponseError` helper (transport error →
  nil-response guard → non-OK status → typed `StatusError`) instead of
  repeating the same checks at each call site.
- **Stamping via an edge interceptor.** Outbound version stamping is applied in
  one interceptor-style decorator wrapped around the mailbox edge (mirroring the
  existing auth decorator), so no individual send path can forget to stamp.

## Wire contract

`ArkVersionPolicy` carries a `version` and an `ACTIVE`/`DISABLED` `state`.
`GetInfoRequest` carries the client's `supported_ark_versions`.
`GetInfoResponse` carries `selected_ark_version` and the per-version
`ark_version_policies` — the operator's enabled set is simply its `ACTIVE`
policies, so there is no separate supported-versions response field. Every
`Envelope` carries `ark_protocol_version`. Permanent status codes:
`MAILBOX_VERSION_UNSUPPORTED`, `ARK_VERSION_UNSUPPORTED`, `ARK_VERSION_MISMATCH`,
`UPGRADE_REQUIRED`. Generated stubs come from `make rpc`.
