### PR TITLE
scripts: fix doc-check.sh swallowing per-package errors

### DIFF
--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -26,7 +26,7 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `Receptionist` — Service locator mapping `ServiceKey` → `ActorRef` for decoupled actor wiring.
 - `Message` — Sealed interface for all actor messages (must embed `BaseMessage`).
 - `MessageCodec` — TLV-based codec for message serialization/deserialization.
-- `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter).
+- `DeliveryStore` / `TxAwareDeliveryStore` — Interfaces for durable mailbox persistence (enqueue, claim, ack, dead-letter). The leaseless single-worker fast path adds `PeekNextMessage` (read-only claim, no lease, no attempts bump; yields an empty lease token), `AckMessageByID` (unfenced delete), and `NackMessageByID` (unfenced release that increments attempts). A `DurableActor` enables it (via `DurableMailboxConfig.SingleWorkerLeaseless`) strictly when `NumWorkers == 1` AND the behavior is the Read/Commit (Right/`TxBehavior`) path, eliminating the per-message lease write transaction. The multi-worker pool and the classic path are byte-for-byte unchanged: they keep `LeaseNextMessage` and the lease-fenced ack. Ack/nack route to the by-ID ops automatically whenever the delivery's lease token is empty; `Delivery.ShouldDeadLetter` counts the in-flight attempt as `Attempts + 1` on the leaseless path so the dead-letter boundary matches the leased path (where attempts is pre-incremented at lease).
 - `DurableActor` — Actor variant with crash-safe mailbox backed by SQL persistence. Provides `Wait(ctx)` to block until the actor stops and `StopAndWait(ctx)` to request a graceful shutdown and then wait.
 - `DurableActorConfig[M, R]` — Configuration struct for `DurableActor`: behavior, store, codec, clock, DLO, WaitGroup, `TellRetryPolicy`, lease/heartbeat/poll durations, max attempts, cleanup timeout, deduplication TTL, and `NumWorkers`.
 - `DurableActorConfig.NumWorkers` — How many concurrent worker loops drain the actor's single mailbox. Default and any value `<= 1` is one worker (strictly-sequential processing). A value `> 1` turns the actor into a competing-consumer pool: that many goroutines each lease distinct messages via `LeaseNextMailboxMessage`, so independent messages run in parallel while per-correlation-key FIFO still keeps same-key messages ordered. Only for behaviors whose handlers are concurrency-safe and hold no writer across their side effects (e.g. the serverconn egress sender on the Read/Commit path). `NewDurableActor` **fails closed** with `ErrConcurrentClassicBehavior` when `NumWorkers > 1` is paired with a classic (`Left`) `ActorBehavior`, since the classic path wraps the whole `Receive` in one write transaction and assumes sequential delivery; pools are only valid on the Read/Commit (`TxBehavior`) path. The test-only `DurableActorConfig.AllowConcurrentClassicBehavior()` escape hatch bypasses the guard for the egress benchmark that measures the forbidden config; production code must never call it.
@@ -81,8 +81,24 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 ## Invariants
 
 - Messages are processed sequentially per actor by default (one worker, no concurrent `Receive` calls). Opting into `DurableActorConfig.NumWorkers > 1` relaxes this: that many worker loops drain the one mailbox concurrently, so `Receive` may run in parallel across distinct messages. The competing-consumer lease guarantees each message is still processed by exactly one worker, and per-correlation-key FIFO holds across workers; only behaviors with concurrency-safe handlers should set it. The combination is structurally restricted to the Read/Commit path: `NewDurableActor` rejects `NumWorkers > 1` on a classic `ActorBehavior` with `ErrConcurrentClassicBehavior` so a stateful, sequentially-assumed actor can never be silently fanned out.
+- **Leaseless consume ownership model.** `SingleWorkerLeaseless` removes the
+  lease-token fence, so its safety argument is "one live runtime owner for this
+  mailbox", not merely "one goroutine in this process". Do not enable it for a
+  mailbox that can be drained by another daemon/process at the same time unless
+  an external singleton/ownership fence already exists. A peeked delivery always
+  carries an empty lease token, even when the persisted row still has stale
+  expired lease metadata from an older leased claim; that empty token is the
+  p-model edge that routes ack/nack to the by-ID operations. Retry-policy
+  decisions must use `Delivery.EffectiveAttempts()` so the in-flight peeked
+  attempt is counted before a nack can raise the row to `max_attempts`.
 - `Tell` with a `DurableActor` persists the message before returning (crash-safe enqueue).
 - Outbox messages are dispatched only after state is persisted (outbox pattern).
+- **Outbox fold p-model.** For tx-aware stores, outbox delivery is
+  `claim -> (target mailbox enqueue + CompleteOutbox) in one write tx`. If the
+  transaction fails before commit, both the enqueue and completion roll back and
+  the claim expiry is the retry mechanism; the publisher must log the
+  transaction failure even when the inner Tell/Complete operations returned nil,
+  because begin/commit failures happen outside those operation-level logs.
 - `ServiceKey` lookup via `Receptionist` is type-safe: mismatched types return `ErrServiceKeyTypeMismatch`.
 - `RestartMessage` has `RestartPriority` (MaxInt32) ensuring it is processed before all other messages on recovery.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.

--- a/db/actordelivery/AGENTS.md
+++ b/db/actordelivery/AGENTS.md
@@ -30,9 +30,20 @@ other services can reuse durable actor storage without pulling unrelated tables.
   a `TxActorDeliveryStore` scoped to that transaction, and on successful commit
   fires outbox-wake callbacks when outbox messages were enqueued inside the tx.
 - `ActorDeliveryQueries` — Interface for all actor delivery SQL operations:
-  mailbox enqueue/lease/ack/nack/extend/expire, ask results, outbox
+  mailbox enqueue/lease/peek/ack/nack/extend/expire, ask results, outbox
   claim/complete/fail, deduplication, FSM checkpoints, dead letters, and
   cleanup. Implemented by the SQLC-generated query set.
+- **Leaseless single-worker consume path** — `PeekNextMailboxMessage` (a
+  READ-only claim that mirrors `LeaseNextMailboxMessage`'s eligibility and
+  ordering but takes no lease and does NOT bump attempts),
+  `AckMailboxMessageByID` (unfenced delete by id), and
+  `NackMailboxMessageByID` (unfenced release that increments attempts).
+  Exposed on both `Store` and `TxActorDeliveryStore` as `PeekNextMessage`
+  (read tx), `AckMessageByID`, and `NackMessageByID`. Used only by
+  `NumWorkers == 1` Read/Commit actors, which have no competing consumer to
+  fence; the multi-worker pool keeps lease + fenced ack. The by-ID nack
+  increments attempts because the peek does not, preserving dead-lettering
+  on max attempts.
 - `BatchedActorDeliveryQueries` — Batched transaction wrapper for
   `ActorDeliveryQueries`.
 - `MigrationOption` — Functional options for migration configuration
@@ -65,6 +76,12 @@ other services can reuse durable actor storage without pulling unrelated tables.
   goroutines.
 - `TxAwareActorDeliveryStore.ExecTx` always defers `tx.Rollback()` so partial
   writes cannot survive a function error; commit is the only success path.
+- `PeekNextMessage` is a read-only eligibility check, not an ownership write.
+  The store adapter must map every peeked row to an empty lease token before it
+  reaches the actor layer, including rows that still carry stale expired lease
+  metadata from a previous leased claim. The by-ID nack path clears that stale
+  metadata while incrementing attempts, preserving the leaseless p-model:
+  `peek -> empty-token delivery -> by-ID ack/nack`.
 
 ## Deep Docs
 

--- a/p-models/durableactor/AGENTS.md
+++ b/p-models/durableactor/AGENTS.md
@@ -3,15 +3,24 @@
 This package models the durable actor mailbox from distributed-systems first
 principles: durable enqueue, lease ownership, retry scheduling, ack/nack token
 validation, dead-letter/removal, idempotent delivery identity,
-per-correlation-key FIFO, and the Read/Commit consume step (lease-fenced
-exactly-once effect application under lease-expiry-during-IO).
+per-correlation-key FIFO, the Read/Commit consume step (lease-fenced
+exactly-once effect application under lease-expiry-during-IO), and the CDC
+outbox fold (the target enqueue and the outbox completion committing as one
+transaction, with no-lost-message and exactly-once-delivery guarantees).
 
 ## Files
 
 - `infra.pproj` — P project for durable actor infrastructure checks.
 - `src/mailbox_fifo.p` — ideal mailbox spec plus claim-ordering profiles.
+- `src/ingress_fold.p` — connection-actor ingress cursor spec: the persisted
+  PullCursor must never cover an envelope whose local enqueue did not commit
+  (the transactional dispatch fold makes batch enqueues + cursor one atomic
+  commit).
 - `test/mailbox_fifo_test.p` — green conformance tests and separate
   counterexample tests.
+- `test/ingress_fold_test.p` — green atomic-fold drain test plus the two
+  cursor-loss counterexamples (eager in-memory cursor after rollback;
+  checkpoint commit ordered before the enqueue commits).
 - `traces/*.json` — concrete scenarios replayed by the Go bridge.
 - `bridge/` — Go conformance harness against the real `db/actordelivery`
   SQLite store and claim SQL.
@@ -29,7 +38,12 @@ exactly-once effect application under lease-expiry-during-IO).
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStageCommitExactlyOnce` | Run the green Stage-then-Commit replay-safety test |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStagedDoubleBroadcastCounterexample` | Demonstrate the unstable-broadcast double-broadcast bug |
 | `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcMailboxStaleStageRegressesCounterexample` | Demonstrate the unfenced-stage checkpoint regression bug |
-| `go test ./p-models/durableactor/bridge` | Replay traces against Go |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressFoldNoLoss` | Run the green transactional ingress-fold no-loss test |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressEagerCursorCounterexample` | Demonstrate the eager-cursor-after-rollback message loss |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcIngressCheckpointFirstCounterexample` | Demonstrate the checkpoint-before-enqueue message loss |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcOutboxFold` | Run the green transactional outbox-fold test |
+| `p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll --testcase tcOutboxSplitWriteCounterexample` | Demonstrate the split-write lost-message bug |
+| `go test ./p-models/durableactor/bridge` | Replay traces and the outbox-fold/crash-restart bridge tests against Go |
 
 ## Modeling Guidance
 

--- a/p-models/durableactor/bridge/AGENTS.md
+++ b/p-models/durableactor/bridge/AGENTS.md
@@ -23,9 +23,34 @@ than the P checker.
   sorted by `TraceID`.
 - `ReplayMailboxTrace(t, trace)` — Replays a trace against a fresh SQLite
   `actordelivery` store in a temp dir. The `commit` op models the Read/Commit
-  fenced-ack pattern exactly: it runs `AckMessage` + `MarkProcessed` inside one
-  writer transaction, rolling back with `actor.ErrLeaseLost` when the ack row
-  count is zero.
+  consume step exactly: it runs the ack + `MarkProcessed` inside one writer
+  transaction, rolling back with `actor.ErrLeaseLost` when the ack row count is
+  zero. The ack op is chosen by lease token exactly as production `ackMessage`
+  routes it: a leased commit (`lease_token` set) acks under the lease fence via
+  `AckMessage`, while a leaseless commit (empty `lease_token`, the single-worker
+  peek path) acks via `AckMessageByID`. Both halves are trace-covered
+  (`mailbox_read_commit_fenced_exactly_once` and
+  `mailbox_leaseless_commit_fold`).
+
+## Direct bridge tests (not JSON-trace driven)
+
+Some contracts span a transaction boundary or a process restart and do not fit
+the per-op JSON replay model, so they are written as direct Go tests that drive
+the real store:
+
+- `outbox_fold_test.go` — the Go analog of the `tcOutboxFold` P scenario. It
+  runs `deliverMessage`'s fold (`EnqueueMessage` + `CompleteOutbox` inside one
+  `ExecTx`) against the real store and asserts the SQL-level contract: a fold
+  that fails after the enqueue rolls back with no orphan in the target mailbox
+  and the outbox row stays pending until claim expiry; a redelivery lands
+  exactly once; and a stale-token completion is a fenced 0-row no-op while the
+  idempotent (`ON CONFLICT id`) enqueue collapses a concurrent reclaim's
+  duplicate.
+- `crash_restart_test.go` — reopens a fresh `*sql.DB` and store against the same
+  on-disk SQLite file to model a process restart. It asserts a peeked-but-unacked
+  message survives a crash with attempts unchanged (peek is read-only), and a
+  leased-but-unacked message survives with its attempt bump durable and becomes
+  re-leasable after `ExpireLeases`.
 
 ## Relationships
 
@@ -38,9 +63,12 @@ than the P checker.
 
 - Every trace op that can fail hard uses `t.Fatal`; partial replays are not
   allowed to proceed silently.
-- The `commit` op is the sole site where `ExecTx`/`AckMessage`/`MarkProcessed`
-  are combined — it deliberately mirrors `execCore.commit` in `baselib/actor`
-  so the P model's commit-fence scenario stays tied to the real SQL path.
+- The `commit` op is the sole site where `ExecTx`/ack/`MarkProcessed` are
+  combined — it deliberately mirrors `execCore.commit` in `baselib/actor`,
+  routing the ack to `AckMessage` (leased) or `AckMessageByID` (leaseless,
+  empty token) exactly as production `ackMessage` does, so the P model's
+  commit-fence scenario stays tied to the real SQL path on both the leased and
+  leaseless single-worker consume.
 - Duplicate enqueue ops (`ExpectDuplicate: true`) must complete without error;
   a future rejection would fail here explicitly rather than at a later lease
   step.

--- a/scripts/doc-check.sh
+++ b/scripts/doc-check.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # doc-check.sh — Verify documentation cross-links are valid.
 #
 # Checks:
@@ -6,30 +6,39 @@
 #   2. All per-package CLAUDE.md files have an identical AGENTS.md.
 #   3. All packages listed in ARCHITECTURE.md have a CLAUDE.md.
 #   4. All files in docs/ are listed in docs/index.md.
+#
+# Uses only portable shell constructs (no bash-only features such as process
+# substitution, `[[ ... ]]`, or `pipefail`). In particular we iterate with
+# `for` over command substitution instead of piping into a `while` loop: a
+# piped `while` runs in a subshell, so the `fail` helper's increments to
+# `errors` would be lost and the script would always exit 0 regardless of the
+# failures it printed. Scanned paths are repo-internal and whitespace-free, so
+# word-splitting in the `for` lists is safe.
 
-set -euo pipefail
+set -eu
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 errors=0
 
-# Helper to report errors without exiting immediately.
+# fail reports an error without exiting immediately.
 fail() {
 	echo "ERROR: $1" >&2
 	errors=$((errors + 1))
 }
 
 echo "==> Checking docs/ files referenced in CLAUDE.md..."
-grep -oE 'docs/[a-zA-Z0-9_-]+\.md' CLAUDE.md | sort -u | while read -r docref; do
+for docref in $(grep -oE 'docs/[a-zA-Z0-9_-]+\.md' CLAUDE.md | sort -u); do
 	if [ ! -f "$docref" ]; then
 		fail "CLAUDE.md references '$docref' but file does not exist"
 	fi
 done
 
 echo "==> Checking per-package CLAUDE.md / AGENTS.md pairs..."
-find . -mindepth 2 -name 'CLAUDE.md' -not -path './.claude/*' \
-	-not -path './.git/*' -not -path './vendor/*' | sort | while read -r claude_file; do
+for claude_file in $(find . -mindepth 2 -name 'CLAUDE.md' \
+	-not -path './.claude/*' -not -path './.git/*' \
+	-not -path './vendor/*' | sort); do
 	dir="$(dirname "$claude_file")"
 	agents_file="$dir/AGENTS.md"
 	if [ ! -f "$agents_file" ]; then
@@ -42,20 +51,20 @@ done
 echo "==> Checking packages in ARCHITECTURE.md have CLAUDE.md..."
 # Extract package directory references from markdown table links like
 # [`name`](path/).
-grep -oE '\[`[^`]+`\]\([^)]+\)' ARCHITECTURE.md | \
-	grep -oE '\([^)]+\)' | tr -d '()' | \
-	sed 's|/$||' | sort -u | while read -r pkg_path; do
+for pkg_path in $(grep -oE '\[`[^`]+`\]\([^)]+\)' ARCHITECTURE.md | \
+	grep -oE '\([^)]+\)' | tr -d '()' | sed 's|/$||' | sort -u); do
 	# Skip docs/ references, anchor-only links, and non-directory refs.
-	if [[ "$pkg_path" == docs/* ]] || [[ "$pkg_path" == \#* ]]; then
-		continue
-	fi
+	case "$pkg_path" in
+	docs/*|'#'*) continue ;;
+	esac
 	if [ -d "$pkg_path" ] && [ ! -f "$pkg_path/CLAUDE.md" ]; then
 		fail "ARCHITECTURE.md references '$pkg_path/' but $pkg_path/CLAUDE.md is missing"
 	fi
 done
 
 echo "==> Checking docs/ files are listed in docs/index.md..."
-find docs/ -maxdepth 1 -name '*.md' -not -name 'index.md' | sort | while read -r docfile; do
+for docfile in $(find docs/ -maxdepth 1 -name '*.md' -not -name 'index.md' | \
+	sort); do
 	basename="$(basename "$docfile")"
 	if ! grep -qF -- "$basename" docs/index.md; then
 		fail "$docfile is not listed in docs/index.md"


### PR DESCRIPTION
## Problem

`make doc-check` (via `scripts/doc-check.sh`) is supposed to enforce, among
other things, that every package's `CLAUDE.md` and `AGENTS.md` are identical.
In practice it **always exited 0**, even while printing `ERROR: … have
diverged` lines.

## Root cause

Each scan was piped into a `while` loop:

```sh
find . -name 'CLAUDE.md' ... | sort | while read -r f; do ... fail ...; done
```

A piped `while` runs in a **subshell**, so the `fail` helper's
`errors=$((errors + 1))` mutated a copy that vanished when the subshell
exited. The final `if [ "$errors" -gt 0 ]` always saw `0`.

Note: this is the local `make doc-check` helper. The CI "in sync" gate
(`.github/scripts/check-agent-docs-sync.sh`) only compares the **root**
`CLAUDE.md`/`AGENTS.md`, so per-package drift was unenforced anywhere.

## Fix

- Iterate with a `for` loop over command substitution instead of piping into
  `while`, so the loop body runs in the current shell and `errors` survives.
- Made the script fully portable per review feedback (no bash-only features):
  `#!/bin/sh`, `set -eu` (dropped `pipefail`), and `case` instead of
  `[[ ... ]]`. Scanned paths are repo-internal and whitespace-free, so the
  unquoted `for` lists are safe.
- The now-working check immediately surfaced 4 drifted mirror pairs; resynced
  them by copying the canonical `CLAUDE.md` over each `AGENTS.md`
  (`baselib/actor`, `db/actordelivery`, `p-models/durableactor`,
  `p-models/durableactor/bridge`).

## Verification

```
$ sh -n scripts/doc-check.sh && dash -n scripts/doc-check.sh   # both clean
$ /bin/sh scripts/doc-check.sh        # synced tree
OK: All documentation cross-links are valid.          (exit 0)

# perturb one AGENTS.md:
$ /bin/sh scripts/doc-check.sh
ERROR: ./baselib/actor/CLAUDE.md and ./baselib/actor/AGENTS.md have diverged
FAIL: 1 documentation cross-link error(s) found.      (exit 1)
```

Commits split so no intermediate state is broken (resync first, then the
script fix).