### PR TITLE
multi: enrich exit status with progress, fees, and an exit summary

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_exit.go
+++ b/cmd/darepocli/darepoclicommands/cmd_exit.go
@@ -53,6 +53,7 @@ func newExitCmd() *cobra.Command {
 			"preview, non-zero on validation failure")
 
 	cmd.AddCommand(newExitStatusCmd())
+	cmd.AddCommand(newExitSummaryCmd())
 	cmd.AddCommand(newExitPlanCmd())
 
 	return cmd
@@ -120,10 +121,17 @@ func newExitStatusCmd() *cobra.Command {
 		Use:   "status",
 		Short: "Query the status of an exit (unroll) job",
 		Long: "Returns the current status of a unilateral exit job " +
-			"for the specified VTXO outpoint, including the " +
-			"job phase, sweep txid, and any errors.\n\n" +
+			"for the specified VTXO outpoint. By default the " +
+			"response includes recovery-tree progress (layer and " +
+			"transaction counts), the CSV maturity countdown, a " +
+			"best-case block estimate to full exit, and the " +
+			"on-chain fee breakdown, alongside the job phase, " +
+			"sweep txid, and any errors. The endpoint stays " +
+			"queryable after the exit completes.\n\n" +
 			"Example:\n" +
-			"  darepocli exit status --outpoint TXID:VOUT",
+			"  darepocli exit status --outpoint TXID:VOUT\n" +
+			"  darepocli exit status --outpoint TXID:VOUT " +
+			"--detailed=false",
 		Args: cobra.NoArgs,
 		RunE: walletExitStatus,
 	}
@@ -131,6 +139,10 @@ func newExitStatusCmd() *cobra.Command {
 	cmd.Flags().String("outpoint", "",
 		"VTXO outpoint to query (txid:vout)")
 	_ = cmd.MarkFlagRequired("outpoint")
+	cmd.Flags().Bool("detailed", true,
+		"include tree/CSV progress, best-case block countdown, and "+
+			"the fee breakdown; pass --detailed=false for a "+
+			"coarse, cheaper phase-only status")
 
 	return cmd
 }
@@ -142,16 +154,58 @@ func walletExitStatus(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	detailed, _ := cmd.Flags().GetBool("detailed")
+
 	return withWalletClient(
 		cmd, func(c walletdkrpc.WalletServiceClient) error {
 			resp, err := c.ExitStatus(
 				cmd.Context(),
 				&walletdkrpc.ExitStatusRequest{
 					Outpoint: outpoint,
+					Detailed: detailed,
 				},
 			)
 			if err != nil {
 				return fmt.Errorf("exit status: %w", err)
+			}
+
+			return printWalletProto(resp)
+		},
+	)
+}
+
+// newExitSummaryCmd builds the `exit summary` subcommand. It dials
+// walletdkrpc.WalletService.ExitSummary to report the wallet-wide portfolio of
+// in-progress exits plus aggregate totals.
+func newExitSummaryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "summary",
+		Short: "Summarize all in-progress exits and their totals",
+		Long: "Lists every in-progress unilateral exit and the " +
+			"aggregate totals across them: the amount still " +
+			"being recovered, the estimated on-chain fees, and " +
+			"the estimated net recoverable. Completed and " +
+			"failed exits are omitted; they have no amount " +
+			"left to recover.\n\n" +
+			"Example:\n" +
+			"  darepocli exit summary",
+		Args: cobra.NoArgs,
+		RunE: walletExitSummary,
+	}
+
+	return cmd
+}
+
+// walletExitSummary implements the `exit summary` subcommand.
+func walletExitSummary(cmd *cobra.Command, _ []string) error {
+	return withWalletClient(
+		cmd, func(c walletdkrpc.WalletServiceClient) error {
+			resp, err := c.ExitSummary(
+				cmd.Context(),
+				&walletdkrpc.ExitSummaryRequest{},
+			)
+			if err != nil {
+				return fmt.Errorf("exit summary: %w", err)
 			}
 
 			return printWalletProto(resp)

--- a/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
+++ b/cmd/darepocli/darepoclicommands/devrpc/registry_generated.go
@@ -509,6 +509,13 @@ func generatedRegistry() []serviceSpec {
 					Comments: "",
 				},
 				{
+					Name:     "ExitSummary",
+					Aliases:  []string{"exit-summary"},
+					Input:    "walletdkrpc.ExitSummaryRequest",
+					Output:   "walletdkrpc.ExitSummaryResponse",
+					Comments: "",
+				},
+				{
 					Name:            "SubscribeWallet",
 					Aliases:         []string{"subscribe-wallet"},
 					Input:           "walletdkrpc.SubscribeWalletRequest",

--- a/cmd/darepocli/darepoclicommands/mcp_wallet.go
+++ b/cmd/darepocli/darepoclicommands/mcp_wallet.go
@@ -97,7 +97,27 @@ func registerMCPWalletQueryTools(s *mcp.Server,
 		resp, err := client.ExitStatus(
 			ctx, &walletdkrpc.ExitStatusRequest{
 				Outpoint: args.Outpoint,
+				Detailed: true,
 			},
+		)
+		if err != nil {
+			return nil, nil, mapWalletRPCError(err)
+		}
+
+		r, err := mcpResult(resp)
+
+		return r, nil, err
+	})
+
+	type exitSummaryArgs struct{}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "exit.summary",
+		Description: "Summarize all in-progress exits and their totals",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest,
+		_ exitSummaryArgs) (*mcp.CallToolResult, any, error) {
+
+		resp, err := client.ExitSummary(
+			ctx, &walletdkrpc.ExitSummaryRequest{},
 		)
 		if err != nil {
 			return nil, nil, mapWalletRPCError(err)

--- a/cmd/darepocli/darepoclicommands/schema_registry.go
+++ b/cmd/darepocli/darepoclicommands/schema_registry.go
@@ -374,6 +374,16 @@ func walletQueryMethodRegistry() []schemaMethod {
 			MCPTool:      true,
 		},
 		{
+			Method: "exit.summary",
+			Description: "Summarize all in-progress exits and " +
+				"their totals",
+			Params:       nil,
+			RequestType:  "ExitSummaryRequest",
+			ResponseType: "ExitSummaryResponse",
+			JSONInput:    false,
+			MCPTool:      true,
+		},
+		{
 			Method: "exit.plan",
 			Description: "Preview backing-wallet funding " +
 				"readiness for an exit",

--- a/cmd/darepocli/darepoclicommands/wallet_client_test.go
+++ b/cmd/darepocli/darepoclicommands/wallet_client_test.go
@@ -265,6 +265,7 @@ func TestWalletCommandsRejectUnexpectedArgs(t *testing.T) {
 		newActivityCmd(),
 		newExitCmd(),
 		newExitStatusCmd(),
+		newExitSummaryCmd(),
 	}
 
 	for _, cmd := range commands {

--- a/cmd/walletdk-wasm/main.go
+++ b/cmd/walletdk-wasm/main.go
@@ -101,6 +101,9 @@ func walletCall(_ js.Value, args []js.Value) any {
 	case "exitStatus":
 		return promise(jsonVerb(req, mobile.ExitStatus))
 
+	case "exitSummary":
+		return promise(jsonVerb(req, mobile.ExitSummary))
+
 	case "getExitPlan":
 		return promise(jsonVerb(req, mobile.GetExitPlan))
 

--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -8338,7 +8338,12 @@ func (x *UnrollResponse) GetActorId() string {
 type GetUnrollStatusRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// outpoint is the VTXO outpoint to query, formatted as "txid:index".
-	Outpoint      string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	Outpoint string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	// detailed enriches the response with tree/CSV progress and a fee
+	// breakdown by querying the live unroll actor. It costs one extra child
+	// actor round-trip plus a fee estimate, so automated pollers should leave
+	// it false and only interactive status commands should set it.
+	Detailed      bool `protobuf:"varint,2,opt,name=detailed,proto3" json:"detailed,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -8380,6 +8385,332 @@ func (x *GetUnrollStatusRequest) GetOutpoint() string {
 	return ""
 }
 
+func (x *GetUnrollStatusRequest) GetDetailed() bool {
+	if x != nil {
+		return x.Detailed
+	}
+	return false
+}
+
+// UnrollProgress describes materialization progress through the exit proof
+// tree. It is populated only for a detailed query against a live unroll job.
+type UnrollProgress struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// confirmed_txs is the number of proof transactions confirmed on-chain.
+	ConfirmedTxs uint32 `protobuf:"varint,1,opt,name=confirmed_txs,json=confirmedTxs,proto3" json:"confirmed_txs,omitempty"`
+	// in_flight_txs is the number of proof transactions broadcast but not yet
+	// observed confirmed.
+	InFlightTxs uint32 `protobuf:"varint,2,opt,name=in_flight_txs,json=inFlightTxs,proto3" json:"in_flight_txs,omitempty"`
+	// ready_txs is the number of proof transactions ready to broadcast now
+	// (all in-proof parents confirmed).
+	ReadyTxs uint32 `protobuf:"varint,3,opt,name=ready_txs,json=readyTxs,proto3" json:"ready_txs,omitempty"`
+	// blocked_txs is the number of proof transactions still waiting on an
+	// unconfirmed in-proof parent.
+	BlockedTxs uint32 `protobuf:"varint,4,opt,name=blocked_txs,json=blockedTxs,proto3" json:"blocked_txs,omitempty"`
+	// total_txs is the total number of transactions in the exit proof tree.
+	TotalTxs uint32 `protobuf:"varint,5,opt,name=total_txs,json=totalTxs,proto3" json:"total_txs,omitempty"`
+	// current_layer is the frontier layer index: the shallowest topological
+	// layer (roots first) that still holds an unconfirmed transaction. It
+	// equals total_layers once every proof node has confirmed.
+	CurrentLayer uint32 `protobuf:"varint,6,opt,name=current_layer,json=currentLayer,proto3" json:"current_layer,omitempty"`
+	// total_layers is the depth of the exit proof tree.
+	TotalLayers uint32 `protobuf:"varint,7,opt,name=total_layers,json=totalLayers,proto3" json:"total_layers,omitempty"`
+	// target_confirmed is true once the target VTXO transaction itself has
+	// confirmed on-chain.
+	TargetConfirmed bool `protobuf:"varint,8,opt,name=target_confirmed,json=targetConfirmed,proto3" json:"target_confirmed,omitempty"`
+	// all_proof_confirmed is true once every proof-tree transaction has
+	// confirmed, so only the CSV wait and final sweep remain.
+	AllProofConfirmed bool `protobuf:"varint,9,opt,name=all_proof_confirmed,json=allProofConfirmed,proto3" json:"all_proof_confirmed,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *UnrollProgress) Reset() {
+	*x = UnrollProgress{}
+	mi := &file_daemon_proto_msgTypes[101]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnrollProgress) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnrollProgress) ProtoMessage() {}
+
+func (x *UnrollProgress) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[101]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnrollProgress.ProtoReflect.Descriptor instead.
+func (*UnrollProgress) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{101}
+}
+
+func (x *UnrollProgress) GetConfirmedTxs() uint32 {
+	if x != nil {
+		return x.ConfirmedTxs
+	}
+	return 0
+}
+
+func (x *UnrollProgress) GetInFlightTxs() uint32 {
+	if x != nil {
+		return x.InFlightTxs
+	}
+	return 0
+}
+
+func (x *UnrollProgress) GetReadyTxs() uint32 {
+	if x != nil {
+		return x.ReadyTxs
+	}
+	return 0
+}
+
+func (x *UnrollProgress) GetBlockedTxs() uint32 {
+	if x != nil {
+		return x.BlockedTxs
+	}
+	return 0
+}
+
+func (x *UnrollProgress) GetTotalTxs() uint32 {
+	if x != nil {
+		return x.TotalTxs
+	}
+	return 0
+}
+
+func (x *UnrollProgress) GetCurrentLayer() uint32 {
+	if x != nil {
+		return x.CurrentLayer
+	}
+	return 0
+}
+
+func (x *UnrollProgress) GetTotalLayers() uint32 {
+	if x != nil {
+		return x.TotalLayers
+	}
+	return 0
+}
+
+func (x *UnrollProgress) GetTargetConfirmed() bool {
+	if x != nil {
+		return x.TargetConfirmed
+	}
+	return false
+}
+
+func (x *UnrollProgress) GetAllProofConfirmed() bool {
+	if x != nil {
+		return x.AllProofConfirmed
+	}
+	return false
+}
+
+// UnrollCSV describes the target's CSV maturity countdown. It is populated only
+// once the target transaction has confirmed.
+type UnrollCSV struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// target_confirm_height is the block height at which the target confirmed.
+	TargetConfirmHeight int32 `protobuf:"varint,1,opt,name=target_confirm_height,json=targetConfirmHeight,proto3" json:"target_confirm_height,omitempty"`
+	// maturity_height is the block height at which the target becomes
+	// timeout-spendable.
+	MaturityHeight int32 `protobuf:"varint,2,opt,name=maturity_height,json=maturityHeight,proto3" json:"maturity_height,omitempty"`
+	// blocks_remaining is how many blocks remain until CSV maturity.
+	BlocksRemaining int32 `protobuf:"varint,3,opt,name=blocks_remaining,json=blocksRemaining,proto3" json:"blocks_remaining,omitempty"`
+	// mature is true once the current height is at or past maturity.
+	Mature        bool `protobuf:"varint,4,opt,name=mature,proto3" json:"mature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnrollCSV) Reset() {
+	*x = UnrollCSV{}
+	mi := &file_daemon_proto_msgTypes[102]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnrollCSV) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnrollCSV) ProtoMessage() {}
+
+func (x *UnrollCSV) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[102]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnrollCSV.ProtoReflect.Descriptor instead.
+func (*UnrollCSV) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{102}
+}
+
+func (x *UnrollCSV) GetTargetConfirmHeight() int32 {
+	if x != nil {
+		return x.TargetConfirmHeight
+	}
+	return 0
+}
+
+func (x *UnrollCSV) GetMaturityHeight() int32 {
+	if x != nil {
+		return x.MaturityHeight
+	}
+	return 0
+}
+
+func (x *UnrollCSV) GetBlocksRemaining() int32 {
+	if x != nil {
+		return x.BlocksRemaining
+	}
+	return 0
+}
+
+func (x *UnrollCSV) GetMature() bool {
+	if x != nil {
+		return x.Mature
+	}
+	return false
+}
+
+// UnrollFees breaks down the on-chain cost of the exit. The CPFP total is
+// estimated from the current fee rate and the recovery-transaction count; the
+// sweep fee is the actual built-sweep fee once known, otherwise estimated.
+type UnrollFees struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// cpfp_fee_sat is the wallet-funded CPFP fee across every recovery
+	// transaction (estimated).
+	CpfpFeeSat int64 `protobuf:"varint,1,opt,name=cpfp_fee_sat,json=cpfpFeeSat,proto3" json:"cpfp_fee_sat,omitempty"`
+	// sweep_fee_sat is the fee the final sweep pays out of the VTXO value.
+	SweepFeeSat int64 `protobuf:"varint,2,opt,name=sweep_fee_sat,json=sweepFeeSat,proto3" json:"sweep_fee_sat,omitempty"`
+	// total_cost_sat is cpfp_fee_sat + sweep_fee_sat.
+	TotalCostSat int64 `protobuf:"varint,3,opt,name=total_cost_sat,json=totalCostSat,proto3" json:"total_cost_sat,omitempty"`
+	// vtxo_amount_sat is the value of the VTXO being exited.
+	VtxoAmountSat int64 `protobuf:"varint,4,opt,name=vtxo_amount_sat,json=vtxoAmountSat,proto3" json:"vtxo_amount_sat,omitempty"`
+	// net_recovered_sat is vtxo_amount_sat - sweep_fee_sat: the value that
+	// lands back in the wallet from the sweep.
+	NetRecoveredSat int64 `protobuf:"varint,5,opt,name=net_recovered_sat,json=netRecoveredSat,proto3" json:"net_recovered_sat,omitempty"`
+	// fee_rate_sat_vbyte is the fee rate used for the estimate.
+	FeeRateSatVbyte int64 `protobuf:"varint,6,opt,name=fee_rate_sat_vbyte,json=feeRateSatVbyte,proto3" json:"fee_rate_sat_vbyte,omitempty"`
+	// sweep_fee_actual is true when sweep_fee_sat is the real built-sweep fee
+	// rather than an estimate.
+	SweepFeeActual bool `protobuf:"varint,7,opt,name=sweep_fee_actual,json=sweepFeeActual,proto3" json:"sweep_fee_actual,omitempty"`
+	// spent_so_far_sat is the estimated on-chain fee already committed at this
+	// point in the exit: CPFP for the confirmed and in-flight recovery
+	// transactions, plus the sweep fee once the sweep is broadcast. It is an
+	// estimate derived from the per-transaction cost model, not a realized
+	// total; total_cost_sat remains the projected cost of the whole exit.
+	SpentSoFarSat int64 `protobuf:"varint,8,opt,name=spent_so_far_sat,json=spentSoFarSat,proto3" json:"spent_so_far_sat,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnrollFees) Reset() {
+	*x = UnrollFees{}
+	mi := &file_daemon_proto_msgTypes[103]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnrollFees) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnrollFees) ProtoMessage() {}
+
+func (x *UnrollFees) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[103]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnrollFees.ProtoReflect.Descriptor instead.
+func (*UnrollFees) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{103}
+}
+
+func (x *UnrollFees) GetCpfpFeeSat() int64 {
+	if x != nil {
+		return x.CpfpFeeSat
+	}
+	return 0
+}
+
+func (x *UnrollFees) GetSweepFeeSat() int64 {
+	if x != nil {
+		return x.SweepFeeSat
+	}
+	return 0
+}
+
+func (x *UnrollFees) GetTotalCostSat() int64 {
+	if x != nil {
+		return x.TotalCostSat
+	}
+	return 0
+}
+
+func (x *UnrollFees) GetVtxoAmountSat() int64 {
+	if x != nil {
+		return x.VtxoAmountSat
+	}
+	return 0
+}
+
+func (x *UnrollFees) GetNetRecoveredSat() int64 {
+	if x != nil {
+		return x.NetRecoveredSat
+	}
+	return 0
+}
+
+func (x *UnrollFees) GetFeeRateSatVbyte() int64 {
+	if x != nil {
+		return x.FeeRateSatVbyte
+	}
+	return 0
+}
+
+func (x *UnrollFees) GetSweepFeeActual() bool {
+	if x != nil {
+		return x.SweepFeeActual
+	}
+	return false
+}
+
+func (x *UnrollFees) GetSpentSoFarSat() int64 {
+	if x != nil {
+		return x.SpentSoFarSat
+	}
+	return 0
+}
+
 type GetUnrollStatusResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// found is true if an unroll job exists for the requested outpoint.
@@ -8391,14 +8722,33 @@ type GetUnrollStatusResponse struct {
 	SweepTxid string `protobuf:"bytes,3,opt,name=sweep_txid,json=sweepTxid,proto3" json:"sweep_txid,omitempty"`
 	// last_error contains the failure reason if the job is in FAILED
 	// status.
-	LastError     string `protobuf:"bytes,4,opt,name=last_error,json=lastError,proto3" json:"last_error,omitempty"`
+	LastError string `protobuf:"bytes,4,opt,name=last_error,json=lastError,proto3" json:"last_error,omitempty"`
+	// phase_detail is a human-readable one-line description of the current
+	// phase, e.g. "materializing layer 2 of 4 (3/7 txs confirmed)". Set only
+	// on a detailed query.
+	PhaseDetail string `protobuf:"bytes,5,opt,name=phase_detail,json=phaseDetail,proto3" json:"phase_detail,omitempty"`
+	// progress is the tree materialization progress. Set only on a detailed
+	// query against a live job.
+	Progress *UnrollProgress `protobuf:"bytes,6,opt,name=progress,proto3" json:"progress,omitempty"`
+	// csv is the CSV maturity countdown. Set only on a detailed query, once
+	// the target has confirmed.
+	Csv *UnrollCSV `protobuf:"bytes,7,opt,name=csv,proto3" json:"csv,omitempty"`
+	// fees is the on-chain cost breakdown for the exit. Set only on a detailed
+	// query.
+	Fees *UnrollFees `protobuf:"bytes,8,opt,name=fees,proto3" json:"fees,omitempty"`
+	// best_case_blocks_remaining is the optimistic block count until a
+	// confirmed sweep. Set only on a detailed query.
+	BestCaseBlocksRemaining int32 `protobuf:"varint,9,opt,name=best_case_blocks_remaining,json=bestCaseBlocksRemaining,proto3" json:"best_case_blocks_remaining,omitempty"`
+	// current_height is the best block height the unroll actor has observed.
+	// Set only on a detailed query against a live job.
+	CurrentHeight int32 `protobuf:"varint,10,opt,name=current_height,json=currentHeight,proto3" json:"current_height,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetUnrollStatusResponse) Reset() {
 	*x = GetUnrollStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[101]
+	mi := &file_daemon_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8410,7 +8760,7 @@ func (x *GetUnrollStatusResponse) String() string {
 func (*GetUnrollStatusResponse) ProtoMessage() {}
 
 func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[101]
+	mi := &file_daemon_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8423,7 +8773,7 @@ func (x *GetUnrollStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUnrollStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetUnrollStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{101}
+	return file_daemon_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *GetUnrollStatusResponse) GetFound() bool {
@@ -8452,6 +8802,48 @@ func (x *GetUnrollStatusResponse) GetLastError() string {
 		return x.LastError
 	}
 	return ""
+}
+
+func (x *GetUnrollStatusResponse) GetPhaseDetail() string {
+	if x != nil {
+		return x.PhaseDetail
+	}
+	return ""
+}
+
+func (x *GetUnrollStatusResponse) GetProgress() *UnrollProgress {
+	if x != nil {
+		return x.Progress
+	}
+	return nil
+}
+
+func (x *GetUnrollStatusResponse) GetCsv() *UnrollCSV {
+	if x != nil {
+		return x.Csv
+	}
+	return nil
+}
+
+func (x *GetUnrollStatusResponse) GetFees() *UnrollFees {
+	if x != nil {
+		return x.Fees
+	}
+	return nil
+}
+
+func (x *GetUnrollStatusResponse) GetBestCaseBlocksRemaining() int32 {
+	if x != nil {
+		return x.BestCaseBlocksRemaining
+	}
+	return 0
+}
+
+func (x *GetUnrollStatusResponse) GetCurrentHeight() int32 {
+	if x != nil {
+		return x.CurrentHeight
+	}
+	return 0
 }
 
 type ArmVHTLCRecoveryRequest struct {
@@ -8505,7 +8897,7 @@ type ArmVHTLCRecoveryRequest struct {
 
 func (x *ArmVHTLCRecoveryRequest) Reset() {
 	*x = ArmVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[102]
+	mi := &file_daemon_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8517,7 +8909,7 @@ func (x *ArmVHTLCRecoveryRequest) String() string {
 func (*ArmVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[102]
+	mi := &file_daemon_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8530,7 +8922,7 @@ func (x *ArmVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{102}
+	return file_daemon_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *ArmVHTLCRecoveryRequest) GetRequestId() string {
@@ -8673,7 +9065,7 @@ type ArmVHTLCRecoveryResponse struct {
 
 func (x *ArmVHTLCRecoveryResponse) Reset() {
 	*x = ArmVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[103]
+	mi := &file_daemon_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8685,7 +9077,7 @@ func (x *ArmVHTLCRecoveryResponse) String() string {
 func (*ArmVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[103]
+	mi := &file_daemon_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8698,7 +9090,7 @@ func (x *ArmVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArmVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*ArmVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{103}
+	return file_daemon_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *ArmVHTLCRecoveryResponse) GetRecoveryId() string {
@@ -8738,7 +9130,7 @@ type EscalateVHTLCRecoveryRequest struct {
 
 func (x *EscalateVHTLCRecoveryRequest) Reset() {
 	*x = EscalateVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[104]
+	mi := &file_daemon_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8750,7 +9142,7 @@ func (x *EscalateVHTLCRecoveryRequest) String() string {
 func (*EscalateVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[104]
+	mi := &file_daemon_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8763,7 +9155,7 @@ func (x *EscalateVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{104}
+	return file_daemon_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *EscalateVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -8797,7 +9189,7 @@ type EscalateVHTLCRecoveryResponse struct {
 
 func (x *EscalateVHTLCRecoveryResponse) Reset() {
 	*x = EscalateVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[105]
+	mi := &file_daemon_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8809,7 +9201,7 @@ func (x *EscalateVHTLCRecoveryResponse) String() string {
 func (*EscalateVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[105]
+	mi := &file_daemon_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8822,7 +9214,7 @@ func (x *EscalateVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EscalateVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*EscalateVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{105}
+	return file_daemon_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *EscalateVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -8846,7 +9238,7 @@ type CancelVHTLCRecoveryRequest struct {
 
 func (x *CancelVHTLCRecoveryRequest) Reset() {
 	*x = CancelVHTLCRecoveryRequest{}
-	mi := &file_daemon_proto_msgTypes[106]
+	mi := &file_daemon_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8858,7 +9250,7 @@ func (x *CancelVHTLCRecoveryRequest) String() string {
 func (*CancelVHTLCRecoveryRequest) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[106]
+	mi := &file_daemon_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8871,7 +9263,7 @@ func (x *CancelVHTLCRecoveryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryRequest.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{106}
+	return file_daemon_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *CancelVHTLCRecoveryRequest) GetRecoveryId() string {
@@ -8905,7 +9297,7 @@ type CancelVHTLCRecoveryResponse struct {
 
 func (x *CancelVHTLCRecoveryResponse) Reset() {
 	*x = CancelVHTLCRecoveryResponse{}
-	mi := &file_daemon_proto_msgTypes[107]
+	mi := &file_daemon_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8917,7 +9309,7 @@ func (x *CancelVHTLCRecoveryResponse) String() string {
 func (*CancelVHTLCRecoveryResponse) ProtoMessage() {}
 
 func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[107]
+	mi := &file_daemon_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8930,7 +9322,7 @@ func (x *CancelVHTLCRecoveryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelVHTLCRecoveryResponse.ProtoReflect.Descriptor instead.
 func (*CancelVHTLCRecoveryResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{107}
+	return file_daemon_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *CancelVHTLCRecoveryResponse) GetStatus() *VHTLCRecoveryStatus {
@@ -8950,7 +9342,7 @@ type GetVHTLCRecoveryStatusRequest struct {
 
 func (x *GetVHTLCRecoveryStatusRequest) Reset() {
 	*x = GetVHTLCRecoveryStatusRequest{}
-	mi := &file_daemon_proto_msgTypes[108]
+	mi := &file_daemon_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8962,7 +9354,7 @@ func (x *GetVHTLCRecoveryStatusRequest) String() string {
 func (*GetVHTLCRecoveryStatusRequest) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[108]
+	mi := &file_daemon_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8975,7 +9367,7 @@ func (x *GetVHTLCRecoveryStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{108}
+	return file_daemon_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *GetVHTLCRecoveryStatusRequest) GetRecoveryId() string {
@@ -8997,7 +9389,7 @@ type GetVHTLCRecoveryStatusResponse struct {
 
 func (x *GetVHTLCRecoveryStatusResponse) Reset() {
 	*x = GetVHTLCRecoveryStatusResponse{}
-	mi := &file_daemon_proto_msgTypes[109]
+	mi := &file_daemon_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9009,7 +9401,7 @@ func (x *GetVHTLCRecoveryStatusResponse) String() string {
 func (*GetVHTLCRecoveryStatusResponse) ProtoMessage() {}
 
 func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[109]
+	mi := &file_daemon_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9022,7 +9414,7 @@ func (x *GetVHTLCRecoveryStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVHTLCRecoveryStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetVHTLCRecoveryStatusResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{109}
+	return file_daemon_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *GetVHTLCRecoveryStatusResponse) GetFound() bool {
@@ -9049,7 +9441,7 @@ type ListVHTLCRecoveriesRequest struct {
 
 func (x *ListVHTLCRecoveriesRequest) Reset() {
 	*x = ListVHTLCRecoveriesRequest{}
-	mi := &file_daemon_proto_msgTypes[110]
+	mi := &file_daemon_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9061,7 +9453,7 @@ func (x *ListVHTLCRecoveriesRequest) String() string {
 func (*ListVHTLCRecoveriesRequest) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[110]
+	mi := &file_daemon_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9074,7 +9466,7 @@ func (x *ListVHTLCRecoveriesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesRequest.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesRequest) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{110}
+	return file_daemon_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *ListVHTLCRecoveriesRequest) GetIncludeTerminal() bool {
@@ -9094,7 +9486,7 @@ type ListVHTLCRecoveriesResponse struct {
 
 func (x *ListVHTLCRecoveriesResponse) Reset() {
 	*x = ListVHTLCRecoveriesResponse{}
-	mi := &file_daemon_proto_msgTypes[111]
+	mi := &file_daemon_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9106,7 +9498,7 @@ func (x *ListVHTLCRecoveriesResponse) String() string {
 func (*ListVHTLCRecoveriesResponse) ProtoMessage() {}
 
 func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[111]
+	mi := &file_daemon_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9119,7 +9511,7 @@ func (x *ListVHTLCRecoveriesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVHTLCRecoveriesResponse.ProtoReflect.Descriptor instead.
 func (*ListVHTLCRecoveriesResponse) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{111}
+	return file_daemon_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *ListVHTLCRecoveriesResponse) GetStatuses() []*VHTLCRecoveryStatus {
@@ -9194,7 +9586,7 @@ type VHTLCRecoveryStatus struct {
 
 func (x *VHTLCRecoveryStatus) Reset() {
 	*x = VHTLCRecoveryStatus{}
-	mi := &file_daemon_proto_msgTypes[112]
+	mi := &file_daemon_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9206,7 +9598,7 @@ func (x *VHTLCRecoveryStatus) String() string {
 func (*VHTLCRecoveryStatus) ProtoMessage() {}
 
 func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_daemon_proto_msgTypes[112]
+	mi := &file_daemon_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9219,7 +9611,7 @@ func (x *VHTLCRecoveryStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VHTLCRecoveryStatus.ProtoReflect.Descriptor instead.
 func (*VHTLCRecoveryStatus) Descriptor() ([]byte, []int) {
-	return file_daemon_proto_rawDescGZIP(), []int{112}
+	return file_daemon_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *VHTLCRecoveryStatus) GetRecoveryId() string {
@@ -9937,16 +10329,51 @@ const file_daemon_proto_rawDesc = "" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\"E\n" +
 	"\x0eUnrollResponse\x12\x18\n" +
 	"\acreated\x18\x01 \x01(\bR\acreated\x12\x19\n" +
-	"\bactor_id\x18\x02 \x01(\tR\aactorId\"4\n" +
+	"\bactor_id\x18\x02 \x01(\tR\aactorId\"P\n" +
 	"\x16GetUnrollStatusRequest\x12\x1a\n" +
-	"\boutpoint\x18\x01 \x01(\tR\boutpoint\"\xa1\x01\n" +
+	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1a\n" +
+	"\bdetailed\x18\x02 \x01(\bR\bdetailed\"\xd7\x02\n" +
+	"\x0eUnrollProgress\x12#\n" +
+	"\rconfirmed_txs\x18\x01 \x01(\rR\fconfirmedTxs\x12\"\n" +
+	"\rin_flight_txs\x18\x02 \x01(\rR\vinFlightTxs\x12\x1b\n" +
+	"\tready_txs\x18\x03 \x01(\rR\breadyTxs\x12\x1f\n" +
+	"\vblocked_txs\x18\x04 \x01(\rR\n" +
+	"blockedTxs\x12\x1b\n" +
+	"\ttotal_txs\x18\x05 \x01(\rR\btotalTxs\x12#\n" +
+	"\rcurrent_layer\x18\x06 \x01(\rR\fcurrentLayer\x12!\n" +
+	"\ftotal_layers\x18\a \x01(\rR\vtotalLayers\x12)\n" +
+	"\x10target_confirmed\x18\b \x01(\bR\x0ftargetConfirmed\x12.\n" +
+	"\x13all_proof_confirmed\x18\t \x01(\bR\x11allProofConfirmed\"\xab\x01\n" +
+	"\tUnrollCSV\x122\n" +
+	"\x15target_confirm_height\x18\x01 \x01(\x05R\x13targetConfirmHeight\x12'\n" +
+	"\x0fmaturity_height\x18\x02 \x01(\x05R\x0ematurityHeight\x12)\n" +
+	"\x10blocks_remaining\x18\x03 \x01(\x05R\x0fblocksRemaining\x12\x16\n" +
+	"\x06mature\x18\x04 \x01(\bR\x06mature\"\xcc\x02\n" +
+	"\n" +
+	"UnrollFees\x12 \n" +
+	"\fcpfp_fee_sat\x18\x01 \x01(\x03R\n" +
+	"cpfpFeeSat\x12\"\n" +
+	"\rsweep_fee_sat\x18\x02 \x01(\x03R\vsweepFeeSat\x12$\n" +
+	"\x0etotal_cost_sat\x18\x03 \x01(\x03R\ftotalCostSat\x12&\n" +
+	"\x0fvtxo_amount_sat\x18\x04 \x01(\x03R\rvtxoAmountSat\x12*\n" +
+	"\x11net_recovered_sat\x18\x05 \x01(\x03R\x0fnetRecoveredSat\x12+\n" +
+	"\x12fee_rate_sat_vbyte\x18\x06 \x01(\x03R\x0ffeeRateSatVbyte\x12(\n" +
+	"\x10sweep_fee_actual\x18\a \x01(\bR\x0esweepFeeActual\x12'\n" +
+	"\x10spent_so_far_sat\x18\b \x01(\x03R\rspentSoFarSat\"\xb2\x03\n" +
 	"\x17GetUnrollStatusResponse\x12\x14\n" +
 	"\x05found\x18\x01 \x01(\bR\x05found\x122\n" +
 	"\x06status\x18\x02 \x01(\x0e2\x1a.daemonrpc.UnrollJobStatusR\x06status\x12\x1d\n" +
 	"\n" +
 	"sweep_txid\x18\x03 \x01(\tR\tsweepTxid\x12\x1d\n" +
 	"\n" +
-	"last_error\x18\x04 \x01(\tR\tlastError\"\xd8\x06\n" +
+	"last_error\x18\x04 \x01(\tR\tlastError\x12!\n" +
+	"\fphase_detail\x18\x05 \x01(\tR\vphaseDetail\x125\n" +
+	"\bprogress\x18\x06 \x01(\v2\x19.daemonrpc.UnrollProgressR\bprogress\x12&\n" +
+	"\x03csv\x18\a \x01(\v2\x14.daemonrpc.UnrollCSVR\x03csv\x12)\n" +
+	"\x04fees\x18\b \x01(\v2\x15.daemonrpc.UnrollFeesR\x04fees\x12;\n" +
+	"\x1abest_case_blocks_remaining\x18\t \x01(\x05R\x17bestCaseBlocksRemaining\x12%\n" +
+	"\x0ecurrent_height\x18\n" +
+	" \x01(\x05R\rcurrentHeight\"\xd8\x06\n" +
 	"\x17ArmVHTLCRecoveryRequest\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12\x17\n" +
@@ -10182,7 +10609,7 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 114)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 117)
 var file_daemon_proto_goTypes = []any{
 	(WalletState)(0),                                               // 0: daemonrpc.WalletState
 	(VTXOStatus)(0),                                                // 1: daemonrpc.VTXOStatus
@@ -10296,19 +10723,22 @@ var file_daemon_proto_goTypes = []any{
 	(*UnrollRequest)(nil),                                          // 109: daemonrpc.UnrollRequest
 	(*UnrollResponse)(nil),                                         // 110: daemonrpc.UnrollResponse
 	(*GetUnrollStatusRequest)(nil),                                 // 111: daemonrpc.GetUnrollStatusRequest
-	(*GetUnrollStatusResponse)(nil),                                // 112: daemonrpc.GetUnrollStatusResponse
-	(*ArmVHTLCRecoveryRequest)(nil),                                // 113: daemonrpc.ArmVHTLCRecoveryRequest
-	(*ArmVHTLCRecoveryResponse)(nil),                               // 114: daemonrpc.ArmVHTLCRecoveryResponse
-	(*EscalateVHTLCRecoveryRequest)(nil),                           // 115: daemonrpc.EscalateVHTLCRecoveryRequest
-	(*EscalateVHTLCRecoveryResponse)(nil),                          // 116: daemonrpc.EscalateVHTLCRecoveryResponse
-	(*CancelVHTLCRecoveryRequest)(nil),                             // 117: daemonrpc.CancelVHTLCRecoveryRequest
-	(*CancelVHTLCRecoveryResponse)(nil),                            // 118: daemonrpc.CancelVHTLCRecoveryResponse
-	(*GetVHTLCRecoveryStatusRequest)(nil),                          // 119: daemonrpc.GetVHTLCRecoveryStatusRequest
-	(*GetVHTLCRecoveryStatusResponse)(nil),                         // 120: daemonrpc.GetVHTLCRecoveryStatusResponse
-	(*ListVHTLCRecoveriesRequest)(nil),                             // 121: daemonrpc.ListVHTLCRecoveriesRequest
-	(*ListVHTLCRecoveriesResponse)(nil),                            // 122: daemonrpc.ListVHTLCRecoveriesResponse
-	(*VHTLCRecoveryStatus)(nil),                                    // 123: daemonrpc.VHTLCRecoveryStatus
-	nil,                                                            // 124: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	(*UnrollProgress)(nil),                                         // 112: daemonrpc.UnrollProgress
+	(*UnrollCSV)(nil),                                              // 113: daemonrpc.UnrollCSV
+	(*UnrollFees)(nil),                                             // 114: daemonrpc.UnrollFees
+	(*GetUnrollStatusResponse)(nil),                                // 115: daemonrpc.GetUnrollStatusResponse
+	(*ArmVHTLCRecoveryRequest)(nil),                                // 116: daemonrpc.ArmVHTLCRecoveryRequest
+	(*ArmVHTLCRecoveryResponse)(nil),                               // 117: daemonrpc.ArmVHTLCRecoveryResponse
+	(*EscalateVHTLCRecoveryRequest)(nil),                           // 118: daemonrpc.EscalateVHTLCRecoveryRequest
+	(*EscalateVHTLCRecoveryResponse)(nil),                          // 119: daemonrpc.EscalateVHTLCRecoveryResponse
+	(*CancelVHTLCRecoveryRequest)(nil),                             // 120: daemonrpc.CancelVHTLCRecoveryRequest
+	(*CancelVHTLCRecoveryResponse)(nil),                            // 121: daemonrpc.CancelVHTLCRecoveryResponse
+	(*GetVHTLCRecoveryStatusRequest)(nil),                          // 122: daemonrpc.GetVHTLCRecoveryStatusRequest
+	(*GetVHTLCRecoveryStatusResponse)(nil),                         // 123: daemonrpc.GetVHTLCRecoveryStatusResponse
+	(*ListVHTLCRecoveriesRequest)(nil),                             // 124: daemonrpc.ListVHTLCRecoveriesRequest
+	(*ListVHTLCRecoveriesResponse)(nil),                            // 125: daemonrpc.ListVHTLCRecoveriesResponse
+	(*VHTLCRecoveryStatus)(nil),                                    // 126: daemonrpc.VHTLCRecoveryStatus
+	nil,                                                            // 127: daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
 	0,   // 0: daemonrpc.GetInfoResponse.wallet_state:type_name -> daemonrpc.WalletState
@@ -10342,7 +10772,7 @@ var file_daemon_proto_depIdxs = []int32{
 	69,  // 28: daemonrpc.SubmitForfeitParticipantSignaturesRequest.signatures:type_name -> daemonrpc.ForfeitParticipantSignature
 	59,  // 29: daemonrpc.LeaveVTXOsRequest.outpoints:type_name -> daemonrpc.OutpointSelection
 	72,  // 30: daemonrpc.LeaveVTXOsRequest.default_destination:type_name -> daemonrpc.LeaveDestination
-	124, // 31: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
+	127, // 31: daemonrpc.LeaveVTXOsRequest.destinations:type_name -> daemonrpc.LeaveVTXOsRequest.DestinationsEntry
 	72,  // 32: daemonrpc.SendOnChainRequest.destination:type_name -> daemonrpc.LeaveDestination
 	82,  // 33: daemonrpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> daemonrpc.BoardingSweepOutput
 	85,  // 34: daemonrpc.BoardingSweep.inputs:type_name -> daemonrpc.BoardingSweepInput
@@ -10362,113 +10792,116 @@ var file_daemon_proto_depIdxs = []int32{
 	104, // 48: daemonrpc.GetFeeHistoryResponse.entries:type_name -> daemonrpc.FeeHistoryEntry
 	107, // 49: daemonrpc.ListTransactionsResponse.transactions:type_name -> daemonrpc.TransactionHistoryEntry
 	7,   // 50: daemonrpc.GetUnrollStatusResponse.status:type_name -> daemonrpc.UnrollJobStatus
-	8,   // 51: daemonrpc.ArmVHTLCRecoveryRequest.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
-	9,   // 52: daemonrpc.ArmVHTLCRecoveryRequest.action:type_name -> daemonrpc.VHTLCRecoveryAction
-	123, // 53: daemonrpc.ArmVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	123, // 54: daemonrpc.EscalateVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	123, // 55: daemonrpc.CancelVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	123, // 56: daemonrpc.GetVHTLCRecoveryStatusResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
-	123, // 57: daemonrpc.ListVHTLCRecoveriesResponse.statuses:type_name -> daemonrpc.VHTLCRecoveryStatus
-	8,   // 58: daemonrpc.VHTLCRecoveryStatus.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
-	9,   // 59: daemonrpc.VHTLCRecoveryStatus.action:type_name -> daemonrpc.VHTLCRecoveryAction
-	10,  // 60: daemonrpc.VHTLCRecoveryStatus.state:type_name -> daemonrpc.VHTLCRecoveryState
-	7,   // 61: daemonrpc.VHTLCRecoveryStatus.unroll_status:type_name -> daemonrpc.UnrollJobStatus
-	72,  // 62: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
-	11,  // 63: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
-	14,  // 64: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
-	16,  // 65: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
-	18,  // 66: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
-	20,  // 67: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
-	24,  // 68: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
-	26,  // 69: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
-	28,  // 70: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
-	30,  // 71: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
-	32,  // 72: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
-	34,  // 73: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
-	36,  // 74: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
-	38,  // 75: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
-	40,  // 76: daemonrpc.DaemonService.GetVTXOExpiryInfo:input_type -> daemonrpc.GetVTXOExpiryInfoRequest
-	42,  // 77: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
-	45,  // 78: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
-	47,  // 79: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
-	51,  // 80: daemonrpc.DaemonService.PrepareOOR:input_type -> daemonrpc.PrepareOORRequest
-	54,  // 81: daemonrpc.DaemonService.SignOORCustomInput:input_type -> daemonrpc.SignOORCustomInputRequest
-	56,  // 82: daemonrpc.DaemonService.SignVTXOForfeit:input_type -> daemonrpc.SignVTXOForfeitRequest
-	60,  // 83: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
-	64,  // 84: daemonrpc.DaemonService.RefreshCustomVTXOs:input_type -> daemonrpc.RefreshCustomVTXOsRequest
-	67,  // 85: daemonrpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:input_type -> daemonrpc.ListPendingForfeitParticipantSignatureRequestsRequest
-	70,  // 86: daemonrpc.DaemonService.SubmitForfeitParticipantSignatures:input_type -> daemonrpc.SubmitForfeitParticipantSignaturesRequest
-	73,  // 87: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
-	75,  // 88: daemonrpc.DaemonService.SendOnChain:input_type -> daemonrpc.SendOnChainRequest
-	77,  // 89: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
-	79,  // 90: daemonrpc.DaemonService.JoinNextRound:input_type -> daemonrpc.JoinNextRoundRequest
-	81,  // 91: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
-	84,  // 92: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
-	90,  // 93: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
-	91,  // 94: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
-	94,  // 95: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
-	97,  // 96: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
-	99,  // 97: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
-	101, // 98: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
-	103, // 99: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
-	106, // 100: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
-	109, // 101: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
-	111, // 102: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
-	113, // 103: daemonrpc.DaemonService.ArmVHTLCRecovery:input_type -> daemonrpc.ArmVHTLCRecoveryRequest
-	115, // 104: daemonrpc.DaemonService.EscalateVHTLCRecovery:input_type -> daemonrpc.EscalateVHTLCRecoveryRequest
-	117, // 105: daemonrpc.DaemonService.CancelVHTLCRecovery:input_type -> daemonrpc.CancelVHTLCRecoveryRequest
-	119, // 106: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> daemonrpc.GetVHTLCRecoveryStatusRequest
-	121, // 107: daemonrpc.DaemonService.ListVHTLCRecoveries:input_type -> daemonrpc.ListVHTLCRecoveriesRequest
-	12,  // 108: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
-	15,  // 109: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
-	17,  // 110: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
-	19,  // 111: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
-	21,  // 112: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
-	25,  // 113: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
-	27,  // 114: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
-	29,  // 115: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
-	31,  // 116: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
-	33,  // 117: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
-	35,  // 118: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
-	37,  // 119: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
-	39,  // 120: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
-	41,  // 121: daemonrpc.DaemonService.GetVTXOExpiryInfo:output_type -> daemonrpc.GetVTXOExpiryInfoResponse
-	43,  // 122: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
-	46,  // 123: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
-	50,  // 124: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
-	53,  // 125: daemonrpc.DaemonService.PrepareOOR:output_type -> daemonrpc.PrepareOORResponse
-	55,  // 126: daemonrpc.DaemonService.SignOORCustomInput:output_type -> daemonrpc.SignOORCustomInputResponse
-	57,  // 127: daemonrpc.DaemonService.SignVTXOForfeit:output_type -> daemonrpc.SignVTXOForfeitResponse
-	61,  // 128: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
-	65,  // 129: daemonrpc.DaemonService.RefreshCustomVTXOs:output_type -> daemonrpc.RefreshCustomVTXOsResponse
-	68,  // 130: daemonrpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:output_type -> daemonrpc.ListPendingForfeitParticipantSignatureRequestsResponse
-	71,  // 131: daemonrpc.DaemonService.SubmitForfeitParticipantSignatures:output_type -> daemonrpc.SubmitForfeitParticipantSignaturesResponse
-	74,  // 132: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
-	76,  // 133: daemonrpc.DaemonService.SendOnChain:output_type -> daemonrpc.SendOnChainResponse
-	78,  // 134: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
-	80,  // 135: daemonrpc.DaemonService.JoinNextRound:output_type -> daemonrpc.JoinNextRoundResponse
-	83,  // 136: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
-	87,  // 137: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
-	93,  // 138: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
-	92,  // 139: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
-	95,  // 140: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
-	98,  // 141: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
-	100, // 142: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
-	102, // 143: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
-	105, // 144: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
-	108, // 145: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
-	110, // 146: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
-	112, // 147: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
-	114, // 148: daemonrpc.DaemonService.ArmVHTLCRecovery:output_type -> daemonrpc.ArmVHTLCRecoveryResponse
-	116, // 149: daemonrpc.DaemonService.EscalateVHTLCRecovery:output_type -> daemonrpc.EscalateVHTLCRecoveryResponse
-	118, // 150: daemonrpc.DaemonService.CancelVHTLCRecovery:output_type -> daemonrpc.CancelVHTLCRecoveryResponse
-	120, // 151: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> daemonrpc.GetVHTLCRecoveryStatusResponse
-	122, // 152: daemonrpc.DaemonService.ListVHTLCRecoveries:output_type -> daemonrpc.ListVHTLCRecoveriesResponse
-	108, // [108:153] is the sub-list for method output_type
-	63,  // [63:108] is the sub-list for method input_type
-	63,  // [63:63] is the sub-list for extension type_name
-	63,  // [63:63] is the sub-list for extension extendee
-	0,   // [0:63] is the sub-list for field type_name
+	112, // 51: daemonrpc.GetUnrollStatusResponse.progress:type_name -> daemonrpc.UnrollProgress
+	113, // 52: daemonrpc.GetUnrollStatusResponse.csv:type_name -> daemonrpc.UnrollCSV
+	114, // 53: daemonrpc.GetUnrollStatusResponse.fees:type_name -> daemonrpc.UnrollFees
+	8,   // 54: daemonrpc.ArmVHTLCRecoveryRequest.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
+	9,   // 55: daemonrpc.ArmVHTLCRecoveryRequest.action:type_name -> daemonrpc.VHTLCRecoveryAction
+	126, // 56: daemonrpc.ArmVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	126, // 57: daemonrpc.EscalateVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	126, // 58: daemonrpc.CancelVHTLCRecoveryResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	126, // 59: daemonrpc.GetVHTLCRecoveryStatusResponse.status:type_name -> daemonrpc.VHTLCRecoveryStatus
+	126, // 60: daemonrpc.ListVHTLCRecoveriesResponse.statuses:type_name -> daemonrpc.VHTLCRecoveryStatus
+	8,   // 61: daemonrpc.VHTLCRecoveryStatus.direction:type_name -> daemonrpc.VHTLCRecoveryDirection
+	9,   // 62: daemonrpc.VHTLCRecoveryStatus.action:type_name -> daemonrpc.VHTLCRecoveryAction
+	10,  // 63: daemonrpc.VHTLCRecoveryStatus.state:type_name -> daemonrpc.VHTLCRecoveryState
+	7,   // 64: daemonrpc.VHTLCRecoveryStatus.unroll_status:type_name -> daemonrpc.UnrollJobStatus
+	72,  // 65: daemonrpc.LeaveVTXOsRequest.DestinationsEntry.value:type_name -> daemonrpc.LeaveDestination
+	11,  // 66: daemonrpc.DaemonService.GetInfo:input_type -> daemonrpc.GetInfoRequest
+	14,  // 67: daemonrpc.DaemonService.GenSeed:input_type -> daemonrpc.GenSeedRequest
+	16,  // 68: daemonrpc.DaemonService.InitWallet:input_type -> daemonrpc.InitWalletRequest
+	18,  // 69: daemonrpc.DaemonService.UnlockWallet:input_type -> daemonrpc.UnlockWalletRequest
+	20,  // 70: daemonrpc.DaemonService.GetBalance:input_type -> daemonrpc.GetBalanceRequest
+	24,  // 71: daemonrpc.DaemonService.ListVTXOs:input_type -> daemonrpc.ListVTXOsRequest
+	26,  // 72: daemonrpc.DaemonService.NewAddress:input_type -> daemonrpc.NewAddressRequest
+	28,  // 73: daemonrpc.DaemonService.NewReceiveScript:input_type -> daemonrpc.NewReceiveScriptRequest
+	30,  // 74: daemonrpc.DaemonService.ReceiveAuthKey:input_type -> daemonrpc.ReceiveAuthKeyRequest
+	32,  // 75: daemonrpc.DaemonService.SignReceiveAuthMessage:input_type -> daemonrpc.SignReceiveAuthMessageRequest
+	34,  // 76: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:input_type -> daemonrpc.SignReceiveAuthMessageCompactRequest
+	36,  // 77: daemonrpc.DaemonService.ReceiveAuthECDH:input_type -> daemonrpc.ReceiveAuthECDHRequest
+	38,  // 78: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:input_type -> daemonrpc.GetIndexedVTXOByPkScriptRequest
+	40,  // 79: daemonrpc.DaemonService.GetVTXOExpiryInfo:input_type -> daemonrpc.GetVTXOExpiryInfoRequest
+	42,  // 80: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:input_type -> daemonrpc.GetIndexedOORSessionByTxidRequest
+	45,  // 81: daemonrpc.DaemonService.SendVTXO:input_type -> daemonrpc.SendVTXORequest
+	47,  // 82: daemonrpc.DaemonService.SendOOR:input_type -> daemonrpc.SendOORRequest
+	51,  // 83: daemonrpc.DaemonService.PrepareOOR:input_type -> daemonrpc.PrepareOORRequest
+	54,  // 84: daemonrpc.DaemonService.SignOORCustomInput:input_type -> daemonrpc.SignOORCustomInputRequest
+	56,  // 85: daemonrpc.DaemonService.SignVTXOForfeit:input_type -> daemonrpc.SignVTXOForfeitRequest
+	60,  // 86: daemonrpc.DaemonService.RefreshVTXOs:input_type -> daemonrpc.RefreshVTXOsRequest
+	64,  // 87: daemonrpc.DaemonService.RefreshCustomVTXOs:input_type -> daemonrpc.RefreshCustomVTXOsRequest
+	67,  // 88: daemonrpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:input_type -> daemonrpc.ListPendingForfeitParticipantSignatureRequestsRequest
+	70,  // 89: daemonrpc.DaemonService.SubmitForfeitParticipantSignatures:input_type -> daemonrpc.SubmitForfeitParticipantSignaturesRequest
+	73,  // 90: daemonrpc.DaemonService.LeaveVTXOs:input_type -> daemonrpc.LeaveVTXOsRequest
+	75,  // 91: daemonrpc.DaemonService.SendOnChain:input_type -> daemonrpc.SendOnChainRequest
+	77,  // 92: daemonrpc.DaemonService.Board:input_type -> daemonrpc.BoardRequest
+	79,  // 93: daemonrpc.DaemonService.JoinNextRound:input_type -> daemonrpc.JoinNextRoundRequest
+	81,  // 94: daemonrpc.DaemonService.SweepBoardingUTXOs:input_type -> daemonrpc.SweepBoardingUTXOsRequest
+	84,  // 95: daemonrpc.DaemonService.ListBoardingSweeps:input_type -> daemonrpc.ListBoardingSweepsRequest
+	90,  // 96: daemonrpc.DaemonService.ListRounds:input_type -> daemonrpc.ListRoundsRequest
+	91,  // 97: daemonrpc.DaemonService.GetRound:input_type -> daemonrpc.GetRoundRequest
+	94,  // 98: daemonrpc.DaemonService.WatchRounds:input_type -> daemonrpc.WatchRoundsRequest
+	97,  // 99: daemonrpc.DaemonService.ListOORSessions:input_type -> daemonrpc.ListOORSessionsRequest
+	99,  // 100: daemonrpc.DaemonService.GetOORSession:input_type -> daemonrpc.GetOORSessionRequest
+	101, // 101: daemonrpc.DaemonService.EstimateFee:input_type -> daemonrpc.EstimateFeeRequest
+	103, // 102: daemonrpc.DaemonService.GetFeeHistory:input_type -> daemonrpc.GetFeeHistoryRequest
+	106, // 103: daemonrpc.DaemonService.ListTransactions:input_type -> daemonrpc.ListTransactionsRequest
+	109, // 104: daemonrpc.DaemonService.Unroll:input_type -> daemonrpc.UnrollRequest
+	111, // 105: daemonrpc.DaemonService.GetUnrollStatus:input_type -> daemonrpc.GetUnrollStatusRequest
+	116, // 106: daemonrpc.DaemonService.ArmVHTLCRecovery:input_type -> daemonrpc.ArmVHTLCRecoveryRequest
+	118, // 107: daemonrpc.DaemonService.EscalateVHTLCRecovery:input_type -> daemonrpc.EscalateVHTLCRecoveryRequest
+	120, // 108: daemonrpc.DaemonService.CancelVHTLCRecovery:input_type -> daemonrpc.CancelVHTLCRecoveryRequest
+	122, // 109: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> daemonrpc.GetVHTLCRecoveryStatusRequest
+	124, // 110: daemonrpc.DaemonService.ListVHTLCRecoveries:input_type -> daemonrpc.ListVHTLCRecoveriesRequest
+	12,  // 111: daemonrpc.DaemonService.GetInfo:output_type -> daemonrpc.GetInfoResponse
+	15,  // 112: daemonrpc.DaemonService.GenSeed:output_type -> daemonrpc.GenSeedResponse
+	17,  // 113: daemonrpc.DaemonService.InitWallet:output_type -> daemonrpc.InitWalletResponse
+	19,  // 114: daemonrpc.DaemonService.UnlockWallet:output_type -> daemonrpc.UnlockWalletResponse
+	21,  // 115: daemonrpc.DaemonService.GetBalance:output_type -> daemonrpc.GetBalanceResponse
+	25,  // 116: daemonrpc.DaemonService.ListVTXOs:output_type -> daemonrpc.ListVTXOsResponse
+	27,  // 117: daemonrpc.DaemonService.NewAddress:output_type -> daemonrpc.NewAddressResponse
+	29,  // 118: daemonrpc.DaemonService.NewReceiveScript:output_type -> daemonrpc.NewReceiveScriptResponse
+	31,  // 119: daemonrpc.DaemonService.ReceiveAuthKey:output_type -> daemonrpc.ReceiveAuthKeyResponse
+	33,  // 120: daemonrpc.DaemonService.SignReceiveAuthMessage:output_type -> daemonrpc.SignReceiveAuthMessageResponse
+	35,  // 121: daemonrpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> daemonrpc.SignReceiveAuthMessageCompactResponse
+	37,  // 122: daemonrpc.DaemonService.ReceiveAuthECDH:output_type -> daemonrpc.ReceiveAuthECDHResponse
+	39,  // 123: daemonrpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> daemonrpc.GetIndexedVTXOByPkScriptResponse
+	41,  // 124: daemonrpc.DaemonService.GetVTXOExpiryInfo:output_type -> daemonrpc.GetVTXOExpiryInfoResponse
+	43,  // 125: daemonrpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> daemonrpc.GetIndexedOORSessionByTxidResponse
+	46,  // 126: daemonrpc.DaemonService.SendVTXO:output_type -> daemonrpc.SendVTXOResponse
+	50,  // 127: daemonrpc.DaemonService.SendOOR:output_type -> daemonrpc.SendOORResponse
+	53,  // 128: daemonrpc.DaemonService.PrepareOOR:output_type -> daemonrpc.PrepareOORResponse
+	55,  // 129: daemonrpc.DaemonService.SignOORCustomInput:output_type -> daemonrpc.SignOORCustomInputResponse
+	57,  // 130: daemonrpc.DaemonService.SignVTXOForfeit:output_type -> daemonrpc.SignVTXOForfeitResponse
+	61,  // 131: daemonrpc.DaemonService.RefreshVTXOs:output_type -> daemonrpc.RefreshVTXOsResponse
+	65,  // 132: daemonrpc.DaemonService.RefreshCustomVTXOs:output_type -> daemonrpc.RefreshCustomVTXOsResponse
+	68,  // 133: daemonrpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:output_type -> daemonrpc.ListPendingForfeitParticipantSignatureRequestsResponse
+	71,  // 134: daemonrpc.DaemonService.SubmitForfeitParticipantSignatures:output_type -> daemonrpc.SubmitForfeitParticipantSignaturesResponse
+	74,  // 135: daemonrpc.DaemonService.LeaveVTXOs:output_type -> daemonrpc.LeaveVTXOsResponse
+	76,  // 136: daemonrpc.DaemonService.SendOnChain:output_type -> daemonrpc.SendOnChainResponse
+	78,  // 137: daemonrpc.DaemonService.Board:output_type -> daemonrpc.BoardResponse
+	80,  // 138: daemonrpc.DaemonService.JoinNextRound:output_type -> daemonrpc.JoinNextRoundResponse
+	83,  // 139: daemonrpc.DaemonService.SweepBoardingUTXOs:output_type -> daemonrpc.SweepBoardingUTXOsResponse
+	87,  // 140: daemonrpc.DaemonService.ListBoardingSweeps:output_type -> daemonrpc.ListBoardingSweepsResponse
+	93,  // 141: daemonrpc.DaemonService.ListRounds:output_type -> daemonrpc.ListRoundsResponse
+	92,  // 142: daemonrpc.DaemonService.GetRound:output_type -> daemonrpc.GetRoundResponse
+	95,  // 143: daemonrpc.DaemonService.WatchRounds:output_type -> daemonrpc.WatchRoundsResponse
+	98,  // 144: daemonrpc.DaemonService.ListOORSessions:output_type -> daemonrpc.ListOORSessionsResponse
+	100, // 145: daemonrpc.DaemonService.GetOORSession:output_type -> daemonrpc.GetOORSessionResponse
+	102, // 146: daemonrpc.DaemonService.EstimateFee:output_type -> daemonrpc.EstimateFeeResponse
+	105, // 147: daemonrpc.DaemonService.GetFeeHistory:output_type -> daemonrpc.GetFeeHistoryResponse
+	108, // 148: daemonrpc.DaemonService.ListTransactions:output_type -> daemonrpc.ListTransactionsResponse
+	110, // 149: daemonrpc.DaemonService.Unroll:output_type -> daemonrpc.UnrollResponse
+	115, // 150: daemonrpc.DaemonService.GetUnrollStatus:output_type -> daemonrpc.GetUnrollStatusResponse
+	117, // 151: daemonrpc.DaemonService.ArmVHTLCRecovery:output_type -> daemonrpc.ArmVHTLCRecoveryResponse
+	119, // 152: daemonrpc.DaemonService.EscalateVHTLCRecovery:output_type -> daemonrpc.EscalateVHTLCRecoveryResponse
+	121, // 153: daemonrpc.DaemonService.CancelVHTLCRecovery:output_type -> daemonrpc.CancelVHTLCRecoveryResponse
+	123, // 154: daemonrpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> daemonrpc.GetVHTLCRecoveryStatusResponse
+	125, // 155: daemonrpc.DaemonService.ListVHTLCRecoveries:output_type -> daemonrpc.ListVHTLCRecoveriesResponse
+	111, // [111:156] is the sub-list for method output_type
+	66,  // [66:111] is the sub-list for method input_type
+	66,  // [66:66] is the sub-list for extension type_name
+	66,  // [66:66] is the sub-list for extension extendee
+	0,   // [0:66] is the sub-list for field type_name
 }
 
 func init() { file_daemon_proto_init() }
@@ -10507,7 +10940,7 @@ func file_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      11,
-			NumMessages:   114,
+			NumMessages:   117,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -2233,6 +2233,103 @@ message UnrollResponse {
 message GetUnrollStatusRequest {
     // outpoint is the VTXO outpoint to query, formatted as "txid:index".
     string outpoint = 1;
+
+    // detailed enriches the response with tree/CSV progress and a fee
+    // breakdown by querying the live unroll actor. It costs one extra child
+    // actor round-trip plus a fee estimate, so automated pollers should leave
+    // it false and only interactive status commands should set it.
+    bool detailed = 2;
+}
+
+// UnrollProgress describes materialization progress through the exit proof
+// tree. It is populated only for a detailed query against a live unroll job.
+message UnrollProgress {
+    // confirmed_txs is the number of proof transactions confirmed on-chain.
+    uint32 confirmed_txs = 1;
+
+    // in_flight_txs is the number of proof transactions broadcast but not yet
+    // observed confirmed.
+    uint32 in_flight_txs = 2;
+
+    // ready_txs is the number of proof transactions ready to broadcast now
+    // (all in-proof parents confirmed).
+    uint32 ready_txs = 3;
+
+    // blocked_txs is the number of proof transactions still waiting on an
+    // unconfirmed in-proof parent.
+    uint32 blocked_txs = 4;
+
+    // total_txs is the total number of transactions in the exit proof tree.
+    uint32 total_txs = 5;
+
+    // current_layer is the frontier layer index: the shallowest topological
+    // layer (roots first) that still holds an unconfirmed transaction. It
+    // equals total_layers once every proof node has confirmed.
+    uint32 current_layer = 6;
+
+    // total_layers is the depth of the exit proof tree.
+    uint32 total_layers = 7;
+
+    // target_confirmed is true once the target VTXO transaction itself has
+    // confirmed on-chain.
+    bool target_confirmed = 8;
+
+    // all_proof_confirmed is true once every proof-tree transaction has
+    // confirmed, so only the CSV wait and final sweep remain.
+    bool all_proof_confirmed = 9;
+}
+
+// UnrollCSV describes the target's CSV maturity countdown. It is populated only
+// once the target transaction has confirmed.
+message UnrollCSV {
+    // target_confirm_height is the block height at which the target confirmed.
+    int32 target_confirm_height = 1;
+
+    // maturity_height is the block height at which the target becomes
+    // timeout-spendable.
+    int32 maturity_height = 2;
+
+    // blocks_remaining is how many blocks remain until CSV maturity.
+    int32 blocks_remaining = 3;
+
+    // mature is true once the current height is at or past maturity.
+    bool mature = 4;
+}
+
+// UnrollFees breaks down the on-chain cost of the exit. The CPFP total is
+// estimated from the current fee rate and the recovery-transaction count; the
+// sweep fee is the actual built-sweep fee once known, otherwise estimated.
+message UnrollFees {
+    // cpfp_fee_sat is the wallet-funded CPFP fee across every recovery
+    // transaction (estimated).
+    int64 cpfp_fee_sat = 1;
+
+    // sweep_fee_sat is the fee the final sweep pays out of the VTXO value.
+    int64 sweep_fee_sat = 2;
+
+    // total_cost_sat is cpfp_fee_sat + sweep_fee_sat.
+    int64 total_cost_sat = 3;
+
+    // vtxo_amount_sat is the value of the VTXO being exited.
+    int64 vtxo_amount_sat = 4;
+
+    // net_recovered_sat is vtxo_amount_sat - sweep_fee_sat: the value that
+    // lands back in the wallet from the sweep.
+    int64 net_recovered_sat = 5;
+
+    // fee_rate_sat_vbyte is the fee rate used for the estimate.
+    int64 fee_rate_sat_vbyte = 6;
+
+    // sweep_fee_actual is true when sweep_fee_sat is the real built-sweep fee
+    // rather than an estimate.
+    bool sweep_fee_actual = 7;
+
+    // spent_so_far_sat is the estimated on-chain fee already committed at this
+    // point in the exit: CPFP for the confirmed and in-flight recovery
+    // transactions, plus the sweep fee once the sweep is broadcast. It is an
+    // estimate derived from the per-transaction cost model, not a realized
+    // total; total_cost_sat remains the projected cost of the whole exit.
+    int64 spent_so_far_sat = 8;
 }
 
 // UnrollJobStatus represents the high-level phase of an unroll job.
@@ -2278,6 +2375,31 @@ message GetUnrollStatusResponse {
     // last_error contains the failure reason if the job is in FAILED
     // status.
     string last_error = 4;
+
+    // phase_detail is a human-readable one-line description of the current
+    // phase, e.g. "materializing layer 2 of 4 (3/7 txs confirmed)". Set only
+    // on a detailed query.
+    string phase_detail = 5;
+
+    // progress is the tree materialization progress. Set only on a detailed
+    // query against a live job.
+    UnrollProgress progress = 6;
+
+    // csv is the CSV maturity countdown. Set only on a detailed query, once
+    // the target has confirmed.
+    UnrollCSV csv = 7;
+
+    // fees is the on-chain cost breakdown for the exit. Set only on a detailed
+    // query.
+    UnrollFees fees = 8;
+
+    // best_case_blocks_remaining is the optimistic block count until a
+    // confirmed sweep. Set only on a detailed query.
+    int32 best_case_blocks_remaining = 9;
+
+    // current_height is the best block height the unroll actor has observed.
+    // Set only on a detailed query against a live job.
+    int32 current_height = 10;
 }
 
 // VHTLCRecoveryDirection records which side owns a recovery job.

--- a/darepod/rpc_auth.go
+++ b/darepod/rpc_auth.go
@@ -178,8 +178,9 @@ func newDarepodRPCPermissions() map[string][]bakery.Op {
 	grant(walletdk, entityAddress, "write",
 		"Recv",
 	)
-	grant(walletdk, entityOnChain, "read",
-		"GetExitPlan", "ExitStatus",
+	grant(
+		walletdk, entityOnChain, "read", "GetExitPlan", "ExitStatus",
+		"ExitSummary",
 	)
 	grant(
 		walletdk, entityOnChain, "write", "PrepareSend", "Send",

--- a/darepod/rpc_exit_plan.go
+++ b/darepod/rpc_exit_plan.go
@@ -541,11 +541,16 @@ func (r *RPCServer) ExitSummary(ctx context.Context) (*ExitSummaryResult,
 	}
 
 	// The fee estimate is wallet-wide, so compute it once and reuse it for
-	// every previewed exit.
+	// every previewed exit. A fee-estimate failure must not sink the whole
+	// summary: the amounts and phases come from the store and are useful on
+	// their own, so degrade to a zero rate (which zeroes only the fee
+	// columns) rather than failing the call.
 	feeRate, err := r.estimateWalletFeeRate(ctx, 0)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "estimate fee: %v",
-			err)
+		r.server.log.DebugS(ctx, "exit summary fee estimate failed; "+
+			"reporting zero fees", slog.String("err", err.Error()))
+
+		feeRate = 0
 	}
 
 	result.Entries = make([]ExitSummaryEntry, 0, len(jobs))

--- a/darepod/rpc_exit_plan.go
+++ b/darepod/rpc_exit_plan.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/unroll"
 	"github.com/lightninglabs/darepo-client/wallet"
 	"google.golang.org/grpc/codes"
@@ -489,4 +490,121 @@ func (s *Server) exitPlanFundingAddress(ctx context.Context, outpoint string,
 	return s.exitFundingAddresses.Address(
 		ctx, outpoint, s.NewWalletAddress,
 	)
+}
+
+// ExitSummaryEntry is one in-progress exit's coarse contribution to the
+// wallet-wide exit portfolio: its phase plus the amount and estimated fees
+// derived from the persisted descriptor. It deliberately avoids querying each
+// live actor, so the summary stays cheap regardless of how many exits are in
+// flight.
+type ExitSummaryEntry struct {
+	Outpoint           string
+	Status             daemonrpc.UnrollJobStatus
+	VTXOAmountSat      int64
+	EstTotalFeeSat     int64
+	EstNetRecoveredSat int64
+}
+
+// ExitSummaryResult is the wallet-wide portfolio of in-progress exits plus
+// aggregate totals. Only non-terminal exits are included: a completed or failed
+// exit has no amount still being recovered.
+type ExitSummaryResult struct {
+	Entries                 []ExitSummaryEntry
+	TotalExits              uint32
+	TotalVTXOAmountSat      int64
+	TotalEstFeeSat          int64
+	TotalEstNetRecoveredSat int64
+}
+
+// ExitSummary returns the wallet-wide portfolio of in-progress unilateral
+// exits. It lists every non-terminal exit job and, for each, projects the VTXO
+// value and the estimated on-chain cost from the persisted descriptor using the
+// same cost model as GetExitPlan, then sums them so a caller can see the total
+// amount still being recovered across all exits at once. A per-outpoint
+// descriptor lookup failure records a zero-cost entry rather than failing the
+// whole summary.
+func (r *RPCServer) ExitSummary(ctx context.Context) (*ExitSummaryResult,
+	error) {
+
+	result := &ExitSummaryResult{Entries: []ExitSummaryEntry{}}
+	if r.server.ueStore == nil {
+		return result, nil
+	}
+
+	jobs, err := r.server.ueStore.ListNonTerminalJobs(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list exit jobs: %v",
+			err)
+	}
+	if len(jobs) == 0 {
+		return result, nil
+	}
+
+	// The fee estimate is wallet-wide, so compute it once and reuse it for
+	// every previewed exit.
+	feeRate, err := r.estimateWalletFeeRate(ctx, 0)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "estimate fee: %v",
+			err)
+	}
+
+	result.Entries = make([]ExitSummaryEntry, 0, len(jobs))
+	for i := range jobs {
+		entry := r.exitSummaryEntry(ctx, jobs[i], feeRate)
+		result.Entries = append(result.Entries, entry)
+
+		result.TotalVTXOAmountSat += entry.VTXOAmountSat
+		result.TotalEstFeeSat += entry.EstTotalFeeSat
+		result.TotalEstNetRecoveredSat += entry.EstNetRecoveredSat
+	}
+	result.TotalExits = uint32(len(result.Entries))
+
+	r.server.log.DebugS(ctx, "ExitSummary computed",
+		slog.Int("num_exits", len(result.Entries)),
+		slog.Int64("total_amount_sat", result.TotalVTXOAmountSat),
+	)
+
+	return result, nil
+}
+
+// exitSummaryEntry projects one non-terminal exit job into a coarse portfolio
+// entry. A descriptor lookup failure yields a phase-only entry with zeroed
+// amounts so one missing descriptor cannot fail the whole summary.
+func (r *RPCServer) exitSummaryEntry(ctx context.Context,
+	job db.UnilateralExitJobRecord, feeRate int64) ExitSummaryEntry {
+
+	entry := ExitSummaryEntry{
+		Outpoint: job.TargetOutpoint.String(),
+		Status:   unrollJobStatusToProto(job.Status),
+	}
+
+	if r.server.vtxoStore == nil {
+		return entry
+	}
+
+	desc, err := r.server.vtxoStore.GetVTXO(ctx, job.TargetOutpoint)
+	if err != nil {
+		r.server.log.DebugS(ctx, "exit summary entry cost skipped",
+			slog.String("outpoint", job.TargetOutpoint.String()),
+			slog.String("err", err.Error()),
+		)
+
+		return entry
+	}
+
+	// A zero wallet snapshot is intentional: the cost fields depend only on
+	// the fee rate, recovery-tx count, and VTXO value. A nil lineage keeps
+	// the aggregate cheap: the summary approximates the OOR chain from the
+	// descriptor's ChainDepth rather than resolving artifacts per exit, and
+	// the single-exit `exit status`/`exit plan` views are the exact source.
+	plan := unroll.PlanExitFunding(
+		desc, nil, btcutil.Amount(feeRate),
+		unroll.ExitFundingSnapshot{},
+	)
+	f := plan.Feasibility
+	entry.VTXOAmountSat = int64(f.VTXOAmountSat)
+	entry.EstTotalFeeSat = int64(f.TotalRecoveryCostSat)
+	entry.EstNetRecoveredSat = int64(f.NetRecoveredSat)
+
+	return entry
 }

--- a/darepod/rpc_exit_status_test.go
+++ b/darepod/rpc_exit_status_test.go
@@ -1,0 +1,187 @@
+package darepod
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/unroll"
+	"github.com/lightninglabs/darepo-client/unrollplan"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpentSoFarSat verifies the estimated fee-committed-so-far projection
+// across the exit lifecycle: coarse/terminal states with no live progress, and
+// live materialization where the CPFP total is prorated over the proof
+// transactions already broadcast (confirmed plus in-flight) with the sweep fee
+// folded in once the sweep is built.
+func TestSpentSoFarSat(t *testing.T) {
+	t.Parallel()
+
+	// A fee breakdown with a round CPFP total so the proration math is easy
+	// to read: 1550 over 5 proof txs is 310 per child.
+	fees := func() *daemonrpc.UnrollFees {
+		return &daemonrpc.UnrollFees{
+			CpfpFeeSat:   1550,
+			SweepFeeSat:  400,
+			TotalCostSat: 1950,
+		}
+	}
+
+	progress := func(confirmed, inFlight, total int) *unroll.ExitProgress {
+		return &unroll.ExitProgress{
+			ConfirmedTxs: confirmed,
+			InFlightTxs:  inFlight,
+			TotalTxs:     total,
+		}
+	}
+
+	tests := []struct {
+		name       string
+		progress   *unroll.ExitProgress
+		sweepBuilt bool
+		status     daemonrpc.UnrollJobStatus
+		want       int64
+	}{
+		{
+			name:     "no progress completed spent whole total",
+			progress: nil,
+			status: daemonrpc.
+				UnrollJobStatus_UNROLL_JOB_STATUS_COMPLETED,
+			want: 1950,
+		},
+		{
+			name:     "materializing no progress spent nothing",
+			progress: nil,
+			status: daemonrpc.
+				UnrollJobStatus_UNROLL_JOB_STATUS_MATERIALIZING,
+			want: 0,
+		},
+		{
+			name:     "prorate cpfp over broadcast txs",
+			progress: progress(2, 1, 5),
+			status: daemonrpc.
+				UnrollJobStatus_UNROLL_JOB_STATUS_MATERIALIZING,
+			// 310 per child * (2 confirmed + 1 in-flight).
+			want: 930,
+		},
+		{
+			name:       "sweep fee folded in once built",
+			progress:   progress(2, 1, 5),
+			sweepBuilt: true,
+			status: daemonrpc.
+				UnrollJobStatus_UNROLL_JOB_STATUS_SWEEPING,
+			// 930 CPFP + 400 sweep.
+			want: 1330,
+		},
+		{
+			name:     "broadcast count clamps to total",
+			progress: progress(5, 3, 5),
+			status: daemonrpc.
+				UnrollJobStatus_UNROLL_JOB_STATUS_MATERIALIZING,
+			// Clamped to 5/5, so the full CPFP total.
+			want: 1550,
+		},
+		{
+			name:     "zero total txs yields zero cpfp",
+			progress: progress(0, 0, 0),
+			status: daemonrpc.
+				UnrollJobStatus_UNROLL_JOB_STATUS_MATERIALIZING,
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := spentSoFarSat(
+				fees(), tc.progress, tc.sweepBuilt, tc.status,
+			)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestUnrollPhaseDetail verifies the human phase line folds live progress into
+// the materializing and CSV-pending descriptions and degrades to a coarse line
+// when no live progress is available.
+func TestUnrollPhaseDetail(t *testing.T) {
+	t.Parallel()
+
+	materializing := &unroll.ExitProgress{
+		ConfirmedTxs: 2,
+		InFlightTxs:  1,
+		TotalTxs:     5,
+		CurrentLayer: 2,
+		TotalLayers:  5,
+	}
+	csvPending := &unroll.ExitProgress{
+		TargetConfirmed:   true,
+		AllProofConfirmed: true,
+		CSV: fn.Some(unrollplan.CSVInfo{
+			MaturityHeight:  900,
+			BlocksRemaining: 42,
+		}),
+	}
+
+	tests := []struct {
+		name     string
+		status   daemonrpc.UnrollJobStatus
+		progress *unroll.ExitProgress
+		contains []string
+	}{
+		{
+			name: "materializing folds in layer and tx counts",
+			status: daemonrpc.
+				UnrollJobStatus_UNROLL_JOB_STATUS_MATERIALIZING,
+			progress: materializing,
+			// CurrentLayer is 0-based; the line renders it 1-based.
+			contains: []string{
+				"layer 3 of 5",
+				"2/5 txs confirmed",
+			},
+		},
+		{
+			name: "materializing without progress is coarse",
+			status: daemonrpc.
+				UnrollJobStatus_UNROLL_JOB_STATUS_MATERIALIZING,
+			progress: nil,
+			contains: []string{
+				"materializing recovery transactions",
+			},
+		},
+		{
+			name: "csv pending folds in the countdown",
+			status: daemonrpc.
+				UnrollJobStatus_UNROLL_JOB_STATUS_CSV_PENDING,
+			progress: csvPending,
+			contains: []string{
+				"42 blocks remaining",
+				"height 900",
+			},
+		},
+		{
+			name: "completed is terminal line",
+			status: daemonrpc.
+				UnrollJobStatus_UNROLL_JOB_STATUS_COMPLETED,
+			progress: nil,
+			contains: []string{
+				"exit complete",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := unrollPhaseDetail(tc.status, tc.progress)
+			for _, want := range tc.contains {
+				require.Contains(t, got, want)
+			}
+		})
+	}
+}

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/lightninglabs/darepo-client/round"
 	"github.com/lightninglabs/darepo-client/serverconn"
 	"github.com/lightninglabs/darepo-client/unroll"
+	"github.com/lightninglabs/darepo-client/unrollplan"
 	"github.com/lightninglabs/darepo-client/vtxo"
 	"github.com/lightninglabs/darepo-client/wallet"
 	"github.com/lightninglabs/lndclient"
@@ -4765,7 +4766,7 @@ func (r *RPCServer) GetUnrollStatus(ctx context.Context,
 
 	if r.server.unrollRegistryRef.IsSome() {
 		resp, found, err := r.queryUnrollRegistry(
-			ctx, outpoint,
+			ctx, outpoint, req.Detailed,
 		)
 		if err != nil {
 			return nil, err
@@ -4805,20 +4806,32 @@ func (r *RPCServer) GetUnrollStatus(ctx context.Context,
 		sweepTxid = hash.String()
 	}
 
-	return &daemonrpc.GetUnrollStatusResponse{
+	resp := &daemonrpc.GetUnrollStatusResponse{
 		Found:     true,
 		Status:    unrollJobStatusToProto(job.Status),
 		SweepTxid: sweepTxid,
 		LastError: job.LastError,
-	}, nil
+	}
+
+	// The registry no longer has a live actor for this target (it was
+	// evicted after reaching a terminal phase), so tree/CSV progress is
+	// gone. A detailed probe can still project the fee breakdown from the
+	// persisted descriptor and a human phase line, which keeps a completed
+	// or failed exit inspectable via this same endpoint.
+	if req.Detailed {
+		resp.PhaseDetail = unrollPhaseDetail(resp.Status, nil)
+		r.enrichExitFees(ctx, resp, outpoint, fn.None[int64](), nil)
+	}
+
+	return resp, nil
 }
 
 // queryUnrollRegistry asks the live unroll registry actor for the
 // status of a target outpoint. It returns the proto response, whether
 // the job was found, and any RPC error.
 func (r *RPCServer) queryUnrollRegistry(ctx context.Context,
-	outpoint wire.OutPoint) (*daemonrpc.GetUnrollStatusResponse, bool,
-	error) {
+	outpoint wire.OutPoint, detailed bool) (
+	*daemonrpc.GetUnrollStatusResponse, bool, error) {
 
 	var registryRef actor.ActorRef[
 		unroll.RegistryMsg, unroll.RegistryResp,
@@ -4835,6 +4848,7 @@ func (r *RPCServer) queryUnrollRegistry(ctx context.Context,
 	resp, askErr := registryRef.Ask(
 		ctx, &unroll.GetStatusRequest{
 			Outpoint: outpoint,
+			Detailed: detailed,
 		},
 	).Await(ctx).Unpack()
 	if askErr != nil {
@@ -4873,12 +4887,251 @@ func (r *RPCServer) queryUnrollRegistry(ctx context.Context,
 		phase = statusResp.State.Phase
 	}
 
-	return &daemonrpc.GetUnrollStatusResponse{
+	out := &daemonrpc.GetUnrollStatusResponse{
 		Found:     true,
 		Status:    unrollPhaseToProto(phase),
 		SweepTxid: sweepTxid,
 		LastError: lastError,
-	}, true, nil
+	}
+	if detailed {
+		r.enrichUnrollDetail(ctx, out, outpoint, statusResp)
+	}
+
+	return out, true, nil
+}
+
+// enrichUnrollDetail fills the detailed status fields (phase line, tree/CSV
+// progress, best-case block countdown, current height, and fee breakdown) from
+// the live child's planner-derived state. It is best-effort: any missing piece
+// (no live actor, planner not yet loaded, descriptor lookup failure) is left
+// unset rather than failing the probe.
+func (r *RPCServer) enrichUnrollDetail(ctx context.Context,
+	out *daemonrpc.GetUnrollStatusResponse, outpoint wire.OutPoint,
+	statusResp *unroll.GetStatusResp) {
+
+	// progress is the live planner projection, present only when the target
+	// has an active child that has loaded its proof and planner.
+	var progress *unroll.ExitProgress
+	var actualSweepFee fn.Option[int64]
+	if statusResp.Active && statusResp.State != nil {
+		out.CurrentHeight = statusResp.State.Height
+		progress = statusResp.State.Progress
+	}
+
+	if progress != nil {
+		out.Progress = unrollProgressToProto(progress)
+		out.Csv = unrollCSVToProto(progress)
+		out.BestCaseBlocksRemaining = progress.BestCaseBlocksRemaining
+		actualSweepFee = progress.ActualSweepFeeSat
+	}
+
+	out.PhaseDetail = unrollPhaseDetail(out.Status, progress)
+
+	r.enrichExitFees(ctx, out, outpoint, actualSweepFee, progress)
+}
+
+// unrollProgressToProto maps the actor's derived progress summary onto the
+// proto progress message.
+func unrollProgressToProto(p *unroll.ExitProgress) *daemonrpc.UnrollProgress {
+	if p == nil {
+		return nil
+	}
+
+	return &daemonrpc.UnrollProgress{
+		ConfirmedTxs:      uint32(p.ConfirmedTxs),
+		InFlightTxs:       uint32(p.InFlightTxs),
+		ReadyTxs:          uint32(p.ReadyTxs),
+		BlockedTxs:        uint32(p.BlockedTxs),
+		TotalTxs:          uint32(p.TotalTxs),
+		CurrentLayer:      uint32(p.CurrentLayer),
+		TotalLayers:       uint32(p.TotalLayers),
+		TargetConfirmed:   p.TargetConfirmed,
+		AllProofConfirmed: p.AllProofConfirmed,
+	}
+}
+
+// unrollCSVToProto maps the planner CSV maturity view onto the proto CSV
+// message. It returns nil until the target confirms (CSV is None), so a caller
+// can distinguish "not yet in the CSV wait" from a zeroed countdown.
+func unrollCSVToProto(p *unroll.ExitProgress) *daemonrpc.UnrollCSV {
+	if p == nil {
+		return nil
+	}
+
+	var out *daemonrpc.UnrollCSV
+	p.CSV.WhenSome(func(csv unrollplan.CSVInfo) {
+		out = &daemonrpc.UnrollCSV{
+			TargetConfirmHeight: csv.TargetConfirmHeight,
+			MaturityHeight:      csv.MaturityHeight,
+			BlocksRemaining:     csv.BlocksRemaining,
+			Mature:              csv.Ready,
+		}
+	})
+
+	return out
+}
+
+// unrollPhaseDetail renders a one-line human description of the current phase.
+// When live progress is available it is folded into the materializing and
+// CSV-pending lines; otherwise a coarse phase description is returned.
+func unrollPhaseDetail(st daemonrpc.UnrollJobStatus,
+	p *unroll.ExitProgress) string {
+
+	switch st {
+	case daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_PENDING:
+		return "queued; recovery transactions not yet broadcast"
+
+	case daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_MATERIALIZING:
+		if p == nil {
+			return "materializing recovery transactions on-chain"
+		}
+
+		return fmt.Sprintf("materializing recovery tree: layer %d of "+
+			"%d, %d/%d txs confirmed (%d in flight, %d ready, %d "+
+			"blocked)", p.CurrentLayer+1, p.TotalLayers,
+			p.ConfirmedTxs, p.TotalTxs, p.InFlightTxs, p.ReadyTxs,
+			p.BlockedTxs)
+
+	case daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_CSV_PENDING:
+		detail := "recovery transactions confirmed; waiting for CSV " +
+			"maturity"
+		if p != nil {
+			p.CSV.WhenSome(func(csv unrollplan.CSVInfo) {
+				detail = fmt.Sprintf("all recovery txs "+
+					"confirmed; waiting for CSV maturity "+
+					"(%d blocks remaining, matures at "+
+					"height %d)", csv.BlocksRemaining,
+					csv.MaturityHeight)
+			})
+		}
+
+		return detail
+
+	case daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_SWEEPING:
+		return "CSV matured; sweep in flight, awaiting confirmation"
+
+	case daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_COMPLETED:
+		return "exit complete; funds swept to the backing wallet"
+
+	case daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_FAILED:
+		return "exit failed; see last_error"
+
+	default:
+		return ""
+	}
+}
+
+// enrichExitFees projects the exit's on-chain cost breakdown onto the response
+// from the persisted VTXO descriptor and the current fee estimate, reusing the
+// same cost model as unroll admission and GetExitPlan. The CPFP total and the
+// default sweep fee are estimates; when the caller supplies the real
+// built-sweep fee it overrides the sweep leg and marks it actual. When live
+// progress is available, spent_so_far is estimated from the CPFP children
+// already broadcast (confirmed + in-flight proof txs) plus the sweep fee once
+// the sweep is built. It is best-effort: a descriptor or fee-estimate failure
+// leaves fees unset rather than failing the probe.
+func (r *RPCServer) enrichExitFees(ctx context.Context,
+	out *daemonrpc.GetUnrollStatusResponse, outpoint wire.OutPoint,
+	actualSweepFee fn.Option[int64], progress *unroll.ExitProgress) {
+
+	if r.server.vtxoStore == nil {
+		return
+	}
+
+	desc, err := r.server.vtxoStore.GetVTXO(ctx, outpoint)
+	if err != nil {
+		r.server.log.DebugS(ctx, "exit fee estimate skipped",
+			slog.String("outpoint", outpoint.String()),
+			slog.String("err", err.Error()),
+		)
+
+		return
+	}
+
+	feeRate, err := r.estimateWalletFeeRate(ctx, 0)
+	if err != nil {
+		return
+	}
+
+	// Resolve the lineage material so the CPFP estimate sizes the OOR
+	// checkpoint/ark transactions exactly, keeping the detailed status fee
+	// in agreement with `exit plan`. It is best-effort: a resolve failure
+	// returns nil, which PlanExitFunding approximates from the descriptor's
+	// ChainDepth.
+	mat := r.resolveExitLineage(ctx, outpoint, desc)
+
+	// A zero wallet snapshot is intentional: the cost fields
+	// (CPFP/sweep/total/net) depend only on the fee rate, recovery-tx
+	// count, and VTXO value, not on wallet funding, so the feasibility
+	// verdict is ignored here.
+	plan := unroll.PlanExitFunding(
+		desc, mat, btcutil.Amount(feeRate),
+		unroll.ExitFundingSnapshot{},
+	)
+	f := plan.Feasibility
+
+	fees := &daemonrpc.UnrollFees{
+		CpfpFeeSat:      int64(f.CPFPFeeTotalSat),
+		SweepFeeSat:     int64(f.SweepFeeSat),
+		VtxoAmountSat:   int64(f.VTXOAmountSat),
+		FeeRateSatVbyte: int64(f.FeeRateSatPerVByte),
+	}
+	sweepBuilt := false
+	actualSweepFee.WhenSome(func(sweepFee int64) {
+		fees.SweepFeeSat = sweepFee
+		fees.SweepFeeActual = true
+		sweepBuilt = true
+	})
+	fees.TotalCostSat = fees.CpfpFeeSat + fees.SweepFeeSat
+	fees.NetRecoveredSat = fees.VtxoAmountSat - fees.SweepFeeSat
+	fees.SpentSoFarSat = spentSoFarSat(
+		fees, progress, sweepBuilt, out.Status,
+	)
+
+	out.Fees = fees
+}
+
+// spentSoFarSat estimates the on-chain fee already committed at this point in
+// the exit. During materialization it prorates the CPFP total over the proof
+// transactions already broadcast (confirmed plus in-flight) and adds the sweep
+// fee once the sweep is built. With no live progress a completed exit has spent
+// the whole projected total; any other terminal or coarse state reports zero
+// (nothing known to be committed).
+//
+// The proration divides by progress.TotalTxs (the deduped proof-graph node
+// count) so numerator and denominator count the same universe: the confirmed
+// and in-flight counts are drawn from that same graph. This is an estimate, not
+// accounting — a confirmed proof tx may be a shared ancestor that another party
+// (or admission) paid the CPFP for, which would make spent_so_far run high.
+func spentSoFarSat(fees *daemonrpc.UnrollFees, progress *unroll.ExitProgress,
+	sweepBuilt bool, st daemonrpc.UnrollJobStatus) int64 {
+
+	if progress == nil {
+		if st == daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_COMPLETED {
+			return fees.TotalCostSat
+		}
+
+		return 0
+	}
+
+	var spent int64
+	if progress.TotalTxs > 0 {
+		broadcast := progress.ConfirmedTxs + progress.InFlightTxs
+		if broadcast > progress.TotalTxs {
+			broadcast = progress.TotalTxs
+		}
+
+		perChild := fees.CpfpFeeSat / int64(progress.TotalTxs)
+		spent = perChild * int64(broadcast)
+	}
+
+	// The sweep fee is committed only once the sweep transaction has been
+	// built and broadcast.
+	if sweepBuilt {
+		spent += fees.SweepFeeSat
+	}
+
+	return spent
 }
 
 // unrollPhaseToProto maps the new unroll phase enum to the proto enum.

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -4986,11 +4986,19 @@ func unrollPhaseDetail(st daemonrpc.UnrollJobStatus,
 			return "materializing recovery transactions on-chain"
 		}
 
+		// The frontier layer collapses to TotalLayers once every proof
+		// node confirms, so clamp the 1-based display so a job that
+		// reads MATERIALIZING after the frontier collapsed cannot
+		// render "layer N+1 of N".
+		layer := p.CurrentLayer + 1
+		if layer > p.TotalLayers {
+			layer = p.TotalLayers
+		}
+
 		return fmt.Sprintf("materializing recovery tree: layer %d of "+
 			"%d, %d/%d txs confirmed (%d in flight, %d ready, %d "+
-			"blocked)", p.CurrentLayer+1, p.TotalLayers,
-			p.ConfirmedTxs, p.TotalTxs, p.InFlightTxs, p.ReadyTxs,
-			p.BlockedTxs)
+			"blocked)", layer, p.TotalLayers, p.ConfirmedTxs,
+			p.TotalTxs, p.InFlightTxs, p.ReadyTxs, p.BlockedTxs)
 
 	case daemonrpc.UnrollJobStatus_UNROLL_JOB_STATUS_CSV_PENDING:
 		detail := "recovery transactions confirmed; waiting for CSV " +
@@ -5121,8 +5129,11 @@ func spentSoFarSat(fees *daemonrpc.UnrollFees, progress *unroll.ExitProgress,
 			broadcast = progress.TotalTxs
 		}
 
-		perChild := fees.CpfpFeeSat / int64(progress.TotalTxs)
-		spent = perChild * int64(broadcast)
+		// Multiply before dividing so the proration keeps precision: a
+		// per-child divide first would truncate to zero whenever the
+		// CPFP total is smaller than the transaction count.
+		spent = fees.CpfpFeeSat * int64(broadcast) /
+			int64(progress.TotalTxs)
 	}
 
 	// The sweep fee is committed only once the sweep transaction has been

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -1131,6 +1131,17 @@ func (c *WalletServiceClient) ExitStatus(ctx context.Context,
 	return out, err
 }
 
+// ExitSummary returns the wallet-wide portfolio of in-progress exits.
+func (c *WalletServiceClient) ExitSummary(ctx context.Context,
+	in *walletdkrpc.ExitSummaryRequest, _ ...grpc.CallOption) (
+	*walletdkrpc.ExitSummaryResponse, error) {
+
+	out := new(walletdkrpc.ExitSummaryResponse)
+	err := c.client.Post(ctx, "/v1/wallet/exit-summary", in, out)
+
+	return out, err
+}
+
 // SubscribeWallet streams wallet updates.
 func (c *WalletServiceClient) SubscribeWallet(ctx context.Context,
 	in *walletdkrpc.SubscribeWalletRequest, _ ...grpc.CallOption) (

--- a/rpc/walletdkrpc/wallet.pb.go
+++ b/rpc/walletdkrpc/wallet.pb.go
@@ -4110,7 +4110,12 @@ type ExitStatusRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// outpoint is the VTXO outpoint to query, formatted as
 	// "txid:index".
-	Outpoint      string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	Outpoint string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	// detailed enriches the response with tree/CSV progress and a fee
+	// breakdown. It costs one extra child actor round-trip plus a fee
+	// estimate, so it should be set only for interactive status commands, not
+	// automated polling.
+	Detailed      bool `protobuf:"varint,2,opt,name=detailed,proto3" json:"detailed,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4152,6 +4157,328 @@ func (x *ExitStatusRequest) GetOutpoint() string {
 	return ""
 }
 
+func (x *ExitStatusRequest) GetDetailed() bool {
+	if x != nil {
+		return x.Detailed
+	}
+	return false
+}
+
+// ExitProgress describes materialization progress through the exit proof tree.
+// It is populated only for a detailed query against a live exit job.
+type ExitProgress struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// confirmed_txs is the number of proof transactions confirmed on-chain.
+	ConfirmedTxs uint32 `protobuf:"varint,1,opt,name=confirmed_txs,json=confirmedTxs,proto3" json:"confirmed_txs,omitempty"`
+	// in_flight_txs is the number of proof transactions broadcast but not yet
+	// observed confirmed.
+	InFlightTxs uint32 `protobuf:"varint,2,opt,name=in_flight_txs,json=inFlightTxs,proto3" json:"in_flight_txs,omitempty"`
+	// ready_txs is the number of proof transactions ready to broadcast now.
+	ReadyTxs uint32 `protobuf:"varint,3,opt,name=ready_txs,json=readyTxs,proto3" json:"ready_txs,omitempty"`
+	// blocked_txs is the number of proof transactions still waiting on an
+	// unconfirmed in-proof parent.
+	BlockedTxs uint32 `protobuf:"varint,4,opt,name=blocked_txs,json=blockedTxs,proto3" json:"blocked_txs,omitempty"`
+	// total_txs is the total number of transactions in the exit proof tree.
+	TotalTxs uint32 `protobuf:"varint,5,opt,name=total_txs,json=totalTxs,proto3" json:"total_txs,omitempty"`
+	// current_layer is the frontier layer index: the shallowest topological
+	// layer (roots first) that still holds an unconfirmed transaction.
+	CurrentLayer uint32 `protobuf:"varint,6,opt,name=current_layer,json=currentLayer,proto3" json:"current_layer,omitempty"`
+	// total_layers is the depth of the exit proof tree.
+	TotalLayers uint32 `protobuf:"varint,7,opt,name=total_layers,json=totalLayers,proto3" json:"total_layers,omitempty"`
+	// target_confirmed is true once the target VTXO transaction has confirmed.
+	TargetConfirmed bool `protobuf:"varint,8,opt,name=target_confirmed,json=targetConfirmed,proto3" json:"target_confirmed,omitempty"`
+	// all_proof_confirmed is true once every proof-tree transaction has
+	// confirmed, so only the CSV wait and final sweep remain.
+	AllProofConfirmed bool `protobuf:"varint,9,opt,name=all_proof_confirmed,json=allProofConfirmed,proto3" json:"all_proof_confirmed,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *ExitProgress) Reset() {
+	*x = ExitProgress{}
+	mi := &file_wallet_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExitProgress) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExitProgress) ProtoMessage() {}
+
+func (x *ExitProgress) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExitProgress.ProtoReflect.Descriptor instead.
+func (*ExitProgress) Descriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *ExitProgress) GetConfirmedTxs() uint32 {
+	if x != nil {
+		return x.ConfirmedTxs
+	}
+	return 0
+}
+
+func (x *ExitProgress) GetInFlightTxs() uint32 {
+	if x != nil {
+		return x.InFlightTxs
+	}
+	return 0
+}
+
+func (x *ExitProgress) GetReadyTxs() uint32 {
+	if x != nil {
+		return x.ReadyTxs
+	}
+	return 0
+}
+
+func (x *ExitProgress) GetBlockedTxs() uint32 {
+	if x != nil {
+		return x.BlockedTxs
+	}
+	return 0
+}
+
+func (x *ExitProgress) GetTotalTxs() uint32 {
+	if x != nil {
+		return x.TotalTxs
+	}
+	return 0
+}
+
+func (x *ExitProgress) GetCurrentLayer() uint32 {
+	if x != nil {
+		return x.CurrentLayer
+	}
+	return 0
+}
+
+func (x *ExitProgress) GetTotalLayers() uint32 {
+	if x != nil {
+		return x.TotalLayers
+	}
+	return 0
+}
+
+func (x *ExitProgress) GetTargetConfirmed() bool {
+	if x != nil {
+		return x.TargetConfirmed
+	}
+	return false
+}
+
+func (x *ExitProgress) GetAllProofConfirmed() bool {
+	if x != nil {
+		return x.AllProofConfirmed
+	}
+	return false
+}
+
+// ExitCSV describes the target's CSV maturity countdown. It is populated only
+// once the target transaction has confirmed.
+type ExitCSV struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// target_confirm_height is the block height at which the target confirmed.
+	TargetConfirmHeight int32 `protobuf:"varint,1,opt,name=target_confirm_height,json=targetConfirmHeight,proto3" json:"target_confirm_height,omitempty"`
+	// maturity_height is the block height at which the target becomes
+	// timeout-spendable.
+	MaturityHeight int32 `protobuf:"varint,2,opt,name=maturity_height,json=maturityHeight,proto3" json:"maturity_height,omitempty"`
+	// blocks_remaining is how many blocks remain until CSV maturity.
+	BlocksRemaining int32 `protobuf:"varint,3,opt,name=blocks_remaining,json=blocksRemaining,proto3" json:"blocks_remaining,omitempty"`
+	// mature is true once the current height is at or past maturity.
+	Mature        bool `protobuf:"varint,4,opt,name=mature,proto3" json:"mature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExitCSV) Reset() {
+	*x = ExitCSV{}
+	mi := &file_wallet_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExitCSV) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExitCSV) ProtoMessage() {}
+
+func (x *ExitCSV) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExitCSV.ProtoReflect.Descriptor instead.
+func (*ExitCSV) Descriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *ExitCSV) GetTargetConfirmHeight() int32 {
+	if x != nil {
+		return x.TargetConfirmHeight
+	}
+	return 0
+}
+
+func (x *ExitCSV) GetMaturityHeight() int32 {
+	if x != nil {
+		return x.MaturityHeight
+	}
+	return 0
+}
+
+func (x *ExitCSV) GetBlocksRemaining() int32 {
+	if x != nil {
+		return x.BlocksRemaining
+	}
+	return 0
+}
+
+func (x *ExitCSV) GetMature() bool {
+	if x != nil {
+		return x.Mature
+	}
+	return false
+}
+
+// ExitFees breaks down the on-chain cost of the exit. The CPFP total is
+// estimated from the current fee rate; the sweep fee is the actual built-sweep
+// fee once known, otherwise estimated.
+type ExitFees struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// cpfp_fee_sat is the wallet-funded CPFP fee across every recovery
+	// transaction (estimated).
+	CpfpFeeSat int64 `protobuf:"varint,1,opt,name=cpfp_fee_sat,json=cpfpFeeSat,proto3" json:"cpfp_fee_sat,omitempty"`
+	// sweep_fee_sat is the fee the final sweep pays out of the VTXO value.
+	SweepFeeSat int64 `protobuf:"varint,2,opt,name=sweep_fee_sat,json=sweepFeeSat,proto3" json:"sweep_fee_sat,omitempty"`
+	// total_cost_sat is cpfp_fee_sat + sweep_fee_sat.
+	TotalCostSat int64 `protobuf:"varint,3,opt,name=total_cost_sat,json=totalCostSat,proto3" json:"total_cost_sat,omitempty"`
+	// vtxo_amount_sat is the value of the VTXO being exited.
+	VtxoAmountSat int64 `protobuf:"varint,4,opt,name=vtxo_amount_sat,json=vtxoAmountSat,proto3" json:"vtxo_amount_sat,omitempty"`
+	// net_recovered_sat is vtxo_amount_sat - sweep_fee_sat.
+	NetRecoveredSat int64 `protobuf:"varint,5,opt,name=net_recovered_sat,json=netRecoveredSat,proto3" json:"net_recovered_sat,omitempty"`
+	// fee_rate_sat_vbyte is the fee rate used for the estimate.
+	FeeRateSatVbyte int64 `protobuf:"varint,6,opt,name=fee_rate_sat_vbyte,json=feeRateSatVbyte,proto3" json:"fee_rate_sat_vbyte,omitempty"`
+	// sweep_fee_actual is true when sweep_fee_sat is the real built-sweep fee
+	// rather than an estimate.
+	SweepFeeActual bool `protobuf:"varint,7,opt,name=sweep_fee_actual,json=sweepFeeActual,proto3" json:"sweep_fee_actual,omitempty"`
+	// spent_so_far_sat is the estimated on-chain fee already committed at this
+	// point in the exit: CPFP for the confirmed and in-flight recovery
+	// transactions, plus the sweep fee once the sweep is broadcast. It is an
+	// estimate, not a realized total; total_cost_sat remains the projected cost
+	// of the whole exit.
+	SpentSoFarSat int64 `protobuf:"varint,8,opt,name=spent_so_far_sat,json=spentSoFarSat,proto3" json:"spent_so_far_sat,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExitFees) Reset() {
+	*x = ExitFees{}
+	mi := &file_wallet_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExitFees) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExitFees) ProtoMessage() {}
+
+func (x *ExitFees) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExitFees.ProtoReflect.Descriptor instead.
+func (*ExitFees) Descriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *ExitFees) GetCpfpFeeSat() int64 {
+	if x != nil {
+		return x.CpfpFeeSat
+	}
+	return 0
+}
+
+func (x *ExitFees) GetSweepFeeSat() int64 {
+	if x != nil {
+		return x.SweepFeeSat
+	}
+	return 0
+}
+
+func (x *ExitFees) GetTotalCostSat() int64 {
+	if x != nil {
+		return x.TotalCostSat
+	}
+	return 0
+}
+
+func (x *ExitFees) GetVtxoAmountSat() int64 {
+	if x != nil {
+		return x.VtxoAmountSat
+	}
+	return 0
+}
+
+func (x *ExitFees) GetNetRecoveredSat() int64 {
+	if x != nil {
+		return x.NetRecoveredSat
+	}
+	return 0
+}
+
+func (x *ExitFees) GetFeeRateSatVbyte() int64 {
+	if x != nil {
+		return x.FeeRateSatVbyte
+	}
+	return 0
+}
+
+func (x *ExitFees) GetSweepFeeActual() bool {
+	if x != nil {
+		return x.SweepFeeActual
+	}
+	return false
+}
+
+func (x *ExitFees) GetSpentSoFarSat() int64 {
+	if x != nil {
+		return x.SpentSoFarSat
+	}
+	return 0
+}
+
 // ExitStatusResponse reports the current phase of an unroll job for
 // WalletService.ExitStatus.
 type ExitStatusResponse struct {
@@ -4165,14 +4492,33 @@ type ExitStatusResponse struct {
 	SweepTxid string `protobuf:"bytes,3,opt,name=sweep_txid,json=sweepTxid,proto3" json:"sweep_txid,omitempty"`
 	// last_error contains the failure reason if the job is in FAILED
 	// status.
-	LastError     string `protobuf:"bytes,4,opt,name=last_error,json=lastError,proto3" json:"last_error,omitempty"`
+	LastError string `protobuf:"bytes,4,opt,name=last_error,json=lastError,proto3" json:"last_error,omitempty"`
+	// phase_detail is a human-readable one-line description of the current
+	// phase, e.g. "materializing layer 2 of 4 (3/7 txs confirmed)". Set only
+	// on a detailed query.
+	PhaseDetail string `protobuf:"bytes,5,opt,name=phase_detail,json=phaseDetail,proto3" json:"phase_detail,omitempty"`
+	// progress is the tree materialization progress. Set only on a detailed
+	// query against a live job.
+	Progress *ExitProgress `protobuf:"bytes,6,opt,name=progress,proto3" json:"progress,omitempty"`
+	// csv is the CSV maturity countdown. Set only on a detailed query, once
+	// the target has confirmed.
+	Csv *ExitCSV `protobuf:"bytes,7,opt,name=csv,proto3" json:"csv,omitempty"`
+	// fees is the on-chain cost breakdown for the exit. Set only on a detailed
+	// query.
+	Fees *ExitFees `protobuf:"bytes,8,opt,name=fees,proto3" json:"fees,omitempty"`
+	// best_case_blocks_remaining is the optimistic block count until a
+	// confirmed sweep. Set only on a detailed query.
+	BestCaseBlocksRemaining int32 `protobuf:"varint,9,opt,name=best_case_blocks_remaining,json=bestCaseBlocksRemaining,proto3" json:"best_case_blocks_remaining,omitempty"`
+	// current_height is the best block height the exit job has observed. Set
+	// only on a detailed query against a live job.
+	CurrentHeight int32 `protobuf:"varint,10,opt,name=current_height,json=currentHeight,proto3" json:"current_height,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExitStatusResponse) Reset() {
 	*x = ExitStatusResponse{}
-	mi := &file_wallet_proto_msgTypes[39]
+	mi := &file_wallet_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4184,7 +4530,7 @@ func (x *ExitStatusResponse) String() string {
 func (*ExitStatusResponse) ProtoMessage() {}
 
 func (x *ExitStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[39]
+	mi := &file_wallet_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4197,7 +4543,7 @@ func (x *ExitStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExitStatusResponse.ProtoReflect.Descriptor instead.
 func (*ExitStatusResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{39}
+	return file_wallet_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ExitStatusResponse) GetFound() bool {
@@ -4228,6 +4574,259 @@ func (x *ExitStatusResponse) GetLastError() string {
 	return ""
 }
 
+func (x *ExitStatusResponse) GetPhaseDetail() string {
+	if x != nil {
+		return x.PhaseDetail
+	}
+	return ""
+}
+
+func (x *ExitStatusResponse) GetProgress() *ExitProgress {
+	if x != nil {
+		return x.Progress
+	}
+	return nil
+}
+
+func (x *ExitStatusResponse) GetCsv() *ExitCSV {
+	if x != nil {
+		return x.Csv
+	}
+	return nil
+}
+
+func (x *ExitStatusResponse) GetFees() *ExitFees {
+	if x != nil {
+		return x.Fees
+	}
+	return nil
+}
+
+func (x *ExitStatusResponse) GetBestCaseBlocksRemaining() int32 {
+	if x != nil {
+		return x.BestCaseBlocksRemaining
+	}
+	return 0
+}
+
+func (x *ExitStatusResponse) GetCurrentHeight() int32 {
+	if x != nil {
+		return x.CurrentHeight
+	}
+	return 0
+}
+
+// ExitSummaryRequest asks for the wallet-wide portfolio of in-progress exits.
+type ExitSummaryRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExitSummaryRequest) Reset() {
+	*x = ExitSummaryRequest{}
+	mi := &file_wallet_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExitSummaryRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExitSummaryRequest) ProtoMessage() {}
+
+func (x *ExitSummaryRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExitSummaryRequest.ProtoReflect.Descriptor instead.
+func (*ExitSummaryRequest) Descriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{43}
+}
+
+// ExitSummaryItem is one in-progress exit's coarse contribution to the
+// portfolio. It is intentionally cheap (phase plus amounts and estimated fees
+// from the persisted descriptor), so the summary does not query each live
+// actor; use ExitStatus --detailed for one exit's tree/CSV progress.
+type ExitSummaryItem struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// outpoint is the exiting VTXO outpoint, formatted as "txid:index".
+	Outpoint string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	// status is the current high-level phase of the exit job.
+	Status ExitJobStatus `protobuf:"varint,2,opt,name=status,proto3,enum=walletdkrpc.ExitJobStatus" json:"status,omitempty"`
+	// vtxo_amount_sat is the value of the VTXO being exited.
+	VtxoAmountSat int64 `protobuf:"varint,3,opt,name=vtxo_amount_sat,json=vtxoAmountSat,proto3" json:"vtxo_amount_sat,omitempty"`
+	// est_total_fee_sat is the projected total on-chain fee for this exit
+	// (estimated CPFP total plus sweep fee).
+	EstTotalFeeSat int64 `protobuf:"varint,4,opt,name=est_total_fee_sat,json=estTotalFeeSat,proto3" json:"est_total_fee_sat,omitempty"`
+	// est_net_recovered_sat is the estimated value that lands back in the
+	// wallet after the sweep fee.
+	EstNetRecoveredSat int64 `protobuf:"varint,5,opt,name=est_net_recovered_sat,json=estNetRecoveredSat,proto3" json:"est_net_recovered_sat,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *ExitSummaryItem) Reset() {
+	*x = ExitSummaryItem{}
+	mi := &file_wallet_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExitSummaryItem) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExitSummaryItem) ProtoMessage() {}
+
+func (x *ExitSummaryItem) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExitSummaryItem.ProtoReflect.Descriptor instead.
+func (*ExitSummaryItem) Descriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *ExitSummaryItem) GetOutpoint() string {
+	if x != nil {
+		return x.Outpoint
+	}
+	return ""
+}
+
+func (x *ExitSummaryItem) GetStatus() ExitJobStatus {
+	if x != nil {
+		return x.Status
+	}
+	return ExitJobStatus_EXIT_JOB_STATUS_UNSPECIFIED
+}
+
+func (x *ExitSummaryItem) GetVtxoAmountSat() int64 {
+	if x != nil {
+		return x.VtxoAmountSat
+	}
+	return 0
+}
+
+func (x *ExitSummaryItem) GetEstTotalFeeSat() int64 {
+	if x != nil {
+		return x.EstTotalFeeSat
+	}
+	return 0
+}
+
+func (x *ExitSummaryItem) GetEstNetRecoveredSat() int64 {
+	if x != nil {
+		return x.EstNetRecoveredSat
+	}
+	return 0
+}
+
+// ExitSummaryResponse is the wallet-wide portfolio of in-progress exits plus
+// aggregate totals. Only non-terminal exits are included: a completed or failed
+// exit has no amount "left" to recover.
+type ExitSummaryResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// exits is one row per in-progress exit.
+	Exits []*ExitSummaryItem `protobuf:"bytes,1,rep,name=exits,proto3" json:"exits,omitempty"`
+	// total_exits is the number of in-progress exits.
+	TotalExits uint32 `protobuf:"varint,2,opt,name=total_exits,json=totalExits,proto3" json:"total_exits,omitempty"`
+	// total_vtxo_amount_sat is the summed value of every VTXO still being
+	// exited: the total amount currently locked in in-progress exits.
+	TotalVtxoAmountSat int64 `protobuf:"varint,3,opt,name=total_vtxo_amount_sat,json=totalVtxoAmountSat,proto3" json:"total_vtxo_amount_sat,omitempty"`
+	// total_est_fee_sat is the summed projected on-chain fee across every
+	// in-progress exit.
+	TotalEstFeeSat int64 `protobuf:"varint,4,opt,name=total_est_fee_sat,json=totalEstFeeSat,proto3" json:"total_est_fee_sat,omitempty"`
+	// total_est_net_recovered_sat is the summed estimated value that will land
+	// back in the wallet once every in-progress exit completes.
+	TotalEstNetRecoveredSat int64 `protobuf:"varint,5,opt,name=total_est_net_recovered_sat,json=totalEstNetRecoveredSat,proto3" json:"total_est_net_recovered_sat,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *ExitSummaryResponse) Reset() {
+	*x = ExitSummaryResponse{}
+	mi := &file_wallet_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExitSummaryResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExitSummaryResponse) ProtoMessage() {}
+
+func (x *ExitSummaryResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_wallet_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExitSummaryResponse.ProtoReflect.Descriptor instead.
+func (*ExitSummaryResponse) Descriptor() ([]byte, []int) {
+	return file_wallet_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *ExitSummaryResponse) GetExits() []*ExitSummaryItem {
+	if x != nil {
+		return x.Exits
+	}
+	return nil
+}
+
+func (x *ExitSummaryResponse) GetTotalExits() uint32 {
+	if x != nil {
+		return x.TotalExits
+	}
+	return 0
+}
+
+func (x *ExitSummaryResponse) GetTotalVtxoAmountSat() int64 {
+	if x != nil {
+		return x.TotalVtxoAmountSat
+	}
+	return 0
+}
+
+func (x *ExitSummaryResponse) GetTotalEstFeeSat() int64 {
+	if x != nil {
+		return x.TotalEstFeeSat
+	}
+	return 0
+}
+
+func (x *ExitSummaryResponse) GetTotalEstNetRecoveredSat() int64 {
+	if x != nil {
+		return x.TotalEstNetRecoveredSat
+	}
+	return 0
+}
+
 // SubscribeWalletRequest configures the WalletService.SubscribeWallet stream.
 type SubscribeWalletRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -4249,7 +4848,7 @@ type SubscribeWalletRequest struct {
 
 func (x *SubscribeWalletRequest) Reset() {
 	*x = SubscribeWalletRequest{}
-	mi := &file_wallet_proto_msgTypes[40]
+	mi := &file_wallet_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4261,7 +4860,7 @@ func (x *SubscribeWalletRequest) String() string {
 func (*SubscribeWalletRequest) ProtoMessage() {}
 
 func (x *SubscribeWalletRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[40]
+	mi := &file_wallet_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4274,7 +4873,7 @@ func (x *SubscribeWalletRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeWalletRequest.ProtoReflect.Descriptor instead.
 func (*SubscribeWalletRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{40}
+	return file_wallet_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *SubscribeWalletRequest) GetIncludeExisting() bool {
@@ -4321,7 +4920,7 @@ type SubscribeWalletResponse struct {
 
 func (x *SubscribeWalletResponse) Reset() {
 	*x = SubscribeWalletResponse{}
-	mi := &file_wallet_proto_msgTypes[41]
+	mi := &file_wallet_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4333,7 +4932,7 @@ func (x *SubscribeWalletResponse) String() string {
 func (*SubscribeWalletResponse) ProtoMessage() {}
 
 func (x *SubscribeWalletResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[41]
+	mi := &file_wallet_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4346,7 +4945,7 @@ func (x *SubscribeWalletResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeWalletResponse.ProtoReflect.Descriptor instead.
 func (*SubscribeWalletResponse) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{41}
+	return file_wallet_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *SubscribeWalletResponse) GetCursor() int64 {
@@ -4415,7 +5014,7 @@ type SubscribeGap struct {
 
 func (x *SubscribeGap) Reset() {
 	*x = SubscribeGap{}
-	mi := &file_wallet_proto_msgTypes[42]
+	mi := &file_wallet_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4427,7 +5026,7 @@ func (x *SubscribeGap) String() string {
 func (*SubscribeGap) ProtoMessage() {}
 
 func (x *SubscribeGap) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[42]
+	mi := &file_wallet_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4440,7 +5039,7 @@ func (x *SubscribeGap) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeGap.ProtoReflect.Descriptor instead.
 func (*SubscribeGap) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{42}
+	return file_wallet_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *SubscribeGap) GetReason() string {
@@ -4514,7 +5113,7 @@ type WalletEntry struct {
 
 func (x *WalletEntry) Reset() {
 	*x = WalletEntry{}
-	mi := &file_wallet_proto_msgTypes[43]
+	mi := &file_wallet_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4526,7 +5125,7 @@ func (x *WalletEntry) String() string {
 func (*WalletEntry) ProtoMessage() {}
 
 func (x *WalletEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[43]
+	mi := &file_wallet_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4539,7 +5138,7 @@ func (x *WalletEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletEntry.ProtoReflect.Descriptor instead.
 func (*WalletEntry) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{43}
+	return file_wallet_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *WalletEntry) GetId() string {
@@ -4650,7 +5249,7 @@ type WalletEntryRequest struct {
 
 func (x *WalletEntryRequest) Reset() {
 	*x = WalletEntryRequest{}
-	mi := &file_wallet_proto_msgTypes[44]
+	mi := &file_wallet_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4662,7 +5261,7 @@ func (x *WalletEntryRequest) String() string {
 func (*WalletEntryRequest) ProtoMessage() {}
 
 func (x *WalletEntryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[44]
+	mi := &file_wallet_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4675,7 +5274,7 @@ func (x *WalletEntryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletEntryRequest.ProtoReflect.Descriptor instead.
 func (*WalletEntryRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{44}
+	return file_wallet_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *WalletEntryRequest) GetRequest() isWalletEntryRequest_Request {
@@ -4753,7 +5352,7 @@ type LightningInvoiceRequest struct {
 
 func (x *LightningInvoiceRequest) Reset() {
 	*x = LightningInvoiceRequest{}
-	mi := &file_wallet_proto_msgTypes[45]
+	mi := &file_wallet_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4765,7 +5364,7 @@ func (x *LightningInvoiceRequest) String() string {
 func (*LightningInvoiceRequest) ProtoMessage() {}
 
 func (x *LightningInvoiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[45]
+	mi := &file_wallet_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4778,7 +5377,7 @@ func (x *LightningInvoiceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LightningInvoiceRequest.ProtoReflect.Descriptor instead.
 func (*LightningInvoiceRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{45}
+	return file_wallet_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *LightningInvoiceRequest) GetInvoice() string {
@@ -4807,7 +5406,7 @@ type OnchainAddressRequest struct {
 
 func (x *OnchainAddressRequest) Reset() {
 	*x = OnchainAddressRequest{}
-	mi := &file_wallet_proto_msgTypes[46]
+	mi := &file_wallet_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4819,7 +5418,7 @@ func (x *OnchainAddressRequest) String() string {
 func (*OnchainAddressRequest) ProtoMessage() {}
 
 func (x *OnchainAddressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[46]
+	mi := &file_wallet_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4832,7 +5431,7 @@ func (x *OnchainAddressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OnchainAddressRequest.ProtoReflect.Descriptor instead.
 func (*OnchainAddressRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{46}
+	return file_wallet_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *OnchainAddressRequest) GetAddress() string {
@@ -4853,7 +5452,7 @@ type ArkAddressRequest struct {
 
 func (x *ArkAddressRequest) Reset() {
 	*x = ArkAddressRequest{}
-	mi := &file_wallet_proto_msgTypes[47]
+	mi := &file_wallet_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4865,7 +5464,7 @@ func (x *ArkAddressRequest) String() string {
 func (*ArkAddressRequest) ProtoMessage() {}
 
 func (x *ArkAddressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[47]
+	mi := &file_wallet_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4878,7 +5477,7 @@ func (x *ArkAddressRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArkAddressRequest.ProtoReflect.Descriptor instead.
 func (*ArkAddressRequest) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{47}
+	return file_wallet_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ArkAddressRequest) GetAddress() string {
@@ -4916,7 +5515,7 @@ type WalletEntryProgress struct {
 
 func (x *WalletEntryProgress) Reset() {
 	*x = WalletEntryProgress{}
-	mi := &file_wallet_proto_msgTypes[48]
+	mi := &file_wallet_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4928,7 +5527,7 @@ func (x *WalletEntryProgress) String() string {
 func (*WalletEntryProgress) ProtoMessage() {}
 
 func (x *WalletEntryProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_wallet_proto_msgTypes[48]
+	mi := &file_wallet_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4941,7 +5540,7 @@ func (x *WalletEntryProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WalletEntryProgress.ProtoReflect.Descriptor instead.
 func (*WalletEntryProgress) Descriptor() ([]byte, []int) {
-	return file_wallet_proto_rawDescGZIP(), []int{48}
+	return file_wallet_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *WalletEntryProgress) GetPhase() WalletEntryPhase {
@@ -5252,16 +5851,64 @@ const file_wallet_proto_rawDesc = "" +
 	"\bactor_id\x18\x02 \x01(\tR\aactorId\x12)\n" +
 	"\x04mode\x18\x03 \x01(\x0e2\x15.walletdkrpc.ExitModeR\x04mode\x12)\n" +
 	"\x10queued_outpoints\x18\x04 \x03(\tR\x0fqueuedOutpoints\x12'\n" +
-	"\x0fonchain_address\x18\x05 \x01(\tR\x0eonchainAddress\"/\n" +
+	"\x0fonchain_address\x18\x05 \x01(\tR\x0eonchainAddress\"K\n" +
 	"\x11ExitStatusRequest\x12\x1a\n" +
-	"\boutpoint\x18\x01 \x01(\tR\boutpoint\"\x9c\x01\n" +
+	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x1a\n" +
+	"\bdetailed\x18\x02 \x01(\bR\bdetailed\"\xd5\x02\n" +
+	"\fExitProgress\x12#\n" +
+	"\rconfirmed_txs\x18\x01 \x01(\rR\fconfirmedTxs\x12\"\n" +
+	"\rin_flight_txs\x18\x02 \x01(\rR\vinFlightTxs\x12\x1b\n" +
+	"\tready_txs\x18\x03 \x01(\rR\breadyTxs\x12\x1f\n" +
+	"\vblocked_txs\x18\x04 \x01(\rR\n" +
+	"blockedTxs\x12\x1b\n" +
+	"\ttotal_txs\x18\x05 \x01(\rR\btotalTxs\x12#\n" +
+	"\rcurrent_layer\x18\x06 \x01(\rR\fcurrentLayer\x12!\n" +
+	"\ftotal_layers\x18\a \x01(\rR\vtotalLayers\x12)\n" +
+	"\x10target_confirmed\x18\b \x01(\bR\x0ftargetConfirmed\x12.\n" +
+	"\x13all_proof_confirmed\x18\t \x01(\bR\x11allProofConfirmed\"\xa9\x01\n" +
+	"\aExitCSV\x122\n" +
+	"\x15target_confirm_height\x18\x01 \x01(\x05R\x13targetConfirmHeight\x12'\n" +
+	"\x0fmaturity_height\x18\x02 \x01(\x05R\x0ematurityHeight\x12)\n" +
+	"\x10blocks_remaining\x18\x03 \x01(\x05R\x0fblocksRemaining\x12\x16\n" +
+	"\x06mature\x18\x04 \x01(\bR\x06mature\"\xca\x02\n" +
+	"\bExitFees\x12 \n" +
+	"\fcpfp_fee_sat\x18\x01 \x01(\x03R\n" +
+	"cpfpFeeSat\x12\"\n" +
+	"\rsweep_fee_sat\x18\x02 \x01(\x03R\vsweepFeeSat\x12$\n" +
+	"\x0etotal_cost_sat\x18\x03 \x01(\x03R\ftotalCostSat\x12&\n" +
+	"\x0fvtxo_amount_sat\x18\x04 \x01(\x03R\rvtxoAmountSat\x12*\n" +
+	"\x11net_recovered_sat\x18\x05 \x01(\x03R\x0fnetRecoveredSat\x12+\n" +
+	"\x12fee_rate_sat_vbyte\x18\x06 \x01(\x03R\x0ffeeRateSatVbyte\x12(\n" +
+	"\x10sweep_fee_actual\x18\a \x01(\bR\x0esweepFeeActual\x12'\n" +
+	"\x10spent_so_far_sat\x18\b \x01(\x03R\rspentSoFarSat\"\xad\x03\n" +
 	"\x12ExitStatusResponse\x12\x14\n" +
 	"\x05found\x18\x01 \x01(\bR\x05found\x122\n" +
 	"\x06status\x18\x02 \x01(\x0e2\x1a.walletdkrpc.ExitJobStatusR\x06status\x12\x1d\n" +
 	"\n" +
 	"sweep_txid\x18\x03 \x01(\tR\tsweepTxid\x12\x1d\n" +
 	"\n" +
-	"last_error\x18\x04 \x01(\tR\tlastError\"\x89\x01\n" +
+	"last_error\x18\x04 \x01(\tR\tlastError\x12!\n" +
+	"\fphase_detail\x18\x05 \x01(\tR\vphaseDetail\x125\n" +
+	"\bprogress\x18\x06 \x01(\v2\x19.walletdkrpc.ExitProgressR\bprogress\x12&\n" +
+	"\x03csv\x18\a \x01(\v2\x14.walletdkrpc.ExitCSVR\x03csv\x12)\n" +
+	"\x04fees\x18\b \x01(\v2\x15.walletdkrpc.ExitFeesR\x04fees\x12;\n" +
+	"\x1abest_case_blocks_remaining\x18\t \x01(\x05R\x17bestCaseBlocksRemaining\x12%\n" +
+	"\x0ecurrent_height\x18\n" +
+	" \x01(\x05R\rcurrentHeight\"\x14\n" +
+	"\x12ExitSummaryRequest\"\xe7\x01\n" +
+	"\x0fExitSummaryItem\x12\x1a\n" +
+	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x122\n" +
+	"\x06status\x18\x02 \x01(\x0e2\x1a.walletdkrpc.ExitJobStatusR\x06status\x12&\n" +
+	"\x0fvtxo_amount_sat\x18\x03 \x01(\x03R\rvtxoAmountSat\x12)\n" +
+	"\x11est_total_fee_sat\x18\x04 \x01(\x03R\x0eestTotalFeeSat\x121\n" +
+	"\x15est_net_recovered_sat\x18\x05 \x01(\x03R\x12estNetRecoveredSat\"\x86\x02\n" +
+	"\x13ExitSummaryResponse\x122\n" +
+	"\x05exits\x18\x01 \x03(\v2\x1c.walletdkrpc.ExitSummaryItemR\x05exits\x12\x1f\n" +
+	"\vtotal_exits\x18\x02 \x01(\rR\n" +
+	"totalExits\x121\n" +
+	"\x15total_vtxo_amount_sat\x18\x03 \x01(\x03R\x12totalVtxoAmountSat\x12)\n" +
+	"\x11total_est_fee_sat\x18\x04 \x01(\x03R\x0etotalEstFeeSat\x12<\n" +
+	"\x1btotal_est_net_recovered_sat\x18\x05 \x01(\x03R\x17totalEstNetRecoveredSat\"\x89\x01\n" +
 	"\x16SubscribeWalletRequest\x12)\n" +
 	"\x10include_existing\x18\x01 \x01(\bR\x0fincludeExisting\x12,\n" +
 	"\x05kinds\x18\x02 \x03(\x0e2\x16.walletdkrpc.EntryKindR\x05kinds\x12\x16\n" +
@@ -5369,7 +6016,7 @@ const file_wallet_proto_rawDesc = "" +
 	"\x1aENTRY_FAILURE_CODE_EXPIRED\x10\x02\x12\x1f\n" +
 	"\x1bENTRY_FAILURE_CODE_REFUNDED\x10\x03\x12)\n" +
 	"%ENTRY_FAILURE_CODE_NEEDS_INTERVENTION\x10\x04\x12\x1d\n" +
-	"\x19ENTRY_FAILURE_CODE_FAILED\x10\x052\xfd\a\n" +
+	"\x19ENTRY_FAILURE_CODE_FAILED\x10\x052\xcf\b\n" +
 	"\rWalletService\x12A\n" +
 	"\x06Create\x12\x1a.walletdkrpc.CreateRequest\x1a\x1b.walletdkrpc.CreateResponse\x12A\n" +
 	"\x06Unlock\x12\x1a.walletdkrpc.UnlockRequest\x1a\x1b.walletdkrpc.UnlockResponse\x12P\n" +
@@ -5384,7 +6031,8 @@ const file_wallet_proto_rawDesc = "" +
 	"\vSweepWallet\x12\x1f.walletdkrpc.SweepWalletRequest\x1a .walletdkrpc.SweepWalletResponse\x12;\n" +
 	"\x04Exit\x12\x18.walletdkrpc.ExitRequest\x1a\x19.walletdkrpc.ExitResponse\x12M\n" +
 	"\n" +
-	"ExitStatus\x12\x1e.walletdkrpc.ExitStatusRequest\x1a\x1f.walletdkrpc.ExitStatusResponse\x12^\n" +
+	"ExitStatus\x12\x1e.walletdkrpc.ExitStatusRequest\x1a\x1f.walletdkrpc.ExitStatusResponse\x12P\n" +
+	"\vExitSummary\x12\x1f.walletdkrpc.ExitSummaryRequest\x1a .walletdkrpc.ExitSummaryResponse\x12^\n" +
 	"\x0fSubscribeWallet\x12#.walletdkrpc.SubscribeWalletRequest\x1a$.walletdkrpc.SubscribeWalletResponse0\x012w\n" +
 	"\x17WalletInspectionService\x12\\\n" +
 	"\x0fInspectActivity\x12#.walletdkrpc.InspectActivityRequest\x1a$.walletdkrpc.InspectActivityResponseB8Z6github.com/lightninglabs/darepo-client/rpc/walletdkrpcb\x06proto3"
@@ -5402,7 +6050,7 @@ func file_wallet_proto_rawDescGZIP() []byte {
 }
 
 var file_wallet_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
-var file_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
+var file_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 55)
 var file_wallet_proto_goTypes = []any{
 	(EntryKind)(0),                  // 0: walletdkrpc.EntryKind
 	(EntryStatus)(0),                // 1: walletdkrpc.EntryStatus
@@ -5452,90 +6100,103 @@ var file_wallet_proto_goTypes = []any{
 	(*ExitRequest)(nil),             // 45: walletdkrpc.ExitRequest
 	(*ExitResponse)(nil),            // 46: walletdkrpc.ExitResponse
 	(*ExitStatusRequest)(nil),       // 47: walletdkrpc.ExitStatusRequest
-	(*ExitStatusResponse)(nil),      // 48: walletdkrpc.ExitStatusResponse
-	(*SubscribeWalletRequest)(nil),  // 49: walletdkrpc.SubscribeWalletRequest
-	(*SubscribeWalletResponse)(nil), // 50: walletdkrpc.SubscribeWalletResponse
-	(*SubscribeGap)(nil),            // 51: walletdkrpc.SubscribeGap
-	(*WalletEntry)(nil),             // 52: walletdkrpc.WalletEntry
-	(*WalletEntryRequest)(nil),      // 53: walletdkrpc.WalletEntryRequest
-	(*LightningInvoiceRequest)(nil), // 54: walletdkrpc.LightningInvoiceRequest
-	(*OnchainAddressRequest)(nil),   // 55: walletdkrpc.OnchainAddressRequest
-	(*ArkAddressRequest)(nil),       // 56: walletdkrpc.ArkAddressRequest
-	(*WalletEntryProgress)(nil),     // 57: walletdkrpc.WalletEntryProgress
+	(*ExitProgress)(nil),            // 48: walletdkrpc.ExitProgress
+	(*ExitCSV)(nil),                 // 49: walletdkrpc.ExitCSV
+	(*ExitFees)(nil),                // 50: walletdkrpc.ExitFees
+	(*ExitStatusResponse)(nil),      // 51: walletdkrpc.ExitStatusResponse
+	(*ExitSummaryRequest)(nil),      // 52: walletdkrpc.ExitSummaryRequest
+	(*ExitSummaryItem)(nil),         // 53: walletdkrpc.ExitSummaryItem
+	(*ExitSummaryResponse)(nil),     // 54: walletdkrpc.ExitSummaryResponse
+	(*SubscribeWalletRequest)(nil),  // 55: walletdkrpc.SubscribeWalletRequest
+	(*SubscribeWalletResponse)(nil), // 56: walletdkrpc.SubscribeWalletResponse
+	(*SubscribeGap)(nil),            // 57: walletdkrpc.SubscribeGap
+	(*WalletEntry)(nil),             // 58: walletdkrpc.WalletEntry
+	(*WalletEntryRequest)(nil),      // 59: walletdkrpc.WalletEntryRequest
+	(*LightningInvoiceRequest)(nil), // 60: walletdkrpc.LightningInvoiceRequest
+	(*OnchainAddressRequest)(nil),   // 61: walletdkrpc.OnchainAddressRequest
+	(*ArkAddressRequest)(nil),       // 62: walletdkrpc.ArkAddressRequest
+	(*WalletEntryProgress)(nil),     // 63: walletdkrpc.WalletEntryProgress
 }
 var file_wallet_proto_depIdxs = []int32{
 	3,  // 0: walletdkrpc.PrepareSendResponse.rail:type_name -> walletdkrpc.SendRail
 	4,  // 1: walletdkrpc.PrepareSendResponse.quote_status:type_name -> walletdkrpc.SendQuoteStatus
 	19, // 2: walletdkrpc.PrepareSendResponse.credit_preview:type_name -> walletdkrpc.CreditPreview
-	52, // 3: walletdkrpc.SendResponse.entry:type_name -> walletdkrpc.WalletEntry
-	52, // 4: walletdkrpc.RecvResponse.entry:type_name -> walletdkrpc.WalletEntry
+	58, // 3: walletdkrpc.SendResponse.entry:type_name -> walletdkrpc.WalletEntry
+	58, // 4: walletdkrpc.RecvResponse.entry:type_name -> walletdkrpc.WalletEntry
 	20, // 5: walletdkrpc.RecvResponse.credit_receive:type_name -> walletdkrpc.CreditReceive
 	2,  // 6: walletdkrpc.ListRequest.view:type_name -> walletdkrpc.ListView
 	0,  // 7: walletdkrpc.ListRequest.kinds:type_name -> walletdkrpc.EntryKind
 	23, // 8: walletdkrpc.ListResponse.activity:type_name -> walletdkrpc.ActivityList
 	24, // 9: walletdkrpc.ListResponse.vtxos:type_name -> walletdkrpc.VTXOInventory
 	26, // 10: walletdkrpc.ListResponse.onchain:type_name -> walletdkrpc.OnchainHistory
-	52, // 11: walletdkrpc.ActivityList.entries:type_name -> walletdkrpc.WalletEntry
+	58, // 11: walletdkrpc.ActivityList.entries:type_name -> walletdkrpc.WalletEntry
 	25, // 12: walletdkrpc.VTXOInventory.vtxos:type_name -> walletdkrpc.WalletVTXO
 	27, // 13: walletdkrpc.OnchainHistory.txs:type_name -> walletdkrpc.OnchainTx
-	52, // 14: walletdkrpc.InspectActivityResponse.entry:type_name -> walletdkrpc.WalletEntry
+	58, // 14: walletdkrpc.InspectActivityResponse.entry:type_name -> walletdkrpc.WalletEntry
 	30, // 15: walletdkrpc.InspectActivityResponse.swap:type_name -> walletdkrpc.ActivitySwapTrace
 	31, // 16: walletdkrpc.InspectActivityResponse.vtxos:type_name -> walletdkrpc.ActivityVTXOTrace
 	32, // 17: walletdkrpc.InspectActivityResponse.ledger_rows:type_name -> walletdkrpc.ActivityLedgerTrace
-	52, // 18: walletdkrpc.DepositResponse.entry:type_name -> walletdkrpc.WalletEntry
+	58, // 18: walletdkrpc.DepositResponse.entry:type_name -> walletdkrpc.WalletEntry
 	36, // 19: walletdkrpc.StatusResponse.balance:type_name -> walletdkrpc.BalanceResponse
 	6,  // 20: walletdkrpc.ExitPlanEntry.exit_status:type_name -> walletdkrpc.ExitJobStatus
 	40, // 21: walletdkrpc.GetExitPlanResponse.plans:type_name -> walletdkrpc.ExitPlanEntry
 	43, // 22: walletdkrpc.SweepWalletResponse.inputs:type_name -> walletdkrpc.WalletSweepInput
 	5,  // 23: walletdkrpc.ExitResponse.mode:type_name -> walletdkrpc.ExitMode
 	6,  // 24: walletdkrpc.ExitStatusResponse.status:type_name -> walletdkrpc.ExitJobStatus
-	0,  // 25: walletdkrpc.SubscribeWalletRequest.kinds:type_name -> walletdkrpc.EntryKind
-	52, // 26: walletdkrpc.SubscribeWalletResponse.entry:type_name -> walletdkrpc.WalletEntry
-	51, // 27: walletdkrpc.SubscribeWalletResponse.gap:type_name -> walletdkrpc.SubscribeGap
-	0,  // 28: walletdkrpc.WalletEntry.kind:type_name -> walletdkrpc.EntryKind
-	1,  // 29: walletdkrpc.WalletEntry.status:type_name -> walletdkrpc.EntryStatus
-	53, // 30: walletdkrpc.WalletEntry.request:type_name -> walletdkrpc.WalletEntryRequest
-	57, // 31: walletdkrpc.WalletEntry.progress:type_name -> walletdkrpc.WalletEntryProgress
-	8,  // 32: walletdkrpc.WalletEntry.failure_code:type_name -> walletdkrpc.EntryFailureCode
-	54, // 33: walletdkrpc.WalletEntryRequest.lightning_invoice:type_name -> walletdkrpc.LightningInvoiceRequest
-	55, // 34: walletdkrpc.WalletEntryRequest.onchain_address:type_name -> walletdkrpc.OnchainAddressRequest
-	56, // 35: walletdkrpc.WalletEntryRequest.ark_address:type_name -> walletdkrpc.ArkAddressRequest
-	7,  // 36: walletdkrpc.WalletEntryProgress.phase:type_name -> walletdkrpc.WalletEntryPhase
-	9,  // 37: walletdkrpc.WalletService.Create:input_type -> walletdkrpc.CreateRequest
-	11, // 38: walletdkrpc.WalletService.Unlock:input_type -> walletdkrpc.UnlockRequest
-	13, // 39: walletdkrpc.WalletService.PrepareSend:input_type -> walletdkrpc.PrepareSendRequest
-	15, // 40: walletdkrpc.WalletService.Send:input_type -> walletdkrpc.SendRequest
-	17, // 41: walletdkrpc.WalletService.Recv:input_type -> walletdkrpc.RecvRequest
-	21, // 42: walletdkrpc.WalletService.List:input_type -> walletdkrpc.ListRequest
-	33, // 43: walletdkrpc.WalletService.Deposit:input_type -> walletdkrpc.DepositRequest
-	35, // 44: walletdkrpc.WalletService.Balance:input_type -> walletdkrpc.BalanceRequest
-	37, // 45: walletdkrpc.WalletService.Status:input_type -> walletdkrpc.StatusRequest
-	39, // 46: walletdkrpc.WalletService.GetExitPlan:input_type -> walletdkrpc.GetExitPlanRequest
-	42, // 47: walletdkrpc.WalletService.SweepWallet:input_type -> walletdkrpc.SweepWalletRequest
-	45, // 48: walletdkrpc.WalletService.Exit:input_type -> walletdkrpc.ExitRequest
-	47, // 49: walletdkrpc.WalletService.ExitStatus:input_type -> walletdkrpc.ExitStatusRequest
-	49, // 50: walletdkrpc.WalletService.SubscribeWallet:input_type -> walletdkrpc.SubscribeWalletRequest
-	28, // 51: walletdkrpc.WalletInspectionService.InspectActivity:input_type -> walletdkrpc.InspectActivityRequest
-	10, // 52: walletdkrpc.WalletService.Create:output_type -> walletdkrpc.CreateResponse
-	12, // 53: walletdkrpc.WalletService.Unlock:output_type -> walletdkrpc.UnlockResponse
-	14, // 54: walletdkrpc.WalletService.PrepareSend:output_type -> walletdkrpc.PrepareSendResponse
-	16, // 55: walletdkrpc.WalletService.Send:output_type -> walletdkrpc.SendResponse
-	18, // 56: walletdkrpc.WalletService.Recv:output_type -> walletdkrpc.RecvResponse
-	22, // 57: walletdkrpc.WalletService.List:output_type -> walletdkrpc.ListResponse
-	34, // 58: walletdkrpc.WalletService.Deposit:output_type -> walletdkrpc.DepositResponse
-	36, // 59: walletdkrpc.WalletService.Balance:output_type -> walletdkrpc.BalanceResponse
-	38, // 60: walletdkrpc.WalletService.Status:output_type -> walletdkrpc.StatusResponse
-	41, // 61: walletdkrpc.WalletService.GetExitPlan:output_type -> walletdkrpc.GetExitPlanResponse
-	44, // 62: walletdkrpc.WalletService.SweepWallet:output_type -> walletdkrpc.SweepWalletResponse
-	46, // 63: walletdkrpc.WalletService.Exit:output_type -> walletdkrpc.ExitResponse
-	48, // 64: walletdkrpc.WalletService.ExitStatus:output_type -> walletdkrpc.ExitStatusResponse
-	50, // 65: walletdkrpc.WalletService.SubscribeWallet:output_type -> walletdkrpc.SubscribeWalletResponse
-	29, // 66: walletdkrpc.WalletInspectionService.InspectActivity:output_type -> walletdkrpc.InspectActivityResponse
-	52, // [52:67] is the sub-list for method output_type
-	37, // [37:52] is the sub-list for method input_type
-	37, // [37:37] is the sub-list for extension type_name
-	37, // [37:37] is the sub-list for extension extendee
-	0,  // [0:37] is the sub-list for field type_name
+	48, // 25: walletdkrpc.ExitStatusResponse.progress:type_name -> walletdkrpc.ExitProgress
+	49, // 26: walletdkrpc.ExitStatusResponse.csv:type_name -> walletdkrpc.ExitCSV
+	50, // 27: walletdkrpc.ExitStatusResponse.fees:type_name -> walletdkrpc.ExitFees
+	6,  // 28: walletdkrpc.ExitSummaryItem.status:type_name -> walletdkrpc.ExitJobStatus
+	53, // 29: walletdkrpc.ExitSummaryResponse.exits:type_name -> walletdkrpc.ExitSummaryItem
+	0,  // 30: walletdkrpc.SubscribeWalletRequest.kinds:type_name -> walletdkrpc.EntryKind
+	58, // 31: walletdkrpc.SubscribeWalletResponse.entry:type_name -> walletdkrpc.WalletEntry
+	57, // 32: walletdkrpc.SubscribeWalletResponse.gap:type_name -> walletdkrpc.SubscribeGap
+	0,  // 33: walletdkrpc.WalletEntry.kind:type_name -> walletdkrpc.EntryKind
+	1,  // 34: walletdkrpc.WalletEntry.status:type_name -> walletdkrpc.EntryStatus
+	59, // 35: walletdkrpc.WalletEntry.request:type_name -> walletdkrpc.WalletEntryRequest
+	63, // 36: walletdkrpc.WalletEntry.progress:type_name -> walletdkrpc.WalletEntryProgress
+	8,  // 37: walletdkrpc.WalletEntry.failure_code:type_name -> walletdkrpc.EntryFailureCode
+	60, // 38: walletdkrpc.WalletEntryRequest.lightning_invoice:type_name -> walletdkrpc.LightningInvoiceRequest
+	61, // 39: walletdkrpc.WalletEntryRequest.onchain_address:type_name -> walletdkrpc.OnchainAddressRequest
+	62, // 40: walletdkrpc.WalletEntryRequest.ark_address:type_name -> walletdkrpc.ArkAddressRequest
+	7,  // 41: walletdkrpc.WalletEntryProgress.phase:type_name -> walletdkrpc.WalletEntryPhase
+	9,  // 42: walletdkrpc.WalletService.Create:input_type -> walletdkrpc.CreateRequest
+	11, // 43: walletdkrpc.WalletService.Unlock:input_type -> walletdkrpc.UnlockRequest
+	13, // 44: walletdkrpc.WalletService.PrepareSend:input_type -> walletdkrpc.PrepareSendRequest
+	15, // 45: walletdkrpc.WalletService.Send:input_type -> walletdkrpc.SendRequest
+	17, // 46: walletdkrpc.WalletService.Recv:input_type -> walletdkrpc.RecvRequest
+	21, // 47: walletdkrpc.WalletService.List:input_type -> walletdkrpc.ListRequest
+	33, // 48: walletdkrpc.WalletService.Deposit:input_type -> walletdkrpc.DepositRequest
+	35, // 49: walletdkrpc.WalletService.Balance:input_type -> walletdkrpc.BalanceRequest
+	37, // 50: walletdkrpc.WalletService.Status:input_type -> walletdkrpc.StatusRequest
+	39, // 51: walletdkrpc.WalletService.GetExitPlan:input_type -> walletdkrpc.GetExitPlanRequest
+	42, // 52: walletdkrpc.WalletService.SweepWallet:input_type -> walletdkrpc.SweepWalletRequest
+	45, // 53: walletdkrpc.WalletService.Exit:input_type -> walletdkrpc.ExitRequest
+	47, // 54: walletdkrpc.WalletService.ExitStatus:input_type -> walletdkrpc.ExitStatusRequest
+	52, // 55: walletdkrpc.WalletService.ExitSummary:input_type -> walletdkrpc.ExitSummaryRequest
+	55, // 56: walletdkrpc.WalletService.SubscribeWallet:input_type -> walletdkrpc.SubscribeWalletRequest
+	28, // 57: walletdkrpc.WalletInspectionService.InspectActivity:input_type -> walletdkrpc.InspectActivityRequest
+	10, // 58: walletdkrpc.WalletService.Create:output_type -> walletdkrpc.CreateResponse
+	12, // 59: walletdkrpc.WalletService.Unlock:output_type -> walletdkrpc.UnlockResponse
+	14, // 60: walletdkrpc.WalletService.PrepareSend:output_type -> walletdkrpc.PrepareSendResponse
+	16, // 61: walletdkrpc.WalletService.Send:output_type -> walletdkrpc.SendResponse
+	18, // 62: walletdkrpc.WalletService.Recv:output_type -> walletdkrpc.RecvResponse
+	22, // 63: walletdkrpc.WalletService.List:output_type -> walletdkrpc.ListResponse
+	34, // 64: walletdkrpc.WalletService.Deposit:output_type -> walletdkrpc.DepositResponse
+	36, // 65: walletdkrpc.WalletService.Balance:output_type -> walletdkrpc.BalanceResponse
+	38, // 66: walletdkrpc.WalletService.Status:output_type -> walletdkrpc.StatusResponse
+	41, // 67: walletdkrpc.WalletService.GetExitPlan:output_type -> walletdkrpc.GetExitPlanResponse
+	44, // 68: walletdkrpc.WalletService.SweepWallet:output_type -> walletdkrpc.SweepWalletResponse
+	46, // 69: walletdkrpc.WalletService.Exit:output_type -> walletdkrpc.ExitResponse
+	51, // 70: walletdkrpc.WalletService.ExitStatus:output_type -> walletdkrpc.ExitStatusResponse
+	54, // 71: walletdkrpc.WalletService.ExitSummary:output_type -> walletdkrpc.ExitSummaryResponse
+	56, // 72: walletdkrpc.WalletService.SubscribeWallet:output_type -> walletdkrpc.SubscribeWalletResponse
+	29, // 73: walletdkrpc.WalletInspectionService.InspectActivity:output_type -> walletdkrpc.InspectActivityResponse
+	58, // [58:74] is the sub-list for method output_type
+	42, // [42:58] is the sub-list for method input_type
+	42, // [42:42] is the sub-list for extension type_name
+	42, // [42:42] is the sub-list for extension extendee
+	0,  // [0:42] is the sub-list for field type_name
 }
 
 func init() { file_wallet_proto_init() }
@@ -5552,12 +6213,12 @@ func file_wallet_proto_init() {
 		(*ListResponse_Vtxos)(nil),
 		(*ListResponse_Onchain)(nil),
 	}
-	file_wallet_proto_msgTypes[41].OneofWrappers = []any{
+	file_wallet_proto_msgTypes[47].OneofWrappers = []any{
 		(*SubscribeWalletResponse_Entry)(nil),
 		(*SubscribeWalletResponse_Gap)(nil),
 	}
-	file_wallet_proto_msgTypes[43].OneofWrappers = []any{}
-	file_wallet_proto_msgTypes[44].OneofWrappers = []any{
+	file_wallet_proto_msgTypes[49].OneofWrappers = []any{}
+	file_wallet_proto_msgTypes[50].OneofWrappers = []any{
 		(*WalletEntryRequest_LightningInvoice)(nil),
 		(*WalletEntryRequest_OnchainAddress)(nil),
 		(*WalletEntryRequest_ArkAddress)(nil),
@@ -5568,7 +6229,7 @@ func file_wallet_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_wallet_proto_rawDesc), len(file_wallet_proto_rawDesc)),
 			NumEnums:      9,
-			NumMessages:   49,
+			NumMessages:   55,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/rpc/walletdkrpc/wallet.pb.gw.go
+++ b/rpc/walletdkrpc/wallet.pb.gw.go
@@ -386,6 +386,33 @@ func local_request_WalletService_ExitStatus_0(ctx context.Context, marshaler run
 	return msg, metadata, err
 }
 
+func request_WalletService_ExitSummary_0(ctx context.Context, marshaler runtime.Marshaler, client WalletServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ExitSummaryRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ExitSummary(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_WalletService_ExitSummary_0(ctx context.Context, marshaler runtime.Marshaler, server WalletServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ExitSummaryRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ExitSummary(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_WalletService_SubscribeWallet_0(ctx context.Context, marshaler runtime.Marshaler, client WalletServiceClient, req *http.Request, pathParams map[string]string) (WalletService_SubscribeWalletClient, runtime.ServerMetadata, error) {
 	var (
 		protoReq SubscribeWalletRequest
@@ -702,6 +729,26 @@ func RegisterWalletServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_WalletService_ExitStatus_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_WalletService_ExitSummary_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/walletdkrpc.WalletService/ExitSummary", runtime.WithHTTPPathPattern("/v1/wallet/exit-summary"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_WalletService_ExitSummary_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_WalletService_ExitSummary_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	mux.Handle(http.MethodPost, pattern_WalletService_SubscribeWallet_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		err := status.Error(codes.Unimplemented, "streaming calls are not yet supported in the in-process transport")
@@ -1000,6 +1047,23 @@ func RegisterWalletServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_WalletService_ExitStatus_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_WalletService_ExitSummary_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/walletdkrpc.WalletService/ExitSummary", runtime.WithHTTPPathPattern("/v1/wallet/exit-summary"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_WalletService_ExitSummary_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_WalletService_ExitSummary_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_WalletService_SubscribeWallet_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -1034,6 +1098,7 @@ var (
 	pattern_WalletService_SweepWallet_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "wallet", "sweep-wallet"}, ""))
 	pattern_WalletService_Exit_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "wallet", "exit"}, ""))
 	pattern_WalletService_ExitStatus_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "wallet", "exit-status"}, ""))
+	pattern_WalletService_ExitSummary_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "wallet", "exit-summary"}, ""))
 	pattern_WalletService_SubscribeWallet_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "wallet", "subscribe"}, ""))
 )
 
@@ -1051,6 +1116,7 @@ var (
 	forward_WalletService_SweepWallet_0     = runtime.ForwardResponseMessage
 	forward_WalletService_Exit_0            = runtime.ForwardResponseMessage
 	forward_WalletService_ExitStatus_0      = runtime.ForwardResponseMessage
+	forward_WalletService_ExitSummary_0     = runtime.ForwardResponseMessage
 	forward_WalletService_SubscribeWallet_0 = runtime.ForwardResponseStream
 )
 

--- a/rpc/walletdkrpc/wallet.proto
+++ b/rpc/walletdkrpc/wallet.proto
@@ -87,6 +87,11 @@ service WalletService {
     // sweep state. Proxies daemonrpc.GetUnrollStatus.
     rpc ExitStatus (ExitStatusRequest) returns (ExitStatusResponse);
 
+    // ExitSummary reports the wallet-wide portfolio of in-progress exits:
+    // one row per active exit plus aggregate totals for the amount still
+    // being recovered, the estimated fees, and the estimated net recoverable.
+    rpc ExitSummary (ExitSummaryRequest) returns (ExitSummaryResponse);
+
     // SubscribeWallet streams activity updates as they happen. The stream
     // is resumable: each response carries a monotonic cursor the client can
     // reconnect from to replay everything after it without gaps.
@@ -1190,6 +1195,99 @@ message ExitStatusRequest {
     // outpoint is the VTXO outpoint to query, formatted as
     // "txid:index".
     string outpoint = 1;
+
+    // detailed enriches the response with tree/CSV progress and a fee
+    // breakdown. It costs one extra child actor round-trip plus a fee
+    // estimate, so it should be set only for interactive status commands, not
+    // automated polling.
+    bool detailed = 2;
+}
+
+// ExitProgress describes materialization progress through the exit proof tree.
+// It is populated only for a detailed query against a live exit job.
+message ExitProgress {
+    // confirmed_txs is the number of proof transactions confirmed on-chain.
+    uint32 confirmed_txs = 1;
+
+    // in_flight_txs is the number of proof transactions broadcast but not yet
+    // observed confirmed.
+    uint32 in_flight_txs = 2;
+
+    // ready_txs is the number of proof transactions ready to broadcast now.
+    uint32 ready_txs = 3;
+
+    // blocked_txs is the number of proof transactions still waiting on an
+    // unconfirmed in-proof parent.
+    uint32 blocked_txs = 4;
+
+    // total_txs is the total number of transactions in the exit proof tree.
+    uint32 total_txs = 5;
+
+    // current_layer is the frontier layer index: the shallowest topological
+    // layer (roots first) that still holds an unconfirmed transaction.
+    uint32 current_layer = 6;
+
+    // total_layers is the depth of the exit proof tree.
+    uint32 total_layers = 7;
+
+    // target_confirmed is true once the target VTXO transaction has confirmed.
+    bool target_confirmed = 8;
+
+    // all_proof_confirmed is true once every proof-tree transaction has
+    // confirmed, so only the CSV wait and final sweep remain.
+    bool all_proof_confirmed = 9;
+}
+
+// ExitCSV describes the target's CSV maturity countdown. It is populated only
+// once the target transaction has confirmed.
+message ExitCSV {
+    // target_confirm_height is the block height at which the target confirmed.
+    int32 target_confirm_height = 1;
+
+    // maturity_height is the block height at which the target becomes
+    // timeout-spendable.
+    int32 maturity_height = 2;
+
+    // blocks_remaining is how many blocks remain until CSV maturity.
+    int32 blocks_remaining = 3;
+
+    // mature is true once the current height is at or past maturity.
+    bool mature = 4;
+}
+
+// ExitFees breaks down the on-chain cost of the exit. The CPFP total is
+// estimated from the current fee rate; the sweep fee is the actual built-sweep
+// fee once known, otherwise estimated.
+message ExitFees {
+    // cpfp_fee_sat is the wallet-funded CPFP fee across every recovery
+    // transaction (estimated).
+    int64 cpfp_fee_sat = 1;
+
+    // sweep_fee_sat is the fee the final sweep pays out of the VTXO value.
+    int64 sweep_fee_sat = 2;
+
+    // total_cost_sat is cpfp_fee_sat + sweep_fee_sat.
+    int64 total_cost_sat = 3;
+
+    // vtxo_amount_sat is the value of the VTXO being exited.
+    int64 vtxo_amount_sat = 4;
+
+    // net_recovered_sat is vtxo_amount_sat - sweep_fee_sat.
+    int64 net_recovered_sat = 5;
+
+    // fee_rate_sat_vbyte is the fee rate used for the estimate.
+    int64 fee_rate_sat_vbyte = 6;
+
+    // sweep_fee_actual is true when sweep_fee_sat is the real built-sweep fee
+    // rather than an estimate.
+    bool sweep_fee_actual = 7;
+
+    // spent_so_far_sat is the estimated on-chain fee already committed at this
+    // point in the exit: CPFP for the confirmed and in-flight recovery
+    // transactions, plus the sweep fee once the sweep is broadcast. It is an
+    // estimate, not a realized total; total_cost_sat remains the projected cost
+    // of the whole exit.
+    int64 spent_so_far_sat = 8;
 }
 
 // ExitJobStatus collapses the underlying unroll job phases to a short
@@ -1240,6 +1338,81 @@ message ExitStatusResponse {
     // last_error contains the failure reason if the job is in FAILED
     // status.
     string last_error = 4;
+
+    // phase_detail is a human-readable one-line description of the current
+    // phase, e.g. "materializing layer 2 of 4 (3/7 txs confirmed)". Set only
+    // on a detailed query.
+    string phase_detail = 5;
+
+    // progress is the tree materialization progress. Set only on a detailed
+    // query against a live job.
+    ExitProgress progress = 6;
+
+    // csv is the CSV maturity countdown. Set only on a detailed query, once
+    // the target has confirmed.
+    ExitCSV csv = 7;
+
+    // fees is the on-chain cost breakdown for the exit. Set only on a detailed
+    // query.
+    ExitFees fees = 8;
+
+    // best_case_blocks_remaining is the optimistic block count until a
+    // confirmed sweep. Set only on a detailed query.
+    int32 best_case_blocks_remaining = 9;
+
+    // current_height is the best block height the exit job has observed. Set
+    // only on a detailed query against a live job.
+    int32 current_height = 10;
+}
+
+// ExitSummaryRequest asks for the wallet-wide portfolio of in-progress exits.
+message ExitSummaryRequest {
+}
+
+// ExitSummaryItem is one in-progress exit's coarse contribution to the
+// portfolio. It is intentionally cheap (phase plus amounts and estimated fees
+// from the persisted descriptor), so the summary does not query each live
+// actor; use ExitStatus --detailed for one exit's tree/CSV progress.
+message ExitSummaryItem {
+    // outpoint is the exiting VTXO outpoint, formatted as "txid:index".
+    string outpoint = 1;
+
+    // status is the current high-level phase of the exit job.
+    ExitJobStatus status = 2;
+
+    // vtxo_amount_sat is the value of the VTXO being exited.
+    int64 vtxo_amount_sat = 3;
+
+    // est_total_fee_sat is the projected total on-chain fee for this exit
+    // (estimated CPFP total plus sweep fee).
+    int64 est_total_fee_sat = 4;
+
+    // est_net_recovered_sat is the estimated value that lands back in the
+    // wallet after the sweep fee.
+    int64 est_net_recovered_sat = 5;
+}
+
+// ExitSummaryResponse is the wallet-wide portfolio of in-progress exits plus
+// aggregate totals. Only non-terminal exits are included: a completed or failed
+// exit has no amount "left" to recover.
+message ExitSummaryResponse {
+    // exits is one row per in-progress exit.
+    repeated ExitSummaryItem exits = 1;
+
+    // total_exits is the number of in-progress exits.
+    uint32 total_exits = 2;
+
+    // total_vtxo_amount_sat is the summed value of every VTXO still being
+    // exited: the total amount currently locked in in-progress exits.
+    int64 total_vtxo_amount_sat = 3;
+
+    // total_est_fee_sat is the summed projected on-chain fee across every
+    // in-progress exit.
+    int64 total_est_fee_sat = 4;
+
+    // total_est_net_recovered_sat is the summed estimated value that will land
+    // back in the wallet once every in-progress exit completes.
+    int64 total_est_net_recovered_sat = 5;
 }
 
 // SubscribeWalletRequest configures the WalletService.SubscribeWallet stream.

--- a/rpc/walletdkrpc/wallet.yaml
+++ b/rpc/walletdkrpc/wallet.yaml
@@ -42,6 +42,9 @@ http:
     - selector: walletdkrpc.WalletService.ExitStatus
       post: /v1/wallet/exit-status
       body: "*"
+    - selector: walletdkrpc.WalletService.ExitSummary
+      post: /v1/wallet/exit-summary
+      body: "*"
     - selector: walletdkrpc.WalletService.SubscribeWallet
       post: /v1/wallet/subscribe
       body: "*"

--- a/rpc/walletdkrpc/wallet_grpc.pb.go
+++ b/rpc/walletdkrpc/wallet_grpc.pb.go
@@ -32,6 +32,7 @@ const (
 	WalletService_SweepWallet_FullMethodName     = "/walletdkrpc.WalletService/SweepWallet"
 	WalletService_Exit_FullMethodName            = "/walletdkrpc.WalletService/Exit"
 	WalletService_ExitStatus_FullMethodName      = "/walletdkrpc.WalletService/ExitStatus"
+	WalletService_ExitSummary_FullMethodName     = "/walletdkrpc.WalletService/ExitSummary"
 	WalletService_SubscribeWallet_FullMethodName = "/walletdkrpc.WalletService/SubscribeWallet"
 )
 
@@ -109,6 +110,10 @@ type WalletServiceClient interface {
 	// specified VTXO outpoint, including recovery chain progress and
 	// sweep state. Proxies daemonrpc.GetUnrollStatus.
 	ExitStatus(ctx context.Context, in *ExitStatusRequest, opts ...grpc.CallOption) (*ExitStatusResponse, error)
+	// ExitSummary reports the wallet-wide portfolio of in-progress exits:
+	// one row per active exit plus aggregate totals for the amount still
+	// being recovered, the estimated fees, and the estimated net recoverable.
+	ExitSummary(ctx context.Context, in *ExitSummaryRequest, opts ...grpc.CallOption) (*ExitSummaryResponse, error)
 	// SubscribeWallet streams activity updates as they happen. The stream
 	// is resumable: each response carries a monotonic cursor the client can
 	// reconnect from to replay everything after it without gaps.
@@ -253,6 +258,16 @@ func (c *walletServiceClient) ExitStatus(ctx context.Context, in *ExitStatusRequ
 	return out, nil
 }
 
+func (c *walletServiceClient) ExitSummary(ctx context.Context, in *ExitSummaryRequest, opts ...grpc.CallOption) (*ExitSummaryResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ExitSummaryResponse)
+	err := c.cc.Invoke(ctx, WalletService_ExitSummary_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *walletServiceClient) SubscribeWallet(ctx context.Context, in *SubscribeWalletRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SubscribeWalletResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &WalletService_ServiceDesc.Streams[0], WalletService_SubscribeWallet_FullMethodName, cOpts...)
@@ -346,6 +361,10 @@ type WalletServiceServer interface {
 	// specified VTXO outpoint, including recovery chain progress and
 	// sweep state. Proxies daemonrpc.GetUnrollStatus.
 	ExitStatus(context.Context, *ExitStatusRequest) (*ExitStatusResponse, error)
+	// ExitSummary reports the wallet-wide portfolio of in-progress exits:
+	// one row per active exit plus aggregate totals for the amount still
+	// being recovered, the estimated fees, and the estimated net recoverable.
+	ExitSummary(context.Context, *ExitSummaryRequest) (*ExitSummaryResponse, error)
 	// SubscribeWallet streams activity updates as they happen. The stream
 	// is resumable: each response carries a monotonic cursor the client can
 	// reconnect from to replay everything after it without gaps.
@@ -398,6 +417,9 @@ func (UnimplementedWalletServiceServer) Exit(context.Context, *ExitRequest) (*Ex
 }
 func (UnimplementedWalletServiceServer) ExitStatus(context.Context, *ExitStatusRequest) (*ExitStatusResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ExitStatus not implemented")
+}
+func (UnimplementedWalletServiceServer) ExitSummary(context.Context, *ExitSummaryRequest) (*ExitSummaryResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ExitSummary not implemented")
 }
 func (UnimplementedWalletServiceServer) SubscribeWallet(*SubscribeWalletRequest, grpc.ServerStreamingServer[SubscribeWalletResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method SubscribeWallet not implemented")
@@ -657,6 +679,24 @@ func _WalletService_ExitStatus_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _WalletService_ExitSummary_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ExitSummaryRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WalletServiceServer).ExitSummary(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WalletService_ExitSummary_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WalletServiceServer).ExitSummary(ctx, req.(*ExitSummaryRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _WalletService_SubscribeWallet_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(SubscribeWalletRequest)
 	if err := stream.RecvMsg(m); err != nil {
@@ -726,6 +766,10 @@ var WalletService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ExitStatus",
 			Handler:    _WalletService_ExitStatus_Handler,
+		},
+		{
+			MethodName: "ExitSummary",
+			Handler:    _WalletService_ExitSummary_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/rpc/walletdkrpc/wallet_mailboxrpc.pb.go
+++ b/rpc/walletdkrpc/wallet_mailboxrpc.pb.go
@@ -50,6 +50,8 @@ type WalletServiceMailboxServer interface {
 	Exit(ctx context.Context, req *ExitRequest) (*ExitResponse, error)
 	// ExitStatus handles ExitStatus.
 	ExitStatus(ctx context.Context, req *ExitStatusRequest) (*ExitStatusResponse, error)
+	// ExitSummary handles ExitSummary.
+	ExitSummary(ctx context.Context, req *ExitSummaryRequest) (*ExitSummaryResponse, error)
 	// SubscribeWallet handles SubscribeWallet.
 	SubscribeWallet(ctx context.Context, req *SubscribeWalletRequest) (*SubscribeWalletResponse, error)
 }
@@ -185,6 +187,16 @@ func RegisterWalletServiceMailboxServer(r rpc.Router, impl WalletServiceMailboxS
 		}
 
 		return impl.ExitStatus(ctx, req)
+	})
+	r.Handle("walletdkrpc.WalletService", "ExitSummary", func() proto.Message {
+		return &ExitSummaryRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*ExitSummaryRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.ExitSummary(ctx, req)
 	})
 	r.Handle("walletdkrpc.WalletService", "SubscribeWallet", func() proto.Message {
 		return &SubscribeWalletRequest{}
@@ -490,6 +502,29 @@ func (c *WalletServiceMailboxClient) ExitStatus(ctx context.Context, req *ExitSt
 	}
 
 	resp := new(ExitStatusResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// ExitSummary calls the ExitSummary RPC.
+func (c *WalletServiceMailboxClient) ExitSummary(ctx context.Context, req *ExitSummaryRequest, opts ...rpc.RPCOptions) (*ExitSummaryResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "walletdkrpc.WalletService",
+		Method:  "ExitSummary",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(ExitSummaryResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}

--- a/sdk/walletdk/client.go
+++ b/sdk/walletdk/client.go
@@ -529,17 +529,33 @@ func (c *Client) ExitStatus(ctx context.Context, req ExitStatusRequest) (
 
 	resp, err := c.wallet.ExitStatus(ctx, &walletdkrpc.ExitStatusRequest{
 		Outpoint: req.Outpoint,
+		Detailed: req.Detailed,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("exit status: %w", err)
 	}
 
-	return &ExitStatusResult{
-		Found:     resp.GetFound(),
-		Status:    exitJobStatusFromProto(resp.GetStatus()),
-		SweepTxid: resp.GetSweepTxid(),
-		LastError: resp.GetLastError(),
-	}, nil
+	return exitStatusResultFromProto(resp), nil
+}
+
+// ExitSummary returns the wallet-wide portfolio of in-progress exits plus
+// aggregate totals: the amount still being recovered, the estimated fees, and
+// the estimated net recoverable. Completed and failed exits are omitted.
+func (c *Client) ExitSummary(ctx context.Context, _ ExitSummaryRequest) (
+	*ExitSummaryResult, error) {
+
+	if err := c.requireWalletRPC(); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.wallet.ExitSummary(
+		ctx, &walletdkrpc.ExitSummaryRequest{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("exit summary: %w", err)
+	}
+
+	return exitSummaryFromProto(resp), nil
 }
 
 // GetExitPlan previews whether the backing wallet is ready to start a

--- a/sdk/walletdk/convert.go
+++ b/sdk/walletdk/convert.go
@@ -217,6 +217,119 @@ func exitJobStatusFromProto(s walletdkrpc.ExitJobStatus) ExitJobStatus {
 	}
 }
 
+// exitStatusResultFromProto projects the walletdkrpc ExitStatus response onto
+// its SDK DTO, mapping the optional progress, CSV, and fee sub-messages to nil
+// pointers when the daemon did not populate them (a coarse query).
+func exitStatusResultFromProto(
+	resp *walletdkrpc.ExitStatusResponse) *ExitStatusResult {
+
+	if resp == nil {
+		return &ExitStatusResult{}
+	}
+
+	return &ExitStatusResult{
+		Found: resp.GetFound(),
+		Status: exitJobStatusFromProto(
+			resp.GetStatus(),
+		),
+		SweepTxid:   resp.GetSweepTxid(),
+		LastError:   resp.GetLastError(),
+		PhaseDetail: resp.GetPhaseDetail(),
+		Progress: exitProgressFromProto(
+			resp.GetProgress(),
+		),
+		CSV:                     exitCSVFromProto(resp.GetCsv()),
+		Fees:                    exitFeesFromProto(resp.GetFees()),
+		BestCaseBlocksRemaining: resp.GetBestCaseBlocksRemaining(),
+		CurrentHeight:           resp.GetCurrentHeight(),
+	}
+}
+
+// exitProgressFromProto projects the proto progress message, returning nil when
+// absent so callers nil-check rather than reading a zeroed struct.
+func exitProgressFromProto(p *walletdkrpc.ExitProgress) *ExitProgress {
+	if p == nil {
+		return nil
+	}
+
+	return &ExitProgress{
+		ConfirmedTxs:      p.GetConfirmedTxs(),
+		InFlightTxs:       p.GetInFlightTxs(),
+		ReadyTxs:          p.GetReadyTxs(),
+		BlockedTxs:        p.GetBlockedTxs(),
+		TotalTxs:          p.GetTotalTxs(),
+		CurrentLayer:      p.GetCurrentLayer(),
+		TotalLayers:       p.GetTotalLayers(),
+		TargetConfirmed:   p.GetTargetConfirmed(),
+		AllProofConfirmed: p.GetAllProofConfirmed(),
+	}
+}
+
+// exitCSVFromProto projects the proto CSV countdown, returning nil until the
+// target confirms.
+func exitCSVFromProto(c *walletdkrpc.ExitCSV) *ExitCSV {
+	if c == nil {
+		return nil
+	}
+
+	return &ExitCSV{
+		TargetConfirmHeight: c.GetTargetConfirmHeight(),
+		MaturityHeight:      c.GetMaturityHeight(),
+		BlocksRemaining:     c.GetBlocksRemaining(),
+		Mature:              c.GetMature(),
+	}
+}
+
+// exitFeesFromProto projects the proto fee breakdown, returning nil when the
+// daemon did not populate it.
+func exitFeesFromProto(f *walletdkrpc.ExitFees) *ExitFees {
+	if f == nil {
+		return nil
+	}
+
+	return &ExitFees{
+		CPFPFeeSat:      f.GetCpfpFeeSat(),
+		SweepFeeSat:     f.GetSweepFeeSat(),
+		TotalCostSat:    f.GetTotalCostSat(),
+		SpentSoFarSat:   f.GetSpentSoFarSat(),
+		VTXOAmountSat:   f.GetVtxoAmountSat(),
+		NetRecoveredSat: f.GetNetRecoveredSat(),
+		FeeRateSatVByte: f.GetFeeRateSatVbyte(),
+		SweepFeeActual:  f.GetSweepFeeActual(),
+	}
+}
+
+// exitSummaryFromProto projects the walletdkrpc ExitSummary response onto its
+// SDK DTO.
+func exitSummaryFromProto(
+	resp *walletdkrpc.ExitSummaryResponse) *ExitSummaryResult {
+
+	if resp == nil {
+		return &ExitSummaryResult{}
+	}
+
+	exits := make([]ExitSummaryEntry, 0, len(resp.GetExits()))
+	for _, e := range resp.GetExits() {
+		exits = append(exits, ExitSummaryEntry{
+			Outpoint: e.GetOutpoint(),
+			Status: exitJobStatusFromProto(
+				e.GetStatus(),
+			),
+			VTXOAmountSat:      e.GetVtxoAmountSat(),
+			EstTotalFeeSat:     e.GetEstTotalFeeSat(),
+			EstNetRecoveredSat: e.GetEstNetRecoveredSat(),
+		})
+	}
+
+	return &ExitSummaryResult{
+		Exits:                   exits,
+		TotalExits:              resp.GetTotalExits(),
+		TotalVTXOAmountSat:      resp.GetTotalVtxoAmountSat(),
+		TotalEstFeeSat:          resp.GetTotalEstFeeSat(),
+		TotalEstNetRecoveredSat: resp.GetTotalEstNetRecoveredSat(),
+	}
+}
+
 func exitPlanFromProto(r *walletdkrpc.GetExitPlanResponse) *GetExitPlanResult {
 	if r == nil {
 		return &GetExitPlanResult{}

--- a/sdk/walletdk/mobile/wallet.go
+++ b/sdk/walletdk/mobile/wallet.go
@@ -233,6 +233,28 @@ func ExitStatus(reqJSON []byte) ([]byte, error) {
 	return marshal(res)
 }
 
+// ExitSummary reports the wallet-wide portfolio of in-progress exits. reqJSON
+// decodes to walletdk.ExitSummaryRequest (an empty object is fine); the
+// response is walletdk.ExitSummaryResult.
+func ExitSummary(reqJSON []byte) ([]byte, error) {
+	client, ctx, err := activeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var req walletdk.ExitSummaryRequest
+	if err := decode(reqJSON, &req); err != nil {
+		return nil, err
+	}
+
+	res, err := client.ExitSummary(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshal(res)
+}
+
 // GetExitPlan previews unilateral-exit readiness for a set of VTXOs. reqJSON
 // decodes to walletdk.GetExitPlanRequest; the response is
 // walletdk.GetExitPlanResult.

--- a/sdk/walletdk/types.go
+++ b/sdk/walletdk/types.go
@@ -465,6 +465,12 @@ type ExitResult struct {
 // ExitStatusRequest queries the current phase of an exit job.
 type ExitStatusRequest struct {
 	Outpoint string
+
+	// Detailed requests recovery-tree progress, a CSV maturity countdown,
+	// a fee breakdown, and a best-case block countdown. It costs one live
+	// actor round-trip plus a fee estimate, so leave it false for a coarse,
+	// cheaper phase-only status.
+	Detailed bool
 }
 
 // ExitJobStatus collapses the underlying unroll job phases to a short
@@ -488,6 +494,90 @@ type ExitStatusResult struct {
 	Status    ExitJobStatus
 	SweepTxid string
 	LastError string
+
+	// PhaseDetail is a one-line human description of the current phase.
+	// Empty on a coarse (non-detailed) query.
+	PhaseDetail string
+
+	// Progress is the recovery-tree materialization progress. Nil on a
+	// coarse query, or when no live actor backs the job.
+	Progress *ExitProgress
+
+	// CSV is the target's CSV maturity countdown. Nil until the target
+	// confirms.
+	CSV *ExitCSV
+
+	// Fees is the on-chain cost breakdown for the exit. Nil on a coarse
+	// query.
+	Fees *ExitFees
+
+	// BestCaseBlocksRemaining is the optimistic block count until a
+	// confirmed sweep. Zero on a coarse query.
+	BestCaseBlocksRemaining int32
+
+	// CurrentHeight is the best block height the exit job has observed.
+	// Zero on a coarse query, or when no live actor backs the job.
+	CurrentHeight int32
+}
+
+// ExitProgress describes materialization progress through the recovery tree.
+type ExitProgress struct {
+	ConfirmedTxs      uint32
+	InFlightTxs       uint32
+	ReadyTxs          uint32
+	BlockedTxs        uint32
+	TotalTxs          uint32
+	CurrentLayer      uint32
+	TotalLayers       uint32
+	TargetConfirmed   bool
+	AllProofConfirmed bool
+}
+
+// ExitCSV describes the target's CSV maturity countdown, populated once the
+// target transaction confirms.
+type ExitCSV struct {
+	TargetConfirmHeight int32
+	MaturityHeight      int32
+	BlocksRemaining     int32
+	Mature              bool
+}
+
+// ExitFees breaks down the on-chain cost of the exit. The CPFP total is
+// estimated; SweepFeeActual reports whether SweepFeeSat is the real built-sweep
+// fee rather than an estimate. SpentSoFarSat is the estimated fee committed so
+// far, while TotalCostSat is the projected cost of the whole exit.
+type ExitFees struct {
+	CPFPFeeSat      int64
+	SweepFeeSat     int64
+	TotalCostSat    int64
+	SpentSoFarSat   int64
+	VTXOAmountSat   int64
+	NetRecoveredSat int64
+	FeeRateSatVByte int64
+	SweepFeeActual  bool
+}
+
+// ExitSummaryRequest asks for the wallet-wide portfolio of in-progress exits.
+type ExitSummaryRequest struct{}
+
+// ExitSummaryResult is the wallet-wide portfolio of in-progress exits plus
+// aggregate totals. Only non-terminal exits are included.
+type ExitSummaryResult struct {
+	Exits                   []ExitSummaryEntry
+	TotalExits              uint32
+	TotalVTXOAmountSat      int64
+	TotalEstFeeSat          int64
+	TotalEstNetRecoveredSat int64
+}
+
+// ExitSummaryEntry is one in-progress exit's coarse contribution to the
+// portfolio.
+type ExitSummaryEntry struct {
+	Outpoint           string
+	Status             ExitJobStatus
+	VTXOAmountSat      int64
+	EstTotalFeeSat     int64
+	EstNetRecoveredSat int64
 }
 
 // GetExitPlanRequest previews unilateral-exit readiness for a slice of VTXOs.

--- a/swapwallet/admin.go
+++ b/swapwallet/admin.go
@@ -391,6 +391,7 @@ func (s *Service) exitStatus(ctx context.Context,
 	resp, err := s.deps.RPCServer.GetUnrollStatus(
 		ctx, &daemonrpc.GetUnrollStatusRequest{
 			Outpoint: req.GetOutpoint(),
+			Detailed: req.GetDetailed(),
 		},
 	)
 	if err != nil {
@@ -399,11 +400,115 @@ func (s *Service) exitStatus(ctx context.Context,
 	}
 
 	return &walletdkrpc.ExitStatusResponse{
-		Found:     resp.GetFound(),
-		Status:    exitStatusFromDaemon(resp.GetStatus()),
-		SweepTxid: resp.GetSweepTxid(),
-		LastError: resp.GetLastError(),
+		Found:       resp.GetFound(),
+		Status:      exitStatusFromDaemon(resp.GetStatus()),
+		SweepTxid:   resp.GetSweepTxid(),
+		LastError:   resp.GetLastError(),
+		PhaseDetail: resp.GetPhaseDetail(),
+		Progress: exitProgressFromDaemon(
+			resp.GetProgress(),
+		),
+		Csv:                     exitCSVFromDaemon(resp.GetCsv()),
+		Fees:                    exitFeesFromDaemon(resp.GetFees()),
+		BestCaseBlocksRemaining: resp.GetBestCaseBlocksRemaining(),
+		CurrentHeight:           resp.GetCurrentHeight(),
 	}, nil
+}
+
+// exitProgressFromDaemon projects the daemon's UnrollProgress onto the
+// wallet-facing ExitProgress. It returns nil when the daemon supplied no
+// progress (a coarse query, or a terminal job with no live actor).
+func exitProgressFromDaemon(
+	p *daemonrpc.UnrollProgress) *walletdkrpc.ExitProgress {
+
+	if p == nil {
+		return nil
+	}
+
+	return &walletdkrpc.ExitProgress{
+		ConfirmedTxs:      p.GetConfirmedTxs(),
+		InFlightTxs:       p.GetInFlightTxs(),
+		ReadyTxs:          p.GetReadyTxs(),
+		BlockedTxs:        p.GetBlockedTxs(),
+		TotalTxs:          p.GetTotalTxs(),
+		CurrentLayer:      p.GetCurrentLayer(),
+		TotalLayers:       p.GetTotalLayers(),
+		TargetConfirmed:   p.GetTargetConfirmed(),
+		AllProofConfirmed: p.GetAllProofConfirmed(),
+	}
+}
+
+// exitCSVFromDaemon projects the daemon's UnrollCSV onto the wallet-facing
+// ExitCSV. It returns nil until the target confirms (no CSV countdown yet).
+func exitCSVFromDaemon(c *daemonrpc.UnrollCSV) *walletdkrpc.ExitCSV {
+	if c == nil {
+		return nil
+	}
+
+	return &walletdkrpc.ExitCSV{
+		TargetConfirmHeight: c.GetTargetConfirmHeight(),
+		MaturityHeight:      c.GetMaturityHeight(),
+		BlocksRemaining:     c.GetBlocksRemaining(),
+		Mature:              c.GetMature(),
+	}
+}
+
+// exitFeesFromDaemon projects the daemon's UnrollFees onto the wallet-facing
+// ExitFees. It returns nil when the daemon supplied no fee breakdown.
+func exitFeesFromDaemon(f *daemonrpc.UnrollFees) *walletdkrpc.ExitFees {
+	if f == nil {
+		return nil
+	}
+
+	return &walletdkrpc.ExitFees{
+		CpfpFeeSat:      f.GetCpfpFeeSat(),
+		SweepFeeSat:     f.GetSweepFeeSat(),
+		TotalCostSat:    f.GetTotalCostSat(),
+		VtxoAmountSat:   f.GetVtxoAmountSat(),
+		NetRecoveredSat: f.GetNetRecoveredSat(),
+		FeeRateSatVbyte: f.GetFeeRateSatVbyte(),
+		SweepFeeActual:  f.GetSweepFeeActual(),
+		SpentSoFarSat:   f.GetSpentSoFarSat(),
+	}
+}
+
+// exitSummary proxies the daemon's aggregate exit portfolio and projects it
+// onto the wallet-facing ExitSummaryResponse.
+func (s *Service) exitSummary(ctx context.Context,
+	_ *walletdkrpc.ExitSummaryRequest) (*walletdkrpc.ExitSummaryResponse,
+	error) {
+
+	if s.deps == nil || s.deps.RPCServer == nil {
+		return nil, statusSwapBackendUnavailable()
+	}
+
+	result, err := s.deps.RPCServer.ExitSummary(ctx)
+	if err != nil {
+		return nil, status.Errorf(status.Code(err), "exit summary: %v",
+			err)
+	}
+
+	resp := &walletdkrpc.ExitSummaryResponse{
+		Exits: make(
+			[]*walletdkrpc.ExitSummaryItem, 0, len(result.Entries),
+		),
+		TotalExits:              result.TotalExits,
+		TotalVtxoAmountSat:      result.TotalVTXOAmountSat,
+		TotalEstFeeSat:          result.TotalEstFeeSat,
+		TotalEstNetRecoveredSat: result.TotalEstNetRecoveredSat,
+	}
+	for i := range result.Entries {
+		entry := result.Entries[i]
+		resp.Exits = append(resp.Exits, &walletdkrpc.ExitSummaryItem{
+			Outpoint:           entry.Outpoint,
+			Status:             exitStatusFromDaemon(entry.Status),
+			VtxoAmountSat:      entry.VTXOAmountSat,
+			EstTotalFeeSat:     entry.EstTotalFeeSat,
+			EstNetRecoveredSat: entry.EstNetRecoveredSat,
+		})
+	}
+
+	return resp, nil
 }
 
 // exitStatusFromDaemon maps daemonrpc.UnrollJobStatus onto the

--- a/swapwallet/deps.go
+++ b/swapwallet/deps.go
@@ -97,6 +97,8 @@ type RPCServer interface {
 		req *daemonrpc.GetUnrollStatusRequest) (
 		*daemonrpc.GetUnrollStatusResponse, error)
 
+	ExitSummary(ctx context.Context) (*darepod.ExitSummaryResult, error)
+
 	GetExitPlan(ctx context.Context,
 		req *darepod.ExitPlanRequest) (*darepod.ExitPlanResponse, error)
 

--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -71,6 +71,10 @@ type fakeRPCServer struct {
 	unrollStatusCalls int
 	unrollStatusLast  *daemonrpc.GetUnrollStatusRequest
 
+	exitSummaryResp  *darepod.ExitSummaryResult
+	exitSummaryErr   error
+	exitSummaryCalls int
+
 	exitPlanResp  *darepod.ExitPlanResponse
 	exitPlanErr   error
 	exitPlanCalls int
@@ -261,6 +265,17 @@ func (f *fakeRPCServer) GetUnrollStatus(_ context.Context,
 	}
 
 	return f.unrollStatusResp, f.unrollStatusErr
+}
+
+func (f *fakeRPCServer) ExitSummary(_ context.Context) (
+	*darepod.ExitSummaryResult, error) {
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.exitSummaryCalls++
+
+	return f.exitSummaryResp, f.exitSummaryErr
 }
 
 func (f *fakeRPCServer) GetExitPlan(_ context.Context,

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -127,6 +127,15 @@ func (s *Service) ExitStatus(ctx context.Context,
 	return s.exitStatus(ctx, req)
 }
 
+// ExitSummary reports the wallet-wide portfolio of in-progress exits by
+// proxying the daemon's aggregate exit view.
+func (s *Service) ExitSummary(ctx context.Context,
+	req *walletdkrpc.ExitSummaryRequest) (*walletdkrpc.ExitSummaryResponse,
+	error) {
+
+	return s.exitSummary(ctx, req)
+}
+
 // Recv opens an out-swap via the daemon-owned swap subserver and returns the
 // daemon-signed BOLT-11 invoice plus the initial WalletEntry. The invoice
 // is signed with a payment-scoped daemon-managed auth key (PR #337);

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -221,7 +221,7 @@ func (b *behavior) Receive(ctx context.Context, msg Msg,
 	// or a Commit. The framework's non-transactional tail acks the Ask once
 	// the behavior returns.
 	if _, ok := msg.(*GetStateRequest); ok {
-		return fn.Ok[Resp](b.stateResponse())
+		return fn.Ok[Resp](b.stateResponse(ctx))
 	}
 
 	// Run the FSM pipeline. Every checkpoint write inside is a short,
@@ -801,8 +801,10 @@ func (b *behavior) deferredCheckpointCallerID() string {
 	return b.cfg.ActorID + "-deferred-checkpoint"
 }
 
-// stateResponse builds the current state response for callers and tests.
-func (b *behavior) stateResponse() *GetStateResp {
+// stateResponse builds the current state response for callers and tests. The
+// context is threaded through to the progress derivation so any diagnostic
+// logging on that read-only path stays tied to the caller's request scope.
+func (b *behavior) stateResponse(ctx context.Context) *GetStateResp {
 	state, err := b.currentState()
 	if err != nil {
 		return &GetStateResp{
@@ -829,7 +831,165 @@ func (b *behavior) stateResponse() *GetStateResp {
 		resp.SweepTxid = &txid
 	}
 
+	resp.Progress = b.exitProgress(ctx, state, job)
+
 	return resp
+}
+
+// exitProgress derives the human-facing progress summary from the planner
+// snapshot at the actor's current best height. It returns nil when the planner
+// or proof is not yet loaded (e.g. a status probe that races actor startup) so
+// callers fall back to the coarse phase view rather than a misleading zero
+// snapshot.
+func (b *behavior) exitProgress(ctx context.Context, state State,
+	job *JobState) *ExitProgress {
+
+	if b.planner == nil || b.proof == nil || isIdleState(state) {
+		return nil
+	}
+
+	plannerState := copyPlannerState(job.PlannerState)
+	snapshot, err := b.planner.Plan(job.Height, &plannerState)
+	if err != nil {
+		// A snapshot failure is not fatal to a read-only status probe;
+		// the coarse phase still describes the job. Trace it and
+		// degrade to nil.
+		b.log.DebugS(ctx, "exit progress plan failed",
+			slog.String("err", err.Error()),
+		)
+
+		return nil
+	}
+
+	layers := b.proof.Layers()
+	totalTxs := 0
+	for _, layer := range layers {
+		totalTxs += len(layer)
+	}
+
+	readyTxs := len(snapshot.Ready)
+	inFlightTxs := len(snapshot.InFlight)
+	blockedTxs := len(snapshot.Blocked)
+	unconfirmed := readyTxs + inFlightTxs + blockedTxs
+
+	totalLayers := len(layers)
+	currentLayer := frontierLayer(snapshot, totalLayers)
+
+	progress := &ExitProgress{
+		ConfirmedTxs:      totalTxs - unconfirmed,
+		InFlightTxs:       inFlightTxs,
+		ReadyTxs:          readyTxs,
+		BlockedTxs:        blockedTxs,
+		TotalTxs:          totalTxs,
+		CurrentLayer:      currentLayer,
+		TotalLayers:       totalLayers,
+		TargetConfirmed:   snapshot.TargetConfirmed,
+		AllProofConfirmed: snapshot.AllProofConfirmed,
+		CSV:               snapshot.CSV,
+		BestCaseBlocksRemaining: bestCaseBlocksRemaining(
+			snapshot, b.proof.CSVDelay(), currentLayer, totalLayers,
+		),
+	}
+
+	if fee, ok := actualSweepFeeSat(b.sweepTx, b.desc); ok {
+		progress.ActualSweepFeeSat = fn.Some(fee)
+	}
+
+	return progress
+}
+
+// frontierLayer returns the shallowest topological layer that still holds an
+// unconfirmed transaction (ready, in-flight, or blocked). When every proof node
+// has confirmed there is no frontier, so it returns totalLayers to signal that
+// materialization is complete.
+func frontierLayer(snapshot *unrollplan.Snapshot, totalLayers int) int {
+	frontier := totalLayers
+	consider := func(layer int) {
+		if layer < frontier {
+			frontier = layer
+		}
+	}
+
+	for _, tx := range snapshot.Ready {
+		consider(tx.Layer)
+	}
+	for _, tx := range snapshot.InFlight {
+		consider(tx.Layer)
+	}
+	for _, tx := range snapshot.Blocked {
+		consider(tx.Layer)
+	}
+
+	return frontier
+}
+
+// bestCaseBlocksRemaining is the optimistic block count until a confirmed
+// sweep. It assumes one confirmation per remaining proof layer, then the CSV
+// wait, then one sweep confirmation. Before the target confirms the CSV wait is
+// the full descriptor delay; afterwards the planner's live BlocksRemaining is
+// used, which shrinks each block.
+func bestCaseBlocksRemaining(snapshot *unrollplan.Snapshot, csvDelay uint32,
+	currentLayer, totalLayers int) int32 {
+
+	// A confirmed sweep is done; a broadcast sweep is one confirmation
+	// away.
+	if snapshot.Done {
+		return 0
+	}
+	if snapshot.Sweep.Status == unrollplan.SweepStatusBroadcasted {
+		return 1
+	}
+
+	// Each proof layer from the frontier through the target layer needs at
+	// least one confirmation. Once the target confirms this term is zero.
+	matBlocks := int32(totalLayers - currentLayer)
+	if matBlocks < 0 {
+		matBlocks = 0
+	}
+
+	// The sweep is gated only on the target's CSV maturity, not on any
+	// straggler proof transaction, so once the target has confirmed the
+	// materialization term must not be added on top of the live CSV
+	// countdown. A multi-transaction layer can still hold an unconfirmed
+	// sibling after the target confirms, which would otherwise inflate the
+	// estimate.
+	if snapshot.TargetConfirmed {
+		matBlocks = 0
+	}
+
+	// The CSV wait is the full descriptor delay until the target confirms,
+	// after which the planner reports the exact remaining window.
+	csvBlocks := int32(csvDelay)
+	snapshot.CSV.WhenSome(func(csv unrollplan.CSVInfo) {
+		csvBlocks = csv.BlocksRemaining
+	})
+
+	// Add one confirmation for the final sweep itself.
+	return matBlocks + csvBlocks + 1
+}
+
+// actualSweepFeeSat derives the real fee the built sweep pays: the value of the
+// single target input (the VTXO amount) minus the swept output value. It
+// returns false until a sweep transaction has been built, or if the numbers do
+// not yield a sane positive fee (a defensive guard against a malformed tx).
+func actualSweepFeeSat(sweepTx *wire.MsgTx,
+	desc *vtxo.Descriptor) (int64, bool) {
+
+	if sweepTx == nil || desc == nil {
+		return 0, false
+	}
+
+	var outputSat int64
+	for _, out := range sweepTx.TxOut {
+		outputSat += out.Value
+	}
+
+	fee := int64(desc.Amount) - outputSat
+	if fee <= 0 {
+		return 0, false
+	}
+
+	return fee, true
 }
 
 // ensureLoaded lazily constructs every piece of actor-lifetime state the

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -157,6 +157,14 @@ type behavior struct {
 	proofSpendWatches map[wire.OutPoint]struct{}
 	terminalNotified  bool
 	exitCostNotified  bool
+
+	// requiredLockTime caches the exit policy's absolute nLockTime once the
+	// policy has been resolved (in startSweep). The standard timeout policy
+	// reports zero; a vHTLC refund-without-receiver policy reports the
+	// height the sweep must wait for. It feeds the best-case block estimate
+	// so a policy-gated sweep is not reported as imminent. None until the
+	// sweep phase resolves the policy.
+	requiredLockTime fn.Option[uint32]
 }
 
 // unrollTx is the transaction-scoped store handed to the unroll behavior inside
@@ -470,6 +478,11 @@ func (b *behavior) startSweep(ctx context.Context,
 				Reason: err.Error(),
 			})
 		}
+
+		// Cache the policy's absolute locktime so the read-only status
+		// probe can fold it into the best-case block estimate without
+		// re-resolving the policy. The value is immutable per job.
+		b.requiredLockTime = fn.Some(policy.RequiredLockTime())
 
 		b.log.InfoS(ctx, "Building unroll exit spend",
 			slog.String(
@@ -875,6 +888,18 @@ func (b *behavior) exitProgress(ctx context.Context, state State,
 	totalLayers := len(layers)
 	currentLayer := frontierLayer(snapshot, totalLayers)
 
+	// The sweep also cannot broadcast before the exit policy's absolute
+	// locktime (a vHTLC refund-without-receiver gates on one; the standard
+	// timeout policy reports zero). Fold the remaining locktime window into
+	// the best-case estimate so a policy-gated sweep is not reported as
+	// imminent. It stays zero until the sweep phase resolves the policy.
+	var lockTimeBlocks int32
+	b.requiredLockTime.WhenSome(func(lockTime uint32) {
+		if remaining := int32(lockTime) - job.Height; remaining > 0 {
+			lockTimeBlocks = remaining
+		}
+	})
+
 	progress := &ExitProgress{
 		ConfirmedTxs:      totalTxs - unconfirmed,
 		InFlightTxs:       inFlightTxs,
@@ -888,11 +913,22 @@ func (b *behavior) exitProgress(ctx context.Context, state State,
 		CSV:               snapshot.CSV,
 		BestCaseBlocksRemaining: bestCaseBlocksRemaining(
 			snapshot, b.proof.CSVDelay(), currentLayer, totalLayers,
+			lockTimeBlocks,
 		),
 	}
 
-	if fee, ok := actualSweepFeeSat(b.sweepTx, b.desc); ok {
-		progress.ActualSweepFeeSat = fn.Some(fee)
+	// The exact sweep fee is the value of the target output the sweep
+	// actually spends, minus the swept output value. Read the input value
+	// from the proof (what the exit spend policy spends) rather than the
+	// descriptor amount, which may differ from the materialized target
+	// output.
+	if b.sweepTx != nil {
+		if targetOut, err := b.proof.TargetOutput(); err == nil {
+			fee, ok := actualSweepFeeSat(b.sweepTx, targetOut.Value)
+			if ok {
+				progress.ActualSweepFeeSat = fn.Some(fee)
+			}
+		}
 	}
 
 	return progress
@@ -924,12 +960,14 @@ func frontierLayer(snapshot *unrollplan.Snapshot, totalLayers int) int {
 }
 
 // bestCaseBlocksRemaining is the optimistic block count until a confirmed
-// sweep. It assumes one confirmation per remaining proof layer, then the CSV
-// wait, then one sweep confirmation. Before the target confirms the CSV wait is
-// the full descriptor delay; afterwards the planner's live BlocksRemaining is
-// used, which shrinks each block.
+// sweep. It assumes one confirmation per remaining proof layer, then the wait
+// for the sweep to become broadcastable, then one sweep confirmation. Before
+// the target confirms the CSV wait is the full descriptor delay; afterwards the
+// planner's live BlocksRemaining is used, which shrinks each block. The sweep
+// can only broadcast once BOTH the CSV timeout and the exit policy's absolute
+// locktime have passed, so the post-target wait is the longer of the two.
 func bestCaseBlocksRemaining(snapshot *unrollplan.Snapshot, csvDelay uint32,
-	currentLayer, totalLayers int) int32 {
+	currentLayer, totalLayers int, lockTimeBlocks int32) int32 {
 
 	// A confirmed sweep is done; a broadcast sweep is one confirmation
 	// away.
@@ -964,18 +1002,25 @@ func bestCaseBlocksRemaining(snapshot *unrollplan.Snapshot, csvDelay uint32,
 		csvBlocks = csv.BlocksRemaining
 	})
 
+	// The policy's absolute locktime is an independent gate on the sweep,
+	// so the effective wait is the longer of the CSV and locktime windows.
+	sweepGate := csvBlocks
+	if lockTimeBlocks > sweepGate {
+		sweepGate = lockTimeBlocks
+	}
+
 	// Add one confirmation for the final sweep itself.
-	return matBlocks + csvBlocks + 1
+	return matBlocks + sweepGate + 1
 }
 
 // actualSweepFeeSat derives the real fee the built sweep pays: the value of the
-// single target input (the VTXO amount) minus the swept output value. It
-// returns false until a sweep transaction has been built, or if the numbers do
-// not yield a sane positive fee (a defensive guard against a malformed tx).
-func actualSweepFeeSat(sweepTx *wire.MsgTx,
-	desc *vtxo.Descriptor) (int64, bool) {
-
-	if sweepTx == nil || desc == nil {
+// single target input the sweep spends (inputValueSat) minus the swept output
+// value. The input value must be the proof's target output value, which is what
+// the exit spend policy actually spends. It returns false until a sweep
+// transaction has been built, or if the numbers do not yield a sane positive
+// fee (a defensive guard against a malformed tx).
+func actualSweepFeeSat(sweepTx *wire.MsgTx, inputValueSat int64) (int64, bool) {
+	if sweepTx == nil {
 		return 0, false
 	}
 
@@ -984,7 +1029,7 @@ func actualSweepFeeSat(sweepTx *wire.MsgTx,
 		outputSat += out.Value
 	}
 
-	fee := int64(desc.Amount) - outputSat
+	fee := inputValueSat - outputSat
 	if fee <= 0 {
 		return 0, false
 	}

--- a/unroll/exit_progress_test.go
+++ b/unroll/exit_progress_test.go
@@ -3,10 +3,8 @@ package unroll
 import (
 	"testing"
 
-	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/darepo-client/unrollplan"
-	"github.com/lightninglabs/darepo-client/vtxo"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -84,11 +82,12 @@ func TestBestCaseBlocksRemaining(t *testing.T) {
 	const broadcasted = unrollplan.SweepStatusBroadcasted
 
 	tests := []struct {
-		name         string
-		snapshot     *unrollplan.Snapshot
-		currentLayer int
-		totalLayers  int
-		want         int32
+		name           string
+		snapshot       *unrollplan.Snapshot
+		currentLayer   int
+		totalLayers    int
+		lockTimeBlocks int32
+		want           int32
 	}{
 		{
 			name: "confirmed sweep is done",
@@ -151,6 +150,41 @@ func TestBestCaseBlocksRemaining(t *testing.T) {
 			totalLayers:  4,
 			want:         0 + 10 + 1,
 		},
+		{
+			name: "policy locktime dominates the csv wait",
+			snapshot: &unrollplan.Snapshot{
+				TargetConfirmed: true,
+				Sweep: unrollplan.SweepState{
+					Status: unrollplan.SweepStatusPending,
+				},
+				CSV: fn.Some(unrollplan.CSVInfo{
+					BlocksRemaining: 10,
+				}),
+			},
+			currentLayer: 4,
+			totalLayers:  4,
+			// The absolute locktime (30 blocks out) gates the sweep
+			// past the CSV maturity (10), so 0 + max(10, 30) + 1.
+			lockTimeBlocks: 30,
+			want:           0 + 30 + 1,
+		},
+		{
+			name: "csv wait dominates a nearer locktime",
+			snapshot: &unrollplan.Snapshot{
+				TargetConfirmed: true,
+				Sweep: unrollplan.SweepState{
+					Status: unrollplan.SweepStatusPending,
+				},
+				CSV: fn.Some(unrollplan.CSVInfo{
+					BlocksRemaining: 20,
+				}),
+			},
+			currentLayer:   4,
+			totalLayers:    4,
+			lockTimeBlocks: 5,
+			// 0 + max(20, 5) + 1.
+			want: 0 + 20 + 1,
+		},
 	}
 
 	for _, tc := range tests {
@@ -160,20 +194,20 @@ func TestBestCaseBlocksRemaining(t *testing.T) {
 
 			got := bestCaseBlocksRemaining(
 				tc.snapshot, csvDelay, tc.currentLayer,
-				tc.totalLayers,
+				tc.totalLayers, tc.lockTimeBlocks,
 			)
 			require.Equal(t, tc.want, got)
 		})
 	}
 }
 
-// TestActualSweepFeeSat verifies the built-sweep fee derivation: target value
-// minus swept output value, with defensive guards for missing or malformed
-// inputs.
+// TestActualSweepFeeSat verifies the built-sweep fee derivation: the target
+// input value the sweep spends minus the swept output value, with defensive
+// guards for missing or malformed inputs.
 func TestActualSweepFeeSat(t *testing.T) {
 	t.Parallel()
 
-	desc := &vtxo.Descriptor{Amount: btcutil.Amount(100_000)}
+	const inputValue int64 = 100_000
 
 	sweepTx := func(outValue int64) *wire.MsgTx {
 		tx := wire.NewMsgTx(3)
@@ -185,21 +219,14 @@ func TestActualSweepFeeSat(t *testing.T) {
 	t.Run("nil tx yields no fee", func(t *testing.T) {
 		t.Parallel()
 
-		_, ok := actualSweepFeeSat(nil, desc)
+		_, ok := actualSweepFeeSat(nil, inputValue)
 		require.False(t, ok)
 	})
 
-	t.Run("nil desc yields no fee", func(t *testing.T) {
+	t.Run("positive fee is input minus output", func(t *testing.T) {
 		t.Parallel()
 
-		_, ok := actualSweepFeeSat(sweepTx(99_000), nil)
-		require.False(t, ok)
-	})
-
-	t.Run("positive fee is target minus output", func(t *testing.T) {
-		t.Parallel()
-
-		fee, ok := actualSweepFeeSat(sweepTx(99_700), desc)
+		fee, ok := actualSweepFeeSat(sweepTx(99_700), inputValue)
 		require.True(t, ok)
 		require.Equal(t, int64(300), fee)
 	})
@@ -207,7 +234,7 @@ func TestActualSweepFeeSat(t *testing.T) {
 	t.Run("non-positive fee is rejected", func(t *testing.T) {
 		t.Parallel()
 
-		_, ok := actualSweepFeeSat(sweepTx(100_000), desc)
+		_, ok := actualSweepFeeSat(sweepTx(100_000), inputValue)
 		require.False(t, ok)
 	})
 }

--- a/unroll/exit_progress_test.go
+++ b/unroll/exit_progress_test.go
@@ -1,0 +1,213 @@
+package unroll
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/darepo-client/unrollplan"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFrontierLayer verifies that the frontier layer is the shallowest layer
+// holding an unconfirmed transaction, and collapses to the tree depth once
+// nothing is left to materialize.
+func TestFrontierLayer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		snapshot    *unrollplan.Snapshot
+		totalLayers int
+		want        int
+	}{
+		{
+			name:        "all confirmed collapses to depth",
+			snapshot:    &unrollplan.Snapshot{},
+			totalLayers: 4,
+			want:        4,
+		},
+		{
+			name: "shallowest blocked wins over deeper ready",
+			snapshot: &unrollplan.Snapshot{
+				Ready: []unrollplan.TxFrontier{
+					{
+						Layer: 3,
+					},
+				},
+				Blocked: []unrollplan.BlockedTx{
+					{TxFrontier: unrollplan.TxFrontier{
+						Layer: 1,
+					}},
+				},
+			},
+			totalLayers: 4,
+			want:        1,
+		},
+		{
+			name: "in-flight sets the frontier",
+			snapshot: &unrollplan.Snapshot{
+				InFlight: []unrollplan.TxFrontier{
+					{
+						Layer: 2,
+					},
+				},
+			},
+			totalLayers: 4,
+			want:        2,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := frontierLayer(tc.snapshot, tc.totalLayers)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestBestCaseBlocksRemaining verifies the optimistic block countdown across
+// the exit lifecycle: materialization (full CSV wait), CSV pending (live
+// remaining), sweep broadcast, and completion.
+func TestBestCaseBlocksRemaining(t *testing.T) {
+	t.Parallel()
+
+	const csvDelay = 144
+
+	// Alias the long enum constant so the deeply-nested table entry below
+	// stays within the 80-column limit.
+	const broadcasted = unrollplan.SweepStatusBroadcasted
+
+	tests := []struct {
+		name         string
+		snapshot     *unrollplan.Snapshot
+		currentLayer int
+		totalLayers  int
+		want         int32
+	}{
+		{
+			name: "confirmed sweep is done",
+			snapshot: &unrollplan.Snapshot{
+				Done: true,
+			},
+			want: 0,
+		},
+		{
+			name: "broadcast sweep is one confirmation away",
+			snapshot: &unrollplan.Snapshot{
+				Sweep: unrollplan.SweepState{
+					Status: broadcasted,
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "materializing uses remaining layers plus CSV",
+			snapshot: &unrollplan.Snapshot{
+				Sweep: unrollplan.SweepState{
+					Status: unrollplan.SweepStatusPending,
+				},
+			},
+			currentLayer: 1,
+			totalLayers:  4,
+			// (4-1) layers + 144 CSV + 1 sweep.
+			want: 3 + csvDelay + 1,
+		},
+		{
+			name: "csv pending uses live blocks remaining",
+			snapshot: &unrollplan.Snapshot{
+				Sweep: unrollplan.SweepState{
+					Status: unrollplan.SweepStatusPending,
+				},
+				CSV: fn.Some(unrollplan.CSVInfo{
+					BlocksRemaining: 10,
+				}),
+			},
+			currentLayer: 4,
+			totalLayers:  4,
+			// 0 layers + 10 CSV + 1 sweep.
+			want: 0 + 10 + 1,
+		},
+		{
+			name: "target confirmed drops straggler layers",
+			snapshot: &unrollplan.Snapshot{
+				TargetConfirmed: true,
+				Sweep: unrollplan.SweepState{
+					Status: unrollplan.SweepStatusPending,
+				},
+				CSV: fn.Some(unrollplan.CSVInfo{
+					BlocksRemaining: 10,
+				}),
+			},
+			// A straggler sibling keeps the frontier below the
+			// target layer, but the sweep is gated only on CSV, so
+			// the materialization term must be dropped: 0 + 10 + 1.
+			currentLayer: 2,
+			totalLayers:  4,
+			want:         0 + 10 + 1,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := bestCaseBlocksRemaining(
+				tc.snapshot, csvDelay, tc.currentLayer,
+				tc.totalLayers,
+			)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestActualSweepFeeSat verifies the built-sweep fee derivation: target value
+// minus swept output value, with defensive guards for missing or malformed
+// inputs.
+func TestActualSweepFeeSat(t *testing.T) {
+	t.Parallel()
+
+	desc := &vtxo.Descriptor{Amount: btcutil.Amount(100_000)}
+
+	sweepTx := func(outValue int64) *wire.MsgTx {
+		tx := wire.NewMsgTx(3)
+		tx.AddTxOut(&wire.TxOut{Value: outValue})
+
+		return tx
+	}
+
+	t.Run("nil tx yields no fee", func(t *testing.T) {
+		t.Parallel()
+
+		_, ok := actualSweepFeeSat(nil, desc)
+		require.False(t, ok)
+	})
+
+	t.Run("nil desc yields no fee", func(t *testing.T) {
+		t.Parallel()
+
+		_, ok := actualSweepFeeSat(sweepTx(99_000), nil)
+		require.False(t, ok)
+	})
+
+	t.Run("positive fee is target minus output", func(t *testing.T) {
+		t.Parallel()
+
+		fee, ok := actualSweepFeeSat(sweepTx(99_700), desc)
+		require.True(t, ok)
+		require.Equal(t, int64(300), fee)
+	})
+
+	t.Run("non-positive fee is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, ok := actualSweepFeeSat(sweepTx(100_000), desc)
+		require.False(t, ok)
+	})
+}

--- a/unroll/messages.go
+++ b/unroll/messages.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
 	"github.com/lightninglabs/darepo-client/unrollplan"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -693,6 +694,69 @@ type GetStateResp struct {
 
 	// SweepTxid records the sweep txid when the actor has built one.
 	SweepTxid *chainhash.Hash
+
+	// Progress carries the derived, human-facing progress summary for the
+	// job, computed from the planner snapshot at the current best height.
+	// It is populated only for a detailed status probe against a live
+	// actor; a coarse probe (or a terminal job served from the store)
+	// leaves it nil.
+	Progress *ExitProgress
+}
+
+// ExitProgress is the derived, human-facing progress summary for one unroll
+// job. Every field is computed from the planner snapshot at the current best
+// height, so it is a read-only projection of durable state rather than any
+// additional persisted record.
+type ExitProgress struct {
+	// ConfirmedTxs is the number of proof transactions confirmed on-chain.
+	ConfirmedTxs int
+
+	// InFlightTxs is the number of proof transactions broadcast to
+	// txconfirm but not yet observed confirmed.
+	InFlightTxs int
+
+	// ReadyTxs is the number of proof transactions whose in-proof parents
+	// are all confirmed, so they are ready to broadcast now.
+	ReadyTxs int
+
+	// BlockedTxs is the number of proof transactions still waiting on an
+	// unconfirmed in-proof parent.
+	BlockedTxs int
+
+	// TotalTxs is the total number of transactions in the exit proof tree.
+	TotalTxs int
+
+	// CurrentLayer is the frontier layer index: the shallowest topological
+	// layer (roots first) that still holds an unconfirmed transaction. It
+	// equals TotalLayers once every proof node has confirmed.
+	CurrentLayer int
+
+	// TotalLayers is the depth of the exit proof tree, from the root layer
+	// through the target layer.
+	TotalLayers int
+
+	// TargetConfirmed is true once the target VTXO transaction itself has
+	// confirmed on-chain.
+	TargetConfirmed bool
+
+	// AllProofConfirmed is true once every proof-tree transaction has
+	// confirmed, so only the CSV wait and final sweep remain.
+	AllProofConfirmed bool
+
+	// CSV carries the target's CSV maturity view. It is populated only once
+	// the target has confirmed.
+	CSV fn.Option[unrollplan.CSVInfo]
+
+	// BestCaseBlocksRemaining is the optimistic number of blocks until a
+	// confirmed sweep, assuming one confirmation per remaining proof layer,
+	// the full CSV wait, and one sweep confirmation. It is a lower bound;
+	// real timing depends on fee market and inclusion latency.
+	BestCaseBlocksRemaining int32
+
+	// ActualSweepFeeSat is the real fee the final sweep pays, derived from
+	// the built sweep transaction as target value minus swept output value.
+	// It is populated only once the sweep transaction has been built.
+	ActualSweepFeeSat fn.Option[int64]
 }
 
 // MessageType returns the stable message type identifier.

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -23,6 +23,13 @@ const (
 	// start a newly-admitted child before falling back to durable retry.
 	childAdmissionTimeout = 30 * time.Second
 
+	// detailedStatusAskTimeout bounds the registry's synchronous Ask to a
+	// live child for a detailed status probe. The registry is single-
+	// goroutine, so an unbounded Ask against a wedged child would stall
+	// every other outpoint; on timeout the probe degrades to the coarse
+	// cached record.
+	detailedStatusAskTimeout = 3 * time.Second
+
 	// initialPersistRetryDelay is the first delay used when retrying
 	// control-plane persistence for a live unroll child.
 	initialPersistRetryDelay = 250 * time.Millisecond
@@ -855,15 +862,22 @@ func (r *registryBehavior) handleGetStatus(ctx context.Context,
 	req *GetStatusRequest) fn.Result[RegistryResp] {
 
 	if child, ok := r.active[req.Outpoint]; ok {
+		// A detailed probe enriches the coarse record with the live
+		// child's planner-derived progress. The child Ask is
+		// best-effort: on failure we fall through to the coarse record
+		// so status never hard-fails on the detail path.
+		detail := r.detailedChildState(ctx, req, child)
+
 		if record, ok := r.pending[req.Outpoint]; ok {
 			cached := cloneRegistryRecord(record)
 			if cached.ActorID == "" {
 				cached.ActorID = child.Ref().ID()
 			}
 
-			return fn.Ok[RegistryResp](
-				statusFromRegistryRecord(cached, true),
-			)
+			resp := statusFromRegistryRecord(cached, true)
+			resp.State = detail
+
+			return fn.Ok[RegistryResp](resp)
 		}
 
 		record, err := r.cfg.Store.GetRecord(ctx, req.Outpoint)
@@ -879,9 +893,10 @@ func (r *registryBehavior) handleGetStatus(ctx context.Context,
 				cached.ActorID = child.Ref().ID()
 			}
 
-			return fn.Ok[RegistryResp](
-				statusFromRegistryRecord(cached, true),
-			)
+			resp := statusFromRegistryRecord(cached, true)
+			resp.State = detail
+
+			return fn.Ok[RegistryResp](resp)
 		}
 
 		return fn.Ok[RegistryResp](&GetStatusResp{
@@ -889,6 +904,7 @@ func (r *registryBehavior) handleGetStatus(ctx context.Context,
 			Active:  true,
 			ActorID: child.Ref().ID(),
 			Phase:   PhasePending,
+			State:   detail,
 		})
 	}
 
@@ -1464,6 +1480,41 @@ func (r *registryBehavior) queryBestHeight(ctx context.Context) (int32, error) {
 	}
 
 	return bestHeight.Height, nil
+}
+
+// detailedChildState returns the live child's planner-derived state for a
+// detailed status probe, or nil for a coarse probe or on any child-Ask
+// failure. It is deliberately best-effort: the caller always has the coarse
+// registry record to fall back on, and a status probe must never fail just
+// because the child was momentarily busy. Only a detailed probe Asks the
+// child, so the common polling path never writes a read-only mailbox row.
+func (r *registryBehavior) detailedChildState(ctx context.Context,
+	req *GetStatusRequest, child *VTXOUnrollActor) *GetStateResp {
+
+	if !req.Detailed {
+		return nil
+	}
+
+	// Bound the child Ask with a local timeout. The registry runs on a
+	// single goroutine, and the caller's context is the (possibly
+	// deadline-free) RPC context, so a child wedged in a redelivery-retry
+	// loop would otherwise stall the whole registry -- admission,
+	// persistence, and every other outpoint's status -- for as long as the
+	// caller waits. On timeout we fall back to the coarse record.
+	askCtx, cancel := context.WithTimeout(ctx, detailedStatusAskTimeout)
+	defer cancel()
+
+	state, err := r.childState(askCtx, child)
+	if err != nil {
+		r.log.DebugS(ctx, "detailed child state unavailable",
+			slog.String("outpoint", req.Outpoint.String()),
+			slog.String("err", err.Error()),
+		)
+
+		return nil
+	}
+
+	return state
 }
 
 // childState reads the detailed state from one active child actor.

--- a/unroll/registry_messages.go
+++ b/unroll/registry_messages.go
@@ -73,6 +73,13 @@ type GetStatusRequest struct {
 
 	// Outpoint identifies the target VTXO.
 	Outpoint wire.OutPoint
+
+	// Detailed asks the registry to enrich the response with the live
+	// child's planner-derived progress (GetStatusResp.State) when the
+	// target has an active actor. It defaults to false so the common
+	// polling path stays coarse and never Asks the durable child, avoiding
+	// stale read-only mailbox rows.
+	Detailed bool
 }
 
 // MessageType returns the stable message type identifier.


### PR DESCRIPTION
In this PR, we make `da exit status` actually useful. Today a unilateral
exit that's grinding its way on-chain reports almost nothing:

```json
{
  "found": true,
  "status": "EXIT_JOB_STATUS_MATERIALIZING",
  "sweep_txid": "",
  "last_error": ""
}
```

A user watching that has no idea where they are: how much of the recovery
tree has confirmed, how many transactions are still left to broadcast,
what they've spent on fees, how far off the CSV timeout is, or roughly how
many blocks until the coin is finally back in their wallet. The status
even lags reality, since the registry answers from a coarse cached record
rather than the live actor, so the phase can read `MATERIALIZING` well
after the target has confirmed.

We fix both. The same call now returns the full picture:

```json
{
  "found": true,
  "status": "EXIT_JOB_STATUS_MATERIALIZING",
  "phase_detail": "materializing recovery tree: layer 3 of 5, 2/5 txs confirmed (1 in flight, 0 ready, 2 blocked)",
  "progress": {
    "confirmed_txs": 2, "in_flight_txs": 1, "ready_txs": 0, "blocked_txs": 2,
    "total_txs": 5, "current_layer": 2, "total_layers": 5,
    "target_confirmed": false, "all_proof_confirmed": false
  },
  "csv": null,
  "fees": {
    "cpfp_fee_sat": "1550", "sweep_fee_sat": "400", "total_cost_sat": "1950",
    "spent_so_far_sat": "620", "vtxo_amount_sat": "177591",
    "net_recovered_sat": "177191", "fee_rate_sat_vbyte": "2",
    "sweep_fee_actual": false
  },
  "best_case_blocks_remaining": 148,
  "current_height": 312354
}
```

Everything here is derived, not newly persisted, so there are no schema
changes anywhere in the PR.

## Where the data comes from

The per-target unroll actor already holds the immutable proof, the pure
`unrollplan.Planner`, and its durable state, so it can run one `Plan` at
the current best height and project the resulting snapshot into a compact
`ExitProgress`: the confirmed / in-flight / ready / blocked transaction
counts, the current frontier layer of the recovery tree, the CSV maturity
countdown (once the target confirms), and an optimistic block estimate to
a confirmed sweep. The fee breakdown reuses the same cost model as
`GetExitPlan` (`unroll.PlanExitFunding`), so `da exit plan` and
`da exit status` agree on the numbers.

Fees are an estimate by design. The CPFP total comes from the cost model
(per-child fees aren't persisted, so there's nothing exact to report), and
`spent_so_far_sat` prorates that total over the proof transactions already
broadcast, then folds in the sweep fee once the sweep exists. The one
number we can pin down exactly is the sweep fee itself, derived from the
built sweep tx (target value minus the swept output) and flagged with
`sweep_fee_actual` when it's real rather than modeled. A completed or
failed exit whose actor has already been evicted still answers from the DB
store with its phase line and a fresh fee estimate, so the endpoint stays
useful after the exit is done.

## Detail is opt-in so the pollers stay cheap

A `GetStateRequest` against a durable child actor becomes a persisted
mailbox row, and the history and reconciler loops hit `GetUnrollStatus`
on every pending exit, so we can't have every status read waking the
child. All of the rich detail is gated behind a `detailed` request flag.
The interactive CLI sets it (so `da exit status` is detailed by default,
with `--detailed=false` as the cheap phase-only escape hatch), the
automated pollers don't. Even on the detailed path the registry Asks the
child under a short local timeout and falls back to the coarse cached
record, so a wedged child can never stall the single-goroutine registry
on a user-triggered probe.

## A wallet-wide view: `da exit summary`

Looking at one exit doesn't tell you how much is still tied up across all
of them. So we add `da exit summary`, a portfolio of every in-progress
exit plus aggregate totals: the amount still being recovered, the
estimated fees, and the estimated net recoverable. It only walks the
non-terminal jobs (a completed exit has nothing left to recover) and stays
cheap by reading the coarse job rows and the descriptor, never probing the
live actors.

```json
{
  "exits": [ { "outpoint": "...", "status": "EXIT_JOB_STATUS_MATERIALIZING",
               "vtxo_amount_sat": "177591", "est_total_fee_sat": "1950",
               "est_net_recovered_sat": "177191" } ],
  "total_exits": 1,
  "total_vtxo_amount_sat": "177591",
  "total_est_fee_sat": "1950",
  "total_est_net_recovered_sat": "177191"
}
```

## Review notes

The change runs bottom-up across the stack (unroll actor/registry, then
the protos, then the regenerated stubs, then the daemon RPC, then the
walletdk projection, then the CLI, then the SDK facades), split into
seven atomic commits. See each commit message for the detailed
description w.r.t the incremental changes. The generated-stubs commit
also carries the hand-written REST transport mirror so the
`WalletServiceClient` interface stays satisfied, which keeps the default
`go build` bisectable at every commit.

The last commit threads the same view through the `walletdk` SDK, its
gomobile JSON facade, and the browser WASM entrypoint, so embedded hosts
get the detailed status and the `exitSummary` verb too, not just the
`darepocli` user.

The progress math (frontier layer, best-case block countdown,
spent-so-far proration, actual sweep fee) is covered by table tests in
`unroll` and `darepod`.
