### PR TITLE
sdk/walletdk: surface WalletEntry progress and request in Entry

### DIFF
--- a/sdk/walletdk/CLAUDE.md
+++ b/sdk/walletdk/CLAUDE.md
@@ -46,8 +46,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   onchain whole-VTXO sweeps), `DepositRequest`/`Result` (boarding
   address + initial `Entry`), `ListRequest`, `ListResult` (tagged union
   on `View`, populates one of `Activity`/`VTXOs`/`Onchain`),
-  `ActivityList`, `VTXOInventory`, `OnchainHistory`, `Entry`,
-  `WalletVTXO`, `OnchainTx`.
+  `ActivityList`, `VTXOInventory`, `OnchainHistory`, `Entry`
+  (optional `Progress *EntryProgress` and `Request *EntryRequest`
+  sub-objects, both nil when absent; `Request` is a `Type`-tagged
+  union over lightning/onchain/ark), `WalletVTXO`, `OnchainTx`.
 - `ExitRequest` / `ExitResult` / `ExitStatusRequest` /
   `ExitStatusResult` / `ExitJobStatus` — exit DTOs. `ExitRequest`
   carries the target outpoint plus an optional on-chain `Destination`
@@ -138,15 +140,21 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   the wrapper boundary on builds without the `walletdkrpc` tag, before
   any RPC is attempted. `ErrSwapRuntimeUnavailable` is an alias for
   source-level compatibility with older swap-only callers.
-- `Entry.Kind`/`Entry.Status` / `ListResult.View` /
-  `WalletVTXO.Status` / `OnchainTx.Kind` / `ExitJobStatus` are
-  wrapper-owned lowercase strings (not proto enums). Projection lives
-  in `convert.go`, intentionally decoupled from proto enum
-  renumbering.
+- `Entry.Kind`/`Entry.Status` / `Entry.Progress.Phase` /
+  `Entry.Request.Type` / `ListResult.View` / `WalletVTXO.Status` /
+  `OnchainTx.Kind` / `ExitJobStatus` are wrapper-owned lowercase
+  strings (not proto enums). Projection lives in `convert.go`,
+  intentionally decoupled from proto enum renumbering.
 - `ListResult` is a discriminated union: read the variant named by
   `View` and treat the others as `nil`. Exhaustiveness is not
   enforced at compile time — switch on `View` rather than chaining
   nil checks.
+- `Entry.Progress` and `Entry.Request` are optional pointers: both are
+  `nil` when the daemon supplied no progress hint / persisted no
+  request, so nil-check before dereferencing. `Entry.Request` is a
+  discriminated union — read the variant named by `Type`
+  (`lightning`/`onchain`/`ark`) and treat the other fields as zero,
+  the same idiom as `ListResult.View`.
 - `Wait()` is single-reader: same shared channel on every call. The
   channel delivers the daemon's terminal run error then closes; a
   closed channel reads as the zero error indefinitely.

--- a/sdk/walletdk/convert.go
+++ b/sdk/walletdk/convert.go
@@ -280,6 +280,99 @@ func entryFromProto(entry *walletdkrpc.WalletEntry) Entry {
 		UpdatedAt:     unixTime(entry.GetUpdatedAtUnix()),
 		Note:          entry.GetNote(),
 		FailureReason: entry.GetFailureReason(),
+		Progress:      entryProgressFromProto(entry.GetProgress()),
+		Request:       entryRequestFromProto(entry.GetRequest()),
+	}
+}
+
+// entryProgressFromProto copies the daemon-normalized lifecycle metadata into
+// wrapper-owned fields. It returns nil when the entry carried no progress, so
+// callers can treat absence and emptiness uniformly.
+func entryProgressFromProto(
+	progress *walletdkrpc.WalletEntryProgress) *EntryProgress {
+
+	if progress == nil {
+		return nil
+	}
+
+	return &EntryProgress{
+		Phase:              entryPhaseFromProto(progress.GetPhase()),
+		PhaseLabel:         progress.GetPhaseLabel(),
+		PaymentHash:        progress.GetPaymentHash(),
+		Txid:               progress.GetTxid(),
+		ConfirmationHeight: progress.GetConfirmationHeight(),
+		VTXOOutpoint:       progress.GetVtxoOutpoint(),
+	}
+}
+
+// entryPhaseFromProto maps the generated lifecycle enum into walletdk's
+// string-like phase, decoupled from proto enum renumbering.
+func entryPhaseFromProto(phase walletdkrpc.WalletEntryPhase) EntryPhase {
+	switch phase {
+	case walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_REQUEST_CREATED:
+		return EntryPhaseRequestCreated
+
+	case walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_WAITING_FOR_PAYMENT: //nolint:ll
+		return EntryPhaseWaitingForPayment
+
+	case walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_PAYMENT_DETECTED:
+		return EntryPhasePaymentDetected
+
+	case walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_SETTLING:
+		return EntryPhaseSettling
+
+	case walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_CONFIRMED:
+		return EntryPhaseConfirmed
+
+	case walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_REFUNDING:
+		return EntryPhaseRefunding
+
+	case walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_REFUNDED:
+		return EntryPhaseRefunded
+
+	case walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_FAILED:
+		return EntryPhaseFailed
+
+	case walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_WAITING_FOR_CONFIRMATION: //nolint:ll
+		return EntryPhaseWaitingForConfirmation
+
+	default:
+		return EntryPhaseUnspecified
+	}
+}
+
+// entryRequestFromProto flattens the request oneof into a wrapper-owned shape
+// with a Type discriminator. It returns nil when no request was carried or no
+// variant is set, so callers can treat absence and emptiness uniformly.
+func entryRequestFromProto(
+	request *walletdkrpc.WalletEntryRequest) *EntryRequest {
+
+	if request == nil {
+		return nil
+	}
+
+	switch req := request.GetRequest().(type) {
+	case *walletdkrpc.WalletEntryRequest_LightningInvoice:
+		return &EntryRequest{
+			Type:             EntryRequestTypeLightning,
+			LightningInvoice: req.LightningInvoice.GetInvoice(),
+			PaymentHash:      req.LightningInvoice.GetPaymentHash(),
+		}
+
+	case *walletdkrpc.WalletEntryRequest_OnchainAddress:
+		return &EntryRequest{
+			Type:           EntryRequestTypeOnchain,
+			OnchainAddress: req.OnchainAddress.GetAddress(),
+		}
+
+	case *walletdkrpc.WalletEntryRequest_ArkAddress:
+		return &EntryRequest{
+			Type:       EntryRequestTypeArk,
+			ArkAddress: req.ArkAddress.GetAddress(),
+		}
+
+	default:
+		return nil
 	}
 }
 

--- a/sdk/walletdk/convert_test.go
+++ b/sdk/walletdk/convert_test.go
@@ -9,8 +9,27 @@ import (
 )
 
 // TestEntryFromProto guards the wrapper-owned wallet activity DTO from
-// accidental protobuf field drift.
+// accidental protobuf field drift, including the progress and request
+// sub-messages.
 func TestEntryFromProto(t *testing.T) {
+	prog := &walletdkrpc.WalletEntryProgress{
+		PhaseLabel:         "settling",
+		PaymentHash:        "phash",
+		Txid:               "txid",
+		ConfirmationHeight: 7,
+		VtxoOutpoint:       "vtxo:0",
+	}
+	prog.Phase = walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_SETTLING
+
+	req := &walletdkrpc.WalletEntryRequest{
+		Request: &walletdkrpc.WalletEntryRequest_LightningInvoice{
+			LightningInvoice: &walletdkrpc.LightningInvoiceRequest{
+				Invoice:     "lnbc1...",
+				PaymentHash: "phash",
+			},
+		},
+	}
+
 	proto := &walletdkrpc.WalletEntry{
 		Id:            "id",
 		Kind:          walletdkrpc.EntryKind_ENTRY_KIND_SEND,
@@ -22,6 +41,8 @@ func TestEntryFromProto(t *testing.T) {
 		UpdatedAtUnix: 12,
 		Note:          "note",
 		FailureReason: "reason",
+		Progress:      prog,
+		Request:       req,
 	}
 
 	entry := entryFromProto(proto)
@@ -35,6 +56,157 @@ func TestEntryFromProto(t *testing.T) {
 	require.Equal(t, time.Unix(12, 0), entry.UpdatedAt)
 	require.Equal(t, "note", entry.Note)
 	require.Equal(t, "reason", entry.FailureReason)
+
+	require.NotNil(t, entry.Progress)
+	require.Equal(t, EntryPhaseSettling, entry.Progress.Phase)
+	require.Equal(t, "settling", entry.Progress.PhaseLabel)
+	require.Equal(t, "phash", entry.Progress.PaymentHash)
+	require.Equal(t, "txid", entry.Progress.Txid)
+	require.EqualValues(t, 7, entry.Progress.ConfirmationHeight)
+	require.Equal(t, "vtxo:0", entry.Progress.VTXOOutpoint)
+
+	require.NotNil(t, entry.Request)
+	require.Equal(t, EntryRequestTypeLightning, entry.Request.Type)
+	require.Equal(t, "lnbc1...", entry.Request.LightningInvoice)
+	require.Equal(t, "phash", entry.Request.PaymentHash)
+}
+
+// TestEntryFromProtoNoProgressOrRequest confirms a bare entry leaves the
+// optional sub-objects nil rather than allocating empty shells, so callers can
+// treat absence uniformly.
+func TestEntryFromProtoNoProgressOrRequest(t *testing.T) {
+	entry := entryFromProto(&walletdkrpc.WalletEntry{Id: "id"})
+	require.Equal(t, "id", entry.ID)
+	require.Nil(t, entry.Progress)
+	require.Nil(t, entry.Request)
+}
+
+// TestEntryPhaseFromProto exhaustively maps every walletdkrpc phase value to
+// the wrapper-owned lowercase string, including the unspecified fallback.
+func TestEntryPhaseFromProto(t *testing.T) {
+	ph := walletdkrpc.WalletEntryPhase_value
+	cases := []struct {
+		in   walletdkrpc.WalletEntryPhase
+		want EntryPhase
+	}{
+		{
+			in:   phaseEnum(ph, "UNSPECIFIED"),
+			want: EntryPhaseUnspecified,
+		},
+		{
+			in:   phaseEnum(ph, "REQUEST_CREATED"),
+			want: EntryPhaseRequestCreated,
+		},
+		{
+			in:   phaseEnum(ph, "WAITING_FOR_PAYMENT"),
+			want: EntryPhaseWaitingForPayment,
+		},
+		{
+			in:   phaseEnum(ph, "PAYMENT_DETECTED"),
+			want: EntryPhasePaymentDetected,
+		},
+		{
+			in:   phaseEnum(ph, "SETTLING"),
+			want: EntryPhaseSettling,
+		},
+		{
+			in:   phaseEnum(ph, "CONFIRMED"),
+			want: EntryPhaseConfirmed,
+		},
+		{
+			in:   phaseEnum(ph, "REFUNDING"),
+			want: EntryPhaseRefunding,
+		},
+		{
+			in:   phaseEnum(ph, "REFUNDED"),
+			want: EntryPhaseRefunded,
+		},
+		{
+			in:   phaseEnum(ph, "FAILED"),
+			want: EntryPhaseFailed,
+		},
+		{
+			in:   phaseEnum(ph, "WAITING_FOR_CONFIRMATION"),
+			want: EntryPhaseWaitingForConfirmation,
+		},
+	}
+
+	// Guard against a new proto phase landing without a wrapper mapping.
+	require.Len(t, cases, len(ph))
+
+	for _, tc := range cases {
+		require.Equal(
+			t, tc.want, entryPhaseFromProto(tc.in),
+			"in=%v", tc.in,
+		)
+	}
+}
+
+// phaseEnum resolves a short phase suffix to its generated enum value, keeping
+// the table above within the line limit.
+func phaseEnum(m map[string]int32, suffix string) walletdkrpc.WalletEntryPhase {
+	return walletdkrpc.WalletEntryPhase(m["WALLET_ENTRY_PHASE_"+suffix])
+}
+
+// TestEntryRequestFromProto covers each oneof variant plus the nil and
+// empty-oneof paths.
+func TestEntryRequestFromProto(t *testing.T) {
+	require.Nil(t, entryRequestFromProto(nil))
+	require.Nil(t, entryRequestFromProto(&walletdkrpc.WalletEntryRequest{}))
+
+	ln := entryRequestFromProto(&walletdkrpc.WalletEntryRequest{
+		Request: &walletdkrpc.WalletEntryRequest_LightningInvoice{
+			LightningInvoice: &walletdkrpc.LightningInvoiceRequest{
+				Invoice:     "lnbc1...",
+				PaymentHash: "phash",
+			},
+		},
+	})
+	require.Equal(t, EntryRequestTypeLightning, ln.Type)
+	require.Equal(t, "lnbc1...", ln.LightningInvoice)
+	require.Equal(t, "phash", ln.PaymentHash)
+
+	onchain := entryRequestFromProto(&walletdkrpc.WalletEntryRequest{
+		Request: &walletdkrpc.WalletEntryRequest_OnchainAddress{
+			OnchainAddress: &walletdkrpc.OnchainAddressRequest{
+				Address: "bc1qaddr",
+			},
+		},
+	})
+	require.Equal(t, EntryRequestTypeOnchain, onchain.Type)
+	require.Equal(t, "bc1qaddr", onchain.OnchainAddress)
+
+	ark := entryRequestFromProto(&walletdkrpc.WalletEntryRequest{
+		Request: &walletdkrpc.WalletEntryRequest_ArkAddress{
+			ArkAddress: &walletdkrpc.ArkAddressRequest{
+				Address: "ark1qaddr",
+			},
+		},
+	})
+	require.Equal(t, EntryRequestTypeArk, ark.Type)
+	require.Equal(t, "ark1qaddr", ark.ArkAddress)
+
+	// A wrapper set with a nil inner message still names the variant via
+	// the type switch; the nil-safe getters then yield empty fields. gRPC
+	// decode always allocates the inner message, so this only arises from a
+	// hand-built struct, but pin the behavior so the type switch stays
+	// honest.
+	nilInner := entryRequestFromProto(&walletdkrpc.WalletEntryRequest{
+		Request: &walletdkrpc.WalletEntryRequest_LightningInvoice{},
+	})
+	require.Equal(t, EntryRequestTypeLightning, nilInner.Type)
+	require.Empty(t, nilInner.LightningInvoice)
+	require.Empty(t, nilInner.PaymentHash)
+}
+
+// TestEntryRequestOneofArity fails fast if a future proto change grows the
+// request oneof without a matching entryRequestFromProto branch, since a new
+// variant would otherwise be silently dropped to nil.
+func TestEntryRequestOneofArity(t *testing.T) {
+	oneofs := (&walletdkrpc.WalletEntryRequest{}).
+		ProtoReflect().Descriptor().Oneofs()
+	require.Equal(t, 1, oneofs.Len())
+	require.Equal(t, 3, oneofs.Get(0).Fields().Len())
 }
 
 // TestEntryKindToProto verifies filters use the expected wallet RPC enum.

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -558,4 +558,129 @@ type Entry struct {
 	UpdatedAt     time.Time
 	Note          string
 	FailureReason string
+
+	// Progress carries the lifecycle metadata the daemon already
+	// normalized for this entry (phase, payment hash, txid, confirmation
+	// height, vHTLC outpoint). It is nil when the backing subsystem
+	// supplied no progress hint.
+	Progress *EntryProgress
+
+	// Request echoes the user-recognizable request that created the entry
+	// (a Lightning invoice, an on-chain address, or an Ark address). It is
+	// nil when the backing subsystem did not persist one.
+	Request *EntryRequest
+}
+
+// EntryPhase is a coarse, wrapper-owned lifecycle phase for an Entry. It does
+// not replace Status: Status answers pending/complete/failed, while Phase
+// explains the current backing-system step. Like the other Entry enums it is
+// a lowercase string decoupled from the proto enum so renumbering cannot break
+// callers; switch on it rather than comparing proto values.
+type EntryPhase string
+
+const (
+	// EntryPhaseUnspecified means the backing subsystem provided no
+	// lifecycle hint.
+	EntryPhaseUnspecified EntryPhase = "unspecified"
+
+	// EntryPhaseRequestCreated means the request was created but no payment
+	// has been observed yet.
+	EntryPhaseRequestCreated EntryPhase = "request_created"
+
+	// EntryPhaseWaitingForPayment means the wallet is waiting for an
+	// inbound payment or swap funding.
+	EntryPhaseWaitingForPayment EntryPhase = "waiting_for_payment"
+
+	// EntryPhasePaymentDetected means a payment was detected but is not yet
+	// settled.
+	EntryPhasePaymentDetected EntryPhase = "payment_detected"
+
+	// EntryPhaseSettling means the operation is settling through Ark,
+	// Lightning, or on-chain machinery.
+	EntryPhaseSettling EntryPhase = "settling"
+
+	// EntryPhaseConfirmed means the backing operation is confirmed or
+	// otherwise durably complete.
+	EntryPhaseConfirmed EntryPhase = "confirmed"
+
+	// EntryPhaseRefunding means the operation is currently refunding.
+	EntryPhaseRefunding EntryPhase = "refunding"
+
+	// EntryPhaseRefunded means the refund path completed.
+	EntryPhaseRefunded EntryPhase = "refunded"
+
+	// EntryPhaseFailed means the backing operation reached a terminal
+	// failed state.
+	EntryPhaseFailed EntryPhase = "failed"
+
+	// EntryPhaseWaitingForConfirmation means an on-chain payment was
+	// detected and is waiting for block confirmation.
+	EntryPhaseWaitingForConfirmation EntryPhase = "waiting_for_confirmation"
+)
+
+// EntryProgress is the wrapper-owned view of the lifecycle metadata the daemon
+// computes for an Entry. Fields are populated on a best-effort basis by the
+// backing subsystem; an empty field means "not applicable / not yet known".
+type EntryProgress struct {
+	// Phase is the coarse lifecycle phase for the entry.
+	Phase EntryPhase
+
+	// PhaseLabel is the short lowercase label the daemon emitted; clients
+	// may render it directly instead of switching on Phase.
+	PhaseLabel string
+
+	// PaymentHash is populated for Lightning-backed send/recv entries.
+	PaymentHash string
+
+	// Txid is populated when the backing ledger row has an on-chain txid.
+	Txid string
+
+	// ConfirmationHeight is populated once the source records it.
+	ConfirmationHeight int32
+
+	// VTXOOutpoint is populated when a swap observes the Ark vHTLC output.
+	VTXOOutpoint string
+}
+
+// EntryRequestType discriminates which request shape an EntryRequest carries.
+// Callers should switch on Type before reading the variant fields.
+type EntryRequestType string
+
+const (
+	// EntryRequestTypeLightning marks a Lightning send/recv request; the
+	// LightningInvoice and PaymentHash fields are populated.
+	EntryRequestTypeLightning EntryRequestType = "lightning"
+
+	// EntryRequestTypeOnchain marks a deposit/exit request; the
+	// OnchainAddress field is populated.
+	EntryRequestTypeOnchain EntryRequestType = "onchain"
+
+	// EntryRequestTypeArk marks a direct Ark send/recv request; the
+	// ArkAddress field is populated.
+	EntryRequestTypeArk EntryRequestType = "ark"
+)
+
+// EntryRequest is the wrapper-owned, flattened view of the proto request
+// oneof. Exactly one variant's fields are populated, named by Type; read Type
+// first and treat the other fields as zero.
+type EntryRequest struct {
+	// Type names the populated variant.
+	Type EntryRequestType
+
+	// LightningInvoice is the BOLT-11 payment request. Populated when Type
+	// is EntryRequestTypeLightning.
+	LightningInvoice string
+
+	// PaymentHash identifies the Lightning invoice and stays stable after
+	// the invoice is no longer convenient to display. Populated when Type
+	// is EntryRequestTypeLightning.
+	PaymentHash string
+
+	// OnchainAddress is the bech32 on-chain address originally issued or
+	// targeted. Populated when Type is EntryRequestTypeOnchain.
+	OnchainAddress string
+
+	// ArkAddress is the Ark address originally issued or targeted.
+	// Populated when Type is EntryRequestTypeArk.
+	ArkAddress string
 }


### PR DESCRIPTION
Closes #777.

## What

`sdk/walletdk`'s `entryFromProto` projected only the 10 scalar fields of
`WalletEntry`, silently dropping the `progress` (`WalletEntryProgress`) and
`request` (`WalletEntryRequest` oneof) sub-messages that the daemon already
computes and ships over the wire. SDK consumers — and the mobile/web UIs built
on them — could therefore only render coarse `PENDING`/`COMPLETE`/`FAILED`, not
the lifecycle phase, payment hash, txid, confirmation height, vHTLC outpoint, or
originating request the daemon already worked out.

This wires both through to the wrapper-owned `Entry`:

- `Entry.Progress *EntryProgress` — phase (+ label), payment hash, txid,
  confirmation height, vHTLC outpoint.
- `Entry.Request *EntryRequest` — the request oneof flattened with a `Type`
  discriminator (lightning / onchain / ark), matching the existing
  `ListResult.View` / `ExitResult.Path` discriminated-union idiom.
- `EntryPhase` is a wrapper-owned lowercase string, decoupled from the proto
  enum per the package's projection invariant.

`entryFromProto` is the single projection chokepoint, so both `List` (activity)
and `Subscribe` now carry the fields. Pure SDK plumbing — no daemon or proto
change. The change is additive to the exported `Entry` struct; existing
keyed-literal callers are unaffected.

## Tests

- Enriched `TestEntryFromProto` (progress + request round-trip) plus a
  bare-entry nil-pointer case.
- `TestEntryPhaseFromProto` exhaustively maps every phase, with a
  `require.Len(cases, len(WalletEntryPhase_value))` guard that fails if a future
  `make rpc` adds a phase without a wrapper mapping.
- `TestEntryRequestFromProto` covers all three oneof variants plus nil/empty,
  and `TestEntryRequestOneofArity` is a protoreflect guard so a newly-added
  oneof variant can't be silently dropped.

`make unit pkg=sdk/walletdk` green; `make lint-changed-local` clean; compiles
under `-tags "walletdkrpc swapruntime"`.
