### PR TITLE
darepod: Restrict lwwallet CPFP fee inputs to default account

### DIFF
--- a/darepod/server.go
+++ b/darepod/server.go
@@ -4883,24 +4883,20 @@ func (w *lwUnrollWallet) ListUnspent(ctx context.Context, minConfs,
 		return nil, fmt.Errorf("wait for wallet sync: %w", err)
 	}
 
+	// Restrict CPFP fee selection to the default account. Imported,
+	// watch-only taproot outputs (e.g. boarding outputs imported via
+	// ImportTaprootScript) live in the imported account: they carry no
+	// BIP32 derivation and no spendable key, so the FinalizePsbt path
+	// cannot sign them and finalization fails with "PSBT is not
+	// finalizable". The default-account filter already surfaces every
+	// wallet-derived (key-spendable) fee input, so a broader all-accounts
+	// query would only readmit the unspendable imported outputs we must
+	// avoid.
 	lnUtxos, err := w.Wallet.BtcWallet.ListUnspentWitness(
 		minConfs, maxConfs, lnwallet.DefaultAccountName,
 	)
 	if err != nil {
 		return nil, err
-	}
-
-	// btcwallet's default-account filter can miss wallet-managed P2TR
-	// outputs in lwwallet mode even though the same UTXOs are visible when
-	// enumerating across all accounts. Fall back to the broader query so
-	// harness-funded fee inputs remain available for CPFP package relay.
-	if len(lnUtxos) == 0 {
-		lnUtxos, err = w.Wallet.BtcWallet.ListUnspentWitness(
-			minConfs, maxConfs, "",
-		)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	result := make([]*wallet.Utxo, 0, len(lnUtxos))

--- a/darepod/unroll_fee_input_test.go
+++ b/darepod/unroll_fee_input_test.go
@@ -1,0 +1,235 @@
+package darepod
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	btcwalletbase "github.com/btcsuite/btcwallet/wallet"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/lightninglabs/darepo-client/lwwallet"
+	"github.com/lightninglabs/darepo-client/wallet"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLwUnrollWalletListUnspentExcludesImported is a regression test for
+// darepo-client#831. On the lwwallet (esplora) backend, CPFP fee selection
+// must only surface wallet-derived, key-spendable outputs. Imported,
+// watch-only taproot outputs (boarding outputs imported via
+// ImportTaprootScript) have no BIP32 derivation and no spendable key, so the
+// FinalizePsbt path cannot sign them and finalization fails with "PSBT is not
+// finalizable", forcing a zero-fee parent broadcast that does not relay.
+//
+// The default-account ListUnspentWitness filter already excludes these
+// imported outputs. The bug was an all-accounts fallback that re-admitted
+// them; this test pins the corrected behaviour: the wallet's own derived
+// output is offered as a fee input, while an imported boarding output is not.
+func TestLwUnrollWalletListUnspentExcludesImported(t *testing.T) {
+	t.Parallel()
+
+	w := newFundedLwWallet(t)
+	ctx := t.Context()
+	uw := &lwUnrollWallet{Wallet: w}
+
+	// Import a watch-only boarding output and fund it as the wallet's only
+	// confirmed UTXO. This is the field scenario: the default account is
+	// empty (the boarding output lives in the imported account), so the
+	// regression was an all-accounts fallback that surfaced this
+	// unspendable output as a CPFP fee input.
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	importedAddr, err := w.BoardingBackend().ImportTaprootScript(
+		ctx, &waddrmgr.Tapscript{
+			Type:          waddrmgr.TaprootFullKeyOnly,
+			FullOutputKey: privKey.PubKey(),
+		},
+	)
+	require.NoError(t, err)
+	importedScript, err := txscript.PayToAddrScript(importedAddr)
+	require.NoError(t, err)
+	importedOp := fundConfirmedUTXO(t, w, importedScript)
+
+	// Sanity check the harness: an all-accounts enumeration must see the
+	// imported output, otherwise the exclusion assertion below would be
+	// vacuous.
+	allUtxos, err := w.BtcWallet.ListUnspentWitness(0, math.MaxInt32, "")
+	require.NoError(t, err)
+	require.True(
+		t, containsOutpoint(allUtxos, importedOp),
+		"harness must fund the imported boarding output",
+	)
+
+	// With only the imported boarding output present, fee selection must
+	// return nothing rather than offering the unspendable output.
+	feeInputs, err := uw.ListUnspent(ctx, 0, math.MaxInt32)
+	require.NoError(t, err)
+	require.False(
+		t, containsFeeInput(feeInputs, importedOp),
+		"imported boarding output must not be a fee input",
+	)
+	require.Empty(t, feeInputs, "no spendable fee inputs available")
+
+	// A wallet-derived taproot output (the kind lwwallet hands back for
+	// change and sweep outputs) must, by contrast, be offered as a fee
+	// input.
+	derivedAddr, err := w.NewAddress(ctx)
+	require.NoError(t, err)
+	derivedScript, err := txscript.PayToAddrScript(derivedAddr)
+	require.NoError(t, err)
+	derivedOp := fundConfirmedUTXO(t, w, derivedScript)
+
+	feeInputs, err = uw.ListUnspent(ctx, 0, math.MaxInt32)
+	require.NoError(t, err)
+	require.True(
+		t, containsFeeInput(feeInputs, derivedOp),
+		"derived output must be a valid fee input",
+	)
+	require.False(
+		t, containsFeeInput(feeInputs, importedOp),
+		"imported boarding output must remain excluded",
+	)
+}
+
+// newFundedLwWallet builds and starts a real lwwallet backed by a mock
+// Esplora server pinned at the regtest genesis block.
+func newFundedLwWallet(t *testing.T) *lwwallet.Wallet {
+	t.Helper()
+
+	var seed [32]byte
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+
+	tipHash := chaincfg.RegressionNetParams.GenesisHash.String()
+	handler := func(rw http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/blocks/tip/height":
+			_, err := rw.Write([]byte("0"))
+			require.NoError(t, err)
+
+		case "/block-height/0":
+			_, err := rw.Write([]byte(tipHash))
+			require.NoError(t, err)
+
+		case "/block/" + tipHash:
+			err := json.NewEncoder(rw).Encode(map[string]any{
+				"id":        tipHash,
+				"height":    0,
+				"timestamp": 1,
+			})
+			require.NoError(t, err)
+
+		default:
+			http.NotFound(rw, r)
+		}
+	}
+	esplora := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(esplora.Close)
+
+	w, err := lwwallet.New(lwwallet.Config{
+		Seed:           seed,
+		EsploraURL:     esplora.URL,
+		ChainParams:    &chaincfg.RegressionNetParams,
+		PollInterval:   time.Hour,
+		RecoveryWindow: 10,
+		DBDir:          t.TempDir(),
+		Log:            fn.None[btclog.Logger](),
+	})
+	require.NoError(t, err)
+	require.NoError(t, w.Start())
+	t.Cleanup(w.Stop)
+
+	return w
+}
+
+// fundConfirmedUTXO records a confirmed credit for the given pkScript directly
+// in btcwallet's transaction store and returns its outpoint. This mirrors
+// btcwallet's own addUtxo test helper: it inserts a transaction paying the
+// script and marks its sole output as a credit at the genesis block.
+func fundConfirmedUTXO(t *testing.T, w *lwwallet.Wallet,
+	pkScript []byte) wire.OutPoint {
+
+	t.Helper()
+
+	const amount = 1_000_000
+	tx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{},
+		},
+		TxOut: []*wire.TxOut{
+			wire.NewTxOut(amount, pkScript),
+		},
+	}
+
+	internal, ok := w.BtcWallet.InternalWallet().(*btcwalletbase.Wallet)
+	require.True(t, ok, "unexpected internal wallet type")
+
+	var buf bytes.Buffer
+	require.NoError(t, tx.Serialize(&buf))
+	rec, err := wtxmgr.NewTxRecord(buf.Bytes(), time.Now())
+	require.NoError(t, err)
+
+	block := &wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Hash:   *chaincfg.RegressionNetParams.GenesisHash,
+			Height: 0,
+		},
+		Time: time.Unix(1, 0),
+	}
+
+	require.NoError(
+		t,
+		walletdb.Update(
+			internal.Database(),
+			func(dbtx walletdb.ReadWriteTx) error {
+				ns := dbtx.ReadWriteBucket([]byte("wtxmgr"))
+				if err := internal.TxStore.InsertTx(
+					ns, rec, block,
+				); err != nil {
+					return err
+				}
+
+				return internal.TxStore.AddCredit(
+					ns, rec, block, 0, false,
+				)
+			},
+		),
+	)
+
+	return wire.OutPoint{Hash: tx.TxHash(), Index: 0}
+}
+
+// containsOutpoint reports whether the given lnwallet UTXOs include op.
+func containsOutpoint(utxos []*lnwallet.Utxo, op wire.OutPoint) bool {
+	for _, u := range utxos {
+		if u.OutPoint == op {
+			return true
+		}
+	}
+
+	return false
+}
+
+// containsFeeInput reports whether the given fee inputs include op.
+func containsFeeInput(utxos []*wallet.Utxo, op wire.OutPoint) bool {
+	for _, u := range utxos {
+		if u.Outpoint == op {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
In this PR, we fix a silent CPFP failure on the `lwwallet` (esplora)
backend where every unroll quietly lost its fee bump. The CPFP child
would fail to finalize with `PSBT is not finalizable` at
`stage=sign_cpfp_child`, after which the broadcaster fell back to
broadcasting the bare, zero-fee ephemeral-anchor parent on its own. That
parent doesn't relay standalone, so the bump was effectively dropped on
the floor.

Fixes #831.

## Root cause

The interesting part here is that this is _not_ a finalization-scope
bug, which is where the issue initially pointed. The wallet's own
derived taproot outputs finalize fine through the default account:
btcwallet's nil-scope `FinalizePsbt` signs P2TR via `ComputeInputScript`
just like p2wkh, independent of the account name. I confirmed this by
porting btcwallet's own `TestFinalizePsbt` to a P2TR fee input against
our pinned version, and it signs cleanly.

The real problem is fee-input _selection_. `lwUnrollWallet.ListUnspent`
fell back to an all-accounts query (`""`) whenever the default account
came up empty:

```go
if len(lnUtxos) == 0 {
        lnUtxos, err = w.Wallet.BtcWallet.ListUnspentWitness(
                minConfs, maxConfs, "",
        )
        ...
}
```

That fallback surfaced imported, watch-only taproot outputs as CPFP fee
inputs. These are boarding outputs imported via `ImportTaprootScript`
(`TaprootFullKeyOnly`): they live in the _imported_ account, and carry
no BIP32 derivation and no spendable key. So btcwallet's `FinalizePsbt`
can't sign them in any scope, skips the input, and `MaybeFinalizeAll`
reports the PSBT as unfinalizable. This also explains the field
symptom, where `ListUnspent` on the default account came back empty
(`utxo_count=2` were both boarding outputs) but the all-accounts fallback
happily handed one back.

I reproduced the exact field log against the pinned btcwallet by
importing a `TaprootFullKeyOnly` output, funding it, and finalizing:

```
default-account utxos=0  all-account utxos=1
FinalizePsbt err = error finalizing PSBT: PSBT is not finalizable
```

## The fix

We drop the all-accounts fallback and let the default account stand on
its own. The default-account filter already excludes the unspendable
imported outputs while still surfacing every wallet-derived,
key-spendable fee input (lwwallet derives its change and sweep addresses
via `NewAddress(TaprootPubkey, DefaultAccountName)`, i.e. BIP86 account
0, which is exactly "default"). The sibling `btcwUnrollWallet.ListUnspent`
path already does precisely this, with a comment saying as much, so this
brings the two backends back in line and matches the function's own
doc comment.

## Test

The regression test in `darepod` builds a real `lwwallet` on a mock
Esplora pinned at the regtest genesis tip, funds an imported boarding
output as the wallet's _only_ UTXO (the field scenario, where the
default account is empty), and asserts fee selection never offers it. It
then funds a wallet-derived taproot output and asserts that one _is_
offered. The test only catches the bug when the imported output is the
sole UTXO: a co-present derived output keeps the default account
non-empty, which hides the fallback entirely. Verified it fails on the
old code and passes on the fix.
