### PR TITLE
docs: nightly doc-gardening sweep 2026-06-16

### DIFF
--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -158,6 +158,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   `BoardingBackend`; lwwallet/btcwallet paths reach into `BtcWallet`
   directly, reinterpreting `wallet.LockID` as `wtxmgr.LockID` via
   direct `[32]byte` cast so leases round-trip across restart.
+- `OperatorPubKey(ctx) (*btcec.PublicKey, error)` (on `RPCServer`) —
+  Fetches the current operator public key via a live `GetInfo` RPC to
+  the server. Used by `swapclientserver` to provide the swap SDK with a
+  fresh key rather than the cached startup value.
 - `reserveCustomInputs` (on `RPCServer`) — atomically claims every
   custom OOR outpoint for a `SendOOR` call. Returns a release
   function (typically deferred).
@@ -285,11 +289,14 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   `vtxo.ManagerMsg` via `MapInputRef`. Compile-time assertions
   enforce that all `round.VTXOManagerMsg` implementors satisfy
   `vtxo.ManagerMsg`.
-- OOR receive-key is derived once at startup via
-  `EnsureDefaultOORReceiveScript` and persisted for restart-safe
-  re-registration. The `DurableUnaryBuilder` is wired through
-  `serverconn.ConnectorConfig` so all indexer queries flow through
-  the durable transport.
+- OOR receive-key uses `oorReceiveKeyFamily = 202` (within lnd's
+  pre-provisioned 0–255 account range). Values outside that range
+  require the master key to create the account on demand, which fails
+  on watch-only + remote-signer wallets with "address manager is
+  watching-only". Derived once at startup via `EnsureDefaultOORReceiveScript`
+  and persisted for restart-safe re-registration. The `DurableUnaryBuilder`
+  is wired through `serverconn.ConnectorConfig` so all indexer queries
+  flow through the durable transport.
 - The OOR artifact store backs three round/vtxo abstractions
   (`OwnedScriptChecker`, `OwnedScriptRegistrar`, `OwnedScriptLookup`).
   One logical "owned receive scripts" table; all ownership questions

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -158,6 +158,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   `BoardingBackend`; lwwallet/btcwallet paths reach into `BtcWallet`
   directly, reinterpreting `wallet.LockID` as `wtxmgr.LockID` via
   direct `[32]byte` cast so leases round-trip across restart.
+- `OperatorPubKey(ctx) (*btcec.PublicKey, error)` (on `RPCServer`) —
+  Fetches the current operator public key via a live `GetInfo` RPC to
+  the server. Used by `swapclientserver` to provide the swap SDK with a
+  fresh key rather than the cached startup value.
 - `reserveCustomInputs` (on `RPCServer`) — atomically claims every
   custom OOR outpoint for a `SendOOR` call. Returns a release
   function (typically deferred).
@@ -285,11 +289,14 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   `vtxo.ManagerMsg` via `MapInputRef`. Compile-time assertions
   enforce that all `round.VTXOManagerMsg` implementors satisfy
   `vtxo.ManagerMsg`.
-- OOR receive-key is derived once at startup via
-  `EnsureDefaultOORReceiveScript` and persisted for restart-safe
-  re-registration. The `DurableUnaryBuilder` is wired through
-  `serverconn.ConnectorConfig` so all indexer queries flow through
-  the durable transport.
+- OOR receive-key uses `oorReceiveKeyFamily = 202` (within lnd's
+  pre-provisioned 0–255 account range). Values outside that range
+  require the master key to create the account on demand, which fails
+  on watch-only + remote-signer wallets with "address manager is
+  watching-only". Derived once at startup via `EnsureDefaultOORReceiveScript`
+  and persisted for restart-safe re-registration. The `DurableUnaryBuilder`
+  is wired through `serverconn.ConnectorConfig` so all indexer queries
+  flow through the durable transport.
 - The OOR artifact store backs three round/vtxo abstractions
   (`OwnedScriptChecker`, `OwnedScriptRegistrar`, `OwnedScriptLookup`).
   One logical "owned receive scripts" table; all ownership questions

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -72,6 +72,19 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — two-stage
   OOR ancestry resolver (`oor_unroll_resolver.go`).
 - `LatestMigrationVersion = 17` — current schema version.
+- `InternalKeyQuerier` — Minimal sqlc interface (`UpsertInternalKey` +
+  `GetInternalKeyByID`) required by the internal-key registry helpers.
+  The sqlc-generated `*Queries` satisfies it, as does every consumer
+  store interface that embeds these two methods.
+- `RegisterInternalKeyTx(ctx, qtx, now, desc) int64` — Idempotently
+  upserts a `(pubkey, key_family, key_index)` triple into the shared
+  `internal_keys` table and returns its surrogate id. Called inside the
+  same transaction that writes the referencing row.
+- `InternalKeyDescByIDTx(ctx, qtx, id) keychain.KeyDescriptor` —
+  Hydrates a `KeyDescriptor` from a stored `internal_keys` id on load.
+  Returns `ErrInternalKeyNotFound` when no row matches.
+- `ErrInternalKeyPubKeyMissing` / `ErrInternalKeyNotFound` — Sentinels
+  for nil-pubkey registration and missing-id hydration errors.
 - `SpendingReservationPersistenceStore` — Persists the durable index of VTXO
   outpoints reserved by an active spend owner (e.g. an outgoing OOR session).
   A row exists IFF the owning session was durably checkpointed, so a startup
@@ -125,6 +138,14 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 
 ### Migration notes
 
+- `internal_keys` registry — A shared `internal_keys(id, pubkey,
+  key_family, key_index, created_at)` table was added to the existing
+  migrations 000002 (`boarding_tables`), 000003 (`round_tables`), and
+  000004 (`oor_artifact_store`). Each of those tables now carries a
+  `*_key_id BIGINT REFERENCES internal_keys(id)` FK in place of the
+  old inline `pubkey/key_family/key_index` columns. This avoids
+  duplicating key material and lets the daemon resolve `KeyDescriptor`
+  instances by id instead of re-deriving them from stored raw bytes.
 - `000017_spending_reservations` — adds `spending_reservations` table with
   `(outpoint_hash, outpoint_index)` PK, `owner_kind`, `owner_id`, and
   `created_at`. A row exists IFF the owning spend session was durably

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -72,6 +72,19 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — two-stage
   OOR ancestry resolver (`oor_unroll_resolver.go`).
 - `LatestMigrationVersion = 17` — current schema version.
+- `InternalKeyQuerier` — Minimal sqlc interface (`UpsertInternalKey` +
+  `GetInternalKeyByID`) required by the internal-key registry helpers.
+  The sqlc-generated `*Queries` satisfies it, as does every consumer
+  store interface that embeds these two methods.
+- `RegisterInternalKeyTx(ctx, qtx, now, desc) int64` — Idempotently
+  upserts a `(pubkey, key_family, key_index)` triple into the shared
+  `internal_keys` table and returns its surrogate id. Called inside the
+  same transaction that writes the referencing row.
+- `InternalKeyDescByIDTx(ctx, qtx, id) keychain.KeyDescriptor` —
+  Hydrates a `KeyDescriptor` from a stored `internal_keys` id on load.
+  Returns `ErrInternalKeyNotFound` when no row matches.
+- `ErrInternalKeyPubKeyMissing` / `ErrInternalKeyNotFound` — Sentinels
+  for nil-pubkey registration and missing-id hydration errors.
 - `SpendingReservationPersistenceStore` — Persists the durable index of VTXO
   outpoints reserved by an active spend owner (e.g. an outgoing OOR session).
   A row exists IFF the owning session was durably checkpointed, so a startup
@@ -125,6 +138,14 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 
 ### Migration notes
 
+- `internal_keys` registry — A shared `internal_keys(id, pubkey,
+  key_family, key_index, created_at)` table was added to the existing
+  migrations 000002 (`boarding_tables`), 000003 (`round_tables`), and
+  000004 (`oor_artifact_store`). Each of those tables now carries a
+  `*_key_id BIGINT REFERENCES internal_keys(id)` FK in place of the
+  old inline `pubkey/key_family/key_index` columns. This avoids
+  duplicating key material and lets the daemon resolve `KeyDescriptor`
+  instances by id instead of re-deriving them from stored raw bytes.
 - `000017_spending_reservations` — adds `spending_reservations` table with
   `(outpoint_hash, outpoint_index)` PK, `owner_kind`, `owner_id`, and
   `created_at`. A row exists IFF the owning spend session was durably

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -26,7 +26,13 @@ server during round participation. These types are used across `round`, `vtxo`,
   `TxProof fn.Option[proof.TxProof]` carries an optional SPV merkle
   inclusion proof for server-side verification of boarding UTXOs without
   requiring the server's own chain source.
-- `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount). `MaxOORLineageVBytes uint32` carries the operator-published cap on the cumulative on-chain vbytes a recipient must publish to claim a VTXO produced by an OOR submit unilaterally. Zero means no cap enforced server-side (clients fall back to a conservative local default).
+- `OperatorTerms` — Server-published round parameters (fee rates, expiry
+  config, connector dust amount). `MaxOORLineageVBytes uint32` carries the
+  operator-published cap on the cumulative on-chain vbytes a recipient must
+  publish to claim a VTXO produced by an OOR submit unilaterally. Zero means no
+  cap enforced server-side (clients fall back to a conservative local default).
+  Note: `ForfeitScript`, `SweepKey`, and `SweepDelay` were removed — these are
+  now delivered per-round in `round.CommitmentTxReceivedState`.
 - `Ancestry` — One rooted commitment-tree fragment contributing ancestry to a VTXO (defined in `lib/types/ancestry.go`). Fields: `TreePath *tree.Tree` (extracted root-to-leaf path), `CommitmentTxID chainhash.Hash`, `InputIndices []uint32` (Ark tx input indices this fragment serves; empty for round-direct VTXOs), `TreeDepth uint32`. Round-direct VTXOs carry a single-element slice; cross-round multi-input OOR VTXOs carry one entry per distinct commitment tx.
 - `MaxAncestryTreeDepth([]Ancestry) int` — Returns the largest `TreeDepth` across a slice; drives worst-case unilateral-exit timing calculations.
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.

--- a/lib/types/CLAUDE.md
+++ b/lib/types/CLAUDE.md
@@ -26,7 +26,13 @@ server during round participation. These types are used across `round`, `vtxo`,
   `TxProof fn.Option[proof.TxProof]` carries an optional SPV merkle
   inclusion proof for server-side verification of boarding UTXOs without
   requiring the server's own chain source.
-- `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount). `MaxOORLineageVBytes uint32` carries the operator-published cap on the cumulative on-chain vbytes a recipient must publish to claim a VTXO produced by an OOR submit unilaterally. Zero means no cap enforced server-side (clients fall back to a conservative local default).
+- `OperatorTerms` — Server-published round parameters (fee rates, expiry
+  config, connector dust amount). `MaxOORLineageVBytes uint32` carries the
+  operator-published cap on the cumulative on-chain vbytes a recipient must
+  publish to claim a VTXO produced by an OOR submit unilaterally. Zero means no
+  cap enforced server-side (clients fall back to a conservative local default).
+  Note: `ForfeitScript`, `SweepKey`, and `SweepDelay` were removed — these are
+  now delivered per-round in `round.CommitmentTxReceivedState`.
 - `Ancestry` — One rooted commitment-tree fragment contributing ancestry to a VTXO (defined in `lib/types/ancestry.go`). Fields: `TreePath *tree.Tree` (extracted root-to-leaf path), `CommitmentTxID chainhash.Hash`, `InputIndices []uint32` (Ark tx input indices this fragment serves; empty for round-direct VTXOs), `TreeDepth uint32`. Round-direct VTXOs carry a single-element slice; cross-round multi-input OOR VTXOs carry one entry per distinct commitment tx.
 - `MaxAncestryTreeDepth([]Ancestry) int` — Returns the largest `TreeDepth` across a slice; drives worst-case unilateral-exit timing calculations.
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -21,6 +21,17 @@ state transitions and validation rules live under [Invariants](#invariants).
   `PartialSigsSentState`, `ForfeitSignaturesCollectingState`,
   `InputSigSentState`, `ConfirmedState`, `ClientFailedState`,
   `RecoveryInitiatedState`.
+- `CommitmentTxReceivedState` — carries five per-round operator keys
+  delivered alongside the commitment tx (nil means old server; FSM
+  falls back to global `OperatorTerms` values):
+  `TreeCosignKey *btcec.PublicKey` (per-round MuSig2 tree cosigner),
+  `ConnectorOperatorKey *btcec.PublicKey` (connector tree rebuild key),
+  `SweepKey *btcec.PublicKey` (VTXO-tree sweep leaf key),
+  `SweepDelay uint32` (batch-wide absolute timelock in blocks),
+  `ForfeitKey *btcec.PublicKey` (BIP-86 forfeit penalty output key).
+  `CommitmentTxValidatedState` and `ForfeitSignaturesCollectingState`
+  carry `SweepDelay` and `ForfeitKey` forward through the signing
+  ceremony.
 - `ClientEvent` — sealed inbound event interface. Notable members:
   `JoinRoundQuoteReceived` (carries reseal `SealPass`), `QuoteAccepted`,
   `QuoteRejected`, `ForfeitCollectionTimedOut`, `ForfeitSignatureResponse`,
@@ -245,6 +256,14 @@ state transitions and validation rules live under [Invariants](#invariants).
   collaborative leaf when the live output uses a custom script policy;
   without it the VTXO actor would build a forfeit against the wrong
   tapscript branch.
+- **Per-round operator keys**: `TreeCosignKey`, `ConnectorOperatorKey`,
+  `SweepKey`, `SweepDelay`, and `ForfeitKey` are delivered per-round in
+  `CommitmentTxReceivedState` (not from global `OperatorTerms`). When
+  nil/zero, the FSM falls back to the corresponding global value so
+  pre-upgrade servers continue to work. Code that rebuilds VTXO trees,
+  connector trees, sweep branches, or forfeit penalty outputs MUST use
+  the per-round value from the state rather than reading from
+  `OperatorTerms` directly.
 
 ## Deep Docs
 

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -21,6 +21,17 @@ state transitions and validation rules live under [Invariants](#invariants).
   `PartialSigsSentState`, `ForfeitSignaturesCollectingState`,
   `InputSigSentState`, `ConfirmedState`, `ClientFailedState`,
   `RecoveryInitiatedState`.
+- `CommitmentTxReceivedState` — carries five per-round operator keys
+  delivered alongside the commitment tx (nil means old server; FSM
+  falls back to global `OperatorTerms` values):
+  `TreeCosignKey *btcec.PublicKey` (per-round MuSig2 tree cosigner),
+  `ConnectorOperatorKey *btcec.PublicKey` (connector tree rebuild key),
+  `SweepKey *btcec.PublicKey` (VTXO-tree sweep leaf key),
+  `SweepDelay uint32` (batch-wide absolute timelock in blocks),
+  `ForfeitKey *btcec.PublicKey` (BIP-86 forfeit penalty output key).
+  `CommitmentTxValidatedState` and `ForfeitSignaturesCollectingState`
+  carry `SweepDelay` and `ForfeitKey` forward through the signing
+  ceremony.
 - `ClientEvent` — sealed inbound event interface. Notable members:
   `JoinRoundQuoteReceived` (carries reseal `SealPass`), `QuoteAccepted`,
   `QuoteRejected`, `ForfeitCollectionTimedOut`, `ForfeitSignatureResponse`,
@@ -245,6 +256,14 @@ state transitions and validation rules live under [Invariants](#invariants).
   collaborative leaf when the live output uses a custom script policy;
   without it the VTXO actor would build a forfeit against the wrong
   tapscript branch.
+- **Per-round operator keys**: `TreeCosignKey`, `ConnectorOperatorKey`,
+  `SweepKey`, `SweepDelay`, and `ForfeitKey` are delivered per-round in
+  `CommitmentTxReceivedState` (not from global `OperatorTerms`). When
+  nil/zero, the FSM falls back to the corresponding global value so
+  pre-upgrade servers continue to work. Code that rebuilds VTXO trees,
+  connector trees, sweep branches, or forfeit penalty outputs MUST use
+  the per-round value from the state rather than reading from
+  `OperatorTerms` directly.
 
 ## Deep Docs
 

--- a/rpc/AGENTS.md
+++ b/rpc/AGENTS.md
@@ -7,7 +7,7 @@ Client-side RPC message definitions and HTTP transport in sub-packages:
 | Sub-package | Kind | Purpose |
 |-------------|------|---------|
 | `rpc/roundpb` | generated | Round protocol messages |
-| `rpc/oorpb` | generated | OOR transfer messages |
+| `rpc/oorpb` | mixed | OOR transfer messages (generated proto + handwritten payload helpers) |
 | `rpc/swapclientrpc` | generated | Swap client service stubs |
 | `rpc/walletdkrpc` | generated | Highest-level wallet service stubs |
 | `rpc/restclient` | hand-written | HTTP/protoJSON transport adapter |
@@ -24,5 +24,5 @@ Client-side RPC message definitions and HTTP transport in sub-packages:
 ## Invariants
 
 - **Never edit generated code** — regenerate via `make rpc`.
-- `rpc/restclient` is the only hand-written sub-package here; all others
-  are generated protobuf stubs.
+- `rpc/restclient` and `rpc/oorpb` are the only sub-packages with
+  hand-written Go; all other sub-packages are pure generated protobuf stubs.

--- a/rpc/CLAUDE.md
+++ b/rpc/CLAUDE.md
@@ -7,7 +7,7 @@ Client-side RPC message definitions and HTTP transport in sub-packages:
 | Sub-package | Kind | Purpose |
 |-------------|------|---------|
 | `rpc/roundpb` | generated | Round protocol messages |
-| `rpc/oorpb` | generated | OOR transfer messages |
+| `rpc/oorpb` | mixed | OOR transfer messages (generated proto + handwritten payload helpers) |
 | `rpc/swapclientrpc` | generated | Swap client service stubs |
 | `rpc/walletdkrpc` | generated | Highest-level wallet service stubs |
 | `rpc/restclient` | hand-written | HTTP/protoJSON transport adapter |
@@ -24,5 +24,5 @@ Client-side RPC message definitions and HTTP transport in sub-packages:
 ## Invariants
 
 - **Never edit generated code** — regenerate via `make rpc`.
-- `rpc/restclient` is the only hand-written sub-package here; all others
-  are generated protobuf stubs.
+- `rpc/restclient` and `rpc/oorpb` are the only sub-packages with
+  hand-written Go; all other sub-packages are pure generated protobuf stubs.

--- a/rpc/oorpb/AGENTS.md
+++ b/rpc/oorpb/AGENTS.md
@@ -1,0 +1,69 @@
+# rpc/oorpb
+
+## Purpose
+
+OOR (out-of-round) transfer gRPC stubs and handwritten payload helpers.
+Generated `*.pb.go` files define the proto message/service types; the
+handwritten `payloads.go` provides typed constructor and parser functions
+so callers never manipulate raw proto bytes directly.
+
+## Key Types
+
+All `*.pb.go` files are generated — never edit directly; regenerate with
+`make rpc`.
+
+The manually-maintained `payloads.go` defines:
+
+- `ServiceName` / `MethodSubmitPackage` / `MethodFinalizePackage` /
+  `MethodIncomingAck` — Mailbox RPC service and method name constants
+  used for OOR submit/finalize request-response routing.
+- `SigningDescriptor` — Domain type carrying the minimal signing
+  metadata the server OOR actor needs to co-sign checkpoint inputs:
+  `Outpoint wire.OutPoint`, `VTXOPolicyTemplate`, `SpendPath`, and
+  `OwnerLeafPolicy` (all serialized arkscript bytes).
+- `NewSubmitPackageRequest` / `ParseSubmitPackageRequest` —
+  Build/decode a `SubmitPackageRequest` from/to domain types
+  (`*psbt.Packet` Ark tx, `[]*psbt.Packet` checkpoints,
+  `[]SigningDescriptor`, `[]oortx.RecipientOutput`).
+- `NewSubmitPackageResponse` / `ParseSubmitPackageResponse` —
+  Build/decode the success branch of a `SubmitPackageResponse`.
+  `ParseSubmitPackageResponse` returns `*SubmitRejectedError` when the
+  response carries a rejection branch so callers can route on the typed
+  `OORRejectCode` without string-matching.
+- `NewSubmitPackageRejection` — Build the rejection branch of a
+  `SubmitPackageResponse` with a typed `OORRejectCode` and session id.
+- `SubmitRejectedError` — Error type wrapping `Code OORRejectCode` and
+  `Reason string`. Returned by `ParseSubmitPackageResponse`; callers
+  use `errors.As` to inspect the code.
+- `NewFinalizePackageRequest` / `ParseFinalizePackageRequest` —
+  Build/decode a `FinalizePackageRequest` (session id +
+  `[]*psbt.Packet` final checkpoints).
+- `NewFinalizePackageResponse` / `ParseFinalizePackageResponse` —
+  Build/decode a `FinalizePackageResponse` (session id echo).
+
+## Relationships
+
+- **Depends on**: `lib/tx/oor` (`RecipientOutput`),
+  `lib/tx/psbtutil` (PSBT serialization), `btcd/wire` (outpoints),
+  `btcd/btcutil/psbt`.
+- **Depended on by**: `oor` (builds submit/finalize requests and
+  decodes responses), `serverconn` (mailbox method dispatch using the
+  method name constants), `darepod` (registers event routes and
+  classifies rejections via `SubmitRejectedError`).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- `ParseSubmitPackageResponse` tolerates a missing `CoSignedArkPsbt`
+  (empty bytes) in the success branch so clients can talk to older
+  operators during a rolling upgrade; recovery flows surface the
+  absence at the recovery boundary, not on every submit.
+- The rejection branch echoes `session_id` so the ingress dispatcher
+  can route the failure to the correct OOR session FSM instead of
+  stalling the cursor on an undispatchable envelope.
+
+## Deep Docs
+
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent rpc package overview.
+- [oor/CLAUDE.md](../../oor/CLAUDE.md) — OOR actor using these helpers.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/rpc/oorpb/CLAUDE.md
+++ b/rpc/oorpb/CLAUDE.md
@@ -1,0 +1,69 @@
+# rpc/oorpb
+
+## Purpose
+
+OOR (out-of-round) transfer gRPC stubs and handwritten payload helpers.
+Generated `*.pb.go` files define the proto message/service types; the
+handwritten `payloads.go` provides typed constructor and parser functions
+so callers never manipulate raw proto bytes directly.
+
+## Key Types
+
+All `*.pb.go` files are generated — never edit directly; regenerate with
+`make rpc`.
+
+The manually-maintained `payloads.go` defines:
+
+- `ServiceName` / `MethodSubmitPackage` / `MethodFinalizePackage` /
+  `MethodIncomingAck` — Mailbox RPC service and method name constants
+  used for OOR submit/finalize request-response routing.
+- `SigningDescriptor` — Domain type carrying the minimal signing
+  metadata the server OOR actor needs to co-sign checkpoint inputs:
+  `Outpoint wire.OutPoint`, `VTXOPolicyTemplate`, `SpendPath`, and
+  `OwnerLeafPolicy` (all serialized arkscript bytes).
+- `NewSubmitPackageRequest` / `ParseSubmitPackageRequest` —
+  Build/decode a `SubmitPackageRequest` from/to domain types
+  (`*psbt.Packet` Ark tx, `[]*psbt.Packet` checkpoints,
+  `[]SigningDescriptor`, `[]oortx.RecipientOutput`).
+- `NewSubmitPackageResponse` / `ParseSubmitPackageResponse` —
+  Build/decode the success branch of a `SubmitPackageResponse`.
+  `ParseSubmitPackageResponse` returns `*SubmitRejectedError` when the
+  response carries a rejection branch so callers can route on the typed
+  `OORRejectCode` without string-matching.
+- `NewSubmitPackageRejection` — Build the rejection branch of a
+  `SubmitPackageResponse` with a typed `OORRejectCode` and session id.
+- `SubmitRejectedError` — Error type wrapping `Code OORRejectCode` and
+  `Reason string`. Returned by `ParseSubmitPackageResponse`; callers
+  use `errors.As` to inspect the code.
+- `NewFinalizePackageRequest` / `ParseFinalizePackageRequest` —
+  Build/decode a `FinalizePackageRequest` (session id +
+  `[]*psbt.Packet` final checkpoints).
+- `NewFinalizePackageResponse` / `ParseFinalizePackageResponse` —
+  Build/decode a `FinalizePackageResponse` (session id echo).
+
+## Relationships
+
+- **Depends on**: `lib/tx/oor` (`RecipientOutput`),
+  `lib/tx/psbtutil` (PSBT serialization), `btcd/wire` (outpoints),
+  `btcd/btcutil/psbt`.
+- **Depended on by**: `oor` (builds submit/finalize requests and
+  decodes responses), `serverconn` (mailbox method dispatch using the
+  method name constants), `darepod` (registers event routes and
+  classifies rejections via `SubmitRejectedError`).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+- `ParseSubmitPackageResponse` tolerates a missing `CoSignedArkPsbt`
+  (empty bytes) in the success branch so clients can talk to older
+  operators during a rolling upgrade; recovery flows surface the
+  absence at the recovery boundary, not on every submit.
+- The rejection branch echoes `session_id` so the ingress dispatcher
+  can route the failure to the correct OOR session FSM instead of
+  stalling the cursor on an undispatchable envelope.
+
+## Deep Docs
+
+- [rpc/CLAUDE.md](../CLAUDE.md) — Parent rpc package overview.
+- [oor/CLAUDE.md](../../oor/CLAUDE.md) — OOR actor using these helpers.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/swaps/AGENTS.md
+++ b/sdk/swaps/AGENTS.md
@@ -40,6 +40,11 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
   to sign receive invoices and decode the forwarded final-hop onion.
   Backed by `daemonReceiveAuthKey`, which delegates to `DaemonConn`
   RPCs rather than holding a raw private key in the SDK.
+- `OutSwapHtlcPart` — single MPP (multi-path payment) shard:
+  `AmountMsat lnwire.MilliSatoshi` and `OnionBlob []byte`. An
+  `OutSwapHtlcEvent` now carries a `Parts []OutSwapHtlcPart` slice so
+  the server can aggregate multi-part Lightning payments into one
+  out-swap event instead of one event per shard.
 - `IncomingVHTLCNotification` — unified type carrying either a
   Lightning-backed `OutSwapHtlcEvent` or a same-Ark `InArkHtlcEvent`,
   plus `AckCursor` and an `Ack` hook.
@@ -56,7 +61,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
 - `Store` — isolated SQLite persistence. Runs its own migration table
   (`swap_client_schema_migrations`) separate from the main daemon DB.
 - `SwapServerConn` / `GRPCSwapServerConn` — remote swap-server gRPC
-  (`RequestChannelID`, `CreateInSwap`).
+  interface; adds `AcknowledgeOutSwapHTLC(ctx, paymentHash, vhtlcPubkey)`
+  so the client can ack receipt of an out-swap HTLC event to the server
+  after durably persisting it.
 - `DaemonConn` — wallet operations (OOR sends, VTXO lookups, key
   queries, receive-auth signing/ECDH) provided by the Ark daemon.
   Includes `ReceiveAuthKey`, `SignReceiveAuthMessage[Compact]`, and

--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -40,6 +40,11 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
   to sign receive invoices and decode the forwarded final-hop onion.
   Backed by `daemonReceiveAuthKey`, which delegates to `DaemonConn`
   RPCs rather than holding a raw private key in the SDK.
+- `OutSwapHtlcPart` — single MPP (multi-path payment) shard:
+  `AmountMsat lnwire.MilliSatoshi` and `OnionBlob []byte`. An
+  `OutSwapHtlcEvent` now carries a `Parts []OutSwapHtlcPart` slice so
+  the server can aggregate multi-part Lightning payments into one
+  out-swap event instead of one event per shard.
 - `IncomingVHTLCNotification` — unified type carrying either a
   Lightning-backed `OutSwapHtlcEvent` or a same-Ark `InArkHtlcEvent`,
   plus `AckCursor` and an `Ack` hook.
@@ -56,7 +61,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/s
 - `Store` — isolated SQLite persistence. Runs its own migration table
   (`swap_client_schema_migrations`) separate from the main daemon DB.
 - `SwapServerConn` / `GRPCSwapServerConn` — remote swap-server gRPC
-  (`RequestChannelID`, `CreateInSwap`).
+  interface; adds `AcknowledgeOutSwapHTLC(ctx, paymentHash, vhtlcPubkey)`
+  so the client can ack receipt of an out-swap HTLC event to the server
+  after durably persisting it.
 - `DaemonConn` — wallet operations (OOR sends, VTXO lookups, key
   queries, receive-auth signing/ECDH) provided by the Ark daemon.
   Includes `ReceiveAuthKey`, `SignReceiveAuthMessage[Compact]`, and

--- a/swapclientserver/AGENTS.md
+++ b/swapclientserver/AGENTS.md
@@ -29,6 +29,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `receiveSessionAdapter` — Adds method accessors over
   `sdk/swaps.ReceiveSession` so both production code and tests share the same
   interface without exposing struct fields.
+- `liveOperatorDaemonConn` / `daemonWithLiveOperatorKey` — Thin wrapper
+  that overrides `DaemonConn.OperatorPubKey` with a live RPC fetcher
+  (`RPCServer.OperatorPubKey`) instead of the cached value held by the
+  Ark SDK facade. Applied in `Register` so vHTLC workflows that derive
+  keys from the operator pubkey always use the current value, not a
+  stale one captured at startup.
 - `Register(ctx, grpcServer, rpcServer, cfg)` — Top-level entry point called
   by a `swapruntime`-tagged `darepod` binary. Opens the daemon-owned SQLite
   swap store, dials `swapdk-server`, creates an in-process Ark SDK facade over

--- a/swapclientserver/CLAUDE.md
+++ b/swapclientserver/CLAUDE.md
@@ -29,6 +29,12 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - `receiveSessionAdapter` — Adds method accessors over
   `sdk/swaps.ReceiveSession` so both production code and tests share the same
   interface without exposing struct fields.
+- `liveOperatorDaemonConn` / `daemonWithLiveOperatorKey` — Thin wrapper
+  that overrides `DaemonConn.OperatorPubKey` with a live RPC fetcher
+  (`RPCServer.OperatorPubKey`) instead of the cached value held by the
+  Ark SDK facade. Applied in `Register` so vHTLC workflows that derive
+  keys from the operator pubkey always use the current value, not a
+  stale one captured at startup.
 - `Register(ctx, grpcServer, rpcServer, cfg)` — Top-level entry point called
   by a `swapruntime`-tagged `darepod` binary. Opens the daemon-owned SQLite
   swap store, dials `swapdk-server`, creates an in-process Ark SDK facade over

--- a/swaprpc/AGENTS.md
+++ b/swaprpc/AGENTS.md
@@ -1,0 +1,41 @@
+# swaprpc
+
+## Purpose
+
+Generated protobuf/gRPC stubs for the swap server protocol
+(`swaprpc/swap.proto`). Defines the wire types used by `sdk/swaps` to
+communicate with the remote swap server for Lightning-to-Ark receive
+swaps.
+
+## Key Proto Messages
+
+All `*.pb.go` files are generated — never edit directly; regenerate with
+`make rpc`.
+
+Notable messages added in recent proto revisions:
+
+- `AcknowledgeOutSwapHtlcRequest` / `AcknowledgeOutSwapHtlcResponse` —
+  Client acknowledges receipt of an out-swap HTLC event to the server
+  after durably persisting it. Carries `payment_hash` and
+  `client_vhtlc_pubkey`.
+- `OutSwapHtlcPart` — Single shard of a multi-path payment (MPP):
+  `amount_msat` and `onion_blob`. An `OutSwapHtlcEvent` now carries a
+  repeated `parts` field so the server can aggregate multi-part
+  Lightning payments into one out-swap event.
+
+## Relationships
+
+- **Depends on**: nothing (proto definitions only).
+- **Depended on by**: `sdk/swaps` (uses generated client stubs and
+  message types for swap server communication), `rpc/restclient`
+  (implements the service interface over HTTP/grpc-gateway).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+
+## Deep Docs
+
+- [sdk/swaps/CLAUDE.md](../sdk/swaps/CLAUDE.md) — Swap SDK using
+  these proto types.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/swaprpc/CLAUDE.md
+++ b/swaprpc/CLAUDE.md
@@ -1,0 +1,41 @@
+# swaprpc
+
+## Purpose
+
+Generated protobuf/gRPC stubs for the swap server protocol
+(`swaprpc/swap.proto`). Defines the wire types used by `sdk/swaps` to
+communicate with the remote swap server for Lightning-to-Ark receive
+swaps.
+
+## Key Proto Messages
+
+All `*.pb.go` files are generated — never edit directly; regenerate with
+`make rpc`.
+
+Notable messages added in recent proto revisions:
+
+- `AcknowledgeOutSwapHtlcRequest` / `AcknowledgeOutSwapHtlcResponse` —
+  Client acknowledges receipt of an out-swap HTLC event to the server
+  after durably persisting it. Carries `payment_hash` and
+  `client_vhtlc_pubkey`.
+- `OutSwapHtlcPart` — Single shard of a multi-path payment (MPP):
+  `amount_msat` and `onion_blob`. An `OutSwapHtlcEvent` now carries a
+  repeated `parts` field so the server can aggregate multi-part
+  Lightning payments into one out-swap event.
+
+## Relationships
+
+- **Depends on**: nothing (proto definitions only).
+- **Depended on by**: `sdk/swaps` (uses generated client stubs and
+  message types for swap server communication), `rpc/restclient`
+  (implements the service interface over HTTP/grpc-gateway).
+
+## Invariants
+
+- **Never edit generated code** — regenerate via `make rpc`.
+
+## Deep Docs
+
+- [sdk/swaps/CLAUDE.md](../sdk/swaps/CLAUDE.md) — Swap SDK using
+  these proto types.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -73,6 +73,14 @@ default builds avoid the swap executor's dependency graph.
   - ← API: `walletdkrpc.{Create,Unlock,Send,Recv,List,Balance,Deposit,
     Status,Exit,ExitStatus,SubscribeWallet}Request`
 
+### History internals
+
+- `collectForfeitedVTXOOutpoints` — queries `RPCServer.ListVTXOs` with
+  `VTXO_STATUS_FORFEITED` and returns a set of outpoint strings. Called
+  lazily by `List` when pending EXIT entries exist so that VTXO entries
+  already forfeited in the daemon are decorated as forfeited in the
+  wallet history view rather than appearing as pending.
+
 ## Invariants
 
 - Admin handlers (`Create`/`Unlock`/`Exit`/`ExitStatus`) are

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -73,6 +73,14 @@ default builds avoid the swap executor's dependency graph.
   - ← API: `walletdkrpc.{Create,Unlock,Send,Recv,List,Balance,Deposit,
     Status,Exit,ExitStatus,SubscribeWallet}Request`
 
+### History internals
+
+- `collectForfeitedVTXOOutpoints` — queries `RPCServer.ListVTXOs` with
+  `VTXO_STATUS_FORFEITED` and returns a set of outpoint strings. Called
+  lazily by `List` when pending EXIT entries exist so that VTXO entries
+  already forfeited in the daemon are decorated as forfeited in the
+  wallet history view rather than appearing as pending.
+
 ## Invariants
 
 - Admin handlers (`Create`/`Unlock`/`Exit`/`ExitStatus`) are


### PR DESCRIPTION
Automated nightly doc-gardening sweep for 2026-06-16.

## Summary

Per-package CLAUDE.md/AGENTS.md updates reflecting Go changes since
the last merged sweep (9ceba73):

- **db** - InternalKeyQuerier, RegisterInternalKeyTx, InternalKeyDescByIDTx;
  internal_keys registry added to migrations 000002-000004.
- **round** - Per-round keys in CommitmentTxReceivedState (TreeCosignKey,
  ConnectorOperatorKey, SweepKey, SweepDelay, ForfeitKey); new invariant
  on per-round key fallback.
- **lib/types** - OperatorTerms field removals noted (ForfeitScript,
  SweepKey, SweepDelay moved to per-round state).
- **sdk/swaps** - OutSwapHtlcPart (MPP payment shards);
  AcknowledgeOutSwapHTLC on SwapServerConn.
- **swapclientserver** - liveOperatorDaemonConn/daemonWithLiveOperatorKey.
- **swapwallet** - collectForfeitedVTXOOutpoints in pending history.
- **darepod** - OperatorPubKey() on RPCServer; oorReceiveKeyFamily=202
  constraint (lnd pre-provisioned account range).
- **rpc/oorpb** - New CLAUDE.md for this mixed generated+handwritten package.
- **swaprpc** - New CLAUDE.md for the generated swap proto package.
- **rpc** - Corrected rpc/oorpb label from "generated" to "mixed".

Please review the updated CLAUDE.md/AGENTS.md diffs before merging.