### PR TITLE
walletdk: expose the wallet SDK to mobile via gomobile

### DIFF
--- a/.github/workflows/mobile-bindings.yml
+++ b/.github/workflows/mobile-bindings.yml
@@ -1,0 +1,144 @@
+name: Mobile Bindings
+
+# The mobile binding package compiles on every relevant PR (a fast, host-tagged
+# build), but the expensive gomobile .aar / .xcframework builds (which cross
+# compile the whole embedded daemon for every ABI) run only when a
+# `mobile-v*` tag is pushed, so routine merges do not trigger them.
+on:
+  push:
+    tags:
+      - "mobile-v*"
+  pull_request:
+    paths:
+      - "sdk/walletdk/**"
+      - "swapwallet/**"
+      - "Makefile"
+      - ".github/workflows/mobile-bindings.yml"
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mobile-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  # If you change this please also update GO_VERSION in Makefile.
+  GO_VERSION: 1.25.5
+  MOBILE_TAGS: "mobile walletdkrpc swapruntime"
+
+jobs:
+  ########################################################################
+  # Fast gate: the facade must compile and its boundary tests must pass.
+  # Runs on PRs and the merge queue, not on tag builds.
+  ########################################################################
+  unit:
+    name: Compile + test (host)
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Test mobile facade
+        run: go test -tags="${MOBILE_TAGS}" ./sdk/walletdk/mobile/...
+
+  ########################################################################
+  # Android .aar — tag builds only.
+  ########################################################################
+  android:
+    name: Build Android .aar
+    if: startsWith(github.ref, 'refs/tags/mobile-v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1
+        id: ndk
+        with:
+          ndk-version: r27c
+
+      - name: Install gomobile
+        run: |
+          go install golang.org/x/mobile/cmd/gomobile@latest
+          go install golang.org/x/mobile/cmd/gobind@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Build .aar
+        env:
+          ANDROID_NDK_HOME: ${{ steps.ndk.outputs.ndk-path }}
+        run: |
+          gomobile init
+          make mobile-android
+
+      - name: Upload .aar
+        uses: actions/upload-artifact@v4
+        with:
+          name: Walletdk-aar
+          path: sdk/walletdk/mobile/build/android/Walletdk.aar
+          if-no-files-found: error
+
+  ########################################################################
+  # iOS .xcframework — tag builds only (macOS runner for Xcode).
+  ########################################################################
+  ios:
+    name: Build iOS .xcframework
+    if: startsWith(github.ref, 'refs/tags/mobile-v')
+    runs-on: macos-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install gomobile
+        run: |
+          go install golang.org/x/mobile/cmd/gomobile@latest
+          go install golang.org/x/mobile/cmd/gobind@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Build .xcframework
+        run: |
+          gomobile init
+          make mobile-ios
+
+      - name: Package .xcframework
+        run: |
+          tar -czf Walletdk.xcframework.tar.gz \
+            -C sdk/walletdk/mobile/build/ios Walletdk.xcframework
+
+      - name: Upload .xcframework
+        uses: actions/upload-artifact@v4
+        with:
+          name: Walletdk-xcframework
+          path: Walletdk.xcframework.tar.gz
+          if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .PHONY: ast-lint ast-grep-fix
 .PHONY: unit unit-cover unit-race unit-swapruntime check-go-version build install clean release
 .PHONY: build build-swapruntime build-swapclient build-walletdkrpc rpc install install-swapruntime install-walletdkrpc help clean-networks
+.PHONY: mobile mobile-android mobile-ios
 .PHONY: systest systest-verbose
 .PHONY: commitmsg-lint commitmsg-fmt commitmsg-reword
 
@@ -435,6 +436,18 @@ build-swapclient: build-swapruntime #? Alias for build-swapruntime
 build-walletdkrpc: #? Build debug binaries with walletdkrpc + swapruntime enabled
 	@$(call print, "Building debug binaries with walletdkrpc and swapruntime.")
 	$(MAKE) build tags="walletdkrpc swapruntime"
+
+mobile: #? Build gomobile bindings for sdk/walletdk (target=android|ios|all)
+	@$(call print, "Building gomobile walletdk bindings.")
+	./sdk/walletdk/mobile/gen_bindings.sh $(or $(target),android)
+
+mobile-android: #? Build the Android .aar for sdk/walletdk
+	@$(call print, "Building Android .aar for walletdk.")
+	./sdk/walletdk/mobile/gen_bindings.sh android
+
+mobile-ios: #? Build the iOS .xcframework for sdk/walletdk
+	@$(call print, "Building iOS .xcframework for walletdk.")
+	./sdk/walletdk/mobile/gen_bindings.sh ios
 
 install: #? Build and install binaries to GOPATH/bin
 	@$(call print, "Installing binaries.")

--- a/docs/walletdk_mobile.md
+++ b/docs/walletdk_mobile.md
@@ -1,0 +1,187 @@
+# walletdk on mobile (gomobile)
+
+`sdk/walletdk/mobile` is a [gomobile](https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile)-safe
+facade over the wallet SDK. It lets an Android (Kotlin/Java) or iOS
+(Swift/ObjC) host drive an embedded `darepod` wallet **in-process** — no
+separate daemon binary, no open socket — by reusing the private `bufconn` gRPC
+transport that [`walletdk.Start`](../sdk/walletdk/embedded.go) already sets up.
+
+It borrows the *bytes-out* idea from `lightninglabs/falafel` and `lnd/mobile`
+**without** the protoc generator or their callback interfaces, because the
+`walletdk` facade already owns the wiring and `walletdk.Start` returns once gRPC
+is serving (`lnd.Main` blocks forever, so lnd needs a callback — we do not).
+
+## Why a separate package
+
+`gomobile bind` only carries a narrow set of types across the FFI boundary:
+signed ints, floats, `string`, `bool`, `[]byte`, and interfaces/structs whose
+members are all of those. It cannot carry `context.Context`, channels, maps,
+`uint*`, `time.Time`, slices other than `[]byte`, or tagged-union structs — all
+of which appear throughout `walletdk`'s public API. So `mobile` is a flat
+translation layer; it never exposes the rich `walletdk` types directly.
+
+The package is gated behind three build tags — `mobile`, `walletdkrpc`, and
+`swapruntime` — so it only compiles into a `gomobile bind` output. An ordinary
+`go build ./...` sees only the unconstrained `doc.go`.
+
+## The payload contract (hybrid)
+
+| Shape | Convention | Verbs |
+|-------|-----------|-------|
+| RPC verbs | **JSON `[]byte` in / out** (throwing) | `GetInfo`, `CreateWallet`, `UnlockWallet`, `Balance`, `Deposit`, `Receive`, `PrepareSend`, `SendPrepared`, `List`, `Exit`, `ExitStatus`, `GetExitPlan`, `SweepWallet`, `Status` |
+| Streaming | **pull handle** `Subscription{ next() []byte; close() }` | `Subscribe` |
+| Hot-path scalars | **plain `int64`/`bool`** | `ConfirmedBalanceSat`, `PendingInboundSat`, `WalletReady`, `IsRunning` |
+
+There are **no host-implemented callback interfaces**. Unary verbs are ordinary
+throwing calls; streaming is pull-based. The host owns its own threads — which
+is where Kotlin coroutines / Swift `async` live anyway.
+
+JSON (not protobuf) keeps hosts free of a protobuf runtime: decode with
+`kotlinx.serialization` on Android or `Codable` on iOS.
+
+Mind the field names. The verb DTOs in `sdk/walletdk/types.go` carry **no**
+`json:"…"` tags, so `encoding/json` uses the Go field names verbatim: the wire
+keys are PascalCase (`Version`, `ConfirmedSat`, `AmountSat`, `IdentityPubKey`),
+not snake_case. Host models must map those exact names (e.g. `@SerialName`
+/ `CodingKeys`), or fields silently decode as zero. The one exception is the
+`Start` config, which is a dedicated tagged struct (`config.go`) and is
+snake_case (`data_dir`, `wallet_esplora_url`, …). Requests decode into the
+matching `walletdk.*Request` DTO, so they follow the same PascalCase rule.
+
+## Lifecycle
+
+```go
+// Start boots the daemon and blocks until gRPC is serving (or errors).
+// Call it off the main thread.
+func Start(cfgJSON string) error
+
+// Stop tears down the daemon. Idempotent; resets the singleton so a host can
+// restart after the OS suspends/resumes the app.
+func Stop() error
+```
+
+- **Synchronous.** `Start` blocks until the embedded daemon's private gRPC
+  transport reports ready, then returns; the daemon keeps running on its own
+  goroutine. The host must call it on a background thread
+  (`withContext(Dispatchers.IO)` / a Swift `Task`).
+- **Singleton-guarded** by a four-state lifecycle (stopped / starting / started
+  / stopping): a second `Start` before `Stop` returns an error instead of
+  booting a second daemon. A `Stop` that races an in-progress `Start` cancels
+  the boot, and that `Start` tears down any client it produced rather than
+  leaking it. A panic in the boot path is recovered into the returned error; an
+  unrecovered panic would kill the host process across the boundary.
+- The wrapper owns an internal `context.Context` created in `Start` and
+  cancelled by `Stop`, so the mobile API never has to express a `context.Context`
+  and in-flight RPCs / subscriptions unwind on shutdown.
+
+### Streaming
+
+```go
+// Subscribe opens a wallet activity stream and returns a pull handle.
+func Subscribe(reqJSON []byte) (*Subscription, error)
+
+func (s *Subscription) Next() ([]byte, error) // blocks; io.EOF at clean end
+func (s *Subscription) Close() error          // cancels a blocked Next
+```
+
+The host loops `next()` on a background thread; this maps directly to a Kotlin
+`Flow` or a Swift `AsyncStream`. `Stop` also ends every open subscription.
+
+## Config
+
+`Start` takes a JSON string decoded into a flat, scalar-only config
+(`config.go`, `mobileConfig`). It is the JSON-friendly subset of
+`walletdk.Config`: it omits `DaemonConfig *darepod.Config` and
+`LogWriter io.Writer`, expresses durations as integer seconds, and follows the
+same enable-only / non-empty overlay semantics (the zero value defers to the
+`walletdkrpc` build defaults). An empty string boots from
+`walletdk.DefaultConfig`.
+
+```json
+{
+  "data_dir": "/data/user/0/<app>/files/walletdk",
+  "network": "regtest",
+  "server_address": "10.0.2.2:9000",
+  "server_insecure": true,
+  "wallet_type": "lwwallet",
+  "wallet_esplora_url": "http://10.0.2.2:3000"
+}
+```
+
+(`10.0.2.2` is the Android emulator's alias for the host loopback.)
+
+## Building the bindings
+
+Prerequisites:
+
+- **gomobile** at a recent version: `go install golang.org/x/mobile/cmd/{gomobile,gobind}@latest`.
+- **Android SDK + NDK** (the `android` CLI installs them under
+  `~/Library/Android/sdk`): `android sdk install platform-tools ndk/<version>`.
+- A **modern JDK** (8 is too old; use 17+). Point `JAVA_HOME` at it.
+- Build with `GOPATH` *not* equal to `GOROOT` (gomobile and the linter both
+  dislike `GOPATH==GOROOT`).
+
+```bash
+make mobile-android       # -> sdk/walletdk/mobile/build/android/Walletdk.aar
+make mobile-ios           # -> sdk/walletdk/mobile/build/ios/Walletdk.xcframework
+make mobile target=all
+```
+
+These call [`gen_bindings.sh`](../sdk/walletdk/mobile/gen_bindings.sh), which
+runs `gomobile bind` with `-tags="mobile walletdkrpc swapruntime"`,
+`-androidapi 21`, and a 16KB-page-size `-extldflags` (for newer Android
+devices). The generated Java package is `engineering.lightning.walletdk`.
+
+> The embedded build pulls in `btcwallet`/`neutrino`/`lnd`, so the `.aar` is
+> large. Measure binary size before shipping.
+
+## Sample app
+
+The sample Android app (and, later, iOS app + idiomatic Kotlin/Swift wrappers)
+lives in a separate repo: **[lightninglabs/damobile](https://github.com/lightninglabs/damobile)**.
+It consumes the `.aar` this repo produces via a `scripts/fetch-aar.sh` that
+calls `make mobile-android` against a sibling `darepo-client` checkout. See that
+repo's README and `docs/signet.md` for the end-to-end run (emulator, signet
+sync).
+
+SDK component install (one time), for reference:
+
+```bash
+android sdk install platform-tools emulator platforms/android-36 \
+  build-tools/36.1.0 ndk/29.0.14206865 \
+  system-images/android-36/google_apis/arm64-v8a
+```
+
+From Kotlin, the generated package exposes the free functions as static methods
+on a `Mobile` class (package `engineering.lightning.walletdk.mobile`):
+
+```kotlin
+import engineering.lightning.walletdk.mobile.Mobile
+
+// Start blocks until gRPC is serving, so run it off the main thread.
+withContext(Dispatchers.IO) { Mobile.start(configJson) }
+
+val balanceJson = Mobile.balance()        // ByteArray of walletdk.Balance JSON
+val confirmed = Mobile.confirmedBalanceSat() // Long, no JSON decode
+
+// Streaming as a Flow:
+fun walletActivity() = flow {
+    val sub = Mobile.subscribe(ByteArray(0))
+    try {
+        while (true) emit(String(sub.next())) // io.EOF throws -> loop ends
+    } finally {
+        sub.close()
+    }
+}.flowOn(Dispatchers.IO)
+```
+
+No interfaces to implement. A thin wrapper that maps these throwing calls to
+Swift `async` is the iOS sibling; both are optional — the generated API is
+callable as-is.
+
+## Not yet wired
+
+- A host-driven `ProcessNextMsg` mailbox pump (issue #713 open question #2)
+  cooperative with OS suspension. The package currently relies on the embedded
+  daemon's always-on background ingress loop.
+- Reference Kotlin/Swift ergonomic wrappers (sketched above, not shipped).

--- a/sdk/walletdk/mobile/.gitignore
+++ b/sdk/walletdk/mobile/.gitignore
@@ -1,0 +1,2 @@
+# gomobile bind outputs are large (100MB+ .so); rebuild with `make mobile-*`.
+/build/

--- a/sdk/walletdk/mobile/config.go
+++ b/sdk/walletdk/mobile/config.go
@@ -1,0 +1,212 @@
+//go:build mobile && walletdkrpc && swapruntime
+
+package mobile
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/sdk/walletdk"
+)
+
+// mobileConfig is the flat, JSON-serializable subset of walletdk.Config that a
+// mobile host can express. It deliberately omits the reference-typed fields of
+// walletdk.Config (DaemonConfig *darepod.Config and LogWriter io.Writer) that
+// cannot cross a JSON / gomobile boundary; hosts that need fine-grained daemon
+// knobs should use the Go SDK directly. Durations are seconds and amounts are
+// int64 to stay JSON-host friendly (no uint, no time.Duration).
+type mobileConfig struct {
+	DataDir    string `json:"data_dir"`
+	Network    string `json:"network"`
+	DebugLevel string `json:"debug_level"`
+
+	// AllowMainnet must be true to run on mainnet.
+	AllowMainnet bool `json:"allow_mainnet"`
+
+	// Ark operator / mailbox edge server.
+	ServerAddress     string `json:"server_address"`
+	ServerTransport   string `json:"server_transport"`
+	ServerTLSCertPath string `json:"server_tls_cert_path"`
+	ServerInsecure    bool   `json:"server_insecure"`
+
+	// Backing wallet.
+	WalletType                string `json:"wallet_type"`
+	WalletEsploraURL          string `json:"wallet_esplora_url"`
+	WalletPasswordFile        string `json:"wallet_password_file"`
+	WalletPollIntervalSeconds int64  `json:"wallet_poll_interval_seconds"`
+	WalletRecoveryWindow      int64  `json:"wallet_recovery_window"`
+	WalletFeeURL              string `json:"wallet_fee_url"`
+	WalletBlockHeadersSource  string `json:"wallet_block_headers_source"`
+	WalletFilterHeadersSource string `json:"wallet_filter_headers_source"`
+
+	// Swap server.
+	SwapServerAddress     string `json:"swap_server_address"`
+	SwapServerTransport   string `json:"swap_server_transport"`
+	SwapServerTLSCertPath string `json:"swap_server_tls_cert_path"`
+	SwapServerInsecure    bool   `json:"swap_server_insecure"`
+	SwapDatabaseFileName  string `json:"swap_database_file_name"`
+
+	MaxOperatorFeeSat int64 `json:"max_operator_fee_sat"`
+	EagerRoundJoin    bool  `json:"eager_round_join"`
+	BufferSize        int   `json:"buffer_size"`
+}
+
+// parseConfig decodes the host JSON config into a walletdk.Config. An empty
+// string yields walletdk.DefaultConfig so a host can boot with all defaults.
+func parseConfig(cfgJSON string) (walletdk.Config, error) {
+	cfg := walletdk.DefaultConfig()
+	if cfgJSON == "" {
+		return cfg, nil
+	}
+
+	var mc mobileConfig
+	if err := json.Unmarshal([]byte(cfgJSON), &mc); err != nil {
+		return walletdk.Config{}, fmt.Errorf("decode mobile config: %w",
+			err)
+	}
+
+	if err := mc.validate(); err != nil {
+		return walletdk.Config{}, err
+	}
+
+	applyMobileConfig(&cfg, mc)
+
+	return cfg, nil
+}
+
+// validate rejects malformed scalar config before it reaches the daemon. The
+// gomobile boundary uses signed integers, so a host can pass a negative where
+// the daemon expects a non-negative count or duration. A negative
+// wallet_poll_interval_seconds in particular becomes a negative time.Duration
+// that panics the lwwallet tip poller's time.NewTicker in a background
+// goroutine after startup; catching it here turns malformed JSON into a clean
+// startup error instead of crashing the host process. The same guard protects
+// the unchecked int64->uint32 conversion of the recovery window.
+func (mc mobileConfig) validate() error {
+	nonNegative := []struct {
+		name string
+		v    int64
+	}{
+		{
+			"wallet_poll_interval_seconds",
+			mc.WalletPollIntervalSeconds,
+		},
+		{
+			"wallet_recovery_window",
+			mc.WalletRecoveryWindow,
+		},
+		{
+			"max_operator_fee_sat",
+			mc.MaxOperatorFeeSat,
+		},
+	}
+	for _, f := range nonNegative {
+		if f.v < 0 {
+			return fmt.Errorf("%s must not be negative: %d", f.name,
+				f.v)
+		}
+	}
+	if mc.BufferSize < 0 {
+		return fmt.Errorf("buffer_size must not be negative: %d",
+			mc.BufferSize)
+	}
+
+	// The recovery window is narrowed to uint32 in applyMobileConfig, so an
+	// absurdly large positive value would silently wrap. Reject it here to
+	// keep the conversion total.
+	if mc.WalletRecoveryWindow > math.MaxUint32 {
+		return fmt.Errorf("wallet_recovery_window exceeds "+
+			"uint32 max: %d", mc.WalletRecoveryWindow)
+	}
+
+	return nil
+}
+
+// applyMobileConfig overlays only the fields the host actually set onto the
+// default config, mirroring walletdk's own enable-only / non-empty convenience
+// merge semantics so the zero value defers to the walletdkrpc build defaults.
+func applyMobileConfig(cfg *walletdk.Config, mc mobileConfig) {
+	if mc.DataDir != "" {
+		cfg.DataDir = mc.DataDir
+	}
+	if mc.Network != "" {
+		cfg.Network = mc.Network
+	}
+	if mc.DebugLevel != "" {
+		cfg.DebugLevel = mc.DebugLevel
+	}
+	if mc.AllowMainnet {
+		cfg.AllowMainnet = true
+	}
+
+	if mc.ServerAddress != "" {
+		cfg.ServerAddress = mc.ServerAddress
+	}
+	if mc.ServerTransport != "" {
+		cfg.ServerTransport = walletdk.Transport(mc.ServerTransport)
+	}
+	if mc.ServerTLSCertPath != "" {
+		cfg.ServerTLSCertPath = mc.ServerTLSCertPath
+	}
+	if mc.ServerInsecure {
+		cfg.ServerInsecure = true
+	}
+
+	if mc.WalletType != "" {
+		cfg.WalletType = mc.WalletType
+	}
+	if mc.WalletEsploraURL != "" {
+		cfg.WalletEsploraURL = mc.WalletEsploraURL
+	}
+	if mc.WalletPasswordFile != "" {
+		cfg.WalletPasswordFile = mc.WalletPasswordFile
+	}
+	if mc.WalletPollIntervalSeconds != 0 {
+		cfg.WalletPollInterval = time.Duration(
+			mc.WalletPollIntervalSeconds,
+		) * time.Second
+	}
+	if mc.WalletRecoveryWindow != 0 {
+		cfg.WalletRecoveryWindow = uint32(mc.WalletRecoveryWindow)
+	}
+	if mc.WalletFeeURL != "" {
+		cfg.WalletFeeURL = mc.WalletFeeURL
+	}
+	if mc.WalletBlockHeadersSource != "" {
+		cfg.WalletBtcwalletBlockHeadersSource = mc.WalletBlockHeadersSource
+	}
+	if mc.WalletFilterHeadersSource != "" {
+		cfg.WalletBtcwalletFilterHeadersSource =
+			mc.WalletFilterHeadersSource
+	}
+
+	if mc.SwapServerAddress != "" {
+		cfg.SwapServerAddress = mc.SwapServerAddress
+	}
+	if mc.SwapServerTransport != "" {
+		cfg.SwapServerTransport = walletdk.Transport(
+			mc.SwapServerTransport,
+		)
+	}
+	if mc.SwapServerTLSCertPath != "" {
+		cfg.SwapServerTLSCertPath = mc.SwapServerTLSCertPath
+	}
+	if mc.SwapServerInsecure {
+		cfg.SwapServerInsecure = true
+	}
+	if mc.SwapDatabaseFileName != "" {
+		cfg.SwapDatabaseFileName = mc.SwapDatabaseFileName
+	}
+
+	if mc.MaxOperatorFeeSat != 0 {
+		cfg.MaxOperatorFeeSat = mc.MaxOperatorFeeSat
+	}
+	if mc.EagerRoundJoin {
+		cfg.EagerRoundJoin = true
+	}
+	if mc.BufferSize != 0 {
+		cfg.BufferSize = mc.BufferSize
+	}
+}

--- a/sdk/walletdk/mobile/convenience.go
+++ b/sdk/walletdk/mobile/convenience.go
@@ -1,0 +1,62 @@
+//go:build mobile && walletdkrpc && swapruntime
+
+package mobile
+
+// This file holds the scalar "hot path" conveniences of the hybrid API. A host
+// that only needs a single number or flag should not have to stand up a JSON
+// decoder, so these return plain gomobile scalars instead of JSON bytes.
+
+// ConfirmedBalanceSat returns the confirmed wallet balance in satoshis.
+func ConfirmedBalanceSat() (int64, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return 0, err
+	}
+
+	bal, err := client.Balance(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return bal.ConfirmedSat, nil
+}
+
+// PendingInboundSat returns the pending inbound balance in satoshis.
+func PendingInboundSat() (int64, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return 0, err
+	}
+
+	bal, err := client.Balance(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return bal.PendingInSat, nil
+}
+
+// WalletReady reports whether the daemon wallet is fully unlocked and ready to
+// sign. It is the scalar form of GetInfo().WalletState == ready.
+func WalletReady() (bool, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return false, err
+	}
+
+	info, err := client.GetInfo(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	return info.WalletReady(), nil
+}
+
+// IsRunning reports whether a daemon lifecycle is active: true from the moment
+// Start begins, across the whole boot window, until Stop completes. It never
+// blocks on an RPC, so a host can poll it cheaply from the UI thread. Note that
+// a true result during the boot window does not yet mean RPCs will succeed; use
+// WalletReady / GetInfo for readiness.
+func IsRunning() bool {
+	return lifecycleActive()
+}

--- a/sdk/walletdk/mobile/doc.go
+++ b/sdk/walletdk/mobile/doc.go
@@ -1,0 +1,20 @@
+// Package mobile is a gomobile-safe facade over sdk/walletdk. It wraps the
+// hand-written wallet SDK in a flat API that respects gomobile's type
+// restrictions: no context.Context, no channels, no maps, no slices other
+// than []byte, and no unsigned integers crossing the boundary.
+//
+// The package borrows the falafel / lnd-mobile bytes-out idea without the
+// protoc generator or its callback interfaces, because sdk/walletdk already
+// owns the in-process bufconn gRPC wiring and walletdk.Start returns once gRPC
+// is serving (lnd.Main blocks forever, so lnd needs a callback; we do not).
+// RPC verbs use a JSON bytes-in / bytes-out convention (the host decodes with
+// kotlinx.serialization / Codable, no protobuf runtime needed), with a handful
+// of scalar convenience methods for the hottest paths. Start is synchronous
+// (call it off the main thread), and the one streaming verb, Subscribe, hands
+// back a pull-based Subscription handle (Next / Close) instead of a callback,
+// since a Go channel cannot cross the gomobile boundary.
+//
+// Everything is gated behind the mobile, walletdkrpc, and swapruntime build
+// tags so the package only compiles into a gomobile bind output; ordinary
+// go build ./... sees the empty stub in stub.go.
+package mobile

--- a/sdk/walletdk/mobile/gen_bindings.sh
+++ b/sdk/walletdk/mobile/gen_bindings.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# gen_bindings.sh builds the gomobile bindings for sdk/walletdk/mobile.
+#
+# It produces an Android .aar and/or an iOS .xcframework from the gomobile-safe
+# facade. The embedded daemon (btcwallet / neutrino / lnd deps) is cross
+# compiled via cgo using the Android NDK, so ANDROID_HOME and a modern JDK must
+# be available.
+#
+# Usage:
+#   ./gen_bindings.sh android   # build the Android .aar (default)
+#   ./gen_bindings.sh ios       # build the iOS .xcframework (macOS + Xcode)
+#   ./gen_bindings.sh all       # build both
+
+set -euo pipefail
+
+# The gomobile-safe package and the build tags it requires. The mobile tag is
+# what gates the facade; walletdkrpc + swapruntime pull in the embedded wallet
+# RPC runtime (both are required by walletdk.requireEmbeddedWalletRuntime).
+MOBILE_PKG="github.com/lightninglabs/darepo-client/sdk/walletdk/mobile"
+MOBILE_TAGS="mobile walletdkrpc swapruntime"
+
+# Minimum Android API level. 21 (Lollipop) matches lnd-mobile.
+ANDROID_API=21
+
+# Newer Android devices use 16KB memory pages; link with a matching max page
+# size so the .so loads on them. Mirrors lnd-mobile's ANDROID_EXTLDFLAGS.
+ANDROID_MAX_PAGE_SIZE=16384
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/build"
+
+# Resolve the Android SDK. The android CLI defaults to ~/Library/Android/sdk on
+# macOS; honor an explicit ANDROID_HOME / ANDROID_SDK_ROOT if set.
+ANDROID_HOME="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-${HOME}/Library/Android/sdk}}"
+export ANDROID_HOME
+export ANDROID_SDK_ROOT="${ANDROID_HOME}"
+
+# gomobile finds the NDK under ${ANDROID_HOME}/ndk/<version>; pick the newest
+# installed one unless ANDROID_NDK_HOME is already set.
+if [[ -z "${ANDROID_NDK_HOME:-}" && -d "${ANDROID_HOME}/ndk" ]]; then
+	# Use find rather than a glob: under `set -euo pipefail` an empty ndk
+	# directory would make `ls -d .../*` exit non-zero and abort the script.
+	ndk_dir="$(
+		find "${ANDROID_HOME}/ndk" -mindepth 1 -maxdepth 1 -type d \
+			2>/dev/null | sort -V | tail -1
+	)"
+	if [[ -n "${ndk_dir}" ]]; then
+		export ANDROID_NDK_HOME="${ndk_dir}"
+	fi
+fi
+
+build_android() {
+	echo "==> building Android .aar -> ${BUILD_DIR}/android/Walletdk.aar"
+	mkdir -p "${BUILD_DIR}/android"
+	gomobile bind \
+		-target=android \
+		-androidapi "${ANDROID_API}" \
+		-javapkg=engineering.lightning.walletdk \
+		-tags="${MOBILE_TAGS}" \
+		-ldflags="-extldflags '-Wl,-z,max-page-size=${ANDROID_MAX_PAGE_SIZE}'" \
+		-v \
+		-o "${BUILD_DIR}/android/Walletdk.aar" \
+		"${MOBILE_PKG}"
+}
+
+build_ios() {
+	echo "==> building iOS .xcframework -> ${BUILD_DIR}/ios/Walletdk.xcframework"
+	mkdir -p "${BUILD_DIR}/ios"
+	gomobile bind \
+		-target=ios,iossimulator \
+		-tags="${MOBILE_TAGS}" \
+		-v \
+		-o "${BUILD_DIR}/ios/Walletdk.xcframework" \
+		"${MOBILE_PKG}"
+}
+
+target="${1:-android}"
+case "${target}" in
+android) build_android ;;
+ios) build_ios ;;
+all)
+	build_android
+	build_ios
+	;;
+*)
+	echo "unknown target: ${target} (want android|ios|all)" >&2
+	exit 1
+	;;
+esac
+
+echo "==> done"

--- a/sdk/walletdk/mobile/mobile.go
+++ b/sdk/walletdk/mobile/mobile.go
@@ -1,0 +1,241 @@
+//go:build mobile && walletdkrpc && swapruntime
+
+package mobile
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/sdk/walletdk"
+)
+
+// startTimeout bounds how long Start will wait for the embedded daemon's gRPC
+// transport to report readiness before giving up. The daemon lifetime itself
+// is owned by walletdk's internal runCtx, so this deadline only cancels
+// dialing, never the running daemon.
+const startTimeout = 90 * time.Second
+
+// lifecycleStatus is the explicit state of the embedded daemon. A plain CAS on
+// a started/stopped bit cannot express the in-between "starting" and "stopping"
+// states, and that gap is exactly where a Stop racing an in-progress Start
+// would strand a live daemon under a guard that reads "stopped". The four-state
+// machine plus the stored startCancel closes that race.
+type lifecycleStatus int32
+
+const (
+	statusStopped lifecycleStatus = iota
+	statusStarting
+	statusStarted
+	statusStopping
+)
+
+// state holds the package-level singleton. gomobile exposes free functions, so
+// the client and its lifecycle live here rather than on a handle the host would
+// carry across the boundary. All fields are guarded by mu.
+var state = struct {
+	mu     sync.Mutex
+	status lifecycleStatus
+
+	// gen is bumped on every status transition that begins or abandons a
+	// boot, so a Start that finishes after a racing Stop (and a possible
+	// subsequent Start) can tell it no longer owns the starting state and
+	// must not publish its client or reset the guard.
+	gen uint64
+
+	// client is the live wallet handle, non-nil only in statusStarted.
+	client *walletdk.Client
+
+	// callCtx is cancelled by Stop so in-flight RPCs and subscriptions
+	// unwind promptly. It is the wrapper-owned context the mobile API uses
+	// in place of a per-call context.Context.
+	callCtx    context.Context
+	callCancel context.CancelFunc
+
+	// startCancel cancels an in-progress walletdk.Start so a racing Stop
+	// can abort a boot rather than orphan the daemon it would produce.
+	startCancel context.CancelFunc
+}{}
+
+// Start boots the embedded darepod wallet daemon from a JSON config and blocks
+// until the private gRPC transport is serving, or returns an error if the boot
+// fails. It is the gomobile-safe equivalent of walletdk.Start.
+//
+// Start may block for several seconds, so the host must call it off the main
+// thread (e.g. Kotlin withContext(Dispatchers.IO) or a Swift background Task);
+// gomobile maps the returned error to a thrown exception. It is singleton
+// guarded: a second Start before Stop returns an error rather than booting a
+// second daemon. A Stop that races an in-progress Start cancels the boot, and
+// Start then tears down any client it produced instead of publishing it. A
+// panic in the boot path is recovered into the returned error so it never
+// crosses the gomobile boundary as a process kill.
+func Start(cfgJSON string) (err error) {
+	state.mu.Lock()
+	if state.status != statusStopped {
+		state.mu.Unlock()
+
+		return errors.New("walletdk mobile already started")
+	}
+	state.status = statusStarting
+	state.gen++
+	gen := state.gen
+
+	startCtx, startCancel := context.WithTimeout(
+		context.Background(), startTimeout,
+	)
+	state.startCancel = startCancel
+	state.mu.Unlock()
+
+	// On any failure or panic, cancel the boot context and return to
+	// stopped, but only if this Start still owns the starting state: a
+	// racing Stop (and a later Start) may have moved on, and clobbering
+	// their state would defeat the guard.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("walletdk mobile panic: %v\n%s", r,
+				debug.Stack())
+		}
+		if err == nil {
+			return
+		}
+
+		startCancel()
+
+		state.mu.Lock()
+		if state.status == statusStarting && state.gen == gen {
+			state.status = statusStopped
+			state.startCancel = nil
+		}
+		state.mu.Unlock()
+	}()
+
+	cfg, err := parseConfig(cfgJSON)
+	if err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+
+	client, err := walletdk.Start(startCtx, cfg)
+	if err != nil {
+		return fmt.Errorf("start embedded wallet: %w", err)
+	}
+
+	callCtx, callCancel := context.WithCancel(context.Background())
+
+	state.mu.Lock()
+	// A Stop raced this boot: it cancelled startCtx and moved us out of the
+	// starting state. Tear the just-booted client down rather than publish
+	// it under a reset guard.
+	if state.status != statusStarting || state.gen != gen {
+		state.mu.Unlock()
+		_ = client.Stop()
+
+		return errors.New("walletdk mobile start cancelled by Stop")
+	}
+	state.client = client
+	state.callCtx = callCtx
+	state.callCancel = callCancel
+	state.startCancel = nil
+	state.status = statusStarted
+	state.mu.Unlock()
+
+	return nil
+}
+
+// Stop tears down the embedded daemon and releases the private transport. It is
+// idempotent: calling it when stopped is a no-op that returns nil. If a Start
+// is still in progress, Stop cancels the boot and returns; that Start then
+// stops any client it produced. Otherwise Stop fully tears down the live client
+// (cancelling the wrapper context unblocks any in-flight Subscription.Next)
+// before resetting to stopped, so a Start that immediately follows cannot race
+// a half-finished shutdown. After Stop the singleton resets so a host can Start
+// again, e.g. after the OS suspends and resumes the app.
+func Stop() error {
+	state.mu.Lock()
+	switch state.status {
+	case statusStopped, statusStopping:
+		// Already stopped, or another Stop owns the teardown.
+		state.mu.Unlock()
+
+		return nil
+
+	case statusStarting:
+		// Cancel the in-progress boot; that Start observes the status /
+		// gen change, stops any client it produced, and returns.
+		if state.startCancel != nil {
+			state.startCancel()
+			state.startCancel = nil
+		}
+		state.status = statusStopped
+		state.gen++
+		state.mu.Unlock()
+
+		return nil
+	}
+
+	// statusStarted: take ownership of the live client and tear it down.
+	state.status = statusStopping
+	state.gen++
+	client := state.client
+	cancel := state.callCancel
+	state.client = nil
+	state.callCtx = nil
+	state.callCancel = nil
+	state.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+
+	var err error
+	if client != nil {
+		err = client.Stop()
+	}
+
+	state.mu.Lock()
+	state.status = statusStopped
+	state.mu.Unlock()
+
+	return err
+}
+
+// activeClient returns the live client and the wrapper-owned call context, or
+// an error when the daemon is not running. Callers must not retain the context
+// past the call; it is cancelled by Stop.
+func activeClient() (*walletdk.Client, context.Context, error) {
+	state.mu.Lock()
+	client := state.client
+	ctx := state.callCtx
+	state.mu.Unlock()
+
+	if client == nil || ctx == nil {
+		return nil, nil, errors.New("walletdk mobile not started")
+	}
+
+	return client, ctx, nil
+}
+
+// lifecycleActive reports whether a daemon lifecycle is in progress, i.e. a
+// Start has begun (including the up-to-startTimeout boot window) and Stop has
+// not yet completed. It backs IsRunning so a host sees "running" across the
+// whole boot, not only once gRPC is serving.
+func lifecycleActive() bool {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	return state.status == statusStarting || state.status == statusStarted
+}
+
+// marshal is a small helper so every verb returns JSON bytes with a uniform
+// error wrap.
+func marshal(v any) ([]byte, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("encode response: %w", err)
+	}
+
+	return b, nil
+}

--- a/sdk/walletdk/mobile/mobile_test.go
+++ b/sdk/walletdk/mobile/mobile_test.go
@@ -1,0 +1,211 @@
+//go:build mobile && walletdkrpc && swapruntime
+
+package mobile
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/sdk/walletdk"
+)
+
+// TestParseConfigEmptyUsesDefaults verifies that an empty config string yields
+// the walletdk defaults rather than a zero config.
+func TestParseConfigEmptyUsesDefaults(t *testing.T) {
+	got, err := parseConfig("")
+	if err != nil {
+		t.Fatalf("parseConfig(\"\"): %v", err)
+	}
+
+	want := walletdk.DefaultConfig()
+	if got.Network != want.Network {
+		t.Fatalf("network = %q, want default %q", got.Network,
+			want.Network)
+	}
+	if got.WalletType != want.WalletType {
+		t.Fatalf("wallet type = %q, want default %q", got.WalletType,
+			want.WalletType)
+	}
+}
+
+// TestParseConfigOverlaysSetFields verifies that only the fields the host set
+// are overlaid onto the defaults, and that the seconds/scalar mappings land on
+// the right walletdk fields.
+func TestParseConfigOverlaysSetFields(t *testing.T) {
+	const cfgJSON = `{
+		"data_dir": "/tmp/walletdk",
+		"network": "regtest",
+		"server_address": "127.0.0.1:9000",
+		"server_insecure": true,
+		"wallet_poll_interval_seconds": 5,
+		"wallet_recovery_window": 250,
+		"max_operator_fee_sat": 1000,
+		"buffer_size": 4096
+	}`
+
+	got, err := parseConfig(cfgJSON)
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+
+	if got.DataDir != "/tmp/walletdk" {
+		t.Fatalf("data dir = %q", got.DataDir)
+	}
+	if got.Network != "regtest" {
+		t.Fatalf("network = %q", got.Network)
+	}
+	if got.ServerAddress != "127.0.0.1:9000" {
+		t.Fatalf("server address = %q", got.ServerAddress)
+	}
+	if !got.ServerInsecure {
+		t.Fatal("server insecure not applied")
+	}
+	if got.WalletPollInterval.Seconds() != 5 {
+		t.Fatalf("poll interval = %v, want 5s", got.WalletPollInterval)
+	}
+	if got.WalletRecoveryWindow != 250 {
+		t.Fatalf("recovery window = %d", got.WalletRecoveryWindow)
+	}
+	if got.MaxOperatorFeeSat != 1000 {
+		t.Fatalf("max operator fee = %d", got.MaxOperatorFeeSat)
+	}
+	if got.BufferSize != 4096 {
+		t.Fatalf("buffer size = %d", got.BufferSize)
+	}
+}
+
+// TestParseConfigRejectsBadJSON verifies malformed JSON is reported as an
+// error rather than silently ignored.
+func TestParseConfigRejectsBadJSON(t *testing.T) {
+	if _, err := parseConfig("{not json"); err == nil {
+		t.Fatal("expected error for malformed config JSON")
+	}
+}
+
+// TestParseConfigRejectsNegativeScalars verifies the signed gomobile config
+// scalars are rejected when negative, so malformed JSON returns a startup error
+// instead of, e.g., a negative poll interval panicking the tip poller.
+func TestParseConfigRejectsNegativeScalars(t *testing.T) {
+	cases := map[string]string{
+		"poll interval":    `{"wallet_poll_interval_seconds": -1}`,
+		"recovery window":  `{"wallet_recovery_window": -5}`,
+		"max operator fee": `{"max_operator_fee_sat": -1000}`,
+		"buffer size":      `{"buffer_size": -1}`,
+	}
+	for name, cfgJSON := range cases {
+		if _, err := parseConfig(cfgJSON); err == nil {
+			t.Fatalf("%s: expected error for negative value", name)
+		}
+	}
+}
+
+// TestParseConfigRejectsOverflowRecoveryWindow verifies a recovery window above
+// the uint32 max is rejected rather than silently wrapping in the conversion.
+func TestParseConfigRejectsOverflowRecoveryWindow(t *testing.T) {
+	// 4294967296 == math.MaxUint32 + 1.
+	if _, err := parseConfig(
+		`{"wallet_recovery_window": 4294967296}`,
+	); err == nil {
+
+		t.Fatal("expected error for recovery window above uint32 max")
+	}
+}
+
+// TestVerbsFailWhenNotStarted verifies that every accessor reports a clear
+// not-started error before Start, instead of panicking on a nil client.
+func TestVerbsFailWhenNotStarted(t *testing.T) {
+	if _, _, err := activeClient(); err == nil {
+		t.Fatal("activeClient should fail before Start")
+	}
+	if _, err := GetInfo(); err == nil {
+		t.Fatal("GetInfo should fail before Start")
+	}
+	if _, err := Balance(); err == nil {
+		t.Fatal("Balance should fail before Start")
+	}
+	if _, err := ConfirmedBalanceSat(); err == nil {
+		t.Fatal("ConfirmedBalanceSat should fail before Start")
+	}
+	if IsRunning() {
+		t.Fatal("IsRunning should be false before Start")
+	}
+}
+
+// TestStopIdempotentWhenNotStarted verifies Stop is a no-op when nothing is
+// running.
+func TestStopIdempotentWhenNotStarted(t *testing.T) {
+	if err := Stop(); err != nil {
+		t.Fatalf("Stop on stopped client = %v, want nil", err)
+	}
+}
+
+// TestStartRejectsBadConfigAndResets verifies that a Start whose config fails
+// to parse returns the error synchronously and releases the singleton so a
+// later Start can run.
+func TestStartRejectsBadConfigAndResets(t *testing.T) {
+	if err := Start("{bad json"); err == nil {
+		t.Fatal("expected error for bad config")
+	}
+
+	// The singleton must have reset; activeClient still reports not
+	// started and a subsequent Stop is clean.
+	if IsRunning() {
+		t.Fatal("IsRunning true after failed Start")
+	}
+	if err := Stop(); err != nil {
+		t.Fatalf("Stop after failed Start = %v", err)
+	}
+}
+
+// TestSubscribeFailsWhenNotStarted verifies Subscribe returns the not-started
+// error rather than panicking on a nil client.
+func TestSubscribeFailsWhenNotStarted(t *testing.T) {
+	if _, err := Subscribe(nil); err == nil {
+		t.Fatal("Subscribe should fail before Start")
+	}
+}
+
+// TestEntryRoundTripsAsJSON guards the bytes-out contract: a walletdk.Entry
+// must marshal to JSON the host can decode, including the optional nested
+// Progress / Request unions.
+func TestEntryRoundTripsAsJSON(t *testing.T) {
+	entry := walletdk.Entry{
+		ID:        "abc",
+		Kind:      walletdk.EntryKindReceive,
+		Status:    walletdk.EntryStatusPending,
+		AmountSat: 1234,
+		Request: &walletdk.EntryRequest{
+			Type:             walletdk.EntryRequestTypeLightning,
+			LightningInvoice: "lnbc1...",
+		},
+	}
+
+	b, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+
+	// The DTOs carry no json tags, so the wire keys are the Go field names
+	// (PascalCase). That is the documented public contract a foreign
+	// decoder relies on, so pin the literal keys here rather than only
+	// proving a Go-to-Go round trip.
+	for _, key := range []string{`"ID"`, `"Kind"`, `"AmountSat"`} {
+		if !strings.Contains(string(b), key) {
+			t.Fatalf("entry JSON missing wire key %s: %s", key, b)
+		}
+	}
+
+	var back walletdk.Entry
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal entry: %v", err)
+	}
+	if back.ID != entry.ID || back.AmountSat != entry.AmountSat {
+		t.Fatalf("round-trip mismatch: %+v", back)
+	}
+	if back.Request == nil ||
+		back.Request.Type != walletdk.EntryRequestTypeLightning {
+
+		t.Fatalf("request union lost in round-trip: %+v", back.Request)
+	}
+}

--- a/sdk/walletdk/mobile/wallet.go
+++ b/sdk/walletdk/mobile/wallet.go
@@ -1,0 +1,393 @@
+//go:build mobile && walletdkrpc && swapruntime
+
+package mobile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"runtime/debug"
+
+	"github.com/lightninglabs/darepo-client/sdk/walletdk"
+)
+
+// GetInfo returns the daemon readiness snapshot as JSON (walletdk.Info).
+func GetInfo() ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := client.GetInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(info)
+}
+
+// CreateWallet creates or imports the embedded wallet. reqJSON decodes to
+// walletdk.CreateWalletRequest; the response is walletdk.CreateWalletResult.
+func CreateWallet(reqJSON []byte) ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req walletdk.CreateWalletRequest
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	res, err := client.CreateWallet(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(res)
+}
+
+// UnlockWallet unlocks an existing wallet. reqJSON decodes to
+// walletdk.UnlockWalletRequest; the response is walletdk.UnlockWalletResult.
+func UnlockWallet(reqJSON []byte) ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req walletdk.UnlockWalletRequest
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	res, err := client.UnlockWallet(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(res)
+}
+
+// Balance returns the wallet balance summary as JSON (walletdk.Balance).
+func Balance() ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	bal, err := client.Balance(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(bal)
+}
+
+// Deposit allocates a fresh boarding address. reqJSON decodes to
+// walletdk.DepositRequest; the response is walletdk.DepositResult.
+func Deposit(reqJSON []byte) ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req walletdk.DepositRequest
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	res, err := client.Deposit(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(res)
+}
+
+// Receive opens a Lightning invoice receive. reqJSON decodes to
+// walletdk.ReceiveRequest; the response is walletdk.ReceiveResult.
+func Receive(reqJSON []byte) ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req walletdk.ReceiveRequest
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	res, err := client.Receive(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(res)
+}
+
+// PrepareSend validates and quotes an outbound payment, returning a single-use
+// SendIntentID. reqJSON decodes to walletdk.PrepareSendRequest; the response is
+// walletdk.PrepareSendResult.
+func PrepareSend(reqJSON []byte) ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req walletdk.PrepareSendRequest
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	res, err := client.PrepareSend(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(res)
+}
+
+// SendPrepared dispatches a previously prepared send. reqJSON decodes to
+// walletdk.SendPreparedRequest; the response is walletdk.SendResult.
+func SendPrepared(reqJSON []byte) ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req walletdk.SendPreparedRequest
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	res, err := client.SendPrepared(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(res)
+}
+
+// List returns the unified wallet view (activity / vtxos / onchain). reqJSON
+// decodes to walletdk.ListRequest; the response is the tagged-union
+// walletdk.ListResult.
+func List(reqJSON []byte) ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req walletdk.ListRequest
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	res, err := client.List(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(res)
+}
+
+// Exit triggers cooperative leave or unilateral unroll for a VTXO. reqJSON
+// decodes to walletdk.ExitRequest; the response is walletdk.ExitResult.
+func Exit(reqJSON []byte) ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req walletdk.ExitRequest
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	res, err := client.Exit(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(res)
+}
+
+// ExitStatus reports the phase of an exit job. reqJSON decodes to
+// walletdk.ExitStatusRequest; the response is walletdk.ExitStatusResult.
+func ExitStatus(reqJSON []byte) ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req walletdk.ExitStatusRequest
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	res, err := client.ExitStatus(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(res)
+}
+
+// GetExitPlan previews unilateral-exit readiness for a set of VTXOs. reqJSON
+// decodes to walletdk.GetExitPlanRequest; the response is
+// walletdk.GetExitPlanResult.
+func GetExitPlan(reqJSON []byte) ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req walletdk.GetExitPlanRequest
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	res, err := client.GetExitPlan(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(res)
+}
+
+// SweepWallet previews or broadcasts a backing-wallet sweep. reqJSON decodes to
+// walletdk.SweepWalletRequest; the response is walletdk.SweepWalletResult.
+func SweepWallet(reqJSON []byte) ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req walletdk.SweepWalletRequest
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	res, err := client.SweepWallet(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(res)
+}
+
+// Status returns wallet readiness, balance, and pending counts as JSON
+// (walletdk.Status).
+func Status() ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	status, err := client.Status(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(status)
+}
+
+// Subscription is a gomobile-safe, pull-based handle over a wallet activity
+// stream. The host calls Next in a loop on a background thread (mapping cleanly
+// to a Kotlin Flow or Swift AsyncStream) and Close to stop early; no
+// host-implemented callback interface is required.
+type Subscription struct {
+	updates <-chan walletdk.Entry
+	errs    <-chan error
+	ctx     context.Context
+	cancel  context.CancelFunc
+}
+
+// Subscribe opens a wallet activity stream and returns a pull handle. reqJSON
+// decodes to walletdk.SubscribeRequest (empty is allowed). The subscription is
+// cancelled by Close, or by Stop when the daemon shuts down.
+func Subscribe(reqJSON []byte) (*Subscription, error) {
+	client, parentCtx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req walletdk.SubscribeRequest
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	// Derive a cancellable context from the wrapper call context so both
+	// Close and Stop terminate a blocked Next.
+	ctx, cancel := context.WithCancel(parentCtx)
+
+	updates, errs, err := client.Subscribe(ctx, req)
+	if err != nil {
+		cancel()
+
+		return nil, err
+	}
+
+	return &Subscription{
+		updates: updates,
+		errs:    errs,
+		ctx:     ctx,
+		cancel:  cancel,
+	}, nil
+}
+
+// Next blocks until the next activity entry is available and returns it as
+// JSON. It returns io.EOF when the stream ends cleanly, or the underlying
+// error otherwise; either is terminal. A panic is recovered into the returned
+// error so it never crosses the gomobile boundary.
+func (s *Subscription) Next() (b []byte, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("walletdk mobile panic: %v\n%s", r,
+				debug.Stack())
+		}
+	}()
+
+	entry, ok := <-s.updates
+	if !ok {
+		// The updates channel has closed. A terminal error (if any) is
+		// buffered on errs; a closed errs reads as nil, which we report
+		// as a clean EOF so the host can tell a normal end from a
+		// failure.
+		streamErr := <-s.errs
+
+		// A self-initiated Close or Stop cancels s.ctx, which surfaces
+		// upstream as a wrapped context.Canceled on errs. Report that
+		// as a clean EOF too, so a host that tears down its own stream
+		// (the app-suspend path) ends its loop without a spurious
+		// error, as the doc promises.
+		if streamErr != nil && s.ctx.Err() == nil {
+			return nil, streamErr
+		}
+
+		return nil, io.EOF
+	}
+
+	return marshal(entry)
+}
+
+// Close cancels the subscription and unblocks any in-flight Next. It is
+// idempotent and safe to call from any thread.
+func (s *Subscription) Close() error {
+	s.cancel()
+
+	return nil
+}
+
+// decode unmarshals a JSON request body with a uniform error wrap. A nil or
+// empty body decodes to the zero request.
+func decode(b []byte, v any) error {
+	if len(b) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(b, v); err != nil {
+		return fmt.Errorf("decode request: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This series exposes `sdk/walletdk` to iOS and Android through `gomobile
bind`, so a React Native, Swift, or Kotlin host can drive an embedded
`darepod` wallet in-process, with no separate daemon binary and no open
socket.

We already do the hard part in `sdk/walletdk`: `Start` boots the daemon and
dials it over a private bufconn gRPC transport. So rather than a
falafel-style protoc plugin, we add a thin hand-written facade,
`sdk/walletdk/mobile`, that translates at the boundary and respects
gomobile's type restrictions.

The facade is callback-free. gomobile carries only a narrow set of types, so
the rich `walletdk.Client` surface (context, channels, maps, unsigned ints,
time.Time, slices of structs) cannot cross directly. Instead:

- RPC verbs take and return JSON bytes; a few hot paths return scalars.
- `Start` is synchronous and singleton-guarded. It returns once gRPC is
  serving, which `walletdk.Start` already guarantees, unlike `lnd.Main`,
  which blocks forever and forces lnd-mobile to use a callback.
- The one streaming verb hands back a pull-based `Subscription` instead of a
  channel or a host callback.
- Every entry point recovers panics into errors, since a panic does not
  cross the gomobile boundary and would otherwise kill the host process.

The package builds only under `mobile && walletdkrpc && swapruntime`, so
default builds are untouched. `make mobile-android` / `mobile-ios` drive
`gen_bindings.sh`.

### What is here

- `sdk/walletdk/mobile`: the facade plus its boundary tests.
- `make mobile-*` targets and `gen_bindings.sh`.
- `docs/walletdk_mobile.md`.
- A Mobile Bindings CI workflow: a fast host-tagged compile on PRs and the
  merge queue, with the heavy `.aar` / `.xcframework` builds gated to
  `mobile-v*` tags so routine merges do not trigger them.

### What is not here

The sample apps and the idiomatic Kotlin (coroutines / `Flow`) and Swift
(`async` / `AsyncThrowingStream`) wrappers live in
[lightninglabs/damobile](https://github.com/lightninglabs/damobile). Both
were validated end to end against signet: the embedded wallet boots
in-process, connects to the operator mailbox, syncs from Esplora, and runs
on the Android emulator and the iOS simulator.

Closes #713.
