### PR TITLE
tlvutil: dedup durable-actor TLV serialization behind shared helpers

### DIFF
--- a/baselib/actor/ask_response.go
+++ b/baselib/actor/ask_response.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -63,8 +64,8 @@ func (m AskResponse) Encode(w io.Writer) error {
 	resultBlob := m.ResultBlob
 	errorText := []byte(m.ErrorText)
 
-	records := []tlv.Record{
-		tlv.MakePrimitiveRecord(
+	return tlvutil.EncodeRecords(
+		w, tlv.MakePrimitiveRecord(
 			askResponseCorrelationIDType, &correlationID,
 		),
 		tlv.MakePrimitiveRecord(
@@ -73,14 +74,7 @@ func (m AskResponse) Encode(w io.Writer) error {
 		tlv.MakePrimitiveRecord(
 			askResponseErrorTextType, &errorText,
 		),
-	}
-
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
+	)
 }
 
 // Decode deserializes the message from the provided reader.
@@ -91,8 +85,8 @@ func (m *AskResponse) Decode(r io.Reader) error {
 		errorText     []byte
 	)
 
-	records := []tlv.Record{
-		tlv.MakePrimitiveRecord(
+	_, err := tlvutil.DecodeRecords(
+		r, tlv.MakePrimitiveRecord(
 			askResponseCorrelationIDType, &correlationID,
 		),
 		tlv.MakePrimitiveRecord(
@@ -101,14 +95,8 @@ func (m *AskResponse) Decode(r io.Reader) error {
 		tlv.MakePrimitiveRecord(
 			askResponseErrorTextType, &errorText,
 		),
-	}
-
-	stream, err := tlv.NewStream(records...)
+	)
 	if err != nil {
-		return err
-	}
-
-	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
 		return err
 	}
 

--- a/baselib/actor/restart.go
+++ b/baselib/actor/restart.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -67,20 +68,13 @@ func (m *RestartMessage) Encode(w io.Writer) error {
 	updatedAt := uint64(cp.UpdatedAt.Unix())
 
 	// Build TLV records. All fields use odd types to signal optional.
-	records := []tlv.Record{
-		tlv.MakePrimitiveRecord(1, &actorIDBytes),
+	return tlvutil.EncodeRecords(
+		w, tlv.MakePrimitiveRecord(1, &actorIDBytes),
 		tlv.MakePrimitiveRecord(3, &stateTypeBytes),
 		tlv.MakePrimitiveRecord(5, &cp.StateData),
 		tlv.MakePrimitiveRecord(7, &version),
 		tlv.MakePrimitiveRecord(9, &updatedAt),
-	}
-
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
+	)
 }
 
 // Decode deserializes a TLV stream into the RestartMessage. Creates local
@@ -96,17 +90,12 @@ func (m *RestartMessage) Decode(r io.Reader) error {
 		updatedAt = tlv.ZeroRecordT[tlv.TlvType9, uint64]()
 	)
 
-	// Build stream with pointers to local variables.
-	stream, err := tlv.NewStream(
-		actorID.Record(), stateType.Record(), stateData.Record(),
+	// Decode into the local variables and get the typeMap showing which
+	// fields were present.
+	typeMap, err := tlvutil.DecodeRecords(
+		r, actorID.Record(), stateType.Record(), stateData.Record(),
 		version.Record(), updatedAt.Record(),
 	)
-	if err != nil {
-		return err
-	}
-
-	// Decode and get typeMap showing which fields were present.
-	typeMap, err := stream.DecodeWithParsedTypes(r)
 	if err != nil {
 		return err
 	}

--- a/baselib/tlvutil/records.go
+++ b/baselib/tlvutil/records.go
@@ -1,0 +1,89 @@
+package tlvutil
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// This file centralizes the encode/decode logic for the domain types that
+// tlv.MakePrimitiveRecord does NOT already handle. The lnd tlv package natively
+// covers uint8/16/32/64, [32]byte, [33]byte, **btcec.PublicKey, [64]byte, and
+// []byte, so those types need no helper here -- call MakePrimitiveRecord
+// directly:
+//
+//   - *btcec.PublicKey : tlv.MakePrimitiveRecord(typ, &pubKey)   // 33-byte
+//   - chainhash.Hash   : tlv.MakePrimitiveRecord(typ, (*[32]byte)(&hash))
+//   - [16]byte etc.    : slice it ([:]) into a *[]byte, as the codecs do today
+//
+// wire.OutPoint is the one recurring field with no native primitive (a 32-byte
+// hash plus a 4-byte index in a single record), so it gets a shared constructor
+// below. The byte format matches the encoding already on the wire and on disk.
+
+// outPointSize is the fixed encoded size of an outpoint: a 32-byte hash
+// followed by a 4-byte index.
+const outPointSize = chainhash.HashSize + 4
+
+// OutPointRecord returns a TLV record under the given type that encodes op as
+// 32 hash bytes followed by a 4-byte little-endian index (36 bytes total). This
+// is the canonical client-side outpoint encoding shared by the ledger and OOR
+// message codecs. The caller's field stays a plain wire.OutPoint.
+func OutPointRecord(typ tlv.Type, op *wire.OutPoint) tlv.Record {
+	return tlv.MakeStaticRecord(
+		typ, op, outPointSize, encodeOutPoint, decodeOutPoint,
+	)
+}
+
+// encodeOutPoint writes the outpoint as 32 hash bytes plus a 4-byte
+// little-endian index.
+func encodeOutPoint(w io.Writer, val interface{}, _ *[8]byte) error {
+	op, ok := val.(*wire.OutPoint)
+	if !ok {
+		return tlv.NewTypeForEncodingErr(val, "wire.OutPoint")
+	}
+
+	if _, err := w.Write(op.Hash[:]); err != nil {
+		return err
+	}
+
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], op.Index)
+
+	_, err := w.Write(buf[:])
+
+	return err
+}
+
+// decodeOutPoint reverses encodeOutPoint. It rejects any payload that is not
+// exactly 36 bytes so a corrupt stream surfaces at the decode boundary rather
+// than producing a truncated or zero-padded outpoint.
+func decodeOutPoint(r io.Reader, val interface{}, _ *[8]byte, l uint64) error {
+	op, ok := val.(*wire.OutPoint)
+	if !ok {
+		return tlv.NewTypeForDecodingErr(
+			val, "wire.OutPoint", l, outPointSize,
+		)
+	}
+
+	if l != outPointSize {
+		return fmt.Errorf("outpoint TLV payload must be %d "+
+			"bytes, got %d", outPointSize, l)
+	}
+
+	if _, err := io.ReadFull(r, op.Hash[:]); err != nil {
+		return err
+	}
+
+	var buf [4]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return err
+	}
+
+	op.Index = binary.LittleEndian.Uint32(buf[:])
+
+	return nil
+}

--- a/baselib/tlvutil/records_test.go
+++ b/baselib/tlvutil/records_test.go
@@ -1,0 +1,134 @@
+package tlvutil
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// genOutPoint draws an arbitrary outpoint.
+func genOutPoint(rt *rapid.T) wire.OutPoint {
+	var h chainhash.Hash
+	copy(h[:], rapid.SliceOfN(rapid.Byte(), 32, 32).Draw(rt, "hash"))
+
+	return wire.OutPoint{
+		Hash:  h,
+		Index: rapid.Uint32().Draw(rt, "index"),
+	}
+}
+
+// legacyOutPointBytes reproduces the hand-rolled 36-byte little-endian outpoint
+// encoding that the ledger and OOR codecs used before OutPointRecord. It is the
+// byte-format oracle the shared record must match exactly.
+func legacyOutPointBytes(op wire.OutPoint) []byte {
+	var buf bytes.Buffer
+	buf.Write(op.Hash[:])
+
+	var idx [4]byte
+	binary.LittleEndian.PutUint32(idx[:], op.Index)
+	buf.Write(idx[:])
+
+	return buf.Bytes()
+}
+
+// TestOutPointRecordMatchesLegacy asserts the OutPointRecord payload is
+// byte-identical to the legacy 36-byte little-endian encoding, and round-trips.
+func TestOutPointRecordMatchesLegacy(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		op := genOutPoint(rt)
+
+		// The record payload (TLV value, sans type/length) must equal
+		// the legacy fixed 36-byte form.
+		src := op
+		buf, err := EncodeRecordsToBytes(OutPointRecord(1, &src))
+		require.NoError(t, err)
+
+		// Strip the 2-byte type+length TLV header (type 1, length 36
+		// both fit in a single byte each) to compare the raw value.
+		require.Equal(t, byte(1), buf[0])
+		require.Equal(t, byte(outPointSize), buf[1])
+		require.Equal(t, legacyOutPointBytes(op), buf[2:])
+
+		// Round-trip back to an equal outpoint.
+		var got wire.OutPoint
+		_, err = DecodeRecordsFromBytes(buf, OutPointRecord(1, &got))
+		require.NoError(t, err)
+		require.Equal(t, op, got)
+	})
+}
+
+// TestOutPointRecordRejectsWrongSize asserts the decoder rejects a payload that
+// is not exactly 36 bytes.
+func TestOutPointRecordRejectsWrongSize(t *testing.T) {
+	t.Parallel()
+
+	// Hand-craft a TLV stream: type 1, length 4, four bytes. The static
+	// record decoder must reject the short length.
+	stream := []byte{0x01, 0x04, 0x00, 0x00, 0x00, 0x00}
+
+	var got wire.OutPoint
+	_, err := DecodeRecordsFromBytes(stream, OutPointRecord(1, &got))
+	require.Error(t, err)
+}
+
+// TestNativePrimitivesReused documents and locks in that the domain types we do
+// NOT wrap are handled directly by tlv.MakePrimitiveRecord, so no helper is
+// needed. A regression that dropped native support would surface here.
+func TestNativePrimitivesReused(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		// *btcec.PublicKey via the native **btcec.PublicKey case.
+		scalar := rapid.SliceOfN(rapid.Byte(), 32, 32).Draw(
+			rt, "scalar",
+		)
+		var modScalar btcec.ModNScalar
+		if modScalar.SetByteSlice(scalar); modScalar.IsZero() {
+			modScalar.SetInt(1)
+		}
+		pub := btcec.PrivKeyFromScalar(&modScalar).PubKey()
+
+		// chainhash.Hash via the native *[32]byte case (array cast).
+		var h chainhash.Hash
+		copy(h[:], rapid.SliceOfN(rapid.Byte(), 32, 32).Draw(rt, "h"))
+
+		srcPub, srcH := pub, h
+		buf, err := EncodeRecordsToBytes(
+			tlv.MakePrimitiveRecord(1, &srcPub),
+			tlv.MakePrimitiveRecord(
+				3, (*[32]byte)(&srcH),
+			),
+			OutPointRecord(
+				5, &wire.OutPoint{
+					Hash:  h,
+					Index: 7,
+				},
+			),
+		)
+		require.NoError(t, err)
+
+		var gotPub *btcec.PublicKey
+		var gotH chainhash.Hash
+		var gotOP wire.OutPoint
+		_, err = DecodeRecordsFromBytes(
+			buf, tlv.MakePrimitiveRecord(1, &gotPub),
+			tlv.MakePrimitiveRecord(
+				3, (*[32]byte)(&gotH),
+			),
+			OutPointRecord(5, &gotOP),
+		)
+		require.NoError(t, err)
+		require.True(t, pub.IsEqual(gotPub))
+		require.Equal(t, h, gotH)
+		require.Equal(t, wire.OutPoint{Hash: h, Index: 7}, gotOP)
+	})
+}

--- a/baselib/tlvutil/stream.go
+++ b/baselib/tlvutil/stream.go
@@ -1,0 +1,65 @@
+// Package tlvutil provides shared helpers that collapse the repetitive TLV
+// stream scaffolding used by durable-actor message codecs across the darepo and
+// darepo-client repositories.
+//
+// Every TLVMessage.Encode/Decode implementation would otherwise hand-write the
+// same NewStream/Encode and NewStream/DecodeWithParsedTypes dance. The helpers
+// here reduce a message body to a records slice plus a single call, without
+// changing the wire format: they are thin wrappers over lnd/tlv that produce
+// byte-identical output to the inlined form they replace.
+package tlvutil
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// EncodeRecords builds a TLV stream from the passed records and writes the
+// encoded form to w. It replaces the repeated NewStream/Encode pair that every
+// message Encode method would otherwise hand-write, and is byte-for-byte
+// equivalent to that inlined form.
+func EncodeRecords(w io.Writer, records ...tlv.Record) error {
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return err
+	}
+
+	return stream.Encode(w)
+}
+
+// EncodeRecordsToBytes encodes the passed records into a freshly allocated
+// buffer and returns the resulting bytes. It is a convenience over
+// EncodeRecords for codecs that need a []byte payload rather than streaming
+// into an existing writer.
+func EncodeRecordsToBytes(records ...tlv.Record) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := EncodeRecords(&buf, records...); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// DecodeRecords builds a TLV stream from the passed records and decodes r into
+// them, returning the parsed-type map so callers can detect which optional
+// records were actually present on the wire. It replaces the repeated
+// NewStream/DecodeWithParsedTypes pair found in every message Decode method.
+func DecodeRecords(r io.Reader, records ...tlv.Record) (tlv.TypeMap, error) {
+	stream, err := tlv.NewStream(records...)
+	if err != nil {
+		return nil, err
+	}
+
+	return stream.DecodeWithParsedTypes(r)
+}
+
+// DecodeRecordsFromBytes decodes the passed byte slice into the given records,
+// returning the parsed-type map. It is a convenience over DecodeRecords for
+// codecs that hold a []byte payload rather than a reader.
+func DecodeRecordsFromBytes(b []byte,
+	records ...tlv.Record) (tlv.TypeMap, error) {
+
+	return DecodeRecords(bytes.NewReader(b), records...)
+}

--- a/baselib/tlvutil/stream_test.go
+++ b/baselib/tlvutil/stream_test.go
@@ -1,0 +1,143 @@
+package tlvutil
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// manualEncode reproduces the inlined NewStream/Encode form that EncodeRecords
+// replaces. It is the byte-format oracle the helpers must match exactly.
+func manualEncode(t *testing.T, records ...tlv.Record) []byte {
+	t.Helper()
+
+	stream, err := tlv.NewStream(records...)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, stream.Encode(&buf))
+
+	return buf.Bytes()
+}
+
+// TestEncodeRecordsMatchesManual asserts that EncodeRecords produces output
+// byte-for-byte identical to the hand-written NewStream/Encode form across
+// arbitrary record sets. This is the wire-compatibility guarantee that lets us
+// migrate existing codecs onto the helper without changing on-disk bytes.
+func TestEncodeRecordsMatchesManual(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		records := genRecords(rt)
+
+		got, err := EncodeRecordsToBytes(records...)
+		require.NoError(t, err)
+
+		want := manualEncode(t, records...)
+		require.Equal(t, want, got)
+	})
+}
+
+// TestEncodeDecodeRecordsRoundTrip asserts that any record set encoded via the
+// helpers decodes back to the same values, and that the parsed-type map reports
+// every encoded record as present.
+func TestEncodeDecodeRecordsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		// Generate source values and the records that view them.
+		src := genFields(rt)
+
+		buf, err := EncodeRecordsToBytes(src.records()...)
+		require.NoError(t, err)
+
+		// Decode into a fresh field set and compare.
+		var dst fields
+		typeMap, err := DecodeRecordsFromBytes(buf, dst.records()...)
+		require.NoError(t, err)
+
+		require.Equal(t, src, dst)
+
+		// Every encoded record must appear in the parsed-type map.
+		for _, rec := range src.records() {
+			_, ok := typeMap[rec.Type()]
+			require.Truef(t, ok, "type %d missing", rec.Type())
+		}
+	})
+}
+
+// TestDecodeRecordsReaderEquivalence asserts the reader and byte-slice decode
+// entry points agree.
+func TestDecodeRecordsReaderEquivalence(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		src := genFields(rt)
+		buf, err := EncodeRecordsToBytes(src.records()...)
+		require.NoError(t, err)
+
+		var viaReader, viaBytes fields
+		_, err = DecodeRecords(
+			bytes.NewReader(buf), viaReader.records()...,
+		)
+		require.NoError(t, err)
+
+		_, err = DecodeRecordsFromBytes(buf, viaBytes.records()...)
+		require.NoError(t, err)
+
+		require.Equal(t, viaReader, viaBytes)
+	})
+}
+
+// fields is a fixed set of typed records exercising the common primitive
+// encodings used throughout the message codecs.
+type fields struct {
+	u64  uint64
+	u32  uint32
+	blob []byte
+}
+
+// records returns the TLV records that view this field set, mirroring how a
+// real message Encode/Decode builds its record slice.
+func (f *fields) records() []tlv.Record {
+	return []tlv.Record{
+		tlv.MakePrimitiveRecord(1, &f.u64),
+		tlv.MakePrimitiveRecord(3, &f.u32),
+		tlv.MakePrimitiveRecord(5, &f.blob),
+	}
+}
+
+// genFields draws an arbitrary field set.
+func genFields(rt *rapid.T) fields {
+	return fields{
+		u64:  rapid.Uint64().Draw(rt, "u64"),
+		u32:  rapid.Uint32().Draw(rt, "u32"),
+		blob: rapid.SliceOf(rapid.Byte()).Draw(rt, "blob"),
+	}
+}
+
+// genRecords draws an arbitrary set of distinct-typed primitive records backed
+// by stable storage for the duration of the check.
+func genRecords(rt *rapid.T) []tlv.Record {
+	store := struct {
+		a uint64
+		b uint32
+		c []byte
+		d uint8
+	}{
+		a: rapid.Uint64().Draw(rt, "a"),
+		b: rapid.Uint32().Draw(rt, "b"),
+		c: rapid.SliceOf(rapid.Byte()).Draw(rt, "c"),
+		d: rapid.Uint8().Draw(rt, "d"),
+	}
+
+	return []tlv.Record{
+		tlv.MakePrimitiveRecord(2, &store.a),
+		tlv.MakePrimitiveRecord(4, &store.b),
+		tlv.MakePrimitiveRecord(6, &store.c),
+		tlv.MakePrimitiveRecord(8, &store.d),
+	}
+}

--- a/ledger/messages.go
+++ b/ledger/messages.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -272,8 +273,8 @@ func (m *FeePaidMsg) Encode(w io.Writer) error {
 	blockHeight := m.BlockHeight
 	idempotency := m.IdempotencyKey
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	return tlvutil.EncodeRecords(
+		w, tlv.MakePrimitiveRecord(
 			feePaidRoundIDType, &roundID,
 		),
 		tlv.MakePrimitiveRecord(
@@ -289,11 +290,6 @@ func (m *FeePaidMsg) Encode(w io.Writer) error {
 			feePaidIdempotencyKeyType, &idempotency,
 		),
 	)
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes a TLV stream into the message.
@@ -306,8 +302,8 @@ func (m *FeePaidMsg) Decode(r io.Reader) error {
 		idempotency []byte
 	)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	if _, err := tlvutil.DecodeRecords(
+		r, tlv.MakePrimitiveRecord(
 			feePaidRoundIDType, &roundID,
 		),
 		tlv.MakePrimitiveRecord(
@@ -322,12 +318,7 @@ func (m *FeePaidMsg) Decode(r io.Reader) error {
 		tlv.MakePrimitiveRecord(
 			feePaidIdempotencyKeyType, &idempotency,
 		),
-	)
-	if err != nil {
-		return err
-	}
-
-	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+	); err != nil {
 		return fmt.Errorf("decode FeePaidMsg: %w", err)
 	}
 
@@ -412,8 +403,8 @@ func (m *VTXOReceivedMsg) Encode(w io.Writer) error {
 	source := []byte(m.Source)
 	roundID := m.RoundID[:]
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	return tlvutil.EncodeRecords(
+		w, tlv.MakePrimitiveRecord(
 			vtxoRecvOutpointHashType, &outpointHash,
 		),
 		tlv.MakePrimitiveRecord(
@@ -429,11 +420,6 @@ func (m *VTXOReceivedMsg) Encode(w io.Writer) error {
 			vtxoRecvRoundIDType, &roundID,
 		),
 	)
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes a TLV stream into the message.
@@ -446,8 +432,8 @@ func (m *VTXOReceivedMsg) Decode(r io.Reader) error {
 		roundID       []byte
 	)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	if _, err := tlvutil.DecodeRecords(
+		r, tlv.MakePrimitiveRecord(
 			vtxoRecvOutpointHashType, &outpointHash,
 		),
 		tlv.MakePrimitiveRecord(
@@ -462,12 +448,7 @@ func (m *VTXOReceivedMsg) Decode(r io.Reader) error {
 		tlv.MakePrimitiveRecord(
 			vtxoRecvRoundIDType, &roundID,
 		),
-	)
-	if err != nil {
-		return err
-	}
-
-	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+	); err != nil {
 		return fmt.Errorf("decode VTXOReceivedMsg: %w", err)
 	}
 
@@ -547,8 +528,8 @@ func (m *VTXOSentMsg) Encode(w io.Writer) error {
 	roundID := m.RoundID[:]
 	outpoint := &outpointRecord{OutPoint: m.Outpoint}
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	return tlvutil.EncodeRecords(
+		w, tlv.MakePrimitiveRecord(
 			vtxoSentSessionIDType, &sessionID,
 		),
 		tlv.MakePrimitiveRecord(
@@ -559,11 +540,6 @@ func (m *VTXOSentMsg) Encode(w io.Writer) error {
 		),
 		makeOutpointRecord(vtxoSentOutpointType, outpoint),
 	)
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes a TLV stream into the message.
@@ -575,8 +551,8 @@ func (m *VTXOSentMsg) Decode(r io.Reader) error {
 		outpoint  outpointRecord
 	)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	if _, err := tlvutil.DecodeRecords(
+		r, tlv.MakePrimitiveRecord(
 			vtxoSentSessionIDType, &sessionID,
 		),
 		tlv.MakePrimitiveRecord(
@@ -586,12 +562,7 @@ func (m *VTXOSentMsg) Decode(r io.Reader) error {
 			vtxoSentRoundIDType, &roundID,
 		),
 		makeOutpointRecord(vtxoSentOutpointType, &outpoint),
-	)
-	if err != nil {
-		return err
-	}
-
-	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+	); err != nil {
 		return fmt.Errorf("decode VTXOSentMsg: %w", err)
 	}
 
@@ -663,8 +634,8 @@ func (m *ExitCostMsg) Encode(w io.Writer) error {
 	exitCostSat := uint64(m.ExitCostSat)
 	blockHeight := m.BlockHeight
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	return tlvutil.EncodeRecords(
+		w, tlv.MakePrimitiveRecord(
 			exitCostOutpointHashType, &outpointHash,
 		),
 		tlv.MakePrimitiveRecord(
@@ -680,11 +651,6 @@ func (m *ExitCostMsg) Encode(w io.Writer) error {
 			exitCostBlockHeightType, &blockHeight,
 		),
 	)
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes a TLV stream into the message.
@@ -697,8 +663,8 @@ func (m *ExitCostMsg) Decode(r io.Reader) error {
 		blockHeight   uint32
 	)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	if _, err := tlvutil.DecodeRecords(
+		r, tlv.MakePrimitiveRecord(
 			exitCostOutpointHashType, &outpointHash,
 		),
 		tlv.MakePrimitiveRecord(
@@ -713,12 +679,7 @@ func (m *ExitCostMsg) Decode(r io.Reader) error {
 		tlv.MakePrimitiveRecord(
 			exitCostBlockHeightType, &blockHeight,
 		),
-	)
-	if err != nil {
-		return err
-	}
-
-	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+	); err != nil {
 		return fmt.Errorf("decode ExitCostMsg: %w", err)
 	}
 
@@ -791,8 +752,8 @@ func (m *UTXOCreatedMsg) Encode(w io.Writer) error {
 	blockHeight := m.BlockHeight
 	classification := []byte(m.Classification)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	return tlvutil.EncodeRecords(
+		w, tlv.MakePrimitiveRecord(
 			utxoOutpointHashType, &outpointHash,
 		),
 		tlv.MakePrimitiveRecord(
@@ -808,11 +769,6 @@ func (m *UTXOCreatedMsg) Encode(w io.Writer) error {
 			utxoClassificationType, &classification,
 		),
 	)
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes a TLV stream into the message.
@@ -825,8 +781,8 @@ func (m *UTXOCreatedMsg) Decode(r io.Reader) error {
 		classification []byte
 	)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	if _, err := tlvutil.DecodeRecords(
+		r, tlv.MakePrimitiveRecord(
 			utxoOutpointHashType, &outpointHash,
 		),
 		tlv.MakePrimitiveRecord(
@@ -841,12 +797,7 @@ func (m *UTXOCreatedMsg) Decode(r io.Reader) error {
 		tlv.MakePrimitiveRecord(
 			utxoClassificationType, &classification,
 		),
-	)
-	if err != nil {
-		return err
-	}
-
-	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+	); err != nil {
 		return fmt.Errorf("decode UTXOCreatedMsg: %w", err)
 	}
 
@@ -917,8 +868,8 @@ func (m *UTXOSpentMsg) Encode(w io.Writer) error {
 	blockHeight := m.BlockHeight
 	classification := []byte(m.Classification)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	return tlvutil.EncodeRecords(
+		w, tlv.MakePrimitiveRecord(
 			utxoOutpointHashType, &outpointHash,
 		),
 		tlv.MakePrimitiveRecord(
@@ -934,11 +885,6 @@ func (m *UTXOSpentMsg) Encode(w io.Writer) error {
 			utxoClassificationType, &classification,
 		),
 	)
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes a TLV stream into the message.
@@ -951,8 +897,8 @@ func (m *UTXOSpentMsg) Decode(r io.Reader) error {
 		classification []byte
 	)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	if _, err := tlvutil.DecodeRecords(
+		r, tlv.MakePrimitiveRecord(
 			utxoOutpointHashType, &outpointHash,
 		),
 		tlv.MakePrimitiveRecord(
@@ -967,12 +913,7 @@ func (m *UTXOSpentMsg) Decode(r io.Reader) error {
 		tlv.MakePrimitiveRecord(
 			utxoClassificationType, &classification,
 		),
-	)
-	if err != nil {
-		return err
-	}
-
-	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+	); err != nil {
 		return fmt.Errorf("decode UTXOSpentMsg: %w", err)
 	}
 

--- a/ledger/messages.go
+++ b/ledger/messages.go
@@ -1,7 +1,6 @@
 package ledger
 
 import (
-	"encoding/binary"
 	"fmt"
 	"io"
 	"math"
@@ -11,78 +10,6 @@ import (
 	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	"github.com/lightningnetwork/lnd/tlv"
 )
-
-// outpointRecord wraps a wire.OutPoint so it can be encoded /
-// decoded as a fixed 36-byte TLV payload (32-byte hash followed
-// by 4-byte little-endian index). Mirrors the pattern used in
-// db/tree_codec.go so callers can thread wire.OutPoint directly
-// through TLV messages instead of splitting the two halves into
-// separate primitive records.
-type outpointRecord struct {
-	wire.OutPoint
-}
-
-// outpointEncoder serializes an outpoint as 32 hash bytes plus
-// 4 little-endian index bytes.
-func outpointEncoder(w io.Writer, val interface{}, _ *[8]byte) error {
-	o, ok := val.(*outpointRecord)
-	if !ok {
-		return tlv.NewTypeForEncodingErr(val, "outpointRecord")
-	}
-
-	if _, err := w.Write(o.Hash[:]); err != nil {
-		return err
-	}
-
-	var buf [4]byte
-	binary.LittleEndian.PutUint32(buf[:], o.Index)
-
-	_, err := w.Write(buf[:])
-
-	return err
-}
-
-// outpointDecoder reverses outpointEncoder. Rejects any payload
-// that is not exactly 36 bytes so a corrupt TLV stream surfaces
-// at the decode boundary rather than producing a truncated or
-// zero-padded outpoint.
-func outpointDecoder(r io.Reader, val interface{}, _ *[8]byte, l uint64) error {
-	if l != 36 {
-		return fmt.Errorf("%w: outpoint TLV payload must be 36 "+
-			"bytes, got %d", ErrInvalidMessage, l)
-	}
-
-	o, ok := val.(*outpointRecord)
-	if !ok {
-		return tlv.NewTypeForDecodingErr(
-			val, "outpointRecord", l, 36,
-		)
-	}
-
-	if _, err := io.ReadFull(r, o.Hash[:]); err != nil {
-		return err
-	}
-
-	var buf [4]byte
-	if _, err := io.ReadFull(r, buf[:]); err != nil {
-		return err
-	}
-
-	o.Index = binary.LittleEndian.Uint32(buf[:])
-
-	return nil
-}
-
-// makeOutpointRecord builds a single-field TLV record of type
-// fieldType backed by outpointEncoder / outpointDecoder. Used by
-// the ledger messages that carry an outpoint (VTXOSentMsg etc.)
-// so the Go field type stays wire.OutPoint instead of split
-// hash / index primitives.
-func makeOutpointRecord(fieldType tlv.Type, rec *outpointRecord) tlv.Record {
-	return tlv.MakeStaticRecord(
-		fieldType, rec, 36, outpointEncoder, outpointDecoder,
-	)
-}
 
 // decodeAmountSat narrows a TLV-decoded uint64 satoshi field to
 // the int64 domain used everywhere downstream. A TLV stream is
@@ -526,7 +453,6 @@ func (m *VTXOSentMsg) Encode(w io.Writer) error {
 	sessionID := m.SessionID[:]
 	amountSat := uint64(m.AmountSat)
 	roundID := m.RoundID[:]
-	outpoint := &outpointRecord{OutPoint: m.Outpoint}
 
 	return tlvutil.EncodeRecords(
 		w, tlv.MakePrimitiveRecord(
@@ -538,7 +464,7 @@ func (m *VTXOSentMsg) Encode(w io.Writer) error {
 		tlv.MakePrimitiveRecord(
 			vtxoSentRoundIDType, &roundID,
 		),
-		makeOutpointRecord(vtxoSentOutpointType, outpoint),
+		tlvutil.OutPointRecord(vtxoSentOutpointType, &m.Outpoint),
 	)
 }
 
@@ -548,7 +474,7 @@ func (m *VTXOSentMsg) Decode(r io.Reader) error {
 		sessionID []byte
 		amountSat uint64
 		roundID   []byte
-		outpoint  outpointRecord
+		outpoint  wire.OutPoint
 	)
 
 	if _, err := tlvutil.DecodeRecords(
@@ -561,7 +487,7 @@ func (m *VTXOSentMsg) Decode(r io.Reader) error {
 		tlv.MakePrimitiveRecord(
 			vtxoSentRoundIDType, &roundID,
 		),
-		makeOutpointRecord(vtxoSentOutpointType, &outpoint),
+		tlvutil.OutPointRecord(vtxoSentOutpointType, &outpoint),
 	); err != nil {
 		return fmt.Errorf("decode VTXOSentMsg: %w", err)
 	}
@@ -586,7 +512,7 @@ func (m *VTXOSentMsg) Decode(r io.Reader) error {
 	copy(m.SessionID[:], sessionID)
 	copy(m.RoundID[:], roundID)
 	m.AmountSat = amt
-	m.Outpoint = outpoint.OutPoint
+	m.Outpoint = outpoint
 
 	return nil
 }

--- a/ledger/messages_roundtrip_test.go
+++ b/ledger/messages_roundtrip_test.go
@@ -1,0 +1,209 @@
+package ledger
+
+import (
+	"bytes"
+	"encoding/hex"
+	"io"
+	"math"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// tlvMessage is the minimal codec surface every ledger message satisfies.
+type tlvMessage interface {
+	Encode(io.Writer) error
+
+	Decode(io.Reader) error
+}
+
+// assertRoundTrip encodes src, decodes the bytes into dst, and asserts the two
+// are deeply equal. This is the core wire-stability check: every durable
+// message must survive an encode/decode cycle unchanged.
+func assertRoundTrip(t require.TestingT, src, dst tlvMessage) {
+	var buf bytes.Buffer
+	require.NoError(t, src.Encode(&buf))
+	require.NoError(t, dst.Decode(bytes.NewReader(buf.Bytes())))
+	require.Equal(t, src, dst)
+}
+
+// genBytes draws a fixed-length byte slice copied into an array of size n.
+func genBytes16(rt *rapid.T) [16]byte {
+	var a [16]byte
+	copy(a[:], rapid.SliceOfN(rapid.Byte(), 16, 16).Draw(rt, "b16"))
+
+	return a
+}
+
+func genBytes32(rt *rapid.T) [32]byte {
+	var a [32]byte
+	copy(a[:], rapid.SliceOfN(rapid.Byte(), 32, 32).Draw(rt, "b32"))
+
+	return a
+}
+
+// genAmount draws a non-negative satoshi amount. Decode rejects values past
+// MaxInt64 (a malformed payload guard), so the round-trippable domain is
+// [0, MaxInt64].
+func genAmount(rt *rapid.T, label string) int64 {
+	return rapid.Int64Range(0, math.MaxInt64).Draw(rt, label)
+}
+
+// genNonEmptyBytes draws a non-empty byte slice, avoiding the nil-vs-empty
+// ambiguity that an optional zero-length TLV field would introduce.
+func genNonEmptyBytes(rt *rapid.T, label string) []byte {
+	return rapid.SliceOfN(rapid.Byte(), 1, 64).Draw(rt, label)
+}
+
+// TestFeePaidMsgRoundTrip property-checks FeePaidMsg encode/decode.
+func TestFeePaidMsgRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		src := &FeePaidMsg{
+			RoundID:        genBytes16(rt),
+			AmountSat:      genAmount(rt, "amt"),
+			FeeType:        rapid.String().Draw(rt, "feeType"),
+			BlockHeight:    rapid.Uint32().Draw(rt, "height"),
+			IdempotencyKey: genNonEmptyBytes(rt, "idem"),
+		}
+		assertRoundTrip(rt, src, &FeePaidMsg{})
+	})
+}
+
+// TestVTXOReceivedMsgRoundTrip property-checks VTXOReceivedMsg encode/decode.
+func TestVTXOReceivedMsgRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		src := &VTXOReceivedMsg{
+			OutpointHash:  genBytes32(rt),
+			OutpointIndex: rapid.Uint32().Draw(rt, "idx"),
+			AmountSat:     genAmount(rt, "amt"),
+			Source:        rapid.String().Draw(rt, "source"),
+			RoundID:       genBytes16(rt),
+		}
+		assertRoundTrip(rt, src, &VTXOReceivedMsg{})
+	})
+}
+
+// TestVTXOSentMsgRoundTrip property-checks VTXOSentMsg encode/decode,
+// exercising the shared tlvutil.OutPointRecord path.
+func TestVTXOSentMsgRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		var h chainhash.Hash
+		copy(h[:], rapid.SliceOfN(rapid.Byte(), 32, 32).Draw(rt, "oph"))
+
+		src := &VTXOSentMsg{
+			SessionID: genBytes32(rt),
+			RoundID:   genBytes16(rt),
+			Outpoint: wire.OutPoint{
+				Hash:  h,
+				Index: rapid.Uint32().Draw(rt, "opi"),
+			},
+			AmountSat: genAmount(rt, "amt"),
+		}
+		assertRoundTrip(rt, src, &VTXOSentMsg{})
+	})
+}
+
+// TestExitCostMsgRoundTrip property-checks ExitCostMsg encode/decode.
+func TestExitCostMsgRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		src := &ExitCostMsg{
+			OutpointHash:  genBytes32(rt),
+			OutpointIndex: rapid.Uint32().Draw(rt, "idx"),
+			AmountSat:     genAmount(rt, "amt"),
+			ExitCostSat:   genAmount(rt, "cost"),
+			BlockHeight:   rapid.Uint32().Draw(rt, "height"),
+		}
+		assertRoundTrip(rt, src, &ExitCostMsg{})
+	})
+}
+
+// TestUTXOCreatedMsgRoundTrip property-checks UTXOCreatedMsg encode/decode.
+func TestUTXOCreatedMsgRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		src := &UTXOCreatedMsg{
+			OutpointHash:   genBytes32(rt),
+			OutpointIndex:  rapid.Uint32().Draw(rt, "idx"),
+			AmountSat:      genAmount(rt, "amt"),
+			BlockHeight:    rapid.Uint32().Draw(rt, "height"),
+			Classification: rapid.String().Draw(rt, "class"),
+		}
+		assertRoundTrip(rt, src, &UTXOCreatedMsg{})
+	})
+}
+
+// TestUTXOSpentMsgRoundTrip property-checks UTXOSpentMsg encode/decode.
+func TestUTXOSpentMsgRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		src := &UTXOSpentMsg{
+			OutpointHash:   genBytes32(rt),
+			OutpointIndex:  rapid.Uint32().Draw(rt, "idx"),
+			AmountSat:      genAmount(rt, "amt"),
+			BlockHeight:    rapid.Uint32().Draw(rt, "height"),
+			Classification: rapid.String().Draw(rt, "class"),
+		}
+		assertRoundTrip(rt, src, &UTXOSpentMsg{})
+	})
+}
+
+// TestVTXOSentMsgGolden pins the exact wire bytes of a fully-populated
+// VTXOSentMsg. It is the cross-version guard required by the migration: a
+// previously persisted durable message (these bytes) must always decode to the
+// same value, and the current encoder must still produce these exact bytes. Any
+// accidental wire-format change -- including a regression in the shared
+// tlvutil.OutPointRecord encoding -- breaks this test loudly.
+func TestVTXOSentMsgGolden(t *testing.T) {
+	t.Parallel()
+
+	// A deterministic, fully-populated message.
+	var sessionID [32]byte
+	for i := range sessionID {
+		sessionID[i] = byte(i + 1)
+	}
+	var roundID [16]byte
+	for i := range roundID {
+		roundID[i] = byte(0xa0 + i)
+	}
+	var opHash chainhash.Hash
+	for i := range opHash {
+		opHash[i] = byte(0x10 + i)
+	}
+
+	src := &VTXOSentMsg{
+		SessionID: sessionID,
+		RoundID:   roundID,
+		Outpoint: wire.OutPoint{
+			Hash:  opHash,
+			Index: 0x04030201,
+		},
+		AmountSat: 0x0102030405,
+	}
+
+	const golden = "01200102030405060708090a0b0c0d0e0f1011121314151617" +
+		"18191a1b1c1d1e1f20030800000001020304050510a0a1a2a3a4a5" +
+		"a6a7a8a9aaabacadaeaf0724101112131415161718191a1b1c1d1e" +
+		"1f202122232425262728292a2b2c2d2e2f01020304"
+
+	var buf bytes.Buffer
+	require.NoError(t, src.Encode(&buf))
+	require.Equal(t, golden, hex.EncodeToString(buf.Bytes()))
+
+	// The golden bytes must decode back to the original message.
+	var got VTXOSentMsg
+	require.NoError(t, got.Decode(bytes.NewReader(buf.Bytes())))
+	require.Equal(t, src, &got)
+}

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	clientdb "github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
@@ -174,17 +175,7 @@ func encodeStartTransferPayload(payload startTransferPayload) ([]byte, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 func decodeStartTransferPayload(raw []byte) (startTransferPayload, error) {
@@ -222,13 +213,8 @@ func decodeStartTransferPayloadWithLimits(raw []byte,
 		tlv.MakePrimitiveRecord(startPayloadIdempotencyKeyType, &idKey),
 	}
 
-	stream, err := tlv.NewStream(records...)
+	_, err := tlvutil.DecodeRecordsFromBytes(raw, records...)
 	if err != nil {
-		return startTransferPayload{}, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
 		return startTransferPayload{}, err
 	}
 
@@ -451,17 +437,7 @@ func encodeAncestryEntry(a vtxo.Ancestry) ([]byte, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 // decodeAncestryEntry is the inverse of encodeAncestryEntry.
@@ -488,13 +464,8 @@ func decodeAncestryEntry(raw []byte) (vtxo.Ancestry, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
+	_, err := tlvutil.DecodeRecordsFromBytes(raw, records...)
 	if err != nil {
-		return vtxo.Ancestry{}, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
 		return vtxo.Ancestry{}, err
 	}
 
@@ -629,17 +600,7 @@ func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 // decodeIncomingMetadataMatchWithLimits decodes one incoming metadata match
@@ -691,13 +652,8 @@ func decodeIncomingMetadataMatchWithLimits(raw []byte,
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
+	_, err := tlvutil.DecodeRecordsFromBytes(raw, records...)
 	if err != nil {
-		return IncomingMetadataMatch{}, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
 		return IncomingMetadataMatch{}, err
 	}
 
@@ -796,17 +752,7 @@ func encodeRecipientPayload(payload recipientPayload) ([]byte, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 func decodeRecipientPayload(raw []byte) (recipientPayload, error) {
@@ -824,13 +770,8 @@ func decodeRecipientPayload(raw []byte) (recipientPayload, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
+	_, err := tlvutil.DecodeRecordsFromBytes(raw, records...)
 	if err != nil {
-		return recipientPayload{}, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
 		return recipientPayload{}, err
 	}
 
@@ -1040,17 +981,7 @@ func encodeTransferInputSnapshot(input *TransferInputSnapshot) ([]byte, error) {
 		)
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 func decodeTransferInputSnapshot(raw []byte) (*TransferInputSnapshot, error) {
@@ -1134,13 +1065,8 @@ func decodeTransferInputSnapshot(raw []byte) (*TransferInputSnapshot, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
+	_, err := tlvutil.DecodeRecordsFromBytes(raw, records...)
 	if err != nil {
-		return nil, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
 		return nil, err
 	}
 
@@ -1434,17 +1360,7 @@ func encodeSessionPayload(sessionID SessionID) ([]byte, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 func decodeSessionPayload(raw []byte) (SessionID, error) {
@@ -1455,13 +1371,9 @@ func decodeSessionPayload(raw []byte) (SessionID, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return SessionID{}, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
+	if _, err := tlvutil.DecodeRecordsFromBytes(
+		raw, records...,
+	); err != nil {
 		return SessionID{}, err
 	}
 
@@ -1476,17 +1388,7 @@ func encodeIdempotencyKeyPayload(idempotencyKey string) ([]byte, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 func decodeIdempotencyKeyPayload(raw []byte) (string, error) {
@@ -1497,13 +1399,9 @@ func decodeIdempotencyKeyPayload(raw []byte) (string, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return "", err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
+	if _, err := tlvutil.DecodeRecordsFromBytes(
+		raw, records...,
+	); err != nil {
 		return "", err
 	}
 
@@ -1529,17 +1427,7 @@ func encodeListSessionsPayload(direction SessionDirection,
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 // decodeListSessionsPayload decodes the durable list-sessions query filters.
@@ -1558,13 +1446,9 @@ func decodeListSessionsPayload(raw []byte) (SessionDirection, bool, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return SessionDirectionAll, false, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
+	if _, err := tlvutil.DecodeRecordsFromBytes(
+		raw, records...,
+	); err != nil {
 		return SessionDirectionAll, false, err
 	}
 
@@ -1606,17 +1490,7 @@ func encodeResolveIncomingTransferPayload(sessionID SessionID,
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 // decodeResolveIncomingTransferPayloadWithLimits decodes an incoming-transfer
@@ -1645,13 +1519,8 @@ func decodeResolveIncomingTransferPayloadWithLimits(raw []byte,
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
+	_, err := tlvutil.DecodeRecordsFromBytes(raw, records...)
 	if err != nil {
-		return SessionID{}, nil, 0, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
 		return SessionID{}, nil, 0, err
 	}
 
@@ -1684,17 +1553,7 @@ func encodeRestoreSnapshotPayload(snapshot *OutgoingSnapshot) ([]byte, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 func decodeRestoreSnapshotPayload(raw []byte) (*OutgoingSnapshot, error) {
@@ -1715,13 +1574,9 @@ func decodeRestoreSnapshotPayloadWithLimits(raw []byte,
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
+	if _, err := tlvutil.DecodeRecordsFromBytes(
+		raw, records...,
+	); err != nil {
 		return nil, err
 	}
 
@@ -1757,17 +1612,7 @@ func encodeDriveEventRequestPayload(sessionID SessionID,
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 // decodeDriveEventRequestPayloadWithLimits decodes a drive-event request and
@@ -1789,13 +1634,8 @@ func decodeDriveEventRequestPayloadWithLimits(raw []byte,
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
+	_, err := tlvutil.DecodeRecordsFromBytes(raw, records...)
 	if err != nil {
-		return SessionID{}, nil, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
 		return SessionID{}, nil, err
 	}
 
@@ -2012,17 +1852,7 @@ func encodeEventPayload(event Event) ([]byte, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 // decodeEventPayloadWithLimits decodes an event payload and applies receive
@@ -2077,13 +1907,8 @@ func decodeEventPayloadWithLimits(raw []byte,
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
+	_, err := tlvutil.DecodeRecordsFromBytes(raw, records...)
 	if err != nil {
-		return nil, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
 		return nil, err
 	}
 

--- a/oor/outbox_messages.go
+++ b/oor/outbox_messages.go
@@ -1,7 +1,6 @@
 package oor
 
 import (
-	"bytes"
 	"fmt"
 	"time"
 
@@ -9,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	oortx "github.com/lightninglabs/darepo-client/lib/tx/oor"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
 	"github.com/lightninglabs/darepo-client/rpc/oorpb"
@@ -519,15 +519,5 @@ func encodeRetryPayload(after time.Duration, reason string) ([]byte, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }

--- a/oor/outgoing_snapshot_codec.go
+++ b/oor/outgoing_snapshot_codec.go
@@ -1,12 +1,12 @@
 package oor
 
 import (
-	"bytes"
 	"fmt"
 	"math"
 	"time"
 
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -83,17 +83,7 @@ func encodeSessionsCheckpoint(checkpoint sessionsCheckpoint) ([]byte, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 func decodeSessionsCheckpoint(raw []byte) (sessionsCheckpoint, error) {
@@ -123,13 +113,8 @@ func decodeSessionsCheckpointWithLimits(raw []byte,
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
+	_, err := tlvutil.DecodeRecordsFromBytes(raw, records...)
 	if err != nil {
-		return sessionsCheckpoint{}, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
 		return sessionsCheckpoint{}, err
 	}
 
@@ -265,17 +250,7 @@ func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 func decodeOutgoingSnapshot(raw []byte) (*OutgoingSnapshot, error) {
@@ -323,13 +298,8 @@ func decodeOutgoingSnapshotWithLimits(raw []byte,
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
+	_, err := tlvutil.DecodeRecordsFromBytes(raw, records...)
 	if err != nil {
-		return nil, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
 		return nil, err
 	}
 

--- a/oor/package_artifact_codec.go
+++ b/oor/package_artifact_codec.go
@@ -1,9 +1,9 @@
 package oor
 
 import (
-	"bytes"
 	"fmt"
 
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -107,17 +107,7 @@ func encodePackageArtifact(artifact PackageArtifact) ([]byte, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 // decodePackageArtifactWithLimits deserializes one package artifact while
@@ -143,13 +133,8 @@ func decodePackageArtifactWithLimits(raw []byte,
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
+	_, err := tlvutil.DecodeRecordsFromBytes(raw, records...)
 	if err != nil {
-		return PackageArtifact{}, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
 		return PackageArtifact{}, err
 	}
 

--- a/oor/receive_snapshot.go
+++ b/oor/receive_snapshot.go
@@ -1,11 +1,11 @@
 package oor
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -307,17 +307,7 @@ func encodeIncomingSnapshot(snapshot *IncomingSnapshot) ([]byte, error) {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 // decodeIncomingSnapshotWithLimits decodes one incoming snapshot and applies
@@ -373,13 +363,8 @@ func decodeIncomingSnapshotWithLimits(raw []byte,
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
+	_, err := tlvutil.DecodeRecordsFromBytes(raw, records...)
 	if err != nil {
-		return nil, err
-	}
-
-	reader := bytes.NewReader(raw)
-	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
 		return nil, err
 	}
 

--- a/oor/signing_effect_actor.go
+++ b/oor/signing_effect_actor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/lib/tx/psbtutil"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -122,12 +123,7 @@ func (m *SigningEffectRequest) Encode(w io.Writer) error {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
+	return tlvutil.EncodeRecords(w, records...)
 }
 
 // Decode deserializes the signing request.
@@ -157,12 +153,8 @@ func (m *SigningEffectRequest) Decode(r io.Reader) error {
 		),
 	}
 
-	stream, err := tlv.NewStream(records...)
+	_, err := tlvutil.DecodeRecords(r, records...)
 	if err != nil {
-		return err
-	}
-
-	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
 		return err
 	}
 

--- a/serverconn/actor.go
+++ b/serverconn/actor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
@@ -268,15 +269,10 @@ func (m *SendClientEventRequest) Encode(w io.Writer) error {
 		corrKeyBytes,
 	)
 
-	stream, err := tlv.NewStream(
-		payload.Record(), msgIDRec.Record(), idemRec.Record(),
+	return tlvutil.EncodeRecords(
+		w, payload.Record(), msgIDRec.Record(), idemRec.Record(),
 		svcRec.Record(), methodRec.Record(), corrKeyRec.Record(),
 	)
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes the message from the provided reader. The proto payload
@@ -295,15 +291,10 @@ func (m *SendClientEventRequest) Decode(r io.Reader) error {
 	methodRec := tlv.ZeroRecordT[rpcMethodRecordTLV, []byte]()
 	corrKeyRec := tlv.ZeroRecordT[correlationKeyRecordTLV, []byte]()
 
-	stream, err := tlv.NewStream(
-		payload.Record(), msgIDRec.Record(), idemRec.Record(),
+	if _, err := tlvutil.DecodeRecords(
+		r, payload.Record(), msgIDRec.Record(), idemRec.Record(),
 		svcRec.Record(), methodRec.Record(), corrKeyRec.Record(),
-	)
-	if err != nil {
-		return err
-	}
-
-	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+	); err != nil {
 		return err
 	}
 
@@ -441,12 +432,7 @@ func (m *SendRPCRequest) Encode(w io.Writer) error {
 		},
 	)
 
-	stream, err := tlv.NewStream(envRec.Record())
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
+	return tlvutil.EncodeRecords(w, envRec.Record())
 }
 
 // Decode deserializes the message from the provided reader.
@@ -457,12 +443,7 @@ func (m *SendRPCRequest) Decode(r io.Reader) error {
 	]()
 	envRec.Val.Val = &mailboxpb.Envelope{}
 
-	stream, err := tlv.NewStream(envRec.Record())
-	if err != nil {
-		return err
-	}
-
-	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+	if _, err := tlvutil.DecodeRecords(r, envRec.Record()); err != nil {
 		return err
 	}
 
@@ -589,15 +570,10 @@ func (m *SendUnaryRequest) Encode(w io.Writer) error {
 		[]byte(m.CorrelationID),
 	)
 
-	stream, err := tlv.NewStream(
-		bodyRec.Record(), msgIDRec.Record(), idemRec.Record(),
+	return tlvutil.EncodeRecords(
+		w, bodyRec.Record(), msgIDRec.Record(), idemRec.Record(),
 		svcRec.Record(), methodRec.Record(), corrRec.Record(),
 	)
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes the message from the provided reader.
@@ -614,15 +590,10 @@ func (m *SendUnaryRequest) Decode(r io.Reader) error {
 	methodRec := tlv.ZeroRecordT[rpcMethodRecordTLV, []byte]()
 	corrRec := tlv.ZeroRecordT[rpcCorrelationRecordTLV, []byte]()
 
-	stream, err := tlv.NewStream(
-		bodyRec.Record(), msgIDRec.Record(), idemRec.Record(),
+	if _, err := tlvutil.DecodeRecords(
+		r, bodyRec.Record(), msgIDRec.Record(), idemRec.Record(),
 		svcRec.Record(), methodRec.Record(), corrRec.Record(),
-	)
-	if err != nil {
-		return err
-	}
-
-	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+	); err != nil {
 		return err
 	}
 

--- a/serverconn/durable_unary_queries.go
+++ b/serverconn/durable_unary_queries.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	"github.com/lightninglabs/darepo-client/internal/indexerlimits"
 	mailboxconn "github.com/lightninglabs/darepo-client/mailbox/conn"
 	mailboxrpc "github.com/lightninglabs/darepo-client/mailbox/rpc"
@@ -180,16 +181,11 @@ func (m *SendListOORRecipientEventsByScriptRequest) Encode(w io.Writer) error {
 		[]byte(idempotencyKey),
 	)
 
-	stream, err := tlv.NewStream(
-		pkScriptRec.Record(), afterEventRec.Record(), limitRec.Record(),
-		correlationRec.Record(), msgIDRec.Record(),
+	return tlvutil.EncodeRecords(
+		w, pkScriptRec.Record(), afterEventRec.Record(),
+		limitRec.Record(), correlationRec.Record(), msgIDRec.Record(),
 		idempotencyRec.Record(),
 	)
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes the message from the provided reader.
@@ -210,16 +206,11 @@ func (m *SendListOORRecipientEventsByScriptRequest) Decode(r io.Reader) error {
 		[]byte,
 	]()
 
-	stream, err := tlv.NewStream(
-		pkScriptRec.Record(), afterEventRec.Record(), limitRec.Record(),
-		correlationRec.Record(), msgIDRec.Record(),
+	if _, err := tlvutil.DecodeRecords(
+		r, pkScriptRec.Record(), afterEventRec.Record(),
+		limitRec.Record(), correlationRec.Record(), msgIDRec.Record(),
 		idempotencyRec.Record(),
-	)
-	if err != nil {
-		return err
-	}
-
-	if _, err := stream.DecodeWithParsedTypes(r); err != nil {
+	); err != nil {
 		return err
 	}
 
@@ -382,16 +373,11 @@ func (m *SendListVTXOsByScriptsRequest) Encode(w io.Writer) error {
 		),
 	)
 
-	stream, err := tlv.NewStream(
-		pkScriptsRec.Record(), limitRec.Record(),
+	return tlvutil.EncodeRecords(
+		w, pkScriptsRec.Record(), limitRec.Record(),
 		correlationRec.Record(), msgIDRec.Record(),
 		idempotencyRec.Record(), afterCursorRec.Record(),
 	)
-	if err != nil {
-		return err
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes the message from the provided reader.
@@ -416,16 +402,11 @@ func (m *SendListVTXOsByScriptsRequest) Decode(r io.Reader) error {
 		[]byte,
 	]()
 
-	stream, err := tlv.NewStream(
-		pkScriptsRec.Record(), legacyCursorRec.Record(),
+	parsed, err := tlvutil.DecodeRecords(
+		r, pkScriptsRec.Record(), legacyCursorRec.Record(),
 		limitRec.Record(), correlationRec.Record(), msgIDRec.Record(),
 		idempotencyRec.Record(), afterCursorRec.Record(),
 	)
-	if err != nil {
-		return err
-	}
-
-	parsed, err := stream.DecodeWithParsedTypes(r)
 	if err != nil {
 		return err
 	}

--- a/unroll/deferred_checkpoint_codec.go
+++ b/unroll/deferred_checkpoint_codec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -73,7 +74,7 @@ func encodeDeferredCheckpointEntry(c *DeferredCheckpoint) ([]byte, error) {
 	txidBytes := c.Txid[:]
 	deadline := uint32(c.DeadlineHeight)
 
-	stream, err := tlv.NewStream(
+	return tlvutil.EncodeRecordsToBytes(
 		tlv.MakePrimitiveRecord(
 			deferredCheckpointTxidRecordType, &txidBytes,
 		),
@@ -81,16 +82,6 @@ func encodeDeferredCheckpointEntry(c *DeferredCheckpoint) ([]byte, error) {
 			deferredCheckpointDeadlineRecordType, &deadline,
 		),
 	)
-	if err != nil {
-		return nil, fmt.Errorf("new entry stream: %w", err)
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, fmt.Errorf("encode entry stream: %w", err)
-	}
-
-	return buf.Bytes(), nil
 }
 
 // decodeDeferredCheckpoints parses deferred checkpoint state encoded by
@@ -147,20 +138,14 @@ func decodeDeferredCheckpointEntry(raw []byte) (DeferredCheckpoint, error) {
 		deadline  uint32
 	)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	if _, err := tlvutil.DecodeRecords(
+		bytes.NewReader(raw), tlv.MakePrimitiveRecord(
 			deferredCheckpointTxidRecordType, &txidBytes,
 		),
 		tlv.MakePrimitiveRecord(
 			deferredCheckpointDeadlineRecordType, &deadline,
 		),
-	)
-	if err != nil {
-		return DeferredCheckpoint{}, fmt.Errorf("new entry stream: %w",
-			err)
-	}
-
-	if err := stream.Decode(bytes.NewReader(raw)); err != nil {
+	); err != nil {
 		return DeferredCheckpoint{}, fmt.Errorf("decode entry "+
 			"stream: %w", err)
 	}

--- a/unroll/messages.go
+++ b/unroll/messages.go
@@ -7,6 +7,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	"github.com/lightninglabs/darepo-client/unrollplan"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -201,12 +202,7 @@ func (m *StartUnrollRequest) Encode(w io.Writer) error {
 		)
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return fmt.Errorf("create stream: %w", err)
-	}
-
-	return stream.Encode(w)
+	return tlvutil.EncodeRecords(w, records...)
 }
 
 // Decode deserializes the message from a TLV stream.
@@ -214,8 +210,8 @@ func (m *StartUnrollRequest) Decode(r io.Reader) error {
 	var height, trigger uint32
 	var policyKind, policyRef []byte
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(startUnrollHeightRecType, &height),
+	parsed, err := tlvutil.DecodeRecords(
+		r, tlv.MakePrimitiveRecord(startUnrollHeightRecType, &height),
 		tlv.MakePrimitiveRecord(startUnrollTriggerRecType, &trigger),
 		tlv.MakePrimitiveRecord(
 			startUnrollExitPolicyKindRecType, &policyKind,
@@ -224,11 +220,6 @@ func (m *StartUnrollRequest) Decode(r io.Reader) error {
 			startUnrollExitPolicyRefRecType, &policyRef,
 		),
 	)
-	if err != nil {
-		return fmt.Errorf("create stream: %w", err)
-	}
-
-	parsed, err := stream.DecodeWithParsedTypes(r)
 	if err != nil {
 		return fmt.Errorf("decode: %w", err)
 	}
@@ -278,28 +269,18 @@ func (m *ResumeUnrollRequest) TLVType() tlv.Type {
 func (m *ResumeUnrollRequest) Encode(w io.Writer) error {
 	height := uint32(m.Height)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(resumeUnrollHeightRecType, &height),
+	return tlvutil.EncodeRecords(
+		w, tlv.MakePrimitiveRecord(resumeUnrollHeightRecType, &height),
 	)
-	if err != nil {
-		return fmt.Errorf("create stream: %w", err)
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes the message from a TLV stream.
 func (m *ResumeUnrollRequest) Decode(r io.Reader) error {
 	var height uint32
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(resumeUnrollHeightRecType, &height),
-	)
-	if err != nil {
-		return fmt.Errorf("create stream: %w", err)
-	}
-
-	if err := stream.Decode(r); err != nil {
+	if _, err := tlvutil.DecodeRecords(
+		r, tlv.MakePrimitiveRecord(resumeUnrollHeightRecType, &height),
+	); err != nil {
 		return fmt.Errorf("decode: %w", err)
 	}
 
@@ -338,28 +319,20 @@ func (m *HeightObservedMsg) Priority() int {
 func (m *HeightObservedMsg) Encode(w io.Writer) error {
 	height := uint32(m.Height)
 
-	stream, err := tlv.NewStream(
+	return tlvutil.EncodeRecords(
+		w,
 		tlv.MakePrimitiveRecord(heightObservedHeightRecType, &height),
 	)
-	if err != nil {
-		return fmt.Errorf("create stream: %w", err)
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes the message from a TLV stream.
 func (m *HeightObservedMsg) Decode(r io.Reader) error {
 	var height uint32
 
-	stream, err := tlv.NewStream(
+	if _, err := tlvutil.DecodeRecords(
+		r,
 		tlv.MakePrimitiveRecord(heightObservedHeightRecType, &height),
-	)
-	if err != nil {
-		return fmt.Errorf("create stream: %w", err)
-	}
-
-	if err := stream.Decode(r); err != nil {
+	); err != nil {
 		return fmt.Errorf("decode: %w", err)
 	}
 
@@ -406,18 +379,13 @@ func (m *TxConfirmedMsg) Encode(w io.Writer) error {
 	height := uint32(m.Height)
 	numConfs := m.NumConfs
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(txConfirmedTxidRecType, &txid),
+	return tlvutil.EncodeRecords(
+		w, tlv.MakePrimitiveRecord(txConfirmedTxidRecType, &txid),
 		tlv.MakePrimitiveRecord(txConfirmedHeightRecType, &height),
 		tlv.MakePrimitiveRecord(
 			txConfirmedNumConfsRecType, &numConfs,
 		),
 	)
-	if err != nil {
-		return fmt.Errorf("create stream: %w", err)
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes the message from a TLV stream.
@@ -428,18 +396,13 @@ func (m *TxConfirmedMsg) Decode(r io.Reader) error {
 		numConfs uint32
 	)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(txConfirmedTxidRecType, &txid),
+	if _, err := tlvutil.DecodeRecords(
+		r, tlv.MakePrimitiveRecord(txConfirmedTxidRecType, &txid),
 		tlv.MakePrimitiveRecord(txConfirmedHeightRecType, &height),
 		tlv.MakePrimitiveRecord(
 			txConfirmedNumConfsRecType, &numConfs,
 		),
-	)
-	if err != nil {
-		return fmt.Errorf("create stream: %w", err)
-	}
-
-	if err := stream.Decode(r); err != nil {
+	); err != nil {
 		return fmt.Errorf("decode: %w", err)
 	}
 
@@ -484,15 +447,10 @@ func (m *TxFailedMsg) Encode(w io.Writer) error {
 	txid := [32]byte(m.Txid)
 	reason := []byte(m.Reason)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(txFailedTxidRecType, &txid),
+	return tlvutil.EncodeRecords(
+		w, tlv.MakePrimitiveRecord(txFailedTxidRecType, &txid),
 		tlv.MakePrimitiveRecord(txFailedReasonRecType, &reason),
 	)
-	if err != nil {
-		return fmt.Errorf("create stream: %w", err)
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes the message from a TLV stream.
@@ -502,15 +460,10 @@ func (m *TxFailedMsg) Decode(r io.Reader) error {
 		reason []byte
 	)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(txFailedTxidRecType, &txid),
+	if _, err := tlvutil.DecodeRecords(
+		r, tlv.MakePrimitiveRecord(txFailedTxidRecType, &txid),
 		tlv.MakePrimitiveRecord(txFailedReasonRecType, &reason),
-	)
-	if err != nil {
-		return fmt.Errorf("create stream: %w", err)
-	}
-
-	if err := stream.Decode(r); err != nil {
+	); err != nil {
 		return fmt.Errorf("decode: %w", err)
 	}
 
@@ -559,19 +512,14 @@ func (m *SpendObservedMsg) Encode(w io.Writer) error {
 	outHash := [32]byte(m.Outpoint.Hash)
 	outIndex := m.Outpoint.Index
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(spendObservedTxidRecType, &txid),
+	return tlvutil.EncodeRecords(
+		w, tlv.MakePrimitiveRecord(spendObservedTxidRecType, &txid),
 		tlv.MakePrimitiveRecord(spendObservedHeightRecType, &height),
 		tlv.MakePrimitiveRecord(spendObservedOutHashRecType, &outHash),
 		tlv.MakePrimitiveRecord(
 			spendObservedOutIndexRecType, &outIndex,
 		),
 	)
-	if err != nil {
-		return fmt.Errorf("create stream: %w", err)
-	}
-
-	return stream.Encode(w)
 }
 
 // Decode deserializes the message from a TLV stream.
@@ -583,19 +531,14 @@ func (m *SpendObservedMsg) Decode(r io.Reader) error {
 		outIndex uint32
 	)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(spendObservedTxidRecType, &txid),
+	if _, err := tlvutil.DecodeRecords(
+		r, tlv.MakePrimitiveRecord(spendObservedTxidRecType, &txid),
 		tlv.MakePrimitiveRecord(spendObservedHeightRecType, &height),
 		tlv.MakePrimitiveRecord(spendObservedOutHashRecType, &outHash),
 		tlv.MakePrimitiveRecord(
 			spendObservedOutIndexRecType, &outIndex,
 		),
-	)
-	if err != nil {
-		return fmt.Errorf("create stream: %w", err)
-	}
-
-	if err := stream.Decode(r); err != nil {
+	); err != nil {
 		return fmt.Errorf("decode: %w", err)
 	}
 

--- a/unroll/snapshot.go
+++ b/unroll/snapshot.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	"github.com/lightninglabs/darepo-client/unrollplan"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -226,17 +227,7 @@ func encodeCheckpoint(value *actorCheckpoint) ([]byte, error) {
 		)
 	}
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, fmt.Errorf("create checkpoint stream: %w", err)
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, fmt.Errorf("encode checkpoint: %w", err)
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 // decodeCheckpoint parses TLV-encoded checkpoint bytes back into an
@@ -268,8 +259,8 @@ func decodeCheckpoint(raw []byte) (*actorCheckpoint, error) {
 		policyRef     []byte
 	)
 
-	stream, err := tlv.NewStream(
-		tlv.MakePrimitiveRecord(
+	parsed, err := tlvutil.DecodeRecords(
+		bytes.NewReader(raw), tlv.MakePrimitiveRecord(
 			checkpointVersionRecordType, &version,
 		),
 		tlv.MakePrimitiveRecord(
@@ -303,11 +294,6 @@ func decodeCheckpoint(raw []byte) (*actorCheckpoint, error) {
 			checkpointExitPolicyRefRecordType, &policyRef,
 		),
 	)
-	if err != nil {
-		return nil, fmt.Errorf("create checkpoint stream: %w", err)
-	}
-
-	parsed, err := stream.DecodeWithParsedTypes(bytes.NewReader(raw))
 	if err != nil {
 		return nil, fmt.Errorf("decode checkpoint: %w", err)
 	}

--- a/unrollplan/state_codec.go
+++ b/unrollplan/state_codec.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/baselib/tlvutil"
 	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -94,17 +95,7 @@ func EncodeState(state *State) ([]byte, error) {
 		),
 	)
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, fmt.Errorf("create state stream: %w", err)
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, fmt.Errorf("encode state: %w", err)
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 // DecodeState parses a TLV-encoded State and rejects unknown codec versions.
@@ -117,7 +108,8 @@ func DecodeState(raw []byte) (*State, error) {
 		sweepRaw            []byte
 	)
 
-	stream, err := tlv.NewStream(
+	parsed, err := tlvutil.DecodeRecords(
+		bytes.NewReader(raw),
 		tlv.MakePrimitiveRecord(stateVersionRecordType, &version),
 		tlv.MakePrimitiveRecord(
 			stateConfirmedTxidsRecordType, &confirmedRaw,
@@ -131,11 +123,6 @@ func DecodeState(raw []byte) (*State, error) {
 		),
 		tlv.MakePrimitiveRecord(stateSweepRecordType, &sweepRaw),
 	)
-	if err != nil {
-		return nil, fmt.Errorf("create state stream: %w", err)
-	}
-
-	parsed, err := stream.DecodeWithParsedTypes(bytes.NewReader(raw))
 	if err != nil {
 		return nil, fmt.Errorf("decode state: %w", err)
 	}
@@ -271,17 +258,7 @@ func encodeSweepState(sweep SweepState) ([]byte, error) {
 		)
 	})
 
-	stream, err := tlv.NewStream(records...)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	if err := stream.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
+	return tlvutil.EncodeRecordsToBytes(records...)
 }
 
 // decodeSweepState reverses encodeSweepState.
@@ -292,18 +269,14 @@ func decodeSweepState(raw []byte) (SweepState, error) {
 		confirmHeight uint32
 	)
 
-	stream, err := tlv.NewStream(
+	parsed, err := tlvutil.DecodeRecords(
+		bytes.NewReader(raw),
 		tlv.MakePrimitiveRecord(sweepStatusRecordType, &statusByte),
 		tlv.MakePrimitiveRecord(sweepTxidRecordType, &txid),
 		tlv.MakePrimitiveRecord(
 			sweepConfirmHeightRecordType, &confirmHeight,
 		),
 	)
-	if err != nil {
-		return SweepState{}, err
-	}
-
-	parsed, err := stream.DecodeWithParsedTypes(bytes.NewReader(raw))
 	if err != nil {
 		return SweepState{}, err
 	}


### PR DESCRIPTION
In this PR, we cut down the pile of near-identical TLV serialization code
that every durable-actor message codec was carrying. Each `Encode`/`Decode`
hand-wrote the same `tlv.NewStream(...)` / `if err != nil` / `Encode(w)` (or
`DecodeWithParsedTypes`) dance, and a handful of domain types (outpoints
especially) were re-encoded from scratch in each package. We pull all of that
behind one small shared package, `baselib/tlvutil`, and migrate the codecs
onto it.

The package lives under `baselib` on purpose: it's the one module both this
repo and the server (darepo) already import, so the same helpers can be reused
on both sides. The server-side migration is a follow-up PR that bumps the
submodule to pick this up (see below).

## What's in tlvutil

Two things, and deliberately not more.

First, the stream helpers: `EncodeRecords`, `DecodeRecords`, and the
byte-slice variants. These are thin wrappers over `tlv.NewStream` that collapse
the repeated scaffolding into a single call. They emit byte-for-byte the same
output as the inlined form they replace, so adopting them is purely mechanical.
There's a property test that checks this equivalence directly against the old
`NewStream`/`Encode` shape.

Second, `OutPointRecord`. This is the one domain type worth centralizing: a
`wire.OutPoint` has no native `tlv` primitive, so every codec re-rolled the
"32-byte hash plus 4-byte little-endian index" encoding by hand. We give it a
single shared constructor that takes a pointer to the caller's existing
`wire.OutPoint` field, so nothing has to change the field's type to adopt it.

Notably, we *don't* add helpers for pubkeys, hashes, or the integer widths.
`tlv.MakePrimitiveRecord` already handles `**btcec.PublicKey`, `*[32]byte`,
`*[33]byte`, the `uint` types, and `[]byte` natively, so those just call the
native primitive directly (a `chainhash.Hash` is a `(*[32]byte)` cast away).
There's a test that locks that reuse in so we don't regrow wrappers later.

## Wire compatibility

This is the important part: durable mailbox state and on-disk blobs are
persisted, so the wire format has to stay byte-identical. It does. The records
passed to the helpers are unchanged, only the surrounding scaffolding moves, so
the encoding can't shift. On top of the property tests, we add a golden test
that pins the exact wire bytes of a fully-populated `VTXOSentMsg` (which goes
through `OutPointRecord`), so any accidental format change breaks loudly.

The `ledger` package had zero codec-level tests before this, so we also add
round-trip coverage for all six of its durable messages while we're here.

## Numbers

The migrated codecs drop ~570 lines net (739 removed, 169 added back as call
sites), against +154 for the one-time shared library, for ~−416 net in
production code in this repo. The new tests add ~486 lines of coverage that
didn't exist before.

See each commit message for the per-package detail.
