### PR TITLE
docs: nightly doc-gardening sweep 2026-06-21

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,6 +18,7 @@ package may import from a higher layer.
 | [`oor`](oor/) | Out-of-round transfer coordination FSM |
 | [`wallet`](wallet/) | On-chain boarding wallet actor (address derivation, UTXO monitoring) |
 | [`ledger`](ledger/) | Client-side durable ledger actor for double-entry fee accounting |
+| [`coinselect`](coinselect/) | Coin-type-agnostic largest-first coin-selection algorithm (no wallet/actor/RPC deps) |
 | [`lib`](lib/) | Shared domain utilities: tree paths, BIP-322, arkscript policy, types |
 | [`lib/arkscript`](lib/arkscript/) | Tapscript AST compiler and policy system for Ark taproot outputs |
 | [`lib/bip322`](lib/bip322/) | BIP-322 intent-bound message authentication |

--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -26,7 +26,7 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `Receptionist` — Service locator mapping `ServiceKey` → `ActorRef` for decoupled actor wiring.
 - `Message` — Sealed interface for all actor messages (must embed `BaseMessage`).
 - `MessageCodec` — TLV-based codec for message serialization/deserialization.
-- `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter).
+- `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter). The leaseless single-worker fast path adds `PeekNextMessage` (read-only claim, no lease, no attempts bump; yields an empty lease token), `AckMessageByID` (unfenced delete), and `NackMessageByID` (unfenced release that increments attempts). A `DurableActor` enables it (via `DurableMailboxConfig.SingleWorkerLeaseless`) strictly when `NumWorkers == 1` AND the behavior is the Read/Commit (Right/`TxBehavior`) path, eliminating the per-message lease write transaction. The multi-worker pool and the classic path are byte-for-byte unchanged: they keep `LeaseNextMessage` and the lease-fenced ack. Ack/nack route to the by-ID ops automatically whenever the delivery's lease token is empty; `Delivery.ShouldDeadLetter` counts the in-flight attempt as `Attempts + 1` on the leaseless path so the dead-letter boundary matches the leased path (where attempts is pre-incremented at lease).
 - `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence. Provides `Wait(ctx)` to block until the actor stops and `StopAndWait(ctx)` to request a graceful shutdown and then wait.
 - `DurableActorConfig[M, R]` — Configuration struct for `DurableActor`: behavior, store, codec, clock, DLO, WaitGroup, `TellRetryPolicy`, lease/heartbeat/poll durations, max attempts, cleanup timeout, deduplication TTL, and `NumWorkers`.
 - `DurableActorConfig.NumWorkers` — How many concurrent worker loops drain the actor's single mailbox. Default and any value `<= 1` is one worker (strictly-sequential processing). A value `> 1` turns the actor into a competing-consumer pool: that many goroutines each lease distinct messages via `LeaseNextMailboxMessage`, so independent messages run in parallel while per-correlation-key FIFO still keeps same-key messages ordered. Only for behaviors whose handlers are concurrency-safe and hold no writer across their side effects (e.g. the serverconn egress sender on the Read/Commit path). `NewDurableActor` **fails closed** with `ErrConcurrentClassicBehavior` when `NumWorkers > 1` is paired with a classic (`Left`) `ActorBehavior`, since the classic path wraps the whole `Receive` in one write transaction and assumes sequential delivery; pools are only valid on the Read/Commit (`TxBehavior`) path. The test-only `DurableActorConfig.AllowConcurrentClassicBehavior()` escape hatch bypasses the guard for the egress benchmark that measures the forbidden config; production code must never call it.
@@ -81,8 +81,24 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 ## Invariants
 
 - Messages are processed sequentially per actor by default (one worker, no concurrent `Receive` calls). Opting into `DurableActorConfig.NumWorkers > 1` relaxes this: that many worker loops drain the one mailbox concurrently, so `Receive` may run in parallel across distinct messages. The competing-consumer lease guarantees each message is still processed by exactly one worker, and per-correlation-key FIFO holds across workers; only behaviors with concurrency-safe handlers should set it. The combination is structurally restricted to the Read/Commit path: `NewDurableActor` rejects `NumWorkers > 1` on a classic `ActorBehavior` with `ErrConcurrentClassicBehavior` so a stateful, sequentially-assumed actor can never be silently fanned out.
+- **Leaseless consume ownership model.** `SingleWorkerLeaseless` removes the
+  lease-token fence, so its safety argument is "one live runtime owner for this
+  mailbox", not merely "one goroutine in this process". Do not enable it for a
+  mailbox that can be drained by another daemon/process at the same time unless
+  an external singleton/ownership fence already exists. A peeked delivery always
+  carries an empty lease token, even when the persisted row still has stale
+  expired lease metadata from an older leased claim; that empty token is the
+  p-model edge that routes ack/nack to the by-ID operations. Retry-policy
+  decisions must use `Delivery.EffectiveAttempts()` so the in-flight peeked
+  attempt is counted before a nack can raise the row to `max_attempts`.
 - `Tell` with a `DurableActor` persists the message before returning (crash-safe enqueue).
 - Outbox messages are dispatched only after state is persisted (outbox pattern).
+- **Outbox fold p-model.** For tx-aware stores, outbox delivery is
+  `claim -> (target mailbox enqueue + CompleteOutbox) in one write tx`. If the
+  transaction fails before commit, both the enqueue and completion roll back and
+  the claim expiry is the retry mechanism; the publisher must log the
+  transaction failure even when the inner Tell/Complete operations returned nil,
+  because begin/commit failures happen outside those operation-level logs.
 - `ServiceKey` lookup via `Receptionist` is type-safe: mismatched types return `ErrServiceKeyTypeMismatch`.
 - `RestartMessage` has `RestartPriority` (MaxInt32) ensuring it is processed before all other messages on recovery.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.

--- a/coinselect/AGENTS.md
+++ b/coinselect/AGENTS.md
@@ -1,0 +1,54 @@
+# coinselect
+
+## Purpose
+
+Coin-type-agnostic largest-first coin-selection algorithm shared across the
+client. Deliberately holds no wallet, actor, or RPC dependencies so every
+layer that needs to pick a covering subset of coins — VTXO manager reservation,
+swap wallet send preview, boarding selection — selects through the same code
+rather than growing parallel implementations.
+
+## Key Types
+
+- `Request` — Selection parameters: `Target` (required for bounded mode,
+  must be positive), `MinChange` (rejects covering selections whose
+  non-zero change falls below this floor; zero disables), `SweepAll`
+  (selects every candidate, takes precedence over Target and MinChange).
+- `Result[T]` — Selection outcome: `Selected` (chosen subset), `Total`
+  (summed amount of selected), `Change` (Total - Target for bounded;
+  zero for sweep-all). On typed errors, `Total` carries the covered amount
+  at the rejection point so callers can build precise diagnostics.
+- `AmountFunc[T]` — Caller-supplied closure extracting `btcutil.Amount`
+  from a candidate. Keeps the selector agnostic to the concrete coin type
+  (`vtxo.Descriptor`, RPC VTXO, boarding intent, etc.).
+- `LargestFirst[T]` — Bounded coin selection: sorts a copy of candidates
+  by descending amount and accumulates until target is covered, honoring
+  `MinChange`. An exact-fit (zero-change) selection is always accepted.
+  A `SweepAll` request delegates to `selectAll`.
+- Error sentinels: `ErrSelectionShortfall` (candidate total < target),
+  `ErrChangeBelowMin` (covering selection exists but leaves dust change),
+  `ErrNoCandidates` (empty set), `ErrInvalidTarget` (non-positive target).
+
+## Relationships
+
+- **Depends on**: `btcsuite/btcd/btcutil` (Amount type only).
+- **Depended on by**: `vtxo` (VTXO reservation selection), `wallet`
+  (boarding and OOR spend selection), `sdk/walletdk` (send preview
+  coin selection).
+- No actor, wallet, or RPC dependencies by design.
+
+## Invariants
+
+- Caller's slice is never mutated — sorting happens on a copy.
+- On `ErrChangeBelowMin`, `Result.Total` is the total at the first
+  dust-rejection point; accumulating further can only grow change, not
+  return to zero, so the first rejection is the definitive bound.
+- Exact-fit (zero-change) selections are always accepted regardless of
+  `MinChange`.
+- `LargestFirst` is stable-sorted by descending amount, making it
+  deterministic for distinct amounts.
+- `SweepAll` preserves input order (no sorting); bounded mode sorts a copy.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/coinselect/CLAUDE.md
+++ b/coinselect/CLAUDE.md
@@ -1,0 +1,54 @@
+# coinselect
+
+## Purpose
+
+Coin-type-agnostic largest-first coin-selection algorithm shared across the
+client. Deliberately holds no wallet, actor, or RPC dependencies so every
+layer that needs to pick a covering subset of coins — VTXO manager reservation,
+swap wallet send preview, boarding selection — selects through the same code
+rather than growing parallel implementations.
+
+## Key Types
+
+- `Request` — Selection parameters: `Target` (required for bounded mode,
+  must be positive), `MinChange` (rejects covering selections whose
+  non-zero change falls below this floor; zero disables), `SweepAll`
+  (selects every candidate, takes precedence over Target and MinChange).
+- `Result[T]` — Selection outcome: `Selected` (chosen subset), `Total`
+  (summed amount of selected), `Change` (Total - Target for bounded;
+  zero for sweep-all). On typed errors, `Total` carries the covered amount
+  at the rejection point so callers can build precise diagnostics.
+- `AmountFunc[T]` — Caller-supplied closure extracting `btcutil.Amount`
+  from a candidate. Keeps the selector agnostic to the concrete coin type
+  (`vtxo.Descriptor`, RPC VTXO, boarding intent, etc.).
+- `LargestFirst[T]` — Bounded coin selection: sorts a copy of candidates
+  by descending amount and accumulates until target is covered, honoring
+  `MinChange`. An exact-fit (zero-change) selection is always accepted.
+  A `SweepAll` request delegates to `selectAll`.
+- Error sentinels: `ErrSelectionShortfall` (candidate total < target),
+  `ErrChangeBelowMin` (covering selection exists but leaves dust change),
+  `ErrNoCandidates` (empty set), `ErrInvalidTarget` (non-positive target).
+
+## Relationships
+
+- **Depends on**: `btcsuite/btcd/btcutil` (Amount type only).
+- **Depended on by**: `vtxo` (VTXO reservation selection), `wallet`
+  (boarding and OOR spend selection), `sdk/walletdk` (send preview
+  coin selection).
+- No actor, wallet, or RPC dependencies by design.
+
+## Invariants
+
+- Caller's slice is never mutated — sorting happens on a copy.
+- On `ErrChangeBelowMin`, `Result.Total` is the total at the first
+  dust-rejection point; accumulating further can only grow change, not
+  return to zero, so the first rejection is the definitive bound.
+- Exact-fit (zero-change) selections are always accepted regardless of
+  `MinChange`.
+- `LargestFirst` is stable-sorted by descending amount, making it
+  deterministic for distinct amounts.
+- `SweepAll` preserves input order (no sorting); bounded mode sorts a copy.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -71,7 +71,22 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   safety bounds enforced during `DeserializeTree`.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — two-stage
   OOR ancestry resolver (`oor_unroll_resolver.go`).
-- `LatestMigrationVersion = 17` — current schema version.
+- `LatestMigrationVersion = 19` — current schema version.
+- `PendingIntentPersistenceStore` — implements `wallet.PendingIntentStore`,
+  the persistence half of the generic restart-safe intent outbox (header
+  `pending_intents` + per-kind detail tables + `pending_intent_anchors`).
+  Maps the sealed `wallet.PendingIntentPayload` concrete types to/from typed
+  detail columns (no blob). Intents are written before the wallet publishes
+  them to the round actor; `CommitState` clears anchors by outpoint
+  (boarding outpoints AND forfeited VTXO outpoints) inside the
+  point-of-no-return round checkpoint transaction, then sweeps orphaned
+  detail rows and headers, so replay-after-adoption is structurally
+  impossible. Methods: `UpsertPendingIntent` (header + detail + anchors
+  atomically; anchor rebind sweeps anchor-less older intents),
+  `ListPendingIntents` (per kind, with anchors), `DeletePendingIntent`,
+  `ClearPendingIntentsByKind`.
+- `PendingIntentStore` / `BatchedPendingIntentStore` — internal sqlc-backed
+  query interfaces for the pending-intent tables.
 - `SpendingReservationPersistenceStore` — Persists the durable index of VTXO
   outpoints reserved by an active spend owner (e.g. an outgoing OOR session).
   A row exists IFF the owning session was durably checkpointed, so a startup
@@ -125,6 +140,15 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 
 ### Migration notes
 
+- `000018_pending_intents` — generalizes the Board-only
+  `pending_board_requests` outbox into a supertype/subtype set:
+  `pending_intent_kinds` (enum table), `pending_intents` (header: 32-byte
+  hash-derived intent id + kind FK + requested_at, no payload blob),
+  per-kind detail tables `pending_board_intents` / `pending_send_intents`
+  with first-class typed columns, and `pending_intent_anchors` (one row per
+  anchored outpoint, PK on the outpoint so a newer intent rebinds, FK to the
+  header). Drops `pending_board_requests` outright (alpha; rows only exist
+  in the narrow crash window between admission and round seal).
 - `000017_spending_reservations` — adds `spending_reservations` table with
   `(outpoint_hash, outpoint_index)` PK, `owner_kind`, `owner_id`, and
   `created_at`. A row exists IFF the owning spend session was durably
@@ -147,7 +171,7 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 - `000013_pending_board_request` — records the user's explicit `Board`
   RPC intent so a daemon restart between Board admission and round
   seal does not silently drop the request. Keyed by the confirmed
-  boarding outpoint.
+  boarding outpoint. Superseded by `000018_pending_intents`.
 - `000012_boarding_sweep_ledger_events` — registers the
   `boarding_sweep_fee_paid` ledger event type so `FeePaidMsg` with
   `FeeType=FeeTypeOnchainSweep` satisfies the `ledger_entries.event_type`

--- a/db/actordelivery/AGENTS.md
+++ b/db/actordelivery/AGENTS.md
@@ -30,9 +30,20 @@ other services can reuse durable actor storage without pulling unrelated tables.
   a `TxActorDeliveryStore` scoped to that transaction, and on successful commit
   fires outbox-wake callbacks when outbox messages were enqueued inside the tx.
 - `ActorDeliveryQueries` — Interface for all actor delivery SQL operations:
-  mailbox enqueue/lease/ack/nack/extend/expire, ask results, outbox
+  mailbox enqueue/lease/peek/ack/nack/extend/expire, ask results, outbox
   claim/complete/fail, deduplication, FSM checkpoints, dead letters, and
   cleanup. Implemented by the SQLC-generated query set.
+- **Leaseless single-worker consume path** — `PeekNextMailboxMessage` (a
+  READ-only claim that mirrors `LeaseNextMailboxMessage`'s eligibility and
+  ordering but takes no lease and does NOT bump attempts),
+  `AckMailboxMessageByID` (unfenced delete by id), and
+  `NackMailboxMessageByID` (unfenced release that increments attempts).
+  Exposed on both `Store` and `TxActorDeliveryStore` as `PeekNextMessage`
+  (read tx), `AckMessageByID`, and `NackMessageByID`. Used only by
+  `NumWorkers == 1` Read/Commit actors, which have no competing consumer to
+  fence; the multi-worker pool keeps lease + fenced ack. The by-ID nack
+  increments attempts because the peek does not, preserving dead-lettering
+  on max attempts.
 - `BatchedActorDeliveryQueries` — Batched transaction wrapper for
   `ActorDeliveryQueries`.
 - `MigrationOption` — Functional options for migration configuration
@@ -65,6 +76,12 @@ other services can reuse durable actor storage without pulling unrelated tables.
   goroutines.
 - `TxAwareActorDeliveryStore.ExecTx` always defers `tx.Rollback()` so partial
   writes cannot survive a function error; commit is the only success path.
+- `PeekNextMessage` is a read-only eligibility check, not an ownership write.
+  The store adapter must map every peeked row to an empty lease token before it
+  reaches the actor layer, including rows that still carry stale expired lease
+  metadata from a previous leased claim. The by-ID nack path clears that stale
+  metadata while incrementing attempts, preserving the leaseless p-model:
+  `peek -> empty-token delivery -> by-ID ack/nack`.
 
 ## Deep Docs
 

--- a/p-models/durableactor/AGENTS.md
+++ b/p-models/durableactor/AGENTS.md
@@ -3,15 +3,24 @@
 This package models the durable actor mailbox from distributed-systems first
 principles: durable enqueue, lease ownership, retry scheduling, ack/nack token
 validation, dead-letter/removal, idempotent delivery identity,
-per-correlation-key FIFO, and the Read/Commit consume step (lease-fenced
-exactly-once effect application under lease-expiry-during-IO).
+per-correlation-key FIFO, the Read/Commit consume step (lease-fenced
+exactly-once effect application under lease-expiry-during-IO), and the CDC
+outbox fold (the target enqueue and the outbox completion committing as one
+transaction, with no-lost-message and exactly-once-delivery guarantees).
 
 ## Files
 
 - `infra.pproj` — P project for durable actor infrastructure checks.
 - `src/mailbox_fifo.p` — ideal mailbox spec plus claim-ordering profiles.
+- `src/ingress_fold.p` — connection-actor ingress cursor spec: the persisted
+  PullCursor must never cover an envelope whose local enqueue did not commit
+  (the transactional dispatch fold makes batch enqueues + cursor one atomic
+  commit).
 - `test/mailbox_fifo_test.p` — green conformance tests and separate
   counterexample tests.
+- `test/ingress_fold_test.p` — green atomic-fold drain test plus the two
+  cursor-loss counterexamples (eager in-memory cursor after rollback;
+  checkpoint commit ordered before the enqueue commits).
 - `traces/*.json` — concrete scenarios replayed by the Go bridge.
 - `bridge/` — Go conformance harness against the real `db/actordelivery`
   SQLite store and claim SQL.
@@ -29,7 +38,12 @@ exactly-once effect application under lease-expiry-during-IO).
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStageCommitExactlyOnce` | Run the green Stage-then-Commit replay-safety test |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStagedDoubleBroadcastCounterexample` | Demonstrate the unstable-broadcast double-broadcast bug |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStaleStageRegressesCounterexample` | Demonstrate the unfenced-stage checkpoint regression bug |
-| `go test ./p-models/durableactor/bridge` | Replay traces against Go |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressFoldNoLoss` | Run the green transactional ingress-fold no-loss test |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressEagerCursorCounterexample` | Demonstrate the eager-cursor-after-rollback message loss |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressCheckpointFirstCounterexample` | Demonstrate the checkpoint-before-enqueue message loss |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcOutboxFold` | Run the green transactional outbox-fold test |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcOutboxSplitWriteCounterexample` | Demonstrate the split-write lost-message bug |
+| `go test ./p-models/durableactor/bridge` | Replay traces and the outbox-fold/crash-restart bridge tests against Go |
 
 ## Modeling Guidance
 

--- a/p-models/durableactor/bridge/AGENTS.md
+++ b/p-models/durableactor/bridge/AGENTS.md
@@ -23,9 +23,34 @@ than the P checker.
   sorted by `TraceID`.
 - `ReplayMailboxTrace(t, trace)` — Replays a trace against a fresh SQLite
   `actordelivery` store in a temp dir. The `commit` op models the Read/Commit
-  fenced-ack pattern exactly: it runs `AckMessage` + `MarkProcessed` inside one
-  writer transaction, rolling back with `actor.ErrLeaseLost` when the ack row
-  count is zero.
+  consume step exactly: it runs the ack + `MarkProcessed` inside one writer
+  transaction, rolling back with `actor.ErrLeaseLost` when the ack row count is
+  zero. The ack op is chosen by lease token exactly as production `ackMessage`
+  routes it: a leased commit (`lease_token` set) acks under the lease fence via
+  `AckMessage`, while a leaseless commit (empty `lease_token`, the single-worker
+  peek path) acks via `AckMessageByID`. Both halves are trace-covered
+  (`mailbox_read_commit_fenced_exactly_once` and
+  `mailbox_leaseless_commit_fold`).
+
+## Direct bridge tests (not JSON-trace driven)
+
+Some contracts span a transaction boundary or a process restart and do not fit
+the per-op JSON replay model, so they are written as direct Go tests that drive
+the real store:
+
+- `outbox_fold_test.go` — the Go analog of the `tcOutboxFold` P scenario. It
+  runs `deliverMessage`'s fold (`EnqueueMessage` + `CompleteOutbox` inside one
+  `ExecTx`) against the real store and asserts the SQL-level contract: a fold
+  that fails after the enqueue rolls back with no orphan in the target mailbox
+  and the outbox row stays pending until claim expiry; a redelivery lands
+  exactly once; and a stale-token completion is a fenced 0-row no-op while the
+  idempotent (`ON CONFLICT id`) enqueue collapses a concurrent reclaim's
+  duplicate.
+- `crash_restart_test.go` — reopens a fresh `*sql.DB` and store against the same
+  on-disk SQLite file to model a process restart. It asserts a peeked-but-unacked
+  message survives a crash with attempts unchanged (peek is read-only), and a
+  leased-but-unacked message survives with its attempt bump durable and becomes
+  re-leasable after `ExpireLeases`.
 
 ## Relationships
 
@@ -38,9 +63,12 @@ than the P checker.
 
 - Every trace op that can fail hard uses `t.Fatal`; partial replays are not
   allowed to proceed silently.
-- The `commit` op is the sole site where `ExecTx`/`AckMessage`/`MarkProcessed`
-  are combined — it deliberately mirrors `execCore.commit` in `baselib/actor`
-  so the P model's commit-fence scenario stays tied to the real SQL path.
+- The `commit` op is the sole site where `ExecTx`/ack/`MarkProcessed` are
+  combined — it deliberately mirrors `execCore.commit` in `baselib/actor`,
+  routing the ack to `AckMessage` (leased) or `AckMessageByID` (leaseless,
+  empty token) exactly as production `ackMessage` does, so the P model's
+  commit-fence scenario stays tied to the real SQL path on both the leased and
+  leaseless single-worker consume.
 - Duplicate enqueue ops (`ExpectDuplicate: true`) must complete without error;
   a future rejection would fail here explicitly rather than at a later lease
   step.

--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -35,9 +35,11 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - Exported helpers usable standalone: `BuildCPFPChild`,
   `EstimatePackageFee`, `EstimateWeight`, `SelectFeeInput`.
 - `Wallet` — interface required by the broadcaster: `ListUnspent`,
-  `NewWalletPkScript`, `FinalizePsbt`, plus `wallet.OutputLeaser`
-  (`LeaseOutput` / `ReleaseOutput`) for cross-subsystem UTXO lock
-  coordination.
+  `NewWalletPkScript`, `FinalizePsbt`, `FundPsbt` (funds, signs, and
+  finalizes a PSBT template; used by the fee-input fanout path to mint
+  right-sized fee inputs when the wallet has no confirmed fee UTXOs),
+  plus `wallet.OutputLeaser` (`LeaseOutput` / `ReleaseOutput`) for
+  cross-subsystem UTXO lock coordination.
 - `EnsureConfirmedReq` / `EnsureConfirmedResp` — public Ask API:
   register interest in a txid with `TargetConfs`, `ConfirmationPkScript`,
   and a subscriber.
@@ -55,6 +57,18 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - `Config.BroadcastFailureAlertThreshold` — consecutive no-mempool
   failures before the operator escalation fires (default 3). Time to
   first alert ≈ threshold × `FeeBumpIntervalBlocks` blocks.
+- Fee-input fanout FSM (`feeBumpStateMachine` / `feeBumpEnvironment`) —
+  internal single-instance `protofsm` that manages a fanout transaction
+  when `ErrCPFPFeeInputUnavailable` is combined with a confirmed-coin
+  shortfall (`errCPFPFeeInputShortfall`). On demand, the FSM funds and
+  broadcasts a wallet-level fanout transaction that mints right-sized
+  fee inputs, then promotes them once confirmed. At most one fanout is
+  ever in flight. The actor drives it via `driveFeeBump` and applies
+  its outbox effects (register/unregister chainsource conf watches,
+  retry stuck broadcasting parents). The FSM does its own wallet and
+  broadcast IO inside transitions (safe because the actor serializes
+  all events); `feeBumpEnvironment.lastErr` captures per-turn IO errors
+  rather than returning them (which would tear the long-lived FSM down).
 
 ## Relationships
 
@@ -85,9 +99,12 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
   covers `ErrCPFPFeeInputUnavailable` and transient package-relay
   rejections (min-relay-fee on the zero-fee anchor parent, mempool-full,
   fee input spent mid-submit) — the conditions CPFP retry exists to
-  overcome. Only a structurally permanent error
-  (`isPermanentBroadcastError`, currently `ErrNonTRUCParent`) fails
-  terminally; `ErrParentAlreadyBroadcast` advances to
+  overcome. When `ErrCPFPFeeInputUnavailable` is paired with a confirmed-
+  coin shortfall, `maybeEnsureFeeInputSupply` kicks off the fee-input
+  fanout FSM to provision fresh fee inputs; the retry loop continues
+  uninterrupted while the fanout awaits confirmation. Only a structurally
+  permanent error (`isPermanentBroadcastError`, currently `ErrNonTRUCParent`)
+  fails terminally; `ErrParentAlreadyBroadcast` advances to
   `AwaitingConfirmation` (a live parent exists on another path). Rationale:
   a fraud-response checkpoint must land before the counterparty's
   CSV-timeout path, so the actor escalates to operators rather than

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -35,9 +35,11 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - Exported helpers usable standalone: `BuildCPFPChild`,
   `EstimatePackageFee`, `EstimateWeight`, `SelectFeeInput`.
 - `Wallet` — interface required by the broadcaster: `ListUnspent`,
-  `NewWalletPkScript`, `FinalizePsbt`, plus `wallet.OutputLeaser`
-  (`LeaseOutput` / `ReleaseOutput`) for cross-subsystem UTXO lock
-  coordination.
+  `NewWalletPkScript`, `FinalizePsbt`, `FundPsbt` (funds, signs, and
+  finalizes a PSBT template; used by the fee-input fanout path to mint
+  right-sized fee inputs when the wallet has no confirmed fee UTXOs),
+  plus `wallet.OutputLeaser` (`LeaseOutput` / `ReleaseOutput`) for
+  cross-subsystem UTXO lock coordination.
 - `EnsureConfirmedReq` / `EnsureConfirmedResp` — public Ask API:
   register interest in a txid with `TargetConfs`, `ConfirmationPkScript`,
   and a subscriber.
@@ -55,6 +57,18 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - `Config.BroadcastFailureAlertThreshold` — consecutive no-mempool
   failures before the operator escalation fires (default 3). Time to
   first alert ≈ threshold × `FeeBumpIntervalBlocks` blocks.
+- Fee-input fanout FSM (`feeBumpStateMachine` / `feeBumpEnvironment`) —
+  internal single-instance `protofsm` that manages a fanout transaction
+  when `ErrCPFPFeeInputUnavailable` is combined with a confirmed-coin
+  shortfall (`errCPFPFeeInputShortfall`). On demand, the FSM funds and
+  broadcasts a wallet-level fanout transaction that mints right-sized
+  fee inputs, then promotes them once confirmed. At most one fanout is
+  ever in flight. The actor drives it via `driveFeeBump` and applies
+  its outbox effects (register/unregister chainsource conf watches,
+  retry stuck broadcasting parents). The FSM does its own wallet and
+  broadcast IO inside transitions (safe because the actor serializes
+  all events); `feeBumpEnvironment.lastErr` captures per-turn IO errors
+  rather than returning them (which would tear the long-lived FSM down).
 
 ## Relationships
 
@@ -85,9 +99,12 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
   covers `ErrCPFPFeeInputUnavailable` and transient package-relay
   rejections (min-relay-fee on the zero-fee anchor parent, mempool-full,
   fee input spent mid-submit) — the conditions CPFP retry exists to
-  overcome. Only a structurally permanent error
-  (`isPermanentBroadcastError`, currently `ErrNonTRUCParent`) fails
-  terminally; `ErrParentAlreadyBroadcast` advances to
+  overcome. When `ErrCPFPFeeInputUnavailable` is paired with a confirmed-
+  coin shortfall, `maybeEnsureFeeInputSupply` kicks off the fee-input
+  fanout FSM to provision fresh fee inputs; the retry loop continues
+  uninterrupted while the fanout awaits confirmation. Only a structurally
+  permanent error (`isPermanentBroadcastError`, currently `ErrNonTRUCParent`)
+  fails terminally; `ErrParentAlreadyBroadcast` advances to
   `AwaitingConfirmation` (a live parent exists on another path). Rationale:
   a fraud-response checkpoint must land before the counterparty's
   CSV-timeout path, so the actor escalates to operators rather than

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -17,7 +17,12 @@ refresh, leave, OOR spend, and directed send flows.
 - `OutputLeaser` — Interface for UTXO output leasing: `LeaseOutput(ctx, outpoint, lockID, expiry)` and `ReleaseOutput(ctx, outpoint, lockID)`. Implemented by all three `BoardingBackend` implementations (`btcwbackend`, `lndbackend`, `lwwallet`) to coordinate cross-subsystem UTXO reservation.
 - `BoardingBackend` — Interface for wallet integration (key derivation, taproot import, ListUnspent). `GetTransaction` returns `*TxInfo` (containing tx, block hash, and block height).
 - `TxInfo` — Struct wrapping a confirmed transaction with its block hash and block height. Returned by `BoardingBackend.GetTransaction`.
-- `BoardingStore` — Interface for persisting boarding addresses and intents.
+- `BoardingStore` — Interface for persisting boarding addresses and intents. Embeds `PendingIntentStore`.
+- `PendingIntent` / `PendingIntentKind` / `PendingIntentID` / `PendingIntentPayload` / `PendingIntentStore` — the generic restart-safe intent outbox (`pending_intent.go`). `Payload` is a sealed `PendingIntentPayload` interface holding the concrete kind-specific struct (not bytes); the db layer stores its fields as typed columns. An intent is persisted BEFORE its round-actor publish, anchored to the outpoints the round consumes on adoption (confirmed boarding outpoints for `board`, reserved forfeit outpoints for `send_onchain`); the round checkpoint clears anchors transactionally. `NewPendingIntentID(payload, anchors)` derives the idempotency key as `sha256(kind ‖ sorted anchors ‖ payload-canonical-digest)`.
+- `PendingIntentReplayer` — per-kind replay strategy registered on the `Ark` actor (`intentReplayers`). `boardIntentReplayer` reconciles anchors against still-Confirmed boarding intents and self-Tells one `BoardRequest`; `sendOnChainIntentReplayer` self-Tells one `ReplaySendOnChainIntent` per persisted intent, whose handler re-reserves the EXACT anchors (never re-running selection), rebuilds the package via `buildSendOnChainIntentPackage`, and registers with `TriggerRegistration=true`. A reservation failure marks a send intent stale and deletes it.
+- `BoardIntentPayload` / `SendOnChainIntentPayload` — concrete `PendingIntentPayload` implementations (`pending_intent.go`); each contributes a deterministic `writeIDDigest` field encoding (for the intent ID only) and is stored as typed columns by the db layer.
+- `ReplayPendingIntentsRequest` / `ReplayPendingIntentsResponse` — daemon startup Ask that walks the replayer registry once every dependent actor is on the receptionist (replaces the Board-only `ReplayPendingBoardRequest`).
+- `ReplaySendOnChainIntent` — internal self-Tell carrying one persisted send intent from the replay pass into the wallet mailbox.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
 - `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
@@ -38,6 +43,11 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendOnChainStatus` — Terminal outcome enum: `SendOnChainStatusSubmitted` (intent queued for next round), `SendOnChainStatusDryRun` (dry-run preview, no commitment).
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
 - `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
+- `WalletBackingSweeper` — Interface for the general backing-wallet sweep backend: lists confirmed UTXOs, leases selected inputs, signs and finalizes the aggregate sweep PSBT. Satisfied by the same per-backend adapter wired as the boarding-sweep signer.
+- `SweepWalletFundsRequest` / `SweepWalletFundsResponse` — Ask-request to preview (and optionally broadcast) a general sweep of all confirmed backing-wallet UTXOs to a single destination address. `DestinationAddress`, optional `FeeRateSatPerVByte` (capped at the actor's configured max), optional `ConfTarget` (falls back to default). Response carries `Inputs`, `TotalAmountSat`, `FeeAmountSat`, `NetAmountSat`, `CanBroadcast`, and `Txid` (populated on successful broadcast). `FailureReason` is set (and the actor response itself succeeds) for application-level failures so the RPC sees them as domain errors rather than transport errors.
+- `WalletSweepInputInfo` — Per-UTXO sweep detail: `Outpoint`, `PkScript`, `AmountSat`.
+- `WalletSweepTxNotification` — Tell carrying a txconfirm terminal notification (`TxConfirmed` or `TxFailed`) for a general wallet sweep tx, re-wrapped via `txconfirm.MapNotification`.
+- `WithWalletSweep(sweeper, maxFeeRate)` — Option to wire the `WalletBackingSweeper` into the actor; when omitted `SweepWalletFundsRequest` returns a clear "subsystem not initialised" error.
 
 ## Relationships
 
@@ -56,7 +66,8 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `SendOnChainRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `SendOnChainRequest`, `SweepWalletFundsRequest`
+  - ← `txconfirm` (Tell): `WalletSweepTxNotification` (terminal outcome for a submitted general wallet sweep tx)
 
 ## Invariants
 
@@ -64,6 +75,7 @@ refresh, leave, OOR spend, and directed send flows.
 - `ListUnspent` runs at most once per tip-tick against the latest known chain tip; a backend whose UTXO reporting lags past one tick interval surfaces the missing UTXO on the next chain advance (whichever tick processes the new tip re-runs the scan). The per-block path no longer carries an inline retry budget — the tick loop is the retry seam.
 - Notifier registration captures `minConf` parameter per actor; different actors can require different confirmation depths.
 - Cooperative admission (refresh/leave) must reserve forfeit inputs through the VTXO manager before sending `RegisterIntentMsg` to the round actor.
+- Persist-before-publish: `handleBoard` and `handleSendOnChain` write their pending intent to the outbox BEFORE the round-actor publish, so every crash window either leaves no row (clean retry) or a replayable row. `handleSendOnChain` deletes the row when registration fails synchronously — the caller saw an error, so the send must not silently resurrect on the next start.
 - `WithEagerRoundJoin(true)` opts the wallet into "drive round-joining without a second RPC" semantics. Two sites change: `handleBlockEpoch` inline-calls `handleBoard` after at least one new boarding UTXO confirms in the block (one `TriggerBoardMsg` per block, not per UTXO), and `handleLeaveVTXOs` forwards its `RegisterIntentMsg` with `TriggerRegistration=true` so the leave moves the round FSM out of `PendingRoundAssembly` immediately. Default off preserves the operator-driven batched semantics that `darepocli` and server hosts rely on; `sdk/walletdk` flips it on via `darepod.Config.EagerRoundJoin` for wallet-shaped SDK hosts.
 - If round registration fails after successful admission, the wallet releases the forfeit reservation so VTXOs return to LiveState.
 - Directed sends use `SelectAndReserveForfeitRequest` (cooperative forfeit path) rather than the OOR spend path. The wallet builds recipient VTXOs with the recipient's key as `OwnerKey` and derives a separate ephemeral `SigningKey` for MuSig2 tree construction.

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -43,6 +43,11 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendOnChainStatus` — Terminal outcome enum: `SendOnChainStatusSubmitted` (intent queued for next round), `SendOnChainStatusDryRun` (dry-run preview, no commitment).
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
 - `VTXODescriptor.EffectivePolicyTemplate` — Decodes the serialized `PolicyTemplate` field on the wallet-level VTXO descriptor using `lib/arkscript`.
+- `WalletBackingSweeper` — Interface for the general backing-wallet sweep backend: lists confirmed UTXOs, leases selected inputs, signs and finalizes the aggregate sweep PSBT. Satisfied by the same per-backend adapter wired as the boarding-sweep signer.
+- `SweepWalletFundsRequest` / `SweepWalletFundsResponse` — Ask-request to preview (and optionally broadcast) a general sweep of all confirmed backing-wallet UTXOs to a single destination address. `DestinationAddress`, optional `FeeRateSatPerVByte` (capped at the actor's configured max), optional `ConfTarget` (falls back to default). Response carries `Inputs`, `TotalAmountSat`, `FeeAmountSat`, `NetAmountSat`, `CanBroadcast`, and `Txid` (populated on successful broadcast). `FailureReason` is set (and the actor response itself succeeds) for application-level failures so the RPC sees them as domain errors rather than transport errors.
+- `WalletSweepInputInfo` — Per-UTXO sweep detail: `Outpoint`, `PkScript`, `AmountSat`.
+- `WalletSweepTxNotification` — Tell carrying a txconfirm terminal notification (`TxConfirmed` or `TxFailed`) for a general wallet sweep tx, re-wrapped via `txconfirm.MapNotification`.
+- `WithWalletSweep(sweeper, maxFeeRate)` — Option to wire the `WalletBackingSweeper` into the actor; when omitted `SweepWalletFundsRequest` returns a clear "subsystem not initialised" error.
 
 ## Relationships
 
@@ -61,7 +66,8 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `SendOnChainRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `SendOnChainRequest`, `SweepWalletFundsRequest`
+  - ← `txconfirm` (Tell): `WalletSweepTxNotification` (terminal outcome for a submitted general wallet sweep tx)
 
 ## Invariants
 


### PR DESCRIPTION
Automated nightly doc-gardening sweep for 2026-06-21.

## Changes

- **coinselect** (new): CLAUDE.md + AGENTS.md for the new coin-type-agnostic
  coin-selection package introduced since the last sweep.
- **txconfirm** (updated): Documents the new `Wallet.FundPsbt` interface method
  and the fee-input fanout FSM (`feeBumpStateMachine` / `feeBumpEnvironment`)
  that provisions fresh fee inputs when `ErrCPFPFeeInputUnavailable` + confirmed
  coin shortfall occurs during CPFP child construction. Also clarifies how
  `maybeEnsureFeeInputSupply` ties into the "never give up" invariant.
- **wallet** (updated): Documents `SweepWalletFundsRequest` / `SweepWalletFundsResponse`,
  `WalletBackingSweeper`, `WalletSweepTxNotification`, `WalletSweepInputInfo`,
  and the `WithWalletSweep` option added for the exit-plan / general wallet sweep
  feature (PRs #697, #763).
- **ARCHITECTURE.md**: Added `coinselect` to the Layer 1 domain table.
- **AGENTS.md sync**: Synced pre-existing divergences in `baselib/actor`,
  `db`, `db/actordelivery`, `p-models/durableactor`, and
  `p-models/durableactor/bridge`.

## Review checklist

- [ ] Review updated `txconfirm/CLAUDE.md` and `txconfirm/AGENTS.md` diffs.
- [ ] Review updated `wallet/CLAUDE.md` and `wallet/AGENTS.md` diffs.
- [ ] Review new `coinselect/CLAUDE.md` and `coinselect/AGENTS.md`.
- [ ] Review ARCHITECTURE.md addition.

`make doc-check` passes on this branch.