### PR TITLE
darepod: add testnet4 network support

### DIFF
--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -94,8 +94,8 @@ func newRootCmd() *cobra.Command {
 		"datadir", cfg.DataDir, "root data directory for daemon state",
 	)
 	f.String(
-		"network", cfg.Network,
-		"bitcoin network (mainnet, testnet, regtest, simnet, signet)",
+		"network", cfg.Network, "bitcoin network (mainnet, "+
+			"testnet, testnet4, regtest, simnet, signet)",
 	)
 	f.String(
 		"debuglevel", cfg.DebugLevel,

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -874,8 +874,8 @@ type GetInfoResponse struct {
 	Version string `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
 	// commit is the short git commit hash of this build.
 	Commit string `protobuf:"bytes,2,opt,name=commit,proto3" json:"commit,omitempty"`
-	// network is the active bitcoin network (mainnet, testnet, regtest,
-	// etc.).
+	// network is the active bitcoin network (mainnet, testnet, testnet4,
+	// regtest, etc.).
 	Network string `protobuf:"bytes,3,opt,name=network,proto3" json:"network,omitempty"`
 	// lnd_identity_pubkey is the hex-encoded public identity key of the
 	// connected lnd node, used for Lightning Network peer identity and

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -300,8 +300,8 @@ message GetInfoResponse {
     // commit is the short git commit hash of this build.
     string commit = 2;
 
-    // network is the active bitcoin network (mainnet, testnet, regtest,
-    // etc.).
+    // network is the active bitcoin network (mainnet, testnet, testnet4,
+    // regtest, etc.).
     string network = 3;
 
     // lnd_identity_pubkey is the hex-encoded public identity key of the

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -137,8 +137,8 @@ type Config struct {
 	// files, logs, and TLS material are stored under this directory.
 	DataDir string `mapstructure:"datadir"`
 
-	// Network selects the bitcoin network: mainnet, testnet, regtest, or
-	// simnet.
+	// Network selects the bitcoin network: mainnet, testnet, testnet4,
+	// regtest, simnet, or signet.
 	Network string `mapstructure:"network"`
 
 	// DebugLevel controls the verbosity of daemon logging. A single value
@@ -982,7 +982,7 @@ func (c *Config) Validate() error {
 	}
 
 	switch c.Network {
-	case "mainnet", "testnet", "regtest", "simnet", "signet":
+	case "mainnet", "testnet", "testnet4", "regtest", "simnet", "signet":
 	default:
 		return fmt.Errorf("unknown network %q", c.Network)
 	}
@@ -1211,6 +1211,9 @@ func networkToChainParams(network string) (*chaincfg.Params, error) {
 
 	case "testnet":
 		return &chaincfg.TestNet3Params, nil
+
+	case "testnet4":
+		return &chaincfg.TestNet4Params, nil
 
 	case "regtest":
 		return &chaincfg.RegressionNetParams, nil

--- a/darepod/config_network_test.go
+++ b/darepod/config_network_test.go
@@ -1,0 +1,183 @@
+package darepod
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightninglabs/lndclient"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigValidateAcceptsSupportedNetworks verifies the daemon accepts every
+// public network string it advertises.
+func TestConfigValidateAcceptsSupportedNetworks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		allowMainnet bool
+	}{
+		{
+			name:         "mainnet",
+			allowMainnet: true,
+		},
+		{
+			name: "testnet",
+		},
+		{
+			name: "testnet4",
+		},
+		{
+			name: "regtest",
+		},
+		{
+			name: "simnet",
+		},
+		{
+			name: "signet",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := DefaultConfig()
+			cfg.Network = tc.name
+			cfg.AllowMainnet = tc.allowMainnet
+			cfg.Wallet.EsploraURL = "http://127.0.0.1:3000"
+
+			require.NoError(t, cfg.Validate())
+		})
+	}
+}
+
+// TestConfigValidateAllowsTestnet4InsecureRPC verifies testnet4 remains a test
+// network for daemon-local RPC security validation.
+func TestConfigValidateAllowsTestnet4InsecureRPC(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.Network = "testnet4"
+	cfg.Wallet.EsploraURL = "http://127.0.0.1:3000"
+	cfg.RPC.NoTLS = true
+	cfg.RPC.NoMacaroons = true
+
+	require.NoError(t, cfg.Validate())
+}
+
+// TestNetworkToChainParams verifies network strings map to their exact btcd
+// chain parameters.
+func TestNetworkToChainParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		network string
+		want    *chaincfg.Params
+		wantErr bool
+	}{
+		{
+			network: "mainnet",
+			want:    &chaincfg.MainNetParams,
+		},
+		{
+			network: "testnet",
+			want:    &chaincfg.TestNet3Params,
+		},
+		{
+			network: "testnet4",
+			want:    &chaincfg.TestNet4Params,
+		},
+		{
+			network: "regtest",
+			want:    &chaincfg.RegressionNetParams,
+		},
+		{
+			network: "simnet",
+			want:    &chaincfg.SimNetParams,
+		},
+		{
+			network: "signet",
+			want:    &chaincfg.SigNetParams,
+		},
+		{
+			network: "fakenet",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.network, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := networkToChainParams(tc.network)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Same(t, tc.want, got)
+		})
+	}
+}
+
+// TestNetworkToLndclient verifies network strings map to lndclient networks.
+func TestNetworkToLndclient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		network string
+		want    lndclient.Network
+		wantErr bool
+	}{
+		{
+			network: "mainnet",
+			want:    lndclient.NetworkMainnet,
+		},
+		{
+			network: "testnet",
+			want:    lndclient.NetworkTestnet,
+		},
+		{
+			network: "testnet4",
+			want:    lndclient.NetworkTestnet4,
+		},
+		{
+			network: "regtest",
+			want:    lndclient.NetworkRegtest,
+		},
+		{
+			network: "simnet",
+			want:    lndclient.NetworkSimnet,
+		},
+		{
+			network: "signet",
+			want:    lndclient.NetworkSignet,
+		},
+		{
+			network: "fakenet",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.network, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := networkToLndclient(tc.network)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/darepod/rpc_leave_test.go
+++ b/darepod/rpc_leave_test.go
@@ -67,6 +67,22 @@ func TestResolveLeaveDestinationValidTaproot(t *testing.T) {
 	)
 }
 
+// TestAddrNetNameAcceptsTestNet4 keeps cross-network address errors honest for
+// every daemon network accepted by Config.Validate. Testnet3, testnet4, and
+// signet share address encoding, so the label includes every possible network.
+func TestAddrNetNameAcceptsTestNet4(t *testing.T) {
+	t.Parallel()
+
+	xOnly := make([]byte, 32)
+	xOnly[0] = 0xcd
+	addr, err := btcutil.NewAddressTaproot(
+		xOnly, &chaincfg.TestNet4Params,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, "testnet3/testnet4/signet", addrNetName(addr))
+}
+
 // TestResolveLeaveDestinationPkScript verifies that the pk_script
 // branch returns the bytes verbatim once the class-whitelist guard
 // has accepted them (a structurally-valid P2TR script in this case).

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -3942,25 +3942,29 @@ func (r *RPCServer) unlockVTXOs(ctx context.Context,
 	})
 }
 
-// addrNetName returns a best-effort network name for a decoded
-// address so cross-network error messages can be specific. We
-// iterate the four standard nets and pick the one the address
-// claims IsForNet on; if none match (structurally impossible for
-// anything DecodeAddress returned successfully) we fall back to
-// "unknown" rather than panic.
+// addrNetName returns a best-effort network name for a decoded address so
+// cross-network error messages can be specific. Testnet3 and testnet4 share
+// address encodings, so a single address can honestly match both networks.
+// Report both instead of pretending the address proves one over the other.
 func addrNetName(addr btcutil.Address) string {
+	var matches []string
 	for _, p := range []*chaincfg.Params{
 		&chaincfg.MainNetParams,
 		&chaincfg.TestNet3Params,
+		&chaincfg.TestNet4Params,
 		&chaincfg.SigNetParams,
 		&chaincfg.RegressionNetParams,
 	} {
 		if addr.IsForNet(p) {
-			return p.Name
+			matches = append(matches, p.Name)
 		}
 	}
 
-	return "unknown"
+	if len(matches) == 0 {
+		return "unknown"
+	}
+
+	return strings.Join(matches, "/")
 }
 
 // resolveLeaveDestination extracts the on-chain pkScript from a

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -4761,6 +4761,9 @@ func networkToLndclient(network string) (lndclient.Network, error) {
 	case "testnet":
 		return lndclient.NetworkTestnet, nil
 
+	case "testnet4":
+		return lndclient.NetworkTestnet4, nil
+
 	case "regtest":
 		return lndclient.NetworkRegtest, nil
 

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -96,7 +96,7 @@ darepod \
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--datadir` | `~/.darepod` | Root data directory for all daemon state |
-| `--network` | `mainnet` | Bitcoin network: mainnet, testnet, regtest, simnet, signet |
+| `--network` | `mainnet` | Bitcoin network: mainnet, testnet, testnet4, regtest, simnet, signet |
 | `--debuglevel` | `info` | Logging verbosity: trace, debug, info, warn, error, critical |
 | `--logdir` | `~/.darepod/logs/<network>` | Directory for persistent daemon logs |
 | `--allow-mainnet` | `false` | Required to run on mainnet (safety guard) |

--- a/lwwallet/config.go
+++ b/lwwallet/config.go
@@ -40,7 +40,8 @@ type Config struct {
 	EsploraURL string
 
 	// ChainParams identifies the Bitcoin network (mainnet, testnet,
-	// regtest). Used for address encoding and HD derivation paths.
+	// testnet4, regtest). Used for address encoding and HD derivation
+	// paths.
 	ChainParams *chaincfg.Params
 
 	// PollInterval controls how frequently the chain backend polls the

--- a/rpc/walletdkrpc/wallet.pb.go
+++ b/rpc/walletdkrpc/wallet.pb.go
@@ -3169,7 +3169,8 @@ type StatusResponse struct {
 	// whether wallet RPCs are currently usable.
 	Unlocked bool `protobuf:"varint,2,opt,name=unlocked,proto3" json:"unlocked,omitempty"`
 	// network is the bitcoin network the daemon is configured for, for
-	// example "mainnet", "testnet", "signet", or "regtest".
+	// example "mainnet", "testnet", "testnet4", "signet", or
+	// "regtest".
 	Network string `protobuf:"bytes,3,opt,name=network,proto3" json:"network,omitempty"`
 	// balance is the unified balance summary at the time of the call.
 	Balance *BalanceResponse `protobuf:"bytes,4,opt,name=balance,proto3" json:"balance,omitempty"`

--- a/rpc/walletdkrpc/wallet.proto
+++ b/rpc/walletdkrpc/wallet.proto
@@ -823,7 +823,8 @@ message StatusResponse {
     bool unlocked = 2;
 
     // network is the bitcoin network the daemon is configured for, for
-    // example "mainnet", "testnet", "signet", or "regtest".
+    // example "mainnet", "testnet", "testnet4", "signet", or
+    // "regtest".
     string network = 3;
 
     // balance is the unified balance summary at the time of the call.

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -14,7 +14,7 @@
 # Root data directory for daemon state.
 # datadir=~/.darepod
 
-# Bitcoin network: mainnet, testnet, regtest, simnet, or signet.
+# Bitcoin network: mainnet, testnet, testnet4, regtest, simnet, or signet.
 # network=mainnet
 
 # Logging verbosity. A single level sets the global level; a comma-separated

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -1059,6 +1059,9 @@ func chainParamsForNetwork(network string) (*chaincfg.Params, error) {
 	case "testnet", "testnet3":
 		return &chaincfg.TestNet3Params, nil
 
+	case "testnet4":
+		return &chaincfg.TestNet4Params, nil
+
 	case "regtest":
 		return &chaincfg.RegressionNetParams, nil
 

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -75,6 +75,16 @@ func TestResumePendingStartsWorkersAndDedupes(t *testing.T) {
 	require.True(t, fakeClient.sawPendingOnlyList())
 }
 
+// TestChainParamsForNetworkAcceptsTestNet4 verifies the swapruntime daemon
+// subserver accepts every network string the main daemon config advertises.
+func TestChainParamsForNetworkAcceptsTestNet4(t *testing.T) {
+	t.Parallel()
+
+	params, err := chainParamsForNetwork("testnet4")
+	require.NoError(t, err)
+	require.Same(t, &chaincfg.TestNet4Params, params)
+}
+
 // TestResumeSwapConcurrentCallsStartOnePayWorker drives many manual resume RPCs
 // for the same pay swap at the same time. ResumeSwap is allowed to be retried
 // by clients, but it must not create parallel FSM drivers for one payment hash.

--- a/swapwallet/deps.go
+++ b/swapwallet/deps.go
@@ -271,6 +271,9 @@ func chainParamsForWalletNetwork(network string) (*chaincfg.Params, error) {
 	case "testnet", "testnet3":
 		return &chaincfg.TestNet3Params, nil
 
+	case "testnet4":
+		return &chaincfg.TestNet4Params, nil
+
 	case "regtest":
 		return &chaincfg.RegressionNetParams, nil
 

--- a/swapwallet/normalize.go
+++ b/swapwallet/normalize.go
@@ -351,6 +351,7 @@ func invoiceDecodeNetworks() []*chaincfg.Params {
 	return []*chaincfg.Params{
 		&chaincfg.MainNetParams,
 		&chaincfg.TestNet3Params,
+		&chaincfg.TestNet4Params,
 		&chaincfg.RegressionNetParams,
 		&chaincfg.SigNetParams,
 		&chaincfg.SimNetParams,

--- a/swapwallet/normalize_test.go
+++ b/swapwallet/normalize_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
@@ -90,6 +92,19 @@ func TestKindFromSwapDirection(t *testing.T) {
 			swapclientrpc.SwapDirection_SWAP_DIRECTION_UNSPECIFIED,
 		),
 	)
+}
+
+// TestInvoiceMemoDecodesTestNet4 verifies wallet history normalization can
+// read memos from persisted invoices on every supported daemon network.
+func TestInvoiceMemoDecodesTestNet4(t *testing.T) {
+	t.Parallel()
+
+	invoice, _ := testPreparedInvoiceOnNet(
+		t, &chaincfg.TestNet4Params, btcutil.Amount(12_345),
+		"testnet4 memo",
+	)
+
+	require.Equal(t, "testnet4 memo", invoiceMemo(invoice))
 }
 
 // TestStatusFromSwapState covers every branch: pending always wins,

--- a/swapwallet/register_test.go
+++ b/swapwallet/register_test.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/lightninglabs/darepo-client/darepod"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,16 @@ type fakeWalletBackend struct {
 
 func (f *fakeWalletBackend) ResumePending(_ context.Context) {
 	f.resumeCalls.Add(1)
+}
+
+// TestChainParamsForWalletNetworkAcceptsTestNet4 verifies the walletdkrpc
+// subserver accepts every network string the main daemon config advertises.
+func TestChainParamsForWalletNetworkAcceptsTestNet4(t *testing.T) {
+	t.Parallel()
+
+	params, err := chainParamsForWalletNetwork("testnet4")
+	require.NoError(t, err)
+	require.Same(t, &chaincfg.TestNet4Params, params)
 }
 
 // TestRegisterDefersResumeUntilWalletReadyHook confirms the wallet subserver

--- a/walletcore/config.go
+++ b/walletcore/config.go
@@ -58,7 +58,8 @@ type Config struct {
 	Birthday time.Time
 
 	// ChainParams identifies the Bitcoin network (mainnet, testnet,
-	// regtest). Used for address encoding and HD derivation paths.
+	// testnet4, regtest). Used for address encoding and HD derivation
+	// paths.
 	ChainParams *chaincfg.Params
 
 	// RecoveryWindow specifies the address look-ahead for


### PR DESCRIPTION
## Summary
- accept `testnet4` as a first-class darepod network string
- map `testnet4` to `chaincfg.TestNet4Params` and `lndclient.NetworkTestnet4`
- extend the optional `swapruntime` and `walletdkrpc` chain-param paths to testnet4
- update CLI/docs/proto comments and add focused network mapping coverage

## Tests
- `make rpc`
- `make fmt-changed`
- `make fmt-changed-check`
- `go test ./darepod ./chainfees -run 'Test(ConfigValidateAcceptsSupportedNetworks|ConfigValidateAllowsTestnet4InsecureRPC|NetworkToChainParams|NetworkToLndclient|DefaultMempoolSpaceURL)$'`
- `go test ./darepod -run 'Test(ConfigValidateAcceptsSupportedNetworks|ConfigValidateAllowsTestnet4InsecureRPC|NetworkToChainParams|NetworkToLndclient|AddrNetNameAcceptsTestNet4)$' -count=1`
- `go test -tags="dev nolog swapruntime" ./swapclientserver -count=1`
- `go test -tags="dev nolog walletdkrpc swapruntime" ./swapwallet -count=1`
- `make lint-changed-local`
- `make commitmsg-lint commit=HEAD`
- `make unit pkg=./darepod timeout=10m`
- `make unit pkg=./chainfees timeout=10m`
- `make unit pkg=./... timeout=10m`

Note: `make tidy-module-check` ran `go mod tidy` but failed because the worktree intentionally had uncommitted code changes; no `go.mod` or `go.sum` files changed.
