### PR TITLE
swapwallet: reconcile activity at the chain tip on startup (C5a)

### DIFF
--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -34,6 +34,8 @@ type fakeRPCServer struct {
 	listTxLastReq    *daemonrpc.ListTransactionsRequest
 	getInfoResp      *daemonrpc.GetInfoResponse
 	getInfoErr       error
+	getInfoHook      func(call int) (*daemonrpc.GetInfoResponse, error)
+	getInfoCalls     int
 	getBalanceResp   *daemonrpc.GetBalanceResponse
 	getBalanceErr    error
 	newAddressResp   *daemonrpc.NewAddressResponse
@@ -151,6 +153,11 @@ func (f *fakeRPCServer) ListTransactions(_ context.Context,
 
 func (f *fakeRPCServer) GetInfo(_ context.Context,
 	_ *daemonrpc.GetInfoRequest) (*daemonrpc.GetInfoResponse, error) {
+
+	f.getInfoCalls++
+	if f.getInfoHook != nil {
+		return f.getInfoHook(f.getInfoCalls)
+	}
 
 	if f.getInfoResp == nil && f.getInfoErr == nil {
 		return &daemonrpc.GetInfoResponse{

--- a/swapwallet/runtime.go
+++ b/swapwallet/runtime.go
@@ -88,6 +88,15 @@ type Runtime struct {
 	// or leave state. Cleared when an entry transitions to a terminal
 	// status through the monitor loop.
 	overlay map[string]overlayStatus
+
+	// tipPollInterval is how often the one-shot startup reconcile-at-tip
+	// loop polls the daemon's best-block height while waiting for the chain
+	// backend to settle. tipReconcileTimeout bounds that wait before the
+	// loop reconciles once anyway and hands off to the periodic reconciler.
+	// They are fields, not consts, so tests can drive the loop without
+	// real-time waits.
+	tipPollInterval     time.Duration
+	tipReconcileTimeout time.Duration
 }
 
 // overlayStatus is the runtime's wallet-level overlay applied on top of an
@@ -116,8 +125,10 @@ func newRuntime(parent context.Context, deps *Deps) *Runtime {
 		subscribers: make(
 			map[*subscriber]struct{},
 		),
-		pending: make(map[string]pendingEntry),
-		overlay: make(map[string]overlayStatus),
+		pending:             make(map[string]pendingEntry),
+		overlay:             make(map[string]overlayStatus),
+		tipPollInterval:     defaultTipPollInterval,
+		tipReconcileTimeout: defaultTipReconcileTimeout,
 	}
 }
 
@@ -134,6 +145,7 @@ func (r *Runtime) start() {
 		r.startMonitorLoop()
 		r.startCreditProjectorLoop()
 		r.startReconcilerLoop()
+		r.startTipReconcileLoop()
 	})
 }
 

--- a/swapwallet/tip_reconciler.go
+++ b/swapwallet/tip_reconciler.go
@@ -1,0 +1,128 @@
+//go:build walletdkrpc && swapruntime
+
+package swapwallet
+
+import (
+	"context"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+)
+
+// defaultTipPollInterval is how often the startup reconcile-at-tip loop polls
+// the daemon's best-block height to decide whether the chain backend has
+// caught up. Polling GetInfo is cheap (a best-block query), so the cadence is
+// tight to minimize the post-restart window in which a settled operation still
+// reads PENDING.
+const defaultTipPollInterval = 5 * time.Second
+
+// defaultTipReconcileTimeout bounds how long the startup loop waits for the
+// backend to settle before reconciling once anyway and handing off to the
+// periodic reconciler. It is a backstop against a wallet that never reaches a
+// stable tip (for example a stuck sync): the coarse periodic reconciler still
+// lands terminal transitions eventually, so the loop must not poll forever.
+const defaultTipReconcileTimeout = 2 * time.Minute
+
+// startTipReconcileLoop starts the one-shot startup reconcile-at-tip goroutine.
+// It is a no-op without a canonical store (the derive-on-read fallback already
+// reflects live state on every read) or without an RPCServer to poll for sync
+// progress.
+func (r *Runtime) startTipReconcileLoop() {
+	if r.deps == nil || r.deps.ActivityStore == nil ||
+		r.deps.RPCServer == nil {
+		return
+	}
+
+	r.wg.Add(1)
+	go r.tipReconcileLoop()
+}
+
+// tipReconcileLoop waits until the daemon's chain backend has caught up to the
+// current tip after startup, then runs a single reconcile pass so a terminal
+// transition that landed while the daemon was down — a confirmed boarding
+// deposit, a swept exit — surfaces immediately, rather than reading PENDING
+// until the periodic reconciler's first tick a full reconcileInterval later.
+//
+// The startup backfill (backfillActivity in resumeAll) already seeded the
+// store, but in lwwallet/lnd modes the wallet is marked ready before the chain
+// backend has synced forward, so that backfill re-derives pre-tip state. This
+// loop re-derives once more once the backend settles. It is one-shot: after
+// the pass (or the timeout backstop) it returns, and the periodic reconciler
+// owns steady-state catch-up.
+//
+// The pass reconciles the same kinds as the periodic reconciler (DEPOSIT /
+// EXIT): those are the backfill-only producers with no live source, so they
+// are what can read stale after a restart. SEND/RECV self-heal through the
+// monitor's live SubscribeSwaps stream as the backend catches up, so the tip
+// pass need not re-derive them.
+//
+// "Caught up" is a heuristic over the only signal the wallet RPC surface
+// exposes: the best-block height has stopped advancing across a poll interval
+// and the wallet state is READY. This detects the chain backend reaching the
+// tip; a small residual wallet-processing lag is covered by the periodic
+// reconciler. A precise wallet-synced-to-tip signal is a follow-up (#899).
+func (r *Runtime) tipReconcileLoop() {
+	defer r.wg.Done()
+
+	ticker := time.NewTicker(r.tipPollInterval)
+	defer ticker.Stop()
+
+	deadline := time.NewTimer(r.tipReconcileTimeout)
+	defer deadline.Stop()
+
+	// lastHeight is the best-block height seen on the previous poll;
+	// observed guards the first comparison so an initial coincidental match
+	// against the zero value cannot be mistaken for a settled tip.
+	var (
+		lastHeight uint32
+		observed   bool
+	)
+
+	for {
+		select {
+		case <-r.rootCtx.Done():
+			return
+
+		case <-deadline.C:
+			// The backend never settled within the window (for
+			// example a slow or stuck sync). Reconcile once anyway;
+			// the periodic reconciler continues from here.
+			r.reconcileActivity(r.rootCtx)
+
+			return
+
+		case <-ticker.C:
+			height, ready, ok := r.chainTipStatus(r.rootCtx)
+			if !ok {
+				continue
+			}
+
+			// Caught up once the wallet is usable and the best
+			// block has stopped advancing across a poll interval.
+			if ready && observed && height == lastHeight {
+				r.reconcileActivity(r.rootCtx)
+
+				return
+			}
+
+			lastHeight = height
+			observed = true
+		}
+	}
+}
+
+// chainTipStatus reads the daemon's current best-block height and whether the
+// wallet state is READY. ok is false on an RPC error, so the caller simply
+// retries on the next poll rather than treating a transient failure as a
+// settled tip.
+func (r *Runtime) chainTipStatus(ctx context.Context) (uint32, bool, bool) {
+	info, err := r.deps.RPCServer.GetInfo(ctx, &daemonrpc.GetInfoRequest{})
+	if err != nil {
+		return 0, false, false
+	}
+
+	ready := info.GetWalletState() ==
+		daemonrpc.WalletState_WALLET_STATE_READY
+
+	return info.GetBlockHeight(), ready, true
+}

--- a/swapwallet/tip_reconciler_test.go
+++ b/swapwallet/tip_reconciler_test.go
@@ -1,0 +1,159 @@
+//go:build walletdkrpc && swapruntime
+
+package swapwallet
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/ledger"
+	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// seedPendingDepositThatConfirms seeds a PENDING deposit row and points
+// ListTransactions at the confirmed boarding row for the same address, so one
+// reconcile pass flips the stored row to COMPLETE. Mirrors the reconciler
+// deposit-flip fixture.
+func seedPendingDepositThatConfirms(t *testing.T, runtime *Runtime,
+	rpc *fakeRPCServer) string {
+
+	t.Helper()
+
+	const depID = "deposit-bcrt1qaddr"
+	runtime.project(context.Background(), &walletdkrpc.WalletEntry{
+		Id:            depID,
+		Kind:          walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT,
+		Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		CreatedAtUnix: 100,
+		UpdatedAtUnix: 100,
+		Progress: &walletdkrpc.WalletEntryProgress{
+			PhaseLabel: "address_issued",
+		},
+	})
+
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{{
+			Type:               "boarding",
+			Subtype:            ledger.EventWalletUTXOCreated,
+			ConfirmationStatus: "confirmed",
+			AmountSat:          100_000,
+			Txid:               "boarding-txid",
+			OutputIndex:        0,
+			BoardingAddress:    "bcrt1qaddr",
+			CreatedAtUnixS:     100,
+		}},
+	}
+
+	return depID
+}
+
+// depositComplete reports whether the stored deposit row has reached COMPLETE.
+func depositComplete(store *db.ActivityPersistenceStore, id string) bool {
+	entry, err := store.GetEntry(context.Background(), id)
+
+	return err == nil && walletdkrpc.EntryStatus(entry.Status) ==
+		walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE
+}
+
+// TestTipReconcileFiresWhenTipSettles verifies the startup loop runs one
+// reconcile pass once the best-block height is stable across a poll interval
+// and the wallet is READY, flipping a deposit that confirmed while down.
+func TestTipReconcileFiresWhenTipSettles(t *testing.T) {
+	t.Parallel()
+
+	runtime, store, rpc := newReconcileFixture(t)
+	depID := seedPendingDepositThatConfirms(t, runtime, rpc)
+
+	// A settled tip: a fixed best-block height (stable across polls) and a
+	// READY wallet.
+	rpc.getInfoResp = &daemonrpc.GetInfoResponse{
+		BlockHeight: 100,
+		WalletState: daemonrpc.WalletState_WALLET_STATE_READY,
+	}
+	runtime.tipPollInterval = time.Millisecond
+
+	runtime.startTipReconcileLoop()
+
+	require.Eventually(t, func() bool {
+		return depositComplete(store, depID)
+	}, 5*time.Second, 5*time.Millisecond,
+		"tip reconcile did not flip the confirmed deposit")
+}
+
+// TestTipReconcileBackstopReconcilesOnTimeout verifies that when the best block
+// never settles (height keeps advancing), the timeout backstop still runs one
+// reconcile pass and hands off to the periodic reconciler.
+func TestTipReconcileBackstopReconcilesOnTimeout(t *testing.T) {
+	t.Parallel()
+
+	runtime, store, rpc := newReconcileFixture(t)
+	depID := seedPendingDepositThatConfirms(t, runtime, rpc)
+
+	// The best block advances on every poll, so the stability heuristic
+	// never triggers; only the timeout backstop can reconcile.
+	var height atomic.Uint32
+	rpc.getInfoHook = func(_ int) (*daemonrpc.GetInfoResponse, error) {
+		return &daemonrpc.GetInfoResponse{
+			BlockHeight: height.Add(1),
+			WalletState: daemonrpc.WalletState_WALLET_STATE_READY,
+		}, nil
+	}
+	runtime.tipPollInterval = time.Millisecond
+	runtime.tipReconcileTimeout = 30 * time.Millisecond
+
+	runtime.startTipReconcileLoop()
+
+	require.Eventually(t, func() bool {
+		return depositComplete(store, depID)
+	}, 5*time.Second, 5*time.Millisecond,
+		"timeout backstop did not reconcile")
+}
+
+// TestTipReconcileWaitsWhileSyncing verifies the loop does not reconcile while
+// the wallet is still SYNCING even if the height is stable: it must wait for
+// READY (the backstop timeout is set far out so it cannot fire in-window).
+func TestTipReconcileWaitsWhileSyncing(t *testing.T) {
+	t.Parallel()
+
+	runtime, store, rpc := newReconcileFixture(t)
+	depID := seedPendingDepositThatConfirms(t, runtime, rpc)
+
+	rpc.getInfoResp = &daemonrpc.GetInfoResponse{
+		BlockHeight: 100,
+		WalletState: daemonrpc.WalletState_WALLET_STATE_SYNCING,
+	}
+	runtime.tipPollInterval = time.Millisecond
+	runtime.tipReconcileTimeout = 10 * time.Second
+
+	runtime.startTipReconcileLoop()
+
+	require.Never(t, func() bool {
+		return depositComplete(store, depID)
+	}, 200*time.Millisecond, 10*time.Millisecond,
+		"tip reconcile must wait until the wallet is READY")
+}
+
+// TestTipReconcileNoDepsIsNoOp verifies the loop is a safe no-op without a
+// canonical store or without an RPCServer to poll.
+func TestTipReconcileNoDepsIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		noStore := newRuntime(
+			t.Context(), &Deps{
+				RPCServer: &fakeRPCServer{},
+			},
+		)
+		t.Cleanup(noStore.stop)
+		noStore.startTipReconcileLoop()
+
+		noRPC := newRuntime(t.Context(), &Deps{})
+		t.Cleanup(noRPC.stop)
+		noRPC.startTipReconcileLoop()
+	})
+}


### PR DESCRIPTION
Implements **C5a** of #899 (startup reconciliation at the chain tip).

## Problem

The startup backfill (`backfillActivity` in `resumeAll`) seeds the activity
store at wallet-ready. In `lwwallet`/`lnd` modes that hook fires **before** the
chain backend has synced forward to the tip, so the backfill re-derives pre-tip
state. A DEPOSIT that confirmed or an EXIT that was swept while the daemon was
down reads PENDING until the periodic reconciler's first tick — up to a full
`reconcileInterval` (60s) later, plus sync lag. A UI reconnecting right after a
restart sees a settled op look stuck, then silently jump to terminal.

## Change

A one-shot startup goroutine (`swapwallet/tip_reconciler.go`, launched from
`start()`) that polls `GetInfo` until the best-block height is **stable across a
poll interval and the wallet is READY**, then runs one reconciler pass
(`reconcileActivity` — DEPOSIT/EXIT, since SEND/RECV self-heal via the live
monitor `SubscribeSwaps` stream). A timeout backstop reconciles once anyway if
the backend never settles; the periodic reconciler owns steady state afterward.
`tipPollInterval`/`tipReconcileTimeout` are `Runtime` fields so tests drive the
loop without real-time waits.

The "caught up" test is a heuristic: `GetInfo.block_height` is the backend's
best-known height and `wallet_state` flips READY at wallet-ready, so there is no
precise "wallet synced to tip" signal on the current RPC surface. This is a
strict improvement (worst case it runs one extra reconcile early; the periodic
reconciler covers any residual wallet-processing lag). A precise tip signal
(e.g. a `GetInfo` target-height field or a block-epoch subscription) is noted as
a follow-up in #899.

## Tests

`swapwallet/tip_reconciler_test.go` (all pass under `-race`): fires on
stable-height + READY, waits while SYNCING, timeout backstop fires when the
height never settles, and is a no-op without a store / RPCServer.

## Scope

This is **C5a**. **C5b** — the durable leave record (the AC2 residual:
restart-survivable cooperative-leave EXIT completion) — is the heavier,
independent follow-up tracked in #899.
