### PR TITLE
swapwallet: use server quotes in PrepareSend

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_send_test.go
+++ b/cmd/darepocli/darepoclicommands/cmd_send_test.go
@@ -60,6 +60,39 @@ func TestPromptSendConfirmationAcceptsYes(t *testing.T) {
 	require.Contains(t, stderr.String(), "Proceed? [y/N]:")
 }
 
+func TestPromptSendConfirmationDisplaysQuoteDetails(t *testing.T) {
+	cmd := newSendCmd()
+	cmd.SetIn(strings.NewReader("yes\n"))
+
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	err := promptSendConfirmation(cmd, &walletdkrpc.PrepareSendResponse{
+		AmountSat:               50_000,
+		ExpectedFeeSat:          123,
+		FeeKnown:                true,
+		ExpectedTotalOutflowSat: 50_123,
+		TotalOutflowKnown:       true,
+		Rail: walletdkrpc.
+			SendRail_SEND_RAIL_LIGHTNING,
+		DestinationSummary: "lnbcrt...",
+		InvoiceDescription: "coffee",
+		PaymentHash:        "abcd",
+		Warning:            "quoted fee exceeds max_fee_sat",
+	})
+	require.NoError(t, err)
+
+	output := stderr.String()
+	require.Contains(t, output, "Send 50000 sats")
+	require.Contains(t, output, "Rail: Lightning")
+	require.Contains(t, output, "Expected fee: 123 sats")
+	require.Contains(t, output, "Expected total outflow: 50123 sats")
+	require.Contains(t, output, "Destination: lnbcrt...")
+	require.Contains(t, output, "Invoice: coffee")
+	require.Contains(t, output, "Payment hash: abcd")
+	require.Contains(t, output, "Warning: quoted fee exceeds max_fee_sat")
+}
+
 func TestPromptSendConfirmationUsesSweepOutflow(t *testing.T) {
 	cmd := newSendCmd()
 	cmd.SetIn(strings.NewReader("yes\n"))

--- a/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
@@ -304,6 +304,13 @@ func generatedRegistry() []serviceSpec {
 			Comments: "SwapClientService exposes daemon-owned Lightning/Ark swap execution to local\nclients. The service is registered only in swapruntime builds.",
 			Methods: []methodSpec{
 				{
+					Name:     "QuotePay",
+					Aliases:  []string{"quote-pay"},
+					Input:    "swapclientrpc.QuotePayRequest",
+					Output:   "swapclientrpc.QuotePayResponse",
+					Comments: "QuotePay previews an Ark-to-Lightning payment without creating durable\nswap state or starting a background worker.",
+				},
+				{
 					Name:     "StartPay",
 					Aliases:  []string{"start-pay"},
 					Input:    "swapclientrpc.StartPayRequest",

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -175,6 +175,17 @@ func (c *SwapServiceClient) CreateInSwap(ctx context.Context,
 	return out, err
 }
 
+// QuoteInSwap previews one Ark-to-Lightning swap with the swap server.
+func (c *SwapServiceClient) QuoteInSwap(ctx context.Context,
+	in *swaprpc.QuoteInSwapRequest, _ ...grpc.CallOption) (
+	*swaprpc.QuoteInSwapResponse, error) {
+
+	out := new(swaprpc.QuoteInSwapResponse)
+	err := c.client.Post(ctx, "/v1/swap/quote-in-swap", in, out)
+
+	return out, err
+}
+
 // AuthorizeInSwapRefund asks the swap server to sign a failed in-swap refund.
 func (c *SwapServiceClient) AuthorizeInSwapRefund(ctx context.Context,
 	in *swaprpc.AuthorizeInSwapRefundRequest, _ ...grpc.CallOption) (
@@ -701,6 +712,17 @@ func NewSwapClientServiceClientFromClient(
 // grpc-gateway.
 type SwapClientServiceClient struct {
 	client *Client
+}
+
+// QuotePay previews a daemon-owned pay swap.
+func (c *SwapClientServiceClient) QuotePay(ctx context.Context,
+	in *swapclientrpc.QuotePayRequest, _ ...grpc.CallOption) (
+	*swapclientrpc.QuotePayResponse, error) {
+
+	out := new(swapclientrpc.QuotePayResponse)
+	err := c.client.Post(ctx, "/v1/swapclient/quote-pay", in, out)
+
+	return out, err
 }
 
 // StartPay starts a daemon-owned pay swap.

--- a/rpc/swapclientrpc/swap_client.pb.go
+++ b/rpc/swapclientrpc/swap_client.pb.go
@@ -201,6 +201,162 @@ func (SwapState) EnumDescriptor() ([]byte, []int) {
 	return file_swap_client_proto_rawDescGZIP(), []int{2}
 }
 
+type QuotePayRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// invoice is the BOLT-11 Lightning invoice to preview.
+	Invoice string `protobuf:"bytes,1,opt,name=invoice,proto3" json:"invoice,omitempty"`
+	// max_fee_sat is the maximum Lightning routing fee the caller accepts.
+	// Zero means no explicit caller cap. Quotes still return when the
+	// estimated fee exceeds this cap so callers can render the fee.
+	MaxFeeSat     uint64 `protobuf:"varint,2,opt,name=max_fee_sat,json=maxFeeSat,proto3" json:"max_fee_sat,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QuotePayRequest) Reset() {
+	*x = QuotePayRequest{}
+	mi := &file_swap_client_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QuotePayRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QuotePayRequest) ProtoMessage() {}
+
+func (x *QuotePayRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_client_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QuotePayRequest.ProtoReflect.Descriptor instead.
+func (*QuotePayRequest) Descriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *QuotePayRequest) GetInvoice() string {
+	if x != nil {
+		return x.Invoice
+	}
+	return ""
+}
+
+func (x *QuotePayRequest) GetMaxFeeSat() uint64 {
+	if x != nil {
+		return x.MaxFeeSat
+	}
+	return 0
+}
+
+type QuotePayResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// payment_hash is the hex Lightning payment hash that identifies the
+	// invoice and eventual swap.
+	PaymentHash string `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// invoice_amount_sat is the whole-satoshi invoice amount.
+	InvoiceAmountSat uint64 `protobuf:"varint,2,opt,name=invoice_amount_sat,json=invoiceAmountSat,proto3" json:"invoice_amount_sat,omitempty"`
+	// amount_sat is the total amount that would leave the wallet.
+	AmountSat uint64 `protobuf:"varint,3,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// fee_sat is the swap-server fee in satoshis.
+	FeeSat         uint64             `protobuf:"varint,4,opt,name=fee_sat,json=feeSat,proto3" json:"fee_sat,omitempty"`
+	SettlementType SwapSettlementType `protobuf:"varint,5,opt,name=settlement_type,json=settlementType,proto3,enum=swapclientrpc.SwapSettlementType" json:"settlement_type,omitempty"`
+	// expires_at_unix is the unix timestamp after which the quote is stale.
+	ExpiresAtUnix int64 `protobuf:"varint,6,opt,name=expires_at_unix,json=expiresAtUnix,proto3" json:"expires_at_unix,omitempty"`
+	// exceeds_max_fee is true when max_fee_sat is non-zero and fee_sat is
+	// larger than that cap.
+	ExceedsMaxFee bool `protobuf:"varint,7,opt,name=exceeds_max_fee,json=exceedsMaxFee,proto3" json:"exceeds_max_fee,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QuotePayResponse) Reset() {
+	*x = QuotePayResponse{}
+	mi := &file_swap_client_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QuotePayResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QuotePayResponse) ProtoMessage() {}
+
+func (x *QuotePayResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_client_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QuotePayResponse.ProtoReflect.Descriptor instead.
+func (*QuotePayResponse) Descriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *QuotePayResponse) GetPaymentHash() string {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return ""
+}
+
+func (x *QuotePayResponse) GetInvoiceAmountSat() uint64 {
+	if x != nil {
+		return x.InvoiceAmountSat
+	}
+	return 0
+}
+
+func (x *QuotePayResponse) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *QuotePayResponse) GetFeeSat() uint64 {
+	if x != nil {
+		return x.FeeSat
+	}
+	return 0
+}
+
+func (x *QuotePayResponse) GetSettlementType() SwapSettlementType {
+	if x != nil {
+		return x.SettlementType
+	}
+	return SwapSettlementType_SWAP_SETTLEMENT_TYPE_UNSPECIFIED
+}
+
+func (x *QuotePayResponse) GetExpiresAtUnix() int64 {
+	if x != nil {
+		return x.ExpiresAtUnix
+	}
+	return 0
+}
+
+func (x *QuotePayResponse) GetExceedsMaxFee() bool {
+	if x != nil {
+		return x.ExceedsMaxFee
+	}
+	return false
+}
+
 type StartPayRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// invoice is the BOLT-11 Lightning invoice to pay.
@@ -218,7 +374,7 @@ type StartPayRequest struct {
 
 func (x *StartPayRequest) Reset() {
 	*x = StartPayRequest{}
-	mi := &file_swap_client_proto_msgTypes[0]
+	mi := &file_swap_client_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -230,7 +386,7 @@ func (x *StartPayRequest) String() string {
 func (*StartPayRequest) ProtoMessage() {}
 
 func (x *StartPayRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[0]
+	mi := &file_swap_client_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -243,7 +399,7 @@ func (x *StartPayRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartPayRequest.ProtoReflect.Descriptor instead.
 func (*StartPayRequest) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{0}
+	return file_swap_client_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *StartPayRequest) GetInvoice() string {
@@ -281,7 +437,7 @@ type StartPayResponse struct {
 
 func (x *StartPayResponse) Reset() {
 	*x = StartPayResponse{}
-	mi := &file_swap_client_proto_msgTypes[1]
+	mi := &file_swap_client_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -293,7 +449,7 @@ func (x *StartPayResponse) String() string {
 func (*StartPayResponse) ProtoMessage() {}
 
 func (x *StartPayResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[1]
+	mi := &file_swap_client_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -306,7 +462,7 @@ func (x *StartPayResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartPayResponse.ProtoReflect.Descriptor instead.
 func (*StartPayResponse) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{1}
+	return file_swap_client_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *StartPayResponse) GetPaymentHash() string {
@@ -339,7 +495,7 @@ type StartReceiveRequest struct {
 
 func (x *StartReceiveRequest) Reset() {
 	*x = StartReceiveRequest{}
-	mi := &file_swap_client_proto_msgTypes[2]
+	mi := &file_swap_client_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -351,7 +507,7 @@ func (x *StartReceiveRequest) String() string {
 func (*StartReceiveRequest) ProtoMessage() {}
 
 func (x *StartReceiveRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[2]
+	mi := &file_swap_client_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -364,7 +520,7 @@ func (x *StartReceiveRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartReceiveRequest.ProtoReflect.Descriptor instead.
 func (*StartReceiveRequest) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{2}
+	return file_swap_client_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *StartReceiveRequest) GetAmountSat() int64 {
@@ -404,7 +560,7 @@ type StartReceiveResponse struct {
 
 func (x *StartReceiveResponse) Reset() {
 	*x = StartReceiveResponse{}
-	mi := &file_swap_client_proto_msgTypes[3]
+	mi := &file_swap_client_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -416,7 +572,7 @@ func (x *StartReceiveResponse) String() string {
 func (*StartReceiveResponse) ProtoMessage() {}
 
 func (x *StartReceiveResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[3]
+	mi := &file_swap_client_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -429,7 +585,7 @@ func (x *StartReceiveResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartReceiveResponse.ProtoReflect.Descriptor instead.
 func (*StartReceiveResponse) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{3}
+	return file_swap_client_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *StartReceiveResponse) GetPaymentHash() string {
@@ -465,7 +621,7 @@ type ResumeSwapRequest struct {
 
 func (x *ResumeSwapRequest) Reset() {
 	*x = ResumeSwapRequest{}
-	mi := &file_swap_client_proto_msgTypes[4]
+	mi := &file_swap_client_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -477,7 +633,7 @@ func (x *ResumeSwapRequest) String() string {
 func (*ResumeSwapRequest) ProtoMessage() {}
 
 func (x *ResumeSwapRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[4]
+	mi := &file_swap_client_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -490,7 +646,7 @@ func (x *ResumeSwapRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeSwapRequest.ProtoReflect.Descriptor instead.
 func (*ResumeSwapRequest) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{4}
+	return file_swap_client_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ResumeSwapRequest) GetPaymentHash() string {
@@ -517,7 +673,7 @@ type ResumeSwapResponse struct {
 
 func (x *ResumeSwapResponse) Reset() {
 	*x = ResumeSwapResponse{}
-	mi := &file_swap_client_proto_msgTypes[5]
+	mi := &file_swap_client_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -529,7 +685,7 @@ func (x *ResumeSwapResponse) String() string {
 func (*ResumeSwapResponse) ProtoMessage() {}
 
 func (x *ResumeSwapResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[5]
+	mi := &file_swap_client_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -542,7 +698,7 @@ func (x *ResumeSwapResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeSwapResponse.ProtoReflect.Descriptor instead.
 func (*ResumeSwapResponse) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{5}
+	return file_swap_client_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ResumeSwapResponse) GetSwap() *SwapSummary {
@@ -561,7 +717,7 @@ type ListSwapsRequest struct {
 
 func (x *ListSwapsRequest) Reset() {
 	*x = ListSwapsRequest{}
-	mi := &file_swap_client_proto_msgTypes[6]
+	mi := &file_swap_client_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -573,7 +729,7 @@ func (x *ListSwapsRequest) String() string {
 func (*ListSwapsRequest) ProtoMessage() {}
 
 func (x *ListSwapsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[6]
+	mi := &file_swap_client_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -586,7 +742,7 @@ func (x *ListSwapsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSwapsRequest.ProtoReflect.Descriptor instead.
 func (*ListSwapsRequest) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{6}
+	return file_swap_client_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ListSwapsRequest) GetPendingOnly() bool {
@@ -606,7 +762,7 @@ type ListSwapsResponse struct {
 
 func (x *ListSwapsResponse) Reset() {
 	*x = ListSwapsResponse{}
-	mi := &file_swap_client_proto_msgTypes[7]
+	mi := &file_swap_client_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -618,7 +774,7 @@ func (x *ListSwapsResponse) String() string {
 func (*ListSwapsResponse) ProtoMessage() {}
 
 func (x *ListSwapsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[7]
+	mi := &file_swap_client_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -631,7 +787,7 @@ func (x *ListSwapsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSwapsResponse.ProtoReflect.Descriptor instead.
 func (*ListSwapsResponse) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{7}
+	return file_swap_client_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ListSwapsResponse) GetSwaps() []*SwapSummary {
@@ -651,7 +807,7 @@ type GetSwapRequest struct {
 
 func (x *GetSwapRequest) Reset() {
 	*x = GetSwapRequest{}
-	mi := &file_swap_client_proto_msgTypes[8]
+	mi := &file_swap_client_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -663,7 +819,7 @@ func (x *GetSwapRequest) String() string {
 func (*GetSwapRequest) ProtoMessage() {}
 
 func (x *GetSwapRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[8]
+	mi := &file_swap_client_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -676,7 +832,7 @@ func (x *GetSwapRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSwapRequest.ProtoReflect.Descriptor instead.
 func (*GetSwapRequest) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{8}
+	return file_swap_client_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GetSwapRequest) GetPaymentHash() string {
@@ -696,7 +852,7 @@ type GetSwapResponse struct {
 
 func (x *GetSwapResponse) Reset() {
 	*x = GetSwapResponse{}
-	mi := &file_swap_client_proto_msgTypes[9]
+	mi := &file_swap_client_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -708,7 +864,7 @@ func (x *GetSwapResponse) String() string {
 func (*GetSwapResponse) ProtoMessage() {}
 
 func (x *GetSwapResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[9]
+	mi := &file_swap_client_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -721,7 +877,7 @@ func (x *GetSwapResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSwapResponse.ProtoReflect.Descriptor instead.
 func (*GetSwapResponse) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{9}
+	return file_swap_client_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *GetSwapResponse) GetSwap() *SwapSummary {
@@ -741,7 +897,7 @@ type SubscribeSwapsRequest struct {
 
 func (x *SubscribeSwapsRequest) Reset() {
 	*x = SubscribeSwapsRequest{}
-	mi := &file_swap_client_proto_msgTypes[10]
+	mi := &file_swap_client_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -753,7 +909,7 @@ func (x *SubscribeSwapsRequest) String() string {
 func (*SubscribeSwapsRequest) ProtoMessage() {}
 
 func (x *SubscribeSwapsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[10]
+	mi := &file_swap_client_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -766,7 +922,7 @@ func (x *SubscribeSwapsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeSwapsRequest.ProtoReflect.Descriptor instead.
 func (*SubscribeSwapsRequest) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{10}
+	return file_swap_client_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *SubscribeSwapsRequest) GetIncludeExisting() bool {
@@ -793,7 +949,7 @@ type SubscribeSwapsResponse struct {
 
 func (x *SubscribeSwapsResponse) Reset() {
 	*x = SubscribeSwapsResponse{}
-	mi := &file_swap_client_proto_msgTypes[11]
+	mi := &file_swap_client_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -805,7 +961,7 @@ func (x *SubscribeSwapsResponse) String() string {
 func (*SubscribeSwapsResponse) ProtoMessage() {}
 
 func (x *SubscribeSwapsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[11]
+	mi := &file_swap_client_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -818,7 +974,7 @@ func (x *SubscribeSwapsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeSwapsResponse.ProtoReflect.Descriptor instead.
 func (*SubscribeSwapsResponse) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{11}
+	return file_swap_client_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *SubscribeSwapsResponse) GetSwap() *SwapSummary {
@@ -884,7 +1040,7 @@ type SwapSummary struct {
 
 func (x *SwapSummary) Reset() {
 	*x = SwapSummary{}
-	mi := &file_swap_client_proto_msgTypes[12]
+	mi := &file_swap_client_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -896,7 +1052,7 @@ func (x *SwapSummary) String() string {
 func (*SwapSummary) ProtoMessage() {}
 
 func (x *SwapSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[12]
+	mi := &file_swap_client_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -909,7 +1065,7 @@ func (x *SwapSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SwapSummary.ProtoReflect.Descriptor instead.
 func (*SwapSummary) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{12}
+	return file_swap_client_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *SwapSummary) GetDirection() SwapDirection {
@@ -1056,7 +1212,19 @@ var File_swap_client_proto protoreflect.FileDescriptor
 
 const file_swap_client_proto_rawDesc = "" +
 	"\n" +
-	"\x11swap_client.proto\x12\rswapclientrpc\"t\n" +
+	"\x11swap_client.proto\x12\rswapclientrpc\"K\n" +
+	"\x0fQuotePayRequest\x12\x18\n" +
+	"\ainvoice\x18\x01 \x01(\tR\ainvoice\x12\x1e\n" +
+	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\"\xb7\x02\n" +
+	"\x10QuotePayResponse\x12!\n" +
+	"\fpayment_hash\x18\x01 \x01(\tR\vpaymentHash\x12,\n" +
+	"\x12invoice_amount_sat\x18\x02 \x01(\x04R\x10invoiceAmountSat\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x03 \x01(\x04R\tamountSat\x12\x17\n" +
+	"\afee_sat\x18\x04 \x01(\x04R\x06feeSat\x12J\n" +
+	"\x0fsettlement_type\x18\x05 \x01(\x0e2!.swapclientrpc.SwapSettlementTypeR\x0esettlementType\x12&\n" +
+	"\x0fexpires_at_unix\x18\x06 \x01(\x03R\rexpiresAtUnix\x12&\n" +
+	"\x0fexceeds_max_fee\x18\a \x01(\bR\rexceedsMaxFee\"t\n" +
 	"\x0fStartPayRequest\x12\x18\n" +
 	"\ainvoice\x18\x01 \x01(\tR\ainvoice\x12\x1e\n" +
 	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\x12'\n" +
@@ -1137,8 +1305,9 @@ const file_swap_client_proto_rawDesc = "" +
 	"\x12\x15\n" +
 	"\x11SWAP_STATE_FAILED\x10\v\x12\x1e\n" +
 	"\x1aSWAP_STATE_INVOICE_CREATED\x10\f\x12\x1e\n" +
-	"\x1aSWAP_STATE_CLAIM_INITIATED\x10\r2\x87\x04\n" +
+	"\x1aSWAP_STATE_CLAIM_INITIATED\x10\r2\xd4\x04\n" +
 	"\x11SwapClientService\x12K\n" +
+	"\bQuotePay\x12\x1e.swapclientrpc.QuotePayRequest\x1a\x1f.swapclientrpc.QuotePayResponse\x12K\n" +
 	"\bStartPay\x12\x1e.swapclientrpc.StartPayRequest\x1a\x1f.swapclientrpc.StartPayResponse\x12W\n" +
 	"\fStartReceive\x12\".swapclientrpc.StartReceiveRequest\x1a#.swapclientrpc.StartReceiveResponse\x12Q\n" +
 	"\n" +
@@ -1160,53 +1329,58 @@ func file_swap_client_proto_rawDescGZIP() []byte {
 }
 
 var file_swap_client_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_swap_client_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_swap_client_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_swap_client_proto_goTypes = []any{
 	(SwapDirection)(0),             // 0: swapclientrpc.SwapDirection
 	(SwapSettlementType)(0),        // 1: swapclientrpc.SwapSettlementType
 	(SwapState)(0),                 // 2: swapclientrpc.SwapState
-	(*StartPayRequest)(nil),        // 3: swapclientrpc.StartPayRequest
-	(*StartPayResponse)(nil),       // 4: swapclientrpc.StartPayResponse
-	(*StartReceiveRequest)(nil),    // 5: swapclientrpc.StartReceiveRequest
-	(*StartReceiveResponse)(nil),   // 6: swapclientrpc.StartReceiveResponse
-	(*ResumeSwapRequest)(nil),      // 7: swapclientrpc.ResumeSwapRequest
-	(*ResumeSwapResponse)(nil),     // 8: swapclientrpc.ResumeSwapResponse
-	(*ListSwapsRequest)(nil),       // 9: swapclientrpc.ListSwapsRequest
-	(*ListSwapsResponse)(nil),      // 10: swapclientrpc.ListSwapsResponse
-	(*GetSwapRequest)(nil),         // 11: swapclientrpc.GetSwapRequest
-	(*GetSwapResponse)(nil),        // 12: swapclientrpc.GetSwapResponse
-	(*SubscribeSwapsRequest)(nil),  // 13: swapclientrpc.SubscribeSwapsRequest
-	(*SubscribeSwapsResponse)(nil), // 14: swapclientrpc.SubscribeSwapsResponse
-	(*SwapSummary)(nil),            // 15: swapclientrpc.SwapSummary
+	(*QuotePayRequest)(nil),        // 3: swapclientrpc.QuotePayRequest
+	(*QuotePayResponse)(nil),       // 4: swapclientrpc.QuotePayResponse
+	(*StartPayRequest)(nil),        // 5: swapclientrpc.StartPayRequest
+	(*StartPayResponse)(nil),       // 6: swapclientrpc.StartPayResponse
+	(*StartReceiveRequest)(nil),    // 7: swapclientrpc.StartReceiveRequest
+	(*StartReceiveResponse)(nil),   // 8: swapclientrpc.StartReceiveResponse
+	(*ResumeSwapRequest)(nil),      // 9: swapclientrpc.ResumeSwapRequest
+	(*ResumeSwapResponse)(nil),     // 10: swapclientrpc.ResumeSwapResponse
+	(*ListSwapsRequest)(nil),       // 11: swapclientrpc.ListSwapsRequest
+	(*ListSwapsResponse)(nil),      // 12: swapclientrpc.ListSwapsResponse
+	(*GetSwapRequest)(nil),         // 13: swapclientrpc.GetSwapRequest
+	(*GetSwapResponse)(nil),        // 14: swapclientrpc.GetSwapResponse
+	(*SubscribeSwapsRequest)(nil),  // 15: swapclientrpc.SubscribeSwapsRequest
+	(*SubscribeSwapsResponse)(nil), // 16: swapclientrpc.SubscribeSwapsResponse
+	(*SwapSummary)(nil),            // 17: swapclientrpc.SwapSummary
 }
 var file_swap_client_proto_depIdxs = []int32{
-	15, // 0: swapclientrpc.StartPayResponse.swap:type_name -> swapclientrpc.SwapSummary
-	15, // 1: swapclientrpc.StartReceiveResponse.swap:type_name -> swapclientrpc.SwapSummary
-	0,  // 2: swapclientrpc.ResumeSwapRequest.direction:type_name -> swapclientrpc.SwapDirection
-	15, // 3: swapclientrpc.ResumeSwapResponse.swap:type_name -> swapclientrpc.SwapSummary
-	15, // 4: swapclientrpc.ListSwapsResponse.swaps:type_name -> swapclientrpc.SwapSummary
-	15, // 5: swapclientrpc.GetSwapResponse.swap:type_name -> swapclientrpc.SwapSummary
-	15, // 6: swapclientrpc.SubscribeSwapsResponse.swap:type_name -> swapclientrpc.SwapSummary
-	0,  // 7: swapclientrpc.SwapSummary.direction:type_name -> swapclientrpc.SwapDirection
-	2,  // 8: swapclientrpc.SwapSummary.state:type_name -> swapclientrpc.SwapState
-	1,  // 9: swapclientrpc.SwapSummary.settlement_type:type_name -> swapclientrpc.SwapSettlementType
-	3,  // 10: swapclientrpc.SwapClientService.StartPay:input_type -> swapclientrpc.StartPayRequest
-	5,  // 11: swapclientrpc.SwapClientService.StartReceive:input_type -> swapclientrpc.StartReceiveRequest
-	7,  // 12: swapclientrpc.SwapClientService.ResumeSwap:input_type -> swapclientrpc.ResumeSwapRequest
-	9,  // 13: swapclientrpc.SwapClientService.ListSwaps:input_type -> swapclientrpc.ListSwapsRequest
-	11, // 14: swapclientrpc.SwapClientService.GetSwap:input_type -> swapclientrpc.GetSwapRequest
-	13, // 15: swapclientrpc.SwapClientService.SubscribeSwaps:input_type -> swapclientrpc.SubscribeSwapsRequest
-	4,  // 16: swapclientrpc.SwapClientService.StartPay:output_type -> swapclientrpc.StartPayResponse
-	6,  // 17: swapclientrpc.SwapClientService.StartReceive:output_type -> swapclientrpc.StartReceiveResponse
-	8,  // 18: swapclientrpc.SwapClientService.ResumeSwap:output_type -> swapclientrpc.ResumeSwapResponse
-	10, // 19: swapclientrpc.SwapClientService.ListSwaps:output_type -> swapclientrpc.ListSwapsResponse
-	12, // 20: swapclientrpc.SwapClientService.GetSwap:output_type -> swapclientrpc.GetSwapResponse
-	14, // 21: swapclientrpc.SwapClientService.SubscribeSwaps:output_type -> swapclientrpc.SubscribeSwapsResponse
-	16, // [16:22] is the sub-list for method output_type
-	10, // [10:16] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	1,  // 0: swapclientrpc.QuotePayResponse.settlement_type:type_name -> swapclientrpc.SwapSettlementType
+	17, // 1: swapclientrpc.StartPayResponse.swap:type_name -> swapclientrpc.SwapSummary
+	17, // 2: swapclientrpc.StartReceiveResponse.swap:type_name -> swapclientrpc.SwapSummary
+	0,  // 3: swapclientrpc.ResumeSwapRequest.direction:type_name -> swapclientrpc.SwapDirection
+	17, // 4: swapclientrpc.ResumeSwapResponse.swap:type_name -> swapclientrpc.SwapSummary
+	17, // 5: swapclientrpc.ListSwapsResponse.swaps:type_name -> swapclientrpc.SwapSummary
+	17, // 6: swapclientrpc.GetSwapResponse.swap:type_name -> swapclientrpc.SwapSummary
+	17, // 7: swapclientrpc.SubscribeSwapsResponse.swap:type_name -> swapclientrpc.SwapSummary
+	0,  // 8: swapclientrpc.SwapSummary.direction:type_name -> swapclientrpc.SwapDirection
+	2,  // 9: swapclientrpc.SwapSummary.state:type_name -> swapclientrpc.SwapState
+	1,  // 10: swapclientrpc.SwapSummary.settlement_type:type_name -> swapclientrpc.SwapSettlementType
+	3,  // 11: swapclientrpc.SwapClientService.QuotePay:input_type -> swapclientrpc.QuotePayRequest
+	5,  // 12: swapclientrpc.SwapClientService.StartPay:input_type -> swapclientrpc.StartPayRequest
+	7,  // 13: swapclientrpc.SwapClientService.StartReceive:input_type -> swapclientrpc.StartReceiveRequest
+	9,  // 14: swapclientrpc.SwapClientService.ResumeSwap:input_type -> swapclientrpc.ResumeSwapRequest
+	11, // 15: swapclientrpc.SwapClientService.ListSwaps:input_type -> swapclientrpc.ListSwapsRequest
+	13, // 16: swapclientrpc.SwapClientService.GetSwap:input_type -> swapclientrpc.GetSwapRequest
+	15, // 17: swapclientrpc.SwapClientService.SubscribeSwaps:input_type -> swapclientrpc.SubscribeSwapsRequest
+	4,  // 18: swapclientrpc.SwapClientService.QuotePay:output_type -> swapclientrpc.QuotePayResponse
+	6,  // 19: swapclientrpc.SwapClientService.StartPay:output_type -> swapclientrpc.StartPayResponse
+	8,  // 20: swapclientrpc.SwapClientService.StartReceive:output_type -> swapclientrpc.StartReceiveResponse
+	10, // 21: swapclientrpc.SwapClientService.ResumeSwap:output_type -> swapclientrpc.ResumeSwapResponse
+	12, // 22: swapclientrpc.SwapClientService.ListSwaps:output_type -> swapclientrpc.ListSwapsResponse
+	14, // 23: swapclientrpc.SwapClientService.GetSwap:output_type -> swapclientrpc.GetSwapResponse
+	16, // 24: swapclientrpc.SwapClientService.SubscribeSwaps:output_type -> swapclientrpc.SubscribeSwapsResponse
+	18, // [18:25] is the sub-list for method output_type
+	11, // [11:18] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_swap_client_proto_init() }
@@ -1220,7 +1394,7 @@ func file_swap_client_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_swap_client_proto_rawDesc), len(file_swap_client_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   13,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rpc/swapclientrpc/swap_client.pb.gw.go
+++ b/rpc/swapclientrpc/swap_client.pb.gw.go
@@ -35,6 +35,33 @@ var (
 	_ = metadata.Join
 )
 
+func request_SwapClientService_QuotePay_0(ctx context.Context, marshaler runtime.Marshaler, client SwapClientServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq QuotePayRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.QuotePay(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SwapClientService_QuotePay_0(ctx context.Context, marshaler runtime.Marshaler, server SwapClientServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq QuotePayRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.QuotePay(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_SwapClientService_StartPay_0(ctx context.Context, marshaler runtime.Marshaler, client SwapClientServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq StartPayRequest
@@ -199,6 +226,26 @@ func request_SwapClientService_SubscribeSwaps_0(ctx context.Context, marshaler r
 // Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterSwapClientServiceHandlerFromEndpoint instead.
 // GRPC interceptors will not work for this type of registration. To use interceptors, you must use the "runtime.WithMiddlewares" option in the "runtime.NewServeMux" call.
 func RegisterSwapClientServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux, server SwapClientServiceServer) error {
+	mux.Handle(http.MethodPost, pattern_SwapClientService_QuotePay_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/swapclientrpc.SwapClientService/QuotePay", runtime.WithHTTPPathPattern("/v1/swapclient/quote-pay"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SwapClientService_QuotePay_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapClientService_QuotePay_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_SwapClientService_StartPay_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -346,6 +393,23 @@ func RegisterSwapClientServiceHandler(ctx context.Context, mux *runtime.ServeMux
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "SwapClientServiceClient" to call the correct interceptors. This client ignores the HTTP middlewares.
 func RegisterSwapClientServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux, client SwapClientServiceClient) error {
+	mux.Handle(http.MethodPost, pattern_SwapClientService_QuotePay_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/swapclientrpc.SwapClientService/QuotePay", runtime.WithHTTPPathPattern("/v1/swapclient/quote-pay"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SwapClientService_QuotePay_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapClientService_QuotePay_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_SwapClientService_StartPay_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -452,6 +516,7 @@ func RegisterSwapClientServiceHandlerClient(ctx context.Context, mux *runtime.Se
 }
 
 var (
+	pattern_SwapClientService_QuotePay_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swapclient", "quote-pay"}, ""))
 	pattern_SwapClientService_StartPay_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swapclient", "start-pay"}, ""))
 	pattern_SwapClientService_StartReceive_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swapclient", "start-receive"}, ""))
 	pattern_SwapClientService_ResumeSwap_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swapclient", "resume-swap"}, ""))
@@ -461,6 +526,7 @@ var (
 )
 
 var (
+	forward_SwapClientService_QuotePay_0       = runtime.ForwardResponseMessage
 	forward_SwapClientService_StartPay_0       = runtime.ForwardResponseMessage
 	forward_SwapClientService_StartReceive_0   = runtime.ForwardResponseMessage
 	forward_SwapClientService_ResumeSwap_0     = runtime.ForwardResponseMessage

--- a/rpc/swapclientrpc/swap_client.proto
+++ b/rpc/swapclientrpc/swap_client.proto
@@ -7,6 +7,10 @@ option go_package = "github.com/lightninglabs/darepo-client/rpc/swapclientrpc";
 // SwapClientService exposes daemon-owned Lightning/Ark swap execution to local
 // clients. The service is registered only in swapruntime builds.
 service SwapClientService {
+    // QuotePay previews an Ark-to-Lightning payment without creating durable
+    // swap state or starting a background worker.
+    rpc QuotePay (QuotePayRequest) returns (QuotePayResponse);
+
     // StartPay starts an Ark-to-Lightning payment and lets the daemon continue
     // the swap in the background.
     rpc StartPay (StartPayRequest) returns (StartPayResponse);
@@ -59,6 +63,40 @@ enum SwapState {
     SWAP_STATE_FAILED = 11;
     SWAP_STATE_INVOICE_CREATED = 12;
     SWAP_STATE_CLAIM_INITIATED = 13;
+}
+
+message QuotePayRequest {
+    // invoice is the BOLT-11 Lightning invoice to preview.
+    string invoice = 1;
+
+    // max_fee_sat is the maximum Lightning routing fee the caller accepts.
+    // Zero means no explicit caller cap. Quotes still return when the
+    // estimated fee exceeds this cap so callers can render the fee.
+    uint64 max_fee_sat = 2;
+}
+
+message QuotePayResponse {
+    // payment_hash is the hex Lightning payment hash that identifies the
+    // invoice and eventual swap.
+    string payment_hash = 1;
+
+    // invoice_amount_sat is the whole-satoshi invoice amount.
+    uint64 invoice_amount_sat = 2;
+
+    // amount_sat is the total amount that would leave the wallet.
+    uint64 amount_sat = 3;
+
+    // fee_sat is the swap-server fee in satoshis.
+    uint64 fee_sat = 4;
+
+    SwapSettlementType settlement_type = 5;
+
+    // expires_at_unix is the unix timestamp after which the quote is stale.
+    int64 expires_at_unix = 6;
+
+    // exceeds_max_fee is true when max_fee_sat is non-zero and fee_sat is
+    // larger than that cap.
+    bool exceeds_max_fee = 7;
 }
 
 message StartPayRequest {

--- a/rpc/swapclientrpc/swap_client.yaml
+++ b/rpc/swapclientrpc/swap_client.yaml
@@ -3,6 +3,9 @@ config_version: 3
 
 http:
   rules:
+    - selector: swapclientrpc.SwapClientService.QuotePay
+      post: /v1/swapclient/quote-pay
+      body: "*"
     - selector: swapclientrpc.SwapClientService.StartPay
       post: /v1/swapclient/start-pay
       body: "*"

--- a/rpc/swapclientrpc/swap_client_grpc.pb.go
+++ b/rpc/swapclientrpc/swap_client_grpc.pb.go
@@ -19,6 +19,7 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
+	SwapClientService_QuotePay_FullMethodName       = "/swapclientrpc.SwapClientService/QuotePay"
 	SwapClientService_StartPay_FullMethodName       = "/swapclientrpc.SwapClientService/StartPay"
 	SwapClientService_StartReceive_FullMethodName   = "/swapclientrpc.SwapClientService/StartReceive"
 	SwapClientService_ResumeSwap_FullMethodName     = "/swapclientrpc.SwapClientService/ResumeSwap"
@@ -34,6 +35,9 @@ const (
 // SwapClientService exposes daemon-owned Lightning/Ark swap execution to local
 // clients. The service is registered only in swapruntime builds.
 type SwapClientServiceClient interface {
+	// QuotePay previews an Ark-to-Lightning payment without creating durable
+	// swap state or starting a background worker.
+	QuotePay(ctx context.Context, in *QuotePayRequest, opts ...grpc.CallOption) (*QuotePayResponse, error)
 	// StartPay starts an Ark-to-Lightning payment and lets the daemon continue
 	// the swap in the background.
 	StartPay(ctx context.Context, in *StartPayRequest, opts ...grpc.CallOption) (*StartPayResponse, error)
@@ -59,6 +63,16 @@ type swapClientServiceClient struct {
 
 func NewSwapClientServiceClient(cc grpc.ClientConnInterface) SwapClientServiceClient {
 	return &swapClientServiceClient{cc}
+}
+
+func (c *swapClientServiceClient) QuotePay(ctx context.Context, in *QuotePayRequest, opts ...grpc.CallOption) (*QuotePayResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(QuotePayResponse)
+	err := c.cc.Invoke(ctx, SwapClientService_QuotePay_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *swapClientServiceClient) StartPay(ctx context.Context, in *StartPayRequest, opts ...grpc.CallOption) (*StartPayResponse, error) {
@@ -137,6 +151,9 @@ type SwapClientService_SubscribeSwapsClient = grpc.ServerStreamingClient[Subscri
 // SwapClientService exposes daemon-owned Lightning/Ark swap execution to local
 // clients. The service is registered only in swapruntime builds.
 type SwapClientServiceServer interface {
+	// QuotePay previews an Ark-to-Lightning payment without creating durable
+	// swap state or starting a background worker.
+	QuotePay(context.Context, *QuotePayRequest) (*QuotePayResponse, error)
 	// StartPay starts an Ark-to-Lightning payment and lets the daemon continue
 	// the swap in the background.
 	StartPay(context.Context, *StartPayRequest) (*StartPayResponse, error)
@@ -164,6 +181,9 @@ type SwapClientServiceServer interface {
 // pointer dereference when methods are called.
 type UnimplementedSwapClientServiceServer struct{}
 
+func (UnimplementedSwapClientServiceServer) QuotePay(context.Context, *QuotePayRequest) (*QuotePayResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method QuotePay not implemented")
+}
 func (UnimplementedSwapClientServiceServer) StartPay(context.Context, *StartPayRequest) (*StartPayResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method StartPay not implemented")
 }
@@ -201,6 +221,24 @@ func RegisterSwapClientServiceServer(s grpc.ServiceRegistrar, srv SwapClientServ
 		t.testEmbeddedByValue()
 	}
 	s.RegisterService(&SwapClientService_ServiceDesc, srv)
+}
+
+func _SwapClientService_QuotePay_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QuotePayRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SwapClientServiceServer).QuotePay(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SwapClientService_QuotePay_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SwapClientServiceServer).QuotePay(ctx, req.(*QuotePayRequest))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _SwapClientService_StartPay_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -311,6 +349,10 @@ var SwapClientService_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "swapclientrpc.SwapClientService",
 	HandlerType: (*SwapClientServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "QuotePay",
+			Handler:    _SwapClientService_QuotePay_Handler,
+		},
 		{
 			MethodName: "StartPay",
 			Handler:    _SwapClientService_StartPay_Handler,

--- a/rpc/swapclientrpc/swap_client_mailboxrpc.pb.go
+++ b/rpc/swapclientrpc/swap_client_mailboxrpc.pb.go
@@ -24,6 +24,8 @@ func NewSwapClientServiceMailboxClient(c rpc.RPCClient) *SwapClientServiceMailbo
 
 // SwapClientServiceMailboxServer is the mailbox server interface for SwapClientService.
 type SwapClientServiceMailboxServer interface {
+	// QuotePay handles QuotePay.
+	QuotePay(ctx context.Context, req *QuotePayRequest) (*QuotePayResponse, error)
 	// StartPay handles StartPay.
 	StartPay(ctx context.Context, req *StartPayRequest) (*StartPayResponse, error)
 	// StartReceive handles StartReceive.
@@ -40,6 +42,16 @@ type SwapClientServiceMailboxServer interface {
 
 // RegisterSwapClientServiceMailboxServer registers handlers for SwapClientService.
 func RegisterSwapClientServiceMailboxServer(r rpc.Router, impl SwapClientServiceMailboxServer) {
+	r.Handle("swapclientrpc.SwapClientService", "QuotePay", func() proto.Message {
+		return &QuotePayRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*QuotePayRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.QuotePay(ctx, req)
+	})
 	r.Handle("swapclientrpc.SwapClientService", "StartPay", func() proto.Message {
 		return &StartPayRequest{}
 	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
@@ -100,6 +112,29 @@ func RegisterSwapClientServiceMailboxServer(r rpc.Router, impl SwapClientService
 
 		return impl.SubscribeSwaps(ctx, req)
 	})
+}
+
+// QuotePay calls the QuotePay RPC.
+func (c *SwapClientServiceMailboxClient) QuotePay(ctx context.Context, req *QuotePayRequest, opts ...rpc.RPCOptions) (*QuotePayResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "swapclientrpc.SwapClientService",
+		Method:  "QuotePay",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(QuotePayResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
 // StartPay calls the StartPay RPC.

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -380,6 +380,36 @@ type InSwapConfig struct {
 	SettlementType SettlementType
 }
 
+// InSwapQuote previews an Ark-to-Lightning payment without creating durable
+// swap state on either side.
+type InSwapQuote struct {
+	// PaymentHash is the SHA-256 payment hash extracted from the
+	// submitted invoice.
+	PaymentHash lntypes.Hash
+
+	// InvoiceAmountSat is the BOLT-11 destination amount.
+	InvoiceAmountSat uint64
+
+	// AmountSat is the total amount in satoshis the wallet would lock in
+	// the vHTLC.
+	AmountSat uint64
+
+	// FeeSat is the fee in satoshis charged by the swap server.
+	FeeSat uint64
+
+	// Expiry is the wall-clock deadline by which the quoted swap must
+	// complete before it is considered stale.
+	Expiry time.Time
+
+	// SettlementType identifies whether the payment would bridge through
+	// Lightning or settle directly inside Ark.
+	SettlementType SettlementType
+
+	// ExceedsMaxFee is true when the caller supplied a max fee and the
+	// quoted fee is larger than that cap.
+	ExceedsMaxFee bool
+}
+
 // SwapServerConn abstracts the connection to the swap server's
 // gRPC service. This allows the client to talk to the swap server
 // without importing the server module.
@@ -397,6 +427,11 @@ type SwapServerConn interface {
 	// CreateInSwap initiates an Ark->LN swap on the server.
 	CreateInSwap(ctx context.Context, invoice string, maxFeeSat uint64,
 		clientVhtlcPubkey *btcec.PublicKey) (*InSwapConfig, error)
+
+	// QuoteInSwap previews an Ark->LN swap without creating server or
+	// client state.
+	QuoteInSwap(ctx context.Context, invoice string, maxFeeSat uint64) (
+		*InSwapQuote, error)
 
 	// AuthorizeInSwapRefund asks the swap server to sign one exact
 	// cooperative refund spend after it has safely failed the Lightning

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -430,8 +430,8 @@ type SwapServerConn interface {
 
 	// QuoteInSwap previews an Ark->LN swap without creating server or
 	// client state.
-	QuoteInSwap(ctx context.Context, invoice string, maxFeeSat uint64) (
-		*InSwapQuote, error)
+	QuoteInSwap(ctx context.Context, invoice string,
+		maxFeeSat uint64) (*InSwapQuote, error)
 
 	// AuthorizeInSwapRefund asks the swap server to sign one exact
 	// cooperative refund spend after it has safely failed the Lightning

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -450,8 +450,7 @@ func inSwapQuoteFromProto(resp *swaprpc.QuoteInSwapResponse) (*InSwapQuote,
 	}
 
 	if resp.GetAmountSat() == 0 {
-		return nil, fmt.Errorf("in-swap quote amount must be " +
-			"positive")
+		return nil, fmt.Errorf("in-swap quote amount must be positive")
 	}
 
 	if resp.GetFeeSat() > maxInt64Uint {

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -128,6 +128,24 @@ func (g *GRPCSwapServerConn) CreateInSwap(ctx context.Context, invoice string,
 	return inSwapConfigFromProto(resp)
 }
 
+// QuoteInSwap previews one Ark-to-Lightning swap on the swap server without
+// creating durable state.
+func (g *GRPCSwapServerConn) QuoteInSwap(ctx context.Context, invoice string,
+	maxFeeSat uint64) (*InSwapQuote, error) {
+
+	resp, err := g.client.QuoteInSwap(
+		ctx, &swaprpc.QuoteInSwapRequest{
+			Invoice:   invoice,
+			MaxFeeSat: maxFeeSat,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("QuoteInSwap RPC: %w", err)
+	}
+
+	return inSwapQuoteFromProto(resp)
+}
+
 // AuthorizeInSwapRefund asks the swap server to sign one prepared cooperative
 // in-swap refund.
 func (g *GRPCSwapServerConn) AuthorizeInSwapRefund(ctx context.Context,
@@ -408,6 +426,78 @@ func inSwapConfigFromProto(resp *swaprpc.CreateInSwapResponse) (*InSwapConfig,
 		VHTLCConfig:    *cfg,
 		Expiry:         expiryTime,
 		SettlementType: settlementType,
+	}, nil
+}
+
+// inSwapQuoteFromProto converts one generated in-swap quote into the local SDK
+// shape.
+func inSwapQuoteFromProto(resp *swaprpc.QuoteInSwapResponse) (*InSwapQuote,
+	error) {
+
+	if resp == nil {
+		return nil, fmt.Errorf("in-swap quote response must be " +
+			"provided")
+	}
+
+	if len(resp.GetPaymentHash()) != lntypes.HashSize {
+		return nil, fmt.Errorf("in-swap quote payment hash must be "+
+			"%d bytes", lntypes.HashSize)
+	}
+
+	if resp.GetInvoiceAmountSat() == 0 {
+		return nil, fmt.Errorf("in-swap quote invoice amount must be " +
+			"positive")
+	}
+
+	if resp.GetAmountSat() == 0 {
+		return nil, fmt.Errorf("in-swap quote amount must be " +
+			"positive")
+	}
+
+	if resp.GetFeeSat() > maxInt64Uint {
+		return nil, fmt.Errorf("in-swap quote fee exceeds int64 range")
+	}
+
+	if resp.GetInvoiceAmountSat() > maxInt64Uint-resp.GetFeeSat() {
+		return nil, fmt.Errorf("in-swap quote amount exceeds int64 " +
+			"range")
+	}
+
+	expectedAmount := resp.GetInvoiceAmountSat() + resp.GetFeeSat()
+	if resp.GetAmountSat() != expectedAmount {
+		return nil, fmt.Errorf("in-swap quote amount %d does not "+
+			"equal invoice amount %d plus fee %d",
+			resp.GetAmountSat(), resp.GetInvoiceAmountSat(),
+			resp.GetFeeSat())
+	}
+
+	if resp.GetExpiry() == nil {
+		return nil, fmt.Errorf("in-swap quote missing expiry")
+	}
+
+	expiryTime := resp.GetExpiry().AsTime()
+	if expiryTime.IsZero() {
+		return nil, fmt.Errorf("in-swap quote expiry must be non-zero")
+	}
+
+	settlementType, err := settlementTypeFromProto(
+		resp.GetSettlementType(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var paymentHash lntypes.Hash
+	copy(paymentHash[:], resp.GetPaymentHash())
+
+	return &InSwapQuote{
+		PaymentHash:      paymentHash,
+		InvoiceAmountSat: resp.GetInvoiceAmountSat(),
+		AmountSat:        resp.GetAmountSat(),
+		FeeSat:           resp.GetFeeSat(),
+		Expiry:           expiryTime,
+		SettlementType:   settlementType,
+		ExceedsMaxFee:    resp.GetExceedsMaxFee(),
 	}, nil
 }
 

--- a/sdk/swaps/in_swap_quote.go
+++ b/sdk/swaps/in_swap_quote.go
@@ -1,6 +1,7 @@
 package swaps
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg"
@@ -45,6 +46,92 @@ func extractInvoiceAmountSat(msat *lnwire.MilliSatoshi) (uint64, error) {
 	}
 
 	return amountMSat / 1000, nil
+}
+
+// QuotePayViaLightning previews a pay-side in-swap without creating durable
+// swap state or starting the pay FSM.
+func (c *SwapClient) QuotePayViaLightning(ctx context.Context,
+	invoice string, maxFeeSat uint64) (*InSwapQuote, error) {
+
+	if c == nil || c.server == nil {
+		return nil, fmt.Errorf("swap server is required")
+	}
+
+	quote, err := c.server.QuoteInSwap(ctx, invoice, maxFeeSat)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateInSwapPreview(
+		invoice, quote, c.chainParams,
+	); err != nil {
+		return nil, err
+	}
+
+	return quote, nil
+}
+
+// validateInSwapPreview verifies that a server quote is bound to the caller's
+// invoice before the wallet renders it as a user-visible preview.
+func validateInSwapPreview(invoice string, quote *InSwapQuote,
+	chainParams *chaincfg.Params) error {
+
+	if quote == nil {
+		return fmt.Errorf("in-swap quote is required")
+	}
+	if quote.InvoiceAmountSat == 0 {
+		return fmt.Errorf("in-swap quote invoice amount must be " +
+			"positive")
+	}
+	if quote.AmountSat == 0 {
+		return fmt.Errorf("in-swap quote amount must be positive")
+	}
+	if quote.SettlementType == "" {
+		return fmt.Errorf("in-swap quote settlement type is required")
+	}
+
+	decoded, err := decodePayInvoice(invoice, chainParams)
+	if err != nil {
+		return err
+	}
+
+	if decoded.PaymentHash == nil {
+		return fmt.Errorf("invoice payment hash is required")
+	}
+
+	invoiceHash := lntypes.Hash(*decoded.PaymentHash)
+	if invoiceHash != quote.PaymentHash {
+		return fmt.Errorf("in-swap quote payment hash does not match " +
+			"invoice")
+	}
+
+	amountSat, err := extractInvoiceAmountSat(decoded.MilliSat)
+	if err != nil {
+		return err
+	}
+
+	if amountSat != quote.InvoiceAmountSat {
+		return fmt.Errorf("in-swap quote invoice amount %d does not "+
+			"match invoice amount %d", quote.InvoiceAmountSat,
+			amountSat)
+	}
+
+	if quote.FeeSat > maxInt64Uint {
+		return fmt.Errorf("in-swap quote fee overflows int64 range")
+	}
+
+	if amountSat > maxInt64Uint-quote.FeeSat {
+		return fmt.Errorf("in-swap quote amount overflows int64 range")
+	}
+
+	expectedAmountSat := amountSat + quote.FeeSat
+	if quote.AmountSat != expectedAmountSat {
+		return fmt.Errorf("in-swap quote amount %d does not equal "+
+			"invoice amount %d plus fee %d", quote.AmountSat,
+			amountSat, quote.FeeSat)
+	}
+
+	return nil
 }
 
 // validateInSwapQuote verifies that the server quote is bound to the caller's

--- a/sdk/swaps/in_swap_quote.go
+++ b/sdk/swaps/in_swap_quote.go
@@ -50,8 +50,8 @@ func extractInvoiceAmountSat(msat *lnwire.MilliSatoshi) (uint64, error) {
 
 // QuotePayViaLightning previews a pay-side in-swap without creating durable
 // swap state or starting the pay FSM.
-func (c *SwapClient) QuotePayViaLightning(ctx context.Context,
-	invoice string, maxFeeSat uint64) (*InSwapQuote, error) {
+func (c *SwapClient) QuotePayViaLightning(ctx context.Context, invoice string,
+	maxFeeSat uint64) (*InSwapQuote, error) {
 
 	if c == nil || c.server == nil {
 		return nil, fmt.Errorf("swap server is required")

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -40,6 +40,12 @@ const (
 
 type testInSwapServerConn struct {
 	cfg                 *InSwapConfig
+	quote               *InSwapQuote
+	quoteErr            error
+	quoteCalls          int
+	quoteInvoice        string
+	quoteMaxFeeSat      uint64
+	createCalls         int
 	refundAuthorization *InSwapRefundAuthorization
 	refundAuthorizeErr  error
 	refundAuthorizeReq  *testRefundAuthorizeReq
@@ -109,7 +115,23 @@ func (c *testInSwapServerConn) AcknowledgeOutSwapHTLC(context.Context,
 func (c *testInSwapServerConn) CreateInSwap(context.Context, string, uint64,
 	*btcec.PublicKey) (*InSwapConfig, error) {
 
+	c.createCalls++
+
 	return c.cfg, nil
+}
+
+// QuoteInSwap returns the preconfigured in-swap quote.
+func (c *testInSwapServerConn) QuoteInSwap(_ context.Context, invoice string,
+	maxFeeSat uint64) (*InSwapQuote, error) {
+
+	c.quoteCalls++
+	c.quoteInvoice = invoice
+	c.quoteMaxFeeSat = maxFeeSat
+	if c.quoteErr != nil {
+		return nil, c.quoteErr
+	}
+
+	return c.quote, nil
 }
 
 // AuthorizeInSwapRefund records and returns the preconfigured refund
@@ -238,6 +260,49 @@ func cloneInSwapConfig(cfg *InSwapConfig) *InSwapConfig {
 	clone := *cfg
 
 	return &clone
+}
+
+// TestQuotePayViaLightningReturnsBoundPreview verifies the non-mutating quote
+// path validates the server preview without creating an in-swap.
+func TestQuotePayViaLightningReturnsBoundPreview(t *testing.T) {
+	t.Parallel()
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	expiry := time.Now().Add(time.Minute)
+	serverConn := &testInSwapServerConn{
+		quote: &InSwapQuote{
+			PaymentHash:      preimage.Hash(),
+			InvoiceAmountSat: testInSwapInvoiceSat,
+			AmountSat:        testInSwapAmountSat,
+			FeeSat:           testInSwapFeeSat,
+			Expiry:           expiry,
+			SettlementType:   SettlementTypeLightning,
+			ExceedsMaxFee:    true,
+		},
+	}
+	client := configureTestPayClient(
+		NewSwapClient(serverConn, nil, nil, nil),
+	)
+
+	quote, err := client.QuotePayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat-1,
+	)
+	require.NoError(t, err)
+	require.Equal(t, preimage.Hash(), quote.PaymentHash)
+	require.Equal(t, uint64(testInSwapInvoiceSat),
+		quote.InvoiceAmountSat)
+	require.Equal(t, uint64(testInSwapAmountSat), quote.AmountSat)
+	require.Equal(t, uint64(testInSwapFeeSat), quote.FeeSat)
+	require.True(t, quote.ExceedsMaxFee)
+	require.Equal(t, SettlementTypeLightning, quote.SettlementType)
+	require.Equal(t, 1, serverConn.quoteCalls)
+	require.Equal(t, invoice, serverConn.quoteInvoice)
+	require.Equal(t, uint64(testInSwapFeeSat-1),
+		serverConn.quoteMaxFeeSat)
+	require.Zero(t, serverConn.createCalls)
 }
 
 // TestValidateInSwapQuoteRejectsServerMismatches verifies the client treats

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -476,6 +476,13 @@ func (c *testSwapServerConn) CreateInSwap(context.Context, string, uint64,
 	return nil, nil
 }
 
+// QuoteInSwap is unused in these tests.
+func (c *testSwapServerConn) QuoteInSwap(context.Context, string, uint64) (
+	*InSwapQuote, error) {
+
+	return nil, nil
+}
+
 // AuthorizeInSwapRefund is unused in these tests.
 func (c *testSwapServerConn) AuthorizeInSwapRefund(context.Context,
 	lntypes.Hash, string, int64, []byte, []byte, []byte) (

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -1582,8 +1582,8 @@ func swapSummaryToProto(summary swaps.SwapSummary) *swapclientrpc.SwapSummary {
 	}
 }
 
-func quotePayToProto(quote *swaps.InSwapQuote) (
-	*swapclientrpc.QuotePayResponse, error) {
+func quotePayToProto(quote *swaps.InSwapQuote) (*swapclientrpc.QuotePayResponse,
+	error) {
 
 	if quote == nil {
 		return nil, status.Error(

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -165,6 +165,11 @@ func daemonWithLiveOperatorKey(daemon swaps.DaemonConn,
 // Wait. Summary methods expose durable state to RPC handlers without requiring
 // the daemon layer to know the SDK store layout.
 type swapRuntimeClient interface {
+	// QuotePayViaLightning previews a pay swap without creating durable
+	// state or scheduling a worker.
+	QuotePayViaLightning(context.Context, string,
+		uint64) (*swaps.InSwapQuote, error)
+
 	// StartPayViaLightning creates a new pay swap for a Lightning invoice
 	// and persists enough state for a background worker to resume it by
 	// payment hash.
@@ -577,6 +582,13 @@ func (a *swapClientAdapter) StartPayViaLightning(ctx context.Context,
 	invoice string, maxFeeSat uint64) (paySwapSession, error) {
 
 	return a.client.StartPayViaLightning(ctx, invoice, maxFeeSat)
+}
+
+// QuotePayViaLightning previews a pay swap without creating durable state.
+func (a *swapClientAdapter) QuotePayViaLightning(ctx context.Context,
+	invoice string, maxFeeSat uint64) (*swaps.InSwapQuote, error) {
+
+	return a.client.QuotePayViaLightning(ctx, invoice, maxFeeSat)
 }
 
 // StartReceiveViaLightning starts a real sdk/swaps receive session and wraps
@@ -1033,6 +1045,33 @@ func (s *swapClientService) validatePayInvoiceAmount(ctx context.Context,
 	return status.Errorf(codes.InvalidArgument, "invoice amount_sat %d is "+
 		"below the %d sat minimum for pay swaps (operator dust limit)",
 		amountSat, minAmountSat)
+}
+
+// QuotePay previews a pay swap through sdk/swaps without starting a daemon
+// worker or creating durable swap state.
+func (s *swapClientService) QuotePay(ctx context.Context,
+	req *swapclientrpc.QuotePayRequest) (*swapclientrpc.QuotePayResponse,
+	error) {
+
+	if req.GetInvoice() == "" {
+		return nil, status.Error(
+			codes.InvalidArgument, "invoice is required",
+		)
+	}
+	if err := s.validatePayInvoiceAmount(
+		ctx, req.GetInvoice(),
+	); err != nil {
+		return nil, err
+	}
+
+	quote, err := s.client.QuotePayViaLightning(
+		ctx, req.GetInvoice(), req.GetMaxFeeSat(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("quote pay swap: %w", err)
+	}
+
+	return quotePayToProto(quote)
 }
 
 // StartPay persists a pay swap through sdk/swaps, starts or reuses the daemon
@@ -1541,6 +1580,28 @@ func swapSummaryToProto(summary swaps.SwapSummary) *swapclientrpc.SwapSummary {
 		),
 		SenderPubkey: senderPubKey,
 	}
+}
+
+func quotePayToProto(quote *swaps.InSwapQuote) (
+	*swapclientrpc.QuotePayResponse, error) {
+
+	if quote == nil {
+		return nil, status.Error(
+			codes.Internal, "quote pay response is empty",
+		)
+	}
+
+	return &swapclientrpc.QuotePayResponse{
+		PaymentHash:      hex.EncodeToString(quote.PaymentHash[:]),
+		InvoiceAmountSat: quote.InvoiceAmountSat,
+		AmountSat:        quote.AmountSat,
+		FeeSat:           quote.FeeSat,
+		SettlementType: swapSettlementTypeToProto(
+			quote.SettlementType,
+		),
+		ExpiresAtUnix: quote.Expiry.Unix(),
+		ExceedsMaxFee: quote.ExceedsMaxFee,
+	}, nil
 }
 
 // swapStateToProto maps sdk/swaps persisted state names into the stable public

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -239,6 +239,51 @@ func TestStartPayReturnsSummaryAndStartsWorker(t *testing.T) {
 	require.Equal(t, 1, fakeClient.payResumeCount(payHash))
 }
 
+// TestQuotePayReturnsRemotePreview verifies the local swap client RPC exposes
+// the SDK's non-mutating pay quote without starting a background worker.
+func TestQuotePayReturnsRemotePreview(t *testing.T) {
+	t.Parallel()
+
+	payHash := testHash(23)
+	expiresAt := time.Unix(1_700_200_000, 0)
+	fakeClient := newFakeSwapRuntime()
+	fakeClient.quotePayResp = &swaps.InSwapQuote{
+		PaymentHash:      payHash,
+		InvoiceAmountSat: 10_000,
+		AmountSat:        10_210,
+		FeeSat:           210,
+		Expiry:           expiresAt,
+		SettlementType:   swaps.SettlementTypeLightning,
+		ExceedsMaxFee:    true,
+	}
+	service := newTestSwapClientService(fakeClient)
+	defer service.cancel()
+
+	resp, err := service.QuotePay(
+		t.Context(), &swapclientrpc.QuotePayRequest{
+			Invoice:   "lnbc1test",
+			MaxFeeSat: 1,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, hex.EncodeToString(payHash[:]), resp.GetPaymentHash())
+	require.Equal(t, uint64(10_000), resp.GetInvoiceAmountSat())
+	require.Equal(t, uint64(10_210), resp.GetAmountSat())
+	require.Equal(t, uint64(210), resp.GetFeeSat())
+	require.Equal(
+		t,
+		swapclientrpc.
+			SwapSettlementType_SWAP_SETTLEMENT_TYPE_LIGHTNING,
+		resp.GetSettlementType(),
+	)
+	require.Equal(t, expiresAt.Unix(), resp.GetExpiresAtUnix())
+	require.True(t, resp.GetExceedsMaxFee())
+	require.Equal(t, 1, fakeClient.quotePayCalls)
+	require.Equal(t, "lnbc1test", fakeClient.quotePayInvoice)
+	require.Equal(t, uint64(1), fakeClient.quotePayMaxFeeSat)
+	require.Equal(t, 0, fakeClient.startPayCount())
+}
+
 // TestStartPayReturnsPendingDuplicateInvoice verifies a repeated StartPay for
 // an invoice with a pending local swap returns that durable swap summary before
 // it can create another server-side in-swap.
@@ -951,8 +996,13 @@ type fakeSwapRuntime struct {
 
 	startPaySession     paySwapSession
 	startReceiveSession receiveSwapSession
+	quotePayResp        *swaps.InSwapQuote
+	quotePayErr         error
 	startPayErr         error
 
+	quotePayCalls      int
+	quotePayInvoice    string
+	quotePayMaxFeeSat  uint64
 	startPayCalls      int
 	startReceiveCalls  int
 	startReceiveMemo   string
@@ -973,6 +1023,25 @@ func newFakeSwapRuntime(summaries ...swaps.SwapSummary) *fakeSwapRuntime {
 		payResumeCh:        make(chan lntypes.Hash, 8),
 		receiveResumeCh:    make(chan lntypes.Hash, 8),
 	}
+}
+
+func (f *fakeSwapRuntime) QuotePayViaLightning(_ context.Context,
+	invoice string, maxFeeSat uint64) (*swaps.InSwapQuote, error) {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.quotePayCalls++
+	f.quotePayInvoice = invoice
+	f.quotePayMaxFeeSat = maxFeeSat
+	if f.quotePayErr != nil {
+		return nil, f.quotePayErr
+	}
+	if f.quotePayResp == nil {
+		return nil, errors.New("quote pay response not configured")
+	}
+
+	return f.quotePayResp, nil
 }
 
 func (f *fakeSwapRuntime) StartPayViaLightning(context.Context, string,

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -271,8 +271,7 @@ func TestQuotePayReturnsRemotePreview(t *testing.T) {
 	require.Equal(t, uint64(10_210), resp.GetAmountSat())
 	require.Equal(t, uint64(210), resp.GetFeeSat())
 	require.Equal(
-		t,
-		swapclientrpc.
+		t, swapclientrpc.
 			SwapSettlementType_SWAP_SETTLEMENT_TYPE_LIGHTNING,
 		resp.GetSettlementType(),
 	)

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -978,6 +978,164 @@ func (x *CreateInSwapResponse) GetSettlementType() SettlementType {
 	return SettlementType_SETTLEMENT_TYPE_UNSPECIFIED
 }
 
+// QuoteInSwapRequest previews one Ark-to-Lightning invoice send.
+type QuoteInSwapRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// invoice is the BOLT-11 invoice the swap server should inspect.
+	Invoice string `protobuf:"bytes,1,opt,name=invoice,proto3" json:"invoice,omitempty"`
+	// max_fee_sat is the caller's fee cap. Quotes still return when the
+	// computed server fee exceeds this cap so callers can render the fee.
+	MaxFeeSat     uint64 `protobuf:"varint,2,opt,name=max_fee_sat,json=maxFeeSat,proto3" json:"max_fee_sat,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QuoteInSwapRequest) Reset() {
+	*x = QuoteInSwapRequest{}
+	mi := &file_swap_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QuoteInSwapRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QuoteInSwapRequest) ProtoMessage() {}
+
+func (x *QuoteInSwapRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QuoteInSwapRequest.ProtoReflect.Descriptor instead.
+func (*QuoteInSwapRequest) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *QuoteInSwapRequest) GetInvoice() string {
+	if x != nil {
+		return x.Invoice
+	}
+	return ""
+}
+
+func (x *QuoteInSwapRequest) GetMaxFeeSat() uint64 {
+	if x != nil {
+		return x.MaxFeeSat
+	}
+	return 0
+}
+
+// QuoteInSwapResponse returns the non-binding preview for one invoice send.
+type QuoteInSwapResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// payment_hash is the SHA-256 payment hash extracted from the invoice.
+	PaymentHash []byte `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// invoice_amount_sat is the whole-satoshi amount requested by the invoice.
+	InvoiceAmountSat uint64 `protobuf:"varint,2,opt,name=invoice_amount_sat,json=invoiceAmountSat,proto3" json:"invoice_amount_sat,omitempty"`
+	// amount_sat is the total amount that would be locked in the vHTLC.
+	AmountSat uint64 `protobuf:"varint,3,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// fee_sat is the fee in satoshis charged by the swap server.
+	FeeSat uint64 `protobuf:"varint,4,opt,name=fee_sat,json=feeSat,proto3" json:"fee_sat,omitempty"`
+	// settlement_type identifies whether the invoice would settle through
+	// Lightning or directly inside the Ark instance.
+	SettlementType SettlementType `protobuf:"varint,5,opt,name=settlement_type,json=settlementType,proto3,enum=swaprpc.SettlementType" json:"settlement_type,omitempty"`
+	// expiry is the wall-clock deadline after which the quote is stale.
+	Expiry *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=expiry,proto3" json:"expiry,omitempty"`
+	// exceeds_max_fee is true when max_fee_sat is non-zero and fee_sat is
+	// larger than that cap.
+	ExceedsMaxFee bool `protobuf:"varint,7,opt,name=exceeds_max_fee,json=exceedsMaxFee,proto3" json:"exceeds_max_fee,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QuoteInSwapResponse) Reset() {
+	*x = QuoteInSwapResponse{}
+	mi := &file_swap_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QuoteInSwapResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QuoteInSwapResponse) ProtoMessage() {}
+
+func (x *QuoteInSwapResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QuoteInSwapResponse.ProtoReflect.Descriptor instead.
+func (*QuoteInSwapResponse) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *QuoteInSwapResponse) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+func (x *QuoteInSwapResponse) GetInvoiceAmountSat() uint64 {
+	if x != nil {
+		return x.InvoiceAmountSat
+	}
+	return 0
+}
+
+func (x *QuoteInSwapResponse) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *QuoteInSwapResponse) GetFeeSat() uint64 {
+	if x != nil {
+		return x.FeeSat
+	}
+	return 0
+}
+
+func (x *QuoteInSwapResponse) GetSettlementType() SettlementType {
+	if x != nil {
+		return x.SettlementType
+	}
+	return SettlementType_SETTLEMENT_TYPE_UNSPECIFIED
+}
+
+func (x *QuoteInSwapResponse) GetExpiry() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Expiry
+	}
+	return nil
+}
+
+func (x *QuoteInSwapResponse) GetExceedsMaxFee() bool {
+	if x != nil {
+		return x.ExceedsMaxFee
+	}
+	return false
+}
+
 type AuthorizeInSwapRefundRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// payment_hash identifies the in-swap.
@@ -998,7 +1156,7 @@ type AuthorizeInSwapRefundRequest struct {
 
 func (x *AuthorizeInSwapRefundRequest) Reset() {
 	*x = AuthorizeInSwapRefundRequest{}
-	mi := &file_swap_proto_msgTypes[12]
+	mi := &file_swap_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1010,7 +1168,7 @@ func (x *AuthorizeInSwapRefundRequest) String() string {
 func (*AuthorizeInSwapRefundRequest) ProtoMessage() {}
 
 func (x *AuthorizeInSwapRefundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[12]
+	mi := &file_swap_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1023,7 +1181,7 @@ func (x *AuthorizeInSwapRefundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthorizeInSwapRefundRequest.ProtoReflect.Descriptor instead.
 func (*AuthorizeInSwapRefundRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{12}
+	return file_swap_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *AuthorizeInSwapRefundRequest) GetPaymentHash() []byte {
@@ -1081,7 +1239,7 @@ type AuthorizeInSwapRefundResponse struct {
 
 func (x *AuthorizeInSwapRefundResponse) Reset() {
 	*x = AuthorizeInSwapRefundResponse{}
-	mi := &file_swap_proto_msgTypes[13]
+	mi := &file_swap_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1093,7 +1251,7 @@ func (x *AuthorizeInSwapRefundResponse) String() string {
 func (*AuthorizeInSwapRefundResponse) ProtoMessage() {}
 
 func (x *AuthorizeInSwapRefundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[13]
+	mi := &file_swap_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1106,7 +1264,7 @@ func (x *AuthorizeInSwapRefundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthorizeInSwapRefundResponse.ProtoReflect.Descriptor instead.
 func (*AuthorizeInSwapRefundResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{13}
+	return file_swap_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *AuthorizeInSwapRefundResponse) GetSignature() *TaprootScriptSignature {
@@ -1142,7 +1300,7 @@ type TaprootScriptSignature struct {
 
 func (x *TaprootScriptSignature) Reset() {
 	*x = TaprootScriptSignature{}
-	mi := &file_swap_proto_msgTypes[14]
+	mi := &file_swap_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1154,7 +1312,7 @@ func (x *TaprootScriptSignature) String() string {
 func (*TaprootScriptSignature) ProtoMessage() {}
 
 func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[14]
+	mi := &file_swap_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1167,7 +1325,7 @@ func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaprootScriptSignature.ProtoReflect.Descriptor instead.
 func (*TaprootScriptSignature) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{14}
+	return file_swap_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *TaprootScriptSignature) GetPubkey() []byte {
@@ -1268,7 +1426,19 @@ const file_swap_proto_rawDesc = "" +
 	"\rserver_pubkey\x18\x04 \x01(\fR\fserverPubkey\x127\n" +
 	"\fvhtlc_config\x18\x05 \x01(\v2\x14.swaprpc.VHTLCConfigR\vvhtlcConfig\x122\n" +
 	"\x06expiry\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x06expiry\x12@\n" +
-	"\x0fsettlement_type\x18\a \x01(\x0e2\x17.swaprpc.SettlementTypeR\x0esettlementType\"\x9b\x02\n" +
+	"\x0fsettlement_type\x18\a \x01(\x0e2\x17.swaprpc.SettlementTypeR\x0esettlementType\"N\n" +
+	"\x12QuoteInSwapRequest\x12\x18\n" +
+	"\ainvoice\x18\x01 \x01(\tR\ainvoice\x12\x1e\n" +
+	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\"\xbc\x02\n" +
+	"\x13QuoteInSwapResponse\x12!\n" +
+	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12,\n" +
+	"\x12invoice_amount_sat\x18\x02 \x01(\x04R\x10invoiceAmountSat\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x03 \x01(\x04R\tamountSat\x12\x17\n" +
+	"\afee_sat\x18\x04 \x01(\x04R\x06feeSat\x12@\n" +
+	"\x0fsettlement_type\x18\x05 \x01(\x0e2\x17.swaprpc.SettlementTypeR\x0esettlementType\x122\n" +
+	"\x06expiry\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x06expiry\x12&\n" +
+	"\x0fexceeds_max_fee\x18\a \x01(\bR\rexceedsMaxFee\"\x9b\x02\n" +
 	"\x1cAuthorizeInSwapRefundRequest\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12%\n" +
 	"\x0evhtlc_outpoint\x18\x02 \x01(\tR\rvhtlcOutpoint\x12(\n" +
@@ -1287,10 +1457,11 @@ const file_swap_proto_rawDesc = "" +
 	"\x0eSettlementType\x12\x1f\n" +
 	"\x1bSETTLEMENT_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19SETTLEMENT_TYPE_LIGHTNING\x10\x01\x12\x1a\n" +
-	"\x16SETTLEMENT_TYPE_IN_ARK\x10\x022\x86\x03\n" +
+	"\x16SETTLEMENT_TYPE_IN_ARK\x10\x022\xd0\x03\n" +
 	"\vSwapService\x12W\n" +
 	"\x10RequestChannelId\x12 .swaprpc.RequestChannelIdRequest\x1a!.swaprpc.RequestChannelIdResponse\x12K\n" +
-	"\fCreateInSwap\x12\x1c.swaprpc.CreateInSwapRequest\x1a\x1d.swaprpc.CreateInSwapResponse\x12f\n" +
+	"\fCreateInSwap\x12\x1c.swaprpc.CreateInSwapRequest\x1a\x1d.swaprpc.CreateInSwapResponse\x12H\n" +
+	"\vQuoteInSwap\x12\x1b.swaprpc.QuoteInSwapRequest\x1a\x1c.swaprpc.QuoteInSwapResponse\x12f\n" +
 	"\x15AuthorizeInSwapRefund\x12%.swaprpc.AuthorizeInSwapRefundRequest\x1a&.swaprpc.AuthorizeInSwapRefundResponse\x12i\n" +
 	"\x16AcknowledgeOutSwapHtlc\x12&.swaprpc.AcknowledgeOutSwapHtlcRequest\x1a'.swaprpc.AcknowledgeOutSwapHtlcResponseB0Z.github.com/lightninglabs/darepo-client/swaprpcb\x06proto3"
 
@@ -1307,7 +1478,7 @@ func file_swap_proto_rawDescGZIP() []byte {
 }
 
 var file_swap_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_swap_proto_goTypes = []any{
 	(SettlementType)(0),                    // 0: swaprpc.SettlementType
 	(*RequestChannelIdRequest)(nil),        // 1: swaprpc.RequestChannelIdRequest
@@ -1322,10 +1493,12 @@ var file_swap_proto_goTypes = []any{
 	(*VHTLCConfig)(nil),                    // 10: swaprpc.VHTLCConfig
 	(*CreateInSwapRequest)(nil),            // 11: swaprpc.CreateInSwapRequest
 	(*CreateInSwapResponse)(nil),           // 12: swaprpc.CreateInSwapResponse
-	(*AuthorizeInSwapRefundRequest)(nil),   // 13: swaprpc.AuthorizeInSwapRefundRequest
-	(*AuthorizeInSwapRefundResponse)(nil),  // 14: swaprpc.AuthorizeInSwapRefundResponse
-	(*TaprootScriptSignature)(nil),         // 15: swaprpc.TaprootScriptSignature
-	(*timestamppb.Timestamp)(nil),          // 16: google.protobuf.Timestamp
+	(*QuoteInSwapRequest)(nil),             // 13: swaprpc.QuoteInSwapRequest
+	(*QuoteInSwapResponse)(nil),            // 14: swaprpc.QuoteInSwapResponse
+	(*AuthorizeInSwapRefundRequest)(nil),   // 15: swaprpc.AuthorizeInSwapRefundRequest
+	(*AuthorizeInSwapRefundResponse)(nil),  // 16: swaprpc.AuthorizeInSwapRefundResponse
+	(*TaprootScriptSignature)(nil),         // 17: swaprpc.TaprootScriptSignature
+	(*timestamppb.Timestamp)(nil),          // 18: google.protobuf.Timestamp
 }
 var file_swap_proto_depIdxs = []int32{
 	9,  // 0: swaprpc.RequestChannelIdResponse.route_hint:type_name -> swaprpc.RouteHint
@@ -1335,22 +1508,26 @@ var file_swap_proto_depIdxs = []int32{
 	8,  // 4: swaprpc.SwapMailboxEvent.in_ark_htlc:type_name -> swaprpc.InArkHtlcEvent
 	10, // 5: swaprpc.InArkHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
 	10, // 6: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	16, // 7: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
+	18, // 7: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
 	0,  // 8: swaprpc.CreateInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
-	15, // 9: swaprpc.AuthorizeInSwapRefundResponse.signature:type_name -> swaprpc.TaprootScriptSignature
-	1,  // 10: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
-	11, // 11: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
-	13, // 12: swaprpc.SwapService.AuthorizeInSwapRefund:input_type -> swaprpc.AuthorizeInSwapRefundRequest
-	3,  // 13: swaprpc.SwapService.AcknowledgeOutSwapHtlc:input_type -> swaprpc.AcknowledgeOutSwapHtlcRequest
-	2,  // 14: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
-	12, // 15: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
-	14, // 16: swaprpc.SwapService.AuthorizeInSwapRefund:output_type -> swaprpc.AuthorizeInSwapRefundResponse
-	4,  // 17: swaprpc.SwapService.AcknowledgeOutSwapHtlc:output_type -> swaprpc.AcknowledgeOutSwapHtlcResponse
-	14, // [14:18] is the sub-list for method output_type
-	10, // [10:14] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	0,  // 9: swaprpc.QuoteInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
+	18, // 10: swaprpc.QuoteInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
+	17, // 11: swaprpc.AuthorizeInSwapRefundResponse.signature:type_name -> swaprpc.TaprootScriptSignature
+	1,  // 12: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
+	11, // 13: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
+	13, // 14: swaprpc.SwapService.QuoteInSwap:input_type -> swaprpc.QuoteInSwapRequest
+	15, // 15: swaprpc.SwapService.AuthorizeInSwapRefund:input_type -> swaprpc.AuthorizeInSwapRefundRequest
+	3,  // 16: swaprpc.SwapService.AcknowledgeOutSwapHtlc:input_type -> swaprpc.AcknowledgeOutSwapHtlcRequest
+	2,  // 17: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
+	12, // 18: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
+	14, // 19: swaprpc.SwapService.QuoteInSwap:output_type -> swaprpc.QuoteInSwapResponse
+	16, // 20: swaprpc.SwapService.AuthorizeInSwapRefund:output_type -> swaprpc.AuthorizeInSwapRefundResponse
+	4,  // 21: swaprpc.SwapService.AcknowledgeOutSwapHtlc:output_type -> swaprpc.AcknowledgeOutSwapHtlcResponse
+	17, // [17:22] is the sub-list for method output_type
+	12, // [12:17] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_swap_proto_init() }
@@ -1368,7 +1545,7 @@ func file_swap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_swap_proto_rawDesc), len(file_swap_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   15,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/swaprpc/swap.pb.gw.go
+++ b/swaprpc/swap.pb.gw.go
@@ -89,6 +89,33 @@ func local_request_SwapService_CreateInSwap_0(ctx context.Context, marshaler run
 	return msg, metadata, err
 }
 
+func request_SwapService_QuoteInSwap_0(ctx context.Context, marshaler runtime.Marshaler, client SwapServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq QuoteInSwapRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.QuoteInSwap(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SwapService_QuoteInSwap_0(ctx context.Context, marshaler runtime.Marshaler, server SwapServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq QuoteInSwapRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.QuoteInSwap(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_SwapService_AuthorizeInSwapRefund_0(ctx context.Context, marshaler runtime.Marshaler, client SwapServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq AuthorizeInSwapRefundRequest
@@ -188,6 +215,26 @@ func RegisterSwapServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux
 			return
 		}
 		forward_SwapService_CreateInSwap_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SwapService_QuoteInSwap_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/swaprpc.SwapService/QuoteInSwap", runtime.WithHTTPPathPattern("/v1/swap/quote-in-swap"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SwapService_QuoteInSwap_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_QuoteInSwap_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPost, pattern_SwapService_AuthorizeInSwapRefund_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -303,6 +350,23 @@ func RegisterSwapServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_SwapService_CreateInSwap_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_SwapService_QuoteInSwap_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/swaprpc.SwapService/QuoteInSwap", runtime.WithHTTPPathPattern("/v1/swap/quote-in-swap"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SwapService_QuoteInSwap_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_QuoteInSwap_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_SwapService_AuthorizeInSwapRefund_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -343,6 +407,7 @@ func RegisterSwapServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux
 var (
 	pattern_SwapService_RequestChannelId_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "request-channel-id"}, ""))
 	pattern_SwapService_CreateInSwap_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "create-in-swap"}, ""))
+	pattern_SwapService_QuoteInSwap_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "quote-in-swap"}, ""))
 	pattern_SwapService_AuthorizeInSwapRefund_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "authorize-in-swap-refund"}, ""))
 	pattern_SwapService_AcknowledgeOutSwapHtlc_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "acknowledge-out-swap-htlc"}, ""))
 )
@@ -350,6 +415,7 @@ var (
 var (
 	forward_SwapService_RequestChannelId_0       = runtime.ForwardResponseMessage
 	forward_SwapService_CreateInSwap_0           = runtime.ForwardResponseMessage
+	forward_SwapService_QuoteInSwap_0            = runtime.ForwardResponseMessage
 	forward_SwapService_AuthorizeInSwapRefund_0  = runtime.ForwardResponseMessage
 	forward_SwapService_AcknowledgeOutSwapHtlc_0 = runtime.ForwardResponseMessage
 )

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -32,6 +32,10 @@ service SwapService {
     // returns the negotiated vHTLC parameters.
     rpc CreateInSwap (CreateInSwapRequest) returns (CreateInSwapResponse);
 
+    // QuoteInSwap previews how an invoice send would settle without creating
+    // durable swap state or notifying a same-Ark receiver.
+    rpc QuoteInSwap (QuoteInSwapRequest) returns (QuoteInSwapResponse);
+
     // AuthorizeInSwapRefund signs a prepared cooperative refund spend for a
     // funded in-swap whose Lightning payment attempt has terminally failed.
     rpc AuthorizeInSwapRefund (AuthorizeInSwapRefundRequest)
@@ -250,6 +254,42 @@ message CreateInSwapResponse {
     // settlement_type identifies whether this negotiation should be completed
     // through Lightning or directly inside the Ark instance.
     SettlementType settlement_type = 7;
+}
+
+// QuoteInSwapRequest previews one Ark-to-Lightning invoice send.
+message QuoteInSwapRequest {
+    // invoice is the BOLT-11 invoice the swap server should inspect.
+    string invoice = 1;
+
+    // max_fee_sat is the caller's fee cap. Quotes still return when the
+    // computed server fee exceeds this cap so callers can render the fee.
+    uint64 max_fee_sat = 2;
+}
+
+// QuoteInSwapResponse returns the non-binding preview for one invoice send.
+message QuoteInSwapResponse {
+    // payment_hash is the SHA-256 payment hash extracted from the invoice.
+    bytes payment_hash = 1;
+
+    // invoice_amount_sat is the whole-satoshi amount requested by the invoice.
+    uint64 invoice_amount_sat = 2;
+
+    // amount_sat is the total amount that would be locked in the vHTLC.
+    uint64 amount_sat = 3;
+
+    // fee_sat is the fee in satoshis charged by the swap server.
+    uint64 fee_sat = 4;
+
+    // settlement_type identifies whether the invoice would settle through
+    // Lightning or directly inside the Ark instance.
+    SettlementType settlement_type = 5;
+
+    // expiry is the wall-clock deadline after which the quote is stale.
+    google.protobuf.Timestamp expiry = 6;
+
+    // exceeds_max_fee is true when max_fee_sat is non-zero and fee_sat is
+    // larger than that cap.
+    bool exceeds_max_fee = 7;
 }
 
 message AuthorizeInSwapRefundRequest {

--- a/swaprpc/swap.yaml
+++ b/swaprpc/swap.yaml
@@ -9,6 +9,9 @@ http:
     - selector: swaprpc.SwapService.CreateInSwap
       post: /v1/swap/create-in-swap
       body: "*"
+    - selector: swaprpc.SwapService.QuoteInSwap
+      post: /v1/swap/quote-in-swap
+      body: "*"
     - selector: swaprpc.SwapService.AuthorizeInSwapRefund
       post: /v1/swap/authorize-in-swap-refund
       body: "*"

--- a/swaprpc/swap_grpc.pb.go
+++ b/swaprpc/swap_grpc.pb.go
@@ -21,6 +21,7 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	SwapService_RequestChannelId_FullMethodName       = "/swaprpc.SwapService/RequestChannelId"
 	SwapService_CreateInSwap_FullMethodName           = "/swaprpc.SwapService/CreateInSwap"
+	SwapService_QuoteInSwap_FullMethodName            = "/swaprpc.SwapService/QuoteInSwap"
 	SwapService_AuthorizeInSwapRefund_FullMethodName  = "/swaprpc.SwapService/AuthorizeInSwapRefund"
 	SwapService_AcknowledgeOutSwapHtlc_FullMethodName = "/swaprpc.SwapService/AcknowledgeOutSwapHtlc"
 )
@@ -38,6 +39,9 @@ type SwapServiceClient interface {
 	// CreateInSwap initiates an Ark-to-Lightning swap for the given invoice and
 	// returns the negotiated vHTLC parameters.
 	CreateInSwap(ctx context.Context, in *CreateInSwapRequest, opts ...grpc.CallOption) (*CreateInSwapResponse, error)
+	// QuoteInSwap previews how an invoice send would settle without creating
+	// durable swap state or notifying a same-Ark receiver.
+	QuoteInSwap(ctx context.Context, in *QuoteInSwapRequest, opts ...grpc.CallOption) (*QuoteInSwapResponse, error)
 	// AuthorizeInSwapRefund signs a prepared cooperative refund spend for a
 	// funded in-swap whose Lightning payment attempt has terminally failed.
 	AuthorizeInSwapRefund(ctx context.Context, in *AuthorizeInSwapRefundRequest, opts ...grpc.CallOption) (*AuthorizeInSwapRefundResponse, error)
@@ -69,6 +73,16 @@ func (c *swapServiceClient) CreateInSwap(ctx context.Context, in *CreateInSwapRe
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(CreateInSwapResponse)
 	err := c.cc.Invoke(ctx, SwapService_CreateInSwap_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *swapServiceClient) QuoteInSwap(ctx context.Context, in *QuoteInSwapRequest, opts ...grpc.CallOption) (*QuoteInSwapResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(QuoteInSwapResponse)
+	err := c.cc.Invoke(ctx, SwapService_QuoteInSwap_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -108,6 +122,9 @@ type SwapServiceServer interface {
 	// CreateInSwap initiates an Ark-to-Lightning swap for the given invoice and
 	// returns the negotiated vHTLC parameters.
 	CreateInSwap(context.Context, *CreateInSwapRequest) (*CreateInSwapResponse, error)
+	// QuoteInSwap previews how an invoice send would settle without creating
+	// durable swap state or notifying a same-Ark receiver.
+	QuoteInSwap(context.Context, *QuoteInSwapRequest) (*QuoteInSwapResponse, error)
 	// AuthorizeInSwapRefund signs a prepared cooperative refund spend for a
 	// funded in-swap whose Lightning payment attempt has terminally failed.
 	AuthorizeInSwapRefund(context.Context, *AuthorizeInSwapRefundRequest) (*AuthorizeInSwapRefundResponse, error)
@@ -130,6 +147,9 @@ func (UnimplementedSwapServiceServer) RequestChannelId(context.Context, *Request
 }
 func (UnimplementedSwapServiceServer) CreateInSwap(context.Context, *CreateInSwapRequest) (*CreateInSwapResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateInSwap not implemented")
+}
+func (UnimplementedSwapServiceServer) QuoteInSwap(context.Context, *QuoteInSwapRequest) (*QuoteInSwapResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method QuoteInSwap not implemented")
 }
 func (UnimplementedSwapServiceServer) AuthorizeInSwapRefund(context.Context, *AuthorizeInSwapRefundRequest) (*AuthorizeInSwapRefundResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AuthorizeInSwapRefund not implemented")
@@ -194,6 +214,24 @@ func _SwapService_CreateInSwap_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SwapService_QuoteInSwap_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QuoteInSwapRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SwapServiceServer).QuoteInSwap(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SwapService_QuoteInSwap_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SwapServiceServer).QuoteInSwap(ctx, req.(*QuoteInSwapRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _SwapService_AuthorizeInSwapRefund_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(AuthorizeInSwapRefundRequest)
 	if err := dec(in); err != nil {
@@ -244,6 +282,10 @@ var SwapService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CreateInSwap",
 			Handler:    _SwapService_CreateInSwap_Handler,
+		},
+		{
+			MethodName: "QuoteInSwap",
+			Handler:    _SwapService_QuoteInSwap_Handler,
 		},
 		{
 			MethodName: "AuthorizeInSwapRefund",

--- a/swaprpc/swap_mailboxrpc.pb.go
+++ b/swaprpc/swap_mailboxrpc.pb.go
@@ -28,6 +28,8 @@ type SwapServiceMailboxServer interface {
 	RequestChannelId(ctx context.Context, req *RequestChannelIdRequest) (*RequestChannelIdResponse, error)
 	// CreateInSwap handles CreateInSwap.
 	CreateInSwap(ctx context.Context, req *CreateInSwapRequest) (*CreateInSwapResponse, error)
+	// QuoteInSwap handles QuoteInSwap.
+	QuoteInSwap(ctx context.Context, req *QuoteInSwapRequest) (*QuoteInSwapResponse, error)
 	// AuthorizeInSwapRefund handles AuthorizeInSwapRefund.
 	AuthorizeInSwapRefund(ctx context.Context, req *AuthorizeInSwapRefundRequest) (*AuthorizeInSwapRefundResponse, error)
 	// AcknowledgeOutSwapHtlc handles AcknowledgeOutSwapHtlc.
@@ -55,6 +57,16 @@ func RegisterSwapServiceMailboxServer(r rpc.Router, impl SwapServiceMailboxServe
 		}
 
 		return impl.CreateInSwap(ctx, req)
+	})
+	r.Handle("swaprpc.SwapService", "QuoteInSwap", func() proto.Message {
+		return &QuoteInSwapRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*QuoteInSwapRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.QuoteInSwap(ctx, req)
 	})
 	r.Handle("swaprpc.SwapService", "AuthorizeInSwapRefund", func() proto.Message {
 		return &AuthorizeInSwapRefundRequest{}
@@ -117,6 +129,29 @@ func (c *SwapServiceMailboxClient) CreateInSwap(ctx context.Context, req *Create
 	}
 
 	resp := new(CreateInSwapResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// QuoteInSwap calls the QuoteInSwap RPC.
+func (c *SwapServiceMailboxClient) QuoteInSwap(ctx context.Context, req *QuoteInSwapRequest, opts ...rpc.RPCOptions) (*QuoteInSwapResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "swaprpc.SwapService",
+		Method:  "QuoteInSwap",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(QuoteInSwapResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -272,6 +272,11 @@ func (f *fakeRPCServer) SendOnChain(_ context.Context,
 type fakeSwapService struct {
 	swapclientrpc.UnimplementedSwapClientServiceServer
 
+	quotePayResp    *swapclientrpc.QuotePayResponse
+	quotePayErr     error
+	quotePayCalls   int
+	quotePayLastReq *swapclientrpc.QuotePayRequest
+
 	startPayResp    *swapclientrpc.StartPayResponse
 	startPayErr     error
 	startPayCalls   int
@@ -286,6 +291,16 @@ type fakeSwapService struct {
 	listSwapsErr   error
 	listSwapsCalls int
 	listSwapsLast  *swapclientrpc.ListSwapsRequest
+}
+
+func (f *fakeSwapService) QuotePay(_ context.Context,
+	req *swapclientrpc.QuotePayRequest) (*swapclientrpc.QuotePayResponse,
+	error) {
+
+	f.quotePayCalls++
+	f.quotePayLastReq = req
+
+	return f.quotePayResp, f.quotePayErr
 }
 
 func (f *fakeSwapService) StartPay(_ context.Context,

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -17,6 +17,8 @@ import (
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 	"github.com/lightningnetwork/lnd/zpay32"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // router dispatches outbound Send requests to the appropriate daemon
@@ -141,14 +143,9 @@ func (r *router) prepareInvoice(ctx context.Context, invoice string,
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("quote pay: %w", err)
-	}
-
-	preview, err := prepareInvoicePreviewFromQuote(
-		invoice, description, paymentHash, quote,
-	)
-	if err != nil {
-		return nil, err
+		if !quotePayUnavailable(err) {
+			return nil, fmt.Errorf("quote pay: %w", err)
+		}
 	}
 
 	intent := &preparedSendIntent{
@@ -157,6 +154,13 @@ func (r *router) prepareInvoice(ctx context.Context, invoice string,
 		amountSat: amountSat,
 		note:      req.GetNote(),
 		maxFeeSat: req.GetMaxFeeSat(),
+	}
+
+	preview, err := prepareInvoicePreview(
+		invoice, description, paymentHash, amountSat, quote, err,
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	if _, err := r.intents.put(intent); err != nil {
@@ -509,25 +513,74 @@ func extractPreparedInvoiceAmountSat(decoded *zpay32.Invoice) (uint64, error) {
 	return amountMSat / 1000, nil
 }
 
+// quotePayUnavailable reports whether a quote failure means the configured
+// daemon or swap server is older than the quote RPC.
+func quotePayUnavailable(err error) bool {
+	switch status.Code(err) {
+	case codes.Unimplemented, codes.NotFound:
+		return true
+
+	default:
+		return false
+	}
+}
+
+// prepareInvoicePreview builds a remote quote preview when available and keeps
+// mixed-version deployments usable with a local-only fallback otherwise.
+func prepareInvoicePreview(invoice, description, paymentHash string,
+	amountSat uint64, quote *swapclientrpc.QuotePayResponse,
+	quoteErr error) (prepareSendPreview, error) {
+
+	if quoteErr != nil {
+		return prepareInvoiceLocalPreview(
+			invoice, description, paymentHash, amountSat,
+		), nil
+	}
+
+	return prepareInvoicePreviewFromQuote(
+		invoice, description, paymentHash, quote,
+	)
+}
+
+// prepareInvoiceLocalPreview records only invoice facts the wallet can verify
+// locally. The fee and exact off-chain rail remain unknown until Send starts.
+func prepareInvoiceLocalPreview(invoice, description, paymentHash string,
+	amountSat uint64) prepareSendPreview {
+
+	return prepareSendPreview{
+		rail:                    walletdkrpc.SendRail_SEND_RAIL_OFFCHAIN_UNKNOWN,
+		quoteStatus:             walletdkrpc.SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY,
+		amountSat:               int64(amountSat),
+		expectedFeeSat:          0,
+		feeKnown:                false,
+		expectedTotalOutflowSat: int64(amountSat),
+		totalOutflowKnown:       false,
+		destinationSummary:      truncate(invoice, 32),
+		invoiceDescription:      description,
+		paymentHash:             paymentHash,
+		warning: "server quote unavailable; fee and rail will be " +
+			"resolved when Send starts",
+	}
+}
+
 func prepareInvoicePreviewFromQuote(invoice, description, paymentHash string,
 	quote *swapclientrpc.QuotePayResponse) (prepareSendPreview, error) {
 
 	if quote == nil {
-		return prepareSendPreview{}, fmt.Errorf("quote pay response is " +
-			"required")
+		return prepareSendPreview{}, fmt.Errorf("quote pay response " +
+			"is required")
 	}
 
 	if quote.GetInvoiceAmountSat() > math.MaxInt64 ||
 		quote.GetAmountSat() > math.MaxInt64 ||
 		quote.GetFeeSat() > math.MaxInt64 {
-
 		return prepareSendPreview{}, fmt.Errorf("%w: quote amount "+
 			"exceeds int64 range", ErrAmountInvalid)
 	}
 
 	if paymentHash != "" && quote.GetPaymentHash() != paymentHash {
-		return prepareSendPreview{}, fmt.Errorf("%w: quote payment hash "+
-			"does not match invoice", ErrInvalidDestination)
+		return prepareSendPreview{}, fmt.Errorf("%w: quote payment "+
+			"hash does not match invoice", ErrInvalidDestination)
 	}
 
 	rail, err := sendRailFromQuoteSettlement(quote.GetSettlementType())
@@ -558,21 +611,18 @@ func prepareInvoicePreviewFromQuote(invoice, description, paymentHash string,
 }
 
 func sendRailFromQuoteSettlement(
-	settlementType swapclientrpc.SwapSettlementType) (
-	walletdkrpc.SendRail, error) {
+	settlementType swapclientrpc.SwapSettlementType) (walletdkrpc.SendRail,
+	error) {
 
 	switch settlementType {
 	case swapclientrpc.
 		SwapSettlementType_SWAP_SETTLEMENT_TYPE_LIGHTNING:
-
 		return walletdkrpc.SendRail_SEND_RAIL_LIGHTNING, nil
 
 	case swapclientrpc.SwapSettlementType_SWAP_SETTLEMENT_TYPE_IN_ARK:
 		return walletdkrpc.SendRail_SEND_RAIL_IN_ARK, nil
 
 	default:
-		return walletdkrpc.SendRail_SEND_RAIL_UNSPECIFIED,
-			fmt.Errorf("%w: unknown quote settlement type %v",
-				ErrInvalidDestination, settlementType)
+		return walletdkrpc.SendRail_SEND_RAIL_OFFCHAIN_UNKNOWN, nil
 	}
 }

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -130,6 +130,27 @@ func (r *router) prepareInvoice(ctx context.Context, invoice string,
 		description = strings.TrimSpace(*decoded.Description)
 	}
 
+	if r.deps.SwapService == nil {
+		return nil, ErrSwapBackendUnavailable
+	}
+
+	quote, err := r.deps.SwapService.QuotePay(
+		ctx, &swapclientrpc.QuotePayRequest{
+			Invoice:   invoice,
+			MaxFeeSat: req.GetMaxFeeSat(),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("quote pay: %w", err)
+	}
+
+	preview, err := prepareInvoicePreviewFromQuote(
+		invoice, description, paymentHash, quote,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	intent := &preparedSendIntent{
 		kind:      preparedSendInvoice,
 		invoice:   invoice,
@@ -142,21 +163,7 @@ func (r *router) prepareInvoice(ctx context.Context, invoice string,
 		return nil, err
 	}
 
-	return prepareResponseFromIntent(
-		intent, prepareSendPreview{
-			rail: walletdkrpc.SendRail_SEND_RAIL_OFFCHAIN_UNKNOWN,
-			quoteStatus: walletdkrpc.
-				SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY,
-			amountSat:          int64(amountSat),
-			feeKnown:           false,
-			totalOutflowKnown:  false,
-			destinationSummary: truncate(invoice, 32),
-			invoiceDescription: description,
-			paymentHash:        paymentHash,
-			warning: "swapserver quote support is not available " +
-				"yet",
-		},
-	), nil
+	return prepareResponseFromIntent(intent, preview), nil
 }
 
 // sendInvoiceIntent routes a prepared BOLT-11 invoice through the
@@ -500,4 +507,72 @@ func extractPreparedInvoiceAmountSat(decoded *zpay32.Invoice) (uint64, error) {
 	}
 
 	return amountMSat / 1000, nil
+}
+
+func prepareInvoicePreviewFromQuote(invoice, description, paymentHash string,
+	quote *swapclientrpc.QuotePayResponse) (prepareSendPreview, error) {
+
+	if quote == nil {
+		return prepareSendPreview{}, fmt.Errorf("quote pay response is " +
+			"required")
+	}
+
+	if quote.GetInvoiceAmountSat() > math.MaxInt64 ||
+		quote.GetAmountSat() > math.MaxInt64 ||
+		quote.GetFeeSat() > math.MaxInt64 {
+
+		return prepareSendPreview{}, fmt.Errorf("%w: quote amount "+
+			"exceeds int64 range", ErrAmountInvalid)
+	}
+
+	if paymentHash != "" && quote.GetPaymentHash() != paymentHash {
+		return prepareSendPreview{}, fmt.Errorf("%w: quote payment hash "+
+			"does not match invoice", ErrInvalidDestination)
+	}
+
+	rail, err := sendRailFromQuoteSettlement(quote.GetSettlementType())
+	if err != nil {
+		return prepareSendPreview{}, err
+	}
+
+	warning := ""
+	if quote.GetExceedsMaxFee() {
+		warning = "quoted fee exceeds max_fee_sat; Send will fail " +
+			"unless prepared with a higher fee cap"
+	}
+
+	return prepareSendPreview{
+		rail: rail,
+		quoteStatus: walletdkrpc.
+			SendQuoteStatus_SEND_QUOTE_STATUS_COMPLETE,
+		amountSat:               int64(quote.GetInvoiceAmountSat()),
+		expectedFeeSat:          int64(quote.GetFeeSat()),
+		feeKnown:                true,
+		expectedTotalOutflowSat: int64(quote.GetAmountSat()),
+		totalOutflowKnown:       true,
+		destinationSummary:      truncate(invoice, 32),
+		invoiceDescription:      description,
+		paymentHash:             quote.GetPaymentHash(),
+		warning:                 warning,
+	}, nil
+}
+
+func sendRailFromQuoteSettlement(
+	settlementType swapclientrpc.SwapSettlementType) (
+	walletdkrpc.SendRail, error) {
+
+	switch settlementType {
+	case swapclientrpc.
+		SwapSettlementType_SWAP_SETTLEMENT_TYPE_LIGHTNING:
+
+		return walletdkrpc.SendRail_SEND_RAIL_LIGHTNING, nil
+
+	case swapclientrpc.SwapSettlementType_SWAP_SETTLEMENT_TYPE_IN_ARK:
+		return walletdkrpc.SendRail_SEND_RAIL_IN_ARK, nil
+
+	default:
+		return walletdkrpc.SendRail_SEND_RAIL_UNSPECIFIED,
+			fmt.Errorf("%w: unknown quote settlement type %v",
+				ErrInvalidDestination, settlementType)
+	}
 }

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -141,15 +141,23 @@ func TestRouterPrepareSendInvoiceRejectsWrongNetwork(t *testing.T) {
 	require.Zero(t, intentCount, "wrong-network invoices create no intent")
 }
 
-// TestRouterPrepareSendInvoiceReturnsLocalPreview confirms the invoice
-// prepare path decodes the BOLT-11 metadata locally, produces a short-lived
-// intent, and honestly marks fee/rail details as local-only until remote quote
-// APIs exist.
-func TestRouterPrepareSendInvoiceReturnsLocalPreview(t *testing.T) {
+// TestRouterPrepareSendInvoiceReturnsRemoteQuote confirms the invoice prepare
+// path asks the swap client service for the non-mutating quote exposed by the
+// remote swap server.
+func TestRouterPrepareSendInvoiceReturnsRemoteQuote(t *testing.T) {
 	t.Parallel()
 
 	r, swap, rpc := newRouterFixture(t)
 	invoice, paymentHash := testPreparedInvoice(t, 12_345, "coffee")
+	swap.quotePayResp = &swapclientrpc.QuotePayResponse{
+		PaymentHash:      paymentHash,
+		InvoiceAmountSat: 12_345,
+		AmountSat:        12_555,
+		FeeSat:           210,
+		SettlementType: swapclientrpc.
+			SwapSettlementType_SWAP_SETTLEMENT_TYPE_LIGHTNING,
+		ExpiresAtUnix: time.Now().Add(time.Minute).Unix(),
+	}
 
 	resp, err := r.PrepareSend(
 		t.Context(), &walletdkrpc.PrepareSendRequest{
@@ -164,23 +172,92 @@ func TestRouterPrepareSendInvoiceReturnsLocalPreview(t *testing.T) {
 	require.NotEmpty(t, resp.GetSendIntentId())
 	require.Equal(t, int64(12_345), resp.GetAmountSat())
 	require.Equal(
-		t, walletdkrpc.SendRail_SEND_RAIL_OFFCHAIN_UNKNOWN,
+		t, walletdkrpc.SendRail_SEND_RAIL_LIGHTNING,
 		resp.GetRail(),
 	)
 	require.Equal(
-		t, walletdkrpc.SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY,
+		t, walletdkrpc.SendQuoteStatus_SEND_QUOTE_STATUS_COMPLETE,
 		resp.GetQuoteStatus(),
 	)
-	require.False(t, resp.GetFeeKnown())
-	require.False(t, resp.GetTotalOutflowKnown())
-	require.Equal(t, int64(0), resp.GetExpectedFeeSat())
-	require.Equal(t, int64(0), resp.GetExpectedTotalOutflowSat())
+	require.True(t, resp.GetFeeKnown())
+	require.True(t, resp.GetTotalOutflowKnown())
+	require.Equal(t, int64(210), resp.GetExpectedFeeSat())
+	require.Equal(t, int64(12_555), resp.GetExpectedTotalOutflowSat())
 	require.Equal(t, "coffee", resp.GetInvoiceDescription())
 	require.Equal(t, paymentHash, resp.GetPaymentHash())
 	require.Contains(t, resp.GetDestinationSummary(), "lnbcrt")
-	require.Contains(t, resp.GetWarning(), "swapserver quote support")
+	require.Empty(t, resp.GetWarning())
+	require.Equal(t, 1, swap.quotePayCalls)
+	require.Equal(t, invoice, swap.quotePayLastReq.GetInvoice())
+	require.Equal(t, uint64(25), swap.quotePayLastReq.GetMaxFeeSat())
 	require.Equal(t, 0, swap.startPayCalls)
 	require.Equal(t, 0, rpc.leaveCalls)
+}
+
+// TestRouterPrepareSendInvoiceQuotesInArk confirms same-Ark previews surface
+// as a concrete in-Ark rail with zero fee.
+func TestRouterPrepareSendInvoiceQuotesInArk(t *testing.T) {
+	t.Parallel()
+
+	r, swap, rpc := newRouterFixture(t)
+	invoice, paymentHash := testPreparedInvoice(t, 12_345, "ark")
+	swap.quotePayResp = &swapclientrpc.QuotePayResponse{
+		PaymentHash:      paymentHash,
+		InvoiceAmountSat: 12_345,
+		AmountSat:        12_345,
+		FeeSat:           0,
+		SettlementType: swapclientrpc.
+			SwapSettlementType_SWAP_SETTLEMENT_TYPE_IN_ARK,
+		ExpiresAtUnix: time.Now().Add(time.Minute).Unix(),
+	}
+
+	resp, err := r.PrepareSend(
+		t.Context(), &walletdkrpc.PrepareSendRequest{
+			Destination: &walletdkrpc.PrepareSendRequest_Invoice{
+				Invoice: invoice,
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, walletdkrpc.SendRail_SEND_RAIL_IN_ARK,
+		resp.GetRail())
+	require.Equal(t, int64(0), resp.GetExpectedFeeSat())
+	require.Equal(t, int64(12_345),
+		resp.GetExpectedTotalOutflowSat())
+	require.Equal(t, 1, swap.quotePayCalls)
+	require.Equal(t, 0, swap.startPayCalls)
+	require.Equal(t, 0, rpc.leaveCalls)
+}
+
+// TestRouterPrepareSendInvoiceWarnsWhenQuoteExceedsMaxFee confirms PrepareSend
+// keeps the non-mutating quote renderable when the caller's cap is too low.
+func TestRouterPrepareSendInvoiceWarnsWhenQuoteExceedsMaxFee(t *testing.T) {
+	t.Parallel()
+
+	r, swap, _ := newRouterFixture(t)
+	invoice, paymentHash := testPreparedInvoice(t, 12_345, "fee cap")
+	swap.quotePayResp = &swapclientrpc.QuotePayResponse{
+		PaymentHash:      paymentHash,
+		InvoiceAmountSat: 12_345,
+		AmountSat:        12_765,
+		FeeSat:           420,
+		SettlementType: swapclientrpc.
+			SwapSettlementType_SWAP_SETTLEMENT_TYPE_LIGHTNING,
+		ExceedsMaxFee: true,
+		ExpiresAtUnix: time.Now().Add(time.Minute).Unix(),
+	}
+
+	resp, err := r.PrepareSend(
+		t.Context(), &walletdkrpc.PrepareSendRequest{
+			Destination: &walletdkrpc.PrepareSendRequest_Invoice{
+				Invoice: invoice,
+			},
+			MaxFeeSat: 1,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(420), resp.GetExpectedFeeSat())
+	require.Contains(t, resp.GetWarning(), "exceeds max_fee_sat")
 }
 
 // TestRouterSendInvoiceDispatchesStartPay confirms an invoice destination

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -172,8 +172,7 @@ func TestRouterPrepareSendInvoiceReturnsRemoteQuote(t *testing.T) {
 	require.NotEmpty(t, resp.GetSendIntentId())
 	require.Equal(t, int64(12_345), resp.GetAmountSat())
 	require.Equal(
-		t, walletdkrpc.SendRail_SEND_RAIL_LIGHTNING,
-		resp.GetRail(),
+		t, walletdkrpc.SendRail_SEND_RAIL_LIGHTNING, resp.GetRail(),
 	)
 	require.Equal(
 		t, walletdkrpc.SendQuoteStatus_SEND_QUOTE_STATUS_COMPLETE,
@@ -192,6 +191,125 @@ func TestRouterPrepareSendInvoiceReturnsRemoteQuote(t *testing.T) {
 	require.Equal(t, uint64(25), swap.quotePayLastReq.GetMaxFeeSat())
 	require.Equal(t, 0, swap.startPayCalls)
 	require.Equal(t, 0, rpc.leaveCalls)
+}
+
+// TestRouterPrepareSendInvoiceFallsBackWhenQuoteUnavailable confirms mixed
+// deployments can still prepare invoice sends when the quote RPC is missing.
+func TestRouterPrepareSendInvoiceFallsBackWhenQuoteUnavailable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code codes.Code
+	}{{
+		name: "grpc-unimplemented",
+		code: codes.Unimplemented,
+	}, {
+		name: "rest-not-found",
+		code: codes.NotFound,
+	}}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, swap, rpc := newRouterFixture(t)
+			invoice, paymentHash := testPreparedInvoice(
+				t, 12_345, "mixed version",
+			)
+			swap.quotePayErr = status.Error(
+				test.code, "missing quote",
+			)
+
+			resp, err := r.PrepareSend(
+				t.Context(), &walletdkrpc.PrepareSendRequest{
+					Destination: &walletdkrpc.
+						PrepareSendRequest_Invoice{
+						Invoice: invoice,
+					},
+					MaxFeeSat: 25,
+				},
+			)
+			require.NoError(t, err)
+			require.NotEmpty(t, resp.GetSendIntentId())
+			require.Equal(t, int64(12_345), resp.GetAmountSat())
+			require.Equal(
+				t, walletdkrpc.
+					SendRail_SEND_RAIL_OFFCHAIN_UNKNOWN,
+				resp.GetRail(),
+			)
+			require.Equal(
+				t, walletdkrpc.
+					SendQuoteStatus_SEND_QUOTE_STATUS_LOCAL_ONLY,
+				resp.GetQuoteStatus(),
+			)
+			require.False(t, resp.GetFeeKnown())
+			require.False(t, resp.GetTotalOutflowKnown())
+			require.Equal(t, int64(0), resp.GetExpectedFeeSat())
+			require.Equal(
+				t, int64(12_345),
+				resp.GetExpectedTotalOutflowSat(),
+			)
+			require.Equal(
+				t, "mixed version",
+				resp.GetInvoiceDescription(),
+			)
+			require.Equal(t, paymentHash, resp.GetPaymentHash())
+			require.Contains(
+				t, resp.GetWarning(),
+				"server quote unavailable",
+			)
+			require.Equal(t, 1, swap.quotePayCalls)
+			require.Equal(
+				t, invoice, swap.quotePayLastReq.GetInvoice(),
+			)
+			require.Equal(
+				t, uint64(25),
+				swap.quotePayLastReq.GetMaxFeeSat(),
+			)
+			require.Equal(t, 0, swap.startPayCalls)
+			require.Equal(t, 0, rpc.leaveCalls)
+		})
+	}
+}
+
+// TestRouterPrepareSendInvoiceMapsUnknownQuoteRail confirms future quote rails
+// still render the quoted amounts even before the wallet knows their names.
+func TestRouterPrepareSendInvoiceMapsUnknownQuoteRail(t *testing.T) {
+	t.Parallel()
+
+	r, swap, _ := newRouterFixture(t)
+	invoice, paymentHash := testPreparedInvoice(t, 12_345, "future rail")
+	swap.quotePayResp = &swapclientrpc.QuotePayResponse{
+		PaymentHash:      paymentHash,
+		InvoiceAmountSat: 12_345,
+		AmountSat:        12_555,
+		FeeSat:           210,
+		SettlementType: swapclientrpc.
+			SwapSettlementType_SWAP_SETTLEMENT_TYPE_UNSPECIFIED,
+		ExpiresAtUnix: time.Now().Add(time.Minute).Unix(),
+	}
+
+	resp, err := r.PrepareSend(
+		t.Context(), &walletdkrpc.PrepareSendRequest{
+			Destination: &walletdkrpc.PrepareSendRequest_Invoice{
+				Invoice: invoice,
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, walletdkrpc.SendRail_SEND_RAIL_OFFCHAIN_UNKNOWN,
+		resp.GetRail(),
+	)
+	require.Equal(
+		t, walletdkrpc.SendQuoteStatus_SEND_QUOTE_STATUS_COMPLETE,
+		resp.GetQuoteStatus(),
+	)
+	require.True(t, resp.GetFeeKnown())
+	require.Equal(t, int64(210), resp.GetExpectedFeeSat())
+	require.Equal(t, int64(12_555), resp.GetExpectedTotalOutflowSat())
 }
 
 // TestRouterPrepareSendInvoiceQuotesInArk confirms same-Ark previews surface


### PR DESCRIPTION
## Summary

This wires `PrepareSend` to the server-side quote path instead of returning
stubbed swap preview values.

- add the generated `QuoteInSwap` client RPC and local `QuotePay` daemon RPC
- add SDK quote helpers that validate the server preview before returning it
- make `PrepareSend` return the quoted rail, fee, total outflow, and max-fee
  warning for Lightning payments

## Testing

- `go test -tags="walletdkrpc swapruntime" ./cmd/darepocli/darepoclicommands ./cmd/darepod ./sdk/swaps ./swapclientserver ./swapwallet ./rpc/restclient ./rpc/swapclientrpc ./swaprpc`
- `make unit-swapruntime`
- `make lint-local`
