### PR TITLE
lndbackend+txconfirm: fix CPFP fee-input selection on the LND backend

### DIFF
--- a/darepod/server.go
+++ b/darepod/server.go
@@ -4783,12 +4783,21 @@ type lndUnrollWallet struct {
 	boardingBackend *lndbackend.BoardingBackend
 }
 
-// ListUnspent delegates to the boarding backend's wallet UTXO
-// enumeration.
+// ListUnspent returns UTXOs from LND's default wallet account only.
+//
+// The boarding backend's unfiltered enumeration also surfaces imported
+// watch-only script outputs (boarding and exit scripts tracked via
+// ImportTaprootScript). Those are not signable by LND's FinalizePsbt, so
+// offering them as CPFP fee inputs makes the child PSBT unsignable and the
+// fee bump fails with "PSBT is not finalizable". Restricting fee selection
+// to the default account keeps selection aligned with what the finalize
+// path can actually sign, mirroring the lwwallet and btcwallet adapters.
 func (w *lndUnrollWallet) ListUnspent(ctx context.Context, minConfs,
 	maxConfs int32) ([]*wallet.Utxo, error) {
 
-	return w.boardingBackend.ListUnspent(ctx, minConfs, maxConfs)
+	return w.boardingBackend.ListUnspentDefaultAccount(
+		ctx, minConfs, maxConfs,
+	)
 }
 
 // NewWalletPkScript returns a fresh wallet-managed taproot pkScript suitable

--- a/darepod/unroll_fee_input_test.go
+++ b/darepod/unroll_fee_input_test.go
@@ -140,7 +140,8 @@ func newFundedLwWallet(t *testing.T) *lwwallet.Wallet {
 	t.Cleanup(esplora.Close)
 
 	w, err := lwwallet.New(lwwallet.Config{
-		Seed:           seed,
+		Seed:           seed[:],
+		WalletPassword: []byte("test-password"),
 		EsploraURL:     esplora.URL,
 		ChainParams:    &chaincfg.RegressionNetParams,
 		PollInterval:   time.Hour,

--- a/lndbackend/boarding_backend.go
+++ b/lndbackend/boarding_backend.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightninglabs/lndclient"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnwallet"
 )
 
 // BoardingBackend implements the wallet.BoardingBackend interface by
@@ -104,15 +105,46 @@ func (l *BoardingBackend) ImportTaprootScript(ctx context.Context,
 // ListUnspent returns all UTXOs known to the LND wallet with confirmation
 // counts between minConfs and maxConfs. Converts from lnwallet.Utxo to the
 // wallet package's Utxo type.
+//
+// The result spans every wallet account, including imported watch-only
+// script outputs (e.g. boarding scripts tracked via ImportTaprootScript).
+// Callers that need outputs the wallet can unilaterally sign, such as CPFP
+// fee-input selection, must use ListUnspentDefaultAccount instead.
 func (l *BoardingBackend) ListUnspent(ctx context.Context, minConfs,
 	maxConfs int32) ([]*wallet.Utxo, error) {
+
+	return l.listUnspent(ctx, minConfs, maxConfs)
+}
+
+// ListUnspentDefaultAccount returns UTXOs from LND's default wallet account
+// only. This excludes imported watch-only script outputs (boarding and exit
+// scripts imported via ImportTaprootScript), which the wallet merely tracks
+// and cannot unilaterally sign. CPFP fee-input selection must use this
+// variant: offering a watch-only output as a fee input makes the child PSBT
+// unsignable and the fee bump fails with "PSBT is not finalizable".
+func (l *BoardingBackend) ListUnspentDefaultAccount(ctx context.Context,
+	minConfs, maxConfs int32) ([]*wallet.Utxo, error) {
+
+	return l.listUnspent(
+		ctx, minConfs, maxConfs,
+		lndclient.WithUnspentAccount(lnwallet.DefaultAccountName),
+	)
+}
+
+// listUnspent performs the walletKit ListUnspent call with the supplied
+// options and converts the results to the wallet package's Utxo type.
+func (l *BoardingBackend) listUnspent(ctx context.Context, minConfs,
+	maxConfs int32, opts ...lndclient.ListUnspentOption) ([]*wallet.Utxo,
+	error) {
 
 	l.logger(ctx).TraceS(ctx, "Listing unspent UTXOs from LND wallet",
 		slog.Int("min_confs", int(minConfs)),
 		slog.Int("max_confs", int(maxConfs)),
 	)
 
-	lndUtxos, err := l.walletKit.ListUnspent(ctx, minConfs, maxConfs)
+	lndUtxos, err := l.walletKit.ListUnspent(
+		ctx, minConfs, maxConfs, opts...,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("list unspent: %w", err)
 	}

--- a/lndbackend/boarding_backend_test.go
+++ b/lndbackend/boarding_backend_test.go
@@ -1,0 +1,98 @@
+package lndbackend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeWalletKit stubs the walletKit ListUnspent call, recording the
+// request that the supplied functional options build so tests can assert
+// which account filter (if any) each backend method applies. The embedded
+// interface panics on any other method, which is fine: these tests only
+// exercise UTXO enumeration.
+type fakeWalletKit struct {
+	lndclient.WalletKitClient
+
+	lastReq *walletrpc.ListUnspentRequest
+	utxos   []*lnwallet.Utxo
+}
+
+// ListUnspent records the effective request and returns the configured
+// UTXO set.
+func (f *fakeWalletKit) ListUnspent(_ context.Context, minConfs, maxConfs int32,
+	opts ...lndclient.ListUnspentOption) ([]*lnwallet.Utxo, error) {
+
+	req := &walletrpc.ListUnspentRequest{
+		MinConfs: minConfs,
+		MaxConfs: maxConfs,
+	}
+	for _, opt := range opts {
+		opt(req)
+	}
+	f.lastReq = req
+
+	return f.utxos, nil
+}
+
+// TestListUnspentAccountScoping verifies that the general ListUnspent
+// enumeration spans all accounts while ListUnspentDefaultAccount pins the
+// query to LND's default account. The distinction is what keeps imported
+// watch-only script outputs (boarding/exit scripts) out of CPFP fee-input
+// selection: those coins list fine but LND's FinalizePsbt cannot sign
+// them, so offering one as a fee input fails the child with "PSBT is not
+// finalizable".
+func TestListUnspentAccountScoping(t *testing.T) {
+	t.Parallel()
+
+	utxo := &lnwallet.Utxo{
+		AddressType:   lnwallet.TaprootPubkey,
+		Value:         btcutil.Amount(50_000),
+		Confirmations: 3,
+		PkScript: []byte{
+			0x51,
+			0x20,
+		},
+		OutPoint: wire.OutPoint{
+			Hash: chainhash.Hash{
+				0x01,
+			},
+			Index: 1,
+		},
+	}
+
+	walletKit := &fakeWalletKit{utxos: []*lnwallet.Utxo{utxo}}
+	backend := NewBoardingBackend(walletKit, nil)
+
+	// The unfiltered enumeration must not set an account: callers like
+	// the wallet actor and boarding detection rely on seeing imported
+	// watch-only outputs.
+	utxos, err := backend.ListUnspent(t.Context(), 1, 100)
+	require.NoError(t, err)
+	require.Empty(t, walletKit.lastReq.Account)
+	require.Equal(t, int32(1), walletKit.lastReq.MinConfs)
+	require.Equal(t, int32(100), walletKit.lastReq.MaxConfs)
+
+	// The converted UTXO carries the outpoint, script, and amount.
+	require.Len(t, utxos, 1)
+	require.Equal(t, utxo.OutPoint, utxos[0].Outpoint)
+	require.Equal(t, utxo.PkScript, utxos[0].PkScript)
+	require.Equal(t, utxo.Value, utxos[0].Amount)
+	require.Equal(t, int32(3), utxos[0].Confirmations)
+
+	// The fee-input enumeration pins the default account so only coins
+	// the wallet can unilaterally sign are offered.
+	utxos, err = backend.ListUnspentDefaultAccount(t.Context(), 1, 100)
+	require.NoError(t, err)
+	require.Equal(
+		t, lnwallet.DefaultAccountName, walletKit.lastReq.Account,
+	)
+	require.Len(t, utxos, 1)
+}

--- a/txconfirm/broadcaster.go
+++ b/txconfirm/broadcaster.go
@@ -346,6 +346,17 @@ type CPFPBroadcaster struct {
 	// and released via Evict when the caller's FSM learns the parent
 	// has terminally confirmed or failed.
 	parentStates map[chainhash.Hash]*parentBumpState
+
+	// suspectFeeInputs records wallet outpoints whose CPFP child failed
+	// during signing. Selection deprioritizes these so a coin the signer
+	// has refused (e.g. an imported watch-only script output that leaked
+	// through the backend's UTXO enumeration) cannot keep winning the
+	// smallest-first pick on every retry while signable coins sit idle.
+	// A suspect is still used as a last resort when no other candidate
+	// qualifies, so a transient signing failure (wallet sync lag) cannot
+	// permanently starve fee bumping, and the mark is cleared the moment
+	// the input finalizes successfully.
+	suspectFeeInputs map[wire.OutPoint]struct{}
 }
 
 // NewCPFPBroadcaster creates a new generic CPFP broadcaster helper.
@@ -359,9 +370,10 @@ func NewCPFPBroadcaster(cfg BroadcasterConfig) *CPFPBroadcaster {
 	}
 
 	return &CPFPBroadcaster{
-		cfg:          cfg,
-		log:          cfg.Log.UnwrapOr(btclog.Disabled),
-		parentStates: make(map[chainhash.Hash]*parentBumpState),
+		cfg:              cfg,
+		log:              cfg.Log.UnwrapOr(btclog.Disabled),
+		parentStates:     make(map[chainhash.Hash]*parentBumpState),
+		suspectFeeInputs: make(map[wire.OutPoint]struct{}),
 	}
 }
 
@@ -911,10 +923,14 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 	)
 	if err != nil {
 		return b.fallbackDirectBroadcast(
-			ctx, req, txid, feeInput.Outpoint, "sign_cpfp_child",
+			ctx, req, txid, feeInput.Outpoint, stageSignCPFPChild,
 			err,
 		)
 	}
+
+	// The input signed cleanly, so clear any suspicion recorded from an
+	// earlier transient failure (e.g. wallet sync lag at first pick).
+	delete(b.suspectFeeInputs, feeInput.Outpoint)
 
 	// Preflight the package (parent + signed child) against local node
 	// policy before asking the backend to relay it. A rejection here is
@@ -1050,6 +1066,12 @@ func (b *CPFPBroadcaster) applyReplacementFloor(parent *wire.MsgTx,
 	return feeRate, totalFee
 }
 
+// stageSignCPFPChild names the CPFP setup stage where the child PSBT is
+// signed and finalized. A failure at this stage indicts the selected fee
+// input specifically (the wallet refused to sign it), which is why
+// fallbackDirectBroadcast marks the input as suspect for this stage only.
+const stageSignCPFPChild = "sign_cpfp_child"
+
 // fallbackDirectBroadcast logs one CPFP setup failure and falls back to
 // broadcasting the parent transaction directly.
 //
@@ -1064,6 +1086,16 @@ func (b *CPFPBroadcaster) fallbackDirectBroadcast(ctx context.Context,
 	*BroadcastResult, error) {
 
 	b.releaseFeeOutpoint(ctx, txid, releaseOutpoint)
+
+	// A signing failure means the wallet refused this specific input;
+	// deprioritize it so the next selection prefers a coin with a clean
+	// history. Other stages (fee estimation, change derivation, child
+	// construction) do not indict the input.
+	if stage == stageSignCPFPChild &&
+		releaseOutpoint != (wire.OutPoint{}) {
+
+		b.suspectFeeInputs[releaseOutpoint] = struct{}{}
+	}
 
 	// A fee bump of a funded-anchor parent must never take the direct
 	// fallback: the parent relayed on its own fee and is (or was) already
@@ -1218,19 +1250,36 @@ func (b *CPFPBroadcaster) selectFeeInput(ctx context.Context,
 
 	deadline := time.Now().Add(2 * time.Second)
 
+	var lastSuspect *walletcore.Utxo
 	for {
 		utxos, err := b.cfg.Wallet.ListUnspent(ctx, 1, 9999999)
 		if err != nil {
 			return nil, fmt.Errorf("list unspent: %w", err)
 		}
 
-		var best *walletcore.Utxo
+		// Track the smallest qualifying candidate in two tiers:
+		// coins with a clean signing history, and coins whose CPFP
+		// child previously failed to sign. A suspect only wins when
+		// no clean candidate qualifies, so one unsignable output can
+		// never shadow a signable coin on every retry.
+		var best, bestSuspect *walletcore.Utxo
 		for _, utxo := range utxos {
 			if _, skip := excluded[utxo.Outpoint]; skip {
 				continue
 			}
 
 			if utxo.Amount < minAmount {
+				continue
+			}
+
+			_, suspect := b.suspectFeeInputs[utxo.Outpoint]
+			if suspect {
+				if bestSuspect == nil ||
+					utxo.Amount < bestSuspect.Amount {
+
+					bestSuspect = utxo
+				}
+
 				continue
 			}
 
@@ -1241,6 +1290,9 @@ func (b *CPFPBroadcaster) selectFeeInput(ctx context.Context,
 
 		if best != nil {
 			return feeInputFromWalletUTXO(best), nil
+		}
+		if bestSuspect != nil {
+			lastSuspect = bestSuspect
 		}
 
 		// After one CPFP package confirms, wallet backends
@@ -1259,6 +1311,15 @@ func (b *CPFPBroadcaster) selectFeeInput(ctx context.Context,
 
 		case <-time.After(100 * time.Millisecond):
 		}
+	}
+
+	// No clean candidate materialized within the poll window. Settle for
+	// a previously refused coin rather than giving up outright: if the
+	// earlier signing failure was transient (wallet sync lag), this
+	// retry recovers, and if the coin is genuinely unsignable the sign
+	// step fails exactly as it would have before the deprioritization.
+	if lastSuspect != nil {
+		return feeInputFromWalletUTXO(lastSuspect), nil
 	}
 
 	return nil, fmt.Errorf("%w: no confirmed wallet UTXOs available (need "+

--- a/txconfirm/broadcaster_test.go
+++ b/txconfirm/broadcaster_test.go
@@ -3039,3 +3039,134 @@ func makeWalletUTXOWithAmount(amount btcutil.Amount,
 		Amount: amount,
 	}
 }
+
+// TestSelectFeeInputDeprioritizesSuspects verifies that fee-input
+// selection prefers coins with a clean signing history over coins whose
+// CPFP child previously failed to sign, while still falling back to a
+// suspect coin when nothing else qualifies.
+func TestSelectFeeInputDeprioritizesSuspects(t *testing.T) {
+	t.Parallel()
+
+	tx := makeTestTx(true)
+	txid := tx.TxHash()
+
+	small := makeWalletUTXOWithAmount(5_000, 0x01)
+	big := makeWalletUTXOWithAmount(50_000, 0x02)
+
+	newBroadcaster := func() *CPFPBroadcaster {
+		return NewCPFPBroadcaster(BroadcasterConfig{
+			ChainSource: newFakeChainSourceRef(100),
+			Wallet: &fakeWallet{
+				utxos: []*walletcore.Utxo{small, big},
+			},
+		})
+	}
+
+	t.Run("clean history keeps smallest-first", func(t *testing.T) {
+		b := newBroadcaster()
+
+		feeInput, err := b.selectFeeInput(t.Context(), txid, 100)
+		require.NoError(t, err)
+		require.Equal(t, small.Outpoint, feeInput.Outpoint)
+	})
+
+	t.Run("suspect loses to bigger clean coin", func(t *testing.T) {
+		b := newBroadcaster()
+		b.suspectFeeInputs[small.Outpoint] = struct{}{}
+
+		feeInput, err := b.selectFeeInput(t.Context(), txid, 100)
+		require.NoError(t, err)
+		require.Equal(t, big.Outpoint, feeInput.Outpoint)
+	})
+
+	t.Run("suspect used as last resort", func(t *testing.T) {
+		b := newBroadcaster()
+		b.suspectFeeInputs[small.Outpoint] = struct{}{}
+		b.suspectFeeInputs[big.Outpoint] = struct{}{}
+
+		feeInput, err := b.selectFeeInput(t.Context(), txid, 100)
+		require.NoError(t, err)
+		require.Equal(t, small.Outpoint, feeInput.Outpoint)
+	})
+}
+
+// TestFallbackDirectBroadcastMarksSuspects verifies that only a failure
+// at the CPFP child signing stage indicts the selected fee input; other
+// setup stages leave the input's history clean.
+func TestFallbackDirectBroadcastMarksSuspects(t *testing.T) {
+	t.Parallel()
+
+	tx := makeTestTx(true)
+	txid := tx.TxHash()
+	req := &BroadcastRequest{Tx: tx, Label: "suspect-test"}
+	op := makeWalletUTXOWithAmount(5_000, 0x03).Outpoint
+
+	t.Run("sign failure marks the input", func(t *testing.T) {
+		b := NewCPFPBroadcaster(BroadcasterConfig{
+			ChainSource: newFakeChainSourceRef(100),
+		})
+
+		_, err := b.fallbackDirectBroadcast(
+			t.Context(), req, txid, op, stageSignCPFPChild,
+			fmt.Errorf("PSBT is not finalizable"),
+		)
+		require.NoError(t, err)
+		require.Contains(t, b.suspectFeeInputs, op)
+	})
+
+	t.Run("other stages do not mark", func(t *testing.T) {
+		b := NewCPFPBroadcaster(BroadcasterConfig{
+			ChainSource: newFakeChainSourceRef(100),
+		})
+
+		_, err := b.fallbackDirectBroadcast(
+			t.Context(), req, txid, op, "build_cpfp_child",
+			fmt.Errorf("boom"),
+		)
+		require.NoError(t, err)
+		require.NotContains(t, b.suspectFeeInputs, op)
+	})
+
+	t.Run("zero outpoint is never marked", func(t *testing.T) {
+		b := NewCPFPBroadcaster(BroadcasterConfig{
+			ChainSource: newFakeChainSourceRef(100),
+		})
+
+		_, err := b.fallbackDirectBroadcast(
+			t.Context(), req, txid, wire.OutPoint{},
+			stageSignCPFPChild, fmt.Errorf("boom"),
+		)
+		require.NoError(t, err)
+		require.Empty(t, b.suspectFeeInputs)
+	})
+}
+
+// TestSubmitClearsSuspectAfterSuccessfulSign verifies the end-to-end
+// recovery path: a coin marked suspect from an earlier transient signing
+// failure is still usable as a last resort, and a successful sign clears
+// the suspicion.
+func TestSubmitClearsSuspectAfterSuccessfulSign(t *testing.T) {
+	t.Parallel()
+
+	utxo := makeWalletUTXO(t)
+
+	b := NewCPFPBroadcaster(BroadcasterConfig{
+		ChainSource: newFakeChainSourceRef(100),
+		Wallet: &fakeWallet{
+			utxos: []*walletcore.Utxo{utxo},
+		},
+	})
+
+	// Simulate an earlier signing refusal of the wallet's only coin.
+	b.suspectFeeInputs[utxo.Outpoint] = struct{}{}
+
+	result, err := b.Submit(t.Context(), 100, &BroadcastRequest{
+		Tx:    makeTestTx(true),
+		Label: "suspect-recovery",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.ChildTxid)
+
+	// The sign succeeded, so the coin's history is clean again.
+	require.NotContains(t, b.suspectFeeInputs, utxo.Outpoint)
+}


### PR DESCRIPTION
In this PR, we fix the LND-backend half of #831: CPFP fee-bumping for
unilateral exits silently failing with `PSBT is not finalizable`. Together
with #836 (the lwwallet half), this closes out the issue across all three
wallet adapters.

## The bug

The boarding backend imports boarding and exit taproot scripts into the same
LND wallet that funds CPFP children, and its unfiltered `ListUnspent`
surfaces those watched outputs alongside the wallet's own coins. LND's
`FinalizePsbt` cannot sign an imported tapscript output, so whenever one won
the smallest-first fee-input pick, the child failed to finalize and the fee
bump degraded to a direct broadcast of a zero-fee anchor parent, which cannot
relay on its own. The `lnd / exits-leave-sweep` itest shard shows this
chronically: a green baseline run on master carries 195 finalize warnings,
with retries recovering only when a signable coin happens to arrive. Under a
real relay-fee floor that means a stuck exit, not a slower one.

## The fix

Two commits. First, the backend gains `ListUnspentDefaultAccount`, which pins
the walletKit query to LND's default account via `WithUnspentAccount`, and
`lndUnrollWallet.ListUnspent` routes through it. The unfiltered enumeration
keeps its all-accounts semantics for the wallet actor, sweep, and recovery
callers that legitimately need to see watched outputs. This mirrors the
account scoping the btcwallet adapter already has and the lwwallet adapter
gains in #836.

Second, defense in depth in the broadcaster: a failure at the
`sign_cpfp_child` stage marks the selected outpoint as suspect, and selection
prefers coins with a clean signing history from then on. Suspects only lose
ties, they are not banned; when nothing else qualifies the broadcaster still
settles for one after the sync-lag poll window, so a transient signing
failure cannot permanently starve fee bumping, and a successful sign clears
the mark. Even if a future backend leaks an unsignable coin into fee
selection again, one bad coin can no longer shadow the whole wallet.

## Testing

`TestListUnspentAccountScoping` pins the account filter on the new backend
method (and the absence of one on the general enumeration).
`TestSelectFeeInputDeprioritizesSuspects`,
`TestFallbackDirectBroadcastMarksSuspects`, and
`TestSubmitClearsSuspectAfterSuccessfulSign` cover the selection tiers, the
stage-scoped marking, and the end-to-end recover-and-clear path. Full suites
for `txconfirm`, `lndbackend`, and `darepod` pass, lint is clean.

Closes #831 (together with #836).
