### PR TITLE
unroll: include recovery-tx weight in the exit CPFP fee estimate

### DIFF
--- a/darepod/rpc_exit_plan.go
+++ b/darepod/rpc_exit_plan.go
@@ -218,8 +218,9 @@ func (r *RPCServer) exitPlanEntry(ctx context.Context, raw string,
 		return entry, verdict
 	}
 
+	mat := r.resolveExitLineage(ctx, outpoint, desc)
 	plan := unroll.PlanExitFunding(
-		desc, btcutil.Amount(feeRate), walletSnapshot,
+		desc, mat, btcutil.Amount(feeRate), walletSnapshot,
 	)
 	verdict = plan.Feasibility
 	if verdict.RequiredWalletInputs == 0 {

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -4631,8 +4631,9 @@ func (r *RPCServer) preflightUnrollFeasibility(ctx context.Context,
 		return status.Errorf(codes.Internal, "preflight wallet "+
 			"unspent: %v", err)
 	}
+	mat := r.resolveExitLineage(ctx, desc.Outpoint, desc)
 	plan := unroll.PlanExitFunding(
-		desc, r.estimateUnrollFeeRate(ctx), walletSnapshot,
+		desc, mat, r.estimateUnrollFeeRate(ctx), walletSnapshot,
 	)
 	verdict := plan.Feasibility
 	if verdict.Feasible {
@@ -4640,6 +4641,41 @@ func (r *RPCServer) preflightUnrollFeasibility(ctx context.Context,
 	}
 
 	return unrollInfeasibleError(verdict)
+}
+
+// resolveExitLineage resolves the OOR lineage material for an exit target so
+// the funding estimate can size the checkpoint/ark transactions of each OOR hop
+// exactly. It returns nil for a round-direct VTXO (ChainDepth == 0), where
+// there are no OOR transactions and the descriptor's extracted tree paths
+// already size the recovery cost exactly, and nil on any resolution failure, so
+// a missing or partial artifact store degrades to the descriptor-only
+// ChainDepth estimate rather than blocking the exit.
+func (r *RPCServer) resolveExitLineage(ctx context.Context,
+	target wire.OutPoint, desc *vtxo.Descriptor) *unroll.LineageMaterial {
+
+	if desc == nil || desc.ChainDepth == 0 {
+		return nil
+	}
+
+	resolver := &unroll.DescriptorLineageResolver{
+		VTXOStore:     r.server.vtxoStore,
+		ArtifactStore: r.newLocalOORArtifactStore(),
+	}
+
+	mat, err := resolver.ResolveLineage(ctx, target)
+	if err != nil {
+		// The exact OOR sizing is a refinement, not a gate: fall back
+		// to the ChainDepth approximation so a resolution hiccup can
+		// never make an otherwise-viable exit look infeasible.
+		r.server.log.DebugS(ctx, "Exit-plan lineage resolve failed; "+
+			"falling back to ChainDepth funding estimate",
+			slog.String("target", target.String()),
+			btclog.Fmt("err", "%v", err))
+
+		return nil
+	}
+
+	return mat
 }
 
 // estimateUnrollFeeRate returns the current fee rate (sat/vByte) for the

--- a/unroll/exit_plan.go
+++ b/unroll/exit_plan.go
@@ -39,10 +39,16 @@ type ExitFundingPlan struct {
 
 // PlanExitFunding computes the backing-wallet funding plan for a unilateral
 // exit using the same recovery counts and economic model as unroll admission.
-func PlanExitFunding(desc *vtxo.Descriptor, feeRate btcutil.Amount,
-	wallet ExitFundingSnapshot) ExitFundingPlan {
+//
+// mat is the resolved lineage material for the target and may be nil. When
+// supplied it lets the estimate size the OOR checkpoint/ark transactions
+// exactly; when nil the OOR chain is approximated from the descriptor's
+// ChainDepth scalar, so a caller that cannot (or need not) resolve artifacts
+// still gets a sound descriptor-only plan.
+func PlanExitFunding(desc *vtxo.Descriptor, mat *LineageMaterial,
+	feeRate btcutil.Amount, wallet ExitFundingSnapshot) ExitFundingPlan {
 
-	numTxs, numPaths := RecoveryTxCount(desc)
+	numTxs, numPaths, vbytes := recoveryEstimate(desc, mat)
 	var amount btcutil.Amount
 	if desc != nil {
 		amount = desc.Amount
@@ -50,6 +56,7 @@ func PlanExitFunding(desc *vtxo.Descriptor, feeRate btcutil.Amount,
 
 	feasibility := AssessExitFeasibility(ExitFeasibilityInput{
 		NumRecoveryTxs:     numTxs,
+		RecoveryTxVBytes:   vbytes,
 		NumAncestryPaths:   numPaths,
 		VTXOAmountSat:      amount,
 		FeeRateSatPerVByte: feeRate,

--- a/unroll/exit_plan_test.go
+++ b/unroll/exit_plan_test.go
@@ -39,7 +39,7 @@ func TestPlanExitFundingShortfallCoversMissingInputs(t *testing.T) {
 	t.Parallel()
 
 	plan := PlanExitFunding(
-		testExitPlanDescriptor(1_000_000, 2), 1,
+		testExitPlanDescriptor(1_000_000, 2), nil, 1,
 		ExitFundingSnapshot{
 			WalletConfirmedSat: 100_000,
 			WalletUsableInputs: 1,
@@ -57,7 +57,7 @@ func TestPlanExitFundingShortfallCoversBalance(t *testing.T) {
 	t.Parallel()
 
 	plan := PlanExitFunding(
-		testExitPlanDescriptor(1_000_000, 2), 1,
+		testExitPlanDescriptor(1_000_000, 2), nil, 1,
 		ExitFundingSnapshot{
 			WalletConfirmedSat: 100,
 			WalletUsableInputs: 2,
@@ -66,7 +66,13 @@ func TestPlanExitFundingShortfallCoversBalance(t *testing.T) {
 
 	require.False(t, plan.Feasibility.Feasible)
 	require.Equal(t, ExitWalletUnderfunded, plan.Feasibility.Reason)
-	require.EqualValues(t, 210, plan.FundingShortfallSat)
+
+	// Two recovery txs at 1 sat/vB. The CPFP budget covers both the
+	// children (2 * 155) and the zero-fee recovery txs themselves, which
+	// have no extracted path here so they fall back to
+	// defaultRecoveryTxVBytes (2 * 200): total 710 sat. Minus the 100 sat
+	// confirmed balance, the shortfall is 610.
+	require.EqualValues(t, 610, plan.FundingShortfallSat)
 }
 
 // TestExitFundingAddressBookReusesCachedAddress verifies polling a plan for

--- a/unroll/feasibility.go
+++ b/unroll/feasibility.go
@@ -4,7 +4,12 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/lightninglabs/darepo-client/lib/recovery"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightninglabs/darepo-client/txconfirm"
 	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/lightningnetwork/lnd/input"
 )
 
 // A unilateral exit is the trust-minimized escape hatch a client uses to
@@ -38,6 +43,16 @@ const (
 	// one P2TR change output. Taproot is the dominant path and 155 vB
 	// gives comfortable headroom over the exact size.
 	defaultCPFPChildVBytes int64 = 155
+
+	// defaultRecoveryTxVBytes is the fallback virtual size charged for a
+	// single recovery (branch / checkpoint) transaction when its actual
+	// size can't be measured — a pruned ancestry fragment that persisted
+	// only a depth, or an OOR checkpoint hop. When the extracted tree
+	// path is present we sum the real per-node sizes instead (see
+	// RecoveryTxVBytes), which is exact across any tree radix. The
+	// constant is deliberately generous so the fallback does not
+	// under-fund an exit.
+	defaultRecoveryTxVBytes int64 = 200
 
 	// defaultSweepOutputDustSat is the floor the swept output must clear
 	// for the sweep transaction to relay. 330 sat is the standard
@@ -179,6 +194,13 @@ type ExitFeasibilityInput struct {
 	// broadcast (and CPFP-bumped) to materialize the target output.
 	NumRecoveryTxs int
 
+	// RecoveryTxVBytes is the summed virtual size of those recovery
+	// transactions themselves. Each recovery tx is zero-fee, so its CPFP
+	// child pays the ancestor-package fee over parent+child weight; the
+	// wallet-funded cost therefore includes these parent vBytes, not just
+	// the children. Resolve it with RecoveryTxVBytes(desc).
+	RecoveryTxVBytes int64
+
 	// NumAncestryPaths is the number of independent commitment-tree
 	// roots in the VTXO's ancestry — one concurrent CPFP parent each.
 	NumAncestryPaths int
@@ -266,9 +288,17 @@ func AssessExitFeasibility(in ExitFeasibilityInput) ExitFeasibility {
 	sweepFee := btcutil.Amount(
 		int64(in.FeeRateSatPerVByte) * cfg.SweepVBytes,
 	)
+
+	// The wallet funds, per recovery tx, a CPFP child AND the ancestor
+	// package fee for the zero-fee recovery tx itself. So the CPFP budget
+	// is the fee over (sum of child vBytes) + (sum of recovery-tx vBytes),
+	// matching the ancestor-aware package fee the txconfirm broadcaster
+	// actually pays. Omitting RecoveryTxVBytes here (the old behavior)
+	// under-counted the exit cost and under-recommended funding.
+	cpfpVBytes := cfg.CPFPChildVBytes*int64(in.NumRecoveryTxs) +
+		in.RecoveryTxVBytes
 	cpfpTotal := btcutil.Amount(
-		int64(in.FeeRateSatPerVByte) * cfg.CPFPChildVBytes *
-			int64(in.NumRecoveryTxs),
+		int64(in.FeeRateSatPerVByte) * cpfpVBytes,
 	)
 	totalCost := cpfpTotal + sweepFee
 	net := in.VTXOAmountSat - sweepFee
@@ -343,39 +373,185 @@ func AssessExitFeasibility(in ExitFeasibilityInput) ExitFeasibility {
 // contributes its tree-path transactions; OOR VTXOs add one checkpoint
 // transaction per hop in the OOR chain (ChainDepth). A nil descriptor
 // yields (0, 0).
+//
+// This is the descriptor-only estimate: it approximates the OOR chain from
+// the ChainDepth scalar. Pass resolved lineage material to recoveryEstimate
+// (via PlanExitFunding) to size the OOR checkpoint/ark transactions exactly.
 func RecoveryTxCount(desc *vtxo.Descriptor) (int, int) {
+	numTxs, numPaths, _ := recoveryEstimate(desc, nil)
+
+	return numTxs, numPaths
+}
+
+// RecoveryTxVBytes estimates the summed virtual size of every recovery
+// transaction that must be broadcast to materialize the target output. It is
+// the parent-weight companion to RecoveryTxCount: the CPFP child that drives
+// each zero-fee recovery tx on chain pays the ancestor-package fee over
+// parent+child, so the exit's wallet-funded cost depends on these sizes.
+//
+// For a fragment that still carries its extracted tree path we sum the actual
+// per-node transaction size, which is exact for any tree radix (a wider branch
+// simply has more child outputs). For a pruned fragment (depth only) or an OOR
+// checkpoint hop, where the real transactions aren't on hand, we fall back to
+// defaultRecoveryTxVBytes per transaction. A nil descriptor yields 0.
+//
+// This is the descriptor-only estimate; see recoveryEstimate for the
+// material-aware path that sizes OOR transactions exactly.
+func RecoveryTxVBytes(desc *vtxo.Descriptor) int64 {
+	_, _, vbytes := recoveryEstimate(desc, nil)
+
+	return vbytes
+}
+
+// recoveryEstimate derives, in one pass, the three quantities the exit-cost
+// model needs from a VTXO's lineage: the recovery-transaction count (one CPFP
+// child each), the number of independent commitment-tree roots (one concurrent
+// CPFP parent each), and the summed virtual size of the recovery transactions
+// themselves (the zero-fee parents the CPFP children must pay for at ancestor
+// feerate). Computing all three together guarantees the count and the vBytes
+// stay in lockstep — a fragment that contributes a tx to the count always
+// contributes a parent size, and vice versa.
+//
+// The commitment-tree ancestry is always sized from the descriptor's extracted
+// paths, which is exact for any radix. The OOR chain is sized from the resolved
+// lineage material when it is supplied (each finalized checkpoint/ark tx
+// measured directly), and otherwise falls back to the ChainDepth scalar at the
+// default per-tx size. A nil descriptor yields (0, 0, 0).
+func recoveryEstimate(desc *vtxo.Descriptor, mat *LineageMaterial) (int, int,
+	int64) {
+
 	if desc == nil {
-		return 0, 0
+		return 0, 0, 0
 	}
 
-	var numTxs, numPaths int
+	var (
+		numTxs   int
+		numPaths int
+		vbytes   int64
+	)
 	for _, a := range desc.Ancestry {
 		numPaths++
 
 		pathTxs := 0
+		var pathVBytes int64
 		switch {
-		case a.TreePath != nil:
+		// Require a non-nil Root, not just a non-nil TreePath:
+		// Tree.NumTx dereferences Root without a guard, so a
+		// TreePath with a nil Root would panic here. Falling through
+		// to the depth or malformed-floor arms instead keeps the
+		// count and the parent weight in lockstep and preserves the
+		// "degrade, never block the exit" contract.
+		case a.TreePath != nil && a.TreePath.Root != nil:
 			pathTxs = a.TreePath.NumTx()
+			pathVBytes = treePathVBytes(a.TreePath)
 
 		case a.TreeDepth > 0:
 			// Tree pruned but depth persisted: use it as a rough
 			// lower bound on the transactions in this fragment.
 			pathTxs = int(a.TreeDepth)
+			pathVBytes = int64(a.TreeDepth) *
+				defaultRecoveryTxVBytes
 		}
 
 		// An ancestry path that exists always has at least one
-		// commitment transaction. Floor at 1 so a malformed fragment
-		// (nil TreePath and zero TreeDepth) still contributes to the
-		// CPFP-fee estimate rather than silently costing nothing,
-		// which would let a wallet-underfunded exit slip through.
+		// commitment transaction. Floor both the count and the parent
+		// weight so a malformed fragment (nil TreePath and zero
+		// TreeDepth) still budgets a CPFP child AND its parent, rather
+		// than silently costing nothing and letting a
+		// wallet-underfunded exit slip through.
 		if pathTxs < 1 {
 			pathTxs = 1
 		}
+		if pathVBytes == 0 {
+			pathVBytes = defaultRecoveryTxVBytes
+		}
 
 		numTxs += pathTxs
+		vbytes += pathVBytes
 	}
 
-	numTxs += desc.ChainDepth
+	oorTxs, oorVBytes := oorRecovery(desc, mat)
+	numTxs += oorTxs
+	vbytes += oorVBytes
 
-	return numTxs, numPaths
+	return numTxs, numPaths, vbytes
+}
+
+// oorRecovery returns the (txCount, vBytes) the OOR checkpoint chain adds to
+// the recovery estimate. When resolved lineage material carrying the finalized
+// checkpoint/ark transactions is supplied it counts and sizes each one exactly
+// — a single OOR hop can carry several checkpoint PSBTs plus one ark tx, which
+// the ChainDepth scalar alone cannot capture. Without material it falls back to
+// one default-sized transaction per ChainDepth hop, matching RecoveryTxCount's
+// long-standing approximation.
+func oorRecovery(desc *vtxo.Descriptor, mat *LineageMaterial) (int, int64) {
+	if mat != nil && len(mat.ExtraNodes) > 0 {
+		var vbytes int64
+		for _, n := range mat.ExtraNodes {
+			vbytes += extraNodeVBytes(n)
+		}
+
+		return len(mat.ExtraNodes), vbytes
+	}
+
+	return desc.ChainDepth, int64(desc.ChainDepth) * defaultRecoveryTxVBytes
+}
+
+// extraNodeVBytes measures the virtual size of a finalized OOR recovery
+// transaction (a checkpoint or ark tx). These carry real witnesses, so unlike
+// the modeled tree nodes we size them directly with the same weight estimator
+// the txconfirm broadcaster uses, keeping the funding recommendation aligned
+// with the fee the broadcaster actually pays. A nil node or tx falls back to
+// the default per-tx size so it still contributes a conservative parent weight.
+func extraNodeVBytes(n *recovery.Node) int64 {
+	if n == nil || n.Tx == nil {
+		return defaultRecoveryTxVBytes
+	}
+
+	return (txconfirm.EstimateWeight(n.Tx) + 3) / 4
+}
+
+// treePathVBytes sums the estimated transaction size of every node on an
+// extracted ancestry tree path.
+func treePathVBytes(t *tree.Tree) int64 {
+	if t == nil || t.Root == nil {
+		return 0
+	}
+
+	var total int64
+	_ = t.Root.ForEach(func(n *tree.Node) error {
+		total += nodeTxVBytes(n)
+
+		return nil
+	})
+
+	return total
+}
+
+// nodeTxVBytes estimates the virtual size of the transaction a tree node
+// represents: a single pre-signed MuSig2 key-spend input plus the node's own
+// outputs (its child outputs and P2A anchor for a branch, or the VTXO output
+// and anchor for a leaf). Extraction preserves each node's full output set, so
+// this matches the transaction the broadcaster fee-bumps, radix and all.
+func nodeTxVBytes(n *tree.Node) int64 {
+	// ForEach can hand us a nil node if the tree carries a nil child, and
+	// a node's Outputs slice can hold nil entries; guard both so a
+	// well-formed-but-empty node can't panic the estimate. (A nil entry
+	// in a node's Children map would still panic inside ForEach itself, on
+	// the nil-receiver traversal — but built and deserialized trees never
+	// carry nil children, so that path is unreachable in practice.)
+	if n == nil {
+		return 0
+	}
+
+	var est input.TxWeightEstimator
+	est.AddTaprootKeySpendInput(txscript.SigHashDefault)
+	for _, out := range n.Outputs {
+		if out == nil {
+			continue
+		}
+		est.AddTxOutput(out)
+	}
+
+	return int64(est.Weight().ToVB())
 }

--- a/unroll/feasibility_test.go
+++ b/unroll/feasibility_test.go
@@ -5,11 +5,25 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/darepo-client/lib/recovery"
 	"github.com/lightninglabs/darepo-client/lib/tree"
 	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/txconfirm"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/stretchr/testify/require"
 )
+
+// p2trTestOut returns a wire output with a P2TR-sized (34-byte) pkScript, for
+// sizing recovery-tx estimates in tests.
+func p2trTestOut() *wire.TxOut {
+	return wire.NewTxOut(1000, make([]byte, 34))
+}
+
+// anchorTestOut returns a wire output with a P2A-sized (4-byte) pkScript.
+func anchorTestOut() *wire.TxOut {
+	return wire.NewTxOut(0, make([]byte, 4))
+}
 
 // TestAssessExitFeasibility exercises the pure economic model across the
 // feasible path and every infeasibility reason, asserting both the
@@ -325,4 +339,294 @@ func TestRecoveryTxCount(t *testing.T) {
 		require.Equal(t, 1, numPaths)
 		require.Equal(t, 1, numTxs)
 	})
+}
+
+// TestRecoveryTxVBytes verifies the parent-weight estimate that the exit
+// funding model now folds into the CPFP budget: the fallback per-tx constant
+// for pruned fragments and OOR checkpoints, and the exact per-node sum for a
+// real extracted tree path (including its radix sensitivity).
+func TestRecoveryTxVBytes(t *testing.T) {
+	t.Parallel()
+
+	// A nil descriptor costs nothing.
+	require.Zero(t, RecoveryTxVBytes(nil))
+
+	// A pruned fragment (depth persisted, no path) falls back to the
+	// per-tx constant, once per level.
+	pruned := &vtxo.Descriptor{
+		Ancestry: []types.Ancestry{
+			{
+				TreeDepth: 3,
+			},
+		},
+	}
+	require.Equal(
+		t, 3*defaultRecoveryTxVBytes, RecoveryTxVBytes(pruned),
+	)
+
+	// A fragment with neither path nor depth still floors at one tx, so
+	// a malformed fragment never silently costs nothing.
+	bare := &vtxo.Descriptor{
+		Ancestry: []types.Ancestry{
+			{
+				CommitmentTxID: chainhash.Hash{
+					1,
+				},
+			},
+		},
+	}
+	require.Equal(t, defaultRecoveryTxVBytes, RecoveryTxVBytes(bare))
+
+	// Each OOR checkpoint hop is one more fallback-sized recovery tx.
+	chain := &vtxo.Descriptor{ChainDepth: 2}
+	require.Equal(
+		t, 2*defaultRecoveryTxVBytes, RecoveryTxVBytes(chain),
+	)
+
+	// A real extracted path sums the actual per-node tx sizes: a root
+	// branch funding three children plus a leaf, each carrying an anchor.
+	leaf := &tree.Node{
+		Outputs: []*wire.TxOut{
+			p2trTestOut(),
+			anchorTestOut(),
+		},
+	}
+	root := &tree.Node{
+		Outputs: []*wire.TxOut{
+			p2trTestOut(), p2trTestOut(), p2trTestOut(),
+			anchorTestOut(),
+		},
+		Children: map[uint32]*tree.Node{
+			0: leaf,
+		},
+	}
+	realPath := &vtxo.Descriptor{
+		Ancestry: []types.Ancestry{
+			{
+				TreePath: &tree.Tree{
+					Root: root,
+				},
+			},
+		},
+	}
+	want := nodeTxVBytes(root) + nodeTxVBytes(leaf)
+	require.Equal(t, want, RecoveryTxVBytes(realPath))
+	require.Greater(t, want, int64(0))
+
+	// Radix sensitivity: a wider branch (more child outputs) is a larger
+	// recovery tx, so it must cost strictly more than a narrow one.
+	narrow := &tree.Node{
+		Outputs: []*wire.TxOut{
+			p2trTestOut(), p2trTestOut(), anchorTestOut(),
+		},
+	}
+	wide := &tree.Node{Outputs: []*wire.TxOut{anchorTestOut()}}
+	for i := 0; i < 8; i++ {
+		wide.Outputs = append(wide.Outputs, p2trTestOut())
+	}
+	require.Greater(t, nodeTxVBytes(wide), nodeTxVBytes(narrow))
+}
+
+// testRecoveryTx builds a finalized-shape recovery transaction with the given
+// number of P2TR outputs plus an anchor, for sizing OOR extra-node estimates.
+func testRecoveryTx(numOut int) *wire.MsgTx {
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{})
+	for i := 0; i < numOut; i++ {
+		tx.AddTxOut(p2trTestOut())
+	}
+	tx.AddTxOut(anchorTestOut())
+
+	return tx
+}
+
+// TestRecoveryEstimateMaterialSizesOOR verifies that when resolved lineage
+// material is supplied, the OOR chain is counted and sized from the actual
+// checkpoint/ark transactions rather than the ChainDepth scalar — so a single
+// hop that carries multiple checkpoint PSBTs is no longer undercounted.
+func TestRecoveryEstimateMaterialSizesOOR(t *testing.T) {
+	t.Parallel()
+
+	// A two-hop OOR VTXO whose descriptor only records ChainDepth == 2.
+	desc := &vtxo.Descriptor{
+		Outpoint: wire.OutPoint{
+			Index: 1,
+		},
+		ChainDepth: 2,
+	}
+
+	// Descriptor-only: two hops at the fallback size, and two recovery txs.
+	numTxs, _, vbytes := recoveryEstimate(desc, nil)
+	require.Equal(t, 2, numTxs)
+	require.Equal(t, 2*defaultRecoveryTxVBytes, vbytes)
+
+	// The real hops: the first hop spent a multi-input source, so it
+	// carries two checkpoint PSBTs plus its ark tx; the second hop a single
+	// checkpoint plus its ark tx. That is four checkpoints/arks, not two.
+	mat := &LineageMaterial{
+		TargetOutpoint: desc.Outpoint,
+		ExtraNodes: []*recovery.Node{
+			{
+				Kind: recovery.NodeKindCheckpoint,
+				Tx:   testRecoveryTx(1),
+			},
+			{
+				Kind: recovery.NodeKindCheckpoint,
+				Tx:   testRecoveryTx(1),
+			},
+			{
+				Kind: recovery.NodeKindArk,
+				Tx:   testRecoveryTx(1),
+			},
+			{
+				Kind: recovery.NodeKindArk,
+				Tx:   testRecoveryTx(2),
+			},
+		},
+	}
+
+	var wantVBytes int64
+	for _, n := range mat.ExtraNodes {
+		wantVBytes += extraNodeVBytes(n)
+	}
+
+	matTxs, _, matVBytes := recoveryEstimate(desc, mat)
+
+	// The material path counts every checkpoint/ark tx and sizes each
+	// exactly, so it exceeds the ChainDepth approximation on both axes.
+	require.Equal(t, len(mat.ExtraNodes), matTxs)
+	require.Greater(t, matTxs, numTxs)
+	require.Equal(t, wantVBytes, matVBytes)
+	require.Greater(t, matVBytes, vbytes)
+
+	// extraNodeVBytes measures a real tx, and a nil node or tx falls back
+	// to the conservative default rather than costing nothing.
+	require.Greater(t, extraNodeVBytes(mat.ExtraNodes[0]), int64(0))
+	require.Equal(t, defaultRecoveryTxVBytes, extraNodeVBytes(nil))
+	require.Equal(
+		t, defaultRecoveryTxVBytes,
+		extraNodeVBytes(
+			&recovery.Node{},
+		),
+	)
+}
+
+// TestExtraNodeVBytesMatchesBroadcaster locks the OOR parent-sizing to the
+// exact primitive the txconfirm broadcaster uses to compute the ancestor
+// package fee. computePackageFee sizes a parent as (EstimateWeight(tx)+3)/4;
+// if extraNodeVBytes ever drifts from that, the up-front funding
+// recommendation would stop matching what the broadcaster actually pays, so
+// this test fails the moment either side changes.
+func TestExtraNodeVBytesMatchesBroadcaster(t *testing.T) {
+	t.Parallel()
+
+	for _, numOut := range []int{1, 2, 4, 8} {
+		tx := testRecoveryTx(numOut)
+		node := &recovery.Node{
+			Kind: recovery.NodeKindCheckpoint,
+			Tx:   tx,
+		}
+
+		want := (txconfirm.EstimateWeight(tx) + 3) / 4
+		require.Equal(t, want, extraNodeVBytes(node))
+	}
+}
+
+// TestRecoveryEstimateNilRootFallsThrough verifies that a descriptor whose
+// TreePath is non-nil but carries a nil Root degrades to the malformed-tx
+// floor instead of panicking in Tree.NumTx, preserving the "estimate always
+// degrades, never blocks the exit" contract.
+func TestRecoveryEstimateNilRootFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	desc := &vtxo.Descriptor{
+		Ancestry: []types.Ancestry{
+			{
+				TreePath: &tree.Tree{
+					Root: nil,
+				},
+			},
+		},
+	}
+
+	var (
+		numTxs   int
+		numPaths int
+		vbytes   int64
+	)
+	require.NotPanics(t, func() {
+		numTxs, numPaths, vbytes = recoveryEstimate(desc, nil)
+	})
+
+	// The fragment still counts as one recovery tx and one path, sized at
+	// the fallback — count and vBytes stay in lockstep.
+	require.Equal(t, 1, numTxs)
+	require.Equal(t, 1, numPaths)
+	require.Equal(t, defaultRecoveryTxVBytes, vbytes)
+}
+
+// TestRecoveryEstimateMixedTreeAndOOR covers the realistic OOR-on-round case:
+// a descriptor with a real commitment-tree ancestry path plus resolved OOR
+// checkpoint/ark material. Both contributions must be summed, on both the
+// count and the vBytes axes.
+func TestRecoveryEstimateMixedTreeAndOOR(t *testing.T) {
+	t.Parallel()
+
+	leaf := &tree.Node{
+		Outputs: []*wire.TxOut{
+			p2trTestOut(),
+			anchorTestOut(),
+		},
+	}
+	root := &tree.Node{
+		Outputs: []*wire.TxOut{
+			p2trTestOut(), p2trTestOut(), anchorTestOut(),
+		},
+		Children: map[uint32]*tree.Node{
+			0: leaf,
+		},
+	}
+	treePath := &tree.Tree{Root: root}
+
+	desc := &vtxo.Descriptor{
+		Outpoint: wire.OutPoint{
+			Index: 1,
+		},
+		ChainDepth: 1,
+		Ancestry: []types.Ancestry{
+			{
+				TreePath: treePath,
+			},
+		},
+	}
+	mat := &LineageMaterial{
+		TargetOutpoint: desc.Outpoint,
+		TreePaths: []*tree.Tree{
+			treePath,
+		},
+		ExtraNodes: []*recovery.Node{
+			{
+				Kind: recovery.NodeKindCheckpoint,
+				Tx:   testRecoveryTx(1),
+			},
+			{
+				Kind: recovery.NodeKindArk,
+				Tx:   testRecoveryTx(1),
+			},
+		},
+	}
+
+	numTxs, numPaths, vbytes := recoveryEstimate(desc, mat)
+
+	// The tree path contributes its node txs; the OOR material adds its
+	// two extra nodes. numPaths counts only the ancestry fragment.
+	wantTreeVBytes := treePathVBytes(treePath)
+	var wantOORVBytes int64
+	for _, n := range mat.ExtraNodes {
+		wantOORVBytes += extraNodeVBytes(n)
+	}
+
+	require.Equal(t, treePath.NumTx()+len(mat.ExtraNodes), numTxs)
+	require.Equal(t, 1, numPaths)
+	require.Equal(t, wantTreeVBytes+wantOORVBytes, vbytes)
 }


### PR DESCRIPTION
In this PR, we fix the unilateral-exit funding estimate so `da exit plan`
recommends enough on-chain funding to actually complete an exit.

A unilateral exit broadcasts every recovery (branch / OOR-checkpoint)
transaction in the VTXO's ancestry, each of which is zero-fee and driven on
chain by a CPFP child. Under package/ancestor-fee semantics the child must
pay the fee for the whole package, i.e. `feeRate * (parentVSize +
childVSize)` per recovery tx. The planning model in `AssessExitFeasibility`
only budgeted the child (`155` vB per recovery tx) and omitted the parent
recovery-tx weight, so the exit-plan cost was undercounted and the
recommended funding came out too low. For small VTXOs the `10_000`-sat
minimum fee-input floor masked it; for larger trees or higher fee rates the
plan could under-recommend, leaving a user who funds exactly to the plan
short at broadcast time.

The actual `txconfirm` broadcaster already computes the correct
ancestor-aware fee (`feeRate * (parentVSize + childVSize)`), so exits still
confirm — this was purely an up-front recommendation bug.

## The fix

We add `RecoveryTxVBytes(desc)`, the parent-weight companion to
`RecoveryTxCount`. When an ancestry fragment still carries its extracted
tree path, we sum the *actual* per-node transaction size, which is exact
for any tree radix: a wider branch simply has more child outputs, and
extraction preserves each node's full output set. When a fragment is pruned
to a depth, or for OOR checkpoint hops where the concrete txs aren't on
hand, we fall back to a conservative per-tx constant.
`AssessExitFeasibility` folds this into the CPFP budget:

```go
cpfpVBytes := cfg.CPFPChildVBytes*numRecoveryTxs + RecoveryTxVBytes
```

The exact-size path matters more now that the operator can build
non-binary VTXO trees (see the server-side dynamic-radix work): a flatter
tree has fewer, wider branch txs, and summing real node sizes prices that
correctly where a per-tx constant could not.

This is client-only and independent of the server's fee model; it does not
change any wire format.
