### PR TITLE
multi: surface in-flight VTXO value in wallet balance

### DIFF
--- a/daemonrpc/daemon.pb.go
+++ b/daemonrpc/daemon.pb.go
@@ -1644,8 +1644,18 @@ type GetBalanceResponse struct {
 	// as boarding address UTXOs, but remain pending inbound balance until
 	// the round's commitment transaction confirms.
 	BoardingAdoptedSat int64 `protobuf:"varint,8,opt,name=boarding_adopted_sat,json=boardingAdoptedSat,proto3" json:"boarding_adopted_sat,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// vtxo_pending_sat is the value of VTXOs being consumed by an
+	// in-flight round or out-of-round spend (pending-forfeit,
+	// forfeiting, spending). Excluded from vtxo_balance_sat and
+	// total_confirmed_sat.
+	VtxoPendingSat int64 `protobuf:"varint,9,opt,name=vtxo_pending_sat,json=vtxoPendingSat,proto3" json:"vtxo_pending_sat,omitempty"`
+	// vtxo_unilateral_exit_sat is the value of VTXOs mid unilateral
+	// exit, not yet swept. Excluded from vtxo_balance_sat and
+	// total_confirmed_sat; reappears under onchain_wallet_confirmed_sat
+	// once the sweep confirms.
+	VtxoUnilateralExitSat int64 `protobuf:"varint,10,opt,name=vtxo_unilateral_exit_sat,json=vtxoUnilateralExitSat,proto3" json:"vtxo_unilateral_exit_sat,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *GetBalanceResponse) Reset() {
@@ -1730,6 +1740,20 @@ func (x *GetBalanceResponse) GetBoardingSweptSat() int64 {
 func (x *GetBalanceResponse) GetBoardingAdoptedSat() int64 {
 	if x != nil {
 		return x.BoardingAdoptedSat
+	}
+	return 0
+}
+
+func (x *GetBalanceResponse) GetVtxoPendingSat() int64 {
+	if x != nil {
+		return x.VtxoPendingSat
+	}
+	return 0
+}
+
+func (x *GetBalanceResponse) GetVtxoUnilateralExitSat() int64 {
+	if x != nil {
+		return x.VtxoUnilateralExitSat
 	}
 	return 0
 }
@@ -9848,7 +9872,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0fwallet_password\x18\x01 \x01(\fR\x0ewalletPassword\"?\n" +
 	"\x14UnlockWalletResponse\x12'\n" +
 	"\x0fidentity_pubkey\x18\x01 \x01(\tR\x0eidentityPubkey\"\x13\n" +
-	"\x11GetBalanceRequest\"\xbc\x03\n" +
+	"\x11GetBalanceRequest\"\x9f\x04\n" +
 	"\x12GetBalanceResponse\x124\n" +
 	"\x16boarding_confirmed_sat\x18\x01 \x01(\x03R\x14boardingConfirmedSat\x128\n" +
 	"\x18boarding_unconfirmed_sat\x18\x02 \x01(\x03R\x16boardingUnconfirmedSat\x12(\n" +
@@ -9857,7 +9881,10 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1conchain_wallet_confirmed_sat\x18\x05 \x01(\x03R\x19onchainWalletConfirmedSat\x12;\n" +
 	"\x1aboarding_pending_sweep_sat\x18\x06 \x01(\x03R\x17boardingPendingSweepSat\x12,\n" +
 	"\x12boarding_swept_sat\x18\a \x01(\x03R\x10boardingSweptSat\x120\n" +
-	"\x14boarding_adopted_sat\x18\b \x01(\x03R\x12boardingAdoptedSat\"\xa0\x03\n" +
+	"\x14boarding_adopted_sat\x18\b \x01(\x03R\x12boardingAdoptedSat\x12(\n" +
+	"\x10vtxo_pending_sat\x18\t \x01(\x03R\x0evtxoPendingSat\x127\n" +
+	"\x18vtxo_unilateral_exit_sat\x18\n" +
+	" \x01(\x03R\x15vtxoUnilateralExitSat\"\xa0\x03\n" +
 	"\x0eVTXOExpiryInfo\x123\n" +
 	"\x06status\x18\x01 \x01(\x0e2\x1b.daemonrpc.VTXOExpiryStatusR\x06status\x12%\n" +
 	"\x0ecurrent_height\x18\x02 \x01(\x05R\rcurrentHeight\x12!\n" +

--- a/daemonrpc/daemon.proto
+++ b/daemonrpc/daemon.proto
@@ -540,6 +540,18 @@ message GetBalanceResponse {
     // as boarding address UTXOs, but remain pending inbound balance until
     // the round's commitment transaction confirms.
     int64 boarding_adopted_sat = 8;
+
+    // vtxo_pending_sat is the value of VTXOs being consumed by an
+    // in-flight round or out-of-round spend (pending-forfeit,
+    // forfeiting, spending). Excluded from vtxo_balance_sat and
+    // total_confirmed_sat.
+    int64 vtxo_pending_sat = 9;
+
+    // vtxo_unilateral_exit_sat is the value of VTXOs mid unilateral
+    // exit, not yet swept. Excluded from vtxo_balance_sat and
+    // total_confirmed_sat; reappears under onchain_wallet_confirmed_sat
+    // once the sweep confirms.
+    int64 vtxo_unilateral_exit_sat = 10;
 }
 
 // VTXOStatus represents the lifecycle state of a virtual transaction

--- a/darepod/rpc_balance_test.go
+++ b/darepod/rpc_balance_test.go
@@ -1,0 +1,137 @@
+package darepod
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/darepo-client/db"
+	"github.com/lightninglabs/darepo-client/lib/actormsg"
+	"github.com/lightninglabs/darepo-client/vtxo"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeExitJobLookup is an in-memory exitJobLookup. A missing outpoint returns
+// db.ErrUnilateralExitJobNotFound, mirroring the real store.
+type fakeExitJobLookup struct {
+	jobs map[wire.OutPoint]*db.UnilateralExitJobRecord
+	err  error
+}
+
+// GetJob returns the seeded job for an outpoint, the seeded error, or
+// db.ErrUnilateralExitJobNotFound.
+func (f *fakeExitJobLookup) GetJob(_ context.Context, target wire.OutPoint) (
+	*db.UnilateralExitJobRecord, error) {
+
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	job, ok := f.jobs[target]
+	if !ok {
+		return nil, db.ErrUnilateralExitJobNotFound
+	}
+
+	return job, nil
+}
+
+// exitOutpoint builds a distinct outpoint from an index.
+func exitOutpoint(i byte) wire.OutPoint {
+	var hash chainhash.Hash
+	hash[0] = i
+
+	return wire.OutPoint{Hash: hash, Index: uint32(i)}
+}
+
+// TestSumWalletUnilateralExits checks that wallet exits (standard policy or
+// no job) are summed and recovery-only targets (non-standard policy) skipped.
+func TestSumWalletUnilateralExits(t *testing.T) {
+	t.Parallel()
+
+	var (
+		standardOp = exitOutpoint(1)
+		emptyOp    = exitOutpoint(2)
+		noJobOp    = exitOutpoint(3)
+		claimOp    = exitOutpoint(4)
+		refundOp   = exitOutpoint(5)
+	)
+
+	exiting := []*vtxo.Descriptor{
+		{
+			Outpoint: standardOp,
+			Amount:   10_000,
+		},
+		{
+			Outpoint: emptyOp,
+			Amount:   20_000,
+		},
+		{
+			Outpoint: noJobOp,
+			Amount:   40_000,
+		},
+		{
+			Outpoint: claimOp,
+			Amount:   80_000,
+		},
+		{
+			Outpoint: refundOp,
+			Amount:   160_000,
+		},
+	}
+
+	// The two vHTLC recovery policy kinds, aliased to keep the map short.
+	claimKind := string(actormsg.ExitPolicyVHTLCClaim)
+	refundKind := string(actormsg.ExitPolicyVHTLCRefundWithoutReceiver)
+
+	job := func(op wire.OutPoint, kind string) *db.UnilateralExitJobRecord {
+		return &db.UnilateralExitJobRecord{
+			TargetOutpoint: op,
+			ExitPolicyKind: kind,
+		}
+	}
+
+	// noJobOp intentionally has no entry: a VTXO with no exit job.
+	lookup := &fakeExitJobLookup{
+		jobs: map[wire.OutPoint]*db.UnilateralExitJobRecord{
+			standardOp: job(standardOp, "standard_vtxo_timeout"),
+			emptyOp:    job(emptyOp, ""),
+			claimOp:    job(claimOp, claimKind),
+			refundOp:   job(refundOp, refundKind),
+		},
+	}
+
+	// Wallet exits only: 10_000 + 20_000 + 40_000.
+	total, err := sumWalletUnilateralExits(t.Context(), exiting, lookup)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(70_000), total)
+}
+
+// TestSumWalletUnilateralExitsPropagatesError confirms a store failure is
+// surfaced rather than counted as zero.
+func TestSumWalletUnilateralExitsPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	lookup := &fakeExitJobLookup{err: errors.New("store down")}
+	exiting := []*vtxo.Descriptor{
+		{
+			Outpoint: exitOutpoint(1),
+			Amount:   10_000,
+		},
+	}
+
+	_, err := sumWalletUnilateralExits(t.Context(), exiting, lookup)
+	require.Error(t, err)
+}
+
+// TestSumWalletUnilateralExitsEmpty guards the empty-input case.
+func TestSumWalletUnilateralExitsEmpty(t *testing.T) {
+	t.Parallel()
+
+	lookup := &fakeExitJobLookup{}
+	total, err := sumWalletUnilateralExits(t.Context(), nil, lookup)
+	require.NoError(t, err)
+	require.Zero(t, total)
+}

--- a/darepod/rpc_server.go
+++ b/darepod/rpc_server.go
@@ -738,19 +738,39 @@ func (r *RPCServer) GetBalance(ctx context.Context,
 	// trusts the response, which is the same rationale that makes
 	// fetchBoardingBalance error-strict above.
 	if r.server.vtxoStore != nil {
-		// ListLiveVTXOs returns every non-terminal VTXO (Live,
-		// PendingForfeit, Forfeiting, Spending) because it backs
-		// actor recovery, not spendability. Sum only the spendable
-		// (Live) subset: counting PendingForfeit/Spending here would
-		// overstate vtxo_balance_sat, which consumers such as the
-		// auto-boarder read as spendable liquidity and would then
-		// stop replenishing.
+		// Only the Live subset is spendable; the other non-terminal
+		// states would overstate vtxo_balance_sat.
 		liveVTXOs, err := r.server.vtxoStore.ListLiveVTXOs(ctx)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "fetch vtxo "+
 				"balance: %v", err)
 		}
 		resp.VtxoBalanceSat = int64(vtxo.SumSpendableBalance(liveVTXOs))
+		resp.VtxoPendingSat = int64(vtxo.SumPendingBalance(liveVTXOs))
+
+		// Exiting VTXOs aren't in ListLiveVTXOs; query them directly.
+		// Light skips the ancestry side table a balance never walks.
+		exiting, err := r.server.vtxoStore.ListVTXOsByStatusLight(
+			ctx, vtxo.VTXOStatusUnilateralExit,
+		)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "fetch "+
+				"exiting vtxo balance: %v", err)
+		}
+
+		// Exclude recovery-only exit targets (not wallet liquidity).
+		// Absent the exit-job store, no such targets exist.
+		exitSat := vtxo.SumBalance(exiting)
+		if r.server.ueStore != nil {
+			exitSat, err = sumWalletUnilateralExits(
+				ctx, exiting, r.server.ueStore,
+			)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal,
+					"sum exiting vtxo balance: %v", err)
+			}
+		}
+		resp.VtxoUnilateralExitSat = int64(exitSat)
 	}
 
 	// Fetch the confirmed balance of the backing on-chain wallet so
@@ -832,6 +852,43 @@ func (r *RPCServer) fetchBoardingBalance(ctx context.Context,
 	resp.BoardingSweptSat = int64(sumAmounts(swept))
 
 	return nil
+}
+
+// exitJobLookup reads one exit job's policy identity; kept narrow so the
+// balance sum can be faked in tests.
+type exitJobLookup interface {
+	GetJob(ctx context.Context,
+		target wire.OutPoint) (*db.UnilateralExitJobRecord, error)
+}
+
+// sumWalletUnilateralExits sums unilateral-exit VTXOs that are wallet
+// inventory, excluding recovery-only targets (a non-standard exit policy,
+// e.g. a vHTLC refund) whose value is not spendable wallet liquidity.
+func sumWalletUnilateralExits(ctx context.Context, exiting []*vtxo.Descriptor,
+	jobs exitJobLookup) (btcutil.Amount, error) {
+
+	var total btcutil.Amount
+	for _, desc := range exiting {
+		job, err := jobs.GetJob(ctx, desc.Outpoint)
+
+		// No job: standard wallet exit.
+		if errors.Is(err, db.ErrUnilateralExitJobNotFound) {
+			total += desc.Amount
+			continue
+		}
+		if err != nil {
+			return 0, err
+		}
+
+		// Non-standard policy: recovery-only, not wallet value.
+		if actormsg.ExitPolicyKind(job.ExitPolicyKind).Valid() {
+			continue
+		}
+
+		total += desc.Amount
+	}
+
+	return total, nil
 }
 
 // fetchUnconfirmedBoardingBalance sums zero-conf wallet UTXOs that pay to known

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -159,8 +159,12 @@ default builds avoid the swap executor's dependency graph.
   shape: `confirmed_sat` is VTXO-only (`vtxo_balance_sat`),
   `pending_in_sat` sums `boarding_confirmed_sat +
   boarding_unconfirmed_sat + boarding_adopted_sat`, and
-  `pending_out_sat` mirrors `boarding_pending_sweep_sat`.
-  Confirmed-but-not-yet-boarded UTXOs must NOT inflate
+  `pending_out_sat` sums `boarding_pending_sweep_sat +
+  vtxo_pending_sat + vtxo_unilateral_exit_sat`. The two VTXO buckets
+  carry value locked in an in-flight round / OOR spend and in a
+  unilateral on-chain exit; folding them into `pending_out_sat` keeps
+  the balance from momentarily reading zero mid-refresh, mid-spend, or
+  mid-leave. Confirmed-but-not-yet-boarded UTXOs must NOT inflate
   `confirmed_sat` (issue #502), and adopted-but-not-yet-live VTXOs
   must stay pending inbound until commitment confirmation (issue #542).
 

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -584,12 +584,17 @@ func (s *Service) fetchBalance(ctx context.Context) (
 	// immediately after a faucet deposit, before any round commit, which
 	// the proto contract (and the `send` verb's runtime check)
 	// explicitly disallow.
+	// pending_out_sat sums outbound and in-flight value: the boarding
+	// sweep plus both in-flight VTXO buckets. confirmed_sat is VTXO-live
+	// only.
 	resp := &walletdkrpc.BalanceResponse{
 		ConfirmedSat: bal.GetVtxoBalanceSat(),
 		PendingInSat: bal.GetBoardingConfirmedSat() +
 			bal.GetBoardingUnconfirmedSat() +
 			bal.GetBoardingAdoptedSat(),
-		PendingOutSat: bal.GetBoardingPendingSweepSat(),
+		PendingOutSat: bal.GetBoardingPendingSweepSat() +
+			bal.GetVtxoPendingSat() +
+			bal.GetVtxoUnilateralExitSat(),
 	}
 
 	if s.deps.SwapService == nil {

--- a/swapwallet/service_test.go
+++ b/swapwallet/service_test.go
@@ -237,6 +237,8 @@ func TestServiceBalanceProjectsDaemonGetBalance(t *testing.T) {
 		BoardingAdoptedSat:      15_000,
 		TotalConfirmedSat:       175_000, // ignored by the mapping
 		BoardingPendingSweepSat: 5_000,
+		VtxoPendingSat:          8_000,
+		VtxoUnilateralExitSat:   3_000,
 	}
 
 	resp, err := svc.Balance(
@@ -245,7 +247,77 @@ func TestServiceBalanceProjectsDaemonGetBalance(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(75_000), resp.GetConfirmedSat())
 	require.Equal(t, int64(135_000), resp.GetPendingInSat())
-	require.Equal(t, int64(5_000), resp.GetPendingOutSat())
+
+	// 5_000 + 8_000 + 3_000.
+	require.Equal(t, int64(16_000), resp.GetPendingOutSat())
+}
+
+// TestServiceBalanceSurfacesInFlightVTXOs checks that in-flight VTXO value
+// surfaces under pending_out rather than reading zero.
+func TestServiceBalanceSurfacesInFlightVTXOs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		balance        *daemonrpc.GetBalanceResponse
+		wantConfirmed  int64
+		wantPendingIn  int64
+		wantPendingOut int64
+	}{
+		{
+			name: "refresh in flight",
+			balance: &daemonrpc.GetBalanceResponse{
+				VtxoPendingSat: 50_000,
+			},
+			wantConfirmed:  0,
+			wantPendingIn:  0,
+			wantPendingOut: 50_000,
+		},
+		{
+			name: "near-expiry pending-forfeit and exit",
+			balance: &daemonrpc.GetBalanceResponse{
+				VtxoPendingSat:        30_000,
+				VtxoUnilateralExitSat: 70_000,
+			},
+			wantConfirmed:  0,
+			wantPendingIn:  0,
+			wantPendingOut: 100_000,
+		},
+		{
+			name: "outgoing send inputs forfeiting",
+			balance: &daemonrpc.GetBalanceResponse{
+				VtxoBalanceSat: 40_000,
+				VtxoPendingSat: 60_000,
+			},
+			wantConfirmed:  40_000,
+			wantPendingIn:  0,
+			wantPendingOut: 60_000,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc, _, rpc := newServiceFixture(t)
+			rpc.getBalanceResp = tc.balance
+
+			resp, err := svc.Balance(
+				t.Context(), &walletdkrpc.BalanceRequest{},
+			)
+			require.NoError(t, err)
+			require.Equal(
+				t, tc.wantConfirmed, resp.GetConfirmedSat(),
+			)
+			require.Equal(
+				t, tc.wantPendingIn, resp.GetPendingInSat(),
+			)
+			require.Equal(
+				t, tc.wantPendingOut, resp.GetPendingOutSat(),
+			)
+		})
+	}
 }
 
 func TestServiceBalanceIncludesCredits(t *testing.T) {

--- a/vtxo/filter.go
+++ b/vtxo/filter.go
@@ -70,3 +70,25 @@ func SumSpendableBalance(descs []*Descriptor) btcutil.Amount {
 
 	return SumBalance(spendable)
 }
+
+// SumPendingBalance sums VTXOs in a non-terminal, non-spendable state
+// (PendingForfeit, Forfeiting, Spending): the complement of
+// SumSpendableBalance over the set ListLiveVTXOs returns. UnilateralExit
+// is not in that set and is accounted for separately.
+func SumPendingBalance(descs []*Descriptor) btcutil.Amount {
+	var total btcutil.Amount
+	for _, d := range descs {
+		switch d.Status {
+		case VTXOStatusPendingForfeit, VTXOStatusForfeiting,
+			VTXOStatusSpending:
+
+			total += d.Amount
+
+		// Spendable, terminal, or separately accounted.
+		case VTXOStatusLive, VTXOStatusForfeited, VTXOStatusSpent,
+			VTXOStatusUnilateralExit, VTXOStatusFailed:
+		}
+	}
+
+	return total
+}

--- a/vtxo/filter_test.go
+++ b/vtxo/filter_test.go
@@ -79,3 +79,85 @@ func TestSumSpendableBalanceEmpty(t *testing.T) {
 	require.Zero(t, SumSpendableBalance(nil))
 	require.Zero(t, SumSpendableBalance([]*Descriptor{}))
 }
+
+// TestSumPendingBalance checks that only PendingForfeit, Forfeiting, and
+// Spending are summed, excluding Live and the terminal states.
+func TestSumPendingBalance(t *testing.T) {
+	t.Parallel()
+
+	descs := []*Descriptor{
+		{
+			Amount: 1_000,
+			Status: VTXOStatusLive,
+		},
+		{
+			Amount: 5_000,
+			Status: VTXOStatusPendingForfeit,
+		},
+		{
+			Amount: 7_000,
+			Status: VTXOStatusForfeiting,
+		},
+		{
+			Amount: 9_000,
+			Status: VTXOStatusSpending,
+		},
+		{
+			Amount: 11_000,
+			Status: VTXOStatusUnilateralExit,
+		},
+		{
+			Amount: 13_000,
+			Status: VTXOStatusForfeited,
+		},
+		{
+			Amount: 17_000,
+			Status: VTXOStatusSpent,
+		},
+		{
+			Amount: 19_000,
+			Status: VTXOStatusFailed,
+		},
+	}
+
+	require.Equal(
+		t, btcutil.Amount(21_000), SumPendingBalance(descs),
+	)
+
+	// Spendable and pending partition the live set with nothing dropped.
+	liveSet := []*Descriptor{
+		{
+			Amount: 1_000,
+			Status: VTXOStatusLive,
+		},
+		{
+			Amount: 2_000,
+			Status: VTXOStatusLive,
+		},
+		{
+			Amount: 5_000,
+			Status: VTXOStatusPendingForfeit,
+		},
+		{
+			Amount: 7_000,
+			Status: VTXOStatusForfeiting,
+		},
+		{
+			Amount: 9_000,
+			Status: VTXOStatusSpending,
+		},
+	}
+	spendable := SumSpendableBalance(liveSet)
+	pending := SumPendingBalance(liveSet)
+	require.Equal(t, btcutil.Amount(3_000), spendable)
+	require.Equal(t, btcutil.Amount(21_000), pending)
+	require.Equal(t, SumBalance(liveSet), spendable+pending)
+}
+
+// TestSumPendingBalanceEmpty guards the empty-input case.
+func TestSumPendingBalanceEmpty(t *testing.T) {
+	t.Parallel()
+
+	require.Zero(t, SumPendingBalance(nil))
+	require.Zero(t, SumPendingBalance([]*Descriptor{}))
+}


### PR DESCRIPTION
In this PR, we fix a balance-accounting gap in `GetBalance`. Today the daemon
derives its balance straight from the VTXO and boarding stores, and there's no
bucket for value that's locked in a non-terminal, in-flight state. A VTXO
mid-refresh (`PENDING_FORFEIT`/`FORFEITING`), one claimed for an out-of-round
spend (`SPENDING`), or one on its way out via a unilateral exit
(`UNILATERAL_EXIT`) falls out of every balance field. The wallet then
momentarily reads _zero_ for that value until the round or exit settles, which
is the root of #648, #760, and #765.

This is a daemon-side accounting gap, not an activity-feed one: it lives on the
`swapwallet.Balance` -> `GetBalance` path and never touches `listActivity`. It
was split out of the event-log epic (#776) for exactly that reason.

## Where the value was going

`GetBalance` reads `ListLiveVTXOs`, which returns every non-terminal VTXO
(`Live`, `PendingForfeit`, `Forfeiting`, `Spending`) because it backs actor
recovery, not spendability. But we only summed the `Live` subset via
`SumSpendableBalance` into `vtxo_balance_sat`, so the other three states were
fetched and then dropped on the floor. `UnilateralExit` isn't even in
`ListLiveVTXOs` (it's terminal for recovery), so it fell through entirely.

The constraint that shapes the fix is that the VTXO FSM models lifecycle phases
only, not business intent: a `PendingForfeit` VTXO can't tell us whether it's a
refresh (the value comes back to us) or a cooperative leave (the value leaves).
So we don't try to split these by direction. We also sum the input/store side
rather than the synthetic pending-round outputs the round FSM projects, since
every in-flight output already has an input representation in the store (a
forfeiting VTXO, or adopted boarding we already count), and counting both would
double the balance while a round is live.

## The fix

We add two fields to `GetBalanceResponse`:

- `vtxo_pending_sat`: value being consumed by an in-flight round or OOR spend
  (`PendingForfeit` + `Forfeiting` + `Spending`), summed by the new
  `vtxo.SumPendingBalance` helper over the same `ListLiveVTXOs` set.
- `vtxo_unilateral_exit_sat`: value in VTXOs mid on-chain exit, queried
  directly via `ListVTXOsByStatusLight(UnilateralExit)` since they're excluded
  from the live set. Once the exit sweep confirms, these proceeds reappear
  under `onchain_wallet_confirmed_sat`.

Both stay out of `total_confirmed_sat`, since the value is neither spendable nor
terminal, and `confirmed_sat`/`vtxo_balance_sat` stays `Live`-only (#502). We
track the two separately rather than as one lump because the exit lifecycle is
distinct and its proceeds land in a different downstream field.

The `swapwallet` Balance projection then folds both into `pending_out_sat`,
alongside the existing `boarding_pending_sweep_sat`. Every non-terminal
VTXO/boarding state now maps to exactly one bucket (confirmed, pending-in, or
pending-out), with nothing falling through. On round or exit confirmation the
handoff is clean: the input goes terminal and drops, and the replacement/change
VTXO is written `Live` (confirmed) or the sweep lands on-chain.

## Testing

Unit coverage for the new sum helper (`vtxo.SumPendingBalance`, plus a
partition check that spendable + pending exactly covers the live set) and for
the Balance projection, with table cases pinning the refresh, near-expiry-exit,
and outgoing-send scenarios.

An end-to-end regression test lives in swapdk-server (the walletdk full-stack
itest): board a VTXO, force-unroll it, then assert its value moves from
`confirmed_sat` to `pending_out_sat` rather than vanishing. It fails on the
pre-fix client ("exiting VTXO value did not move to pending_out_sat") and
passes with this change. That PR follows once this one lands and bumps the
pinned client.

See each commit message for a detailed description w.r.t the incremental
changes.

Fixes #816.
