### PR TITLE
darepod: grant macaroon permissions for credit RPCs

### DIFF
--- a/darepod/rpc_auth.go
+++ b/darepod/rpc_auth.go
@@ -157,11 +157,11 @@ func newDarepodRPCPermissions() map[string][]bakery.Op {
 	swap := swapclientrpc.SwapClientService_ServiceDesc.ServiceName
 	grant(
 		swap, entitySwap, "read", "QuotePay", "ListSwaps", "GetSwap",
-		"SubscribeSwaps",
+		"SubscribeSwaps", "ListCredits",
 	)
 	grant(
 		swap, entitySwap, "write", "StartPay", "StartReceive",
-		"ResumeSwap",
+		"ResumeSwap", "CreateCredit", "RedeemCredit",
 	)
 
 	walletdk := walletdkrpc.WalletService_ServiceDesc.ServiceName

--- a/darepod/rpc_auth_test.go
+++ b/darepod/rpc_auth_test.go
@@ -6,6 +6,8 @@ import (
 	btcrpcserver "github.com/btcsuite/btcwallet/rpc/rpcserver"
 	btcwalletrpc "github.com/btcsuite/btcwallet/rpc/walletrpc"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"gopkg.in/macaroon-bakery.v2/bakery"
@@ -193,6 +195,39 @@ func TestDarepodReadOnlyPermissions(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestDarepodRPCPermissionsCoverDaemonServices registers every service the
+// swapruntime/walletdkrpc daemon serves and asserts the permission map covers
+// all their methods, via the exact check the startup validator runs. Without
+// this, an RPC added without a grant — as happened with the credit RPCs
+// (CreateCredit/RedeemCredit/ListCredits) — only fails when the daemon refuses
+// to boot, not in CI.
+func TestDarepodRPCPermissionsCoverDaemonServices(t *testing.T) {
+	t.Parallel()
+
+	grpcServer := grpc.NewServer()
+	t.Cleanup(grpcServer.Stop)
+
+	daemonrpc.RegisterDaemonServiceServer(
+		grpcServer, &daemonrpc.UnimplementedDaemonServiceServer{},
+	)
+	swapclientrpc.RegisterSwapClientServiceServer(
+		grpcServer,
+		&swapclientrpc.UnimplementedSwapClientServiceServer{},
+	)
+	walletdkrpc.RegisterWalletServiceServer(
+		grpcServer, &walletdkrpc.UnimplementedWalletServiceServer{},
+	)
+	walletdkrpc.RegisterWalletInspectionServiceServer(
+		grpcServer,
+		&walletdkrpc.UnimplementedWalletInspectionServiceServer{},
+	)
+
+	_, err := registeredRPCPermissions(grpcServer)
+	require.NoError(
+		t, err, "every registered method needs a macaroon permission",
+	)
 }
 
 // opActions extracts macaroon action strings for assertions.


### PR DESCRIPTION
## Problem

A daemon built with `swapruntime` and default macaroon settings refuses to start:

```
no macaroon permission registered for /swapclientrpc.SwapClientService/ListCredits
```

The credit RPCs (`CreateCredit`, `RedeemCredit`, `ListCredits`) were added to `SwapClientService` without matching entries in the daemon's macaroon permission map (`darepod/rpc_auth.go`). The startup validator (`registeredRPCPermissions`) requires every registered gRPC method to have a permission entry, so the daemon fails closed before it can serve. This blocks anyone running `main` + `swapruntime`, not just a specific flow.

It slipped through because the existing permission-coverage test only exercised the btcwallet service, never `SwapClientService` / `WalletService`.

## Fix

- Grant the two write credit ops (`CreateCredit`, `RedeemCredit`) and the read `ListCredits` under the existing `swap` entity.
- Add a completeness test that registers the daemon, swap-client, wallet, and wallet-inspection services and runs the exact startup permission check, asserting every served method has a grant. This fails in CI for the whole class of bug, instead of only at daemon boot.

## Testing

- `go test ./darepod/ -run TestDarepodRPCPermissions` passes; the new `TestDarepodRPCPermissionsCoverDaemonServices` fails without the grant.
- Verified manually: before the fix the signet daemon aborts with the error above; after, it boots past permission validation and connects to the operator.

Standalone fix, independent of the C1 activity-log epic.
