### PR TITLE
swapwallet: assert FailureCode on overlay and unroll paths

### DIFF
--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -1103,6 +1103,7 @@ func TestHistorySwapRowsIgnoreTimedOutOverlay(t *testing.T) {
 		status: walletdkrpc.
 			EntryStatus_ENTRY_STATUS_FAILED,
 		failureReason: "timed_out",
+		failureCode:   timedOutCode,
 	}
 	h.runtime.pendingMu.Unlock()
 
@@ -1118,6 +1119,10 @@ func TestHistorySwapRowsIgnoreTimedOutOverlay(t *testing.T) {
 		resp.GetActivity().GetEntries()[0].GetKind(),
 	)
 	require.Empty(t, resp.GetActivity().GetEntries()[0].GetFailureReason())
+	require.Equal(
+		t, unspecCode,
+		resp.GetActivity().GetEntries()[0].GetFailureCode(),
+	)
 }
 
 // TestHistoryWalletRowsApplyTimedOutOverlay confirms wallet-local pending rows
@@ -1144,6 +1149,7 @@ func TestHistoryWalletRowsApplyTimedOutOverlay(t *testing.T) {
 		status: walletdkrpc.
 			EntryStatus_ENTRY_STATUS_FAILED,
 		failureReason: "timed_out",
+		failureCode:   timedOutCode,
 	}
 	h.runtime.pendingMu.Unlock()
 
@@ -1157,6 +1163,10 @@ func TestHistoryWalletRowsApplyTimedOutOverlay(t *testing.T) {
 	require.Equal(
 		t, "timed_out",
 		resp.GetActivity().GetEntries()[0].GetFailureReason(),
+	)
+	require.Equal(
+		t, timedOutCode,
+		resp.GetActivity().GetEntries()[0].GetFailureCode(),
 	)
 }
 
@@ -1521,6 +1531,10 @@ func TestHistoryIncludesUnilateralExitVTXO(t *testing.T) {
 	)
 	require.Equal(t, int64(-7_000), entries[0].GetAmountSat())
 	require.Equal(t, "broadcast failed", entries[0].GetFailureReason())
+	require.Equal(
+		t, walletdkrpc.EntryFailureCode_ENTRY_FAILURE_CODE_FAILED,
+		entries[0].GetFailureCode(),
+	)
 	require.Equal(
 		t, daemonrpc.VTXOStatus_VTXO_STATUS_UNILATERAL_EXIT,
 		rpc.listVTXOsLastReq.GetStatusFilter(),

--- a/swapwallet/runtime_test.go
+++ b/swapwallet/runtime_test.go
@@ -52,6 +52,7 @@ func TestDeadlineWatcherFlagsStuckEntries(t *testing.T) {
 		t, walletdkrpc.EntryStatus_ENTRY_STATUS_FAILED, overlay.status,
 	)
 	require.Equal(t, "timed_out", overlay.failureReason)
+	require.Equal(t, timedOutCode, overlay.failureCode)
 
 	// freshID is identical to staleID for the watcher purposes here
 	// (both deadlines are equally past). To assert the "fresh" guard
@@ -260,6 +261,7 @@ func TestDeadlineWatcherEmitsTimeoutToSubscribers(t *testing.T) {
 			got.GetStatus(),
 		)
 		require.Equal(t, "timed_out", got.GetFailureReason())
+		require.Equal(t, timedOutCode, got.GetFailureCode())
 		require.Equal(
 			t, tick.Unix(), got.GetUpdatedAtUnix(),
 			"updated_at must reflect the watcher tick time",


### PR DESCRIPTION
Test-only follow-up to #790.

That PR wrote `failure_code` on three server paths but only the
swap-state classifier (`failureCodeFromSwapState`) had a direct
assertion. The deadline overlay and the unroll-failed path were
exercised by existing tests that never checked the new field, so a
regression to `UNSPECIFIED` would have shipped undetected.

This adds those assertions on the existing fixtures:

- `markTimedOut` → `timedOutCode` end-to-end (overlay struct + the
  emitted subscriber entry).
- `applyOverlays` propagation: positive (wallet-local row gets
  `timedOutCode`) and negative (swap rows ignore an overlay code).
- `applyUnrollStatus` FAILED → generic `FAILED` on the unilateral-exit
  row.

No production code changes.
