### PR TITLE
swaps: add durable credit payment intents

### DIFF
--- a/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
@@ -361,6 +361,27 @@ func generatedRegistry() []serviceSpec {
 					Comments: "StartReceive starts a Lightning-to-Ark receive swap and lets the daemon\ncontinue the claim flow after the invoice is paid.",
 				},
 				{
+					Name:     "CreateCredit",
+					Aliases:  []string{"create-credit"},
+					Input:    "swapclientrpc.CreateCreditRequest",
+					Output:   "swapclientrpc.CreateCreditResponse",
+					Comments: "CreateCredit starts a durable credit funding session.",
+				},
+				{
+					Name:     "RedeemCredit",
+					Aliases:  []string{"redeem-credit"},
+					Input:    "swapclientrpc.RedeemCreditRequest",
+					Output:   "swapclientrpc.RedeemCreditResponse",
+					Comments: "RedeemCredit materializes available credits back into an Ark output.",
+				},
+				{
+					Name:     "ListCredits",
+					Aliases:  []string{"list-credits"},
+					Input:    "swapclientrpc.ListCreditsRequest",
+					Output:   "swapclientrpc.ListCreditsResponse",
+					Comments: "ListCredits returns the server-authoritative credit account snapshot.",
+				},
+				{
 					Name:     "ResumeSwap",
 					Aliases:  []string{"resume-swap"},
 					Input:    "swapclientrpc.ResumeSwapRequest",

--- a/docs/credit_system.md
+++ b/docs/credit_system.md
@@ -1,0 +1,284 @@
+# Credit System
+
+Credits are a server-held sat balance for one wallet identity. They let a
+wallet handle Lightning amounts that cannot safely become an Ark vTXO yet,
+without changing the operator dust limit.
+
+A credit is not a vTXO. A vTXO is a sat-denominated Ark output that can be
+refreshed, transferred, exited, or used to fund a virtual HTLC. It must clear
+the operator dust limit. A credit is a row in the swap server ledger. The
+server keys that ledger by the wallet identity public key, reserves credits
+before using them, and writes ledger entries when value is credited or debited.
+
+Lightning can carry millisatoshi amounts. The client and server keep those
+msats at the invoice and HTLC validation boundary. When value enters the credit
+ledger, the server rounds it up to sats and accounts for it as sats from then
+on.
+
+The server ledger is authoritative. Local client state records what the wallet
+asked for and what it already started, but `ListCredits` is the source of truth
+after a retry or restart.
+
+```mermaid
+flowchart LR
+    LN["Lightning invoice settlement"] --> S["swap server"]
+    ARK["Ark top-up OOR"] --> S
+    S -->|"ledger credit"| C["credit account<br/>wallet identity key"]
+    C -->|"reserve and debit"| PAY["credit-backed Lightning pay"]
+    C -->|"attach to receive"| RX["dust-clearing receive vHTLC"]
+```
+
+## Account Model
+
+| Field | Unit | Meaning |
+|---|---:|---|
+| `finalized_sat` | sat | Credits minus finalized debits in the server ledger. |
+| `reserved_sat` | sat | Active holds for pay, receive, or redemption operations. |
+| `available_sat` | sat | Balance the server can reserve now. |
+| `amount_sat` | sat | Amount used by funding, pay, receive, and redemption operations. |
+
+The server enforces the balance invariant transactionally:
+
+```text
+available_sat = finalized_sat - finalized_debits_sat - reserved_sat
+```
+
+No operation can move the account negative. Reusing the same idempotency key
+with the same operation parameters returns the existing operation; reusing it
+with different parameters is rejected.
+
+## Client Layers
+
+Wallet-facing callers use `walletdk`. Credit details are folded into `Receive`,
+`PrepareSend`, `Send`, and `Balance`.
+
+Raw callers can use `sdk/swaps` and `swapclientrpc` directly:
+
+- `CreateCredit`: create a server-owned Lightning receive invoice or Ark top-up
+  intent.
+- `ListCredits`: read balances, operations, and ledger entries.
+- `RedeemCredit`: low-level escape hatch for materializing credits into an Ark
+  output. `walletdk` does not expose or automate redemption for normal wallet
+  flows.
+
+```mermaid
+flowchart TB
+    APP["app / CLI"] --> WDK["sdk/walletdk"]
+    WDK --> WRPC["walletdkrpc"]
+    WRPC --> WW["swapwallet"]
+    WW --> SCRPC["swapclientrpc"]
+    SCRPC --> SCS["swapclientserver"]
+    SCS --> RAW["sdk/swaps"]
+    RAW --> SWAPD["swap server"]
+    APP -. "advanced callers" .-> RAW
+```
+
+## Receives
+
+The receive planner decides whether a requested Lightning receive can become a
+normal vHTLC, must become credits, or can attach existing credits to clear the
+dust limit.
+
+| Condition | Rail | Result |
+|---|---|---|
+| `requested_amount_sat >= dust_limit_sat` | normal | Server funds a vHTLC for the requested amount. |
+| `requested_amount_sat < dust_limit_sat` and `requested + available < dust` | credit | Server creates a credit receive invoice. No vHTLC is created. |
+| `requested_amount_sat < dust_limit_sat` and `requested + available >= dust` | credit-assisted | Server reserves all available credits and funds a vHTLC for `requested + attached_credit_sat`. |
+
+For credit-assisted receives, the server attaches all currently available
+credits, not only the shortfall needed to reach dust. The quote/prepare surface
+returns the full plan:
+
+| Field | Meaning |
+|---|---|
+| `requested_amount_sat` | Lightning invoice amount requested by the wallet. |
+| `available_credit_sat` | Server balance considered by the planner. |
+| `attached_credit_sat` | Credits reserved and added to the receive vHTLC. |
+| `vhtlc_amount_sat` | Amount the client must see in the funded vHTLC. |
+| `dust_limit_sat` | Operator dust limit used for the decision. |
+| `settlement_type` | `LIGHTNING`, `CREDIT`, or `MIXED`. |
+
+```mermaid
+flowchart TD
+    A["Receive(requested_amount_sat)"] --> B{"requested >= dust?"}
+    B -->|"yes"| N["normal receive"]
+    B -->|"no"| C{"requested + available_credit >= dust?"}
+    C -->|"no"| R["credit receive invoice"]
+    C -->|"yes"| M["credit-assisted receive"]
+    M --> V["reserve all available credits"]
+    V --> H["expect vHTLC = requested + attached_credit"]
+```
+
+The swap server includes `requested_amount_sat` and `attached_credit_sat` in the
+HTLC event sent to the client. The raw receive FSM verifies three values before
+accepting that event:
+
+- the event payment hash matches the invoice,
+- the event requested amount matches the invoice amount,
+- the funded vHTLC amount equals `requested_amount_sat + attached_credit_sat`.
+
+The onion payload still validates against the Lightning invoice amount. Attached
+credits are Ark-side value added to the vHTLC, not part of the payer's
+Lightning invoice.
+
+## Sends
+
+The public send API stays the same: callers use `PrepareSend`, display the
+preview, and call `Send` with the prepared intent id. There is no public
+`PayWithCredit` RPC.
+
+`PrepareSend` asks the swap server for a pay quote. The quote chooses the rail:
+
+| Rail | Meaning |
+|---|---|
+| `LIGHTNING` | Normal in-swap. The wallet funds the vHTLC. |
+| `CREDIT` | Server pays the Lightning invoice from a credit reservation. No vHTLC is funded. |
+| `MIXED` | Credits cover part of the invoice. The wallet funds the remaining vHTLC amount. |
+
+`CreditPreview` and `credit_quote` use sats:
+
+| Field | Meaning |
+|---|---|
+| `must_use_credit` | This payment must use credits, such as a sub-dust invoice. |
+| `credit_applied_sat` | Credits the server expects to reserve. |
+| `credit_shortfall_sat` | More credits needed before the payment can start. |
+| `credit_topup_sat` | Ark top-up amount needed to cover the shortfall. |
+| `ark_funding_sat` | vHTLC amount still funded by the wallet. |
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Wallet as walletdk / swapwallet
+    participant Swap as swapclientserver
+    participant Server as swap server
+
+    App->>Wallet: PrepareSend(invoice)
+    Wallet->>Swap: QuotePay(max_credit_sat = unlimited)
+    Swap->>Server: QuoteInSwap(max_credit_sat)
+    Server-->>Wallet: rail and credit_quote
+    Wallet-->>App: prepared intent and CreditPreview
+    App->>Wallet: Send(intent_id)
+    alt quote had credit_shortfall_sat
+        Wallet->>Swap: CreateCredit(ARK_TOPUP, credit_topup_sat)
+        Wallet->>Wallet: fund OOR top-up and wait for CREDITED
+    end
+    Wallet->>Swap: StartPay(invoice, max_credit_sat)
+    Swap->>Server: CreateInSwap(max_credit_sat)
+```
+
+For a sub-dust invoice, the quote sets `must_use_credit=true`. If the account
+lacks enough credits, `PrepareSend` shows the required Ark top-up and `Send`
+performs that top-up before starting the credit-backed pay.
+
+For a mixed payment, credits cover only the shortfall. For example, a wallet
+with a 1,000 sat vTXO and 200 sat of credits can pay a 1,200 sat invoice. The
+quote reserves 200 sat of credits and asks the wallet to fund the remaining
+amount through the normal pay flow, plus any swap fee.
+
+## Funding Credits
+
+Credits materialize only after real value reaches the server.
+
+### Lightning Receive
+
+A credit receive creates a server-owned Lightning invoice. When that invoice
+settles, the server rounds the settled msat amount up to sats and credits the
+wallet identity account.
+
+```mermaid
+sequenceDiagram
+    participant Wallet as walletdk / swapwallet
+    participant Swap as swapclientserver
+    participant Server as swap server
+    participant Payer as Lightning payer
+
+    Wallet->>Swap: CreateCredit(LIGHTNING_RECEIVE, amount_sat)
+    Swap->>Server: CreateCredit
+    Server-->>Wallet: invoice, operation_id, payment_hash
+    Payer->>Server: pay invoice
+    Server->>Server: finalize sat credit ledger entry
+    Wallet->>Swap: ListCredits or Balance
+    Swap-->>Wallet: available_sat includes receive
+```
+
+### Ark Top-Up
+
+When a send needs more credits than the account has, `Send` creates an Ark
+top-up intent, sends an OOR transfer to the server destination, and waits until
+the server marks the operation credited.
+
+```mermaid
+sequenceDiagram
+    participant Wallet as walletdk / swapwallet
+    participant Swap as swapclientserver
+    participant Daemon as Ark runtime
+    participant Server as swap server
+
+    Wallet->>Swap: CreateCredit(ARK_TOPUP, amount_sat)
+    Swap->>Server: CreateCredit
+    Server-->>Wallet: destination_pubkey, operation_id
+    Wallet->>Daemon: SendOOR(destination_pubkey, amount_sat)
+    Daemon-->>Server: OOR transfer becomes visible
+    Server->>Server: finalize sat credit ledger entry
+    Wallet->>Swap: ListCredits(operation_id)
+    Swap-->>Wallet: operation is CREDITED
+```
+
+## Operation States
+
+Credit operations are durable server state machines. The client renders them as
+server state and reconciles with `ListCredits` after retries or restart.
+
+```mermaid
+flowchart TB
+    subgraph Funding["funding operation"]
+        F0["created"] --> F1["awaiting_payment"]
+        F1 --> F2["credited"]
+        F1 --> F3["expired"]
+        F1 --> F4["failed"]
+    end
+
+    subgraph Pay["pay operation"]
+        P0["reserved"] --> P1["paying_lightning"]
+        P1 --> P2["debited"]
+        P0 --> P3["released"]
+        P1 --> P3
+        P0 --> P4["failed"]
+        P1 --> P4
+    end
+
+    subgraph Receive["credit-assisted receive"]
+        X0["reserved"] --> X1["attached_to_vhtlc"]
+        X1 --> X2["debited"]
+        X0 --> X3["released"]
+        X1 --> X3
+        X0 --> X4["failed"]
+        X1 --> X4
+    end
+
+    subgraph Redemption["low-level redemption"]
+        R0["reserved"] --> R1["sending_oor"]
+        R1 --> R2["redeemed"]
+        R0 --> R3["released"]
+        R1 --> R3
+        R0 --> R4["failed"]
+        R1 --> R4
+    end
+```
+
+`reserved_sat` is the sum of active reservations. It drops when an operation is
+debited, redeemed, released, or failed.
+
+## Restart Rules
+
+Client state machines are progress trackers. The server ledger owns the money.
+
+If the daemon restarts after an Ark top-up but before the invoice pay starts,
+the value is not lost. The caller prepares the send again, the quote sees the
+available credits, and `Send` continues without repeating an already-credited
+top-up.
+
+If the daemon restarts during a credit-assisted receive, the receive session
+reloads the planned `attached_credit_sat` and `vhtlc_amount_sat`. When the HTLC
+event arrives, the FSM validates the funded vHTLC against that plan before it
+claims the vTXO.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ into specific topics below.
 | [oor_subsystem.md](oor_subsystem.md) | The OOR (out-of-round) subsystem: per-session actor model, the `oor_session_registry` single source of truth, the Read/Commit turn with its inline outbox switch, outgoing/incoming flows, crash recovery, and the per-session concurrency fix for issue #605 |
 | [fee_ledger.md](fee_ledger.md) | Client-side double-entry fee ledger: chart of accounts, per-flow walkthroughs, emission sites, replay safety |
 | [fee-change-model.md](fee-change-model.md) | Seal-time fee handshake (#270): change-output designation rules, 11-scenario catalogue, proto contract, CLI mapping |
+| [credit_system.md](credit_system.md) | Sat-native credit accounts for below-dust receives, credit-assisted receives, credit-backed sends, top-ups, and walletdk integration, with mermaid diagrams |
 | [sdk_layered_architecture.md](sdk_layered_architecture.md) | SDK layering rationale: `sdk/ark` facade, remote vs. embedded modes, `sdk/swaps` future direction |
 | [swap_system.md](swap_system.md) | End-to-end swap walkthrough: vHTLC tree (collaborative vs. unilateral-exit leaves), receive (out-swap) and pay (in-swap) flows, the off-chain-first cancellation/timeout recovery ladder, same-Ark p2p detection, swap-server RPCs, and proof-gated indexer authorization, with mermaid diagrams |
 | [walletdk_integration.md](walletdk_integration.md) | Basic `walletdk` integration flow, startup/config examples, swap accounting, and wrapper guidance |

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -186,6 +186,39 @@ func (c *SwapServiceClient) QuoteInSwap(ctx context.Context,
 	return out, err
 }
 
+// CreateCredit creates a server-owned credit funding operation.
+func (c *SwapServiceClient) CreateCredit(ctx context.Context,
+	in *swaprpc.CreateCreditRequest, _ ...grpc.CallOption) (
+	*swaprpc.CreateCreditResponse, error) {
+
+	out := new(swaprpc.CreateCreditResponse)
+	err := c.client.Post(ctx, "/v1/swap/create-credit", in, out)
+
+	return out, err
+}
+
+// RedeemCredit sends available credits back to an Ark recipient.
+func (c *SwapServiceClient) RedeemCredit(ctx context.Context,
+	in *swaprpc.RedeemCreditRequest, _ ...grpc.CallOption) (
+	*swaprpc.RedeemCreditResponse, error) {
+
+	out := new(swaprpc.RedeemCreditResponse)
+	err := c.client.Post(ctx, "/v1/swap/redeem-credit", in, out)
+
+	return out, err
+}
+
+// ListCredits lists server-side credit account state.
+func (c *SwapServiceClient) ListCredits(ctx context.Context,
+	in *swaprpc.ListCreditsRequest, _ ...grpc.CallOption) (
+	*swaprpc.ListCreditsResponse, error) {
+
+	out := new(swaprpc.ListCreditsResponse)
+	err := c.client.Post(ctx, "/v1/swap/list-credits", in, out)
+
+	return out, err
+}
+
 // AuthorizeInSwapRefund asks the swap server to sign a failed in-swap refund.
 func (c *SwapServiceClient) AuthorizeInSwapRefund(ctx context.Context,
 	in *swaprpc.AuthorizeInSwapRefundRequest, _ ...grpc.CallOption) (
@@ -832,6 +865,39 @@ func (c *SwapClientServiceClient) StartPay(ctx context.Context,
 
 	out := new(swapclientrpc.StartPayResponse)
 	err := c.client.Post(ctx, "/v1/swapclient/start-pay", in, out)
+
+	return out, err
+}
+
+// CreateCredit creates a daemon-owned credit funding operation.
+func (c *SwapClientServiceClient) CreateCredit(ctx context.Context,
+	in *swapclientrpc.CreateCreditRequest, _ ...grpc.CallOption) (
+	*swapclientrpc.CreateCreditResponse, error) {
+
+	out := new(swapclientrpc.CreateCreditResponse)
+	err := c.client.Post(ctx, "/v1/swapclient/create-credit", in, out)
+
+	return out, err
+}
+
+// RedeemCredit redeems daemon wallet credits into an Ark output.
+func (c *SwapClientServiceClient) RedeemCredit(ctx context.Context,
+	in *swapclientrpc.RedeemCreditRequest, _ ...grpc.CallOption) (
+	*swapclientrpc.RedeemCreditResponse, error) {
+
+	out := new(swapclientrpc.RedeemCreditResponse)
+	err := c.client.Post(ctx, "/v1/swapclient/redeem-credit", in, out)
+
+	return out, err
+}
+
+// ListCredits lists daemon wallet credit account state.
+func (c *SwapClientServiceClient) ListCredits(ctx context.Context,
+	in *swapclientrpc.ListCreditsRequest, _ ...grpc.CallOption) (
+	*swapclientrpc.ListCreditsResponse, error) {
+
+	out := new(swapclientrpc.ListCreditsResponse)
+	err := c.client.Post(ctx, "/v1/swapclient/list-credits", in, out)
 
 	return out, err
 }

--- a/rpc/swapclientrpc/swap_client.pb.go
+++ b/rpc/swapclientrpc/swap_client.pb.go
@@ -76,6 +76,8 @@ const (
 	SwapSettlementType_SWAP_SETTLEMENT_TYPE_UNSPECIFIED SwapSettlementType = 0
 	SwapSettlementType_SWAP_SETTLEMENT_TYPE_LIGHTNING   SwapSettlementType = 1
 	SwapSettlementType_SWAP_SETTLEMENT_TYPE_IN_ARK      SwapSettlementType = 2
+	SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT      SwapSettlementType = 3
+	SwapSettlementType_SWAP_SETTLEMENT_TYPE_MIXED       SwapSettlementType = 4
 )
 
 // Enum value maps for SwapSettlementType.
@@ -84,11 +86,15 @@ var (
 		0: "SWAP_SETTLEMENT_TYPE_UNSPECIFIED",
 		1: "SWAP_SETTLEMENT_TYPE_LIGHTNING",
 		2: "SWAP_SETTLEMENT_TYPE_IN_ARK",
+		3: "SWAP_SETTLEMENT_TYPE_CREDIT",
+		4: "SWAP_SETTLEMENT_TYPE_MIXED",
 	}
 	SwapSettlementType_value = map[string]int32{
 		"SWAP_SETTLEMENT_TYPE_UNSPECIFIED": 0,
 		"SWAP_SETTLEMENT_TYPE_LIGHTNING":   1,
 		"SWAP_SETTLEMENT_TYPE_IN_ARK":      2,
+		"SWAP_SETTLEMENT_TYPE_CREDIT":      3,
+		"SWAP_SETTLEMENT_TYPE_MIXED":       4,
 	}
 )
 
@@ -117,6 +123,186 @@ func (x SwapSettlementType) Number() protoreflect.EnumNumber {
 // Deprecated: Use SwapSettlementType.Descriptor instead.
 func (SwapSettlementType) EnumDescriptor() ([]byte, []int) {
 	return file_swap_client_proto_rawDescGZIP(), []int{1}
+}
+
+type CreditFundingSource int32
+
+const (
+	CreditFundingSource_CREDIT_FUNDING_SOURCE_UNSPECIFIED       CreditFundingSource = 0
+	CreditFundingSource_CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE CreditFundingSource = 1
+	CreditFundingSource_CREDIT_FUNDING_SOURCE_ARK_TOPUP         CreditFundingSource = 2
+)
+
+// Enum value maps for CreditFundingSource.
+var (
+	CreditFundingSource_name = map[int32]string{
+		0: "CREDIT_FUNDING_SOURCE_UNSPECIFIED",
+		1: "CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE",
+		2: "CREDIT_FUNDING_SOURCE_ARK_TOPUP",
+	}
+	CreditFundingSource_value = map[string]int32{
+		"CREDIT_FUNDING_SOURCE_UNSPECIFIED":       0,
+		"CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE": 1,
+		"CREDIT_FUNDING_SOURCE_ARK_TOPUP":         2,
+	}
+)
+
+func (x CreditFundingSource) Enum() *CreditFundingSource {
+	p := new(CreditFundingSource)
+	*p = x
+	return p
+}
+
+func (x CreditFundingSource) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CreditFundingSource) Descriptor() protoreflect.EnumDescriptor {
+	return file_swap_client_proto_enumTypes[2].Descriptor()
+}
+
+func (CreditFundingSource) Type() protoreflect.EnumType {
+	return &file_swap_client_proto_enumTypes[2]
+}
+
+func (x CreditFundingSource) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CreditFundingSource.Descriptor instead.
+func (CreditFundingSource) EnumDescriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{2}
+}
+
+type CreditOperationType int32
+
+const (
+	CreditOperationType_CREDIT_OPERATION_TYPE_UNSPECIFIED CreditOperationType = 0
+	CreditOperationType_CREDIT_OPERATION_TYPE_FUNDING     CreditOperationType = 1
+	CreditOperationType_CREDIT_OPERATION_TYPE_PAY         CreditOperationType = 2
+	CreditOperationType_CREDIT_OPERATION_TYPE_REDEMPTION  CreditOperationType = 3
+	CreditOperationType_CREDIT_OPERATION_TYPE_RECEIVE     CreditOperationType = 4
+)
+
+// Enum value maps for CreditOperationType.
+var (
+	CreditOperationType_name = map[int32]string{
+		0: "CREDIT_OPERATION_TYPE_UNSPECIFIED",
+		1: "CREDIT_OPERATION_TYPE_FUNDING",
+		2: "CREDIT_OPERATION_TYPE_PAY",
+		3: "CREDIT_OPERATION_TYPE_REDEMPTION",
+		4: "CREDIT_OPERATION_TYPE_RECEIVE",
+	}
+	CreditOperationType_value = map[string]int32{
+		"CREDIT_OPERATION_TYPE_UNSPECIFIED": 0,
+		"CREDIT_OPERATION_TYPE_FUNDING":     1,
+		"CREDIT_OPERATION_TYPE_PAY":         2,
+		"CREDIT_OPERATION_TYPE_REDEMPTION":  3,
+		"CREDIT_OPERATION_TYPE_RECEIVE":     4,
+	}
+)
+
+func (x CreditOperationType) Enum() *CreditOperationType {
+	p := new(CreditOperationType)
+	*p = x
+	return p
+}
+
+func (x CreditOperationType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CreditOperationType) Descriptor() protoreflect.EnumDescriptor {
+	return file_swap_client_proto_enumTypes[3].Descriptor()
+}
+
+func (CreditOperationType) Type() protoreflect.EnumType {
+	return &file_swap_client_proto_enumTypes[3]
+}
+
+func (x CreditOperationType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CreditOperationType.Descriptor instead.
+func (CreditOperationType) EnumDescriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{3}
+}
+
+type CreditOperationState int32
+
+const (
+	CreditOperationState_CREDIT_OPERATION_STATE_UNSPECIFIED      CreditOperationState = 0
+	CreditOperationState_CREDIT_OPERATION_STATE_CREATED          CreditOperationState = 1
+	CreditOperationState_CREDIT_OPERATION_STATE_AWAITING_PAYMENT CreditOperationState = 2
+	CreditOperationState_CREDIT_OPERATION_STATE_CREDITED         CreditOperationState = 3
+	CreditOperationState_CREDIT_OPERATION_STATE_RESERVED         CreditOperationState = 4
+	CreditOperationState_CREDIT_OPERATION_STATE_PAYING_LIGHTNING CreditOperationState = 5
+	CreditOperationState_CREDIT_OPERATION_STATE_DEBITED          CreditOperationState = 6
+	CreditOperationState_CREDIT_OPERATION_STATE_SENDING_OOR      CreditOperationState = 7
+	CreditOperationState_CREDIT_OPERATION_STATE_REDEEMED         CreditOperationState = 8
+	CreditOperationState_CREDIT_OPERATION_STATE_RELEASED         CreditOperationState = 9
+	CreditOperationState_CREDIT_OPERATION_STATE_EXPIRED          CreditOperationState = 10
+	CreditOperationState_CREDIT_OPERATION_STATE_FAILED           CreditOperationState = 11
+)
+
+// Enum value maps for CreditOperationState.
+var (
+	CreditOperationState_name = map[int32]string{
+		0:  "CREDIT_OPERATION_STATE_UNSPECIFIED",
+		1:  "CREDIT_OPERATION_STATE_CREATED",
+		2:  "CREDIT_OPERATION_STATE_AWAITING_PAYMENT",
+		3:  "CREDIT_OPERATION_STATE_CREDITED",
+		4:  "CREDIT_OPERATION_STATE_RESERVED",
+		5:  "CREDIT_OPERATION_STATE_PAYING_LIGHTNING",
+		6:  "CREDIT_OPERATION_STATE_DEBITED",
+		7:  "CREDIT_OPERATION_STATE_SENDING_OOR",
+		8:  "CREDIT_OPERATION_STATE_REDEEMED",
+		9:  "CREDIT_OPERATION_STATE_RELEASED",
+		10: "CREDIT_OPERATION_STATE_EXPIRED",
+		11: "CREDIT_OPERATION_STATE_FAILED",
+	}
+	CreditOperationState_value = map[string]int32{
+		"CREDIT_OPERATION_STATE_UNSPECIFIED":      0,
+		"CREDIT_OPERATION_STATE_CREATED":          1,
+		"CREDIT_OPERATION_STATE_AWAITING_PAYMENT": 2,
+		"CREDIT_OPERATION_STATE_CREDITED":         3,
+		"CREDIT_OPERATION_STATE_RESERVED":         4,
+		"CREDIT_OPERATION_STATE_PAYING_LIGHTNING": 5,
+		"CREDIT_OPERATION_STATE_DEBITED":          6,
+		"CREDIT_OPERATION_STATE_SENDING_OOR":      7,
+		"CREDIT_OPERATION_STATE_REDEEMED":         8,
+		"CREDIT_OPERATION_STATE_RELEASED":         9,
+		"CREDIT_OPERATION_STATE_EXPIRED":          10,
+		"CREDIT_OPERATION_STATE_FAILED":           11,
+	}
+)
+
+func (x CreditOperationState) Enum() *CreditOperationState {
+	p := new(CreditOperationState)
+	*p = x
+	return p
+}
+
+func (x CreditOperationState) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CreditOperationState) Descriptor() protoreflect.EnumDescriptor {
+	return file_swap_client_proto_enumTypes[4].Descriptor()
+}
+
+func (CreditOperationState) Type() protoreflect.EnumType {
+	return &file_swap_client_proto_enumTypes[4]
+}
+
+func (x CreditOperationState) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CreditOperationState.Descriptor instead.
+func (CreditOperationState) EnumDescriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{4}
 }
 
 type SwapState int32
@@ -185,11 +371,11 @@ func (x SwapState) String() string {
 }
 
 func (SwapState) Descriptor() protoreflect.EnumDescriptor {
-	return file_swap_client_proto_enumTypes[2].Descriptor()
+	return file_swap_client_proto_enumTypes[5].Descriptor()
 }
 
 func (SwapState) Type() protoreflect.EnumType {
-	return &file_swap_client_proto_enumTypes[2]
+	return &file_swap_client_proto_enumTypes[5]
 }
 
 func (x SwapState) Number() protoreflect.EnumNumber {
@@ -198,7 +384,7 @@ func (x SwapState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SwapState.Descriptor instead.
 func (SwapState) EnumDescriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{2}
+	return file_swap_client_proto_rawDescGZIP(), []int{5}
 }
 
 type QuotePayRequest struct {
@@ -208,7 +394,11 @@ type QuotePayRequest struct {
 	// max_fee_sat is the maximum Lightning routing fee the caller accepts.
 	// Zero means no explicit caller cap. Quotes still return when the
 	// estimated fee exceeds this cap so callers can render the fee.
-	MaxFeeSat     uint64 `protobuf:"varint,2,opt,name=max_fee_sat,json=maxFeeSat,proto3" json:"max_fee_sat,omitempty"`
+	MaxFeeSat uint64 `protobuf:"varint,2,opt,name=max_fee_sat,json=maxFeeSat,proto3" json:"max_fee_sat,omitempty"`
+	// max_credit_sat is the maximum credit amount the caller is willing to
+	// use for this quote. Zero means only required-credit shortfalls are
+	// reported.
+	MaxCreditSat  uint64 `protobuf:"varint,3,opt,name=max_credit_sat,json=maxCreditSat,proto3" json:"max_credit_sat,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -257,12 +447,19 @@ func (x *QuotePayRequest) GetMaxFeeSat() uint64 {
 	return 0
 }
 
+func (x *QuotePayRequest) GetMaxCreditSat() uint64 {
+	if x != nil {
+		return x.MaxCreditSat
+	}
+	return 0
+}
+
 type QuotePayResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// payment_hash is the hex Lightning payment hash that identifies the
 	// invoice and eventual swap.
 	PaymentHash string `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
-	// invoice_amount_sat is the whole-satoshi invoice amount.
+	// invoice_amount_sat is the sat-denominated invoice amount.
 	InvoiceAmountSat uint64 `protobuf:"varint,2,opt,name=invoice_amount_sat,json=invoiceAmountSat,proto3" json:"invoice_amount_sat,omitempty"`
 	// amount_sat is the total amount that would leave the wallet.
 	AmountSat uint64 `protobuf:"varint,3,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
@@ -273,7 +470,8 @@ type QuotePayResponse struct {
 	ExpiresAtUnix int64 `protobuf:"varint,6,opt,name=expires_at_unix,json=expiresAtUnix,proto3" json:"expires_at_unix,omitempty"`
 	// exceeds_max_fee is true when max_fee_sat is non-zero and fee_sat is
 	// larger than that cap.
-	ExceedsMaxFee bool `protobuf:"varint,7,opt,name=exceeds_max_fee,json=exceedsMaxFee,proto3" json:"exceeds_max_fee,omitempty"`
+	ExceedsMaxFee bool         `protobuf:"varint,7,opt,name=exceeds_max_fee,json=exceedsMaxFee,proto3" json:"exceeds_max_fee,omitempty"`
+	CreditQuote   *CreditQuote `protobuf:"bytes,8,opt,name=credit_quote,json=creditQuote,proto3" json:"credit_quote,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -357,6 +555,13 @@ func (x *QuotePayResponse) GetExceedsMaxFee() bool {
 	return false
 }
 
+func (x *QuotePayResponse) GetCreditQuote() *CreditQuote {
+	if x != nil {
+		return x.CreditQuote
+	}
+	return nil
+}
+
 type StartPayRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// invoice is the BOLT-11 Lightning invoice to pay.
@@ -368,8 +573,11 @@ type StartPayRequest struct {
 	// guard. The current implementation relies on the persisted swap state
 	// returned by the SDK once the payment hash is known.
 	IdempotencyKey string `protobuf:"bytes,3,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// max_credit_sat is the maximum credit amount the caller authorizes this
+	// pay to reserve.
+	MaxCreditSat  uint64 `protobuf:"varint,4,opt,name=max_credit_sat,json=maxCreditSat,proto3" json:"max_credit_sat,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *StartPayRequest) Reset() {
@@ -421,6 +629,13 @@ func (x *StartPayRequest) GetIdempotencyKey() string {
 		return x.IdempotencyKey
 	}
 	return ""
+}
+
+func (x *StartPayRequest) GetMaxCreditSat() uint64 {
+	if x != nil {
+		return x.MaxCreditSat
+	}
+	return 0
 }
 
 type StartPayResponse struct {
@@ -479,6 +694,714 @@ func (x *StartPayResponse) GetSwap() *SwapSummary {
 	return nil
 }
 
+type CreateCreditRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	IdempotencyKey string                 `protobuf:"bytes,1,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
+	Source         CreditFundingSource    `protobuf:"varint,2,opt,name=source,proto3,enum=swapclientrpc.CreditFundingSource" json:"source,omitempty"`
+	AmountSat      uint64                 `protobuf:"varint,4,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	Memo           string                 `protobuf:"bytes,5,opt,name=memo,proto3" json:"memo,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *CreateCreditRequest) Reset() {
+	*x = CreateCreditRequest{}
+	mi := &file_swap_client_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateCreditRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateCreditRequest) ProtoMessage() {}
+
+func (x *CreateCreditRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_client_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateCreditRequest.ProtoReflect.Descriptor instead.
+func (*CreateCreditRequest) Descriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *CreateCreditRequest) GetIdempotencyKey() string {
+	if x != nil {
+		return x.IdempotencyKey
+	}
+	return ""
+}
+
+func (x *CreateCreditRequest) GetSource() CreditFundingSource {
+	if x != nil {
+		return x.Source
+	}
+	return CreditFundingSource_CREDIT_FUNDING_SOURCE_UNSPECIFIED
+}
+
+func (x *CreateCreditRequest) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *CreateCreditRequest) GetMemo() string {
+	if x != nil {
+		return x.Memo
+	}
+	return ""
+}
+
+type CreateCreditResponse struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	OperationId       string                 `protobuf:"bytes,1,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"`
+	State             CreditOperationState   `protobuf:"varint,2,opt,name=state,proto3,enum=swapclientrpc.CreditOperationState" json:"state,omitempty"`
+	Invoice           string                 `protobuf:"bytes,3,opt,name=invoice,proto3" json:"invoice,omitempty"`
+	PaymentHash       string                 `protobuf:"bytes,4,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	AmountSat         uint64                 `protobuf:"varint,6,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	DestinationPubkey []byte                 `protobuf:"bytes,7,opt,name=destination_pubkey,json=destinationPubkey,proto3" json:"destination_pubkey,omitempty"`
+	ExpiresAtUnix     int64                  `protobuf:"varint,8,opt,name=expires_at_unix,json=expiresAtUnix,proto3" json:"expires_at_unix,omitempty"`
+	Swap              *SwapSummary           `protobuf:"bytes,9,opt,name=swap,proto3" json:"swap,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *CreateCreditResponse) Reset() {
+	*x = CreateCreditResponse{}
+	mi := &file_swap_client_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateCreditResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateCreditResponse) ProtoMessage() {}
+
+func (x *CreateCreditResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_client_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateCreditResponse.ProtoReflect.Descriptor instead.
+func (*CreateCreditResponse) Descriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *CreateCreditResponse) GetOperationId() string {
+	if x != nil {
+		return x.OperationId
+	}
+	return ""
+}
+
+func (x *CreateCreditResponse) GetState() CreditOperationState {
+	if x != nil {
+		return x.State
+	}
+	return CreditOperationState_CREDIT_OPERATION_STATE_UNSPECIFIED
+}
+
+func (x *CreateCreditResponse) GetInvoice() string {
+	if x != nil {
+		return x.Invoice
+	}
+	return ""
+}
+
+func (x *CreateCreditResponse) GetPaymentHash() string {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return ""
+}
+
+func (x *CreateCreditResponse) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *CreateCreditResponse) GetDestinationPubkey() []byte {
+	if x != nil {
+		return x.DestinationPubkey
+	}
+	return nil
+}
+
+func (x *CreateCreditResponse) GetExpiresAtUnix() int64 {
+	if x != nil {
+		return x.ExpiresAtUnix
+	}
+	return 0
+}
+
+func (x *CreateCreditResponse) GetSwap() *SwapSummary {
+	if x != nil {
+		return x.Swap
+	}
+	return nil
+}
+
+type RedeemCreditRequest struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	IdempotencyKey    string                 `protobuf:"bytes,1,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
+	AmountSat         uint64                 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	DestinationPubkey []byte                 `protobuf:"bytes,3,opt,name=destination_pubkey,json=destinationPubkey,proto3" json:"destination_pubkey,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *RedeemCreditRequest) Reset() {
+	*x = RedeemCreditRequest{}
+	mi := &file_swap_client_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RedeemCreditRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RedeemCreditRequest) ProtoMessage() {}
+
+func (x *RedeemCreditRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_client_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RedeemCreditRequest.ProtoReflect.Descriptor instead.
+func (*RedeemCreditRequest) Descriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *RedeemCreditRequest) GetIdempotencyKey() string {
+	if x != nil {
+		return x.IdempotencyKey
+	}
+	return ""
+}
+
+func (x *RedeemCreditRequest) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *RedeemCreditRequest) GetDestinationPubkey() []byte {
+	if x != nil {
+		return x.DestinationPubkey
+	}
+	return nil
+}
+
+type RedeemCreditResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	OperationId   string                 `protobuf:"bytes,1,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"`
+	State         CreditOperationState   `protobuf:"varint,2,opt,name=state,proto3,enum=swapclientrpc.CreditOperationState" json:"state,omitempty"`
+	DebitedSat    uint64                 `protobuf:"varint,3,opt,name=debited_sat,json=debitedSat,proto3" json:"debited_sat,omitempty"`
+	RedeemedSat   uint64                 `protobuf:"varint,4,opt,name=redeemed_sat,json=redeemedSat,proto3" json:"redeemed_sat,omitempty"`
+	SessionId     string                 `protobuf:"bytes,6,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RedeemCreditResponse) Reset() {
+	*x = RedeemCreditResponse{}
+	mi := &file_swap_client_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RedeemCreditResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RedeemCreditResponse) ProtoMessage() {}
+
+func (x *RedeemCreditResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_client_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RedeemCreditResponse.ProtoReflect.Descriptor instead.
+func (*RedeemCreditResponse) Descriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *RedeemCreditResponse) GetOperationId() string {
+	if x != nil {
+		return x.OperationId
+	}
+	return ""
+}
+
+func (x *RedeemCreditResponse) GetState() CreditOperationState {
+	if x != nil {
+		return x.State
+	}
+	return CreditOperationState_CREDIT_OPERATION_STATE_UNSPECIFIED
+}
+
+func (x *RedeemCreditResponse) GetDebitedSat() uint64 {
+	if x != nil {
+		return x.DebitedSat
+	}
+	return 0
+}
+
+func (x *RedeemCreditResponse) GetRedeemedSat() uint64 {
+	if x != nil {
+		return x.RedeemedSat
+	}
+	return 0
+}
+
+func (x *RedeemCreditResponse) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+type ListCreditsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Limit         uint32                 `protobuf:"varint,1,opt,name=limit,proto3" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListCreditsRequest) Reset() {
+	*x = ListCreditsRequest{}
+	mi := &file_swap_client_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListCreditsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListCreditsRequest) ProtoMessage() {}
+
+func (x *ListCreditsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_client_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListCreditsRequest.ProtoReflect.Descriptor instead.
+func (*ListCreditsRequest) Descriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ListCreditsRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+type ListCreditsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	FinalizedSat  uint64                 `protobuf:"varint,1,opt,name=finalized_sat,json=finalizedSat,proto3" json:"finalized_sat,omitempty"`
+	ReservedSat   uint64                 `protobuf:"varint,2,opt,name=reserved_sat,json=reservedSat,proto3" json:"reserved_sat,omitempty"`
+	AvailableSat  uint64                 `protobuf:"varint,3,opt,name=available_sat,json=availableSat,proto3" json:"available_sat,omitempty"`
+	Operations    []*CreditOperation     `protobuf:"bytes,4,rep,name=operations,proto3" json:"operations,omitempty"`
+	LedgerEntries []*CreditLedgerEntry   `protobuf:"bytes,5,rep,name=ledger_entries,json=ledgerEntries,proto3" json:"ledger_entries,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListCreditsResponse) Reset() {
+	*x = ListCreditsResponse{}
+	mi := &file_swap_client_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListCreditsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListCreditsResponse) ProtoMessage() {}
+
+func (x *ListCreditsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_client_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListCreditsResponse.ProtoReflect.Descriptor instead.
+func (*ListCreditsResponse) Descriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *ListCreditsResponse) GetFinalizedSat() uint64 {
+	if x != nil {
+		return x.FinalizedSat
+	}
+	return 0
+}
+
+func (x *ListCreditsResponse) GetReservedSat() uint64 {
+	if x != nil {
+		return x.ReservedSat
+	}
+	return 0
+}
+
+func (x *ListCreditsResponse) GetAvailableSat() uint64 {
+	if x != nil {
+		return x.AvailableSat
+	}
+	return 0
+}
+
+func (x *ListCreditsResponse) GetOperations() []*CreditOperation {
+	if x != nil {
+		return x.Operations
+	}
+	return nil
+}
+
+func (x *ListCreditsResponse) GetLedgerEntries() []*CreditLedgerEntry {
+	if x != nil {
+		return x.LedgerEntries
+	}
+	return nil
+}
+
+type CreditQuote struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	MustUseCredit      bool                   `protobuf:"varint,1,opt,name=must_use_credit,json=mustUseCredit,proto3" json:"must_use_credit,omitempty"`
+	CreditAppliedSat   uint64                 `protobuf:"varint,2,opt,name=credit_applied_sat,json=creditAppliedSat,proto3" json:"credit_applied_sat,omitempty"`
+	CreditShortfallSat uint64                 `protobuf:"varint,3,opt,name=credit_shortfall_sat,json=creditShortfallSat,proto3" json:"credit_shortfall_sat,omitempty"`
+	CreditTopupSat     uint64                 `protobuf:"varint,4,opt,name=credit_topup_sat,json=creditTopupSat,proto3" json:"credit_topup_sat,omitempty"`
+	ArkFundingSat      uint64                 `protobuf:"varint,5,opt,name=ark_funding_sat,json=arkFundingSat,proto3" json:"ark_funding_sat,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *CreditQuote) Reset() {
+	*x = CreditQuote{}
+	mi := &file_swap_client_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreditQuote) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreditQuote) ProtoMessage() {}
+
+func (x *CreditQuote) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_client_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreditQuote.ProtoReflect.Descriptor instead.
+func (*CreditQuote) Descriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *CreditQuote) GetMustUseCredit() bool {
+	if x != nil {
+		return x.MustUseCredit
+	}
+	return false
+}
+
+func (x *CreditQuote) GetCreditAppliedSat() uint64 {
+	if x != nil {
+		return x.CreditAppliedSat
+	}
+	return 0
+}
+
+func (x *CreditQuote) GetCreditShortfallSat() uint64 {
+	if x != nil {
+		return x.CreditShortfallSat
+	}
+	return 0
+}
+
+func (x *CreditQuote) GetCreditTopupSat() uint64 {
+	if x != nil {
+		return x.CreditTopupSat
+	}
+	return 0
+}
+
+func (x *CreditQuote) GetArkFundingSat() uint64 {
+	if x != nil {
+		return x.ArkFundingSat
+	}
+	return 0
+}
+
+type CreditOperation struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	OperationId       string                 `protobuf:"bytes,1,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"`
+	Type              CreditOperationType    `protobuf:"varint,2,opt,name=type,proto3,enum=swapclientrpc.CreditOperationType" json:"type,omitempty"`
+	State             CreditOperationState   `protobuf:"varint,3,opt,name=state,proto3,enum=swapclientrpc.CreditOperationState" json:"state,omitempty"`
+	AmountSat         uint64                 `protobuf:"varint,5,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	PaymentHash       string                 `protobuf:"bytes,6,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	Invoice           string                 `protobuf:"bytes,7,opt,name=invoice,proto3" json:"invoice,omitempty"`
+	DestinationPubkey []byte                 `protobuf:"bytes,8,opt,name=destination_pubkey,json=destinationPubkey,proto3" json:"destination_pubkey,omitempty"`
+	SessionId         string                 `protobuf:"bytes,9,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	CreatedAtUnix     int64                  `protobuf:"varint,10,opt,name=created_at_unix,json=createdAtUnix,proto3" json:"created_at_unix,omitempty"`
+	UpdatedAtUnix     int64                  `protobuf:"varint,11,opt,name=updated_at_unix,json=updatedAtUnix,proto3" json:"updated_at_unix,omitempty"`
+	CompletedAtUnix   int64                  `protobuf:"varint,12,opt,name=completed_at_unix,json=completedAtUnix,proto3" json:"completed_at_unix,omitempty"`
+	LastError         string                 `protobuf:"bytes,13,opt,name=last_error,json=lastError,proto3" json:"last_error,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *CreditOperation) Reset() {
+	*x = CreditOperation{}
+	mi := &file_swap_client_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreditOperation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreditOperation) ProtoMessage() {}
+
+func (x *CreditOperation) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_client_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreditOperation.ProtoReflect.Descriptor instead.
+func (*CreditOperation) Descriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *CreditOperation) GetOperationId() string {
+	if x != nil {
+		return x.OperationId
+	}
+	return ""
+}
+
+func (x *CreditOperation) GetType() CreditOperationType {
+	if x != nil {
+		return x.Type
+	}
+	return CreditOperationType_CREDIT_OPERATION_TYPE_UNSPECIFIED
+}
+
+func (x *CreditOperation) GetState() CreditOperationState {
+	if x != nil {
+		return x.State
+	}
+	return CreditOperationState_CREDIT_OPERATION_STATE_UNSPECIFIED
+}
+
+func (x *CreditOperation) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *CreditOperation) GetPaymentHash() string {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return ""
+}
+
+func (x *CreditOperation) GetInvoice() string {
+	if x != nil {
+		return x.Invoice
+	}
+	return ""
+}
+
+func (x *CreditOperation) GetDestinationPubkey() []byte {
+	if x != nil {
+		return x.DestinationPubkey
+	}
+	return nil
+}
+
+func (x *CreditOperation) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *CreditOperation) GetCreatedAtUnix() int64 {
+	if x != nil {
+		return x.CreatedAtUnix
+	}
+	return 0
+}
+
+func (x *CreditOperation) GetUpdatedAtUnix() int64 {
+	if x != nil {
+		return x.UpdatedAtUnix
+	}
+	return 0
+}
+
+func (x *CreditOperation) GetCompletedAtUnix() int64 {
+	if x != nil {
+		return x.CompletedAtUnix
+	}
+	return 0
+}
+
+func (x *CreditOperation) GetLastError() string {
+	if x != nil {
+		return x.LastError
+	}
+	return ""
+}
+
+type CreditLedgerEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EntryId       string                 `protobuf:"bytes,1,opt,name=entry_id,json=entryId,proto3" json:"entry_id,omitempty"`
+	OperationId   string                 `protobuf:"bytes,2,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"`
+	Direction     string                 `protobuf:"bytes,3,opt,name=direction,proto3" json:"direction,omitempty"`
+	AmountSat     uint64                 `protobuf:"varint,4,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	CreatedAtUnix int64                  `protobuf:"varint,5,opt,name=created_at_unix,json=createdAtUnix,proto3" json:"created_at_unix,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreditLedgerEntry) Reset() {
+	*x = CreditLedgerEntry{}
+	mi := &file_swap_client_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreditLedgerEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreditLedgerEntry) ProtoMessage() {}
+
+func (x *CreditLedgerEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_client_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreditLedgerEntry.ProtoReflect.Descriptor instead.
+func (*CreditLedgerEntry) Descriptor() ([]byte, []int) {
+	return file_swap_client_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *CreditLedgerEntry) GetEntryId() string {
+	if x != nil {
+		return x.EntryId
+	}
+	return ""
+}
+
+func (x *CreditLedgerEntry) GetOperationId() string {
+	if x != nil {
+		return x.OperationId
+	}
+	return ""
+}
+
+func (x *CreditLedgerEntry) GetDirection() string {
+	if x != nil {
+		return x.Direction
+	}
+	return ""
+}
+
+func (x *CreditLedgerEntry) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *CreditLedgerEntry) GetCreatedAtUnix() int64 {
+	if x != nil {
+		return x.CreatedAtUnix
+	}
+	return 0
+}
+
 type StartReceiveRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// amount_sat is the Lightning amount to receive into Ark.
@@ -495,7 +1418,7 @@ type StartReceiveRequest struct {
 
 func (x *StartReceiveRequest) Reset() {
 	*x = StartReceiveRequest{}
-	mi := &file_swap_client_proto_msgTypes[4]
+	mi := &file_swap_client_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -507,7 +1430,7 @@ func (x *StartReceiveRequest) String() string {
 func (*StartReceiveRequest) ProtoMessage() {}
 
 func (x *StartReceiveRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[4]
+	mi := &file_swap_client_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -520,7 +1443,7 @@ func (x *StartReceiveRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartReceiveRequest.ProtoReflect.Descriptor instead.
 func (*StartReceiveRequest) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{4}
+	return file_swap_client_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *StartReceiveRequest) GetAmountSat() int64 {
@@ -553,14 +1476,28 @@ type StartReceiveResponse struct {
 	Invoice string `protobuf:"bytes,2,opt,name=invoice,proto3" json:"invoice,omitempty"`
 	// swap is the initial durable summary after the receive session is
 	// persisted and daemon background execution has been scheduled.
-	Swap          *SwapSummary `protobuf:"bytes,3,opt,name=swap,proto3" json:"swap,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Swap *SwapSummary `protobuf:"bytes,3,opt,name=swap,proto3" json:"swap,omitempty"`
+	// requested_amount_sat is the invoice amount requested by the receiver.
+	RequestedAmountSat uint64 `protobuf:"varint,4,opt,name=requested_amount_sat,json=requestedAmountSat,proto3" json:"requested_amount_sat,omitempty"`
+	// available_credit_sat is the server-authoritative credit balance
+	// considered for the receive plan.
+	AvailableCreditSat uint64 `protobuf:"varint,5,opt,name=available_credit_sat,json=availableCreditSat,proto3" json:"available_credit_sat,omitempty"`
+	// attached_credit_sat is the credit amount reserved and added to the funded
+	// vHTLC for credit-assisted receives.
+	AttachedCreditSat uint64 `protobuf:"varint,6,opt,name=attached_credit_sat,json=attachedCreditSat,proto3" json:"attached_credit_sat,omitempty"`
+	// vhtlc_amount_sat is the funded vHTLC amount the client expects.
+	VhtlcAmountSat uint64 `protobuf:"varint,7,opt,name=vhtlc_amount_sat,json=vhtlcAmountSat,proto3" json:"vhtlc_amount_sat,omitempty"`
+	// dust_limit_sat is the minimum vHTLC output amount used by the server.
+	DustLimitSat uint64 `protobuf:"varint,8,opt,name=dust_limit_sat,json=dustLimitSat,proto3" json:"dust_limit_sat,omitempty"`
+	// settlement_type identifies the selected receive rail.
+	SettlementType SwapSettlementType `protobuf:"varint,9,opt,name=settlement_type,json=settlementType,proto3,enum=swapclientrpc.SwapSettlementType" json:"settlement_type,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *StartReceiveResponse) Reset() {
 	*x = StartReceiveResponse{}
-	mi := &file_swap_client_proto_msgTypes[5]
+	mi := &file_swap_client_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -572,7 +1509,7 @@ func (x *StartReceiveResponse) String() string {
 func (*StartReceiveResponse) ProtoMessage() {}
 
 func (x *StartReceiveResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[5]
+	mi := &file_swap_client_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -585,7 +1522,7 @@ func (x *StartReceiveResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartReceiveResponse.ProtoReflect.Descriptor instead.
 func (*StartReceiveResponse) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{5}
+	return file_swap_client_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *StartReceiveResponse) GetPaymentHash() string {
@@ -609,6 +1546,48 @@ func (x *StartReceiveResponse) GetSwap() *SwapSummary {
 	return nil
 }
 
+func (x *StartReceiveResponse) GetRequestedAmountSat() uint64 {
+	if x != nil {
+		return x.RequestedAmountSat
+	}
+	return 0
+}
+
+func (x *StartReceiveResponse) GetAvailableCreditSat() uint64 {
+	if x != nil {
+		return x.AvailableCreditSat
+	}
+	return 0
+}
+
+func (x *StartReceiveResponse) GetAttachedCreditSat() uint64 {
+	if x != nil {
+		return x.AttachedCreditSat
+	}
+	return 0
+}
+
+func (x *StartReceiveResponse) GetVhtlcAmountSat() uint64 {
+	if x != nil {
+		return x.VhtlcAmountSat
+	}
+	return 0
+}
+
+func (x *StartReceiveResponse) GetDustLimitSat() uint64 {
+	if x != nil {
+		return x.DustLimitSat
+	}
+	return 0
+}
+
+func (x *StartReceiveResponse) GetSettlementType() SwapSettlementType {
+	if x != nil {
+		return x.SettlementType
+	}
+	return SwapSettlementType_SWAP_SETTLEMENT_TYPE_UNSPECIFIED
+}
+
 type ResumeSwapRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// payment_hash identifies the persisted swap to wake up.
@@ -621,7 +1600,7 @@ type ResumeSwapRequest struct {
 
 func (x *ResumeSwapRequest) Reset() {
 	*x = ResumeSwapRequest{}
-	mi := &file_swap_client_proto_msgTypes[6]
+	mi := &file_swap_client_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -633,7 +1612,7 @@ func (x *ResumeSwapRequest) String() string {
 func (*ResumeSwapRequest) ProtoMessage() {}
 
 func (x *ResumeSwapRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[6]
+	mi := &file_swap_client_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -646,7 +1625,7 @@ func (x *ResumeSwapRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeSwapRequest.ProtoReflect.Descriptor instead.
 func (*ResumeSwapRequest) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{6}
+	return file_swap_client_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ResumeSwapRequest) GetPaymentHash() string {
@@ -673,7 +1652,7 @@ type ResumeSwapResponse struct {
 
 func (x *ResumeSwapResponse) Reset() {
 	*x = ResumeSwapResponse{}
-	mi := &file_swap_client_proto_msgTypes[7]
+	mi := &file_swap_client_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -685,7 +1664,7 @@ func (x *ResumeSwapResponse) String() string {
 func (*ResumeSwapResponse) ProtoMessage() {}
 
 func (x *ResumeSwapResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[7]
+	mi := &file_swap_client_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -698,7 +1677,7 @@ func (x *ResumeSwapResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeSwapResponse.ProtoReflect.Descriptor instead.
 func (*ResumeSwapResponse) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{7}
+	return file_swap_client_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ResumeSwapResponse) GetSwap() *SwapSummary {
@@ -717,7 +1696,7 @@ type ListSwapsRequest struct {
 
 func (x *ListSwapsRequest) Reset() {
 	*x = ListSwapsRequest{}
-	mi := &file_swap_client_proto_msgTypes[8]
+	mi := &file_swap_client_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -729,7 +1708,7 @@ func (x *ListSwapsRequest) String() string {
 func (*ListSwapsRequest) ProtoMessage() {}
 
 func (x *ListSwapsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[8]
+	mi := &file_swap_client_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -742,7 +1721,7 @@ func (x *ListSwapsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSwapsRequest.ProtoReflect.Descriptor instead.
 func (*ListSwapsRequest) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{8}
+	return file_swap_client_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ListSwapsRequest) GetPendingOnly() bool {
@@ -762,7 +1741,7 @@ type ListSwapsResponse struct {
 
 func (x *ListSwapsResponse) Reset() {
 	*x = ListSwapsResponse{}
-	mi := &file_swap_client_proto_msgTypes[9]
+	mi := &file_swap_client_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -774,7 +1753,7 @@ func (x *ListSwapsResponse) String() string {
 func (*ListSwapsResponse) ProtoMessage() {}
 
 func (x *ListSwapsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[9]
+	mi := &file_swap_client_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -787,7 +1766,7 @@ func (x *ListSwapsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSwapsResponse.ProtoReflect.Descriptor instead.
 func (*ListSwapsResponse) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{9}
+	return file_swap_client_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ListSwapsResponse) GetSwaps() []*SwapSummary {
@@ -807,7 +1786,7 @@ type GetSwapRequest struct {
 
 func (x *GetSwapRequest) Reset() {
 	*x = GetSwapRequest{}
-	mi := &file_swap_client_proto_msgTypes[10]
+	mi := &file_swap_client_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -819,7 +1798,7 @@ func (x *GetSwapRequest) String() string {
 func (*GetSwapRequest) ProtoMessage() {}
 
 func (x *GetSwapRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[10]
+	mi := &file_swap_client_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -832,7 +1811,7 @@ func (x *GetSwapRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSwapRequest.ProtoReflect.Descriptor instead.
 func (*GetSwapRequest) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{10}
+	return file_swap_client_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *GetSwapRequest) GetPaymentHash() string {
@@ -852,7 +1831,7 @@ type GetSwapResponse struct {
 
 func (x *GetSwapResponse) Reset() {
 	*x = GetSwapResponse{}
-	mi := &file_swap_client_proto_msgTypes[11]
+	mi := &file_swap_client_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -864,7 +1843,7 @@ func (x *GetSwapResponse) String() string {
 func (*GetSwapResponse) ProtoMessage() {}
 
 func (x *GetSwapResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[11]
+	mi := &file_swap_client_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -877,7 +1856,7 @@ func (x *GetSwapResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSwapResponse.ProtoReflect.Descriptor instead.
 func (*GetSwapResponse) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{11}
+	return file_swap_client_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GetSwapResponse) GetSwap() *SwapSummary {
@@ -897,7 +1876,7 @@ type SubscribeSwapsRequest struct {
 
 func (x *SubscribeSwapsRequest) Reset() {
 	*x = SubscribeSwapsRequest{}
-	mi := &file_swap_client_proto_msgTypes[12]
+	mi := &file_swap_client_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -909,7 +1888,7 @@ func (x *SubscribeSwapsRequest) String() string {
 func (*SubscribeSwapsRequest) ProtoMessage() {}
 
 func (x *SubscribeSwapsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[12]
+	mi := &file_swap_client_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -922,7 +1901,7 @@ func (x *SubscribeSwapsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeSwapsRequest.ProtoReflect.Descriptor instead.
 func (*SubscribeSwapsRequest) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{12}
+	return file_swap_client_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *SubscribeSwapsRequest) GetIncludeExisting() bool {
@@ -949,7 +1928,7 @@ type SubscribeSwapsResponse struct {
 
 func (x *SubscribeSwapsResponse) Reset() {
 	*x = SubscribeSwapsResponse{}
-	mi := &file_swap_client_proto_msgTypes[13]
+	mi := &file_swap_client_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -961,7 +1940,7 @@ func (x *SubscribeSwapsResponse) String() string {
 func (*SubscribeSwapsResponse) ProtoMessage() {}
 
 func (x *SubscribeSwapsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[13]
+	mi := &file_swap_client_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -974,7 +1953,7 @@ func (x *SubscribeSwapsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeSwapsResponse.ProtoReflect.Descriptor instead.
 func (*SubscribeSwapsResponse) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{13}
+	return file_swap_client_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *SubscribeSwapsResponse) GetSwap() *SwapSummary {
@@ -1033,14 +2012,26 @@ type SwapSummary struct {
 	// settlement_type identifies the rail selected for the swap when known.
 	SettlementType SwapSettlementType `protobuf:"varint,19,opt,name=settlement_type,json=settlementType,proto3,enum=swapclientrpc.SwapSettlementType" json:"settlement_type,omitempty"`
 	// sender_pubkey is the compressed SEC-encoded vHTLC sender key when known.
-	SenderPubkey  string `protobuf:"bytes,20,opt,name=sender_pubkey,json=senderPubkey,proto3" json:"sender_pubkey,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	SenderPubkey string       `protobuf:"bytes,20,opt,name=sender_pubkey,json=senderPubkey,proto3" json:"sender_pubkey,omitempty"`
+	CreditQuote  *CreditQuote `protobuf:"bytes,21,opt,name=credit_quote,json=creditQuote,proto3" json:"credit_quote,omitempty"`
+	// requested_amount_sat is the invoice amount for receive swaps when it can
+	// differ from the funded vHTLC amount.
+	RequestedAmountSat uint64 `protobuf:"varint,22,opt,name=requested_amount_sat,json=requestedAmountSat,proto3" json:"requested_amount_sat,omitempty"`
+	// attached_credit_sat is the credit amount attached to a credit-assisted
+	// receive.
+	AttachedCreditSat uint64 `protobuf:"varint,23,opt,name=attached_credit_sat,json=attachedCreditSat,proto3" json:"attached_credit_sat,omitempty"`
+	// dust_limit_sat is the server dust limit used for receive planning.
+	DustLimitSat uint64 `protobuf:"varint,24,opt,name=dust_limit_sat,json=dustLimitSat,proto3" json:"dust_limit_sat,omitempty"`
+	// available_credit_sat is the balance considered when the receive route was
+	// planned.
+	AvailableCreditSat uint64 `protobuf:"varint,25,opt,name=available_credit_sat,json=availableCreditSat,proto3" json:"available_credit_sat,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *SwapSummary) Reset() {
 	*x = SwapSummary{}
-	mi := &file_swap_client_proto_msgTypes[14]
+	mi := &file_swap_client_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1052,7 +2043,7 @@ func (x *SwapSummary) String() string {
 func (*SwapSummary) ProtoMessage() {}
 
 func (x *SwapSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_client_proto_msgTypes[14]
+	mi := &file_swap_client_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1065,7 +2056,7 @@ func (x *SwapSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SwapSummary.ProtoReflect.Descriptor instead.
 func (*SwapSummary) Descriptor() ([]byte, []int) {
-	return file_swap_client_proto_rawDescGZIP(), []int{14}
+	return file_swap_client_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *SwapSummary) GetDirection() SwapDirection {
@@ -1208,14 +2199,50 @@ func (x *SwapSummary) GetSenderPubkey() string {
 	return ""
 }
 
+func (x *SwapSummary) GetCreditQuote() *CreditQuote {
+	if x != nil {
+		return x.CreditQuote
+	}
+	return nil
+}
+
+func (x *SwapSummary) GetRequestedAmountSat() uint64 {
+	if x != nil {
+		return x.RequestedAmountSat
+	}
+	return 0
+}
+
+func (x *SwapSummary) GetAttachedCreditSat() uint64 {
+	if x != nil {
+		return x.AttachedCreditSat
+	}
+	return 0
+}
+
+func (x *SwapSummary) GetDustLimitSat() uint64 {
+	if x != nil {
+		return x.DustLimitSat
+	}
+	return 0
+}
+
+func (x *SwapSummary) GetAvailableCreditSat() uint64 {
+	if x != nil {
+		return x.AvailableCreditSat
+	}
+	return 0
+}
+
 var File_swap_client_proto protoreflect.FileDescriptor
 
 const file_swap_client_proto_rawDesc = "" +
 	"\n" +
-	"\x11swap_client.proto\x12\rswapclientrpc\"K\n" +
+	"\x11swap_client.proto\x12\rswapclientrpc\"q\n" +
 	"\x0fQuotePayRequest\x12\x18\n" +
 	"\ainvoice\x18\x01 \x01(\tR\ainvoice\x12\x1e\n" +
-	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\"\xb7\x02\n" +
+	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\x12$\n" +
+	"\x0emax_credit_sat\x18\x03 \x01(\x04R\fmaxCreditSat\"\xf6\x02\n" +
 	"\x10QuotePayResponse\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\tR\vpaymentHash\x12,\n" +
 	"\x12invoice_amount_sat\x18\x02 \x01(\x04R\x10invoiceAmountSat\x12\x1d\n" +
@@ -1224,23 +2251,100 @@ const file_swap_client_proto_rawDesc = "" +
 	"\afee_sat\x18\x04 \x01(\x04R\x06feeSat\x12J\n" +
 	"\x0fsettlement_type\x18\x05 \x01(\x0e2!.swapclientrpc.SwapSettlementTypeR\x0esettlementType\x12&\n" +
 	"\x0fexpires_at_unix\x18\x06 \x01(\x03R\rexpiresAtUnix\x12&\n" +
-	"\x0fexceeds_max_fee\x18\a \x01(\bR\rexceedsMaxFee\"t\n" +
+	"\x0fexceeds_max_fee\x18\a \x01(\bR\rexceedsMaxFee\x12=\n" +
+	"\fcredit_quote\x18\b \x01(\v2\x1a.swapclientrpc.CreditQuoteR\vcreditQuote\"\x9a\x01\n" +
 	"\x0fStartPayRequest\x12\x18\n" +
 	"\ainvoice\x18\x01 \x01(\tR\ainvoice\x12\x1e\n" +
 	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\x12'\n" +
-	"\x0fidempotency_key\x18\x03 \x01(\tR\x0eidempotencyKey\"e\n" +
+	"\x0fidempotency_key\x18\x03 \x01(\tR\x0eidempotencyKey\x12$\n" +
+	"\x0emax_credit_sat\x18\x04 \x01(\x04R\fmaxCreditSat\"e\n" +
 	"\x10StartPayResponse\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\tR\vpaymentHash\x12.\n" +
-	"\x04swap\x18\x02 \x01(\v2\x1a.swapclientrpc.SwapSummaryR\x04swap\"q\n" +
+	"\x04swap\x18\x02 \x01(\v2\x1a.swapclientrpc.SwapSummaryR\x04swap\"\xad\x01\n" +
+	"\x13CreateCreditRequest\x12'\n" +
+	"\x0fidempotency_key\x18\x01 \x01(\tR\x0eidempotencyKey\x12:\n" +
+	"\x06source\x18\x02 \x01(\x0e2\".swapclientrpc.CreditFundingSourceR\x06source\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x04 \x01(\x04R\tamountSat\x12\x12\n" +
+	"\x04memo\x18\x05 \x01(\tR\x04memo\"\xd7\x02\n" +
+	"\x14CreateCreditResponse\x12!\n" +
+	"\foperation_id\x18\x01 \x01(\tR\voperationId\x129\n" +
+	"\x05state\x18\x02 \x01(\x0e2#.swapclientrpc.CreditOperationStateR\x05state\x12\x18\n" +
+	"\ainvoice\x18\x03 \x01(\tR\ainvoice\x12!\n" +
+	"\fpayment_hash\x18\x04 \x01(\tR\vpaymentHash\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x06 \x01(\x04R\tamountSat\x12-\n" +
+	"\x12destination_pubkey\x18\a \x01(\fR\x11destinationPubkey\x12&\n" +
+	"\x0fexpires_at_unix\x18\b \x01(\x03R\rexpiresAtUnix\x12.\n" +
+	"\x04swap\x18\t \x01(\v2\x1a.swapclientrpc.SwapSummaryR\x04swap\"\x8c\x01\n" +
+	"\x13RedeemCreditRequest\x12'\n" +
+	"\x0fidempotency_key\x18\x01 \x01(\tR\x0eidempotencyKey\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x02 \x01(\x04R\tamountSat\x12-\n" +
+	"\x12destination_pubkey\x18\x03 \x01(\fR\x11destinationPubkey\"\xd7\x01\n" +
+	"\x14RedeemCreditResponse\x12!\n" +
+	"\foperation_id\x18\x01 \x01(\tR\voperationId\x129\n" +
+	"\x05state\x18\x02 \x01(\x0e2#.swapclientrpc.CreditOperationStateR\x05state\x12\x1f\n" +
+	"\vdebited_sat\x18\x03 \x01(\x04R\n" +
+	"debitedSat\x12!\n" +
+	"\fredeemed_sat\x18\x04 \x01(\x04R\vredeemedSat\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x06 \x01(\tR\tsessionId\"*\n" +
+	"\x12ListCreditsRequest\x12\x14\n" +
+	"\x05limit\x18\x01 \x01(\rR\x05limit\"\x8b\x02\n" +
+	"\x13ListCreditsResponse\x12#\n" +
+	"\rfinalized_sat\x18\x01 \x01(\x04R\ffinalizedSat\x12!\n" +
+	"\freserved_sat\x18\x02 \x01(\x04R\vreservedSat\x12#\n" +
+	"\ravailable_sat\x18\x03 \x01(\x04R\favailableSat\x12>\n" +
+	"\n" +
+	"operations\x18\x04 \x03(\v2\x1e.swapclientrpc.CreditOperationR\n" +
+	"operations\x12G\n" +
+	"\x0eledger_entries\x18\x05 \x03(\v2 .swapclientrpc.CreditLedgerEntryR\rledgerEntries\"\xe7\x01\n" +
+	"\vCreditQuote\x12&\n" +
+	"\x0fmust_use_credit\x18\x01 \x01(\bR\rmustUseCredit\x12,\n" +
+	"\x12credit_applied_sat\x18\x02 \x01(\x04R\x10creditAppliedSat\x120\n" +
+	"\x14credit_shortfall_sat\x18\x03 \x01(\x04R\x12creditShortfallSat\x12(\n" +
+	"\x10credit_topup_sat\x18\x04 \x01(\x04R\x0ecreditTopupSat\x12&\n" +
+	"\x0fark_funding_sat\x18\x05 \x01(\x04R\rarkFundingSat\"\xec\x03\n" +
+	"\x0fCreditOperation\x12!\n" +
+	"\foperation_id\x18\x01 \x01(\tR\voperationId\x126\n" +
+	"\x04type\x18\x02 \x01(\x0e2\".swapclientrpc.CreditOperationTypeR\x04type\x129\n" +
+	"\x05state\x18\x03 \x01(\x0e2#.swapclientrpc.CreditOperationStateR\x05state\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x05 \x01(\x04R\tamountSat\x12!\n" +
+	"\fpayment_hash\x18\x06 \x01(\tR\vpaymentHash\x12\x18\n" +
+	"\ainvoice\x18\a \x01(\tR\ainvoice\x12-\n" +
+	"\x12destination_pubkey\x18\b \x01(\fR\x11destinationPubkey\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\t \x01(\tR\tsessionId\x12&\n" +
+	"\x0fcreated_at_unix\x18\n" +
+	" \x01(\x03R\rcreatedAtUnix\x12&\n" +
+	"\x0fupdated_at_unix\x18\v \x01(\x03R\rupdatedAtUnix\x12*\n" +
+	"\x11completed_at_unix\x18\f \x01(\x03R\x0fcompletedAtUnix\x12\x1d\n" +
+	"\n" +
+	"last_error\x18\r \x01(\tR\tlastError\"\xb6\x01\n" +
+	"\x11CreditLedgerEntry\x12\x19\n" +
+	"\bentry_id\x18\x01 \x01(\tR\aentryId\x12!\n" +
+	"\foperation_id\x18\x02 \x01(\tR\voperationId\x12\x1c\n" +
+	"\tdirection\x18\x03 \x01(\tR\tdirection\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x04 \x01(\x04R\tamountSat\x12&\n" +
+	"\x0fcreated_at_unix\x18\x05 \x01(\x03R\rcreatedAtUnix\"q\n" +
 	"\x13StartReceiveRequest\x12\x1d\n" +
 	"\n" +
 	"amount_sat\x18\x01 \x01(\x03R\tamountSat\x12'\n" +
 	"\x0fidempotency_key\x18\x02 \x01(\tR\x0eidempotencyKey\x12\x12\n" +
-	"\x04memo\x18\x03 \x01(\tR\x04memo\"\x83\x01\n" +
+	"\x04memo\x18\x03 \x01(\tR\x04memo\"\xb3\x03\n" +
 	"\x14StartReceiveResponse\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\tR\vpaymentHash\x12\x18\n" +
 	"\ainvoice\x18\x02 \x01(\tR\ainvoice\x12.\n" +
-	"\x04swap\x18\x03 \x01(\v2\x1a.swapclientrpc.SwapSummaryR\x04swap\"r\n" +
+	"\x04swap\x18\x03 \x01(\v2\x1a.swapclientrpc.SwapSummaryR\x04swap\x120\n" +
+	"\x14requested_amount_sat\x18\x04 \x01(\x04R\x12requestedAmountSat\x120\n" +
+	"\x14available_credit_sat\x18\x05 \x01(\x04R\x12availableCreditSat\x12.\n" +
+	"\x13attached_credit_sat\x18\x06 \x01(\x04R\x11attachedCreditSat\x12(\n" +
+	"\x10vhtlc_amount_sat\x18\a \x01(\x04R\x0evhtlcAmountSat\x12$\n" +
+	"\x0edust_limit_sat\x18\b \x01(\x04R\fdustLimitSat\x12J\n" +
+	"\x0fsettlement_type\x18\t \x01(\x0e2!.swapclientrpc.SwapSettlementTypeR\x0esettlementType\"r\n" +
 	"\x11ResumeSwapRequest\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\tR\vpaymentHash\x12:\n" +
 	"\tdirection\x18\x02 \x01(\x0e2\x1c.swapclientrpc.SwapDirectionR\tdirection\"D\n" +
@@ -1258,7 +2362,7 @@ const file_swap_client_proto_rawDesc = "" +
 	"\x10include_existing\x18\x01 \x01(\bR\x0fincludeExisting\x12!\n" +
 	"\fpending_only\x18\x02 \x01(\bR\vpendingOnly\"H\n" +
 	"\x16SubscribeSwapsResponse\x12.\n" +
-	"\x04swap\x18\x01 \x01(\v2\x1a.swapclientrpc.SwapSummaryR\x04swap\"\xb5\x06\n" +
+	"\x04swap\x18\x01 \x01(\v2\x1a.swapclientrpc.SwapSummaryR\x04swap\"\xae\b\n" +
 	"\vSwapSummary\x12:\n" +
 	"\tdirection\x18\x01 \x01(\x0e2\x1c.swapclientrpc.SwapDirectionR\tdirection\x12!\n" +
 	"\fpayment_hash\x18\x02 \x01(\tR\vpaymentHash\x12.\n" +
@@ -1281,15 +2385,46 @@ const file_swap_client_proto_rawDesc = "" +
 	"\x0frefund_locktime\x18\x11 \x01(\rR\x0erefundLocktime\x12\x18\n" +
 	"\ainvoice\x18\x12 \x01(\tR\ainvoice\x12J\n" +
 	"\x0fsettlement_type\x18\x13 \x01(\x0e2!.swapclientrpc.SwapSettlementTypeR\x0esettlementType\x12#\n" +
-	"\rsender_pubkey\x18\x14 \x01(\tR\fsenderPubkey*c\n" +
+	"\rsender_pubkey\x18\x14 \x01(\tR\fsenderPubkey\x12=\n" +
+	"\fcredit_quote\x18\x15 \x01(\v2\x1a.swapclientrpc.CreditQuoteR\vcreditQuote\x120\n" +
+	"\x14requested_amount_sat\x18\x16 \x01(\x04R\x12requestedAmountSat\x12.\n" +
+	"\x13attached_credit_sat\x18\x17 \x01(\x04R\x11attachedCreditSat\x12$\n" +
+	"\x0edust_limit_sat\x18\x18 \x01(\x04R\fdustLimitSat\x120\n" +
+	"\x14available_credit_sat\x18\x19 \x01(\x04R\x12availableCreditSat*c\n" +
 	"\rSwapDirection\x12\x1e\n" +
 	"\x1aSWAP_DIRECTION_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12SWAP_DIRECTION_PAY\x10\x01\x12\x1a\n" +
-	"\x16SWAP_DIRECTION_RECEIVE\x10\x02*\x7f\n" +
+	"\x16SWAP_DIRECTION_RECEIVE\x10\x02*\xc0\x01\n" +
 	"\x12SwapSettlementType\x12$\n" +
 	" SWAP_SETTLEMENT_TYPE_UNSPECIFIED\x10\x00\x12\"\n" +
 	"\x1eSWAP_SETTLEMENT_TYPE_LIGHTNING\x10\x01\x12\x1f\n" +
-	"\x1bSWAP_SETTLEMENT_TYPE_IN_ARK\x10\x02*\xa3\x03\n" +
+	"\x1bSWAP_SETTLEMENT_TYPE_IN_ARK\x10\x02\x12\x1f\n" +
+	"\x1bSWAP_SETTLEMENT_TYPE_CREDIT\x10\x03\x12\x1e\n" +
+	"\x1aSWAP_SETTLEMENT_TYPE_MIXED\x10\x04*\x8e\x01\n" +
+	"\x13CreditFundingSource\x12%\n" +
+	"!CREDIT_FUNDING_SOURCE_UNSPECIFIED\x10\x00\x12+\n" +
+	"'CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE\x10\x01\x12#\n" +
+	"\x1fCREDIT_FUNDING_SOURCE_ARK_TOPUP\x10\x02*\xc7\x01\n" +
+	"\x13CreditOperationType\x12%\n" +
+	"!CREDIT_OPERATION_TYPE_UNSPECIFIED\x10\x00\x12!\n" +
+	"\x1dCREDIT_OPERATION_TYPE_FUNDING\x10\x01\x12\x1d\n" +
+	"\x19CREDIT_OPERATION_TYPE_PAY\x10\x02\x12$\n" +
+	" CREDIT_OPERATION_TYPE_REDEMPTION\x10\x03\x12!\n" +
+	"\x1dCREDIT_OPERATION_TYPE_RECEIVE\x10\x04*\xe3\x03\n" +
+	"\x14CreditOperationState\x12&\n" +
+	"\"CREDIT_OPERATION_STATE_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1eCREDIT_OPERATION_STATE_CREATED\x10\x01\x12+\n" +
+	"'CREDIT_OPERATION_STATE_AWAITING_PAYMENT\x10\x02\x12#\n" +
+	"\x1fCREDIT_OPERATION_STATE_CREDITED\x10\x03\x12#\n" +
+	"\x1fCREDIT_OPERATION_STATE_RESERVED\x10\x04\x12+\n" +
+	"'CREDIT_OPERATION_STATE_PAYING_LIGHTNING\x10\x05\x12\"\n" +
+	"\x1eCREDIT_OPERATION_STATE_DEBITED\x10\x06\x12&\n" +
+	"\"CREDIT_OPERATION_STATE_SENDING_OOR\x10\a\x12#\n" +
+	"\x1fCREDIT_OPERATION_STATE_REDEEMED\x10\b\x12#\n" +
+	"\x1fCREDIT_OPERATION_STATE_RELEASED\x10\t\x12\"\n" +
+	"\x1eCREDIT_OPERATION_STATE_EXPIRED\x10\n" +
+	"\x12!\n" +
+	"\x1dCREDIT_OPERATION_STATE_FAILED\x10\v*\xa3\x03\n" +
 	"\tSwapState\x12\x1a\n" +
 	"\x16SWAP_STATE_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12SWAP_STATE_CREATED\x10\x01\x12\x1b\n" +
@@ -1305,11 +2440,14 @@ const file_swap_client_proto_rawDesc = "" +
 	"\x12\x15\n" +
 	"\x11SWAP_STATE_FAILED\x10\v\x12\x1e\n" +
 	"\x1aSWAP_STATE_INVOICE_CREATED\x10\f\x12\x1e\n" +
-	"\x1aSWAP_STATE_CLAIM_INITIATED\x10\r2\xd4\x04\n" +
+	"\x1aSWAP_STATE_CLAIM_INITIATED\x10\r2\xdc\x06\n" +
 	"\x11SwapClientService\x12K\n" +
 	"\bQuotePay\x12\x1e.swapclientrpc.QuotePayRequest\x1a\x1f.swapclientrpc.QuotePayResponse\x12K\n" +
 	"\bStartPay\x12\x1e.swapclientrpc.StartPayRequest\x1a\x1f.swapclientrpc.StartPayResponse\x12W\n" +
-	"\fStartReceive\x12\".swapclientrpc.StartReceiveRequest\x1a#.swapclientrpc.StartReceiveResponse\x12Q\n" +
+	"\fStartReceive\x12\".swapclientrpc.StartReceiveRequest\x1a#.swapclientrpc.StartReceiveResponse\x12W\n" +
+	"\fCreateCredit\x12\".swapclientrpc.CreateCreditRequest\x1a#.swapclientrpc.CreateCreditResponse\x12W\n" +
+	"\fRedeemCredit\x12\".swapclientrpc.RedeemCreditRequest\x1a#.swapclientrpc.RedeemCreditResponse\x12T\n" +
+	"\vListCredits\x12!.swapclientrpc.ListCreditsRequest\x1a\".swapclientrpc.ListCreditsResponse\x12Q\n" +
 	"\n" +
 	"ResumeSwap\x12 .swapclientrpc.ResumeSwapRequest\x1a!.swapclientrpc.ResumeSwapResponse\x12N\n" +
 	"\tListSwaps\x12\x1f.swapclientrpc.ListSwapsRequest\x1a .swapclientrpc.ListSwapsResponse\x12H\n" +
@@ -1328,59 +2466,88 @@ func file_swap_client_proto_rawDescGZIP() []byte {
 	return file_swap_client_proto_rawDescData
 }
 
-var file_swap_client_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_swap_client_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_swap_client_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
+var file_swap_client_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_swap_client_proto_goTypes = []any{
 	(SwapDirection)(0),             // 0: swapclientrpc.SwapDirection
 	(SwapSettlementType)(0),        // 1: swapclientrpc.SwapSettlementType
-	(SwapState)(0),                 // 2: swapclientrpc.SwapState
-	(*QuotePayRequest)(nil),        // 3: swapclientrpc.QuotePayRequest
-	(*QuotePayResponse)(nil),       // 4: swapclientrpc.QuotePayResponse
-	(*StartPayRequest)(nil),        // 5: swapclientrpc.StartPayRequest
-	(*StartPayResponse)(nil),       // 6: swapclientrpc.StartPayResponse
-	(*StartReceiveRequest)(nil),    // 7: swapclientrpc.StartReceiveRequest
-	(*StartReceiveResponse)(nil),   // 8: swapclientrpc.StartReceiveResponse
-	(*ResumeSwapRequest)(nil),      // 9: swapclientrpc.ResumeSwapRequest
-	(*ResumeSwapResponse)(nil),     // 10: swapclientrpc.ResumeSwapResponse
-	(*ListSwapsRequest)(nil),       // 11: swapclientrpc.ListSwapsRequest
-	(*ListSwapsResponse)(nil),      // 12: swapclientrpc.ListSwapsResponse
-	(*GetSwapRequest)(nil),         // 13: swapclientrpc.GetSwapRequest
-	(*GetSwapResponse)(nil),        // 14: swapclientrpc.GetSwapResponse
-	(*SubscribeSwapsRequest)(nil),  // 15: swapclientrpc.SubscribeSwapsRequest
-	(*SubscribeSwapsResponse)(nil), // 16: swapclientrpc.SubscribeSwapsResponse
-	(*SwapSummary)(nil),            // 17: swapclientrpc.SwapSummary
+	(CreditFundingSource)(0),       // 2: swapclientrpc.CreditFundingSource
+	(CreditOperationType)(0),       // 3: swapclientrpc.CreditOperationType
+	(CreditOperationState)(0),      // 4: swapclientrpc.CreditOperationState
+	(SwapState)(0),                 // 5: swapclientrpc.SwapState
+	(*QuotePayRequest)(nil),        // 6: swapclientrpc.QuotePayRequest
+	(*QuotePayResponse)(nil),       // 7: swapclientrpc.QuotePayResponse
+	(*StartPayRequest)(nil),        // 8: swapclientrpc.StartPayRequest
+	(*StartPayResponse)(nil),       // 9: swapclientrpc.StartPayResponse
+	(*CreateCreditRequest)(nil),    // 10: swapclientrpc.CreateCreditRequest
+	(*CreateCreditResponse)(nil),   // 11: swapclientrpc.CreateCreditResponse
+	(*RedeemCreditRequest)(nil),    // 12: swapclientrpc.RedeemCreditRequest
+	(*RedeemCreditResponse)(nil),   // 13: swapclientrpc.RedeemCreditResponse
+	(*ListCreditsRequest)(nil),     // 14: swapclientrpc.ListCreditsRequest
+	(*ListCreditsResponse)(nil),    // 15: swapclientrpc.ListCreditsResponse
+	(*CreditQuote)(nil),            // 16: swapclientrpc.CreditQuote
+	(*CreditOperation)(nil),        // 17: swapclientrpc.CreditOperation
+	(*CreditLedgerEntry)(nil),      // 18: swapclientrpc.CreditLedgerEntry
+	(*StartReceiveRequest)(nil),    // 19: swapclientrpc.StartReceiveRequest
+	(*StartReceiveResponse)(nil),   // 20: swapclientrpc.StartReceiveResponse
+	(*ResumeSwapRequest)(nil),      // 21: swapclientrpc.ResumeSwapRequest
+	(*ResumeSwapResponse)(nil),     // 22: swapclientrpc.ResumeSwapResponse
+	(*ListSwapsRequest)(nil),       // 23: swapclientrpc.ListSwapsRequest
+	(*ListSwapsResponse)(nil),      // 24: swapclientrpc.ListSwapsResponse
+	(*GetSwapRequest)(nil),         // 25: swapclientrpc.GetSwapRequest
+	(*GetSwapResponse)(nil),        // 26: swapclientrpc.GetSwapResponse
+	(*SubscribeSwapsRequest)(nil),  // 27: swapclientrpc.SubscribeSwapsRequest
+	(*SubscribeSwapsResponse)(nil), // 28: swapclientrpc.SubscribeSwapsResponse
+	(*SwapSummary)(nil),            // 29: swapclientrpc.SwapSummary
 }
 var file_swap_client_proto_depIdxs = []int32{
 	1,  // 0: swapclientrpc.QuotePayResponse.settlement_type:type_name -> swapclientrpc.SwapSettlementType
-	17, // 1: swapclientrpc.StartPayResponse.swap:type_name -> swapclientrpc.SwapSummary
-	17, // 2: swapclientrpc.StartReceiveResponse.swap:type_name -> swapclientrpc.SwapSummary
-	0,  // 3: swapclientrpc.ResumeSwapRequest.direction:type_name -> swapclientrpc.SwapDirection
-	17, // 4: swapclientrpc.ResumeSwapResponse.swap:type_name -> swapclientrpc.SwapSummary
-	17, // 5: swapclientrpc.ListSwapsResponse.swaps:type_name -> swapclientrpc.SwapSummary
-	17, // 6: swapclientrpc.GetSwapResponse.swap:type_name -> swapclientrpc.SwapSummary
-	17, // 7: swapclientrpc.SubscribeSwapsResponse.swap:type_name -> swapclientrpc.SwapSummary
-	0,  // 8: swapclientrpc.SwapSummary.direction:type_name -> swapclientrpc.SwapDirection
-	2,  // 9: swapclientrpc.SwapSummary.state:type_name -> swapclientrpc.SwapState
-	1,  // 10: swapclientrpc.SwapSummary.settlement_type:type_name -> swapclientrpc.SwapSettlementType
-	3,  // 11: swapclientrpc.SwapClientService.QuotePay:input_type -> swapclientrpc.QuotePayRequest
-	5,  // 12: swapclientrpc.SwapClientService.StartPay:input_type -> swapclientrpc.StartPayRequest
-	7,  // 13: swapclientrpc.SwapClientService.StartReceive:input_type -> swapclientrpc.StartReceiveRequest
-	9,  // 14: swapclientrpc.SwapClientService.ResumeSwap:input_type -> swapclientrpc.ResumeSwapRequest
-	11, // 15: swapclientrpc.SwapClientService.ListSwaps:input_type -> swapclientrpc.ListSwapsRequest
-	13, // 16: swapclientrpc.SwapClientService.GetSwap:input_type -> swapclientrpc.GetSwapRequest
-	15, // 17: swapclientrpc.SwapClientService.SubscribeSwaps:input_type -> swapclientrpc.SubscribeSwapsRequest
-	4,  // 18: swapclientrpc.SwapClientService.QuotePay:output_type -> swapclientrpc.QuotePayResponse
-	6,  // 19: swapclientrpc.SwapClientService.StartPay:output_type -> swapclientrpc.StartPayResponse
-	8,  // 20: swapclientrpc.SwapClientService.StartReceive:output_type -> swapclientrpc.StartReceiveResponse
-	10, // 21: swapclientrpc.SwapClientService.ResumeSwap:output_type -> swapclientrpc.ResumeSwapResponse
-	12, // 22: swapclientrpc.SwapClientService.ListSwaps:output_type -> swapclientrpc.ListSwapsResponse
-	14, // 23: swapclientrpc.SwapClientService.GetSwap:output_type -> swapclientrpc.GetSwapResponse
-	16, // 24: swapclientrpc.SwapClientService.SubscribeSwaps:output_type -> swapclientrpc.SubscribeSwapsResponse
-	18, // [18:25] is the sub-list for method output_type
-	11, // [11:18] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	16, // 1: swapclientrpc.QuotePayResponse.credit_quote:type_name -> swapclientrpc.CreditQuote
+	29, // 2: swapclientrpc.StartPayResponse.swap:type_name -> swapclientrpc.SwapSummary
+	2,  // 3: swapclientrpc.CreateCreditRequest.source:type_name -> swapclientrpc.CreditFundingSource
+	4,  // 4: swapclientrpc.CreateCreditResponse.state:type_name -> swapclientrpc.CreditOperationState
+	29, // 5: swapclientrpc.CreateCreditResponse.swap:type_name -> swapclientrpc.SwapSummary
+	4,  // 6: swapclientrpc.RedeemCreditResponse.state:type_name -> swapclientrpc.CreditOperationState
+	17, // 7: swapclientrpc.ListCreditsResponse.operations:type_name -> swapclientrpc.CreditOperation
+	18, // 8: swapclientrpc.ListCreditsResponse.ledger_entries:type_name -> swapclientrpc.CreditLedgerEntry
+	3,  // 9: swapclientrpc.CreditOperation.type:type_name -> swapclientrpc.CreditOperationType
+	4,  // 10: swapclientrpc.CreditOperation.state:type_name -> swapclientrpc.CreditOperationState
+	29, // 11: swapclientrpc.StartReceiveResponse.swap:type_name -> swapclientrpc.SwapSummary
+	1,  // 12: swapclientrpc.StartReceiveResponse.settlement_type:type_name -> swapclientrpc.SwapSettlementType
+	0,  // 13: swapclientrpc.ResumeSwapRequest.direction:type_name -> swapclientrpc.SwapDirection
+	29, // 14: swapclientrpc.ResumeSwapResponse.swap:type_name -> swapclientrpc.SwapSummary
+	29, // 15: swapclientrpc.ListSwapsResponse.swaps:type_name -> swapclientrpc.SwapSummary
+	29, // 16: swapclientrpc.GetSwapResponse.swap:type_name -> swapclientrpc.SwapSummary
+	29, // 17: swapclientrpc.SubscribeSwapsResponse.swap:type_name -> swapclientrpc.SwapSummary
+	0,  // 18: swapclientrpc.SwapSummary.direction:type_name -> swapclientrpc.SwapDirection
+	5,  // 19: swapclientrpc.SwapSummary.state:type_name -> swapclientrpc.SwapState
+	1,  // 20: swapclientrpc.SwapSummary.settlement_type:type_name -> swapclientrpc.SwapSettlementType
+	16, // 21: swapclientrpc.SwapSummary.credit_quote:type_name -> swapclientrpc.CreditQuote
+	6,  // 22: swapclientrpc.SwapClientService.QuotePay:input_type -> swapclientrpc.QuotePayRequest
+	8,  // 23: swapclientrpc.SwapClientService.StartPay:input_type -> swapclientrpc.StartPayRequest
+	19, // 24: swapclientrpc.SwapClientService.StartReceive:input_type -> swapclientrpc.StartReceiveRequest
+	10, // 25: swapclientrpc.SwapClientService.CreateCredit:input_type -> swapclientrpc.CreateCreditRequest
+	12, // 26: swapclientrpc.SwapClientService.RedeemCredit:input_type -> swapclientrpc.RedeemCreditRequest
+	14, // 27: swapclientrpc.SwapClientService.ListCredits:input_type -> swapclientrpc.ListCreditsRequest
+	21, // 28: swapclientrpc.SwapClientService.ResumeSwap:input_type -> swapclientrpc.ResumeSwapRequest
+	23, // 29: swapclientrpc.SwapClientService.ListSwaps:input_type -> swapclientrpc.ListSwapsRequest
+	25, // 30: swapclientrpc.SwapClientService.GetSwap:input_type -> swapclientrpc.GetSwapRequest
+	27, // 31: swapclientrpc.SwapClientService.SubscribeSwaps:input_type -> swapclientrpc.SubscribeSwapsRequest
+	7,  // 32: swapclientrpc.SwapClientService.QuotePay:output_type -> swapclientrpc.QuotePayResponse
+	9,  // 33: swapclientrpc.SwapClientService.StartPay:output_type -> swapclientrpc.StartPayResponse
+	20, // 34: swapclientrpc.SwapClientService.StartReceive:output_type -> swapclientrpc.StartReceiveResponse
+	11, // 35: swapclientrpc.SwapClientService.CreateCredit:output_type -> swapclientrpc.CreateCreditResponse
+	13, // 36: swapclientrpc.SwapClientService.RedeemCredit:output_type -> swapclientrpc.RedeemCreditResponse
+	15, // 37: swapclientrpc.SwapClientService.ListCredits:output_type -> swapclientrpc.ListCreditsResponse
+	22, // 38: swapclientrpc.SwapClientService.ResumeSwap:output_type -> swapclientrpc.ResumeSwapResponse
+	24, // 39: swapclientrpc.SwapClientService.ListSwaps:output_type -> swapclientrpc.ListSwapsResponse
+	26, // 40: swapclientrpc.SwapClientService.GetSwap:output_type -> swapclientrpc.GetSwapResponse
+	28, // 41: swapclientrpc.SwapClientService.SubscribeSwaps:output_type -> swapclientrpc.SubscribeSwapsResponse
+	32, // [32:42] is the sub-list for method output_type
+	22, // [22:32] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_swap_client_proto_init() }
@@ -1393,8 +2560,8 @@ func file_swap_client_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_swap_client_proto_rawDesc), len(file_swap_client_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   15,
+			NumEnums:      6,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rpc/swapclientrpc/swap_client.pb.go
+++ b/rpc/swapclientrpc/swap_client.pb.go
@@ -575,9 +575,12 @@ type StartPayRequest struct {
 	IdempotencyKey string `protobuf:"bytes,3,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
 	// max_credit_sat is the maximum credit amount the caller authorizes this
 	// pay to reserve.
-	MaxCreditSat  uint64 `protobuf:"varint,4,opt,name=max_credit_sat,json=maxCreditSat,proto3" json:"max_credit_sat,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	MaxCreditSat uint64 `protobuf:"varint,4,opt,name=max_credit_sat,json=maxCreditSat,proto3" json:"max_credit_sat,omitempty"`
+	// max_credit_topup_sat is the accepted Ark credit top-up bound. Zero means
+	// StartPay must not fund new credits before paying.
+	MaxCreditTopupSat uint64 `protobuf:"varint,5,opt,name=max_credit_topup_sat,json=maxCreditTopupSat,proto3" json:"max_credit_topup_sat,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *StartPayRequest) Reset() {
@@ -634,6 +637,13 @@ func (x *StartPayRequest) GetIdempotencyKey() string {
 func (x *StartPayRequest) GetMaxCreditSat() uint64 {
 	if x != nil {
 		return x.MaxCreditSat
+	}
+	return 0
+}
+
+func (x *StartPayRequest) GetMaxCreditTopupSat() uint64 {
+	if x != nil {
+		return x.MaxCreditTopupSat
 	}
 	return 0
 }
@@ -2252,12 +2262,13 @@ const file_swap_client_proto_rawDesc = "" +
 	"\x0fsettlement_type\x18\x05 \x01(\x0e2!.swapclientrpc.SwapSettlementTypeR\x0esettlementType\x12&\n" +
 	"\x0fexpires_at_unix\x18\x06 \x01(\x03R\rexpiresAtUnix\x12&\n" +
 	"\x0fexceeds_max_fee\x18\a \x01(\bR\rexceedsMaxFee\x12=\n" +
-	"\fcredit_quote\x18\b \x01(\v2\x1a.swapclientrpc.CreditQuoteR\vcreditQuote\"\x9a\x01\n" +
+	"\fcredit_quote\x18\b \x01(\v2\x1a.swapclientrpc.CreditQuoteR\vcreditQuote\"\xcb\x01\n" +
 	"\x0fStartPayRequest\x12\x18\n" +
 	"\ainvoice\x18\x01 \x01(\tR\ainvoice\x12\x1e\n" +
 	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\x12'\n" +
 	"\x0fidempotency_key\x18\x03 \x01(\tR\x0eidempotencyKey\x12$\n" +
-	"\x0emax_credit_sat\x18\x04 \x01(\x04R\fmaxCreditSat\"e\n" +
+	"\x0emax_credit_sat\x18\x04 \x01(\x04R\fmaxCreditSat\x12/\n" +
+	"\x14max_credit_topup_sat\x18\x05 \x01(\x04R\x11maxCreditTopupSat\"e\n" +
 	"\x10StartPayResponse\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\tR\vpaymentHash\x12.\n" +
 	"\x04swap\x18\x02 \x01(\v2\x1a.swapclientrpc.SwapSummaryR\x04swap\"\xad\x01\n" +

--- a/rpc/swapclientrpc/swap_client.pb.gw.go
+++ b/rpc/swapclientrpc/swap_client.pb.gw.go
@@ -116,6 +116,87 @@ func local_request_SwapClientService_StartReceive_0(ctx context.Context, marshal
 	return msg, metadata, err
 }
 
+func request_SwapClientService_CreateCredit_0(ctx context.Context, marshaler runtime.Marshaler, client SwapClientServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateCreditRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.CreateCredit(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SwapClientService_CreateCredit_0(ctx context.Context, marshaler runtime.Marshaler, server SwapClientServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateCreditRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.CreateCredit(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_SwapClientService_RedeemCredit_0(ctx context.Context, marshaler runtime.Marshaler, client SwapClientServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RedeemCreditRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.RedeemCredit(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SwapClientService_RedeemCredit_0(ctx context.Context, marshaler runtime.Marshaler, server SwapClientServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RedeemCreditRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.RedeemCredit(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_SwapClientService_ListCredits_0(ctx context.Context, marshaler runtime.Marshaler, client SwapClientServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListCreditsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListCredits(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SwapClientService_ListCredits_0(ctx context.Context, marshaler runtime.Marshaler, server SwapClientServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListCreditsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ListCredits(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_SwapClientService_ResumeSwap_0(ctx context.Context, marshaler runtime.Marshaler, client SwapClientServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq ResumeSwapRequest
@@ -286,6 +367,66 @@ func RegisterSwapClientServiceHandlerServer(ctx context.Context, mux *runtime.Se
 		}
 		forward_SwapClientService_StartReceive_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_SwapClientService_CreateCredit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/swapclientrpc.SwapClientService/CreateCredit", runtime.WithHTTPPathPattern("/v1/swapclient/create-credit"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SwapClientService_CreateCredit_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapClientService_CreateCredit_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SwapClientService_RedeemCredit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/swapclientrpc.SwapClientService/RedeemCredit", runtime.WithHTTPPathPattern("/v1/swapclient/redeem-credit"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SwapClientService_RedeemCredit_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapClientService_RedeemCredit_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SwapClientService_ListCredits_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/swapclientrpc.SwapClientService/ListCredits", runtime.WithHTTPPathPattern("/v1/swapclient/list-credits"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SwapClientService_ListCredits_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapClientService_ListCredits_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_SwapClientService_ResumeSwap_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -444,6 +585,57 @@ func RegisterSwapClientServiceHandlerClient(ctx context.Context, mux *runtime.Se
 		}
 		forward_SwapClientService_StartReceive_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_SwapClientService_CreateCredit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/swapclientrpc.SwapClientService/CreateCredit", runtime.WithHTTPPathPattern("/v1/swapclient/create-credit"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SwapClientService_CreateCredit_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapClientService_CreateCredit_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SwapClientService_RedeemCredit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/swapclientrpc.SwapClientService/RedeemCredit", runtime.WithHTTPPathPattern("/v1/swapclient/redeem-credit"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SwapClientService_RedeemCredit_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapClientService_RedeemCredit_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SwapClientService_ListCredits_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/swapclientrpc.SwapClientService/ListCredits", runtime.WithHTTPPathPattern("/v1/swapclient/list-credits"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SwapClientService_ListCredits_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapClientService_ListCredits_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_SwapClientService_ResumeSwap_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -519,6 +711,9 @@ var (
 	pattern_SwapClientService_QuotePay_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swapclient", "quote-pay"}, ""))
 	pattern_SwapClientService_StartPay_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swapclient", "start-pay"}, ""))
 	pattern_SwapClientService_StartReceive_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swapclient", "start-receive"}, ""))
+	pattern_SwapClientService_CreateCredit_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swapclient", "create-credit"}, ""))
+	pattern_SwapClientService_RedeemCredit_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swapclient", "redeem-credit"}, ""))
+	pattern_SwapClientService_ListCredits_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swapclient", "list-credits"}, ""))
 	pattern_SwapClientService_ResumeSwap_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swapclient", "resume-swap"}, ""))
 	pattern_SwapClientService_ListSwaps_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swapclient", "list-swaps"}, ""))
 	pattern_SwapClientService_GetSwap_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swapclient", "get-swap"}, ""))
@@ -529,6 +724,9 @@ var (
 	forward_SwapClientService_QuotePay_0       = runtime.ForwardResponseMessage
 	forward_SwapClientService_StartPay_0       = runtime.ForwardResponseMessage
 	forward_SwapClientService_StartReceive_0   = runtime.ForwardResponseMessage
+	forward_SwapClientService_CreateCredit_0   = runtime.ForwardResponseMessage
+	forward_SwapClientService_RedeemCredit_0   = runtime.ForwardResponseMessage
+	forward_SwapClientService_ListCredits_0    = runtime.ForwardResponseMessage
 	forward_SwapClientService_ResumeSwap_0     = runtime.ForwardResponseMessage
 	forward_SwapClientService_ListSwaps_0      = runtime.ForwardResponseMessage
 	forward_SwapClientService_GetSwap_0        = runtime.ForwardResponseMessage

--- a/rpc/swapclientrpc/swap_client.proto
+++ b/rpc/swapclientrpc/swap_client.proto
@@ -19,6 +19,15 @@ service SwapClientService {
     // continue the claim flow after the invoice is paid.
     rpc StartReceive (StartReceiveRequest) returns (StartReceiveResponse);
 
+    // CreateCredit starts a durable credit funding session.
+    rpc CreateCredit (CreateCreditRequest) returns (CreateCreditResponse);
+
+    // RedeemCredit materializes available credits back into an Ark output.
+    rpc RedeemCredit (RedeemCreditRequest) returns (RedeemCreditResponse);
+
+    // ListCredits returns the server-authoritative credit account snapshot.
+    rpc ListCredits (ListCreditsRequest) returns (ListCreditsResponse);
+
     // ResumeSwap asks the daemon to resume one persisted pending swap.
     rpc ResumeSwap (ResumeSwapRequest) returns (ResumeSwapResponse);
 
@@ -46,6 +55,37 @@ enum SwapSettlementType {
     SWAP_SETTLEMENT_TYPE_UNSPECIFIED = 0;
     SWAP_SETTLEMENT_TYPE_LIGHTNING = 1;
     SWAP_SETTLEMENT_TYPE_IN_ARK = 2;
+    SWAP_SETTLEMENT_TYPE_CREDIT = 3;
+    SWAP_SETTLEMENT_TYPE_MIXED = 4;
+}
+
+enum CreditFundingSource {
+    CREDIT_FUNDING_SOURCE_UNSPECIFIED = 0;
+    CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE = 1;
+    CREDIT_FUNDING_SOURCE_ARK_TOPUP = 2;
+}
+
+enum CreditOperationType {
+    CREDIT_OPERATION_TYPE_UNSPECIFIED = 0;
+    CREDIT_OPERATION_TYPE_FUNDING = 1;
+    CREDIT_OPERATION_TYPE_PAY = 2;
+    CREDIT_OPERATION_TYPE_REDEMPTION = 3;
+    CREDIT_OPERATION_TYPE_RECEIVE = 4;
+}
+
+enum CreditOperationState {
+    CREDIT_OPERATION_STATE_UNSPECIFIED = 0;
+    CREDIT_OPERATION_STATE_CREATED = 1;
+    CREDIT_OPERATION_STATE_AWAITING_PAYMENT = 2;
+    CREDIT_OPERATION_STATE_CREDITED = 3;
+    CREDIT_OPERATION_STATE_RESERVED = 4;
+    CREDIT_OPERATION_STATE_PAYING_LIGHTNING = 5;
+    CREDIT_OPERATION_STATE_DEBITED = 6;
+    CREDIT_OPERATION_STATE_SENDING_OOR = 7;
+    CREDIT_OPERATION_STATE_REDEEMED = 8;
+    CREDIT_OPERATION_STATE_RELEASED = 9;
+    CREDIT_OPERATION_STATE_EXPIRED = 10;
+    CREDIT_OPERATION_STATE_FAILED = 11;
 }
 
 enum SwapState {
@@ -73,6 +113,11 @@ message QuotePayRequest {
     // Zero means no explicit caller cap. Quotes still return when the
     // estimated fee exceeds this cap so callers can render the fee.
     uint64 max_fee_sat = 2;
+
+    // max_credit_sat is the maximum credit amount the caller is willing to
+    // use for this quote. Zero means only required-credit shortfalls are
+    // reported.
+    uint64 max_credit_sat = 3;
 }
 
 message QuotePayResponse {
@@ -80,7 +125,7 @@ message QuotePayResponse {
     // invoice and eventual swap.
     string payment_hash = 1;
 
-    // invoice_amount_sat is the whole-satoshi invoice amount.
+    // invoice_amount_sat is the sat-denominated invoice amount.
     uint64 invoice_amount_sat = 2;
 
     // amount_sat is the total amount that would leave the wallet.
@@ -97,6 +142,8 @@ message QuotePayResponse {
     // exceeds_max_fee is true when max_fee_sat is non-zero and fee_sat is
     // larger than that cap.
     bool exceeds_max_fee = 7;
+
+    CreditQuote credit_quote = 8;
 }
 
 message StartPayRequest {
@@ -111,6 +158,10 @@ message StartPayRequest {
     // guard. The current implementation relies on the persisted swap state
     // returned by the SDK once the payment hash is known.
     string idempotency_key = 3;
+
+    // max_credit_sat is the maximum credit amount the caller authorizes this
+    // pay to reserve.
+    uint64 max_credit_sat = 4;
 }
 
 message StartPayResponse {
@@ -121,6 +172,81 @@ message StartPayResponse {
     // swap is the initial durable summary after the pay session is persisted
     // and daemon background execution has been scheduled.
     SwapSummary swap = 2;
+}
+
+message CreateCreditRequest {
+    string idempotency_key = 1;
+    CreditFundingSource source = 2;
+    uint64 amount_sat = 4;
+    string memo = 5;
+}
+
+message CreateCreditResponse {
+    string operation_id = 1;
+    CreditOperationState state = 2;
+    string invoice = 3;
+    string payment_hash = 4;
+    uint64 amount_sat = 6;
+    bytes destination_pubkey = 7;
+    int64 expires_at_unix = 8;
+    SwapSummary swap = 9;
+}
+
+message RedeemCreditRequest {
+    string idempotency_key = 1;
+    uint64 amount_sat = 2;
+    bytes destination_pubkey = 3;
+}
+
+message RedeemCreditResponse {
+    string operation_id = 1;
+    CreditOperationState state = 2;
+    uint64 debited_sat = 3;
+    uint64 redeemed_sat = 4;
+    string session_id = 6;
+}
+
+message ListCreditsRequest {
+    uint32 limit = 1;
+}
+
+message ListCreditsResponse {
+    uint64 finalized_sat = 1;
+    uint64 reserved_sat = 2;
+    uint64 available_sat = 3;
+    repeated CreditOperation operations = 4;
+    repeated CreditLedgerEntry ledger_entries = 5;
+}
+
+message CreditQuote {
+    bool must_use_credit = 1;
+    uint64 credit_applied_sat = 2;
+    uint64 credit_shortfall_sat = 3;
+    uint64 credit_topup_sat = 4;
+    uint64 ark_funding_sat = 5;
+}
+
+message CreditOperation {
+    string operation_id = 1;
+    CreditOperationType type = 2;
+    CreditOperationState state = 3;
+    uint64 amount_sat = 5;
+    string payment_hash = 6;
+    string invoice = 7;
+    bytes destination_pubkey = 8;
+    string session_id = 9;
+    int64 created_at_unix = 10;
+    int64 updated_at_unix = 11;
+    int64 completed_at_unix = 12;
+    string last_error = 13;
+}
+
+message CreditLedgerEntry {
+    string entry_id = 1;
+    string operation_id = 2;
+    string direction = 3;
+    uint64 amount_sat = 4;
+    int64 created_at_unix = 5;
 }
 
 message StartReceiveRequest {
@@ -147,6 +273,26 @@ message StartReceiveResponse {
     // swap is the initial durable summary after the receive session is
     // persisted and daemon background execution has been scheduled.
     SwapSummary swap = 3;
+
+    // requested_amount_sat is the invoice amount requested by the receiver.
+    uint64 requested_amount_sat = 4;
+
+    // available_credit_sat is the server-authoritative credit balance
+    // considered for the receive plan.
+    uint64 available_credit_sat = 5;
+
+    // attached_credit_sat is the credit amount reserved and added to the funded
+    // vHTLC for credit-assisted receives.
+    uint64 attached_credit_sat = 6;
+
+    // vhtlc_amount_sat is the funded vHTLC amount the client expects.
+    uint64 vhtlc_amount_sat = 7;
+
+    // dust_limit_sat is the minimum vHTLC output amount used by the server.
+    uint64 dust_limit_sat = 8;
+
+    // settlement_type identifies the selected receive rail.
+    SwapSettlementType settlement_type = 9;
 }
 
 message ResumeSwapRequest {
@@ -259,4 +405,21 @@ message SwapSummary {
 
     // sender_pubkey is the compressed SEC-encoded vHTLC sender key when known.
     string sender_pubkey = 20;
+
+    CreditQuote credit_quote = 21;
+
+    // requested_amount_sat is the invoice amount for receive swaps when it can
+    // differ from the funded vHTLC amount.
+    uint64 requested_amount_sat = 22;
+
+    // attached_credit_sat is the credit amount attached to a credit-assisted
+    // receive.
+    uint64 attached_credit_sat = 23;
+
+    // dust_limit_sat is the server dust limit used for receive planning.
+    uint64 dust_limit_sat = 24;
+
+    // available_credit_sat is the balance considered when the receive route was
+    // planned.
+    uint64 available_credit_sat = 25;
 }

--- a/rpc/swapclientrpc/swap_client.proto
+++ b/rpc/swapclientrpc/swap_client.proto
@@ -162,6 +162,10 @@ message StartPayRequest {
     // max_credit_sat is the maximum credit amount the caller authorizes this
     // pay to reserve.
     uint64 max_credit_sat = 4;
+
+    // max_credit_topup_sat is the accepted Ark credit top-up bound. Zero means
+    // StartPay must not fund new credits before paying.
+    uint64 max_credit_topup_sat = 5;
 }
 
 message StartPayResponse {

--- a/rpc/swapclientrpc/swap_client.yaml
+++ b/rpc/swapclientrpc/swap_client.yaml
@@ -12,6 +12,15 @@ http:
     - selector: swapclientrpc.SwapClientService.StartReceive
       post: /v1/swapclient/start-receive
       body: "*"
+    - selector: swapclientrpc.SwapClientService.CreateCredit
+      post: /v1/swapclient/create-credit
+      body: "*"
+    - selector: swapclientrpc.SwapClientService.RedeemCredit
+      post: /v1/swapclient/redeem-credit
+      body: "*"
+    - selector: swapclientrpc.SwapClientService.ListCredits
+      post: /v1/swapclient/list-credits
+      body: "*"
     - selector: swapclientrpc.SwapClientService.ResumeSwap
       post: /v1/swapclient/resume-swap
       body: "*"

--- a/rpc/swapclientrpc/swap_client_grpc.pb.go
+++ b/rpc/swapclientrpc/swap_client_grpc.pb.go
@@ -22,6 +22,9 @@ const (
 	SwapClientService_QuotePay_FullMethodName       = "/swapclientrpc.SwapClientService/QuotePay"
 	SwapClientService_StartPay_FullMethodName       = "/swapclientrpc.SwapClientService/StartPay"
 	SwapClientService_StartReceive_FullMethodName   = "/swapclientrpc.SwapClientService/StartReceive"
+	SwapClientService_CreateCredit_FullMethodName   = "/swapclientrpc.SwapClientService/CreateCredit"
+	SwapClientService_RedeemCredit_FullMethodName   = "/swapclientrpc.SwapClientService/RedeemCredit"
+	SwapClientService_ListCredits_FullMethodName    = "/swapclientrpc.SwapClientService/ListCredits"
 	SwapClientService_ResumeSwap_FullMethodName     = "/swapclientrpc.SwapClientService/ResumeSwap"
 	SwapClientService_ListSwaps_FullMethodName      = "/swapclientrpc.SwapClientService/ListSwaps"
 	SwapClientService_GetSwap_FullMethodName        = "/swapclientrpc.SwapClientService/GetSwap"
@@ -44,6 +47,12 @@ type SwapClientServiceClient interface {
 	// StartReceive starts a Lightning-to-Ark receive swap and lets the daemon
 	// continue the claim flow after the invoice is paid.
 	StartReceive(ctx context.Context, in *StartReceiveRequest, opts ...grpc.CallOption) (*StartReceiveResponse, error)
+	// CreateCredit starts a durable credit funding session.
+	CreateCredit(ctx context.Context, in *CreateCreditRequest, opts ...grpc.CallOption) (*CreateCreditResponse, error)
+	// RedeemCredit materializes available credits back into an Ark output.
+	RedeemCredit(ctx context.Context, in *RedeemCreditRequest, opts ...grpc.CallOption) (*RedeemCreditResponse, error)
+	// ListCredits returns the server-authoritative credit account snapshot.
+	ListCredits(ctx context.Context, in *ListCreditsRequest, opts ...grpc.CallOption) (*ListCreditsResponse, error)
 	// ResumeSwap asks the daemon to resume one persisted pending swap.
 	ResumeSwap(ctx context.Context, in *ResumeSwapRequest, opts ...grpc.CallOption) (*ResumeSwapResponse, error)
 	// ListSwaps lists persisted swap sessions from the daemon-owned store.
@@ -89,6 +98,36 @@ func (c *swapClientServiceClient) StartReceive(ctx context.Context, in *StartRec
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(StartReceiveResponse)
 	err := c.cc.Invoke(ctx, SwapClientService_StartReceive_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *swapClientServiceClient) CreateCredit(ctx context.Context, in *CreateCreditRequest, opts ...grpc.CallOption) (*CreateCreditResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateCreditResponse)
+	err := c.cc.Invoke(ctx, SwapClientService_CreateCredit_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *swapClientServiceClient) RedeemCredit(ctx context.Context, in *RedeemCreditRequest, opts ...grpc.CallOption) (*RedeemCreditResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RedeemCreditResponse)
+	err := c.cc.Invoke(ctx, SwapClientService_RedeemCredit_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *swapClientServiceClient) ListCredits(ctx context.Context, in *ListCreditsRequest, opts ...grpc.CallOption) (*ListCreditsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListCreditsResponse)
+	err := c.cc.Invoke(ctx, SwapClientService_ListCredits_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -160,6 +199,12 @@ type SwapClientServiceServer interface {
 	// StartReceive starts a Lightning-to-Ark receive swap and lets the daemon
 	// continue the claim flow after the invoice is paid.
 	StartReceive(context.Context, *StartReceiveRequest) (*StartReceiveResponse, error)
+	// CreateCredit starts a durable credit funding session.
+	CreateCredit(context.Context, *CreateCreditRequest) (*CreateCreditResponse, error)
+	// RedeemCredit materializes available credits back into an Ark output.
+	RedeemCredit(context.Context, *RedeemCreditRequest) (*RedeemCreditResponse, error)
+	// ListCredits returns the server-authoritative credit account snapshot.
+	ListCredits(context.Context, *ListCreditsRequest) (*ListCreditsResponse, error)
 	// ResumeSwap asks the daemon to resume one persisted pending swap.
 	ResumeSwap(context.Context, *ResumeSwapRequest) (*ResumeSwapResponse, error)
 	// ListSwaps lists persisted swap sessions from the daemon-owned store.
@@ -189,6 +234,15 @@ func (UnimplementedSwapClientServiceServer) StartPay(context.Context, *StartPayR
 }
 func (UnimplementedSwapClientServiceServer) StartReceive(context.Context, *StartReceiveRequest) (*StartReceiveResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method StartReceive not implemented")
+}
+func (UnimplementedSwapClientServiceServer) CreateCredit(context.Context, *CreateCreditRequest) (*CreateCreditResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateCredit not implemented")
+}
+func (UnimplementedSwapClientServiceServer) RedeemCredit(context.Context, *RedeemCreditRequest) (*RedeemCreditResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RedeemCredit not implemented")
+}
+func (UnimplementedSwapClientServiceServer) ListCredits(context.Context, *ListCreditsRequest) (*ListCreditsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListCredits not implemented")
 }
 func (UnimplementedSwapClientServiceServer) ResumeSwap(context.Context, *ResumeSwapRequest) (*ResumeSwapResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ResumeSwap not implemented")
@@ -277,6 +331,60 @@ func _SwapClientService_StartReceive_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SwapClientService_CreateCredit_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateCreditRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SwapClientServiceServer).CreateCredit(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SwapClientService_CreateCredit_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SwapClientServiceServer).CreateCredit(ctx, req.(*CreateCreditRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SwapClientService_RedeemCredit_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RedeemCreditRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SwapClientServiceServer).RedeemCredit(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SwapClientService_RedeemCredit_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SwapClientServiceServer).RedeemCredit(ctx, req.(*RedeemCreditRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SwapClientService_ListCredits_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListCreditsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SwapClientServiceServer).ListCredits(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SwapClientService_ListCredits_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SwapClientServiceServer).ListCredits(ctx, req.(*ListCreditsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _SwapClientService_ResumeSwap_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ResumeSwapRequest)
 	if err := dec(in); err != nil {
@@ -360,6 +468,18 @@ var SwapClientService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "StartReceive",
 			Handler:    _SwapClientService_StartReceive_Handler,
+		},
+		{
+			MethodName: "CreateCredit",
+			Handler:    _SwapClientService_CreateCredit_Handler,
+		},
+		{
+			MethodName: "RedeemCredit",
+			Handler:    _SwapClientService_RedeemCredit_Handler,
+		},
+		{
+			MethodName: "ListCredits",
+			Handler:    _SwapClientService_ListCredits_Handler,
 		},
 		{
 			MethodName: "ResumeSwap",

--- a/rpc/swapclientrpc/swap_client_mailboxrpc.pb.go
+++ b/rpc/swapclientrpc/swap_client_mailboxrpc.pb.go
@@ -30,6 +30,12 @@ type SwapClientServiceMailboxServer interface {
 	StartPay(ctx context.Context, req *StartPayRequest) (*StartPayResponse, error)
 	// StartReceive handles StartReceive.
 	StartReceive(ctx context.Context, req *StartReceiveRequest) (*StartReceiveResponse, error)
+	// CreateCredit handles CreateCredit.
+	CreateCredit(ctx context.Context, req *CreateCreditRequest) (*CreateCreditResponse, error)
+	// RedeemCredit handles RedeemCredit.
+	RedeemCredit(ctx context.Context, req *RedeemCreditRequest) (*RedeemCreditResponse, error)
+	// ListCredits handles ListCredits.
+	ListCredits(ctx context.Context, req *ListCreditsRequest) (*ListCreditsResponse, error)
 	// ResumeSwap handles ResumeSwap.
 	ResumeSwap(ctx context.Context, req *ResumeSwapRequest) (*ResumeSwapResponse, error)
 	// ListSwaps handles ListSwaps.
@@ -71,6 +77,36 @@ func RegisterSwapClientServiceMailboxServer(r rpc.Router, impl SwapClientService
 		}
 
 		return impl.StartReceive(ctx, req)
+	})
+	r.Handle("swapclientrpc.SwapClientService", "CreateCredit", func() proto.Message {
+		return &CreateCreditRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*CreateCreditRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.CreateCredit(ctx, req)
+	})
+	r.Handle("swapclientrpc.SwapClientService", "RedeemCredit", func() proto.Message {
+		return &RedeemCreditRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*RedeemCreditRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.RedeemCredit(ctx, req)
+	})
+	r.Handle("swapclientrpc.SwapClientService", "ListCredits", func() proto.Message {
+		return &ListCreditsRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ListCreditsRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ListCredits(ctx, req)
 	})
 	r.Handle("swapclientrpc.SwapClientService", "ResumeSwap", func() proto.Message {
 		return &ResumeSwapRequest{}
@@ -176,6 +212,75 @@ func (c *SwapClientServiceMailboxClient) StartReceive(ctx context.Context, req *
 	}
 
 	resp := new(StartReceiveResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// CreateCredit calls the CreateCredit RPC.
+func (c *SwapClientServiceMailboxClient) CreateCredit(ctx context.Context, req *CreateCreditRequest, opts ...rpc.RPCOptions) (*CreateCreditResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "swapclientrpc.SwapClientService",
+		Method:  "CreateCredit",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(CreateCreditResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// RedeemCredit calls the RedeemCredit RPC.
+func (c *SwapClientServiceMailboxClient) RedeemCredit(ctx context.Context, req *RedeemCreditRequest, opts ...rpc.RPCOptions) (*RedeemCreditResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "swapclientrpc.SwapClientService",
+		Method:  "RedeemCredit",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(RedeemCreditResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ListCredits calls the ListCredits RPC.
+func (c *SwapClientServiceMailboxClient) ListCredits(ctx context.Context, req *ListCreditsRequest, opts ...rpc.RPCOptions) (*ListCreditsResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "swapclientrpc.SwapClientService",
+		Method:  "ListCredits",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ListCreditsResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/rpc/walletdkrpc/wallet.pb.go
+++ b/rpc/walletdkrpc/wallet.pb.go
@@ -209,6 +209,8 @@ const (
 	SendRail_SEND_RAIL_IN_ARK           SendRail = 2
 	SendRail_SEND_RAIL_LIGHTNING        SendRail = 3
 	SendRail_SEND_RAIL_ONCHAIN          SendRail = 4
+	SendRail_SEND_RAIL_CREDIT           SendRail = 5
+	SendRail_SEND_RAIL_MIXED            SendRail = 6
 )
 
 // Enum value maps for SendRail.
@@ -219,6 +221,8 @@ var (
 		2: "SEND_RAIL_IN_ARK",
 		3: "SEND_RAIL_LIGHTNING",
 		4: "SEND_RAIL_ONCHAIN",
+		5: "SEND_RAIL_CREDIT",
+		6: "SEND_RAIL_MIXED",
 	}
 	SendRail_value = map[string]int32{
 		"SEND_RAIL_UNSPECIFIED":      0,
@@ -226,6 +230,8 @@ var (
 		"SEND_RAIL_IN_ARK":           2,
 		"SEND_RAIL_LIGHTNING":        3,
 		"SEND_RAIL_ONCHAIN":          4,
+		"SEND_RAIL_CREDIT":           5,
+		"SEND_RAIL_MIXED":            6,
 	}
 )
 
@@ -1072,7 +1078,10 @@ type PrepareSendResponse struct {
 	SelectedOutpoints []string `protobuf:"bytes,13,rep,name=selected_outpoints,json=selectedOutpoints,proto3" json:"selected_outpoints,omitempty"`
 	// warning carries a concise human-facing caveat for local-only
 	// previews.
-	Warning       string `protobuf:"bytes,14,opt,name=warning,proto3" json:"warning,omitempty"`
+	Warning string `protobuf:"bytes,14,opt,name=warning,proto3" json:"warning,omitempty"`
+	// credit_preview is populated when the invoice send will or can use
+	// sat-native server credits.
+	CreditPreview *CreditPreview `protobuf:"bytes,15,opt,name=credit_preview,json=creditPreview,proto3" json:"credit_preview,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1203,6 +1212,13 @@ func (x *PrepareSendResponse) GetWarning() string {
 		return x.Warning
 	}
 	return ""
+}
+
+func (x *PrepareSendResponse) GetCreditPreview() *CreditPreview {
+	if x != nil {
+		return x.CreditPreview
+	}
+	return nil
 }
 
 type SendRequest struct {
@@ -1374,7 +1390,10 @@ type RecvResponse struct {
 	// the payer.
 	Invoice string `protobuf:"bytes,1,opt,name=invoice,proto3" json:"invoice,omitempty"`
 	// entry is the initial WalletEntry persisted for this receive.
-	Entry         *WalletEntry `protobuf:"bytes,2,opt,name=entry,proto3" json:"entry,omitempty"`
+	Entry *WalletEntry `protobuf:"bytes,2,opt,name=entry,proto3" json:"entry,omitempty"`
+	// credit_receive is populated when the receive is backed by server credits
+	// rather than a client-claimable vHTLC.
+	CreditReceive *CreditReceive `protobuf:"bytes,3,opt,name=credit_receive,json=creditReceive,proto3" json:"credit_receive,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1423,6 +1442,149 @@ func (x *RecvResponse) GetEntry() *WalletEntry {
 	return nil
 }
 
+func (x *RecvResponse) GetCreditReceive() *CreditReceive {
+	if x != nil {
+		return x.CreditReceive
+	}
+	return nil
+}
+
+type CreditPreview struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	MustUseCredit      bool                   `protobuf:"varint,1,opt,name=must_use_credit,json=mustUseCredit,proto3" json:"must_use_credit,omitempty"`
+	CreditAppliedSat   uint64                 `protobuf:"varint,2,opt,name=credit_applied_sat,json=creditAppliedSat,proto3" json:"credit_applied_sat,omitempty"`
+	CreditShortfallSat uint64                 `protobuf:"varint,3,opt,name=credit_shortfall_sat,json=creditShortfallSat,proto3" json:"credit_shortfall_sat,omitempty"`
+	CreditTopupSat     uint64                 `protobuf:"varint,4,opt,name=credit_topup_sat,json=creditTopupSat,proto3" json:"credit_topup_sat,omitempty"`
+	ArkFundingSat      uint64                 `protobuf:"varint,5,opt,name=ark_funding_sat,json=arkFundingSat,proto3" json:"ark_funding_sat,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *CreditPreview) Reset() {
+	*x = CreditPreview{}
+	mi := &file_wallet_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreditPreview) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreditPreview) ProtoMessage() {}
+
+func (x *CreditPreview) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreditPreview.ProtoReflect.Descriptor instead.
+func (*CreditPreview) Descriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *CreditPreview) GetMustUseCredit() bool {
+	if x != nil {
+		return x.MustUseCredit
+	}
+	return false
+}
+
+func (x *CreditPreview) GetCreditAppliedSat() uint64 {
+	if x != nil {
+		return x.CreditAppliedSat
+	}
+	return 0
+}
+
+func (x *CreditPreview) GetCreditShortfallSat() uint64 {
+	if x != nil {
+		return x.CreditShortfallSat
+	}
+	return 0
+}
+
+func (x *CreditPreview) GetCreditTopupSat() uint64 {
+	if x != nil {
+		return x.CreditTopupSat
+	}
+	return 0
+}
+
+func (x *CreditPreview) GetArkFundingSat() uint64 {
+	if x != nil {
+		return x.ArkFundingSat
+	}
+	return 0
+}
+
+type CreditReceive struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	OperationId   string                 `protobuf:"bytes,1,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"`
+	AmountSat     uint64                 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	PaymentHash   string                 `protobuf:"bytes,3,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreditReceive) Reset() {
+	*x = CreditReceive{}
+	mi := &file_wallet_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreditReceive) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreditReceive) ProtoMessage() {}
+
+func (x *CreditReceive) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreditReceive.ProtoReflect.Descriptor instead.
+func (*CreditReceive) Descriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *CreditReceive) GetOperationId() string {
+	if x != nil {
+		return x.OperationId
+	}
+	return ""
+}
+
+func (x *CreditReceive) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *CreditReceive) GetPaymentHash() string {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return ""
+}
+
 type ListRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// view selects which slice of wallet state to return. The default
@@ -1453,7 +1615,7 @@ type ListRequest struct {
 
 func (x *ListRequest) Reset() {
 	*x = ListRequest{}
-	mi := &file_wallet_proto_msgTypes[10]
+	mi := &file_wallet_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1465,7 +1627,7 @@ func (x *ListRequest) String() string {
 func (*ListRequest) ProtoMessage() {}
 
 func (x *ListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[10]
+	mi := &file_wallet_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1478,7 +1640,7 @@ func (x *ListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRequest.ProtoReflect.Descriptor instead.
 func (*ListRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{10}
+	return file_wallet_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ListRequest) GetView() ListView {
@@ -1541,7 +1703,7 @@ type ListResponse struct {
 
 func (x *ListResponse) Reset() {
 	*x = ListResponse{}
-	mi := &file_wallet_proto_msgTypes[11]
+	mi := &file_wallet_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1553,7 +1715,7 @@ func (x *ListResponse) String() string {
 func (*ListResponse) ProtoMessage() {}
 
 func (x *ListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[11]
+	mi := &file_wallet_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1566,7 +1728,7 @@ func (x *ListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListResponse.ProtoReflect.Descriptor instead.
 func (*ListResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{11}
+	return file_wallet_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ListResponse) GetBody() isListResponse_Body {
@@ -1638,7 +1800,7 @@ type ActivityList struct {
 
 func (x *ActivityList) Reset() {
 	*x = ActivityList{}
-	mi := &file_wallet_proto_msgTypes[12]
+	mi := &file_wallet_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1650,7 +1812,7 @@ func (x *ActivityList) String() string {
 func (*ActivityList) ProtoMessage() {}
 
 func (x *ActivityList) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[12]
+	mi := &file_wallet_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1663,7 +1825,7 @@ func (x *ActivityList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActivityList.ProtoReflect.Descriptor instead.
 func (*ActivityList) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{12}
+	return file_wallet_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ActivityList) GetEntries() []*WalletEntry {
@@ -1693,7 +1855,7 @@ type VTXOInventory struct {
 
 func (x *VTXOInventory) Reset() {
 	*x = VTXOInventory{}
-	mi := &file_wallet_proto_msgTypes[13]
+	mi := &file_wallet_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1705,7 +1867,7 @@ func (x *VTXOInventory) String() string {
 func (*VTXOInventory) ProtoMessage() {}
 
 func (x *VTXOInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[13]
+	mi := &file_wallet_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1718,7 +1880,7 @@ func (x *VTXOInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VTXOInventory.ProtoReflect.Descriptor instead.
 func (*VTXOInventory) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{13}
+	return file_wallet_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *VTXOInventory) GetVtxos() []*WalletVTXO {
@@ -1764,7 +1926,7 @@ type WalletVTXO struct {
 
 func (x *WalletVTXO) Reset() {
 	*x = WalletVTXO{}
-	mi := &file_wallet_proto_msgTypes[14]
+	mi := &file_wallet_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1776,7 +1938,7 @@ func (x *WalletVTXO) String() string {
 func (*WalletVTXO) ProtoMessage() {}
 
 func (x *WalletVTXO) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[14]
+	mi := &file_wallet_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1789,7 +1951,7 @@ func (x *WalletVTXO) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletVTXO.ProtoReflect.Descriptor instead.
 func (*WalletVTXO) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{14}
+	return file_wallet_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *WalletVTXO) GetOutpoint() string {
@@ -1850,7 +2012,7 @@ type OnchainHistory struct {
 
 func (x *OnchainHistory) Reset() {
 	*x = OnchainHistory{}
-	mi := &file_wallet_proto_msgTypes[15]
+	mi := &file_wallet_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1862,7 +2024,7 @@ func (x *OnchainHistory) String() string {
 func (*OnchainHistory) ProtoMessage() {}
 
 func (x *OnchainHistory) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[15]
+	mi := &file_wallet_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1875,7 +2037,7 @@ func (x *OnchainHistory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnchainHistory.ProtoReflect.Descriptor instead.
 func (*OnchainHistory) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{15}
+	return file_wallet_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *OnchainHistory) GetTxs() []*OnchainTx {
@@ -1933,7 +2095,7 @@ type OnchainTx struct {
 
 func (x *OnchainTx) Reset() {
 	*x = OnchainTx{}
-	mi := &file_wallet_proto_msgTypes[16]
+	mi := &file_wallet_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1945,7 +2107,7 @@ func (x *OnchainTx) String() string {
 func (*OnchainTx) ProtoMessage() {}
 
 func (x *OnchainTx) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[16]
+	mi := &file_wallet_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1958,7 +2120,7 @@ func (x *OnchainTx) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnchainTx.ProtoReflect.Descriptor instead.
 func (*OnchainTx) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{16}
+	return file_wallet_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *OnchainTx) GetTxid() string {
@@ -2033,7 +2195,7 @@ type InspectActivityRequest struct {
 
 func (x *InspectActivityRequest) Reset() {
 	*x = InspectActivityRequest{}
-	mi := &file_wallet_proto_msgTypes[17]
+	mi := &file_wallet_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2045,7 +2207,7 @@ func (x *InspectActivityRequest) String() string {
 func (*InspectActivityRequest) ProtoMessage() {}
 
 func (x *InspectActivityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[17]
+	mi := &file_wallet_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2058,7 +2220,7 @@ func (x *InspectActivityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectActivityRequest.ProtoReflect.Descriptor instead.
 func (*InspectActivityRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{17}
+	return file_wallet_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *InspectActivityRequest) GetId() string {
@@ -2099,7 +2261,7 @@ type InspectActivityResponse struct {
 
 func (x *InspectActivityResponse) Reset() {
 	*x = InspectActivityResponse{}
-	mi := &file_wallet_proto_msgTypes[18]
+	mi := &file_wallet_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2111,7 +2273,7 @@ func (x *InspectActivityResponse) String() string {
 func (*InspectActivityResponse) ProtoMessage() {}
 
 func (x *InspectActivityResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[18]
+	mi := &file_wallet_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2124,7 +2286,7 @@ func (x *InspectActivityResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InspectActivityResponse.ProtoReflect.Descriptor instead.
 func (*InspectActivityResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{18}
+	return file_wallet_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *InspectActivityResponse) GetEntry() *WalletEntry {
@@ -2218,7 +2380,7 @@ type ActivitySwapTrace struct {
 
 func (x *ActivitySwapTrace) Reset() {
 	*x = ActivitySwapTrace{}
-	mi := &file_wallet_proto_msgTypes[19]
+	mi := &file_wallet_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2230,7 +2392,7 @@ func (x *ActivitySwapTrace) String() string {
 func (*ActivitySwapTrace) ProtoMessage() {}
 
 func (x *ActivitySwapTrace) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[19]
+	mi := &file_wallet_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2243,7 +2405,7 @@ func (x *ActivitySwapTrace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActivitySwapTrace.ProtoReflect.Descriptor instead.
 func (*ActivitySwapTrace) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{19}
+	return file_wallet_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ActivitySwapTrace) GetPaymentHash() string {
@@ -2407,7 +2569,7 @@ type ActivityVTXOTrace struct {
 
 func (x *ActivityVTXOTrace) Reset() {
 	*x = ActivityVTXOTrace{}
-	mi := &file_wallet_proto_msgTypes[20]
+	mi := &file_wallet_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2419,7 +2581,7 @@ func (x *ActivityVTXOTrace) String() string {
 func (*ActivityVTXOTrace) ProtoMessage() {}
 
 func (x *ActivityVTXOTrace) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[20]
+	mi := &file_wallet_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2432,7 +2594,7 @@ func (x *ActivityVTXOTrace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActivityVTXOTrace.ProtoReflect.Descriptor instead.
 func (*ActivityVTXOTrace) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{20}
+	return file_wallet_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ActivityVTXOTrace) GetId() string {
@@ -2537,7 +2699,7 @@ type ActivityLedgerTrace struct {
 
 func (x *ActivityLedgerTrace) Reset() {
 	*x = ActivityLedgerTrace{}
-	mi := &file_wallet_proto_msgTypes[21]
+	mi := &file_wallet_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2549,7 +2711,7 @@ func (x *ActivityLedgerTrace) String() string {
 func (*ActivityLedgerTrace) ProtoMessage() {}
 
 func (x *ActivityLedgerTrace) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[21]
+	mi := &file_wallet_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2562,7 +2724,7 @@ func (x *ActivityLedgerTrace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ActivityLedgerTrace.ProtoReflect.Descriptor instead.
 func (*ActivityLedgerTrace) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{21}
+	return file_wallet_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ActivityLedgerTrace) GetSource() string {
@@ -2703,7 +2865,7 @@ type DepositRequest struct {
 
 func (x *DepositRequest) Reset() {
 	*x = DepositRequest{}
-	mi := &file_wallet_proto_msgTypes[22]
+	mi := &file_wallet_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2715,7 +2877,7 @@ func (x *DepositRequest) String() string {
 func (*DepositRequest) ProtoMessage() {}
 
 func (x *DepositRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[22]
+	mi := &file_wallet_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2728,7 +2890,7 @@ func (x *DepositRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DepositRequest.ProtoReflect.Descriptor instead.
 func (*DepositRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{22}
+	return file_wallet_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *DepositRequest) GetAmtSatHint() uint64 {
@@ -2753,7 +2915,7 @@ type DepositResponse struct {
 
 func (x *DepositResponse) Reset() {
 	*x = DepositResponse{}
-	mi := &file_wallet_proto_msgTypes[23]
+	mi := &file_wallet_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2765,7 +2927,7 @@ func (x *DepositResponse) String() string {
 func (*DepositResponse) ProtoMessage() {}
 
 func (x *DepositResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[23]
+	mi := &file_wallet_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2778,7 +2940,7 @@ func (x *DepositResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DepositResponse.ProtoReflect.Descriptor instead.
 func (*DepositResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{23}
+	return file_wallet_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *DepositResponse) GetOnchainAddress() string {
@@ -2803,7 +2965,7 @@ type BalanceRequest struct {
 
 func (x *BalanceRequest) Reset() {
 	*x = BalanceRequest{}
-	mi := &file_wallet_proto_msgTypes[24]
+	mi := &file_wallet_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2815,7 +2977,7 @@ func (x *BalanceRequest) String() string {
 func (*BalanceRequest) ProtoMessage() {}
 
 func (x *BalanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[24]
+	mi := &file_wallet_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2828,7 +2990,7 @@ func (x *BalanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BalanceRequest.ProtoReflect.Descriptor instead.
 func (*BalanceRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{24}
+	return file_wallet_proto_rawDescGZIP(), []int{26}
 }
 
 type BalanceResponse struct {
@@ -2841,13 +3003,19 @@ type BalanceResponse struct {
 	// pending_out_sat is the total in-flight outbound amount (send plus
 	// exit operations).
 	PendingOutSat int64 `protobuf:"varint,3,opt,name=pending_out_sat,json=pendingOutSat,proto3" json:"pending_out_sat,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// credit_available_sat is the server-authoritative available credit
+	// balance for the wallet identity.
+	CreditAvailableSat uint64 `protobuf:"varint,4,opt,name=credit_available_sat,json=creditAvailableSat,proto3" json:"credit_available_sat,omitempty"`
+	// credit_reserved_sat is the server-authoritative in-flight credit
+	// reservation amount.
+	CreditReservedSat uint64 `protobuf:"varint,5,opt,name=credit_reserved_sat,json=creditReservedSat,proto3" json:"credit_reserved_sat,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *BalanceResponse) Reset() {
 	*x = BalanceResponse{}
-	mi := &file_wallet_proto_msgTypes[25]
+	mi := &file_wallet_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2859,7 +3027,7 @@ func (x *BalanceResponse) String() string {
 func (*BalanceResponse) ProtoMessage() {}
 
 func (x *BalanceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[25]
+	mi := &file_wallet_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2872,7 +3040,7 @@ func (x *BalanceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BalanceResponse.ProtoReflect.Descriptor instead.
 func (*BalanceResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{25}
+	return file_wallet_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *BalanceResponse) GetConfirmedSat() int64 {
@@ -2896,6 +3064,20 @@ func (x *BalanceResponse) GetPendingOutSat() int64 {
 	return 0
 }
 
+func (x *BalanceResponse) GetCreditAvailableSat() uint64 {
+	if x != nil {
+		return x.CreditAvailableSat
+	}
+	return 0
+}
+
+func (x *BalanceResponse) GetCreditReservedSat() uint64 {
+	if x != nil {
+		return x.CreditReservedSat
+	}
+	return 0
+}
+
 type StatusRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -2904,7 +3086,7 @@ type StatusRequest struct {
 
 func (x *StatusRequest) Reset() {
 	*x = StatusRequest{}
-	mi := &file_wallet_proto_msgTypes[26]
+	mi := &file_wallet_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2916,7 +3098,7 @@ func (x *StatusRequest) String() string {
 func (*StatusRequest) ProtoMessage() {}
 
 func (x *StatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[26]
+	mi := &file_wallet_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2929,7 +3111,7 @@ func (x *StatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusRequest.ProtoReflect.Descriptor instead.
 func (*StatusRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{26}
+	return file_wallet_proto_rawDescGZIP(), []int{28}
 }
 
 type StatusResponse struct {
@@ -2954,7 +3136,7 @@ type StatusResponse struct {
 
 func (x *StatusResponse) Reset() {
 	*x = StatusResponse{}
-	mi := &file_wallet_proto_msgTypes[27]
+	mi := &file_wallet_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2966,7 +3148,7 @@ func (x *StatusResponse) String() string {
 func (*StatusResponse) ProtoMessage() {}
 
 func (x *StatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[27]
+	mi := &file_wallet_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2979,7 +3161,7 @@ func (x *StatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusResponse.ProtoReflect.Descriptor instead.
 func (*StatusResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{27}
+	return file_wallet_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *StatusResponse) GetReady() bool {
@@ -3030,7 +3212,7 @@ type GetExitPlanRequest struct {
 
 func (x *GetExitPlanRequest) Reset() {
 	*x = GetExitPlanRequest{}
-	mi := &file_wallet_proto_msgTypes[28]
+	mi := &file_wallet_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3042,7 +3224,7 @@ func (x *GetExitPlanRequest) String() string {
 func (*GetExitPlanRequest) ProtoMessage() {}
 
 func (x *GetExitPlanRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[28]
+	mi := &file_wallet_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3055,7 +3237,7 @@ func (x *GetExitPlanRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExitPlanRequest.ProtoReflect.Descriptor instead.
 func (*GetExitPlanRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{28}
+	return file_wallet_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *GetExitPlanRequest) GetOutpoints() []string {
@@ -3098,7 +3280,7 @@ type ExitPlanEntry struct {
 
 func (x *ExitPlanEntry) Reset() {
 	*x = ExitPlanEntry{}
-	mi := &file_wallet_proto_msgTypes[29]
+	mi := &file_wallet_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3110,7 +3292,7 @@ func (x *ExitPlanEntry) String() string {
 func (*ExitPlanEntry) ProtoMessage() {}
 
 func (x *ExitPlanEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[29]
+	mi := &file_wallet_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3123,7 +3305,7 @@ func (x *ExitPlanEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExitPlanEntry.ProtoReflect.Descriptor instead.
 func (*ExitPlanEntry) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{29}
+	return file_wallet_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ExitPlanEntry) GetOutpoint() string {
@@ -3253,7 +3435,7 @@ type GetExitPlanResponse struct {
 
 func (x *GetExitPlanResponse) Reset() {
 	*x = GetExitPlanResponse{}
-	mi := &file_wallet_proto_msgTypes[30]
+	mi := &file_wallet_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3265,7 +3447,7 @@ func (x *GetExitPlanResponse) String() string {
 func (*GetExitPlanResponse) ProtoMessage() {}
 
 func (x *GetExitPlanResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[30]
+	mi := &file_wallet_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3278,7 +3460,7 @@ func (x *GetExitPlanResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExitPlanResponse.ProtoReflect.Descriptor instead.
 func (*GetExitPlanResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{30}
+	return file_wallet_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetExitPlanResponse) GetPlans() []*ExitPlanEntry {
@@ -3336,7 +3518,7 @@ type SweepWalletRequest struct {
 
 func (x *SweepWalletRequest) Reset() {
 	*x = SweepWalletRequest{}
-	mi := &file_wallet_proto_msgTypes[31]
+	mi := &file_wallet_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3348,7 +3530,7 @@ func (x *SweepWalletRequest) String() string {
 func (*SweepWalletRequest) ProtoMessage() {}
 
 func (x *SweepWalletRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[31]
+	mi := &file_wallet_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3361,7 +3543,7 @@ func (x *SweepWalletRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepWalletRequest.ProtoReflect.Descriptor instead.
 func (*SweepWalletRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{31}
+	return file_wallet_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *SweepWalletRequest) GetDestinationAddress() string {
@@ -3402,7 +3584,7 @@ type WalletSweepInput struct {
 
 func (x *WalletSweepInput) Reset() {
 	*x = WalletSweepInput{}
-	mi := &file_wallet_proto_msgTypes[32]
+	mi := &file_wallet_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3414,7 +3596,7 @@ func (x *WalletSweepInput) String() string {
 func (*WalletSweepInput) ProtoMessage() {}
 
 func (x *WalletSweepInput) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[32]
+	mi := &file_wallet_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3427,7 +3609,7 @@ func (x *WalletSweepInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletSweepInput.ProtoReflect.Descriptor instead.
 func (*WalletSweepInput) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{32}
+	return file_wallet_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *WalletSweepInput) GetOutpoint() string {
@@ -3460,7 +3642,7 @@ type SweepWalletResponse struct {
 
 func (x *SweepWalletResponse) Reset() {
 	*x = SweepWalletResponse{}
-	mi := &file_wallet_proto_msgTypes[33]
+	mi := &file_wallet_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3472,7 +3654,7 @@ func (x *SweepWalletResponse) String() string {
 func (*SweepWalletResponse) ProtoMessage() {}
 
 func (x *SweepWalletResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[33]
+	mi := &file_wallet_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3485,7 +3667,7 @@ func (x *SweepWalletResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SweepWalletResponse.ProtoReflect.Descriptor instead.
 func (*SweepWalletResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{33}
+	return file_wallet_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *SweepWalletResponse) GetInputs() []*WalletSweepInput {
@@ -3562,7 +3744,7 @@ type ExitRequest struct {
 
 func (x *ExitRequest) Reset() {
 	*x = ExitRequest{}
-	mi := &file_wallet_proto_msgTypes[34]
+	mi := &file_wallet_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3574,7 +3756,7 @@ func (x *ExitRequest) String() string {
 func (*ExitRequest) ProtoMessage() {}
 
 func (x *ExitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[34]
+	mi := &file_wallet_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3587,7 +3769,7 @@ func (x *ExitRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExitRequest.ProtoReflect.Descriptor instead.
 func (*ExitRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{34}
+	return file_wallet_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ExitRequest) GetOutpoint() string {
@@ -3632,7 +3814,7 @@ type ExitResponse struct {
 
 func (x *ExitResponse) Reset() {
 	*x = ExitResponse{}
-	mi := &file_wallet_proto_msgTypes[35]
+	mi := &file_wallet_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3644,7 +3826,7 @@ func (x *ExitResponse) String() string {
 func (*ExitResponse) ProtoMessage() {}
 
 func (x *ExitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[35]
+	mi := &file_wallet_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3657,7 +3839,7 @@ func (x *ExitResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExitResponse.ProtoReflect.Descriptor instead.
 func (*ExitResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{35}
+	return file_wallet_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ExitResponse) GetCreated() bool {
@@ -3706,7 +3888,7 @@ type ExitStatusRequest struct {
 
 func (x *ExitStatusRequest) Reset() {
 	*x = ExitStatusRequest{}
-	mi := &file_wallet_proto_msgTypes[36]
+	mi := &file_wallet_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3718,7 +3900,7 @@ func (x *ExitStatusRequest) String() string {
 func (*ExitStatusRequest) ProtoMessage() {}
 
 func (x *ExitStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[36]
+	mi := &file_wallet_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3731,7 +3913,7 @@ func (x *ExitStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExitStatusRequest.ProtoReflect.Descriptor instead.
 func (*ExitStatusRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{36}
+	return file_wallet_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ExitStatusRequest) GetOutpoint() string {
@@ -3759,7 +3941,7 @@ type ExitStatusResponse struct {
 
 func (x *ExitStatusResponse) Reset() {
 	*x = ExitStatusResponse{}
-	mi := &file_wallet_proto_msgTypes[37]
+	mi := &file_wallet_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3771,7 +3953,7 @@ func (x *ExitStatusResponse) String() string {
 func (*ExitStatusResponse) ProtoMessage() {}
 
 func (x *ExitStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[37]
+	mi := &file_wallet_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3784,7 +3966,7 @@ func (x *ExitStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExitStatusResponse.ProtoReflect.Descriptor instead.
 func (*ExitStatusResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{37}
+	return file_wallet_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ExitStatusResponse) GetFound() bool {
@@ -3829,7 +4011,7 @@ type SubscribeWalletRequest struct {
 
 func (x *SubscribeWalletRequest) Reset() {
 	*x = SubscribeWalletRequest{}
-	mi := &file_wallet_proto_msgTypes[38]
+	mi := &file_wallet_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3841,7 +4023,7 @@ func (x *SubscribeWalletRequest) String() string {
 func (*SubscribeWalletRequest) ProtoMessage() {}
 
 func (x *SubscribeWalletRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[38]
+	mi := &file_wallet_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3854,7 +4036,7 @@ func (x *SubscribeWalletRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeWalletRequest.ProtoReflect.Descriptor instead.
 func (*SubscribeWalletRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{38}
+	return file_wallet_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *SubscribeWalletRequest) GetIncludeExisting() bool {
@@ -3930,7 +4112,7 @@ type WalletEntry struct {
 
 func (x *WalletEntry) Reset() {
 	*x = WalletEntry{}
-	mi := &file_wallet_proto_msgTypes[39]
+	mi := &file_wallet_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3942,7 +4124,7 @@ func (x *WalletEntry) String() string {
 func (*WalletEntry) ProtoMessage() {}
 
 func (x *WalletEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[39]
+	mi := &file_wallet_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3955,7 +4137,7 @@ func (x *WalletEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletEntry.ProtoReflect.Descriptor instead.
 func (*WalletEntry) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{39}
+	return file_wallet_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *WalletEntry) GetId() string {
@@ -4066,7 +4248,7 @@ type WalletEntryRequest struct {
 
 func (x *WalletEntryRequest) Reset() {
 	*x = WalletEntryRequest{}
-	mi := &file_wallet_proto_msgTypes[40]
+	mi := &file_wallet_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4078,7 +4260,7 @@ func (x *WalletEntryRequest) String() string {
 func (*WalletEntryRequest) ProtoMessage() {}
 
 func (x *WalletEntryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[40]
+	mi := &file_wallet_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4091,7 +4273,7 @@ func (x *WalletEntryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletEntryRequest.ProtoReflect.Descriptor instead.
 func (*WalletEntryRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{40}
+	return file_wallet_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *WalletEntryRequest) GetRequest() isWalletEntryRequest_Request {
@@ -4169,7 +4351,7 @@ type LightningInvoiceRequest struct {
 
 func (x *LightningInvoiceRequest) Reset() {
 	*x = LightningInvoiceRequest{}
-	mi := &file_wallet_proto_msgTypes[41]
+	mi := &file_wallet_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4181,7 +4363,7 @@ func (x *LightningInvoiceRequest) String() string {
 func (*LightningInvoiceRequest) ProtoMessage() {}
 
 func (x *LightningInvoiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[41]
+	mi := &file_wallet_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4194,7 +4376,7 @@ func (x *LightningInvoiceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LightningInvoiceRequest.ProtoReflect.Descriptor instead.
 func (*LightningInvoiceRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{41}
+	return file_wallet_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *LightningInvoiceRequest) GetInvoice() string {
@@ -4223,7 +4405,7 @@ type OnchainAddressRequest struct {
 
 func (x *OnchainAddressRequest) Reset() {
 	*x = OnchainAddressRequest{}
-	mi := &file_wallet_proto_msgTypes[42]
+	mi := &file_wallet_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4235,7 +4417,7 @@ func (x *OnchainAddressRequest) String() string {
 func (*OnchainAddressRequest) ProtoMessage() {}
 
 func (x *OnchainAddressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[42]
+	mi := &file_wallet_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4248,7 +4430,7 @@ func (x *OnchainAddressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnchainAddressRequest.ProtoReflect.Descriptor instead.
 func (*OnchainAddressRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{42}
+	return file_wallet_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *OnchainAddressRequest) GetAddress() string {
@@ -4269,7 +4451,7 @@ type ArkAddressRequest struct {
 
 func (x *ArkAddressRequest) Reset() {
 	*x = ArkAddressRequest{}
-	mi := &file_wallet_proto_msgTypes[43]
+	mi := &file_wallet_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4281,7 +4463,7 @@ func (x *ArkAddressRequest) String() string {
 func (*ArkAddressRequest) ProtoMessage() {}
 
 func (x *ArkAddressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[43]
+	mi := &file_wallet_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4294,7 +4476,7 @@ func (x *ArkAddressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArkAddressRequest.ProtoReflect.Descriptor instead.
 func (*ArkAddressRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{43}
+	return file_wallet_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *ArkAddressRequest) GetAddress() string {
@@ -4327,7 +4509,7 @@ type WalletEntryProgress struct {
 
 func (x *WalletEntryProgress) Reset() {
 	*x = WalletEntryProgress{}
-	mi := &file_wallet_proto_msgTypes[44]
+	mi := &file_wallet_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4339,7 +4521,7 @@ func (x *WalletEntryProgress) String() string {
 func (*WalletEntryProgress) ProtoMessage() {}
 
 func (x *WalletEntryProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[44]
+	mi := &file_wallet_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4352,7 +4534,7 @@ func (x *WalletEntryProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletEntryProgress.ProtoReflect.Descriptor instead.
 func (*WalletEntryProgress) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{44}
+	return file_wallet_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *WalletEntryProgress) GetPhase() WalletEntryPhase {
@@ -4428,7 +4610,7 @@ const file_wallet_proto_rawDesc = "" +
 	"\x04note\x18\x04 \x01(\tR\x04note\x12\x1e\n" +
 	"\vmax_fee_sat\x18\x05 \x01(\x04R\tmaxFeeSat\x12\x1b\n" +
 	"\tsweep_all\x18\x06 \x01(\bR\bsweepAllB\r\n" +
-	"\vdestination\"\xf0\x04\n" +
+	"\vdestination\"\xb3\x05\n" +
 	"\x13PrepareSendResponse\x12$\n" +
 	"\x0esend_intent_id\x18\x01 \x01(\tR\fsendIntentId\x12\x1d\n" +
 	"\n" +
@@ -4445,7 +4627,8 @@ const file_wallet_proto_rawDesc = "" +
 	"\fpayment_hash\x18\v \x01(\tR\vpaymentHash\x12&\n" +
 	"\x0fexpires_at_unix\x18\f \x01(\x03R\rexpiresAtUnix\x12-\n" +
 	"\x12selected_outpoints\x18\r \x03(\tR\x11selectedOutpoints\x12\x18\n" +
-	"\awarning\x18\x0e \x01(\tR\awarning\"3\n" +
+	"\awarning\x18\x0e \x01(\tR\awarning\x12A\n" +
+	"\x0ecredit_preview\x18\x0f \x01(\v2\x1a.walletdkrpc.CreditPreviewR\rcreditPreview\"3\n" +
 	"\vSendRequest\x12$\n" +
 	"\x0esend_intent_id\x18\x01 \x01(\tR\fsendIntentId\"j\n" +
 	"\fSendResponse\x12.\n" +
@@ -4453,10 +4636,22 @@ const file_wallet_proto_rawDesc = "" +
 	"\x11actual_amount_sat\x18\x02 \x01(\x03R\x0factualAmountSat\":\n" +
 	"\vRecvRequest\x12\x17\n" +
 	"\aamt_sat\x18\x01 \x01(\x04R\x06amtSat\x12\x12\n" +
-	"\x04memo\x18\x02 \x01(\tR\x04memo\"X\n" +
+	"\x04memo\x18\x02 \x01(\tR\x04memo\"\x9b\x01\n" +
 	"\fRecvResponse\x12\x18\n" +
 	"\ainvoice\x18\x01 \x01(\tR\ainvoice\x12.\n" +
-	"\x05entry\x18\x02 \x01(\v2\x18.walletdkrpc.WalletEntryR\x05entry\"\xb7\x01\n" +
+	"\x05entry\x18\x02 \x01(\v2\x18.walletdkrpc.WalletEntryR\x05entry\x12A\n" +
+	"\x0ecredit_receive\x18\x03 \x01(\v2\x1a.walletdkrpc.CreditReceiveR\rcreditReceive\"\xe9\x01\n" +
+	"\rCreditPreview\x12&\n" +
+	"\x0fmust_use_credit\x18\x01 \x01(\bR\rmustUseCredit\x12,\n" +
+	"\x12credit_applied_sat\x18\x02 \x01(\x04R\x10creditAppliedSat\x120\n" +
+	"\x14credit_shortfall_sat\x18\x03 \x01(\x04R\x12creditShortfallSat\x12(\n" +
+	"\x10credit_topup_sat\x18\x04 \x01(\x04R\x0ecreditTopupSat\x12&\n" +
+	"\x0fark_funding_sat\x18\x05 \x01(\x04R\rarkFundingSat\"t\n" +
+	"\rCreditReceive\x12!\n" +
+	"\foperation_id\x18\x01 \x01(\tR\voperationId\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x02 \x01(\x04R\tamountSat\x12!\n" +
+	"\fpayment_hash\x18\x03 \x01(\tR\vpaymentHash\"\xb7\x01\n" +
 	"\vListRequest\x12)\n" +
 	"\x04view\x18\x01 \x01(\x0e2\x15.walletdkrpc.ListViewR\x04view\x12!\n" +
 	"\fpending_only\x18\x02 \x01(\bR\vpendingOnly\x12,\n" +
@@ -4567,11 +4762,13 @@ const file_wallet_proto_rawDesc = "" +
 	"\x0fDepositResponse\x12'\n" +
 	"\x0fonchain_address\x18\x01 \x01(\tR\x0eonchainAddress\x12.\n" +
 	"\x05entry\x18\x02 \x01(\v2\x18.walletdkrpc.WalletEntryR\x05entry\"\x10\n" +
-	"\x0eBalanceRequest\"\x84\x01\n" +
+	"\x0eBalanceRequest\"\xe6\x01\n" +
 	"\x0fBalanceResponse\x12#\n" +
 	"\rconfirmed_sat\x18\x01 \x01(\x03R\fconfirmedSat\x12$\n" +
 	"\x0epending_in_sat\x18\x02 \x01(\x03R\fpendingInSat\x12&\n" +
-	"\x0fpending_out_sat\x18\x03 \x01(\x03R\rpendingOutSat\"\x0f\n" +
+	"\x0fpending_out_sat\x18\x03 \x01(\x03R\rpendingOutSat\x120\n" +
+	"\x14credit_available_sat\x18\x04 \x01(\x04R\x12creditAvailableSat\x12.\n" +
+	"\x13credit_reserved_sat\x18\x05 \x01(\x04R\x11creditReservedSat\"\x0f\n" +
 	"\rStatusRequest\"\xb9\x01\n" +
 	"\x0eStatusResponse\x12\x14\n" +
 	"\x05ready\x18\x01 \x01(\bR\x05ready\x12\x1a\n" +
@@ -4701,13 +4898,15 @@ const file_wallet_proto_rawDesc = "" +
 	"\x15LIST_VIEW_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12LIST_VIEW_ACTIVITY\x10\x01\x12\x13\n" +
 	"\x0fLIST_VIEW_VTXOS\x10\x02\x12\x15\n" +
-	"\x11LIST_VIEW_ONCHAIN\x10\x03*\x8b\x01\n" +
+	"\x11LIST_VIEW_ONCHAIN\x10\x03*\xb6\x01\n" +
 	"\bSendRail\x12\x19\n" +
 	"\x15SEND_RAIL_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aSEND_RAIL_OFFCHAIN_UNKNOWN\x10\x01\x12\x14\n" +
 	"\x10SEND_RAIL_IN_ARK\x10\x02\x12\x17\n" +
 	"\x13SEND_RAIL_LIGHTNING\x10\x03\x12\x15\n" +
-	"\x11SEND_RAIL_ONCHAIN\x10\x04*v\n" +
+	"\x11SEND_RAIL_ONCHAIN\x10\x04\x12\x14\n" +
+	"\x10SEND_RAIL_CREDIT\x10\x05\x12\x13\n" +
+	"\x0fSEND_RAIL_MIXED\x10\x06*v\n" +
 	"\x0fSendQuoteStatus\x12!\n" +
 	"\x1dSEND_QUOTE_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aSEND_QUOTE_STATUS_COMPLETE\x10\x01\x12 \n" +
@@ -4774,7 +4973,7 @@ func file_wallet_proto_rawDescGZIP() []byte {
 }
 
 var file_wallet_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 45)
+var file_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
 var file_wallet_proto_goTypes = []any{
 	(EntryKind)(0),                  // 0: walletdkrpc.EntryKind
 	(EntryStatus)(0),                // 1: walletdkrpc.EntryStatus
@@ -4795,111 +4994,115 @@ var file_wallet_proto_goTypes = []any{
 	(*SendResponse)(nil),            // 16: walletdkrpc.SendResponse
 	(*RecvRequest)(nil),             // 17: walletdkrpc.RecvRequest
 	(*RecvResponse)(nil),            // 18: walletdkrpc.RecvResponse
-	(*ListRequest)(nil),             // 19: walletdkrpc.ListRequest
-	(*ListResponse)(nil),            // 20: walletdkrpc.ListResponse
-	(*ActivityList)(nil),            // 21: walletdkrpc.ActivityList
-	(*VTXOInventory)(nil),           // 22: walletdkrpc.VTXOInventory
-	(*WalletVTXO)(nil),              // 23: walletdkrpc.WalletVTXO
-	(*OnchainHistory)(nil),          // 24: walletdkrpc.OnchainHistory
-	(*OnchainTx)(nil),               // 25: walletdkrpc.OnchainTx
-	(*InspectActivityRequest)(nil),  // 26: walletdkrpc.InspectActivityRequest
-	(*InspectActivityResponse)(nil), // 27: walletdkrpc.InspectActivityResponse
-	(*ActivitySwapTrace)(nil),       // 28: walletdkrpc.ActivitySwapTrace
-	(*ActivityVTXOTrace)(nil),       // 29: walletdkrpc.ActivityVTXOTrace
-	(*ActivityLedgerTrace)(nil),     // 30: walletdkrpc.ActivityLedgerTrace
-	(*DepositRequest)(nil),          // 31: walletdkrpc.DepositRequest
-	(*DepositResponse)(nil),         // 32: walletdkrpc.DepositResponse
-	(*BalanceRequest)(nil),          // 33: walletdkrpc.BalanceRequest
-	(*BalanceResponse)(nil),         // 34: walletdkrpc.BalanceResponse
-	(*StatusRequest)(nil),           // 35: walletdkrpc.StatusRequest
-	(*StatusResponse)(nil),          // 36: walletdkrpc.StatusResponse
-	(*GetExitPlanRequest)(nil),      // 37: walletdkrpc.GetExitPlanRequest
-	(*ExitPlanEntry)(nil),           // 38: walletdkrpc.ExitPlanEntry
-	(*GetExitPlanResponse)(nil),     // 39: walletdkrpc.GetExitPlanResponse
-	(*SweepWalletRequest)(nil),      // 40: walletdkrpc.SweepWalletRequest
-	(*WalletSweepInput)(nil),        // 41: walletdkrpc.WalletSweepInput
-	(*SweepWalletResponse)(nil),     // 42: walletdkrpc.SweepWalletResponse
-	(*ExitRequest)(nil),             // 43: walletdkrpc.ExitRequest
-	(*ExitResponse)(nil),            // 44: walletdkrpc.ExitResponse
-	(*ExitStatusRequest)(nil),       // 45: walletdkrpc.ExitStatusRequest
-	(*ExitStatusResponse)(nil),      // 46: walletdkrpc.ExitStatusResponse
-	(*SubscribeWalletRequest)(nil),  // 47: walletdkrpc.SubscribeWalletRequest
-	(*WalletEntry)(nil),             // 48: walletdkrpc.WalletEntry
-	(*WalletEntryRequest)(nil),      // 49: walletdkrpc.WalletEntryRequest
-	(*LightningInvoiceRequest)(nil), // 50: walletdkrpc.LightningInvoiceRequest
-	(*OnchainAddressRequest)(nil),   // 51: walletdkrpc.OnchainAddressRequest
-	(*ArkAddressRequest)(nil),       // 52: walletdkrpc.ArkAddressRequest
-	(*WalletEntryProgress)(nil),     // 53: walletdkrpc.WalletEntryProgress
+	(*CreditPreview)(nil),           // 19: walletdkrpc.CreditPreview
+	(*CreditReceive)(nil),           // 20: walletdkrpc.CreditReceive
+	(*ListRequest)(nil),             // 21: walletdkrpc.ListRequest
+	(*ListResponse)(nil),            // 22: walletdkrpc.ListResponse
+	(*ActivityList)(nil),            // 23: walletdkrpc.ActivityList
+	(*VTXOInventory)(nil),           // 24: walletdkrpc.VTXOInventory
+	(*WalletVTXO)(nil),              // 25: walletdkrpc.WalletVTXO
+	(*OnchainHistory)(nil),          // 26: walletdkrpc.OnchainHistory
+	(*OnchainTx)(nil),               // 27: walletdkrpc.OnchainTx
+	(*InspectActivityRequest)(nil),  // 28: walletdkrpc.InspectActivityRequest
+	(*InspectActivityResponse)(nil), // 29: walletdkrpc.InspectActivityResponse
+	(*ActivitySwapTrace)(nil),       // 30: walletdkrpc.ActivitySwapTrace
+	(*ActivityVTXOTrace)(nil),       // 31: walletdkrpc.ActivityVTXOTrace
+	(*ActivityLedgerTrace)(nil),     // 32: walletdkrpc.ActivityLedgerTrace
+	(*DepositRequest)(nil),          // 33: walletdkrpc.DepositRequest
+	(*DepositResponse)(nil),         // 34: walletdkrpc.DepositResponse
+	(*BalanceRequest)(nil),          // 35: walletdkrpc.BalanceRequest
+	(*BalanceResponse)(nil),         // 36: walletdkrpc.BalanceResponse
+	(*StatusRequest)(nil),           // 37: walletdkrpc.StatusRequest
+	(*StatusResponse)(nil),          // 38: walletdkrpc.StatusResponse
+	(*GetExitPlanRequest)(nil),      // 39: walletdkrpc.GetExitPlanRequest
+	(*ExitPlanEntry)(nil),           // 40: walletdkrpc.ExitPlanEntry
+	(*GetExitPlanResponse)(nil),     // 41: walletdkrpc.GetExitPlanResponse
+	(*SweepWalletRequest)(nil),      // 42: walletdkrpc.SweepWalletRequest
+	(*WalletSweepInput)(nil),        // 43: walletdkrpc.WalletSweepInput
+	(*SweepWalletResponse)(nil),     // 44: walletdkrpc.SweepWalletResponse
+	(*ExitRequest)(nil),             // 45: walletdkrpc.ExitRequest
+	(*ExitResponse)(nil),            // 46: walletdkrpc.ExitResponse
+	(*ExitStatusRequest)(nil),       // 47: walletdkrpc.ExitStatusRequest
+	(*ExitStatusResponse)(nil),      // 48: walletdkrpc.ExitStatusResponse
+	(*SubscribeWalletRequest)(nil),  // 49: walletdkrpc.SubscribeWalletRequest
+	(*WalletEntry)(nil),             // 50: walletdkrpc.WalletEntry
+	(*WalletEntryRequest)(nil),      // 51: walletdkrpc.WalletEntryRequest
+	(*LightningInvoiceRequest)(nil), // 52: walletdkrpc.LightningInvoiceRequest
+	(*OnchainAddressRequest)(nil),   // 53: walletdkrpc.OnchainAddressRequest
+	(*ArkAddressRequest)(nil),       // 54: walletdkrpc.ArkAddressRequest
+	(*WalletEntryProgress)(nil),     // 55: walletdkrpc.WalletEntryProgress
 }
 var file_wallet_proto_depIdxs = []int32{
 	3,  // 0: walletdkrpc.PrepareSendResponse.rail:type_name -> walletdkrpc.SendRail
 	4,  // 1: walletdkrpc.PrepareSendResponse.quote_status:type_name -> walletdkrpc.SendQuoteStatus
-	48, // 2: walletdkrpc.SendResponse.entry:type_name -> walletdkrpc.WalletEntry
-	48, // 3: walletdkrpc.RecvResponse.entry:type_name -> walletdkrpc.WalletEntry
-	2,  // 4: walletdkrpc.ListRequest.view:type_name -> walletdkrpc.ListView
-	0,  // 5: walletdkrpc.ListRequest.kinds:type_name -> walletdkrpc.EntryKind
-	21, // 6: walletdkrpc.ListResponse.activity:type_name -> walletdkrpc.ActivityList
-	22, // 7: walletdkrpc.ListResponse.vtxos:type_name -> walletdkrpc.VTXOInventory
-	24, // 8: walletdkrpc.ListResponse.onchain:type_name -> walletdkrpc.OnchainHistory
-	48, // 9: walletdkrpc.ActivityList.entries:type_name -> walletdkrpc.WalletEntry
-	23, // 10: walletdkrpc.VTXOInventory.vtxos:type_name -> walletdkrpc.WalletVTXO
-	25, // 11: walletdkrpc.OnchainHistory.txs:type_name -> walletdkrpc.OnchainTx
-	48, // 12: walletdkrpc.InspectActivityResponse.entry:type_name -> walletdkrpc.WalletEntry
-	28, // 13: walletdkrpc.InspectActivityResponse.swap:type_name -> walletdkrpc.ActivitySwapTrace
-	29, // 14: walletdkrpc.InspectActivityResponse.vtxos:type_name -> walletdkrpc.ActivityVTXOTrace
-	30, // 15: walletdkrpc.InspectActivityResponse.ledger_rows:type_name -> walletdkrpc.ActivityLedgerTrace
-	48, // 16: walletdkrpc.DepositResponse.entry:type_name -> walletdkrpc.WalletEntry
-	34, // 17: walletdkrpc.StatusResponse.balance:type_name -> walletdkrpc.BalanceResponse
-	6,  // 18: walletdkrpc.ExitPlanEntry.exit_status:type_name -> walletdkrpc.ExitJobStatus
-	38, // 19: walletdkrpc.GetExitPlanResponse.plans:type_name -> walletdkrpc.ExitPlanEntry
-	41, // 20: walletdkrpc.SweepWalletResponse.inputs:type_name -> walletdkrpc.WalletSweepInput
-	5,  // 21: walletdkrpc.ExitResponse.mode:type_name -> walletdkrpc.ExitMode
-	6,  // 22: walletdkrpc.ExitStatusResponse.status:type_name -> walletdkrpc.ExitJobStatus
-	0,  // 23: walletdkrpc.SubscribeWalletRequest.kinds:type_name -> walletdkrpc.EntryKind
-	0,  // 24: walletdkrpc.WalletEntry.kind:type_name -> walletdkrpc.EntryKind
-	1,  // 25: walletdkrpc.WalletEntry.status:type_name -> walletdkrpc.EntryStatus
-	49, // 26: walletdkrpc.WalletEntry.request:type_name -> walletdkrpc.WalletEntryRequest
-	53, // 27: walletdkrpc.WalletEntry.progress:type_name -> walletdkrpc.WalletEntryProgress
-	8,  // 28: walletdkrpc.WalletEntry.failure_code:type_name -> walletdkrpc.EntryFailureCode
-	50, // 29: walletdkrpc.WalletEntryRequest.lightning_invoice:type_name -> walletdkrpc.LightningInvoiceRequest
-	51, // 30: walletdkrpc.WalletEntryRequest.onchain_address:type_name -> walletdkrpc.OnchainAddressRequest
-	52, // 31: walletdkrpc.WalletEntryRequest.ark_address:type_name -> walletdkrpc.ArkAddressRequest
-	7,  // 32: walletdkrpc.WalletEntryProgress.phase:type_name -> walletdkrpc.WalletEntryPhase
-	9,  // 33: walletdkrpc.WalletService.Create:input_type -> walletdkrpc.CreateRequest
-	11, // 34: walletdkrpc.WalletService.Unlock:input_type -> walletdkrpc.UnlockRequest
-	13, // 35: walletdkrpc.WalletService.PrepareSend:input_type -> walletdkrpc.PrepareSendRequest
-	15, // 36: walletdkrpc.WalletService.Send:input_type -> walletdkrpc.SendRequest
-	17, // 37: walletdkrpc.WalletService.Recv:input_type -> walletdkrpc.RecvRequest
-	19, // 38: walletdkrpc.WalletService.List:input_type -> walletdkrpc.ListRequest
-	31, // 39: walletdkrpc.WalletService.Deposit:input_type -> walletdkrpc.DepositRequest
-	33, // 40: walletdkrpc.WalletService.Balance:input_type -> walletdkrpc.BalanceRequest
-	35, // 41: walletdkrpc.WalletService.Status:input_type -> walletdkrpc.StatusRequest
-	37, // 42: walletdkrpc.WalletService.GetExitPlan:input_type -> walletdkrpc.GetExitPlanRequest
-	40, // 43: walletdkrpc.WalletService.SweepWallet:input_type -> walletdkrpc.SweepWalletRequest
-	43, // 44: walletdkrpc.WalletService.Exit:input_type -> walletdkrpc.ExitRequest
-	45, // 45: walletdkrpc.WalletService.ExitStatus:input_type -> walletdkrpc.ExitStatusRequest
-	47, // 46: walletdkrpc.WalletService.SubscribeWallet:input_type -> walletdkrpc.SubscribeWalletRequest
-	26, // 47: walletdkrpc.WalletInspectionService.InspectActivity:input_type -> walletdkrpc.InspectActivityRequest
-	10, // 48: walletdkrpc.WalletService.Create:output_type -> walletdkrpc.CreateResponse
-	12, // 49: walletdkrpc.WalletService.Unlock:output_type -> walletdkrpc.UnlockResponse
-	14, // 50: walletdkrpc.WalletService.PrepareSend:output_type -> walletdkrpc.PrepareSendResponse
-	16, // 51: walletdkrpc.WalletService.Send:output_type -> walletdkrpc.SendResponse
-	18, // 52: walletdkrpc.WalletService.Recv:output_type -> walletdkrpc.RecvResponse
-	20, // 53: walletdkrpc.WalletService.List:output_type -> walletdkrpc.ListResponse
-	32, // 54: walletdkrpc.WalletService.Deposit:output_type -> walletdkrpc.DepositResponse
-	34, // 55: walletdkrpc.WalletService.Balance:output_type -> walletdkrpc.BalanceResponse
-	36, // 56: walletdkrpc.WalletService.Status:output_type -> walletdkrpc.StatusResponse
-	39, // 57: walletdkrpc.WalletService.GetExitPlan:output_type -> walletdkrpc.GetExitPlanResponse
-	42, // 58: walletdkrpc.WalletService.SweepWallet:output_type -> walletdkrpc.SweepWalletResponse
-	44, // 59: walletdkrpc.WalletService.Exit:output_type -> walletdkrpc.ExitResponse
-	46, // 60: walletdkrpc.WalletService.ExitStatus:output_type -> walletdkrpc.ExitStatusResponse
-	48, // 61: walletdkrpc.WalletService.SubscribeWallet:output_type -> walletdkrpc.WalletEntry
-	27, // 62: walletdkrpc.WalletInspectionService.InspectActivity:output_type -> walletdkrpc.InspectActivityResponse
-	48, // [48:63] is the sub-list for method output_type
-	33, // [33:48] is the sub-list for method input_type
-	33, // [33:33] is the sub-list for extension type_name
-	33, // [33:33] is the sub-list for extension extendee
-	0,  // [0:33] is the sub-list for field type_name
+	19, // 2: walletdkrpc.PrepareSendResponse.credit_preview:type_name -> walletdkrpc.CreditPreview
+	50, // 3: walletdkrpc.SendResponse.entry:type_name -> walletdkrpc.WalletEntry
+	50, // 4: walletdkrpc.RecvResponse.entry:type_name -> walletdkrpc.WalletEntry
+	20, // 5: walletdkrpc.RecvResponse.credit_receive:type_name -> walletdkrpc.CreditReceive
+	2,  // 6: walletdkrpc.ListRequest.view:type_name -> walletdkrpc.ListView
+	0,  // 7: walletdkrpc.ListRequest.kinds:type_name -> walletdkrpc.EntryKind
+	23, // 8: walletdkrpc.ListResponse.activity:type_name -> walletdkrpc.ActivityList
+	24, // 9: walletdkrpc.ListResponse.vtxos:type_name -> walletdkrpc.VTXOInventory
+	26, // 10: walletdkrpc.ListResponse.onchain:type_name -> walletdkrpc.OnchainHistory
+	50, // 11: walletdkrpc.ActivityList.entries:type_name -> walletdkrpc.WalletEntry
+	25, // 12: walletdkrpc.VTXOInventory.vtxos:type_name -> walletdkrpc.WalletVTXO
+	27, // 13: walletdkrpc.OnchainHistory.txs:type_name -> walletdkrpc.OnchainTx
+	50, // 14: walletdkrpc.InspectActivityResponse.entry:type_name -> walletdkrpc.WalletEntry
+	30, // 15: walletdkrpc.InspectActivityResponse.swap:type_name -> walletdkrpc.ActivitySwapTrace
+	31, // 16: walletdkrpc.InspectActivityResponse.vtxos:type_name -> walletdkrpc.ActivityVTXOTrace
+	32, // 17: walletdkrpc.InspectActivityResponse.ledger_rows:type_name -> walletdkrpc.ActivityLedgerTrace
+	50, // 18: walletdkrpc.DepositResponse.entry:type_name -> walletdkrpc.WalletEntry
+	36, // 19: walletdkrpc.StatusResponse.balance:type_name -> walletdkrpc.BalanceResponse
+	6,  // 20: walletdkrpc.ExitPlanEntry.exit_status:type_name -> walletdkrpc.ExitJobStatus
+	40, // 21: walletdkrpc.GetExitPlanResponse.plans:type_name -> walletdkrpc.ExitPlanEntry
+	43, // 22: walletdkrpc.SweepWalletResponse.inputs:type_name -> walletdkrpc.WalletSweepInput
+	5,  // 23: walletdkrpc.ExitResponse.mode:type_name -> walletdkrpc.ExitMode
+	6,  // 24: walletdkrpc.ExitStatusResponse.status:type_name -> walletdkrpc.ExitJobStatus
+	0,  // 25: walletdkrpc.SubscribeWalletRequest.kinds:type_name -> walletdkrpc.EntryKind
+	0,  // 26: walletdkrpc.WalletEntry.kind:type_name -> walletdkrpc.EntryKind
+	1,  // 27: walletdkrpc.WalletEntry.status:type_name -> walletdkrpc.EntryStatus
+	51, // 28: walletdkrpc.WalletEntry.request:type_name -> walletdkrpc.WalletEntryRequest
+	55, // 29: walletdkrpc.WalletEntry.progress:type_name -> walletdkrpc.WalletEntryProgress
+	8,  // 30: walletdkrpc.WalletEntry.failure_code:type_name -> walletdkrpc.EntryFailureCode
+	52, // 31: walletdkrpc.WalletEntryRequest.lightning_invoice:type_name -> walletdkrpc.LightningInvoiceRequest
+	53, // 32: walletdkrpc.WalletEntryRequest.onchain_address:type_name -> walletdkrpc.OnchainAddressRequest
+	54, // 33: walletdkrpc.WalletEntryRequest.ark_address:type_name -> walletdkrpc.ArkAddressRequest
+	7,  // 34: walletdkrpc.WalletEntryProgress.phase:type_name -> walletdkrpc.WalletEntryPhase
+	9,  // 35: walletdkrpc.WalletService.Create:input_type -> walletdkrpc.CreateRequest
+	11, // 36: walletdkrpc.WalletService.Unlock:input_type -> walletdkrpc.UnlockRequest
+	13, // 37: walletdkrpc.WalletService.PrepareSend:input_type -> walletdkrpc.PrepareSendRequest
+	15, // 38: walletdkrpc.WalletService.Send:input_type -> walletdkrpc.SendRequest
+	17, // 39: walletdkrpc.WalletService.Recv:input_type -> walletdkrpc.RecvRequest
+	21, // 40: walletdkrpc.WalletService.List:input_type -> walletdkrpc.ListRequest
+	33, // 41: walletdkrpc.WalletService.Deposit:input_type -> walletdkrpc.DepositRequest
+	35, // 42: walletdkrpc.WalletService.Balance:input_type -> walletdkrpc.BalanceRequest
+	37, // 43: walletdkrpc.WalletService.Status:input_type -> walletdkrpc.StatusRequest
+	39, // 44: walletdkrpc.WalletService.GetExitPlan:input_type -> walletdkrpc.GetExitPlanRequest
+	42, // 45: walletdkrpc.WalletService.SweepWallet:input_type -> walletdkrpc.SweepWalletRequest
+	45, // 46: walletdkrpc.WalletService.Exit:input_type -> walletdkrpc.ExitRequest
+	47, // 47: walletdkrpc.WalletService.ExitStatus:input_type -> walletdkrpc.ExitStatusRequest
+	49, // 48: walletdkrpc.WalletService.SubscribeWallet:input_type -> walletdkrpc.SubscribeWalletRequest
+	28, // 49: walletdkrpc.WalletInspectionService.InspectActivity:input_type -> walletdkrpc.InspectActivityRequest
+	10, // 50: walletdkrpc.WalletService.Create:output_type -> walletdkrpc.CreateResponse
+	12, // 51: walletdkrpc.WalletService.Unlock:output_type -> walletdkrpc.UnlockResponse
+	14, // 52: walletdkrpc.WalletService.PrepareSend:output_type -> walletdkrpc.PrepareSendResponse
+	16, // 53: walletdkrpc.WalletService.Send:output_type -> walletdkrpc.SendResponse
+	18, // 54: walletdkrpc.WalletService.Recv:output_type -> walletdkrpc.RecvResponse
+	22, // 55: walletdkrpc.WalletService.List:output_type -> walletdkrpc.ListResponse
+	34, // 56: walletdkrpc.WalletService.Deposit:output_type -> walletdkrpc.DepositResponse
+	36, // 57: walletdkrpc.WalletService.Balance:output_type -> walletdkrpc.BalanceResponse
+	38, // 58: walletdkrpc.WalletService.Status:output_type -> walletdkrpc.StatusResponse
+	41, // 59: walletdkrpc.WalletService.GetExitPlan:output_type -> walletdkrpc.GetExitPlanResponse
+	44, // 60: walletdkrpc.WalletService.SweepWallet:output_type -> walletdkrpc.SweepWalletResponse
+	46, // 61: walletdkrpc.WalletService.Exit:output_type -> walletdkrpc.ExitResponse
+	48, // 62: walletdkrpc.WalletService.ExitStatus:output_type -> walletdkrpc.ExitStatusResponse
+	50, // 63: walletdkrpc.WalletService.SubscribeWallet:output_type -> walletdkrpc.WalletEntry
+	29, // 64: walletdkrpc.WalletInspectionService.InspectActivity:output_type -> walletdkrpc.InspectActivityResponse
+	50, // [50:65] is the sub-list for method output_type
+	35, // [35:50] is the sub-list for method input_type
+	35, // [35:35] is the sub-list for extension type_name
+	35, // [35:35] is the sub-list for extension extendee
+	0,  // [0:35] is the sub-list for field type_name
 }
 
 func init() { file_wallet_proto_init() }
@@ -4911,12 +5114,12 @@ func file_wallet_proto_init() {
 		(*PrepareSendRequest_Invoice)(nil),
 		(*PrepareSendRequest_OnchainAddress)(nil),
 	}
-	file_wallet_proto_msgTypes[11].OneofWrappers = []any{
+	file_wallet_proto_msgTypes[13].OneofWrappers = []any{
 		(*ListResponse_Activity)(nil),
 		(*ListResponse_Vtxos)(nil),
 		(*ListResponse_Onchain)(nil),
 	}
-	file_wallet_proto_msgTypes[40].OneofWrappers = []any{
+	file_wallet_proto_msgTypes[42].OneofWrappers = []any{
 		(*WalletEntryRequest_LightningInvoice)(nil),
 		(*WalletEntryRequest_OnchainAddress)(nil),
 		(*WalletEntryRequest_ArkAddress)(nil),
@@ -4927,7 +5130,7 @@ func file_wallet_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wallet_proto_rawDesc), len(file_wallet_proto_rawDesc)),
 			NumEnums:      9,
-			NumMessages:   45,
+			NumMessages:   47,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/rpc/walletdkrpc/wallet.proto
+++ b/rpc/walletdkrpc/wallet.proto
@@ -156,6 +156,8 @@ enum SendRail {
     SEND_RAIL_IN_ARK = 2;
     SEND_RAIL_LIGHTNING = 3;
     SEND_RAIL_ONCHAIN = 4;
+    SEND_RAIL_CREDIT = 5;
+    SEND_RAIL_MIXED = 6;
 }
 
 // SendQuoteStatus describes how complete the prepare-time quote is.
@@ -339,6 +341,10 @@ message PrepareSendResponse {
     // warning carries a concise human-facing caveat for local-only
     // previews.
     string warning = 14;
+
+    // credit_preview is populated when the invoice send will or can use
+    // sat-native server credits.
+    CreditPreview credit_preview = 15;
 }
 
 message SendRequest {
@@ -379,6 +385,24 @@ message RecvResponse {
 
     // entry is the initial WalletEntry persisted for this receive.
     WalletEntry entry = 2;
+
+    // credit_receive is populated when the receive is backed by server credits
+    // rather than a client-claimable vHTLC.
+    CreditReceive credit_receive = 3;
+}
+
+message CreditPreview {
+    bool must_use_credit = 1;
+    uint64 credit_applied_sat = 2;
+    uint64 credit_shortfall_sat = 3;
+    uint64 credit_topup_sat = 4;
+    uint64 ark_funding_sat = 5;
+}
+
+message CreditReceive {
+    string operation_id = 1;
+    uint64 amount_sat = 2;
+    string payment_hash = 3;
 }
 
 message ListRequest {
@@ -754,6 +778,14 @@ message BalanceResponse {
     // pending_out_sat is the total in-flight outbound amount (send plus
     // exit operations).
     int64 pending_out_sat = 3;
+
+    // credit_available_sat is the server-authoritative available credit
+    // balance for the wallet identity.
+    uint64 credit_available_sat = 4;
+
+    // credit_reserved_sat is the server-authoritative in-flight credit
+    // reservation amount.
+    uint64 credit_reserved_sat = 5;
 }
 
 message StatusRequest {

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -998,6 +998,40 @@ func (c *Client) SendOORWithPolicyAndKeyDetails(ctx context.Context,
 	}, nil
 }
 
+// SendOORToPubKey sends one OOR transfer to a standard x-only pubkey
+// destination using the supplied idempotency key.
+func (c *Client) SendOORToPubKey(ctx context.Context, recipientPubKey []byte,
+	amountSat int64, idempotencyKey string) (*OORSendResult, error) {
+
+	resp, err := c.SendOOR(ctx, &daemonrpc.SendOORRequest{
+		Recipients: []*daemonrpc.Output{
+			{
+				Destination: &daemonrpc.Output_Pubkey{
+					Pubkey: append(
+						[]byte(nil), recipientPubKey...,
+					),
+				},
+				AmountSat: amountSat,
+			},
+		},
+		IdempotencyKey: idempotencyKey,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	recipientOutpoints := resp.GetRecipientOutpoints()
+	recipientOutpoint := ""
+	if len(recipientOutpoints) > 0 {
+		recipientOutpoint = recipientOutpoints[0]
+	}
+
+	return &OORSendResult{
+		SessionID:         resp.GetSessionId(),
+		RecipientOutpoint: recipientOutpoint,
+	}, nil
+}
+
 // SendOORWithCustomInputs sends one OOR transfer using caller-specified
 // inputs and a standard x-only pubkey destination.
 func (c *Client) SendOORWithCustomInputs(ctx context.Context,

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -714,6 +714,11 @@ type DaemonConn interface {
 	SendOORWithPolicyDetails(ctx context.Context, amountSat int64,
 		recipientPolicyTemplate []byte) (*OORSendResult, error)
 
+	// SendOORToPubKey sends an OOR transfer to a standard pubkey
+	// destination using the supplied idempotency key.
+	SendOORToPubKey(ctx context.Context, recipientPubKey []byte,
+		amountSat int64, idempotencyKey string) (*OORSendResult, error)
+
 	// SendOORWithCustomInputs sends an OOR with custom inputs into one
 	// standard pubkey-backed Ark receive destination.
 	SendOORWithCustomInputs(ctx context.Context, recipientPubKey []byte,

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -42,7 +42,123 @@ const (
 	// SettlementTypeInArk means the sender and receiver settle with one
 	// vHTLC inside the same Ark instance.
 	SettlementTypeInArk SettlementType = "in_ark"
+
+	// SettlementTypeCredit means the swap server pays Lightning from a
+	// reserved credit balance without a client-funded vHTLC.
+	SettlementTypeCredit SettlementType = "credit"
+
+	// SettlementTypeMixed means the invoice is funded by both a vHTLC and
+	// a reserved credit balance.
+	SettlementTypeMixed SettlementType = "mixed"
 )
+
+// CreditQuote describes how a pay quote uses wallet credits.
+type CreditQuote struct {
+	MustUseCredit      bool
+	CreditAppliedSat   uint64
+	CreditShortfallSat uint64
+	CreditTopupSat     uint64
+	ArkFundingSat      uint64
+}
+
+// CreditFundingSource identifies how value enters a credit account.
+type CreditFundingSource string
+
+const (
+	// CreditFundingLightningReceive means the server creates and owns the
+	// Lightning invoice, then credits the wallet account after settlement.
+	CreditFundingLightningReceive CreditFundingSource = "lightning_receive"
+
+	// CreditFundingArkTopUp means the server returns a pubkey-backed Ark
+	// destination and credits the account after the OOR top-up is visible.
+	CreditFundingArkTopUp CreditFundingSource = "ark_topup"
+)
+
+// CreditOperationType identifies the durable credit operation family.
+type CreditOperationType string
+
+const (
+	CreditOperationFunding    CreditOperationType = "funding"
+	CreditOperationPay        CreditOperationType = "pay"
+	CreditOperationRedemption CreditOperationType = "redemption"
+	CreditOperationReceive    CreditOperationType = "receive"
+)
+
+// CreditOperationState is the externally visible credit state-machine state.
+type CreditOperationState string
+
+const (
+	CreditStateCreated         CreditOperationState = "created"
+	CreditStateAwaitingPayment CreditOperationState = "awaiting_payment"
+	CreditStateCredited        CreditOperationState = "credited"
+	CreditStateReserved        CreditOperationState = "reserved"
+	CreditStatePayingLightning CreditOperationState = "paying_lightning"
+	CreditStateDebited         CreditOperationState = "debited"
+	CreditStateSendingOOR      CreditOperationState = "sending_oor"
+	CreditStateRedeemed        CreditOperationState = "redeemed"
+	CreditStateReleased        CreditOperationState = "released"
+	CreditStateExpired         CreditOperationState = "expired"
+	CreditStateFailed          CreditOperationState = "failed"
+)
+
+// CreateCreditRequest describes one caller intent to materialize credits.
+type CreateCreditRequest struct {
+	IdempotencyKey string
+	Source         CreditFundingSource
+	AmountSat      uint64
+	Memo           string
+}
+
+// RedeemCreditRequest describes one caller intent to materialize credits back
+// into a dust-clearing Ark output.
+type RedeemCreditRequest struct {
+	IdempotencyKey    string
+	AmountSat         uint64
+	DestinationPubKey []byte
+}
+
+// CreditOperation is one server-authoritative credit state machine.
+type CreditOperation struct {
+	OperationID    string
+	Type           CreditOperationType
+	State          CreditOperationState
+	AmountSat      uint64
+	PaymentHash    *lntypes.Hash
+	Invoice        string
+	DestinationKey []byte
+	SessionID      string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	CompletedAt    *time.Time
+	ExpiresAt      *time.Time
+	LastError      string
+}
+
+// CreditLedgerEntry records one immutable finalized credit or debit.
+type CreditLedgerEntry struct {
+	EntryID     string
+	OperationID string
+	Direction   string
+	AmountSat   uint64
+	CreatedAt   time.Time
+}
+
+// CreditSnapshot is the server-authoritative account view.
+type CreditSnapshot struct {
+	FinalizedSat  uint64
+	ReservedSat   uint64
+	AvailableSat  uint64
+	Operations    []CreditOperation
+	LedgerEntries []CreditLedgerEntry
+}
+
+// CreditRedemption records the result of a successful credit redemption.
+type CreditRedemption struct {
+	Operation   CreditOperation
+	DebitedSat  uint64
+	RedeemedSat uint64
+	SessionID   string
+}
 
 // OORSendResult contains daemon metadata for an accepted OOR transfer.
 type OORSendResult = sdkark.OORSendResult
@@ -97,6 +213,25 @@ type SwapSummary struct {
 	// SettlementType identifies whether the swap settles through Lightning
 	// or as a same-Ark payment when that detail is durably known.
 	SettlementType SettlementType
+
+	// CreditQuote records the credit component of a pay quote when the
+	// server selected a credit or mixed rail.
+	CreditQuote *CreditQuote
+
+	// RequestedAmountSat is the invoice amount for receive swaps when it
+	// can differ from the funded vHTLC amount.
+	RequestedAmountSat uint64
+
+	// AttachedCreditSat is the credit amount attached to a credit-assisted
+	// receive.
+	AttachedCreditSat uint64
+
+	// AvailableCreditSat is the balance considered when the receive route
+	// was planned.
+	AvailableCreditSat uint64
+
+	// DustLimitSat is the vHTLC dust limit used for receive planning.
+	DustLimitSat uint64
 
 	// SenderPubkey is the vHTLC sender key when that remote party is
 	// durably known. For same-Ark receives this identifies the paying
@@ -225,6 +360,26 @@ type OutSwapQuote struct {
 
 	// PayerFeeMsat is the payer-paid route fee quoted by the swap server.
 	PayerFeeMsat uint64
+
+	// RequestedAmountSat is the invoice amount requested by the receiver.
+	RequestedAmountSat uint64
+
+	// AvailableCreditSat is the server-authoritative credit balance
+	// considered when the receive route was planned.
+	AvailableCreditSat uint64
+
+	// AttachedCreditSat is the credit amount reserved and added to the
+	// funded vHTLC.
+	AttachedCreditSat uint64
+
+	// VHTLCAmountSat is the funded vHTLC amount the client should expect.
+	VHTLCAmountSat uint64
+
+	// DustLimitSat is the minimum vHTLC output amount used by the server.
+	DustLimitSat uint64
+
+	// SettlementType identifies the receive rail selected by the server.
+	SettlementType SettlementType
 }
 
 // VHTLCConfig holds the timelocks and keys for a vHTLC.
@@ -259,6 +414,13 @@ type OutSwapHtlcEvent struct {
 
 	// AmountSat is the amount funded by the server.
 	AmountSat int64
+
+	// RequestedAmountSat is the invoice amount that the Lightning HTLCs
+	// pay.
+	RequestedAmountSat uint64
+
+	// AttachedCreditSat is the credit amount attached to this vHTLC.
+	AttachedCreditSat uint64
 
 	// OnionBlob is the raw final-hop onion blob forwarded by the server.
 	OnionBlob []byte
@@ -444,6 +606,14 @@ type InSwapConfig struct {
 	// SettlementType identifies whether this pay session is bridged through
 	// Lightning or settled directly inside Ark.
 	SettlementType SettlementType
+
+	// CreditQuote records the credit reservation used by credit or mixed
+	// pays.
+	CreditQuote *CreditQuote
+
+	// Preimage is set for credit-only pays that complete inside the server
+	// CreateInSwap call without creating a vHTLC.
+	Preimage *lntypes.Preimage
 }
 
 // InSwapQuote previews an Ark-to-Lightning payment without creating durable
@@ -474,6 +644,9 @@ type InSwapQuote struct {
 	// ExceedsMaxFee is true when the caller supplied a max fee and the
 	// quoted fee is larger than that cap.
 	ExceedsMaxFee bool
+
+	// CreditQuote describes how credits would be used for this invoice.
+	CreditQuote *CreditQuote
 }
 
 // SwapServerConn abstracts the connection to the swap server's

--- a/sdk/swaps/credits.go
+++ b/sdk/swaps/credits.go
@@ -1,0 +1,99 @@
+package swaps
+
+import (
+	"context"
+	"fmt"
+)
+
+type creditServerConn interface {
+	CreateCredit(context.Context, []byte,
+		CreateCreditRequest) (*CreditOperation, error)
+
+	RedeemCredit(context.Context, []byte,
+		RedeemCreditRequest) (*CreditRedemption, error)
+
+	ListCredits(context.Context, []byte, uint32) (*CreditSnapshot, error)
+}
+
+// CreateCredit starts one server-owned credit funding operation for this
+// wallet's identity account.
+func (c *SwapClient) CreateCredit(ctx context.Context,
+	req CreateCreditRequest) (*CreditOperation, error) {
+
+	server, err := c.creditServer()
+	if err != nil {
+		return nil, err
+	}
+
+	accountKey, err := c.creditAccountKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return server.CreateCredit(ctx, accountKey, req)
+}
+
+// RedeemCredit asks the swap server to materialize available credits back into
+// the supplied Ark destination for this wallet's identity account.
+func (c *SwapClient) RedeemCredit(ctx context.Context,
+	req RedeemCreditRequest) (*CreditRedemption, error) {
+
+	server, err := c.creditServer()
+	if err != nil {
+		return nil, err
+	}
+
+	accountKey, err := c.creditAccountKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return server.RedeemCredit(ctx, accountKey, req)
+}
+
+// ListCredits returns the server-authoritative credit account snapshot for the
+// wallet identity account.
+func (c *SwapClient) ListCredits(ctx context.Context, limit uint32) (
+	*CreditSnapshot, error) {
+
+	server, err := c.creditServer()
+	if err != nil {
+		return nil, err
+	}
+
+	accountKey, err := c.creditAccountKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return server.ListCredits(ctx, accountKey, limit)
+}
+
+func (c *SwapClient) creditServer() (creditServerConn, error) {
+	if c == nil || c.server == nil {
+		return nil, fmt.Errorf("swap server is not configured")
+	}
+
+	server, ok := c.server.(creditServerConn)
+	if !ok {
+		return nil, fmt.Errorf("swap server does not support credits")
+	}
+
+	return server, nil
+}
+
+func (c *SwapClient) creditAccountKey(ctx context.Context) ([]byte, error) {
+	if c == nil || c.daemon == nil {
+		return nil, fmt.Errorf("daemon is not configured")
+	}
+
+	accountKey, err := c.daemon.IdentityPubKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get credit account pubkey: %w", err)
+	}
+	if accountKey == nil {
+		return nil, fmt.Errorf("credit account pubkey is required")
+	}
+
+	return accountKey.SerializeCompressed(), nil
+}

--- a/sdk/swaps/errors.go
+++ b/sdk/swaps/errors.go
@@ -28,6 +28,10 @@ var (
 	// ErrSwapSummaryNotFound is returned when no persisted pay or receive
 	// swap summary exists for a requested payment hash.
 	ErrSwapSummaryNotFound = errors.New("swap summary not found")
+
+	// ErrPaySessionNotFound is returned when no persisted pay session
+	// exists for a requested payment hash.
+	ErrPaySessionNotFound = errors.New("pay session not found")
 )
 
 // errSwapExpired is kept as an internal alias for older tests and helpers.

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -21,6 +21,9 @@ type GRPCSwapServerConn struct {
 	client swaprpc.SwapServiceClient
 }
 
+const wireCreditFundingLightningReceive = swaprpc.
+	CreditFundingSource_CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE
+
 // NewGRPCSwapServerConn creates a gRPC-backed SwapServerConn from one connected
 // gRPC client connection.
 func NewGRPCSwapServerConn(conn grpc.ClientConnInterface) *GRPCSwapServerConn {
@@ -60,7 +63,7 @@ func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 			PaymentHash: append(
 				[]byte(nil), paymentHash[:]...,
 			),
-			AmountMsat: uint64(amountSat) * 1000,
+			AmountSat: uint64(amountSat),
 		},
 	)
 	if err != nil {
@@ -72,12 +75,30 @@ func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 		return nil, err
 	}
 
+	settlementType, err := settlementTypeFromProto(resp.GetSettlementType())
+	if err != nil {
+		return nil, err
+	}
+
+	requestedAmountSat := resp.GetRequestedAmountSat()
+	if requestedAmountSat == 0 {
+		requestedAmountSat = uint64(amountSat)
+	}
+	vhtlcAmountSat := resp.GetVhtlcAmountSat()
+	if vhtlcAmountSat == 0 {
+		vhtlcAmountSat = requestedAmountSat
+	}
+
 	return &OutSwapQuote{
-		RouteHint: hint,
-		// The server binds the route to the requested amount but does
-		// not echo it, so keep the caller's amount in the quote.
-		ReceiveAmountSat: amountSat,
-		PayerFeeMsat:     resp.GetPayerFeeMsat(),
+		RouteHint:          hint,
+		ReceiveAmountSat:   btcutil.Amount(requestedAmountSat),
+		PayerFeeMsat:       resp.GetPayerFeeMsat(),
+		RequestedAmountSat: requestedAmountSat,
+		AvailableCreditSat: resp.GetAvailableCreditSat(),
+		AttachedCreditSat:  resp.GetAttachedCreditSat(),
+		VHTLCAmountSat:     vhtlcAmountSat,
+		DustLimitSat:       resp.GetDustLimitSat(),
+		SettlementType:     settlementType,
 	}, nil
 }
 
@@ -110,6 +131,18 @@ func (g *GRPCSwapServerConn) CreateInSwap(ctx context.Context, invoice string,
 	maxFeeSat uint64, clientVhtlcPubkey *btcec.PublicKey) (*InSwapConfig,
 	error) {
 
+	return g.CreateInSwapWithCredits(
+		ctx, invoice, maxFeeSat, clientVhtlcPubkey, nil, 0,
+	)
+}
+
+// CreateInSwapWithCredits initiates one Ark-to-Lightning swap and authorizes
+// the server to reserve credits from accountPubKey when maxCreditSat is
+// non-zero or credit is mandatory.
+func (g *GRPCSwapServerConn) CreateInSwapWithCredits(ctx context.Context,
+	invoice string, maxFeeSat uint64, clientVhtlcPubkey *btcec.PublicKey,
+	accountPubKey []byte, maxCreditSat uint64) (*InSwapConfig, error) {
+
 	if clientVhtlcPubkey == nil {
 		return nil, fmt.Errorf("client vHTLC pubkey must be provided")
 	}
@@ -120,6 +153,8 @@ func (g *GRPCSwapServerConn) CreateInSwap(ctx context.Context, invoice string,
 			MaxFeeSat: maxFeeSat,
 			ClientVhtlcPubkey: clientVhtlcPubkey.
 				SerializeCompressed(),
+			AccountPubkey: append([]byte(nil), accountPubKey...),
+			MaxCreditSat:  maxCreditSat,
 		},
 	)
 	if err != nil {
@@ -134,10 +169,21 @@ func (g *GRPCSwapServerConn) CreateInSwap(ctx context.Context, invoice string,
 func (g *GRPCSwapServerConn) QuoteInSwap(ctx context.Context, invoice string,
 	maxFeeSat uint64) (*InSwapQuote, error) {
 
+	return g.QuoteInSwapWithCredits(ctx, invoice, maxFeeSat, nil, 0)
+}
+
+// QuoteInSwapWithCredits previews one Ark-to-Lightning swap with optional
+// credit use.
+func (g *GRPCSwapServerConn) QuoteInSwapWithCredits(ctx context.Context,
+	invoice string, maxFeeSat uint64, accountPubKey []byte,
+	maxCreditSat uint64) (*InSwapQuote, error) {
+
 	resp, err := g.client.QuoteInSwap(
 		ctx, &swaprpc.QuoteInSwapRequest{
-			Invoice:   invoice,
-			MaxFeeSat: maxFeeSat,
+			Invoice:       invoice,
+			MaxFeeSat:     maxFeeSat,
+			AccountPubkey: append([]byte(nil), accountPubKey...),
+			MaxCreditSat:  maxCreditSat,
 		},
 	)
 	if err != nil {
@@ -145,6 +191,97 @@ func (g *GRPCSwapServerConn) QuoteInSwap(ctx context.Context, invoice string,
 	}
 
 	return inSwapQuoteFromProto(resp)
+}
+
+// CreateCredit starts one server-owned credit funding operation.
+func (g *GRPCSwapServerConn) CreateCredit(ctx context.Context,
+	accountPubKey []byte, req CreateCreditRequest) (*CreditOperation,
+	error) {
+
+	source, err := creditFundingSourceToProto(req.Source)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := g.client.CreateCredit(ctx, &swaprpc.CreateCreditRequest{
+		AccountPubkey:  append([]byte(nil), accountPubKey...),
+		IdempotencyKey: req.IdempotencyKey,
+		Source:         source,
+		AmountSat:      req.AmountSat,
+		Memo:           req.Memo,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("CreateCredit RPC: %w", err)
+	}
+
+	op := creditOperationFromCreate(resp)
+
+	return &op, nil
+}
+
+// RedeemCredit materializes available credits back into an Ark output.
+func (g *GRPCSwapServerConn) RedeemCredit(ctx context.Context,
+	accountPubKey []byte, req RedeemCreditRequest) (*CreditRedemption,
+	error) {
+
+	resp, err := g.client.RedeemCredit(ctx, &swaprpc.RedeemCreditRequest{
+		AccountPubkey:  append([]byte(nil), accountPubKey...),
+		IdempotencyKey: req.IdempotencyKey,
+		AmountSat:      req.AmountSat,
+		DestinationPubkey: append(
+			[]byte(nil), req.DestinationPubKey...,
+		),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("RedeemCredit RPC: %w", err)
+	}
+
+	op := CreditOperation{
+		OperationID: resp.GetOperationId(),
+		Type:        CreditOperationRedemption,
+		State:       creditStateFromProto(resp.GetState()),
+		AmountSat:   resp.GetRedeemedSat(),
+		SessionID:   resp.GetSessionId(),
+	}
+
+	return &CreditRedemption{
+		Operation:   op,
+		DebitedSat:  resp.GetDebitedSat(),
+		RedeemedSat: resp.GetRedeemedSat(),
+		SessionID:   resp.GetSessionId(),
+	}, nil
+}
+
+// ListCredits returns the account's server-authoritative credit snapshot.
+func (g *GRPCSwapServerConn) ListCredits(ctx context.Context,
+	accountPubKey []byte, limit uint32) (*CreditSnapshot, error) {
+
+	resp, err := g.client.ListCredits(ctx, &swaprpc.ListCreditsRequest{
+		AccountPubkey: append([]byte(nil), accountPubKey...),
+		Limit:         limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ListCredits RPC: %w", err)
+	}
+
+	snapshot := &CreditSnapshot{
+		FinalizedSat: resp.GetFinalizedSat(),
+		ReservedSat:  resp.GetReservedSat(),
+		AvailableSat: resp.GetAvailableSat(),
+	}
+	for _, op := range resp.GetOperations() {
+		snapshot.Operations = append(
+			snapshot.Operations, creditOperationFromProto(op),
+		)
+	}
+	for _, entry := range resp.GetLedgerEntries() {
+		snapshot.LedgerEntries = append(
+			snapshot.LedgerEntries,
+			creditLedgerEntryFromProto(entry),
+		)
+	}
+
+	return snapshot, nil
 }
 
 // AuthorizeInSwapRefund asks the swap server to sign one prepared cooperative
@@ -368,8 +505,10 @@ func outSwapHtlcEventFromProto(event *swaprpc.OutSwapHtlcEvent) (
 	}
 
 	return &OutSwapHtlcEvent{
-		PaymentHash: paymentHash,
-		AmountSat:   int64(event.GetAmountSat()),
+		PaymentHash:        paymentHash,
+		AmountSat:          int64(event.GetAmountSat()),
+		RequestedAmountSat: event.GetRequestedAmountSat(),
+		AttachedCreditSat:  event.GetAttachedCreditSat(),
 		OnionBlob: append(
 			[]byte(nil), event.GetOnionBlob()...,
 		),
@@ -596,32 +735,8 @@ func inSwapConfigFromProto(resp *swaprpc.CreateInSwapResponse) (*InSwapConfig,
 			"%d bytes", lntypes.HashSize)
 	}
 
-	if resp.GetAmountSat() == 0 {
-		return nil, fmt.Errorf("in-swap response amount must be " +
-			"positive")
-	}
-
-	if resp.GetAmountSat() > math.MaxInt64 {
-		return nil, fmt.Errorf("in-swap response amount exceeds " +
-			"int64 range")
-	}
-
-	if len(resp.GetServerPubkey()) == 0 {
-		return nil, fmt.Errorf("in-swap response missing server pubkey")
-	}
-
 	var paymentHash lntypes.Hash
 	copy(paymentHash[:], resp.GetPaymentHash())
-
-	serverPubkey, err := btcec.ParsePubKey(resp.GetServerPubkey())
-	if err != nil {
-		return nil, fmt.Errorf("parse server pubkey: %w", err)
-	}
-
-	cfg, err := vhtlcConfigFromProto(resp.GetVhtlcConfig())
-	if err != nil {
-		return nil, err
-	}
 
 	if resp.GetExpiry() == nil {
 		return nil, fmt.Errorf("in-swap response missing expiry")
@@ -640,6 +755,56 @@ func inSwapConfigFromProto(resp *swaprpc.CreateInSwapResponse) (*InSwapConfig,
 		return nil, err
 	}
 
+	creditQuote := creditQuoteFromProto(resp.GetCreditQuote())
+	if settlementType == SettlementTypeCredit {
+		if resp.GetAmountSat() != 0 {
+			return nil, fmt.Errorf("credit in-swap response " +
+				"amount must be zero")
+		}
+
+		preimage, err := lntypes.MakePreimage(resp.GetPreimage())
+		if err != nil {
+			return nil, fmt.Errorf("parse credit pay preimage: %w",
+				err)
+		}
+		if preimage.Hash() != paymentHash {
+			return nil, fmt.Errorf("credit pay preimage does not " +
+				"match payment hash")
+		}
+
+		return &InSwapConfig{
+			PaymentHash:    paymentHash,
+			AmountSat:      0,
+			FeeSat:         resp.GetFeeSat(),
+			Expiry:         expiryTime,
+			SettlementType: settlementType,
+			CreditQuote:    creditQuote,
+			Preimage:       &preimage,
+		}, nil
+	}
+
+	if resp.GetAmountSat() == 0 {
+		return nil, fmt.Errorf("in-swap response amount must be " +
+			"positive")
+	}
+	if resp.GetAmountSat() > math.MaxInt64 {
+		return nil, fmt.Errorf("in-swap response amount exceeds " +
+			"int64 range")
+	}
+	if len(resp.GetServerPubkey()) == 0 {
+		return nil, fmt.Errorf("in-swap response missing server pubkey")
+	}
+
+	serverPubkey, err := btcec.ParsePubKey(resp.GetServerPubkey())
+	if err != nil {
+		return nil, fmt.Errorf("parse server pubkey: %w", err)
+	}
+
+	cfg, err := vhtlcConfigFromProto(resp.GetVhtlcConfig())
+	if err != nil {
+		return nil, err
+	}
+
 	return &InSwapConfig{
 		PaymentHash:    paymentHash,
 		AmountSat:      int64(resp.GetAmountSat()),
@@ -648,6 +813,7 @@ func inSwapConfigFromProto(resp *swaprpc.CreateInSwapResponse) (*InSwapConfig,
 		VHTLCConfig:    *cfg,
 		Expiry:         expiryTime,
 		SettlementType: settlementType,
+		CreditQuote:    creditQuote,
 	}, nil
 }
 
@@ -671,10 +837,6 @@ func inSwapQuoteFromProto(resp *swaprpc.QuoteInSwapResponse) (*InSwapQuote,
 			"positive")
 	}
 
-	if resp.GetAmountSat() == 0 {
-		return nil, fmt.Errorf("in-swap quote amount must be positive")
-	}
-
 	if resp.GetFeeSat() > maxInt64Uint {
 		return nil, fmt.Errorf("in-swap quote fee exceeds int64 range")
 	}
@@ -682,14 +844,6 @@ func inSwapQuoteFromProto(resp *swaprpc.QuoteInSwapResponse) (*InSwapQuote,
 	if resp.GetInvoiceAmountSat() > maxInt64Uint-resp.GetFeeSat() {
 		return nil, fmt.Errorf("in-swap quote amount exceeds int64 " +
 			"range")
-	}
-
-	expectedAmount := resp.GetInvoiceAmountSat() + resp.GetFeeSat()
-	if resp.GetAmountSat() != expectedAmount {
-		return nil, fmt.Errorf("in-swap quote amount %d does not "+
-			"equal invoice amount %d plus fee %d",
-			resp.GetAmountSat(), resp.GetInvoiceAmountSat(),
-			resp.GetFeeSat())
 	}
 
 	if resp.GetExpiry() == nil {
@@ -708,6 +862,40 @@ func inSwapQuoteFromProto(resp *swaprpc.QuoteInSwapResponse) (*InSwapQuote,
 		return nil, err
 	}
 
+	creditQuote := creditQuoteFromProto(resp.GetCreditQuote())
+	switch settlementType {
+	case SettlementTypeCredit:
+		if resp.GetAmountSat() != 0 {
+			return nil, fmt.Errorf("credit in-swap quote amount " +
+				"must be zero")
+		}
+
+	case SettlementTypeMixed:
+		if creditQuote == nil {
+			return nil, fmt.Errorf("mixed in-swap quote missing " +
+				"credit quote")
+		}
+		if resp.GetAmountSat() != creditQuote.ArkFundingSat {
+			return nil, fmt.Errorf("mixed in-swap quote amount %d "+
+				"does not equal ark funding %d",
+				resp.GetAmountSat(), creditQuote.ArkFundingSat)
+		}
+
+	default:
+		if resp.GetAmountSat() == 0 {
+			return nil, fmt.Errorf("in-swap quote amount must be " +
+				"positive")
+		}
+
+		expectedAmount := resp.GetInvoiceAmountSat() + resp.GetFeeSat()
+		if resp.GetAmountSat() != expectedAmount {
+			return nil, fmt.Errorf("in-swap quote amount %d does "+
+				"not equal invoice amount %d plus fee %d",
+				resp.GetAmountSat(), resp.GetInvoiceAmountSat(),
+				resp.GetFeeSat())
+		}
+	}
+
 	var paymentHash lntypes.Hash
 	copy(paymentHash[:], resp.GetPaymentHash())
 
@@ -719,7 +907,196 @@ func inSwapQuoteFromProto(resp *swaprpc.QuoteInSwapResponse) (*InSwapQuote,
 		Expiry:           expiryTime,
 		SettlementType:   settlementType,
 		ExceedsMaxFee:    resp.GetExceedsMaxFee(),
+		CreditQuote:      creditQuote,
 	}, nil
+}
+
+func creditFundingSourceToProto(source CreditFundingSource) (
+	swaprpc.CreditFundingSource, error) {
+
+	switch source {
+	case CreditFundingLightningReceive:
+		return wireCreditFundingLightningReceive, nil
+
+	case CreditFundingArkTopUp:
+		wireSource := swaprpc.
+			CreditFundingSource_CREDIT_FUNDING_SOURCE_ARK_TOPUP
+
+		return wireSource, nil
+
+	default:
+		return 0, fmt.Errorf("unknown credit funding source %q", source)
+	}
+}
+
+func creditOperationFromCreate(
+	resp *swaprpc.CreateCreditResponse) CreditOperation {
+
+	if resp == nil {
+		return CreditOperation{}
+	}
+
+	op := CreditOperation{
+		OperationID: resp.GetOperationId(),
+		Type:        CreditOperationFunding,
+		State:       creditStateFromProto(resp.GetState()),
+		AmountSat:   resp.GetAmountSat(),
+		PaymentHash: creditPaymentHashFromProto(
+			resp.GetPaymentHash(),
+		),
+		Invoice: resp.GetInvoice(),
+		DestinationKey: append(
+			[]byte(nil), resp.GetDestinationPubkey()...,
+		),
+	}
+	if expiresAt := resp.GetExpiresAt(); expiresAt != nil {
+		expires := expiresAt.AsTime()
+		op.ExpiresAt = &expires
+	}
+
+	return op
+}
+
+func creditOperationFromProto(resp *swaprpc.CreditOperation) CreditOperation {
+	if resp == nil {
+		return CreditOperation{}
+	}
+
+	op := CreditOperation{
+		OperationID: resp.GetOperationId(),
+		Type:        creditTypeFromProto(resp.GetType()),
+		State:       creditStateFromProto(resp.GetState()),
+		AmountSat:   resp.GetAmountSat(),
+		PaymentHash: creditPaymentHashFromProto(
+			resp.GetPaymentHash(),
+		),
+		Invoice: resp.GetInvoice(),
+		DestinationKey: append(
+			[]byte(nil), resp.GetDestinationPubkey()...,
+		),
+		SessionID: resp.GetSessionId(),
+		LastError: resp.GetLastError(),
+	}
+	if createdAt := resp.GetCreatedAt(); createdAt != nil {
+		op.CreatedAt = createdAt.AsTime()
+	}
+	if updatedAt := resp.GetUpdatedAt(); updatedAt != nil {
+		op.UpdatedAt = updatedAt.AsTime()
+	}
+	if completedAt := resp.GetCompletedAt(); completedAt != nil {
+		completed := completedAt.AsTime()
+		op.CompletedAt = &completed
+	}
+
+	return op
+}
+
+func creditLedgerEntryFromProto(
+	resp *swaprpc.CreditLedgerEntry) CreditLedgerEntry {
+
+	if resp == nil {
+		return CreditLedgerEntry{}
+	}
+
+	entry := CreditLedgerEntry{
+		EntryID:     resp.GetEntryId(),
+		OperationID: resp.GetOperationId(),
+		Direction:   resp.GetDirection(),
+		AmountSat:   resp.GetAmountSat(),
+	}
+	if createdAt := resp.GetCreatedAt(); createdAt != nil {
+		entry.CreatedAt = createdAt.AsTime()
+	}
+
+	return entry
+}
+
+func creditPaymentHashFromProto(raw []byte) *lntypes.Hash {
+	if len(raw) != lntypes.HashSize {
+		return nil
+	}
+
+	var hash lntypes.Hash
+	copy(hash[:], raw)
+
+	return &hash
+}
+
+func creditTypeFromProto(typ swaprpc.CreditOperationType) CreditOperationType {
+	switch typ {
+	case swaprpc.CreditOperationType_CREDIT_OPERATION_TYPE_FUNDING:
+		return CreditOperationFunding
+
+	case swaprpc.CreditOperationType_CREDIT_OPERATION_TYPE_PAY:
+		return CreditOperationPay
+
+	case swaprpc.CreditOperationType_CREDIT_OPERATION_TYPE_REDEMPTION:
+		return CreditOperationRedemption
+
+	case swaprpc.CreditOperationType_CREDIT_OPERATION_TYPE_RECEIVE:
+		return CreditOperationReceive
+
+	default:
+		return ""
+	}
+}
+
+func creditStateFromProto(
+	state swaprpc.CreditOperationState) CreditOperationState {
+
+	switch state {
+	case swaprpc.CreditOperationState_CREDIT_OPERATION_STATE_CREATED:
+		return CreditStateCreated
+
+	case swaprpc.
+		CreditOperationState_CREDIT_OPERATION_STATE_AWAITING_PAYMENT:
+		return CreditStateAwaitingPayment
+
+	case swaprpc.CreditOperationState_CREDIT_OPERATION_STATE_CREDITED:
+		return CreditStateCredited
+
+	case swaprpc.CreditOperationState_CREDIT_OPERATION_STATE_RESERVED:
+		return CreditStateReserved
+
+	case swaprpc.
+		CreditOperationState_CREDIT_OPERATION_STATE_PAYING_LIGHTNING:
+		return CreditStatePayingLightning
+
+	case swaprpc.CreditOperationState_CREDIT_OPERATION_STATE_DEBITED:
+		return CreditStateDebited
+
+	case swaprpc.CreditOperationState_CREDIT_OPERATION_STATE_SENDING_OOR:
+		return CreditStateSendingOOR
+
+	case swaprpc.CreditOperationState_CREDIT_OPERATION_STATE_REDEEMED:
+		return CreditStateRedeemed
+
+	case swaprpc.CreditOperationState_CREDIT_OPERATION_STATE_RELEASED:
+		return CreditStateReleased
+
+	case swaprpc.CreditOperationState_CREDIT_OPERATION_STATE_EXPIRED:
+		return CreditStateExpired
+
+	case swaprpc.CreditOperationState_CREDIT_OPERATION_STATE_FAILED:
+		return CreditStateFailed
+
+	default:
+		return ""
+	}
+}
+
+func creditQuoteFromProto(resp *swaprpc.CreditQuote) *CreditQuote {
+	if resp == nil {
+		return nil
+	}
+
+	return &CreditQuote{
+		MustUseCredit:      resp.GetMustUseCredit(),
+		CreditAppliedSat:   resp.GetCreditAppliedSat(),
+		CreditShortfallSat: resp.GetCreditShortfallSat(),
+		CreditTopupSat:     resp.GetCreditTopupSat(),
+		ArkFundingSat:      resp.GetArkFundingSat(),
+	}
 }
 
 // settlementTypeFromProto converts the wire settlement enum, treating
@@ -734,6 +1111,12 @@ func settlementTypeFromProto(wireType swaprpc.SettlementType) (SettlementType,
 
 	case swaprpc.SettlementType_SETTLEMENT_TYPE_IN_ARK:
 		return SettlementTypeInArk, nil
+
+	case swaprpc.SettlementType_SETTLEMENT_TYPE_CREDIT:
+		return SettlementTypeCredit, nil
+
+	case swaprpc.SettlementType_SETTLEMENT_TYPE_MIXED:
+		return SettlementTypeMixed, nil
 
 	default:
 		return "", fmt.Errorf("unknown settlement type %v", wireType)

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -228,11 +228,12 @@ var payTransitions = map[PayState]map[payEvent]PayState{
 type paySession struct {
 	client *SwapClient
 
-	invoice   string
-	maxFeeSat uint64
-	state     PayState
-	createdAt time.Time
-	updatedAt time.Time
+	invoice      string
+	maxFeeSat    uint64
+	maxCreditSat uint64
+	state        PayState
+	createdAt    time.Time
+	updatedAt    time.Time
 
 	cfg                 *InSwapConfig
 	vhtlcPolicy         *arkscript.VHTLCPolicy
@@ -471,11 +472,21 @@ func (c *SwapClient) PayViaLightning(ctx context.Context, invoice string,
 func (c *SwapClient) StartPayViaLightning(ctx context.Context, invoice string,
 	maxFeeSat uint64) (*PaySession, error) {
 
+	return c.StartPayViaLightningWithCredits(ctx, invoice, maxFeeSat, 0)
+}
+
+// StartPayViaLightningWithCredits creates an Ark-to-Lightning pay session and
+// allows the swap server to reserve up to maxCreditSat credits.
+func (c *SwapClient) StartPayViaLightningWithCredits(ctx context.Context,
+	invoice string, maxFeeSat uint64, maxCreditSat uint64) (*PaySession,
+	error) {
+
 	session := &paySession{
-		client:    c,
-		invoice:   invoice,
-		maxFeeSat: maxFeeSat,
-		state:     PayStateCreated,
+		client:       c,
+		invoice:      invoice,
+		maxFeeSat:    maxFeeSat,
+		maxCreditSat: maxCreditSat,
+		state:        PayStateCreated,
 	}
 
 	if err := session.runUntil(ctx, PayStateSwapCreated); err != nil {
@@ -511,6 +522,10 @@ func (s *paySession) runUntil(ctx context.Context, target PayState) error {
 
 	for s.state != target {
 		if s.state.IsTerminal() {
+			if s.state == PayStateCompleted {
+				return nil
+			}
+
 			return s.terminalErr()
 		}
 
@@ -543,9 +558,21 @@ func (s *paySession) createSwap(ctx context.Context) error {
 		return fmt.Errorf("get client pubkey: %w", err)
 	}
 
-	cfg, err := s.client.server.CreateInSwap(
-		ctx, s.invoice, s.maxFeeSat, clientKey,
-	)
+	var cfg *InSwapConfig
+	if server, ok := s.client.server.(interface {
+		CreateInSwapWithCredits(context.Context, string, uint64,
+			*btcec.PublicKey, []byte, uint64) (*InSwapConfig, error)
+	}); ok {
+
+		cfg, err = server.CreateInSwapWithCredits(
+			ctx, s.invoice, s.maxFeeSat, clientKey,
+			clientKey.SerializeCompressed(), s.maxCreditSat,
+		)
+	} else {
+		cfg, err = s.client.server.CreateInSwap(
+			ctx, s.invoice, s.maxFeeSat, clientKey,
+		)
+	}
 	if err != nil {
 		return fmt.Errorf("create in-swap: %w", err)
 	}
@@ -561,6 +588,37 @@ func (s *paySession) createSwap(ctx context.Context) error {
 	)
 	if err != nil {
 		return fmt.Errorf("validate in-swap quote: %w", err)
+	}
+
+	if cfg.SettlementType == SettlementTypeCredit {
+		var creditAppliedSat uint64
+		if cfg.CreditQuote != nil {
+			creditAppliedSat = cfg.CreditQuote.CreditAppliedSat
+		}
+
+		s.client.log.InfoS(ctx, "Credit in-swap completed",
+			btclog.Hex("hash", cfg.PaymentHash[:]),
+			slog.Uint64("credit_applied_sat", creditAppliedSat),
+			slog.Time("deadline", cfg.Expiry),
+		)
+
+		return s.mutateAndPersist(ctx, func() error {
+			if s.createdAt.IsZero() {
+				s.createdAt = s.client.currentTime()
+			}
+			s.cfg = cfg
+			s.preimage = cfg.Preimage
+			s.clientPubKey = clientKey
+			s.operatorPubKey = clientKey
+			s.serverPubKey = clientKey
+			if err := s.transition(
+				payEventSwapCreated,
+			); err != nil {
+				return err
+			}
+
+			return s.transition(payEventCompleted)
+		})
 	}
 
 	operatorKey, err := s.client.daemon.OperatorPubKey(ctx)

--- a/sdk/swaps/in_swap_fsm.go
+++ b/sdk/swaps/in_swap_fsm.go
@@ -225,6 +225,9 @@ func (m *payLoopFSM) eventForProgress(prev PayState) loopfsm.EventType {
 	if m.session.state == prev || m.session.state == m.target {
 		return loopfsm.NoOp
 	}
+	if m.session.state.IsTerminal() {
+		return loopfsm.NoOp
+	}
 
 	return payEventForState(m.session.state)
 }

--- a/sdk/swaps/in_swap_quote.go
+++ b/sdk/swaps/in_swap_quote.go
@@ -31,8 +31,7 @@ func decodePayInvoice(invoice string,
 	return decoded, nil
 }
 
-// extractInvoiceAmountSat extracts a positive whole-satoshi invoice amount.
-func extractInvoiceAmountSat(msat *lnwire.MilliSatoshi) (uint64, error) {
+func extractInvoiceAmountMsat(msat *lnwire.MilliSatoshi) (uint64, error) {
 	if msat == nil {
 		return 0, fmt.Errorf("invoice amount is required")
 	}
@@ -41,11 +40,16 @@ func extractInvoiceAmountSat(msat *lnwire.MilliSatoshi) (uint64, error) {
 	if amountMSat == 0 {
 		return 0, fmt.Errorf("invoice amount must be positive")
 	}
-	if amountMSat%1000 != 0 {
-		return 0, fmt.Errorf("invoice amount must be whole satoshis")
+
+	return amountMSat, nil
+}
+
+func ceilMsatToSat(msat uint64) uint64 {
+	if msat == 0 {
+		return 0
 	}
 
-	return amountMSat / 1000, nil
+	return (msat + 999) / 1000
 }
 
 // QuotePayViaLightning previews a pay-side in-swap without creating durable
@@ -53,13 +57,44 @@ func extractInvoiceAmountSat(msat *lnwire.MilliSatoshi) (uint64, error) {
 func (c *SwapClient) QuotePayViaLightning(ctx context.Context, invoice string,
 	maxFeeSat uint64) (*InSwapQuote, error) {
 
+	return c.QuotePayViaLightningWithCredits(ctx, invoice, maxFeeSat, 0)
+}
+
+// QuotePayViaLightningWithCredits previews a pay-side in-swap with optional
+// credit use.
+func (c *SwapClient) QuotePayViaLightningWithCredits(ctx context.Context,
+	invoice string, maxFeeSat uint64, maxCreditSat uint64) (*InSwapQuote,
+	error) {
+
 	if c == nil || c.server == nil {
 		return nil, fmt.Errorf("swap server is required")
 	}
 
-	quote, err := c.server.QuoteInSwap(ctx, invoice, maxFeeSat)
-	if err != nil {
-		return nil, err
+	var quote *InSwapQuote
+	if server, ok := c.server.(interface {
+		QuoteInSwapWithCredits(context.Context, string, uint64, []byte,
+			uint64) (*InSwapQuote, error)
+	}); ok {
+
+		accountKey, err := c.daemon.IdentityPubKey(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("get credit account pubkey: %w",
+				err)
+		}
+
+		quote, err = server.QuoteInSwapWithCredits(
+			ctx, invoice, maxFeeSat,
+			accountKey.SerializeCompressed(), maxCreditSat,
+		)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var err error
+		quote, err = c.server.QuoteInSwap(ctx, invoice, maxFeeSat)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if err := validateInSwapPreview(
@@ -83,7 +118,8 @@ func validateInSwapPreview(invoice string, quote *InSwapQuote,
 		return fmt.Errorf("in-swap quote invoice amount must be " +
 			"positive")
 	}
-	if quote.AmountSat == 0 {
+	if quote.AmountSat == 0 &&
+		quote.SettlementType != SettlementTypeCredit {
 		return fmt.Errorf("in-swap quote amount must be positive")
 	}
 	if quote.SettlementType == "" {
@@ -105,30 +141,44 @@ func validateInSwapPreview(invoice string, quote *InSwapQuote,
 			"invoice")
 	}
 
-	amountSat, err := extractInvoiceAmountSat(decoded.MilliSat)
+	amountMsat, err := extractInvoiceAmountMsat(decoded.MilliSat)
 	if err != nil {
 		return err
 	}
 
-	if amountSat != quote.InvoiceAmountSat {
+	expectedInvoiceSat := ceilMsatToSat(amountMsat)
+	if expectedInvoiceSat != quote.InvoiceAmountSat {
 		return fmt.Errorf("in-swap quote invoice amount %d does not "+
 			"match invoice amount %d", quote.InvoiceAmountSat,
-			amountSat)
+			expectedInvoiceSat)
 	}
 
 	if quote.FeeSat > maxInt64Uint {
 		return fmt.Errorf("in-swap quote fee overflows int64 range")
 	}
 
-	if amountSat > maxInt64Uint-quote.FeeSat {
+	if expectedInvoiceSat > maxInt64Uint-quote.FeeSat {
 		return fmt.Errorf("in-swap quote amount overflows int64 range")
 	}
 
-	expectedAmountSat := amountSat + quote.FeeSat
+	expectedAmountSat := expectedInvoiceSat + quote.FeeSat
+	switch quote.SettlementType {
+	case "", SettlementTypeLightning, SettlementTypeInArk:
+	case SettlementTypeCredit:
+		expectedAmountSat = 0
+
+	case SettlementTypeMixed:
+		if quote.CreditQuote == nil {
+			return fmt.Errorf("mixed in-swap quote missing " +
+				"credit quote")
+		}
+		expectedAmountSat = quote.CreditQuote.ArkFundingSat
+	}
+
 	if quote.AmountSat != expectedAmountSat {
 		return fmt.Errorf("in-swap quote amount %d does not equal "+
 			"invoice amount %d plus fee %d", quote.AmountSat,
-			amountSat, quote.FeeSat)
+			expectedInvoiceSat, quote.FeeSat)
 	}
 
 	return nil
@@ -142,7 +192,7 @@ func validateInSwapQuote(invoice string, maxFeeSat uint64, cfg *InSwapConfig,
 	if cfg == nil {
 		return fmt.Errorf("in-swap config is required")
 	}
-	if cfg.AmountSat <= 0 {
+	if cfg.AmountSat <= 0 && cfg.SettlementType != SettlementTypeCredit {
 		return fmt.Errorf("in-swap amount must be positive")
 	}
 
@@ -160,10 +210,11 @@ func validateInSwapQuote(invoice string, maxFeeSat uint64, cfg *InSwapConfig,
 		return fmt.Errorf("in-swap payment hash does not match invoice")
 	}
 
-	amountSat, err := extractInvoiceAmountSat(decoded.MilliSat)
+	amountMsat, err := extractInvoiceAmountMsat(decoded.MilliSat)
 	if err != nil {
 		return err
 	}
+	amountSat := ceilMsatToSat(amountMsat)
 
 	if cfg.FeeSat > maxFeeSat {
 		return fmt.Errorf("in-swap fee %d exceeds max fee %d",
@@ -179,6 +230,27 @@ func validateInSwapQuote(invoice string, maxFeeSat uint64, cfg *InSwapConfig,
 	}
 
 	expectedAmountSat := amountSat + cfg.FeeSat
+	switch cfg.SettlementType {
+	case "", SettlementTypeLightning, SettlementTypeInArk:
+	case SettlementTypeCredit:
+		if cfg.Preimage == nil {
+			return fmt.Errorf("credit in-swap config missing " +
+				"preimage")
+		}
+		if cfg.Preimage.Hash() != cfg.PaymentHash {
+			return fmt.Errorf("credit in-swap preimage does not " +
+				"match payment hash")
+		}
+		expectedAmountSat = 0
+
+	case SettlementTypeMixed:
+		if cfg.CreditQuote == nil {
+			return fmt.Errorf("mixed in-swap config missing " +
+				"credit quote")
+		}
+		expectedAmountSat = cfg.CreditQuote.ArkFundingSat
+	}
+
 	if uint64(cfg.AmountSat) != expectedAmountSat {
 		return fmt.Errorf("in-swap amount %d does not equal invoice "+
 			"amount %d plus fee %d", cfg.AmountSat, amountSat,

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -46,6 +46,8 @@ type testInSwapServerConn struct {
 	quoteInvoice        string
 	quoteMaxFeeSat      uint64
 	createCalls         int
+	createAccountKey    []byte
+	createMaxCreditSat  uint64
 	refundAuthorization *InSwapRefundAuthorization
 	refundAuthorizeErr  error
 	refundAuthorizeReq  *testRefundAuthorizeReq
@@ -116,6 +118,19 @@ func (c *testInSwapServerConn) CreateInSwap(context.Context, string, uint64,
 	*btcec.PublicKey) (*InSwapConfig, error) {
 
 	c.createCalls++
+
+	return c.cfg, nil
+}
+
+// CreateInSwapWithCredits returns the preconfigured in-swap config and records
+// the credit account options passed by the client.
+func (c *testInSwapServerConn) CreateInSwapWithCredits(_ context.Context,
+	_ string, _ uint64, _ *btcec.PublicKey, accountKey []byte,
+	maxCreditSat uint64) (*InSwapConfig, error) {
+
+	c.createCalls++
+	c.createAccountKey = append([]byte(nil), accountKey...)
+	c.createMaxCreditSat = maxCreditSat
 
 	return c.cfg, nil
 }
@@ -319,6 +334,34 @@ func TestQuotePayViaLightningReturnsBoundPreview(t *testing.T) {
 	require.Zero(t, serverConn.createCalls)
 }
 
+// TestValidateInSwapPreviewAllowsCreditOnlyZeroAmount verifies credit-only
+// quotes can report zero Ark funding while still binding to the invoice.
+func TestValidateInSwapPreviewAllowsCreditOnlyZeroAmount(t *testing.T) {
+	t.Parallel()
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	quote := &InSwapQuote{
+		PaymentHash:      preimage.Hash(),
+		InvoiceAmountSat: testInSwapInvoiceSat,
+		AmountSat:        0,
+		FeeSat:           0,
+		Expiry:           time.Now().Add(time.Minute),
+		SettlementType:   SettlementTypeCredit,
+		CreditQuote: &CreditQuote{
+			MustUseCredit:    true,
+			CreditAppliedSat: uint64(testInSwapInvoiceSat),
+		},
+	}
+
+	err = validateInSwapPreview(
+		invoice, quote, &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+}
+
 // TestValidateInSwapQuoteRejectsServerMismatches verifies the client treats
 // the swap server response as a quote that must match the caller's invoice.
 func TestValidateInSwapQuoteRejectsServerMismatches(t *testing.T) {
@@ -490,6 +533,62 @@ func TestPaySessionRejectsUnboundInSwapQuote(t *testing.T) {
 	require.Nil(t, session)
 	require.ErrorContains(t, err, "payment hash does not match")
 	require.Zero(t, daemonConn.sendPolicyCalls)
+}
+
+// TestPaySessionCreditOnlyStartCompletesWithoutVHTLC verifies credit-only
+// pays can complete during creation without forcing the Loop FSM through a
+// vHTLC funding state.
+func TestPaySessionCreditOnlyStartCompletesWithoutVHTLC(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+	creditSat := uint64(testInSwapInvoiceSat)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:    preimage.Hash(),
+			AmountSat:      0,
+			FeeSat:         0,
+			SettlementType: SettlementTypeCredit,
+			CreditQuote: &CreditQuote{
+				MustUseCredit:    true,
+				CreditAppliedSat: creditSat,
+			},
+			Preimage: &preimage,
+			Expiry:   time.Now().Add(time.Minute),
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+	}
+
+	client := configureTestPayClient(
+		NewSwapClient(serverConn, daemonConn, nil, nil),
+	)
+
+	session, err := client.StartPayViaLightningWithCredits(
+		t.Context(), invoice, testInSwapFeeSat, creditSat,
+	)
+	require.NoError(t, err)
+	require.Equal(t, PayStateCompleted, session.State())
+	require.Zero(t, daemonConn.sendPolicyCalls)
+	require.Equal(t, 1, serverConn.createCalls)
+	require.Equal(
+		t, clientPriv.PubKey().SerializeCompressed(),
+		serverConn.createAccountKey,
+	)
+	require.Equal(t, creditSat, serverConn.createMaxCreditSat)
+
+	result, err := session.Wait(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, preimage.Hash(), result.PaymentHash)
+	require.Equal(t, preimage, result.Preimage)
 }
 
 // TestPayViaLightningReturnsClaimPreimage asserts the SDK recovers the

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -48,6 +48,13 @@ type testInSwapServerConn struct {
 	createCalls         int
 	createAccountKey    []byte
 	createMaxCreditSat  uint64
+	creditCreateResp    *CreditOperation
+	creditCreateReq     CreateCreditRequest
+	creditCreateCalls   int
+	creditAccountKey    []byte
+	listCreditsResp     *CreditSnapshot
+	listCreditsHook     func(int) *CreditSnapshot
+	listCreditsCalls    int
 	refundAuthorization *InSwapRefundAuthorization
 	refundAuthorizeErr  error
 	refundAuthorizeReq  *testRefundAuthorizeReq

--- a/sdk/swaps/migrations/000003_receive_credit_plan.down.sql
+++ b/sdk/swaps/migrations/000003_receive_credit_plan.down.sql
@@ -1,0 +1,13 @@
+-- Remove durable receive credit-assist planning metadata.
+
+ALTER TABLE receive_swaps
+    DROP COLUMN dust_limit_sat;
+
+ALTER TABLE receive_swaps
+    DROP COLUMN attached_credit_sat;
+
+ALTER TABLE receive_swaps
+    DROP COLUMN available_credit_sat;
+
+ALTER TABLE receive_swaps
+    DROP COLUMN requested_amount_sat;

--- a/sdk/swaps/migrations/000003_receive_credit_plan.up.sql
+++ b/sdk/swaps/migrations/000003_receive_credit_plan.up.sql
@@ -1,0 +1,13 @@
+-- Add durable receive credit-assist planning metadata.
+
+ALTER TABLE receive_swaps
+    ADD COLUMN requested_amount_sat BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE receive_swaps
+    ADD COLUMN available_credit_sat BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE receive_swaps
+    ADD COLUMN attached_credit_sat BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE receive_swaps
+    ADD COLUMN dust_limit_sat BIGINT NOT NULL DEFAULT 0;

--- a/sdk/swaps/migrations/000004_payment_intents.down.sql
+++ b/sdk/swaps/migrations/000004_payment_intents.down.sql
@@ -1,0 +1,5 @@
+-- Remove durable wallet payment orchestration intents.
+
+DROP INDEX IF EXISTS idx_payment_intents_state;
+
+DROP TABLE IF EXISTS payment_intents;

--- a/sdk/swaps/migrations/000004_payment_intents.up.sql
+++ b/sdk/swaps/migrations/000004_payment_intents.up.sql
@@ -1,0 +1,22 @@
+-- Add durable wallet payment orchestration intents.
+
+CREATE TABLE IF NOT EXISTS payment_intents (
+    payment_hash BLOB PRIMARY KEY,
+    invoice TEXT NOT NULL,
+    max_fee_sat BIGINT NOT NULL,
+    max_credit_sat BIGINT NOT NULL,
+    max_credit_topup_sat BIGINT NOT NULL,
+    state TEXT NOT NULL,
+    credit_idempotency_key TEXT NOT NULL,
+    credit_operation_id TEXT NOT NULL DEFAULT '',
+    credit_topup_sat BIGINT NOT NULL DEFAULT 0,
+    credit_destination_pubkey BLOB,
+    credit_oor_session_id TEXT NOT NULL DEFAULT '',
+    pay_started_hash BLOB,
+    last_error TEXT NOT NULL DEFAULT '',
+    created_at_unix BIGINT NOT NULL,
+    updated_at_unix BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_payment_intents_state
+    ON payment_intents(state, updated_at_unix);

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -253,16 +253,21 @@ type ReceiveSession struct {
 	// PaymentHash is the Lightning payment hash for this receive flow.
 	PaymentHash lntypes.Hash
 
-	client         *SwapClient
-	amountSat      btcutil.Amount
-	memo           string
-	payerFeeMsat   uint64
-	state          ReceiveState
-	deadline       time.Time
-	createdAt      time.Time
-	updatedAt      time.Time
-	clientPubKey   *btcec.PublicKey
-	operatorPubKey *btcec.PublicKey
+	client             *SwapClient
+	amountSat          btcutil.Amount
+	memo               string
+	payerFeeMsat       uint64
+	requestedAmountSat uint64
+	availableCreditSat uint64
+	attachedCreditSat  uint64
+	expectedVHTLCSat   uint64
+	dustLimitSat       uint64
+	state              ReceiveState
+	deadline           time.Time
+	createdAt          time.Time
+	updatedAt          time.Time
+	clientPubKey       *btcec.PublicKey
+	operatorPubKey     *btcec.PublicKey
 	// swapServerPubKey is the remote sender in the accepted vHTLC policy.
 	// For Lightning-backed receives this is the swap server key; for
 	// direct same-Ark receives this is the paying client's sender key.
@@ -673,10 +678,36 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 	if quote == nil || quote.RouteHint == nil {
 		return fmt.Errorf("route quote must be provided")
 	}
+	requestedAmountSat := quote.RequestedAmountSat
+	if requestedAmountSat == 0 {
+		requestedAmountSat = uint64(s.amountSat)
+	}
+	if requestedAmountSat != uint64(s.amountSat) {
+		return fmt.Errorf("route quote amount %d does not match "+
+			"requested receive amount %d", requestedAmountSat,
+			s.amountSat)
+	}
+	expectedVHTLCSat := quote.VHTLCAmountSat
+	if expectedVHTLCSat == 0 {
+		expectedVHTLCSat = requestedAmountSat
+	}
+	if quote.AttachedCreditSat > ^uint64(0)-requestedAmountSat {
+		return fmt.Errorf("route quote attached credit overflows " +
+			"vHTLC amount")
+	}
+	if quote.AttachedCreditSat > 0 &&
+		expectedVHTLCSat != requestedAmountSat+quote.AttachedCreditSat {
+		return fmt.Errorf("route quote vHTLC amount %d does not equal "+
+			"requested amount %d plus attached credit %d",
+			expectedVHTLCSat, requestedAmountSat,
+			quote.AttachedCreditSat)
+	}
 
 	s.client.log.InfoS(ctx, "Received route hint from swap server",
 		slog.Uint64("channel_id", quote.RouteHint.ChannelID),
 		slog.Uint64("payer_fee_msat", quote.PayerFeeMsat),
+		slog.Uint64("attached_credit_sat", quote.AttachedCreditSat),
+		slog.Uint64("vhtlc_amount_sat", expectedVHTLCSat),
 	)
 
 	inv, hash, err := s.client.invoiceGen.CreateInvoiceWithKey(
@@ -704,6 +735,12 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 		s.Preimage = preimage
 		s.PaymentHash = hash
 		s.payerFeeMsat = quote.PayerFeeMsat
+		s.requestedAmountSat = requestedAmountSat
+		s.availableCreditSat = quote.AvailableCreditSat
+		s.attachedCreditSat = quote.AttachedCreditSat
+		s.expectedVHTLCSat = expectedVHTLCSat
+		s.dustLimitSat = quote.DustLimitSat
+		s.settlementType = quote.SettlementType
 		s.deadline = s.client.currentTime().Add(expiry)
 		if s.createdAt.IsZero() {
 			s.createdAt = s.client.currentTime()
@@ -945,11 +982,37 @@ func (s *ReceiveSession) acceptOutSwapHtlcEvent(ctx context.Context,
 			nil,
 		)
 	}
-	if event.AmountSat != int64(s.amountSat) {
+	requestedAmountSat := event.RequestedAmountSat
+	if requestedAmountSat == 0 {
+		requestedAmountSat = uint64(s.amountSat)
+	}
+	if requestedAmountSat != uint64(s.amountSat) {
+		return s.failTerminal(
+			ctx, fmt.Sprintf("out-swap HTLC requested amount %d "+
+				"does not match invoice amount %d",
+				requestedAmountSat, s.amountSat),
+			nil,
+			nil,
+		)
+	}
+	if event.AttachedCreditSat != s.attachedCreditSat {
+		return s.failTerminal(
+			ctx, fmt.Sprintf("out-swap HTLC attached credit %d "+
+				"does not match expected credit %d",
+				event.AttachedCreditSat, s.attachedCreditSat),
+			nil,
+			nil,
+		)
+	}
+	expectedVHTLCSat := s.expectedVHTLCSat
+	if expectedVHTLCSat == 0 {
+		expectedVHTLCSat = uint64(s.amountSat)
+	}
+	if event.AmountSat != int64(expectedVHTLCSat) {
 		return s.failTerminal(
 			ctx, fmt.Sprintf("out-swap HTLC amount %d does not "+
-				"match invoice amount %d", event.AmountSat,
-				s.amountSat),
+				"match expected vHTLC amount %d",
+				event.AmountSat, expectedVHTLCSat),
 			nil,
 			nil,
 		)
@@ -997,7 +1060,9 @@ func (s *ReceiveSession) acceptOutSwapHtlcEvent(ctx context.Context,
 
 	return s.mutateAndPersist(ctx, func() error {
 		s.swapServerPubKey = serverKey
-		s.settlementType = SettlementTypeLightning
+		if s.settlementType == "" {
+			s.settlementType = SettlementTypeLightning
+		}
 		s.vhtlcConfig = event.VHTLCConfig
 		s.vhtlcPolicy = policy
 		s.vhtlcPolicyTemplate = policyTemplate
@@ -1051,8 +1116,7 @@ func (s *ReceiveSession) ackAcceptedHTLCEvent(ctx context.Context,
 // acknowledgeOutSwapHTLC records the receiver's durable event acceptance with
 // the swap server before clearing the local pending ACK marker.
 func (s *ReceiveSession) acknowledgeOutSwapHTLC(ctx context.Context) error {
-	if s.settlementType != "" &&
-		s.settlementType != SettlementTypeLightning {
+	if s.settlementType == SettlementTypeInArk {
 		return nil
 	}
 	if s.client == nil || s.client.server == nil {
@@ -1322,10 +1386,16 @@ func (s *ReceiveSession) ensureReceiveFundingStillPossible(
 func (s *ReceiveSession) validateReceiveFunding(ctx context.Context,
 	outpoint string, amount int64) error {
 
-	if amount != int64(s.amountSat) {
+	expectedAmountSat := s.expectedVHTLCSat
+	if expectedAmountSat == 0 {
+		expectedAmountSat = uint64(s.amountSat)
+	}
+
+	if amount != int64(expectedAmountSat) {
 		return s.failTerminal(ctx, fmt.Sprintf("funded "+
 			"vHTLC amount %d does not match "+
-			"invoice amount %d", amount, s.amountSat), nil, func() {
+			"expected vHTLC amount %d", amount,
+			expectedAmountSat), nil, func() {
 			s.vhtlcOutpoint = outpoint
 			s.vhtlcAmount = amount
 		})

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -1454,6 +1454,7 @@ type testDaemonConn struct {
 	preparedOOR       *PreparedOOR
 	prepareOOREErr    error
 	sendPolicyErr     error
+	sendPubKeyErr     error
 	sendCustomErr     error
 	oorSession        *daemonrpc.OORSessionInfo
 	oorSessionErr     error
@@ -1464,11 +1465,14 @@ type testDaemonConn struct {
 	spentLookupBlock  time.Duration
 	spendOnCustom     bool
 	sendPolicyCalls   int
+	sendPubKeyCalls   int
 	sendCustomCalls   int
 	oorSessionCalls   int
 	liveLookupCalls   int
 	spentLookupCalls  int
 	lastSendPolicy    []byte
+	lastSendPubKey    []byte
+	lastSendTopUpKey  string
 	lastClaimPubKey   []byte
 	lastClaimInput    []CustomInput
 	lastOORSessionID  string
@@ -1510,6 +1514,24 @@ func (d *testDaemonConn) SendOORWithPolicyDetails(_ context.Context, _ int64,
 
 	if d.sendPolicyErr != nil {
 		return nil, d.sendPolicyErr
+	}
+
+	return &OORSendResult{
+		SessionID:         d.sendSessionID,
+		RecipientOutpoint: d.sendOutpoint,
+	}, nil
+}
+
+// SendOORToPubKey records a standard pubkey OOR transfer request.
+func (d *testDaemonConn) SendOORToPubKey(_ context.Context,
+	recipientPubKey []byte, _ int64, idempotencyKey string) (
+	*OORSendResult, error) {
+
+	d.sendPubKeyCalls++
+	d.lastSendPubKey = append([]byte(nil), recipientPubKey...)
+	d.lastSendTopUpKey = idempotencyKey
+	if d.sendPubKeyErr != nil {
+		return nil, d.sendPubKeyErr
 	}
 
 	return &OORSendResult{

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -327,6 +327,80 @@ func TestReceiveSessionSkipsServerAckForSameArkHTLCEvent(t *testing.T) {
 	require.Zero(t, session.pendingHTLCAckCursor)
 }
 
+// TestReceiveSessionAcksServerForCreditAssistedOutSwap verifies a
+// credit-assisted receive still follows the server-funded out-swap ACK path.
+func TestReceiveSessionAcksServerForCreditAssistedOutSwap(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage := lntypes.Preimage{0x7, 0x8, 0x9}
+	hash := preimage.Hash()
+	serverConn := &testSwapServerConn{}
+	daemonConn := &testDaemonConn{}
+	client := NewSwapClient(serverConn, daemonConn, nil, nil)
+	useTestOnionDecoder(client, 300)
+
+	cfg := VHTLCConfig{}
+	cfg.RefundLocktime = 144
+	cfg.UnilateralClaimDelay = 12
+	cfg.UnilateralRefundDelay = 24
+	cfg.UnilateralRefundWithoutReceiverDelay = 36
+	cfg.SwapServerPubkey = serverPriv.PubKey().SerializeCompressed()
+
+	ackCalls := 0
+	client.outEvents = &testIncomingEventReceiver{
+		notification: &IncomingVHTLCNotification{
+			OutSwap: &OutSwapHtlcEvent{
+				PaymentHash:        hash,
+				AmountSat:          1_100,
+				RequestedAmountSat: 300,
+				AttachedCreditSat:  800,
+				VHTLCConfig:        cfg,
+			},
+			AckCursor: 24,
+			Ack: func(context.Context) error {
+				ackCalls++
+
+				return nil
+			},
+		},
+	}
+
+	session := &ReceiveSession{
+		client:            client,
+		amountSat:         300,
+		expectedVHTLCSat:  1_100,
+		attachedCreditSat: 800,
+		settlementType:    SettlementTypeMixed,
+		state:             ReceiveStateInvoiceCreated,
+		PaymentHash:       hash,
+		clientPubKey:      clientPriv.PubKey(),
+		operatorPubKey:    operatorPriv.PubKey(),
+	}
+
+	err = session.waitForHTLCEvent(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, session.State())
+	require.Equal(t, 1, ackCalls)
+	require.Equal(t, 1, serverConn.serverAckCalls)
+	require.Equal(t, hash, serverConn.lastServerAckHash)
+	require.True(
+		t,
+		serverConn.lastServerAckPubkey.IsEqual(
+			clientPriv.PubKey(),
+		),
+	)
+	require.Zero(t, session.pendingHTLCAckCursor)
+}
+
 // TestReceiveSessionHandlesOutSwapForfeitSignatureRequest verifies the
 // receive side signs a mailbox forfeit-signature request locally, submits the
 // signature to the swap server, then acknowledges the mailbox event.
@@ -814,6 +888,88 @@ func useMappedOnionDecoder(client *SwapClient,
 
 		return payload, nil
 	}
+}
+
+// TestReceiveSessionAcceptsCreditAssistedOutSwapHTLC verifies the client checks
+// the funded vHTLC against the server's planned invoice amount plus attached
+// credits while the onion payload still commits to the invoice amount.
+func TestReceiveSessionAcceptsCreditAssistedOutSwapHTLC(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage := lntypes.Preimage{0x1, 0x2, 0x3}
+	hash := preimage.Hash()
+	client := &SwapClient{}
+	useTestOnionDecoder(client, 300)
+
+	session := &ReceiveSession{
+		client:            client,
+		amountSat:         300,
+		expectedVHTLCSat:  1_100,
+		attachedCreditSat: 800,
+		settlementType:    SettlementTypeMixed,
+		state:             ReceiveStateInvoiceCreated,
+		PaymentHash:       hash,
+		clientPubKey:      clientPriv.PubKey(),
+		operatorPubKey:    operatorPriv.PubKey(),
+	}
+	cfg := VHTLCConfig{
+		RefundLocktime:                       900,
+		UnilateralClaimDelay:                 5,
+		UnilateralRefundDelay:                6,
+		UnilateralRefundWithoutReceiverDelay: 7,
+		SwapServerPubkey: serverPriv.PubKey().
+			SerializeCompressed(),
+	}
+
+	err = session.acceptOutSwapHtlcEvent(
+		t.Context(), &OutSwapHtlcEvent{
+			PaymentHash:        hash,
+			AmountSat:          1_100,
+			RequestedAmountSat: 300,
+			AttachedCreditSat:  800,
+			VHTLCConfig:        cfg,
+		}, &daemonReceiveAuthKey{}, 0,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, session.State())
+	require.Equal(t, SettlementTypeMixed, session.settlementType)
+}
+
+// TestReceiveSessionRejectsCreditAssistedFundingMismatch verifies a
+// credit-assisted receive cannot be accepted if the event funds only the
+// invoice amount instead of the invoice amount plus attached credits.
+func TestReceiveSessionRejectsCreditAssistedFundingMismatch(t *testing.T) {
+	t.Parallel()
+
+	preimage := lntypes.Preimage{0x4, 0x5, 0x6}
+	session := &ReceiveSession{
+		client:            NewSwapClient(nil, nil, nil, nil),
+		amountSat:         300,
+		expectedVHTLCSat:  1_100,
+		attachedCreditSat: 800,
+		state:             ReceiveStateInvoiceCreated,
+		PaymentHash:       preimage.Hash(),
+	}
+
+	err := session.acceptOutSwapHtlcEvent(
+		t.Context(), &OutSwapHtlcEvent{
+			PaymentHash:        preimage.Hash(),
+			AmountSat:          300,
+			RequestedAmountSat: 300,
+			AttachedCreditSat:  800,
+		}, &daemonReceiveAuthKey{}, 0,
+	)
+	require.ErrorContains(t, err, "expected vHTLC amount 1100")
+	require.Equal(t, ReceiveStateFailed, session.State())
 }
 
 // TestReceiveSessionValidateOnionPayloadAcceptsMPPParts verifies the client
@@ -2938,7 +3094,7 @@ func TestReceiveSessionOverdueInvoiceAcceptsDeliveredEvent(t *testing.T) {
 
 // TestReceiveSessionFailsOnAmountMismatch asserts the client stops with an
 // ordinary terminal failure when the funded vHTLC amount does not match the
-// invoice amount it requested.
+// amount it expected.
 func TestReceiveSessionFailsOnAmountMismatch(t *testing.T) {
 	t.Parallel()
 
@@ -2999,7 +3155,7 @@ func TestReceiveSessionFailsOnAmountMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = session.Wait(t.Context())
-	require.ErrorContains(t, err, "does not match invoice amount")
+	require.ErrorContains(t, err, "does not match expected vHTLC amount")
 
 	resumed, err := client.ResumeReceiveViaLightning(
 		t.Context(), session.PaymentHash,
@@ -3008,7 +3164,7 @@ func TestReceiveSessionFailsOnAmountMismatch(t *testing.T) {
 	require.Equal(t, ReceiveStateFailed, resumed.State())
 	require.Contains(
 		t, resumed.TerminalReason(),
-		"does not match invoice amount",
+		"does not match expected vHTLC amount",
 	)
 	require.Empty(t, resumed.InterventionReason())
 	require.Equal(t, "funding:0", resumed.vhtlcOutpoint)
@@ -3214,11 +3370,11 @@ func TestReceiveSessionClaimFailsOnAmountMismatch(t *testing.T) {
 	acceptTestOutSwapHtlcEvent(t, client, session, cfg)
 
 	_, err = session.Claim(t.Context(), "funding:0", 41_999)
-	require.ErrorContains(t, err, "does not match invoice amount")
+	require.ErrorContains(t, err, "does not match expected vHTLC amount")
 	require.Equal(t, ReceiveStateFailed, session.State())
 	require.Contains(
 		t, session.TerminalReason(),
-		"does not match invoice amount",
+		"does not match expected vHTLC amount",
 	)
 	require.Empty(t, session.InterventionReason())
 	require.Zero(t, daemonConn.sendCustomCalls)

--- a/sdk/swaps/payment_intent.go
+++ b/sdk/swaps/payment_intent.go
@@ -1,0 +1,562 @@
+package swaps
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	swapsqlc "github.com/lightninglabs/darepo-client/sdk/swaps/sqlc"
+	"github.com/lightningnetwork/lnd/lntypes"
+)
+
+// PaymentIntentState identifies the durable wallet-level orchestration state
+// that runs before the pay-swap FSM exists.
+type PaymentIntentState string
+
+const (
+	PaymentIntentAccepted           PaymentIntentState = "Accepted"
+	PaymentIntentCreditTopUpCreated PaymentIntentState = "CreditTopUp" +
+		"Created"
+	PaymentIntentCreditTopUpSent PaymentIntentState = "CreditTopUpSent"
+	PaymentIntentCreditAvailable PaymentIntentState = "CreditAvailable"
+	PaymentIntentPayStarted      PaymentIntentState = "PayStarted"
+	PaymentIntentExpired         PaymentIntentState = "Expired"
+	PaymentIntentFailed          PaymentIntentState = "Failed"
+)
+
+// IsTerminal returns true once no payment-intent worker should resume.
+func (s PaymentIntentState) IsTerminal() bool {
+	return s == PaymentIntentPayStarted ||
+		s == PaymentIntentExpired ||
+		s == PaymentIntentFailed
+}
+
+// PaymentIntentSummary is the restart-resume view for one durable payment
+// orchestration intent.
+type PaymentIntentSummary struct {
+	PaymentHash lntypes.Hash
+	Invoice     string
+	State       PaymentIntentState
+	Pending     bool
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	LastError   string
+}
+
+type paymentIntent struct {
+	client *SwapClient
+
+	paymentHash          lntypes.Hash
+	invoice              string
+	maxFeeSat            uint64
+	maxCreditSat         uint64
+	maxCreditTopUpSat    uint64
+	state                PaymentIntentState
+	creditIdempotencyKey string
+	creditOperationID    string
+	creditTopUpSat       uint64
+	creditDestinationKey []byte
+	creditOORSessionID   string
+	payStartedHash       *lntypes.Hash
+	lastError            string
+	createdAt            time.Time
+	updatedAt            time.Time
+}
+
+// StartPayViaLightningWithCreditTopUp starts or resumes a durable wallet-level
+// payment orchestration flow, funding credits first when the accepted quote
+// requires a bounded Ark top-up.
+func (c *SwapClient) StartPayViaLightningWithCreditTopUp(ctx context.Context,
+	invoice string, maxFeeSat uint64, maxCreditSat uint64,
+	maxCreditTopUpSat uint64) (*PaySession, error) {
+
+	paymentHash, err := c.paymentHashForInvoice(invoice)
+	if err != nil {
+		return nil, err
+	}
+
+	intent, err := c.getPaymentIntent(ctx, paymentHash)
+	switch {
+	case err == nil && !intent.state.IsTerminal():
+		return intent.run(ctx)
+
+	case err == nil && intent.state == PaymentIntentPayStarted:
+		return c.ResumePayViaLightning(ctx, paymentHash)
+
+	case err == nil:
+		return nil, fmt.Errorf("payment intent %x is %s: %s",
+			paymentHash[:], intent.state, intent.lastError)
+
+	case !errors.Is(err, sql.ErrNoRows):
+		return nil, err
+	}
+
+	if maxCreditTopUpSat == 0 {
+		return c.StartPayViaLightningWithCredits(
+			ctx, invoice, maxFeeSat, maxCreditSat,
+		)
+	}
+	if c == nil || c.store == nil || c.store.queries == nil {
+		return nil, fmt.Errorf(
+			"swap store is required for credit top-up " +
+				"payment intent",
+		)
+	}
+
+	intent = &paymentIntent{
+		client:               c,
+		paymentHash:          paymentHash,
+		invoice:              invoice,
+		maxFeeSat:            maxFeeSat,
+		maxCreditSat:         maxCreditSat,
+		maxCreditTopUpSat:    maxCreditTopUpSat,
+		state:                PaymentIntentAccepted,
+		creditIdempotencyKey: creditTopUpID(paymentHash),
+		creditDestinationKey: nil,
+		creditOORSessionID:   "",
+		creditOperationID:    "",
+		creditTopUpSat:       0,
+		payStartedHash:       nil,
+		lastError:            "",
+		createdAt:            c.currentTime(),
+		updatedAt:            c.currentTime(),
+	}
+	if err := intent.persist(ctx); err != nil {
+		return nil, err
+	}
+
+	return intent.run(ctx)
+}
+
+// ResumePaymentIntent reloads and advances one durable payment intent by
+// payment hash.
+func (c *SwapClient) ResumePaymentIntent(ctx context.Context,
+	paymentHash lntypes.Hash) (*PaySession, error) {
+
+	intent, err := c.getPaymentIntent(ctx, paymentHash)
+	if err != nil {
+		return nil, err
+	}
+
+	return intent.run(ctx)
+}
+
+// ListPendingPaymentIntents returns every non-terminal payment intent.
+func (c *SwapClient) ListPendingPaymentIntents(ctx context.Context) (
+	[]PaymentIntentSummary, error) {
+
+	if c == nil || c.store == nil || c.store.queries == nil {
+		return nil, fmt.Errorf("swap store is not configured")
+	}
+
+	rows, err := c.store.queries.ListPendingPaymentIntents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list pending payment intents: %w", err)
+	}
+
+	summaries := make([]PaymentIntentSummary, 0, len(rows))
+	for i := range rows {
+		summary, err := paymentIntentSummaryFromRow(rows[i])
+		if err != nil {
+			return nil, err
+		}
+
+		summaries = append(summaries, summary)
+	}
+
+	return summaries, nil
+}
+
+func (c *SwapClient) paymentHashForInvoice(invoice string) (lntypes.Hash,
+	error) {
+
+	decoded, err := decodePayInvoice(invoice, c.chainParams)
+	if err != nil {
+		return lntypes.Hash{}, err
+	}
+	if decoded.PaymentHash == nil {
+		return lntypes.Hash{}, fmt.Errorf(
+			"invoice payment hash is required",
+		)
+	}
+
+	return lntypes.Hash(*decoded.PaymentHash), nil
+}
+
+func (c *SwapClient) getPaymentIntent(ctx context.Context,
+	paymentHash lntypes.Hash) (*paymentIntent, error) {
+
+	if c == nil || c.store == nil || c.store.queries == nil {
+		return nil, sql.ErrNoRows
+	}
+
+	row, err := c.store.queries.GetPaymentIntent(ctx, paymentHash[:])
+	if err != nil {
+		return nil, err
+	}
+
+	return paymentIntentFromRow(c, row)
+}
+
+func (p *paymentIntent) run(ctx context.Context) (*PaySession, error) {
+	if p == nil || p.client == nil {
+		return nil, fmt.Errorf("payment intent must be provided")
+	}
+
+	if session, ok, err := p.existingPaySession(ctx); ok || err != nil {
+		if err != nil {
+			return nil, err
+		}
+
+		if markErr := p.markPayStarted(ctx); markErr != nil {
+			return nil, markErr
+		}
+
+		return session, nil
+	}
+
+	switch p.state {
+	case PaymentIntentAccepted:
+		if err := p.createTopUpIfNeeded(ctx); err != nil {
+			return nil, err
+		}
+
+	case PaymentIntentCreditTopUpCreated,
+		PaymentIntentCreditTopUpSent,
+		PaymentIntentCreditAvailable:
+
+	default:
+		return nil, fmt.Errorf("payment intent %x is %s: %s",
+			p.paymentHash[:], p.state, p.lastError)
+	}
+
+	if p.creditOperationID != "" &&
+		p.state != PaymentIntentCreditAvailable {
+
+		available, err := p.creditAvailable(ctx)
+		if err != nil {
+			return nil, p.fail(ctx, err)
+		}
+		if !available {
+			if err := p.submitTopUp(ctx); err != nil {
+				return nil, err
+			}
+			if err := p.waitCreditAvailable(ctx); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if err := p.setState(
+		ctx, PaymentIntentCreditAvailable, "",
+	); err != nil {
+		return nil, err
+	}
+
+	session, err := p.client.StartPayViaLightningWithCredits(
+		ctx, p.invoice, p.maxFeeSat, p.maxCreditSat,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	p.payStartedHash = &p.paymentHash
+	if err := p.markPayStarted(ctx); err != nil {
+		return nil, err
+	}
+
+	return session, nil
+}
+
+func (p *paymentIntent) existingPaySession(ctx context.Context) (*PaySession,
+	bool, error) {
+
+	session, err := p.client.ResumePayViaLightning(ctx, p.paymentHash)
+	if err == nil {
+		return session, true, nil
+	}
+	if errors.Is(err, ErrPaySessionNotFound) {
+		return nil, false, nil
+	}
+
+	return nil, false, err
+}
+
+func (p *paymentIntent) createTopUpIfNeeded(ctx context.Context) error {
+	quote, err := p.client.QuotePayViaLightningWithCredits(
+		ctx, p.invoice, p.maxFeeSat, p.maxCreditSat,
+	)
+	if err != nil {
+		return err
+	}
+
+	creditQuote := quote.CreditQuote
+	if creditQuote == nil || creditQuote.CreditShortfallSat == 0 {
+		return p.setState(ctx, PaymentIntentCreditAvailable, "")
+	}
+
+	topupSat := creditQuote.CreditTopupSat
+	if topupSat == 0 {
+		return p.fail(ctx, fmt.Errorf("credit top-up amount missing"))
+	}
+	if topupSat > p.maxCreditTopUpSat {
+		return p.fail(ctx, fmt.Errorf("credit top-up %d exceeds "+
+			"accepted bound %d", topupSat, p.maxCreditTopUpSat))
+	}
+	if topupSat > math.MaxInt64 {
+		return p.fail(
+			ctx, fmt.Errorf("credit top-up exceeds int64 range"),
+		)
+	}
+
+	op, err := p.client.CreateCredit(ctx, CreateCreditRequest{
+		IdempotencyKey: p.creditIdempotencyKey,
+		Source:         CreditFundingArkTopUp,
+		AmountSat:      topupSat,
+	})
+	if err != nil {
+		return err
+	}
+	if op == nil {
+		return p.fail(
+			ctx, fmt.Errorf("credit top-up operation missing"),
+		)
+	}
+
+	p.creditOperationID = op.OperationID
+	p.creditTopUpSat = topupSat
+	p.creditDestinationKey = append(
+		[]byte(nil), op.DestinationKey...,
+	)
+	if op.State == CreditStateCredited {
+		return p.setState(ctx, PaymentIntentCreditAvailable, "")
+	}
+
+	return p.setState(ctx, PaymentIntentCreditTopUpCreated, "")
+}
+
+func (p *paymentIntent) submitTopUp(ctx context.Context) error {
+	if p.creditTopUpSat == 0 {
+		return p.fail(ctx, fmt.Errorf("credit top-up amount missing"))
+	}
+	if len(p.creditDestinationKey) == 0 {
+		return p.fail(
+			ctx, fmt.Errorf("credit top-up destination missing"),
+		)
+	}
+	if p.creditTopUpSat > math.MaxInt64 {
+		return p.fail(
+			ctx, fmt.Errorf("credit top-up exceeds int64 range"),
+		)
+	}
+
+	result, err := p.client.daemon.SendOORToPubKey(
+		ctx, p.creditDestinationKey, int64(p.creditTopUpSat),
+		p.creditIdempotencyKey,
+	)
+	if err != nil {
+		return err
+	}
+
+	if result != nil {
+		p.creditOORSessionID = result.SessionID
+	}
+
+	return p.setState(ctx, PaymentIntentCreditTopUpSent, "")
+}
+
+func (p *paymentIntent) waitCreditAvailable(ctx context.Context) error {
+	for {
+		available, err := p.creditAvailable(ctx)
+		if err != nil {
+			return p.fail(ctx, err)
+		}
+		if available {
+			return p.setState(ctx, PaymentIntentCreditAvailable, "")
+		}
+
+		if err := waitForFixedPoll(
+			ctx, p.client.waitPollInterval,
+		); err != nil {
+			return err
+		}
+	}
+}
+
+func (p *paymentIntent) creditAvailable(ctx context.Context) (bool, error) {
+	snapshot, err := p.client.ListCredits(ctx, ^uint32(0))
+	if err != nil {
+		return false, err
+	}
+	if snapshot == nil {
+		return false, nil
+	}
+
+	for _, op := range snapshot.Operations {
+		if op.OperationID != p.creditOperationID {
+			continue
+		}
+
+		switch op.State {
+		case CreditStateCredited:
+			return snapshot.AvailableSat >= p.maxCreditSat, nil
+
+		case CreditStateFailed, CreditStateExpired, CreditStateReleased:
+			return false, fmt.Errorf("credit top-up %s ended in %s",
+				p.creditOperationID, op.State)
+
+		case CreditStateCreated, CreditStateAwaitingPayment,
+			CreditStateReserved, CreditStatePayingLightning,
+			CreditStateDebited, CreditStateSendingOOR,
+			CreditStateRedeemed:
+
+			return false, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (p *paymentIntent) markPayStarted(ctx context.Context) error {
+	p.payStartedHash = &p.paymentHash
+
+	return p.setState(ctx, PaymentIntentPayStarted, "")
+}
+
+func (p *paymentIntent) fail(ctx context.Context, err error) error {
+	if err == nil {
+		err = fmt.Errorf("payment intent failed")
+	}
+	if setErr := p.setState(
+		ctx, PaymentIntentFailed, err.Error(),
+	); setErr != nil {
+		return setErr
+	}
+
+	return err
+}
+
+func (p *paymentIntent) setState(ctx context.Context, state PaymentIntentState,
+	lastError string) error {
+
+	p.state = state
+	p.lastError = lastError
+
+	return p.persist(ctx)
+}
+
+func (p *paymentIntent) persist(ctx context.Context) error {
+	if p == nil || p.client == nil || p.client.store == nil ||
+		p.client.store.queries == nil {
+		return fmt.Errorf("swap store is not configured")
+	}
+
+	now := p.client.currentTime().Unix()
+	if p.createdAt.IsZero() {
+		p.createdAt = time.Unix(now, 0)
+	}
+
+	var payStartedHash []byte
+	if p.payStartedHash != nil {
+		payStartedHash = append([]byte(nil), p.payStartedHash[:]...)
+	}
+
+	err := p.client.store.queries.UpsertPaymentIntent(
+		ctx, swapsqlc.UpsertPaymentIntentParams{
+			PaymentHash: append([]byte(nil), p.paymentHash[:]...),
+			Invoice:     p.invoice,
+			MaxFeeSat:   int64(p.maxFeeSat),
+			MaxCreditSat: int64(
+				p.maxCreditSat,
+			),
+			MaxCreditTopupSat: int64(p.maxCreditTopUpSat),
+			State:             string(p.state),
+			CreditIdempotencyKey: p.
+				creditIdempotencyKey,
+			CreditOperationID: p.creditOperationID,
+			CreditTopupSat:    int64(p.creditTopUpSat),
+			CreditDestinationPubkey: append(
+				[]byte(nil), p.creditDestinationKey...,
+			),
+			CreditOorSessionID: p.creditOORSessionID,
+			PayStartedHash:     payStartedHash,
+			LastError:          p.lastError,
+			CreatedAtUnix:      p.createdAt.Unix(),
+			UpdatedAtUnix:      now,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("persist payment intent: %w", err)
+	}
+
+	p.updatedAt = time.Unix(now, 0)
+
+	return nil
+}
+
+func paymentIntentFromRow(c *SwapClient,
+	row swapsqlc.PaymentIntent) (*paymentIntent, error) {
+
+	hash, err := hashFromBytes(row.PaymentHash)
+	if err != nil {
+		return nil, err
+	}
+
+	var payStartedHash *lntypes.Hash
+	if len(row.PayStartedHash) != 0 {
+		hash, err := hashFromBytes(row.PayStartedHash)
+		if err != nil {
+			return nil, err
+		}
+		payStartedHash = &hash
+	}
+
+	return &paymentIntent{
+		client:               c,
+		paymentHash:          hash,
+		invoice:              row.Invoice,
+		maxFeeSat:            uint64(row.MaxFeeSat),
+		maxCreditSat:         uint64(row.MaxCreditSat),
+		maxCreditTopUpSat:    uint64(row.MaxCreditTopupSat),
+		state:                PaymentIntentState(row.State),
+		creditIdempotencyKey: row.CreditIdempotencyKey,
+		creditOperationID:    row.CreditOperationID,
+		creditTopUpSat:       uint64(row.CreditTopupSat),
+		creditDestinationKey: cloneBytesOrEmpty(
+			row.CreditDestinationPubkey,
+		),
+		creditOORSessionID: row.CreditOorSessionID,
+		payStartedHash:     payStartedHash,
+		lastError:          row.LastError,
+		createdAt:          time.Unix(row.CreatedAtUnix, 0),
+		updatedAt:          time.Unix(row.UpdatedAtUnix, 0),
+	}, nil
+}
+
+func paymentIntentSummaryFromRow(row swapsqlc.PaymentIntent) (
+	PaymentIntentSummary, error) {
+
+	hash, err := hashFromBytes(row.PaymentHash)
+	if err != nil {
+		return PaymentIntentSummary{}, err
+	}
+
+	state := PaymentIntentState(row.State)
+
+	return PaymentIntentSummary{
+		PaymentHash: hash,
+		Invoice:     row.Invoice,
+		State:       state,
+		Pending:     !state.IsTerminal(),
+		CreatedAt:   time.Unix(row.CreatedAtUnix, 0),
+		UpdatedAt:   time.Unix(row.UpdatedAtUnix, 0),
+		LastError:   row.LastError,
+	}, nil
+}
+
+func creditTopUpID(paymentHash lntypes.Hash) string {
+	return fmt.Sprintf("credit-topup-pay-%x", paymentHash[:])
+}

--- a/sdk/swaps/payment_intent_test.go
+++ b/sdk/swaps/payment_intent_test.go
@@ -1,0 +1,231 @@
+package swaps
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// CreateCredit records one test credit funding request.
+func (c *testInSwapServerConn) CreateCredit(_ context.Context,
+	accountPubKey []byte, req CreateCreditRequest) (*CreditOperation,
+	error) {
+
+	c.creditCreateCalls++
+	c.creditAccountKey = append([]byte(nil), accountPubKey...)
+	c.creditCreateReq = req
+
+	return c.creditCreateResp, nil
+}
+
+// RedeemCredit is unused in payment-intent tests.
+func (c *testInSwapServerConn) RedeemCredit(context.Context, []byte,
+	RedeemCreditRequest) (*CreditRedemption, error) {
+
+	return nil, fmt.Errorf("unexpected redeem credit request")
+}
+
+// ListCredits records one test credit snapshot request.
+func (c *testInSwapServerConn) ListCredits(_ context.Context,
+	_ []byte, _ uint32) (*CreditSnapshot, error) {
+
+	c.listCreditsCalls++
+	if c.listCreditsHook != nil {
+		return c.listCreditsHook(c.listCreditsCalls), nil
+	}
+
+	return c.listCreditsResp, nil
+}
+
+// TestPaymentIntentTopUpCreatesOORBeforePay verifies the durable payment
+// runner creates one credit top-up, sends the server-owned OOR, waits until
+// ListCredits reports the credits, then starts the normal credit-backed pay.
+func TestPaymentIntentTopUpCreatesOORBeforePay(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+	creditSat := uint64(testInSwapInvoiceSat)
+	topUpSat := uint64(1_000)
+
+	serverConn := &testInSwapServerConn{
+		quote: &InSwapQuote{
+			PaymentHash:      preimage.Hash(),
+			InvoiceAmountSat: testInSwapInvoiceSat,
+			AmountSat:        0,
+			FeeSat:           0,
+			Expiry:           time.Now().Add(time.Minute),
+			SettlementType:   SettlementTypeCredit,
+			CreditQuote: &CreditQuote{
+				MustUseCredit:      true,
+				CreditShortfallSat: creditSat,
+				CreditTopupSat:     topUpSat,
+			},
+		},
+		cfg: &InSwapConfig{
+			PaymentHash:    preimage.Hash(),
+			AmountSat:      0,
+			FeeSat:         0,
+			SettlementType: SettlementTypeCredit,
+			CreditQuote: &CreditQuote{
+				MustUseCredit:    true,
+				CreditAppliedSat: creditSat,
+			},
+			Preimage: &preimage,
+			Expiry:   time.Now().Add(time.Minute),
+		},
+		creditCreateResp: &CreditOperation{
+			OperationID:    "cr_topup",
+			State:          CreditStateAwaitingPayment,
+			AmountSat:      topUpSat,
+			DestinationKey: []byte{9, 9, 9},
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey:   clientPriv.PubKey(),
+		sendSessionID: "oor-topup",
+	}
+	serverConn.listCreditsHook = func(_ int) *CreditSnapshot {
+		opState := CreditStateAwaitingPayment
+		availableSat := uint64(0)
+		if daemonConn.sendPubKeyCalls > 0 {
+			opState = CreditStateCredited
+			availableSat = creditSat
+		}
+
+		return &CreditSnapshot{
+			AvailableSat: availableSat,
+			Operations: []CreditOperation{{
+				OperationID: "cr_topup",
+				State:       opState,
+				AmountSat:   topUpSat,
+			}},
+		}
+	}
+
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+
+	session, err := client.StartPayViaLightningWithCreditTopUp(
+		ctx, invoice, testInSwapFeeSat, creditSat, topUpSat,
+	)
+	require.NoError(t, err)
+	require.Equal(t, PayStateCompleted, session.State())
+
+	paymentHash := preimage.Hash()
+	require.Equal(t, 1, serverConn.creditCreateCalls)
+	require.Equal(
+		t, clientPriv.PubKey().SerializeCompressed(),
+		serverConn.creditAccountKey,
+	)
+	require.Equal(t, topUpSat, serverConn.creditCreateReq.AmountSat)
+	require.Equal(
+		t, creditTopUpID(paymentHash),
+		serverConn.creditCreateReq.IdempotencyKey,
+	)
+	require.Equal(t, 1, daemonConn.sendPubKeyCalls)
+	require.Equal(t, []byte{9, 9, 9}, daemonConn.lastSendPubKey)
+	require.Equal(
+		t, creditTopUpID(paymentHash), daemonConn.lastSendTopUpKey,
+	)
+	require.Equal(t, 1, serverConn.createCalls)
+	require.Equal(t, creditSat, serverConn.createMaxCreditSat)
+
+	intents, err := client.ListPendingPaymentIntents(ctx)
+	require.NoError(t, err)
+	require.Empty(t, intents)
+}
+
+// TestPaymentIntentResumeSkipsOORWhenCreditAlreadyAvailable verifies a restart
+// after creating the top-up operation reconciles ListCredits before submitting
+// another OOR. If the server already credited the operation, the runner starts
+// the pay FSM without gifting a second top-up.
+func TestPaymentIntentResumeSkipsOORWhenCreditAlreadyAvailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+	paymentHash := preimage.Hash()
+	creditSat := uint64(testInSwapInvoiceSat)
+	topUpSat := uint64(1_000)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:    paymentHash,
+			AmountSat:      0,
+			FeeSat:         0,
+			SettlementType: SettlementTypeCredit,
+			CreditQuote: &CreditQuote{
+				MustUseCredit:    true,
+				CreditAppliedSat: creditSat,
+			},
+			Preimage: &preimage,
+			Expiry:   time.Now().Add(time.Minute),
+		},
+		listCreditsResp: &CreditSnapshot{
+			AvailableSat: creditSat,
+			Operations: []CreditOperation{{
+				OperationID: "cr_topup",
+				State:       CreditStateCredited,
+				AmountSat:   topUpSat,
+			}},
+		},
+	}
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+	}
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+
+	intent := &paymentIntent{
+		client:               client,
+		paymentHash:          paymentHash,
+		invoice:              invoice,
+		maxFeeSat:            testInSwapFeeSat,
+		maxCreditSat:         creditSat,
+		maxCreditTopUpSat:    topUpSat,
+		state:                PaymentIntentCreditTopUpCreated,
+		creditIdempotencyKey: creditTopUpID(paymentHash),
+		creditOperationID:    "cr_topup",
+		creditTopUpSat:       topUpSat,
+		creditDestinationKey: []byte{9, 9, 9},
+		creditOORSessionID:   "",
+		createdAt:            time.Now(),
+		updatedAt:            time.Now(),
+	}
+	require.NoError(t, intent.persist(ctx))
+
+	session, err := client.ResumePaymentIntent(ctx, paymentHash)
+	require.NoError(t, err)
+	require.Equal(t, PayStateCompleted, session.State())
+	require.Zero(t, daemonConn.sendPubKeyCalls)
+	require.Zero(t, serverConn.creditCreateCalls)
+	require.Equal(t, 1, serverConn.listCreditsCalls)
+	require.Equal(t, 1, serverConn.createCalls)
+	require.Equal(t, creditSat, serverConn.createMaxCreditSat)
+}

--- a/sdk/swaps/queries/swaps.sql
+++ b/sdk/swaps/queries/swaps.sql
@@ -23,14 +23,19 @@ INSERT INTO receive_swaps (
     pending_htlc_ack_cursor,
     claim_receive_pubkey,
     claim_receive_pkscript,
-    claim_session_id,
-    claim_recovery_id,
-    intervention_reason,
-    created_at_unix,
-    updated_at_unix
+	claim_session_id,
+	claim_recovery_id,
+	intervention_reason,
+	requested_amount_sat,
+	available_credit_sat,
+	attached_credit_sat,
+	dust_limit_sat,
+	created_at_unix,
+	updated_at_unix
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
-    $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28
+	$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+	$16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28,
+	$29, $30, $31, $32
 )
 ON CONFLICT (payment_hash) DO UPDATE SET
     amount_sat = EXCLUDED.amount_sat,
@@ -56,10 +61,14 @@ ON CONFLICT (payment_hash) DO UPDATE SET
     pending_htlc_ack_cursor = EXCLUDED.pending_htlc_ack_cursor,
     claim_receive_pubkey = EXCLUDED.claim_receive_pubkey,
     claim_receive_pkscript = EXCLUDED.claim_receive_pkscript,
-    claim_session_id = EXCLUDED.claim_session_id,
-    claim_recovery_id = EXCLUDED.claim_recovery_id,
-    intervention_reason = EXCLUDED.intervention_reason,
-    updated_at_unix = EXCLUDED.updated_at_unix;
+	claim_session_id = EXCLUDED.claim_session_id,
+	claim_recovery_id = EXCLUDED.claim_recovery_id,
+	intervention_reason = EXCLUDED.intervention_reason,
+	requested_amount_sat = EXCLUDED.requested_amount_sat,
+	available_credit_sat = EXCLUDED.available_credit_sat,
+	attached_credit_sat = EXCLUDED.attached_credit_sat,
+	dust_limit_sat = EXCLUDED.dust_limit_sat,
+	updated_at_unix = EXCLUDED.updated_at_unix;
 
 -- name: GetReceiveSwap :one
 SELECT * FROM receive_swaps

--- a/sdk/swaps/queries/swaps.sql
+++ b/sdk/swaps/queries/swaps.sql
@@ -162,3 +162,48 @@ WHERE state NOT IN (
     'Completed', 'Expired', 'Refunded', 'NeedsIntervention', 'Failed'
 )
 ORDER BY created_at_unix ASC;
+
+-- name: UpsertPaymentIntent :exec
+INSERT INTO payment_intents (
+    payment_hash,
+    invoice,
+    max_fee_sat,
+    max_credit_sat,
+    max_credit_topup_sat,
+    state,
+    credit_idempotency_key,
+    credit_operation_id,
+    credit_topup_sat,
+    credit_destination_pubkey,
+    credit_oor_session_id,
+    pay_started_hash,
+    last_error,
+    created_at_unix,
+    updated_at_unix
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+)
+ON CONFLICT (payment_hash) DO UPDATE SET
+    invoice = EXCLUDED.invoice,
+    max_fee_sat = EXCLUDED.max_fee_sat,
+    max_credit_sat = EXCLUDED.max_credit_sat,
+    max_credit_topup_sat = EXCLUDED.max_credit_topup_sat,
+    state = EXCLUDED.state,
+    credit_idempotency_key = EXCLUDED.credit_idempotency_key,
+    credit_operation_id = EXCLUDED.credit_operation_id,
+    credit_topup_sat = EXCLUDED.credit_topup_sat,
+    credit_destination_pubkey = EXCLUDED.credit_destination_pubkey,
+    credit_oor_session_id = EXCLUDED.credit_oor_session_id,
+    pay_started_hash = EXCLUDED.pay_started_hash,
+    last_error = EXCLUDED.last_error,
+    updated_at_unix = EXCLUDED.updated_at_unix;
+
+-- name: GetPaymentIntent :one
+SELECT * FROM payment_intents
+WHERE payment_hash = $1
+LIMIT 1;
+
+-- name: ListPendingPaymentIntents :many
+SELECT * FROM payment_intents
+WHERE state NOT IN ('PayStarted', 'Expired', 'Failed')
+ORDER BY created_at_unix ASC;

--- a/sdk/swaps/sqlc/models.go
+++ b/sdk/swaps/sqlc/models.go
@@ -64,4 +64,8 @@ type ReceiveSwap struct {
 	CreatedAtUnix                        int64
 	UpdatedAtUnix                        int64
 	SettlementType                       string
+	RequestedAmountSat                   int64
+	AvailableCreditSat                   int64
+	AttachedCreditSat                    int64
+	DustLimitSat                         int64
 }

--- a/sdk/swaps/sqlc/models.go
+++ b/sdk/swaps/sqlc/models.go
@@ -35,6 +35,24 @@ type PaySwap struct {
 	SettlementType                       string
 }
 
+type PaymentIntent struct {
+	PaymentHash             []byte
+	Invoice                 string
+	MaxFeeSat               int64
+	MaxCreditSat            int64
+	MaxCreditTopupSat       int64
+	State                   string
+	CreditIdempotencyKey    string
+	CreditOperationID       string
+	CreditTopupSat          int64
+	CreditDestinationPubkey []byte
+	CreditOorSessionID      string
+	PayStartedHash          []byte
+	LastError               string
+	CreatedAtUnix           int64
+	UpdatedAtUnix           int64
+}
+
 type ReceiveSwap struct {
 	PaymentHash                          []byte
 	AmountSat                            int64

--- a/sdk/swaps/sqlc/querier.go
+++ b/sdk/swaps/sqlc/querier.go
@@ -10,12 +10,15 @@ import (
 
 type Querier interface {
 	GetPaySwap(ctx context.Context, paymentHash []byte) (PaySwap, error)
+	GetPaymentIntent(ctx context.Context, paymentHash []byte) (PaymentIntent, error)
 	GetReceiveSwap(ctx context.Context, paymentHash []byte) (ReceiveSwap, error)
 	ListPaySwaps(ctx context.Context) ([]PaySwap, error)
 	ListPendingPaySwaps(ctx context.Context) ([]PaySwap, error)
+	ListPendingPaymentIntents(ctx context.Context) ([]PaymentIntent, error)
 	ListPendingReceiveSwaps(ctx context.Context) ([]ReceiveSwap, error)
 	ListReceiveSwaps(ctx context.Context) ([]ReceiveSwap, error)
 	UpsertPaySwap(ctx context.Context, arg UpsertPaySwapParams) error
+	UpsertPaymentIntent(ctx context.Context, arg UpsertPaymentIntentParams) error
 	UpsertReceiveSwap(ctx context.Context, arg UpsertReceiveSwapParams) error
 }
 

--- a/sdk/swaps/sqlc/swaps.sql.go
+++ b/sdk/swaps/sqlc/swaps.sql.go
@@ -52,7 +52,7 @@ func (q *Queries) GetPaySwap(ctx context.Context, paymentHash []byte) (PaySwap, 
 }
 
 const GetReceiveSwap = `-- name: GetReceiveSwap :one
-SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, claim_recovery_id, intervention_reason, created_at_unix, updated_at_unix, settlement_type FROM receive_swaps
+SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, claim_recovery_id, intervention_reason, created_at_unix, updated_at_unix, settlement_type, requested_amount_sat, available_credit_sat, attached_credit_sat, dust_limit_sat FROM receive_swaps
 WHERE payment_hash = $1
 LIMIT 1
 `
@@ -89,6 +89,10 @@ func (q *Queries) GetReceiveSwap(ctx context.Context, paymentHash []byte) (Recei
 		&i.CreatedAtUnix,
 		&i.UpdatedAtUnix,
 		&i.SettlementType,
+		&i.RequestedAmountSat,
+		&i.AvailableCreditSat,
+		&i.AttachedCreditSat,
+		&i.DustLimitSat,
 	)
 	return i, err
 }
@@ -211,7 +215,7 @@ func (q *Queries) ListPendingPaySwaps(ctx context.Context) ([]PaySwap, error) {
 }
 
 const ListPendingReceiveSwaps = `-- name: ListPendingReceiveSwaps :many
-SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, claim_recovery_id, intervention_reason, created_at_unix, updated_at_unix, settlement_type FROM receive_swaps
+SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, claim_recovery_id, intervention_reason, created_at_unix, updated_at_unix, settlement_type, requested_amount_sat, available_credit_sat, attached_credit_sat, dust_limit_sat FROM receive_swaps
 WHERE state NOT IN ('Completed', 'Expired', 'NeedsIntervention', 'Failed')
 ORDER BY created_at_unix ASC
 `
@@ -254,6 +258,10 @@ func (q *Queries) ListPendingReceiveSwaps(ctx context.Context) ([]ReceiveSwap, e
 			&i.CreatedAtUnix,
 			&i.UpdatedAtUnix,
 			&i.SettlementType,
+			&i.RequestedAmountSat,
+			&i.AvailableCreditSat,
+			&i.AttachedCreditSat,
+			&i.DustLimitSat,
 		); err != nil {
 			return nil, err
 		}
@@ -269,7 +277,7 @@ func (q *Queries) ListPendingReceiveSwaps(ctx context.Context) ([]ReceiveSwap, e
 }
 
 const ListReceiveSwaps = `-- name: ListReceiveSwaps :many
-SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, claim_recovery_id, intervention_reason, created_at_unix, updated_at_unix, settlement_type FROM receive_swaps
+SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, claim_recovery_id, intervention_reason, created_at_unix, updated_at_unix, settlement_type, requested_amount_sat, available_credit_sat, attached_credit_sat, dust_limit_sat FROM receive_swaps
 ORDER BY created_at_unix ASC
 `
 
@@ -311,6 +319,10 @@ func (q *Queries) ListReceiveSwaps(ctx context.Context) ([]ReceiveSwap, error) {
 			&i.CreatedAtUnix,
 			&i.UpdatedAtUnix,
 			&i.SettlementType,
+			&i.RequestedAmountSat,
+			&i.AvailableCreditSat,
+			&i.AttachedCreditSat,
+			&i.DustLimitSat,
 		); err != nil {
 			return nil, err
 		}
@@ -479,14 +491,19 @@ INSERT INTO receive_swaps (
     pending_htlc_ack_cursor,
     claim_receive_pubkey,
     claim_receive_pkscript,
-    claim_session_id,
-    claim_recovery_id,
-    intervention_reason,
-    created_at_unix,
-    updated_at_unix
+	claim_session_id,
+	claim_recovery_id,
+	intervention_reason,
+	requested_amount_sat,
+	available_credit_sat,
+	attached_credit_sat,
+	dust_limit_sat,
+	created_at_unix,
+	updated_at_unix
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
-    $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28
+	$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+	$16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28,
+	$29, $30, $31, $32
 )
 ON CONFLICT (payment_hash) DO UPDATE SET
     amount_sat = EXCLUDED.amount_sat,
@@ -512,10 +529,14 @@ ON CONFLICT (payment_hash) DO UPDATE SET
     pending_htlc_ack_cursor = EXCLUDED.pending_htlc_ack_cursor,
     claim_receive_pubkey = EXCLUDED.claim_receive_pubkey,
     claim_receive_pkscript = EXCLUDED.claim_receive_pkscript,
-    claim_session_id = EXCLUDED.claim_session_id,
-    claim_recovery_id = EXCLUDED.claim_recovery_id,
-    intervention_reason = EXCLUDED.intervention_reason,
-    updated_at_unix = EXCLUDED.updated_at_unix
+	claim_session_id = EXCLUDED.claim_session_id,
+	claim_recovery_id = EXCLUDED.claim_recovery_id,
+	intervention_reason = EXCLUDED.intervention_reason,
+	requested_amount_sat = EXCLUDED.requested_amount_sat,
+	available_credit_sat = EXCLUDED.available_credit_sat,
+	attached_credit_sat = EXCLUDED.attached_credit_sat,
+	dust_limit_sat = EXCLUDED.dust_limit_sat,
+	updated_at_unix = EXCLUDED.updated_at_unix
 `
 
 type UpsertReceiveSwapParams struct {
@@ -545,6 +566,10 @@ type UpsertReceiveSwapParams struct {
 	ClaimSessionID                       string
 	ClaimRecoveryID                      string
 	InterventionReason                   string
+	RequestedAmountSat                   int64
+	AvailableCreditSat                   int64
+	AttachedCreditSat                    int64
+	DustLimitSat                         int64
 	CreatedAtUnix                        int64
 	UpdatedAtUnix                        int64
 }
@@ -577,6 +602,10 @@ func (q *Queries) UpsertReceiveSwap(ctx context.Context, arg UpsertReceiveSwapPa
 		arg.ClaimSessionID,
 		arg.ClaimRecoveryID,
 		arg.InterventionReason,
+		arg.RequestedAmountSat,
+		arg.AvailableCreditSat,
+		arg.AttachedCreditSat,
+		arg.DustLimitSat,
 		arg.CreatedAtUnix,
 		arg.UpdatedAtUnix,
 	)

--- a/sdk/swaps/sqlc/swaps.sql.go
+++ b/sdk/swaps/sqlc/swaps.sql.go
@@ -51,6 +51,35 @@ func (q *Queries) GetPaySwap(ctx context.Context, paymentHash []byte) (PaySwap, 
 	return i, err
 }
 
+const GetPaymentIntent = `-- name: GetPaymentIntent :one
+SELECT payment_hash, invoice, max_fee_sat, max_credit_sat, max_credit_topup_sat, state, credit_idempotency_key, credit_operation_id, credit_topup_sat, credit_destination_pubkey, credit_oor_session_id, pay_started_hash, last_error, created_at_unix, updated_at_unix FROM payment_intents
+WHERE payment_hash = $1
+LIMIT 1
+`
+
+func (q *Queries) GetPaymentIntent(ctx context.Context, paymentHash []byte) (PaymentIntent, error) {
+	row := q.db.QueryRowContext(ctx, GetPaymentIntent, paymentHash)
+	var i PaymentIntent
+	err := row.Scan(
+		&i.PaymentHash,
+		&i.Invoice,
+		&i.MaxFeeSat,
+		&i.MaxCreditSat,
+		&i.MaxCreditTopupSat,
+		&i.State,
+		&i.CreditIdempotencyKey,
+		&i.CreditOperationID,
+		&i.CreditTopupSat,
+		&i.CreditDestinationPubkey,
+		&i.CreditOorSessionID,
+		&i.PayStartedHash,
+		&i.LastError,
+		&i.CreatedAtUnix,
+		&i.UpdatedAtUnix,
+	)
+	return i, err
+}
+
 const GetReceiveSwap = `-- name: GetReceiveSwap :one
 SELECT payment_hash, amount_sat, payer_fee_msat, state, invoice, preimage, deadline_unix, client_pubkey, payment_addr, operator_pubkey, swap_server_pubkey, refund_locktime, unilateral_claim_delay, unilateral_refund_delay, unilateral_refund_without_receiver_delay, vhtlc_pkscript, vhtlc_policy_template, vhtlc_outpoint, vhtlc_amount, pending_htlc_ack_cursor, claim_receive_pubkey, claim_receive_pkscript, claim_session_id, claim_recovery_id, intervention_reason, created_at_unix, updated_at_unix, settlement_type, requested_amount_sat, available_credit_sat, attached_credit_sat, dust_limit_sat FROM receive_swaps
 WHERE payment_hash = $1
@@ -200,6 +229,51 @@ func (q *Queries) ListPendingPaySwaps(ctx context.Context) ([]PaySwap, error) {
 			&i.CreatedAtUnix,
 			&i.UpdatedAtUnix,
 			&i.SettlementType,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListPendingPaymentIntents = `-- name: ListPendingPaymentIntents :many
+SELECT payment_hash, invoice, max_fee_sat, max_credit_sat, max_credit_topup_sat, state, credit_idempotency_key, credit_operation_id, credit_topup_sat, credit_destination_pubkey, credit_oor_session_id, pay_started_hash, last_error, created_at_unix, updated_at_unix FROM payment_intents
+WHERE state NOT IN ('PayStarted', 'Expired', 'Failed')
+ORDER BY created_at_unix ASC
+`
+
+func (q *Queries) ListPendingPaymentIntents(ctx context.Context) ([]PaymentIntent, error) {
+	rows, err := q.db.QueryContext(ctx, ListPendingPaymentIntents)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []PaymentIntent
+	for rows.Next() {
+		var i PaymentIntent
+		if err := rows.Scan(
+			&i.PaymentHash,
+			&i.Invoice,
+			&i.MaxFeeSat,
+			&i.MaxCreditSat,
+			&i.MaxCreditTopupSat,
+			&i.State,
+			&i.CreditIdempotencyKey,
+			&i.CreditOperationID,
+			&i.CreditTopupSat,
+			&i.CreditDestinationPubkey,
+			&i.CreditOorSessionID,
+			&i.PayStartedHash,
+			&i.LastError,
+			&i.CreatedAtUnix,
+			&i.UpdatedAtUnix,
 		); err != nil {
 			return nil, err
 		}
@@ -460,6 +534,81 @@ func (q *Queries) UpsertPaySwap(ctx context.Context, arg UpsertPaySwapParams) er
 		arg.RefundRecoveryID,
 		arg.Preimage,
 		arg.InterventionReason,
+		arg.CreatedAtUnix,
+		arg.UpdatedAtUnix,
+	)
+	return err
+}
+
+const UpsertPaymentIntent = `-- name: UpsertPaymentIntent :exec
+INSERT INTO payment_intents (
+    payment_hash,
+    invoice,
+    max_fee_sat,
+    max_credit_sat,
+    max_credit_topup_sat,
+    state,
+    credit_idempotency_key,
+    credit_operation_id,
+    credit_topup_sat,
+    credit_destination_pubkey,
+    credit_oor_session_id,
+    pay_started_hash,
+    last_error,
+    created_at_unix,
+    updated_at_unix
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+)
+ON CONFLICT (payment_hash) DO UPDATE SET
+    invoice = EXCLUDED.invoice,
+    max_fee_sat = EXCLUDED.max_fee_sat,
+    max_credit_sat = EXCLUDED.max_credit_sat,
+    max_credit_topup_sat = EXCLUDED.max_credit_topup_sat,
+    state = EXCLUDED.state,
+    credit_idempotency_key = EXCLUDED.credit_idempotency_key,
+    credit_operation_id = EXCLUDED.credit_operation_id,
+    credit_topup_sat = EXCLUDED.credit_topup_sat,
+    credit_destination_pubkey = EXCLUDED.credit_destination_pubkey,
+    credit_oor_session_id = EXCLUDED.credit_oor_session_id,
+    pay_started_hash = EXCLUDED.pay_started_hash,
+    last_error = EXCLUDED.last_error,
+    updated_at_unix = EXCLUDED.updated_at_unix
+`
+
+type UpsertPaymentIntentParams struct {
+	PaymentHash             []byte
+	Invoice                 string
+	MaxFeeSat               int64
+	MaxCreditSat            int64
+	MaxCreditTopupSat       int64
+	State                   string
+	CreditIdempotencyKey    string
+	CreditOperationID       string
+	CreditTopupSat          int64
+	CreditDestinationPubkey []byte
+	CreditOorSessionID      string
+	PayStartedHash          []byte
+	LastError               string
+	CreatedAtUnix           int64
+	UpdatedAtUnix           int64
+}
+
+func (q *Queries) UpsertPaymentIntent(ctx context.Context, arg UpsertPaymentIntentParams) error {
+	_, err := q.db.ExecContext(ctx, UpsertPaymentIntent,
+		arg.PaymentHash,
+		arg.Invoice,
+		arg.MaxFeeSat,
+		arg.MaxCreditSat,
+		arg.MaxCreditTopupSat,
+		arg.State,
+		arg.CreditIdempotencyKey,
+		arg.CreditOperationID,
+		arg.CreditTopupSat,
+		arg.CreditDestinationPubkey,
+		arg.CreditOorSessionID,
+		arg.PayStartedHash,
+		arg.LastError,
 		arg.CreatedAtUnix,
 		arg.UpdatedAtUnix,
 	)

--- a/sdk/swaps/store.go
+++ b/sdk/swaps/store.go
@@ -48,7 +48,7 @@ const (
 	defaultConnMaxLifetime = 10 * time.Minute
 
 	// LatestMigrationVersion is the latest swap-client schema migration.
-	LatestMigrationVersion uint = 2
+	LatestMigrationVersion uint = 3
 )
 
 //go:embed migrations/*.sql

--- a/sdk/swaps/store.go
+++ b/sdk/swaps/store.go
@@ -48,7 +48,7 @@ const (
 	defaultConnMaxLifetime = 10 * time.Minute
 
 	// LatestMigrationVersion is the latest swap-client schema migration.
-	LatestMigrationVersion uint = 3
+	LatestMigrationVersion uint = 4
 )
 
 //go:embed migrations/*.sql

--- a/sdk/swaps/store_sessions.go
+++ b/sdk/swaps/store_sessions.go
@@ -50,7 +50,7 @@ func (c *SwapClient) ResumePayViaLightning(ctx context.Context,
 	row, err := c.store.queries.GetPaySwap(ctx, paymentHash[:])
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("pay session not found")
+			return nil, ErrPaySessionNotFound
 		}
 
 		return nil, fmt.Errorf("load pay session: %w", err)

--- a/sdk/swaps/store_sessions.go
+++ b/sdk/swaps/store_sessions.go
@@ -350,24 +350,33 @@ func receiveSummaryFromRow(row swapsqlc.ReceiveSwap) (SwapSummary, error) {
 		return SwapSummary{}, err
 	}
 
+	requestedAmountSat := uint64(row.RequestedAmountSat)
+	if requestedAmountSat == 0 {
+		requestedAmountSat = uint64(row.AmountSat)
+	}
+
 	return SwapSummary{
-		Direction:      SwapDirectionReceive,
-		PaymentHash:    paymentHash,
-		Invoice:        row.Invoice,
-		State:          state.String(),
-		Pending:        !state.IsTerminal(),
-		AmountSat:      row.AmountSat,
-		PayerFeeMsat:   uint64(row.PayerFeeMsat),
-		VHTLCOutpoint:  row.VhtlcOutpoint,
-		VHTLCAmountSat: row.VhtlcAmount,
-		ClaimSessionID: row.ClaimSessionID,
-		SettlementType: SettlementType(row.SettlementType),
-		SenderPubkey:   senderPubKey,
-		TerminalReason: row.InterventionReason,
-		CreatedAt:      time.Unix(row.CreatedAtUnix, 0),
-		UpdatedAt:      time.Unix(row.UpdatedAtUnix, 0),
-		Deadline:       time.Unix(row.DeadlineUnix, 0),
-		RefundLocktime: uint32(row.RefundLocktime),
+		Direction:          SwapDirectionReceive,
+		PaymentHash:        paymentHash,
+		Invoice:            row.Invoice,
+		State:              state.String(),
+		Pending:            !state.IsTerminal(),
+		AmountSat:          row.AmountSat,
+		PayerFeeMsat:       uint64(row.PayerFeeMsat),
+		VHTLCOutpoint:      row.VhtlcOutpoint,
+		VHTLCAmountSat:     row.VhtlcAmount,
+		ClaimSessionID:     row.ClaimSessionID,
+		SettlementType:     SettlementType(row.SettlementType),
+		RequestedAmountSat: requestedAmountSat,
+		AvailableCreditSat: uint64(row.AvailableCreditSat),
+		AttachedCreditSat:  uint64(row.AttachedCreditSat),
+		DustLimitSat:       uint64(row.DustLimitSat),
+		SenderPubkey:       senderPubKey,
+		TerminalReason:     row.InterventionReason,
+		CreatedAt:          time.Unix(row.CreatedAtUnix, 0),
+		UpdatedAt:          time.Unix(row.UpdatedAtUnix, 0),
+		Deadline:           time.Unix(row.DeadlineUnix, 0),
+		RefundLocktime:     uint32(row.RefundLocktime),
 	}, nil
 }
 
@@ -488,6 +497,10 @@ func (s *ReceiveSession) persist(ctx context.Context) error {
 		ClaimSessionID:       s.claimSessionID,
 		ClaimRecoveryID:      s.claimRecoveryID,
 		InterventionReason:   s.interventionReason,
+		RequestedAmountSat:   int64(s.requestedAmountSat),
+		AvailableCreditSat:   int64(s.availableCreditSat),
+		AttachedCreditSat:    int64(s.attachedCreditSat),
+		DustLimitSat:         int64(s.dustLimitSat),
 		CreatedAtUnix:        s.createdAt.Unix(),
 		UpdatedAtUnix:        now,
 	}
@@ -644,24 +657,18 @@ func (s *paySession) persist(ctx context.Context) error {
 		UnilateralRefundWithoutReceiverDelay: int64(
 			s.cfg.VHTLCConfig.UnilateralRefundWithoutReceiverDelay,
 		),
-		VhtlcPkscript: append([]byte(nil), s.vhtlcPkScript...),
-		VhtlcPolicyTemplate: append(
-			[]byte(nil), s.vhtlcPolicyTemplate...,
-		),
-		VhtlcOutpoint:    s.vhtlcOutpoint,
-		VhtlcAmount:      s.vhtlcAmount,
-		FundingSessionID: s.fundingSessionID,
-		RefundReceivePubkey: append(
-			[]byte(nil), s.refundReceivePubKey...,
-		),
-		RefundReceivePkscript: append(
-			[]byte(nil), s.refundReceiveScript...,
-		),
-		RefundSessionID:    s.refundSessionID,
-		RefundRecoveryID:   s.refundRecoveryID,
-		InterventionReason: s.interventionReason,
-		CreatedAtUnix:      s.createdAt.Unix(),
-		UpdatedAtUnix:      now,
+		VhtlcPkscript:         cloneBytesOrEmpty(s.vhtlcPkScript),
+		VhtlcPolicyTemplate:   cloneBytesOrEmpty(s.vhtlcPolicyTemplate),
+		VhtlcOutpoint:         s.vhtlcOutpoint,
+		VhtlcAmount:           s.vhtlcAmount,
+		FundingSessionID:      s.fundingSessionID,
+		RefundReceivePubkey:   cloneBytesOrEmpty(s.refundReceivePubKey),
+		RefundReceivePkscript: cloneBytesOrEmpty(s.refundReceiveScript),
+		RefundSessionID:       s.refundSessionID,
+		RefundRecoveryID:      s.refundRecoveryID,
+		InterventionReason:    s.interventionReason,
+		CreatedAtUnix:         s.createdAt.Unix(),
+		UpdatedAtUnix:         now,
 	}
 	if s.preimage != nil {
 		params.Preimage = append([]byte(nil), s.preimage[:]...)
@@ -777,6 +784,13 @@ func receiveSessionFromRow(c *SwapClient,
 		vhtlcPkScript: append([]byte(nil), row.VhtlcPkscript...),
 		vhtlcOutpoint: row.VhtlcOutpoint,
 		vhtlcAmount:   row.VhtlcAmount,
+		requestedAmountSat: uint64(
+			row.RequestedAmountSat,
+		),
+		availableCreditSat: uint64(row.AvailableCreditSat),
+		attachedCreditSat:  uint64(row.AttachedCreditSat),
+		expectedVHTLCSat:   receiveExpectedVHTLCSat(row),
+		dustLimitSat:       uint64(row.DustLimitSat),
 		pendingHTLCAckCursor: uint64(
 			row.PendingHtlcAckCursor,
 		),
@@ -797,6 +811,15 @@ func receiveSessionFromRow(c *SwapClient,
 		createdAt:          time.Unix(row.CreatedAtUnix, 0),
 		updatedAt:          time.Unix(row.UpdatedAtUnix, 0),
 	}, nil
+}
+
+func receiveExpectedVHTLCSat(row swapsqlc.ReceiveSwap) uint64 {
+	requestedAmountSat := uint64(row.RequestedAmountSat)
+	if requestedAmountSat == 0 {
+		requestedAmountSat = uint64(row.AmountSat)
+	}
+
+	return requestedAmountSat + uint64(row.AttachedCreditSat)
 }
 
 // paySessionFromRow reconstructs one pay session from its persisted SQL row.
@@ -828,36 +851,39 @@ func paySessionFromRow(c *SwapClient,
 		return nil, err
 	}
 
-	policy, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
-		Sender:       clientKey,
-		Receiver:     serverKey,
-		Server:       operatorKey,
-		PreimageHash: paymentHash,
-		RefundLocktime: uint32(
-			row.RefundLocktime,
-		),
-		UnilateralClaimDelay: uint32(
-			row.UnilateralClaimDelay,
-		),
-		UnilateralRefundDelay: uint32(
-			row.UnilateralRefundDelay,
-		),
-		UnilateralRefundWithoutReceiverDelay: uint32(
-			row.UnilateralRefundWithoutReceiverDelay,
-		),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("rebuild pay vHTLC policy: %w", err)
+	settlementType := SettlementType(row.SettlementType)
+	var policy *arkscript.VHTLCPolicy
+	if settlementType != SettlementTypeCredit {
+		policy, err = arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+			Sender:       clientKey,
+			Receiver:     serverKey,
+			Server:       operatorKey,
+			PreimageHash: paymentHash,
+			RefundLocktime: uint32(
+				row.RefundLocktime,
+			),
+			UnilateralClaimDelay: uint32(
+				row.UnilateralClaimDelay,
+			),
+			UnilateralRefundDelay: uint32(
+				row.UnilateralRefundDelay,
+			),
+			UnilateralRefundWithoutReceiverDelay: uint32(
+				row.UnilateralRefundWithoutReceiverDelay,
+			),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("rebuild pay vHTLC policy: %w",
+				err)
+		}
 	}
 
 	cfg := &InSwapConfig{
-		PaymentHash:  paymentHash,
-		AmountSat:    row.AmountSat,
-		FeeSat:       uint64(row.FeeSat),
-		ServerPubkey: serverKey,
-		SettlementType: SettlementType(
-			row.SettlementType,
-		),
+		PaymentHash:    paymentHash,
+		AmountSat:      row.AmountSat,
+		FeeSat:         uint64(row.FeeSat),
+		ServerPubkey:   serverKey,
+		SettlementType: settlementType,
 		VHTLCConfig: restoreVHTLCConfig(
 			row.RefundLocktime, row.UnilateralClaimDelay,
 			row.UnilateralRefundDelay,

--- a/sdk/swaps/store_test.go
+++ b/sdk/swaps/store_test.go
@@ -117,6 +117,58 @@ func TestSwapSqliteStoreRunsMigrations(t *testing.T) {
 	require.False(t, dirty)
 }
 
+// TestPaySessionPersistAllowsCreditOnlyWithoutVHTLC verifies credit-only pays
+// can be durably recorded without Ark vHTLC artifacts.
+func TestPaySessionPersistAllowsCreditOnlyWithoutVHTLC(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestSwapStore(t)
+	client := NewSwapClientWithStore(nil, nil, nil, nil, store)
+
+	key, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+
+	now := time.Now()
+	session := &paySession{
+		client:    client,
+		invoice:   "ln-credit-only",
+		maxFeeSat: 100,
+		state:     PayStateCompleted,
+		cfg: &InSwapConfig{
+			PaymentHash:    preimage.Hash(),
+			SettlementType: SettlementTypeCredit,
+			Preimage:       &preimage,
+			Expiry:         now.Add(time.Hour),
+		},
+		preimage:       &preimage,
+		clientPubKey:   key.PubKey(),
+		operatorPubKey: key.PubKey(),
+		serverPubKey:   key.PubKey(),
+		createdAt:      now,
+	}
+
+	require.NoError(t, session.persist(ctx))
+
+	paymentHash := preimage.Hash()
+	row, err := store.queries.GetPaySwap(ctx, paymentHash[:])
+	require.NoError(t, err)
+	require.Equal(t, string(SettlementTypeCredit), row.SettlementType)
+	require.Empty(t, row.VhtlcPkscript)
+	require.Empty(t, row.VhtlcPolicyTemplate)
+	require.Empty(t, row.VhtlcOutpoint)
+	require.Zero(t, row.VhtlcAmount)
+
+	resumed, err := client.ResumePayViaLightning(ctx, paymentHash)
+	require.NoError(t, err)
+	require.Equal(t, SettlementTypeCredit, resumed.cfg.SettlementType)
+	require.Empty(t, resumed.vhtlcPkScript)
+	require.Empty(t, resumed.vhtlcPolicyTemplate)
+}
+
 // TestReceiveAuthKeyDerivesAcrossRestart verifies receive-auth keys come from
 // the wallet-backed daemon derivation and are not stored in the swap DB.
 func TestReceiveAuthKeyDerivesAcrossRestart(t *testing.T) {

--- a/sdk/walletdk/convert.go
+++ b/sdk/walletdk/convert.go
@@ -131,7 +131,8 @@ func prepareSendResultFromProto(
 		SelectedOutpoints: append(
 			[]string(nil), resp.GetSelectedOutpoints()...,
 		),
-		Warning: resp.GetWarning(),
+		Warning:       resp.GetWarning(),
+		CreditPreview: creditPreviewFromProto(resp.GetCreditPreview()),
 	}
 }
 
@@ -149,8 +150,28 @@ func sendRailFromProto(rail walletdkrpc.SendRail) SendRail {
 	case walletdkrpc.SendRail_SEND_RAIL_ONCHAIN:
 		return SendRailOnchain
 
+	case walletdkrpc.SendRail_SEND_RAIL_CREDIT:
+		return SendRailCredit
+
+	case walletdkrpc.SendRail_SEND_RAIL_MIXED:
+		return SendRailMixed
+
 	default:
 		return SendRailUnspecified
+	}
+}
+
+func creditPreviewFromProto(preview *walletdkrpc.CreditPreview) *CreditPreview {
+	if preview == nil {
+		return nil
+	}
+
+	return &CreditPreview{
+		MustUseCredit:      preview.GetMustUseCredit(),
+		CreditAppliedSat:   preview.GetCreditAppliedSat(),
+		CreditShortfallSat: preview.GetCreditShortfallSat(),
+		CreditTopupSat:     preview.GetCreditTopupSat(),
+		ArkFundingSat:      preview.GetArkFundingSat(),
 	}
 }
 
@@ -489,9 +510,11 @@ func balanceFromProto(balance *walletdkrpc.BalanceResponse) Balance {
 	}
 
 	return Balance{
-		ConfirmedSat:  balance.GetConfirmedSat(),
-		PendingInSat:  balance.GetPendingInSat(),
-		PendingOutSat: balance.GetPendingOutSat(),
+		ConfirmedSat:       balance.GetConfirmedSat(),
+		PendingInSat:       balance.GetPendingInSat(),
+		PendingOutSat:      balance.GetPendingOutSat(),
+		CreditAvailableSat: balance.GetCreditAvailableSat(),
+		CreditReservedSat:  balance.GetCreditReservedSat(),
 	}
 }
 

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -126,9 +126,11 @@ type UnlockWalletResult struct {
 
 // Balance is the wallet-level balance view.
 type Balance struct {
-	ConfirmedSat  int64
-	PendingInSat  int64
-	PendingOutSat int64
+	ConfirmedSat       int64
+	PendingInSat       int64
+	PendingOutSat      int64
+	CreditAvailableSat uint64
+	CreditReservedSat  uint64
 }
 
 // DepositRequest creates a tracked boarding address.
@@ -178,6 +180,8 @@ const (
 	SendRailInArk           SendRail = "in_ark"
 	SendRailLightning       SendRail = "lightning"
 	SendRailOnchain         SendRail = "onchain"
+	SendRailCredit          SendRail = "credit"
+	SendRailMixed           SendRail = "mixed"
 )
 
 // SendQuoteStatus describes how complete the prepare-time quote is.
@@ -205,6 +209,17 @@ type PrepareSendResult struct {
 	ExpiresAtUnix           int64
 	SelectedOutpoints       []string
 	Warning                 string
+	CreditPreview           *CreditPreview
+}
+
+// CreditPreview describes how a prepared invoice send will use sat-native
+// server credits.
+type CreditPreview struct {
+	MustUseCredit      bool
+	CreditAppliedSat   uint64
+	CreditShortfallSat uint64
+	CreditTopupSat     uint64
+	ArkFundingSat      uint64
 }
 
 // SendPreparedRequest dispatches a prepared outbound payment.

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -631,6 +631,32 @@ func (a *swapClientAdapter) StartPayViaLightningWithCredits(ctx context.Context,
 	)
 }
 
+// StartPayViaLightningWithCreditTopUp starts a real sdk/swaps pay session
+// through the durable wallet payment intent runner.
+func (a *swapClientAdapter) StartPayViaLightningWithCreditTopUp(
+	ctx context.Context, invoice string, maxFeeSat uint64, maxCreditSat uint64,
+	maxCreditTopUpSat uint64) (paySwapSession, error) {
+
+	return a.client.StartPayViaLightningWithCreditTopUp(
+		ctx, invoice, maxFeeSat, maxCreditSat, maxCreditTopUpSat,
+	)
+}
+
+// ResumePaymentIntent resumes a durable wallet payment intent by payment hash.
+func (a *swapClientAdapter) ResumePaymentIntent(ctx context.Context,
+	hash lntypes.Hash) (paySwapSession, error) {
+
+	return a.client.ResumePaymentIntent(ctx, hash)
+}
+
+// ListPendingPaymentIntents returns durable wallet payment intents that must
+// resume before a pay swap row necessarily exists.
+func (a *swapClientAdapter) ListPendingPaymentIntents(ctx context.Context) (
+	[]swaps.PaymentIntentSummary, error) {
+
+	return a.client.ListPendingPaymentIntents(ctx)
+}
+
 // QuotePayViaLightning previews a pay swap without creating durable state.
 func (a *swapClientAdapter) QuotePayViaLightning(ctx context.Context,
 	invoice string, maxFeeSat uint64) (*swaps.InSwapQuote, error) {
@@ -1037,7 +1063,26 @@ func (s *swapClientService) quotePay(ctx context.Context, invoice string,
 }
 
 func (s *swapClientService) startPay(ctx context.Context, invoice string,
-	maxFeeSat uint64, maxCreditSat uint64) (paySwapSession, error) {
+	maxFeeSat uint64, maxCreditSat uint64,
+	maxCreditTopUpSat uint64) (paySwapSession, error) {
+
+	if maxCreditTopUpSat > 0 {
+		if client, ok := s.client.(interface {
+			StartPayViaLightningWithCreditTopUp(context.Context,
+				string, uint64, uint64, uint64) (paySwapSession,
+				error)
+		}); ok {
+			return client.StartPayViaLightningWithCreditTopUp(
+				ctx, invoice, maxFeeSat, maxCreditSat,
+				maxCreditTopUpSat,
+			)
+		}
+
+		return nil, status.Error(
+			codes.Unimplemented,
+			"credit top-up payment intents are not supported",
+		)
+	}
 
 	if client, ok := s.client.(interface {
 		StartPayViaLightningWithCredits(context.Context, string, uint64,
@@ -1101,7 +1146,7 @@ func (s *swapClientService) StartPay(ctx context.Context,
 
 	session, err := s.startPay(
 		ctx, req.GetInvoice(), req.GetMaxFeeSat(),
-		req.GetMaxCreditSat(),
+		req.GetMaxCreditSat(), req.GetMaxCreditTopupSat(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("start pay swap: %w", err)
@@ -1483,6 +1528,21 @@ func (s *swapClientService) SubscribeSwaps(
 // swapruntime daemon starts, the store is scanned before the RPC server begins
 // accepting control calls.
 func (s *swapClientService) resumePending(ctx context.Context) {
+	if client, ok := s.client.(interface {
+		ListPendingPaymentIntents(context.Context) (
+			[]swaps.PaymentIntentSummary, error)
+	}); ok {
+		intents, err := client.ListPendingPaymentIntents(ctx)
+		if err != nil {
+			s.log.Warnf("unable to list pending payment intents on "+
+				"startup: %v", err)
+		} else {
+			for _, intent := range intents {
+				s.startPaymentIntentWorker(intent.PaymentHash)
+			}
+		}
+	}
+
 	summaries, err := s.client.ListSwapSummaries(ctx, true)
 	if err != nil {
 		s.log.Warnf("unable to list pending swaps on startup: %v", err)
@@ -1499,6 +1559,45 @@ func (s *swapClientService) resumePending(ctx context.Context) {
 			s.startReceiveWorker(summary.PaymentHash)
 		}
 	}
+}
+
+// startPaymentIntentWorker claims process-local ownership for the wallet-level
+// payment intent and runs it until the underlying sdk/swaps pay FSM exists.
+// Once the pay session is available, the same goroutine waits on the pay FSM so
+// another worker cannot concurrently drive the same payment hash.
+func (s *swapClientService) startPaymentIntentWorker(hash lntypes.Hash) {
+	key := hex.EncodeToString(hash[:])
+	if !s.markActive(key) {
+		return
+	}
+
+	go func() {
+		defer s.markInactive(key)
+		defer s.publishHash(hash)
+
+		client, ok := s.client.(interface {
+			ResumePaymentIntent(context.Context,
+				lntypes.Hash) (paySwapSession, error)
+		})
+		if !ok {
+			s.log.Warnf("unable to resume payment intent %s: "+
+				"runtime does not support payment intents", key)
+
+			return
+		}
+
+		session, err := client.ResumePaymentIntent(s.rootCtx, hash)
+		if err != nil {
+			s.log.Warnf("payment intent %s stopped: %v", key, err)
+
+			return
+		}
+
+		_, err = session.Wait(s.rootCtx)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			s.log.Warnf("pay swap %s stopped: %v", key, err)
+		}
+	}()
 }
 
 // startPayWorker claims process-local ownership for a pay swap FSM and runs

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -100,19 +100,6 @@ type swapClientService struct {
 	// ListSwaps.
 	subscribers map[chan *swapclientrpc.SwapSummary]struct{}
 
-	// receiveMinAmount returns the current minimum output amount that a
-	// receive-swap vHTLC must satisfy before it is safe to hand a BOLT-11
-	// invoice to a payer. Production derives this from the daemon's cached
-	// operator terms; tests may leave it nil to disable this preflight.
-	receiveMinAmount func(context.Context) (uint64, error)
-
-	// payMinAmount returns the current minimum output amount that a
-	// pay-swap vHTLC must satisfy before sdk/swaps persists the pay
-	// session. This mirrors the receive guard so high-level wallet RPC
-	// callers fail before a background worker reaches the daemon's SendOOR
-	// dust check.
-	payMinAmount func(context.Context) (uint64, error)
-
 	// chainParams decodes BOLT-11 pay invoices for local amount preflight
 	// and duplicate in-flight checks before swap creation mutates remote
 	// swapdk-server state.
@@ -479,15 +466,6 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 		return nil, nil, err
 	}
 
-	minAmount := func(ctx context.Context) (uint64, error) {
-		info, err := arkClient.GetInfo(ctx)
-		if err != nil {
-			return 0, err
-		}
-
-		return vtxoMinAmountSat(info.ServerInfo)
-	}
-
 	service := &swapClientService{
 		client: &swapClientAdapter{
 			client: swapClient,
@@ -500,9 +478,7 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 		subscribers: make(
 			map[chan *swapclientrpc.SwapSummary]struct{},
 		),
-		receiveMinAmount: minAmount,
-		payMinAmount:     minAmount,
-		chainParams:      chainParams,
+		chainParams: chainParams,
 	}
 
 	cleanup := func() {
@@ -644,11 +620,53 @@ func (a *swapClientAdapter) StartPayViaLightning(ctx context.Context,
 	return a.client.StartPayViaLightning(ctx, invoice, maxFeeSat)
 }
 
+// StartPayViaLightningWithCredits starts a real sdk/swaps pay session with
+// optional credit use.
+func (a *swapClientAdapter) StartPayViaLightningWithCredits(ctx context.Context,
+	invoice string, maxFeeSat uint64, maxCreditSat uint64) (paySwapSession,
+	error) {
+
+	return a.client.StartPayViaLightningWithCredits(
+		ctx, invoice, maxFeeSat, maxCreditSat,
+	)
+}
+
 // QuotePayViaLightning previews a pay swap without creating durable state.
 func (a *swapClientAdapter) QuotePayViaLightning(ctx context.Context,
 	invoice string, maxFeeSat uint64) (*swaps.InSwapQuote, error) {
 
 	return a.client.QuotePayViaLightning(ctx, invoice, maxFeeSat)
+}
+
+// QuotePayViaLightningWithCredits previews a pay swap with optional credit use.
+func (a *swapClientAdapter) QuotePayViaLightningWithCredits(ctx context.Context,
+	invoice string, maxFeeSat uint64, maxCreditSat uint64) (
+	*swaps.InSwapQuote, error) {
+
+	return a.client.QuotePayViaLightningWithCredits(
+		ctx, invoice, maxFeeSat, maxCreditSat,
+	)
+}
+
+// CreateCredit forwards credit funding requests to sdk/swaps.
+func (a *swapClientAdapter) CreateCredit(ctx context.Context,
+	req swaps.CreateCreditRequest) (*swaps.CreditOperation, error) {
+
+	return a.client.CreateCredit(ctx, req)
+}
+
+// RedeemCredit forwards credit redemption requests to sdk/swaps.
+func (a *swapClientAdapter) RedeemCredit(ctx context.Context,
+	req swaps.RedeemCreditRequest) (*swaps.CreditRedemption, error) {
+
+	return a.client.RedeemCredit(ctx, req)
+}
+
+// ListCredits forwards credit account snapshots to sdk/swaps.
+func (a *swapClientAdapter) ListCredits(ctx context.Context, limit uint32) (
+	*swaps.CreditSnapshot, error) {
+
+	return a.client.ListCredits(ctx, limit)
 }
 
 // StartReceiveViaLightning starts a real sdk/swaps receive session and wraps
@@ -1003,111 +1021,34 @@ func chainParamsForNetwork(network string) (*chaincfg.Params, error) {
 	}
 }
 
-// vtxoMinAmountSat returns the effective minimum VTXO output amount. Pay
-// and receive swaps both create Ark VTXOs, so both rails use the same VTXO
-// floor before asking the swap server for route hints or persisting local
-// swap state.
-func vtxoMinAmountSat(info *sdkark.ServerInfo) (uint64, error) {
-	if info == nil {
-		return 0, fmt.Errorf("operator terms unavailable")
-	}
+func (s *swapClientService) quotePay(ctx context.Context, invoice string,
+	maxFeeSat uint64, maxCreditSat uint64) (*swaps.InSwapQuote, error) {
 
-	if info.MinVTXOAmountSat > info.DustLimit {
-		return info.MinVTXOAmountSat, nil
-	}
-
-	return info.DustLimit, nil
-}
-
-// validateReceiveAmount rejects locally-impossible receive amounts before the
-// SDK requests a route hint and returns a payer-visible BOLT-11 invoice.
-func (s *swapClientService) validateReceiveAmount(ctx context.Context,
-	amountSat int64) error {
-
-	if s.receiveMinAmount == nil {
-		return nil
-	}
-
-	minAmountSat, err := s.receiveMinAmount(ctx)
-	if err != nil {
-		return status.Errorf(codes.Unavailable, "receive amount "+
-			"preflight failed: %v", err)
-	}
-	if minAmountSat == 0 {
-		return nil
-	}
-	if uint64(amountSat) >= minAmountSat {
-		return nil
-	}
-
-	return status.Errorf(codes.InvalidArgument, "amount_sat %d is below "+
-		"the %d sat minimum for receive swaps (operator VTXO minimum)",
-		amountSat, minAmountSat)
-}
-
-// payInvoiceAmountSat decodes the BOLT-11 invoice amount in whole satoshis.
-// The swap pay path funds one Ark vHTLC of this value, so a nil, zero, or
-// millisatoshi-only invoice cannot be admitted through the daemon subserver.
-func payInvoiceAmountSat(invoice string,
-	chainParams *chaincfg.Params) (uint64, error) {
-
-	decoded, err := zpay32.Decode(invoice, chainParams)
-	if err != nil {
-		return 0, err
-	}
-
-	if decoded.MilliSat == nil {
-		return 0, fmt.Errorf("invoice amount is required")
-	}
-
-	amountMSat := uint64(*decoded.MilliSat)
-	if amountMSat == 0 {
-		return 0, fmt.Errorf("invoice amount must be positive")
-	}
-	if amountMSat%1000 != 0 {
-		return 0, fmt.Errorf("invoice amount must be whole satoshis")
-	}
-
-	return amountMSat / 1000, nil
-}
-
-// validatePayInvoiceAmount rejects locally-impossible pay invoices before the
-// SDK persists a swap session and starts a background worker.
-func (s *swapClientService) validatePayInvoiceAmount(ctx context.Context,
-	invoice string) error {
-
-	if s.payMinAmount == nil {
-		return nil
-	}
-
-	if s.chainParams == nil {
-		return status.Error(
-			codes.Internal,
-			"chain params required for pay invoice validation",
+	if client, ok := s.client.(interface {
+		QuotePayViaLightningWithCredits(context.Context, string, uint64,
+			uint64) (*swaps.InSwapQuote, error)
+	}); ok {
+		return client.QuotePayViaLightningWithCredits(
+			ctx, invoice, maxFeeSat, maxCreditSat,
 		)
 	}
 
-	amountSat, err := payInvoiceAmountSat(invoice, s.chainParams)
-	if err != nil {
-		return status.Errorf(codes.InvalidArgument, "invoice amount "+
-			"preflight failed: %v", err)
+	return s.client.QuotePayViaLightning(ctx, invoice, maxFeeSat)
+}
+
+func (s *swapClientService) startPay(ctx context.Context, invoice string,
+	maxFeeSat uint64, maxCreditSat uint64) (paySwapSession, error) {
+
+	if client, ok := s.client.(interface {
+		StartPayViaLightningWithCredits(context.Context, string, uint64,
+			uint64) (paySwapSession, error)
+	}); ok {
+		return client.StartPayViaLightningWithCredits(
+			ctx, invoice, maxFeeSat, maxCreditSat,
+		)
 	}
 
-	minAmountSat, err := s.payMinAmount(ctx)
-	if err != nil {
-		return status.Errorf(codes.Unavailable, "pay amount preflight "+
-			"failed: %v", err)
-	}
-	if minAmountSat == 0 {
-		return nil
-	}
-	if amountSat >= minAmountSat {
-		return nil
-	}
-
-	return status.Errorf(codes.InvalidArgument, "invoice amount_sat %d is "+
-		"below the %d sat minimum for pay swaps (operator VTXO "+
-		"minimum)", amountSat, minAmountSat)
+	return s.client.StartPayViaLightning(ctx, invoice, maxFeeSat)
 }
 
 // QuotePay previews a pay swap through sdk/swaps without starting a daemon
@@ -1121,14 +1062,9 @@ func (s *swapClientService) QuotePay(ctx context.Context,
 			codes.InvalidArgument, "invoice is required",
 		)
 	}
-	if err := s.validatePayInvoiceAmount(
-		ctx, req.GetInvoice(),
-	); err != nil {
-		return nil, err
-	}
-
-	quote, err := s.client.QuotePayViaLightning(
+	quote, err := s.quotePay(
 		ctx, req.GetInvoice(), req.GetMaxFeeSat(),
+		req.GetMaxCreditSat(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("quote pay swap: %w", err)
@@ -1155,12 +1091,6 @@ func (s *swapClientService) StartPay(ctx context.Context,
 			"idempotency_key is reserved for future use",
 		)
 	}
-	if err := s.validatePayInvoiceAmount(
-		ctx, req.GetInvoice(),
-	); err != nil {
-		return nil, err
-	}
-
 	existing, ok, err := s.pendingSwapForInvoice(ctx, req.GetInvoice())
 	if err != nil {
 		return nil, err
@@ -1169,8 +1099,9 @@ func (s *swapClientService) StartPay(ctx context.Context,
 		return existing, nil
 	}
 
-	session, err := s.client.StartPayViaLightning(
+	session, err := s.startPay(
 		ctx, req.GetInvoice(), req.GetMaxFeeSat(),
+		req.GetMaxCreditSat(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("start pay swap: %w", err)
@@ -1208,10 +1139,6 @@ func (s *swapClientService) StartReceive(ctx context.Context,
 			"idempotency_key is reserved for future use",
 		)
 	}
-	if err := s.validateReceiveAmount(ctx, req.GetAmountSat()); err != nil {
-		return nil, err
-	}
-
 	session, err := s.client.StartReceiveViaLightning(
 		ctx,
 		btcutil.Amount(
@@ -1233,10 +1160,143 @@ func (s *swapClientService) StartReceive(ctx context.Context,
 	}
 
 	return &swapclientrpc.StartReceiveResponse{
-		PaymentHash: hex.EncodeToString(hash[:]),
-		Invoice:     session.Invoice(),
-		Swap:        summary,
+		PaymentHash:        hex.EncodeToString(hash[:]),
+		Invoice:            session.Invoice(),
+		Swap:               summary,
+		RequestedAmountSat: summary.GetRequestedAmountSat(),
+		AvailableCreditSat: summary.GetAvailableCreditSat(),
+		AttachedCreditSat:  summary.GetAttachedCreditSat(),
+		VhtlcAmountSat:     receivePlanVHTLCAmount(summary),
+		DustLimitSat:       summary.GetDustLimitSat(),
+		SettlementType:     summary.GetSettlementType(),
 	}, nil
+}
+
+func receivePlanVHTLCAmount(summary *swapclientrpc.SwapSummary) uint64 {
+	if summary == nil {
+		return 0
+	}
+	if summary.GetVhtlcAmountSat() > 0 {
+		return uint64(summary.GetVhtlcAmountSat())
+	}
+
+	requested := summary.GetRequestedAmountSat()
+	if requested == 0 {
+		requested = uint64(summary.GetAmountSat())
+	}
+
+	return requested + summary.GetAttachedCreditSat()
+}
+
+// CreateCredit starts one server-owned credit funding operation for the daemon
+// wallet identity account.
+func (s *swapClientService) CreateCredit(ctx context.Context,
+	req *swapclientrpc.CreateCreditRequest) (
+	*swapclientrpc.CreateCreditResponse, error) {
+
+	if req.GetIdempotencyKey() == "" {
+		return nil, status.Error(
+			codes.InvalidArgument, "idempotency_key is required",
+		)
+	}
+
+	source, err := creditFundingSourceFromProto(req.GetSource())
+	if err != nil {
+		return nil, err
+	}
+
+	client, ok := s.client.(interface {
+		CreateCredit(context.Context,
+			swaps.CreateCreditRequest) (
+			*swaps.CreditOperation,
+			error,
+		)
+	})
+	if !ok {
+		return nil, status.Error(
+			codes.Unimplemented, "credits are not supported",
+		)
+	}
+
+	op, err := client.CreateCredit(ctx, swaps.CreateCreditRequest{
+		IdempotencyKey: req.GetIdempotencyKey(),
+		Source:         source,
+		AmountSat:      req.GetAmountSat(),
+		Memo:           req.GetMemo(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create credit: %w", err)
+	}
+
+	return creditCreateResponseToProto(op), nil
+}
+
+// RedeemCredit materializes available credits back into an Ark output.
+func (s *swapClientService) RedeemCredit(ctx context.Context,
+	req *swapclientrpc.RedeemCreditRequest) (
+	*swapclientrpc.RedeemCreditResponse, error) {
+
+	if req.GetIdempotencyKey() == "" {
+		return nil, status.Error(
+			codes.InvalidArgument, "idempotency_key is required",
+		)
+	}
+
+	client, ok := s.client.(interface {
+		RedeemCredit(context.Context,
+			swaps.RedeemCreditRequest) (
+			*swaps.CreditRedemption,
+			error,
+		)
+	})
+	if !ok {
+		return nil, status.Error(
+			codes.Unimplemented, "credits are not supported",
+		)
+	}
+
+	result, err := client.RedeemCredit(ctx, swaps.RedeemCreditRequest{
+		IdempotencyKey: req.GetIdempotencyKey(),
+		AmountSat:      req.GetAmountSat(),
+		DestinationPubKey: append(
+			[]byte(nil), req.GetDestinationPubkey()...,
+		),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("redeem credit: %w", err)
+	}
+
+	return &swapclientrpc.RedeemCreditResponse{
+		OperationId: result.Operation.OperationID,
+		State:       creditStateToProto(result.Operation.State),
+		DebitedSat:  result.DebitedSat,
+		RedeemedSat: result.RedeemedSat,
+		SessionId:   result.SessionID,
+	}, nil
+}
+
+// ListCredits returns the server-authoritative credit snapshot for the daemon
+// wallet identity account.
+func (s *swapClientService) ListCredits(ctx context.Context,
+	req *swapclientrpc.ListCreditsRequest) (
+	*swapclientrpc.ListCreditsResponse, error) {
+
+	client, ok := s.client.(interface {
+		ListCredits(context.Context,
+			uint32) (*swaps.CreditSnapshot, error)
+	})
+	if !ok {
+		return nil, status.Error(
+			codes.Unimplemented, "credits are not supported",
+		)
+	}
+
+	snapshot, err := client.ListCredits(ctx, req.GetLimit())
+	if err != nil {
+		return nil, fmt.Errorf("list credits: %w", err)
+	}
+
+	return creditSnapshotToProto(snapshot), nil
 }
 
 // pendingSwapForInvoice decodes a real BOLT-11 invoice and checks whether the
@@ -1641,7 +1701,12 @@ func swapSummaryToProto(summary swaps.SwapSummary) *swapclientrpc.SwapSummary {
 		SettlementType: swapSettlementTypeToProto(
 			summary.SettlementType,
 		),
-		SenderPubkey: senderPubKey,
+		SenderPubkey:       senderPubKey,
+		CreditQuote:        creditQuoteToProto(summary.CreditQuote),
+		RequestedAmountSat: summary.RequestedAmountSat,
+		AttachedCreditSat:  summary.AttachedCreditSat,
+		DustLimitSat:       summary.DustLimitSat,
+		AvailableCreditSat: summary.AvailableCreditSat,
 	}
 }
 
@@ -1664,7 +1729,211 @@ func quotePayToProto(quote *swaps.InSwapQuote) (*swapclientrpc.QuotePayResponse,
 		),
 		ExpiresAtUnix: quote.Expiry.Unix(),
 		ExceedsMaxFee: quote.ExceedsMaxFee,
+		CreditQuote:   creditQuoteToProto(quote.CreditQuote),
 	}, nil
+}
+
+func creditQuoteToProto(quote *swaps.CreditQuote) *swapclientrpc.CreditQuote {
+	if quote == nil {
+		return nil
+	}
+
+	return &swapclientrpc.CreditQuote{
+		MustUseCredit:      quote.MustUseCredit,
+		CreditAppliedSat:   quote.CreditAppliedSat,
+		CreditShortfallSat: quote.CreditShortfallSat,
+		CreditTopupSat:     quote.CreditTopupSat,
+		ArkFundingSat:      quote.ArkFundingSat,
+	}
+}
+
+func creditFundingSourceFromProto(source swapclientrpc.CreditFundingSource) (
+	swaps.CreditFundingSource, error) {
+
+	switch source {
+	case swapclientrpc.
+		CreditFundingSource_CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE:
+		return swaps.CreditFundingLightningReceive, nil
+
+	case swapclientrpc.CreditFundingSource_CREDIT_FUNDING_SOURCE_ARK_TOPUP:
+		return swaps.CreditFundingArkTopUp, nil
+
+	default:
+		return "", status.Error(
+			codes.InvalidArgument, "credit source is required",
+		)
+	}
+}
+
+func creditCreateResponseToProto(
+	op *swaps.CreditOperation) *swapclientrpc.CreateCreditResponse {
+
+	if op == nil {
+		return nil
+	}
+
+	resp := &swapclientrpc.CreateCreditResponse{
+		OperationId:       op.OperationID,
+		State:             creditStateToProto(op.State),
+		Invoice:           op.Invoice,
+		PaymentHash:       creditPaymentHashString(op.PaymentHash),
+		AmountSat:         op.AmountSat,
+		DestinationPubkey: append([]byte(nil), op.DestinationKey...),
+	}
+	if op.ExpiresAt != nil {
+		resp.ExpiresAtUnix = op.ExpiresAt.Unix()
+	}
+
+	return resp
+}
+
+func creditSnapshotToProto(
+	snapshot *swaps.CreditSnapshot) *swapclientrpc.ListCreditsResponse {
+
+	if snapshot == nil {
+		return nil
+	}
+
+	resp := &swapclientrpc.ListCreditsResponse{
+		FinalizedSat: snapshot.FinalizedSat,
+		ReservedSat:  snapshot.ReservedSat,
+		AvailableSat: snapshot.AvailableSat,
+	}
+	for _, op := range snapshot.Operations {
+		resp.Operations = append(
+			resp.Operations, creditOperationToProto(op),
+		)
+	}
+	for _, entry := range snapshot.LedgerEntries {
+		resp.LedgerEntries = append(
+			resp.LedgerEntries, creditLedgerEntryToProto(entry),
+		)
+	}
+
+	return resp
+}
+
+func creditOperationToProto(
+	op swaps.CreditOperation) *swapclientrpc.CreditOperation {
+
+	resp := &swapclientrpc.CreditOperation{
+		OperationId:       op.OperationID,
+		Type:              creditTypeToProto(op.Type),
+		State:             creditStateToProto(op.State),
+		AmountSat:         op.AmountSat,
+		PaymentHash:       creditPaymentHashString(op.PaymentHash),
+		Invoice:           op.Invoice,
+		DestinationPubkey: append([]byte(nil), op.DestinationKey...),
+		SessionId:         op.SessionID,
+		CreatedAtUnix:     op.CreatedAt.Unix(),
+		UpdatedAtUnix:     op.UpdatedAt.Unix(),
+		LastError:         op.LastError,
+	}
+	if op.CompletedAt != nil {
+		resp.CompletedAtUnix = op.CompletedAt.Unix()
+	}
+
+	return resp
+}
+
+func creditLedgerEntryToProto(
+	entry swaps.CreditLedgerEntry) *swapclientrpc.CreditLedgerEntry {
+
+	return &swapclientrpc.CreditLedgerEntry{
+		EntryId:       entry.EntryID,
+		OperationId:   entry.OperationID,
+		Direction:     entry.Direction,
+		AmountSat:     entry.AmountSat,
+		CreatedAtUnix: entry.CreatedAt.Unix(),
+	}
+}
+
+func creditPaymentHashString(hash *lntypes.Hash) string {
+	if hash == nil {
+		return ""
+	}
+
+	return hex.EncodeToString(hash[:])
+}
+
+func creditTypeToProto(
+	typ swaps.CreditOperationType) swapclientrpc.CreditOperationType {
+
+	switch typ {
+	case swaps.CreditOperationFunding:
+		return swapclientrpc.
+			CreditOperationType_CREDIT_OPERATION_TYPE_FUNDING
+
+	case swaps.CreditOperationPay:
+		return swapclientrpc.
+			CreditOperationType_CREDIT_OPERATION_TYPE_PAY
+
+	case swaps.CreditOperationRedemption:
+		return swapclientrpc.
+			CreditOperationType_CREDIT_OPERATION_TYPE_REDEMPTION
+
+	case swaps.CreditOperationReceive:
+		return swapclientrpc.
+			CreditOperationType_CREDIT_OPERATION_TYPE_RECEIVE
+
+	default:
+		return swapclientrpc.
+			CreditOperationType_CREDIT_OPERATION_TYPE_UNSPECIFIED
+	}
+}
+
+func creditStateToProto(
+	state swaps.CreditOperationState) swapclientrpc.CreditOperationState {
+
+	switch state {
+	case swaps.CreditStateCreated:
+		return swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_CREATED
+
+	case swaps.CreditStateAwaitingPayment:
+		return swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_AWAITING_PAYMENT
+
+	case swaps.CreditStateCredited:
+		return swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_CREDITED
+
+	case swaps.CreditStateReserved:
+		return swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_RESERVED
+
+	case swaps.CreditStatePayingLightning:
+		return swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_PAYING_LIGHTNING
+
+	case swaps.CreditStateDebited:
+		return swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_DEBITED
+
+	case swaps.CreditStateSendingOOR:
+		return swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_SENDING_OOR
+
+	case swaps.CreditStateRedeemed:
+		return swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_REDEEMED
+
+	case swaps.CreditStateReleased:
+		return swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_RELEASED
+
+	case swaps.CreditStateExpired:
+		return swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_EXPIRED
+
+	case swaps.CreditStateFailed:
+		return swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_FAILED
+
+	default:
+		return swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_UNSPECIFIED
+	}
 }
 
 // swapStateToProto maps sdk/swaps persisted state names into the stable public
@@ -1745,6 +2014,13 @@ func swapSettlementTypeToProto(
 
 	case swaps.SettlementTypeInArk:
 		return swapclientrpc.SwapSettlementType_SWAP_SETTLEMENT_TYPE_IN_ARK
+
+	case swaps.SettlementTypeCredit:
+		return swapclientrpc.
+			SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT
+
+	case swaps.SettlementTypeMixed:
+		return swapclientrpc.SwapSettlementType_SWAP_SETTLEMENT_TYPE_MIXED
 
 	default:
 		return swapclientrpc.

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/lightninglabs/darepo-client/darepod"
 	mailboxpb "github.com/lightninglabs/darepo-client/mailbox/pb"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
-	sdkark "github.com/lightninglabs/darepo-client/sdk/ark"
 	"github.com/lightninglabs/darepo-client/sdk/swaps"
 	"github.com/lightninglabs/darepo-client/serverconn"
 	"github.com/lightninglabs/darepo-client/swaprpc"
@@ -408,20 +407,15 @@ func TestStartPayPreservesRuntimeStatusCode(t *testing.T) {
 	)
 }
 
-// TestStartPayRejectsInvoiceBelowOperatorVTXOMin verifies the wallet RPC
-// facade applies the same operator VTXO minimum as the underlying daemon OOR
-// sender before it persists a pay swap. Without this synchronous preflight, a
-// too-small BOLT-11 invoice could be admitted, then fail later in the
-// background worker after the user-facing Send RPC already returned.
-func TestStartPayRejectsInvoiceBelowOperatorVTXOMin(t *testing.T) {
+// TestStartPayAllowsInvoiceBelowOperatorDust verifies sub-dust pays are no
+// longer rejected by the daemon facade before the swap server can quote a
+// credit-backed payment.
+func TestStartPayAllowsInvoiceBelowOperatorDust(t *testing.T) {
 	t.Parallel()
 
 	fakeClient := newFakeSwapRuntime()
 	service := newTestSwapClientService(fakeClient)
 	service.chainParams = &chaincfg.RegressionNetParams
-	service.payMinAmount = func(context.Context) (uint64, error) {
-		return 1000, nil
-	}
 	defer service.cancel()
 
 	_, err := service.StartPay(
@@ -429,27 +423,18 @@ func TestStartPayRejectsInvoiceBelowOperatorVTXOMin(t *testing.T) {
 			Invoice: testSwapPayInvoice(t, 999),
 		},
 	)
-	require.Equal(t, codes.InvalidArgument, status.Code(err))
-	require.ErrorContains(
-		t, err, "invoice amount_sat 999 is below the 1000 sat "+
-			"minimum for pay swaps",
-	)
-	require.Equal(t, 0, fakeClient.startPayCount())
+	require.ErrorContains(t, err, "start pay session not configured")
+	require.Equal(t, 1, fakeClient.startPayCount())
 }
 
-// TestStartPayRejectsMissingChainParamsAsInternal verifies a daemon wiring
-// error is not reported as a caller invoice problem. Pay invoice dust
-// validation needs network parameters to parse BOLT-11 correctly; if the
-// service is missing them, the RPC should fail as an internal server error
-// before touching the swap runtime.
-func TestStartPayRejectsMissingChainParamsAsInternal(t *testing.T) {
+// TestStartPayDefersMissingChainParamsToRuntime verifies pay invoice amount
+// validation no longer requires daemon-local chain params before the swap
+// server can quote credit-backed pays.
+func TestStartPayDefersMissingChainParamsToRuntime(t *testing.T) {
 	t.Parallel()
 
 	fakeClient := newFakeSwapRuntime()
 	service := newTestSwapClientService(fakeClient)
-	service.payMinAmount = func(context.Context) (uint64, error) {
-		return 1000, nil
-	}
 	defer service.cancel()
 
 	_, err := service.StartPay(
@@ -457,11 +442,8 @@ func TestStartPayRejectsMissingChainParamsAsInternal(t *testing.T) {
 			Invoice: testSwapPayInvoice(t, 999),
 		},
 	)
-	require.Equal(t, codes.Internal, status.Code(err))
-	require.ErrorContains(
-		t, err, "chain params required for pay invoice validation",
-	)
-	require.Equal(t, 0, fakeClient.startPayCount())
+	require.ErrorContains(t, err, "start pay session not configured")
+	require.Equal(t, 1, fakeClient.startPayCount())
 }
 
 // TestStartReceiveReturnsInvoiceAndStartsWorker verifies receive startup
@@ -504,57 +486,184 @@ func TestStartReceiveReturnsInvoiceAndStartsWorker(t *testing.T) {
 	require.Equal(t, 1, fakeClient.receiveResumeCount(receiveHash))
 }
 
-// TestStartReceiveRejectsAmountBelowOperatorVTXOMin proves receive startup
-// fails before sdk/swaps creates a session or invoice when the requested
-// amount is below the operator-advertised VTXO minimum.
-func TestStartReceiveRejectsAmountBelowOperatorVTXOMin(t *testing.T) {
+// TestStartReceiveReturnsCreditAssistedPlan verifies receive startup returns
+// the server's credit-assisted plan even before a vHTLC outpoint exists
+// locally.
+func TestStartReceiveReturnsCreditAssistedPlan(t *testing.T) {
 	t.Parallel()
 
-	fakeClient := newFakeSwapRuntime()
-	service := newTestSwapClientService(fakeClient)
-	service.receiveMinAmount = func(context.Context) (uint64, error) {
-		return 1_000, nil
+	receiveHash := testHash(49)
+	fakeClient := newFakeSwapRuntime(
+		swaps.SwapSummary{
+			Direction:          swaps.SwapDirectionReceive,
+			PaymentHash:        receiveHash,
+			State:              "invoice_created",
+			Pending:            true,
+			AmountSat:          300,
+			RequestedAmountSat: 300,
+			AvailableCreditSat: 800,
+			AttachedCreditSat:  800,
+			DustLimitSat:       1_000,
+			SettlementType:     swaps.SettlementTypeMixed,
+		},
+	)
+	fakeClient.startReceiveSession = &fakeReceiveSession{
+		hash:    receiveHash,
+		invoice: "lnbc1receive",
 	}
+	service := newTestSwapClientService(fakeClient)
 	defer service.cancel()
 
-	_, err := service.StartReceive(
+	resp, err := service.StartReceive(
 		t.Context(), &swapclientrpc.StartReceiveRequest{
 			AmountSat: 300,
 		},
 	)
-	require.Error(t, err)
-	require.Equal(t, codes.InvalidArgument, status.Code(err))
-	require.Contains(t, status.Convert(err).Message(), "300")
-	require.Contains(t, status.Convert(err).Message(), "1000 sat minimum")
-	require.Contains(
-		t, status.Convert(err).Message(),
-		"operator VTXO minimum",
+	require.NoError(t, err)
+	require.Equal(t, 1, fakeClient.startReceiveCount())
+	require.Equal(t, uint64(300), resp.GetRequestedAmountSat())
+	require.Equal(t, uint64(800), resp.GetAvailableCreditSat())
+	require.Equal(t, uint64(800), resp.GetAttachedCreditSat())
+	require.Equal(t, uint64(1_100), resp.GetVhtlcAmountSat())
+	require.Equal(t, uint64(1_000), resp.GetDustLimitSat())
+	require.Equal(
+		t, swapclientrpc.SwapSettlementType_SWAP_SETTLEMENT_TYPE_MIXED,
+		resp.GetSettlementType(),
 	)
-	require.Equal(t, 0, fakeClient.startReceiveCount())
 }
 
-func TestVTXOMinAmountUsesMinVTXOAmount(t *testing.T) {
+func TestCreateCreditForwardsLightningReceive(t *testing.T) {
 	t.Parallel()
 
-	amount, err := vtxoMinAmountSat(&sdkark.ServerInfo{
-		DustLimit:        546,
-		MinVTXOAmountSat: 1_234,
-	})
-	require.NoError(t, err)
-	require.Equal(t, uint64(1_234), amount)
+	hash := testHash(50)
+	expiresAt := time.Now().Add(time.Hour)
+	fakeClient := newFakeSwapRuntime()
+	fakeClient.createCreditResp = &swaps.CreditOperation{
+		OperationID: "cr_receive",
+		State:       swaps.CreditStateAwaitingPayment,
+		AmountSat:   123,
+		PaymentHash: &hash,
+		Invoice:     "lnbc1credit",
+		ExpiresAt:   &expiresAt,
+	}
+	service := newTestSwapClientService(fakeClient)
+	defer service.cancel()
 
-	amount, err = vtxoMinAmountSat(&sdkark.ServerInfo{
-		DustLimit: 546,
-	})
+	resp, err := service.CreateCredit(
+		t.Context(), &swapclientrpc.CreateCreditRequest{
+			IdempotencyKey: "idem-recv",
+			Source: swapclientrpc.
+				CreditFundingSource_CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE,
+			AmountSat: 123,
+			Memo:      "dust receive",
+		},
+	)
 	require.NoError(t, err)
-	require.Equal(t, uint64(546), amount)
+	require.Equal(t, 1, fakeClient.createCreditCalls)
+	require.Equal(
+		t, swaps.CreditFundingLightningReceive,
+		fakeClient.createCreditReq.Source,
+	)
+	require.Equal(t, "idem-recv", fakeClient.createCreditReq.IdempotencyKey)
+	require.Equal(t, uint64(123), fakeClient.createCreditReq.AmountSat)
+	require.Equal(t, "cr_receive", resp.GetOperationId())
+	require.Equal(t, uint64(123), resp.GetAmountSat())
+	require.Equal(t, hex.EncodeToString(hash[:]), resp.GetPaymentHash())
+	require.Equal(t, "lnbc1credit", resp.GetInvoice())
+	require.Equal(t, expiresAt.Unix(), resp.GetExpiresAtUnix())
+}
 
-	amount, err = vtxoMinAmountSat(&sdkark.ServerInfo{
-		DustLimit:        546,
-		MinVTXOAmountSat: 100,
-	})
+func TestRedeemCreditForwardsDestination(t *testing.T) {
+	t.Parallel()
+
+	fakeClient := newFakeSwapRuntime()
+	fakeClient.redeemCreditResp = &swaps.CreditRedemption{
+		Operation: swaps.CreditOperation{
+			OperationID: "cr_redeem",
+			State:       swaps.CreditStateRedeemed,
+		},
+		DebitedSat:  1_000,
+		RedeemedSat: 1_000,
+		SessionID:   "oor-session",
+	}
+	service := newTestSwapClientService(fakeClient)
+	defer service.cancel()
+
+	resp, err := service.RedeemCredit(
+		t.Context(), &swapclientrpc.RedeemCreditRequest{
+			IdempotencyKey:    "idem-redeem",
+			AmountSat:         1_000,
+			DestinationPubkey: []byte{1, 2, 3},
+		},
+	)
 	require.NoError(t, err)
-	require.Equal(t, uint64(546), amount)
+	require.Equal(t, 1, fakeClient.redeemCreditCalls)
+	require.Equal(
+		t, "idem-redeem", fakeClient.redeemCreditReq.IdempotencyKey,
+	)
+	require.Equal(t, uint64(1_000), fakeClient.redeemCreditReq.AmountSat)
+	require.Equal(
+		t, []byte{1, 2, 3},
+		fakeClient.redeemCreditReq.DestinationPubKey,
+	)
+	require.Equal(t, "cr_redeem", resp.GetOperationId())
+	require.Equal(t, uint64(1_000), resp.GetDebitedSat())
+	require.Equal(t, uint64(1_000), resp.GetRedeemedSat())
+	require.Equal(t, "oor-session", resp.GetSessionId())
+}
+
+func TestListCreditsReturnsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	hash := testHash(51)
+	createdAt := time.Now()
+	fakeClient := newFakeSwapRuntime()
+	fakeClient.listCreditsResp = &swaps.CreditSnapshot{
+		FinalizedSat: 10_000,
+		ReservedSat:  3_000,
+		AvailableSat: 7_000,
+		Operations: []swaps.CreditOperation{{
+			OperationID: "cr_pay",
+			Type:        swaps.CreditOperationPay,
+			State:       swaps.CreditStateDebited,
+			AmountSat:   3_000,
+			PaymentHash: &hash,
+			DestinationKey: []byte{
+				4,
+				5,
+				6,
+			},
+			CreatedAt: createdAt,
+			UpdatedAt: createdAt,
+		}},
+		LedgerEntries: []swaps.CreditLedgerEntry{{
+			EntryID:     "cle_1",
+			OperationID: "cr_pay",
+			Direction:   "debit",
+			AmountSat:   3_000,
+			CreatedAt:   createdAt,
+		}},
+	}
+	service := newTestSwapClientService(fakeClient)
+	defer service.cancel()
+
+	resp, err := service.ListCredits(
+		t.Context(), &swapclientrpc.ListCreditsRequest{
+			Limit: 10,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, fakeClient.listCreditsCalls)
+	require.Equal(t, uint32(10), fakeClient.listCreditsLimit)
+	require.Equal(t, uint64(7_000), resp.GetAvailableSat())
+	require.Len(t, resp.GetOperations(), 1)
+	require.Equal(t, "cr_pay", resp.GetOperations()[0].GetOperationId())
+	require.Equal(
+		t, hex.EncodeToString(hash[:]),
+		resp.GetOperations()[0].GetPaymentHash(),
+	)
+	require.Len(t, resp.GetLedgerEntries(), 1)
+	require.Equal(t, "cle_1", resp.GetLedgerEntries()[0].GetEntryId())
 }
 
 func TestResumeSwapValidatesPaymentHashAndDirection(t *testing.T) {
@@ -1023,6 +1132,12 @@ type fakeSwapRuntime struct {
 	quotePayResp        *swaps.InSwapQuote
 	quotePayErr         error
 	startPayErr         error
+	createCreditResp    *swaps.CreditOperation
+	createCreditErr     error
+	redeemCreditResp    *swaps.CreditRedemption
+	redeemCreditErr     error
+	listCreditsResp     *swaps.CreditSnapshot
+	listCreditsErr      error
 
 	quotePayCalls      int
 	quotePayInvoice    string
@@ -1030,6 +1145,12 @@ type fakeSwapRuntime struct {
 	startPayCalls      int
 	startReceiveCalls  int
 	startReceiveMemo   string
+	createCreditCalls  int
+	createCreditReq    swaps.CreateCreditRequest
+	redeemCreditCalls  int
+	redeemCreditReq    swaps.RedeemCreditRequest
+	listCreditsCalls   int
+	listCreditsLimit   uint32
 	getSummaryCalls    int
 	listPendingOnly    []bool
 	payResumeCalls     map[lntypes.Hash]int
@@ -1122,6 +1243,51 @@ func (f *fakeSwapRuntime) ResumeReceiveViaLightning(_ context.Context,
 	f.receiveResumeCh <- hash
 
 	return &fakeReceiveSession{hash: hash}, nil
+}
+
+func (f *fakeSwapRuntime) CreateCredit(_ context.Context,
+	req swaps.CreateCreditRequest) (*swaps.CreditOperation, error) {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.createCreditCalls++
+	f.createCreditReq = req
+	if f.createCreditErr != nil {
+		return nil, f.createCreditErr
+	}
+
+	return f.createCreditResp, nil
+}
+
+func (f *fakeSwapRuntime) RedeemCredit(_ context.Context,
+	req swaps.RedeemCreditRequest) (*swaps.CreditRedemption, error) {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.redeemCreditCalls++
+	f.redeemCreditReq = req
+	if f.redeemCreditErr != nil {
+		return nil, f.redeemCreditErr
+	}
+
+	return f.redeemCreditResp, nil
+}
+
+func (f *fakeSwapRuntime) ListCredits(_ context.Context, limit uint32) (
+	*swaps.CreditSnapshot, error) {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.listCreditsCalls++
+	f.listCreditsLimit = limit
+	if f.listCreditsErr != nil {
+		return nil, f.listCreditsErr
+	}
+
+	return f.listCreditsResp, nil
 }
 
 func (f *fakeSwapRuntime) GetSwapSummary(_ context.Context, hash lntypes.Hash) (

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -75,6 +75,37 @@ func TestResumePendingStartsWorkersAndDedupes(t *testing.T) {
 	require.True(t, fakeClient.sawPendingOnlyList())
 }
 
+// TestResumePendingStartsPaymentIntentBeforePayWorker verifies a restart first
+// resumes the wallet payment-intent runner that may still need to reconcile a
+// credit top-up. The ordinary pay worker must not also drive the same payment
+// hash while the intent runner owns it.
+func TestResumePendingStartsPaymentIntentBeforePayWorker(t *testing.T) {
+	t.Parallel()
+
+	payHash := testHash(40)
+	fakeClient := newFakeSwapRuntime(swaps.SwapSummary{
+		Direction:   swaps.SwapDirectionPay,
+		PaymentHash: payHash,
+		State:       "created",
+		Pending:     true,
+	})
+	fakeClient.pendingPaymentIntents = []swaps.PaymentIntentSummary{
+		{
+			PaymentHash: payHash,
+			State:       swaps.PaymentIntentCreditTopUpSent,
+			Pending:     true,
+		},
+	}
+	service := newTestSwapClientService(fakeClient)
+	defer service.cancel()
+
+	service.resumePending(t.Context())
+	fakeClient.awaitPaymentIntentResume(t, payHash)
+
+	require.Equal(t, 1, fakeClient.paymentIntentResumeCount(payHash))
+	require.Equal(t, 0, fakeClient.payResumeCount(payHash))
+}
+
 // TestResumeSwapConcurrentCallsStartOnePayWorker drives many manual resume RPCs
 // for the same pay swap at the same time. ResumeSwap is allowed to be retried
 // by clients, but it must not create parallel FSM drivers for one payment hash.
@@ -237,6 +268,42 @@ func TestStartPayReturnsSummaryAndStartsWorker(t *testing.T) {
 	fakeClient.awaitPayResume(t, payHash)
 	require.Equal(t, 1, fakeClient.startPayCount())
 	require.Equal(t, 1, fakeClient.payResumeCount(payHash))
+}
+
+// TestStartPayForwardsCreditTopUpBound verifies walletdk's accepted credit
+// funding cap reaches the durable payment runner instead of being discarded by
+// the daemon RPC facade.
+func TestStartPayForwardsCreditTopUpBound(t *testing.T) {
+	t.Parallel()
+
+	payHash := testHash(41)
+	fakeClient := newFakeSwapRuntime(
+		swaps.SwapSummary{
+			Direction:   swaps.SwapDirectionPay,
+			PaymentHash: payHash,
+			State:       "created",
+			Pending:     true,
+			AmountSat:   1,
+			MaxFeeSat:   25,
+		},
+	)
+	fakeClient.startPaySession = &fakePaySession{hash: payHash}
+	service := newTestSwapClientService(fakeClient)
+	defer service.cancel()
+
+	_, err := service.StartPay(
+		t.Context(), &swapclientrpc.StartPayRequest{
+			Invoice:           "lnbc1credit",
+			MaxFeeSat:         25,
+			MaxCreditSat:      1,
+			MaxCreditTopupSat: 1_000,
+		},
+	)
+	require.NoError(t, err)
+
+	creditSat, topUpSat := fakeClient.startPayCreditBounds()
+	require.Equal(t, uint64(1), creditSat)
+	require.Equal(t, uint64(1_000), topUpSat)
 }
 
 // TestQuotePayReturnsRemotePreview verifies the local swap client RPC exposes
@@ -1125,7 +1192,8 @@ func testSwapPayInvoice(t *testing.T, amountSat btcutil.Amount) string {
 type fakeSwapRuntime struct {
 	mu sync.Mutex
 
-	summaries []swaps.SwapSummary
+	summaries             []swaps.SwapSummary
+	pendingPaymentIntents []swaps.PaymentIntentSummary
 
 	startPaySession     paySwapSession
 	startReceiveSession receiveSwapSession
@@ -1139,34 +1207,42 @@ type fakeSwapRuntime struct {
 	listCreditsResp     *swaps.CreditSnapshot
 	listCreditsErr      error
 
-	quotePayCalls      int
-	quotePayInvoice    string
-	quotePayMaxFeeSat  uint64
-	startPayCalls      int
-	startReceiveCalls  int
-	startReceiveMemo   string
-	createCreditCalls  int
-	createCreditReq    swaps.CreateCreditRequest
-	redeemCreditCalls  int
-	redeemCreditReq    swaps.RedeemCreditRequest
-	listCreditsCalls   int
-	listCreditsLimit   uint32
-	getSummaryCalls    int
-	listPendingOnly    []bool
-	payResumeCalls     map[lntypes.Hash]int
-	receiveResumeCalls map[lntypes.Hash]int
+	quotePayCalls               int
+	quotePayInvoice             string
+	quotePayMaxFeeSat           uint64
+	quotePayMaxCreditSat        uint64
+	startPayCalls               int
+	startPayMaxCreditSat        uint64
+	startPayMaxCreditTopUpSat   uint64
+	startReceiveCalls           int
+	startReceiveMemo            string
+	paymentIntentResumeCalls    map[lntypes.Hash]int
+	createCreditCalls           int
+	createCreditReq             swaps.CreateCreditRequest
+	redeemCreditCalls           int
+	redeemCreditReq             swaps.RedeemCreditRequest
+	listCreditsCalls            int
+	listCreditsLimit            uint32
+	getSummaryCalls             int
+	listPendingOnly             []bool
+	listPendingPaymentIntentHit int
+	payResumeCalls              map[lntypes.Hash]int
+	receiveResumeCalls          map[lntypes.Hash]int
 
-	payResumeCh     chan lntypes.Hash
-	receiveResumeCh chan lntypes.Hash
+	payResumeCh           chan lntypes.Hash
+	receiveResumeCh       chan lntypes.Hash
+	paymentIntentResumeCh chan lntypes.Hash
 }
 
 func newFakeSwapRuntime(summaries ...swaps.SwapSummary) *fakeSwapRuntime {
 	return &fakeSwapRuntime{
-		summaries:          summaries,
-		payResumeCalls:     make(map[lntypes.Hash]int),
-		receiveResumeCalls: make(map[lntypes.Hash]int),
-		payResumeCh:        make(chan lntypes.Hash, 8),
-		receiveResumeCh:    make(chan lntypes.Hash, 8),
+		summaries:                summaries,
+		paymentIntentResumeCalls: make(map[lntypes.Hash]int),
+		payResumeCalls:           make(map[lntypes.Hash]int),
+		receiveResumeCalls:       make(map[lntypes.Hash]int),
+		payResumeCh:              make(chan lntypes.Hash, 8),
+		receiveResumeCh:          make(chan lntypes.Hash, 8),
+		paymentIntentResumeCh:    make(chan lntypes.Hash, 8),
 	}
 }
 
@@ -1189,13 +1265,46 @@ func (f *fakeSwapRuntime) QuotePayViaLightning(_ context.Context,
 	return f.quotePayResp, nil
 }
 
+func (f *fakeSwapRuntime) QuotePayViaLightningWithCredits(
+	ctx context.Context, invoice string, maxFeeSat uint64,
+	maxCreditSat uint64) (*swaps.InSwapQuote, error) {
+
+	f.mu.Lock()
+	f.quotePayMaxCreditSat = maxCreditSat
+	f.mu.Unlock()
+
+	return f.QuotePayViaLightning(ctx, invoice, maxFeeSat)
+}
+
 func (f *fakeSwapRuntime) StartPayViaLightning(context.Context, string,
 	uint64) (paySwapSession, error) {
+
+	return f.startPay(0, 0)
+}
+
+func (f *fakeSwapRuntime) StartPayViaLightningWithCredits(
+	_ context.Context, _ string, _ uint64, maxCreditSat uint64) (
+	paySwapSession, error) {
+
+	return f.startPay(maxCreditSat, 0)
+}
+
+func (f *fakeSwapRuntime) StartPayViaLightningWithCreditTopUp(
+	_ context.Context, _ string, _ uint64, maxCreditSat uint64,
+	maxCreditTopUpSat uint64) (paySwapSession, error) {
+
+	return f.startPay(maxCreditSat, maxCreditTopUpSat)
+}
+
+func (f *fakeSwapRuntime) startPay(maxCreditSat uint64,
+	maxCreditTopUpSat uint64) (paySwapSession, error) {
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	f.startPayCalls++
+	f.startPayMaxCreditSat = maxCreditSat
+	f.startPayMaxCreditTopUpSat = maxCreditTopUpSat
 	if f.startPayErr != nil {
 		return nil, f.startPayErr
 	}
@@ -1204,6 +1313,33 @@ func (f *fakeSwapRuntime) StartPayViaLightning(context.Context, string,
 	}
 
 	return f.startPaySession, nil
+}
+
+func (f *fakeSwapRuntime) ResumePaymentIntent(_ context.Context,
+	hash lntypes.Hash) (paySwapSession, error) {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.paymentIntentResumeCalls[hash]++
+	f.paymentIntentResumeCh <- hash
+
+	return &fakePaySession{hash: hash}, nil
+}
+
+func (f *fakeSwapRuntime) ListPendingPaymentIntents(_ context.Context) (
+	[]swaps.PaymentIntentSummary, error) {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.listPendingPaymentIntentHit++
+	intents := make(
+		[]swaps.PaymentIntentSummary, len(f.pendingPaymentIntents),
+	)
+	copy(intents, f.pendingPaymentIntents)
+
+	return intents, nil
 }
 
 func (f *fakeSwapRuntime) StartReceiveViaLightning(_ context.Context,
@@ -1350,11 +1486,32 @@ func (f *fakeSwapRuntime) awaitReceiveResume(t *testing.T, hash lntypes.Hash) {
 	}
 }
 
+func (f *fakeSwapRuntime) awaitPaymentIntentResume(t *testing.T,
+	hash lntypes.Hash) {
+
+	t.Helper()
+
+	select {
+	case got := <-f.paymentIntentResumeCh:
+		require.Equal(t, hash, got)
+
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for payment intent resume")
+	}
+}
+
 func (f *fakeSwapRuntime) startPayCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	return f.startPayCalls
+}
+
+func (f *fakeSwapRuntime) startPayCreditBounds() (uint64, uint64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.startPayMaxCreditSat, f.startPayMaxCreditTopUpSat
 }
 
 func (f *fakeSwapRuntime) startReceiveCount() int {
@@ -1376,6 +1533,13 @@ func (f *fakeSwapRuntime) receiveResumeCount(hash lntypes.Hash) int {
 	defer f.mu.Unlock()
 
 	return f.receiveResumeCalls[hash]
+}
+
+func (f *fakeSwapRuntime) paymentIntentResumeCount(hash lntypes.Hash) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.paymentIntentResumeCalls[hash]
 }
 
 func (f *fakeSwapRuntime) sawPendingOnlyList() bool {

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -34,6 +34,12 @@ const (
 	// SETTLEMENT_TYPE_IN_ARK means sender and receiver settle with one Ark
 	// vHTLC inside the same Ark instance.
 	SettlementType_SETTLEMENT_TYPE_IN_ARK SettlementType = 2
+	// SETTLEMENT_TYPE_CREDIT means the swap server pays Lightning from a
+	// reserved credit balance without requiring a client-funded vHTLC.
+	SettlementType_SETTLEMENT_TYPE_CREDIT SettlementType = 3
+	// SETTLEMENT_TYPE_MIXED means the invoice is funded by both a vHTLC and
+	// a reserved credit balance.
+	SettlementType_SETTLEMENT_TYPE_MIXED SettlementType = 4
 )
 
 // Enum value maps for SettlementType.
@@ -42,11 +48,15 @@ var (
 		0: "SETTLEMENT_TYPE_UNSPECIFIED",
 		1: "SETTLEMENT_TYPE_LIGHTNING",
 		2: "SETTLEMENT_TYPE_IN_ARK",
+		3: "SETTLEMENT_TYPE_CREDIT",
+		4: "SETTLEMENT_TYPE_MIXED",
 	}
 	SettlementType_value = map[string]int32{
 		"SETTLEMENT_TYPE_UNSPECIFIED": 0,
 		"SETTLEMENT_TYPE_LIGHTNING":   1,
 		"SETTLEMENT_TYPE_IN_ARK":      2,
+		"SETTLEMENT_TYPE_CREDIT":      3,
+		"SETTLEMENT_TYPE_MIXED":       4,
 	}
 )
 
@@ -77,6 +87,190 @@ func (SettlementType) EnumDescriptor() ([]byte, []int) {
 	return file_swap_proto_rawDescGZIP(), []int{0}
 }
 
+// CreditFundingSource identifies how value enters a credit account.
+type CreditFundingSource int32
+
+const (
+	CreditFundingSource_CREDIT_FUNDING_SOURCE_UNSPECIFIED       CreditFundingSource = 0
+	CreditFundingSource_CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE CreditFundingSource = 1
+	CreditFundingSource_CREDIT_FUNDING_SOURCE_ARK_TOPUP         CreditFundingSource = 2
+)
+
+// Enum value maps for CreditFundingSource.
+var (
+	CreditFundingSource_name = map[int32]string{
+		0: "CREDIT_FUNDING_SOURCE_UNSPECIFIED",
+		1: "CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE",
+		2: "CREDIT_FUNDING_SOURCE_ARK_TOPUP",
+	}
+	CreditFundingSource_value = map[string]int32{
+		"CREDIT_FUNDING_SOURCE_UNSPECIFIED":       0,
+		"CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE": 1,
+		"CREDIT_FUNDING_SOURCE_ARK_TOPUP":         2,
+	}
+)
+
+func (x CreditFundingSource) Enum() *CreditFundingSource {
+	p := new(CreditFundingSource)
+	*p = x
+	return p
+}
+
+func (x CreditFundingSource) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CreditFundingSource) Descriptor() protoreflect.EnumDescriptor {
+	return file_swap_proto_enumTypes[1].Descriptor()
+}
+
+func (CreditFundingSource) Type() protoreflect.EnumType {
+	return &file_swap_proto_enumTypes[1]
+}
+
+func (x CreditFundingSource) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CreditFundingSource.Descriptor instead.
+func (CreditFundingSource) EnumDescriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{1}
+}
+
+// CreditOperationType identifies the durable credit state machine family.
+type CreditOperationType int32
+
+const (
+	CreditOperationType_CREDIT_OPERATION_TYPE_UNSPECIFIED CreditOperationType = 0
+	CreditOperationType_CREDIT_OPERATION_TYPE_FUNDING     CreditOperationType = 1
+	CreditOperationType_CREDIT_OPERATION_TYPE_PAY         CreditOperationType = 2
+	CreditOperationType_CREDIT_OPERATION_TYPE_REDEMPTION  CreditOperationType = 3
+	CreditOperationType_CREDIT_OPERATION_TYPE_RECEIVE     CreditOperationType = 4
+)
+
+// Enum value maps for CreditOperationType.
+var (
+	CreditOperationType_name = map[int32]string{
+		0: "CREDIT_OPERATION_TYPE_UNSPECIFIED",
+		1: "CREDIT_OPERATION_TYPE_FUNDING",
+		2: "CREDIT_OPERATION_TYPE_PAY",
+		3: "CREDIT_OPERATION_TYPE_REDEMPTION",
+		4: "CREDIT_OPERATION_TYPE_RECEIVE",
+	}
+	CreditOperationType_value = map[string]int32{
+		"CREDIT_OPERATION_TYPE_UNSPECIFIED": 0,
+		"CREDIT_OPERATION_TYPE_FUNDING":     1,
+		"CREDIT_OPERATION_TYPE_PAY":         2,
+		"CREDIT_OPERATION_TYPE_REDEMPTION":  3,
+		"CREDIT_OPERATION_TYPE_RECEIVE":     4,
+	}
+)
+
+func (x CreditOperationType) Enum() *CreditOperationType {
+	p := new(CreditOperationType)
+	*p = x
+	return p
+}
+
+func (x CreditOperationType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CreditOperationType) Descriptor() protoreflect.EnumDescriptor {
+	return file_swap_proto_enumTypes[2].Descriptor()
+}
+
+func (CreditOperationType) Type() protoreflect.EnumType {
+	return &file_swap_proto_enumTypes[2]
+}
+
+func (x CreditOperationType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CreditOperationType.Descriptor instead.
+func (CreditOperationType) EnumDescriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{2}
+}
+
+// CreditOperationState is the externally visible state of one credit
+// operation.
+type CreditOperationState int32
+
+const (
+	CreditOperationState_CREDIT_OPERATION_STATE_UNSPECIFIED      CreditOperationState = 0
+	CreditOperationState_CREDIT_OPERATION_STATE_CREATED          CreditOperationState = 1
+	CreditOperationState_CREDIT_OPERATION_STATE_AWAITING_PAYMENT CreditOperationState = 2
+	CreditOperationState_CREDIT_OPERATION_STATE_CREDITED         CreditOperationState = 3
+	CreditOperationState_CREDIT_OPERATION_STATE_RESERVED         CreditOperationState = 4
+	CreditOperationState_CREDIT_OPERATION_STATE_PAYING_LIGHTNING CreditOperationState = 5
+	CreditOperationState_CREDIT_OPERATION_STATE_DEBITED          CreditOperationState = 6
+	CreditOperationState_CREDIT_OPERATION_STATE_SENDING_OOR      CreditOperationState = 7
+	CreditOperationState_CREDIT_OPERATION_STATE_REDEEMED         CreditOperationState = 8
+	CreditOperationState_CREDIT_OPERATION_STATE_RELEASED         CreditOperationState = 9
+	CreditOperationState_CREDIT_OPERATION_STATE_EXPIRED          CreditOperationState = 10
+	CreditOperationState_CREDIT_OPERATION_STATE_FAILED           CreditOperationState = 11
+)
+
+// Enum value maps for CreditOperationState.
+var (
+	CreditOperationState_name = map[int32]string{
+		0:  "CREDIT_OPERATION_STATE_UNSPECIFIED",
+		1:  "CREDIT_OPERATION_STATE_CREATED",
+		2:  "CREDIT_OPERATION_STATE_AWAITING_PAYMENT",
+		3:  "CREDIT_OPERATION_STATE_CREDITED",
+		4:  "CREDIT_OPERATION_STATE_RESERVED",
+		5:  "CREDIT_OPERATION_STATE_PAYING_LIGHTNING",
+		6:  "CREDIT_OPERATION_STATE_DEBITED",
+		7:  "CREDIT_OPERATION_STATE_SENDING_OOR",
+		8:  "CREDIT_OPERATION_STATE_REDEEMED",
+		9:  "CREDIT_OPERATION_STATE_RELEASED",
+		10: "CREDIT_OPERATION_STATE_EXPIRED",
+		11: "CREDIT_OPERATION_STATE_FAILED",
+	}
+	CreditOperationState_value = map[string]int32{
+		"CREDIT_OPERATION_STATE_UNSPECIFIED":      0,
+		"CREDIT_OPERATION_STATE_CREATED":          1,
+		"CREDIT_OPERATION_STATE_AWAITING_PAYMENT": 2,
+		"CREDIT_OPERATION_STATE_CREDITED":         3,
+		"CREDIT_OPERATION_STATE_RESERVED":         4,
+		"CREDIT_OPERATION_STATE_PAYING_LIGHTNING": 5,
+		"CREDIT_OPERATION_STATE_DEBITED":          6,
+		"CREDIT_OPERATION_STATE_SENDING_OOR":      7,
+		"CREDIT_OPERATION_STATE_REDEEMED":         8,
+		"CREDIT_OPERATION_STATE_RELEASED":         9,
+		"CREDIT_OPERATION_STATE_EXPIRED":          10,
+		"CREDIT_OPERATION_STATE_FAILED":           11,
+	}
+)
+
+func (x CreditOperationState) Enum() *CreditOperationState {
+	p := new(CreditOperationState)
+	*p = x
+	return p
+}
+
+func (x CreditOperationState) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CreditOperationState) Descriptor() protoreflect.EnumDescriptor {
+	return file_swap_proto_enumTypes[3].Descriptor()
+}
+
+func (CreditOperationState) Type() protoreflect.EnumType {
+	return &file_swap_proto_enumTypes[3]
+}
+
+func (x CreditOperationState) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CreditOperationState.Descriptor instead.
+func (CreditOperationState) EnumDescriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{3}
+}
+
 // RequestChannelIdRequest starts one Lightning-to-Ark receive negotiation.
 type RequestChannelIdRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -90,11 +284,8 @@ type RequestChannelIdRequest struct {
 	// with client_vhtlc_pubkey to derive a unique virtual channel ID without
 	// adding a separate auth identity.
 	PaymentHash []byte `protobuf:"bytes,3,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
-	// amount_msat is the exact amount the Ark receiver expects to receive,
-	// expressed in millisatoshis. The swap server's out-swap fee is charged to
-	// the Lightning payer through the route hint and does not reduce this
-	// amount.
-	AmountMsat    uint64 `protobuf:"varint,4,opt,name=amount_msat,json=amountMsat,proto3" json:"amount_msat,omitempty"`
+	// amount_sat is the exact invoice amount the payer should send.
+	AmountSat     uint64 `protobuf:"varint,4,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -150,9 +341,9 @@ func (x *RequestChannelIdRequest) GetPaymentHash() []byte {
 	return nil
 }
 
-func (x *RequestChannelIdRequest) GetAmountMsat() uint64 {
+func (x *RequestChannelIdRequest) GetAmountSat() uint64 {
 	if x != nil {
-		return x.AmountMsat
+		return x.AmountSat
 	}
 	return 0
 }
@@ -164,10 +355,26 @@ type RequestChannelIdResponse struct {
 	RouteHint *RouteHint `protobuf:"bytes,1,opt,name=route_hint,json=routeHint,proto3" json:"route_hint,omitempty"`
 	// payer_fee_msat is the quoted Lightning route fee paid by the sender for
 	// the swap server's virtual hop. Callers that want a "payer pays" total
-	// compute it as amount_msat plus payer_fee_msat.
-	PayerFeeMsat  uint64 `protobuf:"varint,2,opt,name=payer_fee_msat,json=payerFeeMsat,proto3" json:"payer_fee_msat,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// compute it as amount_sat*1000 plus payer_fee_msat.
+	PayerFeeMsat uint64 `protobuf:"varint,2,opt,name=payer_fee_msat,json=payerFeeMsat,proto3" json:"payer_fee_msat,omitempty"`
+	// requested_amount_sat is the invoice amount requested by the receiver.
+	RequestedAmountSat uint64 `protobuf:"varint,3,opt,name=requested_amount_sat,json=requestedAmountSat,proto3" json:"requested_amount_sat,omitempty"`
+	// available_credit_sat is the credit balance considered for the receive
+	// plan at route creation time.
+	AvailableCreditSat uint64 `protobuf:"varint,4,opt,name=available_credit_sat,json=availableCreditSat,proto3" json:"available_credit_sat,omitempty"`
+	// attached_credit_sat is the credit amount the server reserved and will
+	// add to the funded vHTLC.
+	AttachedCreditSat uint64 `protobuf:"varint,5,opt,name=attached_credit_sat,json=attachedCreditSat,proto3" json:"attached_credit_sat,omitempty"`
+	// vhtlc_amount_sat is the Ark vHTLC output amount the client should
+	// expect if this route is paid.
+	VhtlcAmountSat uint64 `protobuf:"varint,6,opt,name=vhtlc_amount_sat,json=vhtlcAmountSat,proto3" json:"vhtlc_amount_sat,omitempty"`
+	// dust_limit_sat is the minimum Ark vHTLC amount used for this decision.
+	DustLimitSat uint64 `protobuf:"varint,7,opt,name=dust_limit_sat,json=dustLimitSat,proto3" json:"dust_limit_sat,omitempty"`
+	// settlement_type identifies whether the route is normal Lightning or
+	// credit-assisted.
+	SettlementType SettlementType `protobuf:"varint,8,opt,name=settlement_type,json=settlementType,proto3,enum=swaprpc.SettlementType" json:"settlement_type,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *RequestChannelIdResponse) Reset() {
@@ -212,6 +419,48 @@ func (x *RequestChannelIdResponse) GetPayerFeeMsat() uint64 {
 		return x.PayerFeeMsat
 	}
 	return 0
+}
+
+func (x *RequestChannelIdResponse) GetRequestedAmountSat() uint64 {
+	if x != nil {
+		return x.RequestedAmountSat
+	}
+	return 0
+}
+
+func (x *RequestChannelIdResponse) GetAvailableCreditSat() uint64 {
+	if x != nil {
+		return x.AvailableCreditSat
+	}
+	return 0
+}
+
+func (x *RequestChannelIdResponse) GetAttachedCreditSat() uint64 {
+	if x != nil {
+		return x.AttachedCreditSat
+	}
+	return 0
+}
+
+func (x *RequestChannelIdResponse) GetVhtlcAmountSat() uint64 {
+	if x != nil {
+		return x.VhtlcAmountSat
+	}
+	return 0
+}
+
+func (x *RequestChannelIdResponse) GetDustLimitSat() uint64 {
+	if x != nil {
+		return x.DustLimitSat
+	}
+	return 0
+}
+
+func (x *RequestChannelIdResponse) GetSettlementType() SettlementType {
+	if x != nil {
+		return x.SettlementType
+	}
+	return SettlementType_SETTLEMENT_TYPE_UNSPECIFIED
 }
 
 // AcknowledgeOutSwapHtlcRequest confirms that the receiver has validated and
@@ -318,7 +567,7 @@ type OutSwapHtlcEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// payment_hash is the intercepted HTLC hash.
 	PaymentHash []byte `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
-	// amount_sat is the whole-satoshi amount funded in the vHTLC.
+	// amount_sat is the sat-denominated amount funded in the vHTLC.
 	AmountSat uint64 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
 	// onion_blob is the raw next-hop onion blob delivered by LND.
 	OnionBlob []byte `protobuf:"bytes,3,opt,name=onion_blob,json=onionBlob,proto3" json:"onion_blob,omitempty"`
@@ -328,11 +577,15 @@ type OutSwapHtlcEvent struct {
 	// parts lists the individual HTLC shards that make up a multi-part
 	// payment set. When empty the event describes a legacy single-part
 	// payment carried by onion_blob. When populated, amount_sat is still
-	// the whole-satoshi total funded in the vHTLC and onion_blob mirrors
+	// the sat-denominated total funded in the vHTLC and onion_blob mirrors
 	// the first part for backwards compatibility.
-	Parts         []*OutSwapHtlcPart `protobuf:"bytes,5,rep,name=parts,proto3" json:"parts,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Parts []*OutSwapHtlcPart `protobuf:"bytes,5,rep,name=parts,proto3" json:"parts,omitempty"`
+	// requested_amount_sat is the Lightning invoice amount paid by the payer.
+	RequestedAmountSat uint64 `protobuf:"varint,6,opt,name=requested_amount_sat,json=requestedAmountSat,proto3" json:"requested_amount_sat,omitempty"`
+	// attached_credit_sat is the reserved credit amount added to the vHTLC.
+	AttachedCreditSat uint64 `protobuf:"varint,7,opt,name=attached_credit_sat,json=attachedCreditSat,proto3" json:"attached_credit_sat,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *OutSwapHtlcEvent) Reset() {
@@ -398,6 +651,20 @@ func (x *OutSwapHtlcEvent) GetParts() []*OutSwapHtlcPart {
 		return x.Parts
 	}
 	return nil
+}
+
+func (x *OutSwapHtlcEvent) GetRequestedAmountSat() uint64 {
+	if x != nil {
+		return x.RequestedAmountSat
+	}
+	return 0
+}
+
+func (x *OutSwapHtlcEvent) GetAttachedCreditSat() uint64 {
+	if x != nil {
+		return x.AttachedCreditSat
+	}
+	return 0
 }
 
 // OutSwapHtlcPart describes one HTLC shard of a multi-part out-swap payment
@@ -573,7 +840,7 @@ type InArkHtlcEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// payment_hash is the invoice payment hash.
 	PaymentHash []byte `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
-	// amount_sat is the whole-satoshi amount funded in the vHTLC.
+	// amount_sat is the sat-denominated amount funded in the vHTLC.
 	AmountSat uint64 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
 	// sender_pubkey is the payment sender's public key used in the vHTLC
 	// refund paths.
@@ -841,8 +1108,14 @@ type CreateInSwapRequest struct {
 	// client_vhtlc_pubkey is the client's public key used in the vHTLC spend
 	// paths.
 	ClientVhtlcPubkey []byte `protobuf:"bytes,3,opt,name=client_vhtlc_pubkey,json=clientVhtlcPubkey,proto3" json:"client_vhtlc_pubkey,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// account_pubkey identifies the wallet credit account to inspect or
+	// reserve from when credit funding is allowed.
+	AccountPubkey []byte `protobuf:"bytes,4,opt,name=account_pubkey,json=accountPubkey,proto3" json:"account_pubkey,omitempty"`
+	// max_credit_sat is the maximum credit amount the caller authorizes this
+	// payment to reserve. Zero means credit use is not allowed.
+	MaxCreditSat  uint64 `protobuf:"varint,5,opt,name=max_credit_sat,json=maxCreditSat,proto3" json:"max_credit_sat,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateInSwapRequest) Reset() {
@@ -896,6 +1169,20 @@ func (x *CreateInSwapRequest) GetClientVhtlcPubkey() []byte {
 	return nil
 }
 
+func (x *CreateInSwapRequest) GetAccountPubkey() []byte {
+	if x != nil {
+		return x.AccountPubkey
+	}
+	return nil
+}
+
+func (x *CreateInSwapRequest) GetMaxCreditSat() uint64 {
+	if x != nil {
+		return x.MaxCreditSat
+	}
+	return 0
+}
+
 // CreateInSwapResponse returns the negotiated parameters for one in-swap.
 type CreateInSwapResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -914,8 +1201,13 @@ type CreateInSwapResponse struct {
 	// settlement_type identifies whether this negotiation should be completed
 	// through Lightning or directly inside the Ark instance.
 	SettlementType SettlementType `protobuf:"varint,7,opt,name=settlement_type,json=settlementType,proto3,enum=swaprpc.SettlementType" json:"settlement_type,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// credit_quote describes any credit reservation attached to this pay.
+	CreditQuote *CreditQuote `protobuf:"bytes,8,opt,name=credit_quote,json=creditQuote,proto3" json:"credit_quote,omitempty"`
+	// preimage is set for credit-only pays after the swap server has already
+	// paid the Lightning invoice from reserved credits.
+	Preimage      []byte `protobuf:"bytes,9,opt,name=preimage,proto3" json:"preimage,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateInSwapResponse) Reset() {
@@ -997,6 +1289,20 @@ func (x *CreateInSwapResponse) GetSettlementType() SettlementType {
 	return SettlementType_SETTLEMENT_TYPE_UNSPECIFIED
 }
 
+func (x *CreateInSwapResponse) GetCreditQuote() *CreditQuote {
+	if x != nil {
+		return x.CreditQuote
+	}
+	return nil
+}
+
+func (x *CreateInSwapResponse) GetPreimage() []byte {
+	if x != nil {
+		return x.Preimage
+	}
+	return nil
+}
+
 // QuoteInSwapRequest previews one Ark-to-Lightning invoice send.
 type QuoteInSwapRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1004,7 +1310,14 @@ type QuoteInSwapRequest struct {
 	Invoice string `protobuf:"bytes,1,opt,name=invoice,proto3" json:"invoice,omitempty"`
 	// max_fee_sat is the caller's fee cap. Quotes still return when the
 	// computed server fee exceeds this cap so callers can render the fee.
-	MaxFeeSat     uint64 `protobuf:"varint,2,opt,name=max_fee_sat,json=maxFeeSat,proto3" json:"max_fee_sat,omitempty"`
+	MaxFeeSat uint64 `protobuf:"varint,2,opt,name=max_fee_sat,json=maxFeeSat,proto3" json:"max_fee_sat,omitempty"`
+	// account_pubkey identifies the wallet credit account to inspect. Empty
+	// means the quote ignores credits.
+	AccountPubkey []byte `protobuf:"bytes,3,opt,name=account_pubkey,json=accountPubkey,proto3" json:"account_pubkey,omitempty"`
+	// max_credit_sat is the maximum credit amount the caller is willing to
+	// use. Zero means the quote reports whether credits are required but does
+	// not apply optional credits.
+	MaxCreditSat  uint64 `protobuf:"varint,4,opt,name=max_credit_sat,json=maxCreditSat,proto3" json:"max_credit_sat,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1053,12 +1366,27 @@ func (x *QuoteInSwapRequest) GetMaxFeeSat() uint64 {
 	return 0
 }
 
+func (x *QuoteInSwapRequest) GetAccountPubkey() []byte {
+	if x != nil {
+		return x.AccountPubkey
+	}
+	return nil
+}
+
+func (x *QuoteInSwapRequest) GetMaxCreditSat() uint64 {
+	if x != nil {
+		return x.MaxCreditSat
+	}
+	return 0
+}
+
 // QuoteInSwapResponse returns the non-binding preview for one invoice send.
 type QuoteInSwapResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// payment_hash is the SHA-256 payment hash extracted from the invoice.
 	PaymentHash []byte `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
-	// invoice_amount_sat is the whole-satoshi amount requested by the invoice.
+	// invoice_amount_sat is the sat-denominated amount requested by the
+	// invoice.
 	InvoiceAmountSat uint64 `protobuf:"varint,2,opt,name=invoice_amount_sat,json=invoiceAmountSat,proto3" json:"invoice_amount_sat,omitempty"`
 	// amount_sat is the total amount that would be locked in the vHTLC.
 	AmountSat uint64 `protobuf:"varint,3,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
@@ -1072,6 +1400,8 @@ type QuoteInSwapResponse struct {
 	// exceeds_max_fee is true when max_fee_sat is non-zero and fee_sat is
 	// larger than that cap.
 	ExceedsMaxFee bool `protobuf:"varint,7,opt,name=exceeds_max_fee,json=exceedsMaxFee,proto3" json:"exceeds_max_fee,omitempty"`
+	// credit_quote describes how credits would be used for this invoice.
+	CreditQuote   *CreditQuote `protobuf:"bytes,8,opt,name=credit_quote,json=creditQuote,proto3" json:"credit_quote,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1155,6 +1485,757 @@ func (x *QuoteInSwapResponse) GetExceedsMaxFee() bool {
 	return false
 }
 
+func (x *QuoteInSwapResponse) GetCreditQuote() *CreditQuote {
+	if x != nil {
+		return x.CreditQuote
+	}
+	return nil
+}
+
+// CreditQuote describes the credit component of a pay quote.
+type CreditQuote struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// must_use_credit is true when the invoice amount cannot be represented by
+	// the normal vHTLC path.
+	MustUseCredit bool `protobuf:"varint,1,opt,name=must_use_credit,json=mustUseCredit,proto3" json:"must_use_credit,omitempty"`
+	// credit_applied_sat is the credit amount the quote expects to reserve.
+	CreditAppliedSat uint64 `protobuf:"varint,2,opt,name=credit_applied_sat,json=creditAppliedSat,proto3" json:"credit_applied_sat,omitempty"`
+	// credit_shortfall_sat is the additional credit needed before this
+	// payment can be admitted.
+	CreditShortfallSat uint64 `protobuf:"varint,3,opt,name=credit_shortfall_sat,json=creditShortfallSat,proto3" json:"credit_shortfall_sat,omitempty"`
+	// credit_topup_sat is the Ark top-up amount required to cover the
+	// shortfall. It is rounded up and dust-limited by the server.
+	CreditTopupSat uint64 `protobuf:"varint,4,opt,name=credit_topup_sat,json=creditTopupSat,proto3" json:"credit_topup_sat,omitempty"`
+	// ark_funding_sat is the amount the client must still fund through the
+	// normal vHTLC path.
+	ArkFundingSat uint64 `protobuf:"varint,5,opt,name=ark_funding_sat,json=arkFundingSat,proto3" json:"ark_funding_sat,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreditQuote) Reset() {
+	*x = CreditQuote{}
+	mi := &file_swap_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreditQuote) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreditQuote) ProtoMessage() {}
+
+func (x *CreditQuote) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreditQuote.ProtoReflect.Descriptor instead.
+func (*CreditQuote) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *CreditQuote) GetMustUseCredit() bool {
+	if x != nil {
+		return x.MustUseCredit
+	}
+	return false
+}
+
+func (x *CreditQuote) GetCreditAppliedSat() uint64 {
+	if x != nil {
+		return x.CreditAppliedSat
+	}
+	return 0
+}
+
+func (x *CreditQuote) GetCreditShortfallSat() uint64 {
+	if x != nil {
+		return x.CreditShortfallSat
+	}
+	return 0
+}
+
+func (x *CreditQuote) GetCreditTopupSat() uint64 {
+	if x != nil {
+		return x.CreditTopupSat
+	}
+	return 0
+}
+
+func (x *CreditQuote) GetArkFundingSat() uint64 {
+	if x != nil {
+		return x.ArkFundingSat
+	}
+	return 0
+}
+
+type CreateCreditRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// account_pubkey identifies the wallet credit account.
+	AccountPubkey []byte `protobuf:"bytes,1,opt,name=account_pubkey,json=accountPubkey,proto3" json:"account_pubkey,omitempty"`
+	// idempotency_key identifies one caller intent across retries.
+	IdempotencyKey string              `protobuf:"bytes,2,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
+	Source         CreditFundingSource `protobuf:"varint,3,opt,name=source,proto3,enum=swaprpc.CreditFundingSource" json:"source,omitempty"`
+	// amount_sat is the credit amount to create.
+	AmountSat uint64 `protobuf:"varint,4,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// memo is embedded into server-owned Lightning receive invoices when the
+	// source is LIGHTNING_RECEIVE.
+	Memo          string `protobuf:"bytes,5,opt,name=memo,proto3" json:"memo,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateCreditRequest) Reset() {
+	*x = CreateCreditRequest{}
+	mi := &file_swap_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateCreditRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateCreditRequest) ProtoMessage() {}
+
+func (x *CreateCreditRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateCreditRequest.ProtoReflect.Descriptor instead.
+func (*CreateCreditRequest) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *CreateCreditRequest) GetAccountPubkey() []byte {
+	if x != nil {
+		return x.AccountPubkey
+	}
+	return nil
+}
+
+func (x *CreateCreditRequest) GetIdempotencyKey() string {
+	if x != nil {
+		return x.IdempotencyKey
+	}
+	return ""
+}
+
+func (x *CreateCreditRequest) GetSource() CreditFundingSource {
+	if x != nil {
+		return x.Source
+	}
+	return CreditFundingSource_CREDIT_FUNDING_SOURCE_UNSPECIFIED
+}
+
+func (x *CreateCreditRequest) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *CreateCreditRequest) GetMemo() string {
+	if x != nil {
+		return x.Memo
+	}
+	return ""
+}
+
+type CreateCreditResponse struct {
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	OperationId string                 `protobuf:"bytes,1,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"`
+	State       CreditOperationState   `protobuf:"varint,2,opt,name=state,proto3,enum=swaprpc.CreditOperationState" json:"state,omitempty"`
+	// invoice is set for LIGHTNING_RECEIVE credit funding.
+	Invoice string `protobuf:"bytes,3,opt,name=invoice,proto3" json:"invoice,omitempty"`
+	// payment_hash is set when an invoice-backed operation exists.
+	PaymentHash []byte `protobuf:"bytes,4,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// amount_sat is the sat amount that will be credited when complete.
+	AmountSat uint64 `protobuf:"varint,5,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// destination_pubkey is the server-owned x-only Ark recipient pubkey for
+	// ARK_TOPUP.
+	DestinationPubkey []byte                 `protobuf:"bytes,7,opt,name=destination_pubkey,json=destinationPubkey,proto3" json:"destination_pubkey,omitempty"`
+	ExpiresAt         *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *CreateCreditResponse) Reset() {
+	*x = CreateCreditResponse{}
+	mi := &file_swap_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateCreditResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateCreditResponse) ProtoMessage() {}
+
+func (x *CreateCreditResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateCreditResponse.ProtoReflect.Descriptor instead.
+func (*CreateCreditResponse) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *CreateCreditResponse) GetOperationId() string {
+	if x != nil {
+		return x.OperationId
+	}
+	return ""
+}
+
+func (x *CreateCreditResponse) GetState() CreditOperationState {
+	if x != nil {
+		return x.State
+	}
+	return CreditOperationState_CREDIT_OPERATION_STATE_UNSPECIFIED
+}
+
+func (x *CreateCreditResponse) GetInvoice() string {
+	if x != nil {
+		return x.Invoice
+	}
+	return ""
+}
+
+func (x *CreateCreditResponse) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+func (x *CreateCreditResponse) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *CreateCreditResponse) GetDestinationPubkey() []byte {
+	if x != nil {
+		return x.DestinationPubkey
+	}
+	return nil
+}
+
+func (x *CreateCreditResponse) GetExpiresAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return nil
+}
+
+type RedeemCreditRequest struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	AccountPubkey     []byte                 `protobuf:"bytes,1,opt,name=account_pubkey,json=accountPubkey,proto3" json:"account_pubkey,omitempty"`
+	IdempotencyKey    string                 `protobuf:"bytes,2,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
+	AmountSat         uint64                 `protobuf:"varint,3,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	DestinationPubkey []byte                 `protobuf:"bytes,4,opt,name=destination_pubkey,json=destinationPubkey,proto3" json:"destination_pubkey,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *RedeemCreditRequest) Reset() {
+	*x = RedeemCreditRequest{}
+	mi := &file_swap_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RedeemCreditRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RedeemCreditRequest) ProtoMessage() {}
+
+func (x *RedeemCreditRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RedeemCreditRequest.ProtoReflect.Descriptor instead.
+func (*RedeemCreditRequest) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *RedeemCreditRequest) GetAccountPubkey() []byte {
+	if x != nil {
+		return x.AccountPubkey
+	}
+	return nil
+}
+
+func (x *RedeemCreditRequest) GetIdempotencyKey() string {
+	if x != nil {
+		return x.IdempotencyKey
+	}
+	return ""
+}
+
+func (x *RedeemCreditRequest) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *RedeemCreditRequest) GetDestinationPubkey() []byte {
+	if x != nil {
+		return x.DestinationPubkey
+	}
+	return nil
+}
+
+type RedeemCreditResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	OperationId   string                 `protobuf:"bytes,1,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"`
+	State         CreditOperationState   `protobuf:"varint,2,opt,name=state,proto3,enum=swaprpc.CreditOperationState" json:"state,omitempty"`
+	DebitedSat    uint64                 `protobuf:"varint,3,opt,name=debited_sat,json=debitedSat,proto3" json:"debited_sat,omitempty"`
+	RedeemedSat   uint64                 `protobuf:"varint,4,opt,name=redeemed_sat,json=redeemedSat,proto3" json:"redeemed_sat,omitempty"`
+	SessionId     string                 `protobuf:"bytes,5,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RedeemCreditResponse) Reset() {
+	*x = RedeemCreditResponse{}
+	mi := &file_swap_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RedeemCreditResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RedeemCreditResponse) ProtoMessage() {}
+
+func (x *RedeemCreditResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RedeemCreditResponse.ProtoReflect.Descriptor instead.
+func (*RedeemCreditResponse) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *RedeemCreditResponse) GetOperationId() string {
+	if x != nil {
+		return x.OperationId
+	}
+	return ""
+}
+
+func (x *RedeemCreditResponse) GetState() CreditOperationState {
+	if x != nil {
+		return x.State
+	}
+	return CreditOperationState_CREDIT_OPERATION_STATE_UNSPECIFIED
+}
+
+func (x *RedeemCreditResponse) GetDebitedSat() uint64 {
+	if x != nil {
+		return x.DebitedSat
+	}
+	return 0
+}
+
+func (x *RedeemCreditResponse) GetRedeemedSat() uint64 {
+	if x != nil {
+		return x.RedeemedSat
+	}
+	return 0
+}
+
+func (x *RedeemCreditResponse) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+type ListCreditsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AccountPubkey []byte                 `protobuf:"bytes,1,opt,name=account_pubkey,json=accountPubkey,proto3" json:"account_pubkey,omitempty"`
+	Limit         uint32                 `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListCreditsRequest) Reset() {
+	*x = ListCreditsRequest{}
+	mi := &file_swap_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListCreditsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListCreditsRequest) ProtoMessage() {}
+
+func (x *ListCreditsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListCreditsRequest.ProtoReflect.Descriptor instead.
+func (*ListCreditsRequest) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *ListCreditsRequest) GetAccountPubkey() []byte {
+	if x != nil {
+		return x.AccountPubkey
+	}
+	return nil
+}
+
+func (x *ListCreditsRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+type ListCreditsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	FinalizedSat  uint64                 `protobuf:"varint,1,opt,name=finalized_sat,json=finalizedSat,proto3" json:"finalized_sat,omitempty"`
+	ReservedSat   uint64                 `protobuf:"varint,2,opt,name=reserved_sat,json=reservedSat,proto3" json:"reserved_sat,omitempty"`
+	AvailableSat  uint64                 `protobuf:"varint,3,opt,name=available_sat,json=availableSat,proto3" json:"available_sat,omitempty"`
+	Operations    []*CreditOperation     `protobuf:"bytes,4,rep,name=operations,proto3" json:"operations,omitempty"`
+	LedgerEntries []*CreditLedgerEntry   `protobuf:"bytes,5,rep,name=ledger_entries,json=ledgerEntries,proto3" json:"ledger_entries,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListCreditsResponse) Reset() {
+	*x = ListCreditsResponse{}
+	mi := &file_swap_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListCreditsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListCreditsResponse) ProtoMessage() {}
+
+func (x *ListCreditsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListCreditsResponse.ProtoReflect.Descriptor instead.
+func (*ListCreditsResponse) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *ListCreditsResponse) GetFinalizedSat() uint64 {
+	if x != nil {
+		return x.FinalizedSat
+	}
+	return 0
+}
+
+func (x *ListCreditsResponse) GetReservedSat() uint64 {
+	if x != nil {
+		return x.ReservedSat
+	}
+	return 0
+}
+
+func (x *ListCreditsResponse) GetAvailableSat() uint64 {
+	if x != nil {
+		return x.AvailableSat
+	}
+	return 0
+}
+
+func (x *ListCreditsResponse) GetOperations() []*CreditOperation {
+	if x != nil {
+		return x.Operations
+	}
+	return nil
+}
+
+func (x *ListCreditsResponse) GetLedgerEntries() []*CreditLedgerEntry {
+	if x != nil {
+		return x.LedgerEntries
+	}
+	return nil
+}
+
+type CreditOperation struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	OperationId       string                 `protobuf:"bytes,1,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"`
+	Type              CreditOperationType    `protobuf:"varint,2,opt,name=type,proto3,enum=swaprpc.CreditOperationType" json:"type,omitempty"`
+	State             CreditOperationState   `protobuf:"varint,3,opt,name=state,proto3,enum=swaprpc.CreditOperationState" json:"state,omitempty"`
+	AmountSat         uint64                 `protobuf:"varint,4,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	PaymentHash       []byte                 `protobuf:"bytes,6,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	Invoice           string                 `protobuf:"bytes,7,opt,name=invoice,proto3" json:"invoice,omitempty"`
+	DestinationPubkey []byte                 `protobuf:"bytes,8,opt,name=destination_pubkey,json=destinationPubkey,proto3" json:"destination_pubkey,omitempty"`
+	SessionId         string                 `protobuf:"bytes,9,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	CreatedAt         *timestamppb.Timestamp `protobuf:"bytes,10,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt         *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	CompletedAt       *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=completed_at,json=completedAt,proto3" json:"completed_at,omitempty"`
+	LastError         string                 `protobuf:"bytes,13,opt,name=last_error,json=lastError,proto3" json:"last_error,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *CreditOperation) Reset() {
+	*x = CreditOperation{}
+	mi := &file_swap_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreditOperation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreditOperation) ProtoMessage() {}
+
+func (x *CreditOperation) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreditOperation.ProtoReflect.Descriptor instead.
+func (*CreditOperation) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *CreditOperation) GetOperationId() string {
+	if x != nil {
+		return x.OperationId
+	}
+	return ""
+}
+
+func (x *CreditOperation) GetType() CreditOperationType {
+	if x != nil {
+		return x.Type
+	}
+	return CreditOperationType_CREDIT_OPERATION_TYPE_UNSPECIFIED
+}
+
+func (x *CreditOperation) GetState() CreditOperationState {
+	if x != nil {
+		return x.State
+	}
+	return CreditOperationState_CREDIT_OPERATION_STATE_UNSPECIFIED
+}
+
+func (x *CreditOperation) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *CreditOperation) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+func (x *CreditOperation) GetInvoice() string {
+	if x != nil {
+		return x.Invoice
+	}
+	return ""
+}
+
+func (x *CreditOperation) GetDestinationPubkey() []byte {
+	if x != nil {
+		return x.DestinationPubkey
+	}
+	return nil
+}
+
+func (x *CreditOperation) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *CreditOperation) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *CreditOperation) GetUpdatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return nil
+}
+
+func (x *CreditOperation) GetCompletedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CompletedAt
+	}
+	return nil
+}
+
+func (x *CreditOperation) GetLastError() string {
+	if x != nil {
+		return x.LastError
+	}
+	return ""
+}
+
+type CreditLedgerEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EntryId       string                 `protobuf:"bytes,1,opt,name=entry_id,json=entryId,proto3" json:"entry_id,omitempty"`
+	OperationId   string                 `protobuf:"bytes,2,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"`
+	Direction     string                 `protobuf:"bytes,3,opt,name=direction,proto3" json:"direction,omitempty"`
+	AmountSat     uint64                 `protobuf:"varint,4,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreditLedgerEntry) Reset() {
+	*x = CreditLedgerEntry{}
+	mi := &file_swap_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreditLedgerEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreditLedgerEntry) ProtoMessage() {}
+
+func (x *CreditLedgerEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreditLedgerEntry.ProtoReflect.Descriptor instead.
+func (*CreditLedgerEntry) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *CreditLedgerEntry) GetEntryId() string {
+	if x != nil {
+		return x.EntryId
+	}
+	return ""
+}
+
+func (x *CreditLedgerEntry) GetOperationId() string {
+	if x != nil {
+		return x.OperationId
+	}
+	return ""
+}
+
+func (x *CreditLedgerEntry) GetDirection() string {
+	if x != nil {
+		return x.Direction
+	}
+	return ""
+}
+
+func (x *CreditLedgerEntry) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *CreditLedgerEntry) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
 type AuthorizeInSwapRefundRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// payment_hash identifies the in-swap.
@@ -1175,7 +2256,7 @@ type AuthorizeInSwapRefundRequest struct {
 
 func (x *AuthorizeInSwapRefundRequest) Reset() {
 	*x = AuthorizeInSwapRefundRequest{}
-	mi := &file_swap_proto_msgTypes[14]
+	mi := &file_swap_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1187,7 +2268,7 @@ func (x *AuthorizeInSwapRefundRequest) String() string {
 func (*AuthorizeInSwapRefundRequest) ProtoMessage() {}
 
 func (x *AuthorizeInSwapRefundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[14]
+	mi := &file_swap_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1200,7 +2281,7 @@ func (x *AuthorizeInSwapRefundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthorizeInSwapRefundRequest.ProtoReflect.Descriptor instead.
 func (*AuthorizeInSwapRefundRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{14}
+	return file_swap_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *AuthorizeInSwapRefundRequest) GetPaymentHash() []byte {
@@ -1258,7 +2339,7 @@ type AuthorizeInSwapRefundResponse struct {
 
 func (x *AuthorizeInSwapRefundResponse) Reset() {
 	*x = AuthorizeInSwapRefundResponse{}
-	mi := &file_swap_proto_msgTypes[15]
+	mi := &file_swap_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1270,7 +2351,7 @@ func (x *AuthorizeInSwapRefundResponse) String() string {
 func (*AuthorizeInSwapRefundResponse) ProtoMessage() {}
 
 func (x *AuthorizeInSwapRefundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[15]
+	mi := &file_swap_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1283,7 +2364,7 @@ func (x *AuthorizeInSwapRefundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthorizeInSwapRefundResponse.ProtoReflect.Descriptor instead.
 func (*AuthorizeInSwapRefundResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{15}
+	return file_swap_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *AuthorizeInSwapRefundResponse) GetSignature() *TaprootScriptSignature {
@@ -1334,7 +2415,7 @@ type ForfeitSignaturePayload struct {
 
 func (x *ForfeitSignaturePayload) Reset() {
 	*x = ForfeitSignaturePayload{}
-	mi := &file_swap_proto_msgTypes[16]
+	mi := &file_swap_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1346,7 +2427,7 @@ func (x *ForfeitSignaturePayload) String() string {
 func (*ForfeitSignaturePayload) ProtoMessage() {}
 
 func (x *ForfeitSignaturePayload) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[16]
+	mi := &file_swap_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1359,7 +2440,7 @@ func (x *ForfeitSignaturePayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForfeitSignaturePayload.ProtoReflect.Descriptor instead.
 func (*ForfeitSignaturePayload) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{16}
+	return file_swap_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ForfeitSignaturePayload) GetRequestId() []byte {
@@ -1460,7 +2541,7 @@ type ForfeitParticipantSignature struct {
 
 func (x *ForfeitParticipantSignature) Reset() {
 	*x = ForfeitParticipantSignature{}
-	mi := &file_swap_proto_msgTypes[17]
+	mi := &file_swap_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1472,7 +2553,7 @@ func (x *ForfeitParticipantSignature) String() string {
 func (*ForfeitParticipantSignature) ProtoMessage() {}
 
 func (x *ForfeitParticipantSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[17]
+	mi := &file_swap_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1485,7 +2566,7 @@ func (x *ForfeitParticipantSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForfeitParticipantSignature.ProtoReflect.Descriptor instead.
 func (*ForfeitParticipantSignature) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{17}
+	return file_swap_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ForfeitParticipantSignature) GetPubkey() []byte {
@@ -1512,7 +2593,7 @@ type SignInSwapForfeitRequest struct {
 
 func (x *SignInSwapForfeitRequest) Reset() {
 	*x = SignInSwapForfeitRequest{}
-	mi := &file_swap_proto_msgTypes[18]
+	mi := &file_swap_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1524,7 +2605,7 @@ func (x *SignInSwapForfeitRequest) String() string {
 func (*SignInSwapForfeitRequest) ProtoMessage() {}
 
 func (x *SignInSwapForfeitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[18]
+	mi := &file_swap_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1537,7 +2618,7 @@ func (x *SignInSwapForfeitRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignInSwapForfeitRequest.ProtoReflect.Descriptor instead.
 func (*SignInSwapForfeitRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{18}
+	return file_swap_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *SignInSwapForfeitRequest) GetPayload() *ForfeitSignaturePayload {
@@ -1557,7 +2638,7 @@ type SignInSwapForfeitResponse struct {
 
 func (x *SignInSwapForfeitResponse) Reset() {
 	*x = SignInSwapForfeitResponse{}
-	mi := &file_swap_proto_msgTypes[19]
+	mi := &file_swap_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1569,7 +2650,7 @@ func (x *SignInSwapForfeitResponse) String() string {
 func (*SignInSwapForfeitResponse) ProtoMessage() {}
 
 func (x *SignInSwapForfeitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[19]
+	mi := &file_swap_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1582,7 +2663,7 @@ func (x *SignInSwapForfeitResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignInSwapForfeitResponse.ProtoReflect.Descriptor instead.
 func (*SignInSwapForfeitResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{19}
+	return file_swap_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *SignInSwapForfeitResponse) GetSignature() *ForfeitParticipantSignature {
@@ -1602,7 +2683,7 @@ type OutSwapForfeitSignatureRequest struct {
 
 func (x *OutSwapForfeitSignatureRequest) Reset() {
 	*x = OutSwapForfeitSignatureRequest{}
-	mi := &file_swap_proto_msgTypes[20]
+	mi := &file_swap_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1614,7 +2695,7 @@ func (x *OutSwapForfeitSignatureRequest) String() string {
 func (*OutSwapForfeitSignatureRequest) ProtoMessage() {}
 
 func (x *OutSwapForfeitSignatureRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[20]
+	mi := &file_swap_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1627,7 +2708,7 @@ func (x *OutSwapForfeitSignatureRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutSwapForfeitSignatureRequest.ProtoReflect.Descriptor instead.
 func (*OutSwapForfeitSignatureRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{20}
+	return file_swap_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *OutSwapForfeitSignatureRequest) GetPayload() *ForfeitSignaturePayload {
@@ -1650,7 +2731,7 @@ type SubmitOutSwapForfeitSignatureRequest struct {
 
 func (x *SubmitOutSwapForfeitSignatureRequest) Reset() {
 	*x = SubmitOutSwapForfeitSignatureRequest{}
-	mi := &file_swap_proto_msgTypes[21]
+	mi := &file_swap_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1662,7 +2743,7 @@ func (x *SubmitOutSwapForfeitSignatureRequest) String() string {
 func (*SubmitOutSwapForfeitSignatureRequest) ProtoMessage() {}
 
 func (x *SubmitOutSwapForfeitSignatureRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[21]
+	mi := &file_swap_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1675,7 +2756,7 @@ func (x *SubmitOutSwapForfeitSignatureRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use SubmitOutSwapForfeitSignatureRequest.ProtoReflect.Descriptor instead.
 func (*SubmitOutSwapForfeitSignatureRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{21}
+	return file_swap_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *SubmitOutSwapForfeitSignatureRequest) GetPayload() *ForfeitSignaturePayload {
@@ -1700,7 +2781,7 @@ type SubmitOutSwapForfeitSignatureResponse struct {
 
 func (x *SubmitOutSwapForfeitSignatureResponse) Reset() {
 	*x = SubmitOutSwapForfeitSignatureResponse{}
-	mi := &file_swap_proto_msgTypes[22]
+	mi := &file_swap_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1712,7 +2793,7 @@ func (x *SubmitOutSwapForfeitSignatureResponse) String() string {
 func (*SubmitOutSwapForfeitSignatureResponse) ProtoMessage() {}
 
 func (x *SubmitOutSwapForfeitSignatureResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[22]
+	mi := &file_swap_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1725,7 +2806,7 @@ func (x *SubmitOutSwapForfeitSignatureResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use SubmitOutSwapForfeitSignatureResponse.ProtoReflect.Descriptor instead.
 func (*SubmitOutSwapForfeitSignatureResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{22}
+	return file_swap_proto_rawDescGZIP(), []int{31}
 }
 
 // TaprootScriptSignature carries one externally produced tapscript signature.
@@ -1747,7 +2828,7 @@ type TaprootScriptSignature struct {
 
 func (x *TaprootScriptSignature) Reset() {
 	*x = TaprootScriptSignature{}
-	mi := &file_swap_proto_msgTypes[23]
+	mi := &file_swap_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1759,7 +2840,7 @@ func (x *TaprootScriptSignature) String() string {
 func (*TaprootScriptSignature) ProtoMessage() {}
 
 func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[23]
+	mi := &file_swap_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1772,7 +2853,7 @@ func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaprootScriptSignature.ProtoReflect.Descriptor instead.
 func (*TaprootScriptSignature) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{23}
+	return file_swap_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *TaprootScriptSignature) GetPubkey() []byte {
@@ -1808,21 +2889,27 @@ var File_swap_proto protoreflect.FileDescriptor
 const file_swap_proto_rawDesc = "" +
 	"\n" +
 	"\n" +
-	"swap.proto\x12\aswaprpc\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb4\x01\n" +
+	"swap.proto\x12\aswaprpc\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb2\x01\n" +
 	"\x17RequestChannelIdRequest\x12%\n" +
 	"\x0eexpiry_seconds\x18\x01 \x01(\rR\rexpirySeconds\x12.\n" +
 	"\x13client_vhtlc_pubkey\x18\x02 \x01(\fR\x11clientVhtlcPubkey\x12!\n" +
-	"\fpayment_hash\x18\x03 \x01(\fR\vpaymentHash\x12\x1f\n" +
-	"\vamount_msat\x18\x04 \x01(\x04R\n" +
-	"amountMsat\"s\n" +
+	"\fpayment_hash\x18\x03 \x01(\fR\vpaymentHash\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x04 \x01(\x04R\tamountSat\"\x99\x03\n" +
 	"\x18RequestChannelIdResponse\x121\n" +
 	"\n" +
 	"route_hint\x18\x01 \x01(\v2\x12.swaprpc.RouteHintR\trouteHint\x12$\n" +
-	"\x0epayer_fee_msat\x18\x02 \x01(\x04R\fpayerFeeMsat\"r\n" +
+	"\x0epayer_fee_msat\x18\x02 \x01(\x04R\fpayerFeeMsat\x120\n" +
+	"\x14requested_amount_sat\x18\x03 \x01(\x04R\x12requestedAmountSat\x120\n" +
+	"\x14available_credit_sat\x18\x04 \x01(\x04R\x12availableCreditSat\x12.\n" +
+	"\x13attached_credit_sat\x18\x05 \x01(\x04R\x11attachedCreditSat\x12(\n" +
+	"\x10vhtlc_amount_sat\x18\x06 \x01(\x04R\x0evhtlcAmountSat\x12$\n" +
+	"\x0edust_limit_sat\x18\a \x01(\x04R\fdustLimitSat\x12@\n" +
+	"\x0fsettlement_type\x18\b \x01(\x0e2\x17.swaprpc.SettlementTypeR\x0esettlementType\"r\n" +
 	"\x1dAcknowledgeOutSwapHtlcRequest\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12.\n" +
 	"\x13client_vhtlc_pubkey\x18\x02 \x01(\fR\x11clientVhtlcPubkey\" \n" +
-	"\x1eAcknowledgeOutSwapHtlcResponse\"\xdc\x01\n" +
+	"\x1eAcknowledgeOutSwapHtlcResponse\"\xbe\x02\n" +
 	"\x10OutSwapHtlcEvent\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x1d\n" +
 	"\n" +
@@ -1830,7 +2917,9 @@ const file_swap_proto_rawDesc = "" +
 	"\n" +
 	"onion_blob\x18\x03 \x01(\fR\tonionBlob\x127\n" +
 	"\fvhtlc_config\x18\x04 \x01(\v2\x14.swaprpc.VHTLCConfigR\vvhtlcConfig\x12.\n" +
-	"\x05parts\x18\x05 \x03(\v2\x18.swaprpc.OutSwapHtlcPartR\x05parts\"Q\n" +
+	"\x05parts\x18\x05 \x03(\v2\x18.swaprpc.OutSwapHtlcPartR\x05parts\x120\n" +
+	"\x14requested_amount_sat\x18\x06 \x01(\x04R\x12requestedAmountSat\x12.\n" +
+	"\x13attached_credit_sat\x18\a \x01(\x04R\x11attachedCreditSat\"Q\n" +
 	"\x0fOutSwapHtlcPart\x12\x1f\n" +
 	"\vamount_msat\x18\x01 \x01(\x04R\n" +
 	"amountMsat\x12\x1d\n" +
@@ -1861,11 +2950,13 @@ const file_swap_proto_rawDesc = "" +
 	"\x16unilateral_claim_delay\x18\x02 \x01(\rR\x14unilateralClaimDelay\x126\n" +
 	"\x17unilateral_refund_delay\x18\x03 \x01(\rR\x15unilateralRefundDelay\x12V\n" +
 	"(unilateral_refund_without_receiver_delay\x18\x04 \x01(\rR$unilateralRefundWithoutReceiverDelay\x12+\n" +
-	"\x11swapserver_pubkey\x18\x05 \x01(\fR\x10swapserverPubkey\"\x7f\n" +
+	"\x11swapserver_pubkey\x18\x05 \x01(\fR\x10swapserverPubkey\"\xcc\x01\n" +
 	"\x13CreateInSwapRequest\x12\x18\n" +
 	"\ainvoice\x18\x01 \x01(\tR\ainvoice\x12\x1e\n" +
 	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\x12.\n" +
-	"\x13client_vhtlc_pubkey\x18\x03 \x01(\fR\x11clientVhtlcPubkey\"\xc5\x02\n" +
+	"\x13client_vhtlc_pubkey\x18\x03 \x01(\fR\x11clientVhtlcPubkey\x12%\n" +
+	"\x0eaccount_pubkey\x18\x04 \x01(\fR\raccountPubkey\x12$\n" +
+	"\x0emax_credit_sat\x18\x05 \x01(\x04R\fmaxCreditSat\"\x9a\x03\n" +
 	"\x14CreateInSwapResponse\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x1d\n" +
 	"\n" +
@@ -1874,10 +2965,14 @@ const file_swap_proto_rawDesc = "" +
 	"\rserver_pubkey\x18\x04 \x01(\fR\fserverPubkey\x127\n" +
 	"\fvhtlc_config\x18\x05 \x01(\v2\x14.swaprpc.VHTLCConfigR\vvhtlcConfig\x122\n" +
 	"\x06expiry\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x06expiry\x12@\n" +
-	"\x0fsettlement_type\x18\a \x01(\x0e2\x17.swaprpc.SettlementTypeR\x0esettlementType\"N\n" +
+	"\x0fsettlement_type\x18\a \x01(\x0e2\x17.swaprpc.SettlementTypeR\x0esettlementType\x127\n" +
+	"\fcredit_quote\x18\b \x01(\v2\x14.swaprpc.CreditQuoteR\vcreditQuote\x12\x1a\n" +
+	"\bpreimage\x18\t \x01(\fR\bpreimage\"\x9b\x01\n" +
 	"\x12QuoteInSwapRequest\x12\x18\n" +
 	"\ainvoice\x18\x01 \x01(\tR\ainvoice\x12\x1e\n" +
-	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\"\xbc\x02\n" +
+	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\x12%\n" +
+	"\x0eaccount_pubkey\x18\x03 \x01(\fR\raccountPubkey\x12$\n" +
+	"\x0emax_credit_sat\x18\x04 \x01(\x04R\fmaxCreditSat\"\xf5\x02\n" +
 	"\x13QuoteInSwapResponse\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12,\n" +
 	"\x12invoice_amount_sat\x18\x02 \x01(\x04R\x10invoiceAmountSat\x12\x1d\n" +
@@ -1886,7 +2981,83 @@ const file_swap_proto_rawDesc = "" +
 	"\afee_sat\x18\x04 \x01(\x04R\x06feeSat\x12@\n" +
 	"\x0fsettlement_type\x18\x05 \x01(\x0e2\x17.swaprpc.SettlementTypeR\x0esettlementType\x122\n" +
 	"\x06expiry\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x06expiry\x12&\n" +
-	"\x0fexceeds_max_fee\x18\a \x01(\bR\rexceedsMaxFee\"\x9b\x02\n" +
+	"\x0fexceeds_max_fee\x18\a \x01(\bR\rexceedsMaxFee\x127\n" +
+	"\fcredit_quote\x18\b \x01(\v2\x14.swaprpc.CreditQuoteR\vcreditQuote\"\xe7\x01\n" +
+	"\vCreditQuote\x12&\n" +
+	"\x0fmust_use_credit\x18\x01 \x01(\bR\rmustUseCredit\x12,\n" +
+	"\x12credit_applied_sat\x18\x02 \x01(\x04R\x10creditAppliedSat\x120\n" +
+	"\x14credit_shortfall_sat\x18\x03 \x01(\x04R\x12creditShortfallSat\x12(\n" +
+	"\x10credit_topup_sat\x18\x04 \x01(\x04R\x0ecreditTopupSat\x12&\n" +
+	"\x0fark_funding_sat\x18\x05 \x01(\x04R\rarkFundingSat\"\xce\x01\n" +
+	"\x13CreateCreditRequest\x12%\n" +
+	"\x0eaccount_pubkey\x18\x01 \x01(\fR\raccountPubkey\x12'\n" +
+	"\x0fidempotency_key\x18\x02 \x01(\tR\x0eidempotencyKey\x124\n" +
+	"\x06source\x18\x03 \x01(\x0e2\x1c.swaprpc.CreditFundingSourceR\x06source\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x04 \x01(\x04R\tamountSat\x12\x12\n" +
+	"\x04memo\x18\x05 \x01(\tR\x04memo\"\xb4\x02\n" +
+	"\x14CreateCreditResponse\x12!\n" +
+	"\foperation_id\x18\x01 \x01(\tR\voperationId\x123\n" +
+	"\x05state\x18\x02 \x01(\x0e2\x1d.swaprpc.CreditOperationStateR\x05state\x12\x18\n" +
+	"\ainvoice\x18\x03 \x01(\tR\ainvoice\x12!\n" +
+	"\fpayment_hash\x18\x04 \x01(\fR\vpaymentHash\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x05 \x01(\x04R\tamountSat\x12-\n" +
+	"\x12destination_pubkey\x18\a \x01(\fR\x11destinationPubkey\x129\n" +
+	"\n" +
+	"expires_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\"\xb3\x01\n" +
+	"\x13RedeemCreditRequest\x12%\n" +
+	"\x0eaccount_pubkey\x18\x01 \x01(\fR\raccountPubkey\x12'\n" +
+	"\x0fidempotency_key\x18\x02 \x01(\tR\x0eidempotencyKey\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x03 \x01(\x04R\tamountSat\x12-\n" +
+	"\x12destination_pubkey\x18\x04 \x01(\fR\x11destinationPubkey\"\xd1\x01\n" +
+	"\x14RedeemCreditResponse\x12!\n" +
+	"\foperation_id\x18\x01 \x01(\tR\voperationId\x123\n" +
+	"\x05state\x18\x02 \x01(\x0e2\x1d.swaprpc.CreditOperationStateR\x05state\x12\x1f\n" +
+	"\vdebited_sat\x18\x03 \x01(\x04R\n" +
+	"debitedSat\x12!\n" +
+	"\fredeemed_sat\x18\x04 \x01(\x04R\vredeemedSat\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x05 \x01(\tR\tsessionId\"Q\n" +
+	"\x12ListCreditsRequest\x12%\n" +
+	"\x0eaccount_pubkey\x18\x01 \x01(\fR\raccountPubkey\x12\x14\n" +
+	"\x05limit\x18\x02 \x01(\rR\x05limit\"\xff\x01\n" +
+	"\x13ListCreditsResponse\x12#\n" +
+	"\rfinalized_sat\x18\x01 \x01(\x04R\ffinalizedSat\x12!\n" +
+	"\freserved_sat\x18\x02 \x01(\x04R\vreservedSat\x12#\n" +
+	"\ravailable_sat\x18\x03 \x01(\x04R\favailableSat\x128\n" +
+	"\n" +
+	"operations\x18\x04 \x03(\v2\x18.swaprpc.CreditOperationR\n" +
+	"operations\x12A\n" +
+	"\x0eledger_entries\x18\x05 \x03(\v2\x1a.swaprpc.CreditLedgerEntryR\rledgerEntries\"\x99\x04\n" +
+	"\x0fCreditOperation\x12!\n" +
+	"\foperation_id\x18\x01 \x01(\tR\voperationId\x120\n" +
+	"\x04type\x18\x02 \x01(\x0e2\x1c.swaprpc.CreditOperationTypeR\x04type\x123\n" +
+	"\x05state\x18\x03 \x01(\x0e2\x1d.swaprpc.CreditOperationStateR\x05state\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x04 \x01(\x04R\tamountSat\x12!\n" +
+	"\fpayment_hash\x18\x06 \x01(\fR\vpaymentHash\x12\x18\n" +
+	"\ainvoice\x18\a \x01(\tR\ainvoice\x12-\n" +
+	"\x12destination_pubkey\x18\b \x01(\fR\x11destinationPubkey\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\t \x01(\tR\tsessionId\x129\n" +
+	"\n" +
+	"created_at\x18\n" +
+	" \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
+	"\n" +
+	"updated_at\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\x12=\n" +
+	"\fcompleted_at\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\vcompletedAt\x12\x1d\n" +
+	"\n" +
+	"last_error\x18\r \x01(\tR\tlastError\"\xc9\x01\n" +
+	"\x11CreditLedgerEntry\x12\x19\n" +
+	"\bentry_id\x18\x01 \x01(\tR\aentryId\x12!\n" +
+	"\foperation_id\x18\x02 \x01(\tR\voperationId\x12\x1c\n" +
+	"\tdirection\x18\x03 \x01(\tR\tdirection\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x04 \x01(\x04R\tamountSat\x129\n" +
+	"\n" +
+	"created_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"\x9b\x02\n" +
 	"\x1cAuthorizeInSwapRefundRequest\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12%\n" +
 	"\x0evhtlc_outpoint\x18\x02 \x01(\tR\rvhtlcOutpoint\x12(\n" +
@@ -1929,15 +3100,44 @@ const file_swap_proto_rawDesc = "" +
 	"\x06pubkey\x18\x01 \x01(\fR\x06pubkey\x12%\n" +
 	"\x0ewitness_script\x18\x02 \x01(\fR\rwitnessScript\x12\x1c\n" +
 	"\tsignature\x18\x03 \x01(\fR\tsignature\x12\x18\n" +
-	"\asighash\x18\x04 \x01(\rR\asighash*l\n" +
+	"\asighash\x18\x04 \x01(\rR\asighash*\xa3\x01\n" +
 	"\x0eSettlementType\x12\x1f\n" +
 	"\x1bSETTLEMENT_TYPE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19SETTLEMENT_TYPE_LIGHTNING\x10\x01\x12\x1a\n" +
-	"\x16SETTLEMENT_TYPE_IN_ARK\x10\x022\xac\x05\n" +
+	"\x16SETTLEMENT_TYPE_IN_ARK\x10\x02\x12\x1a\n" +
+	"\x16SETTLEMENT_TYPE_CREDIT\x10\x03\x12\x19\n" +
+	"\x15SETTLEMENT_TYPE_MIXED\x10\x04*\x8e\x01\n" +
+	"\x13CreditFundingSource\x12%\n" +
+	"!CREDIT_FUNDING_SOURCE_UNSPECIFIED\x10\x00\x12+\n" +
+	"'CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE\x10\x01\x12#\n" +
+	"\x1fCREDIT_FUNDING_SOURCE_ARK_TOPUP\x10\x02*\xc7\x01\n" +
+	"\x13CreditOperationType\x12%\n" +
+	"!CREDIT_OPERATION_TYPE_UNSPECIFIED\x10\x00\x12!\n" +
+	"\x1dCREDIT_OPERATION_TYPE_FUNDING\x10\x01\x12\x1d\n" +
+	"\x19CREDIT_OPERATION_TYPE_PAY\x10\x02\x12$\n" +
+	" CREDIT_OPERATION_TYPE_REDEMPTION\x10\x03\x12!\n" +
+	"\x1dCREDIT_OPERATION_TYPE_RECEIVE\x10\x04*\xe3\x03\n" +
+	"\x14CreditOperationState\x12&\n" +
+	"\"CREDIT_OPERATION_STATE_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1eCREDIT_OPERATION_STATE_CREATED\x10\x01\x12+\n" +
+	"'CREDIT_OPERATION_STATE_AWAITING_PAYMENT\x10\x02\x12#\n" +
+	"\x1fCREDIT_OPERATION_STATE_CREDITED\x10\x03\x12#\n" +
+	"\x1fCREDIT_OPERATION_STATE_RESERVED\x10\x04\x12+\n" +
+	"'CREDIT_OPERATION_STATE_PAYING_LIGHTNING\x10\x05\x12\"\n" +
+	"\x1eCREDIT_OPERATION_STATE_DEBITED\x10\x06\x12&\n" +
+	"\"CREDIT_OPERATION_STATE_SENDING_OOR\x10\a\x12#\n" +
+	"\x1fCREDIT_OPERATION_STATE_REDEEMED\x10\b\x12#\n" +
+	"\x1fCREDIT_OPERATION_STATE_RELEASED\x10\t\x12\"\n" +
+	"\x1eCREDIT_OPERATION_STATE_EXPIRED\x10\n" +
+	"\x12!\n" +
+	"\x1dCREDIT_OPERATION_STATE_FAILED\x10\v2\x90\a\n" +
 	"\vSwapService\x12W\n" +
 	"\x10RequestChannelId\x12 .swaprpc.RequestChannelIdRequest\x1a!.swaprpc.RequestChannelIdResponse\x12K\n" +
 	"\fCreateInSwap\x12\x1c.swaprpc.CreateInSwapRequest\x1a\x1d.swaprpc.CreateInSwapResponse\x12H\n" +
-	"\vQuoteInSwap\x12\x1b.swaprpc.QuoteInSwapRequest\x1a\x1c.swaprpc.QuoteInSwapResponse\x12f\n" +
+	"\vQuoteInSwap\x12\x1b.swaprpc.QuoteInSwapRequest\x1a\x1c.swaprpc.QuoteInSwapResponse\x12K\n" +
+	"\fCreateCredit\x12\x1c.swaprpc.CreateCreditRequest\x1a\x1d.swaprpc.CreateCreditResponse\x12K\n" +
+	"\fRedeemCredit\x12\x1c.swaprpc.RedeemCreditRequest\x1a\x1d.swaprpc.RedeemCreditResponse\x12H\n" +
+	"\vListCredits\x12\x1b.swaprpc.ListCreditsRequest\x1a\x1c.swaprpc.ListCreditsResponse\x12f\n" +
 	"\x15AuthorizeInSwapRefund\x12%.swaprpc.AuthorizeInSwapRefundRequest\x1a&.swaprpc.AuthorizeInSwapRefundResponse\x12i\n" +
 	"\x16AcknowledgeOutSwapHtlc\x12&.swaprpc.AcknowledgeOutSwapHtlcRequest\x1a'.swaprpc.AcknowledgeOutSwapHtlcResponse\x12Z\n" +
 	"\x11SignInSwapForfeit\x12!.swaprpc.SignInSwapForfeitRequest\x1a\".swaprpc.SignInSwapForfeitResponse\x12~\n" +
@@ -1955,74 +3155,107 @@ func file_swap_proto_rawDescGZIP() []byte {
 	return file_swap_proto_rawDescData
 }
 
-var file_swap_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_swap_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_swap_proto_goTypes = []any{
 	(SettlementType)(0),                           // 0: swaprpc.SettlementType
-	(*RequestChannelIdRequest)(nil),               // 1: swaprpc.RequestChannelIdRequest
-	(*RequestChannelIdResponse)(nil),              // 2: swaprpc.RequestChannelIdResponse
-	(*AcknowledgeOutSwapHtlcRequest)(nil),         // 3: swaprpc.AcknowledgeOutSwapHtlcRequest
-	(*AcknowledgeOutSwapHtlcResponse)(nil),        // 4: swaprpc.AcknowledgeOutSwapHtlcResponse
-	(*OutSwapHtlcEvent)(nil),                      // 5: swaprpc.OutSwapHtlcEvent
-	(*OutSwapHtlcPart)(nil),                       // 6: swaprpc.OutSwapHtlcPart
-	(*SwapMailboxEvent)(nil),                      // 7: swaprpc.SwapMailboxEvent
-	(*InArkHtlcEvent)(nil),                        // 8: swaprpc.InArkHtlcEvent
-	(*RouteHint)(nil),                             // 9: swaprpc.RouteHint
-	(*VHTLCConfig)(nil),                           // 10: swaprpc.VHTLCConfig
-	(*CreateInSwapRequest)(nil),                   // 11: swaprpc.CreateInSwapRequest
-	(*CreateInSwapResponse)(nil),                  // 12: swaprpc.CreateInSwapResponse
-	(*QuoteInSwapRequest)(nil),                    // 13: swaprpc.QuoteInSwapRequest
-	(*QuoteInSwapResponse)(nil),                   // 14: swaprpc.QuoteInSwapResponse
-	(*AuthorizeInSwapRefundRequest)(nil),          // 15: swaprpc.AuthorizeInSwapRefundRequest
-	(*AuthorizeInSwapRefundResponse)(nil),         // 16: swaprpc.AuthorizeInSwapRefundResponse
-	(*ForfeitSignaturePayload)(nil),               // 17: swaprpc.ForfeitSignaturePayload
-	(*ForfeitParticipantSignature)(nil),           // 18: swaprpc.ForfeitParticipantSignature
-	(*SignInSwapForfeitRequest)(nil),              // 19: swaprpc.SignInSwapForfeitRequest
-	(*SignInSwapForfeitResponse)(nil),             // 20: swaprpc.SignInSwapForfeitResponse
-	(*OutSwapForfeitSignatureRequest)(nil),        // 21: swaprpc.OutSwapForfeitSignatureRequest
-	(*SubmitOutSwapForfeitSignatureRequest)(nil),  // 22: swaprpc.SubmitOutSwapForfeitSignatureRequest
-	(*SubmitOutSwapForfeitSignatureResponse)(nil), // 23: swaprpc.SubmitOutSwapForfeitSignatureResponse
-	(*TaprootScriptSignature)(nil),                // 24: swaprpc.TaprootScriptSignature
-	(*timestamppb.Timestamp)(nil),                 // 25: google.protobuf.Timestamp
+	(CreditFundingSource)(0),                      // 1: swaprpc.CreditFundingSource
+	(CreditOperationType)(0),                      // 2: swaprpc.CreditOperationType
+	(CreditOperationState)(0),                     // 3: swaprpc.CreditOperationState
+	(*RequestChannelIdRequest)(nil),               // 4: swaprpc.RequestChannelIdRequest
+	(*RequestChannelIdResponse)(nil),              // 5: swaprpc.RequestChannelIdResponse
+	(*AcknowledgeOutSwapHtlcRequest)(nil),         // 6: swaprpc.AcknowledgeOutSwapHtlcRequest
+	(*AcknowledgeOutSwapHtlcResponse)(nil),        // 7: swaprpc.AcknowledgeOutSwapHtlcResponse
+	(*OutSwapHtlcEvent)(nil),                      // 8: swaprpc.OutSwapHtlcEvent
+	(*OutSwapHtlcPart)(nil),                       // 9: swaprpc.OutSwapHtlcPart
+	(*SwapMailboxEvent)(nil),                      // 10: swaprpc.SwapMailboxEvent
+	(*InArkHtlcEvent)(nil),                        // 11: swaprpc.InArkHtlcEvent
+	(*RouteHint)(nil),                             // 12: swaprpc.RouteHint
+	(*VHTLCConfig)(nil),                           // 13: swaprpc.VHTLCConfig
+	(*CreateInSwapRequest)(nil),                   // 14: swaprpc.CreateInSwapRequest
+	(*CreateInSwapResponse)(nil),                  // 15: swaprpc.CreateInSwapResponse
+	(*QuoteInSwapRequest)(nil),                    // 16: swaprpc.QuoteInSwapRequest
+	(*QuoteInSwapResponse)(nil),                   // 17: swaprpc.QuoteInSwapResponse
+	(*CreditQuote)(nil),                           // 18: swaprpc.CreditQuote
+	(*CreateCreditRequest)(nil),                   // 19: swaprpc.CreateCreditRequest
+	(*CreateCreditResponse)(nil),                  // 20: swaprpc.CreateCreditResponse
+	(*RedeemCreditRequest)(nil),                   // 21: swaprpc.RedeemCreditRequest
+	(*RedeemCreditResponse)(nil),                  // 22: swaprpc.RedeemCreditResponse
+	(*ListCreditsRequest)(nil),                    // 23: swaprpc.ListCreditsRequest
+	(*ListCreditsResponse)(nil),                   // 24: swaprpc.ListCreditsResponse
+	(*CreditOperation)(nil),                       // 25: swaprpc.CreditOperation
+	(*CreditLedgerEntry)(nil),                     // 26: swaprpc.CreditLedgerEntry
+	(*AuthorizeInSwapRefundRequest)(nil),          // 27: swaprpc.AuthorizeInSwapRefundRequest
+	(*AuthorizeInSwapRefundResponse)(nil),         // 28: swaprpc.AuthorizeInSwapRefundResponse
+	(*ForfeitSignaturePayload)(nil),               // 29: swaprpc.ForfeitSignaturePayload
+	(*ForfeitParticipantSignature)(nil),           // 30: swaprpc.ForfeitParticipantSignature
+	(*SignInSwapForfeitRequest)(nil),              // 31: swaprpc.SignInSwapForfeitRequest
+	(*SignInSwapForfeitResponse)(nil),             // 32: swaprpc.SignInSwapForfeitResponse
+	(*OutSwapForfeitSignatureRequest)(nil),        // 33: swaprpc.OutSwapForfeitSignatureRequest
+	(*SubmitOutSwapForfeitSignatureRequest)(nil),  // 34: swaprpc.SubmitOutSwapForfeitSignatureRequest
+	(*SubmitOutSwapForfeitSignatureResponse)(nil), // 35: swaprpc.SubmitOutSwapForfeitSignatureResponse
+	(*TaprootScriptSignature)(nil),                // 36: swaprpc.TaprootScriptSignature
+	(*timestamppb.Timestamp)(nil),                 // 37: google.protobuf.Timestamp
 }
 var file_swap_proto_depIdxs = []int32{
-	9,  // 0: swaprpc.RequestChannelIdResponse.route_hint:type_name -> swaprpc.RouteHint
-	10, // 1: swaprpc.OutSwapHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	6,  // 2: swaprpc.OutSwapHtlcEvent.parts:type_name -> swaprpc.OutSwapHtlcPart
-	5,  // 3: swaprpc.SwapMailboxEvent.out_swap_htlc:type_name -> swaprpc.OutSwapHtlcEvent
-	8,  // 4: swaprpc.SwapMailboxEvent.in_ark_htlc:type_name -> swaprpc.InArkHtlcEvent
-	21, // 5: swaprpc.SwapMailboxEvent.out_swap_forfeit_signature_request:type_name -> swaprpc.OutSwapForfeitSignatureRequest
-	10, // 6: swaprpc.InArkHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	10, // 7: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	25, // 8: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
-	0,  // 9: swaprpc.CreateInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
-	0,  // 10: swaprpc.QuoteInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
-	25, // 11: swaprpc.QuoteInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
-	24, // 12: swaprpc.AuthorizeInSwapRefundResponse.signature:type_name -> swaprpc.TaprootScriptSignature
-	17, // 13: swaprpc.SignInSwapForfeitRequest.payload:type_name -> swaprpc.ForfeitSignaturePayload
-	18, // 14: swaprpc.SignInSwapForfeitResponse.signature:type_name -> swaprpc.ForfeitParticipantSignature
-	17, // 15: swaprpc.OutSwapForfeitSignatureRequest.payload:type_name -> swaprpc.ForfeitSignaturePayload
-	17, // 16: swaprpc.SubmitOutSwapForfeitSignatureRequest.payload:type_name -> swaprpc.ForfeitSignaturePayload
-	18, // 17: swaprpc.SubmitOutSwapForfeitSignatureRequest.signature:type_name -> swaprpc.ForfeitParticipantSignature
-	1,  // 18: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
-	11, // 19: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
-	13, // 20: swaprpc.SwapService.QuoteInSwap:input_type -> swaprpc.QuoteInSwapRequest
-	15, // 21: swaprpc.SwapService.AuthorizeInSwapRefund:input_type -> swaprpc.AuthorizeInSwapRefundRequest
-	3,  // 22: swaprpc.SwapService.AcknowledgeOutSwapHtlc:input_type -> swaprpc.AcknowledgeOutSwapHtlcRequest
-	19, // 23: swaprpc.SwapService.SignInSwapForfeit:input_type -> swaprpc.SignInSwapForfeitRequest
-	22, // 24: swaprpc.SwapService.SubmitOutSwapForfeitSignature:input_type -> swaprpc.SubmitOutSwapForfeitSignatureRequest
-	2,  // 25: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
-	12, // 26: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
-	14, // 27: swaprpc.SwapService.QuoteInSwap:output_type -> swaprpc.QuoteInSwapResponse
-	16, // 28: swaprpc.SwapService.AuthorizeInSwapRefund:output_type -> swaprpc.AuthorizeInSwapRefundResponse
-	4,  // 29: swaprpc.SwapService.AcknowledgeOutSwapHtlc:output_type -> swaprpc.AcknowledgeOutSwapHtlcResponse
-	20, // 30: swaprpc.SwapService.SignInSwapForfeit:output_type -> swaprpc.SignInSwapForfeitResponse
-	23, // 31: swaprpc.SwapService.SubmitOutSwapForfeitSignature:output_type -> swaprpc.SubmitOutSwapForfeitSignatureResponse
-	25, // [25:32] is the sub-list for method output_type
-	18, // [18:25] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	12, // 0: swaprpc.RequestChannelIdResponse.route_hint:type_name -> swaprpc.RouteHint
+	0,  // 1: swaprpc.RequestChannelIdResponse.settlement_type:type_name -> swaprpc.SettlementType
+	13, // 2: swaprpc.OutSwapHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	9,  // 3: swaprpc.OutSwapHtlcEvent.parts:type_name -> swaprpc.OutSwapHtlcPart
+	8,  // 4: swaprpc.SwapMailboxEvent.out_swap_htlc:type_name -> swaprpc.OutSwapHtlcEvent
+	11, // 5: swaprpc.SwapMailboxEvent.in_ark_htlc:type_name -> swaprpc.InArkHtlcEvent
+	33, // 6: swaprpc.SwapMailboxEvent.out_swap_forfeit_signature_request:type_name -> swaprpc.OutSwapForfeitSignatureRequest
+	13, // 7: swaprpc.InArkHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	13, // 8: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	37, // 9: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
+	0,  // 10: swaprpc.CreateInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
+	18, // 11: swaprpc.CreateInSwapResponse.credit_quote:type_name -> swaprpc.CreditQuote
+	0,  // 12: swaprpc.QuoteInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
+	37, // 13: swaprpc.QuoteInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
+	18, // 14: swaprpc.QuoteInSwapResponse.credit_quote:type_name -> swaprpc.CreditQuote
+	1,  // 15: swaprpc.CreateCreditRequest.source:type_name -> swaprpc.CreditFundingSource
+	3,  // 16: swaprpc.CreateCreditResponse.state:type_name -> swaprpc.CreditOperationState
+	37, // 17: swaprpc.CreateCreditResponse.expires_at:type_name -> google.protobuf.Timestamp
+	3,  // 18: swaprpc.RedeemCreditResponse.state:type_name -> swaprpc.CreditOperationState
+	25, // 19: swaprpc.ListCreditsResponse.operations:type_name -> swaprpc.CreditOperation
+	26, // 20: swaprpc.ListCreditsResponse.ledger_entries:type_name -> swaprpc.CreditLedgerEntry
+	2,  // 21: swaprpc.CreditOperation.type:type_name -> swaprpc.CreditOperationType
+	3,  // 22: swaprpc.CreditOperation.state:type_name -> swaprpc.CreditOperationState
+	37, // 23: swaprpc.CreditOperation.created_at:type_name -> google.protobuf.Timestamp
+	37, // 24: swaprpc.CreditOperation.updated_at:type_name -> google.protobuf.Timestamp
+	37, // 25: swaprpc.CreditOperation.completed_at:type_name -> google.protobuf.Timestamp
+	37, // 26: swaprpc.CreditLedgerEntry.created_at:type_name -> google.protobuf.Timestamp
+	36, // 27: swaprpc.AuthorizeInSwapRefundResponse.signature:type_name -> swaprpc.TaprootScriptSignature
+	29, // 28: swaprpc.SignInSwapForfeitRequest.payload:type_name -> swaprpc.ForfeitSignaturePayload
+	30, // 29: swaprpc.SignInSwapForfeitResponse.signature:type_name -> swaprpc.ForfeitParticipantSignature
+	29, // 30: swaprpc.OutSwapForfeitSignatureRequest.payload:type_name -> swaprpc.ForfeitSignaturePayload
+	29, // 31: swaprpc.SubmitOutSwapForfeitSignatureRequest.payload:type_name -> swaprpc.ForfeitSignaturePayload
+	30, // 32: swaprpc.SubmitOutSwapForfeitSignatureRequest.signature:type_name -> swaprpc.ForfeitParticipantSignature
+	4,  // 33: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
+	14, // 34: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
+	16, // 35: swaprpc.SwapService.QuoteInSwap:input_type -> swaprpc.QuoteInSwapRequest
+	19, // 36: swaprpc.SwapService.CreateCredit:input_type -> swaprpc.CreateCreditRequest
+	21, // 37: swaprpc.SwapService.RedeemCredit:input_type -> swaprpc.RedeemCreditRequest
+	23, // 38: swaprpc.SwapService.ListCredits:input_type -> swaprpc.ListCreditsRequest
+	27, // 39: swaprpc.SwapService.AuthorizeInSwapRefund:input_type -> swaprpc.AuthorizeInSwapRefundRequest
+	6,  // 40: swaprpc.SwapService.AcknowledgeOutSwapHtlc:input_type -> swaprpc.AcknowledgeOutSwapHtlcRequest
+	31, // 41: swaprpc.SwapService.SignInSwapForfeit:input_type -> swaprpc.SignInSwapForfeitRequest
+	34, // 42: swaprpc.SwapService.SubmitOutSwapForfeitSignature:input_type -> swaprpc.SubmitOutSwapForfeitSignatureRequest
+	5,  // 43: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
+	15, // 44: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
+	17, // 45: swaprpc.SwapService.QuoteInSwap:output_type -> swaprpc.QuoteInSwapResponse
+	20, // 46: swaprpc.SwapService.CreateCredit:output_type -> swaprpc.CreateCreditResponse
+	22, // 47: swaprpc.SwapService.RedeemCredit:output_type -> swaprpc.RedeemCreditResponse
+	24, // 48: swaprpc.SwapService.ListCredits:output_type -> swaprpc.ListCreditsResponse
+	28, // 49: swaprpc.SwapService.AuthorizeInSwapRefund:output_type -> swaprpc.AuthorizeInSwapRefundResponse
+	7,  // 50: swaprpc.SwapService.AcknowledgeOutSwapHtlc:output_type -> swaprpc.AcknowledgeOutSwapHtlcResponse
+	32, // 51: swaprpc.SwapService.SignInSwapForfeit:output_type -> swaprpc.SignInSwapForfeitResponse
+	35, // 52: swaprpc.SwapService.SubmitOutSwapForfeitSignature:output_type -> swaprpc.SubmitOutSwapForfeitSignatureResponse
+	43, // [43:53] is the sub-list for method output_type
+	33, // [33:43] is the sub-list for method input_type
+	33, // [33:33] is the sub-list for extension type_name
+	33, // [33:33] is the sub-list for extension extendee
+	0,  // [0:33] is the sub-list for field type_name
 }
 
 func init() { file_swap_proto_init() }
@@ -2040,8 +3273,8 @@ func file_swap_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_swap_proto_rawDesc), len(file_swap_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   24,
+			NumEnums:      4,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/swaprpc/swap.pb.gw.go
+++ b/swaprpc/swap.pb.gw.go
@@ -116,6 +116,87 @@ func local_request_SwapService_QuoteInSwap_0(ctx context.Context, marshaler runt
 	return msg, metadata, err
 }
 
+func request_SwapService_CreateCredit_0(ctx context.Context, marshaler runtime.Marshaler, client SwapServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateCreditRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.CreateCredit(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SwapService_CreateCredit_0(ctx context.Context, marshaler runtime.Marshaler, server SwapServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateCreditRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.CreateCredit(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_SwapService_RedeemCredit_0(ctx context.Context, marshaler runtime.Marshaler, client SwapServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RedeemCreditRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.RedeemCredit(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SwapService_RedeemCredit_0(ctx context.Context, marshaler runtime.Marshaler, server SwapServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RedeemCreditRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.RedeemCredit(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_SwapService_ListCredits_0(ctx context.Context, marshaler runtime.Marshaler, client SwapServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListCreditsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListCredits(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SwapService_ListCredits_0(ctx context.Context, marshaler runtime.Marshaler, server SwapServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListCreditsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ListCredits(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_SwapService_AuthorizeInSwapRefund_0(ctx context.Context, marshaler runtime.Marshaler, client SwapServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq AuthorizeInSwapRefundRequest
@@ -290,6 +371,66 @@ func RegisterSwapServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_SwapService_QuoteInSwap_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_SwapService_CreateCredit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/swaprpc.SwapService/CreateCredit", runtime.WithHTTPPathPattern("/v1/swap/create-credit"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SwapService_CreateCredit_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_CreateCredit_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SwapService_RedeemCredit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/swaprpc.SwapService/RedeemCredit", runtime.WithHTTPPathPattern("/v1/swap/redeem-credit"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SwapService_RedeemCredit_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_RedeemCredit_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SwapService_ListCredits_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/swaprpc.SwapService/ListCredits", runtime.WithHTTPPathPattern("/v1/swap/list-credits"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SwapService_ListCredits_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_ListCredits_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_SwapService_AuthorizeInSwapRefund_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -461,6 +602,57 @@ func RegisterSwapServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_SwapService_QuoteInSwap_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_SwapService_CreateCredit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/swaprpc.SwapService/CreateCredit", runtime.WithHTTPPathPattern("/v1/swap/create-credit"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SwapService_CreateCredit_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_CreateCredit_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SwapService_RedeemCredit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/swaprpc.SwapService/RedeemCredit", runtime.WithHTTPPathPattern("/v1/swap/redeem-credit"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SwapService_RedeemCredit_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_RedeemCredit_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_SwapService_ListCredits_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/swaprpc.SwapService/ListCredits", runtime.WithHTTPPathPattern("/v1/swap/list-credits"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SwapService_ListCredits_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SwapService_ListCredits_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_SwapService_AuthorizeInSwapRefund_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -536,6 +728,9 @@ var (
 	pattern_SwapService_RequestChannelId_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "request-channel-id"}, ""))
 	pattern_SwapService_CreateInSwap_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "create-in-swap"}, ""))
 	pattern_SwapService_QuoteInSwap_0                   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "quote-in-swap"}, ""))
+	pattern_SwapService_CreateCredit_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "create-credit"}, ""))
+	pattern_SwapService_RedeemCredit_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "redeem-credit"}, ""))
+	pattern_SwapService_ListCredits_0                   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "list-credits"}, ""))
 	pattern_SwapService_AuthorizeInSwapRefund_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "authorize-in-swap-refund"}, ""))
 	pattern_SwapService_AcknowledgeOutSwapHtlc_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "acknowledge-out-swap-htlc"}, ""))
 	pattern_SwapService_SignInSwapForfeit_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "swap", "sign-in-swap-forfeit"}, ""))
@@ -546,6 +741,9 @@ var (
 	forward_SwapService_RequestChannelId_0              = runtime.ForwardResponseMessage
 	forward_SwapService_CreateInSwap_0                  = runtime.ForwardResponseMessage
 	forward_SwapService_QuoteInSwap_0                   = runtime.ForwardResponseMessage
+	forward_SwapService_CreateCredit_0                  = runtime.ForwardResponseMessage
+	forward_SwapService_RedeemCredit_0                  = runtime.ForwardResponseMessage
+	forward_SwapService_ListCredits_0                   = runtime.ForwardResponseMessage
 	forward_SwapService_AuthorizeInSwapRefund_0         = runtime.ForwardResponseMessage
 	forward_SwapService_AcknowledgeOutSwapHtlc_0        = runtime.ForwardResponseMessage
 	forward_SwapService_SignInSwapForfeit_0             = runtime.ForwardResponseMessage

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -18,6 +18,47 @@ enum SettlementType {
     // SETTLEMENT_TYPE_IN_ARK means sender and receiver settle with one Ark
     // vHTLC inside the same Ark instance.
     SETTLEMENT_TYPE_IN_ARK = 2;
+
+    // SETTLEMENT_TYPE_CREDIT means the swap server pays Lightning from a
+    // reserved credit balance without requiring a client-funded vHTLC.
+    SETTLEMENT_TYPE_CREDIT = 3;
+
+    // SETTLEMENT_TYPE_MIXED means the invoice is funded by both a vHTLC and
+    // a reserved credit balance.
+    SETTLEMENT_TYPE_MIXED = 4;
+}
+
+// CreditFundingSource identifies how value enters a credit account.
+enum CreditFundingSource {
+    CREDIT_FUNDING_SOURCE_UNSPECIFIED = 0;
+    CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE = 1;
+    CREDIT_FUNDING_SOURCE_ARK_TOPUP = 2;
+}
+
+// CreditOperationType identifies the durable credit state machine family.
+enum CreditOperationType {
+    CREDIT_OPERATION_TYPE_UNSPECIFIED = 0;
+    CREDIT_OPERATION_TYPE_FUNDING = 1;
+    CREDIT_OPERATION_TYPE_PAY = 2;
+    CREDIT_OPERATION_TYPE_REDEMPTION = 3;
+    CREDIT_OPERATION_TYPE_RECEIVE = 4;
+}
+
+// CreditOperationState is the externally visible state of one credit
+// operation.
+enum CreditOperationState {
+    CREDIT_OPERATION_STATE_UNSPECIFIED = 0;
+    CREDIT_OPERATION_STATE_CREATED = 1;
+    CREDIT_OPERATION_STATE_AWAITING_PAYMENT = 2;
+    CREDIT_OPERATION_STATE_CREDITED = 3;
+    CREDIT_OPERATION_STATE_RESERVED = 4;
+    CREDIT_OPERATION_STATE_PAYING_LIGHTNING = 5;
+    CREDIT_OPERATION_STATE_DEBITED = 6;
+    CREDIT_OPERATION_STATE_SENDING_OOR = 7;
+    CREDIT_OPERATION_STATE_REDEEMED = 8;
+    CREDIT_OPERATION_STATE_RELEASED = 9;
+    CREDIT_OPERATION_STATE_EXPIRED = 10;
+    CREDIT_OPERATION_STATE_FAILED = 11;
 }
 
 // SwapService exposes the external swap server API consumed by the client SDK.
@@ -35,6 +76,19 @@ service SwapService {
     // QuoteInSwap previews how an invoice send would settle without creating
     // durable swap state or notifying a same-Ark receiver.
     rpc QuoteInSwap (QuoteInSwapRequest) returns (QuoteInSwapResponse);
+
+    // CreateCredit creates a durable credit funding operation. Lightning
+    // receives return a server-owned invoice; Ark top-ups return a
+    // server-owned OOR destination.
+    rpc CreateCredit (CreateCreditRequest) returns (CreateCreditResponse);
+
+    // RedeemCredit materializes available credits back into an Ark OOR
+    // output. The OOR output amount must be at least dust.
+    rpc RedeemCredit (RedeemCreditRequest) returns (RedeemCreditResponse);
+
+    // ListCredits returns the account balance plus recent credit operations
+    // and ledger rows.
+    rpc ListCredits (ListCreditsRequest) returns (ListCreditsResponse);
 
     // AuthorizeInSwapRefund signs a prepared cooperative refund spend for a
     // funded in-swap whose Lightning payment attempt has terminally failed.
@@ -75,11 +129,8 @@ message RequestChannelIdRequest {
     // adding a separate auth identity.
     bytes payment_hash = 3;
 
-    // amount_msat is the exact amount the Ark receiver expects to receive,
-    // expressed in millisatoshis. The swap server's out-swap fee is charged to
-    // the Lightning payer through the route hint and does not reduce this
-    // amount.
-    uint64 amount_msat = 4;
+    // amount_sat is the exact invoice amount the payer should send.
+    uint64 amount_sat = 4;
 }
 
 // RequestChannelIdResponse returns the route hint for one receive negotiation.
@@ -89,8 +140,30 @@ message RequestChannelIdResponse {
 
     // payer_fee_msat is the quoted Lightning route fee paid by the sender for
     // the swap server's virtual hop. Callers that want a "payer pays" total
-    // compute it as amount_msat plus payer_fee_msat.
+    // compute it as amount_sat*1000 plus payer_fee_msat.
     uint64 payer_fee_msat = 2;
+
+    // requested_amount_sat is the invoice amount requested by the receiver.
+    uint64 requested_amount_sat = 3;
+
+    // available_credit_sat is the credit balance considered for the receive
+    // plan at route creation time.
+    uint64 available_credit_sat = 4;
+
+    // attached_credit_sat is the credit amount the server reserved and will
+    // add to the funded vHTLC.
+    uint64 attached_credit_sat = 5;
+
+    // vhtlc_amount_sat is the Ark vHTLC output amount the client should
+    // expect if this route is paid.
+    uint64 vhtlc_amount_sat = 6;
+
+    // dust_limit_sat is the minimum Ark vHTLC amount used for this decision.
+    uint64 dust_limit_sat = 7;
+
+    // settlement_type identifies whether the route is normal Lightning or
+    // credit-assisted.
+    SettlementType settlement_type = 8;
 }
 
 // AcknowledgeOutSwapHtlcRequest confirms that the receiver has validated and
@@ -118,7 +191,7 @@ message OutSwapHtlcEvent {
     // payment_hash is the intercepted HTLC hash.
     bytes payment_hash = 1;
 
-    // amount_sat is the whole-satoshi amount funded in the vHTLC.
+    // amount_sat is the sat-denominated amount funded in the vHTLC.
     uint64 amount_sat = 2;
 
     // onion_blob is the raw next-hop onion blob delivered by LND.
@@ -131,9 +204,15 @@ message OutSwapHtlcEvent {
     // parts lists the individual HTLC shards that make up a multi-part
     // payment set. When empty the event describes a legacy single-part
     // payment carried by onion_blob. When populated, amount_sat is still
-    // the whole-satoshi total funded in the vHTLC and onion_blob mirrors
+    // the sat-denominated total funded in the vHTLC and onion_blob mirrors
     // the first part for backwards compatibility.
     repeated OutSwapHtlcPart parts = 5;
+
+    // requested_amount_sat is the Lightning invoice amount paid by the payer.
+    uint64 requested_amount_sat = 6;
+
+    // attached_credit_sat is the reserved credit amount added to the vHTLC.
+    uint64 attached_credit_sat = 7;
 }
 
 // OutSwapHtlcPart describes one HTLC shard of a multi-part out-swap payment
@@ -175,7 +254,7 @@ message InArkHtlcEvent {
     // payment_hash is the invoice payment hash.
     bytes payment_hash = 1;
 
-    // amount_sat is the whole-satoshi amount funded in the vHTLC.
+    // amount_sat is the sat-denominated amount funded in the vHTLC.
     uint64 amount_sat = 2;
 
     // sender_pubkey is the payment sender's public key used in the vHTLC
@@ -246,6 +325,14 @@ message CreateInSwapRequest {
     // client_vhtlc_pubkey is the client's public key used in the vHTLC spend
     // paths.
     bytes client_vhtlc_pubkey = 3;
+
+    // account_pubkey identifies the wallet credit account to inspect or
+    // reserve from when credit funding is allowed.
+    bytes account_pubkey = 4;
+
+    // max_credit_sat is the maximum credit amount the caller authorizes this
+    // payment to reserve. Zero means credit use is not allowed.
+    uint64 max_credit_sat = 5;
 }
 
 // CreateInSwapResponse returns the negotiated parameters for one in-swap.
@@ -271,6 +358,13 @@ message CreateInSwapResponse {
     // settlement_type identifies whether this negotiation should be completed
     // through Lightning or directly inside the Ark instance.
     SettlementType settlement_type = 7;
+
+    // credit_quote describes any credit reservation attached to this pay.
+    CreditQuote credit_quote = 8;
+
+    // preimage is set for credit-only pays after the swap server has already
+    // paid the Lightning invoice from reserved credits.
+    bytes preimage = 9;
 }
 
 // QuoteInSwapRequest previews one Ark-to-Lightning invoice send.
@@ -281,6 +375,15 @@ message QuoteInSwapRequest {
     // max_fee_sat is the caller's fee cap. Quotes still return when the
     // computed server fee exceeds this cap so callers can render the fee.
     uint64 max_fee_sat = 2;
+
+    // account_pubkey identifies the wallet credit account to inspect. Empty
+    // means the quote ignores credits.
+    bytes account_pubkey = 3;
+
+    // max_credit_sat is the maximum credit amount the caller is willing to
+    // use. Zero means the quote reports whether credits are required but does
+    // not apply optional credits.
+    uint64 max_credit_sat = 4;
 }
 
 // QuoteInSwapResponse returns the non-binding preview for one invoice send.
@@ -288,7 +391,8 @@ message QuoteInSwapResponse {
     // payment_hash is the SHA-256 payment hash extracted from the invoice.
     bytes payment_hash = 1;
 
-    // invoice_amount_sat is the whole-satoshi amount requested by the invoice.
+    // invoice_amount_sat is the sat-denominated amount requested by the
+    // invoice.
     uint64 invoice_amount_sat = 2;
 
     // amount_sat is the total amount that would be locked in the vHTLC.
@@ -307,6 +411,119 @@ message QuoteInSwapResponse {
     // exceeds_max_fee is true when max_fee_sat is non-zero and fee_sat is
     // larger than that cap.
     bool exceeds_max_fee = 7;
+
+    // credit_quote describes how credits would be used for this invoice.
+    CreditQuote credit_quote = 8;
+}
+
+// CreditQuote describes the credit component of a pay quote.
+message CreditQuote {
+    // must_use_credit is true when the invoice amount cannot be represented by
+    // the normal vHTLC path.
+    bool must_use_credit = 1;
+
+    // credit_applied_sat is the credit amount the quote expects to reserve.
+    uint64 credit_applied_sat = 2;
+
+    // credit_shortfall_sat is the additional credit needed before this
+    // payment can be admitted.
+    uint64 credit_shortfall_sat = 3;
+
+    // credit_topup_sat is the Ark top-up amount required to cover the
+    // shortfall. It is rounded up and dust-limited by the server.
+    uint64 credit_topup_sat = 4;
+
+    // ark_funding_sat is the amount the client must still fund through the
+    // normal vHTLC path.
+    uint64 ark_funding_sat = 5;
+}
+
+message CreateCreditRequest {
+    // account_pubkey identifies the wallet credit account.
+    bytes account_pubkey = 1;
+
+    // idempotency_key identifies one caller intent across retries.
+    string idempotency_key = 2;
+
+    CreditFundingSource source = 3;
+
+    // amount_sat is the credit amount to create.
+    uint64 amount_sat = 4;
+
+    // memo is embedded into server-owned Lightning receive invoices when the
+    // source is LIGHTNING_RECEIVE.
+    string memo = 5;
+}
+
+message CreateCreditResponse {
+    string operation_id = 1;
+    CreditOperationState state = 2;
+
+    // invoice is set for LIGHTNING_RECEIVE credit funding.
+    string invoice = 3;
+
+    // payment_hash is set when an invoice-backed operation exists.
+    bytes payment_hash = 4;
+
+    // amount_sat is the sat amount that will be credited when complete.
+    uint64 amount_sat = 5;
+
+    // destination_pubkey is the server-owned x-only Ark recipient pubkey for
+    // ARK_TOPUP.
+    bytes destination_pubkey = 7;
+
+    google.protobuf.Timestamp expires_at = 8;
+}
+
+message RedeemCreditRequest {
+    bytes account_pubkey = 1;
+    string idempotency_key = 2;
+    uint64 amount_sat = 3;
+    bytes destination_pubkey = 4;
+}
+
+message RedeemCreditResponse {
+    string operation_id = 1;
+    CreditOperationState state = 2;
+    uint64 debited_sat = 3;
+    uint64 redeemed_sat = 4;
+    string session_id = 5;
+}
+
+message ListCreditsRequest {
+    bytes account_pubkey = 1;
+    uint32 limit = 2;
+}
+
+message ListCreditsResponse {
+    uint64 finalized_sat = 1;
+    uint64 reserved_sat = 2;
+    uint64 available_sat = 3;
+    repeated CreditOperation operations = 4;
+    repeated CreditLedgerEntry ledger_entries = 5;
+}
+
+message CreditOperation {
+    string operation_id = 1;
+    CreditOperationType type = 2;
+    CreditOperationState state = 3;
+    uint64 amount_sat = 4;
+    bytes payment_hash = 6;
+    string invoice = 7;
+    bytes destination_pubkey = 8;
+    string session_id = 9;
+    google.protobuf.Timestamp created_at = 10;
+    google.protobuf.Timestamp updated_at = 11;
+    google.protobuf.Timestamp completed_at = 12;
+    string last_error = 13;
+}
+
+message CreditLedgerEntry {
+    string entry_id = 1;
+    string operation_id = 2;
+    string direction = 3;
+    uint64 amount_sat = 4;
+    google.protobuf.Timestamp created_at = 5;
 }
 
 message AuthorizeInSwapRefundRequest {

--- a/swaprpc/swap.yaml
+++ b/swaprpc/swap.yaml
@@ -12,6 +12,15 @@ http:
     - selector: swaprpc.SwapService.QuoteInSwap
       post: /v1/swap/quote-in-swap
       body: "*"
+    - selector: swaprpc.SwapService.CreateCredit
+      post: /v1/swap/create-credit
+      body: "*"
+    - selector: swaprpc.SwapService.RedeemCredit
+      post: /v1/swap/redeem-credit
+      body: "*"
+    - selector: swaprpc.SwapService.ListCredits
+      post: /v1/swap/list-credits
+      body: "*"
     - selector: swaprpc.SwapService.AuthorizeInSwapRefund
       post: /v1/swap/authorize-in-swap-refund
       body: "*"

--- a/swaprpc/swap_grpc.pb.go
+++ b/swaprpc/swap_grpc.pb.go
@@ -22,6 +22,9 @@ const (
 	SwapService_RequestChannelId_FullMethodName              = "/swaprpc.SwapService/RequestChannelId"
 	SwapService_CreateInSwap_FullMethodName                  = "/swaprpc.SwapService/CreateInSwap"
 	SwapService_QuoteInSwap_FullMethodName                   = "/swaprpc.SwapService/QuoteInSwap"
+	SwapService_CreateCredit_FullMethodName                  = "/swaprpc.SwapService/CreateCredit"
+	SwapService_RedeemCredit_FullMethodName                  = "/swaprpc.SwapService/RedeemCredit"
+	SwapService_ListCredits_FullMethodName                   = "/swaprpc.SwapService/ListCredits"
 	SwapService_AuthorizeInSwapRefund_FullMethodName         = "/swaprpc.SwapService/AuthorizeInSwapRefund"
 	SwapService_AcknowledgeOutSwapHtlc_FullMethodName        = "/swaprpc.SwapService/AcknowledgeOutSwapHtlc"
 	SwapService_SignInSwapForfeit_FullMethodName             = "/swaprpc.SwapService/SignInSwapForfeit"
@@ -44,6 +47,16 @@ type SwapServiceClient interface {
 	// QuoteInSwap previews how an invoice send would settle without creating
 	// durable swap state or notifying a same-Ark receiver.
 	QuoteInSwap(ctx context.Context, in *QuoteInSwapRequest, opts ...grpc.CallOption) (*QuoteInSwapResponse, error)
+	// CreateCredit creates a durable credit funding operation. Lightning
+	// receives return a server-owned invoice; Ark top-ups return a
+	// server-owned OOR destination.
+	CreateCredit(ctx context.Context, in *CreateCreditRequest, opts ...grpc.CallOption) (*CreateCreditResponse, error)
+	// RedeemCredit materializes available credits back into an Ark OOR
+	// output. The OOR output amount must be at least dust.
+	RedeemCredit(ctx context.Context, in *RedeemCreditRequest, opts ...grpc.CallOption) (*RedeemCreditResponse, error)
+	// ListCredits returns the account balance plus recent credit operations
+	// and ledger rows.
+	ListCredits(ctx context.Context, in *ListCreditsRequest, opts ...grpc.CallOption) (*ListCreditsResponse, error)
 	// AuthorizeInSwapRefund signs a prepared cooperative refund spend for a
 	// funded in-swap whose Lightning payment attempt has terminally failed.
 	AuthorizeInSwapRefund(ctx context.Context, in *AuthorizeInSwapRefundRequest, opts ...grpc.CallOption) (*AuthorizeInSwapRefundResponse, error)
@@ -93,6 +106,36 @@ func (c *swapServiceClient) QuoteInSwap(ctx context.Context, in *QuoteInSwapRequ
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(QuoteInSwapResponse)
 	err := c.cc.Invoke(ctx, SwapService_QuoteInSwap_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *swapServiceClient) CreateCredit(ctx context.Context, in *CreateCreditRequest, opts ...grpc.CallOption) (*CreateCreditResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateCreditResponse)
+	err := c.cc.Invoke(ctx, SwapService_CreateCredit_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *swapServiceClient) RedeemCredit(ctx context.Context, in *RedeemCreditRequest, opts ...grpc.CallOption) (*RedeemCreditResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RedeemCreditResponse)
+	err := c.cc.Invoke(ctx, SwapService_RedeemCredit_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *swapServiceClient) ListCredits(ctx context.Context, in *ListCreditsRequest, opts ...grpc.CallOption) (*ListCreditsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListCreditsResponse)
+	err := c.cc.Invoke(ctx, SwapService_ListCredits_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -155,6 +198,16 @@ type SwapServiceServer interface {
 	// QuoteInSwap previews how an invoice send would settle without creating
 	// durable swap state or notifying a same-Ark receiver.
 	QuoteInSwap(context.Context, *QuoteInSwapRequest) (*QuoteInSwapResponse, error)
+	// CreateCredit creates a durable credit funding operation. Lightning
+	// receives return a server-owned invoice; Ark top-ups return a
+	// server-owned OOR destination.
+	CreateCredit(context.Context, *CreateCreditRequest) (*CreateCreditResponse, error)
+	// RedeemCredit materializes available credits back into an Ark OOR
+	// output. The OOR output amount must be at least dust.
+	RedeemCredit(context.Context, *RedeemCreditRequest) (*RedeemCreditResponse, error)
+	// ListCredits returns the account balance plus recent credit operations
+	// and ledger rows.
+	ListCredits(context.Context, *ListCreditsRequest) (*ListCreditsResponse, error)
 	// AuthorizeInSwapRefund signs a prepared cooperative refund spend for a
 	// funded in-swap whose Lightning payment attempt has terminally failed.
 	AuthorizeInSwapRefund(context.Context, *AuthorizeInSwapRefundRequest) (*AuthorizeInSwapRefundResponse, error)
@@ -188,6 +241,15 @@ func (UnimplementedSwapServiceServer) CreateInSwap(context.Context, *CreateInSwa
 }
 func (UnimplementedSwapServiceServer) QuoteInSwap(context.Context, *QuoteInSwapRequest) (*QuoteInSwapResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method QuoteInSwap not implemented")
+}
+func (UnimplementedSwapServiceServer) CreateCredit(context.Context, *CreateCreditRequest) (*CreateCreditResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateCredit not implemented")
+}
+func (UnimplementedSwapServiceServer) RedeemCredit(context.Context, *RedeemCreditRequest) (*RedeemCreditResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RedeemCredit not implemented")
+}
+func (UnimplementedSwapServiceServer) ListCredits(context.Context, *ListCreditsRequest) (*ListCreditsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListCredits not implemented")
 }
 func (UnimplementedSwapServiceServer) AuthorizeInSwapRefund(context.Context, *AuthorizeInSwapRefundRequest) (*AuthorizeInSwapRefundResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AuthorizeInSwapRefund not implemented")
@@ -272,6 +334,60 @@ func _SwapService_QuoteInSwap_Handler(srv interface{}, ctx context.Context, dec 
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(SwapServiceServer).QuoteInSwap(ctx, req.(*QuoteInSwapRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SwapService_CreateCredit_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateCreditRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SwapServiceServer).CreateCredit(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SwapService_CreateCredit_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SwapServiceServer).CreateCredit(ctx, req.(*CreateCreditRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SwapService_RedeemCredit_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RedeemCreditRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SwapServiceServer).RedeemCredit(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SwapService_RedeemCredit_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SwapServiceServer).RedeemCredit(ctx, req.(*RedeemCreditRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SwapService_ListCredits_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListCreditsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SwapServiceServer).ListCredits(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SwapService_ListCredits_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SwapServiceServer).ListCredits(ctx, req.(*ListCreditsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -366,6 +482,18 @@ var SwapService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "QuoteInSwap",
 			Handler:    _SwapService_QuoteInSwap_Handler,
+		},
+		{
+			MethodName: "CreateCredit",
+			Handler:    _SwapService_CreateCredit_Handler,
+		},
+		{
+			MethodName: "RedeemCredit",
+			Handler:    _SwapService_RedeemCredit_Handler,
+		},
+		{
+			MethodName: "ListCredits",
+			Handler:    _SwapService_ListCredits_Handler,
 		},
 		{
 			MethodName: "AuthorizeInSwapRefund",

--- a/swaprpc/swap_mailboxrpc.pb.go
+++ b/swaprpc/swap_mailboxrpc.pb.go
@@ -30,6 +30,12 @@ type SwapServiceMailboxServer interface {
 	CreateInSwap(ctx context.Context, req *CreateInSwapRequest) (*CreateInSwapResponse, error)
 	// QuoteInSwap handles QuoteInSwap.
 	QuoteInSwap(ctx context.Context, req *QuoteInSwapRequest) (*QuoteInSwapResponse, error)
+	// CreateCredit handles CreateCredit.
+	CreateCredit(ctx context.Context, req *CreateCreditRequest) (*CreateCreditResponse, error)
+	// RedeemCredit handles RedeemCredit.
+	RedeemCredit(ctx context.Context, req *RedeemCreditRequest) (*RedeemCreditResponse, error)
+	// ListCredits handles ListCredits.
+	ListCredits(ctx context.Context, req *ListCreditsRequest) (*ListCreditsResponse, error)
 	// AuthorizeInSwapRefund handles AuthorizeInSwapRefund.
 	AuthorizeInSwapRefund(ctx context.Context, req *AuthorizeInSwapRefundRequest) (*AuthorizeInSwapRefundResponse, error)
 	// AcknowledgeOutSwapHtlc handles AcknowledgeOutSwapHtlc.
@@ -71,6 +77,36 @@ func RegisterSwapServiceMailboxServer(r rpc.Router, impl SwapServiceMailboxServe
 		}
 
 		return impl.QuoteInSwap(ctx, req)
+	})
+	r.Handle("swaprpc.SwapService", "CreateCredit", func() proto.Message {
+		return &CreateCreditRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*CreateCreditRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.CreateCredit(ctx, req)
+	})
+	r.Handle("swaprpc.SwapService", "RedeemCredit", func() proto.Message {
+		return &RedeemCreditRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*RedeemCreditRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.RedeemCredit(ctx, req)
+	})
+	r.Handle("swaprpc.SwapService", "ListCredits", func() proto.Message {
+		return &ListCreditsRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ListCreditsRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ListCredits(ctx, req)
 	})
 	r.Handle("swaprpc.SwapService", "AuthorizeInSwapRefund", func() proto.Message {
 		return &AuthorizeInSwapRefundRequest{}
@@ -176,6 +212,75 @@ func (c *SwapServiceMailboxClient) QuoteInSwap(ctx context.Context, req *QuoteIn
 	}
 
 	resp := new(QuoteInSwapResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// CreateCredit calls the CreateCredit RPC.
+func (c *SwapServiceMailboxClient) CreateCredit(ctx context.Context, req *CreateCreditRequest, opts ...rpc.RPCOptions) (*CreateCreditResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "swaprpc.SwapService",
+		Method:  "CreateCredit",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(CreateCreditResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// RedeemCredit calls the RedeemCredit RPC.
+func (c *SwapServiceMailboxClient) RedeemCredit(ctx context.Context, req *RedeemCreditRequest, opts ...rpc.RPCOptions) (*RedeemCreditResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "swaprpc.SwapService",
+		Method:  "RedeemCredit",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(RedeemCreditResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ListCredits calls the ListCredits RPC.
+func (c *SwapServiceMailboxClient) ListCredits(ctx context.Context, req *ListCreditsRequest, opts ...rpc.RPCOptions) (*ListCreditsResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "swaprpc.SwapService",
+		Method:  "ListCredits",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ListCreditsResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/swapwallet/deps.go
+++ b/swapwallet/deps.go
@@ -35,6 +35,12 @@ type RPCServer interface {
 		req *daemonrpc.SendOnChainRequest) (
 		*daemonrpc.SendOnChainResponse, error)
 
+	SendOOR(ctx context.Context,
+		req *daemonrpc.SendOORRequest) (
+		*daemonrpc.SendOORResponse,
+		error,
+	)
+
 	ListVTXOs(ctx context.Context,
 		req *daemonrpc.ListVTXOsRequest) (
 		*daemonrpc.ListVTXOsResponse,

--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -90,6 +90,11 @@ type fakeRPCServer struct {
 	sendOnChainCalls   int
 	sendOnChainLastReq *daemonrpc.SendOnChainRequest
 
+	sendOORResp    *daemonrpc.SendOORResponse
+	sendOORErr     error
+	sendOORCalls   int
+	sendOORLastReq *daemonrpc.SendOORRequest
+
 	estimateFeeResp    *daemonrpc.EstimateFeeResponse
 	estimateFeeErr     error
 	estimateFeeCalls   int
@@ -299,6 +304,18 @@ func (f *fakeRPCServer) SendOnChain(_ context.Context,
 	return f.sendOnChainResp, f.sendOnChainErr
 }
 
+func (f *fakeRPCServer) SendOOR(_ context.Context,
+	req *daemonrpc.SendOORRequest) (*daemonrpc.SendOORResponse, error) {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.sendOORCalls++
+	f.sendOORLastReq = req
+
+	return f.sendOORResp, f.sendOORErr
+}
+
 // fakeSwapService is a minimal swapclientrpc.SwapClientServiceServer used
 // by router/recv/history/service tests. Each method returns canned
 // responses or errors set by the test. Streaming methods are not invoked
@@ -326,6 +343,16 @@ type fakeSwapService struct {
 	listSwapsErr   error
 	listSwapsCalls int
 	listSwapsLast  *swapclientrpc.ListSwapsRequest
+
+	createCreditResp  *swapclientrpc.CreateCreditResponse
+	createCreditErr   error
+	createCreditCalls int
+	createCreditLast  *swapclientrpc.CreateCreditRequest
+
+	listCreditsResp  *swapclientrpc.ListCreditsResponse
+	listCreditsErr   error
+	listCreditsCalls int
+	listCreditsLast  *swapclientrpc.ListCreditsRequest
 }
 
 func (f *fakeSwapService) QuotePay(_ context.Context,
@@ -356,6 +383,26 @@ func (f *fakeSwapService) StartReceive(_ context.Context,
 	f.startReceiveLast = req
 
 	return f.startReceiveResp, f.startReceiveErr
+}
+
+func (f *fakeSwapService) CreateCredit(_ context.Context,
+	req *swapclientrpc.CreateCreditRequest) (
+	*swapclientrpc.CreateCreditResponse, error) {
+
+	f.createCreditCalls++
+	f.createCreditLast = req
+
+	return f.createCreditResp, f.createCreditErr
+}
+
+func (f *fakeSwapService) ListCredits(_ context.Context,
+	req *swapclientrpc.ListCreditsRequest) (
+	*swapclientrpc.ListCreditsResponse, error) {
+
+	f.listCreditsCalls++
+	f.listCreditsLast = req
+
+	return f.listCreditsResp, f.listCreditsErr
 }
 
 func (f *fakeSwapService) ListSwaps(_ context.Context,

--- a/swapwallet/recv.go
+++ b/swapwallet/recv.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 )
@@ -50,13 +51,31 @@ func (r *receiver) Recv(ctx context.Context, req *walletdkrpc.RecvRequest) (
 			ErrAmountInvalid)
 	}
 
+	plannedVHTLCSat := amt
+	dustLimit, err := r.receiveDustLimit(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if dustLimit > 0 && amt < dustLimit {
+		availableCreditSat, err := r.availableCreditSat(ctx)
+		if err != nil {
+			return r.recvCredit(ctx, req, amt)
+		}
+		if amt > ^uint64(0)-availableCreditSat ||
+			amt+availableCreditSat < dustLimit {
+			return r.recvCredit(ctx, req, amt)
+		}
+
+		plannedVHTLCSat = amt + availableCreditSat
+	}
+
 	// Enforce the operator's per-VTXO and total-balance limits before a
-	// swap session (and invoice) is created, so the user gets a clean
-	// rejection instead of a stuck swap.
+	// swap session is created. For credit-assisted receives, check the
+	// actual vHTLC amount the server will ask the client to accept.
 	if r.deps.RPCServer != nil {
 		err := checkReceiveLimits(
 			ctx, r.deps.RPCServer, r.deps.resolveLog(),
-			btcutil.Amount(amt),
+			btcutil.Amount(plannedVHTLCSat),
 		)
 		if err != nil {
 			return nil, err
@@ -93,4 +112,100 @@ func (r *receiver) Recv(ctx context.Context, req *walletdkrpc.RecvRequest) (
 		Invoice: startResp.GetInvoice(),
 		Entry:   entry,
 	}, nil
+}
+
+func (r *receiver) receiveDustLimit(ctx context.Context) (uint64, error) {
+	if r.deps.RPCServer == nil {
+		return 0, nil
+	}
+
+	info, err := r.deps.RPCServer.GetInfo(ctx, &daemonrpc.GetInfoRequest{})
+	if err != nil {
+		return 0, fmt.Errorf("get server info: %w", err)
+	}
+	if info.GetServerInfo() == nil {
+		return 0, nil
+	}
+
+	return info.GetServerInfo().GetDustLimit(), nil
+}
+
+func (r *receiver) availableCreditSat(ctx context.Context) (uint64, error) {
+	credits, err := r.deps.SwapService.ListCredits(
+		ctx, &swapclientrpc.ListCreditsRequest{
+			Limit: 1,
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	return credits.GetAvailableSat(), nil
+}
+
+func (r *receiver) recvCredit(ctx context.Context, req *walletdkrpc.RecvRequest,
+	amt uint64) (*walletdkrpc.RecvResponse, error) {
+
+	idempotencyKey, err := newSendIntentID()
+	if err != nil {
+		return nil, fmt.Errorf("create credit receive id: %w", err)
+	}
+
+	creditResp, err := r.deps.SwapService.CreateCredit(
+		ctx, &swapclientrpc.CreateCreditRequest{
+			IdempotencyKey: idempotencyKey,
+			Source: swapclientrpc.
+				CreditFundingSource_CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE,
+			AmountSat: amt,
+			Memo:      req.GetMemo(),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create credit receive: %w", err)
+	}
+
+	entry := creditReceiveEntry(req, creditResp, amt)
+
+	return &walletdkrpc.RecvResponse{
+		Invoice: creditResp.GetInvoice(),
+		Entry:   entry,
+		CreditReceive: &walletdkrpc.CreditReceive{
+			OperationId: creditResp.GetOperationId(),
+			AmountSat:   creditResp.GetAmountSat(),
+			PaymentHash: creditResp.GetPaymentHash(),
+		},
+	}, nil
+}
+
+func creditReceiveEntry(req *walletdkrpc.RecvRequest,
+	resp *swapclientrpc.CreateCreditResponse,
+	amt uint64) *walletdkrpc.WalletEntry {
+
+	now := nowUnix()
+
+	return &walletdkrpc.WalletEntry{
+		Id:            resp.GetOperationId(),
+		Kind:          walletdkrpc.EntryKind_ENTRY_KIND_RECV,
+		Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		AmountSat:     int64(amt),
+		Counterparty:  "credit",
+		CreatedAtUnix: now,
+		UpdatedAtUnix: now,
+		Note:          req.GetMemo(),
+		Request: &walletdkrpc.WalletEntryRequest{
+			Request: &walletdkrpc.WalletEntryRequest_LightningInvoice{
+				LightningInvoice: &walletdkrpc.
+					LightningInvoiceRequest{
+					Invoice:     resp.GetInvoice(),
+					PaymentHash: resp.GetPaymentHash(),
+				},
+			},
+		},
+		Progress: &walletdkrpc.WalletEntryProgress{
+			Phase: walletdkrpc.
+				WalletEntryPhase_WALLET_ENTRY_PHASE_WAITING_FOR_PAYMENT,
+			PhaseLabel:  "waiting_for_payment",
+			PaymentHash: resp.GetPaymentHash(),
+		},
+	}
 }

--- a/swapwallet/recv_test.go
+++ b/swapwallet/recv_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 	"github.com/stretchr/testify/require"
@@ -68,6 +69,62 @@ func TestRecvDispatchesStartReceive(t *testing.T) {
 	)
 	require.Equal(
 		t, walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_SETTLING,
+		resp.GetEntry().GetProgress().GetPhase(),
+	)
+}
+
+func TestRecvBelowDustCreatesCreditReceive(t *testing.T) {
+	t.Parallel()
+
+	swap := &fakeSwapService{
+		createCreditResp: &swapclientrpc.CreateCreditResponse{
+			OperationId: "cr_recv",
+			Invoice:     "lnbc1credit",
+			PaymentHash: "hash-credit",
+			AmountSat:   500,
+		},
+	}
+	rpc := &fakeRPCServer{
+		getInfoResp: &daemonrpc.GetInfoResponse{
+			ServerInfo: &daemonrpc.ServerInfo{
+				DustLimit: 1_000,
+			},
+		},
+	}
+	deps := &Deps{
+		SwapService: swap,
+		RPCServer:   rpc,
+	}
+	runtime := newRuntime(t.Context(), deps)
+	t.Cleanup(runtime.stop)
+	receiver := newReceiver(deps, runtime)
+
+	resp, err := receiver.Recv(
+		t.Context(), &walletdkrpc.RecvRequest{
+			AmtSat: 500,
+			Memo:   "tiny",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 0, swap.startReceiveCalls)
+	require.Equal(t, 1, swap.createCreditCalls)
+	require.Equal(
+		t, swapclientrpc.
+			CreditFundingSource_CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE,
+		swap.createCreditLast.GetSource(),
+	)
+	require.Equal(t, uint64(500), swap.createCreditLast.GetAmountSat())
+	require.Equal(t, "tiny", swap.createCreditLast.GetMemo())
+	require.Equal(t, "lnbc1credit", resp.GetInvoice())
+	require.Equal(t, "cr_recv", resp.GetCreditReceive().GetOperationId())
+	require.Equal(t, int64(500), resp.GetEntry().GetAmountSat())
+	require.Equal(
+		t, walletdkrpc.EntryKind_ENTRY_KIND_RECV,
+		resp.GetEntry().GetKind(),
+	)
+	require.Equal(
+		t, walletdkrpc.
+			WalletEntryPhase_WALLET_ENTRY_PHASE_WAITING_FOR_PAYMENT,
 		resp.GetEntry().GetProgress().GetPhase(),
 	)
 }

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -138,8 +139,9 @@ func (r *router) prepareInvoice(ctx context.Context, invoice string,
 
 	quote, err := r.deps.SwapService.QuotePay(
 		ctx, &swapclientrpc.QuotePayRequest{
-			Invoice:   invoice,
-			MaxFeeSat: req.GetMaxFeeSat(),
+			Invoice:      invoice,
+			MaxFeeSat:    req.GetMaxFeeSat(),
+			MaxCreditSat: ^uint64(0),
 		},
 	)
 	if err != nil {
@@ -162,6 +164,23 @@ func (r *router) prepareInvoice(ctx context.Context, invoice string,
 	if err != nil {
 		return nil, err
 	}
+	if quote != nil && quote.GetCreditQuote() != nil {
+		creditQuote := quote.GetCreditQuote()
+		intent.creditPreview = preview.creditPreview
+		intent.maxCreditSat = creditQuote.GetCreditAppliedSat()
+		if creditQuote.GetCreditShortfallSat() >
+			^uint64(0)-intent.maxCreditSat {
+
+			intent.maxCreditSat = ^uint64(0)
+		} else {
+			intent.maxCreditSat += creditQuote.GetCreditShortfallSat()
+		}
+		if quote.GetCreditQuote().GetMustUseCredit() {
+			if uint64(amountSat) > intent.maxCreditSat {
+				intent.maxCreditSat = uint64(amountSat)
+			}
+		}
+	}
 
 	if _, err := r.intents.put(intent); err != nil {
 		return nil, err
@@ -179,10 +198,15 @@ func (r *router) sendInvoiceIntent(ctx context.Context,
 		return nil, ErrSwapBackendUnavailable
 	}
 
+	if err := r.fundInvoiceCreditShortfall(ctx, intent); err != nil {
+		return nil, err
+	}
+
 	startResp, err := r.deps.SwapService.StartPay(
 		ctx, &swapclientrpc.StartPayRequest{
-			Invoice:   intent.invoice,
-			MaxFeeSat: intent.maxFeeSat,
+			Invoice:      intent.invoice,
+			MaxFeeSat:    intent.maxFeeSat,
+			MaxCreditSat: intent.maxCreditSat,
 		},
 	)
 	if err != nil {
@@ -197,10 +221,144 @@ func (r *router) sendInvoiceIntent(ctx context.Context,
 	// For invoice sends actual_amount_sat is the swap's negotiated
 	// principal: that's what is being paid to the BOLT-11 destination
 	// (routing fees are tracked separately via fee_sat on the entry).
+	actualAmountSat := startResp.GetSwap().GetAmountSat()
+	if actualAmountSat == 0 {
+		actualAmountSat = int64(intent.amountSat)
+	}
+
 	return &walletdkrpc.SendResponse{
 		Entry:           entry,
-		ActualAmountSat: startResp.GetSwap().GetAmountSat(),
+		ActualAmountSat: actualAmountSat,
 	}, nil
+}
+
+func (r *router) fundInvoiceCreditShortfall(ctx context.Context,
+	intent *preparedSendIntent) error {
+
+	if intent == nil || intent.creditPreview == nil ||
+		intent.creditPreview.GetCreditShortfallSat() == 0 {
+		return nil
+	}
+	if r.deps.RPCServer == nil {
+		return ErrSwapBackendUnavailable
+	}
+
+	topupSat := intent.creditPreview.GetCreditTopupSat()
+	if topupSat == 0 {
+		return fmt.Errorf("%w: credit top-up amount missing",
+			ErrAmountInvalid)
+	}
+	if topupSat > math.MaxInt64 {
+		return fmt.Errorf("%w: credit top-up exceeds int64 range",
+			ErrAmountInvalid)
+	}
+
+	idempotencyKey := "credit-topup-" + intent.id
+	creditResp, err := r.deps.SwapService.CreateCredit(
+		ctx, &swapclientrpc.CreateCreditRequest{
+			IdempotencyKey: idempotencyKey,
+			Source: swapclientrpc.
+				CreditFundingSource_CREDIT_FUNDING_SOURCE_ARK_TOPUP,
+			AmountSat: topupSat,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("create credit top-up: %w", err)
+	}
+
+	if creditResp.GetState() != swapclientrpc.
+		CreditOperationState_CREDIT_OPERATION_STATE_CREDITED {
+
+		if len(creditResp.GetDestinationPubkey()) == 0 {
+			return fmt.Errorf("credit top-up destination missing")
+		}
+
+		_, err = r.deps.RPCServer.SendOOR(
+			ctx, &daemonrpc.SendOORRequest{
+				Recipients: []*daemonrpc.Output{{
+					Destination: &daemonrpc.Output_Pubkey{
+						Pubkey: append(
+							[]byte(nil),
+							creditResp.GetDestinationPubkey()...,
+						),
+					},
+					AmountSat: int64(topupSat),
+				}},
+				IdempotencyKey: idempotencyKey,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("fund credit top-up: %w", err)
+		}
+	}
+
+	return r.waitCreditTopUp(
+		ctx, creditResp.GetOperationId(), intent.maxCreditSat,
+	)
+}
+
+func (r *router) waitCreditTopUp(ctx context.Context, operationID string,
+	requiredAvailableSat uint64) error {
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		credits, err := r.deps.SwapService.ListCredits(
+			ctx, &swapclientrpc.ListCreditsRequest{
+				Limit: ^uint32(0),
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("list credits: %w", err)
+		}
+		credited, terminalErr := creditOperationCredited(
+			credits, operationID,
+		)
+		if terminalErr != nil {
+			return terminalErr
+		}
+		if credits.GetAvailableSat() >= requiredAvailableSat &&
+			credited {
+			return nil
+		}
+
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func creditOperationCredited(snapshot *swapclientrpc.ListCreditsResponse,
+	operationID string) (bool, error) {
+
+	for _, op := range snapshot.GetOperations() {
+		if op.GetOperationId() != operationID {
+			continue
+		}
+
+		switch op.GetState() {
+		case swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_CREDITED:
+			return true, nil
+
+		case swapclientrpc.
+			CreditOperationState_CREDIT_OPERATION_STATE_FAILED,
+			swapclientrpc.
+				CreditOperationState_CREDIT_OPERATION_STATE_EXPIRED,
+			swapclientrpc.
+				CreditOperationState_CREDIT_OPERATION_STATE_RELEASED:
+			return false, fmt.Errorf("credit top-up %s ended in %s",
+				operationID, op.GetState())
+
+		default:
+			return false, nil
+		}
+	}
+
+	return false, nil
 }
 
 // prepareOnchain validates an onchain destination and builds a fee-aware
@@ -506,8 +664,7 @@ func extractPreparedInvoiceAmountSat(decoded *zpay32.Invoice) (uint64, error) {
 			ErrAmountInvalid)
 	}
 	if amountMSat%1000 != 0 {
-		return 0, fmt.Errorf("%w: invoice amount must be whole "+
-			"satoshis", ErrAmountInvalid)
+		return (amountMSat + 999) / 1000, nil
 	}
 
 	return amountMSat / 1000, nil
@@ -593,6 +750,11 @@ func prepareInvoicePreviewFromQuote(invoice, description, paymentHash string,
 		warning = "quoted fee exceeds max_fee_sat; Send will fail " +
 			"unless prepared with a higher fee cap"
 	}
+	creditPreview := creditPreviewFromQuote(quote.GetCreditQuote())
+	if creditPreview != nil && creditPreview.GetCreditShortfallSat() > 0 {
+		warning = fmt.Sprintf("credit shortfall requires %d sat top-up",
+			creditPreview.GetCreditTopupSat())
+	}
 
 	return prepareSendPreview{
 		rail: rail,
@@ -607,7 +769,24 @@ func prepareInvoicePreviewFromQuote(invoice, description, paymentHash string,
 		invoiceDescription:      description,
 		paymentHash:             quote.GetPaymentHash(),
 		warning:                 warning,
+		creditPreview:           creditPreview,
 	}, nil
+}
+
+func creditPreviewFromQuote(
+	quote *swapclientrpc.CreditQuote) *walletdkrpc.CreditPreview {
+
+	if quote == nil {
+		return nil
+	}
+
+	return &walletdkrpc.CreditPreview{
+		MustUseCredit:      quote.GetMustUseCredit(),
+		CreditAppliedSat:   quote.GetCreditAppliedSat(),
+		CreditShortfallSat: quote.GetCreditShortfallSat(),
+		CreditTopupSat:     quote.GetCreditTopupSat(),
+		ArkFundingSat:      quote.GetArkFundingSat(),
+	}
 }
 
 func sendRailFromQuoteSettlement(
@@ -621,6 +800,12 @@ func sendRailFromQuoteSettlement(
 
 	case swapclientrpc.SwapSettlementType_SWAP_SETTLEMENT_TYPE_IN_ARK:
 		return walletdkrpc.SendRail_SEND_RAIL_IN_ARK, nil
+
+	case swapclientrpc.SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT:
+		return walletdkrpc.SendRail_SEND_RAIL_CREDIT, nil
+
+	case swapclientrpc.SwapSettlementType_SWAP_SETTLEMENT_TYPE_MIXED:
+		return walletdkrpc.SendRail_SEND_RAIL_MIXED, nil
 
 	default:
 		return walletdkrpc.SendRail_SEND_RAIL_OFFCHAIN_UNKNOWN, nil

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -175,11 +174,12 @@ func (r *router) prepareInvoice(ctx context.Context, invoice string,
 		} else {
 			intent.maxCreditSat += creditQuote.GetCreditShortfallSat()
 		}
-		if quote.GetCreditQuote().GetMustUseCredit() {
+		if creditQuote.GetMustUseCredit() {
 			if uint64(amountSat) > intent.maxCreditSat {
 				intent.maxCreditSat = uint64(amountSat)
 			}
 		}
+		intent.maxCreditTopUpSat = creditQuote.GetCreditTopupSat()
 	}
 
 	if _, err := r.intents.put(intent); err != nil {
@@ -198,15 +198,12 @@ func (r *router) sendInvoiceIntent(ctx context.Context,
 		return nil, ErrSwapBackendUnavailable
 	}
 
-	if err := r.fundInvoiceCreditShortfall(ctx, intent); err != nil {
-		return nil, err
-	}
-
 	startResp, err := r.deps.SwapService.StartPay(
 		ctx, &swapclientrpc.StartPayRequest{
-			Invoice:      intent.invoice,
-			MaxFeeSat:    intent.maxFeeSat,
-			MaxCreditSat: intent.maxCreditSat,
+			Invoice:           intent.invoice,
+			MaxFeeSat:         intent.maxFeeSat,
+			MaxCreditSat:      intent.maxCreditSat,
+			MaxCreditTopupSat: intent.maxCreditTopUpSat,
 		},
 	)
 	if err != nil {
@@ -230,135 +227,6 @@ func (r *router) sendInvoiceIntent(ctx context.Context,
 		Entry:           entry,
 		ActualAmountSat: actualAmountSat,
 	}, nil
-}
-
-func (r *router) fundInvoiceCreditShortfall(ctx context.Context,
-	intent *preparedSendIntent) error {
-
-	if intent == nil || intent.creditPreview == nil ||
-		intent.creditPreview.GetCreditShortfallSat() == 0 {
-		return nil
-	}
-	if r.deps.RPCServer == nil {
-		return ErrSwapBackendUnavailable
-	}
-
-	topupSat := intent.creditPreview.GetCreditTopupSat()
-	if topupSat == 0 {
-		return fmt.Errorf("%w: credit top-up amount missing",
-			ErrAmountInvalid)
-	}
-	if topupSat > math.MaxInt64 {
-		return fmt.Errorf("%w: credit top-up exceeds int64 range",
-			ErrAmountInvalid)
-	}
-
-	idempotencyKey := "credit-topup-" + intent.id
-	creditResp, err := r.deps.SwapService.CreateCredit(
-		ctx, &swapclientrpc.CreateCreditRequest{
-			IdempotencyKey: idempotencyKey,
-			Source: swapclientrpc.
-				CreditFundingSource_CREDIT_FUNDING_SOURCE_ARK_TOPUP,
-			AmountSat: topupSat,
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("create credit top-up: %w", err)
-	}
-
-	if creditResp.GetState() != swapclientrpc.
-		CreditOperationState_CREDIT_OPERATION_STATE_CREDITED {
-
-		if len(creditResp.GetDestinationPubkey()) == 0 {
-			return fmt.Errorf("credit top-up destination missing")
-		}
-
-		_, err = r.deps.RPCServer.SendOOR(
-			ctx, &daemonrpc.SendOORRequest{
-				Recipients: []*daemonrpc.Output{{
-					Destination: &daemonrpc.Output_Pubkey{
-						Pubkey: append(
-							[]byte(nil),
-							creditResp.GetDestinationPubkey()...,
-						),
-					},
-					AmountSat: int64(topupSat),
-				}},
-				IdempotencyKey: idempotencyKey,
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("fund credit top-up: %w", err)
-		}
-	}
-
-	return r.waitCreditTopUp(
-		ctx, creditResp.GetOperationId(), intent.maxCreditSat,
-	)
-}
-
-func (r *router) waitCreditTopUp(ctx context.Context, operationID string,
-	requiredAvailableSat uint64) error {
-
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		credits, err := r.deps.SwapService.ListCredits(
-			ctx, &swapclientrpc.ListCreditsRequest{
-				Limit: ^uint32(0),
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("list credits: %w", err)
-		}
-		credited, terminalErr := creditOperationCredited(
-			credits, operationID,
-		)
-		if terminalErr != nil {
-			return terminalErr
-		}
-		if credits.GetAvailableSat() >= requiredAvailableSat &&
-			credited {
-			return nil
-		}
-
-		select {
-		case <-ticker.C:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-}
-
-func creditOperationCredited(snapshot *swapclientrpc.ListCreditsResponse,
-	operationID string) (bool, error) {
-
-	for _, op := range snapshot.GetOperations() {
-		if op.GetOperationId() != operationID {
-			continue
-		}
-
-		switch op.GetState() {
-		case swapclientrpc.
-			CreditOperationState_CREDIT_OPERATION_STATE_CREDITED:
-			return true, nil
-
-		case swapclientrpc.
-			CreditOperationState_CREDIT_OPERATION_STATE_FAILED,
-			swapclientrpc.
-				CreditOperationState_CREDIT_OPERATION_STATE_EXPIRED,
-			swapclientrpc.
-				CreditOperationState_CREDIT_OPERATION_STATE_RELEASED:
-			return false, fmt.Errorf("credit top-up %s ended in %s",
-				operationID, op.GetState())
-
-		default:
-			return false, nil
-		}
-	}
-
-	return false, nil
 }
 
 // prepareOnchain validates an onchain destination and builds a fee-aware

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -407,6 +407,99 @@ func TestRouterSendInvoiceDispatchesStartPay(t *testing.T) {
 	)
 }
 
+func TestRouterSendInvoiceTopsUpCreditsBeforeStartPay(t *testing.T) {
+	t.Parallel()
+
+	r, swap, rpc := newRouterFixture(t)
+	invoice, paymentHash := testPreparedInvoice(t, 500, "tiny")
+	swap.quotePayResp = &swapclientrpc.QuotePayResponse{
+		PaymentHash:      paymentHash,
+		InvoiceAmountSat: 500,
+		AmountSat:        0,
+		SettlementType: swapclientrpc.
+			SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT,
+		CreditQuote: &swapclientrpc.CreditQuote{
+			MustUseCredit:      true,
+			CreditShortfallSat: 500_000,
+			CreditTopupSat:     1_000,
+		},
+		ExpiresAtUnix: time.Now().Add(time.Minute).Unix(),
+	}
+	swap.createCreditResp = &swapclientrpc.CreateCreditResponse{
+		OperationId: "cr_topup",
+		State:       swapclientrpc.CreditOperationState_CREDIT_OPERATION_STATE_AWAITING_PAYMENT,
+		AmountSat:   1_000,
+		DestinationPubkey: []byte{
+			9,
+			9,
+			9,
+		},
+	}
+	swap.listCreditsResp = &swapclientrpc.ListCreditsResponse{
+		AvailableSat: 500_000,
+		Operations: []*swapclientrpc.CreditOperation{{
+			OperationId: "cr_topup",
+			State: swapclientrpc.
+				CreditOperationState_CREDIT_OPERATION_STATE_CREDITED,
+		}},
+	}
+	swap.startPayResp = &swapclientrpc.StartPayResponse{
+		PaymentHash: paymentHash,
+		Swap: &swapclientrpc.SwapSummary{
+			PaymentHash: paymentHash,
+			Direction: swapclientrpc.
+				SwapDirection_SWAP_DIRECTION_PAY,
+			AmountSat:      0,
+			Pending:        false,
+			SettlementType: swapclientrpc.SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT,
+		},
+	}
+	rpc.sendOORResp = &daemonrpc.SendOORResponse{
+		SessionId: "oor-topup",
+	}
+
+	prepareResp, err := r.PrepareSend(
+		t.Context(), &walletdkrpc.PrepareSendRequest{
+			Destination: &walletdkrpc.PrepareSendRequest_Invoice{
+				Invoice: invoice,
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, uint64(1_000),
+		prepareResp.GetCreditPreview().GetCreditTopupSat(),
+	)
+
+	resp, err := sendPrepared(t, r, prepareResp)
+	require.NoError(t, err)
+	require.Equal(t, int64(500), resp.GetActualAmountSat())
+	require.Equal(t, 1, swap.createCreditCalls)
+	require.Equal(
+		t,
+		swapclientrpc.CreditFundingSource_CREDIT_FUNDING_SOURCE_ARK_TOPUP,
+		swap.createCreditLast.GetSource(),
+	)
+	require.Equal(t, uint64(1_000), swap.createCreditLast.GetAmountSat())
+	require.Equal(t, 1, rpc.sendOORCalls)
+	require.Equal(
+		t, "credit-topup-"+prepareResp.GetSendIntentId(),
+		rpc.sendOORLastReq.GetIdempotencyKey(),
+	)
+	require.Equal(
+		t, []byte{9, 9, 9},
+		rpc.sendOORLastReq.GetRecipients()[0].GetPubkey(),
+	)
+	require.Equal(
+		t, int64(1_000),
+		rpc.sendOORLastReq.GetRecipients()[0].GetAmountSat(),
+	)
+	require.Equal(t, 1, swap.startPayCalls)
+	require.Equal(
+		t, uint64(500_000), swap.startPayLastReq.GetMaxCreditSat(),
+	)
+}
+
 // TestRouterSendOnchainSelectsVTXOsAndCallsLeave confirms that an onchain
 // destination triggers a local VTXO snapshot via ListVTXOs during prepare
 // (for the preview), and that the Send step then dispatches to the

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -420,28 +420,10 @@ func TestRouterSendInvoiceTopsUpCreditsBeforeStartPay(t *testing.T) {
 			SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT,
 		CreditQuote: &swapclientrpc.CreditQuote{
 			MustUseCredit:      true,
-			CreditShortfallSat: 500_000,
+			CreditShortfallSat: 500,
 			CreditTopupSat:     1_000,
 		},
 		ExpiresAtUnix: time.Now().Add(time.Minute).Unix(),
-	}
-	swap.createCreditResp = &swapclientrpc.CreateCreditResponse{
-		OperationId: "cr_topup",
-		State:       swapclientrpc.CreditOperationState_CREDIT_OPERATION_STATE_AWAITING_PAYMENT,
-		AmountSat:   1_000,
-		DestinationPubkey: []byte{
-			9,
-			9,
-			9,
-		},
-	}
-	swap.listCreditsResp = &swapclientrpc.ListCreditsResponse{
-		AvailableSat: 500_000,
-		Operations: []*swapclientrpc.CreditOperation{{
-			OperationId: "cr_topup",
-			State: swapclientrpc.
-				CreditOperationState_CREDIT_OPERATION_STATE_CREDITED,
-		}},
 	}
 	swap.startPayResp = &swapclientrpc.StartPayResponse{
 		PaymentHash: paymentHash,
@@ -474,29 +456,13 @@ func TestRouterSendInvoiceTopsUpCreditsBeforeStartPay(t *testing.T) {
 	resp, err := sendPrepared(t, r, prepareResp)
 	require.NoError(t, err)
 	require.Equal(t, int64(500), resp.GetActualAmountSat())
-	require.Equal(t, 1, swap.createCreditCalls)
-	require.Equal(
-		t,
-		swapclientrpc.CreditFundingSource_CREDIT_FUNDING_SOURCE_ARK_TOPUP,
-		swap.createCreditLast.GetSource(),
-	)
-	require.Equal(t, uint64(1_000), swap.createCreditLast.GetAmountSat())
-	require.Equal(t, 1, rpc.sendOORCalls)
-	require.Equal(
-		t, "credit-topup-"+prepareResp.GetSendIntentId(),
-		rpc.sendOORLastReq.GetIdempotencyKey(),
-	)
-	require.Equal(
-		t, []byte{9, 9, 9},
-		rpc.sendOORLastReq.GetRecipients()[0].GetPubkey(),
-	)
-	require.Equal(
-		t, int64(1_000),
-		rpc.sendOORLastReq.GetRecipients()[0].GetAmountSat(),
-	)
+	require.Equal(t, 0, swap.createCreditCalls)
+	require.Equal(t, 0, rpc.sendOORCalls)
 	require.Equal(t, 1, swap.startPayCalls)
+	require.Equal(t, uint64(500), swap.startPayLastReq.GetMaxCreditSat())
 	require.Equal(
-		t, uint64(500_000), swap.startPayLastReq.GetMaxCreditSat(),
+		t, uint64(1_000),
+		swap.startPayLastReq.GetMaxCreditTopupSat(),
 	)
 }
 

--- a/swapwallet/send_intents.go
+++ b/swapwallet/send_intents.go
@@ -26,14 +26,15 @@ type preparedSendIntent struct {
 	kind      preparedSendKind
 	expiresAt time.Time
 
-	invoice        string
-	onchainAddress string
-	amountSat      uint64
-	note           string
-	maxFeeSat      uint64
-	maxCreditSat   uint64
-	creditPreview  *walletdkrpc.CreditPreview
-	sweepAll       bool
+	invoice           string
+	onchainAddress    string
+	amountSat         uint64
+	note              string
+	maxFeeSat         uint64
+	maxCreditSat      uint64
+	maxCreditTopUpSat uint64
+	creditPreview     *walletdkrpc.CreditPreview
+	sweepAll          bool
 
 	selectedOutpoints []string
 	actualAmountSat   int64

--- a/swapwallet/send_intents.go
+++ b/swapwallet/send_intents.go
@@ -31,6 +31,8 @@ type preparedSendIntent struct {
 	amountSat      uint64
 	note           string
 	maxFeeSat      uint64
+	maxCreditSat   uint64
+	creditPreview  *walletdkrpc.CreditPreview
 	sweepAll       bool
 
 	selectedOutpoints []string
@@ -49,6 +51,7 @@ type prepareSendPreview struct {
 	invoiceDescription      string
 	paymentHash             string
 	warning                 string
+	creditPreview           *walletdkrpc.CreditPreview
 }
 
 type preparedSendStore struct {
@@ -148,6 +151,7 @@ func prepareResponseFromIntent(intent *preparedSendIntent,
 		SelectedOutpoints: append(
 			[]string(nil), intent.selectedOutpoints...,
 		),
-		Warning: preview.warning,
+		Warning:       preview.warning,
+		CreditPreview: preview.creditPreview,
 	}
 }

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -390,13 +391,31 @@ func (s *Service) fetchBalance(ctx context.Context) (
 	// immediately after a faucet deposit, before any round commit, which
 	// the proto contract (and the `send` verb's runtime check)
 	// explicitly disallow.
-	return &walletdkrpc.BalanceResponse{
+	resp := &walletdkrpc.BalanceResponse{
 		ConfirmedSat: bal.GetVtxoBalanceSat(),
 		PendingInSat: bal.GetBoardingConfirmedSat() +
 			bal.GetBoardingUnconfirmedSat() +
 			bal.GetBoardingAdoptedSat(),
 		PendingOutSat: bal.GetBoardingPendingSweepSat(),
-	}, nil
+	}
+
+	if s.deps.SwapService == nil {
+		return resp, nil
+	}
+
+	credits, err := s.deps.SwapService.ListCredits(
+		ctx, &swapclientrpc.ListCreditsRequest{
+			Limit: 1,
+		},
+	)
+	if err != nil {
+		return resp, nil
+	}
+
+	resp.CreditAvailableSat = credits.GetAvailableSat()
+	resp.CreditReservedSat = credits.GetReservedSat()
+
+	return resp, nil
 }
 
 // countPendingEntries asks the history merger for a pending-only page and

--- a/swapwallet/service_test.go
+++ b/swapwallet/service_test.go
@@ -204,6 +204,29 @@ func TestServiceBalanceProjectsDaemonGetBalance(t *testing.T) {
 	require.Equal(t, int64(5_000), resp.GetPendingOutSat())
 }
 
+func TestServiceBalanceIncludesCredits(t *testing.T) {
+	t.Parallel()
+
+	svc, swap, rpc := newServiceFixture(t)
+	rpc.getBalanceResp = &daemonrpc.GetBalanceResponse{
+		VtxoBalanceSat: 75_000,
+	}
+	swap.listCreditsResp = &swapclientrpc.ListCreditsResponse{
+		AvailableSat: 12_345,
+		ReservedSat:  6_789,
+	}
+
+	resp, err := svc.Balance(
+		t.Context(), &walletdkrpc.BalanceRequest{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(75_000), resp.GetConfirmedSat())
+	require.Equal(t, uint64(12_345), resp.GetCreditAvailableSat())
+	require.Equal(t, uint64(6_789), resp.GetCreditReservedSat())
+	require.Equal(t, 1, swap.listCreditsCalls)
+	require.Equal(t, uint32(1), swap.listCreditsLast.GetLimit())
+}
+
 // TestServiceBalanceKeepsAdoptedBoardingPending pins issue #542: after a
 // boarding UTXO is adopted into a round, the underlying on-chain UTXO is
 // spent before the resulting VTXO is live. The balance must keep that value


### PR DESCRIPTION
## Summary
- add a durable wallet-level payment intent store and runner for credit top-ups
- pass the accepted credit top-up bound through StartPay
- move walletdk invoice-send credit top-up execution into the durable runner
- resume pending payment intents before ordinary pay workers on daemon startup

## Validation
- go test ./sdk/swaps
- go test -tags swapruntime ./swapclientserver
- go test -tags "walletdkrpc swapruntime" ./swapwallet
- go test -tags "walletdkrpc swapruntime" ./sdk/walletdk
- make lint-local

## Not Run
- swapserver itests requiring Docker: Docker socket is unavailable at /var/run/docker.sock on this machine
