### PR TITLE
oor: fix postgres unit-job deadlock in registry deps test

### DIFF
--- a/oor/registry_test.go
+++ b/oor/registry_test.go
@@ -1938,10 +1938,20 @@ func TestOORRegistryStopDuringInFlightAdmission(t *testing.T) {
 func TestNewOORRegistryActorValidatesRequiredDeps(t *testing.T) {
 	t.Parallel()
 
+	// Share one delivery store across all subtests. The constructor only
+	// checks the dependency for presence, and building the store per
+	// subtest is not just wasteful under the postgres tag, it deadlocks:
+	// each store spins up a docker fixture gated by a package-level
+	// semaphore of four slots, and because this closure captures the
+	// parent t, no fixture is torn down until the whole test ends. The
+	// first four sequential subtests would hold every slot and the fifth
+	// would block on the semaphore until the test binary's timeout.
+	deliveryStore := newTestDeliveryStore(t)
+
 	valid := func() OORRegistryConfig {
 		return OORRegistryConfig{
 			RegistryStore: newFakeRegistryStore(),
-			DeliveryStore: newTestDeliveryStore(t),
+			DeliveryStore: deliveryStore,
 			ServerConn:    fakeServerConnRef{},
 			Signer:        testSigner(t),
 			IncomingHandler: &fakeRecipientFilter{


### PR DESCRIPTION
In this PR, we fix the deterministic 30-minute hang in the `unit
tags="test_postgres"` CI job that has been failing on main and on every PR
since the registry deps-validation test landed.

## Root cause

`TestNewOORRegistryActorValidatesRequiredDeps` builds its base config through
a `valid()` closure, and that closure called `newTestDeliveryStore(t)`, so
every one of the eight subtests spun up its own docker postgres fixture.
Fixture creation is gated by a package-level semaphore
(`testPgFixtureParallelism = 4`), and because the closure captures the
*parent* `t`, the per-fixture cleanups only run when the whole test ends. The
four sequential subtests that run first hold all four slots, and the fifth
(`missing_incoming_handler`) blocks on `acquireTestPgFixtureSlot()` until go
test's 30m timeout kills the binary. That is byte-for-byte the failure
signature in the CI dumps:

```
panic: test timed out after 30m0s
	running tests:
		TestNewOORRegistryActorValidatesRequiredDeps (30m0s)
		TestNewOORRegistryActorValidatesRequiredDeps/missing_incoming_handler (29m46s)
```

The sqlite tag never hit this because its test store is an in-memory open,
not a docker container behind a semaphore.

## The fix

The constructor only checks the dependency for presence, so all subtests can
share a single delivery store: hoist one `newTestDeliveryStore(t)` out of the
closure. Under the postgres tag the test drops from a 30-minute timeout to
about two seconds; the sqlite variant is unaffected.

This unblocks green CI for #836 and #849 (the #831 fix series), both of which
currently fail only this job.
