### PR TITLE
docs: nightly doc-gardening sweep 2026-06-22

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,6 +26,7 @@ package may import from a higher layer.
 | [`lib/tx/oor`](lib/tx/oor/) | OOR submit/finalize package builders and validators |
 | [`lib/tx/psbtutil`](lib/tx/psbtutil/) | PSBT encoding, decoding, and signature attachment helpers |
 | [`lib/recovery`](lib/recovery/) | Immutable recovery proof graph, session state machine, TLV codec for unilateral exit |
+| [`coinselect`](coinselect/) | Coin-type-agnostic largest-first coin selection shared across VTXO reservation and onchain send preview paths |
 | [`unrollplan`](unrollplan/) | Pure dependency-resolution planner driving unilateral-exit broadcast/sweep ordering |
 | [`vhtlcrecovery`](vhtlcrecovery/) | Durable control-plane types for vHTLC on-chain recovery jobs (action, state, script parameters, swap linkage) |
 

--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -26,7 +26,7 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `Receptionist` — Service locator mapping `ServiceKey` → `ActorRef` for decoupled actor wiring.
 - `Message` — Sealed interface for all actor messages (must embed `BaseMessage`).
 - `MessageCodec` — TLV-based codec for message serialization/deserialization.
-- `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter).
+- `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter). The leaseless single-worker fast path adds `PeekNextMessage` (read-only claim, no lease, no attempts bump; yields an empty lease token), `AckMessageByID` (unfenced delete), and `NackMessageByID` (unfenced release that increments attempts). A `DurableActor` enables it (via `DurableMailboxConfig.SingleWorkerLeaseless`) strictly when `NumWorkers == 1` AND the behavior is the Read/Commit (Right/`TxBehavior`) path, eliminating the per-message lease write transaction. The multi-worker pool and the classic path are byte-for-byte unchanged: they keep `LeaseNextMessage` and the lease-fenced ack. Ack/nack route to the by-ID ops automatically whenever the delivery's lease token is empty; `Delivery.ShouldDeadLetter` counts the in-flight attempt as `Attempts + 1` on the leaseless path so the dead-letter boundary matches the leased path (where attempts is pre-incremented at lease).
 - `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence. Provides `Wait(ctx)` to block until the actor stops and `StopAndWait(ctx)` to request a graceful shutdown and then wait.
 - `DurableActorConfig[M, R]` — Configuration struct for `DurableActor`: behavior, store, codec, clock, DLO, WaitGroup, `TellRetryPolicy`, lease/heartbeat/poll durations, max attempts, cleanup timeout, deduplication TTL, and `NumWorkers`.
 - `DurableActorConfig.NumWorkers` — How many concurrent worker loops drain the actor's single mailbox. Default and any value `<= 1` is one worker (strictly-sequential processing). A value `> 1` turns the actor into a competing-consumer pool: that many goroutines each lease distinct messages via `LeaseNextMailboxMessage`, so independent messages run in parallel while per-correlation-key FIFO still keeps same-key messages ordered. Only for behaviors whose handlers are concurrency-safe and hold no writer across their side effects (e.g. the serverconn egress sender on the Read/Commit path). `NewDurableActor` **fails closed** with `ErrConcurrentClassicBehavior` when `NumWorkers > 1` is paired with a classic (`Left`) `ActorBehavior`, since the classic path wraps the whole `Receive` in one write transaction and assumes sequential delivery; pools are only valid on the Read/Commit (`TxBehavior`) path. The test-only `DurableActorConfig.AllowConcurrentClassicBehavior()` escape hatch bypasses the guard for the egress benchmark that measures the forbidden config; production code must never call it.
@@ -81,8 +81,24 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 ## Invariants
 
 - Messages are processed sequentially per actor by default (one worker, no concurrent `Receive` calls). Opting into `DurableActorConfig.NumWorkers > 1` relaxes this: that many worker loops drain the one mailbox concurrently, so `Receive` may run in parallel across distinct messages. The competing-consumer lease guarantees each message is still processed by exactly one worker, and per-correlation-key FIFO holds across workers; only behaviors with concurrency-safe handlers should set it. The combination is structurally restricted to the Read/Commit path: `NewDurableActor` rejects `NumWorkers > 1` on a classic `ActorBehavior` with `ErrConcurrentClassicBehavior` so a stateful, sequentially-assumed actor can never be silently fanned out.
+- **Leaseless consume ownership model.** `SingleWorkerLeaseless` removes the
+  lease-token fence, so its safety argument is "one live runtime owner for this
+  mailbox", not merely "one goroutine in this process". Do not enable it for a
+  mailbox that can be drained by another daemon/process at the same time unless
+  an external singleton/ownership fence already exists. A peeked delivery always
+  carries an empty lease token, even when the persisted row still has stale
+  expired lease metadata from an older leased claim; that empty token is the
+  p-model edge that routes ack/nack to the by-ID operations. Retry-policy
+  decisions must use `Delivery.EffectiveAttempts()` so the in-flight peeked
+  attempt is counted before a nack can raise the row to `max_attempts`.
 - `Tell` with a `DurableActor` persists the message before returning (crash-safe enqueue).
 - Outbox messages are dispatched only after state is persisted (outbox pattern).
+- **Outbox fold p-model.** For tx-aware stores, outbox delivery is
+  `claim -> (target mailbox enqueue + CompleteOutbox) in one write tx`. If the
+  transaction fails before commit, both the enqueue and completion roll back and
+  the claim expiry is the retry mechanism; the publisher must log the
+  transaction failure even when the inner Tell/Complete operations returned nil,
+  because begin/commit failures happen outside those operation-level logs.
 - `ServiceKey` lookup via `Receptionist` is type-safe: mismatched types return `ErrServiceKeyTypeMismatch`.
 - `RestartMessage` has `RestartPriority` (MaxInt32) ensuring it is processed before all other messages on recovery.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.

--- a/coinselect/AGENTS.md
+++ b/coinselect/AGENTS.md
@@ -1,0 +1,51 @@
+# coinselect
+
+## Purpose
+
+Coin-type-agnostic, largest-first coin selection algorithm shared across the
+client. Deliberately holds no wallet, actor, or RPC dependencies so it can be
+reused by any subsystem that needs to pick a subset of fungible inputs to cover
+a target amount.
+
+## Key Types
+
+- `Request` — Selection parameters: `Target` (required amount), `MinChange`
+  (dust-change floor; zero disables), `SweepAll` (select every candidate,
+  ignoring `Target` and `MinChange`).
+- `Result[T]` — Selection outcome: `Selected` slice, `Total` sum, and `Change`
+  (zero for sweep-all).
+- `AmountFunc[T]` — Caller-supplied extractor that maps a candidate `T` to its
+  `btcutil.Amount`; keeps the algorithm generic over concrete VTXO types, RPC
+  types, boarding intents, etc.
+- `LargestFirst[T]` — The single exported selection function. Sorts a copy of
+  candidates by descending amount (never mutates the caller's slice), then
+  accumulates until `Target` is covered. Respects `MinChange` by continuing
+  accumulation when the candidate after exact-fit would produce dust change;
+  exact-fit selections (zero change) are always accepted regardless of
+  `MinChange`.
+
+## Relationships
+
+- **Depends on**: `github.com/btcsuite/btcd/btcutil` only — no internal
+  repo imports.
+- **Depended on by**: `vtxo` (VTXO manager reservation paths),
+  `swapwallet` (onchain send previews).
+- **Sends**: nothing — pure function, no actor messaging.
+- **Receives**: nothing — pure function, no actor messaging.
+
+## Invariants
+
+- **Non-mutating**: `LargestFirst` sorts a copy of the input slice; callers'
+  candidate ordering is preserved.
+- **Exact-fit bypass**: a selection whose `Change` would be zero is accepted
+  even when `MinChange > 0`, preventing the algorithm from over-selecting just
+  to avoid a dust floor that doesn't apply.
+- **Error taxonomy**: `ErrSelectionShortfall` (insufficient total),
+  `ErrChangeBelowMin` (dust change after best selection), `ErrNoCandidates`
+  (empty input), `ErrInvalidTarget` (non-positive target on bounded runs).
+  Callers distinguish locked-UTXO shortfall from true balance shortfall using
+  these sentinels.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/coinselect/CLAUDE.md
+++ b/coinselect/CLAUDE.md
@@ -1,0 +1,51 @@
+# coinselect
+
+## Purpose
+
+Coin-type-agnostic, largest-first coin selection algorithm shared across the
+client. Deliberately holds no wallet, actor, or RPC dependencies so it can be
+reused by any subsystem that needs to pick a subset of fungible inputs to cover
+a target amount.
+
+## Key Types
+
+- `Request` — Selection parameters: `Target` (required amount), `MinChange`
+  (dust-change floor; zero disables), `SweepAll` (select every candidate,
+  ignoring `Target` and `MinChange`).
+- `Result[T]` — Selection outcome: `Selected` slice, `Total` sum, and `Change`
+  (zero for sweep-all).
+- `AmountFunc[T]` — Caller-supplied extractor that maps a candidate `T` to its
+  `btcutil.Amount`; keeps the algorithm generic over concrete VTXO types, RPC
+  types, boarding intents, etc.
+- `LargestFirst[T]` — The single exported selection function. Sorts a copy of
+  candidates by descending amount (never mutates the caller's slice), then
+  accumulates until `Target` is covered. Respects `MinChange` by continuing
+  accumulation when the candidate after exact-fit would produce dust change;
+  exact-fit selections (zero change) are always accepted regardless of
+  `MinChange`.
+
+## Relationships
+
+- **Depends on**: `github.com/btcsuite/btcd/btcutil` only — no internal
+  repo imports.
+- **Depended on by**: `vtxo` (VTXO manager reservation paths),
+  `swapwallet` (onchain send previews).
+- **Sends**: nothing — pure function, no actor messaging.
+- **Receives**: nothing — pure function, no actor messaging.
+
+## Invariants
+
+- **Non-mutating**: `LargestFirst` sorts a copy of the input slice; callers'
+  candidate ordering is preserved.
+- **Exact-fit bypass**: a selection whose `Change` would be zero is accepted
+  even when `MinChange > 0`, preventing the algorithm from over-selecting just
+  to avoid a dust floor that doesn't apply.
+- **Error taxonomy**: `ErrSelectionShortfall` (insufficient total),
+  `ErrChangeBelowMin` (dust change after best selection), `ErrNoCandidates`
+  (empty input), `ErrInvalidTarget` (non-positive target on bounded runs).
+  Callers distinguish locked-UTXO shortfall from true balance shortfall using
+  these sentinels.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -71,7 +71,22 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   safety bounds enforced during `DeserializeTree`.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — two-stage
   OOR ancestry resolver (`oor_unroll_resolver.go`).
-- `LatestMigrationVersion = 17` — current schema version.
+- `LatestMigrationVersion = 19` — current schema version.
+- `PendingIntentPersistenceStore` — implements `wallet.PendingIntentStore`,
+  the persistence half of the generic restart-safe intent outbox (header
+  `pending_intents` + per-kind detail tables + `pending_intent_anchors`).
+  Maps the sealed `wallet.PendingIntentPayload` concrete types to/from typed
+  detail columns (no blob). Intents are written before the wallet publishes
+  them to the round actor; `CommitState` clears anchors by outpoint
+  (boarding outpoints AND forfeited VTXO outpoints) inside the
+  point-of-no-return round checkpoint transaction, then sweeps orphaned
+  detail rows and headers, so replay-after-adoption is structurally
+  impossible. Methods: `UpsertPendingIntent` (header + detail + anchors
+  atomically; anchor rebind sweeps anchor-less older intents),
+  `ListPendingIntents` (per kind, with anchors), `DeletePendingIntent`,
+  `ClearPendingIntentsByKind`.
+- `PendingIntentStore` / `BatchedPendingIntentStore` — internal sqlc-backed
+  query interfaces for the pending-intent tables.
 - `SpendingReservationPersistenceStore` — Persists the durable index of VTXO
   outpoints reserved by an active spend owner (e.g. an outgoing OOR session).
   A row exists IFF the owning session was durably checkpointed, so a startup
@@ -125,6 +140,15 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 
 ### Migration notes
 
+- `000018_pending_intents` — generalizes the Board-only
+  `pending_board_requests` outbox into a supertype/subtype set:
+  `pending_intent_kinds` (enum table), `pending_intents` (header: 32-byte
+  hash-derived intent id + kind FK + requested_at, no payload blob),
+  per-kind detail tables `pending_board_intents` / `pending_send_intents`
+  with first-class typed columns, and `pending_intent_anchors` (one row per
+  anchored outpoint, PK on the outpoint so a newer intent rebinds, FK to the
+  header). Drops `pending_board_requests` outright (alpha; rows only exist
+  in the narrow crash window between admission and round seal).
 - `000017_spending_reservations` — adds `spending_reservations` table with
   `(outpoint_hash, outpoint_index)` PK, `owner_kind`, `owner_id`, and
   `created_at`. A row exists IFF the owning spend session was durably
@@ -147,7 +171,7 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 - `000013_pending_board_request` — records the user's explicit `Board`
   RPC intent so a daemon restart between Board admission and round
   seal does not silently drop the request. Keyed by the confirmed
-  boarding outpoint.
+  boarding outpoint. Superseded by `000018_pending_intents`.
 - `000012_boarding_sweep_ledger_events` — registers the
   `boarding_sweep_fee_paid` ledger event type so `FeePaidMsg` with
   `FeeType=FeeTypeOnchainSweep` satisfies the `ledger_entries.event_type`

--- a/db/actordelivery/AGENTS.md
+++ b/db/actordelivery/AGENTS.md
@@ -30,9 +30,20 @@ other services can reuse durable actor storage without pulling unrelated tables.
   a `TxActorDeliveryStore` scoped to that transaction, and on successful commit
   fires outbox-wake callbacks when outbox messages were enqueued inside the tx.
 - `ActorDeliveryQueries` — Interface for all actor delivery SQL operations:
-  mailbox enqueue/lease/ack/nack/extend/expire, ask results, outbox
+  mailbox enqueue/lease/peek/ack/nack/extend/expire, ask results, outbox
   claim/complete/fail, deduplication, FSM checkpoints, dead letters, and
   cleanup. Implemented by the SQLC-generated query set.
+- **Leaseless single-worker consume path** — `PeekNextMailboxMessage` (a
+  READ-only claim that mirrors `LeaseNextMailboxMessage`'s eligibility and
+  ordering but takes no lease and does NOT bump attempts),
+  `AckMailboxMessageByID` (unfenced delete by id), and
+  `NackMailboxMessageByID` (unfenced release that increments attempts).
+  Exposed on both `Store` and `TxActorDeliveryStore` as `PeekNextMessage`
+  (read tx), `AckMessageByID`, and `NackMessageByID`. Used only by
+  `NumWorkers == 1` Read/Commit actors, which have no competing consumer to
+  fence; the multi-worker pool keeps lease + fenced ack. The by-ID nack
+  increments attempts because the peek does not, preserving dead-lettering
+  on max attempts.
 - `BatchedActorDeliveryQueries` — Batched transaction wrapper for
   `ActorDeliveryQueries`.
 - `MigrationOption` — Functional options for migration configuration
@@ -65,6 +76,12 @@ other services can reuse durable actor storage without pulling unrelated tables.
   goroutines.
 - `TxAwareActorDeliveryStore.ExecTx` always defers `tx.Rollback()` so partial
   writes cannot survive a function error; commit is the only success path.
+- `PeekNextMessage` is a read-only eligibility check, not an ownership write.
+  The store adapter must map every peeked row to an empty lease token before it
+  reaches the actor layer, including rows that still carry stale expired lease
+  metadata from a previous leased claim. The by-ID nack path clears that stale
+  metadata while incrementing attempts, preserving the leaseless p-model:
+  `peek -> empty-token delivery -> by-ID ack/nack`.
 
 ## Deep Docs
 

--- a/p-models/durableactor/AGENTS.md
+++ b/p-models/durableactor/AGENTS.md
@@ -3,15 +3,24 @@
 This package models the durable actor mailbox from distributed-systems first
 principles: durable enqueue, lease ownership, retry scheduling, ack/nack token
 validation, dead-letter/removal, idempotent delivery identity,
-per-correlation-key FIFO, and the Read/Commit consume step (lease-fenced
-exactly-once effect application under lease-expiry-during-IO).
+per-correlation-key FIFO, the Read/Commit consume step (lease-fenced
+exactly-once effect application under lease-expiry-during-IO), and the CDC
+outbox fold (the target enqueue and the outbox completion committing as one
+transaction, with no-lost-message and exactly-once-delivery guarantees).
 
 ## Files
 
 - `infra.pproj` — P project for durable actor infrastructure checks.
 - `src/mailbox_fifo.p` — ideal mailbox spec plus claim-ordering profiles.
+- `src/ingress_fold.p` — connection-actor ingress cursor spec: the persisted
+  PullCursor must never cover an envelope whose local enqueue did not commit
+  (the transactional dispatch fold makes batch enqueues + cursor one atomic
+  commit).
 - `test/mailbox_fifo_test.p` — green conformance tests and separate
   counterexample tests.
+- `test/ingress_fold_test.p` — green atomic-fold drain test plus the two
+  cursor-loss counterexamples (eager in-memory cursor after rollback;
+  checkpoint commit ordered before the enqueue commits).
 - `traces/*.json` — concrete scenarios replayed by the Go bridge.
 - `bridge/` — Go conformance harness against the real `db/actordelivery`
   SQLite store and claim SQL.
@@ -29,7 +38,12 @@ exactly-once effect application under lease-expiry-during-IO).
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStageCommitExactlyOnce` | Run the green Stage-then-Commit replay-safety test |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStagedDoubleBroadcastCounterexample` | Demonstrate the unstable-broadcast double-broadcast bug |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStaleStageRegressesCounterexample` | Demonstrate the unfenced-stage checkpoint regression bug |
-| `go test ./p-models/durableactor/bridge` | Replay traces against Go |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressFoldNoLoss` | Run the green transactional ingress-fold no-loss test |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressEagerCursorCounterexample` | Demonstrate the eager-cursor-after-rollback message loss |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressCheckpointFirstCounterexample` | Demonstrate the checkpoint-before-enqueue message loss |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcOutboxFold` | Run the green transactional outbox-fold test |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcOutboxSplitWriteCounterexample` | Demonstrate the split-write lost-message bug |
+| `go test ./p-models/durableactor/bridge` | Replay traces and the outbox-fold/crash-restart bridge tests against Go |
 
 ## Modeling Guidance
 

--- a/p-models/durableactor/bridge/AGENTS.md
+++ b/p-models/durableactor/bridge/AGENTS.md
@@ -23,9 +23,34 @@ than the P checker.
   sorted by `TraceID`.
 - `ReplayMailboxTrace(t, trace)` — Replays a trace against a fresh SQLite
   `actordelivery` store in a temp dir. The `commit` op models the Read/Commit
-  fenced-ack pattern exactly: it runs `AckMessage` + `MarkProcessed` inside one
-  writer transaction, rolling back with `actor.ErrLeaseLost` when the ack row
-  count is zero.
+  consume step exactly: it runs the ack + `MarkProcessed` inside one writer
+  transaction, rolling back with `actor.ErrLeaseLost` when the ack row count is
+  zero. The ack op is chosen by lease token exactly as production `ackMessage`
+  routes it: a leased commit (`lease_token` set) acks under the lease fence via
+  `AckMessage`, while a leaseless commit (empty `lease_token`, the single-worker
+  peek path) acks via `AckMessageByID`. Both halves are trace-covered
+  (`mailbox_read_commit_fenced_exactly_once` and
+  `mailbox_leaseless_commit_fold`).
+
+## Direct bridge tests (not JSON-trace driven)
+
+Some contracts span a transaction boundary or a process restart and do not fit
+the per-op JSON replay model, so they are written as direct Go tests that drive
+the real store:
+
+- `outbox_fold_test.go` — the Go analog of the `tcOutboxFold` P scenario. It
+  runs `deliverMessage`'s fold (`EnqueueMessage` + `CompleteOutbox` inside one
+  `ExecTx`) against the real store and asserts the SQL-level contract: a fold
+  that fails after the enqueue rolls back with no orphan in the target mailbox
+  and the outbox row stays pending until claim expiry; a redelivery lands
+  exactly once; and a stale-token completion is a fenced 0-row no-op while the
+  idempotent (`ON CONFLICT id`) enqueue collapses a concurrent reclaim's
+  duplicate.
+- `crash_restart_test.go` — reopens a fresh `*sql.DB` and store against the same
+  on-disk SQLite file to model a process restart. It asserts a peeked-but-unacked
+  message survives a crash with attempts unchanged (peek is read-only), and a
+  leased-but-unacked message survives with its attempt bump durable and becomes
+  re-leasable after `ExpireLeases`.
 
 ## Relationships
 
@@ -38,9 +63,12 @@ than the P checker.
 
 - Every trace op that can fail hard uses `t.Fatal`; partial replays are not
   allowed to proceed silently.
-- The `commit` op is the sole site where `ExecTx`/`AckMessage`/`MarkProcessed`
-  are combined — it deliberately mirrors `execCore.commit` in `baselib/actor`
-  so the P model's commit-fence scenario stays tied to the real SQL path.
+- The `commit` op is the sole site where `ExecTx`/ack/`MarkProcessed` are
+  combined — it deliberately mirrors `execCore.commit` in `baselib/actor`,
+  routing the ack to `AckMessage` (leased) or `AckMessageByID` (leaseless,
+  empty token) exactly as production `ackMessage` does, so the P model's
+  commit-fence scenario stays tied to the real SQL path on both the leased and
+  leaseless single-worker consume.
 - Duplicate enqueue ops (`ExpectDuplicate: true`) must complete without error;
   a future rejection would fail here explicitly rather than at a later lease
   step.

--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -35,9 +35,21 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - Exported helpers usable standalone: `BuildCPFPChild`,
   `EstimatePackageFee`, `EstimateWeight`, `SelectFeeInput`.
 - `Wallet` — interface required by the broadcaster: `ListUnspent`,
-  `NewWalletPkScript`, `FinalizePsbt`, plus `wallet.OutputLeaser`
+  `NewWalletPkScript`, `FinalizePsbt`, `FundPsbt` (used by the fanout FSM to
+  fund and sign fanout transactions), plus `wallet.OutputLeaser`
   (`LeaseOutput` / `ReleaseOutput`) for cross-subsystem UTXO lock
   coordination.
+- `feeBumpStateMachine` / `feeBumpEnvironment` — internal FSM that manages the
+  fee-input fanout lifecycle. Two states: `feeBumpStateIdle` (no fanout in
+  flight) and `feeBumpStateFanoutPending` (fanout broadcast, awaiting
+  confirmation). Owned as a field of `TxBroadcasterActor`; driven by
+  `maybeEnsureFeeInputSupply` whenever a CPFP broadcast fails with
+  `errCPFPFeeInputShortfall`.
+- `pendingFeeInputFanout` / `feeInputDemand` — internal types tracking an
+  in-flight fanout transaction and the per-parent demands it satisfies.
+- `PredictedFeeInputs` (`map[wire.OutPoint]*FeeInput`) — field on
+  `parentBumpState`: outputs from an in-flight fanout already committed to a
+  parent. Promoted to "used" once the fanout confirms.
 - `EnsureConfirmedReq` / `EnsureConfirmedResp` — public Ask API:
   register interest in a txid with `TargetConfs`, `ConfirmationPkScript`,
   and a subscriber.
@@ -62,15 +74,16 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
   (confirmation watches, block epochs, broadcast, package submission,
   fee estimation, preflight), `wallet` (`Utxo`, `OutputLeaser`,
   `LockID`), `lib/tx/arktx` (`TxVersion` constant, `IsAnchorOutput`).
-- **Depended on by**: `unroll`, `btcwbackend` (fee-input selection
-  helper), `darepod`, `db`.
+- **Depended on by**: `unroll`, `wallet` (sweep actors delegate broadcast +
+  CPFP to txconfirm), `btcwbackend` (fee-input selection helper),
+  `darepod`, `db`.
 - **Sends → `chainsource`** (Ask): `BestHeightRequest`,
   `SubscribeBlocksRequest`, `RegisterConfRequest`,
   `UnregisterConfRequest`, `BroadcastTxRequest`,
   `SubmitPackageRequest`, `TestMempoolAcceptRequest`,
   `FeeEstimateRequest`.
 - **Sends → `Wallet`** (direct): `ListUnspent`, `NewWalletPkScript`,
-  `FinalizePsbt`, `LeaseOutput`, `ReleaseOutput`.
+  `FinalizePsbt`, `FundPsbt` (fanout), `LeaseOutput`, `ReleaseOutput`.
 - **Sends → caller subscriber** (Tell): `TxConfirmed`, `TxFailed`.
 - **Receives ← `chainsource`** (mapped Tell refs): `BlockEpoch` →
   `blockEpochObservedMsg`; `ConfirmationEvent` →
@@ -131,6 +144,16 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - **Service-key symmetry**: `RegisterConfRequest` and
   `UnregisterConfRequest` both carry `PkScript` so chainsource's
   txid+script keyed service-actor lookup resolves symmetrically.
+- **Fee-input fanout supply**: when a parent CPFP broadcast fails with
+  `errCPFPFeeInputShortfall` (no confirmed wallet inputs available), the actor
+  automatically fans out a funded transaction via `FundPsbt` that produces
+  right-sized fee inputs. The fanout FSM runs as `feeBumpStateMachine` inside
+  the actor and re-drives affected parents once the fanout confirms.
+- **Predicted fee-input accounting**: outputs from a pending fanout are tracked
+  as `PredictedFeeInputs` in `parentBumpState`. They are excluded from other
+  parents' selection but not yet "used". On fanout confirmation they are
+  promoted to the reserved set; on parent eviction or fanout eviction they are
+  released.
 - **Terminal eviction**: on Confirmed or Failed, the actor delivers
   terminal notifications first. If a subscriber is slow or transiently
   fails, the tracked entry is retained without a conf watch and

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -35,9 +35,21 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - Exported helpers usable standalone: `BuildCPFPChild`,
   `EstimatePackageFee`, `EstimateWeight`, `SelectFeeInput`.
 - `Wallet` — interface required by the broadcaster: `ListUnspent`,
-  `NewWalletPkScript`, `FinalizePsbt`, plus `wallet.OutputLeaser`
+  `NewWalletPkScript`, `FinalizePsbt`, `FundPsbt` (used by the fanout FSM to
+  fund and sign fanout transactions), plus `wallet.OutputLeaser`
   (`LeaseOutput` / `ReleaseOutput`) for cross-subsystem UTXO lock
   coordination.
+- `feeBumpStateMachine` / `feeBumpEnvironment` — internal FSM that manages the
+  fee-input fanout lifecycle. Two states: `feeBumpStateIdle` (no fanout in
+  flight) and `feeBumpStateFanoutPending` (fanout broadcast, awaiting
+  confirmation). Owned as a field of `TxBroadcasterActor`; driven by
+  `maybeEnsureFeeInputSupply` whenever a CPFP broadcast fails with
+  `errCPFPFeeInputShortfall`.
+- `pendingFeeInputFanout` / `feeInputDemand` — internal types tracking an
+  in-flight fanout transaction and the per-parent demands it satisfies.
+- `PredictedFeeInputs` (`map[wire.OutPoint]*FeeInput`) — field on
+  `parentBumpState`: outputs from an in-flight fanout already committed to a
+  parent. Promoted to "used" once the fanout confirms.
 - `EnsureConfirmedReq` / `EnsureConfirmedResp` — public Ask API:
   register interest in a txid with `TargetConfs`, `ConfirmationPkScript`,
   and a subscriber.
@@ -62,15 +74,16 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
   (confirmation watches, block epochs, broadcast, package submission,
   fee estimation, preflight), `wallet` (`Utxo`, `OutputLeaser`,
   `LockID`), `lib/tx/arktx` (`TxVersion` constant, `IsAnchorOutput`).
-- **Depended on by**: `unroll`, `btcwbackend` (fee-input selection
-  helper), `darepod`, `db`.
+- **Depended on by**: `unroll`, `wallet` (sweep actors delegate broadcast +
+  CPFP to txconfirm), `btcwbackend` (fee-input selection helper),
+  `darepod`, `db`.
 - **Sends → `chainsource`** (Ask): `BestHeightRequest`,
   `SubscribeBlocksRequest`, `RegisterConfRequest`,
   `UnregisterConfRequest`, `BroadcastTxRequest`,
   `SubmitPackageRequest`, `TestMempoolAcceptRequest`,
   `FeeEstimateRequest`.
 - **Sends → `Wallet`** (direct): `ListUnspent`, `NewWalletPkScript`,
-  `FinalizePsbt`, `LeaseOutput`, `ReleaseOutput`.
+  `FinalizePsbt`, `FundPsbt` (fanout), `LeaseOutput`, `ReleaseOutput`.
 - **Sends → caller subscriber** (Tell): `TxConfirmed`, `TxFailed`.
 - **Receives ← `chainsource`** (mapped Tell refs): `BlockEpoch` →
   `blockEpochObservedMsg`; `ConfirmationEvent` →
@@ -131,6 +144,16 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - **Service-key symmetry**: `RegisterConfRequest` and
   `UnregisterConfRequest` both carry `PkScript` so chainsource's
   txid+script keyed service-actor lookup resolves symmetrically.
+- **Fee-input fanout supply**: when a parent CPFP broadcast fails with
+  `errCPFPFeeInputShortfall` (no confirmed wallet inputs available), the actor
+  automatically fans out a funded transaction via `FundPsbt` that produces
+  right-sized fee inputs. The fanout FSM runs as `feeBumpStateMachine` inside
+  the actor and re-drives affected parents once the fanout confirms.
+- **Predicted fee-input accounting**: outputs from a pending fanout are tracked
+  as `PredictedFeeInputs` in `parentBumpState`. They are excluded from other
+  parents' selection but not yet "used". On fanout confirmation they are
+  promoted to the reserved set; on parent eviction or fanout eviction they are
+  released.
 - **Terminal eviction**: on Confirmed or Failed, the actor delivers
   terminal notifications first. If a subscriber is slow or transiently
   fails, the tracked entry is retained without a conf watch and

--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -80,6 +80,25 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
   `db.UnilateralExitStore` via `statusForPhase`/`phaseFromDB` +
   `triggerToDB`/`triggerFromDB` (round-tripped in
   `db_store_test.go`).
+- `SessionOption` — functional option (`func(*Environment)`) for customizing
+  the FSM environment per-session. Currently used to override
+  `FraudCheckpointSafetyMargin`; future extension point for other per-session
+  tuning.
+- `ExitFundingSnapshot` — wallet state for exit-funding planning:
+  `WalletConfirmedSat` and `WalletUsableInputs` (confirmed UTXOs above dust).
+- `ExitFundingPlan` — user-facing funding projection returned by
+  `PlanExitFunding`: `Feasibility`, `RequiredConfirmations`,
+  `RecommendedUTXOAmountSat`, `RecommendedTotalFundingSat`,
+  `FundingShortfallSat`.
+- `ExitFundingAddressBook` — address cache for planning that reuses cached
+  funding addresses to avoid advancing the wallet index during repeated
+  polling.
+- `PlanExitFunding(desc, feeRate, wallet)` — combines `RecoveryTxCount()` and
+  `AssessExitFeasibility()` to derive funding projections using the same CPFP
+  cost breakdown as unroll admission.
+- `RecommendedExitFeeInputAmount(verdict)` — per-input fee suggestion from a
+  full feasibility breakdown; floors at `DefaultFeeInputMinAmountSat` (10k
+  sats).
 - `EnsureUnrollRequest` / `EnsureUnrollResp` — admission API. Must
   include `ExitPolicyKind` and `ExitPolicyRef` for non-standard exits;
   `validateExitPolicyIdentity` checks consistency at admit time. Dedup

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -80,6 +80,25 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
   `db.UnilateralExitStore` via `statusForPhase`/`phaseFromDB` +
   `triggerToDB`/`triggerFromDB` (round-tripped in
   `db_store_test.go`).
+- `SessionOption` — functional option (`func(*Environment)`) for customizing
+  the FSM environment per-session. Currently used to override
+  `FraudCheckpointSafetyMargin`; future extension point for other per-session
+  tuning.
+- `ExitFundingSnapshot` — wallet state for exit-funding planning:
+  `WalletConfirmedSat` and `WalletUsableInputs` (confirmed UTXOs above dust).
+- `ExitFundingPlan` — user-facing funding projection returned by
+  `PlanExitFunding`: `Feasibility`, `RequiredConfirmations`,
+  `RecommendedUTXOAmountSat`, `RecommendedTotalFundingSat`,
+  `FundingShortfallSat`.
+- `ExitFundingAddressBook` — address cache for planning that reuses cached
+  funding addresses to avoid advancing the wallet index during repeated
+  polling.
+- `PlanExitFunding(desc, feeRate, wallet)` — combines `RecoveryTxCount()` and
+  `AssessExitFeasibility()` to derive funding projections using the same CPFP
+  cost breakdown as unroll admission.
+- `RecommendedExitFeeInputAmount(verdict)` — per-input fee suggestion from a
+  full feasibility breakdown; floors at `DefaultFeeInputMinAmountSat` (10k
+  sats).
 - `EnsureUnrollRequest` / `EnsureUnrollResp` — admission API. Must
   include `ExitPolicyKind` and `ExitPolicyRef` for non-standard exits;
   `validateExitPolicyIdentity` checks consistency at admit time. Dedup

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -17,7 +17,41 @@ refresh, leave, OOR spend, and directed send flows.
 - `OutputLeaser` — Interface for UTXO output leasing: `LeaseOutput(ctx, outpoint, lockID, expiry)` and `ReleaseOutput(ctx, outpoint, lockID)`. Implemented by all three `BoardingBackend` implementations (`btcwbackend`, `lndbackend`, `lwwallet`) to coordinate cross-subsystem UTXO reservation.
 - `BoardingBackend` — Interface for wallet integration (key derivation, taproot import, ListUnspent). `GetTransaction` returns `*TxInfo` (containing tx, block hash, and block height).
 - `TxInfo` — Struct wrapping a confirmed transaction with its block hash and block height. Returned by `BoardingBackend.GetTransaction`.
-- `BoardingStore` — Interface for persisting boarding addresses and intents.
+- `BoardingStore` — Interface for persisting boarding addresses and intents. Embeds `PendingIntentStore`.
+- `PendingIntent` / `PendingIntentKind` / `PendingIntentID` / `PendingIntentPayload` / `PendingIntentStore` — the generic restart-safe intent outbox (`pending_intent.go`). `Payload` is a sealed `PendingIntentPayload` interface holding the concrete kind-specific struct (not bytes); the db layer stores its fields as typed columns. An intent is persisted BEFORE its round-actor publish, anchored to the outpoints the round consumes on adoption (confirmed boarding outpoints for `board`, reserved forfeit outpoints for `send_onchain`); the round checkpoint clears anchors transactionally. `NewPendingIntentID(payload, anchors)` derives the idempotency key as `sha256(kind ‖ sorted anchors ‖ payload-canonical-digest)`.
+- `PendingIntentReplayer` — per-kind replay strategy registered on the `Ark` actor (`intentReplayers`). `boardIntentReplayer` reconciles anchors against still-Confirmed boarding intents and self-Tells one `BoardRequest`; `sendOnChainIntentReplayer` self-Tells one `ReplaySendOnChainIntent` per persisted intent, whose handler re-reserves the EXACT anchors (never re-running selection), rebuilds the package via `buildSendOnChainIntentPackage`, and registers with `TriggerRegistration=true`. A reservation failure marks a send intent stale and deletes it.
+- `BoardIntentPayload` / `SendOnChainIntentPayload` — concrete `PendingIntentPayload` implementations (`pending_intent.go`); each contributes a deterministic `writeIDDigest` field encoding (for the intent ID only) and is stored as typed columns by the db layer.
+- `ReplayPendingIntentsRequest` / `ReplayPendingIntentsResponse` — daemon startup Ask that walks the replayer registry once every dependent actor is on the receptionist (replaces the Board-only `ReplayPendingBoardRequest`).
+- `ReplaySendOnChainIntent` — internal self-Tell carrying one persisted send intent from the replay pass into the wallet mailbox.
+- `SweepWalletFundsRequest` / `SweepWalletFundsResponse` — Ask-request to
+  preview or broadcast a general backing-wallet sweep. Drains all confirmed
+  non-boarding UTXOs to a single destination address. Not persisted —
+  interrupted sweeps re-run cleanly. Fee rate is always capped by
+  `applyWalletSweepFeeCap` (falls back to `txconfirm.DefaultMaxFeeRateSatPerVByte`).
+- `WalletBackingSweeper` — Backend interface for the general sweep: `ListUnspent`,
+  `LeaseOutput`, `ReleaseOutput`, `FundPsbt`, `NewWalletPkScript`.
+- `WalletSweepInputInfo` — Single backing UTXO selected for a general sweep.
+- `WalletSweepTxNotification` — Tell from the `txconfirm` subscriber carrying
+  a terminal confirm/fail event for a general-wallet sweep tx.
+- `SweepBoardingUTXOsRequest` / `SweepBoardingUTXOsResponse` — Ask-request to
+  preview or broadcast a boarding-timeout sweep. Recovers mature boarding UTXOs
+  (past their timeout heights) as aggregate transactions. Persisted with full
+  recovery semantics.
+- `BoardingSweepOutput` — Single boarding UTXO candidate (outpoint, amount,
+  maturity height).
+- `BoardingSweepRecord` / `BoardingSweepInputRecord` — Persisted sweep state
+  and per-input status (Pending → Published → Spent/ExternalResolved).
+- `BoardingSweepStore` — Persistence interface: `CreatePendingBoardingSweep`,
+  `MarkBoardingSweepPublished`, `MarkBoardingSweepInputSpent`,
+  `MarkBoardingSweepFailed`, `ListPendingBoardingSweeps`,
+  `GetBoardingSweep`.
+- `SweepSigner` — Builds and signs boarding-timeout sweep transactions.
+- `BoardingSweepSpendNotification` / `BoardingSweepTxNotification` —
+  async notifications from chainsource spend watches and `txconfirm`
+  respectively, routed back through the wallet actor mailbox.
+- `ResumeBoardingSweepsRequest` / `ResumeBoardingSweepsResponse` — startup
+  recovery flow: re-registers chainsource spend watches and re-submits pending
+  sweep txids to `txconfirm`.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
 - `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
@@ -41,7 +75,11 @@ refresh, leave, OOR spend, and directed send flows.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch
+  notifications, spend watches for boarding sweeps), `lib/actormsg` (VTXO
+  manager admission types), `txconfirm` (broadcast + CPFP + confirmation
+  for both sweep flows), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg`
+  / `ClassificationDeposit` / `UTXOSpentMsg` / `FeePaidMsg` constants).
 - **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
@@ -51,12 +89,29 @@ refresh, leave, OOR spend, and directed send flows.
     so the round FSM advances from `PendingRoundAssembly` immediately,
     `false` for refresh/leave batching
   - → `vtxo` manager (via `lib/actormsg`): `SelectAndReserveSpendRequest`, `ReleaseSpendRequest`, `CompleteSpendRequest`, `ReserveForfeitRequest`, `ReleaseForfeitRequest`, `SelectAndReserveForfeitRequest`
-  - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`): `UTXOCreatedMsg` on every processed confirmed wallet UTXO, tagged `ClassificationDeposit`. `handleUTXOCreated` expands this into both a `wallet_utxo_log` audit row AND a double-entry deposit leg (debit `wallet_balance`, credit `opening_balance`). (`UTXOSpentMsg` emission is a planned follow-up.)
+  - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`): `UTXOCreatedMsg`
+    on every processed confirmed wallet UTXO (`ClassificationDeposit`); on
+    boarding-sweep confirmation emits `FeePaidMsg` (`FeeTypeOnchainSweep`),
+    `UTXOSpentMsg` per input (`ClassificationBoardingSweepInput`), and
+    `UTXOCreatedMsg` for wallet-derived destinations
+    (`ClassificationBoardingSweepReturn`).
+  - → `txconfirm` (Ask): `EnsureConfirmedReq` for both `SweepBoardingUTXOs`
+    and `SweepWalletFunds` broadcast paths; terminal events re-wrapped as
+    `BoardingSweepTxNotification` / `WalletSweepTxNotification` and routed
+    back to the wallet mailbox.
+  - → `chainsource` (Ask): `RegisterSpendRequest` per boarding-sweep input
+    to detect external spends; events re-wrapped as
+    `BoardingSweepSpendNotification`.
   - → `round` (via `lib/types.VTXORequest.Origin`): wallet intent composition tags each locally-owned VTXO output with a `VTXOOrigin` classifier so the round actor's downstream ledger emission dispatches to the correct `Source`. Refresh outputs and directed-send self-change get `VTXOOriginRoundRefresh`; boarding-path tagging lives in `round.handleTriggerBoard` (`VTXOOriginRoundBoarding`).
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `SendOnChainRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`,
+    `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`,
+    `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`,
+    `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`,
+    `SendVTXOsRequest`, `SendOnChainRequest`, `SweepBoardingUTXOsRequest`,
+    `SweepWalletFundsRequest`, `ResumeBoardingSweepsRequest`
 
 ## Invariants
 
@@ -64,11 +119,24 @@ refresh, leave, OOR spend, and directed send flows.
 - `ListUnspent` runs at most once per tip-tick against the latest known chain tip; a backend whose UTXO reporting lags past one tick interval surfaces the missing UTXO on the next chain advance (whichever tick processes the new tip re-runs the scan). The per-block path no longer carries an inline retry budget — the tick loop is the retry seam.
 - Notifier registration captures `minConf` parameter per actor; different actors can require different confirmation depths.
 - Cooperative admission (refresh/leave) must reserve forfeit inputs through the VTXO manager before sending `RegisterIntentMsg` to the round actor.
+- Persist-before-publish: `handleBoard` and `handleSendOnChain` write their pending intent to the outbox BEFORE the round-actor publish, so every crash window either leaves no row (clean retry) or a replayable row. `handleSendOnChain` deletes the row when registration fails synchronously — the caller saw an error, so the send must not silently resurrect on the next start.
 - `WithEagerRoundJoin(true)` opts the wallet into "drive round-joining without a second RPC" semantics. Two sites change: `handleBlockEpoch` inline-calls `handleBoard` after at least one new boarding UTXO confirms in the block (one `TriggerBoardMsg` per block, not per UTXO), and `handleLeaveVTXOs` forwards its `RegisterIntentMsg` with `TriggerRegistration=true` so the leave moves the round FSM out of `PendingRoundAssembly` immediately. Default off preserves the operator-driven batched semantics that `darepocli` and server hosts rely on; `sdk/walletdk` flips it on via `darepod.Config.EagerRoundJoin` for wallet-shaped SDK hosts.
 - If round registration fails after successful admission, the wallet releases the forfeit reservation so VTXOs return to LiveState.
 - Directed sends use `SelectAndReserveForfeitRequest` (cooperative forfeit path) rather than the OOR spend path. The wallet builds recipient VTXOs with the recipient's key as `OwnerKey` and derives a separate ephemeral `SigningKey` for MuSig2 tree construction.
 - Local ownership of a round-produced VTXO is no longer tracked with a per-intent `IsOwner` flag. `types.VTXORequest` / `round.VTXOIntent` no longer carry `IsOwner`; at round confirmation time the round FSM asks a `round.OwnedScriptChecker` (backed in production by the OOR owned-receive-scripts store) which pkScripts to persist as local balance. The wallet's only job is to supply the correct `OwnerKey` per intent — local-origin owner keys keep their populated `KeyLocator` so `handleRegisterIntent` registers them via `OwnedScriptRegistrar`, while remote recipients carry a zero `KeyLocator` and are intentionally left unregistered.
 - `handleSendVTXOs` uses a `defer`-based release rather than a `releaseAndFail` helper: any error path (including dry-run) falls through to the deferred release, and the `committed` flag is set only after the round actor accepts the intent. Context is preserved via `context.WithoutCancel` so cleanup is not dropped when the caller disconnects.
+- **General wallet sweep is ephemeral**: `SweepWalletFunds` is not persisted —
+  if interrupted, the daemon re-runs it on the next request. UTXO leases
+  (`walletSweepLockID`) are released on broadcast failure but retained on
+  success so txconfirm holds exclusive access during rebroadcast.
+- **Boarding sweep is durable**: `SweepBoardingUTXOs` persists a
+  `BoardingSweepRecord` before submitting to txconfirm. `ResumeBoardingSweeps`
+  re-registers spend watches and re-submits pending sweeps on startup.
+  Input status advances Pending → Published → Spent, ensuring idempotent
+  restart convergence.
+- **Boarding sweep fee cap is implicit**: the boarding-sweep transaction
+  includes a P2A anchor output so txconfirm can CPFP-fee-bump it. The
+  general wallet sweep always applies an explicit fee cap.
 - `handleSendVTXOs` rejects pre-flight any directed send with multiple recipients and exactly-zero change residual under the #270 seal-time fee handshake. The server is the amount authority and absorbs the operator fee out of the designated `IsChange=true` slot; if there is no residual to absorb the fee against, the server has no slack to deduct fees without silently shifting them onto a recipient leg. The wallet refuses the request rather than letting the server pick the loser.
 - `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
 - Per-subsystem logging via `build.LoggerFromContext` (no global mutable loggers).

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -23,6 +23,35 @@ refresh, leave, OOR spend, and directed send flows.
 - `BoardIntentPayload` / `SendOnChainIntentPayload` — concrete `PendingIntentPayload` implementations (`pending_intent.go`); each contributes a deterministic `writeIDDigest` field encoding (for the intent ID only) and is stored as typed columns by the db layer.
 - `ReplayPendingIntentsRequest` / `ReplayPendingIntentsResponse` — daemon startup Ask that walks the replayer registry once every dependent actor is on the receptionist (replaces the Board-only `ReplayPendingBoardRequest`).
 - `ReplaySendOnChainIntent` — internal self-Tell carrying one persisted send intent from the replay pass into the wallet mailbox.
+- `SweepWalletFundsRequest` / `SweepWalletFundsResponse` — Ask-request to
+  preview or broadcast a general backing-wallet sweep. Drains all confirmed
+  non-boarding UTXOs to a single destination address. Not persisted —
+  interrupted sweeps re-run cleanly. Fee rate is always capped by
+  `applyWalletSweepFeeCap` (falls back to `txconfirm.DefaultMaxFeeRateSatPerVByte`).
+- `WalletBackingSweeper` — Backend interface for the general sweep: `ListUnspent`,
+  `LeaseOutput`, `ReleaseOutput`, `FundPsbt`, `NewWalletPkScript`.
+- `WalletSweepInputInfo` — Single backing UTXO selected for a general sweep.
+- `WalletSweepTxNotification` — Tell from the `txconfirm` subscriber carrying
+  a terminal confirm/fail event for a general-wallet sweep tx.
+- `SweepBoardingUTXOsRequest` / `SweepBoardingUTXOsResponse` — Ask-request to
+  preview or broadcast a boarding-timeout sweep. Recovers mature boarding UTXOs
+  (past their timeout heights) as aggregate transactions. Persisted with full
+  recovery semantics.
+- `BoardingSweepOutput` — Single boarding UTXO candidate (outpoint, amount,
+  maturity height).
+- `BoardingSweepRecord` / `BoardingSweepInputRecord` — Persisted sweep state
+  and per-input status (Pending → Published → Spent/ExternalResolved).
+- `BoardingSweepStore` — Persistence interface: `CreatePendingBoardingSweep`,
+  `MarkBoardingSweepPublished`, `MarkBoardingSweepInputSpent`,
+  `MarkBoardingSweepFailed`, `ListPendingBoardingSweeps`,
+  `GetBoardingSweep`.
+- `SweepSigner` — Builds and signs boarding-timeout sweep transactions.
+- `BoardingSweepSpendNotification` / `BoardingSweepTxNotification` —
+  async notifications from chainsource spend watches and `txconfirm`
+  respectively, routed back through the wallet actor mailbox.
+- `ResumeBoardingSweepsRequest` / `ResumeBoardingSweepsResponse` — startup
+  recovery flow: re-registers chainsource spend watches and re-submits pending
+  sweep txids to `txconfirm`.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
 - `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
@@ -46,7 +75,11 @@ refresh, leave, OOR spend, and directed send flows.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch
+  notifications, spend watches for boarding sweeps), `lib/actormsg` (VTXO
+  manager admission types), `txconfirm` (broadcast + CPFP + confirmation
+  for both sweep flows), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg`
+  / `ClassificationDeposit` / `UTXOSpentMsg` / `FeePaidMsg` constants).
 - **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
@@ -56,12 +89,29 @@ refresh, leave, OOR spend, and directed send flows.
     so the round FSM advances from `PendingRoundAssembly` immediately,
     `false` for refresh/leave batching
   - → `vtxo` manager (via `lib/actormsg`): `SelectAndReserveSpendRequest`, `ReleaseSpendRequest`, `CompleteSpendRequest`, `ReserveForfeitRequest`, `ReleaseForfeitRequest`, `SelectAndReserveForfeitRequest`
-  - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`): `UTXOCreatedMsg` on every processed confirmed wallet UTXO, tagged `ClassificationDeposit`. `handleUTXOCreated` expands this into both a `wallet_utxo_log` audit row AND a double-entry deposit leg (debit `wallet_balance`, credit `opening_balance`). (`UTXOSpentMsg` emission is a planned follow-up.)
+  - → `ledger` actor (via `ledger.Sink` Tell, when `fn.Some`): `UTXOCreatedMsg`
+    on every processed confirmed wallet UTXO (`ClassificationDeposit`); on
+    boarding-sweep confirmation emits `FeePaidMsg` (`FeeTypeOnchainSweep`),
+    `UTXOSpentMsg` per input (`ClassificationBoardingSweepInput`), and
+    `UTXOCreatedMsg` for wallet-derived destinations
+    (`ClassificationBoardingSweepReturn`).
+  - → `txconfirm` (Ask): `EnsureConfirmedReq` for both `SweepBoardingUTXOs`
+    and `SweepWalletFunds` broadcast paths; terminal events re-wrapped as
+    `BoardingSweepTxNotification` / `WalletSweepTxNotification` and routed
+    back to the wallet mailbox.
+  - → `chainsource` (Ask): `RegisterSpendRequest` per boarding-sweep input
+    to detect external spends; events re-wrapped as
+    `BoardingSweepSpendNotification`.
   - → `round` (via `lib/types.VTXORequest.Origin`): wallet intent composition tags each locally-owned VTXO output with a `VTXOOrigin` classifier so the round actor's downstream ledger emission dispatches to the correct `Source`. Refresh outputs and directed-send self-change get `VTXOOriginRoundRefresh`; boarding-path tagging lives in `round.handleTriggerBoard` (`VTXOOriginRoundBoarding`).
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `SendOnChainRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`,
+    `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`,
+    `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`,
+    `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`,
+    `SendVTXOsRequest`, `SendOnChainRequest`, `SweepBoardingUTXOsRequest`,
+    `SweepWalletFundsRequest`, `ResumeBoardingSweepsRequest`
 
 ## Invariants
 
@@ -75,6 +125,18 @@ refresh, leave, OOR spend, and directed send flows.
 - Directed sends use `SelectAndReserveForfeitRequest` (cooperative forfeit path) rather than the OOR spend path. The wallet builds recipient VTXOs with the recipient's key as `OwnerKey` and derives a separate ephemeral `SigningKey` for MuSig2 tree construction.
 - Local ownership of a round-produced VTXO is no longer tracked with a per-intent `IsOwner` flag. `types.VTXORequest` / `round.VTXOIntent` no longer carry `IsOwner`; at round confirmation time the round FSM asks a `round.OwnedScriptChecker` (backed in production by the OOR owned-receive-scripts store) which pkScripts to persist as local balance. The wallet's only job is to supply the correct `OwnerKey` per intent — local-origin owner keys keep their populated `KeyLocator` so `handleRegisterIntent` registers them via `OwnedScriptRegistrar`, while remote recipients carry a zero `KeyLocator` and are intentionally left unregistered.
 - `handleSendVTXOs` uses a `defer`-based release rather than a `releaseAndFail` helper: any error path (including dry-run) falls through to the deferred release, and the `committed` flag is set only after the round actor accepts the intent. Context is preserved via `context.WithoutCancel` so cleanup is not dropped when the caller disconnects.
+- **General wallet sweep is ephemeral**: `SweepWalletFunds` is not persisted —
+  if interrupted, the daemon re-runs it on the next request. UTXO leases
+  (`walletSweepLockID`) are released on broadcast failure but retained on
+  success so txconfirm holds exclusive access during rebroadcast.
+- **Boarding sweep is durable**: `SweepBoardingUTXOs` persists a
+  `BoardingSweepRecord` before submitting to txconfirm. `ResumeBoardingSweeps`
+  re-registers spend watches and re-submits pending sweeps on startup.
+  Input status advances Pending → Published → Spent, ensuring idempotent
+  restart convergence.
+- **Boarding sweep fee cap is implicit**: the boarding-sweep transaction
+  includes a P2A anchor output so txconfirm can CPFP-fee-bump it. The
+  general wallet sweep always applies an explicit fee cap.
 - `handleSendVTXOs` rejects pre-flight any directed send with multiple recipients and exactly-zero change residual under the #270 seal-time fee handshake. The server is the amount authority and absorbs the operator fee out of the designated `IsChange=true` slot; if there is no residual to absorb the fee against, the server has no slack to deduct fees without silently shifting them onto a recipient leg. The wallet refuses the request rather than letting the server pick the loser.
 - `VTXOReader` / `VTXODescriptor` / `SelectedVTXO` break the vtxo → round → wallet import cycle by providing wallet-level types that don't reference `vtxo.Descriptor` directly.
 - Per-subsystem logging via `build.LoggerFromContext` (no global mutable loggers).


### PR DESCRIPTION
Automated nightly documentation sweep covering changes merged since the last doc-gardening PR.

**Workflow run:** https://github.com/lightninglabs/darepo-client/actions/runs/0

## What changed

- **coinselect/CLAUDE.md** (new) — Documents the new coin-type-agnostic coin selection package (`LargestFirst`, `Request`, `Result`, error sentinels). Added to ARCHITECTURE.md Layer 1 table.
- **txconfirm/CLAUDE.md** — Updated to document the fee-input fanout FSM (`feeBumpStateMachine`, `feeBumpEnvironment`, `pendingFeeInputFanout`, `PredictedFeeInputs`), the new `Wallet.FundPsbt` method, and two new invariants for fanout supply and predicted fee-input accounting.
- **unroll/CLAUDE.md** — Added exit-funding planning types: `SessionOption`, `ExitFundingPlan`, `ExitFundingSnapshot`, `ExitFundingAddressBook`, `PlanExitFunding`, `RecommendedExitFeeInputAmount`.
- **wallet/CLAUDE.md** — Added both sweep actor subsystems: `SweepWalletFundsRequest`/`WalletBackingSweeper` (ephemeral general sweep), `SweepBoardingUTXOsRequest`/`BoardingSweepStore`/`SweepSigner` (durable boarding-timeout sweep), `ResumeBoardingSweepsRequest`, ledger emissions on boarding-sweep confirmation, and txconfirm delegation.
- **baselib/actor, db, db/actordelivery, p-models/durableactor, p-models/durableactor/bridge AGENTS.md** — Synced to match their CLAUDE.md counterparts (diverged due to commits since last sweep).

Please review the updated CLAUDE.md/AGENTS.md and ARCHITECTURE.md diffs before merging.
