### PR TITLE
walletdkrpc: resumable SubscribeWallet (C4)

### DIFF
--- a/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
@@ -512,7 +512,7 @@ func generatedRegistry() []serviceSpec {
 					Name:            "SubscribeWallet",
 					Aliases:         []string{"subscribe-wallet"},
 					Input:           "walletdkrpc.SubscribeWalletRequest",
-					Output:          "walletdkrpc.WalletEntry",
+					Output:          "walletdkrpc.SubscribeWalletResponse",
 					ServerStreaming: true,
 					Comments:        "",
 				},

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -652,14 +652,24 @@ type SwapBackend interface {
 // boundary and lets tests pass nil.
 type ActivityStore interface {
 	// ProjectEntry advances the activity row to the projected state and
-	// records the transition, atomically.
-	ProjectEntry(ctx context.Context, p db.ActivityProjection) error
+	// records the transition, atomically. It returns the event_seq assigned
+	// to the appended transition, or 0 when the projection was
+	// change-suppressed (no transition, so nothing to emit).
+	ProjectEntry(ctx context.Context,
+		p db.ActivityProjection) (int64, error)
 
 	// ListEntries returns up to limit current-state rows newest-first,
 	// starting after the (cursorCreated, cursorID) keyset. A cursorCreated
 	// of 0 starts from the newest row.
 	ListEntries(ctx context.Context, cursorCreated int64, cursorID string,
 		limit int32) ([]sqlc.ActivityEntry, error)
+
+	// PullEvents returns up to limit append-only transition rows with
+	// event_seq strictly greater than cursor, oldest-first. It is the
+	// resumable-subscribe replay primitive: a reconnecting client passes
+	// the last event_seq it processed and receives everything after it.
+	PullEvents(ctx context.Context, cursor int64,
+		limit int32) ([]sqlc.ActivityEvent, error)
 
 	// CountByStatus returns the number of current-state rows in the given
 	// status. It backs the wallet status summary's full-feed pending count,

--- a/db/activity_store.go
+++ b/db/activity_store.go
@@ -18,7 +18,7 @@ type ActivityStore interface {
 		arg sqlc.UpsertActivityEntryParams) error
 
 	AppendActivityEvent(ctx context.Context,
-		arg sqlc.AppendActivityEventParams) error
+		arg sqlc.AppendActivityEventParams) (int64, error)
 
 	GetActivityEntry(ctx context.Context,
 		canonicalID string) (sqlc.ActivityEntry, error)
@@ -103,9 +103,11 @@ func NewActivityPersistenceStore(
 
 // ProjectEntry advances the activity row to the projected state and records the
 // transition, atomically. The entry is upserted before the event is appended so
-// the activity_events foreign key is satisfied within the same transaction.
+// the activity_events foreign key is satisfied within the same transaction. It
+// returns the event_seq assigned to the appended transition, or 0 when the
+// projection was change-suppressed (no transition, so nothing to emit).
 func (s *ActivityPersistenceStore) ProjectEntry(ctx context.Context,
-	p ActivityProjection) error {
+	p ActivityProjection) (int64, error) {
 
 	// A row must carry a creation and update time. When the projection
 	// omits them (a malformed or synthetic entry), fall back to the
@@ -120,7 +122,11 @@ func (s *ActivityPersistenceStore) ProjectEntry(ctx context.Context,
 		updatedAt = now
 	}
 
-	return s.db.ExecTx(ctx, WriteTxOption(), func(q ActivityStore) error {
+	var eventSeq int64
+	err := s.db.ExecTx(ctx, WriteTxOption(), func(q ActivityStore) error {
+		// Reset per attempt: ExecTx may retry the closure.
+		eventSeq = 0
+
 		// Only record a transition when the projection actually changes
 		// the current-state row. Redundant re-emits — the startup
 		// backfill on every wallet-ready start, and the swap monitor's
@@ -171,7 +177,7 @@ func (s *ActivityPersistenceStore) ProjectEntry(ctx context.Context,
 			return err
 		}
 
-		return q.AppendActivityEvent(
+		seq, err := q.AppendActivityEvent(
 			ctx, sqlc.AppendActivityEventParams{
 				CanonicalID:   p.CanonicalID,
 				Status:        p.Status,
@@ -180,7 +186,15 @@ func (s *ActivityPersistenceStore) ProjectEntry(ctx context.Context,
 				CreatedAtUnix: updatedAt,
 			},
 		)
+		if err != nil {
+			return err
+		}
+		eventSeq = seq
+
+		return nil
 	})
+
+	return eventSeq, err
 }
 
 // GetEntry returns one current-state row by its canonical id.

--- a/db/activity_store_test.go
+++ b/db/activity_store_test.go
@@ -28,6 +28,12 @@ func newActivityStoreForTest(t *testing.T) *ActivityPersistenceStore {
 	return NewActivityPersistenceStore(activityDB, clock.NewDefaultClock())
 }
 
+// projected discards the event_seq returned by ProjectEntry so a call slots
+// straight into require.NoError / require.Error.
+func projected(_ int64, err error) error {
+	return err
+}
+
 // sampleProjection returns a populated projection for the given canonical id.
 func sampleProjection(id string) ActivityProjection {
 	return ActivityProjection{
@@ -59,7 +65,14 @@ func TestActivityStoreProjectInsertsEntryAndEvent(t *testing.T) {
 	ctx := context.Background()
 	store := newActivityStoreForTest(t)
 
-	require.NoError(t, store.ProjectEntry(ctx, sampleProjection("a")))
+	require.NoError(
+		t,
+		projected(
+			store.ProjectEntry(
+				ctx, sampleProjection("a"),
+			),
+		),
+	)
 
 	entry, err := store.GetEntry(ctx, "a")
 	require.NoError(t, err)
@@ -88,9 +101,23 @@ func TestActivityStoreCountByStatus(t *testing.T) {
 	// Two pending rows (status 1) and one complete row (status 2).
 	complete := sampleProjection("c1")
 	complete.Status = 2
-	require.NoError(t, store.ProjectEntry(ctx, sampleProjection("p1")))
-	require.NoError(t, store.ProjectEntry(ctx, sampleProjection("p2")))
-	require.NoError(t, store.ProjectEntry(ctx, complete))
+	require.NoError(
+		t,
+		projected(
+			store.ProjectEntry(
+				ctx, sampleProjection("p1"),
+			),
+		),
+	)
+	require.NoError(
+		t,
+		projected(
+			store.ProjectEntry(
+				ctx, sampleProjection("p2"),
+			),
+		),
+	)
+	require.NoError(t, projected(store.ProjectEntry(ctx, complete)))
 
 	pending, err := store.CountByStatus(ctx, 1)
 	require.NoError(t, err)
@@ -114,8 +141,22 @@ func TestActivityStoreProjectSuppressesUnchanged(t *testing.T) {
 	ctx := context.Background()
 	store := newActivityStoreForTest(t)
 
-	require.NoError(t, store.ProjectEntry(ctx, sampleProjection("a")))
-	require.NoError(t, store.ProjectEntry(ctx, sampleProjection("a")))
+	require.NoError(
+		t,
+		projected(
+			store.ProjectEntry(
+				ctx, sampleProjection("a"),
+			),
+		),
+	)
+	require.NoError(
+		t,
+		projected(
+			store.ProjectEntry(
+				ctx, sampleProjection("a"),
+			),
+		),
+	)
 
 	events, err := store.PullEvents(ctx, 0, 10)
 	require.NoError(t, err)
@@ -133,7 +174,14 @@ func TestActivityStoreReProjectUpdatesInPlace(t *testing.T) {
 	ctx := context.Background()
 	store := newActivityStoreForTest(t)
 
-	require.NoError(t, store.ProjectEntry(ctx, sampleProjection("a")))
+	require.NoError(
+		t,
+		projected(
+			store.ProjectEntry(
+				ctx, sampleProjection("a"),
+			),
+		),
+	)
 
 	// Advance the row: complete, new phase, later update time, and a nil
 	// payment hash + zero created time that must NOT clobber the originals.
@@ -144,7 +192,7 @@ func TestActivityStoreReProjectUpdatesInPlace(t *testing.T) {
 	next.CreatedAtUnix = 0
 	next.PaymentHash = nil
 	next.Txid = []byte{0x11, 0x22}
-	require.NoError(t, store.ProjectEntry(ctx, next))
+	require.NoError(t, projected(store.ProjectEntry(ctx, next)))
 
 	entry, err := store.GetEntry(ctx, "a")
 	require.NoError(t, err)
@@ -177,11 +225,11 @@ func TestActivityStoreEnumForeignKey(t *testing.T) {
 
 	badKind := sampleProjection("a")
 	badKind.Kind = 99
-	require.Error(t, store.ProjectEntry(ctx, badKind))
+	require.Error(t, projected(store.ProjectEntry(ctx, badKind)))
 
 	badStatus := sampleProjection("b")
 	badStatus.Status = 99
-	require.Error(t, store.ProjectEntry(ctx, badStatus))
+	require.Error(t, projected(store.ProjectEntry(ctx, badStatus)))
 }
 
 // TestActivityStoreNilBlobStaysNull verifies an empty hash handle is stored as
@@ -195,7 +243,7 @@ func TestActivityStoreNilBlobStaysNull(t *testing.T) {
 	p := sampleProjection("a")
 	p.PaymentHash = nil
 	p.Txid = nil
-	require.NoError(t, store.ProjectEntry(ctx, p))
+	require.NoError(t, projected(store.ProjectEntry(ctx, p)))
 
 	entry, err := store.GetEntry(ctx, "a")
 	require.NoError(t, err)
@@ -217,7 +265,7 @@ func TestActivityStoreListKeyset(t *testing.T) {
 		p := sampleProjection(id)
 		p.CreatedAtUnix = created
 		p.UpdatedAtUnix = created
-		require.NoError(t, store.ProjectEntry(ctx, p))
+		require.NoError(t, projected(store.ProjectEntry(ctx, p)))
 	}
 
 	page, err := store.ListEntries(ctx, 0, "", 2)
@@ -243,8 +291,22 @@ func TestActivityStorePullEventsAfterCursor(t *testing.T) {
 	ctx := context.Background()
 	store := newActivityStoreForTest(t)
 
-	require.NoError(t, store.ProjectEntry(ctx, sampleProjection("a")))
-	require.NoError(t, store.ProjectEntry(ctx, sampleProjection("b")))
+	require.NoError(
+		t,
+		projected(
+			store.ProjectEntry(
+				ctx, sampleProjection("a"),
+			),
+		),
+	)
+	require.NoError(
+		t,
+		projected(
+			store.ProjectEntry(
+				ctx, sampleProjection("b"),
+			),
+		),
+	)
 
 	all, err := store.PullEvents(ctx, 0, 10)
 	require.NoError(t, err)

--- a/db/sqlc/activity_log.sql.go
+++ b/db/sqlc/activity_log.sql.go
@@ -10,12 +10,13 @@ import (
 	"database/sql"
 )
 
-const AppendActivityEvent = `-- name: AppendActivityEvent :exec
+const AppendActivityEvent = `-- name: AppendActivityEvent :one
 INSERT INTO activity_events (
     canonical_id, status, phase, entry_json, created_at_unix
 ) VALUES (
     $1, $2, $3, $4, $5
 )
+RETURNING event_seq
 `
 
 type AppendActivityEventParams struct {
@@ -26,17 +27,20 @@ type AppendActivityEventParams struct {
 	CreatedAtUnix int64
 }
 
-// AppendActivityEvent records one immutable lifecycle-transition row. event_seq
-// is assigned by the database (monotonic, not necessarily contiguous).
-func (q *Queries) AppendActivityEvent(ctx context.Context, arg AppendActivityEventParams) error {
-	_, err := q.db.ExecContext(ctx, AppendActivityEvent,
+// AppendActivityEvent records one immutable lifecycle-transition row and
+// returns the event_seq the database assigned (monotonic, not necessarily
+// contiguous). Callers use it as the resumable-subscribe cursor for the update.
+func (q *Queries) AppendActivityEvent(ctx context.Context, arg AppendActivityEventParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, AppendActivityEvent,
 		arg.CanonicalID,
 		arg.Status,
 		arg.Phase,
 		arg.EntryJson,
 		arg.CreatedAtUnix,
 	)
-	return err
+	var event_seq int64
+	err := row.Scan(&event_seq)
+	return event_seq, err
 }
 
 const CountActivityEntriesByStatus = `-- name: CountActivityEntriesByStatus :one

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -10,9 +10,10 @@ import (
 )
 
 type Querier interface {
-	// AppendActivityEvent records one immutable lifecycle-transition row. event_seq
-	// is assigned by the database (monotonic, not necessarily contiguous).
-	AppendActivityEvent(ctx context.Context, arg AppendActivityEventParams) error
+	// AppendActivityEvent records one immutable lifecycle-transition row and
+	// returns the event_seq the database assigned (monotonic, not necessarily
+	// contiguous). Callers use it as the resumable-subscribe cursor for the update.
+	AppendActivityEvent(ctx context.Context, arg AppendActivityEventParams) (int64, error)
 	CancelVHTLCRecoveryJob(ctx context.Context, arg CancelVHTLCRecoveryJobParams) (int64, error)
 	ClearPendingIntentAnchorByOutpoint(ctx context.Context, arg ClearPendingIntentAnchorByOutpointParams) error
 	CompleteVHTLCRecoveryJob(ctx context.Context, arg CompleteVHTLCRecoveryJobParams) (int64, error)

--- a/db/sqlc/queries/activity_log.sql
+++ b/db/sqlc/queries/activity_log.sql
@@ -43,14 +43,16 @@ ON CONFLICT (canonical_id) DO UPDATE SET
     request_json    = EXCLUDED.request_json,
     updated_at_unix = EXCLUDED.updated_at_unix;
 
--- name: AppendActivityEvent :exec
--- AppendActivityEvent records one immutable lifecycle-transition row. event_seq
--- is assigned by the database (monotonic, not necessarily contiguous).
+-- name: AppendActivityEvent :one
+-- AppendActivityEvent records one immutable lifecycle-transition row and
+-- returns the event_seq the database assigned (monotonic, not necessarily
+-- contiguous). Callers use it as the resumable-subscribe cursor for the update.
 INSERT INTO activity_events (
     canonical_id, status, phase, entry_json, created_at_unix
 ) VALUES (
     $1, $2, $3, $4, $5
-);
+)
+RETURNING event_seq;
 
 -- name: GetActivityEntry :one
 -- GetActivityEntry returns one entry by its canonical id.

--- a/rpc/restclient/client_test.go
+++ b/rpc/restclient/client_test.go
@@ -207,7 +207,8 @@ func TestWalletStream(t *testing.T) {
 
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write([]byte(
-				`{"result":{"id":"entry-1"}}` + "\n",
+				`{"result":{"cursor":"5",` +
+					`"entry":{"id":"entry-1"}}}` + "\n",
 			))
 			require.NoError(t, err)
 		},
@@ -220,9 +221,10 @@ func TestWalletStream(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	entry, err := stream.Recv()
+	resp, err := stream.Recv()
 	require.NoError(t, err)
-	require.Equal(t, "entry-1", entry.GetId())
+	require.Equal(t, int64(5), resp.GetCursor())
+	require.Equal(t, "entry-1", resp.GetEntry().GetId())
 
 	_, err = stream.Recv()
 	require.True(t, errors.Is(err, io.EOF))

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -25,10 +25,10 @@ type (
 	}
 	subscribeSwapsREST = StreamClient[swapclientrpc.SubscribeSwapsResponse]
 
-	walletEntryStream interface {
-		grpc.ServerStreamingClient[walletdkrpc.WalletEntry]
+	subscribeWalletStream interface {
+		grpc.ServerStreamingClient[walletdkrpc.SubscribeWalletResponse]
 	}
-	walletEntryREST = StreamClient[walletdkrpc.WalletEntry]
+	subscribeWalletREST = StreamClient[walletdkrpc.SubscribeWalletResponse]
 )
 
 var (
@@ -40,7 +40,7 @@ var (
 	_ walletdkrpc.WalletServiceClient = (*WalletServiceClient)(nil)
 	_ watchRoundsStream               = (*watchRoundsREST)(nil)
 	_ subscribeSwapsStream            = (*subscribeSwapsREST)(nil)
-	_ walletEntryStream               = (*walletEntryREST)(nil)
+	_ subscribeWalletStream           = (*subscribeWalletREST)(nil)
 )
 
 // NewArkServiceClient creates an ArkService REST client.
@@ -1134,7 +1134,8 @@ func (c *WalletServiceClient) ExitStatus(ctx context.Context,
 // SubscribeWallet streams wallet updates.
 func (c *WalletServiceClient) SubscribeWallet(ctx context.Context,
 	in *walletdkrpc.SubscribeWalletRequest, _ ...grpc.CallOption) (
-	grpc.ServerStreamingClient[walletdkrpc.WalletEntry], error) {
+	grpc.ServerStreamingClient[walletdkrpc.SubscribeWalletResponse],
+	error) {
 
 	resp, err := c.client.Stream( //nolint:bodyclose // Stream owns body.
 		ctx, "/v1/wallet/subscribe", in,
@@ -1143,9 +1144,10 @@ func (c *WalletServiceClient) SubscribeWallet(ctx context.Context,
 		return nil, err
 	}
 
-	return NewStreamClient[walletdkrpc.WalletEntry](
-		resp, "SubscribeWallet", func() *walletdkrpc.WalletEntry {
-			return new(walletdkrpc.WalletEntry)
+	return NewStreamClient[walletdkrpc.SubscribeWalletResponse](
+		resp, "SubscribeWallet",
+		func() *walletdkrpc.SubscribeWalletResponse {
+			return new(walletdkrpc.SubscribeWalletResponse)
 		},
 	), nil
 }

--- a/rpc/walletdkrpc/wallet.pb.go
+++ b/rpc/walletdkrpc/wallet.pb.go
@@ -4231,12 +4231,18 @@ func (x *ExitStatusResponse) GetLastError() string {
 // SubscribeWalletRequest configures the WalletService.SubscribeWallet stream.
 type SubscribeWalletRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// include_existing instructs the daemon to emit the current
-	// snapshot before the live subscription is registered.
+	// include_existing replays the full activity history before live
+	// updates. It is ignored when cursor is set (cursor already selects the
+	// replay start).
 	IncludeExisting bool `protobuf:"varint,1,opt,name=include_existing,json=includeExisting,proto3" json:"include_existing,omitempty"`
-	// kinds optionally narrows the live stream to specific entry
-	// categories. When empty, all kinds are streamed.
-	Kinds         []EntryKind `protobuf:"varint,2,rep,packed,name=kinds,proto3,enum=walletdkrpc.EntryKind" json:"kinds,omitempty"`
+	// kinds optionally narrows the stream to specific entry categories.
+	// When empty, all kinds are streamed.
+	Kinds []EntryKind `protobuf:"varint,2,rep,packed,name=kinds,proto3,enum=walletdkrpc.EntryKind" json:"kinds,omitempty"`
+	// cursor resumes the stream from a prior SubscribeWalletResponse.cursor:
+	// the daemon replays every event after it, then continues live. Zero
+	// (unset) starts from the full history when include_existing is set, or
+	// from the current tip otherwise.
+	Cursor        int64 `protobuf:"varint,3,opt,name=cursor,proto3" json:"cursor,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4283,6 +4289,165 @@ func (x *SubscribeWalletRequest) GetKinds() []EntryKind {
 		return x.Kinds
 	}
 	return nil
+}
+
+func (x *SubscribeWalletRequest) GetCursor() int64 {
+	if x != nil {
+		return x.Cursor
+	}
+	return 0
+}
+
+// SubscribeWalletResponse is one item in the SubscribeWallet stream: either a
+// projected activity row or a gap signal telling the subscriber it fell behind
+// and must reconcile.
+type SubscribeWalletResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// cursor is the monotonic event-log position of this update. A client
+	// persists it and reconnects with SubscribeWalletRequest.cursor set to the
+	// last value it processed to resume without gaps. The sequence is
+	// monotonic but NOT contiguous: a value may be skipped, so a client treats
+	// any cursor past its last as new and never infers a dropped event from a
+	// gap in the numbers.
+	Cursor int64 `protobuf:"varint,1,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	// Types that are valid to be assigned to Update:
+	//
+	//	*SubscribeWalletResponse_Entry
+	//	*SubscribeWalletResponse_Gap
+	Update        isSubscribeWalletResponse_Update `protobuf_oneof:"update"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SubscribeWalletResponse) Reset() {
+	*x = SubscribeWalletResponse{}
+	mi := &file_wallet_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SubscribeWalletResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SubscribeWalletResponse) ProtoMessage() {}
+
+func (x *SubscribeWalletResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SubscribeWalletResponse.ProtoReflect.Descriptor instead.
+func (*SubscribeWalletResponse) Descriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *SubscribeWalletResponse) GetCursor() int64 {
+	if x != nil {
+		return x.Cursor
+	}
+	return 0
+}
+
+func (x *SubscribeWalletResponse) GetUpdate() isSubscribeWalletResponse_Update {
+	if x != nil {
+		return x.Update
+	}
+	return nil
+}
+
+func (x *SubscribeWalletResponse) GetEntry() *WalletEntry {
+	if x != nil {
+		if x, ok := x.Update.(*SubscribeWalletResponse_Entry); ok {
+			return x.Entry
+		}
+	}
+	return nil
+}
+
+func (x *SubscribeWalletResponse) GetGap() *SubscribeGap {
+	if x != nil {
+		if x, ok := x.Update.(*SubscribeWalletResponse_Gap); ok {
+			return x.Gap
+		}
+	}
+	return nil
+}
+
+type isSubscribeWalletResponse_Update interface {
+	isSubscribeWalletResponse_Update()
+}
+
+type SubscribeWalletResponse_Entry struct {
+	// entry is a projected activity row at cursor.
+	Entry *WalletEntry `protobuf:"bytes,2,opt,name=entry,proto3,oneof"`
+}
+
+type SubscribeWalletResponse_Gap struct {
+	// gap signals the subscriber fell behind the live buffer and should
+	// reconcile current state via List, then resume from cursor.
+	Gap *SubscribeGap `protobuf:"bytes,3,opt,name=gap,proto3,oneof"`
+}
+
+func (*SubscribeWalletResponse_Entry) isSubscribeWalletResponse_Update() {}
+
+func (*SubscribeWalletResponse_Gap) isSubscribeWalletResponse_Update() {}
+
+// SubscribeGap tells a subscriber the daemon could not keep it current on the
+// live stream (a slow consumer overflowed the send buffer). The subscriber
+// should reconcile via List and resume from the enclosing cursor. No activity
+// is lost: the canonical event log retains every event, so the resume replays
+// anything missed.
+type SubscribeGap struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// reason is a short human-readable description of why the gap was emitted.
+	Reason        string `protobuf:"bytes,1,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SubscribeGap) Reset() {
+	*x = SubscribeGap{}
+	mi := &file_wallet_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SubscribeGap) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SubscribeGap) ProtoMessage() {}
+
+func (x *SubscribeGap) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SubscribeGap.ProtoReflect.Descriptor instead.
+func (*SubscribeGap) Descriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *SubscribeGap) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
 }
 
 // WalletEntry is the single flat row type returned by the ACTIVITY view of
@@ -4349,7 +4514,7 @@ type WalletEntry struct {
 
 func (x *WalletEntry) Reset() {
 	*x = WalletEntry{}
-	mi := &file_wallet_proto_msgTypes[41]
+	mi := &file_wallet_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4361,7 +4526,7 @@ func (x *WalletEntry) String() string {
 func (*WalletEntry) ProtoMessage() {}
 
 func (x *WalletEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[41]
+	mi := &file_wallet_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4374,7 +4539,7 @@ func (x *WalletEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletEntry.ProtoReflect.Descriptor instead.
 func (*WalletEntry) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{41}
+	return file_wallet_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *WalletEntry) GetId() string {
@@ -4485,7 +4650,7 @@ type WalletEntryRequest struct {
 
 func (x *WalletEntryRequest) Reset() {
 	*x = WalletEntryRequest{}
-	mi := &file_wallet_proto_msgTypes[42]
+	mi := &file_wallet_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4497,7 +4662,7 @@ func (x *WalletEntryRequest) String() string {
 func (*WalletEntryRequest) ProtoMessage() {}
 
 func (x *WalletEntryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[42]
+	mi := &file_wallet_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4510,7 +4675,7 @@ func (x *WalletEntryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletEntryRequest.ProtoReflect.Descriptor instead.
 func (*WalletEntryRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{42}
+	return file_wallet_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *WalletEntryRequest) GetRequest() isWalletEntryRequest_Request {
@@ -4588,7 +4753,7 @@ type LightningInvoiceRequest struct {
 
 func (x *LightningInvoiceRequest) Reset() {
 	*x = LightningInvoiceRequest{}
-	mi := &file_wallet_proto_msgTypes[43]
+	mi := &file_wallet_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4600,7 +4765,7 @@ func (x *LightningInvoiceRequest) String() string {
 func (*LightningInvoiceRequest) ProtoMessage() {}
 
 func (x *LightningInvoiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[43]
+	mi := &file_wallet_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4613,7 +4778,7 @@ func (x *LightningInvoiceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LightningInvoiceRequest.ProtoReflect.Descriptor instead.
 func (*LightningInvoiceRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{43}
+	return file_wallet_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *LightningInvoiceRequest) GetInvoice() string {
@@ -4642,7 +4807,7 @@ type OnchainAddressRequest struct {
 
 func (x *OnchainAddressRequest) Reset() {
 	*x = OnchainAddressRequest{}
-	mi := &file_wallet_proto_msgTypes[44]
+	mi := &file_wallet_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4654,7 +4819,7 @@ func (x *OnchainAddressRequest) String() string {
 func (*OnchainAddressRequest) ProtoMessage() {}
 
 func (x *OnchainAddressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[44]
+	mi := &file_wallet_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4667,7 +4832,7 @@ func (x *OnchainAddressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnchainAddressRequest.ProtoReflect.Descriptor instead.
 func (*OnchainAddressRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{44}
+	return file_wallet_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *OnchainAddressRequest) GetAddress() string {
@@ -4688,7 +4853,7 @@ type ArkAddressRequest struct {
 
 func (x *ArkAddressRequest) Reset() {
 	*x = ArkAddressRequest{}
-	mi := &file_wallet_proto_msgTypes[45]
+	mi := &file_wallet_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4700,7 +4865,7 @@ func (x *ArkAddressRequest) String() string {
 func (*ArkAddressRequest) ProtoMessage() {}
 
 func (x *ArkAddressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[45]
+	mi := &file_wallet_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4713,7 +4878,7 @@ func (x *ArkAddressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArkAddressRequest.ProtoReflect.Descriptor instead.
 func (*ArkAddressRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{45}
+	return file_wallet_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *ArkAddressRequest) GetAddress() string {
@@ -4751,7 +4916,7 @@ type WalletEntryProgress struct {
 
 func (x *WalletEntryProgress) Reset() {
 	*x = WalletEntryProgress{}
-	mi := &file_wallet_proto_msgTypes[46]
+	mi := &file_wallet_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4763,7 +4928,7 @@ func (x *WalletEntryProgress) String() string {
 func (*WalletEntryProgress) ProtoMessage() {}
 
 func (x *WalletEntryProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[46]
+	mi := &file_wallet_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4776,7 +4941,7 @@ func (x *WalletEntryProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletEntryProgress.ProtoReflect.Descriptor instead.
 func (*WalletEntryProgress) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{46}
+	return file_wallet_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *WalletEntryProgress) GetPhase() WalletEntryPhase {
@@ -5096,10 +5261,18 @@ const file_wallet_proto_rawDesc = "" +
 	"\n" +
 	"sweep_txid\x18\x03 \x01(\tR\tsweepTxid\x12\x1d\n" +
 	"\n" +
-	"last_error\x18\x04 \x01(\tR\tlastError\"q\n" +
+	"last_error\x18\x04 \x01(\tR\tlastError\"\x89\x01\n" +
 	"\x16SubscribeWalletRequest\x12)\n" +
 	"\x10include_existing\x18\x01 \x01(\bR\x0fincludeExisting\x12,\n" +
-	"\x05kinds\x18\x02 \x03(\x0e2\x16.walletdkrpc.EntryKindR\x05kinds\"\xb3\x04\n" +
+	"\x05kinds\x18\x02 \x03(\x0e2\x16.walletdkrpc.EntryKindR\x05kinds\x12\x16\n" +
+	"\x06cursor\x18\x03 \x01(\x03R\x06cursor\"\x9c\x01\n" +
+	"\x17SubscribeWalletResponse\x12\x16\n" +
+	"\x06cursor\x18\x01 \x01(\x03R\x06cursor\x120\n" +
+	"\x05entry\x18\x02 \x01(\v2\x18.walletdkrpc.WalletEntryH\x00R\x05entry\x12-\n" +
+	"\x03gap\x18\x03 \x01(\v2\x19.walletdkrpc.SubscribeGapH\x00R\x03gapB\b\n" +
+	"\x06update\"&\n" +
+	"\fSubscribeGap\x12\x16\n" +
+	"\x06reason\x18\x01 \x01(\tR\x06reason\"\xb3\x04\n" +
 	"\vWalletEntry\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12*\n" +
 	"\x04kind\x18\x02 \x01(\x0e2\x16.walletdkrpc.EntryKindR\x04kind\x120\n" +
@@ -5196,7 +5369,7 @@ const file_wallet_proto_rawDesc = "" +
 	"\x1aENTRY_FAILURE_CODE_EXPIRED\x10\x02\x12\x1f\n" +
 	"\x1bENTRY_FAILURE_CODE_REFUNDED\x10\x03\x12)\n" +
 	"%ENTRY_FAILURE_CODE_NEEDS_INTERVENTION\x10\x04\x12\x1d\n" +
-	"\x19ENTRY_FAILURE_CODE_FAILED\x10\x052\xf1\a\n" +
+	"\x19ENTRY_FAILURE_CODE_FAILED\x10\x052\xfd\a\n" +
 	"\rWalletService\x12A\n" +
 	"\x06Create\x12\x1a.walletdkrpc.CreateRequest\x1a\x1b.walletdkrpc.CreateResponse\x12A\n" +
 	"\x06Unlock\x12\x1a.walletdkrpc.UnlockRequest\x1a\x1b.walletdkrpc.UnlockResponse\x12P\n" +
@@ -5211,8 +5384,8 @@ const file_wallet_proto_rawDesc = "" +
 	"\vSweepWallet\x12\x1f.walletdkrpc.SweepWalletRequest\x1a .walletdkrpc.SweepWalletResponse\x12;\n" +
 	"\x04Exit\x12\x18.walletdkrpc.ExitRequest\x1a\x19.walletdkrpc.ExitResponse\x12M\n" +
 	"\n" +
-	"ExitStatus\x12\x1e.walletdkrpc.ExitStatusRequest\x1a\x1f.walletdkrpc.ExitStatusResponse\x12R\n" +
-	"\x0fSubscribeWallet\x12#.walletdkrpc.SubscribeWalletRequest\x1a\x18.walletdkrpc.WalletEntry0\x012w\n" +
+	"ExitStatus\x12\x1e.walletdkrpc.ExitStatusRequest\x1a\x1f.walletdkrpc.ExitStatusResponse\x12^\n" +
+	"\x0fSubscribeWallet\x12#.walletdkrpc.SubscribeWalletRequest\x1a$.walletdkrpc.SubscribeWalletResponse0\x012w\n" +
 	"\x17WalletInspectionService\x12\\\n" +
 	"\x0fInspectActivity\x12#.walletdkrpc.InspectActivityRequest\x1a$.walletdkrpc.InspectActivityResponseB8Z6github.com/lightninglabs/darepo-client/rpc/walletdkrpcb\x06proto3"
 
@@ -5229,7 +5402,7 @@ func file_wallet_proto_rawDescGZIP() []byte {
 }
 
 var file_wallet_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
+var file_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
 var file_wallet_proto_goTypes = []any{
 	(EntryKind)(0),                  // 0: walletdkrpc.EntryKind
 	(EntryStatus)(0),                // 1: walletdkrpc.EntryStatus
@@ -5281,33 +5454,35 @@ var file_wallet_proto_goTypes = []any{
 	(*ExitStatusRequest)(nil),       // 47: walletdkrpc.ExitStatusRequest
 	(*ExitStatusResponse)(nil),      // 48: walletdkrpc.ExitStatusResponse
 	(*SubscribeWalletRequest)(nil),  // 49: walletdkrpc.SubscribeWalletRequest
-	(*WalletEntry)(nil),             // 50: walletdkrpc.WalletEntry
-	(*WalletEntryRequest)(nil),      // 51: walletdkrpc.WalletEntryRequest
-	(*LightningInvoiceRequest)(nil), // 52: walletdkrpc.LightningInvoiceRequest
-	(*OnchainAddressRequest)(nil),   // 53: walletdkrpc.OnchainAddressRequest
-	(*ArkAddressRequest)(nil),       // 54: walletdkrpc.ArkAddressRequest
-	(*WalletEntryProgress)(nil),     // 55: walletdkrpc.WalletEntryProgress
+	(*SubscribeWalletResponse)(nil), // 50: walletdkrpc.SubscribeWalletResponse
+	(*SubscribeGap)(nil),            // 51: walletdkrpc.SubscribeGap
+	(*WalletEntry)(nil),             // 52: walletdkrpc.WalletEntry
+	(*WalletEntryRequest)(nil),      // 53: walletdkrpc.WalletEntryRequest
+	(*LightningInvoiceRequest)(nil), // 54: walletdkrpc.LightningInvoiceRequest
+	(*OnchainAddressRequest)(nil),   // 55: walletdkrpc.OnchainAddressRequest
+	(*ArkAddressRequest)(nil),       // 56: walletdkrpc.ArkAddressRequest
+	(*WalletEntryProgress)(nil),     // 57: walletdkrpc.WalletEntryProgress
 }
 var file_wallet_proto_depIdxs = []int32{
 	3,  // 0: walletdkrpc.PrepareSendResponse.rail:type_name -> walletdkrpc.SendRail
 	4,  // 1: walletdkrpc.PrepareSendResponse.quote_status:type_name -> walletdkrpc.SendQuoteStatus
 	19, // 2: walletdkrpc.PrepareSendResponse.credit_preview:type_name -> walletdkrpc.CreditPreview
-	50, // 3: walletdkrpc.SendResponse.entry:type_name -> walletdkrpc.WalletEntry
-	50, // 4: walletdkrpc.RecvResponse.entry:type_name -> walletdkrpc.WalletEntry
+	52, // 3: walletdkrpc.SendResponse.entry:type_name -> walletdkrpc.WalletEntry
+	52, // 4: walletdkrpc.RecvResponse.entry:type_name -> walletdkrpc.WalletEntry
 	20, // 5: walletdkrpc.RecvResponse.credit_receive:type_name -> walletdkrpc.CreditReceive
 	2,  // 6: walletdkrpc.ListRequest.view:type_name -> walletdkrpc.ListView
 	0,  // 7: walletdkrpc.ListRequest.kinds:type_name -> walletdkrpc.EntryKind
 	23, // 8: walletdkrpc.ListResponse.activity:type_name -> walletdkrpc.ActivityList
 	24, // 9: walletdkrpc.ListResponse.vtxos:type_name -> walletdkrpc.VTXOInventory
 	26, // 10: walletdkrpc.ListResponse.onchain:type_name -> walletdkrpc.OnchainHistory
-	50, // 11: walletdkrpc.ActivityList.entries:type_name -> walletdkrpc.WalletEntry
+	52, // 11: walletdkrpc.ActivityList.entries:type_name -> walletdkrpc.WalletEntry
 	25, // 12: walletdkrpc.VTXOInventory.vtxos:type_name -> walletdkrpc.WalletVTXO
 	27, // 13: walletdkrpc.OnchainHistory.txs:type_name -> walletdkrpc.OnchainTx
-	50, // 14: walletdkrpc.InspectActivityResponse.entry:type_name -> walletdkrpc.WalletEntry
+	52, // 14: walletdkrpc.InspectActivityResponse.entry:type_name -> walletdkrpc.WalletEntry
 	30, // 15: walletdkrpc.InspectActivityResponse.swap:type_name -> walletdkrpc.ActivitySwapTrace
 	31, // 16: walletdkrpc.InspectActivityResponse.vtxos:type_name -> walletdkrpc.ActivityVTXOTrace
 	32, // 17: walletdkrpc.InspectActivityResponse.ledger_rows:type_name -> walletdkrpc.ActivityLedgerTrace
-	50, // 18: walletdkrpc.DepositResponse.entry:type_name -> walletdkrpc.WalletEntry
+	52, // 18: walletdkrpc.DepositResponse.entry:type_name -> walletdkrpc.WalletEntry
 	36, // 19: walletdkrpc.StatusResponse.balance:type_name -> walletdkrpc.BalanceResponse
 	6,  // 20: walletdkrpc.ExitPlanEntry.exit_status:type_name -> walletdkrpc.ExitJobStatus
 	40, // 21: walletdkrpc.GetExitPlanResponse.plans:type_name -> walletdkrpc.ExitPlanEntry
@@ -5315,50 +5490,52 @@ var file_wallet_proto_depIdxs = []int32{
 	5,  // 23: walletdkrpc.ExitResponse.mode:type_name -> walletdkrpc.ExitMode
 	6,  // 24: walletdkrpc.ExitStatusResponse.status:type_name -> walletdkrpc.ExitJobStatus
 	0,  // 25: walletdkrpc.SubscribeWalletRequest.kinds:type_name -> walletdkrpc.EntryKind
-	0,  // 26: walletdkrpc.WalletEntry.kind:type_name -> walletdkrpc.EntryKind
-	1,  // 27: walletdkrpc.WalletEntry.status:type_name -> walletdkrpc.EntryStatus
-	51, // 28: walletdkrpc.WalletEntry.request:type_name -> walletdkrpc.WalletEntryRequest
-	55, // 29: walletdkrpc.WalletEntry.progress:type_name -> walletdkrpc.WalletEntryProgress
-	8,  // 30: walletdkrpc.WalletEntry.failure_code:type_name -> walletdkrpc.EntryFailureCode
-	52, // 31: walletdkrpc.WalletEntryRequest.lightning_invoice:type_name -> walletdkrpc.LightningInvoiceRequest
-	53, // 32: walletdkrpc.WalletEntryRequest.onchain_address:type_name -> walletdkrpc.OnchainAddressRequest
-	54, // 33: walletdkrpc.WalletEntryRequest.ark_address:type_name -> walletdkrpc.ArkAddressRequest
-	7,  // 34: walletdkrpc.WalletEntryProgress.phase:type_name -> walletdkrpc.WalletEntryPhase
-	9,  // 35: walletdkrpc.WalletService.Create:input_type -> walletdkrpc.CreateRequest
-	11, // 36: walletdkrpc.WalletService.Unlock:input_type -> walletdkrpc.UnlockRequest
-	13, // 37: walletdkrpc.WalletService.PrepareSend:input_type -> walletdkrpc.PrepareSendRequest
-	15, // 38: walletdkrpc.WalletService.Send:input_type -> walletdkrpc.SendRequest
-	17, // 39: walletdkrpc.WalletService.Recv:input_type -> walletdkrpc.RecvRequest
-	21, // 40: walletdkrpc.WalletService.List:input_type -> walletdkrpc.ListRequest
-	33, // 41: walletdkrpc.WalletService.Deposit:input_type -> walletdkrpc.DepositRequest
-	35, // 42: walletdkrpc.WalletService.Balance:input_type -> walletdkrpc.BalanceRequest
-	37, // 43: walletdkrpc.WalletService.Status:input_type -> walletdkrpc.StatusRequest
-	39, // 44: walletdkrpc.WalletService.GetExitPlan:input_type -> walletdkrpc.GetExitPlanRequest
-	42, // 45: walletdkrpc.WalletService.SweepWallet:input_type -> walletdkrpc.SweepWalletRequest
-	45, // 46: walletdkrpc.WalletService.Exit:input_type -> walletdkrpc.ExitRequest
-	47, // 47: walletdkrpc.WalletService.ExitStatus:input_type -> walletdkrpc.ExitStatusRequest
-	49, // 48: walletdkrpc.WalletService.SubscribeWallet:input_type -> walletdkrpc.SubscribeWalletRequest
-	28, // 49: walletdkrpc.WalletInspectionService.InspectActivity:input_type -> walletdkrpc.InspectActivityRequest
-	10, // 50: walletdkrpc.WalletService.Create:output_type -> walletdkrpc.CreateResponse
-	12, // 51: walletdkrpc.WalletService.Unlock:output_type -> walletdkrpc.UnlockResponse
-	14, // 52: walletdkrpc.WalletService.PrepareSend:output_type -> walletdkrpc.PrepareSendResponse
-	16, // 53: walletdkrpc.WalletService.Send:output_type -> walletdkrpc.SendResponse
-	18, // 54: walletdkrpc.WalletService.Recv:output_type -> walletdkrpc.RecvResponse
-	22, // 55: walletdkrpc.WalletService.List:output_type -> walletdkrpc.ListResponse
-	34, // 56: walletdkrpc.WalletService.Deposit:output_type -> walletdkrpc.DepositResponse
-	36, // 57: walletdkrpc.WalletService.Balance:output_type -> walletdkrpc.BalanceResponse
-	38, // 58: walletdkrpc.WalletService.Status:output_type -> walletdkrpc.StatusResponse
-	41, // 59: walletdkrpc.WalletService.GetExitPlan:output_type -> walletdkrpc.GetExitPlanResponse
-	44, // 60: walletdkrpc.WalletService.SweepWallet:output_type -> walletdkrpc.SweepWalletResponse
-	46, // 61: walletdkrpc.WalletService.Exit:output_type -> walletdkrpc.ExitResponse
-	48, // 62: walletdkrpc.WalletService.ExitStatus:output_type -> walletdkrpc.ExitStatusResponse
-	50, // 63: walletdkrpc.WalletService.SubscribeWallet:output_type -> walletdkrpc.WalletEntry
-	29, // 64: walletdkrpc.WalletInspectionService.InspectActivity:output_type -> walletdkrpc.InspectActivityResponse
-	50, // [50:65] is the sub-list for method output_type
-	35, // [35:50] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	35, // [35:35] is the sub-list for extension extendee
-	0,  // [0:35] is the sub-list for field type_name
+	52, // 26: walletdkrpc.SubscribeWalletResponse.entry:type_name -> walletdkrpc.WalletEntry
+	51, // 27: walletdkrpc.SubscribeWalletResponse.gap:type_name -> walletdkrpc.SubscribeGap
+	0,  // 28: walletdkrpc.WalletEntry.kind:type_name -> walletdkrpc.EntryKind
+	1,  // 29: walletdkrpc.WalletEntry.status:type_name -> walletdkrpc.EntryStatus
+	53, // 30: walletdkrpc.WalletEntry.request:type_name -> walletdkrpc.WalletEntryRequest
+	57, // 31: walletdkrpc.WalletEntry.progress:type_name -> walletdkrpc.WalletEntryProgress
+	8,  // 32: walletdkrpc.WalletEntry.failure_code:type_name -> walletdkrpc.EntryFailureCode
+	54, // 33: walletdkrpc.WalletEntryRequest.lightning_invoice:type_name -> walletdkrpc.LightningInvoiceRequest
+	55, // 34: walletdkrpc.WalletEntryRequest.onchain_address:type_name -> walletdkrpc.OnchainAddressRequest
+	56, // 35: walletdkrpc.WalletEntryRequest.ark_address:type_name -> walletdkrpc.ArkAddressRequest
+	7,  // 36: walletdkrpc.WalletEntryProgress.phase:type_name -> walletdkrpc.WalletEntryPhase
+	9,  // 37: walletdkrpc.WalletService.Create:input_type -> walletdkrpc.CreateRequest
+	11, // 38: walletdkrpc.WalletService.Unlock:input_type -> walletdkrpc.UnlockRequest
+	13, // 39: walletdkrpc.WalletService.PrepareSend:input_type -> walletdkrpc.PrepareSendRequest
+	15, // 40: walletdkrpc.WalletService.Send:input_type -> walletdkrpc.SendRequest
+	17, // 41: walletdkrpc.WalletService.Recv:input_type -> walletdkrpc.RecvRequest
+	21, // 42: walletdkrpc.WalletService.List:input_type -> walletdkrpc.ListRequest
+	33, // 43: walletdkrpc.WalletService.Deposit:input_type -> walletdkrpc.DepositRequest
+	35, // 44: walletdkrpc.WalletService.Balance:input_type -> walletdkrpc.BalanceRequest
+	37, // 45: walletdkrpc.WalletService.Status:input_type -> walletdkrpc.StatusRequest
+	39, // 46: walletdkrpc.WalletService.GetExitPlan:input_type -> walletdkrpc.GetExitPlanRequest
+	42, // 47: walletdkrpc.WalletService.SweepWallet:input_type -> walletdkrpc.SweepWalletRequest
+	45, // 48: walletdkrpc.WalletService.Exit:input_type -> walletdkrpc.ExitRequest
+	47, // 49: walletdkrpc.WalletService.ExitStatus:input_type -> walletdkrpc.ExitStatusRequest
+	49, // 50: walletdkrpc.WalletService.SubscribeWallet:input_type -> walletdkrpc.SubscribeWalletRequest
+	28, // 51: walletdkrpc.WalletInspectionService.InspectActivity:input_type -> walletdkrpc.InspectActivityRequest
+	10, // 52: walletdkrpc.WalletService.Create:output_type -> walletdkrpc.CreateResponse
+	12, // 53: walletdkrpc.WalletService.Unlock:output_type -> walletdkrpc.UnlockResponse
+	14, // 54: walletdkrpc.WalletService.PrepareSend:output_type -> walletdkrpc.PrepareSendResponse
+	16, // 55: walletdkrpc.WalletService.Send:output_type -> walletdkrpc.SendResponse
+	18, // 56: walletdkrpc.WalletService.Recv:output_type -> walletdkrpc.RecvResponse
+	22, // 57: walletdkrpc.WalletService.List:output_type -> walletdkrpc.ListResponse
+	34, // 58: walletdkrpc.WalletService.Deposit:output_type -> walletdkrpc.DepositResponse
+	36, // 59: walletdkrpc.WalletService.Balance:output_type -> walletdkrpc.BalanceResponse
+	38, // 60: walletdkrpc.WalletService.Status:output_type -> walletdkrpc.StatusResponse
+	41, // 61: walletdkrpc.WalletService.GetExitPlan:output_type -> walletdkrpc.GetExitPlanResponse
+	44, // 62: walletdkrpc.WalletService.SweepWallet:output_type -> walletdkrpc.SweepWalletResponse
+	46, // 63: walletdkrpc.WalletService.Exit:output_type -> walletdkrpc.ExitResponse
+	48, // 64: walletdkrpc.WalletService.ExitStatus:output_type -> walletdkrpc.ExitStatusResponse
+	50, // 65: walletdkrpc.WalletService.SubscribeWallet:output_type -> walletdkrpc.SubscribeWalletResponse
+	29, // 66: walletdkrpc.WalletInspectionService.InspectActivity:output_type -> walletdkrpc.InspectActivityResponse
+	52, // [52:67] is the sub-list for method output_type
+	37, // [37:52] is the sub-list for method input_type
+	37, // [37:37] is the sub-list for extension type_name
+	37, // [37:37] is the sub-list for extension extendee
+	0,  // [0:37] is the sub-list for field type_name
 }
 
 func init() { file_wallet_proto_init() }
@@ -5375,8 +5552,12 @@ func file_wallet_proto_init() {
 		(*ListResponse_Vtxos)(nil),
 		(*ListResponse_Onchain)(nil),
 	}
-	file_wallet_proto_msgTypes[41].OneofWrappers = []any{}
-	file_wallet_proto_msgTypes[42].OneofWrappers = []any{
+	file_wallet_proto_msgTypes[41].OneofWrappers = []any{
+		(*SubscribeWalletResponse_Entry)(nil),
+		(*SubscribeWalletResponse_Gap)(nil),
+	}
+	file_wallet_proto_msgTypes[43].OneofWrappers = []any{}
+	file_wallet_proto_msgTypes[44].OneofWrappers = []any{
 		(*WalletEntryRequest_LightningInvoice)(nil),
 		(*WalletEntryRequest_OnchainAddress)(nil),
 		(*WalletEntryRequest_ArkAddress)(nil),
@@ -5387,7 +5568,7 @@ func file_wallet_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wallet_proto_rawDesc), len(file_wallet_proto_rawDesc)),
 			NumEnums:      9,
-			NumMessages:   47,
+			NumMessages:   49,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/rpc/walletdkrpc/wallet.proto
+++ b/rpc/walletdkrpc/wallet.proto
@@ -87,10 +87,11 @@ service WalletService {
     // sweep state. Proxies daemonrpc.GetUnrollStatus.
     rpc ExitStatus (ExitStatusRequest) returns (ExitStatusResponse);
 
-    // SubscribeWallet streams normalized WalletEntry updates as they
-    // happen. When include_existing is set, the daemon emits the current
-    // snapshot before live updates.
-    rpc SubscribeWallet (SubscribeWalletRequest) returns (stream WalletEntry);
+    // SubscribeWallet streams activity updates as they happen. The stream
+    // is resumable: each response carries a monotonic cursor the client can
+    // reconnect from to replay everything after it without gaps.
+    rpc SubscribeWallet (SubscribeWalletRequest)
+        returns (stream SubscribeWalletResponse);
 }
 
 // WalletInspectionService exposes technical drill-downs for wallet activity.
@@ -1243,13 +1244,52 @@ message ExitStatusResponse {
 
 // SubscribeWalletRequest configures the WalletService.SubscribeWallet stream.
 message SubscribeWalletRequest {
-    // include_existing instructs the daemon to emit the current
-    // snapshot before the live subscription is registered.
+    // include_existing replays the full activity history before live
+    // updates. It is ignored when cursor is set (cursor already selects the
+    // replay start).
     bool include_existing = 1;
 
-    // kinds optionally narrows the live stream to specific entry
-    // categories. When empty, all kinds are streamed.
+    // kinds optionally narrows the stream to specific entry categories.
+    // When empty, all kinds are streamed.
     repeated EntryKind kinds = 2;
+
+    // cursor resumes the stream from a prior SubscribeWalletResponse.cursor:
+    // the daemon replays every event after it, then continues live. Zero
+    // (unset) starts from the full history when include_existing is set, or
+    // from the current tip otherwise.
+    int64 cursor = 3;
+}
+
+// SubscribeWalletResponse is one item in the SubscribeWallet stream: either a
+// projected activity row or a gap signal telling the subscriber it fell behind
+// and must reconcile.
+message SubscribeWalletResponse {
+    // cursor is the monotonic event-log position of this update. A client
+    // persists it and reconnects with SubscribeWalletRequest.cursor set to the
+    // last value it processed to resume without gaps. The sequence is
+    // monotonic but NOT contiguous: a value may be skipped, so a client treats
+    // any cursor past its last as new and never infers a dropped event from a
+    // gap in the numbers.
+    int64 cursor = 1;
+
+    oneof update {
+        // entry is a projected activity row at cursor.
+        WalletEntry entry = 2;
+
+        // gap signals the subscriber fell behind the live buffer and should
+        // reconcile current state via List, then resume from cursor.
+        SubscribeGap gap = 3;
+    }
+}
+
+// SubscribeGap tells a subscriber the daemon could not keep it current on the
+// live stream (a slow consumer overflowed the send buffer). The subscriber
+// should reconcile via List and resume from the enclosing cursor. No activity
+// is lost: the canonical event log retains every event, so the resume replays
+// anything missed.
+message SubscribeGap {
+    // reason is a short human-readable description of why the gap was emitted.
+    string reason = 1;
 }
 
 // WalletEntry is the single flat row type returned by the ACTIVITY view of

--- a/rpc/walletdkrpc/wallet_grpc.pb.go
+++ b/rpc/walletdkrpc/wallet_grpc.pb.go
@@ -109,10 +109,10 @@ type WalletServiceClient interface {
 	// specified VTXO outpoint, including recovery chain progress and
 	// sweep state. Proxies daemonrpc.GetUnrollStatus.
 	ExitStatus(ctx context.Context, in *ExitStatusRequest, opts ...grpc.CallOption) (*ExitStatusResponse, error)
-	// SubscribeWallet streams normalized WalletEntry updates as they
-	// happen. When include_existing is set, the daemon emits the current
-	// snapshot before live updates.
-	SubscribeWallet(ctx context.Context, in *SubscribeWalletRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WalletEntry], error)
+	// SubscribeWallet streams activity updates as they happen. The stream
+	// is resumable: each response carries a monotonic cursor the client can
+	// reconnect from to replay everything after it without gaps.
+	SubscribeWallet(ctx context.Context, in *SubscribeWalletRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SubscribeWalletResponse], error)
 }
 
 type walletServiceClient struct {
@@ -253,13 +253,13 @@ func (c *walletServiceClient) ExitStatus(ctx context.Context, in *ExitStatusRequ
 	return out, nil
 }
 
-func (c *walletServiceClient) SubscribeWallet(ctx context.Context, in *SubscribeWalletRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WalletEntry], error) {
+func (c *walletServiceClient) SubscribeWallet(ctx context.Context, in *SubscribeWalletRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SubscribeWalletResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &WalletService_ServiceDesc.Streams[0], WalletService_SubscribeWallet_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &grpc.GenericClientStream[SubscribeWalletRequest, WalletEntry]{ClientStream: stream}
+	x := &grpc.GenericClientStream[SubscribeWalletRequest, SubscribeWalletResponse]{ClientStream: stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}
@@ -270,7 +270,7 @@ func (c *walletServiceClient) SubscribeWallet(ctx context.Context, in *Subscribe
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type WalletService_SubscribeWalletClient = grpc.ServerStreamingClient[WalletEntry]
+type WalletService_SubscribeWalletClient = grpc.ServerStreamingClient[SubscribeWalletResponse]
 
 // WalletServiceServer is the server API for WalletService service.
 // All implementations must embed UnimplementedWalletServiceServer
@@ -346,10 +346,10 @@ type WalletServiceServer interface {
 	// specified VTXO outpoint, including recovery chain progress and
 	// sweep state. Proxies daemonrpc.GetUnrollStatus.
 	ExitStatus(context.Context, *ExitStatusRequest) (*ExitStatusResponse, error)
-	// SubscribeWallet streams normalized WalletEntry updates as they
-	// happen. When include_existing is set, the daemon emits the current
-	// snapshot before live updates.
-	SubscribeWallet(*SubscribeWalletRequest, grpc.ServerStreamingServer[WalletEntry]) error
+	// SubscribeWallet streams activity updates as they happen. The stream
+	// is resumable: each response carries a monotonic cursor the client can
+	// reconnect from to replay everything after it without gaps.
+	SubscribeWallet(*SubscribeWalletRequest, grpc.ServerStreamingServer[SubscribeWalletResponse]) error
 	mustEmbedUnimplementedWalletServiceServer()
 }
 
@@ -399,7 +399,7 @@ func (UnimplementedWalletServiceServer) Exit(context.Context, *ExitRequest) (*Ex
 func (UnimplementedWalletServiceServer) ExitStatus(context.Context, *ExitStatusRequest) (*ExitStatusResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ExitStatus not implemented")
 }
-func (UnimplementedWalletServiceServer) SubscribeWallet(*SubscribeWalletRequest, grpc.ServerStreamingServer[WalletEntry]) error {
+func (UnimplementedWalletServiceServer) SubscribeWallet(*SubscribeWalletRequest, grpc.ServerStreamingServer[SubscribeWalletResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method SubscribeWallet not implemented")
 }
 func (UnimplementedWalletServiceServer) mustEmbedUnimplementedWalletServiceServer() {}
@@ -662,11 +662,11 @@ func _WalletService_SubscribeWallet_Handler(srv interface{}, stream grpc.ServerS
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
-	return srv.(WalletServiceServer).SubscribeWallet(m, &grpc.GenericServerStream[SubscribeWalletRequest, WalletEntry]{ServerStream: stream})
+	return srv.(WalletServiceServer).SubscribeWallet(m, &grpc.GenericServerStream[SubscribeWalletRequest, SubscribeWalletResponse]{ServerStream: stream})
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type WalletService_SubscribeWalletServer = grpc.ServerStreamingServer[WalletEntry]
+type WalletService_SubscribeWalletServer = grpc.ServerStreamingServer[SubscribeWalletResponse]
 
 // WalletService_ServiceDesc is the grpc.ServiceDesc for WalletService service.
 // It's only intended for direct use with grpc.RegisterService,

--- a/rpc/walletdkrpc/wallet_mailboxrpc.pb.go
+++ b/rpc/walletdkrpc/wallet_mailboxrpc.pb.go
@@ -51,7 +51,7 @@ type WalletServiceMailboxServer interface {
 	// ExitStatus handles ExitStatus.
 	ExitStatus(ctx context.Context, req *ExitStatusRequest) (*ExitStatusResponse, error)
 	// SubscribeWallet handles SubscribeWallet.
-	SubscribeWallet(ctx context.Context, req *SubscribeWalletRequest) (*WalletEntry, error)
+	SubscribeWallet(ctx context.Context, req *SubscribeWalletRequest) (*SubscribeWalletResponse, error)
 }
 
 // RegisterWalletServiceMailboxServer registers handlers for WalletService.
@@ -498,7 +498,7 @@ func (c *WalletServiceMailboxClient) ExitStatus(ctx context.Context, req *ExitSt
 }
 
 // SubscribeWallet calls the SubscribeWallet RPC.
-func (c *WalletServiceMailboxClient) SubscribeWallet(ctx context.Context, req *SubscribeWalletRequest, opts ...rpc.RPCOptions) (*WalletEntry, error) {
+func (c *WalletServiceMailboxClient) SubscribeWallet(ctx context.Context, req *SubscribeWalletRequest, opts ...rpc.RPCOptions) (*SubscribeWalletResponse, error) {
 	var opt rpc.RPCOptions
 	if len(opts) > 0 {
 		opt = opts[0]
@@ -512,7 +512,7 @@ func (c *WalletServiceMailboxClient) SubscribeWallet(ctx context.Context, req *S
 		return nil, err
 	}
 
-	resp := new(WalletEntry)
+	resp := new(SubscribeWalletResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/sdk/walletdk/client.go
+++ b/sdk/walletdk/client.go
@@ -633,6 +633,7 @@ func (c *Client) Subscribe(ctx context.Context, req SubscribeRequest) (
 		ctx, &walletdkrpc.SubscribeWalletRequest{
 			IncludeExisting: req.IncludeExisting,
 			Kinds:           kinds,
+			Cursor:          req.Cursor,
 		},
 	)
 	if err != nil {
@@ -659,24 +660,32 @@ func (c *Client) Subscribe(ctx context.Context, req SubscribeRequest) (
 			}
 
 			// A gap tells the consumer it fell behind the live
-			// stream. Surface it as a terminal error so the host
-			// reconciles current state via List and re-subscribes,
-			// rather than silently dropping the missed updates.
+			// stream. Surface it as a typed terminal error carrying
+			// the resume cursor: the host opens a new subscription
+			// with SubscribeRequest.Cursor set to it, and the
+			// replay is gap-free rather than silently dropping
+			// updates.
 			if gap := resp.GetGap(); gap != nil {
-				errs <- fmt.Errorf("wallet subscription gap: "+
-					"%s: reconcile via List and "+
-					"re-subscribe", gap.GetReason())
+				errs <- &SubscribeGapError{
+					Cursor: resp.GetCursor(),
+					Reason: gap.GetReason(),
+				}
 
 				return
 			}
 
-			entry := resp.GetEntry()
-			if entry == nil {
+			protoEntry := resp.GetEntry()
+			if protoEntry == nil {
 				continue
 			}
 
+			// Stamp the event-log cursor so the host can persist it
+			// and resume from it on reconnect.
+			entry := entryFromProto(protoEntry)
+			entry.Cursor = resp.GetCursor()
+
 			select {
-			case updates <- entryFromProto(entry):
+			case updates <- entry:
 			case <-ctx.Done():
 				errs <- fmt.Errorf("wallet subscription "+
 					"closed: %w", ctx.Err())

--- a/sdk/walletdk/client.go
+++ b/sdk/walletdk/client.go
@@ -658,8 +658,25 @@ func (c *Client) Subscribe(ctx context.Context, req SubscribeRequest) (
 				return
 			}
 
+			// A gap tells the consumer it fell behind the live
+			// stream. Surface it as a terminal error so the host
+			// reconciles current state via List and re-subscribes,
+			// rather than silently dropping the missed updates.
+			if gap := resp.GetGap(); gap != nil {
+				errs <- fmt.Errorf("wallet subscription gap: "+
+					"%s: reconcile via List and "+
+					"re-subscribe", gap.GetReason())
+
+				return
+			}
+
+			entry := resp.GetEntry()
+			if entry == nil {
+				continue
+			}
+
 			select {
-			case updates <- entryFromProto(resp):
+			case updates <- entryFromProto(entry):
 			case <-ctx.Done():
 				errs <- fmt.Errorf("wallet subscription "+
 					"closed: %w", ctx.Err())

--- a/sdk/walletdk/errors.go
+++ b/sdk/walletdk/errors.go
@@ -1,6 +1,28 @@
 package walletdk
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
+
+// SubscribeGapError signals that a live SubscribeWallet stream fell behind (the
+// server-side send buffer overflowed). No activity is lost: the consumer should
+// open a new subscription with SubscribeRequest.Cursor set to Cursor, and the
+// replay from it is gap-free because the event log retains everything after it.
+type SubscribeGapError struct {
+	// Cursor is the resume point: the last event-log position the stream
+	// is known to have covered before falling behind.
+	Cursor int64
+
+	// Reason is the daemon's human-readable description of the gap.
+	Reason string
+}
+
+// Error implements the error interface.
+func (e *SubscribeGapError) Error() string {
+	return fmt.Sprintf("wallet subscription gap at cursor %d: %s: resume "+
+		"a new subscription from the cursor", e.Cursor, e.Reason)
+}
 
 // ErrWalletRPCUnavailable reports that an embedded walletdk runtime was built
 // without the wallet RPC subserver needed by wallet payment methods.

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -566,6 +566,12 @@ type Status struct {
 type SubscribeRequest struct {
 	IncludeExisting bool
 	Kinds           []EntryKind
+
+	// Cursor resumes the stream after a prior Entry.Cursor (or a
+	// *SubscribeGapError.Cursor): the daemon replays every activity event
+	// after it, then streams live. Zero replays the full history when
+	// IncludeExisting is set, or streams live-only otherwise.
+	Cursor int64
 }
 
 // EntryKind is the user-visible wallet activity category.
@@ -611,6 +617,12 @@ type Entry struct {
 	UpdatedAt     time.Time
 	Note          string
 	FailureReason string
+
+	// Cursor is the monotonic event-log position of this update on a
+	// SubscribeWallet stream. Persist it and pass it back as
+	// SubscribeRequest.Cursor to resume without gaps. It is zero outside
+	// the subscription path (List / Send / Recv / Deposit results).
+	Cursor int64
 
 	// Progress carries the lifecycle metadata the daemon already
 	// normalized for this entry (phase, payment hash, txid, confirmation

--- a/swapwallet/credit_projector_test.go
+++ b/swapwallet/credit_projector_test.go
@@ -16,13 +16,13 @@ const payHashHex = "00112233445566778899aabbccddeeff" +
 	"00112233445566778899aabbccddeeff"
 
 // drainEntries non-blockingly collects every WalletEntry currently queued on a
-// subscriber channel.
-func drainEntries(ch chan *walletdkrpc.WalletEntry) []*walletdkrpc.WalletEntry {
+// subscriber.
+func drainEntries(sub *subscriber) []*walletdkrpc.WalletEntry {
 	var out []*walletdkrpc.WalletEntry
 	for {
 		select {
-		case e := <-ch:
-			out = append(out, e)
+		case u := <-sub.ch:
+			out = append(out, u.entry)
 
 		default:
 			return out

--- a/swapwallet/list_store_test.go
+++ b/swapwallet/list_store_test.go
@@ -50,7 +50,9 @@ func seedActivity(t *testing.T, store *db.ActivityPersistenceStore, id string,
 		UpdatedAtUnix: created,
 	})
 	require.NoError(t, err)
-	require.NoError(t, store.ProjectEntry(context.Background(), proj))
+
+	_, err = store.ProjectEntry(context.Background(), proj)
+	require.NoError(t, err)
 }
 
 func activityIDs(list *walletdkrpc.ActivityList) []string {
@@ -305,7 +307,9 @@ func TestRowToWalletEntryRoundTrip(t *testing.T) {
 
 	proj, err := entryToProjection(entry)
 	require.NoError(t, err)
-	require.NoError(t, store.ProjectEntry(ctx, proj))
+
+	_, err = store.ProjectEntry(ctx, proj)
+	require.NoError(t, err)
 
 	row, err := store.GetEntry(ctx, entry.GetId())
 	require.NoError(t, err)

--- a/swapwallet/monitor_test.go
+++ b/swapwallet/monitor_test.go
@@ -58,15 +58,13 @@ func (f *streamingFakeSwap) SubscribeSwaps(
 
 // drainOne pulls the next emitted WalletEntry from a subscriber channel
 // within the test deadline.
-func drainOne(t *testing.T,
-	ch <-chan *walletdkrpc.WalletEntry) *walletdkrpc.WalletEntry {
-
+func drainOne(t *testing.T, sub *subscriber) *walletdkrpc.WalletEntry {
 	t.Helper()
 	select {
-	case e, ok := <-ch:
+	case u, ok := <-sub.ch:
 		require.True(t, ok, "subscriber channel closed unexpectedly")
 
-		return e
+		return u.entry
 
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for monitor update")
@@ -250,8 +248,8 @@ func TestMonitorLoopRecoversAfterTransientFailure(t *testing.T) {
 		}
 
 		select {
-		case e := <-sub:
-			require.Equal(t, "after-recovery", e.GetId())
+		case u := <-sub.ch:
+			require.Equal(t, "after-recovery", u.entry.GetId())
 
 			// Reconnect must NOT replay the existing-row
 			// snapshot. The first subscribe gets

--- a/swapwallet/projector.go
+++ b/swapwallet/projector.go
@@ -75,7 +75,21 @@ func (r *Runtime) project(ctx context.Context, entry *walletdkrpc.WalletEntry) (
 func (r *Runtime) projectAndEmit(ctx context.Context,
 	entry *walletdkrpc.WalletEntry) {
 
-	seq, _ := r.project(ctx, entry)
+	r.projectEmitLocked(ctx, entry)
+}
+
+// projectEmitLocked projects entry and fans it out, holding projectMu across
+// both so the event_seq assigned in the projection and the emit that carries it
+// stay in the same order across concurrent producers. It returns the projected
+// seq (0 when change-suppressed / no store) and the projection error, so the
+// reconciler can gate its pending-clear on a durable write. See projectMu.
+func (r *Runtime) projectEmitLocked(ctx context.Context,
+	entry *walletdkrpc.WalletEntry) (int64, error) {
+
+	r.projectMu.Lock()
+	defer r.projectMu.Unlock()
+
+	seq, err := r.project(ctx, entry)
 
 	switch {
 	case r.deps == nil || r.deps.ActivityStore == nil:
@@ -84,6 +98,8 @@ func (r *Runtime) projectAndEmit(ctx context.Context,
 	case seq > 0:
 		r.emit(seq, entry)
 	}
+
+	return seq, err
 }
 
 // reprojectActivity pages the derive-on-read feed and projects every row into
@@ -137,21 +153,18 @@ func (r *Runtime) reprojectActivity(ctx context.Context,
 		}
 
 		for _, entry := range entries {
-			seq, err := r.project(ctx, entry)
-			if err != nil {
+			// projectEmitLocked serializes the project+emit so a
+			// reconciled transition (a confirmed deposit, a
+			// forfeited leave) reaches live subscribers in seq
+			// order; a change-suppressed no-op fans out nothing.
+			if _, err := r.projectEmitLocked(
+				ctx, entry,
+			); err != nil {
+
 				// Best-effort: the next pass retries. Do not
 				// clear any pending record when the write did
 				// not land.
 				continue
-			}
-
-			// A real transition observed here (a confirmed deposit,
-			// a forfeited leave) must also reach live subscribers,
-			// not just the store; a change-suppressed no-op (seq 0)
-			// does not, so a re-poll of unchanged rows fans out
-			// nothing.
-			if seq > 0 {
-				r.emit(seq, entry)
 			}
 
 			r.clearProjectedTerminalExit(entry)

--- a/swapwallet/projector.go
+++ b/swapwallet/projector.go
@@ -16,20 +16,18 @@ import (
 
 // project writes one emitted WalletEntry into the canonical activity log: it
 // upserts the current-state row and appends the transition event, atomically.
-// Projection is best-effort and MUST NOT block or fail emit — a store error is
-// logged at warn level (it is an operational hiccup, not an internal bug) and
-// the caller still fans the update out to live subscribers. When no store is
-// wired (tests, or a build without a database) projection is a no-op and the
-// legacy derive-on-read path continues unchanged.
-// project writes entry into the canonical activity store. It returns nil on a
-// successful (or intentionally skipped) projection and the underlying error
-// when the durable write failed, so a caller can gate a follow-up side effect
-// on the row actually landing.
-func (r *Runtime) project(ctx context.Context,
-	entry *walletdkrpc.WalletEntry) error {
+// It returns the event_seq assigned to the appended transition with a nil error
+// on success, (0, nil) when the projection was intentionally skipped (no store,
+// no id, or a change-suppressed no-op), and (0, err) when the durable write
+// failed. A caller stamps a live update with the returned seq and can gate a
+// follow-up side effect on the row actually landing. When no store is wired
+// (tests, or a build without a database) projection is a no-op and the legacy
+// derive-on-read path continues unchanged.
+func (r *Runtime) project(ctx context.Context, entry *walletdkrpc.WalletEntry) (
+	int64, error) {
 
 	if r.deps == nil || r.deps.ActivityStore == nil {
-		return nil
+		return 0, nil
 	}
 
 	// A row with no canonical id cannot be keyed; skip it, matching the
@@ -41,7 +39,7 @@ func (r *Runtime) project(ctx context.Context,
 	// real txid:vout id.
 	if entry.GetId() == "" ||
 		entry.GetId() == syntheticBoardingUnconfirmedID {
-		return nil
+		return 0, nil
 	}
 
 	projection, err := entryToProjection(entry)
@@ -49,32 +47,43 @@ func (r *Runtime) project(ctx context.Context,
 		r.deps.resolveLog().WarnS(ctx, "Activity projection skipped: "+
 			"encode failed", err)
 
-		return err
+		return 0, err
 	}
 
-	if err := r.deps.ActivityStore.ProjectEntry(
-		ctx, projection,
-	); err != nil {
-
+	seq, err := r.deps.ActivityStore.ProjectEntry(ctx, projection)
+	if err != nil {
 		r.deps.resolveLog().WarnS(ctx, "Activity projection failed",
 			err,
 		)
 
-		return err
+		return 0, err
 	}
 
-	return nil
+	return seq, nil
 }
 
 // projectAndEmit projects the entry into the canonical activity log and then
 // fans it out to live subscribers. Projection runs first so a row is durable
-// before any subscriber observes it, but a projection failure never suppresses
-// the emit.
+// before any subscriber observes it.
+//
+// With a canonical store, a live update carries the event_seq the transition
+// was assigned, and only real transitions (seq > 0) are emitted: a
+// change-suppressed re-projection is not a new event, and a failed projection
+// is not durable, so neither reaches subscribers — they recover from the event
+// log or a List reconcile. Without a store there is no event log, so it emits
+// best-effort at seq 0 for a live-only stream.
 func (r *Runtime) projectAndEmit(ctx context.Context,
 	entry *walletdkrpc.WalletEntry) {
 
-	r.project(ctx, entry)
-	r.emit(entry)
+	seq, _ := r.project(ctx, entry)
+
+	switch {
+	case r.deps == nil || r.deps.ActivityStore == nil:
+		r.emit(0, entry)
+
+	case seq > 0:
+		r.emit(seq, entry)
+	}
 }
 
 // reprojectActivity pages the derive-on-read feed and projects every row into
@@ -128,11 +137,21 @@ func (r *Runtime) reprojectActivity(ctx context.Context,
 		}
 
 		for _, entry := range entries {
-			if err := r.project(ctx, entry); err != nil {
+			seq, err := r.project(ctx, entry)
+			if err != nil {
 				// Best-effort: the next pass retries. Do not
 				// clear any pending record when the write did
 				// not land.
 				continue
+			}
+
+			// A real transition observed here (a confirmed deposit,
+			// a forfeited leave) must also reach live subscribers,
+			// not just the store; a change-suppressed no-op (seq 0)
+			// does not, so a re-poll of unchanged rows fans out
+			// nothing.
+			if seq > 0 {
+				r.emit(seq, entry)
 			}
 
 			r.clearProjectedTerminalExit(entry)

--- a/swapwallet/projector_test.go
+++ b/swapwallet/projector_test.go
@@ -30,7 +30,7 @@ type fakeActivityProjector struct {
 }
 
 func (f *fakeActivityProjector) ProjectEntry(_ context.Context,
-	p db.ActivityProjection) error {
+	p db.ActivityProjection) (int64, error) {
 
 	if f.onProject != nil {
 		f.onProject()
@@ -40,12 +40,14 @@ func (f *fakeActivityProjector) ProjectEntry(_ context.Context,
 	defer f.mu.Unlock()
 
 	if f.err != nil {
-		return f.err
+		return 0, f.err
 	}
 
 	f.projected = append(f.projected, p)
 
-	return nil
+	// Return a positive, increasing seq so projectAndEmit treats each
+	// successful projection as a real transition worth emitting.
+	return int64(len(f.projected)), nil
 }
 
 func (f *fakeActivityProjector) count() int {
@@ -70,6 +72,15 @@ func (f *fakeActivityProjector) CountByStatus(_ context.Context, _ int64) (
 	int64, error) {
 
 	return 0, nil
+}
+
+// PullEvents satisfies darepod.ActivityStore. This fake exercises only the
+// write path; the resumable-subscribe replay is tested against a real DB
+// store, so this returns no events.
+func (f *fakeActivityProjector) PullEvents(_ context.Context, _ int64,
+	_ int32) ([]sqlc.ActivityEvent, error) {
+
+	return nil, nil
 }
 
 // ids returns the set of canonical ids the fake has been asked to project.
@@ -169,8 +180,7 @@ func TestEntryToProjectionEmptyHandles(t *testing.T) {
 // newProjectorRuntime builds a runtime wired with the given projector (which
 // may be nil) and a subscriber channel.
 func newProjectorRuntime(t *testing.T,
-	store *fakeActivityProjector) (*Runtime,
-	chan *walletdkrpc.WalletEntry) {
+	store *fakeActivityProjector) (*Runtime, *subscriber) {
 
 	t.Helper()
 
@@ -188,15 +198,13 @@ func newProjectorRuntime(t *testing.T,
 	return runtime, ch
 }
 
-// recvEntry reads one entry from the subscriber channel within a short window.
-func recvEntry(t *testing.T,
-	ch chan *walletdkrpc.WalletEntry) *walletdkrpc.WalletEntry {
-
+// recvEntry reads one entry from the subscriber within a short window.
+func recvEntry(t *testing.T, sub *subscriber) *walletdkrpc.WalletEntry {
 	t.Helper()
 
 	select {
-	case e := <-ch:
-		return e
+	case u := <-sub.ch:
+		return u.entry
 
 	case <-time.After(time.Second):
 		t.Fatal("expected an emitted entry")
@@ -215,7 +223,7 @@ func TestProjectAndEmitProjectsBeforeEmitting(t *testing.T) {
 	var chLenAtProject int
 	runtime, ch := newProjectorRuntime(t, store)
 	store.onProject = func() {
-		chLenAtProject = len(ch)
+		chLenAtProject = len(ch.ch)
 	}
 
 	runtime.projectAndEmit(context.Background(), sampleWalletEntry())
@@ -241,8 +249,9 @@ func TestProjectAndEmitNilStore(t *testing.T) {
 	require.Equal(t, "payment-hash", recvEntry(t, ch).GetId())
 }
 
-// TestProjectAndEmitSkipsEmptyID verifies an id-less entry is not projected but
-// is still emitted.
+// TestProjectAndEmitSkipsEmptyID verifies an id-less entry is neither projected
+// nor emitted: with a store wired it cannot be keyed, so it has no event_seq to
+// carry as a cursor.
 func TestProjectAndEmitSkipsEmptyID(t *testing.T) {
 	t.Parallel()
 
@@ -253,26 +262,31 @@ func TestProjectAndEmitSkipsEmptyID(t *testing.T) {
 	entry.Id = ""
 	runtime.projectAndEmit(context.Background(), entry)
 
-	require.NotNil(t, recvEntry(t, ch))
+	require.Empty(t, drainEntries(ch), "id-less entry must not be emitted")
 	require.Equal(t, 0, store.count())
 }
 
-// TestProjectAndEmitStoreErrorStillEmits verifies a store failure never
-// suppresses the emit.
-func TestProjectAndEmitStoreErrorStillEmits(t *testing.T) {
+// TestProjectAndEmitStoreErrorDoesNotEmit verifies a failed projection is not
+// emitted: without a durable event there is no cursor to advance, so the update
+// is left for the consumer to recover from the log or a List reconcile rather
+// than delivered un-cursored.
+func TestProjectAndEmitStoreErrorDoesNotEmit(t *testing.T) {
 	t.Parallel()
 
 	store := &fakeActivityProjector{err: context.DeadlineExceeded}
 	runtime, ch := newProjectorRuntime(t, store)
 
 	runtime.projectAndEmit(context.Background(), sampleWalletEntry())
-	require.Equal(t, "payment-hash", recvEntry(t, ch).GetId())
+	require.Empty(
+		t, drainEntries(ch),
+		"a failed projection must not be emitted",
+	)
 }
 
 // TestProjectAndEmitSkipsEphemeralBoardingRow verifies the synthetic
-// boarding-unconfirmed row is emitted to subscribers but never persisted: it
-// is ephemeral live state with no durable id, and a delete-free store could
-// never clear it once the deposit confirms under its real txid:vout id.
+// boarding-unconfirmed row is neither persisted nor emitted: it is ephemeral
+// live state with no durable id (the store-backed List omits it too), so it
+// carries no event_seq to stream.
 func TestProjectAndEmitSkipsEphemeralBoardingRow(t *testing.T) {
 	t.Parallel()
 
@@ -283,8 +297,9 @@ func TestProjectAndEmitSkipsEphemeralBoardingRow(t *testing.T) {
 	entry.Id = syntheticBoardingUnconfirmedID
 	runtime.projectAndEmit(context.Background(), entry)
 
-	require.Equal(
-		t, syntheticBoardingUnconfirmedID, recvEntry(t, ch).GetId(),
+	require.Empty(
+		t, drainEntries(ch),
+		"ephemeral boarding row must not be emitted",
 	)
 	require.Equal(t, 0, store.count(), "ephemeral row must not be stored")
 }

--- a/swapwallet/reconciler_test.go
+++ b/swapwallet/reconciler_test.go
@@ -223,7 +223,7 @@ type failingProjectStore struct {
 }
 
 func (failingProjectStore) ProjectEntry(context.Context,
-	db.ActivityProjection) error {
+	db.ActivityProjection) (int64, error) {
 
-	return errors.New("injected project failure")
+	return 0, errors.New("injected project failure")
 }

--- a/swapwallet/runtime.go
+++ b/swapwallet/runtime.go
@@ -5,6 +5,7 @@ package swapwallet
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
@@ -57,12 +58,13 @@ type Runtime struct {
 	// subsMu guards subscribers.
 	subsMu sync.Mutex
 
-	// subscribers receive normalized WalletEntry updates from the
-	// monitor loop. Channels are best-effort, buffered, and
-	// non-blocking: a slow consumer drops updates rather than stalling
-	// the runtime. SubscribeWallet handlers reconcile with List on
-	// reconnect.
-	subscribers map[chan *walletdkrpc.WalletEntry]struct{}
+	// subscribers receive activity updates from the projection paths.
+	// Each update carries the event_seq its transition was assigned so a
+	// SubscribeWallet stream can hand the consumer a resumable cursor.
+	// Sends are non-blocking: a slow consumer's buffer fills and its
+	// overflowed flag is set rather than dropping silently, so the handler
+	// signals a gap and the consumer reconciles via List.
+	subscribers map[*subscriber]struct{}
 
 	// pendingMu guards pending and overlay.
 	pendingMu sync.Mutex
@@ -104,7 +106,7 @@ func newRuntime(parent context.Context, deps *Deps) *Runtime {
 		rootCtx: rootCtx,
 		cancel:  cancel,
 		subscribers: make(
-			map[chan *walletdkrpc.WalletEntry]struct{},
+			map[*subscriber]struct{},
 		),
 		pending: make(map[string]pendingEntry),
 		overlay: make(map[string]overlayStatus),
@@ -439,48 +441,69 @@ func isSwapKind(kind walletdkrpc.EntryKind) bool {
 		kind == walletdkrpc.EntryKind_ENTRY_KIND_RECV
 }
 
-// subscribe registers a channel to receive normalized WalletEntry updates
-// from the monitor loop. The caller must drain the channel; the runtime
-// drops updates rather than blocking on a slow consumer.
-func (r *Runtime) subscribe() chan *walletdkrpc.WalletEntry {
-	ch := make(
-		chan *walletdkrpc.WalletEntry,
-		int(
-			r.deps.resolveSubscribeBuffer(),
+// subscribeUpdate is one activity update fanned to a subscriber: the projected
+// WalletEntry plus the event_seq its transition was assigned, which a
+// SubscribeWallet stream surfaces as the resumable cursor.
+type subscribeUpdate struct {
+	seq   int64
+	entry *walletdkrpc.WalletEntry
+}
+
+// subscriber is a registered SubscribeWallet consumer. Updates arrive on ch;
+// when a send would block (the consumer is slower than the producer),
+// overflowed is set instead of dropping silently, so the handler can signal a
+// gap and let the consumer reconcile via List.
+type subscriber struct {
+	ch         chan subscribeUpdate
+	overflowed atomic.Bool
+}
+
+// subscribe registers a consumer to receive activity updates. The caller must
+// drain the channel and unsubscribe when done.
+func (r *Runtime) subscribe() *subscriber {
+	sub := &subscriber{
+		ch: make(
+			chan subscribeUpdate,
+			int(
+				r.deps.resolveSubscribeBuffer(),
+			),
 		),
-	)
+	}
 
 	r.subsMu.Lock()
-	r.subscribers[ch] = struct{}{}
+	r.subscribers[sub] = struct{}{}
 	r.subsMu.Unlock()
 
-	return ch
+	return sub
 }
 
 // unsubscribe removes a previously-registered subscriber. Safe to call
 // multiple times; the channel is closed exactly once.
-func (r *Runtime) unsubscribe(ch chan *walletdkrpc.WalletEntry) {
+func (r *Runtime) unsubscribe(sub *subscriber) {
 	r.subsMu.Lock()
 	defer r.subsMu.Unlock()
 
-	if _, ok := r.subscribers[ch]; !ok {
+	if _, ok := r.subscribers[sub]; !ok {
 		return
 	}
-	delete(r.subscribers, ch)
-	close(ch)
+	delete(r.subscribers, sub)
+	close(sub.ch)
 }
 
-// emit fans a WalletEntry update out to every subscribed channel using a
-// non-blocking send. Slow consumers drop updates; they can reconcile via
-// List on reconnect.
-func (r *Runtime) emit(entry *walletdkrpc.WalletEntry) {
+// emit fans one activity update out to every subscriber with a non-blocking
+// send. A consumer whose buffer is full has its overflowed flag set rather
+// than losing the update silently: the handler turns that into a gap signal so
+// the consumer reconciles via List and resumes from its cursor.
+func (r *Runtime) emit(seq int64, entry *walletdkrpc.WalletEntry) {
 	r.subsMu.Lock()
 	defer r.subsMu.Unlock()
 
-	for ch := range r.subscribers {
+	update := subscribeUpdate{seq: seq, entry: entry}
+	for sub := range r.subscribers {
 		select {
-		case ch <- entry:
+		case sub.ch <- update:
 		default:
+			sub.overflowed.Store(true)
 		}
 	}
 }
@@ -495,9 +518,9 @@ func (r *Runtime) stop() {
 	r.wg.Wait()
 
 	r.subsMu.Lock()
-	for ch := range r.subscribers {
-		delete(r.subscribers, ch)
-		close(ch)
+	for sub := range r.subscribers {
+		delete(r.subscribers, sub)
+		close(sub.ch)
 	}
 	r.subsMu.Unlock()
 }

--- a/swapwallet/runtime.go
+++ b/swapwallet/runtime.go
@@ -55,6 +55,14 @@ type Runtime struct {
 	// deadline goroutines if future wiring accidentally invokes it twice.
 	startOnce sync.Once
 
+	// projectMu serializes project-then-emit so the event_seq a
+	// transition is assigned and the emit that carries it stay in the same
+	// order across the concurrent producers (monitor, reconciler, credit
+	// poll, deadline watcher, RPC handlers). Without it a later-committed
+	// but lower-seq event could emit after a higher one, and the live
+	// cursor would advance past it and drop it silently.
+	projectMu sync.Mutex
+
 	// subsMu guards subscribers.
 	subsMu sync.Mutex
 
@@ -498,8 +506,15 @@ func (r *Runtime) emit(seq int64, entry *walletdkrpc.WalletEntry) {
 	r.subsMu.Lock()
 	defer r.subsMu.Unlock()
 
-	update := subscribeUpdate{seq: seq, entry: entry}
 	for sub := range r.subscribers {
+		// Each subscriber gets its own copy: the handler goroutines
+		// marshal their responses concurrently, and Marshal mutates a
+		// *WalletEntry's internal size cache, so a shared pointer would
+		// race across two subscribers (e.g. CLI + app).
+		update := subscribeUpdate{
+			seq:   seq,
+			entry: cloneWalletEntry(entry),
+		}
 		select {
 		case sub.ch <- update:
 		default:

--- a/swapwallet/runtime_test.go
+++ b/swapwallet/runtime_test.go
@@ -251,19 +251,20 @@ func TestDeadlineWatcherEmitsTimeoutToSubscribers(t *testing.T) {
 	r.applyDeadlines(tick)
 
 	select {
-	case got := <-sub:
-		require.Equal(t, "stuck", got.GetId())
+	case got := <-sub.ch:
+		require.Equal(t, "stuck", got.entry.GetId())
 		require.Equal(
-			t, walletdkrpc.EntryKind_ENTRY_KIND_EXIT, got.GetKind(),
+			t, walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+			got.entry.GetKind(),
 		)
 		require.Equal(
 			t, walletdkrpc.EntryStatus_ENTRY_STATUS_FAILED,
-			got.GetStatus(),
+			got.entry.GetStatus(),
 		)
-		require.Equal(t, "timed_out", got.GetFailureReason())
-		require.Equal(t, timedOutCode, got.GetFailureCode())
+		require.Equal(t, "timed_out", got.entry.GetFailureReason())
+		require.Equal(t, timedOutCode, got.entry.GetFailureCode())
 		require.Equal(
-			t, tick.Unix(), got.GetUpdatedAtUnix(),
+			t, tick.Unix(), got.entry.GetUpdatedAtUnix(),
 			"updated_at must reflect the watcher tick time",
 		)
 
@@ -333,11 +334,11 @@ func TestDeadlineWatcherDoesNotReEmitAlreadyTimedOut(t *testing.T) {
 	)
 	tick := time.Now().Add(2 * deadline)
 	r.applyDeadlines(tick)
-	<-sub // drain the first emit
+	<-sub.ch // drain the first emit
 
 	r.applyDeadlines(tick)
 	select {
-	case <-sub:
+	case <-sub.ch:
 		t.Fatal(
 			"watcher must not re-emit on an already-timed-out " +
 				"entry",
@@ -373,17 +374,19 @@ func TestDeadlineWatcherSkipsNoTimeoutEntries(t *testing.T) {
 	require.False(t, ok, "no-timeout row must not receive overlay")
 
 	select {
-	case got := <-sub:
-		t.Fatalf("no-timeout row must not emit timeout update: %v", got)
+	case got := <-sub.ch:
+		t.Fatalf("no-timeout row must not emit timeout update: %v",
+			got.entry)
 
 	case <-time.After(50 * time.Millisecond):
 	}
 }
 
-// TestSubscribeFanOutAndDropOnSlowConsumer asserts that emit delivers
-// updates to live subscribers and drops on a saturated buffer rather than
-// blocking the runtime.
-func TestSubscribeFanOutAndDropOnSlowConsumer(t *testing.T) {
+// TestSubscribeFanOutAndFlagsOverflow asserts that emit delivers updates to
+// live subscribers with their event_seq, and on a saturated buffer sets the
+// subscriber's overflowed flag (so the handler can signal a gap) rather than
+// dropping silently or blocking the runtime.
+func TestSubscribeFanOutAndFlagsOverflow(t *testing.T) {
 	t.Parallel()
 
 	deps := &Deps{}
@@ -397,26 +400,32 @@ func TestSubscribeFanOutAndDropOnSlowConsumer(t *testing.T) {
 		Id:   "abc",
 		Kind: walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
 	}
-	r.emit(entry)
+	r.emit(1, entry)
 
 	select {
-	case got := <-fast:
-		require.Equal(t, entry, got)
+	case got := <-fast.ch:
+		require.Equal(t, entry, got.entry)
+		require.Equal(t, int64(1), got.seq)
 
 	case <-time.After(time.Second):
 		t.Fatal("fast subscriber did not receive update")
 	}
 
-	// Now saturate slow's buffer so subsequent emits are dropped on
-	// that subscriber. The runtime must not block.
+	// Saturate slow's buffer so subsequent emits cannot enqueue. The
+	// runtime must not block, and slow must be flagged overflowed rather
+	// than losing the updates silently.
 	for i := 0; i < int(defaultSubscribeBufferConst)+5; i++ {
-		r.emit(entry)
+		r.emit(int64(i+2), entry)
 	}
+	require.True(
+		t, slow.overflowed.Load(),
+		"a saturated subscriber must be flagged overflowed",
+	)
 
 	// Drain fast so the runtime is not stuck on it either.
 	for {
 		select {
-		case <-fast:
+		case <-fast.ch:
 		default:
 			r.unsubscribe(slow)
 

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // Service implements the daemon-side WalletService gRPC handler. It is a
@@ -296,47 +297,59 @@ func (s *Service) Status(ctx context.Context, req *walletdkrpc.StatusRequest) (
 	}, nil
 }
 
-// SubscribeWallet streams WalletEntry updates. v1 optionally emits the
-// current snapshot before live updates and then forwards updates from the
-// runtime event bus until the caller disconnects or the daemon shuts down.
+// SubscribeWallet streams activity updates and is resumable: each response
+// carries the monotonic event_seq of the update as its cursor, and a client
+// reconnects with SubscribeWalletRequest.cursor set to the last value it
+// processed to replay everything after it without gaps.
+//
+// Replay start:
+//   - cursor > 0: replay events after cursor, then stream live.
+//   - cursor == 0 && include_existing: replay the full history, then live.
+//   - cursor == 0 && !include_existing: stream live only.
+//
+// A slow consumer that overflows the send buffer receives a SubscribeGap
+// rather than losing updates silently; it reconciles via List and resumes from
+// the cursor. Without a canonical store the stream degrades to the legacy
+// live-only behaviour (an optional List snapshot, then best-effort updates).
 func (s *Service) SubscribeWallet(req *walletdkrpc.SubscribeWalletRequest,
 	stream walletdkrpc.WalletService_SubscribeWalletServer) error {
 
 	ctx := stream.Context()
 
-	// Subscribe BEFORE taking the snapshot so the runtime starts
-	// buffering updates immediately. Otherwise any update that fires
-	// between snapshot fetch and subscribe registration is lost to this
-	// stream. Clients dedupe by WalletEntry.id, so the snapshot+stream
-	// overlap window is harmless.
-	updates := s.runtime.subscribe()
-	defer s.runtime.unsubscribe(updates)
-
-	if req.GetIncludeExisting() {
-		// Use the configured hard cap rather than the default page
-		// size so wallets with more than defaultListLimit entries
-		// receive a complete initial snapshot. A truncated snapshot
-		// would let the subscriber observe live updates that
-		// reference rows it never saw.
-		snapshot, err := s.history.List(ctx, &walletdkrpc.ListRequest{
-			View:  walletdkrpc.ListView_LIST_VIEW_ACTIVITY,
-			Kinds: req.GetKinds(),
-			Limit: s.deps.resolveMaxListLimit(),
-		})
-		if err != nil {
-			return fmt.Errorf("snapshot: %w", err)
-		}
-
-		for _, e := range snapshot.GetActivity().GetEntries() {
-			if err := stream.Send(e); err != nil {
-				return err
-			}
-		}
-	}
-
 	kindFilter, err := buildKindFilter(req.GetKinds())
 	if err != nil {
 		return err
+	}
+
+	// Subscribe BEFORE the replay/snapshot so live updates that fire during
+	// it are buffered rather than lost; the cursor dedupes the overlap.
+	sub := s.runtime.subscribe()
+	defer s.runtime.unsubscribe(sub)
+
+	store := s.deps.ActivityStore
+
+	// lastSeq is the highest cursor sent so far. It bounds the live loop's
+	// dedup against the replay and is the resume point advertised in a gap.
+	var lastSeq int64
+	switch {
+	case store != nil:
+		from, replay := replayStart(req)
+		if replay {
+			last, replayErr := s.replayEvents(
+				ctx, stream, from, kindFilter,
+			)
+			if replayErr != nil {
+				return replayErr
+			}
+			lastSeq = last
+		}
+
+	case req.GetIncludeExisting():
+		// Legacy no-store fallback: a one-shot List snapshot with no
+		// cursor, then best-effort live updates.
+		if err := s.streamListSnapshot(ctx, stream, req); err != nil {
+			return err
+		}
 	}
 
 	for {
@@ -344,19 +357,190 @@ func (s *Service) SubscribeWallet(req *walletdkrpc.SubscribeWalletRequest,
 		case <-ctx.Done():
 			return ctx.Err()
 
-		case e, ok := <-updates:
+		case upd, ok := <-sub.ch:
 			if !ok {
 				return nil
 			}
-			if len(kindFilter) > 0 {
-				if _, in := kindFilter[e.GetKind()]; !in {
-					continue
+
+			// A consumer that fell behind is told to reconcile
+			// rather than silently missing the dropped updates.
+			if sub.overflowed.Swap(false) {
+				if err := stream.Send(
+					gapResponse(lastSeq),
+				); err != nil {
+					return err
 				}
 			}
-			if err := stream.Send(e); err != nil {
+
+			// With a store, skip anything the replay already sent;
+			// the no-store path has no cursor, so it forwards all.
+			if store != nil && upd.seq <= lastSeq {
+				continue
+			}
+			if !kindAllowed(kindFilter, upd.entry) {
+				continue
+			}
+
+			if err := stream.Send(
+				entryResponse(upd.seq, upd.entry),
+			); err != nil {
 				return err
 			}
+			if upd.seq > lastSeq {
+				lastSeq = upd.seq
+			}
 		}
+	}
+}
+
+// replayStart resolves where a resumable subscribe replays from. A non-zero
+// cursor resumes strictly after it; a zero cursor with include_existing
+// replays the full history; a zero cursor without it skips replay and streams
+// live only.
+func replayStart(req *walletdkrpc.SubscribeWalletRequest) (int64, bool) {
+	switch {
+	case req.GetCursor() > 0:
+		return req.GetCursor(), true
+
+	case req.GetIncludeExisting():
+		return 0, true
+
+	default:
+		return 0, false
+	}
+}
+
+// replayEvents pages the append-only event log from cursor and streams each
+// transition, returning the highest event_seq sent. The client's cursor
+// selects the start and every row past it is new: the sequence is monotonic
+// but not contiguous, so a burned value is simply absent, never a dropped
+// event.
+func (s *Service) replayEvents(ctx context.Context,
+	stream walletdkrpc.WalletService_SubscribeWalletServer, from int64,
+	kindFilter map[walletdkrpc.EntryKind]struct{}) (int64, error) {
+
+	store := s.deps.ActivityStore
+	limit := int32(s.deps.resolveMaxListLimit())
+	cursor := from
+	for {
+		events, err := store.PullEvents(ctx, cursor, limit)
+		if err != nil {
+			return cursor, fmt.Errorf("subscribe replay: %w", err)
+		}
+		if len(events) == 0 {
+			return cursor, nil
+		}
+
+		for _, ev := range events {
+			cursor = ev.EventSeq
+
+			entry, err := walletEntryFromEventJSON(ev.EntryJson)
+			if err != nil {
+				// A single corrupt row must not kill the
+				// stream; the cursor has already advanced past
+				// it.
+				s.deps.resolveLog().WarnS(ctx, "Subscribe "+
+					"replay skipped: decode failed", err)
+
+				continue
+			}
+			if !kindAllowed(kindFilter, entry) {
+				continue
+			}
+			if err := stream.Send(
+				entryResponse(ev.EventSeq, entry),
+			); err != nil {
+				return cursor, err
+			}
+		}
+
+		if len(events) < int(limit) {
+			return cursor, nil
+		}
+	}
+}
+
+// streamListSnapshot sends the current activity snapshot as cursor-0 entry
+// responses. It is the no-store legacy path: without an event log there is no
+// resumable cursor, so a fresh List stands in for the replay.
+func (s *Service) streamListSnapshot(ctx context.Context,
+	stream walletdkrpc.WalletService_SubscribeWalletServer,
+	req *walletdkrpc.SubscribeWalletRequest) error {
+
+	// Use the configured hard cap rather than the default page size so a
+	// wallet with more than defaultListLimit entries gets a complete
+	// snapshot; a truncated one would let the subscriber observe live
+	// updates referencing rows it never saw.
+	snapshot, err := s.history.List(ctx, &walletdkrpc.ListRequest{
+		View:  walletdkrpc.ListView_LIST_VIEW_ACTIVITY,
+		Kinds: req.GetKinds(),
+		Limit: s.deps.resolveMaxListLimit(),
+	})
+	if err != nil {
+		return fmt.Errorf("snapshot: %w", err)
+	}
+
+	for _, e := range snapshot.GetActivity().GetEntries() {
+		if err := stream.Send(entryResponse(0, e)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// kindAllowed reports whether entry passes the kind filter. A nil/empty filter
+// admits every kind.
+func kindAllowed(filter map[walletdkrpc.EntryKind]struct{},
+	entry *walletdkrpc.WalletEntry) bool {
+
+	if len(filter) == 0 {
+		return true
+	}
+	_, ok := filter[entry.GetKind()]
+
+	return ok
+}
+
+// walletEntryFromEventJSON reconstructs the emitted WalletEntry from an event
+// row's protojson snapshot.
+func walletEntryFromEventJSON(entryJSON string) (*walletdkrpc.WalletEntry,
+	error) {
+
+	var entry walletdkrpc.WalletEntry
+	opts := protojson.UnmarshalOptions{DiscardUnknown: true}
+	if err := opts.Unmarshal([]byte(entryJSON), &entry); err != nil {
+		return nil, err
+	}
+
+	return &entry, nil
+}
+
+// entryResponse wraps a projected activity row and its cursor as a stream item.
+func entryResponse(cursor int64,
+	entry *walletdkrpc.WalletEntry) *walletdkrpc.SubscribeWalletResponse {
+
+	return &walletdkrpc.SubscribeWalletResponse{
+		Cursor: cursor,
+		Update: &walletdkrpc.SubscribeWalletResponse_Entry{
+			Entry: entry,
+		},
+	}
+}
+
+// gapResponse signals the consumer fell behind the live buffer. It carries the
+// resume cursor: the consumer reconciles current state via List, then resumes
+// the subscription from it.
+func gapResponse(cursor int64) *walletdkrpc.SubscribeWalletResponse {
+	return &walletdkrpc.SubscribeWalletResponse{
+		Cursor: cursor,
+		Update: &walletdkrpc.SubscribeWalletResponse_Gap{
+			Gap: &walletdkrpc.SubscribeGap{
+				Reason: "subscriber fell behind the live " +
+					"buffer; reconcile via List and " +
+					"resume from cursor",
+			},
+		},
 	}
 }
 

--- a/swapwallet/subscribe_test.go
+++ b/swapwallet/subscribe_test.go
@@ -1,0 +1,348 @@
+//go:build walletdkrpc && swapruntime
+
+package swapwallet
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// fakeSubscribeStream is a minimal WalletService_SubscribeWalletServer that
+// records every response. When release is non-nil the FIRST Send blocks on it
+// (after recording), so a test can wedge the live loop mid-send and overflow
+// the subscriber buffer deterministically.
+type fakeSubscribeStream struct {
+	grpc.ServerStream
+
+	ctx context.Context
+
+	mu   sync.Mutex
+	sent []*walletdkrpc.SubscribeWalletResponse
+
+	entered chan struct{}
+	release chan struct{}
+	blocked bool
+}
+
+// Context returns the stream context.
+func (f *fakeSubscribeStream) Context() context.Context {
+	return f.ctx
+}
+
+// Send records the response and, on the first call when a release gate is set,
+// signals entry and blocks until released.
+func (f *fakeSubscribeStream) Send(
+	r *walletdkrpc.SubscribeWalletResponse) error {
+
+	f.mu.Lock()
+	f.sent = append(f.sent, r)
+	first := !f.blocked && f.release != nil
+	if first {
+		f.blocked = true
+	}
+	f.mu.Unlock()
+
+	if first {
+		if f.entered != nil {
+			close(f.entered)
+		}
+		<-f.release
+	}
+
+	return nil
+}
+
+// responses returns a copy of everything sent so far.
+func (f *fakeSubscribeStream) responses() []*walletdkrpc.SubscribeWalletResponse {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append(
+		[]*walletdkrpc.SubscribeWalletResponse(nil), f.sent...,
+	)
+}
+
+// newSubscribeFixture builds a Service backed by a real activity store so the
+// resumable event-log replay can be exercised end to end. buffer overrides the
+// per-subscriber channel size (0 uses the default).
+func newSubscribeFixture(t *testing.T, buffer uint32) (*Service,
+	*db.ActivityPersistenceStore, *Runtime) {
+
+	t.Helper()
+
+	testDB := db.NewTestDB(t)
+	store := db.NewStore(
+		testDB.DB, testDB.Queries, testDB.Backend(), btclog.Disabled,
+	).NewActivityStore(clock.NewDefaultClock())
+
+	deps := &Deps{
+		SwapService:     &fakeSwapService{},
+		RPCServer:       &fakeRPCServer{},
+		ActivityStore:   store,
+		SubscribeBuffer: buffer,
+	}
+	runtime := newRuntime(t.Context(), deps)
+	t.Cleanup(runtime.stop)
+
+	return newService(deps, runtime), store, runtime
+}
+
+// projectTestEntry writes one transition into the store and returns its
+// event_seq, so a test can assert the cursor a replay/live update carries.
+func projectTestEntry(t *testing.T, store *db.ActivityPersistenceStore,
+	id string, kind walletdkrpc.EntryKind,
+	status walletdkrpc.EntryStatus) int64 {
+
+	t.Helper()
+
+	proj, err := entryToProjection(&walletdkrpc.WalletEntry{
+		Id:            id,
+		Kind:          kind,
+		Status:        status,
+		CreatedAtUnix: 100,
+		UpdatedAtUnix: 100,
+	})
+	require.NoError(t, err)
+
+	seq, err := store.ProjectEntry(context.Background(), proj)
+	require.NoError(t, err)
+
+	return seq
+}
+
+// TestReplayStart pins the cursor/include_existing → replay-start mapping.
+func TestReplayStart(t *testing.T) {
+	t.Parallel()
+
+	from, replay := replayStart(&walletdkrpc.SubscribeWalletRequest{
+		Cursor: 7,
+	})
+	require.True(t, replay, "a non-zero cursor replays")
+	require.Equal(t, int64(7), from)
+
+	from, replay = replayStart(&walletdkrpc.SubscribeWalletRequest{
+		IncludeExisting: true,
+	})
+	require.True(t, replay, "include_existing replays the full history")
+	require.Equal(t, int64(0), from)
+
+	from, replay = replayStart(&walletdkrpc.SubscribeWalletRequest{})
+	require.False(
+		t, replay, "no cursor and no include_existing is live-only",
+	)
+	require.Equal(t, int64(0), from)
+}
+
+// TestSubscribeReplaysFromCursor verifies the event-log replay: from cursor 0
+// it streams every transition oldest-first with ascending cursors, and from a
+// prior cursor it streams only what came after — the resume path.
+func TestSubscribeReplaysFromCursor(t *testing.T) {
+	t.Parallel()
+
+	svc, store, _ := newSubscribeFixture(t, 0)
+
+	// Three transitions: a new deposit, a new send, then the send settling.
+	s1 := projectTestEntry(
+		t, store, "dep", walletdkrpc.
+			EntryKind_ENTRY_KIND_DEPOSIT,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+	)
+	s2 := projectTestEntry(
+		t, store, "snd", walletdkrpc.
+			EntryKind_ENTRY_KIND_SEND,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+	)
+	s3 := projectTestEntry(
+		t, store, "snd", walletdkrpc.
+			EntryKind_ENTRY_KIND_SEND,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+	)
+
+	// Full replay from 0.
+	full := &fakeSubscribeStream{ctx: context.Background()}
+	last, err := svc.replayEvents(context.Background(), full, 0, nil)
+	require.NoError(t, err)
+	require.Equal(t, s3, last, "replay returns the highest cursor sent")
+
+	resp := full.responses()
+	require.Len(t, resp, 3)
+	require.Equal(t, s1, resp[0].GetCursor())
+	require.Equal(t, "dep", resp[0].GetEntry().GetId())
+	require.Equal(t, s3, resp[2].GetCursor())
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		resp[2].GetEntry().GetStatus(),
+	)
+
+	// Resume from s2: only the settling transition (s3) is new.
+	resume := &fakeSubscribeStream{ctx: context.Background()}
+	last, err = svc.replayEvents(context.Background(), resume, s2, nil)
+	require.NoError(t, err)
+	require.Equal(t, s3, last)
+
+	only := resume.responses()
+	require.Len(t, only, 1, "resume replays only events after the cursor")
+	require.Equal(t, s3, only[0].GetCursor())
+	require.Equal(t, "snd", only[0].GetEntry().GetId())
+}
+
+// TestSubscribeReplayHonorsKindFilter verifies the kind filter gates the
+// replayed events.
+func TestSubscribeReplayHonorsKindFilter(t *testing.T) {
+	t.Parallel()
+
+	svc, store, _ := newSubscribeFixture(t, 0)
+
+	projectTestEntry(
+		t, store, "dep", walletdkrpc.
+			EntryKind_ENTRY_KIND_DEPOSIT,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+	)
+	projectTestEntry(
+		t, store, "snd", walletdkrpc.
+			EntryKind_ENTRY_KIND_SEND,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+	)
+
+	filter, err := buildKindFilter([]walletdkrpc.EntryKind{
+		walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT,
+	})
+	require.NoError(t, err)
+
+	stream := &fakeSubscribeStream{ctx: context.Background()}
+	_, err = svc.replayEvents(context.Background(), stream, 0, filter)
+	require.NoError(t, err)
+
+	resp := stream.responses()
+	require.Len(t, resp, 1, "only the DEPOSIT event passes the filter")
+	require.Equal(
+		t, walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT,
+		resp[0].GetEntry().GetKind(),
+	)
+}
+
+// TestSubscribeStreamsLiveUpdate verifies a live transition after subscribe is
+// streamed with its event_seq as the cursor.
+func TestSubscribeStreamsLiveUpdate(t *testing.T) {
+	t.Parallel()
+
+	svc, _, runtime := newSubscribeFixture(t, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream := &fakeSubscribeStream{ctx: ctx}
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.SubscribeWallet(
+			&walletdkrpc.SubscribeWalletRequest{}, stream,
+		)
+	}()
+
+	// A live transition after subscribe must reach the stream.
+	runtime.projectAndEmit(context.Background(), &walletdkrpc.WalletEntry{
+		Id:            "live",
+		Kind:          walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+		Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		CreatedAtUnix: 100,
+		UpdatedAtUnix: 100,
+	})
+
+	require.Eventually(t, func() bool {
+		resp := stream.responses()
+
+		return len(resp) == 1 && resp[0].GetEntry().GetId() == "live"
+	}, time.Second, 10*time.Millisecond)
+
+	resp := stream.responses()
+	require.Positive(
+		t, resp[0].GetCursor(),
+		"a live update carries its event_seq as the cursor",
+	)
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+// TestSubscribeSignalsGapOnOverflow verifies that when a consumer falls behind
+// (its send buffer overflows), it receives a SubscribeGap carrying the resume
+// cursor rather than losing updates silently.
+func TestSubscribeSignalsGapOnOverflow(t *testing.T) {
+	t.Parallel()
+
+	// A one-slot buffer makes overflow deterministic.
+	svc, _, runtime := newSubscribeFixture(t, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream := &fakeSubscribeStream{
+		ctx:     ctx,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.SubscribeWallet(
+			&walletdkrpc.SubscribeWalletRequest{}, stream,
+		)
+	}()
+
+	emit := func(id string) {
+		runtime.projectAndEmit(context.Background(),
+			&walletdkrpc.WalletEntry{
+				Id:            id,
+				Kind:          walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+				Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+				CreatedAtUnix: 100,
+				UpdatedAtUnix: 100,
+			})
+	}
+
+	// First update: the live loop receives it and wedges inside Send.
+	emit("u1")
+	<-stream.entered
+
+	// While the loop is wedged, overflow the one-slot buffer: u2 buffers,
+	// u3/u4 cannot enqueue and flag the subscriber overflowed.
+	emit("u2")
+	emit("u3")
+	emit("u4")
+
+	// Release the wedged send; the loop then observes the overflow and
+	// signals a gap before continuing.
+	close(stream.release)
+
+	require.Eventually(t, func() bool {
+		for _, r := range stream.responses() {
+			if r.GetGap() != nil {
+				return true
+			}
+		}
+
+		return false
+	}, time.Second, 10*time.Millisecond, "overflow must yield a gap signal")
+
+	// The gap carries a resume cursor (the last entry cursor sent before
+	// it).
+	for _, r := range stream.responses() {
+		if r.GetGap() != nil {
+			require.Positive(
+				t, r.GetCursor(),
+				"gap advertises a resume cursor",
+			)
+		}
+	}
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}

--- a/swapwallet/subscribe_test.go
+++ b/swapwallet/subscribe_test.go
@@ -4,6 +4,7 @@ package swapwallet
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -345,4 +346,65 @@ func TestSubscribeSignalsGapOnOverflow(t *testing.T) {
 
 	cancel()
 	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+// TestProjectAndEmitConcurrentProducersMonotonic is the H-1 regression: many
+// producers projecting and emitting concurrently must reach a subscriber in
+// strictly ascending event_seq order with no drops. Without the project/emit
+// serialization a later-committed but lower seq could emit after a higher one,
+// and the live cursor would skip it silently.
+func TestProjectAndEmitConcurrentProducersMonotonic(t *testing.T) {
+	t.Parallel()
+
+	// A large buffer so nothing overflows: this exercises ordering, not the
+	// gap path.
+	_, _, runtime := newSubscribeFixture(t, 256)
+	sub := runtime.subscribe()
+	defer runtime.unsubscribe(sub)
+
+	const producers = 50
+	var wg sync.WaitGroup
+	for i := 0; i < producers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			runtime.projectAndEmit(context.Background(),
+				&walletdkrpc.WalletEntry{
+					Id: fmt.Sprintf("op-%d", i),
+					Kind: walletdkrpc.
+						EntryKind_ENTRY_KIND_EXIT,
+					Status: walletdkrpc.
+						EntryStatus_ENTRY_STATUS_PENDING,
+					CreatedAtUnix: 100,
+					UpdatedAtUnix: 100,
+				})
+		}(i)
+	}
+	wg.Wait()
+
+	// Every distinct projection must arrive exactly once, strictly
+	// ascending.
+	var last int64
+	seen := make(map[string]bool)
+	for i := 0; i < producers; i++ {
+		select {
+		case u := <-sub.ch:
+			require.Greater(
+				t, u.seq, last,
+				"emits must arrive in strictly ascending seq",
+			)
+			last = u.seq
+			require.False(
+				t, seen[u.entry.GetId()], "duplicate entry %q",
+				u.entry.GetId(),
+			)
+			seen[u.entry.GetId()] = true
+
+		case <-time.After(5 * time.Second):
+			t.Fatalf("received only %d of %d concurrent emits", i,
+				producers)
+		}
+	}
+	require.Len(t, seen, producers)
 }


### PR DESCRIPTION
## What

Implements **C4** of the canonical activity-log epic — lightninglabs/darepo-client#775 (EPIC lightninglabs/darepo-client#776): a resumable, gap-tolerant `SubscribeWallet` backed by C1's append-only `activity_events` log.

Today `SubscribeWallet` is **lossy** (a slow consumer's updates are dropped by a non-blocking `emit`) and **non-resumable** (`include_existing` re-snapshots on every connect; no cursor). This makes it resumable from a monotonic cursor and tells a consumer when it fell behind instead of dropping silently.

## Behaviour

- **Resumable:** the request carries a `cursor`; on (re)connect the daemon replays `activity_events` with `event_seq > cursor`, then streams live. Each `SubscribeWalletResponse` carries its `event_seq` as the cursor the client persists and reconnects with.
  - `cursor > 0` → replay after it; `cursor == 0 && include_existing` → full history; else live-only from the current tip.
- **Gap-tolerant, no silent drops:** a slow consumer that overflows its send buffer receives a `SubscribeGap` (carrying the resume cursor) telling it to reconcile via `List`, rather than losing updates. `event_seq` is monotonic-but-not-contiguous by design, so a client never infers a dropped event from a numbering gap.
- **Live coverage:** `ProjectEntry` now returns the appended `event_seq` so the emit path stamps live updates; the reconciler emits its re-projected transitions too, so a settled deposit/exit reaches a connected subscriber, not just the store.

## Wire change (breaking, cheap now)

`rpc SubscribeWallet` now returns `stream SubscribeWalletResponse { int64 cursor; oneof { WalletEntry entry; SubscribeGap gap } }` (was `stream WalletEntry`), plus a `cursor` field on the request. There are no deployed consumers yet (the TS SDK is still being built), so the break is free.

## Deferred

- **Ack / retention:** the event log stays append-only (no GC). The gap signal covers slow consumers now; a retention + `AckUpTo` policy is a follow-up (the gap arm is wired for it).
- **Integration test:** the swapdk-server resume/replay-on-reconnect + gap itest follows once this lands in a client commit that repo can pin.

## Tests

- `swapwallet/subscribe_test.go` (new): replay-from-cursor, resume-after-reconnect, kind filter, live streaming, and a deterministic gap-on-overflow.
- `db/activity_store_test.go`: `AppendActivityEvent` / `ProjectEntry` thread the `event_seq`.
- Existing swapwallet / db / restclient suites updated and green; `make lint-changed-local` clean.

## Commits

1. `walletdkrpc:` add the resumable protocol; regenerate stubs.
2. `db:` `AppendActivityEvent` returns `event_seq`; regenerate sqlc.
3. `multi:` back `SubscribeWallet` with the event log (store/interface/service/runtime/projector + REST client + walletdk SDK).
