### PR TITLE
multi: truth-up walletdk docs, guides, and overpay warnings

### DIFF
--- a/docs/walletdk_integration.md
+++ b/docs/walletdk_integration.md
@@ -24,8 +24,8 @@ Without those tags, `Start` fails with `walletdk.ErrWalletRPCUnavailable`.
 2. Start the embedded daemon with `walletdk.Start`, or connect to an external
    daemon with `walletdk.Connect`.
 3. Create or unlock the wallet.
-4. Use `Status`, `Balance`, `Deposit`, `Receive`, `Send`, `List`, and
-   `Subscribe`.
+4. Use `Status`, `Balance`, `Deposit`, `Receive`, `PrepareSend` /
+   `SendPrepared`, `List`, and `Subscribe`.
 5. Call `Stop` when the host app shuts down.
 
 ```go
@@ -143,10 +143,13 @@ fmt.Println("invoice:", receive.Invoice)
 fmt.Println("entry:", receive.Entry.ID, receive.Entry.Status)
 ```
 
-Send to a Lightning invoice or on-chain address:
+Send to a Lightning invoice or on-chain address. Sending is a two-step flow:
+`PrepareSend` validates and quotes the payment and returns a single-use
+`SendIntentID`; `SendPrepared` then dispatches that intent. This lets a UI show
+the fee/rail quote before the user commits.
 
 ```go
-send, err := client.Send(ctx, walletdk.SendRequest{
+prepared, err := client.PrepareSend(ctx, walletdk.PrepareSendRequest{
 	Invoice:   bolt11Invoice,
 	MaxFeeSat: 1_000,
 	Note:      "demo payment",
@@ -155,7 +158,21 @@ if err != nil {
 	panic(err)
 }
 
+// Inspect the quote before committing: prepared.AmountSat,
+// prepared.ExpectedFeeSat / prepared.FeeKnown, prepared.Rail,
+// prepared.QuoteStatus, and prepared.ExpiresAtUnix.
+send, err := client.SendPrepared(ctx, walletdk.SendPreparedRequest{
+	SendIntentID: prepared.SendIntentID,
+})
+if err != nil {
+	panic(err)
+}
+
+// ActualAmountSat equals the requested amount for a bounded send; for a
+// sweep-all send it is the swept total. Echo it before treating the send
+// as confirmed.
 fmt.Println("entry:", send.Entry.ID, send.Entry.Status)
+fmt.Println("actual outflow:", send.ActualAmountSat)
 ```
 
 ## Native btcwallet RPC
@@ -185,18 +202,20 @@ before the self-managed wallet has been created or unlocked.
 
 ## Wallet Activity
 
-`List` is the durable wallet activity view. It returns normalized `Entry` rows
+`List` returns a `ListResult` tagged union: read the variant named by `View`
+(`Activity`, `VTXOs`, or `Onchain`) and treat the others as `nil`. The default
+view is `ListViewActivity`, whose `Activity.Entries` are normalized `Entry` rows
 for sends, receives, deposits, and exits.
 
 ```go
 history, err := client.List(ctx, walletdk.ListRequest{
-	PendingOnly: false,
+	View: walletdk.ListViewActivity,
 })
 if err != nil {
 	panic(err)
 }
 
-for _, entry := range history.Entries {
+for _, entry := range history.Activity.Entries {
 	fmt.Println(entry.Kind, entry.ID, entry.Status, entry.AmountSat)
 }
 ```
@@ -241,8 +260,8 @@ Keep host-language bindings thin:
 
 - Own one `*walletdk.Client` per wallet runtime.
 - Expose explicit `Start` or `Connect`, `Stop`, `CreateWallet`,
-  `UnlockWallet`, `Status`, `Balance`, `Deposit`, `Receive`, `Send`, `List`,
-  and `Subscribe` methods.
+  `UnlockWallet`, `Status`, `Balance`, `Deposit`, `Receive`, `PrepareSend`,
+  `SendPrepared`, `List`, and `Subscribe` methods.
 - Convert SDK structs into plain host DTOs. Do not expose protobuf messages to
   mobile or JavaScript callers.
 - Accept caller-provided timeouts or cancellation handles for every operation.

--- a/rpc/walletdkrpc/AGENTS.md
+++ b/rpc/walletdkrpc/AGENTS.md
@@ -16,11 +16,12 @@ Proto source: `rpc/walletdkrpc/wallet.proto`.
 |--------|---------|
 | `Create` | Initialize a new wallet (proxies `GenSeed` + `InitWallet`) |
 | `Unlock` | Unlock an existing wallet (proxies `UnlockWallet`) |
-| `Send` | Outbound payment; destination oneof picks invoice vs onchain |
+| `PrepareSend` | Validate + quote an outbound payment; returns a single-use `send_intent_id` |
+| `Send` | Dispatch a prepared send; consumes `send_intent_id` |
 | `Recv` | Inbound Lightning invoice (offchain receive) |
 | `List` | Unified wallet view; `ListView` selects activity/vtxos/onchain |
 | `Balance` | Flat balance (confirmed / pending_in / pending_out) |
-| `Exit` | Unilateral exit / unroll (proxies `Unroll`) |
+| `Exit` | Cooperative leave by default; unilateral unroll only with the exact force-ack |
 | `Deposit` | Fresh boarding address (used by `recv --onchain`) |
 | `Status` | Daemon + wallet readiness summary |
 | `ExitStatus` | Phase of an exit job (proxies `GetUnrollStatus`) |

--- a/rpc/walletdkrpc/CLAUDE.md
+++ b/rpc/walletdkrpc/CLAUDE.md
@@ -16,11 +16,12 @@ Proto source: `rpc/walletdkrpc/wallet.proto`.
 |--------|---------|
 | `Create` | Initialize a new wallet (proxies `GenSeed` + `InitWallet`) |
 | `Unlock` | Unlock an existing wallet (proxies `UnlockWallet`) |
-| `Send` | Outbound payment; destination oneof picks invoice vs onchain |
+| `PrepareSend` | Validate + quote an outbound payment; returns a single-use `send_intent_id` |
+| `Send` | Dispatch a prepared send; consumes `send_intent_id` |
 | `Recv` | Inbound Lightning invoice (offchain receive) |
 | `List` | Unified wallet view; `ListView` selects activity/vtxos/onchain |
 | `Balance` | Flat balance (confirmed / pending_in / pending_out) |
-| `Exit` | Unilateral exit / unroll (proxies `Unroll`) |
+| `Exit` | Cooperative leave by default; unilateral unroll only with the exact force-ack |
 | `Deposit` | Fresh boarding address (used by `recv --onchain`) |
 | `Status` | Daemon + wallet readiness summary |
 | `ExitStatus` | Phase of an exit job (proxies `GetUnrollStatus`) |

--- a/rpc/walletdkrpc/wallet.pb.go
+++ b/rpc/walletdkrpc/wallet.pb.go
@@ -1186,11 +1186,13 @@ type SendResponse struct {
 	Entry *WalletEntry `protobuf:"bytes,1,opt,name=entry,proto3" json:"entry,omitempty"`
 	// actual_amount_sat is the real amount that will leave the wallet
 	// for this operation. For invoice sends it matches the caller's
-	// amt_sat (or the invoice amount for amount-bearing invoices). For
-	// onchain sends it reflects the SUM of selected VTXOs, which under
-	// v1 whole-VTXO sweep semantics may exceed amt_sat. CLI and UI
-	// surfaces SHOULD echo this back to the user before treating the
-	// send as confirmed.
+	// amt_sat (or the invoice amount for amount-bearing invoices). For a
+	// bounded onchain send it matches the requested amt_sat: the
+	// seal-time fee handshake returns a change VTXO rather than sweeping
+	// whole VTXOs. For a sweep_all onchain send it reflects the SUM of
+	// the swept VTXOs (the whole-wallet drain). CLI and UI surfaces
+	// SHOULD echo this back to the user before treating the send as
+	// confirmed.
 	ActualAmountSat int64 `protobuf:"varint,2,opt,name=actual_amount_sat,json=actualAmountSat,proto3" json:"actual_amount_sat,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache

--- a/rpc/walletdkrpc/wallet.proto
+++ b/rpc/walletdkrpc/wallet.proto
@@ -354,11 +354,13 @@ message SendResponse {
 
     // actual_amount_sat is the real amount that will leave the wallet
     // for this operation. For invoice sends it matches the caller's
-    // amt_sat (or the invoice amount for amount-bearing invoices). For
-    // onchain sends it reflects the SUM of selected VTXOs, which under
-    // v1 whole-VTXO sweep semantics may exceed amt_sat. CLI and UI
-    // surfaces SHOULD echo this back to the user before treating the
-    // send as confirmed.
+    // amt_sat (or the invoice amount for amount-bearing invoices). For a
+    // bounded onchain send it matches the requested amt_sat: the
+    // seal-time fee handshake returns a change VTXO rather than sweeping
+    // whole VTXOs. For a sweep_all onchain send it reflects the SUM of
+    // the swept VTXOs (the whole-wallet drain). CLI and UI surfaces
+    // SHOULD echo this back to the user before treating the send as
+    // confirmed.
     int64 actual_amount_sat = 2;
 }
 

--- a/sdk/walletdk/AGENTS.md
+++ b/sdk/walletdk/AGENTS.md
@@ -41,9 +41,12 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   `daemonCfg.EagerRoundJoin = false`.
 - DTOs (wrapper-owned, isolated from proto enums): `Info`, `Balance`,
   `CreateWalletResult`, `UnlockWalletResult`, `ReceiveRequest`/`Result`
-  (returns invoice + initial `Entry`), `SendRequest`/`Result` (returns
-  `Entry` + `ActualAmountSat`, which can exceed requested amount for
-  onchain whole-VTXO sweeps), `DepositRequest`/`Result` (boarding
+  (returns invoice + initial `Entry`), the two-step send DTOs
+  `PrepareSendRequest`/`PrepareSendResult` and
+  `SendPreparedRequest`/`SendResult` (`PrepareSend` quotes and returns a
+  single-use `SendIntentID`; `SendPrepared` dispatches it and returns
+  `Entry` + `ActualAmountSat`, which equals the requested amount for a
+  bounded send and the swept total for sweep-all), `DepositRequest`/`Result` (boarding
   address + initial `Entry`), `ListRequest`, `ListResult` (tagged union
   on `View`, populates one of `Activity`/`VTXOs`/`Onchain`),
   `ActivityList`, `VTXOInventory`, `OnchainHistory`, `Entry`,
@@ -79,7 +82,8 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
 | `Balance` | Flat balance (`confirmed_sat`, `pending_in_sat`, `pending_out_sat`). |
 | `Deposit` | Allocate a fresh boarding address (`recv --onchain` from CLI). |
 | `Receive` | Open a Lightning invoice receive (`recv --offchain`). Returns `{Invoice, Entry}`. |
-| `Send` | Outbound payment by invoice or onchain address. Returns `{Entry, ActualAmountSat}`. |
+| `PrepareSend` | Validate + quote an outbound payment; returns a single-use `SendIntentID`. |
+| `SendPrepared` | Dispatch a prepared send (consumes `SendIntentID`). Returns `{Entry, ActualAmountSat}`. |
 | `List` | Unified history view (Activity / VTXOs / Onchain) as a tagged-union `ListResult`. |
 | `Exit` | Trigger cooperative leave or unilateral unroll for a VTXO. |
 | `ExitStatus` | Query the phase of an exit job. |

--- a/sdk/walletdk/CLAUDE.md
+++ b/sdk/walletdk/CLAUDE.md
@@ -41,9 +41,12 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   `daemonCfg.EagerRoundJoin = false`.
 - DTOs (wrapper-owned, isolated from proto enums): `Info`, `Balance`,
   `CreateWalletResult`, `UnlockWalletResult`, `ReceiveRequest`/`Result`
-  (returns invoice + initial `Entry`), `SendRequest`/`Result` (returns
-  `Entry` + `ActualAmountSat`, which can exceed requested amount for
-  onchain whole-VTXO sweeps), `DepositRequest`/`Result` (boarding
+  (returns invoice + initial `Entry`), the two-step send DTOs
+  `PrepareSendRequest`/`PrepareSendResult` and
+  `SendPreparedRequest`/`SendResult` (`PrepareSend` quotes and returns a
+  single-use `SendIntentID`; `SendPrepared` dispatches it and returns
+  `Entry` + `ActualAmountSat`, which equals the requested amount for a
+  bounded send and the swept total for sweep-all), `DepositRequest`/`Result` (boarding
   address + initial `Entry`), `ListRequest`, `ListResult` (tagged union
   on `View`, populates one of `Activity`/`VTXOs`/`Onchain`),
   `ActivityList`, `VTXOInventory`, `OnchainHistory`, `Entry`
@@ -81,7 +84,8 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
 | `Balance` | Flat balance (`confirmed_sat`, `pending_in_sat`, `pending_out_sat`). |
 | `Deposit` | Allocate a fresh boarding address (`recv --onchain` from CLI). |
 | `Receive` | Open a Lightning invoice receive (`recv --offchain`). Returns `{Invoice, Entry}`. |
-| `Send` | Outbound payment by invoice or onchain address. Returns `{Entry, ActualAmountSat}`. |
+| `PrepareSend` | Validate + quote an outbound payment; returns a single-use `SendIntentID`. |
+| `SendPrepared` | Dispatch a prepared send (consumes `SendIntentID`). Returns `{Entry, ActualAmountSat}`. |
 | `List` | Unified history view (Activity / VTXOs / Onchain) as a tagged-union `ListResult`. |
 | `Exit` | Trigger cooperative leave or unilateral unroll for a VTXO. |
 | `ExitStatus` | Query the phase of an exit job. |

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -220,10 +220,10 @@ type SendResult struct {
 
 	// ActualAmountSat is the real amount that will leave the wallet for
 	// this operation. For invoice sends it matches the invoice principal.
-	// For onchain sends it reflects the sum of selected VTXOs and may
-	// exceed the requested amount under v1 whole-VTXO sweep semantics, so
-	// host UIs SHOULD echo it back to the user before treating the send
-	// as confirmed.
+	// For a bounded onchain send it matches the requested amount (the
+	// seal-time fee handshake returns change). For a sweep-all onchain
+	// send it reflects the swept VTXO total, so host UIs SHOULD echo it
+	// back to the user before treating the send as confirmed.
 	ActualAmountSat int64
 }
 

--- a/swapwallet/doc.go
+++ b/swapwallet/doc.go
@@ -57,12 +57,15 @@
 // in v1 should track the WalletEntry.Counterparty (truncated bech32
 // address or txid) and the persisted ledger txid via separate queries.
 //
-// Onchain SEND sweep semantics: the cooperative-leave path sweeps WHOLE
-// selected VTXOs to the destination, so the recipient may receive more
-// than the caller's amt_sat. SendResponse.actual_amount_sat carries the
-// real outflow and SHOULD be echoed to the user before treating the
-// send as confirmed. The "drain the wallet" intent is structurally
-// distinct in v1: SendRequest.sweep_all must be set explicitly and
-// amt_sat must be zero; a typo'd amt_sat=0 without sweep_all is rejected
-// up front at the wallet layer and again at the CLI.
+// Onchain SEND sweep semantics: a bounded onchain send (amt_sat > 0)
+// lands exactly amt_sat at the destination and returns the remainder as
+// a change VTXO under the seal-time fee handshake, so it does not
+// overpay. Only a sweep_all send drains WHOLE selected VTXOs, so only
+// then does SendResponse.actual_amount_sat exceed any single requested
+// figure; it carries the real outflow and SHOULD be echoed to the user
+// before treating the send as confirmed. The "drain the wallet" intent
+// is structurally distinct in v1: SendRequest.sweep_all must be set
+// explicitly and amt_sat must be zero; a typo'd amt_sat=0 without
+// sweep_all is rejected up front at the wallet layer and again at the
+// CLI.
 package swapwallet


### PR DESCRIPTION
Closes #778.

## What

Documentation and proto/AGENTS comments described a `walletdk` SDK API that no
longer exists and an overpay behavior that was fixed (#634 / PR #646). This
truths them up against current `main`:

- **Integration guide** (`docs/walletdk_integration.md`): rewrote the send
  example around the real two-step `PrepareSend` + `SendPrepared` flow, and the
  activity example around the `ListResult` tagged union
  (`history.Activity.Entries`, not `history.Entries`). Updated the verb lists.
- **SDK guides** (`sdk/walletdk/{AGENTS,CLAUDE}.md`): the DTO list and the
  RPC-methods table referenced a `Send` / `SendRequest` the SDK `Client` does
  not have; replaced with `PrepareSend` / `SendPrepared` +
  `PrepareSendRequest` / `SendPreparedRequest` / `SendResult`.
- **RPC guides** (`rpc/walletdkrpc/{AGENTS,CLAUDE}.md`): added the `PrepareSend`
  RPC to the method table (the `Send` RPC genuinely exists, so it stays) and
  corrected the `Exit` row — the SDK default is cooperative leave, not
  unilateral unroll.
- **Overpay warnings** scoped to **sweep-all** in `sdk/walletdk/types.go`
  (`SendResult`), `swapwallet/doc.go`, and the `SendResponse.actual_amount_sat`
  proto comment (`rpc/walletdkrpc/wallet.proto`, regenerated via `make rpc`).
  After #634 a bounded onchain send lands exactly `amt_sat` and returns change
  under the #270 seal-time fee handshake, so "may exceed amt_sat" is true only
  for sweep-all.

Comment/doc-only (plus the regenerated proto stub); no behavior change. Builds
under `-tags "walletdkrpc swapruntime"`; `make lint-changed-local` clean.
