### PR TITLE
credit: wait for children on registry stop

### DIFF
--- a/credit/op_actor.go
+++ b/credit/op_actor.go
@@ -48,6 +48,25 @@ func (a *OpActor) Stop() {
 	a.durable.Stop()
 }
 
+// StopAndWait stops the underlying durable actor and waits for its worker loop
+// to exit.
+func (a *OpActor) StopAndWait(ctx context.Context) error {
+	if a == nil || a.durable == nil {
+		return nil
+	}
+
+	return a.durable.StopAndWait(ctx)
+}
+
+// Wait blocks until the underlying durable actor exits.
+func (a *OpActor) Wait(ctx context.Context) error {
+	if a == nil || a.durable == nil {
+		return nil
+	}
+
+	return a.durable.Wait(ctx)
+}
+
 // NewOpActor creates and starts one durable per-operation credit actor,
 // restoring its state from the credit_operations row before the mailbox starts
 // draining.

--- a/credit/registry.go
+++ b/credit/registry.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
@@ -16,6 +17,8 @@ import (
 	"github.com/lightninglabs/darepo-client/db"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
+
+const creditChildStopTimeout = 5 * time.Second
 
 // Registry is the credit subsystem coordinator. It is a plain (non-durable)
 // supervisor actor: it admits operations by writing their control-plane row in
@@ -251,13 +254,57 @@ func (b *registryBehavior) Receive(ctx context.Context,
 	}
 }
 
-// OnStop stops resident child actors from the registry actor goroutine. Keeping
-// teardown inside the actor prevents shutdown from racing with terminal-child
-// reaping, which also mutates the active child map.
-func (b *registryBehavior) OnStop(context.Context) error {
-	b.stopChildren()
+// OnStop stops resident child actors from the registry actor goroutine and
+// waits for their durable mailbox workers to exit. Keeping teardown inside the
+// actor prevents shutdown from racing with terminal-child reaping, which also
+// mutates the active child map.
+func (b *registryBehavior) OnStop(ctx context.Context) error {
+	return b.stopChildren(ctx)
+}
 
-	return nil
+// stopChild stops a terminal child and waits under a bounded context so reaping
+// cannot wedge the registry supervisor indefinitely.
+func (b *registryBehavior) stopChild(ctx context.Context, opID string,
+	child *OpActor) {
+
+	stopCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx), creditChildStopTimeout,
+	)
+	defer cancel()
+
+	if err := child.StopAndWait(stopCtx); err != nil {
+		b.logger(ctx).WarnS(ctx, "Unable to stop credit child cleanly",
+			err,
+			slog.String("op_id", opID),
+		)
+	}
+}
+
+// reap stops and drops a child once its operation reaches a terminal status.
+// The durable row is re-checked so a stale notification is harmless. Reaping
+// waits for the child to exit under a short timeout, keeping actor ownership
+// clear without letting one stuck child wedge the coordinator.
+func (b *registryBehavior) reap(ctx context.Context, opID string) {
+	rec, err := b.cfg.Store.GetOperation(ctx, opID)
+	switch {
+	case err == nil && !rec.Status.IsTerminal():
+		// Not actually terminal; ignore the stale notification.
+		return
+
+	case err != nil && !errors.Is(err, db.ErrCreditOperationNotFound):
+		b.logger(ctx).WarnS(ctx, "Unable to confirm credit terminal "+
+			"state", err, slog.String("op_id", opID))
+
+		return
+	}
+
+	if child, ok := b.active[opID]; ok {
+		b.stopChild(ctx, opID, child)
+		delete(b.active, opID)
+		b.logger(ctx).InfoS(ctx, "Credit child reaped",
+			slog.String("op_id", opID),
+		)
+	}
 }
 
 // admit dedups by op key and, for a fresh operation, writes the control-plane
@@ -454,31 +501,6 @@ func (b *registryBehavior) ensureChild(ctx context.Context, opID string) (
 	return child, nil
 }
 
-// reap stops and drops a child once its operation reaches a terminal status.
-// The durable row is re-checked so a stale notification is harmless.
-func (b *registryBehavior) reap(ctx context.Context, opID string) {
-	rec, err := b.cfg.Store.GetOperation(ctx, opID)
-	switch {
-	case err == nil && !rec.Status.IsTerminal():
-		// Not actually terminal; ignore the stale notification.
-		return
-
-	case err != nil && !errors.Is(err, db.ErrCreditOperationNotFound):
-		b.logger(ctx).WarnS(ctx, "Unable to confirm credit terminal "+
-			"state", err, slog.String("op_id", opID))
-
-		return
-	}
-
-	if child, ok := b.active[opID]; ok {
-		child.Stop()
-		delete(b.active, opID)
-		b.logger(ctx).InfoS(ctx, "Credit child reaped",
-			slog.String("op_id", opID),
-		)
-	}
-}
-
 // restoreNonTerminal respawns and resumes every non-terminal operation.
 func (b *registryBehavior) restoreNonTerminal(ctx context.Context) error {
 	rows, err := b.cfg.Store.ListNonTerminal(ctx)
@@ -647,11 +669,23 @@ func (b *registryBehavior) childConfig(opID string) OpActorConfig {
 }
 
 // stopChildren stops every resident child on teardown.
-func (b *registryBehavior) stopChildren() {
-	for opID, child := range b.active {
+func (b *registryBehavior) stopChildren(ctx context.Context) error {
+	for _, child := range b.active {
 		child.Stop()
+	}
+
+	var stopErr error
+	for opID, child := range b.active {
+		if err := child.Wait(ctx); err != nil {
+			stopErr = errors.Join(
+				stopErr, fmt.Errorf("stop credit child %s: %w",
+					opID, err),
+			)
+		}
 		delete(b.active, opID)
 	}
+
+	return stopErr
 }
 
 // newOpID mints a fresh random operation id.

--- a/credit/registry_test.go
+++ b/credit/registry_test.go
@@ -179,6 +179,49 @@ func TestRegistryReceiveReturnsInvoice(t *testing.T) {
 	require.Equal(t, 1, server.createCalls["recv:abc"])
 }
 
+// TestRegistryStopWaitsForResidentChildren asserts Registry.Stop does not
+// return until the per-operation durable actors it owns have exited. The
+// registry tests share a sqlite-backed delivery store with those children, so
+// returning early can race t.TempDir cleanup against a child mailbox still
+// touching the sqlite files.
+func TestRegistryStopWaitsForResidentChildren(t *testing.T) {
+	t.Parallel()
+
+	store, delivery := newFakeStore(), newTestDelivery(t)
+	server, daemon := newFakeServer(), newFakeDaemon()
+
+	registry, err := NewRegistry(RegistryConfig{
+		Store:         store,
+		DeliveryStore: delivery,
+		Server:        server,
+		Daemon:        daemon,
+		PollInterval:  50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	resp, err := registry.Ref().Ask(ctx, &StartCreditReceiveRequest{
+		OpKey:     "recv:stop",
+		AmountSat: 42,
+		Memo:      "shutdown",
+	}).Await(ctx).Unpack()
+	require.NoError(t, err)
+
+	start, ok := resp.(*StartCreditResponse)
+	require.True(t, ok)
+
+	child := registry.behavior.active[start.OpID]
+	require.NotNil(t, child)
+
+	registry.Stop()
+
+	waitCtx, cancel := context.WithTimeout(
+		context.Background(), 5*time.Second,
+	)
+	defer cancel()
+	require.NoError(t, child.Wait(waitCtx))
+}
+
 // TestRegistryListSurfacesTerminalCreditOnly drives a credit-only pay to
 // completion, then asserts the full list surfaces the terminal row (carrying
 // the credit-only marker so the wallet projector can own its transition) while


### PR DESCRIPTION
## Summary

Fixes #862.

This PR makes the credit registry wait for resident durable child actors before `Registry.Stop` returns. The registry already stopped its supervisor actor and called `Stop` on each child during teardown, but child `Stop` is non-blocking. In tests, those children share the sqlite-backed durable mailbox delivery store created under `t.TempDir`. Returning from `Registry.Stop` before the child mailbox worker exits can race Go's tempdir cleanup against sqlite activity, producing failures such as:

```text
TempDir RemoveAll cleanup: unlinkat /tmp/TestRegistryReceiveReturnsInvoice.../001: directory not empty
```

## What Changed

- Added `OpActor.StopAndWait(ctx)` and `OpActor.Wait(ctx)` wrappers around the underlying durable actor.
- Updated registry shutdown to stop resident children synchronously from the supervisor actor's `OnStop` hook.
- Updated terminal reaping to wait for a child actor to exit before dropping it from the active map.
- Added `TestRegistryStopWaitsForResidentChildren`, which exercises the receive path that surfaced the flake and asserts that the child actor is stopped by the time `Registry.Stop` returns.

## Why

The sqlite test helper closes the database at test cleanup, and then `t.TempDir` removes the directory. That cleanup assumes all users of the sqlite files have stopped. The registry supervisor was waiting for its own goroutine but not for the durable child goroutines it owned, so a child mailbox could still be polling or acking against the same database after the parent cleanup continued.

Waiting for children makes ownership explicit: the registry owns the child actor lifetime, and the delivery store outlives every actor using it.

## Validation

```shell
make unit pkg=./credit timeout=5m
go test -tags="dev nolog" -run 'TestRegistry(ReceiveReturnsInvoice|StopWaitsForResidentChildren)$' -count=100 ./credit
make fmt-changed && make lint-changed-local
make commitmsg-lint range="origin/main..HEAD"
```
