### PR TITLE
multi: stable canonical id for boarding deposits (#774)

### DIFF
--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -8011,9 +8011,14 @@ type TransactionHistoryEntry struct {
 	ConfirmationHeight int32 `protobuf:"varint,15,opt,name=confirmation_height,json=confirmationHeight,proto3" json:"confirmation_height,omitempty"`
 	// output_index is the transaction output index associated with txid.
 	// A negative value means the source has no output index.
-	OutputIndex   int32 `protobuf:"varint,16,opt,name=output_index,json=outputIndex,proto3" json:"output_index,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	OutputIndex int32 `protobuf:"varint,16,opt,name=output_index,json=outputIndex,proto3" json:"output_index,omitempty"`
+	// boarding_address is the allocated boarding address a confirmed
+	// boarding-deposit (wallet_utxo_created) row paid to, letting a client
+	// correlate the confirmed row back to its pending deposit row by a
+	// shared, address-scoped id. Empty for every other row type.
+	BoardingAddress string `protobuf:"bytes,17,opt,name=boarding_address,json=boardingAddress,proto3" json:"boarding_address,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *TransactionHistoryEntry) Reset() {
@@ -8156,6 +8161,13 @@ func (x *TransactionHistoryEntry) GetOutputIndex() int32 {
 		return x.OutputIndex
 	}
 	return 0
+}
+
+func (x *TransactionHistoryEntry) GetBoardingAddress() string {
+	if x != nil {
+		return x.BoardingAddress
+	}
+	return ""
 }
 
 type ListTransactionsResponse struct {
@@ -9894,7 +9906,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\tto_unix_s\x18\x02 \x01(\x03R\atoUnixS\x12\x14\n" +
 	"\x05limit\x18\x03 \x01(\rR\x05limit\x12\x16\n" +
 	"\x06offset\x18\x04 \x01(\rR\x06offset\x12\x12\n" +
-	"\x04type\x18\x05 \x01(\tR\x04type\"\x9e\x04\n" +
+	"\x04type\x18\x05 \x01(\tR\x04type\"\xc9\x04\n" +
 	"\x17TransactionHistoryEntry\x12\x16\n" +
 	"\x06source\x18\x01 \x01(\tR\x06source\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x18\n" +
@@ -9914,7 +9926,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\n" +
 	"session_id\x18\x0e \x01(\fR\tsessionId\x12/\n" +
 	"\x13confirmation_height\x18\x0f \x01(\x05R\x12confirmationHeight\x12!\n" +
-	"\foutput_index\x18\x10 \x01(\x05R\voutputIndex\"\x9e\x01\n" +
+	"\foutput_index\x18\x10 \x01(\x05R\voutputIndex\x12)\n" +
+	"\x10boarding_address\x18\x11 \x01(\tR\x0fboardingAddress\"\x9e\x01\n" +
 	"\x18ListTransactionsResponse\x12F\n" +
 	"\ftransactions\x18\x01 \x03(\v2\".daemonrpc.TransactionHistoryEntryR\ftransactions\x12\x1f\n" +
 	"\vnext_offset\x18\x02 \x01(\rR\n" +

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -2195,6 +2195,12 @@ message TransactionHistoryEntry {
     // output_index is the transaction output index associated with txid.
     // A negative value means the source has no output index.
     int32 output_index = 16;
+
+    // boarding_address is the allocated boarding address a confirmed
+    // boarding-deposit (wallet_utxo_created) row paid to, letting a client
+    // correlate the confirmed row back to its pending deposit row by a
+    // shared, address-scoped id. Empty for every other row type.
+    string boarding_address = 17;
 }
 
 message ListTransactionsResponse {

--- a/darepod/rpc_fees.go
+++ b/darepod/rpc_fees.go
@@ -460,6 +460,7 @@ func transactionHistoryRowToProto(row *sqlc.ListTransactionHistoryRow) (
 		SessionId:          row.SessionID,
 		ConfirmationHeight: row.ConfirmationHeight,
 		OutputIndex:        row.OutputIndex,
+		BoardingAddress:    row.BoardingAddress,
 	}, nil
 }
 

--- a/db/ledger_store_test.go
+++ b/db/ledger_store_test.go
@@ -314,6 +314,103 @@ func TestLedgerStoreTransactionHistoryFiltersBeforePagination(t *testing.T) {
 	require.Equal(t, int64(40), sweepRows[0].FeeSat)
 }
 
+// TestLedgerStoreTransactionHistorySurfacesBoardingAddress verifies the
+// history query resolves a confirmed boarding-deposit row back to its
+// allocated boarding address (via boarding_intents -> boarding_addresses), so
+// the client can key the confirmed DEPOSIT row by the same id as its pending
+// row. Non-deposit rows carry no boarding address.
+func TestLedgerStoreTransactionHistorySurfacesBoardingAddress(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store, db := newLedgerStoreAndDBForTest(t)
+
+	// Seed the durable outpoint -> address link: internal key ->
+	// boarding_addresses -> boarding_intents for a confirmed outpoint.
+	keyID := insertTestInternalKey(ctx, t, db, 0x10)
+	pkScript := testBytes(34, 0x20)
+	const addr = "bcrt1qtestboardingaddr"
+	outpointHash := testBytes(32, 0x30)
+	var outpointIndex int32
+
+	require.NoError(
+		t,
+		db.InsertBoardingAddress(
+			ctx, sqlc.InsertBoardingAddressParams{
+				PkScript:       pkScript,
+				AddressString:  addr,
+				ClientKeyID:    keyID,
+				OperatorPubkey: testBytes(33, 0x40),
+				ExitDelay:      144,
+			},
+		),
+	)
+	require.NoError(
+		t,
+		db.InsertBoardingIntent(
+			ctx, sqlc.InsertBoardingIntentParams{
+				OutpointHash:  outpointHash,
+				OutpointIndex: outpointIndex,
+				PkScript:      pkScript,
+				Amount:        100_000,
+				ConfHeight:    500,
+				ConfHash:      testBytes(32, 0x70),
+				ConfTx:        testBytes(64, 0x80),
+				Status:        "confirmed",
+			},
+		),
+	)
+
+	// The confirmed boarding-deposit ledger row, keyed by the same
+	// outpoint.
+	idx := outpointIndex
+	require.NoError(
+		t,
+		store.InsertLedgerEntry(
+			ctx, ledger.LedgerEntry{
+				DebitAccount:   ledger.AccountWalletBalance,
+				CreditAccount:  ledger.AccountOpeningBalance,
+				AmountSat:      100_000,
+				EventType:      ledger.EventWalletUTXOCreated,
+				Description:    "boarding deposit",
+				CreatedAt:      300,
+				IdempotencyKey: testBytes(36, 0x50),
+				ChainTxid:      outpointHash,
+				ChainVout:      &idx,
+			},
+		),
+	)
+
+	rows, err := store.ListTransactionHistory(ctx, "boarding", 0, 0, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, ledger.EventWalletUTXOCreated, rows[0].Subtype)
+	require.Equal(
+		t, addr, rows[0].BoardingAddress,
+		"confirmed boarding deposit must surface its allocated address",
+	)
+
+	// A non-deposit row must not carry a boarding address.
+	require.NoError(
+		t,
+		store.InsertLedgerEntry(
+			ctx, ledger.LedgerEntry{
+				DebitAccount:  ledger.AccountTransfersOut,
+				CreditAccount: ledger.AccountVTXOBalance,
+				AmountSat:     1_000,
+				SessionID:     testBytes(32, 0x60),
+				EventType:     ledger.EventVTXOSent,
+				Description:   "oor send",
+				CreatedAt:     400,
+			},
+		),
+	)
+	oorRows, err := store.ListTransactionHistory(ctx, "oor", 0, 0, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, oorRows, 1)
+	require.Empty(t, oorRows[0].BoardingAddress)
+}
+
 // TestLedgerStoreTransactionHistoryClassifiesOORReceiveWithoutSessionID
 // verifies OOR receive rows are user-visible OOR history even though the
 // ledger cannot stamp session_id on them without colliding on multi-output

--- a/db/sqlc/fee_accounting.sql.go
+++ b/db/sqlc/fee_accounting.sql.go
@@ -425,8 +425,8 @@ FROM (
            -- boarding_address links a confirmed boarding-deposit
            -- (wallet_utxo_created) row back to the allocated boarding
            -- address, so the client can key the confirmed DEPOSIT row by
-           -- the same stable id as its pending row. NULL for every other
-           -- event type.
+           -- the same stable id as its pending row. Empty ('') for every
+           -- other event type; the CASE/COALESCE never yields NULL.
            CASE
                WHEN le.event_type = 'wallet_utxo_created'
                THEN COALESCE(deposit_ba.address_string, '')

--- a/db/sqlc/fee_accounting.sql.go
+++ b/db/sqlc/fee_accounting.sql.go
@@ -365,7 +365,7 @@ const ListTransactionHistory = `-- name: ListTransactionHistory :many
 SELECT source, entry_id, txid, transaction_type, subtype,
        amount_sat, fee_sat, created_at, status, description,
        debit_account, credit_account, round_id, session_id,
-       confirmation_height, output_index
+       confirmation_height, output_index, boarding_address
 FROM (
     SELECT 0 AS source_order,
            'ledger' AS source,
@@ -421,7 +421,17 @@ FROM (
            COALESCE(le.session_id, oor_created.session_id) AS session_id,
            COALESCE(le.confirmation_height, 0) AS confirmation_height,
            COALESCE(le.chain_vout, oor_created.outpoint_index, -1) AS
-               output_index
+               output_index,
+           -- boarding_address links a confirmed boarding-deposit
+           -- (wallet_utxo_created) row back to the allocated boarding
+           -- address, so the client can key the confirmed DEPOSIT row by
+           -- the same stable id as its pending row. NULL for every other
+           -- event type.
+           CASE
+               WHEN le.event_type = 'wallet_utxo_created'
+               THEN COALESCE(deposit_ba.address_string, '')
+               ELSE ''
+           END AS boarding_address
     FROM ledger_entries AS le
     LEFT JOIN oor_vtxo_bindings AS oor_created
         ON oor_created.outpoint_hash = le.chain_txid
@@ -512,6 +522,11 @@ FROM (
     ) AS boarding_round
         ON boarding_round.outpoint_hash = le.chain_txid
        AND boarding_round.outpoint_index = le.chain_vout
+    LEFT JOIN boarding_intents AS deposit_bi
+        ON deposit_bi.outpoint_hash = le.chain_txid
+       AND deposit_bi.outpoint_index = le.chain_vout
+    LEFT JOIN boarding_addresses AS deposit_ba
+        ON deposit_ba.pk_script = deposit_bi.pk_script
 
     UNION ALL
 
@@ -534,7 +549,8 @@ FROM (
            NULL AS round_id,
            b.session_id,
            CAST(0 AS INTEGER) AS confirmation_height,
-           b.outpoint_index AS output_index
+           b.outpoint_index AS output_index,
+           '' AS boarding_address
     FROM oor_vtxo_bindings AS b
     JOIN vtxos AS v
         ON v.outpoint_hash = b.outpoint_hash
@@ -568,7 +584,8 @@ FROM (
            NULL AS round_id,
            NULL AS session_id,
            COALESCE(confirmed_height, 0) AS confirmation_height,
-           CAST(-1 AS INTEGER) AS output_index
+           CAST(-1 AS INTEGER) AS output_index,
+           '' AS boarding_address
     FROM boarding_sweeps
 ) AS history
 WHERE ($1 = ''
@@ -607,6 +624,7 @@ type ListTransactionHistoryRow struct {
 	SessionID          []byte
 	ConfirmationHeight int32
 	OutputIndex        int32
+	BoardingAddress    string
 }
 
 // ListTransactionHistory returns a unified newest-first history from the
@@ -645,6 +663,7 @@ func (q *Queries) ListTransactionHistory(ctx context.Context, arg ListTransactio
 			&i.SessionID,
 			&i.ConfirmationHeight,
 			&i.OutputIndex,
+			&i.BoardingAddress,
 		); err != nil {
 			return nil, err
 		}

--- a/db/sqlc/queries/fee_accounting.sql
+++ b/db/sqlc/queries/fee_accounting.sql
@@ -111,8 +111,8 @@ FROM (
            -- boarding_address links a confirmed boarding-deposit
            -- (wallet_utxo_created) row back to the allocated boarding
            -- address, so the client can key the confirmed DEPOSIT row by
-           -- the same stable id as its pending row. NULL for every other
-           -- event type.
+           -- the same stable id as its pending row. Empty ('') for every
+           -- other event type; the CASE/COALESCE never yields NULL.
            CASE
                WHEN le.event_type = 'wallet_utxo_created'
                THEN COALESCE(deposit_ba.address_string, '')

--- a/db/sqlc/queries/fee_accounting.sql
+++ b/db/sqlc/queries/fee_accounting.sql
@@ -51,7 +51,7 @@ LIMIT $2 OFFSET $3;
 SELECT source, entry_id, txid, transaction_type, subtype,
        amount_sat, fee_sat, created_at, status, description,
        debit_account, credit_account, round_id, session_id,
-       confirmation_height, output_index
+       confirmation_height, output_index, boarding_address
 FROM (
     SELECT 0 AS source_order,
            'ledger' AS source,
@@ -107,7 +107,17 @@ FROM (
            COALESCE(le.session_id, oor_created.session_id) AS session_id,
            COALESCE(le.confirmation_height, 0) AS confirmation_height,
            COALESCE(le.chain_vout, oor_created.outpoint_index, -1) AS
-               output_index
+               output_index,
+           -- boarding_address links a confirmed boarding-deposit
+           -- (wallet_utxo_created) row back to the allocated boarding
+           -- address, so the client can key the confirmed DEPOSIT row by
+           -- the same stable id as its pending row. NULL for every other
+           -- event type.
+           CASE
+               WHEN le.event_type = 'wallet_utxo_created'
+               THEN COALESCE(deposit_ba.address_string, '')
+               ELSE ''
+           END AS boarding_address
     FROM ledger_entries AS le
     LEFT JOIN oor_vtxo_bindings AS oor_created
         ON oor_created.outpoint_hash = le.chain_txid
@@ -198,6 +208,11 @@ FROM (
     ) AS boarding_round
         ON boarding_round.outpoint_hash = le.chain_txid
        AND boarding_round.outpoint_index = le.chain_vout
+    LEFT JOIN boarding_intents AS deposit_bi
+        ON deposit_bi.outpoint_hash = le.chain_txid
+       AND deposit_bi.outpoint_index = le.chain_vout
+    LEFT JOIN boarding_addresses AS deposit_ba
+        ON deposit_ba.pk_script = deposit_bi.pk_script
 
     UNION ALL
 
@@ -220,7 +235,8 @@ FROM (
            NULL AS round_id,
            b.session_id,
            CAST(0 AS INTEGER) AS confirmation_height,
-           b.outpoint_index AS output_index
+           b.outpoint_index AS output_index,
+           '' AS boarding_address
     FROM oor_vtxo_bindings AS b
     JOIN vtxos AS v
         ON v.outpoint_hash = b.outpoint_hash
@@ -254,7 +270,8 @@ FROM (
            NULL AS round_id,
            NULL AS session_id,
            COALESCE(confirmed_height, 0) AS confirmation_height,
-           CAST(-1 AS INTEGER) AS output_index
+           CAST(-1 AS INTEGER) AS output_index,
+           '' AS boarding_address
     FROM boarding_sweeps
 ) AS history
 WHERE (sqlc.arg(type_filter) = ''

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -114,15 +114,17 @@ default builds avoid the swap executor's dependency graph.
   stuck row appears as FAILED even when the caller asks for
   `pending_only=false`.
 - **DEPOSIT rows backed by the `wallet_utxo_created` ledger event**
-  mirror the ledger confirmation status. `Deposit` projects a pending
-  row keyed `deposit-<address>`; the confirmed boarding-deposit ledger
-  row carries the same allocated address
-  (`TransactionHistoryEntry.boarding_address`) and keys to the same id,
-  so the store upsert flips it to `ENTRY_STATUS_COMPLETE`. This is
-  address-granularity: multiple UTXOs to one (single-use-by-design)
-  boarding address collapse into one row. The synthetic
-  `boarding-unconfirmed` row from `GetBalance` is a derive-path-only
-  aggregate, never projected into the store.
+  mirror the ledger confirmation status and are keyed
+  `deposit-<address>` from the confirmed row's
+  `TransactionHistoryEntry.boarding_address`; every UTXO paid to that
+  address is SUMMED into one row (`sumDepositsByAddress`) so a reused
+  address shows its total. `Deposit` does NOT project a row — allocating
+  an address is not a pending deposit — it only returns that id so a
+  caller can correlate the eventual confirmed row. Per-address is the
+  CONFIRMED phase only: unconfirmed boarding funds have no per-address
+  source (the daemon exposes only aggregate `boarding_unconfirmed_sat`),
+  so they surface via `Balance` and the single derive-path-only
+  `boarding-unconfirmed` row, never projected into the store.
 - **`Balance` projection** maps daemonrpc fields onto the walletdkrpc
   shape: `confirmed_sat` is VTXO-only (`vtxo_balance_sat`),
   `pending_in_sat` sums `boarding_confirmed_sat +

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -82,10 +82,15 @@ default builds avoid the swap executor's dependency graph.
 - Background goroutines (monitor loop, deadline watcher, resume
   sweep) are anchored to the daemon root context, NEVER to RPC-call
   contexts. An RPC client disconnect cannot cancel in-flight work.
-- `WalletEntry.id` is the stable canonical id for SEND-invoice and
-  RECV (Lightning payment_hash) across the entire pending → terminal
-  lifecycle. EXIT and DEPOSIT rows do not yet share an id between
-  pending and confirmed in v1; see `doc.go`.
+- `WalletEntry.id` is the stable canonical id across the entire pending
+  → terminal lifecycle for SEND-invoice and RECV (Lightning
+  payment_hash), on-chain-send / cooperative-leave EXIT (the daemon's
+  leave-job id / `send_job_id`), and DEPOSIT (`deposit-<address>`, keyed
+  on the allocated boarding address surfaced on the confirmed history
+  row). A unilateral EXIT still keys by the consumed VTXO outpoint. The
+  pending → COMPLETE transition for EXIT/DEPOSIT lands via the
+  derive/backfill pass; live cross-restart reconciliation is C2. See
+  `doc.go`.
 - Onchain SEND is routed through `RPCServer.SendOnChain` which delegates to
   `wallet.SendOnChainRequest`. Two modes: **sweep-all** (non-empty
   `SweepOutpoints` — drains those VTXOs exactly, no change, leave output
@@ -109,10 +114,15 @@ default builds avoid the swap executor's dependency graph.
   stuck row appears as FAILED even when the caller asks for
   `pending_only=false`.
 - **DEPOSIT rows backed by the `wallet_utxo_created` ledger event**
-  mirror the ledger confirmation status. Confirmed on-chain boarding
-  deposits surface as `ENTRY_STATUS_COMPLETE`, while unconfirmed
-  boarding funds are represented by the synthetic
-  `boarding-unconfirmed` pending row from `GetBalance`.
+  mirror the ledger confirmation status. `Deposit` projects a pending
+  row keyed `deposit-<address>`; the confirmed boarding-deposit ledger
+  row carries the same allocated address
+  (`TransactionHistoryEntry.boarding_address`) and keys to the same id,
+  so the store upsert flips it to `ENTRY_STATUS_COMPLETE`. This is
+  address-granularity: multiple UTXOs to one (single-use-by-design)
+  boarding address collapse into one row. The synthetic
+  `boarding-unconfirmed` row from `GetBalance` is a derive-path-only
+  aggregate, never projected into the store.
 - **`Balance` projection** maps daemonrpc fields onto the walletdkrpc
   shape: `confirmed_sat` is VTXO-only (`vtxo_balance_sat`),
   `pending_in_sat` sums `boarding_confirmed_sat +

--- a/swapwallet/doc.go
+++ b/swapwallet/doc.go
@@ -44,22 +44,25 @@
 // An on-chain-send / cooperative-leave EXIT row keys by the daemon's
 // leave-job id (SendOnChainResponse.send_job_id); see the CANONICAL
 // ACTIVITY LOG note. A DEPOSIT keys by an address-scoped id
-// (deposit-<address>): Deposit projects the pending row under that id, and
-// the confirmed boarding-deposit ledger row carries the same allocated
-// boarding address (TransactionHistoryEntry.boarding_address) so it
-// upserts onto the same canonical id and flips the row to COMPLETE. This
-// is address-granularity, not per-outpoint: multiple UTXOs paid to the
-// same boarding address (which is single-use by design — Deposit issues a
-// fresh address each call) collapse into one DEPOSIT row. As with the
-// leave row, the pending → COMPLETE transition is applied by the
-// derive/backfill pass matching a confirmed/forfeited source, so LIVE
-// cross-restart terminal reconciliation is tracked separately (C2).
+// (deposit-<address>) once the daemon records it on-chain: the confirmed
+// boarding-deposit ledger row carries the allocated boarding address
+// (TransactionHistoryEntry.boarding_address), and every UTXO paid to that
+// address is SUMMED into one deposit-<address> row (sumDepositsByAddress),
+// so a reused boarding address shows its total received rather than
+// hiding funds behind one UTXO. Generating an address does NOT create a
+// row — allocating an address is not a pending deposit — so the row
+// appears only from the point the daemon records an incoming UTXO. The
+// Deposit RPC still returns that same deposit-<address> id so a caller can
+// correlate. An older daemon that does not populate boarding_address falls
+// back to per-UTXO txid:vout deposit rows (no summing, still correct).
 //
-// Remaining v1 gaps: a unilateral EXIT row still keys by the consumed VTXO
-// outpoint with no durable link to its eventual sweep txid; and an older
-// daemon that does not populate boarding_address leaves a DEPOSIT's
-// pending and confirmed rows separately keyed (txid:vout), the pre-change
-// behavior.
+// This is address-granularity for the CONFIRMED (recorded) phase only. The
+// pre-confirmation phase cannot be per-address: the daemon exposes only an
+// aggregate boarding_unconfirmed_sat, so unconfirmed boarding funds surface
+// via Balance and as the single synthetic boarding-unconfirmed row, not a
+// per-address row. Per-address unconfirmed deposits need a daemon change and
+// are deferred. A unilateral EXIT row likewise still keys by the consumed
+// VTXO outpoint with no durable link to its eventual sweep txid.
 //
 // Onchain SEND sweep semantics: a bounded onchain send (amt_sat > 0)
 // lands exactly amt_sat at the destination and returns the remainder as

--- a/swapwallet/doc.go
+++ b/swapwallet/doc.go
@@ -41,21 +41,25 @@
 // swap subserver's row keys by Lightning payment_hash, which the wallet
 // layer also uses as the canonical id, so the projection is a no-op.
 //
-// EXIT and DEPOSIT operations DO surface a row at submit time and a
-// separate confirmed ledger row later, but the two rows do NOT share an
-// id in v1 because there is no daemon-side notification hook that links
-// (a) an exit's queued outpoints to its eventual sweep txid, or (b) a
-// deposit's boarding address to its eventual boarding txid. Cooperative
-// leave rows can still complete while the original runtime-local row is
-// alive: once the source VTXO is terminally forfeited, the pending EXIT
-// row is shown as COMPLETE. After restart, however, the daemon cannot
-// recreate the original counterparty/note from durable state alone. A v2
-// canonical-id projection lands when the daemon exposes the missing
-// hooks; the right home for that link is the daemon-side persistence
-// (leave job, deposit address record), not a process-local map. Callers
-// that need to correlate EXIT/DEPOSIT pending → confirmed across restart
-// in v1 should track the WalletEntry.Counterparty (truncated bech32
-// address or txid) and the persisted ledger txid via separate queries.
+// An on-chain-send / cooperative-leave EXIT row keys by the daemon's
+// leave-job id (SendOnChainResponse.send_job_id); see the CANONICAL
+// ACTIVITY LOG note. A DEPOSIT keys by an address-scoped id
+// (deposit-<address>): Deposit projects the pending row under that id, and
+// the confirmed boarding-deposit ledger row carries the same allocated
+// boarding address (TransactionHistoryEntry.boarding_address) so it
+// upserts onto the same canonical id and flips the row to COMPLETE. This
+// is address-granularity, not per-outpoint: multiple UTXOs paid to the
+// same boarding address (which is single-use by design — Deposit issues a
+// fresh address each call) collapse into one DEPOSIT row. As with the
+// leave row, the pending → COMPLETE transition is applied by the
+// derive/backfill pass matching a confirmed/forfeited source, so LIVE
+// cross-restart terminal reconciliation is tracked separately (C2).
+//
+// Remaining v1 gaps: a unilateral EXIT row still keys by the consumed VTXO
+// outpoint with no durable link to its eventual sweep txid; and an older
+// daemon that does not populate boarding_address leaves a DEPOSIT's
+// pending and confirmed rows separately keyed (txid:vout), the pre-change
+// behavior.
 //
 // Onchain SEND sweep semantics: a bounded onchain send (amt_sat > 0)
 // lands exactly amt_sat at the destination and returns the remainder as

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -1399,9 +1399,13 @@ func walletEntryFromLedgerRow(t *daemonrpc.TransactionHistoryEntry) (
 }
 
 // ledgerActivityID returns the stable activity id for one ledger-backed row.
-// Boarding UTXO creation rows are identified by outpoint, not bare txid, so a
-// single Bitcoin transaction that pays multiple wallet-owned outputs surfaces
-// every deposit instead of collapsing them during activity de-duplication.
+// A confirmed boarding-deposit (wallet_utxo_created) row is keyed by
+// deposit-<boarding_address> when the daemon surfaces the address, so it shares
+// the id of the pending row Deposit projected and upserts onto it. It falls
+// back to txid:vout for an older daemon that does not set boarding_address, and
+// then to the bare txid. Because the key is the address, multiple UTXOs paid to
+// the same (single-use-by-design) boarding address collapse into one row; the
+// ledger and the ONCHAIN view retain the per-UTXO truth.
 func ledgerActivityID(t *daemonrpc.TransactionHistoryEntry,
 	kind walletdkrpc.EntryKind) string {
 

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -936,14 +936,56 @@ func (h *history) collectLedgerEntries(ctx context.Context, offset,
 			entry.AmountSat = amount
 		}
 
-		// v1 SCOPE: EXIT and DEPOSIT ledger rows carry txid but no
-		// link back to the original pending intent, so they
-		// surface under their synthetic id (the ledger txid or
-		// the entry_id fallback). See swapwallet/doc.go.
 		out = append(out, entry)
 	}
 
-	return out, nil
+	// Confirmed boarding deposits keyed by deposit-<address> (the daemon
+	// surfaced the boarding address) are summed per address so multiple
+	// UTXOs paid to the same address show their total rather than
+	// overwriting each other. See sumDepositsByAddress.
+	return sumDepositsByAddress(out), nil
+}
+
+// sumDepositsByAddress collapses boarding-deposit rows that share a canonical
+// id into one row whose amount is the SUM of every UTXO under that id, so a
+// reused boarding address (multiple UTXOs → one deposit-<address> id) shows the
+// total received instead of a single UTXO's amount. Rows with a unique id
+// (older-daemon txid:vout deposits, and every non-deposit row) form a group of
+// one and pass through unchanged. The most-recently-updated row in each group
+// supplies the non-amount fields (status, phase, txid), so the collapsed row
+// reflects the latest deposit's state with the correct running total. Order is
+// not preserved; deriveActivity re-sorts by updated_at.
+func sumDepositsByAddress(
+	entries []*walletdkrpc.WalletEntry) []*walletdkrpc.WalletEntry {
+
+	sums := make(map[string]int64)
+	rep := make(map[string]*walletdkrpc.WalletEntry)
+	out := make([]*walletdkrpc.WalletEntry, 0, len(entries))
+
+	for _, e := range entries {
+		id := e.GetId()
+		if e.GetKind() != walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT ||
+			id == "" {
+
+			out = append(out, e)
+
+			continue
+		}
+
+		sums[id] += e.GetAmountSat()
+		if cur, ok := rep[id]; !ok ||
+			e.GetUpdatedAtUnix() >= cur.GetUpdatedAtUnix() {
+
+			rep[id] = e
+		}
+	}
+
+	for id, e := range rep {
+		e.AmountSat = sums[id]
+		out = append(out, e)
+	}
+
+	return out
 }
 
 // swapOORCorrelations keeps the swap-side session metadata needed to hide

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -1436,7 +1436,14 @@ func walletEntryFromLedgerRow(t *daemonrpc.TransactionHistoryEntry) (
 		Counterparty:  ledgerCounterparty(t, kind),
 		CreatedAtUnix: t.GetCreatedAtUnixS(),
 		UpdatedAtUnix: t.GetCreatedAtUnixS(),
-		Progress:      progressFromLedgerRow(t),
+		// A confirmed boarding deposit carries its allocated address as
+		// a structured onchain-address request, so a client reads the
+		// deposit address from request.onchain_address rather than
+		// parsing it out of the deposit-<address> id. Nil for every
+		// non-deposit row and for an older daemon that does not surface
+		// boarding_address.
+		Request:  requestFromOnchainAddress(t.GetBoardingAddress()),
+		Progress: progressFromLedgerRow(t),
 	}, true
 }
 

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -1410,9 +1410,20 @@ func ledgerActivityID(t *daemonrpc.TransactionHistoryEntry,
 	}
 
 	if kind == walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT &&
-		t.GetSubtype() == ledger.EventWalletUTXOCreated &&
-		t.GetOutputIndex() >= 0 {
-		return fmt.Sprintf("%s:%d", t.GetTxid(), t.GetOutputIndex())
+		t.GetSubtype() == ledger.EventWalletUTXOCreated {
+
+		// Prefer the address-scoped id so the confirmed deposit row
+		// shares a canonical id with the pending deposit-<address> row
+		// projected by Deposit, letting the store upsert flip it to
+		// COMPLETE. Fall back to txid:vout for older daemons that do
+		// not surface the boarding address on the history row.
+		if addr := t.GetBoardingAddress(); addr != "" {
+			return fmt.Sprintf("deposit-%s", addr)
+		}
+		if t.GetOutputIndex() >= 0 {
+			return fmt.Sprintf("%s:%d", t.GetTxid(),
+				t.GetOutputIndex())
+		}
 	}
 
 	return t.GetTxid()

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -2017,9 +2017,13 @@ func TestHistoryDepositKeyedByBoardingAddress(t *testing.T) {
 	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{})
 	require.NoError(t, err)
 	require.Len(t, resp.GetActivity().GetEntries(), 1)
+	entry := resp.GetActivity().GetEntries()[0]
+	require.Equal(t, "deposit-bcrt1qboardingaddr", entry.GetId())
 	require.Equal(
-		t, "deposit-bcrt1qboardingaddr",
-		resp.GetActivity().GetEntries()[0].GetId(),
+		t, "bcrt1qboardingaddr",
+		entry.GetRequest().GetOnchainAddress().GetAddress(),
+		"confirmed deposit must carry its address as a structured "+
+			"request",
 	)
 }
 

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -2023,6 +2023,53 @@ func TestHistoryDepositKeyedByBoardingAddress(t *testing.T) {
 	)
 }
 
+// TestHistoryDepositsSameAddressSummed verifies two confirmed boarding UTXOs
+// paid to the same address collapse into one activity row whose amount is the
+// SUM, so a reused boarding address never hides funds in the feed.
+func TestHistoryDepositsSameAddressSummed(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:               "boarding",
+				Subtype:            ledger.EventWalletUTXOCreated,
+				ConfirmationStatus: "confirmed",
+				AmountSat:          100_000,
+				Txid:               "txid-a",
+				OutputIndex:        0,
+				BoardingAddress:    "bcrt1qshared",
+				CreatedAtUnixS:     100,
+			},
+			{
+				Type:               "boarding",
+				Subtype:            ledger.EventWalletUTXOCreated,
+				ConfirmationStatus: "confirmed",
+				AmountSat:          250_000,
+				Txid:               "txid-b",
+				OutputIndex:        1,
+				BoardingAddress:    "bcrt1qshared",
+				CreatedAtUnixS:     200,
+			},
+		},
+	}
+
+	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{})
+	require.NoError(t, err)
+	require.Len(
+		t, resp.GetActivity().GetEntries(), 1,
+		"two UTXOs to one address collapse into one row",
+	)
+	entry := resp.GetActivity().GetEntries()[0]
+	require.Equal(t, "deposit-bcrt1qshared", entry.GetId())
+	require.EqualValues(
+		t, 350_000, entry.GetAmountSat(),
+		"the row must show the summed total, not one UTXO",
+	)
+}
+
 // TestDecorateCooperativeLeaveMatchesRetainedOutpoint verifies that after #610
 // (row keyed by the stable leave-job id), the forfeit-driven completion
 // correlates on the retained consumed outpoint in vtxo_outpoint, not the id.

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -1924,6 +1924,105 @@ func TestHistoryDepositCompletesAfterBoarding(t *testing.T) {
 	require.Equal(t, "confirmed", entry.GetProgress().GetPhaseLabel())
 }
 
+// TestLedgerActivityIDDeposit verifies confirmed-deposit id keying: the
+// address-scoped id when the daemon surfaces boarding_address, falling back to
+// txid:vout (then bare txid) for older daemons, only for the
+// wallet_utxo_created subtype.
+func TestLedgerActivityIDDeposit(t *testing.T) {
+	t.Parallel()
+
+	dep := walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT
+	tests := []struct {
+		name  string
+		entry *daemonrpc.TransactionHistoryEntry
+		want  string
+	}{
+		{
+			name: "boarding_address present keys by address",
+			entry: &daemonrpc.TransactionHistoryEntry{
+				Txid:            "boardingtx",
+				Subtype:         ledger.EventWalletUTXOCreated,
+				OutputIndex:     1,
+				BoardingAddress: "bcrt1qaddr",
+			},
+			want: "deposit-bcrt1qaddr",
+		},
+		{
+			name: "older daemon without address falls back to txid:vout",
+			entry: &daemonrpc.TransactionHistoryEntry{
+				Txid:        "boardingtx",
+				Subtype:     ledger.EventWalletUTXOCreated,
+				OutputIndex: 1,
+			},
+			want: "boardingtx:1",
+		},
+		{
+			name: "no address and no output index falls back to txid",
+			entry: &daemonrpc.TransactionHistoryEntry{
+				Txid:        "boardingtx",
+				Subtype:     ledger.EventWalletUTXOCreated,
+				OutputIndex: -1,
+			},
+			want: "boardingtx",
+		},
+		{
+			name: "non-deposit subtype ignores boarding_address",
+			entry: &daemonrpc.TransactionHistoryEntry{
+				Txid:            "boardingtx",
+				Subtype:         "boarding_fee_paid",
+				BoardingAddress: "bcrt1qaddr",
+			},
+			want: "boardingtx",
+		},
+		{
+			name:  "empty txid returns empty",
+			entry: &daemonrpc.TransactionHistoryEntry{},
+			want:  "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(
+				t, tc.want, ledgerActivityID(tc.entry, dep),
+			)
+		})
+	}
+}
+
+// TestHistoryDepositKeyedByBoardingAddress verifies a confirmed boarding
+// deposit surfaced through List is keyed by the shared deposit-<address> id
+// when the daemon populates boarding_address, so it matches the pending row
+// Deposit projected under the same id.
+func TestHistoryDepositKeyedByBoardingAddress(t *testing.T) {
+	t.Parallel()
+
+	h, swap, rpc := newHistoryFixture(t)
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{}
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:               "boarding",
+				Subtype:            ledger.EventWalletUTXOCreated,
+				ConfirmationStatus: "confirmed",
+				AmountSat:          100_000,
+				Txid:               "boarding-txid",
+				OutputIndex:        0,
+				BoardingAddress:    "bcrt1qboardingaddr",
+				CreatedAtUnixS:     100,
+			},
+		},
+	}
+
+	resp, err := h.List(t.Context(), &walletdkrpc.ListRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.GetActivity().GetEntries(), 1)
+	require.Equal(
+		t, "deposit-bcrt1qboardingaddr",
+		resp.GetActivity().GetEntries()[0].GetId(),
+	)
+}
+
 // TestDecorateCooperativeLeaveMatchesRetainedOutpoint verifies that after #610
 // (row keyed by the stable leave-job id), the forfeit-driven completion
 // correlates on the retained consumed outpoint in vtxo_outpoint, not the id.

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -165,10 +165,18 @@ func (s *Service) Deposit(ctx context.Context,
 		return nil, fmt.Errorf("new boarding address: %w", err)
 	}
 
+	// The returned entry is keyed by the address-scoped id the confirmed
+	// deposit will later carry (deposit-<address>), so a caller can
+	// correlate this response with the eventual activity row. It is
+	// deliberately NOT projected into the store: merely allocating an
+	// address is not a pending deposit (no funds are in flight), so
+	// persisting it would strand a PENDING row for every unfunded address a
+	// user ever requests. A deposit becomes an activity row only once the
+	// daemon records the incoming UTXO (at confirmation); before that,
+	// unconfirmed boarding funds surface via Balance.
 	createdAt := nowUnix()
-	canonicalID := fmt.Sprintf("deposit-%s", addrResp.GetAddress())
 	entry := &walletdkrpc.WalletEntry{
-		Id:            canonicalID,
+		Id:            fmt.Sprintf("deposit-%s", addrResp.GetAddress()),
 		Kind:          walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT,
 		Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
 		AmountSat:     int64(req.GetAmtSatHint()),
@@ -181,16 +189,6 @@ func (s *Service) Deposit(ctx context.Context,
 			PhaseLabel: "address_issued",
 		},
 	}
-
-	// Project the pending deposit row into the canonical activity store
-	// under its address-scoped id (deposit-<address>) so List surfaces it
-	// durably. The confirmed boarding-deposit ledger row later carries the
-	// same boarding address and keys to the same canonical id, so the
-	// delete-free upsert flips this row PENDING -> COMPLETE rather than
-	// creating a second, differently-keyed row. Use a cancel-safe context
-	// so a client disconnect cannot drop the store write of an
-	// already-issued address.
-	s.runtime.projectAndEmit(context.WithoutCancel(ctx), entry)
 
 	return &walletdkrpc.DepositResponse{
 		OnchainAddress: addrResp.GetAddress(),

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -182,13 +182,15 @@ func (s *Service) Deposit(ctx context.Context,
 		},
 	}
 
-	// v1 SCOPE: deposit pending tracking is omitted because there is
-	// no daemon-side hook to observe the eventual boarding txid for
-	// this address. The boarding ledger row that lands later will
-	// surface under its own synthetic id; canonical-id correlation
-	// between the Deposit response and the ledger row is deferred to
-	// v2 — see swapwallet/doc.go for the limitation note.
-	_ = canonicalID
+	// Project the pending deposit row into the canonical activity store
+	// under its address-scoped id (deposit-<address>) so List surfaces it
+	// durably. The confirmed boarding-deposit ledger row later carries the
+	// same boarding address and keys to the same canonical id, so the
+	// delete-free upsert flips this row PENDING -> COMPLETE rather than
+	// creating a second, differently-keyed row. Use a cancel-safe context
+	// so a client disconnect cannot drop the store write of an
+	// already-issued address.
+	s.runtime.projectAndEmit(context.WithoutCancel(ctx), entry)
 
 	return &walletdkrpc.DepositResponse{
 		OnchainAddress: addrResp.GetAddress(),

--- a/swapwallet/service_test.go
+++ b/swapwallet/service_test.go
@@ -72,12 +72,11 @@ func TestServiceDepositReturnsAddress(t *testing.T) {
 	)
 }
 
-// TestServiceDepositProjectsPendingRow confirms Deposit projects the pending
-// deposit row into the canonical store under its address-scoped id, so the
-// confirmed boarding-deposit ledger row (which carries the same boarding
-// address) later upserts onto the same canonical id instead of creating a
-// second, differently-keyed row.
-func TestServiceDepositProjectsPendingRow(t *testing.T) {
+// TestServiceDepositDoesNotProjectAtAllocation confirms Deposit does NOT
+// persist a row when an address is merely generated — allocating an address is
+// not a pending deposit. The returned entry still carries the address-scoped
+// id the confirmed deposit will later use, so a caller can correlate.
+func TestServiceDepositDoesNotProjectAtAllocation(t *testing.T) {
 	t.Parallel()
 
 	swap := &fakeSwapService{}
@@ -92,17 +91,18 @@ func TestServiceDepositProjectsPendingRow(t *testing.T) {
 	t.Cleanup(runtime.stop)
 	svc := newService(deps, runtime)
 
-	_, err := svc.Deposit(
+	resp, err := svc.Deposit(
 		t.Context(), &walletdkrpc.DepositRequest{
 			AmtSatHint: 50_000,
 		},
 	)
 	require.NoError(t, err)
-
-	require.Equal(t, 1, store.count(), "pending deposit row must be stored")
-	require.True(
-		t, store.ids()["deposit-bcrt1qboardingaddr"],
-		"pending row must be keyed by deposit-<address>",
+	require.Equal(
+		t, "deposit-bcrt1qboardingaddr", resp.GetEntry().GetId(),
+	)
+	require.Equal(
+		t, 0, store.count(),
+		"generating an address must not persist a pending row",
 	)
 }
 

--- a/swapwallet/service_test.go
+++ b/swapwallet/service_test.go
@@ -34,11 +34,8 @@ func newServiceFixture(t *testing.T) (*Service, *fakeSwapService,
 }
 
 // TestServiceDepositReturnsAddress confirms Deposit calls NewAddress and
-// returns a DEPOSIT-kind WalletEntry with the boarding address. v1 does
-// NOT register a canonical-id intent for deposits because the daemon
-// has no notification hook from boarding-address to the eventual
-// boarding txid; correlation between this entry and the later boarding
-// ledger row is a v2 task (see swapwallet/doc.go).
+// returns a DEPOSIT-kind WalletEntry with the boarding address, keyed by the
+// address-scoped canonical id.
 func TestServiceDepositReturnsAddress(t *testing.T) {
 	t.Parallel()
 
@@ -69,6 +66,43 @@ func TestServiceDepositReturnsAddress(t *testing.T) {
 	require.Equal(
 		t, "address_issued",
 		resp.GetEntry().GetProgress().GetPhaseLabel(),
+	)
+	require.Equal(
+		t, "deposit-bcrt1qboardingaddr", resp.GetEntry().GetId(),
+	)
+}
+
+// TestServiceDepositProjectsPendingRow confirms Deposit projects the pending
+// deposit row into the canonical store under its address-scoped id, so the
+// confirmed boarding-deposit ledger row (which carries the same boarding
+// address) later upserts onto the same canonical id instead of creating a
+// second, differently-keyed row.
+func TestServiceDepositProjectsPendingRow(t *testing.T) {
+	t.Parallel()
+
+	swap := &fakeSwapService{}
+	rpc := &fakeRPCServer{
+		newAddressResp: &daemonrpc.NewAddressResponse{
+			Address: "bcrt1qboardingaddr",
+		},
+	}
+	store := &fakeActivityProjector{}
+	deps := &Deps{SwapService: swap, RPCServer: rpc, ActivityStore: store}
+	runtime := newRuntime(t.Context(), deps)
+	t.Cleanup(runtime.stop)
+	svc := newService(deps, runtime)
+
+	_, err := svc.Deposit(
+		t.Context(), &walletdkrpc.DepositRequest{
+			AmtSatHint: 50_000,
+		},
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, store.count(), "pending deposit row must be stored")
+	require.True(
+		t, store.ids()["deposit-bcrt1qboardingaddr"],
+		"pending row must be keyed by deposit-<address>",
 	)
 }
 


### PR DESCRIPTION
## What

Give a boarding **DEPOSIT** one stable canonical id from allocation (`recv --onchain` / `Deposit`) through the confirmed boarding txid, so its pending and confirmed activity rows share an id. This closes the EXIT/DEPOSIT half of C1's stable-id acceptance criterion (#774); the on-chain-send/leave EXIT half landed in #843.

## How

The daemon already durably links a boarding outpoint to its allocated address (`boarding_intents.pk_script → boarding_addresses.address_string`), and `ListTransactionHistory` already joins `boarding_intents` on the confirmed outpoint — it just never surfaced the address. So this is the direct analogue of the #610 approach (surface an already-durable value, then key by it), one half-step larger because the value needs a JOIN rather than being in hand.

- **db**: `ListTransactionHistory` gains a 1:1 `LEFT JOIN` to `boarding_addresses` and a new `boarding_address` column (empty for non-deposit rows).
- **daemonrpc**: new `TransactionHistoryEntry.boarding_address` field, populated by the darepod mapper.
- **swapwallet**: `Deposit` stops discarding the `deposit-<address>` id and projects the pending row under it; `ledgerActivityID` keys a confirmed boarding-deposit row by `deposit-<boarding_address>` when present, falling back to `txid:vout` for an older daemon. The delete-free store upsert then flips the pending row to `COMPLETE` on the shared id.

## Deliberate trade-off

This is **address-granularity**, not per-outpoint: multiple UTXOs paid to the same boarding address collapse into one DEPOSIT row. Boarding addresses are single-use by design (fresh per `Deposit`), so the common path is unaffected. Per-outpoint fidelity is fundamentally incompatible with "pending and confirmed share an id" (the pending side exists before any outpoint), so address-granularity is the minimal way to satisfy #774; a per-deposit intent id is the larger scheme the issue defers. Documented in `doc.go`.

## Scope / not in scope

Live cross-restart terminal reconciliation (pending→COMPLETE without a restart) remains **C2** — the transition still lands via the derive/backfill pass, consistent with the merged C1 behavior. No migration (query + proto only). Wire-additive; graceful degradation against an older daemon.

## Testing

- **db**: `ListTransactionHistory` surfaces the allocated address for a confirmed boarding deposit and leaves it empty for non-deposit rows (real boarding_intents/boarding_addresses seed).
- **swapwallet**: `ledgerActivityID` table test (address-keyed / older-daemon fallback / non-deposit); `Deposit` projects the pending row under `deposit-<address>`; `List` surfaces a confirmed deposit keyed by the shared id.
- Full `db` + `swapwallet` + `darepod` unit suites, `make sqlc`/`make rpc` (comment/column-only regen), `lint-changed-local` (0 issues), `commitmsg-lint`.

Part of #776. Child issue #774.
