### PR TITLE
docs: nightly doc-gardening sweep 2026-06-29

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,6 +36,8 @@ package may import from a higher layer.
 | [`baselib`](baselib/) | Actor framework (`baselib/actor`) and protofsm state machine engine (`baselib/protofsm`) |
 | [`chainsource`](chainsource/) | `ChainBackend` interface: fee estimation, block/conf/spend notifications |
 | [`chainbackends`](chainbackends/) | LND-backed `ChainBackend` implementation plus lndclient adapters (`TxBroadcaster`, `PackageSubmitter`) |
+| [`chainfees`](chainfees/) | Reusable `chainfee.Estimator` implementations: WalletKit proxy, mempool.space HTTP client, and a min-selector combinator |
+| [`coinselect`](coinselect/) | Coin-type-agnostic largest-first coin selection (no wallet/actor/RPC dependencies) shared by vtxo and swapwallet |
 | [`chain`](chain/) | Bitcoind RPC utilities (package relay, `SubmitPackage`) |
 | [`txconfirm`](txconfirm/) | Generic "broadcast + CPFP fee-bump + notify on confirm" actor with per-parent fee-input reservations and BIP-125 Rule 3/4 enforcement |
 | [`unroll`](unroll/) | Durable per-target unilateral-exit actor + thin registry: owns proof assembly, materialization, CSV maturity, final sweep build, persist-before-broadcast, and control-plane record persistence |
@@ -61,10 +63,12 @@ package may import from a higher layer.
 | [`sdk/ark`](sdk/ark/) | Consumer-facing Go SDK facade: remote or embedded daemon access with typed models |
 | [`sdk/swaps`](sdk/swaps/) | Lightning-to-Ark / Ark-to-Lightning atomic swap SDK with durable FSM flows |
 | [`sdk/walletdk`](sdk/walletdk/) | Wallet-shaped SDK facade for host apps: embeds the daemon in-process, dials it over a private bufconn transport, exposes typed methods for the seven core wallet verbs (create, unlock, send, recv, list, balance, exit). The highest-level layer in the stack; wraps `walletdkrpc.WalletService`. Wallet RPC methods gated behind `walletdkrpc` (which transitively requires `swapruntime`) |
+| [`sdk/walletdk/mobile`](sdk/walletdk/mobile/) | gomobile-safe JSON facade over `sdk/walletdk`; shared by gomobile bindings (Android/iOS) and `cmd/walletdk-wasm` (browser) |
 | [`swapwallet`](swapwallet/) | Optional daemon-side `walletdkrpc.WalletService` implementation (build tags `walletdkrpc swapruntime`): composes the swap subsystem, cooperative leave, boarding, ledger, and unilateral-exit registry behind one flat, swap-vocabulary-free wallet API |
 | [`swapclientserver`](swapclientserver/) | Optional daemon-side swap subserver (build tag `swapruntime`): translates `swapclientrpc` RPCs into `sdk/swaps` operations and manages the daemon-local worker registry |
 | [`cmd/darepod`](cmd/darepod/) | Daemon entry point |
 | [`cmd/darepocli`](cmd/darepocli/) | CLI client |
+| [`cmd/walletdk-wasm`](cmd/walletdk-wasm/) | Browser WebAssembly binary: thin `syscall/js` adapter over `sdk/walletdk/mobile`; installs `walletdkCall` global |
 | [`timeout`](timeout/) | Generic timeout scheduling actor |
 | [`indexer`](indexer/) | Server indexing client for receive script registration |
 | [`arkrpc`](arkrpc/) | Server-side gRPC service definitions (ArkService, IndexerService) |
@@ -83,6 +87,7 @@ package may import from a higher layer.
 | [`harness`](harness/) | Docker-based Bitcoin/LND integration test environment |
 | [`systest`](systest/) | System-level end-to-end tests |
 | [`internal/actortest`](internal/actortest/) | Durable actor integration tests with real DB backends |
+| [`internal/sqlbase`](internal/sqlbase/) | WASM-only `walletdb.DB` implementation over a raw SQL connection (gated `js && wasm`; not compiled in native builds) |
 | [`internal/testutils`](internal/testutils/) | Deterministic key/signature generation for tests |
 | [`internal/indexerlimits`](internal/indexerlimits/) | Client-side bounds for indexer pagination cursors (defense-in-depth against misbehaving remotes) |
 | [`rules`](rules/) | ast-grep linting rules for code style enforcement |

--- a/chainfees/AGENTS.md
+++ b/chainfees/AGENTS.md
@@ -1,0 +1,54 @@
+# chainfees
+
+## Purpose
+
+Reusable `chainfee.Estimator` implementations and combinators for wallet and
+daemon chain backends. Provides an lndclient-backed WalletKit estimator, an
+HTTP-backed mempool.space estimator, and a min-selector combinator that picks
+the lowest live estimate from multiple providers.
+
+## Key Types
+
+- `WalletKitEstimator` — `chainfee.Estimator` backed by an
+  `lndclient.WalletKitClient`. Two modes: fail-fast (default, safe to
+  compose inside a selector) and fallback (returns last cached rate on
+  error, for standalone use only).
+- `WalletKitEstimatorConfig` — config for `WalletKitEstimator`. Fields:
+  `WalletKit`, `Log`, `Timeout`, `FallbackOnError`.
+- `MempoolSpaceEstimator` — HTTP-backed `chainfee.Estimator` that polls
+  mempool.space's recommended-fee endpoint with response caching.
+- `MempoolSpaceConfig` — config for `MempoolSpaceEstimator`. Fields:
+  `URL` (optional override), `Params` (selects default endpoint),
+  `Log`, `Timeout`, `CacheTTL`.
+- `MinEstimator` — `chainfee.Estimator` combinator that returns the minimum
+  successful estimate from a set of named child estimators. Falls back to
+  the last successful rate if all children fail.
+- `NamedEstimator` — attaches a stable log name to a child estimator.
+
+## Relationships
+
+- **Depends on**: `lndclient` (WalletKitClient), `lnd/lnwallet/chainfee`
+  (Estimator interface + SatPerKWeight), `chaincfg` (network params for
+  mempool.space URL selection).
+- **Depended on by**: `chainbackends` (wires WalletKitEstimator for the
+  lndclient chain backend), `darepod` (wires MinEstimator with optional
+  mempool.space provider).
+- **Sends**: nothing (all calls are synchronous; no actor or RPC messages).
+- **Receives**: nothing.
+
+## Invariants
+
+- `NewWalletKitEstimator` and `NewWalletKitEstimatorWithTimeout` produce
+  fail-fast estimators. Never pass a `FallbackOnError=true` estimator into
+  `MinEstimator` — a stale fallback floor can incorrectly win over another
+  provider's live estimate.
+- `MinEstimator` falls back to its own last successful rate when all children
+  fail; it never returns an error after receiving at least one prior success.
+- Sub-floor rates from any provider are clamped to `chainfee.FeePerKwFloor`
+  before selection or caching.
+- `MempoolSpaceEstimator` response bodies are capped at 64 KiB to guard
+  against unbounded reads from a misbehaving endpoint.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/chainfees/CLAUDE.md
+++ b/chainfees/CLAUDE.md
@@ -1,0 +1,54 @@
+# chainfees
+
+## Purpose
+
+Reusable `chainfee.Estimator` implementations and combinators for wallet and
+daemon chain backends. Provides an lndclient-backed WalletKit estimator, an
+HTTP-backed mempool.space estimator, and a min-selector combinator that picks
+the lowest live estimate from multiple providers.
+
+## Key Types
+
+- `WalletKitEstimator` — `chainfee.Estimator` backed by an
+  `lndclient.WalletKitClient`. Two modes: fail-fast (default, safe to
+  compose inside a selector) and fallback (returns last cached rate on
+  error, for standalone use only).
+- `WalletKitEstimatorConfig` — config for `WalletKitEstimator`. Fields:
+  `WalletKit`, `Log`, `Timeout`, `FallbackOnError`.
+- `MempoolSpaceEstimator` — HTTP-backed `chainfee.Estimator` that polls
+  mempool.space's recommended-fee endpoint with response caching.
+- `MempoolSpaceConfig` — config for `MempoolSpaceEstimator`. Fields:
+  `URL` (optional override), `Params` (selects default endpoint),
+  `Log`, `Timeout`, `CacheTTL`.
+- `MinEstimator` — `chainfee.Estimator` combinator that returns the minimum
+  successful estimate from a set of named child estimators. Falls back to
+  the last successful rate if all children fail.
+- `NamedEstimator` — attaches a stable log name to a child estimator.
+
+## Relationships
+
+- **Depends on**: `lndclient` (WalletKitClient), `lnd/lnwallet/chainfee`
+  (Estimator interface + SatPerKWeight), `chaincfg` (network params for
+  mempool.space URL selection).
+- **Depended on by**: `chainbackends` (wires WalletKitEstimator for the
+  lndclient chain backend), `darepod` (wires MinEstimator with optional
+  mempool.space provider).
+- **Sends**: nothing (all calls are synchronous; no actor or RPC messages).
+- **Receives**: nothing.
+
+## Invariants
+
+- `NewWalletKitEstimator` and `NewWalletKitEstimatorWithTimeout` produce
+  fail-fast estimators. Never pass a `FallbackOnError=true` estimator into
+  `MinEstimator` — a stale fallback floor can incorrectly win over another
+  provider's live estimate.
+- `MinEstimator` falls back to its own last successful rate when all children
+  fail; it never returns an error after receiving at least one prior success.
+- Sub-floor rates from any provider are clamped to `chainfee.FeePerKwFloor`
+  before selection or caching.
+- `MempoolSpaceEstimator` response bodies are capped at 64 KiB to guard
+  against unbounded reads from a misbehaving endpoint.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/cmd/walletdk-wasm/AGENTS.md
+++ b/cmd/walletdk-wasm/AGENTS.md
@@ -1,0 +1,50 @@
+# cmd/walletdk-wasm
+
+## Purpose
+
+Browser-facing WebAssembly binary that bridges the embedded walletdk runtime
+to browser JavaScript. It is a thin `syscall/js` adapter over the
+`sdk/walletdk/mobile` JSON facade: every verb takes a JS request object and
+resolves a JS response object so the daemon, swap, and OOR machinery all run
+in-process in the browser VM with no separate gateway.
+
+Only meaningful as a `js/wasm` target. On native toolchains a stub `main`
+compiles in place of the real binary to keep `go build ./...` green.
+
+Build with:
+```
+GOOS=js GOARCH=wasm go build \
+    -tags "mobile walletdkrpc swapruntime" ./cmd/walletdk-wasm
+```
+
+## Key Types
+
+- `walletCall` — the single JS entry point registered as `walletdkCall` on
+  `js.Global()`. Takes a method name string and an optional request object;
+  returns a Promise that resolves with the verb's JSON-decoded JS response or
+  rejects with a JS Error.
+
+## Relationships
+
+- **Depends on**: `sdk/walletdk/mobile` (JSON facade — every verb delegates
+  here), `syscall/js` (browser bridge).
+- **Depended on by**: browser host applications (import the compiled `.wasm`
+  and call `walletdkCall`).
+- **Sends**: nothing (delegates to `sdk/walletdk/mobile` in-process).
+- **Receives**: method dispatch from `walletdkCall` JS calls.
+
+## Invariants
+
+- The facade is the single source of truth shared with the gomobile bindings;
+  this bridge never reaches into `walletdk.Client` directly and cannot drift
+  from the mobile API.
+- On startup, emits a `walletdk-ready` `CustomEvent` on `js.Global()` once
+  the entry point is registered.
+- The Go runtime parks indefinitely after registration (`select {}`) so
+  exported JS callbacks stay live for the lifetime of the page.
+
+## Deep Docs
+
+- [sdk/walletdk/mobile/CLAUDE.md](../../sdk/walletdk/mobile/CLAUDE.md) —
+  JSON facade this binary wraps.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/cmd/walletdk-wasm/CLAUDE.md
+++ b/cmd/walletdk-wasm/CLAUDE.md
@@ -1,0 +1,50 @@
+# cmd/walletdk-wasm
+
+## Purpose
+
+Browser-facing WebAssembly binary that bridges the embedded walletdk runtime
+to browser JavaScript. It is a thin `syscall/js` adapter over the
+`sdk/walletdk/mobile` JSON facade: every verb takes a JS request object and
+resolves a JS response object so the daemon, swap, and OOR machinery all run
+in-process in the browser VM with no separate gateway.
+
+Only meaningful as a `js/wasm` target. On native toolchains a stub `main`
+compiles in place of the real binary to keep `go build ./...` green.
+
+Build with:
+```
+GOOS=js GOARCH=wasm go build \
+    -tags "mobile walletdkrpc swapruntime" ./cmd/walletdk-wasm
+```
+
+## Key Types
+
+- `walletCall` — the single JS entry point registered as `walletdkCall` on
+  `js.Global()`. Takes a method name string and an optional request object;
+  returns a Promise that resolves with the verb's JSON-decoded JS response or
+  rejects with a JS Error.
+
+## Relationships
+
+- **Depends on**: `sdk/walletdk/mobile` (JSON facade — every verb delegates
+  here), `syscall/js` (browser bridge).
+- **Depended on by**: browser host applications (import the compiled `.wasm`
+  and call `walletdkCall`).
+- **Sends**: nothing (delegates to `sdk/walletdk/mobile` in-process).
+- **Receives**: method dispatch from `walletdkCall` JS calls.
+
+## Invariants
+
+- The facade is the single source of truth shared with the gomobile bindings;
+  this bridge never reaches into `walletdk.Client` directly and cannot drift
+  from the mobile API.
+- On startup, emits a `walletdk-ready` `CustomEvent` on `js.Global()` once
+  the entry point is registered.
+- The Go runtime parks indefinitely after registration (`select {}`) so
+  exported JS callbacks stay live for the lifetime of the page.
+
+## Deep Docs
+
+- [sdk/walletdk/mobile/CLAUDE.md](../../sdk/walletdk/mobile/CLAUDE.md) —
+  JSON facade this binary wraps.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/coinselect/AGENTS.md
+++ b/coinselect/AGENTS.md
@@ -1,0 +1,48 @@
+# coinselect
+
+## Purpose
+
+Coin-type-agnostic coin-selection algorithm shared across all layers that
+need to pick a covering subset of coins. Deliberately holds no wallet, actor,
+or RPC dependencies so the VTXO manager's reservation path and the swap
+wallet's send preview both select through the same code rather than growing
+parallel implementations.
+
+## Key Types
+
+- `Request` — parameterizes a selection pass. `Target` (bounded) or
+  `SweepAll` (selects everything, ignores `Target` and `MinChange`).
+  `MinChange` rejects a covering selection whose non-zero change falls
+  below the dust floor; an exact-fit (zero-change) result is always
+  accepted regardless.
+- `Result[T]` — outcome of a selection pass. `Selected` is the chosen
+  subset; `Total` is their sum; `Change` is `Total - Target`.
+- `AmountFunc[T]` — caller-supplied extractor that maps any candidate
+  type to its `btcutil.Amount` so the selector stays agnostic to the
+  concrete coin type (VTXO descriptor, boarding intent, etc.).
+- `LargestFirst[T]` — main algorithm. Sorts candidates descending by
+  amount and accumulates until covered. Does not mutate the caller's
+  slice.
+- Error sentinels: `ErrSelectionShortfall`, `ErrChangeBelowMin`,
+  `ErrNoCandidates`, `ErrInvalidTarget`.
+
+## Relationships
+
+- **Depends on**: `btcutil` only.
+- **Depended on by**: `vtxo` (VTXO manager reservation path),
+  `swapwallet` (send preview and sweep-all selection).
+- **Sends**: nothing.
+- **Receives**: nothing.
+
+## Invariants
+
+- Caller's candidate slice is never mutated; sorting is done on a copy.
+- On failure, `Result.Total` carries the covered total at the rejection
+  point so callers can render precise diagnostics (e.g. distinguishing
+  a true shortfall from a dust-change rejection).
+- `SweepAll` selects every candidate in input order regardless of
+  `Target` and `MinChange`; the caller owns the single output value.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/coinselect/CLAUDE.md
+++ b/coinselect/CLAUDE.md
@@ -1,0 +1,48 @@
+# coinselect
+
+## Purpose
+
+Coin-type-agnostic coin-selection algorithm shared across all layers that
+need to pick a covering subset of coins. Deliberately holds no wallet, actor,
+or RPC dependencies so the VTXO manager's reservation path and the swap
+wallet's send preview both select through the same code rather than growing
+parallel implementations.
+
+## Key Types
+
+- `Request` — parameterizes a selection pass. `Target` (bounded) or
+  `SweepAll` (selects everything, ignores `Target` and `MinChange`).
+  `MinChange` rejects a covering selection whose non-zero change falls
+  below the dust floor; an exact-fit (zero-change) result is always
+  accepted regardless.
+- `Result[T]` — outcome of a selection pass. `Selected` is the chosen
+  subset; `Total` is their sum; `Change` is `Total - Target`.
+- `AmountFunc[T]` — caller-supplied extractor that maps any candidate
+  type to its `btcutil.Amount` so the selector stays agnostic to the
+  concrete coin type (VTXO descriptor, boarding intent, etc.).
+- `LargestFirst[T]` — main algorithm. Sorts candidates descending by
+  amount and accumulates until covered. Does not mutate the caller's
+  slice.
+- Error sentinels: `ErrSelectionShortfall`, `ErrChangeBelowMin`,
+  `ErrNoCandidates`, `ErrInvalidTarget`.
+
+## Relationships
+
+- **Depends on**: `btcutil` only.
+- **Depended on by**: `vtxo` (VTXO manager reservation path),
+  `swapwallet` (send preview and sweep-all selection).
+- **Sends**: nothing.
+- **Receives**: nothing.
+
+## Invariants
+
+- Caller's candidate slice is never mutated; sorting is done on a copy.
+- On failure, `Result.Total` carries the covered total at the rejection
+  point so callers can render precise diagnostics (e.g. distinguishing
+  a true shortfall from a dust-change rejection).
+- `SweepAll` selects every candidate in input order regardless of
+  `Target` and `MinChange`; the caller owns the single output value.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/darepod/AGENTS.md
+++ b/darepod/AGENTS.md
@@ -39,6 +39,27 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   (`MaxCheckpoints`, `MaxVTXOMatches`, `MaxMailboxItems`,
   `MaxMailboxScriptBytes`). `Config.OORReceiveLimits()` normalizes
   into `oor.ReceiveLimits`.
+- `DBConfig` — groups per-backend DB tuning knobs under the `db.*`
+  namespace. `Sqlite DBSqliteConfig` (WAL, page size, busy timeout,
+  cache size) and `Postgres DBPostgresConfig` (reserved, empty today).
+  Only SQLite is wired; Postgres tuning is deferred.
+- `FeeEstimationConfig` / `MempoolSpaceFeeConfig` — optional external
+  chain fee providers under the `feeestimation.*` namespace. When
+  `MempoolSpace` is non-nil and enabled, the daemon wires a
+  `chainfees.MinEstimator` that selects the lowest of WalletKit and
+  mempool.space estimates. `Config.MempoolSpaceFeeEnabled()` and
+  `Config.MempoolSpaceFeeURL()` are nil-safe accessors.
+- `forfeitSignatureBroker` (internal) — coordinates VTXO forfeit
+  participant signing. Exposes connector-bound signer callbacks to the
+  vtxo actor via `vtxo.ForfeitParticipantSigner`. Manages pending
+  signature requests (list, submit, wait, prune) so the RPC layer and
+  the vtxo FSM can rendezvous on forfeit signatures without coupling.
+- `SaveEncryptedSeed` / `LoadEncryptedSeed` / `SeedFileExists` —
+  platform-split seed storage. Native builds use the filesystem
+  (`seed_storage_native.go`); WASM builds use the browser's Origin
+  Private File System (OPFS) via `syscall/js` promises
+  (`seed_storage_wasm.go`). `SeedFileExists` fails closed on OPFS
+  errors (returns `false` rather than panicking or blocking).
 - `WalletState` — `None` / `Locked` / `Ready`.
 
 ### RPC Handlers
@@ -229,7 +250,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
 ## Relationships
 
 - **Depends on**: `baselib/actor`, `btcwbackend`, `chainbackends`,
-  `chainsource`, `lib/actormsg`, `db`, `ledger`, `round`, `txconfirm`,
+  `chainfees` (min-estimator wiring for mempool.space fee provider),
+  `chainsource`, `coinselect` (boarding sweep coin selection),
+  `lib/actormsg`, `db`, `ledger`, `round`, `txconfirm`,
   `unroll`, `vtxo`, `wallet`, `walletcore`, `oor`, `serverconn`,
   `indexer`, `arkrpc`, `lndbackend`, `harness` (bitcoind package
   submitter wiring in `cmd/darepod`), `fraud`, `gateway`,

--- a/darepod/CLAUDE.md
+++ b/darepod/CLAUDE.md
@@ -39,6 +39,27 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
   (`MaxCheckpoints`, `MaxVTXOMatches`, `MaxMailboxItems`,
   `MaxMailboxScriptBytes`). `Config.OORReceiveLimits()` normalizes
   into `oor.ReceiveLimits`.
+- `DBConfig` — groups per-backend DB tuning knobs under the `db.*`
+  namespace. `Sqlite DBSqliteConfig` (WAL, page size, busy timeout,
+  cache size) and `Postgres DBPostgresConfig` (reserved, empty today).
+  Only SQLite is wired; Postgres tuning is deferred.
+- `FeeEstimationConfig` / `MempoolSpaceFeeConfig` — optional external
+  chain fee providers under the `feeestimation.*` namespace. When
+  `MempoolSpace` is non-nil and enabled, the daemon wires a
+  `chainfees.MinEstimator` that selects the lowest of WalletKit and
+  mempool.space estimates. `Config.MempoolSpaceFeeEnabled()` and
+  `Config.MempoolSpaceFeeURL()` are nil-safe accessors.
+- `forfeitSignatureBroker` (internal) — coordinates VTXO forfeit
+  participant signing. Exposes connector-bound signer callbacks to the
+  vtxo actor via `vtxo.ForfeitParticipantSigner`. Manages pending
+  signature requests (list, submit, wait, prune) so the RPC layer and
+  the vtxo FSM can rendezvous on forfeit signatures without coupling.
+- `SaveEncryptedSeed` / `LoadEncryptedSeed` / `SeedFileExists` —
+  platform-split seed storage. Native builds use the filesystem
+  (`seed_storage_native.go`); WASM builds use the browser's Origin
+  Private File System (OPFS) via `syscall/js` promises
+  (`seed_storage_wasm.go`). `SeedFileExists` fails closed on OPFS
+  errors (returns `false` rather than panicking or blocking).
 - `WalletState` — `None` / `Locked` / `Ready`.
 
 ### RPC Handlers
@@ -229,7 +250,9 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/darep
 ## Relationships
 
 - **Depends on**: `baselib/actor`, `btcwbackend`, `chainbackends`,
-  `chainsource`, `lib/actormsg`, `db`, `ledger`, `round`, `txconfirm`,
+  `chainfees` (min-estimator wiring for mempool.space fee provider),
+  `chainsource`, `coinselect` (boarding sweep coin selection),
+  `lib/actormsg`, `db`, `ledger`, `round`, `txconfirm`,
   `unroll`, `vtxo`, `wallet`, `walletcore`, `oor`, `serverconn`,
   `indexer`, `arkrpc`, `lndbackend`, `harness` (bitcoind package
   submitter wiring in `cmd/darepod`), `fraud`, `gateway`,

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -97,6 +97,24 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   `vtxo.SpendingReservationStore`.
 - `SpendingReservationStore` / `BatchedSpendingReservationStore` — Internal
   sqlc-backed query interfaces for the reservation table.
+- `OORSessionRegistryStoreDB` — durable OOR session registry store.
+  Persists inbound/outbound session direction and status (pending,
+  terminal); enables the daemon to enumerate non-terminal sessions on
+  restart and resume or time them out. Methods: `UpsertOORSession`,
+  `GetOORSession`, `ListNonTerminalOORSessions`.
+- `OORSessionDirection` / `OORSessionStatus` — typed enum values
+  (`Inbound`/`Outbound` and `Pending`/`Terminal`).
+- `OORSessionRegistryRecord` — persistent OOR session row: session ID,
+  direction, status, timestamps.
+- `InternalKeyQuerier` interface + `RegisterInternalKeyTx` /
+  `InternalKeyDescByIDTx` — transaction-scoped helpers for deriving and
+  looking up internal wallet keys by their DB row ID. Used to associate
+  a key descriptor with a wallet-generated key without carrying the full
+  key manager across package boundaries.
+- `wasmSQLiteDriver` — internal `database/sql` driver registered under
+  the `"wasm_sqlite"` name that forwards to the browser's SQLite WASM
+  build. Enabled only on `js/wasm` builds; native builds use the standard
+  sqlite3 cgo driver.
 
 ## Relationships
 
@@ -147,6 +165,14 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   collapsing on `(round_id, event_type, debit_account, credit_account)`.
   Renumbered from 000019 to land after `000019_oor_session_registry`,
   which merged to main while this work was in review.
+- `000021_vhtlc_recovery_job_generations` — rebuilds `vhtlc_recovery_jobs`
+  to widen the uniqueness key from `(swap_id, action)` to
+  `(swap_id, action, vtxo_txid, vtxo_vout)`, so a refreshed vHTLC (new
+  outpoint) arms a new recovery "generation" instead of colliding with the
+  prior job. SQLite cannot widen a UNIQUE constraint in place, so the table
+  is recreated, rows are copied, and the state / swap-action / unroll-target
+  indexes are rebuilt. The down migration collapses each `(swap_id, action)`
+  to its newest row before restoring the narrower constraint.
 - `000018_pending_intents` — generalizes the Board-only
   `pending_board_requests` outbox into a supertype/subtype set:
   `pending_intent_kinds` (enum table), `pending_intents` (header: 32-byte
@@ -156,14 +182,6 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   anchored outpoint, PK on the outpoint so a newer intent rebinds, FK to the
   header). Drops `pending_board_requests` outright (alpha; rows only exist
   in the narrow crash window between admission and round seal).
-- `000021_vhtlc_recovery_job_generations` — rebuilds `vhtlc_recovery_jobs`
-  to widen the uniqueness key from `(swap_id, action)` to
-  `(swap_id, action, vtxo_txid, vtxo_vout)`, so a refreshed vHTLC (new
-  outpoint) arms a new recovery "generation" instead of colliding with the
-  prior job. SQLite cannot widen a UNIQUE constraint in place, so the table
-  is recreated, rows are copied, and the state / swap-action / unroll-target
-  indexes are rebuilt. The down migration collapses each `(swap_id, action)`
-  to its newest row before restoring the narrower constraint.
 - `000017_spending_reservations` — adds `spending_reservations` table with
   `(outpoint_hash, outpoint_index)` PK, `owner_kind`, `owner_id`, and
   `created_at`. A row exists IFF the owning spend session was durably

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -97,6 +97,24 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   `vtxo.SpendingReservationStore`.
 - `SpendingReservationStore` / `BatchedSpendingReservationStore` — Internal
   sqlc-backed query interfaces for the reservation table.
+- `OORSessionRegistryStoreDB` — durable OOR session registry store.
+  Persists inbound/outbound session direction and status (pending,
+  terminal); enables the daemon to enumerate non-terminal sessions on
+  restart and resume or time them out. Methods: `UpsertOORSession`,
+  `GetOORSession`, `ListNonTerminalOORSessions`.
+- `OORSessionDirection` / `OORSessionStatus` — typed enum values
+  (`Inbound`/`Outbound` and `Pending`/`Terminal`).
+- `OORSessionRegistryRecord` — persistent OOR session row: session ID,
+  direction, status, timestamps.
+- `InternalKeyQuerier` interface + `RegisterInternalKeyTx` /
+  `InternalKeyDescByIDTx` — transaction-scoped helpers for deriving and
+  looking up internal wallet keys by their DB row ID. Used to associate
+  a key descriptor with a wallet-generated key without carrying the full
+  key manager across package boundaries.
+- `wasmSQLiteDriver` — internal `database/sql` driver registered under
+  the `"wasm_sqlite"` name that forwards to the browser's SQLite WASM
+  build. Enabled only on `js/wasm` builds; native builds use the standard
+  sqlite3 cgo driver.
 
 ## Relationships
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ into specific topics below.
 | [sdk_layered_architecture.md](sdk_layered_architecture.md) | SDK layering rationale: `sdk/ark` facade, remote vs. embedded modes, `sdk/swaps` future direction |
 | [swap_system.md](swap_system.md) | End-to-end swap walkthrough: vHTLC tree (collaborative vs. unilateral-exit leaves), receive (out-swap) and pay (in-swap) flows, the off-chain-first cancellation/timeout recovery ladder, same-Ark p2p detection, swap-server RPCs, and proof-gated indexer authorization, with mermaid diagrams |
 | [walletdk_integration.md](walletdk_integration.md) | Basic `walletdk` integration flow, startup/config examples, swap accounting, and wrapper guidance |
+| [walletdk_mobile.md](walletdk_mobile.md) | gomobile integration guide: `sdk/walletdk/mobile` facade, lifecycle, JSON verb contract, passkey flow, and WASM bridge |
 | [walletdkrpc_build.md](walletdkrpc_build.md) | How to build and install the daemon and CLI with the wallet RPC subserver enabled (`walletdkrpc` + `swapruntime` tags) |
 | [seed_restore_recovery.md](seed_restore_recovery.md) | Restore a self-managed seed and recover Ark state from chain/indexer data |
 | [swap_background_execution.md](swap_background_execution.md) | Optional build-tagged daemon executor for background swap progress and daemon-backed CLI control |

--- a/internal/sqlbase/AGENTS.md
+++ b/internal/sqlbase/AGENTS.md
@@ -1,0 +1,47 @@
+# internal/sqlbase
+
+## Purpose
+
+WebAssembly-gated SQL backend that implements `walletdb.DB` (btcwallet's
+key-value database interface) over a raw SQL connection. Provides the
+`walletdb`-compatible transaction layer needed to run `btcwallet` inside a
+WASM environment where the standard BoltDB-backed implementation is not
+available.
+
+This package is gated on `//go:build js && wasm` — it compiles only for
+the `wasm` target and is invisible to native builds.
+
+## Key Types
+
+- `Config` — SQL connection configuration. Fields: `DriverName`, `Dsn`,
+  `Timeout`, `Schema`, `TableNamePrefix`, `SQLiteCmdReplacements`,
+  `WithTxLevelLock`.
+- `db` (unexported) — concrete `walletdb.DB` implementation. Wraps a
+  `*sql.DB` connection and a global connection set. Implements
+  `View`, `Update`, `BeginReadWriteTx`, `BeginReadTx`, `Close`.
+- `Init(maxConnections)` — initializes the global connection set; must be
+  called before `NewSqlBackend`.
+- `NewSqlBackend(ctx, cfg)` — opens or reuses a connection from the global
+  set, creates the KV schema table, and returns a `walletdb.DB`.
+
+## Relationships
+
+- **Depends on**: `btcwallet/walletdb` (DB/ReadTx/ReadWriteTx interfaces),
+  `lnd/sqldb` (transaction retry logic, serialization error detection).
+- **Depended on by**: `lwwallet` (wasm build: provides the walletdb backend
+  for the embedded btcwallet), `db/migrate` (wasm build: migration driver).
+- **Sends**: nothing.
+- **Receives**: nothing.
+
+## Invariants
+
+- `Init` is idempotent; a second call when the connection set is already
+  initialized is a no-op.
+- `NewSqlBackend` fails with an error if `Init` has not been called, rather
+  than panicking or returning a typed nil.
+- Transaction retries are handled via `sqldb.ExecuteSQLTransactionWithRetry`
+  with `DefaultNumTxRetries = 50` to absorb SQLite serialization errors.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/internal/sqlbase/CLAUDE.md
+++ b/internal/sqlbase/CLAUDE.md
@@ -1,0 +1,47 @@
+# internal/sqlbase
+
+## Purpose
+
+WebAssembly-gated SQL backend that implements `walletdb.DB` (btcwallet's
+key-value database interface) over a raw SQL connection. Provides the
+`walletdb`-compatible transaction layer needed to run `btcwallet` inside a
+WASM environment where the standard BoltDB-backed implementation is not
+available.
+
+This package is gated on `//go:build js && wasm` — it compiles only for
+the `wasm` target and is invisible to native builds.
+
+## Key Types
+
+- `Config` — SQL connection configuration. Fields: `DriverName`, `Dsn`,
+  `Timeout`, `Schema`, `TableNamePrefix`, `SQLiteCmdReplacements`,
+  `WithTxLevelLock`.
+- `db` (unexported) — concrete `walletdb.DB` implementation. Wraps a
+  `*sql.DB` connection and a global connection set. Implements
+  `View`, `Update`, `BeginReadWriteTx`, `BeginReadTx`, `Close`.
+- `Init(maxConnections)` — initializes the global connection set; must be
+  called before `NewSqlBackend`.
+- `NewSqlBackend(ctx, cfg)` — opens or reuses a connection from the global
+  set, creates the KV schema table, and returns a `walletdb.DB`.
+
+## Relationships
+
+- **Depends on**: `btcwallet/walletdb` (DB/ReadTx/ReadWriteTx interfaces),
+  `lnd/sqldb` (transaction retry logic, serialization error detection).
+- **Depended on by**: `lwwallet` (wasm build: provides the walletdb backend
+  for the embedded btcwallet), `db/migrate` (wasm build: migration driver).
+- **Sends**: nothing.
+- **Receives**: nothing.
+
+## Invariants
+
+- `Init` is idempotent; a second call when the connection set is already
+  initialized is a no-op.
+- `NewSqlBackend` fails with an error if `Init` has not been called, rather
+  than panicking or returning a typed nil.
+- Transaction retries are handled via `sqldb.ExecuteSQLTransactionWithRetry`
+  with `DefaultNumTxRetries = 50` to absorb SQLite serialization errors.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/walletdk/AGENTS.md
+++ b/sdk/walletdk/AGENTS.md
@@ -49,8 +49,25 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   bounded send and the swept total for sweep-all), `DepositRequest`/`Result` (boarding
   address + initial `Entry`), `ListRequest`, `ListResult` (tagged union
   on `View`, populates one of `Activity`/`VTXOs`/`Onchain`),
-  `ActivityList`, `VTXOInventory`, `OnchainHistory`, `Entry`,
-  `WalletVTXO`, `OnchainTx`.
+  `ActivityList`, `VTXOInventory`, `OnchainHistory`, `Entry`
+  (optional `Progress *EntryProgress` and `Request *EntryRequest`
+  sub-objects, both nil when absent; `Request` is a `Type`-tagged
+  union over lightning/onchain/ark), `WalletVTXO`, `OnchainTx`.
+- `GetExitPlanRequest` / `GetExitPlanResult` / `ExitPlanEntry` — exit
+  plan DTOs. `GetExitPlan` previews unilateral-exit readiness for a
+  set of VTXOs: each `ExitPlanEntry` lists the required on-chain
+  funding amount and whether the backing wallet already has sufficient
+  confirmed balance.
+- `SweepWalletRequest` / `SweepWalletResult` / `WalletSweepInput` —
+  backing-wallet sweep DTOs. `SweepWallet` previews or broadcasts a
+  sweep of confirmed backing-wallet UTXOs (e.g. to fund a forced exit).
+  `BroadcastSweep=false` is preview-only; `true` broadcasts and
+  returns the txid.
+- `OpenWalletFromPasskey(ctx, passkeyPRFOutput []byte)` —
+  deterministically creates or unlocks the embedded wallet from a
+  WebAuthn PRF output. Derives seed entropy + DB password via HKDF so
+  the caller never handles raw seed material. Raises an error if the
+  PRF output is shorter than 32 bytes.
 - `ExitRequest` / `ExitResult` / `ExitStatusRequest` /
   `ExitStatusResult` / `ExitJobStatus` — exit DTOs. `ExitRequest`
   carries the target outpoint plus an optional on-chain `Destination`
@@ -79,12 +96,15 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
 | `GetInfo` | Daemon readiness snapshot (version, network, identity, wallet/server readiness). |
 | `CreateWallet` | Create or import the embedded wallet (auto-generates seed when mnemonic empty); proxies daemonrpc. |
 | `UnlockWallet` | Unlock an existing wallet; proxies daemonrpc. |
+| `OpenWalletFromPasskey` | Create or unlock wallet from WebAuthn PRF output; seed derived via HKDF. |
 | `Balance` | Flat balance (`confirmed_sat`, `pending_in_sat`, `pending_out_sat`). |
 | `Deposit` | Allocate a fresh boarding address (`recv --onchain` from CLI). |
 | `Receive` | Open a Lightning invoice receive (`recv --offchain`). Returns `{Invoice, Entry}`. |
 | `PrepareSend` | Validate + quote an outbound payment; returns a single-use `SendIntentID`. |
 | `SendPrepared` | Dispatch a prepared send (consumes `SendIntentID`). Returns `{Entry, ActualAmountSat}`. |
 | `List` | Unified history view (Activity / VTXOs / Onchain) as a tagged-union `ListResult`. |
+| `GetExitPlan` | Preview unilateral-exit readiness and required backing-wallet funding. |
+| `SweepWallet` | Preview or broadcast a confirmed backing-wallet UTXO sweep (for exit funding). |
 | `Exit` | Trigger cooperative leave or unilateral unroll for a VTXO. |
 | `ExitStatus` | Query the phase of an exit job. |
 | `Status` | Wallet readiness, balance, pending-entry count. |
@@ -142,15 +162,21 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   the wrapper boundary on builds without the `walletdkrpc` tag, before
   any RPC is attempted. `ErrSwapRuntimeUnavailable` is an alias for
   source-level compatibility with older swap-only callers.
-- `Entry.Kind`/`Entry.Status` / `ListResult.View` /
-  `WalletVTXO.Status` / `OnchainTx.Kind` / `ExitJobStatus` are
-  wrapper-owned lowercase strings (not proto enums). Projection lives
-  in `convert.go`, intentionally decoupled from proto enum
-  renumbering.
+- `Entry.Kind`/`Entry.Status` / `Entry.Progress.Phase` /
+  `Entry.Request.Type` / `ListResult.View` / `WalletVTXO.Status` /
+  `OnchainTx.Kind` / `ExitJobStatus` are wrapper-owned lowercase
+  strings (not proto enums). Projection lives in `convert.go`,
+  intentionally decoupled from proto enum renumbering.
 - `ListResult` is a discriminated union: read the variant named by
   `View` and treat the others as `nil`. Exhaustiveness is not
   enforced at compile time — switch on `View` rather than chaining
   nil checks.
+- `Entry.Progress` and `Entry.Request` are optional pointers: both are
+  `nil` when the daemon supplied no progress hint / persisted no
+  request, so nil-check before dereferencing. `Entry.Request` is a
+  discriminated union — read the variant named by `Type`
+  (`lightning`/`onchain`/`ark`) and treat the other fields as zero,
+  the same idiom as `ListResult.View`.
 - `Wait()` is single-reader: same shared channel on every call. The
   channel delivers the daemon's terminal run error then closes; a
   closed channel reads as the zero error indefinitely.

--- a/sdk/walletdk/CLAUDE.md
+++ b/sdk/walletdk/CLAUDE.md
@@ -53,6 +53,21 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   (optional `Progress *EntryProgress` and `Request *EntryRequest`
   sub-objects, both nil when absent; `Request` is a `Type`-tagged
   union over lightning/onchain/ark), `WalletVTXO`, `OnchainTx`.
+- `GetExitPlanRequest` / `GetExitPlanResult` / `ExitPlanEntry` — exit
+  plan DTOs. `GetExitPlan` previews unilateral-exit readiness for a
+  set of VTXOs: each `ExitPlanEntry` lists the required on-chain
+  funding amount and whether the backing wallet already has sufficient
+  confirmed balance.
+- `SweepWalletRequest` / `SweepWalletResult` / `WalletSweepInput` —
+  backing-wallet sweep DTOs. `SweepWallet` previews or broadcasts a
+  sweep of confirmed backing-wallet UTXOs (e.g. to fund a forced exit).
+  `BroadcastSweep=false` is preview-only; `true` broadcasts and
+  returns the txid.
+- `OpenWalletFromPasskey(ctx, passkeyPRFOutput []byte)` —
+  deterministically creates or unlocks the embedded wallet from a
+  WebAuthn PRF output. Derives seed entropy + DB password via HKDF so
+  the caller never handles raw seed material. Raises an error if the
+  PRF output is shorter than 32 bytes.
 - `ExitRequest` / `ExitResult` / `ExitStatusRequest` /
   `ExitStatusResult` / `ExitJobStatus` — exit DTOs. `ExitRequest`
   carries the target outpoint plus an optional on-chain `Destination`
@@ -81,12 +96,15 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
 | `GetInfo` | Daemon readiness snapshot (version, network, identity, wallet/server readiness). |
 | `CreateWallet` | Create or import the embedded wallet (auto-generates seed when mnemonic empty); proxies daemonrpc. |
 | `UnlockWallet` | Unlock an existing wallet; proxies daemonrpc. |
+| `OpenWalletFromPasskey` | Create or unlock wallet from WebAuthn PRF output; seed derived via HKDF. |
 | `Balance` | Flat balance (`confirmed_sat`, `pending_in_sat`, `pending_out_sat`). |
 | `Deposit` | Allocate a fresh boarding address (`recv --onchain` from CLI). |
 | `Receive` | Open a Lightning invoice receive (`recv --offchain`). Returns `{Invoice, Entry}`. |
 | `PrepareSend` | Validate + quote an outbound payment; returns a single-use `SendIntentID`. |
 | `SendPrepared` | Dispatch a prepared send (consumes `SendIntentID`). Returns `{Entry, ActualAmountSat}`. |
 | `List` | Unified history view (Activity / VTXOs / Onchain) as a tagged-union `ListResult`. |
+| `GetExitPlan` | Preview unilateral-exit readiness and required backing-wallet funding. |
+| `SweepWallet` | Preview or broadcast a confirmed backing-wallet UTXO sweep (for exit funding). |
 | `Exit` | Trigger cooperative leave or unilateral unroll for a VTXO. |
 | `ExitStatus` | Query the phase of an exit job. |
 | `Status` | Wallet readiness, balance, pending-entry count. |

--- a/sdk/walletdk/mobile/AGENTS.md
+++ b/sdk/walletdk/mobile/AGENTS.md
@@ -1,0 +1,72 @@
+# sdk/walletdk/mobile
+
+## Purpose
+
+gomobile-safe JSON facade over `sdk/walletdk`. Wraps the wallet SDK in a
+flat API that respects gomobile's type restrictions (no `context.Context`,
+no channels, no maps, no slices other than `[]byte`, no unsigned integers
+crossing the boundary). Uses a JSON bytes-in / bytes-out convention so host
+apps decode with their native JSON tools (kotlinx.serialization, Codable)
+without a protobuf runtime. Also shared by `cmd/walletdk-wasm` as the
+single source of truth for the browser bridge.
+
+The entire package is gated on `//go:build mobile && walletdkrpc && swapruntime`.
+
+## Key Types
+
+- `lifecycleStatus` — four-state machine (`Stopped`, `Starting`, `Started`,
+  `Stopping`) guarding the singleton daemon lifetime. Prevents a racing
+  `Stop` from orphaning an in-progress `Start`.
+- `state` — package-level singleton holding the live `*walletdk.Client`,
+  call context, start/stop cancel functions, and a generation counter that
+  lets a late-finishing boot detect it has been superseded.
+- `Subscription` — pull-based subscription handle returned by `Subscribe`.
+  `Next() ([]byte, error)` blocks until an event arrives or the
+  subscription closes; `Close()` tears it down. Returned instead of a
+  callback because Go channels cannot cross the gomobile boundary.
+
+## Key Functions (API surface)
+
+- `Start(cfgJSON string) error` / `Stop() error` — lifecycle. `Start` is
+  synchronous (call off the main thread); `Stop` cancels in-flight calls
+  and shuts down the embedded daemon.
+- `IsRunning() bool` — returns `true` only in `statusStarted`.
+- `GetInfo`, `CreateWallet`, `UnlockWallet`, `OpenWalletFromPasskey` —
+  wallet lifecycle verbs. `OpenWalletFromPasskey` derives the seed from a
+  WebAuthn PRF output in Go so the host never handles raw seed material.
+- `Balance`, `Deposit`, `Receive`, `PrepareSend`, `SendPrepared`, `List`,
+  `Exit`, `ExitStatus`, `Status`, `Subscribe` — core wallet verbs (JSON
+  in / JSON out).
+- `ConfirmedBalanceSat() (int64, error)`, `PendingInboundSat() (int64, error)`,
+  `WalletReady() (bool, error)` — scalar convenience methods for the
+  hottest widget paths.
+
+## Relationships
+
+- **Depends on**: `sdk/walletdk` (embedded daemon lifecycle and all typed
+  wallet methods).
+- **Depended on by**: `cmd/walletdk-wasm` (browser WASM bridge), gomobile
+  bind output (Android/iOS).
+- **Sends**: nothing (delegates in-process to `sdk/walletdk`).
+- **Receives**: method calls from the host app (via gomobile or WASM).
+
+## Invariants
+
+- Singleton: only one daemon instance runs at a time. `Start` while
+  `statusStarted` or `statusStarting` returns an error immediately.
+- `Stop` racing an in-progress `Start` aborts the boot via `startCancel`
+  rather than orphaning the daemon.
+- The call context (`callCtx`) is cancelled by `Stop` so in-flight RPCs
+  and `Subscription.Next` unwind promptly on shutdown.
+- `Start` has a 90-second startup deadline; the daemon lifetime itself is
+  owned by walletdk's internal `runCtx`, not the startup context.
+- The package is source-compatible with `cmd/walletdk-wasm` — any new verb
+  added here must also be wired into the WASM bridge switch.
+
+## Deep Docs
+
+- [sdk/walletdk/CLAUDE.md](../CLAUDE.md) — The underlying client this
+  package wraps.
+- [cmd/walletdk-wasm/CLAUDE.md](../../../cmd/walletdk-wasm/CLAUDE.md) —
+  The browser bridge built on top of this facade.
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/walletdk/mobile/CLAUDE.md
+++ b/sdk/walletdk/mobile/CLAUDE.md
@@ -1,0 +1,72 @@
+# sdk/walletdk/mobile
+
+## Purpose
+
+gomobile-safe JSON facade over `sdk/walletdk`. Wraps the wallet SDK in a
+flat API that respects gomobile's type restrictions (no `context.Context`,
+no channels, no maps, no slices other than `[]byte`, no unsigned integers
+crossing the boundary). Uses a JSON bytes-in / bytes-out convention so host
+apps decode with their native JSON tools (kotlinx.serialization, Codable)
+without a protobuf runtime. Also shared by `cmd/walletdk-wasm` as the
+single source of truth for the browser bridge.
+
+The entire package is gated on `//go:build mobile && walletdkrpc && swapruntime`.
+
+## Key Types
+
+- `lifecycleStatus` — four-state machine (`Stopped`, `Starting`, `Started`,
+  `Stopping`) guarding the singleton daemon lifetime. Prevents a racing
+  `Stop` from orphaning an in-progress `Start`.
+- `state` — package-level singleton holding the live `*walletdk.Client`,
+  call context, start/stop cancel functions, and a generation counter that
+  lets a late-finishing boot detect it has been superseded.
+- `Subscription` — pull-based subscription handle returned by `Subscribe`.
+  `Next() ([]byte, error)` blocks until an event arrives or the
+  subscription closes; `Close()` tears it down. Returned instead of a
+  callback because Go channels cannot cross the gomobile boundary.
+
+## Key Functions (API surface)
+
+- `Start(cfgJSON string) error` / `Stop() error` — lifecycle. `Start` is
+  synchronous (call off the main thread); `Stop` cancels in-flight calls
+  and shuts down the embedded daemon.
+- `IsRunning() bool` — returns `true` only in `statusStarted`.
+- `GetInfo`, `CreateWallet`, `UnlockWallet`, `OpenWalletFromPasskey` —
+  wallet lifecycle verbs. `OpenWalletFromPasskey` derives the seed from a
+  WebAuthn PRF output in Go so the host never handles raw seed material.
+- `Balance`, `Deposit`, `Receive`, `PrepareSend`, `SendPrepared`, `List`,
+  `Exit`, `ExitStatus`, `Status`, `Subscribe` — core wallet verbs (JSON
+  in / JSON out).
+- `ConfirmedBalanceSat() (int64, error)`, `PendingInboundSat() (int64, error)`,
+  `WalletReady() (bool, error)` — scalar convenience methods for the
+  hottest widget paths.
+
+## Relationships
+
+- **Depends on**: `sdk/walletdk` (embedded daemon lifecycle and all typed
+  wallet methods).
+- **Depended on by**: `cmd/walletdk-wasm` (browser WASM bridge), gomobile
+  bind output (Android/iOS).
+- **Sends**: nothing (delegates in-process to `sdk/walletdk`).
+- **Receives**: method calls from the host app (via gomobile or WASM).
+
+## Invariants
+
+- Singleton: only one daemon instance runs at a time. `Start` while
+  `statusStarted` or `statusStarting` returns an error immediately.
+- `Stop` racing an in-progress `Start` aborts the boot via `startCancel`
+  rather than orphaning the daemon.
+- The call context (`callCtx`) is cancelled by `Stop` so in-flight RPCs
+  and `Subscription.Next` unwind promptly on shutdown.
+- `Start` has a 90-second startup deadline; the daemon lifetime itself is
+  owned by walletdk's internal `runCtx`, not the startup context.
+- The package is source-compatible with `cmd/walletdk-wasm` — any new verb
+  added here must also be wired into the WASM bridge switch.
+
+## Deep Docs
+
+- [sdk/walletdk/CLAUDE.md](../CLAUDE.md) — The underlying client this
+  package wraps.
+- [cmd/walletdk-wasm/CLAUDE.md](../../../cmd/walletdk-wasm/CLAUDE.md) —
+  The browser bridge built on top of this facade.
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -10,6 +10,7 @@ background ingress polling with event routing.
 
 - `Runtime` — Main entry point wrapping DurableActor, ServerConnectionActor, and UnaryFacade. The egress DurableActor runs on the Read/Commit (`TxBehavior`) path: each handler builds its envelope and calls `Edge.Send` with NO SQLite writer held, then a short lease-fenced Commit folds the ack + dedup. It runs as a competing-consumer pool of `ConnectorConfig.EgressWorkers` worker loops, so the round and out-of-round actors' sends proceed concurrently; the single ingress puller is separate and unaffected.
 - `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop. Dispatches `DurableUnaryQuery` values generically via `buildDurableUnary`.
+- `ArkVersionNegotiator` — Single home for Ark protocol version selection (`ark_version.go`). `Bootstrap` performs the one bootstrap `GetInfo` over the operator's **direct** ArkService connection (`ArkVersionGetInfoClient`, never the mailbox edge) and returns the response + selected version; the daemon parses domain terms from the same response. The free function `ValidateRefreshSelection(resp, boundVersion)` enforces that a refresh-only `GetInfo` keeps the runtime bound (returns a permanent `*StatusError` on drift/disable). Enabled versions are derived from the response's ACTIVE `ArkVersionPolicy` entries.
 - `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path). Also provides `AwaitRPCTimeout` for bounded waits.
 - `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store, durable unary builder, `EgressWorkers`). `EgressWorkers` sizes the egress worker pool (default `DefaultEgressWorkers` = 4); `<= 1` keeps the legacy single sender. The `DurableUnaryBuilder` field must be set to handle `DurableUnaryQuery` message types; otherwise those messages are rejected. The `AuthSignature` field holds the Schnorr auth sig injected into every outbound envelope via `mergeAuthHeaders` (auth header always wins over caller-provided headers).
 - `PubKeyMailboxID` — Derives canonical mailbox ID from a public key (hex-encoded compressed SEC). Panics on nil.
@@ -34,7 +35,7 @@ background ingress polling with event routing.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (DurableActor infrastructure), `mailbox/*` (Envelope, RpcMeta, MailboxServiceClient).
+- **Depends on**: `baselib/actor` (DurableActor infrastructure), `mailbox/*` (Envelope, RpcMeta, MailboxServiceClient), `arkrpc` (`GetInfo` request/response + `ArkVersionPolicy` for version negotiation).
 - **Depended on by**: `round` (outbound RPCs), `oor` (durable transport), `darepod` (wiring).
 - **Sends (egress → remote mailbox)**:
   - `SendClientEventRequest` (durable): wraps `JoinRoundRequest`, `JoinRoundAccept`, `JoinRoundReject`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`. `JoinRoundAccept` / `JoinRoundReject` are the explicit responses to a server-issued seal-time `JoinRoundQuote` (#270); both echo the `quote_id` so the server can drop stale responses after a reseal.

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -32,9 +32,21 @@ default builds avoid the swap executor's dependency graph.
   covering every daemonrpc method swapwallet composes against:
   LeaveVTXOs, SendOnChain, ListVTXOs, ListTransactions, NewAddress, GetInfo,
   GetBalance, GenSeed, InitWallet, UnlockWallet, Unroll,
-  GetUnrollStatus, JoinNextRound. The admin-shape methods (GenSeed/InitWallet/
-  UnlockWallet/Unroll/GetUnrollStatus) are reachable BEFORE the swap
-  runtime is live.
+  GetUnrollStatus, JoinNextRound, GetExitPlan, SweepWallet. The
+  admin-shape methods (GenSeed/InitWallet/UnlockWallet/Unroll/
+  GetUnrollStatus) are reachable BEFORE the swap runtime is live.
+- `ErrorMappingInterceptor` — gRPC unary server interceptor that maps
+  internal sentinel errors to structured `google.rpc.Status` errors
+  (with `ErrorInfo.Reason` strings) so `sdk/walletdk` can reconstruct
+  typed sentinels on the client side without depending on server-side
+  error types.
+- `sentinelMapping` — table-driven mapping from sentinel error to the
+  walletdkrpc wire contract string (domain + reason). Covers swap
+  backend unavailability, receive limit errors, and other typed
+  failures.
+- `checkReceiveLimits` (internal helper) — validates an incoming
+  receive request against daemon-configured limits before issuing the
+  invoice, surfacing limit errors as mapped sentinels.
 - `WalletEntry` (re-exported from walletdkrpc) — Flat row type the entire
   history/streaming surface returns. Every internal correlator
   (session_id, round_id, settlement_type, mailbox subtype) is dropped

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -32,9 +32,21 @@ default builds avoid the swap executor's dependency graph.
   covering every daemonrpc method swapwallet composes against:
   LeaveVTXOs, SendOnChain, ListVTXOs, ListTransactions, NewAddress, GetInfo,
   GetBalance, GenSeed, InitWallet, UnlockWallet, Unroll,
-  GetUnrollStatus, JoinNextRound. The admin-shape methods (GenSeed/InitWallet/
-  UnlockWallet/Unroll/GetUnrollStatus) are reachable BEFORE the swap
-  runtime is live.
+  GetUnrollStatus, JoinNextRound, GetExitPlan, SweepWallet. The
+  admin-shape methods (GenSeed/InitWallet/UnlockWallet/Unroll/
+  GetUnrollStatus) are reachable BEFORE the swap runtime is live.
+- `ErrorMappingInterceptor` — gRPC unary server interceptor that maps
+  internal sentinel errors to structured `google.rpc.Status` errors
+  (with `ErrorInfo.Reason` strings) so `sdk/walletdk` can reconstruct
+  typed sentinels on the client side without depending on server-side
+  error types.
+- `sentinelMapping` — table-driven mapping from sentinel error to the
+  walletdkrpc wire contract string (domain + reason). Covers swap
+  backend unavailability, receive limit errors, and other typed
+  failures.
+- `checkReceiveLimits` (internal helper) — validates an incoming
+  receive request against daemon-configured limits before issuing the
+  invoice, surfacing limit errors as mapped sentinels.
 - `WalletEntry` (re-exported from walletdkrpc) — Flat row type the entire
   history/streaming surface returns. Every internal correlator
   (session_id, round_id, settlement_type, mailbox subtype) is dropped

--- a/txconfirm/AGENTS.md
+++ b/txconfirm/AGENTS.md
@@ -55,6 +55,22 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - `Config.BroadcastFailureAlertThreshold` — consecutive no-mempool
   failures before the operator escalation fires (default 3). Time to
   first alert ≈ threshold × `FeeBumpIntervalBlocks` blocks.
+- Fee-input fanout FSM (internal) — separates the concern of supplying
+  fee inputs for multiple concurrent anchor parents:
+  - `feeBumpState` / `feeBumpEvent` / `feeBumpOutboxEvent` — protofsm
+    interfaces for the two-state machine.
+  - `feeBumpStateIdle` — initial state; collects fee-input demands from
+    all tracked parent txids and fans out a single fee-input tx.
+  - `feeBumpStateFanoutPending` — waits for the fanout tx to confirm,
+    retrying parents on each block epoch.
+  - `feeBumpEnvironment` — shared broadcaster context and demand list
+    threaded through FSM transitions.
+  - `pendingFeeInputFanout` — tracks the outstanding fanout tx (txid,
+    reserved outputs, predicted outputs for reuse).
+  - `feeInputDemand` — one parent's fee-input requirement (outpoint,
+    amount, weight, script).
+  - Outbox events: `feeBumpWatchFanout`, `feeBumpUnwatchFanout`,
+    `feeBumpRetryParents`.
 
 ## Relationships
 

--- a/txconfirm/CLAUDE.md
+++ b/txconfirm/CLAUDE.md
@@ -55,6 +55,22 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/txcon
 - `Config.BroadcastFailureAlertThreshold` — consecutive no-mempool
   failures before the operator escalation fires (default 3). Time to
   first alert ≈ threshold × `FeeBumpIntervalBlocks` blocks.
+- Fee-input fanout FSM (internal) — separates the concern of supplying
+  fee inputs for multiple concurrent anchor parents:
+  - `feeBumpState` / `feeBumpEvent` / `feeBumpOutboxEvent` — protofsm
+    interfaces for the two-state machine.
+  - `feeBumpStateIdle` — initial state; collects fee-input demands from
+    all tracked parent txids and fans out a single fee-input tx.
+  - `feeBumpStateFanoutPending` — waits for the fanout tx to confirm,
+    retrying parents on each block epoch.
+  - `feeBumpEnvironment` — shared broadcaster context and demand list
+    threaded through FSM transitions.
+  - `pendingFeeInputFanout` — tracks the outstanding fanout tx (txid,
+    reserved outputs, predicted outputs for reuse).
+  - `feeInputDemand` — one parent's fee-input requirement (outpoint,
+    amount, weight, script).
+  - Outbox events: `feeBumpWatchFanout`, `feeBumpUnwatchFanout`,
+    `feeBumpRetryParents`.
 
 ## Relationships
 


### PR DESCRIPTION
Automated nightly doc-gardening sweep for 2026-06-29.

**Workflow run**: https://github.com/lightninglabs/darepo-client/actions/runs/0

## What changed

**New CLAUDE.md / AGENTS.md** (packages with no docs before this sweep):
- `chainfees` — WalletKitEstimator, MempoolSpaceEstimator, MinEstimator
- `coinselect` — largest-first coin-selection algorithm
- `cmd/walletdk-wasm` — browser WASM bridge over the mobile JSON facade
- `internal/sqlbase` — WASM-gated `walletdb.DB` SQL backend
- `sdk/walletdk/mobile` — gomobile-safe JSON facade shared by Android/iOS and WASM

**Updated CLAUDE.md / AGENTS.md** (stale since last sweep):
- `darepod` — new `DBConfig`, `FeeEstimationConfig`, `MempoolSpaceFeeConfig`, `forfeitSignatureBroker`, OPFS seed storage
- `sdk/walletdk` — `GetExitPlan`, `SweepWallet`, `OpenWalletFromPasskey`
- `swapwallet` — `ErrorMappingInterceptor`, `GetExitPlan`/`SweepWallet` RPCs, `checkReceiveLimits`
- `txconfirm` — fee-input fanout FSM (`feeBumpStateIdle`, `feeBumpStateFanoutPending`, `pendingFeeInputFanout`)
- `db` — `OORSessionRegistryStoreDB`, `InternalKeyQuerier`, `wasmSQLiteDriver`
- `serverconn` — synced diverged AGENTS.md

**docs/index.md** — added missing entry for `walletdk_mobile.md`

**ARCHITECTURE.md** — added layer entries for `chainfees`, `coinselect`,
`cmd/walletdk-wasm`, `sdk/walletdk/mobile`, `internal/sqlbase`

## Review checklist

- [ ] `ARCHITECTURE.md` layer assignments look right
- [ ] New `CLAUDE.md` files accurately reflect the packages' purpose and types
- [ ] Updated sections in stale `CLAUDE.md` files match current source
- [ ] `docs/index.md` entry for `walletdk_mobile.md` is accurate
