### PR TITLE
docs: nightly doc-gardening sweep 2026-06-30

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,6 +18,8 @@ package may import from a higher layer.
 | [`oor`](oor/) | Out-of-round transfer coordination FSM |
 | [`wallet`](wallet/) | On-chain boarding wallet actor (address derivation, UTXO monitoring) |
 | [`ledger`](ledger/) | Client-side durable ledger actor for double-entry fee accounting |
+| [`credit`](credit/) | Durable credit subsystem: per-operation protofsm actors for sub-dust pays, Lightning receives, and Ark redemptions, supervised by a plain Registry coordinator |
+| [`coinselect`](coinselect/) | Coin-type-agnostic LargestFirst coin selection shared by the VTXO manager and swap wallet send path |
 | [`lib`](lib/) | Shared domain utilities: tree paths, BIP-322, arkscript policy, types |
 | [`lib/arkscript`](lib/arkscript/) | Tapscript AST compiler and policy system for Ark taproot outputs |
 | [`lib/bip322`](lib/bip322/) | BIP-322 intent-bound message authentication |
@@ -35,6 +37,7 @@ package may import from a higher layer.
 |---------|---------|
 | [`baselib`](baselib/) | Actor framework (`baselib/actor`) and protofsm state machine engine (`baselib/protofsm`) |
 | [`chainsource`](chainsource/) | `ChainBackend` interface: fee estimation, block/conf/spend notifications |
+| [`chainfees`](chainfees/) | Reusable `chainfee.Estimator` implementations (mempool.space, WalletKit) and a MinEstimator combinator |
 | [`chainbackends`](chainbackends/) | LND-backed `ChainBackend` implementation plus lndclient adapters (`TxBroadcaster`, `PackageSubmitter`) |
 | [`chain`](chain/) | Bitcoind RPC utilities (package relay, `SubmitPackage`) |
 | [`txconfirm`](txconfirm/) | Generic "broadcast + CPFP fee-bump + notify on confirm" actor with per-parent fee-input reservations and BIP-125 Rule 3/4 enforcement |
@@ -47,7 +50,8 @@ package may import from a higher layer.
 | [`fraud`](fraud/) | Fraud detection actor: watches OOR ancestor outpoints on-chain and triggers unilateral exit when an ancestor is spent |
 | [`vhtlcrecovery/coordinator`](vhtlcrecovery/coordinator/) | Runtime coordinator for durable vHTLC recovery jobs: arms, escalates into unroll, cancels, and reconciles after restart |
 | [`vhtlcrecovery/unrollpolicy`](vhtlcrecovery/unrollpolicy/) | Adapter that resolves `(exit_policy_kind, recovery_id)` into a concrete `unroll.ExitSpendPolicy` for vHTLC claim and refund exits |
-| [`db`](db/) | SQLite/PostgreSQL persistence: boarding, rounds, VTXOs, OOR artifacts, fee ledger |
+| [`db`](db/) | SQLite/PostgreSQL persistence: boarding, rounds, VTXOs, OOR artifacts, fee ledger, credit operations |
+| [`internal/sqlbase`](internal/sqlbase/) | WebAssembly-only (`js && wasm`) SQLite adapter implementing `walletdb.DB` for `lwwallet` in WASM builds |
 | [`mailbox`](mailbox/) | Mailbox protocol primitives across three sub-packages (pb, rpc, conn) |
 | [`serverconn`](serverconn/) | Unified server connector: durable egress, ingress polling, unary RPC facade |
 | [`serverconn/mailboxpull`](serverconn/mailboxpull/) | Shared exponential-backoff retry primitives for mailbox pull loops (used by serverconn ingress and SDK swap consumers) |
@@ -60,11 +64,13 @@ package may import from a higher layer.
 | [`gateway`](gateway/) | HTTP gateway utilities (mux options, CORS, endpoint normalization) for grpc-gateway integration |
 | [`sdk/ark`](sdk/ark/) | Consumer-facing Go SDK facade: remote or embedded daemon access with typed models |
 | [`sdk/swaps`](sdk/swaps/) | Lightning-to-Ark / Ark-to-Lightning atomic swap SDK with durable FSM flows |
-| [`sdk/walletdk`](sdk/walletdk/) | Wallet-shaped SDK facade for host apps: embeds the daemon in-process, dials it over a private bufconn transport, exposes typed methods for the seven core wallet verbs (create, unlock, send, recv, list, balance, exit). The highest-level layer in the stack; wraps `walletdkrpc.WalletService`. Wallet RPC methods gated behind `walletdkrpc` (which transitively requires `swapruntime`) |
+| [`sdk/walletdk`](sdk/walletdk/) | Wallet-shaped SDK facade for host apps: embeds the daemon in-process, dials it over a private bufconn transport, exposes typed methods for the seven core wallet verbs (create, unlock, send, recv, list, balance, exit) plus passkey-based wallet open. The highest-level layer in the stack; wraps `walletdkrpc.WalletService`. Wallet RPC methods gated behind `walletdkrpc` (which transitively requires `swapruntime`) |
+| [`sdk/walletdk/mobile`](sdk/walletdk/mobile/) | gomobile-safe facade over `sdk/walletdk` for Android/iOS native bindings; also the WASM bridge entry point. JSON bytes-in/out convention; pull-based `Subscription` for streaming. Build-tag gated (`mobile walletdkrpc swapruntime`) |
 | [`swapwallet`](swapwallet/) | Optional daemon-side `walletdkrpc.WalletService` implementation (build tags `walletdkrpc swapruntime`): composes the swap subsystem, cooperative leave, boarding, ledger, and unilateral-exit registry behind one flat, swap-vocabulary-free wallet API |
 | [`swapclientserver`](swapclientserver/) | Optional daemon-side swap subserver (build tag `swapruntime`): translates `swapclientrpc` RPCs into `sdk/swaps` operations and manages the daemon-local worker registry |
 | [`cmd/darepod`](cmd/darepod/) | Daemon entry point |
 | [`cmd/darepocli`](cmd/darepocli/) | CLI client |
+| [`cmd/walletdk-wasm`](cmd/walletdk-wasm/) | WebAssembly entry point for the walletdk embedded daemon; stub keeps native `go build ./...` green |
 | [`timeout`](timeout/) | Generic timeout scheduling actor |
 | [`indexer`](indexer/) | Server indexing client for receive script registration |
 | [`arkrpc`](arkrpc/) | Server-side gRPC service definitions (ArkService, IndexerService) |

--- a/chainfees/AGENTS.md
+++ b/chainfees/AGENTS.md
@@ -1,0 +1,50 @@
+# chainfees
+
+## Purpose
+
+Reusable `chainfee.Estimator` implementations and combinators for
+wallet and daemon chain backends. Provides a mempool.space HTTP
+estimator, an LND WalletKit estimator, and a `MinEstimator` combinator
+that takes the minimum of N named estimators — giving callers a
+single fee surface without coupling to a specific backend.
+
+## Key Types
+
+- `MempoolSpaceEstimator` — Polls mempool.space's fee API for real-time
+  fee estimates. Configured by `MempoolSpaceConfig` (URL, network,
+  timeout, poll interval).
+- `WalletKitEstimator` — Wraps `lndclient.WalletKitClient` to provide
+  fee estimates via LND's `EstimateFee` RPC. Several constructors cover
+  the common configurations: plain, fallback (returns zero on error),
+  with-timeout, and fully configured.
+- `WalletKitEstimatorConfig` — Configuration for `WalletKitEstimator`:
+  wallet kit client, logger, timeout, and fallback behavior.
+- `MinEstimator` — Combinator that returns the minimum fee estimate
+  across a set of named child estimators. Used by chain backends that
+  want to pick the cheapest reliable estimate.
+- `NamedEstimator` — Name + `chainfee.Estimator` pair used by
+  `MinEstimator`.
+- `DefaultMempoolSpaceURL` — Returns the canonical mempool.space URL
+  for a given Bitcoin network.
+
+## Relationships
+
+- **Depends on**: no internal packages (only external: `lndclient`,
+  `btcwallet/chain/chainfee`, `btcwallet/chaincfg`, `btclog`).
+- **Depended on by**:
+  - `chainbackends` (uses WalletKitEstimator and MempoolSpaceEstimator
+    when constructing fee estimators for chain backends)
+  - `darepod` (wires chain backend fee estimators into daemon config)
+- **Sends**: nothing.
+- **Receives**: nothing.
+
+## Invariants
+
+- All estimators implement `chainfee.Estimator`; callers should use
+  the interface, not concrete types, except at construction sites.
+- `MinEstimator` requires at least one child estimator; `NewMinEstimator`
+  returns an error if the slice is empty.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/chainfees/CLAUDE.md
+++ b/chainfees/CLAUDE.md
@@ -1,0 +1,50 @@
+# chainfees
+
+## Purpose
+
+Reusable `chainfee.Estimator` implementations and combinators for
+wallet and daemon chain backends. Provides a mempool.space HTTP
+estimator, an LND WalletKit estimator, and a `MinEstimator` combinator
+that takes the minimum of N named estimators — giving callers a
+single fee surface without coupling to a specific backend.
+
+## Key Types
+
+- `MempoolSpaceEstimator` — Polls mempool.space's fee API for real-time
+  fee estimates. Configured by `MempoolSpaceConfig` (URL, network,
+  timeout, poll interval).
+- `WalletKitEstimator` — Wraps `lndclient.WalletKitClient` to provide
+  fee estimates via LND's `EstimateFee` RPC. Several constructors cover
+  the common configurations: plain, fallback (returns zero on error),
+  with-timeout, and fully configured.
+- `WalletKitEstimatorConfig` — Configuration for `WalletKitEstimator`:
+  wallet kit client, logger, timeout, and fallback behavior.
+- `MinEstimator` — Combinator that returns the minimum fee estimate
+  across a set of named child estimators. Used by chain backends that
+  want to pick the cheapest reliable estimate.
+- `NamedEstimator` — Name + `chainfee.Estimator` pair used by
+  `MinEstimator`.
+- `DefaultMempoolSpaceURL` — Returns the canonical mempool.space URL
+  for a given Bitcoin network.
+
+## Relationships
+
+- **Depends on**: no internal packages (only external: `lndclient`,
+  `btcwallet/chain/chainfee`, `btcwallet/chaincfg`, `btclog`).
+- **Depended on by**:
+  - `chainbackends` (uses WalletKitEstimator and MempoolSpaceEstimator
+    when constructing fee estimators for chain backends)
+  - `darepod` (wires chain backend fee estimators into daemon config)
+- **Sends**: nothing.
+- **Receives**: nothing.
+
+## Invariants
+
+- All estimators implement `chainfee.Estimator`; callers should use
+  the interface, not concrete types, except at construction sites.
+- `MinEstimator` requires at least one child estimator; `NewMinEstimator`
+  returns an error if the slice is empty.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/cmd/walletdk-wasm/AGENTS.md
+++ b/cmd/walletdk-wasm/AGENTS.md
@@ -1,0 +1,35 @@
+# cmd/walletdk-wasm
+
+## Purpose
+
+WebAssembly binary entry point for the walletdk embedded daemon. The
+real `main` (compiled with `GOOS=js GOARCH=wasm`) boots the
+`sdk/walletdk/mobile` facade and exposes it to JavaScript via the
+WASM/JS bridge. A stub `main` in `stub.go` makes the package
+build-clean under native toolchains and explains how to build the real
+WASM binary.
+
+## Key Types
+
+- `main` — Entry point; only meaningful as a `js/wasm` target.
+
+## Relationships
+
+- **Depends on**:
+  - `sdk/walletdk/mobile` (gomobile/WASM facade over the embedded daemon)
+- **Depended on by**: nothing at the Go level; the compiled `.wasm`
+  binary is loaded by JavaScript in the host web application.
+- **Sends**: nothing (passes control to the mobile facade).
+- **Receives**: nothing at the Go level.
+
+## Invariants
+
+- Only the `js/wasm` build is meaningful. Native builds compile via
+  `stub.go` only to keep `go build ./...` green.
+- Build: `GOOS=js GOARCH=wasm go build -tags 'mobile walletdkrpc swapruntime' ./cmd/walletdk-wasm`
+
+## Deep Docs
+
+- [sdk/walletdk/mobile/CLAUDE.md](../../sdk/walletdk/mobile/CLAUDE.md)
+  — The WASM/mobile facade this command boots.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/cmd/walletdk-wasm/CLAUDE.md
+++ b/cmd/walletdk-wasm/CLAUDE.md
@@ -1,0 +1,35 @@
+# cmd/walletdk-wasm
+
+## Purpose
+
+WebAssembly binary entry point for the walletdk embedded daemon. The
+real `main` (compiled with `GOOS=js GOARCH=wasm`) boots the
+`sdk/walletdk/mobile` facade and exposes it to JavaScript via the
+WASM/JS bridge. A stub `main` in `stub.go` makes the package
+build-clean under native toolchains and explains how to build the real
+WASM binary.
+
+## Key Types
+
+- `main` — Entry point; only meaningful as a `js/wasm` target.
+
+## Relationships
+
+- **Depends on**:
+  - `sdk/walletdk/mobile` (gomobile/WASM facade over the embedded daemon)
+- **Depended on by**: nothing at the Go level; the compiled `.wasm`
+  binary is loaded by JavaScript in the host web application.
+- **Sends**: nothing (passes control to the mobile facade).
+- **Receives**: nothing at the Go level.
+
+## Invariants
+
+- Only the `js/wasm` build is meaningful. Native builds compile via
+  `stub.go` only to keep `go build ./...` green.
+- Build: `GOOS=js GOARCH=wasm go build -tags 'mobile walletdkrpc swapruntime' ./cmd/walletdk-wasm`
+
+## Deep Docs
+
+- [sdk/walletdk/mobile/CLAUDE.md](../../sdk/walletdk/mobile/CLAUDE.md)
+  — The WASM/mobile facade this command boots.
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/coinselect/AGENTS.md
+++ b/coinselect/AGENTS.md
@@ -1,0 +1,44 @@
+# coinselect
+
+## Purpose
+
+Coin-type-agnostic coin-selection algorithm shared across the client.
+Provides a single `LargestFirst` selector generic over any coin type,
+so the VTXO manager's reservation path and the swap wallet's send
+preview select from the same code rather than growing parallel
+implementations. Deliberately holds no wallet, actor, or RPC
+dependencies.
+
+## Key Types
+
+- `LargestFirst[T]` — Greedy coin-selection function. Selects the
+  smallest subset of candidates (ordered largest-first) that covers
+  `req.TargetAmount + req.FeeHeadroom`. Returns a `Result[T]` with the
+  chosen coins, total selected, change, and shortfall.
+- `Request` — Selection parameters: target amount, fee headroom,
+  and optional maximum number of coins.
+- `Result[T]` — Selection outcome: chosen coins, total selected,
+  change amount, and whether the selection was exact.
+- `AmountFunc[T]` — Caller-supplied projection from a coin value of
+  type `T` to `btcutil.Amount` so the selector remains generic.
+- `ErrSelectionShortfall` — Returned when the full candidate set still
+  cannot cover the target + headroom.
+
+## Relationships
+
+- **Depends on**: none (no internal package imports).
+- **Depended on by**:
+  - `vtxo` (VTXO reservation path uses LargestFirst to select VTXOs)
+  - `swapwallet` (send preview path uses LargestFirst)
+- **Sends**: nothing.
+- **Receives**: nothing.
+
+## Invariants
+
+- No wallet, actor, or RPC dependencies — intentionally a pure
+  algorithm package to keep all coin-selection logic in one place.
+- `LargestFirst` is deterministic given a fixed candidate list order.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/coinselect/CLAUDE.md
+++ b/coinselect/CLAUDE.md
@@ -1,0 +1,44 @@
+# coinselect
+
+## Purpose
+
+Coin-type-agnostic coin-selection algorithm shared across the client.
+Provides a single `LargestFirst` selector generic over any coin type,
+so the VTXO manager's reservation path and the swap wallet's send
+preview select from the same code rather than growing parallel
+implementations. Deliberately holds no wallet, actor, or RPC
+dependencies.
+
+## Key Types
+
+- `LargestFirst[T]` — Greedy coin-selection function. Selects the
+  smallest subset of candidates (ordered largest-first) that covers
+  `req.TargetAmount + req.FeeHeadroom`. Returns a `Result[T]` with the
+  chosen coins, total selected, change, and shortfall.
+- `Request` — Selection parameters: target amount, fee headroom,
+  and optional maximum number of coins.
+- `Result[T]` — Selection outcome: chosen coins, total selected,
+  change amount, and whether the selection was exact.
+- `AmountFunc[T]` — Caller-supplied projection from a coin value of
+  type `T` to `btcutil.Amount` so the selector remains generic.
+- `ErrSelectionShortfall` — Returned when the full candidate set still
+  cannot cover the target + headroom.
+
+## Relationships
+
+- **Depends on**: none (no internal package imports).
+- **Depended on by**:
+  - `vtxo` (VTXO reservation path uses LargestFirst to select VTXOs)
+  - `swapwallet` (send preview path uses LargestFirst)
+- **Sends**: nothing.
+- **Receives**: nothing.
+
+## Invariants
+
+- No wallet, actor, or RPC dependencies — intentionally a pure
+  algorithm package to keep all coin-selection logic in one place.
+- `LargestFirst` is deterministic given a fixed candidate list order.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/credit/AGENTS.md
+++ b/credit/AGENTS.md
@@ -1,0 +1,91 @@
+# credit
+
+## Purpose
+
+Durable credit subsystem: manages server-side micro-credit operations
+for sub-dust payments, Lightning receives, and Ark redemptions. A plain
+supervisor actor (`Registry`) spawns and monitors per-operation durable
+child actors (`OpActor`), each running a protofsm FSM that drives the
+full lifecycle of one credit operation (quoting → funding → settlement
+→ terminal). The subsystem handles crash recovery by restoring
+non-terminal operations from the durable store on boot.
+
+## Key Types
+
+- `Registry` — Supervisor actor. Admits new operations, routes resume
+  timers, reaps terminal children, and restores in-flight operations on
+  restart. Runs on a plain (non-durable) in-memory mailbox; no durable
+  state of its own.
+- `OpActor` — Wraps one per-operation durable actor. Owns the TLV
+  mailbox, the protofsm engine, and the durable DB row. Stopped by the
+  Registry when a terminal state is reached.
+- `CreditMsg` — Sealed message interface for the supervisor mailbox
+  (actor.Message only — not TLV-serializable, since supervisor state is
+  in-memory).
+- `CreditDurableMsg` — Sealed message interface for per-operation child
+  mailboxes (must implement `actor.TLVMessage` for durable restart).
+- `ResumeCreditOpRequest` — The only application-level message that
+  crosses a durable child mailbox. Carries the operation ID so the
+  child re-fetches its state from the DB after restart.
+- `CreditState` / `CreditTransition` / `CreditEmittedEvent` — protofsm
+  aliases for the credit FSM's state, transition, and emitted-event
+  types.
+- `Store` — Interface the subsystem requires for durable persistence;
+  satisfied by `db.CreditOperationStoreDB`.
+- `CreditServer` — Interface for reaching the swap server's credit RPC
+  surface (CreateCredit, ListCredits, RedeemCredit, QuoteCredit); satisfied
+  by `swapclientserver.creditServerBridge`.
+- `CreditDaemon` — Interface for reaching daemon-side wallet actions
+  (e.g. triggering OOR pays for top-ups); satisfied by the daemon facade.
+- `AutoRedeemConfig` — Config for the auto-redeem policy that
+  materializes idle credits back into Ark vTXOs above a threshold.
+
+## Relationships
+
+- **Depends on**:
+  - `baselib/actor` (actor primitives, TLVMessage, ServiceKey, mailbox)
+  - `baselib/protofsm` (FSM engine, EmittedEvent, StateTransition)
+  - `db` (CreditOperationStoreDB, CreditOpKind, CreditOpStatus)
+  - `timeout` (retry/callback timing)
+  - `build` (subsystem logger)
+- **Depended on by**:
+  - `swapwallet` (routes credit-backed sends and receives through the
+    Registry, projects credit op states onto wallet rows)
+  - `swapclientserver` (implements CreditServer via creditServerBridge)
+  - `darepod` (wires Registry into daemon startup, registers service key)
+- **Sends**:
+  - → `db` (CreditOperationStoreDB): UpsertOperation, GetOperation,
+    ListNonTerminal (via actor transaction context)
+  - → `swapclientserver` (via CreditServer): CreateCredit, ListCredits,
+    RedeemCredit, QuoteCredit
+  - → `swapwallet` (via CreditDaemon): OOR pay requests for Ark top-ups
+- **Receives**:
+  - ← `swapwallet`: StartCreditPayRequest, StartCreditReceiveRequest,
+    ConsiderRedeemRequest, ListCreditOpsRequest
+  - ← `darepod`: RestoreNonTerminalRequest (on daemon boot),
+    ResumeCreditOpRequest (retry callbacks)
+
+## Invariants
+
+- The supervisor (`Registry`) holds no durable state; all crash-safe
+  state lives in `db.CreditOperationStoreDB` and each child's TLV
+  mailbox.
+- `ResumeCreditOpRequestTLVType = 0x7102` must not collide with actor
+  framework reserved types (0xFFFE/0xFFFF), OOR range (0x70xx first
+  byte changes), or ledger range (0x90xx).
+- The supervisor pre-writes the control-plane row before spawning a
+  child, so a crash between spawn and first ack still restores
+  correctly on restart via `RestoreNonTerminal`.
+- `CreditOpKind` and `CreditOpStatus` values are append-only: numeric
+  meanings must never shift.
+- Auto-redeem policy runs only when credits exceed the configured
+  threshold; it uses `EarmarkFunc` to avoid racing with an in-flight
+  spend.
+
+## Deep Docs
+
+- [docs/credit_durable_actor.md](../docs/credit_durable_actor.md) —
+  Credit subsystem design: FSM states, durable schema, resume path.
+- [docs/durable_actor_architecture.md](../docs/durable_actor_architecture.md)
+  — CDC pattern and durable mailbox lifecycle.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/credit/CLAUDE.md
+++ b/credit/CLAUDE.md
@@ -1,0 +1,91 @@
+# credit
+
+## Purpose
+
+Durable credit subsystem: manages server-side micro-credit operations
+for sub-dust payments, Lightning receives, and Ark redemptions. A plain
+supervisor actor (`Registry`) spawns and monitors per-operation durable
+child actors (`OpActor`), each running a protofsm FSM that drives the
+full lifecycle of one credit operation (quoting → funding → settlement
+→ terminal). The subsystem handles crash recovery by restoring
+non-terminal operations from the durable store on boot.
+
+## Key Types
+
+- `Registry` — Supervisor actor. Admits new operations, routes resume
+  timers, reaps terminal children, and restores in-flight operations on
+  restart. Runs on a plain (non-durable) in-memory mailbox; no durable
+  state of its own.
+- `OpActor` — Wraps one per-operation durable actor. Owns the TLV
+  mailbox, the protofsm engine, and the durable DB row. Stopped by the
+  Registry when a terminal state is reached.
+- `CreditMsg` — Sealed message interface for the supervisor mailbox
+  (actor.Message only — not TLV-serializable, since supervisor state is
+  in-memory).
+- `CreditDurableMsg` — Sealed message interface for per-operation child
+  mailboxes (must implement `actor.TLVMessage` for durable restart).
+- `ResumeCreditOpRequest` — The only application-level message that
+  crosses a durable child mailbox. Carries the operation ID so the
+  child re-fetches its state from the DB after restart.
+- `CreditState` / `CreditTransition` / `CreditEmittedEvent` — protofsm
+  aliases for the credit FSM's state, transition, and emitted-event
+  types.
+- `Store` — Interface the subsystem requires for durable persistence;
+  satisfied by `db.CreditOperationStoreDB`.
+- `CreditServer` — Interface for reaching the swap server's credit RPC
+  surface (CreateCredit, ListCredits, RedeemCredit, QuoteCredit); satisfied
+  by `swapclientserver.creditServerBridge`.
+- `CreditDaemon` — Interface for reaching daemon-side wallet actions
+  (e.g. triggering OOR pays for top-ups); satisfied by the daemon facade.
+- `AutoRedeemConfig` — Config for the auto-redeem policy that
+  materializes idle credits back into Ark vTXOs above a threshold.
+
+## Relationships
+
+- **Depends on**:
+  - `baselib/actor` (actor primitives, TLVMessage, ServiceKey, mailbox)
+  - `baselib/protofsm` (FSM engine, EmittedEvent, StateTransition)
+  - `db` (CreditOperationStoreDB, CreditOpKind, CreditOpStatus)
+  - `timeout` (retry/callback timing)
+  - `build` (subsystem logger)
+- **Depended on by**:
+  - `swapwallet` (routes credit-backed sends and receives through the
+    Registry, projects credit op states onto wallet rows)
+  - `swapclientserver` (implements CreditServer via creditServerBridge)
+  - `darepod` (wires Registry into daemon startup, registers service key)
+- **Sends**:
+  - → `db` (CreditOperationStoreDB): UpsertOperation, GetOperation,
+    ListNonTerminal (via actor transaction context)
+  - → `swapclientserver` (via CreditServer): CreateCredit, ListCredits,
+    RedeemCredit, QuoteCredit
+  - → `swapwallet` (via CreditDaemon): OOR pay requests for Ark top-ups
+- **Receives**:
+  - ← `swapwallet`: StartCreditPayRequest, StartCreditReceiveRequest,
+    ConsiderRedeemRequest, ListCreditOpsRequest
+  - ← `darepod`: RestoreNonTerminalRequest (on daemon boot),
+    ResumeCreditOpRequest (retry callbacks)
+
+## Invariants
+
+- The supervisor (`Registry`) holds no durable state; all crash-safe
+  state lives in `db.CreditOperationStoreDB` and each child's TLV
+  mailbox.
+- `ResumeCreditOpRequestTLVType = 0x7102` must not collide with actor
+  framework reserved types (0xFFFE/0xFFFF), OOR range (0x70xx first
+  byte changes), or ledger range (0x90xx).
+- The supervisor pre-writes the control-plane row before spawning a
+  child, so a crash between spawn and first ack still restores
+  correctly on restart via `RestoreNonTerminal`.
+- `CreditOpKind` and `CreditOpStatus` values are append-only: numeric
+  meanings must never shift.
+- Auto-redeem policy runs only when credits exceed the configured
+  threshold; it uses `EarmarkFunc` to avoid racing with an in-flight
+  spend.
+
+## Deep Docs
+
+- [docs/credit_durable_actor.md](../docs/credit_durable_actor.md) —
+  Credit subsystem design: FSM states, durable schema, resume path.
+- [docs/durable_actor_architecture.md](../docs/durable_actor_architecture.md)
+  — CDC pattern and durable mailbox lifecycle.
+- [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -71,7 +71,7 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   safety bounds enforced during `DeserializeTree`.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — two-stage
   OOR ancestry resolver (`oor_unroll_resolver.go`).
-- `LatestMigrationVersion = 21` — current schema version.
+- `LatestMigrationVersion = 22` — current schema version.
 - `PendingIntentPersistenceStore` — implements `wallet.PendingIntentStore`,
   the persistence half of the generic restart-safe intent outbox (header
   `pending_intents` + per-kind detail tables + `pending_intent_anchors`).
@@ -97,6 +97,18 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   `vtxo.SpendingReservationStore`.
 - `SpendingReservationStore` / `BatchedSpendingReservationStore` — Internal
   sqlc-backed query interfaces for the reservation table.
+- `CreditOperationStoreDB` — implements `credit.Store`. Bridges
+  credit-operation control-plane rows to sqlc queries. Every method
+  wraps the query in `ExecTx` so writes join an ambient actor tx
+  (via `actor.TxFromContext`) or open their own short tx. Methods:
+  `UpsertOperation`, `GetOperation`, `LookupActiveOperationByKey`,
+  `ListNonTerminal`, `ListOperations`.
+- `CreditOperationRecord` — Domain type for a single credit operation
+  row: `OperationID`, `Kind`, `Status`, `IdempotencyKey`,
+  `CreatedAt`, `UpdatedAt`.
+- `CreditOpKind` / `CreditOpStatus` — Append-only enumerations for
+  credit operation family (`Pay`, `Receive`, `Redeem`) and terminal
+  state (`Pending`, `Completed`, `Failed`).
 
 ## Relationships
 
@@ -105,7 +117,8 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   persistence), `ledger` (interfaces + domain types), `wallet`
   (`BoardingStore` interface + domain types).
 - **Depended on by**: `round`, `vtxo`, `oor`, `wallet` (storage
-  interfaces), `darepod` (wires DB backends).
+  interfaces), `credit` (CreditOperationStoreDB satisfies credit.Store),
+  `darepod` (wires DB backends).
 
 ## Invariants
 
@@ -147,6 +160,21 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   collapsing on `(round_id, event_type, debit_account, credit_account)`.
   Renumbered from 000019 to land after `000019_oor_session_registry`,
   which merged to main while this work was in review.
+- `000022_credit_operations` — adds the `credit_operations` table for
+  the durable credit subsystem. Columns: `operation_id` (TEXT PK),
+  `kind` (INTEGER, append-only `CreditOpKind`), `status` (INTEGER,
+  append-only `CreditOpStatus`), `idempotency_key` (TEXT, nullable),
+  `created_at` / `updated_at`. The table is the sole durable
+  control-plane record per credit operation; the per-operation actor
+  mailbox in `db/actordelivery` holds the durable message log.
+- `000021_vhtlc_recovery_job_generations` — rebuilds `vhtlc_recovery_jobs`
+  to widen the uniqueness key from `(swap_id, action)` to
+  `(swap_id, action, vtxo_txid, vtxo_vout)`, so a refreshed vHTLC (new
+  outpoint) arms a new recovery "generation" instead of colliding with the
+  prior job. SQLite cannot widen a UNIQUE constraint in place, so the table
+  is recreated, rows are copied, and the state / swap-action / unroll-target
+  indexes are rebuilt. The down migration collapses each `(swap_id, action)`
+  to its newest row before restoring the narrower constraint.
 - `000018_pending_intents` — generalizes the Board-only
   `pending_board_requests` outbox into a supertype/subtype set:
   `pending_intent_kinds` (enum table), `pending_intents` (header: 32-byte
@@ -156,14 +184,6 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   anchored outpoint, PK on the outpoint so a newer intent rebinds, FK to the
   header). Drops `pending_board_requests` outright (alpha; rows only exist
   in the narrow crash window between admission and round seal).
-- `000021_vhtlc_recovery_job_generations` — rebuilds `vhtlc_recovery_jobs`
-  to widen the uniqueness key from `(swap_id, action)` to
-  `(swap_id, action, vtxo_txid, vtxo_vout)`, so a refreshed vHTLC (new
-  outpoint) arms a new recovery "generation" instead of colliding with the
-  prior job. SQLite cannot widen a UNIQUE constraint in place, so the table
-  is recreated, rows are copied, and the state / swap-action / unroll-target
-  indexes are rebuilt. The down migration collapses each `(swap_id, action)`
-  to its newest row before restoring the narrower constraint.
 - `000017_spending_reservations` — adds `spending_reservations` table with
   `(outpoint_hash, outpoint_index)` PK, `owner_kind`, `owner_id`, and
   `created_at`. A row exists IFF the owning spend session was durably

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -71,7 +71,7 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   safety bounds enforced during `DeserializeTree`.
 - `resolveInputPackage` / `loadPackageBundleBySessionID` — two-stage
   OOR ancestry resolver (`oor_unroll_resolver.go`).
-- `LatestMigrationVersion = 21` — current schema version.
+- `LatestMigrationVersion = 22` — current schema version.
 - `PendingIntentPersistenceStore` — implements `wallet.PendingIntentStore`,
   the persistence half of the generic restart-safe intent outbox (header
   `pending_intents` + per-kind detail tables + `pending_intent_anchors`).
@@ -97,6 +97,18 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   `vtxo.SpendingReservationStore`.
 - `SpendingReservationStore` / `BatchedSpendingReservationStore` — Internal
   sqlc-backed query interfaces for the reservation table.
+- `CreditOperationStoreDB` — implements `credit.Store`. Bridges
+  credit-operation control-plane rows to sqlc queries. Every method
+  wraps the query in `ExecTx` so writes join an ambient actor tx
+  (via `actor.TxFromContext`) or open their own short tx. Methods:
+  `UpsertOperation`, `GetOperation`, `LookupActiveOperationByKey`,
+  `ListNonTerminal`, `ListOperations`.
+- `CreditOperationRecord` — Domain type for a single credit operation
+  row: `OperationID`, `Kind`, `Status`, `IdempotencyKey`,
+  `CreatedAt`, `UpdatedAt`.
+- `CreditOpKind` / `CreditOpStatus` — Append-only enumerations for
+  credit operation family (`Pay`, `Receive`, `Redeem`) and terminal
+  state (`Pending`, `Completed`, `Failed`).
 
 ## Relationships
 
@@ -105,7 +117,8 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   persistence), `ledger` (interfaces + domain types), `wallet`
   (`BoardingStore` interface + domain types).
 - **Depended on by**: `round`, `vtxo`, `oor`, `wallet` (storage
-  interfaces), `darepod` (wires DB backends).
+  interfaces), `credit` (CreditOperationStoreDB satisfies credit.Store),
+  `darepod` (wires DB backends).
 
 ## Invariants
 
@@ -147,6 +160,13 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/db.<S
   collapsing on `(round_id, event_type, debit_account, credit_account)`.
   Renumbered from 000019 to land after `000019_oor_session_registry`,
   which merged to main while this work was in review.
+- `000022_credit_operations` — adds the `credit_operations` table for
+  the durable credit subsystem. Columns: `operation_id` (TEXT PK),
+  `kind` (INTEGER, append-only `CreditOpKind`), `status` (INTEGER,
+  append-only `CreditOpStatus`), `idempotency_key` (TEXT, nullable),
+  `created_at` / `updated_at`. The table is the sole durable
+  control-plane record per credit operation; the per-operation actor
+  mailbox in `db/actordelivery` holds the durable message log.
 - `000021_vhtlc_recovery_job_generations` — rebuilds `vhtlc_recovery_jobs`
   to widen the uniqueness key from `(swap_id, action)` to
   `(swap_id, action, vtxo_txid, vtxo_vout)`, so a refreshed vHTLC (new

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,8 @@ into specific topics below.
 | [fee_ledger.md](fee_ledger.md) | Client-side double-entry fee ledger: chart of accounts, per-flow walkthroughs, emission sites, replay safety |
 | [fee-change-model.md](fee-change-model.md) | Seal-time fee handshake (#270): change-output designation rules, 11-scenario catalogue, proto contract, CLI mapping |
 | [credit_system.md](credit_system.md) | Sat-native credit accounts for below-dust receives, credit-assisted receives, credit-backed sends, top-ups, and walletdk integration, with mermaid diagrams |
+| [credit_durable_actor_design.md](credit_durable_actor_design.md) | Technical design of the durable credit subsystem: FSM states and transitions for pay/receive/redeem flows, durable schema, actor wiring, and crash-recovery path |
+| [walletdk_mobile.md](walletdk_mobile.md) | gomobile facade over `sdk/walletdk`: Android/iOS/WASM integration guide, JSON bytes-in/out convention, pull-based streaming, build tags, and passkey PRF-based wallet derivation |
 | [sdk_layered_architecture.md](sdk_layered_architecture.md) | SDK layering rationale: `sdk/ark` facade, remote vs. embedded modes, `sdk/swaps` future direction |
 | [swap_system.md](swap_system.md) | End-to-end swap walkthrough: vHTLC tree (collaborative vs. unilateral-exit leaves), receive (out-swap) and pay (in-swap) flows, the off-chain-first cancellation/timeout recovery ladder, same-Ark p2p detection, swap-server RPCs, and proof-gated indexer authorization, with mermaid diagrams |
 | [walletdk_integration.md](walletdk_integration.md) | Basic `walletdk` integration flow, startup/config examples, swap accounting, and wrapper guidance |

--- a/internal/sqlbase/AGENTS.md
+++ b/internal/sqlbase/AGENTS.md
@@ -1,0 +1,48 @@
+# internal/sqlbase
+
+## Purpose
+
+WebAssembly-only (`js && wasm` build tag) SQLite database adapter that
+implements `walletdb.DB` and related `walletdb` interfaces on top of a
+plain `database/sql` connection. Bridges the LND wallet's database
+abstraction to a `sql.DB` backend in environments where the full
+`bbolt`/`kvdb` stack is unavailable, enabling `lwwallet` to run in a
+WASM context with a SQLite KV store.
+
+## Key Types
+
+- `DB` — Implements `walletdb.DB`. Wraps a `*sql.DB` with retry
+  semantics (`DefaultNumTxRetries = 50`) and a per-transaction mutex
+  for the WASM single-threaded constraint.
+- `Config` — Connection parameters: DSN, max open/idle connections,
+  and busy timeout.
+- `SQLiteCmdReplacements` — Map of SQLite keyword substitutions applied
+  at schema creation time, used to normalize commands across minor
+  SQLite variants.
+- `ReadWriteBucket` / `ReadWriteCursor` / `ReadWriteTx` — Implement
+  the `walletdb` bucket, cursor, and transaction interfaces over the KV
+  table schema.
+
+## Relationships
+
+- **Depends on**: `btcwallet/walletdb`, `lnd/sqldb` (for retry
+  helpers), `database/sql`.
+- **Depended on by**:
+  - `lwwallet` (uses this adapter to open the LND wallet DB in WASM
+    builds)
+- **Sends**: nothing.
+- **Receives**: nothing.
+
+## Invariants
+
+- Only compiled under `//go:build js && wasm` — the package is
+  invisible to native builds.
+- The KV schema (`kv` table with `parent_id`, `key`, `value`) is
+  created at `Open` time; callers must not assume any pre-existing
+  schema.
+- `DefaultNumTxRetries = 50` with exponential backoff handles SQLite
+  busy/locked errors in WASM.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/internal/sqlbase/CLAUDE.md
+++ b/internal/sqlbase/CLAUDE.md
@@ -1,0 +1,48 @@
+# internal/sqlbase
+
+## Purpose
+
+WebAssembly-only (`js && wasm` build tag) SQLite database adapter that
+implements `walletdb.DB` and related `walletdb` interfaces on top of a
+plain `database/sql` connection. Bridges the LND wallet's database
+abstraction to a `sql.DB` backend in environments where the full
+`bbolt`/`kvdb` stack is unavailable, enabling `lwwallet` to run in a
+WASM context with a SQLite KV store.
+
+## Key Types
+
+- `DB` — Implements `walletdb.DB`. Wraps a `*sql.DB` with retry
+  semantics (`DefaultNumTxRetries = 50`) and a per-transaction mutex
+  for the WASM single-threaded constraint.
+- `Config` — Connection parameters: DSN, max open/idle connections,
+  and busy timeout.
+- `SQLiteCmdReplacements` — Map of SQLite keyword substitutions applied
+  at schema creation time, used to normalize commands across minor
+  SQLite variants.
+- `ReadWriteBucket` / `ReadWriteCursor` / `ReadWriteTx` — Implement
+  the `walletdb` bucket, cursor, and transaction interfaces over the KV
+  table schema.
+
+## Relationships
+
+- **Depends on**: `btcwallet/walletdb`, `lnd/sqldb` (for retry
+  helpers), `database/sql`.
+- **Depended on by**:
+  - `lwwallet` (uses this adapter to open the LND wallet DB in WASM
+    builds)
+- **Sends**: nothing.
+- **Receives**: nothing.
+
+## Invariants
+
+- Only compiled under `//go:build js && wasm` — the package is
+  invisible to native builds.
+- The KV schema (`kv` table with `parent_id`, `key`, `value`) is
+  created at `Open` time; callers must not assume any pre-existing
+  schema.
+- `DefaultNumTxRetries = 50` with exponential backoff handles SQLite
+  busy/locked errors in WASM.
+
+## Deep Docs
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/walletdk/AGENTS.md
+++ b/sdk/walletdk/AGENTS.md
@@ -49,8 +49,10 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   bounded send and the swept total for sweep-all), `DepositRequest`/`Result` (boarding
   address + initial `Entry`), `ListRequest`, `ListResult` (tagged union
   on `View`, populates one of `Activity`/`VTXOs`/`Onchain`),
-  `ActivityList`, `VTXOInventory`, `OnchainHistory`, `Entry`,
-  `WalletVTXO`, `OnchainTx`.
+  `ActivityList`, `VTXOInventory`, `OnchainHistory`, `Entry`
+  (optional `Progress *EntryProgress` and `Request *EntryRequest`
+  sub-objects, both nil when absent; `Request` is a `Type`-tagged
+  union over lightning/onchain/ark), `WalletVTXO`, `OnchainTx`.
 - `ExitRequest` / `ExitResult` / `ExitStatusRequest` /
   `ExitStatusResult` / `ExitJobStatus` — exit DTOs. `ExitRequest`
   carries the target outpoint plus an optional on-chain `Destination`
@@ -67,6 +69,15 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   populated by current behavior. Status strings are the wrapper-owned
   lowercase set
   (`pending`/`materializing`/`csv_pending`/`sweeping`/`completed`/`failed`/`unspecified`).
+- `OpenWalletFromPasskey(ctx, passkeyPRFOutput)` — derives a
+  reproducible wallet seed from a WebAuthn passkey PRF output via HKDF
+  and either imports it (fresh device) or unlocks an existing local
+  wallet. Returns `*OpenWalletResult` (`Imported bool`, `Mnemonic`,
+  `IdentityPubKey`). The PRF input salt must be fixed and identical
+  on every device; varying it yields a different seed and makes funds
+  unrecoverable.
+- `OpenWalletResult` — outcome of `OpenWalletFromPasskey`: `Imported`
+  is true on a fresh device (new wallet created), false on unlock.
 - `ErrWalletRPCUnavailable` — sentinel returned by every wallet method
   on builds without the `walletdkrpc` tag.
 - `ErrSwapRuntimeUnavailable` — back-compat alias for
@@ -79,6 +90,7 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
 | `GetInfo` | Daemon readiness snapshot (version, network, identity, wallet/server readiness). |
 | `CreateWallet` | Create or import the embedded wallet (auto-generates seed when mnemonic empty); proxies daemonrpc. |
 | `UnlockWallet` | Unlock an existing wallet; proxies daemonrpc. |
+| `OpenWalletFromPasskey` | Derive wallet from WebAuthn passkey PRF output; imports on fresh device, unlocks on existing. |
 | `Balance` | Flat balance (`confirmed_sat`, `pending_in_sat`, `pending_out_sat`). |
 | `Deposit` | Allocate a fresh boarding address (`recv --onchain` from CLI). |
 | `Receive` | Open a Lightning invoice receive (`recv --offchain`). Returns `{Invoice, Entry}`. |
@@ -102,8 +114,8 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   `swapclientserver` (registered as daemon-side swap subserver in
   `swapruntime` builds), `swapwallet` (daemon-side walletdkrpc subserver
   in `walletdkrpc` builds), `google.golang.org/grpc/test/bufconn`.
-- **Depended on by**: host Go apps, gomobile / React Native / WASM
-  bridges, and `cmd/walletdk-tui`.
+- **Depended on by**: host Go apps, `sdk/walletdk/mobile` (gomobile
+  facade), `cmd/walletdk-wasm` (WASM binary), and `cmd/walletdk-tui`.
 - **Sends** → `darepod` (in-process via bufconn): all daemon RPCs are
   routed across the private gRPC connection, not the daemon's public
   listener.
@@ -142,15 +154,21 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   the wrapper boundary on builds without the `walletdkrpc` tag, before
   any RPC is attempted. `ErrSwapRuntimeUnavailable` is an alias for
   source-level compatibility with older swap-only callers.
-- `Entry.Kind`/`Entry.Status` / `ListResult.View` /
-  `WalletVTXO.Status` / `OnchainTx.Kind` / `ExitJobStatus` are
-  wrapper-owned lowercase strings (not proto enums). Projection lives
-  in `convert.go`, intentionally decoupled from proto enum
-  renumbering.
+- `Entry.Kind`/`Entry.Status` / `Entry.Progress.Phase` /
+  `Entry.Request.Type` / `ListResult.View` / `WalletVTXO.Status` /
+  `OnchainTx.Kind` / `ExitJobStatus` are wrapper-owned lowercase
+  strings (not proto enums). Projection lives in `convert.go`,
+  intentionally decoupled from proto enum renumbering.
 - `ListResult` is a discriminated union: read the variant named by
   `View` and treat the others as `nil`. Exhaustiveness is not
   enforced at compile time — switch on `View` rather than chaining
   nil checks.
+- `Entry.Progress` and `Entry.Request` are optional pointers: both are
+  `nil` when the daemon supplied no progress hint / persisted no
+  request, so nil-check before dereferencing. `Entry.Request` is a
+  discriminated union — read the variant named by `Type`
+  (`lightning`/`onchain`/`ark`) and treat the other fields as zero,
+  the same idiom as `ListResult.View`.
 - `Wait()` is single-reader: same shared channel on every call. The
   channel delivers the daemon's terminal run error then closes; a
   closed channel reads as the zero error indefinitely.
@@ -159,6 +177,11 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   single terminal error.
 - New options should follow the "apply after merge" placement so
   override semantics stay consistent.
+- `OpenWalletFromPasskey` requires at least 32 bytes of PRF output;
+  shorter input is rejected to prevent a caller bug from deriving a
+  publicly-known seed. The PRF input salt (WebAuthn evaluation salt)
+  must be fixed per application — any variation yields a different
+  seed and makes the wallet irrecoverable.
 
 ## Deep Docs
 
@@ -168,6 +191,8 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
 - [docs/sdk_layered_architecture.md](../../docs/sdk_layered_architecture.md)
   — Layering rationale; walletdk sits one layer above `sdk/ark` for
   wallet-shaped hosts.
+- [sdk/walletdk/mobile/CLAUDE.md](mobile/CLAUDE.md) — gomobile/WASM
+  facade over this package.
 - [sdk/ark/CLAUDE.md](../ark/CLAUDE.md) — Lower-level Ark SDK facade.
 - [sdk/swaps/CLAUDE.md](../swaps/CLAUDE.md) — Swap FSM and durable
   session semantics. Reach the underlying swap RPC client via

--- a/sdk/walletdk/CLAUDE.md
+++ b/sdk/walletdk/CLAUDE.md
@@ -69,6 +69,15 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   populated by current behavior. Status strings are the wrapper-owned
   lowercase set
   (`pending`/`materializing`/`csv_pending`/`sweeping`/`completed`/`failed`/`unspecified`).
+- `OpenWalletFromPasskey(ctx, passkeyPRFOutput)` — derives a
+  reproducible wallet seed from a WebAuthn passkey PRF output via HKDF
+  and either imports it (fresh device) or unlocks an existing local
+  wallet. Returns `*OpenWalletResult` (`Imported bool`, `Mnemonic`,
+  `IdentityPubKey`). The PRF input salt must be fixed and identical
+  on every device; varying it yields a different seed and makes funds
+  unrecoverable.
+- `OpenWalletResult` — outcome of `OpenWalletFromPasskey`: `Imported`
+  is true on a fresh device (new wallet created), false on unlock.
 - `ErrWalletRPCUnavailable` — sentinel returned by every wallet method
   on builds without the `walletdkrpc` tag.
 - `ErrSwapRuntimeUnavailable` — back-compat alias for
@@ -81,6 +90,7 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
 | `GetInfo` | Daemon readiness snapshot (version, network, identity, wallet/server readiness). |
 | `CreateWallet` | Create or import the embedded wallet (auto-generates seed when mnemonic empty); proxies daemonrpc. |
 | `UnlockWallet` | Unlock an existing wallet; proxies daemonrpc. |
+| `OpenWalletFromPasskey` | Derive wallet from WebAuthn passkey PRF output; imports on fresh device, unlocks on existing. |
 | `Balance` | Flat balance (`confirmed_sat`, `pending_in_sat`, `pending_out_sat`). |
 | `Deposit` | Allocate a fresh boarding address (`recv --onchain` from CLI). |
 | `Receive` | Open a Lightning invoice receive (`recv --offchain`). Returns `{Invoice, Entry}`. |
@@ -104,8 +114,8 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   `swapclientserver` (registered as daemon-side swap subserver in
   `swapruntime` builds), `swapwallet` (daemon-side walletdkrpc subserver
   in `walletdkrpc` builds), `google.golang.org/grpc/test/bufconn`.
-- **Depended on by**: host Go apps, gomobile / React Native / WASM
-  bridges, and `cmd/walletdk-tui`.
+- **Depended on by**: host Go apps, `sdk/walletdk/mobile` (gomobile
+  facade), `cmd/walletdk-wasm` (WASM binary), and `cmd/walletdk-tui`.
 - **Sends** → `darepod` (in-process via bufconn): all daemon RPCs are
   routed across the private gRPC connection, not the daemon's public
   listener.
@@ -167,6 +177,11 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
   single terminal error.
 - New options should follow the "apply after merge" placement so
   override semantics stay consistent.
+- `OpenWalletFromPasskey` requires at least 32 bytes of PRF output;
+  shorter input is rejected to prevent a caller bug from deriving a
+  publicly-known seed. The PRF input salt (WebAuthn evaluation salt)
+  must be fixed per application — any variation yields a different
+  seed and makes the wallet irrecoverable.
 
 ## Deep Docs
 
@@ -176,6 +191,8 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/sdk/w
 - [docs/sdk_layered_architecture.md](../../docs/sdk_layered_architecture.md)
   — Layering rationale; walletdk sits one layer above `sdk/ark` for
   wallet-shaped hosts.
+- [sdk/walletdk/mobile/CLAUDE.md](mobile/CLAUDE.md) — gomobile/WASM
+  facade over this package.
 - [sdk/ark/CLAUDE.md](../ark/CLAUDE.md) — Lower-level Ark SDK facade.
 - [sdk/swaps/CLAUDE.md](../swaps/CLAUDE.md) — Swap FSM and durable
   session semantics. Reach the underlying swap RPC client via

--- a/sdk/walletdk/mobile/AGENTS.md
+++ b/sdk/walletdk/mobile/AGENTS.md
@@ -1,0 +1,59 @@
+# sdk/walletdk/mobile
+
+## Purpose
+
+gomobile-safe facade over `sdk/walletdk` for Android/iOS native
+bindings. Wraps the Go wallet SDK in a flat API that obeys gomobile's
+type restrictions (no `context.Context`, no channels, no maps, no
+slices except `[]byte`, no unsigned integers at the boundary). Uses a
+JSON bytes-in / bytes-out convention for RPC verbs and a pull-based
+`Subscription` handle for streaming, avoiding the callback-interface
+pattern used by lnd-mobile.
+
+Only compiles under the `mobile`, `walletdkrpc`, and `swapruntime`
+build tags — native `go build ./...` sees the empty `stub.go`.
+
+## Key Types
+
+- `Wallet` — Top-level gomobile-safe handle. `Start` is synchronous
+  (call off the main thread); returns once gRPC is serving. All verb
+  methods are synchronous and return `[]byte` (JSON-encoded response)
+  or a `string` error message.
+- `Subscription` — Pull-based streaming handle returned by
+  `Wallet.Subscribe`. `Next()` blocks until an update arrives (returns
+  `[]byte`); `Close()` tears down the stream.
+- `Config` — gomobile-safe config struct for `Start`. Wraps network,
+  server address, data dir, and other daemon options as plain-type
+  fields.
+- `PasskeyPRFOutput` — gomobile-safe passkey credential type that
+  wraps the raw PRF bytes for `Wallet.OpenWalletFromPasskey`.
+
+## Relationships
+
+- **Depends on**:
+  - `sdk/walletdk` (delegates all wallet operations)
+- **Depended on by**:
+  - `cmd/walletdk-wasm` (imports mobile for the WASM bridge; the
+    gomobile binding for native is built separately via `gomobile bind`)
+- **Sends** → `sdk/walletdk`: all wallet RPCs via the embedded daemon.
+- **Receives** ← platform (Android/iOS/WASM): method calls from the
+  host runtime via the generated gomobile or WASM binding layer.
+
+## Invariants
+
+- No `context.Context`, channel, map, or unsigned integer type may
+  appear in exported symbols — these types cannot cross the gomobile
+  boundary.
+- `Start` must be called on a background thread; it blocks until gRPC
+  is ready.
+- The JSON request/response convention is intentional: the host decodes
+  with kotlinx.serialization or Codable, so no protobuf runtime is
+  needed on the platform side.
+- Build tags (`mobile`, `walletdkrpc`, `swapruntime`) ensure this
+  package never contaminates the native build graph.
+
+## Deep Docs
+
+- [sdk/walletdk/CLAUDE.md](../CLAUDE.md) — The underlying Go SDK this
+  package wraps.
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/walletdk/mobile/CLAUDE.md
+++ b/sdk/walletdk/mobile/CLAUDE.md
@@ -1,0 +1,59 @@
+# sdk/walletdk/mobile
+
+## Purpose
+
+gomobile-safe facade over `sdk/walletdk` for Android/iOS native
+bindings. Wraps the Go wallet SDK in a flat API that obeys gomobile's
+type restrictions (no `context.Context`, no channels, no maps, no
+slices except `[]byte`, no unsigned integers at the boundary). Uses a
+JSON bytes-in / bytes-out convention for RPC verbs and a pull-based
+`Subscription` handle for streaming, avoiding the callback-interface
+pattern used by lnd-mobile.
+
+Only compiles under the `mobile`, `walletdkrpc`, and `swapruntime`
+build tags — native `go build ./...` sees the empty `stub.go`.
+
+## Key Types
+
+- `Wallet` — Top-level gomobile-safe handle. `Start` is synchronous
+  (call off the main thread); returns once gRPC is serving. All verb
+  methods are synchronous and return `[]byte` (JSON-encoded response)
+  or a `string` error message.
+- `Subscription` — Pull-based streaming handle returned by
+  `Wallet.Subscribe`. `Next()` blocks until an update arrives (returns
+  `[]byte`); `Close()` tears down the stream.
+- `Config` — gomobile-safe config struct for `Start`. Wraps network,
+  server address, data dir, and other daemon options as plain-type
+  fields.
+- `PasskeyPRFOutput` — gomobile-safe passkey credential type that
+  wraps the raw PRF bytes for `Wallet.OpenWalletFromPasskey`.
+
+## Relationships
+
+- **Depends on**:
+  - `sdk/walletdk` (delegates all wallet operations)
+- **Depended on by**:
+  - `cmd/walletdk-wasm` (imports mobile for the WASM bridge; the
+    gomobile binding for native is built separately via `gomobile bind`)
+- **Sends** → `sdk/walletdk`: all wallet RPCs via the embedded daemon.
+- **Receives** ← platform (Android/iOS/WASM): method calls from the
+  host runtime via the generated gomobile or WASM binding layer.
+
+## Invariants
+
+- No `context.Context`, channel, map, or unsigned integer type may
+  appear in exported symbols — these types cannot cross the gomobile
+  boundary.
+- `Start` must be called on a background thread; it blocks until gRPC
+  is ready.
+- The JSON request/response convention is intentional: the host decodes
+  with kotlinx.serialization or Codable, so no protobuf runtime is
+  needed on the platform side.
+- Build tags (`mobile`, `walletdkrpc`, `swapruntime`) ensure this
+  package never contaminates the native build graph.
+
+## Deep Docs
+
+- [sdk/walletdk/CLAUDE.md](../CLAUDE.md) — The underlying Go SDK this
+  package wraps.
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -10,6 +10,7 @@ background ingress polling with event routing.
 
 - `Runtime` — Main entry point wrapping DurableActor, ServerConnectionActor, and UnaryFacade. The egress DurableActor runs on the Read/Commit (`TxBehavior`) path: each handler builds its envelope and calls `Edge.Send` with NO SQLite writer held, then a short lease-fenced Commit folds the ack + dedup. It runs as a competing-consumer pool of `ConnectorConfig.EgressWorkers` worker loops, so the round and out-of-round actors' sends proceed concurrently; the single ingress puller is separate and unaffected.
 - `ServerConnectionActor` — Core behavior handling egress messages and the ingress loop. Dispatches `DurableUnaryQuery` values generically via `buildDurableUnary`.
+- `ArkVersionNegotiator` — Single home for Ark protocol version selection (`ark_version.go`). `Bootstrap` performs the one bootstrap `GetInfo` over the operator's **direct** ArkService connection (`ArkVersionGetInfoClient`, never the mailbox edge) and returns the response + selected version; the daemon parses domain terms from the same response. The free function `ValidateRefreshSelection(resp, boundVersion)` enforces that a refresh-only `GetInfo` keeps the runtime bound (returns a permanent `*StatusError` on drift/disable). Enabled versions are derived from the response's ACTIVE `ArkVersionPolicy` entries.
 - `UnaryFacade` — Implements `mailboxrpc.RPCClient` for generated RPC stubs (low-latency path). Also provides `AwaitRPCTimeout` for bounded waits.
 - `ConnectorConfig` — Wiring configuration (edge address, mailbox IDs, dispatchers, store, durable unary builder, `EgressWorkers`). `EgressWorkers` sizes the egress worker pool (default `DefaultEgressWorkers` = 4); `<= 1` keeps the legacy single sender. The `DurableUnaryBuilder` field must be set to handle `DurableUnaryQuery` message types; otherwise those messages are rejected. The `AuthSignature` field holds the Schnorr auth sig injected into every outbound envelope via `mergeAuthHeaders` (auth header always wins over caller-provided headers).
 - `PubKeyMailboxID` — Derives canonical mailbox ID from a public key (hex-encoded compressed SEC). Panics on nil.
@@ -34,7 +35,7 @@ background ingress polling with event routing.
 
 ## Relationships
 
-- **Depends on**: `baselib/actor` (DurableActor infrastructure), `mailbox/*` (Envelope, RpcMeta, MailboxServiceClient).
+- **Depends on**: `baselib/actor` (DurableActor infrastructure), `mailbox/*` (Envelope, RpcMeta, MailboxServiceClient), `arkrpc` (`GetInfo` request/response + `ArkVersionPolicy` for version negotiation).
 - **Depended on by**: `round` (outbound RPCs), `oor` (durable transport), `darepod` (wiring).
 - **Sends (egress → remote mailbox)**:
   - `SendClientEventRequest` (durable): wraps `JoinRoundRequest`, `JoinRoundAccept`, `JoinRoundReject`, `SubmitNoncesRequest`, `SubmitPartialSigRequest`, `SubmitForfeitSigRequest`. `JoinRoundAccept` / `JoinRoundReject` are the explicit responses to a server-issued seal-time `JoinRoundQuote` (#270); both echo the `quote_id` so the server can drop stale responses after a reseal.

--- a/swapclientserver/AGENTS.md
+++ b/swapclientserver/AGENTS.md
@@ -38,6 +38,11 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
   `SwapClient` so out-swap HTLC events flow over the mailbox transport,
   registers the gRPC subserver, calls `resumePending`, and returns a cleanup
   function.
+- `creditServerBridge` — Adapts the swap subserver to the `credit.CreditServer`
+  interface so the credit actor reuses the existing swapclientrpc handlers
+  (CreateCredit, ListCredits, RedeemCredit, QuoteCredit) without importing
+  gRPC stubs into the credit package. Returned by `Register` and injected
+  into the credit `Registry`.
 
 ## RPC Methods
 
@@ -55,7 +60,8 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - **Depends on**: `sdk/swaps` (swap FSM, `SwapClient`, `Store`, session
   types), `sdk/ark` (`WrapDaemonServer`, in-process Ark facade), `darepod`
   (`RPCServer`, `Config`, `SwapConfig`, `SwapSubsystem`), `rpc/swapclientrpc`
-  (generated gRPC stubs + proto types).
+  (generated gRPC stubs + proto types), `credit` (CreditServer interface
+  satisfied by creditServerBridge).
 - **Depended on by**: `cmd/darepod` (calls `swapclientserver.Register` when
   built with the `swapruntime` tag), `cmd/darepocli/darepoclicommands`
   (swap RPC CLI commands under `swapruntime`).

--- a/swapclientserver/CLAUDE.md
+++ b/swapclientserver/CLAUDE.md
@@ -38,6 +38,11 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
   `SwapClient` so out-swap HTLC events flow over the mailbox transport,
   registers the gRPC subserver, calls `resumePending`, and returns a cleanup
   function.
+- `creditServerBridge` — Adapts the swap subserver to the `credit.CreditServer`
+  interface so the credit actor reuses the existing swapclientrpc handlers
+  (CreateCredit, ListCredits, RedeemCredit, QuoteCredit) without importing
+  gRPC stubs into the credit package. Returned by `Register` and injected
+  into the credit `Registry`.
 
 ## RPC Methods
 
@@ -55,7 +60,8 @@ protocol behavior remain entirely inside `sdk/swaps` and `swapdk-server`.
 - **Depends on**: `sdk/swaps` (swap FSM, `SwapClient`, `Store`, session
   types), `sdk/ark` (`WrapDaemonServer`, in-process Ark facade), `darepod`
   (`RPCServer`, `Config`, `SwapConfig`, `SwapSubsystem`), `rpc/swapclientrpc`
-  (generated gRPC stubs + proto types).
+  (generated gRPC stubs + proto types), `credit` (CreditServer interface
+  satisfied by creditServerBridge).
 - **Depended on by**: `cmd/darepod` (calls `swapclientserver.Register` when
   built with the `swapruntime` tag), `cmd/darepocli/darepoclicommands`
   (swap RPC CLI commands under `swapruntime`).

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -10,7 +10,10 @@ the seven wallet verbs (Create, Unlock, Send, Recv, List, Balance,
 Exit) plus the supporting Deposit / Status / SubscribeWallet methods.
 
 The whole package lives behind `//go:build walletdkrpc && swapruntime` so
-default builds avoid the swap executor's dependency graph.
+default builds avoid the swap executor's dependency graph. Sub-dust and
+shortfall payments are routed through the credit subsystem (`credit.Registry`)
+instead of failing; received credits are tracked and projected onto wallet rows
+by the `Runtime` credit projector.
 
 ## Key Types
 
@@ -24,10 +27,13 @@ default builds avoid the swap executor's dependency graph.
   never cancel in-flight work.
 - `Deps` — Composition struct: `SwapBackend` (in-Go swap runtime),
   `SwapService` (gRPC-shaped swap subserver handle), `RPCServer`
-  (narrow daemonrpc contract), `ChainParams` (Bitcoin network — used to
-  validate BOLT-11 invoice decoding in `PrepareSend` so a cross-network
-  invoice is rejected before a send intent is issued), plus wallet-level
-  deadline, list-limit, and subscribe-buffer knobs.
+  (narrow daemonrpc contract), `CreditRegistry`
+  (`actor.ActorRef[credit.CreditMsg, credit.CreditResp]` — credit
+  supervisor reference injected at daemon startup), `ChainParams`
+  (Bitcoin network — used to validate BOLT-11 invoice decoding in
+  `PrepareSend` so a cross-network invoice is rejected before a send
+  intent is issued), plus wallet-level deadline, list-limit, and
+  subscribe-buffer knobs.
 - `RPCServer` interface — Narrow contract over `*darepod.RPCServer`
   covering every daemonrpc method swapwallet composes against:
   LeaveVTXOs, SendOnChain, ListVTXOs, ListTransactions, NewAddress, GetInfo,
@@ -54,6 +60,10 @@ default builds avoid the swap executor's dependency graph.
     StartPay, StartReceive)
   - `swapclientserver` (typed `Backend` handle and runtime resume)
   - `darepod` (`SwapBackend` interface)
+  - `credit` (CreditMsg/CreditResp types for the CreditRegistry ref;
+    StartCreditPayRequest, StartCreditReceiveRequest, ConsiderRedeemRequest,
+    ListCreditOpsRequest for credit routing)
+  - `coinselect` (LargestFirst for VTXO selection in the send path)
   - `ledger` (account name constants for OOR ledger projection)
   - `btclog/v2` (subsystem logger)
 - **Depended on by**:

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -10,7 +10,10 @@ the seven wallet verbs (Create, Unlock, Send, Recv, List, Balance,
 Exit) plus the supporting Deposit / Status / SubscribeWallet methods.
 
 The whole package lives behind `//go:build walletdkrpc && swapruntime` so
-default builds avoid the swap executor's dependency graph.
+default builds avoid the swap executor's dependency graph. Sub-dust and
+shortfall payments are routed through the credit subsystem (`credit.Registry`)
+instead of failing; received credits are tracked and projected onto wallet rows
+by the `Runtime` credit projector.
 
 ## Key Types
 
@@ -24,10 +27,13 @@ default builds avoid the swap executor's dependency graph.
   never cancel in-flight work.
 - `Deps` — Composition struct: `SwapBackend` (in-Go swap runtime),
   `SwapService` (gRPC-shaped swap subserver handle), `RPCServer`
-  (narrow daemonrpc contract), `ChainParams` (Bitcoin network — used to
-  validate BOLT-11 invoice decoding in `PrepareSend` so a cross-network
-  invoice is rejected before a send intent is issued), plus wallet-level
-  deadline, list-limit, and subscribe-buffer knobs.
+  (narrow daemonrpc contract), `CreditRegistry`
+  (`actor.ActorRef[credit.CreditMsg, credit.CreditResp]` — credit
+  supervisor reference injected at daemon startup), `ChainParams`
+  (Bitcoin network — used to validate BOLT-11 invoice decoding in
+  `PrepareSend` so a cross-network invoice is rejected before a send
+  intent is issued), plus wallet-level deadline, list-limit, and
+  subscribe-buffer knobs.
 - `RPCServer` interface — Narrow contract over `*darepod.RPCServer`
   covering every daemonrpc method swapwallet composes against:
   LeaveVTXOs, SendOnChain, ListVTXOs, ListTransactions, NewAddress, GetInfo,
@@ -54,6 +60,10 @@ default builds avoid the swap executor's dependency graph.
     StartPay, StartReceive)
   - `swapclientserver` (typed `Backend` handle and runtime resume)
   - `darepod` (`SwapBackend` interface)
+  - `credit` (CreditMsg/CreditResp types for the CreditRegistry ref;
+    StartCreditPayRequest, StartCreditReceiveRequest, ConsiderRedeemRequest,
+    ListCreditOpsRequest for credit routing)
+  - `coinselect` (LargestFirst for VTXO selection in the send path)
   - `ledger` (account name constants for OOR ledger projection)
   - `btclog/v2` (subsystem logger)
 - **Depended on by**:


### PR DESCRIPTION
Automated nightly documentation graph sweep for 2026-06-30.

## What changed

**New CLAUDE.md/AGENTS.md** (6 packages previously undocumented):
- `credit` — durable protofsm-backed credit subsystem (supervisor + per-op actors)
- `coinselect` — coin-type-agnostic LargestFirst selection algorithm
- `chainfees` — reusable `chainfee.Estimator` implementations and MinEstimator combinator
- `internal/sqlbase` — js/wasm SQLite `walletdb.DB` adapter for lwwallet
- `sdk/walletdk/mobile` — gomobile-safe facade over sdk/walletdk
- `cmd/walletdk-wasm` — WASM entry point for the embedded wallet daemon

**Updated CLAUDE.md/AGENTS.md** (5 packages with notable Go changes):
- `db` — added `CreditOperationStoreDB`, migration `000022_credit_operations`
- `swapwallet` — credit routing, `CreditRegistry` in `Deps`, `coinselect` dependency
- `swapclientserver` — `creditServerBridge` implementing `credit.CreditServer`
- `sdk/walletdk` — `OpenWalletFromPasskey`, mobile/WASM facade dependency
- `serverconn` — AGENTS.md synced to match existing CLAUDE.md

**ARCHITECTURE.md** — layer table rows added for all new packages.

**docs/index.md** — entries added for `credit_durable_actor_design.md` and `walletdk_mobile.md`.

## Review checklist

- [ ] Verify `credit/CLAUDE.md` accurately reflects the protofsm FSM states and Registry wiring
- [ ] Verify `db/CLAUDE.md` migration 22 description matches the actual schema migration
- [ ] Verify `swapwallet/CLAUDE.md` Deps and Relationships reflect current credit routing
- [ ] Verify ARCHITECTURE.md layer placements are correct for new packages
- [ ] Verify `docs/index.md` new entries have accurate descriptions
