### PR TITLE
multi: fail a cooperative send when the operator can't fund the round

### DIFF
--- a/db/migrations.go
+++ b/db/migrations.go
@@ -10,7 +10,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion uint = 10
+	LatestMigrationVersion uint = 11
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -224,6 +224,15 @@ type RoundStore interface {
 	// intents vanish in the same transaction.
 	DeleteOrphanedPendingIntents(ctx context.Context) error
 
+	// MarkPendingSendIntentFailedByOutpoint terminally fails the pending
+	// send intent anchored to one outpoint, recording the reason and typed
+	// code. Called from FailForfeitIntents when a round fails terminally so
+	// the intent stops replaying and its activity entry can surface as
+	// failed. Anchors are retained so the failed job stays correlatable by
+	// its consumed outpoint.
+	MarkPendingSendIntentFailedByOutpoint(ctx context.Context,
+		arg sqlc.MarkPendingSendIntentFailedByOutpointParams) error
+
 	ListRoundsPaginated(ctx context.Context,
 		arg ListRoundsPaginatedParams) ([]RoundRow, error)
 
@@ -475,17 +484,35 @@ func (s *RoundPersistenceStore) CommitState(ctx context.Context, r *round.Round,
 func clearForfeitIntentAnchors(ctx context.Context, q RoundStore,
 	r *round.Round) error {
 
+	outpoints := make([]wire.OutPoint, 0, len(r.Intents.Forfeits))
 	for _, forfeit := range r.Intents.Forfeits {
 		if forfeit.VTXOOutpoint == nil {
 			continue
 		}
 
+		outpoints = append(outpoints, *forfeit.VTXOOutpoint)
+	}
+
+	return clearForfeitIntentAnchorsByOutpoints(ctx, q, outpoints)
+}
+
+// clearForfeitIntentAnchorsByOutpoints clears the pending-intent anchors bound
+// to the given forfeited VTXO outpoints, then sweeps any pending intent left
+// without anchors. It backs the success path (clearForfeitIntentAnchors, from
+// CommitState): once a round adopts the reserved forfeit set, the originating
+// job's outbox row must go, or a restart would replay an already-adopted send.
+// The terminal-failure path deliberately does not use this helper; it marks the
+// intent 'failed' and keeps the anchors (see FailForfeitIntents) so the record
+// stays a durable, correlatable entry rather than being deleted. Per-kind
+// detail rows foreign-key the header, so they are swept before the headers.
+func clearForfeitIntentAnchorsByOutpoints(ctx context.Context, q RoundStore,
+	outpoints []wire.OutPoint) error {
+
+	for _, op := range outpoints {
 		err := q.ClearPendingIntentAnchorByOutpoint(
 			ctx, ClearAnchorParams{
-				OutpointHash: forfeit.VTXOOutpoint.Hash[:],
-				OutpointIndex: int32(
-					forfeit.VTXOOutpoint.Index,
-				),
+				OutpointHash:  op.Hash[:],
+				OutpointIndex: int32(op.Index),
 			},
 		)
 		if err != nil {
@@ -504,6 +531,60 @@ func clearForfeitIntentAnchors(ctx context.Context, q RoundStore,
 
 	if err := q.DeleteOrphanedPendingIntents(ctx); err != nil {
 		return fmt.Errorf("sweep orphaned pending intents: %w", err)
+	}
+
+	return nil
+}
+
+// FailForfeitIntents terminally fails the pending send intents anchored to the
+// given forfeited VTXO outpoints, recording the reason and typed failure code,
+// all in one write transaction. It is the terminal-failure counterpart to the
+// anchor clear CommitState performs on the success path: when a round fails
+// terminally (e.g. the operator cannot fund the commitment tx) the originating
+// job must not keep replaying into the same wall. Marking (rather than
+// deleting) the intent both stops the replay — ListPendingSendIntents skips
+// non-pending rows — and leaves a durable, anchor-correlatable record the
+// activity projection surfaces as failed with the reason. It is a no-op for an
+// empty outpoint set.
+func (s *RoundPersistenceStore) FailForfeitIntents(ctx context.Context,
+	outpoints []wire.OutPoint, reason string,
+	code round.RoundFailureCode) error {
+
+	if len(outpoints) == 0 {
+		return nil
+	}
+
+	failureReason := sql.NullString{String: reason, Valid: reason != ""}
+
+	writeTxOpts := WriteTxOption()
+
+	return s.db.ExecTx(ctx, writeTxOpts, func(q RoundStore) error {
+		return markSendIntentsFailedByOutpoint(
+			ctx, q, outpoints, failureReason, int32(code),
+		)
+	})
+}
+
+// markSendIntentsFailedByOutpoint marks the pending send intent anchored to
+// each outpoint as failed, recording the shared reason and code. Extracted from
+// FailForfeitIntents' write-tx closure so the generated method call sits at a
+// shallow enough indentation to read.
+func markSendIntentsFailedByOutpoint(ctx context.Context, q RoundStore,
+	outpoints []wire.OutPoint, reason sql.NullString, code int32) error {
+
+	for _, op := range outpoints {
+		params := sqlc.MarkPendingSendIntentFailedByOutpointParams{
+			OutpointHash:  op.Hash[:],
+			OutpointIndex: int32(op.Index),
+			FailureReason: reason,
+			FailureCode:   code,
+		}
+
+		err := q.MarkPendingSendIntentFailedByOutpoint(ctx, params)
+		if err != nil {
+			return fmt.Errorf("mark pending send intent failed "+
+				"for forfeited vtxo: %w", err)
+		}
 	}
 
 	return nil

--- a/db/round_store_test.go
+++ b/db/round_store_test.go
@@ -1691,3 +1691,332 @@ func TestCommitStateClearsSendIntentAnchors(t *testing.T) {
 		t, []wire.OutPoint{opOther}, remaining[0].Anchors,
 	)
 }
+
+// TestFailForfeitIntentsMarksSendFailed verifies the terminal-failure half of
+// the send-intent lifecycle: FailForfeitIntents marks the send intent anchored
+// to the failed round's forfeit set as failed (recording reason and code) so it
+// is excluded from replay, retains its anchors and header so the record is
+// durable and still correlatable, and leaves an unrelated intent untouched.
+func TestFailForfeitIntentsMarksSendFailed(t *testing.T) {
+	t.Parallel()
+
+	store, baseDB := newRoundStoreForTest(t)
+	ctx := t.Context()
+
+	intentDB := NewTransactionExecutor(
+		baseDB,
+		func(tx *sql.Tx) PendingIntentStore {
+			return baseDB.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+	intentStore := NewPendingIntentPersistenceStore(intentDB)
+
+	opA := wire.OutPoint{Hash: chainhash.Hash{0xb1}, Index: 0}
+	opB := wire.OutPoint{Hash: chainhash.Hash{0xb2}, Index: 1}
+	opOther := wire.OutPoint{Hash: chainhash.Hash{0xb3}, Index: 0}
+
+	failingPayload := &wallet.SendOnChainIntentPayload{
+		DestinationPkScript: append(
+			[]byte{0x51, 0x20}, make([]byte, 32)...,
+		),
+		TargetAmountSat: 30_000,
+	}
+	failing := wallet.PendingIntent{
+		ID: wallet.NewPendingIntentID(
+			failingPayload, []wire.OutPoint{opA, opB},
+		),
+		Payload:     failingPayload,
+		RequestedAt: 1_700_000_000,
+		Anchors: []wire.OutPoint{
+			opA,
+			opB,
+		},
+	}
+	survivorPayload := &wallet.SendOnChainIntentPayload{
+		DestinationPkScript: append(
+			[]byte{0x51, 0x20}, make([]byte, 32)...,
+		),
+		TargetAmountSat: 45_000,
+	}
+	survivor := wallet.PendingIntent{
+		ID: wallet.NewPendingIntentID(
+			survivorPayload, []wire.OutPoint{opOther},
+		),
+		Payload:     survivorPayload,
+		RequestedAt: 1_700_000_001,
+		Anchors: []wire.OutPoint{
+			opOther,
+		},
+	}
+	require.NoError(t, intentStore.UpsertPendingIntent(ctx, failing))
+	require.NoError(t, intentStore.UpsertPendingIntent(ctx, survivor))
+
+	const reason = "build commitment tx: fund psbt: insufficient funds"
+
+	// Fail the send intent anchored to the round's forfeit set.
+	require.NoError(
+		t,
+		store.FailForfeitIntents(
+			ctx, []wire.OutPoint{opA, opB}, reason,
+			round.RoundFailureInsufficientOperatorFunds,
+		),
+	)
+
+	// The failed intent must be excluded from the replay list (it must not
+	// re-submit into the same wall); the survivor still replays.
+	remaining, err := intentStore.ListPendingIntents(
+		ctx, wallet.PendingIntentKindSendOnChain,
+	)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	require.Equal(t, survivor.ID, remaining[0].ID)
+
+	// The failed intent's header is retained (not deleted) with the reason
+	// and typed code, so the failure is a durable, correlatable record.
+	var (
+		status     string
+		failReason sql.NullString
+		failCode   int64
+	)
+	row := baseDB.QueryRowContext(ctx,
+		`SELECT status, failure_reason, failure_code
+		 FROM pending_intents WHERE intent_id = ?`,
+		failing.ID[:],
+	)
+	require.NoError(t, row.Scan(&status, &failReason, &failCode))
+	require.Equal(t, "failed", status)
+	require.True(t, failReason.Valid)
+	require.Equal(t, reason, failReason.String)
+	require.Equal(
+		t, int64(round.RoundFailureInsufficientOperatorFunds), failCode,
+	)
+
+	// The failed intent's anchors are retained so the record stays
+	// correlatable by its consumed outpoints.
+	var anchorCount int
+	require.NoError(t, baseDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pending_intent_anchors `+
+			`WHERE intent_id = ?`,
+		failing.ID[:],
+	).Scan(&anchorCount))
+	require.Equal(t, 2, anchorCount)
+
+	// Idempotent: re-failing the same outpoints is a no-op (status guard).
+	require.NoError(
+		t,
+		store.FailForfeitIntents(
+			ctx, []wire.OutPoint{opA}, "second call",
+			round.RoundFailureUnknown,
+		),
+	)
+	row = baseDB.QueryRowContext(
+		ctx,
+		`SELECT failure_reason FROM pending_intents `+
+			`WHERE intent_id = ?`,
+		failing.ID[:],
+	)
+	require.NoError(t, row.Scan(&failReason))
+	require.Equal(
+		t, reason, failReason.String,
+		"a repeat fail must not overwrite the original reason",
+	)
+}
+
+// TestRepersistFailedSendIntentRearmsReplay verifies that re-persisting a
+// terminally failed send intent re-arms it as pending. NewPendingIntentID is
+// deterministic, so a user retrying the same send (same inputs, same payload)
+// reuses the same intent_id and upserts onto the retained 'failed' row; the
+// upsert must reset the status back to pending so the retry is replayable
+// again. Without the reset, a retry that crashes before the round adopts it
+// would be silently dropped by the pending-only replay filter.
+func TestRepersistFailedSendIntentRearmsReplay(t *testing.T) {
+	t.Parallel()
+
+	store, baseDB := newRoundStoreForTest(t)
+	ctx := t.Context()
+
+	intentDB := NewTransactionExecutor(
+		baseDB,
+		func(tx *sql.Tx) PendingIntentStore {
+			return baseDB.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+	intentStore := NewPendingIntentPersistenceStore(intentDB)
+
+	opA := wire.OutPoint{Hash: chainhash.Hash{0xc1}, Index: 0}
+
+	payload := &wallet.SendOnChainIntentPayload{
+		DestinationPkScript: append(
+			[]byte{0x51, 0x20}, make([]byte, 32)...,
+		),
+		TargetAmountSat: 30_000,
+	}
+	intent := wallet.PendingIntent{
+		ID: wallet.NewPendingIntentID(
+			payload, []wire.OutPoint{opA},
+		),
+		Payload:     payload,
+		RequestedAt: 1_700_000_000,
+		Anchors: []wire.OutPoint{
+			opA,
+		},
+	}
+	require.NoError(t, intentStore.UpsertPendingIntent(ctx, intent))
+
+	// Terminally fail the intent, then confirm it drops out of the replay
+	// list.
+	require.NoError(
+		t,
+		store.FailForfeitIntents(
+			ctx, []wire.OutPoint{opA}, "build commitment tx: "+
+				"insufficient funds",
+			round.RoundFailureInsufficientOperatorFunds,
+		),
+	)
+	remaining, err := intentStore.ListPendingIntents(
+		ctx, wallet.PendingIntentKindSendOnChain,
+	)
+	require.NoError(t, err)
+	require.Empty(t, remaining, "failed intent must not replay")
+
+	// Re-persist the identical intent, as a retry of the same send would.
+	// The deterministic ID collides with the retained failed row, so the
+	// upsert must re-arm it as pending.
+	require.NoError(t, intentStore.UpsertPendingIntent(ctx, intent))
+
+	remaining, err = intentStore.ListPendingIntents(
+		ctx, wallet.PendingIntentKindSendOnChain,
+	)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1, "re-persisted intent must replay again")
+	require.Equal(t, intent.ID, remaining[0].ID)
+
+	// The status and failure fields must be cleared so no stale failure
+	// leaks onto the re-armed record.
+	var (
+		status     string
+		failReason sql.NullString
+		failCode   int64
+	)
+	row := baseDB.QueryRowContext(ctx,
+		`SELECT status, failure_reason, failure_code
+		 FROM pending_intents WHERE intent_id = ?`,
+		intent.ID[:],
+	)
+	require.NoError(t, row.Scan(&status, &failReason, &failCode))
+	require.Equal(t, "pending", status)
+	require.False(t, failReason.Valid, "failure reason must be cleared")
+	require.Equal(t, int64(0), failCode, "failure code must be cleared")
+}
+
+// TestOrphanSweepKeepsFailedSendRecord verifies that the durable failed record
+// survives the orphan sweep even after its consumed coin is reused by a later
+// send. When the released VTXO is respent, persisting the new intent rebinds
+// the shared anchor away from the failed intent, orphaning it, and the sweep
+// that runs on every upsert would delete the header and detail of a plain
+// pending orphan. A 'failed' intent must be spared so its reason and typed code
+// stay a durable, intent_id-correlated record for the activity projection.
+func TestOrphanSweepKeepsFailedSendRecord(t *testing.T) {
+	t.Parallel()
+
+	store, baseDB := newRoundStoreForTest(t)
+	ctx := t.Context()
+
+	intentDB := NewTransactionExecutor(
+		baseDB,
+		func(tx *sql.Tx) PendingIntentStore {
+			return baseDB.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+	intentStore := NewPendingIntentPersistenceStore(intentDB)
+
+	opShared := wire.OutPoint{Hash: chainhash.Hash{0xd1}, Index: 0}
+
+	// A single-anchor send intent, terminally failed. Its lone anchor is
+	// the coin that returns to LIVE and can be respent.
+	failingPayload := &wallet.SendOnChainIntentPayload{
+		DestinationPkScript: append(
+			[]byte{0x51, 0x20}, make([]byte, 32)...,
+		),
+		TargetAmountSat: 30_000,
+	}
+	failing := wallet.PendingIntent{
+		ID: wallet.NewPendingIntentID(
+			failingPayload, []wire.OutPoint{opShared},
+		),
+		Payload:     failingPayload,
+		RequestedAt: 1_700_000_000,
+		Anchors: []wire.OutPoint{
+			opShared,
+		},
+	}
+	require.NoError(t, intentStore.UpsertPendingIntent(ctx, failing))
+
+	const reason = "build commitment tx: insufficient funds"
+	require.NoError(
+		t,
+		store.FailForfeitIntents(
+			ctx, []wire.OutPoint{opShared}, reason,
+			round.RoundFailureInsufficientOperatorFunds,
+		),
+	)
+
+	// A later send reuses the released coin. Its distinct payload yields a
+	// distinct intent_id, so persisting it rebinds the shared anchor away
+	// from the failed intent, orphaning it, then runs the sweep.
+	retryPayload := &wallet.SendOnChainIntentPayload{
+		DestinationPkScript: append(
+			[]byte{0x51, 0x20}, make([]byte, 32)...,
+		),
+		TargetAmountSat: 55_000,
+	}
+	retry := wallet.PendingIntent{
+		ID: wallet.NewPendingIntentID(
+			retryPayload, []wire.OutPoint{opShared},
+		),
+		Payload:     retryPayload,
+		RequestedAt: 1_700_000_100,
+		Anchors: []wire.OutPoint{
+			opShared,
+		},
+	}
+	require.NoError(t, intentStore.UpsertPendingIntent(ctx, retry))
+
+	// The failed record must survive the sweep: both its header (status and
+	// reason) and its send detail are retained.
+	var (
+		status     string
+		failReason sql.NullString
+	)
+	row := baseDB.QueryRowContext(ctx,
+		`SELECT status, failure_reason
+		 FROM pending_intents WHERE intent_id = ?`,
+		failing.ID[:],
+	)
+	require.NoError(t, row.Scan(&status, &failReason))
+	require.Equal(
+		t, "failed", status, "failed header must survive the sweep",
+	)
+	require.Equal(t, reason, failReason.String)
+
+	var detailCount int
+	require.NoError(t, baseDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pending_send_intents WHERE intent_id = ?`,
+		failing.ID[:],
+	).Scan(&detailCount))
+	require.Equal(
+		t, 1, detailCount, "failed send detail must survive the sweep",
+	)
+
+	// The retry is the sole live pending intent; the failed one does not
+	// replay.
+	remaining, err := intentStore.ListPendingIntents(
+		ctx, wallet.PendingIntentKindSendOnChain,
+	)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	require.Equal(t, retry.ID, remaining[0].ID)
+}

--- a/db/sqlc/migrations/000011_pending_intent_status.down.sql
+++ b/db/sqlc/migrations/000011_pending_intent_status.down.sql
@@ -1,0 +1,8 @@
+-- Reverse the pending-intent terminal-failure status columns.
+DROP INDEX IF EXISTS idx_pending_intents_kind_status;
+
+ALTER TABLE pending_intents DROP COLUMN failure_code;
+
+ALTER TABLE pending_intents DROP COLUMN failure_reason;
+
+ALTER TABLE pending_intents DROP COLUMN status;

--- a/db/sqlc/migrations/000011_pending_intent_status.up.sql
+++ b/db/sqlc/migrations/000011_pending_intent_status.up.sql
@@ -1,0 +1,32 @@
+-- Add a terminal-failure status to the pending-intent outbox. Until now a
+-- pending intent had exactly two fates: adopted by a round (row cleared in the
+-- CommitState transaction) or replayed on restart. A round that fails
+-- terminally — e.g. the operator cannot fund the commitment tx — had no way to
+-- record that the originating job is dead, so the intent replayed forever into
+-- the same wall and the user's activity entry stayed pending indefinitely.
+--
+-- A 'failed' status lets the daemon durably retire such an intent: the replayer
+-- skips it (no more replay) and the activity projection surfaces it as FAILED
+-- with the operator-supplied reason instead of leaving it stuck pending. The
+-- columns live on the kind-agnostic header so both Board and SendOnChain
+-- intents share one status vocabulary.
+ALTER TABLE pending_intents
+    ADD COLUMN status TEXT NOT NULL DEFAULT 'pending';
+
+-- failure_reason is the human-readable failure description, surfaced on the
+-- originating job's activity entry. NULL while status = 'pending'.
+ALTER TABLE pending_intents
+    ADD COLUMN failure_reason TEXT;
+
+-- failure_code is the typed round.RoundFailureCode classification (0 =
+-- unknown). Zero while status = 'pending'.
+ALTER TABLE pending_intents
+    ADD COLUMN failure_code INTEGER NOT NULL DEFAULT 0;
+
+-- Successful intents are deleted the moment a round adopts them, while failed
+-- intents are retained indefinitely as durable records, so over time this
+-- outbox accumulates only 'failed' rows. Both replay queries scan on
+-- kind = ? AND status = 'pending', so a composite index keeps the replayer's
+-- startup scan off the growing pile of retained failures.
+CREATE INDEX IF NOT EXISTS idx_pending_intents_kind_status
+    ON pending_intents (kind, status);

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -268,6 +268,9 @@ type PendingIntent struct {
 	IntentID        []byte
 	Kind            string
 	RequestedAtUnix int64
+	Status          string
+	FailureReason   sql.NullString
+	FailureCode     int32
 }
 
 type PendingIntentAnchor struct {

--- a/db/sqlc/pending_intents.sql.go
+++ b/db/sqlc/pending_intents.sql.go
@@ -7,6 +7,7 @@ package sqlc
 
 import (
 	"context"
+	"database/sql"
 )
 
 const ClearPendingIntentAnchorByOutpoint = `-- name: ClearPendingIntentAnchorByOutpoint :exec
@@ -43,8 +44,12 @@ WHERE NOT EXISTS (
     SELECT 1 FROM pending_intent_anchors a
     WHERE a.intent_id = pending_intents.intent_id
 )
+AND status <> 'failed'
 `
 
+// A terminally failed intent is a durable record, not a sweepable orphan:
+// keep its header even once its anchors are reused. Replay already skips it on
+// the status filter, and the activity projection still surfaces it as failed.
 func (q *Queries) DeleteOrphanedPendingIntents(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, DeleteOrphanedPendingIntents)
 	return err
@@ -56,8 +61,17 @@ WHERE NOT EXISTS (
     SELECT 1 FROM pending_intent_anchors a
     WHERE a.intent_id = pending_send_intents.intent_id
 )
+AND NOT EXISTS (
+    SELECT 1 FROM pending_intents i
+    WHERE i.intent_id = pending_send_intents.intent_id
+      AND i.status = 'failed'
+)
 `
 
+// Keep the detail row of a terminally failed send even after its anchors are
+// gone (a released coin got reused by a later send, stealing the anchor). The
+// failed record is durable and correlated by intent_id, so its detail must
+// survive alongside its header for the activity projection to surface it.
 func (q *Queries) DeleteOrphanedPendingSendIntents(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, DeleteOrphanedPendingSendIntents)
 	return err
@@ -149,7 +163,7 @@ SELECT
     b.target_vtxo_count
 FROM pending_intents i
 JOIN pending_board_intents b ON b.intent_id = i.intent_id
-WHERE i.kind = 'board'
+WHERE i.kind = 'board' AND i.status = 'pending'
 ORDER BY i.requested_at_unix ASC, i.intent_id ASC
 `
 
@@ -159,6 +173,8 @@ type ListPendingBoardIntentsRow struct {
 	TargetVtxoCount int32
 }
 
+// Only status = 'pending' rows replay; a 'failed' intent is terminally
+// retired and must not be re-submitted on restart.
 func (q *Queries) ListPendingBoardIntents(ctx context.Context) ([]ListPendingBoardIntentsRow, error) {
 	rows, err := q.db.QueryContext(ctx, ListPendingBoardIntents)
 	if err != nil {
@@ -220,7 +236,7 @@ SELECT
     s.operator_key, s.vtxo_exit_delay, s.dust_limit_sat
 FROM pending_intents i
 JOIN pending_send_intents s ON s.intent_id = i.intent_id
-WHERE i.kind = 'send_onchain'
+WHERE i.kind = 'send_onchain' AND i.status = 'pending'
 ORDER BY i.requested_at_unix ASC, i.intent_id ASC
 `
 
@@ -235,6 +251,8 @@ type ListPendingSendIntentsRow struct {
 	DustLimitSat    int64
 }
 
+// Only status = 'pending' rows replay; a 'failed' intent is terminally
+// retired and must not be re-submitted on restart.
 func (q *Queries) ListPendingSendIntents(ctx context.Context) ([]ListPendingSendIntentsRow, error) {
 	rows, err := q.db.QueryContext(ctx, ListPendingSendIntents)
 	if err != nil {
@@ -265,6 +283,41 @@ func (q *Queries) ListPendingSendIntents(ctx context.Context) ([]ListPendingSend
 		return nil, err
 	}
 	return items, nil
+}
+
+const MarkPendingSendIntentFailedByOutpoint = `-- name: MarkPendingSendIntentFailedByOutpoint :exec
+UPDATE pending_intents
+SET status = 'failed',
+    failure_reason = $3,
+    failure_code = $4
+WHERE kind = 'send_onchain'
+  AND status = 'pending'
+  AND intent_id IN (
+      SELECT a.intent_id FROM pending_intent_anchors a
+      WHERE a.outpoint_hash = $1 AND a.outpoint_index = $2
+  )
+`
+
+type MarkPendingSendIntentFailedByOutpointParams struct {
+	OutpointHash  []byte
+	OutpointIndex int32
+	FailureReason sql.NullString
+	FailureCode   int32
+}
+
+// Terminally fail the pending send intent anchored to the given outpoint,
+// recording the reason and typed failure code. Idempotent: the status guard
+// makes a repeat call (e.g. a second forfeit outpoint of the same intent) a
+// no-op. Anchors are intentionally retained so the activity projection can
+// still correlate the failed job by its consumed outpoint.
+func (q *Queries) MarkPendingSendIntentFailedByOutpoint(ctx context.Context, arg MarkPendingSendIntentFailedByOutpointParams) error {
+	_, err := q.db.ExecContext(ctx, MarkPendingSendIntentFailedByOutpoint,
+		arg.OutpointHash,
+		arg.OutpointIndex,
+		arg.FailureReason,
+		arg.FailureCode,
+	)
+	return err
 }
 
 const UpsertPendingBoardIntent = `-- name: UpsertPendingBoardIntent :exec
@@ -314,7 +367,10 @@ INSERT INTO pending_intents (
     requested_at_unix
 ) VALUES ($1, $2, $3)
 ON CONFLICT (intent_id) DO UPDATE
-SET requested_at_unix = excluded.requested_at_unix
+SET requested_at_unix = excluded.requested_at_unix,
+    status = 'pending',
+    failure_reason = NULL,
+    failure_code = 0
 `
 
 type UpsertPendingIntentHeaderParams struct {
@@ -323,6 +379,12 @@ type UpsertPendingIntentHeaderParams struct {
 	RequestedAtUnix int64
 }
 
+// Re-arm a re-persisted intent as pending. NewPendingIntentID is
+// deterministic, so retrying a terminally failed send (same inputs and
+// payload) reuses the same intent_id and lands here on the retained 'failed'
+// row. Resetting the status and failure fields makes the retry replayable
+// again; without it the replay query (which now skips non-pending rows) would
+// silently drop a retry that crashes before the round adopts it.
 func (q *Queries) UpsertPendingIntentHeader(ctx context.Context, arg UpsertPendingIntentHeaderParams) error {
 	_, err := q.db.ExecContext(ctx, UpsertPendingIntentHeader, arg.IntentID, arg.Kind, arg.RequestedAtUnix)
 	return err

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -31,7 +31,14 @@ type Querier interface {
 	DeleteClientTreeTxids(ctx context.Context, arg DeleteClientTreeTxidsParams) error
 	DeleteOORPackageCheckpoints(ctx context.Context, sessionID []byte) error
 	DeleteOrphanedPendingBoardIntents(ctx context.Context) error
+	// A terminally failed intent is a durable record, not a sweepable orphan:
+	// keep its header even once its anchors are reused. Replay already skips it on
+	// the status filter, and the activity projection still surfaces it as failed.
 	DeleteOrphanedPendingIntents(ctx context.Context) error
+	// Keep the detail row of a terminally failed send even after its anchors are
+	// gone (a released coin got reused by a later send, stealing the anchor). The
+	// failed record is durable and correlated by intent_id, so its detail must
+	// survive alongside its header for the activity projection to surface it.
 	DeleteOrphanedPendingSendIntents(ctx context.Context) error
 	DeletePendingBoardIntentByID(ctx context.Context, intentID []byte) error
 	DeletePendingBoardIntentsAll(ctx context.Context) error
@@ -211,10 +218,14 @@ type Querier interface {
 	ListOORRecipientCursors(ctx context.Context) ([]OorRecipientCursor, error)
 	ListOORVTXOBindingsBySession(ctx context.Context, sessionID []byte) ([]ListOORVTXOBindingsBySessionRow, error)
 	ListOwnedReceiveScripts(ctx context.Context) ([]OwnedReceiveScript, error)
+	// Only status = 'pending' rows replay; a 'failed' intent is terminally
+	// retired and must not be re-submitted on restart.
 	ListPendingBoardIntents(ctx context.Context) ([]ListPendingBoardIntentsRow, error)
 	ListPendingBoardingSweepInputs(ctx context.Context) ([]BoardingSweepInput, error)
 	ListPendingBoardingSweeps(ctx context.Context) ([]BoardingSweep, error)
 	ListPendingIntentAnchorsByKind(ctx context.Context, kind string) ([]PendingIntentAnchor, error)
+	// Only status = 'pending' rows replay; a 'failed' intent is terminally
+	// retired and must not be re-submitted on restart.
 	ListPendingSendIntents(ctx context.Context) ([]ListPendingSendIntentsRow, error)
 	ListRoundsByStatus(ctx context.Context, status string) ([]Round, error)
 	// ListRoundsPaginated returns rounds ordered by round_id with cursor-
@@ -271,6 +282,12 @@ type Querier interface {
 	MarkBoardingSweepInputStatus(ctx context.Context, arg MarkBoardingSweepInputStatusParams) error
 	MarkBoardingSweepInputsStatus(ctx context.Context, arg MarkBoardingSweepInputsStatusParams) error
 	MarkBoardingSweepStatus(ctx context.Context, arg MarkBoardingSweepStatusParams) error
+	// Terminally fail the pending send intent anchored to the given outpoint,
+	// recording the reason and typed failure code. Idempotent: the status guard
+	// makes a repeat call (e.g. a second forfeit outpoint of the same intent) a
+	// no-op. Anchors are intentionally retained so the activity projection can
+	// still correlate the failed job by its consumed outpoint.
+	MarkPendingSendIntentFailedByOutpoint(ctx context.Context, arg MarkPendingSendIntentFailedByOutpointParams) error
 	MarkUnilateralExitJobTerminal(ctx context.Context, arg MarkUnilateralExitJobTerminalParams) error
 	MarkVHTLCRecoveryExitTxBroadcast(ctx context.Context, arg MarkVHTLCRecoveryExitTxBroadcastParams) error
 	MarkVHTLCRecoveryExitTxBuilt(ctx context.Context, arg MarkVHTLCRecoveryExitTxBuiltParams) error
@@ -331,6 +348,12 @@ type Querier interface {
 	UpsertOwnedReceiveScript(ctx context.Context, arg UpsertOwnedReceiveScriptParams) error
 	UpsertPendingBoardIntent(ctx context.Context, arg UpsertPendingBoardIntentParams) error
 	UpsertPendingIntentAnchor(ctx context.Context, arg UpsertPendingIntentAnchorParams) error
+	// Re-arm a re-persisted intent as pending. NewPendingIntentID is
+	// deterministic, so retrying a terminally failed send (same inputs and
+	// payload) reuses the same intent_id and lands here on the retained 'failed'
+	// row. Resetting the status and failure fields makes the retry replayable
+	// again; without it the replay query (which now skips non-pending rows) would
+	// silently drop a retry that crashes before the round adopts it.
 	UpsertPendingIntentHeader(ctx context.Context, arg UpsertPendingIntentHeaderParams) error
 	UpsertPendingSendIntent(ctx context.Context, arg UpsertPendingSendIntentParams) error
 	// Spending reservation queries.

--- a/db/sqlc/queries/pending_intents.sql
+++ b/db/sqlc/queries/pending_intents.sql
@@ -114,6 +114,15 @@ DELETE FROM pending_send_intents
 WHERE NOT EXISTS (
     SELECT 1 FROM pending_intent_anchors a
     WHERE a.intent_id = pending_send_intents.intent_id
+)
+-- Keep the detail row of a terminally failed send even after its anchors are
+-- gone (a released coin got reused by a later send, stealing the anchor). The
+-- failed record is durable and correlated by intent_id, so its detail must
+-- survive alongside its header for the activity projection to surface it.
+AND NOT EXISTS (
+    SELECT 1 FROM pending_intents i
+    WHERE i.intent_id = pending_send_intents.intent_id
+      AND i.status = 'failed'
 );
 
 -- name: DeleteOrphanedPendingIntents :exec
@@ -121,7 +130,11 @@ DELETE FROM pending_intents
 WHERE NOT EXISTS (
     SELECT 1 FROM pending_intent_anchors a
     WHERE a.intent_id = pending_intents.intent_id
-);
+)
+-- A terminally failed intent is a durable record, not a sweepable orphan:
+-- keep its header even once its anchors are reused. Replay already skips it on
+-- the status filter, and the activity projection still surfaces it as failed.
+AND status <> 'failed';
 
 -- name: DeletePendingIntentAnchorsByIntentID :exec
 DELETE FROM pending_intent_anchors

--- a/db/sqlc/queries/pending_intents.sql
+++ b/db/sqlc/queries/pending_intents.sql
@@ -5,7 +5,16 @@ INSERT INTO pending_intents (
     requested_at_unix
 ) VALUES ($1, $2, $3)
 ON CONFLICT (intent_id) DO UPDATE
-SET requested_at_unix = excluded.requested_at_unix;
+-- Re-arm a re-persisted intent as pending. NewPendingIntentID is
+-- deterministic, so retrying a terminally failed send (same inputs and
+-- payload) reuses the same intent_id and lands here on the retained 'failed'
+-- row. Resetting the status and failure fields makes the retry replayable
+-- again; without it the replay query (which now skips non-pending rows) would
+-- silently drop a retry that crashes before the round adopts it.
+SET requested_at_unix = excluded.requested_at_unix,
+    status = 'pending',
+    failure_reason = NULL,
+    failure_code = 0;
 
 -- name: UpsertPendingBoardIntent :exec
 INSERT INTO pending_board_intents (
@@ -43,23 +52,44 @@ ON CONFLICT (outpoint_hash, outpoint_index) DO UPDATE
 SET intent_id = excluded.intent_id;
 
 -- name: ListPendingBoardIntents :many
+-- Only status = 'pending' rows replay; a 'failed' intent is terminally
+-- retired and must not be re-submitted on restart.
 SELECT
     i.intent_id, i.requested_at_unix,
     b.target_vtxo_count
 FROM pending_intents i
 JOIN pending_board_intents b ON b.intent_id = i.intent_id
-WHERE i.kind = 'board'
+WHERE i.kind = 'board' AND i.status = 'pending'
 ORDER BY i.requested_at_unix ASC, i.intent_id ASC;
 
 -- name: ListPendingSendIntents :many
+-- Only status = 'pending' rows replay; a 'failed' intent is terminally
+-- retired and must not be re-submitted on restart.
 SELECT
     i.intent_id, i.requested_at_unix,
     s.dest_pkscript, s.target_amount_sat, s.sweep_all,
     s.operator_key, s.vtxo_exit_delay, s.dust_limit_sat
 FROM pending_intents i
 JOIN pending_send_intents s ON s.intent_id = i.intent_id
-WHERE i.kind = 'send_onchain'
+WHERE i.kind = 'send_onchain' AND i.status = 'pending'
 ORDER BY i.requested_at_unix ASC, i.intent_id ASC;
+
+-- name: MarkPendingSendIntentFailedByOutpoint :exec
+-- Terminally fail the pending send intent anchored to the given outpoint,
+-- recording the reason and typed failure code. Idempotent: the status guard
+-- makes a repeat call (e.g. a second forfeit outpoint of the same intent) a
+-- no-op. Anchors are intentionally retained so the activity projection can
+-- still correlate the failed job by its consumed outpoint.
+UPDATE pending_intents
+SET status = 'failed',
+    failure_reason = $3,
+    failure_code = $4
+WHERE kind = 'send_onchain'
+  AND status = 'pending'
+  AND intent_id IN (
+      SELECT a.intent_id FROM pending_intent_anchors a
+      WHERE a.outpoint_hash = $1 AND a.outpoint_index = $2
+  );
 
 -- name: ListPendingIntentAnchorsByKind :many
 SELECT a.outpoint_hash, a.outpoint_index, a.intent_id

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -539,6 +539,9 @@ ON pending_intent_anchors (intent_id);
 CREATE INDEX idx_pending_intents_kind
 ON pending_intents (kind);
 
+CREATE INDEX idx_pending_intents_kind_status
+    ON pending_intents (kind, status);
+
 CREATE INDEX idx_processed_messages_expires
     ON processed_messages(expires_at);
 
@@ -1070,7 +1073,7 @@ CREATE TABLE pending_intents (
     -- requested_at_unix is when the user issued the intent. Replay
     -- diagnostics surface it; newer intents win when reconciling.
     requested_at_unix BIGINT NOT NULL CHECK (requested_at_unix > 0)
-);
+, status TEXT NOT NULL DEFAULT 'pending', failure_reason TEXT, failure_code INTEGER NOT NULL DEFAULT 0);
 
 CREATE TABLE pending_send_intents (
     intent_id BLOB PRIMARY KEY

--- a/round/actor.go
+++ b/round/actor.go
@@ -528,6 +528,52 @@ func (a *RoundClientActor) emitRoundCompleted(ctx context.Context, roundID,
 	})
 }
 
+// handleTerminalJobFailure reacts to a round that failed with a
+// terminal-for-job code (e.g. the operator could not fund the commitment tx).
+// The accompanying ReleaseForfeitReservation has already returned the reserved
+// VTXOs to the live set, so here we drop the originating job's persisted
+// pending intent, keyed by its forfeited outpoints. That halts the recoverable
+// replay loop: without it, the send-onchain intent replayer would re-submit
+// the same inputs into the same operator on every restart. Dropping is
+// best-effort — a store error degrades to the pre-existing replay behavior
+// rather than wedging the round actor, so it is logged, not returned.
+func (a *RoundClientActor) handleTerminalJobFailure(ctx context.Context,
+	m *TerminalJobFailedNotification) {
+
+	roundIDStr := "none"
+	m.RoundID.WhenSome(func(id RoundID) {
+		roundIDStr = id.String()
+	})
+
+	a.log.WarnS(ctx, "Round failed terminally; dropping originating "+
+		"job intent",
+		nil,
+		slog.String("round_id", roundIDStr),
+		slog.String("reason", m.Reason),
+		slog.Int("failure_code", int(m.FailureCode)),
+		slog.Int("forfeit_outpoint_count", len(m.ForfeitOutpoints)),
+	)
+
+	// This mark runs in the same processOutbox turn that just enqueued the
+	// ReleaseForfeitReservation Tell to the VTXO manager, before that
+	// manager has moved the coins back to LiveState. A programmatic retry
+	// of the same send therefore cannot observe the released coin and
+	// re-persist a fresh intent between the release and this mark, so we
+	// can key the mark on the forfeited outpoints without racing a live
+	// retry. A future refactor that defers this mark to a later turn must
+	// revisit that assumption.
+	if err := a.cfg.RoundStore.FailForfeitIntents(
+		ctx, m.ForfeitOutpoints, m.Reason, m.FailureCode,
+	); err != nil {
+
+		a.log.WarnS(ctx, "Failed to mark pending intent failed after "+
+			"terminal round failure; it may replay on restart",
+			err,
+			slog.String("round_id", roundIDStr),
+		)
+	}
+}
+
 // emitRoundJoined reports a round-join attempt to the metrics actor so
 // darepod_rounds_joined_total advances. It is emitted from createNewRound
 // so it counts every round the client assembles — manual and eager alike
@@ -2521,6 +2567,16 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 			// counter pairs with the confirmed branch above so an
 			// operator can track the join-to-completion ratio.
 			a.emitRoundCompleted(ctx, roundIDStr, "failed")
+
+		case *TerminalJobFailedNotification:
+			// A terminal-for-job round failure (e.g. the operator
+			// could not fund the commitment tx). The accompanying
+			// ReleaseForfeitReservation has already returned the
+			// VTXOs to the live set; here we drop the originating
+			// job's persisted pending intent so restart replay does
+			// not re-submit the same inputs into the same wall, and
+			// surface the job's activity entry as failed.
+			a.handleTerminalJobFailure(ctx, m)
 
 		case *ForfeitRequestToVTXO:
 			// Route forfeit request to VTXO actor via service key.

--- a/round/events.go
+++ b/round/events.go
@@ -350,6 +350,40 @@ type BoardingConfirmed struct {
 
 func (e *BoardingConfirmed) clientEventSealed() {}
 
+// RoundFailureCode classifies, in client-domain terms, why a round the client
+// had joined failed. It is mapped from the wire roundpb.RoundFailureCode only
+// at the RPC boundary (BoardingFailed.FromProto), so the FSM and its consumers
+// never traffic in proto types.
+type RoundFailureCode uint8
+
+const (
+	// RoundFailureUnknown is the default, unclassified failure. The client
+	// treats it as a generic recoverable failure and relies on Reason. An
+	// unrecognized wire code also maps here.
+	RoundFailureUnknown RoundFailureCode = iota
+
+	// RoundFailureInsufficientOperatorFunds indicates the operator could
+	// not fund the round's commitment transaction from its own on-chain
+	// wallet. The client's inputs were never committed and its
+	// forfeit-reserved inputs are released back to the live set, so the
+	// originating job (e.g. a cooperative on-chain send) must be failed
+	// terminally rather than auto-retried into the same wall.
+	RoundFailureInsufficientOperatorFunds
+)
+
+// IsTerminalForJob reports whether a failure code should terminally fail the
+// job that triggered the round (dropping its persisted intent and marking its
+// activity entry failed) rather than leaving it to recoverable replay.
+func (c RoundFailureCode) IsTerminalForJob() bool {
+	switch c {
+	case RoundFailureInsufficientOperatorFunds:
+		return true
+
+	default:
+		return false
+	}
+}
+
 // BoardingFailed is emitted when an error occurs during the boarding
 // process.
 type BoardingFailed struct {
@@ -369,6 +403,12 @@ type BoardingFailed struct {
 	// Recoverable indicates if the client can retry or if CSV recovery
 	// is needed.
 	Recoverable bool
+
+	// FailureCode is the server's typed classification of the failure. It
+	// defaults to RoundFailureUnknown for older servers and unclassified
+	// failures. Terminal-for-job codes drive the originating job to a
+	// terminal failure instead of recoverable replay.
+	FailureCode RoundFailureCode
 }
 
 func (e *BoardingFailed) clientEventSealed() {}

--- a/round/failure_code_test.go
+++ b/round/failure_code_test.go
@@ -1,0 +1,148 @@
+package round
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/darepo-client/lib/types"
+	"github.com/lightninglabs/darepo-client/rpc/roundpb"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// insufficientFundsWire aliases the verbose wire enum value so the assertions
+// below stay within the line-length limit.
+const insufficientFundsWire = roundpb.
+	RoundFailureCode_ROUND_FAILURE_INSUFFICIENT_OPERATOR_FUNDS
+
+// TestRoundFailureCodeIsTerminalForJob verifies only the operator-funds code
+// terminally fails the originating job; unknown stays recoverable.
+func TestRoundFailureCodeIsTerminalForJob(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, RoundFailureUnknown.IsTerminalForJob())
+	require.True(
+		t, RoundFailureInsufficientOperatorFunds.IsTerminalForJob(),
+	)
+}
+
+// TestFailureCodeFromProto verifies the wire-to-native mapping, including the
+// degrade of an unrecognized (newer-server) wire code to unknown.
+func TestFailureCodeFromProto(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t, RoundFailureUnknown, failureCodeFromProto(
+			roundpb.RoundFailureCode_ROUND_FAILURE_UNKNOWN,
+		),
+	)
+	require.Equal(
+		t, RoundFailureInsufficientOperatorFunds,
+		failureCodeFromProto(insufficientFundsWire),
+	)
+	require.Equal(
+		t, RoundFailureUnknown,
+		failureCodeFromProto(
+			roundpb.RoundFailureCode(99),
+		),
+	)
+}
+
+// TestBoardingFailedFromProtoCarriesCode verifies BoardingFailed decodes the
+// typed failure code from the ClientRoundFailedResp at the RPC boundary.
+func TestBoardingFailedFromProtoCarriesCode(t *testing.T) {
+	t.Parallel()
+
+	e := &BoardingFailed{}
+	err := e.FromProto(&roundpb.ClientRoundFailedResp{
+		Reason:      "fund psbt: insufficient funds",
+		FailureCode: insufficientFundsWire,
+	})
+	require.NoError(t, err)
+	require.Equal(t, RoundFailureInsufficientOperatorFunds, e.FailureCode)
+	require.True(t, e.Recoverable)
+}
+
+// terminalJobMsg returns the sole TerminalJobFailedNotification in the
+// transition's outbox, or nil when none is present.
+func terminalJobMsg(t *ClientStateTransition) *TerminalJobFailedNotification {
+	var found *TerminalJobFailedNotification
+	t.NewEvents.WhenSome(func(e ClientEmittedEvent) {
+		for _, msg := range e.Outbox {
+			if n, ok := msg.(*TerminalJobFailedNotification); ok {
+				found = n
+			}
+		}
+	})
+
+	return found
+}
+
+// TestReleaseForfeitsOnFailureTerminalEmitsDrop verifies that a
+// terminal-for-job failure into ClientFailedState, with forfeits reserved,
+// emits a TerminalJobFailedNotification carrying the forfeited outpoints so the
+// actor can fail the originating job.
+func TestReleaseForfeitsOnFailureTerminalEmitsDrop(t *testing.T) {
+	t.Parallel()
+
+	roundID := fn.Some(RoundID{0xaa})
+	outpoint := op(0x10, 1)
+	forfeits := []types.ForfeitRequest{{VTXOOutpoint: opPtr(outpoint)}}
+
+	transition := &ClientStateTransition{
+		NextState: &ClientFailedState{
+			Reason:      "operator broke",
+			Recoverable: true,
+			FailureCode: RoundFailureInsufficientOperatorFunds,
+		},
+	}
+
+	out, err := releaseForfeitsOnFailure(
+		transition, nil, roundID, forfeits,
+	)
+	require.NoError(t, err)
+
+	msg := terminalJobMsg(out)
+	require.NotNil(t, msg, "terminal-for-job failure must emit a drop")
+	require.Equal(t, RoundFailureInsufficientOperatorFunds, msg.FailureCode)
+	require.Equal(t, "operator broke", msg.Reason)
+	require.Equal(t, []wire.OutPoint{outpoint}, msg.ForfeitOutpoints)
+}
+
+// TestReleaseForfeitsOnFailureUnknownNoDrop verifies a generic (recoverable)
+// failure still releases the forfeit but does NOT terminally fail the job, so
+// its intent stays eligible for replay.
+func TestReleaseForfeitsOnFailureUnknownNoDrop(t *testing.T) {
+	t.Parallel()
+
+	roundID := fn.Some(RoundID{0xbb})
+	forfeits := []types.ForfeitRequest{{VTXOOutpoint: opPtr(op(0x11, 0))}}
+
+	transition := &ClientStateTransition{
+		NextState: &ClientFailedState{
+			Reason:      "transient hiccup",
+			Recoverable: true,
+			FailureCode: RoundFailureUnknown,
+		},
+	}
+
+	out, err := releaseForfeitsOnFailure(
+		transition, nil, roundID, forfeits,
+	)
+	require.NoError(t, err)
+	require.Nil(
+		t, terminalJobMsg(out),
+		"unknown failure must not terminally fail the job",
+	)
+
+	// The forfeit release must still fire so the VTXO returns to LiveState.
+	var sawRelease bool
+	out.NewEvents.WhenSome(func(e ClientEmittedEvent) {
+		for _, msg := range e.Outbox {
+			if _, ok := msg.(*ReleaseForfeitReservation); ok {
+				sawRelease = true
+			}
+		}
+	})
+	require.True(t, sawRelease, "forfeit release must still fire")
+}

--- a/round/forfeit_release_on_failure_test.go
+++ b/round/forfeit_release_on_failure_test.go
@@ -360,6 +360,171 @@ func TestPreSigningFailureReleasesForfeits(t *testing.T) {
 	}
 }
 
+// TestPreSigningTerminalFailureRetiresJob is the regression for the
+// terminal-notification-swallowed bug. A pre-signing state that fails on a
+// BoardingFailed carrying a terminal-for-job code must emit BOTH the forfeit
+// release (VTXOs back to LiveState) AND a TerminalJobFailedNotification (retire
+// the originating pending intent), for every wrapped pre-signing state,
+// including the ones that build their own failure outbox (IntentSentState,
+// CommitmentTxReceivedState). Before the fix, releaseForfeitsOnFailure's
+// release-idempotency guard early-returned before the notification block for
+// exactly those states, so the operator-fund-failure send replayed forever, the
+// #889 bug surviving on its own fix path. The failed round in the production
+// incident lands in IntentSentState (the client stays there after RoundJoined
+// admission until the commitment tx arrives), which is one of the two
+// failure-outbox states, so this is the reachable case, not a latent one.
+func TestPreSigningTerminalFailureRetiresJob(t *testing.T) {
+	t.Parallel()
+
+	terminal := &BoardingFailed{
+		Reason:      "operator cannot fund the commitment tx",
+		Error:       errors.New("fund psbt: insufficient funds"),
+		Recoverable: true,
+		FailureCode: RoundFailureInsufficientOperatorFunds,
+	}
+
+	cases := []preSigningFailure{
+		{
+			name: "PendingRoundAssembly",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &PendingRoundAssembly{
+					Forfeits: ff,
+				}
+			},
+			event: terminal,
+		},
+		{
+			// The reachable #889 path: still in IntentSentState at
+			// seal time, and this handler builds its own failure
+			// outbox, so the old guard swallowed the drop here.
+			name: "IntentSentState",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &IntentSentState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: terminal,
+		},
+		{
+			name: "RoundJoinedState",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &RoundJoinedState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: terminal,
+		},
+		{
+			// Second failure-outbox state, latent for the current
+			// code (commitment tx is already funded here) but wired
+			// so future terminal codes stay correct.
+			name: "CommitmentTxReceivedState",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &CommitmentTxReceivedState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: terminal,
+		},
+		{
+			name: "NoncesSentState",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &NoncesSentState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: terminal,
+		},
+		{
+			name: "PartialSigsSentState",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &PartialSigsSentState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: terminal,
+		},
+		{
+			name: "ForfeitSignaturesCollectingState",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &ForfeitSignaturesCollectingState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: terminal,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			forfeits, outpoints := frcForfeits()
+			env := &ClientEnvironment{Log: btclog.Disabled}
+
+			tr, err := tc.state(forfeits).ProcessEvent(
+				context.Background(), tc.event, env,
+			)
+			require.NoError(t, err)
+
+			failed, ok := tr.NextState.(*ClientFailedState)
+			require.True(
+				t, ok, "expected ClientFailedState, got %T",
+				tr.NextState,
+			)
+			require.Equal(
+				t, RoundFailureInsufficientOperatorFunds,
+				failed.FailureCode,
+			)
+
+			outbox := tr.NewEvents.UnwrapOr(
+				ClientEmittedEvent{},
+			).Outbox
+
+			// The inputs still return to the live set, exactly
+			// once.
+			release, ok := findOutbox[*ReleaseForfeitReservation](
+				outbox,
+			)
+			require.True(
+				t, ok, "terminal failure must release forfeits",
+			)
+			require.ElementsMatch(t, outpoints, release.Outpoints)
+
+			// And, in the same breath, the originating job is
+			// retired: the drop carries the forfeited outpoints so
+			// the actor marks the pending intent failed instead of
+			// replaying it into the broke operator.
+			drop, ok := findOutbox[*TerminalJobFailedNotification](
+				outbox,
+			)
+			require.True(
+				t, ok, "terminal failure must retire the "+
+					"originating job",
+			)
+			require.Equal(
+				t, RoundFailureInsufficientOperatorFunds,
+				drop.FailureCode,
+			)
+			require.ElementsMatch(
+				t, outpoints, drop.ForfeitOutpoints,
+			)
+		})
+	}
+}
+
 // TestPostSigningFailureDoesNotReleaseForfeits is the safety control: once the
 // client has submitted its forfeit signatures (InputSigSentState onward), a
 // failed round must NOT auto-release the inputs, since the server could still

--- a/round/forfeit_release_on_failure_test.go
+++ b/round/forfeit_release_on_failure_test.go
@@ -325,6 +325,44 @@ func TestPreSigningFailureReleasesForfeits(t *testing.T) {
 				Reason: "fee exceeds cap",
 			},
 		},
+		{
+			// A recoverable server round failure arriving while the
+			// client holds the quote or is mid VTXO-tree signing
+			// must still release the forfeits. These states had no
+			// BoardingFailed case, so the release was silently
+			// dropped and the inputs stranded in pending-forfeit.
+			name: "QuoteReceivedState/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &QuoteReceivedState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			name: "CommitmentTxValidatedState/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &CommitmentTxValidatedState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
+		{
+			name: "NoncesAggregatedState/BoardingFailed",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &NoncesAggregatedState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: boardingFailed,
+		},
 	}
 
 	for _, tc := range cases {
@@ -458,6 +496,42 @@ func TestPreSigningTerminalFailureRetiresJob(t *testing.T) {
 			name: "ForfeitSignaturesCollectingState",
 			state: func(ff []types.ForfeitRequest) ClientState {
 				return &ForfeitSignaturesCollectingState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: terminal,
+		},
+		{
+			// These three states used to have no BoardingFailed
+			// case, so a server round failure there was self-looped
+			// and both the release and the drop were swallowed.
+			name: "QuoteReceivedState",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &QuoteReceivedState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: terminal,
+		},
+		{
+			name: "CommitmentTxValidatedState",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &CommitmentTxValidatedState{
+					Intents: Intents{
+						Forfeits: ff,
+					},
+				}
+			},
+			event: terminal,
+		},
+		{
+			name: "NoncesAggregatedState",
+			state: func(ff []types.ForfeitRequest) ClientState {
+				return &NoncesAggregatedState{
 					Intents: Intents{
 						Forfeits: ff,
 					},

--- a/round/from_proto.go
+++ b/round/from_proto.go
@@ -442,7 +442,16 @@ func (e *BoardingFailed) FromProto(p proto.Message) error {
 	switch pb := p.(type) {
 	case *roundpb.ClientRoundFailedResp:
 		e.Reason = pb.Reason
+
+		// Recoverable and FailureCode are orthogonal axes.
+		// Recoverable is round-level: this round is over, so its inputs
+		// return to the live set. FailureCode is job-level: a terminal
+		// code (e.g. insufficient operator funds) tells the actor the
+		// originating job is dead and must not replay, even though the
+		// round is recoverable. So a terminal failure is still
+		// Recoverable = true here; do not conflate the two.
 		e.Recoverable = true
+		e.FailureCode = failureCodeFromProto(pb.FailureCode)
 
 		// Carry the server-assigned round id when present so the actor
 		// can route this failure deterministically to the matching FSM.
@@ -470,6 +479,20 @@ func (e *BoardingFailed) FromProto(p proto.Message) error {
 		return fmt.Errorf("unexpected proto type: %T, want "+
 			"*roundpb.ClientRoundFailedResp or "+
 			"*roundpb.ClientErrorResp", p)
+	}
+}
+
+// failureCodeFromProto maps the wire roundpb.RoundFailureCode onto the native
+// RoundFailureCode. This is the RPC boundary; an unrecognized wire code (a
+// newer server than this client) degrades to RoundFailureUnknown so the client
+// falls back to recoverable handling and the reason string.
+func failureCodeFromProto(code roundpb.RoundFailureCode) RoundFailureCode {
+	switch code {
+	case roundpb.RoundFailureCode_ROUND_FAILURE_INSUFFICIENT_OPERATOR_FUNDS:
+		return RoundFailureInsufficientOperatorFunds
+
+	default:
+		return RoundFailureUnknown
 	}
 }
 

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -98,6 +98,14 @@ func (m *MockRoundStore) FinalizeRound(ctx context.Context, roundID RoundID,
 	return args.Error(0)
 }
 
+func (m *MockRoundStore) FailForfeitIntents(ctx context.Context,
+	outpoints []wire.OutPoint, reason string, code RoundFailureCode) error {
+
+	args := m.Called(ctx, outpoints, reason, code)
+
+	return args.Error(0)
+}
+
 // Compile-time check that MockRoundStore implements RoundStore.
 var _ RoundStore = (*MockRoundStore)(nil)
 

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -446,6 +446,18 @@ type RoundStore interface {
 	// confirmed.
 	FinalizeRound(ctx context.Context, roundID RoundID, txid chainhash.Hash,
 		confInfo ConfInfo) error
+
+	// FailForfeitIntents terminally fails the pending send intents anchored
+	// to the given forfeited VTXO outpoints, recording the reason and typed
+	// failure code. It is the terminal-failure counterpart to the anchor
+	// clear CommitState performs on the success path: when a round fails
+	// terminally (e.g. the operator cannot fund the commitment tx), the
+	// originating job is marked failed so restart replay does not re-submit
+	// the same forfeit inputs into the same wall, and the activity entry
+	// surfaces as failed rather than stuck pending. It is a no-op for an
+	// empty outpoint set.
+	FailForfeitIntents(ctx context.Context, outpoints []wire.OutPoint,
+		reason string, code RoundFailureCode) error
 }
 
 // ClientVTXO represents a Virtual UTXO owned by the client, including all

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -961,3 +961,33 @@ type RoundFailedNotification struct {
 }
 
 func (m *RoundFailedNotification) clientOutMsgSealed() {}
+
+// TerminalJobFailedNotification is emitted when a round fails, before any
+// forfeit signatures were sent, with a terminal-for-job failure code (e.g. the
+// operator cannot fund the commitment tx). It carries the forfeited VTXO
+// outpoints — which are exactly the originating job's pending-intent anchors —
+// so the round actor can drop the persisted pending intent, halting the
+// recoverable-replay loop, and surface the originating job as failed. The
+// forfeit reservations themselves are released by the ReleaseForfeitReservation
+// message that accompanies this one, returning the VTXOs to the live set.
+type TerminalJobFailedNotification struct {
+	actor.BaseMessage
+
+	// RoundID identifies the failed round. None if the failure occurred
+	// before a round was assigned.
+	RoundID fn.Option[RoundID]
+
+	// ForfeitOutpoints are the forfeited VTXO outpoints reserved by the
+	// originating job; they double as the job's pending-intent anchors.
+	ForfeitOutpoints []wire.OutPoint
+
+	// FailureCode is the terminal-for-job classification that triggered
+	// this notification.
+	FailureCode RoundFailureCode
+
+	// Reason is a human-readable description of the failure, surfaced on
+	// the originating job's activity entry.
+	Reason string
+}
+
+func (m *TerminalJobFailedNotification) clientOutMsgSealed() {}

--- a/round/states.go
+++ b/round/states.go
@@ -745,6 +745,14 @@ type ClientFailedState struct {
 	// Recoverable indicates if the client can retry or if CSV recovery is
 	// needed.
 	Recoverable bool
+
+	// FailureCode is the server's typed classification of the failure,
+	// carried through from BoardingFailed. It defaults to
+	// RoundFailureUnknown. A terminal-for-job code (e.g.
+	// RoundFailureInsufficientOperatorFunds) tells the pre-signing
+	// forfeit-release chokepoint to also fail the originating job instead
+	// of leaving it to recoverable replay.
+	FailureCode RoundFailureCode
 }
 
 func (s *ClientFailedState) String() string {

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -1649,6 +1649,21 @@ func (s *QuoteReceivedState) processEvent(ctx context.Context,
 			}),
 		}, nil
 
+	case *BoardingFailed:
+		// A server-pushed round failure while we hold the quote is
+		// still pre-signing: fail into ClientFailedState carrying the
+		// typed code, and let ProcessEvent's releaseForfeitsOnFailure
+		// wrapper return the forfeits to LiveState and retire the job
+		// on a terminal-for-job code.
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+				FailureCode: evt.FailureCode,
+			},
+		}, nil
+
 	default:
 		return selfLoop(s), nil
 	}
@@ -2327,7 +2342,7 @@ func (s *CommitmentTxValidatedState) processEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
-	switch event.(type) {
+	switch evt := event.(type) {
 	case *GenerateNonces:
 		env.Log.InfoS(
 			ctx,
@@ -2520,6 +2535,22 @@ func (s *CommitmentTxValidatedState) processEvent(ctx context.Context,
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: []ClientOutMsg{nonceMsg},
 			}),
+		}, nil
+
+	case *BoardingFailed:
+		// Still pre-signing (VTXO forfeit sigs only cross to the server
+		// on the ForfeitSignaturesCollecting -> InputSigSent
+		// transition): fail into ClientFailedState with the typed code
+		// and let ProcessEvent's releaseForfeitsOnFailure wrapper
+		// release the forfeits and retire the job on a terminal-for-job
+		// code.
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+				FailureCode: evt.FailureCode,
+			},
 		}, nil
 
 	default:
@@ -2993,7 +3024,7 @@ func (s *NoncesAggregatedState) processEvent(ctx context.Context,
 	event ClientEvent, env *ClientEnvironment) (*ClientStateTransition,
 	error) {
 
-	switch event.(type) {
+	switch evt := event.(type) {
 	case *GeneratePartialSigs:
 		env.Log.InfoS(
 			ctx,
@@ -3054,6 +3085,22 @@ func (s *NoncesAggregatedState) processEvent(ctx context.Context,
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: []ClientOutMsg{submitPartialSigsMsg},
 			}),
+		}, nil
+
+	case *BoardingFailed:
+		// Still pre-signing (VTXO forfeit sigs only cross to the server
+		// on the ForfeitSignaturesCollecting -> InputSigSent
+		// transition): fail into ClientFailedState with the typed code
+		// and let ProcessEvent's releaseForfeitsOnFailure wrapper
+		// release the forfeits and retire the job on a terminal-for-job
+		// code.
+		return &ClientStateTransition{
+			NextState: &ClientFailedState{
+				Reason:      evt.Reason,
+				Error:       evt.Error,
+				Recoverable: evt.Recoverable,
+				FailureCode: evt.FailureCode,
+			},
 		}, nil
 
 	default:

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -117,7 +117,8 @@ func releaseForfeitsOnFailure(transition *ClientStateTransition, err error,
 
 	// Only a transition into the terminal failure state can strand forfeit
 	// reservations; leave every other transition untouched.
-	if _, failed := transition.NextState.(*ClientFailedState); !failed {
+	failedState, failed := transition.NextState.(*ClientFailedState)
+	if !failed {
 		return transition, err
 	}
 
@@ -127,20 +128,72 @@ func releaseForfeitsOnFailure(transition *ClientStateTransition, err error,
 
 	emitted := transition.NewEvents.UnwrapOr(ClientEmittedEvent{})
 
-	// Stay idempotent: a handler that already rolled back (the admission
-	// timeout in IntentSentState) must not release/drop the same inputs
-	// twice.
+	// Some handlers (the admission timeout in IntentSentState, or any state
+	// that fails through failureOutbox) already queued the rollback
+	// themselves, and a few could in principle already carry the terminal
+	// notification. Scan once for both so we neither release the same
+	// inputs twice nor duplicate the drop, while keeping the two concerns
+	// independent: the release returns the VTXOs to LiveState, the
+	// notification retires the originating job, and a handler doing the
+	// former must not suppress the latter.
+	var alreadyReleased, alreadyNotified bool
 	for _, msg := range emitted.Outbox {
 		switch msg.(type) {
 		case *ReleaseForfeitReservation, *DropCustomForfeitReservation:
-			return transition, err
+			alreadyReleased = true
+
+		case *TerminalJobFailedNotification:
+			alreadyNotified = true
 		}
 	}
 
-	emitted.Outbox = append(rollback, emitted.Outbox...)
+	if !alreadyReleased {
+		emitted.Outbox = append(rollback, emitted.Outbox...)
+	}
+
+	// A terminal-for-job failure (e.g. the operator cannot fund the
+	// commitment tx) must not sit in recoverable replay: the round is dead
+	// and re-submitting these same inputs next start just hits the same
+	// wall. Alongside the forfeit release (which returns the VTXOs to the
+	// live set), emit a notification carrying the forfeited outpoints,
+	// which are exactly the originating job's pending-intent anchors, so
+	// the actor drops the persisted pending intent and surfaces the job as
+	// failed. This is orthogonal to the release above: a handler that
+	// already rolled back still needs the job retired, so we key only on
+	// whether the drop is already present, not on whether we performed the
+	// release. This runs only in the pre-signing states this wrapper
+	// guards, where returning the inputs to LiveState cannot double-spend.
+	if failedState.FailureCode.IsTerminalForJob() && !alreadyNotified {
+		emitted.Outbox = append(emitted.Outbox,
+			&TerminalJobFailedNotification{
+				RoundID:          roundID,
+				ForfeitOutpoints: forfeitOutpoints(forfeits),
+				FailureCode:      failedState.FailureCode,
+				Reason:           failedState.Reason,
+			},
+		)
+	}
+
 	transition.NewEvents = fn.Some(emitted)
 
 	return transition, err
+}
+
+// forfeitOutpoints extracts the VTXO outpoints from a set of forfeit requests,
+// skipping any with a nil outpoint. These outpoints are the pending-intent
+// anchors of the job that reserved them, so the actor uses them to drop the
+// job's persisted intent on a terminal failure.
+func forfeitOutpoints(forfeits []types.ForfeitRequest) []wire.OutPoint {
+	outpoints := make([]wire.OutPoint, 0, len(forfeits))
+	for _, forfeit := range forfeits {
+		if forfeit.VTXOOutpoint == nil {
+			continue
+		}
+
+		outpoints = append(outpoints, *forfeit.VTXOOutpoint)
+	}
+
+	return outpoints
 }
 
 // rollbackOutbox builds local rollback messages for a round that failed before
@@ -161,6 +214,26 @@ func rollbackOutbox(forfeits []types.ForfeitRequest) []ClientOutMsg {
 	}
 
 	return outbox
+}
+
+// withFailureCode stamps a typed RoundFailureCode onto a transition's
+// ClientFailedState when that is where it lands. BoardingFailed handlers that
+// build their failed state through a helper (which defaults the code to
+// RoundFailureUnknown) use this to carry evt.FailureCode onto the state
+// without threading the code through every failure helper's signature. It is a
+// no-op for a nil transition, an Unknown code, or a non-failure transition.
+func withFailureCode(t *ClientStateTransition,
+	code RoundFailureCode) *ClientStateTransition {
+
+	if t == nil || code == RoundFailureUnknown {
+		return t
+	}
+
+	if fs, ok := t.NextState.(*ClientFailedState); ok {
+		fs.FailureCode = code
+	}
+
+	return t
 }
 
 // failureOutbox builds the common failure notification and rollback messages
@@ -681,6 +754,7 @@ func (s *PendingRoundAssembly) processEvent(ctx context.Context,
 				Reason:      evt.Reason,
 				Error:       evt.Error,
 				Recoverable: evt.Recoverable,
+				FailureCode: evt.FailureCode,
 			},
 		}, nil
 
@@ -894,6 +968,7 @@ func (s *IntentSentState) processEvent(ctx context.Context, event ClientEvent,
 				Reason:      evt.Reason,
 				Error:       evt.Error,
 				Recoverable: evt.Recoverable,
+				FailureCode: evt.FailureCode,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: failureOutbox(
@@ -1738,6 +1813,7 @@ func (s *RoundJoinedState) processEvent(ctx context.Context, event ClientEvent,
 				Reason:      evt.Reason,
 				Error:       evt.Error,
 				Recoverable: evt.Recoverable,
+				FailureCode: evt.FailureCode,
 			},
 		}, nil
 
@@ -2216,9 +2292,12 @@ func (s *CommitmentTxReceivedState) processEvent(ctx context.Context,
 		}, nil
 
 	case *BoardingFailed:
-		return failBeforeForfeitSigning(
-			evt.Reason, evt.Error, evt.Recoverable, s.RoundID,
-			s.Intents.Forfeits,
+		return withFailureCode(
+			failBeforeForfeitSigning(
+				evt.Reason, evt.Error, evt.Recoverable,
+				s.RoundID, s.Intents.Forfeits,
+			),
+			evt.FailureCode,
 		), nil
 
 	default:
@@ -2548,6 +2627,7 @@ func (s *ForfeitSignaturesCollectingState) processEvent(ctx context.Context,
 				Reason:      evt.Reason,
 				Error:       evt.Error,
 				Recoverable: evt.Recoverable,
+				FailureCode: evt.FailureCode,
 			},
 			NewEvents: fn.Some(ClientEmittedEvent{
 				Outbox: cancelForfeitTimeout(
@@ -2882,6 +2962,7 @@ func (s *NoncesSentState) processEvent(ctx context.Context, event ClientEvent,
 				Reason:      evt.Reason,
 				Error:       evt.Error,
 				Recoverable: evt.Recoverable,
+				FailureCode: evt.FailureCode,
 			},
 		}, nil
 
@@ -3221,6 +3302,7 @@ func (s *PartialSigsSentState) processEvent(ctx context.Context,
 				Reason:      evt.Reason,
 				Error:       evt.Error,
 				Recoverable: evt.Recoverable,
+				FailureCode: evt.FailureCode,
 			},
 		}, nil
 
@@ -4114,6 +4196,7 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 				Reason:      evt.Reason,
 				Error:       evt.Error,
 				Recoverable: evt.Recoverable,
+				FailureCode: evt.FailureCode,
 			},
 		}, nil
 

--- a/rpc/roundpb/round.pb.go
+++ b/rpc/roundpb/round.pb.go
@@ -21,6 +21,67 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// RoundFailureCode classifies why a round the client had already joined
+// failed, so the client can react programmatically instead of parsing the
+// human-readable reason string. New codes may be added over time; a client
+// MUST treat an unrecognized code as ROUND_FAILURE_UNKNOWN and fall back to
+// the reason string.
+type RoundFailureCode int32
+
+const (
+	// ROUND_FAILURE_UNKNOWN is the default, unclassified failure. Older
+	// servers that predate this field also leave it here. The client
+	// treats it as a generic recoverable failure and relies on the
+	// reason string.
+	RoundFailureCode_ROUND_FAILURE_UNKNOWN RoundFailureCode = 0
+	// ROUND_FAILURE_INSUFFICIENT_OPERATOR_FUNDS indicates the operator
+	// could not fund the round's commitment transaction from its own
+	// on-chain wallet. The client's inputs were never committed, so any
+	// forfeit-reserved inputs are released back to the live set. The
+	// client should terminally fail the originating job rather than
+	// auto-retry it into the same wall.
+	RoundFailureCode_ROUND_FAILURE_INSUFFICIENT_OPERATOR_FUNDS RoundFailureCode = 1
+)
+
+// Enum value maps for RoundFailureCode.
+var (
+	RoundFailureCode_name = map[int32]string{
+		0: "ROUND_FAILURE_UNKNOWN",
+		1: "ROUND_FAILURE_INSUFFICIENT_OPERATOR_FUNDS",
+	}
+	RoundFailureCode_value = map[string]int32{
+		"ROUND_FAILURE_UNKNOWN":                     0,
+		"ROUND_FAILURE_INSUFFICIENT_OPERATOR_FUNDS": 1,
+	}
+)
+
+func (x RoundFailureCode) Enum() *RoundFailureCode {
+	p := new(RoundFailureCode)
+	*p = x
+	return p
+}
+
+func (x RoundFailureCode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RoundFailureCode) Descriptor() protoreflect.EnumDescriptor {
+	return file_round_proto_enumTypes[0].Descriptor()
+}
+
+func (RoundFailureCode) Type() protoreflect.EnumType {
+	return &file_round_proto_enumTypes[0]
+}
+
+func (x RoundFailureCode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RoundFailureCode.Descriptor instead.
+func (RoundFailureCode) EnumDescriptor() ([]byte, []int) {
+	return file_round_proto_rawDescGZIP(), []int{0}
+}
+
 // QuoteReason classifies why a JoinRoundQuote failed to admit the
 // client's intent. When reject_reason != QUOTE_OK the quote's
 // vtxo_quotes / leave_quotes lists are empty and the client is
@@ -67,11 +128,11 @@ func (x QuoteReason) String() string {
 }
 
 func (QuoteReason) Descriptor() protoreflect.EnumDescriptor {
-	return file_round_proto_enumTypes[0].Descriptor()
+	return file_round_proto_enumTypes[1].Descriptor()
 }
 
 func (QuoteReason) Type() protoreflect.EnumType {
-	return &file_round_proto_enumTypes[0]
+	return &file_round_proto_enumTypes[1]
 }
 
 func (x QuoteReason) Number() protoreflect.EnumNumber {
@@ -80,7 +141,7 @@ func (x QuoteReason) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use QuoteReason.Descriptor instead.
 func (QuoteReason) EnumDescriptor() ([]byte, []int) {
-	return file_round_proto_rawDescGZIP(), []int{0}
+	return file_round_proto_rawDescGZIP(), []int{1}
 }
 
 // Outpoint identifies a transaction output by its transaction hash and output
@@ -944,7 +1005,11 @@ type ClientRoundFailedResp struct {
 	// round_id is the UUID of the round (16 bytes).
 	RoundId []byte `protobuf:"bytes,1,opt,name=round_id,json=roundId,proto3" json:"round_id,omitempty"`
 	// reason describes why the round failed.
-	Reason        string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	Reason string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	// failure_code classifies the failure so the client can react
+	// programmatically. Servers that predate this field, and failures
+	// that are not specifically classified, leave it ROUND_FAILURE_UNKNOWN.
+	FailureCode   RoundFailureCode `protobuf:"varint,3,opt,name=failure_code,json=failureCode,proto3,enum=round.v1.RoundFailureCode" json:"failure_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -991,6 +1056,13 @@ func (x *ClientRoundFailedResp) GetReason() string {
 		return x.Reason
 	}
 	return ""
+}
+
+func (x *ClientRoundFailedResp) GetFailureCode() RoundFailureCode {
+	if x != nil {
+		return x.FailureCode
+	}
+	return RoundFailureCode_ROUND_FAILURE_UNKNOWN
 }
 
 // ClientErrorResp sends an error message to a client.
@@ -2643,10 +2715,11 @@ const file_round_proto_rawDesc = "" +
 	"\bagg_sigs\x18\x02 \x03(\v2(.round.v1.ClientVTXOAggSigs.AggSigsEntryR\aaggSigs\x1a:\n" +
 	"\fAggSigsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"J\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"\x89\x01\n" +
 	"\x15ClientRoundFailedResp\x12\x19\n" +
 	"\bround_id\x18\x01 \x01(\fR\aroundId\x12\x16\n" +
-	"\x06reason\x18\x02 \x01(\tR\x06reason\".\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\x12=\n" +
+	"\ffailure_code\x18\x03 \x01(\x0e2\x1a.round.v1.RoundFailureCodeR\vfailureCode\".\n" +
 	"\x0fClientErrorResp\x12\x1b\n" +
 	"\terror_msg\x18\x01 \x01(\tR\berrorMsg\"\x85\x01\n" +
 	"\x0fBoardingRequest\x12.\n" +
@@ -2768,7 +2841,10 @@ const file_round_proto_rawDesc = "" +
 	"\x1cSubmitVTXOForfeitSigsRequest\x12\x19\n" +
 	"\bround_id\x18\x01 \x01(\fR\aroundId\x127\n" +
 	"\vforfeit_txs\x18\x02 \x03(\v2\x16.round.v1.ForfeitTxSigR\n" +
-	"forfeitTxs*V\n" +
+	"forfeitTxs*\\\n" +
+	"\x10RoundFailureCode\x12\x19\n" +
+	"\x15ROUND_FAILURE_UNKNOWN\x10\x00\x12-\n" +
+	")ROUND_FAILURE_INSUFFICIENT_OPERATOR_FUNDS\x10\x01*V\n" +
 	"\vQuoteReason\x12\f\n" +
 	"\bQUOTE_OK\x10\x00\x12\x19\n" +
 	"\x15INSUFFICIENT_RESIDUAL\x10\x01\x12\x1e\n" +
@@ -2794,113 +2870,115 @@ func file_round_proto_rawDescGZIP() []byte {
 	return file_round_proto_rawDescData
 }
 
-var file_round_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_round_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_round_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
 var file_round_proto_goTypes = []any{
-	(QuoteReason)(0),                     // 0: round.v1.QuoteReason
-	(*Outpoint)(nil),                     // 1: round.v1.Outpoint
-	(*TxOut)(nil),                        // 2: round.v1.TxOut
-	(*TreeNode)(nil),                     // 3: round.v1.TreeNode
-	(*VTXOTree)(nil),                     // 4: round.v1.VTXOTree
-	(*ConnectorLeafInfo)(nil),            // 5: round.v1.ConnectorLeafInfo
-	(*ClientConnectorLeafInfo)(nil),      // 6: round.v1.ClientConnectorLeafInfo
-	(*ClientSuccessResp)(nil),            // 7: round.v1.ClientSuccessResp
-	(*ClientBatchInfo)(nil),              // 8: round.v1.ClientBatchInfo
-	(*ClientAwaitingInputSigsResp)(nil),  // 9: round.v1.ClientAwaitingInputSigsResp
-	(*ClientVTXOAggNonces)(nil),          // 10: round.v1.ClientVTXOAggNonces
-	(*ClientVTXOAggSigs)(nil),            // 11: round.v1.ClientVTXOAggSigs
-	(*ClientRoundFailedResp)(nil),        // 12: round.v1.ClientRoundFailedResp
-	(*ClientErrorResp)(nil),              // 13: round.v1.ClientErrorResp
-	(*BoardingRequest)(nil),              // 14: round.v1.BoardingRequest
-	(*VTXORequest)(nil),                  // 15: round.v1.VTXORequest
-	(*ForfeitRequest)(nil),               // 16: round.v1.ForfeitRequest
-	(*LeaveRequest)(nil),                 // 17: round.v1.LeaveRequest
-	(*JoinRoundAuth)(nil),                // 18: round.v1.JoinRoundAuth
-	(*JoinRoundRequest)(nil),             // 19: round.v1.JoinRoundRequest
-	(*FeeBreakdown)(nil),                 // 20: round.v1.FeeBreakdown
-	(*VTXOQuote)(nil),                    // 21: round.v1.VTXOQuote
-	(*LeaveQuote)(nil),                   // 22: round.v1.LeaveQuote
-	(*JoinRoundQuote)(nil),               // 23: round.v1.JoinRoundQuote
-	(*JoinRoundAccept)(nil),              // 24: round.v1.JoinRoundAccept
-	(*JoinRoundReject)(nil),              // 25: round.v1.JoinRoundReject
-	(*SubmitNoncesRequest)(nil),          // 26: round.v1.SubmitNoncesRequest
-	(*SignerNonces)(nil),                 // 27: round.v1.SignerNonces
-	(*SubmitPartialSigRequest)(nil),      // 28: round.v1.SubmitPartialSigRequest
-	(*SignerPartialSigs)(nil),            // 29: round.v1.SignerPartialSigs
-	(*BoardingInputSignature)(nil),       // 30: round.v1.BoardingInputSignature
-	(*SubmitForfeitSigRequest)(nil),      // 31: round.v1.SubmitForfeitSigRequest
-	(*ForfeitParticipantSig)(nil),        // 32: round.v1.ForfeitParticipantSig
-	(*ForfeitTxSig)(nil),                 // 33: round.v1.ForfeitTxSig
-	(*SubmitVTXOForfeitSigsRequest)(nil), // 34: round.v1.SubmitVTXOForfeitSigsRequest
-	nil,                                  // 35: round.v1.TreeNode.ChildrenEntry
-	nil,                                  // 36: round.v1.ClientBatchInfo.VtxoTreePathsEntry
-	nil,                                  // 37: round.v1.ClientBatchInfo.ConnectorLeafMapEntry
-	nil,                                  // 38: round.v1.ClientVTXOAggNonces.AggNoncesEntry
-	nil,                                  // 39: round.v1.ClientVTXOAggSigs.AggSigsEntry
-	nil,                                  // 40: round.v1.SubmitNoncesRequest.NoncesEntry
-	nil,                                  // 41: round.v1.SignerNonces.TxNoncesEntry
-	nil,                                  // 42: round.v1.SubmitPartialSigRequest.SignaturesEntry
-	nil,                                  // 43: round.v1.SignerPartialSigs.TxSigsEntry
+	(RoundFailureCode)(0),                // 0: round.v1.RoundFailureCode
+	(QuoteReason)(0),                     // 1: round.v1.QuoteReason
+	(*Outpoint)(nil),                     // 2: round.v1.Outpoint
+	(*TxOut)(nil),                        // 3: round.v1.TxOut
+	(*TreeNode)(nil),                     // 4: round.v1.TreeNode
+	(*VTXOTree)(nil),                     // 5: round.v1.VTXOTree
+	(*ConnectorLeafInfo)(nil),            // 6: round.v1.ConnectorLeafInfo
+	(*ClientConnectorLeafInfo)(nil),      // 7: round.v1.ClientConnectorLeafInfo
+	(*ClientSuccessResp)(nil),            // 8: round.v1.ClientSuccessResp
+	(*ClientBatchInfo)(nil),              // 9: round.v1.ClientBatchInfo
+	(*ClientAwaitingInputSigsResp)(nil),  // 10: round.v1.ClientAwaitingInputSigsResp
+	(*ClientVTXOAggNonces)(nil),          // 11: round.v1.ClientVTXOAggNonces
+	(*ClientVTXOAggSigs)(nil),            // 12: round.v1.ClientVTXOAggSigs
+	(*ClientRoundFailedResp)(nil),        // 13: round.v1.ClientRoundFailedResp
+	(*ClientErrorResp)(nil),              // 14: round.v1.ClientErrorResp
+	(*BoardingRequest)(nil),              // 15: round.v1.BoardingRequest
+	(*VTXORequest)(nil),                  // 16: round.v1.VTXORequest
+	(*ForfeitRequest)(nil),               // 17: round.v1.ForfeitRequest
+	(*LeaveRequest)(nil),                 // 18: round.v1.LeaveRequest
+	(*JoinRoundAuth)(nil),                // 19: round.v1.JoinRoundAuth
+	(*JoinRoundRequest)(nil),             // 20: round.v1.JoinRoundRequest
+	(*FeeBreakdown)(nil),                 // 21: round.v1.FeeBreakdown
+	(*VTXOQuote)(nil),                    // 22: round.v1.VTXOQuote
+	(*LeaveQuote)(nil),                   // 23: round.v1.LeaveQuote
+	(*JoinRoundQuote)(nil),               // 24: round.v1.JoinRoundQuote
+	(*JoinRoundAccept)(nil),              // 25: round.v1.JoinRoundAccept
+	(*JoinRoundReject)(nil),              // 26: round.v1.JoinRoundReject
+	(*SubmitNoncesRequest)(nil),          // 27: round.v1.SubmitNoncesRequest
+	(*SignerNonces)(nil),                 // 28: round.v1.SignerNonces
+	(*SubmitPartialSigRequest)(nil),      // 29: round.v1.SubmitPartialSigRequest
+	(*SignerPartialSigs)(nil),            // 30: round.v1.SignerPartialSigs
+	(*BoardingInputSignature)(nil),       // 31: round.v1.BoardingInputSignature
+	(*SubmitForfeitSigRequest)(nil),      // 32: round.v1.SubmitForfeitSigRequest
+	(*ForfeitParticipantSig)(nil),        // 33: round.v1.ForfeitParticipantSig
+	(*ForfeitTxSig)(nil),                 // 34: round.v1.ForfeitTxSig
+	(*SubmitVTXOForfeitSigsRequest)(nil), // 35: round.v1.SubmitVTXOForfeitSigsRequest
+	nil,                                  // 36: round.v1.TreeNode.ChildrenEntry
+	nil,                                  // 37: round.v1.ClientBatchInfo.VtxoTreePathsEntry
+	nil,                                  // 38: round.v1.ClientBatchInfo.ConnectorLeafMapEntry
+	nil,                                  // 39: round.v1.ClientVTXOAggNonces.AggNoncesEntry
+	nil,                                  // 40: round.v1.ClientVTXOAggSigs.AggSigsEntry
+	nil,                                  // 41: round.v1.SubmitNoncesRequest.NoncesEntry
+	nil,                                  // 42: round.v1.SignerNonces.TxNoncesEntry
+	nil,                                  // 43: round.v1.SubmitPartialSigRequest.SignaturesEntry
+	nil,                                  // 44: round.v1.SignerPartialSigs.TxSigsEntry
 }
 var file_round_proto_depIdxs = []int32{
-	1,  // 0: round.v1.TreeNode.input:type_name -> round.v1.Outpoint
-	2,  // 1: round.v1.TreeNode.outputs:type_name -> round.v1.TxOut
-	35, // 2: round.v1.TreeNode.children:type_name -> round.v1.TreeNode.ChildrenEntry
-	3,  // 3: round.v1.VTXOTree.nodes:type_name -> round.v1.TreeNode
-	1,  // 4: round.v1.VTXOTree.batch_outpoint:type_name -> round.v1.Outpoint
-	2,  // 5: round.v1.VTXOTree.batch_output:type_name -> round.v1.TxOut
-	1,  // 6: round.v1.ConnectorLeafInfo.leaf_outpoint:type_name -> round.v1.Outpoint
-	2,  // 7: round.v1.ConnectorLeafInfo.leaf_output:type_name -> round.v1.TxOut
-	1,  // 8: round.v1.ClientConnectorLeafInfo.connector_outpoint:type_name -> round.v1.Outpoint
-	1,  // 9: round.v1.ClientSuccessResp.accepted_boarding_outpoints:type_name -> round.v1.Outpoint
-	1,  // 10: round.v1.ClientSuccessResp.accepted_vtxo_outpoints:type_name -> round.v1.Outpoint
-	36, // 11: round.v1.ClientBatchInfo.vtxo_tree_paths:type_name -> round.v1.ClientBatchInfo.VtxoTreePathsEntry
-	37, // 12: round.v1.ClientBatchInfo.connector_leaf_map:type_name -> round.v1.ClientBatchInfo.ConnectorLeafMapEntry
-	38, // 13: round.v1.ClientVTXOAggNonces.agg_nonces:type_name -> round.v1.ClientVTXOAggNonces.AggNoncesEntry
-	39, // 14: round.v1.ClientVTXOAggSigs.agg_sigs:type_name -> round.v1.ClientVTXOAggSigs.AggSigsEntry
-	1,  // 15: round.v1.BoardingRequest.outpoint:type_name -> round.v1.Outpoint
-	1,  // 16: round.v1.ForfeitRequest.vtxo_outpoint:type_name -> round.v1.Outpoint
-	14, // 17: round.v1.JoinRoundRequest.boarding_requests:type_name -> round.v1.BoardingRequest
-	15, // 18: round.v1.JoinRoundRequest.vtxo_requests:type_name -> round.v1.VTXORequest
-	16, // 19: round.v1.JoinRoundRequest.forfeit_requests:type_name -> round.v1.ForfeitRequest
-	17, // 20: round.v1.JoinRoundRequest.leave_requests:type_name -> round.v1.LeaveRequest
-	18, // 21: round.v1.JoinRoundRequest.auth:type_name -> round.v1.JoinRoundAuth
-	21, // 22: round.v1.JoinRoundQuote.vtxo_quotes:type_name -> round.v1.VTXOQuote
-	22, // 23: round.v1.JoinRoundQuote.leave_quotes:type_name -> round.v1.LeaveQuote
-	20, // 24: round.v1.JoinRoundQuote.breakdown:type_name -> round.v1.FeeBreakdown
-	0,  // 25: round.v1.JoinRoundQuote.reject_reason:type_name -> round.v1.QuoteReason
-	40, // 26: round.v1.SubmitNoncesRequest.nonces:type_name -> round.v1.SubmitNoncesRequest.NoncesEntry
-	41, // 27: round.v1.SignerNonces.tx_nonces:type_name -> round.v1.SignerNonces.TxNoncesEntry
-	42, // 28: round.v1.SubmitPartialSigRequest.signatures:type_name -> round.v1.SubmitPartialSigRequest.SignaturesEntry
-	43, // 29: round.v1.SignerPartialSigs.tx_sigs:type_name -> round.v1.SignerPartialSigs.TxSigsEntry
-	1,  // 30: round.v1.BoardingInputSignature.outpoint:type_name -> round.v1.Outpoint
-	30, // 31: round.v1.SubmitForfeitSigRequest.signatures:type_name -> round.v1.BoardingInputSignature
-	1,  // 32: round.v1.ForfeitTxSig.vtxo_outpoint:type_name -> round.v1.Outpoint
-	32, // 33: round.v1.ForfeitTxSig.participant_sigs:type_name -> round.v1.ForfeitParticipantSig
-	33, // 34: round.v1.SubmitVTXOForfeitSigsRequest.forfeit_txs:type_name -> round.v1.ForfeitTxSig
-	4,  // 35: round.v1.ClientBatchInfo.VtxoTreePathsEntry.value:type_name -> round.v1.VTXOTree
-	5,  // 36: round.v1.ClientBatchInfo.ConnectorLeafMapEntry.value:type_name -> round.v1.ConnectorLeafInfo
-	27, // 37: round.v1.SubmitNoncesRequest.NoncesEntry.value:type_name -> round.v1.SignerNonces
-	29, // 38: round.v1.SubmitPartialSigRequest.SignaturesEntry.value:type_name -> round.v1.SignerPartialSigs
-	19, // 39: round.v1.RoundService.JoinRound:input_type -> round.v1.JoinRoundRequest
-	24, // 40: round.v1.RoundService.AcceptQuote:input_type -> round.v1.JoinRoundAccept
-	25, // 41: round.v1.RoundService.RejectQuote:input_type -> round.v1.JoinRoundReject
-	26, // 42: round.v1.RoundService.SubmitNonces:input_type -> round.v1.SubmitNoncesRequest
-	28, // 43: round.v1.RoundService.SubmitPartialSigs:input_type -> round.v1.SubmitPartialSigRequest
-	31, // 44: round.v1.RoundService.SubmitForfeitSigs:input_type -> round.v1.SubmitForfeitSigRequest
-	34, // 45: round.v1.RoundService.SubmitVTXOForfeitSigs:input_type -> round.v1.SubmitVTXOForfeitSigsRequest
-	7,  // 46: round.v1.RoundService.JoinRound:output_type -> round.v1.ClientSuccessResp
-	7,  // 47: round.v1.RoundService.AcceptQuote:output_type -> round.v1.ClientSuccessResp
-	7,  // 48: round.v1.RoundService.RejectQuote:output_type -> round.v1.ClientSuccessResp
-	10, // 49: round.v1.RoundService.SubmitNonces:output_type -> round.v1.ClientVTXOAggNonces
-	11, // 50: round.v1.RoundService.SubmitPartialSigs:output_type -> round.v1.ClientVTXOAggSigs
-	9,  // 51: round.v1.RoundService.SubmitForfeitSigs:output_type -> round.v1.ClientAwaitingInputSigsResp
-	7,  // 52: round.v1.RoundService.SubmitVTXOForfeitSigs:output_type -> round.v1.ClientSuccessResp
-	46, // [46:53] is the sub-list for method output_type
-	39, // [39:46] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	39, // [39:39] is the sub-list for extension extendee
-	0,  // [0:39] is the sub-list for field type_name
+	2,  // 0: round.v1.TreeNode.input:type_name -> round.v1.Outpoint
+	3,  // 1: round.v1.TreeNode.outputs:type_name -> round.v1.TxOut
+	36, // 2: round.v1.TreeNode.children:type_name -> round.v1.TreeNode.ChildrenEntry
+	4,  // 3: round.v1.VTXOTree.nodes:type_name -> round.v1.TreeNode
+	2,  // 4: round.v1.VTXOTree.batch_outpoint:type_name -> round.v1.Outpoint
+	3,  // 5: round.v1.VTXOTree.batch_output:type_name -> round.v1.TxOut
+	2,  // 6: round.v1.ConnectorLeafInfo.leaf_outpoint:type_name -> round.v1.Outpoint
+	3,  // 7: round.v1.ConnectorLeafInfo.leaf_output:type_name -> round.v1.TxOut
+	2,  // 8: round.v1.ClientConnectorLeafInfo.connector_outpoint:type_name -> round.v1.Outpoint
+	2,  // 9: round.v1.ClientSuccessResp.accepted_boarding_outpoints:type_name -> round.v1.Outpoint
+	2,  // 10: round.v1.ClientSuccessResp.accepted_vtxo_outpoints:type_name -> round.v1.Outpoint
+	37, // 11: round.v1.ClientBatchInfo.vtxo_tree_paths:type_name -> round.v1.ClientBatchInfo.VtxoTreePathsEntry
+	38, // 12: round.v1.ClientBatchInfo.connector_leaf_map:type_name -> round.v1.ClientBatchInfo.ConnectorLeafMapEntry
+	39, // 13: round.v1.ClientVTXOAggNonces.agg_nonces:type_name -> round.v1.ClientVTXOAggNonces.AggNoncesEntry
+	40, // 14: round.v1.ClientVTXOAggSigs.agg_sigs:type_name -> round.v1.ClientVTXOAggSigs.AggSigsEntry
+	0,  // 15: round.v1.ClientRoundFailedResp.failure_code:type_name -> round.v1.RoundFailureCode
+	2,  // 16: round.v1.BoardingRequest.outpoint:type_name -> round.v1.Outpoint
+	2,  // 17: round.v1.ForfeitRequest.vtxo_outpoint:type_name -> round.v1.Outpoint
+	15, // 18: round.v1.JoinRoundRequest.boarding_requests:type_name -> round.v1.BoardingRequest
+	16, // 19: round.v1.JoinRoundRequest.vtxo_requests:type_name -> round.v1.VTXORequest
+	17, // 20: round.v1.JoinRoundRequest.forfeit_requests:type_name -> round.v1.ForfeitRequest
+	18, // 21: round.v1.JoinRoundRequest.leave_requests:type_name -> round.v1.LeaveRequest
+	19, // 22: round.v1.JoinRoundRequest.auth:type_name -> round.v1.JoinRoundAuth
+	22, // 23: round.v1.JoinRoundQuote.vtxo_quotes:type_name -> round.v1.VTXOQuote
+	23, // 24: round.v1.JoinRoundQuote.leave_quotes:type_name -> round.v1.LeaveQuote
+	21, // 25: round.v1.JoinRoundQuote.breakdown:type_name -> round.v1.FeeBreakdown
+	1,  // 26: round.v1.JoinRoundQuote.reject_reason:type_name -> round.v1.QuoteReason
+	41, // 27: round.v1.SubmitNoncesRequest.nonces:type_name -> round.v1.SubmitNoncesRequest.NoncesEntry
+	42, // 28: round.v1.SignerNonces.tx_nonces:type_name -> round.v1.SignerNonces.TxNoncesEntry
+	43, // 29: round.v1.SubmitPartialSigRequest.signatures:type_name -> round.v1.SubmitPartialSigRequest.SignaturesEntry
+	44, // 30: round.v1.SignerPartialSigs.tx_sigs:type_name -> round.v1.SignerPartialSigs.TxSigsEntry
+	2,  // 31: round.v1.BoardingInputSignature.outpoint:type_name -> round.v1.Outpoint
+	31, // 32: round.v1.SubmitForfeitSigRequest.signatures:type_name -> round.v1.BoardingInputSignature
+	2,  // 33: round.v1.ForfeitTxSig.vtxo_outpoint:type_name -> round.v1.Outpoint
+	33, // 34: round.v1.ForfeitTxSig.participant_sigs:type_name -> round.v1.ForfeitParticipantSig
+	34, // 35: round.v1.SubmitVTXOForfeitSigsRequest.forfeit_txs:type_name -> round.v1.ForfeitTxSig
+	5,  // 36: round.v1.ClientBatchInfo.VtxoTreePathsEntry.value:type_name -> round.v1.VTXOTree
+	6,  // 37: round.v1.ClientBatchInfo.ConnectorLeafMapEntry.value:type_name -> round.v1.ConnectorLeafInfo
+	28, // 38: round.v1.SubmitNoncesRequest.NoncesEntry.value:type_name -> round.v1.SignerNonces
+	30, // 39: round.v1.SubmitPartialSigRequest.SignaturesEntry.value:type_name -> round.v1.SignerPartialSigs
+	20, // 40: round.v1.RoundService.JoinRound:input_type -> round.v1.JoinRoundRequest
+	25, // 41: round.v1.RoundService.AcceptQuote:input_type -> round.v1.JoinRoundAccept
+	26, // 42: round.v1.RoundService.RejectQuote:input_type -> round.v1.JoinRoundReject
+	27, // 43: round.v1.RoundService.SubmitNonces:input_type -> round.v1.SubmitNoncesRequest
+	29, // 44: round.v1.RoundService.SubmitPartialSigs:input_type -> round.v1.SubmitPartialSigRequest
+	32, // 45: round.v1.RoundService.SubmitForfeitSigs:input_type -> round.v1.SubmitForfeitSigRequest
+	35, // 46: round.v1.RoundService.SubmitVTXOForfeitSigs:input_type -> round.v1.SubmitVTXOForfeitSigsRequest
+	8,  // 47: round.v1.RoundService.JoinRound:output_type -> round.v1.ClientSuccessResp
+	8,  // 48: round.v1.RoundService.AcceptQuote:output_type -> round.v1.ClientSuccessResp
+	8,  // 49: round.v1.RoundService.RejectQuote:output_type -> round.v1.ClientSuccessResp
+	11, // 50: round.v1.RoundService.SubmitNonces:output_type -> round.v1.ClientVTXOAggNonces
+	12, // 51: round.v1.RoundService.SubmitPartialSigs:output_type -> round.v1.ClientVTXOAggSigs
+	10, // 52: round.v1.RoundService.SubmitForfeitSigs:output_type -> round.v1.ClientAwaitingInputSigsResp
+	8,  // 53: round.v1.RoundService.SubmitVTXOForfeitSigs:output_type -> round.v1.ClientSuccessResp
+	47, // [47:54] is the sub-list for method output_type
+	40, // [40:47] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_round_proto_init() }
@@ -2913,7 +2991,7 @@ func file_round_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_round_proto_rawDesc), len(file_round_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   43,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/rpc/roundpb/round.proto
+++ b/rpc/roundpb/round.proto
@@ -242,6 +242,27 @@ message ClientVTXOAggSigs {
     map<string, bytes> agg_sigs = 2;
 }
 
+// RoundFailureCode classifies why a round the client had already joined
+// failed, so the client can react programmatically instead of parsing the
+// human-readable reason string. New codes may be added over time; a client
+// MUST treat an unrecognized code as ROUND_FAILURE_UNKNOWN and fall back to
+// the reason string.
+enum RoundFailureCode {
+    // ROUND_FAILURE_UNKNOWN is the default, unclassified failure. Older
+    // servers that predate this field also leave it here. The client
+    // treats it as a generic recoverable failure and relies on the
+    // reason string.
+    ROUND_FAILURE_UNKNOWN = 0;
+
+    // ROUND_FAILURE_INSUFFICIENT_OPERATOR_FUNDS indicates the operator
+    // could not fund the round's commitment transaction from its own
+    // on-chain wallet. The client's inputs were never committed, so any
+    // forfeit-reserved inputs are released back to the live set. The
+    // client should terminally fail the originating job rather than
+    // auto-retry it into the same wall.
+    ROUND_FAILURE_INSUFFICIENT_OPERATOR_FUNDS = 1;
+}
+
 // ClientRoundFailedResp notifies a client that the round they joined has
 // failed.
 message ClientRoundFailedResp {
@@ -250,6 +271,11 @@ message ClientRoundFailedResp {
 
     // reason describes why the round failed.
     string reason = 2;
+
+    // failure_code classifies the failure so the client can react
+    // programmatically. Servers that predate this field, and failures
+    // that are not specifically classified, leave it ROUND_FAILURE_UNKNOWN.
+    RoundFailureCode failure_code = 3;
 }
 
 // ClientErrorResp sends an error message to a client.

--- a/systest/send_onchain_strand_test.go
+++ b/systest/send_onchain_strand_test.go
@@ -1,0 +1,123 @@
+//go:build systest
+
+package systest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/darepo-client/daemonrpc"
+	"github.com/lightninglabs/darepo-client/darepod"
+	"github.com/lightninglabs/darepo-client/rpc/roundpb"
+	"github.com/stretchr/testify/require"
+)
+
+// insufficientOperatorFundsCode aliases the verbose wire enum value so the
+// arming below stays within the line-length limit.
+const insufficientOperatorFundsCode = roundpb.
+	RoundFailureCode_ROUND_FAILURE_INSUFFICIENT_OPERATOR_FUNDS
+
+// TestSendOnChainInsufficientOperatorFundsRetiresJob is the end-to-end
+// reproduction of issue #889 on the cooperative send path. A send --onchain
+// --sweep-all reserves the client's VTXO and registers a round, but the
+// operator admits the registration and then fails the round because it cannot
+// fund the commitment transaction. The client must classify that failure,
+// return the VTXO to LIVE, and terminally retire the send intent so it never
+// replays into the broke operator on restart.
+//
+// This exercises the exact path the Fable review's Finding 1 broke: the client
+// sits in IntentSentState when the terminal ClientRoundFailedResp arrives, and
+// that handler builds its own failure outbox, so the release-idempotency guard
+// in releaseForfeitsOnFailure used to early-return before the terminal-drop
+// block. The restart-and-assert-no-replay check is what distinguishes a durably
+// retired job from one that merely released its VTXO but stayed pending: a
+// swallowed terminal drop would replay the send on restart, sending a second
+// JoinRound.
+func TestSendOnChainInsufficientOperatorFundsRetiresJob(t *testing.T) {
+	ParallelN(t)
+
+	// EagerRoundJoin drives the send straight into IntentSentState,
+	// matching the wallet/SDK hosts where #889 was observed.
+	fixture := newDirectedSendFixture(t, func(c *darepod.Config) {
+		c.EagerRoundJoin = true
+	})
+
+	// Arm the operator to admit the registration and then immediately fail
+	// the round with the typed insufficient-operator-funds code.
+	fixture.mailboxServer.setFailRoundOnJoin(&roundpb.ClientRoundFailedResp{
+		Reason:      "fund psbt: insufficient funds",
+		FailureCode: insufficientOperatorFundsCode,
+	})
+
+	// The seeded VTXO starts LIVE and is the whole spendable balance.
+	startVTXOs := listAllVTXOs(t, fixture.client)
+	require.Len(t, startVTXOs, 1)
+	require.Equal(
+		t, daemonrpc.VTXOStatus_VTXO_STATUS_LIVE, startVTXOs[0].Status,
+	)
+
+	// A standard P2TR destination script; only its script class matters to
+	// the RPC's leave-script guard.
+	destPkScript := append([]byte{0x51, 0x20}, make([]byte, 32)...)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	// Issue the cooperative sweep-all send. It persists the send intent,
+	// reserves the VTXO, and registers the round.
+	sendResp, err := fixture.client.SendOnChain(
+		ctx, &daemonrpc.SendOnChainRequest{
+			Destination: &daemonrpc.LeaveDestination{
+				Target: &daemonrpc.LeaveDestination_PkScript{
+					PkScript: destPkScript,
+				},
+			},
+			Amount: &daemonrpc.SendOnChainRequest_SweepAll{
+				SweepAll: true,
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "submitted", sendResp.Status)
+
+	// The operator failed the round, so the client must return the VTXO to
+	// LIVE rather than strand it in pending-forfeit.
+	requireVTXOStatusEventually(
+		t, fixture.client, fixture.seededOutpoint,
+		daemonrpc.VTXOStatus_VTXO_STATUS_LIVE, 30*time.Second,
+	)
+	require.Equal(
+		t, testSeededAmountSat, vtxoBalanceSat(t, fixture.client),
+		"spendable balance must be restored after the failed send",
+	)
+
+	// Exactly one JoinRound was sent for the now-dead send.
+	require.Eventually(t, func() bool {
+		return len(fixture.mailboxServer.joinRoundRequests()) == 1
+	}, 5*time.Second, 100*time.Millisecond,
+		"the send should have registered exactly one round")
+
+	// The heart of the fix: the send intent is terminally retired, not left
+	// pending. Restart the daemon, which replays pending intents on
+	// startup. A durably failed intent is skipped, so no second JoinRound
+	// is sent, whereas a swallowed terminal drop would replay it here.
+	fixture.restart()
+	waitForDaemonReady(t, fixture.client)
+
+	// Disarm the failure so that a wrongly-replayed send would proceed
+	// (and register a second JoinRound) rather than re-fail, making any
+	// replay unambiguous.
+	fixture.mailboxServer.setFailRoundOnJoin(nil)
+
+	require.Never(t, func() bool {
+		return len(fixture.mailboxServer.joinRoundRequests()) > 1
+	}, 5*time.Second, 200*time.Millisecond,
+		"a terminally failed send must not replay on restart")
+
+	// The balance is still the full seeded VTXO after the restart, which
+	// also implies the VTXO stayed LIVE (a stranded forfeit would zero it).
+	require.Equal(
+		t, testSeededAmountSat, vtxoBalanceSat(t, fixture.client),
+	)
+}

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -79,6 +79,12 @@ type fakeMailboxServer struct {
 	oorSubmitReqs   []*oorpb.SubmitPackageRequest
 	oorSubmitEnvs   []*mailboxpb.Envelope
 	inboxSignalChan chan struct{}
+
+	// failRoundOnJoin, when set, makes the operator push this
+	// ClientRoundFailedResp back to the client immediately on every
+	// JoinRound, simulating an operator that admits the registration but
+	// cannot seal the round (e.g. it cannot fund the commitment tx).
+	failRoundOnJoin *roundpb.ClientRoundFailedResp
 }
 
 // newFakeMailboxServer constructs a fake mailbox edge with the given operator
@@ -249,7 +255,12 @@ func (s *fakeMailboxServer) handleOperatorEnvelope(ctx context.Context,
 
 	case env.Rpc.Service == roundpb.ServiceName &&
 		env.Rpc.Method == roundpb.MethodJoinRound:
-		return s.recordJoinRound(env)
+
+		if err := s.recordJoinRound(env); err != nil {
+			return err
+		}
+
+		return s.maybePushRoundFailed(env)
 
 	case env.Rpc.Service == oorpb.ServiceName &&
 		env.Rpc.Method == oorpb.MethodSubmitPackage:
@@ -335,6 +346,61 @@ func (s *fakeMailboxServer) recordJoinRound(env *mailboxpb.Envelope) error {
 
 	s.joinRoundReqs = append(s.joinRoundReqs, &req)
 	s.joinRoundEnvs = append(s.joinRoundEnvs, env)
+
+	return nil
+}
+
+// setFailRoundOnJoin arms the operator to push the given ClientRoundFailedResp
+// back to the client on every subsequent JoinRound. Pass nil to disarm.
+func (s *fakeMailboxServer) setFailRoundOnJoin(
+	resp *roundpb.ClientRoundFailedResp) {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.failRoundOnJoin = resp
+}
+
+// maybePushRoundFailed pushes the armed ClientRoundFailedResp back to the
+// client that just sent a JoinRound, as a KIND_EVENT round-failed push routed
+// to the daemon's round mailbox (the JoinRound envelope's sender). It is a
+// no-op when the operator is not armed to fail the round.
+func (s *fakeMailboxServer) maybePushRoundFailed(
+	joinEnv *mailboxpb.Envelope) error {
+
+	s.mu.Lock()
+	resp := s.failRoundOnJoin
+	s.mu.Unlock()
+
+	if resp == nil {
+		return nil
+	}
+
+	body, err := anypb.New(resp)
+	if err != nil {
+		return fmt.Errorf("wrap round failed: %w", err)
+	}
+
+	s.enqueueEnvelope(&mailboxpb.Envelope{
+		// Echo the JoinRound's protocol versions rather than hardcoding
+		// them: the daemon's inbound validation drops any envelope
+		// whose versions don't match its runtime binding, so copying
+		// the versions off the daemon's own outbound envelope
+		// guarantees the push survives that check. Hardcoding here
+		// would silently drop the push and hang the test.
+		ProtocolVersion:    joinEnv.ProtocolVersion,
+		ArkProtocolVersion: joinEnv.ArkProtocolVersion,
+		Sender:             s.operatorMailbox,
+		Recipient:          joinEnv.Sender,
+		CreatedAtUnixMs:    time.Now().UnixMilli(),
+		Body:               body,
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:    mailboxpb.RpcMeta_KIND_EVENT,
+			Service: roundpb.ServiceName,
+			Method:  roundpb.MethodRoundFailed,
+			ReplyTo: s.operatorMailbox,
+		},
+	})
 
 	return nil
 }


### PR DESCRIPTION
In this PR, we fix the client half of #889: a `send --onchain --sweep-all` (or any cooperative consumption) that hangs forever as "pending" while the balance comes back, and re-tries into the same wall on every restart.

The root cause turned out to be operator-side. On signet and testnet the operator's lnd wallet was empty, so arkd's FundPsbt failed for every commitment tx. But the client couldn't tell that apart from a transient hiccup. It got an opaque reason string, treated the failure as recoverable, released its forfeit (so the VTXO went back to LIVE, which is the "balance returned" the reporter saw), but left the persisted send intent in place. On the next restart the intent replayer re-submitted it into the same broke operator, and the activity entry sat pending indefinitely. This is not the vHTLC/unroll path from #909: that repro was an OOR coin, this is a plain cooperative round.

## The typed failure code

We add a native `round.RoundFailureCode` enum, carried on `BoardingFailed` and `ClientFailedState`, and mapped to and from the wire `roundpb.RoundFailureCode` only at the RPC boundary (`FromProto`/`ToProto`) so the FSM never traffics in proto types. The shared `ClientRoundFailedResp` proto grows a `failure_code` field. An older server, or a failure we don't classify, leaves it `ROUND_FAILURE_UNKNOWN`, and the client falls back to the reason string exactly as before.

## Retiring the dead send job

The forfeit-release chokepoint does the work. `releaseForfeitsOnFailure` already runs for the pre-signing states (where an operator-funding failure lands), already detects the transition into `ClientFailedState`, and already holds the forfeit set, which is exactly the originating job's pending-intent anchors. When the failure code is terminal-for-job, it emits a `TerminalJobFailedNotification` carrying those outpoints alongside the existing forfeit release, so the job is failed in the same breath its inputs return to the live set. The round actor hands that to the store's `FailForfeitIntents`.

On the db side we mark the intent failed rather than delete it (migration `000011` adds a status, reason, and typed code to the pending-intents header). Marking both stops the replay, since the replay query now selects only `pending` rows, and leaves a durable, anchor-correlatable record. A generic or unknown failure is untouched: it releases the forfeit and leaves the intent eligible for replay, which is right when the operator is only briefly down.

Since failed rows are retained while successful ones are deleted on adoption, the outbox accumulates only failures over time, so `000011` also adds a composite `(kind, status)` index to keep the replayer's startup scan off that pile.

## Re-arming a retried send

`NewPendingIntentID` is deterministic over the consumed inputs and payload, so a user retrying the exact same failed send reuses the same `intent_id` and upserts straight onto the retained `failed` row. `UpsertPendingIntentHeader` now resets `status`/`failure_reason`/`failure_code` on conflict, so the retry re-arms as `pending`. Without that reset, a retry persisted but not yet adopted by a round would be silently dropped by the new `pending`-only replay filter if the daemon crashed in that window, which is the same "hangs forever" failure mode one hop removed. Thanks to the Codex and Gemini review passes for catching this and the index.

## Follow-up

Surfacing the activity entry as FAILED, rather than dropping it back to pending, is deliberately left to the C2 activity-correlation work. The cooperative-leave EXIT is a runtime-local row that only the SDK runtime can project with fidelity, and it has no daemon read for a failed cooperative send yet. The durable failure record this PR lands is what that follow-up will read.

## Testing

Unit coverage for the code mapping in both directions (including an unrecognized newer-server code degrading to unknown), the release chokepoint emitting the terminal drop only for a classified failure, the store marking the intent failed and excluding it from replay while keeping the record, and a regression that fails an intent, re-persists the identical one, and asserts it replays again with the failure fields cleared. The server-side end-to-end regression lives in the darepo PR.

See each commit message for the detailed reasoning w.r.t the incremental changes.
