### PR TITLE
walletdk: open a wallet from a passkey-derived seed

### DIFF
--- a/cmd/walletdk-wasm/main.go
+++ b/cmd/walletdk-wasm/main.go
@@ -77,6 +77,9 @@ func walletCall(_ js.Value, args []js.Value) any {
 	case "unlockWallet":
 		return promise(jsonVerb(req, mobile.UnlockWallet))
 
+	case "openWalletFromPasskey":
+		return promise(jsonVerb(req, mobile.OpenWalletFromPasskey))
+
 	case "deposit":
 		return promise(jsonVerb(req, mobile.Deposit))
 

--- a/darepod/seed_storage_wasm.go
+++ b/darepod/seed_storage_wasm.go
@@ -19,6 +19,33 @@ import (
 // off the JS call stack (the verb goroutines spawned by promise() satisfy
 // this).
 
+// errOPFSUnavailable is returned when the OPFS API is absent from the current
+// JS context. This is a deterministic capability gap rather than a transient
+// failure, so callers can safely treat it as "no seed has ever been persisted".
+var errOPFSUnavailable = errors.New("OPFS (navigator.storage.getDirectory) " +
+	"is unavailable")
+
+// opfsError wraps a rejected OPFS promise, preserving the DOMException name
+// (e.g. "NotFoundError") alongside its string form so callers can tell a
+// genuinely-absent file apart from an ambiguous runtime failure.
+type opfsError struct {
+	name string
+	msg  string
+}
+
+// Error returns the string form of the underlying OPFS rejection.
+func (e *opfsError) Error() string {
+	return e.msg
+}
+
+// isNotFound reports whether err is an OPFS rejection caused by a missing file
+// or directory (a DOMException with name "NotFoundError").
+func isNotFound(err error) bool {
+	var oerr *opfsError
+
+	return errors.As(err, &oerr) && oerr.name == "NotFoundError"
+}
+
 // awaitJSPromise blocks the calling goroutine until the JS promise settles and
 // returns its resolved value, or an error built from the rejection reason. The
 // channel is buffered so the settle callback never blocks the JS event loop.
@@ -41,11 +68,19 @@ func awaitJSPromise(p js.Value) (js.Value, error) {
 	defer onResolve.Release()
 
 	onReject := js.FuncOf(func(_ js.Value, args []js.Value) any {
-		msg := "promise rejected"
+		oerr := &opfsError{msg: "promise rejected"}
 		if len(args) > 0 && args[0].Truthy() {
-			msg = args[0].Call("toString").String()
+			reason := args[0]
+			oerr.msg = reason.Call("toString").String()
+
+			// DOMExceptions carry the failure kind on .name
+			// (e.g. "NotFoundError"); preserve it so callers can
+			// distinguish a missing file from other failures.
+			if n := reason.Get("name"); n.Type() == js.TypeString {
+				oerr.name = n.String()
+			}
 		}
-		ch <- settled{err: errors.New(msg)}
+		ch <- settled{err: oerr}
 
 		return nil
 	})
@@ -63,8 +98,7 @@ func awaitJSPromise(p js.Value) (js.Value, error) {
 func opfsRootDir() (js.Value, error) {
 	storage := js.Global().Get("navigator").Get("storage")
 	if !storage.Truthy() || storage.Get("getDirectory").IsUndefined() {
-		return js.Value{}, errors.New("OPFS " +
-			"(navigator.storage.getDirectory) is unavailable")
+		return js.Value{}, errOPFSUnavailable
 	}
 
 	return awaitJSPromise(storage.Call("getDirectory"))
@@ -201,10 +235,23 @@ func LoadEncryptedSeed(path string) ([]byte, error) {
 	return data, nil
 }
 
-// SeedFileExists returns true if an encrypted seed file exists in OPFS for the
-// network data directory.
+// SeedFileExists reports whether an encrypted seed file exists in OPFS for the
+// network data directory. It returns false only when absence is confirmed: a
+// NotFoundError for the file or one of its parent directories, or OPFS being
+// unavailable (so nothing could ever have been persisted). Any other error is
+// ambiguous (transient I/O, quota, a handle locked by a concurrent writer), so
+// the seed is reported as present to keep the daemon out of the "no wallet"
+// state, where a later InitWallet would overwrite a seed that may exist.
 func SeedFileExists(networkDir string) bool {
 	_, err := openSeedFile(SeedFilePath(networkDir))
+	switch {
+	case err == nil:
+		return true
 
-	return err == nil
+	case isNotFound(err), errors.Is(err, errOPFSUnavailable):
+		return false
+
+	default:
+		return true
+	}
 }

--- a/darepod/seed_storage_wasm.go
+++ b/darepod/seed_storage_wasm.go
@@ -3,60 +3,208 @@
 package darepod
 
 import (
-	"encoding/base64"
+	"errors"
 	"fmt"
+	"strings"
 	"syscall/js"
 )
 
-const wasmSeedStoragePrefix = "darepod:encrypted-seed:"
+// The encrypted seed is persisted as a single file in the origin-private file
+// system (OPFS). OPFS is reachable from both the window and worker globals,
+// unlike localStorage which is window-only, so the daemon can run inside a Web
+// Worker. SeedFilePath produces a "/dir/dir/wallet_seed.enc" path; it is split
+// on "/" and walked as OPFS directory handles, placing the seed alongside the
+// daemon's other OPFS data. These functions block the calling goroutine on the
+// async OPFS promises, so they keep their synchronous signatures; they must run
+// off the JS call stack (the verb goroutines spawned by promise() satisfy
+// this).
 
-// SaveEncryptedSeed stores the encrypted seed in browser localStorage. The
-// payload is already password-encrypted by EncryptSeed before this boundary.
-func SaveEncryptedSeed(path string, ciphertext []byte) error {
-	storage := js.Global().Get("localStorage")
-	if storage.IsUndefined() || storage.IsNull() {
-		return fmt.Errorf("browser localStorage is unavailable")
+// awaitJSPromise blocks the calling goroutine until the JS promise settles and
+// returns its resolved value, or an error built from the rejection reason. The
+// channel is buffered so the settle callback never blocks the JS event loop.
+func awaitJSPromise(p js.Value) (js.Value, error) {
+	type settled struct {
+		value js.Value
+		err   error
+	}
+	ch := make(chan settled, 1)
+
+	onResolve := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		var v js.Value
+		if len(args) > 0 {
+			v = args[0]
+		}
+		ch <- settled{value: v}
+
+		return nil
+	})
+	defer onResolve.Release()
+
+	onReject := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		msg := "promise rejected"
+		if len(args) > 0 && args[0].Truthy() {
+			msg = args[0].Call("toString").String()
+		}
+		ch <- settled{err: errors.New(msg)}
+
+		return nil
+	})
+	defer onReject.Release()
+
+	p.Call("then", onResolve, onReject)
+
+	res := <-ch
+
+	return res.value, res.err
+}
+
+// opfsRootDir resolves the OPFS root directory handle, returning an error when
+// OPFS is unavailable in the current context.
+func opfsRootDir() (js.Value, error) {
+	storage := js.Global().Get("navigator").Get("storage")
+	if !storage.Truthy() || storage.Get("getDirectory").IsUndefined() {
+		return js.Value{}, errors.New("OPFS " +
+			"(navigator.storage.getDirectory) is unavailable")
 	}
 
-	storage.Call(
-		"setItem", wasmSeedStoragePrefix+path,
-		base64.StdEncoding.EncodeToString(ciphertext),
+	return awaitJSPromise(storage.Call("getDirectory"))
+}
+
+// splitSeedPath splits a "/a/b/file" seed path into its directory segments and
+// the final file name, skipping empty segments.
+func splitSeedPath(path string) (dirs []string, file string) {
+	var parts []string
+	for _, p := range strings.Split(path, "/") {
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+
+	if len(parts) == 0 {
+		return nil, ""
+	}
+
+	return parts[:len(parts)-1], parts[len(parts)-1]
+}
+
+// opfsSeedDir walks the OPFS directory chain for the seed path, optionally
+// creating it, and returns the parent directory handle and the file name.
+func opfsSeedDir(path string, create bool) (js.Value, string, error) {
+	dirs, file := splitSeedPath(path)
+	if file == "" {
+		return js.Value{}, "", fmt.Errorf("invalid seed path %q", path)
+	}
+
+	dir, err := opfsRootDir()
+	if err != nil {
+		return js.Value{}, "", err
+	}
+
+	opts := map[string]any{"create": create}
+	for _, name := range dirs {
+		dir, err = awaitJSPromise(
+			dir.Call("getDirectoryHandle", name, opts),
+		)
+		if err != nil {
+			return js.Value{}, "", err
+		}
+	}
+
+	return dir, file, nil
+}
+
+// openSeedFile resolves the handle for an existing seed file, returning the
+// underlying OPFS error (e.g. a NotFoundError) when the file or one of its
+// parent directories is absent.
+func openSeedFile(path string) (js.Value, error) {
+	dir, file, err := opfsSeedDir(path, false)
+	if err != nil {
+		return js.Value{}, err
+	}
+
+	return awaitJSPromise(
+		dir.Call(
+			"getFileHandle", file, map[string]any{
+				"create": false,
+			},
+		),
 	)
+}
+
+// SaveEncryptedSeed writes the encrypted seed ciphertext to its OPFS file. The
+// payload is already password-encrypted by EncryptSeed before this boundary.
+func SaveEncryptedSeed(path string, ciphertext []byte) error {
+	dir, file, err := opfsSeedDir(path, true)
+	if err != nil {
+		return fmt.Errorf("opening seed directory for %q: %w", path,
+			err)
+	}
+
+	handle, err := awaitJSPromise(
+		dir.Call(
+			"getFileHandle", file, map[string]any{
+				"create": true,
+			},
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("creating seed file %q: %w", path, err)
+	}
+
+	writable, err := awaitJSPromise(handle.Call("createWritable"))
+	if err != nil {
+		return fmt.Errorf("opening seed file %q for write: %w", path,
+			err)
+	}
+
+	buf := js.Global().Get("Uint8Array").New(len(ciphertext))
+	js.CopyBytesToJS(buf, ciphertext)
+
+	// A writable stream holds an exclusive lock on the file until it is
+	// closed, so close it unconditionally even when the write fails;
+	// otherwise the leaked lock blocks later reads and writes until the
+	// stream is garbage-collected. The write error takes precedence.
+	_, writeErr := awaitJSPromise(writable.Call("write", buf))
+	_, closeErr := awaitJSPromise(writable.Call("close"))
+
+	if writeErr != nil {
+		return fmt.Errorf("writing seed file %q: %w", path, writeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("closing seed file %q: %w", path, closeErr)
+	}
 
 	return nil
 }
 
-// LoadEncryptedSeed reads the encrypted seed ciphertext from browser
-// localStorage.
+// LoadEncryptedSeed reads the encrypted seed ciphertext from its OPFS file.
 func LoadEncryptedSeed(path string) ([]byte, error) {
-	storage := js.Global().Get("localStorage")
-	if storage.IsUndefined() || storage.IsNull() {
-		return nil, fmt.Errorf("browser localStorage is unavailable")
-	}
-
-	value := storage.Call("getItem", wasmSeedStoragePrefix+path)
-	if value.IsNull() || value.IsUndefined() {
-		return nil, fmt.Errorf("reading seed file %q: not found", path)
-	}
-
-	data, err := base64.StdEncoding.DecodeString(value.String())
+	handle, err := openSeedFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("decode seed file %q: %w", path, err)
+		return nil, fmt.Errorf("reading seed file %q: %w", path, err)
 	}
+
+	fileObj, err := awaitJSPromise(handle.Call("getFile"))
+	if err != nil {
+		return nil, fmt.Errorf("opening seed file %q: %w", path, err)
+	}
+
+	bufVal, err := awaitJSPromise(fileObj.Call("arrayBuffer"))
+	if err != nil {
+		return nil, fmt.Errorf("reading seed file %q: %w", path, err)
+	}
+
+	arr := js.Global().Get("Uint8Array").New(bufVal)
+	data := make([]byte, arr.Get("length").Int())
+	js.CopyBytesToGo(data, arr)
 
 	return data, nil
 }
 
-// SeedFileExists returns true if an encrypted seed exists in browser
-// localStorage for the network data directory.
+// SeedFileExists returns true if an encrypted seed file exists in OPFS for the
+// network data directory.
 func SeedFileExists(networkDir string) bool {
-	path := SeedFilePath(networkDir)
-	storage := js.Global().Get("localStorage")
-	if storage.IsUndefined() || storage.IsNull() {
-		return false
-	}
+	_, err := openSeedFile(SeedFilePath(networkDir))
 
-	value := storage.Call("getItem", wasmSeedStoragePrefix+path)
-
-	return !value.IsNull() && !value.IsUndefined()
+	return err == nil
 }

--- a/darepod/seed_storage_wasm.go
+++ b/darepod/seed_storage_wasm.go
@@ -13,11 +13,12 @@ import (
 // system (OPFS). OPFS is reachable from both the window and worker globals,
 // unlike localStorage which is window-only, so the daemon can run inside a Web
 // Worker. SeedFilePath produces a "/dir/dir/wallet_seed.enc" path; it is split
-// on "/" and walked as OPFS directory handles, placing the seed alongside the
-// daemon's other OPFS data. These functions block the calling goroutine on the
-// async OPFS promises, so they keep their synchronous signatures; they must run
-// off the JS call stack (the verb goroutines spawned by promise() satisfy
-// this).
+// on "/" and walked as OPFS directory handles, persisting the seed at that
+// nested path in the OPFS origin (the daemon's SQLite data is stored
+// separately, under hashed flat names at the OPFS root). These functions block
+// the calling goroutine on the async OPFS promises, so they keep their
+// synchronous signatures; they must run off the JS call stack (the verb
+// goroutines spawned by promise() satisfy this).
 
 // errOPFSUnavailable is returned when the OPFS API is absent from the current
 // JS context. This is a deterministic capability gap rather than a transient
@@ -48,7 +49,8 @@ func isNotFound(err error) bool {
 
 // awaitJSPromise blocks the calling goroutine until the JS promise settles and
 // returns its resolved value, or an error built from the rejection reason. The
-// channel is buffered so the settle callback never blocks the JS event loop.
+// channel is buffered so the settle callback never blocks the JS event loop. p
+// must be a thenable (a real Promise); every OPFS caller here passes one.
 func awaitJSPromise(p js.Value) (js.Value, error) {
 	type settled struct {
 		value js.Value

--- a/sdk/walletdk/client.go
+++ b/sdk/walletdk/client.go
@@ -220,6 +220,26 @@ func (c *Client) CreateWallet(ctx context.Context, req CreateWalletRequest) (
 	}, nil
 }
 
+// initFromMnemonic runs the daemon InitWallet step for an already-derived
+// mnemonic, returning the daemon identity pubkey. The passkey import path uses
+// it; CreateWallet inlines its own InitWallet call.
+func (c *Client) initFromMnemonic(ctx context.Context, mnemonic []string,
+	seedPassphrase, walletPassword []byte) (string, error) {
+
+	initResp, err := c.daemon.InitWallet(ctx,
+		&daemonrpc.InitWalletRequest{
+			Mnemonic:       mnemonic,
+			SeedPassphrase: bytes.Clone(seedPassphrase),
+			WalletPassword: bytes.Clone(walletPassword),
+		},
+	)
+	if err != nil {
+		return "", fmt.Errorf("initialize wallet: %w", err)
+	}
+
+	return initResp.GetIdentityPubkey(), nil
+}
+
 // UnlockWallet unlocks an existing embedded daemon wallet.
 func (c *Client) UnlockWallet(ctx context.Context, req UnlockWalletRequest) (
 	*UnlockWalletResult, error) {

--- a/sdk/walletdk/mobile/passkey.go
+++ b/sdk/walletdk/mobile/passkey.go
@@ -1,0 +1,42 @@
+//go:build mobile && walletdkrpc && swapruntime
+
+package mobile
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+// OpenWalletFromPasskey imports or unlocks the embedded wallet from a WebAuthn
+// passkey PRF output. reqJSON decodes to a {prfOutput} object carrying the
+// hex-encoded PRF bytes the host obtained from the passkey ceremony; the
+// response is walletdk.OpenWalletResult. The PRF→seed derivation stays in Go so
+// the wasm and gomobile bindings share one source of truth and the browser
+// never handles raw seed material.
+func OpenWalletFromPasskey(reqJSON []byte) ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req struct {
+		// PRFOutput is the hex-encoded WebAuthn PRF assertion output.
+		// The JSON key matches the camelCase the browser bridge sends.
+		PRFOutput string `json:"prfOutput"`
+	}
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	prf, err := hex.DecodeString(req.PRFOutput)
+	if err != nil {
+		return nil, fmt.Errorf("decode passkey prf output: %w", err)
+	}
+
+	res, err := client.OpenWalletFromPasskey(ctx, prf)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(res)
+}

--- a/sdk/walletdk/passkey.go
+++ b/sdk/walletdk/passkey.go
@@ -1,0 +1,158 @@
+package walletdk
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/lightningnetwork/lnd/aezeed"
+	"golang.org/x/crypto/hkdf"
+)
+
+// hkdfSeedInfo and hkdfDBKeyInfo domain-separate the two secrets pulled from
+// one PRF output.
+const (
+	hkdfSeedInfo  = "walletdk:seed:v1"
+	hkdfDBKeyInfo = "walletdk:dbpw:v1"
+)
+
+// OpenWalletFromPasskey derives a reproducible wallet from a passkey's PRF
+// output and either imports it (fresh device) or unlocks it (wallet already
+// present locally). passkeyPRFOutput is the raw bytes from the platform's
+// WebAuthn PRF evaluation; the ceremony itself lives in the platform layer.
+//
+// The entire wallet seed is HKDF(passkeyPRFOutput), so the caller MUST run
+// the PRF ceremony with a fixed, app-controlled PRF input (the WebAuthn prf
+// evaluation salt) that is identical on every device and every call for a
+// given wallet. If that input ever varies, the same passkey yields a
+// different seed, and the wallet and its funds become unrecoverable.
+func (c *Client) OpenWalletFromPasskey(ctx context.Context,
+	passkeyPRFOutput []byte) (*OpenWalletResult, error) {
+
+	// WebAuthn PRF evaluations are at least 32 bytes. Reject anything
+	// shorter so a caller bug or empty input cannot derive a fixed,
+	// publicly-known seed and silently import an attacker-reproducible
+	// wallet.
+	if len(passkeyPRFOutput) < 32 {
+		return nil, fmt.Errorf("passkey prf output too short: got %d "+
+			"bytes, need at least 32", len(passkeyPRFOutput))
+	}
+
+	entropy, dbPassword := deriveSeedAndPassword(passkeyPRFOutput)
+
+	// Read the current wallet lifecycle state so we can decide whether to
+	// import a fresh seed or unlock an existing local wallet.
+	info, err := c.GetInfo(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read wallet state: %w", err)
+	}
+
+	switch info.WalletState {
+	case WalletStateNone:
+		return c.createWalletFromEntropy(ctx, entropy, dbPassword)
+
+	case WalletStateLocked:
+		unlock, err := c.UnlockWallet(ctx, UnlockWalletRequest{
+			WalletPassword: dbPassword,
+		})
+		// UnlockWallet already wraps with "unlock wallet:".
+		if err != nil {
+			return nil, err
+		}
+
+		return &OpenWalletResult{
+			Imported:       false,
+			IdentityPubKey: unlock.IdentityPubKey,
+		}, nil
+
+	case WalletStateReady, WalletStateSyncing:
+		// A wallet is already open. The daemon exposes no way to
+		// confirm it was derived from the presented passkey, so
+		// opening it again is treated as an error. The password path
+		// does the same: InitWallet and UnlockWallet both error once
+		// the wallet is unlocked.
+		return nil, fmt.Errorf("wallet is already unlocked")
+
+	default:
+		return nil, fmt.Errorf("unexpected wallet state %v: cannot "+
+			"open wallet", info.WalletState)
+	}
+}
+
+// createWalletFromEntropy builds the deterministic aezeed and initializes a new
+// local wallet from it.
+func (c *Client) createWalletFromEntropy(ctx context.Context,
+	entropy [aezeed.EntropySize]byte, dbPassword []byte) (*OpenWalletResult,
+	error) {
+
+	mnemonic, err := entropyToMnemonic(entropy)
+	if err != nil {
+		return nil, fmt.Errorf("derive mnemonic: %w", err)
+	}
+
+	// The passkey seed is reproducible from entropy alone, so the seed
+	// passphrase must stay empty to match deriveSeedAndPassword's contract.
+	words := mnemonic[:]
+	identity, err := c.initFromMnemonic(ctx, words, nil, dbPassword)
+	if err != nil {
+		return nil, fmt.Errorf("init wallet from mnemonic: %w", err)
+	}
+
+	return &OpenWalletResult{
+		Imported:       true,
+		Mnemonic:       append([]string(nil), words...),
+		IdentityPubKey: identity,
+	}, nil
+}
+
+// deriveSeedAndPassword expands a passkey's PRF output into the 16-byte wallet
+// entropy and a local DB password. The DB password only protects the device's
+// local database, so it need not match across devices; deriving it here just
+// means a passkey wallet never prompts for a password.
+func deriveSeedAndPassword(passkeyPRFOutput []byte) ([aezeed.EntropySize]byte,
+	[]byte) {
+
+	// HKDF-SHA256 ReadFull never errors for these fixed-size reads (both
+	// outputs are well under the 255*HashLen HKDF limit), so the errors
+	// are safe to ignore for both the seed and DB-password expansions.
+	var entropy [aezeed.EntropySize]byte
+	seedReader := hkdf.New(
+		sha256.New, passkeyPRFOutput, nil, []byte(hkdfSeedInfo),
+	)
+	_, _ = io.ReadFull(seedReader, entropy[:])
+
+	var raw [32]byte
+	pwReader := hkdf.New(
+		sha256.New, passkeyPRFOutput, nil, []byte(hkdfDBKeyInfo),
+	)
+	_, _ = io.ReadFull(pwReader, raw[:])
+
+	// Encode into a preallocated slice rather than via hex.EncodeToString,
+	// which would also hold the DB key as an intermediate string copy that
+	// cannot be cleared and lingers until GC.
+	dbPassword := make([]byte, hex.EncodedLen(len(raw)))
+	hex.Encode(dbPassword, raw[:])
+
+	return entropy, dbPassword
+}
+
+// entropyToMnemonic builds a reproducible aezeed mnemonic from fixed entropy.
+// Version and birthday are pinned so the wallet depends only on the entropy.
+// Note: each call returns a different 24-word string because it constructs a
+// fresh aezeed with a newly drawn random salt; every such string deciphers back
+// to the same entropy, and therefore the same HD wallet. Birthday sets rescan
+// depth, not derived keys; pinning it avoids leaking a real creation time. The
+// passphrase is empty so the seed is reproducible from entropy alone — callers
+// MUST pass the same empty passphrase to InitWallet.
+func entropyToMnemonic(entropy [aezeed.EntropySize]byte) (aezeed.Mnemonic,
+	error) {
+
+	cipherSeed, err := aezeed.New(0, &entropy, aezeed.BitcoinGenesisDate)
+	if err != nil {
+		return aezeed.Mnemonic{}, err
+	}
+
+	return cipherSeed.ToMnemonic(nil)
+}

--- a/sdk/walletdk/passkey_test.go
+++ b/sdk/walletdk/passkey_test.go
@@ -1,0 +1,412 @@
+package walletdk
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightningnetwork/lnd/aezeed"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// stubDaemonServer is a minimal DaemonServiceServer that records which
+// wallet-bootstrap RPCs OpenWalletFromPasskey drives for a given wallet state.
+type stubDaemonServer struct {
+	daemonrpc.UnimplementedDaemonServiceServer
+
+	state         daemonrpc.WalletState
+	identity      string
+	initErr       error
+	unlockErr     error
+	initCalled    bool
+	unlockCalled  bool
+	lastInitReq   *daemonrpc.InitWalletRequest
+	lastUnlockReq *daemonrpc.UnlockWalletRequest
+}
+
+// GetInfo reports the configured wallet state so the SDK can branch between
+// import and unlock.
+func (s *stubDaemonServer) GetInfo(context.Context, *daemonrpc.GetInfoRequest) (
+	*daemonrpc.GetInfoResponse, error) {
+
+	return &daemonrpc.GetInfoResponse{
+		WalletState:    s.state,
+		IdentityPubkey: s.identity,
+	}, nil
+}
+
+// InitWallet records the import call and its request, then returns the
+// configured error (if any) so error propagation can be exercised.
+func (s *stubDaemonServer) InitWallet(_ context.Context,
+	req *daemonrpc.InitWalletRequest) (*daemonrpc.InitWalletResponse,
+	error) {
+
+	s.initCalled = true
+	s.lastInitReq = req
+	if s.initErr != nil {
+		return nil, s.initErr
+	}
+
+	return &daemonrpc.InitWalletResponse{IdentityPubkey: "init-id"}, nil
+}
+
+// UnlockWallet records the unlock call, then returns the configured error (if
+// any) so unlock-failure propagation can be exercised.
+func (s *stubDaemonServer) UnlockWallet(_ context.Context,
+	req *daemonrpc.UnlockWalletRequest) (*daemonrpc.UnlockWalletResponse,
+	error) {
+
+	s.unlockCalled = true
+	s.lastUnlockReq = req
+	if s.unlockErr != nil {
+		return nil, s.unlockErr
+	}
+
+	return &daemonrpc.UnlockWalletResponse{IdentityPubkey: "unlock-id"}, nil
+}
+
+// newStubClient wires a walletdk Client to an in-process stub daemon over a
+// private bufconn gRPC transport, mirroring the embedded build's wiring.
+func newStubClient(t *testing.T, stub *stubDaemonServer) *Client {
+	t.Helper()
+
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer()
+	daemonrpc.RegisterDaemonServiceServer(server, stub)
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(server.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (
+			net.Conn, error) {
+
+			return listener.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(
+			insecure.NewCredentials(),
+		),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return newClient(
+		conn, true, closedWaitChan(),
+		func(context.Context) error { return conn.Close() },
+	)
+}
+
+// TestDeriveSeedAndPasswordDeterministic checks that the same PRF output always
+// yields the same entropy and DB password, and different PRF output does not.
+func TestDeriveSeedAndPasswordDeterministic(t *testing.T) {
+	t.Parallel()
+
+	prfA := []byte("00000000000000000000000000000000")
+	prfB := []byte("11111111111111111111111111111111")
+
+	e1, p1 := deriveSeedAndPassword(prfA)
+	e2, p2 := deriveSeedAndPassword(prfA)
+	e3, p3 := deriveSeedAndPassword(prfB)
+
+	require.Equal(t, e1, e2, "entropy must be stable for one PRF output")
+	require.Equal(t, p1, p2, "password must be stable for one PRF output")
+	require.NotEqual(
+		t, e1, e3, "entropy must differ for different PRF output",
+	)
+	require.NotEqual(
+		t, p1, p3, "password must differ for different PRF output",
+	)
+
+	require.Len(t, p1, 64)
+	_, err := hex.DecodeString(string(p1))
+	require.NoError(t, err)
+
+	// Confirm the two HKDF info labels actually produce independent
+	// outputs: the password's leading bytes must not equal the entropy.
+	rawPW, err := hex.DecodeString(string(p1))
+	require.NoError(t, err)
+	require.NotEqual(
+		t, e1[:], rawPW[:len(e1)],
+		"entropy and password must be domain-separated",
+	)
+}
+
+// TestDeriveSeedAndPasswordGoldenVector pins the HKDF derivation, including the
+// hkdfSeedInfo/hkdfDBKeyInfo info labels, to fixed output. Those labels are
+// wire-format constants: silently editing one changes every derived seed and
+// bricks existing passkey wallets, so any such change must fail here loudly.
+func TestDeriveSeedAndPasswordGoldenVector(t *testing.T) {
+	t.Parallel()
+
+	prf := make([]byte, 32)
+	for i := range prf {
+		prf[i] = byte(i)
+	}
+
+	entropy, dbPassword := deriveSeedAndPassword(prf)
+
+	require.Equal(
+		t, "6ad5679bd637393ebe56c19abf44756a",
+		hex.EncodeToString(entropy[:]),
+	)
+	require.Equal(
+		t, "d9fc4929726454ad8c70c6d38c8d2c96dd93573c6c8822050b0f31bc"+
+			"5954f8ae", string(dbPassword),
+	)
+}
+
+// TestEntropyToMnemonicRoundTrip checks the derived aezeed deciphers back to
+// the exact entropy it was built from, so the same entropy always reaches the
+// same HD wallet even though the 24-word string varies per call (random salt).
+func TestEntropyToMnemonicRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var entropy [aezeed.EntropySize]byte
+	copy(entropy[:], "walletdk-fixed-e") // exactly 16 bytes
+
+	mnemonic, err := entropyToMnemonic(entropy)
+	require.NoError(t, err)
+	require.Len(t, mnemonic, aezeed.NumMnemonicWords)
+
+	cipherSeed, err := mnemonic.ToCipherSeed(nil)
+	require.NoError(t, err)
+	require.Equal(t, entropy, cipherSeed.Entropy)
+}
+
+// TestEntropyToMnemonicVariesPerCall confirms the documented behavior: the same
+// entropy yields different 24-word strings across calls (random KDF salt), yet
+// every string deciphers back to the same entropy and thus the same wallet.
+func TestEntropyToMnemonicVariesPerCall(t *testing.T) {
+	t.Parallel()
+
+	var entropy [aezeed.EntropySize]byte
+	copy(entropy[:], "walletdk-fixed-e")
+
+	m1, err := entropyToMnemonic(entropy)
+	require.NoError(t, err)
+	m2, err := entropyToMnemonic(entropy)
+	require.NoError(t, err)
+
+	require.NotEqual(t, m1, m2, "mnemonic must vary due to random KDF salt")
+
+	cs1, err := m1.ToCipherSeed(nil)
+	require.NoError(t, err)
+	cs2, err := m2.ToCipherSeed(nil)
+	require.NoError(t, err)
+	require.Equal(t, entropy, cs1.Entropy)
+	require.Equal(t, entropy, cs2.Entropy)
+}
+
+// TestOpenWalletFromPasskeyImportsWhenNone verifies a fresh device (no wallet)
+// triggers a deterministic InitWallet import.
+func TestOpenWalletFromPasskeyImportsWhenNone(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubDaemonServer{
+		state:    daemonrpc.WalletState_WALLET_STATE_NONE,
+		identity: "init-id",
+	}
+	client := newStubClient(t, stub)
+
+	prf := []byte("prf-output-bytes-0123456789abcdef")
+	res, err := client.OpenWalletFromPasskey(context.Background(), prf)
+	require.NoError(t, err)
+	require.True(t, stub.initCalled)
+	require.False(t, stub.unlockCalled)
+	require.True(t, res.Imported)
+	require.Len(t, res.Mnemonic, 24)
+	require.Equal(t, "init-id", res.IdentityPubKey)
+
+	// The derived DB password must reach InitWallet so a fresh device and a
+	// re-importing device produce the same locally-encrypted wallet.
+	_, wantDBPassword := deriveSeedAndPassword(prf)
+	require.Equal(t, wantDBPassword, stub.lastInitReq.WalletPassword)
+}
+
+// TestOpenWalletFromPasskeyUnlocksWhenLocked verifies an existing local wallet
+// is unlocked, not re-created.
+func TestOpenWalletFromPasskeyUnlocksWhenLocked(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubDaemonServer{
+		state:    daemonrpc.WalletState_WALLET_STATE_LOCKED,
+		identity: "unlock-id",
+	}
+	client := newStubClient(t, stub)
+
+	prf := []byte("prf-output-bytes-0123456789abcdef")
+	res, err := client.OpenWalletFromPasskey(context.Background(), prf)
+	require.NoError(t, err)
+	require.True(t, stub.unlockCalled)
+	require.False(t, stub.initCalled)
+	require.False(t, res.Imported)
+	require.Equal(t, "unlock-id", res.IdentityPubKey)
+
+	// The same derived DB password must drive unlock, so the device that
+	// imported the wallet can later unlock it from the same passkey.
+	_, wantDBPassword := deriveSeedAndPassword(prf)
+	require.Equal(t, wantDBPassword, stub.lastUnlockReq.WalletPassword)
+}
+
+// TestOpenWalletFromPasskeyErrorsWhenAlreadyUnlocked verifies that opening a
+// passkey wallet when one is already unlocked returns an error and issues no
+// import or unlock RPC, for both the ready and still-syncing states.
+func TestOpenWalletFromPasskeyErrorsWhenAlreadyUnlocked(t *testing.T) {
+	t.Parallel()
+
+	states := []daemonrpc.WalletState{
+		daemonrpc.WalletState_WALLET_STATE_READY,
+		daemonrpc.WalletState_WALLET_STATE_SYNCING,
+	}
+	for _, state := range states {
+		t.Run(state.String(), func(t *testing.T) {
+			t.Parallel()
+
+			stub := &stubDaemonServer{
+				state:    state,
+				identity: "open-id",
+			}
+			client := newStubClient(t, stub)
+
+			_, err := client.OpenWalletFromPasskey(
+				context.Background(),
+				[]byte("prf-output-bytes-0123456789abcdef"),
+			)
+			require.Error(t, err)
+			require.False(t, stub.initCalled)
+			require.False(t, stub.unlockCalled)
+		})
+	}
+}
+
+// TestOpenWalletFromPasskeyErrorsOnUnexpectedState verifies an unspecified
+// wallet state returns an error and issues no import or unlock RPC.
+func TestOpenWalletFromPasskeyErrorsOnUnexpectedState(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubDaemonServer{
+		state: daemonrpc.WalletState_WALLET_STATE_UNSPECIFIED,
+	}
+	client := newStubClient(t, stub)
+
+	_, err := client.OpenWalletFromPasskey(
+		context.Background(),
+		[]byte("prf-output-bytes-0123456789abcdef"),
+	)
+	require.Error(t, err)
+	require.False(t, stub.initCalled)
+	require.False(t, stub.unlockCalled)
+}
+
+// TestOpenWalletFromPasskeyRejectsShortPRF verifies a too-short PRF output is
+// rejected before any derivation or wallet bootstrap runs, so a caller bug or
+// empty input cannot import a fixed, publicly-known seed. 31 bytes is the
+// boundary just below the 32-byte minimum.
+func TestOpenWalletFromPasskeyRejectsShortPRF(t *testing.T) {
+	t.Parallel()
+
+	for _, n := range []int{0, 9, 31} {
+		t.Run(fmt.Sprintf("len-%d", n), func(t *testing.T) {
+			t.Parallel()
+
+			stub := &stubDaemonServer{
+				state: daemonrpc.WalletState_WALLET_STATE_NONE,
+			}
+			client := newStubClient(t, stub)
+
+			_, err := client.OpenWalletFromPasskey(
+				context.Background(), make([]byte, n),
+			)
+			require.Error(t, err)
+			require.False(t, stub.initCalled)
+			require.False(t, stub.unlockCalled)
+		})
+	}
+}
+
+// TestOpenWalletFromPasskeyAcceptsMinimumLength verifies the exact 32-byte
+// boundary is accepted and drives a normal import.
+func TestOpenWalletFromPasskeyAcceptsMinimumLength(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubDaemonServer{
+		state:    daemonrpc.WalletState_WALLET_STATE_NONE,
+		identity: "init-id",
+	}
+	client := newStubClient(t, stub)
+
+	res, err := client.OpenWalletFromPasskey(
+		context.Background(), make([]byte, 32),
+	)
+	require.NoError(t, err)
+	require.True(t, stub.initCalled)
+	require.True(t, res.Imported)
+}
+
+// TestOpenWalletFromPasskeyImportUsesEmptySeedPassphrase pins the load-bearing
+// reproducibility invariant: the import path must initialize the wallet with an
+// empty seed passphrase so the seed depends only on the derived entropy.
+func TestOpenWalletFromPasskeyImportUsesEmptySeedPassphrase(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubDaemonServer{
+		state:    daemonrpc.WalletState_WALLET_STATE_NONE,
+		identity: "init-id",
+	}
+	client := newStubClient(t, stub)
+
+	_, err := client.OpenWalletFromPasskey(
+		context.Background(),
+		[]byte("prf-output-bytes-0123456789abcdef"),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, stub.lastInitReq)
+	require.Empty(t, stub.lastInitReq.SeedPassphrase)
+}
+
+// TestOpenWalletFromPasskeyPropagatesInitError verifies an InitWallet failure
+// on the import path surfaces to the caller rather than being swallowed.
+func TestOpenWalletFromPasskeyPropagatesInitError(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubDaemonServer{
+		state:   daemonrpc.WalletState_WALLET_STATE_NONE,
+		initErr: errors.New("init boom"),
+	}
+	client := newStubClient(t, stub)
+
+	_, err := client.OpenWalletFromPasskey(
+		context.Background(),
+		[]byte("prf-output-bytes-0123456789abcdef"),
+	)
+	require.Error(t, err)
+	require.True(t, stub.initCalled)
+}
+
+// TestOpenWalletFromPasskeyPropagatesUnlockError verifies an UnlockWallet
+// failure (e.g. a wrong passkey) on the unlock path surfaces to the caller.
+func TestOpenWalletFromPasskeyPropagatesUnlockError(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubDaemonServer{
+		state:     daemonrpc.WalletState_WALLET_STATE_LOCKED,
+		unlockErr: errors.New("unlock boom"),
+	}
+	client := newStubClient(t, stub)
+
+	_, err := client.OpenWalletFromPasskey(
+		context.Background(),
+		[]byte("prf-output-bytes-0123456789abcdef"),
+	)
+	require.Error(t, err)
+	require.True(t, stub.unlockCalled)
+}

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -124,6 +124,16 @@ type UnlockWalletResult struct {
 	IdentityPubKey string
 }
 
+// OpenWalletResult reports the outcome of OpenWalletFromPasskey. Imported is
+// true when a new local wallet was created from the derived seed (fresh
+// device); false when an existing local wallet was unlocked. Mnemonic is set
+// only on import, for backup display.
+type OpenWalletResult struct {
+	Imported       bool
+	Mnemonic       []string
+	IdentityPubKey string
+}
+
 // Balance is the wallet-level balance view.
 type Balance struct {
 	ConfirmedSat  int64


### PR DESCRIPTION
## Summary

The TS SDKs and the wallet demo app need to create or unlock an embedded wallet from a WebAuthn passkey, deriving the wallet seed from the passkey's PRF output. Keeping that derivation in Go (shared by the js/wasm and gomobile bindings) means the browser never handles raw seed material and every platform derives the *same* wallet from the same passkey. This adds that capability to the `walletdk` SDK and exposes it through the shared mobile/wasm facade.

## Changes

- Add `Client.OpenWalletFromPasskey`: HKDF-expands the PRF output into reproducible aezeed entropy plus a local DB password (domain-separated `:v1` labels), then imports on a fresh device or unlocks an existing local wallet. Derivation lives in `sdk/walletdk/passkey.go`.
- Fail closed on misuse: reject too-short PRF inputs (`< 32` bytes) before any derivation, and error on an already-open wallet, matching the password path.
- Expose the verb through the shared FFI facade (`mobile.OpenWalletFromPasskey`, JSON in/out) and wire the `openWalletFromPasskey` case into the `cmd/walletdk-wasm` browser bridge, so the gomobile and wasm bindings share one derivation source of truth.
- Add the `OpenWalletResult` DTO and a test suite: derivation determinism/domain-separation, a golden HKDF vector pinning the `:v1` labels, import/unlock/already-unlocked/short-PRF paths, RPC-error propagation, and the empty-seed-passphrase reproducibility invariant.

## Testing

- `make unit pkg=sdk/walletdk`: all derivation, state-branch, and error-path tests pass.
- `GOOS=js GOARCH=wasm` build of `cmd/walletdk-wasm` confirms the facade verb compiles into the browser bridge.
- End-to-end passkey create/unlock exercised by the demo app in the consuming TS SDK repo (separate `dawallet` repo).
