### PR TITLE
harness: wait for parseable lnd TLS certs

### DIFF
--- a/harness/harness.go
+++ b/harness/harness.go
@@ -2201,8 +2201,7 @@ func (h *Harness) startLNDInstance(name, dataDir string) *LndInstance {
 
 	require.Eventually(
 		h.T, func() bool {
-			_, err := os.Stat(inst.TLSCert)
-			if err != nil {
+			if !lndTLSReady(inst.TLSCert) {
 				return false
 			}
 
@@ -2247,12 +2246,14 @@ func (h *Harness) initAndWaitLNDInstance(
 	}
 
 	addr := net.JoinHostPort("127.0.0.1", inst.GRPCPort)
-	tlsCert, err := credentials.NewClientTLSFromFile(inst.TLSCert, "")
-	require.NoError(h.T, err, "failed to load %s TLS", inst.Name)
-
 	h.Logf("Waiting for %s to reach SERVER_ACTIVE state...", inst.Name)
 	require.Eventually(h.T, func() bool {
 		const checkTimeout = 5 * time.Second
+
+		tlsCert, err := loadClientTLSCredentials(inst.TLSCert)
+		if err != nil {
+			return false
+		}
 
 		ctxt, cancel := context.WithTimeout(
 			context.Background(), checkTimeout,
@@ -2280,7 +2281,7 @@ func (h *Harness) initAndWaitLNDInstance(
 		fmt.Sprintf("%s not active", inst.Name),
 	)
 
-	err = h.pool.Retry(func() error {
+	err := h.pool.Retry(func() error {
 		if _, err := os.Stat(inst.Macaroon); err != nil {
 			return err
 		}
@@ -2303,6 +2304,22 @@ func (h *Harness) initAndWaitLNDInstance(
 	h.waitForLNDChainSyncInstance(inst)
 
 	return services
+}
+
+// lndTLSReady reports whether the TLS certificate at the given path can be
+// parsed into client transport credentials.
+func lndTLSReady(tlsPath string) bool {
+	_, err := loadClientTLSCredentials(tlsPath)
+
+	return err == nil
+}
+
+// loadClientTLSCredentials loads gRPC client credentials from a TLS
+// certificate file.
+func loadClientTLSCredentials(tlsPath string) (credentials.TransportCredentials,
+	error) {
+
+	return credentials.NewClientTLSFromFile(tlsPath, "")
 }
 
 // StartAdditionalLND launches an extra LND instance with the given name and

--- a/harness/tapd_harness.go
+++ b/harness/tapd_harness.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 // TapdHarness represents a paired LND and tapd instance for test clients.
@@ -347,8 +346,7 @@ func (th *TapdHarness) setupLNDPaths() {
 
 	// Wait for TLS cert to be available.
 	require.Eventually(th.h.T, func() bool {
-		_, err := os.Stat(th.LNDTLSCert)
-		if err != nil {
+		if !lndTLSReady(th.LNDTLSCert) {
 			return false
 		}
 
@@ -386,13 +384,16 @@ func (th *TapdHarness) setupTapdPaths() {
 // initAndWaitLND initializes the LND wallet and waits until it's active.
 func (th *TapdHarness) initAndWaitLND() {
 	addr := net.JoinHostPort("127.0.0.1", th.LNDGRPCPort)
-	tlsCert, err := credentials.NewClientTLSFromFile(th.LNDTLSCert, "")
-	require.NoError(th.h.T, err, "failed to load "+th.Name+" lnd TLS")
-
 	// Wait for LND's state service to report SERVER_ACTIVE.
 	th.h.Logf("Waiting for %s LND to reach SERVER_ACTIVE state...", th.Name)
 	require.Eventually(th.h.T, func() bool {
 		const checkTimeout = 5 * time.Second
+
+		tlsCert, err := loadClientTLSCredentials(th.LNDTLSCert)
+		if err != nil {
+			return false
+		}
+
 		ctx, cancel := context.WithTimeout(
 			context.Background(), checkTimeout,
 		)
@@ -418,7 +419,7 @@ func (th *TapdHarness) initAndWaitLND() {
 	}, defaultTimeout, time.Second, th.Name+" LND not active")
 
 	// Wait for macaroon file.
-	err = th.h.pool.Retry(func() error {
+	err := th.h.pool.Retry(func() error {
 		if _, err := os.Stat(th.LNDMacaroon); err != nil {
 			return err
 		}

--- a/harness/tls_ready_test.go
+++ b/harness/tls_ready_test.go
@@ -1,0 +1,68 @@
+package harness
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLndTLSReady verifies partial certificate files are not treated as ready.
+func TestLndTLSReady(t *testing.T) {
+	t.Parallel()
+
+	certPath := filepath.Join(t.TempDir(), "tls.cert")
+
+	require.NoError(
+		t,
+		os.WriteFile(
+			certPath, []byte("-----BEGIN CERTIFICATE-----\n"),
+			0o600,
+		),
+	)
+	require.False(t, lndTLSReady(certPath))
+
+	require.NoError(
+		t,
+		os.WriteFile(
+			certPath, testCertificatePEM(t), 0o600,
+		),
+	)
+	require.True(t, lndTLSReady(certPath))
+}
+
+// testCertificatePEM returns a valid self-signed certificate in PEM form.
+func testCertificatePEM(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(time.Hour),
+	}
+
+	der, err := x509.CreateCertificate(
+		rand.Reader, template, template, &key.PublicKey, key,
+	)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: der,
+	})
+}


### PR DESCRIPTION
## Summary

This fixes a startup race in the integration-test LND harness.

The harness used to wait for `tls.cert` to exist, then later loaded that cert exactly once while waiting for LND to become `SERVER_ACTIVE`. In CI, an extra LND instance can briefly expose an empty or partially written cert file. If the one-shot load lands in that window, gRPC fails with `credentials: failed to append certificates` and the test aborts even though LND is still starting normally.

This PR changes LND TLS readiness to mean that the certificate can be parsed into gRPC client credentials. It also reloads the TLS credentials inside the existing `SERVER_ACTIVE` polling loop, so transient cert-write races remain inside the normal startup timeout.

The same readiness rule is applied to the tapd harness LND path because it had the same file-exists check and one-shot TLS load pattern.

## Tests

- `go test ./harness -run TestLndTLSReady -count=1`
- `go test ./harness -count=1`
- `make lint-changed-local base=origin/main`
- `make commitmsg-lint range=origin/main..HEAD`
- `git diff --check`

Related to lightninglabs/swapdk-server#136.
