### PR TITLE
vtxo: release orphaned forfeit reservations on startup

### DIFF
--- a/systest/refresh_strand_test.go
+++ b/systest/refresh_strand_test.go
@@ -1,0 +1,116 @@
+//go:build systest
+
+package systest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/darepod"
+	"github.com/stretchr/testify/require"
+)
+
+// refreshRestartRecoveryWindow bounds how long we wait after the restart for
+// the manager's startup orphan-forfeit sweep to return the VTXO to LIVE. The
+// sweep runs during VTXO manager startup, but the daemon must first reconnect
+// its LND backend and recover actors, so we allow generous slack under parallel
+// Dockerized systest load.
+const refreshRestartRecoveryWindow = 60 * time.Second
+
+// TestRefreshStrandedVTXORecoversOnRestart proves the startup orphan-forfeit
+// sweep. A cooperative refresh reserves the seeded VTXO into pending-forfeit
+// and parks a temp REGISTRATION_SENT round, but the fake operator never returns
+// a RoundJoined admission watermark. The admission timeout is disabled, so the
+// in-flight round's own recovery path (darepo-client#653) can never fire — the
+// only thing that can rescue the reserved VTXO is the manager's startup sweep.
+//
+// We then restart the daemon. The in-memory round FSM dies, and the VTXO is
+// recovered from disk still in pending-forfeit. Because no forfeit signature
+// was ever submitted (that happens only on the pending-forfeit -> forfeiting
+// transition), the VTXO is provably orphaned and the startup sweep returns it
+// to LIVE with the spendable balance restored. On an unfixed daemon the VTXO
+// stays pending-forfeit forever and the final assertion times out.
+func TestRefreshStrandedVTXORecoversOnRestart(t *testing.T) {
+	ParallelN(t)
+
+	// EagerRoundJoin drives the refresh into IntentSentState immediately. A
+	// negative RegistrationTimeout disables the admission timeout entirely,
+	// so the round never self-recovers and the startup sweep is isolated as
+	// the sole recovery mechanism under test.
+	fixture := newDirectedSendFixture(t, func(c *darepod.Config) {
+		c.EagerRoundJoin = true
+		c.RegistrationTimeout = -1 * time.Second
+	})
+
+	// The seeded VTXO starts LIVE and is the entire spendable balance.
+	startVTXOs := listAllVTXOs(t, fixture.client)
+	require.Len(t, startVTXOs, 1)
+	require.Equal(
+		t, daemonrpc.VTXOStatus_VTXO_STATUS_LIVE, startVTXOs[0].Status,
+	)
+	require.Equal(
+		t, testSeededAmountSat, vtxoBalanceSat(t, fixture.client),
+	)
+
+	// Issue the refresh. The reservation into pending-forfeit is
+	// synchronous, so by the time this returns the VTXO is already
+	// reserved.
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	refreshResp, err := fixture.client.RefreshVTXOs(
+		ctx, &daemonrpc.RefreshVTXOsRequest{
+			Selection: &daemonrpc.RefreshVTXOsRequest_Outpoints{
+				Outpoints: &daemonrpc.OutpointSelection{
+					Outpoints: []string{
+						outpointString(
+							fixture.seededOutpoint,
+						),
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err, "RefreshVTXOs RPC failed")
+	require.Equal(t, "queued", refreshResp.Status)
+	require.Contains(
+		t, refreshResp.QueuedOutpoints,
+		outpointString(fixture.seededOutpoint),
+	)
+
+	// The stranded condition: the refresh reserves the VTXO into
+	// pending-forfeit synchronously. With the admission timeout disabled
+	// and the operator never admitting the round, the reservation is owned
+	// only by the in-memory round FSM and holds indefinitely until the
+	// restart.
+	requireVTXOStatusEventually(
+		t, fixture.client, fixture.seededOutpoint,
+		daemonrpc.VTXOStatus_VTXO_STATUS_PENDING_FORFEIT,
+		parkedObserveWindow,
+	)
+
+	// The crash: restart the daemon against the same data directory. The
+	// in-memory round FSM is lost; the reserved VTXO is recovered from disk
+	// still in pending-forfeit.
+	fixture.restart()
+
+	// The fix: the startup orphan-forfeit sweep returns the VTXO to LIVE.
+	requireVTXOStatusEventually(
+		t, fixture.client, fixture.seededOutpoint,
+		daemonrpc.VTXOStatus_VTXO_STATUS_LIVE,
+		refreshRestartRecoveryWindow,
+	)
+
+	// The spendable balance is restored to its starting value.
+	require.Eventually(
+		t,
+		func() bool {
+			return vtxoBalanceSat(t, fixture.client) ==
+				testSeededAmountSat
+		},
+		20*time.Second, 100*time.Millisecond,
+		"vtxo balance not restored after restart recovery",
+	)
+}

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -424,6 +424,20 @@ type directedSendFixture struct {
 	mailboxServer  *fakeMailboxServer
 	operatorKey    *btcec.PublicKey
 	seededOutpoint wire.OutPoint
+
+	// cfg is the daemon configuration. It is retained so the daemon can be
+	// torn down and relaunched against the same data directory by
+	// restart().
+	cfg *darepod.Config
+
+	// rpcAddr is the daemon's gRPC listen address, reused across restarts
+	// so the client reconnects to the same endpoint.
+	rpcAddr string
+
+	// serverCancel cancels the currently running daemon, and serverErrChan
+	// receives its run error. Both are replaced on every launch().
+	serverCancel  context.CancelFunc
+	serverErrChan chan error
 }
 
 // newDirectedSendFixture starts a full darepod instance against the systest
@@ -437,8 +451,6 @@ func newDirectedSendFixture(t *testing.T,
 	t.Helper()
 
 	h := NewSysTestHarness(t)
-	ctx, cancel := context.WithCancel(h.Context())
-	t.Cleanup(cancel)
 
 	operatorPriv, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
@@ -501,53 +513,93 @@ func newDirectedSendFixture(t *testing.T,
 		btcutil.Amount(testSeededAmountSat),
 	)
 
-	server, err := darepod.NewServer(cfg)
+	fixture := &directedSendFixture{
+		t:              t,
+		harness:        h,
+		mailboxServer:  mailboxServer,
+		operatorKey:    operatorPriv.PubKey(),
+		seededOutpoint: seededOutpoint,
+		cfg:            cfg,
+		rpcAddr:        rpcAddr,
+	}
+
+	// Register the shutdown before launching so a launch that fails its
+	// readiness wait (which t.Fatals) still tears down the server
+	// goroutine. shutdown is idempotent and a no-op when nothing started.
+	t.Cleanup(fixture.shutdown)
+	fixture.launch()
+
+	return fixture
+}
+
+// launch starts a fresh darepod instance from the fixture's retained config and
+// connects a new client to it, waiting for the daemon RPC to become ready. It
+// is used both for the initial start and for relaunch after restart().
+func (f *directedSendFixture) launch() {
+	t := f.t
+
+	ctx, cancel := context.WithCancel(f.harness.Context())
+
+	server, err := darepod.NewServer(f.cfg)
 	require.NoError(t, err)
 
-	serverErrChan := make(chan error, 1)
+	errChan := make(chan error, 1)
 	go func() {
-		serverErrChan <- server.RunWithContext(ctx)
+		errChan <- server.RunWithContext(ctx)
 	}()
 
-	t.Cleanup(func() {
-		cancel()
-
-		select {
-		case runErr := <-serverErrChan:
-			if runErr != nil &&
-				!errors.Is(runErr, context.Canceled) {
-
-				require.NoError(t, runErr)
-			}
-
-		case <-time.After(10 * time.Second):
-			t.Fatal("timeout waiting for darepod shutdown")
-		}
-	})
+	f.serverCancel = cancel
+	f.serverErrChan = errChan
 
 	conn, err := grpc.NewClient(
-		rpcAddr,
+		f.rpcAddr,
 		grpc.WithTransportCredentials(
 			insecure.NewCredentials(),
 		),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, conn.Close())
-	})
 
-	client := daemonrpc.NewDaemonServiceClient(conn)
-	waitForDaemonReady(t, client)
+	f.conn = conn
+	f.client = daemonrpc.NewDaemonServiceClient(conn)
 
-	return &directedSendFixture{
-		t:              t,
-		harness:        h,
-		client:         client,
-		conn:           conn,
-		mailboxServer:  mailboxServer,
-		operatorKey:    operatorPriv.PubKey(),
-		seededOutpoint: seededOutpoint,
+	waitForDaemonReady(t, f.client)
+}
+
+// shutdown stops the currently running daemon and closes its client connection,
+// waiting for a clean exit. It is idempotent so it is safe both as the test
+// cleanup and as the first half of restart().
+func (f *directedSendFixture) shutdown() {
+	t := f.t
+
+	if f.conn != nil {
+		require.NoError(t, f.conn.Close())
+		f.conn = nil
 	}
+
+	if f.serverCancel == nil {
+		return
+	}
+
+	f.serverCancel()
+	select {
+	case runErr := <-f.serverErrChan:
+		if runErr != nil && !errors.Is(runErr, context.Canceled) {
+			require.NoError(t, runErr)
+		}
+
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for darepod shutdown")
+	}
+
+	f.serverCancel = nil
+}
+
+// restart tears the daemon down and brings it back up against the same data
+// directory, simulating a crash/restart. Persisted state (including VTXOs
+// reserved into pending-forfeit) survives; the in-memory round FSM does not.
+func (f *directedSendFixture) restart() {
+	f.shutdown()
+	f.launch()
 }
 
 // waitForDaemonReady polls GetInfo until the daemon reports wallet

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -470,6 +470,11 @@ func (m *Manager) Start(ctx context.Context,
 	// spend died before its reservation was durably recorded (orphans).
 	m.sweepOrphanedReservations(ctx)
 
+	// Likewise, return any VTXOs stranded in PendingForfeitState to Live:
+	// their owning round FSM is in-memory only and cannot have survived the
+	// restart to release the reservation itself.
+	m.releaseOrphanedForfeits(ctx)
+
 	return nil
 }
 
@@ -1482,6 +1487,11 @@ func (m *Manager) sweepOrphanedReservations(ctx context.Context) {
 			continue
 		}
 
+		// Refresh the recovery-time liveDescriptors snapshot so the
+		// released VTXO no longer reads as Spending (see
+		// markDescriptorLive).
+		m.markDescriptorLive(op)
+
 		released++
 	}
 
@@ -1530,6 +1540,104 @@ func (m *Manager) sweepOrphanedReservations(ctx context.Context) {
 		slog.Int("released", released),
 		slog.Int("redriven", redriven),
 	)
+}
+
+// releaseOrphanedForfeits returns VTXOs stranded in PendingForfeitState back to
+// LiveState at startup. A VTXO enters PendingForfeitState when an in-flight
+// cooperative round (refresh, leave, or directed send) reserves it as a forfeit
+// input. That reservation is owned by the round FSM, which is in-memory only:
+// temp rounds are never persisted, and the rounds table is not written until
+// InputSigSentState, the point of no return. A daemon that restarts while a
+// round sits in any pre-signing state therefore loses the FSM that would have
+// released the reservation on failure (round.releaseForfeitsOnFailure), leaving
+// the VTXO orphaned in PendingForfeitState with no path back to Live.
+//
+// Any VTXO found in PendingForfeitState at startup is provably orphaned.
+// Forfeit signatures are only submitted on the PendingForfeit -> Forfeiting
+// transition, so a still-PendingForfeit VTXO has leaked no signature and the
+// operator cannot broadcast a forfeit; returning it to LiveState is safe and
+// cannot double-spend. VTXOs already in Forfeiting or Forfeited are past the
+// point of no return and are deliberately left untouched for chain-confirmation
+// reconciliation.
+func (m *Manager) releaseOrphanedForfeits(ctx context.Context) {
+	pending, err := m.cfg.Store.ListVTXOsByStatus(
+		ctx, VTXOStatusPendingForfeit,
+	)
+	if err != nil {
+		m.logger(ctx).ErrorS(
+			ctx,
+			"Forfeit sweep: list PendingForfeit VTXOs failed",
+			err,
+		)
+
+		return
+	}
+
+	var released int
+	for _, desc := range pending {
+		op := desc.Outpoint
+
+		ref, ok := m.actors[op]
+		if !ok {
+			m.logger(ctx).WarnS(ctx,
+				"Forfeit sweep: no actor for orphaned "+
+					"PendingForfeit VTXO", nil,
+				slog.String("outpoint", op.String()),
+			)
+
+			continue
+		}
+
+		// Bound the ask so a single wedged child actor cannot stall the
+		// daemon's startup critical path indefinitely; this matches
+		// every other forfeit-path ask in the manager.
+		result := m.askForfeitVTXOActor(
+			ctx, ref, &ForfeitReleasedEvent{},
+		)
+		if _, err := result.Unpack(); err != nil {
+			m.logger(ctx).WarnS(
+				ctx,
+				"Forfeit sweep: release failed",
+				err,
+				slog.String("outpoint", op.String()),
+			)
+
+			continue
+		}
+
+		// The release flipped the actor and DB status to Live, but the
+		// liveDescriptors snapshot was captured during actor recovery
+		// before this sweep ran. Refresh it so downstream consumers
+		// such as the fraud-watch restore do not see the stale
+		// PendingForfeit status and skip the now-live VTXO.
+		m.markDescriptorLive(op)
+
+		released++
+	}
+
+	m.logger(ctx).InfoS(ctx, "Forfeit sweep complete",
+		slog.Int("pending_forfeit", len(pending)),
+		slog.Int("released", released),
+	)
+}
+
+// markDescriptorLive updates the cached liveDescriptors snapshot so a VTXO that
+// a startup sweep returned to LiveState is reported with its true status. The
+// snapshot is captured during actor recovery, before the sweeps run, so without
+// this refresh a released VTXO would still read with its pre-sweep status
+// (PendingForfeit or Spending). Consumers that key on status would then act on
+// stale data: the fraud-watch restore, for one, skips any descriptor whose
+// status is not Live and would leave a swept OOR VTXO's ancestor spend watches
+// un-armed. The entries are pointers into the same descriptors the snapshot
+// shares, so mutating Status in place is visible to every reader.
+func (m *Manager) markDescriptorLive(op wire.OutPoint) {
+	for _, desc := range m.liveDescriptors {
+		if desc.Outpoint == op {
+			desc.Status = VTXOStatusLive
+
+			return
+		}
+	}
 }
 
 // handleReleaseSpend releases VTXOs from spend reservation back to

--- a/vtxo/manager_exit_test.go
+++ b/vtxo/manager_exit_test.go
@@ -202,6 +202,9 @@ func TestManagerStartReconcilesConfirmedExit(t *testing.T) {
 	store.On(
 		"ListVTXOsByStatus", t.Context(), VTXOStatusUnilateralExit,
 	).Return([]*Descriptor{vtxo}, nil)
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusPendingForfeit,
+	).Return([]*Descriptor{}, nil)
 	store.On("GetVTXO", t.Context(), vtxo.Outpoint).Return(vtxo, nil)
 	store.On(
 		"UpdateVTXOStatus", t.Context(), vtxo.Outpoint, VTXOStatusSpent,

--- a/vtxo/manager_forfeit_release_test.go
+++ b/vtxo/manager_forfeit_release_test.go
@@ -1,0 +1,153 @@
+package vtxo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// newPendingForfeitManager builds a Manager whose actors are all in
+// PendingForfeitState for the given descriptors. This mirrors the state a VTXO
+// is left in when an in-flight cooperative round (refresh, leave, or directed
+// send) reserved it as a forfeit input and the daemon then restarted before the
+// round reached the point of no return.
+func newPendingForfeitManager(t *testing.T,
+	descriptors []*Descriptor) (*Manager, *MockVTXOStore) {
+
+	t.Helper()
+
+	store := &MockVTXOStore{}
+	mgr := &Manager{
+		cfg: &ManagerConfig{
+			Store:      store,
+			RoundActor: newMockRoundActorRef(t),
+		},
+		actors: make(map[wire.OutPoint]VTXOActorRef),
+	}
+
+	for _, vtxo := range descriptors {
+		// Mirror real recovery: the descriptor is cached in the
+		// liveDescriptors snapshot with its on-disk PendingForfeit
+		// status, and an actor is spawned in PendingForfeitState.
+		vtxo.Status = VTXOStatusPendingForfeit
+		mgr.liveDescriptors = append(mgr.liveDescriptors, vtxo)
+
+		ref := newMockVTXOActorRef(
+			vtxo.Outpoint.String(),
+			&PendingForfeitState{
+				VTXO:              vtxo,
+				RequestedAtHeight: vtxo.CreatedHeight,
+			},
+		)
+		mgr.actors[vtxo.Outpoint] = ref
+	}
+
+	return mgr, store
+}
+
+// snapshotStatus returns the status of the given outpoint in the manager's
+// cached liveDescriptors snapshot, or false if it is absent.
+func snapshotStatus(mgr *Manager, op wire.OutPoint) (VTXOStatus, bool) {
+	for _, desc := range mgr.liveDescriptors {
+		if desc.Outpoint == op {
+			return desc.Status, true
+		}
+	}
+
+	return 0, false
+}
+
+// TestReleaseOrphanedForfeitsReturnsToLive verifies that the startup sweep
+// returns every VTXO stranded in PendingForfeitState back to LiveState. The
+// owning round FSM is in-memory only, so any PendingForfeit VTXO found at
+// startup is provably orphaned and safe to release: no forfeit signature has
+// left the process yet, so the operator cannot broadcast a forfeit.
+func TestReleaseOrphanedForfeitsReturnsToLive(t *testing.T) {
+	t.Parallel()
+
+	orphanA := makeDescriptor(t, 50000, 0)
+	orphanB := makeDescriptor(t, 40000, 1)
+
+	mgr, store := newPendingForfeitManager(
+		t, []*Descriptor{orphanA, orphanB},
+	)
+
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusPendingForfeit,
+	).Return([]*Descriptor{orphanA, orphanB}, nil)
+
+	mgr.releaseOrphanedForfeits(t.Context())
+
+	_, ok := actorState(t, mgr, orphanA.Outpoint).(*LiveState)
+	require.True(t, ok, "orphan A must be released to Live")
+
+	_, ok = actorState(t, mgr, orphanB.Outpoint).(*LiveState)
+	require.True(t, ok, "orphan B must be released to Live")
+
+	// The cached liveDescriptors snapshot must also be refreshed to Live,
+	// so downstream consumers (e.g. the fraud-watch restore) do not skip
+	// the now-live VTXOs on a stale PendingForfeit status.
+	statusA, foundA := snapshotStatus(mgr, orphanA.Outpoint)
+	require.True(t, foundA)
+	require.Equal(t, VTXOStatusLive, statusA, "snapshot A must read Live")
+
+	statusB, foundB := snapshotStatus(mgr, orphanB.Outpoint)
+	require.True(t, foundB)
+	require.Equal(t, VTXOStatusLive, statusB, "snapshot B must read Live")
+
+	store.AssertExpectations(t)
+}
+
+// TestReleaseOrphanedForfeitsListErrorIsNoop verifies that a failure listing
+// PendingForfeit VTXOs aborts the sweep without touching any actor, so a
+// transient store error cannot mis-handle a reservation.
+func TestReleaseOrphanedForfeitsListErrorIsNoop(t *testing.T) {
+	t.Parallel()
+
+	orphan := makeDescriptor(t, 50000, 0)
+
+	mgr, store := newPendingForfeitManager(t, []*Descriptor{orphan})
+
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusPendingForfeit,
+	).Return([]*Descriptor(nil), errors.New("store unreadable"))
+
+	mgr.releaseOrphanedForfeits(t.Context())
+
+	_, ok := actorState(t, mgr, orphan.Outpoint).(*PendingForfeitState)
+	require.True(t, ok, "VTXO must remain PendingForfeit on list error")
+
+	store.AssertExpectations(t)
+}
+
+// TestReleaseOrphanedForfeitsSkipsMissingActor verifies that a persisted
+// PendingForfeit descriptor with no recovered actor is skipped without panic
+// and without disturbing the actors that are present.
+func TestReleaseOrphanedForfeitsSkipsMissingActor(t *testing.T) {
+	t.Parallel()
+
+	tracked := makeDescriptor(t, 50000, 0)
+	missing := makeDescriptor(t, 40000, 1)
+
+	// Only `tracked` gets an actor; `missing` is returned by the store but
+	// is absent from the actor map.
+	mgr, store := newPendingForfeitManager(t, []*Descriptor{tracked})
+
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusPendingForfeit,
+	).Return([]*Descriptor{tracked, missing}, nil)
+
+	mgr.releaseOrphanedForfeits(t.Context())
+
+	// The tracked VTXO is still released to Live; the missing one is simply
+	// skipped.
+	_, ok := actorState(t, mgr, tracked.Outpoint).(*LiveState)
+	require.True(t, ok, "tracked VTXO must be released to Live")
+
+	_, present := mgr.actors[missing.Outpoint]
+	require.False(t, present, "missing VTXO must not gain an actor")
+
+	store.AssertExpectations(t)
+}


### PR DESCRIPTION
### Motivation

When a cooperative round (a refresh, leave, or directed send) reserves a
VTXO as a forfeit input, the VTXO moves into `PendingForfeitState`. That
reservation is owned by the round FSM, and the round FSM is in-memory
only: temp rounds are never persisted, and the `rounds` table isn't
written until `InputSigSentState`, the point of no return.

So there's a window. If the daemon restarts while a round is still in any
pre-signing state, the FSM that would have released the reservation on
failure dies with it. The VTXO comes back from disk still in
`PendingForfeitState`, and nothing drives it back to `LiveState`. The
balance is silently stranded until batch expiry eventually forces a
unilateral exit.

This is the restart twin of #653. That issue handled the running-daemon
failure path, where the round fails and `releaseForfeitsOnFailure`
returns the inputs to live. A crash skips right past it, because the FSM
never gets to run its failure transition.

I hit this in live signet testing: a refresh that I restarted mid-flight
left the VTXO wedged in `PENDING_FORFEIT`, and `refresh --all` couldn't
touch it, since it only selects live VTXOs.

### Approach

We add a startup sweep, `releaseOrphanedForfeits`, that mirrors the
existing orphaned-spend reservation sweep. Once actor recovery completes,
any VTXO still in `PendingForfeitState` is returned to `LiveState`.

The safety argument is local and total. Forfeit signatures are only
submitted on the `PendingForfeit -> Forfeiting` transition, so a VTXO
still in `PendingForfeitState` has leaked no signature: the operator
holds nothing it could broadcast, and the original VTXO is unambiguously
still ours. Returning it to live cannot double-spend. And because round
FSMs are non-durable and temp rounds aren't persisted, every
`PendingForfeit` VTXO observed at startup has necessarily lost its round,
so the sweep needs no other input to know it is orphaned.

VTXOs already in `Forfeiting` or `Forfeited` are deliberately left alone.
Those are past the point of no return: we can't prove the operator does
not hold our forfeit signature, so the safe resolution there stays
unilateral exit at batch expiry rather than a release. Closing that other
half needs a server-authoritative round-status reconcile, which is filed
as a server-side follow-up since the round actor isn't durable today.

### Testing

Unit tests in `vtxo` cover the sweep directly: a recovered
`PendingForfeit` VTXO returns to live, a store error aborts cleanly, and
a descriptor with no recovered actor is skipped without a panic.

A new client-level systest, `TestRefreshStrandedVTXORecoversOnRestart`,
proves it end to end. A refresh reserves the seeded VTXO into
pending-forfeit, and then we restart the daemon over the same data
directory. The admission timeout is disabled and the round FSM is gone
after the restart, so the startup sweep is the only thing that can rescue
the reservation. The VTXO returning to LIVE with its balance restored is
the proof.

To support the restart, the directed-send systest fixture is now
restartable. It retains its config and gRPC address and gains
launch/shutdown/restart helpers, and the constructor routes its initial
start through the same launch helper so existing fixture users are
unaffected.


### Follow-up

The post-signing half (a `Forfeiting` VTXO stranded when the non-durable server round actor dies after we send signatures) is tracked server-side in lightninglabs/darepo#618.
