### PR TITLE
docs: nightly doc-gardening sweep 2026-06-23

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -27,6 +27,7 @@ package may import from a higher layer.
 | [`lib/tx/psbtutil`](lib/tx/psbtutil/) | PSBT encoding, decoding, and signature attachment helpers |
 | [`lib/recovery`](lib/recovery/) | Immutable recovery proof graph, session state machine, TLV codec for unilateral exit |
 | [`unrollplan`](unrollplan/) | Pure dependency-resolution planner driving unilateral-exit broadcast/sweep ordering |
+| [`coinselect`](coinselect/) | Coin-type-agnostic largest-first coin selector; shared by vtxo and swapwallet |
 | [`vhtlcrecovery`](vhtlcrecovery/) | Durable control-plane types for vHTLC on-chain recovery jobs (action, state, script parameters, swap linkage) |
 
 ### Layer 2: Infrastructure (Chain, Storage, Messaging)

--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -26,7 +26,7 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `Receptionist` — Service locator mapping `ServiceKey` → `ActorRef` for decoupled actor wiring.
 - `Message` — Sealed interface for all actor messages (must embed `BaseMessage`).
 - `MessageCodec` — TLV-based codec for message serialization/deserialization.
-- `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter).
+- `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter). The leaseless single-worker fast path adds `PeekNextMessage` (read-only claim, no lease, no attempts bump; yields an empty lease token), `AckMessageByID` (unfenced delete), and `NackMessageByID` (unfenced release that increments attempts). A `DurableActor` enables it (via `DurableMailboxConfig.SingleWorkerLeaseless`) strictly when `NumWorkers == 1` AND the behavior is the Read/Commit (Right/`TxBehavior`) path, eliminating the per-message lease write transaction. The multi-worker pool and the classic path are byte-for-byte unchanged: they keep `LeaseNextMessage` and the lease-fenced ack. Ack/nack route to the by-ID ops automatically whenever the delivery's lease token is empty; `Delivery.ShouldDeadLetter` counts the in-flight attempt as `Attempts + 1` on the leaseless path so the dead-letter boundary matches the leased path (where attempts is pre-incremented at lease).
 - `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence. Provides `Wait(ctx)` to block until the actor stops and `StopAndWait(ctx)` to request a graceful shutdown and then wait.
 - `DurableActorConfig[M, R]` — Configuration struct for `DurableActor`: behavior, store, codec, clock, DLO, WaitGroup, `TellRetryPolicy`, lease/heartbeat/poll durations, max attempts, cleanup timeout, deduplication TTL, and `NumWorkers`.
 - `DurableActorConfig.NumWorkers` — How many concurrent worker loops drain the actor's single mailbox. Default and any value `<= 1` is one worker (strictly-sequential processing). A value `> 1` turns the actor into a competing-consumer pool: that many goroutines each lease distinct messages via `LeaseNextMailboxMessage`, so independent messages run in parallel while per-correlation-key FIFO still keeps same-key messages ordered. Only for behaviors whose handlers are concurrency-safe and hold no writer across their side effects (e.g. the serverconn egress sender on the Read/Commit path). `NewDurableActor` **fails closed** with `ErrConcurrentClassicBehavior` when `NumWorkers > 1` is paired with a classic (`Left`) `ActorBehavior`, since the classic path wraps the whole `Receive` in one write transaction and assumes sequential delivery; pools are only valid on the Read/Commit (`TxBehavior`) path. The test-only `DurableActorConfig.AllowConcurrentClassicBehavior()` escape hatch bypasses the guard for the egress benchmark that measures the forbidden config; production code must never call it.
@@ -81,8 +81,24 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 ## Invariants
 
 - Messages are processed sequentially per actor by default (one worker, no concurrent `Receive` calls). Opting into `DurableActorConfig.NumWorkers > 1` relaxes this: that many worker loops drain the one mailbox concurrently, so `Receive` may run in parallel across distinct messages. The competing-consumer lease guarantees each message is still processed by exactly one worker, and per-correlation-key FIFO holds across workers; only behaviors with concurrency-safe handlers should set it. The combination is structurally restricted to the Read/Commit path: `NewDurableActor` rejects `NumWorkers > 1` on a classic `ActorBehavior` with `ErrConcurrentClassicBehavior` so a stateful, sequentially-assumed actor can never be silently fanned out.
+- **Leaseless consume ownership model.** `SingleWorkerLeaseless` removes the
+  lease-token fence, so its safety argument is "one live runtime owner for this
+  mailbox", not merely "one goroutine in this process". Do not enable it for a
+  mailbox that can be drained by another daemon/process at the same time unless
+  an external singleton/ownership fence already exists. A peeked delivery always
+  carries an empty lease token, even when the persisted row still has stale
+  expired lease metadata from an older leased claim; that empty token is the
+  p-model edge that routes ack/nack to the by-ID operations. Retry-policy
+  decisions must use `Delivery.EffectiveAttempts()` so the in-flight peeked
+  attempt is counted before a nack can raise the row to `max_attempts`.
 - `Tell` with a `DurableActor` persists the message before returning (crash-safe enqueue).
 - Outbox messages are dispatched only after state is persisted (outbox pattern).
+- **Outbox fold p-model.** For tx-aware stores, outbox delivery is
+  `claim -> (target mailbox enqueue + CompleteOutbox) in one write tx`. If the
+  transaction fails before commit, both the enqueue and completion roll back and
+  the claim expiry is the retry mechanism; the publisher must log the
+  transaction failure even when the inner Tell/Complete operations returned nil,
+  because begin/commit failures happen outside those operation-level logs.
 - `ServiceKey` lookup via `Receptionist` is type-safe: mismatched types return `ErrServiceKeyTypeMismatch`.
 - `RestartMessage` has `RestartPriority` (MaxInt32) ensuring it is processed before all other messages on recovery.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.

--- a/coinselect/AGENTS.md
+++ b/coinselect/AGENTS.md
@@ -1,0 +1,55 @@
+# coinselect
+
+## Purpose
+
+Coin-type-agnostic coin-selection algorithm. Provides a single
+`LargestFirst` selector that callers parameterize with an amount
+extractor (`AmountFunc[T]`) so every layer that needs a covering
+subset of coins (VTXOs, boarding intents, backing-wallet UTXOs) reuses
+the same implementation instead of maintaining parallel custom selectors.
+
+## Key Types
+
+- `AmountFunc[T]` — `func(T) btcutil.Amount`; extracts the satoshi
+  value of a candidate. Caller-supplied so the selector stays agnostic
+  to concrete coin types.
+- `Request` — parameterizes one coin-selection pass:
+  `Target btcutil.Amount` (required unless `SweepAll`),
+  `MinChange btcutil.Amount` (rejects non-zero change below this
+  floor; zero disables), `SweepAll bool` (select every candidate,
+  ignore Target/MinChange).
+- `Result[T]` — outcome: `Selected []T` (chosen subset in selection
+  order), `Total btcutil.Amount` (sum of Selected), `Change
+  btcutil.Amount` (Total − Target; zero for sweep).
+- `LargestFirst[T any](candidates, amount, req)` — main exported
+  function. Sorts candidates by descending amount and accumulates
+  until Target covered. When `MinChange > 0`, rejects selections
+  whose non-zero change falls below the floor. Exact (zero-change)
+  fits are always accepted. Returns typed errors on failure.
+
+## Error Sentinels
+
+- `ErrSelectionShortfall` — candidate set cannot cover Target.
+- `ErrChangeBelowMin` — covering selection exists but change is
+  non-zero and below `MinChange`.
+- `ErrNoCandidates` — selection requested over empty candidate set.
+- `ErrInvalidTarget` — bounded selection with non-positive Target.
+
+## Relationships
+
+- **Depends on**: `github.com/btcsuite/btcd/btcutil` (Bitcoin amount
+  types); standard library only.
+- **Depended on by**: `vtxo` (VTXO manager reservation path),
+  `swapwallet` (swap wallet send preview and routing).
+
+## Invariants
+
+- Caller's candidate slice is never mutated; sorting operates on a
+  copy.
+- Selection is deterministic for distinct amounts (stable sort).
+- On failure, the returned `Result` still carries the partial
+  `Total` so callers can report a shortfall amount.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/coinselect/CLAUDE.md
+++ b/coinselect/CLAUDE.md
@@ -1,0 +1,55 @@
+# coinselect
+
+## Purpose
+
+Coin-type-agnostic coin-selection algorithm. Provides a single
+`LargestFirst` selector that callers parameterize with an amount
+extractor (`AmountFunc[T]`) so every layer that needs a covering
+subset of coins (VTXOs, boarding intents, backing-wallet UTXOs) reuses
+the same implementation instead of maintaining parallel custom selectors.
+
+## Key Types
+
+- `AmountFunc[T]` — `func(T) btcutil.Amount`; extracts the satoshi
+  value of a candidate. Caller-supplied so the selector stays agnostic
+  to concrete coin types.
+- `Request` — parameterizes one coin-selection pass:
+  `Target btcutil.Amount` (required unless `SweepAll`),
+  `MinChange btcutil.Amount` (rejects non-zero change below this
+  floor; zero disables), `SweepAll bool` (select every candidate,
+  ignore Target/MinChange).
+- `Result[T]` — outcome: `Selected []T` (chosen subset in selection
+  order), `Total btcutil.Amount` (sum of Selected), `Change
+  btcutil.Amount` (Total − Target; zero for sweep).
+- `LargestFirst[T any](candidates, amount, req)` — main exported
+  function. Sorts candidates by descending amount and accumulates
+  until Target covered. When `MinChange > 0`, rejects selections
+  whose non-zero change falls below the floor. Exact (zero-change)
+  fits are always accepted. Returns typed errors on failure.
+
+## Error Sentinels
+
+- `ErrSelectionShortfall` — candidate set cannot cover Target.
+- `ErrChangeBelowMin` — covering selection exists but change is
+  non-zero and below `MinChange`.
+- `ErrNoCandidates` — selection requested over empty candidate set.
+- `ErrInvalidTarget` — bounded selection with non-positive Target.
+
+## Relationships
+
+- **Depends on**: `github.com/btcsuite/btcd/btcutil` (Bitcoin amount
+  types); standard library only.
+- **Depended on by**: `vtxo` (VTXO manager reservation path),
+  `swapwallet` (swap wallet send preview and routing).
+
+## Invariants
+
+- Caller's candidate slice is never mutated; sorting operates on a
+  copy.
+- Selection is deterministic for distinct amounts (stable sort).
+- On failure, the returned `Result` still carries the partial
+  `Total` so callers can report a shortfall amount.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -105,6 +105,18 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   an aggregate tx via `buildBoardingSweepTx`, persists, broadcasts,
   and wakes `boardingSweepWatcher`. Returns preview when
   `broadcast=false`.
+- `SweepWallet` — sweeps confirmed backing-wallet UTXOs to a
+  destination address. Thin RPC shim: validates the request, asks the
+  wallet actor via `SweepWalletFundsRequest`, and maps the
+  `SweepWalletFundsResponse`. All tx-building, fee-capping, signing,
+  and txconfirm submission are owned by the wallet actor. Fee rate is
+  always capped (operator-configured max or 100 sat/vByte default).
+- `GetExitPlan` — batch preview of backing-wallet readiness for a set
+  of VTXO outpoints. Routes to `unroll.PlanExitFunding` with a running
+  wallet allocation that reserves `RequiredWalletInputs` per feasible
+  entry before assessing the next, preventing over-reporting of
+  feasibility in multi-outpoint batches. Bad or unknown outpoints set
+  a per-entry error rather than failing the whole batch.
 - `ListBoardingSweeps` — paginated persisted aggregate sweeps with
   optional status filter and cursor-based pagination.
 - `ArmVHTLCRecovery` — persists a dormant vHTLC on-chain recovery job (armed

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -105,6 +105,18 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   an aggregate tx via `buildBoardingSweepTx`, persists, broadcasts,
   and wakes `boardingSweepWatcher`. Returns preview when
   `broadcast=false`.
+- `SweepWallet` — sweeps confirmed backing-wallet UTXOs to a
+  destination address. Thin RPC shim: validates the request, asks the
+  wallet actor via `SweepWalletFundsRequest`, and maps the
+  `SweepWalletFundsResponse`. All tx-building, fee-capping, signing,
+  and txconfirm submission are owned by the wallet actor. Fee rate is
+  always capped (operator-configured max or 100 sat/vByte default).
+- `GetExitPlan` — batch preview of backing-wallet readiness for a set
+  of VTXO outpoints. Routes to `unroll.PlanExitFunding` with a running
+  wallet allocation that reserves `RequiredWalletInputs` per feasible
+  entry before assessing the next, preventing over-reporting of
+  feasibility in multi-outpoint batches. Bad or unknown outpoints set
+  a per-entry error rather than failing the whole batch.
 - `ListBoardingSweeps` — paginated persisted aggregate sweeps with
   optional status filter and cursor-based pagination.
 - `ArmVHTLCRecovery` — persists a dormant vHTLC on-chain recovery job (armed

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -71,7 +71,22 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   safety bounds enforced during `DeserializeTree`.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — two-stage
   OOR ancestry resolver (`oor_unroll_resolver.go`).
-- `LatestMigrationVersion = 17` — current schema version.
+- `LatestMigrationVersion = 19` — current schema version.
+- `PendingIntentPersistenceStore` — implements `wallet.PendingIntentStore`,
+  the persistence half of the generic restart-safe intent outbox (header
+  `pending_intents` + per-kind detail tables + `pending_intent_anchors`).
+  Maps the sealed `wallet.PendingIntentPayload` concrete types to/from typed
+  detail columns (no blob). Intents are written before the wallet publishes
+  them to the round actor; `CommitState` clears anchors by outpoint
+  (boarding outpoints AND forfeited VTXO outpoints) inside the
+  point-of-no-return round checkpoint transaction, then sweeps orphaned
+  detail rows and headers, so replay-after-adoption is structurally
+  impossible. Methods: `UpsertPendingIntent` (header + detail + anchors
+  atomically; anchor rebind sweeps anchor-less older intents),
+  `ListPendingIntents` (per kind, with anchors), `DeletePendingIntent`,
+  `ClearPendingIntentsByKind`.
+- `PendingIntentStore` / `BatchedPendingIntentStore` — internal sqlc-backed
+  query interfaces for the pending-intent tables.
 - `SpendingReservationPersistenceStore` — Persists the durable index of VTXO
   outpoints reserved by an active spend owner (e.g. an outgoing OOR session).
   A row exists IFF the owning session was durably checkpointed, so a startup
@@ -125,6 +140,15 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 
 ### Migration notes
 
+- `000018_pending_intents` — generalizes the Board-only
+  `pending_board_requests` outbox into a supertype/subtype set:
+  `pending_intent_kinds` (enum table), `pending_intents` (header: 32-byte
+  hash-derived intent id + kind FK + requested_at, no payload blob),
+  per-kind detail tables `pending_board_intents` / `pending_send_intents`
+  with first-class typed columns, and `pending_intent_anchors` (one row per
+  anchored outpoint, PK on the outpoint so a newer intent rebinds, FK to the
+  header). Drops `pending_board_requests` outright (alpha; rows only exist
+  in the narrow crash window between admission and round seal).
 - `000017_spending_reservations` — adds `spending_reservations` table with
   `(outpoint_hash, outpoint_index)` PK, `owner_kind`, `owner_id`, and
   `created_at`. A row exists IFF the owning spend session was durably
@@ -147,7 +171,7 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
 - `000013_pending_board_request` — records the user's explicit `Board`
   RPC intent so a daemon restart between Board admission and round
   seal does not silently drop the request. Keyed by the confirmed
-  boarding outpoint.
+  boarding outpoint. Superseded by `000018_pending_intents`.
 - `000012_boarding_sweep_ledger_events` — registers the
   `boarding_sweep_fee_paid` ledger event type so `FeePaidMsg` with
   `FeeType=FeeTypeOnchainSweep` satisfies the `ledger_entries.event_type`

--- a/db/actordelivery/AGENTS.md
+++ b/db/actordelivery/AGENTS.md
@@ -30,9 +30,20 @@ other services can reuse durable actor storage without pulling unrelated tables.
   a `TxActorDeliveryStore` scoped to that transaction, and on successful commit
   fires outbox-wake callbacks when outbox messages were enqueued inside the tx.
 - `ActorDeliveryQueries` — Interface for all actor delivery SQL operations:
-  mailbox enqueue/lease/ack/nack/extend/expire, ask results, outbox
+  mailbox enqueue/lease/peek/ack/nack/extend/expire, ask results, outbox
   claim/complete/fail, deduplication, FSM checkpoints, dead letters, and
   cleanup. Implemented by the SQLC-generated query set.
+- **Leaseless single-worker consume path** — `PeekNextMailboxMessage` (a
+  READ-only claim that mirrors `LeaseNextMailboxMessage`'s eligibility and
+  ordering but takes no lease and does NOT bump attempts),
+  `AckMailboxMessageByID` (unfenced delete by id), and
+  `NackMailboxMessageByID` (unfenced release that increments attempts).
+  Exposed on both `Store` and `TxActorDeliveryStore` as `PeekNextMessage`
+  (read tx), `AckMessageByID`, and `NackMessageByID`. Used only by
+  `NumWorkers == 1` Read/Commit actors, which have no competing consumer to
+  fence; the multi-worker pool keeps lease + fenced ack. The by-ID nack
+  increments attempts because the peek does not, preserving dead-lettering
+  on max attempts.
 - `BatchedActorDeliveryQueries` — Batched transaction wrapper for
   `ActorDeliveryQueries`.
 - `MigrationOption` — Functional options for migration configuration
@@ -65,6 +76,12 @@ other services can reuse durable actor storage without pulling unrelated tables.
   goroutines.
 - `TxAwareActorDeliveryStore.ExecTx` always defers `tx.Rollback()` so partial
   writes cannot survive a function error; commit is the only success path.
+- `PeekNextMessage` is a read-only eligibility check, not an ownership write.
+  The store adapter must map every peeked row to an empty lease token before it
+  reaches the actor layer, including rows that still carry stale expired lease
+  metadata from a previous leased claim. The by-ID nack path clears that stale
+  metadata while incrementing attempts, preserving the leaseless p-model:
+  `peek -> empty-token delivery -> by-ID ack/nack`.
 
 ## Deep Docs
 

--- a/p-models/durableactor/AGENTS.md
+++ b/p-models/durableactor/AGENTS.md
@@ -3,15 +3,24 @@
 This package models the durable actor mailbox from distributed-systems first
 principles: durable enqueue, lease ownership, retry scheduling, ack/nack token
 validation, dead-letter/removal, idempotent delivery identity,
-per-correlation-key FIFO, and the Read/Commit consume step (lease-fenced
-exactly-once effect application under lease-expiry-during-IO).
+per-correlation-key FIFO, the Read/Commit consume step (lease-fenced
+exactly-once effect application under lease-expiry-during-IO), and the CDC
+outbox fold (the target enqueue and the outbox completion committing as one
+transaction, with no-lost-message and exactly-once-delivery guarantees).
 
 ## Files
 
 - `infra.pproj` — P project for durable actor infrastructure checks.
 - `src/mailbox_fifo.p` — ideal mailbox spec plus claim-ordering profiles.
+- `src/ingress_fold.p` — connection-actor ingress cursor spec: the persisted
+  PullCursor must never cover an envelope whose local enqueue did not commit
+  (the transactional dispatch fold makes batch enqueues + cursor one atomic
+  commit).
 - `test/mailbox_fifo_test.p` — green conformance tests and separate
   counterexample tests.
+- `test/ingress_fold_test.p` — green atomic-fold drain test plus the two
+  cursor-loss counterexamples (eager in-memory cursor after rollback;
+  checkpoint commit ordered before the enqueue commits).
 - `traces/*.json` — concrete scenarios replayed by the Go bridge.
 - `bridge/` — Go conformance harness against the real `db/actordelivery`
   SQLite store and claim SQL.
@@ -29,7 +38,12 @@ exactly-once effect application under lease-expiry-during-IO).
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStageCommitExactlyOnce` | Run the green Stage-then-Commit replay-safety test |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStagedDoubleBroadcastCounterexample` | Demonstrate the unstable-broadcast double-broadcast bug |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStaleStageRegressesCounterexample` | Demonstrate the unfenced-stage checkpoint regression bug |
-| `go test ./p-models/durableactor/bridge` | Replay traces against Go |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressFoldNoLoss` | Run the green transactional ingress-fold no-loss test |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressEagerCursorCounterexample` | Demonstrate the eager-cursor-after-rollback message loss |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressCheckpointFirstCounterexample` | Demonstrate the checkpoint-before-enqueue message loss |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcOutboxFold` | Run the green transactional outbox-fold test |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcOutboxSplitWriteCounterexample` | Demonstrate the split-write lost-message bug |
+| `go test ./p-models/durableactor/bridge` | Replay traces and the outbox-fold/crash-restart bridge tests against Go |
 
 ## Modeling Guidance
 

--- a/p-models/durableactor/bridge/AGENTS.md
+++ b/p-models/durableactor/bridge/AGENTS.md
@@ -23,9 +23,34 @@ than the P checker.
   sorted by `TraceID`.
 - `ReplayMailboxTrace(t, trace)` — Replays a trace against a fresh SQLite
   `actordelivery` store in a temp dir. The `commit` op models the Read/Commit
-  fenced-ack pattern exactly: it runs `AckMessage` + `MarkProcessed` inside one
-  writer transaction, rolling back with `actor.ErrLeaseLost` when the ack row
-  count is zero.
+  consume step exactly: it runs the ack + `MarkProcessed` inside one writer
+  transaction, rolling back with `actor.ErrLeaseLost` when the ack row count is
+  zero. The ack op is chosen by lease token exactly as production `ackMessage`
+  routes it: a leased commit (`lease_token` set) acks under the lease fence via
+  `AckMessage`, while a leaseless commit (empty `lease_token`, the single-worker
+  peek path) acks via `AckMessageByID`. Both halves are trace-covered
+  (`mailbox_read_commit_fenced_exactly_once` and
+  `mailbox_leaseless_commit_fold`).
+
+## Direct bridge tests (not JSON-trace driven)
+
+Some contracts span a transaction boundary or a process restart and do not fit
+the per-op JSON replay model, so they are written as direct Go tests that drive
+the real store:
+
+- `outbox_fold_test.go` — the Go analog of the `tcOutboxFold` P scenario. It
+  runs `deliverMessage`'s fold (`EnqueueMessage` + `CompleteOutbox` inside one
+  `ExecTx`) against the real store and asserts the SQL-level contract: a fold
+  that fails after the enqueue rolls back with no orphan in the target mailbox
+  and the outbox row stays pending until claim expiry; a redelivery lands
+  exactly once; and a stale-token completion is a fenced 0-row no-op while the
+  idempotent (`ON CONFLICT id`) enqueue collapses a concurrent reclaim's
+  duplicate.
+- `crash_restart_test.go` — reopens a fresh `*sql.DB` and store against the same
+  on-disk SQLite file to model a process restart. It asserts a peeked-but-unacked
+  message survives a crash with attempts unchanged (peek is read-only), and a
+  leased-but-unacked message survives with its attempt bump durable and becomes
+  re-leasable after `ExpireLeases`.
 
 ## Relationships
 
@@ -38,9 +63,12 @@ than the P checker.
 
 - Every trace op that can fail hard uses `t.Fatal`; partial replays are not
   allowed to proceed silently.
-- The `commit` op is the sole site where `ExecTx`/`AckMessage`/`MarkProcessed`
-  are combined — it deliberately mirrors `execCore.commit` in `baselib/actor`
-  so the P model's commit-fence scenario stays tied to the real SQL path.
+- The `commit` op is the sole site where `ExecTx`/ack/`MarkProcessed` are
+  combined — it deliberately mirrors `execCore.commit` in `baselib/actor`,
+  routing the ack to `AckMessage` (leased) or `AckMessageByID` (leaseless,
+  empty token) exactly as production `ackMessage` does, so the P model's
+  commit-fence scenario stays tied to the real SQL path on both the leased and
+  leaseless single-worker consume.
 - Duplicate enqueue ops (`ExpectDuplicate: true`) must complete without error;
   a future rejection would fail here explicitly rather than at a later lease
   step.

--- a/sdk/walletdk/AGENTS.md
+++ b/sdk/walletdk/AGENTS.md
@@ -48,6 +48,19 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   on `View`, populates one of `Activity`/`VTXOs`/`Onchain`),
   `ActivityList`, `VTXOInventory`, `OnchainHistory`, `Entry`,
   `WalletVTXO`, `OnchainTx`.
+- `GetExitPlanRequest` / `GetExitPlanResult` / `ExitPlanEntry` —
+  batch exit-plan preview DTOs. `GetExitPlanRequest.Outpoints` is a
+  slice of outpoint strings; `ExitPlanEntry` carries per-outpoint
+  status including `FundingAddress`, `RequiredFeeUTXOCount`,
+  `UsableFeeUTXOCount`, `RecommendedTotalFundingSat`,
+  `FundingShortfallSat`, `CanStart`, `ExitStatus`, and a per-entry
+  `Err` string. Unknown or invalid outpoints set `Err` without
+  failing the whole batch.
+- `SweepWalletRequest` / `SweepWalletResult` / `WalletSweepInput` —
+  backing-wallet sweep DTOs. Request carries `DestinationAddress`,
+  `Broadcast bool`, `FeeRateSatPerVByte`, `ConfTarget`. Result
+  carries per-input `WalletSweepInput` slice, totals, fee rate,
+  `CanBroadcast`, `Txid` (populated when broadcast), `FailureReason`.
 - `ExitRequest` / `ExitResult` / `ExitStatusRequest` /
   `ExitStatusResult` / `ExitJobStatus` — exit DTOs. `ExitRequest`
   carries the target outpoint plus an optional on-chain `Destination`
@@ -83,6 +96,8 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
 | `List` | Unified history view (Activity / VTXOs / Onchain) as a tagged-union `ListResult`. |
 | `Exit` | Trigger cooperative leave or unilateral unroll for a VTXO. |
 | `ExitStatus` | Query the phase of an exit job. |
+| `GetExitPlan` | Batch preview of backing-wallet readiness for a set of VTXO outpoints; returns aggregate funding plan. |
+| `SweepWallet` | Preview or broadcast a sweep of confirmed backing-wallet UTXOs to a destination address. |
 | `Status` | Wallet readiness, balance, pending-entry count. |
 | `Subscribe` | Stream wallet activity (`Entry`) updates. |
 | `Stop` / `Close` | Shut down the embedded daemon, release the private transport. |

--- a/sdk/walletdk/CLAUDE.md
+++ b/sdk/walletdk/CLAUDE.md
@@ -48,6 +48,19 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   on `View`, populates one of `Activity`/`VTXOs`/`Onchain`),
   `ActivityList`, `VTXOInventory`, `OnchainHistory`, `Entry`,
   `WalletVTXO`, `OnchainTx`.
+- `GetExitPlanRequest` / `GetExitPlanResult` / `ExitPlanEntry` —
+  batch exit-plan preview DTOs. `GetExitPlanRequest.Outpoints` is a
+  slice of outpoint strings; `ExitPlanEntry` carries per-outpoint
+  status including `FundingAddress`, `RequiredFeeUTXOCount`,
+  `UsableFeeUTXOCount`, `RecommendedTotalFundingSat`,
+  `FundingShortfallSat`, `CanStart`, `ExitStatus`, and a per-entry
+  `Err` string. Unknown or invalid outpoints set `Err` without
+  failing the whole batch.
+- `SweepWalletRequest` / `SweepWalletResult` / `WalletSweepInput` —
+  backing-wallet sweep DTOs. Request carries `DestinationAddress`,
+  `Broadcast bool`, `FeeRateSatPerVByte`, `ConfTarget`. Result
+  carries per-input `WalletSweepInput` slice, totals, fee rate,
+  `CanBroadcast`, `Txid` (populated when broadcast), `FailureReason`.
 - `ExitRequest` / `ExitResult` / `ExitStatusRequest` /
   `ExitStatusResult` / `ExitJobStatus` — exit DTOs. `ExitRequest`
   carries the target outpoint plus an optional on-chain `Destination`
@@ -83,6 +96,8 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
 | `List` | Unified history view (Activity / VTXOs / Onchain) as a tagged-union `ListResult`. |
 | `Exit` | Trigger cooperative leave or unilateral unroll for a VTXO. |
 | `ExitStatus` | Query the phase of an exit job. |
+| `GetExitPlan` | Batch preview of backing-wallet readiness for a set of VTXO outpoints; returns aggregate funding plan. |
+| `SweepWallet` | Preview or broadcast a sweep of confirmed backing-wallet UTXOs to a destination address. |
 | `Status` | Wallet readiness, balance, pending-entry count. |
 | `Subscribe` | Stream wallet activity (`Entry`) updates. |
 | `Stop` / `Close` | Shut down the embedded daemon, release the private transport. |

--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -55,6 +55,17 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - `Config.BroadcastFailureAlertThreshold` — consecutive no-mempool
   failures before the operator escalation fires (default 3). Time to
   first alert ≈ threshold × `FeeBumpIntervalBlocks` blocks.
+- **Fee-input fanout FSM** (internal, driven by actor): when CPFP
+  broadcast fails with `ErrCPFPFeeInputUnavailable`, the actor drives
+  a long-lived `feeBumpStateMachine` (protofsm) that funds, signs, and
+  broadcasts a single fanout tx splitting one backing-wallet UTXO into
+  multiple fee inputs. The FSM persists across actor ticks; at most one
+  fanout is in flight per `TxBroadcasterActor`. Operational errors
+  (wallet failures, broadcast rejections) are stashed on
+  `feeBumpEnvironment` rather than returned, so transient failures
+  never tear down the long-lived FSM instance. The actor applies FSM
+  outbox events to register/unregister confirmation watches and to
+  retry stuck parents once the fanout confirms.
 
 ## Relationships
 
@@ -62,8 +73,8 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
   (confirmation watches, block epochs, broadcast, package submission,
   fee estimation, preflight), `wallet` (`Utxo`, `OutputLeaser`,
   `LockID`), `lib/tx/arktx` (`TxVersion` constant, `IsAnchorOutput`).
-- **Depended on by**: `unroll`, `btcwbackend` (fee-input selection
-  helper), `darepod`, `db`.
+- **Depended on by**: `unroll`, `wallet` (sweep submission path),
+  `btcwbackend` (fee-input selection helper), `darepod`, `db`.
 - **Sends → `chainsource`** (Ask): `BestHeightRequest`,
   `SubscribeBlocksRequest`, `RegisterConfRequest`,
   `UnregisterConfRequest`, `BroadcastTxRequest`,
@@ -79,6 +90,15 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 
 ## Invariants
 
+- **Fee-input fanout is actor-owned**: the `feeBumpStateMachine` FSM
+  is long-lived (one per `TxBroadcasterActor`, lazy-started) and
+  serialized by the actor loop. Only one fanout tx is in flight at a
+  time; the FSM transitions directly do their own wallet IO
+  (`FundPsbt`, `FinalizePsbt`, `LeaseOutput`) and broadcast
+  (`BroadcastTxRequest`). Errors are stashed on `feeBumpEnvironment`
+  rather than returned so the FSM stays alive across transient
+  failures. The actor reads `feeBumpEnv.takeLastErr()` after each
+  transition and logs it without aborting the FSM.
 - **Never give up on a no-mempool tx**: a tx whose broadcast reached no
   mempool stays in `Broadcasting` and is re-attempted every
   `FeeBumpIntervalBlocks`, never transitioning to terminal `Failed`. This

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -55,6 +55,17 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - `Config.BroadcastFailureAlertThreshold` — consecutive no-mempool
   failures before the operator escalation fires (default 3). Time to
   first alert ≈ threshold × `FeeBumpIntervalBlocks` blocks.
+- **Fee-input fanout FSM** (internal, driven by actor): when CPFP
+  broadcast fails with `ErrCPFPFeeInputUnavailable`, the actor drives
+  a long-lived `feeBumpStateMachine` (protofsm) that funds, signs, and
+  broadcasts a single fanout tx splitting one backing-wallet UTXO into
+  multiple fee inputs. The FSM persists across actor ticks; at most one
+  fanout is in flight per `TxBroadcasterActor`. Operational errors
+  (wallet failures, broadcast rejections) are stashed on
+  `feeBumpEnvironment` rather than returned, so transient failures
+  never tear down the long-lived FSM instance. The actor applies FSM
+  outbox events to register/unregister confirmation watches and to
+  retry stuck parents once the fanout confirms.
 
 ## Relationships
 
@@ -62,8 +73,8 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
   (confirmation watches, block epochs, broadcast, package submission,
   fee estimation, preflight), `wallet` (`Utxo`, `OutputLeaser`,
   `LockID`), `lib/tx/arktx` (`TxVersion` constant, `IsAnchorOutput`).
-- **Depended on by**: `unroll`, `btcwbackend` (fee-input selection
-  helper), `darepod`, `db`.
+- **Depended on by**: `unroll`, `wallet` (sweep submission path),
+  `btcwbackend` (fee-input selection helper), `darepod`, `db`.
 - **Sends → `chainsource`** (Ask): `BestHeightRequest`,
   `SubscribeBlocksRequest`, `RegisterConfRequest`,
   `UnregisterConfRequest`, `BroadcastTxRequest`,
@@ -79,6 +90,15 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 
 ## Invariants
 
+- **Fee-input fanout is actor-owned**: the `feeBumpStateMachine` FSM
+  is long-lived (one per `TxBroadcasterActor`, lazy-started) and
+  serialized by the actor loop. Only one fanout tx is in flight at a
+  time; the FSM transitions directly do their own wallet IO
+  (`FundPsbt`, `FinalizePsbt`, `LeaseOutput`) and broadcast
+  (`BroadcastTxRequest`). Errors are stashed on `feeBumpEnvironment`
+  rather than returned so the FSM stays alive across transient
+  failures. The actor reads `feeBumpEnv.takeLastErr()` after each
+  transition and logs it without aborting the FSM.
 - **Never give up on a no-mempool tx**: a tx whose broadcast reached no
   mempool stays in `Broadcasting` and is re-attempted every
   `FeeBumpIntervalBlocks`, never transitioning to terminal `Failed`. This

--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -28,7 +28,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
   `ChainSource`, `Wallet` (`SweepWallet`),
   `MaxSweepFeeRateSatPerVByte`, `FraudCheckpointSafetyMargin int32`
   (overrides the fraud-triggered unroll backstop margin in blocks;
-  zero falls back to the default), `RegistryRef`.
+  zero falls back to the default), `RegistryRef`,
+  `FeeInputFanoutCoordinator` (set by registry on every child;
+  the per-actor `FeeInputPlanner` wraps the shared coordinator).
 - `behavior` — actor behavior implementing `actor.TxBehavior[Msg, Resp,
   unrollTx]`. Holds `b.sweepTx` (restored from checkpoint on boot) so
   retries and replays converge on a single sweep txid / pkScript under
@@ -39,9 +41,21 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
   response, FSM event, and FSM outbox interfaces.
 - Mailbox messages: `StartUnrollRequest`, `ResumeUnrollRequest`,
   `HeightObservedMsg`, `TxConfirmedMsg`, `TxFailedMsg`,
-  `SpendObservedMsg`, `GetStateRequest`. Each ships a per-message TLV
-  codec (no JSON) with a pinned record-type layout; round-trips in
-  `messages_test.go`.
+  `SpendObservedMsg`, `GetStateRequest`, `FeeInputsAvailableMsg`.
+  Each ships a per-message TLV codec (no JSON) with a pinned
+  record-type layout; round-trips in `messages_test.go`.
+  `FeeInputsAvailableMsg` delivers a fanout-confirmation signal from
+  the registry's chainsource watch into the per-actor FSM.
+- FSM events: `FeeInputsAvailableEvent` — resumes an actor paused in
+  `AwaitingFeeInputFanout` after the fanout tx confirms.
+- FSM outbox event: `RequestFeeInputFanout` — emitted when the FSM
+  determines fee inputs are insufficient; routes to
+  `behavior.startFeeInputFanout()`, which asks the coordinator to
+  create or join an existing fanout and registers a chainsource
+  confirmation watch for it.
+- FSM state: `AwaitingFeeInputFanout` — non-terminal pause state. The
+  actor holds in this state until the `FeeInputFanoutCoordinator`
+  confirms the fanout and delivers `FeeInputsAvailableMsg`.
 - `StartTrigger` — `TriggerManual`, `TriggerCriticalExpiry`,
   `TriggerRestart`, `TriggerFraudSpend`.
 - `Phase` — control-plane phase: `PhasePending`,
@@ -60,10 +74,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
   `VTXOStore`, `TxConfirmRef`, `ChainSource`, `Wallet`,
   `MaxSweepFeeRateSatPerVByte`, `ExitSpendPolicyResolver` (optional;
   reconstructs the exit spend policy from `(ExitPolicyKind, ExitPolicyRef)`
-  after restart; nil means every child uses the standard VTXO timeout), and
+  after restart; nil means every child uses the standard VTXO timeout),
   optional `VTXOExitObserver`
-  (`fn.Option[actor.TellOnlyRef[vtxo.ManagerMsg]]`). When set, each child's
-  terminal outcome is forwarded to the VTXO manager as a
+  (`fn.Option[actor.TellOnlyRef[vtxo.ManagerMsg]]`), and optional
+  `FeeInputFanoutCoordinator *FeeInputFanoutCoordinator` (auto-created
+  by `NewUnrollRegistryActor` when the wallet implements
+  `txconfirm.Wallet`; forwarded to every spawned child). When set,
+  each child's terminal outcome is forwarded to the VTXO manager as a
   `vtxo.ExitOutcomeNotification` so VTXO lifecycle tracks the unroll's
   terminal on-chain result rather than the user's intent to exit
   (darepo-client#602): a clean failure (`!HadOnChainFootprint`) →
@@ -100,6 +117,27 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
 
 ### Support
 
+- `FeeInputFanoutCoordinator` — registry-scoped coordinator shared by
+  all child actors. Serializes demand from sibling children
+  (coalescing window: 500ms), maintains in-flight fanout state, and
+  ensures at most one fanout tx is created per window. Key methods:
+  `PlanFeeInputs()`, `PlanFeeInputsForChild()`, `EnsureFanout()`,
+  `MarkConfirmed()`. Auto-instantiated by `NewUnrollRegistryActor`
+  when the backing wallet implements `txconfirm.Wallet`.
+- `FeeInputPlanner` — interface with `PlanFeeInputs(ctx, ready)` used
+  by the per-actor FSM session. Implemented by a child-scoped adapter
+  wrapping `FeeInputFanoutCoordinator.PlanFeeInputsForChild`.
+- `FeeInputPlan` — result of a `PlanFeeInputs` call: `RequiredFeeInputsNow`,
+  `UsableFeeInputs`, `FanoutOutputsNeeded`,
+  `RecommendedFanoutOutputAmountSat`, `FanoutFundingShortfallSat`,
+  `PendingFanoutTxid`, `PendingFanoutPkScript`. `NeedsFanout()` method
+  returns true when the plan requires a new fanout before proceeding.
+- `ExitFundingSnapshot` / `ExitFundingPlan` / `PlanExitFunding()` —
+  exit-plan funding model. `PlanExitFunding` aggregates wallet fee-input
+  status across a set of VTXO targets and produces a per-target plan.
+- `ExitFundingAddressBook` — caches funding addresses per outpoint to
+  avoid advancing the wallet index on repeated `GetExitPlan` polls.
+- Constants: `RequiredFeeInputConfirmations` (1), `DefaultFeeInputMinAmountSat` (10,000 sat).
 - `LocalProofAssembler` — assembles a `recovery.Proof` from the VTXO
   descriptor and its OOR artifact lineage; implements
   `ProofAssembler`. Also exposes `EnsureProofForHarness`, a
@@ -154,7 +192,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
     the final sweep; txid dedup makes retries idempotent.
   - → `chainsource` (Ask): `RegisterSpendRequest` on the target
     outpoint to catch external spends, `BestHeightRequest`,
-    `FeeEstimateRequest`.
+    `FeeEstimateRequest`, `RegisterConfRequest` (for fanout tx watch
+    when `FeeInputFanoutCoordinator` is active),
+    `BroadcastTxRequest` (for fanout tx broadcast via coordinator).
   - → registry (Tell): `UnrollTerminatedMsg` from each child on
     terminal transition.
   - → `vtxo` (indirect via chain-resolver seam, #264).
@@ -170,7 +210,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
   - ← `txconfirm` subscriber: `TxConfirmed` / `TxFailed` mapped to
     `TxConfirmedMsg` / `TxFailedMsg`.
   - ← `chainsource` block epochs / spend notifications mapped to
-    `HeightObservedMsg` / `SpendObservedMsg`.
+    `HeightObservedMsg` / `SpendObservedMsg`; fanout confirmation
+    mapped to `FeeInputsAvailableMsg` (delivered by registry to child
+    after `FeeInputFanoutCoordinator.MarkConfirmed`).
 
 ## Multi-Tree Ancestry
 
@@ -189,6 +231,14 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
 
 ## Invariants
 
+- **Fee-input fanout is registry-singleton.** The
+  `FeeInputFanoutCoordinator` is shared by all sibling
+  `VTXOUnrollActor`s within a registry. Sibling demand is coalesced
+  over a 500ms window; the first child to call `EnsureFanout`
+  broadcasts the fanout tx, and subsequent siblings await that same
+  tx. The actor pauses in `AwaitingFeeInputFanout` until the registry
+  delivers `FeeInputsAvailableMsg` after the fanout confirms. This
+  prevents N concurrent actors from each creating their own fanout tx.
 - **Persist-before-broadcast.** `startSweep` calls
   `persistCheckpoint` (writing `b.sweepTx` into the TLV checkpoint)
   BEFORE `txconfirm.Ask`. Any handler retry or restart restores the

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -28,7 +28,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
   `ChainSource`, `Wallet` (`SweepWallet`),
   `MaxSweepFeeRateSatPerVByte`, `FraudCheckpointSafetyMargin int32`
   (overrides the fraud-triggered unroll backstop margin in blocks;
-  zero falls back to the default), `RegistryRef`.
+  zero falls back to the default), `RegistryRef`,
+  `FeeInputFanoutCoordinator` (set by registry on every child;
+  the per-actor `FeeInputPlanner` wraps the shared coordinator).
 - `behavior` — actor behavior implementing `actor.TxBehavior[Msg, Resp,
   unrollTx]`. Holds `b.sweepTx` (restored from checkpoint on boot) so
   retries and replays converge on a single sweep txid / pkScript under
@@ -39,9 +41,21 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
   response, FSM event, and FSM outbox interfaces.
 - Mailbox messages: `StartUnrollRequest`, `ResumeUnrollRequest`,
   `HeightObservedMsg`, `TxConfirmedMsg`, `TxFailedMsg`,
-  `SpendObservedMsg`, `GetStateRequest`. Each ships a per-message TLV
-  codec (no JSON) with a pinned record-type layout; round-trips in
-  `messages_test.go`.
+  `SpendObservedMsg`, `GetStateRequest`, `FeeInputsAvailableMsg`.
+  Each ships a per-message TLV codec (no JSON) with a pinned
+  record-type layout; round-trips in `messages_test.go`.
+  `FeeInputsAvailableMsg` delivers a fanout-confirmation signal from
+  the registry's chainsource watch into the per-actor FSM.
+- FSM events: `FeeInputsAvailableEvent` — resumes an actor paused in
+  `AwaitingFeeInputFanout` after the fanout tx confirms.
+- FSM outbox event: `RequestFeeInputFanout` — emitted when the FSM
+  determines fee inputs are insufficient; routes to
+  `behavior.startFeeInputFanout()`, which asks the coordinator to
+  create or join an existing fanout and registers a chainsource
+  confirmation watch for it.
+- FSM state: `AwaitingFeeInputFanout` — non-terminal pause state. The
+  actor holds in this state until the `FeeInputFanoutCoordinator`
+  confirms the fanout and delivers `FeeInputsAvailableMsg`.
 - `StartTrigger` — `TriggerManual`, `TriggerCriticalExpiry`,
   `TriggerRestart`, `TriggerFraudSpend`.
 - `Phase` — control-plane phase: `PhasePending`,
@@ -60,10 +74,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
   `VTXOStore`, `TxConfirmRef`, `ChainSource`, `Wallet`,
   `MaxSweepFeeRateSatPerVByte`, `ExitSpendPolicyResolver` (optional;
   reconstructs the exit spend policy from `(ExitPolicyKind, ExitPolicyRef)`
-  after restart; nil means every child uses the standard VTXO timeout), and
+  after restart; nil means every child uses the standard VTXO timeout),
   optional `VTXOExitObserver`
-  (`fn.Option[actor.TellOnlyRef[vtxo.ManagerMsg]]`). When set, each child's
-  terminal outcome is forwarded to the VTXO manager as a
+  (`fn.Option[actor.TellOnlyRef[vtxo.ManagerMsg]]`), and optional
+  `FeeInputFanoutCoordinator *FeeInputFanoutCoordinator` (auto-created
+  by `NewUnrollRegistryActor` when the wallet implements
+  `txconfirm.Wallet`; forwarded to every spawned child). When set,
+  each child's terminal outcome is forwarded to the VTXO manager as a
   `vtxo.ExitOutcomeNotification` so VTXO lifecycle tracks the unroll's
   terminal on-chain result rather than the user's intent to exit
   (darepo-client#602): a clean failure (`!HadOnChainFootprint`) →
@@ -100,6 +117,27 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
 
 ### Support
 
+- `FeeInputFanoutCoordinator` — registry-scoped coordinator shared by
+  all child actors. Serializes demand from sibling children
+  (coalescing window: 500ms), maintains in-flight fanout state, and
+  ensures at most one fanout tx is created per window. Key methods:
+  `PlanFeeInputs()`, `PlanFeeInputsForChild()`, `EnsureFanout()`,
+  `MarkConfirmed()`. Auto-instantiated by `NewUnrollRegistryActor`
+  when the backing wallet implements `txconfirm.Wallet`.
+- `FeeInputPlanner` — interface with `PlanFeeInputs(ctx, ready)` used
+  by the per-actor FSM session. Implemented by a child-scoped adapter
+  wrapping `FeeInputFanoutCoordinator.PlanFeeInputsForChild`.
+- `FeeInputPlan` — result of a `PlanFeeInputs` call: `RequiredFeeInputsNow`,
+  `UsableFeeInputs`, `FanoutOutputsNeeded`,
+  `RecommendedFanoutOutputAmountSat`, `FanoutFundingShortfallSat`,
+  `PendingFanoutTxid`, `PendingFanoutPkScript`. `NeedsFanout()` method
+  returns true when the plan requires a new fanout before proceeding.
+- `ExitFundingSnapshot` / `ExitFundingPlan` / `PlanExitFunding()` —
+  exit-plan funding model. `PlanExitFunding` aggregates wallet fee-input
+  status across a set of VTXO targets and produces a per-target plan.
+- `ExitFundingAddressBook` — caches funding addresses per outpoint to
+  avoid advancing the wallet index on repeated `GetExitPlan` polls.
+- Constants: `RequiredFeeInputConfirmations` (1), `DefaultFeeInputMinAmountSat` (10,000 sat).
 - `LocalProofAssembler` — assembles a `recovery.Proof` from the VTXO
   descriptor and its OOR artifact lineage; implements
   `ProofAssembler`. Also exposes `EnsureProofForHarness`, a
@@ -154,7 +192,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
     the final sweep; txid dedup makes retries idempotent.
   - → `chainsource` (Ask): `RegisterSpendRequest` on the target
     outpoint to catch external spends, `BestHeightRequest`,
-    `FeeEstimateRequest`.
+    `FeeEstimateRequest`, `RegisterConfRequest` (for fanout tx watch
+    when `FeeInputFanoutCoordinator` is active),
+    `BroadcastTxRequest` (for fanout tx broadcast via coordinator).
   - → registry (Tell): `UnrollTerminatedMsg` from each child on
     terminal transition.
   - → `vtxo` (indirect via chain-resolver seam, #264).
@@ -170,7 +210,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
   - ← `txconfirm` subscriber: `TxConfirmed` / `TxFailed` mapped to
     `TxConfirmedMsg` / `TxFailedMsg`.
   - ← `chainsource` block epochs / spend notifications mapped to
-    `HeightObservedMsg` / `SpendObservedMsg`.
+    `HeightObservedMsg` / `SpendObservedMsg`; fanout confirmation
+    mapped to `FeeInputsAvailableMsg` (delivered by registry to child
+    after `FeeInputFanoutCoordinator.MarkConfirmed`).
 
 ## Multi-Tree Ancestry
 
@@ -189,6 +231,14 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
 
 ## Invariants
 
+- **Fee-input fanout is registry-singleton.** The
+  `FeeInputFanoutCoordinator` is shared by all sibling
+  `VTXOUnrollActor`s within a registry. Sibling demand is coalesced
+  over a 500ms window; the first child to call `EnsureFanout`
+  broadcasts the fanout tx, and subsequent siblings await that same
+  tx. The actor pauses in `AwaitingFeeInputFanout` until the registry
+  delivers `FeeInputsAvailableMsg` after the fanout confirms. This
+  prevents N concurrent actors from each creating their own fanout tx.
 - **Persist-before-broadcast.** `startSweep` calls
   `persistCheckpoint` (writing `b.sweepTx` into the TLV checkpoint)
   BEFORE `txconfirm.Ask`. Any handler retry or restart restores the

--- a/wallet/AGENTS.md
+++ b/wallet/AGENTS.md
@@ -17,7 +17,12 @@ refresh, leave, OOR spend, and directed send flows.
 - `OutputLeaser` — Interface for UTXO output leasing: `LeaseOutput(ctx, outpoint, lockID, expiry)` and `ReleaseOutput(ctx, outpoint, lockID)`. Implemented by all three `BoardingBackend` implementations (`btcwbackend`, `lndbackend`, `lwwallet`) to coordinate cross-subsystem UTXO reservation.
 - `BoardingBackend` — Interface for wallet integration (key derivation, taproot import, ListUnspent). `GetTransaction` returns `*TxInfo` (containing tx, block hash, and block height).
 - `TxInfo` — Struct wrapping a confirmed transaction with its block hash and block height. Returned by `BoardingBackend.GetTransaction`.
-- `BoardingStore` — Interface for persisting boarding addresses and intents.
+- `BoardingStore` — Interface for persisting boarding addresses and intents. Embeds `PendingIntentStore`.
+- `PendingIntent` / `PendingIntentKind` / `PendingIntentID` / `PendingIntentPayload` / `PendingIntentStore` — the generic restart-safe intent outbox (`pending_intent.go`). `Payload` is a sealed `PendingIntentPayload` interface holding the concrete kind-specific struct (not bytes); the db layer stores its fields as typed columns. An intent is persisted BEFORE its round-actor publish, anchored to the outpoints the round consumes on adoption (confirmed boarding outpoints for `board`, reserved forfeit outpoints for `send_onchain`); the round checkpoint clears anchors transactionally. `NewPendingIntentID(payload, anchors)` derives the idempotency key as `sha256(kind ‖ sorted anchors ‖ payload-canonical-digest)`.
+- `PendingIntentReplayer` — per-kind replay strategy registered on the `Ark` actor (`intentReplayers`). `boardIntentReplayer` reconciles anchors against still-Confirmed boarding intents and self-Tells one `BoardRequest`; `sendOnChainIntentReplayer` self-Tells one `ReplaySendOnChainIntent` per persisted intent, whose handler re-reserves the EXACT anchors (never re-running selection), rebuilds the package via `buildSendOnChainIntentPackage`, and registers with `TriggerRegistration=true`. A reservation failure marks a send intent stale and deletes it.
+- `BoardIntentPayload` / `SendOnChainIntentPayload` — concrete `PendingIntentPayload` implementations (`pending_intent.go`); each contributes a deterministic `writeIDDigest` field encoding (for the intent ID only) and is stored as typed columns by the db layer.
+- `ReplayPendingIntentsRequest` / `ReplayPendingIntentsResponse` — daemon startup Ask that walks the replayer registry once every dependent actor is on the receptionist (replaces the Board-only `ReplayPendingBoardRequest`).
+- `ReplaySendOnChainIntent` — internal self-Tell carrying one persisted send intent from the replay pass into the wallet mailbox.
 - `VTXOReader` — Read-only interface for loading VTXO descriptors by outpoint. Wallet uses this to build intent packages without importing `vtxo` directly.
 - `VTXODescriptor` — Wallet-level VTXO descriptor (outpoint, amount, pkscript, tree, expiry). Avoids direct dependency on `vtxo.Descriptor`.
 - `SelectedVTXO` — Describes a VTXO selected and locked for use as a transfer input (outpoint, amount, pkscript). Breaks the vtxo → round → wallet import cycle.
@@ -34,6 +39,28 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendRecipient` — Describes a single directed send destination (pkscript, amount, recipient client key).
 - `SendVTXOsRequest` / `SendVTXOsResponse` — Ask-request for in-round directed sends. Validates each recipient amount is within `(0, MaxSatoshi]` and that the running total never overflows `int64`, atomically selects and reserves VTXOs via `SelectAndReserveForfeitRequest`, builds forfeit + recipient VTXO intents, and registers with the round actor. Supports dry-run mode for previewing coin selection without committing. Reserved VTXOs are released via a deferred cleanup that uses `context.WithoutCancel` so cleanup survives caller disconnect; on success, a `committed` flag is set to skip the release.
 - `SendOnChainRequest` — Ask-request to plan and submit an atomic on-chain payment from VTXOs. Supports two modes: bounded send (`TargetAmountSat` > 0, empty `SweepOutpoints`) and sweep-all (`SweepOutpoints` non-empty). Bounded mode selects VTXOs with headroom for `OperatorFee + DustLimit` and creates a change VTXO. Sweep-all drains the exact outpoints to the destination with no change. Supports `DryRun` mode.
+- `SweepWalletFundsRequest` / `SweepWalletFundsResponse` — Ask-request
+  for a general backing-wallet sweep (all confirmed UTXOs → destination
+  address). Fee rate is always capped at the operator-configured max or
+  100 sat/vByte. Supports dry-run (preview without broadcast) and
+  `Broadcast` mode. The sweep is submitted through `txconfirm` for
+  durable CPFP and confirmation tracking. Per-input details are returned
+  as `WalletSweepInputInfo`.
+- `WalletSweepTxNotification` — Tell from `txconfirm` subscriber
+  delivering `TxConfirmed` / `TxFailed` terminal events for backing-wallet
+  sweeps. Mapped via `MapNotification` on the subscriber.
+- `WalletSweepNotificationAck` — No-op ack for the Tell semantics.
+- `WalletBackingSweeper` — Narrow interface the actor requires from the
+  backing wallet for sweep operations: `ListUnspent`, `FinalizePsbt`,
+  `LeaseOutput`, `ReleaseOutput`.
+- `WithWalletSweep(backing WalletBackingSweeper, maxFeeRateSatPerVByte int64)` —
+  Option that wires the backing-wallet sweep subsystem into the actor.
+  Without this option, `SweepWalletFundsRequest` returns an error.
+- `submitSweepToConfirm(ctx, tx, pkScript, heightHint, label, subscriber)` —
+  Shared internal helper used by both the boarding-sweep and
+  backing-wallet-sweep paths to submit a signed tx to `txconfirm`. Handles
+  `EnsureConfirmedReq`, `LookupRef`, and the synchronous `TxStateFailed`
+  guard in one place.
 - `SendOnChainResponse` — Response to `SendOnChainRequest` carrying the selected outpoints, total amount, operator fee, and leave output details.
 - `SendOnChainStatus` — Terminal outcome enum: `SendOnChainStatusSubmitted` (intent queued for next round), `SendOnChainStatusDryRun` (dry-run preview, no commitment).
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
@@ -41,8 +68,13 @@ refresh, leave, OOR spend, and directed send flows.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants).
-- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block
+  epoch notifications), `lib/actormsg` (VTXO manager admission types),
+  `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` /
+  `ClassificationDeposit` constants), `txconfirm` (sweep submission,
+  durable broadcast + confirmation via `submitSweepToConfirm`).
+- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`,
+  `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
   - → `round` (via `lib/actormsg`): `TriggerBoardMsg` (VTXO amounts for
@@ -56,7 +88,9 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `SendOnChainRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `SendOnChainRequest`, `SweepWalletFundsRequest`
+  - ← `txconfirm` subscriber (Tell): `WalletSweepTxNotification`
+    (terminal outcome for backing-wallet sweeps)
 
 ## Invariants
 
@@ -64,6 +98,7 @@ refresh, leave, OOR spend, and directed send flows.
 - `ListUnspent` runs at most once per tip-tick against the latest known chain tip; a backend whose UTXO reporting lags past one tick interval surfaces the missing UTXO on the next chain advance (whichever tick processes the new tip re-runs the scan). The per-block path no longer carries an inline retry budget — the tick loop is the retry seam.
 - Notifier registration captures `minConf` parameter per actor; different actors can require different confirmation depths.
 - Cooperative admission (refresh/leave) must reserve forfeit inputs through the VTXO manager before sending `RegisterIntentMsg` to the round actor.
+- Persist-before-publish: `handleBoard` and `handleSendOnChain` write their pending intent to the outbox BEFORE the round-actor publish, so every crash window either leaves no row (clean retry) or a replayable row. `handleSendOnChain` deletes the row when registration fails synchronously — the caller saw an error, so the send must not silently resurrect on the next start.
 - `WithEagerRoundJoin(true)` opts the wallet into "drive round-joining without a second RPC" semantics. Two sites change: `handleBlockEpoch` inline-calls `handleBoard` after at least one new boarding UTXO confirms in the block (one `TriggerBoardMsg` per block, not per UTXO), and `handleLeaveVTXOs` forwards its `RegisterIntentMsg` with `TriggerRegistration=true` so the leave moves the round FSM out of `PendingRoundAssembly` immediately. Default off preserves the operator-driven batched semantics that `darepocli` and server hosts rely on; `sdk/walletdk` flips it on via `darepod.Config.EagerRoundJoin` for wallet-shaped SDK hosts.
 - If round registration fails after successful admission, the wallet releases the forfeit reservation so VTXOs return to LiveState.
 - Directed sends use `SelectAndReserveForfeitRequest` (cooperative forfeit path) rather than the OOR spend path. The wallet builds recipient VTXOs with the recipient's key as `OwnerKey` and derives a separate ephemeral `SigningKey` for MuSig2 tree construction.

--- a/wallet/CLAUDE.md
+++ b/wallet/CLAUDE.md
@@ -39,6 +39,28 @@ refresh, leave, OOR spend, and directed send flows.
 - `SendRecipient` — Describes a single directed send destination (pkscript, amount, recipient client key).
 - `SendVTXOsRequest` / `SendVTXOsResponse` — Ask-request for in-round directed sends. Validates each recipient amount is within `(0, MaxSatoshi]` and that the running total never overflows `int64`, atomically selects and reserves VTXOs via `SelectAndReserveForfeitRequest`, builds forfeit + recipient VTXO intents, and registers with the round actor. Supports dry-run mode for previewing coin selection without committing. Reserved VTXOs are released via a deferred cleanup that uses `context.WithoutCancel` so cleanup survives caller disconnect; on success, a `committed` flag is set to skip the release.
 - `SendOnChainRequest` — Ask-request to plan and submit an atomic on-chain payment from VTXOs. Supports two modes: bounded send (`TargetAmountSat` > 0, empty `SweepOutpoints`) and sweep-all (`SweepOutpoints` non-empty). Bounded mode selects VTXOs with headroom for `OperatorFee + DustLimit` and creates a change VTXO. Sweep-all drains the exact outpoints to the destination with no change. Supports `DryRun` mode.
+- `SweepWalletFundsRequest` / `SweepWalletFundsResponse` — Ask-request
+  for a general backing-wallet sweep (all confirmed UTXOs → destination
+  address). Fee rate is always capped at the operator-configured max or
+  100 sat/vByte. Supports dry-run (preview without broadcast) and
+  `Broadcast` mode. The sweep is submitted through `txconfirm` for
+  durable CPFP and confirmation tracking. Per-input details are returned
+  as `WalletSweepInputInfo`.
+- `WalletSweepTxNotification` — Tell from `txconfirm` subscriber
+  delivering `TxConfirmed` / `TxFailed` terminal events for backing-wallet
+  sweeps. Mapped via `MapNotification` on the subscriber.
+- `WalletSweepNotificationAck` — No-op ack for the Tell semantics.
+- `WalletBackingSweeper` — Narrow interface the actor requires from the
+  backing wallet for sweep operations: `ListUnspent`, `FinalizePsbt`,
+  `LeaseOutput`, `ReleaseOutput`.
+- `WithWalletSweep(backing WalletBackingSweeper, maxFeeRateSatPerVByte int64)` —
+  Option that wires the backing-wallet sweep subsystem into the actor.
+  Without this option, `SweepWalletFundsRequest` returns an error.
+- `submitSweepToConfirm(ctx, tx, pkScript, heightHint, label, subscriber)` —
+  Shared internal helper used by both the boarding-sweep and
+  backing-wallet-sweep paths to submit a signed tx to `txconfirm`. Handles
+  `EnsureConfirmedReq`, `LookupRef`, and the synchronous `TxStateFailed`
+  guard in one place.
 - `SendOnChainResponse` — Response to `SendOnChainRequest` carrying the selected outpoints, total amount, operator fee, and leave output details.
 - `SendOnChainStatus` — Terminal outcome enum: `SendOnChainStatusSubmitted` (intent queued for next round), `SendOnChainStatusDryRun` (dry-run preview, no commitment).
 - `GetConfirmedBoardingIntentsRequest` / `GetConfirmedBoardingIntentsResponse` — Ask-request to retrieve currently confirmed boarding intents (used by the RPC/CLI layer to report boarding balance with policy metadata).
@@ -46,8 +68,13 @@ refresh, leave, OOR spend, and directed send flows.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (actor system), `chainsource` (block epoch notifications), `lib/actormsg` (VTXO manager admission types), `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` / `ClassificationDeposit` constants).
-- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`, `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
+- **Depends on**: `baselib/actor` (actor system), `chainsource` (block
+  epoch notifications), `lib/actormsg` (VTXO manager admission types),
+  `ledger` (`Sink` alias for emission + `UTXOCreatedMsg` /
+  `ClassificationDeposit` constants), `txconfirm` (sweep submission,
+  durable broadcast + confirmation via `submitSweepToConfirm`).
+- **Depended on by**: `round` (boarding intents, types: `BoardingAddress`,
+  `SelectedVTXO`), `db` (persistence), `darepod` (wiring).
 - **Sends**:
   - → `round` (via registered notifier): `BoardingUtxoConfirmedEvent`
   - → `round` (via `lib/actormsg`): `TriggerBoardMsg` (VTXO amounts for
@@ -61,7 +88,9 @@ refresh, leave, OOR spend, and directed send flows.
 - **Receives**:
   - ← `chainsource`: `BlockEpochNotification` (triggers UTXO polling)
   - ← `round`: `RegisterConfirmationNotifierRequest`, `UnregisterConfirmationNotifierRequest`
-  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `SendOnChainRequest`
+  - ← API: `CreateBoardingAddressRequest`, `GetActiveBoardingAddressesRequest`, `GetBoardingBalanceRequest`, `GetConfirmedBoardingIntentsRequest`, `RefreshVTXOsRequest`, `SelectAndLockVTXOsRequest`, `LeaveVTXOsRequest`, `BoardRequest`, `CompleteSpendVTXOsRequest`, `UnlockVTXOsRequest`, `SendVTXOsRequest`, `SendOnChainRequest`, `SweepWalletFundsRequest`
+  - ← `txconfirm` subscriber (Tell): `WalletSweepTxNotification`
+    (terminal outcome for backing-wallet sweeps)
 
 ## Invariants
 


### PR DESCRIPTION
Automated nightly documentation sweep for 2026-06-23.

## What changed

- **txconfirm**: documents the new fee-input fanout FSM (`feeBumpStateMachine`) that replaced the removed `FeeBumpInputController`; adds invariants for long-lived FSM lifetime and error-stashing semantics.
- **wallet**: adds `SweepWalletFundsRequest/Response`, `WalletSweepTxNotification`, `WalletBackingSweeper`, `WithWalletSweep`, and the shared `submitSweepToConfirm` path.
- **unroll**: adds `FeeInputFanoutCoordinator`, `FeeInputPlanner`, `FeeInputPlan`, `AwaitingFeeInputFanout` state, `FeeInputsAvailableMsg/Event`, `RequestFeeInputFanout`, `ExitFundingSnapshot/Plan`, `ExitFundingAddressBook`, and a fanout invariant.
- **darepod**: adds `SweepWallet` (thin wallet-actor shim) and `GetExitPlan` (batch preview with running wallet allocation) RPC handler docs.
- **sdk/walletdk**: adds `GetExitPlan` and `SweepWallet` methods and their DTOs.
- **coinselect** (new): creates `CLAUDE.md`/`AGENTS.md` for the coin-type-agnostic largest-first selector.
- **AGENTS.md sync**: `baselib/actor`, `db`, `db/actordelivery`, `p-models/durableactor`, `p-models/durableactor/bridge` — synced `AGENTS.md` to match `CLAUDE.md` updated in earlier commits since the last sweep.
- **ARCHITECTURE.md**: adds `coinselect` to the Layer 1 table.

Please review the diffs for `CLAUDE.md`/`AGENTS.md` in the packages above and `ARCHITECTURE.md` to verify accuracy.
