### PR TITLE
harness: add opt-in --requireinterceptor for the primary lnd

### DIFF
--- a/harness/harness.go
+++ b/harness/harness.go
@@ -302,6 +302,12 @@ type Options struct {
 	// LNDImage is the docker image:tag to use for lnd.
 	LNDImage string
 
+	// LNDRequireInterceptor, when true, starts the main lnd node with
+	// --requireinterceptor so held HTLCs are retained on interceptor
+	// disconnect and replayed on reconnect, rather than resumed and failed.
+	// It applies only to the primary lnd; additional nodes never set it.
+	LNDRequireInterceptor bool
+
 	// LNDBuildPath is optional: build LND image from local path instead of
 	// pulling tag. Leave empty to skip build and pull image instead.
 	LNDBuildPath string
@@ -2155,7 +2161,9 @@ func (h *Harness) bitcoindSendToAddress(address string, amount float64) string {
 // startLND launches an lnd container and waits until its gRPC is responsive
 // and TLS cert and admin macaroon are available.
 func (h *Harness) startLND() *LndInstance {
-	inst := h.startLNDInstance("lnd", h.lndDataDir)
+	inst := h.startLNDInstance(
+		"lnd", h.lndDataDir, h.opts.LNDRequireInterceptor,
+	)
 	h.lnd = inst.Resource
 	h.LNDGRPCPort = inst.GRPCPort
 	h.LNDRestPort = inst.RESTPort
@@ -2165,19 +2173,22 @@ func (h *Harness) startLND() *LndInstance {
 	return inst
 }
 
-func (h *Harness) startLNDInstance(name, dataDir string) *LndInstance {
+func (h *Harness) startLNDInstance(name, dataDir string,
+	requireInterceptor bool) *LndInstance {
+
 	h.T.Helper()
 
 	require.NoError(h.T, os.MkdirAll(dataDir, 0o755))
 
 	res := h.startLNDContainer(lndConfig{
-		name:         name,
-		dataDir:      dataDir,
-		bitcoindName: h.bitcoindName,
-		network:      h.network,
-		group:        h.group,
-		image:        imageRepo(h.opts.LNDImage),
-		tag:          imageTag(h.opts.LNDImage),
+		name:               name,
+		dataDir:            dataDir,
+		bitcoindName:       h.bitcoindName,
+		network:            h.network,
+		group:              h.group,
+		image:              imageRepo(h.opts.LNDImage),
+		tag:                imageTag(h.opts.LNDImage),
+		requireInterceptor: requireInterceptor,
 	})
 
 	inst := &LndInstance{
@@ -2336,7 +2347,7 @@ func (h *Harness) StartAdditionalLND(name string) *LndInstance {
 	}
 
 	dataDir := filepath.Join(h.artifactsDir, name)
-	inst := h.startLNDInstance(name, dataDir)
+	inst := h.startLNDInstance(name, dataDir, false)
 	h.initAndWaitLNDInstance(inst)
 	h.extraLNDs[name] = inst
 

--- a/harness/tapd_harness.go
+++ b/harness/tapd_harness.go
@@ -74,6 +74,11 @@ type lndConfig struct {
 	group        string
 	image        string
 	tag          string
+
+	// requireInterceptor starts the node with --requireinterceptor so held
+	// HTLCs survive an interceptor disconnect. Only the primary swap node
+	// sets it.
+	requireInterceptor bool
 }
 
 // tapdConfig holds the configuration for starting a tapd container.
@@ -169,6 +174,13 @@ func (h *Harness) startLNDContainer(cfg lndConfig) *dockertest.Resource {
 		"--accept-keysend",
 		"--protocol.option-scid-alias",
 		"--protocol.zero-conf",
+	}
+
+	// The swap node must retain and replay held HTLCs across an interceptor
+	// disconnect rather than resuming (and thus failing) them, which is
+	// what out-swap fund safety depends on.
+	if cfg.requireInterceptor {
+		cmd = append(cmd, "--requireinterceptor")
 	}
 
 	lndHostDir, err := filepath.Abs(cfg.dataDir)


### PR DESCRIPTION
Add `Options.LNDRequireInterceptor`, threaded through `startLNDInstance` into the primary lnd container args as `--requireinterceptor`. Only the primary swap node sets it; additional nodes (payer, extra) never do, so their forwarding is unaffected.

The swapdk server's out-swap disconnect itests use this to run the swap lnd under lnd's retain-and-replay-on-reconnect interceptor policy, which out-swap fund safety depends on when a held HTLC's subscriber drops.