### PR TITLE
txconfirm: CPFP fee-bump a funded-anchor parent + BumpNow override

### DIFF
--- a/lib/tx/arktx/canonical.go
+++ b/lib/tx/arktx/canonical.go
@@ -30,6 +30,36 @@ func IsAnchorOutput(out *wire.TxOut) bool {
 	return bytes.Equal(out.PkScript, arkscript.AnchorPkScript)
 }
 
+// IsP2AAnchorScript returns true if pkScript is the keyless P2A anchor
+// script, regardless of the spending output's value. Unlike IsAnchorOutput,
+// this does not require the zero-value ephemeral-dust form: it also matches a
+// "funded" anchor whose value has been lifted above the P2A dust threshold
+// (see arkscript.WithAnchorValue) so that its parent transaction can pay a
+// non-zero miner fee and confirm on its own. Use this when locating a CPFP
+// anchor to spend on a parent that is already independently valid, where the
+// anchor is a spare fee-bump handle rather than the parent's only fee source.
+func IsP2AAnchorScript(pkScript []byte) bool {
+	return bytes.Equal(pkScript, arkscript.AnchorPkScript)
+}
+
+// IsFundedAnchorOutput returns true if out is a P2A anchor output carrying a
+// non-zero value (the "funded" anchor form). A funded anchor lets its parent
+// pay its own fee and confirm standalone, with the anchor reserved as an
+// optional CPFP handle for fee-bumping only when the parent is stuck. This is
+// the complement of IsAnchorOutput, which matches only the zero-value
+// ephemeral form used by TRUC parents that pay zero fee themselves.
+func IsFundedAnchorOutput(out *wire.TxOut) bool {
+	if out == nil {
+		return false
+	}
+
+	if out.Value == 0 {
+		return false
+	}
+
+	return bytes.Equal(out.PkScript, arkscript.AnchorPkScript)
+}
+
 // ValidateCanonicalTx validates canonical ordering rules for an Ark tx
 // (as a raw transaction), including that it contains exactly one anchor output
 // and that the anchor output is the last output.

--- a/lib/tx/arktx/canonical_test.go
+++ b/lib/tx/arktx/canonical_test.go
@@ -49,3 +49,34 @@ func TestCanonicalizeOrderingSortsAndValidates(t *testing.T) {
 
 	require.True(t, IsAnchorOutput(tx.TxOut[len(tx.TxOut)-1]))
 }
+
+// TestAnchorPredicates asserts the relationship between the zero-value
+// ephemeral anchor predicate (IsAnchorOutput), the funded anchor predicate
+// (IsFundedAnchorOutput), and the value-agnostic script matcher
+// (IsP2AAnchorScript). A funded anchor must be recognised as a P2A anchor by
+// script while being excluded from the strict zero-value ephemeral form.
+func TestAnchorPredicates(t *testing.T) {
+	t.Parallel()
+
+	ephemeral := arkscript.AnchorOutput()
+	funded := arkscript.AnchorOutput(arkscript.WithAnchorValue(330))
+	nonAnchor := &wire.TxOut{Value: 330, PkScript: []byte{0x51, 0x20}}
+
+	// The script matcher accepts both anchor forms and rejects everything
+	// else, since it ignores value entirely.
+	require.True(t, IsP2AAnchorScript(ephemeral.PkScript))
+	require.True(t, IsP2AAnchorScript(funded.PkScript))
+	require.False(t, IsP2AAnchorScript(nonAnchor.PkScript))
+
+	// The strict ephemeral predicate accepts only the zero-value form.
+	require.True(t, IsAnchorOutput(ephemeral))
+	require.False(t, IsAnchorOutput(funded))
+	require.False(t, IsAnchorOutput(nonAnchor))
+
+	// The funded predicate is the exact complement over P2A outputs: it
+	// accepts the non-zero anchor and rejects the ephemeral one.
+	require.False(t, IsFundedAnchorOutput(ephemeral))
+	require.True(t, IsFundedAnchorOutput(funded))
+	require.False(t, IsFundedAnchorOutput(nonAnchor))
+	require.False(t, IsFundedAnchorOutput(nil))
+}

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -890,6 +890,21 @@ func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
 
 	bumpedState, _ := entry.currentTxState()
 
+	// A submission that produced no CPFP child did not actually bump
+	// anything: the ephemeral path's hail-mary fallback re-broadcasts the
+	// parent directly when child setup fails, and reporting that as a
+	// successful bump would hide the failure from the operator. Report the
+	// honest no-op instead; the tracked tx remains live either way.
+	if result.ChildTxid == nil {
+		return &BumpNowResp{
+			Txid:   req.Txid,
+			State:  bumpedState,
+			Bumped: false,
+			Reason: "cpfp child unavailable; parent re-broadcast " +
+				"directly without a fee bump",
+		}, nil
+	}
+
 	// Surface the rate the package actually targets so a silently clamped
 	// operator request is visible: Clamped is true when the supplied target
 	// exceeded the broadcaster's ceiling and was reduced.

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -212,6 +212,13 @@ type trackedTx struct {
 	// round trips for entries whose watch was never registered (e.g.
 	// entries that failed during block-subscription setup).
 	confWatchRegistered bool
+
+	// pendingTargetFeeRate carries a one-shot operator-supplied fee rate
+	// (sat/vB) for the next fee bump, set by a BumpNowReq. It overrides the
+	// estimator for exactly one bump and is cleared once consumed, so
+	// subsequent interval-paced bumps fall back to the estimator. Zero
+	// means "no override pending".
+	pendingTargetFeeRate int64
 }
 
 // confirmationObservedMsg routes a chainsource confirmation callback back into
@@ -325,6 +332,14 @@ func (a *TxBroadcasterActor) Receive(ctx context.Context,
 
 	case *CancelInterestReq:
 		resp, err := a.handleCancel(ctx, req)
+		if err != nil {
+			return fn.Err[Resp](err)
+		}
+
+		return fn.Ok[Resp](resp)
+
+	case *BumpNowReq:
+		resp, err := a.handleBumpNow(ctx, req)
 		if err != nil {
 			return fn.Err[Resp](err)
 		}
@@ -491,7 +506,7 @@ func (a *TxBroadcasterActor) handleEnsure(ctx context.Context,
 		return a.ensureResp(entry, true), nil
 	}
 
-	err = a.broadcastTrackedTx(ctx, entry, TxStateBroadcasting)
+	_, err = a.broadcastTrackedTx(ctx, entry, TxStateBroadcasting)
 	a.recordInitialBroadcastOutcome(ctx, entry, err)
 
 	return a.ensureResp(entry, true), nil
@@ -716,6 +731,115 @@ func (a *TxBroadcasterActor) handleCancel(ctx context.Context,
 	return resp, nil
 }
 
+// handleBumpNow forces an immediate CPFP fee bump of an already-tracked
+// transaction at an operator-supplied target rate, rather than waiting for the
+// next interval-paced bump. It is a no-op (reported via Bumped=false) when the
+// txid is not tracked, has already reached a terminal state, has not yet
+// reached a mempool (still broadcasting, so there is nothing to bump), or
+// carries no anchor to attach a child to. Otherwise it stamps the one-shot
+// target rate onto the entry and runs one fee-bump pass, returning the
+// submitted child's txid.
+func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
+	req *BumpNowReq) (*BumpNowResp, error) {
+
+	if req == nil {
+		return nil, fmt.Errorf("bump request required")
+	}
+
+	entry, ok := a.tracked[req.Txid]
+	if !ok {
+		return &BumpNowResp{
+			Txid:   req.Txid,
+			Bumped: false,
+			Reason: "transaction not tracked",
+		}, nil
+	}
+
+	state, err := entry.currentTxState()
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case state == TxStateConfirmed:
+		return &BumpNowResp{
+			Txid:   req.Txid,
+			State:  state,
+			Reason: "transaction already confirmed",
+		}, nil
+
+	case state == TxStateFailed:
+		return &BumpNowResp{
+			Txid:   req.Txid,
+			State:  state,
+			Reason: "transaction in terminal failure",
+		}, nil
+
+	// A tx that has not reached any mempool yet is still in the broadcast
+	// retry loop; there is no in-mempool parent to attach a CPFP child to,
+	// so forcing a bump now would be meaningless. The retry loop already
+	// re-attempts on its own interval.
+	case state == TxStateBroadcasting:
+		return &BumpNowResp{
+			Txid:   req.Txid,
+			State:  state,
+			Reason: "transaction not yet in mempool",
+		}, nil
+	}
+
+	// Only an anchor-bearing parent can be CPFP-bumped; a plain parent has
+	// no child handle, so report the no-op rather than spinning up a doomed
+	// fee-bump pass.
+	if findAnchorOutput(entry.data.Tx) < 0 {
+		return &BumpNowResp{
+			Txid:   req.Txid,
+			State:  state,
+			Reason: "transaction has no anchor to bump",
+		}, nil
+	}
+
+	// Stamp the one-shot operator target rate and run a single fee-bump
+	// pass. broadcastTrackedTx consumes and clears the override.
+	entry.pendingTargetFeeRate = req.TargetFeeRateSatPerVByte
+
+	result, bumpErr := a.broadcastTrackedTx(ctx, entry, TxStateFeeBumping)
+	if bumpErr != nil {
+		a.maybeEnsureFeeInputSupply(ctx, bumpErr)
+
+		// A failed forced bump is non-terminal, exactly like an
+		// interval-paced bump failure: the original broadcast is still
+		// live and the confirmation watch remains active. Recover the
+		// FSM back to AwaitingConfirmation with an updated broadcast
+		// height so the next interval bump waits the full interval.
+		a.log.WarnS(ctx, "Forced fee bump failed", bumpErr,
+			"txid", entry.data.Txid)
+
+		_ = a.advanceTrackedTxFSM(ctx, entry, &trackedTxBroadcastAccepted{
+			Progress: trackedTxProgress{
+				LastBroadcastHeight: fn.Some(a.bestHeight),
+			},
+		})
+
+		bumpedState, _ := entry.currentTxState()
+
+		return &BumpNowResp{
+			Txid:   req.Txid,
+			State:  bumpedState,
+			Bumped: false,
+			Reason: fmt.Sprintf("fee bump failed: %v", bumpErr),
+		}, nil
+	}
+
+	bumpedState, _ := entry.currentTxState()
+
+	return &BumpNowResp{
+		Txid:      req.Txid,
+		State:     bumpedState,
+		Bumped:    true,
+		ChildTxid: copyHash(result.ChildTxid),
+	}, nil
+}
+
 // handleConfirmationObserved marks a tracked txid as confirmed and fans the
 // result out to all subscribers.
 func (a *TxBroadcasterActor) handleConfirmationObserved(ctx context.Context,
@@ -811,14 +935,14 @@ func (a *TxBroadcasterActor) handleBlockObserved(ctx context.Context,
 		// A tx that never reached any mempool is re-attempted from
 		// scratch and routed through the shared outcome handler.
 		case a.shouldRetryBroadcast(entry):
-			err := a.broadcastTrackedTx(
+			_, err := a.broadcastTrackedTx(
 				ctx, entry, TxStateBroadcasting,
 			)
 			a.recordInitialBroadcastOutcome(ctx, entry, err)
 
 		// A tx already in a mempool is fee-bumped.
 		case a.shouldFeeBump(entry):
-			if err := a.broadcastTrackedTx(
+			if _, err := a.broadcastTrackedTx(
 				ctx, entry, TxStateFeeBumping,
 			); err != nil {
 
@@ -938,6 +1062,7 @@ func (a *TxBroadcasterActor) newTrackedTx(ctx context.Context,
 		Label:       req.Label,
 		HeightHint:  heightHint,
 		TargetConfs: targetConfs,
+		ParentFee:   req.ParentFee,
 	}
 	fsm := newTrackedTxStateMachine(fsmLog, data)
 	fsm.Start(ctx)
@@ -1156,7 +1281,7 @@ func (a *TxBroadcasterActor) unregisterConfWatch(ctx context.Context,
 // broadcastTrackedTx submits one tracked transaction and records the latest
 // broadcast metadata.
 func (a *TxBroadcasterActor) broadcastTrackedTx(ctx context.Context,
-	entry *trackedTx, nextState TxState) error {
+	entry *trackedTx, nextState TxState) (*BroadcastResult, error) {
 
 	var startEvent trackedTxEvent
 	switch nextState {
@@ -1167,21 +1292,43 @@ func (a *TxBroadcasterActor) broadcastTrackedTx(ctx context.Context,
 		startEvent = &trackedTxFeeBumpStarted{}
 
 	default:
-		return fmt.Errorf("unexpected broadcast state %v", nextState)
+		return nil, fmt.Errorf("unexpected broadcast state %v", nextState)
 	}
 
 	if err := a.advanceTrackedTxFSM(ctx, entry, startEvent); err != nil {
-		return err
+		return nil, err
+	}
+
+	// A fee-bump pass is what builds a CPFP child for a funded-anchor
+	// parent (the initial pass broadcasts the parent directly). Carry the
+	// parent's own fee so the child only pays the package shortfall, and
+	// consume any one-shot operator target rate set by a BumpNowReq.
+	isFeeBump := nextState == TxStateFeeBumping
+	targetFeeRate := int64(0)
+	if isFeeBump {
+		targetFeeRate = entry.pendingTargetFeeRate
 	}
 
 	result, err := a.broadcaster.Submit(
 		ctx, a.bestHeight, &BroadcastRequest{
-			Tx:    entry.data.Tx,
-			Label: entry.data.Label,
+			Tx:                       entry.data.Tx,
+			Label:                    entry.data.Label,
+			IsFeeBump:                isFeeBump,
+			ParentFee:                entry.data.ParentFee,
+			TargetFeeRateSatPerVByte: targetFeeRate,
 		},
 	)
+
+	// The one-shot target rate applies to exactly one bump attempt
+	// regardless of its outcome, so clear it here: a failed forced bump
+	// should not silently pin the operator's rate onto later interval-paced
+	// bumps.
+	if isFeeBump {
+		entry.pendingTargetFeeRate = 0
+	}
+
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := a.advanceTrackedTxFSM(
@@ -1193,10 +1340,10 @@ func (a *TxBroadcasterActor) broadcastTrackedTx(ctx context.Context,
 			},
 		},
 	); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return result, nil
 }
 
 // shouldFeeBump reports whether a tracked transaction that already reached a

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -760,6 +760,12 @@ func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
 		return nil, err
 	}
 
+	// Locate the anchor up front: it decides both whether a bump is
+	// possible at all and whether a never-broadcast parent can be carried
+	// into the mempool by a package submit.
+	anchorIdx := findAnchorOutput(entry.data.Tx)
+	funded := anchorIdx >= 0 && anchorIsFunded(entry.data.Tx, anchorIdx)
+
 	switch {
 	case state == TxStateConfirmed:
 		return &BumpNowResp{
@@ -775,11 +781,32 @@ func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
 			Reason: "transaction in terminal failure",
 		}, nil
 
-	// A tx that has not reached any mempool yet is still in the broadcast
-	// retry loop; there is no in-mempool parent to attach a CPFP child to,
-	// so forcing a bump now would be meaningless. The retry loop already
-	// re-attempts on its own interval.
-	case state == TxStateBroadcasting:
+	// An entry still in New never accepted its initial submission event;
+	// there is nothing coherent to bump yet.
+	case state == TxStateNew:
+		return &BumpNowResp{
+			Txid:   req.Txid,
+			State:  state,
+			Reason: "transaction not yet submitted",
+		}, nil
+
+	// A concurrent bump pass is already in flight (or the FSM was left
+	// mid-transition); stacking a second one would race the replacement
+	// accounting.
+	case state == TxStateFeeBumping:
+		return &BumpNowResp{
+			Txid:   req.Txid,
+			State:  state,
+			Reason: "fee bump already in progress",
+		}, nil
+
+	// An ephemeral (zero-fee) parent that has not reached any mempool is
+	// already being re-submitted as a full CPFP package by the retry loop
+	// on every interval; a forced pass adds nothing. A FUNDED parent in
+	// Broadcasting is different — its retries are plain direct broadcasts
+	// at its fixed fee, so it falls through to the forced package submit
+	// below, which is exactly what carries a never-in-mempool parent in.
+	case state == TxStateBroadcasting && !funded:
 		return &BumpNowResp{
 			Txid:   req.Txid,
 			State:  state,
@@ -790,7 +817,7 @@ func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
 	// Only an anchor-bearing parent can be CPFP-bumped; a plain parent has
 	// no child handle, so report the no-op rather than spinning up a doomed
 	// fee-bump pass.
-	if findAnchorOutput(entry.data.Tx) < 0 {
+	if anchorIdx < 0 {
 		return &BumpNowResp{
 			Txid:   req.Txid,
 			State:  state,
@@ -798,12 +825,39 @@ func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
 		}, nil
 	}
 
-	// Stamp the one-shot operator target rate and run a single fee-bump
-	// pass. broadcastTrackedTx consumes and clears the override.
+	// Stamp the one-shot operator target rate; broadcastTrackedTxOpts
+	// consumes and clears the override on every outcome.
 	entry.pendingTargetFeeRate = req.TargetFeeRateSatPerVByte
 
-	result, bumpErr := a.broadcastTrackedTx(ctx, entry, TxStateFeeBumping)
+	// A funded parent still in Broadcasting never reached a mempool on its
+	// own fee, so its bump stays on the Broadcasting state track (the
+	// success condition is "parent finally landed") while still submitting
+	// as a parent+child package.
+	nextState := TxStateFeeBumping
+	if state == TxStateBroadcasting {
+		nextState = TxStateBroadcasting
+	}
+
+	result, bumpErr := a.broadcastTrackedTxOpts(ctx, entry, nextState, true)
 	if bumpErr != nil {
+		// A never-broadcast parent routes its failure through the
+		// shared initial-outcome handler: it stays in Broadcasting
+		// (with the escalation counter ticking) or fails terminally on
+		// structural errors, identical to an interval retry.
+		if nextState == TxStateBroadcasting {
+			a.recordInitialBroadcastOutcome(ctx, entry, bumpErr)
+
+			bumpedState, _ := entry.currentTxState()
+
+			return &BumpNowResp{
+				Txid:   req.Txid,
+				State:  bumpedState,
+				Bumped: false,
+				Reason: fmt.Sprintf("fee bump failed: %v",
+					bumpErr),
+			}, nil
+		}
+
 		a.maybeEnsureFeeInputSupply(ctx, bumpErr)
 
 		// A failed forced bump is non-terminal, exactly like an
@@ -814,11 +868,15 @@ func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
 		a.log.WarnS(ctx, "Forced fee bump failed", bumpErr,
 			"txid", entry.data.Txid)
 
-		_ = a.advanceTrackedTxFSM(ctx, entry, &trackedTxBroadcastAccepted{
-			Progress: trackedTxProgress{
-				LastBroadcastHeight: fn.Some(a.bestHeight),
+		_ = a.advanceTrackedTxFSM(
+			ctx, entry, &trackedTxBroadcastAccepted{
+				Progress: trackedTxProgress{
+					LastBroadcastHeight: fn.Some(
+						a.bestHeight,
+					),
+				},
 			},
-		})
+		)
 
 		bumpedState, _ := entry.currentTxState()
 
@@ -832,11 +890,18 @@ func (a *TxBroadcasterActor) handleBumpNow(ctx context.Context,
 
 	bumpedState, _ := entry.currentTxState()
 
+	// Surface the rate the package actually targets so a silently clamped
+	// operator request is visible: Clamped is true when the supplied target
+	// exceeded the broadcaster's ceiling and was reduced.
 	return &BumpNowResp{
 		Txid:      req.Txid,
 		State:     bumpedState,
 		Bumped:    true,
 		ChildTxid: copyHash(result.ChildTxid),
+
+		EffectiveFeeRateSatPerVByte: result.FeeRate,
+		Clamped: req.TargetFeeRateSatPerVByte > 0 &&
+			result.FeeRate < req.TargetFeeRateSatPerVByte,
 	}, nil
 }
 
@@ -1279,9 +1344,25 @@ func (a *TxBroadcasterActor) unregisterConfWatch(ctx context.Context,
 }
 
 // broadcastTrackedTx submits one tracked transaction and records the latest
-// broadcast metadata.
+// broadcast metadata. The fee-bump intent is derived from the FSM state being
+// entered: a FeeBumping pass builds a CPFP child, a Broadcasting pass is an
+// initial (or retried) submission.
 func (a *TxBroadcasterActor) broadcastTrackedTx(ctx context.Context,
 	entry *trackedTx, nextState TxState) (*BroadcastResult, error) {
+
+	return a.broadcastTrackedTxOpts(
+		ctx, entry, nextState, nextState == TxStateFeeBumping,
+	)
+}
+
+// broadcastTrackedTxOpts is broadcastTrackedTx with an explicit fee-bump
+// intent, decoupled from the FSM state. A forced bump of a funded-anchor
+// parent that never reached a mempool stays on the Broadcasting state track
+// (its success path is "parent finally landed", not "replacement landed") but
+// must still submit as a CPFP package, which is what isFeeBump controls.
+func (a *TxBroadcasterActor) broadcastTrackedTxOpts(ctx context.Context,
+	entry *trackedTx, nextState TxState, isFeeBump bool) (*BroadcastResult,
+	error) {
 
 	var startEvent trackedTxEvent
 	switch nextState {
@@ -1292,7 +1373,20 @@ func (a *TxBroadcasterActor) broadcastTrackedTx(ctx context.Context,
 		startEvent = &trackedTxFeeBumpStarted{}
 
 	default:
-		return nil, fmt.Errorf("unexpected broadcast state %v", nextState)
+		return nil, fmt.Errorf("unexpected broadcast state %v",
+			nextState)
+	}
+
+	// The one-shot target rate applies to exactly one bump attempt
+	// regardless of its outcome (including an early FSM-advance failure
+	// below), so clear it on every exit path: a failed forced bump must not
+	// silently pin the operator's rate onto later interval-paced bumps.
+	targetFeeRate := int64(0)
+	if isFeeBump {
+		targetFeeRate = entry.pendingTargetFeeRate
+		defer func() {
+			entry.pendingTargetFeeRate = 0
+		}()
 	}
 
 	if err := a.advanceTrackedTxFSM(ctx, entry, startEvent); err != nil {
@@ -1301,14 +1395,7 @@ func (a *TxBroadcasterActor) broadcastTrackedTx(ctx context.Context,
 
 	// A fee-bump pass is what builds a CPFP child for a funded-anchor
 	// parent (the initial pass broadcasts the parent directly). Carry the
-	// parent's own fee so the child only pays the package shortfall, and
-	// consume any one-shot operator target rate set by a BumpNowReq.
-	isFeeBump := nextState == TxStateFeeBumping
-	targetFeeRate := int64(0)
-	if isFeeBump {
-		targetFeeRate = entry.pendingTargetFeeRate
-	}
-
+	// parent's own fee so the child only pays the package shortfall.
 	result, err := a.broadcaster.Submit(
 		ctx, a.bestHeight, &BroadcastRequest{
 			Tx:                       entry.data.Tx,
@@ -1318,15 +1405,6 @@ func (a *TxBroadcasterActor) broadcastTrackedTx(ctx context.Context,
 			TargetFeeRateSatPerVByte: targetFeeRate,
 		},
 	)
-
-	// The one-shot target rate applies to exactly one bump attempt
-	// regardless of its outcome, so clear it here: a failed forced bump
-	// should not silently pin the operator's rate onto later interval-paced
-	// bumps.
-	if isFeeBump {
-		entry.pendingTargetFeeRate = 0
-	}
-
 	if err != nil {
 		return nil, err
 	}

--- a/txconfirm/broadcaster.go
+++ b/txconfirm/broadcaster.go
@@ -42,6 +42,13 @@ const (
 	// relay bandwidth on top of the replaced package's fee).
 	DefaultIncrementalRelayFeeSatPerVByte int64 = 1
 
+	// minRelayFeeRateSatPerVByte is Bitcoin Core's default minimum relay
+	// fee rate (minrelaytxfee, 1000 sat/kvB). A transaction paying less
+	// than this per vbyte is rejected by every default-configured
+	// mempool, so a CPFP child whose residual fee falls under
+	// vsize * this rate is doomed at relay and not worth building.
+	minRelayFeeRateSatPerVByte int64 = 1
+
 	// DefaultFeeInputLeaseExpiry is how long the broadcaster asks the
 	// wallet to lease a CPFP fee-input UTXO. The lease is explicitly
 	// released on terminal eviction and on fallback paths, but that
@@ -70,17 +77,29 @@ var (
 		"shortfall")
 
 	// ErrNonTRUCParent indicates that the caller submitted a parent
-	// transaction whose version is not v3 (TRUC). txconfirm relies on
-	// BIP-431 ephemeral-anchor and TRUC-package semantics for its
-	// CPFP fee-bump strategy: without v3, package RBF replacement
-	// rules and the zero-fee anchor are not policy-legal on a
-	// standard Bitcoin Core mempool, and anchor detection becomes
-	// structurally ambiguous (a legitimate output script could match
-	// the anyone-can-spend anchor pattern by accident). We therefore
-	// reject non-v3 parents at the Submit boundary rather than
-	// silently attaching a CPFP child that would never relay.
+	// carrying a zero-value ephemeral anchor whose version is not v3
+	// (TRUC). The ephemeral-anchor CPFP strategy relies on BIP-431
+	// package semantics: without v3, package RBF replacement rules and
+	// the zero-fee anchor are not policy-legal on a standard Bitcoin
+	// Core mempool. We therefore reject non-v3 ephemeral-anchor parents
+	// at the Submit boundary rather than silently attaching a CPFP
+	// child that would never relay. Funded-anchor parents (non-zero
+	// anchor value) pay their own fee and are exempt: they broadcast as
+	// ordinary v2 transactions and only spend the anchor when a bump is
+	// requested.
 	ErrNonTRUCParent = errors.New("parent transaction must be v3 (TRUC) " +
 		"for CPFP broadcast")
+
+	// ErrParentFeeSufficient indicates that a fee-bump request resolved
+	// to a target package fee the parent already pays on its own, so the
+	// CPFP child's share would fall below what a mempool will relay. The
+	// bump is refused as a no-op rather than burning a wallet round-trip
+	// on a child that is guaranteed a min-relay-fee reject. Callers
+	// should treat this as "nothing to do at this rate": either the fee
+	// estimator has fallen to (or below) the parent's own rate, or an
+	// operator supplied a target at or under it.
+	ErrParentFeeSufficient = errors.New("parent fee already meets target " +
+		"package fee; cpfp child would not relay")
 
 	// ErrParentAlreadyBroadcast indicates that the SubmitPackage RPC
 	// reported the parent transaction as already known to the network
@@ -597,7 +616,8 @@ func (b *CPFPBroadcaster) Submit(ctx context.Context, height int32,
 	default:
 		if req.Tx.Version != arktx.TxVersion {
 			return nil, fmt.Errorf("%w: got version %d, want %d",
-				ErrNonTRUCParent, req.Tx.Version, arktx.TxVersion)
+				ErrNonTRUCParent, req.Tx.Version,
+				arktx.TxVersion)
 		}
 
 		return b.broadcastWithCPFP(ctx, height, req, txid, anchorIdx)
@@ -775,6 +795,27 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 	feeRate, totalFee = b.applyReplacementFloor(
 		req.Tx, txid, feeRate, totalFee, childVSize,
 	)
+
+	// A funded parent may already pay the whole package target on its own
+	// (a flat-rate re-bump, or an operator target at or under the parent's
+	// own rate). The child's residual share would then sit below the
+	// minimum relay fee for its vsize and every mempool would reject it,
+	// so refuse the bump up front as a no-op rather than deriving scripts,
+	// leasing a fee input, and signing a child that is doomed at relay.
+	// Zero-fee ephemeral parents (ParentFee == 0) never trip this: their
+	// child always carries the full package fee.
+	if req.ParentFee > 0 {
+		childFee := childFeeFromPackageFee(totalFee, req.ParentFee)
+		minChildFee := btcutil.Amount(
+			childVSize * minRelayFeeRateSatPerVByte,
+		)
+		if childFee < minChildFee {
+			return nil, fmt.Errorf("%w: parent pays %d of %d sat "+
+				"package fee at %d sat/vB",
+				ErrParentFeeSufficient, req.ParentFee, totalFee,
+				feeRate)
+		}
+	}
 
 	// Select a fee input that covers the package fee *plus* a spendable
 	// (non-dust) change output. Selecting for totalFee alone can pick a
@@ -1015,6 +1056,23 @@ func (b *CPFPBroadcaster) fallbackDirectBroadcast(ctx context.Context,
 
 	b.releaseFeeOutpoint(ctx, txid, releaseOutpoint)
 
+	// A fee bump of a funded-anchor parent must never take the direct
+	// fallback: the parent relayed on its own fee and is (or was) already
+	// in the mempool, so re-broadcasting it is answered with an ignorable
+	// "already known" reject and the call would report success with no
+	// child submitted. Surfacing the setup failure instead lets the caller
+	// report an honest Bumped=false with the real reason. The fallback
+	// remains the right hail-mary for a zero-fee ephemeral parent, whose
+	// only route into a mempool is a package, and for initial funded
+	// broadcasts, which are direct anyway.
+	if req.IsFeeBump {
+		anchorIdx := findAnchorOutput(req.Tx)
+		if anchorIdx >= 0 && anchorIsFunded(req.Tx, anchorIdx) {
+			return nil, fmt.Errorf("cpfp setup failed at %s: %w",
+				stage, err)
+		}
+	}
+
 	b.log.WarnS(ctx, "CPFP unavailable; broadcasting parent directly",
 		err, "txid", txid, "stage", stage, "label", req.Label)
 
@@ -1094,7 +1152,9 @@ func (b *CPFPBroadcaster) targetOrEstimatedFeeRate(ctx context.Context,
 // satoshi so the child always pays a positive fee even when the parent's fee
 // already covers (or exceeds) the target, which can happen on a flat-rate
 // re-bump.
-func childFeeFromPackageFee(packageFee, parentFee btcutil.Amount) btcutil.Amount {
+func childFeeFromPackageFee(
+	packageFee, parentFee btcutil.Amount) btcutil.Amount {
+
 	childFee := packageFee - parentFee
 	if childFee < 1 {
 		childFee = 1

--- a/txconfirm/broadcaster.go
+++ b/txconfirm/broadcaster.go
@@ -180,6 +180,33 @@ type BroadcastRequest struct {
 
 	// Label is a human-readable label for logging.
 	Label string
+
+	// IsFeeBump distinguishes an initial broadcast from a fee-bump
+	// re-attempt. It only matters for a funded-anchor parent: such a
+	// parent is independently valid and pays its own miner fee, so its
+	// initial broadcast goes out directly (no CPFP child, no fee-input
+	// reservation) and a CPFP child is built only when a bump is actually
+	// needed. A zero-value ephemeral-anchor parent ignores this flag: it
+	// pays zero fee and must always ride a CPFP package, on the initial
+	// submission and on every bump.
+	IsFeeBump bool
+
+	// ParentFee is the absolute miner fee the parent transaction already
+	// pays, in satoshis. It is used only on the funded-anchor CPFP path to
+	// avoid double-counting the parent's fee: the CPFP child pays the
+	// package-fee target minus what the parent already contributes, so the
+	// combined parent+child fee lands on the requested rate rather than
+	// overshooting it by the parent's own fee. Zero (the default, and the
+	// only value used by the zero-fee ephemeral path) makes the child pay
+	// the full package fee, which is correct when the parent pays nothing.
+	ParentFee btcutil.Amount
+
+	// TargetFeeRateSatPerVByte, when positive, overrides the estimator and
+	// forces the CPFP package to a specific fee rate, clamped to
+	// MaxFeeRateSatPerVByte. It is how an operator-driven "bump now to this
+	// rate" request reaches the broadcaster. Zero defers to the fee
+	// estimator, the default behaviour for interval-paced bumps.
+	TargetFeeRateSatPerVByte int64
 }
 
 // BroadcastResult describes the outcome of one broadcast attempt.
@@ -543,18 +570,38 @@ func (b *CPFPBroadcaster) Submit(ctx context.Context, height int32,
 		return nil, fmt.Errorf("broadcast request and tx required")
 	}
 
-	if req.Tx.Version != arktx.TxVersion {
-		return nil, fmt.Errorf("%w: got version %d, want %d",
-			ErrNonTRUCParent, req.Tx.Version, arktx.TxVersion)
-	}
-
 	txid := req.Tx.TxHash()
 	anchorIdx := findAnchorOutput(req.Tx)
-	if anchorIdx < 0 {
-		return b.broadcastDirect(ctx, req, txid)
-	}
 
-	return b.broadcastWithCPFP(ctx, height, req, txid, anchorIdx)
+	switch {
+	// No anchor at all: a plain transaction with no CPFP handle. Broadcast
+	// it directly and let it ride; there is nothing to fee-bump.
+	case anchorIdx < 0:
+		return b.broadcastDirect(ctx, req, txid)
+
+	// Funded anchor: the parent pays its own fee and is independently
+	// valid, so it does not need TRUC/package semantics. On the initial
+	// broadcast we send the parent directly and reserve no fee input — the
+	// anchor is a spare handle we only spend when a bump is requested. On a
+	// fee-bump we build the CPFP child off the funded anchor.
+	case anchorIsFunded(req.Tx, anchorIdx):
+		if !req.IsFeeBump {
+			return b.broadcastDirect(ctx, req, txid)
+		}
+
+		return b.broadcastWithCPFP(ctx, height, req, txid, anchorIdx)
+
+	// Zero-value ephemeral anchor: the parent pays zero fee and can only
+	// relay as part of a CPFP package, so it must be v3 (TRUC) and always
+	// rides a child — on the initial submission and on every bump.
+	default:
+		if req.Tx.Version != arktx.TxVersion {
+			return nil, fmt.Errorf("%w: got version %d, want %d",
+				ErrNonTRUCParent, req.Tx.Version, arktx.TxVersion)
+		}
+
+		return b.broadcastWithCPFP(ctx, height, req, txid, anchorIdx)
+	}
 }
 
 // broadcastDirect broadcasts a transaction without CPFP.
@@ -707,7 +754,13 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 	// side, which is safer than under-estimating.
 	childVSize := estimateChildVSize(changePkScript, changePkScript)
 
-	feeRate, err := b.EstimateFeeRate(ctx)
+	// An operator-supplied target rate (a "bump now to this rate" request)
+	// overrides the estimator; otherwise we use the current estimate. Both
+	// are clamped to MaxFeeRateSatPerVByte inside the respective helpers so
+	// a stuck-tx bump can never blow past the configured ceiling.
+	feeRate, err := b.targetOrEstimatedFeeRate(
+		ctx, req.TargetFeeRateSatPerVByte,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("estimate fee: %w", err)
 	}
@@ -781,9 +834,20 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 	anchorOutpoint := wire.OutPoint{Hash: txid, Index: uint32(anchorIdx)}
 	anchorOutput := req.Tx.TxOut[anchorIdx]
 
+	// The child only needs to pay the package fee that the parent does not
+	// already cover. For a zero-fee ephemeral parent ParentFee is zero and
+	// the child pays the whole package fee (unchanged behaviour). For a
+	// funded parent we subtract the fee it already pays so the combined
+	// parent+child fee lands on the target rate instead of overshooting it.
+	// totalFee remains the combined package fee recorded for BIP-125
+	// replacement accounting; only the child's share is reduced here. The
+	// fee input was selected against totalFee+DustLimit, so a smaller child
+	// fee just yields a larger (still valid) change output.
+	childFee := childFeeFromPackageFee(totalFee, req.ParentFee)
+
 	child, err := BuildCPFPChild(
 		req.Tx.Version, anchorOutpoint, anchorOutput, feeInput,
-		changePkScript, totalFee,
+		changePkScript, childFee,
 	)
 	if err != nil {
 		return b.fallbackDirectBroadcast(
@@ -1000,6 +1064,43 @@ func (b *CPFPBroadcaster) EstimateFeeRate(ctx context.Context) (int64, error) {
 	}
 
 	return rate, nil
+}
+
+// targetOrEstimatedFeeRate returns the fee rate to use for a CPFP package. A
+// positive target (an operator-driven "bump now to this rate" request)
+// overrides the estimator and is clamped to MaxFeeRateSatPerVByte so a manual
+// bump can never exceed the configured ceiling; a non-positive target defers
+// to the estimator, which applies the same clamp.
+func (b *CPFPBroadcaster) targetOrEstimatedFeeRate(ctx context.Context,
+	targetRate int64) (int64, error) {
+
+	if targetRate <= 0 {
+		return b.EstimateFeeRate(ctx)
+	}
+
+	if b.cfg.MaxFeeRateSatPerVByte > 0 &&
+		targetRate > b.cfg.MaxFeeRateSatPerVByte {
+
+		targetRate = b.cfg.MaxFeeRateSatPerVByte
+	}
+
+	return targetRate, nil
+}
+
+// childFeeFromPackageFee splits the combined package fee into the portion the
+// CPFP child must pay, given the fee the parent already contributes. The
+// parent's fee is subtracted so the combined parent+child fee equals the
+// package target rather than overshooting it; the result is floored at one
+// satoshi so the child always pays a positive fee even when the parent's fee
+// already covers (or exceeds) the target, which can happen on a flat-rate
+// re-bump.
+func childFeeFromPackageFee(packageFee, parentFee btcutil.Amount) btcutil.Amount {
+	childFee := packageFee - parentFee
+	if childFee < 1 {
+		childFee = 1
+	}
+
+	return childFee
 }
 
 // selectFeeInput finds the smallest confirmed wallet UTXO that covers the
@@ -1302,16 +1403,28 @@ func (b *CPFPBroadcaster) broadcastIndividually(ctx context.Context,
 	return nil
 }
 
-// findAnchorOutput returns the index of the anchor output in the transaction
-// or -1 if none is found.
+// findAnchorOutput returns the index of the P2A anchor output in the
+// transaction or -1 if none is found. It matches the anchor by script
+// regardless of value, so it locates both the zero-value ephemeral anchor
+// used by TRUC parents and the funded anchor used by an independently-valid
+// parent. Callers that need to distinguish the two forms inspect the value
+// of the returned output (see anchorIsFunded).
 func findAnchorOutput(tx *wire.MsgTx) int {
 	for i, out := range tx.TxOut {
-		if arktx.IsAnchorOutput(out) {
+		if arktx.IsP2AAnchorScript(out.PkScript) {
 			return i
 		}
 	}
 
 	return -1
+}
+
+// anchorIsFunded reports whether the anchor at anchorIdx carries a non-zero
+// value, i.e. it is the funded form whose parent pays its own fee and can
+// confirm standalone, rather than the zero-value ephemeral form that relies
+// on a CPFP descendant to fund the package.
+func anchorIsFunded(tx *wire.MsgTx, anchorIdx int) bool {
+	return arktx.IsFundedAnchorOutput(tx.TxOut[anchorIdx])
 }
 
 // estimateChildVSize returns the vbyte size of the CPFP child this

--- a/txconfirm/broadcaster.go
+++ b/txconfirm/broadcaster.go
@@ -576,12 +576,15 @@ func (b *CPFPBroadcaster) excludedOutpointsForOtherParents(
 // "give me a signed parent, I'll handle the rest, including the CPFP
 // child and its fee-bump lifecycle."
 //
-// Parents that are not v3 (TRUC) are rejected with ErrNonTRUCParent: the
-// whole CPFP fee-bump strategy in this package assumes BIP-431 semantics
-// for anchor-bearing transactions, and relying on pattern-based anchor
-// detection against non-v3 parents is structurally unsafe (a coincidental
-// anyone-can-spend-looking output would silently receive a CPFP child
-// that the mempool then rejects, burning the caller's fee input).
+// The anchor's value picks the strategy. A zero-value ephemeral anchor
+// marks a BIP-431 TRUC parent that pays no fee of its own: such parents
+// must be v3 (non-v3 is rejected with ErrNonTRUCParent, since package RBF
+// and the zero-fee anchor are not policy-legal without TRUC semantics)
+// and always ride a CPFP package. A funded (non-zero) anchor marks an
+// independently valid parent that pays its own fee: it broadcasts
+// directly on the initial pass regardless of version, and the anchor is
+// only spent when a fee bump is requested. Anchorless transactions
+// broadcast directly with no fee-bump handle at all.
 func (b *CPFPBroadcaster) Submit(ctx context.Context, height int32,
 	req *BroadcastRequest) (*BroadcastResult, error) {
 
@@ -817,14 +820,27 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 		}
 	}
 
-	// Select a fee input that covers the package fee *plus* a spendable
-	// (non-dust) change output. Selecting for totalFee alone can pick a
+	// The child's own fee is the package target minus what the parent
+	// already pays; that (not the full package fee) is what the wallet
+	// input must fund. The anchor's value is also credited into the
+	// child's change, so it reduces the wallet's share further. Selecting
+	// against the full package fee on a funded parent would reject
+	// perfectly adequate UTXOs and surface a false fee-input shortage.
+	anchorOutpoint := wire.OutPoint{Hash: txid, Index: uint32(anchorIdx)}
+	anchorOutput := req.Tx.TxOut[anchorIdx]
+	anchorValue := btcutil.Amount(anchorOutput.Value)
+	childFee := childFeeFromPackageFee(totalFee, req.ParentFee)
+
+	// Select a fee input that covers the child's fee *plus* a spendable
+	// (non-dust) change output. Selecting for the fee alone can pick a
 	// UTXO whose post-fee remainder is below the dust limit, which would
 	// force BuildCPFPChild to drop its only output and produce a
 	// zero-output child that FinalizePsbt rejects. Requiring the dust
 	// buffer up front skips near-dust UTXOs and lands on one that always
 	// yields a valid change output.
-	feeInput, err := b.selectFeeInput(ctx, txid, totalFee+DustLimit)
+	feeInput, err := b.selectFeeInput(
+		ctx, txid, childFeeInputTarget(childFee, anchorValue),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrCPFPFeeInputUnavailable,
 			err)
@@ -846,7 +862,13 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 			req.Tx, btcutil.Amount(feeRate), preciseChildVSize,
 		)
 		if feeErr == nil && preciseFee > totalFee {
+			// totalFee remains the combined package fee recorded
+			// for BIP-125 replacement accounting; childFee tracks
+			// the child's own share of it.
 			totalFee = preciseFee
+			childFee = childFeeFromPackageFee(
+				totalFee, req.ParentFee,
+			)
 
 			// Growing the fee can push the already-selected
 			// input's change below the dust limit. Reselect
@@ -857,7 +879,8 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 			// retry. The reservation cache keeps the current
 			// input when it already covers the larger fee.
 			reselected, selErr := b.selectFeeInput(
-				ctx, txid, totalFee+DustLimit,
+				ctx, txid,
+				childFeeInputTarget(childFee, anchorValue),
 			)
 			if selErr != nil {
 				return b.fallbackDirectBroadcast(
@@ -871,20 +894,6 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 			}
 		}
 	}
-
-	anchorOutpoint := wire.OutPoint{Hash: txid, Index: uint32(anchorIdx)}
-	anchorOutput := req.Tx.TxOut[anchorIdx]
-
-	// The child only needs to pay the package fee that the parent does not
-	// already cover. For a zero-fee ephemeral parent ParentFee is zero and
-	// the child pays the whole package fee (unchanged behaviour). For a
-	// funded parent we subtract the fee it already pays so the combined
-	// parent+child fee lands on the target rate instead of overshooting it.
-	// totalFee remains the combined package fee recorded for BIP-125
-	// replacement accounting; only the child's share is reduced here. The
-	// fee input was selected against totalFee+DustLimit, so a smaller child
-	// fee just yields a larger (still valid) change output.
-	childFee := childFeeFromPackageFee(totalFee, req.ParentFee)
 
 	child, err := BuildCPFPChild(
 		req.Tx.Version, anchorOutpoint, anchorOutput, feeInput,
@@ -1161,6 +1170,22 @@ func childFeeFromPackageFee(
 	}
 
 	return childFee
+}
+
+// childFeeInputTarget returns the minimum wallet fee-input value needed to
+// fund a CPFP child paying childFee: the fee plus a dust buffer so the change
+// output is always spendable, minus the anchor's own value, which is credited
+// into the change alongside the fee input. The floor of one satoshi keeps the
+// selection meaningful when a large funded anchor covers the whole child fee
+// on its own — the child still structurally requires a confirmed wallet input
+// (it is what later RBF replacements double-spend), just not a big one.
+func childFeeInputTarget(childFee, anchorValue btcutil.Amount) btcutil.Amount {
+	target := childFee + DustLimit - anchorValue
+	if target < 1 {
+		target = 1
+	}
+
+	return target
 }
 
 // selectFeeInput finds the smallest confirmed wallet UTXO that covers the
@@ -1606,13 +1631,20 @@ func EstimatePackageFee(parentTx *wire.MsgTx,
 }
 
 // BuildCPFPChild constructs an unsigned CPFP child that spends an anchor
-// output and one confirmed wallet fee input.
+// output and one confirmed wallet fee input. childFee is the fee the child
+// itself pays: for a zero-fee ephemeral parent that is the whole package fee,
+// for a funded parent it is the package fee minus what the parent already
+// contributes.
 func BuildCPFPChild(parentVersion int32, anchorOutpoint wire.OutPoint,
 	anchorOutput *wire.TxOut, feeInput *FeeInput, changePkScript []byte,
-	totalFee btcutil.Amount) (*wire.MsgTx, error) {
+	childFee btcutil.Amount) (*wire.MsgTx, error) {
 
 	if feeInput == nil || feeInput.Output == nil {
 		return nil, fmt.Errorf("fee input and output required")
+	}
+
+	if anchorOutput == nil {
+		return nil, fmt.Errorf("anchor output required")
 	}
 
 	if !feeInput.Confirmed {
@@ -1639,24 +1671,33 @@ func BuildCPFPChild(parentVersion int32, anchorOutpoint wire.OutPoint,
 		Sequence:         wire.MaxTxInSequenceNum - 2,
 	})
 
-	changeValue := btcutil.Amount(feeInput.Output.Value) - totalFee
+	// Every value-bearing input must be credited into the change or it is
+	// silently donated to miners as fee the caller never asked for. The
+	// anchor is such an input on the funded path: a non-zero anchor value
+	// recovered here is exactly how the operator gets the anchor's sats
+	// back when a bump fires. For a zero-value ephemeral anchor this
+	// credit is zero and the arithmetic reduces to the fee input alone.
+	anchorValue := btcutil.Amount(anchorOutput.Value)
+	changeValue := btcutil.Amount(feeInput.Output.Value) + anchorValue -
+		childFee
 	if changeValue < 0 {
-		return nil, fmt.Errorf("fee input value %d insufficient "+
-			"for fee %d", feeInput.Output.Value, int64(totalFee))
+		return nil, fmt.Errorf("fee input value %d plus anchor value "+
+			"%d insufficient for fee %d", feeInput.Output.Value,
+			int64(anchorValue), int64(childFee))
 	}
 
-	// The CPFP child's only spendable output is this change output: the
-	// other input is the parent's zero-value ephemeral anchor. If the
+	// The CPFP child's only spendable output is this change output. If the
 	// remainder after fees is below the dust limit we cannot emit a valid
 	// output, so refuse here rather than return a zero-output transaction
 	// that the wallet's FinalizePsbt rejects ("PSBT packet must contain at
-	// least one output"). Callers select fee inputs covering totalFee +
-	// DustLimit, so this is a defensive backstop against a post-selection
-	// fee top-up (mixed-type wallets) eroding the dust margin.
+	// least one output"). Callers select fee inputs against the child fee
+	// plus a dust buffer, so this is a defensive backstop against a
+	// post-selection fee top-up (mixed-type wallets) eroding the margin.
 	if changeValue < DustLimit {
-		return nil, fmt.Errorf("%w: fee input %d leaves %d change "+
-			"below dust limit %d", ErrFeeInputProducesDust,
-			feeInput.Output.Value, int64(changeValue),
+		return nil, fmt.Errorf("%w: fee input %d + anchor %d leaves "+
+			"%d change below dust limit %d",
+			ErrFeeInputProducesDust, feeInput.Output.Value,
+			int64(anchorValue), int64(changeValue),
 			int64(DustLimit))
 	}
 

--- a/txconfirm/fee_input_actor.go
+++ b/txconfirm/fee_input_actor.go
@@ -307,7 +307,7 @@ func (a *TxBroadcasterActor) retryBroadcastingParents(ctx context.Context) {
 			continue
 		}
 
-		err = a.broadcastTrackedTx(ctx, entry, TxStateBroadcasting)
+		_, err = a.broadcastTrackedTx(ctx, entry, TxStateBroadcasting)
 		a.recordInitialBroadcastOutcome(ctx, entry, err)
 	}
 }

--- a/txconfirm/fsm_types.go
+++ b/txconfirm/fsm_types.go
@@ -3,6 +3,7 @@ package txconfirm
 import (
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
@@ -70,6 +71,14 @@ type trackedTxData struct {
 
 	// TargetConfs is the required confirmation count.
 	TargetConfs uint32
+
+	// ParentFee is the absolute miner fee, in satoshis, that the tracked
+	// transaction already pays on its own. It is used only for a funded-
+	// anchor parent, where the CPFP child subtracts it so a fee bump lands
+	// the combined parent+child fee on the target rate instead of
+	// overshooting by the parent's own fee. Zero for zero-fee ephemeral
+	// parents and for callers that do not supply it.
+	ParentFee btcutil.Amount
 }
 
 // trackedTxProgress is the mutable per-broadcast progress carried by FSM

--- a/txconfirm/funded_anchor_test.go
+++ b/txconfirm/funded_anchor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -168,6 +169,93 @@ func TestTargetOrEstimatedFeeRate(t *testing.T) {
 	rate, err = b.targetOrEstimatedFeeRate(t.Context(), 999)
 	require.NoError(t, err)
 	require.EqualValues(t, 50, rate)
+}
+
+// TestBuildCPFPChildCreditsAnchorValue asserts the funded anchor's value is
+// credited into the child's change output rather than silently burned as
+// extra miner fee: the child's effective fee (inputs minus outputs) must
+// equal exactly the childFee the caller asked for.
+func TestBuildCPFPChildCreditsAnchorValue(t *testing.T) {
+	t.Parallel()
+
+	const (
+		anchorValue = int64(330)
+		feeInputVal = int64(50_000)
+		childFee    = btcutil.Amount(1_000)
+	)
+
+	parent := makeFundedAnchorTx(20, anchorValue)
+	anchorIdx := len(parent.TxOut) - 1
+	anchorOutpoint := wire.OutPoint{
+		Hash:  parent.TxHash(),
+		Index: uint32(anchorIdx),
+	}
+
+	feeInput := &FeeInput{
+		Outpoint: wire.OutPoint{
+			Hash: chainhash.Hash{
+				0xfe,
+			},
+			Index: 0,
+		},
+		Output: &wire.TxOut{
+			Value:    feeInputVal,
+			PkScript: dummyChildP2WKHScript(),
+		},
+		Confirmed: true,
+	}
+
+	child, err := BuildCPFPChild(
+		parent.Version, anchorOutpoint, parent.TxOut[anchorIdx],
+		feeInput, dummyChildP2WKHScript(), childFee,
+	)
+	require.NoError(t, err)
+	require.Len(t, child.TxOut, 1)
+
+	// Effective fee = value in - value out. Both inputs carry value: the
+	// funded anchor and the wallet fee input.
+	valueIn := anchorValue + feeInputVal
+	effectiveFee := valueIn - child.TxOut[0].Value
+	require.EqualValues(
+		t, childFee, effectiveFee,
+		"anchor value must be credited to change, not burned as fee",
+	)
+
+	// The change explicitly includes the anchor's value.
+	require.EqualValues(
+		t, feeInputVal+anchorValue-int64(childFee),
+		child.TxOut[0].Value,
+	)
+}
+
+// dummyChildP2WKHScript returns a syntactically valid P2WKH pkScript for
+// child-construction tests.
+func dummyChildP2WKHScript() []byte {
+	return append([]byte{txscript.OP_0, 0x14}, make([]byte, 20)...)
+}
+
+// TestChildFeeInputTarget asserts the wallet fee-input selection target is the
+// child's own need: fee plus dust buffer, net of the anchor value it recovers,
+// floored at one satoshi.
+func TestChildFeeInputTarget(t *testing.T) {
+	t.Parallel()
+
+	// Ephemeral anchor (zero value): target is fee + dust, the historical
+	// behaviour.
+	require.EqualValues(
+		t, 1_000+DustLimit, childFeeInputTarget(1_000, 0),
+	)
+
+	// Funded anchor: its value offsets the wallet's share.
+	require.EqualValues(
+		t, 1_000+DustLimit-330, childFeeInputTarget(1_000, 330),
+	)
+
+	// A large anchor covering the whole child fee still requires some
+	// confirmed wallet input, so the target floors at one satoshi.
+	require.EqualValues(
+		t, 1, childFeeInputTarget(500, 10_000),
+	)
 }
 
 // failingPkScriptWallet wraps fakeWallet so CPFP-child setup fails at the

--- a/txconfirm/funded_anchor_test.go
+++ b/txconfirm/funded_anchor_test.go
@@ -1,11 +1,16 @@
 package txconfirm
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
 	"github.com/lightninglabs/darepo-client/walletcore"
 	"github.com/stretchr/testify/require"
@@ -26,7 +31,11 @@ func makeFundedAnchorTx(seed byte, anchorValue int64) *wire.MsgTx {
 		Value:    100_000,
 		PkScript: []byte{txscript.OP_TRUE},
 	})
-	tx.AddTxOut(arkscript.AnchorOutput(arkscript.WithAnchorValue(anchorValue)))
+	tx.AddTxOut(
+		arkscript.AnchorOutput(
+			arkscript.WithAnchorValue(anchorValue),
+		),
+	)
 
 	return tx
 }
@@ -159,4 +168,377 @@ func TestTargetOrEstimatedFeeRate(t *testing.T) {
 	rate, err = b.targetOrEstimatedFeeRate(t.Context(), 999)
 	require.NoError(t, err)
 	require.EqualValues(t, 50, rate)
+}
+
+// failingPkScriptWallet wraps fakeWallet so CPFP-child setup fails at the
+// change-script derivation stage, the first fallback site in
+// broadcastWithCPFP.
+type failingPkScriptWallet struct {
+	*fakeWallet
+}
+
+func (w *failingPkScriptWallet) NewWalletPkScript(_ context.Context) ([]byte,
+	error) {
+
+	return nil, fmt.Errorf("wallet says no")
+}
+
+// TestSubmitFundedBumpNoSilentFallback asserts that a fee bump of a funded
+// parent whose CPFP setup fails returns the setup error instead of falling
+// back to a direct re-broadcast of a parent that is already in the mempool
+// (which would be swallowed as "already known" and reported as success).
+func TestSubmitFundedBumpNoSilentFallback(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	b := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource: chain,
+		Wallet: &failingPkScriptWallet{
+			fakeWallet: &fakeWallet{
+				utxos: []*walletcore.Utxo{makeWalletUTXO(t)},
+			},
+		},
+	})
+
+	_, err := b.Submit(t.Context(), 100, &BroadcastRequest{
+		Tx:        makeFundedAnchorTx(10, 330),
+		Label:     "funded-bump-nofallback",
+		IsFeeBump: true,
+		ParentFee: 500,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cpfp setup failed")
+
+	// No hail-mary direct broadcast happened: the parent is already in a
+	// mempool and re-broadcasting it would masquerade as success.
+	require.Equal(t, 0, chain.broadcastCallCount())
+	require.Equal(t, 0, chain.packageCallCount())
+}
+
+// TestSubmitEphemeralKeepsDirectFallback asserts the ephemeral (zero-fee TRUC)
+// path retains its hail-mary direct fallback when CPFP setup fails: that
+// parent's only route into a mempool is external help, so the fallback is
+// still the right behaviour there.
+func TestSubmitEphemeralKeepsDirectFallback(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	b := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource: chain,
+		Wallet: &failingPkScriptWallet{
+			fakeWallet: &fakeWallet{
+				utxos: []*walletcore.Utxo{makeWalletUTXO(t)},
+			},
+		},
+	})
+
+	result, err := b.Submit(t.Context(), 100, &BroadcastRequest{
+		Tx:        makeTestTx(true),
+		Label:     "ephemeral-fallback",
+		IsFeeBump: true,
+	})
+	require.NoError(t, err)
+	require.Nil(t, result.ChildTxid)
+	require.Equal(t, 1, chain.broadcastCallCount())
+}
+
+// TestSubmitFundedBumpParentFeeSufficient asserts the bump is refused up
+// front, before any wallet round-trip, when the parent's own fee already
+// covers the target package fee: the child's residual share would sit below
+// min relay and be rejected by every mempool.
+func TestSubmitFundedBumpParentFeeSufficient(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	wallet := &fakeWallet{utxos: []*walletcore.Utxo{makeWalletUTXO(t)}}
+	b := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource: chain,
+		Wallet:      wallet,
+	})
+
+	_, err := b.Submit(t.Context(), 100, &BroadcastRequest{
+		Tx:        makeFundedAnchorTx(11, 330),
+		Label:     "funded-sufficient",
+		IsFeeBump: true,
+		ParentFee: 10_000_000,
+	})
+	require.ErrorIs(t, err, ErrParentFeeSufficient)
+
+	// The short-circuit fires before fee-input selection: no lease was
+	// taken and nothing hit the network.
+	require.Empty(t, wallet.leaseCalls)
+	require.Equal(t, 0, chain.broadcastCallCount())
+	require.Equal(t, 0, chain.packageCallCount())
+}
+
+// newBumpTestBehavior constructs an unstarted txconfirm behavior driven
+// synchronously via Receive, so tests can inspect internal tracked state
+// without racing an actor goroutine.
+func newBumpTestBehavior(t *testing.T, chain *fakeChainSourceRef,
+	w Wallet) *TxBroadcasterActor {
+
+	t.Helper()
+
+	behavior := NewTxBroadcasterActor(Config{
+		ChainSource: chain,
+		Wallet:      w,
+	})
+	behavior.SetSelfRef(
+		actor.NewChannelTellOnlyRef[Msg]("txconfirm-bump-test", 8),
+	)
+
+	return behavior
+}
+
+// mustReceiveEnsure drives one EnsureConfirmedReq through Receive.
+func mustReceiveEnsure(t *testing.T, behavior *TxBroadcasterActor,
+	req *EnsureConfirmedReq) *EnsureConfirmedResp {
+
+	t.Helper()
+
+	resp, err := behavior.Receive(t.Context(), req).Unpack()
+	require.NoError(t, err)
+
+	typed, ok := resp.(*EnsureConfirmedResp)
+	require.True(t, ok)
+
+	return typed
+}
+
+// mustReceiveBump drives one BumpNowReq through Receive.
+func mustReceiveBump(t *testing.T, behavior *TxBroadcasterActor,
+	req *BumpNowReq) *BumpNowResp {
+
+	t.Helper()
+
+	resp, err := behavior.Receive(t.Context(), req).Unpack()
+	require.NoError(t, err)
+
+	typed, ok := resp.(*BumpNowResp)
+	require.True(t, ok)
+
+	return typed
+}
+
+// TestBumpNowFundedParent covers the operator happy path: a funded parent in
+// AwaitingConfirmation is force-bumped at a within-ceiling target, producing a
+// CPFP child at exactly that rate, and the one-shot override is cleared.
+func TestBumpNowFundedParent(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	wallet := &fakeWallet{utxos: []*walletcore.Utxo{makeWalletUTXO(t)}}
+	behavior := newBumpTestBehavior(t, chain, wallet)
+
+	sub := actor.NewChannelTellOnlyRef[Notification]("bump-sub", 8)
+	tx := makeFundedAnchorTx(12, 330)
+	txid := tx.TxHash()
+
+	ensureResp := mustReceiveEnsure(t, behavior, &EnsureConfirmedReq{
+		Tx:         tx,
+		Label:      "bump-happy",
+		ParentFee:  500,
+		Subscriber: sub,
+	})
+	require.Equal(t, TxStateAwaitingConfirmation, ensureResp.State)
+	require.Equal(t, 1, chain.broadcastCallCount())
+
+	bumpResp := mustReceiveBump(t, behavior, &BumpNowReq{
+		Txid:                     txid,
+		TargetFeeRateSatPerVByte: 25,
+	})
+	require.True(t, bumpResp.Bumped)
+	require.NotNil(t, bumpResp.ChildTxid)
+	require.EqualValues(t, 25, bumpResp.EffectiveFeeRateSatPerVByte)
+	require.False(t, bumpResp.Clamped)
+	require.Equal(t, 1, chain.packageCallCount())
+
+	// The one-shot operator override was consumed and cleared, so the next
+	// interval-paced bump falls back to the estimator.
+	require.Zero(t, behavior.tracked[txid].pendingTargetFeeRate)
+}
+
+// TestBumpNowClampedTarget asserts an over-ceiling operator target is clamped
+// to the broadcaster maximum and the clamp is surfaced in the response rather
+// than silently reported as a full success.
+func TestBumpNowClampedTarget(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	wallet := &fakeWallet{utxos: []*walletcore.Utxo{makeWalletUTXO(t)}}
+	behavior := newBumpTestBehavior(t, chain, wallet)
+
+	sub := actor.NewChannelTellOnlyRef[Notification]("clamp-sub", 8)
+	tx := makeFundedAnchorTx(13, 330)
+
+	mustReceiveEnsure(t, behavior, &EnsureConfirmedReq{
+		Tx:         tx,
+		Label:      "bump-clamp",
+		ParentFee:  500,
+		Subscriber: sub,
+	})
+
+	bumpResp := mustReceiveBump(t, behavior, &BumpNowReq{
+		Txid:                     tx.TxHash(),
+		TargetFeeRateSatPerVByte: 999,
+	})
+	require.True(t, bumpResp.Bumped)
+	require.EqualValues(
+		t, DefaultMaxFeeRateSatPerVByte,
+		bumpResp.EffectiveFeeRateSatPerVByte,
+	)
+	require.True(t, bumpResp.Clamped)
+}
+
+// TestBumpNowFundedBroadcastingSubmitsPackage covers the stuck-at-relay case:
+// a funded parent whose direct broadcast keeps failing (mempool min fee above
+// its fixed rate) sits in Broadcasting, and a forced bump submits parent+child
+// as a package, which is exactly what carries a never-in-mempool parent in.
+func TestBumpNowFundedBroadcastingSubmitsPackage(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	chain.broadcastErr = fmt.Errorf("min relay fee not met")
+	wallet := &fakeWallet{utxos: []*walletcore.Utxo{makeWalletUTXO(t)}}
+	behavior := newBumpTestBehavior(t, chain, wallet)
+
+	sub := actor.NewChannelTellOnlyRef[Notification]("stuck-sub", 8)
+	tx := makeFundedAnchorTx(14, 330)
+
+	ensureResp := mustReceiveEnsure(t, behavior, &EnsureConfirmedReq{
+		Tx:         tx,
+		Label:      "bump-stuck",
+		ParentFee:  200,
+		Subscriber: sub,
+	})
+	require.Equal(t, TxStateBroadcasting, ensureResp.State)
+
+	bumpResp := mustReceiveBump(t, behavior, &BumpNowReq{
+		Txid:                     tx.TxHash(),
+		TargetFeeRateSatPerVByte: 30,
+	})
+	require.True(t, bumpResp.Bumped)
+	require.NotNil(t, bumpResp.ChildTxid)
+	require.Equal(t, TxStateAwaitingConfirmation, bumpResp.State)
+	require.Equal(t, 1, chain.packageCallCount())
+}
+
+// TestBumpNowEphemeralBroadcastingRefused asserts a zero-fee ephemeral parent
+// that never reached a mempool still refuses a forced bump: its retry loop is
+// already package-submitting on every interval, so the forced pass adds
+// nothing.
+func TestBumpNowEphemeralBroadcastingRefused(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	chain.packageErr = fmt.Errorf("package rejected")
+	chain.broadcastErr = fmt.Errorf("min relay fee not met")
+	wallet := &fakeWallet{utxos: []*walletcore.Utxo{makeWalletUTXO(t)}}
+	behavior := newBumpTestBehavior(t, chain, wallet)
+
+	sub := actor.NewChannelTellOnlyRef[Notification]("eph-sub", 8)
+	tx := makeTestTx(true)
+
+	ensureResp := mustReceiveEnsure(t, behavior, &EnsureConfirmedReq{
+		Tx:         tx,
+		Label:      "eph-stuck",
+		Subscriber: sub,
+	})
+	require.Equal(t, TxStateBroadcasting, ensureResp.State)
+
+	bumpResp := mustReceiveBump(t, behavior, &BumpNowReq{
+		Txid:                     tx.TxHash(),
+		TargetFeeRateSatPerVByte: 30,
+	})
+	require.False(t, bumpResp.Bumped)
+	require.Contains(t, bumpResp.Reason, "not yet in mempool")
+}
+
+// TestBumpNowParentFeeSufficient asserts a forced bump whose target the parent
+// already meets reports an honest no-op (with the sentinel reason) and leaves
+// the tracked tx awaiting confirmation.
+func TestBumpNowParentFeeSufficient(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	wallet := &fakeWallet{utxos: []*walletcore.Utxo{makeWalletUTXO(t)}}
+	behavior := newBumpTestBehavior(t, chain, wallet)
+
+	sub := actor.NewChannelTellOnlyRef[Notification]("suff-sub", 8)
+	tx := makeFundedAnchorTx(15, 330)
+
+	mustReceiveEnsure(t, behavior, &EnsureConfirmedReq{
+		Tx:         tx,
+		Label:      "bump-sufficient",
+		ParentFee:  10_000_000,
+		Subscriber: sub,
+	})
+
+	bumpResp := mustReceiveBump(t, behavior, &BumpNowReq{
+		Txid:                     tx.TxHash(),
+		TargetFeeRateSatPerVByte: 5,
+	})
+	require.False(t, bumpResp.Bumped)
+	require.Contains(t, bumpResp.Reason, "parent fee already meets")
+	require.Equal(t, TxStateAwaitingConfirmation, bumpResp.State)
+
+	// The refused bump consumed its one-shot override too.
+	require.Zero(t, behavior.tracked[tx.TxHash()].pendingTargetFeeRate)
+}
+
+// TestBumpNowUntrackedAndTerminal covers the remaining no-op guards: an
+// untracked txid, and a transaction that confirmed and was evicted from
+// tracking (a confirmed entry whose terminal notification is delivered is
+// dropped from the map, so a late bump lands in the untracked branch).
+func TestBumpNowUntrackedAndTerminal(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	wallet := &fakeWallet{utxos: []*walletcore.Utxo{makeWalletUTXO(t)}}
+	behavior := newBumpTestBehavior(t, chain, wallet)
+
+	// Untracked txid.
+	bumpResp := mustReceiveBump(t, behavior, &BumpNowReq{
+		Txid: chainhash.Hash{0xaa},
+	})
+	require.False(t, bumpResp.Bumped)
+	require.Contains(t, bumpResp.Reason, "not tracked")
+
+	// Already-confirmed transaction: the fake chain reports an immediate
+	// confirmation on watch registration.
+	tx := makeFundedAnchorTx(16, 330)
+	chain.alreadyConfirmed[tx.TxHash()] = chainsource.ConfirmationEvent{
+		Txid:        tx.TxHash(),
+		BlockHeight: 99,
+		NumConfs:    1,
+	}
+
+	sub := actor.NewChannelTellOnlyRef[Notification]("term-sub", 8)
+	mustReceiveEnsure(t, behavior, &EnsureConfirmedReq{
+		Tx:         tx,
+		Label:      "confirmed",
+		Subscriber: sub,
+	})
+
+	// Drain the confirmation callback the fake chain delivered to the
+	// self ref so the entry reaches its terminal state and, with its
+	// notification delivered, is evicted from tracking.
+	selfRef, ok := behavior.selfRef.(*actor.ChannelTellOnlyRef[Msg])
+	require.True(t, ok)
+	for {
+		msg, ok := selfRef.AwaitMessage(100 * time.Millisecond)
+		if !ok {
+			break
+		}
+		_, _ = behavior.Receive(t.Context(), msg).Unpack()
+	}
+	require.NotNil(t, mustAwaitNotification(t, sub))
+
+	// A bump after eviction reports the untracked no-op: there is no
+	// entry left to bump, which is the correct answer for a confirmed tx.
+	bumpResp = mustReceiveBump(t, behavior, &BumpNowReq{
+		Txid: tx.TxHash(),
+	})
+	require.False(t, bumpResp.Bumped)
+	require.Contains(t, bumpResp.Reason, "not tracked")
 }

--- a/txconfirm/funded_anchor_test.go
+++ b/txconfirm/funded_anchor_test.go
@@ -1,0 +1,162 @@
+package txconfirm
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/darepo-client/lib/arkscript"
+	"github.com/lightninglabs/darepo-client/walletcore"
+	"github.com/stretchr/testify/require"
+)
+
+// makeFundedAnchorTx builds a v2 transaction carrying a funded (non-zero) P2A
+// anchor, modelling an independently-valid commitment-style parent that pays
+// its own fee and reserves the anchor as a CPFP handle.
+func makeFundedAnchorTx(seed byte, anchorValue int64) *wire.MsgTx {
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{seed},
+			Index: 0,
+		},
+	})
+	tx.AddTxOut(&wire.TxOut{
+		Value:    100_000,
+		PkScript: []byte{txscript.OP_TRUE},
+	})
+	tx.AddTxOut(arkscript.AnchorOutput(arkscript.WithAnchorValue(anchorValue)))
+
+	return tx
+}
+
+// TestSubmitFundedAnchorInitialBroadcastsDirect asserts that the initial
+// submission of a funded-anchor parent goes out as a plain direct broadcast:
+// the parent is independently valid, so no CPFP child is built and no fee
+// input is reserved until a bump is actually requested.
+func TestSubmitFundedAnchorInitialBroadcastsDirect(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	b := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource: chain,
+		Wallet: &fakeWallet{
+			utxos: []*walletcore.Utxo{makeWalletUTXO(t)},
+		},
+	})
+
+	result, err := b.Submit(t.Context(), 100, &BroadcastRequest{
+		Tx:        makeFundedAnchorTx(7, 330),
+		Label:     "funded-initial",
+		IsFeeBump: false,
+	})
+	require.NoError(t, err)
+
+	// A direct broadcast leaves no CPFP child and submits no package.
+	require.Nil(t, result.ChildTxid)
+	require.Equal(t, 1, chain.broadcastCallCount())
+	require.Equal(t, 0, chain.packageCallCount())
+}
+
+// TestSubmitFundedAnchorFeeBumpBuildsChild asserts that a fee-bump submission
+// of a funded-anchor parent (the path a stuck-tx bump drives) builds and
+// submits a CPFP child spending the funded anchor.
+func TestSubmitFundedAnchorFeeBumpBuildsChild(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	b := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource: chain,
+		Wallet: &fakeWallet{
+			utxos: []*walletcore.Utxo{makeWalletUTXO(t)},
+		},
+	})
+
+	result, err := b.Submit(t.Context(), 100, &BroadcastRequest{
+		Tx:        makeFundedAnchorTx(8, 330),
+		Label:     "funded-bump",
+		IsFeeBump: true,
+		ParentFee: 500,
+	})
+	require.NoError(t, err)
+
+	// A fee bump submits a parent+child package and surfaces the child.
+	require.NotNil(t, result.ChildTxid)
+	require.Equal(t, 1, chain.packageCallCount())
+}
+
+// TestSubmitFundedAnchorV2NotRejected asserts that a v2 funded-anchor parent is
+// accepted rather than rejected by the TRUC version gate, which only applies to
+// zero-value ephemeral anchors.
+func TestSubmitFundedAnchorV2NotRejected(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	b := NewCPFPBroadcaster(BroadcasterConfig{ChainSource: chain})
+
+	tx := makeFundedAnchorTx(9, 330)
+	require.EqualValues(t, 2, tx.Version)
+
+	_, err := b.Submit(t.Context(), 100, &BroadcastRequest{
+		Tx:        tx,
+		Label:     "funded-v2",
+		IsFeeBump: false,
+	})
+	require.NoError(t, err)
+	require.NotErrorIs(t, err, ErrNonTRUCParent)
+}
+
+// TestChildFeeFromPackageFee asserts the package fee is split so the child pays
+// only the shortfall the parent does not already cover, with a positive floor.
+func TestChildFeeFromPackageFee(t *testing.T) {
+	t.Parallel()
+
+	// Parent pays nothing (ephemeral): the child pays the whole package.
+	require.EqualValues(
+		t, 1_000, childFeeFromPackageFee(1_000, 0),
+	)
+
+	// Funded parent: the child pays the package fee minus the parent's fee.
+	require.EqualValues(
+		t, 700, childFeeFromPackageFee(1_000, 300),
+	)
+
+	// Parent fee already covers (or exceeds) the package target: the child
+	// still pays a positive floor of one satoshi.
+	require.EqualValues(
+		t, 1, childFeeFromPackageFee(1_000, 1_000),
+	)
+	require.EqualValues(
+		t, 1, childFeeFromPackageFee(1_000, 5_000),
+	)
+}
+
+// TestTargetOrEstimatedFeeRate asserts an operator-supplied target overrides
+// the estimator and is clamped to the configured maximum, while a non-positive
+// target defers to the estimator.
+func TestTargetOrEstimatedFeeRate(t *testing.T) {
+	t.Parallel()
+
+	chain := newFakeChainSourceRef(100)
+	chain.feeRate = 5
+	b := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource:           chain,
+		MaxFeeRateSatPerVByte: 50,
+	})
+
+	// A non-positive target defers to the estimator (5 sat/vB).
+	rate, err := b.targetOrEstimatedFeeRate(t.Context(), 0)
+	require.NoError(t, err)
+	require.EqualValues(t, 5, rate)
+
+	// A target within the cap is used verbatim.
+	rate, err = b.targetOrEstimatedFeeRate(t.Context(), 25)
+	require.NoError(t, err)
+	require.EqualValues(t, 25, rate)
+
+	// A target above the cap is clamped to the maximum.
+	rate, err = b.targetOrEstimatedFeeRate(t.Context(), 999)
+	require.NoError(t, err)
+	require.EqualValues(t, 50, rate)
+}

--- a/txconfirm/messages.go
+++ b/txconfirm/messages.go
@@ -3,6 +3,7 @@ package txconfirm
 import (
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
@@ -118,6 +119,13 @@ type EnsureConfirmedReq struct {
 	// TargetConfs is the required confirmation count. Zero defaults to one.
 	TargetConfs uint32
 
+	// ParentFee is the absolute miner fee, in satoshis, that Tx already
+	// pays. It is used only for a funded-anchor parent so a later CPFP fee
+	// bump subtracts the parent's own fee and lands the combined fee on the
+	// target rate. Zero (the default) is correct for zero-fee ephemeral
+	// parents and for callers that do not fee-bump.
+	ParentFee btcutil.Amount
+
 	// Subscriber receives TxConfirmed or TxFailed notifications for this
 	// request.
 	Subscriber actor.TellOnlyRef[Notification]
@@ -204,6 +212,63 @@ func (m *CancelInterestResp) MessageType() string {
 
 // txConfirmRespSealed seals CancelInterestResp into the package response set.
 func (m *CancelInterestResp) txConfirmRespSealed() {}
+
+// BumpNowReq asks the actor to force an immediate CPFP fee bump of an
+// already-tracked transaction at an operator-supplied fee rate, rather than
+// waiting for the next interval-paced bump. It is the mechanism behind an
+// operator "bump this stuck transaction now" command. The transaction must
+// carry a CPFP anchor for the bump to do anything; a plain transaction has no
+// handle to attach a child to.
+type BumpNowReq struct {
+	actor.BaseMessage
+
+	// Txid identifies the tracked transaction to bump.
+	Txid chainhash.Hash
+
+	// TargetFeeRateSatPerVByte is the fee rate the forced CPFP package
+	// should target, clamped to the broadcaster's configured maximum. Zero
+	// defers to the fee estimator, matching an interval-paced bump.
+	TargetFeeRateSatPerVByte int64
+}
+
+// MessageType returns the stable message type identifier.
+func (m *BumpNowReq) MessageType() string {
+	return "BumpNowReq"
+}
+
+// txConfirmMsgSealed seals BumpNowReq into the package message set.
+func (m *BumpNowReq) txConfirmMsgSealed() {}
+
+// BumpNowResp reports the outcome of a forced fee bump.
+type BumpNowResp struct {
+	actor.BaseMessage
+
+	// Txid echoes the bumped transaction's hash.
+	Txid chainhash.Hash
+
+	// State is the tracked transaction's state after the bump attempt.
+	State TxState
+
+	// Bumped is true when a fresh CPFP child was built and submitted, and
+	// false when the bump was a no-op (e.g. the txid is not tracked, is
+	// already terminal, or carries no anchor to bump).
+	Bumped bool
+
+	// ChildTxid is the hash of the CPFP child submitted by this bump, set
+	// only when Bumped is true.
+	ChildTxid *chainhash.Hash
+
+	// Reason is a stable human-readable explanation when Bumped is false.
+	Reason string
+}
+
+// MessageType returns the stable message type identifier.
+func (m *BumpNowResp) MessageType() string {
+	return "BumpNowResp"
+}
+
+// txConfirmRespSealed seals BumpNowResp into the package response set.
+func (m *BumpNowResp) txConfirmRespSealed() {}
 
 // TxConfirmed notifies a subscriber that the tracked transaction reached its
 // requested confirmation target.

--- a/txconfirm/messages.go
+++ b/txconfirm/messages.go
@@ -258,6 +258,18 @@ type BumpNowResp struct {
 	// only when Bumped is true.
 	ChildTxid *chainhash.Hash
 
+	// EffectiveFeeRateSatPerVByte is the fee rate the submitted package
+	// actually targets, set when Bumped is true. It can differ from the
+	// requested rate: an over-ceiling target is clamped down, and the
+	// BIP-125 replacement floor can ratchet a flat target up.
+	EffectiveFeeRateSatPerVByte int64
+
+	// Clamped is true when the operator-supplied target rate exceeded the
+	// broadcaster's configured maximum and was reduced. Callers should
+	// surface this: a "successful" bump at a clamped rate may still sit
+	// below the market rate the operator asked for.
+	Clamped bool
+
 	// Reason is a stable human-readable explanation when Bumped is false.
 	Reason string
 }


### PR DESCRIPTION
In this PR, we teach the `txconfirm` broadcaster to fee-bump a *funded*-anchor
parent: a v2 transaction that pays its own miner fee and confirms standalone,
with a non-zero P2A anchor reserved as a CPFP handle. Until now txconfirm only
knew the zero-value ephemeral anchor on a v3/TRUC parent, which it must always
ride out as a package because that parent pays zero fee. The server side
(darepo) wants to attach a funded anchor to every round/commitment transaction
so an operator can unstick a round whose original fee rate the mempool has
since outpaced, without forcing the commitment tx itself to be a 0-fee TRUC
package.

## arktx predicates

We add two predicates alongside the existing zero-value `IsAnchorOutput`.
`IsP2AAnchorScript` matches the P2A anchor by script regardless of value, and
`IsFundedAnchorOutput` is the exact complement of `IsAnchorOutput` over P2A
outputs (non-zero value). A funded anchor is one whose value sits above the P2A
dust threshold (240 sats per BIP-433), so its parent pays its own fee rather
than relying on a CPFP descendant to fund the package.

## Funded-anchor CPFP path

`Submit` now branches on the anchor form. A funded parent broadcasts directly
on its first pass: no CPFP child, no fee-input reservation, since we may never
need to bump. It only builds a v2 CPFP child when a fee bump is actually
requested (the interval-paced bump or a forced one). The TRUC version gate
stays in force for the ephemeral path but no longer rejects a v2 funded parent.

The fee math subtracts the parent's own fee, threaded through as `ParentFee`,
so the combined parent+child fee lands on the target rate instead of
overshooting it by the parent's fee. `ParentFee` defaults to zero, which is
exactly right for the zero-fee ephemeral case and a safe overpay when a caller
doesn't supply it.

## BumpNow override

We add a `BumpNowReq` message so an operator can force an immediate CPFP at a
chosen fee rate (clamped to the configured max) rather than waiting for the
interval-paced bump. `broadcastTrackedTx` now carries the one-shot target rate
and the fee-bump intent and returns the `BroadcastResult` so the bump handler
can surface the child txid. The existing fraud-responder path (zero-value
ephemeral, v3/TRUC) is unchanged: all of its tests stay green.

See each commit message for a detailed description w.r.t the incremental
changes.