### PR TITLE
multi: floor VTXO minimum at dust

### DIFF
--- a/darepod/rpc_oor_custom_input_test.go
+++ b/darepod/rpc_oor_custom_input_test.go
@@ -204,13 +204,13 @@ func TestRequireCustomSpendsMature(t *testing.T) {
 	}
 }
 
-// TestPrepareOORRejectsRecipientBelowDust verifies prepared custom-input OOR
-// packages use the same recipient dust guard as submitted OOR sends. The swap
-// cooperative-refund flow asks PrepareOOR to build a deterministic package
-// before any operator authorization happens, so a sub-dust recipient amount
-// must be rejected at this boundary instead of producing checkpoint material
-// that would later create an unusable receiver VTXO.
-func TestPrepareOORRejectsRecipientBelowDust(t *testing.T) {
+// TestPrepareOORRejectsRecipientBelowFloor verifies prepared custom-input
+// OOR packages use the same recipient VTXO-floor guard as submitted OOR sends.
+// The swap cooperative-refund flow asks PrepareOOR to build a deterministic
+// package before any operator authorization happens, so a sub-floor recipient
+// amount must be rejected at this boundary instead of producing checkpoint
+// material that would later create an unusable receiver VTXO.
+func TestPrepareOORRejectsRecipientBelowFloor(t *testing.T) {
 	t.Parallel()
 
 	fixture := newCustomOORRPCFixture(t)
@@ -226,7 +226,7 @@ func TestPrepareOORRejectsRecipientBelowDust(t *testing.T) {
 	)
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 	require.ErrorContains(
-		t, err, "amount 999 below operator dust_limit 1000",
+		t, err, "amount 999 below operator min_vtxo_amount_sat 1000",
 	)
 }
 

--- a/darepod/rpc_oor_idempotency_test.go
+++ b/darepod/rpc_oor_idempotency_test.go
@@ -220,13 +220,13 @@ func (a *capturingSendOORActor) capturedRequests() []*oor.StartTransferRequest {
 	return requests
 }
 
-// TestSendOORRejectsRecipientBelowDustBeforeWalletSelection verifies the
-// daemon enforces the operator's advertised dust limit before it selects wallet
-// inputs or submits work to the OOR actor. This is the daemon-side guard behind
-// `darepocli ark send oor`: a caller that asks to create a sub-dust recipient
-// VTXO must fail synchronously instead of leaving the receiver with a live VTXO
-// they cannot later spend cooperatively.
-func TestSendOORRejectsRecipientBelowDustBeforeWalletSelection(t *testing.T) {
+// TestSendOORRejectsRecipientBelowFloorBeforeWalletSelection verifies the
+// daemon enforces the operator's VTXO floor before it selects wallet inputs or
+// submits work to the OOR actor. This is the daemon-side guard behind
+// `darepocli ark send oor`: a caller that asks to create a below-floor
+// recipient VTXO must fail synchronously instead of leaving the receiver with a
+// live VTXO they cannot later spend cooperatively.
+func TestSendOORRejectsRecipientBelowFloorBeforeWalletSelection(t *testing.T) {
 	t.Parallel()
 
 	operatorKey, err := btcec.NewPrivateKey()
@@ -271,7 +271,7 @@ func TestSendOORRejectsRecipientBelowDustBeforeWalletSelection(t *testing.T) {
 	})
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 	require.ErrorContains(
-		t, err, "amount 999 below operator dust_limit 1000",
+		t, err, "amount 999 below operator min_vtxo_amount_sat 1000",
 	)
 }
 

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -269,7 +269,7 @@ func sumOORInputAmounts(inputs []oor.TransferInput) (btcutil.Amount, error) {
 // fee-less, so the selected input sum must be paid out exactly.
 func appendOORChangeRecipient(ctx context.Context,
 	recipients []oortx.RecipientOutput,
-	inputTotal, dustLimit btcutil.Amount,
+	inputTotal, outputFloor btcutil.Amount,
 	buildChange oorChangeRecipientBuilder) ([]oortx.RecipientOutput,
 	btcutil.Amount, error) {
 
@@ -300,11 +300,11 @@ func appendOORChangeRecipient(ctx context.Context,
 		return out, 0, nil
 	}
 
-	if dustLimit > 0 && change < dustLimit {
+	if outputFloor > 0 && change < outputFloor {
 		return nil, change, status.Errorf(codes.InvalidArgument, "OOR "+
-			"change output %d sat is below dust limit %d sat; "+
+			"change output %d sat is below VTXO minimum %d sat; "+
 			"choose exact inputs or a larger amount", change,
-			dustLimit)
+			outputFloor)
 	}
 
 	if buildChange == nil {
@@ -334,22 +334,24 @@ func appendOORChangeRecipient(ctx context.Context,
 	return out, change, nil
 }
 
-// validateOORRecipientDust enforces the operator's advertised output floor for
+// validateOORRecipientFloor enforces the operator's output floor for
 // caller-selected OOR recipients. Change outputs are checked later after input
 // selection; this guard prevents creating a receiver VTXO that the operator
 // would not accept in subsequent cooperative spends.
-func validateOORRecipientDust(amountSat int64, dustLimit btcutil.Amount) error {
-	if dustLimit <= 0 {
+func validateOORRecipientFloor(amountSat int64,
+	outputFloor btcutil.Amount) error {
+
+	if outputFloor <= 0 {
 		return nil
 	}
 
 	amount := btcutil.Amount(amountSat)
-	if amount >= dustLimit {
+	if amount >= outputFloor {
 		return nil
 	}
 
 	return status.Errorf(codes.InvalidArgument, "amount %d below operator "+
-		"dust_limit %d", amount, dustLimit)
+		"min_vtxo_amount_sat %d", amount, outputFloor)
 }
 
 // sendOORRequestRecipients returns the caller-requested OOR recipients in
@@ -430,8 +432,8 @@ func (r *RPCServer) buildSendOORRecipients(ctx context.Context,
 			return nil, indexedSendOORRecipientError(i, err)
 		}
 
-		if err := validateOORRecipientDust(
-			out.AmountSat, terms.DustLimit,
+		if err := validateOORRecipientFloor(
+			out.AmountSat, terms.MinVTXOAmountFloor(),
 		); err != nil {
 			return nil, indexedSendOORRecipientError(i, err)
 		}
@@ -617,10 +619,7 @@ func (r *RPCServer) GetInfo(ctx context.Context, _ *daemonrpc.GetInfoRequest) (
 			return resp, nil
 		}
 
-		minVTXOAmount := terms.MinVTXOAmount
-		if minVTXOAmount == 0 {
-			minVTXOAmount = terms.DustLimit
-		}
+		minVTXOAmount := terms.MinVTXOAmountFloor()
 
 		// The forfeit penalty key, sweep key and delay are no longer
 		// global operator terms; they are delivered per round in the
@@ -1947,7 +1946,7 @@ func (r *RPCServer) SendOnChain(ctx context.Context,
 		TargetAmountSat:     targetAmount,
 		SweepOutpoints:      sweepOutpoints,
 		OperatorFee:         terms.MinOperatorFee,
-		DustLimit:           terms.DustLimit,
+		DustLimit:           terms.MinVTXOAmountFloor(),
 		OperatorKey:         terms.PubKey,
 		VTXOExitDelay:       terms.VTXOExitDelay,
 		DryRun:              req.DryRun,
@@ -2265,7 +2264,7 @@ func (r *RPCServer) SendVTXO(ctx context.Context,
 	sendReq := &wallet.SendVTXOsRequest{
 		Recipients:    recipients,
 		OperatorFee:   terms.MinOperatorFee,
-		DustLimit:     terms.DustLimit,
+		DustLimit:     terms.MinVTXOAmountFloor(),
 		OperatorKey:   terms.PubKey,
 		VTXOExitDelay: terms.VTXOExitDelay,
 		DryRun:        req.DryRun,
@@ -2500,7 +2499,7 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 
 		selectReq := &wallet.SelectAndLockVTXOsRequest{
 			TargetAmount:    targetAmt,
-			MinChangeAmount: terms.DustLimit,
+			MinChangeAmount: terms.MinVTXOAmountFloor(),
 		}
 		selectFuture := wRef.Ask(ctx, selectReq)
 		selectResult := selectFuture.Await(ctx)
@@ -2558,7 +2557,7 @@ func (r *RPCServer) SendOOR(ctx context.Context,
 	}
 
 	recipients, changeAmt, err := appendOORChangeRecipient(
-		ctx, recipients, inputTotal, terms.DustLimit,
+		ctx, recipients, inputTotal, terms.MinVTXOAmountFloor(),
 		func(ctx context.Context, change btcutil.Amount) (
 			oortx.RecipientOutput, error) {
 
@@ -2758,8 +2757,8 @@ func (r *RPCServer) PrepareOOR(ctx context.Context,
 			"operator terms: %v", err)
 	}
 
-	if err := validateOORRecipientDust(
-		req.GetRecipient().GetAmountSat(), terms.DustLimit,
+	if err := validateOORRecipientFloor(
+		req.GetRecipient().GetAmountSat(), terms.MinVTXOAmountFloor(),
 	); err != nil {
 		return nil, err
 	}
@@ -2796,7 +2795,7 @@ func (r *RPCServer) PrepareOOR(ctx context.Context,
 	}}
 
 	recipients, _, err = appendOORChangeRecipient(
-		ctx, recipients, inputTotal, terms.DustLimit,
+		ctx, recipients, inputTotal, terms.MinVTXOAmountFloor(),
 		func(ctx context.Context, change btcutil.Amount) (
 			oortx.RecipientOutput, error) {
 

--- a/darepod/rpc_server_test.go
+++ b/darepod/rpc_server_test.go
@@ -272,7 +272,7 @@ func TestAppendOORChangeRecipient(t *testing.T) {
 		)
 	})
 
-	t.Run("dust change rejected", func(t *testing.T) {
+	t.Run("below-floor change rejected", func(t *testing.T) {
 		t.Parallel()
 
 		_, change, err := appendOORChangeRecipient(
@@ -285,10 +285,10 @@ func TestAppendOORChangeRecipient(t *testing.T) {
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		require.Equal(t, codes.InvalidArgument, st.Code())
-		require.Contains(t, st.Message(), "below dust limit")
+		require.Contains(t, st.Message(), "below VTXO minimum")
 	})
 
-	t.Run("limit change accepted", func(t *testing.T) {
+	t.Run("floor change accepted", func(t *testing.T) {
 		t.Parallel()
 
 		recipients, change, err := appendOORChangeRecipient(
@@ -981,6 +981,39 @@ func TestGetInfoIncludesServerInfo(t *testing.T) {
 	require.Equal(t, uint32(2), resp.ServerInfo.MinConfirmations)
 }
 
+// TestGetInfoFloorsMinVTXOAmountAtDust verifies GetInfo never exposes a
+// VTXO minimum below the cached dust limit.
+func TestGetInfoFloorsMinVTXOAmountAtDust(t *testing.T) {
+	t.Parallel()
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	server := &Server{
+		cfg: &Config{
+			Network: "regtest",
+			Wallet: &WalletConfig{
+				Type: WalletTypeBtcwallet,
+			},
+		},
+		log: btclog.Disabled,
+	}
+	server.setServerConnected(true)
+	server.storeOperatorTerms(&types.OperatorTerms{
+		PubKey:        operatorPriv.PubKey(),
+		DustLimit:     btcutil.Amount(546),
+		MinVTXOAmount: btcutil.Amount(100),
+	})
+	r := &RPCServer{server: server}
+
+	resp, err := r.GetInfo(
+		context.Background(), &daemonrpc.GetInfoRequest{},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp.ServerInfo)
+	require.Equal(t, uint64(546), resp.ServerInfo.MinVtxoAmountSat)
+}
+
 // TestOperatorPubKeyFetchesFreshTerms verifies callers that construct new
 // policy scripts can bypass GetInfo's cached server-info snapshot and refresh
 // it after a successful direct operator fetch.
@@ -1045,6 +1078,54 @@ func TestOperatorPubKeyFetchesFreshTerms(t *testing.T) {
 	)
 	require.Equal(
 		t, uint32(99), server.loadOperatorTerms().MaxOORLineageVBytes,
+	)
+}
+
+// TestOperatorPubKeyFloorsFetchedMinVTXOAmountAtDust verifies direct
+// operator refreshes normalize below-dust VTXO floors before caching them.
+func TestOperatorPubKeyFloorsFetchedMinVTXOAmountAtDust(t *testing.T) {
+	t.Parallel()
+
+	freshPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	server := &Server{
+		cfg: &Config{
+			Network: "regtest",
+			Wallet: &WalletConfig{
+				Type: WalletTypeBtcwallet,
+			},
+		},
+		log: btclog.Disabled,
+		serverConn: newBufconnClient(t, &fakeArkService{
+			getInfoResponse: &arkrpc.GetInfoResponse{
+				Pubkey: freshPriv.
+					PubKey().
+					SerializeCompressed(),
+				BoardingExitDelay: 144,
+				VtxoExitDelay:     288,
+				DustLimit:         546,
+				MinVtxoAmountSat:  100,
+			},
+		}),
+	}
+	r := &RPCServer{server: server}
+
+	key, err := r.OperatorPubKey(context.Background())
+	require.NoError(t, err)
+	require.True(t, key.IsEqual(freshPriv.PubKey()))
+
+	require.Equal(
+		t, btcutil.Amount(546),
+		server.loadOperatorTerms().MinVTXOAmount,
+	)
+
+	info, err := r.GetInfo(
+		context.Background(), &daemonrpc.GetInfoRequest{},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, uint64(546), info.GetServerInfo().GetMinVtxoAmountSat(),
 	)
 }
 

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -4209,7 +4209,7 @@ func (s *Server) fetchOperatorTerms(ctx context.Context) (*types.OperatorTerms,
 	}
 
 	minVTXOAmount := resp.MinVtxoAmountSat
-	if minVTXOAmount == 0 {
+	if minVTXOAmount < resp.DustLimit {
 		minVTXOAmount = resp.DustLimit
 	}
 

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -107,7 +107,13 @@ func NewPostgresStore(cfg *PostgresConfig,
 		slog.String("dsn", cfg.DSN(true)),
 	)
 
-	rawDB, err := sql.Open("pgx", cfg.DSN(false))
+	// Open with the version-qualified "pgx/v5" driver name rather than
+	// the bare "pgx" alias. The pgx v4 and v5 stdlib packages each
+	// register the unqualified name if no other major version has already
+	// claimed it, so the bare alias can depend on init order. Pinning the
+	// major version keeps the backend deterministic for migrations and
+	// error classification.
+	rawDB, err := sql.Open("pgx/v5", cfg.DSN(false))
 	if err != nil {
 		return nil, MapSQLError(err)
 	}

--- a/db/sqlerrors.go
+++ b/db/sqlerrors.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jackc/pgconn"
+	pgconnv4 "github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
+	pgconnv5 "github.com/jackc/pgx/v5/pgconn"
 	"modernc.org/sqlite"
 	sqlite3 "modernc.org/sqlite/lib"
 )
@@ -57,10 +58,17 @@ func MapSQLError(err error) error {
 		return parseSqliteError(sqliteErr)
 	}
 
-	// Attempt to interpret the error as a postgres error.
-	var pqErr *pgconn.PgError
-	if errors.As(err, &pqErr) {
-		return parsePostgresError(pqErr)
+	// Attempt to interpret the error as a postgres error. The pgx v4 and
+	// v5 stdlib drivers return distinct *pgconn.PgError types, so match
+	// both and classify by the shared SQLSTATE code.
+	var pgErrV4 *pgconnv4.PgError
+	if errors.As(err, &pgErrV4) {
+		return classifyPostgresError(pgErrV4.Code, pgErrV4)
+	}
+
+	var pgErrV5 *pgconnv5.PgError
+	if errors.As(err, &pgErrV5) {
+		return classifyPostgresError(pgErrV5.Code, pgErrV5)
 	}
 
 	// As a last step, check if this is a connection error that needs
@@ -115,38 +123,38 @@ func parseSqliteError(sqliteErr *sqlite.Error) error {
 	}
 }
 
-// parsePostgresError attempts to parse a postgres error as a database agnostic
+// classifyPostgresError maps a postgres SQLSTATE code to a database agnostic
 // SQL error.
-func parsePostgresError(pqErr *pgconn.PgError) error {
-	switch pqErr.Code {
+func classifyPostgresError(code string, dbErr error) error {
+	switch code {
 	// Handle unique constraint violation error.
 	case pgerrcode.UniqueViolation:
 		return &ErrSQLUniqueConstraintViolation{
-			DBError: pqErr,
+			DBError: dbErr,
 		}
 
 	// Unable to serialize the transaction, so we'll need to try again.
 	case pgerrcode.SerializationFailure:
 		return &ErrSerializationError{
-			DBError: pqErr,
+			DBError: dbErr,
 		}
 
 	// A write operation could not continue because of a conflict within
 	// the same database connection.
 	case pgerrcode.DeadlockDetected:
 		return &ErrDeadlockError{
-			DBError: pqErr,
+			DBError: dbErr,
 		}
 
 	// Handle schema error.
 	case pgerrcode.UndefinedColumn, pgerrcode.UndefinedTable:
 		return &ErrSchemaError{
-			DBError: pqErr,
+			DBError: dbErr,
 		}
 
 	default:
 		return fmt.Errorf("unknown postgres error: %w",
-			sanitizeConnectionError(pqErr))
+			sanitizeConnectionError(dbErr))
 	}
 }
 

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -76,6 +76,21 @@ type OperatorTerms struct {
 	MaxOORLineageVBytes uint32
 }
 
+// MinVTXOAmountFloor returns the effective minimum for a VTXO output. The
+// advertised VTXO minimum is authoritative when it is above dust, but dust
+// remains the floor for older or misconfigured operator snapshots.
+func (t *OperatorTerms) MinVTXOAmountFloor() btcutil.Amount {
+	if t == nil {
+		return 0
+	}
+
+	if t.MinVTXOAmount < t.DustLimit {
+		return t.DustLimit
+	}
+
+	return t.MinVTXOAmount
+}
+
 // JoinRoundRequest represents a participant's request to join a round.
 type JoinRoundRequest struct {
 	// Identifier is the participant's public key identifier associated with

--- a/lib/types/boarding_test.go
+++ b/lib/types/boarding_test.go
@@ -1,0 +1,60 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOperatorTermsMinVTXOAmountFloor verifies the effective VTXO floor
+// never falls below the operator's dust limit.
+func TestOperatorTermsMinVTXOAmountFloor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		terms *OperatorTerms
+		want  btcutil.Amount
+	}{{
+		name:  "nil terms",
+		terms: nil,
+		want:  0,
+	}, {
+		name: "uses VTXO minimum above dust",
+		terms: &OperatorTerms{
+			DustLimit:     btcutil.Amount(546),
+			MinVTXOAmount: btcutil.Amount(1234),
+		},
+		want: btcutil.Amount(1234),
+	}, {
+		name: "floors zero VTXO minimum at dust",
+		terms: &OperatorTerms{
+			DustLimit: btcutil.Amount(546),
+		},
+		want: btcutil.Amount(546),
+	}, {
+		name: "floors below-dust VTXO minimum at dust",
+		terms: &OperatorTerms{
+			DustLimit:     btcutil.Amount(546),
+			MinVTXOAmount: btcutil.Amount(100),
+		},
+		want: btcutil.Amount(546),
+	}, {
+		name: "floors negative VTXO minimum at dust",
+		terms: &OperatorTerms{
+			DustLimit:     btcutil.Amount(546),
+			MinVTXOAmount: btcutil.Amount(-1),
+		},
+		want: btcutil.Amount(546),
+	}}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.want, tc.terms.MinVTXOAmountFloor())
+		})
+	}
+}

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -471,7 +471,7 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 			return 0, err
 		}
 
-		return receiveSwapMinAmountSat(info.ServerInfo)
+		return vtxoMinAmountSat(info.ServerInfo)
 	}
 
 	service := &swapClientService{
@@ -943,17 +943,16 @@ func chainParamsForNetwork(network string) (*chaincfg.Params, error) {
 	}
 }
 
-// receiveSwapMinAmountSat returns the operator-advertised minimum VTXO output
-// amount for receive swaps. A Lightning-to-Ark receive is funded as an Ark
-// vHTLC, not as an on-chain boarding deposit, so the VTXO floor is the
-// relevant local preflight. The swap server may still apply additional
-// server-side policy before returning a route hint.
-func receiveSwapMinAmountSat(info *sdkark.ServerInfo) (uint64, error) {
+// vtxoMinAmountSat returns the effective minimum VTXO output amount. Pay
+// and receive swaps both create Ark VTXOs, so both rails use the same VTXO
+// floor before asking the swap server for route hints or persisting local
+// swap state.
+func vtxoMinAmountSat(info *sdkark.ServerInfo) (uint64, error) {
 	if info == nil {
 		return 0, fmt.Errorf("operator terms unavailable")
 	}
 
-	if info.MinVTXOAmountSat > 0 {
+	if info.MinVTXOAmountSat > info.DustLimit {
 		return info.MinVTXOAmountSat, nil
 	}
 

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -533,18 +533,25 @@ func TestStartReceiveRejectsAmountBelowOperatorVTXOMin(t *testing.T) {
 	require.Equal(t, 0, fakeClient.startReceiveCount())
 }
 
-func TestReceiveSwapMinAmountUsesMinVTXOAmount(t *testing.T) {
+func TestVTXOMinAmountUsesMinVTXOAmount(t *testing.T) {
 	t.Parallel()
 
-	amount, err := receiveSwapMinAmountSat(&sdkark.ServerInfo{
+	amount, err := vtxoMinAmountSat(&sdkark.ServerInfo{
 		DustLimit:        546,
 		MinVTXOAmountSat: 1_234,
 	})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1_234), amount)
 
-	amount, err = receiveSwapMinAmountSat(&sdkark.ServerInfo{
+	amount, err = vtxoMinAmountSat(&sdkark.ServerInfo{
 		DustLimit: 546,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(546), amount)
+
+	amount, err = vtxoMinAmountSat(&sdkark.ServerInfo{
+		DustLimit:        546,
+		MinVTXOAmountSat: 100,
 	})
 	require.NoError(t, err)
 	require.Equal(t, uint64(546), amount)

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -669,8 +669,8 @@ type SendVTXOsRequest struct {
 	// operator.
 	OperatorFee btcutil.Amount
 
-	// DustLimit is the minimum viable VTXO output amount. Change
-	// below this threshold causes the send to be rejected.
+	// DustLimit is the effective minimum viable VTXO output amount.
+	// Change below this threshold causes the send to be rejected.
 	DustLimit btcutil.Amount
 
 	// OperatorKey is the operator's public key for constructing
@@ -761,9 +761,9 @@ type SendOnChainRequest struct {
 	// binding fee comes from the server's seal-time quote.
 	OperatorFee btcutil.Amount
 
-	// DustLimit is the change-VTXO dust floor (typically
-	// OperatorTerms.DustLimit). Added to OperatorFee when computing
-	// coin-selection headroom in bounded mode.
+	// DustLimit is the effective change-VTXO floor. Added to
+	// OperatorFee when computing coin-selection headroom in bounded
+	// mode.
 	DustLimit btcutil.Amount
 
 	// OperatorKey is the operator's pubkey for the change-VTXO

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2521,10 +2521,10 @@ func (a *Ark) handleSendVTXOs(ctx context.Context,
 		)
 	}
 
-	if change > 0 && change <= req.DustLimit {
+	if change > 0 && change < req.DustLimit {
 		return fn.Err[WalletResp](
-			fmt.Errorf("change %d is below dust limit %d; adjust "+
-				"send amount", change, req.DustLimit),
+			fmt.Errorf("change %d is below VTXO minimum %d; "+
+				"adjust send amount", change, req.DustLimit),
 		)
 	}
 
@@ -2889,8 +2889,8 @@ func (a *Ark) handleSendOnChain(ctx context.Context,
 		change = totalSelected - req.TargetAmountSat
 		if change < req.DustLimit {
 			return fn.Err[WalletResp](
-				fmt.Errorf("change amount %d is below dust "+
-					"limit %d", change, req.DustLimit),
+				fmt.Errorf("change amount %d is below VTXO "+
+					"minimum %d", change, req.DustLimit),
 			)
 		}
 	}

--- a/wallet/wallet_admission_test.go
+++ b/wallet/wallet_admission_test.go
@@ -1254,9 +1254,9 @@ func TestSendVTXOsMultiRecipientZeroChangeRejects(t *testing.T) {
 	require.Zero(t, roundActor.registerCalls)
 }
 
-// TestSendVTXOsDustChange verifies that change below the dust limit
+// TestSendVTXOsBelowFloorChange verifies that change below the VTXO floor
 // is rejected.
-func TestSendVTXOsDustChange(t *testing.T) {
+func TestSendVTXOsBelowFloorChange(t *testing.T) {
 	t.Parallel()
 
 	mgr := &mockVTXOManagerBehavior{
@@ -1291,10 +1291,54 @@ func TestSendVTXOsDustChange(t *testing.T) {
 	})
 	_, err := result.Unpack()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "below dust limit")
+	require.Contains(t, err.Error(), "below VTXO minimum")
 
 	// Round should not have been called.
 	require.Equal(t, 0, roundActor.registerCalls)
+}
+
+// TestSendVTXOsFloorChange verifies that change exactly at the VTXO floor
+// is accepted.
+func TestSendVTXOsFloorChange(t *testing.T) {
+	t.Parallel()
+
+	mgr := &mockVTXOManagerBehavior{
+		selectForfeitResp: &actormsg.SelectAndReserveForfeitResponse{
+			SelectedVTXOs: []actormsg.SelectedVTXO{
+				{
+					Outpoint: testOutpoint(0),
+					Amount:   41546,
+					PkScript: []byte{
+						0x51,
+						0x20,
+						0x01,
+					},
+				},
+			},
+			TotalSelected: 41546,
+		},
+		forfeitReleaseResp: &actormsg.ReleaseForfeitResponse{
+			ReleasedCount: 1,
+		},
+	}
+	roundActor := &mockRoundActorBehavior{}
+
+	w := newTestWalletForSend(t, mgr, roundActor)
+
+	result := w.Receive(t.Context(), &SendVTXOsRequest{
+		Recipients:    []SendRecipient{testSendRecipient(40000)},
+		OperatorFee:   1000,
+		DustLimit:     546,
+		OperatorKey:   testOperatorKey(),
+		VTXOExitDelay: 144,
+	})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	sendResp, ok := resp.(*SendVTXOsResponse)
+	require.True(t, ok)
+	require.Equal(t, btcutil.Amount(546), sendResp.ChangeAmount)
+	require.Equal(t, 1, roundActor.registerCalls)
 }
 
 // TestSendVTXOsDryRun verifies that dry-run validates selection then


### PR DESCRIPTION
## Summary

This follow-up addresses the review feedback from #771 and the boundary comments on this PR.

- Floor the advertised VTXO minimum at the operator dust limit before caching terms or returning `GetInfo`.
- Use the effective VTXO floor for swap preflight and for daemon-created VTXO outputs such as OOR change, directed sends, and SendOnChain change.
- Accept wallet change exactly at the VTXO floor, reject only change below it, and report the threshold as the VTXO minimum rather than a dust limit.
- Rename the swap helper so it reflects both pay and receive flows, then add below-dust coverage for each touched path.

## Tests

- `make unit pkg=lib/types timeout=5m`
- `make unit pkg=darepod timeout=5m`
- `make unit pkg=wallet timeout=5m`
- `make unit pkg=swapclientserver tags="swapruntime walletdkrpc" timeout=5m`
- `make fmt-changed`
- `make lint-changed-local`
- `make commitmsg-lint`
- `make fmt-changed-check`
