### PR TITLE
round: release forfeit reservations on pre-signing round failure

### DIFF
--- a/round/forfeit_release_on_failure_test.go
+++ b/round/forfeit_release_on_failure_test.go
@@ -1,0 +1,556 @@
+package round
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// frcOutpoint builds a deterministic VTXO outpoint for the forfeit-release
+// tests.
+func frcOutpoint(seed byte, index uint32) wire.OutPoint {
+	op := frcSeedOutpoint(seed)
+	op.Index = index
+
+	return op
+}
+
+func frcSeedOutpoint(seed byte) wire.OutPoint {
+	return regTimeoutOutpoint(seed, 0)
+}
+
+// frcForfeits builds a two-input forfeit reservation plus the outpoints it
+// covers, shared across the pre-signing release table.
+func frcForfeits() ([]types.ForfeitRequest, []wire.OutPoint) {
+	op1 := frcOutpoint(0x11, 0)
+	op2 := frcOutpoint(0x22, 3)
+
+	return []types.ForfeitRequest{
+		mkForfeit(op1, 10_000),
+		mkForfeit(op2, 30_000),
+	}, []wire.OutPoint{op1, op2}
+}
+
+// TestReleaseForfeitsOnFailureHelper exercises the centralized helper directly:
+// it must release exactly the reserved inputs when (and only when) a transition
+// lands in ClientFailedState, stay idempotent against a handler that already
+// released, and never touch a non-failure transition.
+func TestReleaseForfeitsOnFailureHelper(t *testing.T) {
+	t.Parallel()
+
+	forfeits, outpoints := frcForfeits()
+
+	noID := fn.None[RoundID]()
+
+	t.Run("nil transition is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := releaseForfeitsOnFailure(nil, nil, noID, forfeits)
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("non-failure transition untouched", func(t *testing.T) {
+		t.Parallel()
+
+		tr := &ClientStateTransition{NextState: &RoundJoinedState{}}
+		got, err := releaseForfeitsOnFailure(tr, nil, noID, forfeits)
+		require.NoError(t, err)
+
+		require.False(
+			t, got.NewEvents.IsSome(),
+			"a non-failure transition must not emit a release",
+		)
+	})
+
+	t.Run("failure with forfeits releases them", func(t *testing.T) {
+		t.Parallel()
+
+		tr := &ClientStateTransition{NextState: &ClientFailedState{}}
+		got, err := releaseForfeitsOnFailure(tr, nil, noID, forfeits)
+		require.NoError(t, err)
+
+		outbox := got.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+		release, ok := findOutbox[*ReleaseForfeitReservation](outbox)
+		require.True(t, ok, "expected ReleaseForfeitReservation")
+		require.ElementsMatch(t, outpoints, release.Outpoints)
+	})
+
+	t.Run("failure with no forfeits releases nothing", func(t *testing.T) {
+		t.Parallel()
+
+		tr := &ClientStateTransition{NextState: &ClientFailedState{}}
+		got, err := releaseForfeitsOnFailure(tr, nil, noID, nil)
+		require.NoError(t, err)
+
+		_, ok := findOutbox[*ReleaseForfeitReservation](
+			got.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox,
+		)
+		require.False(t, ok, "no inputs reserved, nothing to release")
+	})
+
+	t.Run("idempotent against an explicit release", func(t *testing.T) {
+		t.Parallel()
+
+		// Mirror the IntentSentState admission-timeout path, which
+		// already emits a release of its own.
+		tr := &ClientStateTransition{
+			NextState: &ClientFailedState{},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{
+					&RoundFailedNotification{},
+					&ReleaseForfeitReservation{
+						Outpoints: outpoints,
+					},
+				},
+			}),
+		}
+		got, err := releaseForfeitsOnFailure(tr, nil, noID, forfeits)
+		require.NoError(t, err)
+
+		// Exactly one release must remain: the helper must not append a
+		// duplicate.
+		outbox := got.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+		var releases int
+		for _, m := range outbox {
+			if _, ok := m.(*ReleaseForfeitReservation); ok {
+				releases++
+			}
+		}
+		require.Equal(t, 1, releases,
+			"release must not be duplicated")
+	})
+
+	t.Run("inner error synthesizes a failure release", func(t *testing.T) {
+		t.Parallel()
+
+		// A raw (nil, err) from the wrapped handler must be converted
+		// into a clean ClientFailedState transition that releases the
+		// forfeits, and the now-handled error must be dropped so the
+		// FSM engine does not tear the state machine down (which would
+		// skip the release entirely).
+		innerErr := errors.New("populateForfeitMappingAmounts failed")
+		got, err := releaseForfeitsOnFailure(
+			nil, innerErr, noID, forfeits,
+		)
+		require.NoError(t, err, "handled error must be dropped")
+		require.NotNil(t, got)
+
+		_, ok := got.NextState.(*ClientFailedState)
+		require.True(t, ok, "expected synthesized ClientFailedState")
+
+		outbox := got.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+		release, ok := findOutbox[*ReleaseForfeitReservation](outbox)
+		require.True(t, ok, "synthesized failure must release forfeits")
+		require.ElementsMatch(t, outpoints, release.Outpoints)
+	})
+
+	t.Run("inner error with no forfeits propagates", func(t *testing.T) {
+		t.Parallel()
+
+		// With nothing to release, the established behavior (letting
+		// the error propagate to the engine) is preserved.
+		innerErr := errors.New("validation failed")
+		got, err := releaseForfeitsOnFailure(nil, innerErr, noID, nil)
+		require.ErrorIs(t, err, innerErr)
+		require.Nil(t, got)
+	})
+
+	t.Run("release is prepended before other outbox", func(t *testing.T) {
+		t.Parallel()
+
+		// A failure transition that already carries a server Tell (e.g.
+		// JoinRoundRejectOutbox) must have the local release dispatched
+		// first, so a failing Tell cannot short-circuit the outbox
+		// before the VTXOs are returned to LiveState.
+		tr := &ClientStateTransition{
+			NextState: &ClientFailedState{},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{
+					&JoinRoundRejectOutbox{},
+				},
+			}),
+		}
+		got, err := releaseForfeitsOnFailure(tr, nil, noID, forfeits)
+		require.NoError(t, err)
+
+		outbox := got.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+		require.Len(t, outbox, 2)
+
+		_, ok := outbox[0].(*ReleaseForfeitReservation)
+		require.True(
+			t, ok, "release must be the first outbox item, got %T",
+			outbox[0],
+		)
+	})
+}
+
+// preSigningFailure describes a pre-signing state plus a failure event it
+// genuinely transitions to ClientFailedState on. Releasing forfeits in any of
+// these states is safe because the client has not yet submitted VTXO forfeit
+// signatures to the server.
+type preSigningFailure struct {
+	name  string
+	state func(forfeits []types.ForfeitRequest) ClientState
+	event ClientEvent
+}
+
+// TestPreSigningFailureReleasesForfeits is the core regression for the
+// strand-on-failure bug: every pre-signing state that fails the round (whether
+// from a server-pushed BoardingFailed, a local rejection, or a collection
+// timeout) must return its forfeit-reserved inputs to LiveState instead of
+// leaving them wedged in pending-forfeit.
+func TestPreSigningFailureReleasesForfeits(t *testing.T) {
+	t.Parallel()
+
+	boardingFailed := &BoardingFailed{
+		Reason:      "server failed the round",
+		Error:       errors.New("commitment tx build failed"),
+		Recoverable: true,
+	}
+
+	cases := []preSigningFailure{
+		{
+			name: "PendingRoundAssembly/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &PendingRoundAssembly{
+					Forfeits: ff,
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			name: "IntentSentState/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &IntentSentState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			// The production incident: the server admits the
+			// client, then fails the round while the client waits
+			// in RoundJoinedState for the commitment tx.
+			name: "RoundJoinedState/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &RoundJoinedState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			name: "CommitmentTxReceivedState/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &CommitmentTxReceivedState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			name: "NoncesSentState/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &NoncesSentState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			name: "PartialSigsSentState/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &PartialSigsSentState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			// Boundary state: failures here are still pre-signing
+			// because VTXO forfeit sigs only cross to the server on
+			// the success transition out of this state.
+			name: "ForfeitSignaturesCollecting/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &ForfeitSignaturesCollectingState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			name: "ForfeitSignaturesCollecting/Timeout",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &ForfeitSignaturesCollectingState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: &ForfeitCollectionTimedOut{},
+		},
+		{
+			// A non-BoardingFailed failure that also emits its own
+			// outbox (JoinRoundRejectOutbox): the release must
+			// compose with, not replace, the existing message.
+			name: "QuoteReceivedState/QuoteRejected",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &QuoteReceivedState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: &QuoteRejected{
+				Reason: "fee exceeds cap",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			forfeits, outpoints := frcForfeits()
+			env := &ClientEnvironment{Log: btclog.Disabled}
+
+			tr, err := tc.state(forfeits).ProcessEvent(
+				context.Background(), tc.event, env,
+			)
+			require.NoError(t, err)
+
+			_, ok := tr.NextState.(*ClientFailedState)
+			require.True(
+				t, ok, "expected ClientFailedState, got %T",
+				tr.NextState,
+			)
+
+			outbox := tr.NewEvents.UnwrapOr(
+				ClientEmittedEvent{},
+			).Outbox
+			release, ok := findOutbox[*ReleaseForfeitReservation](
+				outbox,
+			)
+			require.True(
+				t, ok,
+				"pre-signing failure must release forfeits",
+			)
+			require.ElementsMatch(t, outpoints, release.Outpoints)
+		})
+	}
+}
+
+// TestPostSigningFailureDoesNotReleaseForfeits is the safety control: once the
+// client has submitted its forfeit signatures (InputSigSentState onward), a
+// failed round must NOT auto-release the inputs, since the server could still
+// broadcast the forfeit if the commitment confirms. Releasing here would risk a
+// double-spend, so the post-signing states are deliberately not wired to the
+// release helper.
+func TestPostSigningFailureDoesNotReleaseForfeits(t *testing.T) {
+	t.Parallel()
+
+	forfeits, _ := frcForfeits()
+	env := &ClientEnvironment{Log: btclog.Disabled}
+
+	s := &InputSigSentState{Intents: Intents{Forfeits: forfeits}}
+	tr, err := s.ProcessEvent(context.Background(), &BoardingFailed{
+		Reason:      "post-signing failure",
+		Recoverable: false,
+	}, env)
+	require.NoError(t, err)
+
+	failed, ok := tr.NextState.(*ClientFailedState)
+	require.True(t, ok, "expected ClientFailedState, got %T", tr.NextState)
+	require.False(t, failed.Recoverable)
+
+	_, ok = findOutbox[*ReleaseForfeitReservation](
+		tr.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox,
+	)
+	require.False(
+		t, ok, "post-signing failure must not auto-release forfeits",
+	)
+}
+
+// TestPreSigningInternalEventFailureReleasesForfeits is the second half of the
+// strand-on-failure regression: two pre-signing states fail only on internal
+// FSM events (not on a server-pushed BoardingFailed), so the table in
+// TestPreSigningFailureReleasesForfeits cannot reach them. These states wrap
+// their handlers in ProcessEvent so that a raw (nil, err) return from the inner
+// processEvent is converted into a clean ClientFailedState that returns the
+// forfeit-reserved inputs to LiveState. A refactor that dropped either wrapper,
+// or let the raw error propagate to the FSM engine, would silently re-strand
+// the forfeits for these cases with no other test going red.
+func TestPreSigningInternalEventFailureReleasesForfeits(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CommitmentTxValidated/GenerateNonces", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		forfeits, outpoints := frcForfeits()
+
+		// Build a VTXO intent so the GenerateNonces handler enters its
+		// per-VTXO session loop, but leave ClientTrees empty so the
+		// signer-key lookup misses and the handler hits its raw
+		// "no client tree for signer key" error path. This mirrors the
+		// buildClientVTXOs_error subtest in transitions_test.go.
+		intent := h.newTestBoardingIntent()
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
+
+		state := &CommitmentTxValidatedState{
+			RoundID: testRoundIDTr("frc-gen-nonces"),
+			CommitmentTx: h.newTestCommitmentTx(
+				[]BoardingIntent{intent},
+			),
+			VTXOTreePaths: map[int]*tree.Tree{
+				0: h.newTestVTXOTreeForIntents(
+					[]types.VTXORequest{vtxoReq},
+				),
+			},
+			Intents: Intents{
+				Boarding: []BoardingIntent{
+					intent,
+				},
+				VTXOs: []types.VTXORequest{
+					vtxoReq,
+				},
+				Forfeits: forfeits,
+			},
+			ClientTrees: make(map[SignerKey]*tree.Tree),
+			BoardingInputIndices: map[wire.OutPoint]int{
+				intent.Outpoint: 0,
+			},
+		}
+
+		assertReleasesForfeits(
+			t, h, state, &GenerateNonces{}, outpoints,
+		)
+	})
+
+	t.Run("NoncesAggregated/GeneratePartialSigs", func(t *testing.T) {
+		t.Parallel()
+
+		h := newRealSigningTestHarness(t)
+
+		forfeits, outpoints := frcForfeits()
+
+		intent := h.newTestBoardingIntent()
+		vtxoReq := h.newTestVTXORequestForIntent(intent)
+		vtxtTree := h.newTestVTXOTreeForIntents(
+			[]types.VTXORequest{vtxoReq},
+		)
+
+		// Build a real signing session that never had its aggregated
+		// nonces registered. Its Signatures(true) call therefore fails
+		// with "not all nonces registered" inside the
+		// GeneratePartialSigs handler, exercising the raw "failed to
+		// generate partial signatures" error path. Using a real signer
+		// (rather than the always-succeeding wallet mock) is what makes
+		// Signatures(true) actually error here.
+		session := h.newUnaggregatedSignerSession(vtxoReq, vtxtTree)
+		signerKey := NewSignerKey(vtxoReq.SigningKey.PubKey)
+
+		state := &NoncesAggregatedState{
+			RoundID: testRoundIDTr("frc-partial-sigs"),
+			CommitmentTx: h.newTestCommitmentTx(
+				[]BoardingIntent{intent},
+			),
+			VTXOTreePaths: map[int]*tree.Tree{
+				0: vtxtTree,
+			},
+			Intents: Intents{
+				Boarding: []BoardingIntent{
+					intent,
+				},
+				VTXOs: []types.VTXORequest{
+					vtxoReq,
+				},
+				Forfeits: forfeits,
+			},
+			ClientTrees: make(map[SignerKey]*tree.Tree),
+			Musig2Sessions: map[SignerKey]*tree.SignerSession{
+				signerKey: session,
+			},
+			BoardingInputIndices: map[wire.OutPoint]int{
+				intent.Outpoint: 0,
+			},
+		}
+
+		assertReleasesForfeits(
+			t, h.boardingTestHarness, state, &GeneratePartialSigs{},
+			outpoints,
+		)
+	})
+}
+
+// newUnaggregatedSignerSession builds a real tree.SignerSession for the given
+// VTXO request and tree, backed by the harness's real MuSig2 signer, but
+// deliberately skips registering aggregated nonces. The resulting session's
+// Signatures(true) returns an error ("not all nonces registered"), which is the
+// least-brittle way to force the raw error path in the GeneratePartialSigs
+// handler without a large signing fixture.
+func (h *realSigningTestHarness) newUnaggregatedSignerSession(
+	vtxoReq types.VTXORequest, vtxtTree *tree.Tree) *tree.SignerSession {
+
+	h.t.Helper()
+
+	prevOutFetcher, err := vtxtTree.Root.PrevOutputFetcher(
+		vtxtTree.BatchOutput,
+	)
+	require.NoError(h.t, err)
+
+	session, err := tree.NewSignerSession(
+		h.clientSigner, &vtxoReq.SigningKey,
+		vtxtTree.SweepTapscriptRoot, prevOutFetcher, vtxtTree.Root,
+	)
+	require.NoError(h.t, err)
+
+	return session
+}
+
+// assertReleasesForfeits drives the given internal event through the state's
+// exported ProcessEvent (not the unexported processEvent, so the release
+// wrapper is exercised) and asserts the transition lands in ClientFailedState
+// while emitting a ReleaseForfeitReservation covering exactly the reserved
+// outpoints.
+func assertReleasesForfeits(t *testing.T, h *boardingTestHarness,
+	state ClientState, event ClientEvent, outpoints []wire.OutPoint) {
+
+	t.Helper()
+
+	tr, err := state.ProcessEvent(h.ctx, event, h.env)
+	require.NoError(t, err, "handled error must be dropped by the wrapper")
+
+	_, ok := tr.NextState.(*ClientFailedState)
+	require.True(
+		t, ok, "expected ClientFailedState, got %T", tr.NextState,
+	)
+
+	outbox := tr.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+	release, ok := findOutbox[*ReleaseForfeitReservation](outbox)
+	require.True(
+		t, ok, "internal-event failure must release forfeits",
+	)
+	require.ElementsMatch(t, outpoints, release.Outpoints)
+}

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -57,6 +57,91 @@ func failWithNotification(reason string, err error, recoverable bool,
 	}
 }
 
+// releaseForfeitsOnFailure prepends a ReleaseForfeitReservation to a transition
+// that lands in ClientFailedState, returning the given forfeit-reserved VTXOs
+// to LiveState so they are not stranded in pending-forfeit after a failed
+// round. It is a no-op for any non-failure transition, for rounds that
+// reserved no forfeits, and when a release was already emitted (so the
+// IntentSentState admission-timeout path, which releases explicitly, is not
+// double-counted).
+//
+// When the wrapped handler returns a raw (nil, err) — a pre-signing validation
+// failure such as a forfeit-mapping or forfeit-tx construction error — there is
+// no transition for the FSM to fail on, so the engine would tear the state
+// machine down without ever emitting a ClientFailedState. That strands the
+// forfeit-reserved inputs in pending-forfeit. To avoid this, an inner error is
+// converted into a synthetic failure transition (mirroring
+// failWithNotification) so the round fails cleanly, the failure stays
+// observable, and the release still fires. The caller drops the now-handled
+// error.
+//
+// Releasing is only safe BEFORE the client submits its VTXO forfeit signatures
+// to the server (SubmitVTXOForfeitSigsToServer, emitted on the
+// ForfeitSignaturesCollectingState -> InputSigSentState transition): until that
+// point the server holds no forfeit signature and cannot broadcast a forfeit,
+// so returning the inputs to LiveState cannot double-spend. Callers therefore
+// wire this only into the pre-signing states (PendingRoundAssembly through
+// ForfeitSignaturesCollectingState); the post-signing states (InputSigSentState
+// onward) deliberately do not release.
+//
+// ReleaseForfeitReservation is prepended (not appended) so it is the first item
+// processOutbox dispatches. The local vtxo-manager release is handled
+// best-effort (log-and-continue) and never returns an error, whereas the
+// server/timeout Tells that may already be in the outbox
+// (JoinRoundRejectOutbox, CancelTimeoutReq) can fail mid-flight (TCP RST,
+// mailbox reconnect) and short-circuit the rest of the outbox. Dispatching the
+// release first guarantees the VTXOs are returned to LiveState regardless of
+// whether those Tells succeed.
+func releaseForfeitsOnFailure(transition *ClientStateTransition, err error,
+	roundID fn.Option[RoundID],
+	forfeits []types.ForfeitRequest) (*ClientStateTransition, error) {
+
+	outpoints := forfeitOutpoints(forfeits)
+
+	// A raw inner error has no transition for the FSM to land on;
+	// synthesize a failure transition so the release below has somewhere to
+	// attach, and drop the now-handled error so the engine does not tear
+	// the FSM down. We only do this when there are forfeits to release:
+	// with none, letting the error propagate is the established behavior.
+	if transition == nil {
+		if err == nil || len(outpoints) == 0 {
+			return transition, err
+		}
+
+		transition = failWithNotification(
+			err.Error(), err, false, roundID,
+		)
+		err = nil
+	}
+
+	// Only a transition into the terminal failure state can strand forfeit
+	// reservations; leave every other transition untouched.
+	if _, failed := transition.NextState.(*ClientFailedState); !failed {
+		return transition, err
+	}
+
+	if len(outpoints) == 0 {
+		return transition, err
+	}
+
+	emitted := transition.NewEvents.UnwrapOr(ClientEmittedEvent{})
+
+	// Stay idempotent: a handler that already released (the admission
+	// timeout in IntentSentState) must not release the same inputs twice.
+	for _, msg := range emitted.Outbox {
+		if _, ok := msg.(*ReleaseForfeitReservation); ok {
+			return transition, err
+		}
+	}
+
+	emitted.Outbox = append([]ClientOutMsg{&ReleaseForfeitReservation{
+		Outpoints: outpoints,
+	}}, emitted.Outbox...)
+	transition.NewEvents = fn.Some(emitted)
+
+	return transition, err
+}
+
 // selfLoop creates a self-loop transition that stays in the current state
 // without emitting any events. Used for unknown events in non-terminal states
 // to avoid halting the FSM.
@@ -186,9 +271,25 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 
 // ProcessEvent for PendingRoundAssembly tracks confirmed boarding intents and
 // transitions to registration once all are ready.
+func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(
+		transition, err, fn.None[RoundID](), s.Forfeits,
+	)
+}
+
+// processEvent runs the PendingRoundAssembly event handling; ProcessEvent wraps
+// it to return forfeit-reserved inputs to LiveState on failure.
 //
 //nolint:funlen
-func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
+func (s *PendingRoundAssembly) processEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
@@ -529,6 +630,22 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 
 // ProcessEvent for IntentSentState.
 func (s *IntentSentState) ProcessEvent(ctx context.Context, event ClientEvent,
+	env *ClientEnvironment) (*ClientStateTransition, error) {
+
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure. Idempotent with the admission-timeout path,
+	// which already releases explicitly.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(
+		transition, err, fn.Some(s.AdmittedRoundID), s.Intents.Forfeits,
+	)
+}
+
+// processEvent runs the IntentSentState event handling; ProcessEvent wraps it
+// to return forfeit-reserved inputs to LiveState on failure.
+func (s *IntentSentState) processEvent(ctx context.Context, event ClientEvent,
 	env *ClientEnvironment) (*ClientStateTransition, error) {
 
 	switch evt := event.(type) {
@@ -1218,6 +1335,22 @@ func (s *QuoteReceivedState) ProcessEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(
+		transition, err, fn.Some(s.RoundID), s.Intents.Forfeits,
+	)
+}
+
+// processEvent runs the QuoteReceivedState event handling; ProcessEvent wraps
+// it to return forfeit-reserved inputs to LiveState on failure.
+func (s *QuoteReceivedState) processEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
 	switch evt := event.(type) {
 	case *JoinRoundQuoteReceived:
 		// Server reseal: a later pass arrives while we still
@@ -1328,6 +1461,21 @@ func (s *QuoteReceivedState) ProcessEvent(ctx context.Context,
 
 // ProcessEvent for RoundJoinedState.
 func (s *RoundJoinedState) ProcessEvent(ctx context.Context, event ClientEvent,
+	env *ClientEnvironment) (*ClientStateTransition, error) {
+
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(
+		transition, err, fn.Some(s.RoundID), s.Intents.Forfeits,
+	)
+}
+
+// processEvent runs the RoundJoinedState event handling; ProcessEvent wraps it
+// to return forfeit-reserved inputs to LiveState on failure.
+func (s *RoundJoinedState) processEvent(ctx context.Context, event ClientEvent,
 	env *ClientEnvironment) (*ClientStateTransition, error) {
 
 	switch evt := event.(type) {
@@ -1604,9 +1752,25 @@ func quoteLeaveAmounts(quote *ClientQuote,
 }
 
 // ProcessEvent for CommitmentTxReceivedState.
+func (s *CommitmentTxReceivedState) ProcessEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(
+		transition, err, fn.Some(s.RoundID), s.Intents.Forfeits,
+	)
+}
+
+// processEvent runs the CommitmentTxReceivedState event handling; ProcessEvent
+// wraps it to return forfeit-reserved inputs to LiveState on failure.
 //
 //nolint:funlen,ll
-func (s *CommitmentTxReceivedState) ProcessEvent(ctx context.Context,
+func (s *CommitmentTxReceivedState) processEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
@@ -1974,6 +2138,22 @@ func (s *CommitmentTxValidatedState) ProcessEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(
+		transition, err, fn.Some(s.RoundID), s.Intents.Forfeits,
+	)
+}
+
+// processEvent runs the CommitmentTxValidatedState event handling; ProcessEvent
+// wraps it to return forfeit-reserved inputs to LiveState on failure.
+func (s *CommitmentTxValidatedState) processEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
 	switch event.(type) {
 	case *GenerateNonces:
 		env.Log.InfoS(
@@ -2184,6 +2364,25 @@ func (s *CommitmentTxValidatedState) ProcessEvent(ctx context.Context,
 // sign boarding inputs, submit all signatures to the server, and transition
 // to InputSigSentState.
 func (s *ForfeitSignaturesCollectingState) ProcessEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
+	// Failures here are still pre-signing: VTXO forfeit signatures are only
+	// submitted to the server on the success transition to
+	// InputSigSentState (SubmitVTXOForfeitSigsToServer), so any transition
+	// into ClientFailedState may safely return forfeit-reserved inputs to
+	// LiveState; see releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(
+		transition, err, fn.Some(s.RoundID), s.Intents.Forfeits,
+	)
+}
+
+// processEvent runs the ForfeitSignaturesCollectingState event handling;
+// ProcessEvent wraps it to return forfeit-reserved inputs to LiveState on
+// failure.
+func (s *ForfeitSignaturesCollectingState) processEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
@@ -2507,6 +2706,21 @@ func (s *ForfeitSignaturesCollectingState) inputSigSentState(
 func (s *NoncesSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 	env *ClientEnvironment) (*ClientStateTransition, error) {
 
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(
+		transition, err, fn.Some(s.RoundID), s.Intents.Forfeits,
+	)
+}
+
+// processEvent runs the NoncesSentState event handling; ProcessEvent wraps it
+// to return forfeit-reserved inputs to LiveState on failure.
+func (s *NoncesSentState) processEvent(ctx context.Context, event ClientEvent,
+	env *ClientEnvironment) (*ClientStateTransition, error) {
+
 	switch evt := event.(type) {
 	case *NoncesAggregated:
 		env.Log.InfoS(ctx, "Received aggregated nonces from server",
@@ -2585,6 +2799,22 @@ func (s *NoncesAggregatedState) ProcessEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(
+		transition, err, fn.Some(s.RoundID), s.Intents.Forfeits,
+	)
+}
+
+// processEvent runs the NoncesAggregatedState event handling; ProcessEvent
+// wraps it to return forfeit-reserved inputs to LiveState on failure.
+func (s *NoncesAggregatedState) processEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
 	switch event.(type) {
 	case *GeneratePartialSigs:
 		env.Log.InfoS(
@@ -2655,6 +2885,24 @@ func (s *NoncesAggregatedState) ProcessEvent(ctx context.Context,
 
 // ProcessEvent for PartialSigsSentState.
 func (s *PartialSigsSentState) ProcessEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
+	// Still pre-signing: this state submits MuSig2 partial sigs, not VTXO
+	// forfeit sigs (those go out only when ForfeitSignaturesCollectingState
+	// transitions to InputSigSentState). Any transition into
+	// ClientFailedState may safely return forfeit-reserved inputs to
+	// LiveState; see releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(
+		transition, err, fn.Some(s.RoundID), s.Intents.Forfeits,
+	)
+}
+
+// processEvent runs the PartialSigsSentState event handling; ProcessEvent wraps
+// it to return forfeit-reserved inputs to LiveState on failure.
+func (s *PartialSigsSentState) processEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -734,6 +734,34 @@ func (s *ForfeitingState) ProcessEvent(ctx context.Context, event VTXOEvent,
 			NewEvents: fn.Some(VTXOEmittedEvent{Outbox: outbox}),
 		}, nil
 
+	case *ForfeitReleasedEvent:
+		// A pre-signing round failure released this VTXO. We can land
+		// here, not just in PendingForfeitState, when the round fails
+		// during ForfeitSignaturesCollecting after this VTXO already
+		// replied with its forfeit signature and advanced to
+		// ForfeitingState. The release is still safe: no forfeit
+		// signature reaches the server until the success edge out of
+		// ForfeitSignaturesCollecting calls
+		// SubmitVTXOForfeitSigsToServer, so a failure before then has
+		// handed nothing to the operator. Return the VTXO to LiveState
+		// rather than leaving it wedged in FORFEITING. ForfeitingState
+		// tracks no block height, so LastCheckedHeight stays zero and
+		// the next block epoch re-seeds expiry checking (mirroring the
+		// ForceUnrollEvent recovery path above).
+		return &VTXOStateTransition{
+			NextState: &LiveState{
+				VTXO: s.VTXO,
+			},
+			NewEvents: fn.Some(VTXOEmittedEvent{
+				Outbox: []VTXOOutMsg{
+					&VTXOStatusUpdate{
+						Outpoint:  s.VTXO.Outpoint,
+						NewStatus: VTXOStatusLive,
+					},
+				},
+			}),
+		}, nil
+
 	case *VTXOFailedEvent:
 		return &VTXOStateTransition{
 			NextState: &FailedState{

--- a/vtxo/transitions_test.go
+++ b/vtxo/transitions_test.go
@@ -1299,6 +1299,38 @@ func TestForfeitReleasedFromPendingForfeit(t *testing.T) {
 	require.Equal(t, VTXOStatusLive, su.NewStatus)
 }
 
+// TestForfeitReleasedFromForfeiting verifies that ForfeitingState also
+// transitions back to LiveState on ForfeitReleasedEvent. A VTXO reaches
+// ForfeitingState once it has replied with its forfeit signature, so a round
+// that fails mid-collection (a partial ForfeitCollectionTimedOut) must be able
+// to unwedge these already-advanced VTXOs, not just the ones still in
+// PendingForfeitState. The release is safe because no forfeit signature reaches
+// the server until the success edge out of ForfeitSignaturesCollecting.
+func TestForfeitReleasedFromForfeiting(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	h.withState(&ForfeitingState{
+		VTXO:       vtxo,
+		NewRoundID: "round-123",
+	})
+
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint, VTXOStatusLive,
+	).Return(nil)
+
+	_, err := h.sendEvent(&round.ForfeitReleasedEvent{})
+	require.NoError(t, err)
+
+	state := assertState[*LiveState](h)
+	require.Equal(t, vtxo, state.VTXO)
+
+	su := assertOutboxContains[*VTXOStatusUpdate](h)
+	require.Equal(t, VTXOStatusLive, su.NewStatus)
+}
+
 // TestSpendingStateResumeStaysInSpending verifies that SpendingState stays in
 // SpendingState on ResumeVTXOEvent. The OOR session will resume and later
 // release or complete the claim.


### PR DESCRIPTION
In this PR, we close a gap where a refresh/leave round that fails *after*
the client has been admitted strands its forfeit-reserved VTXOs in
`PENDING_FORFEIT` with no way back to `LIVE`.

darepo-client#653 added a release on the registration-timeout path: if the
server never returns a `RoundJoined` admission watermark, the FSM fails the
round and returns the forfeit-reserved inputs to `LiveState`. But that's the
only path that releases. Once the server admits the client (which cancels the
registration timeout), any later failure (a server-pushed `BoardingFailed`, a
local commitment-tx rejection, a quote rejection, a forfeit-collection
timeout) walks the FSM into `ClientFailedState` without releasing anything.
The inputs sit in `PENDING_FORFEIT`, the manager won't re-offer them to a new
round (it only reserves `LIVE` inputs), and the only recovery left is a
critical-expiry unilateral exit.

We hit this on signet: the operator kept failing round builds (lnd's
`max_fee_ratio` rejecting a small commitment tx, fixed server-side in
darepo#582), and a wallet's VTXOs wedged in `PENDING_FORFEIT` with no path
out.

## The fix

In `round/transitions.go`, we add `releaseForfeitsOnFailure`, which appends a
`ReleaseForfeitReservation` to any transition that lands in
`ClientFailedState` while the round still holds forfeit reservations. We wire
it into every pre-signing state (`PendingRoundAssembly` through
`ForfeitSignaturesCollectingState`) via a thin `ProcessEvent` wrapper that
delegates to an unexported `processEvent` and post-processes its result.

Releasing is only safe before the client submits its VTXO forfeit signatures
to the server. That submission happens exactly once, on the success
transition out of `ForfeitSignaturesCollectingState` into `InputSigSentState`
(`SubmitVTXOForfeitSigsToServer`). Up to that point the server holds no
forfeit signature and can't broadcast a forfeit, so returning the inputs to
`LiveState` can't double-spend. The post-signing states (`InputSigSentState`
onward) deliberately don't release, and the helper is idempotent so the
existing #653 admission-timeout release isn't double-counted.

The release plumbing already exists from #653: the FSM emits
`ReleaseForfeitReservation`, the round actor routes it to the VTXO manager,
and the manager sends `ForfeitReleasedEvent` to each VTXO actor to move it
back to `LiveState`. We just wire it into the rest of the pre-signing failure
surface.

## Tests

`round/forfeit_release_on_failure_test.go` covers the helper directly
(only-on-failure, idempotent, empty/nil no-ops), drives every pre-signing
state to a failure and asserts the release fires with the right outpoints,
and adds a post-signing control that asserts `InputSigSentState` does NOT
release.

An end-to-end systest lands in a follow-up stacked on #761, which is the
routing fix that delivers the server's failure to the re-keyed FSM in the
first place. Without #761 the post-admission `BoardingFailed` never reaches
the round, so the two changes are complementary: #761 delivers the failure,
this PR releases the inputs on it.
