### PR TITLE
swapwallet: make cooperative-leave EXIT restart-survivable (C5, #776)

### DIFF
--- a/darepod/config.go
+++ b/darepod/config.go
@@ -664,6 +664,13 @@ type ActivityStore interface {
 	ListEntries(ctx context.Context, cursorCreated int64, cursorID string,
 		limit int32) ([]sqlc.ActivityEntry, error)
 
+	// ListEntriesByKindStatus returns up to limit rows of the given kind
+	// and status, paged by canonical_id ascending after cursorID. It backs
+	// the startup rehydration of the wallet-local pending map, scanning
+	// only the matching rows rather than decoding the whole feed.
+	ListEntriesByKindStatus(ctx context.Context, kind, status int64,
+		cursorID string, limit int32) ([]sqlc.ActivityEntry, error)
+
 	// PullEvents returns up to limit append-only transition rows with
 	// event_seq strictly greater than cursor, oldest-first. It is the
 	// resumable-subscribe replay primitive: a reconnecting client passes

--- a/db/activity_store.go
+++ b/db/activity_store.go
@@ -32,6 +32,12 @@ type ActivityStore interface {
 		error,
 	)
 
+	ListEntriesByKindStatus(ctx context.Context,
+		arg sqlc.ListEntriesByKindStatusParams) (
+		[]sqlc.ActivityEntry,
+		error,
+	)
+
 	PullActivityEvents(ctx context.Context,
 		arg sqlc.PullActivityEventsParams) ([]sqlc.ActivityEvent, error)
 }
@@ -248,6 +254,34 @@ func (s *ActivityPersistenceStore) ListEntries(ctx context.Context,
 				CursorCreated: cursorCreated,
 				CursorID:      cursorID,
 				LimitCount:    limit,
+			},
+		)
+
+		return err
+	})
+
+	return rows, err
+}
+
+// ListEntriesByKindStatus returns up to limit entries of the given kind and
+// status, paged by canonical_id ascending after cursorID. Filtering in SQL
+// keeps a scan for a specific kind/status (e.g. the startup rehydration of
+// PENDING EXIT rows) proportional to the matching rows, and the unique
+// canonical_id cursor is strictly monotonic.
+func (s *ActivityPersistenceStore) ListEntriesByKindStatus(ctx context.Context,
+	kind, status int64, cursorID string, limit int32) ([]sqlc.ActivityEntry,
+	error) {
+
+	var rows []sqlc.ActivityEntry
+
+	err := s.db.ExecTx(ctx, ReadTxOption(), func(q ActivityStore) error {
+		var err error
+		rows, err = q.ListEntriesByKindStatus(
+			ctx, sqlc.ListEntriesByKindStatusParams{
+				Kind:       kind,
+				Status:     status,
+				CursorID:   cursorID,
+				LimitCount: limit,
 			},
 		)
 

--- a/db/sqlc/activity_log.sql.go
+++ b/db/sqlc/activity_log.sql.go
@@ -160,6 +160,77 @@ func (q *Queries) ListActivityEntries(ctx context.Context, arg ListActivityEntri
 	return items, nil
 }
 
+const ListEntriesByKindStatus = `-- name: ListEntriesByKindStatus :many
+SELECT canonical_id, kind, status, amount_sat, fee_sat, counterparty, note, phase, phase_label, failure_code, failure_reason, payment_hash, txid, confirmation_height, vtxo_outpoint, swap_session_id, ledger_txid, boarding_addr, request_json, created_at_unix, updated_at_unix FROM activity_entries
+WHERE kind = $1
+    AND status = $2
+    AND canonical_id > $3
+ORDER BY canonical_id ASC
+LIMIT $4
+`
+
+type ListEntriesByKindStatusParams struct {
+	Kind       int64
+	Status     int64
+	CursorID   string
+	LimitCount int32
+}
+
+// ListEntriesByKindStatus returns entries of the given kind and status, paged
+// by the unique canonical_id ascending. It backs the startup rehydration of
+// the wallet-local pending map: filtering in SQL keeps that scan O(matching
+// rows) instead of decoding the whole activity feed, and the canonical_id
+// cursor is strictly monotonic (a full page always advances it).
+func (q *Queries) ListEntriesByKindStatus(ctx context.Context, arg ListEntriesByKindStatusParams) ([]ActivityEntry, error) {
+	rows, err := q.db.QueryContext(ctx, ListEntriesByKindStatus,
+		arg.Kind,
+		arg.Status,
+		arg.CursorID,
+		arg.LimitCount,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ActivityEntry
+	for rows.Next() {
+		var i ActivityEntry
+		if err := rows.Scan(
+			&i.CanonicalID,
+			&i.Kind,
+			&i.Status,
+			&i.AmountSat,
+			&i.FeeSat,
+			&i.Counterparty,
+			&i.Note,
+			&i.Phase,
+			&i.PhaseLabel,
+			&i.FailureCode,
+			&i.FailureReason,
+			&i.PaymentHash,
+			&i.Txid,
+			&i.ConfirmationHeight,
+			&i.VtxoOutpoint,
+			&i.SwapSessionID,
+			&i.LedgerTxid,
+			&i.BoardingAddr,
+			&i.RequestJson,
+			&i.CreatedAtUnix,
+			&i.UpdatedAtUnix,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const PullActivityEvents = `-- name: PullActivityEvents :many
 SELECT event_seq, canonical_id, status, phase, entry_json, created_at_unix FROM activity_events
 WHERE event_seq > $1

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -175,6 +175,12 @@ type Querier interface {
 	ListClientLedgerEntries(ctx context.Context, arg ListClientLedgerEntriesParams) ([]LedgerEntry, error)
 	ListClientLedgerEntriesByType(ctx context.Context, arg ListClientLedgerEntriesByTypeParams) ([]LedgerEntry, error)
 	ListClientLedgerEventTotals(ctx context.Context) ([]ListClientLedgerEventTotalsRow, error)
+	// ListEntriesByKindStatus returns entries of the given kind and status, paged
+	// by the unique canonical_id ascending. It backs the startup rehydration of
+	// the wallet-local pending map: filtering in SQL keeps that scan O(matching
+	// rows) instead of decoding the whole activity feed, and the canonical_id
+	// cursor is strictly monotonic (a full page always advances it).
+	ListEntriesByKindStatus(ctx context.Context, arg ListEntriesByKindStatusParams) ([]ActivityEntry, error)
 	// ListLiveVTXOAncestryPaths returns every ancestry row whose parent VTXO
 	// is non-terminal, mirroring the filter on ListLiveVTXOs. Used as a
 	// single batched companion query so descriptor materialization across

--- a/db/sqlc/queries/activity_log.sql
+++ b/db/sqlc/queries/activity_log.sql
@@ -81,6 +81,19 @@ WHERE (
 ORDER BY created_at_unix DESC, canonical_id ASC
 LIMIT sqlc.arg(limit_count);
 
+-- name: ListEntriesByKindStatus :many
+-- ListEntriesByKindStatus returns entries of the given kind and status, paged
+-- by the unique canonical_id ascending. It backs the startup rehydration of
+-- the wallet-local pending map: filtering in SQL keeps that scan O(matching
+-- rows) instead of decoding the whole activity feed, and the canonical_id
+-- cursor is strictly monotonic (a full page always advances it).
+SELECT * FROM activity_entries
+WHERE kind = sqlc.arg(kind)
+    AND status = sqlc.arg(status)
+    AND canonical_id > sqlc.arg(cursor_id)
+ORDER BY canonical_id ASC
+LIMIT sqlc.arg(limit_count);
+
 -- name: PullActivityEvents :many
 -- PullActivityEvents returns transition rows strictly after the cursor in
 -- event_seq order, the resumable-subscribe replay primitive.

--- a/swapwallet/doc.go
+++ b/swapwallet/doc.go
@@ -121,10 +121,12 @@
 // inputs — and the periodic reconciler lands its terminal transition into the
 // store live: each pass matches the retained consumed outpoint (kept in
 // vtxo_outpoint) against a forfeited VTXO and upserts the row to COMPLETE.
-// This stays best-effort — the row is wallet-local (in-memory) with no durable
-// leave-job → forfeit link, so a restarted daemon cannot rebuild the original
-// counterparty/note from durable state alone. A durable leave record (making
-// leave completion restart-survivable rather than best-effort), a
-// per-block/confirmation reconcile trigger, and startup-at-tip reconciliation
-// (C5) are deferred.
+// Its COMPLETE transition is restart-survivable: the PENDING row is persisted
+// at submit (canonical_id = send_job_id, the retained consumed outpoint in
+// vtxo_outpoint, plus counterparty/note/amount), and on startup the runtime
+// re-tracks the store's PENDING EXIT rows (rehydrateWalletLocalPending) so the
+// same forfeit correlation lands COMPLETE under the stable id after a restart.
+// Deferred: a per-block/confirmation reconcile trigger would lower latency, but
+// a block epoch fires before the wallet processes that block into the derive
+// sources, so the coarse, ordering-independent periodic reconciler is kept.
 package swapwallet

--- a/swapwallet/projector_test.go
+++ b/swapwallet/projector_test.go
@@ -66,6 +66,14 @@ func (f *fakeActivityProjector) ListEntries(_ context.Context, _ int64,
 	return nil, nil
 }
 
+// ListEntriesByKindStatus satisfies darepod.ActivityStore. The rehydration
+// read path is tested against a real DB store, so this returns no rows.
+func (f *fakeActivityProjector) ListEntriesByKindStatus(_ context.Context, _,
+	_ int64, _ string, _ int32) ([]sqlc.ActivityEntry, error) {
+
+	return nil, nil
+}
+
 // CountByStatus satisfies darepod.ActivityStore. The count path is tested
 // against a real DB store, so this fake reports nothing.
 func (f *fakeActivityProjector) CountByStatus(_ context.Context, _ int64) (

--- a/swapwallet/reconciler_test.go
+++ b/swapwallet/reconciler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/darepod"
 	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/db/sqlc"
 	"github.com/lightninglabs/darepo-client/ledger"
 	"github.com/lightninglabs/darepo-client/rpc/swapclientrpc"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
@@ -226,4 +227,197 @@ func (failingProjectStore) ProjectEntry(context.Context,
 	db.ActivityProjection) (int64, error) {
 
 	return 0, errors.New("injected project failure")
+}
+
+// TestReconcileCompletesLeaveAfterRestart is the restart-survivability
+// regression for cooperative-leave EXIT completion. It models a
+// restart: the PENDING leave row is durably in the store but the in-memory
+// pending map is empty (project writes only the store).
+// rehydrateWalletLocalPending restores the correlation from the durable row so
+// the reconciler flips the row COMPLETE under its stable send_job_id — the
+// transition that was previously stranded PENDING forever after a mid-flight
+// restart.
+func TestReconcileCompletesLeaveAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtime, store, rpc := newReconcileFixture(t)
+
+	const (
+		jobID    = "sendjob-abc"
+		outpoint = "aabbcc:0"
+	)
+
+	// The retained outpoint is reported forfeited (the round sealed) and
+	// the leave has no unroll job, so the correlation flips it COMPLETE.
+	rpc.unrollStatusResp = &daemonrpc.GetUnrollStatusResponse{Found: false}
+	rpc.listVTXOsByStatus = map[daemonrpc.VTXOStatus]*daemonrpc.ListVTXOsResponse{
+		daemonrpc.VTXOStatus_VTXO_STATUS_FORFEITED: {
+			Vtxos: []*daemonrpc.VTXO{
+				{
+					Outpoint: outpoint,
+				},
+			},
+		},
+	}
+
+	// Submit durably projected the PENDING row (keyed by send_job_id, with
+	// the retained outpoint); a restart leaves the in-memory pending map
+	// empty.
+	runtime.project(ctx, &walletdkrpc.WalletEntry{
+		Id:            jobID,
+		Kind:          walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+		Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		CreatedAtUnix: 100,
+		UpdatedAtUnix: 100,
+		Counterparty:  "cooperative",
+		Progress: &walletdkrpc.WalletEntryProgress{
+			VtxoOutpoint: outpoint,
+		},
+	})
+	require.NotContains(
+		t, pendingSnapshotIDs(runtime), jobID,
+		"restart starts with an empty in-memory pending map",
+	)
+
+	// resumeAll rehydrates the pending map from the store. The fixture has
+	// no SwapBackend, so this also asserts rehydration runs BEFORE the
+	// swap- backend guard (and hence in degraded/test configs).
+	runtime.resumeAll(ctx)
+	require.Contains(
+		t, pendingSnapshotIDs(runtime), jobID,
+		"resumeAll must re-track the store's pending EXIT row",
+	)
+
+	// One reconcile pass now flips the stored row COMPLETE under
+	// send_job_id.
+	runtime.reconcileActivity(ctx)
+
+	entry, err := store.GetEntry(ctx, jobID)
+	require.NoError(t, err)
+	require.EqualValues(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE, entry.Status,
+		"rehydrated leave must complete under its stable id after "+
+			"restart",
+	)
+	require.Equal(
+		t, outpoint, entry.VtxoOutpoint,
+		"the retained outpoint must survive the completion re-project",
+	)
+	require.NotContains(
+		t, pendingSnapshotIDs(runtime), jobID,
+		"the pending record is cleared after the durable project",
+	)
+}
+
+// TestRehydrateWalletLocalPending verifies startup rehydration re-tracks only
+// wallet-local PENDING EXIT rows: PENDING EXITs (both send_job_id- and
+// outpoint-keyed) are restored; a COMPLETE EXIT and a PENDING SEND are not.
+func TestRehydrateWalletLocalPending(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtime, _, _ := newReconcileFixture(t)
+
+	seed := func(id string, kind walletdkrpc.EntryKind,
+		status walletdkrpc.EntryStatus) {
+
+		runtime.project(ctx, &walletdkrpc.WalletEntry{
+			Id:            id,
+			Kind:          kind,
+			Status:        status,
+			CreatedAtUnix: 100,
+			UpdatedAtUnix: 100,
+		})
+	}
+	seed(
+		"sendjob-abc", walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+	)
+	seed(
+		"ddeeff:0", walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+	)
+	seed(
+		"sendjob-done", walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+	)
+	seed(
+		"payhash-send", walletdkrpc.EntryKind_ENTRY_KIND_SEND,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+	)
+
+	// project writes only the store; the in-memory map starts empty.
+	require.Empty(t, pendingSnapshotIDs(runtime))
+
+	runtime.rehydrateWalletLocalPending(ctx)
+
+	ids := pendingSnapshotIDs(runtime)
+	require.Contains(t, ids, "sendjob-abc")
+	require.Contains(t, ids, "ddeeff:0")
+	require.NotContains(
+		t, ids, "sendjob-done", "COMPLETE rows must not be re-tracked",
+	)
+	require.NotContains(
+		t, ids, "payhash-send", "SEND rows must not be re-tracked",
+	)
+}
+
+// TestRehydratePagesMultipleBatches verifies the scan advances its canonical_id
+// cursor across pages and terminates: with a page size of 2 and five PENDING
+// EXIT rows it restores all five exactly once (three pages: 2, 2, 1).
+func TestRehydratePagesMultipleBatches(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtime, _, _ := newReconcileFixture(t)
+	runtime.rehydratePageSize = 2
+
+	ids := []string{"exit-a", "exit-b", "exit-c", "exit-d", "exit-e"}
+	for _, id := range ids {
+		runtime.project(ctx, &walletdkrpc.WalletEntry{
+			Id:            id,
+			Kind:          walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
+			Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+			CreatedAtUnix: 100,
+			UpdatedAtUnix: 100,
+		})
+	}
+
+	runtime.rehydrateWalletLocalPending(ctx)
+
+	got := pendingSnapshotIDs(runtime)
+	for _, id := range ids {
+		require.Contains(
+			t, got, id,
+			"every pending EXIT must be restored across pages",
+		)
+	}
+	require.Len(t, got, len(ids), "no row restored more than once")
+}
+
+// TestRehydrateReturnsOnScanError verifies a scan error aborts rehydration
+// cleanly (no panic, empty map) rather than partially populating it.
+func TestRehydrateReturnsOnScanError(t *testing.T) {
+	t.Parallel()
+
+	runtime, store, _ := newReconcileFixture(t)
+	runtime.deps.ActivityStore = erringRehydrateStore{ActivityStore: store}
+
+	require.NotPanics(t, func() {
+		runtime.rehydrateWalletLocalPending(context.Background())
+	})
+	require.Empty(t, pendingSnapshotIDs(runtime))
+}
+
+// erringRehydrateStore fails only the rehydration scan, delegating every other
+// method to a real store.
+type erringRehydrateStore struct {
+	darepod.ActivityStore
+}
+
+func (erringRehydrateStore) ListEntriesByKindStatus(context.Context, int64,
+	int64, string, int32) ([]sqlc.ActivityEntry, error) {
+
+	return nil, errors.New("injected scan failure")
 }

--- a/swapwallet/runtime.go
+++ b/swapwallet/runtime.go
@@ -4,6 +4,7 @@ package swapwallet
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -88,6 +89,12 @@ type Runtime struct {
 	// or leave state. Cleared when an entry transitions to a terminal
 	// status through the monitor loop.
 	overlay map[string]overlayStatus
+
+	// rehydratePageSize is the keyset page size for the startup
+	// pending-EXIT rehydration scan. A field (not a const) so tests can
+	// drive multi-page paths without seeding hundreds of rows; newRuntime
+	// defaults it to defaultRehydratePageSize.
+	rehydratePageSize int32
 }
 
 // overlayStatus is the runtime's wallet-level overlay applied on top of an
@@ -116,8 +123,9 @@ func newRuntime(parent context.Context, deps *Deps) *Runtime {
 		subscribers: make(
 			map[*subscriber]struct{},
 		),
-		pending: make(map[string]pendingEntry),
-		overlay: make(map[string]overlayStatus),
+		pending:           make(map[string]pendingEntry),
+		overlay:           make(map[string]overlayStatus),
+		rehydratePageSize: defaultRehydratePageSize,
 	}
 }
 
@@ -146,6 +154,15 @@ func (r *Runtime) start() {
 func (r *Runtime) resumeAll(ctx context.Context) {
 	log := r.deps.resolveLog()
 
+	// Restore wallet-local PENDING EXIT rows from the store into the
+	// in-memory pending map before anything else. This keeps the
+	// cooperative-leave forfeit->COMPLETE correlation restart-survivable
+	// (see rehydrateWalletLocalPending), and runs before backfillActivity
+	// so a leave that sealed while the daemon was down completes in the
+	// single startup pass. It depends only on the store, so it must run
+	// even when no swap backend is configured (below).
+	r.rehydrateWalletLocalPending(ctx)
+
 	if r.deps.SwapBackend == nil {
 		log.WarnS(ctx, "Skipping unified resume sweep",
 			ErrSwapBackendUnavailable,
@@ -166,6 +183,94 @@ func (r *Runtime) resumeAll(ctx context.Context) {
 	// live transition is projected. Idempotent on canonical_id; a no-op
 	// when no activity store is wired.
 	r.backfillActivity(ctx)
+}
+
+// defaultRehydratePageSize is the keyset page size for the pending-EXIT
+// rehydration scan. Pending leaves are few, so a modest page keeps the
+// one-shot startup scan cheap.
+const defaultRehydratePageSize = 256
+
+// rehydrateWalletLocalPending re-tracks wallet-local PENDING EXIT rows from the
+// canonical store into the in-memory pending map at startup.
+//
+// A cooperative-leave EXIT is projected durably at submit, keyed by its stable
+// send_job_id and carrying the retained consumed outpoint. But its
+// pending->COMPLETE flip is driven by matching that outpoint against the
+// forfeited-VTXO set, and the only source the completion pass reads is the
+// in-memory pending map — which a restart empties, since the map is populated
+// only by the (RPC-driven) submit path. Without re-tracking, a leave that
+// sealed while the daemon was down, or was interrupted by any mid-flight
+// restart, is stranded PENDING in the store forever.
+//
+// Re-tracking restores the correlation from the durable store row so the
+// existing derive/reconcile pass flips it COMPLETE under its stable id. Only
+// EXIT rows are scanned: SEND/RECV are owned by the live monitor and DEPOSIT
+// re-derives from the ledger. A unilateral EXIT (outpoint-keyed) is re-tracked
+// too — redundant but harmless (it re-derives to the same id and dedupes).
+//
+// The scan is filtered to PENDING EXIT in SQL and paged by the unique
+// canonical_id, so it reads only the matching rows (not the whole feed) and its
+// cursor is strictly monotonic — a full page always advances it.
+func (r *Runtime) rehydrateWalletLocalPending(ctx context.Context) {
+	if r.deps == nil || r.deps.ActivityStore == nil {
+		return
+	}
+
+	log := r.deps.resolveLog()
+
+	pageSize := r.rehydratePageSize
+	if pageSize <= 0 {
+		pageSize = defaultRehydratePageSize
+	}
+
+	var (
+		cursorID string
+		restored int
+	)
+	for {
+		batch, err := r.deps.ActivityStore.ListEntriesByKindStatus(
+			ctx, int64(walletdkrpc.EntryKind_ENTRY_KIND_EXIT),
+			int64(walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING),
+			cursorID, pageSize,
+		)
+		if err != nil {
+			log.WarnS(ctx, "Pending-EXIT rehydration scan failed",
+				err,
+			)
+
+			return
+		}
+		if len(batch) == 0 {
+			break
+		}
+
+		for _, row := range batch {
+			cursorID = row.CanonicalID
+
+			entry, err := rowToWalletEntry(row)
+			if err != nil {
+				log.WarnS(ctx, "Skipping undecodable activity "+
+					"row during rehydration", err,
+					slog.String("id", row.CanonicalID),
+				)
+
+				continue
+			}
+
+			r.trackPendingEntryWithoutTimeout(entry)
+			restored++
+		}
+
+		if len(batch) < int(pageSize) {
+			break
+		}
+	}
+
+	if restored > 0 {
+		log.InfoS(ctx, "Rehydrated wallet-local pending EXIT rows",
+			slog.Int("count", restored),
+		)
+	}
 }
 
 // trackPending records a new or refreshed wallet-local pending entry so the


### PR DESCRIPTION
Implements the durable-leave-record work in #899 (the last remaining piece of the activity-log epic #776): make cooperative-leave EXIT completion restart-survivable.

## Problem (AC2 residual)

The on-chain cooperative-leave EXIT is projected as a durable PENDING row at submit, keyed by its stable `send_job_id` with the retained consumed outpoint in `vtxo_outpoint`. But its PENDING→COMPLETE flip is driven by matching that outpoint against the forfeited-VTXO set, and the only source the completion pass reads is the runtime's **in-memory pending map** — populated only by the (RPC-driven) submit path. A restart empties that map, so a leave interrupted mid-flight, or one that sealed while the daemon was down, was stranded PENDING in the store forever.

## Change

`rehydrateWalletLocalPending` (called at the top of `resumeAll`, before the swap-backend guard and before `backfillActivity`) pages the store's current-state rows and re-tracks the PENDING EXIT ones into the in-memory pending map. The existing derive → `decorateCooperativeLeaveEntry` → reproject → clear pipeline then flips the row COMPLETE under its stable id on the first backfill/reconcile pass after a restart — no behavior change to that pipeline.

**No new table / SQL.** The `send_job_id → retained-outpoint` link already round-trips through the `activity_entries` row (`canonical_id` + `vtxo_outpoint`); rehydration reuses the existing `ActivityStore.ListEntries` keyset scan. Also corrected the now-stale `doc.go` note (completion is restart-survivable; counterparty/note/amount survive in the store).

## Design notes

- This is what remained of C5 after the startup-reconciliation-at-tip mechanism was dropped (the ordering-independent 60s reconciler is kept; block-epoch triggering was rejected as the wrong layer — a block epoch fires before the wallet processes the block into the derive sources; see #899).
- A cooperative leave books a hidden `round`-type ledger row with **no txid**, so there is no duplicate txid-keyed EXIT row — the bug was exactly one stranded PENDING row, so no dedup is needed.

## Tests

- `TestReconcileCompletesLeaveAfterRestart` — models a restart (PENDING row in the store, empty in-memory map), runs `resumeAll` (rehydrate — also asserting it runs *before* the swap-backend guard) + one reconcile, and asserts the row completes under `send_job_id`, the outpoint is preserved, and the pending record is cleared.
- `TestRehydrateWalletLocalPending` — only PENDING EXIT rows (both `send_job_id`- and outpoint-keyed) are re-tracked; a COMPLETE EXIT and a PENDING SEND are not.

All pass under `-race`; full `swapwallet` suite green; `lint-changed-local` clean.

Closes #899.
