### PR TITLE
swapwallet: keep pay activity live

### DIFF
--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -1044,7 +1044,24 @@ func (s *paySession) waitForClaimPreimage(ctx context.Context) error {
 
 		height, err := s.client.daemon.BlockHeight(ctx)
 		if err != nil {
-			return fmt.Errorf("get block height: %w", err)
+			s.client.log.DebugS(
+				ctx,
+				"Unable to query block height while waiting "+
+					"for in-swap claim",
+				slog.String("err", err.Error()),
+				btclog.Hex("hash", s.cfg.PaymentHash[:]),
+			)
+			if err := s.waitForNextPoll(ctx); err != nil {
+				if errors.Is(err, errSwapExpired) {
+					return s.initiateRefund(
+						ctx, "claim deadline elapsed",
+					)
+				}
+
+				return err
+			}
+
+			continue
 		}
 		if height >= s.cfg.VHTLCConfig.RefundLocktime {
 			return s.initiateRefund(
@@ -1136,7 +1153,15 @@ func (s *paySession) completeRefund(ctx context.Context) error {
 
 	height, err := s.client.daemon.BlockHeight(ctx)
 	if err != nil {
-		return fmt.Errorf("get block height: %w", err)
+		s.client.log.DebugS(
+			ctx,
+			"Unable to query block height while waiting for "+
+				"in-swap refund maturity",
+			slog.String("err", err.Error()),
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+		)
+
+		return waitForFixedPoll(ctx, s.client.waitPollInterval)
 	}
 	if height < s.cfg.VHTLCConfig.RefundLocktime {
 		wait := s.refundLocktimePollInterval(height)

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -1972,6 +1972,103 @@ func TestPaySessionCancelDoesNotPersistFailed(t *testing.T) {
 	require.NotEqual(t, PayStateNeedsIntervention, resumed.State())
 }
 
+// TestPaySessionClaimWaitBlockHeightErrorDoesNotPersistFailed asserts a
+// transient daemon read failure after vHTLC funding does not durably fail the
+// pay. The server may still settle Lightning and claim the vHTLC, so a later
+// resume must keep observing for the preimage.
+func TestPaySessionClaimWaitBlockHeightErrorDoesNotPersistFailed(
+	t *testing.T) {
+
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:  preimage.Hash(),
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
+			ServerPubkey: serverPriv.PubKey(),
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime:                       144,
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			Expiry: time.Now().Add(time.Minute),
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey:   clientPriv.PubKey(),
+		operatorKey:   operatorPriv.PubKey(),
+		blockHeight:   50,
+		sendSessionID: "funding-session",
+		sendOutpoint:  "funding:0",
+	}
+
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	client.waitPollInterval = time.Millisecond
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	err = session.runUntil(t.Context(), PayStateWaitingForClaim)
+	require.NoError(t, err)
+	require.Equal(t, PayStateWaitingForClaim, session.State())
+
+	daemonConn.blockHeightErr = errors.New("height unavailable")
+	waitCtx, cancel := context.WithTimeout(t.Context(), 5*time.Millisecond)
+	defer cancel()
+
+	_, err = session.Wait(waitCtx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, PayStateWaitingForClaim, session.State())
+
+	resumed, err := client.ResumePayViaLightning(
+		t.Context(), preimage.Hash(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, PayStateWaitingForClaim, resumed.State())
+
+	daemonConn.blockHeightErr = nil
+	daemonConn.spentVTXO = &VTXOInfo{
+		Outpoint:  "funding:0",
+		AmountSat: testInSwapAmountSat,
+		SpentByTxID: "0123456789abcdef0123456789abcdef" +
+			"0123456789abcdef0123456789abcdef",
+	}
+	daemonConn.indexedPackage = &OORPackageInfo{
+		CheckpointPSBTs: [][]byte{
+			testCheckpointPSBTWithPreimage(t, preimage[:]),
+		},
+	}
+
+	result, err := resumed.Wait(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, preimage.Hash(), result.PaymentHash)
+	require.Equal(t, preimage, result.Preimage)
+}
+
 // TestPaySessionUsesFundingResponseOutpointWhenIndexerRejectsLiveLookup
 // asserts the pay FSM can adopt its funded vHTLC from local OOR metadata
 // instead of depending on the remote pkScript indexer to reveal the outpoint.

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -1579,6 +1579,7 @@ type testDaemonConn struct {
 	identityKey       *btcec.PublicKey
 	operatorKey       *btcec.PublicKey
 	blockHeight       uint32
+	blockHeightErr    error
 	liveVTXOs         []VTXOInfo
 	spentVTXOs        []VTXOInfo
 	vhtlc             *VTXOInfo
@@ -1637,6 +1638,10 @@ type testDaemonConn struct {
 
 // BlockHeight returns the configured best block height.
 func (d *testDaemonConn) BlockHeight(context.Context) (uint32, error) {
+	if d.blockHeightErr != nil {
+		return 0, d.blockHeightErr
+	}
+
 	return d.blockHeight, nil
 }
 

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -216,6 +216,12 @@ func (r *router) sendInvoiceIntent(ctx context.Context,
 		walletdkrpc.EntryKind_ENTRY_KIND_SEND,
 	)
 
+	// Project the admitted pay immediately. SubscribeSwaps only publishes
+	// this row again after the daemon worker exits, so relying on the
+	// monitor alone can leave activity empty until the next startup
+	// backfill.
+	r.runtime.projectAndEmit(context.WithoutCancel(ctx), entry)
+
 	// For invoice sends actual_amount_sat is the swap's negotiated
 	// principal: that's what is being paid to the BOLT-11 destination
 	// (routing fees are tracked separately via fee_sat on the entry).

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -407,6 +407,53 @@ func TestRouterSendInvoiceDispatchesStartPay(t *testing.T) {
 	)
 }
 
+// TestRouterSendInvoiceProjectsActivityImmediately verifies direct Lightning
+// pays land in the canonical activity store as soon as StartPay accepts them.
+func TestRouterSendInvoiceProjectsActivityImmediately(t *testing.T) {
+	t.Parallel()
+
+	swap := &fakeSwapService{}
+	store := &fakeActivityProjector{}
+	deps := &Deps{
+		SwapBackend:   nil,
+		SwapService:   swap,
+		ActivityStore: store,
+		ChainParams:   &chaincfg.RegressionNetParams,
+	}
+	runtime := newRuntime(t.Context(), deps)
+	t.Cleanup(runtime.stop)
+
+	ch := runtime.subscribe()
+	t.Cleanup(func() { runtime.unsubscribe(ch) })
+
+	r := newRouter(deps, runtime)
+	swap.startPayResp = &swapclientrpc.StartPayResponse{
+		PaymentHash: "deadbeef",
+		Swap: &swapclientrpc.SwapSummary{
+			PaymentHash:   "deadbeef",
+			Direction:     swapclientrpc.SwapDirection_SWAP_DIRECTION_PAY,
+			State:         swapclientrpc.SwapState_SWAP_STATE_SWAP_CREATED,
+			Pending:       true,
+			AmountSat:     1001,
+			FeeSat:        1,
+			CreatedAtUnix: 100,
+			UpdatedAtUnix: 100,
+		},
+	}
+
+	resp, err := sendPreparedInvoice(t, r, "lnbc1example", 25)
+	require.NoError(t, err)
+	require.Equal(t, "deadbeef", resp.GetEntry().GetId())
+	require.Equal(t, 1, store.count())
+
+	emitted := recvEntry(t, ch)
+	require.Equal(t, "deadbeef", emitted.GetId())
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		emitted.GetStatus(),
+	)
+}
+
 // TestRouterSendInvoiceHandsCreditPayToRegistry asserts that a credit-backed
 // pay is handed off to the durable credit registry under a payment-hash-derived
 // idempotency key, rather than driving the top-up and pay inline. The router no


### PR DESCRIPTION
## Summary

Fixes #881.

This PR fixes two client-side edges that can make a direct Lightning pay confusing or misleading in wallet activity:

- Direct Lightning sends now project the admitted `StartPay` row into the canonical activity store immediately.
- Pay sessions that are already funded keep polling when a local block-height lookup fails instead of durably marking the pay `FAILED`.

## Root Cause

The direct send path returned the `StartPay` summary to the caller, but it did not write that row into the canonical activity store. The path implicitly relied on the swap monitor. The monitor sends existing rows when the daemon subscribes and publishes again when a background worker exits, so a newly admitted direct pay could be absent from `darepocli activity` until restart backfill derived it from the swap store.

Separately, after a pay-side vHTLC was funded and the client was waiting for the server claim/preimage, a `BlockHeight` read error was returned as an ordinary action error. The generic FSM failure handler can persist ordinary action errors as `PayStateFailed`. That is unsafe after funding, because the server may still settle Lightning and claim the vHTLC, and a terminal `FAILED` row will no longer resume to observe the eventual preimage.

## Changes

- Project and emit the direct-pay `WalletEntry` immediately after `StartPay` succeeds.
- Treat block-height lookup failures during claim waiting as a transient poll condition.
- Treat block-height lookup failures during refund-maturity waiting as a transient poll condition.
- Add a router regression proving direct pays land in activity immediately.
- Add a pay-session regression proving a post-funding height-read failure does not persist `FAILED`, and that a resumed session can still complete once the claim preimage is indexed.

## Validation

```bash
go test ./sdk/swaps
go test -tags 'walletdkrpc swapruntime' ./swapwallet
git diff --check
```

I could not fetch the log attachment from #881 because GitHub returns `404 Not Found` for the linked file, so the fix is based on the reported activity row plus the code path that can produce the described symptoms.