### PR TITLE
round: Parallelize large autoboard signing

### DIFF
--- a/cmd/darepod/main.go
+++ b/cmd/darepod/main.go
@@ -184,6 +184,14 @@ func newRootCmd() *cobra.Command {
 			"seal-time quote; must be positive",
 	)
 
+	// Bound concurrent MuSig2 work. Zero lets the daemon choose a safe
+	// backend-aware default; one restores serial signing.
+	f.Int(
+		"signingworkers", cfg.SigningWorkers, "maximum VTXO "+
+			"signing sessions processed in parallel; zero "+
+			"selects a wallet-backend default",
+	)
+
 	// EagerRoundJoin makes the wallet actor drive round-joining
 	// without a follow-up Board / LeaveVTXOs RPC. The default is
 	// inherited from darepod.DefaultConfig, which is build-tag

--- a/darepod/config.go
+++ b/darepod/config.go
@@ -68,6 +68,19 @@ const (
 	// during a round.
 	DefaultForfeitCollectionTimeout = 2 * time.Minute
 
+	// DefaultSigningWorkers selects backend-aware MuSig2 concurrency. The
+	// profiled lwwallet backend uses a small bounded pool, while other
+	// signer backends remain serial unless explicitly configured otherwise.
+	DefaultSigningWorkers = 0
+
+	// DefaultLwwalletSigningWorkers is the bounded MuSig2 concurrency used
+	// by the profiled in-process lwwallet signer in automatic mode.
+	DefaultLwwalletSigningWorkers = 4
+
+	// MaxSigningWorkers prevents a local configuration mistake from
+	// creating an excessive number of simultaneous cryptographic jobs.
+	MaxSigningWorkers = 64
+
 	// DefaultWalletType is the default wallet backend. The "lwwallet"
 	// backend uses an in-process lightweight wallet backed by
 	// btcwallet and Esplora, requiring no external lnd node.
@@ -224,6 +237,11 @@ type Config struct {
 	// If zero, the default of 2 minutes is used.
 	//nolint:ll
 	ForfeitCollectionTimeout time.Duration `mapstructure:"forfeitcollectiontimeout"`
+
+	// SigningWorkers bounds the number of VTXO signer sessions processed in
+	// parallel. Zero selects a backend-aware default and one preserves the
+	// original serial behavior.
+	SigningWorkers int `mapstructure:"signingworkers"`
 
 	// RegistrationTimeout is the maximum wall-clock duration to
 	// wait for the server's RoundJoined admission watermark after
@@ -966,6 +984,7 @@ func DefaultConfig() *Config {
 			VHTLCRecovery:   swapRecovery,
 		},
 		MaxOperatorFeeSat: DefaultMaxOperatorFeeSat,
+		SigningWorkers:    DefaultSigningWorkers,
 		OOR:               defaultOORConfig(),
 		FeeEstimation: &FeeEstimationConfig{
 			MempoolSpace: &MempoolSpaceFeeConfig{},
@@ -1002,6 +1021,15 @@ func (c *Config) Validate() error {
 	if c.MaxOperatorFeeSat <= 0 {
 		return fmt.Errorf("maxoperatorfeesat must be positive: got %d",
 			c.MaxOperatorFeeSat)
+	}
+
+	if c.SigningWorkers < 0 {
+		return fmt.Errorf("signingworkers must be non-negative: got %d",
+			c.SigningWorkers)
+	}
+	if c.SigningWorkers > MaxSigningWorkers {
+		return fmt.Errorf("signingworkers exceeds maximum %d: got %d",
+			MaxSigningWorkers, c.SigningWorkers)
 	}
 
 	if c.OOR == nil {

--- a/darepod/config_signing_workers_test.go
+++ b/darepod/config_signing_workers_test.go
@@ -1,0 +1,104 @@
+package darepod
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSigningWorkersConfig verifies automatic, serial, and invalid worker
+// configuration values.
+func TestSigningWorkersConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default selects automatic mode", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultConfig()
+		require.Equal(t, DefaultSigningWorkers, cfg.SigningWorkers)
+	})
+
+	t.Run("explicit serial mode is valid", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultConfig()
+		cfg.Network = "regtest"
+		cfg.Wallet.EsploraURL = "http://localhost:3002"
+		cfg.SigningWorkers = 1
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("negative worker count is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultConfig()
+		cfg.Network = "regtest"
+		cfg.Wallet.EsploraURL = "http://localhost:3002"
+		cfg.SigningWorkers = -1
+		err := cfg.Validate()
+		require.ErrorContains(
+			t, err, "signingworkers must be non-negative",
+		)
+	})
+
+	t.Run("excessive worker count is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultConfig()
+		cfg.Network = "regtest"
+		cfg.Wallet.EsploraURL = "http://localhost:3002"
+		cfg.SigningWorkers = MaxSigningWorkers + 1
+		err := cfg.Validate()
+		require.ErrorContains(
+			t, err, "signingworkers exceeds maximum",
+		)
+	})
+}
+
+// TestSigningWorkerCount verifies backend-aware automatic selection while
+// preserving an explicit operator override.
+func TestSigningWorkerCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		walletType string
+		configured int
+		expected   int
+	}{
+		{
+			name:       "lwwallet automatic",
+			walletType: WalletTypeLwwallet,
+			expected:   DefaultLwwalletSigningWorkers,
+		},
+		{
+			name:       "btcwallet automatic",
+			walletType: WalletTypeBtcwallet,
+			expected:   1,
+		},
+		{
+			name:       "remote lnd automatic",
+			walletType: WalletTypeLnd,
+			expected:   1,
+		},
+		{
+			name:       "explicit override",
+			walletType: WalletTypeLnd,
+			configured: 8,
+			expected:   8,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(
+				t, test.expected, signingWorkerCount(
+					test.walletType, test.configured,
+				),
+			)
+		})
+	}
+}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -3932,6 +3932,23 @@ func (s *Server) initWalletActor(ctx context.Context,
 	return walletRef, nil
 }
 
+// signingWorkerCount resolves automatic signing concurrency by wallet
+// backend. Only the profiled lwwallet path enables automatic parallelism;
+// remote lnd and btcwallet signing remain serial until benchmarked separately.
+func signingWorkerCount(walletType string, configured int) int {
+	if configured > 0 {
+		return configured
+	}
+
+	switch walletType {
+	case WalletTypeLwwallet:
+		return DefaultLwwalletSigningWorkers
+
+	default:
+		return 1
+	}
+}
+
 // initRoundActor creates, registers, and starts the round client
 // actor. The round actor manages client-side participation in Ark
 // rounds: boarding intent submission, MuSig2 nonce exchange, partial
@@ -3971,6 +3988,10 @@ func (s *Server) initRoundActor(ctx context.Context,
 	case WalletTypeBtcwallet:
 		clientWallet = s.btcwWallet.UnsafeFromSome()
 	}
+
+	signingWorkers := signingWorkerCount(
+		s.cfg.Wallet.Type, s.cfg.SigningWorkers,
+	)
 
 	dbStore := db.NewStore(
 		s.db.DB, s.db.Queries, s.db.Backend(),
@@ -4021,9 +4042,12 @@ func (s *Server) initRoundActor(ctx context.Context,
 	}
 
 	roundCfg := &round.RoundClientConfig{
-		Name:           "round-client",
-		Logger:         s.subLogger(round.Subsystem),
-		Wallet:         clientWallet,
+		Name:   "round-client",
+		Logger: s.subLogger(round.Subsystem),
+		Wallet: clientWallet,
+		SigningExecutor: round.NewSigningExecutor(
+			signingWorkers,
+		),
 		RoundStore:     roundStore,
 		VTXOStore:      roundStore,
 		OperatorTerms:  operatorTerms,

--- a/lib/tree/signing.go
+++ b/lib/tree/signing.go
@@ -1,7 +1,9 @@
 package tree
 
 import (
+	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
@@ -30,6 +32,11 @@ type TxSignerSession struct {
 	signer      input.MuSig2Signer
 	signSession *input.MuSig2SessionInfo
 	sigHash     [32]byte
+
+	// cleanupMu serializes signing and cleanup so that a session cannot be
+	// removed while it is being used. It also makes Cleanup idempotent.
+	cleanupMu   sync.Mutex
+	cleanupDone bool
 }
 
 // NewTxSignerSession creates a new signing session for a single transaction
@@ -89,6 +96,13 @@ func (s *TxSignerSession) GetNonce() Musig2PubNonce {
 func (s *TxSignerSession) RegisterAggNonce(
 	aggNonce [musig2.PubNonceSize]byte) error {
 
+	s.cleanupMu.Lock()
+	defer s.cleanupMu.Unlock()
+
+	if s.cleanupDone {
+		return fmt.Errorf("signing session has been cleaned up")
+	}
+
 	return s.signer.MuSig2RegisterCombinedNonce(
 		s.signSession.SessionID, aggNonce,
 	)
@@ -97,9 +111,49 @@ func (s *TxSignerSession) RegisterAggNonce(
 // Sign generates the partial signature for this transaction.
 // If cleanup is true, the signing session is cleaned up after signing.
 func (s *TxSignerSession) Sign(cleanup bool) (*musig2.PartialSignature, error) {
-	return s.signer.MuSig2Sign(
+	s.cleanupMu.Lock()
+	defer s.cleanupMu.Unlock()
+
+	if s.cleanupDone {
+		return nil, fmt.Errorf("signing session has been cleaned up")
+	}
+
+	sig, err := s.signer.MuSig2Sign(
 		s.signSession.SessionID, s.sigHash, cleanup,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	// MuSig2Sign removes the underlying session after a successful call
+	// when cleanup is requested. Remember that here so a later Cleanup
+	// call does not try to remove it a second time.
+	if cleanup {
+		s.cleanupDone = true
+	}
+
+	return sig, nil
+}
+
+// Cleanup removes the underlying MuSig2 session. It is safe to call Cleanup
+// more than once after it succeeds. A failed cleanup remains retryable because
+// a remote signer may recover from a transient transport error.
+func (s *TxSignerSession) Cleanup() error {
+	s.cleanupMu.Lock()
+	defer s.cleanupMu.Unlock()
+
+	if s.cleanupDone {
+		return nil
+	}
+
+	err := s.signer.MuSig2Cleanup(s.signSession.SessionID)
+	if err != nil {
+		return err
+	}
+
+	s.cleanupDone = true
+
+	return nil
 }
 
 // SignerSession manages signing for all transactions in a client's path in a
@@ -166,6 +220,14 @@ func NewSignerSession(signer input.MuSig2Signer,
 		return nil
 	})
 	if err != nil {
+		cleanupErr := cleanupSignerSessions(txs)
+		if cleanupErr != nil {
+			return nil, errors.Join(
+				err, fmt.Errorf("failed to clean up signer "+
+					"session: %w", cleanupErr),
+			)
+		}
+
 		return nil, err
 	}
 
@@ -173,6 +235,29 @@ func NewSignerSession(signer input.MuSig2Signer,
 		signerKey: signerKey,
 		txs:       txs,
 	}, nil
+}
+
+// Cleanup removes every underlying MuSig2 session. It is safe to call Cleanup
+// more than once, including after a partially successful signing attempt.
+func (s *SignerSession) Cleanup() error {
+	return cleanupSignerSessions(s.txs)
+}
+
+// cleanupSignerSessions removes all transaction sessions and combines any
+// cleanup errors so one failure does not prevent the remaining cleanup work.
+func cleanupSignerSessions(txs map[TxID]*TxSignerSession) error {
+	errs := make([]error, 0)
+	for txid, txSession := range txs {
+		err := txSession.Cleanup()
+		if err != nil {
+			errs = append(
+				errs, fmt.Errorf("failed to clean up tx "+
+					"%s: %w", txid, err),
+			)
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 // PubKey returns the signer's public key.

--- a/lib/tree/signing_test.go
+++ b/lib/tree/signing_test.go
@@ -1,6 +1,7 @@
 package tree
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -223,6 +224,47 @@ func (m *mockMuSig2Signer) MuSig2Cleanup(
 	delete(m.sessions, sessionID)
 
 	return nil
+}
+
+// cleanupTrackingSigner tracks session creation and cleanup and can inject
+// failures into either operation.
+type cleanupTrackingSigner struct {
+	*mockMuSig2Signer
+
+	createCalls  int
+	failCreateAt int
+	cleanupCalls int
+	cleanupErr   error
+}
+
+// MuSig2CreateSession creates a session unless the configured call should
+// fail.
+func (s *cleanupTrackingSigner) MuSig2CreateSession(version input.MuSig2Version,
+	keyLoc keychain.KeyLocator, signers []*btcec.PublicKey,
+	tweaks *input.MuSig2Tweaks, otherNonces [][musig2.PubNonceSize]byte,
+	localNonces *musig2.Nonces) (*input.MuSig2SessionInfo, error) {
+
+	s.createCalls++
+	if s.createCalls == s.failCreateAt {
+		return nil, fmt.Errorf("injected session creation failure")
+	}
+
+	return s.mockMuSig2Signer.MuSig2CreateSession(
+		version, keyLoc, signers, tweaks, otherNonces, localNonces,
+	)
+}
+
+// MuSig2Cleanup records cleanup attempts and delegates successful attempts to
+// the underlying signer.
+func (s *cleanupTrackingSigner) MuSig2Cleanup(
+	sessionID input.MuSig2SessionID) error {
+
+	s.cleanupCalls++
+	if s.cleanupErr != nil {
+		return s.cleanupErr
+	}
+
+	return s.mockMuSig2Signer.MuSig2Cleanup(sessionID)
 }
 
 // TestTxSignerSession tests the TxSignerSession functionality.
@@ -697,6 +739,139 @@ func TestSignerSession(t *testing.T) {
 		require.Contains(t, err.Error(), "aggregated nonce for tx")
 		require.Contains(t, err.Error(), "not found")
 	})
+}
+
+// TestSignerSessionCleanup verifies that cleanup is idempotent and that a
+// partially constructed signer session rolls back every created transaction
+// session.
+func TestSignerSessionCleanup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tx cleanup is idempotent", func(t *testing.T) {
+		t.Parallel()
+
+		privKey, pubKey := createTestKey(t)
+		signer := &cleanupTrackingSigner{
+			mockMuSig2Signer: newMockMuSig2Signer(privKey),
+		}
+		tree, fetcher := createTwoNodeSignerTree(t, pubKey)
+		keyDesc := &keychain.KeyDescriptor{PubKey: pubKey}
+
+		session, err := tree.NewTxSignerSession(
+			signer, make([]byte, 32), keyDesc, fetcher,
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, session.Cleanup())
+		require.NoError(t, session.Cleanup())
+		require.Equal(t, 1, signer.cleanupCalls)
+		require.Empty(t, signer.sessions)
+	})
+
+	t.Run("cleanup error can be retried", func(t *testing.T) {
+		t.Parallel()
+
+		privKey, pubKey := createTestKey(t)
+		cleanupErr := errors.New("cleanup failed")
+		signer := &cleanupTrackingSigner{
+			mockMuSig2Signer: newMockMuSig2Signer(privKey),
+			cleanupErr:       cleanupErr,
+		}
+		tree, fetcher := createTwoNodeSignerTree(t, pubKey)
+		keyDesc := &keychain.KeyDescriptor{PubKey: pubKey}
+
+		session, err := tree.NewTxSignerSession(
+			signer, make([]byte, 32), keyDesc, fetcher,
+		)
+		require.NoError(t, err)
+
+		require.ErrorIs(t, session.Cleanup(), cleanupErr)
+		signer.cleanupErr = nil
+		require.NoError(t, session.Cleanup())
+		require.NoError(t, session.Cleanup())
+		require.Equal(t, 2, signer.cleanupCalls)
+		require.Empty(t, signer.sessions)
+	})
+
+	t.Run("signer cleanup covers every tx", func(t *testing.T) {
+		t.Parallel()
+
+		privKey, pubKey := createTestKey(t)
+		signer := &cleanupTrackingSigner{
+			mockMuSig2Signer: newMockMuSig2Signer(privKey),
+		}
+		tree, fetcher := createTwoNodeSignerTree(t, pubKey)
+		keyDesc := &keychain.KeyDescriptor{PubKey: pubKey}
+
+		session, err := NewSignerSession(
+			signer, keyDesc, make([]byte, 32), fetcher, tree,
+		)
+		require.NoError(t, err)
+		require.Len(t, session.txs, 2)
+
+		require.NoError(t, session.Cleanup())
+		require.NoError(t, session.Cleanup())
+		require.Equal(t, 2, signer.cleanupCalls)
+		require.Empty(t, signer.sessions)
+	})
+
+	t.Run("construction failure rolls back sessions", func(t *testing.T) {
+		t.Parallel()
+
+		privKey, pubKey := createTestKey(t)
+		signer := &cleanupTrackingSigner{
+			mockMuSig2Signer: newMockMuSig2Signer(privKey),
+			failCreateAt:     2,
+		}
+		tree, fetcher := createTwoNodeSignerTree(t, pubKey)
+		keyDesc := &keychain.KeyDescriptor{PubKey: pubKey}
+
+		session, err := NewSignerSession(
+			signer, keyDesc, make([]byte, 32), fetcher, tree,
+		)
+		require.ErrorContains(
+			t, err, "injected session creation failure",
+		)
+		require.Nil(t, session)
+		require.Equal(t, 2, signer.createCalls)
+		require.Equal(t, 1, signer.cleanupCalls)
+		require.Empty(t, signer.sessions)
+	})
+}
+
+// createTwoNodeSignerTree creates a root and leaf that both belong to the same
+// signer, plus the previous-output fetcher needed to construct sessions.
+func createTwoNodeSignerTree(t *testing.T,
+	signer *btcec.PublicKey) (*Node, txscript.PrevOutputFetcher) {
+
+	t.Helper()
+
+	leaf := createSimpleLeaf("leaf", 1000, []*btcec.PublicKey{signer})
+	root := &Node{
+		Input: wire.OutPoint{
+			Hash: chainhash.HashH([]byte("cleanup-root")),
+		},
+		Outputs: []*wire.TxOut{
+			{
+				Value: 1000,
+			},
+		},
+		CoSigners: []*btcec.PublicKey{
+			signer,
+		},
+		Children: map[uint32]*Node{
+			0: leaf,
+		},
+	}
+
+	rootTXID, err := root.TXID()
+	require.NoError(t, err)
+	leaf.Input = wire.OutPoint{Hash: rootTXID}
+
+	fetcher, err := root.PrevOutputFetcher(&wire.TxOut{Value: 5000})
+	require.NoError(t, err)
+
+	return root, fetcher
 }
 
 // TestSignerSessionMultiTx tests SignerSession with multiple transactions.

--- a/round/actor.go
+++ b/round/actor.go
@@ -258,6 +258,10 @@ type RoundClientConfig struct {
 	// actor.
 	Wallet ClientWallet
 
+	// SigningExecutor runs independent VTXO MuSig2 sessions with bounded
+	// concurrency. If nil, the actor preserves serial behavior.
+	SigningExecutor SigningExecutor
+
 	// RoundStore persists round coordination and checkpointing.
 	RoundStore RoundStore
 
@@ -382,12 +386,16 @@ func NewRoundClientActor(cfg *RoundClientConfig) fn.Result[*RoundClientActor] {
 		RoundStore:             cfg.RoundStore,
 		VTXOStore:              cfg.VTXOStore,
 		Wallet:                 cfg.Wallet,
+		SigningExecutor:        cfg.SigningExecutor,
 		OperatorTerms:          cfg.OperatorTerms,
 		ChainParams:            cfg.ChainParams,
 		MaxOperatorFee:         cfg.MaxOperatorFee,
 		Log:                    actorLog,
 		DisableJoinRequestAuth: cfg.DisableJoinRequestAuth,
 		OwnedScriptChecker:     cfg.OwnedScriptChecker,
+	}
+	if env.SigningExecutor == nil {
+		env.SigningExecutor = NewSigningExecutor(1)
 	}
 
 	// The sweep delay is no longer a global operator term: it is delivered
@@ -735,6 +743,7 @@ func (a *RoundClientActor) createRoundFSMFromDB(ctx context.Context,
 		RoundStore:             a.cfg.RoundStore,
 		VTXOStore:              a.cfg.VTXOStore,
 		Wallet:                 a.cfg.Wallet,
+		SigningExecutor:        a.env.SigningExecutor,
 		OperatorTerms:          a.cfg.OperatorTerms,
 		ChainParams:            a.cfg.ChainParams,
 		MaxOperatorFee:         a.cfg.MaxOperatorFee,
@@ -805,6 +814,7 @@ func (a *RoundClientActor) createNewRound(ctx context.Context) (*RoundFSM,
 		RoundStore:             a.cfg.RoundStore,
 		VTXOStore:              a.cfg.VTXOStore,
 		Wallet:                 a.cfg.Wallet,
+		SigningExecutor:        a.env.SigningExecutor,
 		OperatorTerms:          a.cfg.OperatorTerms,
 		ChainParams:            a.cfg.ChainParams,
 		MaxOperatorFee:         a.cfg.MaxOperatorFee,
@@ -1132,8 +1142,26 @@ func (a *RoundClientActor) replayCheckpointedServerMessages(
 	})
 }
 
-// OnStop implements actor.Stoppable to gracefully shut down all FSMs when the
-// actor is stopping. This prevents goroutine leaks by stopping all round FSMs.
+// signingSessionsFromState returns ephemeral MuSig2 sessions that still need
+// cleanup when a round is stopped before partial signing completes.
+func signingSessionsFromState(
+	state ClientState) map[SignerKey]*tree.SignerSession {
+
+	switch state := state.(type) {
+	case *NoncesSentState:
+		return state.Musig2Sessions
+
+	case *NoncesAggregatedState:
+		return state.Musig2Sessions
+
+	default:
+		return nil
+	}
+}
+
+// OnStop implements actor.Stoppable to gracefully clean live MuSig2 sessions
+// and stop all FSMs. This prevents external signer state and goroutines from
+// leaking across a daemon restart.
 func (a *RoundClientActor) OnStop(ctx context.Context) error {
 	a.log.InfoS(ctx, "Stopping round client actor",
 		slog.Int("rounds", len(a.rounds)),
@@ -1144,6 +1172,26 @@ func (a *RoundClientActor) OnStop(ctx context.Context) error {
 		a.log.DebugS(ctx, "Stopping round FSM",
 			slog.String("key", string(keyStr)),
 		)
+
+		state, err := roundFSM.FSM.CurrentState()
+		if err == nil {
+			clientState, ok := state.(ClientState)
+			if !ok {
+				roundFSM.FSM.Stop()
+
+				continue
+			}
+
+			cleanupErr := cleanupSignerSessions(
+				signingSessionsFromState(clientState),
+			)
+			if cleanupErr != nil {
+				a.log.WarnS(ctx, "Unable to clean up round "+
+					"MuSig2 sessions", cleanupErr,
+					slog.String("key", string(keyStr)),
+				)
+			}
+		}
 
 		roundFSM.FSM.Stop()
 	}

--- a/round/actor.go
+++ b/round/actor.go
@@ -758,13 +758,15 @@ func (a *RoundClientActor) createRoundFSMFromDB(ctx context.Context,
 		OwnedScriptChecker:  a.cfg.OwnedScriptChecker,
 	}
 	fsmCfg := ClientStateMachineCfg{
-		Logger:        fsmLogger,
-		ErrorReporter: newContextErrorReporter(ctx, fsmPrefix),
-		InitialState:  state,
-		Env:           env,
+		Logger: fsmLogger,
+		ErrorReporter: newContextErrorReporter(
+			a.lifecycleCtx(ctx), fsmPrefix,
+		),
+		InitialState: state,
+		Env:          env,
 	}
 	fsm := protofsm.NewStateMachine(fsmCfg)
-	fsm.Start(ctx)
+	a.startRoundFSM(ctx, &fsm)
 
 	a.log.InfoS(ctx, "Created round FSM from checkpoint",
 		slog.String("round_id", round.RoundID.String()),
@@ -829,13 +831,15 @@ func (a *RoundClientActor) createNewRound(ctx context.Context) (*RoundFSM,
 		OwnedScriptChecker:  a.cfg.OwnedScriptChecker,
 	}
 	fsmCfg := ClientStateMachineCfg{
-		Logger:        fsmLogger,
-		ErrorReporter: newContextErrorReporter(ctx, fsmPrefix),
-		InitialState:  &Idle{},
-		Env:           env,
+		Logger: fsmLogger,
+		ErrorReporter: newContextErrorReporter(
+			a.lifecycleCtx(ctx), fsmPrefix,
+		),
+		InitialState: &Idle{},
+		Env:          env,
 	}
 	fsm := protofsm.NewStateMachine(fsmCfg)
-	fsm.Start(ctx)
+	a.startRoundFSM(ctx, &fsm)
 
 	roundFSM := &RoundFSM{
 		FSM: &fsm,
@@ -1061,7 +1065,7 @@ func (a *RoundClientActor) registerCommitmentConfirmation(ctx context.Context,
 	}
 
 	if err := a.cfg.ChainSource.Tell(
-		a.registrationCtx(ctx), confReq,
+		a.lifecycleCtx(ctx), confReq,
 	); err != nil {
 
 		a.log.WarnS(ctx, "Failed to register confirmation", err)
@@ -1201,18 +1205,24 @@ func (a *RoundClientActor) OnStop(ctx context.Context) error {
 	return nil
 }
 
-// registrationCtx returns the actor-owned context used for registrations that
-// must outlive the current Receive call. Some tests construct actor shells
-// without calling Start, so the fallback detaches cancellation from the current
-// call while preserving context values for logs and tracing.
-func (a *RoundClientActor) registrationCtx(
-	ctx context.Context) context.Context {
-
+// lifecycleCtx returns the actor-owned context for work that must outlive the
+// current Receive call. Some tests construct actor shells without calling
+// Start, so the fallback detaches cancellation from the current call while
+// preserving context values for logs and tracing.
+func (a *RoundClientActor) lifecycleCtx(ctx context.Context) context.Context {
 	if a.runCtx != nil {
 		return a.runCtx
 	}
 
 	return context.WithoutCancel(ctx)
+}
+
+// startRoundFSM starts a round state machine with the actor lifecycle rather
+// than the context of the request that happened to create it.
+func (a *RoundClientActor) startRoundFSM(ctx context.Context,
+	fsm *ClientStateMachine) {
+
+	fsm.Start(a.lifecycleCtx(ctx))
 }
 
 // Start initializes the actor by registering with the wallet actor to receive
@@ -2776,7 +2786,7 @@ func (a *RoundClientActor) processConfirmationRequest(
 	)
 
 	if err := a.cfg.ChainSource.Tell(
-		a.registrationCtx(ctx), confReq,
+		a.lifecycleCtx(ctx), confReq,
 	); err != nil {
 
 		a.log.WarnS(ctx,

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/darepo-client/baselib/actor"
+	"github.com/lightninglabs/darepo-client/baselib/protofsm"
 	"github.com/lightninglabs/darepo-client/internal/testutils"
 	"github.com/lightninglabs/darepo-client/lib/actormsg"
 	"github.com/lightninglabs/darepo-client/lib/arkscript"
@@ -25,6 +27,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type lifecycleProbeState struct {
+	ctxErr chan error
+}
+
+// ProcessEvent records whether the state machine lifecycle context was
+// cancelled when a later event was processed.
+func (s *lifecycleProbeState) ProcessEvent(ctx context.Context, _ ClientEvent,
+	_ *ClientEnvironment) (*ClientStateTransition, error) {
+
+	s.ctxErr <- ctx.Err()
+
+	return &ClientStateTransition{NextState: s}, nil
+}
+
+// IsTerminal reports that the lifecycle probe remains active.
+func (s *lifecycleProbeState) IsTerminal() bool {
+	return false
+}
+
+// String returns the lifecycle probe state name.
+func (s *lifecycleProbeState) String() string {
+	return "LifecycleProbe"
+}
+
 func stdTpl(t *testing.T, clientKey, operatorKey *btcec.PublicKey,
 	exitDelay uint32) []byte {
 
@@ -36,6 +62,36 @@ func stdTpl(t *testing.T, clientKey, operatorKey *btcec.PublicKey,
 	require.NoError(t, err)
 
 	return policy
+}
+
+// TestRoundFSMOutlivesCreationRequest verifies that a round FSM retains the
+// actor lifecycle after the Ask request that created it has completed.
+func TestRoundFSMOutlivesCreationRequest(t *testing.T) {
+	t.Parallel()
+
+	state := &lifecycleProbeState{ctxErr: make(chan error, 1)}
+	fsm := protofsm.NewStateMachine(ClientStateMachineCfg{
+		Logger:        btclog.Disabled,
+		ErrorReporter: newContextErrorReporter(t.Context(), "probe"),
+		InitialState:  state,
+		Env:           &ClientEnvironment{},
+	})
+
+	actor := &RoundClientActor{runCtx: t.Context()}
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	actor.startRoundFSM(requestCtx, &fsm)
+	t.Cleanup(fsm.Stop)
+
+	// Actor Ask processing cancels its merged request context immediately
+	// after Receive returns. A later protocol event must still run using
+	// the actor-owned context.
+	cancelRequest()
+	result := fsm.AskEvent(t.Context(), &GenerateNonces{}).Await(
+		t.Context(),
+	)
+	_, err := result.Unpack()
+	require.NoError(t, err)
+	require.NoError(t, <-state.ctxErr)
 }
 
 // TestActorStart verifies the actor initialization sequence, ensuring proper

--- a/round/fsm_environment.go
+++ b/round/fsm_environment.go
@@ -27,6 +27,10 @@ type ClientEnvironment struct {
 	// Wallet provides signing capabilities for round participation.
 	Wallet ClientWallet
 
+	// SigningExecutor bounds independent VTXO MuSig2 work. A nil executor
+	// falls back to serial execution for focused FSM tests.
+	SigningExecutor SigningExecutor
+
 	// OperatorTerms contains the operator's parameters including sweep
 	// keys, fee targets, confirmation thresholds, and amount limits.
 	OperatorTerms *types.OperatorTerms
@@ -116,6 +120,16 @@ func (e *ClientEnvironment) now() time.Time {
 	return time.Now()
 }
 
+// signingExecutor returns the configured shared executor or a serial fallback
+// for construction sites that only exercise focused FSM behavior.
+func (e *ClientEnvironment) signingExecutor() SigningExecutor {
+	if e.SigningExecutor != nil {
+		return e.SigningExecutor
+	}
+
+	return NewSigningExecutor(1)
+}
+
 // Name returns the unique identifier for this FSM instance.
 func (e *ClientEnvironment) Name() string {
 	return "round_fsm"
@@ -137,6 +151,7 @@ func NewClientEnvironment(roundStore RoundStore, vtxoStore VTXOStore,
 		RoundStore:               roundStore,
 		VTXOStore:                vtxoStore,
 		Wallet:                   wallet,
+		SigningExecutor:          NewSigningExecutor(1),
 		OperatorTerms:            terms,
 		ChainParams:              chainParams,
 		MaxOperatorFee:           maxOperatorFee,

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -1223,6 +1223,10 @@ func (h *boardingTestHarness) setupMockWalletForMuSig2() {
 	h.wallet.On(
 		"MuSig2Sign", mock.Anything, mock.Anything, mock.Anything,
 	).Return(partialSig, nil)
+
+	// Batch signing performs explicit cleanup after every worker returns so
+	// partial failures cannot leave a subset of sessions live.
+	h.wallet.On("MuSig2Cleanup", mock.Anything).Return(nil)
 }
 
 func (h *boardingTestHarness) setupMockWalletForBoardingSigning() {

--- a/round/signing_executor.go
+++ b/round/signing_executor.go
@@ -242,6 +242,8 @@ func (e *boundedSigningExecutor) run(ctx context.Context, numJobs int,
 
 				jobErrors[index] = err
 				cancel()
+
+				return
 			}
 		}()
 	}
@@ -257,12 +259,17 @@ sendJobs:
 	close(jobs)
 	workers.Wait()
 
-	// Prefer a concrete job error over the cancellation it caused. Scan
-	// by index so concurrent completion does not make errors unstable.
+	// Prefer concrete job errors over the cancellation they caused. Join
+	// them by index so concurrent completion does not make diagnostics
+	// unstable.
+	var errs []error
 	for _, err := range jobErrors {
 		if err != nil {
-			return err
+			errs = append(errs, err)
 		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
 	}
 
 	return ctx.Err()

--- a/round/signing_executor.go
+++ b/round/signing_executor.go
@@ -1,0 +1,313 @@
+package round
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// CreateSignerSessionJob contains the inputs needed to create all MuSig2
+// sessions for one VTXO signing key.
+type CreateSignerSessionJob struct {
+	// SignerKey identifies the result in round protocol messages.
+	SignerKey SignerKey
+
+	// Signer creates and operates the MuSig2 sessions.
+	Signer input.MuSig2Signer
+
+	// SigningKey is the private-key locator for this VTXO path.
+	SigningKey keychain.KeyDescriptor
+
+	// SweepTapscriptRoot tweaks the VTXO tree key-spend path.
+	SweepTapscriptRoot []byte
+
+	// PrevOuts provides the outputs spent by transactions in the path.
+	PrevOuts txscript.PrevOutputFetcher
+
+	// Root is the root of the VTXO tree containing the signer path.
+	Root *tree.Node
+}
+
+// SignerSessionResult is an index-stable signer session and its public
+// nonces.
+type SignerSessionResult struct {
+	// SignerKey identifies the session in round protocol messages.
+	SignerKey SignerKey
+
+	// Session owns all transaction-level MuSig2 sessions for this path.
+	Session *tree.SignerSession
+
+	// Nonces contains one public nonce for every transaction in the path.
+	Nonces map[tree.TxID]tree.Musig2PubNonce
+}
+
+// SignerSessionSignatures contains all partial signatures for one VTXO
+// signing key.
+type SignerSessionSignatures struct {
+	// SignerKey identifies the signatures in round protocol messages.
+	SignerKey SignerKey
+
+	// Signatures contains one partial signature for every path transaction.
+	Signatures map[tree.TxID]*musig2.PartialSignature
+}
+
+// SigningExecutor runs independent VTXO signing sessions with bounded
+// concurrency. Each method returns results in the same order as its input.
+type SigningExecutor interface {
+	// CreateSessions creates the MuSig2 sessions and public nonces for a
+	// batch of VTXO signing keys.
+	CreateSessions(context.Context,
+		[]CreateSignerSessionJob) ([]SignerSessionResult, error)
+
+	// Sign generates partial signatures and cleans every input session.
+	// An error returns no partial results.
+	Sign(context.Context,
+		[]SignerSessionResult) ([]SignerSessionSignatures, error)
+}
+
+// boundedSigningExecutor shares one concurrency bound across all batches.
+type boundedSigningExecutor struct {
+	maxWorkers  int
+	workerSlots chan struct{}
+
+	createSession func(CreateSignerSessionJob) (*tree.SignerSession, error)
+	getNonces     func(
+		*tree.SignerSession) map[tree.TxID]tree.Musig2PubNonce
+	signSession func(*tree.SignerSession) (
+		map[tree.TxID]*musig2.PartialSignature, error)
+	cleanupSession func(*tree.SignerSession) error
+}
+
+// NewSigningExecutor creates a signing executor. Values smaller than one
+// select the safe, serial behavior.
+func NewSigningExecutor(maxWorkers int) SigningExecutor {
+	if maxWorkers < 1 {
+		maxWorkers = 1
+	}
+
+	return &boundedSigningExecutor{
+		maxWorkers:  maxWorkers,
+		workerSlots: make(chan struct{}, maxWorkers),
+		createSession: func(job CreateSignerSessionJob) (
+			*tree.SignerSession, error) {
+
+			return tree.NewSignerSession(
+				job.Signer, &job.SigningKey,
+				job.SweepTapscriptRoot, job.PrevOuts, job.Root,
+			)
+		},
+		getNonces: func(
+			session *tree.SignerSession,
+		) map[tree.TxID]tree.Musig2PubNonce {
+
+			return session.GetNonces()
+		},
+		signSession: func(session *tree.SignerSession) (
+			map[tree.TxID]*musig2.PartialSignature, error) {
+
+			// Successful calls retain the original signer behavior
+			// and clean each transaction session as its signature
+			// is produced. The batch cleanup below then handles
+			// only failed or unstarted sessions, avoiding an extra
+			// remote cleanup RPC per signature.
+			return session.Signatures(true)
+		},
+		cleanupSession: func(session *tree.SignerSession) error {
+			return session.Cleanup()
+		},
+	}
+}
+
+// CreateSessions creates signer sessions in parallel while retaining the
+// input order in the returned slice.
+func (e *boundedSigningExecutor) CreateSessions(ctx context.Context,
+	jobs []CreateSignerSessionJob) ([]SignerSessionResult, error) {
+
+	results := make([]SignerSessionResult, len(jobs))
+	err := e.run(ctx, len(jobs), func(index int) error {
+		job := jobs[index]
+		session, err := e.createSession(job)
+		if err != nil {
+			return fmt.Errorf("create session %d for signer %x: %w",
+				index, job.SignerKey[:], err)
+		}
+		if session == nil {
+			return fmt.Errorf("create session %d for signer %x: "+
+				"signer returned a nil session", index,
+				job.SignerKey[:])
+		}
+
+		results[index] = SignerSessionResult{
+			SignerKey: job.SignerKey,
+			Session:   session,
+			Nonces:    e.getNonces(session),
+		}
+
+		return nil
+	})
+	if err == nil {
+		return results, nil
+	}
+
+	cleanupErr := e.cleanup(results)
+
+	return nil, errors.Join(err, cleanupErr)
+}
+
+// Sign generates partial signatures in parallel. Explicit recovery cleanup
+// starts only after every in-flight signing call has returned; successful
+// signer calls clean their own transaction session inline.
+func (e *boundedSigningExecutor) Sign(ctx context.Context,
+	sessions []SignerSessionResult) ([]SignerSessionSignatures, error) {
+
+	results := make([]SignerSessionSignatures, len(sessions))
+	err := e.run(ctx, len(sessions), func(index int) error {
+		session := sessions[index]
+		if session.Session == nil {
+			return fmt.Errorf("sign session %d for signer %x: "+
+				"session is nil", index, session.SignerKey[:])
+		}
+
+		partialSigs, err := e.signSession(session.Session)
+		if err != nil {
+			return fmt.Errorf("sign session %d for signer %x: %w",
+				index, session.SignerKey[:], err)
+		}
+
+		results[index] = SignerSessionSignatures{
+			SignerKey:  session.SignerKey,
+			Signatures: partialSigs,
+		}
+
+		return nil
+	})
+
+	cleanupErr := e.cleanup(sessions)
+	if err != nil || cleanupErr != nil {
+		return nil, errors.Join(err, cleanupErr)
+	}
+
+	return results, nil
+}
+
+// run executes indexed jobs using a batch-local worker pool and an
+// executor-wide concurrency limiter.
+func (e *boundedSigningExecutor) run(ctx context.Context, numJobs int,
+	job func(int) error) error {
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if numJobs == 0 {
+		return nil
+	}
+
+	batchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	jobs := make(chan int)
+	jobErrors := make([]error, numJobs)
+	numWorkers := min(e.maxWorkers, numJobs)
+
+	var workers sync.WaitGroup
+	workers.Add(numWorkers)
+	for range numWorkers {
+		go func() {
+			defer workers.Done()
+
+			for index := range jobs {
+				if !e.acquire(batchCtx) {
+					return
+				}
+
+				if err := batchCtx.Err(); err != nil {
+					e.release()
+
+					return
+				}
+
+				err := job(index)
+				e.release()
+				if err == nil {
+					continue
+				}
+
+				jobErrors[index] = err
+				cancel()
+			}
+		}()
+	}
+
+sendJobs:
+	for index := range numJobs {
+		select {
+		case jobs <- index:
+		case <-batchCtx.Done():
+			break sendJobs
+		}
+	}
+	close(jobs)
+	workers.Wait()
+
+	// Prefer a concrete job error over the cancellation it caused. Scan
+	// by index so concurrent completion does not make errors unstable.
+	for _, err := range jobErrors {
+		if err != nil {
+			return err
+		}
+	}
+
+	return ctx.Err()
+}
+
+// acquire reserves one executor-wide worker slot.
+func (e *boundedSigningExecutor) acquire(ctx context.Context) bool {
+	select {
+	case e.workerSlots <- struct{}{}:
+		return true
+
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// release returns one executor-wide worker slot.
+func (e *boundedSigningExecutor) release() {
+	<-e.workerSlots
+}
+
+// cleanup releases each distinct session once, preserving input order for
+// deterministic error reporting.
+func (e *boundedSigningExecutor) cleanup(sessions []SignerSessionResult) error {
+	seen := make(map[*tree.SignerSession]struct{}, len(sessions))
+	var cleanupErrors []error
+	for index, result := range sessions {
+		if result.Session == nil {
+			continue
+		}
+
+		if _, ok := seen[result.Session]; ok {
+			continue
+		}
+		seen[result.Session] = struct{}{}
+
+		err := e.cleanupSession(result.Session)
+		if err != nil {
+			cleanupErrors = append(
+				cleanupErrors, fmt.Errorf("cleanup session "+
+					"%d for signer %x: %w", index,
+					result.SignerKey[:], err),
+			)
+		}
+	}
+
+	return errors.Join(cleanupErrors...)
+}

--- a/round/signing_executor_test.go
+++ b/round/signing_executor_test.go
@@ -1,0 +1,485 @@
+package round
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/lightninglabs/darepo-client/lib/tree"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSigningExecutorSharedBound verifies that simultaneous batches share the
+// same executor-wide concurrency limit.
+func TestSigningExecutorSharedBound(t *testing.T) {
+	t.Parallel()
+
+	executor := newTestSigningExecutor(t, 2)
+	started := make(chan struct{}, 8)
+	release := make(chan struct{})
+
+	var active atomic.Int32
+	var maxActive atomic.Int32
+	executor.createSession = func(job CreateSignerSessionJob) (
+		*tree.SignerSession, error) {
+
+		current := active.Add(1)
+		for {
+			oldMax := maxActive.Load()
+			if current <= oldMax || maxActive.CompareAndSwap(
+				oldMax, current,
+			) {
+
+				break
+			}
+		}
+
+		started <- struct{}{}
+		<-release
+		active.Add(-1)
+
+		return &tree.SignerSession{}, nil
+	}
+	executor.getNonces = func(
+		*tree.SignerSession) map[tree.TxID]tree.Musig2PubNonce {
+
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := executor.CreateSessions(
+				ctx, makeSignerSessionJobs(4),
+			)
+			results <- err
+		}()
+	}
+
+	for range 2 {
+		select {
+		case <-started:
+		case <-ctx.Done():
+			require.NoError(t, ctx.Err())
+		}
+	}
+	close(release)
+
+	for range 2 {
+		require.NoError(t, <-results)
+	}
+	require.Equal(t, int32(2), maxActive.Load())
+}
+
+// TestSigningExecutorSerialOrder verifies that one worker retains the input
+// execution order used by the old sequential loops.
+func TestSigningExecutorSerialOrder(t *testing.T) {
+	t.Parallel()
+
+	executor := newTestSigningExecutor(t, 1)
+	jobs := makeSignerSessionJobs(5)
+	sessions := make([]*tree.SignerSession, len(jobs))
+	for index := range sessions {
+		sessions[index] = &tree.SignerSession{}
+	}
+
+	var order []byte
+	executor.createSession = func(job CreateSignerSessionJob) (
+		*tree.SignerSession, error) {
+
+		order = append(order, job.SignerKey[0])
+
+		return sessions[int(job.SignerKey[0])], nil
+	}
+	executor.getNonces = func(
+		*tree.SignerSession) map[tree.TxID]tree.Musig2PubNonce {
+
+		return nil
+	}
+
+	results, err := executor.CreateSessions(context.Background(), jobs)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0, 1, 2, 3, 4}, order)
+	require.Len(t, results, len(jobs))
+	for index, result := range results {
+		require.Equal(t, jobs[index].SignerKey, result.SignerKey)
+		require.Same(t, sessions[index], result.Session)
+	}
+}
+
+// TestSigningExecutorIndexedResults verifies that completion order cannot
+// reorder protocol results.
+func TestSigningExecutorIndexedResults(t *testing.T) {
+	t.Parallel()
+
+	executor := newTestSigningExecutor(t, 3)
+	jobs := makeSignerSessionJobs(3)
+	sessions := []*tree.SignerSession{
+		{}, {}, {},
+	}
+	started := make(chan byte, len(jobs))
+	completed := make(chan byte, len(jobs))
+	releases := []chan struct{}{
+		make(chan struct{}),
+		make(chan struct{}),
+		make(chan struct{}),
+	}
+	executor.createSession = func(job CreateSignerSessionJob) (
+		*tree.SignerSession, error) {
+
+		index := int(job.SignerKey[0])
+		started <- job.SignerKey[0]
+		<-releases[index]
+		completed <- job.SignerKey[0]
+
+		return sessions[index], nil
+	}
+	executor.getNonces = func(
+		*tree.SignerSession) map[tree.TxID]tree.Musig2PubNonce {
+
+		return nil
+	}
+
+	type createResult struct {
+		results []SignerSessionResult
+		err     error
+	}
+	resultChan := make(chan createResult, 1)
+	go func() {
+		results, err := executor.CreateSessions(
+			context.Background(), jobs,
+		)
+		resultChan <- createResult{results: results, err: err}
+	}()
+
+	for range jobs {
+		<-started
+	}
+	for index := len(releases) - 1; index >= 0; index-- {
+		close(releases[index])
+		require.Equal(t, byte(index), <-completed)
+	}
+
+	result := <-resultChan
+	require.NoError(t, result.err)
+	for index := range jobs {
+		require.Equal(
+			t, jobs[index].SignerKey,
+			result.results[index].SignerKey,
+		)
+		require.Same(t, sessions[index], result.results[index].Session)
+	}
+}
+
+// TestSigningExecutorCreateFailure verifies all-or-nothing results and
+// cleanup of sessions created before failure.
+func TestSigningExecutorCreateFailure(t *testing.T) {
+	t.Parallel()
+
+	executor := newTestSigningExecutor(t, 1)
+	jobs := makeSignerSessionJobs(3)
+	sessions := []*tree.SignerSession{{}, {}, {}}
+	errOne := errors.New("one failed")
+	var createCalls atomic.Int32
+	executor.createSession = func(job CreateSignerSessionJob) (
+		*tree.SignerSession, error) {
+
+		createCalls.Add(1)
+		index := int(job.SignerKey[0])
+		switch index {
+		case 0:
+			return sessions[index], nil
+
+		case 1:
+			return nil, errOne
+
+		default:
+			return sessions[index], nil
+		}
+	}
+	executor.getNonces = func(
+		*tree.SignerSession) map[tree.TxID]tree.Musig2PubNonce {
+
+		return nil
+	}
+
+	var cleanupCalls atomic.Int32
+	cleanedSessions := make(chan *tree.SignerSession, 1)
+	executor.cleanupSession = func(session *tree.SignerSession) error {
+		cleanedSessions <- session
+		cleanupCalls.Add(1)
+
+		return nil
+	}
+
+	results, err := executor.CreateSessions(context.Background(), jobs)
+	require.Nil(t, results)
+	require.ErrorIs(t, err, errOne)
+	require.Equal(t, int32(2), createCalls.Load())
+	require.Equal(t, int32(1), cleanupCalls.Load())
+	require.Same(t, sessions[0], <-cleanedSessions)
+}
+
+// TestSigningExecutorCancellation verifies cancellation stops new jobs and
+// cleans a session returned by an already-running signer call.
+func TestSigningExecutorCancellation(t *testing.T) {
+	t.Parallel()
+
+	executor := newTestSigningExecutor(t, 1)
+	jobs := makeSignerSessionJobs(3)
+	session := &tree.SignerSession{}
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	var createCalls atomic.Int32
+	executor.createSession = func(CreateSignerSessionJob) (
+		*tree.SignerSession, error) {
+
+		createCalls.Add(1)
+		close(started)
+		<-release
+
+		return session, nil
+	}
+	executor.getNonces = func(
+		*tree.SignerSession) map[tree.TxID]tree.Musig2PubNonce {
+
+		return nil
+	}
+
+	var cleanupCalls atomic.Int32
+	cleanedSessions := make(chan *tree.SignerSession, 1)
+	executor.cleanupSession = func(session *tree.SignerSession) error {
+		cleanedSessions <- session
+		cleanupCalls.Add(1)
+
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	type createResult struct {
+		results []SignerSessionResult
+		err     error
+	}
+	resultChan := make(chan createResult, 1)
+	go func() {
+		results, err := executor.CreateSessions(ctx, jobs)
+		resultChan <- createResult{results: results, err: err}
+	}()
+	<-started
+	cancel()
+	close(release)
+
+	result := <-resultChan
+	require.Nil(t, result.results)
+	require.ErrorIs(t, result.err, context.Canceled)
+	require.Equal(t, int32(1), createCalls.Load())
+	require.Equal(t, int32(1), cleanupCalls.Load())
+	require.Same(t, session, <-cleanedSessions)
+}
+
+// TestSigningExecutorSign verifies parallel signing remains index-stable and
+// cleans every distinct session after all signing calls finish.
+func TestSigningExecutorSign(t *testing.T) {
+	t.Parallel()
+
+	executor := newTestSigningExecutor(t, 2)
+	sessions := makeSignerSessionResults(3)
+
+	var mu sync.Mutex
+	signed := make(map[*tree.SignerSession]struct{})
+	executor.signSession = func(session *tree.SignerSession) (
+		map[tree.TxID]*musig2.PartialSignature, error) {
+
+		mu.Lock()
+		signed[session] = struct{}{}
+		mu.Unlock()
+
+		return nil, nil
+	}
+
+	cleaned := make(map[*tree.SignerSession]int)
+	executor.cleanupSession = func(session *tree.SignerSession) error {
+		mu.Lock()
+		defer mu.Unlock()
+
+		require.Contains(t, signed, session)
+		cleaned[session]++
+
+		return nil
+	}
+
+	results, err := executor.Sign(context.Background(), sessions)
+	require.NoError(t, err)
+	require.Len(t, results, len(sessions))
+	for index, result := range results {
+		require.Equal(t, sessions[index].SignerKey, result.SignerKey)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, cleaned, len(sessions))
+	for _, count := range cleaned {
+		require.Equal(t, 1, count)
+	}
+}
+
+// TestSigningExecutorSignFailure verifies signing and cleanup failures never
+// expose a partial result.
+func TestSigningExecutorSignFailure(t *testing.T) {
+	t.Parallel()
+
+	executor := newTestSigningExecutor(t, 1)
+	sessions := makeSignerSessionResults(3)
+	signErr := errors.New("sign failed")
+	cleanupErr := errors.New("cleanup failed")
+
+	var signCalls atomic.Int32
+	executor.signSession = func(*tree.SignerSession) (
+		map[tree.TxID]*musig2.PartialSignature, error) {
+
+		call := signCalls.Add(1)
+		if call == 2 {
+			return nil, signErr
+		}
+
+		return nil, nil
+	}
+
+	var cleanupCalls atomic.Int32
+	executor.cleanupSession = func(session *tree.SignerSession) error {
+		call := cleanupCalls.Add(1)
+		if call == 3 {
+			return cleanupErr
+		}
+
+		return nil
+	}
+
+	results, err := executor.Sign(context.Background(), sessions)
+	require.Nil(t, results)
+	require.ErrorIs(t, err, signErr)
+	require.ErrorIs(t, err, cleanupErr)
+	require.Equal(t, int32(2), signCalls.Load())
+	require.Equal(t, int32(3), cleanupCalls.Load())
+}
+
+// TestSigningExecutorRealMuSigManager exercises concurrent session creation
+// through the same LND manager embedded by lwwallet and btcwallet. The gated
+// key fetcher proves four real manager calls overlap without relying on sleeps.
+func TestSigningExecutorRealMuSigManager(t *testing.T) {
+	t.Parallel()
+
+	const workerCount = 4
+
+	h := newTestHarness(t)
+	started := make(chan struct{}, workerCount)
+	release := make(chan struct{})
+	var fetchCalls atomic.Int32
+	signer := input.NewMusigSessionManager(func(*keychain.KeyDescriptor) (
+		*btcec.PrivateKey, error) {
+
+		call := fetchCalls.Add(1)
+		if call <= workerCount {
+			started <- struct{}{}
+			<-release
+		}
+
+		return h.clientPrivKey, nil
+	})
+
+	vtxoTree, _ := h.newTestVTXOTree(8)
+	prevOuts, err := vtxoTree.Root.PrevOutputFetcher(
+		vtxoTree.BatchOutput,
+	)
+	require.NoError(t, err)
+
+	jobs := make([]CreateSignerSessionJob, 8)
+	for index := range jobs {
+		jobs[index] = CreateSignerSessionJob{
+			SignerKey: SignerKey{
+				byte(index),
+			},
+			Signer: signer,
+			SigningKey: keychain.KeyDescriptor{
+				PubKey: h.clientPubKey,
+			},
+			SweepTapscriptRoot: vtxoTree.SweepTapscriptRoot,
+			PrevOuts:           prevOuts,
+			Root:               vtxoTree.Root,
+		}
+	}
+
+	type createResult struct {
+		results []SignerSessionResult
+		err     error
+	}
+	resultChan := make(chan createResult, 1)
+	go func() {
+		results, err := NewSigningExecutor(workerCount).CreateSessions(
+			t.Context(), jobs,
+		)
+		resultChan <- createResult{results: results, err: err}
+	}()
+
+	for range workerCount {
+		select {
+		case <-started:
+		case <-time.After(5 * time.Second):
+			t.Fatal("real MuSig2 session creation did not overlap")
+		}
+	}
+	close(release)
+
+	result := <-resultChan
+	require.NoError(t, result.err)
+	require.Len(t, result.results, len(jobs))
+	for _, session := range result.results {
+		require.NoError(t, session.Session.Cleanup())
+	}
+}
+
+// makeSignerSessionJobs returns jobs whose first signer-key byte is their
+// input index.
+func makeSignerSessionJobs(count int) []CreateSignerSessionJob {
+	jobs := make([]CreateSignerSessionJob, count)
+	for index := range jobs {
+		jobs[index].SignerKey[0] = byte(index)
+	}
+
+	return jobs
+}
+
+// makeSignerSessionResults returns indexed results with distinct sessions.
+func makeSignerSessionResults(count int) []SignerSessionResult {
+	results := make([]SignerSessionResult, count)
+	for index := range results {
+		results[index] = SignerSessionResult{
+			Session: &tree.SignerSession{},
+		}
+		results[index].SignerKey[0] = byte(index)
+	}
+
+	return results
+}
+
+// newTestSigningExecutor returns the concrete executor so tests can replace
+// its operation hooks without unchecked type assertions at each call site.
+func newTestSigningExecutor(t *testing.T, workers int) *boundedSigningExecutor {
+	t.Helper()
+
+	executor, ok := NewSigningExecutor(workers).(*boundedSigningExecutor)
+	require.True(t, ok)
+
+	return executor
+}

--- a/round/signing_executor_test.go
+++ b/round/signing_executor_test.go
@@ -230,6 +230,30 @@ func TestSigningExecutorCreateFailure(t *testing.T) {
 	require.Same(t, sessions[0], <-cleanedSessions)
 }
 
+// TestSigningExecutorConcurrentFailures verifies that failures from jobs
+// already running at cancellation remain available in deterministic order.
+func TestSigningExecutorConcurrentFailures(t *testing.T) {
+	t.Parallel()
+
+	executor := newTestSigningExecutor(t, 2)
+	errZero := errors.New("zero failed")
+	errOne := errors.New("one failed")
+	jobErrors := []error{errZero, errOne}
+
+	var started sync.WaitGroup
+	started.Add(len(jobErrors))
+	err := executor.run(t.Context(), len(jobErrors), func(index int) error {
+		started.Done()
+		started.Wait()
+
+		return jobErrors[index]
+	})
+
+	require.ErrorIs(t, err, errZero)
+	require.ErrorIs(t, err, errOne)
+	require.EqualError(t, err, "zero failed\none failed")
+}
+
 // TestSigningExecutorCancellation verifies cancellation stops new jobs and
 // cleans a session returned by an already-running signer call.
 func TestSigningExecutorCancellation(t *testing.T) {

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -3,6 +3,7 @@ package round
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -31,6 +32,27 @@ import (
 // BoardingIntent.
 func buildBoardingRequest(intent BoardingIntent) types.BoardingRequest {
 	return intent.Request
+}
+
+// cleanupSignerSessions releases all transaction-level MuSig2 sessions. It
+// attempts every signer path so one cleanup failure cannot strand the rest.
+func cleanupSignerSessions(sessions map[SignerKey]*tree.SignerSession) error {
+	cleanupErrors := make([]error, 0)
+	for signerKey, session := range sessions {
+		if session == nil {
+			continue
+		}
+
+		err := session.Cleanup()
+		if err != nil {
+			cleanupErrors = append(
+				cleanupErrors, fmt.Errorf("clean up signer "+
+					"%x: %w", signerKey[:], err),
+			)
+		}
+	}
+
+	return errors.Join(cleanupErrors...)
 }
 
 // failWithNotification creates a state transition to ClientFailedState and
@@ -2356,10 +2378,12 @@ func (s *CommitmentTxValidatedState) processEvent(ctx context.Context,
 		}
 
 		// At this point, all the basic validation checks have passed.
-		// So now we'll generate a musig2 session to create nonces to
-		// sign the VTXO tree. Each VTXO that we created will
-		// effectively be a new musig session.
-		musig2Sessions := make(map[SignerKey]*tree.SignerSession)
+		// Build one independent signing job for each VTXO. The executor
+		// bounds concurrency across signer paths while each path keeps
+		// its transaction sessions ordered locally.
+		sessionJobs := make(
+			[]CreateSignerSessionJob, 0, len(s.Intents.VTXOs),
+		)
 		for _, vtxoReq := range s.Intents.VTXOs {
 			signerKey := NewSignerKey(
 				vtxoReq.SigningKey.PubKey,
@@ -2385,30 +2409,35 @@ func (s *CommitmentTxValidatedState) processEvent(ctx context.Context,
 					signerKey[:], err)
 			}
 
-			// TODO(roasbeef): actually use the interface
-			// in front of this?
-			session, err := tree.NewSignerSession(
-				env.Wallet, &vtxoReq.SigningKey, sweepTweak,
-				prevOutFetcher, clientTree.Root,
+			sessionJobs = append(
+				sessionJobs, CreateSignerSessionJob{
+					SignerKey:          signerKey,
+					Signer:             env.Wallet,
+					SigningKey:         vtxoReq.SigningKey,
+					SweepTapscriptRoot: sweepTweak,
+					PrevOuts:           prevOutFetcher,
+					Root:               root,
+				},
 			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create "+
-					"signing session for client %x: %w",
-					signerKey[:], err)
-			}
-
-			musig2Sessions[signerKey] = session
 		}
 
-		// Now that we have all our sessions created, we'll have each
-		// of them generate nonces to use in tree signing. The server
-		// expects nonces grouped by signer key first, then by txid.
+		sessionResults, err := env.signingExecutor().CreateSessions(
+			ctx, sessionJobs,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create signing "+
+				"sessions: %w", err)
+		}
+
+		// Build protocol maps only after every worker completes. This
+		// keeps ordinary Go maps owned by the FSM goroutine.
+		musig2Sessions := make(map[SignerKey]*tree.SignerSession)
 		allNonces := make(
 			map[SignerKey]map[tree.TxID]tree.Musig2PubNonce,
 		)
-		for signerKey, session := range musig2Sessions {
-			nonces := session.GetNonces()
-			allNonces[signerKey] = nonces
+		for _, result := range sessionResults {
+			musig2Sessions[result.SignerKey] = result.Session
+			allNonces[result.SignerKey] = result.Nonces
 		}
 
 		env.Log.InfoS(ctx, "Generated MuSig2 nonces, sending to server",
@@ -2843,8 +2872,13 @@ func (s *NoncesSentState) processEvent(ctx context.Context, event ClientEvent,
 			// session.
 			err := musig2Session.RegisterAggNonces(aggNoncesMap)
 			if err != nil {
-				return nil, fmt.Errorf("failed to register "+
+				registerErr := fmt.Errorf("failed to register "+
 					"combined nonces: %w", err)
+				cleanupErr := cleanupSignerSessions(
+					s.Musig2Sessions,
+				)
+
+				return nil, errors.Join(registerErr, cleanupErr)
 			}
 		}
 
@@ -2877,6 +2911,13 @@ func (s *NoncesSentState) processEvent(ctx context.Context, event ClientEvent,
 		}, nil
 
 	case *BoardingFailed:
+		cleanupErr := cleanupSignerSessions(s.Musig2Sessions)
+		if cleanupErr != nil {
+			env.Log.WarnS(ctx, "Unable to clean up MuSig2 sessions",
+				cleanupErr,
+			)
+		}
+
 		return &ClientStateTransition{
 			NextState: &ClientFailedState{
 				Reason:      evt.Reason,
@@ -2925,20 +2966,50 @@ func (s *NoncesAggregatedState) processEvent(ctx context.Context,
 		// client, so now we'll generate and send our partial
 		// signatures. The server expects signatures grouped by signer
 		// key first, then by transaction ID.
-		allSignatures := make(
-			map[SignerKey]map[tree.TxID]*musig2.PartialSignature,
+		sessionResults := make(
+			[]SignerSessionResult, 0, len(s.Musig2Sessions),
 		)
+		signerKeys := slices.Collect(maps.Keys(s.Musig2Sessions))
+		slices.SortFunc(signerKeys, func(a, b SignerKey) int {
+			return bytes.Compare(a[:], b[:])
+		})
+		for _, signerKey := range signerKeys {
+			session := s.Musig2Sessions[signerKey]
+			if session == nil {
+				cleanupErr := cleanupSignerSessions(
+					s.Musig2Sessions,
+				)
 
-		for signerKey, musig2Session := range s.Musig2Sessions {
-			// Generate partial signatures for all transactions in
-			// our path. The map is keyed by transaction ID.
-			partialSigs, err := musig2Session.Signatures(true)
-			if err != nil {
-				return nil, fmt.Errorf("failed to generate "+
-					"partial signatures: %w", err)
+				return nil, errors.Join(
+					fmt.Errorf("signing session for "+
+						"client %x not found",
+						signerKey[:]),
+					cleanupErr,
+				)
 			}
 
-			allSignatures[signerKey] = partialSigs
+			sessionResults = append(
+				sessionResults, SignerSessionResult{
+					SignerKey: signerKey,
+					Session:   session,
+				},
+			)
+		}
+
+		signatureResults, err := env.signingExecutor().Sign(
+			ctx, sessionResults,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate partial "+
+				"signatures: %w", err)
+		}
+
+		allSignatures := make(
+			map[SignerKey]map[tree.TxID]*musig2.PartialSignature,
+			len(signatureResults),
+		)
+		for _, result := range signatureResults {
+			allSignatures[result.SignerKey] = result.Signatures
 		}
 
 		// Create a single message with all signatures grouped by signer

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -2384,10 +2384,22 @@ func (s *CommitmentTxValidatedState) processEvent(ctx context.Context,
 		sessionJobs := make(
 			[]CreateSignerSessionJob, 0, len(s.Intents.VTXOs),
 		)
+		seenSignerKeys := make(
+			map[SignerKey]struct{}, len(s.Intents.VTXOs),
+		)
 		for _, vtxoReq := range s.Intents.VTXOs {
 			signerKey := NewSignerKey(
 				vtxoReq.SigningKey.PubKey,
 			)
+
+			// Protocol session and nonce maps are keyed solely by
+			// signer key. Reject duplicates before creating signer
+			// resources so map assembly cannot orphan a session.
+			if _, ok := seenSignerKeys[signerKey]; ok {
+				return nil, fmt.Errorf("duplicate "+
+					"signer key %x", signerKey[:])
+			}
+			seenSignerKeys[signerKey] = struct{}{}
 
 			// Get the client tree for this signer key.
 			// The sweep tweak and batch output are

--- a/round/transitions_test.go
+++ b/round/transitions_test.go
@@ -1637,6 +1637,26 @@ func TestCommitmentTxValidatedState(t *testing.T) {
 		h.assertOutboxContainsType("*round.SubmitNoncesRequest")
 	})
 
+	t.Run("duplicate_signer_key_rejected", func(t *testing.T) {
+		t.Parallel()
+
+		h := newTestHarness(t)
+		intent := h.newTestBoardingIntent()
+		state := h.newCommitmentTxValidatedState(
+			testRoundIDTr("duplicate-signer"),
+			[]BoardingIntent{intent},
+		)
+		state.Intents.VTXOs = append(
+			state.Intents.VTXOs, state.Intents.VTXOs[0],
+		)
+		h.withState(state)
+
+		transition, err := h.sendEvent(&GenerateNonces{})
+		require.ErrorContains(t, err, "duplicate signer key")
+		require.Nil(t, transition)
+		h.wallet.AssertNotCalled(t, "MuSig2CreateSession")
+	})
+
 	t.Run("leave_only_round_starts_forfeit_timeout", func(t *testing.T) {
 		t.Parallel()
 

--- a/sample-darepod.conf
+++ b/sample-darepod.conf
@@ -35,6 +35,11 @@
 # value disables the timeout.
 # registrationtimeout=0s
 
+# Maximum number of VTXO MuSig2 signer sessions processed concurrently. Zero
+# selects four workers for the profiled lwwallet backend and one worker for lnd,
+# btcwallet, and unknown signers. Set one to force serial signing.
+# signingworkers=0
+
 # Explicit opt-in for mainnet operation.
 # allow-mainnet=false
 

--- a/sdk/walletdk/embedded.go
+++ b/sdk/walletdk/embedded.go
@@ -44,6 +44,7 @@ func DefaultConfig() Config {
 		SwapServerInsecure:    cfg.Swap.ServerInsecure,
 		SwapDatabaseFileName:  cfg.Swap.DatabaseFileName,
 		MaxOperatorFeeSat:     cfg.MaxOperatorFeeSat,
+		SigningWorkers:        cfg.SigningWorkers,
 		EagerRoundJoin:        cfg.EagerRoundJoin,
 	}
 }
@@ -259,6 +260,9 @@ func applyConfigOverrides(daemonCfg *darepod.Config, cfg Config) {
 	}
 	if cfg.MaxOperatorFeeSat != 0 {
 		daemonCfg.MaxOperatorFeeSat = cfg.MaxOperatorFeeSat
+	}
+	if cfg.SigningWorkers != 0 {
+		daemonCfg.SigningWorkers = cfg.SigningWorkers
 	}
 	if cfg.EagerRoundJoin {
 		daemonCfg.EagerRoundJoin = true

--- a/sdk/walletdk/embedded_config.go
+++ b/sdk/walletdk/embedded_config.go
@@ -7,6 +7,10 @@ import (
 	"github.com/lightninglabs/darepo-client/darepod"
 )
 
+// MaxSigningWorkers is the largest bounded MuSig2 worker count accepted by
+// the embedded daemon and mobile configuration surfaces.
+const MaxSigningWorkers = darepod.MaxSigningWorkers
+
 // Config controls the embedded daemon and wallet facade.
 type Config struct {
 	// DaemonConfig supplies the full daemon config. When nil, walletdk
@@ -94,6 +98,10 @@ type Config struct {
 
 	// MaxOperatorFeeSat caps the per-round operator fee the daemon accepts.
 	MaxOperatorFeeSat int64
+
+	// SigningWorkers bounds concurrent VTXO MuSig2 signer sessions. Zero
+	// selects the wallet-backend default and one forces serial signing.
+	SigningWorkers int
 
 	// EagerRoundJoin makes the embedded daemon's wallet drive
 	// round-joining without waiting for a follow-up Board /

--- a/sdk/walletdk/embedded_test.go
+++ b/sdk/walletdk/embedded_test.go
@@ -13,6 +13,32 @@ import (
 	"google.golang.org/grpc"
 )
 
+// TestSigningWorkersOverride verifies embedded hosts can force serial signing
+// while a zero convenience value preserves a caller-owned daemon setting.
+func TestSigningWorkersOverride(t *testing.T) {
+	t.Parallel()
+
+	t.Run("convenience override", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultConfig()
+		cfg.SigningWorkers = 1
+		daemonCfg, err := daemonConfig(cfg)
+		require.NoError(t, err)
+		require.Equal(t, 1, daemonCfg.SigningWorkers)
+	})
+
+	t.Run("zero preserves daemon config", func(t *testing.T) {
+		t.Parallel()
+
+		base := darepod.DefaultConfig()
+		base.SigningWorkers = 8
+		daemonCfg, err := daemonConfig(Config{DaemonConfig: base})
+		require.NoError(t, err)
+		require.Equal(t, 8, daemonCfg.SigningWorkers)
+	})
+}
+
 // TestCloneDaemonConfigIsolation verifies that cloneDaemonConfig produces a
 // graph whose reference-typed fields can be mutated independently of the
 // original. This is the actual contract Start relies on when it injects its

--- a/sdk/walletdk/mobile/config.go
+++ b/sdk/walletdk/mobile/config.go
@@ -49,6 +49,7 @@ type mobileConfig struct {
 	SwapDatabaseFileName  string `json:"swap_database_file_name"`
 
 	MaxOperatorFeeSat int64 `json:"max_operator_fee_sat"`
+	SigningWorkers    int64 `json:"signing_workers"`
 	EagerRoundJoin    bool  `json:"eager_round_join"`
 	BufferSize        int   `json:"buffer_size"`
 }
@@ -101,6 +102,10 @@ func (mc mobileConfig) validate() error {
 			"max_operator_fee_sat",
 			mc.MaxOperatorFeeSat,
 		},
+		{
+			"signing_workers",
+			mc.SigningWorkers,
+		},
 	}
 	for _, f := range nonNegative {
 		if f.v < 0 {
@@ -119,6 +124,10 @@ func (mc mobileConfig) validate() error {
 	if mc.WalletRecoveryWindow > math.MaxUint32 {
 		return fmt.Errorf("wallet_recovery_window exceeds "+
 			"uint32 max: %d", mc.WalletRecoveryWindow)
+	}
+	if mc.SigningWorkers > int64(walletdk.MaxSigningWorkers) {
+		return fmt.Errorf("signing_workers exceeds maximum %d: %d",
+			walletdk.MaxSigningWorkers, mc.SigningWorkers)
 	}
 
 	return nil
@@ -202,6 +211,9 @@ func applyMobileConfig(cfg *walletdk.Config, mc mobileConfig) {
 
 	if mc.MaxOperatorFeeSat != 0 {
 		cfg.MaxOperatorFeeSat = mc.MaxOperatorFeeSat
+	}
+	if mc.SigningWorkers != 0 {
+		cfg.SigningWorkers = int(mc.SigningWorkers)
 	}
 	if mc.EagerRoundJoin {
 		cfg.EagerRoundJoin = true

--- a/sdk/walletdk/mobile/mobile_test.go
+++ b/sdk/walletdk/mobile/mobile_test.go
@@ -4,6 +4,7 @@ package mobile
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -41,6 +42,7 @@ func TestParseConfigOverlaysSetFields(t *testing.T) {
 		"wallet_poll_interval_seconds": 5,
 		"wallet_recovery_window": 250,
 		"max_operator_fee_sat": 1000,
+		"signing_workers": 1,
 		"buffer_size": 4096
 	}`
 
@@ -70,6 +72,9 @@ func TestParseConfigOverlaysSetFields(t *testing.T) {
 	if got.MaxOperatorFeeSat != 1000 {
 		t.Fatalf("max operator fee = %d", got.MaxOperatorFeeSat)
 	}
+	if got.SigningWorkers != 1 {
+		t.Fatalf("signing workers = %d", got.SigningWorkers)
+	}
 	if got.BufferSize != 4096 {
 		t.Fatalf("buffer size = %d", got.BufferSize)
 	}
@@ -91,6 +96,7 @@ func TestParseConfigRejectsNegativeScalars(t *testing.T) {
 		"poll interval":    `{"wallet_poll_interval_seconds": -1}`,
 		"recovery window":  `{"wallet_recovery_window": -5}`,
 		"max operator fee": `{"max_operator_fee_sat": -1000}`,
+		"signing workers":  `{"signing_workers": -1}`,
 		"buffer size":      `{"buffer_size": -1}`,
 	}
 	for name, cfgJSON := range cases {
@@ -109,6 +115,16 @@ func TestParseConfigRejectsOverflowRecoveryWindow(t *testing.T) {
 	); err == nil {
 
 		t.Fatal("expected error for recovery window above uint32 max")
+	}
+}
+
+// TestParseConfigRejectsExcessiveSigningWorkers verifies the mobile boundary
+// applies the same bounded concurrency cap as darepod.
+func TestParseConfigRejectsExcessiveSigningWorkers(t *testing.T) {
+	cfgJSON := fmt.Sprintf(`{"signing_workers": %d}`,
+		walletdk.MaxSigningWorkers+1)
+	if _, err := parseConfig(cfgJSON); err == nil {
+		t.Fatal("expected error for excessive signing worker count")
 	}
 }
 


### PR DESCRIPTION
Systest coverage and benchmark harness: lightninglabs/darepo#665.

## Summary

- add a shared bounded signing executor across independent VTXO sessions while preserving sequential MuSig work within each path and the existing protocol barriers
- make MuSig session cleanup idempotent and retryable, including partial construction, failure, and actor shutdown paths
- default the in-process lwwallet signer to four workers while keeping LND, btcwallet, and unknown backends serial unless explicitly configured
- expose the bounded worker count through darepod, walletdk, and mobile configuration

## Benchmark

The production-shaped systest boards 1 BTC as 500 x 200,000 sat VTXOs. This creates 3,988 transaction signing sessions and 996 aggregate signatures.

The serial baseline spent 10.841s in the observed nonce window and 21.767s in the observed partial-signature window. Two workers still took 11.290s for partial signatures. Four workers passed the real ten-second timeout actor in three consecutive runs:

| Run | Nonce window | Signature window |
| --- | ---: | ---: |
| 1 | 4.764s | 6.919s |
| 2 | 5.112s | 6.965s |
| 3 | 5.446s | 7.156s |

Eight workers reduced the comparison signature window further to 4.252s, but four is the smallest tested default that stays within the production deadline.

## Testing

- `make fmt-changed`
- `go test ./lib/tree ./round ./darepod ./cmd/darepod ./sdk/walletdk -count=1`
- `go test -tags="mobile walletdkrpc swapruntime" ./sdk/walletdk/mobile -count=1`
- `go test -race ./lib/tree ./round -count=1`
- `go test -race ./round -run ^TestSigningExecutorRealMuSigManager$ -count=5`
- `make lint-changed-local`
- `make build`
- commit message lint