### PR TITLE
swapwallet+darepocli: fix Lightning send activity race (#883)

### DIFF
--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -224,6 +224,16 @@ func (r *router) sendInvoiceIntent(ctx context.Context,
 		actualAmountSat = int64(intent.amountSat)
 	}
 
+	// Project the pending SEND row synchronously so it is store-addressable
+	// the instant Send returns; an immediate read (List / inspect) must not
+	// race the swap monitor's first push. The monitor drives this same
+	// payment-hash-keyed row to its terminal, and projectAndEmit is
+	// idempotent on the canonical id, so that later push is a safe upsert.
+	// Project off the RPC context so a client disconnect cannot cancel the
+	// write of an already-accepted pay.
+	r.runtime.trackPendingEntryWithoutTimeout(entry)
+	r.runtime.projectAndEmit(context.WithoutCancel(ctx), entry)
+
 	return &walletdkrpc.SendResponse{
 		Entry:           entry,
 		ActualAmountSat: actualAmountSat,

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -407,6 +407,54 @@ func TestRouterSendInvoiceDispatchesStartPay(t *testing.T) {
 	)
 }
 
+// TestRouterSendInvoiceProjectsPendingRow asserts a pure-Lightning invoice send
+// projects its PENDING SEND row into the activity store synchronously, so an
+// immediate store-backed read (List / inspect) cannot race the swap monitor's
+// first push. The credit and on-chain send paths already project inline; this
+// covers the Lightning path.
+func TestRouterSendInvoiceProjectsPendingRow(t *testing.T) {
+	t.Parallel()
+
+	r, swap, _ := newRouterFixture(t)
+	store := &fakeActivityProjector{}
+	r.deps.ActivityStore = store
+
+	invoice, paymentHash := testPreparedInvoice(t, 500, "tiny")
+	swap.startPayResp = &swapclientrpc.StartPayResponse{
+		PaymentHash: paymentHash,
+		Swap: &swapclientrpc.SwapSummary{
+			PaymentHash: paymentHash,
+			Direction: swapclientrpc.
+				SwapDirection_SWAP_DIRECTION_PAY,
+			Pending: true,
+		},
+	}
+
+	resp, err := sendPreparedInvoice(t, r, invoice, 25)
+	require.NoError(t, err)
+	require.Equal(t, paymentHash, resp.GetEntry().GetId())
+	require.Equal(
+		t, walletdkrpc.EntryKind_ENTRY_KIND_SEND,
+		resp.GetEntry().GetKind(),
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		resp.GetEntry().GetStatus(),
+	)
+
+	// The pending row must be in the store the instant Send returns, keyed
+	// by the payment hash, so an immediate inspect finds it rather than
+	// racing the monitor's deferred projection.
+	require.Equal(
+		t, 1, store.count(),
+		"invoice send must project its pending row synchronously",
+	)
+	require.True(
+		t, store.ids()[paymentHash],
+		"pending row must be keyed by the payment hash",
+	)
+}
+
 // TestRouterSendInvoiceHandsCreditPayToRegistry asserts that a credit-backed
 // pay is handed off to the durable credit registry under a payment-hash-derived
 // idempotency key, rather than driving the top-up and pay inline. The router no


### PR DESCRIPTION
Fixes #883.

## Problem

`darepocli send --offchain <invoice>` prints the accepted PENDING SEND entry
and then immediately fails with
`NOT_FOUND: activity entry "<hash>" not found` — even though the payment is in
flight and settles moments later (`In-swap completed … "server claim observed"`
in the issue log, no restart).

## Root cause

`swapwallet/router.go` `sendInvoiceIntent` (the pure-Lightning send path) was
the *only* send path that did not synchronously project its pending row into
the canonical activity store — `sendCreditInvoiceIntent` and `sendOnchainIntent`
both call `trackPendingEntryWithoutTimeout` + `projectAndEmit`. The Lightning
path deferred projection to the swap monitor's first `SubscribeSwaps` push, so a
store-backed read fired immediately after `Send` (the CLI's `InspectActivity`
poll) raced it and missed the row.

## Fix

`sendInvoiceIntent` now projects the pending SEND row synchronously off the RPC
context, exactly like the credit/onchain paths. `projectAndEmit` is idempotent
on the canonical id, so the monitor's later terminal push is a safe upsert.

## Tests

`swapwallet`: `TestRouterSendInvoiceProjectsPendingRow` — asserts a Lightning
invoice send projects a PENDING SEND row into the store synchronously (fails
without the fix). Full `swapwallet` suite green; `lint-changed-local` clean.
End-to-end walletdk regression (verified PASS with the fix / FAIL without) in
lightninglabs/swapdk-server#208.

## Notes

- Reproduced on `main`; the reporter's build was `0.0.2-alpha` (a local
  btcwallet build).
- Related but **separate**: #881 (a settled payment shown as FAILED) is a client
  pay-FSM resume defect in `sdk/swaps`, not this projection race.
