### PR TITLE
swapwallet: Sign credit-only sends as outflows

### DIFF
--- a/swapwallet/credit_projector.go
+++ b/swapwallet/credit_projector.go
@@ -191,12 +191,23 @@ func creditEntryFromSummary(op credit.CreditOpSummary) (
 		return nil, false
 	}
 
+	// A SEND is an outflow, so it carries a negative amount to match the
+	// sign convention of every other outgoing row (normal swap sends are
+	// normalized to negative by swapEntryFromSummary). Credit-only sends
+	// reach the feed only through this projector, so without the flip a
+	// sub-dust pay renders as positive and looks like an incoming transfer
+	// (issue #829).
+	amountSat := op.AmountSat
+	if kind == walletdkrpc.EntryKind_ENTRY_KIND_SEND {
+		amountSat = -op.AmountSat
+	}
+
 	now := nowUnix()
 	entry := &walletdkrpc.WalletEntry{
 		Id:            id,
 		Kind:          kind,
 		Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
-		AmountSat:     op.AmountSat,
+		AmountSat:     amountSat,
 		Counterparty:  creditCounterparty,
 		UpdatedAtUnix: now,
 		Progress: &walletdkrpc.WalletEntryProgress{

--- a/swapwallet/credit_projector_test.go
+++ b/swapwallet/credit_projector_test.go
@@ -107,7 +107,7 @@ func TestCreditProjectorProjectsOwnedTerminals(t *testing.T) {
 		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
 		pay.GetStatus(),
 	)
-	require.Equal(t, int64(500), pay.GetAmountSat())
+	require.Equal(t, int64(-500), pay.GetAmountSat())
 	require.Equal(
 		t, walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_CONFIRMED,
 		pay.GetProgress().GetPhase(),

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -332,10 +332,14 @@ func creditPayEntry(intent *preparedSendIntent,
 	paymentHashHex := hex.EncodeToString(paymentHash[:])
 
 	return &walletdkrpc.WalletEntry{
-		Id:            paymentHashHex,
-		Kind:          walletdkrpc.EntryKind_ENTRY_KIND_SEND,
-		Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
-		AmountSat:     int64(intent.amountSat),
+		Id:     paymentHashHex,
+		Kind:   walletdkrpc.EntryKind_ENTRY_KIND_SEND,
+		Status: walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+
+		// A SEND is an outflow, so the pending credit-pay row carries a
+		// negative amount to match every other outgoing row; otherwise
+		// a sub-dust send renders as an incoming transfer (issue #829).
+		AmountSat:     -int64(intent.amountSat),
 		Counterparty:  "credit",
 		CreatedAtUnix: now,
 		UpdatedAtUnix: now,

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -470,6 +470,10 @@ func TestRouterSendInvoiceHandsCreditPayToRegistry(t *testing.T) {
 		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
 		resp.GetEntry().GetStatus(),
 	)
+
+	// A SEND is an outflow, so the pending row carries a negative amount
+	// (issue #829).
+	require.Equal(t, int64(-500), resp.GetEntry().GetAmountSat())
 }
 
 // TestRouterSendOnchainSelectsVTXOsAndCallsLeave confirms that an onchain


### PR DESCRIPTION
## What changed

Credit-only Lightning sends (the sub-dust pay path that cannot be
represented as a normal vHTLC-backed swap) reached the wallet activity
feed with a **positive** amount, so they rendered as *incoming*
transfers. This signs them as outflows, matching every other outgoing
row.

Both places that build a credit SEND row copied the operation amount
verbatim, unlike normal swap sends which `swapEntryFromSummary` already
normalizes to a negative amount:

- `router.go` `creditPayEntry` — the pending row now carries `-amountSat`;
- `credit_projector.go` `creditEntryFromSummary` — the projected row negates `AmountSat` for `SEND`.

Fixes #829.

## Scope note

This PR was originally larger. Since it was opened, the #774 canonical
activity-log epic landed on `main`:

- **#840** routes the credit projector and credit-pay pending emit through `projectAndEmit`, so credit rows now persist in the canonical activity store.
- **#842** cut `ListActivity` over to read from that store.

That already fixes the *disappearing-row* half of #829 (a settled credit
send returning `NOT_FOUND` on `activity inspect`): the store is now the
durable source, so the earlier read-time `collectCreditEntries` backfill
is no longer needed and has been dropped. The credit-op timestamp
plumbing has likewise been dropped as out of scope for #829. What remains
is the sign fix — the one part of the original bug still unaddressed on
`main`.

## Validation

- `go test -tags 'walletdkrpc swapruntime' ./swapwallet ./credit`
- `make fmt-changed`
- `make lint-changed-local`