### PR TITLE
build: bump version to v0.1.0

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -15,7 +15,7 @@ const (
 	AppMinor uint = 1
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 99
+	AppPatch uint = 0
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.

--- a/build/version_test.go
+++ b/build/version_test.go
@@ -1,30 +1,39 @@
 package build
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
 
-// TestVersion verifies that Version() returns the correct semantic version.
+// TestVersion verifies that Version() renders the version constants in the
+// documented semantic-versioning format. It derives the expectation from the
+// constants so a version bump never breaks this test.
 func TestVersion(t *testing.T) {
 	version := Version()
 
-	// Expected format: "0.0.2-alpha"
-	if !strings.HasPrefix(version, "0.0.2") {
-		t.Fatalf("expected version to start with 0.0.2, got: %s",
+	// The numeric major.minor.patch prefix must come straight from the
+	// constants.
+	prefix := fmt.Sprintf("%d.%d.%d", AppMajor, AppMinor, AppPatch)
+	if !strings.HasPrefix(version, prefix) {
+		t.Fatalf("expected version to start with %s, got: %s", prefix,
 			version)
 	}
 
-	if !strings.Contains(version, "alpha") {
-		t.Fatalf("expected version to contain 'alpha', got: %s",
-			version)
-	}
+	// A pre-release suffix, when set, is appended after a dash; when
+	// empty, the version is exactly the numeric prefix.
+	switch {
+	case AppPreRelease != "":
+		if version != prefix+"-"+AppPreRelease {
+			t.Fatalf("expected version %s-%s, got: %s", prefix,
+				AppPreRelease, version)
+		}
 
-	// Verify exact match.
-	expectedVersion := "0.0.2-alpha"
-	if version != expectedVersion {
-		t.Fatalf("expected version %s, got: %s", expectedVersion,
-			version)
+	default:
+		if version != prefix {
+			t.Fatalf("expected version %s, got: %s", prefix,
+				version)
+		}
 	}
 }
 


### PR DESCRIPTION
Sets `build/version.go` on the `v0.1.x-branch` release branch to **0.1.0** for
the first public release.

Once merged, tag the merge commit:

```bash
./scripts/tag-release.sh v0.1.0 --branch v0.1.x-branch
git push origin v0.1.0
```

The helper refuses to tag unless HEAD matches the upstream release branch and
`build/version.go` reads `0.1.0`.

Base is `v0.1.x-branch` (not `main`); `main` stays at `0.1.99`. Depends on
#890 (branching plumbing) landing on `main`.