### PR TITLE
sdk/swaps: embed route hint paths in invoices

### DIFF
--- a/harness/tapd_harness.go
+++ b/harness/tapd_harness.go
@@ -168,6 +168,8 @@ func (h *Harness) startLNDContainer(cfg lndConfig) *dockertest.Resource {
 		"--noseedbackup",
 		"--nobootstrap",
 		"--accept-keysend",
+		"--protocol.option-scid-alias",
+		"--protocol.zero-conf",
 	}
 
 	lndHostDir, err := filepath.Abs(cfg.dataDir)

--- a/internal/actortest/e2e_test.go
+++ b/internal/actortest/e2e_test.go
@@ -174,15 +174,16 @@ func eventuallyWithOutboxPublish(t *testing.T, publisher *actor.OutboxPublisher,
 }
 
 // durableAskResponseTimeout is a shared timeout budget for DurableAsk response
-// delivery assertions in this test suite.
-const durableAskResponseTimeout = 10 * time.Second
+// delivery assertions in this test suite. Keep this aligned with the outbox
+// delivery timeout because DurableAsk responses are also delivered through the
+// outbox in these end-to-end tests.
+const durableAskResponseTimeout = 30 * time.Second
 
 // outboxForwardProcessingTimeout is the timeout budget for waiting on the
 // source actor to durably process a forward request before any outbox delivery
-// assertions. This is intentionally looser than basic actor assertions because
-// these end-to-end tests run with real SQLite persistence and under `-race` in
-// CI.
-const outboxForwardProcessingTimeout = 5 * time.Second
+// assertions. Keep this aligned with the delivery timeout because CI can
+// schedule these SQLite-backed tests slowly under `-race`.
+const outboxForwardProcessingTimeout = 30 * time.Second
 
 // outboxDeliveryTimeout is the timeout budget for waiting on OutboxPublisher
 // delivery in end-to-end tests. The helper actively triggers publish attempts

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -190,6 +190,16 @@ type InvoiceCreator interface {
 		authKey keychain.SingleKeyMessageSigner,
 		preimage *lntypes.Preimage) (*invoices.Invoice, lntypes.Hash,
 		error)
+
+	// CreateInvoiceWithKeyRouteHintPath builds one signed invoice with the
+	// client's receive auth key and private route-hint path from the
+	// server.
+	CreateInvoiceWithKeyRouteHintPath(ctx context.Context,
+		amountSat btcutil.Amount, memo string,
+		routeHintPath []*RouteHint, expiry time.Duration,
+		authKey keychain.SingleKeyMessageSigner,
+		preimage *lntypes.Preimage) (*invoices.Invoice, lntypes.Hash,
+		error)
 }
 
 // RouteHint describes a single hop hint for Lightning invoices.
@@ -217,8 +227,9 @@ type RouteHint struct {
 // OutSwapQuote is the complete server quote for one Lightning-to-Ark receive
 // route.
 type OutSwapQuote struct {
-	// RouteHint is the private hop hint the SDK embeds in the invoice.
-	RouteHint *RouteHint
+	// RouteHintPath is the full private route-hint path the SDK embeds in
+	// the invoice. The final hop is the swap server's virtual channel.
+	RouteHintPath []*RouteHint
 
 	// ReceiveAmountSat is the exact Ark amount the receiver expects.
 	ReceiveAmountSat btcutil.Amount

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -67,13 +67,16 @@ func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 		return nil, fmt.Errorf("RequestChannelId RPC: %w", err)
 	}
 
-	hint, err := routeHintFromProto(resp.GetRouteHint())
+	hintPath, err := routeHintPathFromProto(resp.GetRouteHintPath())
 	if err != nil {
 		return nil, err
 	}
+	if len(hintPath) == 0 {
+		return nil, fmt.Errorf("route hint path must be provided")
+	}
 
 	return &OutSwapQuote{
-		RouteHint: hint,
+		RouteHintPath: hintPath,
 		// The server binds the route to the requested amount but does
 		// not echo it, so keep the caller's amount in the quote.
 		ReceiveAmountSat: amountSat,
@@ -280,6 +283,27 @@ func routeHintFromProto(hint *swaprpc.RouteHint) (*RouteHint, error) {
 	}
 
 	return routeHint, nil
+}
+
+// routeHintPathFromProto converts one generated route-hint path into the SDK
+// shape while preserving hop order.
+func routeHintPathFromProto(hints []*swaprpc.RouteHint) ([]*RouteHint, error) {
+	if len(hints) == 0 {
+		return nil, nil
+	}
+
+	routeHintPath := make([]*RouteHint, 0, len(hints))
+	for i, hint := range hints {
+		routeHint, err := routeHintFromProto(hint)
+		if err != nil {
+			return nil, fmt.Errorf("route hint path hop %d: %w", i,
+				err)
+		}
+
+		routeHintPath = append(routeHintPath, routeHint)
+	}
+
+	return routeHintPath, nil
 }
 
 // vhtlcConfigFromProto converts one generated swaprpc vHTLC config into the

--- a/sdk/swaps/invoice.go
+++ b/sdk/swaps/invoice.go
@@ -221,7 +221,8 @@ func (g *InvoiceGenerator) CreateInvoice(ctx context.Context,
 	lntypes.Hash, error) {
 
 	return g.createInvoice(
-		ctx, g.invoiceCfg, amountSat, memo, routeHint, expiry, preimage,
+		ctx, g.invoiceCfg, amountSat, memo, []*RouteHint{routeHint},
+		expiry, preimage,
 	)
 }
 
@@ -244,14 +245,41 @@ func (g *InvoiceGenerator) CreateInvoiceWithKey(ctx context.Context,
 	invoiceCfg.NodeSigner = netann.NewNodeSigner(authKey)
 
 	return g.createInvoice(
-		ctx, &invoiceCfg, amountSat, memo, routeHint, expiry, preimage,
+		ctx, &invoiceCfg, amountSat, memo, []*RouteHint{routeHint},
+		expiry, preimage,
+	)
+}
+
+// CreateInvoiceWithKeyRouteHintPath creates one invoice signed by the supplied
+// auth key and carrying the full route-hint path.
+func (g *InvoiceGenerator) CreateInvoiceWithKeyRouteHintPath(
+	ctx context.Context, amountSat btcutil.Amount, memo string,
+	routeHintPath []*RouteHint, expiry time.Duration,
+	authKey keychain.SingleKeyMessageSigner, preimage *lntypes.Preimage) (
+	*invoices.Invoice, lntypes.Hash, error) {
+
+	if authKey == nil {
+		return nil, lntypes.Hash{}, fmt.Errorf("invoice auth key is " +
+			"required")
+	}
+	if g == nil || g.invoiceCfg == nil {
+		return nil, lntypes.Hash{}, fmt.Errorf("invoice generator is " +
+			"required")
+	}
+
+	invoiceCfg := *g.invoiceCfg
+	invoiceCfg.NodeSigner = netann.NewNodeSigner(authKey)
+
+	return g.createInvoice(
+		ctx, &invoiceCfg, amountSat, memo, routeHintPath, expiry,
+		preimage,
 	)
 }
 
 // createInvoice builds one signed BOLT-11 invoice through invoicesrpc.
 func (g *InvoiceGenerator) createInvoice(ctx context.Context,
 	cfg *invoicesrpc.AddInvoiceConfig, amountSat btcutil.Amount,
-	memo string, routeHint *RouteHint, expiry time.Duration,
+	memo string, routeHintPath []*RouteHint, expiry time.Duration,
 	preimage *lntypes.Preimage) (*invoices.Invoice, lntypes.Hash, error) {
 
 	if g == nil || cfg == nil || cfg.NodeSigner == nil {
@@ -266,7 +294,7 @@ func (g *InvoiceGenerator) createInvoice(ctx context.Context,
 		return nil, lntypes.Hash{}, err
 	}
 
-	hopHint, err := zpayHopHint(routeHint)
+	hopHints, err := zpayHopHintPath(routeHintPath)
 	if err != nil {
 		return nil, lntypes.Hash{}, err
 	}
@@ -281,9 +309,7 @@ func (g *InvoiceGenerator) createInvoice(ctx context.Context,
 			amountSat,
 		),
 		RouteHints: [][]zpay32.HopHint{
-			{
-				hopHint,
-			},
+			hopHints,
 		},
 		Expiry: int64(expiry.Seconds()),
 	}
@@ -331,6 +357,24 @@ func (g *DirectInvoiceCreator) CreateInvoiceWithKey(ctx context.Context,
 	)
 }
 
+// CreateInvoiceWithKeyRouteHintPath creates one signed invoice with the full
+// route-hint path and the supplied auth key.
+func (g *DirectInvoiceCreator) CreateInvoiceWithKeyRouteHintPath(
+	ctx context.Context, amountSat btcutil.Amount, memo string,
+	routeHintPath []*RouteHint, expiry time.Duration,
+	authKey keychain.SingleKeyMessageSigner, preimage *lntypes.Preimage) (
+	*invoices.Invoice, lntypes.Hash, error) {
+
+	if g == nil || g.generator == nil {
+		return nil, lntypes.Hash{}, fmt.Errorf("invoice generator is " +
+			"required")
+	}
+
+	return g.generator.CreateInvoiceWithKeyRouteHintPath(
+		ctx, amountSat, memo, routeHintPath, expiry, authKey, preimage,
+	)
+}
+
 func validateInvoiceAmount(amountSat btcutil.Amount) error {
 	return validateSatoshiAmount(amountSat, "invoice amount")
 }
@@ -369,6 +413,29 @@ func zpayHopHint(routeHint *RouteHint) (zpay32.HopHint, error) {
 	}, nil
 }
 
+// zpayHopHintPath converts the ordered SDK route-hint path into the zpay32
+// representation embedded in a BOLT-11 invoice.
+func zpayHopHintPath(routeHintPath []*RouteHint) ([]zpay32.HopHint, error) {
+	if len(routeHintPath) == 0 {
+		return nil, fmt.Errorf("route hint path is required")
+	}
+
+	hopHints := make([]zpay32.HopHint, 0, len(routeHintPath))
+	for i, routeHint := range routeHintPath {
+		hopHint, err := zpayHopHint(routeHint)
+		if err != nil {
+			return nil, fmt.Errorf("route hint path hop %d: %w", i,
+				err)
+		}
+
+		hopHints = append(hopHints, hopHint)
+	}
+
+	return hopHints, nil
+}
+
+// validateRouteHint checks that one SDK route hint can be safely converted
+// into the narrower zpay32 hop hint shape.
 func validateRouteHint(routeHint *RouteHint) error {
 	if routeHint == nil {
 		return fmt.Errorf("route hint is required")
@@ -376,6 +443,10 @@ func validateRouteHint(routeHint *RouteHint) error {
 
 	if len(routeHint.NodeID) == 0 {
 		return fmt.Errorf("route hint node ID is required")
+	}
+
+	if routeHint.ChannelID == 0 {
+		return fmt.Errorf("route hint channel ID is required")
 	}
 
 	if routeHint.FeeBaseMsat > uint64(^uint32(0)) {
@@ -391,6 +462,9 @@ func validateRouteHint(routeHint *RouteHint) error {
 	if routeHint.CltvExpiryDelta > uint32(^uint16(0)) {
 		return fmt.Errorf("route hint CLTV expiry delta %d "+
 			"exceeds uint16", routeHint.CltvExpiryDelta)
+	}
+	if routeHint.CltvExpiryDelta == 0 {
+		return fmt.Errorf("route hint CLTV expiry delta is required")
 	}
 
 	return nil

--- a/sdk/swaps/invoice_test.go
+++ b/sdk/swaps/invoice_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/zpay32"
 	"github.com/stretchr/testify/require"
@@ -23,22 +24,51 @@ func TestValidateRouteHintRejectsTruncatedFields(t *testing.T) {
 	nodeID := privKey.PubKey().SerializeCompressed()
 
 	routeHint := &RouteHint{
-		NodeID:      nodeID,
-		FeeBaseMsat: uint64(^uint32(0)) + 1,
+		NodeID:          nodeID,
+		ChannelID:       42,
+		FeeBaseMsat:     uint64(^uint32(0)) + 1,
+		CltvExpiryDelta: 40,
 	}
 	err = validateRouteHint(routeHint)
 	require.ErrorContains(t, err, "fee base msat")
 
 	routeHint = &RouteHint{
-		NodeID:     nodeID,
-		FeePropPpm: uint64(^uint32(0)) + 1,
+		NodeID:          nodeID,
+		ChannelID:       42,
+		FeePropPpm:      uint64(^uint32(0)) + 1,
+		CltvExpiryDelta: 40,
 	}
 	err = validateRouteHint(routeHint)
 	require.ErrorContains(t, err, "fee proportional ppm")
 
 	routeHint = &RouteHint{
 		NodeID:          nodeID,
+		ChannelID:       42,
 		CltvExpiryDelta: uint32(^uint16(0)) + 1,
+	}
+	err = validateRouteHint(routeHint)
+	require.ErrorContains(t, err, "CLTV expiry delta")
+}
+
+// TestValidateRouteHintRejectsZeroFields verifies unusable zero-valued hop
+// fields are rejected before invoice creation.
+func TestValidateRouteHintRejectsZeroFields(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	nodeID := privKey.PubKey().SerializeCompressed()
+
+	routeHint := &RouteHint{
+		NodeID:          nodeID,
+		CltvExpiryDelta: 40,
+	}
+	err = validateRouteHint(routeHint)
+	require.ErrorContains(t, err, "channel ID")
+
+	routeHint = &RouteHint{
+		NodeID:    nodeID,
+		ChannelID: 42,
 	}
 	err = validateRouteHint(routeHint)
 	require.ErrorContains(t, err, "CLTV expiry delta")
@@ -144,4 +174,71 @@ func TestInvoiceGeneratorPreservesPayerFeeRouteHint(t *testing.T) {
 	require.Equal(t, uint32(10_000), hop.FeeProportionalMillionths)
 	require.True(t, decoded.Features.IsSet(lnwire.MPPOptional))
 	require.False(t, decoded.Features.IsSet(lnwire.MPPRequired))
+}
+
+// TestInvoiceGeneratorEmbedsRouteHintPath verifies receive invoices encode a
+// private ingress hop before the swap server's virtual hop.
+func TestInvoiceGeneratorEmbedsRouteHintPath(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	gatewayKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	creator := NewEphemeralInvoiceGenerator(
+		privKey, nil, &chaincfg.RegressionNetParams,
+	)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	routeHintPath := []*RouteHint{{
+		NodeID:          gatewayKey.PubKey().SerializeCompressed(),
+		ChannelID:       21,
+		FeeBaseMsat:     1,
+		FeePropPpm:      2,
+		CltvExpiryDelta: 40,
+	}, {
+		NodeID:          privKey.PubKey().SerializeCompressed(),
+		ChannelID:       42,
+		FeeBaseMsat:     0,
+		FeePropPpm:      10_000,
+		CltvExpiryDelta: 60,
+	}}
+
+	authKey := keychain.NewPrivKeyMessageSigner(
+		privKey, keychain.KeyLocator{},
+	)
+	invoice, _, err := creator.CreateInvoiceWithKeyRouteHintPath(
+		context.Background(), btcutil.Amount(50_000),
+		"swap", routeHintPath, time.Hour, authKey, &preimage,
+	)
+	require.NoError(t, err)
+
+	decoded, err := zpay32.Decode(
+		string(invoice.PaymentRequest), &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+	require.Len(t, decoded.RouteHints, 1)
+	require.Len(t, decoded.RouteHints[0], 2)
+
+	require.Equal(t, uint64(21), decoded.RouteHints[0][0].ChannelID)
+	require.Equal(t, uint32(1), decoded.RouteHints[0][0].FeeBaseMSat)
+	require.Equal(
+		t, uint32(2),
+		decoded.RouteHints[0][0].FeeProportionalMillionths,
+	)
+	require.Equal(
+		t, uint16(40), decoded.RouteHints[0][0].CLTVExpiryDelta,
+	)
+	require.Equal(t, uint64(42), decoded.RouteHints[0][1].ChannelID)
+	require.Equal(
+		t, uint32(10_000),
+		decoded.RouteHints[0][1].FeeProportionalMillionths,
+	)
+	require.Equal(
+		t, uint16(60), decoded.RouteHints[0][1].CLTVExpiryDelta,
+	)
 }

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -670,19 +670,22 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("request channel ID: %w", err)
 	}
-	if quote == nil || quote.RouteHint == nil {
+	if quote == nil || len(quote.RouteHintPath) == 0 {
 		return fmt.Errorf("route quote must be provided")
 	}
+	finalHop := quote.RouteHintPath[len(quote.RouteHintPath)-1]
 
 	s.client.log.InfoS(ctx, "Received route hint from swap server",
-		slog.Uint64("channel_id", quote.RouteHint.ChannelID),
+		slog.Uint64("channel_id", finalHop.ChannelID),
+		slog.Int("path_hops", len(quote.RouteHintPath)),
 		slog.Uint64("payer_fee_msat", quote.PayerFeeMsat),
 	)
 
-	inv, hash, err := s.client.invoiceGen.CreateInvoiceWithKey(
-		ctx, s.amountSat, s.memo, quote.RouteHint, expiry, authKey,
-		&preimage,
-	)
+	inv, hash, err := s.client.invoiceGen.
+		CreateInvoiceWithKeyRouteHintPath(
+			ctx, s.amountSat, s.memo, quote.RouteHintPath, expiry,
+			authKey, &preimage,
+		)
 	if err != nil {
 		return fmt.Errorf("create invoice: %w", err)
 	}

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -65,6 +65,24 @@ func (c *testInvoiceCreator) CreateInvoiceWithKey(ctx context.Context,
 	return c.CreateInvoice(ctx, amount, memo, hint, expiry, preimage)
 }
 
+// CreateInvoiceWithKeyRouteHintPath returns the preconfigured invoice and
+// payment hash for path-aware receive tests.
+func (c *testInvoiceCreator) CreateInvoiceWithKeyRouteHintPath(
+	ctx context.Context, amount btcutil.Amount, memo string,
+	hints []*RouteHint, expiry time.Duration,
+	authKey keychain.SingleKeyMessageSigner, preimage *lntypes.Preimage) (
+	*invoices.Invoice, lntypes.Hash, error) {
+
+	var hint *RouteHint
+	if len(hints) > 0 {
+		hint = hints[len(hints)-1]
+	}
+
+	return c.CreateInvoiceWithKey(
+		ctx, amount, memo, hint, expiry, authKey, preimage,
+	)
+}
+
 // TestStartReceiveRejectsInvalidAmount verifies invalid amounts are rejected
 // before the SDK requests route metadata or creates an invoice.
 func TestStartReceiveRejectsInvalidAmount(t *testing.T) {
@@ -662,7 +680,9 @@ func (c *testSwapServerConn) RequestChannelID(_ context.Context,
 	c.lastAmountSat = amountSat
 
 	return &OutSwapQuote{
-		RouteHint:        c.hint,
+		RouteHintPath: []*RouteHint{
+			c.hint,
+		},
 		ReceiveAmountSat: amountSat,
 		PayerFeeMsat:     c.payerFeeMsat,
 	}, nil

--- a/sdk/swaps/rest_conn_test.go
+++ b/sdk/swaps/rest_conn_test.go
@@ -35,10 +35,13 @@ func TestRESTSwapServerConnRequestChannelID(t *testing.T) {
 					r.URL.Path,
 				)
 
+				routeHintPath := []*swaprpc.RouteHint{
+					routeHint,
+				}
 				body, err := protojson.Marshal(
 					&swaprpc.RequestChannelIdResponse{
-						RouteHint:    routeHint,
-						PayerFeeMsat: 123,
+						RouteHintPath: routeHintPath,
+						PayerFeeMsat:  123,
 					},
 				)
 				require.NoError(t, err)
@@ -62,7 +65,8 @@ func TestRESTSwapServerConnRequestChannelID(t *testing.T) {
 		btcutil.Amount(42_000), 30,
 	)
 	require.NoError(t, err)
-	hint := quote.RouteHint
+	require.Len(t, quote.RouteHintPath, 1)
+	hint := quote.RouteHintPath[0]
 	require.Equal(t, uint64(42), hint.ChannelID)
 	require.Equal(t, nodeID, hint.NodeID)
 	require.EqualValues(t, 42_000, quote.ReceiveAmountSat)

--- a/swapclientserver/invoice_generator_test.go
+++ b/swapclientserver/invoice_generator_test.go
@@ -18,8 +18,9 @@ import (
 
 // stubInvoiceCreator records calls and returns canned responses.
 type stubInvoiceCreator struct {
-	withKeyCalls int
-	noKeyCalls   int
+	withKeyCalls     int
+	withKeyPathCalls int
+	noKeyCalls       int
 }
 
 // CreateInvoice records a no-key invocation. The daemonAuthOnlyInvoiceCreator
@@ -45,6 +46,18 @@ func (s *stubInvoiceCreator) CreateInvoiceWithKey(_ context.Context,
 	return &invoices.Invoice{}, lntypes.Hash{}, nil
 }
 
+// CreateInvoiceWithKeyRouteHintPath records a keyed full-path invocation so
+// the test can confirm that the wrapper forwards new route-hint-aware calls.
+func (s *stubInvoiceCreator) CreateInvoiceWithKeyRouteHintPath(
+	_ context.Context, _ btcutil.Amount, _ string, _ []*swaps.RouteHint,
+	_ time.Duration, _ keychain.SingleKeyMessageSigner,
+	_ *lntypes.Preimage) (*invoices.Invoice, lntypes.Hash, error) {
+
+	s.withKeyPathCalls++
+
+	return &invoices.Invoice{}, lntypes.Hash{}, nil
+}
+
 // TestDaemonAuthOnlyInvoiceCreatorRejectsNoKey asserts that the daemon swap
 // path can never silently fall back to ephemeral-key signing: a direct
 // CreateInvoice call returns an error and the underlying generator is never
@@ -66,6 +79,7 @@ func TestDaemonAuthOnlyInvoiceCreatorRejectsNoKey(t *testing.T) {
 		"inner CreateInvoice must not be reached",
 	)
 	require.Equal(t, 0, stub.withKeyCalls)
+	require.Equal(t, 0, stub.withKeyPathCalls)
 }
 
 // TestDaemonAuthOnlyInvoiceCreatorForwardsKeyedPath asserts that the wrapper
@@ -91,5 +105,31 @@ func TestDaemonAuthOnlyInvoiceCreatorForwardsKeyedPath(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, 1, stub.withKeyCalls)
+	require.Equal(t, 0, stub.withKeyPathCalls)
+	require.Equal(t, 0, stub.noKeyCalls)
+}
+
+// TestDaemonAuthOnlyInvoiceCreatorForwardsKeyedRouteHintPath asserts that the
+// daemon wrapper preserves the full route-hint path used for hidden-primary
+// payments.
+func TestDaemonAuthOnlyInvoiceCreatorForwardsKeyedRouteHintPath(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubInvoiceCreator{}
+	wrapper := &daemonAuthOnlyInvoiceCreator{inner: stub}
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	authKey := keychain.NewPrivKeyMessageSigner(
+		priv, keychain.KeyLocator{},
+	)
+
+	_, _, err = wrapper.CreateInvoiceWithKeyRouteHintPath(
+		t.Context(), btcutil.Amount(1000),
+		"memo", nil, time.Minute, authKey, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 0, stub.withKeyCalls)
+	require.Equal(t, 1, stub.withKeyPathCalls)
 	require.Equal(t, 0, stub.noKeyCalls)
 }

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -795,6 +795,19 @@ func (d *daemonAuthOnlyInvoiceCreator) CreateInvoiceWithKey(ctx context.Context,
 	)
 }
 
+// CreateInvoiceWithKeyRouteHintPath delegates to the underlying generator with
+// the full private route-hint path and daemon-derived auth key.
+func (d *daemonAuthOnlyInvoiceCreator) CreateInvoiceWithKeyRouteHintPath(
+	ctx context.Context, amountSat btcutil.Amount, memo string,
+	routeHintPath []*swaps.RouteHint, expiry time.Duration,
+	authKey keychain.SingleKeyMessageSigner, preimage *lntypes.Preimage) (
+	*invoices.Invoice, lntypes.Hash, error) {
+
+	return d.inner.CreateInvoiceWithKeyRouteHintPath(
+		ctx, amountSat, memo, routeHintPath, expiry, authKey, preimage,
+	)
+}
+
 // swapServerDialOptions maps daemon swap config into gRPC transport options
 // for swapdk-server.
 func swapServerDialOptions(cfg *darepod.SwapConfig, addr string,

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -765,7 +765,9 @@ func TestNewSwapServerClientsREST(t *testing.T) {
 		CltvExpiryDelta:    40,
 	}
 	channelIDResp := &swaprpc.RequestChannelIdResponse{
-		RouteHint: routeHint,
+		RouteHintPath: []*swaprpc.RouteHint{
+			routeHint,
+		},
 	}
 
 	server := httptest.NewServer(
@@ -841,8 +843,9 @@ func TestNewSwapServerClientsREST(t *testing.T) {
 		btcutil.Amount(42_000), 30,
 	)
 	require.NoError(t, err)
-	require.Equal(t, uint64(42), hint.RouteHint.ChannelID)
-	require.Equal(t, nodeID, hint.RouteHint.NodeID)
+	require.Len(t, hint.RouteHintPath, 1)
+	require.Equal(t, uint64(42), hint.RouteHintPath[0].ChannelID)
+	require.Equal(t, nodeID, hint.RouteHintPath[0].NodeID)
 
 	_, err = clients.mailbox.Pull(
 		t.Context(), &mailboxpb.PullRequest{

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -157,11 +157,14 @@ func (x *RequestChannelIdRequest) GetAmountMsat() uint64 {
 	return 0
 }
 
-// RequestChannelIdResponse returns the route hint for one receive negotiation.
+// RequestChannelIdResponse returns the route hint path for one receive
+// negotiation.
 type RequestChannelIdResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// route_hint contains the hop hint the client should embed in the invoice.
-	RouteHint *RouteHint `protobuf:"bytes,1,opt,name=route_hint,json=routeHint,proto3" json:"route_hint,omitempty"`
+	// route_hint_path contains the full private path the client should embed in
+	// the invoice. The last hop is the swap server's virtual channel. Earlier
+	// hops may route from a public gateway node into a private swap LND node.
+	RouteHintPath []*RouteHint `protobuf:"bytes,1,rep,name=route_hint_path,json=routeHintPath,proto3" json:"route_hint_path,omitempty"`
 	// payer_fee_msat is the quoted Lightning route fee paid by the sender for
 	// the swap server's virtual hop. Callers that want a "payer pays" total
 	// compute it as amount_msat plus payer_fee_msat.
@@ -200,9 +203,9 @@ func (*RequestChannelIdResponse) Descriptor() ([]byte, []int) {
 	return file_swap_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *RequestChannelIdResponse) GetRouteHint() *RouteHint {
+func (x *RequestChannelIdResponse) GetRouteHintPath() []*RouteHint {
 	if x != nil {
-		return x.RouteHint
+		return x.RouteHintPath
 	}
 	return nil
 }
@@ -1814,10 +1817,9 @@ const file_swap_proto_rawDesc = "" +
 	"\x13client_vhtlc_pubkey\x18\x02 \x01(\fR\x11clientVhtlcPubkey\x12!\n" +
 	"\fpayment_hash\x18\x03 \x01(\fR\vpaymentHash\x12\x1f\n" +
 	"\vamount_msat\x18\x04 \x01(\x04R\n" +
-	"amountMsat\"s\n" +
-	"\x18RequestChannelIdResponse\x121\n" +
-	"\n" +
-	"route_hint\x18\x01 \x01(\v2\x12.swaprpc.RouteHintR\trouteHint\x12$\n" +
+	"amountMsat\"|\n" +
+	"\x18RequestChannelIdResponse\x12:\n" +
+	"\x0froute_hint_path\x18\x01 \x03(\v2\x12.swaprpc.RouteHintR\rrouteHintPath\x12$\n" +
 	"\x0epayer_fee_msat\x18\x02 \x01(\x04R\fpayerFeeMsat\"r\n" +
 	"\x1dAcknowledgeOutSwapHtlcRequest\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12.\n" +
@@ -1986,7 +1988,7 @@ var file_swap_proto_goTypes = []any{
 	(*timestamppb.Timestamp)(nil),                 // 25: google.protobuf.Timestamp
 }
 var file_swap_proto_depIdxs = []int32{
-	9,  // 0: swaprpc.RequestChannelIdResponse.route_hint:type_name -> swaprpc.RouteHint
+	9,  // 0: swaprpc.RequestChannelIdResponse.route_hint_path:type_name -> swaprpc.RouteHint
 	10, // 1: swaprpc.OutSwapHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
 	6,  // 2: swaprpc.OutSwapHtlcEvent.parts:type_name -> swaprpc.OutSwapHtlcPart
 	5,  // 3: swaprpc.SwapMailboxEvent.out_swap_htlc:type_name -> swaprpc.OutSwapHtlcEvent

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -82,10 +82,13 @@ message RequestChannelIdRequest {
     uint64 amount_msat = 4;
 }
 
-// RequestChannelIdResponse returns the route hint for one receive negotiation.
+// RequestChannelIdResponse returns the route hint path for one receive
+// negotiation.
 message RequestChannelIdResponse {
-    // route_hint contains the hop hint the client should embed in the invoice.
-    RouteHint route_hint = 1;
+    // route_hint_path contains the full private path the client should embed in
+    // the invoice. The last hop is the swap server's virtual channel. Earlier
+    // hops may route from a public gateway node into a private swap LND node.
+    repeated RouteHint route_hint_path = 1;
 
     // payer_fee_msat is the quoted Lightning route fee paid by the sender for
     // the swap server's virtual hop. Callers that want a "payer pays" total


### PR DESCRIPTION
## Summary

This PR changes out-swap receive quotes to use one ordered route-hint path.

Before this change, the quote exposed one final hop into the swap server. That
was enough when the payer could already reach the swap server's LND node. It is
not enough for the Ark hidden-primary setup, where the swap server uses a private
primary LND behind a public gateway LND.

The protocol now has a single response shape for this part of the quote:

- `route_hint_path` is the ordered private path that the SDK puts in the invoice.
- The last hop is the virtual swap-server channel.
- Earlier hops, when present, lead from a public gateway into the private primary.

There is no separate `route_hint` field. We do not need the compatibility field
because this path is not released to users yet.

This PR is paired with the server PR that creates the hidden-primary path and
uses it in real integration tests:

https://github.com/lightninglabs/swapdk-server/pull/141

## Flow Change

The receive flow now works like this:

1. The SDK asks the swap server for a channel ID quote.
2. The server returns `route_hint_path`.
3. The SDK validates every hop in that path.
4. The SDK creates the BOLT-11 invoice with that ordered path.
5. A payer can route through the gateway hop first, then through the final virtual
   swap hop.

For a normal one-node setup, the path has one hop. For a hidden-primary setup,
the path has at least two hops: the gateway-to-primary hop first, then the
virtual swap hop.

## LND Harness Support

The paired server integration test uses a trusted virtual channel between the
gateway LND and primary LND. That channel uses LND's zero-conf and SCID alias
features.

This PR enables the matching feature bits in the shared LND harness:

- `--protocol.option-scid-alias`
- `--protocol.zero-conf`

That lets the server integration test exercise the hidden-primary topology with
real LND nodes. The harness change is test infrastructure only. It does not
change SDK production behavior.

## Validation

The SDK rejects route-hint hops that cannot produce a payable invoice:

- missing node ID
- zero channel ID
- fee fields that do not fit in the BOLT-11 hop-hint type
- zero CLTV delta
- CLTV delta that does not fit in the BOLT-11 hop-hint type

This prevents the SDK from creating an invoice that looks valid but cannot be
paid because one hop has no short channel ID or no CLTV delta.

## Test Coverage

The tests cover the new behavior at the SDK boundary:

- protobuf quote parsing carries `route_hint_path` through to the SDK quote type
- the SDK rejects quote responses that do not include a path
- invoice generation embeds a two-hop path in order
- invoice generation preserves channel IDs, fees, and CLTV deltas for both hops
- route-hint validation rejects zero channel IDs and zero CLTV deltas
- out-swap receive tests use a mock quote that matches the production contract
- REST swap-client tests parse and expose the path-only response shape
- the shared LND harness can start nodes with zero-conf and SCID alias support

The PR also keeps the earlier CI hardening commit for `internal/actortest`. That
commit only raises bounded waits in the outbox end-to-end tests. It does not
change SDK, swap, harness, or production actor behavior.

## Checks

- `go test ./sdk/swaps/...`
- `go test -tags=swapruntime ./swapclientserver`
- `make commitmsg-lint range="origin/main..HEAD"`

The paired server branch also passed:

- `go test ./swapserver`
- `go test -tags="itest dev nolog" ./itest -run TestOutSwapHiddenPrimaryHappyPath -count=1`
- `make commitmsg-lint range="origin/master..HEAD"`
