### PR TITLE
swapwallet: project pending invoice send on dispatch

### DIFF
--- a/swapwallet/projector_test.go
+++ b/swapwallet/projector_test.go
@@ -83,6 +83,15 @@ func (f *fakeActivityProjector) PullEvents(_ context.Context, _ int64,
 	return nil, nil
 }
 
+// lastProjection returns the most recent projection the fake recorded. It
+// panics when nothing has been projected, so a caller must guard with count.
+func (f *fakeActivityProjector) lastProjection() db.ActivityProjection {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.projected[len(f.projected)-1]
+}
+
 // ids returns the set of canonical ids the fake has been asked to project.
 func (f *fakeActivityProjector) ids() map[string]bool {
 	f.mu.Lock()

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -216,6 +216,26 @@ func (r *router) sendInvoiceIntent(ctx context.Context,
 		walletdkrpc.EntryKind_ENTRY_KIND_SEND,
 	)
 
+	// Eagerly project the just-dispatched entry into the canonical activity
+	// store so it is inspectable the instant Send returns. The swap monitor
+	// stays the terminal authority and supersedes this row idempotently
+	// (keyed by payment hash) as the pay progresses, but its SubscribeSwaps
+	// projection is asynchronous: without this eager write a caller that
+	// polls InspectActivity to block on settlement — `da send` does exactly
+	// this by default — races the monitor and sees NOT_FOUND on the first
+	// poll, aborting the wait and surfacing a still-in-flight pay as merely
+	// pending. Projected off the RPC context so a client disconnect cannot
+	// cancel the write of an already-accepted pay. This mirrors the credit
+	// pay path, which projects its pending row for the same reason.
+	//
+	// We call project rather than projectAndEmit on purpose: this row is
+	// swap-backed, so the monitor loop owns the live SubscribeWallet emit
+	// for it. Emitting here too would fan the same pending row out twice.
+	// We only need the durable store write so pollers
+	// (InspectActivity/List) can see it immediately; the monitor's first
+	// update handles the live emit.
+	r.runtime.project(context.WithoutCancel(ctx), entry)
+
 	// For invoice sends actual_amount_sat is the swap's negotiated
 	// principal: that's what is being paid to the BOLT-11 destination
 	// (routing fees are tracked separately via fee_sat on the entry).

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -407,6 +407,51 @@ func TestRouterSendInvoiceDispatchesStartPay(t *testing.T) {
 	)
 }
 
+// TestRouterSendInvoiceProjectsPendingEntry asserts that dispatching a
+// pure-Lightning invoice eagerly projects the pending entry into the activity
+// store, keyed by its payment hash, before Send returns. Without this the swap
+// monitor's asynchronous SubscribeSwaps projection is the only writer, so a
+// caller that polls InspectActivity to block on settlement (the default `da
+// send` behavior) races the monitor and sees NOT_FOUND on the first poll,
+// aborting the wait and reporting a still-in-flight pay as merely pending.
+func TestRouterSendInvoiceProjectsPendingEntry(t *testing.T) {
+	t.Parallel()
+
+	r, swap, _ := newRouterFixture(t)
+	store := &fakeActivityProjector{}
+	r.deps.ActivityStore = store
+	swap.startPayResp = &swapclientrpc.StartPayResponse{
+		PaymentHash: "deadbeef",
+		Swap: &swapclientrpc.SwapSummary{
+			PaymentHash: "deadbeef",
+			Direction: swapclientrpc.
+				SwapDirection_SWAP_DIRECTION_PAY,
+			Pending: true,
+		},
+	}
+
+	resp, err := sendPreparedInvoice(t, r, "lnbc1example", 0)
+	require.NoError(t, err)
+	require.Equal(t, "deadbeef", resp.GetEntry().GetId())
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		resp.GetEntry().GetStatus(),
+	)
+
+	// The dispatched pay must be durable and inspectable the instant Send
+	// returns, so the wait loop can poll it through to a terminal state.
+	require.Equal(t, 1, store.count())
+	require.True(
+		t, store.ids()["deadbeef"],
+		"pending pay must be projected by payment hash on dispatch",
+	)
+	require.Equal(
+		t, int64(walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING),
+		store.lastProjection().Status,
+		"eagerly projected row must be PENDING",
+	)
+}
+
 // TestRouterSendInvoiceHandsCreditPayToRegistry asserts that a credit-backed
 // pay is handed off to the durable credit registry under a payment-hash-derived
 // idempotency key, rather than driving the top-up and pay inline. The router no


### PR DESCRIPTION
In this PR, we fix `da send` so it actually blocks until settlement for a
pure-Lightning or in-Ark pay, instead of returning right away as PENDING.

By default `send` waits: once the daemon accepts the pay, the CLI polls
`InspectActivity` on the entry's payment hash until the row reaches a terminal
state (that's what "block until the recipient pulls it" means for an in-Ark
send). In practice the wait aborted on the very first poll with `activity entry
"<hash>" not found`, and the send surfaced as merely pending:

```
{
  "status": "PENDING",
  "kind": "SEND",
  ...
  "id": "7f8ca5204b5c6edc335087a4f8c8caf4e8d60b25b0716a07964465f8fa885b31"
}
{
  "error": {
    "code": "NOT_FOUND",
    "message": "activity entry \"7f8ca5204b5c6edc335087a4f8c8caf4e8d60b25b0716a07964465f8fa885b31\" not found"
  }
}
```

## Root cause

It's a write-path asymmetry in `swapwallet`. `router.sendInvoiceIntent` returned
an entry keyed by the payment hash straight off `StartPay`, but never wrote that
row to the canonical activity store. The store is populated only by the swap
monitor's `SubscribeSwaps` stream, which is asynchronous, so the CLI raced the
monitor and inspected an id that didn't exist yet. The first poll 404s, the wait
treats that as a hard failure, and we fall back to the pending receipt.

The credit pay path (`sendCreditInvoiceIntent`) already sidesteps this by
projecting its pending row on dispatch. The plain invoice path just didn't, so
the two send rails behaved differently for no good reason.

## The fix

In this commit, we project the just-dispatched entry into the activity store
before `Send` returns, so the id the caller is handed is inspectable the instant
it lands. The swap monitor stays the terminal authority and supersedes the row
idempotently (keyed by payment hash) as the pay progresses to COMPLETE or
FAILED. We project off the RPC context (`context.WithoutCancel`) so a client
disconnect can't cancel the write of an already-accepted pay, matching what the
credit path does.

Net effect: the wait now polls PENDING through to a terminal state, i.e. `da
send` blocks until the payment is pulled, rather than 404-ing on the first tick.

## Testing

New unit test `TestRouterSendInvoiceProjectsPendingEntry` asserts that
dispatching an invoice eagerly projects a PENDING row keyed by the payment hash
before `Send` returns. The full `swapwallet` suite, `make lint-changed-local`
(0 issues), and `make commitmsg-lint` all pass.

This is a daemon-side fix; the `darepocli` binary is unchanged. A running
instance needs a rebuild (`make install-walletdkrpc`) and restart to pick it up.
