### PR TITLE
multi: lnd package relay (WalletKit.SubmitPackage) + itest harness support

### DIFF
--- a/chainbackends/lnd.go
+++ b/chainbackends/lnd.go
@@ -18,6 +18,15 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
 
+// lndNeutrinoBroadcastMsg mirrors the PackageMsg that a neutrino-backed lnd
+// returns from WalletKit.SubmitPackage. A light client has no mempool and
+// cannot validate or atomically accept a package, so lnd instead broadcasts
+// each transaction individually over P2P (relying on a peer's 1p1c relay to
+// reassemble the package) and reports this sentinel rather than "success". It
+// is kept in sync with lnd's btcwallet.neutrinoBroadcastMsg, which is
+// unexported there and so must be matched by value.
+const lndNeutrinoBroadcastMsg = "broadcast-unverified"
+
 // TxBroadcaster is a minimal interface for broadcasting transactions. This
 // allows LNDBackend to work with both lnwallet.WalletController (in-process
 // lnd) and lndclient wrappers (remote lnd via gRPC).
@@ -241,6 +250,22 @@ func (b *LNDBackend) SubmitPackage(ctx context.Context, parents []*wire.MsgTx,
 				),
 			)
 		}
+	}
+
+	// A neutrino-backed lnd cannot return a package-accept verdict; it
+	// broadcasts each tx individually over P2P and reports the best-effort
+	// sentinel instead of "success". The transactions are already on the
+	// wire and carry no per-tx errors, so treat this as a successful
+	// broadcast and let the confirmation watch decide the outcome, rather
+	// than failing the submit as if the package had been rejected.
+	if result.PackageMsg == lndNeutrinoBroadcastMsg && len(txErrors) == 0 {
+		b.logger(ctx).InfoS(
+			ctx,
+			"Package broadcast best-effort via light client",
+			slog.Int("tx_count", len(parents)+1),
+		)
+
+		return nil
 	}
 
 	// On rejection, only wrap txErrors via %w when we actually have

--- a/chainbackends/lnd_test.go
+++ b/chainbackends/lnd_test.go
@@ -335,6 +335,33 @@ func TestSubmitPackageRejectedWithoutTxErrors(t *testing.T) {
 	require.NotContains(t, err.Error(), "%!w(<nil>)")
 }
 
+// TestSubmitPackageNeutrinoBestEffort verifies that a neutrino-backed lnd's
+// best-effort broadcast ("broadcast-unverified", no per-tx errors) is treated
+// as a successful submit rather than a package rejection, so the caller does
+// not spuriously fail an exit that lnd has already broadcast one-by-one.
+func TestSubmitPackageNeutrinoBestEffort(t *testing.T) {
+	t.Parallel()
+
+	backend := NewLNDBackend(
+		&stubNotifier{}, &stubFeeEstimator{}, &stubBroadcaster{},
+	)
+	backend.SetPackageSubmitter(&stubPackageSubmitter{
+		result: &btcjson.SubmitPackageResult{
+			PackageMsg: lndNeutrinoBroadcastMsg,
+			TxResults: map[string]btcjson.SubmitPackageTxResult{
+				"wtxid-1": {
+					TxID: chainhash.Hash{1},
+				},
+			},
+		},
+	})
+
+	err := backend.SubmitPackage(
+		t.Context(), []*wire.MsgTx{wire.NewMsgTx(3)}, wire.NewMsgTx(3),
+	)
+	require.NoError(t, err)
+}
+
 const (
 	pollInterval = 50 * time.Millisecond
 	testTimeout  = 5 * pollInterval

--- a/chainbackends/lndsubmitter/submitter.go
+++ b/chainbackends/lndsubmitter/submitter.go
@@ -1,0 +1,130 @@
+// Package lndsubmitter provides a chainbackends.PackageSubmitter backed by
+// lnd's WalletKit.SubmitPackage RPC. It lets a darepod using the lnd wallet
+// relay its zero-fee unilateral-exit v3/TRUC packages through lnd's own chain
+// connection, so no separate bitcoind RPC or Esplora endpoint is required.
+package lndsubmitter
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+)
+
+const (
+	// satoshiPerBTC is the number of satoshis in one bitcoin. It converts
+	// the chainbackends interface's BTC/kvB fee-rate ceiling into the
+	// sat/vByte unit lnd's SubmitPackage RPC expects.
+	satoshiPerBTC = 1e8
+
+	// vBytesPerKvB is the number of virtual bytes in one kilo-virtual-byte
+	// (the "kvB" denominator of bitcoind's BTC/kvB maxfeerate).
+	vBytesPerKvB = 1000
+)
+
+// walletKitSubmitter is the subset of lndclient.WalletKitClient used to submit
+// a package. lndclient.WalletKitClient satisfies it; narrowing the surface
+// keeps the submitter easy to fake in tests.
+type walletKitSubmitter interface {
+	// SubmitPackage submits a topologically-sorted package (unconfirmed
+	// parents first, child last) to lnd's chain backend. A nil maxFeeRate
+	// leaves the node default unchanged.
+	SubmitPackage(ctx context.Context, txns []*wire.MsgTx,
+		maxFeeRate *chainfee.SatPerVByte) (
+		*lndclient.SubmitPackageResult, error)
+}
+
+// Submitter relays v3 CPFP packages through lnd's WalletKit.SubmitPackage RPC.
+type Submitter struct {
+	walletKit walletKitSubmitter
+}
+
+// New creates a Submitter backed by the given lndclient WalletKit client.
+func New(walletKit walletKitSubmitter) *Submitter {
+	return &Submitter{walletKit: walletKit}
+}
+
+// SubmitPackage implements chainbackends.PackageSubmitter. It assembles the
+// parents-first, child-last package, forwards it to lnd's
+// WalletKit.SubmitPackage RPC, and maps the lndclient-native result back to
+// the btcjson type callers expect.
+func (s *Submitter) SubmitPackage(ctx context.Context, parents []*wire.MsgTx,
+	child *wire.MsgTx, maxFeeRate *float64) (*btcjson.SubmitPackageResult,
+	error) {
+
+	// Guard against nil transactions up front: they would otherwise panic
+	// deep in lndclient/wire serialization with a nil pointer dereference.
+	if child == nil {
+		return nil, fmt.Errorf("nil child transaction")
+	}
+	for i, parent := range parents {
+		if parent == nil {
+			return nil, fmt.Errorf("nil parent transaction at "+
+				"index %d", i)
+		}
+	}
+
+	txns := make([]*wire.MsgTx, 0, len(parents)+1)
+	txns = append(txns, parents...)
+	txns = append(txns, child)
+
+	// chainbackends.PackageSubmitter carries the optional ceiling as a
+	// *float64 in BTC/kvB (bitcoind's maxfeerate shape), while lnd's RPC
+	// wants an integer sat/vByte, so convert. Round to nearest rather than
+	// truncate: truncation would silently lower the ceiling (e.g. 12.5
+	// sat/vByte → 12), making it stricter than the caller asked for. A nil
+	// value passes through as the node default.
+	var rate *chainfee.SatPerVByte
+	if maxFeeRate != nil {
+		satPerVByte := chainfee.SatPerVByte(
+			math.Round(
+				*maxFeeRate * satoshiPerBTC / vBytesPerKvB,
+			),
+		)
+		rate = &satPerVByte
+	}
+
+	res, err := s.walletKit.SubmitPackage(ctx, txns, rate)
+	if err != nil {
+		return nil, fmt.Errorf("lnd submit package: %w", err)
+	}
+	if res == nil {
+		return nil, fmt.Errorf("lnd submit package returned nil result")
+	}
+
+	return mapResult(res), nil
+}
+
+// mapResult converts the lndclient-native SubmitPackageResult into the
+// btcjson.SubmitPackageResult returned by chainbackends.PackageSubmitter.
+func mapResult(
+	res *lndclient.SubmitPackageResult) *btcjson.SubmitPackageResult {
+
+	out := &btcjson.SubmitPackageResult{
+		PackageMsg:           res.PackageMsg,
+		ReplacedTransactions: res.ReplacedTransactions,
+		TxResults: make(
+			map[string]btcjson.SubmitPackageTxResult,
+			len(res.TxResults),
+		),
+	}
+
+	for wtxid, r := range res.TxResults {
+		entry := btcjson.SubmitPackageTxResult{TxID: r.Txid}
+
+		// Only surface a rejection reason when lnd reported one; an
+		// empty string means the tx was accepted.
+		if r.Err != "" {
+			reason := r.Err
+			entry.Error = &reason
+		}
+
+		out.TxResults[wtxid] = entry
+	}
+
+	return out
+}

--- a/chainbackends/lndsubmitter/submitter_test.go
+++ b/chainbackends/lndsubmitter/submitter_test.go
@@ -1,0 +1,163 @@
+package lndsubmitter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeWalletKit is a walletKitSubmitter that records its inputs and returns a
+// canned result.
+type fakeWalletKit struct {
+	gotTxns    []*wire.MsgTx
+	gotMaxRate *chainfee.SatPerVByte
+	result     *lndclient.SubmitPackageResult
+	err        error
+}
+
+// SubmitPackage records the call and returns the canned result/err.
+func (f *fakeWalletKit) SubmitPackage(_ context.Context, txns []*wire.MsgTx,
+	maxFeeRate *chainfee.SatPerVByte) (*lndclient.SubmitPackageResult,
+	error) {
+
+	f.gotTxns = txns
+	f.gotMaxRate = maxFeeRate
+
+	return f.result, f.err
+}
+
+// TestSubmitPackageAssemblesAndMaps verifies that the submitter assembles the
+// package parents-first/child-last, forwards a nil fee rate untouched, and maps
+// the lndclient-native result into the btcjson result (including the per-tx
+// error mapping).
+func TestSubmitPackageAssemblesAndMaps(t *testing.T) {
+	t.Parallel()
+
+	parent := wire.NewMsgTx(3)
+	child := wire.NewMsgTx(3)
+	childHash := child.TxHash()
+
+	fake := &fakeWalletKit{
+		result: &lndclient.SubmitPackageResult{
+			PackageMsg: "success",
+			ReplacedTransactions: []chainhash.Hash{
+				{
+					0x01,
+				},
+			},
+			TxResults: map[string]lndclient.SubmitPackageTxResult{
+				"wtxid-ok": {
+					Txid: childHash,
+					Err:  "",
+				},
+				"wtxid-bad": {
+					Txid: chainhash.Hash{
+						0x02,
+					},
+					Err: "too-low-fee",
+				},
+			},
+		},
+	}
+
+	s := New(fake)
+	res, err := s.SubmitPackage(
+		context.Background(), []*wire.MsgTx{parent}, child, nil,
+	)
+	require.NoError(t, err)
+
+	// Package assembled parents-first, child last.
+	require.Len(t, fake.gotTxns, 2)
+	require.Equal(t, parent, fake.gotTxns[0])
+	require.Equal(t, child, fake.gotTxns[1])
+
+	// Nil fee rate forwarded as nil (node default).
+	require.Nil(t, fake.gotMaxRate)
+
+	// Package-level fields mapped through.
+	require.Equal(t, "success", res.PackageMsg)
+	require.Equal(
+		t, fake.result.ReplacedTransactions, res.ReplacedTransactions,
+	)
+
+	// Accepted tx: no error surfaced.
+	require.Nil(t, res.TxResults["wtxid-ok"].Error)
+	require.Equal(t, childHash, res.TxResults["wtxid-ok"].TxID)
+
+	// Rejected tx: error surfaced as a non-nil pointer to the reason.
+	require.NotNil(t, res.TxResults["wtxid-bad"].Error)
+	require.Equal(t, "too-low-fee", *res.TxResults["wtxid-bad"].Error)
+}
+
+// TestSubmitPackageForwardsMaxFeeRate verifies a non-nil ceiling is converted
+// from BTC/kvB to sat/vByte and forwarded to lnd, rounding to the nearest
+// integer rather than truncating (which would lower the ceiling).
+func TestSubmitPackageForwardsMaxFeeRate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		btcKvB float64
+		want   chainfee.SatPerVByte
+	}{
+		{
+			// 0.00012 BTC/kvB == 12 sat/vByte exactly.
+			name:   "exact",
+			btcKvB: 0.00012,
+			want:   12,
+		},
+		{
+			// 0.000125 BTC/kvB == 12.5 sat/vByte, which must round
+			// up to 13 rather than truncate down to 12.
+			name:   "rounds up",
+			btcKvB: 0.000125,
+			want:   13,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &fakeWalletKit{
+				result: &lndclient.SubmitPackageResult{
+					PackageMsg: "success",
+				},
+			}
+
+			rate := tc.btcKvB
+
+			s := New(fake)
+			_, err := s.SubmitPackage(
+				context.Background(), nil, wire.NewMsgTx(3),
+				&rate,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, fake.gotMaxRate)
+			require.Equal(t, tc.want, *fake.gotMaxRate)
+		})
+	}
+}
+
+// TestSubmitPackageRejectsNilTxns verifies that a nil child or a nil parent is
+// rejected with an error rather than causing a nil pointer panic.
+func TestSubmitPackageRejectsNilTxns(t *testing.T) {
+	t.Parallel()
+
+	s := New(&fakeWalletKit{})
+
+	// Nil child is rejected.
+	_, err := s.SubmitPackage(context.Background(), nil, nil, nil)
+	require.ErrorContains(t, err, "nil child transaction")
+
+	// A nil parent is rejected.
+	_, err = s.SubmitPackage(
+		context.Background(), []*wire.MsgTx{nil}, wire.NewMsgTx(3), nil,
+	)
+	require.ErrorContains(t, err, "nil parent transaction")
+}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/lightninglabs/darepo-client/btcwbackend"
 	"github.com/lightninglabs/darepo-client/build"
 	"github.com/lightninglabs/darepo-client/chainbackends"
+	"github.com/lightninglabs/darepo-client/chainbackends/lndsubmitter"
 	"github.com/lightninglabs/darepo-client/chainfees"
 	"github.com/lightninglabs/darepo-client/chainsource"
 	"github.com/lightninglabs/darepo-client/credit"
@@ -2192,8 +2193,19 @@ func (s *Server) initChainBackend(ctx context.Context) error {
 		)
 		backend.Log = fn.Some(s.subLogger(chainbackends.Subsystem))
 
-		if s.cfg.PackageSubmitter != nil {
+		// Wire v3 CPFP package relay. An explicitly injected submitter
+		// (bitcoind) takes precedence; otherwise relay through lnd's
+		// own WalletKit.SubmitPackage so an lnd-backed daemon needs no
+		// separate bitcoind RPC or Esplora endpoint to broadcast its
+		// zero-fee unilateral-exit parents (darepo-client#590/#678).
+		switch {
+		case s.cfg.PackageSubmitter != nil:
 			backend.SetPackageSubmitter(s.cfg.PackageSubmitter)
+
+		default:
+			backend.SetPackageSubmitter(
+				lndsubmitter.New(lndSvc.WalletKit),
+			)
 		}
 
 		s.chainBackend = backend

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -76,6 +76,16 @@ const (
 	// for each harness instance to ensure isolation between test runs.
 	networkPrefix = "ark-harness-"
 
+	// LNDChainBackendBitcoind backs a harness lnd node with the regtest
+	// bitcoind over RPC + ZMQ. This is the default.
+	LNDChainBackendBitcoind = "bitcoind"
+
+	// LNDChainBackendNeutrino backs a harness lnd node with neutrino,
+	// syncing and broadcasting over the regtest bitcoind's P2P interface
+	// (which serves compact block filters). Used to exercise lnd's native
+	// SPV / 1p1c broadcast path.
+	LNDChainBackendNeutrino = "neutrino"
+
 	// BitcoindRPCUser is the RPC username for bitcoind in regtest mode.
 	BitcoindRPCUser = "admin1"
 
@@ -2163,6 +2173,7 @@ func (h *Harness) bitcoindSendToAddress(address string, amount float64) string {
 func (h *Harness) startLND() *LndInstance {
 	inst := h.startLNDInstance(
 		"lnd", h.lndDataDir, h.opts.LNDRequireInterceptor,
+		LNDChainBackendBitcoind,
 	)
 	h.lnd = inst.Resource
 	h.LNDGRPCPort = inst.GRPCPort
@@ -2174,7 +2185,7 @@ func (h *Harness) startLND() *LndInstance {
 }
 
 func (h *Harness) startLNDInstance(name, dataDir string,
-	requireInterceptor bool) *LndInstance {
+	requireInterceptor bool, chainBackend string) *LndInstance {
 
 	h.T.Helper()
 
@@ -2189,6 +2200,7 @@ func (h *Harness) startLNDInstance(name, dataDir string,
 		image:              imageRepo(h.opts.LNDImage),
 		tag:                imageTag(h.opts.LNDImage),
 		requireInterceptor: requireInterceptor,
+		chainBackend:       chainBackend,
 	})
 
 	inst := &LndInstance{
@@ -2336,6 +2348,15 @@ func loadClientTLSCredentials(tlsPath string) (credentials.TransportCredentials,
 // StartAdditionalLND launches an extra LND instance with the given name and
 // returns its handle.
 func (h *Harness) StartAdditionalLND(name string) *LndInstance {
+	return h.StartAdditionalLNDWithBackend(name, LNDChainBackendBitcoind)
+}
+
+// StartAdditionalLNDWithBackend launches an extra LND instance with the given
+// name and chain backend (LNDChainBackendBitcoind or LNDChainBackendNeutrino)
+// and returns its handle.
+func (h *Harness) StartAdditionalLNDWithBackend(name,
+	chainBackend string) *LndInstance {
+
 	h.T.Helper()
 
 	if name == "" {
@@ -2347,7 +2368,7 @@ func (h *Harness) StartAdditionalLND(name string) *LndInstance {
 	}
 
 	dataDir := filepath.Join(h.artifactsDir, name)
-	inst := h.startLNDInstance(name, dataDir, false)
+	inst := h.startLNDInstance(name, dataDir, false, chainBackend)
 	h.initAndWaitLNDInstance(inst)
 	h.extraLNDs[name] = inst
 

--- a/harness/tapd_harness.go
+++ b/harness/tapd_harness.go
@@ -79,6 +79,12 @@ type lndConfig struct {
 	// HTLCs survive an interceptor disconnect. Only the primary swap node
 	// sets it.
 	requireInterceptor bool
+
+	// chainBackend selects lnd's chain backend: LNDChainBackendBitcoind
+	// (default) or LNDChainBackendNeutrino. Neutrino backs lnd via SPV over
+	// the regtest bitcoind's P2P + compact filters, exercising lnd's native
+	// 1p1c broadcast path instead of bitcoind's synchronous mempool checks.
+	chainBackend string
 }
 
 // tapdConfig holds the configuration for starting a tapd container.
@@ -156,14 +162,6 @@ func (h *Harness) startLNDContainer(cfg lndConfig) *dockertest.Resource {
 		fmt.Sprintf("--lnddir=%s", lndDirInContainer),
 		"--bitcoin.active",
 		"--bitcoin.regtest",
-		"--bitcoin.node=bitcoind",
-		fmt.Sprintf("--bitcoind.rpchost=%s:18443", cfg.bitcoindName),
-		fmt.Sprintf("--bitcoind.rpcuser=%s", BitcoindRPCUser),
-		fmt.Sprintf("--bitcoind.rpcpass=%s", BitcoindRPCPass),
-		fmt.Sprintf("--bitcoind.zmqpubrawblock=tcp://%s:28332",
-			cfg.bitcoindName),
-		fmt.Sprintf("--bitcoind.zmqpubrawtx=tcp://%s:28333",
-			cfg.bitcoindName),
 		"--rpclisten=0.0.0.0:10009",
 		"--restlisten=0.0.0.0:8080",
 		"--listen=0.0.0.0:9735",
@@ -181,6 +179,33 @@ func (h *Harness) startLNDContainer(cfg lndConfig) *dockertest.Resource {
 	// what out-swap fund safety depends on.
 	if cfg.requireInterceptor {
 		cmd = append(cmd, "--requireinterceptor")
+	}
+
+	// Append the chain-backend-specific flags. Neutrino syncs and
+	// broadcasts over the regtest bitcoind's P2P interface (which serves
+	// compact block filters), so lnd uses its SPV broadcast path; this is
+	// what lets us observe whether an lnd-backed daemon can relay zero-fee
+	// v3 anchor packages via 1p1c instead of a direct bitcoind submitter.
+	switch cfg.chainBackend {
+	case LNDChainBackendNeutrino:
+		cmd = append(
+			cmd, "--bitcoin.node=neutrino",
+			fmt.Sprintf("--neutrino.connect=%s:18444",
+				cfg.bitcoindName),
+		)
+
+	default:
+		cmd = append(
+			cmd, "--bitcoin.node=bitcoind",
+			fmt.Sprintf("--bitcoind.rpchost=%s:18443",
+				cfg.bitcoindName),
+			fmt.Sprintf("--bitcoind.rpcuser=%s", BitcoindRPCUser),
+			fmt.Sprintf("--bitcoind.rpcpass=%s", BitcoindRPCPass),
+			fmt.Sprintf("--bitcoind.zmqpubrawblock=tcp://%s:28332",
+				cfg.bitcoindName),
+			fmt.Sprintf("--bitcoind.zmqpubrawtx=tcp://%s:28333",
+				cfg.bitcoindName),
+		)
 	}
 
 	lndHostDir, err := filepath.Abs(cfg.dataDir)


### PR DESCRIPTION
Combines the two client-side package-relay changes into one PR for review
(previously split across #873 and #734). Two commits:

### 1. `multi: relay v3 packages via lnd WalletKit.SubmitPackage`

Adds the **lnd-backed package submitter** — the consumer of the merged
`lndclient.WalletKit.SubmitPackage` ([lndclient #280](https://github.com/lightninglabs/lndclient/pull/280)).
`chainbackends/lndsubmitter` is a `chainbackends.PackageSubmitter` that assembles
the parents-first/child-last package, forwards it to lnd, and maps lndclient's
native `SubmitPackageResult` → `btcjson.SubmitPackageResult`. Wired into
`darepod/server.go` as the lnd chain backend's default submitter when no
explicit (bitcoind) submitter is injected. Lets an lnd-backed darepod relay its
zero-fee unilateral-exit v3/TRUC packages through lnd's own chain connection —
no separate bitcoind RPC or Esplora endpoint (darepo-client #590 / #678). Unit
tests cover assembly order, result mapping, and fee-rate forwarding.

### 2. `harness: add neutrino chain-backend option for lnd nodes`

Adds a per-client lnd chain-backend option to the itest harness so package-relay
itests can drive an lnd node against a neutrino backend. Consumed by the server
package-relay itest matrix (darepo #564).

Depends only on merged upstream. Builds + vets green.