### PR TITLE
walletdk: make WalletEntry.failure_code optional so non-failed entries omit it

### DIFF
--- a/cmd/protoc-gen-mailboxrpc/main.go
+++ b/cmd/protoc-gen-mailboxrpc/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/lightninglabs/darepo-client/cmd/protoc-gen-mailboxrpc/internal/gen"
 	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 // main runs the protoc plugin entrypoint.
@@ -21,6 +22,10 @@ func main() {
 	}
 
 	opts.Run(func(plugin *protogen.Plugin) error {
+		plugin.SupportedFeatures = uint64(
+			pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL,
+		)
+
 		cfg := gen.Config{
 			ExcludeService: *excludeService,
 		}

--- a/rpc/walletdkrpc/wallet.pb.go
+++ b/rpc/walletdkrpc/wallet.pb.go
@@ -3921,9 +3921,11 @@ type WalletEntry struct {
 	// phase without inferring meaning from swap/ledger internals.
 	Progress *WalletEntryProgress `protobuf:"bytes,12,opt,name=progress,proto3" json:"progress,omitempty"`
 	// failure_code is a stable, machine-readable classification of why a
-	// FAILED entry failed. It is ENTRY_FAILURE_CODE_UNSPECIFIED unless status
-	// is FAILED. failure_reason remains the human-readable supplement.
-	FailureCode   EntryFailureCode `protobuf:"varint,13,opt,name=failure_code,json=failureCode,proto3,enum=walletdkrpc.EntryFailureCode" json:"failure_code,omitempty"`
+	// FAILED entry failed. It is set ONLY on FAILED entries; a non-failed
+	// entry omits the field entirely (presence-tracked), so its absence is the
+	// canonical "no failure" signal and ENTRY_FAILURE_CODE_UNSPECIFIED is never
+	// sent on the wire. failure_reason remains the human-readable supplement.
+	FailureCode   *EntryFailureCode `protobuf:"varint,13,opt,name=failure_code,json=failureCode,proto3,enum=walletdkrpc.EntryFailureCode,oneof" json:"failure_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4043,8 +4045,8 @@ func (x *WalletEntry) GetProgress() *WalletEntryProgress {
 }
 
 func (x *WalletEntry) GetFailureCode() EntryFailureCode {
-	if x != nil {
-		return x.FailureCode
+	if x != nil && x.FailureCode != nil {
+		return *x.FailureCode
 	}
 	return EntryFailureCode_ENTRY_FAILURE_CODE_UNSPECIFIED
 }
@@ -4648,7 +4650,7 @@ const file_wallet_proto_rawDesc = "" +
 	"last_error\x18\x04 \x01(\tR\tlastError\"q\n" +
 	"\x16SubscribeWalletRequest\x12)\n" +
 	"\x10include_existing\x18\x01 \x01(\bR\x0fincludeExisting\x12,\n" +
-	"\x05kinds\x18\x02 \x03(\x0e2\x16.walletdkrpc.EntryKindR\x05kinds\"\x9d\x04\n" +
+	"\x05kinds\x18\x02 \x03(\x0e2\x16.walletdkrpc.EntryKindR\x05kinds\"\xb3\x04\n" +
 	"\vWalletEntry\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12*\n" +
 	"\x04kind\x18\x02 \x01(\x0e2\x16.walletdkrpc.EntryKindR\x04kind\x120\n" +
@@ -4663,8 +4665,9 @@ const file_wallet_proto_rawDesc = "" +
 	"\x0efailure_reason\x18\n" +
 	" \x01(\tR\rfailureReason\x129\n" +
 	"\arequest\x18\v \x01(\v2\x1f.walletdkrpc.WalletEntryRequestR\arequest\x12<\n" +
-	"\bprogress\x18\f \x01(\v2 .walletdkrpc.WalletEntryProgressR\bprogress\x12@\n" +
-	"\ffailure_code\x18\r \x01(\x0e2\x1d.walletdkrpc.EntryFailureCodeR\vfailureCode\"\x86\x02\n" +
+	"\bprogress\x18\f \x01(\v2 .walletdkrpc.WalletEntryProgressR\bprogress\x12E\n" +
+	"\ffailure_code\x18\r \x01(\x0e2\x1d.walletdkrpc.EntryFailureCodeH\x00R\vfailureCode\x88\x01\x01B\x0f\n" +
+	"\r_failure_code\"\x86\x02\n" +
 	"\x12WalletEntryRequest\x12S\n" +
 	"\x11lightning_invoice\x18\x01 \x01(\v2$.walletdkrpc.LightningInvoiceRequestH\x00R\x10lightningInvoice\x12M\n" +
 	"\x0fonchain_address\x18\x02 \x01(\v2\".walletdkrpc.OnchainAddressRequestH\x00R\x0eonchainAddress\x12A\n" +
@@ -4916,6 +4919,7 @@ func file_wallet_proto_init() {
 		(*ListResponse_Vtxos)(nil),
 		(*ListResponse_Onchain)(nil),
 	}
+	file_wallet_proto_msgTypes[39].OneofWrappers = []any{}
 	file_wallet_proto_msgTypes[40].OneofWrappers = []any{
 		(*WalletEntryRequest_LightningInvoice)(nil),
 		(*WalletEntryRequest_OnchainAddress)(nil),

--- a/rpc/walletdkrpc/wallet.proto
+++ b/rpc/walletdkrpc/wallet.proto
@@ -1033,9 +1033,11 @@ message WalletEntry {
     WalletEntryProgress progress = 12;
 
     // failure_code is a stable, machine-readable classification of why a
-    // FAILED entry failed. It is ENTRY_FAILURE_CODE_UNSPECIFIED unless status
-    // is FAILED. failure_reason remains the human-readable supplement.
-    EntryFailureCode failure_code = 13;
+    // FAILED entry failed. It is set ONLY on FAILED entries; a non-failed
+    // entry omits the field entirely (presence-tracked), so its absence is the
+    // canonical "no failure" signal and ENTRY_FAILURE_CODE_UNSPECIFIED is never
+    // sent on the wire. failure_reason remains the human-readable supplement.
+    optional EntryFailureCode failure_code = 13;
 }
 
 // WalletEntryRequest describes the user-recognizable request that created a

--- a/sdk/walletdk/convert.go
+++ b/sdk/walletdk/convert.go
@@ -400,8 +400,11 @@ func entryFailureCodeFromProto(
 	case walletdkrpc.EntryFailureCode_ENTRY_FAILURE_CODE_FAILED:
 		return EntryFailureCodeFailed
 
+	// An absent (presence-tracked) or unrecognized code is not a failure;
+	// surface the empty string, mirroring FailureReason, rather than a
+	// sentinel a non-failed entry would carry.
 	default:
-		return EntryFailureCodeUnspecified
+		return ""
 	}
 }
 

--- a/sdk/walletdk/convert_test.go
+++ b/sdk/walletdk/convert_test.go
@@ -80,10 +80,14 @@ func TestEntryFromProtoNoProgressOrRequest(t *testing.T) {
 	require.Equal(t, "id", entry.ID)
 	require.Nil(t, entry.Progress)
 	require.Nil(t, entry.Request)
+
+	// A non-failed entry carries no failure code: the empty string, not a
+	// sentinel, parallels the empty FailureReason.
+	require.Empty(t, entry.FailureCode)
 }
 
 // TestEntryFailureCodeFromProto exhaustively maps every walletdkrpc failure
-// code to the wrapper-owned string, including the unspecified fallback.
+// code to the wrapper-owned string, including the empty no-failure case.
 func TestEntryFailureCodeFromProto(t *testing.T) {
 	codes := walletdkrpc.EntryFailureCode_value
 	cases := []struct {
@@ -91,7 +95,7 @@ func TestEntryFailureCodeFromProto(t *testing.T) {
 		want EntryFailureCode
 	}{{
 		in:   failureCodeEnum("UNSPECIFIED"),
-		want: EntryFailureCodeUnspecified,
+		want: "",
 	}, {
 		in:   failureCodeEnum("TIMED_OUT"),
 		want: EntryFailureCodeTimedOut,

--- a/sdk/walletdk/convert_test.go
+++ b/sdk/walletdk/convert_test.go
@@ -43,7 +43,7 @@ func TestEntryFromProto(t *testing.T) {
 		FailureReason: "reason",
 		Progress:      prog,
 		Request:       req,
-		FailureCode:   failureCodeEnum("TIMED_OUT"),
+		FailureCode:   failureCodeEnum("TIMED_OUT").Enum(),
 	}
 
 	entry := entryFromProto(proto)

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -571,8 +571,8 @@ type Entry struct {
 	Request *EntryRequest
 
 	// FailureCode is a stable, machine-readable classification of why the
-	// entry failed. It is EntryFailureCodeUnspecified unless Status is
-	// failed; FailureReason remains the human-readable supplement.
+	// entry failed. It is empty unless Status is failed, mirroring
+	// FailureReason, which remains the human-readable supplement.
 	FailureCode EntryFailureCode
 }
 
@@ -696,10 +696,6 @@ type EntryRequest struct {
 type EntryFailureCode string
 
 const (
-	// EntryFailureCodeUnspecified means the entry has not failed, or the
-	// cause is unknown.
-	EntryFailureCodeUnspecified EntryFailureCode = "unspecified"
-
 	// EntryFailureCodeTimedOut means the operation exceeded the wallet
 	// deadline before reaching a terminal state.
 	EntryFailureCodeTimedOut EntryFailureCode = "timed_out"

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -961,9 +961,7 @@ func (h *history) applyOverlays(entries []*walletdkrpc.WalletEntry,
 		if ov.failureReason != "" {
 			e.FailureReason = ov.failureReason
 		}
-		if ov.failureCode != unspecCode {
-			e.FailureCode = ov.failureCode
-		}
+		e.FailureCode = failureCodePtr(ov.failureCode)
 	}
 }
 

--- a/swapwallet/normalize.go
+++ b/swapwallet/normalize.go
@@ -73,8 +73,10 @@ func swapEntryFromSummary(s *swapclientrpc.SwapSummary, note string,
 		FailureReason: failureReasonFromTerminal(s.GetTerminalReason()),
 		Request:       requestFromSwapSummary(s, counterparty, kind),
 		Progress:      progressFromSwapSummary(s),
-		FailureCode: failureCodeFromSwapState(
-			s.GetState(), s.GetPending(),
+		FailureCode: failureCodePtr(
+			failureCodeFromSwapState(
+				s.GetState(), s.GetPending(),
+			),
 		),
 	}
 
@@ -281,6 +283,20 @@ func failureCodeFromSwapState(state swapclientrpc.SwapState,
 	default:
 		return unspecCode
 	}
+}
+
+// failureCodePtr adapts a classifier result to the optional failure_code proto
+// field. It returns nil for the unspecified (no-failure) sentinel so the field
+// stays absent on the wire, and a pointer to a concrete code otherwise; only a
+// genuinely failed entry carries a failure_code.
+func failureCodePtr(
+	code walletdkrpc.EntryFailureCode) *walletdkrpc.EntryFailureCode {
+
+	if code == unspecCode {
+		return nil
+	}
+
+	return code.Enum()
 }
 
 // failureReasonFromTerminal surfaces the SDK's terminal reason string only
@@ -555,8 +571,8 @@ func applyUnrollStatus(entry *walletdkrpc.WalletEntry,
 	case daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_FAILED:
 		entry.Status = walletdkrpc.EntryStatus_ENTRY_STATUS_FAILED
 		entry.FailureReason = resp.GetLastError()
-		entry.FailureCode =
-			walletdkrpc.EntryFailureCode_ENTRY_FAILURE_CODE_FAILED
+		entry.FailureCode = walletdkrpc.
+			EntryFailureCode_ENTRY_FAILURE_CODE_FAILED.Enum()
 		progress.Phase = walletdkrpc.
 			WalletEntryPhase_WALLET_ENTRY_PHASE_FAILED
 		progress.PhaseLabel = "failed"

--- a/swapwallet/normalize_test.go
+++ b/swapwallet/normalize_test.go
@@ -3,6 +3,7 @@
 package swapwallet
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // TestTruncate confirms truncate clips a long string to n bytes and
@@ -548,5 +550,76 @@ func TestSwapEntryFromSummaryNilSafe(t *testing.T) {
 	require.NotNil(t, out)
 	require.Equal(
 		t, walletdkrpc.EntryKind_ENTRY_KIND_UNSPECIFIED, out.GetKind(),
+	)
+
+	// A nil summary is not a failure, so failure_code stays unset.
+	require.Nil(t, out.FailureCode)
+}
+
+// TestSwapEntryFromSummaryFailureCodePresence confirms failure_code is
+// presence-tracked: a non-failed entry leaves it unset (its absence is the
+// canonical "no failure" signal), while a failed entry carries the concrete
+// code. GetFailureCode still reads back UNSPECIFIED when absent.
+func TestSwapEntryFromSummaryFailureCodePresence(t *testing.T) {
+	t.Parallel()
+
+	ok := swapEntryFromSummary(&swapclientrpc.SwapSummary{
+		PaymentHash: "ph-ok",
+		State:       swapclientrpc.SwapState_SWAP_STATE_COMPLETED,
+	}, "", "", walletdkrpc.EntryKind_ENTRY_KIND_RECV)
+	require.Nil(
+		t, ok.FailureCode, "non-failed entry must omit failure_code",
+	)
+	require.Equal(t, unspecCode, ok.GetFailureCode())
+
+	failed := swapEntryFromSummary(&swapclientrpc.SwapSummary{
+		PaymentHash: "ph-expired",
+		State:       swapclientrpc.SwapState_SWAP_STATE_EXPIRED,
+	}, "", "", walletdkrpc.EntryKind_ENTRY_KIND_RECV)
+	require.NotNil(
+		t, failed.FailureCode, "failed entry must set failure_code",
+	)
+	require.Equal(t, fcEnum("EXPIRED"), failed.GetFailureCode())
+}
+
+// TestWalletEntryFailureCodeJSONShape reproduces the gateway's JSON marshaling
+// (UseProtoNames + EmitUnpopulated, per gateway.ServeMuxOptions) and confirms
+// the presence-tracked failure_code is omitted for a non-failed entry and
+// present for a failed one. Before failure_code was made optional it serialized
+// as "ENTRY_FAILURE_CODE_UNSPECIFIED" on every non-failed entry; this is the
+// shape guard that pins that regression shut.
+func TestWalletEntryFailureCodeJSONShape(t *testing.T) {
+	t.Parallel()
+
+	marshal := protojson.MarshalOptions{
+		UseProtoNames:   true,
+		EmitUnpopulated: true,
+	}
+	decode := func(e *walletdkrpc.WalletEntry) map[string]any {
+		raw, err := marshal.Marshal(e)
+		require.NoError(t, err)
+
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(raw, &m))
+
+		return m
+	}
+
+	ok := swapEntryFromSummary(&swapclientrpc.SwapSummary{
+		PaymentHash: "ph-ok",
+		State:       swapclientrpc.SwapState_SWAP_STATE_COMPLETED,
+	}, "", "", walletdkrpc.EntryKind_ENTRY_KIND_RECV)
+	_, present := decode(ok)["failure_code"]
+	require.False(
+		t, present, "non-failed entry JSON must not carry failure_code",
+	)
+
+	failed := swapEntryFromSummary(&swapclientrpc.SwapSummary{
+		PaymentHash: "ph-expired",
+		State:       swapclientrpc.SwapState_SWAP_STATE_EXPIRED,
+	}, "", "", walletdkrpc.EntryKind_ENTRY_KIND_RECV)
+	require.Equal(
+		t, "ENTRY_FAILURE_CODE_EXPIRED", decode(failed)["failure_code"],
+		"failed entry JSON must carry the concrete failure_code",
 	)
 }

--- a/swapwallet/runtime.go
+++ b/swapwallet/runtime.go
@@ -397,7 +397,7 @@ func (r *Runtime) markTimedOut(now time.Time) []*walletdkrpc.WalletEntry {
 		}
 		notifyEntry.Status = ov.status
 		notifyEntry.FailureReason = ov.failureReason
-		notifyEntry.FailureCode = ov.failureCode
+		notifyEntry.FailureCode = failureCodePtr(ov.failureCode)
 		notifyEntry.UpdatedAtUnix = now.Unix()
 		notify = append(notify, notifyEntry)
 	}


### PR DESCRIPTION
## What

A non-failed `WalletEntry` was surfacing a failure code. Over REST/CLI/MCP the
JSON carried `"failure_code": "ENTRY_FAILURE_CODE_UNSPECIFIED"` on *every*
non-failed entry, and the Go SDK reported `FailureCode == "unspecified"`. A
naive consumer reads that non-empty value as "this entry failed".

This makes `failure_code` presence-tracked: a non-failed entry omits it
entirely, so its **absence** is the canonical "no failure" signal — exactly how
`failure_reason` already works (empty string when there's nothing to report).

## Why it happened

`failure_code` was a singular proto3 enum, which has no field presence: its zero
value (`UNSPECIFIED`) is indistinguishable from "unset". The HTTP gateway
marshals with `EmitUnpopulated: true` (`gateway/gateway.go`), so it emitted the
zero enum as a string on every entry — same as it does for `kind`, `status`,
etc. The stored value was always correct (`UNSPECIFIED` = no failure); only the
serialized shape was misleading.

## On keeping `ENTRY_FAILURE_CODE_UNSPECIFIED`

Proto3 *requires* an enum's first member to be `= 0`, so `UNSPECIFIED` must stay
in the proto enum — it's the value `GetFailureCode()` returns when the field is
absent. We keep it at `0` deliberately: an absent field then reads back as a
safe "no failure" rather than a real code. We simply never put it on the wire.

The Go SDK is different: `EntryFailureCode` is a plain string (zero value `""`),
so it needs no named sentinel. A non-failed `Entry` now reports an empty
`FailureCode`, mirroring its empty `FailureReason` sibling; the redundant
`EntryFailureCodeUnspecified` constant is removed.

## Changes

- **`protoc-gen-mailboxrpc`**: advertise `FEATURE_PROTO3_OPTIONAL`. The plugin
  emits only service stubs, so optional message fields don't change its output —
  it just has to declare support so `protoc` accepts the input. (Prerequisite:
  `make rpc` rejected the optional field without this.)
- **`walletdkrpc`**: `optional EntryFailureCode failure_code = 13;` + regenerated
  stubs (the field becomes presence-tracked `*EntryFailureCode`).
- **`swapwallet`**: set `failure_code` only when an entry actually failed, via a
  `failureCodePtr` helper that maps the unspecified sentinel to `nil`. This also
  fixes a latent asymmetry — the deadline-overlay notify path set the code
  unconditionally while the history path guarded it; both now route through the
  one helper.
- **`sdk/walletdk`**: drop `EntryFailureCodeUnspecified`; an absent code maps to
  the empty string.

## Net effect

A non-failed entry now has **no `failure_code` key in REST/CLI/MCP JSON** and an
**empty `FailureCode` in the Go SDK** — consistent across the whole stack. A
failed entry still carries its concrete code.

## Testing

- `swapwallet`: a JSON-shape test that reproduces the gateway's exact marshaling
  (`UseProtoNames + EmitUnpopulated`) and asserts the `failure_code` key is
  absent for a non-failed entry and present for a failed one — i.e. it pins the
  reported regression shut — plus a write-path presence test. Existing
  value-level assertions (`GetFailureCode() == UNSPECIFIED` for non-failed) keep
  passing unchanged.
- `sdk/walletdk`: a bare-entry test asserts an empty `FailureCode`; the
  exhaustive mapping test maps the unspecified input to `""`.
- Builds green under default, `-tags walletdkrpc,swapruntime`, and
  `GOOS=js GOARCH=wasm`; full `swapwallet` + `sdk/walletdk` suites,
  `make fmt-changed`, and `make lint-changed-local` (0 issues) all pass.

## Notes

Follow-up to the entry-level `failure_code` taxonomy added in #790.