### PR TITLE
rpc: expose VTXO expiry info

### DIFF
--- a/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
@@ -107,6 +107,13 @@ func generatedRegistry() []serviceSpec {
 					Comments: "GetIndexedVTXOByPkScript queries the authoritative indexer for the\nfirst VTXO matching the given script and status filter.",
 				},
 				{
+					Name:     "GetVTXOExpiryInfo",
+					Aliases:  []string{"get-vtxo-expiry-info"},
+					Input:    "daemonrpc.GetVTXOExpiryInfoRequest",
+					Output:   "daemonrpc.GetVTXOExpiryInfoResponse",
+					Comments: "GetVTXOExpiryInfo returns the wallet/VTXO layer's expiry posture for a\nVTXO identified by outpoint or pkScript.",
+				},
+				{
 					Name:     "GetIndexedOORSessionByTxid",
 					Aliases:  []string{"get-indexed-oor-session-by-txid"},
 					Input:    "daemonrpc.GetIndexedOORSessionByTxidRequest",

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -186,6 +186,73 @@ func (VTXOStatus) EnumDescriptor() ([]byte, []int) {
 	return file_daemon_proto_rawDescGZIP(), []int{1}
 }
 
+// VTXOExpiryStatus describes how close a VTXO is to batch expiry using the
+// daemon's wallet/VTXO expiry policy.
+type VTXOExpiryStatus int32
+
+const (
+	// VTXO_EXPIRY_STATUS_UNKNOWN is returned when the daemon cannot
+	// classify the VTXO, for example because timing metadata is missing.
+	VTXOExpiryStatus_VTXO_EXPIRY_STATUS_UNKNOWN VTXOExpiryStatus = 0
+	// VTXO_EXPIRY_STATUS_SAFE indicates the VTXO is outside the refresh
+	// threshold.
+	VTXOExpiryStatus_VTXO_EXPIRY_STATUS_SAFE VTXOExpiryStatus = 1
+	// VTXO_EXPIRY_STATUS_NEEDS_REFRESH indicates the VTXO has entered the
+	// cooperative refresh window but is not yet critical.
+	VTXOExpiryStatus_VTXO_EXPIRY_STATUS_NEEDS_REFRESH VTXOExpiryStatus = 2
+	// VTXO_EXPIRY_STATUS_CRITICAL indicates the VTXO should stop waiting for
+	// cooperative refresh and move to unilateral exit/recovery handling.
+	VTXOExpiryStatus_VTXO_EXPIRY_STATUS_CRITICAL VTXOExpiryStatus = 3
+	// VTXO_EXPIRY_STATUS_EXPIRED indicates the VTXO's batch expiry has
+	// passed.
+	VTXOExpiryStatus_VTXO_EXPIRY_STATUS_EXPIRED VTXOExpiryStatus = 4
+)
+
+// Enum value maps for VTXOExpiryStatus.
+var (
+	VTXOExpiryStatus_name = map[int32]string{
+		0: "VTXO_EXPIRY_STATUS_UNKNOWN",
+		1: "VTXO_EXPIRY_STATUS_SAFE",
+		2: "VTXO_EXPIRY_STATUS_NEEDS_REFRESH",
+		3: "VTXO_EXPIRY_STATUS_CRITICAL",
+		4: "VTXO_EXPIRY_STATUS_EXPIRED",
+	}
+	VTXOExpiryStatus_value = map[string]int32{
+		"VTXO_EXPIRY_STATUS_UNKNOWN":       0,
+		"VTXO_EXPIRY_STATUS_SAFE":          1,
+		"VTXO_EXPIRY_STATUS_NEEDS_REFRESH": 2,
+		"VTXO_EXPIRY_STATUS_CRITICAL":      3,
+		"VTXO_EXPIRY_STATUS_EXPIRED":       4,
+	}
+)
+
+func (x VTXOExpiryStatus) Enum() *VTXOExpiryStatus {
+	p := new(VTXOExpiryStatus)
+	*p = x
+	return p
+}
+
+func (x VTXOExpiryStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (VTXOExpiryStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_daemon_proto_enumTypes[2].Descriptor()
+}
+
+func (VTXOExpiryStatus) Type() protoreflect.EnumType {
+	return &file_daemon_proto_enumTypes[2]
+}
+
+func (x VTXOExpiryStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use VTXOExpiryStatus.Descriptor instead.
+func (VTXOExpiryStatus) EnumDescriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{2}
+}
+
 // RoundState represents the lifecycle state of a client's round FSM.
 type RoundState int32
 
@@ -291,11 +358,11 @@ func (x RoundState) String() string {
 }
 
 func (RoundState) Descriptor() protoreflect.EnumDescriptor {
-	return file_daemon_proto_enumTypes[2].Descriptor()
+	return file_daemon_proto_enumTypes[3].Descriptor()
 }
 
 func (RoundState) Type() protoreflect.EnumType {
-	return &file_daemon_proto_enumTypes[2]
+	return &file_daemon_proto_enumTypes[3]
 }
 
 func (x RoundState) Number() protoreflect.EnumNumber {
@@ -304,7 +371,7 @@ func (x RoundState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use RoundState.Descriptor instead.
 func (RoundState) EnumDescriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{2}
+	return file_daemon_proto_rawDescGZIP(), []int{3}
 }
 
 type OORSessionDirection int32
@@ -340,11 +407,11 @@ func (x OORSessionDirection) String() string {
 }
 
 func (OORSessionDirection) Descriptor() protoreflect.EnumDescriptor {
-	return file_daemon_proto_enumTypes[3].Descriptor()
+	return file_daemon_proto_enumTypes[4].Descriptor()
 }
 
 func (OORSessionDirection) Type() protoreflect.EnumType {
-	return &file_daemon_proto_enumTypes[3]
+	return &file_daemon_proto_enumTypes[4]
 }
 
 func (x OORSessionDirection) Number() protoreflect.EnumNumber {
@@ -353,7 +420,7 @@ func (x OORSessionDirection) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use OORSessionDirection.Descriptor instead.
 func (OORSessionDirection) EnumDescriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{3}
+	return file_daemon_proto_rawDescGZIP(), []int{4}
 }
 
 type OORSessionStatus int32
@@ -392,11 +459,11 @@ func (x OORSessionStatus) String() string {
 }
 
 func (OORSessionStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_daemon_proto_enumTypes[4].Descriptor()
+	return file_daemon_proto_enumTypes[5].Descriptor()
 }
 
 func (OORSessionStatus) Type() protoreflect.EnumType {
-	return &file_daemon_proto_enumTypes[4]
+	return &file_daemon_proto_enumTypes[5]
 }
 
 func (x OORSessionStatus) Number() protoreflect.EnumNumber {
@@ -405,7 +472,7 @@ func (x OORSessionStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use OORSessionStatus.Descriptor instead.
 func (OORSessionStatus) EnumDescriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{4}
+	return file_daemon_proto_rawDescGZIP(), []int{5}
 }
 
 // UnrollJobStatus represents the high-level phase of an unroll job.
@@ -466,11 +533,11 @@ func (x UnrollJobStatus) String() string {
 }
 
 func (UnrollJobStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_daemon_proto_enumTypes[5].Descriptor()
+	return file_daemon_proto_enumTypes[6].Descriptor()
 }
 
 func (UnrollJobStatus) Type() protoreflect.EnumType {
-	return &file_daemon_proto_enumTypes[5]
+	return &file_daemon_proto_enumTypes[6]
 }
 
 func (x UnrollJobStatus) Number() protoreflect.EnumNumber {
@@ -479,7 +546,7 @@ func (x UnrollJobStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use UnrollJobStatus.Descriptor instead.
 func (UnrollJobStatus) EnumDescriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{5}
+	return file_daemon_proto_rawDescGZIP(), []int{6}
 }
 
 // VHTLCRecoveryDirection records which side owns a recovery job.
@@ -529,11 +596,11 @@ func (x VHTLCRecoveryDirection) String() string {
 }
 
 func (VHTLCRecoveryDirection) Descriptor() protoreflect.EnumDescriptor {
-	return file_daemon_proto_enumTypes[6].Descriptor()
+	return file_daemon_proto_enumTypes[7].Descriptor()
 }
 
 func (VHTLCRecoveryDirection) Type() protoreflect.EnumType {
-	return &file_daemon_proto_enumTypes[6]
+	return &file_daemon_proto_enumTypes[7]
 }
 
 func (x VHTLCRecoveryDirection) Number() protoreflect.EnumNumber {
@@ -542,7 +609,7 @@ func (x VHTLCRecoveryDirection) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use VHTLCRecoveryDirection.Descriptor instead.
 func (VHTLCRecoveryDirection) EnumDescriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{6}
+	return file_daemon_proto_rawDescGZIP(), []int{7}
 }
 
 // VHTLCRecoveryAction selects the unilateral vHTLC leaf to execute.
@@ -583,11 +650,11 @@ func (x VHTLCRecoveryAction) String() string {
 }
 
 func (VHTLCRecoveryAction) Descriptor() protoreflect.EnumDescriptor {
-	return file_daemon_proto_enumTypes[7].Descriptor()
+	return file_daemon_proto_enumTypes[8].Descriptor()
 }
 
 func (VHTLCRecoveryAction) Type() protoreflect.EnumType {
-	return &file_daemon_proto_enumTypes[7]
+	return &file_daemon_proto_enumTypes[8]
 }
 
 func (x VHTLCRecoveryAction) Number() protoreflect.EnumNumber {
@@ -596,7 +663,7 @@ func (x VHTLCRecoveryAction) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use VHTLCRecoveryAction.Descriptor instead.
 func (VHTLCRecoveryAction) EnumDescriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{7}
+	return file_daemon_proto_rawDescGZIP(), []int{8}
 }
 
 // VHTLCRecoveryState mirrors the durable vhtlc_recovery_jobs state column. The
@@ -664,11 +731,11 @@ func (x VHTLCRecoveryState) String() string {
 }
 
 func (VHTLCRecoveryState) Descriptor() protoreflect.EnumDescriptor {
-	return file_daemon_proto_enumTypes[8].Descriptor()
+	return file_daemon_proto_enumTypes[9].Descriptor()
 }
 
 func (VHTLCRecoveryState) Type() protoreflect.EnumType {
-	return &file_daemon_proto_enumTypes[8]
+	return &file_daemon_proto_enumTypes[9]
 }
 
 func (x VHTLCRecoveryState) Number() protoreflect.EnumNumber {
@@ -677,7 +744,7 @@ func (x VHTLCRecoveryState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use VHTLCRecoveryState.Descriptor instead.
 func (VHTLCRecoveryState) EnumDescriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{8}
+	return file_daemon_proto_rawDescGZIP(), []int{9}
 }
 
 type GetInfoRequest struct {
@@ -1557,6 +1624,130 @@ func (x *GetBalanceResponse) GetBoardingAdoptedSat() int64 {
 	return 0
 }
 
+// VTXOExpiryInfo reports the thresholds and current classification the
+// wallet/VTXO layer uses for expiry monitoring.
+type VTXOExpiryInfo struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// status is the VTXO's current expiry posture.
+	Status VTXOExpiryStatus `protobuf:"varint,1,opt,name=status,proto3,enum=daemonrpc.VTXOExpiryStatus" json:"status,omitempty"`
+	// current_height is the chain height used for this classification.
+	CurrentHeight int32 `protobuf:"varint,2,opt,name=current_height,json=currentHeight,proto3" json:"current_height,omitempty"`
+	// batch_expiry is the VTXO batch expiry height.
+	BatchExpiry int32 `protobuf:"varint,3,opt,name=batch_expiry,json=batchExpiry,proto3" json:"batch_expiry,omitempty"`
+	// blocks_remaining is batch_expiry - current_height.
+	BlocksRemaining int32 `protobuf:"varint,4,opt,name=blocks_remaining,json=blocksRemaining,proto3" json:"blocks_remaining,omitempty"`
+	// refresh_threshold_blocks is the number of blocks before batch expiry at
+	// which cooperative refresh should begin.
+	RefreshThresholdBlocks int32 `protobuf:"varint,5,opt,name=refresh_threshold_blocks,json=refreshThresholdBlocks,proto3" json:"refresh_threshold_blocks,omitempty"`
+	// critical_threshold_blocks is the number of blocks before batch expiry at
+	// which recovery/unilateral-exit handling should begin.
+	CriticalThresholdBlocks int32 `protobuf:"varint,6,opt,name=critical_threshold_blocks,json=criticalThresholdBlocks,proto3" json:"critical_threshold_blocks,omitempty"`
+	// relative_expiry is the CSV delay used in the threshold calculation.
+	RelativeExpiry uint32 `protobuf:"varint,7,opt,name=relative_expiry,json=relativeExpiry,proto3" json:"relative_expiry,omitempty"`
+	// max_tree_depth is the worst-case VTXO tree depth used in the threshold
+	// calculation.
+	MaxTreeDepth uint32 `protobuf:"varint,8,opt,name=max_tree_depth,json=maxTreeDepth,proto3" json:"max_tree_depth,omitempty"`
+	// chain_depth is the number of OOR checkpoint hops between this VTXO and
+	// the most recent on-chain commitment. It is included for diagnostics but
+	// is distinct from max_tree_depth.
+	ChainDepth    uint32 `protobuf:"varint,9,opt,name=chain_depth,json=chainDepth,proto3" json:"chain_depth,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *VTXOExpiryInfo) Reset() {
+	*x = VTXOExpiryInfo{}
+	mi := &file_daemon_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VTXOExpiryInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VTXOExpiryInfo) ProtoMessage() {}
+
+func (x *VTXOExpiryInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VTXOExpiryInfo.ProtoReflect.Descriptor instead.
+func (*VTXOExpiryInfo) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *VTXOExpiryInfo) GetStatus() VTXOExpiryStatus {
+	if x != nil {
+		return x.Status
+	}
+	return VTXOExpiryStatus_VTXO_EXPIRY_STATUS_UNKNOWN
+}
+
+func (x *VTXOExpiryInfo) GetCurrentHeight() int32 {
+	if x != nil {
+		return x.CurrentHeight
+	}
+	return 0
+}
+
+func (x *VTXOExpiryInfo) GetBatchExpiry() int32 {
+	if x != nil {
+		return x.BatchExpiry
+	}
+	return 0
+}
+
+func (x *VTXOExpiryInfo) GetBlocksRemaining() int32 {
+	if x != nil {
+		return x.BlocksRemaining
+	}
+	return 0
+}
+
+func (x *VTXOExpiryInfo) GetRefreshThresholdBlocks() int32 {
+	if x != nil {
+		return x.RefreshThresholdBlocks
+	}
+	return 0
+}
+
+func (x *VTXOExpiryInfo) GetCriticalThresholdBlocks() int32 {
+	if x != nil {
+		return x.CriticalThresholdBlocks
+	}
+	return 0
+}
+
+func (x *VTXOExpiryInfo) GetRelativeExpiry() uint32 {
+	if x != nil {
+		return x.RelativeExpiry
+	}
+	return 0
+}
+
+func (x *VTXOExpiryInfo) GetMaxTreeDepth() uint32 {
+	if x != nil {
+		return x.MaxTreeDepth
+	}
+	return 0
+}
+
+func (x *VTXOExpiryInfo) GetChainDepth() uint32 {
+	if x != nil {
+		return x.ChainDepth
+	}
+	return 0
+}
+
 type VTXO struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// outpoint is the VTXO's outpoint in "txid:index" format.
@@ -1590,14 +1781,17 @@ type VTXO struct {
 	OorFinalCheckpointPsbts [][]byte `protobuf:"bytes,11,rep,name=oor_final_checkpoint_psbts,json=oorFinalCheckpointPsbts,proto3" json:"oor_final_checkpoint_psbts,omitempty"`
 	// spent_by_txid is the hex-encoded Ark/OOR transaction txid that spent
 	// this VTXO through an out-of-round package, when known.
-	SpentByTxid   string `protobuf:"bytes,12,opt,name=spent_by_txid,json=spentByTxid,proto3" json:"spent_by_txid,omitempty"`
+	SpentByTxid string `protobuf:"bytes,12,opt,name=spent_by_txid,json=spentByTxid,proto3" json:"spent_by_txid,omitempty"`
+	// expiry_info reports the wallet/VTXO layer's current expiry posture for
+	// this VTXO when the daemon has enough timing context to classify it.
+	ExpiryInfo    *VTXOExpiryInfo `protobuf:"bytes,13,opt,name=expiry_info,json=expiryInfo,proto3" json:"expiry_info,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *VTXO) Reset() {
 	*x = VTXO{}
-	mi := &file_daemon_proto_msgTypes[11]
+	mi := &file_daemon_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1609,7 +1803,7 @@ func (x *VTXO) String() string {
 func (*VTXO) ProtoMessage() {}
 
 func (x *VTXO) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[11]
+	mi := &file_daemon_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1622,7 +1816,7 @@ func (x *VTXO) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VTXO.ProtoReflect.Descriptor instead.
 func (*VTXO) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{11}
+	return file_daemon_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *VTXO) GetOutpoint() string {
@@ -1709,6 +1903,13 @@ func (x *VTXO) GetSpentByTxid() string {
 	return ""
 }
 
+func (x *VTXO) GetExpiryInfo() *VTXOExpiryInfo {
+	if x != nil {
+		return x.ExpiryInfo
+	}
+	return nil
+}
+
 type ListVTXOsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// status_filter restricts the response to VTXOs matching this status.
@@ -1728,7 +1929,7 @@ type ListVTXOsRequest struct {
 
 func (x *ListVTXOsRequest) Reset() {
 	*x = ListVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[12]
+	mi := &file_daemon_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1740,7 +1941,7 @@ func (x *ListVTXOsRequest) String() string {
 func (*ListVTXOsRequest) ProtoMessage() {}
 
 func (x *ListVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[12]
+	mi := &file_daemon_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1753,7 +1954,7 @@ func (x *ListVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*ListVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{12}
+	return file_daemon_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ListVTXOsRequest) GetStatusFilter() VTXOStatus {
@@ -1787,7 +1988,7 @@ type ListVTXOsResponse struct {
 
 func (x *ListVTXOsResponse) Reset() {
 	*x = ListVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[13]
+	mi := &file_daemon_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1799,7 +2000,7 @@ func (x *ListVTXOsResponse) String() string {
 func (*ListVTXOsResponse) ProtoMessage() {}
 
 func (x *ListVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[13]
+	mi := &file_daemon_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1812,7 +2013,7 @@ func (x *ListVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*ListVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{13}
+	return file_daemon_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ListVTXOsResponse) GetVtxos() []*VTXO {
@@ -1830,7 +2031,7 @@ type NewAddressRequest struct {
 
 func (x *NewAddressRequest) Reset() {
 	*x = NewAddressRequest{}
-	mi := &file_daemon_proto_msgTypes[14]
+	mi := &file_daemon_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1842,7 +2043,7 @@ func (x *NewAddressRequest) String() string {
 func (*NewAddressRequest) ProtoMessage() {}
 
 func (x *NewAddressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[14]
+	mi := &file_daemon_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1855,7 +2056,7 @@ func (x *NewAddressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewAddressRequest.ProtoReflect.Descriptor instead.
 func (*NewAddressRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{14}
+	return file_daemon_proto_rawDescGZIP(), []int{15}
 }
 
 type NewAddressResponse struct {
@@ -1868,7 +2069,7 @@ type NewAddressResponse struct {
 
 func (x *NewAddressResponse) Reset() {
 	*x = NewAddressResponse{}
-	mi := &file_daemon_proto_msgTypes[15]
+	mi := &file_daemon_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1880,7 +2081,7 @@ func (x *NewAddressResponse) String() string {
 func (*NewAddressResponse) ProtoMessage() {}
 
 func (x *NewAddressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[15]
+	mi := &file_daemon_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1893,7 +2094,7 @@ func (x *NewAddressResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewAddressResponse.ProtoReflect.Descriptor instead.
 func (*NewAddressResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{15}
+	return file_daemon_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *NewAddressResponse) GetAddress() string {
@@ -1914,7 +2115,7 @@ type NewReceiveScriptRequest struct {
 
 func (x *NewReceiveScriptRequest) Reset() {
 	*x = NewReceiveScriptRequest{}
-	mi := &file_daemon_proto_msgTypes[16]
+	mi := &file_daemon_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1926,7 +2127,7 @@ func (x *NewReceiveScriptRequest) String() string {
 func (*NewReceiveScriptRequest) ProtoMessage() {}
 
 func (x *NewReceiveScriptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[16]
+	mi := &file_daemon_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1939,7 +2140,7 @@ func (x *NewReceiveScriptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewReceiveScriptRequest.ProtoReflect.Descriptor instead.
 func (*NewReceiveScriptRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{16}
+	return file_daemon_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *NewReceiveScriptRequest) GetLabel() string {
@@ -1967,7 +2168,7 @@ type NewReceiveScriptResponse struct {
 
 func (x *NewReceiveScriptResponse) Reset() {
 	*x = NewReceiveScriptResponse{}
-	mi := &file_daemon_proto_msgTypes[17]
+	mi := &file_daemon_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1979,7 +2180,7 @@ func (x *NewReceiveScriptResponse) String() string {
 func (*NewReceiveScriptResponse) ProtoMessage() {}
 
 func (x *NewReceiveScriptResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[17]
+	mi := &file_daemon_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1992,7 +2193,7 @@ func (x *NewReceiveScriptResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewReceiveScriptResponse.ProtoReflect.Descriptor instead.
 func (*NewReceiveScriptResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{17}
+	return file_daemon_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *NewReceiveScriptResponse) GetPkScriptHex() string {
@@ -2041,7 +2242,7 @@ type ReceiveAuthKeyRequest struct {
 
 func (x *ReceiveAuthKeyRequest) Reset() {
 	*x = ReceiveAuthKeyRequest{}
-	mi := &file_daemon_proto_msgTypes[18]
+	mi := &file_daemon_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2053,7 +2254,7 @@ func (x *ReceiveAuthKeyRequest) String() string {
 func (*ReceiveAuthKeyRequest) ProtoMessage() {}
 
 func (x *ReceiveAuthKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[18]
+	mi := &file_daemon_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2066,7 +2267,7 @@ func (x *ReceiveAuthKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthKeyRequest.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthKeyRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{18}
+	return file_daemon_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ReceiveAuthKeyRequest) GetPaymentHash() []byte {
@@ -2087,7 +2288,7 @@ type ReceiveAuthKeyResponse struct {
 
 func (x *ReceiveAuthKeyResponse) Reset() {
 	*x = ReceiveAuthKeyResponse{}
-	mi := &file_daemon_proto_msgTypes[19]
+	mi := &file_daemon_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2099,7 +2300,7 @@ func (x *ReceiveAuthKeyResponse) String() string {
 func (*ReceiveAuthKeyResponse) ProtoMessage() {}
 
 func (x *ReceiveAuthKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[19]
+	mi := &file_daemon_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2112,7 +2313,7 @@ func (x *ReceiveAuthKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthKeyResponse.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthKeyResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{19}
+	return file_daemon_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ReceiveAuthKeyResponse) GetPubkey() []byte {
@@ -2138,7 +2339,7 @@ type SignReceiveAuthMessageRequest struct {
 
 func (x *SignReceiveAuthMessageRequest) Reset() {
 	*x = SignReceiveAuthMessageRequest{}
-	mi := &file_daemon_proto_msgTypes[20]
+	mi := &file_daemon_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2150,7 +2351,7 @@ func (x *SignReceiveAuthMessageRequest) String() string {
 func (*SignReceiveAuthMessageRequest) ProtoMessage() {}
 
 func (x *SignReceiveAuthMessageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[20]
+	mi := &file_daemon_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2163,7 +2364,7 @@ func (x *SignReceiveAuthMessageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignReceiveAuthMessageRequest.ProtoReflect.Descriptor instead.
 func (*SignReceiveAuthMessageRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{20}
+	return file_daemon_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *SignReceiveAuthMessageRequest) GetPaymentHash() []byte {
@@ -2197,7 +2398,7 @@ type SignReceiveAuthMessageResponse struct {
 
 func (x *SignReceiveAuthMessageResponse) Reset() {
 	*x = SignReceiveAuthMessageResponse{}
-	mi := &file_daemon_proto_msgTypes[21]
+	mi := &file_daemon_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2209,7 +2410,7 @@ func (x *SignReceiveAuthMessageResponse) String() string {
 func (*SignReceiveAuthMessageResponse) ProtoMessage() {}
 
 func (x *SignReceiveAuthMessageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[21]
+	mi := &file_daemon_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2222,7 +2423,7 @@ func (x *SignReceiveAuthMessageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignReceiveAuthMessageResponse.ProtoReflect.Descriptor instead.
 func (*SignReceiveAuthMessageResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{21}
+	return file_daemon_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *SignReceiveAuthMessageResponse) GetSignature() []byte {
@@ -2248,7 +2449,7 @@ type SignReceiveAuthMessageCompactRequest struct {
 
 func (x *SignReceiveAuthMessageCompactRequest) Reset() {
 	*x = SignReceiveAuthMessageCompactRequest{}
-	mi := &file_daemon_proto_msgTypes[22]
+	mi := &file_daemon_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2260,7 +2461,7 @@ func (x *SignReceiveAuthMessageCompactRequest) String() string {
 func (*SignReceiveAuthMessageCompactRequest) ProtoMessage() {}
 
 func (x *SignReceiveAuthMessageCompactRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[22]
+	mi := &file_daemon_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2273,7 +2474,7 @@ func (x *SignReceiveAuthMessageCompactRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use SignReceiveAuthMessageCompactRequest.ProtoReflect.Descriptor instead.
 func (*SignReceiveAuthMessageCompactRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{22}
+	return file_daemon_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *SignReceiveAuthMessageCompactRequest) GetPaymentHash() []byte {
@@ -2307,7 +2508,7 @@ type SignReceiveAuthMessageCompactResponse struct {
 
 func (x *SignReceiveAuthMessageCompactResponse) Reset() {
 	*x = SignReceiveAuthMessageCompactResponse{}
-	mi := &file_daemon_proto_msgTypes[23]
+	mi := &file_daemon_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2319,7 +2520,7 @@ func (x *SignReceiveAuthMessageCompactResponse) String() string {
 func (*SignReceiveAuthMessageCompactResponse) ProtoMessage() {}
 
 func (x *SignReceiveAuthMessageCompactResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[23]
+	mi := &file_daemon_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2332,7 +2533,7 @@ func (x *SignReceiveAuthMessageCompactResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use SignReceiveAuthMessageCompactResponse.ProtoReflect.Descriptor instead.
 func (*SignReceiveAuthMessageCompactResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{23}
+	return file_daemon_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *SignReceiveAuthMessageCompactResponse) GetSignature() []byte {
@@ -2355,7 +2556,7 @@ type ReceiveAuthECDHRequest struct {
 
 func (x *ReceiveAuthECDHRequest) Reset() {
 	*x = ReceiveAuthECDHRequest{}
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2367,7 +2568,7 @@ func (x *ReceiveAuthECDHRequest) String() string {
 func (*ReceiveAuthECDHRequest) ProtoMessage() {}
 
 func (x *ReceiveAuthECDHRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2380,7 +2581,7 @@ func (x *ReceiveAuthECDHRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthECDHRequest.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthECDHRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{24}
+	return file_daemon_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ReceiveAuthECDHRequest) GetPaymentHash() []byte {
@@ -2407,7 +2608,7 @@ type ReceiveAuthECDHResponse struct {
 
 func (x *ReceiveAuthECDHResponse) Reset() {
 	*x = ReceiveAuthECDHResponse{}
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2419,7 +2620,7 @@ func (x *ReceiveAuthECDHResponse) String() string {
 func (*ReceiveAuthECDHResponse) ProtoMessage() {}
 
 func (x *ReceiveAuthECDHResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2432,7 +2633,7 @@ func (x *ReceiveAuthECDHResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthECDHResponse.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthECDHResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{25}
+	return file_daemon_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ReceiveAuthECDHResponse) GetSharedSecret() []byte {
@@ -2455,7 +2656,7 @@ type GetIndexedVTXOByPkScriptRequest struct {
 
 func (x *GetIndexedVTXOByPkScriptRequest) Reset() {
 	*x = GetIndexedVTXOByPkScriptRequest{}
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2467,7 +2668,7 @@ func (x *GetIndexedVTXOByPkScriptRequest) String() string {
 func (*GetIndexedVTXOByPkScriptRequest) ProtoMessage() {}
 
 func (x *GetIndexedVTXOByPkScriptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2480,7 +2681,7 @@ func (x *GetIndexedVTXOByPkScriptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetIndexedVTXOByPkScriptRequest.ProtoReflect.Descriptor instead.
 func (*GetIndexedVTXOByPkScriptRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{26}
+	return file_daemon_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetIndexedVTXOByPkScriptRequest) GetPkScript() []byte {
@@ -2507,7 +2708,7 @@ type GetIndexedVTXOByPkScriptResponse struct {
 
 func (x *GetIndexedVTXOByPkScriptResponse) Reset() {
 	*x = GetIndexedVTXOByPkScriptResponse{}
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2519,7 +2720,7 @@ func (x *GetIndexedVTXOByPkScriptResponse) String() string {
 func (*GetIndexedVTXOByPkScriptResponse) ProtoMessage() {}
 
 func (x *GetIndexedVTXOByPkScriptResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2532,10 +2733,185 @@ func (x *GetIndexedVTXOByPkScriptResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetIndexedVTXOByPkScriptResponse.ProtoReflect.Descriptor instead.
 func (*GetIndexedVTXOByPkScriptResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{27}
+	return file_daemon_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GetIndexedVTXOByPkScriptResponse) GetVtxo() *VTXO {
+	if x != nil {
+		return x.Vtxo
+	}
+	return nil
+}
+
+// GetVTXOExpiryInfoRequest identifies one VTXO whose expiry posture should be
+// classified by the daemon's wallet/VTXO expiry policy.
+type GetVTXOExpiryInfoRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// target selects whether the daemon should resolve the VTXO from the local
+	// wallet store by outpoint or from the authoritative indexer by pkScript.
+	//
+	// Types that are valid to be assigned to Target:
+	//
+	//	*GetVTXOExpiryInfoRequest_Outpoint
+	//	*GetVTXOExpiryInfoRequest_PkScript
+	Target isGetVTXOExpiryInfoRequest_Target `protobuf_oneof:"target"`
+	// status_filter restricts pk_script lookups to matching lifecycle states.
+	// It is ignored for outpoint lookups.
+	StatusFilter []VTXOStatus `protobuf:"varint,3,rep,packed,name=status_filter,json=statusFilter,proto3,enum=daemonrpc.VTXOStatus" json:"status_filter,omitempty"`
+	// current_height overrides the chain height used for classification. If
+	// zero, the daemon uses its current best chain height.
+	CurrentHeight int32 `protobuf:"varint,4,opt,name=current_height,json=currentHeight,proto3" json:"current_height,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetVTXOExpiryInfoRequest) Reset() {
+	*x = GetVTXOExpiryInfoRequest{}
+	mi := &file_daemon_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetVTXOExpiryInfoRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetVTXOExpiryInfoRequest) ProtoMessage() {}
+
+func (x *GetVTXOExpiryInfoRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetVTXOExpiryInfoRequest.ProtoReflect.Descriptor instead.
+func (*GetVTXOExpiryInfoRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *GetVTXOExpiryInfoRequest) GetTarget() isGetVTXOExpiryInfoRequest_Target {
+	if x != nil {
+		return x.Target
+	}
+	return nil
+}
+
+func (x *GetVTXOExpiryInfoRequest) GetOutpoint() string {
+	if x != nil {
+		if x, ok := x.Target.(*GetVTXOExpiryInfoRequest_Outpoint); ok {
+			return x.Outpoint
+		}
+	}
+	return ""
+}
+
+func (x *GetVTXOExpiryInfoRequest) GetPkScript() []byte {
+	if x != nil {
+		if x, ok := x.Target.(*GetVTXOExpiryInfoRequest_PkScript); ok {
+			return x.PkScript
+		}
+	}
+	return nil
+}
+
+func (x *GetVTXOExpiryInfoRequest) GetStatusFilter() []VTXOStatus {
+	if x != nil {
+		return x.StatusFilter
+	}
+	return nil
+}
+
+func (x *GetVTXOExpiryInfoRequest) GetCurrentHeight() int32 {
+	if x != nil {
+		return x.CurrentHeight
+	}
+	return 0
+}
+
+type isGetVTXOExpiryInfoRequest_Target interface {
+	isGetVTXOExpiryInfoRequest_Target()
+}
+
+type GetVTXOExpiryInfoRequest_Outpoint struct {
+	// outpoint identifies a locally known VTXO in "txid:index" format.
+	Outpoint string `protobuf:"bytes,1,opt,name=outpoint,proto3,oneof"`
+}
+
+type GetVTXOExpiryInfoRequest_PkScript struct {
+	// pk_script queries the authoritative indexer for a matching VTXO.
+	PkScript []byte `protobuf:"bytes,2,opt,name=pk_script,json=pkScript,proto3,oneof"`
+}
+
+func (*GetVTXOExpiryInfoRequest_Outpoint) isGetVTXOExpiryInfoRequest_Target() {}
+
+func (*GetVTXOExpiryInfoRequest_PkScript) isGetVTXOExpiryInfoRequest_Target() {}
+
+// GetVTXOExpiryInfoResponse returns the VTXO matched by the request together
+// with the expiry posture calculated from the daemon's authoritative metadata.
+type GetVTXOExpiryInfoResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// found reports whether the daemon found a VTXO for the request target.
+	Found bool `protobuf:"varint,1,opt,name=found,proto3" json:"found,omitempty"`
+	// expiry_info is present when found is true and the VTXO had enough timing
+	// metadata to classify.
+	ExpiryInfo *VTXOExpiryInfo `protobuf:"bytes,2,opt,name=expiry_info,json=expiryInfo,proto3" json:"expiry_info,omitempty"`
+	// vtxo is the VTXO used for classification when found.
+	Vtxo          *VTXO `protobuf:"bytes,3,opt,name=vtxo,proto3" json:"vtxo,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetVTXOExpiryInfoResponse) Reset() {
+	*x = GetVTXOExpiryInfoResponse{}
+	mi := &file_daemon_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetVTXOExpiryInfoResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetVTXOExpiryInfoResponse) ProtoMessage() {}
+
+func (x *GetVTXOExpiryInfoResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetVTXOExpiryInfoResponse.ProtoReflect.Descriptor instead.
+func (*GetVTXOExpiryInfoResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *GetVTXOExpiryInfoResponse) GetFound() bool {
+	if x != nil {
+		return x.Found
+	}
+	return false
+}
+
+func (x *GetVTXOExpiryInfoResponse) GetExpiryInfo() *VTXOExpiryInfo {
+	if x != nil {
+		return x.ExpiryInfo
+	}
+	return nil
+}
+
+func (x *GetVTXOExpiryInfoResponse) GetVtxo() *VTXO {
 	if x != nil {
 		return x.Vtxo
 	}
@@ -2554,7 +2930,7 @@ type GetIndexedOORSessionByTxidRequest struct {
 
 func (x *GetIndexedOORSessionByTxidRequest) Reset() {
 	*x = GetIndexedOORSessionByTxidRequest{}
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2566,7 +2942,7 @@ func (x *GetIndexedOORSessionByTxidRequest) String() string {
 func (*GetIndexedOORSessionByTxidRequest) ProtoMessage() {}
 
 func (x *GetIndexedOORSessionByTxidRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2579,7 +2955,7 @@ func (x *GetIndexedOORSessionByTxidRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetIndexedOORSessionByTxidRequest.ProtoReflect.Descriptor instead.
 func (*GetIndexedOORSessionByTxidRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{28}
+	return file_daemon_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetIndexedOORSessionByTxidRequest) GetPkScript() []byte {
@@ -2609,7 +2985,7 @@ type GetIndexedOORSessionByTxidResponse struct {
 
 func (x *GetIndexedOORSessionByTxidResponse) Reset() {
 	*x = GetIndexedOORSessionByTxidResponse{}
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2621,7 +2997,7 @@ func (x *GetIndexedOORSessionByTxidResponse) String() string {
 func (*GetIndexedOORSessionByTxidResponse) ProtoMessage() {}
 
 func (x *GetIndexedOORSessionByTxidResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2634,7 +3010,7 @@ func (x *GetIndexedOORSessionByTxidResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GetIndexedOORSessionByTxidResponse.ProtoReflect.Descriptor instead.
 func (*GetIndexedOORSessionByTxidResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{29}
+	return file_daemon_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetIndexedOORSessionByTxidResponse) GetArkPsbt() []byte {
@@ -2672,7 +3048,7 @@ type Output struct {
 
 func (x *Output) Reset() {
 	*x = Output{}
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2684,7 +3060,7 @@ func (x *Output) String() string {
 func (*Output) ProtoMessage() {}
 
 func (x *Output) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2697,7 +3073,7 @@ func (x *Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Output.ProtoReflect.Descriptor instead.
 func (*Output) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{30}
+	return file_daemon_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *Output) GetDestination() isOutput_Destination {
@@ -2794,7 +3170,7 @@ type SendVTXORequest struct {
 
 func (x *SendVTXORequest) Reset() {
 	*x = SendVTXORequest{}
-	mi := &file_daemon_proto_msgTypes[31]
+	mi := &file_daemon_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2806,7 +3182,7 @@ func (x *SendVTXORequest) String() string {
 func (*SendVTXORequest) ProtoMessage() {}
 
 func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[31]
+	mi := &file_daemon_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2819,7 +3195,7 @@ func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXORequest.ProtoReflect.Descriptor instead.
 func (*SendVTXORequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{31}
+	return file_daemon_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *SendVTXORequest) GetRecipients() []*Output {
@@ -2859,7 +3235,7 @@ type SendVTXOResponse struct {
 
 func (x *SendVTXOResponse) Reset() {
 	*x = SendVTXOResponse{}
-	mi := &file_daemon_proto_msgTypes[32]
+	mi := &file_daemon_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2871,7 +3247,7 @@ func (x *SendVTXOResponse) String() string {
 func (*SendVTXOResponse) ProtoMessage() {}
 
 func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[32]
+	mi := &file_daemon_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2884,7 +3260,7 @@ func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXOResponse.ProtoReflect.Descriptor instead.
 func (*SendVTXOResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{32}
+	return file_daemon_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *SendVTXOResponse) GetStatus() string {
@@ -2944,7 +3320,7 @@ type SendOORRequest struct {
 
 func (x *SendOORRequest) Reset() {
 	*x = SendOORRequest{}
-	mi := &file_daemon_proto_msgTypes[33]
+	mi := &file_daemon_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2956,7 +3332,7 @@ func (x *SendOORRequest) String() string {
 func (*SendOORRequest) ProtoMessage() {}
 
 func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[33]
+	mi := &file_daemon_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2969,7 +3345,7 @@ func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORRequest.ProtoReflect.Descriptor instead.
 func (*SendOORRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{33}
+	return file_daemon_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *SendOORRequest) GetRecipients() []*Output {
@@ -3028,7 +3404,7 @@ type CustomOORInput struct {
 
 func (x *CustomOORInput) Reset() {
 	*x = CustomOORInput{}
-	mi := &file_daemon_proto_msgTypes[34]
+	mi := &file_daemon_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3040,7 +3416,7 @@ func (x *CustomOORInput) String() string {
 func (*CustomOORInput) ProtoMessage() {}
 
 func (x *CustomOORInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[34]
+	mi := &file_daemon_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3053,7 +3429,7 @@ func (x *CustomOORInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CustomOORInput.ProtoReflect.Descriptor instead.
 func (*CustomOORInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{34}
+	return file_daemon_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *CustomOORInput) GetOutpoint() string {
@@ -3118,7 +3494,7 @@ type TaprootScriptSignature struct {
 
 func (x *TaprootScriptSignature) Reset() {
 	*x = TaprootScriptSignature{}
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3130,7 +3506,7 @@ func (x *TaprootScriptSignature) String() string {
 func (*TaprootScriptSignature) ProtoMessage() {}
 
 func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3143,7 +3519,7 @@ func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaprootScriptSignature.ProtoReflect.Descriptor instead.
 func (*TaprootScriptSignature) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{35}
+	return file_daemon_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *TaprootScriptSignature) GetPubkey() []byte {
@@ -3194,7 +3570,7 @@ type SendOORResponse struct {
 
 func (x *SendOORResponse) Reset() {
 	*x = SendOORResponse{}
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3206,7 +3582,7 @@ func (x *SendOORResponse) String() string {
 func (*SendOORResponse) ProtoMessage() {}
 
 func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3219,7 +3595,7 @@ func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORResponse.ProtoReflect.Descriptor instead.
 func (*SendOORResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{36}
+	return file_daemon_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *SendOORResponse) GetStatus() string {
@@ -3257,7 +3633,7 @@ type PrepareOORRequest struct {
 
 func (x *PrepareOORRequest) Reset() {
 	*x = PrepareOORRequest{}
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3269,7 +3645,7 @@ func (x *PrepareOORRequest) String() string {
 func (*PrepareOORRequest) ProtoMessage() {}
 
 func (x *PrepareOORRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3282,7 +3658,7 @@ func (x *PrepareOORRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareOORRequest.ProtoReflect.Descriptor instead.
 func (*PrepareOORRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{37}
+	return file_daemon_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *PrepareOORRequest) GetRecipient() *Output {
@@ -3317,7 +3693,7 @@ type PreparedOORCustomInput struct {
 
 func (x *PreparedOORCustomInput) Reset() {
 	*x = PreparedOORCustomInput{}
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3329,7 +3705,7 @@ func (x *PreparedOORCustomInput) String() string {
 func (*PreparedOORCustomInput) ProtoMessage() {}
 
 func (x *PreparedOORCustomInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3342,7 +3718,7 @@ func (x *PreparedOORCustomInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedOORCustomInput.ProtoReflect.Descriptor instead.
 func (*PreparedOORCustomInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{38}
+	return file_daemon_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *PreparedOORCustomInput) GetOutpoint() string {
@@ -3390,7 +3766,7 @@ type PrepareOORResponse struct {
 
 func (x *PrepareOORResponse) Reset() {
 	*x = PrepareOORResponse{}
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3402,7 +3778,7 @@ func (x *PrepareOORResponse) String() string {
 func (*PrepareOORResponse) ProtoMessage() {}
 
 func (x *PrepareOORResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3415,7 +3791,7 @@ func (x *PrepareOORResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareOORResponse.ProtoReflect.Descriptor instead.
 func (*PrepareOORResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{39}
+	return file_daemon_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *PrepareOORResponse) GetArkPsbt() []byte {
@@ -3458,7 +3834,7 @@ type SignOORCustomInputRequest struct {
 
 func (x *SignOORCustomInputRequest) Reset() {
 	*x = SignOORCustomInputRequest{}
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3470,7 +3846,7 @@ func (x *SignOORCustomInputRequest) String() string {
 func (*SignOORCustomInputRequest) ProtoMessage() {}
 
 func (x *SignOORCustomInputRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3483,7 +3859,7 @@ func (x *SignOORCustomInputRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignOORCustomInputRequest.ProtoReflect.Descriptor instead.
 func (*SignOORCustomInputRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{40}
+	return file_daemon_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *SignOORCustomInputRequest) GetCustomInput() *CustomOORInput {
@@ -3510,7 +3886,7 @@ type SignOORCustomInputResponse struct {
 
 func (x *SignOORCustomInputResponse) Reset() {
 	*x = SignOORCustomInputResponse{}
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3522,7 +3898,7 @@ func (x *SignOORCustomInputResponse) String() string {
 func (*SignOORCustomInputResponse) ProtoMessage() {}
 
 func (x *SignOORCustomInputResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3535,7 +3911,7 @@ func (x *SignOORCustomInputResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignOORCustomInputResponse.ProtoReflect.Descriptor instead.
 func (*SignOORCustomInputResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{41}
+	return file_daemon_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *SignOORCustomInputResponse) GetSignature() *TaprootScriptSignature {
@@ -3558,7 +3934,7 @@ type OutpointSelection struct {
 
 func (x *OutpointSelection) Reset() {
 	*x = OutpointSelection{}
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3570,7 +3946,7 @@ func (x *OutpointSelection) String() string {
 func (*OutpointSelection) ProtoMessage() {}
 
 func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3583,7 +3959,7 @@ func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutpointSelection.ProtoReflect.Descriptor instead.
 func (*OutpointSelection) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{42}
+	return file_daemon_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *OutpointSelection) GetOutpoints() []string {
@@ -3608,7 +3984,7 @@ type RefreshVTXOsRequest struct {
 
 func (x *RefreshVTXOsRequest) Reset() {
 	*x = RefreshVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3620,7 +3996,7 @@ func (x *RefreshVTXOsRequest) String() string {
 func (*RefreshVTXOsRequest) ProtoMessage() {}
 
 func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3633,7 +4009,7 @@ func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{43}
+	return file_daemon_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *RefreshVTXOsRequest) GetSelection() isRefreshVTXOsRequest_Selection {
@@ -3700,7 +4076,7 @@ type RefreshVTXOsResponse struct {
 
 func (x *RefreshVTXOsResponse) Reset() {
 	*x = RefreshVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3712,7 +4088,7 @@ func (x *RefreshVTXOsResponse) String() string {
 func (*RefreshVTXOsResponse) ProtoMessage() {}
 
 func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3725,7 +4101,7 @@ func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{44}
+	return file_daemon_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *RefreshVTXOsResponse) GetQueuedOutpoints() []string {
@@ -3759,7 +4135,7 @@ type LeaveDestination struct {
 
 func (x *LeaveDestination) Reset() {
 	*x = LeaveDestination{}
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3771,7 +4147,7 @@ func (x *LeaveDestination) String() string {
 func (*LeaveDestination) ProtoMessage() {}
 
 func (x *LeaveDestination) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3784,7 +4160,7 @@ func (x *LeaveDestination) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveDestination.ProtoReflect.Descriptor instead.
 func (*LeaveDestination) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{45}
+	return file_daemon_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *LeaveDestination) GetTarget() isLeaveDestination_Target {
@@ -3865,7 +4241,7 @@ type LeaveVTXOsRequest struct {
 
 func (x *LeaveVTXOsRequest) Reset() {
 	*x = LeaveVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3877,7 +4253,7 @@ func (x *LeaveVTXOsRequest) String() string {
 func (*LeaveVTXOsRequest) ProtoMessage() {}
 
 func (x *LeaveVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3890,7 +4266,7 @@ func (x *LeaveVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*LeaveVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{46}
+	return file_daemon_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *LeaveVTXOsRequest) GetSelection() isLeaveVTXOsRequest_Selection {
@@ -3973,7 +4349,7 @@ type LeaveVTXOsResponse struct {
 
 func (x *LeaveVTXOsResponse) Reset() {
 	*x = LeaveVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3985,7 +4361,7 @@ func (x *LeaveVTXOsResponse) String() string {
 func (*LeaveVTXOsResponse) ProtoMessage() {}
 
 func (x *LeaveVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3998,7 +4374,7 @@ func (x *LeaveVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*LeaveVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{47}
+	return file_daemon_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *LeaveVTXOsResponse) GetQueuedOutpoints() []string {
@@ -4036,7 +4412,7 @@ type SendOnChainRequest struct {
 
 func (x *SendOnChainRequest) Reset() {
 	*x = SendOnChainRequest{}
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4048,7 +4424,7 @@ func (x *SendOnChainRequest) String() string {
 func (*SendOnChainRequest) ProtoMessage() {}
 
 func (x *SendOnChainRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4061,7 +4437,7 @@ func (x *SendOnChainRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOnChainRequest.ProtoReflect.Descriptor instead.
 func (*SendOnChainRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{48}
+	return file_daemon_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *SendOnChainRequest) GetDestination() *LeaveDestination {
@@ -4160,7 +4536,7 @@ type SendOnChainResponse struct {
 
 func (x *SendOnChainResponse) Reset() {
 	*x = SendOnChainResponse{}
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4172,7 +4548,7 @@ func (x *SendOnChainResponse) String() string {
 func (*SendOnChainResponse) ProtoMessage() {}
 
 func (x *SendOnChainResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4185,7 +4561,7 @@ func (x *SendOnChainResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOnChainResponse.ProtoReflect.Descriptor instead.
 func (*SendOnChainResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{49}
+	return file_daemon_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *SendOnChainResponse) GetActualAmountSat() int64 {
@@ -4244,7 +4620,7 @@ type BoardRequest struct {
 
 func (x *BoardRequest) Reset() {
 	*x = BoardRequest{}
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4256,7 +4632,7 @@ func (x *BoardRequest) String() string {
 func (*BoardRequest) ProtoMessage() {}
 
 func (x *BoardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4269,7 +4645,7 @@ func (x *BoardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardRequest.ProtoReflect.Descriptor instead.
 func (*BoardRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{50}
+	return file_daemon_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *BoardRequest) GetTargetVtxoCount() uint32 {
@@ -4300,7 +4676,7 @@ type BoardResponse struct {
 
 func (x *BoardResponse) Reset() {
 	*x = BoardResponse{}
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4312,7 +4688,7 @@ func (x *BoardResponse) String() string {
 func (*BoardResponse) ProtoMessage() {}
 
 func (x *BoardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4325,7 +4701,7 @@ func (x *BoardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardResponse.ProtoReflect.Descriptor instead.
 func (*BoardResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{51}
+	return file_daemon_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *BoardResponse) GetStatus() string {
@@ -4350,7 +4726,7 @@ type JoinNextRoundRequest struct {
 
 func (x *JoinNextRoundRequest) Reset() {
 	*x = JoinNextRoundRequest{}
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4362,7 +4738,7 @@ func (x *JoinNextRoundRequest) String() string {
 func (*JoinNextRoundRequest) ProtoMessage() {}
 
 func (x *JoinNextRoundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4375,7 +4751,7 @@ func (x *JoinNextRoundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinNextRoundRequest.ProtoReflect.Descriptor instead.
 func (*JoinNextRoundRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{52}
+	return file_daemon_proto_rawDescGZIP(), []int{55}
 }
 
 type JoinNextRoundResponse struct {
@@ -4390,7 +4766,7 @@ type JoinNextRoundResponse struct {
 
 func (x *JoinNextRoundResponse) Reset() {
 	*x = JoinNextRoundResponse{}
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4402,7 +4778,7 @@ func (x *JoinNextRoundResponse) String() string {
 func (*JoinNextRoundResponse) ProtoMessage() {}
 
 func (x *JoinNextRoundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4415,7 +4791,7 @@ func (x *JoinNextRoundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinNextRoundResponse.ProtoReflect.Descriptor instead.
 func (*JoinNextRoundResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{53}
+	return file_daemon_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *JoinNextRoundResponse) GetStatus() string {
@@ -4451,7 +4827,7 @@ type SweepBoardingUTXOsRequest struct {
 
 func (x *SweepBoardingUTXOsRequest) Reset() {
 	*x = SweepBoardingUTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4463,7 +4839,7 @@ func (x *SweepBoardingUTXOsRequest) String() string {
 func (*SweepBoardingUTXOsRequest) ProtoMessage() {}
 
 func (x *SweepBoardingUTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4476,7 +4852,7 @@ func (x *SweepBoardingUTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepBoardingUTXOsRequest.ProtoReflect.Descriptor instead.
 func (*SweepBoardingUTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{54}
+	return file_daemon_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *SweepBoardingUTXOsRequest) GetOutpoints() []string {
@@ -4529,7 +4905,7 @@ type BoardingSweepOutput struct {
 
 func (x *BoardingSweepOutput) Reset() {
 	*x = BoardingSweepOutput{}
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4541,7 +4917,7 @@ func (x *BoardingSweepOutput) String() string {
 func (*BoardingSweepOutput) ProtoMessage() {}
 
 func (x *BoardingSweepOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4554,7 +4930,7 @@ func (x *BoardingSweepOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweepOutput.ProtoReflect.Descriptor instead.
 func (*BoardingSweepOutput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{55}
+	return file_daemon_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *BoardingSweepOutput) GetOutpoint() string {
@@ -4620,7 +4996,7 @@ type SweepBoardingUTXOsResponse struct {
 
 func (x *SweepBoardingUTXOsResponse) Reset() {
 	*x = SweepBoardingUTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4632,7 +5008,7 @@ func (x *SweepBoardingUTXOsResponse) String() string {
 func (*SweepBoardingUTXOsResponse) ProtoMessage() {}
 
 func (x *SweepBoardingUTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4645,7 +5021,7 @@ func (x *SweepBoardingUTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepBoardingUTXOsResponse.ProtoReflect.Descriptor instead.
 func (*SweepBoardingUTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{56}
+	return file_daemon_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *SweepBoardingUTXOsResponse) GetStatus() string {
@@ -4749,7 +5125,7 @@ type ListBoardingSweepsRequest struct {
 
 func (x *ListBoardingSweepsRequest) Reset() {
 	*x = ListBoardingSweepsRequest{}
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4761,7 +5137,7 @@ func (x *ListBoardingSweepsRequest) String() string {
 func (*ListBoardingSweepsRequest) ProtoMessage() {}
 
 func (x *ListBoardingSweepsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4774,7 +5150,7 @@ func (x *ListBoardingSweepsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBoardingSweepsRequest.ProtoReflect.Descriptor instead.
 func (*ListBoardingSweepsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{57}
+	return file_daemon_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *ListBoardingSweepsRequest) GetStatus() string {
@@ -4817,7 +5193,7 @@ type BoardingSweepInput struct {
 
 func (x *BoardingSweepInput) Reset() {
 	*x = BoardingSweepInput{}
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4829,7 +5205,7 @@ func (x *BoardingSweepInput) String() string {
 func (*BoardingSweepInput) ProtoMessage() {}
 
 func (x *BoardingSweepInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4842,7 +5218,7 @@ func (x *BoardingSweepInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweepInput.ProtoReflect.Descriptor instead.
 func (*BoardingSweepInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{58}
+	return file_daemon_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *BoardingSweepInput) GetOutpoint() string {
@@ -4912,7 +5288,7 @@ type BoardingSweep struct {
 
 func (x *BoardingSweep) Reset() {
 	*x = BoardingSweep{}
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4924,7 +5300,7 @@ func (x *BoardingSweep) String() string {
 func (*BoardingSweep) ProtoMessage() {}
 
 func (x *BoardingSweep) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4937,7 +5313,7 @@ func (x *BoardingSweep) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweep.ProtoReflect.Descriptor instead.
 func (*BoardingSweep) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{59}
+	return file_daemon_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *BoardingSweep) GetTxid() string {
@@ -5029,7 +5405,7 @@ type ListBoardingSweepsResponse struct {
 
 func (x *ListBoardingSweepsResponse) Reset() {
 	*x = ListBoardingSweepsResponse{}
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5041,7 +5417,7 @@ func (x *ListBoardingSweepsResponse) String() string {
 func (*ListBoardingSweepsResponse) ProtoMessage() {}
 
 func (x *ListBoardingSweepsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5054,7 +5430,7 @@ func (x *ListBoardingSweepsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBoardingSweepsResponse.ProtoReflect.Descriptor instead.
 func (*ListBoardingSweepsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{60}
+	return file_daemon_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ListBoardingSweepsResponse) GetSweeps() []*BoardingSweep {
@@ -5084,7 +5460,7 @@ type RoundVTXOInfo struct {
 
 func (x *RoundVTXOInfo) Reset() {
 	*x = RoundVTXOInfo{}
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5096,7 +5472,7 @@ func (x *RoundVTXOInfo) String() string {
 func (*RoundVTXOInfo) ProtoMessage() {}
 
 func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5109,7 +5485,7 @@ func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundVTXOInfo.ProtoReflect.Descriptor instead.
 func (*RoundVTXOInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{61}
+	return file_daemon_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *RoundVTXOInfo) GetOutpoint() string {
@@ -5177,7 +5553,7 @@ type RoundInfo struct {
 
 func (x *RoundInfo) Reset() {
 	*x = RoundInfo{}
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5189,7 +5565,7 @@ func (x *RoundInfo) String() string {
 func (*RoundInfo) ProtoMessage() {}
 
 func (x *RoundInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5202,7 +5578,7 @@ func (x *RoundInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundInfo.ProtoReflect.Descriptor instead.
 func (*RoundInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{62}
+	return file_daemon_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *RoundInfo) GetRoundId() string {
@@ -5314,7 +5690,7 @@ type ListRoundsRequest struct {
 
 func (x *ListRoundsRequest) Reset() {
 	*x = ListRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5326,7 +5702,7 @@ func (x *ListRoundsRequest) String() string {
 func (*ListRoundsRequest) ProtoMessage() {}
 
 func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5339,7 +5715,7 @@ func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{63}
+	return file_daemon_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *ListRoundsRequest) GetPageSize() int32 {
@@ -5394,7 +5770,7 @@ type GetRoundRequest struct {
 
 func (x *GetRoundRequest) Reset() {
 	*x = GetRoundRequest{}
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5406,7 +5782,7 @@ func (x *GetRoundRequest) String() string {
 func (*GetRoundRequest) ProtoMessage() {}
 
 func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5419,7 +5795,7 @@ func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundRequest.ProtoReflect.Descriptor instead.
 func (*GetRoundRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{64}
+	return file_daemon_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *GetRoundRequest) GetRoundId() string {
@@ -5439,7 +5815,7 @@ type GetRoundResponse struct {
 
 func (x *GetRoundResponse) Reset() {
 	*x = GetRoundResponse{}
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5451,7 +5827,7 @@ func (x *GetRoundResponse) String() string {
 func (*GetRoundResponse) ProtoMessage() {}
 
 func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5464,7 +5840,7 @@ func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundResponse.ProtoReflect.Descriptor instead.
 func (*GetRoundResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{65}
+	return file_daemon_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *GetRoundResponse) GetRound() *RoundInfo {
@@ -5487,7 +5863,7 @@ type ListRoundsResponse struct {
 
 func (x *ListRoundsResponse) Reset() {
 	*x = ListRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[66]
+	mi := &file_daemon_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5499,7 +5875,7 @@ func (x *ListRoundsResponse) String() string {
 func (*ListRoundsResponse) ProtoMessage() {}
 
 func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[66]
+	mi := &file_daemon_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5512,7 +5888,7 @@ func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{66}
+	return file_daemon_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *ListRoundsResponse) GetRounds() []*RoundInfo {
@@ -5537,7 +5913,7 @@ type WatchRoundsRequest struct {
 
 func (x *WatchRoundsRequest) Reset() {
 	*x = WatchRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[67]
+	mi := &file_daemon_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5549,7 +5925,7 @@ func (x *WatchRoundsRequest) String() string {
 func (*WatchRoundsRequest) ProtoMessage() {}
 
 func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[67]
+	mi := &file_daemon_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5562,7 +5938,7 @@ func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsRequest.ProtoReflect.Descriptor instead.
 func (*WatchRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{67}
+	return file_daemon_proto_rawDescGZIP(), []int{70}
 }
 
 type WatchRoundsResponse struct {
@@ -5576,7 +5952,7 @@ type WatchRoundsResponse struct {
 
 func (x *WatchRoundsResponse) Reset() {
 	*x = WatchRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[68]
+	mi := &file_daemon_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5588,7 +5964,7 @@ func (x *WatchRoundsResponse) String() string {
 func (*WatchRoundsResponse) ProtoMessage() {}
 
 func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[68]
+	mi := &file_daemon_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5601,7 +5977,7 @@ func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsResponse.ProtoReflect.Descriptor instead.
 func (*WatchRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{68}
+	return file_daemon_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *WatchRoundsResponse) GetRound() *RoundInfo {
@@ -5639,7 +6015,7 @@ type OORSessionInfo struct {
 
 func (x *OORSessionInfo) Reset() {
 	*x = OORSessionInfo{}
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5651,7 +6027,7 @@ func (x *OORSessionInfo) String() string {
 func (*OORSessionInfo) ProtoMessage() {}
 
 func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5664,7 +6040,7 @@ func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OORSessionInfo.ProtoReflect.Descriptor instead.
 func (*OORSessionInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{69}
+	return file_daemon_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *OORSessionInfo) GetSessionId() string {
@@ -5748,7 +6124,7 @@ type ListOORSessionsRequest struct {
 
 func (x *ListOORSessionsRequest) Reset() {
 	*x = ListOORSessionsRequest{}
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5760,7 +6136,7 @@ func (x *ListOORSessionsRequest) String() string {
 func (*ListOORSessionsRequest) ProtoMessage() {}
 
 func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5773,7 +6149,7 @@ func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{70}
+	return file_daemon_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *ListOORSessionsRequest) GetPageSize() int32 {
@@ -5817,7 +6193,7 @@ type ListOORSessionsResponse struct {
 
 func (x *ListOORSessionsResponse) Reset() {
 	*x = ListOORSessionsResponse{}
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5829,7 +6205,7 @@ func (x *ListOORSessionsResponse) String() string {
 func (*ListOORSessionsResponse) ProtoMessage() {}
 
 func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5842,7 +6218,7 @@ func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{71}
+	return file_daemon_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *ListOORSessionsResponse) GetSessions() []*OORSessionInfo {
@@ -5869,7 +6245,7 @@ type GetOORSessionRequest struct {
 
 func (x *GetOORSessionRequest) Reset() {
 	*x = GetOORSessionRequest{}
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5881,7 +6257,7 @@ func (x *GetOORSessionRequest) String() string {
 func (*GetOORSessionRequest) ProtoMessage() {}
 
 func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5894,7 +6270,7 @@ func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionRequest.ProtoReflect.Descriptor instead.
 func (*GetOORSessionRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{72}
+	return file_daemon_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *GetOORSessionRequest) GetSessionId() string {
@@ -5914,7 +6290,7 @@ type GetOORSessionResponse struct {
 
 func (x *GetOORSessionResponse) Reset() {
 	*x = GetOORSessionResponse{}
-	mi := &file_daemon_proto_msgTypes[73]
+	mi := &file_daemon_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5926,7 +6302,7 @@ func (x *GetOORSessionResponse) String() string {
 func (*GetOORSessionResponse) ProtoMessage() {}
 
 func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[73]
+	mi := &file_daemon_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5939,7 +6315,7 @@ func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionResponse.ProtoReflect.Descriptor instead.
 func (*GetOORSessionResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{73}
+	return file_daemon_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *GetOORSessionResponse) GetSession() *OORSessionInfo {
@@ -5967,7 +6343,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_daemon_proto_msgTypes[74]
+	mi := &file_daemon_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5979,7 +6355,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[74]
+	mi := &file_daemon_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5992,7 +6368,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{74}
+	return file_daemon_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *EstimateFeeRequest) GetAmountSat() int64 {
@@ -6046,7 +6422,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_daemon_proto_msgTypes[75]
+	mi := &file_daemon_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6058,7 +6434,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[75]
+	mi := &file_daemon_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6071,7 +6447,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{75}
+	return file_daemon_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *EstimateFeeResponse) GetLiquidityFeeSat() int64 {
@@ -6141,7 +6517,7 @@ type GetFeeHistoryRequest struct {
 
 func (x *GetFeeHistoryRequest) Reset() {
 	*x = GetFeeHistoryRequest{}
-	mi := &file_daemon_proto_msgTypes[76]
+	mi := &file_daemon_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6153,7 +6529,7 @@ func (x *GetFeeHistoryRequest) String() string {
 func (*GetFeeHistoryRequest) ProtoMessage() {}
 
 func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[76]
+	mi := &file_daemon_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6166,7 +6542,7 @@ func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryRequest.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{76}
+	return file_daemon_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *GetFeeHistoryRequest) GetLimit() uint32 {
@@ -6241,7 +6617,7 @@ type FeeHistoryEntry struct {
 
 func (x *FeeHistoryEntry) Reset() {
 	*x = FeeHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[77]
+	mi := &file_daemon_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6253,7 +6629,7 @@ func (x *FeeHistoryEntry) String() string {
 func (*FeeHistoryEntry) ProtoMessage() {}
 
 func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[77]
+	mi := &file_daemon_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6266,7 +6642,7 @@ func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeHistoryEntry.ProtoReflect.Descriptor instead.
 func (*FeeHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{77}
+	return file_daemon_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *FeeHistoryEntry) GetEntryId() int64 {
@@ -6346,7 +6722,7 @@ type GetFeeHistoryResponse struct {
 
 func (x *GetFeeHistoryResponse) Reset() {
 	*x = GetFeeHistoryResponse{}
-	mi := &file_daemon_proto_msgTypes[78]
+	mi := &file_daemon_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6358,7 +6734,7 @@ func (x *GetFeeHistoryResponse) String() string {
 func (*GetFeeHistoryResponse) ProtoMessage() {}
 
 func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[78]
+	mi := &file_daemon_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6371,7 +6747,7 @@ func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryResponse.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{78}
+	return file_daemon_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *GetFeeHistoryResponse) GetEntries() []*FeeHistoryEntry {
@@ -6412,7 +6788,7 @@ type ListTransactionsRequest struct {
 
 func (x *ListTransactionsRequest) Reset() {
 	*x = ListTransactionsRequest{}
-	mi := &file_daemon_proto_msgTypes[79]
+	mi := &file_daemon_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6424,7 +6800,7 @@ func (x *ListTransactionsRequest) String() string {
 func (*ListTransactionsRequest) ProtoMessage() {}
 
 func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[79]
+	mi := &file_daemon_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6437,7 +6813,7 @@ func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsRequest.ProtoReflect.Descriptor instead.
 func (*ListTransactionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{79}
+	return file_daemon_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *ListTransactionsRequest) GetFromUnixS() int64 {
@@ -6523,7 +6899,7 @@ type TransactionHistoryEntry struct {
 
 func (x *TransactionHistoryEntry) Reset() {
 	*x = TransactionHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[80]
+	mi := &file_daemon_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6535,7 +6911,7 @@ func (x *TransactionHistoryEntry) String() string {
 func (*TransactionHistoryEntry) ProtoMessage() {}
 
 func (x *TransactionHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[80]
+	mi := &file_daemon_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6548,7 +6924,7 @@ func (x *TransactionHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionHistoryEntry.ProtoReflect.Descriptor instead.
 func (*TransactionHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{80}
+	return file_daemon_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *TransactionHistoryEntry) GetSource() string {
@@ -6678,7 +7054,7 @@ type ListTransactionsResponse struct {
 
 func (x *ListTransactionsResponse) Reset() {
 	*x = ListTransactionsResponse{}
-	mi := &file_daemon_proto_msgTypes[81]
+	mi := &file_daemon_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6690,7 +7066,7 @@ func (x *ListTransactionsResponse) String() string {
 func (*ListTransactionsResponse) ProtoMessage() {}
 
 func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[81]
+	mi := &file_daemon_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6703,7 +7079,7 @@ func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsResponse.ProtoReflect.Descriptor instead.
 func (*ListTransactionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{81}
+	return file_daemon_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *ListTransactionsResponse) GetTransactions() []*TransactionHistoryEntry {
@@ -6738,7 +7114,7 @@ type UnrollRequest struct {
 
 func (x *UnrollRequest) Reset() {
 	*x = UnrollRequest{}
-	mi := &file_daemon_proto_msgTypes[82]
+	mi := &file_daemon_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6750,7 +7126,7 @@ func (x *UnrollRequest) String() string {
 func (*UnrollRequest) ProtoMessage() {}
 
 func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[82]
+	mi := &file_daemon_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6763,7 +7139,7 @@ func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollRequest.ProtoReflect.Descriptor instead.
 func (*UnrollRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{82}
+	return file_daemon_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *UnrollRequest) GetOutpoint() string {
@@ -6786,7 +7162,7 @@ type UnrollResponse struct {
 
 func (x *UnrollResponse) Reset() {
 	*x = UnrollResponse{}
-	mi := &file_daemon_proto_msgTypes[83]
+	mi := &file_daemon_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6798,7 +7174,7 @@ func (x *UnrollResponse) String() string {
 func (*UnrollResponse) ProtoMessage() {}
 
 func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[83]
+	mi := &file_daemon_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6811,7 +7187,7 @@ func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollResponse.ProtoReflect.Descriptor instead.
 func (*UnrollResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{83}
+	return file_daemon_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *UnrollResponse) GetCreated() bool {
@@ -6838,7 +7214,7 @@ type GetUnrollStatusRequest struct {
 
 func (x *GetUnrollStatusRequest) Reset() {
 	*x = GetUnrollStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[84]
+	mi := &file_daemon_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6850,7 +7226,7 @@ func (x *GetUnrollStatusRequest) String() string {
 func (*GetUnrollStatusRequest) ProtoMessage() {}
 
 func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[84]
+	mi := &file_daemon_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6863,7 +7239,7 @@ func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{84}
+	return file_daemon_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *GetUnrollStatusRequest) GetOutpoint() string {
@@ -6891,7 +7267,7 @@ type GetUnrollStatusResponse struct {
 
 func (x *GetUnrollStatusResponse) Reset() {
 	*x = GetUnrollStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[85]
+	mi := &file_daemon_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6903,7 +7279,7 @@ func (x *GetUnrollStatusResponse) String() string {
 func (*GetUnrollStatusResponse) ProtoMessage() {}
 
 func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[85]
+	mi := &file_daemon_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6916,7 +7292,7 @@ func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{85}
+	return file_daemon_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *GetUnrollStatusResponse) GetFound() bool {
@@ -6998,7 +7374,7 @@ type ArmVHTLCRecoveryRequest struct {
 
 func (x *ArmVHTLCRecoveryRequest) Reset() {
 	*x = ArmVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[86]
+	mi := &file_daemon_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7010,7 +7386,7 @@ func (x *ArmVHTLCRecoveryRequest) String() string {
 func (*ArmVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[86]
+	mi := &file_daemon_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7023,7 +7399,7 @@ func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{86}
+	return file_daemon_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *ArmVHTLCRecoveryRequest) GetRequestId() string {
@@ -7166,7 +7542,7 @@ type ArmVHTLCRecoveryResponse struct {
 
 func (x *ArmVHTLCRecoveryResponse) Reset() {
 	*x = ArmVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[87]
+	mi := &file_daemon_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7178,7 +7554,7 @@ func (x *ArmVHTLCRecoveryResponse) String() string {
 func (*ArmVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[87]
+	mi := &file_daemon_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7191,7 +7567,7 @@ func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{87}
+	return file_daemon_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *ArmVHTLCRecoveryResponse) GetRecoveryId() string {
@@ -7231,7 +7607,7 @@ type EscalateVHTLCRecoveryRequest struct {
 
 func (x *EscalateVHTLCRecoveryRequest) Reset() {
 	*x = EscalateVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[88]
+	mi := &file_daemon_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7243,7 +7619,7 @@ func (x *EscalateVHTLCRecoveryRequest) String() string {
 func (*EscalateVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[88]
+	mi := &file_daemon_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7256,7 +7632,7 @@ func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{88}
+	return file_daemon_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *EscalateVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -7290,7 +7666,7 @@ type EscalateVHTLCRecoveryResponse struct {
 
 func (x *EscalateVHTLCRecoveryResponse) Reset() {
 	*x = EscalateVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[89]
+	mi := &file_daemon_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7302,7 +7678,7 @@ func (x *EscalateVHTLCRecoveryResponse) String() string {
 func (*EscalateVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[89]
+	mi := &file_daemon_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7315,7 +7691,7 @@ func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{89}
+	return file_daemon_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *EscalateVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -7339,7 +7715,7 @@ type CancelVHTLCRecoveryRequest struct {
 
 func (x *CancelVHTLCRecoveryRequest) Reset() {
 	*x = CancelVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[90]
+	mi := &file_daemon_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7351,7 +7727,7 @@ func (x *CancelVHTLCRecoveryRequest) String() string {
 func (*CancelVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[90]
+	mi := &file_daemon_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7364,7 +7740,7 @@ func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{90}
+	return file_daemon_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *CancelVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -7398,7 +7774,7 @@ type CancelVHTLCRecoveryResponse struct {
 
 func (x *CancelVHTLCRecoveryResponse) Reset() {
 	*x = CancelVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[91]
+	mi := &file_daemon_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7410,7 +7786,7 @@ func (x *CancelVHTLCRecoveryResponse) String() string {
 func (*CancelVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[91]
+	mi := &file_daemon_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7423,7 +7799,7 @@ func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{91}
+	return file_daemon_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *CancelVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -7443,7 +7819,7 @@ type GetVHTLCRecoveryStatusRequest struct {
 
 func (x *GetVHTLCRecoveryStatusRequest) Reset() {
 	*x = GetVHTLCRecoveryStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[92]
+	mi := &file_daemon_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7455,7 +7831,7 @@ func (x *GetVHTLCRecoveryStatusRequest) String() string {
 func (*GetVHTLCRecoveryStatusRequest) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[92]
+	mi := &file_daemon_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7468,7 +7844,7 @@ func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{92}
+	return file_daemon_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *GetVHTLCRecoveryStatusRequest) GetRecoveryId() string {
@@ -7490,7 +7866,7 @@ type GetVHTLCRecoveryStatusResponse struct {
 
 func (x *GetVHTLCRecoveryStatusResponse) Reset() {
 	*x = GetVHTLCRecoveryStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[93]
+	mi := &file_daemon_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7502,7 +7878,7 @@ func (x *GetVHTLCRecoveryStatusResponse) String() string {
 func (*GetVHTLCRecoveryStatusResponse) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[93]
+	mi := &file_daemon_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7515,7 +7891,7 @@ func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{93}
+	return file_daemon_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *GetVHTLCRecoveryStatusResponse) GetFound() bool {
@@ -7542,7 +7918,7 @@ type ListVHTLCRecoveriesRequest struct {
 
 func (x *ListVHTLCRecoveriesRequest) Reset() {
 	*x = ListVHTLCRecoveriesRequest{}
-	mi := &file_daemon_proto_msgTypes[94]
+	mi := &file_daemon_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7554,7 +7930,7 @@ func (x *ListVHTLCRecoveriesRequest) String() string {
 func (*ListVHTLCRecoveriesRequest) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[94]
+	mi := &file_daemon_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7567,7 +7943,7 @@ func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesRequest.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{94}
+	return file_daemon_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *ListVHTLCRecoveriesRequest) GetIncludeTerminal() bool {
@@ -7587,7 +7963,7 @@ type ListVHTLCRecoveriesResponse struct {
 
 func (x *ListVHTLCRecoveriesResponse) Reset() {
 	*x = ListVHTLCRecoveriesResponse{}
-	mi := &file_daemon_proto_msgTypes[95]
+	mi := &file_daemon_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7599,7 +7975,7 @@ func (x *ListVHTLCRecoveriesResponse) String() string {
 func (*ListVHTLCRecoveriesResponse) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[95]
+	mi := &file_daemon_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7612,7 +7988,7 @@ func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesResponse.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{95}
+	return file_daemon_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *ListVHTLCRecoveriesResponse) GetStatuses() []*VHTLCRecoveryStatus {
@@ -7687,7 +8063,7 @@ type VHTLCRecoveryStatus struct {
 
 func (x *VHTLCRecoveryStatus) Reset() {
 	*x = VHTLCRecoveryStatus{}
-	mi := &file_daemon_proto_msgTypes[96]
+	mi := &file_daemon_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7699,7 +8075,7 @@ func (x *VHTLCRecoveryStatus) String() string {
 func (*VHTLCRecoveryStatus) ProtoMessage() {}
 
 func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[96]
+	mi := &file_daemon_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7712,7 +8088,7 @@ func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VHTLCRecoveryStatus.ProtoReflect.Descriptor instead.
 func (*VHTLCRecoveryStatus) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{96}
+	return file_daemon_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *VHTLCRecoveryStatus) GetRecoveryId() string {
@@ -7956,7 +8332,18 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1conchain_wallet_confirmed_sat\x18\x05 \x01(\x03R\x19onchainWalletConfirmedSat\x12;\n" +
 	"\x1aboarding_pending_sweep_sat\x18\x06 \x01(\x03R\x17boardingPendingSweepSat\x12,\n" +
 	"\x12boarding_swept_sat\x18\a \x01(\x03R\x10boardingSweptSat\x120\n" +
-	"\x14boarding_adopted_sat\x18\b \x01(\x03R\x12boardingAdoptedSat\"\xc6\x03\n" +
+	"\x14boarding_adopted_sat\x18\b \x01(\x03R\x12boardingAdoptedSat\"\xa0\x03\n" +
+	"\x0eVTXOExpiryInfo\x123\n" +
+	"\x06status\x18\x01 \x01(\x0e2\x1b.daemonrpc.VTXOExpiryStatusR\x06status\x12%\n" +
+	"\x0ecurrent_height\x18\x02 \x01(\x05R\rcurrentHeight\x12!\n" +
+	"\fbatch_expiry\x18\x03 \x01(\x05R\vbatchExpiry\x12)\n" +
+	"\x10blocks_remaining\x18\x04 \x01(\x05R\x0fblocksRemaining\x128\n" +
+	"\x18refresh_threshold_blocks\x18\x05 \x01(\x05R\x16refreshThresholdBlocks\x12:\n" +
+	"\x19critical_threshold_blocks\x18\x06 \x01(\x05R\x17criticalThresholdBlocks\x12'\n" +
+	"\x0frelative_expiry\x18\a \x01(\rR\x0erelativeExpiry\x12$\n" +
+	"\x0emax_tree_depth\x18\b \x01(\rR\fmaxTreeDepth\x12\x1f\n" +
+	"\vchain_depth\x18\t \x01(\rR\n" +
+	"chainDepth\"\x82\x04\n" +
 	"\x04VTXO\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1d\n" +
 	"\n" +
@@ -7972,7 +8359,9 @@ const file_daemon_proto_rawDesc = "" +
 	" \x01(\rR\n" +
 	"chainDepth\x12;\n" +
 	"\x1aoor_final_checkpoint_psbts\x18\v \x03(\fR\x17oorFinalCheckpointPsbts\x12\"\n" +
-	"\rspent_by_txid\x18\f \x01(\tR\vspentByTxid\"\xae\x01\n" +
+	"\rspent_by_txid\x18\f \x01(\tR\vspentByTxid\x12:\n" +
+	"\vexpiry_info\x18\r \x01(\v2\x19.daemonrpc.VTXOExpiryInfoR\n" +
+	"expiryInfo\"\xae\x01\n" +
 	"\x10ListVTXOsRequest\x12:\n" +
 	"\rstatus_filter\x18\x01 \x01(\x0e2\x15.daemonrpc.VTXOStatusR\fstatusFilter\x12$\n" +
 	"\x0emin_amount_sat\x18\x02 \x01(\x03R\fminAmountSat\x128\n" +
@@ -8018,7 +8407,18 @@ const file_daemon_proto_rawDesc = "" +
 	"\tpk_script\x18\x01 \x01(\fR\bpkScript\x12:\n" +
 	"\rstatus_filter\x18\x02 \x03(\x0e2\x15.daemonrpc.VTXOStatusR\fstatusFilter\"G\n" +
 	" GetIndexedVTXOByPkScriptResponse\x12#\n" +
-	"\x04vtxo\x18\x01 \x01(\v2\x0f.daemonrpc.VTXOR\x04vtxo\"c\n" +
+	"\x04vtxo\x18\x01 \x01(\v2\x0f.daemonrpc.VTXOR\x04vtxo\"\xc4\x01\n" +
+	"\x18GetVTXOExpiryInfoRequest\x12\x1c\n" +
+	"\boutpoint\x18\x01 \x01(\tH\x00R\boutpoint\x12\x1d\n" +
+	"\tpk_script\x18\x02 \x01(\fH\x00R\bpkScript\x12:\n" +
+	"\rstatus_filter\x18\x03 \x03(\x0e2\x15.daemonrpc.VTXOStatusR\fstatusFilter\x12%\n" +
+	"\x0ecurrent_height\x18\x04 \x01(\x05R\rcurrentHeightB\b\n" +
+	"\x06target\"\x92\x01\n" +
+	"\x19GetVTXOExpiryInfoResponse\x12\x14\n" +
+	"\x05found\x18\x01 \x01(\bR\x05found\x12:\n" +
+	"\vexpiry_info\x18\x02 \x01(\v2\x19.daemonrpc.VTXOExpiryInfoR\n" +
+	"expiryInfo\x12#\n" +
+	"\x04vtxo\x18\x03 \x01(\v2\x0f.daemonrpc.VTXOR\x04vtxo\"c\n" +
 	"!GetIndexedOORSessionByTxidRequest\x12\x1b\n" +
 	"\tpk_script\x18\x01 \x01(\fR\bpkScript\x12!\n" +
 	"\fsession_txid\x18\x02 \x01(\fR\vsessionTxid\"j\n" +
@@ -8436,7 +8836,13 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1bVTXO_STATUS_UNILATERAL_EXIT\x10\x06\x12\x16\n" +
 	"\x12VTXO_STATUS_FAILED\x10\a\x12\x18\n" +
 	"\x14VTXO_STATUS_SPENDING\x10\b\x12\x1d\n" +
-	"\x19VTXO_STATUS_PENDING_ROUND\x10\t*\xf7\x03\n" +
+	"\x19VTXO_STATUS_PENDING_ROUND\x10\t*\xb6\x01\n" +
+	"\x10VTXOExpiryStatus\x12\x1e\n" +
+	"\x1aVTXO_EXPIRY_STATUS_UNKNOWN\x10\x00\x12\x1b\n" +
+	"\x17VTXO_EXPIRY_STATUS_SAFE\x10\x01\x12$\n" +
+	" VTXO_EXPIRY_STATUS_NEEDS_REFRESH\x10\x02\x12\x1f\n" +
+	"\x1bVTXO_EXPIRY_STATUS_CRITICAL\x10\x03\x12\x1e\n" +
+	"\x1aVTXO_EXPIRY_STATUS_EXPIRED\x10\x04*\xf7\x03\n" +
 	"\n" +
 	"RoundState\x12\x17\n" +
 	"\x13ROUND_STATE_UNKNOWN\x10\x00\x12\x14\n" +
@@ -8496,7 +8902,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1eVHTLC_RECOVERY_STATE_COMPLETED\x10\t\x12\"\n" +
 	"\x1eVHTLC_RECOVERY_STATE_CANCELLED\x10\n" +
 	"\x12\x1f\n" +
-	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\x9e\x1b\n" +
+	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\xfe\x1b\n" +
 	"\rDaemonService\x12@\n" +
 	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
 	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
@@ -8513,7 +8919,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\x16SignReceiveAuthMessage\x12(.daemonrpc.SignReceiveAuthMessageRequest\x1a).daemonrpc.SignReceiveAuthMessageResponse\x12\x82\x01\n" +
 	"\x1dSignReceiveAuthMessageCompact\x12/.daemonrpc.SignReceiveAuthMessageCompactRequest\x1a0.daemonrpc.SignReceiveAuthMessageCompactResponse\x12X\n" +
 	"\x0fReceiveAuthECDH\x12!.daemonrpc.ReceiveAuthECDHRequest\x1a\".daemonrpc.ReceiveAuthECDHResponse\x12s\n" +
-	"\x18GetIndexedVTXOByPkScript\x12*.daemonrpc.GetIndexedVTXOByPkScriptRequest\x1a+.daemonrpc.GetIndexedVTXOByPkScriptResponse\x12y\n" +
+	"\x18GetIndexedVTXOByPkScript\x12*.daemonrpc.GetIndexedVTXOByPkScriptRequest\x1a+.daemonrpc.GetIndexedVTXOByPkScriptResponse\x12^\n" +
+	"\x11GetVTXOExpiryInfo\x12#.daemonrpc.GetVTXOExpiryInfoRequest\x1a$.daemonrpc.GetVTXOExpiryInfoResponse\x12y\n" +
 	"\x1aGetIndexedOORSessionByTxid\x12,.daemonrpc.GetIndexedOORSessionByTxidRequest\x1a-.daemonrpc.GetIndexedOORSessionByTxidResponse\x12C\n" +
 	"\bSendVTXO\x12\x1a.daemonrpc.SendVTXORequest\x1a\x1b.daemonrpc.SendVTXOResponse\x12@\n" +
 	"\aSendOOR\x12\x19.daemonrpc.SendOORRequest\x1a\x1a.daemonrpc.SendOORResponse\x12I\n" +
@@ -8557,254 +8964,265 @@ func file_daemon_proto_rawDescGZIP() []byte {
 	return file_daemon_proto_rawDescData
 }
 
-var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 98)
+var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 101)
 var file_daemon_proto_goTypes = []any{
 	(WalletState)(0),                              // 0: daemonrpc.WalletState
 	(VTXOStatus)(0),                               // 1: daemonrpc.VTXOStatus
-	(RoundState)(0),                               // 2: daemonrpc.RoundState
-	(OORSessionDirection)(0),                      // 3: daemonrpc.OORSessionDirection
-	(OORSessionStatus)(0),                         // 4: daemonrpc.OORSessionStatus
-	(UnrollJobStatus)(0),                          // 5: daemonrpc.UnrollJobStatus
-	(VHTLCRecoveryDirection)(0),                   // 6: daemonrpc.VHTLCRecoveryDirection
-	(VHTLCRecoveryAction)(0),                      // 7: daemonrpc.VHTLCRecoveryAction
-	(VHTLCRecoveryState)(0),                       // 8: daemonrpc.VHTLCRecoveryState
-	(*GetInfoRequest)(nil),                        // 9: daemonrpc.GetInfoRequest
-	(*GetInfoResponse)(nil),                       // 10: daemonrpc.GetInfoResponse
-	(*ServerInfo)(nil),                            // 11: daemonrpc.ServerInfo
-	(*GenSeedRequest)(nil),                        // 12: daemonrpc.GenSeedRequest
-	(*GenSeedResponse)(nil),                       // 13: daemonrpc.GenSeedResponse
-	(*InitWalletRequest)(nil),                     // 14: daemonrpc.InitWalletRequest
-	(*InitWalletResponse)(nil),                    // 15: daemonrpc.InitWalletResponse
-	(*UnlockWalletRequest)(nil),                   // 16: daemonrpc.UnlockWalletRequest
-	(*UnlockWalletResponse)(nil),                  // 17: daemonrpc.UnlockWalletResponse
-	(*GetBalanceRequest)(nil),                     // 18: daemonrpc.GetBalanceRequest
-	(*GetBalanceResponse)(nil),                    // 19: daemonrpc.GetBalanceResponse
-	(*VTXO)(nil),                                  // 20: daemonrpc.VTXO
-	(*ListVTXOsRequest)(nil),                      // 21: daemonrpc.ListVTXOsRequest
-	(*ListVTXOsResponse)(nil),                     // 22: daemonrpc.ListVTXOsResponse
-	(*NewAddressRequest)(nil),                     // 23: daemonrpc.NewAddressRequest
-	(*NewAddressResponse)(nil),                    // 24: daemonrpc.NewAddressResponse
-	(*NewReceiveScriptRequest)(nil),               // 25: daemonrpc.NewReceiveScriptRequest
-	(*NewReceiveScriptResponse)(nil),              // 26: daemonrpc.NewReceiveScriptResponse
-	(*ReceiveAuthKeyRequest)(nil),                 // 27: daemonrpc.ReceiveAuthKeyRequest
-	(*ReceiveAuthKeyResponse)(nil),                // 28: daemonrpc.ReceiveAuthKeyResponse
-	(*SignReceiveAuthMessageRequest)(nil),         // 29: daemonrpc.SignReceiveAuthMessageRequest
-	(*SignReceiveAuthMessageResponse)(nil),        // 30: daemonrpc.SignReceiveAuthMessageResponse
-	(*SignReceiveAuthMessageCompactRequest)(nil),  // 31: daemonrpc.SignReceiveAuthMessageCompactRequest
-	(*SignReceiveAuthMessageCompactResponse)(nil), // 32: daemonrpc.SignReceiveAuthMessageCompactResponse
-	(*ReceiveAuthECDHRequest)(nil),                // 33: daemonrpc.ReceiveAuthECDHRequest
-	(*ReceiveAuthECDHResponse)(nil),               // 34: daemonrpc.ReceiveAuthECDHResponse
-	(*GetIndexedVTXOByPkScriptRequest)(nil),       // 35: daemonrpc.GetIndexedVTXOByPkScriptRequest
-	(*GetIndexedVTXOByPkScriptResponse)(nil),      // 36: daemonrpc.GetIndexedVTXOByPkScriptResponse
-	(*GetIndexedOORSessionByTxidRequest)(nil),     // 37: daemonrpc.GetIndexedOORSessionByTxidRequest
-	(*GetIndexedOORSessionByTxidResponse)(nil),    // 38: daemonrpc.GetIndexedOORSessionByTxidResponse
-	(*Output)(nil),                                // 39: daemonrpc.Output
-	(*SendVTXORequest)(nil),                       // 40: daemonrpc.SendVTXORequest
-	(*SendVTXOResponse)(nil),                      // 41: daemonrpc.SendVTXOResponse
-	(*SendOORRequest)(nil),                        // 42: daemonrpc.SendOORRequest
-	(*CustomOORInput)(nil),                        // 43: daemonrpc.CustomOORInput
-	(*TaprootScriptSignature)(nil),                // 44: daemonrpc.TaprootScriptSignature
-	(*SendOORResponse)(nil),                       // 45: daemonrpc.SendOORResponse
-	(*PrepareOORRequest)(nil),                     // 46: daemonrpc.PrepareOORRequest
-	(*PreparedOORCustomInput)(nil),                // 47: daemonrpc.PreparedOORCustomInput
-	(*PrepareOORResponse)(nil),                    // 48: daemonrpc.PrepareOORResponse
-	(*SignOORCustomInputRequest)(nil),             // 49: daemonrpc.SignOORCustomInputRequest
-	(*SignOORCustomInputResponse)(nil),            // 50: daemonrpc.SignOORCustomInputResponse
-	(*OutpointSelection)(nil),                     // 51: daemonrpc.OutpointSelection
-	(*RefreshVTXOsRequest)(nil),                   // 52: daemonrpc.RefreshVTXOsRequest
-	(*RefreshVTXOsResponse)(nil),                  // 53: daemonrpc.RefreshVTXOsResponse
-	(*LeaveDestination)(nil),                      // 54: daemonrpc.LeaveDestination
-	(*LeaveVTXOsRequest)(nil),                     // 55: daemonrpc.LeaveVTXOsRequest
-	(*LeaveVTXOsResponse)(nil),                    // 56: daemonrpc.LeaveVTXOsResponse
-	(*SendOnChainRequest)(nil),                    // 57: daemonrpc.SendOnChainRequest
-	(*SendOnChainResponse)(nil),                   // 58: daemonrpc.SendOnChainResponse
-	(*BoardRequest)(nil),                          // 59: daemonrpc.BoardRequest
-	(*BoardResponse)(nil),                         // 60: daemonrpc.BoardResponse
-	(*JoinNextRoundRequest)(nil),                  // 61: daemonrpc.JoinNextRoundRequest
-	(*JoinNextRoundResponse)(nil),                 // 62: daemonrpc.JoinNextRoundResponse
-	(*SweepBoardingUTXOsRequest)(nil),             // 63: daemonrpc.SweepBoardingUTXOsRequest
-	(*BoardingSweepOutput)(nil),                   // 64: daemonrpc.BoardingSweepOutput
-	(*SweepBoardingUTXOsResponse)(nil),            // 65: daemonrpc.SweepBoardingUTXOsResponse
-	(*ListBoardingSweepsRequest)(nil),             // 66: daemonrpc.ListBoardingSweepsRequest
-	(*BoardingSweepInput)(nil),                    // 67: daemonrpc.BoardingSweepInput
-	(*BoardingSweep)(nil),                         // 68: daemonrpc.BoardingSweep
-	(*ListBoardingSweepsResponse)(nil),            // 69: daemonrpc.ListBoardingSweepsResponse
-	(*RoundVTXOInfo)(nil),                         // 70: daemonrpc.RoundVTXOInfo
-	(*RoundInfo)(nil),                             // 71: daemonrpc.RoundInfo
-	(*ListRoundsRequest)(nil),                     // 72: daemonrpc.ListRoundsRequest
-	(*GetRoundRequest)(nil),                       // 73: daemonrpc.GetRoundRequest
-	(*GetRoundResponse)(nil),                      // 74: daemonrpc.GetRoundResponse
-	(*ListRoundsResponse)(nil),                    // 75: daemonrpc.ListRoundsResponse
-	(*WatchRoundsRequest)(nil),                    // 76: daemonrpc.WatchRoundsRequest
-	(*WatchRoundsResponse)(nil),                   // 77: daemonrpc.WatchRoundsResponse
-	(*OORSessionInfo)(nil),                        // 78: daemonrpc.OORSessionInfo
-	(*ListOORSessionsRequest)(nil),                // 79: daemonrpc.ListOORSessionsRequest
-	(*ListOORSessionsResponse)(nil),               // 80: daemonrpc.ListOORSessionsResponse
-	(*GetOORSessionRequest)(nil),                  // 81: daemonrpc.GetOORSessionRequest
-	(*GetOORSessionResponse)(nil),                 // 82: daemonrpc.GetOORSessionResponse
-	(*EstimateFeeRequest)(nil),                    // 83: daemonrpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil),                   // 84: daemonrpc.EstimateFeeResponse
-	(*GetFeeHistoryRequest)(nil),                  // 85: daemonrpc.GetFeeHistoryRequest
-	(*FeeHistoryEntry)(nil),                       // 86: daemonrpc.FeeHistoryEntry
-	(*GetFeeHistoryResponse)(nil),                 // 87: daemonrpc.GetFeeHistoryResponse
-	(*ListTransactionsRequest)(nil),               // 88: daemonrpc.ListTransactionsRequest
-	(*TransactionHistoryEntry)(nil),               // 89: daemonrpc.TransactionHistoryEntry
-	(*ListTransactionsResponse)(nil),              // 90: daemonrpc.ListTransactionsResponse
-	(*UnrollRequest)(nil),                         // 91: daemonrpc.UnrollRequest
-	(*UnrollResponse)(nil),                        // 92: daemonrpc.UnrollResponse
-	(*GetUnrollStatusRequest)(nil),                // 93: daemonrpc.GetUnrollStatusRequest
-	(*GetUnrollStatusResponse)(nil),               // 94: daemonrpc.GetUnrollStatusResponse
-	(*ArmVHTLCRecoveryRequest)(nil),               // 95: daemonrpc.ArmVHTLCRecoveryRequest
-	(*ArmVHTLCRecoveryResponse)(nil),              // 96: daemonrpc.ArmVHTLCRecoveryResponse
-	(*EscalateVHTLCRecoveryRequest)(nil),          // 97: daemonrpc.EscalateVHTLCRecoveryRequest
-	(*EscalateVHTLCRecoveryResponse)(nil),         // 98: daemonrpc.EscalateVHTLCRecoveryResponse
-	(*CancelVHTLCRecoveryRequest)(nil),            // 99: daemonrpc.CancelVHTLCRecoveryRequest
-	(*CancelVHTLCRecoveryResponse)(nil),           // 100: daemonrpc.CancelVHTLCRecoveryResponse
-	(*GetVHTLCRecoveryStatusRequest)(nil),         // 101: daemonrpc.GetVHTLCRecoveryStatusRequest
-	(*GetVHTLCRecoveryStatusResponse)(nil),        // 102: daemonrpc.GetVHTLCRecoveryStatusResponse
-	(*ListVHTLCRecoveriesRequest)(nil),            // 103: daemonrpc.ListVHTLCRecoveriesRequest
-	(*ListVHTLCRecoveriesResponse)(nil),           // 104: daemonrpc.ListVHTLCRecoveriesResponse
-	(*VHTLCRecoveryStatus)(nil),                   // 105: daemonrpc.VHTLCRecoveryStatus
-	nil,                                           // 106: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	(VTXOExpiryStatus)(0),                         // 2: daemonrpc.VTXOExpiryStatus
+	(RoundState)(0),                               // 3: daemonrpc.RoundState
+	(OORSessionDirection)(0),                      // 4: daemonrpc.OORSessionDirection
+	(OORSessionStatus)(0),                         // 5: daemonrpc.OORSessionStatus
+	(UnrollJobStatus)(0),                          // 6: daemonrpc.UnrollJobStatus
+	(VHTLCRecoveryDirection)(0),                   // 7: daemonrpc.VHTLCRecoveryDirection
+	(VHTLCRecoveryAction)(0),                      // 8: daemonrpc.VHTLCRecoveryAction
+	(VHTLCRecoveryState)(0),                       // 9: daemonrpc.VHTLCRecoveryState
+	(*GetInfoRequest)(nil),                        // 10: daemonrpc.GetInfoRequest
+	(*GetInfoResponse)(nil),                       // 11: daemonrpc.GetInfoResponse
+	(*ServerInfo)(nil),                            // 12: daemonrpc.ServerInfo
+	(*GenSeedRequest)(nil),                        // 13: daemonrpc.GenSeedRequest
+	(*GenSeedResponse)(nil),                       // 14: daemonrpc.GenSeedResponse
+	(*InitWalletRequest)(nil),                     // 15: daemonrpc.InitWalletRequest
+	(*InitWalletResponse)(nil),                    // 16: daemonrpc.InitWalletResponse
+	(*UnlockWalletRequest)(nil),                   // 17: daemonrpc.UnlockWalletRequest
+	(*UnlockWalletResponse)(nil),                  // 18: daemonrpc.UnlockWalletResponse
+	(*GetBalanceRequest)(nil),                     // 19: daemonrpc.GetBalanceRequest
+	(*GetBalanceResponse)(nil),                    // 20: daemonrpc.GetBalanceResponse
+	(*VTXOExpiryInfo)(nil),                        // 21: daemonrpc.VTXOExpiryInfo
+	(*VTXO)(nil),                                  // 22: daemonrpc.VTXO
+	(*ListVTXOsRequest)(nil),                      // 23: daemonrpc.ListVTXOsRequest
+	(*ListVTXOsResponse)(nil),                     // 24: daemonrpc.ListVTXOsResponse
+	(*NewAddressRequest)(nil),                     // 25: daemonrpc.NewAddressRequest
+	(*NewAddressResponse)(nil),                    // 26: daemonrpc.NewAddressResponse
+	(*NewReceiveScriptRequest)(nil),               // 27: daemonrpc.NewReceiveScriptRequest
+	(*NewReceiveScriptResponse)(nil),              // 28: daemonrpc.NewReceiveScriptResponse
+	(*ReceiveAuthKeyRequest)(nil),                 // 29: daemonrpc.ReceiveAuthKeyRequest
+	(*ReceiveAuthKeyResponse)(nil),                // 30: daemonrpc.ReceiveAuthKeyResponse
+	(*SignReceiveAuthMessageRequest)(nil),         // 31: daemonrpc.SignReceiveAuthMessageRequest
+	(*SignReceiveAuthMessageResponse)(nil),        // 32: daemonrpc.SignReceiveAuthMessageResponse
+	(*SignReceiveAuthMessageCompactRequest)(nil),  // 33: daemonrpc.SignReceiveAuthMessageCompactRequest
+	(*SignReceiveAuthMessageCompactResponse)(nil), // 34: daemonrpc.SignReceiveAuthMessageCompactResponse
+	(*ReceiveAuthECDHRequest)(nil),                // 35: daemonrpc.ReceiveAuthECDHRequest
+	(*ReceiveAuthECDHResponse)(nil),               // 36: daemonrpc.ReceiveAuthECDHResponse
+	(*GetIndexedVTXOByPkScriptRequest)(nil),       // 37: daemonrpc.GetIndexedVTXOByPkScriptRequest
+	(*GetIndexedVTXOByPkScriptResponse)(nil),      // 38: daemonrpc.GetIndexedVTXOByPkScriptResponse
+	(*GetVTXOExpiryInfoRequest)(nil),              // 39: daemonrpc.GetVTXOExpiryInfoRequest
+	(*GetVTXOExpiryInfoResponse)(nil),             // 40: daemonrpc.GetVTXOExpiryInfoResponse
+	(*GetIndexedOORSessionByTxidRequest)(nil),     // 41: daemonrpc.GetIndexedOORSessionByTxidRequest
+	(*GetIndexedOORSessionByTxidResponse)(nil),    // 42: daemonrpc.GetIndexedOORSessionByTxidResponse
+	(*Output)(nil),                                // 43: daemonrpc.Output
+	(*SendVTXORequest)(nil),                       // 44: daemonrpc.SendVTXORequest
+	(*SendVTXOResponse)(nil),                      // 45: daemonrpc.SendVTXOResponse
+	(*SendOORRequest)(nil),                        // 46: daemonrpc.SendOORRequest
+	(*CustomOORInput)(nil),                        // 47: daemonrpc.CustomOORInput
+	(*TaprootScriptSignature)(nil),                // 48: daemonrpc.TaprootScriptSignature
+	(*SendOORResponse)(nil),                       // 49: daemonrpc.SendOORResponse
+	(*PrepareOORRequest)(nil),                     // 50: daemonrpc.PrepareOORRequest
+	(*PreparedOORCustomInput)(nil),                // 51: daemonrpc.PreparedOORCustomInput
+	(*PrepareOORResponse)(nil),                    // 52: daemonrpc.PrepareOORResponse
+	(*SignOORCustomInputRequest)(nil),             // 53: daemonrpc.SignOORCustomInputRequest
+	(*SignOORCustomInputResponse)(nil),            // 54: daemonrpc.SignOORCustomInputResponse
+	(*OutpointSelection)(nil),                     // 55: daemonrpc.OutpointSelection
+	(*RefreshVTXOsRequest)(nil),                   // 56: daemonrpc.RefreshVTXOsRequest
+	(*RefreshVTXOsResponse)(nil),                  // 57: daemonrpc.RefreshVTXOsResponse
+	(*LeaveDestination)(nil),                      // 58: daemonrpc.LeaveDestination
+	(*LeaveVTXOsRequest)(nil),                     // 59: daemonrpc.LeaveVTXOsRequest
+	(*LeaveVTXOsResponse)(nil),                    // 60: daemonrpc.LeaveVTXOsResponse
+	(*SendOnChainRequest)(nil),                    // 61: daemonrpc.SendOnChainRequest
+	(*SendOnChainResponse)(nil),                   // 62: daemonrpc.SendOnChainResponse
+	(*BoardRequest)(nil),                          // 63: daemonrpc.BoardRequest
+	(*BoardResponse)(nil),                         // 64: daemonrpc.BoardResponse
+	(*JoinNextRoundRequest)(nil),                  // 65: daemonrpc.JoinNextRoundRequest
+	(*JoinNextRoundResponse)(nil),                 // 66: daemonrpc.JoinNextRoundResponse
+	(*SweepBoardingUTXOsRequest)(nil),             // 67: daemonrpc.SweepBoardingUTXOsRequest
+	(*BoardingSweepOutput)(nil),                   // 68: daemonrpc.BoardingSweepOutput
+	(*SweepBoardingUTXOsResponse)(nil),            // 69: daemonrpc.SweepBoardingUTXOsResponse
+	(*ListBoardingSweepsRequest)(nil),             // 70: daemonrpc.ListBoardingSweepsRequest
+	(*BoardingSweepInput)(nil),                    // 71: daemonrpc.BoardingSweepInput
+	(*BoardingSweep)(nil),                         // 72: daemonrpc.BoardingSweep
+	(*ListBoardingSweepsResponse)(nil),            // 73: daemonrpc.ListBoardingSweepsResponse
+	(*RoundVTXOInfo)(nil),                         // 74: daemonrpc.RoundVTXOInfo
+	(*RoundInfo)(nil),                             // 75: daemonrpc.RoundInfo
+	(*ListRoundsRequest)(nil),                     // 76: daemonrpc.ListRoundsRequest
+	(*GetRoundRequest)(nil),                       // 77: daemonrpc.GetRoundRequest
+	(*GetRoundResponse)(nil),                      // 78: daemonrpc.GetRoundResponse
+	(*ListRoundsResponse)(nil),                    // 79: daemonrpc.ListRoundsResponse
+	(*WatchRoundsRequest)(nil),                    // 80: daemonrpc.WatchRoundsRequest
+	(*WatchRoundsResponse)(nil),                   // 81: daemonrpc.WatchRoundsResponse
+	(*OORSessionInfo)(nil),                        // 82: daemonrpc.OORSessionInfo
+	(*ListOORSessionsRequest)(nil),                // 83: daemonrpc.ListOORSessionsRequest
+	(*ListOORSessionsResponse)(nil),               // 84: daemonrpc.ListOORSessionsResponse
+	(*GetOORSessionRequest)(nil),                  // 85: daemonrpc.GetOORSessionRequest
+	(*GetOORSessionResponse)(nil),                 // 86: daemonrpc.GetOORSessionResponse
+	(*EstimateFeeRequest)(nil),                    // 87: daemonrpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil),                   // 88: daemonrpc.EstimateFeeResponse
+	(*GetFeeHistoryRequest)(nil),                  // 89: daemonrpc.GetFeeHistoryRequest
+	(*FeeHistoryEntry)(nil),                       // 90: daemonrpc.FeeHistoryEntry
+	(*GetFeeHistoryResponse)(nil),                 // 91: daemonrpc.GetFeeHistoryResponse
+	(*ListTransactionsRequest)(nil),               // 92: daemonrpc.ListTransactionsRequest
+	(*TransactionHistoryEntry)(nil),               // 93: daemonrpc.TransactionHistoryEntry
+	(*ListTransactionsResponse)(nil),              // 94: daemonrpc.ListTransactionsResponse
+	(*UnrollRequest)(nil),                         // 95: daemonrpc.UnrollRequest
+	(*UnrollResponse)(nil),                        // 96: daemonrpc.UnrollResponse
+	(*GetUnrollStatusRequest)(nil),                // 97: daemonrpc.GetUnrollStatusRequest
+	(*GetUnrollStatusResponse)(nil),               // 98: daemonrpc.GetUnrollStatusResponse
+	(*ArmVHTLCRecoveryRequest)(nil),               // 99: daemonrpc.ArmVHTLCRecoveryRequest
+	(*ArmVHTLCRecoveryResponse)(nil),              // 100: daemonrpc.ArmVHTLCRecoveryResponse
+	(*EscalateVHTLCRecoveryRequest)(nil),          // 101: daemonrpc.EscalateVHTLCRecoveryRequest
+	(*EscalateVHTLCRecoveryResponse)(nil),         // 102: daemonrpc.EscalateVHTLCRecoveryResponse
+	(*CancelVHTLCRecoveryRequest)(nil),            // 103: daemonrpc.CancelVHTLCRecoveryRequest
+	(*CancelVHTLCRecoveryResponse)(nil),           // 104: daemonrpc.CancelVHTLCRecoveryResponse
+	(*GetVHTLCRecoveryStatusRequest)(nil),         // 105: daemonrpc.GetVHTLCRecoveryStatusRequest
+	(*GetVHTLCRecoveryStatusResponse)(nil),        // 106: daemonrpc.GetVHTLCRecoveryStatusResponse
+	(*ListVHTLCRecoveriesRequest)(nil),            // 107: daemonrpc.ListVHTLCRecoveriesRequest
+	(*ListVHTLCRecoveriesResponse)(nil),           // 108: daemonrpc.ListVHTLCRecoveriesResponse
+	(*VHTLCRecoveryStatus)(nil),                   // 109: daemonrpc.VHTLCRecoveryStatus
+	nil,                                           // 110: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
 	0,   // 0: daemonrpc.GetInfoResponse.wallet_state:type_name -> daemonrpc.WalletState
-	11,  // 1: daemonrpc.GetInfoResponse.server_info:type_name -> daemonrpc.ServerInfo
-	1,   // 2: daemonrpc.VTXO.status:type_name -> daemonrpc.VTXOStatus
-	1,   // 3: daemonrpc.ListVTXOsRequest.status_filter:type_name -> daemonrpc.VTXOStatus
-	20,  // 4: daemonrpc.ListVTXOsResponse.vtxos:type_name -> daemonrpc.VTXO
-	1,   // 5: daemonrpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> daemonrpc.VTXOStatus
-	20,  // 6: daemonrpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> daemonrpc.VTXO
-	39,  // 7: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
-	39,  // 8: daemonrpc.SendOORRequest.recipients:type_name -> daemonrpc.Output
-	43,  // 9: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
-	44,  // 10: daemonrpc.CustomOORInput.external_signatures:type_name -> daemonrpc.TaprootScriptSignature
-	39,  // 11: daemonrpc.PrepareOORRequest.recipient:type_name -> daemonrpc.Output
-	43,  // 12: daemonrpc.PrepareOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
-	47,  // 13: daemonrpc.PrepareOORResponse.custom_inputs:type_name -> daemonrpc.PreparedOORCustomInput
-	43,  // 14: daemonrpc.SignOORCustomInputRequest.custom_input:type_name -> daemonrpc.CustomOORInput
-	44,  // 15: daemonrpc.SignOORCustomInputResponse.signature:type_name -> daemonrpc.TaprootScriptSignature
-	51,  // 16: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
-	51,  // 17: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
-	54,  // 18: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
-	106, // 19: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
-	54,  // 20: daemonrpc.SendOnChainRequest.destination:type_name -> daemonrpc.LeaveDestination
-	64,  // 21: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
-	67,  // 22: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
-	68,  // 23: daemonrpc.ListBoardingSweepsResponse.sweeps:type_name -> daemonrpc.BoardingSweep
-	2,   // 24: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
-	70,  // 25: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
-	2,   // 26: daemonrpc.ListRoundsRequest.state_filter:type_name -> daemonrpc.RoundState
-	71,  // 27: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
-	71,  // 28: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
-	71,  // 29: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
-	3,   // 30: daemonrpc.OORSessionInfo.direction:type_name -> daemonrpc.OORSessionDirection
-	4,   // 31: daemonrpc.OORSessionInfo.status:type_name -> daemonrpc.OORSessionStatus
-	3,   // 32: daemonrpc.ListOORSessionsRequest.direction_filter:type_name -> daemonrpc.OORSessionDirection
-	4,   // 33: daemonrpc.ListOORSessionsRequest.status_filter:type_name -> daemonrpc.OORSessionStatus
-	78,  // 34: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
-	78,  // 35: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
-	86,  // 36: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
-	89,  // 37: daemonrpc.ListTransactionsResponse.transactions:type_name -> daemonrpc.TransactionHistoryEntry
-	5,   // 38: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
-	6,   // 39: daemonrpc.ArmVHTLCRecoveryRequest.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
-	7,   // 40: daemonrpc.ArmVHTLCRecoveryRequest.action:type_name -> daemonrpc.VHTLCRecoveryAction
-	105, // 41: daemonrpc.ArmVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	105, // 42: daemonrpc.EscalateVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	105, // 43: daemonrpc.CancelVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	105, // 44: daemonrpc.GetVHTLCRecoveryStatusResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	105, // 45: daemonrpc.ListVHTLCRecoveriesResponse.statuses:type_name -> daemonrpc.VHTLCRecoveryStatus
-	6,   // 46: daemonrpc.VHTLCRecoveryStatus.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
-	7,   // 47: daemonrpc.VHTLCRecoveryStatus.action:type_name -> daemonrpc.VHTLCRecoveryAction
-	8,   // 48: daemonrpc.VHTLCRecoveryStatus.state:type_name -> daemonrpc.VHTLCRecoveryState
-	5,   // 49: daemonrpc.VHTLCRecoveryStatus.unroll_status:type_name -> daemonrpc.UnrollJobStatus
-	54,  // 50: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
-	9,   // 51: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
-	12,  // 52: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
-	14,  // 53: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
-	16,  // 54: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
-	18,  // 55: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
-	21,  // 56: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
-	23,  // 57: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
-	25,  // 58: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
-	27,  // 59: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
-	29,  // 60: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
-	31,  // 61: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
-	33,  // 62: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
-	35,  // 63: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
-	37,  // 64: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
-	40,  // 65: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
-	42,  // 66: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
-	46,  // 67: daemonrpc.DaemonService.PrepareOOR:input_type -> daemonrpc.PrepareOORRequest
-	49,  // 68: daemonrpc.DaemonService.SignOORCustomInput:input_type -> daemonrpc.SignOORCustomInputRequest
-	52,  // 69: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
-	55,  // 70: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
-	57,  // 71: daemonrpc.DaemonService.SendOnChain:input_type -> daemonrpc.SendOnChainRequest
-	59,  // 72: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
-	61,  // 73: daemonrpc.DaemonService.JoinNextRound:input_type -> daemonrpc.JoinNextRoundRequest
-	63,  // 74: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
-	66,  // 75: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
-	72,  // 76: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
-	73,  // 77: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
-	76,  // 78: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
-	79,  // 79: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
-	81,  // 80: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
-	83,  // 81: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
-	85,  // 82: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
-	88,  // 83: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
-	91,  // 84: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
-	93,  // 85: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
-	95,  // 86: daemonrpc.DaemonService.ArmVHTLCRecovery:input_type -> daemonrpc.ArmVHTLCRecoveryRequest
-	97,  // 87: daemonrpc.DaemonService.EscalateVHTLCRecovery:input_type -> daemonrpc.EscalateVHTLCRecoveryRequest
-	99,  // 88: daemonrpc.DaemonService.CancelVHTLCRecovery:input_type -> daemonrpc.CancelVHTLCRecoveryRequest
-	101, // 89: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> daemonrpc.GetVHTLCRecoveryStatusRequest
-	103, // 90: daemonrpc.DaemonService.ListVHTLCRecoveries:input_type -> daemonrpc.ListVHTLCRecoveriesRequest
-	10,  // 91: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	13,  // 92: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	15,  // 93: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	17,  // 94: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	19,  // 95: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	22,  // 96: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	24,  // 97: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	26,  // 98: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
-	28,  // 99: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
-	30,  // 100: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
-	32,  // 101: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
-	34,  // 102: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
-	36,  // 103: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
-	38,  // 104: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
-	41,  // 105: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	45,  // 106: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	48,  // 107: daemonrpc.DaemonService.PrepareOOR:output_type -> daemonrpc.PrepareOORResponse
-	50,  // 108: daemonrpc.DaemonService.SignOORCustomInput:output_type -> daemonrpc.SignOORCustomInputResponse
-	53,  // 109: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	56,  // 110: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
-	58,  // 111: daemonrpc.DaemonService.SendOnChain:output_type -> daemonrpc.SendOnChainResponse
-	60,  // 112: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	62,  // 113: daemonrpc.DaemonService.JoinNextRound:output_type -> daemonrpc.JoinNextRoundResponse
-	65,  // 114: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
-	69,  // 115: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
-	75,  // 116: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	74,  // 117: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
-	77,  // 118: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	80,  // 119: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
-	82,  // 120: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
-	84,  // 121: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
-	87,  // 122: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
-	90,  // 123: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
-	92,  // 124: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
-	94,  // 125: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
-	96,  // 126: daemonrpc.DaemonService.ArmVHTLCRecovery:output_type -> daemonrpc.ArmVHTLCRecoveryResponse
-	98,  // 127: daemonrpc.DaemonService.EscalateVHTLCRecovery:output_type -> daemonrpc.EscalateVHTLCRecoveryResponse
-	100, // 128: daemonrpc.DaemonService.CancelVHTLCRecovery:output_type -> daemonrpc.CancelVHTLCRecoveryResponse
-	102, // 129: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> daemonrpc.GetVHTLCRecoveryStatusResponse
-	104, // 130: daemonrpc.DaemonService.ListVHTLCRecoveries:output_type -> daemonrpc.ListVHTLCRecoveriesResponse
-	91,  // [91:131] is the sub-list for method output_type
-	51,  // [51:91] is the sub-list for method input_type
-	51,  // [51:51] is the sub-list for extension type_name
-	51,  // [51:51] is the sub-list for extension extendee
-	0,   // [0:51] is the sub-list for field type_name
+	12,  // 1: daemonrpc.GetInfoResponse.server_info:type_name -> daemonrpc.ServerInfo
+	2,   // 2: daemonrpc.VTXOExpiryInfo.status:type_name -> daemonrpc.VTXOExpiryStatus
+	1,   // 3: daemonrpc.VTXO.status:type_name -> daemonrpc.VTXOStatus
+	21,  // 4: daemonrpc.VTXO.expiry_info:type_name -> daemonrpc.VTXOExpiryInfo
+	1,   // 5: daemonrpc.ListVTXOsRequest.status_filter:type_name -> daemonrpc.VTXOStatus
+	22,  // 6: daemonrpc.ListVTXOsResponse.vtxos:type_name -> daemonrpc.VTXO
+	1,   // 7: daemonrpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> daemonrpc.VTXOStatus
+	22,  // 8: daemonrpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> daemonrpc.VTXO
+	1,   // 9: daemonrpc.GetVTXOExpiryInfoRequest.status_filter:type_name -> daemonrpc.VTXOStatus
+	21,  // 10: daemonrpc.GetVTXOExpiryInfoResponse.expiry_info:type_name -> daemonrpc.VTXOExpiryInfo
+	22,  // 11: daemonrpc.GetVTXOExpiryInfoResponse.vtxo:type_name -> daemonrpc.VTXO
+	43,  // 12: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
+	43,  // 13: daemonrpc.SendOORRequest.recipients:type_name -> daemonrpc.Output
+	47,  // 14: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
+	48,  // 15: daemonrpc.CustomOORInput.external_signatures:type_name -> daemonrpc.TaprootScriptSignature
+	43,  // 16: daemonrpc.PrepareOORRequest.recipient:type_name -> daemonrpc.Output
+	47,  // 17: daemonrpc.PrepareOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
+	51,  // 18: daemonrpc.PrepareOORResponse.custom_inputs:type_name -> daemonrpc.PreparedOORCustomInput
+	47,  // 19: daemonrpc.SignOORCustomInputRequest.custom_input:type_name -> daemonrpc.CustomOORInput
+	48,  // 20: daemonrpc.SignOORCustomInputResponse.signature:type_name -> daemonrpc.TaprootScriptSignature
+	55,  // 21: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	55,  // 22: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	58,  // 23: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
+	110, // 24: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	58,  // 25: daemonrpc.SendOnChainRequest.destination:type_name -> daemonrpc.LeaveDestination
+	68,  // 26: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
+	71,  // 27: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
+	72,  // 28: daemonrpc.ListBoardingSweepsResponse.sweeps:type_name -> daemonrpc.BoardingSweep
+	3,   // 29: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
+	74,  // 30: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
+	3,   // 31: daemonrpc.ListRoundsRequest.state_filter:type_name -> daemonrpc.RoundState
+	75,  // 32: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
+	75,  // 33: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
+	75,  // 34: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
+	4,   // 35: daemonrpc.OORSessionInfo.direction:type_name -> daemonrpc.OORSessionDirection
+	5,   // 36: daemonrpc.OORSessionInfo.status:type_name -> daemonrpc.OORSessionStatus
+	4,   // 37: daemonrpc.ListOORSessionsRequest.direction_filter:type_name -> daemonrpc.OORSessionDirection
+	5,   // 38: daemonrpc.ListOORSessionsRequest.status_filter:type_name -> daemonrpc.OORSessionStatus
+	82,  // 39: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
+	82,  // 40: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
+	90,  // 41: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
+	93,  // 42: daemonrpc.ListTransactionsResponse.transactions:type_name -> daemonrpc.TransactionHistoryEntry
+	6,   // 43: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
+	7,   // 44: daemonrpc.ArmVHTLCRecoveryRequest.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
+	8,   // 45: daemonrpc.ArmVHTLCRecoveryRequest.action:type_name -> daemonrpc.VHTLCRecoveryAction
+	109, // 46: daemonrpc.ArmVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	109, // 47: daemonrpc.EscalateVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	109, // 48: daemonrpc.CancelVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	109, // 49: daemonrpc.GetVHTLCRecoveryStatusResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	109, // 50: daemonrpc.ListVHTLCRecoveriesResponse.statuses:type_name -> daemonrpc.VHTLCRecoveryStatus
+	7,   // 51: daemonrpc.VHTLCRecoveryStatus.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
+	8,   // 52: daemonrpc.VHTLCRecoveryStatus.action:type_name -> daemonrpc.VHTLCRecoveryAction
+	9,   // 53: daemonrpc.VHTLCRecoveryStatus.state:type_name -> daemonrpc.VHTLCRecoveryState
+	6,   // 54: daemonrpc.VHTLCRecoveryStatus.unroll_status:type_name -> daemonrpc.UnrollJobStatus
+	58,  // 55: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
+	10,  // 56: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
+	13,  // 57: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
+	15,  // 58: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
+	17,  // 59: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
+	19,  // 60: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
+	23,  // 61: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
+	25,  // 62: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
+	27,  // 63: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
+	29,  // 64: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
+	31,  // 65: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
+	33,  // 66: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
+	35,  // 67: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
+	37,  // 68: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
+	39,  // 69: daemonrpc.DaemonService.GetVTXOExpiryInfo:input_type -> daemonrpc.GetVTXOExpiryInfoRequest
+	41,  // 70: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
+	44,  // 71: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	46,  // 72: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	50,  // 73: daemonrpc.DaemonService.PrepareOOR:input_type -> daemonrpc.PrepareOORRequest
+	53,  // 74: daemonrpc.DaemonService.SignOORCustomInput:input_type -> daemonrpc.SignOORCustomInputRequest
+	56,  // 75: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	59,  // 76: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
+	61,  // 77: daemonrpc.DaemonService.SendOnChain:input_type -> daemonrpc.SendOnChainRequest
+	63,  // 78: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
+	65,  // 79: daemonrpc.DaemonService.JoinNextRound:input_type -> daemonrpc.JoinNextRoundRequest
+	67,  // 80: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
+	70,  // 81: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
+	76,  // 82: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
+	77,  // 83: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
+	80,  // 84: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
+	83,  // 85: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
+	85,  // 86: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
+	87,  // 87: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
+	89,  // 88: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
+	92,  // 89: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
+	95,  // 90: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
+	97,  // 91: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
+	99,  // 92: daemonrpc.DaemonService.ArmVHTLCRecovery:input_type -> daemonrpc.ArmVHTLCRecoveryRequest
+	101, // 93: daemonrpc.DaemonService.EscalateVHTLCRecovery:input_type -> daemonrpc.EscalateVHTLCRecoveryRequest
+	103, // 94: daemonrpc.DaemonService.CancelVHTLCRecovery:input_type -> daemonrpc.CancelVHTLCRecoveryRequest
+	105, // 95: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> daemonrpc.GetVHTLCRecoveryStatusRequest
+	107, // 96: daemonrpc.DaemonService.ListVHTLCRecoveries:input_type -> daemonrpc.ListVHTLCRecoveriesRequest
+	11,  // 97: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	14,  // 98: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	16,  // 99: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	18,  // 100: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	20,  // 101: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	24,  // 102: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	26,  // 103: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	28,  // 104: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
+	30,  // 105: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
+	32,  // 106: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
+	34,  // 107: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
+	36,  // 108: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
+	38,  // 109: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
+	40,  // 110: daemonrpc.DaemonService.GetVTXOExpiryInfo:output_type -> daemonrpc.GetVTXOExpiryInfoResponse
+	42,  // 111: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
+	45,  // 112: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	49,  // 113: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	52,  // 114: daemonrpc.DaemonService.PrepareOOR:output_type -> daemonrpc.PrepareOORResponse
+	54,  // 115: daemonrpc.DaemonService.SignOORCustomInput:output_type -> daemonrpc.SignOORCustomInputResponse
+	57,  // 116: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	60,  // 117: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
+	62,  // 118: daemonrpc.DaemonService.SendOnChain:output_type -> daemonrpc.SendOnChainResponse
+	64,  // 119: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	66,  // 120: daemonrpc.DaemonService.JoinNextRound:output_type -> daemonrpc.JoinNextRoundResponse
+	69,  // 121: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
+	73,  // 122: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
+	79,  // 123: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	78,  // 124: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
+	81,  // 125: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	84,  // 126: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
+	86,  // 127: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
+	88,  // 128: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
+	91,  // 129: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
+	94,  // 130: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
+	96,  // 131: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
+	98,  // 132: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
+	100, // 133: daemonrpc.DaemonService.ArmVHTLCRecovery:output_type -> daemonrpc.ArmVHTLCRecoveryResponse
+	102, // 134: daemonrpc.DaemonService.EscalateVHTLCRecovery:output_type -> daemonrpc.EscalateVHTLCRecoveryResponse
+	104, // 135: daemonrpc.DaemonService.CancelVHTLCRecovery:output_type -> daemonrpc.CancelVHTLCRecoveryResponse
+	106, // 136: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> daemonrpc.GetVHTLCRecoveryStatusResponse
+	108, // 137: daemonrpc.DaemonService.ListVHTLCRecoveries:output_type -> daemonrpc.ListVHTLCRecoveriesResponse
+	97,  // [97:138] is the sub-list for method output_type
+	56,  // [56:97] is the sub-list for method input_type
+	56,  // [56:56] is the sub-list for extension type_name
+	56,  // [56:56] is the sub-list for extension extendee
+	0,   // [0:56] is the sub-list for field type_name
 }
 
 func init() { file_daemon_proto_init() }
@@ -8812,24 +9230,28 @@ func file_daemon_proto_init() {
 	if File_daemon_proto != nil {
 		return
 	}
-	file_daemon_proto_msgTypes[30].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[29].OneofWrappers = []any{
+		(*GetVTXOExpiryInfoRequest_Outpoint)(nil),
+		(*GetVTXOExpiryInfoRequest_PkScript)(nil),
+	}
+	file_daemon_proto_msgTypes[33].OneofWrappers = []any{
 		(*Output_Address)(nil),
 		(*Output_Pubkey)(nil),
 		(*Output_PolicyTemplate)(nil),
 	}
-	file_daemon_proto_msgTypes[43].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[46].OneofWrappers = []any{
 		(*RefreshVTXOsRequest_Outpoints)(nil),
 		(*RefreshVTXOsRequest_All)(nil),
 	}
-	file_daemon_proto_msgTypes[45].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[48].OneofWrappers = []any{
 		(*LeaveDestination_Address)(nil),
 		(*LeaveDestination_PkScript)(nil),
 	}
-	file_daemon_proto_msgTypes[46].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[49].OneofWrappers = []any{
 		(*LeaveVTXOsRequest_Outpoints)(nil),
 		(*LeaveVTXOsRequest_All)(nil),
 	}
-	file_daemon_proto_msgTypes[48].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[51].OneofWrappers = []any{
 		(*SendOnChainRequest_AmountSat)(nil),
 		(*SendOnChainRequest_SweepAll)(nil),
 	}
@@ -8838,8 +9260,8 @@ func file_daemon_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
-			NumEnums:      9,
-			NumMessages:   98,
+			NumEnums:      10,
+			NumMessages:   101,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.pb.gw.go
+++ b/daemonrpc/daemon.pb.gw.go
@@ -386,6 +386,33 @@ func local_request_DaemonService_GetIndexedVTXOByPkScript_0(ctx context.Context,
 	return msg, metadata, err
 }
 
+func request_DaemonService_GetVTXOExpiryInfo_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetVTXOExpiryInfoRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.GetVTXOExpiryInfo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_DaemonService_GetVTXOExpiryInfo_0(ctx context.Context, marshaler runtime.Marshaler, server DaemonServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetVTXOExpiryInfoRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetVTXOExpiryInfo(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_DaemonService_GetIndexedOORSessionByTxid_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq GetIndexedOORSessionByTxidRequest
@@ -1377,6 +1404,26 @@ func RegisterDaemonServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_GetIndexedVTXOByPkScript_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_GetVTXOExpiryInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/daemonrpc.DaemonService/GetVTXOExpiryInfo", runtime.WithHTTPPathPattern("/v1/daemon/get-vtxo-expiry-info"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_DaemonService_GetVTXOExpiryInfo_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_GetVTXOExpiryInfo_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_DaemonService_GetIndexedOORSessionByTxid_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2165,6 +2212,23 @@ func RegisterDaemonServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_GetIndexedVTXOByPkScript_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_GetVTXOExpiryInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/daemonrpc.DaemonService/GetVTXOExpiryInfo", runtime.WithHTTPPathPattern("/v1/daemon/get-vtxo-expiry-info"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_DaemonService_GetVTXOExpiryInfo_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_GetVTXOExpiryInfo_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_DaemonService_GetIndexedOORSessionByTxid_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2641,6 +2705,7 @@ var (
 	pattern_DaemonService_SignReceiveAuthMessageCompact_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "sign-receive-auth-message-compact"}, ""))
 	pattern_DaemonService_ReceiveAuthECDH_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "receive-auth-ecdh"}, ""))
 	pattern_DaemonService_GetIndexedVTXOByPkScript_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "get-indexed-vtxo-by-pk-script"}, ""))
+	pattern_DaemonService_GetVTXOExpiryInfo_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "get-vtxo-expiry-info"}, ""))
 	pattern_DaemonService_GetIndexedOORSessionByTxid_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "get-indexed-oor-session-by-txid"}, ""))
 	pattern_DaemonService_SendVTXO_0                      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "send-vtxo"}, ""))
 	pattern_DaemonService_SendOOR_0                       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "send-oor"}, ""))
@@ -2684,6 +2749,7 @@ var (
 	forward_DaemonService_SignReceiveAuthMessageCompact_0 = runtime.ForwardResponseMessage
 	forward_DaemonService_ReceiveAuthECDH_0               = runtime.ForwardResponseMessage
 	forward_DaemonService_GetIndexedVTXOByPkScript_0      = runtime.ForwardResponseMessage
+	forward_DaemonService_GetVTXOExpiryInfo_0             = runtime.ForwardResponseMessage
 	forward_DaemonService_GetIndexedOORSessionByTxid_0    = runtime.ForwardResponseMessage
 	forward_DaemonService_SendVTXO_0                      = runtime.ForwardResponseMessage
 	forward_DaemonService_SendOOR_0                       = runtime.ForwardResponseMessage

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -70,6 +70,11 @@ service DaemonService {
     rpc GetIndexedVTXOByPkScript (GetIndexedVTXOByPkScriptRequest)
         returns (GetIndexedVTXOByPkScriptResponse);
 
+    // GetVTXOExpiryInfo returns the wallet/VTXO layer's expiry posture for a
+    // VTXO identified by outpoint or pkScript.
+    rpc GetVTXOExpiryInfo (GetVTXOExpiryInfoRequest)
+        returns (GetVTXOExpiryInfoResponse);
+
     // GetIndexedOORSessionByTxid queries the authoritative indexer for one
     // OOR session using a spent script proof and deterministic session txid.
     rpc GetIndexedOORSessionByTxid (GetIndexedOORSessionByTxidRequest)
@@ -528,6 +533,66 @@ enum VTXOStatus {
     VTXO_STATUS_PENDING_ROUND = 9;
 }
 
+// VTXOExpiryStatus describes how close a VTXO is to batch expiry using the
+// daemon's wallet/VTXO expiry policy.
+enum VTXOExpiryStatus {
+    // VTXO_EXPIRY_STATUS_UNKNOWN is returned when the daemon cannot
+    // classify the VTXO, for example because timing metadata is missing.
+    VTXO_EXPIRY_STATUS_UNKNOWN = 0;
+
+    // VTXO_EXPIRY_STATUS_SAFE indicates the VTXO is outside the refresh
+    // threshold.
+    VTXO_EXPIRY_STATUS_SAFE = 1;
+
+    // VTXO_EXPIRY_STATUS_NEEDS_REFRESH indicates the VTXO has entered the
+    // cooperative refresh window but is not yet critical.
+    VTXO_EXPIRY_STATUS_NEEDS_REFRESH = 2;
+
+    // VTXO_EXPIRY_STATUS_CRITICAL indicates the VTXO should stop waiting for
+    // cooperative refresh and move to unilateral exit/recovery handling.
+    VTXO_EXPIRY_STATUS_CRITICAL = 3;
+
+    // VTXO_EXPIRY_STATUS_EXPIRED indicates the VTXO's batch expiry has
+    // passed.
+    VTXO_EXPIRY_STATUS_EXPIRED = 4;
+}
+
+// VTXOExpiryInfo reports the thresholds and current classification the
+// wallet/VTXO layer uses for expiry monitoring.
+message VTXOExpiryInfo {
+    // status is the VTXO's current expiry posture.
+    VTXOExpiryStatus status = 1;
+
+    // current_height is the chain height used for this classification.
+    int32 current_height = 2;
+
+    // batch_expiry is the VTXO batch expiry height.
+    int32 batch_expiry = 3;
+
+    // blocks_remaining is batch_expiry - current_height.
+    int32 blocks_remaining = 4;
+
+    // refresh_threshold_blocks is the number of blocks before batch expiry at
+    // which cooperative refresh should begin.
+    int32 refresh_threshold_blocks = 5;
+
+    // critical_threshold_blocks is the number of blocks before batch expiry at
+    // which recovery/unilateral-exit handling should begin.
+    int32 critical_threshold_blocks = 6;
+
+    // relative_expiry is the CSV delay used in the threshold calculation.
+    uint32 relative_expiry = 7;
+
+    // max_tree_depth is the worst-case VTXO tree depth used in the threshold
+    // calculation.
+    uint32 max_tree_depth = 8;
+
+    // chain_depth is the number of OOR checkpoint hops between this VTXO and
+    // the most recent on-chain commitment. It is included for diagnostics but
+    // is distinct from max_tree_depth.
+    uint32 chain_depth = 9;
+}
+
 message VTXO {
     // outpoint is the VTXO's outpoint in "txid:index" format.
     string outpoint = 1;
@@ -572,6 +637,10 @@ message VTXO {
     // spent_by_txid is the hex-encoded Ark/OOR transaction txid that spent
     // this VTXO through an out-of-round package, when known.
     string spent_by_txid = 12;
+
+    // expiry_info reports the wallet/VTXO layer's current expiry posture for
+    // this VTXO when the daemon has enough timing context to classify it.
+    VTXOExpiryInfo expiry_info = 13;
 }
 
 message ListVTXOsRequest {
@@ -700,6 +769,42 @@ message GetIndexedVTXOByPkScriptRequest {
 message GetIndexedVTXOByPkScriptResponse {
     // vtxo is the first matching VTXO, when found.
     VTXO vtxo = 1;
+}
+
+// GetVTXOExpiryInfoRequest identifies one VTXO whose expiry posture should be
+// classified by the daemon's wallet/VTXO expiry policy.
+message GetVTXOExpiryInfoRequest {
+    // target selects whether the daemon should resolve the VTXO from the local
+    // wallet store by outpoint or from the authoritative indexer by pkScript.
+    oneof target {
+        // outpoint identifies a locally known VTXO in "txid:index" format.
+        string outpoint = 1;
+
+        // pk_script queries the authoritative indexer for a matching VTXO.
+        bytes pk_script = 2;
+    }
+
+    // status_filter restricts pk_script lookups to matching lifecycle states.
+    // It is ignored for outpoint lookups.
+    repeated VTXOStatus status_filter = 3;
+
+    // current_height overrides the chain height used for classification. If
+    // zero, the daemon uses its current best chain height.
+    int32 current_height = 4;
+}
+
+// GetVTXOExpiryInfoResponse returns the VTXO matched by the request together
+// with the expiry posture calculated from the daemon's authoritative metadata.
+message GetVTXOExpiryInfoResponse {
+    // found reports whether the daemon found a VTXO for the request target.
+    bool found = 1;
+
+    // expiry_info is present when found is true and the VTXO had enough timing
+    // metadata to classify.
+    VTXOExpiryInfo expiry_info = 2;
+
+    // vtxo is the VTXO used for classification when found.
+    VTXO vtxo = 3;
 }
 
 message GetIndexedOORSessionByTxidRequest {

--- a/daemonrpc/daemon.yaml
+++ b/daemonrpc/daemon.yaml
@@ -42,6 +42,9 @@ http:
     - selector: daemonrpc.DaemonService.GetIndexedVTXOByPkScript
       post: /v1/daemon/get-indexed-vtxo-by-pk-script
       body: "*"
+    - selector: daemonrpc.DaemonService.GetVTXOExpiryInfo
+      post: /v1/daemon/get-vtxo-expiry-info
+      body: "*"
     - selector: daemonrpc.DaemonService.GetIndexedOORSessionByTxid
       post: /v1/daemon/get-indexed-oor-session-by-txid
       body: "*"

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -32,6 +32,7 @@ const (
 	DaemonService_SignReceiveAuthMessageCompact_FullMethodName = "/daemonrpc.DaemonService/SignReceiveAuthMessageCompact"
 	DaemonService_ReceiveAuthECDH_FullMethodName               = "/daemonrpc.DaemonService/ReceiveAuthECDH"
 	DaemonService_GetIndexedVTXOByPkScript_FullMethodName      = "/daemonrpc.DaemonService/GetIndexedVTXOByPkScript"
+	DaemonService_GetVTXOExpiryInfo_FullMethodName             = "/daemonrpc.DaemonService/GetVTXOExpiryInfo"
 	DaemonService_GetIndexedOORSessionByTxid_FullMethodName    = "/daemonrpc.DaemonService/GetIndexedOORSessionByTxid"
 	DaemonService_SendVTXO_FullMethodName                      = "/daemonrpc.DaemonService/SendVTXO"
 	DaemonService_SendOOR_FullMethodName                       = "/daemonrpc.DaemonService/SendOOR"
@@ -113,6 +114,9 @@ type DaemonServiceClient interface {
 	// GetIndexedVTXOByPkScript queries the authoritative indexer for the
 	// first VTXO matching the given script and status filter.
 	GetIndexedVTXOByPkScript(ctx context.Context, in *GetIndexedVTXOByPkScriptRequest, opts ...grpc.CallOption) (*GetIndexedVTXOByPkScriptResponse, error)
+	// GetVTXOExpiryInfo returns the wallet/VTXO layer's expiry posture for a
+	// VTXO identified by outpoint or pkScript.
+	GetVTXOExpiryInfo(ctx context.Context, in *GetVTXOExpiryInfoRequest, opts ...grpc.CallOption) (*GetVTXOExpiryInfoResponse, error)
 	// GetIndexedOORSessionByTxid queries the authoritative indexer for one
 	// OOR session using a spent script proof and deterministic session txid.
 	GetIndexedOORSessionByTxid(ctx context.Context, in *GetIndexedOORSessionByTxidRequest, opts ...grpc.CallOption) (*GetIndexedOORSessionByTxidResponse, error)
@@ -352,6 +356,16 @@ func (c *daemonServiceClient) GetIndexedVTXOByPkScript(ctx context.Context, in *
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetIndexedVTXOByPkScriptResponse)
 	err := c.cc.Invoke(ctx, DaemonService_GetIndexedVTXOByPkScript_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) GetVTXOExpiryInfo(ctx context.Context, in *GetVTXOExpiryInfoRequest, opts ...grpc.CallOption) (*GetVTXOExpiryInfoResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetVTXOExpiryInfoResponse)
+	err := c.cc.Invoke(ctx, DaemonService_GetVTXOExpiryInfo_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -689,6 +703,9 @@ type DaemonServiceServer interface {
 	// GetIndexedVTXOByPkScript queries the authoritative indexer for the
 	// first VTXO matching the given script and status filter.
 	GetIndexedVTXOByPkScript(context.Context, *GetIndexedVTXOByPkScriptRequest) (*GetIndexedVTXOByPkScriptResponse, error)
+	// GetVTXOExpiryInfo returns the wallet/VTXO layer's expiry posture for a
+	// VTXO identified by outpoint or pkScript.
+	GetVTXOExpiryInfo(context.Context, *GetVTXOExpiryInfoRequest) (*GetVTXOExpiryInfoResponse, error)
 	// GetIndexedOORSessionByTxid queries the authoritative indexer for one
 	// OOR session using a spent script proof and deterministic session txid.
 	GetIndexedOORSessionByTxid(context.Context, *GetIndexedOORSessionByTxidRequest) (*GetIndexedOORSessionByTxidResponse, error)
@@ -842,6 +859,9 @@ func (UnimplementedDaemonServiceServer) ReceiveAuthECDH(context.Context, *Receiv
 }
 func (UnimplementedDaemonServiceServer) GetIndexedVTXOByPkScript(context.Context, *GetIndexedVTXOByPkScriptRequest) (*GetIndexedVTXOByPkScriptResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetIndexedVTXOByPkScript not implemented")
+}
+func (UnimplementedDaemonServiceServer) GetVTXOExpiryInfo(context.Context, *GetVTXOExpiryInfoRequest) (*GetVTXOExpiryInfoResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVTXOExpiryInfo not implemented")
 }
 func (UnimplementedDaemonServiceServer) GetIndexedOORSessionByTxid(context.Context, *GetIndexedOORSessionByTxidRequest) (*GetIndexedOORSessionByTxidResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetIndexedOORSessionByTxid not implemented")
@@ -1175,6 +1195,24 @@ func _DaemonService_GetIndexedVTXOByPkScript_Handler(srv interface{}, ctx contex
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(DaemonServiceServer).GetIndexedVTXOByPkScript(ctx, req.(*GetIndexedVTXOByPkScriptRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_GetVTXOExpiryInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetVTXOExpiryInfoRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).GetVTXOExpiryInfo(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_GetVTXOExpiryInfo_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).GetVTXOExpiryInfo(ctx, req.(*GetVTXOExpiryInfoRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1716,6 +1754,10 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetIndexedVTXOByPkScript",
 			Handler:    _DaemonService_GetIndexedVTXOByPkScript_Handler,
+		},
+		{
+			MethodName: "GetVTXOExpiryInfo",
+			Handler:    _DaemonService_GetVTXOExpiryInfo_Handler,
 		},
 		{
 			MethodName: "GetIndexedOORSessionByTxid",

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -50,6 +50,8 @@ type DaemonServiceMailboxServer interface {
 	ReceiveAuthECDH(ctx context.Context, req *ReceiveAuthECDHRequest) (*ReceiveAuthECDHResponse, error)
 	// GetIndexedVTXOByPkScript handles GetIndexedVTXOByPkScript.
 	GetIndexedVTXOByPkScript(ctx context.Context, req *GetIndexedVTXOByPkScriptRequest) (*GetIndexedVTXOByPkScriptResponse, error)
+	// GetVTXOExpiryInfo handles GetVTXOExpiryInfo.
+	GetVTXOExpiryInfo(ctx context.Context, req *GetVTXOExpiryInfoRequest) (*GetVTXOExpiryInfoResponse, error)
 	// GetIndexedOORSessionByTxid handles GetIndexedOORSessionByTxid.
 	GetIndexedOORSessionByTxid(ctx context.Context, req *GetIndexedOORSessionByTxidRequest) (*GetIndexedOORSessionByTxidResponse, error)
 	// SendVTXO handles SendVTXO.
@@ -237,6 +239,16 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.GetIndexedVTXOByPkScript(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "GetVTXOExpiryInfo", func() proto.Message {
+		return &GetVTXOExpiryInfoRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*GetVTXOExpiryInfoRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.GetVTXOExpiryInfo(ctx, req)
 	})
 	r.Handle("daemonrpc.DaemonService", "GetIndexedOORSessionByTxid", func() proto.Message {
 		return &GetIndexedOORSessionByTxidRequest{}
@@ -802,6 +814,29 @@ func (c *DaemonServiceMailboxClient) GetIndexedVTXOByPkScript(ctx context.Contex
 	}
 
 	resp := new(GetIndexedVTXOByPkScriptResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// GetVTXOExpiryInfo calls the GetVTXOExpiryInfo RPC.
+func (c *DaemonServiceMailboxClient) GetVTXOExpiryInfo(ctx context.Context, req *GetVTXOExpiryInfoRequest, opts ...rpc.RPCOptions) (*GetVTXOExpiryInfoResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "GetVTXOExpiryInfo",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(GetVTXOExpiryInfoResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/daemonrpc/daemon_proto_test.go
+++ b/daemonrpc/daemon_proto_test.go
@@ -13,6 +13,7 @@ const (
 	testRecoveryAction    = VHTLCRecoveryAction_VHTLC_RECOVERY_ACTION_CLAIM
 	testRecoveryState     = VHTLCRecoveryState_VHTLC_RECOVERY_STATE_UNROLL_STARTED
 	testUnrollStatus      = UnrollJobStatus_UNROLL_JOB_STATUS_MATERIALIZING
+	testExpiryStatus      = VTXOExpiryStatus_VTXO_EXPIRY_STATUS_NEEDS_REFRESH
 )
 
 // TestSendVTXOResponseProtoRoundTrip guards against stale generated
@@ -36,6 +37,62 @@ func TestSendVTXOResponseProtoRoundTrip(t *testing.T) {
 	require.Equal(t, original.TotalAmountSat, decoded.TotalAmountSat)
 	require.Equal(t, original.ChangeAmountSat, decoded.ChangeAmountSat)
 	require.Equal(t, original.SelectedCount, decoded.SelectedCount)
+}
+
+// TestVTXOExpiryInfoProtoRoundTrip guards the expiry posture fields that swap
+// services use to decide whether a VTXO is safe to build a swap around.
+func TestVTXOExpiryInfoProtoRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := &GetVTXOExpiryInfoResponse{
+		Found: true,
+		ExpiryInfo: &VTXOExpiryInfo{
+			Status:                  testExpiryStatus,
+			CurrentHeight:           784,
+			BatchExpiry:             1000,
+			BlocksRemaining:         216,
+			RefreshThresholdBlocks:  234,
+			CriticalThresholdBlocks: 162,
+			RelativeExpiry:          144,
+			MaxTreeDepth:            3,
+			ChainDepth:              2,
+		},
+		Vtxo: &VTXO{
+			Outpoint:       "00:1",
+			AmountSat:      42_000,
+			Status:         VTXOStatus_VTXO_STATUS_LIVE,
+			BatchExpiry:    1000,
+			RelativeExpiry: 144,
+			ExpiryInfo: &VTXOExpiryInfo{
+				Status:          testExpiryStatus,
+				BlocksRemaining: 216,
+			},
+		},
+	}
+
+	payload, err := proto.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded GetVTXOExpiryInfoResponse
+	require.NoError(t, proto.Unmarshal(payload, &decoded))
+	require.True(t, decoded.GetFound())
+	require.Equal(t, testExpiryStatus, decoded.GetExpiryInfo().GetStatus())
+	require.Equal(t, int32(784), decoded.GetExpiryInfo().GetCurrentHeight())
+	require.Equal(t, int32(1000), decoded.GetExpiryInfo().GetBatchExpiry())
+	require.Equal(t, int32(216), decoded.GetExpiryInfo().GetBlocksRemaining())
+	require.Equal(
+		t, int32(234),
+		decoded.GetExpiryInfo().GetRefreshThresholdBlocks(),
+	)
+	require.Equal(
+		t, int32(162),
+		decoded.GetExpiryInfo().GetCriticalThresholdBlocks(),
+	)
+	require.Equal(t, uint32(144), decoded.GetExpiryInfo().GetRelativeExpiry())
+	require.Equal(t, uint32(3), decoded.GetExpiryInfo().GetMaxTreeDepth())
+	require.Equal(t, uint32(2), decoded.GetExpiryInfo().GetChainDepth())
+	require.Equal(t, "00:1", decoded.GetVtxo().GetOutpoint())
+	require.Equal(t, testExpiryStatus, decoded.GetVtxo().GetExpiryInfo().GetStatus())
 }
 
 // TestVHTLCRecoveryStatusProtoRoundTrip guards the recovery control-plane

--- a/darepod/rpc_swap_lookup.go
+++ b/darepod/rpc_swap_lookup.go
@@ -63,7 +63,13 @@ func (r *RPCServer) GetIndexedVTXOByPkScript(ctx context.Context,
 		return &daemonrpc.GetIndexedVTXOByPkScriptResponse{}, nil
 	}
 
-	vtxo, err := indexedVTXOToProto(vtxos[0])
+	currentHeight, heightErr := r.currentBlockHeight(ctx)
+	if heightErr != nil {
+		r.server.log.WarnS(ctx, "Unable to fetch block height for "+
+			"indexed VTXO expiry info", heightErr)
+	}
+
+	vtxo, err := indexedVTXOToProto(vtxos[0], currentHeight)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert indexed "+
 			"vtxo: %v", err)
@@ -163,7 +169,8 @@ func daemonStatusToIndexerStatus(status daemonrpc.VTXOStatus) (
 
 // indexedVTXOToProto converts an authoritative indexer VTXO into the daemon's
 // simplified VTXO response shape.
-func indexedVTXOToProto(vtxo *arkrpc.VTXO) (*daemonrpc.VTXO, error) {
+func indexedVTXOToProto(vtxo *arkrpc.VTXO,
+	currentHeight int32) (*daemonrpc.VTXO, error) {
 	if vtxo == nil {
 		return nil, fmt.Errorf("vtxo must be provided")
 	}
@@ -220,6 +227,7 @@ func indexedVTXOToProto(vtxo *arkrpc.VTXO) (*daemonrpc.VTXO, error) {
 			vtxo.GetOorFinalCheckpointPsbts(),
 		),
 		SpentByTxid: spentByTxid,
+		ExpiryInfo:  expiryInfoFromIndexedVTXO(vtxo, currentHeight),
 	}, nil
 }
 

--- a/darepod/rpc_vtxo_expiry.go
+++ b/darepod/rpc_vtxo_expiry.go
@@ -1,0 +1,298 @@
+package darepod
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/indexer"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightninglabs/lndclient"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// GetVTXOExpiryInfo returns the daemon's authoritative expiry posture for a
+// VTXO identified either by local outpoint or indexed pkScript.
+func (r *RPCServer) GetVTXOExpiryInfo(ctx context.Context,
+	req *daemonrpc.GetVTXOExpiryInfoRequest) (
+	*daemonrpc.GetVTXOExpiryInfoResponse, error) {
+
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument,
+			"request is required")
+	}
+
+	currentHeight := req.GetCurrentHeight()
+	if currentHeight == 0 {
+		height, err := r.currentBlockHeight(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		currentHeight = height
+	}
+
+	switch target := req.GetTarget().(type) {
+	case *daemonrpc.GetVTXOExpiryInfoRequest_Outpoint:
+		return r.getLocalVTXOExpiryInfo(
+			ctx, target.Outpoint, currentHeight,
+		)
+
+	case *daemonrpc.GetVTXOExpiryInfoRequest_PkScript:
+		return r.getIndexedVTXOExpiryInfo(
+			ctx, target.PkScript, req.GetStatusFilter(),
+			currentHeight,
+		)
+
+	default:
+		return nil, status.Error(codes.InvalidArgument,
+			"outpoint or pk_script is required")
+	}
+}
+
+// getLocalVTXOExpiryInfo resolves a locally persisted VTXO by outpoint and
+// classifies it with the descriptor's full ancestry metadata.
+func (r *RPCServer) getLocalVTXOExpiryInfo(ctx context.Context,
+	outpoint string, currentHeight int32) (
+	*daemonrpc.GetVTXOExpiryInfoResponse, error) {
+
+	if outpoint == "" {
+		return nil, status.Error(codes.InvalidArgument,
+			"missing outpoint")
+	}
+	if r.server.vtxoStore == nil {
+		return nil, status.Error(codes.Internal,
+			"vtxo store not initialized")
+	}
+
+	op, err := parseOutpointString(outpoint)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"invalid outpoint: %v", err)
+	}
+
+	desc, err := r.server.vtxoStore.GetVTXO(ctx, op)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return &daemonrpc.GetVTXOExpiryInfoResponse{}, nil
+		}
+
+		return nil, status.Errorf(codes.Internal,
+			"get vtxo: %v", err)
+	}
+
+	protoVTXO := descriptorToProto(desc)
+	protoVTXO.ExpiryInfo = expiryInfoFromDescriptor(
+		desc, currentHeight,
+	)
+
+	return &daemonrpc.GetVTXOExpiryInfoResponse{
+		Found:      true,
+		ExpiryInfo: protoVTXO.GetExpiryInfo(),
+		Vtxo:       protoVTXO,
+	}, nil
+}
+
+// getIndexedVTXOExpiryInfo resolves one indexed VTXO by pkScript and
+// classifies it with the metadata returned by the authoritative indexer.
+func (r *RPCServer) getIndexedVTXOExpiryInfo(ctx context.Context,
+	pkScript []byte, filters []daemonrpc.VTXOStatus, currentHeight int32) (
+	*daemonrpc.GetVTXOExpiryInfoResponse, error) {
+
+	if len(pkScript) == 0 {
+		return nil, status.Error(codes.InvalidArgument,
+			"missing pk_script")
+	}
+	if r.server.indexer == nil {
+		return nil, status.Error(codes.Internal,
+			"indexer client not initialized")
+	}
+
+	statusFilter := make([]arkrpc.VTXOStatus, 0, len(filters))
+	for i := range filters {
+		st, err := daemonStatusToIndexerStatus(filters[i])
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"invalid status filter: %v", err)
+		}
+
+		statusFilter = append(statusFilter, st)
+	}
+
+	resp, err := r.server.indexer.ListVTXOsByScriptsTaproot(
+		ctx,
+		[]indexer.TaprootScriptScope{{
+			PkScript: append([]byte(nil), pkScript...),
+		}},
+		nil, 1, statusFilter,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"indexer query failed: %v", err)
+	}
+
+	vtxos := vtxo.FlattenListVTXOsByScriptsResponse(resp)
+	if len(vtxos) == 0 {
+		return &daemonrpc.GetVTXOExpiryInfoResponse{}, nil
+	}
+
+	protoVTXO, err := indexedVTXOToProto(vtxos[0], currentHeight)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"convert indexed vtxo: %v", err)
+	}
+
+	return &daemonrpc.GetVTXOExpiryInfoResponse{
+		Found:      true,
+		ExpiryInfo: protoVTXO.GetExpiryInfo(),
+		Vtxo:       protoVTXO,
+	}, nil
+}
+
+// currentBlockHeight returns the daemon's best chain height from the active
+// chain backend.
+func (r *RPCServer) currentBlockHeight(ctx context.Context) (int32, error) {
+	var (
+		height int32
+		err    error
+		found  bool
+	)
+
+	r.server.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
+		_, bestHeight, bestErr := lndSvc.ChainKit.GetBestBlock(ctx)
+		if bestErr != nil {
+			err = fmt.Errorf("fetch lnd best block: %w", bestErr)
+			return
+		}
+
+		height = int32(bestHeight)
+		found = true
+	})
+	if err != nil {
+		return 0, status.Errorf(codes.Unavailable,
+			"fetch block height: %v", err)
+	}
+	if found {
+		return height, nil
+	}
+
+	if r.server.chainBackend == nil {
+		return 0, status.Error(codes.Unavailable,
+			"chain backend not initialized")
+	}
+
+	height, _, err = r.server.chainBackend.BestBlock(ctx)
+	if err != nil {
+		return 0, status.Errorf(codes.Unavailable,
+			"fetch block height: %v", err)
+	}
+
+	return height, nil
+}
+
+// expiryInfoFromDescriptor classifies a locally stored VTXO descriptor at the
+// supplied chain height.
+func expiryInfoFromDescriptor(desc *vtxo.Descriptor,
+	currentHeight int32) *daemonrpc.VTXOExpiryInfo {
+
+	if desc == nil {
+		return nil
+	}
+
+	return expiryInfoFromTiming(
+		desc.BatchExpiry, desc.RelativeExpiry,
+		uint32(desc.MaxTreeDepth()), uint32(desc.ChainDepth),
+		currentHeight,
+	)
+}
+
+// expiryInfoFromIndexedVTXO classifies an indexer VTXO at the supplied chain
+// height using max tree depth across its ancestry paths.
+func expiryInfoFromIndexedVTXO(indexed *arkrpc.VTXO,
+	currentHeight int32) *daemonrpc.VTXOExpiryInfo {
+
+	if indexed == nil {
+		return nil
+	}
+
+	var maxTreeDepth uint32
+	for _, ancestry := range indexed.GetAncestryPaths() {
+		if ancestry.GetTreeDepth() > maxTreeDepth {
+			maxTreeDepth = ancestry.GetTreeDepth()
+		}
+	}
+
+	return expiryInfoFromTiming(
+		indexed.GetBatchExpiryHeight(), indexed.GetRelativeExpiry(),
+		maxTreeDepth, indexed.GetChainDepth(), currentHeight,
+	)
+}
+
+// expiryInfoFromTiming classifies one VTXO from the timing inputs used by the
+// wallet expiry policy.
+func expiryInfoFromTiming(batchExpiry int32, relativeExpiry, maxTreeDepth,
+	chainDepth uint32, currentHeight int32) *daemonrpc.VTXOExpiryInfo {
+
+	info := &daemonrpc.VTXOExpiryInfo{
+		CurrentHeight:  currentHeight,
+		BatchExpiry:    batchExpiry,
+		RelativeExpiry: relativeExpiry,
+		MaxTreeDepth:   maxTreeDepth,
+		ChainDepth:     chainDepth,
+		Status: daemonrpc.
+			VTXOExpiryStatus_VTXO_EXPIRY_STATUS_UNKNOWN,
+	}
+
+	if batchExpiry <= 0 || currentHeight <= 0 {
+		return info
+	}
+
+	desc := &vtxo.Descriptor{
+		BatchExpiry:    batchExpiry,
+		RelativeExpiry: relativeExpiry,
+		Ancestry: []vtxo.Ancestry{{
+			TreeDepth: maxTreeDepth,
+		}},
+	}
+	cfg := vtxo.DefaultExpiryConfig()
+
+	info.BlocksRemaining = vtxo.BlocksUntilExpiry(desc, currentHeight)
+	info.CriticalThresholdBlocks = cfg.CalculateCriticalThreshold(desc)
+	info.RefreshThresholdBlocks = cfg.CalculateRefreshThreshold(desc)
+	info.Status = expiryStatusToProto(
+		cfg.CheckExpiry(desc, currentHeight),
+	)
+
+	return info
+}
+
+// expiryStatusToProto maps the wallet expiry enum onto the public daemon RPC
+// enum.
+func expiryStatusToProto(status vtxo.ExpiryStatus) daemonrpc.VTXOExpiryStatus {
+
+	switch status {
+	case vtxo.ExpiryStatusSafe:
+		return daemonrpc.VTXOExpiryStatus_VTXO_EXPIRY_STATUS_SAFE
+
+	case vtxo.ExpiryStatusNeedsRefresh:
+		return daemonrpc.
+			VTXOExpiryStatus_VTXO_EXPIRY_STATUS_NEEDS_REFRESH
+
+	case vtxo.ExpiryStatusCritical:
+		return daemonrpc.VTXOExpiryStatus_VTXO_EXPIRY_STATUS_CRITICAL
+
+	case vtxo.ExpiryStatusExpired:
+		return daemonrpc.VTXOExpiryStatus_VTXO_EXPIRY_STATUS_EXPIRED
+
+	default:
+		return daemonrpc.VTXOExpiryStatus_VTXO_EXPIRY_STATUS_UNKNOWN
+	}
+}

--- a/darepod/rpc_vtxo_expiry_test.go
+++ b/darepod/rpc_vtxo_expiry_test.go
@@ -1,0 +1,135 @@
+package darepod
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/arkrpc"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/stretchr/testify/require"
+)
+
+// testExpiryStatusUnknown keeps expiry status assertions readable.
+const testExpiryStatusUnknown = daemonrpc.
+	VTXOExpiryStatus_VTXO_EXPIRY_STATUS_UNKNOWN
+
+// TestExpiryInfoFromDescriptorUsesDefaultThresholds verifies that local VTXO
+// descriptors are classified with the wallet's dynamic expiry thresholds.
+func TestExpiryInfoFromDescriptorUsesDefaultThresholds(t *testing.T) {
+	t.Parallel()
+
+	desc := &vtxo.Descriptor{
+		BatchExpiry:    1000,
+		RelativeExpiry: 144,
+		Ancestry: []vtxo.Ancestry{
+			{
+				TreeDepth: 1,
+			},
+			{
+				TreeDepth: 3,
+			},
+		},
+		ChainDepth: 2,
+	}
+
+	info := expiryInfoFromDescriptor(desc, 784)
+
+	require.Equal(
+		t,
+		daemonrpc.
+			VTXOExpiryStatus_VTXO_EXPIRY_STATUS_NEEDS_REFRESH,
+		info.GetStatus(),
+	)
+	require.Equal(t, int32(784), info.GetCurrentHeight())
+	require.Equal(t, int32(1000), info.GetBatchExpiry())
+	require.Equal(t, int32(216), info.GetBlocksRemaining())
+	require.Equal(t, int32(234), info.GetRefreshThresholdBlocks())
+	require.Equal(t, int32(162), info.GetCriticalThresholdBlocks())
+	require.Equal(t, uint32(144), info.GetRelativeExpiry())
+	require.Equal(t, uint32(3), info.GetMaxTreeDepth())
+	require.Equal(t, uint32(2), info.GetChainDepth())
+}
+
+// TestExpiryInfoFromTimingClassifiesPostures verifies the boundary conditions
+// returned to RPC callers.
+func TestExpiryInfoFromTimingClassifiesPostures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		currentHeight int32
+		wantStatus    daemonrpc.VTXOExpiryStatus
+	}{{
+		name:          "safe",
+		currentHeight: 700,
+		wantStatus: daemonrpc.
+			VTXOExpiryStatus_VTXO_EXPIRY_STATUS_SAFE,
+	}, {
+		name:          "needs refresh",
+		currentHeight: 784,
+		wantStatus: daemonrpc.
+			VTXOExpiryStatus_VTXO_EXPIRY_STATUS_NEEDS_REFRESH,
+	}, {
+		name:          "critical",
+		currentHeight: 850,
+		wantStatus: daemonrpc.
+			VTXOExpiryStatus_VTXO_EXPIRY_STATUS_CRITICAL,
+	}, {
+		name:          "expired",
+		currentHeight: 1000,
+		wantStatus: daemonrpc.
+			VTXOExpiryStatus_VTXO_EXPIRY_STATUS_EXPIRED,
+	}, {
+		name:          "unknown without height",
+		currentHeight: 0,
+		wantStatus:    testExpiryStatusUnknown,
+	}}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			info := expiryInfoFromTiming(
+				1000, 144, 3, 0, test.currentHeight,
+			)
+
+			require.Equal(t, test.wantStatus, info.GetStatus())
+		})
+	}
+}
+
+// TestExpiryInfoFromIndexedVTXOUsesMaxAncestryPathDepth verifies indexed
+// pkScript lookups classify against the deepest indexer ancestry path.
+func TestExpiryInfoFromIndexedVTXOUsesMaxAncestryPathDepth(t *testing.T) {
+	t.Parallel()
+
+	indexed := &arkrpc.VTXO{
+		BatchExpiryHeight: 1000,
+		RelativeExpiry:    24,
+		ChainDepth:        5,
+		AncestryPaths: []*arkrpc.AncestryPath{
+			{
+				TreeDepth: 2,
+			},
+			{
+				TreeDepth: 9,
+			},
+		},
+	}
+
+	info := expiryInfoFromIndexedVTXO(indexed, 850)
+
+	require.Equal(
+		t,
+		daemonrpc.
+			VTXOExpiryStatus_VTXO_EXPIRY_STATUS_NEEDS_REFRESH,
+		info.GetStatus(),
+	)
+	require.Equal(t, int32(150), info.GetBlocksRemaining())
+	require.Equal(t, int32(150), info.GetRefreshThresholdBlocks())
+	require.Equal(t, int32(78), info.GetCriticalThresholdBlocks())
+	require.Equal(t, uint32(24), info.GetRelativeExpiry())
+	require.Equal(t, uint32(9), info.GetMaxTreeDepth())
+	require.Equal(t, uint32(5), info.GetChainDepth())
+}

--- a/rpc/restclient/client_test.go
+++ b/rpc/restclient/client_test.go
@@ -66,6 +66,40 @@ func TestDaemonClientPost(t *testing.T) {
 	require.True(t, sawMetadata)
 }
 
+// TestDaemonClientGetVTXOExpiryInfoPost verifies the VTXO expiry RPC uses the
+// grpc-gateway route exposed by daemon.yaml.
+func TestDaemonClientGetVTXOExpiryInfoPost(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(
+				t, "/v1/daemon/get-vtxo-expiry-info",
+				r.URL.Path,
+			)
+
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(
+				`{"found":true,` +
+					`"expiryInfo":{"status":` +
+					`"VTXO_EXPIRY_STATUS_SAFE"}}`,
+			))
+			require.NoError(t, err)
+		},
+	))
+	defer server.Close()
+
+	client := NewDaemonServiceClient(server.URL)
+	resp, err := client.GetVTXOExpiryInfo(
+		t.Context(), &daemonrpc.GetVTXOExpiryInfoRequest{},
+	)
+	require.NoError(t, err)
+	require.True(t, resp.GetFound())
+	require.Equal(
+		t,
+		daemonrpc.VTXOExpiryStatus_VTXO_EXPIRY_STATUS_SAFE,
+		resp.GetExpiryInfo().GetStatus(),
+	)
+}
+
 func TestNewDefaultsSchemelessRemoteToHTTPS(t *testing.T) {
 	t.Parallel()
 

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -382,6 +382,19 @@ func (c *DaemonServiceClient) GetIndexedVTXOByPkScript(ctx context.Context,
 	return out, err
 }
 
+// GetVTXOExpiryInfo classifies one VTXO's expiry posture.
+func (c *DaemonServiceClient) GetVTXOExpiryInfo(ctx context.Context,
+	in *daemonrpc.GetVTXOExpiryInfoRequest, _ ...grpc.CallOption) (
+	*daemonrpc.GetVTXOExpiryInfoResponse, error) {
+
+	out := new(daemonrpc.GetVTXOExpiryInfoResponse)
+	err := c.client.Post(
+		ctx, "/v1/daemon/get-vtxo-expiry-info", in, out,
+	)
+
+	return out, err
+}
+
 // GetIndexedOORSessionByTxid looks up one indexed OOR session by txid.
 func (c *DaemonServiceClient) GetIndexedOORSessionByTxid(ctx context.Context,
 	in *daemonrpc.GetIndexedOORSessionByTxidRequest, _ ...grpc.CallOption) (

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -172,6 +172,41 @@ type WalletInitResult struct {
 	IdentityPubKey string
 }
 
+// VTXOExpiryInfo is the SDK-owned typed view of a VTXO expiry
+// classification.
+type VTXOExpiryInfo struct {
+	// Status is the daemon's current expiry posture for the VTXO.
+	Status daemonrpc.VTXOExpiryStatus
+
+	// CurrentHeight is the chain height used for classification.
+	CurrentHeight int32
+
+	// BatchExpiry is the VTXO batch expiry height.
+	BatchExpiry int32
+
+	// BlocksRemaining is BatchExpiry - CurrentHeight.
+	BlocksRemaining int32
+
+	// RefreshThresholdBlocks is the blocks-before-expiry threshold at
+	// which cooperative refresh should begin.
+	RefreshThresholdBlocks int32
+
+	// CriticalThresholdBlocks is the blocks-before-expiry threshold at
+	// which recovery/unilateral-exit handling should begin.
+	CriticalThresholdBlocks int32
+
+	// RelativeExpiry is the CSV delay used in the threshold calculation.
+	RelativeExpiry uint32
+
+	// MaxTreeDepth is the worst-case VTXO tree depth used in the threshold
+	// calculation.
+	MaxTreeDepth uint32
+
+	// ChainDepth is the number of OOR checkpoint hops between this VTXO
+	// and the most recent on-chain commitment.
+	ChainDepth uint32
+}
+
 // VTXOInfo is the SDK-owned typed view of a daemon VTXO record.
 type VTXOInfo struct {
 	// Outpoint is the VTXO's outpoint in "txid:index" format.
@@ -213,6 +248,10 @@ type VTXOInfo struct {
 
 	// SpentByTxID is the Ark or OOR txid that spent this VTXO when known.
 	SpentByTxID string
+
+	// ExpiryInfo is the daemon's current expiry posture for this VTXO when
+	// available.
+	ExpiryInfo *VTXOExpiryInfo
 }
 
 // ReceiveInfo is the SDK-owned typed view of a wallet-owned receive
@@ -700,6 +739,24 @@ func (c *Client) GetIndexedVTXOByPkScript(ctx context.Context,
 	resp, err := c.daemon.GetIndexedVTXOByPkScript(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("get indexed vtxo by script: %w", err)
+	}
+
+	return resp, nil
+}
+
+// GetVTXOExpiryInfo asks the daemon to classify a VTXO using the
+// authoritative wallet/VTXO expiry policy. Passing nil uses an empty request.
+func (c *Client) GetVTXOExpiryInfo(ctx context.Context,
+	req *daemonrpc.GetVTXOExpiryInfoRequest) (
+	*daemonrpc.GetVTXOExpiryInfoResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.GetVTXOExpiryInfoRequest{}
+	}
+
+	resp, err := c.daemon.GetVTXOExpiryInfo(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("get vtxo expiry info: %w", err)
 	}
 
 	return resp, nil
@@ -1373,7 +1430,28 @@ func newVTXOInfo(vtxo *daemonrpc.VTXO) (*VTXOInfo, error) {
 		ChainDepth:           vtxo.GetChainDepth(),
 		FinalCheckpointPSBTs: checkpoints,
 		SpentByTxID:          vtxo.GetSpentByTxid(),
+		ExpiryInfo:           newVTXOExpiryInfo(vtxo.GetExpiryInfo()),
 	}, nil
+}
+
+// newVTXOExpiryInfo converts one daemon protobuf VTXO expiry info message into
+// the SDK-owned typed model.
+func newVTXOExpiryInfo(info *daemonrpc.VTXOExpiryInfo) *VTXOExpiryInfo {
+	if info == nil {
+		return nil
+	}
+
+	return &VTXOExpiryInfo{
+		Status:                  info.GetStatus(),
+		CurrentHeight:           info.GetCurrentHeight(),
+		BatchExpiry:             info.GetBatchExpiry(),
+		BlocksRemaining:         info.GetBlocksRemaining(),
+		RefreshThresholdBlocks:  info.GetRefreshThresholdBlocks(),
+		CriticalThresholdBlocks: info.GetCriticalThresholdBlocks(),
+		RelativeExpiry:          info.GetRelativeExpiry(),
+		MaxTreeDepth:            info.GetMaxTreeDepth(),
+		ChainDepth:              info.GetChainDepth(),
+	}
 }
 
 // newReceiveInfo converts one daemon protobuf receive-script response

--- a/sdk/ark/client_test.go
+++ b/sdk/ark/client_test.go
@@ -39,11 +39,13 @@ type fakeDaemonService struct {
 	listVtxosResp         *daemonrpc.ListVTXOsResponse
 	newReceiveResp        *daemonrpc.NewReceiveScriptResponse
 	indexedVTXOResp       *daemonrpc.GetIndexedVTXOByPkScriptResponse
+	expiryInfoResp        *daemonrpc.GetVTXOExpiryInfoResponse
 	indexedOORSessionResp *daemonrpc.GetIndexedOORSessionByTxidResponse
 	sendOORResp           *daemonrpc.SendOORResponse
 
 	lastListVTXOsReq   *daemonrpc.ListVTXOsRequest
 	lastIndexedVTXOReq *daemonrpc.GetIndexedVTXOByPkScriptRequest
+	lastExpiryInfoReq  *daemonrpc.GetVTXOExpiryInfoRequest
 	lastIndexedOORReq  *daemonrpc.GetIndexedOORSessionByTxidRequest
 	lastSendOORReq     *daemonrpc.SendOORRequest
 }
@@ -52,6 +54,18 @@ const (
 	// testLiveVTXOStatus keeps the fake VTXO response readable while
 	// staying within the repository's line-length limit.
 	testLiveVTXOStatus = daemonrpc.VTXOStatus_VTXO_STATUS_LIVE
+
+	// testSafeExpiryStatus keeps fake expiry info fixtures readable while
+	// staying within the repository's line-length limit.
+	testSafeExpiryStatus = daemonrpc.VTXOExpiryStatus_VTXO_EXPIRY_STATUS_SAFE
+
+	// testRefreshExpiryStatus keeps fake expiry info fixtures readable while
+	// staying within the repository's line-length limit.
+	testRefreshExpiryStatus = daemonrpc.VTXOExpiryStatus_VTXO_EXPIRY_STATUS_NEEDS_REFRESH
+
+	// testCriticalExpiryStatus keeps fake expiry info fixtures readable while
+	// staying within the repository's line-length limit.
+	testCriticalExpiryStatus = daemonrpc.VTXOExpiryStatus_VTXO_EXPIRY_STATUS_CRITICAL
 )
 
 // watchRoundsResponse shortens the generic stream signature used by the fake
@@ -109,6 +123,17 @@ func newFakeDaemonService() *fakeDaemonService {
 						},
 					},
 					SpentByTxid: "spent-txid",
+					ExpiryInfo: &daemonrpc.VTXOExpiryInfo{
+						Status:                  testSafeExpiryStatus,
+						CurrentHeight:           700,
+						BatchExpiry:             1000,
+						BlocksRemaining:         300,
+						RefreshThresholdBlocks:  216,
+						CriticalThresholdBlocks: 144,
+						RelativeExpiry:          144,
+						MaxTreeDepth:            0,
+						ChainDepth:              0,
+					},
 				},
 			},
 		},
@@ -133,6 +158,37 @@ func newFakeDaemonService() *fakeDaemonService {
 					},
 				},
 				SpentByTxid: "indexed-spender",
+				ExpiryInfo: &daemonrpc.VTXOExpiryInfo{
+					Status:                  testRefreshExpiryStatus,
+					CurrentHeight:           784,
+					BatchExpiry:             1000,
+					BlocksRemaining:         216,
+					RefreshThresholdBlocks:  216,
+					CriticalThresholdBlocks: 144,
+					RelativeExpiry:          144,
+					MaxTreeDepth:            0,
+					ChainDepth:              1,
+				},
+			},
+		},
+		expiryInfoResp: &daemonrpc.GetVTXOExpiryInfoResponse{
+			Found: true,
+			ExpiryInfo: &daemonrpc.VTXOExpiryInfo{
+				Status:                  testCriticalExpiryStatus,
+				CurrentHeight:           900,
+				BatchExpiry:             1000,
+				BlocksRemaining:         100,
+				RefreshThresholdBlocks:  216,
+				CriticalThresholdBlocks: 144,
+				RelativeExpiry:          144,
+				MaxTreeDepth:            0,
+				ChainDepth:              2,
+			},
+			Vtxo: &daemonrpc.VTXO{
+				Outpoint:  "expiry:0",
+				AmountSat: 21_000,
+				Status:    testLiveVTXOStatus,
+				PkScript:  "5120c0ffee",
 			},
 		},
 		indexedOORSessionResp: &daemonrpc.
@@ -416,6 +472,19 @@ func (f *fakeDaemonService) GetIndexedVTXOByPkScript(_ context.Context,
 	return f.indexedVTXOResp, nil
 }
 
+// GetVTXOExpiryInfo returns one deterministic expiry classification and
+// records the lookup request for helper assertions.
+func (f *fakeDaemonService) GetVTXOExpiryInfo(_ context.Context,
+	req *daemonrpc.GetVTXOExpiryInfoRequest) (
+	*daemonrpc.GetVTXOExpiryInfoResponse, error) {
+
+	f.mu.Lock()
+	f.lastExpiryInfoReq = req
+	f.mu.Unlock()
+
+	return f.expiryInfoResp, nil
+}
+
 // GetIndexedOORSessionByTxid returns one deterministic indexed OOR session
 // and records the lookup request for helper assertions.
 func (f *fakeDaemonService) GetIndexedOORSessionByTxid(_ context.Context,
@@ -691,6 +760,12 @@ func TestDialRemotePolicyHelpers(t *testing.T) {
 	require.Equal(
 		t, []byte{0x51, 0x20, 0xc0, 0xff, 0xee}, liveVTXOs[0].PkScript,
 	)
+	require.NotNil(t, liveVTXOs[0].ExpiryInfo)
+	require.Equal(t, testSafeExpiryStatus, liveVTXOs[0].ExpiryInfo.Status)
+	require.Equal(t, int32(300), liveVTXOs[0].ExpiryInfo.BlocksRemaining)
+	require.Equal(
+		t, int32(216), liveVTXOs[0].ExpiryInfo.RefreshThresholdBlocks,
+	)
 
 	service.mu.Lock()
 	listReq := service.lastListVTXOsReq
@@ -708,6 +783,11 @@ func TestDialRemotePolicyHelpers(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, indexedVTXO)
 	require.Equal(t, "indexed:1", indexedVTXO.Outpoint)
+	require.NotNil(t, indexedVTXO.ExpiryInfo)
+	require.Equal(
+		t, testRefreshExpiryStatus, indexedVTXO.ExpiryInfo.Status,
+	)
+	require.Equal(t, uint32(1), indexedVTXO.ExpiryInfo.ChainDepth)
 
 	service.mu.Lock()
 	indexedReq := service.lastIndexedVTXOReq
@@ -721,6 +801,33 @@ func TestDialRemotePolicyHelpers(t *testing.T) {
 	require.Equal(t, []daemonrpc.VTXOStatus{
 		daemonrpc.VTXOStatus_VTXO_STATUS_SPENT,
 	}, indexedReq.GetStatusFilter())
+
+	expiryResp, err := client.GetVTXOExpiryInfo(
+		context.Background(),
+		&daemonrpc.GetVTXOExpiryInfoRequest{
+			Target: &daemonrpc.GetVTXOExpiryInfoRequest_PkScript{
+				PkScript: []byte{0x51, 0x20, 0xc0, 0xff, 0xee},
+			},
+			StatusFilter: []daemonrpc.VTXOStatus{
+				daemonrpc.VTXOStatus_VTXO_STATUS_LIVE,
+			},
+			CurrentHeight: 900,
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, expiryResp.GetFound())
+	require.Equal(t, testCriticalExpiryStatus, expiryResp.GetExpiryInfo().GetStatus())
+
+	service.mu.Lock()
+	expiryReq := service.lastExpiryInfoReq
+	service.mu.Unlock()
+
+	require.NotNil(t, expiryReq)
+	require.Equal(t, int32(900), expiryReq.GetCurrentHeight())
+	require.Equal(
+		t, []byte{0x51, 0x20, 0xc0, 0xff, 0xee},
+		expiryReq.GetPkScript(),
+	)
 
 	receiveInfo, err := client.AllocateReceiveScript(
 		context.Background(),


### PR DESCRIPTION
## Summary

Adds a daemon RPC surface for querying the wallet/VTXO layer's expiry posture for a VTXO by local outpoint or indexed pkScript.

This gives higher-level swap code an authoritative answer for refresh safety decisions instead of duplicating threshold math outside darepo-client.

## What changed

- Added `GetVTXOExpiryInfo` to `DaemonService`, including grpc-gateway and mailbox/generated bindings.
- Added `VTXOExpiryStatus` and `VTXOExpiryInfo` to the daemon proto, plus an optional `expiry_info` field on `VTXO`.
- Implemented daemon-side expiry classification using `vtxo.DefaultExpiryConfig()`.
- Supports local outpoint lookup from the VTXO store and indexed pkScript lookup from the indexer.
- Carries expiry info through indexed VTXO lookup responses when chain height is available.
- Exposed the RPC and typed expiry info through `sdk/ark` and the REST client.
- Added comments for the new proto fields and all new hand-written functions, including unexported helpers.

## Validation

- `make rpc`
- `git diff --check`
- `go test ./...`
