### PR TITLE
darepocli: emit a compact JSON summary on successful send

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_send.go
+++ b/cmd/darepocli/darepoclicommands/cmd_send.go
@@ -207,12 +207,18 @@ func walletSend(cmd *cobra.Command, args []string) error {
 					err)
 			}
 
-			if err := printWalletProto(resp); err != nil {
-				return err
-			}
-
 			if noWait, _ := cmd.Flags().GetBool("no-wait"); noWait {
-				return nil
+
+				// Without waiting there is no terminal state to
+				// summarize yet, so echo the dispatched entry
+				// as a compact pending receipt rather than the
+				// full proto dump.
+				return printSendResult(
+					cmd.OutOrStdout(),
+					sendResultFromEntry(
+						resp.GetEntry(),
+					),
+				)
 			}
 
 			return waitForSendTerminal(cmd, resp.GetEntry())
@@ -228,6 +234,7 @@ func walletSend(cmd *cobra.Command, args []string) error {
 // The poll runs over the always-available WalletInspectionService so the wait
 // surface does not depend on the optional swapruntime build. A failed terminal
 // state returns an error so an agent or shell sees a non-zero exit; a timeout
+// emits the latest observed entry as a compact pending receipt on stdout, then
 // returns the last observed status without claiming success or failure.
 func waitForSendTerminal(cmd *cobra.Command,
 	entry *walletdkrpc.WalletEntry) error {
@@ -257,7 +264,22 @@ func waitForSendTerminal(cmd *cobra.Command,
 	out := cmd.ErrOrStderr()
 	lastPhase := ""
 	failedMsg := "send reached a failed state"
+
+	// The daemon has already accepted the send by the time we start
+	// waiting, so any exit that is not a terminal verdict still owes the
+	// caller a machine-readable receipt: emit the latest observed entry as
+	// the compact pending summary on stdout before surfacing the error on
+	// stderr, so a JSON pipeline keeps the id of a payment that may still
+	// settle.
+	lastEntry := entry
+	emitReceipt := func() {
+		_ = printSendResult(
+			cmd.OutOrStdout(), sendResultFromEntry(lastEntry),
+		)
+	}
 	timeoutErr := func() error {
+		emitReceipt()
+
 		return PrintError(
 			"WAIT_TIMEOUT",
 			fmt.Sprintf(
@@ -286,11 +308,19 @@ func waitForSendTerminal(cmd *cobra.Command,
 						return timeoutErr()
 					}
 
+					// The send itself was accepted, so
+					// leave a pending receipt behind even
+					// though inspection broke.
+					emitReceipt()
+
 					return fmt.Errorf("inspect "+
 						"activity: %w", err)
 				}
 
 				inspected := resp.GetEntry()
+				if inspected != nil {
+					lastEntry = inspected
+				}
 				phase := formatEntryPhase(
 					inspected.GetProgress(),
 				)
@@ -301,8 +331,13 @@ func waitForSendTerminal(cmd *cobra.Command,
 
 				switch inspected.GetStatus() {
 				case entryStatusComplete:
-					return printWalletInspectionExpanded(
-						resp,
+					// On success collapse the verbose trace
+					// down to the compact summary; the full
+					// breakdown stays available via `da
+					// activity inspect <id>`.
+					return printSendResult(
+						cmd.OutOrStdout(),
+						sendResultFromInspection(resp),
 					)
 
 				case entryStatusFailed:

--- a/cmd/darepocli/darepoclicommands/send_result.go
+++ b/cmd/darepocli/darepoclicommands/send_result.go
@@ -1,0 +1,122 @@
+package darepoclicommands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+)
+
+// sendResult is the compact summary printed after a send settles. It distills
+// the verbose inspection trace down to the fields a caller actually needs: the
+// amount that left the wallet, the fee, and, for a Lightning send, the payment
+// preimage that proves the invoice was paid. The full ledger, VTXO, and swap
+// breakdown stays available on demand via `da activity inspect <id>`.
+type sendResult struct {
+	// Status is the short terminal status label (e.g. COMPLETE, PENDING).
+	Status string `json:"status"`
+
+	// Kind is the short activity kind label (SEND for this verb).
+	Kind string `json:"kind"`
+
+	// AmountSat is the signed amount that left the wallet in satoshis.
+	AmountSat int64 `json:"amount_sat"`
+
+	// FeeSat is the fee paid for the send in satoshis.
+	FeeSat int64 `json:"fee_sat"`
+
+	// Settlement is the short settlement label (e.g. IN_ARK, LIGHTNING) for
+	// swap-backed sends, omitted when the send did not run over a swap.
+	Settlement string `json:"settlement,omitempty"`
+
+	// Destination is the counterparty summary the daemon recorded for the
+	// send (invoice prefix or onchain address).
+	Destination string `json:"destination,omitempty"`
+
+	// PaymentHash is the Lightning payment hash for invoice sends.
+	PaymentHash string `json:"payment_hash,omitempty"`
+
+	// Preimage is the hex payment preimage, the proof of payment for a
+	// completed Lightning send. It is empty until the swap reveals it.
+	Preimage string `json:"preimage,omitempty"`
+
+	// Txid is the settling transaction id for onchain sends.
+	Txid string `json:"txid,omitempty"`
+
+	// VtxoOutpoint is the settling vHTLC/VTXO outpoint when known.
+	VtxoOutpoint string `json:"vtxo_outpoint,omitempty"`
+
+	// ID is the wallet entry id, the handle for `da activity inspect`.
+	ID string `json:"id"`
+}
+
+// sendResultFromEntry builds the compact summary from a wallet entry alone,
+// used both for the dispatched (still-pending) receipt and as the base for the
+// settled summary.
+func sendResultFromEntry(entry *walletdkrpc.WalletEntry) sendResult {
+	res := sendResult{
+		Status:      formatEntryStatus(entry.GetStatus()),
+		Kind:        formatEntryKind(entry.GetKind()),
+		AmountSat:   entry.GetAmountSat(),
+		FeeSat:      entry.GetFeeSat(),
+		Destination: entry.GetCounterparty(),
+		ID:          entry.GetId(),
+	}
+
+	if progress := entry.GetProgress(); progress != nil {
+		res.PaymentHash = progress.GetPaymentHash()
+		res.Txid = progress.GetTxid()
+		res.VtxoOutpoint = progress.GetVtxoOutpoint()
+	}
+
+	// A freshly dispatched entry may not carry a progress payment hash yet,
+	// so fall back to the one echoed on the original invoice request.
+	if res.PaymentHash == "" {
+		if ln := entry.GetRequest().GetLightningInvoice(); ln != nil {
+			res.PaymentHash = ln.GetPaymentHash()
+		}
+	}
+
+	return res
+}
+
+// sendResultFromInspection builds the settled summary from a terminal
+// inspection response, folding in the swap preimage and settlement type when
+// the send ran over a swap.
+func sendResultFromInspection(
+	resp *walletdkrpc.InspectActivityResponse) sendResult {
+
+	res := sendResultFromEntry(resp.GetEntry())
+
+	if swap := resp.GetSwap(); swap != nil {
+		res.Preimage = swap.GetPreimage()
+		res.Settlement = trimSettlementType(swap.GetSettlementType())
+		if res.PaymentHash == "" {
+			res.PaymentHash = swap.GetPaymentHash()
+		}
+	}
+
+	return res
+}
+
+// printSendResult writes the compact send summary to w as pretty JSON so a
+// shell pipeline can consume it while the phase transitions stay on stderr.
+// Callers pass the command's stdout so tests can capture the output.
+func printSendResult(w io.Writer, res sendResult) error {
+	data, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal send result: %w", err)
+	}
+
+	fmt.Fprintln(w, string(data))
+
+	return nil
+}
+
+// trimSettlementType strips the swap settlement enum prefix down to its short
+// label (SWAP_SETTLEMENT_TYPE_IN_ARK -> IN_ARK).
+func trimSettlementType(s string) string {
+	return strings.TrimPrefix(s, "SWAP_SETTLEMENT_TYPE_")
+}

--- a/cmd/darepocli/darepoclicommands/send_result_test.go
+++ b/cmd/darepocli/darepoclicommands/send_result_test.go
@@ -1,0 +1,123 @@
+package darepoclicommands
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSendResultFromInspectionLightning verifies a settled Lightning send
+// distills down to its amount, fee, payment hash, and, crucially, the preimage
+// proof of payment, pulled from the correlated swap trace.
+func TestSendResultFromInspectionLightning(t *testing.T) {
+	resp := &walletdkrpc.InspectActivityResponse{
+		Entry: &walletdkrpc.WalletEntry{
+			Id:           "hash-id",
+			Kind:         walletdkrpc.EntryKind_ENTRY_KIND_SEND,
+			Status:       entryStatusComplete,
+			AmountSat:    -1000,
+			FeeSat:       0,
+			Counterparty: "lntbs10u1p4ytrgq",
+			Progress: &walletdkrpc.WalletEntryProgress{
+				PaymentHash:  "hash-id",
+				VtxoOutpoint: "5d2f:0",
+			},
+		},
+		Swap: &walletdkrpc.ActivitySwapTrace{
+			Preimage:       "a6837e6d",
+			SettlementType: "SWAP_SETTLEMENT_TYPE_IN_ARK",
+			PaymentHash:    "hash-id",
+		},
+	}
+
+	res := sendResultFromInspection(resp)
+	require.Equal(t, "COMPLETE", res.Status)
+	require.Equal(t, "SEND", res.Kind)
+	require.Equal(t, int64(-1000), res.AmountSat)
+	require.Equal(t, int64(0), res.FeeSat)
+	require.Equal(t, "IN_ARK", res.Settlement)
+	require.Equal(t, "lntbs10u1p4ytrgq", res.Destination)
+	require.Equal(t, "hash-id", res.PaymentHash)
+	require.Equal(t, "a6837e6d", res.Preimage)
+	require.Equal(t, "5d2f:0", res.VtxoOutpoint)
+	require.Equal(t, "hash-id", res.ID)
+
+	// An onchain-only field must stay absent for a Lightning send.
+	require.Empty(t, res.Txid)
+}
+
+// TestSendResultFromEntryFallsBackToRequestHash verifies a dispatched (still
+// pending) receipt recovers the payment hash from the invoice request when the
+// progress snapshot has not surfaced one yet.
+func TestSendResultFromEntryFallsBackToRequestHash(t *testing.T) {
+	entry := &walletdkrpc.WalletEntry{
+		Id:     "entry-id",
+		Kind:   walletdkrpc.EntryKind_ENTRY_KIND_SEND,
+		Status: entryStatusPending,
+		Request: &walletdkrpc.WalletEntryRequest{
+			Request: &walletdkrpc.
+				WalletEntryRequest_LightningInvoice{
+				LightningInvoice: &walletdkrpc.
+					LightningInvoiceRequest{
+					PaymentHash: "req-hash",
+				},
+			},
+		},
+	}
+
+	res := sendResultFromEntry(entry)
+	require.Equal(t, "PENDING", res.Status)
+	require.Equal(t, "req-hash", res.PaymentHash)
+	require.Empty(t, res.Preimage)
+	require.Empty(t, res.Settlement)
+}
+
+// TestPrintSendResult verifies the compact summary renders as pretty JSON on
+// the provided writer and that empty optional fields are omitted entirely, so
+// a pipeline can key off field presence.
+func TestPrintSendResult(t *testing.T) {
+	var buf bytes.Buffer
+	res := sendResult{
+		Status:    "COMPLETE",
+		Kind:      "SEND",
+		AmountSat: -1000,
+		FeeSat:    2,
+		Preimage:  "a6837e6d",
+		ID:        "entry-id",
+	}
+	require.NoError(t, printSendResult(&buf, res))
+
+	// The output must be a single well-formed JSON document followed by a
+	// trailing newline so `da send | jq` consumes it cleanly.
+	require.True(t, bytes.HasSuffix(buf.Bytes(), []byte("\n")))
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	require.Equal(t, "COMPLETE", decoded["status"])
+	require.Equal(t, "SEND", decoded["kind"])
+	require.Equal(t, float64(-1000), decoded["amount_sat"])
+	require.Equal(t, float64(2), decoded["fee_sat"])
+	require.Equal(t, "a6837e6d", decoded["preimage"])
+	require.Equal(t, "entry-id", decoded["id"])
+
+	// Optional fields left empty must be omitted, not rendered as empty
+	// strings.
+	require.NotContains(t, decoded, "settlement")
+	require.NotContains(t, decoded, "txid")
+	require.NotContains(t, decoded, "payment_hash")
+	require.NotContains(t, decoded, "vtxo_outpoint")
+	require.NotContains(t, decoded, "destination")
+}
+
+// TestTrimSettlementType verifies the settlement enum prefix is stripped to its
+// short label and non-prefixed input is left untouched.
+func TestTrimSettlementType(t *testing.T) {
+	require.Equal(
+		t, "IN_ARK", trimSettlementType("SWAP_SETTLEMENT_TYPE_IN_ARK"),
+	)
+	require.Equal(t, "", trimSettlementType(""))
+	require.Equal(t, "LIGHTNING", trimSettlementType("LIGHTNING"))
+}


### PR DESCRIPTION
In this PR, we clean up what `da send` prints on success. Right now a
completed send is a wall of text: first the full dispatch entry dumped as
JSON, then the entire markdown inspection trace (the activity block, the
swap block, the whole VTXO set, every ledger row, and the correlation
notes). The invoice string alone shows up four times across roughly ninety
lines, and the one thing you actually want back, the payment preimage, is
buried somewhere in the middle.

We collapse all of that down to a single compact JSON object. On a terminal
completion we print the distilled summary and stop:

```json
{
  "status": "COMPLETE",
  "kind": "SEND",
  "amount_sat": -1000,
  "fee_sat": 0,
  "settlement": "IN_ARK",
  "destination": "lntbs10u1p4ytrgqpp56wep0fmm4l8d9",
  "payment_hash": "d3b217a77bafced29fece043f417dafe91fd8c060f238e2681628e9f9033f14d",
  "preimage": "a6837e6d587a7a297fa7a35fbf22a67fdcbed60b9c1ddc12cac22723fc22c1c9",
  "vtxo_outpoint": "5d2f5b892ca87f7857e9bf80a9a013afe5bacb05cf51326670183f2c74f3ff65:0",
  "id": "d3b217a77bafced29fece043f417dafe91fd8c060f238e2681628e9f9033f14d"
}
```

That's the amount that left the wallet, the fee, the settlement rail, and,
for a Lightning send, the preimage that proves the invoice was paid. The
`id` is the handle you feed to `da activity inspect <id>` when you do want
the full ledger, VTXO, and swap breakdown, so nothing is lost, it just
moves off the happy path.

## What changed

The dispatch-time proto dump is dropped from the waiting path. The `phase:`
transitions already narrate progress on stderr, so echoing the raw entry
before we even start waiting was pure noise. `--no-wait` now echoes the same
compact receipt instead of the raw proto, so the two modes match.

The failed path is deliberately left alone: a send that fails is exactly
when you want the expanded trace, since the ledger and VTXO rows are what
you'll be staring at to figure out what went sideways.

stdout stays machine-readable JSON and the `phase:` lines stay on stderr, so
a shell pipeline can keep consuming the body while a human watching the
terminal still sees progress.

See each commit message for a detailed description w.r.t the incremental
changes.
