### PR TITLE
db: harden Postgres fixture cleanup

### DIFF
--- a/db/test_postgres.go
+++ b/db/test_postgres.go
@@ -75,13 +75,19 @@ func NewTestDBHandleFromPath(t testing.TB, dbPath string) *PostgresStore {
 		)
 
 		store, err := NewPostgresStore(sqlFixture.GetConfig(), log)
-		require.NoError(t, err)
+		if err != nil {
+			sqlFixture.TearDown(t)
+			require.NoError(t, err)
+		}
 
 		testPgFixtureMtx.Lock()
 		existingFixture, alreadyCreated := testPgFixturesByPath[dbPath]
 		if alreadyCreated {
 			testPgFixtureMtx.Unlock()
 
+			// Defensive guard: callers should only reopen dbPath
+			// sequentially within one test, but avoid leaking an
+			// extra fixture if that invariant is violated.
 			_ = store.DB.Close()
 			sqlFixture.TearDown(t)
 
@@ -101,13 +107,13 @@ func NewTestDBHandleFromPath(t testing.TB, dbPath string) *PostgresStore {
 		testPgFixtureMtx.Unlock()
 
 		t.Cleanup(func() {
-			sqlFixture.TearDown(t)
-
 			testPgFixtureMtx.Lock()
 			if testPgFixturesByPath[dbPath] == sqlFixture {
 				delete(testPgFixturesByPath, dbPath)
 			}
 			testPgFixtureMtx.Unlock()
+
+			sqlFixture.TearDown(t)
 		})
 
 		// Close this pool at test end even if the caller's restart

--- a/wallet/send_onchain_replay_test.go
+++ b/wallet/send_onchain_replay_test.go
@@ -344,7 +344,10 @@ func TestHandleSendOnChainCallerCancelKeepsIntent(t *testing.T) {
 			ReleasedCount: 1,
 		},
 	}
-	roundActor := &mockRoundActorBehavior{}
+	registerGate := make(chan struct{})
+	roundActor := &mockRoundActorBehavior{
+		registerGate: registerGate,
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -360,6 +363,9 @@ func TestHandleSendOnChainCallerCancelKeepsIntent(t *testing.T) {
 	}).Return(nil)
 
 	w := newSendReplayTestWallet(t, mgr, roundActor, store, nil)
+	t.Cleanup(func() {
+		close(registerGate)
+	})
 
 	priv, err := btcec.NewPrivateKey()
 	require.NoError(t, err)

--- a/wallet/wallet_admission_test.go
+++ b/wallet/wallet_admission_test.go
@@ -441,6 +441,11 @@ type mockRoundActorBehavior struct {
 	// registerErr when set causes RegisterIntentMsg to fail.
 	registerErr error
 
+	// registerGate, when set, blocks RegisterIntentMsg handling until
+	// the channel is closed. Tests use this to keep the Ask pending
+	// while exercising caller-side Await cancellation.
+	registerGate <-chan struct{}
+
 	// registerCalls tracks how many times RegisterIntentMsg was received.
 	registerCalls int
 
@@ -502,6 +507,10 @@ func (m *mockRoundActorBehavior) Receive(_ context.Context,
 
 	switch typedMsg := msg.(type) {
 	case *actormsg.RegisterIntentMsg:
+		if m.registerGate != nil {
+			<-m.registerGate
+		}
+
 		m.registerCalls++
 		m.capturedIntent = typedMsg
 


### PR DESCRIPTION
## Summary
- tear down a newly created Postgres fixture if opening the first store fails
- evict path-cache entries before purging the fixture container during cleanup
- document the duplicate-creator branch as a defensive invariant guard

## Review comment analysis
- Copilot was right: after `NewTestPgFixture`, a `NewPostgresStore` failure could skip `TearDown` and leak the fixture semaphore slot.
- Gemini was directionally right: cleanup should delete the cache entry before Docker purge so no caller can observe a tearing-down fixture. This is defensive under the documented per-test path invariant, but cheap and safer.
- Claude's nit about the double-check branch being defensive-only was also valid, so this adds a short comment.

## Verification
- `go test -tags="dev test_postgres nolog" ./db -run '^$'`
- `make fmt-changed`
- `make lint-changed-local`

Follow-up to #864.