### PR TITLE
swapwallet: live pending→settled activity reconciler (C2)

### DIFF
--- a/swapwallet/doc.go
+++ b/swapwallet/doc.go
@@ -54,7 +54,11 @@
 // appears only from the point the daemon records an incoming UTXO. The
 // Deposit RPC still returns that same deposit-<address> id so a caller can
 // correlate. An older daemon that does not populate boarding_address falls
-// back to per-UTXO txid:vout deposit rows (no summing, still correct).
+// back to per-UTXO txid:vout deposit rows (no summing, still correct). The
+// confirmed deposit is applied by the derive-and-project pass; the
+// reconciler (see CANONICAL ACTIVITY LOG) re-runs that pass on a periodic
+// tick, so it lands in the store within a tick rather than only at the
+// next startup backfill.
 //
 // This is address-granularity for the CONFIRMED (recorded) phase only. The
 // pre-confirmation phase cannot be per-address: the daemon exposes only an
@@ -84,7 +88,8 @@
 // projection and activity_events is the append-only transition log. Writes
 // happen project-then-emit at the swap monitor loop, the cooperative-leave
 // submit, the credit poll, the forced unilateral exit, and the deadline
-// overlay, plus a one-time startup backfill from the collectors below.
+// overlay, plus a one-time startup backfill and a periodic reconciler pass
+// (reprojectActivity), both from the collectors below.
 //
 // The RPC read path now reads the store: List(ACTIVITY) pages activity_entries
 // by the immutable (created_at_unix, canonical_id) keyset cursor, and
@@ -95,10 +100,13 @@
 // not newest-by-update.
 //
 // Consequences of the store-backed read that are tracked, not yet closed:
-//   - Producers without an ongoing projector — confirmed boarding DEPOSIT and
-//     daemon-side sweep/EXIT rows derived from ListTransactions — reach the
-//     store only via the startup backfill, so a newly-confirmed one appears in
-//     List after the next restart rather than immediately.
+//   - Producers without a per-event projector — confirmed boarding DEPOSIT and
+//     daemon-side sweep/EXIT rows derived from ListTransactions — are landed by
+//     the periodic reconciler (reconcileInterval) re-deriving and re-projecting
+//     them, so a newly-confirmed one appears in List within a reconcile tick
+//     rather than only after a restart. The tick is coarse, so there is a
+//     bounded delay; a per-block/confirmation hook (cheaper, lower latency) is
+//     a deferred optimization.
 //   - The synthetic boarding-unconfirmed DEPOSIT row is derive-path-only: it
 //     is ephemeral live state (recomputed from GetBalance, no durable id) and
 //     is deliberately NOT projected, so on a store build an unconfirmed
@@ -110,12 +118,13 @@
 // deterministic hash of the consumed outpoints) and the wallet uses it as the
 // row id, so a single handle represents a multi-input sweep and stays the same
 // across the round seal. The id is deterministic — reproducible from the same
-// inputs — but the row itself is wallet-local (in-memory) and its terminal
-// status is NOT reconciled across a restart yet: completion currently fires
-// only when the derive/backfill pass matches the retained consumed outpoint
-// (kept in vtxo_outpoint) against a forfeited VTXO. A DEPOSIT is still keyed by
-// txid:vout pending its own stable-id work. That DEPOSIT id, projecting the
-// backfill-only producers on an ongoing basis, and live cross-restart terminal
-// reconciliation under the id (projecting forfeit/settlement into the store
-// rather than relying on the startup backfill) are tracked separately (C2).
+// inputs — and the periodic reconciler lands its terminal transition into the
+// store live: each pass matches the retained consumed outpoint (kept in
+// vtxo_outpoint) against a forfeited VTXO and upserts the row to COMPLETE.
+// This stays best-effort — the row is wallet-local (in-memory) with no durable
+// leave-job → forfeit link, so a restarted daemon cannot rebuild the original
+// counterparty/note from durable state alone. A durable leave record (making
+// leave completion restart-survivable rather than best-effort), a
+// per-block/confirmation reconcile trigger, and startup-at-tip reconciliation
+// (C5) are deferred.
 package swapwallet

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -644,8 +644,18 @@ func (h *history) collectUnilateralExitEntries(ctx context.Context) (
 			}
 		}
 
+		// A per-row GetUnrollStatus error must not abort the whole
+		// derive pass: that would block every other terminal flip
+		// (deposits, other exits) on this and every reconcile/backfill
+		// pass. Log-and-skip like collectWalletLocalPendingEntries; the
+		// row stays at its pre-decoration (PENDING) status and is
+		// retried next pass.
 		if err := h.decorateExitEntry(ctx, entry, nil); err != nil {
-			return nil, err
+			h.deps.resolveLog().DebugS(
+				ctx,
+				"Unilateral exit status decorate skipped",
+				err,
+			)
 		}
 
 		out = append(out, entry)
@@ -769,26 +779,12 @@ func (h *history) decorateExitEntry(ctx context.Context,
 		return nil
 	}
 
-	// Once this row is decorated to a terminal status, drop its in-memory
-	// pending record: the store now holds the terminal row, and leaving the
-	// id in the pending map would leak it for the process lifetime and
-	// force every later reconcile pass to re-decorate a settled row
-	// (re-issuing its GetUnrollStatus / forfeit-scan work). Clearing here
-	// is a no-op for ids not in the map (e.g. unilateral rows
-	// re-synthesized from ListVTXOs). The deferred check reads the final
-	// status so it covers the cooperative and unilateral paths alike, and
-	// skips the error path where the status stays PENDING.
-	defer func() {
-		if h.runtime == nil {
-			return
-		}
-		switch entry.GetStatus() {
-		case walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
-			walletdkrpc.EntryStatus_ENTRY_STATUS_FAILED:
-
-			h.runtime.clearPending(entry.GetId())
-		}
-	}()
+	// decorateExitEntry only reads/annotates: it never clears the pending
+	// map. Clearing a terminal wallet-local EXIT is done exclusively from
+	// reprojectActivity, after the terminal row is durably projected
+	// (clearProjectedTerminalExit) — decorating happens on the read/derive
+	// path too, where clearing a cooperative-leave row (which lives only in
+	// the pending map) before it is persisted would strand it forever.
 
 	// GetUnrollStatus is keyed by the VTXO outpoint. A unilateral-exit
 	// row's id IS that outpoint; a cooperative-leave row is keyed by the

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -769,6 +769,27 @@ func (h *history) decorateExitEntry(ctx context.Context,
 		return nil
 	}
 
+	// Once this row is decorated to a terminal status, drop its in-memory
+	// pending record: the store now holds the terminal row, and leaving the
+	// id in the pending map would leak it for the process lifetime and
+	// force every later reconcile pass to re-decorate a settled row
+	// (re-issuing its GetUnrollStatus / forfeit-scan work). Clearing here
+	// is a no-op for ids not in the map (e.g. unilateral rows
+	// re-synthesized from ListVTXOs). The deferred check reads the final
+	// status so it covers the cooperative and unilateral paths alike, and
+	// skips the error path where the status stays PENDING.
+	defer func() {
+		if h.runtime == nil {
+			return
+		}
+		switch entry.GetStatus() {
+		case walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+			walletdkrpc.EntryStatus_ENTRY_STATUS_FAILED:
+
+			h.runtime.clearPending(entry.GetId())
+		}
+	}()
+
 	// GetUnrollStatus is keyed by the VTXO outpoint. A unilateral-exit
 	// row's id IS that outpoint; a cooperative-leave row is keyed by the
 	// stable send_job_id (a bare hash, not an outpoint) and retains the

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -2074,11 +2074,13 @@ func TestHistoryDepositsSameAddressSummed(t *testing.T) {
 	)
 }
 
-// TestDecorateExitEntryClearsPendingOnTerminal verifies that once a
-// wallet-local EXIT row is decorated to a terminal status, its in-memory
-// pending record is cleared — so the reconciler does not re-decorate a settled
-// row every pass and the pending map does not leak.
-func TestDecorateExitEntryClearsPendingOnTerminal(t *testing.T) {
+// TestDecorateExitEntryDoesNotClearPending verifies that decorating a
+// wallet-local EXIT row to a terminal status does NOT clear its in-memory
+// pending record. Decoration runs on the read/derive path, and a
+// cooperative-leave row lives only in the pending map, so clearing it before
+// its terminal row is durably projected would strand it. The clear is done
+// exclusively by reprojectActivity, after a successful project.
+func TestDecorateExitEntryDoesNotClearPending(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -2101,7 +2103,7 @@ func TestDecorateExitEntryClearsPendingOnTerminal(t *testing.T) {
 	require.Contains(t, pendingSnapshotIDs(h.runtime), jobID)
 
 	// Decorating it terminal (the retained outpoint is forfeited) flips it
-	// to COMPLETE and clears the pending record.
+	// to COMPLETE but leaves the pending record in place.
 	require.NoError(
 		t,
 		h.decorateExitEntry(
@@ -2112,9 +2114,9 @@ func TestDecorateExitEntryClearsPendingOnTerminal(t *testing.T) {
 		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
 		entry.GetStatus(),
 	)
-	require.NotContains(
-		t, pendingSnapshotIDs(h.runtime), jobID,
-		"a terminal EXIT must be cleared from the pending map",
+	require.Contains(
+		t, pendingSnapshotIDs(h.runtime), jobID, "decorate must "+
+			"not clear the pending map; reprojectActivity does",
 	)
 }
 

--- a/swapwallet/history_test.go
+++ b/swapwallet/history_test.go
@@ -2074,6 +2074,62 @@ func TestHistoryDepositsSameAddressSummed(t *testing.T) {
 	)
 }
 
+// TestDecorateExitEntryClearsPendingOnTerminal verifies that once a
+// wallet-local EXIT row is decorated to a terminal status, its in-memory
+// pending record is cleared — so the reconciler does not re-decorate a settled
+// row every pass and the pending map does not leak.
+func TestDecorateExitEntryClearsPendingOnTerminal(t *testing.T) {
+	t.Parallel()
+
+	const (
+		jobID    = "sendjob-xyz"
+		outpoint = "aabbcc:0"
+	)
+
+	h, _, rpc := newHistoryFixture(t)
+	rpc.unrollStatusResp = &daemonrpc.GetUnrollStatusResponse{Found: false}
+
+	entry := &walletdkrpc.WalletEntry{
+		Id:     jobID,
+		Kind:   walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+		Status: walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		Progress: &walletdkrpc.WalletEntryProgress{
+			VtxoOutpoint: outpoint,
+		},
+	}
+	h.runtime.trackPendingEntryWithoutTimeout(entry)
+	require.Contains(t, pendingSnapshotIDs(h.runtime), jobID)
+
+	// Decorating it terminal (the retained outpoint is forfeited) flips it
+	// to COMPLETE and clears the pending record.
+	require.NoError(
+		t,
+		h.decorateExitEntry(
+			t.Context(), entry, map[string]struct{}{outpoint: {}},
+		),
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		entry.GetStatus(),
+	)
+	require.NotContains(
+		t, pendingSnapshotIDs(h.runtime), jobID,
+		"a terminal EXIT must be cleared from the pending map",
+	)
+}
+
+// pendingSnapshotIDs returns the ids currently tracked in the runtime's
+// in-memory pending map.
+func pendingSnapshotIDs(r *Runtime) []string {
+	entries := r.pendingSnapshot()
+	ids := make([]string, 0, len(entries))
+	for _, e := range entries {
+		ids = append(ids, e.GetId())
+	}
+
+	return ids
+}
+
 // TestDecorateCooperativeLeaveMatchesRetainedOutpoint verifies that after #610
 // (row keyed by the stable leave-job id), the forfeit-driven completion
 // correlates on the retained consumed outpoint in vtxo_outpoint, not the id.

--- a/swapwallet/projector.go
+++ b/swapwallet/projector.go
@@ -21,9 +21,15 @@ import (
 // the caller still fans the update out to live subscribers. When no store is
 // wired (tests, or a build without a database) projection is a no-op and the
 // legacy derive-on-read path continues unchanged.
-func (r *Runtime) project(ctx context.Context, entry *walletdkrpc.WalletEntry) {
+// project writes entry into the canonical activity store. It returns nil on a
+// successful (or intentionally skipped) projection and the underlying error
+// when the durable write failed, so a caller can gate a follow-up side effect
+// on the row actually landing.
+func (r *Runtime) project(ctx context.Context,
+	entry *walletdkrpc.WalletEntry) error {
+
 	if r.deps == nil || r.deps.ActivityStore == nil {
-		return
+		return nil
 	}
 
 	// A row with no canonical id cannot be keyed; skip it, matching the
@@ -35,7 +41,7 @@ func (r *Runtime) project(ctx context.Context, entry *walletdkrpc.WalletEntry) {
 	// real txid:vout id.
 	if entry.GetId() == "" ||
 		entry.GetId() == syntheticBoardingUnconfirmedID {
-		return
+		return nil
 	}
 
 	projection, err := entryToProjection(entry)
@@ -43,7 +49,7 @@ func (r *Runtime) project(ctx context.Context, entry *walletdkrpc.WalletEntry) {
 		r.deps.resolveLog().WarnS(ctx, "Activity projection skipped: "+
 			"encode failed", err)
 
-		return
+		return err
 	}
 
 	if err := r.deps.ActivityStore.ProjectEntry(
@@ -53,7 +59,11 @@ func (r *Runtime) project(ctx context.Context, entry *walletdkrpc.WalletEntry) {
 		r.deps.resolveLog().WarnS(ctx, "Activity projection failed",
 			err,
 		)
+
+		return err
 	}
+
+	return nil
 }
 
 // projectAndEmit projects the entry into the canonical activity log and then
@@ -74,7 +84,19 @@ func (r *Runtime) projectAndEmit(ctx context.Context,
 // deposit, a forfeited leave, a completed unroll) while leaving unchanged rows
 // untouched. It backs both the one-time startup backfill and the ongoing
 // reconciler. Returns (0, nil) when no store is wired.
-func (r *Runtime) reprojectActivity(ctx context.Context) (int, error) {
+//
+// kinds optionally restricts the derived feed: the startup backfill passes nil
+// to seed every kind, while the reconciler passes only the backfill-only
+// producers (DEPOSIT, EXIT) so it neither re-projects nor contends with the
+// monitor-owned SEND/RECV rows.
+//
+// A wallet-local EXIT's pending record is cleared only here, and only after its
+// terminal row is durably projected — never from the read/derive path — so a
+// failed projection or a row that paged out is retried on a later pass instead
+// of being stranded PENDING in the store.
+func (r *Runtime) reprojectActivity(ctx context.Context,
+	kinds []walletdkrpc.EntryKind) (int, error) {
+
 	if r.deps == nil || r.deps.ActivityStore == nil {
 		return 0, nil
 	}
@@ -90,6 +112,7 @@ func (r *Runtime) reprojectActivity(ctx context.Context) (int, error) {
 		list, err := h.deriveActivity(ctx, &walletdkrpc.ListRequest{
 			Limit:  limit,
 			Offset: offset,
+			Kinds:  kinds,
 		})
 		if err != nil {
 			return projected, err
@@ -105,7 +128,14 @@ func (r *Runtime) reprojectActivity(ctx context.Context) (int, error) {
 		}
 
 		for _, entry := range entries {
-			r.project(ctx, entry)
+			if err := r.project(ctx, entry); err != nil {
+				// Best-effort: the next pass retries. Do not
+				// clear any pending record when the write did
+				// not land.
+				continue
+			}
+
+			r.clearProjectedTerminalExit(entry)
 		}
 		projected += len(entries)
 
@@ -116,6 +146,26 @@ func (r *Runtime) reprojectActivity(ctx context.Context) (int, error) {
 	}
 
 	return projected, nil
+}
+
+// clearProjectedTerminalExit drops a wallet-local EXIT's in-memory pending
+// record once its terminal row has been durably projected. A cooperative-leave
+// EXIT exists only in the pending map, so this must run strictly after a
+// successful project (not while decorating): the store now holds the terminal
+// row, and dropping the record stops later passes from re-decorating a settled
+// row. It is a no-op for ids not in the map (e.g. unilateral rows synthesized
+// from ListVTXOs) and for non-terminal or non-EXIT rows.
+func (r *Runtime) clearProjectedTerminalExit(entry *walletdkrpc.WalletEntry) {
+	if entry.GetKind() != walletdkrpc.EntryKind_ENTRY_KIND_EXIT {
+		return
+	}
+
+	switch entry.GetStatus() {
+	case walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_FAILED:
+
+		r.clearPending(entry.GetId())
+	}
 }
 
 // backfillActivity seeds the canonical activity log from the existing
@@ -129,7 +179,7 @@ func (r *Runtime) backfillActivity(ctx context.Context) {
 	}
 
 	log := r.deps.resolveLog()
-	projected, err := r.reprojectActivity(ctx)
+	projected, err := r.reprojectActivity(ctx, nil)
 	if err != nil {
 		log.WarnS(ctx, "Activity backfill stopped: list failed", err)
 

--- a/swapwallet/projector.go
+++ b/swapwallet/projector.go
@@ -67,17 +67,18 @@ func (r *Runtime) projectAndEmit(ctx context.Context,
 	r.emit(entry)
 }
 
-// backfillActivity seeds the canonical activity log from the existing
-// derive-on-read collectors once at startup, so the store reflects current
-// state before any new transition lands. It pages through the merged feed and
-// projects every row; the upsert is idempotent on canonical_id, so re-running
-// across restarts is safe. No-op when no store is wired.
-func (r *Runtime) backfillActivity(ctx context.Context) {
+// reprojectActivity pages the derive-on-read feed and projects every row into
+// the canonical activity store, returning the number of rows projected. Because
+// ProjectEntry is idempotent on canonical_id and suppresses no-op changes,
+// re-running observes any terminal transition since the last pass (a confirmed
+// deposit, a forfeited leave, a completed unroll) while leaving unchanged rows
+// untouched. It backs both the one-time startup backfill and the ongoing
+// reconciler. Returns (0, nil) when no store is wired.
+func (r *Runtime) reprojectActivity(ctx context.Context) (int, error) {
 	if r.deps == nil || r.deps.ActivityStore == nil {
-		return
+		return 0, nil
 	}
 
-	log := r.deps.resolveLog()
 	h := newHistory(r.deps, r)
 	limit := r.deps.resolveMaxListLimit()
 
@@ -91,11 +92,7 @@ func (r *Runtime) backfillActivity(ctx context.Context) {
 			Offset: offset,
 		})
 		if err != nil {
-			log.WarnS(ctx, "Activity backfill stopped: list failed",
-				err,
-			)
-
-			return
+			return projected, err
 		}
 
 		entries := list.GetEntries()
@@ -116,6 +113,27 @@ func (r *Runtime) backfillActivity(ctx context.Context) {
 		if uint32(len(entries)) < limit || offset >= list.GetTotal() {
 			break
 		}
+	}
+
+	return projected, nil
+}
+
+// backfillActivity seeds the canonical activity log from the existing
+// derive-on-read collectors once at startup, so the store reflects current
+// state before any new transition lands. The upsert is idempotent on
+// canonical_id, so re-running across restarts is safe. No-op when no store is
+// wired.
+func (r *Runtime) backfillActivity(ctx context.Context) {
+	if r.deps == nil || r.deps.ActivityStore == nil {
+		return
+	}
+
+	log := r.deps.resolveLog()
+	projected, err := r.reprojectActivity(ctx)
+	if err != nil {
+		log.WarnS(ctx, "Activity backfill stopped: list failed", err)
+
+		return
 	}
 
 	log.InfoS(ctx, "Activity backfill complete",

--- a/swapwallet/reconciler.go
+++ b/swapwallet/reconciler.go
@@ -1,0 +1,67 @@
+//go:build walletdkrpc && swapruntime
+
+package swapwallet
+
+import (
+	"context"
+	"time"
+)
+
+// reconcileInterval is how often the reconciler re-derives the activity feed
+// and re-projects it into the canonical store. It lands pending -> terminal
+// transitions — a confirmed boarding deposit, a forfeited cooperative leave, a
+// completed unilateral exit — live while the daemon runs, rather than only at
+// the next startup backfill. The cadence is deliberately coarse: one pass
+// re-queries every history source (plus one GetUnrollStatus per pending
+// unilateral exit), and on-chain settlement is not latency-sensitive to the
+// second. It is much slower than the credit poll, whose per-op registry read
+// is far cheaper.
+const reconcileInterval = 60 * time.Second
+
+// startReconcilerLoop starts the activity reconciler goroutine. It is a no-op
+// without a canonical store: the derive-on-read fallback already reflects live
+// state on every List, so there is nothing to reconcile into.
+func (r *Runtime) startReconcilerLoop() {
+	if r.deps == nil || r.deps.ActivityStore == nil {
+		return
+	}
+
+	r.wg.Add(1)
+	go r.reconcilerLoop()
+}
+
+// reconcilerLoop periodically re-projects the derived feed so terminal
+// transitions land in the store live. backfillActivity already ran during
+// resumeAll, so the loop starts straight into the ticker rather than
+// projecting once immediately. It is anchored to the daemon root context and
+// drained by the runtime's wait group on stop.
+func (r *Runtime) reconcilerLoop() {
+	defer r.wg.Done()
+
+	ticker := time.NewTicker(reconcileInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.rootCtx.Done():
+			return
+
+		case <-ticker.C:
+			r.reconcileActivity(r.rootCtx)
+		}
+	}
+}
+
+// reconcileActivity runs one re-derive-and-project pass, factored out so it can
+// be unit-tested directly. A pass failure is a transient history-source RPC
+// error, logged at debug: the next tick retries, and ProjectEntry
+// change-suppression means a partial pass never corrupts the store.
+func (r *Runtime) reconcileActivity(ctx context.Context) {
+	if _, err := r.reprojectActivity(ctx); err != nil {
+		r.deps.resolveLog().DebugS(
+			ctx,
+			"Activity reconcile pass failed",
+			err,
+		)
+	}
+}

--- a/swapwallet/reconciler.go
+++ b/swapwallet/reconciler.go
@@ -5,7 +5,19 @@ package swapwallet
 import (
 	"context"
 	"time"
+
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 )
+
+// reconcilerKinds are the activity kinds the reconciler re-projects: the
+// backfill-only producers whose pending -> terminal transition would otherwise
+// land in the store only at the next startup backfill. SEND/RECV are owned by
+// the swap monitor / credit poll, which project them live, so re-deriving them
+// here only wastes work and contends with those loops.
+var reconcilerKinds = []walletdkrpc.EntryKind{
+	walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT,
+	walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+}
 
 // reconcileInterval is how often the reconciler re-derives the activity feed
 // and re-projects it into the canonical store. It lands pending -> terminal
@@ -52,15 +64,17 @@ func (r *Runtime) reconcilerLoop() {
 	}
 }
 
-// reconcileActivity runs one re-derive-and-project pass, factored out so it can
-// be unit-tested directly. A pass failure is a transient history-source RPC
-// error, logged at debug: the next tick retries, and ProjectEntry
-// change-suppression means a partial pass never corrupts the store.
+// reconcileActivity runs one re-derive-and-project pass over the backfill-only
+// kinds, factored out so it can be unit-tested directly. A pass failure is a
+// transient history-source RPC error: the next tick retries, ProjectEntry
+// change-suppression keeps a partial pass from appending spurious events, and a
+// pending record is cleared only after its terminal row is durably projected,
+// so a partial pass never strands or corrupts a row. It is the only live path
+// landing these flips, so a failure is logged at warn (not debug) — matching
+// the sibling credit poll and backfill.
 func (r *Runtime) reconcileActivity(ctx context.Context) {
-	if _, err := r.reprojectActivity(ctx); err != nil {
-		r.deps.resolveLog().DebugS(
-			ctx,
-			"Activity reconcile pass failed",
+	if _, err := r.reprojectActivity(ctx, reconcilerKinds); err != nil {
+		r.deps.resolveLog().WarnS(ctx, "Activity reconcile pass failed",
 			err,
 		)
 	}

--- a/swapwallet/reconciler_test.go
+++ b/swapwallet/reconciler_test.go
@@ -4,10 +4,12 @@ package swapwallet
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/darepod"
 	"github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/ledger"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
@@ -125,4 +127,103 @@ func TestReconcileActivityNoStoreIsNoOp(t *testing.T) {
 		runtime.startReconcilerLoop()
 		runtime.reconcileActivity(context.Background())
 	})
+}
+
+// trackForfeitedCooperativeExit tracks a wallet-local cooperative-leave EXIT
+// whose retained VTXO outpoint is reported forfeited, so a reconcile pass
+// decorates it COMPLETE. It returns the leave-job id.
+func trackForfeitedCooperativeExit(runtime *Runtime,
+	rpc *fakeRPCServer) string {
+
+	const (
+		jobID    = "sendjob-abc"
+		outpoint = "aabbcc:0"
+	)
+
+	// A cooperative leave has no unroll job, and its retained outpoint is
+	// in the forfeited set — so decorateExitEntry flips it to COMPLETE.
+	rpc.unrollStatusResp = &daemonrpc.GetUnrollStatusResponse{Found: false}
+	rpc.listVTXOsByStatus = map[daemonrpc.VTXOStatus]*daemonrpc.ListVTXOsResponse{
+		daemonrpc.VTXOStatus_VTXO_STATUS_FORFEITED: {
+			Vtxos: []*daemonrpc.VTXO{
+				{
+					Outpoint: outpoint,
+				},
+			},
+		},
+	}
+
+	runtime.trackPendingEntryWithoutTimeout(&walletdkrpc.WalletEntry{
+		Id:     jobID,
+		Kind:   walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+		Status: walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		Progress: &walletdkrpc.WalletEntryProgress{
+			VtxoOutpoint: outpoint,
+		},
+	})
+
+	return jobID
+}
+
+// TestReconcileClearsTerminalExitAfterProject verifies that once a
+// cooperative-leave EXIT flips terminal, one reconcile pass durably projects
+// the COMPLETE row AND clears the in-memory pending record — the clear happens
+// after the successful project, not while decorating.
+func TestReconcileClearsTerminalExitAfterProject(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtime, store, rpc := newReconcileFixture(t)
+
+	jobID := trackForfeitedCooperativeExit(runtime, rpc)
+	require.Contains(t, pendingSnapshotIDs(runtime), jobID)
+
+	runtime.reconcileActivity(ctx)
+
+	entry, err := store.GetEntry(ctx, jobID)
+	require.NoError(t, err)
+	require.EqualValues(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE, entry.Status,
+		"reconciler must land the forfeited leave COMPLETE",
+	)
+	require.NotContains(
+		t, pendingSnapshotIDs(runtime), jobID,
+		"pending record must be cleared after a durable project",
+	)
+}
+
+// TestReconcileRetainsPendingExitOnProjectFailure is the H-1 regression guard:
+// when the terminal projection fails, the pending record must be retained so a
+// later pass can retry, rather than stranding the row PENDING in the store with
+// its only in-memory source destroyed.
+func TestReconcileRetainsPendingExitOnProjectFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtime, store, rpc := newReconcileFixture(t)
+
+	// Wrap the store so every terminal projection fails.
+	runtime.deps.ActivityStore = failingProjectStore{ActivityStore: store}
+
+	jobID := trackForfeitedCooperativeExit(runtime, rpc)
+	require.Contains(t, pendingSnapshotIDs(runtime), jobID)
+
+	runtime.reconcileActivity(ctx)
+
+	require.Contains(
+		t, pendingSnapshotIDs(runtime), jobID, "a failed terminal "+
+			"projection must not clear the pending record",
+	)
+}
+
+// failingProjectStore wraps a real activity store but fails every ProjectEntry,
+// to exercise the reconciler's must-not-clear-on-write-failure path.
+type failingProjectStore struct {
+	darepod.ActivityStore
+}
+
+func (failingProjectStore) ProjectEntry(context.Context,
+	db.ActivityProjection) error {
+
+	return errors.New("injected project failure")
 }

--- a/swapwallet/reconciler_test.go
+++ b/swapwallet/reconciler_test.go
@@ -1,0 +1,128 @@
+//go:build walletdkrpc && swapruntime
+
+package swapwallet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/ledger"
+	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/stretchr/testify/require"
+)
+
+// newReconcileFixture wires a Runtime over a real activity store plus fake RPC
+// and swap services, so the reconciler's re-derive-and-project pass can be
+// exercised end to end against the store.
+func newReconcileFixture(t *testing.T) (*Runtime, *db.ActivityPersistenceStore,
+	*fakeRPCServer) {
+
+	t.Helper()
+
+	testDB := db.NewTestDB(t)
+	store := db.NewStore(
+		testDB.DB, testDB.Queries, testDB.Backend(), btclog.Disabled,
+	).NewActivityStore(clock.NewDefaultClock())
+
+	rpc := &fakeRPCServer{}
+	swap := &fakeSwapService{
+		listSwapsResp: &swapclientrpc.ListSwapsResponse{},
+	}
+	deps := &Deps{ActivityStore: store, RPCServer: rpc, SwapService: swap}
+	runtime := newRuntime(t.Context(), deps)
+	t.Cleanup(runtime.stop)
+
+	return runtime, store, rpc
+}
+
+// TestReconcileActivityFlipsDepositLive verifies the reconciler lands a
+// confirmed boarding deposit's PENDING -> COMPLETE transition into the store
+// live (no restart), and that a second pass is a no-op (ProjectEntry
+// change-suppression) appending no duplicate transition event.
+func TestReconcileActivityFlipsDepositLive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtime, store, rpc := newReconcileFixture(t)
+
+	// A pending deposit row already in the store, as Deposit would project
+	// it, keyed by its address-scoped id.
+	const depID = "deposit-bcrt1qaddr"
+	runtime.project(ctx, &walletdkrpc.WalletEntry{
+		Id:            depID,
+		Kind:          walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT,
+		Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		CreatedAtUnix: 100,
+		UpdatedAtUnix: 100,
+		Progress: &walletdkrpc.WalletEntryProgress{
+			PhaseLabel: "address_issued",
+		},
+	})
+
+	entry, err := store.GetEntry(ctx, depID)
+	require.NoError(t, err)
+	require.EqualValues(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING, entry.Status,
+	)
+
+	// The deposit confirms: ListTransactions now returns the confirmed
+	// wallet_utxo_created row carrying the same boarding address, so it
+	// keys to the same deposit-<address> id as the pending row.
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:               "boarding",
+				Subtype:            ledger.EventWalletUTXOCreated,
+				ConfirmationStatus: "confirmed",
+				AmountSat:          100_000,
+				Txid:               "boarding-txid",
+				OutputIndex:        0,
+				BoardingAddress:    "bcrt1qaddr",
+				CreatedAtUnixS:     100,
+			},
+		},
+	}
+
+	// One reconcile pass flips the stored row to COMPLETE.
+	runtime.reconcileActivity(ctx)
+
+	entry, err = store.GetEntry(ctx, depID)
+	require.NoError(t, err)
+	require.EqualValues(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE, entry.Status,
+		"reconciler must land the confirmed deposit live",
+	)
+
+	events, err := store.PullEvents(ctx, 0, 100)
+	require.NoError(t, err)
+	settled := len(events)
+
+	// A second pass is a no-op: no duplicate transition event.
+	runtime.reconcileActivity(ctx)
+	events, err = store.PullEvents(ctx, 0, 100)
+	require.NoError(t, err)
+	require.Len(
+		t, events, settled, "re-reconcile must append no new event",
+	)
+}
+
+// TestReconcileActivityNoStoreIsNoOp verifies the reconciler is a safe no-op
+// without a canonical store: the loop is never started and a direct pass does
+// not panic.
+func TestReconcileActivityNoStoreIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	deps := &Deps{}
+	runtime := newRuntime(t.Context(), deps)
+	t.Cleanup(runtime.stop)
+
+	require.NotPanics(t, func() {
+		runtime.startReconcilerLoop()
+		runtime.reconcileActivity(context.Background())
+	})
+}

--- a/swapwallet/runtime.go
+++ b/swapwallet/runtime.go
@@ -123,6 +123,7 @@ func (r *Runtime) start() {
 
 		r.startMonitorLoop()
 		r.startCreditProjectorLoop()
+		r.startReconcilerLoop()
 	})
 }
 


### PR DESCRIPTION
## What

C2 of the activity-log epic: make an activity row's terminal transition (PENDING → COMPLETE/FAILED) land in the canonical store **live while the daemon runs**, instead of only at the next startup backfill.

After the C1 read cutover, three terminal flips were backfill-only — a confirmed boarding **DEPOSIT**, a forfeited cooperative-leave **EXIT**, and a completed unilateral **EXIT**. Their pending row was projected live, but the flip to COMPLETE was computed only inside `deriveActivity`, which ran only at startup. So `activity` showed a stale PENDING row until a restart.

## How

A coarse **~60s reconciler loop** (`reconciler.go`) that re-runs the backfill's re-derive-and-project pass (`reprojectActivity`, extracted from `backfillActivity`). Because `ProjectEntry` already suppresses no-op changes, re-projecting is idempotent — a re-run flips a now-settled row and appends exactly one transition event, and leaves unchanged rows untouched. The loop mirrors the credit projector (root-context-anchored, wait-group-drained) and is a no-op without a canonical store.

One behavioral fix: clear a wallet-local EXIT from the in-memory pending map once it's decorated terminal. Nothing cleared it before (only swap/credit rows), so without this the map would leak for the process lifetime and every pass would re-decorate a settled row (re-issuing its `GetUnrollStatus` / forfeit-scan).

## Why a poll, not a block/confirmation hook

swapwallet's `RPCServer` surface is entirely unary — there is no block-epoch / confirmation subscription to hook. A real chain trigger would be net-new streaming plumbing (new RPC + daemon chainntnfs wiring), which is a cost optimization, not a correctness requirement. A plain ticker matches the existing deadline-watcher / credit-projector precedents.

## Scope / deferred

No new daemon records, no proto/sqlc. Deferred: a per-block/confirmation reconcile trigger (cheaper, lower latency); a durable cooperative-leave record (so leave completion is restart-survivable rather than best-effort forfeit-outpoint correlation); startup-at-tip reconciliation (**C5**); live-subscriber push of reconciled terminals (that's the resumable-`SubscribeWallet` event cursor, **C4/#775**) — C2 makes the store/`List` correct.

## Testing

- `reconcileActivity` flips a confirmed DEPOSIT PENDING→COMPLETE live and a second pass appends no duplicate event (idempotency via change-suppression).
- `decorateExitEntry` clears a terminal wallet-local EXIT from the pending map.
- reconciler is a safe no-op without a store.
- Full `swapwallet` suite; `lint-changed-local` (0 issues); `commitmsg-lint`.

**Stacked on #857** (full DEPOSIT liveness relies on that PR's `deposit-<address>` keying; rebase onto main once it merges). Part of #776.
