### PR TITLE
rpc: expose min VTXO amount in GetInfo

### DIFF
--- a/arkrpc/ark.pb.go
+++ b/arkrpc/ark.pb.go
@@ -104,8 +104,12 @@ type GetInfoResponse struct {
 	// cap pre-submit to avoid round-trip rejections; a value of 0 means
 	// the operator does not enforce a cap.
 	MaxOorLineageVbytes uint32 `protobuf:"varint,18,opt,name=max_oor_lineage_vbytes,json=maxOorLineageVbytes,proto3" json:"max_oor_lineage_vbytes,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// The operator-advertised minimum VTXO output amount in satoshis.
+	// Clients can use this wallet-facing floor to decide whether an
+	// amount can materialize as a VTXO or must use a different rail.
+	MinVtxoAmountSat int64 `protobuf:"varint,19,opt,name=min_vtxo_amount_sat,json=minVtxoAmountSat,proto3" json:"min_vtxo_amount_sat,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *GetInfoResponse) Reset() {
@@ -239,6 +243,13 @@ func (x *GetInfoResponse) GetBaseMarginSat() int64 {
 func (x *GetInfoResponse) GetMaxOorLineageVbytes() uint32 {
 	if x != nil {
 		return x.MaxOorLineageVbytes
+	}
+	return 0
+}
+
+func (x *GetInfoResponse) GetMinVtxoAmountSat() int64 {
+	if x != nil {
+		return x.MinVtxoAmountSat
 	}
 	return 0
 }
@@ -421,7 +432,7 @@ var File_ark_proto protoreflect.FileDescriptor
 const file_ark_proto_rawDesc = "" +
 	"\n" +
 	"\tark.proto\x12\x06arkrpc\"\x10\n" +
-	"\x0eGetInfoRequest\"\xc7\x04\n" +
+	"\x0eGetInfoRequest\"\xf6\x04\n" +
 	"\x0fGetInfoResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x16\n" +
 	"\x06pubkey\x18\x02 \x01(\fR\x06pubkey\x12\x18\n" +
@@ -440,7 +451,8 @@ const file_ark_proto_rawDesc = "" +
 	"\vannual_rate\x18\x10 \x01(\x01R\n" +
 	"annualRate\x12&\n" +
 	"\x0fbase_margin_sat\x18\x11 \x01(\x03R\rbaseMarginSat\x123\n" +
-	"\x16max_oor_lineage_vbytes\x18\x12 \x01(\rR\x13maxOorLineageVbytes\"\x7f\n" +
+	"\x16max_oor_lineage_vbytes\x18\x12 \x01(\rR\x13maxOorLineageVbytes\x12-\n" +
+	"\x13min_vtxo_amount_sat\x18\x13 \x01(\x03R\x10minVtxoAmountSat\"\x7f\n" +
 	"\x12EstimateFeeRequest\x12\x1d\n" +
 	"\n" +
 	"amount_sat\x18\x01 \x01(\x03R\tamountSat\x12\x1f\n" +

--- a/arkrpc/ark.proto
+++ b/arkrpc/ark.proto
@@ -81,6 +81,11 @@ message GetInfoResponse {
     // cap pre-submit to avoid round-trip rejections; a value of 0 means
     // the operator does not enforce a cap.
     uint32 max_oor_lineage_vbytes = 18;
+
+    // The operator-advertised minimum VTXO output amount in satoshis.
+    // Clients can use this wallet-facing floor to decide whether an
+    // amount can materialize as a VTXO or must use a different rail.
+    int64 min_vtxo_amount_sat = 19;
 }
 
 // EstimateFeeRequest asks the server to estimate the fee for a

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -904,6 +904,11 @@ type ServerInfo struct {
 	// min_confirmations is the minimum confirmations required on
 	// boarding inputs.
 	MinConfirmations uint32 `protobuf:"varint,12,opt,name=min_confirmations,json=minConfirmations,proto3" json:"min_confirmations,omitempty"`
+	// min_vtxo_amount_sat is the operator-advertised minimum VTXO
+	// output amount in satoshis. Callers can use this wallet-facing
+	// floor to decide whether an amount can materialize as a VTXO or
+	// must use a different rail.
+	MinVtxoAmountSat uint64 `protobuf:"varint,13,opt,name=min_vtxo_amount_sat,json=minVtxoAmountSat,proto3" json:"min_vtxo_amount_sat,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -997,6 +1002,13 @@ func (x *ServerInfo) GetMinOperatorFee() uint64 {
 func (x *ServerInfo) GetMinConfirmations() uint32 {
 	if x != nil {
 		return x.MinConfirmations
+	}
+	return 0
+}
+
+func (x *ServerInfo) GetMinVtxoAmountSat() uint64 {
+	if x != nil {
+		return x.MinVtxoAmountSat
 	}
 	return 0
 }
@@ -7910,7 +7922,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0fidentity_pubkey\x18\n" +
 	" \x01(\tR\x0eidentityPubkey\x126\n" +
 	"\vserver_info\x18\v \x01(\v2\x15.daemonrpc.ServerInfoR\n" +
-	"serverInfo\"\xfe\x02\n" +
+	"serverInfo\"\xad\x03\n" +
 	"\n" +
 	"ServerInfo\x12'\n" +
 	"\x0foperator_pubkey\x18\x01 \x01(\fR\x0eoperatorPubkey\x12.\n" +
@@ -7923,7 +7935,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\bfee_rate\x18\n" +
 	" \x01(\x04R\afeeRate\x12(\n" +
 	"\x10min_operator_fee\x18\v \x01(\x04R\x0eminOperatorFee\x12+\n" +
-	"\x11min_confirmations\x18\f \x01(\rR\x10minConfirmations\"9\n" +
+	"\x11min_confirmations\x18\f \x01(\rR\x10minConfirmations\x12-\n" +
+	"\x13min_vtxo_amount_sat\x18\r \x01(\x04R\x10minVtxoAmountSat\"9\n" +
 	"\x0eGenSeedRequest\x12'\n" +
 	"\x0fseed_passphrase\x18\x01 \x01(\fR\x0eseedPassphrase\"V\n" +
 	"\x0fGenSeedResponse\x12\x1a\n" +

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -345,6 +345,12 @@ message ServerInfo {
     // min_confirmations is the minimum confirmations required on
     // boarding inputs.
     uint32 min_confirmations = 12;
+
+    // min_vtxo_amount_sat is the operator-advertised minimum VTXO
+    // output amount in satoshis. Callers can use this wallet-facing
+    // floor to decide whether an amount can materialize as a VTXO or
+    // must use a different rail.
+    uint64 min_vtxo_amount_sat = 13;
 }
 
 message GenSeedRequest {

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -616,6 +616,11 @@ func (r *RPCServer) GetInfo(ctx context.Context, _ *daemonrpc.GetInfoRequest) (
 			return resp, nil
 		}
 
+		minVTXOAmount := terms.MinVTXOAmount
+		if minVTXOAmount == 0 {
+			minVTXOAmount = terms.DustLimit
+		}
+
 		// The forfeit penalty key, sweep key and delay are no longer
 		// global operator terms; they are delivered per round in the
 		// round batch info, so they are not surfaced on this
@@ -630,6 +635,7 @@ func (r *RPCServer) GetInfo(ctx context.Context, _ *daemonrpc.GetInfoRequest) (
 			FeeRate:           uint64(terms.FeeRate),
 			MinOperatorFee:    uint64(terms.MinOperatorFee),
 			MinConfirmations:  terms.MinConfirmations,
+			MinVtxoAmountSat:  uint64(minVTXOAmount),
 		}
 	}
 

--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -947,6 +947,7 @@ func TestGetInfoIncludesServerInfo(t *testing.T) {
 		BoardingExitDelay: 144,
 		VTXOExitDelay:     288,
 		DustLimit:         btcutil.Amount(546),
+		MinVTXOAmount:     btcutil.Amount(1234),
 		MinBoardingAmount: btcutil.Amount(10_000),
 		MaxBoardingAmount: btcutil.Amount(500_000),
 		FeeRate:           btcutil.Amount(12),
@@ -968,6 +969,7 @@ func TestGetInfoIncludesServerInfo(t *testing.T) {
 	require.Equal(t, uint32(144), resp.ServerInfo.BoardingExitDelay)
 	require.Equal(t, uint32(288), resp.ServerInfo.VtxoExitDelay)
 	require.Equal(t, uint64(546), resp.ServerInfo.DustLimit)
+	require.Equal(t, uint64(1234), resp.ServerInfo.MinVtxoAmountSat)
 	require.Equal(t, uint64(10_000),
 		resp.ServerInfo.MinBoardingAmount,
 	)
@@ -1007,6 +1009,7 @@ func TestOperatorPubKeyFetchesFreshTerms(t *testing.T) {
 				BoardingExitDelay:   144,
 				VtxoExitDelay:       288,
 				DustLimit:           546,
+				MinVtxoAmountSat:    1234,
 				MinBoardingAmount:   10_000,
 				MaxBoardingAmount:   500_000,
 				FeeRate:             12,
@@ -1032,6 +1035,13 @@ func TestOperatorPubKeyFetchesFreshTerms(t *testing.T) {
 	require.Equal(
 		t, freshPriv.PubKey().SerializeCompressed(),
 		info.GetServerInfo().GetOperatorPubkey(),
+	)
+	require.Equal(
+		t, uint64(1234), info.GetServerInfo().GetMinVtxoAmountSat(),
+	)
+	require.Equal(
+		t, btcutil.Amount(1234),
+		server.loadOperatorTerms().MinVTXOAmount,
 	)
 	require.Equal(
 		t, uint32(99), server.loadOperatorTerms().MaxOORLineageVBytes,

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -4030,6 +4030,11 @@ func (s *Server) fetchOperatorTerms(ctx context.Context) (*types.OperatorTerms,
 		return nil, fmt.Errorf("parse operator pubkey: %w", err)
 	}
 
+	minVTXOAmount := resp.MinVtxoAmountSat
+	if minVTXOAmount == 0 {
+		minVTXOAmount = resp.DustLimit
+	}
+
 	// The forfeit penalty key, sweep key and sweep delay are no longer
 	// global operator terms; they are delivered per round in the batch
 	// info, so GetInfo no longer carries them.
@@ -4038,6 +4043,7 @@ func (s *Server) fetchOperatorTerms(ctx context.Context) (*types.OperatorTerms,
 		BoardingExitDelay:   resp.BoardingExitDelay,
 		VTXOExitDelay:       resp.VtxoExitDelay,
 		DustLimit:           btcutil.Amount(resp.DustLimit),
+		MinVTXOAmount:       btcutil.Amount(minVTXOAmount),
 		MinBoardingAmount:   btcutil.Amount(resp.MinBoardingAmount),
 		MaxBoardingAmount:   btcutil.Amount(resp.MaxBoardingAmount),
 		FeeRate:             btcutil.Amount(resp.FeeRate),

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -45,6 +45,10 @@ type OperatorTerms struct {
 	// DustLimit enforces minimum output value for boarding/funding flows.
 	DustLimit btcutil.Amount
 
+	// MinVTXOAmount is the operator-advertised minimum VTXO output
+	// amount.
+	MinVTXOAmount btcutil.Amount
+
 	// MinBoardingAmount is the minimum amount clients must contribute.
 	MinBoardingAmount btcutil.Amount
 

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -135,6 +135,10 @@ type ServerInfo struct {
 	// DustLimit is the minimum output value accepted by the operator.
 	DustLimit uint64
 
+	// MinVTXOAmountSat is the operator-advertised minimum VTXO output
+	// amount in satoshis.
+	MinVTXOAmountSat uint64
+
 	// MinBoardingAmount is the smallest boarding amount accepted by the
 	// operator.
 	MinBoardingAmount uint64
@@ -407,6 +411,7 @@ func (c *Client) GetInfo(ctx context.Context) (*Info, error) {
 			BoardingExitDelay: resp.ServerInfo.BoardingExitDelay,
 			VTXOExitDelay:     resp.ServerInfo.VtxoExitDelay,
 			DustLimit:         resp.ServerInfo.DustLimit,
+			MinVTXOAmountSat:  resp.ServerInfo.MinVtxoAmountSat,
 			MinBoardingAmount: resp.ServerInfo.MinBoardingAmount,
 			MaxBoardingAmount: resp.ServerInfo.MaxBoardingAmount,
 			FeeRate:           resp.ServerInfo.FeeRate,

--- a/sdk/ark/client_test.go
+++ b/sdk/ark/client_test.go
@@ -88,6 +88,7 @@ func newFakeDaemonService() *fakeDaemonService {
 				BoardingExitDelay: 144,
 				VtxoExitDelay:     288,
 				DustLimit:         546,
+				MinVtxoAmountSat:  1234,
 				MinBoardingAmount: 10_000,
 				MaxBoardingAmount: 20_000,
 				FeeRate:           15,
@@ -525,6 +526,9 @@ func TestDialRemoteGetInfo(t *testing.T) {
 	)
 	require.Equal(t, uint32(144),
 		info.ServerInfo.BoardingExitDelay,
+	)
+	require.Equal(t, uint64(1234),
+		info.ServerInfo.MinVTXOAmountSat,
 	)
 	require.Equal(t, uint64(20),
 		info.ServerInfo.MinOperatorFee,

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -465,7 +465,7 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 		),
 	)
 
-	dustLimit := func(ctx context.Context) (uint64, error) {
+	minAmount := func(ctx context.Context) (uint64, error) {
 		info, err := arkClient.GetInfo(ctx)
 		if err != nil {
 			return 0, err
@@ -486,8 +486,8 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 		subscribers: make(
 			map[chan *swapclientrpc.SwapSummary]struct{},
 		),
-		receiveMinAmount: dustLimit,
-		payMinAmount:     dustLimit,
+		receiveMinAmount: minAmount,
+		payMinAmount:     minAmount,
 		chainParams:      chainParams,
 	}
 
@@ -943,14 +943,18 @@ func chainParamsForNetwork(network string) (*chaincfg.Params, error) {
 	}
 }
 
-// receiveSwapMinAmountSat returns the operator-enforced minimum vHTLC output
+// receiveSwapMinAmountSat returns the operator-advertised minimum VTXO output
 // amount for receive swaps. A Lightning-to-Ark receive is funded as an Ark
-// vHTLC, not as an on-chain boarding deposit, so the operator dust limit is the
+// vHTLC, not as an on-chain boarding deposit, so the VTXO floor is the
 // relevant local preflight. The swap server may still apply additional
 // server-side policy before returning a route hint.
 func receiveSwapMinAmountSat(info *sdkark.ServerInfo) (uint64, error) {
 	if info == nil {
 		return 0, fmt.Errorf("operator terms unavailable")
+	}
+
+	if info.MinVTXOAmountSat > 0 {
+		return info.MinVTXOAmountSat, nil
 	}
 
 	return info.DustLimit, nil
@@ -978,7 +982,7 @@ func (s *swapClientService) validateReceiveAmount(ctx context.Context,
 	}
 
 	return status.Errorf(codes.InvalidArgument, "amount_sat %d is below "+
-		"the %d sat minimum for receive swaps (operator dust limit)",
+		"the %d sat minimum for receive swaps (operator VTXO minimum)",
 		amountSat, minAmountSat)
 }
 
@@ -1043,8 +1047,8 @@ func (s *swapClientService) validatePayInvoiceAmount(ctx context.Context,
 	}
 
 	return status.Errorf(codes.InvalidArgument, "invoice amount_sat %d is "+
-		"below the %d sat minimum for pay swaps (operator dust limit)",
-		amountSat, minAmountSat)
+		"below the %d sat minimum for pay swaps (operator VTXO "+
+		"minimum)", amountSat, minAmountSat)
 }
 
 // QuotePay previews a pay swap through sdk/swaps without starting a daemon

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lightninglabs/darepo-client/darepod"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
+	sdkark "github.com/lightninglabs/darepo-client/sdk/ark"
 	"github.com/lightninglabs/darepo-client/sdk/swaps"
 	"github.com/lightninglabs/darepo-client/serverconn"
 	"github.com/lightninglabs/darepo-client/swaprpc"
@@ -407,12 +408,12 @@ func TestStartPayPreservesRuntimeStatusCode(t *testing.T) {
 	)
 }
 
-// TestStartPayRejectsInvoiceBelowOperatorDust verifies the wallet RPC facade
-// applies the same operator dust limit as the underlying daemon OOR sender
-// before it persists a pay swap. Without this synchronous preflight, a
-// sub-dust BOLT-11 invoice could be admitted, then fail later in the
+// TestStartPayRejectsInvoiceBelowOperatorVTXOMin verifies the wallet RPC
+// facade applies the same operator VTXO minimum as the underlying daemon OOR
+// sender before it persists a pay swap. Without this synchronous preflight, a
+// too-small BOLT-11 invoice could be admitted, then fail later in the
 // background worker after the user-facing Send RPC already returned.
-func TestStartPayRejectsInvoiceBelowOperatorDust(t *testing.T) {
+func TestStartPayRejectsInvoiceBelowOperatorVTXOMin(t *testing.T) {
 	t.Parallel()
 
 	fakeClient := newFakeSwapRuntime()
@@ -503,10 +504,10 @@ func TestStartReceiveReturnsInvoiceAndStartsWorker(t *testing.T) {
 	require.Equal(t, 1, fakeClient.receiveResumeCount(receiveHash))
 }
 
-// TestStartReceiveRejectsAmountBelowOperatorDust proves receive startup fails
-// before sdk/swaps creates a session or invoice when the requested amount is
-// below the operator dust limit cached in darepod's server terms.
-func TestStartReceiveRejectsAmountBelowOperatorDust(t *testing.T) {
+// TestStartReceiveRejectsAmountBelowOperatorVTXOMin proves receive startup
+// fails before sdk/swaps creates a session or invoice when the requested
+// amount is below the operator-advertised VTXO minimum.
+func TestStartReceiveRejectsAmountBelowOperatorVTXOMin(t *testing.T) {
 	t.Parallel()
 
 	fakeClient := newFakeSwapRuntime()
@@ -527,9 +528,26 @@ func TestStartReceiveRejectsAmountBelowOperatorDust(t *testing.T) {
 	require.Contains(t, status.Convert(err).Message(), "1000 sat minimum")
 	require.Contains(
 		t, status.Convert(err).Message(),
-		"operator dust limit",
+		"operator VTXO minimum",
 	)
 	require.Equal(t, 0, fakeClient.startReceiveCount())
+}
+
+func TestReceiveSwapMinAmountUsesMinVTXOAmount(t *testing.T) {
+	t.Parallel()
+
+	amount, err := receiveSwapMinAmountSat(&sdkark.ServerInfo{
+		DustLimit:        546,
+		MinVTXOAmountSat: 1_234,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1_234), amount)
+
+	amount, err = receiveSwapMinAmountSat(&sdkark.ServerInfo{
+		DustLimit: 546,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(546), amount)
 }
 
 func TestResumeSwapValidatesPaymentHashAndDirection(t *testing.T) {


### PR DESCRIPTION
## Summary

Expose the operator-advertised minimum VTXO output amount as an explicit `GetInfo` value.

The operator already had this policy internally, but client code had to infer the VTXO floor from older boarding and dust fields. This PR adds `min_vtxo_amount_sat` to the operator `GetInfo` response, carries it through daemon `ServerInfo`, and exposes it as `sdk/ark.ServerInfo.MinVTXOAmountSat`.

Swap preflight now prefers that explicit VTXO minimum when it rejects pay and receive amounts that cannot materialize as VTXOs. It still falls back to the legacy dust limit when talking to older daemons or operators.

Paired root PR: lightninglabs/darepo#597.

## Tests

- `make rpc`
- `make unit pkg=./darepod case=TestGetInfoIncludesServerInfo`
- `make unit pkg=./darepod case=TestOperatorPubKeyFetchesFreshTerms`
- `make unit pkg=./sdk/ark case=TestDialRemoteGetInfo`
- `make unit pkg=./swapclientserver case=TestReceiveSwapMinAmountUsesMinVTXOAmount tags="swapruntime walletdkrpc"`
- `make unit pkg=./swapclientserver case=TestStartReceiveRejectsAmountBelowOperatorVTXOMin tags="swapruntime walletdkrpc"`
- `make unit pkg=./swapclientserver case=TestStartPayRejectsInvoiceBelowOperatorVTXOMin tags="swapruntime walletdkrpc"`
- `make fmt-changed-check`
- `make lint-changed-local`
- `make commitmsg-lint range=origin/main..HEAD`
