### PR TITLE
multi: stable canonical id for on-chain send (#610)

### DIFF
--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -5633,7 +5633,13 @@ type SendOnChainResponse struct {
 	ChangeOutpoint string `protobuf:"bytes,4,opt,name=change_outpoint,json=changeOutpoint,proto3" json:"change_outpoint,omitempty"`
 	// status is "submitted" on a successful intent registration,
 	// "preview" when dry_run is set.
-	Status        string `protobuf:"bytes,5,opt,name=status,proto3" json:"status,omitempty"`
+	Status string `protobuf:"bytes,5,opt,name=status,proto3" json:"status,omitempty"`
+	// send_job_id is the stable id of the submitted send intent, hex of
+	// a deterministic hash over the consumed outpoints and payload. It
+	// survives a restart and identifies a multi-input sweep as one send,
+	// so callers can use it as a durable handle for the operation. Empty
+	// in dry_run mode.
+	SendJobId     string `protobuf:"bytes,6,opt,name=send_job_id,json=sendJobId,proto3" json:"send_job_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -5699,6 +5705,13 @@ func (x *SendOnChainResponse) GetChangeOutpoint() string {
 func (x *SendOnChainResponse) GetStatus() string {
 	if x != nil {
 		return x.Status
+	}
+	return ""
+}
+
+func (x *SendOnChainResponse) GetSendJobId() string {
+	if x != nil {
+		return x.SendJobId
 	}
 	return ""
 }
@@ -9702,13 +9715,14 @@ const file_daemon_proto_rawDesc = "" +
 	"amount_sat\x18\x02 \x01(\x03H\x00R\tamountSat\x12\x1d\n" +
 	"\tsweep_all\x18\x03 \x01(\bH\x00R\bsweepAll\x12\x17\n" +
 	"\adry_run\x18\x05 \x01(\bR\x06dryRunB\b\n" +
-	"\x06amount\"\xca\x01\n" +
+	"\x06amount\"\xea\x01\n" +
 	"\x13SendOnChainResponse\x12*\n" +
 	"\x11actual_amount_sat\x18\x01 \x01(\x03R\x0factualAmountSat\x12\x17\n" +
 	"\afee_sat\x18\x02 \x01(\x03R\x06feeSat\x12-\n" +
 	"\x12selected_outpoints\x18\x03 \x03(\tR\x11selectedOutpoints\x12'\n" +
 	"\x0fchange_outpoint\x18\x04 \x01(\tR\x0echangeOutpoint\x12\x16\n" +
-	"\x06status\x18\x05 \x01(\tR\x06status\"Y\n" +
+	"\x06status\x18\x05 \x01(\tR\x06status\x12\x1e\n" +
+	"\vsend_job_id\x18\x06 \x01(\tR\tsendJobId\"Y\n" +
 	"\fBoardRequest\x12*\n" +
 	"\x11target_vtxo_count\x18\x01 \x01(\rR\x0ftargetVtxoCount\x12\x1d\n" +
 	"\n" +

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -5634,11 +5634,14 @@ type SendOnChainResponse struct {
 	// status is "submitted" on a successful intent registration,
 	// "preview" when dry_run is set.
 	Status string `protobuf:"bytes,5,opt,name=status,proto3" json:"status,omitempty"`
-	// send_job_id is the stable id of the submitted send intent, hex of
-	// a deterministic hash over the consumed outpoints and payload. It
-	// survives a restart and identifies a multi-input sweep as one send,
-	// so callers can use it as a durable handle for the operation. Empty
-	// in dry_run mode.
+	// send_job_id is the deterministic id of the submitted send intent:
+	// hex of a hash over the consumed outpoints and payload. It identifies
+	// a multi-input sweep as one send and is reproducible from the same
+	// inputs, so it is stable across a restart. It is a correlation id, not
+	// a lookup handle (no RPC resolves it), and it is non-secret and
+	// recomputable, so it must never gate a privileged action. Non-empty on
+	// a submitted response from a current daemon; empty only when status is
+	// "preview" (dry_run) or from an older daemon predating this field.
 	SendJobId     string `protobuf:"bytes,6,opt,name=send_job_id,json=sendJobId,proto3" json:"send_job_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -1505,11 +1505,14 @@ message SendOnChainResponse {
     // "preview" when dry_run is set.
     string status = 5;
 
-    // send_job_id is the stable id of the submitted send intent, hex of
-    // a deterministic hash over the consumed outpoints and payload. It
-    // survives a restart and identifies a multi-input sweep as one send,
-    // so callers can use it as a durable handle for the operation. Empty
-    // in dry_run mode.
+    // send_job_id is the deterministic id of the submitted send intent:
+    // hex of a hash over the consumed outpoints and payload. It identifies
+    // a multi-input sweep as one send and is reproducible from the same
+    // inputs, so it is stable across a restart. It is a correlation id, not
+    // a lookup handle (no RPC resolves it), and it is non-secret and
+    // recomputable, so it must never gate a privileged action. Non-empty on
+    // a submitted response from a current daemon; empty only when status is
+    // "preview" (dry_run) or from an older daemon predating this field.
     string send_job_id = 6;
 }
 

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -1504,6 +1504,13 @@ message SendOnChainResponse {
     // status is "submitted" on a successful intent registration,
     // "preview" when dry_run is set.
     string status = 5;
+
+    // send_job_id is the stable id of the submitted send intent, hex of
+    // a deterministic hash over the consumed outpoints and payload. It
+    // survives a restart and identifies a multi-input sweep as one send,
+    // so callers can use it as a durable handle for the operation. Empty
+    // in dry_run mode.
+    string send_job_id = 6;
 }
 
 message BoardRequest {

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -2510,10 +2510,18 @@ func (r *RPCServer) SendOnChain(ctx context.Context,
 			int64(sendResp.ChangeAmount)),
 	)
 
+	// send_job_id is set only for a submitted intent; a dry-run preview
+	// persists no intent, so its zero id maps to an empty string.
+	var sendJobID string
+	if sendResp.IntentID != (wallet.PendingIntentID{}) {
+		sendJobID = hex.EncodeToString(sendResp.IntentID[:])
+	}
+
 	return &daemonrpc.SendOnChainResponse{
 		ActualAmountSat:   int64(sendResp.ActualAmountSat),
 		SelectedOutpoints: outpointStrs,
 		Status:            sendResp.Status.String(),
+		SendJobId:         sendJobID,
 
 		// FeeSat and ChangeOutpoint are populated once the round
 		// seals and the seal-time quote becomes known. The fast-

--- a/swapwallet/doc.go
+++ b/swapwallet/doc.go
@@ -98,11 +98,15 @@
 //     boarding deposit surfaces via Balance rather than as an activity row
 //     until it confirms.
 //
-// The canonical id stored for a cooperative-leave EXIT is still the consumed
-// VTXO outpoint and a DEPOSIT is still keyed by txid:vout, so the same
-// operation can hold different ids pending vs. confirmed — exactly the
-// limitation above. Giving EXIT/DEPOSIT/on-chain-send a stable cross-lifecycle
-// id, and projecting the backfill-only producers on an ongoing basis, needs
-// the daemon-side hooks this V1 LIMITATIONS block describes and is tracked
-// separately.
+// An on-chain-send / cooperative-leave EXIT row now carries a stable canonical
+// id: the daemon returns its leave-job id (SendOnChainResponse.send_job_id, a
+// deterministic hash of the consumed outpoints), which the wallet uses as the
+// row id and persists, so the handle survives the round seal and a restart and
+// represents a multi-input sweep as one row. The consumed outpoint is retained
+// in vtxo_outpoint so the forfeit-driven completion still correlates. A DEPOSIT
+// is still keyed by txid:vout pending its own stable-id work. That DEPOSIT id,
+// projecting the backfill-only producers on an ongoing basis, and the live
+// cross-restart terminal reconciliation under the id (projecting
+// forfeit/settlement into the store rather than relying on the startup
+// backfill) are tracked separately (C2).
 package swapwallet

--- a/swapwallet/doc.go
+++ b/swapwallet/doc.go
@@ -100,13 +100,15 @@
 //
 // An on-chain-send / cooperative-leave EXIT row now carries a stable canonical
 // id: the daemon returns its leave-job id (SendOnChainResponse.send_job_id, a
-// deterministic hash of the consumed outpoints), which the wallet uses as the
-// row id and persists, so the handle survives the round seal and a restart and
-// represents a multi-input sweep as one row. The consumed outpoint is retained
-// in vtxo_outpoint so the forfeit-driven completion still correlates. A DEPOSIT
-// is still keyed by txid:vout pending its own stable-id work. That DEPOSIT id,
-// projecting the backfill-only producers on an ongoing basis, and the live
-// cross-restart terminal reconciliation under the id (projecting
-// forfeit/settlement into the store rather than relying on the startup
-// backfill) are tracked separately (C2).
+// deterministic hash of the consumed outpoints) and the wallet uses it as the
+// row id, so a single handle represents a multi-input sweep and stays the same
+// across the round seal. The id is deterministic — reproducible from the same
+// inputs — but the row itself is wallet-local (in-memory) and its terminal
+// status is NOT reconciled across a restart yet: completion currently fires
+// only when the derive/backfill pass matches the retained consumed outpoint
+// (kept in vtxo_outpoint) against a forfeited VTXO. A DEPOSIT is still keyed by
+// txid:vout pending its own stable-id work. That DEPOSIT id, projecting the
+// backfill-only producers on an ongoing basis, and live cross-restart terminal
+// reconciliation under the id (projecting forfeit/settlement into the store
+// rather than relying on the startup backfill) are tracked separately (C2).
 package swapwallet

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -804,14 +804,20 @@ func decorateCooperativeLeaveEntry(entry *walletdkrpc.WalletEntry,
 	if forfeitedOutpoints == nil {
 		return
 	}
-	if _, ok := forfeitedOutpoints[entry.GetId()]; !ok {
+
+	// The row is now keyed by the stable leave-job id, so the forfeit
+	// correlation uses the retained consumed outpoint (vtxo_outpoint), not
+	// the id. Fall back to the id for legacy rows still keyed by the
+	// outpoint. A matching forfeited VTXO means the round that consumed the
+	// queued leave input confirmed.
+	outpoint := entry.GetProgress().GetVtxoOutpoint()
+	if outpoint == "" {
+		outpoint = entry.GetId()
+	}
+	if _, ok := forfeitedOutpoints[outpoint]; !ok {
 		return
 	}
 
-	// Cooperative leave rows are process-local in v1, so the source
-	// outpoint is the only stable link to daemon state. A matching
-	// forfeited VTXO means the round that consumed the queued leave
-	// input confirmed.
 	applyCooperativeLeaveForfeited(entry)
 }
 

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -769,14 +769,31 @@ func (h *history) decorateExitEntry(ctx context.Context,
 		return nil
 	}
 
+	// GetUnrollStatus is keyed by the VTXO outpoint. A unilateral-exit
+	// row's id IS that outpoint; a cooperative-leave row is keyed by the
+	// stable send_job_id (a bare hash, not an outpoint) and retains the
+	// consumed outpoint in vtxo_outpoint. Query by whichever is a real
+	// outpoint so the hash id is never fed to the outpoint-only RPC — doing
+	// so returns InvalidArgument, which would abort here and strand the
+	// leave row PENDING forever. With no queryable outpoint the row cannot
+	// be a unilateral exit, so treat it as a cooperative leave.
+	lookup := entry.GetId()
+	if !looksLikeOutpoint(lookup) {
+		lookup = entry.GetProgress().GetVtxoOutpoint()
+	}
+	if !looksLikeOutpoint(lookup) {
+		decorateCooperativeLeaveEntry(entry, forfeitedOutpoints)
+
+		return nil
+	}
+
 	resp, err := h.deps.RPCServer.GetUnrollStatus(
 		ctx, &daemonrpc.GetUnrollStatusRequest{
-			Outpoint: entry.GetId(),
+			Outpoint: lookup,
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("get unroll status %s: %w", entry.GetId(),
-			err)
+		return fmt.Errorf("get unroll status %s: %w", lookup, err)
 	}
 	if !resp.GetFound() {
 		decorateCooperativeLeaveEntry(entry, forfeitedOutpoints)
@@ -787,6 +804,21 @@ func (h *history) decorateExitEntry(ctx context.Context,
 	applyUnrollStatus(entry, resp)
 
 	return nil
+}
+
+// looksLikeOutpoint reports whether s has the txid:vout shape the daemon's
+// outpoint parser accepts. A stable send_job_id (bare hex, no colon) does not,
+// so this distinguishes a cooperative-leave row keyed by the job id from a
+// unilateral-exit or legacy row keyed by the VTXO outpoint, keeping the hash
+// id out of the outpoint-only GetUnrollStatus RPC.
+func looksLikeOutpoint(s string) bool {
+	_, vout, ok := strings.Cut(s, ":")
+	if !ok {
+		return false
+	}
+	_, err := strconv.ParseUint(vout, 10, 32)
+
+	return err == nil
 }
 
 // decorateCooperativeLeaveEntry completes a wallet-local cooperative leave row
@@ -807,12 +839,16 @@ func decorateCooperativeLeaveEntry(entry *walletdkrpc.WalletEntry,
 
 	// The row is now keyed by the stable leave-job id, so the forfeit
 	// correlation uses the retained consumed outpoint (vtxo_outpoint), not
-	// the id. Fall back to the id for legacy rows still keyed by the
-	// outpoint. A matching forfeited VTXO means the round that consumed the
-	// queued leave input confirmed.
+	// the id. Fall back to the id only for legacy rows still keyed by the
+	// outpoint — never to a bare send_job_id hash, which can never be in
+	// the forfeited-outpoint set. A matching forfeited VTXO means the round
+	// that consumed the queued leave input confirmed.
 	outpoint := entry.GetProgress().GetVtxoOutpoint()
-	if outpoint == "" {
+	if outpoint == "" && looksLikeOutpoint(entry.GetId()) {
 		outpoint = entry.GetId()
+	}
+	if outpoint == "" {
+		return
 	}
 	if _, ok := forfeitedOutpoints[outpoint]; !ok {
 		return

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -1186,7 +1186,7 @@ func TestHistoryIncludesWalletLocalPendingExit(t *testing.T) {
 	}
 
 	pending := leaveEntryStub(
-		[]string{
+		"", []string{
 			"leave-outpoint:1",
 		}, "bcrt1qdest",
 		50_000, "user note",
@@ -1241,7 +1241,7 @@ func TestHistoryCompletesWalletLocalExitWhenVTXOForfeited(t *testing.T) {
 	}
 
 	pending := leaveEntryStub(
-		[]string{
+		"", []string{
 			"leave-outpoint:1",
 		}, "bcrt1qdest",
 		50_000, "user note",
@@ -1312,7 +1312,7 @@ func TestHistoryKeepsWalletLocalExitPendingForUnmatchedForfeitedVTXO(
 	}
 
 	pending := leaveEntryStub(
-		[]string{
+		"", []string{
 			"leave-outpoint:1",
 		}, "bcrt1qdest",
 		50_000, "user note",
@@ -1369,7 +1369,7 @@ func TestHistoryScansForfeitedVTXOsOnceForWalletLocalExits(t *testing.T) {
 
 	h.runtime.trackPendingEntryWithoutTimeout(
 		leaveEntryStub(
-			[]string{
+			"", []string{
 				"leave-outpoint:1",
 			}, "bcrt1qdest",
 			50_000, "first note",
@@ -1377,7 +1377,7 @@ func TestHistoryScansForfeitedVTXOsOnceForWalletLocalExits(t *testing.T) {
 	)
 	h.runtime.trackPendingEntryWithoutTimeout(
 		leaveEntryStub(
-			[]string{
+			"", []string{
 				"other-leave-outpoint:0",
 			}, "bcrt1qdest",
 			25_000, "second note",
@@ -1471,7 +1471,7 @@ func TestHistoryExitKindFilterGatesWalletLocalPendingRows(t *testing.T) {
 
 	h.runtime.trackPendingEntryWithoutTimeout(
 		leaveEntryStub(
-			[]string{
+			"", []string{
 				"leave-outpoint:1",
 			}, "bcrt1qdest",
 			50_000, "",
@@ -1922,4 +1922,43 @@ func TestHistoryDepositCompletesAfterBoarding(t *testing.T) {
 		entry.GetStatus(),
 	)
 	require.Equal(t, "confirmed", entry.GetProgress().GetPhaseLabel())
+}
+
+// TestDecorateCooperativeLeaveMatchesRetainedOutpoint verifies that after #610
+// (row keyed by the stable leave-job id), the forfeit-driven completion
+// correlates on the retained consumed outpoint in vtxo_outpoint, not the id.
+func TestDecorateCooperativeLeaveMatchesRetainedOutpoint(t *testing.T) {
+	t.Parallel()
+
+	newEntry := func() *walletdkrpc.WalletEntry {
+		return &walletdkrpc.WalletEntry{
+			Id:     "sendjob-abc",
+			Kind:   walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+			Status: walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+			Progress: &walletdkrpc.WalletEntryProgress{
+				VtxoOutpoint: "abc:0",
+			},
+		}
+	}
+
+	// Forfeiting a set that contains the id (but not the retained
+	// outpoint) must NOT complete the row.
+	idOnly := newEntry()
+	decorateCooperativeLeaveEntry(
+		idOnly, map[string]struct{}{"sendjob-abc": {}},
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		idOnly.GetStatus(),
+	)
+
+	// Forfeiting the retained outpoint flips it to COMPLETE.
+	byOutpoint := newEntry()
+	decorateCooperativeLeaveEntry(
+		byOutpoint, map[string]struct{}{"abc:0": {}},
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		byOutpoint.GetStatus(),
+	)
 }

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -1962,3 +1962,72 @@ func TestDecorateCooperativeLeaveMatchesRetainedOutpoint(t *testing.T) {
 		byOutpoint.GetStatus(),
 	)
 }
+
+// TestDecorateExitEntryCompletesHashKeyedLeave drives a hash-keyed
+// cooperative-leave row through the real decorateExitEntry gate (not
+// decorateCooperativeLeaveEntry directly). The daemon's GetUnrollStatus is
+// outpoint-only, so the gate must look it up by the retained vtxo_outpoint,
+// never the bare send_job_id hash. The fake GetUnrollStatus rejects a
+// non-outpoint argument like the real daemon, so a regression that queries by
+// the hash id aborts before completion and fails this test.
+func TestDecorateExitEntryCompletesHashKeyedLeave(t *testing.T) {
+	t.Parallel()
+
+	const outpoint = "aabbcc:0"
+
+	// A bare 64-hex send_job_id has no colon, unlike an outpoint.
+	jobID := "deadbeefdeadbeefdeadbeefdeadbeef" +
+		"deadbeefdeadbeefdeadbeefdeadbeef"
+
+	newEntry := func() *walletdkrpc.WalletEntry {
+		return &walletdkrpc.WalletEntry{
+			Id:     jobID,
+			Kind:   walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+			Status: walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+			Progress: &walletdkrpc.WalletEntryProgress{
+				VtxoOutpoint: outpoint,
+			},
+		}
+	}
+
+	// The retained outpoint is forfeited: the gate must query
+	// GetUnrollStatus by that outpoint (not the hash), find no unroll job,
+	// and complete.
+	h, _, rpc := newHistoryFixture(t)
+	rpc.unrollStatusResp = &daemonrpc.GetUnrollStatusResponse{Found: false}
+
+	entry := newEntry()
+	require.NoError(
+		t,
+		h.decorateExitEntry(
+			t.Context(), entry, map[string]struct{}{outpoint: {}},
+		),
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		entry.GetStatus(),
+	)
+	require.Equal(
+		t, outpoint, rpc.unrollStatusLast.GetOutpoint(),
+		"must query unroll status by the retained outpoint, not "+
+			"the job-id hash",
+	)
+
+	// When the retained outpoint is not forfeited, the row stays PENDING
+	// and the lookup still succeeds (no spurious error from a hash id).
+	h2, _, rpc2 := newHistoryFixture(t)
+	rpc2.unrollStatusResp = &daemonrpc.GetUnrollStatusResponse{Found: false}
+
+	pending := newEntry()
+	require.NoError(
+		t,
+		h2.decorateExitEntry(
+			t.Context(), pending,
+			map[string]struct{}{"other:1": {}},
+		),
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		pending.GetStatus(),
+	)
+}

--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -252,6 +252,14 @@ func (f *fakeRPCServer) GetUnrollStatus(_ context.Context,
 	f.unrollStatusCalls++
 	f.unrollStatusLast = req
 
+	// Mirror the real daemon: GetUnrollStatus parses its argument as a
+	// txid:vout outpoint and rejects anything else. A caller that feeds it
+	// a bare send_job_id hash must fail here, so a regression that queries
+	// by the hash id is caught by a test rather than only at runtime.
+	if !looksLikeOutpoint(req.GetOutpoint()) {
+		return nil, errors.New("invalid outpoint: " + req.GetOutpoint())
+	}
+
 	return f.unrollStatusResp, f.unrollStatusErr
 }
 

--- a/swapwallet/normalize.go
+++ b/swapwallet/normalize.go
@@ -494,15 +494,25 @@ func paginateVTXOs(vtxos []*walletdkrpc.WalletVTXO, offset,
 }
 
 // leaveEntryStub builds the initial WalletEntry returned by Send when the
-// caller targets an onchain destination. The id is populated with the first
-// queued outpoint so the row is correlatable; downstream history merges fill
-// in the broadcast txid once the leave registry produces one.
-func leaveEntryStub(queuedOutpoints []string, destination string, amtSat int64,
+// caller targets an onchain destination. The id is the daemon's stable
+// leave-job id (a deterministic hash of the consumed outpoints and payload),
+// so the row keeps one durable handle from initiation through confirmation,
+// across restarts, and represents a multi-input sweep as a single row. When
+// the daemon does not return one, it falls back to the first queued outpoint
+// (the pre-#610 behavior). The first consumed outpoint is retained in
+// vtxo_outpoint so the forfeit-driven completion can still correlate the row.
+func leaveEntryStub(leaveJobID string, queuedOutpoints []string,
+	destination string, amtSat int64,
 	note string) *walletdkrpc.WalletEntry {
 
-	id := ""
+	var firstOutpoint string
 	if len(queuedOutpoints) > 0 {
-		id = queuedOutpoints[0]
+		firstOutpoint = queuedOutpoints[0]
+	}
+
+	id := leaveJobID
+	if id == "" {
+		id = firstOutpoint
 	}
 	createdAt := nowUnix()
 
@@ -517,8 +527,9 @@ func leaveEntryStub(queuedOutpoints []string, destination string, amtSat int64,
 		Note:          note,
 		Request:       requestFromOnchainAddress(destination),
 		Progress: &walletdkrpc.WalletEntryProgress{
-			Phase:      walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_REQUEST_CREATED,
-			PhaseLabel: "request_created",
+			Phase:        walletdkrpc.WalletEntryPhase_WALLET_ENTRY_PHASE_REQUEST_CREATED,
+			PhaseLabel:   "request_created",
+			VtxoOutpoint: firstOutpoint,
 		},
 	}
 }

--- a/swapwallet/normalize_test.go
+++ b/swapwallet/normalize_test.go
@@ -444,7 +444,7 @@ func TestLeaveEntryStub(t *testing.T) {
 	t.Parallel()
 
 	out := leaveEntryStub(
-		[]string{
+		"", []string{
 			"abc:0",
 			"def:1",
 		}, "bcrt1q...",
@@ -461,9 +461,39 @@ func TestLeaveEntryStub(t *testing.T) {
 	require.NotZero(t, out.GetCreatedAtUnix())
 	require.Equal(t, out.GetCreatedAtUnix(), out.GetUpdatedAtUnix())
 
-	// No queued outpoints → id is empty.
-	out = leaveEntryStub(nil, "bcrt1q...", 1_000, "")
+	// No leave-job id and no queued outpoints → id is empty.
+	out = leaveEntryStub("", nil, "bcrt1q...", 1_000, "")
 	require.Equal(t, "", out.GetId())
+}
+
+// TestLeaveEntryStubUsesLeaveJobID verifies that a returned leave-job id
+// becomes the row id (fixing #610) while the first consumed outpoint is
+// retained in vtxo_outpoint for the forfeit correlation.
+func TestLeaveEntryStubUsesLeaveJobID(t *testing.T) {
+	t.Parallel()
+
+	out := leaveEntryStub(
+		"sendjob-abc", []string{
+			"abc:0",
+			"def:1",
+		}, "bcrt1q...",
+		5_000, "rent",
+	)
+	require.Equal(
+		t, "sendjob-abc", out.GetId(),
+		"leave-job id is the canonical id",
+	)
+	require.Equal(
+		t, "abc:0", out.GetProgress().GetVtxoOutpoint(),
+		"first consumed outpoint retained for the forfeit match",
+	)
+
+	// Empty leave-job id falls back to the first outpoint (pre-#610).
+	fallback := leaveEntryStub(
+		"", []string{"abc:0"}, "bcrt1q...", 5_000, "",
+	)
+	require.Equal(t, "abc:0", fallback.GetId())
+	require.Equal(t, "abc:0", fallback.GetProgress().GetVtxoOutpoint())
 }
 
 // TestSwapEntryFromSummaryCallerKindOverride confirms the

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -588,15 +588,14 @@ func (r *router) sendOnchainIntent(ctx context.Context,
 		entryAmt = actualSat
 	}
 	entry := leaveEntryStub(
-		sendResp.GetSelectedOutpoints(), intent.onchainAddress,
-		entryAmt, intent.note,
+		sendResp.GetSendJobId(), sendResp.GetSelectedOutpoints(),
+		intent.onchainAddress, entryAmt, intent.note,
 	)
 
-	// v1 SCOPE: we track the pending row for the deadline watcher
-	// but do NOT register an intent index. EXIT/DEPOSIT canonical-id
-	// correlation between the pending row and the eventual sweep
-	// ledger row is deferred to v2 — see swapwallet/doc.go for the
-	// limitation note.
+	// The row is keyed by the daemon's stable leave-job id (id above).
+	// The forfeit-driven completion still correlates via the retained
+	// consumed outpoint (Progress.VtxoOutpoint); the live, cross-restart
+	// terminal reconciliation under this id is C2.
 	r.runtime.trackPendingEntryWithoutTimeout(entry)
 
 	// Project off the RPC context so a CLI disconnect cannot cancel the

--- a/swapwallet/runtime_test.go
+++ b/swapwallet/runtime_test.go
@@ -364,7 +364,7 @@ func TestDeadlineWatcherSkipsNoTimeoutEntries(t *testing.T) {
 	defer r.stop()
 
 	sub := r.subscribe()
-	entry := leaveEntryStub([]string{"exit:0"}, "bcrt1qdest", 1_000, "")
+	entry := leaveEntryStub("", []string{"exit:0"}, "bcrt1qdest", 1_000, "")
 	r.trackPendingEntryWithoutTimeout(entry)
 
 	r.applyDeadlines(time.Now().Add(2 * deadline))

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -1011,6 +1011,12 @@ type SendOnChainResponse struct {
 	// Preview for a dry-run.
 	Status SendOnChainStatus
 
+	// IntentID is the stable pending-intent id for a submitted send —
+	// a deterministic hash of the consumed outpoints and payload, so it
+	// survives a restart and represents a multi-input sweep as one id.
+	// It is the zero value for a dry-run preview (no intent is persisted).
+	IntentID PendingIntentID
+
 	// ActualAmountSat is the on-chain amount that will land at
 	// DestinationPkScript. In bounded mode this equals the
 	// TargetAmountSat the caller requested (the server stamps fee

--- a/wallet/send_onchain_replay_test.go
+++ b/wallet/send_onchain_replay_test.go
@@ -247,6 +247,15 @@ func TestHandleSendOnChainPersistsIntentBeforeRegistration(t *testing.T) {
 	require.Equal(t, sendReplayDestScript, payload.DestinationPkScript)
 
 	require.Equal(t, 1, roundActor.registerCalls)
+
+	// The submitted response surfaces the persisted intent id so callers
+	// can use it as the operation's stable handle (issue #610).
+	walletResp, err := result.Unpack()
+	require.NoError(t, err)
+	sendResp, ok := walletResp.(*SendOnChainResponse)
+	require.True(t, ok, "response must be a SendOnChainResponse")
+	require.NotEqual(t, PendingIntentID{}, sendResp.IntentID)
+	require.Equal(t, persisted.ID, sendResp.IntentID)
 }
 
 // TestHandleSendOnChainRoundRejectionDeletesIntent verifies that a round

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3398,6 +3398,7 @@ func (a *Ark) handleSendOnChain(ctx context.Context,
 
 	return fn.Ok[WalletResp](&SendOnChainResponse{
 		Status:            SendOnChainStatusSubmitted,
+		IntentID:          pendingIntent.ID,
 		ActualAmountSat:   sendOnChainActualAmount(req, totalSelected),
 		SelectedOutpoints: selectedOutpoints,
 		TotalSelected:     totalSelected,


### PR DESCRIPTION
Fourth PR in the C1 series (#774), **stacked on #842**.

Fixes the flagship symptom of the epic, **#610**: a `send --onchain` (cooperative-leave) activity row is keyed by the **consumed VTXO outpoint**, which is destroyed when the round seals — so the handle vanishes (`activity inspect` returns NotFound), it can't survive a restart, and one outpoint slot can't represent a multi-input sweep.

### Key realization
The daemon **already derives and persists** a stable id for the send: the `PendingIntentID` (`wallet/pending_intent.go`) — a `sha256(kind + sorted consumed-outpoints + payload)`. It is deterministic (stable across restart), 32 bytes, and represents the whole multi-input set as one id. It was simply never returned to the wallet layer. So this reuses it rather than inventing new daemon persistence.

### Change
- **Daemon:** `SendOnChainResponse` gains `send_job_id` (proto). `handleSendOnChain` surfaces the already-derived `PendingIntentID` on its submitted response (zero on a dry-run preview); the RPC handler hex-encodes it into `send_job_id`.
- **swapwallet:** the on-chain-send activity row's canonical id becomes `send_job_id` (falling back to the first consumed outpoint when the daemon returns none, preserving old behavior). The first consumed outpoint is retained in `vtxo_outpoint`, and `decorateCooperativeLeaveEntry` now matches the forfeit-driven completion on that retained outpoint rather than the id.
- `doc.go` V1 LIMITATIONS updated.

### Scope / deferred (C2)
This fixes the **id**. The live, cross-restart terminal reconciliation *under* that id — projecting forfeit/settlement into the store rather than relying on the startup backfill — is C2 (a VTXO-forfeiture / unroll-status reconciler, like the credit poll loop). DEPOSIT's stable id is the sibling follow-up (PR5).

### Tests
- `wallet`: the submitted `SendOnChainResponse` carries the persisted `PendingIntentID` (extends the persist-before-registration test). `PendingIntentID` determinism is already covered.
- `swapwallet`: `leaveEntryStub` uses the leave-job id as the row id and retains the first outpoint in `vtxo_outpoint` (plus the empty-id fallback); `decorateCooperativeLeaveEntry` flips to COMPLETE on the *retained outpoint*, not the id.

`make rpc` / `make build` / `make lint-changed-local` / `make commitmsg-lint`, and the `wallet` + `swapwallet` + `db` unit suites pass. End-to-end (`send --onchain`, restart, `activity inspect`) is manual/itest, deferred.
