### PR TITLE
wallet: fix onchain sweep-all send failing before it leaves the daemon

### DIFF
--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -826,6 +826,62 @@ func TestPendingRoundAssemblyState(t *testing.T) {
 		require.Contains(t, failedState.Reason, "no VTXO output amount")
 	})
 
+	t.Run("sweep_all_leave_only_intent_passes", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+
+		// A sweep-all onchain send has no VTXO requests: the input
+		// comes entirely from a forfeited VTXO and the sole output is
+		// one IsChange leave. buildSendOnChainIntentPackage stamps the
+		// pre-fee Σ(inputs) onto that leave so this intent clears the
+		// IntentRequested output validation instead of tripping the
+		// "no VTXO output amount" guard on a bare-zero leave — the
+		// exact failure that killed every sweep-all send before the
+		// fix.
+		forfeitOutpoint := wire.OutPoint{
+			Hash: chainhash.Hash{
+				0xaa,
+			},
+			Index: 0,
+		}
+		const sweepAmount = btcutil.Amount(50000)
+		h.vtxoStore.On(
+			"GetVTXO", mock.Anything, forfeitOutpoint,
+		).Return(&ClientVTXO{
+			Outpoint: forfeitOutpoint,
+			Amount:   sweepAmount,
+		}, nil)
+
+		leavePkScript := append(
+			[]byte{0x51, 0x20}, bytes.Repeat([]byte{0xcd}, 32)...,
+		)
+		h.withState(&PendingRoundAssembly{
+			Forfeits: []types.ForfeitRequest{{
+				VTXOOutpoint: &forfeitOutpoint,
+				Amount:       sweepAmount,
+			}},
+			Leaves: []*types.LeaveRequest{{
+				Output: &wire.TxOut{
+					Value:    int64(sweepAmount),
+					PkScript: leavePkScript,
+				},
+				IsChange: true,
+			}},
+		})
+
+		transition, err := h.sendEvent(&IntentRequested{})
+		require.NoError(t, err)
+		require.NotNil(t, transition)
+
+		nextState := assertStateType[*IntentSentState](h)
+		require.Len(t, nextState.Intents.Leaves, 1)
+		require.Empty(
+			t, nextState.Intents.VTXOs,
+			"sweep-all intent carries no VTXO requests",
+		)
+	})
+
 	t.Run("output_exceeds_input_fails", func(t *testing.T) {
 		t.Parallel()
 

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -414,6 +414,25 @@ func (s *fakeMailboxServer) oorSubmitPackages() []*oorpb.SubmitPackageRequest {
 	return reqs
 }
 
+// joinRoundRequests returns a defensive copy of the JoinRound requests the
+// daemon has published to the fake operator mailbox so far.
+func (s *fakeMailboxServer) joinRoundRequests() []*roundpb.JoinRoundRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	reqs := make([]*roundpb.JoinRoundRequest, 0, len(s.joinRoundReqs))
+	for _, req := range s.joinRoundReqs {
+		cloned, ok := proto.Clone(req).(*roundpb.JoinRoundRequest)
+		if !ok {
+			continue
+		}
+
+		reqs = append(reqs, cloned)
+	}
+
+	return reqs
+}
+
 // directedSendFixture owns the daemon under test, its fake operator edge, and
 // the gRPC client used by the systest.
 type directedSendFixture struct {
@@ -1043,4 +1062,92 @@ func TestSendOORMultipleRecipientsEndToEnd(t *testing.T) {
 		amountA: 1,
 		amountB: 1,
 	}, recipientAmounts)
+}
+
+// TestSendOnChainSweepAllEndToEnd exercises the atomic onchain sweep-all send
+// through the full daemon stack and pins the regression where the round FSM
+// rejected the sweep-all intent before it ever reached the operator. The
+// sweep-all leave ships IsChange=true with the pre-fee Σ(inputs) as its
+// placeholder value; a bare-zero placeholder tripped the IntentRequested
+// "total VTXO output is zero" guard, failing the round at PendingRoundAssembly
+// and dropping every sweep-all send. The assertion is made at the fake
+// operator mailbox boundary: a JoinRound request must egress, which only
+// happens once the FSM clears IntentRequested and publishes the registration.
+func TestSendOnChainSweepAllEndToEnd(t *testing.T) {
+	ParallelN(t)
+
+	fixture := newDirectedSendFixture(t)
+
+	initialVTXOs := listAllVTXOs(t, fixture.client)
+	require.Len(t, initialVTXOs, 1)
+	require.Equal(
+		t, daemonrpc.VTXOStatus_VTXO_STATUS_LIVE,
+		initialVTXOs[0].Status,
+	)
+
+	// A standard P2TR destination script: OP_1 followed by a 32-byte
+	// witness program. The content is irrelevant to the round FSM; only
+	// its recognised script class matters to the RPC's leave-script guard.
+	destPkScript := append(
+		[]byte{0x51, 0x20}, make([]byte, 32)...,
+	)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	sendResp, err := fixture.client.SendOnChain(
+		ctx, &daemonrpc.SendOnChainRequest{
+			Destination: &daemonrpc.LeaveDestination{
+				Target: &daemonrpc.LeaveDestination_PkScript{
+					PkScript: destPkScript,
+				},
+			},
+			Amount: &daemonrpc.SendOnChainRequest_SweepAll{
+				SweepAll: true,
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "submitted", sendResp.Status)
+
+	// Sweep-all reports the pre-fee Σ(inputs) as the actual amount; the
+	// operator reduces it by the seal-time fee.
+	require.Equal(t, testSeededAmountSat, sendResp.ActualAmountSat)
+
+	// The seeded VTXO must move to pending-forfeit as the round adopts it.
+	require.Eventually(
+		t,
+		func() bool {
+			vtxos := listAllVTXOs(t, fixture.client)
+			vtxoInfo := findVTXOByOutpoint(
+				vtxos, fixture.seededOutpoint,
+			)
+			if vtxoInfo == nil {
+				return false
+			}
+
+			return vtxoInfo.Status ==
+				daemonrpc.VTXOStatus_VTXO_STATUS_PENDING_FORFEIT
+		},
+		20*time.Second,
+		200*time.Millisecond,
+		"seeded VTXO did not transition to pending forfeit",
+	)
+
+	// The core regression assertion: the sweep-all intent must clear the
+	// round FSM's IntentRequested validation and publish a JoinRound
+	// request to the operator. Before the fix the FSM failed the round at
+	// PendingRoundAssembly ("total VTXO output is zero") and nothing
+	// egressed, so this Eventually would time out.
+	require.Eventually(
+		t,
+		func() bool {
+			reqs := fixture.mailboxServer.joinRoundRequests()
+
+			return len(reqs) >= 1
+		},
+		20*time.Second,
+		200*time.Millisecond,
+		"sweep-all send did not publish a JoinRound request",
+	)
 }

--- a/wallet/send_onchain_intent_replayer.go
+++ b/wallet/send_onchain_intent_replayer.go
@@ -54,12 +54,28 @@ func (a *Ark) buildSendOnChainIntentPackage(ctx context.Context,
 	)
 
 	if p.SweepAll {
-		// One leave output, IsChange=true: server stamps the
-		// residual (Σinputs − fee) onto it at seal time.
+		// One leave output, IsChange=true: the server stamps the
+		// residual (Σinputs − fee) onto it at seal time. We still ship
+		// the pre-fee Σ(inputs) as the placeholder value rather than a
+		// bare zero. The round FSM's IntentRequested validation sums
+		// the leave output values and rejects a zero total ("no VTXO
+		// output amount"), and the operator's join-request validation
+		// rejects a sub-dust output before the seal-time builder runs —
+		// the same admission-time floor the bounded-mode change VTXO
+		// below relies on. Σ(inputs) is above dust by construction (the
+		// forfeited VTXOs each cleared it), so both checks pass and the
+		// server rewrites the slot at seal time regardless of the
+		// placeholder.
+		var totalInput btcutil.Amount
+		for _, amt := range selectedAmounts {
+			totalInput += amt
+		}
+
 		leaves = []*types.LeaveRequest{
 			{
 				Output: &wire.TxOut{
 					PkScript: p.DestinationPkScript,
+					Value:    int64(totalInput),
 				},
 				IsChange: true,
 			},

--- a/wallet/send_onchain_replay_test.go
+++ b/wallet/send_onchain_replay_test.go
@@ -514,6 +514,163 @@ func TestReplaySendOnChainReRegistersExactAnchors(t *testing.T) {
 	require.True(t, captured.VTXOs[0].IsChange)
 }
 
+// TestHandleSendOnChainSweepAllLeaveValue pins the sweep-all regression: the
+// intent builder must stamp the pre-fee Σ(inputs) onto the single IsChange
+// leave rather than shipping a bare zero. A zero-valued leave passed the
+// wallet's coin selection but then died in the round FSM's IntentRequested
+// validation ("total VTXO output is zero"), so every sweep-all onchain send
+// failed before it ever reached the operator. The server rewrites the slot
+// with the residual at seal time, but the placeholder must already be
+// non-zero and above dust to clear both the client FSM check and the
+// operator's ValidateLeaveRequest floor.
+func TestHandleSendOnChainSweepAllLeaveValue(t *testing.T) {
+	t.Parallel()
+
+	opA := testOutpoint(20)
+	opB := testOutpoint(21)
+
+	mgr := &mockVTXOManagerBehavior{
+		forfeitReserveResp: &actormsg.ReserveForfeitResponse{},
+	}
+	roundActor := &mockRoundActorBehavior{}
+
+	// The sweep-all path materializes amounts through the VTXO reader for
+	// the enumerated outpoints; totalSelected is their sum.
+	descs := map[wire.OutPoint]*VTXODescriptor{
+		opA: {
+			Outpoint: opA,
+			Amount:   40_000,
+		},
+		opB: {
+			Outpoint: opB,
+			Amount:   25_000,
+		},
+	}
+
+	store := &MockBoardingStore{}
+	store.On(
+		"UpsertPendingIntent", mock.Anything, mock.Anything,
+	).Return(nil)
+
+	w := newSendReplayTestWallet(t, mgr, roundActor, store, descs)
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	result := w.Receive(t.Context(), &SendOnChainRequest{
+		DestinationPkScript: sendReplayDestScript,
+		SweepOutpoints:      []wire.OutPoint{opA, opB},
+		OperatorFee:         1_000,
+		DustLimit:           330,
+		OperatorKey:         priv.PubKey(),
+		VTXOExitDelay:       144,
+	})
+	require.True(
+		t, result.IsOk(),
+		"sweep-all send must succeed; got %v", result.Err(),
+	)
+
+	require.Equal(t, 1, roundActor.registerCalls)
+	captured := roundActor.capturedIntent
+	require.NotNil(t, captured)
+
+	// Exactly one leave, marked IsChange so the server absorbs the fee, and
+	// carrying the pre-fee Σ(inputs) placeholder — not zero.
+	require.Len(t, captured.Leaves, 1)
+	require.True(
+		t, captured.Leaves[0].IsChange, "sweep-all leave must be "+
+			"IsChange so the server stamps the seal-time residual",
+	)
+	require.EqualValues(
+		t, 65_000, captured.Leaves[0].Output.Value,
+		"sweep-all leave must carry the pre-fee Σ(inputs), not zero",
+	)
+	require.Equal(
+		t, sendReplayDestScript, captured.Leaves[0].Output.PkScript,
+	)
+
+	// Sweep-all drains everything to the destination: no change VTXO.
+	require.Empty(
+		t, captured.VTXOs, "sweep-all must not create a change VTXO",
+	)
+
+	// Forfeits are exactly the enumerated sweep outpoints.
+	gotForfeits := make([]wire.OutPoint, 0, len(captured.Forfeits))
+	for _, f := range captured.Forfeits {
+		gotForfeits = append(gotForfeits, *f.VTXOOutpoint)
+	}
+	require.ElementsMatch(t, []wire.OutPoint{opA, opB}, gotForfeits)
+}
+
+// TestReplaySendOnChainSweepAllLeaveValue mirrors the sweep-all leave-value
+// guard on the restart replay path, which shares buildSendOnChainIntentPackage
+// with the live path: a replayed sweep-all intent must rebuild the same
+// non-zero IsChange leave.
+func TestReplaySendOnChainSweepAllLeaveValue(t *testing.T) {
+	t.Parallel()
+
+	opA := testOutpoint(22)
+	opB := testOutpoint(23)
+
+	mgr := &mockVTXOManagerBehavior{
+		forfeitReserveResp: &actormsg.ReserveForfeitResponse{},
+	}
+	roundActor := &mockRoundActorBehavior{}
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	payload := &SendOnChainIntentPayload{
+		DestinationPkScript: sendReplayDestScript,
+		SweepAll:            true,
+		OperatorKey:         priv.PubKey(),
+		VTXOExitDelay:       144,
+		DustLimit:           330,
+	}
+	anchors := []wire.OutPoint{opA, opB}
+	intent := PendingIntent{
+		ID:          NewPendingIntentID(payload, anchors),
+		Payload:     payload,
+		RequestedAt: 1_700_000_000,
+		Anchors:     anchors,
+	}
+
+	descs := map[wire.OutPoint]*VTXODescriptor{
+		opA: {
+			Outpoint: opA,
+			Amount:   40_000,
+		},
+		opB: {
+			Outpoint: opB,
+			Amount:   25_000,
+		},
+	}
+
+	store := &MockBoardingStore{}
+
+	w := newSendReplayTestWallet(t, mgr, roundActor, store, descs)
+
+	result := w.Receive(t.Context(), &ReplaySendOnChainIntent{
+		Intent: intent,
+	})
+	require.True(
+		t, result.IsOk(),
+		"sweep-all replay must succeed; got %v", result.Err(),
+	)
+
+	require.Equal(t, 1, roundActor.registerCalls)
+	captured := roundActor.capturedIntent
+	require.NotNil(t, captured)
+
+	require.Len(t, captured.Leaves, 1)
+	require.True(t, captured.Leaves[0].IsChange)
+	require.EqualValues(
+		t, 65_000, captured.Leaves[0].Output.Value,
+		"replayed sweep-all leave must carry the pre-fee Σ(inputs)",
+	)
+	require.Empty(t, captured.VTXOs)
+}
+
 // TestReplayPendingIntentsDispatchesSendKind verifies the registry wiring:
 // a persisted send_onchain intent surfaces from the generic replay Ask as
 // a ReplaySendOnChainIntent self-Tell into the wallet's own mailbox.


### PR DESCRIPTION
In this PR, we fix a bug where a `da send <addr> --onchain --sweep-all` never made it out of the daemon. The send would be accepted, the forfeits reserved, the intent registered, and then the round would die on the very next turn:

```
ROND: temp(ff45310c) State transition from_state=PendingRoundAssembly to_state="ClientFailed: no VTXO output amount"
ROND: Round failed err="total VTXO output is zero" reason="no VTXO output amount" recoverable=true
DRPD: SendOnChain completed status=submitted sweep_all=true actual_amount_sat=1317437
```

So the CLI cheerfully reported `status=submitted` while the round had already failed underneath it. Every sweep-all onchain send hit this.

## Root cause

The break is in the intent builder (`buildSendOnChainIntentPackage`). On the sweep-all path we shipped the single leave output with no value at all, on the theory that the server stamps the real amount onto it at seal time since it's the `IsChange` slot. But the round FSM's `IntentRequested` transition sums the leave output values to compute the intent's total output, and hard-fails a zero total (`"total VTXO output is zero"`) before the intent ever reaches the operator.

The bounded-mode change VTXO right below already understood this: it ships a real, non-zero placeholder above the operator's dust floor precisely so it clears admission. The sweep-all leave just broke that invariant by leaving `Value` at zero.

## The fix

In `wallet`, we stamp the pre-fee `Σ(inputs)` onto the sweep-all leave. `IsChange` is still set, so the server rewrites the slot with the seal-time residual (`Σin - fee`) regardless of the placeholder we send. The value only has to be non-zero for the client FSM and above dust for the operator's `ValidateLeaveRequest` floor, both of which `Σ(inputs)` satisfies by construction (each forfeited VTXO already cleared dust). The change lands in the builder shared by the live send and the restart-replay path, so both produce the identical shape.

I checked the server side (darepo `rounds/seal_time_fee_builder.go`) to be sure: it excludes the `IsChange` leave from the fixed-output total and stamps `residual = Σin - fee` onto it, so our placeholder never distorts the fee math. The bug is entirely client-side and the server needs no change.

## Testing

The wallet unit tests cover both the live and replay builder paths, and both fail on a bare-zero leave (verified by reverting the one-line fix). The `round` FSM test drives a forfeit-funded, leave-only, zero-VTXO intent (the exact sweep-all shape) through `IntentRequested` and asserts it clears into `IntentSent` rather than failing the round.

The gap that let this ship was that nothing drove a real sweep-all through the round FSM, so we also add `TestSendOnChainSweepAllEndToEnd`: it seeds a live VTXO, submits a sweep-all `SendOnChain` against the full daemon stack, and asserts a `JoinRound` request egresses to the fake operator mailbox, which only happens once the FSM clears `IntentRequested`. Against a live daemon the round now walks `PendingRoundAssembly -> IntentSent` and publishes the registration:

```
ROND: temp(f7a8054e) Intent balance check passed total_input="0.00100000 BTC" total_output="0.00100000 BTC" estimated_operator_fee="0 BTC"
ROND: temp(f7a8054e) Sending JoinRoundRequest to server forfeit_requests=1 leave_requests=1
ROND: temp(f7a8054e) State transition from_state=PendingRoundAssembly to_state=IntentSent
```

See each commit message for a detailed description w.r.t the incremental changes.

Note this is stacked on `send-invoice-eager-projection`.

Fixes https://github.com/lightninglabs/darepo-client/issues/889