### PR TITLE
build: bump version to v0.1.0-rc2

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -15,11 +15,11 @@ const (
 	AppMinor uint = 1
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 99
+	AppPatch uint = 0
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.
-	AppPreRelease = ""
+	AppPreRelease = "rc2"
 )
 
 var (


### PR DESCRIPTION
Release branch was reset to main's current tip. Bump to v0.1.0-rc2 (rc1 is already tagged).