### PR TITLE
multi: Bound credit awaiting polls to fail fast

### DIFF
--- a/credit/config.go
+++ b/credit/config.go
@@ -377,4 +377,24 @@ const (
 	// DefaultAdmitTimeout bounds the synchronous server work an admission
 	// performs on the supervisor goroutine.
 	DefaultAdmitTimeout = 30 * time.Second
+
+	// DefaultMaxAwaitingPolls bounds how many reconciliation polls a single
+	// awaiting state (top-up funding or credit-pay settlement) may take
+	// before the operation terminal-fails. It is the production backstop
+	// against a credit-backed send parking forever when the server never
+	// reports a terminal state for the top-up or the pay — the hang behind
+	// darepo-client#880, where a confirmed credit-shortfall send never
+	// completes and never fails.
+	//
+	// At DefaultPollInterval (2s) this is ~4 minutes of awaiting per state:
+	// generous enough to absorb a slow OOR top-up credit or real-Lightning
+	// settlement, yet deliberately under the CLI's 5-minute default send
+	// wait (cmd/darepocli defaultSendWaitTimeout) so a stuck operation's
+	// clear terminal failure reason usually surfaces before the CLI falls
+	// back to a generic wait timeout. Zero (the OpActorConfig /
+	// RegistryConfig field default) still means "unlimited" for tests and
+	// embedders that rely on server-reported terminal states; production
+	// wiring coerces zero to this cap so the fail-fast bound is never
+	// silently disabled.
+	DefaultMaxAwaitingPolls uint32 = 120
 )

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -653,6 +653,30 @@ type CreditConfig struct {
 	// settled receive triggers a redeem. Zero defaults to the operator dust
 	// limit, the smallest amount that can legally become a vTXO.
 	AutoRedeemMinSat uint64 `mapstructure:"autoredeemminsat"`
+
+	// MaxAwaitingPolls caps how many reconciliation polls a single
+	// credit-operation awaiting state (top-up funding or credit-pay
+	// settlement) may take before the operation terminal-fails. It is the
+	// backstop that stops a credit-backed send from parking forever when
+	// the server never reports a terminal state (darepo-client#880). Zero
+	// applies credit.DefaultMaxAwaitingPolls: the fail-fast bound cannot be
+	// disabled from config because an unbounded wait is the hang this
+	// guards against; operators who need a longer ceiling set an explicit
+	// larger value.
+	MaxAwaitingPolls uint32 `mapstructure:"maxawaitingpolls"`
+}
+
+// MaxAwaitingPollsOrDefault resolves the awaiting-state poll cap the credit
+// registry runs with. A zero value (the default) is coerced to
+// credit.DefaultMaxAwaitingPolls so the production daemon never runs with the
+// unbounded wait that lets a credit-backed send hang forever
+// (darepo-client#880); a non-zero value is an explicit operator override.
+func (c CreditConfig) MaxAwaitingPollsOrDefault() uint32 {
+	if c.MaxAwaitingPolls == 0 {
+		return credit.DefaultMaxAwaitingPolls
+	}
+
+	return c.MaxAwaitingPolls
 }
 
 // SwapVHTLCRecoveryConfig controls automatic escalation from cooperative vHTLC

--- a/darepod/credit_registry.go
+++ b/darepod/credit_registry.go
@@ -64,6 +64,11 @@ func (s *Server) initCreditRegistry(ctx context.Context) error {
 		TimeoutActor:  creditTimeoutRef,
 		CallbackRef:   callbackRef,
 		ActorSystem:   s.actorSystem,
+
+		// Bound the awaiting states so a stuck credit-backed send fails
+		// fast rather than parking forever (darepo-client#880); see
+		// MaxAwaitingPollsOrDefault for the zero-coercion rationale.
+		MaxAwaitingPolls: s.cfg.Swap.Credit.MaxAwaitingPollsOrDefault(),
 		AutoRedeem: credit.AutoRedeemConfig{
 			Enabled:      !s.cfg.Swap.Credit.AutoRedeemDisabled,
 			MinRedeemSat: s.cfg.Swap.Credit.AutoRedeemMinSat,

--- a/darepod/credit_registry_test.go
+++ b/darepod/credit_registry_test.go
@@ -1,0 +1,52 @@
+package darepod
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/darepo-client/credit"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreditMaxAwaitingPollsCoercesZero asserts the production credit registry
+// never runs with the unbounded awaiting wait that lets a credit-backed send
+// hang forever (darepo-client#880): an unset (zero) config value is coerced to
+// the fail-fast default, while an explicit value passes through as an operator
+// override.
+func TestCreditMaxAwaitingPollsCoercesZero(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		cfg  CreditConfig
+		want uint32
+	}{
+		{
+			name: "zero coerces to fail-fast default",
+			cfg: CreditConfig{
+				MaxAwaitingPolls: 0,
+			},
+			want: credit.DefaultMaxAwaitingPolls,
+		},
+		{
+			name: "explicit override passes through",
+			cfg: CreditConfig{
+				MaxAwaitingPolls: 42,
+			},
+			want: 42,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(
+				t, tc.want, tc.cfg.MaxAwaitingPollsOrDefault(),
+			)
+		})
+	}
+
+	// The default must be a bounded, positive cap: a zero default would
+	// silently re-introduce the unbounded hang this guard exists to close.
+	require.Positive(t, credit.DefaultMaxAwaitingPolls)
+}

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -244,6 +244,14 @@
 # auto-redeem back into a vTXO. Zero uses the operator dust limit.
 # swap.credit.autoredeemminsat=0
 
+# Maximum reconciliation polls a single credit-operation awaiting state (top-up
+# funding or credit-pay settlement) may take before the operation terminal-fails
+# with a clear error. This is the backstop that stops a credit-backed send from
+# hanging forever when the server never reports a terminal state. Zero uses the
+# built-in fail-fast default; set a larger value only if you need a longer
+# ceiling (the bound cannot be disabled).
+# swap.credit.maxawaitingpolls=0
+
 # Wallet-level deadline applied to every PENDING walletdkrpc entry. Once an
 # entry sits past this duration without a terminal transition, the runtime
 # overlays its status as FAILED with failure_reason="timed_out". Zero uses


### PR DESCRIPTION
## Problem

Fixes #880. `darepocli send --offchain` on a **credit-shortfall** invoice (the CLI warns e.g. `Warning: credit shortfall requires 546 sat top-up`) lets the user confirm, then hangs indefinitely — with no error and the payment never made.

## Root cause

A credit-backed send routes through the durable credit subsystem (`swapwallet/router.go` → `sendCreditInvoiceIntent` → `credit.Registry`). The per-operation FSM performs the Ark top-up then the pay, parking in awaiting states (`topupAwaitingCredit`, `payAwaitingSettlement`) that poll the server until it reports a terminal state.

The FSM already has a fail-fast valve — `MaxAwaitingPolls` → `awaitExhausted()` → `b.fail(...)`, covered by `credit.TestAwaitingPollCapFailsOp`. **But the production daemon wiring (`darepod/credit_registry.go`) never set `MaxAwaitingPolls`, so it defaulted to `0` = unlimited**, disabling the cap in production. When the top-up funding or the credit pay never converges server-side, the op polls forever, the wallet entry stays `PENDING` forever, and the CLI hangs.

## Fix

Wire a bounded default into the credit registry:

- `credit.DefaultMaxAwaitingPolls = 120` (~4 min per awaiting state at the 2s poll interval, deliberately under the CLI's 5-min `defaultSendWaitTimeout` so the clear failure reason surfaces first). Documented rationale in-comment.
- New configurable `CreditConfig.MaxAwaitingPolls` daemon knob (`credit.maxawaitingpolls`); `darepod` coerces `0` → the default so production can never run unbounded. The library keeps its `0 = unlimited` contract for tests/embedders.

A stuck credit-shortfall send now **terminal-fails** with a clear reason (`"top-up credit not finalized within poll cap"` / `"credit pay not settled within poll cap"`); the projector flips the same payment-hash-keyed entry to `FAILED`, and the CLI surfaces `SEND_FAILED` instead of hanging.

## Testing

- `go build` (credit + darepod, `swapruntime,walletdkrpc`), `go vet`, `make lint-changed-local` (0 issues), `make fmt-changed` — clean.
- `go test ./credit/` and the new `darepod` wiring test pass.
- Note: `arktest` cannot reproduce this path — its topology has no swap-server/credit/Lightning-invoice wiring — so verification rests on the static analysis plus the FSM-level (`TestAwaitingPollCapFailsOp`) and wiring-level unit tests.

## Known adjacent limitation

For a *mixed* credit+Lightning pay (`creditOnly=false`), the projector deliberately skips the row (the swap monitor owns it). If a mixed pay's top-up stalls, the op now fails but the entry isn't flipped by the projector, so the CLI bounds at its 5-min wait rather than showing the credit reason. The reported case is credit-only (shortfall covers the full amount → `creditOnly=true`) and is fully resolved.