### PR TITLE
round: route boarding failures by round id (darepo#571)

### DIFF
--- a/round/actor.go
+++ b/round/actor.go
@@ -1792,12 +1792,44 @@ func (a *RoundClientActor) routeServerMessageToPending(ctx context.Context,
 
 	roundFSM := a.findPendingRound()
 
-	// Round failures can arrive after the round is keyed by a
-	// server-assigned RoundID. When there is exactly one tracked
-	// round, route the failure there.
+	// Round failures can arrive after the round has been re-keyed by a
+	// server-assigned RoundID, so findPendingRound (which only matches
+	// temp-keyed rounds) misses them. Route them deterministically by the
+	// RoundID the failure carries, falling back to the sole-round heuristic
+	// for failures that predate round assignment (e.g. ClientErrorResp).
 	if roundFSM == nil {
-		_, isBoardingFailed := msg.(*BoardingFailed)
-		if isBoardingFailed && len(a.rounds) == 1 {
+		bf, isBoardingFailed := msg.(*BoardingFailed)
+
+		// Prefer the deterministic lookup by the server-assigned
+		// RoundID. This works regardless of how many rounds (including
+		// lingering terminal ones) are tracked.
+		if isBoardingFailed {
+			bf.RoundID.WhenSome(func(rid RoundID) {
+				keyStr := RoundKeyStr(rid.KeyString())
+				if candidate, ok := a.rounds[keyStr]; ok {
+					roundFSM = candidate
+
+					a.log.DebugS(ctx,
+						"Routing BoardingFailed by "+
+							"RoundID",
+						slog.String(
+							"key", candidate.Key.
+								KeyString(),
+						))
+				}
+			})
+		}
+
+		// Fall back to the sole-round heuristic only for failures that
+		// carry no RoundID (pre-assignment failures, e.g.
+		// ClientErrorResp) when exactly one round is tracked. A failure
+		// that carries a RoundID which matched nothing above is a
+		// genuine miss (e.g. the round was already reaped); routing it
+		// to an unrelated sole round would fail the wrong round, so we
+		// let it miss instead.
+		if roundFSM == nil && isBoardingFailed && bf.RoundID.IsNone() &&
+			len(a.rounds) == 1 {
+
 			for _, candidate := range a.rounds {
 				roundFSM = candidate
 			}

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -1079,6 +1079,37 @@ func (h *actorTestHarness) setupRoundInIntentSentState() TempRoundKey {
 	return tempKey
 }
 
+// injectRoundInState creates a round FSM in the given initial state, keyed by
+// the supplied server-assigned RoundID, and adds it to the actor's rounds map.
+// It mirrors the construction of the other setupRoundIn* helpers but lets the
+// caller pick the state, which the BoardingFailed routing test needs to stage
+// both a lingering terminal round and a live waiting round under distinct
+// RoundIDs.
+func (h *actorTestHarness) injectRoundInState(roundID RoundID,
+	initialState ClientState) {
+
+	h.t.Helper()
+
+	errReporter := newContextErrorReporter(
+		h.ctx, roundID.LogPrefix(),
+	)
+	fsmCfg := ClientStateMachineCfg{
+		Logger:        h.actor.log.WithPrefix(roundID.LogPrefix()),
+		ErrorReporter: errReporter,
+		InitialState:  initialState,
+		Env:           h.actor.env,
+	}
+	newFSM := protofsm.NewStateMachine(fsmCfg)
+	newFSM.Start(h.ctx)
+
+	keyStr := RoundKeyStr(roundID.KeyString())
+	h.actor.rounds[keyStr] = &RoundFSM{
+		FSM:     &newFSM,
+		Key:     roundID,
+		RoundID: roundID,
+	}
+}
+
 // setupMockRoundStoreForRecovery configures the RoundStore mock to return
 // active rounds for recovery on Start(), using PartialSigsSentState which is
 // stable and won't immediately transition on recovery.

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -1517,6 +1517,125 @@ func TestActorServerMessageRouting(t *testing.T) {
 	}
 }
 
+// TestBoardingFailedRoutesByRoundIDWithLingeringRound reproduces the
+// darepo-client#571 dropped-event bug and proves the RoundID-keyed routing
+// fix. Two rounds are tracked: a lingering terminal round (ClientFailedState,
+// which is never evicted from a.rounds) and a live round re-keyed to a
+// server-assigned RoundID sitting in RoundJoinedState. A server
+// ClientRoundFailedResp for the live round arrives as a BoardingFailed
+// carrying that RoundID. Before the fix, findPendingRound missed the re-keyed
+// live round and the sole-round fallback bailed (len(a.rounds) == 2), so the
+// failure was silently dropped and the live round stayed stuck projecting a
+// phantom pending VTXO forever. With the fix, the failure is routed
+// deterministically by RoundID and the live round transitions to
+// ClientFailedState.
+func TestBoardingFailedRoutesByRoundIDWithLingeringRound(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	h.setupMockRoundStoreForStart()
+	require.NoError(t, h.start())
+
+	// Stage a lingering terminal round under its own RoundID. Terminal
+	// FSMs are reaped lazily, not on entry, so this round stays in
+	// a.rounds and is what makes the sole-round heuristic bail.
+	lingeringID := testRoundID("lingering-failed-round")
+	h.injectRoundInState(lingeringID, &ClientFailedState{
+		Reason:      "earlier round failed",
+		Recoverable: true,
+	})
+
+	// Stage the live round re-keyed to its server-assigned RoundID, parked
+	// in a waiting state (RoundJoinedState) that projects a pending VTXO.
+	liveID := testRoundID("live-joined-round")
+	h.injectRoundInState(liveID, &RoundJoinedState{
+		RoundID: liveID,
+	})
+
+	// Sanity check: two rounds are tracked, so the sole-round heuristic
+	// alone cannot route the failure.
+	require.Len(t, h.queryState(), 2)
+
+	// Deliver the server failure for the live round through the same path
+	// handleServerMessage uses, carrying the live round's RoundID exactly
+	// as BoardingFailed.FromProto populates it from a
+	// ClientRoundFailedResp.
+	h.sendServerMessage(&BoardingFailed{
+		RoundID:     fn.Some(liveID),
+		Reason:      "operator failed to build round",
+		Recoverable: true,
+	})
+
+	// The live round must have consumed the failure and transitioned to
+	// ClientFailedState rather than dropping it and staying in
+	// RoundJoinedState.
+	states := h.queryState()
+
+	liveInfo, ok := states[liveID.KeyString()]
+	require.True(t, ok, "live round should still be tracked")
+	require.IsType(
+		t, &ClientFailedState{}, liveInfo.State,
+		"live round should have failed, not stayed in RoundJoinedState",
+	)
+
+	// The lingering round must be untouched: routing was deterministic and
+	// did not leak the failure into the wrong FSM.
+	lingeringInfo, ok := states[lingeringID.KeyString()]
+	require.True(t, ok, "lingering round should still be tracked")
+	require.IsType(
+		t, &ClientFailedState{}, lingeringInfo.State,
+	)
+	failed, ok := lingeringInfo.State.(*ClientFailedState)
+	require.True(t, ok)
+	require.Equal(
+		t, "earlier round failed", failed.Reason,
+		"lingering round's failure reason must be unchanged",
+	)
+}
+
+// TestBoardingFailedMismatchedRoundIDDoesNotMisroute verifies that a
+// BoardingFailed carrying a RoundID that matches no tracked round is treated
+// as a genuine miss rather than being misrouted to the sole tracked round.
+// The sole-round fallback must apply only to failures that carry NO RoundID
+// (pre-assignment failures); a present-but-mismatched id (e.g. for an
+// already-reaped round) must not fail an unrelated round.
+func TestBoardingFailedMismatchedRoundIDDoesNotMisroute(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	h.setupMockRoundStoreForStart()
+	require.NoError(t, h.start())
+
+	// Exactly one round is tracked, parked in a waiting state.
+	liveID := testRoundID("live-joined-round")
+	h.injectRoundInState(liveID, &RoundJoinedState{RoundID: liveID})
+	require.Len(t, h.queryState(), 1)
+
+	// Deliver a failure for a DIFFERENT round id. findPendingRound misses
+	// (the round is re-keyed), the RoundID lookup misses (no such round),
+	// and the sole-round fallback must NOT fire because the id is present.
+	otherID := testRoundID("some-other-round")
+	result := h.receive(&ServerMessageNotification{
+		Message: &BoardingFailed{
+			RoundID:     fn.Some(otherID),
+			Reason:      "failure for an unrelated round",
+			Recoverable: true,
+		},
+	})
+	require.False(
+		t, result.IsOk(),
+		"a mismatched-RoundID failure must miss, not misroute",
+	)
+
+	// The sole round must be untouched — still in its waiting state.
+	liveInfo, ok := h.queryState()[liveID.KeyString()]
+	require.True(t, ok, "the live round should still be tracked")
+	require.IsType(
+		t, &RoundJoinedState{}, liveInfo.State,
+		"sole round must not have been failed by an unrelated failure",
+	)
+}
+
 // TestHandleRefreshVTXORequest verifies that refresh requests from VTXO actors
 // are properly forwarded to the primary FSM and tracked for inclusion in the
 // next round registration.

--- a/round/events.go
+++ b/round/events.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
 // ClientEvent is a sealed interface for all events that can be processed by
@@ -346,6 +347,13 @@ func (e *BoardingConfirmed) clientEventSealed() {}
 // BoardingFailed is emitted when an error occurs during the boarding
 // process.
 type BoardingFailed struct {
+	// RoundID is the server-assigned round id when the failure carries
+	// one (ClientRoundFailedResp). It is None for failures that arrive
+	// before a round was assigned (e.g. ClientErrorResp). When set, the
+	// actor routes the failure deterministically to the matching FSM
+	// instead of relying on the sole-round heuristic.
+	RoundID fn.Option[RoundID]
+
 	// Reason is a human-readable description of the failure.
 	Reason string
 

--- a/round/from_proto.go
+++ b/round/from_proto.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"google.golang.org/protobuf/proto"
 )
@@ -428,6 +429,18 @@ func (e *BoardingFailed) FromProto(p proto.Message) error {
 	case *roundpb.ClientRoundFailedResp:
 		e.Reason = pb.Reason
 		e.Recoverable = true
+
+		// Carry the server-assigned round id when present so the actor
+		// can route this failure deterministically to the matching FSM.
+		// A failure that arrives before the round was assigned
+		// legitimately has no id (len != roundIDLen), in which case
+		// RoundID stays None and routing falls back to the sole-round
+		// heuristic.
+		if len(pb.RoundId) == roundIDLen {
+			var rid RoundID
+			copy(rid[:], pb.RoundId)
+			e.RoundID = fn.Some(rid)
+		}
 
 		return nil
 

--- a/round/from_proto_test.go
+++ b/round/from_proto_test.go
@@ -220,10 +220,17 @@ func TestOperatorSignedFromProto(t *testing.T) {
 }
 
 // TestBoardingFailedFromProtoRoundFailed verifies that BoardingFailed
-// handles ClientRoundFailedResp.
+// handles ClientRoundFailedResp and carries the server-assigned RoundID
+// when the proto includes a well-formed 16-byte round_id
+// (darepo-client#571).
 func TestBoardingFailedFromProtoRoundFailed(t *testing.T) {
+	roundID := [16]byte{
+		1, 2, 3, 4, 5, 6, 7, 8,
+		9, 10, 11, 12, 13, 14, 15, 16,
+	}
+
 	pb := &roundpb.ClientRoundFailedResp{
-		RoundId: make([]byte, 16),
+		RoundId: roundID[:],
 		Reason:  "timeout expired",
 	}
 
@@ -231,10 +238,35 @@ func TestBoardingFailedFromProtoRoundFailed(t *testing.T) {
 	require.NoError(t, got.FromProto(pb))
 	require.Equal(t, "timeout expired", got.Reason)
 	require.True(t, got.Recoverable)
+	require.True(
+		t, got.RoundID.IsSome(),
+		"a 16-byte round_id should populate RoundID",
+	)
+	require.Equal(t, RoundID(roundID), got.RoundID.UnwrapOr(RoundID{}))
+}
+
+// TestBoardingFailedFromProtoRoundFailedNoRoundID verifies that a
+// ClientRoundFailedResp without a well-formed 16-byte round_id (a failure
+// that arrives before the round was assigned) leaves RoundID as None
+// rather than erroring (darepo-client#571).
+func TestBoardingFailedFromProtoRoundFailedNoRoundID(t *testing.T) {
+	pb := &roundpb.ClientRoundFailedResp{
+		Reason: "pre-assignment failure",
+	}
+
+	var got BoardingFailed
+	require.NoError(t, got.FromProto(pb))
+	require.Equal(t, "pre-assignment failure", got.Reason)
+	require.True(t, got.Recoverable)
+	require.True(
+		t, got.RoundID.IsNone(),
+		"an empty round_id should leave RoundID None",
+	)
 }
 
 // TestBoardingFailedFromProtoErrorResp verifies that BoardingFailed
 // handles ClientErrorResp (the other proto type that maps to this event).
+// ClientErrorResp has no round_id, so RoundID stays None.
 func TestBoardingFailedFromProtoErrorResp(t *testing.T) {
 	pb := &roundpb.ClientErrorResp{
 		ErrorMsg: "internal error",
@@ -244,6 +276,10 @@ func TestBoardingFailedFromProtoErrorResp(t *testing.T) {
 	require.NoError(t, got.FromProto(pb))
 	require.Equal(t, "internal error", got.Reason)
 	require.True(t, got.Recoverable)
+	require.True(
+		t, got.RoundID.IsNone(),
+		"ClientErrorResp carries no round_id",
+	)
 }
 
 // TestFromProtoWrongType verifies that FromProto returns an error for

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -52,6 +52,11 @@ type Musig2PubNonce = tree.Musig2PubNonce
 // RoundID is a unique identifier for rounds, using UUID v7 for time-ordering.
 type RoundID uuid.UUID
 
+// roundIDLen is the wire byte length of a RoundID (a UUID). Derived from
+// the type so it tracks RoundID automatically. Used to validate raw
+// round_id byte slices decoded off the wire.
+const roundIDLen = len(RoundID{})
+
 // NewRoundID generates a new unique RoundID using cryptographic randomness.
 func NewRoundID() (RoundID, error) {
 	id, err := uuid.NewV7()


### PR DESCRIPTION
## Summary

Client-side half of [darepo#571](https://github.com/lightninglabs/darepo/issues/571) (proposal #3): *"surface round-build failures back to the client so a deposit does not sit silently pending."*

### Root cause

When the operator fails to build a round, it sends every client a `ClientRoundFailedResp` carrying the round id. On the client this becomes a `BoardingFailed` event, and the transition table maps `BoardingFailed → ClientFailedState` from every state — so **if the event reaches the FSM**, the round fails cleanly and stops projecting pending VTXOs.

But `BoardingFailed.FromProto` **discarded the round id**. With no id, `extractRoundID` has no `*BoardingFailed` case, so routing fell to `routeServerMessageToPending`, which only matches *temp-keyed* rounds via `findPendingRound`. After `RoundJoined` re-keys the FSM to its server-assigned round id, that lookup misses, and delivery fell back to a heuristic that routes the failure **only when exactly one round is tracked**. Terminal FSMs (`ClientFailedState`/`ConfirmedState`) are never evicted from the rounds map, so as soon as any prior round lingered, `len(a.rounds) != 1`, the heuristic bailed, and the failure was **silently dropped** (the durable `Tell` had already acked, so the ingress cursor advanced and the envelope was GC'd).

The live round then stayed stuck in a waiting state (e.g. `RoundJoinedState`), whose `liveRoundDetails` projects a synthetic `VTXO_STATUS_PENDING_ROUND` — so the boarding deposit appeared **"pending" forever**.

### Fix

- Carry the round id on `BoardingFailed` (`fn.Option[RoundID]`), populated from the 16-byte `ClientRoundFailedResp.round_id`. It stays `None` for failures that predate round assignment (e.g. `ClientErrorResp`, which has no round id).
- In `routeServerMessageToPending`, route a `BoardingFailed` **deterministically by its round id** (looking up the re-keyed FSM directly), regardless of how many rounds are tracked. The sole-round heuristic is retained only as a fallback for failures that carry no id.

With this, a server round failure always reaches the correct FSM → `ClientFailedState` → the phantom pending VTXO disappears, and `ListRounds`/`GetRound` surface `ROUND_STATE_FAILED` with the reason.

## Testing

- New `TestBoardingFailedRoutesByRoundIDWithLingeringRound`: stages a lingering terminal round **plus** a live re-keyed round (so `len(a.rounds) == 2`), delivers the failure, and asserts it routes to the live round (→ `ClientFailedState`) while the lingering round is untouched. Verified that reverting only the routing change makes this test fail with the exact dropped-event symptom (`no pending round for event *round.BoardingFailed`).
- `FromProto` tests for round-id present (→ `Some`), empty round-id (→ `None`), and `ClientErrorResp` (→ `None`).
- `go build`, `go test ./round/...`, `make fmt-changed`, `make lint-changed-local` (0 issues), `make commitmsg-lint` all pass.

## Scope / follow-up

This fixes the **"pending forever"** mechanism (the headline symptom). One further enhancement from the issue — **auto-retrying** a failed boarding on a *running* daemon (today a confirmed boarding intent is only re-boarded on daemon-restart replay, not after a live round failure) — is intentionally left as a separate change; it is a larger wallet-orchestration feature and is independent of this routing correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)