### PR TITLE
darepod: default public test networks to deployed endpoints

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -170,9 +170,9 @@ darepod \
   --wallet.feeurl=https://mempool.space/signet/api/v1/fees/recommended
 ```
 
-The Ark and swap connections resolve to the public staging signet endpoints
+The Ark and swap connections resolve from the configured public test network
 unless explicitly overridden. See [`docs/signet.md`](docs/signet.md) for the
-gRPC and REST addresses.
+testnet3, testnet4, and signet gRPC and REST addresses.
 
 ### `lnd`
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -170,6 +170,10 @@ darepod \
   --wallet.feeurl=https://mempool.space/signet/api/v1/fees/recommended
 ```
 
+The Ark and swap connections resolve to the public staging signet endpoints
+unless explicitly overridden. See [`docs/signet.md`](docs/signet.md) for the
+gRPC and REST addresses.
+
 ### `lnd`
 
 Uses an existing lnd node for signing and chain access. The node must be

--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ Common knobs:
 | `--wallet.type`            | `lwwallet`         | `lwwallet`, `btcwallet`, or `lnd`.       |
 | `--wallet.esploraurl`      |                    | Esplora REST URL (`lwwallet`).           |
 | `--lnd.host`               | `localhost:10009`  | lnd gRPC (`lnd` backend).                |
-| `--server.host`            | `localhost:10010`  | Ark operator mailbox address.            |
+| `--server.host`            | `localhost:10010`  | Ark operator address. Signet defaults to `arkd-signet.staging.lightningcluster.com:443`. |
+| `--server.transport`       | `grpc`             | Ark operator transport: `grpc` or `rest`. |
+| `--swap.serveraddress`     | `localhost:10030`  | Swap server address. Signet defaults to `swapd-signet.staging.lightningcluster.com:443`. |
 | `--rpc.listenaddr`         | `localhost:10029`  | Daemon gRPC listen address.              |
 
 ---
@@ -176,6 +178,7 @@ own `CLAUDE.md` / `AGENTS.md` with package-local context.
 |----------------------------------|-----------------------------------------------------------------------|
 | System architecture              | [`ARCHITECTURE.md`](ARCHITECTURE.md)                                  |
 | Install, configure, operate      | [`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md)                |
+| Public signet endpoints          | [`docs/signet.md`](docs/signet.md)                                    |
 | Build-tag matrix                 | [`docs/walletdkrpc_build.md`](docs/walletdkrpc_build.md)                  |
 | Durable actor pattern            | [`docs/durable_actor_architecture.md`](docs/durable_actor_architecture.md) |
 | Mailbox transport                | [`docs/mailbox_architecture.md`](docs/mailbox_architecture.md)        |

--- a/README.md
+++ b/README.md
@@ -139,13 +139,13 @@ Common knobs:
 | Flag                       | Default            | Purpose                                  |
 |----------------------------|--------------------|------------------------------------------|
 | `--datadir`                | `~/.darepod`       | Root data directory.                     |
-| `--network`                | `mainnet`          | `mainnet`, `testnet`, `signet`, `regtest`, `simnet`. |
+| `--network`                | `mainnet`          | `mainnet`, `testnet`, `testnet4`, `signet`, `regtest`, `simnet`. |
 | `--wallet.type`            | `lwwallet`         | `lwwallet`, `btcwallet`, or `lnd`.       |
 | `--wallet.esploraurl`      |                    | Esplora REST URL (`lwwallet`).           |
 | `--lnd.host`               | `localhost:10009`  | lnd gRPC (`lnd` backend).                |
-| `--server.host`            | `localhost:10010`  | Ark operator address. Signet defaults to `arkd-signet.staging.lightningcluster.com:443`. |
+| `--server.host`            | network default    | Ark operator address override.           |
 | `--server.transport`       | `grpc`             | Ark operator transport: `grpc` or `rest`. |
-| `--swap.serveraddress`     | `localhost:10030`  | Swap server address. Signet defaults to `swapd-signet.staging.lightningcluster.com:443`. |
+| `--swap.serveraddress`     | network default    | Swap server address override.            |
 | `--rpc.listenaddr`         | `localhost:10029`  | Daemon gRPC listen address.              |
 
 ---
@@ -178,7 +178,7 @@ own `CLAUDE.md` / `AGENTS.md` with package-local context.
 |----------------------------------|-----------------------------------------------------------------------|
 | System architecture              | [`ARCHITECTURE.md`](ARCHITECTURE.md)                                  |
 | Install, configure, operate      | [`docs/daemon_cli_guide.md`](docs/daemon_cli_guide.md)                |
-| Public signet endpoints          | [`docs/signet.md`](docs/signet.md)                                    |
+| Public test-network endpoints    | [`docs/signet.md`](docs/signet.md)                                    |
 | Build-tag matrix                 | [`docs/walletdkrpc_build.md`](docs/walletdkrpc_build.md)                  |
 | Durable actor pattern            | [`docs/durable_actor_architecture.md`](docs/durable_actor_architecture.md) |
 | Mailbox transport                | [`docs/mailbox_architecture.md`](docs/mailbox_architecture.md)        |

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -49,6 +49,31 @@ const (
 	// mailbox edge server.
 	DefaultServerHost = "localhost:10010"
 
+	// defaultSwapServerHost is the default address for the swap server.
+	defaultSwapServerHost = "localhost:10030"
+
+	// defaultSignetServerGRPCHost is the public signet Ark operator gRPC
+	// endpoint.
+	defaultSignetServerGRPCHost = "arkd-signet.staging." +
+		"lightningcluster.com:443"
+
+	// defaultSignetServerRESTHost is the public signet Ark operator REST
+	// endpoint. The REST client adds the HTTPS scheme when the configured
+	// host is bare.
+	defaultSignetServerRESTHost = "arkd-signet-rest.staging." +
+		"lightningcluster.com"
+
+	// defaultSignetSwapServerGRPCHost is the public signet swap server gRPC
+	// endpoint.
+	defaultSignetSwapServerGRPCHost = "swapd-signet.staging." +
+		"lightningcluster.com:443"
+
+	// defaultSignetSwapServerRESTHost is the public signet swap server REST
+	// endpoint. The REST client adds the HTTPS scheme when the configured
+	// host is bare.
+	defaultSignetSwapServerRESTHost = "swapd-signet-rest.staging." +
+		"lightningcluster.com"
+
 	// DefaultIndexerServerID is the canonical operator identifier used
 	// in signed indexer proofs.
 	DefaultIndexerServerID = "arkd"
@@ -978,7 +1003,7 @@ func DefaultConfig() *Config {
 			RecoveryWindow: DefaultRecoveryWindow,
 		},
 		Swap: &SwapConfig{
-			ServerAddress:   "localhost:10030",
+			ServerAddress:   defaultSwapServerHost,
 			ServerTransport: RPCTransportGRPC,
 			VHTLCRecovery:   swapRecovery,
 		},
@@ -1003,6 +1028,8 @@ func (c *Config) Validate() error {
 	default:
 		return fmt.Errorf("unknown network %q", c.Network)
 	}
+
+	c.applyNetworkEndpointDefaults()
 
 	// Require explicit opt-in for mainnet to prevent accidental
 	// use during development.
@@ -1142,6 +1169,41 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// applyNetworkEndpointDefaults replaces the local development endpoints with
+// the public signet deployment when the caller selects signet without
+// configuring an operator or swap server. An insecure connection or a pinned
+// certificate keeps the local value intact, since either setting indicates an
+// intentional development override.
+func (c *Config) applyNetworkEndpointDefaults() {
+	if c.Network != "signet" {
+		return
+	}
+
+	if c.Server != nil && c.Server.Host == DefaultServerHost &&
+		!c.Server.Insecure && c.Server.TLSCertPath == "" {
+
+		switch c.Server.Transport {
+		case "", RPCTransportGRPC:
+			c.Server.Host = defaultSignetServerGRPCHost
+
+		case RPCTransportREST:
+			c.Server.Host = defaultSignetServerRESTHost
+		}
+	}
+
+	if c.Swap != nil && c.Swap.ServerAddress == defaultSwapServerHost &&
+		!c.Swap.ServerInsecure && c.Swap.ServerTLSCertPath == "" {
+
+		switch c.Swap.ServerTransport {
+		case "", RPCTransportGRPC:
+			c.Swap.ServerAddress = defaultSignetSwapServerGRPCHost
+
+		case RPCTransportREST:
+			c.Swap.ServerAddress = defaultSignetSwapServerRESTHost
+		}
+	}
 }
 
 // validateBtcwalletHeadersImportConfig checks that header import sources are

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -52,6 +52,46 @@ const (
 	// defaultSwapServerHost is the default address for the swap server.
 	defaultSwapServerHost = "localhost:10030"
 
+	// defaultTestnet3ServerGRPCHost is the public testnet3 Ark operator
+	// gRPC endpoint.
+	defaultTestnet3ServerGRPCHost = "arkd.testnet." +
+		"lightningcluster.com:443"
+
+	// defaultTestnet3ServerRESTHost is the public testnet3 Ark operator
+	// REST endpoint.
+	defaultTestnet3ServerRESTHost = "arkd-rest.testnet." +
+		"lightningcluster.com"
+
+	// defaultTestnet3SwapServerGRPCHost is the public testnet3 swap server
+	// gRPC endpoint.
+	defaultTestnet3SwapServerGRPCHost = "swapd.testnet." +
+		"lightningcluster.com:443"
+
+	// defaultTestnet3SwapServerRESTHost is the public testnet3 swap server
+	// REST endpoint.
+	defaultTestnet3SwapServerRESTHost = "swapd-rest.testnet." +
+		"lightningcluster.com"
+
+	// defaultTestnet4ServerGRPCHost is the public testnet4 Ark operator
+	// gRPC endpoint.
+	defaultTestnet4ServerGRPCHost = "arkd-testnet4.testnet." +
+		"lightningcluster.com:443"
+
+	// defaultTestnet4ServerRESTHost is the public testnet4 Ark operator
+	// REST endpoint.
+	defaultTestnet4ServerRESTHost = "arkd-testnet4-rest.testnet." +
+		"lightningcluster.com"
+
+	// defaultTestnet4SwapServerGRPCHost is the public testnet4 swap server
+	// gRPC endpoint.
+	defaultTestnet4SwapServerGRPCHost = "swapd-testnet4.testnet." +
+		"lightningcluster.com:443"
+
+	// defaultTestnet4SwapServerRESTHost is the public testnet4 swap server
+	// REST endpoint.
+	defaultTestnet4SwapServerRESTHost = "swapd-testnet4-rest.testnet." +
+		"lightningcluster.com"
+
 	// defaultSignetServerGRPCHost is the public signet Ark operator gRPC
 	// endpoint.
 	defaultSignetServerGRPCHost = "arkd-signet.staging." +
@@ -525,8 +565,8 @@ func (c *Config) OORReceiveLimits() oor.ReceiveLimits {
 type SwapConfig struct {
 	// ServerAddress is the swapdk-server endpoint used by the daemon
 	// executor. Its meaning follows ServerTransport: host:port for gRPC,
-	// or an HTTP gateway base URL for REST. Empty values fall back to the
-	// local development default.
+	// or an HTTP gateway base URL for REST. Empty selects the configured
+	// network+transport default.
 	ServerAddress string `mapstructure:"serveraddress"`
 
 	// ServerTransport selects the daemon-owned swapdk-server transport.
@@ -773,7 +813,8 @@ type LndConfig struct {
 // edge server.
 type ServerConfig struct {
 	// Host is the ark operator endpoint. Its meaning follows Transport:
-	// host:port for gRPC, or an HTTP gateway base URL for REST.
+	// host:port for gRPC, or an HTTP gateway base URL for REST. Empty
+	// selects the configured network+transport default.
 	Host string `mapstructure:"host"`
 
 	// Transport selects the daemon-owned outbound transport for ArkService
@@ -989,7 +1030,6 @@ func DefaultConfig() *Config {
 			RPCTimeout: DefaultRPCTimeout,
 		},
 		Server: &ServerConfig{
-			Host:         DefaultServerHost,
 			Transport:    RPCTransportGRPC,
 			MaxTreeNodes: roundpb.DefaultMaxTreeNodes,
 		},
@@ -1003,7 +1043,6 @@ func DefaultConfig() *Config {
 			RecoveryWindow: DefaultRecoveryWindow,
 		},
 		Swap: &SwapConfig{
-			ServerAddress:   defaultSwapServerHost,
 			ServerTransport: RPCTransportGRPC,
 			VHTLCRecovery:   swapRecovery,
 		},
@@ -1028,8 +1067,6 @@ func (c *Config) Validate() error {
 	default:
 		return fmt.Errorf("unknown network %q", c.Network)
 	}
-
-	c.applyNetworkEndpointDefaults()
 
 	// Require explicit opt-in for mainnet to prevent accidental
 	// use during development.
@@ -1111,13 +1148,13 @@ func (c *Config) Validate() error {
 	if c.Server == nil {
 		return fmt.Errorf("server config is required")
 	}
-	if c.Server.Host == "" {
-		return fmt.Errorf("server host is required")
-	}
 	if err := validateRPCTransport(
 		"server.transport", c.Server.Transport,
 	); err != nil {
 		return err
+	}
+	if c.ArkServerAddress() == "" {
+		return fmt.Errorf("server host is required")
 	}
 	if c.Swap != nil {
 		if err := validateRPCTransport(
@@ -1171,39 +1208,125 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// applyNetworkEndpointDefaults replaces the local development endpoints with
-// the public signet deployment when the caller selects signet without
-// configuring an operator or swap server. An insecure connection or a pinned
-// certificate keeps the local value intact, since either setting indicates an
-// intentional development override.
-func (c *Config) applyNetworkEndpointDefaults() {
-	if c.Network != "signet" {
-		return
+// transportEndpoints holds the gRPC and REST addresses for one service.
+type transportEndpoints struct {
+	grpc string
+	rest string
+}
+
+// forTransport returns the endpoint matching transport. An empty transport
+// selects gRPC, matching the daemon transport default.
+func (e transportEndpoints) forTransport(transport string) string {
+	switch transport {
+	case "", RPCTransportGRPC:
+		return e.grpc
+
+	case RPCTransportREST:
+		return e.rest
+
+	default:
+		return ""
+	}
+}
+
+// networkEndpoints holds the Ark and swap service defaults for one network.
+type networkEndpoints struct {
+	ark  transportEndpoints
+	swap transportEndpoints
+}
+
+// defaultNetworkEndpoints returns the outbound service defaults for network.
+// Public test networks use the Lightning Labs deployments; networks without a
+// public service deployment keep the historical local development endpoints.
+func defaultNetworkEndpoints(network string) (networkEndpoints, bool) {
+	switch network {
+	case "mainnet", "regtest", "simnet":
+		return networkEndpoints{
+			ark: transportEndpoints{
+				grpc: DefaultServerHost,
+				rest: DefaultServerHost,
+			},
+			swap: transportEndpoints{
+				grpc: defaultSwapServerHost,
+				rest: defaultSwapServerHost,
+			},
+		}, true
+
+	case "testnet":
+		return networkEndpoints{
+			ark: transportEndpoints{
+				grpc: defaultTestnet3ServerGRPCHost,
+				rest: defaultTestnet3ServerRESTHost,
+			},
+			swap: transportEndpoints{
+				grpc: defaultTestnet3SwapServerGRPCHost,
+				rest: defaultTestnet3SwapServerRESTHost,
+			},
+		}, true
+
+	case "testnet4":
+		return networkEndpoints{
+			ark: transportEndpoints{
+				grpc: defaultTestnet4ServerGRPCHost,
+				rest: defaultTestnet4ServerRESTHost,
+			},
+			swap: transportEndpoints{
+				grpc: defaultTestnet4SwapServerGRPCHost,
+				rest: defaultTestnet4SwapServerRESTHost,
+			},
+		}, true
+
+	case "signet":
+		return networkEndpoints{
+			ark: transportEndpoints{
+				grpc: defaultSignetServerGRPCHost,
+				rest: defaultSignetServerRESTHost,
+			},
+			swap: transportEndpoints{
+				grpc: defaultSignetSwapServerGRPCHost,
+				rest: defaultSignetSwapServerRESTHost,
+			},
+		}, true
+
+	default:
+		return networkEndpoints{}, false
+	}
+}
+
+// ArkServerAddress returns the configured Ark operator address, or the
+// network+transport default when server.host is empty.
+func (c *Config) ArkServerAddress() string {
+	if c == nil || c.Server == nil {
+		return ""
+	}
+	if c.Server.Host != "" {
+		return c.Server.Host
 	}
 
-	if c.Server != nil && c.Server.Host == DefaultServerHost &&
-		!c.Server.Insecure && c.Server.TLSCertPath == "" {
-
-		switch c.Server.Transport {
-		case "", RPCTransportGRPC:
-			c.Server.Host = defaultSignetServerGRPCHost
-
-		case RPCTransportREST:
-			c.Server.Host = defaultSignetServerRESTHost
-		}
+	defaults, ok := defaultNetworkEndpoints(c.Network)
+	if !ok {
+		return ""
 	}
 
-	if c.Swap != nil && c.Swap.ServerAddress == defaultSwapServerHost &&
-		!c.Swap.ServerInsecure && c.Swap.ServerTLSCertPath == "" {
+	return defaults.ark.forTransport(c.Server.Transport)
+}
 
-		switch c.Swap.ServerTransport {
-		case "", RPCTransportGRPC:
-			c.Swap.ServerAddress = defaultSignetSwapServerGRPCHost
-
-		case RPCTransportREST:
-			c.Swap.ServerAddress = defaultSignetSwapServerRESTHost
-		}
+// SwapServerAddress returns the configured swap server address, or the
+// network+transport default when swap.serveraddress is empty.
+func (c *Config) SwapServerAddress() string {
+	if c == nil || c.Swap == nil {
+		return ""
 	}
+	if c.Swap.ServerAddress != "" {
+		return c.Swap.ServerAddress
+	}
+
+	defaults, ok := defaultNetworkEndpoints(c.Network)
+	if !ok {
+		return ""
+	}
+
+	return defaults.swap.forTransport(c.Swap.ServerTransport)
 }
 
 // validateBtcwalletHeadersImportConfig checks that header import sources are

--- a/darepod/config_network_test.go
+++ b/darepod/config_network_test.go
@@ -49,17 +49,10 @@ func TestConfigValidateAcceptsSupportedNetworks(t *testing.T) {
 			cfg.Wallet.EsploraURL = "http://127.0.0.1:3000"
 
 			require.NoError(t, cfg.Validate())
-
-			if tc.name == "signet" {
-				require.Equal(
-					t, defaultSignetServerGRPCHost,
-					cfg.Server.Host,
-				)
-				require.Equal(
-					t, defaultSignetSwapServerGRPCHost,
-					cfg.Swap.ServerAddress,
-				)
-			}
+			require.NotEmpty(t, cfg.ArkServerAddress())
+			require.NotEmpty(t, cfg.SwapServerAddress())
+			require.Empty(t, cfg.Server.Host)
+			require.Empty(t, cfg.Swap.ServerAddress)
 		})
 	}
 }
@@ -78,10 +71,9 @@ func TestConfigValidateAllowsTestnet4InsecureRPC(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 }
 
-// TestApplyNetworkEndpointDefaults verifies signet selects the public staging
-// deployment for both outbound transports while every other network keeps the
-// local development endpoints.
-func TestApplyNetworkEndpointDefaults(t *testing.T) {
+// TestConfigEndpointDefaults verifies the config resolves each empty endpoint
+// from one network+transport table without mutating the explicit config fields.
+func TestConfigEndpointDefaults(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -91,6 +83,41 @@ func TestApplyNetworkEndpointDefaults(t *testing.T) {
 		wantArkHost  string
 		wantSwapHost string
 	}{
+		{
+			name:         "mainnet grpc",
+			network:      "mainnet",
+			transport:    RPCTransportGRPC,
+			wantArkHost:  DefaultServerHost,
+			wantSwapHost: defaultSwapServerHost,
+		},
+		{
+			name:         "testnet3 grpc",
+			network:      "testnet",
+			transport:    RPCTransportGRPC,
+			wantArkHost:  defaultTestnet3ServerGRPCHost,
+			wantSwapHost: defaultTestnet3SwapServerGRPCHost,
+		},
+		{
+			name:         "testnet3 rest",
+			network:      "testnet",
+			transport:    RPCTransportREST,
+			wantArkHost:  defaultTestnet3ServerRESTHost,
+			wantSwapHost: defaultTestnet3SwapServerRESTHost,
+		},
+		{
+			name:         "testnet4 grpc",
+			network:      "testnet4",
+			transport:    RPCTransportGRPC,
+			wantArkHost:  defaultTestnet4ServerGRPCHost,
+			wantSwapHost: defaultTestnet4SwapServerGRPCHost,
+		},
+		{
+			name:         "testnet4 rest",
+			network:      "testnet4",
+			transport:    RPCTransportREST,
+			wantArkHost:  defaultTestnet4ServerRESTHost,
+			wantSwapHost: defaultTestnet4SwapServerRESTHost,
+		},
 		{
 			name:         "signet grpc",
 			network:      "signet",
@@ -106,9 +133,9 @@ func TestApplyNetworkEndpointDefaults(t *testing.T) {
 			wantSwapHost: defaultSignetSwapServerRESTHost,
 		},
 		{
-			name:         "regtest",
+			name:         "regtest rest",
 			network:      "regtest",
-			transport:    RPCTransportGRPC,
+			transport:    RPCTransportREST,
 			wantArkHost:  DefaultServerHost,
 			wantSwapHost: defaultSwapServerHost,
 		},
@@ -124,50 +151,28 @@ func TestApplyNetworkEndpointDefaults(t *testing.T) {
 			cfg.Server.Transport = tc.transport
 			cfg.Swap.ServerTransport = tc.transport
 
-			cfg.applyNetworkEndpointDefaults()
-
-			require.Equal(t, tc.wantArkHost, cfg.Server.Host)
+			require.Empty(t, cfg.Server.Host)
+			require.Empty(t, cfg.Swap.ServerAddress)
+			require.Equal(t, tc.wantArkHost, cfg.ArkServerAddress())
 			require.Equal(
-				t, tc.wantSwapHost, cfg.Swap.ServerAddress,
+				t, tc.wantSwapHost, cfg.SwapServerAddress(),
 			)
 		})
 	}
 }
 
-// TestApplyNetworkEndpointDefaultsPreservesOverrides verifies signet does not
-// replace custom endpoints or an explicitly insecure local development setup.
-func TestApplyNetworkEndpointDefaultsPreservesOverrides(t *testing.T) {
+// TestConfigEndpointDefaultsPreserveOverrides verifies an explicit address
+// always wins, including a caller that deliberately points signet at localhost.
+func TestConfigEndpointDefaultsPreserveOverrides(t *testing.T) {
 	t.Parallel()
 
-	t.Run("custom endpoints", func(t *testing.T) {
-		t.Parallel()
+	cfg := DefaultConfig()
+	cfg.Network = "signet"
+	cfg.Server.Host = "localhost:11010"
+	cfg.Swap.ServerAddress = "localhost:11030"
 
-		cfg := DefaultConfig()
-		cfg.Network = "signet"
-		cfg.Server.Host = "ark.example.com:443"
-		cfg.Swap.ServerAddress = "swap.example.com:443"
-
-		cfg.applyNetworkEndpointDefaults()
-
-		require.Equal(t, "ark.example.com:443", cfg.Server.Host)
-		require.Equal(
-			t, "swap.example.com:443", cfg.Swap.ServerAddress,
-		)
-	})
-
-	t.Run("insecure local endpoints", func(t *testing.T) {
-		t.Parallel()
-
-		cfg := DefaultConfig()
-		cfg.Network = "signet"
-		cfg.Server.Insecure = true
-		cfg.Swap.ServerInsecure = true
-
-		cfg.applyNetworkEndpointDefaults()
-
-		require.Equal(t, DefaultServerHost, cfg.Server.Host)
-		require.Equal(t, defaultSwapServerHost, cfg.Swap.ServerAddress)
-	})
+	require.Equal(t, "localhost:11010", cfg.ArkServerAddress())
+	require.Equal(t, "localhost:11030", cfg.SwapServerAddress())
 }
 
 // TestNetworkToChainParams verifies network strings map to their exact btcd

--- a/darepod/config_network_test.go
+++ b/darepod/config_network_test.go
@@ -49,6 +49,17 @@ func TestConfigValidateAcceptsSupportedNetworks(t *testing.T) {
 			cfg.Wallet.EsploraURL = "http://127.0.0.1:3000"
 
 			require.NoError(t, cfg.Validate())
+
+			if tc.name == "signet" {
+				require.Equal(
+					t, defaultSignetServerGRPCHost,
+					cfg.Server.Host,
+				)
+				require.Equal(
+					t, defaultSignetSwapServerGRPCHost,
+					cfg.Swap.ServerAddress,
+				)
+			}
 		})
 	}
 }
@@ -65,6 +76,98 @@ func TestConfigValidateAllowsTestnet4InsecureRPC(t *testing.T) {
 	cfg.RPC.NoMacaroons = true
 
 	require.NoError(t, cfg.Validate())
+}
+
+// TestApplyNetworkEndpointDefaults verifies signet selects the public staging
+// deployment for both outbound transports while every other network keeps the
+// local development endpoints.
+func TestApplyNetworkEndpointDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		network      string
+		transport    string
+		wantArkHost  string
+		wantSwapHost string
+	}{
+		{
+			name:         "signet grpc",
+			network:      "signet",
+			transport:    RPCTransportGRPC,
+			wantArkHost:  defaultSignetServerGRPCHost,
+			wantSwapHost: defaultSignetSwapServerGRPCHost,
+		},
+		{
+			name:         "signet rest",
+			network:      "signet",
+			transport:    RPCTransportREST,
+			wantArkHost:  defaultSignetServerRESTHost,
+			wantSwapHost: defaultSignetSwapServerRESTHost,
+		},
+		{
+			name:         "regtest",
+			network:      "regtest",
+			transport:    RPCTransportGRPC,
+			wantArkHost:  DefaultServerHost,
+			wantSwapHost: defaultSwapServerHost,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := DefaultConfig()
+			cfg.Network = tc.network
+			cfg.Server.Transport = tc.transport
+			cfg.Swap.ServerTransport = tc.transport
+
+			cfg.applyNetworkEndpointDefaults()
+
+			require.Equal(t, tc.wantArkHost, cfg.Server.Host)
+			require.Equal(
+				t, tc.wantSwapHost, cfg.Swap.ServerAddress,
+			)
+		})
+	}
+}
+
+// TestApplyNetworkEndpointDefaultsPreservesOverrides verifies signet does not
+// replace custom endpoints or an explicitly insecure local development setup.
+func TestApplyNetworkEndpointDefaultsPreservesOverrides(t *testing.T) {
+	t.Parallel()
+
+	t.Run("custom endpoints", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultConfig()
+		cfg.Network = "signet"
+		cfg.Server.Host = "ark.example.com:443"
+		cfg.Swap.ServerAddress = "swap.example.com:443"
+
+		cfg.applyNetworkEndpointDefaults()
+
+		require.Equal(t, "ark.example.com:443", cfg.Server.Host)
+		require.Equal(
+			t, "swap.example.com:443", cfg.Swap.ServerAddress,
+		)
+	})
+
+	t.Run("insecure local endpoints", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultConfig()
+		cfg.Network = "signet"
+		cfg.Server.Insecure = true
+		cfg.Swap.ServerInsecure = true
+
+		cfg.applyNetworkEndpointDefaults()
+
+		require.Equal(t, DefaultServerHost, cfg.Server.Host)
+		require.Equal(t, defaultSwapServerHost, cfg.Swap.ServerAddress)
+	})
 }
 
 // TestNetworkToChainParams verifies network strings map to their exact btcd

--- a/darepod/outbound_clients.go
+++ b/darepod/outbound_clients.go
@@ -49,7 +49,10 @@ func (s *Server) connectOperatorClients() (*operatorClients, error) {
 		}
 
 		transport := restclient.New(
-			operatorRESTBaseURL(s.cfg.Server), opts...,
+			operatorRESTBaseURL(
+				s.cfg.Server, s.cfg.ArkServerAddress(),
+			),
+			opts...,
 		)
 
 		return &operatorClients{
@@ -159,17 +162,17 @@ func cloneDefaultHTTPTransport() *http.Transport {
 }
 
 // operatorRESTBaseURL returns the base URL used for grpc-gateway calls.
-func operatorRESTBaseURL(cfg *ServerConfig) string {
-	if strings.HasPrefix(cfg.Host, "http://") ||
-		strings.HasPrefix(cfg.Host, "https://") {
-		return cfg.Host
+func operatorRESTBaseURL(cfg *ServerConfig, addr string) string {
+	if strings.HasPrefix(addr, "http://") ||
+		strings.HasPrefix(addr, "https://") {
+		return addr
 	}
 
 	if cfg.Insecure {
-		return "http://" + cfg.Host
+		return "http://" + addr
 	}
 
-	return "https://" + cfg.Host
+	return "https://" + addr
 }
 
 // operatorArkClient returns the configured ArkService client, preserving the

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -2653,7 +2653,7 @@ func (s *Server) dialServer() (*grpc.ClientConn, error) {
 		dialOpts = append(dialOpts, macaroonOpt)
 	}
 
-	return grpc.NewClient(s.cfg.Server.Host, dialOpts...)
+	return grpc.NewClient(s.cfg.ArkServerAddress(), dialOpts...)
 }
 
 // newMailboxEdge creates a MailboxServiceClient from the established server
@@ -3647,7 +3647,8 @@ func (s *Server) connectAndBootstrapMailbox(ctx context.Context) error {
 
 	// Connect to the ark operator's mailbox edge server.
 	s.log.InfoS(ctx, "Connecting to ark server",
-		"host", s.cfg.Server.Host)
+		"host", s.cfg.ArkServerAddress(),
+	)
 
 	operatorClients, err := s.connectOperatorClients()
 	if err != nil {

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -112,7 +112,7 @@ darepod \
 | `--lnd.tlspath` | | Path to lnd TLS certificate |
 | `--lnd.macaroonpath` | | Path to lnd admin macaroon |
 | `--lnd.rpctimeout` | `30s` | Timeout for lnd RPC calls |
-| `--server.host` | `localhost:10010`; signet: `arkd-signet.staging.lightningcluster.com:443` | Ark operator address for the selected transport |
+| `--server.host` | network default | Ark operator address override for the selected transport |
 | `--server.transport` | `grpc` | Ark operator transport: `grpc` or `rest` |
 | `--server.insecure` | `false` | Disable TLS for server connection |
 | `--server.tlscertpath` | | Operator TLS certificate path |
@@ -121,12 +121,12 @@ darepod \
 | `--rpc.listenaddr` | `localhost:10029` | Daemon gRPC listen address |
 | `--rpc.tlscertpath` | | Custom TLS cert for daemon RPC |
 | `--rpc.tlskeypath` | | Custom TLS key for daemon RPC |
-| `--swap.serveraddress` | `localhost:10030`; signet: `swapd-signet.staging.lightningcluster.com:443` | Swap server address for swapruntime builds |
+| `--swap.serveraddress` | network default | Swap server address override for swapruntime builds |
 | `--swap.servertransport` | `grpc` | Swap server transport: `grpc` or `rest` |
 
-When either transport is `rest`, signet resolves the matching HTTPS gateway
-instead of the gRPC endpoint. See [signet.md](signet.md) for the four public
-endpoints and override examples.
+Empty Ark and swap addresses resolve from the selected network and transport.
+See [signet.md](signet.md) for the testnet3, testnet4, and signet endpoints and
+override examples.
 
 ### Environment Variables
 

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -112,7 +112,8 @@ darepod \
 | `--lnd.tlspath` | | Path to lnd TLS certificate |
 | `--lnd.macaroonpath` | | Path to lnd admin macaroon |
 | `--lnd.rpctimeout` | `30s` | Timeout for lnd RPC calls |
-| `--server.host` | `localhost:10010` | Ark operator mailbox address |
+| `--server.host` | `localhost:10010`; signet: `arkd-signet.staging.lightningcluster.com:443` | Ark operator address for the selected transport |
+| `--server.transport` | `grpc` | Ark operator transport: `grpc` or `rest` |
 | `--server.insecure` | `false` | Disable TLS for server connection |
 | `--server.tlscertpath` | | Operator TLS certificate path |
 | `--server.localmailboxid` | | This client's mailbox ID |
@@ -120,6 +121,12 @@ darepod \
 | `--rpc.listenaddr` | `localhost:10029` | Daemon gRPC listen address |
 | `--rpc.tlscertpath` | | Custom TLS cert for daemon RPC |
 | `--rpc.tlskeypath` | | Custom TLS key for daemon RPC |
+| `--swap.serveraddress` | `localhost:10030`; signet: `swapd-signet.staging.lightningcluster.com:443` | Swap server address for swapruntime builds |
+| `--swap.servertransport` | `grpc` | Swap server transport: `grpc` or `rest` |
+
+When either transport is `rest`, signet resolves the matching HTTPS gateway
+instead of the gRPC endpoint. See [signet.md](signet.md) for the four public
+endpoints and override examples.
 
 ### Environment Variables
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ into specific topics below.
 | Document | Description |
 |----------|-------------|
 | [daemon_cli_guide.md](daemon_cli_guide.md) | darepod/darepocli installation, configuration, CLI reference |
-| [signet.md](signet.md) | Public signet Ark and swap endpoints, gRPC/REST selection, and local overrides |
+| [signet.md](signet.md) | Public testnet3, testnet4, and signet Ark/swap endpoints, transport selection, and local overrides |
 | [accounting_report.md](accounting_report.md) | Accounting report command: reading the fee ledger from SQLite or Postgres, text/JSON/CSV output, fiat conversion, read-only behavior |
 
 ## Plans

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,7 @@ into specific topics below.
 | Document | Description |
 |----------|-------------|
 | [daemon_cli_guide.md](daemon_cli_guide.md) | darepod/darepocli installation, configuration, CLI reference |
+| [signet.md](signet.md) | Public signet Ark and swap endpoints, gRPC/REST selection, and local overrides |
 | [accounting_report.md](accounting_report.md) | Accounting report command: reading the fee ledger from SQLite or Postgres, text/JSON/CSV output, fiat conversion, read-only behavior |
 
 ## Plans

--- a/docs/signet.md
+++ b/docs/signet.md
@@ -1,0 +1,96 @@
+# Signet Endpoints
+
+`darepod` connects to the public staging Ark and swap services when the
+configured Bitcoin network is `signet`. The default outbound transport is
+gRPC, so a signet config with no server overrides resolves to:
+
+| Service | Transport | Endpoint |
+|---------|-----------|----------|
+| Ark operator | gRPC | `arkd-signet.staging.lightningcluster.com:443` |
+| Swap server | gRPC | `swapd-signet.staging.lightningcluster.com:443` |
+
+Both endpoints use publicly trusted TLS certificates. Leave
+`server.insecure` and `swap.serverinsecure` disabled, and leave the custom TLS
+certificate paths empty so the clients use the system certificate pool.
+
+The wallet backend still needs its own signet chain source. As an example, an
+`lwwallet` deployment can start with an operator-provided signet Esplora URL:
+
+```bash
+darepod \
+  --network=signet \
+  --wallet.type=lwwallet \
+  --wallet.esploraurl=https://your-signet-esplora.example/api
+```
+
+The swap endpoint is consumed only by builds that include `swapruntime`.
+
+## REST Transport
+
+Set both transport selectors to `rest` when the host cannot use native gRPC:
+
+```bash
+darepod \
+  --network=signet \
+  --server.transport=rest \
+  --swap.servertransport=rest \
+  --wallet.type=lwwallet \
+  --wallet.esploraurl=https://your-signet-esplora.example/api
+```
+
+The resolved HTTPS gateways are:
+
+| Service | Endpoint |
+|---------|----------|
+| Ark operator | `https://arkd-signet-rest.staging.lightningcluster.com` |
+| Swap server | `https://swapd-signet-rest.staging.lightningcluster.com` |
+
+The same Ark gateway carries both `ArkService` and `MailboxService`. The swap
+gateway carries the swap RPC surface used by the daemon-owned swap runtime.
+
+## Custom Deployments
+
+Custom endpoint values take precedence over the public signet defaults:
+
+```bash
+darepod \
+  --network=signet \
+  --server.host=ark.example.com:443 \
+  --swap.serveraddress=swap.example.com:443 \
+  --wallet.type=lwwallet \
+  --wallet.esploraurl=https://your-signet-esplora.example/api
+```
+
+For a local signet development stack, keep the local endpoint defaults and
+enable the two insecure flags:
+
+```bash
+darepod \
+  --network=signet \
+  --server.insecure \
+  --swap.serverinsecure \
+  --wallet.type=lwwallet \
+  --wallet.esploraurl=http://localhost:3000
+```
+
+The insecure flags are an explicit local-development signal, so the daemon
+keeps `localhost:10010` and `localhost:10030` instead of replacing them with
+the public staging endpoints.
+
+## walletdk
+
+The embedded Go SDK uses the same network-aware defaults. Set the network and
+wallet chain source, but leave the Ark and swap address fields untouched:
+
+```go
+cfg := walletdk.DefaultConfig()
+cfg.Network = "signet"
+cfg.WalletType = "lwwallet"
+cfg.WalletEsploraURL = "https://your-signet-esplora.example/api"
+
+client, err := walletdk.Start(ctx, cfg)
+```
+
+`walletdk.Start` resolves the gRPC staging endpoints while it validates the
+embedded daemon config. Set `ServerTransport` and `SwapServerTransport` to
+`walletdk.TransportREST` to select the two HTTPS gateways instead.

--- a/docs/signet.md
+++ b/docs/signet.md
@@ -1,33 +1,17 @@
-# Signet Endpoints
+# Public Test Network Endpoints
 
-`darepod` connects to the public staging Ark and swap services when the
-configured Bitcoin network is `signet`. The default outbound transport is
-gRPC, so a signet config with no server overrides resolves to:
+`darepod` has built-in Ark and swap service endpoints for testnet3, testnet4,
+and signet. Leave `server.host` and `swap.serveraddress` empty to select the
+endpoint for the configured Bitcoin network and outbound transport.
 
-| Service | Transport | Endpoint |
-|---------|-----------|----------|
-| Ark operator | gRPC | `arkd-signet.staging.lightningcluster.com:443` |
-| Swap server | gRPC | `swapd-signet.staging.lightningcluster.com:443` |
+| Network config | Ark gRPC | Ark REST | Swap gRPC | Swap REST |
+|----------------|----------|----------|-----------|-----------|
+| `testnet` | `arkd.testnet.lightningcluster.com:443` | `https://arkd-rest.testnet.lightningcluster.com` | `swapd.testnet.lightningcluster.com:443` | `https://swapd-rest.testnet.lightningcluster.com` |
+| `testnet4` | `arkd-testnet4.testnet.lightningcluster.com:443` | `https://arkd-testnet4-rest.testnet.lightningcluster.com` | `swapd-testnet4.testnet.lightningcluster.com:443` | `https://swapd-testnet4-rest.testnet.lightningcluster.com` |
+| `signet` | `arkd-signet.staging.lightningcluster.com:443` | `https://arkd-signet-rest.staging.lightningcluster.com` | `swapd-signet.staging.lightningcluster.com:443` | `https://swapd-signet-rest.staging.lightningcluster.com` |
 
-Both endpoints use publicly trusted TLS certificates. Leave
-`server.insecure` and `swap.serverinsecure` disabled, and leave the custom TLS
-certificate paths empty so the clients use the system certificate pool.
-
-The wallet backend still needs its own signet chain source. As an example, an
-`lwwallet` deployment can start with an operator-provided signet Esplora URL:
-
-```bash
-darepod \
-  --network=signet \
-  --wallet.type=lwwallet \
-  --wallet.esploraurl=https://your-signet-esplora.example/api
-```
-
-The swap endpoint is consumed only by builds that include `swapruntime`.
-
-## REST Transport
-
-Set both transport selectors to `rest` when the host cannot use native gRPC:
+The daemon defaults both outbound transports to gRPC. Set the selectors to
+`rest` when the host cannot use native gRPC:
 
 ```bash
 darepod \
@@ -38,49 +22,48 @@ darepod \
   --wallet.esploraurl=https://your-signet-esplora.example/api
 ```
 
-The resolved HTTPS gateways are:
+All public endpoints use publicly trusted TLS certificates. Leave
+`server.insecure` and `swap.serverinsecure` disabled, and leave the custom TLS
+certificate paths empty so the clients use the system certificate pool. The
+swap endpoint is consumed only by builds that include `swapruntime`.
 
-| Service | Endpoint |
-|---------|----------|
-| Ark operator | `https://arkd-signet-rest.staging.lightningcluster.com` |
-| Swap server | `https://swapd-signet-rest.staging.lightningcluster.com` |
+The testnet4 REST gateways are live. The testnet4 gRPC hostnames are already
+the deployment names, but their public NLBs remain disabled until the
+certificate work in
+[lightning-infra#3517](https://github.com/lightninglabs/lightning-infra/pull/3517)
+lands.
 
-The same Ark gateway carries both `ArkService` and `MailboxService`. The swap
-gateway carries the swap RPC surface used by the daemon-owned swap runtime.
+## Config Resolution
 
-## Custom Deployments
+`darepod.DefaultConfig()` leaves the two explicit address fields empty. The
+config accessors resolve the effective values without mutating those fields:
 
-Custom endpoint values take precedence over the public signet defaults:
+- `Config.ArkServerAddress()` selects from `network`, `server.transport`, and
+  `server.host`.
+- `Config.SwapServerAddress()` selects from `network`,
+  `swap.servertransport`, and `swap.serveraddress`.
 
-```bash
-darepod \
-  --network=signet \
-  --server.host=ark.example.com:443 \
-  --swap.serveraddress=swap.example.com:443 \
-  --wallet.type=lwwallet \
-  --wallet.esploraurl=https://your-signet-esplora.example/api
-```
-
-For a local signet development stack, keep the local endpoint defaults and
-enable the two insecure flags:
+An explicit address always wins. This includes local test-network stacks:
 
 ```bash
 darepod \
   --network=signet \
+  --server.host=localhost:10010 \
   --server.insecure \
+  --swap.serveraddress=localhost:10030 \
   --swap.serverinsecure \
   --wallet.type=lwwallet \
   --wallet.esploraurl=http://localhost:3000
 ```
 
-The insecure flags are an explicit local-development signal, so the daemon
-keeps `localhost:10010` and `localhost:10030` instead of replacing them with
-the public staging endpoints.
+Mainnet, regtest, and simnet have no public service deployment in the default
+table, so empty address fields resolve to `localhost:10010` and
+`localhost:10030`.
 
 ## walletdk
 
-The embedded Go SDK uses the same network-aware defaults. Set the network and
-wallet chain source, but leave the Ark and swap address fields untouched:
+The embedded Go SDK uses the same config-level lookup. Set the network and
+wallet chain source, but leave the Ark and swap address fields empty:
 
 ```go
 cfg := walletdk.DefaultConfig()
@@ -91,6 +74,5 @@ cfg.WalletEsploraURL = "https://your-signet-esplora.example/api"
 client, err := walletdk.Start(ctx, cfg)
 ```
 
-`walletdk.Start` resolves the gRPC staging endpoints while it validates the
-embedded daemon config. Set `ServerTransport` and `SwapServerTransport` to
+Set `ServerTransport` and `SwapServerTransport` to
 `walletdk.TransportREST` to select the two HTTPS gateways instead.

--- a/docs/walletdk_integration.md
+++ b/docs/walletdk_integration.md
@@ -20,6 +20,13 @@ Without those tags, `Start` fails with `walletdk.ErrWalletRPCUnavailable`.
 
 ## Runtime Flow
 
+`walletdk.DefaultConfig()` leaves `ServerAddress` and `SwapServerAddress`
+empty. `Start` treats an empty value as "no explicit override", then resolves
+the effective endpoint from `Network` and the matching transport through the
+embedded `darepod` config. Host apps that need to display or forward a concrete
+address should set it explicitly. See [signet.md](signet.md) for the built-in
+testnet3, testnet4, and signet endpoints.
+
 1. Build a `walletdk.Config`.
 2. Start the embedded daemon with `walletdk.Start`, or connect to an external
    daemon with `walletdk.Connect`.

--- a/docs/walletdk_mobile.md
+++ b/docs/walletdk_mobile.md
@@ -97,6 +97,10 @@ same enable-only / non-empty overlay semantics (the zero value defers to the
 `walletdkrpc` build defaults). An empty string boots from
 `walletdk.DefaultConfig`.
 
+Empty `server_address` and `swap_server_address` values select the endpoint
+for the configured network and transport. They don't disable either service.
+Set the fields explicitly when a mobile host needs a custom or local endpoint.
+
 ```json
 {
   "data_dir": "/data/user/0/<app>/files/walletdk",

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -96,9 +96,9 @@
 # Maximum duration for individual RPC calls to lnd.
 # lnd.rpctimeout=30s
 
-# Ark operator server address. The untouched local default resolves to the
-# public staging Ark endpoint when network=signet; see docs/signet.md.
-# server.host=localhost:10010
+# Ark operator server address. Empty uses the network+transport default; see
+# docs/signet.md for the public test-network endpoints.
+# server.host=
 
 # Ark operator RPC transport: grpc or rest.
 # server.transport=grpc
@@ -200,10 +200,9 @@
 # Maximum unroll fee rate in sat/vB. The zero value uses the unroll default.
 # unroll.maxfeeratesatpervbyte=0
 
-# Swap server address for swapruntime builds. The untouched local default
-# resolves to the public staging swap endpoint when network=signet; see
-# docs/signet.md.
-# swap.serveraddress=localhost:10030
+# Swap server address for swapruntime builds. Empty uses the network+transport
+# default; see docs/signet.md for the public test-network endpoints.
+# swap.serveraddress=
 
 # Swap server RPC transport for swapruntime builds: grpc or rest.
 # swap.servertransport=grpc

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -96,7 +96,8 @@
 # Maximum duration for individual RPC calls to lnd.
 # lnd.rpctimeout=30s
 
-# Ark operator mailbox server address.
+# Ark operator server address. The untouched local default resolves to the
+# public staging Ark endpoint when network=signet; see docs/signet.md.
 # server.host=localhost:10010
 
 # Ark operator RPC transport: grpc or rest.
@@ -199,7 +200,9 @@
 # Maximum unroll fee rate in sat/vB. The zero value uses the unroll default.
 # unroll.maxfeeratesatpervbyte=0
 
-# Swap server gRPC address for swapruntime builds.
+# Swap server address for swapruntime builds. The untouched local default
+# resolves to the public staging swap endpoint when network=signet; see
+# docs/signet.md.
 # swap.serveraddress=localhost:10030
 
 # Swap server RPC transport for swapruntime builds: grpc or rest.

--- a/sdk/walletdk/embedded_config.go
+++ b/sdk/walletdk/embedded_config.go
@@ -31,7 +31,8 @@ type Config struct {
 	// a caller-owned config needs an explicit false value.
 	AllowMainnet bool
 
-	// ServerAddress is the Ark operator mailbox edge server address.
+	// ServerAddress is the Ark operator mailbox edge server address. Empty
+	// selects the daemon network+transport default.
 	ServerAddress string
 
 	// ServerTransport selects how the embedded daemon talks to the Ark
@@ -74,7 +75,7 @@ type Config struct {
 	WalletBtcwalletFilterHeadersSource string
 
 	// SwapServerAddress is the swapdk-server address for the selected
-	// transport.
+	// transport. Empty selects the daemon network+transport default.
 	SwapServerAddress string
 
 	// SwapServerTransport selects how the embedded daemon talks to

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -393,10 +393,12 @@ func newSwapClientService(ctx context.Context, rpcServer *darepod.RPCServer,
 			"resolver: %w", err)
 	}
 
-	swapAddr := cfg.ServerAddress
-	if swapAddr == "" {
-		swapAddr = "localhost:10030"
-	}
+	// Resolve through a shallow config copy so the nil-Swap fallback above
+	// participates in the same network+transport lookup without mutating
+	// the caller-owned daemon config.
+	resolvedCfg := *daemonCfg
+	resolvedCfg.Swap = cfg
+	swapAddr := resolvedCfg.SwapServerAddress()
 
 	var clientCerts clientTLSCertProvider
 	if !cfg.ServerInsecure {


### PR DESCRIPTION
In this PR, we move the default Ark and swap endpoint selection into the config layer. Empty address fields now resolve from the selected network+transport pair, while explicit addresses continue to win and config validation remains side effect free.

Testnet3, testnet4, and signet select their public Lightning Labs gRPC or REST deployments. Mainnet, regtest, and simnet keep the historical localhost endpoints. The signet addresses follow the deployment work in [lightning-infra#3509](https://github.com/lightninglabs/lightning-infra/pull/3509). The testnet4 names match the pending rollout in [lightning-infra#3517](https://github.com/lightninglabs/lightning-infra/pull/3517), so the defaults are ready once its public gRPC listeners come online.

See each commit message for a detailed description w.r.t the incremental changes.

## Validation

- `go test ./darepod ./sdk/walletdk -count=1`
- `go test -tags "swapruntime walletdkrpc" ./swapclientserver ./sdk/walletdk -count=1`
- `make lint-changed-local`
- `make fmt-changed-check`
- `make sample-conf-check`
- `make commitmsg-lint range="origin/main..HEAD"`

`make doc-check` still reports the six pre-existing documentation graph failures: four diverged `CLAUDE.md`/`AGENTS.md` pairs and two unrelated docs missing from `docs/index.md`.