### PR TITLE
oor: avoid stale self-transfer reaps

### DIFF
--- a/oor/registry.go
+++ b/oor/registry.go
@@ -214,10 +214,11 @@ func NewOORRegistryActor(cfg OORRegistryConfig) (*OORRegistryActor, error) {
 	cfg.Limits = normalizeReceiveLimits(cfg.Limits)
 
 	behavior := &oorRegistryBehavior{
-		cfg:      cfg,
-		log:      cfg.Log.UnwrapOr(btclog.Disabled),
-		active:   make(map[SessionID]*OORSessionActor),
-		incoming: make(map[SessionID]struct{}),
+		cfg:        cfg,
+		log:        cfg.Log.UnwrapOr(btclog.Disabled),
+		active:     make(map[SessionID]*OORSessionActor),
+		activeDirs: make(map[SessionID]clientdb.OORSessionDirection),
+		incoming:   make(map[SessionID]struct{}),
 		parkedSelfHints: make(
 			map[SessionID]*ResolveIncomingTransferRequest,
 		),
@@ -302,6 +303,13 @@ type oorRegistryBehavior struct {
 	cfg    OORRegistryConfig
 	log    btclog.Logger
 	active map[SessionID]*OORSessionActor
+
+	// activeDirs tracks the direction of each resident child in active. A
+	// terminal notification carries only the session id, so the registry
+	// uses this map to distinguish a stale outgoing-child notification from
+	// a replacement incoming child admitted under the same self-transfer
+	// session id.
+	activeDirs map[SessionID]clientdb.OORSessionDirection
 
 	// incoming tracks the session ids of resident incoming receive children
 	// so admission can bound their count. It is a subset of active,
@@ -1093,6 +1101,21 @@ func (r *oorRegistryBehavior) handleSessionTerminal(ctx context.Context,
 	case err != nil:
 		return fn.Err[ActorResp](err)
 
+	case r.activeDirectionKnown(msg.SessionID) &&
+		record.Direction != r.activeDirs[msg.SessionID]:
+
+		r.logger(ctx).DebugS(ctx, "Ignoring stale terminal OOR "+
+			"session notification for replaced child",
+			slog.String("session_id", msg.SessionID.String()),
+			slog.Int("record_direction", int(record.Direction)),
+			slog.Int(
+				"active_direction",
+				int(r.activeDirs[msg.SessionID]),
+			),
+		)
+
+		return fn.Ok[ActorResp](&DriveEventResponse{})
+
 	// The row is authoritative: a notification that races a later
 	// non-terminal write (or a replaced session) must not reap a live
 	// child.
@@ -1116,6 +1139,16 @@ func (r *oorRegistryBehavior) handleSessionTerminal(ctx context.Context,
 	// retention sweep, if ever needed, should age out all terminal rows
 	// uniformly rather than deleting one class at reap time.
 	return fn.Ok[ActorResp](&DriveEventResponse{})
+}
+
+// activeDirectionKnown reports whether the registry knows the direction of the
+// resident child. Production children are installed through ensureChild, which
+// records the direction; tests and hand-constructed behaviors may still install
+// active entries directly, and those should keep the historical reap behavior.
+func (r *oorRegistryBehavior) activeDirectionKnown(sessionID SessionID) bool {
+	_, ok := r.activeDirs[sessionID]
+
+	return ok
 }
 
 // handleResumeSession routes a retry-timer expiry to its session's child so
@@ -1388,6 +1421,7 @@ func (r *oorRegistryBehavior) ensureChild(sessionID SessionID,
 	}
 
 	r.active[sessionID] = child
+	r.activeDirs[sessionID] = direction
 	if direction == clientdb.OORSessionDirectionIncoming {
 		r.incoming[sessionID] = struct{}{}
 	}
@@ -1409,6 +1443,7 @@ func (r *oorRegistryBehavior) dropChild(sessionID SessionID,
 
 	child.Stop()
 	delete(r.active, sessionID)
+	delete(r.activeDirs, sessionID)
 	delete(r.incoming, sessionID)
 }
 

--- a/oor/registry_test.go
+++ b/oor/registry_test.go
@@ -140,9 +140,10 @@ func newTestRegistryBehavior(store SessionRegistryStore) (*oorRegistryBehavior,
 			RegistryStore: store,
 			Limits:        DefaultReceiveLimits(),
 		},
-		log:      btclog.Disabled,
-		active:   make(map[SessionID]*OORSessionActor),
-		incoming: make(map[SessionID]struct{}),
+		log:        btclog.Disabled,
+		active:     make(map[SessionID]*OORSessionActor),
+		activeDirs: make(map[SessionID]clientdb.OORSessionDirection),
+		incoming:   make(map[SessionID]struct{}),
 	}
 	b.spawnFunc = func(id SessionID, dir clientdb.OORSessionDirection) (
 		*OORSessionActor, error) {
@@ -1076,6 +1077,38 @@ func TestOORRegistrySelfTransferParkAndRedrive(t *testing.T) {
 		rec.dirs,
 	)
 	require.Empty(t, b.parkedSelfHints)
+}
+
+// TestOORRegistryStaleTerminalDoesNotReapReplacementIncoming verifies that an
+// outgoing terminal notification racing an incoming self-transfer replacement
+// cannot reap the fresh incoming child before it commits its first snapshot.
+func TestOORRegistryStaleTerminalDoesNotReapReplacementIncoming(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	id := oorSessionID(0x72)
+
+	store := newFakeRegistryStore()
+	upsertRegistryRow(
+		t, store, id, clientdb.OORSessionDirectionOutgoing, "completed",
+		"", clientdb.OORSessionStatusCompleted,
+	)
+
+	b, rec := newTestRegistryBehavior(store)
+	child, err := b.ensureChild(id, clientdb.OORSessionDirectionIncoming)
+	require.NoError(t, err)
+	require.NotNil(t, child)
+
+	res := b.Receive(ctx, &SessionTerminalNotification{
+		SessionID: id,
+	}, fakeExec{})
+	require.True(t, res.IsOk(), res.Err())
+
+	require.Contains(t, b.active, id)
+	require.Equal(
+		t, clientdb.OORSessionDirectionIncoming, b.activeDirs[id],
+	)
+	require.Equal(t, 0, rec.stopCount())
 }
 
 // TestOORRegistryDurableEndToEnd exercises the durable registry against a


### PR DESCRIPTION
## Summary

This PR fixes an intermittent OOR self-transfer race observed by `swapdk-server` in `TestInSwapLateFundAfterExpiryClientUnilateralRefund`.

When a client sends an OOR transfer to one of its own receive scripts, the outgoing OOR session and the incoming recipient session share the same deterministic session id. The registry already has logic to admit the incoming replacement only after the outgoing session reaches a terminal state, but terminal notifications only carried the session id. That let a stale terminal notification from the outgoing child race with the replacement incoming child and reap whichever child was currently active under that id.

The failure mode is:

1. The outgoing OOR session commits `completed`.
2. A terminal notification is sent asynchronously to the registry.
3. The incoming self-transfer hint is admitted and an incoming child is installed under the same session id.
4. The stale outgoing terminal notification reaches the registry before the incoming child commits its first snapshot.
5. The registry sees a terminal durable row for that session id and drops the active child, which is now the incoming replacement.
6. The incoming `ResolveIncomingTransferRequest` stays in the session mailbox, so the recipient VTXO exists on the operator/indexer side but never becomes a live local wallet VTXO.

## Changes

- Track the direction of each active OOR session child alongside the active child map.
- Ignore terminal notifications whose durable row direction does not match the currently active child direction.
- Keep historical behavior for hand-constructed/test-only active entries that do not have direction metadata.
- Add a regression test that models a terminal outgoing row, an active replacement incoming child, and a stale terminal notification racing in afterward.

## Validation

- `go test ./oor -run 'TestOORRegistry(SelfTransferParkAndRedrive|StaleTerminalDoesNotReapReplacementIncoming|SessionTerminal|RestoreNonTerminal)' -count=1`
- `go test ./oor ./darepod -count=1`
- `make lint`
- `make commitmsg-lint commit=HEAD`

The first `make lint` attempt hit a transient Docker/compiler resource failure (`compile: signal: killed`) while typechecking an unrelated package. A rerun with warm caches completed successfully with zero issues.

Fixes lightninglabs/swapdk-server#195
