### PR TITLE
walletdk: surface the Lightning payment preimage on settled sends

### DIFF
--- a/rpc/walletdkrpc/wallet.pb.go
+++ b/rpc/walletdkrpc/wallet.pb.go
@@ -4515,7 +4515,12 @@ type WalletEntryProgress struct {
 	// confirmation_height is populated once the source records it.
 	ConfirmationHeight int32 `protobuf:"varint,5,opt,name=confirmation_height,json=confirmationHeight,proto3" json:"confirmation_height,omitempty"`
 	// vtxo_outpoint is populated when a swap observes the Ark vHTLC output.
-	VtxoOutpoint  string `protobuf:"bytes,6,opt,name=vtxo_outpoint,json=vtxoOutpoint,proto3" json:"vtxo_outpoint,omitempty"`
+	VtxoOutpoint string `protobuf:"bytes,6,opt,name=vtxo_outpoint,json=vtxoOutpoint,proto3" json:"vtxo_outpoint,omitempty"`
+	// preimage is the hex-encoded Lightning payment preimage once the swap
+	// revealed it. For a completed Lightning-backed send this is the proof of
+	// payment for the paid invoice (sha256(preimage) == payment_hash); it is
+	// empty until the preimage is durably known and for non-Lightning entries.
+	Preimage      string `protobuf:"bytes,7,opt,name=preimage,proto3" json:"preimage,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4588,6 +4593,13 @@ func (x *WalletEntryProgress) GetConfirmationHeight() int32 {
 func (x *WalletEntryProgress) GetVtxoOutpoint() string {
 	if x != nil {
 		return x.VtxoOutpoint
+	}
+	return ""
+}
+
+func (x *WalletEntryProgress) GetPreimage() string {
+	if x != nil {
+		return x.Preimage
 	}
 	return ""
 }
@@ -4889,7 +4901,7 @@ const file_wallet_proto_rawDesc = "" +
 	"\x15OnchainAddressRequest\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\"-\n" +
 	"\x11ArkAddressRequest\x12\x18\n" +
-	"\aaddress\x18\x01 \x01(\tR\aaddress\"\xf8\x01\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\"\x94\x02\n" +
 	"\x13WalletEntryProgress\x123\n" +
 	"\x05phase\x18\x01 \x01(\x0e2\x1d.walletdkrpc.WalletEntryPhaseR\x05phase\x12\x1f\n" +
 	"\vphase_label\x18\x02 \x01(\tR\n" +
@@ -4897,7 +4909,8 @@ const file_wallet_proto_rawDesc = "" +
 	"\fpayment_hash\x18\x03 \x01(\tR\vpaymentHash\x12\x12\n" +
 	"\x04txid\x18\x04 \x01(\tR\x04txid\x12/\n" +
 	"\x13confirmation_height\x18\x05 \x01(\x05R\x12confirmationHeight\x12#\n" +
-	"\rvtxo_outpoint\x18\x06 \x01(\tR\fvtxoOutpoint*~\n" +
+	"\rvtxo_outpoint\x18\x06 \x01(\tR\fvtxoOutpoint\x12\x1a\n" +
+	"\bpreimage\x18\a \x01(\tR\bpreimage*~\n" +
 	"\tEntryKind\x12\x1a\n" +
 	"\x16ENTRY_KIND_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fENTRY_KIND_SEND\x10\x01\x12\x13\n" +

--- a/rpc/walletdkrpc/wallet.proto
+++ b/rpc/walletdkrpc/wallet.proto
@@ -1182,6 +1182,12 @@ message WalletEntryProgress {
 
     // vtxo_outpoint is populated when a swap observes the Ark vHTLC output.
     string vtxo_outpoint = 6;
+
+    // preimage is the hex-encoded Lightning payment preimage once the swap
+    // revealed it. For a completed Lightning-backed send this is the proof of
+    // payment for the paid invoice (sha256(preimage) == payment_hash); it is
+    // empty until the preimage is durably known and for non-Lightning entries.
+    string preimage = 7;
 }
 
 // EntryFailureCode is a stable, machine-readable classification of why a FAILED

--- a/sdk/walletdk/convert.go
+++ b/sdk/walletdk/convert.go
@@ -326,6 +326,7 @@ func entryProgressFromProto(
 		Txid:               progress.GetTxid(),
 		ConfirmationHeight: progress.GetConfirmationHeight(),
 		VTXOOutpoint:       progress.GetVtxoOutpoint(),
+		Preimage:           progress.GetPreimage(),
 	}
 }
 

--- a/sdk/walletdk/convert_test.go
+++ b/sdk/walletdk/convert_test.go
@@ -18,6 +18,7 @@ func TestEntryFromProto(t *testing.T) {
 		Txid:               "txid",
 		ConfirmationHeight: 7,
 		VtxoOutpoint:       "vtxo:0",
+		Preimage:           "deadbeef",
 	}
 	prog.Phase = walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_SETTLING
 
@@ -64,6 +65,7 @@ func TestEntryFromProto(t *testing.T) {
 	require.Equal(t, "txid", entry.Progress.Txid)
 	require.EqualValues(t, 7, entry.Progress.ConfirmationHeight)
 	require.Equal(t, "vtxo:0", entry.Progress.VTXOOutpoint)
+	require.Equal(t, "deadbeef", entry.Progress.Preimage)
 
 	require.NotNil(t, entry.Request)
 	require.Equal(t, EntryRequestTypeLightning, entry.Request.Type)

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -670,6 +670,12 @@ type EntryProgress struct {
 
 	// VTXOOutpoint is populated when a swap observes the Ark vHTLC output.
 	VTXOOutpoint string
+
+	// Preimage is the hex-encoded Lightning payment preimage once the swap
+	// revealed it. For a completed Lightning-backed send this is the proof
+	// of payment for the paid invoice (sha256(preimage) == PaymentHash); it
+	// is empty until durably known and for non-Lightning entries.
+	Preimage string
 }
 
 // EntryRequestType discriminates which request shape an EntryRequest carries.

--- a/swapwallet/normalize.go
+++ b/swapwallet/normalize.go
@@ -155,6 +155,7 @@ func progressFromSwapSummary(
 		PhaseLabel:   label,
 		PaymentHash:  s.GetPaymentHash(),
 		VtxoOutpoint: s.GetVhtlcOutpoint(),
+		Preimage:     s.GetPreimage(),
 	}
 }
 

--- a/swapwallet/normalize_test.go
+++ b/swapwallet/normalize_test.go
@@ -539,6 +539,33 @@ func TestSwapEntryFromSummaryRequestMetadata(t *testing.T) {
 	require.Empty(t, req.GetInvoice())
 }
 
+// TestSwapEntryFromSummaryPreimage confirms the Lightning payment preimage
+// rides from the swap summary onto the entry's progress once durably known,
+// and stays empty while the send is still in flight. The preimage is the
+// L402 proof-of-payment surfaced on a settled Lightning send.
+func TestSwapEntryFromSummaryPreimage(t *testing.T) {
+	t.Parallel()
+
+	// A completed pay swap with a revealed preimage carries it onto the
+	// progress sub-object so a settle watcher can read it off the row.
+	settled := swapEntryFromSummary(&swapclientrpc.SwapSummary{
+		PaymentHash: "ph",
+		Direction:   swapclientrpc.SwapDirection_SWAP_DIRECTION_PAY,
+		State:       swapclientrpc.SwapState_SWAP_STATE_COMPLETED,
+		Preimage:    "deadbeef",
+	}, "", "", walletdkrpc.EntryKind_ENTRY_KIND_SEND)
+	require.Equal(t, "deadbeef", settled.GetProgress().GetPreimage())
+
+	// A still-pending send has no preimage yet, so the field stays empty.
+	pending := swapEntryFromSummary(&swapclientrpc.SwapSummary{
+		PaymentHash: "ph",
+		Direction:   swapclientrpc.SwapDirection_SWAP_DIRECTION_PAY,
+		State:       swapclientrpc.SwapState_SWAP_STATE_WAITING_FOR_CLAIM,
+		Pending:     true,
+	}, "", "", walletdkrpc.EntryKind_ENTRY_KIND_SEND)
+	require.Empty(t, pending.GetProgress().GetPreimage())
+}
+
 // TestSwapEntryFromSummaryNilSafe confirms a nil input does not
 // panic and returns a usable (empty) WalletEntry.
 func TestSwapEntryFromSummaryNilSafe(t *testing.T) {


### PR DESCRIPTION
In this PR, we surface the Lightning payment preimage on settled `send`
entries so a walletdk caller can read it back as an L402 proof-of-payment.
walletdk can already pay a BOLT11 invoice end to end (`PrepareSend{Invoice}`
→ `SendPrepared`, with the Ark→Lightning swap hidden underneath), and the
swap layer durably observes the preimage when the server claims the funded
vHTLC. Until now that preimage stopped one layer below the wallet surface:
a caller of a settled send could read the `payment_hash` and a settlement
`status`, but not the preimage itself. That's the one missing primitive
keeping a loaded walletdk wallet (including the in-browser/in-Node WASM
build) from being a drop-in L402 `InvoicePayer`.

This is a propagation gap, not new crypto. The value is already observed and
persisted: the swap FSM extracts it in `paySession.waitForClaimPreimage`,
it's stored on the swap status, the `SwapSummary` carries it, and it's even
projected onto `ActivitySwapTrace.preimage` (field 20) via `InspectActivity`.
The streamed `WalletEntry` rows are built from that *same* `SwapSummary` in
`swapEntryFromSummary`, but `WalletEntryProgress` had nowhere to put it, so
it got dropped right at the point that builds the row.

Fixes #835.

## What changed

We add a hex-encoded `preimage` field to `WalletEntryProgress` (field 7),
documented the same way as the existing `ActivitySwapTrace.preimage`:
populated only once durably known for a Lightning-backed send
(`sha256(preimage) == payment_hash`), empty otherwise and for non-Lightning
entries. The daemon sets it in `progressFromSwapSummary` from
`s.GetPreimage()`. Both the `List` path (`history.go`) and the `Subscribe`
live stream (`monitor.go`) build their rows through that same normalizer,
so the field rides both surfaces with no second RPC and no id-correlation
round-trip: a settle watcher reads `progress.preimage` straight off the row
it's already watching.

On the SDK side, we add `Preimage` to the wrapper-owned `walletdk.EntryProgress`
and map it in `entryProgressFromProto`. The mobile facade (`sdk/walletdk/mobile`)
and the WASM bridge (`cmd/walletdk-wasm`) carry it for free: `List` and
`Subscribe` already marshal walletdk types to JSON, so the new field shows
up on the entry objects returned by `walletdkCall("list", …)` and the
`subscribe` handle's `next()` results without a new verb or `case`.

See each commit message for a detailed description w.r.t the incremental
changes.

## Testing

Unit coverage pins both ends of the new path. In `swapwallet`, a new test
asserts a completed pay swap carries the preimage onto the entry while a
still-pending send leaves it empty. In `sdk/walletdk`, the entry-conversion
test now checks the field round-trips through `entryProgressFromProto`
rather than silently drifting.

The full regtest WASM round-trip the issue names as the real acceptance
gate (a live Lightning send showing the hex preimage on a
`walletdkCall("subscribe", …)` entry) is not yet wired up here; the change
is pure additive propagation through a single shared normalizer that both
`List` and `Subscribe` already use, so the unit tests cover each hop.