### PR TITLE
walletdk: machine-readable rejection taxonomy + errors.Is sentinels

### DIFF
--- a/cmd/darepod/walletdkrpc.go
+++ b/cmd/darepod/walletdkrpc.go
@@ -30,4 +30,10 @@ func configureWalletRPC(cfg *darepod.Config) {
 	cfg.RPCGatewayRegistrars = append(
 		cfg.RPCGatewayRegistrars, swapwallet.RegisterGateway,
 	)
+
+	// Map walletdkrpc sentinel errors to machine-readable status codes so
+	// clients can branch on failure cause without string matching.
+	cfg.UnaryServerInterceptors = append(
+		cfg.UnaryServerInterceptors, swapwallet.ErrorMappingInterceptor,
+	)
 }

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -193,6 +193,12 @@ type Config struct {
 	// user-provided daemon settings.
 	RPCServiceRegistrars []RPCServiceRegistrar
 
+	// UnaryServerInterceptors wrap every unary RPC handler on the daemon
+	// gRPC server. Like RPCServiceRegistrars they wire compiled-in runtime
+	// capabilities (such as mapping walletdkrpc sentinel errors to
+	// machine-readable status codes), not user-provided daemon settings.
+	UnaryServerInterceptors []grpc.UnaryServerInterceptor
+
 	// RPCGatewayRegistrars are programmatic hooks that may register
 	// optional subservers on the daemon HTTP/JSON gateway after
 	// DaemonService is registered.

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1214,7 +1214,9 @@ func (s *Server) run(ctx context.Context, shutdownFn func()) error {
 	//
 	// TODO(roasbeef): Wire RPC.TLSCertPath/TLSKeyPath into
 	// grpc.Creds() once the auto-gen TLS material is in place.
-	s.grpcServer = grpc.NewServer()
+	s.grpcServer = grpc.NewServer(
+		grpc.ChainUnaryInterceptor(s.cfg.UnaryServerInterceptors...),
+	)
 	daemonrpc.RegisterDaemonServiceServer(
 		s.grpcServer, s.rpcServer,
 	)

--- a/rpc/walletdkrpc/failure_reasons.go
+++ b/rpc/walletdkrpc/failure_reasons.go
@@ -1,0 +1,27 @@
+package walletdkrpc
+
+// This file is hand-written (not generated): it defines the wallet rejection
+// taxonomy that the daemon attaches to a failed wallet RPC as a
+// google.rpc.ErrorInfo, and that SDK clients reconstruct into typed errors.
+// It lives in walletdkrpc because the reasons are part of the wallet RPC wire
+// contract; both the daemon-side mapper and the SDK reconstructor import these
+// constants so the two halves cannot drift.
+
+// FailureDomain is the google.rpc.ErrorInfo Domain that tags walletdk wallet
+// rejection reasons. Clients confirm this domain before branching on Reason so
+// a same-named reason from another subsystem is not misread.
+const FailureDomain = "walletdk"
+
+// Stable, machine-readable wallet rejection reasons carried in the ErrorInfo
+// detail of a failed wallet RPC. These are a wire contract: existing values
+// MUST NOT be renamed (clients match on them); add new values as needed.
+const (
+	ReasonInvalidDestination     = "INVALID_DESTINATION"
+	ReasonInvalidSendIntent      = "INVALID_SEND_INTENT"
+	ReasonAmountRequired         = "AMOUNT_REQUIRED"
+	ReasonAmountInvalid          = "AMOUNT_INVALID"
+	ReasonUnsupportedKind        = "UNSUPPORTED_KIND"
+	ReasonSwapBackendUnavailable = "SWAP_BACKEND_UNAVAILABLE"
+	ReasonAmountExceedsVTXOLimit = "AMOUNT_EXCEEDS_VTXO_LIMIT"
+	ReasonBalanceLimitExceeded   = "BALANCE_LIMIT_EXCEEDED"
+)

--- a/sdk/walletdk/connect_grpc.go
+++ b/sdk/walletdk/connect_grpc.go
@@ -20,6 +20,13 @@ func connectGRPC(ctx context.Context, cfg ConnectConfig) (*Client, error) {
 		)
 	}
 
+	// Reconstruct errors.Is-able sentinels from the daemon's walletdk
+	// ErrorInfo details on every wallet RPC.
+	dialOpts = append(
+		dialOpts,
+		grpc.WithChainUnaryInterceptor(errorReconstructInterceptor),
+	)
+
 	conn, err := grpc.NewClient(cfg.Address, dialOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("dial wallet daemon: %w", err)

--- a/sdk/walletdk/embedded.go
+++ b/sdk/walletdk/embedded.go
@@ -162,6 +162,7 @@ func Start(ctx context.Context, cfg Config, opts ...Option) (*Client, error) {
 
 			return listener.DialContext(dialCtx)
 		}),
+		grpc.WithChainUnaryInterceptor(errorReconstructInterceptor),
 	}
 
 	conn, err := grpc.NewClient("passthrough:///bufnet", dialOpts...)
@@ -364,6 +365,10 @@ func cloneDaemonConfig(cfg *darepod.Config) *darepod.Config {
 
 	clone.RPCServiceRegistrars = append(
 		[]darepod.RPCServiceRegistrar(nil), cfg.RPCServiceRegistrars...,
+	)
+	clone.UnaryServerInterceptors = append(
+		[]grpc.UnaryServerInterceptor(nil),
+		cfg.UnaryServerInterceptors...,
 	)
 	clone.WalletReadyHooks = append(
 		[]darepod.WalletReadyHook(nil), cfg.WalletReadyHooks...,

--- a/sdk/walletdk/embedded_test.go
+++ b/sdk/walletdk/embedded_test.go
@@ -66,6 +66,13 @@ func TestCloneDaemonConfigIsolation(t *testing.T) {
 			return nil
 		},
 	}
+	original.UnaryServerInterceptors = []grpc.UnaryServerInterceptor{
+		func(ctx context.Context, req any, _ *grpc.UnaryServerInfo,
+			handler grpc.UnaryHandler) (any, error) {
+
+			return handler(ctx, req)
+		},
+	}
 
 	clone := cloneDaemonConfig(original)
 

--- a/sdk/walletdk/errmap.go
+++ b/sdk/walletdk/errmap.go
@@ -1,0 +1,82 @@
+//go:build !js
+
+package walletdk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+// reasonToSentinel maps each daemon failure reason to the SDK sentinel callers
+// match with errors.Is. The reason strings come from walletdkrpc so the client
+// and the daemon-side mapper share one source of truth.
+var reasonToSentinel = map[string]error{
+	walletdkrpc.ReasonInvalidDestination:     ErrInvalidDestination,
+	walletdkrpc.ReasonInvalidSendIntent:      ErrInvalidSendIntent,
+	walletdkrpc.ReasonAmountRequired:         ErrAmountRequired,
+	walletdkrpc.ReasonAmountInvalid:          ErrAmountInvalid,
+	walletdkrpc.ReasonUnsupportedKind:        ErrUnsupportedKind,
+	walletdkrpc.ReasonSwapBackendUnavailable: ErrSwapBackendUnavailable,
+	walletdkrpc.ReasonAmountExceedsVTXOLimit: ErrAmountExceedsVTXOLimit,
+	walletdkrpc.ReasonBalanceLimitExceeded:   ErrBalanceLimitExceeded,
+}
+
+// sentinelForReason looks up the SDK sentinel for a daemon failure reason.
+// Unknown reasons return nil so the original status error is preserved
+// unchanged.
+func sentinelForReason(reason string) error {
+	return reasonToSentinel[reason]
+}
+
+// reconstructSentinel inspects a gRPC status error for a walletdk ErrorInfo
+// detail and, when present, wraps the matching SDK sentinel so callers can use
+// errors.Is. The original status error is also wrapped, so status.FromError /
+// status.Code keep working on the result. Errors that carry no recognizable
+// walletdk reason are returned unchanged.
+func reconstructSentinel(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		return err
+	}
+
+	for _, detail := range st.Details() {
+		info, ok := detail.(*errdetails.ErrorInfo)
+		if !ok || info.GetDomain() != walletdkrpc.FailureDomain {
+			continue
+		}
+
+		sentinel := sentinelForReason(info.GetReason())
+		if sentinel == nil {
+			continue
+		}
+
+		// Wrap both the sentinel and the original status error so the
+		// result is errors.Is-able AND still resolves via
+		// status.FromError.
+		return fmt.Errorf("%w: %w", sentinel, err)
+	}
+
+	return err
+}
+
+// errorReconstructInterceptor is a unary client interceptor that rewrites a
+// returned walletdk rejection into an errors.Is-able SDK sentinel. It is
+// installed on every walletdk client connection so all wallet RPCs surface
+// typed failures uniformly.
+func errorReconstructInterceptor(ctx context.Context, method string,
+	req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption) error {
+
+	return reconstructSentinel(
+		invoker(ctx, method, req, reply, cc, opts...),
+	)
+}

--- a/sdk/walletdk/errmap_roundtrip_test.go
+++ b/sdk/walletdk/errmap_roundtrip_test.go
@@ -1,0 +1,127 @@
+//go:build walletdkrpc && swapruntime
+
+package walletdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"github.com/lightninglabs/darepo-client/swapwallet"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// reasonContract pins, per machine-readable reason, the daemon-side swapwallet
+// sentinel, the SDK-side walletdk sentinel, and the gRPC code that flows across
+// the wire. It is the single place the two independently-defined sentinel sets
+// are cross-checked against the shared reason constant.
+var reasonContract = []struct {
+	reason string
+	server error
+	sdk    error
+	code   codes.Code
+}{
+	{
+		walletdkrpc.ReasonInvalidDestination,
+		swapwallet.ErrInvalidDestination, ErrInvalidDestination,
+		codes.InvalidArgument,
+	},
+	{
+		walletdkrpc.ReasonInvalidSendIntent,
+		swapwallet.ErrInvalidSendIntent, ErrInvalidSendIntent,
+		codes.FailedPrecondition,
+	},
+	{
+		walletdkrpc.ReasonAmountRequired,
+		swapwallet.ErrAmountRequired, ErrAmountRequired,
+		codes.InvalidArgument,
+	},
+	{
+		walletdkrpc.ReasonAmountInvalid,
+		swapwallet.ErrAmountInvalid, ErrAmountInvalid,
+		codes.InvalidArgument,
+	},
+	{
+		walletdkrpc.ReasonUnsupportedKind,
+		swapwallet.ErrUnsupportedKind, ErrUnsupportedKind,
+		codes.InvalidArgument,
+	},
+	{
+		walletdkrpc.ReasonSwapBackendUnavailable,
+		swapwallet.ErrSwapBackendUnavailable, ErrSwapBackendUnavailable,
+		codes.Unavailable,
+	},
+	{
+		walletdkrpc.ReasonAmountExceedsVTXOLimit,
+		swapwallet.ErrAmountExceedsVTXOLimit, ErrAmountExceedsVTXOLimit,
+		codes.FailedPrecondition,
+	},
+	{
+		walletdkrpc.ReasonBalanceLimitExceeded,
+		swapwallet.ErrBalanceLimitExceeded, ErrBalanceLimitExceeded,
+		codes.FailedPrecondition,
+	},
+}
+
+// TestSentinelMessageParity guards against drift between the daemon's
+// swapwallet sentinels and the SDK's walletdk sentinels. The two sets are
+// distinct error values bound only by the shared reason string, and matching is
+// by reason (not by message), so a divergence in the human-readable text would
+// not break errors.Is and would otherwise go unnoticed. This test is that
+// guard, and it also asserts the SDK reason lookup is complete: the contract
+// below must name every reason the SDK knows how to reconstruct.
+func TestSentinelMessageParity(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range reasonContract {
+		require.Equal(
+			t, c.server.Error(), c.sdk.Error(),
+			"message drift between server and SDK for reason %s",
+			c.reason,
+		)
+		require.ErrorIs(
+			t, sentinelForReason(c.reason), c.sdk, "SDK reason "+
+				"lookup wrong for %s", c.reason,
+		)
+	}
+
+	// The contract enumerates exactly the reasons the SDK reconstructs; a
+	// new reason added to reasonToSentinel without a contract row trips
+	// this.
+	require.Len(t, reasonContract, len(reasonToSentinel))
+}
+
+// TestServerToSDKRoundTrip exercises the full wire contract end to end: a
+// daemon handler returns a bare swapwallet sentinel, the server interceptor
+// maps it to a gRPC status carrying an ErrorInfo, and the SDK client
+// reconstructor turns that status back into the errors.Is-able SDK sentinel
+// while preserving the gRPC code. Each half is unit tested in isolation
+// elsewhere; this is the only test that runs them together, so a serialization,
+// domain, or code-mapping mismatch between the two halves surfaces here.
+func TestServerToSDKRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range reasonContract {
+		// Server side: a handler returns the bare server sentinel, and
+		// the mapping interceptor turns it into a status + ErrorInfo.
+		_, wire := swapwallet.ErrorMappingInterceptor(
+			context.Background(), nil, &grpc.UnaryServerInfo{},
+			func(context.Context, any) (any, error) {
+				return nil, c.server
+			},
+		)
+		require.Error(t, wire, "reason %s", c.reason)
+
+		// Client side: the reconstructor turns the wire status back
+		// into the SDK sentinel, preserving the gRPC code.
+		got := reconstructSentinel(wire)
+		require.ErrorIs(t, got, c.sdk, "reason %s", c.reason)
+		require.Equal(
+			t, c.code, status.Code(got),
+			"gRPC code not preserved for reason %s", c.reason,
+		)
+	}
+}

--- a/sdk/walletdk/errmap_test.go
+++ b/sdk/walletdk/errmap_test.go
@@ -1,0 +1,98 @@
+//go:build !js
+
+package walletdk
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestReconstructSentinel turns each walletdk ErrorInfo reason back into an
+// errors.Is-able SDK sentinel while preserving the gRPC status, and leaves
+// unknown reasons and non-walletdk errors unchanged. It builds inputs from the
+// shared walletdkrpc reason constants, so it doubles as a wire-contract check
+// against the daemon-side mapper.
+func TestReconstructSentinel(t *testing.T) {
+	cases := []struct {
+		reason string
+		want   error
+	}{
+		{
+			walletdkrpc.ReasonInvalidDestination,
+			ErrInvalidDestination,
+		},
+		{
+			walletdkrpc.ReasonInvalidSendIntent,
+			ErrInvalidSendIntent,
+		},
+		{
+			walletdkrpc.ReasonAmountRequired,
+			ErrAmountRequired,
+		},
+		{
+			walletdkrpc.ReasonAmountInvalid,
+			ErrAmountInvalid,
+		},
+		{
+			walletdkrpc.ReasonUnsupportedKind,
+			ErrUnsupportedKind,
+		},
+		{
+			walletdkrpc.ReasonSwapBackendUnavailable,
+			ErrSwapBackendUnavailable,
+		},
+		{
+			walletdkrpc.ReasonAmountExceedsVTXOLimit,
+			ErrAmountExceedsVTXOLimit,
+		},
+		{
+			walletdkrpc.ReasonBalanceLimitExceeded,
+			ErrBalanceLimitExceeded,
+		},
+	}
+	for _, tc := range cases {
+		in := statusWithReason(t, walletdkrpc.FailureDomain, tc.reason)
+		got := reconstructSentinel(in)
+
+		// The result is both errors.Is-able and still a gRPC status.
+		require.ErrorIs(t, got, tc.want, "reason=%s", tc.reason)
+		require.Equal(
+			t, codes.InvalidArgument, status.Code(got),
+			"reason=%s", tc.reason,
+		)
+	}
+
+	// An unknown reason in our domain leaves the original error unchanged.
+	unknown := statusWithReason(
+		t, walletdkrpc.FailureDomain, "SOMETHING_ELSE",
+	)
+	require.Equal(t, unknown, reconstructSentinel(unknown))
+
+	// A reason from a different domain is ignored.
+	foreign := statusWithReason(t, "other", walletdkrpc.ReasonAmountInvalid)
+	require.Equal(t, foreign, reconstructSentinel(foreign))
+
+	// A plain (non-status) error passes through, and nil stays nil.
+	plain := errors.New("boom")
+	require.Equal(t, plain, reconstructSentinel(plain))
+	require.NoError(t, reconstructSentinel(nil))
+}
+
+// statusWithReason builds a gRPC status error carrying an ErrorInfo detail with
+// the given domain and reason.
+func statusWithReason(t *testing.T, domain, reason string) error {
+	t.Helper()
+
+	st, err := status.New(codes.InvalidArgument, "rejected").WithDetails(
+		&errdetails.ErrorInfo{Reason: reason, Domain: domain},
+	)
+	require.NoError(t, err)
+
+	return st.Err()
+}

--- a/sdk/walletdk/errors.go
+++ b/sdk/walletdk/errors.go
@@ -10,3 +10,49 @@ var ErrWalletRPCUnavailable = errors.New("walletdk wallet rpc unavailable; " +
 // ErrSwapRuntimeUnavailable is retained as a compatibility sentinel for code
 // that still checks the old swapruntime-only error.
 var ErrSwapRuntimeUnavailable = ErrWalletRPCUnavailable
+
+// The sentinels below mirror the daemon's walletdkrpc rejection taxonomy. The
+// daemon attaches a machine-readable google.rpc.ErrorInfo reason to a failed
+// wallet RPC; the SDK reconstructs these errors.Is-able sentinels from that
+// reason (see errmap.go) so callers can branch on failure cause without
+// matching gRPC status strings.
+var (
+	// ErrInvalidDestination reports that a send destination was unset or
+	// empty: supply exactly one of an invoice or an on-chain address.
+	ErrInvalidDestination = errors.New("send destination must set " +
+		"invoice or onchain_address")
+
+	// ErrInvalidSendIntent reports that a send ran without a live prepared
+	// send intent (missing, expired, or already consumed).
+	ErrInvalidSendIntent = errors.New("send intent is missing, expired, " +
+		"or already consumed")
+
+	// ErrAmountRequired reports that an amount was required but not
+	// supplied (an on-chain send, or an amountless invoice with no caller
+	// amount).
+	ErrAmountRequired = errors.New("amt_sat is required for the " +
+		"requested send")
+
+	// ErrAmountInvalid reports that an amount was out of range.
+	ErrAmountInvalid = errors.New("amt_sat is out of range")
+
+	// ErrUnsupportedKind reports that a list filter used an entry kind the
+	// daemon does not support.
+	ErrUnsupportedKind = errors.New("unsupported entry kind in list filter")
+
+	// ErrSwapBackendUnavailable reports that the daemon's swap backend
+	// handle was unavailable (a daemon misconfiguration).
+	ErrSwapBackendUnavailable = errors.New("swap backend handle is " +
+		"unavailable")
+
+	// ErrAmountExceedsVTXOLimit reports that a receive amount exceeds the
+	// operator's advertised maximum VTXO size.
+	ErrAmountExceedsVTXOLimit = errors.New("amount exceeds the " +
+		"operator's maximum VTXO size")
+
+	// ErrBalanceLimitExceeded reports that an inflow would push the
+	// wallet's total balance above the operator's advertised maximum user
+	// balance.
+	ErrBalanceLimitExceeded = errors.New("amount would exceed the " +
+		"maximum allowed wallet balance")
+)

--- a/sdk/walletdk/walletdkrpc.go
+++ b/sdk/walletdk/walletdkrpc.go
@@ -20,6 +20,13 @@ func configureWalletRPC(cfg *darepod.Config, enabled bool) {
 	cfg.RPCServiceRegistrars = append(
 		cfg.RPCServiceRegistrars, swapwallet.Register,
 	)
+
+	// Map walletdkrpc sentinel errors to machine-readable status codes so
+	// the embedded client's reconstruct interceptor can surface typed
+	// failures, matching the standalone daemon's behavior.
+	cfg.UnaryServerInterceptors = append(
+		cfg.UnaryServerInterceptors, swapwallet.ErrorMappingInterceptor,
+	)
 }
 
 // walletRPCAvailable reports whether this build can register walletdkrpc.

--- a/swapwallet/admin.go
+++ b/swapwallet/admin.go
@@ -34,9 +34,7 @@ func (s *Service) create(ctx context.Context, req *walletdkrpc.CreateRequest) (
 	*walletdkrpc.CreateResponse, error) {
 
 	if s.deps == nil || s.deps.RPCServer == nil {
-		return nil, status.Error(
-			codes.Unavailable, ErrSwapBackendUnavailable.Error(),
-		)
+		return nil, statusSwapBackendUnavailable()
 	}
 
 	if len(req.GetWalletPassword()) == 0 {
@@ -95,9 +93,7 @@ func (s *Service) unlock(ctx context.Context, req *walletdkrpc.UnlockRequest) (
 	*walletdkrpc.UnlockResponse, error) {
 
 	if s.deps == nil || s.deps.RPCServer == nil {
-		return nil, status.Error(
-			codes.Unavailable, ErrSwapBackendUnavailable.Error(),
-		)
+		return nil, statusSwapBackendUnavailable()
 	}
 
 	if len(req.GetWalletPassword()) == 0 {
@@ -127,9 +123,7 @@ func (s *Service) exit(ctx context.Context, req *walletdkrpc.ExitRequest) (
 	*walletdkrpc.ExitResponse, error) {
 
 	if s.deps == nil || s.deps.RPCServer == nil {
-		return nil, status.Error(
-			codes.Unavailable, ErrSwapBackendUnavailable.Error(),
-		)
+		return nil, statusSwapBackendUnavailable()
 	}
 
 	if req.GetOutpoint() == "" {
@@ -276,9 +270,7 @@ func (s *Service) getExitPlan(ctx context.Context,
 	error) {
 
 	if s.deps == nil || s.deps.RPCServer == nil {
-		return nil, status.Error(
-			codes.Unavailable, ErrSwapBackendUnavailable.Error(),
-		)
+		return nil, statusSwapBackendUnavailable()
 	}
 
 	if len(req.GetOutpoints()) == 0 {
@@ -336,9 +328,7 @@ func (s *Service) sweepWallet(ctx context.Context,
 	error) {
 
 	if s.deps == nil || s.deps.RPCServer == nil {
-		return nil, status.Error(
-			codes.Unavailable, ErrSwapBackendUnavailable.Error(),
-		)
+		return nil, statusSwapBackendUnavailable()
 	}
 
 	resp, err := s.deps.RPCServer.SweepWallet(
@@ -383,9 +373,7 @@ func (s *Service) exitStatus(ctx context.Context,
 	error) {
 
 	if s.deps == nil || s.deps.RPCServer == nil {
-		return nil, status.Error(
-			codes.Unavailable, ErrSwapBackendUnavailable.Error(),
-		)
+		return nil, statusSwapBackendUnavailable()
 	}
 
 	if req.GetOutpoint() == "" {

--- a/swapwallet/admin_test.go
+++ b/swapwallet/admin_test.go
@@ -117,7 +117,16 @@ func TestCreateRequiresRPCServer(t *testing.T) {
 		WalletPassword: []byte("password"),
 	})
 	require.Error(t, err)
-	require.Equal(t, codes.Unavailable, status.Code(err))
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Unavailable, st.Code())
+
+	// The rejection carries the machine-readable reason so the SDK can
+	// reconstruct it, rather than a bare code-only status.
+	require.Equal(
+		t, walletdkrpc.ReasonSwapBackendUnavailable,
+		errorInfoReason(t, st),
+	)
 }
 
 // TestUnlockProxiesDaemon confirms Unlock plumbs the caller's password

--- a/swapwallet/errors_grpc.go
+++ b/swapwallet/errors_grpc.go
@@ -1,0 +1,132 @@
+//go:build walletdkrpc && swapruntime
+
+package swapwallet
+
+import (
+	"context"
+	"errors"
+
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// sentinelMapping pairs a swapwallet sentinel with the gRPC status code and the
+// stable, machine-readable reason surfaced to clients alongside the
+// human-readable message.
+type sentinelMapping struct {
+	err    error
+	code   codes.Code
+	reason string
+}
+
+// sentinelMappings is the canonical sentinel → (code, reason) table. The reason
+// strings are the walletdkrpc wire contract (clients reconstruct typed
+// sentinels from them), so they come from walletdkrpc rather than being
+// duplicated here.
+//
+// ErrWalletNotReady is intentionally absent: the wallet-readiness gate
+// (requireWalletReady) returns daemonrpc's own structured WALLET_NOT_READY
+// status, so the bare sentinel never reaches this interceptor.
+var sentinelMappings = []sentinelMapping{
+	{
+		ErrInvalidDestination, codes.InvalidArgument,
+		walletdkrpc.ReasonInvalidDestination,
+	},
+	{
+		ErrInvalidSendIntent, codes.FailedPrecondition,
+		walletdkrpc.ReasonInvalidSendIntent,
+	},
+	{
+		ErrAmountRequired, codes.InvalidArgument,
+		walletdkrpc.ReasonAmountRequired,
+	},
+	{
+		ErrAmountInvalid, codes.InvalidArgument,
+		walletdkrpc.ReasonAmountInvalid,
+	},
+	{
+		ErrUnsupportedKind, codes.InvalidArgument,
+		walletdkrpc.ReasonUnsupportedKind,
+	},
+	{
+		ErrSwapBackendUnavailable, codes.Unavailable,
+		walletdkrpc.ReasonSwapBackendUnavailable,
+	},
+
+	// The two receive-limit rejections are FailedPrecondition rather than
+	// InvalidArgument: the amount is well-formed, but the operator's
+	// advertised terms (a per-VTXO cap, a total-balance cap) reject it. The
+	// same amount can succeed against different terms or a lower balance,
+	// so the failure is a function of system state, not a malformed
+	// argument.
+	{
+		ErrAmountExceedsVTXOLimit, codes.FailedPrecondition,
+		walletdkrpc.ReasonAmountExceedsVTXOLimit,
+	},
+	{
+		ErrBalanceLimitExceeded, codes.FailedPrecondition,
+		walletdkrpc.ReasonBalanceLimitExceeded,
+	},
+}
+
+// statusSwapBackendUnavailable returns the canonical gRPC status for a missing
+// swap backend handle, carrying the same machine-readable ErrorInfo the
+// interceptor attaches to a bare ErrSwapBackendUnavailable. Handlers that must
+// return a pre-formed status directly -- the readiness gate and the admin
+// proxies, which run before the swap runtime is live and whose direct return
+// value (not just the wire result) is asserted on -- call this so their
+// rejection is SDK-reconstructable exactly like an interceptor-mapped sentinel,
+// rather than a code-only status the SDK cannot branch on.
+func statusSwapBackendUnavailable() error {
+	return mapSentinel(ErrSwapBackendUnavailable)
+}
+
+// ErrorMappingInterceptor is a unary server interceptor that maps a returned
+// swapwallet sentinel into a gRPC status carrying a machine-readable
+// google.rpc.ErrorInfo reason, so clients can branch on the failure cause
+// without string matching. Errors that already carry a gRPC status, and errors
+// that match no sentinel, pass through unchanged.
+func ErrorMappingInterceptor(ctx context.Context, req any,
+	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+
+	resp, err := handler(ctx, req)
+	if err == nil {
+		return resp, nil
+	}
+
+	return resp, mapSentinel(err)
+}
+
+// mapSentinel translates a bare swapwallet sentinel into a status error with an
+// ErrorInfo detail. Errors that already carry a gRPC status (a handler that
+// already chose a code) and non-sentinel errors are returned unchanged.
+func mapSentinel(err error) error {
+	// An error that already carries a gRPC status was deliberately coded by
+	// the handler; do not second-guess it. status.FromError reports ok for
+	// such errors (and for nil, already excluded by the caller).
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+
+	for _, m := range sentinelMappings {
+		if !errors.Is(err, m.err) {
+			continue
+		}
+
+		st := status.New(m.code, err.Error())
+		detailed, detailErr := st.WithDetails(&errdetails.ErrorInfo{
+			Reason: m.reason,
+			Domain: walletdkrpc.FailureDomain,
+		})
+		if detailErr != nil {
+			return st.Err()
+		}
+
+		return detailed.Err()
+	}
+
+	return err
+}

--- a/swapwallet/errors_grpc_test.go
+++ b/swapwallet/errors_grpc_test.go
@@ -1,0 +1,220 @@
+//go:build walletdkrpc && swapruntime
+
+package swapwallet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestMapSentinel maps each swapwallet sentinel to its gRPC code and stable
+// ErrorInfo reason, and leaves pre-formed statuses and unknown errors alone.
+func TestMapSentinel(t *testing.T) {
+	t.Parallel()
+
+	for _, m := range sentinelMappings {
+		// A wrapped sentinel maps to the right code + reason detail.
+		mapped := mapSentinel(fmt.Errorf("context: %w", m.err))
+		st, ok := status.FromError(mapped)
+		require.True(t, ok, "reason=%s", m.reason)
+		require.Equal(t, m.code, st.Code(), "reason=%s", m.reason)
+		require.Equal(t, m.reason, errorInfoReason(t, st))
+	}
+
+	// A non-sentinel error passes through unchanged.
+	other := errors.New("some other failure")
+	require.Equal(t, other, mapSentinel(other))
+
+	// An error that already carries a gRPC status is left alone.
+	pre := status.Error(codes.NotFound, "missing")
+	require.Equal(t, pre, mapSentinel(pre))
+}
+
+// TestSentinelMappingsCoverage asserts that every request-rejection sentinel
+// the package defines is either mapped to a machine-readable reason or
+// explicitly exempt. A new sentinel added to errors.go without a mapping (the
+// regression that left the Recv limit errors as opaque codes.Unknown) is caught
+// here: add it to sentinelMappings, or to exempt below with a justification.
+func TestSentinelMappingsCoverage(t *testing.T) {
+	t.Parallel()
+
+	// Every request-rejection sentinel the swapwallet package defines.
+	allTaxonomySentinels := []error{
+		ErrSwapBackendUnavailable,
+		ErrInvalidDestination,
+		ErrInvalidSendIntent,
+		ErrAmountRequired,
+		ErrAmountInvalid,
+		ErrUnsupportedKind,
+		ErrAmountExceedsVTXOLimit,
+		ErrBalanceLimitExceeded,
+		ErrWalletNotReady,
+	}
+
+	// ErrWalletNotReady is intentionally unmapped: the readiness gate
+	// returns daemonrpc's own structured WALLET_NOT_READY status, so the
+	// bare sentinel never reaches the interceptor.
+	exempt := map[error]bool{
+		ErrWalletNotReady: true,
+	}
+
+	// The table itself must be internally consistent: no duplicate
+	// sentinel, no duplicate reason, no empty reason.
+	mapped := make(map[error]bool, len(sentinelMappings))
+	reasons := make(map[string]bool, len(sentinelMappings))
+	for _, m := range sentinelMappings {
+		require.NotNil(t, m.err, "mapping has a nil sentinel")
+		require.NotEmpty(t, m.reason, "mapping has an empty reason")
+		require.False(
+			t, mapped[m.err], "duplicate sentinel in table: %v",
+			m.err,
+		)
+		require.False(
+			t, reasons[m.reason], "duplicate reason in table: %s",
+			m.reason,
+		)
+		mapped[m.err] = true
+		reasons[m.reason] = true
+	}
+
+	// Every taxonomy sentinel is mapped unless it is explicitly exempt.
+	for _, s := range allTaxonomySentinels {
+		if exempt[s] {
+			require.False(
+				t, mapped[s], "exempt sentinel must not be "+
+					"mapped: %v", s,
+			)
+
+			continue
+		}
+
+		require.True(
+			t, mapped[s], "taxonomy sentinel is not mapped; add "+
+				"it to sentinelMappings or exempt it: %v", s,
+		)
+	}
+
+	// The table covers exactly the non-exempt taxonomy sentinels: a stray
+	// mapping not listed above, or a listed sentinel left unmapped, trips
+	// this length check.
+	require.Len(
+		t, sentinelMappings, len(allTaxonomySentinels)-len(exempt),
+	)
+}
+
+// TestRecvLimitSentinelsMapped locks the fix that brought the two
+// operator-limit Recv rejections into the taxonomy: each must map to
+// FailedPrecondition with its stable reason, rather than crossing the wire as
+// an opaque codes.Unknown.
+func TestRecvLimitSentinelsMapped(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		sentinel error
+		reason   string
+	}{
+		{
+			ErrAmountExceedsVTXOLimit,
+			walletdkrpc.ReasonAmountExceedsVTXOLimit,
+		},
+		{
+			ErrBalanceLimitExceeded,
+			walletdkrpc.ReasonBalanceLimitExceeded,
+		},
+	}
+	for _, tc := range cases {
+		mapped := mapSentinel(fmt.Errorf("context: %w", tc.sentinel))
+		st, ok := status.FromError(mapped)
+		require.True(t, ok, "reason=%s", tc.reason)
+		require.Equal(
+			t, codes.FailedPrecondition, st.Code(),
+			"reason=%s", tc.reason,
+		)
+		require.Equal(t, tc.reason, errorInfoReason(t, st))
+	}
+}
+
+// TestStatusSwapBackendUnavailable confirms the shared pre-formed-status helper
+// carries the same code and ErrorInfo the interceptor attaches to a bare
+// sentinel, so handlers that must return a status directly (the readiness gate,
+// the admin proxies) stay SDK-reconstructable.
+func TestStatusSwapBackendUnavailable(t *testing.T) {
+	t.Parallel()
+
+	st, ok := status.FromError(statusSwapBackendUnavailable())
+	require.True(t, ok)
+	require.Equal(t, codes.Unavailable, st.Code())
+	require.Equal(
+		t, walletdkrpc.ReasonSwapBackendUnavailable,
+		errorInfoReason(t, st),
+	)
+}
+
+// TestErrorMappingInterceptor confirms the interceptor passes a nil error and
+// happy-path response through, and maps a handler sentinel.
+func TestErrorMappingInterceptor(t *testing.T) {
+	t.Parallel()
+
+	okHandler := func(context.Context, any) (any, error) {
+		return "resp", nil
+	}
+	resp, err := ErrorMappingInterceptor(
+		context.Background(), nil, &grpc.UnaryServerInfo{}, okHandler,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "resp", resp)
+
+	failHandler := func(context.Context, any) (any, error) {
+		return nil, ErrAmountInvalid
+	}
+	_, err = ErrorMappingInterceptor(
+		context.Background(), nil, &grpc.UnaryServerInfo{}, failHandler,
+	)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.InvalidArgument, st.Code())
+	require.Equal(
+		t, walletdkrpc.ReasonAmountInvalid, errorInfoReason(t, st),
+	)
+
+	// A handler returning a pre-formed status is passed through untouched.
+	statusHandler := func(context.Context, any) (any, error) {
+		return nil, status.Error(codes.NotFound, "missing")
+	}
+	_, err = ErrorMappingInterceptor(
+		context.Background(), nil, &grpc.UnaryServerInfo{},
+		statusHandler,
+	)
+	st, ok = status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.NotFound, st.Code())
+	require.Empty(t, st.Details())
+}
+
+// errorInfoReason extracts the walletdk ErrorInfo reason from a status, failing
+// the test if no walletdk detail is present.
+func errorInfoReason(t *testing.T, st *status.Status) string {
+	t.Helper()
+
+	for _, detail := range st.Details() {
+		info, ok := detail.(*errdetails.ErrorInfo)
+		if !ok {
+			continue
+		}
+		require.Equal(t, walletdkrpc.FailureDomain, info.GetDomain())
+
+		return info.GetReason()
+	}
+	t.Fatalf("status carried no walletdk ErrorInfo detail: %v", st)
+
+	return ""
+}

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // Service implements the daemon-side WalletService gRPC handler. It is a
@@ -193,9 +191,7 @@ func (s *Service) Deposit(ctx context.Context,
 // before they can reach swap or address-generation code paths.
 func (s *Service) requireWalletReady(ctx context.Context) error {
 	if s == nil || s.deps == nil || s.deps.RPCServer == nil {
-		return status.Error(
-			codes.Unavailable, ErrSwapBackendUnavailable.Error(),
-		)
+		return statusSwapBackendUnavailable()
 	}
 
 	info, err := s.deps.RPCServer.GetInfo(
@@ -251,9 +247,7 @@ func (s *Service) Status(ctx context.Context, req *walletdkrpc.StatusRequest) (
 	*walletdkrpc.StatusResponse, error) {
 
 	if s.deps.RPCServer == nil {
-		return nil, status.Error(
-			codes.Unavailable, ErrSwapBackendUnavailable.Error(),
-		)
+		return nil, statusSwapBackendUnavailable()
 	}
 
 	info, err := s.deps.RPCServer.GetInfo(
@@ -363,9 +357,7 @@ func (s *Service) fetchBalance(ctx context.Context) (
 	*walletdkrpc.BalanceResponse, error) {
 
 	if s.deps.RPCServer == nil {
-		return nil, status.Error(
-			codes.Unavailable, ErrSwapBackendUnavailable.Error(),
-		)
+		return nil, statusSwapBackendUnavailable()
 	}
 
 	bal, err := s.deps.RPCServer.GetBalance(

--- a/swapwallet/service_test.go
+++ b/swapwallet/service_test.go
@@ -172,7 +172,17 @@ func TestServiceRecvWithoutRPCServerReturnsUnavailable(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
-	require.Equal(t, codes.Unavailable, status.Code(err))
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Unavailable, st.Code())
+
+	// The readiness gate's pre-formed status carries the machine-readable
+	// reason so the SDK can reconstruct it like an interceptor-mapped
+	// sentinel.
+	require.Equal(
+		t, walletdkrpc.ReasonSwapBackendUnavailable,
+		errorInfoReason(t, st),
+	)
 	require.Equal(t, 0, swap.startReceiveCalls)
 }
 


### PR DESCRIPTION
Closes #779 (PR2 of 2).

## What

PR1 (#790) added entry-level `WalletEntry.failure_code`. PR2 completes the
taxonomy with the **request-rejection** half: a failed wallet RPC now carries a
stable, machine-readable reason so clients can `errors.Is` it instead of
string-matching an opaque gRPC status.

**Server**
- `rpc/walletdkrpc/failure_reasons.go` (hand-written): the wire contract —
  `FailureDomain` + `Reason*` constants, imported by both the daemon mapper and
  the SDK so the two halves cannot drift.
- `darepod.Config.UnaryServerInterceptors` — additive hook (parallel to
  `RPCServiceRegistrars`), wired into `grpc.NewServer` (a no-op when empty, so
  default builds are unaffected).
- `swapwallet.ErrorMappingInterceptor` — maps each `swapwallet` sentinel to a
  gRPC code + a `google.rpc.ErrorInfo{Reason, Domain}` detail. Pre-formed
  statuses and non-sentinel errors pass through untouched. Wired into both the
  standalone daemon (`cmd/darepod`) and the embedded SDK daemon.

**SDK** (`sdk/walletdk`)
- `errors.Is`-able sentinels + a single client interceptor (`errmap.go`,
  installed on the remote and embedded dial paths) that reconstructs the
  sentinel from the `ErrorInfo` reason. The result wraps the original status, so
  `status.Code` keeps working alongside `errors.Is`.

## Scope notes

- `WALLET_NOT_READY` is intentionally NOT in this taxonomy: the readiness gate
  already returns daemonrpc's own structured `WALLET_NOT_READY` status (domain
  `darepo-client/wallet`). Teaching the SDK to also reconstruct that existing
  reason is a small follow-up.
- Distinct from #614 (error-string hygiene), which can layer onto the same
  interceptor boundary.

## Tests

Server interceptor mapping incl. pre-formed-status pass-through; SDK
reconstruction built from the shared reason constants (a wire-contract check),
gRPC-code preservation, and foreign-domain / unknown-reason / nil pass-through;
`cloneDaemonConfig` isolation extended to the new config field.

Builds under `-tags walletdkrpc,swapruntime`, `GOOS=js`, and default; full
`swapwallet` + `sdk/walletdk` suites + `make lint-changed-local` green; `go mod
tidy` clean.
