### PR TITLE
multi: fix inverted swap-direction wording in wallet facade docs

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_recv.go
+++ b/cmd/darepocli/darepoclicommands/cmd_recv.go
@@ -17,7 +17,7 @@ func newRecvCmd() *cobra.Command {
 		Short: "Receive a payment (offchain invoice / onchain addr)",
 		Long: "Asks the daemon to materialize an inbound payment " +
 			"surface. With --offchain (default) the daemon opens " +
-			"a swap-in and returns a BOLT-11 invoice signed " +
+			"an out-swap and returns a BOLT-11 invoice signed " +
 			"with a daemon-managed key. With --onchain the " +
 			"daemon returns a fresh boarding address; fund it " +
 			"and the daemon rolls the boarding output into the " +

--- a/rpc/walletdkrpc/wallet.pb.go
+++ b/rpc/walletdkrpc/wallet.pb.go
@@ -1029,9 +1029,9 @@ type isPrepareSendRequest_Destination interface {
 }
 
 type PrepareSendRequest_Invoice struct {
-	// invoice is a BOLT-11 Lightning invoice. The daemon opens an
-	// out-swap; the swap server picks same-Ark p2p vs real Lightning
-	// transparently.
+	// invoice is a BOLT-11 Lightning invoice. The daemon pays it via
+	// its owned swap subsystem; the swap server picks same-Ark p2p vs
+	// real Lightning transparently.
 	Invoice string `protobuf:"bytes,1,opt,name=invoice,proto3,oneof"`
 }
 

--- a/rpc/walletdkrpc/wallet.proto
+++ b/rpc/walletdkrpc/wallet.proto
@@ -38,9 +38,9 @@ service WalletService {
     rpc Send (SendRequest) returns (SendResponse);
 
     // Recv asks the daemon for a Lightning invoice the caller can hand
-    // out. Internally this opens a swap-in via the daemon-owned swap
-    // subsystem; the invoice is signed with a daemon-managed key, not an
-    // ephemeral process-local key.
+    // out. Internally the daemon sets up the inbound receive via its
+    // owned swap subsystem; the invoice is signed with a daemon-managed
+    // key, not an ephemeral process-local key.
     rpc Recv (RecvRequest) returns (RecvResponse);
 
     // List returns the unified wallet view selected by ListRequest.view:
@@ -261,9 +261,9 @@ message PrepareSendRequest {
     // destination selects the outbound payment target. Exactly one
     // variant must be set.
     oneof destination {
-        // invoice is a BOLT-11 Lightning invoice. The daemon opens an
-        // out-swap; the swap server picks same-Ark p2p vs real Lightning
-        // transparently.
+        // invoice is a BOLT-11 Lightning invoice. The daemon pays it via
+        // its owned swap subsystem; the swap server picks same-Ark p2p vs
+        // real Lightning transparently.
         string invoice = 1;
 
         // onchain_address is a bech32 onchain destination. The daemon

--- a/rpc/walletdkrpc/wallet_grpc.pb.go
+++ b/rpc/walletdkrpc/wallet_grpc.pb.go
@@ -69,9 +69,9 @@ type WalletServiceClient interface {
 	// total-outflow details before funds move.
 	Send(ctx context.Context, in *SendRequest, opts ...grpc.CallOption) (*SendResponse, error)
 	// Recv asks the daemon for a Lightning invoice the caller can hand
-	// out. Internally this opens a swap-in via the daemon-owned swap
-	// subsystem; the invoice is signed with a daemon-managed key, not an
-	// ephemeral process-local key.
+	// out. Internally the daemon sets up the inbound receive via its
+	// owned swap subsystem; the invoice is signed with a daemon-managed
+	// key, not an ephemeral process-local key.
 	Recv(ctx context.Context, in *RecvRequest, opts ...grpc.CallOption) (*RecvResponse, error)
 	// List returns the unified wallet view selected by ListRequest.view:
 	// ACTIVITY (default) is the merged WalletEntry stream; VTXOS is the
@@ -306,9 +306,9 @@ type WalletServiceServer interface {
 	// total-outflow details before funds move.
 	Send(context.Context, *SendRequest) (*SendResponse, error)
 	// Recv asks the daemon for a Lightning invoice the caller can hand
-	// out. Internally this opens a swap-in via the daemon-owned swap
-	// subsystem; the invoice is signed with a daemon-managed key, not an
-	// ephemeral process-local key.
+	// out. Internally the daemon sets up the inbound receive via its
+	// owned swap subsystem; the invoice is signed with a daemon-managed
+	// key, not an ephemeral process-local key.
 	Recv(context.Context, *RecvRequest) (*RecvResponse, error)
 	// List returns the unified wallet view selected by ListRequest.view:
 	// ACTIVITY (default) is the merged WalletEntry stream; VTXOS is the

--- a/swapwallet/doc.go
+++ b/swapwallet/doc.go
@@ -15,7 +15,7 @@
 //     the swap subsystem (which may settle as a same-Ark p2p vHTLC or a real
 //     Lightning hop, transparently); onchain destinations are routed through
 //     LeaveVTXOs cooperative exits. The caller never sees swap vocabulary.
-//   - Recv asks the daemon to open a swap-in and returns a BOLT-11 invoice
+//   - Recv asks the daemon to open an out-swap and returns a BOLT-11 invoice
 //     signed with a daemon-managed payment-scoped auth key.
 //   - List merges swap, OOR, boarding, and exit history into the flat
 //     WalletEntry shape sorted by updated-at descending.

--- a/swapwallet/recv.go
+++ b/swapwallet/recv.go
@@ -29,7 +29,7 @@ func newReceiver(deps *Deps, runtime *Runtime) *receiver {
 	return &receiver{deps: deps, runtime: runtime}
 }
 
-// Recv opens a swap-in session via the daemon-owned swap subserver and
+// Recv opens an out-swap session via the daemon-owned swap subserver and
 // returns the daemon-signed BOLT-11 invoice plus the initial WalletEntry.
 // Background lifecycle (waiting for the LN payer, claiming the vHTLC,
 // terminal transitions) is owned by the swap subsystem; the wallet layer

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -126,7 +126,7 @@ func (s *Service) ExitStatus(ctx context.Context,
 	return s.exitStatus(ctx, req)
 }
 
-// Recv opens a swap-in via the daemon-owned swap subserver and returns the
+// Recv opens an out-swap via the daemon-owned swap subserver and returns the
 // daemon-signed BOLT-11 invoice plus the initial WalletEntry. The invoice
 // is signed with a payment-scoped daemon-managed auth key (PR #337);
 // nothing in the wallet layer generates or holds raw private keys.


### PR DESCRIPTION
## Summary

The wallet-facing facade describes `Recv` (Lightning receive) as opening a
"swap-in" and the invoice `Send` / `PrepareSend` (pay) as an "out-swap." That is
backwards relative to the swap subsystem's own canonical convention, where an
**in-swap is the Ark-to-Lightning pay direction** and an **out-swap is the
Lightning-to-Ark receive direction** (see `swaprpc` / `sdk/swaps`, e.g.
`CreateInSwap initiates an Ark-to-Lightning swap` and the `out-swap HTLC
notification for one receive invoice`). The wrong terminology flowed downstream
into the generated SDK API reference and confused a protocol reviewer.

The fix is split by layer:

- `wallet.proto` is documented as a "simplified, swap-vocabulary-free wallet
  API," and these two comments were the only place leaking swap-direction jargon
  into it. They are reworded to drop the jargon entirely and describe the
  operations as receive / send.
- The internal Go comments and CLI help legitimately use the swap subsystem's
  vocabulary, so those are left using it: just the inverted direction is
  corrected (a receive is an `out-swap`).

## Changes

- `rpc/walletdkrpc/wallet.proto`: reword the `Recv` RPC and
  `PrepareSendRequest.invoice` comments to describe receive / send without
  "swap-in" / "out-swap." Updated the generated `wallet.pb.go` and
  `wallet_grpc.pb.go` doc comments to match.
- `swapwallet/service.go`, `swapwallet/recv.go`, `swapwallet/doc.go`: correct
  the `Recv` doc comments from "swap-in" to "out-swap" (its actual direction).
- `cmd/darepocli/darepoclicommands/cmd_recv.go`: same direction fix in the
  `recv --offchain` CLI help text.
- No behavior change; comments only. The swap subsystem's own in-swap /
  out-swap vocabulary (`swaprpc`, `swapclientserver`, `sdk/swaps`) is correct
  and left untouched.

## Testing

- `git grep -nE 'swap-in' rpc/walletdkrpc swapwallet cmd` returns no matches,
  and the remaining `out-swap` usages describe the receive direction correctly.
- Comment-only change; no build or runtime behavior affected.
- The generated `.pb.go` comments were synced by hand to match the proto;
  running `make rpc` should confirm no drift.
