### PR TITLE
Add swapserver-backed vHTLC recovery

### DIFF
--- a/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
@@ -93,6 +93,13 @@ func generatedRegistry() []serviceSpec {
 					Comments: "SignReceiveAuthMessageCompact signs one message with the\nper-payment receive-auth key and returns a compact signature.",
 				},
 				{
+					Name:     "SignIdentitySchnorr",
+					Aliases:  []string{"sign-identity-schnorr"},
+					Input:    "daemonrpc.SignIdentitySchnorrRequest",
+					Output:   "daemonrpc.SignIdentitySchnorrResponse",
+					Comments: "SignIdentitySchnorr signs one domain-separated message with the daemon\nidentity key. The private key never leaves the daemon.",
+				},
+				{
 					Name:     "ReceiveAuthECDH",
 					Aliases:  []string{"receive-auth-ecdh"},
 					Input:    "daemonrpc.ReceiveAuthECDHRequest",

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -1216,8 +1216,17 @@ type InitWalletResponse struct {
 	// recovered_oor_events is the number of OOR recipient events processed
 	// during recovery.
 	RecoveredOorEvents uint32 `protobuf:"varint,7,opt,name=recovered_oor_events,json=recoveredOorEvents,proto3" json:"recovered_oor_events,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// recovered_vhtlcs is the number of swapserver recoverable vHTLC rows
+	// validated during recovery.
+	RecoveredVhtlcs uint32 `protobuf:"varint,8,opt,name=recovered_vhtlcs,json=recoveredVhtlcs,proto3" json:"recovered_vhtlcs,omitempty"`
+	// recovered_vhtlc_refunds is the number of pay-side refund recovery rows
+	// armed from recovered in-swaps.
+	RecoveredVhtlcRefunds uint32 `protobuf:"varint,9,opt,name=recovered_vhtlc_refunds,json=recoveredVhtlcRefunds,proto3" json:"recovered_vhtlc_refunds,omitempty"`
+	// recovered_vhtlc_claims is the number of receive-side claim recovery
+	// rows armed from recovered out-swaps.
+	RecoveredVhtlcClaims uint32 `protobuf:"varint,10,opt,name=recovered_vhtlc_claims,json=recoveredVhtlcClaims,proto3" json:"recovered_vhtlc_claims,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *InitWalletResponse) Reset() {
@@ -1295,6 +1304,27 @@ func (x *InitWalletResponse) GetRecoveredOorReceiveScripts() uint32 {
 func (x *InitWalletResponse) GetRecoveredOorEvents() uint32 {
 	if x != nil {
 		return x.RecoveredOorEvents
+	}
+	return 0
+}
+
+func (x *InitWalletResponse) GetRecoveredVhtlcs() uint32 {
+	if x != nil {
+		return x.RecoveredVhtlcs
+	}
+	return 0
+}
+
+func (x *InitWalletResponse) GetRecoveredVhtlcRefunds() uint32 {
+	if x != nil {
+		return x.RecoveredVhtlcRefunds
+	}
+	return 0
+}
+
+func (x *InitWalletResponse) GetRecoveredVhtlcClaims() uint32 {
+	if x != nil {
+		return x.RecoveredVhtlcClaims
 	}
 	return 0
 }
@@ -2342,6 +2372,105 @@ func (x *SignReceiveAuthMessageCompactResponse) GetSignature() []byte {
 	return nil
 }
 
+type SignIdentitySchnorrRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// message is the raw domain-separated message to sign.
+	Message []byte `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	// tag is the BIP-340 tag used for tagged Schnorr signing.
+	Tag           []byte `protobuf:"bytes,2,opt,name=tag,proto3" json:"tag,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignIdentitySchnorrRequest) Reset() {
+	*x = SignIdentitySchnorrRequest{}
+	mi := &file_daemon_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignIdentitySchnorrRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignIdentitySchnorrRequest) ProtoMessage() {}
+
+func (x *SignIdentitySchnorrRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignIdentitySchnorrRequest.ProtoReflect.Descriptor instead.
+func (*SignIdentitySchnorrRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *SignIdentitySchnorrRequest) GetMessage() []byte {
+	if x != nil {
+		return x.Message
+	}
+	return nil
+}
+
+func (x *SignIdentitySchnorrRequest) GetTag() []byte {
+	if x != nil {
+		return x.Tag
+	}
+	return nil
+}
+
+type SignIdentitySchnorrResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// signature is the raw 64-byte BIP-340 Schnorr signature.
+	Signature     []byte `protobuf:"bytes,1,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignIdentitySchnorrResponse) Reset() {
+	*x = SignIdentitySchnorrResponse{}
+	mi := &file_daemon_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignIdentitySchnorrResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignIdentitySchnorrResponse) ProtoMessage() {}
+
+func (x *SignIdentitySchnorrResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignIdentitySchnorrResponse.ProtoReflect.Descriptor instead.
+func (*SignIdentitySchnorrResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *SignIdentitySchnorrResponse) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
 type ReceiveAuthECDHRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// payment_hash is the 32-byte Lightning payment hash for the receive
@@ -2355,7 +2484,7 @@ type ReceiveAuthECDHRequest struct {
 
 func (x *ReceiveAuthECDHRequest) Reset() {
 	*x = ReceiveAuthECDHRequest{}
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2367,7 +2496,7 @@ func (x *ReceiveAuthECDHRequest) String() string {
 func (*ReceiveAuthECDHRequest) ProtoMessage() {}
 
 func (x *ReceiveAuthECDHRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[24]
+	mi := &file_daemon_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2380,7 +2509,7 @@ func (x *ReceiveAuthECDHRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthECDHRequest.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthECDHRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{24}
+	return file_daemon_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ReceiveAuthECDHRequest) GetPaymentHash() []byte {
@@ -2407,7 +2536,7 @@ type ReceiveAuthECDHResponse struct {
 
 func (x *ReceiveAuthECDHResponse) Reset() {
 	*x = ReceiveAuthECDHResponse{}
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2419,7 +2548,7 @@ func (x *ReceiveAuthECDHResponse) String() string {
 func (*ReceiveAuthECDHResponse) ProtoMessage() {}
 
 func (x *ReceiveAuthECDHResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[25]
+	mi := &file_daemon_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2432,7 +2561,7 @@ func (x *ReceiveAuthECDHResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReceiveAuthECDHResponse.ProtoReflect.Descriptor instead.
 func (*ReceiveAuthECDHResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{25}
+	return file_daemon_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ReceiveAuthECDHResponse) GetSharedSecret() []byte {
@@ -2455,7 +2584,7 @@ type GetIndexedVTXOByPkScriptRequest struct {
 
 func (x *GetIndexedVTXOByPkScriptRequest) Reset() {
 	*x = GetIndexedVTXOByPkScriptRequest{}
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2467,7 +2596,7 @@ func (x *GetIndexedVTXOByPkScriptRequest) String() string {
 func (*GetIndexedVTXOByPkScriptRequest) ProtoMessage() {}
 
 func (x *GetIndexedVTXOByPkScriptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[26]
+	mi := &file_daemon_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2480,7 +2609,7 @@ func (x *GetIndexedVTXOByPkScriptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetIndexedVTXOByPkScriptRequest.ProtoReflect.Descriptor instead.
 func (*GetIndexedVTXOByPkScriptRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{26}
+	return file_daemon_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GetIndexedVTXOByPkScriptRequest) GetPkScript() []byte {
@@ -2507,7 +2636,7 @@ type GetIndexedVTXOByPkScriptResponse struct {
 
 func (x *GetIndexedVTXOByPkScriptResponse) Reset() {
 	*x = GetIndexedVTXOByPkScriptResponse{}
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2519,7 +2648,7 @@ func (x *GetIndexedVTXOByPkScriptResponse) String() string {
 func (*GetIndexedVTXOByPkScriptResponse) ProtoMessage() {}
 
 func (x *GetIndexedVTXOByPkScriptResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[27]
+	mi := &file_daemon_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2532,7 +2661,7 @@ func (x *GetIndexedVTXOByPkScriptResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetIndexedVTXOByPkScriptResponse.ProtoReflect.Descriptor instead.
 func (*GetIndexedVTXOByPkScriptResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{27}
+	return file_daemon_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *GetIndexedVTXOByPkScriptResponse) GetVtxo() *VTXO {
@@ -2554,7 +2683,7 @@ type GetIndexedOORSessionByTxidRequest struct {
 
 func (x *GetIndexedOORSessionByTxidRequest) Reset() {
 	*x = GetIndexedOORSessionByTxidRequest{}
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2566,7 +2695,7 @@ func (x *GetIndexedOORSessionByTxidRequest) String() string {
 func (*GetIndexedOORSessionByTxidRequest) ProtoMessage() {}
 
 func (x *GetIndexedOORSessionByTxidRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[28]
+	mi := &file_daemon_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2579,7 +2708,7 @@ func (x *GetIndexedOORSessionByTxidRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetIndexedOORSessionByTxidRequest.ProtoReflect.Descriptor instead.
 func (*GetIndexedOORSessionByTxidRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{28}
+	return file_daemon_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *GetIndexedOORSessionByTxidRequest) GetPkScript() []byte {
@@ -2609,7 +2738,7 @@ type GetIndexedOORSessionByTxidResponse struct {
 
 func (x *GetIndexedOORSessionByTxidResponse) Reset() {
 	*x = GetIndexedOORSessionByTxidResponse{}
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2621,7 +2750,7 @@ func (x *GetIndexedOORSessionByTxidResponse) String() string {
 func (*GetIndexedOORSessionByTxidResponse) ProtoMessage() {}
 
 func (x *GetIndexedOORSessionByTxidResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[29]
+	mi := &file_daemon_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2634,7 +2763,7 @@ func (x *GetIndexedOORSessionByTxidResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GetIndexedOORSessionByTxidResponse.ProtoReflect.Descriptor instead.
 func (*GetIndexedOORSessionByTxidResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{29}
+	return file_daemon_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetIndexedOORSessionByTxidResponse) GetArkPsbt() []byte {
@@ -2672,7 +2801,7 @@ type Output struct {
 
 func (x *Output) Reset() {
 	*x = Output{}
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2684,7 +2813,7 @@ func (x *Output) String() string {
 func (*Output) ProtoMessage() {}
 
 func (x *Output) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[30]
+	mi := &file_daemon_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2697,7 +2826,7 @@ func (x *Output) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Output.ProtoReflect.Descriptor instead.
 func (*Output) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{30}
+	return file_daemon_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *Output) GetDestination() isOutput_Destination {
@@ -2794,7 +2923,7 @@ type SendVTXORequest struct {
 
 func (x *SendVTXORequest) Reset() {
 	*x = SendVTXORequest{}
-	mi := &file_daemon_proto_msgTypes[31]
+	mi := &file_daemon_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2806,7 +2935,7 @@ func (x *SendVTXORequest) String() string {
 func (*SendVTXORequest) ProtoMessage() {}
 
 func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[31]
+	mi := &file_daemon_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2819,7 +2948,7 @@ func (x *SendVTXORequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXORequest.ProtoReflect.Descriptor instead.
 func (*SendVTXORequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{31}
+	return file_daemon_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *SendVTXORequest) GetRecipients() []*Output {
@@ -2859,7 +2988,7 @@ type SendVTXOResponse struct {
 
 func (x *SendVTXOResponse) Reset() {
 	*x = SendVTXOResponse{}
-	mi := &file_daemon_proto_msgTypes[32]
+	mi := &file_daemon_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2871,7 +3000,7 @@ func (x *SendVTXOResponse) String() string {
 func (*SendVTXOResponse) ProtoMessage() {}
 
 func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[32]
+	mi := &file_daemon_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2884,7 +3013,7 @@ func (x *SendVTXOResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendVTXOResponse.ProtoReflect.Descriptor instead.
 func (*SendVTXOResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{32}
+	return file_daemon_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *SendVTXOResponse) GetStatus() string {
@@ -2944,7 +3073,7 @@ type SendOORRequest struct {
 
 func (x *SendOORRequest) Reset() {
 	*x = SendOORRequest{}
-	mi := &file_daemon_proto_msgTypes[33]
+	mi := &file_daemon_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2956,7 +3085,7 @@ func (x *SendOORRequest) String() string {
 func (*SendOORRequest) ProtoMessage() {}
 
 func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[33]
+	mi := &file_daemon_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2969,7 +3098,7 @@ func (x *SendOORRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORRequest.ProtoReflect.Descriptor instead.
 func (*SendOORRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{33}
+	return file_daemon_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *SendOORRequest) GetRecipients() []*Output {
@@ -3028,7 +3157,7 @@ type CustomOORInput struct {
 
 func (x *CustomOORInput) Reset() {
 	*x = CustomOORInput{}
-	mi := &file_daemon_proto_msgTypes[34]
+	mi := &file_daemon_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3040,7 +3169,7 @@ func (x *CustomOORInput) String() string {
 func (*CustomOORInput) ProtoMessage() {}
 
 func (x *CustomOORInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[34]
+	mi := &file_daemon_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3053,7 +3182,7 @@ func (x *CustomOORInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CustomOORInput.ProtoReflect.Descriptor instead.
 func (*CustomOORInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{34}
+	return file_daemon_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *CustomOORInput) GetOutpoint() string {
@@ -3118,7 +3247,7 @@ type TaprootScriptSignature struct {
 
 func (x *TaprootScriptSignature) Reset() {
 	*x = TaprootScriptSignature{}
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3130,7 +3259,7 @@ func (x *TaprootScriptSignature) String() string {
 func (*TaprootScriptSignature) ProtoMessage() {}
 
 func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[35]
+	mi := &file_daemon_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3143,7 +3272,7 @@ func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaprootScriptSignature.ProtoReflect.Descriptor instead.
 func (*TaprootScriptSignature) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{35}
+	return file_daemon_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *TaprootScriptSignature) GetPubkey() []byte {
@@ -3194,7 +3323,7 @@ type SendOORResponse struct {
 
 func (x *SendOORResponse) Reset() {
 	*x = SendOORResponse{}
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3206,7 +3335,7 @@ func (x *SendOORResponse) String() string {
 func (*SendOORResponse) ProtoMessage() {}
 
 func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[36]
+	mi := &file_daemon_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3219,7 +3348,7 @@ func (x *SendOORResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOORResponse.ProtoReflect.Descriptor instead.
 func (*SendOORResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{36}
+	return file_daemon_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *SendOORResponse) GetStatus() string {
@@ -3257,7 +3386,7 @@ type PrepareOORRequest struct {
 
 func (x *PrepareOORRequest) Reset() {
 	*x = PrepareOORRequest{}
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3269,7 +3398,7 @@ func (x *PrepareOORRequest) String() string {
 func (*PrepareOORRequest) ProtoMessage() {}
 
 func (x *PrepareOORRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[37]
+	mi := &file_daemon_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3282,7 +3411,7 @@ func (x *PrepareOORRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareOORRequest.ProtoReflect.Descriptor instead.
 func (*PrepareOORRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{37}
+	return file_daemon_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *PrepareOORRequest) GetRecipient() *Output {
@@ -3317,7 +3446,7 @@ type PreparedOORCustomInput struct {
 
 func (x *PreparedOORCustomInput) Reset() {
 	*x = PreparedOORCustomInput{}
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3329,7 +3458,7 @@ func (x *PreparedOORCustomInput) String() string {
 func (*PreparedOORCustomInput) ProtoMessage() {}
 
 func (x *PreparedOORCustomInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[38]
+	mi := &file_daemon_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3342,7 +3471,7 @@ func (x *PreparedOORCustomInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedOORCustomInput.ProtoReflect.Descriptor instead.
 func (*PreparedOORCustomInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{38}
+	return file_daemon_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *PreparedOORCustomInput) GetOutpoint() string {
@@ -3390,7 +3519,7 @@ type PrepareOORResponse struct {
 
 func (x *PrepareOORResponse) Reset() {
 	*x = PrepareOORResponse{}
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3402,7 +3531,7 @@ func (x *PrepareOORResponse) String() string {
 func (*PrepareOORResponse) ProtoMessage() {}
 
 func (x *PrepareOORResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[39]
+	mi := &file_daemon_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3415,7 +3544,7 @@ func (x *PrepareOORResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareOORResponse.ProtoReflect.Descriptor instead.
 func (*PrepareOORResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{39}
+	return file_daemon_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *PrepareOORResponse) GetArkPsbt() []byte {
@@ -3458,7 +3587,7 @@ type SignOORCustomInputRequest struct {
 
 func (x *SignOORCustomInputRequest) Reset() {
 	*x = SignOORCustomInputRequest{}
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3470,7 +3599,7 @@ func (x *SignOORCustomInputRequest) String() string {
 func (*SignOORCustomInputRequest) ProtoMessage() {}
 
 func (x *SignOORCustomInputRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[40]
+	mi := &file_daemon_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3483,7 +3612,7 @@ func (x *SignOORCustomInputRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignOORCustomInputRequest.ProtoReflect.Descriptor instead.
 func (*SignOORCustomInputRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{40}
+	return file_daemon_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *SignOORCustomInputRequest) GetCustomInput() *CustomOORInput {
@@ -3510,7 +3639,7 @@ type SignOORCustomInputResponse struct {
 
 func (x *SignOORCustomInputResponse) Reset() {
 	*x = SignOORCustomInputResponse{}
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3522,7 +3651,7 @@ func (x *SignOORCustomInputResponse) String() string {
 func (*SignOORCustomInputResponse) ProtoMessage() {}
 
 func (x *SignOORCustomInputResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[41]
+	mi := &file_daemon_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3535,7 +3664,7 @@ func (x *SignOORCustomInputResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignOORCustomInputResponse.ProtoReflect.Descriptor instead.
 func (*SignOORCustomInputResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{41}
+	return file_daemon_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *SignOORCustomInputResponse) GetSignature() *TaprootScriptSignature {
@@ -3558,7 +3687,7 @@ type OutpointSelection struct {
 
 func (x *OutpointSelection) Reset() {
 	*x = OutpointSelection{}
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3570,7 +3699,7 @@ func (x *OutpointSelection) String() string {
 func (*OutpointSelection) ProtoMessage() {}
 
 func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[42]
+	mi := &file_daemon_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3583,7 +3712,7 @@ func (x *OutpointSelection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutpointSelection.ProtoReflect.Descriptor instead.
 func (*OutpointSelection) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{42}
+	return file_daemon_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *OutpointSelection) GetOutpoints() []string {
@@ -3608,7 +3737,7 @@ type RefreshVTXOsRequest struct {
 
 func (x *RefreshVTXOsRequest) Reset() {
 	*x = RefreshVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3620,7 +3749,7 @@ func (x *RefreshVTXOsRequest) String() string {
 func (*RefreshVTXOsRequest) ProtoMessage() {}
 
 func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[43]
+	mi := &file_daemon_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3633,7 +3762,7 @@ func (x *RefreshVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{43}
+	return file_daemon_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *RefreshVTXOsRequest) GetSelection() isRefreshVTXOsRequest_Selection {
@@ -3700,7 +3829,7 @@ type RefreshVTXOsResponse struct {
 
 func (x *RefreshVTXOsResponse) Reset() {
 	*x = RefreshVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3712,7 +3841,7 @@ func (x *RefreshVTXOsResponse) String() string {
 func (*RefreshVTXOsResponse) ProtoMessage() {}
 
 func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[44]
+	mi := &file_daemon_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3725,7 +3854,7 @@ func (x *RefreshVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RefreshVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*RefreshVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{44}
+	return file_daemon_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *RefreshVTXOsResponse) GetQueuedOutpoints() []string {
@@ -3759,7 +3888,7 @@ type LeaveDestination struct {
 
 func (x *LeaveDestination) Reset() {
 	*x = LeaveDestination{}
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3771,7 +3900,7 @@ func (x *LeaveDestination) String() string {
 func (*LeaveDestination) ProtoMessage() {}
 
 func (x *LeaveDestination) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[45]
+	mi := &file_daemon_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3784,7 +3913,7 @@ func (x *LeaveDestination) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveDestination.ProtoReflect.Descriptor instead.
 func (*LeaveDestination) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{45}
+	return file_daemon_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *LeaveDestination) GetTarget() isLeaveDestination_Target {
@@ -3865,7 +3994,7 @@ type LeaveVTXOsRequest struct {
 
 func (x *LeaveVTXOsRequest) Reset() {
 	*x = LeaveVTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3877,7 +4006,7 @@ func (x *LeaveVTXOsRequest) String() string {
 func (*LeaveVTXOsRequest) ProtoMessage() {}
 
 func (x *LeaveVTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[46]
+	mi := &file_daemon_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3890,7 +4019,7 @@ func (x *LeaveVTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveVTXOsRequest.ProtoReflect.Descriptor instead.
 func (*LeaveVTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{46}
+	return file_daemon_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *LeaveVTXOsRequest) GetSelection() isLeaveVTXOsRequest_Selection {
@@ -3973,7 +4102,7 @@ type LeaveVTXOsResponse struct {
 
 func (x *LeaveVTXOsResponse) Reset() {
 	*x = LeaveVTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3985,7 +4114,7 @@ func (x *LeaveVTXOsResponse) String() string {
 func (*LeaveVTXOsResponse) ProtoMessage() {}
 
 func (x *LeaveVTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[47]
+	mi := &file_daemon_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3998,7 +4127,7 @@ func (x *LeaveVTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveVTXOsResponse.ProtoReflect.Descriptor instead.
 func (*LeaveVTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{47}
+	return file_daemon_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *LeaveVTXOsResponse) GetQueuedOutpoints() []string {
@@ -4036,7 +4165,7 @@ type SendOnChainRequest struct {
 
 func (x *SendOnChainRequest) Reset() {
 	*x = SendOnChainRequest{}
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4048,7 +4177,7 @@ func (x *SendOnChainRequest) String() string {
 func (*SendOnChainRequest) ProtoMessage() {}
 
 func (x *SendOnChainRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[48]
+	mi := &file_daemon_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4061,7 +4190,7 @@ func (x *SendOnChainRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOnChainRequest.ProtoReflect.Descriptor instead.
 func (*SendOnChainRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{48}
+	return file_daemon_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *SendOnChainRequest) GetDestination() *LeaveDestination {
@@ -4160,7 +4289,7 @@ type SendOnChainResponse struct {
 
 func (x *SendOnChainResponse) Reset() {
 	*x = SendOnChainResponse{}
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4172,7 +4301,7 @@ func (x *SendOnChainResponse) String() string {
 func (*SendOnChainResponse) ProtoMessage() {}
 
 func (x *SendOnChainResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[49]
+	mi := &file_daemon_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4185,7 +4314,7 @@ func (x *SendOnChainResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SendOnChainResponse.ProtoReflect.Descriptor instead.
 func (*SendOnChainResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{49}
+	return file_daemon_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *SendOnChainResponse) GetActualAmountSat() int64 {
@@ -4244,7 +4373,7 @@ type BoardRequest struct {
 
 func (x *BoardRequest) Reset() {
 	*x = BoardRequest{}
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4256,7 +4385,7 @@ func (x *BoardRequest) String() string {
 func (*BoardRequest) ProtoMessage() {}
 
 func (x *BoardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[50]
+	mi := &file_daemon_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4269,7 +4398,7 @@ func (x *BoardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardRequest.ProtoReflect.Descriptor instead.
 func (*BoardRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{50}
+	return file_daemon_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *BoardRequest) GetTargetVtxoCount() uint32 {
@@ -4300,7 +4429,7 @@ type BoardResponse struct {
 
 func (x *BoardResponse) Reset() {
 	*x = BoardResponse{}
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4312,7 +4441,7 @@ func (x *BoardResponse) String() string {
 func (*BoardResponse) ProtoMessage() {}
 
 func (x *BoardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[51]
+	mi := &file_daemon_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4325,7 +4454,7 @@ func (x *BoardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardResponse.ProtoReflect.Descriptor instead.
 func (*BoardResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{51}
+	return file_daemon_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *BoardResponse) GetStatus() string {
@@ -4350,7 +4479,7 @@ type JoinNextRoundRequest struct {
 
 func (x *JoinNextRoundRequest) Reset() {
 	*x = JoinNextRoundRequest{}
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4362,7 +4491,7 @@ func (x *JoinNextRoundRequest) String() string {
 func (*JoinNextRoundRequest) ProtoMessage() {}
 
 func (x *JoinNextRoundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[52]
+	mi := &file_daemon_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4375,7 +4504,7 @@ func (x *JoinNextRoundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinNextRoundRequest.ProtoReflect.Descriptor instead.
 func (*JoinNextRoundRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{52}
+	return file_daemon_proto_rawDescGZIP(), []int{54}
 }
 
 type JoinNextRoundResponse struct {
@@ -4390,7 +4519,7 @@ type JoinNextRoundResponse struct {
 
 func (x *JoinNextRoundResponse) Reset() {
 	*x = JoinNextRoundResponse{}
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4402,7 +4531,7 @@ func (x *JoinNextRoundResponse) String() string {
 func (*JoinNextRoundResponse) ProtoMessage() {}
 
 func (x *JoinNextRoundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[53]
+	mi := &file_daemon_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4415,7 +4544,7 @@ func (x *JoinNextRoundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinNextRoundResponse.ProtoReflect.Descriptor instead.
 func (*JoinNextRoundResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{53}
+	return file_daemon_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *JoinNextRoundResponse) GetStatus() string {
@@ -4451,7 +4580,7 @@ type SweepBoardingUTXOsRequest struct {
 
 func (x *SweepBoardingUTXOsRequest) Reset() {
 	*x = SweepBoardingUTXOsRequest{}
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4463,7 +4592,7 @@ func (x *SweepBoardingUTXOsRequest) String() string {
 func (*SweepBoardingUTXOsRequest) ProtoMessage() {}
 
 func (x *SweepBoardingUTXOsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[54]
+	mi := &file_daemon_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4476,7 +4605,7 @@ func (x *SweepBoardingUTXOsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepBoardingUTXOsRequest.ProtoReflect.Descriptor instead.
 func (*SweepBoardingUTXOsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{54}
+	return file_daemon_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *SweepBoardingUTXOsRequest) GetOutpoints() []string {
@@ -4529,7 +4658,7 @@ type BoardingSweepOutput struct {
 
 func (x *BoardingSweepOutput) Reset() {
 	*x = BoardingSweepOutput{}
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4541,7 +4670,7 @@ func (x *BoardingSweepOutput) String() string {
 func (*BoardingSweepOutput) ProtoMessage() {}
 
 func (x *BoardingSweepOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[55]
+	mi := &file_daemon_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4554,7 +4683,7 @@ func (x *BoardingSweepOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweepOutput.ProtoReflect.Descriptor instead.
 func (*BoardingSweepOutput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{55}
+	return file_daemon_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *BoardingSweepOutput) GetOutpoint() string {
@@ -4620,7 +4749,7 @@ type SweepBoardingUTXOsResponse struct {
 
 func (x *SweepBoardingUTXOsResponse) Reset() {
 	*x = SweepBoardingUTXOsResponse{}
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4632,7 +4761,7 @@ func (x *SweepBoardingUTXOsResponse) String() string {
 func (*SweepBoardingUTXOsResponse) ProtoMessage() {}
 
 func (x *SweepBoardingUTXOsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[56]
+	mi := &file_daemon_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4645,7 +4774,7 @@ func (x *SweepBoardingUTXOsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepBoardingUTXOsResponse.ProtoReflect.Descriptor instead.
 func (*SweepBoardingUTXOsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{56}
+	return file_daemon_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *SweepBoardingUTXOsResponse) GetStatus() string {
@@ -4749,7 +4878,7 @@ type ListBoardingSweepsRequest struct {
 
 func (x *ListBoardingSweepsRequest) Reset() {
 	*x = ListBoardingSweepsRequest{}
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4761,7 +4890,7 @@ func (x *ListBoardingSweepsRequest) String() string {
 func (*ListBoardingSweepsRequest) ProtoMessage() {}
 
 func (x *ListBoardingSweepsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[57]
+	mi := &file_daemon_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4774,7 +4903,7 @@ func (x *ListBoardingSweepsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBoardingSweepsRequest.ProtoReflect.Descriptor instead.
 func (*ListBoardingSweepsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{57}
+	return file_daemon_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *ListBoardingSweepsRequest) GetStatus() string {
@@ -4817,7 +4946,7 @@ type BoardingSweepInput struct {
 
 func (x *BoardingSweepInput) Reset() {
 	*x = BoardingSweepInput{}
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4829,7 +4958,7 @@ func (x *BoardingSweepInput) String() string {
 func (*BoardingSweepInput) ProtoMessage() {}
 
 func (x *BoardingSweepInput) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[58]
+	mi := &file_daemon_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4842,7 +4971,7 @@ func (x *BoardingSweepInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweepInput.ProtoReflect.Descriptor instead.
 func (*BoardingSweepInput) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{58}
+	return file_daemon_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *BoardingSweepInput) GetOutpoint() string {
@@ -4912,7 +5041,7 @@ type BoardingSweep struct {
 
 func (x *BoardingSweep) Reset() {
 	*x = BoardingSweep{}
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4924,7 +5053,7 @@ func (x *BoardingSweep) String() string {
 func (*BoardingSweep) ProtoMessage() {}
 
 func (x *BoardingSweep) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[59]
+	mi := &file_daemon_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4937,7 +5066,7 @@ func (x *BoardingSweep) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoardingSweep.ProtoReflect.Descriptor instead.
 func (*BoardingSweep) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{59}
+	return file_daemon_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *BoardingSweep) GetTxid() string {
@@ -5029,7 +5158,7 @@ type ListBoardingSweepsResponse struct {
 
 func (x *ListBoardingSweepsResponse) Reset() {
 	*x = ListBoardingSweepsResponse{}
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5041,7 +5170,7 @@ func (x *ListBoardingSweepsResponse) String() string {
 func (*ListBoardingSweepsResponse) ProtoMessage() {}
 
 func (x *ListBoardingSweepsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[60]
+	mi := &file_daemon_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5054,7 +5183,7 @@ func (x *ListBoardingSweepsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBoardingSweepsResponse.ProtoReflect.Descriptor instead.
 func (*ListBoardingSweepsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{60}
+	return file_daemon_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *ListBoardingSweepsResponse) GetSweeps() []*BoardingSweep {
@@ -5084,7 +5213,7 @@ type RoundVTXOInfo struct {
 
 func (x *RoundVTXOInfo) Reset() {
 	*x = RoundVTXOInfo{}
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5096,7 +5225,7 @@ func (x *RoundVTXOInfo) String() string {
 func (*RoundVTXOInfo) ProtoMessage() {}
 
 func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[61]
+	mi := &file_daemon_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5109,7 +5238,7 @@ func (x *RoundVTXOInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundVTXOInfo.ProtoReflect.Descriptor instead.
 func (*RoundVTXOInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{61}
+	return file_daemon_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *RoundVTXOInfo) GetOutpoint() string {
@@ -5177,7 +5306,7 @@ type RoundInfo struct {
 
 func (x *RoundInfo) Reset() {
 	*x = RoundInfo{}
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5189,7 +5318,7 @@ func (x *RoundInfo) String() string {
 func (*RoundInfo) ProtoMessage() {}
 
 func (x *RoundInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[62]
+	mi := &file_daemon_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5202,7 +5331,7 @@ func (x *RoundInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoundInfo.ProtoReflect.Descriptor instead.
 func (*RoundInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{62}
+	return file_daemon_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *RoundInfo) GetRoundId() string {
@@ -5314,7 +5443,7 @@ type ListRoundsRequest struct {
 
 func (x *ListRoundsRequest) Reset() {
 	*x = ListRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5326,7 +5455,7 @@ func (x *ListRoundsRequest) String() string {
 func (*ListRoundsRequest) ProtoMessage() {}
 
 func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[63]
+	mi := &file_daemon_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5339,7 +5468,7 @@ func (x *ListRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsRequest.ProtoReflect.Descriptor instead.
 func (*ListRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{63}
+	return file_daemon_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ListRoundsRequest) GetPageSize() int32 {
@@ -5394,7 +5523,7 @@ type GetRoundRequest struct {
 
 func (x *GetRoundRequest) Reset() {
 	*x = GetRoundRequest{}
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5406,7 +5535,7 @@ func (x *GetRoundRequest) String() string {
 func (*GetRoundRequest) ProtoMessage() {}
 
 func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[64]
+	mi := &file_daemon_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5419,7 +5548,7 @@ func (x *GetRoundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundRequest.ProtoReflect.Descriptor instead.
 func (*GetRoundRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{64}
+	return file_daemon_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *GetRoundRequest) GetRoundId() string {
@@ -5439,7 +5568,7 @@ type GetRoundResponse struct {
 
 func (x *GetRoundResponse) Reset() {
 	*x = GetRoundResponse{}
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5451,7 +5580,7 @@ func (x *GetRoundResponse) String() string {
 func (*GetRoundResponse) ProtoMessage() {}
 
 func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[65]
+	mi := &file_daemon_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5464,7 +5593,7 @@ func (x *GetRoundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoundResponse.ProtoReflect.Descriptor instead.
 func (*GetRoundResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{65}
+	return file_daemon_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *GetRoundResponse) GetRound() *RoundInfo {
@@ -5487,7 +5616,7 @@ type ListRoundsResponse struct {
 
 func (x *ListRoundsResponse) Reset() {
 	*x = ListRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[66]
+	mi := &file_daemon_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5499,7 +5628,7 @@ func (x *ListRoundsResponse) String() string {
 func (*ListRoundsResponse) ProtoMessage() {}
 
 func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[66]
+	mi := &file_daemon_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5512,7 +5641,7 @@ func (x *ListRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoundsResponse.ProtoReflect.Descriptor instead.
 func (*ListRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{66}
+	return file_daemon_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *ListRoundsResponse) GetRounds() []*RoundInfo {
@@ -5537,7 +5666,7 @@ type WatchRoundsRequest struct {
 
 func (x *WatchRoundsRequest) Reset() {
 	*x = WatchRoundsRequest{}
-	mi := &file_daemon_proto_msgTypes[67]
+	mi := &file_daemon_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5549,7 +5678,7 @@ func (x *WatchRoundsRequest) String() string {
 func (*WatchRoundsRequest) ProtoMessage() {}
 
 func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[67]
+	mi := &file_daemon_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5562,7 +5691,7 @@ func (x *WatchRoundsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsRequest.ProtoReflect.Descriptor instead.
 func (*WatchRoundsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{67}
+	return file_daemon_proto_rawDescGZIP(), []int{69}
 }
 
 type WatchRoundsResponse struct {
@@ -5576,7 +5705,7 @@ type WatchRoundsResponse struct {
 
 func (x *WatchRoundsResponse) Reset() {
 	*x = WatchRoundsResponse{}
-	mi := &file_daemon_proto_msgTypes[68]
+	mi := &file_daemon_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5588,7 +5717,7 @@ func (x *WatchRoundsResponse) String() string {
 func (*WatchRoundsResponse) ProtoMessage() {}
 
 func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[68]
+	mi := &file_daemon_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5601,7 +5730,7 @@ func (x *WatchRoundsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRoundsResponse.ProtoReflect.Descriptor instead.
 func (*WatchRoundsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{68}
+	return file_daemon_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *WatchRoundsResponse) GetRound() *RoundInfo {
@@ -5639,7 +5768,7 @@ type OORSessionInfo struct {
 
 func (x *OORSessionInfo) Reset() {
 	*x = OORSessionInfo{}
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5651,7 +5780,7 @@ func (x *OORSessionInfo) String() string {
 func (*OORSessionInfo) ProtoMessage() {}
 
 func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[69]
+	mi := &file_daemon_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5664,7 +5793,7 @@ func (x *OORSessionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OORSessionInfo.ProtoReflect.Descriptor instead.
 func (*OORSessionInfo) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{69}
+	return file_daemon_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *OORSessionInfo) GetSessionId() string {
@@ -5748,7 +5877,7 @@ type ListOORSessionsRequest struct {
 
 func (x *ListOORSessionsRequest) Reset() {
 	*x = ListOORSessionsRequest{}
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5760,7 +5889,7 @@ func (x *ListOORSessionsRequest) String() string {
 func (*ListOORSessionsRequest) ProtoMessage() {}
 
 func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[70]
+	mi := &file_daemon_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5773,7 +5902,7 @@ func (x *ListOORSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{70}
+	return file_daemon_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *ListOORSessionsRequest) GetPageSize() int32 {
@@ -5817,7 +5946,7 @@ type ListOORSessionsResponse struct {
 
 func (x *ListOORSessionsResponse) Reset() {
 	*x = ListOORSessionsResponse{}
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5829,7 +5958,7 @@ func (x *ListOORSessionsResponse) String() string {
 func (*ListOORSessionsResponse) ProtoMessage() {}
 
 func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[71]
+	mi := &file_daemon_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5842,7 +5971,7 @@ func (x *ListOORSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOORSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ListOORSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{71}
+	return file_daemon_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *ListOORSessionsResponse) GetSessions() []*OORSessionInfo {
@@ -5869,7 +5998,7 @@ type GetOORSessionRequest struct {
 
 func (x *GetOORSessionRequest) Reset() {
 	*x = GetOORSessionRequest{}
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5881,7 +6010,7 @@ func (x *GetOORSessionRequest) String() string {
 func (*GetOORSessionRequest) ProtoMessage() {}
 
 func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[72]
+	mi := &file_daemon_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5894,7 +6023,7 @@ func (x *GetOORSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionRequest.ProtoReflect.Descriptor instead.
 func (*GetOORSessionRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{72}
+	return file_daemon_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *GetOORSessionRequest) GetSessionId() string {
@@ -5914,7 +6043,7 @@ type GetOORSessionResponse struct {
 
 func (x *GetOORSessionResponse) Reset() {
 	*x = GetOORSessionResponse{}
-	mi := &file_daemon_proto_msgTypes[73]
+	mi := &file_daemon_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5926,7 +6055,7 @@ func (x *GetOORSessionResponse) String() string {
 func (*GetOORSessionResponse) ProtoMessage() {}
 
 func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[73]
+	mi := &file_daemon_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5939,7 +6068,7 @@ func (x *GetOORSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionResponse.ProtoReflect.Descriptor instead.
 func (*GetOORSessionResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{73}
+	return file_daemon_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *GetOORSessionResponse) GetSession() *OORSessionInfo {
@@ -5967,7 +6096,7 @@ type EstimateFeeRequest struct {
 
 func (x *EstimateFeeRequest) Reset() {
 	*x = EstimateFeeRequest{}
-	mi := &file_daemon_proto_msgTypes[74]
+	mi := &file_daemon_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5979,7 +6108,7 @@ func (x *EstimateFeeRequest) String() string {
 func (*EstimateFeeRequest) ProtoMessage() {}
 
 func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[74]
+	mi := &file_daemon_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5992,7 +6121,7 @@ func (x *EstimateFeeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeRequest.ProtoReflect.Descriptor instead.
 func (*EstimateFeeRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{74}
+	return file_daemon_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *EstimateFeeRequest) GetAmountSat() int64 {
@@ -6046,7 +6175,7 @@ type EstimateFeeResponse struct {
 
 func (x *EstimateFeeResponse) Reset() {
 	*x = EstimateFeeResponse{}
-	mi := &file_daemon_proto_msgTypes[75]
+	mi := &file_daemon_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6058,7 +6187,7 @@ func (x *EstimateFeeResponse) String() string {
 func (*EstimateFeeResponse) ProtoMessage() {}
 
 func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[75]
+	mi := &file_daemon_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6071,7 +6200,7 @@ func (x *EstimateFeeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EstimateFeeResponse.ProtoReflect.Descriptor instead.
 func (*EstimateFeeResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{75}
+	return file_daemon_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *EstimateFeeResponse) GetLiquidityFeeSat() int64 {
@@ -6141,7 +6270,7 @@ type GetFeeHistoryRequest struct {
 
 func (x *GetFeeHistoryRequest) Reset() {
 	*x = GetFeeHistoryRequest{}
-	mi := &file_daemon_proto_msgTypes[76]
+	mi := &file_daemon_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6153,7 +6282,7 @@ func (x *GetFeeHistoryRequest) String() string {
 func (*GetFeeHistoryRequest) ProtoMessage() {}
 
 func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[76]
+	mi := &file_daemon_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6166,7 +6295,7 @@ func (x *GetFeeHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryRequest.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{76}
+	return file_daemon_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *GetFeeHistoryRequest) GetLimit() uint32 {
@@ -6241,7 +6370,7 @@ type FeeHistoryEntry struct {
 
 func (x *FeeHistoryEntry) Reset() {
 	*x = FeeHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[77]
+	mi := &file_daemon_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6253,7 +6382,7 @@ func (x *FeeHistoryEntry) String() string {
 func (*FeeHistoryEntry) ProtoMessage() {}
 
 func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[77]
+	mi := &file_daemon_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6266,7 +6395,7 @@ func (x *FeeHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FeeHistoryEntry.ProtoReflect.Descriptor instead.
 func (*FeeHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{77}
+	return file_daemon_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *FeeHistoryEntry) GetEntryId() int64 {
@@ -6346,7 +6475,7 @@ type GetFeeHistoryResponse struct {
 
 func (x *GetFeeHistoryResponse) Reset() {
 	*x = GetFeeHistoryResponse{}
-	mi := &file_daemon_proto_msgTypes[78]
+	mi := &file_daemon_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6358,7 +6487,7 @@ func (x *GetFeeHistoryResponse) String() string {
 func (*GetFeeHistoryResponse) ProtoMessage() {}
 
 func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[78]
+	mi := &file_daemon_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6371,7 +6500,7 @@ func (x *GetFeeHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFeeHistoryResponse.ProtoReflect.Descriptor instead.
 func (*GetFeeHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{78}
+	return file_daemon_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *GetFeeHistoryResponse) GetEntries() []*FeeHistoryEntry {
@@ -6412,7 +6541,7 @@ type ListTransactionsRequest struct {
 
 func (x *ListTransactionsRequest) Reset() {
 	*x = ListTransactionsRequest{}
-	mi := &file_daemon_proto_msgTypes[79]
+	mi := &file_daemon_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6424,7 +6553,7 @@ func (x *ListTransactionsRequest) String() string {
 func (*ListTransactionsRequest) ProtoMessage() {}
 
 func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[79]
+	mi := &file_daemon_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6437,7 +6566,7 @@ func (x *ListTransactionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsRequest.ProtoReflect.Descriptor instead.
 func (*ListTransactionsRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{79}
+	return file_daemon_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *ListTransactionsRequest) GetFromUnixS() int64 {
@@ -6523,7 +6652,7 @@ type TransactionHistoryEntry struct {
 
 func (x *TransactionHistoryEntry) Reset() {
 	*x = TransactionHistoryEntry{}
-	mi := &file_daemon_proto_msgTypes[80]
+	mi := &file_daemon_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6535,7 +6664,7 @@ func (x *TransactionHistoryEntry) String() string {
 func (*TransactionHistoryEntry) ProtoMessage() {}
 
 func (x *TransactionHistoryEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[80]
+	mi := &file_daemon_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6548,7 +6677,7 @@ func (x *TransactionHistoryEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionHistoryEntry.ProtoReflect.Descriptor instead.
 func (*TransactionHistoryEntry) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{80}
+	return file_daemon_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *TransactionHistoryEntry) GetSource() string {
@@ -6678,7 +6807,7 @@ type ListTransactionsResponse struct {
 
 func (x *ListTransactionsResponse) Reset() {
 	*x = ListTransactionsResponse{}
-	mi := &file_daemon_proto_msgTypes[81]
+	mi := &file_daemon_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6690,7 +6819,7 @@ func (x *ListTransactionsResponse) String() string {
 func (*ListTransactionsResponse) ProtoMessage() {}
 
 func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[81]
+	mi := &file_daemon_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6703,7 +6832,7 @@ func (x *ListTransactionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransactionsResponse.ProtoReflect.Descriptor instead.
 func (*ListTransactionsResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{81}
+	return file_daemon_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *ListTransactionsResponse) GetTransactions() []*TransactionHistoryEntry {
@@ -6738,7 +6867,7 @@ type UnrollRequest struct {
 
 func (x *UnrollRequest) Reset() {
 	*x = UnrollRequest{}
-	mi := &file_daemon_proto_msgTypes[82]
+	mi := &file_daemon_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6750,7 +6879,7 @@ func (x *UnrollRequest) String() string {
 func (*UnrollRequest) ProtoMessage() {}
 
 func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[82]
+	mi := &file_daemon_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6763,7 +6892,7 @@ func (x *UnrollRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollRequest.ProtoReflect.Descriptor instead.
 func (*UnrollRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{82}
+	return file_daemon_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *UnrollRequest) GetOutpoint() string {
@@ -6786,7 +6915,7 @@ type UnrollResponse struct {
 
 func (x *UnrollResponse) Reset() {
 	*x = UnrollResponse{}
-	mi := &file_daemon_proto_msgTypes[83]
+	mi := &file_daemon_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6798,7 +6927,7 @@ func (x *UnrollResponse) String() string {
 func (*UnrollResponse) ProtoMessage() {}
 
 func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[83]
+	mi := &file_daemon_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6811,7 +6940,7 @@ func (x *UnrollResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrollResponse.ProtoReflect.Descriptor instead.
 func (*UnrollResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{83}
+	return file_daemon_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *UnrollResponse) GetCreated() bool {
@@ -6838,7 +6967,7 @@ type GetUnrollStatusRequest struct {
 
 func (x *GetUnrollStatusRequest) Reset() {
 	*x = GetUnrollStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[84]
+	mi := &file_daemon_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6850,7 +6979,7 @@ func (x *GetUnrollStatusRequest) String() string {
 func (*GetUnrollStatusRequest) ProtoMessage() {}
 
 func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[84]
+	mi := &file_daemon_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6863,7 +6992,7 @@ func (x *GetUnrollStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{84}
+	return file_daemon_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *GetUnrollStatusRequest) GetOutpoint() string {
@@ -6891,7 +7020,7 @@ type GetUnrollStatusResponse struct {
 
 func (x *GetUnrollStatusResponse) Reset() {
 	*x = GetUnrollStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[85]
+	mi := &file_daemon_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6903,7 +7032,7 @@ func (x *GetUnrollStatusResponse) String() string {
 func (*GetUnrollStatusResponse) ProtoMessage() {}
 
 func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[85]
+	mi := &file_daemon_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6916,7 +7045,7 @@ func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{85}
+	return file_daemon_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *GetUnrollStatusResponse) GetFound() bool {
@@ -6998,7 +7127,7 @@ type ArmVHTLCRecoveryRequest struct {
 
 func (x *ArmVHTLCRecoveryRequest) Reset() {
 	*x = ArmVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[86]
+	mi := &file_daemon_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7010,7 +7139,7 @@ func (x *ArmVHTLCRecoveryRequest) String() string {
 func (*ArmVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[86]
+	mi := &file_daemon_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7023,7 +7152,7 @@ func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{86}
+	return file_daemon_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *ArmVHTLCRecoveryRequest) GetRequestId() string {
@@ -7166,7 +7295,7 @@ type ArmVHTLCRecoveryResponse struct {
 
 func (x *ArmVHTLCRecoveryResponse) Reset() {
 	*x = ArmVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[87]
+	mi := &file_daemon_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7178,7 +7307,7 @@ func (x *ArmVHTLCRecoveryResponse) String() string {
 func (*ArmVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[87]
+	mi := &file_daemon_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7191,7 +7320,7 @@ func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{87}
+	return file_daemon_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *ArmVHTLCRecoveryResponse) GetRecoveryId() string {
@@ -7231,7 +7360,7 @@ type EscalateVHTLCRecoveryRequest struct {
 
 func (x *EscalateVHTLCRecoveryRequest) Reset() {
 	*x = EscalateVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[88]
+	mi := &file_daemon_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7243,7 +7372,7 @@ func (x *EscalateVHTLCRecoveryRequest) String() string {
 func (*EscalateVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[88]
+	mi := &file_daemon_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7256,7 +7385,7 @@ func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{88}
+	return file_daemon_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *EscalateVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -7290,7 +7419,7 @@ type EscalateVHTLCRecoveryResponse struct {
 
 func (x *EscalateVHTLCRecoveryResponse) Reset() {
 	*x = EscalateVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[89]
+	mi := &file_daemon_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7302,7 +7431,7 @@ func (x *EscalateVHTLCRecoveryResponse) String() string {
 func (*EscalateVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[89]
+	mi := &file_daemon_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7315,7 +7444,7 @@ func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{89}
+	return file_daemon_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *EscalateVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -7339,7 +7468,7 @@ type CancelVHTLCRecoveryRequest struct {
 
 func (x *CancelVHTLCRecoveryRequest) Reset() {
 	*x = CancelVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[90]
+	mi := &file_daemon_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7351,7 +7480,7 @@ func (x *CancelVHTLCRecoveryRequest) String() string {
 func (*CancelVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[90]
+	mi := &file_daemon_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7364,7 +7493,7 @@ func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{90}
+	return file_daemon_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *CancelVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -7398,7 +7527,7 @@ type CancelVHTLCRecoveryResponse struct {
 
 func (x *CancelVHTLCRecoveryResponse) Reset() {
 	*x = CancelVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[91]
+	mi := &file_daemon_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7410,7 +7539,7 @@ func (x *CancelVHTLCRecoveryResponse) String() string {
 func (*CancelVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[91]
+	mi := &file_daemon_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7423,7 +7552,7 @@ func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{91}
+	return file_daemon_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *CancelVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -7443,7 +7572,7 @@ type GetVHTLCRecoveryStatusRequest struct {
 
 func (x *GetVHTLCRecoveryStatusRequest) Reset() {
 	*x = GetVHTLCRecoveryStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[92]
+	mi := &file_daemon_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7455,7 +7584,7 @@ func (x *GetVHTLCRecoveryStatusRequest) String() string {
 func (*GetVHTLCRecoveryStatusRequest) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[92]
+	mi := &file_daemon_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7468,7 +7597,7 @@ func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{92}
+	return file_daemon_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *GetVHTLCRecoveryStatusRequest) GetRecoveryId() string {
@@ -7490,7 +7619,7 @@ type GetVHTLCRecoveryStatusResponse struct {
 
 func (x *GetVHTLCRecoveryStatusResponse) Reset() {
 	*x = GetVHTLCRecoveryStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[93]
+	mi := &file_daemon_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7502,7 +7631,7 @@ func (x *GetVHTLCRecoveryStatusResponse) String() string {
 func (*GetVHTLCRecoveryStatusResponse) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[93]
+	mi := &file_daemon_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7515,7 +7644,7 @@ func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{93}
+	return file_daemon_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *GetVHTLCRecoveryStatusResponse) GetFound() bool {
@@ -7542,7 +7671,7 @@ type ListVHTLCRecoveriesRequest struct {
 
 func (x *ListVHTLCRecoveriesRequest) Reset() {
 	*x = ListVHTLCRecoveriesRequest{}
-	mi := &file_daemon_proto_msgTypes[94]
+	mi := &file_daemon_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7554,7 +7683,7 @@ func (x *ListVHTLCRecoveriesRequest) String() string {
 func (*ListVHTLCRecoveriesRequest) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[94]
+	mi := &file_daemon_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7567,7 +7696,7 @@ func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesRequest.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{94}
+	return file_daemon_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *ListVHTLCRecoveriesRequest) GetIncludeTerminal() bool {
@@ -7587,7 +7716,7 @@ type ListVHTLCRecoveriesResponse struct {
 
 func (x *ListVHTLCRecoveriesResponse) Reset() {
 	*x = ListVHTLCRecoveriesResponse{}
-	mi := &file_daemon_proto_msgTypes[95]
+	mi := &file_daemon_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7599,7 +7728,7 @@ func (x *ListVHTLCRecoveriesResponse) String() string {
 func (*ListVHTLCRecoveriesResponse) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[95]
+	mi := &file_daemon_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7612,7 +7741,7 @@ func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesResponse.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{95}
+	return file_daemon_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *ListVHTLCRecoveriesResponse) GetStatuses() []*VHTLCRecoveryStatus {
@@ -7687,7 +7816,7 @@ type VHTLCRecoveryStatus struct {
 
 func (x *VHTLCRecoveryStatus) Reset() {
 	*x = VHTLCRecoveryStatus{}
-	mi := &file_daemon_proto_msgTypes[96]
+	mi := &file_daemon_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7699,7 +7828,7 @@ func (x *VHTLCRecoveryStatus) String() string {
 func (*VHTLCRecoveryStatus) ProtoMessage() {}
 
 func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[96]
+	mi := &file_daemon_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7712,7 +7841,7 @@ func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VHTLCRecoveryStatus.ProtoReflect.Descriptor instead.
 func (*VHTLCRecoveryStatus) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{96}
+	return file_daemon_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *VHTLCRecoveryStatus) GetRecoveryId() string {
@@ -7934,7 +8063,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0fwallet_password\x18\x02 \x01(\fR\x0ewalletPassword\x12'\n" +
 	"\x0fseed_passphrase\x18\x03 \x01(\fR\x0eseedPassphrase\x12#\n" +
 	"\rrecover_state\x18\x04 \x01(\bR\frecoverState\x12'\n" +
-	"\x0frecovery_window\x18\x05 \x01(\rR\x0erecoveryWindow\"\xfa\x02\n" +
+	"\x0frecovery_window\x18\x05 \x01(\rR\x0erecoveryWindow\"\x93\x04\n" +
 	"\x12InitWalletResponse\x12'\n" +
 	"\x0fidentity_pubkey\x18\x01 \x01(\tR\x0eidentityPubkey\x12!\n" +
 	"\frecovery_ran\x18\x02 \x01(\bR\vrecoveryRan\x12@\n" +
@@ -7942,7 +8071,11 @@ const file_daemon_proto_rawDesc = "" +
 	"\x18recovered_boarding_utxos\x18\x04 \x01(\rR\x16recoveredBoardingUtxos\x12'\n" +
 	"\x0frecovered_vtxos\x18\x05 \x01(\rR\x0erecoveredVtxos\x12A\n" +
 	"\x1drecovered_oor_receive_scripts\x18\x06 \x01(\rR\x1arecoveredOorReceiveScripts\x120\n" +
-	"\x14recovered_oor_events\x18\a \x01(\rR\x12recoveredOorEvents\">\n" +
+	"\x14recovered_oor_events\x18\a \x01(\rR\x12recoveredOorEvents\x12)\n" +
+	"\x10recovered_vhtlcs\x18\b \x01(\rR\x0frecoveredVhtlcs\x126\n" +
+	"\x17recovered_vhtlc_refunds\x18\t \x01(\rR\x15recoveredVhtlcRefunds\x124\n" +
+	"\x16recovered_vhtlc_claims\x18\n" +
+	" \x01(\rR\x14recoveredVhtlcClaims\">\n" +
 	"\x13UnlockWalletRequest\x12'\n" +
 	"\x0fwallet_password\x18\x01 \x01(\fR\x0ewalletPassword\"?\n" +
 	"\x14UnlockWalletResponse\x12'\n" +
@@ -8008,6 +8141,11 @@ const file_daemon_proto_rawDesc = "" +
 	"\vdouble_hash\x18\x03 \x01(\bR\n" +
 	"doubleHash\"E\n" +
 	"%SignReceiveAuthMessageCompactResponse\x12\x1c\n" +
+	"\tsignature\x18\x01 \x01(\fR\tsignature\"H\n" +
+	"\x1aSignIdentitySchnorrRequest\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\fR\amessage\x12\x10\n" +
+	"\x03tag\x18\x02 \x01(\fR\x03tag\";\n" +
+	"\x1bSignIdentitySchnorrResponse\x12\x1c\n" +
 	"\tsignature\x18\x01 \x01(\fR\tsignature\"S\n" +
 	"\x16ReceiveAuthECDHRequest\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x16\n" +
@@ -8496,7 +8634,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1eVHTLC_RECOVERY_STATE_COMPLETED\x10\t\x12\"\n" +
 	"\x1eVHTLC_RECOVERY_STATE_CANCELLED\x10\n" +
 	"\x12\x1f\n" +
-	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\x9e\x1b\n" +
+	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\x84\x1c\n" +
 	"\rDaemonService\x12@\n" +
 	"\aGetInfo\x12\x19.daemonrpc.GetInfoRequest\x1a\x1a.daemonrpc.GetInfoResponse\x12@\n" +
 	"\aGenSeed\x12\x19.daemonrpc.GenSeedRequest\x1a\x1a.daemonrpc.GenSeedResponse\x12I\n" +
@@ -8511,7 +8649,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\x10NewReceiveScript\x12\".daemonrpc.NewReceiveScriptRequest\x1a#.daemonrpc.NewReceiveScriptResponse\x12U\n" +
 	"\x0eReceiveAuthKey\x12 .daemonrpc.ReceiveAuthKeyRequest\x1a!.daemonrpc.ReceiveAuthKeyResponse\x12m\n" +
 	"\x16SignReceiveAuthMessage\x12(.daemonrpc.SignReceiveAuthMessageRequest\x1a).daemonrpc.SignReceiveAuthMessageResponse\x12\x82\x01\n" +
-	"\x1dSignReceiveAuthMessageCompact\x12/.daemonrpc.SignReceiveAuthMessageCompactRequest\x1a0.daemonrpc.SignReceiveAuthMessageCompactResponse\x12X\n" +
+	"\x1dSignReceiveAuthMessageCompact\x12/.daemonrpc.SignReceiveAuthMessageCompactRequest\x1a0.daemonrpc.SignReceiveAuthMessageCompactResponse\x12d\n" +
+	"\x13SignIdentitySchnorr\x12%.daemonrpc.SignIdentitySchnorrRequest\x1a&.daemonrpc.SignIdentitySchnorrResponse\x12X\n" +
 	"\x0fReceiveAuthECDH\x12!.daemonrpc.ReceiveAuthECDHRequest\x1a\".daemonrpc.ReceiveAuthECDHResponse\x12s\n" +
 	"\x18GetIndexedVTXOByPkScript\x12*.daemonrpc.GetIndexedVTXOByPkScriptRequest\x1a+.daemonrpc.GetIndexedVTXOByPkScriptResponse\x12y\n" +
 	"\x1aGetIndexedOORSessionByTxid\x12,.daemonrpc.GetIndexedOORSessionByTxidRequest\x1a-.daemonrpc.GetIndexedOORSessionByTxidResponse\x12C\n" +
@@ -8558,7 +8697,7 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 98)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 100)
 var file_daemon_proto_goTypes = []any{
 	(WalletState)(0),                              // 0: daemonrpc.WalletState
 	(VTXOStatus)(0),                               // 1: daemonrpc.VTXOStatus
@@ -8593,80 +8732,82 @@ var file_daemon_proto_goTypes = []any{
 	(*SignReceiveAuthMessageResponse)(nil),        // 30: daemonrpc.SignReceiveAuthMessageResponse
 	(*SignReceiveAuthMessageCompactRequest)(nil),  // 31: daemonrpc.SignReceiveAuthMessageCompactRequest
 	(*SignReceiveAuthMessageCompactResponse)(nil), // 32: daemonrpc.SignReceiveAuthMessageCompactResponse
-	(*ReceiveAuthECDHRequest)(nil),                // 33: daemonrpc.ReceiveAuthECDHRequest
-	(*ReceiveAuthECDHResponse)(nil),               // 34: daemonrpc.ReceiveAuthECDHResponse
-	(*GetIndexedVTXOByPkScriptRequest)(nil),       // 35: daemonrpc.GetIndexedVTXOByPkScriptRequest
-	(*GetIndexedVTXOByPkScriptResponse)(nil),      // 36: daemonrpc.GetIndexedVTXOByPkScriptResponse
-	(*GetIndexedOORSessionByTxidRequest)(nil),     // 37: daemonrpc.GetIndexedOORSessionByTxidRequest
-	(*GetIndexedOORSessionByTxidResponse)(nil),    // 38: daemonrpc.GetIndexedOORSessionByTxidResponse
-	(*Output)(nil),                                // 39: daemonrpc.Output
-	(*SendVTXORequest)(nil),                       // 40: daemonrpc.SendVTXORequest
-	(*SendVTXOResponse)(nil),                      // 41: daemonrpc.SendVTXOResponse
-	(*SendOORRequest)(nil),                        // 42: daemonrpc.SendOORRequest
-	(*CustomOORInput)(nil),                        // 43: daemonrpc.CustomOORInput
-	(*TaprootScriptSignature)(nil),                // 44: daemonrpc.TaprootScriptSignature
-	(*SendOORResponse)(nil),                       // 45: daemonrpc.SendOORResponse
-	(*PrepareOORRequest)(nil),                     // 46: daemonrpc.PrepareOORRequest
-	(*PreparedOORCustomInput)(nil),                // 47: daemonrpc.PreparedOORCustomInput
-	(*PrepareOORResponse)(nil),                    // 48: daemonrpc.PrepareOORResponse
-	(*SignOORCustomInputRequest)(nil),             // 49: daemonrpc.SignOORCustomInputRequest
-	(*SignOORCustomInputResponse)(nil),            // 50: daemonrpc.SignOORCustomInputResponse
-	(*OutpointSelection)(nil),                     // 51: daemonrpc.OutpointSelection
-	(*RefreshVTXOsRequest)(nil),                   // 52: daemonrpc.RefreshVTXOsRequest
-	(*RefreshVTXOsResponse)(nil),                  // 53: daemonrpc.RefreshVTXOsResponse
-	(*LeaveDestination)(nil),                      // 54: daemonrpc.LeaveDestination
-	(*LeaveVTXOsRequest)(nil),                     // 55: daemonrpc.LeaveVTXOsRequest
-	(*LeaveVTXOsResponse)(nil),                    // 56: daemonrpc.LeaveVTXOsResponse
-	(*SendOnChainRequest)(nil),                    // 57: daemonrpc.SendOnChainRequest
-	(*SendOnChainResponse)(nil),                   // 58: daemonrpc.SendOnChainResponse
-	(*BoardRequest)(nil),                          // 59: daemonrpc.BoardRequest
-	(*BoardResponse)(nil),                         // 60: daemonrpc.BoardResponse
-	(*JoinNextRoundRequest)(nil),                  // 61: daemonrpc.JoinNextRoundRequest
-	(*JoinNextRoundResponse)(nil),                 // 62: daemonrpc.JoinNextRoundResponse
-	(*SweepBoardingUTXOsRequest)(nil),             // 63: daemonrpc.SweepBoardingUTXOsRequest
-	(*BoardingSweepOutput)(nil),                   // 64: daemonrpc.BoardingSweepOutput
-	(*SweepBoardingUTXOsResponse)(nil),            // 65: daemonrpc.SweepBoardingUTXOsResponse
-	(*ListBoardingSweepsRequest)(nil),             // 66: daemonrpc.ListBoardingSweepsRequest
-	(*BoardingSweepInput)(nil),                    // 67: daemonrpc.BoardingSweepInput
-	(*BoardingSweep)(nil),                         // 68: daemonrpc.BoardingSweep
-	(*ListBoardingSweepsResponse)(nil),            // 69: daemonrpc.ListBoardingSweepsResponse
-	(*RoundVTXOInfo)(nil),                         // 70: daemonrpc.RoundVTXOInfo
-	(*RoundInfo)(nil),                             // 71: daemonrpc.RoundInfo
-	(*ListRoundsRequest)(nil),                     // 72: daemonrpc.ListRoundsRequest
-	(*GetRoundRequest)(nil),                       // 73: daemonrpc.GetRoundRequest
-	(*GetRoundResponse)(nil),                      // 74: daemonrpc.GetRoundResponse
-	(*ListRoundsResponse)(nil),                    // 75: daemonrpc.ListRoundsResponse
-	(*WatchRoundsRequest)(nil),                    // 76: daemonrpc.WatchRoundsRequest
-	(*WatchRoundsResponse)(nil),                   // 77: daemonrpc.WatchRoundsResponse
-	(*OORSessionInfo)(nil),                        // 78: daemonrpc.OORSessionInfo
-	(*ListOORSessionsRequest)(nil),                // 79: daemonrpc.ListOORSessionsRequest
-	(*ListOORSessionsResponse)(nil),               // 80: daemonrpc.ListOORSessionsResponse
-	(*GetOORSessionRequest)(nil),                  // 81: daemonrpc.GetOORSessionRequest
-	(*GetOORSessionResponse)(nil),                 // 82: daemonrpc.GetOORSessionResponse
-	(*EstimateFeeRequest)(nil),                    // 83: daemonrpc.EstimateFeeRequest
-	(*EstimateFeeResponse)(nil),                   // 84: daemonrpc.EstimateFeeResponse
-	(*GetFeeHistoryRequest)(nil),                  // 85: daemonrpc.GetFeeHistoryRequest
-	(*FeeHistoryEntry)(nil),                       // 86: daemonrpc.FeeHistoryEntry
-	(*GetFeeHistoryResponse)(nil),                 // 87: daemonrpc.GetFeeHistoryResponse
-	(*ListTransactionsRequest)(nil),               // 88: daemonrpc.ListTransactionsRequest
-	(*TransactionHistoryEntry)(nil),               // 89: daemonrpc.TransactionHistoryEntry
-	(*ListTransactionsResponse)(nil),              // 90: daemonrpc.ListTransactionsResponse
-	(*UnrollRequest)(nil),                         // 91: daemonrpc.UnrollRequest
-	(*UnrollResponse)(nil),                        // 92: daemonrpc.UnrollResponse
-	(*GetUnrollStatusRequest)(nil),                // 93: daemonrpc.GetUnrollStatusRequest
-	(*GetUnrollStatusResponse)(nil),               // 94: daemonrpc.GetUnrollStatusResponse
-	(*ArmVHTLCRecoveryRequest)(nil),               // 95: daemonrpc.ArmVHTLCRecoveryRequest
-	(*ArmVHTLCRecoveryResponse)(nil),              // 96: daemonrpc.ArmVHTLCRecoveryResponse
-	(*EscalateVHTLCRecoveryRequest)(nil),          // 97: daemonrpc.EscalateVHTLCRecoveryRequest
-	(*EscalateVHTLCRecoveryResponse)(nil),         // 98: daemonrpc.EscalateVHTLCRecoveryResponse
-	(*CancelVHTLCRecoveryRequest)(nil),            // 99: daemonrpc.CancelVHTLCRecoveryRequest
-	(*CancelVHTLCRecoveryResponse)(nil),           // 100: daemonrpc.CancelVHTLCRecoveryResponse
-	(*GetVHTLCRecoveryStatusRequest)(nil),         // 101: daemonrpc.GetVHTLCRecoveryStatusRequest
-	(*GetVHTLCRecoveryStatusResponse)(nil),        // 102: daemonrpc.GetVHTLCRecoveryStatusResponse
-	(*ListVHTLCRecoveriesRequest)(nil),            // 103: daemonrpc.ListVHTLCRecoveriesRequest
-	(*ListVHTLCRecoveriesResponse)(nil),           // 104: daemonrpc.ListVHTLCRecoveriesResponse
-	(*VHTLCRecoveryStatus)(nil),                   // 105: daemonrpc.VHTLCRecoveryStatus
-	nil,                                           // 106: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	(*SignIdentitySchnorrRequest)(nil),            // 33: daemonrpc.SignIdentitySchnorrRequest
+	(*SignIdentitySchnorrResponse)(nil),           // 34: daemonrpc.SignIdentitySchnorrResponse
+	(*ReceiveAuthECDHRequest)(nil),                // 35: daemonrpc.ReceiveAuthECDHRequest
+	(*ReceiveAuthECDHResponse)(nil),               // 36: daemonrpc.ReceiveAuthECDHResponse
+	(*GetIndexedVTXOByPkScriptRequest)(nil),       // 37: daemonrpc.GetIndexedVTXOByPkScriptRequest
+	(*GetIndexedVTXOByPkScriptResponse)(nil),      // 38: daemonrpc.GetIndexedVTXOByPkScriptResponse
+	(*GetIndexedOORSessionByTxidRequest)(nil),     // 39: daemonrpc.GetIndexedOORSessionByTxidRequest
+	(*GetIndexedOORSessionByTxidResponse)(nil),    // 40: daemonrpc.GetIndexedOORSessionByTxidResponse
+	(*Output)(nil),                                // 41: daemonrpc.Output
+	(*SendVTXORequest)(nil),                       // 42: daemonrpc.SendVTXORequest
+	(*SendVTXOResponse)(nil),                      // 43: daemonrpc.SendVTXOResponse
+	(*SendOORRequest)(nil),                        // 44: daemonrpc.SendOORRequest
+	(*CustomOORInput)(nil),                        // 45: daemonrpc.CustomOORInput
+	(*TaprootScriptSignature)(nil),                // 46: daemonrpc.TaprootScriptSignature
+	(*SendOORResponse)(nil),                       // 47: daemonrpc.SendOORResponse
+	(*PrepareOORRequest)(nil),                     // 48: daemonrpc.PrepareOORRequest
+	(*PreparedOORCustomInput)(nil),                // 49: daemonrpc.PreparedOORCustomInput
+	(*PrepareOORResponse)(nil),                    // 50: daemonrpc.PrepareOORResponse
+	(*SignOORCustomInputRequest)(nil),             // 51: daemonrpc.SignOORCustomInputRequest
+	(*SignOORCustomInputResponse)(nil),            // 52: daemonrpc.SignOORCustomInputResponse
+	(*OutpointSelection)(nil),                     // 53: daemonrpc.OutpointSelection
+	(*RefreshVTXOsRequest)(nil),                   // 54: daemonrpc.RefreshVTXOsRequest
+	(*RefreshVTXOsResponse)(nil),                  // 55: daemonrpc.RefreshVTXOsResponse
+	(*LeaveDestination)(nil),                      // 56: daemonrpc.LeaveDestination
+	(*LeaveVTXOsRequest)(nil),                     // 57: daemonrpc.LeaveVTXOsRequest
+	(*LeaveVTXOsResponse)(nil),                    // 58: daemonrpc.LeaveVTXOsResponse
+	(*SendOnChainRequest)(nil),                    // 59: daemonrpc.SendOnChainRequest
+	(*SendOnChainResponse)(nil),                   // 60: daemonrpc.SendOnChainResponse
+	(*BoardRequest)(nil),                          // 61: daemonrpc.BoardRequest
+	(*BoardResponse)(nil),                         // 62: daemonrpc.BoardResponse
+	(*JoinNextRoundRequest)(nil),                  // 63: daemonrpc.JoinNextRoundRequest
+	(*JoinNextRoundResponse)(nil),                 // 64: daemonrpc.JoinNextRoundResponse
+	(*SweepBoardingUTXOsRequest)(nil),             // 65: daemonrpc.SweepBoardingUTXOsRequest
+	(*BoardingSweepOutput)(nil),                   // 66: daemonrpc.BoardingSweepOutput
+	(*SweepBoardingUTXOsResponse)(nil),            // 67: daemonrpc.SweepBoardingUTXOsResponse
+	(*ListBoardingSweepsRequest)(nil),             // 68: daemonrpc.ListBoardingSweepsRequest
+	(*BoardingSweepInput)(nil),                    // 69: daemonrpc.BoardingSweepInput
+	(*BoardingSweep)(nil),                         // 70: daemonrpc.BoardingSweep
+	(*ListBoardingSweepsResponse)(nil),            // 71: daemonrpc.ListBoardingSweepsResponse
+	(*RoundVTXOInfo)(nil),                         // 72: daemonrpc.RoundVTXOInfo
+	(*RoundInfo)(nil),                             // 73: daemonrpc.RoundInfo
+	(*ListRoundsRequest)(nil),                     // 74: daemonrpc.ListRoundsRequest
+	(*GetRoundRequest)(nil),                       // 75: daemonrpc.GetRoundRequest
+	(*GetRoundResponse)(nil),                      // 76: daemonrpc.GetRoundResponse
+	(*ListRoundsResponse)(nil),                    // 77: daemonrpc.ListRoundsResponse
+	(*WatchRoundsRequest)(nil),                    // 78: daemonrpc.WatchRoundsRequest
+	(*WatchRoundsResponse)(nil),                   // 79: daemonrpc.WatchRoundsResponse
+	(*OORSessionInfo)(nil),                        // 80: daemonrpc.OORSessionInfo
+	(*ListOORSessionsRequest)(nil),                // 81: daemonrpc.ListOORSessionsRequest
+	(*ListOORSessionsResponse)(nil),               // 82: daemonrpc.ListOORSessionsResponse
+	(*GetOORSessionRequest)(nil),                  // 83: daemonrpc.GetOORSessionRequest
+	(*GetOORSessionResponse)(nil),                 // 84: daemonrpc.GetOORSessionResponse
+	(*EstimateFeeRequest)(nil),                    // 85: daemonrpc.EstimateFeeRequest
+	(*EstimateFeeResponse)(nil),                   // 86: daemonrpc.EstimateFeeResponse
+	(*GetFeeHistoryRequest)(nil),                  // 87: daemonrpc.GetFeeHistoryRequest
+	(*FeeHistoryEntry)(nil),                       // 88: daemonrpc.FeeHistoryEntry
+	(*GetFeeHistoryResponse)(nil),                 // 89: daemonrpc.GetFeeHistoryResponse
+	(*ListTransactionsRequest)(nil),               // 90: daemonrpc.ListTransactionsRequest
+	(*TransactionHistoryEntry)(nil),               // 91: daemonrpc.TransactionHistoryEntry
+	(*ListTransactionsResponse)(nil),              // 92: daemonrpc.ListTransactionsResponse
+	(*UnrollRequest)(nil),                         // 93: daemonrpc.UnrollRequest
+	(*UnrollResponse)(nil),                        // 94: daemonrpc.UnrollResponse
+	(*GetUnrollStatusRequest)(nil),                // 95: daemonrpc.GetUnrollStatusRequest
+	(*GetUnrollStatusResponse)(nil),               // 96: daemonrpc.GetUnrollStatusResponse
+	(*ArmVHTLCRecoveryRequest)(nil),               // 97: daemonrpc.ArmVHTLCRecoveryRequest
+	(*ArmVHTLCRecoveryResponse)(nil),              // 98: daemonrpc.ArmVHTLCRecoveryResponse
+	(*EscalateVHTLCRecoveryRequest)(nil),          // 99: daemonrpc.EscalateVHTLCRecoveryRequest
+	(*EscalateVHTLCRecoveryResponse)(nil),         // 100: daemonrpc.EscalateVHTLCRecoveryResponse
+	(*CancelVHTLCRecoveryRequest)(nil),            // 101: daemonrpc.CancelVHTLCRecoveryRequest
+	(*CancelVHTLCRecoveryResponse)(nil),           // 102: daemonrpc.CancelVHTLCRecoveryResponse
+	(*GetVHTLCRecoveryStatusRequest)(nil),         // 103: daemonrpc.GetVHTLCRecoveryStatusRequest
+	(*GetVHTLCRecoveryStatusResponse)(nil),        // 104: daemonrpc.GetVHTLCRecoveryStatusResponse
+	(*ListVHTLCRecoveriesRequest)(nil),            // 105: daemonrpc.ListVHTLCRecoveriesRequest
+	(*ListVHTLCRecoveriesResponse)(nil),           // 106: daemonrpc.ListVHTLCRecoveriesResponse
+	(*VHTLCRecoveryStatus)(nil),                   // 107: daemonrpc.VHTLCRecoveryStatus
+	nil,                                           // 108: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
 	0,   // 0: daemonrpc.GetInfoResponse.wallet_state:type_name -> daemonrpc.WalletState
@@ -8676,50 +8817,50 @@ var file_daemon_proto_depIdxs = []int32{
 	20,  // 4: daemonrpc.ListVTXOsResponse.vtxos:type_name -> daemonrpc.VTXO
 	1,   // 5: daemonrpc.GetIndexedVTXOByPkScriptRequest.status_filter:type_name -> daemonrpc.VTXOStatus
 	20,  // 6: daemonrpc.GetIndexedVTXOByPkScriptResponse.vtxo:type_name -> daemonrpc.VTXO
-	39,  // 7: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
-	39,  // 8: daemonrpc.SendOORRequest.recipients:type_name -> daemonrpc.Output
-	43,  // 9: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
-	44,  // 10: daemonrpc.CustomOORInput.external_signatures:type_name -> daemonrpc.TaprootScriptSignature
-	39,  // 11: daemonrpc.PrepareOORRequest.recipient:type_name -> daemonrpc.Output
-	43,  // 12: daemonrpc.PrepareOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
-	47,  // 13: daemonrpc.PrepareOORResponse.custom_inputs:type_name -> daemonrpc.PreparedOORCustomInput
-	43,  // 14: daemonrpc.SignOORCustomInputRequest.custom_input:type_name -> daemonrpc.CustomOORInput
-	44,  // 15: daemonrpc.SignOORCustomInputResponse.signature:type_name -> daemonrpc.TaprootScriptSignature
-	51,  // 16: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
-	51,  // 17: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
-	54,  // 18: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
-	106, // 19: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
-	54,  // 20: daemonrpc.SendOnChainRequest.destination:type_name -> daemonrpc.LeaveDestination
-	64,  // 21: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
-	67,  // 22: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
-	68,  // 23: daemonrpc.ListBoardingSweepsResponse.sweeps:type_name -> daemonrpc.BoardingSweep
+	41,  // 7: daemonrpc.SendVTXORequest.recipients:type_name -> daemonrpc.Output
+	41,  // 8: daemonrpc.SendOORRequest.recipients:type_name -> daemonrpc.Output
+	45,  // 9: daemonrpc.SendOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
+	46,  // 10: daemonrpc.CustomOORInput.external_signatures:type_name -> daemonrpc.TaprootScriptSignature
+	41,  // 11: daemonrpc.PrepareOORRequest.recipient:type_name -> daemonrpc.Output
+	45,  // 12: daemonrpc.PrepareOORRequest.custom_inputs:type_name -> daemonrpc.CustomOORInput
+	49,  // 13: daemonrpc.PrepareOORResponse.custom_inputs:type_name -> daemonrpc.PreparedOORCustomInput
+	45,  // 14: daemonrpc.SignOORCustomInputRequest.custom_input:type_name -> daemonrpc.CustomOORInput
+	46,  // 15: daemonrpc.SignOORCustomInputResponse.signature:type_name -> daemonrpc.TaprootScriptSignature
+	53,  // 16: daemonrpc.RefreshVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	53,  // 17: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
+	56,  // 18: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
+	108, // 19: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	56,  // 20: daemonrpc.SendOnChainRequest.destination:type_name -> daemonrpc.LeaveDestination
+	66,  // 21: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
+	69,  // 22: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
+	70,  // 23: daemonrpc.ListBoardingSweepsResponse.sweeps:type_name -> daemonrpc.BoardingSweep
 	2,   // 24: daemonrpc.RoundInfo.state:type_name -> daemonrpc.RoundState
-	70,  // 25: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
+	72,  // 25: daemonrpc.RoundInfo.vtxos:type_name -> daemonrpc.RoundVTXOInfo
 	2,   // 26: daemonrpc.ListRoundsRequest.state_filter:type_name -> daemonrpc.RoundState
-	71,  // 27: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
-	71,  // 28: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
-	71,  // 29: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
+	73,  // 27: daemonrpc.GetRoundResponse.round:type_name -> daemonrpc.RoundInfo
+	73,  // 28: daemonrpc.ListRoundsResponse.rounds:type_name -> daemonrpc.RoundInfo
+	73,  // 29: daemonrpc.WatchRoundsResponse.round:type_name -> daemonrpc.RoundInfo
 	3,   // 30: daemonrpc.OORSessionInfo.direction:type_name -> daemonrpc.OORSessionDirection
 	4,   // 31: daemonrpc.OORSessionInfo.status:type_name -> daemonrpc.OORSessionStatus
 	3,   // 32: daemonrpc.ListOORSessionsRequest.direction_filter:type_name -> daemonrpc.OORSessionDirection
 	4,   // 33: daemonrpc.ListOORSessionsRequest.status_filter:type_name -> daemonrpc.OORSessionStatus
-	78,  // 34: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
-	78,  // 35: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
-	86,  // 36: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
-	89,  // 37: daemonrpc.ListTransactionsResponse.transactions:type_name -> daemonrpc.TransactionHistoryEntry
+	80,  // 34: daemonrpc.ListOORSessionsResponse.sessions:type_name -> daemonrpc.OORSessionInfo
+	80,  // 35: daemonrpc.GetOORSessionResponse.session:type_name -> daemonrpc.OORSessionInfo
+	88,  // 36: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
+	91,  // 37: daemonrpc.ListTransactionsResponse.transactions:type_name -> daemonrpc.TransactionHistoryEntry
 	5,   // 38: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
 	6,   // 39: daemonrpc.ArmVHTLCRecoveryRequest.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
 	7,   // 40: daemonrpc.ArmVHTLCRecoveryRequest.action:type_name -> daemonrpc.VHTLCRecoveryAction
-	105, // 41: daemonrpc.ArmVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	105, // 42: daemonrpc.EscalateVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	105, // 43: daemonrpc.CancelVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	105, // 44: daemonrpc.GetVHTLCRecoveryStatusResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	105, // 45: daemonrpc.ListVHTLCRecoveriesResponse.statuses:type_name -> daemonrpc.VHTLCRecoveryStatus
+	107, // 41: daemonrpc.ArmVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	107, // 42: daemonrpc.EscalateVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	107, // 43: daemonrpc.CancelVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	107, // 44: daemonrpc.GetVHTLCRecoveryStatusResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	107, // 45: daemonrpc.ListVHTLCRecoveriesResponse.statuses:type_name -> daemonrpc.VHTLCRecoveryStatus
 	6,   // 46: daemonrpc.VHTLCRecoveryStatus.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
 	7,   // 47: daemonrpc.VHTLCRecoveryStatus.action:type_name -> daemonrpc.VHTLCRecoveryAction
 	8,   // 48: daemonrpc.VHTLCRecoveryStatus.state:type_name -> daemonrpc.VHTLCRecoveryState
 	5,   // 49: daemonrpc.VHTLCRecoveryStatus.unroll_status:type_name -> daemonrpc.UnrollJobStatus
-	54,  // 50: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
+	56,  // 50: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
 	9,   // 51: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
 	12,  // 52: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
 	14,  // 53: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
@@ -8731,77 +8872,79 @@ var file_daemon_proto_depIdxs = []int32{
 	27,  // 59: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
 	29,  // 60: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
 	31,  // 61: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
-	33,  // 62: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
-	35,  // 63: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
-	37,  // 64: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
-	40,  // 65: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
-	42,  // 66: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
-	46,  // 67: daemonrpc.DaemonService.PrepareOOR:input_type -> daemonrpc.PrepareOORRequest
-	49,  // 68: daemonrpc.DaemonService.SignOORCustomInput:input_type -> daemonrpc.SignOORCustomInputRequest
-	52,  // 69: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
-	55,  // 70: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
-	57,  // 71: daemonrpc.DaemonService.SendOnChain:input_type -> daemonrpc.SendOnChainRequest
-	59,  // 72: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
-	61,  // 73: daemonrpc.DaemonService.JoinNextRound:input_type -> daemonrpc.JoinNextRoundRequest
-	63,  // 74: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
-	66,  // 75: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
-	72,  // 76: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
-	73,  // 77: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
-	76,  // 78: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
-	79,  // 79: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
-	81,  // 80: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
-	83,  // 81: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
-	85,  // 82: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
-	88,  // 83: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
-	91,  // 84: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
-	93,  // 85: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
-	95,  // 86: daemonrpc.DaemonService.ArmVHTLCRecovery:input_type -> daemonrpc.ArmVHTLCRecoveryRequest
-	97,  // 87: daemonrpc.DaemonService.EscalateVHTLCRecovery:input_type -> daemonrpc.EscalateVHTLCRecoveryRequest
-	99,  // 88: daemonrpc.DaemonService.CancelVHTLCRecovery:input_type -> daemonrpc.CancelVHTLCRecoveryRequest
-	101, // 89: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> daemonrpc.GetVHTLCRecoveryStatusRequest
-	103, // 90: daemonrpc.DaemonService.ListVHTLCRecoveries:input_type -> daemonrpc.ListVHTLCRecoveriesRequest
-	10,  // 91: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	13,  // 92: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	15,  // 93: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	17,  // 94: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	19,  // 95: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	22,  // 96: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	24,  // 97: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	26,  // 98: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
-	28,  // 99: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
-	30,  // 100: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
-	32,  // 101: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
-	34,  // 102: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
-	36,  // 103: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
-	38,  // 104: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
-	41,  // 105: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	45,  // 106: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	48,  // 107: daemonrpc.DaemonService.PrepareOOR:output_type -> daemonrpc.PrepareOORResponse
-	50,  // 108: daemonrpc.DaemonService.SignOORCustomInput:output_type -> daemonrpc.SignOORCustomInputResponse
-	53,  // 109: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	56,  // 110: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
-	58,  // 111: daemonrpc.DaemonService.SendOnChain:output_type -> daemonrpc.SendOnChainResponse
-	60,  // 112: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	62,  // 113: daemonrpc.DaemonService.JoinNextRound:output_type -> daemonrpc.JoinNextRoundResponse
-	65,  // 114: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
-	69,  // 115: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
-	75,  // 116: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	74,  // 117: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
-	77,  // 118: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	80,  // 119: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
-	82,  // 120: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
-	84,  // 121: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
-	87,  // 122: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
-	90,  // 123: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
-	92,  // 124: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
-	94,  // 125: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
-	96,  // 126: daemonrpc.DaemonService.ArmVHTLCRecovery:output_type -> daemonrpc.ArmVHTLCRecoveryResponse
-	98,  // 127: daemonrpc.DaemonService.EscalateVHTLCRecovery:output_type -> daemonrpc.EscalateVHTLCRecoveryResponse
-	100, // 128: daemonrpc.DaemonService.CancelVHTLCRecovery:output_type -> daemonrpc.CancelVHTLCRecoveryResponse
-	102, // 129: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> daemonrpc.GetVHTLCRecoveryStatusResponse
-	104, // 130: daemonrpc.DaemonService.ListVHTLCRecoveries:output_type -> daemonrpc.ListVHTLCRecoveriesResponse
-	91,  // [91:131] is the sub-list for method output_type
-	51,  // [51:91] is the sub-list for method input_type
+	33,  // 62: daemonrpc.DaemonService.SignIdentitySchnorr:input_type -> daemonrpc.SignIdentitySchnorrRequest
+	35,  // 63: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
+	37,  // 64: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
+	39,  // 65: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
+	42,  // 66: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	44,  // 67: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	48,  // 68: daemonrpc.DaemonService.PrepareOOR:input_type -> daemonrpc.PrepareOORRequest
+	51,  // 69: daemonrpc.DaemonService.SignOORCustomInput:input_type -> daemonrpc.SignOORCustomInputRequest
+	54,  // 70: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	57,  // 71: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
+	59,  // 72: daemonrpc.DaemonService.SendOnChain:input_type -> daemonrpc.SendOnChainRequest
+	61,  // 73: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
+	63,  // 74: daemonrpc.DaemonService.JoinNextRound:input_type -> daemonrpc.JoinNextRoundRequest
+	65,  // 75: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
+	68,  // 76: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
+	74,  // 77: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
+	75,  // 78: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
+	78,  // 79: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
+	81,  // 80: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
+	83,  // 81: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
+	85,  // 82: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
+	87,  // 83: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
+	90,  // 84: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
+	93,  // 85: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
+	95,  // 86: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
+	97,  // 87: daemonrpc.DaemonService.ArmVHTLCRecovery:input_type -> daemonrpc.ArmVHTLCRecoveryRequest
+	99,  // 88: daemonrpc.DaemonService.EscalateVHTLCRecovery:input_type -> daemonrpc.EscalateVHTLCRecoveryRequest
+	101, // 89: daemonrpc.DaemonService.CancelVHTLCRecovery:input_type -> daemonrpc.CancelVHTLCRecoveryRequest
+	103, // 90: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> daemonrpc.GetVHTLCRecoveryStatusRequest
+	105, // 91: daemonrpc.DaemonService.ListVHTLCRecoveries:input_type -> daemonrpc.ListVHTLCRecoveriesRequest
+	10,  // 92: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	13,  // 93: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	15,  // 94: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	17,  // 95: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	19,  // 96: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	22,  // 97: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	24,  // 98: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	26,  // 99: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
+	28,  // 100: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
+	30,  // 101: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
+	32,  // 102: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
+	34,  // 103: daemonrpc.DaemonService.SignIdentitySchnorr:output_type -> daemonrpc.SignIdentitySchnorrResponse
+	36,  // 104: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
+	38,  // 105: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
+	40,  // 106: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
+	43,  // 107: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	47,  // 108: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	50,  // 109: daemonrpc.DaemonService.PrepareOOR:output_type -> daemonrpc.PrepareOORResponse
+	52,  // 110: daemonrpc.DaemonService.SignOORCustomInput:output_type -> daemonrpc.SignOORCustomInputResponse
+	55,  // 111: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	58,  // 112: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
+	60,  // 113: daemonrpc.DaemonService.SendOnChain:output_type -> daemonrpc.SendOnChainResponse
+	62,  // 114: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	64,  // 115: daemonrpc.DaemonService.JoinNextRound:output_type -> daemonrpc.JoinNextRoundResponse
+	67,  // 116: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
+	71,  // 117: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
+	77,  // 118: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	76,  // 119: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
+	79,  // 120: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	82,  // 121: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
+	84,  // 122: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
+	86,  // 123: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
+	89,  // 124: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
+	92,  // 125: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
+	94,  // 126: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
+	96,  // 127: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
+	98,  // 128: daemonrpc.DaemonService.ArmVHTLCRecovery:output_type -> daemonrpc.ArmVHTLCRecoveryResponse
+	100, // 129: daemonrpc.DaemonService.EscalateVHTLCRecovery:output_type -> daemonrpc.EscalateVHTLCRecoveryResponse
+	102, // 130: daemonrpc.DaemonService.CancelVHTLCRecovery:output_type -> daemonrpc.CancelVHTLCRecoveryResponse
+	104, // 131: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> daemonrpc.GetVHTLCRecoveryStatusResponse
+	106, // 132: daemonrpc.DaemonService.ListVHTLCRecoveries:output_type -> daemonrpc.ListVHTLCRecoveriesResponse
+	92,  // [92:133] is the sub-list for method output_type
+	51,  // [51:92] is the sub-list for method input_type
 	51,  // [51:51] is the sub-list for extension type_name
 	51,  // [51:51] is the sub-list for extension extendee
 	0,   // [0:51] is the sub-list for field type_name
@@ -8812,24 +8955,24 @@ func file_daemon_proto_init() {
 	if File_daemon_proto != nil {
 		return
 	}
-	file_daemon_proto_msgTypes[30].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[32].OneofWrappers = []any{
 		(*Output_Address)(nil),
 		(*Output_Pubkey)(nil),
 		(*Output_PolicyTemplate)(nil),
 	}
-	file_daemon_proto_msgTypes[43].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[45].OneofWrappers = []any{
 		(*RefreshVTXOsRequest_Outpoints)(nil),
 		(*RefreshVTXOsRequest_All)(nil),
 	}
-	file_daemon_proto_msgTypes[45].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[47].OneofWrappers = []any{
 		(*LeaveDestination_Address)(nil),
 		(*LeaveDestination_PkScript)(nil),
 	}
-	file_daemon_proto_msgTypes[46].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[48].OneofWrappers = []any{
 		(*LeaveVTXOsRequest_Outpoints)(nil),
 		(*LeaveVTXOsRequest_All)(nil),
 	}
-	file_daemon_proto_msgTypes[48].OneofWrappers = []any{
+	file_daemon_proto_msgTypes[50].OneofWrappers = []any{
 		(*SendOnChainRequest_AmountSat)(nil),
 		(*SendOnChainRequest_SweepAll)(nil),
 	}
@@ -8839,7 +8982,7 @@ func file_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      9,
-			NumMessages:   98,
+			NumMessages:   100,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.pb.gw.go
+++ b/daemonrpc/daemon.pb.gw.go
@@ -332,6 +332,33 @@ func local_request_DaemonService_SignReceiveAuthMessageCompact_0(ctx context.Con
 	return msg, metadata, err
 }
 
+func request_DaemonService_SignIdentitySchnorr_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SignIdentitySchnorrRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.SignIdentitySchnorr(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_DaemonService_SignIdentitySchnorr_0(ctx context.Context, marshaler runtime.Marshaler, server DaemonServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SignIdentitySchnorrRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.SignIdentitySchnorr(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_DaemonService_ReceiveAuthECDH_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq ReceiveAuthECDHRequest
@@ -1337,6 +1364,26 @@ func RegisterDaemonServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_SignReceiveAuthMessageCompact_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_SignIdentitySchnorr_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/daemonrpc.DaemonService/SignIdentitySchnorr", runtime.WithHTTPPathPattern("/v1/daemon/sign-identity-schnorr"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_DaemonService_SignIdentitySchnorr_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_SignIdentitySchnorr_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_DaemonService_ReceiveAuthECDH_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2131,6 +2178,23 @@ func RegisterDaemonServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_SignReceiveAuthMessageCompact_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_SignIdentitySchnorr_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/daemonrpc.DaemonService/SignIdentitySchnorr", runtime.WithHTTPPathPattern("/v1/daemon/sign-identity-schnorr"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_DaemonService_SignIdentitySchnorr_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_SignIdentitySchnorr_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_DaemonService_ReceiveAuthECDH_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2639,6 +2703,7 @@ var (
 	pattern_DaemonService_ReceiveAuthKey_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "receive-auth-key"}, ""))
 	pattern_DaemonService_SignReceiveAuthMessage_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "sign-receive-auth-message"}, ""))
 	pattern_DaemonService_SignReceiveAuthMessageCompact_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "sign-receive-auth-message-compact"}, ""))
+	pattern_DaemonService_SignIdentitySchnorr_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "sign-identity-schnorr"}, ""))
 	pattern_DaemonService_ReceiveAuthECDH_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "receive-auth-ecdh"}, ""))
 	pattern_DaemonService_GetIndexedVTXOByPkScript_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "get-indexed-vtxo-by-pk-script"}, ""))
 	pattern_DaemonService_GetIndexedOORSessionByTxid_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "get-indexed-oor-session-by-txid"}, ""))
@@ -2682,6 +2747,7 @@ var (
 	forward_DaemonService_ReceiveAuthKey_0                = runtime.ForwardResponseMessage
 	forward_DaemonService_SignReceiveAuthMessage_0        = runtime.ForwardResponseMessage
 	forward_DaemonService_SignReceiveAuthMessageCompact_0 = runtime.ForwardResponseMessage
+	forward_DaemonService_SignIdentitySchnorr_0           = runtime.ForwardResponseMessage
 	forward_DaemonService_ReceiveAuthECDH_0               = runtime.ForwardResponseMessage
 	forward_DaemonService_GetIndexedVTXOByPkScript_0      = runtime.ForwardResponseMessage
 	forward_DaemonService_GetIndexedOORSessionByTxid_0    = runtime.ForwardResponseMessage

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -60,6 +60,11 @@ service DaemonService {
     rpc SignReceiveAuthMessageCompact (SignReceiveAuthMessageCompactRequest)
         returns (SignReceiveAuthMessageCompactResponse);
 
+    // SignIdentitySchnorr signs one domain-separated message with the daemon
+    // identity key. The private key never leaves the daemon.
+    rpc SignIdentitySchnorr (SignIdentitySchnorrRequest)
+        returns (SignIdentitySchnorrResponse);
+
     // ReceiveAuthECDH derives one Sphinx shared secret with the
     // per-payment receive-auth key.
     rpc ReceiveAuthECDH (ReceiveAuthECDHRequest)
@@ -417,6 +422,18 @@ message InitWalletResponse {
     // recovered_oor_events is the number of OOR recipient events processed
     // during recovery.
     uint32 recovered_oor_events = 7;
+
+    // recovered_vhtlcs is the number of swapserver recoverable vHTLC rows
+    // validated during recovery.
+    uint32 recovered_vhtlcs = 8;
+
+    // recovered_vhtlc_refunds is the number of pay-side refund recovery rows
+    // armed from recovered in-swaps.
+    uint32 recovered_vhtlc_refunds = 9;
+
+    // recovered_vhtlc_claims is the number of receive-side claim recovery
+    // rows armed from recovered out-swaps.
+    uint32 recovered_vhtlc_claims = 10;
 }
 
 message UnlockWalletRequest {
@@ -671,6 +688,19 @@ message SignReceiveAuthMessageCompactRequest {
 
 message SignReceiveAuthMessageCompactResponse {
     // signature is the compact public-key-recoverable ECDSA signature.
+    bytes signature = 1;
+}
+
+message SignIdentitySchnorrRequest {
+    // message is the raw domain-separated message to sign.
+    bytes message = 1;
+
+    // tag is the BIP-340 tag used for tagged Schnorr signing.
+    bytes tag = 2;
+}
+
+message SignIdentitySchnorrResponse {
+    // signature is the raw 64-byte BIP-340 Schnorr signature.
     bytes signature = 1;
 }
 

--- a/daemonrpc/daemon.yaml
+++ b/daemonrpc/daemon.yaml
@@ -39,6 +39,9 @@ http:
     - selector: daemonrpc.DaemonService.ReceiveAuthECDH
       post: /v1/daemon/receive-auth-ecdh
       body: "*"
+    - selector: daemonrpc.DaemonService.SignIdentitySchnorr
+      post: /v1/daemon/sign-identity-schnorr
+      body: "*"
     - selector: daemonrpc.DaemonService.GetIndexedVTXOByPkScript
       post: /v1/daemon/get-indexed-vtxo-by-pk-script
       body: "*"

--- a/daemonrpc/daemon_grpc.pb.go
+++ b/daemonrpc/daemon_grpc.pb.go
@@ -30,6 +30,7 @@ const (
 	DaemonService_ReceiveAuthKey_FullMethodName                = "/daemonrpc.DaemonService/ReceiveAuthKey"
 	DaemonService_SignReceiveAuthMessage_FullMethodName        = "/daemonrpc.DaemonService/SignReceiveAuthMessage"
 	DaemonService_SignReceiveAuthMessageCompact_FullMethodName = "/daemonrpc.DaemonService/SignReceiveAuthMessageCompact"
+	DaemonService_SignIdentitySchnorr_FullMethodName           = "/daemonrpc.DaemonService/SignIdentitySchnorr"
 	DaemonService_ReceiveAuthECDH_FullMethodName               = "/daemonrpc.DaemonService/ReceiveAuthECDH"
 	DaemonService_GetIndexedVTXOByPkScript_FullMethodName      = "/daemonrpc.DaemonService/GetIndexedVTXOByPkScript"
 	DaemonService_GetIndexedOORSessionByTxid_FullMethodName    = "/daemonrpc.DaemonService/GetIndexedOORSessionByTxid"
@@ -107,6 +108,9 @@ type DaemonServiceClient interface {
 	// SignReceiveAuthMessageCompact signs one message with the
 	// per-payment receive-auth key and returns a compact signature.
 	SignReceiveAuthMessageCompact(ctx context.Context, in *SignReceiveAuthMessageCompactRequest, opts ...grpc.CallOption) (*SignReceiveAuthMessageCompactResponse, error)
+	// SignIdentitySchnorr signs one domain-separated message with the daemon
+	// identity key. The private key never leaves the daemon.
+	SignIdentitySchnorr(ctx context.Context, in *SignIdentitySchnorrRequest, opts ...grpc.CallOption) (*SignIdentitySchnorrResponse, error)
 	// ReceiveAuthECDH derives one Sphinx shared secret with the
 	// per-payment receive-auth key.
 	ReceiveAuthECDH(ctx context.Context, in *ReceiveAuthECDHRequest, opts ...grpc.CallOption) (*ReceiveAuthECDHResponse, error)
@@ -332,6 +336,16 @@ func (c *daemonServiceClient) SignReceiveAuthMessageCompact(ctx context.Context,
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(SignReceiveAuthMessageCompactResponse)
 	err := c.cc.Invoke(ctx, DaemonService_SignReceiveAuthMessageCompact_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) SignIdentitySchnorr(ctx context.Context, in *SignIdentitySchnorrRequest, opts ...grpc.CallOption) (*SignIdentitySchnorrResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SignIdentitySchnorrResponse)
+	err := c.cc.Invoke(ctx, DaemonService_SignIdentitySchnorr_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -683,6 +697,9 @@ type DaemonServiceServer interface {
 	// SignReceiveAuthMessageCompact signs one message with the
 	// per-payment receive-auth key and returns a compact signature.
 	SignReceiveAuthMessageCompact(context.Context, *SignReceiveAuthMessageCompactRequest) (*SignReceiveAuthMessageCompactResponse, error)
+	// SignIdentitySchnorr signs one domain-separated message with the daemon
+	// identity key. The private key never leaves the daemon.
+	SignIdentitySchnorr(context.Context, *SignIdentitySchnorrRequest) (*SignIdentitySchnorrResponse, error)
 	// ReceiveAuthECDH derives one Sphinx shared secret with the
 	// per-payment receive-auth key.
 	ReceiveAuthECDH(context.Context, *ReceiveAuthECDHRequest) (*ReceiveAuthECDHResponse, error)
@@ -836,6 +853,9 @@ func (UnimplementedDaemonServiceServer) SignReceiveAuthMessage(context.Context, 
 }
 func (UnimplementedDaemonServiceServer) SignReceiveAuthMessageCompact(context.Context, *SignReceiveAuthMessageCompactRequest) (*SignReceiveAuthMessageCompactResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SignReceiveAuthMessageCompact not implemented")
+}
+func (UnimplementedDaemonServiceServer) SignIdentitySchnorr(context.Context, *SignIdentitySchnorrRequest) (*SignIdentitySchnorrResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SignIdentitySchnorr not implemented")
 }
 func (UnimplementedDaemonServiceServer) ReceiveAuthECDH(context.Context, *ReceiveAuthECDHRequest) (*ReceiveAuthECDHResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ReceiveAuthECDH not implemented")
@@ -1139,6 +1159,24 @@ func _DaemonService_SignReceiveAuthMessageCompact_Handler(srv interface{}, ctx c
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(DaemonServiceServer).SignReceiveAuthMessageCompact(ctx, req.(*SignReceiveAuthMessageCompactRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_SignIdentitySchnorr_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SignIdentitySchnorrRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).SignIdentitySchnorr(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_SignIdentitySchnorr_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).SignIdentitySchnorr(ctx, req.(*SignIdentitySchnorrRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1708,6 +1746,10 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SignReceiveAuthMessageCompact",
 			Handler:    _DaemonService_SignReceiveAuthMessageCompact_Handler,
+		},
+		{
+			MethodName: "SignIdentitySchnorr",
+			Handler:    _DaemonService_SignIdentitySchnorr_Handler,
 		},
 		{
 			MethodName: "ReceiveAuthECDH",

--- a/daemonrpc/daemon_mailboxrpc.pb.go
+++ b/daemonrpc/daemon_mailboxrpc.pb.go
@@ -46,6 +46,8 @@ type DaemonServiceMailboxServer interface {
 	SignReceiveAuthMessage(ctx context.Context, req *SignReceiveAuthMessageRequest) (*SignReceiveAuthMessageResponse, error)
 	// SignReceiveAuthMessageCompact handles SignReceiveAuthMessageCompact.
 	SignReceiveAuthMessageCompact(ctx context.Context, req *SignReceiveAuthMessageCompactRequest) (*SignReceiveAuthMessageCompactResponse, error)
+	// SignIdentitySchnorr handles SignIdentitySchnorr.
+	SignIdentitySchnorr(ctx context.Context, req *SignIdentitySchnorrRequest) (*SignIdentitySchnorrResponse, error)
 	// ReceiveAuthECDH handles ReceiveAuthECDH.
 	ReceiveAuthECDH(ctx context.Context, req *ReceiveAuthECDHRequest) (*ReceiveAuthECDHResponse, error)
 	// GetIndexedVTXOByPkScript handles GetIndexedVTXOByPkScript.
@@ -217,6 +219,16 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.SignReceiveAuthMessageCompact(ctx, req)
+	})
+	r.Handle("daemonrpc.DaemonService", "SignIdentitySchnorr", func() proto.Message {
+		return &SignIdentitySchnorrRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*SignIdentitySchnorrRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.SignIdentitySchnorr(ctx, req)
 	})
 	r.Handle("daemonrpc.DaemonService", "ReceiveAuthECDH", func() proto.Message {
 		return &ReceiveAuthECDHRequest{}
@@ -756,6 +768,29 @@ func (c *DaemonServiceMailboxClient) SignReceiveAuthMessageCompact(ctx context.C
 	}
 
 	resp := new(SignReceiveAuthMessageCompactResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// SignIdentitySchnorr calls the SignIdentitySchnorr RPC.
+func (c *DaemonServiceMailboxClient) SignIdentitySchnorr(ctx context.Context, req *SignIdentitySchnorrRequest, opts ...rpc.RPCOptions) (*SignIdentitySchnorrResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "daemonrpc.DaemonService",
+		Method:  "SignIdentitySchnorr",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(SignIdentitySchnorrResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -512,11 +512,27 @@ func (c SwapVHTLCRecoveryConfig) WithDefaults() SwapVHTLCRecoveryConfig {
 	return c
 }
 
+// SwapRecoveryResult summarizes vHTLC recovery work performed by the optional
+// swap runtime during seed restore.
+type SwapRecoveryResult struct {
+	// RecoveredVHTLCs counts recoverable rows returned by the swapserver
+	// that had vHTLC metadata the runtime could validate.
+	RecoveredVHTLCs uint32
+
+	// RecoveredVHTLCRefunds counts pay-side refund recovery rows armed
+	// from recovered in-swaps.
+	RecoveredVHTLCRefunds uint32
+
+	// RecoveredVHTLCClaims counts receive-side claim recovery rows armed
+	// from recovered out-swaps.
+	RecoveredVHTLCClaims uint32
+}
+
 // SwapBackend is the in-Go handle exposed by swapclientserver after Register
 // completes. It lets higher-level subservers (such as the walletdkrpc
-// subserver) drive the swap runtime without dialing the daemon's gRPC server
-// from inside the same process. The interface is intentionally small and grows
-// only as new wallet-layer needs arise.
+// subserver) and seed recovery drive the swap runtime without dialing the
+// daemon's gRPC server from inside the same process. The interface is
+// intentionally small and grows only as new wallet-layer needs arise.
 type SwapBackend interface {
 	// ResumePending re-arms background workers for every persisted
 	// pending swap session. It is idempotent: payment hashes already
@@ -524,6 +540,10 @@ type SwapBackend interface {
 	// when the active resume policy is allowed to start background
 	// workers.
 	ResumePending(ctx context.Context)
+
+	// RecoverVHTLCs asks the swap runtime to discover swapserver-owned
+	// recoverable vHTLC rows and arm daemon-owned recovery jobs.
+	RecoverVHTLCs(ctx context.Context) (*SwapRecoveryResult, error)
 }
 
 // SwapWalletConfig configures the optional walletdkrpc subserver. The struct

--- a/darepod/rpc_wallet.go
+++ b/darepod/rpc_wallet.go
@@ -108,19 +108,21 @@ func (r *RPCServer) SignIdentitySchnorr(ctx context.Context,
 	*daemonrpc.SignIdentitySchnorrResponse, error) {
 
 	if len(req.GetTag()) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "tag is required")
+		return nil, status.Error(
+			codes.InvalidArgument, "tag is required",
+		)
 	}
 	if err := r.requireWalletReady(); err != nil {
 		return nil, err
 	}
 
 	sig, err := r.server.signTaggedSchnorr(
-		ctx, req.GetMessage(), req.GetTag(), "identity schnorr",
+		ctx, req.GetMessage(), req.GetTag(),
+		"identity schnorr",
 	)
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal, "sign identity schnorr: %v", err,
-		)
+		return nil, status.Errorf(codes.Internal, "sign identity "+
+			"schnorr: %v", err)
 	}
 
 	return &daemonrpc.SignIdentitySchnorrResponse{

--- a/darepod/rpc_wallet.go
+++ b/darepod/rpc_wallet.go
@@ -101,6 +101,33 @@ func (r *RPCServer) ReceiveAuthECDH(ctx context.Context,
 	}, nil
 }
 
+// SignIdentitySchnorr signs one tagged Schnorr message with the daemon
+// identity key without returning private-key-equivalent material.
+func (r *RPCServer) SignIdentitySchnorr(ctx context.Context,
+	req *daemonrpc.SignIdentitySchnorrRequest) (
+	*daemonrpc.SignIdentitySchnorrResponse, error) {
+
+	if len(req.GetTag()) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "tag is required")
+	}
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+
+	sig, err := r.server.signTaggedSchnorr(
+		ctx, req.GetMessage(), req.GetTag(), "identity schnorr",
+	)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal, "sign identity schnorr: %v", err,
+		)
+	}
+
+	return &daemonrpc.SignIdentitySchnorrResponse{
+		Signature: sig.Serialize(),
+	}, nil
+}
+
 // deriveReceiveAuthKey derives the receive-auth base using the same
 // Diffie-Hellman construction as lnd's Signer.DeriveSharedKey RPC, then
 // domain-separates it for one payment hash.

--- a/darepod/wallet_recovery.go
+++ b/darepod/wallet_recovery.go
@@ -45,6 +45,9 @@ type walletRecoveryResult struct {
 	VTXOs             uint32
 	OORReceiveScripts uint32
 	OOREvents         uint32
+	VHTLCs            uint32
+	VHTLCRefunds      uint32
+	VHTLCClaims       uint32
 }
 
 // retryRecoveryIndexerRPC retries recovery-local indexer calls that hit the
@@ -84,6 +87,9 @@ func (r walletRecoveryResult) apply(resp *daemonrpc.InitWalletResponse) {
 	resp.RecoveredVtxos = r.VTXOs
 	resp.RecoveredOorReceiveScripts = r.OORReceiveScripts
 	resp.RecoveredOorEvents = r.OOREvents
+	resp.RecoveredVhtlcs = r.VHTLCs
+	resp.RecoveredVhtlcRefunds = r.VHTLCRefunds
+	resp.RecoveredVhtlcClaims = r.VHTLCClaims
 }
 
 func (r *RPCServer) recoverWalletState(ctx context.Context, window uint32) (
@@ -135,8 +141,35 @@ func (r *RPCServer) recoverWalletState(ctx context.Context, window uint32) (
 	); err != nil {
 		return nil, fmt.Errorf("recover OOR receive scripts: %w", err)
 	}
+	if err := r.recoverSwapVHTLCs(ctx, &result); err != nil {
+		return nil, fmt.Errorf("recover swap vHTLCs: %w", err)
+	}
 
 	return &result, nil
+}
+
+// recoverSwapVHTLCs delegates swapserver-owned vHTLC discovery to the
+// configured swap runtime after the wallet seed is available for signing.
+func (r *RPCServer) recoverSwapVHTLCs(ctx context.Context,
+	result *walletRecoveryResult) error {
+
+	if r.server.cfg.Swap == nil || r.server.cfg.Swap.Backend == nil {
+		return nil
+	}
+
+	recovered, err := r.server.cfg.Swap.Backend.RecoverVHTLCs(ctx)
+	if err != nil {
+		return err
+	}
+	if recovered == nil {
+		return nil
+	}
+
+	result.VHTLCs += recovered.RecoveredVHTLCs
+	result.VHTLCRefunds += recovered.RecoveredVHTLCRefunds
+	result.VHTLCClaims += recovered.RecoveredVHTLCClaims
+
+	return nil
 }
 
 func (r *RPCServer) recoverBoardingKeys(ctx context.Context,

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -199,6 +199,19 @@ func (c *SwapServiceClient) AuthorizeInSwapRefund(ctx context.Context,
 	return out, err
 }
 
+// ListRecoverableSwaps returns authenticated recovery candidates.
+func (c *SwapServiceClient) ListRecoverableSwaps(ctx context.Context,
+	in *swaprpc.ListRecoverableSwapsRequest, _ ...grpc.CallOption) (
+	*swaprpc.ListRecoverableSwapsResponse, error) {
+
+	out := new(swaprpc.ListRecoverableSwapsResponse)
+	err := c.client.Post(
+		ctx, "/v1/swap/list-recoverable-swaps", in, out,
+	)
+
+	return out, err
+}
+
 // AcknowledgeOutSwapHtlc tells the swap server an out-swap receiver durably
 // accepted the HTLC event.
 func (c *SwapServiceClient) AcknowledgeOutSwapHtlc(ctx context.Context,
@@ -365,6 +378,19 @@ func (c *DaemonServiceClient) ReceiveAuthECDH(ctx context.Context,
 
 	out := new(daemonrpc.ReceiveAuthECDHResponse)
 	err := c.client.Post(ctx, "/v1/daemon/receive-auth-ecdh", in, out)
+
+	return out, err
+}
+
+// SignIdentitySchnorr signs a tagged message with the daemon identity key.
+func (c *DaemonServiceClient) SignIdentitySchnorr(ctx context.Context,
+	in *daemonrpc.SignIdentitySchnorrRequest, _ ...grpc.CallOption) (
+	*daemonrpc.SignIdentitySchnorrResponse, error) {
+
+	out := new(daemonrpc.SignIdentitySchnorrResponse)
+	err := c.client.Post(
+		ctx, "/v1/daemon/sign-identity-schnorr", in, out,
+	)
 
 	return out, err
 }

--- a/rpc/walletdkrpc/wallet.pb.go
+++ b/rpc/walletdkrpc/wallet.pb.go
@@ -648,8 +648,17 @@ type CreateResponse struct {
 	// recovered_oor_events is the number of OOR recipient events processed
 	// during recovery.
 	RecoveredOorEvents uint32 `protobuf:"varint,8,opt,name=recovered_oor_events,json=recoveredOorEvents,proto3" json:"recovered_oor_events,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// recovered_vhtlcs is the number of swapserver recoverable vHTLC rows
+	// validated during recovery.
+	RecoveredVhtlcs uint32 `protobuf:"varint,9,opt,name=recovered_vhtlcs,json=recoveredVhtlcs,proto3" json:"recovered_vhtlcs,omitempty"`
+	// recovered_vhtlc_refunds is the number of pay-side refund recovery rows
+	// armed from recovered in-swaps.
+	RecoveredVhtlcRefunds uint32 `protobuf:"varint,10,opt,name=recovered_vhtlc_refunds,json=recoveredVhtlcRefunds,proto3" json:"recovered_vhtlc_refunds,omitempty"`
+	// recovered_vhtlc_claims is the number of receive-side claim recovery
+	// rows armed from recovered out-swaps.
+	RecoveredVhtlcClaims uint32 `protobuf:"varint,11,opt,name=recovered_vhtlc_claims,json=recoveredVhtlcClaims,proto3" json:"recovered_vhtlc_claims,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *CreateResponse) Reset() {
@@ -734,6 +743,27 @@ func (x *CreateResponse) GetRecoveredOorReceiveScripts() uint32 {
 func (x *CreateResponse) GetRecoveredOorEvents() uint32 {
 	if x != nil {
 		return x.RecoveredOorEvents
+	}
+	return 0
+}
+
+func (x *CreateResponse) GetRecoveredVhtlcs() uint32 {
+	if x != nil {
+		return x.RecoveredVhtlcs
+	}
+	return 0
+}
+
+func (x *CreateResponse) GetRecoveredVhtlcRefunds() uint32 {
+	if x != nil {
+		return x.RecoveredVhtlcRefunds
+	}
+	return 0
+}
+
+func (x *CreateResponse) GetRecoveredVhtlcClaims() uint32 {
+	if x != nil {
+		return x.RecoveredVhtlcClaims
 	}
 	return 0
 }
@@ -3795,7 +3825,7 @@ const file_wallet_proto_rawDesc = "" +
 	"\x0fseed_passphrase\x18\x02 \x01(\fR\x0eseedPassphrase\x12\x1a\n" +
 	"\bmnemonic\x18\x03 \x03(\tR\bmnemonic\x12#\n" +
 	"\rrecover_state\x18\x04 \x01(\bR\frecoverState\x12'\n" +
-	"\x0frecovery_window\x18\x05 \x01(\rR\x0erecoveryWindow\"\x92\x03\n" +
+	"\x0frecovery_window\x18\x05 \x01(\rR\x0erecoveryWindow\"\xab\x04\n" +
 	"\x0eCreateResponse\x12\x1a\n" +
 	"\bmnemonic\x18\x01 \x03(\tR\bmnemonic\x12'\n" +
 	"\x0fidentity_pubkey\x18\x02 \x01(\tR\x0eidentityPubkey\x12!\n" +
@@ -3804,7 +3834,11 @@ const file_wallet_proto_rawDesc = "" +
 	"\x18recovered_boarding_utxos\x18\x05 \x01(\rR\x16recoveredBoardingUtxos\x12'\n" +
 	"\x0frecovered_vtxos\x18\x06 \x01(\rR\x0erecoveredVtxos\x12A\n" +
 	"\x1drecovered_oor_receive_scripts\x18\a \x01(\rR\x1arecoveredOorReceiveScripts\x120\n" +
-	"\x14recovered_oor_events\x18\b \x01(\rR\x12recoveredOorEvents\"8\n" +
+	"\x14recovered_oor_events\x18\b \x01(\rR\x12recoveredOorEvents\x12)\n" +
+	"\x10recovered_vhtlcs\x18\t \x01(\rR\x0frecoveredVhtlcs\x126\n" +
+	"\x17recovered_vhtlc_refunds\x18\n" +
+	" \x01(\rR\x15recoveredVhtlcRefunds\x124\n" +
+	"\x16recovered_vhtlc_claims\x18\v \x01(\rR\x14recoveredVhtlcClaims\"8\n" +
 	"\rUnlockRequest\x12'\n" +
 	"\x0fwallet_password\x18\x01 \x01(\fR\x0ewalletPassword\"9\n" +
 	"\x0eUnlockResponse\x12'\n" +

--- a/rpc/walletdkrpc/wallet.proto
+++ b/rpc/walletdkrpc/wallet.proto
@@ -232,6 +232,18 @@ message CreateResponse {
     // recovered_oor_events is the number of OOR recipient events processed
     // during recovery.
     uint32 recovered_oor_events = 8;
+
+    // recovered_vhtlcs is the number of swapserver recoverable vHTLC rows
+    // validated during recovery.
+    uint32 recovered_vhtlcs = 9;
+
+    // recovered_vhtlc_refunds is the number of pay-side refund recovery rows
+    // armed from recovered in-swaps.
+    uint32 recovered_vhtlc_refunds = 10;
+
+    // recovered_vhtlc_claims is the number of receive-side claim recovery
+    // rows armed from recovered out-swaps.
+    uint32 recovered_vhtlc_claims = 11;
 }
 
 message UnlockRequest {

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -688,8 +688,8 @@ func (c *Client) ReceiveAuthECDH(ctx context.Context, paymentHash lntypes.Hash,
 
 // SignIdentitySchnorr asks the daemon wallet to sign one domain-separated
 // message with the daemon identity key.
-func (c *Client) SignIdentitySchnorr(ctx context.Context, message,
-	tag []byte) ([]byte, error) {
+func (c *Client) SignIdentitySchnorr(ctx context.Context, message, tag []byte) (
+	[]byte, error) {
 
 	resp, err := c.daemon.SignIdentitySchnorr(
 		ctx, &daemonrpc.SignIdentitySchnorrRequest{
@@ -1042,6 +1042,24 @@ func (c *Client) GetVHTLCRecoveryStatus(ctx context.Context,
 	resp, err := c.daemon.GetVHTLCRecoveryStatus(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("get vhtlc recovery status: %w", err)
+	}
+
+	return resp, nil
+}
+
+// ListVHTLCRecoveries returns all daemon-owned recovery rows. Restore uses
+// this as a narrow idempotency lookup before allocating fresh destinations.
+func (c *Client) ListVHTLCRecoveries(ctx context.Context,
+	req *daemonrpc.ListVHTLCRecoveriesRequest) (
+	*daemonrpc.ListVHTLCRecoveriesResponse, error) {
+
+	if req == nil {
+		req = &daemonrpc.ListVHTLCRecoveriesRequest{}
+	}
+
+	resp, err := c.daemon.ListVHTLCRecoveries(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("list vhtlc recoveries: %w", err)
 	}
 
 	return resp, nil

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -686,6 +686,24 @@ func (c *Client) ReceiveAuthECDH(ctx context.Context, paymentHash lntypes.Hash,
 	return sharedSecret, nil
 }
 
+// SignIdentitySchnorr asks the daemon wallet to sign one domain-separated
+// message with the daemon identity key.
+func (c *Client) SignIdentitySchnorr(ctx context.Context, message,
+	tag []byte) ([]byte, error) {
+
+	resp, err := c.daemon.SignIdentitySchnorr(
+		ctx, &daemonrpc.SignIdentitySchnorrRequest{
+			Message: message,
+			Tag:     tag,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign identity schnorr: %w", err)
+	}
+
+	return append([]byte(nil), resp.GetSignature()...), nil
+}
+
 // GetIndexedVTXOByPkScript asks the daemon's indexer client for the first VTXO
 // matching the supplied script and status filters. Passing nil uses the
 // daemon defaults.

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	sdkark "github.com/lightninglabs/darepo-client/sdk/ark"
+	"github.com/lightninglabs/darepo-client/swaprpc"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -417,7 +418,8 @@ type SwapServerConn interface {
 	// RequestChannelID asks the server for a route hint for this swap.
 	RequestChannelID(ctx context.Context, vhtlcPubkey *btcec.PublicKey,
 		paymentHash lntypes.Hash, amountSat btcutil.Amount,
-		expirySeconds uint32) (*OutSwapQuote, error)
+		expirySeconds uint32, ownerProof *swaprpc.SwapOwnerProof,
+		encryptedRecoveryBlob []byte) (*OutSwapQuote, error)
 
 	// AcknowledgeOutSwapHTLC tells the server this receiver validated and
 	// durably accepted the out-swap HTLC event.
@@ -426,7 +428,14 @@ type SwapServerConn interface {
 
 	// CreateInSwap initiates an Ark->LN swap on the server.
 	CreateInSwap(ctx context.Context, invoice string, maxFeeSat uint64,
-		clientVhtlcPubkey *btcec.PublicKey) (*InSwapConfig, error)
+		clientVhtlcPubkey *btcec.PublicKey,
+		ownerProof *swaprpc.SwapOwnerProof) (*InSwapConfig, error)
+
+	// ListRecoverableSwaps returns server-owned recoverable swap metadata
+	// for the authenticated daemon identity key.
+	ListRecoverableSwaps(ctx context.Context,
+		ownerProof *swaprpc.SwapOwnerProof) (
+		[]*swaprpc.RecoverableSwap, error)
 
 	// QuoteInSwap previews an Ark->LN swap without creating server or
 	// client state.
@@ -550,6 +559,11 @@ type DaemonConn interface {
 	// payment-scoped receive-auth key.
 	ReceiveAuthECDH(ctx context.Context, paymentHash lntypes.Hash,
 		pubKey *btcec.PublicKey) ([32]byte, error)
+
+	// SignIdentitySchnorr signs one domain-separated message with the
+	// daemon identity key.
+	SignIdentitySchnorr(ctx context.Context, message, tag []byte) (
+		[]byte, error)
 }
 
 // CustomInput aliases the Ark SDK's typed custom OOR input.

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -435,7 +435,9 @@ type SwapServerConn interface {
 	// for the authenticated daemon identity key.
 	ListRecoverableSwaps(ctx context.Context,
 		ownerProof *swaprpc.SwapOwnerProof) (
-		[]*swaprpc.RecoverableSwap, error)
+		[]*swaprpc.RecoverableSwap,
+		error,
+	)
 
 	// QuoteInSwap previews an Ark->LN swap without creating server or
 	// client state.
@@ -497,6 +499,12 @@ type DaemonConn interface {
 	GetVHTLCRecoveryStatus(ctx context.Context,
 		req *daemonrpc.GetVHTLCRecoveryStatusRequest) (
 		*daemonrpc.GetVHTLCRecoveryStatusResponse, error)
+
+	// ListVHTLCRecoveries returns durable recovery rows so restore can
+	// retry arming idempotently after a previous partial attempt.
+	ListVHTLCRecoveries(ctx context.Context,
+		req *daemonrpc.ListVHTLCRecoveriesRequest) (
+		*daemonrpc.ListVHTLCRecoveriesResponse, error)
 
 	// PrepareOORWithCustomInputs builds a deterministic custom-input OOR
 	// package without submitting it.
@@ -562,8 +570,8 @@ type DaemonConn interface {
 
 	// SignIdentitySchnorr signs one domain-separated message with the
 	// daemon identity key.
-	SignIdentitySchnorr(ctx context.Context, message, tag []byte) (
-		[]byte, error)
+	SignIdentitySchnorr(ctx context.Context, message,
+		tag []byte) ([]byte, error)
 }
 
 // CustomInput aliases the Ark SDK's typed custom OOR input.

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -42,7 +42,9 @@ func NewRESTSwapServerConn(addr string,
 // Lightning-to-Ark receive flow.
 func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 	vhtlcPubkey *btcec.PublicKey, paymentHash lntypes.Hash,
-	amountSat btcutil.Amount, expirySeconds uint32) (*OutSwapQuote, error) {
+	amountSat btcutil.Amount, expirySeconds uint32,
+	ownerProof *swaprpc.SwapOwnerProof,
+	encryptedRecoveryBlob []byte) (*OutSwapQuote, error) {
 
 	if vhtlcPubkey == nil {
 		return nil, fmt.Errorf("vHTLC pubkey must be provided")
@@ -60,6 +62,10 @@ func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 				[]byte(nil), paymentHash[:]...,
 			),
 			AmountMsat: uint64(amountSat) * 1000,
+			OwnerProof: ownerProof,
+			EncryptedRecoveryBlob: append(
+				[]byte(nil), encryptedRecoveryBlob...,
+			),
 		},
 	)
 	if err != nil {
@@ -106,8 +112,8 @@ func (g *GRPCSwapServerConn) AcknowledgeOutSwapHTLC(ctx context.Context,
 
 // CreateInSwap initiates one Ark-to-Lightning swap on the swap server.
 func (g *GRPCSwapServerConn) CreateInSwap(ctx context.Context, invoice string,
-	maxFeeSat uint64, clientVhtlcPubkey *btcec.PublicKey) (*InSwapConfig,
-	error) {
+	maxFeeSat uint64, clientVhtlcPubkey *btcec.PublicKey,
+	ownerProof *swaprpc.SwapOwnerProof) (*InSwapConfig, error) {
 
 	if clientVhtlcPubkey == nil {
 		return nil, fmt.Errorf("client vHTLC pubkey must be provided")
@@ -119,6 +125,7 @@ func (g *GRPCSwapServerConn) CreateInSwap(ctx context.Context, invoice string,
 			MaxFeeSat: maxFeeSat,
 			ClientVhtlcPubkey: clientVhtlcPubkey.
 				SerializeCompressed(),
+			OwnerProof: ownerProof,
 		},
 	)
 	if err != nil {
@@ -126,6 +133,23 @@ func (g *GRPCSwapServerConn) CreateInSwap(ctx context.Context, invoice string,
 	}
 
 	return inSwapConfigFromProto(resp)
+}
+
+// ListRecoverableSwaps returns owner-scoped recovery candidates from the swap
+// server.
+func (g *GRPCSwapServerConn) ListRecoverableSwaps(ctx context.Context,
+	ownerProof *swaprpc.SwapOwnerProof) ([]*swaprpc.RecoverableSwap, error) {
+
+	resp, err := g.client.ListRecoverableSwaps(
+		ctx, &swaprpc.ListRecoverableSwapsRequest{
+			OwnerProof: ownerProof,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("ListRecoverableSwaps RPC: %w", err)
+	}
+
+	return resp.GetSwaps(), nil
 }
 
 // QuoteInSwap previews one Ark-to-Lightning swap on the swap server without

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -43,8 +43,8 @@ func NewRESTSwapServerConn(addr string,
 func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 	vhtlcPubkey *btcec.PublicKey, paymentHash lntypes.Hash,
 	amountSat btcutil.Amount, expirySeconds uint32,
-	ownerProof *swaprpc.SwapOwnerProof,
-	encryptedRecoveryBlob []byte) (*OutSwapQuote, error) {
+	ownerProof *swaprpc.SwapOwnerProof, encryptedRecoveryBlob []byte) (
+	*OutSwapQuote, error) {
 
 	if vhtlcPubkey == nil {
 		return nil, fmt.Errorf("vHTLC pubkey must be provided")
@@ -138,7 +138,8 @@ func (g *GRPCSwapServerConn) CreateInSwap(ctx context.Context, invoice string,
 // ListRecoverableSwaps returns owner-scoped recovery candidates from the swap
 // server.
 func (g *GRPCSwapServerConn) ListRecoverableSwaps(ctx context.Context,
-	ownerProof *swaprpc.SwapOwnerProof) ([]*swaprpc.RecoverableSwap, error) {
+	ownerProof *swaprpc.SwapOwnerProof) ([]*swaprpc.RecoverableSwap,
+	error) {
 
 	resp, err := g.client.ListRecoverableSwaps(
 		ctx, &swaprpc.ListRecoverableSwapsRequest{

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -543,12 +543,14 @@ func (s *paySession) createSwap(ctx context.Context) error {
 		return fmt.Errorf("get client pubkey: %w", err)
 	}
 
+	// Bind the requested vHTLC participant key into the owner proof even
+	// though it currently matches the daemon identity key. If those keys
+	// diverge later, old proofs cannot be replayed for a different script
+	// key.
 	ownerProof, err := newSwapOwnerProof(
 		ctx, s.client.daemon, clientKey, swapRecoveryAuthCreateIn,
-		s.client.currentTime().Unix(),
-		clientKey.SerializeCompressed(),
-		[]byte(s.invoice),
-		recoveryUint64Field(s.maxFeeSat),
+		s.client.currentTime().Unix(), clientKey.SerializeCompressed(),
+		[]byte(s.invoice), recoveryUint64Field(s.maxFeeSat),
 	)
 	if err != nil {
 		return fmt.Errorf("create owner proof: %w", err)

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -543,8 +543,19 @@ func (s *paySession) createSwap(ctx context.Context) error {
 		return fmt.Errorf("get client pubkey: %w", err)
 	}
 
+	ownerProof, err := newSwapOwnerProof(
+		ctx, s.client.daemon, clientKey, swapRecoveryAuthCreateIn,
+		s.client.currentTime().Unix(),
+		clientKey.SerializeCompressed(),
+		[]byte(s.invoice),
+		recoveryUint64Field(s.maxFeeSat),
+	)
+	if err != nil {
+		return fmt.Errorf("create owner proof: %w", err)
+	}
+
 	cfg, err := s.client.server.CreateInSwap(
-		ctx, s.invoice, s.maxFeeSat, clientKey,
+		ctx, s.invoice, s.maxFeeSat, clientKey, ownerProof,
 	)
 	if err != nil {
 		return fmt.Errorf("create in-swap: %w", err)

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	swapsqlc "github.com/lightninglabs/darepo-client/sdk/swaps/sqlc"
+	"github.com/lightninglabs/darepo-client/swaprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/lightningnetwork/lnd/zpay32"
 	"github.com/stretchr/testify/require"
@@ -98,7 +99,8 @@ func (f *failAtExecDBTX) QueryRowContext(ctx context.Context, query string,
 
 // RequestChannelID is unused in these tests.
 func (c *testInSwapServerConn) RequestChannelID(_ context.Context,
-	_ *btcec.PublicKey, _ lntypes.Hash, _ btcutil.Amount, _ uint32) (
+	_ *btcec.PublicKey, _ lntypes.Hash, _ btcutil.Amount, _ uint32,
+	_ *swaprpc.SwapOwnerProof, _ []byte) (
 	*OutSwapQuote, error) {
 
 	return nil, nil
@@ -113,11 +115,18 @@ func (c *testInSwapServerConn) AcknowledgeOutSwapHTLC(context.Context,
 
 // CreateInSwap returns the preconfigured in-swap config.
 func (c *testInSwapServerConn) CreateInSwap(context.Context, string, uint64,
-	*btcec.PublicKey) (*InSwapConfig, error) {
+	*btcec.PublicKey, *swaprpc.SwapOwnerProof) (*InSwapConfig, error) {
 
 	c.createCalls++
 
 	return c.cfg, nil
+}
+
+// ListRecoverableSwaps is unused in these tests.
+func (c *testInSwapServerConn) ListRecoverableSwaps(context.Context,
+	*swaprpc.SwapOwnerProof) ([]*swaprpc.RecoverableSwap, error) {
+
+	return nil, nil
 }
 
 // QuoteInSwap returns the preconfigured in-swap quote.

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -100,8 +100,7 @@ func (f *failAtExecDBTX) QueryRowContext(ctx context.Context, query string,
 // RequestChannelID is unused in these tests.
 func (c *testInSwapServerConn) RequestChannelID(_ context.Context,
 	_ *btcec.PublicKey, _ lntypes.Hash, _ btcutil.Amount, _ uint32,
-	_ *swaprpc.SwapOwnerProof, _ []byte) (
-	*OutSwapQuote, error) {
+	_ *swaprpc.SwapOwnerProof, _ []byte) (*OutSwapQuote, error) {
 
 	return nil, nil
 }

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -3,6 +3,7 @@ package swaps
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -615,6 +616,13 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 	}
 	paymentHash := preimage.Hash()
 
+	encryptedRecoveryBlob, err := sealOutSwapRecoveryBlob(
+		ctx, s.client.daemon, clientKey, paymentHash, preimage,
+	)
+	if err != nil {
+		return fmt.Errorf("seal recovery preimage: %w", err)
+	}
+
 	authKey, err := s.client.receiveAuthKey(ctx, paymentHash)
 	if err != nil {
 		return fmt.Errorf("get receive auth key: %w", err)
@@ -641,9 +649,24 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 	// database. The session is persisted before the invoice is returned to
 	// the caller.
 	expiry := time.Duration(defaultReceiveExpirySeconds) * time.Second
+	blobHash := sha256.Sum256(encryptedRecoveryBlob)
+	ownerProof, err := newSwapOwnerProof(
+		ctx, s.client.daemon, clientKey,
+		swapRecoveryAuthRequestChannel,
+		s.client.currentTime().Unix(),
+		clientKey.SerializeCompressed(),
+		paymentHash[:],
+		recoveryUint64Field(uint64(s.amountSat)*1000),
+		recoveryUint64Field(defaultReceiveExpirySeconds),
+		blobHash[:],
+	)
+	if err != nil {
+		return fmt.Errorf("create owner proof: %w", err)
+	}
+
 	quote, err := s.client.server.RequestChannelID(
 		ctx, clientKey, paymentHash, s.amountSat,
-		defaultReceiveExpirySeconds,
+		defaultReceiveExpirySeconds, ownerProof, encryptedRecoveryBlob,
 	)
 	if err != nil {
 		return fmt.Errorf("request channel ID: %w", err)

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -650,15 +650,15 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 	// the caller.
 	expiry := time.Duration(defaultReceiveExpirySeconds) * time.Second
 	blobHash := sha256.Sum256(encryptedRecoveryBlob)
+	// Bind the requested vHTLC participant key into the owner proof even
+	// though it currently matches the daemon identity key. If those keys
+	// diverge later, old proofs cannot be replayed for a different script
+	// key.
 	ownerProof, err := newSwapOwnerProof(
-		ctx, s.client.daemon, clientKey,
-		swapRecoveryAuthRequestChannel,
-		s.client.currentTime().Unix(),
-		clientKey.SerializeCompressed(),
-		paymentHash[:],
-		recoveryUint64Field(uint64(s.amountSat)*1000),
-		recoveryUint64Field(defaultReceiveExpirySeconds),
-		blobHash[:],
+		ctx, s.client.daemon, clientKey, swapRecoveryAuthRequestChannel,
+		s.client.currentTime().Unix(), clientKey.SerializeCompressed(),
+		paymentHash[:], recoveryUint64Field(uint64(s.amountSat)*1000),
+		recoveryUint64Field(defaultReceiveExpirySeconds), blobHash[:],
 	)
 	if err != nil {
 		return fmt.Errorf("create owner proof: %w", err)

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -15,9 +15,11 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/swaprpc"
 	"github.com/lightningnetwork/lnd/invoices"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -325,25 +327,30 @@ func TestReceiveSessionSkipsServerAckForSameArkHTLCEvent(t *testing.T) {
 }
 
 type testSwapServerConn struct {
-	hint           *RouteHint
-	payerFeeMsat   uint64
-	cfg            *VHTLCConfig
-	htlcAmountSat  uint64
-	waitErr        error
-	ackErr         error
-	ackErrs        []error
-	serverAckErr   error
-	serverAckErrs  []error
-	ackCursor      uint64
-	waitCalls      int
-	ackCalls       int
-	serverAckCalls int
-	lastAckCursor  uint64
+	hint            *RouteHint
+	payerFeeMsat    uint64
+	cfg             *VHTLCConfig
+	htlcAmountSat   uint64
+	recoverableRows []*swaprpc.RecoverableSwap
+	waitErr         error
+	ackErr          error
+	recoverableErr  error
+	ackErrs         []error
+	serverAckErr    error
+	serverAckErrs   []error
+	ackCursor       uint64
+	waitCalls       int
+	ackCalls        int
+	serverAckCalls  int
+	lastAckCursor   uint64
 
-	lastVhtlcPubkey     *btcec.PublicKey
-	lastAmountSat       btcutil.Amount
-	lastServerAckHash   lntypes.Hash
-	lastServerAckPubkey *btcec.PublicKey
+	lastVhtlcPubkey      *btcec.PublicKey
+	lastAmountSat        btcutil.Amount
+	lastOwnerProof       *swaprpc.SwapOwnerProof
+	lastRecoveryBlob     []byte
+	lastServerAckHash    lntypes.Hash
+	lastServerAckPubkey  *btcec.PublicKey
+	lastRecoverableProof *swaprpc.SwapOwnerProof
 }
 
 type testIncomingEventReceiver struct {
@@ -390,10 +397,13 @@ func (r *testIncomingEventReceiver) WaitIncomingVHTLC(context.Context,
 // RequestChannelID returns the preconfigured out-swap route hint.
 func (c *testSwapServerConn) RequestChannelID(_ context.Context,
 	vhtlcPubkey *btcec.PublicKey, _ lntypes.Hash, amountSat btcutil.Amount,
-	_ uint32) (*OutSwapQuote, error) {
+	_ uint32, ownerProof *swaprpc.SwapOwnerProof,
+	encryptedRecoveryBlob []byte) (*OutSwapQuote, error) {
 
 	c.lastVhtlcPubkey = vhtlcPubkey
 	c.lastAmountSat = amountSat
+	c.lastOwnerProof = ownerProof
+	c.lastRecoveryBlob = append([]byte(nil), encryptedRecoveryBlob...)
 
 	return &OutSwapQuote{
 		RouteHint:        c.hint,
@@ -471,9 +481,21 @@ func (c *testSwapServerConn) AcknowledgeOutSwapHTLC(_ context.Context,
 
 // CreateInSwap is unused in these tests.
 func (c *testSwapServerConn) CreateInSwap(context.Context, string, uint64,
-	*btcec.PublicKey) (*InSwapConfig, error) {
+	*btcec.PublicKey, *swaprpc.SwapOwnerProof) (*InSwapConfig, error) {
 
 	return nil, nil
+}
+
+// ListRecoverableSwaps returns the configured recoverable swap rows.
+func (c *testSwapServerConn) ListRecoverableSwaps(_ context.Context,
+	proof *swaprpc.SwapOwnerProof) ([]*swaprpc.RecoverableSwap, error) {
+
+	c.lastRecoverableProof = proof
+	if c.recoverableErr != nil {
+		return nil, c.recoverableErr
+	}
+
+	return append([]*swaprpc.RecoverableSwap(nil), c.recoverableRows...), nil
 }
 
 // QuoteInSwap is unused in these tests.
@@ -992,6 +1014,7 @@ func TestWaitForVHTLCExpiresOnPersistentUnregisteredScript(t *testing.T) {
 }
 
 type testDaemonConn struct {
+	identityPriv      *btcec.PrivateKey
 	identityKey       *btcec.PublicKey
 	operatorKey       *btcec.PublicKey
 	blockHeight       uint32
@@ -1042,9 +1065,34 @@ type testDaemonConn struct {
 	cancelCalls       int
 	statusCalls       int
 	lastArmRecovery   *daemonrpc.ArmVHTLCRecoveryRequest
+	armRecoveries     []*daemonrpc.ArmVHTLCRecoveryRequest
 	lastEscalate      *daemonrpc.EscalateVHTLCRecoveryRequest
 	lastCancel        *daemonrpc.CancelVHTLCRecoveryRequest
 	lastStatus        *daemonrpc.GetVHTLCRecoveryStatusRequest
+}
+
+// SignIdentitySchnorr signs a tagged message with deterministic test identity
+// material.
+func (d *testDaemonConn) SignIdentitySchnorr(_ context.Context, message,
+	tag []byte) ([]byte, error) {
+
+	privKey := d.identityPriv
+	if privKey == nil {
+		seed := d.receiveAuthKey
+		if len(seed) == 0 {
+			seed = bytes.Repeat([]byte{1}, 32)
+		}
+
+		privKey, _ = btcec.PrivKeyFromBytes(seed)
+	}
+
+	digest := chainhash.TaggedHash(tag, message)
+	sig, err := schnorr.Sign(privKey, digest[:])
+	if err != nil {
+		return nil, err
+	}
+
+	return sig.Serialize(), nil
 }
 
 // BlockHeight returns the configured best block height.
@@ -1144,6 +1192,7 @@ func (d *testDaemonConn) ArmVHTLCRecovery(_ context.Context,
 
 	d.armRecoveryCalls++
 	d.lastArmRecovery = req
+	d.armRecoveries = append(d.armRecoveries, req)
 	if d.armRecoveryErr != nil {
 		return nil, d.armRecoveryErr
 	}

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -495,7 +495,9 @@ func (c *testSwapServerConn) ListRecoverableSwaps(_ context.Context,
 		return nil, c.recoverableErr
 	}
 
-	return append([]*swaprpc.RecoverableSwap(nil), c.recoverableRows...), nil
+	return append(
+		[]*swaprpc.RecoverableSwap(nil), c.recoverableRows...,
+	), nil
 }
 
 // QuoteInSwap is unused in these tests.
@@ -1014,67 +1016,80 @@ func TestWaitForVHTLCExpiresOnPersistentUnregisteredScript(t *testing.T) {
 }
 
 type testDaemonConn struct {
-	identityPriv      *btcec.PrivateKey
-	identityKey       *btcec.PublicKey
-	operatorKey       *btcec.PublicKey
-	blockHeight       uint32
-	liveVTXOs         []VTXOInfo
-	spentVTXOs        []VTXOInfo
-	vhtlc             *VTXOInfo
-	liveByPkScript    map[string]*VTXOInfo
-	spentVTXO         *VTXOInfo
-	indexedPackage    *OORPackageInfo
-	indexedPackages   []*OORPackageInfo
-	receiveInfo       *ReceiveInfo
-	receiveAuthKey    []byte
-	receiveAuthErr    error
-	receiveAllocCalls int
-	sendSessionID     string
-	sendOutpoint      string
-	preparedOOR       *PreparedOOR
-	prepareOOREErr    error
-	sendPolicyErr     error
-	sendCustomErr     error
-	oorSession        *daemonrpc.OORSessionInfo
-	oorSessionErr     error
-	listSpentErr      error
-	liveLookupErr     error
-	liveLookupHook    func(call int) (*VTXOInfo, error)
-	spentLookupErr    error
-	spentLookupBlock  time.Duration
-	spendOnCustom     bool
-	sendPolicyCalls   int
-	sendCustomCalls   int
-	oorSessionCalls   int
-	liveLookupCalls   int
-	spentLookupCalls  int
-	lastSendPolicy    []byte
-	lastClaimPubKey   []byte
-	lastClaimInput    []CustomInput
-	lastOORSessionID  string
-	armRecoveryResp   *daemonrpc.ArmVHTLCRecoveryResponse
-	armRecoveryErr    error
-	escalateResp      *daemonrpc.EscalateVHTLCRecoveryResponse
-	escalateErr       error
-	cancelResp        *daemonrpc.CancelVHTLCRecoveryResponse
-	cancelErr         error
-	statusResp        *daemonrpc.GetVHTLCRecoveryStatusResponse
-	statusErr         error
-	armRecoveryCalls  int
-	escalateCalls     int
-	cancelCalls       int
-	statusCalls       int
-	lastArmRecovery   *daemonrpc.ArmVHTLCRecoveryRequest
-	armRecoveries     []*daemonrpc.ArmVHTLCRecoveryRequest
-	lastEscalate      *daemonrpc.EscalateVHTLCRecoveryRequest
-	lastCancel        *daemonrpc.CancelVHTLCRecoveryRequest
-	lastStatus        *daemonrpc.GetVHTLCRecoveryStatusRequest
+	identityPriv        *btcec.PrivateKey
+	identityKey         *btcec.PublicKey
+	operatorKey         *btcec.PublicKey
+	blockHeight         uint32
+	liveVTXOs           []VTXOInfo
+	spentVTXOs          []VTXOInfo
+	vhtlc               *VTXOInfo
+	liveByPkScript      map[string]*VTXOInfo
+	spentVTXO           *VTXOInfo
+	indexedPackage      *OORPackageInfo
+	indexedPackages     []*OORPackageInfo
+	receiveInfo         *ReceiveInfo
+	receiveAuthKey      []byte
+	receiveAuthErr      error
+	receiveAllocCalls   int
+	sendSessionID       string
+	sendOutpoint        string
+	preparedOOR         *PreparedOOR
+	prepareOOREErr      error
+	sendPolicyErr       error
+	sendCustomErr       error
+	oorSession          *daemonrpc.OORSessionInfo
+	oorSessionErr       error
+	listSpentErr        error
+	liveLookupErr       error
+	liveLookupHook      func(call int) (*VTXOInfo, error)
+	spentLookupErr      error
+	spentLookupBlock    time.Duration
+	spendOnCustom       bool
+	sendPolicyCalls     int
+	sendCustomCalls     int
+	oorSessionCalls     int
+	liveLookupCalls     int
+	spentLookupCalls    int
+	lastSendPolicy      []byte
+	lastClaimPubKey     []byte
+	lastClaimInput      []CustomInput
+	lastOORSessionID    string
+	armRecoveryResp     *daemonrpc.ArmVHTLCRecoveryResponse
+	armRecoveryErr      error
+	escalateResp        *daemonrpc.EscalateVHTLCRecoveryResponse
+	escalateErr         error
+	cancelResp          *daemonrpc.CancelVHTLCRecoveryResponse
+	cancelErr           error
+	statusResp          *daemonrpc.GetVHTLCRecoveryStatusResponse
+	statusErr           error
+	listRecoveriesResp  *daemonrpc.ListVHTLCRecoveriesResponse
+	listRecoveriesErr   error
+	identitySignature   []byte
+	identitySignErr     error
+	armRecoveryCalls    int
+	escalateCalls       int
+	cancelCalls         int
+	statusCalls         int
+	listRecoveriesCalls int
+	lastArmRecovery     *daemonrpc.ArmVHTLCRecoveryRequest
+	armRecoveries       []*daemonrpc.ArmVHTLCRecoveryRequest
+	lastEscalate        *daemonrpc.EscalateVHTLCRecoveryRequest
+	lastCancel          *daemonrpc.CancelVHTLCRecoveryRequest
+	lastStatus          *daemonrpc.GetVHTLCRecoveryStatusRequest
+	lastListRecoveries  *daemonrpc.ListVHTLCRecoveriesRequest
 }
 
 // SignIdentitySchnorr signs a tagged message with deterministic test identity
 // material.
 func (d *testDaemonConn) SignIdentitySchnorr(_ context.Context, message,
 	tag []byte) ([]byte, error) {
+
+	if d.identitySignErr != nil {
+		return nil, d.identitySignErr
+	}
+	if d.identitySignature != nil {
+		return append([]byte(nil), d.identitySignature...), nil
+	}
 
 	privKey := d.identityPriv
 	if privKey == nil {
@@ -1273,6 +1288,23 @@ func (d *testDaemonConn) GetVHTLCRecoveryStatus(_ context.Context,
 	return &daemonrpc.GetVHTLCRecoveryStatusResponse{
 		Found: false,
 	}, nil
+}
+
+// ListVHTLCRecoveries records the daemon recovery list request.
+func (d *testDaemonConn) ListVHTLCRecoveries(_ context.Context,
+	req *daemonrpc.ListVHTLCRecoveriesRequest) (
+	*daemonrpc.ListVHTLCRecoveriesResponse, error) {
+
+	d.listRecoveriesCalls++
+	d.lastListRecoveries = req
+	if d.listRecoveriesErr != nil {
+		return nil, d.listRecoveriesErr
+	}
+	if d.listRecoveriesResp != nil {
+		return d.listRecoveriesResp, nil
+	}
+
+	return &daemonrpc.ListVHTLCRecoveriesResponse{}, nil
 }
 
 // PrepareOORWithCustomInputs records the requested package and returns

--- a/sdk/swaps/recovery.go
+++ b/sdk/swaps/recovery.go
@@ -277,6 +277,69 @@ func pubKeyBytesForRecovery(pubKey *btcec.PublicKey,
 	return pubKey.SerializeCompressed(), nil
 }
 
+// armVHTLCRecoveryParams is the stable request shape shared by live swap
+// sessions and seed-restore recovery.
+type armVHTLCRecoveryParams struct {
+	RequestID   string
+	PaymentHash lntypes.Hash
+	Direction   daemonrpc.VHTLCRecoveryDirection
+	Action      daemonrpc.VHTLCRecoveryAction
+
+	VTXOOutpoint  string
+	VTXOAmountSat int64
+
+	SenderPubkey   []byte
+	ReceiverPubkey []byte
+	ServerPubkey   []byte
+
+	RefundLocktime                       int32
+	UnilateralClaimDelay                 int32
+	UnilateralRefundDelay                int32
+	UnilateralRefundWithoutReceiverDelay int32
+
+	DestinationScript []byte
+	MaxFeeRateSatKW   int32
+}
+
+// buildArmVHTLCRecoveryRequest clones the durable request fields so retries
+// compare against stable bytes regardless of the caller's backing slices.
+func buildArmVHTLCRecoveryRequest(
+	params armVHTLCRecoveryParams) *daemonrpc.ArmVHTLCRecoveryRequest {
+
+	return &daemonrpc.ArmVHTLCRecoveryRequest{
+		RequestId:     params.RequestID,
+		SwapId:        append([]byte(nil), params.PaymentHash[:]...),
+		Direction:     params.Direction,
+		Action:        params.Action,
+		VtxoOutpoint:  params.VTXOOutpoint,
+		VtxoAmountSat: params.VTXOAmountSat,
+		SenderPubkey: append(
+			[]byte(nil), params.SenderPubkey...,
+		),
+		ReceiverPubkey: append(
+			[]byte(nil), params.ReceiverPubkey...,
+		),
+		ServerPubkey: append(
+			[]byte(nil), params.ServerPubkey...,
+		),
+		RefundLocktime:       params.RefundLocktime,
+		UnilateralClaimDelay: params.UnilateralClaimDelay,
+		UnilateralRefundDelay: params.
+			UnilateralRefundDelay,
+		UnilateralRefundWithoutReceiverDelay: params.
+			UnilateralRefundWithoutReceiverDelay,
+		PreimageHash: append(
+			[]byte(nil), params.PaymentHash[:]...,
+		),
+		SignerKeyFamily: recoverySignerFamily(),
+		SignerKeyIndex:  recoverySignerKeyIndex,
+		DestinationScript: append(
+			[]byte(nil), params.DestinationScript...,
+		),
+		MaxFeeRateSatPerKw: params.MaxFeeRateSatKW,
+	}
+}
+
 // ensurePayRefundRecoveryArmed stores a dormant refund-without-receiver
 // recovery row for the funded pay-side vHTLC. The row is armed before refund
 // locktime pressure so escalation later only flips existing durable state.
@@ -310,47 +373,36 @@ func (s *paySession) ensurePayRefundRecoveryArmed(ctx context.Context) error {
 		return err
 	}
 
-	resp, err := s.client.daemon.ArmVHTLCRecovery(
-		ctx, &daemonrpc.ArmVHTLCRecoveryRequest{
-			RequestId: recoveryRequestID(
-				string(SwapDirectionPay), s.cfg.PaymentHash,
-				recoveryActionRefundWithoutReceiver,
-			),
-			SwapId: append(
-				[]byte(nil), s.cfg.PaymentHash[:]...,
-			),
-			Direction:      recoveryDirectionPay,
-			Action:         recoveryActionRefundWithoutReceiver,
-			VtxoOutpoint:   s.vhtlcOutpoint,
-			VtxoAmountSat:  s.vhtlcAmount,
-			SenderPubkey:   sender,
-			ReceiverPubkey: receiver,
-			ServerPubkey:   server,
-			RefundLocktime: int32(
-				s.cfg.VHTLCConfig.RefundLocktime,
-			),
-			UnilateralClaimDelay: int32(
-				s.cfg.VHTLCConfig.UnilateralClaimDelay,
-			),
-			UnilateralRefundDelay: int32(
-				s.cfg.VHTLCConfig.UnilateralRefundDelay,
-			),
-			UnilateralRefundWithoutReceiverDelay: int32(
-				s.cfg.VHTLCConfig.
-					UnilateralRefundWithoutReceiverDelay,
-			),
-			PreimageHash: append(
-				[]byte(nil), s.cfg.PaymentHash[:]...,
-			),
-			SignerKeyFamily: recoverySignerFamily(),
-			SignerKeyIndex:  recoverySignerKeyIndex,
-			DestinationScript: append(
-				[]byte(nil), s.refundReceiveScript...,
-			),
-			MaxFeeRateSatPerKw: s.client.recoveryPolicy.
-				MaxFeeRateSatPerKW,
-		},
-	)
+	req := buildArmVHTLCRecoveryRequest(armVHTLCRecoveryParams{
+		RequestID: recoveryRequestID(
+			string(SwapDirectionPay), s.cfg.PaymentHash,
+			recoveryActionRefundWithoutReceiver,
+		),
+		PaymentHash:    s.cfg.PaymentHash,
+		Direction:      recoveryDirectionPay,
+		Action:         recoveryActionRefundWithoutReceiver,
+		VTXOOutpoint:   s.vhtlcOutpoint,
+		VTXOAmountSat:  s.vhtlcAmount,
+		SenderPubkey:   sender,
+		ReceiverPubkey: receiver,
+		ServerPubkey:   server,
+		RefundLocktime: int32(
+			s.cfg.VHTLCConfig.RefundLocktime,
+		),
+		UnilateralClaimDelay: int32(
+			s.cfg.VHTLCConfig.UnilateralClaimDelay,
+		),
+		UnilateralRefundDelay: int32(
+			s.cfg.VHTLCConfig.UnilateralRefundDelay,
+		),
+		UnilateralRefundWithoutReceiverDelay: int32(
+			s.cfg.VHTLCConfig.UnilateralRefundWithoutReceiverDelay,
+		),
+		DestinationScript: s.refundReceiveScript,
+		MaxFeeRateSatKW:   s.client.recoveryPolicy.MaxFeeRateSatPerKW,
+	})
+
+	resp, err := s.client.daemon.ArmVHTLCRecovery(ctx, req)
 	if err != nil {
 		return fmt.Errorf("arm pay refund recovery: %w", err)
 	}
@@ -417,47 +469,36 @@ func (s *ReceiveSession) ensureReceiveClaimRecoveryArmed(
 		return err
 	}
 
-	resp, err := s.client.daemon.ArmVHTLCRecovery(
-		ctx, &daemonrpc.ArmVHTLCRecoveryRequest{
-			RequestId: recoveryRequestID(
-				string(SwapDirectionReceive), s.PaymentHash,
-				recoveryActionClaim,
-			),
-			SwapId: append(
-				[]byte(nil), s.PaymentHash[:]...,
-			),
-			Direction:      recoveryDirectionReceive,
-			Action:         recoveryActionClaim,
-			VtxoOutpoint:   s.vhtlcOutpoint,
-			VtxoAmountSat:  s.vhtlcAmount,
-			SenderPubkey:   sender,
-			ReceiverPubkey: receiver,
-			ServerPubkey:   server,
-			RefundLocktime: int32(
-				s.vhtlcConfig.RefundLocktime,
-			),
-			UnilateralClaimDelay: int32(
-				s.vhtlcConfig.UnilateralClaimDelay,
-			),
-			UnilateralRefundDelay: int32(
-				s.vhtlcConfig.UnilateralRefundDelay,
-			),
-			UnilateralRefundWithoutReceiverDelay: int32(
-				s.vhtlcConfig.
-					UnilateralRefundWithoutReceiverDelay,
-			),
-			PreimageHash: append(
-				[]byte(nil), s.PaymentHash[:]...,
-			),
-			SignerKeyFamily: recoverySignerFamily(),
-			SignerKeyIndex:  recoverySignerKeyIndex,
-			DestinationScript: append(
-				[]byte(nil), s.claimReceiveScript...,
-			),
-			MaxFeeRateSatPerKw: s.client.recoveryPolicy.
-				MaxFeeRateSatPerKW,
-		},
-	)
+	req := buildArmVHTLCRecoveryRequest(armVHTLCRecoveryParams{
+		RequestID: recoveryRequestID(
+			string(SwapDirectionReceive), s.PaymentHash,
+			recoveryActionClaim,
+		),
+		PaymentHash:    s.PaymentHash,
+		Direction:      recoveryDirectionReceive,
+		Action:         recoveryActionClaim,
+		VTXOOutpoint:   s.vhtlcOutpoint,
+		VTXOAmountSat:  s.vhtlcAmount,
+		SenderPubkey:   sender,
+		ReceiverPubkey: receiver,
+		ServerPubkey:   server,
+		RefundLocktime: int32(
+			s.vhtlcConfig.RefundLocktime,
+		),
+		UnilateralClaimDelay: int32(
+			s.vhtlcConfig.UnilateralClaimDelay,
+		),
+		UnilateralRefundDelay: int32(
+			s.vhtlcConfig.UnilateralRefundDelay,
+		),
+		UnilateralRefundWithoutReceiverDelay: int32(
+			s.vhtlcConfig.UnilateralRefundWithoutReceiverDelay,
+		),
+		DestinationScript: s.claimReceiveScript,
+		MaxFeeRateSatKW:   s.client.recoveryPolicy.MaxFeeRateSatPerKW,
+	})
+
+	resp, err := s.client.daemon.ArmVHTLCRecovery(ctx, req)
 	if err != nil {
 		return fmt.Errorf("arm receive claim recovery: %w", err)
 	}

--- a/sdk/swaps/recovery_auth.go
+++ b/sdk/swaps/recovery_auth.go
@@ -24,6 +24,7 @@ const (
 	swapRecoveryNonceLen    = 16
 	swapRecoveryBlobVersion = 1
 	swapRecoveryBlobTag     = "darepo-swap-recovery-blob-v1"
+	secretboxNonceSize      = 24
 )
 
 // newSwapOwnerProof signs one swap recovery owner proof with the daemon
@@ -37,6 +38,10 @@ func newSwapOwnerProof(ctx context.Context, daemon DaemonConn,
 	}
 	if clientKey == nil {
 		return nil, fmt.Errorf("client identity key is required")
+	}
+	if timestampUnix < 0 {
+		return nil, fmt.Errorf("owner proof timestamp must be " +
+			"non-negative")
 	}
 
 	nonce := make([]byte, swapRecoveryNonceLen)
@@ -53,6 +58,9 @@ func newSwapOwnerProof(ctx context.Context, daemon DaemonConn,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("sign owner proof: %w", err)
+	}
+	if len(sig) != 64 {
+		return nil, fmt.Errorf("owner proof signature must be 64 bytes")
 	}
 
 	return &swaprpc.SwapOwnerProof{
@@ -115,7 +123,7 @@ func sealOutSwapRecoveryBlob(ctx context.Context, daemon DaemonConn,
 		return nil, err
 	}
 
-	var nonce [24]byte
+	var nonce [secretboxNonceSize]byte
 	if _, err := io.ReadFull(rand.Reader, nonce[:]); err != nil {
 		return nil, fmt.Errorf("generate recovery blob nonce: %w", err)
 	}
@@ -134,7 +142,7 @@ func openOutSwapRecoveryBlob(ctx context.Context, daemon DaemonConn,
 	clientKey *btcec.PublicKey, paymentHash lntypes.Hash,
 	blob []byte) (*lntypes.Preimage, error) {
 
-	if len(blob) < 1+24 {
+	if len(blob) < 1+secretboxNonceSize {
 		return nil, fmt.Errorf("recovery blob is too short")
 	}
 	if blob[0] != swapRecoveryBlobVersion {
@@ -147,10 +155,12 @@ func openOutSwapRecoveryBlob(ctx context.Context, daemon DaemonConn,
 		return nil, err
 	}
 
-	var nonce [24]byte
-	copy(nonce[:], blob[1:25])
+	var nonce [secretboxNonceSize]byte
+	copy(nonce[:], blob[1:1+secretboxNonceSize])
 
-	plaintext, ok := secretbox.Open(nil, blob[25:], &nonce, &key)
+	plaintext, ok := secretbox.Open(
+		nil, blob[1+secretboxNonceSize:], &nonce, &key,
+	)
 	if !ok {
 		return nil, fmt.Errorf("open recovery blob")
 	}
@@ -169,7 +179,8 @@ func openOutSwapRecoveryBlob(ctx context.Context, daemon DaemonConn,
 // outSwapRecoveryBlobKey derives the symmetric key used to seal one out-swap
 // preimage without exposing raw seed material outside the daemon.
 func outSwapRecoveryBlobKey(ctx context.Context, daemon DaemonConn,
-	clientKey *btcec.PublicKey, paymentHash lntypes.Hash) ([32]byte, error) {
+	clientKey *btcec.PublicKey,
+	paymentHash lntypes.Hash) ([32]byte, error) {
 
 	if daemon == nil {
 		return [32]byte{}, fmt.Errorf("daemon connection is required")
@@ -185,9 +196,7 @@ func outSwapRecoveryBlobKey(ctx context.Context, daemon DaemonConn,
 	}
 
 	key := chainhash.TaggedHash(
-		[]byte(swapRecoveryBlobTag),
-		sharedSecret[:],
-		paymentHash[:],
+		[]byte(swapRecoveryBlobTag), sharedSecret[:], paymentHash[:],
 		clientKey.SerializeCompressed(),
 	)
 

--- a/sdk/swaps/recovery_auth.go
+++ b/sdk/swaps/recovery_auth.go
@@ -1,0 +1,195 @@
+package swaps
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/lightninglabs/darepo-client/swaprpc"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"golang.org/x/crypto/nacl/secretbox"
+)
+
+const (
+	swapRecoveryAuthTag = "darepo-swap-recovery-owner-v1"
+
+	swapRecoveryAuthList           = "list-recoverable-swaps"
+	swapRecoveryAuthCreateIn       = "create-in-swap"
+	swapRecoveryAuthRequestChannel = "request-channel-id"
+
+	swapRecoveryNonceLen    = 16
+	swapRecoveryBlobVersion = 1
+	swapRecoveryBlobTag     = "darepo-swap-recovery-blob-v1"
+)
+
+// newSwapOwnerProof signs one swap recovery owner proof with the daemon
+// identity key.
+func newSwapOwnerProof(ctx context.Context, daemon DaemonConn,
+	clientKey *btcec.PublicKey, kind string, timestampUnix int64,
+	fields ...[]byte) (*swaprpc.SwapOwnerProof, error) {
+
+	if daemon == nil {
+		return nil, fmt.Errorf("daemon connection is required")
+	}
+	if clientKey == nil {
+		return nil, fmt.Errorf("client identity key is required")
+	}
+
+	nonce := make([]byte, swapRecoveryNonceLen)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("generate owner proof nonce: %w", err)
+	}
+
+	clientKeyBytes := clientKey.SerializeCompressed()
+	msg := swapRecoveryAuthMessage(
+		kind, clientKeyBytes, timestampUnix, nonce, fields...,
+	)
+	sig, err := daemon.SignIdentitySchnorr(
+		ctx, msg, []byte(swapRecoveryAuthTag),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign owner proof: %w", err)
+	}
+
+	return &swaprpc.SwapOwnerProof{
+		ClientIdentityPubkey: clientKeyBytes,
+		TimestampUnix:        timestampUnix,
+		Nonce:                nonce,
+		Signature:            sig,
+	}, nil
+}
+
+// swapRecoveryAuthMessage builds the length-delimited message signed by the
+// daemon identity key for swap recovery ownership.
+func swapRecoveryAuthMessage(kind string, clientIdentity []byte,
+	timestamp int64, nonce []byte, fields ...[]byte) []byte {
+
+	msg := make([]byte, 0, 128)
+	msg = appendRecoveryField(msg, []byte(kind))
+	msg = appendRecoveryField(msg, clientIdentity)
+
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], uint64(timestamp))
+	msg = appendRecoveryField(msg, ts[:])
+	msg = appendRecoveryField(msg, nonce)
+
+	for _, field := range fields {
+		msg = appendRecoveryField(msg, field)
+	}
+
+	return msg
+}
+
+// appendRecoveryField adds one length-prefixed field to the signed recovery
+// message so adjacent fields cannot be reinterpreted.
+func appendRecoveryField(msg []byte, field []byte) []byte {
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(field)))
+
+	msg = append(msg, lenBuf[:]...)
+	msg = append(msg, field...)
+
+	return msg
+}
+
+// recoveryUint64Field encodes numeric RPC fields in the recovery auth message.
+func recoveryUint64Field(v uint64) []byte {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], v)
+
+	return buf[:]
+}
+
+// sealOutSwapRecoveryBlob encrypts the invoice preimage so a seed-restored
+// receiver can recover the claim path without server-side plaintext storage.
+func sealOutSwapRecoveryBlob(ctx context.Context, daemon DaemonConn,
+	clientKey *btcec.PublicKey, paymentHash lntypes.Hash,
+	preimage lntypes.Preimage) ([]byte, error) {
+
+	key, err := outSwapRecoveryBlobKey(ctx, daemon, clientKey, paymentHash)
+	if err != nil {
+		return nil, err
+	}
+
+	var nonce [24]byte
+	if _, err := io.ReadFull(rand.Reader, nonce[:]); err != nil {
+		return nil, fmt.Errorf("generate recovery blob nonce: %w", err)
+	}
+
+	ciphertext := secretbox.Seal(nil, preimage[:], &nonce, &key)
+	blob := make([]byte, 1, 1+len(nonce)+len(ciphertext))
+	blob[0] = swapRecoveryBlobVersion
+	blob = append(blob, nonce[:]...)
+	blob = append(blob, ciphertext...)
+
+	return blob, nil
+}
+
+// openOutSwapRecoveryBlob decrypts and verifies an out-swap recovery preimage.
+func openOutSwapRecoveryBlob(ctx context.Context, daemon DaemonConn,
+	clientKey *btcec.PublicKey, paymentHash lntypes.Hash,
+	blob []byte) (*lntypes.Preimage, error) {
+
+	if len(blob) < 1+24 {
+		return nil, fmt.Errorf("recovery blob is too short")
+	}
+	if blob[0] != swapRecoveryBlobVersion {
+		return nil, fmt.Errorf("unsupported recovery blob version %d",
+			blob[0])
+	}
+
+	key, err := outSwapRecoveryBlobKey(ctx, daemon, clientKey, paymentHash)
+	if err != nil {
+		return nil, err
+	}
+
+	var nonce [24]byte
+	copy(nonce[:], blob[1:25])
+
+	plaintext, ok := secretbox.Open(nil, blob[25:], &nonce, &key)
+	if !ok {
+		return nil, fmt.Errorf("open recovery blob")
+	}
+
+	preimage, err := lntypes.MakePreimage(plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("parse recovery preimage: %w", err)
+	}
+	if preimage.Hash() != paymentHash {
+		return nil, fmt.Errorf("recovery preimage hash mismatch")
+	}
+
+	return &preimage, nil
+}
+
+// outSwapRecoveryBlobKey derives the symmetric key used to seal one out-swap
+// preimage without exposing raw seed material outside the daemon.
+func outSwapRecoveryBlobKey(ctx context.Context, daemon DaemonConn,
+	clientKey *btcec.PublicKey, paymentHash lntypes.Hash) ([32]byte, error) {
+
+	if daemon == nil {
+		return [32]byte{}, fmt.Errorf("daemon connection is required")
+	}
+	if clientKey == nil {
+		return [32]byte{}, fmt.Errorf("client identity key is required")
+	}
+
+	sharedSecret, err := daemon.ReceiveAuthECDH(ctx, paymentHash, clientKey)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("derive recovery blob secret: %w",
+			err)
+	}
+
+	key := chainhash.TaggedHash(
+		[]byte(swapRecoveryBlobTag),
+		sharedSecret[:],
+		paymentHash[:],
+		clientKey.SerializeCompressed(),
+	)
+
+	return [32]byte(*key), nil
+}

--- a/sdk/swaps/rest_conn_test.go
+++ b/sdk/swaps/rest_conn_test.go
@@ -59,7 +59,7 @@ func TestRESTSwapServerConnRequestChannelID(t *testing.T) {
 	client := NewRESTSwapServerConn(server.URL)
 	quote, err := client.RequestChannelID(
 		t.Context(), clientPriv.PubKey(), lntypes.Hash{1},
-		btcutil.Amount(42_000), 30,
+		btcutil.Amount(42_000), 30, nil, nil,
 	)
 	require.NoError(t, err)
 	hint := quote.RouteHint

--- a/sdk/swaps/server_recovery.go
+++ b/sdk/swaps/server_recovery.go
@@ -1,0 +1,357 @@
+package swaps
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/swaprpc"
+	"github.com/lightningnetwork/lnd/lntypes"
+)
+
+// SwapserverRecoveryResult summarizes vHTLC recovery rows restored from the
+// swapserver-owned discovery API.
+type SwapserverRecoveryResult struct {
+	// RecoveredVHTLCs counts recoverable rows returned by the swapserver
+	// that had vHTLC metadata the SDK could validate.
+	RecoveredVHTLCs uint32
+
+	// RecoveredVHTLCRefunds counts pay-side refund recovery rows armed
+	// from recoverable in-swaps.
+	RecoveredVHTLCRefunds uint32
+
+	// RecoveredVHTLCClaims counts receive-side claim recovery rows armed
+	// from recoverable out-swaps.
+	RecoveredVHTLCClaims uint32
+}
+
+// RecoverSwapserverVHTLCs discovers swapserver-owned recoverable vHTLC rows and
+// arms daemon-owned recovery for live outputs.
+func (c *SwapClient) RecoverSwapserverVHTLCs(ctx context.Context) (
+	*SwapserverRecoveryResult, error) {
+
+	if c == nil || c.server == nil || c.daemon == nil {
+		return &SwapserverRecoveryResult{}, nil
+	}
+
+	clientKey, err := c.daemon.IdentityPubKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get recovery identity pubkey: %w", err)
+	}
+
+	ownerProof, err := newSwapOwnerProof(
+		ctx, c.daemon, clientKey, swapRecoveryAuthList,
+		c.currentTime().Unix(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create recovery owner proof: %w", err)
+	}
+
+	rows, err := c.server.ListRecoverableSwaps(ctx, ownerProof)
+	if err != nil {
+		return nil, fmt.Errorf("list recoverable swaps: %w", err)
+	}
+
+	result := &SwapserverRecoveryResult{}
+	for _, row := range rows {
+		recovered, err := c.recoverSwapserverVHTLC(
+			ctx, clientKey, row,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if !recovered {
+			continue
+		}
+
+		result.RecoveredVHTLCs++
+		switch row.GetDirection() {
+		case swaprpc.
+			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN:
+			result.RecoveredVHTLCRefunds++
+
+		case swaprpc.
+			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_OUT:
+			result.RecoveredVHTLCClaims++
+		}
+	}
+
+	return result, nil
+}
+
+// recoverSwapserverVHTLC validates one server row against the vHTLC policy and
+// arms recovery only when the daemon/indexer still reports a live output.
+func (c *SwapClient) recoverSwapserverVHTLC(ctx context.Context,
+	clientKey *btcec.PublicKey, row *swaprpc.RecoverableSwap) (bool, error) {
+
+	if row == nil || len(row.GetVhtlcPkScript()) == 0 {
+		return false, nil
+	}
+
+	paymentHash, _, pkScript, err := recoverableSwapPolicy(row)
+	if err != nil {
+		return false, err
+	}
+	if !bytes.Equal(pkScript, row.GetVhtlcPkScript()) {
+		return false, fmt.Errorf("recoverable swap %x pkScript mismatch",
+			paymentHash[:])
+	}
+
+	live, err := c.daemon.FindLiveVTXOByPkScript(ctx, pkScript)
+	if err != nil {
+		return false, fmt.Errorf("query live recoverable vHTLC %x: %w",
+			paymentHash[:], err)
+	}
+	if live == nil {
+		return false, nil
+	}
+
+	switch row.GetDirection() {
+	case swaprpc.
+		RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN:
+
+		return true, c.armRecoveredInSwapRefund(
+			ctx, row, paymentHash, live,
+		)
+
+	case swaprpc.
+		RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_OUT:
+
+		return true, c.armRecoveredOutSwapClaim(
+			ctx, clientKey, row, paymentHash, live,
+		)
+
+	default:
+		return false, nil
+	}
+}
+
+// armRecoveredInSwapRefund installs a pay-side daemon recovery row that uses
+// the refund-without-receiver path instead of sending the Lightning payment.
+func (c *SwapClient) armRecoveredInSwapRefund(ctx context.Context,
+	row *swaprpc.RecoverableSwap, paymentHash lntypes.Hash,
+	live *VTXOInfo) error {
+
+	destination, err := c.daemon.AllocateReceiveScript(
+		ctx, "vhtlc-recovery-refund",
+	)
+	if err != nil {
+		return fmt.Errorf("allocate refund destination: %w", err)
+	}
+
+	_, err = c.daemon.ArmVHTLCRecovery(
+		ctx, &daemonrpc.ArmVHTLCRecoveryRequest{
+			RequestId: recoveryRequestID(
+				string(SwapDirectionPay), paymentHash,
+				recoveryActionRefundWithoutReceiver,
+			),
+			SwapId:         append([]byte(nil), paymentHash[:]...),
+			Direction:      recoveryDirectionPay,
+			Action:         recoveryActionRefundWithoutReceiver,
+			VtxoOutpoint:   live.Outpoint,
+			VtxoAmountSat:  live.AmountSat,
+			SenderPubkey:   append([]byte(nil), row.GetSenderPubkey()...),
+			ReceiverPubkey: append([]byte(nil), row.GetReceiverPubkey()...),
+			ServerPubkey:   append([]byte(nil), row.GetOperatorPubkey()...),
+			RefundLocktime: int32(row.GetRefundLocktime()),
+			UnilateralClaimDelay: int32(
+				row.GetUnilateralClaimDelay(),
+			),
+			UnilateralRefundDelay: int32(
+				row.GetUnilateralRefundDelay(),
+			),
+			UnilateralRefundWithoutReceiverDelay: int32(
+				row.GetUnilateralRefundWithoutReceiverDelay(),
+			),
+			PreimageHash:      append([]byte(nil), paymentHash[:]...),
+			SignerKeyFamily:   recoverySignerFamily(),
+			SignerKeyIndex:    recoverySignerKeyIndex,
+			DestinationScript: destination.PkScript,
+			MaxFeeRateSatPerKw: c.recoveryPolicy.
+				MaxFeeRateSatPerKW,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("arm recovered in-swap refund: %w", err)
+	}
+
+	return nil
+}
+
+// armRecoveredOutSwapClaim decrypts the sealed preimage and starts the
+// receive-side claim recovery path for a live server-funded vHTLC.
+func (c *SwapClient) armRecoveredOutSwapClaim(ctx context.Context,
+	clientKey *btcec.PublicKey, row *swaprpc.RecoverableSwap,
+	paymentHash lntypes.Hash, live *VTXOInfo) error {
+
+	preimage, err := openOutSwapRecoveryBlob(
+		ctx, c.daemon, clientKey, paymentHash,
+		row.GetEncryptedRecoveryBlob(),
+	)
+	if err != nil {
+		return fmt.Errorf("open recovered out-swap preimage: %w", err)
+	}
+
+	destination, err := c.daemon.AllocateReceiveScript(
+		ctx, "vhtlc-recovery-claim",
+	)
+	if err != nil {
+		return fmt.Errorf("allocate claim destination: %w", err)
+	}
+
+	resp, err := c.daemon.ArmVHTLCRecovery(
+		ctx, &daemonrpc.ArmVHTLCRecoveryRequest{
+			RequestId: recoveryRequestID(
+				string(SwapDirectionReceive), paymentHash,
+				recoveryActionClaim,
+			),
+			SwapId:        append([]byte(nil), paymentHash[:]...),
+			Direction:     recoveryDirectionReceive,
+			Action:        recoveryActionClaim,
+			VtxoOutpoint:  live.Outpoint,
+			VtxoAmountSat: live.AmountSat,
+			SenderPubkey: append(
+				[]byte(nil), row.GetSenderPubkey()...,
+			),
+			ReceiverPubkey: append(
+				[]byte(nil), row.GetReceiverPubkey()...,
+			),
+			ServerPubkey: append(
+				[]byte(nil), row.GetOperatorPubkey()...,
+			),
+			RefundLocktime: int32(row.GetRefundLocktime()),
+			UnilateralClaimDelay: int32(
+				row.GetUnilateralClaimDelay(),
+			),
+			UnilateralRefundDelay: int32(
+				row.GetUnilateralRefundDelay(),
+			),
+			UnilateralRefundWithoutReceiverDelay: int32(
+				row.GetUnilateralRefundWithoutReceiverDelay(),
+			),
+			PreimageHash:      append([]byte(nil), paymentHash[:]...),
+			SignerKeyFamily:   recoverySignerFamily(),
+			SignerKeyIndex:    recoverySignerKeyIndex,
+			DestinationScript: destination.PkScript,
+			MaxFeeRateSatPerKw: c.recoveryPolicy.
+				MaxFeeRateSatPerKW,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("arm recovered out-swap claim: %w", err)
+	}
+	if resp.GetRecoveryId() == "" {
+		return fmt.Errorf("arm recovered out-swap claim returned empty id")
+	}
+
+	err = c.escalateRecoveredOutSwapClaim(
+		ctx, resp.GetRecoveryId(), preimage,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// escalateRecoveredOutSwapClaim supplies the recovered preimage to the
+// daemon-owned recovery executor so it can spend the claim path.
+func (c *SwapClient) escalateRecoveredOutSwapClaim(ctx context.Context,
+	recoveryID string, preimage *lntypes.Preimage) error {
+
+	_, err := c.daemon.EscalateVHTLCRecovery(
+		ctx, &daemonrpc.EscalateVHTLCRecoveryRequest{
+			RecoveryId:    recoveryID,
+			Reason:        "swapserver recovery claim",
+			ClaimPreimage: (*preimage)[:],
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("escalate recovered out-swap claim: %w", err)
+	}
+
+	return nil
+}
+
+// recoverableSwapPolicy rebuilds the script policy advertised by the
+// swapserver and returns the pkScript that must match indexer state.
+func recoverableSwapPolicy(row *swaprpc.RecoverableSwap) (
+	lntypes.Hash, *arkscript.VHTLCPolicy, []byte, error) {
+
+	paymentHash, err := lntypes.MakeHash(row.GetPaymentHash())
+	if err != nil {
+		return lntypes.Hash{}, nil, nil, fmt.Errorf(
+			"parse recoverable payment hash: %w", err,
+		)
+	}
+
+	sender, err := btcec.ParsePubKey(row.GetSenderPubkey())
+	if err != nil {
+		return lntypes.Hash{}, nil, nil, fmt.Errorf(
+			"parse recoverable sender key: %w", err,
+		)
+	}
+	receiver, err := btcec.ParsePubKey(row.GetReceiverPubkey())
+	if err != nil {
+		return lntypes.Hash{}, nil, nil, fmt.Errorf(
+			"parse recoverable receiver key: %w", err,
+		)
+	}
+	server, err := btcec.ParsePubKey(row.GetOperatorPubkey())
+	if err != nil {
+		return lntypes.Hash{}, nil, nil, fmt.Errorf(
+			"parse recoverable operator key: %w", err,
+		)
+	}
+
+	preimageHash := paymentHash
+	if len(row.GetPreimageHash()) != 0 {
+		preimageHash, err = lntypes.MakeHash(row.GetPreimageHash())
+		if err != nil {
+			return lntypes.Hash{}, nil, nil, fmt.Errorf(
+				"parse recoverable preimage hash: %w", err,
+			)
+		}
+	}
+	if preimageHash != paymentHash {
+		return lntypes.Hash{}, nil, nil, fmt.Errorf(
+			"recoverable preimage hash mismatch",
+		)
+	}
+
+	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:                sender,
+		Receiver:              receiver,
+		Server:                server,
+		PreimageHash:          preimageHash,
+		RefundLocktime:        row.GetRefundLocktime(),
+		UnilateralClaimDelay:  row.GetUnilateralClaimDelay(),
+		UnilateralRefundDelay: row.GetUnilateralRefundDelay(),
+		UnilateralRefundWithoutReceiverDelay: row.
+			GetUnilateralRefundWithoutReceiverDelay(),
+	})
+	if err != nil {
+		return lntypes.Hash{}, nil, nil, fmt.Errorf(
+			"build recoverable vHTLC policy: %w", err,
+		)
+	}
+
+	pkScript, err := policy.PkScript()
+	if err != nil {
+		return lntypes.Hash{}, nil, nil, fmt.Errorf(
+			"build recoverable vHTLC pkScript: %w", err,
+		)
+	}
+	if len(row.GetVhtlcPkScript()) != 0 &&
+		!bytes.Equal(pkScript, row.GetVhtlcPkScript()) {
+
+		return lntypes.Hash{}, nil, nil, fmt.Errorf(
+			"recoverable vHTLC pkScript mismatch",
+		)
+	}
+
+	return paymentHash, policy, pkScript, nil
+}

--- a/sdk/swaps/server_recovery.go
+++ b/sdk/swaps/server_recovery.go
@@ -3,14 +3,49 @@ package swaps
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightninglabs/darepo-client/swaprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 )
+
+const maxDaemonRecoveryInt32 = uint32(1<<31 - 1)
+
+type malformedRecoverableSwapError struct {
+	err error
+}
+
+// Error returns the underlying malformed recoverable row error.
+func (e *malformedRecoverableSwapError) Error() string {
+	return e.err.Error()
+}
+
+// Unwrap returns the underlying malformed recoverable row error.
+func (e *malformedRecoverableSwapError) Unwrap() error {
+	return e.err
+}
+
+// malformedRecoverableSwap marks an error as local to one server row.
+func malformedRecoverableSwap(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return &malformedRecoverableSwapError{err: err}
+}
+
+// isMalformedRecoverableSwap reports whether restore can skip the row.
+func isMalformedRecoverableSwap(err error) bool {
+	var malformed *malformedRecoverableSwapError
+
+	return errors.As(err, &malformed)
+}
 
 // SwapserverRecoveryResult summarizes vHTLC recovery rows restored from the
 // swapserver-owned discovery API.
@@ -61,7 +96,22 @@ func (c *SwapClient) RecoverSwapserverVHTLCs(ctx context.Context) (
 			ctx, clientKey, row,
 		)
 		if err != nil {
-			return nil, err
+			if !isMalformedRecoverableSwap(err) {
+				return nil, err
+			}
+
+			c.log.WarnS(ctx, "Skipping malformed recoverable swap",
+				err,
+				btclog.Hex(
+					"payment_hash", row.GetPaymentHash(),
+				),
+				slog.String(
+					"direction",
+					row.GetDirection().String(),
+				),
+			)
+
+			continue
 		}
 		if !recovered {
 			continue
@@ -71,11 +121,16 @@ func (c *SwapClient) RecoverSwapserverVHTLCs(ctx context.Context) (
 		switch row.GetDirection() {
 		case swaprpc.
 			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN:
+
 			result.RecoveredVHTLCRefunds++
 
 		case swaprpc.
 			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_OUT:
+
 			result.RecoveredVHTLCClaims++
+
+		case swaprpc.
+			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_UNSPECIFIED: //nolint:ll
 		}
 	}
 
@@ -85,7 +140,8 @@ func (c *SwapClient) RecoverSwapserverVHTLCs(ctx context.Context) (
 // recoverSwapserverVHTLC validates one server row against the vHTLC policy and
 // arms recovery only when the daemon/indexer still reports a live output.
 func (c *SwapClient) recoverSwapserverVHTLC(ctx context.Context,
-	clientKey *btcec.PublicKey, row *swaprpc.RecoverableSwap) (bool, error) {
+	clientKey *btcec.PublicKey, row *swaprpc.RecoverableSwap) (bool,
+	error) {
 
 	if row == nil || len(row.GetVhtlcPkScript()) == 0 {
 		return false, nil
@@ -93,11 +149,7 @@ func (c *SwapClient) recoverSwapserverVHTLC(ctx context.Context,
 
 	paymentHash, _, pkScript, err := recoverableSwapPolicy(row)
 	if err != nil {
-		return false, err
-	}
-	if !bytes.Equal(pkScript, row.GetVhtlcPkScript()) {
-		return false, fmt.Errorf("recoverable swap %x pkScript mismatch",
-			paymentHash[:])
+		return false, malformedRecoverableSwap(err)
 	}
 
 	live, err := c.daemon.FindLiveVTXOByPkScript(ctx, pkScript)
@@ -112,21 +164,195 @@ func (c *SwapClient) recoverSwapserverVHTLC(ctx context.Context,
 	switch row.GetDirection() {
 	case swaprpc.
 		RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN:
-
 		return true, c.armRecoveredInSwapRefund(
 			ctx, row, paymentHash, live,
 		)
 
 	case swaprpc.
 		RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_OUT:
-
 		return true, c.armRecoveredOutSwapClaim(
 			ctx, clientKey, row, paymentHash, live,
 		)
 
+	case swaprpc.
+		RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_UNSPECIFIED:
+		return false, nil
+
 	default:
 		return false, nil
 	}
+}
+
+// recoveredArmParams turns a swapserver row into the daemon arm request shape
+// after checking that server uint32 script parameters fit the daemon int32 API.
+func recoveredArmParams(row *swaprpc.RecoverableSwap, paymentHash lntypes.Hash,
+	live *VTXOInfo, direction daemonrpc.VHTLCRecoveryDirection,
+	action daemonrpc.VHTLCRecoveryAction,
+	destinationScript []byte) (armVHTLCRecoveryParams, error) {
+
+	refundLocktime, err := recoveryInt32Field(
+		"refund_locktime", row.GetRefundLocktime(),
+	)
+	if err != nil {
+		return armVHTLCRecoveryParams{}, err
+	}
+	claimDelay, err := recoveryInt32Field(
+		"unilateral_claim_delay", row.GetUnilateralClaimDelay(),
+	)
+	if err != nil {
+		return armVHTLCRecoveryParams{}, err
+	}
+	refundDelay, err := recoveryInt32Field(
+		"unilateral_refund_delay", row.GetUnilateralRefundDelay(),
+	)
+	if err != nil {
+		return armVHTLCRecoveryParams{}, err
+	}
+	refundWithoutReceiverDelay, err := recoveryInt32Field(
+		"unilateral_refund_without_receiver_delay",
+		row.GetUnilateralRefundWithoutReceiverDelay(),
+	)
+	if err != nil {
+		return armVHTLCRecoveryParams{}, err
+	}
+
+	params := armVHTLCRecoveryParams{
+		RequestID: recoveryRequestID(
+			recoveryDirectionString(direction), paymentHash, action,
+		),
+		PaymentHash:   paymentHash,
+		Direction:     direction,
+		Action:        action,
+		VTXOOutpoint:  live.Outpoint,
+		VTXOAmountSat: live.AmountSat,
+		SenderPubkey: append(
+			[]byte(nil), row.GetSenderPubkey()...,
+		),
+		ReceiverPubkey: append(
+			[]byte(nil), row.GetReceiverPubkey()...,
+		),
+		ServerPubkey: append(
+			[]byte(nil), row.GetOperatorPubkey()...,
+		),
+		RefundLocktime:        refundLocktime,
+		UnilateralClaimDelay:  claimDelay,
+		UnilateralRefundDelay: refundDelay,
+		DestinationScript: append(
+			[]byte(nil), destinationScript...,
+		),
+		MaxFeeRateSatKW: DefaultRecoveryMaxFeeRateSatPerKW,
+	}
+	params.UnilateralRefundWithoutReceiverDelay = refundWithoutReceiverDelay
+
+	return params, nil
+}
+
+// recoveryDirectionString maps daemon recovery directions to SDK request-id
+// direction labels.
+func recoveryDirectionString(
+	direction daemonrpc.VHTLCRecoveryDirection) string {
+
+	switch direction {
+	case recoveryDirectionPay:
+		return string(SwapDirectionPay)
+
+	case recoveryDirectionReceive:
+		return string(SwapDirectionReceive)
+
+	default:
+		return direction.String()
+	}
+}
+
+// recoveryInt32Field validates that server uint32 script fields fit the daemon
+// recovery API before conversion.
+func recoveryInt32Field(name string, value uint32) (int32, error) {
+	if value > maxDaemonRecoveryInt32 {
+		return 0, fmt.Errorf("%s exceeds int32", name)
+	}
+
+	return int32(value), nil
+}
+
+// existingRecoverableVHTLC returns a matching non-terminal daemon recovery row
+// for a deterministic restore request id, when one already exists.
+func (c *SwapClient) existingRecoverableVHTLC(ctx context.Context,
+	expected armVHTLCRecoveryParams) (*daemonrpc.VHTLCRecoveryStatus,
+	error) {
+
+	resp, err := c.daemon.ListVHTLCRecoveries(
+		ctx, &daemonrpc.ListVHTLCRecoveriesRequest{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list vhtlc recoveries: %w", err)
+	}
+
+	for _, status := range resp.GetStatuses() {
+		if status.GetRequestId() != expected.RequestID ||
+			recoveryStatusTerminal(status.GetState()) {
+
+			continue
+		}
+
+		if err := validateExistingRecovery(
+			status, expected,
+		); err != nil {
+			return nil, malformedRecoverableSwap(err)
+		}
+
+		return status, nil
+	}
+
+	return nil, nil
+}
+
+// recoveryStatusTerminal reports whether a daemon recovery row should not be
+// reused for restore arming.
+func recoveryStatusTerminal(state daemonrpc.VHTLCRecoveryState) bool {
+	switch state {
+	case recoveryStateCompleted, recoveryStateCancelled,
+		recoveryStateFailed:
+		return true
+
+	default:
+		return false
+	}
+}
+
+// validateExistingRecovery checks that a request-id match is the same vHTLC
+// recovery row before restore reuses it.
+func validateExistingRecovery(status *daemonrpc.VHTLCRecoveryStatus,
+	expected armVHTLCRecoveryParams) error {
+
+	if status.GetRecoveryId() == "" {
+		return fmt.Errorf("existing recovery has empty id")
+	}
+	if !bytes.Equal(status.GetSwapId(), expected.PaymentHash[:]) {
+		return fmt.Errorf("existing recovery swap id mismatch")
+	}
+	if status.GetDirection() != expected.Direction {
+		return fmt.Errorf("existing recovery direction mismatch")
+	}
+	if status.GetAction() != expected.Action {
+		return fmt.Errorf("existing recovery action mismatch")
+	}
+	if status.GetVtxoOutpoint() != expected.VTXOOutpoint {
+		return fmt.Errorf("existing recovery outpoint mismatch")
+	}
+	if status.GetVtxoAmountSat() != expected.VTXOAmountSat {
+		return fmt.Errorf("existing recovery amount mismatch")
+	}
+	if status.GetRefundLocktime() != expected.RefundLocktime ||
+		status.GetUnilateralClaimDelay() !=
+			expected.UnilateralClaimDelay ||
+		status.GetUnilateralRefundDelay() !=
+			expected.UnilateralRefundDelay ||
+		status.GetUnilateralRefundWithoutReceiverDelay() !=
+			expected.UnilateralRefundWithoutReceiverDelay {
+		return fmt.Errorf("existing recovery vHTLC config mismatch")
+	}
+
+	return nil
 }
 
 // armRecoveredInSwapRefund installs a pay-side daemon recovery row that uses
@@ -135,44 +361,36 @@ func (c *SwapClient) armRecoveredInSwapRefund(ctx context.Context,
 	row *swaprpc.RecoverableSwap, paymentHash lntypes.Hash,
 	live *VTXOInfo) error {
 
+	params, err := recoveredArmParams(
+		row, paymentHash, live, recoveryDirectionPay,
+		recoveryActionRefundWithoutReceiver, nil,
+	)
+	if err != nil {
+		return malformedRecoverableSwap(err)
+	}
+
+	existing, err := c.existingRecoverableVHTLC(ctx, params)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		return nil
+	}
+
 	destination, err := c.daemon.AllocateReceiveScript(
 		ctx, "vhtlc-recovery-refund",
 	)
 	if err != nil {
 		return fmt.Errorf("allocate refund destination: %w", err)
 	}
+	if destination == nil || len(destination.PkScript) == 0 {
+		return fmt.Errorf("refund destination script is required")
+	}
 
+	params.DestinationScript = destination.PkScript
+	params.MaxFeeRateSatKW = c.recoveryPolicy.MaxFeeRateSatPerKW
 	_, err = c.daemon.ArmVHTLCRecovery(
-		ctx, &daemonrpc.ArmVHTLCRecoveryRequest{
-			RequestId: recoveryRequestID(
-				string(SwapDirectionPay), paymentHash,
-				recoveryActionRefundWithoutReceiver,
-			),
-			SwapId:         append([]byte(nil), paymentHash[:]...),
-			Direction:      recoveryDirectionPay,
-			Action:         recoveryActionRefundWithoutReceiver,
-			VtxoOutpoint:   live.Outpoint,
-			VtxoAmountSat:  live.AmountSat,
-			SenderPubkey:   append([]byte(nil), row.GetSenderPubkey()...),
-			ReceiverPubkey: append([]byte(nil), row.GetReceiverPubkey()...),
-			ServerPubkey:   append([]byte(nil), row.GetOperatorPubkey()...),
-			RefundLocktime: int32(row.GetRefundLocktime()),
-			UnilateralClaimDelay: int32(
-				row.GetUnilateralClaimDelay(),
-			),
-			UnilateralRefundDelay: int32(
-				row.GetUnilateralRefundDelay(),
-			),
-			UnilateralRefundWithoutReceiverDelay: int32(
-				row.GetUnilateralRefundWithoutReceiverDelay(),
-			),
-			PreimageHash:      append([]byte(nil), paymentHash[:]...),
-			SignerKeyFamily:   recoverySignerFamily(),
-			SignerKeyIndex:    recoverySignerKeyIndex,
-			DestinationScript: destination.PkScript,
-			MaxFeeRateSatPerKw: c.recoveryPolicy.
-				MaxFeeRateSatPerKW,
-		},
+		ctx, buildArmVHTLCRecoveryRequest(params),
 	)
 	if err != nil {
 		return fmt.Errorf("arm recovered in-swap refund: %w", err)
@@ -192,7 +410,27 @@ func (c *SwapClient) armRecoveredOutSwapClaim(ctx context.Context,
 		row.GetEncryptedRecoveryBlob(),
 	)
 	if err != nil {
-		return fmt.Errorf("open recovered out-swap preimage: %w", err)
+		return malformedRecoverableSwap(
+			fmt.Errorf("open recovered out-swap preimage: %w", err),
+		)
+	}
+
+	params, err := recoveredArmParams(
+		row, paymentHash, live, recoveryDirectionReceive,
+		recoveryActionClaim, nil,
+	)
+	if err != nil {
+		return malformedRecoverableSwap(err)
+	}
+
+	existing, err := c.existingRecoverableVHTLC(ctx, params)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		return c.escalateRecoveredOutSwapClaim(
+			ctx, existing.GetRecoveryId(), preimage,
+		)
 	}
 
 	destination, err := c.daemon.AllocateReceiveScript(
@@ -201,50 +439,21 @@ func (c *SwapClient) armRecoveredOutSwapClaim(ctx context.Context,
 	if err != nil {
 		return fmt.Errorf("allocate claim destination: %w", err)
 	}
+	if destination == nil || len(destination.PkScript) == 0 {
+		return fmt.Errorf("claim destination script is required")
+	}
 
+	params.DestinationScript = destination.PkScript
+	params.MaxFeeRateSatKW = c.recoveryPolicy.MaxFeeRateSatPerKW
 	resp, err := c.daemon.ArmVHTLCRecovery(
-		ctx, &daemonrpc.ArmVHTLCRecoveryRequest{
-			RequestId: recoveryRequestID(
-				string(SwapDirectionReceive), paymentHash,
-				recoveryActionClaim,
-			),
-			SwapId:        append([]byte(nil), paymentHash[:]...),
-			Direction:     recoveryDirectionReceive,
-			Action:        recoveryActionClaim,
-			VtxoOutpoint:  live.Outpoint,
-			VtxoAmountSat: live.AmountSat,
-			SenderPubkey: append(
-				[]byte(nil), row.GetSenderPubkey()...,
-			),
-			ReceiverPubkey: append(
-				[]byte(nil), row.GetReceiverPubkey()...,
-			),
-			ServerPubkey: append(
-				[]byte(nil), row.GetOperatorPubkey()...,
-			),
-			RefundLocktime: int32(row.GetRefundLocktime()),
-			UnilateralClaimDelay: int32(
-				row.GetUnilateralClaimDelay(),
-			),
-			UnilateralRefundDelay: int32(
-				row.GetUnilateralRefundDelay(),
-			),
-			UnilateralRefundWithoutReceiverDelay: int32(
-				row.GetUnilateralRefundWithoutReceiverDelay(),
-			),
-			PreimageHash:      append([]byte(nil), paymentHash[:]...),
-			SignerKeyFamily:   recoverySignerFamily(),
-			SignerKeyIndex:    recoverySignerKeyIndex,
-			DestinationScript: destination.PkScript,
-			MaxFeeRateSatPerKw: c.recoveryPolicy.
-				MaxFeeRateSatPerKW,
-		},
+		ctx, buildArmVHTLCRecoveryRequest(params),
 	)
 	if err != nil {
 		return fmt.Errorf("arm recovered out-swap claim: %w", err)
 	}
 	if resp.GetRecoveryId() == "" {
-		return fmt.Errorf("arm recovered out-swap claim returned empty id")
+		return fmt.Errorf("arm recovered out-swap claim returned " +
+			"empty id")
 	}
 
 	err = c.escalateRecoveredOutSwapClaim(
@@ -278,48 +487,42 @@ func (c *SwapClient) escalateRecoveredOutSwapClaim(ctx context.Context,
 
 // recoverableSwapPolicy rebuilds the script policy advertised by the
 // swapserver and returns the pkScript that must match indexer state.
-func recoverableSwapPolicy(row *swaprpc.RecoverableSwap) (
-	lntypes.Hash, *arkscript.VHTLCPolicy, []byte, error) {
+func recoverableSwapPolicy(row *swaprpc.RecoverableSwap) (lntypes.Hash,
+	*arkscript.VHTLCPolicy, []byte, error) {
 
 	paymentHash, err := lntypes.MakeHash(row.GetPaymentHash())
 	if err != nil {
-		return lntypes.Hash{}, nil, nil, fmt.Errorf(
-			"parse recoverable payment hash: %w", err,
-		)
+		return lntypes.Hash{}, nil, nil, fmt.Errorf("parse "+
+			"recoverable payment hash: %w", err)
 	}
 
 	sender, err := btcec.ParsePubKey(row.GetSenderPubkey())
 	if err != nil {
-		return lntypes.Hash{}, nil, nil, fmt.Errorf(
-			"parse recoverable sender key: %w", err,
-		)
+		return lntypes.Hash{}, nil, nil, fmt.Errorf("parse "+
+			"recoverable sender key: %w", err)
 	}
 	receiver, err := btcec.ParsePubKey(row.GetReceiverPubkey())
 	if err != nil {
-		return lntypes.Hash{}, nil, nil, fmt.Errorf(
-			"parse recoverable receiver key: %w", err,
-		)
+		return lntypes.Hash{}, nil, nil, fmt.Errorf("parse "+
+			"recoverable receiver key: %w", err)
 	}
 	server, err := btcec.ParsePubKey(row.GetOperatorPubkey())
 	if err != nil {
-		return lntypes.Hash{}, nil, nil, fmt.Errorf(
-			"parse recoverable operator key: %w", err,
-		)
+		return lntypes.Hash{}, nil, nil, fmt.Errorf("parse "+
+			"recoverable operator key: %w", err)
 	}
 
 	preimageHash := paymentHash
 	if len(row.GetPreimageHash()) != 0 {
 		preimageHash, err = lntypes.MakeHash(row.GetPreimageHash())
 		if err != nil {
-			return lntypes.Hash{}, nil, nil, fmt.Errorf(
-				"parse recoverable preimage hash: %w", err,
-			)
+			return lntypes.Hash{}, nil, nil, fmt.Errorf("parse "+
+				"recoverable preimage hash: %w", err)
 		}
 	}
 	if preimageHash != paymentHash {
-		return lntypes.Hash{}, nil, nil, fmt.Errorf(
-			"recoverable preimage hash mismatch",
-		)
+		return lntypes.Hash{}, nil, nil, fmt.Errorf("recoverable " +
+			"preimage hash mismatch")
 	}
 
 	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
@@ -334,23 +537,19 @@ func recoverableSwapPolicy(row *swaprpc.RecoverableSwap) (
 			GetUnilateralRefundWithoutReceiverDelay(),
 	})
 	if err != nil {
-		return lntypes.Hash{}, nil, nil, fmt.Errorf(
-			"build recoverable vHTLC policy: %w", err,
-		)
+		return lntypes.Hash{}, nil, nil, fmt.Errorf("build "+
+			"recoverable vHTLC policy: %w", err)
 	}
 
 	pkScript, err := policy.PkScript()
 	if err != nil {
-		return lntypes.Hash{}, nil, nil, fmt.Errorf(
-			"build recoverable vHTLC pkScript: %w", err,
-		)
+		return lntypes.Hash{}, nil, nil, fmt.Errorf("build "+
+			"recoverable vHTLC pkScript: %w", err)
 	}
 	if len(row.GetVhtlcPkScript()) != 0 &&
 		!bytes.Equal(pkScript, row.GetVhtlcPkScript()) {
-
-		return lntypes.Hash{}, nil, nil, fmt.Errorf(
-			"recoverable vHTLC pkScript mismatch",
-		)
+		return lntypes.Hash{}, nil, nil, fmt.Errorf("recoverable " +
+			"vHTLC pkScript mismatch")
 	}
 
 	return paymentHash, policy, pkScript, nil

--- a/sdk/swaps/server_recovery_test.go
+++ b/sdk/swaps/server_recovery_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightninglabs/darepo-client/swaprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 // TestSealOutSwapRecoveryBlobRoundTrip verifies that the out-swap preimage is
@@ -29,15 +31,14 @@ func TestSealOutSwapRecoveryBlobRoundTrip(t *testing.T) {
 	}
 
 	blob, err := sealOutSwapRecoveryBlob(
-		t.Context(), daemonConn, clientPriv.PubKey(),
-		paymentHash, preimage,
+		t.Context(), daemonConn, clientPriv.PubKey(), paymentHash,
+		preimage,
 	)
 	require.NoError(t, err)
 	require.False(t, bytes.Contains(blob, preimage[:]))
 
 	recovered, err := openOutSwapRecoveryBlob(
-		t.Context(), daemonConn, clientPriv.PubKey(),
-		paymentHash, blob,
+		t.Context(), daemonConn, clientPriv.PubKey(), paymentHash, blob,
 	)
 	require.NoError(t, err)
 	require.Equal(t, preimage, *recovered)
@@ -45,8 +46,8 @@ func TestSealOutSwapRecoveryBlobRoundTrip(t *testing.T) {
 	corrupt := append([]byte(nil), blob...)
 	corrupt[len(corrupt)-1] ^= 0x01
 	_, err = openOutSwapRecoveryBlob(
-		t.Context(), daemonConn, clientPriv.PubKey(),
-		paymentHash, corrupt,
+		t.Context(), daemonConn, clientPriv.PubKey(), paymentHash,
+		corrupt,
 	)
 	require.ErrorContains(t, err, "open recovery blob")
 
@@ -56,6 +57,31 @@ func TestSealOutSwapRecoveryBlobRoundTrip(t *testing.T) {
 		t.Context(), daemonConn, clientPriv.PubKey(), wrongHash, blob,
 	)
 	require.ErrorContains(t, err, "open recovery blob")
+}
+
+// TestNewSwapOwnerProofValidation verifies owner proofs reject malformed local
+// inputs before sending recoverability data to the server.
+func TestNewSwapOwnerProofValidation(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	daemonConn := &testDaemonConn{
+		identitySignature: bytes.Repeat([]byte{1}, 63),
+	}
+	_, err = newSwapOwnerProof(
+		t.Context(), daemonConn, clientPriv.PubKey(),
+		swapRecoveryAuthList, 1,
+	)
+	require.ErrorContains(t, err, "signature must be 64 bytes")
+
+	daemonConn = &testDaemonConn{}
+	_, err = newSwapOwnerProof(
+		t.Context(), daemonConn, clientPriv.PubKey(),
+		swapRecoveryAuthList, -1,
+	)
+	require.ErrorContains(t, err, "non-negative")
 }
 
 // TestRecoverSwapserverVHTLCsArmsRefundAndClaim verifies restore discovery
@@ -76,7 +102,9 @@ func TestRecoverSwapserverVHTLCsArmsRefundAndClaim(t *testing.T) {
 		identityKey:    clientPriv.PubKey(),
 		receiveAuthKey: bytes.Repeat([]byte{4}, 32),
 		receiveInfo: &ReceiveInfo{
-			PkScript:    []byte{0x51},
+			PkScript: []byte{
+				0x51,
+			},
 			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
 		},
 		liveByPkScript: make(map[string]*VTXOInfo),
@@ -84,11 +112,13 @@ func TestRecoverSwapserverVHTLCsArmsRefundAndClaim(t *testing.T) {
 
 	inHash := lntypes.Hash(testHash(101))
 	inRow := recoverableSwapForTest(
-		t,
-		swaprpc.
+		t, swaprpc.
 			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN,
-		inHash, clientPriv.PubKey(), serverPriv.PubKey(),
-		operatorPriv.PubKey(), nil,
+		inHash,
+		clientPriv.PubKey(),
+		serverPriv.PubKey(),
+		operatorPriv.PubKey(),
+		nil,
 	)
 	daemonConn.liveByPkScript[hex.EncodeToString(
 		inRow.GetVhtlcPkScript(),
@@ -104,11 +134,13 @@ func TestRecoverSwapserverVHTLCsArmsRefundAndClaim(t *testing.T) {
 	)
 	require.NoError(t, err)
 	outRow := recoverableSwapForTest(
-		t,
-		swaprpc.
+		t, swaprpc.
 			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_OUT,
-		outHash, serverPriv.PubKey(), clientPriv.PubKey(),
-		operatorPriv.PubKey(), outBlob,
+		outHash,
+		serverPriv.PubKey(),
+		clientPriv.PubKey(),
+		operatorPriv.PubKey(),
+		outBlob,
 	)
 	daemonConn.liveByPkScript[hex.EncodeToString(
 		outRow.GetVhtlcPkScript(),
@@ -117,12 +149,15 @@ func TestRecoverSwapserverVHTLCsArmsRefundAndClaim(t *testing.T) {
 		AmountSat: 43_000,
 	}
 
+	outDirection := swaprpc.
+		RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_OUT
 	serverConn := &testSwapServerConn{
 		recoverableRows: []*swaprpc.RecoverableSwap{
 			inRow,
 			outRow,
-			{Direction: swaprpc.
-				RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_OUT},
+			{
+				Direction: outDirection,
+			},
 		},
 	}
 	client := NewSwapClient(serverConn, daemonConn, nil, nil)
@@ -135,27 +170,239 @@ func TestRecoverSwapserverVHTLCsArmsRefundAndClaim(t *testing.T) {
 	require.EqualValues(t, 1, result.RecoveredVHTLCClaims)
 	require.Equal(t, 2, daemonConn.armRecoveryCalls)
 	require.Equal(t, 1, daemonConn.escalateCalls)
-	require.Equal(t, outPreimage[:],
-		daemonConn.lastEscalate.GetClaimPreimage())
+	require.Equal(
+		t, outPreimage[:], daemonConn.lastEscalate.GetClaimPreimage(),
+	)
 
 	seenRefund := false
 	seenClaim := false
 	for _, req := range daemonConn.armRecoveries {
 		switch req.GetAction() {
+		case daemonrpc.
+			VHTLCRecoveryAction_VHTLC_RECOVERY_ACTION_UNSPECIFIED:
+
+			require.Fail(t, "unexpected unspecified action")
+
 		case recoveryActionRefundWithoutReceiver:
 			seenRefund = true
-			require.Equal(t, recoveryDirectionPay, req.GetDirection())
+			require.Equal(
+				t, recoveryDirectionPay, req.GetDirection(),
+			)
 			require.Equal(t, "in-funding:0", req.GetVtxoOutpoint())
 
 		case recoveryActionClaim:
 			seenClaim = true
-			require.Equal(t, recoveryDirectionReceive,
-				req.GetDirection())
+			require.Equal(
+				t, recoveryDirectionReceive, req.GetDirection(),
+			)
 			require.Equal(t, "out-funding:0", req.GetVtxoOutpoint())
 		}
 	}
 	require.True(t, seenRefund)
 	require.True(t, seenClaim)
+}
+
+// TestRecoverSwapserverVHTLCsReusesExistingRecovery verifies restore retries
+// reuse matching daemon rows instead of allocating new destinations.
+func TestRecoverSwapserverVHTLCsReusesExistingRecovery(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	daemonConn := &testDaemonConn{
+		identityPriv:   clientPriv,
+		identityKey:    clientPriv.PubKey(),
+		receiveAuthKey: bytes.Repeat([]byte{5}, 32),
+		liveByPkScript: make(map[string]*VTXOInfo),
+	}
+
+	inHash := lntypes.Hash(testHash(121))
+	inRow := recoverableSwapForTest(
+		t, swaprpc.
+			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN,
+		inHash,
+		clientPriv.PubKey(),
+		serverPriv.PubKey(),
+		operatorPriv.PubKey(),
+		nil,
+	)
+	inLive := &VTXOInfo{
+		Outpoint:  "existing-in:0",
+		AmountSat: 42_000,
+	}
+	daemonConn.liveByPkScript[hex.EncodeToString(
+		inRow.GetVhtlcPkScript(),
+	)] = inLive
+
+	outPreimage := lntypes.Preimage(testHash(122))
+	outHash := outPreimage.Hash()
+	outBlob, err := sealOutSwapRecoveryBlob(
+		ctx, daemonConn, clientPriv.PubKey(), outHash, outPreimage,
+	)
+	require.NoError(t, err)
+	outRow := recoverableSwapForTest(
+		t, swaprpc.
+			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_OUT,
+		outHash,
+		serverPriv.PubKey(),
+		clientPriv.PubKey(),
+		operatorPriv.PubKey(),
+		outBlob,
+	)
+	outLive := &VTXOInfo{
+		Outpoint:  "existing-out:0",
+		AmountSat: 42_000,
+	}
+	daemonConn.liveByPkScript[hex.EncodeToString(
+		outRow.GetVhtlcPkScript(),
+	)] = outLive
+	daemonConn.listRecoveriesResp = &daemonrpc.
+		ListVHTLCRecoveriesResponse{
+		Statuses: []*daemonrpc.VHTLCRecoveryStatus{
+			recoverableStatusForTest(
+				inRow, inHash, inLive, "existing-in-recovery",
+				recoveryDirectionPay,
+				recoveryActionRefundWithoutReceiver,
+			),
+			recoverableStatusForTest(
+				outRow, outHash, outLive,
+				"existing-out-recovery",
+				recoveryDirectionReceive, recoveryActionClaim,
+			),
+		},
+	}
+
+	serverConn := &testSwapServerConn{
+		recoverableRows: []*swaprpc.RecoverableSwap{
+			inRow, outRow,
+		},
+	}
+	client := NewSwapClient(serverConn, daemonConn, nil, nil)
+
+	result, err := client.RecoverSwapserverVHTLCs(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, result.RecoveredVHTLCs)
+	require.EqualValues(t, 1, result.RecoveredVHTLCRefunds)
+	require.EqualValues(t, 1, result.RecoveredVHTLCClaims)
+	require.Zero(t, daemonConn.armRecoveryCalls)
+	require.Zero(t, daemonConn.receiveAllocCalls)
+	require.Equal(t, 1, daemonConn.escalateCalls)
+	require.Equal(
+		t, "existing-out-recovery",
+		daemonConn.lastEscalate.GetRecoveryId(),
+	)
+	require.Equal(
+		t, outPreimage[:], daemonConn.lastEscalate.GetClaimPreimage(),
+	)
+}
+
+// TestRecoverSwapserverVHTLCsSkipsMalformedRows verifies one bad server row
+// does not abort recovery for the remaining rows.
+func TestRecoverSwapserverVHTLCsSkipsMalformedRows(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	validHash := lntypes.Hash(testHash(131))
+	validRow := recoverableSwapForTest(
+		t, swaprpc.
+			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN,
+		validHash,
+		clientPriv.PubKey(),
+		serverPriv.PubKey(),
+		operatorPriv.PubKey(),
+		nil,
+	)
+	malformedRow, ok := proto.Clone(validRow).(*swaprpc.RecoverableSwap)
+	require.True(t, ok)
+	malformedRow.PaymentHash = []byte{1}
+	validPkScript := hex.EncodeToString(validRow.GetVhtlcPkScript())
+
+	daemonConn := &testDaemonConn{
+		identityPriv: clientPriv,
+		identityKey:  clientPriv.PubKey(),
+		receiveInfo: &ReceiveInfo{
+			PkScript: []byte{
+				0x51,
+			},
+		},
+		liveByPkScript: map[string]*VTXOInfo{
+			validPkScript: {
+				Outpoint:  "valid:0",
+				AmountSat: 42_000,
+			},
+		},
+	}
+	serverConn := &testSwapServerConn{
+		recoverableRows: []*swaprpc.RecoverableSwap{
+			malformedRow, validRow,
+		},
+	}
+	client := NewSwapClient(serverConn, daemonConn, nil, nil)
+
+	result, err := client.RecoverSwapserverVHTLCs(t.Context())
+	require.NoError(t, err)
+	require.EqualValues(t, 1, result.RecoveredVHTLCs)
+	require.Equal(t, 1, daemonConn.armRecoveryCalls)
+}
+
+// TestRecoverSwapserverVHTLCsSkipsOverflowConfig verifies server uint32 script
+// parameters are bounds-checked before daemon int32 request construction.
+func TestRecoverSwapserverVHTLCsSkipsOverflowConfig(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	row := recoverableSwapForTest(
+		t, swaprpc.
+			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN,
+		lntypes.Hash(
+			testHash(141),
+		),
+		clientPriv.PubKey(),
+		serverPriv.PubKey(),
+		operatorPriv.PubKey(),
+		nil,
+	)
+	row.RefundLocktime = 1 << 31
+
+	daemonConn := &testDaemonConn{
+		identityPriv: clientPriv,
+		identityKey:  clientPriv.PubKey(),
+		liveByPkScript: map[string]*VTXOInfo{
+			hex.EncodeToString(row.GetVhtlcPkScript()): &VTXOInfo{
+				Outpoint:  "overflow:0",
+				AmountSat: 42_000,
+			},
+		},
+	}
+	serverConn := &testSwapServerConn{
+		recoverableRows: []*swaprpc.RecoverableSwap{
+			row,
+		},
+	}
+	client := NewSwapClient(serverConn, daemonConn, nil, nil)
+
+	result, err := client.RecoverSwapserverVHTLCs(t.Context())
+	require.NoError(t, err)
+	require.Zero(t, result.RecoveredVHTLCs)
+	require.Zero(t, daemonConn.armRecoveryCalls)
 }
 
 // TestRecoverSwapserverVHTLCsSkipsUnfundedRows verifies server-discovered rows
@@ -171,14 +418,20 @@ func TestRecoverSwapserverVHTLCsSkipsUnfundedRows(t *testing.T) {
 	require.NoError(t, err)
 
 	row := recoverableSwapForTest(
-		t,
-		swaprpc.
+		t, swaprpc.
 			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN,
-		lntypes.Hash(testHash(111)), clientPriv.PubKey(),
-		serverPriv.PubKey(), operatorPriv.PubKey(), nil,
+		lntypes.Hash(
+			testHash(111),
+		),
+		clientPriv.PubKey(),
+		serverPriv.PubKey(),
+		operatorPriv.PubKey(),
+		nil,
 	)
 	serverConn := &testSwapServerConn{
-		recoverableRows: []*swaprpc.RecoverableSwap{row},
+		recoverableRows: []*swaprpc.RecoverableSwap{
+			row,
+		},
 	}
 	daemonConn := &testDaemonConn{
 		identityPriv: clientPriv,
@@ -191,6 +444,37 @@ func TestRecoverSwapserverVHTLCsSkipsUnfundedRows(t *testing.T) {
 	require.Zero(t, result.RecoveredVHTLCs)
 	require.Zero(t, daemonConn.armRecoveryCalls)
 	require.Equal(t, 1, daemonConn.liveLookupCalls)
+}
+
+func recoverableStatusForTest(row *swaprpc.RecoverableSwap,
+	paymentHash lntypes.Hash, live *VTXOInfo, recoveryID string,
+	direction daemonrpc.VHTLCRecoveryDirection,
+	action daemonrpc.VHTLCRecoveryAction) *daemonrpc.VHTLCRecoveryStatus {
+
+	return &daemonrpc.VHTLCRecoveryStatus{
+		RecoveryId: recoveryID,
+		RequestId: recoveryRequestID(
+			recoveryDirectionString(direction), paymentHash, action,
+		),
+		SwapId:        append([]byte(nil), paymentHash[:]...),
+		Direction:     direction,
+		Action:        action,
+		State:         recoveryStateArmed,
+		VtxoOutpoint:  live.Outpoint,
+		VtxoAmountSat: live.AmountSat,
+		RefundLocktime: int32(
+			row.GetRefundLocktime(),
+		),
+		UnilateralClaimDelay: int32(
+			row.GetUnilateralClaimDelay(),
+		),
+		UnilateralRefundDelay: int32(
+			row.GetUnilateralRefundDelay(),
+		),
+		UnilateralRefundWithoutReceiverDelay: int32(
+			row.GetUnilateralRefundWithoutReceiverDelay(),
+		),
+	}
 }
 
 func recoverableSwapForTest(t *testing.T,
@@ -216,19 +500,25 @@ func recoverableSwapForTest(t *testing.T,
 	require.NoError(t, err)
 
 	return &swaprpc.RecoverableSwap{
-		Direction:                            direction,
-		PaymentHash:                          append([]byte(nil), paymentHash[:]...),
-		AmountSat:                            42_000,
-		StateName:                            "test",
-		SenderPubkey:                         sender.SerializeCompressed(),
-		ReceiverPubkey:                       receiver.SerializeCompressed(),
-		OperatorPubkey:                       operator.SerializeCompressed(),
-		PreimageHash:                         append([]byte(nil), paymentHash[:]...),
+		Direction: direction,
+		PaymentHash: append(
+			[]byte(nil), paymentHash[:]...,
+		),
+		AmountSat:      42_000,
+		StateName:      "test",
+		SenderPubkey:   sender.SerializeCompressed(),
+		ReceiverPubkey: receiver.SerializeCompressed(),
+		OperatorPubkey: operator.SerializeCompressed(),
+		PreimageHash: append(
+			[]byte(nil), paymentHash[:]...,
+		),
 		RefundLocktime:                       144,
 		UnilateralClaimDelay:                 10,
 		UnilateralRefundDelay:                20,
 		UnilateralRefundWithoutReceiverDelay: 30,
-		VhtlcPkScript:                        append([]byte(nil), pkScript...),
+		VhtlcPkScript: append(
+			[]byte(nil), pkScript...,
+		),
 		RefundAuthorizationAvailable: direction == swaprpc.
 			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN,
 		EncryptedRecoveryBlob: append([]byte(nil), encryptedBlob...),

--- a/sdk/swaps/server_recovery_test.go
+++ b/sdk/swaps/server_recovery_test.go
@@ -1,0 +1,236 @@
+package swaps
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/swaprpc"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSealOutSwapRecoveryBlobRoundTrip verifies that the out-swap preimage is
+// recoverable with seed-restorable daemon key material but not with corrupted
+// ciphertext or a mismatched payment hash.
+func TestSealOutSwapRecoveryBlobRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage := lntypes.Preimage(testHash(91))
+	paymentHash := preimage.Hash()
+	daemonConn := &testDaemonConn{
+		receiveAuthKey: bytes.Repeat([]byte{3}, 32),
+	}
+
+	blob, err := sealOutSwapRecoveryBlob(
+		t.Context(), daemonConn, clientPriv.PubKey(),
+		paymentHash, preimage,
+	)
+	require.NoError(t, err)
+	require.False(t, bytes.Contains(blob, preimage[:]))
+
+	recovered, err := openOutSwapRecoveryBlob(
+		t.Context(), daemonConn, clientPriv.PubKey(),
+		paymentHash, blob,
+	)
+	require.NoError(t, err)
+	require.Equal(t, preimage, *recovered)
+
+	corrupt := append([]byte(nil), blob...)
+	corrupt[len(corrupt)-1] ^= 0x01
+	_, err = openOutSwapRecoveryBlob(
+		t.Context(), daemonConn, clientPriv.PubKey(),
+		paymentHash, corrupt,
+	)
+	require.ErrorContains(t, err, "open recovery blob")
+
+	wrongPreimage := lntypes.Preimage(testHash(92))
+	wrongHash := wrongPreimage.Hash()
+	_, err = openOutSwapRecoveryBlob(
+		t.Context(), daemonConn, clientPriv.PubKey(), wrongHash, blob,
+	)
+	require.ErrorContains(t, err, "open recovery blob")
+}
+
+// TestRecoverSwapserverVHTLCsArmsRefundAndClaim verifies restore discovery
+// turns live in-swap and out-swap rows into daemon-owned recovery rows.
+func TestRecoverSwapserverVHTLCsArmsRefundAndClaim(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	daemonConn := &testDaemonConn{
+		identityPriv:   clientPriv,
+		identityKey:    clientPriv.PubKey(),
+		receiveAuthKey: bytes.Repeat([]byte{4}, 32),
+		receiveInfo: &ReceiveInfo{
+			PkScript:    []byte{0x51},
+			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+		},
+		liveByPkScript: make(map[string]*VTXOInfo),
+	}
+
+	inHash := lntypes.Hash(testHash(101))
+	inRow := recoverableSwapForTest(
+		t,
+		swaprpc.
+			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN,
+		inHash, clientPriv.PubKey(), serverPriv.PubKey(),
+		operatorPriv.PubKey(), nil,
+	)
+	daemonConn.liveByPkScript[hex.EncodeToString(
+		inRow.GetVhtlcPkScript(),
+	)] = &VTXOInfo{
+		Outpoint:  "in-funding:0",
+		AmountSat: 42_000,
+	}
+
+	outPreimage := lntypes.Preimage(testHash(102))
+	outHash := outPreimage.Hash()
+	outBlob, err := sealOutSwapRecoveryBlob(
+		ctx, daemonConn, clientPriv.PubKey(), outHash, outPreimage,
+	)
+	require.NoError(t, err)
+	outRow := recoverableSwapForTest(
+		t,
+		swaprpc.
+			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_OUT,
+		outHash, serverPriv.PubKey(), clientPriv.PubKey(),
+		operatorPriv.PubKey(), outBlob,
+	)
+	daemonConn.liveByPkScript[hex.EncodeToString(
+		outRow.GetVhtlcPkScript(),
+	)] = &VTXOInfo{
+		Outpoint:  "out-funding:0",
+		AmountSat: 43_000,
+	}
+
+	serverConn := &testSwapServerConn{
+		recoverableRows: []*swaprpc.RecoverableSwap{
+			inRow,
+			outRow,
+			{Direction: swaprpc.
+				RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_OUT},
+		},
+	}
+	client := NewSwapClient(serverConn, daemonConn, nil, nil)
+
+	result, err := client.RecoverSwapserverVHTLCs(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, serverConn.lastRecoverableProof)
+	require.EqualValues(t, 2, result.RecoveredVHTLCs)
+	require.EqualValues(t, 1, result.RecoveredVHTLCRefunds)
+	require.EqualValues(t, 1, result.RecoveredVHTLCClaims)
+	require.Equal(t, 2, daemonConn.armRecoveryCalls)
+	require.Equal(t, 1, daemonConn.escalateCalls)
+	require.Equal(t, outPreimage[:],
+		daemonConn.lastEscalate.GetClaimPreimage())
+
+	seenRefund := false
+	seenClaim := false
+	for _, req := range daemonConn.armRecoveries {
+		switch req.GetAction() {
+		case recoveryActionRefundWithoutReceiver:
+			seenRefund = true
+			require.Equal(t, recoveryDirectionPay, req.GetDirection())
+			require.Equal(t, "in-funding:0", req.GetVtxoOutpoint())
+
+		case recoveryActionClaim:
+			seenClaim = true
+			require.Equal(t, recoveryDirectionReceive,
+				req.GetDirection())
+			require.Equal(t, "out-funding:0", req.GetVtxoOutpoint())
+		}
+	}
+	require.True(t, seenRefund)
+	require.True(t, seenClaim)
+}
+
+// TestRecoverSwapserverVHTLCsSkipsUnfundedRows verifies server-discovered rows
+// do not arm recovery until the indexer reports the vHTLC as live.
+func TestRecoverSwapserverVHTLCsSkipsUnfundedRows(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	row := recoverableSwapForTest(
+		t,
+		swaprpc.
+			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN,
+		lntypes.Hash(testHash(111)), clientPriv.PubKey(),
+		serverPriv.PubKey(), operatorPriv.PubKey(), nil,
+	)
+	serverConn := &testSwapServerConn{
+		recoverableRows: []*swaprpc.RecoverableSwap{row},
+	}
+	daemonConn := &testDaemonConn{
+		identityPriv: clientPriv,
+		identityKey:  clientPriv.PubKey(),
+	}
+	client := NewSwapClient(serverConn, daemonConn, nil, nil)
+
+	result, err := client.RecoverSwapserverVHTLCs(t.Context())
+	require.NoError(t, err)
+	require.Zero(t, result.RecoveredVHTLCs)
+	require.Zero(t, daemonConn.armRecoveryCalls)
+	require.Equal(t, 1, daemonConn.liveLookupCalls)
+}
+
+func recoverableSwapForTest(t *testing.T,
+	direction swaprpc.RecoverableSwapDirection, paymentHash lntypes.Hash,
+	sender, receiver, operator *btcec.PublicKey,
+	encryptedBlob []byte) *swaprpc.RecoverableSwap {
+
+	t.Helper()
+
+	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:                               sender,
+		Receiver:                             receiver,
+		Server:                               operator,
+		PreimageHash:                         paymentHash,
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 10,
+		UnilateralRefundDelay:                20,
+		UnilateralRefundWithoutReceiverDelay: 30,
+	})
+	require.NoError(t, err)
+
+	pkScript, err := policy.PkScript()
+	require.NoError(t, err)
+
+	return &swaprpc.RecoverableSwap{
+		Direction:                            direction,
+		PaymentHash:                          append([]byte(nil), paymentHash[:]...),
+		AmountSat:                            42_000,
+		StateName:                            "test",
+		SenderPubkey:                         sender.SerializeCompressed(),
+		ReceiverPubkey:                       receiver.SerializeCompressed(),
+		OperatorPubkey:                       operator.SerializeCompressed(),
+		PreimageHash:                         append([]byte(nil), paymentHash[:]...),
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 10,
+		UnilateralRefundDelay:                20,
+		UnilateralRefundWithoutReceiverDelay: 30,
+		VhtlcPkScript:                        append([]byte(nil), pkScript...),
+		RefundAuthorizationAvailable: direction == swaprpc.
+			RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN,
+		EncryptedRecoveryBlob: append([]byte(nil), encryptedBlob...),
+	}
+}

--- a/sdk/walletdk/client.go
+++ b/sdk/walletdk/client.go
@@ -218,8 +218,9 @@ func (c *Client) CreateWallet(ctx context.Context, req CreateWalletRequest) (
 			GetRecoveredOorReceiveScripts(),
 		RecoveredOORRecipientEvents: initResp.GetRecoveredOorEvents(),
 		RecoveredVHTLCs:             initResp.GetRecoveredVhtlcs(),
-		RecoveredVHTLCRefunds:       initResp.GetRecoveredVhtlcRefunds(),
-		RecoveredVHTLCClaims:        initResp.GetRecoveredVhtlcClaims(),
+		RecoveredVHTLCRefunds: initResp.
+			GetRecoveredVhtlcRefunds(),
+		RecoveredVHTLCClaims: initResp.GetRecoveredVhtlcClaims(),
 	}, nil
 }
 

--- a/sdk/walletdk/client.go
+++ b/sdk/walletdk/client.go
@@ -217,6 +217,9 @@ func (c *Client) CreateWallet(ctx context.Context, req CreateWalletRequest) (
 		RecoveredOORReceiveScripts: initResp.
 			GetRecoveredOorReceiveScripts(),
 		RecoveredOORRecipientEvents: initResp.GetRecoveredOorEvents(),
+		RecoveredVHTLCs:             initResp.GetRecoveredVhtlcs(),
+		RecoveredVHTLCRefunds:       initResp.GetRecoveredVhtlcRefunds(),
+		RecoveredVHTLCClaims:        initResp.GetRecoveredVhtlcClaims(),
 	}, nil
 }
 

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -112,6 +112,9 @@ type CreateWalletResult struct {
 	RecoveredVTXOs              uint32
 	RecoveredOORReceiveScripts  uint32
 	RecoveredOORRecipientEvents uint32
+	RecoveredVHTLCs             uint32
+	RecoveredVHTLCRefunds       uint32
+	RecoveredVHTLCClaims        uint32
 }
 
 // UnlockWalletRequest unlocks an existing embedded daemon wallet.

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -201,8 +201,8 @@ type swapRuntimeClient interface {
 
 	// RecoverSwapserverVHTLCs discovers swapserver-owned recoverable vHTLC
 	// rows and arms daemon-owned recovery jobs.
-	RecoverSwapserverVHTLCs(context.Context) (*swaps.SwapserverRecoveryResult,
-		error)
+	RecoverSwapserverVHTLCs(context.Context) (
+		*swaps.SwapserverRecoveryResult, error)
 }
 
 // paySwapSession is the subset of a pay swap FSM that the daemon executor

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -198,6 +198,11 @@ type swapRuntimeClient interface {
 	// ListSwapSummaries reads durable swap summaries, optionally filtering
 	// to swaps that sdk/swaps still considers pending.
 	ListSwapSummaries(context.Context, bool) ([]swaps.SwapSummary, error)
+
+	// RecoverSwapserverVHTLCs discovers swapserver-owned recoverable vHTLC
+	// rows and arms daemon-owned recovery jobs.
+	RecoverSwapserverVHTLCs(context.Context) (*swaps.SwapserverRecoveryResult,
+		error)
 }
 
 // paySwapSession is the subset of a pay swap FSM that the daemon executor
@@ -310,6 +315,26 @@ func Register(ctx context.Context, grpcServer *grpc.Server,
 // wallet-level lifecycle policy.
 func (s *swapClientService) ResumePending(ctx context.Context) {
 	s.resumePending(ctx)
+}
+
+// RecoverVHTLCs discovers swapserver-owned recoverable vHTLC rows and arms
+// daemon-owned recovery jobs. The method satisfies darepod.SwapBackend.
+func (s *swapClientService) RecoverVHTLCs(ctx context.Context) (
+	*darepod.SwapRecoveryResult, error) {
+
+	result, err := s.client.RecoverSwapserverVHTLCs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return &darepod.SwapRecoveryResult{}, nil
+	}
+
+	return &darepod.SwapRecoveryResult{
+		RecoveredVHTLCs:       result.RecoveredVHTLCs,
+		RecoveredVHTLCRefunds: result.RecoveredVHTLCRefunds,
+		RecoveredVHTLCClaims:  result.RecoveredVHTLCClaims,
+	}, nil
 }
 
 // RegisterGateway installs the optional SwapClientService handlers on the
@@ -623,6 +648,13 @@ func (a *swapClientAdapter) ResumeReceiveViaLightning(ctx context.Context,
 	}
 
 	return &receiveSessionAdapter{session: session}, nil
+}
+
+// RecoverSwapserverVHTLCs delegates seed-restore vHTLC recovery to sdk/swaps.
+func (a *swapClientAdapter) RecoverSwapserverVHTLCs(ctx context.Context) (
+	*swaps.SwapserverRecoveryResult, error) {
+
+	return a.client.RecoverSwapserverVHTLCs(ctx)
 }
 
 // GetSwapSummary forwards direct payment-hash lookups to sdk/swaps so the

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -813,7 +813,7 @@ func TestNewSwapServerClientsREST(t *testing.T) {
 
 	hint, err := clients.server.RequestChannelID(
 		t.Context(), clientPriv.PubKey(), lntypes.Hash{1},
-		btcutil.Amount(42_000), 30,
+		btcutil.Amount(42_000), 30, nil, nil,
 	)
 	require.NoError(t, err)
 	require.Equal(t, uint64(42), hint.RouteHint.ChannelID)
@@ -1133,6 +1133,12 @@ func (f *fakeSwapRuntime) ListSwapSummaries(_ context.Context,
 	}
 
 	return summaries, nil
+}
+
+func (f *fakeSwapRuntime) RecoverSwapserverVHTLCs(context.Context) (
+	*swaps.SwapserverRecoveryResult, error) {
+
+	return &swaps.SwapserverRecoveryResult{}, nil
 }
 
 func (f *fakeSwapRuntime) awaitPayResume(t *testing.T, hash lntypes.Hash) {

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -77,6 +77,137 @@ func (SettlementType) EnumDescriptor() ([]byte, []int) {
 	return file_swap_proto_rawDescGZIP(), []int{0}
 }
 
+// RecoverableSwapDirection identifies which recovery path a row belongs to.
+type RecoverableSwapDirection int32
+
+const (
+	RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_UNSPECIFIED RecoverableSwapDirection = 0
+	// RECOVERABLE_SWAP_DIRECTION_IN identifies an Ark-to-Lightning in-swap
+	// where the client is the vHTLC sender/refunder.
+	RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_IN RecoverableSwapDirection = 1
+	// RECOVERABLE_SWAP_DIRECTION_OUT identifies a Lightning-to-Ark out-swap
+	// where the client is the vHTLC receiver/claimer.
+	RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_OUT RecoverableSwapDirection = 2
+)
+
+// Enum value maps for RecoverableSwapDirection.
+var (
+	RecoverableSwapDirection_name = map[int32]string{
+		0: "RECOVERABLE_SWAP_DIRECTION_UNSPECIFIED",
+		1: "RECOVERABLE_SWAP_DIRECTION_IN",
+		2: "RECOVERABLE_SWAP_DIRECTION_OUT",
+	}
+	RecoverableSwapDirection_value = map[string]int32{
+		"RECOVERABLE_SWAP_DIRECTION_UNSPECIFIED": 0,
+		"RECOVERABLE_SWAP_DIRECTION_IN":          1,
+		"RECOVERABLE_SWAP_DIRECTION_OUT":         2,
+	}
+)
+
+func (x RecoverableSwapDirection) Enum() *RecoverableSwapDirection {
+	p := new(RecoverableSwapDirection)
+	*p = x
+	return p
+}
+
+func (x RecoverableSwapDirection) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RecoverableSwapDirection) Descriptor() protoreflect.EnumDescriptor {
+	return file_swap_proto_enumTypes[1].Descriptor()
+}
+
+func (RecoverableSwapDirection) Type() protoreflect.EnumType {
+	return &file_swap_proto_enumTypes[1]
+}
+
+func (x RecoverableSwapDirection) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RecoverableSwapDirection.Descriptor instead.
+func (RecoverableSwapDirection) EnumDescriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{1}
+}
+
+// SwapOwnerProof proves control of one client identity key for swap recovery
+// ownership. The signature is a BIP-340 tagged Schnorr signature over the
+// server-defined canonical request message.
+type SwapOwnerProof struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// client_identity_pubkey is the compressed daemon identity pubkey that
+	// owns recoverable swap rows.
+	ClientIdentityPubkey []byte `protobuf:"bytes,1,opt,name=client_identity_pubkey,json=clientIdentityPubkey,proto3" json:"client_identity_pubkey,omitempty"`
+	// timestamp_unix is the caller's current unix timestamp. The server uses
+	// this to bound replay of list requests.
+	TimestampUnix int64 `protobuf:"varint,2,opt,name=timestamp_unix,json=timestampUnix,proto3" json:"timestamp_unix,omitempty"`
+	// nonce is caller-generated entropy included in the signed message.
+	Nonce []byte `protobuf:"bytes,3,opt,name=nonce,proto3" json:"nonce,omitempty"`
+	// signature is the raw 64-byte BIP-340 Schnorr signature.
+	Signature     []byte `protobuf:"bytes,4,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SwapOwnerProof) Reset() {
+	*x = SwapOwnerProof{}
+	mi := &file_swap_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SwapOwnerProof) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SwapOwnerProof) ProtoMessage() {}
+
+func (x *SwapOwnerProof) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SwapOwnerProof.ProtoReflect.Descriptor instead.
+func (*SwapOwnerProof) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *SwapOwnerProof) GetClientIdentityPubkey() []byte {
+	if x != nil {
+		return x.ClientIdentityPubkey
+	}
+	return nil
+}
+
+func (x *SwapOwnerProof) GetTimestampUnix() int64 {
+	if x != nil {
+		return x.TimestampUnix
+	}
+	return 0
+}
+
+func (x *SwapOwnerProof) GetNonce() []byte {
+	if x != nil {
+		return x.Nonce
+	}
+	return nil
+}
+
+func (x *SwapOwnerProof) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
 // RequestChannelIdRequest starts one Lightning-to-Ark receive negotiation.
 type RequestChannelIdRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -94,14 +225,22 @@ type RequestChannelIdRequest struct {
 	// expressed in millisatoshis. The swap server's out-swap fee is charged to
 	// the Lightning payer through the route hint and does not reduce this
 	// amount.
-	AmountMsat    uint64 `protobuf:"varint,4,opt,name=amount_msat,json=amountMsat,proto3" json:"amount_msat,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	AmountMsat uint64 `protobuf:"varint,4,opt,name=amount_msat,json=amountMsat,proto3" json:"amount_msat,omitempty"`
+	// owner_proof authenticates the daemon identity that may later list this
+	// receive negotiation for seed recovery. Rows created without this proof
+	// remain usable but are not returned by ListRecoverableSwaps.
+	OwnerProof *SwapOwnerProof `protobuf:"bytes,5,opt,name=owner_proof,json=ownerProof,proto3" json:"owner_proof,omitempty"`
+	// encrypted_recovery_blob is opaque client-encrypted recovery metadata.
+	// For out-swaps it contains the invoice preimage, sealed so only the
+	// restored client seed can decrypt it.
+	EncryptedRecoveryBlob []byte `protobuf:"bytes,6,opt,name=encrypted_recovery_blob,json=encryptedRecoveryBlob,proto3" json:"encrypted_recovery_blob,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *RequestChannelIdRequest) Reset() {
 	*x = RequestChannelIdRequest{}
-	mi := &file_swap_proto_msgTypes[0]
+	mi := &file_swap_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -113,7 +252,7 @@ func (x *RequestChannelIdRequest) String() string {
 func (*RequestChannelIdRequest) ProtoMessage() {}
 
 func (x *RequestChannelIdRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[0]
+	mi := &file_swap_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -126,7 +265,7 @@ func (x *RequestChannelIdRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequestChannelIdRequest.ProtoReflect.Descriptor instead.
 func (*RequestChannelIdRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{0}
+	return file_swap_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *RequestChannelIdRequest) GetExpirySeconds() uint32 {
@@ -157,6 +296,20 @@ func (x *RequestChannelIdRequest) GetAmountMsat() uint64 {
 	return 0
 }
 
+func (x *RequestChannelIdRequest) GetOwnerProof() *SwapOwnerProof {
+	if x != nil {
+		return x.OwnerProof
+	}
+	return nil
+}
+
+func (x *RequestChannelIdRequest) GetEncryptedRecoveryBlob() []byte {
+	if x != nil {
+		return x.EncryptedRecoveryBlob
+	}
+	return nil
+}
+
 // RequestChannelIdResponse returns the route hint for one receive negotiation.
 type RequestChannelIdResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -172,7 +325,7 @@ type RequestChannelIdResponse struct {
 
 func (x *RequestChannelIdResponse) Reset() {
 	*x = RequestChannelIdResponse{}
-	mi := &file_swap_proto_msgTypes[1]
+	mi := &file_swap_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -184,7 +337,7 @@ func (x *RequestChannelIdResponse) String() string {
 func (*RequestChannelIdResponse) ProtoMessage() {}
 
 func (x *RequestChannelIdResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[1]
+	mi := &file_swap_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -197,7 +350,7 @@ func (x *RequestChannelIdResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequestChannelIdResponse.ProtoReflect.Descriptor instead.
 func (*RequestChannelIdResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{1}
+	return file_swap_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *RequestChannelIdResponse) GetRouteHint() *RouteHint {
@@ -230,7 +383,7 @@ type AcknowledgeOutSwapHtlcRequest struct {
 
 func (x *AcknowledgeOutSwapHtlcRequest) Reset() {
 	*x = AcknowledgeOutSwapHtlcRequest{}
-	mi := &file_swap_proto_msgTypes[2]
+	mi := &file_swap_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -242,7 +395,7 @@ func (x *AcknowledgeOutSwapHtlcRequest) String() string {
 func (*AcknowledgeOutSwapHtlcRequest) ProtoMessage() {}
 
 func (x *AcknowledgeOutSwapHtlcRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[2]
+	mi := &file_swap_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -255,7 +408,7 @@ func (x *AcknowledgeOutSwapHtlcRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AcknowledgeOutSwapHtlcRequest.ProtoReflect.Descriptor instead.
 func (*AcknowledgeOutSwapHtlcRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{2}
+	return file_swap_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *AcknowledgeOutSwapHtlcRequest) GetPaymentHash() []byte {
@@ -281,7 +434,7 @@ type AcknowledgeOutSwapHtlcResponse struct {
 
 func (x *AcknowledgeOutSwapHtlcResponse) Reset() {
 	*x = AcknowledgeOutSwapHtlcResponse{}
-	mi := &file_swap_proto_msgTypes[3]
+	mi := &file_swap_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -293,7 +446,7 @@ func (x *AcknowledgeOutSwapHtlcResponse) String() string {
 func (*AcknowledgeOutSwapHtlcResponse) ProtoMessage() {}
 
 func (x *AcknowledgeOutSwapHtlcResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[3]
+	mi := &file_swap_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -306,7 +459,7 @@ func (x *AcknowledgeOutSwapHtlcResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AcknowledgeOutSwapHtlcResponse.ProtoReflect.Descriptor instead.
 func (*AcknowledgeOutSwapHtlcResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{3}
+	return file_swap_proto_rawDescGZIP(), []int{4}
 }
 
 // OutSwapHtlcEvent describes one intercepted HTLC and the vHTLC terms the swap
@@ -337,7 +490,7 @@ type OutSwapHtlcEvent struct {
 
 func (x *OutSwapHtlcEvent) Reset() {
 	*x = OutSwapHtlcEvent{}
-	mi := &file_swap_proto_msgTypes[4]
+	mi := &file_swap_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -349,7 +502,7 @@ func (x *OutSwapHtlcEvent) String() string {
 func (*OutSwapHtlcEvent) ProtoMessage() {}
 
 func (x *OutSwapHtlcEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[4]
+	mi := &file_swap_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -362,7 +515,7 @@ func (x *OutSwapHtlcEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutSwapHtlcEvent.ProtoReflect.Descriptor instead.
 func (*OutSwapHtlcEvent) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{4}
+	return file_swap_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *OutSwapHtlcEvent) GetPaymentHash() []byte {
@@ -417,7 +570,7 @@ type OutSwapHtlcPart struct {
 
 func (x *OutSwapHtlcPart) Reset() {
 	*x = OutSwapHtlcPart{}
-	mi := &file_swap_proto_msgTypes[5]
+	mi := &file_swap_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -429,7 +582,7 @@ func (x *OutSwapHtlcPart) String() string {
 func (*OutSwapHtlcPart) ProtoMessage() {}
 
 func (x *OutSwapHtlcPart) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[5]
+	mi := &file_swap_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -442,7 +595,7 @@ func (x *OutSwapHtlcPart) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutSwapHtlcPart.ProtoReflect.Descriptor instead.
 func (*OutSwapHtlcPart) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{5}
+	return file_swap_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *OutSwapHtlcPart) GetAmountMsat() uint64 {
@@ -474,7 +627,7 @@ type SwapMailboxEvent struct {
 
 func (x *SwapMailboxEvent) Reset() {
 	*x = SwapMailboxEvent{}
-	mi := &file_swap_proto_msgTypes[6]
+	mi := &file_swap_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -486,7 +639,7 @@ func (x *SwapMailboxEvent) String() string {
 func (*SwapMailboxEvent) ProtoMessage() {}
 
 func (x *SwapMailboxEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[6]
+	mi := &file_swap_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -499,7 +652,7 @@ func (x *SwapMailboxEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SwapMailboxEvent.ProtoReflect.Descriptor instead.
 func (*SwapMailboxEvent) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{6}
+	return file_swap_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *SwapMailboxEvent) GetEvent() isSwapMailboxEvent_Event {
@@ -573,7 +726,7 @@ type InArkHtlcEvent struct {
 
 func (x *InArkHtlcEvent) Reset() {
 	*x = InArkHtlcEvent{}
-	mi := &file_swap_proto_msgTypes[7]
+	mi := &file_swap_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -585,7 +738,7 @@ func (x *InArkHtlcEvent) String() string {
 func (*InArkHtlcEvent) ProtoMessage() {}
 
 func (x *InArkHtlcEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[7]
+	mi := &file_swap_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -598,7 +751,7 @@ func (x *InArkHtlcEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InArkHtlcEvent.ProtoReflect.Descriptor instead.
 func (*InArkHtlcEvent) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{7}
+	return file_swap_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *InArkHtlcEvent) GetPaymentHash() []byte {
@@ -662,7 +815,7 @@ type RouteHint struct {
 
 func (x *RouteHint) Reset() {
 	*x = RouteHint{}
-	mi := &file_swap_proto_msgTypes[8]
+	mi := &file_swap_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -674,7 +827,7 @@ func (x *RouteHint) String() string {
 func (*RouteHint) ProtoMessage() {}
 
 func (x *RouteHint) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[8]
+	mi := &file_swap_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -687,7 +840,7 @@ func (x *RouteHint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteHint.ProtoReflect.Descriptor instead.
 func (*RouteHint) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{8}
+	return file_swap_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *RouteHint) GetNodeId() []byte {
@@ -749,7 +902,7 @@ type VHTLCConfig struct {
 
 func (x *VHTLCConfig) Reset() {
 	*x = VHTLCConfig{}
-	mi := &file_swap_proto_msgTypes[9]
+	mi := &file_swap_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -761,7 +914,7 @@ func (x *VHTLCConfig) String() string {
 func (*VHTLCConfig) ProtoMessage() {}
 
 func (x *VHTLCConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[9]
+	mi := &file_swap_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -774,7 +927,7 @@ func (x *VHTLCConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VHTLCConfig.ProtoReflect.Descriptor instead.
 func (*VHTLCConfig) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{9}
+	return file_swap_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *VHTLCConfig) GetRefundLocktime() uint32 {
@@ -822,13 +975,17 @@ type CreateInSwapRequest struct {
 	// client_vhtlc_pubkey is the client's public key used in the vHTLC spend
 	// paths.
 	ClientVhtlcPubkey []byte `protobuf:"bytes,3,opt,name=client_vhtlc_pubkey,json=clientVhtlcPubkey,proto3" json:"client_vhtlc_pubkey,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// owner_proof authenticates the daemon identity that may later list this
+	// in-swap for seed recovery. Rows created without this proof remain usable
+	// but are not returned by ListRecoverableSwaps.
+	OwnerProof    *SwapOwnerProof `protobuf:"bytes,4,opt,name=owner_proof,json=ownerProof,proto3" json:"owner_proof,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateInSwapRequest) Reset() {
 	*x = CreateInSwapRequest{}
-	mi := &file_swap_proto_msgTypes[10]
+	mi := &file_swap_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -840,7 +997,7 @@ func (x *CreateInSwapRequest) String() string {
 func (*CreateInSwapRequest) ProtoMessage() {}
 
 func (x *CreateInSwapRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[10]
+	mi := &file_swap_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -853,7 +1010,7 @@ func (x *CreateInSwapRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateInSwapRequest.ProtoReflect.Descriptor instead.
 func (*CreateInSwapRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{10}
+	return file_swap_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *CreateInSwapRequest) GetInvoice() string {
@@ -873,6 +1030,290 @@ func (x *CreateInSwapRequest) GetMaxFeeSat() uint64 {
 func (x *CreateInSwapRequest) GetClientVhtlcPubkey() []byte {
 	if x != nil {
 		return x.ClientVhtlcPubkey
+	}
+	return nil
+}
+
+func (x *CreateInSwapRequest) GetOwnerProof() *SwapOwnerProof {
+	if x != nil {
+		return x.OwnerProof
+	}
+	return nil
+}
+
+// ListRecoverableSwapsRequest lists server-owned recovery metadata for one
+// authenticated client identity.
+type ListRecoverableSwapsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// owner_proof authenticates the client identity whose recoverable rows are
+	// requested.
+	OwnerProof    *SwapOwnerProof `protobuf:"bytes,1,opt,name=owner_proof,json=ownerProof,proto3" json:"owner_proof,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRecoverableSwapsRequest) Reset() {
+	*x = ListRecoverableSwapsRequest{}
+	mi := &file_swap_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRecoverableSwapsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRecoverableSwapsRequest) ProtoMessage() {}
+
+func (x *ListRecoverableSwapsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRecoverableSwapsRequest.ProtoReflect.Descriptor instead.
+func (*ListRecoverableSwapsRequest) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ListRecoverableSwapsRequest) GetOwnerProof() *SwapOwnerProof {
+	if x != nil {
+		return x.OwnerProof
+	}
+	return nil
+}
+
+// ListRecoverableSwapsResponse returns every server row that is safe for the
+// client to inspect during seed recovery.
+type ListRecoverableSwapsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// swaps are sorted by creation time within the server store.
+	Swaps         []*RecoverableSwap `protobuf:"bytes,1,rep,name=swaps,proto3" json:"swaps,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRecoverableSwapsResponse) Reset() {
+	*x = ListRecoverableSwapsResponse{}
+	mi := &file_swap_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRecoverableSwapsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRecoverableSwapsResponse) ProtoMessage() {}
+
+func (x *ListRecoverableSwapsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRecoverableSwapsResponse.ProtoReflect.Descriptor instead.
+func (*ListRecoverableSwapsResponse) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *ListRecoverableSwapsResponse) GetSwaps() []*RecoverableSwap {
+	if x != nil {
+		return x.Swaps
+	}
+	return nil
+}
+
+// RecoverableSwap carries enough server-owned metadata for a restored client
+// to rebuild a candidate vHTLC and then verify its chain/indexer state.
+type RecoverableSwap struct {
+	state                                protoimpl.MessageState   `protogen:"open.v1"`
+	Direction                            RecoverableSwapDirection `protobuf:"varint,1,opt,name=direction,proto3,enum=swaprpc.RecoverableSwapDirection" json:"direction,omitempty"`
+	PaymentHash                          []byte                   `protobuf:"bytes,2,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	AmountSat                            uint64                   `protobuf:"varint,3,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	State                                int32                    `protobuf:"varint,4,opt,name=state,proto3" json:"state,omitempty"`
+	StateName                            string                   `protobuf:"bytes,5,opt,name=state_name,json=stateName,proto3" json:"state_name,omitempty"`
+	SenderPubkey                         []byte                   `protobuf:"bytes,6,opt,name=sender_pubkey,json=senderPubkey,proto3" json:"sender_pubkey,omitempty"`
+	ReceiverPubkey                       []byte                   `protobuf:"bytes,7,opt,name=receiver_pubkey,json=receiverPubkey,proto3" json:"receiver_pubkey,omitempty"`
+	OperatorPubkey                       []byte                   `protobuf:"bytes,8,opt,name=operator_pubkey,json=operatorPubkey,proto3" json:"operator_pubkey,omitempty"`
+	PreimageHash                         []byte                   `protobuf:"bytes,9,opt,name=preimage_hash,json=preimageHash,proto3" json:"preimage_hash,omitempty"`
+	RefundLocktime                       uint32                   `protobuf:"varint,10,opt,name=refund_locktime,json=refundLocktime,proto3" json:"refund_locktime,omitempty"`
+	UnilateralClaimDelay                 uint32                   `protobuf:"varint,11,opt,name=unilateral_claim_delay,json=unilateralClaimDelay,proto3" json:"unilateral_claim_delay,omitempty"`
+	UnilateralRefundDelay                uint32                   `protobuf:"varint,12,opt,name=unilateral_refund_delay,json=unilateralRefundDelay,proto3" json:"unilateral_refund_delay,omitempty"`
+	UnilateralRefundWithoutReceiverDelay uint32                   `protobuf:"varint,13,opt,name=unilateral_refund_without_receiver_delay,json=unilateralRefundWithoutReceiverDelay,proto3" json:"unilateral_refund_without_receiver_delay,omitempty"`
+	VhtlcPkScript                        []byte                   `protobuf:"bytes,14,opt,name=vhtlc_pk_script,json=vhtlcPkScript,proto3" json:"vhtlc_pk_script,omitempty"`
+	VhtlcOutpoint                        string                   `protobuf:"bytes,15,opt,name=vhtlc_outpoint,json=vhtlcOutpoint,proto3" json:"vhtlc_outpoint,omitempty"`
+	RefundAuthorizationAvailable         bool                     `protobuf:"varint,16,opt,name=refund_authorization_available,json=refundAuthorizationAvailable,proto3" json:"refund_authorization_available,omitempty"`
+	EncryptedRecoveryBlob                []byte                   `protobuf:"bytes,17,opt,name=encrypted_recovery_blob,json=encryptedRecoveryBlob,proto3" json:"encrypted_recovery_blob,omitempty"`
+	ExpiresAt                            *timestamppb.Timestamp   `protobuf:"bytes,18,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	unknownFields                        protoimpl.UnknownFields
+	sizeCache                            protoimpl.SizeCache
+}
+
+func (x *RecoverableSwap) Reset() {
+	*x = RecoverableSwap{}
+	mi := &file_swap_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecoverableSwap) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecoverableSwap) ProtoMessage() {}
+
+func (x *RecoverableSwap) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecoverableSwap.ProtoReflect.Descriptor instead.
+func (*RecoverableSwap) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *RecoverableSwap) GetDirection() RecoverableSwapDirection {
+	if x != nil {
+		return x.Direction
+	}
+	return RecoverableSwapDirection_RECOVERABLE_SWAP_DIRECTION_UNSPECIFIED
+}
+
+func (x *RecoverableSwap) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+func (x *RecoverableSwap) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *RecoverableSwap) GetState() int32 {
+	if x != nil {
+		return x.State
+	}
+	return 0
+}
+
+func (x *RecoverableSwap) GetStateName() string {
+	if x != nil {
+		return x.StateName
+	}
+	return ""
+}
+
+func (x *RecoverableSwap) GetSenderPubkey() []byte {
+	if x != nil {
+		return x.SenderPubkey
+	}
+	return nil
+}
+
+func (x *RecoverableSwap) GetReceiverPubkey() []byte {
+	if x != nil {
+		return x.ReceiverPubkey
+	}
+	return nil
+}
+
+func (x *RecoverableSwap) GetOperatorPubkey() []byte {
+	if x != nil {
+		return x.OperatorPubkey
+	}
+	return nil
+}
+
+func (x *RecoverableSwap) GetPreimageHash() []byte {
+	if x != nil {
+		return x.PreimageHash
+	}
+	return nil
+}
+
+func (x *RecoverableSwap) GetRefundLocktime() uint32 {
+	if x != nil {
+		return x.RefundLocktime
+	}
+	return 0
+}
+
+func (x *RecoverableSwap) GetUnilateralClaimDelay() uint32 {
+	if x != nil {
+		return x.UnilateralClaimDelay
+	}
+	return 0
+}
+
+func (x *RecoverableSwap) GetUnilateralRefundDelay() uint32 {
+	if x != nil {
+		return x.UnilateralRefundDelay
+	}
+	return 0
+}
+
+func (x *RecoverableSwap) GetUnilateralRefundWithoutReceiverDelay() uint32 {
+	if x != nil {
+		return x.UnilateralRefundWithoutReceiverDelay
+	}
+	return 0
+}
+
+func (x *RecoverableSwap) GetVhtlcPkScript() []byte {
+	if x != nil {
+		return x.VhtlcPkScript
+	}
+	return nil
+}
+
+func (x *RecoverableSwap) GetVhtlcOutpoint() string {
+	if x != nil {
+		return x.VhtlcOutpoint
+	}
+	return ""
+}
+
+func (x *RecoverableSwap) GetRefundAuthorizationAvailable() bool {
+	if x != nil {
+		return x.RefundAuthorizationAvailable
+	}
+	return false
+}
+
+func (x *RecoverableSwap) GetEncryptedRecoveryBlob() []byte {
+	if x != nil {
+		return x.EncryptedRecoveryBlob
+	}
+	return nil
+}
+
+func (x *RecoverableSwap) GetExpiresAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ExpiresAt
 	}
 	return nil
 }
@@ -901,7 +1342,7 @@ type CreateInSwapResponse struct {
 
 func (x *CreateInSwapResponse) Reset() {
 	*x = CreateInSwapResponse{}
-	mi := &file_swap_proto_msgTypes[11]
+	mi := &file_swap_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -913,7 +1354,7 @@ func (x *CreateInSwapResponse) String() string {
 func (*CreateInSwapResponse) ProtoMessage() {}
 
 func (x *CreateInSwapResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[11]
+	mi := &file_swap_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -926,7 +1367,7 @@ func (x *CreateInSwapResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateInSwapResponse.ProtoReflect.Descriptor instead.
 func (*CreateInSwapResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{11}
+	return file_swap_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *CreateInSwapResponse) GetPaymentHash() []byte {
@@ -992,7 +1433,7 @@ type QuoteInSwapRequest struct {
 
 func (x *QuoteInSwapRequest) Reset() {
 	*x = QuoteInSwapRequest{}
-	mi := &file_swap_proto_msgTypes[12]
+	mi := &file_swap_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1004,7 +1445,7 @@ func (x *QuoteInSwapRequest) String() string {
 func (*QuoteInSwapRequest) ProtoMessage() {}
 
 func (x *QuoteInSwapRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[12]
+	mi := &file_swap_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1017,7 +1458,7 @@ func (x *QuoteInSwapRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuoteInSwapRequest.ProtoReflect.Descriptor instead.
 func (*QuoteInSwapRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{12}
+	return file_swap_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *QuoteInSwapRequest) GetInvoice() string {
@@ -1059,7 +1500,7 @@ type QuoteInSwapResponse struct {
 
 func (x *QuoteInSwapResponse) Reset() {
 	*x = QuoteInSwapResponse{}
-	mi := &file_swap_proto_msgTypes[13]
+	mi := &file_swap_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1071,7 +1512,7 @@ func (x *QuoteInSwapResponse) String() string {
 func (*QuoteInSwapResponse) ProtoMessage() {}
 
 func (x *QuoteInSwapResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[13]
+	mi := &file_swap_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1084,7 +1525,7 @@ func (x *QuoteInSwapResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuoteInSwapResponse.ProtoReflect.Descriptor instead.
 func (*QuoteInSwapResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{13}
+	return file_swap_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *QuoteInSwapResponse) GetPaymentHash() []byte {
@@ -1156,7 +1597,7 @@ type AuthorizeInSwapRefundRequest struct {
 
 func (x *AuthorizeInSwapRefundRequest) Reset() {
 	*x = AuthorizeInSwapRefundRequest{}
-	mi := &file_swap_proto_msgTypes[14]
+	mi := &file_swap_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1168,7 +1609,7 @@ func (x *AuthorizeInSwapRefundRequest) String() string {
 func (*AuthorizeInSwapRefundRequest) ProtoMessage() {}
 
 func (x *AuthorizeInSwapRefundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[14]
+	mi := &file_swap_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1181,7 +1622,7 @@ func (x *AuthorizeInSwapRefundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthorizeInSwapRefundRequest.ProtoReflect.Descriptor instead.
 func (*AuthorizeInSwapRefundRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{14}
+	return file_swap_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *AuthorizeInSwapRefundRequest) GetPaymentHash() []byte {
@@ -1239,7 +1680,7 @@ type AuthorizeInSwapRefundResponse struct {
 
 func (x *AuthorizeInSwapRefundResponse) Reset() {
 	*x = AuthorizeInSwapRefundResponse{}
-	mi := &file_swap_proto_msgTypes[15]
+	mi := &file_swap_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1251,7 +1692,7 @@ func (x *AuthorizeInSwapRefundResponse) String() string {
 func (*AuthorizeInSwapRefundResponse) ProtoMessage() {}
 
 func (x *AuthorizeInSwapRefundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[15]
+	mi := &file_swap_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1264,7 +1705,7 @@ func (x *AuthorizeInSwapRefundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthorizeInSwapRefundResponse.ProtoReflect.Descriptor instead.
 func (*AuthorizeInSwapRefundResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{15}
+	return file_swap_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *AuthorizeInSwapRefundResponse) GetSignature() *TaprootScriptSignature {
@@ -1300,7 +1741,7 @@ type TaprootScriptSignature struct {
 
 func (x *TaprootScriptSignature) Reset() {
 	*x = TaprootScriptSignature{}
-	mi := &file_swap_proto_msgTypes[16]
+	mi := &file_swap_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1312,7 +1753,7 @@ func (x *TaprootScriptSignature) String() string {
 func (*TaprootScriptSignature) ProtoMessage() {}
 
 func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[16]
+	mi := &file_swap_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1325,7 +1766,7 @@ func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaprootScriptSignature.ProtoReflect.Descriptor instead.
 func (*TaprootScriptSignature) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{16}
+	return file_swap_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *TaprootScriptSignature) GetPubkey() []byte {
@@ -1361,13 +1802,21 @@ var File_swap_proto protoreflect.FileDescriptor
 const file_swap_proto_rawDesc = "" +
 	"\n" +
 	"\n" +
-	"swap.proto\x12\aswaprpc\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb4\x01\n" +
+	"swap.proto\x12\aswaprpc\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa1\x01\n" +
+	"\x0eSwapOwnerProof\x124\n" +
+	"\x16client_identity_pubkey\x18\x01 \x01(\fR\x14clientIdentityPubkey\x12%\n" +
+	"\x0etimestamp_unix\x18\x02 \x01(\x03R\rtimestampUnix\x12\x14\n" +
+	"\x05nonce\x18\x03 \x01(\fR\x05nonce\x12\x1c\n" +
+	"\tsignature\x18\x04 \x01(\fR\tsignature\"\xa6\x02\n" +
 	"\x17RequestChannelIdRequest\x12%\n" +
 	"\x0eexpiry_seconds\x18\x01 \x01(\rR\rexpirySeconds\x12.\n" +
 	"\x13client_vhtlc_pubkey\x18\x02 \x01(\fR\x11clientVhtlcPubkey\x12!\n" +
 	"\fpayment_hash\x18\x03 \x01(\fR\vpaymentHash\x12\x1f\n" +
 	"\vamount_msat\x18\x04 \x01(\x04R\n" +
-	"amountMsat\"s\n" +
+	"amountMsat\x128\n" +
+	"\vowner_proof\x18\x05 \x01(\v2\x17.swaprpc.SwapOwnerProofR\n" +
+	"ownerProof\x126\n" +
+	"\x17encrypted_recovery_blob\x18\x06 \x01(\fR\x15encryptedRecoveryBlob\"s\n" +
 	"\x18RequestChannelIdResponse\x121\n" +
 	"\n" +
 	"route_hint\x18\x01 \x01(\v2\x12.swaprpc.RouteHintR\trouteHint\x12$\n" +
@@ -1413,11 +1862,41 @@ const file_swap_proto_rawDesc = "" +
 	"\x16unilateral_claim_delay\x18\x02 \x01(\rR\x14unilateralClaimDelay\x126\n" +
 	"\x17unilateral_refund_delay\x18\x03 \x01(\rR\x15unilateralRefundDelay\x12V\n" +
 	"(unilateral_refund_without_receiver_delay\x18\x04 \x01(\rR$unilateralRefundWithoutReceiverDelay\x12+\n" +
-	"\x11swapserver_pubkey\x18\x05 \x01(\fR\x10swapserverPubkey\"\x7f\n" +
+	"\x11swapserver_pubkey\x18\x05 \x01(\fR\x10swapserverPubkey\"\xb9\x01\n" +
 	"\x13CreateInSwapRequest\x12\x18\n" +
 	"\ainvoice\x18\x01 \x01(\tR\ainvoice\x12\x1e\n" +
 	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\x12.\n" +
-	"\x13client_vhtlc_pubkey\x18\x03 \x01(\fR\x11clientVhtlcPubkey\"\xc5\x02\n" +
+	"\x13client_vhtlc_pubkey\x18\x03 \x01(\fR\x11clientVhtlcPubkey\x128\n" +
+	"\vowner_proof\x18\x04 \x01(\v2\x17.swaprpc.SwapOwnerProofR\n" +
+	"ownerProof\"W\n" +
+	"\x1bListRecoverableSwapsRequest\x128\n" +
+	"\vowner_proof\x18\x01 \x01(\v2\x17.swaprpc.SwapOwnerProofR\n" +
+	"ownerProof\"N\n" +
+	"\x1cListRecoverableSwapsResponse\x12.\n" +
+	"\x05swaps\x18\x01 \x03(\v2\x18.swaprpc.RecoverableSwapR\x05swaps\"\xdc\x06\n" +
+	"\x0fRecoverableSwap\x12?\n" +
+	"\tdirection\x18\x01 \x01(\x0e2!.swaprpc.RecoverableSwapDirectionR\tdirection\x12!\n" +
+	"\fpayment_hash\x18\x02 \x01(\fR\vpaymentHash\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x03 \x01(\x04R\tamountSat\x12\x14\n" +
+	"\x05state\x18\x04 \x01(\x05R\x05state\x12\x1d\n" +
+	"\n" +
+	"state_name\x18\x05 \x01(\tR\tstateName\x12#\n" +
+	"\rsender_pubkey\x18\x06 \x01(\fR\fsenderPubkey\x12'\n" +
+	"\x0freceiver_pubkey\x18\a \x01(\fR\x0ereceiverPubkey\x12'\n" +
+	"\x0foperator_pubkey\x18\b \x01(\fR\x0eoperatorPubkey\x12#\n" +
+	"\rpreimage_hash\x18\t \x01(\fR\fpreimageHash\x12'\n" +
+	"\x0frefund_locktime\x18\n" +
+	" \x01(\rR\x0erefundLocktime\x124\n" +
+	"\x16unilateral_claim_delay\x18\v \x01(\rR\x14unilateralClaimDelay\x126\n" +
+	"\x17unilateral_refund_delay\x18\f \x01(\rR\x15unilateralRefundDelay\x12V\n" +
+	"(unilateral_refund_without_receiver_delay\x18\r \x01(\rR$unilateralRefundWithoutReceiverDelay\x12&\n" +
+	"\x0fvhtlc_pk_script\x18\x0e \x01(\fR\rvhtlcPkScript\x12%\n" +
+	"\x0evhtlc_outpoint\x18\x0f \x01(\tR\rvhtlcOutpoint\x12D\n" +
+	"\x1erefund_authorization_available\x18\x10 \x01(\bR\x1crefundAuthorizationAvailable\x126\n" +
+	"\x17encrypted_recovery_blob\x18\x11 \x01(\fR\x15encryptedRecoveryBlob\x129\n" +
+	"\n" +
+	"expires_at\x18\x12 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\"\xc5\x02\n" +
 	"\x14CreateInSwapResponse\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x1d\n" +
 	"\n" +
@@ -1457,13 +1936,18 @@ const file_swap_proto_rawDesc = "" +
 	"\x0eSettlementType\x12\x1f\n" +
 	"\x1bSETTLEMENT_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19SETTLEMENT_TYPE_LIGHTNING\x10\x01\x12\x1a\n" +
-	"\x16SETTLEMENT_TYPE_IN_ARK\x10\x022\xd0\x03\n" +
+	"\x16SETTLEMENT_TYPE_IN_ARK\x10\x02*\x8d\x01\n" +
+	"\x18RecoverableSwapDirection\x12*\n" +
+	"&RECOVERABLE_SWAP_DIRECTION_UNSPECIFIED\x10\x00\x12!\n" +
+	"\x1dRECOVERABLE_SWAP_DIRECTION_IN\x10\x01\x12\"\n" +
+	"\x1eRECOVERABLE_SWAP_DIRECTION_OUT\x10\x022\xb5\x04\n" +
 	"\vSwapService\x12W\n" +
 	"\x10RequestChannelId\x12 .swaprpc.RequestChannelIdRequest\x1a!.swaprpc.RequestChannelIdResponse\x12K\n" +
 	"\fCreateInSwap\x12\x1c.swaprpc.CreateInSwapRequest\x1a\x1d.swaprpc.CreateInSwapResponse\x12H\n" +
 	"\vQuoteInSwap\x12\x1b.swaprpc.QuoteInSwapRequest\x1a\x1c.swaprpc.QuoteInSwapResponse\x12f\n" +
 	"\x15AuthorizeInSwapRefund\x12%.swaprpc.AuthorizeInSwapRefundRequest\x1a&.swaprpc.AuthorizeInSwapRefundResponse\x12i\n" +
-	"\x16AcknowledgeOutSwapHtlc\x12&.swaprpc.AcknowledgeOutSwapHtlcRequest\x1a'.swaprpc.AcknowledgeOutSwapHtlcResponseB0Z.github.com/lightninglabs/darepo-client/swaprpcb\x06proto3"
+	"\x16AcknowledgeOutSwapHtlc\x12&.swaprpc.AcknowledgeOutSwapHtlcRequest\x1a'.swaprpc.AcknowledgeOutSwapHtlcResponse\x12c\n" +
+	"\x14ListRecoverableSwaps\x12$.swaprpc.ListRecoverableSwapsRequest\x1a%.swaprpc.ListRecoverableSwapsResponseB0Z.github.com/lightninglabs/darepo-client/swaprpcb\x06proto3"
 
 var (
 	file_swap_proto_rawDescOnce sync.Once
@@ -1477,57 +1961,70 @@ func file_swap_proto_rawDescGZIP() []byte {
 	return file_swap_proto_rawDescData
 }
 
-var file_swap_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_swap_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_swap_proto_goTypes = []any{
 	(SettlementType)(0),                    // 0: swaprpc.SettlementType
-	(*RequestChannelIdRequest)(nil),        // 1: swaprpc.RequestChannelIdRequest
-	(*RequestChannelIdResponse)(nil),       // 2: swaprpc.RequestChannelIdResponse
-	(*AcknowledgeOutSwapHtlcRequest)(nil),  // 3: swaprpc.AcknowledgeOutSwapHtlcRequest
-	(*AcknowledgeOutSwapHtlcResponse)(nil), // 4: swaprpc.AcknowledgeOutSwapHtlcResponse
-	(*OutSwapHtlcEvent)(nil),               // 5: swaprpc.OutSwapHtlcEvent
-	(*OutSwapHtlcPart)(nil),                // 6: swaprpc.OutSwapHtlcPart
-	(*SwapMailboxEvent)(nil),               // 7: swaprpc.SwapMailboxEvent
-	(*InArkHtlcEvent)(nil),                 // 8: swaprpc.InArkHtlcEvent
-	(*RouteHint)(nil),                      // 9: swaprpc.RouteHint
-	(*VHTLCConfig)(nil),                    // 10: swaprpc.VHTLCConfig
-	(*CreateInSwapRequest)(nil),            // 11: swaprpc.CreateInSwapRequest
-	(*CreateInSwapResponse)(nil),           // 12: swaprpc.CreateInSwapResponse
-	(*QuoteInSwapRequest)(nil),             // 13: swaprpc.QuoteInSwapRequest
-	(*QuoteInSwapResponse)(nil),            // 14: swaprpc.QuoteInSwapResponse
-	(*AuthorizeInSwapRefundRequest)(nil),   // 15: swaprpc.AuthorizeInSwapRefundRequest
-	(*AuthorizeInSwapRefundResponse)(nil),  // 16: swaprpc.AuthorizeInSwapRefundResponse
-	(*TaprootScriptSignature)(nil),         // 17: swaprpc.TaprootScriptSignature
-	(*timestamppb.Timestamp)(nil),          // 18: google.protobuf.Timestamp
+	(RecoverableSwapDirection)(0),          // 1: swaprpc.RecoverableSwapDirection
+	(*SwapOwnerProof)(nil),                 // 2: swaprpc.SwapOwnerProof
+	(*RequestChannelIdRequest)(nil),        // 3: swaprpc.RequestChannelIdRequest
+	(*RequestChannelIdResponse)(nil),       // 4: swaprpc.RequestChannelIdResponse
+	(*AcknowledgeOutSwapHtlcRequest)(nil),  // 5: swaprpc.AcknowledgeOutSwapHtlcRequest
+	(*AcknowledgeOutSwapHtlcResponse)(nil), // 6: swaprpc.AcknowledgeOutSwapHtlcResponse
+	(*OutSwapHtlcEvent)(nil),               // 7: swaprpc.OutSwapHtlcEvent
+	(*OutSwapHtlcPart)(nil),                // 8: swaprpc.OutSwapHtlcPart
+	(*SwapMailboxEvent)(nil),               // 9: swaprpc.SwapMailboxEvent
+	(*InArkHtlcEvent)(nil),                 // 10: swaprpc.InArkHtlcEvent
+	(*RouteHint)(nil),                      // 11: swaprpc.RouteHint
+	(*VHTLCConfig)(nil),                    // 12: swaprpc.VHTLCConfig
+	(*CreateInSwapRequest)(nil),            // 13: swaprpc.CreateInSwapRequest
+	(*ListRecoverableSwapsRequest)(nil),    // 14: swaprpc.ListRecoverableSwapsRequest
+	(*ListRecoverableSwapsResponse)(nil),   // 15: swaprpc.ListRecoverableSwapsResponse
+	(*RecoverableSwap)(nil),                // 16: swaprpc.RecoverableSwap
+	(*CreateInSwapResponse)(nil),           // 17: swaprpc.CreateInSwapResponse
+	(*QuoteInSwapRequest)(nil),             // 18: swaprpc.QuoteInSwapRequest
+	(*QuoteInSwapResponse)(nil),            // 19: swaprpc.QuoteInSwapResponse
+	(*AuthorizeInSwapRefundRequest)(nil),   // 20: swaprpc.AuthorizeInSwapRefundRequest
+	(*AuthorizeInSwapRefundResponse)(nil),  // 21: swaprpc.AuthorizeInSwapRefundResponse
+	(*TaprootScriptSignature)(nil),         // 22: swaprpc.TaprootScriptSignature
+	(*timestamppb.Timestamp)(nil),          // 23: google.protobuf.Timestamp
 }
 var file_swap_proto_depIdxs = []int32{
-	9,  // 0: swaprpc.RequestChannelIdResponse.route_hint:type_name -> swaprpc.RouteHint
-	10, // 1: swaprpc.OutSwapHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	6,  // 2: swaprpc.OutSwapHtlcEvent.parts:type_name -> swaprpc.OutSwapHtlcPart
-	5,  // 3: swaprpc.SwapMailboxEvent.out_swap_htlc:type_name -> swaprpc.OutSwapHtlcEvent
-	8,  // 4: swaprpc.SwapMailboxEvent.in_ark_htlc:type_name -> swaprpc.InArkHtlcEvent
-	10, // 5: swaprpc.InArkHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	10, // 6: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	18, // 7: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
-	0,  // 8: swaprpc.CreateInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
-	0,  // 9: swaprpc.QuoteInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
-	18, // 10: swaprpc.QuoteInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
-	17, // 11: swaprpc.AuthorizeInSwapRefundResponse.signature:type_name -> swaprpc.TaprootScriptSignature
-	1,  // 12: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
-	11, // 13: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
-	13, // 14: swaprpc.SwapService.QuoteInSwap:input_type -> swaprpc.QuoteInSwapRequest
-	15, // 15: swaprpc.SwapService.AuthorizeInSwapRefund:input_type -> swaprpc.AuthorizeInSwapRefundRequest
-	3,  // 16: swaprpc.SwapService.AcknowledgeOutSwapHtlc:input_type -> swaprpc.AcknowledgeOutSwapHtlcRequest
-	2,  // 17: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
-	12, // 18: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
-	14, // 19: swaprpc.SwapService.QuoteInSwap:output_type -> swaprpc.QuoteInSwapResponse
-	16, // 20: swaprpc.SwapService.AuthorizeInSwapRefund:output_type -> swaprpc.AuthorizeInSwapRefundResponse
-	4,  // 21: swaprpc.SwapService.AcknowledgeOutSwapHtlc:output_type -> swaprpc.AcknowledgeOutSwapHtlcResponse
-	17, // [17:22] is the sub-list for method output_type
-	12, // [12:17] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	2,  // 0: swaprpc.RequestChannelIdRequest.owner_proof:type_name -> swaprpc.SwapOwnerProof
+	11, // 1: swaprpc.RequestChannelIdResponse.route_hint:type_name -> swaprpc.RouteHint
+	12, // 2: swaprpc.OutSwapHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	8,  // 3: swaprpc.OutSwapHtlcEvent.parts:type_name -> swaprpc.OutSwapHtlcPart
+	7,  // 4: swaprpc.SwapMailboxEvent.out_swap_htlc:type_name -> swaprpc.OutSwapHtlcEvent
+	10, // 5: swaprpc.SwapMailboxEvent.in_ark_htlc:type_name -> swaprpc.InArkHtlcEvent
+	12, // 6: swaprpc.InArkHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	2,  // 7: swaprpc.CreateInSwapRequest.owner_proof:type_name -> swaprpc.SwapOwnerProof
+	2,  // 8: swaprpc.ListRecoverableSwapsRequest.owner_proof:type_name -> swaprpc.SwapOwnerProof
+	16, // 9: swaprpc.ListRecoverableSwapsResponse.swaps:type_name -> swaprpc.RecoverableSwap
+	1,  // 10: swaprpc.RecoverableSwap.direction:type_name -> swaprpc.RecoverableSwapDirection
+	23, // 11: swaprpc.RecoverableSwap.expires_at:type_name -> google.protobuf.Timestamp
+	12, // 12: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	23, // 13: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
+	0,  // 14: swaprpc.CreateInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
+	0,  // 15: swaprpc.QuoteInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
+	23, // 16: swaprpc.QuoteInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
+	22, // 17: swaprpc.AuthorizeInSwapRefundResponse.signature:type_name -> swaprpc.TaprootScriptSignature
+	3,  // 18: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
+	13, // 19: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
+	18, // 20: swaprpc.SwapService.QuoteInSwap:input_type -> swaprpc.QuoteInSwapRequest
+	20, // 21: swaprpc.SwapService.AuthorizeInSwapRefund:input_type -> swaprpc.AuthorizeInSwapRefundRequest
+	5,  // 22: swaprpc.SwapService.AcknowledgeOutSwapHtlc:input_type -> swaprpc.AcknowledgeOutSwapHtlcRequest
+	14, // 23: swaprpc.SwapService.ListRecoverableSwaps:input_type -> swaprpc.ListRecoverableSwapsRequest
+	4,  // 24: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
+	17, // 25: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
+	19, // 26: swaprpc.SwapService.QuoteInSwap:output_type -> swaprpc.QuoteInSwapResponse
+	21, // 27: swaprpc.SwapService.AuthorizeInSwapRefund:output_type -> swaprpc.AuthorizeInSwapRefundResponse
+	6,  // 28: swaprpc.SwapService.AcknowledgeOutSwapHtlc:output_type -> swaprpc.AcknowledgeOutSwapHtlcResponse
+	15, // 29: swaprpc.SwapService.ListRecoverableSwaps:output_type -> swaprpc.ListRecoverableSwapsResponse
+	24, // [24:30] is the sub-list for method output_type
+	18, // [18:24] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_swap_proto_init() }
@@ -1535,7 +2032,7 @@ func file_swap_proto_init() {
 	if File_swap_proto != nil {
 		return
 	}
-	file_swap_proto_msgTypes[6].OneofWrappers = []any{
+	file_swap_proto_msgTypes[7].OneofWrappers = []any{
 		(*SwapMailboxEvent_OutSwapHtlc)(nil),
 		(*SwapMailboxEvent_InArkHtlc)(nil),
 	}
@@ -1544,8 +2041,8 @@ func file_swap_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_swap_proto_rawDesc), len(file_swap_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   17,
+			NumEnums:      2,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -142,7 +142,8 @@ type SwapOwnerProof struct {
 	// timestamp_unix is the caller's current unix timestamp. The server uses
 	// this to bound replay of list requests.
 	TimestampUnix int64 `protobuf:"varint,2,opt,name=timestamp_unix,json=timestampUnix,proto3" json:"timestamp_unix,omitempty"`
-	// nonce is caller-generated entropy included in the signed message.
+	// nonce is 16 cryptographically random bytes generated uniquely for each
+	// request and included in the signed message.
 	Nonce []byte `protobuf:"bytes,3,opt,name=nonce,proto3" json:"nonce,omitempty"`
 	// signature is the raw 64-byte BIP-340 Schnorr signature.
 	Signature     []byte `protobuf:"bytes,4,opt,name=signature,proto3" json:"signature,omitempty"`

--- a/swaprpc/swap.pb.gw.go
+++ b/swaprpc/swap.pb.gw.go
@@ -170,6 +170,33 @@ func local_request_SwapService_AcknowledgeOutSwapHtlc_0(ctx context.Context, mar
 	return msg, metadata, err
 }
 
+func request_SwapService_ListRecoverableSwaps_0(ctx context.Context, marshaler runtime.Marshaler, client SwapServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListRecoverableSwapsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListRecoverableSwaps(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SwapService_ListRecoverableSwaps_0(ctx context.Context, marshaler runtime.Marshaler, server SwapServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListRecoverableSwapsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ListRecoverableSwaps(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterSwapServiceHandlerServer registers the http handlers for service SwapService to "mux".
 // UnaryRPC     :call SwapServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -275,6 +302,26 @@ func RegisterSwapServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux
 			return
 		}
 		forward_SwapService_AcknowledgeOutSwapHtlc_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SwapService_ListRecoverableSwaps_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/swaprpc.SwapService/ListRecoverableSwaps", runtime.WithHTTPPathPattern("/v1/swap/list-recoverable-swaps"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SwapService_ListRecoverableSwaps_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_ListRecoverableSwaps_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -401,6 +448,23 @@ func RegisterSwapServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_SwapService_AcknowledgeOutSwapHtlc_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_SwapService_ListRecoverableSwaps_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/swaprpc.SwapService/ListRecoverableSwaps", runtime.WithHTTPPathPattern("/v1/swap/list-recoverable-swaps"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SwapService_ListRecoverableSwaps_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_ListRecoverableSwaps_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -410,6 +474,7 @@ var (
 	pattern_SwapService_QuoteInSwap_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "quote-in-swap"}, ""))
 	pattern_SwapService_AuthorizeInSwapRefund_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "authorize-in-swap-refund"}, ""))
 	pattern_SwapService_AcknowledgeOutSwapHtlc_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "acknowledge-out-swap-htlc"}, ""))
+	pattern_SwapService_ListRecoverableSwaps_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "list-recoverable-swaps"}, ""))
 )
 
 var (
@@ -418,4 +483,5 @@ var (
 	forward_SwapService_QuoteInSwap_0            = runtime.ForwardResponseMessage
 	forward_SwapService_AuthorizeInSwapRefund_0  = runtime.ForwardResponseMessage
 	forward_SwapService_AcknowledgeOutSwapHtlc_0 = runtime.ForwardResponseMessage
+	forward_SwapService_ListRecoverableSwaps_0   = runtime.ForwardResponseMessage
 )

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -67,7 +67,8 @@ message SwapOwnerProof {
     // this to bound replay of list requests.
     int64 timestamp_unix = 2;
 
-    // nonce is caller-generated entropy included in the signed message.
+    // nonce is 16 cryptographically random bytes generated uniquely for each
+    // request and included in the signed message.
     bytes nonce = 3;
 
     // signature is the raw 64-byte BIP-340 Schnorr signature.

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -46,6 +46,32 @@ service SwapService {
     // acknowledgement before funding the Ark vHTLC.
     rpc AcknowledgeOutSwapHtlc (AcknowledgeOutSwapHtlcRequest)
         returns (AcknowledgeOutSwapHtlcResponse);
+
+    // ListRecoverableSwaps returns non-terminal swap rows owned by the
+    // authenticated client identity. The swap server is the discovery source;
+    // clients still verify live/spent vHTLC state against the indexer before
+    // starting recovery.
+    rpc ListRecoverableSwaps (ListRecoverableSwapsRequest)
+        returns (ListRecoverableSwapsResponse);
+}
+
+// SwapOwnerProof proves control of one client identity key for swap recovery
+// ownership. The signature is a BIP-340 tagged Schnorr signature over the
+// server-defined canonical request message.
+message SwapOwnerProof {
+    // client_identity_pubkey is the compressed daemon identity pubkey that
+    // owns recoverable swap rows.
+    bytes client_identity_pubkey = 1;
+
+    // timestamp_unix is the caller's current unix timestamp. The server uses
+    // this to bound replay of list requests.
+    int64 timestamp_unix = 2;
+
+    // nonce is caller-generated entropy included in the signed message.
+    bytes nonce = 3;
+
+    // signature is the raw 64-byte BIP-340 Schnorr signature.
+    bytes signature = 4;
 }
 
 // RequestChannelIdRequest starts one Lightning-to-Ark receive negotiation.
@@ -68,6 +94,16 @@ message RequestChannelIdRequest {
     // the Lightning payer through the route hint and does not reduce this
     // amount.
     uint64 amount_msat = 4;
+
+    // owner_proof authenticates the daemon identity that may later list this
+    // receive negotiation for seed recovery. Rows created without this proof
+    // remain usable but are not returned by ListRecoverableSwaps.
+    SwapOwnerProof owner_proof = 5;
+
+    // encrypted_recovery_blob is opaque client-encrypted recovery metadata.
+    // For out-swaps it contains the invoice preimage, sealed so only the
+    // restored client seed can decrypt it.
+    bytes encrypted_recovery_blob = 6;
 }
 
 // RequestChannelIdResponse returns the route hint for one receive negotiation.
@@ -229,6 +265,62 @@ message CreateInSwapRequest {
     // client_vhtlc_pubkey is the client's public key used in the vHTLC spend
     // paths.
     bytes client_vhtlc_pubkey = 3;
+
+    // owner_proof authenticates the daemon identity that may later list this
+    // in-swap for seed recovery. Rows created without this proof remain usable
+    // but are not returned by ListRecoverableSwaps.
+    SwapOwnerProof owner_proof = 4;
+}
+
+// RecoverableSwapDirection identifies which recovery path a row belongs to.
+enum RecoverableSwapDirection {
+    RECOVERABLE_SWAP_DIRECTION_UNSPECIFIED = 0;
+
+    // RECOVERABLE_SWAP_DIRECTION_IN identifies an Ark-to-Lightning in-swap
+    // where the client is the vHTLC sender/refunder.
+    RECOVERABLE_SWAP_DIRECTION_IN = 1;
+
+    // RECOVERABLE_SWAP_DIRECTION_OUT identifies a Lightning-to-Ark out-swap
+    // where the client is the vHTLC receiver/claimer.
+    RECOVERABLE_SWAP_DIRECTION_OUT = 2;
+}
+
+// ListRecoverableSwapsRequest lists server-owned recovery metadata for one
+// authenticated client identity.
+message ListRecoverableSwapsRequest {
+    // owner_proof authenticates the client identity whose recoverable rows are
+    // requested.
+    SwapOwnerProof owner_proof = 1;
+}
+
+// ListRecoverableSwapsResponse returns every server row that is safe for the
+// client to inspect during seed recovery.
+message ListRecoverableSwapsResponse {
+    // swaps are sorted by creation time within the server store.
+    repeated RecoverableSwap swaps = 1;
+}
+
+// RecoverableSwap carries enough server-owned metadata for a restored client
+// to rebuild a candidate vHTLC and then verify its chain/indexer state.
+message RecoverableSwap {
+    RecoverableSwapDirection direction = 1;
+    bytes payment_hash = 2;
+    uint64 amount_sat = 3;
+    int32 state = 4;
+    string state_name = 5;
+    bytes sender_pubkey = 6;
+    bytes receiver_pubkey = 7;
+    bytes operator_pubkey = 8;
+    bytes preimage_hash = 9;
+    uint32 refund_locktime = 10;
+    uint32 unilateral_claim_delay = 11;
+    uint32 unilateral_refund_delay = 12;
+    uint32 unilateral_refund_without_receiver_delay = 13;
+    bytes vhtlc_pk_script = 14;
+    string vhtlc_outpoint = 15;
+    bool refund_authorization_available = 16;
+    bytes encrypted_recovery_blob = 17;
+    google.protobuf.Timestamp expires_at = 18;
 }
 
 // CreateInSwapResponse returns the negotiated parameters for one in-swap.

--- a/swaprpc/swap.yaml
+++ b/swaprpc/swap.yaml
@@ -15,6 +15,9 @@ http:
     - selector: swaprpc.SwapService.AuthorizeInSwapRefund
       post: /v1/swap/authorize-in-swap-refund
       body: "*"
+    - selector: swaprpc.SwapService.ListRecoverableSwaps
+      post: /v1/swap/list-recoverable-swaps
+      body: "*"
     - selector: swaprpc.SwapService.AcknowledgeOutSwapHtlc
       post: /v1/swap/acknowledge-out-swap-htlc
       body: "*"

--- a/swaprpc/swap_grpc.pb.go
+++ b/swaprpc/swap_grpc.pb.go
@@ -24,6 +24,7 @@ const (
 	SwapService_QuoteInSwap_FullMethodName            = "/swaprpc.SwapService/QuoteInSwap"
 	SwapService_AuthorizeInSwapRefund_FullMethodName  = "/swaprpc.SwapService/AuthorizeInSwapRefund"
 	SwapService_AcknowledgeOutSwapHtlc_FullMethodName = "/swaprpc.SwapService/AcknowledgeOutSwapHtlc"
+	SwapService_ListRecoverableSwaps_FullMethodName   = "/swaprpc.SwapService/ListRecoverableSwaps"
 )
 
 // SwapServiceClient is the client API for SwapService service.
@@ -49,6 +50,11 @@ type SwapServiceClient interface {
 	// accepted the out-swap HTLC mailbox event. The swap server waits for this
 	// acknowledgement before funding the Ark vHTLC.
 	AcknowledgeOutSwapHtlc(ctx context.Context, in *AcknowledgeOutSwapHtlcRequest, opts ...grpc.CallOption) (*AcknowledgeOutSwapHtlcResponse, error)
+	// ListRecoverableSwaps returns non-terminal swap rows owned by the
+	// authenticated client identity. The swap server is the discovery source;
+	// clients still verify live/spent vHTLC state against the indexer before
+	// starting recovery.
+	ListRecoverableSwaps(ctx context.Context, in *ListRecoverableSwapsRequest, opts ...grpc.CallOption) (*ListRecoverableSwapsResponse, error)
 }
 
 type swapServiceClient struct {
@@ -109,6 +115,16 @@ func (c *swapServiceClient) AcknowledgeOutSwapHtlc(ctx context.Context, in *Ackn
 	return out, nil
 }
 
+func (c *swapServiceClient) ListRecoverableSwaps(ctx context.Context, in *ListRecoverableSwapsRequest, opts ...grpc.CallOption) (*ListRecoverableSwapsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListRecoverableSwapsResponse)
+	err := c.cc.Invoke(ctx, SwapService_ListRecoverableSwaps_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SwapServiceServer is the server API for SwapService service.
 // All implementations must embed UnimplementedSwapServiceServer
 // for forward compatibility.
@@ -132,6 +148,11 @@ type SwapServiceServer interface {
 	// accepted the out-swap HTLC mailbox event. The swap server waits for this
 	// acknowledgement before funding the Ark vHTLC.
 	AcknowledgeOutSwapHtlc(context.Context, *AcknowledgeOutSwapHtlcRequest) (*AcknowledgeOutSwapHtlcResponse, error)
+	// ListRecoverableSwaps returns non-terminal swap rows owned by the
+	// authenticated client identity. The swap server is the discovery source;
+	// clients still verify live/spent vHTLC state against the indexer before
+	// starting recovery.
+	ListRecoverableSwaps(context.Context, *ListRecoverableSwapsRequest) (*ListRecoverableSwapsResponse, error)
 	mustEmbedUnimplementedSwapServiceServer()
 }
 
@@ -156,6 +177,9 @@ func (UnimplementedSwapServiceServer) AuthorizeInSwapRefund(context.Context, *Au
 }
 func (UnimplementedSwapServiceServer) AcknowledgeOutSwapHtlc(context.Context, *AcknowledgeOutSwapHtlcRequest) (*AcknowledgeOutSwapHtlcResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AcknowledgeOutSwapHtlc not implemented")
+}
+func (UnimplementedSwapServiceServer) ListRecoverableSwaps(context.Context, *ListRecoverableSwapsRequest) (*ListRecoverableSwapsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListRecoverableSwaps not implemented")
 }
 func (UnimplementedSwapServiceServer) mustEmbedUnimplementedSwapServiceServer() {}
 func (UnimplementedSwapServiceServer) testEmbeddedByValue()                     {}
@@ -268,6 +292,24 @@ func _SwapService_AcknowledgeOutSwapHtlc_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SwapService_ListRecoverableSwaps_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListRecoverableSwapsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SwapServiceServer).ListRecoverableSwaps(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SwapService_ListRecoverableSwaps_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SwapServiceServer).ListRecoverableSwaps(ctx, req.(*ListRecoverableSwapsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SwapService_ServiceDesc is the grpc.ServiceDesc for SwapService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -294,6 +336,10 @@ var SwapService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AcknowledgeOutSwapHtlc",
 			Handler:    _SwapService_AcknowledgeOutSwapHtlc_Handler,
+		},
+		{
+			MethodName: "ListRecoverableSwaps",
+			Handler:    _SwapService_ListRecoverableSwaps_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/swaprpc/swap_mailboxrpc.pb.go
+++ b/swaprpc/swap_mailboxrpc.pb.go
@@ -34,6 +34,8 @@ type SwapServiceMailboxServer interface {
 	AuthorizeInSwapRefund(ctx context.Context, req *AuthorizeInSwapRefundRequest) (*AuthorizeInSwapRefundResponse, error)
 	// AcknowledgeOutSwapHtlc handles AcknowledgeOutSwapHtlc.
 	AcknowledgeOutSwapHtlc(ctx context.Context, req *AcknowledgeOutSwapHtlcRequest) (*AcknowledgeOutSwapHtlcResponse, error)
+	// ListRecoverableSwaps handles ListRecoverableSwaps.
+	ListRecoverableSwaps(ctx context.Context, req *ListRecoverableSwapsRequest) (*ListRecoverableSwapsResponse, error)
 }
 
 // RegisterSwapServiceMailboxServer registers handlers for SwapService.
@@ -87,6 +89,16 @@ func RegisterSwapServiceMailboxServer(r rpc.Router, impl SwapServiceMailboxServe
 		}
 
 		return impl.AcknowledgeOutSwapHtlc(ctx, req)
+	})
+	r.Handle("swaprpc.SwapService", "ListRecoverableSwaps", func() proto.Message {
+		return &ListRecoverableSwapsRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ListRecoverableSwapsRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ListRecoverableSwaps(ctx, req)
 	})
 }
 
@@ -198,6 +210,29 @@ func (c *SwapServiceMailboxClient) AcknowledgeOutSwapHtlc(ctx context.Context, r
 	}
 
 	resp := new(AcknowledgeOutSwapHtlcResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ListRecoverableSwaps calls the ListRecoverableSwaps RPC.
+func (c *SwapServiceMailboxClient) ListRecoverableSwaps(ctx context.Context, req *ListRecoverableSwapsRequest, opts ...rpc.RPCOptions) (*ListRecoverableSwapsResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "swaprpc.SwapService",
+		Method:  "ListRecoverableSwaps",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ListRecoverableSwapsResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/swapwallet/admin.go
+++ b/swapwallet/admin.go
@@ -83,6 +83,9 @@ func (s *Service) create(ctx context.Context, req *walletdkrpc.CreateRequest) (
 		RecoveredVtxos:             initResp.GetRecoveredVtxos(),
 		RecoveredOorReceiveScripts: initResp.GetRecoveredOorReceiveScripts(),
 		RecoveredOorEvents:         initResp.GetRecoveredOorEvents(),
+		RecoveredVhtlcs:            initResp.GetRecoveredVhtlcs(),
+		RecoveredVhtlcRefunds:      initResp.GetRecoveredVhtlcRefunds(),
+		RecoveredVhtlcClaims:       initResp.GetRecoveredVhtlcClaims(),
 	}, nil
 }
 

--- a/swapwallet/register_test.go
+++ b/swapwallet/register_test.go
@@ -25,6 +25,12 @@ func (f *fakeResumeOnlyBackend) ResumePending(_ context.Context) {
 	f.resumeCalls.Add(1)
 }
 
+func (f *fakeResumeOnlyBackend) RecoverVHTLCs(context.Context) (
+	*darepod.SwapRecoveryResult, error) {
+
+	return &darepod.SwapRecoveryResult{}, nil
+}
+
 // fakeWalletBackend satisfies both the in-Go resume handle and the gRPC-shaped
 // swap service required by the wallet registrar.
 type fakeWalletBackend struct {
@@ -35,6 +41,12 @@ type fakeWalletBackend struct {
 
 func (f *fakeWalletBackend) ResumePending(_ context.Context) {
 	f.resumeCalls.Add(1)
+}
+
+func (f *fakeWalletBackend) RecoverVHTLCs(context.Context) (
+	*darepod.SwapRecoveryResult, error) {
+
+	return &darepod.SwapRecoveryResult{}, nil
 }
 
 // TestRegisterDefersResumeUntilWalletReadyHook confirms the wallet subserver


### PR DESCRIPTION
## Summary
- add recoverable-swap RPCs, owner-proof fields, daemon identity Schnorr signing, and wallet recovery counters
- register in-swap owner proofs and sealed out-swap recovery blobs at swap setup time
- call ListRecoverableSwaps during wallet recovery to arm safe in-swap refunds and decrypt/escalate out-swap claims
- companion swapserver PR: lightninglabs/swapdk-server#131

## Tests
- make rpc
- make commitmsg-lint range=origin/main..HEAD
- go test ./sdk/swaps ./darepod ./sdk/ark ./sdk/walletdk
- go test -tags=swapruntime ./swapclientserver
- go test -tags='swapruntime walletdkrpc' ./swapwallet