### PR TITLE
swaps+darepocli: sane in-swap fee default, preimage, blocking send

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_send.go
+++ b/cmd/darepocli/darepoclicommands/cmd_send.go
@@ -2,11 +2,32 @@ package darepoclicommands
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 	"github.com/spf13/cobra"
+)
+
+const (
+	// defaultSendWaitTimeout bounds how long `send` blocks on settlement
+	// before returning the last observed status. A pay swap that has to
+	// route over real Lightning can take a while, so the ceiling is
+	// generous.
+	defaultSendWaitTimeout = 5 * time.Minute
+
+	// defaultSendWaitPollInterval is how often `send` re-inspects the
+	// dispatched entry while it is still pending. It is kept tight so a
+	// fast same-Ark p2p settlement is reported with minimal latency.
+	defaultSendWaitPollInterval = 200 * time.Millisecond
+
+	entryStatusUnspecified = walletdkrpc.
+				EntryStatus_ENTRY_STATUS_UNSPECIFIED
+	entryStatusPending  = walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING
+	entryStatusComplete = walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE
+	entryStatusFailed   = walletdkrpc.EntryStatus_ENTRY_STATUS_FAILED
 )
 
 // newSendCmd builds the top-level `send` verb. It dispatches an
@@ -50,7 +71,10 @@ func newSendCmd() *cobra.Command {
 		"amount in satoshis (required for onchain unless "+
 			"--sweep-all; ignored for amount-bearing invoices)")
 	cmd.Flags().Uint64("max_fee", 0,
-		"max fee in satoshis; 0 lets the daemon use defaults")
+		"max swap fee in satoshis for invoice (Lightning) sends; 0 "+
+			"lets the daemon default the cap to ~1% of the amount "+
+			"(with a small floor), so a normal payment routes "+
+			"without setting this")
 	cmd.Flags().String("note", "",
 		"caller-supplied label to attach to the entry")
 	cmd.Flags().Bool("sweep-all", false,
@@ -62,6 +86,17 @@ func newSendCmd() *cobra.Command {
 		"skip interactive confirmation after prepare")
 	cmd.Flags().Bool("yes", false,
 		"alias for --force")
+	cmd.Flags().Bool("no-wait", false,
+		"return as soon as the send is dispatched instead of blocking "+
+			"until it reaches a terminal state; by default send "+
+			"waits and Lightning sends print the payment preimage")
+	cmd.Flags().Duration("wait-timeout", defaultSendWaitTimeout,
+		"while waiting: give up after this long and return the last "+
+			"observed status (0 waits indefinitely; ignored with "+
+			"--no-wait)")
+	cmd.Flags().Duration("wait-poll-interval", defaultSendWaitPollInterval,
+		"while waiting: how often to poll the daemon for status "+
+			"updates (ignored with --no-wait)")
 
 	return cmd
 }
@@ -172,9 +207,143 @@ func walletSend(cmd *cobra.Command, args []string) error {
 					err)
 			}
 
-			return printWalletProto(resp)
+			if err := printWalletProto(resp); err != nil {
+				return err
+			}
+
+			if noWait, _ := cmd.Flags().GetBool("no-wait"); noWait {
+				return nil
+			}
+
+			return waitForSendTerminal(cmd, resp.GetEntry())
 		},
 	)
+}
+
+// waitForSendTerminal blocks until the dispatched send entry reaches a terminal
+// status (complete or failed), printing each lifecycle phase transition as it
+// is observed and rendering the final inspection trace at the end. For a
+// Lightning send the trace carries the payment preimage, the proof of payment.
+//
+// The poll runs over the always-available WalletInspectionService so the wait
+// surface does not depend on the optional swapruntime build. A failed terminal
+// state returns an error so an agent or shell sees a non-zero exit; a timeout
+// returns the last observed status without claiming success or failure.
+func waitForSendTerminal(cmd *cobra.Command,
+	entry *walletdkrpc.WalletEntry) error {
+
+	id := entry.GetId()
+	if id == "" {
+		return PrintError(
+			"WAIT_UNAVAILABLE", "send did not return an entry "+
+				"id to wait on; poll `da activity inspect "+
+				"<id>` manually",
+		)
+	}
+
+	timeout, _ := cmd.Flags().GetDuration("wait-timeout")
+	pollInterval, _ := cmd.Flags().GetDuration("wait-poll-interval")
+	if pollInterval <= 0 {
+		pollInterval = defaultSendWaitPollInterval
+	}
+
+	ctx := cmd.Context()
+	if timeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	out := cmd.ErrOrStderr()
+	lastPhase := ""
+	failedMsg := "send reached a failed state"
+	timeoutErr := func() error {
+		return PrintError(
+			"WAIT_TIMEOUT",
+			fmt.Sprintf(
+				"timed out after %s waiting for %s; last "+
+					"phase: %s", timeout, id,
+				emptyDash(lastPhase),
+			),
+		)
+	}
+
+	return withWalletInspectionClient(
+		cmd, func(c walletdkrpc.WalletInspectionServiceClient) error {
+			ticker := time.NewTicker(pollInterval)
+			defer ticker.Stop()
+
+			for {
+				req := &walletdkrpc.InspectActivityRequest{
+					Id: id,
+				}
+				resp, err := c.InspectActivity(ctx, req)
+				if err != nil {
+					// A deadline hit while polling is a
+					// timeout, not a hard failure: report
+					// the last phase the user saw.
+					if ctx.Err() != nil {
+						return timeoutErr()
+					}
+
+					return fmt.Errorf("inspect "+
+						"activity: %w", err)
+				}
+
+				inspected := resp.GetEntry()
+				phase := formatEntryPhase(
+					inspected.GetProgress(),
+				)
+				if phase != lastPhase {
+					fmt.Fprintf(out, "phase: %s\n", phase)
+					lastPhase = phase
+				}
+
+				switch inspected.GetStatus() {
+				case entryStatusComplete:
+					return printWalletInspectionExpanded(
+						resp,
+					)
+
+				case entryStatusFailed:
+					rerr := printWalletInspectionExpanded(
+						resp,
+					)
+					if rerr != nil {
+						return rerr
+					}
+
+					reason := inspected.GetFailureReason()
+
+					return PrintError(
+						"SEND_FAILED", emptyNonEmpty(
+							reason, failedMsg,
+						),
+					)
+
+				case entryStatusUnspecified, entryStatusPending:
+				}
+
+				select {
+				case <-ctx.Done():
+					return timeoutErr()
+
+				case <-ticker.C:
+				}
+			}
+		},
+	)
+}
+
+// emptyNonEmpty returns value when it is non-empty after trimming, otherwise
+// the fallback. It keeps the failure-reason rendering terse without importing a
+// second nonEmpty helper into the CLI package.
+func emptyNonEmpty(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+
+	return value
 }
 
 func confirmSendIfNeeded(cmd *cobra.Command,

--- a/cmd/darepocli/darepoclicommands/cmd_send_test.go
+++ b/cmd/darepocli/darepoclicommands/cmd_send_test.go
@@ -119,3 +119,29 @@ func TestPromptSendConfirmationDefaultsNo(t *testing.T) {
 	err := promptSendConfirmation(cmd, &walletdkrpc.PrepareSendResponse{})
 	require.ErrorContains(t, err, "aborted by user")
 }
+
+// TestSendWaitFlagDefaults verifies the wait family is wired with the expected
+// defaults: `send` blocks on settlement by default and --no-wait opts out, so a
+// caller gets the preimage without further tuning.
+func TestSendWaitFlagDefaults(t *testing.T) {
+	cmd := newSendCmd()
+
+	noWait, err := cmd.Flags().GetBool("no-wait")
+	require.NoError(t, err)
+	require.False(t, noWait)
+
+	timeout, err := cmd.Flags().GetDuration("wait-timeout")
+	require.NoError(t, err)
+	require.Equal(t, defaultSendWaitTimeout, timeout)
+
+	interval, err := cmd.Flags().GetDuration("wait-poll-interval")
+	require.NoError(t, err)
+	require.Equal(t, defaultSendWaitPollInterval, interval)
+}
+
+// TestEmptyNonEmpty verifies the terse failure-reason fallback used by the
+// wait renderer.
+func TestEmptyNonEmpty(t *testing.T) {
+	require.Equal(t, "fallback", emptyNonEmpty("   ", "fallback"))
+	require.Equal(t, "reason", emptyNonEmpty("reason", "fallback"))
+}

--- a/cmd/darepocli/darepoclicommands/cmd_swap_rpc.go
+++ b/cmd/darepocli/darepoclicommands/cmd_swap_rpc.go
@@ -231,7 +231,8 @@ func newSwapPayCmd() *cobra.Command {
 	cmd.Flags().String("invoice", "",
 		"BOLT-11 Lightning invoice to pay (required; or via --json)")
 	cmd.Flags().Uint64("maxfee", 0,
-		"maximum fee in satoshis (0 = no limit)")
+		"maximum swap fee in satoshis (0 lets the daemon default the "+
+			"cap to ~1% of the amount, with a small floor)")
 
 	return cmd
 }

--- a/cmd/darepocli/darepoclicommands/mcp_swap.go
+++ b/cmd/darepocli/darepoclicommands/mcp_swap.go
@@ -125,8 +125,8 @@ func registerMCPSwapMutateTools(s *mcp.Server,
 	})
 
 	type payArgs struct {
-		Invoice   string `json:"invoice" jsonschema:"BOLT-11 invoice to pay (required)"`                          //nolint:ll
-		MaxFeeSat uint64 `json:"max_fee_sat,omitempty" jsonschema:"maximum fee in satoshis; zero means no limit"` //nolint:ll
+		Invoice   string `json:"invoice" jsonschema:"BOLT-11 invoice to pay (required)"`                                                                     //nolint:ll
+		MaxFeeSat uint64 `json:"max_fee_sat,omitempty" jsonschema:"maximum swap fee in satoshis; zero lets the daemon default the cap to ~1% of the amount"` //nolint:ll
 	}
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "swap.pay",

--- a/cmd/darepocli/darepoclicommands/wallet_inspection_table.go
+++ b/cmd/darepocli/darepoclicommands/wallet_inspection_table.go
@@ -147,6 +147,7 @@ func renderSwapSection(out io.Writer, swap *walletdkrpc.ActivitySwapTrace) {
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Swap")
 	printBullet(out, 0, "payment_hash", emptyDash(swap.GetPaymentHash()))
+	printOptionalBullet(out, "preimage", swap.GetPreimage())
 	printBullet(out, 0, "direction", emptyDash(swap.GetDirection()))
 	printBullet(out, 0, "state", emptyDash(swap.GetState()))
 	printBullet(out, 0, "pending", fmt.Sprintf("%t", swap.GetPending()))

--- a/cmd/darepocli/darepoclicommands/wallet_inspection_table_test.go
+++ b/cmd/darepocli/darepoclicommands/wallet_inspection_table_test.go
@@ -29,6 +29,7 @@ func TestRenderWalletInspectionExpanded(t *testing.T) {
 			AmountSat:        1234,
 			SettlementType:   "SWAP_SETTLEMENT_TYPE_IN_ARK",
 			SenderPubkey:     "sender-pubkey",
+			Preimage:         "abcd1234",
 			VhtlcOutpoint:    "vhtlc-txid:0",
 			VhtlcAmountSat:   1234,
 			FundingSessionId: "funding-session",
@@ -75,6 +76,7 @@ func TestRenderWalletInspectionExpanded(t *testing.T) {
 		t, got, "- settlement_type: SWAP_SETTLEMENT_TYPE_IN_ARK",
 	)
 	require.Contains(t, got, "- sender_pubkey: sender-pubkey")
+	require.Contains(t, got, "- preimage: abcd1234")
 	require.Contains(t, got, "VTXOs\n")
 	require.Contains(t, got, "spent_input")
 	require.Contains(t, got, "Ledger\n")

--- a/rpc/swapclientrpc/swap_client.pb.go
+++ b/rpc/swapclientrpc/swap_client.pb.go
@@ -1033,7 +1033,11 @@ type SwapSummary struct {
 	// settlement_type identifies the rail selected for the swap when known.
 	SettlementType SwapSettlementType `protobuf:"varint,19,opt,name=settlement_type,json=settlementType,proto3,enum=swapclientrpc.SwapSettlementType" json:"settlement_type,omitempty"`
 	// sender_pubkey is the compressed SEC-encoded vHTLC sender key when known.
-	SenderPubkey  string `protobuf:"bytes,20,opt,name=sender_pubkey,json=senderPubkey,proto3" json:"sender_pubkey,omitempty"`
+	SenderPubkey string `protobuf:"bytes,20,opt,name=sender_pubkey,json=senderPubkey,proto3" json:"sender_pubkey,omitempty"`
+	// preimage is the hex-encoded Lightning payment preimage once the swap
+	// revealed it. For a completed pay swap this is the proof of payment for
+	// the paid invoice; it is empty until the preimage is durably known.
+	Preimage      string `protobuf:"bytes,21,opt,name=preimage,proto3" json:"preimage,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1208,6 +1212,13 @@ func (x *SwapSummary) GetSenderPubkey() string {
 	return ""
 }
 
+func (x *SwapSummary) GetPreimage() string {
+	if x != nil {
+		return x.Preimage
+	}
+	return ""
+}
+
 var File_swap_client_proto protoreflect.FileDescriptor
 
 const file_swap_client_proto_rawDesc = "" +
@@ -1258,7 +1269,7 @@ const file_swap_client_proto_rawDesc = "" +
 	"\x10include_existing\x18\x01 \x01(\bR\x0fincludeExisting\x12!\n" +
 	"\fpending_only\x18\x02 \x01(\bR\vpendingOnly\"H\n" +
 	"\x16SubscribeSwapsResponse\x12.\n" +
-	"\x04swap\x18\x01 \x01(\v2\x1a.swapclientrpc.SwapSummaryR\x04swap\"\xb5\x06\n" +
+	"\x04swap\x18\x01 \x01(\v2\x1a.swapclientrpc.SwapSummaryR\x04swap\"\xd1\x06\n" +
 	"\vSwapSummary\x12:\n" +
 	"\tdirection\x18\x01 \x01(\x0e2\x1c.swapclientrpc.SwapDirectionR\tdirection\x12!\n" +
 	"\fpayment_hash\x18\x02 \x01(\tR\vpaymentHash\x12.\n" +
@@ -1281,7 +1292,8 @@ const file_swap_client_proto_rawDesc = "" +
 	"\x0frefund_locktime\x18\x11 \x01(\rR\x0erefundLocktime\x12\x18\n" +
 	"\ainvoice\x18\x12 \x01(\tR\ainvoice\x12J\n" +
 	"\x0fsettlement_type\x18\x13 \x01(\x0e2!.swapclientrpc.SwapSettlementTypeR\x0esettlementType\x12#\n" +
-	"\rsender_pubkey\x18\x14 \x01(\tR\fsenderPubkey*c\n" +
+	"\rsender_pubkey\x18\x14 \x01(\tR\fsenderPubkey\x12\x1a\n" +
+	"\bpreimage\x18\x15 \x01(\tR\bpreimage*c\n" +
 	"\rSwapDirection\x12\x1e\n" +
 	"\x1aSWAP_DIRECTION_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12SWAP_DIRECTION_PAY\x10\x01\x12\x1a\n" +

--- a/rpc/swapclientrpc/swap_client.proto
+++ b/rpc/swapclientrpc/swap_client.proto
@@ -259,4 +259,9 @@ message SwapSummary {
 
     // sender_pubkey is the compressed SEC-encoded vHTLC sender key when known.
     string sender_pubkey = 20;
+
+    // preimage is the hex-encoded Lightning payment preimage once the swap
+    // revealed it. For a completed pay swap this is the proof of payment for
+    // the paid invoice; it is empty until the preimage is durably known.
+    string preimage = 21;
 }

--- a/rpc/walletdkrpc/wallet.pb.go
+++ b/rpc/walletdkrpc/wallet.pb.go
@@ -2211,7 +2211,11 @@ type ActivitySwapTrace struct {
 	// when known.
 	SettlementType string `protobuf:"bytes,18,opt,name=settlement_type,json=settlementType,proto3" json:"settlement_type,omitempty"`
 	// sender_pubkey is the compressed SEC-encoded vHTLC sender key when known.
-	SenderPubkey  string `protobuf:"bytes,19,opt,name=sender_pubkey,json=senderPubkey,proto3" json:"sender_pubkey,omitempty"`
+	SenderPubkey string `protobuf:"bytes,19,opt,name=sender_pubkey,json=senderPubkey,proto3" json:"sender_pubkey,omitempty"`
+	// preimage is the hex-encoded Lightning payment preimage once the swap
+	// revealed it. For a completed pay swap this is the proof of payment for
+	// the paid invoice; it is empty until the preimage is durably known.
+	Preimage      string `protobuf:"bytes,20,opt,name=preimage,proto3" json:"preimage,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2375,6 +2379,13 @@ func (x *ActivitySwapTrace) GetSettlementType() string {
 func (x *ActivitySwapTrace) GetSenderPubkey() string {
 	if x != nil {
 		return x.SenderPubkey
+	}
+	return ""
+}
+
+func (x *ActivitySwapTrace) GetPreimage() string {
+	if x != nil {
+		return x.Preimage
 	}
 	return ""
 }
@@ -4506,7 +4517,7 @@ const file_wallet_proto_rawDesc = "" +
 	"\x05vtxos\x18\x03 \x03(\v2\x1e.walletdkrpc.ActivityVTXOTraceR\x05vtxos\x12A\n" +
 	"\vledger_rows\x18\x04 \x03(\v2 .walletdkrpc.ActivityLedgerTraceR\n" +
 	"ledgerRows\x12\x14\n" +
-	"\x05notes\x18\x05 \x03(\tR\x05notes\"\xc0\x05\n" +
+	"\x05notes\x18\x05 \x03(\tR\x05notes\"\xdc\x05\n" +
 	"\x11ActivitySwapTrace\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\tR\vpaymentHash\x12\x1c\n" +
 	"\tdirection\x18\x02 \x01(\tR\tdirection\x12\x14\n" +
@@ -4528,7 +4539,8 @@ const file_wallet_proto_rawDesc = "" +
 	"\rdeadline_unix\x18\x10 \x01(\x03R\fdeadlineUnix\x12'\n" +
 	"\x0frefund_locktime\x18\x11 \x01(\rR\x0erefundLocktime\x12'\n" +
 	"\x0fsettlement_type\x18\x12 \x01(\tR\x0esettlementType\x12#\n" +
-	"\rsender_pubkey\x18\x13 \x01(\tR\fsenderPubkey\"\xc4\x01\n" +
+	"\rsender_pubkey\x18\x13 \x01(\tR\fsenderPubkey\x12\x1a\n" +
+	"\bpreimage\x18\x14 \x01(\tR\bpreimage\"\xc4\x01\n" +
 	"\x11ActivityVTXOTrace\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +

--- a/rpc/walletdkrpc/wallet.proto
+++ b/rpc/walletdkrpc/wallet.proto
@@ -626,6 +626,11 @@ message ActivitySwapTrace {
 
     // sender_pubkey is the compressed SEC-encoded vHTLC sender key when known.
     string sender_pubkey = 19;
+
+    // preimage is the hex-encoded Lightning payment preimage once the swap
+    // revealed it. For a completed pay swap this is the proof of payment for
+    // the paid invoice; it is empty until the preimage is durably known.
+    string preimage = 20;
 }
 
 // ActivityVTXOTrace describes one VTXO movement correlated to a wallet activity

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -55,6 +55,11 @@ type SwapSummary struct {
 	// PaymentHash is the Lightning payment hash for the swap.
 	PaymentHash lntypes.Hash
 
+	// Preimage is the Lightning payment preimage once the swap revealed it.
+	// For a completed pay swap this is the proof of payment for the paid
+	// invoice; it is nil until the preimage is durably known.
+	Preimage *lntypes.Preimage
+
 	// Invoice is the BOLT-11 invoice associated with the swap.
 	Invoice string
 

--- a/sdk/swaps/pay_summary_preimage_test.go
+++ b/sdk/swaps/pay_summary_preimage_test.go
@@ -1,0 +1,55 @@
+package swaps
+
+import (
+	"testing"
+
+	swapsqlc "github.com/lightninglabs/darepo-client/sdk/swaps/sqlc"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPaySummaryFromRowSurfacesPreimage verifies a completed pay row exposes
+// its persisted preimage on the summary, the proof of payment for the paid
+// invoice.
+func TestPaySummaryFromRowSurfacesPreimage(t *testing.T) {
+	t.Parallel()
+
+	var preimage lntypes.Preimage
+	for i := range preimage {
+		preimage[i] = byte(i + 1)
+	}
+	paymentHash := preimage.Hash()
+
+	row := swapsqlc.PaySwap{
+		PaymentHash: paymentHash[:],
+		State:       PayStateCompleted.String(),
+		AmountSat:   10_000,
+		Preimage:    preimage[:],
+	}
+
+	summary, err := paySummaryFromRow(row)
+	require.NoError(t, err)
+	require.NotNil(t, summary.Preimage)
+	require.Equal(t, preimage, *summary.Preimage)
+}
+
+// TestPaySummaryFromRowNilPreimageWhilePending verifies a pay row that has not
+// yet revealed a preimage leaves the summary preimage nil rather than zero.
+func TestPaySummaryFromRowNilPreimageWhilePending(t *testing.T) {
+	t.Parallel()
+
+	var paymentHash lntypes.Hash
+	for i := range paymentHash {
+		paymentHash[i] = 0xab
+	}
+
+	row := swapsqlc.PaySwap{
+		PaymentHash: paymentHash[:],
+		State:       PayStateWaitingForClaim.String(),
+		AmountSat:   10_000,
+	}
+
+	summary, err := paySummaryFromRow(row)
+	require.NoError(t, err)
+	require.Nil(t, summary.Preimage)
+}

--- a/sdk/swaps/store_sessions.go
+++ b/sdk/swaps/store_sessions.go
@@ -308,9 +308,23 @@ func paySummaryFromRow(row swapsqlc.PaySwap) (SwapSummary, error) {
 		return SwapSummary{}, err
 	}
 
+	// The preimage column is only populated once the server's vHTLC claim
+	// reveals it, so a pending pay swap leaves it nil. When present it is
+	// the proof of payment for the paid invoice.
+	var preimage *lntypes.Preimage
+	if len(row.Preimage) != 0 {
+		decoded, err := preimageFromBytes(row.Preimage)
+		if err != nil {
+			return SwapSummary{}, err
+		}
+
+		preimage = &decoded
+	}
+
 	return SwapSummary{
 		Direction:        SwapDirectionPay,
 		PaymentHash:      paymentHash,
+		Preimage:         preimage,
 		Invoice:          row.Invoice,
 		State:            state.String(),
 		Pending:          !state.IsTerminal(),

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -1058,6 +1058,96 @@ func (s *swapClientService) validateReceiveAmount(ctx context.Context,
 		amountSat, minAmountSat)
 }
 
+// Default in-swap fee cap parameters. When the caller does not pin a max fee
+// (max_fee_sat == 0), the daemon derives a proportional cap from the invoice
+// amount so a normal payment routes without the caller having to reason about
+// the swap server's quoted fee. The proportional rate is applied in parts per
+// million for integer precision, and a small absolute floor keeps tiny swaps
+// routable when 1% rounds down below the server's flat fee component.
+const (
+	// defaultInSwapMaxFeePPM is the proportional in-swap fee cap applied
+	// when the caller does not set max_fee_sat. 10_000 ppm == 1% of the
+	// invoice amount.
+	defaultInSwapMaxFeePPM = 10_000
+
+	// defaultInSwapMaxFeeFloorSat is the absolute lower bound on the
+	// derived in-swap fee cap. Tiny invoices (a 5_000 sat swap quotes 1
+	// sat) would otherwise floor the 1% cap below the server's flat fee, so
+	// the floor guarantees a small payment still clears.
+	defaultInSwapMaxFeeFloorSat = 10
+)
+
+// defaultInSwapMaxFeeSat derives the effective in-swap fee cap for a swap of
+// amountSat satoshis. It returns the larger of the proportional 1% cap and the
+// absolute floor so the cap never collapses below the server's flat fee on a
+// small payment.
+func defaultInSwapMaxFeeSat(amountSat uint64) uint64 {
+	// We multiply before dividing so the proportional cap scales with the
+	// invoice for amounts below 1_000_000 sat. Integer division first would
+	// truncate amountSat/1_000_000 to 0 and collapse every routine swap to
+	// the floor. amountSat is a uint64 sat value, so this product cannot
+	// overflow at any realistic invoice size.
+	proportional := amountSat * defaultInSwapMaxFeePPM / 1_000_000
+
+	if proportional < defaultInSwapMaxFeeFloorSat {
+		return defaultInSwapMaxFeeFloorSat
+	}
+
+	return proportional
+}
+
+// effectiveMaxFeeSat resolves the in-swap fee cap to forward to sdk/swaps. A
+// caller-supplied non-zero max fee is honoured verbatim; a zero max fee (the
+// CLI default) is replaced with the proportional ~1% default so a routine
+// payment is not rejected by a 0 sat hard cap. The decoded invoice amount is
+// used to size the proportional cap; if the invoice cannot be decoded the
+// caller's zero is preserved so the existing downstream validation surfaces the
+// original error.
+func (s *swapClientService) effectiveMaxFeeSat(requested uint64,
+	invoice string) uint64 {
+
+	if requested != 0 {
+		return requested
+	}
+	if s.chainParams == nil {
+		return requested
+	}
+
+	amountSat, err := payInvoiceAmountSat(invoice, s.chainParams)
+	if err != nil {
+		return requested
+	}
+
+	return defaultInSwapMaxFeeSat(amountSat)
+}
+
+// errMsgInSwapFeeExceedsCap recognizes the in-swap fee-cap rejection. The
+// substring is shared by both the client's own pre-funding check in
+// sdk/swaps (validateInSwapQuote) and the swap server's CreateInSwap
+// INVALID_ARGUMENT response, so matching on the substring catches the
+// rejection regardless of which side quoted the offending fee.
+const errMsgInSwapFeeExceedsCap = "exceeds max fee"
+
+// wrapInSwapFeeError rewrites the terse "in-swap fee N exceeds max fee M"
+// rejection into an actionable message that names the client-side max-fee cap
+// and tells the caller how to raise it. The effective cap is included because
+// the daemon may have derived it from the ~1% default rather than from a
+// caller-supplied --max_fee, so a bare "max fee 0" would otherwise be
+// misleading. Errors that are not a fee-cap rejection pass through untouched.
+func wrapInSwapFeeError(err error, maxFeeSat uint64) error {
+	if err == nil {
+		return nil
+	}
+	if !strings.Contains(err.Error(), errMsgInSwapFeeExceedsCap) {
+		return err
+	}
+
+	return fmt.Errorf("the swap server's quoted in-swap fee exceeds the "+
+		"client's max-fee cap of %d sat; raise it with `da send "+
+		"--max_fee <sat>` (the cap defaults to ~1%% of the amount "+
+		"when unset): %w", maxFeeSat, err)
+}
+
 // payInvoiceAmountSat decodes the BOLT-11 invoice amount in whole satoshis.
 // The swap pay path funds one Ark vHTLC of this value, so a nil, zero, or
 // millisatoshi-only invoice cannot be admitted through the daemon subserver.
@@ -1140,11 +1230,17 @@ func (s *swapClientService) QuotePay(ctx context.Context,
 		return nil, err
 	}
 
+	maxFeeSat := s.effectiveMaxFeeSat(
+		req.GetMaxFeeSat(), req.GetInvoice(),
+	)
+
 	quote, err := s.client.QuotePayViaLightning(
-		ctx, req.GetInvoice(), req.GetMaxFeeSat(),
+		ctx, req.GetInvoice(), maxFeeSat,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("quote pay swap: %w", err)
+		return nil, fmt.Errorf("quote pay swap: %w", wrapInSwapFeeError(
+			err, maxFeeSat,
+		))
 	}
 
 	return quotePayToProto(quote)
@@ -1182,11 +1278,17 @@ func (s *swapClientService) StartPay(ctx context.Context,
 		return existing, nil
 	}
 
+	maxFeeSat := s.effectiveMaxFeeSat(
+		req.GetMaxFeeSat(), req.GetInvoice(),
+	)
+
 	session, err := s.client.StartPayViaLightning(
-		ctx, req.GetInvoice(), req.GetMaxFeeSat(),
+		ctx, req.GetInvoice(), maxFeeSat,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("start pay swap: %w", err)
+		return nil, fmt.Errorf("start pay swap: %w", wrapInSwapFeeError(
+			err, maxFeeSat,
+		))
 	}
 
 	hash := session.PaymentHash()
@@ -1632,6 +1734,11 @@ func swapSummaryToProto(summary swaps.SwapSummary) *swapclientrpc.SwapSummary {
 		)
 	}
 
+	var preimage string
+	if summary.Preimage != nil {
+		preimage = hex.EncodeToString(summary.Preimage[:])
+	}
+
 	return &swapclientrpc.SwapSummary{
 		Direction:        swapDirectionToProto(summary.Direction),
 		PaymentHash:      hex.EncodeToString(summary.PaymentHash[:]),
@@ -1655,6 +1762,7 @@ func swapSummaryToProto(summary swaps.SwapSummary) *swapclientrpc.SwapSummary {
 			summary.SettlementType,
 		),
 		SenderPubkey: senderPubKey,
+		Preimage:     preimage,
 	}
 }
 

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -1030,6 +1030,7 @@ type fakeSwapRuntime struct {
 	quotePayCalls      int
 	quotePayInvoice    string
 	quotePayMaxFeeSat  uint64
+	startPayMaxFeeSat  uint64
 	startPayCalls      int
 	startReceiveCalls  int
 	startReceiveMemo   string
@@ -1071,13 +1072,14 @@ func (f *fakeSwapRuntime) QuotePayViaLightning(_ context.Context,
 	return f.quotePayResp, nil
 }
 
-func (f *fakeSwapRuntime) StartPayViaLightning(context.Context, string,
-	uint64) (paySwapSession, error) {
+func (f *fakeSwapRuntime) StartPayViaLightning(_ context.Context, _ string,
+	maxFeeSat uint64) (paySwapSession, error) {
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	f.startPayCalls++
+	f.startPayMaxFeeSat = maxFeeSat
 	if f.startPayErr != nil {
 		return nil, f.startPayErr
 	}

--- a/swapclientserver/swap_fee_defaults_test.go
+++ b/swapclientserver/swap_fee_defaults_test.go
@@ -1,0 +1,225 @@
+//go:build swapruntime
+
+package swapclientserver
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
+	"github.com/lightninglabs/darepo-client/sdk/swaps"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultInSwapMaxFeeSat verifies the proportional ~1% cap with its
+// absolute floor for representative swap sizes.
+func TestDefaultInSwapMaxFeeSat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		amountSat uint64
+		want      uint64
+	}{
+		{
+			// The exact case from the bug report: a 5_000 sat swap
+			// quoted 1 sat. 1% is 50 sat, comfortably above the 1
+			// sat quote, so the payment now clears where the old
+			// 0-cap default rejected it.
+			name:      "bug report swap clears",
+			amountSat: 5_000,
+			want:      50,
+		},
+		{
+			// Below 1_000 sat the 1% cap rounds beneath the floor,
+			// so the absolute floor takes over and keeps the tiny
+			// payment routable.
+			name:      "sub-thousand swap floored",
+			amountSat: 500,
+			want:      defaultInSwapMaxFeeFloorSat,
+		},
+		{
+			// 1% of an intermediate sub-1_000_000 swap. This case
+			// guards the multiply-before-divide ordering: integer
+			// division first would truncate the cap to the floor.
+			name:      "proportional fee below one million",
+			amountSat: 500_000,
+			want:      5_000,
+		},
+		{
+			name:      "one percent above floor",
+			amountSat: 1_000_000,
+			want:      10_000,
+		},
+		{
+			name:      "one percent of large swap",
+			amountSat: 50_000_000,
+			want:      500_000,
+		},
+		{
+			name:      "zero amount floored",
+			amountSat: 0,
+			want:      defaultInSwapMaxFeeFloorSat,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(
+				t, tc.want,
+				defaultInSwapMaxFeeSat(tc.amountSat),
+			)
+		})
+	}
+}
+
+// TestEffectiveMaxFeeSatHonoursCaller verifies a caller-supplied non-zero cap
+// is forwarded verbatim and never overwritten by the proportional default.
+func TestEffectiveMaxFeeSatHonoursCaller(t *testing.T) {
+	t.Parallel()
+
+	s := &swapClientService{chainParams: &chaincfg.RegressionNetParams}
+
+	got := s.effectiveMaxFeeSat(42, "lnbc1invalid")
+	require.Equal(t, uint64(42), got)
+}
+
+// TestEffectiveMaxFeeSatDefaultsFromInvoice verifies a zero cap is replaced
+// with the ~1% default derived from the decoded invoice amount.
+func TestEffectiveMaxFeeSatDefaultsFromInvoice(t *testing.T) {
+	t.Parallel()
+
+	s := &swapClientService{chainParams: &chaincfg.RegressionNetParams}
+
+	invoice := testStartPayInvoice(t, testHash(7), 5_000)
+	got := s.effectiveMaxFeeSat(0, invoice)
+	require.Equal(t, uint64(50), got)
+
+	invoice = testStartPayInvoice(t, testHash(8), 1_000_000)
+	got = s.effectiveMaxFeeSat(0, invoice)
+	require.Equal(t, uint64(10_000), got)
+}
+
+// TestEffectiveMaxFeeSatPreservesZeroOnUndecodable verifies an undecodable
+// invoice leaves the caller's zero intact so the existing downstream validation
+// surfaces the original decode error rather than a derived cap.
+func TestEffectiveMaxFeeSatPreservesZeroOnUndecodable(t *testing.T) {
+	t.Parallel()
+
+	s := &swapClientService{chainParams: &chaincfg.RegressionNetParams}
+
+	require.Equal(t, uint64(0), s.effectiveMaxFeeSat(0, "not-an-invoice"))
+}
+
+// TestStartPayDefaultsMaxFeeWhenUnset verifies StartPay forwards the ~1%
+// default to sdk/swaps when the caller does not pin a max fee, so a routine
+// payment is not rejected by a 0 sat hard cap.
+func TestStartPayDefaultsMaxFeeWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	payHash := testHash(91)
+	invoice := testStartPayInvoice(t, payHash, 1_000_000)
+
+	// The seeded summary is terminal so the pending-invoice dedup misses
+	// and StartPay proceeds to StartPayViaLightning, where the forwarded
+	// max fee is recorded. summaryByHash still resolves it afterwards.
+	fakeClient := newFakeSwapRuntime(
+		swaps.SwapSummary{
+			Direction:   swaps.SwapDirectionPay,
+			PaymentHash: payHash,
+			State:       "completed",
+			Pending:     false,
+			AmountSat:   1_000_000,
+		},
+	)
+	fakeClient.startPaySession = &fakePaySession{hash: payHash}
+	service := newTestSwapClientService(fakeClient)
+	service.chainParams = &chaincfg.RegressionNetParams
+	defer service.cancel()
+
+	_, err := service.StartPay(
+		t.Context(), &swapclientrpc.StartPayRequest{
+			Invoice:   invoice,
+			MaxFeeSat: 0,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10_000), fakeClient.startPayMaxFeeSat)
+}
+
+// TestQuotePayDefaultsMaxFeeWhenUnset verifies QuotePay derives the same ~1%
+// default for the non-mutating preview path.
+func TestQuotePayDefaultsMaxFeeWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	payHash := testHash(92)
+	invoice := testStartPayInvoice(t, payHash, 1_000_000)
+	fakeClient := newFakeSwapRuntime()
+	fakeClient.quotePayResp = &swaps.InSwapQuote{
+		PaymentHash:      payHash,
+		InvoiceAmountSat: 1_000_000,
+		AmountSat:        1_000_210,
+		FeeSat:           210,
+		SettlementType:   swaps.SettlementTypeLightning,
+	}
+	service := newTestSwapClientService(fakeClient)
+	service.chainParams = &chaincfg.RegressionNetParams
+	defer service.cancel()
+
+	_, err := service.QuotePay(
+		t.Context(), &swapclientrpc.QuotePayRequest{
+			Invoice:   invoice,
+			MaxFeeSat: 0,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10_000), fakeClient.quotePayMaxFeeSat)
+}
+
+// TestQuotePayWrapsMaxFeeError verifies quote previews surface the same
+// actionable fee-cap error as the mutating send path.
+func TestQuotePayWrapsMaxFeeError(t *testing.T) {
+	t.Parallel()
+
+	payHash := testHash(93)
+	invoice := testStartPayInvoice(t, payHash, 1_000_000)
+	feeErr := fmt.Errorf("quote in-swap: invalid in-swap request: " +
+		"in-swap fee 250 sat exceeds max fee 100 sat")
+	fakeClient := newFakeSwapRuntime()
+	fakeClient.quotePayErr = feeErr
+	service := newTestSwapClientService(fakeClient)
+	service.chainParams = &chaincfg.RegressionNetParams
+	defer service.cancel()
+
+	_, err := service.QuotePay(
+		t.Context(), &swapclientrpc.QuotePayRequest{
+			Invoice:   invoice,
+			MaxFeeSat: 100,
+		},
+	)
+	require.ErrorContains(t, err, "max-fee cap of 100 sat")
+	require.ErrorContains(t, err, "--max_fee")
+	require.ErrorIs(t, err, feeErr)
+}
+
+// TestWrapInSwapFeeError verifies the fee-cap rejection is rewritten into an
+// actionable message while unrelated errors pass through untouched.
+func TestWrapInSwapFeeError(t *testing.T) {
+	t.Parallel()
+
+	feeErr := fmt.Errorf("create in-swap: invalid in-swap request: " +
+		"in-swap fee 1 sat exceeds max fee 0 sat")
+	wrapped := wrapInSwapFeeError(feeErr, 0)
+	require.ErrorContains(t, wrapped, "max-fee cap of 0 sat")
+	require.ErrorContains(t, wrapped, "--max_fee")
+	require.ErrorIs(t, wrapped, feeErr)
+
+	other := errors.New("boom")
+	require.Equal(t, other, wrapInSwapFeeError(other, 5))
+
+	require.NoError(t, wrapInSwapFeeError(nil, 5))
+}

--- a/swapwallet/inspection.go
+++ b/swapwallet/inspection.go
@@ -577,6 +577,7 @@ func swapTraceFromSummary(
 			swap.GetSettlementType(),
 		),
 		SenderPubkey: swap.GetSenderPubkey(),
+		Preimage:     swap.GetPreimage(),
 	}
 }
 

--- a/swapwallet/inspection_test.go
+++ b/swapwallet/inspection_test.go
@@ -54,6 +54,7 @@ func TestInspectActivityShowsPayFundingTrace(t *testing.T) {
 				SettlementType: swapclientrpc.
 					SwapSettlementType_SWAP_SETTLEMENT_TYPE_IN_ARK,
 				SenderPubkey:     "sender-pubkey",
+				Preimage:         "deadbeef",
 				VhtlcOutpoint:    "vhtlc-txid:0",
 				VhtlcAmountSat:   1_234,
 				UpdatedAtUnix:    200,
@@ -101,6 +102,7 @@ func TestInspectActivityShowsPayFundingTrace(t *testing.T) {
 		resp.GetSwap().GetSettlementType(),
 	)
 	require.Equal(t, "sender-pubkey", resp.GetSwap().GetSenderPubkey())
+	require.Equal(t, "deadbeef", resp.GetSwap().GetPreimage())
 	require.Len(t, resp.GetLedgerRows(), 2)
 	require.Len(t, resp.GetVtxos(), 3)
 


### PR DESCRIPTION
## Motivation

Three rough edges in the Ark→Lightning (in-swap) pay path made a routine `da send <invoice>` fail for no good reason and, when it did succeed, hide its proof of payment. This was confirmed on a live signet node:

```
INVALID_ARGUMENT: create in-swap: invalid in-swap request:
in-swap fee 1 sat exceeds max fee 0 sat
```

## Changes

### 1. Sane default in-swap fee cap (~1%)
`--max_fee` defaulted to `0` but the daemon forwarded that `0` verbatim as a hard cap to the swap server's `CreateInSwap` RPC. A 5_000 sat swap that quoted a 1 sat fee was rejected because `1 > 0`. A user should never have to set `--max_fee` for a normal payment.

The effective cap is now derived in the daemon's in-swap creation path (`QuotePay` + `StartPay`), so **every** entry point benefits at once — the `da send` flag, the MCP `swap.pay` tool, and the `cmd_swap_rpc` verb. When unset, the cap is sized at **~1% of the swap amount** (10_000 ppm) with a small absolute floor so tiny swaps still clear the server's flat fee. A caller-supplied non-zero cap is honoured verbatim. Help text on all three surfaces updated.

### 2. Actionable fee-cap error
When the quoted fee genuinely exceeds the cap, the terse rejection is wrapped into a message that names the client-side cap and tells the caller how to raise it (`da send --max_fee <sat>`). Matches on the shared `"exceeds max fee"` substring so it catches the rejection whether it came from the client's own pre-funding check or from the swap server.

### 3. Surface the payment preimage in `da activity inspect`
A completed LN pay swap persists the claim preimage in the `pay_swaps` row but it never surfaced in `da activity inspect`, even though the preimage is the proof of payment. Plumbed through: SDK `SwapSummary.Preimage` (from the durable row) → `swapclientrpc`/`walletdkrpc` proto `preimage` fields → daemon mappers → activity inspect renderer (printed under the payment hash).

### 4. `da send` blocks on settlement by default (`--no-wait` to opt out)
`da send` now blocks on the always-available `WalletInspectionService` until the entry reaches a terminal state, printing each lifecycle phase and rendering the final trace (with the preimage) at the end. Failed terminal state → non-zero exit. Pass `--no-wait` to return as soon as the send is dispatched (the old fire-and-forget behaviour). `--wait-timeout` / `--wait-poll-interval` tune the poll.

## Testing
- `go build ./...` and `go build -tags "swapruntime walletdkrpc" ./...` clean
- New unit tests: proportional cap + floor, `effectiveMaxFeeSat`, `StartPay`/`QuotePay` defaulting, error wrapping, `paySummaryFromRow` preimage, inspection trace + renderer preimage, `send` wait-by-default flags
- `go test` green for `swapclientserver`, `swapwallet`, `sdk/swaps`, `cmd/darepocli/darepoclicommands`

## Follow-up (out of scope — swapdk-server)
The raw `"in-swap fee N sat exceeds max fee M sat"` / `"invalid in-swap request"` text returned over `CreateInSwap` originates in **swapdk-server** (a separate repo). This PR wraps it client-side; tightening the server-side message itself is a separate follow-up.