### PR TITLE
coinselect: unify coin selection, fix onchain send preview outflow

### DIFF
--- a/coinselect/selector.go
+++ b/coinselect/selector.go
@@ -1,0 +1,183 @@
+// Package coinselect provides a single, coin-type-agnostic coin-selection
+// algorithm shared across the client. It deliberately holds no wallet,
+// actor, or RPC dependencies so every layer that needs to pick a covering
+// subset of coins — the VTXO manager's reservation path and the swap
+// wallet's send preview alike — selects through the same code rather than
+// growing parallel implementations.
+package coinselect
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/btcsuite/btcd/btcutil"
+)
+
+// Selection errors. The selector stays policy-free: it reports why a pass
+// failed and the covered total, and leaves layer-specific diagnostics (for
+// example distinguishing locked liquidity from a true shortfall) to
+// callers.
+var (
+	// ErrSelectionShortfall means the candidate set cannot cover the
+	// requested target even when every candidate is selected. The
+	// returned Result.Total carries the full candidate sum so callers
+	// can render a precise message.
+	ErrSelectionShortfall = errors.New("insufficient candidates to cover " +
+		"target")
+
+	// ErrChangeBelowMin means a covering selection exists but its
+	// non-zero change falls below the requested minimum, and no
+	// exact-fit (zero-change) selection was found. The returned
+	// Result.Total carries the total at the first rejection point.
+	ErrChangeBelowMin = errors.New("selection change below minimum")
+
+	// ErrNoCandidates means selection was requested over an empty
+	// candidate set.
+	ErrNoCandidates = errors.New("no candidates to select")
+
+	// ErrInvalidTarget means a bounded selection was requested with a
+	// non-positive target.
+	ErrInvalidTarget = errors.New("selection target must be positive")
+)
+
+// Request parameterizes a coin-selection pass over a homogeneous candidate
+// set. Either Target (> 0) drives a bounded selection, or SweepAll selects
+// every candidate; SweepAll takes precedence and ignores Target and
+// MinChange.
+type Request struct {
+	// Target is the amount the selected candidates must cover. It is
+	// required and must be positive unless SweepAll is set, in which
+	// case it is ignored.
+	Target btcutil.Amount
+
+	// MinChange rejects a covering selection whose non-zero change is
+	// below this floor, continuing the search for an exact-fit set.
+	// Zero disables the constraint. An exact-fit selection
+	// (change == 0) is always accepted regardless of MinChange. Ignored
+	// when SweepAll is set.
+	MinChange btcutil.Amount
+
+	// SweepAll selects every candidate and ignores Target and MinChange.
+	SweepAll bool
+}
+
+// Result is the outcome of a coin-selection pass. On success it carries the
+// chosen subset; on the typed errors above it carries only the covered
+// Total so callers can build precise diagnostics.
+type Result[T any] struct {
+	// Selected is the chosen subset (or every candidate for a sweep), in
+	// selection order: largest-first for a bounded selection, input
+	// order for a sweep.
+	Selected []T
+
+	// Total is the summed amount of Selected.
+	Total btcutil.Amount
+
+	// Change is Total - Target for a bounded selection. It is zero for a
+	// sweep-all, where the caller owns the single output value.
+	Change btcutil.Amount
+}
+
+// AmountFunc extracts the satoshi value of a candidate. Callers supply it
+// so the selector stays agnostic to the concrete coin type (a VTXO
+// Descriptor, an RPC VTXO, a boarding intent, and so on).
+type AmountFunc[T any] func(T) btcutil.Amount
+
+// LargestFirst runs largest-first coin selection. Candidates are sorted by
+// descending amount and accumulated until the target is covered. When
+// MinChange is set, a covering selection whose change would be non-zero but
+// below MinChange is rejected in favour of accumulating further until the
+// change clears MinChange; if no covering selection leaves change at or
+// above MinChange, ErrChangeBelowMin is returned. An exact (zero-change)
+// fit is always accepted. A SweepAll request selects every candidate
+// regardless of Target.
+//
+// The caller's slice is never mutated; sorting happens on a copy. On
+// failure the returned error is one of the typed errors in this file and
+// the Result carries the relevant covered total.
+func LargestFirst[T any](candidates []T, amount AmountFunc[T],
+	req Request) (Result[T], error) {
+
+	if req.SweepAll {
+		return selectAll(candidates, amount)
+	}
+
+	if req.Target <= 0 {
+		return Result[T]{}, ErrInvalidTarget
+	}
+	if len(candidates) == 0 {
+		return Result[T]{}, ErrNoCandidates
+	}
+
+	// Sort a copy by descending amount so the caller's slice is left
+	// untouched and selection is deterministic for distinct amounts.
+	sorted := make([]T, len(candidates))
+	copy(sorted, candidates)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return amount(sorted[i]) > amount(sorted[j])
+	})
+
+	var (
+		total           btcutil.Amount
+		rejectedTotal   btcutil.Amount
+		rejectedForDust bool
+	)
+
+	// At most every candidate is selected, so size the slice up front to
+	// avoid re-allocating its backing array as we accumulate.
+	selected := make([]T, 0, len(sorted))
+	for _, c := range sorted {
+		selected = append(selected, c)
+		total += amount(c)
+
+		if total < req.Target {
+			continue
+		}
+
+		// Accept an exact fit, or any change at or above the floor
+		// (a zero floor disables the dust check entirely).
+		change := total - req.Target
+		if change == 0 || req.MinChange == 0 ||
+			change >= req.MinChange {
+			return Result[T]{
+				Selected: selected,
+				Total:    total,
+				Change:   change,
+			}, nil
+		}
+
+		// The selection covers the target but leaves dust change.
+		// Remember the first such point and keep accumulating: adding
+		// more value only grows the change, so a deeper selection may
+		// clear MinChange (a dust-safe fit), though it can never return
+		// to an exact zero-change fit.
+		if !rejectedForDust {
+			rejectedTotal = total
+			rejectedForDust = true
+		}
+	}
+
+	if rejectedForDust {
+		return Result[T]{Total: rejectedTotal}, ErrChangeBelowMin
+	}
+
+	return Result[T]{Total: total}, ErrSelectionShortfall
+}
+
+// selectAll returns every candidate and their summed amount, modelling a
+// sweep where no target or change applies.
+func selectAll[T any](candidates []T, amount AmountFunc[T]) (Result[T], error) {
+	if len(candidates) == 0 {
+		return Result[T]{}, ErrNoCandidates
+	}
+
+	selected := make([]T, len(candidates))
+	copy(selected, candidates)
+
+	var total btcutil.Amount
+	for _, c := range selected {
+		total += amount(c)
+	}
+
+	return Result[T]{Selected: selected, Total: total}, nil
+}

--- a/coinselect/selector_test.go
+++ b/coinselect/selector_test.go
@@ -1,0 +1,212 @@
+package coinselect
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/stretchr/testify/require"
+)
+
+// coin is a minimal candidate type for exercising the selector without
+// pulling in any wallet types.
+type coin struct {
+	id     int
+	amount btcutil.Amount
+}
+
+// coinAmount is the AmountFunc for the test coin type.
+func coinAmount(c coin) btcutil.Amount {
+	return c.amount
+}
+
+// coins builds a candidate slice from the given amounts, assigning each a
+// distinct id so selection identity is observable.
+func coins(amounts ...btcutil.Amount) []coin {
+	out := make([]coin, len(amounts))
+	for i, a := range amounts {
+		out[i] = coin{id: i, amount: a}
+	}
+
+	return out
+}
+
+// TestLargestFirstBounded exercises bounded largest-first selection:
+// ordering, exact fit, multi-input coverage, and the dust-change search.
+func TestLargestFirstBounded(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		amounts   []btcutil.Amount
+		target    btcutil.Amount
+		minChange btcutil.Amount
+		wantCount int
+		wantTotal btcutil.Amount
+		wantErr   error
+	}{
+		{
+			name: "single covers target",
+			amounts: []btcutil.Amount{
+				50000,
+				30000,
+				10000,
+			},
+			target:    40000,
+			wantCount: 1,
+			wantTotal: 50000,
+		},
+		{
+			name: "largest first picks biggest",
+			amounts: []btcutil.Amount{
+				10000,
+				50000,
+				30000,
+			},
+			target:    45000,
+			wantCount: 1,
+			wantTotal: 50000,
+		},
+		{
+			name: "two inputs needed",
+			amounts: []btcutil.Amount{
+				30000,
+				25000,
+				10000,
+			},
+			target:    50000,
+			wantCount: 2,
+			wantTotal: 55000,
+		},
+		{
+			name: "exact fit zero change",
+			amounts: []btcutil.Amount{
+				50000,
+			},
+			target:    50000,
+			wantCount: 1,
+			wantTotal: 50000,
+		},
+		{
+			name: "shortfall",
+			amounts: []btcutil.Amount{
+				20000,
+				10000,
+			},
+			target:    50000,
+			wantTotal: 30000,
+			wantErr:   ErrSelectionShortfall,
+		},
+		{
+			name:    "empty candidates",
+			amounts: nil,
+			target:  1000,
+			wantErr: ErrNoCandidates,
+		},
+		{
+			name: "non-positive target",
+			amounts: []btcutil.Amount{
+				1000,
+			},
+			target:  0,
+			wantErr: ErrInvalidTarget,
+		},
+		{
+			// 50000 covers 49900 but leaves 100 change, below the
+			// 1000 floor; no deeper exact fit exists, so the pass
+			// fails with the rejected total surfaced.
+			name: "dust change rejected no exact fit",
+			amounts: []btcutil.Amount{
+				50000,
+			},
+			target:    49900,
+			minChange: 1000,
+			wantTotal: 50000,
+			wantErr:   ErrChangeBelowMin,
+		},
+		{
+			// 30000 leaves dust change for target 30100, but adding
+			// the 100 yields an exact (zero-change) fit, which is
+			// always accepted.
+			name: "dust rejected then exact fit found",
+			amounts: []btcutil.Amount{
+				30000,
+				100,
+			},
+			target:    30100,
+			minChange: 1000,
+			wantCount: 2,
+			wantTotal: 30100,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := LargestFirst(
+				coins(tc.amounts...), coinAmount, Request{
+					Target:    tc.target,
+					MinChange: tc.minChange,
+				},
+			)
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Nil(t, res.Selected)
+				require.Equal(t, tc.wantTotal, res.Total)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, res.Selected, tc.wantCount)
+			require.Equal(t, tc.wantTotal, res.Total)
+			require.Equal(t, tc.wantTotal-tc.target, res.Change)
+			require.GreaterOrEqual(
+				t, int64(res.Total), int64(tc.target),
+			)
+		})
+	}
+}
+
+// TestLargestFirstSweepAll verifies sweep-all selects every candidate, sums
+// them, and reports zero change regardless of input order.
+func TestLargestFirstSweepAll(t *testing.T) {
+	t.Parallel()
+
+	res, err := LargestFirst(
+		coins(10000, 50000, 30000), coinAmount, Request{
+			SweepAll: true,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, res.Selected, 3)
+	require.Equal(t, btcutil.Amount(90000), res.Total)
+	require.Equal(t, btcutil.Amount(0), res.Change)
+}
+
+// TestSweepAllEmpty verifies a sweep over no candidates is an error, never a
+// silent empty success.
+func TestSweepAllEmpty(t *testing.T) {
+	t.Parallel()
+
+	_, err := LargestFirst(coins(), coinAmount, Request{SweepAll: true})
+	require.ErrorIs(t, err, ErrNoCandidates)
+}
+
+// TestLargestFirstDoesNotMutateInput guards the contract that the caller's
+// candidate slice ordering is never disturbed by the internal sort.
+func TestLargestFirstDoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	candidates := coins(10000, 50000, 30000)
+	before := append([]coin(nil), candidates...)
+
+	_, err := LargestFirst(
+		candidates, coinAmount, Request{
+			Target: 40000,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, before, candidates)
+}

--- a/swapwallet/deps.go
+++ b/swapwallet/deps.go
@@ -51,6 +51,10 @@ type RPCServer interface {
 		error,
 	)
 
+	EstimateFee(ctx context.Context,
+		req *daemonrpc.EstimateFeeRequest) (
+		*daemonrpc.EstimateFeeResponse, error)
+
 	GetBalance(ctx context.Context,
 		req *daemonrpc.GetBalanceRequest) (
 		*daemonrpc.GetBalanceResponse, error)

--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -78,6 +78,11 @@ type fakeRPCServer struct {
 	sendOnChainErr     error
 	sendOnChainCalls   int
 	sendOnChainLastReq *daemonrpc.SendOnChainRequest
+
+	estimateFeeResp    *daemonrpc.EstimateFeeResponse
+	estimateFeeErr     error
+	estimateFeeCalls   int
+	estimateFeeLastReq *daemonrpc.EstimateFeeRequest
 }
 
 func (f *fakeRPCServer) LeaveVTXOs(_ context.Context,
@@ -134,6 +139,19 @@ func (f *fakeRPCServer) GetInfo(_ context.Context,
 	}
 
 	return f.getInfoResp, f.getInfoErr
+}
+
+func (f *fakeRPCServer) EstimateFee(_ context.Context,
+	req *daemonrpc.EstimateFeeRequest) (*daemonrpc.EstimateFeeResponse,
+	error) {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.estimateFeeCalls++
+	f.estimateFeeLastReq = req
+
+	return f.estimateFeeResp, f.estimateFeeErr
 }
 
 func (f *fakeRPCServer) GetBalance(_ context.Context,

--- a/swapwallet/onchain_fee.go
+++ b/swapwallet/onchain_fee.go
@@ -1,0 +1,162 @@
+//go:build walletdkrpc && swapruntime
+
+package swapwallet
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+)
+
+// Local cooperative-leave fee-floor sizing. These virtual sizes drive the
+// offline fallback estimate only: when the operator's EstimateFee quote is
+// unreachable we approximate the on-chain share the client would bear if it
+// were the sole intent in the round (batch size 1). They are deliberately
+// conservative so the floor never under-promises the eventual seal-time
+// fee more than the (operator-only) liquidity and congestion components
+// already force it to.
+const (
+	// leaveBaseVBytes is the fixed v3 transaction overhead attributed to
+	// a cooperative-leave commitment at batch size 1: version, locktime,
+	// segwit marker/flag, input/output counts, and the above-dust P2A
+	// anchor every leave package carries.
+	leaveBaseVBytes = 60
+
+	// leaveInputVBytes is the virtual size of one taproot key-spend
+	// forfeit input (outpoint, sequence, and a single Schnorr witness),
+	// rounded up from ~57.5 vB.
+	leaveInputVBytes = 58
+
+	// leaveOutputVBytes is the virtual size of one taproot (P2TR)
+	// output.
+	leaveOutputVBytes = 43
+)
+
+// onchainFeeQuote is the resolved fee preview for a cooperative leave: the
+// estimated fee, how complete the quote is, and an optional warning to
+// surface when the number is a local floor rather than an operator quote.
+type onchainFeeQuote struct {
+	feeSat      int64
+	feeKnown    bool
+	quoteStatus walletdkrpc.SendQuoteStatus
+	warning     string
+}
+
+// onchainTerms holds the operator-policy values the preview needs from a
+// single GetInfo call: the target feerate plus the minimum-operator-fee
+// and dust-limit headroom the daemon selects against. All zero when GetInfo
+// or its ServerInfo is unavailable, which degrades the preview to a
+// zero-headroom, zero-floor estimate rather than failing outright.
+type onchainTerms struct {
+	feeRate        btcutil.Amount
+	minOperatorFee btcutil.Amount
+	dustLimit      btcutil.Amount
+}
+
+// fetchOnchainTerms reads the daemon's cached operator terms once so the
+// caller can size both the coin-selection headroom and the local fee floor
+// from a single lookup. A failed lookup (or a nil response/ServerInfo)
+// yields a zero-valued struct so the preview still renders.
+func (r *router) fetchOnchainTerms(ctx context.Context) onchainTerms {
+	info, err := r.deps.RPCServer.GetInfo(
+		ctx, &daemonrpc.GetInfoRequest{},
+	)
+	if err != nil || info == nil {
+		return onchainTerms{}
+	}
+
+	server := info.GetServerInfo()
+	if server == nil {
+		return onchainTerms{}
+	}
+
+	return onchainTerms{
+		feeRate:        btcutil.Amount(server.GetFeeRate()),
+		minOperatorFee: btcutil.Amount(server.GetMinOperatorFee()),
+		dustLimit:      btcutil.Amount(server.GetDustLimit()),
+	}
+}
+
+// estimateOnchainFee resolves the prepare-time fee preview for a
+// cooperative leave. It prefers the operator's dynamic EstimateFee quote
+// (which folds in the on-chain share, liquidity, and margin the server
+// charges at seal time) and falls back to a purely local batch-size-1
+// floor when the operator is unreachable, so a preview is still produced
+// offline. amountSat is the leave amount; numInputs and sweepAll size the
+// local fallback's on-chain footprint; terms supplies the floor's feerate
+// and minimum-fee inputs.
+func (r *router) estimateOnchainFee(ctx context.Context, amountSat int64,
+	numInputs int, sweepAll bool, terms onchainTerms) onchainFeeQuote {
+
+	// Prefer the operator's dynamic quote. RemainingBlocks is zero: a
+	// leave exits the funds now, so there is no residual lock time to
+	// price the time-value component against. A successful quote backs
+	// every fee field, so the preview is COMPLETE. The feeResp nil guard
+	// is belt-and-suspenders: the generated getter is nil-safe, but the
+	// explicit check keeps the intent obvious at the call site.
+	feeResp, err := r.deps.RPCServer.EstimateFee(
+		ctx, &daemonrpc.EstimateFeeRequest{
+			AmountSat:       amountSat,
+			IsBoarding:      false,
+			RemainingBlocks: 0,
+		},
+	)
+	if err == nil && feeResp != nil && feeResp.GetTotalFeeSat() > 0 {
+		return onchainFeeQuote{
+			feeSat:   feeResp.GetTotalFeeSat(),
+			feeKnown: true,
+			quoteStatus: walletdkrpc.
+				SendQuoteStatus_SEND_QUOTE_STATUS_COMPLETE,
+		}
+	}
+
+	// Operator quote unavailable: fall back to a local floor derived
+	// from the cached operator terms. This captures the on-chain share
+	// at batch size 1 plus the operator's minimum fee, but cannot see
+	// the operator's liquidity/congestion components, so it is a lower
+	// bound the caller must treat as LOCAL_ONLY.
+	floor := localOnchainFeeFloor(numInputs, sweepAll, terms)
+
+	return onchainFeeQuote{
+		feeSat:   floor,
+		feeKnown: false,
+		quoteStatus: walletdkrpc.
+			SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY,
+		warning: "fee is a local estimate assuming a batch size of " +
+			"one; the operator quote was unavailable and the " +
+			"binding fee is set when the round seals",
+	}
+}
+
+// localOnchainFeeFloor computes a batch-size-1 fee lower bound from the
+// cached operator terms: the larger of the operator's minimum fee and the
+// on-chain cost of this leave's footprint at the operator's target feerate.
+// Zero-valued terms (an unavailable GetInfo) yield a zero floor rather than
+// failing the preview.
+func localOnchainFeeFloor(numInputs int, sweepAll bool,
+	terms onchainTerms) int64 {
+
+	// A bounded leave produces a leave output plus a change VTXO output;
+	// a sweep collapses to a single fee-absorbing leave output.
+	numOutputs := 2
+	if sweepAll {
+		numOutputs = 1
+	}
+
+	vbytes := int64(leaveBaseVBytes) +
+		int64(numInputs)*leaveInputVBytes +
+		int64(numOutputs)*leaveOutputVBytes
+
+	onchainShare := int64(terms.feeRate) * vbytes
+
+	// Floor the on-chain share at the operator's stated minimum fee:
+	// the true total is at least MinOperatorFee regardless of size.
+	minFee := int64(terms.minOperatorFee)
+	if onchainShare > minFee {
+		return onchainShare
+	}
+
+	return minFee
+}

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -5,11 +5,14 @@ package swapwallet
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightninglabs/darepo-client/coinselect"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
@@ -189,18 +192,18 @@ func (r *router) sendInvoiceIntent(ctx context.Context,
 	}, nil
 }
 
-// prepareOnchain validates an onchain destination through local VTXO
-// selection. The router selects VTXOs covering the
-// requested amount using the existing wallet listing surface — no new
-// coin-selection primitive is introduced here.
+// prepareOnchain validates an onchain destination and builds a fee-aware
+// preview. The router selects live VTXOs through the shared coinselect
+// package (the same largest-first algorithm the daemon runs), so it does
+// not grow a parallel coin-selection primitive.
 //
-// v1 semantics: LeaveVTXOs sweeps WHOLE VTXOs to the destination, so the
-// caller's onchain wallet may receive more than amt_sat (the sum of the
-// selected VTXOs is what actually leaves the wallet). The router returns
-// that sum on SendResponse.actual_amount_sat so the CLI / UI can echo it
-// before the user treats the send as confirmed. A future enhancement can
-// pre-split a VTXO via OOR for exact amounts; that work is intentionally
-// out of scope here.
+// A bounded send delivers exactly amt_sat to the destination and pays the
+// fee on top; the residual returns as a change VTXO under the #270
+// seal-time handshake, so the net outflow reported is amt_sat plus the
+// estimated fee, not the gross sum of the selected VTXOs. Selection uses
+// the same amount + operator-fee + dust headroom the daemon applies, and
+// the preview is rejected if the selected funds cannot cover amt_sat plus
+// the fee, so a confirmed preview is always fundable.
 //
 // Sweep semantics are gated on the explicit PrepareSendRequest.sweep_all flag:
 // amt_sat = 0 with sweep_all = false is rejected (the most common typo)
@@ -238,36 +241,87 @@ func (r *router) prepareOnchain(ctx context.Context, addr string,
 			ErrAmountInvalid)
 	}
 
-	var (
-		actualSat int64
-		selected  []string
+	// Fetch the operator terms once: they size the coin-selection
+	// headroom here and the local fee floor in the quote below.
+	liveVTXOs, err := r.listLiveVTXOsForLeave(ctx)
+	if err != nil {
+		return nil, err
+	}
+	terms := r.fetchOnchainTerms(ctx)
+
+	// Select live VTXOs through the shared selector so the preview
+	// mirrors the largest-first selection the daemon will run for the
+	// real send, rather than a parallel greedy walk. For a bounded send
+	// we select against the same amount + operator-fee + dust headroom
+	// the daemon uses (wallet.handleSendOnChain), so the preview does not
+	// under-select relative to what the real send needs. Selection stays
+	// local (over the daemon's live-VTXO view) so a preview is still
+	// produced when the operator is offline; only the fee quote below
+	// reaches out to the operator.
+	selectTarget := btcutil.Amount(amtSat)
+	if !sweepAll {
+		selectTarget += terms.minOperatorFee + terms.dustLimit
+	}
+
+	vtxoAmount := func(v *daemonrpc.VTXO) btcutil.Amount {
+		return btcutil.Amount(v.GetAmountSat())
+	}
+	res, err := coinselect.LargestFirst(
+		liveVTXOs, vtxoAmount, coinselect.Request{
+			Target:   selectTarget,
+			SweepAll: sweepAll,
+		},
 	)
 	switch {
-	case sweepAll:
-		vtxos, err := r.listLiveVTXOsForLeave(ctx)
-		if err != nil {
-			return nil, err
-		}
-		selected, actualSat = outpointsAndSum(vtxos)
-		if actualSat == 0 {
+	case errors.Is(err, coinselect.ErrNoCandidates):
+		if sweepAll {
 			return nil, fmt.Errorf("%w: no live VTXOs to sweep",
 				ErrAmountRequired)
 		}
 
-	default:
-		// Caller-bounded send: select live VTXOs whose total covers
-		// the requested amount, then sweep them. The selected set
-		// is the input to LeaveVTXOs; per-outpoint destinations are
-		// omitted so DefaultDestination applies to every selected
-		// outpoint.
-		selectedSet, selectedSum, err := r.selectVTXOsForAmount(
-			ctx, int64(amtSat),
-		)
-		if err != nil {
-			return nil, err
+		return nil, fmt.Errorf("%w: no live VTXOs to cover %d sat",
+			ErrAmountRequired, amtSat)
+
+	case errors.Is(err, coinselect.ErrSelectionShortfall):
+		return nil, fmt.Errorf("%w: live VTXOs cover %d of %d sat",
+			ErrAmountRequired, int64(res.Total),
+			int64(selectTarget))
+
+	case err != nil:
+		return nil, err
+	}
+
+	selectedTotal := int64(res.Total)
+	selected := make([]string, 0, len(res.Selected))
+	for _, v := range res.Selected {
+		selected = append(selected, v.GetOutpoint())
+	}
+
+	// previewAmount is the amount delivered to the destination: the
+	// requested amount for a bounded send, or the entire swept balance
+	// for a sweep.
+	previewAmount := int64(amtSat)
+	if sweepAll {
+		previewAmount = selectedTotal
+	}
+
+	feeQuote := r.estimateOnchainFee(
+		ctx, previewAmount, len(res.Selected), sweepAll, terms,
+	)
+
+	// Guard the preview's coherence: a bounded send must not report an
+	// outflow its own selected funds cannot cover. The daemon re-selects
+	// for the real send, but the preview should reject an unaffordable
+	// amount + fee here rather than confirm a stale, unfundable quote
+	// that the SendOnChain path will later fail. A sweep moves the whole
+	// balance, so it is affordable by construction.
+	if !sweepAll {
+		needed := int64(amtSat) + feeQuote.feeSat
+		if selectedTotal < needed {
+			return nil, fmt.Errorf("%w: live VTXOs cover %d sat, "+
+				"need %d sat (amount plus fee)",
+				ErrAmountRequired, selectedTotal, needed)
 		}
-		selected = selectedSet
-		actualSat = selectedSum
 	}
 
 	intent := &preparedSendIntent{
@@ -278,32 +332,34 @@ func (r *router) prepareOnchain(ctx context.Context, addr string,
 		maxFeeSat:         req.GetMaxFeeSat(),
 		sweepAll:          sweepAll,
 		selectedOutpoints: append([]string(nil), selected...),
-		actualAmountSat:   actualSat,
+		actualAmountSat:   selectedTotal,
 	}
 
 	if _, err := r.intents.put(intent); err != nil {
 		return nil, err
 	}
 
-	warning := "operator cooperative-leave quote support is not " +
-		"available yet"
-
-	previewAmount := int64(amtSat)
-	if sweepAll {
-		previewAmount = actualSat
+	// Net outflow is what actually leaves the wallet. A bounded send
+	// delivers exactly amtSat and pays the fee on top; the residual
+	// returns as a change VTXO, so the gross selected total is NOT the
+	// outflow. A sweep moves the entire selected balance (the fee is
+	// absorbed out of the single leave output).
+	expectedOutflow := selectedTotal
+	if !sweepAll {
+		expectedOutflow = int64(amtSat) + feeQuote.feeSat
 	}
 
 	return prepareResponseFromIntent(
 		intent, prepareSendPreview{
-			rail: walletdkrpc.SendRail_SEND_RAIL_ONCHAIN,
-			quoteStatus: walletdkrpc.
-				SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY,
+			rail:                    walletdkrpc.SendRail_SEND_RAIL_ONCHAIN,
+			quoteStatus:             feeQuote.quoteStatus,
 			amountSat:               previewAmount,
-			feeKnown:                false,
-			expectedTotalOutflowSat: actualSat,
+			expectedFeeSat:          feeQuote.feeSat,
+			feeKnown:                feeQuote.feeKnown,
+			expectedTotalOutflowSat: expectedOutflow,
 			totalOutflowKnown:       true,
 			destinationSummary:      addr,
-			warning:                 warning,
+			warning:                 feeQuote.warning,
 		},
 	), nil
 }
@@ -408,63 +464,6 @@ func (r *router) listLiveVTXOsForLeave(ctx context.Context) ([]*daemonrpc.VTXO,
 	}
 
 	return listResp.GetVtxos(), nil
-}
-
-// selectVTXOsForAmount returns the smallest-sufficient set of live VTXO
-// outpoints whose summed amount covers target, plus the actual sum of
-// the selection. The selection is greedy by VTXO order returned from the
-// daemon; v1 does not optimize for change minimization because
-// LeaveVTXOs already sweeps WHOLE VTXOs, so any remainder above target
-// lands at the destination. Callers surface that sum back to the user
-// via SendResponse.actual_amount_sat.
-//
-// Returns ErrAmountInvalid when target is non-positive, and
-// ErrAmountRequired when no combination of live VTXOs covers target.
-func (r *router) selectVTXOsForAmount(ctx context.Context, target int64) (
-	[]string, int64, error) {
-
-	if target <= 0 {
-		return nil, 0, ErrAmountInvalid
-	}
-
-	vtxos, err := r.listLiveVTXOsForLeave(ctx)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	var (
-		selected []string
-		covered  int64
-	)
-	for _, v := range vtxos {
-		if v.GetAmountSat() <= 0 {
-			continue
-		}
-		selected = append(selected, v.GetOutpoint())
-		covered += v.GetAmountSat()
-		if covered >= target {
-			return selected, covered, nil
-		}
-	}
-
-	return nil, 0, fmt.Errorf("%w: insufficient live VTXOs cover %d sat "+
-		"(covered=%d)", ErrAmountRequired, target, covered)
-}
-
-func outpointsAndSum(vtxos []*daemonrpc.VTXO) ([]string, int64) {
-	var (
-		outpoints []string
-		total     int64
-	)
-	for _, v := range vtxos {
-		if v.GetAmountSat() <= 0 {
-			continue
-		}
-		outpoints = append(outpoints, v.GetOutpoint())
-		total += v.GetAmountSat()
-	}
-
-	return outpoints, total
 }
 
 func decodePreparedInvoice(invoice string,

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -248,6 +248,13 @@ func TestRouterSendOnchainSelectsVTXOsAndCallsLeave(t *testing.T) {
 		Status: "submitted",
 	}
 
+	// The operator returns a dynamic fee quote, so the preview is a
+	// COMPLETE quote: net outflow is the amount delivered plus the fee,
+	// not the gross VTXO bundle selected to cover it.
+	rpc.estimateFeeResp = &daemonrpc.EstimateFeeResponse{
+		TotalFeeSat: 500,
+	}
+
 	prepareResp, err := r.PrepareSend(
 		t.Context(), &walletdkrpc.PrepareSendRequest{
 			Destination: &walletdkrpc.
@@ -263,16 +270,27 @@ func TestRouterSendOnchainSelectsVTXOsAndCallsLeave(t *testing.T) {
 		prepareResp.GetRail(),
 	)
 	require.Equal(
-		t, walletdkrpc.SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY,
+		t, walletdkrpc.SendQuoteStatus_SEND_QUOTE_STATUS_COMPLETE,
 		prepareResp.GetQuoteStatus(),
 	)
+	require.True(t, prepareResp.GetFeeKnown())
 	require.Equal(
-		t, int64(12_000), prepareResp.GetExpectedTotalOutflowSat(),
+		t, int64(500), prepareResp.GetExpectedFeeSat(),
 	)
+
+	// Net outflow is amount + fee (10000 + 500); the ~2000 sat residual
+	// over the 12000 sat selected bundle returns as a change VTXO and is
+	// NOT part of the outflow.
+	require.Equal(
+		t, int64(10_500), prepareResp.GetExpectedTotalOutflowSat(),
+	)
+
+	// The preview selects largest-first (7000, then 5000), mirroring the
+	// daemon's selection rather than the daemon's response order.
 	require.Equal(
 		t, []string{
-			"tx1:0",
 			"tx2:1",
+			"tx1:0",
 		},
 		prepareResp.GetSelectedOutpoints(),
 	)
@@ -334,6 +352,102 @@ func TestRouterSendOnchainSelectsVTXOsAndCallsLeave(t *testing.T) {
 		t, 1, rpc.sendOnChainCalls,
 		"prepared send intents must be consume-once",
 	)
+}
+
+// TestRouterSendOnchainFeeFallsBackToLocalFloor verifies that when the
+// operator's EstimateFee quote is unavailable, the preview falls back to a
+// local batch-size-1 fee floor derived from the daemon's cached operator
+// terms, marks the quote LOCAL_ONLY, and surfaces a warning.
+func TestRouterSendOnchainFeeFallsBackToLocalFloor(t *testing.T) {
+	t.Parallel()
+
+	r, _, rpc := newRouterFixture(t)
+	rpc.listVTXOsResp = &daemonrpc.ListVTXOsResponse{
+		Vtxos: []*daemonrpc.VTXO{
+			{
+				Outpoint:  "tx1:0",
+				AmountSat: 10000,
+			},
+		},
+	}
+
+	// Operator quote unavailable forces the local floor.
+	rpc.estimateFeeErr = errors.New("operator unreachable")
+
+	// Cached operator terms drive the floor: at 10 sat/vByte a bounded
+	// leave with one input and two outputs is
+	// 60 + 58 + 2*43 = 204 vBytes, i.e. 2040 sats on-chain, which
+	// exceeds the 300 sat minimum operator fee.
+	rpc.getInfoResp = &daemonrpc.GetInfoResponse{
+		WalletState: daemonrpc.WalletState_WALLET_STATE_READY,
+		ServerInfo: &daemonrpc.ServerInfo{
+			FeeRate:        10,
+			MinOperatorFee: 300,
+		},
+	}
+
+	prepareResp, err := r.PrepareSend(
+		t.Context(), &walletdkrpc.PrepareSendRequest{
+			Destination: &walletdkrpc.
+				PrepareSendRequest_OnchainAddress{
+				OnchainAddress: "bcrt1qaddr",
+			},
+			AmtSat: 5000,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, walletdkrpc.SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY,
+		prepareResp.GetQuoteStatus(),
+	)
+	require.False(t, prepareResp.GetFeeKnown())
+	require.Equal(t, int64(2040), prepareResp.GetExpectedFeeSat())
+	require.Equal(
+		t, int64(7040), prepareResp.GetExpectedTotalOutflowSat(),
+	)
+	require.NotEmpty(t, prepareResp.GetWarning())
+}
+
+// TestRouterSendOnchainRejectsWhenFundsCannotCoverFee verifies that a
+// bounded preview is rejected when the selected live VTXOs cover the
+// principal but not the principal plus the quoted fee, rather than
+// confirming an unaffordable outflow the real send would later fail.
+func TestRouterSendOnchainRejectsWhenFundsCannotCoverFee(t *testing.T) {
+	t.Parallel()
+
+	r, _, rpc := newRouterFixture(t)
+
+	// A single 6000 sat VTXO covers the 5000 sat principal (plus the
+	// 300 sat selection headroom) but not the 5000 + 2040 sat amount +
+	// fee, so the preview must reject rather than report a 7040 sat
+	// outflow it cannot fund.
+	rpc.listVTXOsResp = &daemonrpc.ListVTXOsResponse{
+		Vtxos: []*daemonrpc.VTXO{
+			{
+				Outpoint:  "tx1:0",
+				AmountSat: 6000,
+			},
+		},
+	}
+	rpc.estimateFeeErr = errors.New("operator unreachable")
+	rpc.getInfoResp = &daemonrpc.GetInfoResponse{
+		WalletState: daemonrpc.WalletState_WALLET_STATE_READY,
+		ServerInfo: &daemonrpc.ServerInfo{
+			FeeRate:        10,
+			MinOperatorFee: 300,
+		},
+	}
+
+	_, err := r.PrepareSend(
+		t.Context(), &walletdkrpc.PrepareSendRequest{
+			Destination: &walletdkrpc.
+				PrepareSendRequest_OnchainAddress{
+				OnchainAddress: "bcrt1qaddr",
+			},
+			AmtSat: 5000,
+		},
+	)
+	require.ErrorIs(t, err, ErrAmountRequired)
 }
 
 // TestRouterSendOnchainSweepAllRoutesToSendOnChain confirms that the

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"sort"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -18,6 +17,7 @@ import (
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/chainsource"
+	"github.com/lightninglabs/darepo-client/coinselect"
 	"github.com/lightninglabs/darepo-client/ledger"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/round"
@@ -891,22 +891,34 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context, p reserveParams) (
 		return nil, 0, fmt.Errorf("list live vtxos: %w", err)
 	}
 
-	// Run largest-first selection.
-	selected, selectedTotal := selectLargestFirstWithMinChange(
-		candidates, p.targetAmount, p.minChangeAmount,
+	// Run largest-first selection through the shared selector. Map its
+	// typed outcomes back onto the manager's liquidity diagnostics: a
+	// dust-change rejection is reported verbatim, while any shortfall
+	// (including an empty candidate set) is refined into the
+	// locked-vs-absent distinction.
+	res, err := coinselect.LargestFirst(
+		candidates, func(d *Descriptor) btcutil.Amount {
+			return d.Amount
+		}, coinselect.Request{
+			Target:    p.targetAmount,
+			MinChange: p.minChangeAmount,
+		},
 	)
-	if selected == nil {
-		if selectedTotal >= p.targetAmount && p.minChangeAmount > 0 {
-			change := selectedTotal - p.targetAmount
+	switch {
+	case errors.Is(err, coinselect.ErrChangeBelowMin):
+		change := res.Total - p.targetAmount
 
-			return nil, 0, fmt.Errorf("change %d is below minimum "+
-				"change amount %d", change, p.minChangeAmount)
-		}
+		return nil, 0, fmt.Errorf("change %d is below minimum change "+
+			"amount %d", change, p.minChangeAmount)
 
-		err := m.insufficientLiquidityError(ctx, candidates, p)
+	case errors.Is(err, coinselect.ErrSelectionShortfall),
+		errors.Is(err, coinselect.ErrNoCandidates):
+		return nil, 0, m.insufficientLiquidityError(ctx, candidates, p)
 
+	case err != nil:
 		return nil, 0, err
 	}
+	selected := res.Selected
 
 	// Reserve each selected VTXO via its actor. Track successfully
 	// reserved outpoints so we can roll back on partial failure.
@@ -1438,66 +1450,6 @@ func (m *Manager) handleSelectAndReserveForfeit(ctx context.Context,
 			TotalSelected: total,
 		},
 	)
-}
-
-// =============================================================================
-// Coin selection
-// =============================================================================
-
-// selectLargestFirst implements largest-first coin selection. It sorts
-// candidates by amount descending and picks VTXOs until the target is met.
-// Returns nil if the candidates cannot cover the target.
-func selectLargestFirst(candidates []*Descriptor,
-	target btcutil.Amount) []*Descriptor {
-
-	selected, _ := selectLargestFirstWithMinChange(candidates, target, 0)
-
-	return selected
-}
-
-// selectLargestFirstWithMinChange implements largest-first coin selection
-// while avoiding non-zero change below minChange. Exact spends remain valid,
-// because no change output is produced in that case.
-func selectLargestFirstWithMinChange(candidates []*Descriptor,
-	target, minChange btcutil.Amount) ([]*Descriptor, btcutil.Amount) {
-
-	// Sort by amount descending.
-	sorted := make([]*Descriptor, len(candidates))
-	copy(sorted, candidates)
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].Amount > sorted[j].Amount
-	})
-
-	var (
-		selected        []*Descriptor
-		total           btcutil.Amount
-		rejectedTotal   btcutil.Amount
-		rejectedForDust bool
-	)
-	for _, vtxo := range sorted {
-		selected = append(selected, vtxo)
-		total += vtxo.Amount
-
-		if total < target {
-			continue
-		}
-
-		change := total - target
-		if change == 0 || minChange == 0 || change >= minChange {
-			return selected, total
-		}
-
-		if !rejectedForDust {
-			rejectedTotal = total
-			rejectedForDust = true
-		}
-	}
-
-	if rejectedForDust {
-		return nil, rejectedTotal
-	}
-
-	return nil, total
 }
 
 // dedupOutpoints returns a copy of the slice with duplicate outpoints

--- a/vtxo/manager_admission_test.go
+++ b/vtxo/manager_admission_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/coinselect"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
@@ -1055,21 +1056,27 @@ func TestSelectLargestFirst(t *testing.T) {
 				})
 			}
 
-			selected := selectLargestFirst(
-				candidates, tc.target,
+			res, err := coinselect.LargestFirst(
+				candidates, func(d *Descriptor) btcutil.Amount {
+					return d.Amount
+				}, coinselect.Request{
+					Target: tc.target,
+				},
 			)
 
 			if tc.wantNil {
-				require.Nil(t, selected)
+				require.Error(t, err)
+				require.Nil(t, res.Selected)
 
 				return
 			}
 
-			require.Len(t, selected, tc.wantCount)
+			require.NoError(t, err)
+			require.Len(t, res.Selected, tc.wantCount)
 
 			// Verify total covers target.
 			var total btcutil.Amount
-			for _, v := range selected {
+			for _, v := range res.Selected {
 				total += v.Amount
 			}
 			require.GreaterOrEqual(


### PR DESCRIPTION
In this PR, we fix a misleading onchain send preview and, in the process,
consolidate coin selection behind a single shared abstraction. The bug
that kicked this off: a bounded `--amt 9000` send to an onchain address
would preview an "Expected total outflow" of 101196 sats. The 9000 sat
send hadn't suddenly grown a 90k+ fee, the preview was just reporting the
gross sum of the VTXO bundle it selected to cover the send, not the sats
that actually leave the wallet. Under the seal-time change-VTXO semantics
(#634, #270) a bounded send lands exactly the requested amount at the
destination and the residual comes back as a change VTXO, so the real net
outflow is amount + fee. The preview now reports that.

While digging in we found the root cause was deeper than a label. The swap
wallet router had its own greedy `selectVTXOsForAmount` walk that existed
only to build the preview (the real send re-selects in the daemon and
ignores it entirely). That's a parallel coin-selection implementation the
`swapwallet` deps contract explicitly says this layer should never grow.
So rather than patch the number in place, we pull selection into one
place and route everyone through it.

## coinselect

We add a new `coinselect` leaf package with a single, coin-type-agnostic
`LargestFirst`. It depends only on `btcutil`, so both the VTXO manager's
reservation path and the swap wallet's preview select through the same
code instead of each maintaining its own accumulate-until-covered loop.
It's generic over the candidate type via an `AmountFunc[T]` accessor, does
largest-first selection with optional dust-change avoidance, supports a
sweep-all mode, and reports failures as typed errors (shortfall,
dust-change, empty set) that carry the covered total so callers can map
them onto their own diagnostics.

## vtxo + swapwallet

In `vtxo`, the manager drops its private `selectLargestFirst*` helpers and
calls `coinselect.LargestFirst`, keeping its actor-coupled reservation and
rollback. This is behavior-preserving: the algorithm was already
largest-first with dust avoidance.

In `swapwallet`, we delete the duplicate greedy selector and have the
preview select through `coinselect` too, so it now mirrors the daemon's
largest-first selection rather than a divergent first-fit walk. Selection
stays local over the daemon's live-VTXO view so a preview still works when
the operator is offline.

We also replace the hardcoded "cooperative-leave quote support is not
available yet" warning with a real fee estimate. We prefer the operator's
dynamic `EstimateFee` quote (which folds in the on-chain share, liquidity,
and margin charged at seal time) and mark that preview COMPLETE. When the
operator is unreachable, we fall back to a local batch-size-1 floor
derived from the daemon's cached operator terms: the larger of the minimum
operator fee and the on-chain cost of this leave's footprint at the
operator's target feerate. That floor can't see the operator's
liquidity/congestion components, so it's a lower bound the caller sees as
LOCAL_ONLY with an explanatory warning.

One caveat worth flagging for review: the local floor uses approximate
taproot vbyte constants (`leaveInputVBytes = 58`, etc.) and is only shown
when the operator can't be reached. The binding fee is still set
server-side at seal time.

See each commit message for a detailed description w.r.t the incremental
changes.