### PR TITLE
build: adopt v0.1.x release branching and backport automation

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,120 @@
+name: Backport
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  backport:
+    name: Backport PR
+    runs-on: ubuntu-latest
+    # Only run on merged PRs with backport labels.
+    # Labels must match pattern: backport-v* (e.g., backport-v0.1.x-branch).
+    # This excludes labels like "backport candidate" or "backport-candidate".
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(join(github.event.pull_request.labels.*.name, ','), 'backport-v')
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Validate target branches exist
+        id: validate
+        shell: bash
+        run: |
+          # Extract all backport labels
+          labels='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+          echo "All labels: $labels"
+
+          # Parse labels and extract branch names
+          # Only match labels starting with "backport-v" to exclude labels like
+          # "backport candidate" or "backport-candidate"
+          backport_labels=$(echo "$labels" | jq -r '.[] | select(startswith("backport-v"))')
+
+          if [ -z "$backport_labels" ]; then
+            echo "::error::No valid backport labels found (must start with 'backport-v')"
+            exit 1
+          fi
+
+          echo "Found backport labels:"
+          echo "$backport_labels"
+
+          # Check each target branch exists
+          missing_branches=()
+          valid_branches=()
+          while IFS= read -r label; do
+            # Extract branch name (everything after "backport-")
+            branch_name="${label#backport-}"
+            echo "Checking if branch exists: $branch_name"
+
+            # Check if branch exists in remote
+            if ! git ls-remote --heads origin "$branch_name" | grep -q "$branch_name"; then
+              echo "::warning::Target branch '$branch_name' does not exist (from label '$label')"
+              missing_branches+=("$branch_name")
+            else
+              echo "✓ Branch '$branch_name' exists"
+              valid_branches+=("$branch_name")
+            fi
+          done <<< "$backport_labels"
+
+          # Report validation results
+          if [ ${#missing_branches[@]} -gt 0 ]; then
+            echo "::warning::The following target branches do not exist and will be skipped: ${missing_branches[*]}"
+            echo "::warning::Please check the branch names or create the branches before retrying"
+          fi
+
+          # Only fail if ALL branches are invalid
+          if [ ${#valid_branches[@]} -eq 0 ]; then
+            echo "::error::No valid target branches found. All backport labels reference non-existent branches."
+            exit 1
+          fi
+
+          echo "✓ Found ${#valid_branches[@]} valid target branch(es): ${valid_branches[*]}"
+          if [ ${#missing_branches[@]} -gt 0 ]; then
+            echo "⚠ Skipping ${#missing_branches[@]} invalid branch(es): ${missing_branches[*]}"
+          fi
+
+      - name: Create backport PRs
+        # Uses version v3.4, we pin to a hash here. For more details to
+        # available versions, see:
+        # https://github.com/korthout/backport-action/releases.
+        uses: korthout/backport-action@d07416681cab29bf2661702f925f020aaa962997
+        with:
+          # Automatically detect target branches from labels.
+          # Labels must be in format: backport-v0.1.x-branch (must start
+          # with "backport-v"). This excludes labels like "backport candidate"
+          # or "backport-candidate". The pattern extracts everything after
+          # "backport-" as the branch name.
+          label_pattern: '^backport-(v.+)$'
+
+          # GitHub token for creating PRs.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+          # PR title format - shows it's a backport with original PR number.
+          pull_title: '[${target_branch}] Backport #${pull_number}: ${pull_title}'
+
+          # PR description template - links back to original PR.
+          pull_description: |-
+            Backport of #${pull_number}
+
+            ---
+
+            ${pull_description}
+
+          # Copy milestone from original PR to backport PR.
+          copy_milestone: true
+
+          # Merge strategy - skip merge commits, use cherry-pick only.
+          merge_commits: skip
+
+          # If conflicts occur, create a draft PR with conflict markers.
+          experimental: '{"conflict_resolution": "draft_commit_conflicts"}'

--- a/build/version.go
+++ b/build/version.go
@@ -12,14 +12,14 @@ const (
 	AppMajor uint = 0
 
 	// AppMinor defines the minor version of this binary.
-	AppMinor uint = 0
+	AppMinor uint = 1
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 2
+	AppPatch uint = 99
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.
-	AppPreRelease = "alpha"
+	AppPreRelease = ""
 )
 
 var (

--- a/build/version_test.go
+++ b/build/version_test.go
@@ -1,30 +1,39 @@
 package build
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
 
-// TestVersion verifies that Version() returns the correct semantic version.
+// TestVersion verifies that Version() renders the version constants in the
+// documented semantic-versioning format. It derives the expectation from the
+// constants so a version bump never breaks this test.
 func TestVersion(t *testing.T) {
 	version := Version()
 
-	// Expected format: "0.0.2-alpha"
-	if !strings.HasPrefix(version, "0.0.2") {
-		t.Fatalf("expected version to start with 0.0.2, got: %s",
+	// The numeric major.minor.patch prefix must come straight from the
+	// constants.
+	prefix := fmt.Sprintf("%d.%d.%d", AppMajor, AppMinor, AppPatch)
+	if !strings.HasPrefix(version, prefix) {
+		t.Fatalf("expected version to start with %s, got: %s", prefix,
 			version)
 	}
 
-	if !strings.Contains(version, "alpha") {
-		t.Fatalf("expected version to contain 'alpha', got: %s",
-			version)
-	}
+	// A pre-release suffix, when set, is appended after a dash; when
+	// empty, the version is exactly the numeric prefix.
+	switch {
+	case AppPreRelease != "":
+		if version != prefix+"-"+AppPreRelease {
+			t.Fatalf("expected version %s-%s, got: %s", prefix,
+				AppPreRelease, version)
+		}
 
-	// Verify exact match.
-	expectedVersion := "0.0.2-alpha"
-	if version != expectedVersion {
-		t.Fatalf("expected version %s, got: %s", expectedVersion,
-			version)
+	default:
+		if version != prefix {
+			t.Fatalf("expected version %s, got: %s", prefix,
+				version)
+		}
 	}
 }
 

--- a/docs/backport-workflow.md
+++ b/docs/backport-workflow.md
@@ -1,0 +1,101 @@
+# Automated Backport Workflow
+
+This document describes the automated backport workflow for darepo-client. It
+backports merged `main` pull requests to release branches (for example,
+`v0.1.x-branch`) without manual cherry-picking.
+
+## Overview
+
+Instead of manually creating branches, cherry-picking commits, and opening PRs,
+a maintainer adds a label to the merged `main` PR and the workflow does the rest:
+it validates the target branch, cherry-picks the commits, and opens a PR against
+the release branch.
+
+## How to Use
+
+1. Merge a PR to `main` (or start from one already merged).
+2. Add a backport label in the format `backport-v<version>-branch`, for example
+   `backport-v0.1.x-branch`.
+3. The workflow then:
+   - validates the target branch exists,
+   - cherry-picks the commits,
+   - opens a new PR targeting the release branch.
+
+The label can be added before or after the merge — both trigger the workflow.
+Adding it before merge fires on the PR-close event; adding it afterward fires on
+the label event.
+
+## Label Format
+
+Labels **must** start with `backport-v` to trigger the workflow:
+
+- ✅ `backport-v0.1.x-branch` → backports to `v0.1.x-branch`
+- ✅ `backport-v0.2.x-branch` → backports to `v0.2.x-branch`
+
+These labels are ignored:
+
+- ❌ `backport candidate` — discussion label only
+- ❌ `backport-candidate` — does not start with `backport-v`
+- ❌ `needs-backport` — wrong prefix
+
+This lets you use discussion labels without accidentally triggering a backport.
+The branch name is everything after the `backport-` prefix:
+
+```
+Label:  backport-v0.1.x-branch
+            ↓ (drop "backport-")
+Branch: v0.1.x-branch
+```
+
+## Workflow Steps
+
+1. **Checkout** — fetch full history and check out the PR's base branch
+   (usually `main`).
+2. **Validate target branches** — for each `backport-v*` label, extract the
+   branch name and confirm it exists on `origin`. If a labeled branch is
+   missing, that branch is skipped; the job only fails if every labeled branch
+   is missing.
+3. **Create backport PRs** — for each valid label, cherry-pick the PR's commits
+   onto a fresh `backport-<pr-number>-to-<target-branch>` branch and open a PR
+   against the release branch. Merge commits are skipped; authorship and commit
+   messages are preserved. The backport PR title is
+   `[<target-branch>] Backport #<pr-number>: <original title>` and its body links
+   back to the original PR.
+
+## Handling Conflicts
+
+When the cherry-pick applies cleanly, the workflow opens a regular (non-draft)
+PR ready for review. When it conflicts, the workflow commits the conflict markers
+and opens a **draft** PR. Resolve it manually:
+
+```bash
+git fetch origin
+git checkout backport-<pr-number>-to-v0.1.x-branch
+# resolve conflicts in the affected files
+git add <resolved-files>
+git commit -m "Resolve backport conflicts"
+git push origin backport-<pr-number>-to-v0.1.x-branch
+# mark the PR "Ready for review" in the GitHub UI
+```
+
+Test locally before pushing, explain what conflicts were resolved in the commit
+message, and get the backport PR reviewed like any other change.
+
+## Multiple Backports
+
+Add multiple `backport-v*` labels to backport to several release branches at
+once. Each backport is processed independently: one may apply cleanly while
+another conflicts, and each produces its own branch and PR.
+
+## Technical Details
+
+- **Workflow file:** `.github/workflows/backport.yml`
+- **Triggers:** `pull_request_target` on `[closed, labeled]`
+- **Condition:** runs only when the PR is actually merged and carries at least
+  one label containing `backport-v`
+- **Action:** [`korthout/backport-action`](https://github.com/korthout/backport-action),
+  pinned to a commit hash, with `label_pattern: '^backport-(v.+)$'`,
+  `merge_commits: skip`, and draft PRs on conflict
+
+See [release_branch_management.md](release_branch_management.md) for how release
+branches are created and tagged.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,13 @@ into specific topics below.
 | [policy_arkscript_review_guide.md](policy_arkscript_review_guide.md) | Policy-first arkscript reviewer guide |
 | [dev_rpc_cli_builder.md](dev_rpc_cli_builder.md) | Generated `darepocli dev` command builder and request flag rules |
 
+## Release Engineering
+
+| Document | Description |
+|----------|-------------|
+| [release_branch_management.md](release_branch_management.md) | Trunk-based release model: `v0.1.x-branch` release branches, the `main` `.99` version convention, tagging with `scripts/tag-release.sh` |
+| [backport-workflow.md](backport-workflow.md) | Automated backport of merged `main` PRs to release branches via `backport-v*` labels |
+
 ## Operations
 
 | Document | Description |

--- a/docs/release_branch_management.md
+++ b/docs/release_branch_management.md
@@ -1,0 +1,189 @@
+# Release Branch Management
+
+## Overview
+
+This document describes the branch management workflow for darepo-client
+releases. The `main` branch remains open for merges at all times. Release
+stabilization happens on dedicated release branches, with CI automation handling
+backports of labeled changes. This approach keeps development velocity high while
+still shipping stable releases.
+
+## Branch Model Principles
+
+The release process rests on four principles:
+
+**Main is always open.** Developers merge approved pull requests at any time,
+with no coordination around release windows and no merge freezes.
+
+**Each major release gets a dedicated branch.** When cutting a new major
+version, we branch from `main`. That branch carries every release candidate and
+patch release for the version series.
+
+**CI automation handles backports.** Pull requests merged to `main` and tagged
+with a `backport-v*` label are automatically backported to the matching release
+branch. The automation opens a backport PR whenever the cherry-pick conflicts.
+
+**Changes flow one direction only.** Changes move from `main` to release
+branches, never in reverse. `main` always represents the latest development
+state.
+
+## Main Branch
+
+The `main` branch holds ongoing development for future releases. It never freezes
+for a release.
+
+### Main Version Convention
+
+`main` uses a `.99` patch version to mark unreleased development work. After
+cutting `v0.1.x-branch`, `build/version.go` on `main` reads `0.1.99`. That
+clearly signals post-0.1 but pre-0.2 code. When we cut `v0.2.x-branch` later,
+`main` moves to `0.2.99`. The pattern sorts correctly and is immediately
+recognizable as a development build.
+
+### Merging to Main
+
+Developers merge to `main` through the normal review process. If a change should
+land in an active or upcoming release, add the matching `backport-v*` label
+(for example `backport-v0.1.x-branch`); the automation backports it after merge.
+No special coordination is required — merge whenever the PR is approved,
+regardless of ongoing release activity.
+
+## Major Release Process
+
+A major release introduces new features and represents a new minor version
+(for example, 0.1.0, 0.2.0).
+
+### Creating the Release Branch
+
+When ready to begin a major release:
+
+1. Create a release branch from `main`: `git checkout -b v0.1.x-branch main`
+2. Push the branch: `git push origin v0.1.x-branch`
+3. Update `build/version.go` on the release branch to the release version
+   (`0.1.0`) via a pull request against the release branch.
+4. Update `main`'s version to `0.1.99` via a separate pull request against
+   `main`.
+5. Configure branch protection for `v0.1.x-branch` on GitHub.
+6. Create the `backport-v0.1.x-branch` label so the backport automation can
+   route fixes to the branch.
+
+### Tagging the Release
+
+After the version-bump PR merges onto the release branch, tag the merge commit
+with the release tagging helper:
+
+```bash
+./scripts/tag-release.sh v0.1.0 --branch v0.1.x-branch
+git push <upstream-remote> v0.1.0
+```
+
+The helper verifies that HEAD is in sync with the upstream release branch and
+that `build/version.go` matches the requested tag before creating the signed
+tag, then prints the exact push command to run as the final maintainer step.
+
+### Release Candidate Cycle (optional)
+
+For a release that needs a stabilization period, use release-candidate tags. Set
+`build/version.go` to a candidate version (for example `0.1.0-rc1` by setting
+`AppPreRelease = "rc1"`), merge the bump onto the release branch, then tag it:
+
+```bash
+./scripts/tag-release.sh v0.1.0-rc1 --branch v0.1.x-branch
+git push <upstream-remote> v0.1.0-rc1
+```
+
+As testing uncovers issues, develop fixes on `main`, label them
+`backport-v0.1.x-branch`, and let CI backport them. Repeat the bump-and-tag cycle
+(rc2, rc3, …) until stable, then drop the suffix for the final `v0.1.0` tag.
+
+## Minor Release Process
+
+Minor (patch) releases fix bugs or security issues in released versions. They
+reuse the existing release branch for that version series.
+
+When a critical fix is needed for `0.1.0`:
+
+1. Develop and merge the fix to `main`.
+2. Add the `backport-v0.1.x-branch` label so CI backports it.
+3. Update `build/version.go` on the release branch to `0.1.1` via a pull request
+   against the release branch.
+4. After the PR merges, tag the merge commit:
+   `./scripts/tag-release.sh v0.1.1 --branch v0.1.x-branch`
+5. Push the tag: `git push <upstream-remote> v0.1.1`
+
+Multiple patch releases (0.1.1, 0.1.2, …) live on the same `v0.1.x-branch`
+throughout the version's lifetime.
+
+## Manual Cherry-Picking
+
+Occasionally a fix is needed on a release branch that does not apply to `main`
+(a release-specific issue, or an older branch where `main` has diverged
+significantly).
+
+```bash
+# Switch to the release branch.
+git checkout v0.1.x-branch
+
+# Cherry-pick the commit from main.
+git cherry-pick <commit-hash>
+
+# If conflicts occur, resolve them and continue.
+git cherry-pick --continue
+```
+
+Manual cherry-picks still follow the normal PR flow: open a PR into the target
+release branch for review and CI. When bypassing the normal backport flow,
+document why, and make sure any corresponding change also lands on `main` so the
+bug does not reappear in a future release.
+
+## Backport Automation
+
+CI automation monitors merged PRs and backports labeled changes to the matching
+release branch. When a PR carrying a `backport-v0.1.x-branch` label merges to
+`main`:
+
+1. CI extracts the target branch from the label and confirms it exists.
+2. CI cherry-picks the PR's commits onto a fresh branch off the release branch.
+3. CI opens a backport PR against the release branch.
+4. If the cherry-pick conflicts, CI opens a draft PR with conflict markers for
+   manual resolution.
+
+See [backport-workflow.md](backport-workflow.md) for the full workflow, label
+format, and conflict-resolution steps.
+
+## Version Bump Timing
+
+Version numbers in `build/version.go` update at specific points:
+
+- **On release branches:** update immediately before tagging. The commit that
+  updates the version is the commit that gets tagged, so built binaries report
+  the correct version.
+- **On main:** update when creating a new release branch. `main` moves from
+  `0.0.x` to `0.1.99` when `v0.1.x-branch` is created, then to `0.2.99` when
+  `v0.2.x-branch` is created.
+
+## Branch Model Visualization
+
+```mermaid
+gitGraph
+    commit id: "Development"
+    commit id: "More work"
+    branch v0.1.x-branch
+    commit id: "Version -> 0.1.0" tag: "v0.1.0"
+    checkout main
+    commit id: "Feature (for 0.2)"
+    commit id: "Feature (for 0.2)"
+    checkout v0.1.x-branch
+    commit id: "Backport: Fix X"
+    commit id: "Version -> 0.1.1" tag: "v0.1.1"
+    checkout main
+    commit id: "Keep developing"
+    branch v0.2.x-branch
+    commit id: "Version -> 0.2.0" tag: "v0.2.0"
+    checkout main
+    commit id: "Future work"
+```
+
+After `v0.1.x-branch` is created, both branches evolve independently. `main`
+continues with features for future releases while the release branch focuses on
+stabilization and bug fixes.

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+#
+# tag-release.sh creates a signed annotated git tag for a darepo-client release
+# after verifying (a) HEAD is in sync with the upstream
+# lightninglabs/darepo-client branch, and (b) build/version.go at HEAD matches
+# the requested tag. Guards against tagging a commit that has not been merged
+# upstream yet, or one whose embedded version disagrees with the tag.
+
+set -euo pipefail
+
+VERSION_FILE="build/version.go"
+
+# Match the canonical upstream URL across https / git@ / ssh:// forms, with or
+# without a `.git` suffix. We identify the remote by URL because `origin` is
+# conventionally the fork in a `gh repo fork` setup. The URL is lower-cased
+# before matching (see below), so this pattern stays lower-case: GitHub treats
+# the org/repo as case-insensitive, and `origin` is often a mixed-case
+# `LightningLabs/darepo-client`.
+UPSTREAM_URL_REGEX='[:/]lightninglabs/darepo-client(\.git)?$'
+
+usage() {
+  cat >&2 <<EOF
+Usage: $(basename "$0") <tag-name> [--branch <branch>]
+
+  <tag-name>          Release tag, e.g. v0.1.0. Must match the constants
+                      defined in ${VERSION_FILE} at HEAD.
+  --branch <branch>   Upstream branch to verify HEAD against. Defaults to
+                      the currently checked-out branch (typically a release
+                      branch such as v0.1.x-branch).
+EOF
+  exit 1
+}
+
+TAG=""
+UPSTREAM_BRANCH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)   usage ;;
+    --branch)    [[ $# -ge 2 ]] || usage; UPSTREAM_BRANCH="$2"; shift 2 ;;
+    --branch=*)  UPSTREAM_BRANCH="${1#--branch=}"; shift ;;
+    -*)          echo "Unknown flag: $1" >&2; usage ;;
+    *)           [[ -z "${TAG}" ]] || usage; TAG="$1"; shift ;;
+  esac
+done
+[[ -n "${TAG}" ]] || usage
+
+cd "$(git rev-parse --show-toplevel)"
+
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  echo "Error: tag ${TAG} already exists locally." >&2
+  exit 1
+fi
+
+if [[ -z "${UPSTREAM_BRANCH}" ]]; then
+  UPSTREAM_BRANCH="$(git symbolic-ref --quiet --short HEAD || true)"
+  [[ -n "${UPSTREAM_BRANCH}" ]] \
+    || { echo "Error: detached HEAD; pass --branch <name>." >&2; exit 1; }
+fi
+
+# Discover the upstream remote by URL (see UPSTREAM_URL_REGEX).
+UPSTREAM_REMOTES=()
+while IFS= read -r line; do
+  UPSTREAM_REMOTES+=("$line")
+done < <(git remote -v | awk -v re="${UPSTREAM_URL_REGEX}" \
+  '$3 == "(fetch)" && tolower($2) ~ re { print $1 }' | sort -u)
+
+case "${#UPSTREAM_REMOTES[@]}" in
+  0) echo "Error: no git remote points at lightninglabs/darepo-client. Add" \
+          "one with 'git remote add upstream" \
+          "https://github.com/lightninglabs/darepo-client.git'." >&2
+     exit 1 ;;
+  1) UPSTREAM_REMOTE="${UPSTREAM_REMOTES[0]}" ;;
+  *) echo "Error: multiple remotes match lightninglabs/darepo-client:" >&2
+     printf '  %s\n' "${UPSTREAM_REMOTES[@]}" >&2
+     exit 1 ;;
+esac
+
+# Fetch first so every later check runs against confirmed-current upstream
+# state. Without this, a stale local HEAD could pass the version-match check
+# while still being out of sync with what's on the release branch.
+echo "Fetching ${UPSTREAM_REMOTE} ${UPSTREAM_BRANCH}..."
+git fetch --quiet "${UPSTREAM_REMOTE}" "${UPSTREAM_BRANCH}"
+
+# Catch the race where another maintainer has already published this tag.
+if git ls-remote --exit-code --tags "${UPSTREAM_REMOTE}" \
+    "refs/tags/${TAG}" >/dev/null 2>&1; then
+  echo "Error: tag ${TAG} already exists on ${UPSTREAM_REMOTE}." >&2
+  exit 1
+fi
+
+# Compare against FETCH_HEAD rather than refs/remotes/<remote>/<branch>:
+# FETCH_HEAD is always written by `git fetch <remote> <branch>`, while the
+# remote-tracking ref depends on the user's refspec configuration.
+HEAD_SHA="$(git rev-parse HEAD)"
+UP_SHA="$(git rev-parse FETCH_HEAD)"
+if [[ "${HEAD_SHA}" != "${UP_SHA}" ]]; then
+  AHEAD="$(git rev-list --count FETCH_HEAD..HEAD)"
+  BEHIND="$(git rev-list --count HEAD..FETCH_HEAD)"
+  cat >&2 <<EOF
+
+Error: HEAD does not match ${UPSTREAM_REMOTE}/${UPSTREAM_BRANCH}.
+  HEAD:     ${HEAD_SHA}
+  Upstream: ${UP_SHA}
+  Ahead: ${AHEAD}, behind: ${BEHIND}.
+
+Push (or wait for) the version bump on ${UPSTREAM_BRANCH}, then re-run.
+EOF
+  exit 1
+fi
+
+# Parse version.go from HEAD (now confirmed in sync with upstream) so the
+# check reflects exactly what the tag will commit to. A single awk pass
+# extracts all four constants in the order they appear in the file. The
+# `|| :` keeps `set -e` from terminating the script if AppPreRelease is
+# absent from version.go and the final read hits EOF.
+{ read -r M && read -r m && read -r p && read -r pre || :; } < <(
+  git show "HEAD:${VERSION_FILE}" 2>/dev/null | awk '
+    /^[[:space:]]*AppMajor[[:space:]]+uint[[:space:]]*=/   { sub(/.*=[[:space:]]*/,""); sub(/[^0-9].*/,""); print }
+    /^[[:space:]]*AppMinor[[:space:]]+uint[[:space:]]*=/   { sub(/.*=[[:space:]]*/,""); sub(/[^0-9].*/,""); print }
+    /^[[:space:]]*AppPatch[[:space:]]+uint[[:space:]]*=/   { sub(/.*=[[:space:]]*/,""); sub(/[^0-9].*/,""); print }
+    /^[[:space:]]*AppPreRelease[[:space:]]*=/              { match($0,/"[^"]*"/); print substr($0,RSTART+1,RLENGTH-2) }
+  '
+)
+
+if [[ -z "${M}" || -z "${m}" || -z "${p}" ]]; then
+  echo "Error: failed to parse version constants from HEAD:${VERSION_FILE}." \
+       >&2
+  exit 1
+fi
+
+# Go treats `01` as an octal literal but %d prints it as decimal; force
+# base-10 here so we match build.Version()'s output.
+EXPECTED="v$((10#$M)).$((10#$m)).$((10#$p))"
+[[ -n "${pre}" ]] && EXPECTED="${EXPECTED}-${pre}"
+
+echo "Requested: ${TAG}"
+echo "Expected:  ${EXPECTED}  (from HEAD:${VERSION_FILE})"
+
+if [[ "${TAG}" != "${EXPECTED}" ]]; then
+  cat >&2 <<EOF
+
+Error: requested tag does not match HEAD:${VERSION_FILE}.
+  Requested: ${TAG}
+  Expected:  ${EXPECTED}
+
+Bump AppMajor/AppMinor/AppPatch/AppPreRelease and commit before tagging.
+EOF
+  exit 1
+fi
+
+echo "Creating signed tag ${TAG} at ${HEAD_SHA}."
+git tag -s -m "${TAG}" "${TAG}"
+echo "Done. Push with: git push ${UPSTREAM_REMOTE} ${TAG}"


### PR DESCRIPTION
Prep for the public **v0.1** release: adopt lnd's trunk-based release model so
`main` keeps moving while a stable release line lives on a side branch
(`v0.1.x-branch`), with fixes flowing back via labeled backports instead of
merge freezes.

### What's here
- **`.github/workflows/backport.yml`** — cherry-picks a merged `main` PR onto a
  release branch when it carries a `backport-v<version>-branch` label (draft PR
  on conflict). Pinned `korthout/backport-action`.
- **`scripts/tag-release.sh`** — creates the signed release tag only after
  confirming HEAD is in sync with the upstream release branch and that
  `build/version.go` matches the requested tag.
- **`docs/release_branch_management.md`** + **`docs/backport-workflow.md`** — the
  branch model, the `main` `.99` version convention, and the backport flow;
  linked from `docs/index.md`.
- **`build/version.go`** — `main` bumped to **0.1.99** to mark post-0.1,
  pre-0.2 development.

### Follow-ups (out of band)
- The `v0.1.x-branch` release branch + its `0.1.0` version PR.
- Create the `backport-v0.1.x-branch` label and branch protection on GitHub.

Part of a coordinated v0.1 setup across darepo-client, darepo, swapdk-server,
dawallet, and damobile.