### PR TITLE
systest: cover post-admission round failure handling

### DIFF
--- a/round/actor.go
+++ b/round/actor.go
@@ -1792,12 +1792,38 @@ func (a *RoundClientActor) routeServerMessageToPending(ctx context.Context,
 
 	roundFSM := a.findPendingRound()
 
-	// Round failures can arrive after the round is keyed by a
-	// server-assigned RoundID. When there is exactly one tracked
-	// round, route the failure there.
+	// Round failures can arrive after the round has been re-keyed by a
+	// server-assigned RoundID, so findPendingRound (which only matches
+	// temp-keyed rounds) misses them. Route them deterministically by the
+	// RoundID the failure carries, falling back to the sole-round heuristic
+	// for failures that predate round assignment (e.g. ClientErrorResp).
 	if roundFSM == nil {
-		_, isBoardingFailed := msg.(*BoardingFailed)
-		if isBoardingFailed && len(a.rounds) == 1 {
+		bf, isBoardingFailed := msg.(*BoardingFailed)
+
+		// Prefer the deterministic lookup by the server-assigned
+		// RoundID. This works regardless of how many rounds (including
+		// lingering terminal ones) are tracked.
+		if isBoardingFailed {
+			bf.RoundID.WhenSome(func(rid RoundID) {
+				keyStr := RoundKeyStr(rid.KeyString())
+				if candidate, ok := a.rounds[keyStr]; ok {
+					roundFSM = candidate
+
+					a.log.DebugS(ctx,
+						"Routing BoardingFailed by "+
+							"RoundID",
+						slog.String(
+							"key", candidate.Key.
+								KeyString(),
+						))
+				}
+			})
+		}
+
+		// Fall back to the sole-round heuristic for failures that carry
+		// no RoundID (pre-assignment failures) when exactly one round
+		// is tracked.
+		if roundFSM == nil && isBoardingFailed && len(a.rounds) == 1 {
 			for _, candidate := range a.rounds {
 				roundFSM = candidate
 			}

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -1079,6 +1079,37 @@ func (h *actorTestHarness) setupRoundInIntentSentState() TempRoundKey {
 	return tempKey
 }
 
+// injectRoundInState creates a round FSM in the given initial state, keyed by
+// the supplied server-assigned RoundID, and adds it to the actor's rounds map.
+// It mirrors the construction of the other setupRoundIn* helpers but lets the
+// caller pick the state, which the BoardingFailed routing test needs to stage
+// both a lingering terminal round and a live waiting round under distinct
+// RoundIDs.
+func (h *actorTestHarness) injectRoundInState(roundID RoundID,
+	initialState ClientState) {
+
+	h.t.Helper()
+
+	errReporter := newContextErrorReporter(
+		h.ctx, roundID.LogPrefix(),
+	)
+	fsmCfg := ClientStateMachineCfg{
+		Logger:        h.actor.log.WithPrefix(roundID.LogPrefix()),
+		ErrorReporter: errReporter,
+		InitialState:  initialState,
+		Env:           h.actor.env,
+	}
+	newFSM := protofsm.NewStateMachine(fsmCfg)
+	newFSM.Start(h.ctx)
+
+	keyStr := RoundKeyStr(roundID.KeyString())
+	h.actor.rounds[keyStr] = &RoundFSM{
+		FSM:     &newFSM,
+		Key:     roundID,
+		RoundID: roundID,
+	}
+}
+
 // setupMockRoundStoreForRecovery configures the RoundStore mock to return
 // active rounds for recovery on Start(), using PartialSigsSentState which is
 // stable and won't immediately transition on recovery.

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -1517,6 +1517,82 @@ func TestActorServerMessageRouting(t *testing.T) {
 	}
 }
 
+// TestBoardingFailedRoutesByRoundIDWithLingeringRound reproduces the
+// darepo-client#571 dropped-event bug and proves the RoundID-keyed routing
+// fix. Two rounds are tracked: a lingering terminal round (ClientFailedState,
+// which is never evicted from a.rounds) and a live round re-keyed to a
+// server-assigned RoundID sitting in RoundJoinedState. A server
+// ClientRoundFailedResp for the live round arrives as a BoardingFailed
+// carrying that RoundID. Before the fix, findPendingRound missed the re-keyed
+// live round and the sole-round fallback bailed (len(a.rounds) == 2), so the
+// failure was silently dropped and the live round stayed stuck projecting a
+// phantom pending VTXO forever. With the fix, the failure is routed
+// deterministically by RoundID and the live round transitions to
+// ClientFailedState.
+func TestBoardingFailedRoutesByRoundIDWithLingeringRound(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	h.setupMockRoundStoreForStart()
+	require.NoError(t, h.start())
+
+	// Stage a lingering terminal round under its own RoundID. Terminal
+	// FSMs are reaped lazily, not on entry, so this round stays in
+	// a.rounds and is what makes the sole-round heuristic bail.
+	lingeringID := testRoundID("lingering-failed-round")
+	h.injectRoundInState(lingeringID, &ClientFailedState{
+		Reason:      "earlier round failed",
+		Recoverable: true,
+	})
+
+	// Stage the live round re-keyed to its server-assigned RoundID, parked
+	// in a waiting state (RoundJoinedState) that projects a pending VTXO.
+	liveID := testRoundID("live-joined-round")
+	h.injectRoundInState(liveID, &RoundJoinedState{
+		RoundID: liveID,
+	})
+
+	// Sanity check: two rounds are tracked, so the sole-round heuristic
+	// alone cannot route the failure.
+	require.Len(t, h.queryState(), 2)
+
+	// Deliver the server failure for the live round through the same path
+	// handleServerMessage uses, carrying the live round's RoundID exactly
+	// as BoardingFailed.FromProto populates it from a
+	// ClientRoundFailedResp.
+	h.sendServerMessage(&BoardingFailed{
+		RoundID:     fn.Some(liveID),
+		Reason:      "operator failed to build round",
+		Recoverable: true,
+	})
+
+	// The live round must have consumed the failure and transitioned to
+	// ClientFailedState rather than dropping it and staying in
+	// RoundJoinedState.
+	states := h.queryState()
+
+	liveInfo, ok := states[liveID.KeyString()]
+	require.True(t, ok, "live round should still be tracked")
+	require.IsType(
+		t, &ClientFailedState{}, liveInfo.State,
+		"live round should have failed, not stayed in RoundJoinedState",
+	)
+
+	// The lingering round must be untouched: routing was deterministic and
+	// did not leak the failure into the wrong FSM.
+	lingeringInfo, ok := states[lingeringID.KeyString()]
+	require.True(t, ok, "lingering round should still be tracked")
+	require.IsType(
+		t, &ClientFailedState{}, lingeringInfo.State,
+	)
+	failed, ok := lingeringInfo.State.(*ClientFailedState)
+	require.True(t, ok)
+	require.Equal(
+		t, "earlier round failed", failed.Reason,
+		"lingering round's failure reason must be unchanged",
+	)
+}
+
 // TestHandleRefreshVTXORequest verifies that refresh requests from VTXO actors
 // are properly forwarded to the primary FSM and tracked for inclusion in the
 // next round registration.

--- a/round/events.go
+++ b/round/events.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
 // ClientEvent is a sealed interface for all events that can be processed by
@@ -346,6 +347,13 @@ func (e *BoardingConfirmed) clientEventSealed() {}
 // BoardingFailed is emitted when an error occurs during the boarding
 // process.
 type BoardingFailed struct {
+	// RoundID is the server-assigned round id when the failure carries
+	// one (ClientRoundFailedResp). It is None for failures that arrive
+	// before a round was assigned (e.g. ClientErrorResp). When set, the
+	// actor routes the failure deterministically to the matching FSM
+	// instead of relying on the sole-round heuristic.
+	RoundID fn.Option[RoundID]
+
 	// Reason is a human-readable description of the failure.
 	Reason string
 

--- a/round/forfeit_release_on_failure_test.go
+++ b/round/forfeit_release_on_failure_test.go
@@ -1,0 +1,320 @@
+package round
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// frcOutpoint builds a deterministic VTXO outpoint for the forfeit-release
+// tests.
+func frcOutpoint(seed byte, index uint32) wire.OutPoint {
+	op := frcSeedOutpoint(seed)
+	op.Index = index
+
+	return op
+}
+
+func frcSeedOutpoint(seed byte) wire.OutPoint {
+	return regTimeoutOutpoint(seed, 0)
+}
+
+// frcForfeits builds a two-input forfeit reservation plus the outpoints it
+// covers, shared across the pre-signing release table.
+func frcForfeits() ([]types.ForfeitRequest, []wire.OutPoint) {
+	op1 := frcOutpoint(0x11, 0)
+	op2 := frcOutpoint(0x22, 3)
+
+	return []types.ForfeitRequest{
+		mkForfeit(op1, 10_000),
+		mkForfeit(op2, 30_000),
+	}, []wire.OutPoint{op1, op2}
+}
+
+// TestReleaseForfeitsOnFailureHelper exercises the centralized helper directly:
+// it must release exactly the reserved inputs when (and only when) a transition
+// lands in ClientFailedState, stay idempotent against a handler that already
+// released, and never touch a non-failure transition.
+func TestReleaseForfeitsOnFailureHelper(t *testing.T) {
+	t.Parallel()
+
+	forfeits, outpoints := frcForfeits()
+
+	t.Run("nil transition is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		require.Nil(t, releaseForfeitsOnFailure(nil, forfeits))
+	})
+
+	t.Run("non-failure transition untouched", func(t *testing.T) {
+		t.Parallel()
+
+		tr := &ClientStateTransition{NextState: &RoundJoinedState{}}
+		got := releaseForfeitsOnFailure(tr, forfeits)
+
+		require.False(
+			t, got.NewEvents.IsSome(),
+			"a non-failure transition must not emit a release",
+		)
+	})
+
+	t.Run("failure with forfeits releases them", func(t *testing.T) {
+		t.Parallel()
+
+		tr := &ClientStateTransition{NextState: &ClientFailedState{}}
+		got := releaseForfeitsOnFailure(tr, forfeits)
+
+		outbox := got.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+		release, ok := findOutbox[*ReleaseForfeitReservation](outbox)
+		require.True(t, ok, "expected ReleaseForfeitReservation")
+		require.ElementsMatch(t, outpoints, release.Outpoints)
+	})
+
+	t.Run("failure with no forfeits releases nothing", func(t *testing.T) {
+		t.Parallel()
+
+		tr := &ClientStateTransition{NextState: &ClientFailedState{}}
+		got := releaseForfeitsOnFailure(tr, nil)
+
+		_, ok := findOutbox[*ReleaseForfeitReservation](
+			got.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox,
+		)
+		require.False(t, ok, "no inputs reserved, nothing to release")
+	})
+
+	t.Run("idempotent against an explicit release", func(t *testing.T) {
+		t.Parallel()
+
+		// Mirror the IntentSentState admission-timeout path, which
+		// already emits a release of its own.
+		tr := &ClientStateTransition{
+			NextState: &ClientFailedState{},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{
+					&RoundFailedNotification{},
+					&ReleaseForfeitReservation{
+						Outpoints: outpoints,
+					},
+				},
+			}),
+		}
+		got := releaseForfeitsOnFailure(tr, forfeits)
+
+		// Exactly one release must remain: the helper must not append a
+		// duplicate.
+		outbox := got.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+		var releases int
+		for _, m := range outbox {
+			if _, ok := m.(*ReleaseForfeitReservation); ok {
+				releases++
+			}
+		}
+		require.Equal(t, 1, releases,
+			"release must not be duplicated")
+	})
+}
+
+// preSigningFailure describes a pre-signing state plus a failure event it
+// genuinely transitions to ClientFailedState on. Releasing forfeits in any of
+// these states is safe because the client has not yet submitted VTXO forfeit
+// signatures to the server.
+type preSigningFailure struct {
+	name  string
+	state func(forfeits []types.ForfeitRequest) ClientState
+	event ClientEvent
+}
+
+// TestPreSigningFailureReleasesForfeits is the core regression for the
+// strand-on-failure bug: every pre-signing state that fails the round (whether
+// from a server-pushed BoardingFailed, a local rejection, or a collection
+// timeout) must return its forfeit-reserved inputs to LiveState instead of
+// leaving them wedged in pending-forfeit.
+func TestPreSigningFailureReleasesForfeits(t *testing.T) {
+	t.Parallel()
+
+	boardingFailed := &BoardingFailed{
+		Reason:      "server failed the round",
+		Error:       errors.New("commitment tx build failed"),
+		Recoverable: true,
+	}
+
+	cases := []preSigningFailure{
+		{
+			name: "PendingRoundAssembly/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &PendingRoundAssembly{
+					Forfeits: ff,
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			name: "IntentSentState/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &IntentSentState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			// The production incident: the server admits the
+			// client, then fails the round while the client waits
+			// in RoundJoinedState for the commitment tx.
+			name: "RoundJoinedState/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &RoundJoinedState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			name: "CommitmentTxReceivedState/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &CommitmentTxReceivedState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			name: "NoncesSentState/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &NoncesSentState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			name: "PartialSigsSentState/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &PartialSigsSentState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			// Boundary state: failures here are still pre-signing
+			// because VTXO forfeit sigs only cross to the server on
+			// the success transition out of this state.
+			name: "ForfeitSignaturesCollecting/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &ForfeitSignaturesCollectingState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			name: "ForfeitSignaturesCollecting/Timeout",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &ForfeitSignaturesCollectingState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: &ForfeitCollectionTimedOut{},
+		},
+		{
+			// A non-BoardingFailed failure that also emits its own
+			// outbox (JoinRoundRejectOutbox): the release must
+			// compose with, not replace, the existing message.
+			name: "QuoteReceivedState/QuoteRejected",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &QuoteReceivedState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: &QuoteRejected{
+				Reason: "fee exceeds cap",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			forfeits, outpoints := frcForfeits()
+			env := &ClientEnvironment{Log: btclog.Disabled}
+
+			tr, err := tc.state(forfeits).ProcessEvent(
+				context.Background(), tc.event, env,
+			)
+			require.NoError(t, err)
+
+			_, ok := tr.NextState.(*ClientFailedState)
+			require.True(
+				t, ok, "expected ClientFailedState, got %T",
+				tr.NextState,
+			)
+
+			outbox := tr.NewEvents.UnwrapOr(
+				ClientEmittedEvent{},
+			).Outbox
+			release, ok := findOutbox[*ReleaseForfeitReservation](
+				outbox,
+			)
+			require.True(
+				t, ok,
+				"pre-signing failure must release forfeits",
+			)
+			require.ElementsMatch(t, outpoints, release.Outpoints)
+		})
+	}
+}
+
+// TestPostSigningFailureDoesNotReleaseForfeits is the safety control: once the
+// client has submitted its forfeit signatures (InputSigSentState onward), a
+// failed round must NOT auto-release the inputs, since the server could still
+// broadcast the forfeit if the commitment confirms. Releasing here would risk a
+// double-spend, so the post-signing states are deliberately not wired to the
+// release helper.
+func TestPostSigningFailureDoesNotReleaseForfeits(t *testing.T) {
+	t.Parallel()
+
+	forfeits, _ := frcForfeits()
+	env := &ClientEnvironment{Log: btclog.Disabled}
+
+	s := &InputSigSentState{Intents: Intents{Forfeits: forfeits}}
+	tr, err := s.ProcessEvent(context.Background(), &BoardingFailed{
+		Reason:      "post-signing failure",
+		Recoverable: false,
+	}, env)
+	require.NoError(t, err)
+
+	failed, ok := tr.NextState.(*ClientFailedState)
+	require.True(t, ok, "expected ClientFailedState, got %T", tr.NextState)
+	require.False(t, failed.Recoverable)
+
+	_, ok = findOutbox[*ReleaseForfeitReservation](
+		tr.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox,
+	)
+	require.False(
+		t, ok, "post-signing failure must not auto-release forfeits",
+	)
+}

--- a/round/from_proto.go
+++ b/round/from_proto.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
 	"github.com/lightninglabs/darepo-client/rpc/roundpb"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"google.golang.org/protobuf/proto"
 )
@@ -428,6 +429,18 @@ func (e *BoardingFailed) FromProto(p proto.Message) error {
 	case *roundpb.ClientRoundFailedResp:
 		e.Reason = pb.Reason
 		e.Recoverable = true
+
+		// Carry the server-assigned round id when present so the actor
+		// can route this failure deterministically to the matching FSM.
+		// A failure that arrives before the round was assigned
+		// legitimately has no id (len != 16), in which case RoundID
+		// stays None and routing falls back to the sole-round
+		// heuristic.
+		if len(pb.RoundId) == 16 {
+			var rid RoundID
+			copy(rid[:], pb.RoundId)
+			e.RoundID = fn.Some(rid)
+		}
 
 		return nil
 

--- a/round/from_proto_test.go
+++ b/round/from_proto_test.go
@@ -220,10 +220,17 @@ func TestOperatorSignedFromProto(t *testing.T) {
 }
 
 // TestBoardingFailedFromProtoRoundFailed verifies that BoardingFailed
-// handles ClientRoundFailedResp.
+// handles ClientRoundFailedResp and carries the server-assigned RoundID
+// when the proto includes a well-formed 16-byte round_id
+// (darepo-client#571).
 func TestBoardingFailedFromProtoRoundFailed(t *testing.T) {
+	roundID := [16]byte{
+		1, 2, 3, 4, 5, 6, 7, 8,
+		9, 10, 11, 12, 13, 14, 15, 16,
+	}
+
 	pb := &roundpb.ClientRoundFailedResp{
-		RoundId: make([]byte, 16),
+		RoundId: roundID[:],
 		Reason:  "timeout expired",
 	}
 
@@ -231,10 +238,35 @@ func TestBoardingFailedFromProtoRoundFailed(t *testing.T) {
 	require.NoError(t, got.FromProto(pb))
 	require.Equal(t, "timeout expired", got.Reason)
 	require.True(t, got.Recoverable)
+	require.True(
+		t, got.RoundID.IsSome(),
+		"a 16-byte round_id should populate RoundID",
+	)
+	require.Equal(t, RoundID(roundID), got.RoundID.UnwrapOr(RoundID{}))
+}
+
+// TestBoardingFailedFromProtoRoundFailedNoRoundID verifies that a
+// ClientRoundFailedResp without a well-formed 16-byte round_id (a failure
+// that arrives before the round was assigned) leaves RoundID as None
+// rather than erroring (darepo-client#571).
+func TestBoardingFailedFromProtoRoundFailedNoRoundID(t *testing.T) {
+	pb := &roundpb.ClientRoundFailedResp{
+		Reason: "pre-assignment failure",
+	}
+
+	var got BoardingFailed
+	require.NoError(t, got.FromProto(pb))
+	require.Equal(t, "pre-assignment failure", got.Reason)
+	require.True(t, got.Recoverable)
+	require.True(
+		t, got.RoundID.IsNone(),
+		"an empty round_id should leave RoundID None",
+	)
 }
 
 // TestBoardingFailedFromProtoErrorResp verifies that BoardingFailed
 // handles ClientErrorResp (the other proto type that maps to this event).
+// ClientErrorResp has no round_id, so RoundID stays None.
 func TestBoardingFailedFromProtoErrorResp(t *testing.T) {
 	pb := &roundpb.ClientErrorResp{
 		ErrorMsg: "internal error",
@@ -244,6 +276,10 @@ func TestBoardingFailedFromProtoErrorResp(t *testing.T) {
 	require.NoError(t, got.FromProto(pb))
 	require.Equal(t, "internal error", got.Reason)
 	require.True(t, got.Recoverable)
+	require.True(
+		t, got.RoundID.IsNone(),
+		"ClientErrorResp carries no round_id",
+	)
 }
 
 // TestFromProtoWrongType verifies that FromProto returns an error for

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -57,6 +57,58 @@ func failWithNotification(reason string, err error, recoverable bool,
 	}
 }
 
+// releaseForfeitsOnFailure appends a ReleaseForfeitReservation to a transition
+// that lands in ClientFailedState, returning the given forfeit-reserved VTXOs
+// to LiveState so they are not stranded in pending-forfeit after a failed
+// round. It is a no-op for any non-failure transition, for rounds that
+// reserved no forfeits, and when a release was already emitted (so the
+// IntentSentState admission-timeout path, which releases explicitly, is not
+// double-counted).
+//
+// Releasing is only safe BEFORE the client submits its VTXO forfeit signatures
+// to the server (SubmitVTXOForfeitSigsToServer, emitted on the
+// ForfeitSignaturesCollectingState -> InputSigSentState transition): until that
+// point the server holds no forfeit signature and cannot broadcast a forfeit,
+// so returning the inputs to LiveState cannot double-spend. Callers therefore
+// wire this only into the pre-signing states (PendingRoundAssembly through
+// ForfeitSignaturesCollectingState); the post-signing states (InputSigSentState
+// onward) deliberately do not release.
+func releaseForfeitsOnFailure(transition *ClientStateTransition,
+	forfeits []types.ForfeitRequest) *ClientStateTransition {
+
+	if transition == nil {
+		return transition
+	}
+
+	// Only a transition into the terminal failure state can strand forfeit
+	// reservations; leave every other transition untouched.
+	if _, failed := transition.NextState.(*ClientFailedState); !failed {
+		return transition
+	}
+
+	outpoints := forfeitOutpoints(forfeits)
+	if len(outpoints) == 0 {
+		return transition
+	}
+
+	emitted := transition.NewEvents.UnwrapOr(ClientEmittedEvent{})
+
+	// Stay idempotent: a handler that already released (the admission
+	// timeout in IntentSentState) must not release the same inputs twice.
+	for _, msg := range emitted.Outbox {
+		if _, ok := msg.(*ReleaseForfeitReservation); ok {
+			return transition
+		}
+	}
+
+	emitted.Outbox = append(emitted.Outbox, &ReleaseForfeitReservation{
+		Outpoints: outpoints,
+	})
+	transition.NewEvents = fn.Some(emitted)
+
+	return transition
+}
+
 // selfLoop creates a self-loop transition that stays in the current state
 // without emitting any events. Used for unknown events in non-terminal states
 // to avoid halting the FSM.
@@ -186,9 +238,23 @@ func (s *Idle) ProcessEvent(ctx context.Context, event ClientEvent,
 
 // ProcessEvent for PendingRoundAssembly tracks confirmed boarding intents and
 // transitions to registration once all are ready.
+func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(transition, s.Forfeits), err
+}
+
+// processEvent runs the PendingRoundAssembly event handling; ProcessEvent wraps
+// it to return forfeit-reserved inputs to LiveState on failure.
 //
 //nolint:funlen
-func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
+func (s *PendingRoundAssembly) processEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
@@ -529,6 +595,20 @@ func (s *PendingRoundAssembly) ProcessEvent(ctx context.Context,
 
 // ProcessEvent for IntentSentState.
 func (s *IntentSentState) ProcessEvent(ctx context.Context, event ClientEvent,
+	env *ClientEnvironment) (*ClientStateTransition, error) {
+
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure. Idempotent with the admission-timeout path,
+	// which already releases explicitly.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(transition, s.Intents.Forfeits), err
+}
+
+// processEvent runs the IntentSentState event handling; ProcessEvent wraps it
+// to return forfeit-reserved inputs to LiveState on failure.
+func (s *IntentSentState) processEvent(ctx context.Context, event ClientEvent,
 	env *ClientEnvironment) (*ClientStateTransition, error) {
 
 	switch evt := event.(type) {
@@ -1218,6 +1298,20 @@ func (s *QuoteReceivedState) ProcessEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(transition, s.Intents.Forfeits), err
+}
+
+// processEvent runs the QuoteReceivedState event handling; ProcessEvent wraps
+// it to return forfeit-reserved inputs to LiveState on failure.
+func (s *QuoteReceivedState) processEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
 	switch evt := event.(type) {
 	case *JoinRoundQuoteReceived:
 		// Server reseal: a later pass arrives while we still
@@ -1328,6 +1422,19 @@ func (s *QuoteReceivedState) ProcessEvent(ctx context.Context,
 
 // ProcessEvent for RoundJoinedState.
 func (s *RoundJoinedState) ProcessEvent(ctx context.Context, event ClientEvent,
+	env *ClientEnvironment) (*ClientStateTransition, error) {
+
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(transition, s.Intents.Forfeits), err
+}
+
+// processEvent runs the RoundJoinedState event handling; ProcessEvent wraps it
+// to return forfeit-reserved inputs to LiveState on failure.
+func (s *RoundJoinedState) processEvent(ctx context.Context, event ClientEvent,
 	env *ClientEnvironment) (*ClientStateTransition, error) {
 
 	switch evt := event.(type) {
@@ -1604,9 +1711,23 @@ func quoteLeaveAmounts(quote *ClientQuote,
 }
 
 // ProcessEvent for CommitmentTxReceivedState.
+func (s *CommitmentTxReceivedState) ProcessEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(transition, s.Intents.Forfeits), err
+}
+
+// processEvent runs the CommitmentTxReceivedState event handling; ProcessEvent
+// wraps it to return forfeit-reserved inputs to LiveState on failure.
 //
 //nolint:funlen,ll
-func (s *CommitmentTxReceivedState) ProcessEvent(ctx context.Context,
+func (s *CommitmentTxReceivedState) processEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
@@ -1974,6 +2095,20 @@ func (s *CommitmentTxValidatedState) ProcessEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(transition, s.Intents.Forfeits), err
+}
+
+// processEvent runs the CommitmentTxValidatedState event handling; ProcessEvent
+// wraps it to return forfeit-reserved inputs to LiveState on failure.
+func (s *CommitmentTxValidatedState) processEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
 	switch event.(type) {
 	case *GenerateNonces:
 		env.Log.InfoS(
@@ -2184,6 +2319,23 @@ func (s *CommitmentTxValidatedState) ProcessEvent(ctx context.Context,
 // sign boarding inputs, submit all signatures to the server, and transition
 // to InputSigSentState.
 func (s *ForfeitSignaturesCollectingState) ProcessEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
+	// Failures here are still pre-signing: VTXO forfeit signatures are only
+	// submitted to the server on the success transition to
+	// InputSigSentState (SubmitVTXOForfeitSigsToServer), so any transition
+	// into ClientFailedState may safely return forfeit-reserved inputs to
+	// LiveState; see releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(transition, s.Intents.Forfeits), err
+}
+
+// processEvent runs the ForfeitSignaturesCollectingState event handling;
+// ProcessEvent wraps it to return forfeit-reserved inputs to LiveState on
+// failure.
+func (s *ForfeitSignaturesCollectingState) processEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
@@ -2507,6 +2659,19 @@ func (s *ForfeitSignaturesCollectingState) inputSigSentState(
 func (s *NoncesSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 	env *ClientEnvironment) (*ClientStateTransition, error) {
 
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(transition, s.Intents.Forfeits), err
+}
+
+// processEvent runs the NoncesSentState event handling; ProcessEvent wraps it
+// to return forfeit-reserved inputs to LiveState on failure.
+func (s *NoncesSentState) processEvent(ctx context.Context, event ClientEvent,
+	env *ClientEnvironment) (*ClientStateTransition, error) {
+
 	switch evt := event.(type) {
 	case *NoncesAggregated:
 		env.Log.InfoS(ctx, "Received aggregated nonces from server",
@@ -2585,6 +2750,20 @@ func (s *NoncesAggregatedState) ProcessEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
+	// Any transition into ClientFailedState from this pre-signing state
+	// returns forfeit-reserved inputs to LiveState; see
+	// releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(transition, s.Intents.Forfeits), err
+}
+
+// processEvent runs the NoncesAggregatedState event handling; ProcessEvent
+// wraps it to return forfeit-reserved inputs to LiveState on failure.
+func (s *NoncesAggregatedState) processEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
 	switch event.(type) {
 	case *GeneratePartialSigs:
 		env.Log.InfoS(
@@ -2655,6 +2834,22 @@ func (s *NoncesAggregatedState) ProcessEvent(ctx context.Context,
 
 // ProcessEvent for PartialSigsSentState.
 func (s *PartialSigsSentState) ProcessEvent(ctx context.Context,
+	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
+	error) {
+
+	// Still pre-signing: this state submits MuSig2 partial sigs, not VTXO
+	// forfeit sigs (those go out only when ForfeitSignaturesCollectingState
+	// transitions to InputSigSentState). Any transition into
+	// ClientFailedState may safely return forfeit-reserved inputs to
+	// LiveState; see releaseForfeitsOnFailure.
+	transition, err := s.processEvent(ctx, event, env)
+
+	return releaseForfeitsOnFailure(transition, s.Intents.Forfeits), err
+}
+
+// processEvent runs the PartialSigsSentState event handling; ProcessEvent wraps
+// it to return forfeit-reserved inputs to LiveState on failure.
+func (s *PartialSigsSentState) processEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 

--- a/systest/boarding_fail_route_test.go
+++ b/systest/boarding_fail_route_test.go
@@ -1,0 +1,101 @@
+//go:build systest
+
+package systest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/darepod"
+	"github.com/stretchr/testify/require"
+)
+
+// boardingFundAmount is the on-chain value funded into the boarding address
+// under test. It is comfortably above dust so the deposit is a viable round
+// input.
+const boardingFundAmount = btcutil.Amount(200_000)
+
+// TestBoardingRoundFailureSurfacedNotStuck exercises the round-id failure
+// routing added in darepo-client#761 for a boarding deposit. A confirmed
+// boarding deposit eagerly joins a round; the fake operator admits the client
+// (re-keying the round to the server id) and then fails it. Before #761 the
+// failure carried no round id, so it was dropped for the re-keyed round and the
+// boarding sat projecting a synthetic VTXO_STATUS_PENDING_ROUND forever. With
+// #761 the failure reaches the re-keyed round, which surfaces as
+// ROUND_STATE_FAILED, and the phantom pending VTXO clears.
+//
+// The registration timeout is disabled so a FAILED round can only come from the
+// server-pushed failure, not the admission timer.
+func TestBoardingRoundFailureSurfacedNotStuck(t *testing.T) {
+	ParallelN(t)
+
+	fixture := newDirectedSendFixture(t, func(c *darepod.Config) {
+		c.EagerRoundJoin = true
+		c.RegistrationTimeout = -1
+	})
+
+	// Arm the operator to admit-then-fail the boarding round.
+	fixture.mailboxServer.failRoundsAfterAdmission(
+		"simulated post-admission boarding round failure",
+	)
+
+	// Create a boarding address and fund it on-chain. A single confirmation
+	// satisfies the operator's MinConfirmations, after which the eager-join
+	// wallet drives the round.
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	addrResp, err := fixture.client.NewAddress(
+		ctx, &daemonrpc.NewAddressRequest{},
+	)
+	require.NoError(t, err, "NewAddress RPC failed")
+	require.NotEmpty(t, addrResp.Address)
+
+	fixture.harness.Harness.Faucet(addrResp.Address, boardingFundAmount)
+	fixture.harness.Harness.Generate(1)
+	fixture.harness.WaitForLNDSync()
+
+	// The boarding deposit confirms, the daemon eagerly joins a round, the
+	// operator admits then fails it, and the failure reaches the re-keyed
+	// round (#761) so it surfaces as FAILED rather than hanging. On a
+	// daemon without #761 the failure is dropped and no round ever reaches
+	// FAILED.
+	require.Eventuallyf(
+		t,
+		func() bool {
+			for _, r := range listRounds(t, fixture.client) {
+				if r.State == daemonrpc.RoundState_ROUND_STATE_FAILED { //nolint:ll
+					return true
+				}
+			}
+
+			return false
+		},
+		60*time.Second, 250*time.Millisecond,
+		"boarding round never surfaced as ROUND_STATE_FAILED",
+	)
+
+	// Once the round has failed, the boarding deposit must not keep
+	// projecting a synthetic PENDING_ROUND VTXO (the "pending forever"
+	// symptom #761 fixes). No further blocks are mined, so the failed round
+	// is not re-joined while we observe.
+	require.Eventuallyf(
+		t,
+		func() bool {
+			for _, v := range listAllVTXOs(t, fixture.client) {
+				pending := daemonrpc.VTXOStatus_VTXO_STATUS_PENDING_ROUND //nolint:ll
+				if v.Status == pending {
+					return false
+				}
+			}
+
+			return true
+		},
+		30*time.Second, 250*time.Millisecond,
+		"boarding deposit still projects a PENDING_ROUND VTXO after "+
+			"the round failed",
+	)
+}

--- a/systest/forfeit_release_post_admission_test.go
+++ b/systest/forfeit_release_post_admission_test.go
@@ -1,0 +1,225 @@
+//go:build systest
+
+package systest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/darepod"
+	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
+	"github.com/lightninglabs/darepo-client/rpc/roundpb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// injectedPostAdmissionRoundID is the fixed 16-byte (UUID-shaped) round id the
+// fake operator assigns when it admits then fails a round. The same id is
+// echoed on both the RoundJoined admission and the ClientRoundFailedResp
+// failure so the client re-keys its FSM to this id and then routes the failure
+// back to that same re-keyed round (the routing fixed in darepo-client#761).
+var injectedPostAdmissionRoundID = [16]byte{
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+}
+
+// postAdmissionRecoveryWindow bounds how long we wait for the server-pushed
+// round failure to release the forfeit-reserved VTXO back to LIVE. It is
+// generous to tolerate the several async actor hops (ingress → round actor →
+// VTXO manager → VTXO actor) under parallel Dockerized systest load.
+const postAdmissionRecoveryWindow = 60 * time.Second
+
+// failRoundsAfterAdmission arms the fake operator so that every JoinRound it
+// receives is first admitted (RoundJoined) and then failed
+// (ClientRoundFailedResp), reproducing a server round-build failure that lands
+// after the client has already been admitted.
+func (s *fakeMailboxServer) failRoundsAfterAdmission(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.failRoundAfterAdmission = true
+	s.failRoundReason = reason
+}
+
+// maybeFailRoundAfterAdmission, when arming is enabled, pushes a RoundJoined
+// admission watermark followed by a round-failure to the client that sent the
+// given JoinRound envelope. The admission is sent first so the client FSM
+// re-keys to the server-assigned round id and cancels its registration timeout;
+// the failure then carries that same id so it routes back to the re-keyed round
+// (darepo-client#761) and drives it into ClientFailedState, where the
+// pre-signing forfeit release runs.
+func (s *fakeMailboxServer) maybeFailRoundAfterAdmission(
+	joinEnv *mailboxpb.Envelope) error {
+
+	s.mu.Lock()
+	enabled := s.failRoundAfterAdmission
+	reason := s.failRoundReason
+	s.mu.Unlock()
+
+	if !enabled {
+		return nil
+	}
+
+	// The client re-keys a pending round to the server id only when the
+	// RoundJoined echoes the round's accepted inputs (handleRoundJoined
+	// matches by outpoint). Echo the forfeited VTXO outpoints from the
+	// JoinRound so the admission matches the leave's pending round.
+	var req roundpb.JoinRoundRequest
+	if err := joinEnv.Body.UnmarshalTo(&req); err != nil {
+		return fmt.Errorf("decode join round for admission: %w", err)
+	}
+
+	acceptedVTXOs := make([]*roundpb.Outpoint, 0, len(req.ForfeitRequests))
+	for _, ff := range req.ForfeitRequests {
+		if ff.VtxoOutpoint != nil {
+			acceptedVTXOs = append(acceptedVTXOs, ff.VtxoOutpoint)
+		}
+	}
+
+	rid := injectedPostAdmissionRoundID
+
+	// Admit first: the client matches the echoed outpoints to its pending
+	// round, re-keys it to this id, and parks in IntentSentState.
+	admit := &roundpb.ClientSuccessResp{
+		RoundId:               rid[:],
+		AcceptedVtxoOutpoints: acceptedVTXOs,
+	}
+	if err := s.pushRoundEvent(
+		joinEnv, roundpb.MethodJoinAck, admit,
+	); err != nil {
+		return err
+	}
+
+	// Then fail: the same round id routes this back to the re-keyed round,
+	// which fails recoverably and (with the fix) releases its
+	// forfeit-reserved inputs.
+	failed := &roundpb.ClientRoundFailedResp{
+		RoundId: rid[:],
+		Reason:  reason,
+	}
+
+	return s.pushRoundEvent(joinEnv, roundpb.MethodRoundFailed, failed)
+}
+
+// pushRoundEvent enqueues a server→client round-protocol push (a KIND_EVENT
+// envelope) back to the mailbox that sent reqEnv, mirroring how the real
+// operator delivers round lifecycle notifications.
+func (s *fakeMailboxServer) pushRoundEvent(reqEnv *mailboxpb.Envelope,
+	method string, msg proto.Message) error {
+
+	body, err := anypb.New(msg)
+	if err != nil {
+		return err
+	}
+
+	s.enqueueEnvelope(&mailboxpb.Envelope{
+		ProtocolVersion: reqEnv.ProtocolVersion,
+		Sender:          s.operatorMailbox,
+		Recipient:       reqEnv.Rpc.ReplyTo,
+		CreatedAtUnixMs: time.Now().UnixMilli(),
+		Body:            body,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:    mailboxpb.RpcMeta_KIND_EVENT,
+			Service: roundpb.ServiceName,
+			Method:  method,
+			ReplyTo: s.operatorMailbox,
+		},
+	})
+
+	return nil
+}
+
+// TestForfeitReleasedOnPostAdmissionRoundFailure proves the post-admission
+// forfeit-release fix end to end. A cooperative leave reserves the VTXO into
+// pending-forfeit and registers the round; the fake operator admits the client
+// (so the registration timeout is cancelled and the FSM is re-keyed) and then
+// fails the round. The registration timeout is disabled, so the ONLY path back
+// to LIVE is the release that runs when the post-admission failure drives the
+// round into ClientFailedState. On an unfixed daemon the VTXO would stay
+// stranded in pending-forfeit forever and the test would time out.
+//
+// This also exercises the darepo-client#761 routing fix: the failure carries
+// the server-assigned round id and must reach the re-keyed round, not be
+// dropped.
+func TestForfeitReleasedOnPostAdmissionRoundFailure(t *testing.T) {
+	ParallelN(t)
+
+	// Disable the admission timeout so a return to LIVE can only come from
+	// the post-admission release, never from the registration-timeout
+	// safety net exercised by
+	// TestLeaveStrandedVTXORecoversOnAdmissionTimeout.
+	fixture := newDirectedSendFixture(t, func(c *darepod.Config) {
+		c.EagerRoundJoin = true
+		c.RegistrationTimeout = -1
+	})
+
+	// Arm the operator to admit-then-fail any round the client joins.
+	fixture.mailboxServer.failRoundsAfterAdmission(
+		"simulated post-admission round build failure",
+	)
+
+	// The seeded VTXO starts LIVE and is the entire spendable balance.
+	startVTXOs := listAllVTXOs(t, fixture.client)
+	require.Len(t, startVTXOs, 1)
+	require.Equal(
+		t, daemonrpc.VTXOStatus_VTXO_STATUS_LIVE, startVTXOs[0].Status,
+	)
+	require.Equal(
+		t, testSeededAmountSat, vtxoBalanceSat(t, fixture.client),
+	)
+
+	destAddr := newRegtestTaprootAddr(t)
+
+	// Issue the cooperative leave. The reservation into pending-forfeit is
+	// synchronous, so the VTXO is already reserved when this returns and
+	// the JoinRound that triggers the admit-then-fail is in flight.
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	leaveResp, err := fixture.client.LeaveVTXOs(
+		ctx, &daemonrpc.LeaveVTXOsRequest{
+			Selection: &daemonrpc.LeaveVTXOsRequest_Outpoints{
+				Outpoints: &daemonrpc.OutpointSelection{
+					Outpoints: []string{
+						outpointString(
+							fixture.seededOutpoint,
+						),
+					},
+				},
+			},
+			DefaultDestination: &daemonrpc.LeaveDestination{
+				Target: &daemonrpc.LeaveDestination_Address{
+					Address: destAddr,
+				},
+			},
+		},
+	)
+	require.NoError(t, err, "LeaveVTXOs RPC failed")
+	require.Equal(t, "queued", leaveResp.Status)
+
+	// The fix: the server-pushed round failure reaches the re-keyed round,
+	// fails it recoverably, and releases the VTXO back to LIVE. With the
+	// admission timeout disabled, reaching LIVE proves the release came
+	// from the post-admission failure path. On the unfixed daemon this
+	// never happens and the assertion times out.
+	requireVTXOStatusEventually(
+		t, fixture.client, fixture.seededOutpoint,
+		daemonrpc.VTXOStatus_VTXO_STATUS_LIVE,
+		postAdmissionRecoveryWindow,
+	)
+
+	// The spendable balance is restored to its starting value.
+	require.Eventually(
+		t,
+		func() bool {
+			return vtxoBalanceSat(t, fixture.client) ==
+				testSeededAmountSat
+		},
+		20*time.Second, 100*time.Millisecond,
+		"vtxo balance not restored after post-admission release",
+	)
+}

--- a/systest/forfeit_release_post_admission_test.go
+++ b/systest/forfeit_release_post_admission_test.go
@@ -66,11 +66,21 @@ func (s *fakeMailboxServer) maybeFailRoundAfterAdmission(
 
 	// The client re-keys a pending round to the server id only when the
 	// RoundJoined echoes the round's accepted inputs (handleRoundJoined
-	// matches by outpoint). Echo the forfeited VTXO outpoints from the
-	// JoinRound so the admission matches the leave's pending round.
+	// matches by outpoint). Echo both the boarding and forfeited VTXO
+	// outpoints from the JoinRound so the admission matches the pending
+	// round whether it is a boarding or a leave/refresh.
 	var req roundpb.JoinRoundRequest
 	if err := joinEnv.Body.UnmarshalTo(&req); err != nil {
 		return fmt.Errorf("decode join round for admission: %w", err)
+	}
+
+	acceptedBoarding := make(
+		[]*roundpb.Outpoint, 0, len(req.BoardingRequests),
+	)
+	for _, b := range req.BoardingRequests {
+		if b.Outpoint != nil {
+			acceptedBoarding = append(acceptedBoarding, b.Outpoint)
+		}
 	}
 
 	acceptedVTXOs := make([]*roundpb.Outpoint, 0, len(req.ForfeitRequests))
@@ -85,8 +95,9 @@ func (s *fakeMailboxServer) maybeFailRoundAfterAdmission(
 	// Admit first: the client matches the echoed outpoints to its pending
 	// round, re-keys it to this id, and parks in IntentSentState.
 	admit := &roundpb.ClientSuccessResp{
-		RoundId:               rid[:],
-		AcceptedVtxoOutpoints: acceptedVTXOs,
+		RoundId:                   rid[:],
+		AcceptedBoardingOutpoints: acceptedBoarding,
+		AcceptedVtxoOutpoints:     acceptedVTXOs,
 	}
 	if err := s.pushRoundEvent(
 		joinEnv, roundpb.MethodJoinAck, admit,

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -79,6 +79,15 @@ type fakeMailboxServer struct {
 	oorSubmitReqs   []*oorpb.SubmitPackageRequest
 	oorSubmitEnvs   []*mailboxpb.Envelope
 	inboxSignalChan chan struct{}
+
+	// failRoundAfterAdmission, when set, makes the fake operator admit a
+	// client's JoinRound (push RoundJoined) and then immediately fail the
+	// round (push ClientRoundFailedResp), reproducing a server round-build
+	// failure that lands after the client has already been admitted. Used
+	// to exercise the post-admission forfeit-release path. See
+	// forfeit_release_post_admission_test.go.
+	failRoundAfterAdmission bool
+	failRoundReason         string
 }
 
 // newFakeMailboxServer constructs a fake mailbox edge with the given operator
@@ -249,7 +258,12 @@ func (s *fakeMailboxServer) handleOperatorEnvelope(ctx context.Context,
 
 	case env.Rpc.Service == roundpb.ServiceName &&
 		env.Rpc.Method == roundpb.MethodJoinRound:
-		return s.recordJoinRound(env)
+
+		if err := s.recordJoinRound(env); err != nil {
+			return err
+		}
+
+		return s.maybeFailRoundAfterAdmission(env)
 
 	case env.Rpc.Service == oorpb.ServiceName &&
 		env.Rpc.Method == oorpb.MethodSubmitPackage:


### PR DESCRIPTION
In this PR, we add two systests for how the client handles a round that
fails *after* it's been admitted. This stacks on #761 (the round-id failure
routing) and exercises it together with the forfeit-release fix in #763.

The fake operator in the systest harness gains an admit-then-fail mode: when
it receives a `JoinRound`, it pushes a `RoundJoined` that echoes the round's
accepted inputs (so the client re-keys its pending round to the server id,
the way `handleRoundJoined` matches by outpoint), and then pushes a
`ClientRoundFailedResp` carrying that same id. The failure routes back to the
re-keyed round (the #761 path) and drives it into `ClientFailedState`. This
is the smallest faithful reproduction of the production incident: admit,
then fail, with no quote or commitment dance.

## Forfeit release

`TestForfeitReleasedOnPostAdmissionRoundFailure` reserves a VTXO via a
cooperative leave (so it lands in `PENDING_FORFEIT`), then has the operator
admit and fail the round. We disable the registration timeout, so the only
way the VTXO can get back to `LIVE` is the post-admission forfeit release from
#763. On a daemon without that fix it stays stranded; we confirmed the test
catches it by neutering the release and watching the assertion time out
(~73s) where the fixed daemon recovers in ~14s.

## Boarding failure routing

`TestBoardingRoundFailureSurfacedNotStuck` funds a real boarding deposit,
lets the eager-join wallet register it, and has the operator admit then fail
the round. Before #761 the failure carried no round id and got dropped for
the re-keyed round, so the boarding sat projecting a synthetic
`PENDING_ROUND` VTXO forever. Here we assert the round surfaces as
`ROUND_STATE_FAILED` and the phantom pending VTXO clears.

See each commit message for the incremental details. Note this is based on
the #761 branch, so the shared release-fix commit drops out once #761 and
#763 land in main.
