### PR TITLE
multi: Persist exit funding address across restarts

### DIFF
--- a/darepod/rpc_exit_plan.go
+++ b/darepod/rpc_exit_plan.go
@@ -487,9 +487,29 @@ func (s *Server) exitPlanFundingAddress(ctx context.Context, outpoint string,
 		return "", nil
 	}
 
-	return s.exitFundingAddresses.Address(
-		ctx, outpoint, s.NewWalletAddress,
-	)
+	target, err := parseOutpointString(outpoint)
+	if err != nil {
+		return "", fmt.Errorf("parse funding outpoint: %w", err)
+	}
+
+	// The funding address is persisted per target outpoint so it is stable
+	// across daemon restarts: a restart must not derive a fresh address and
+	// demand a second deposit for the same VTXO (darepo-client#893).
+	//
+	// Reuse the daemon's already-initialized unilateral-exit store; only
+	// build one in the rare window before startup wires s.ueStore. This
+	// avoids recreating the store and its logger on every call, e.g. across
+	// a batch exit-plan request that funds several outpoints.
+	store := s.ueStore
+	if store == nil {
+		dbStore := db.NewStore(
+			s.db.DB, s.db.Queries, s.db.Backend(),
+			s.subLogger(db.Subsystem),
+		)
+		store = dbStore.NewUnilateralExitStore(s.clk)
+	}
+
+	return store.FundingAddress(ctx, target, s.NewWalletAddress)
 }
 
 // ExitSummaryEntry is one in-progress exit's coarse contribution to the

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -254,11 +254,6 @@ type Server struct {
 	// handlers that require wallet access select on this channel.
 	walletReady chan struct{}
 
-	// exitFundingAddresses caches backing-wallet funding addresses returned
-	// by GetExitPlan. The unroll package owns the address-book policy so
-	// RPC handlers only request an address for a target.
-	exitFundingAddresses unroll.ExitFundingAddressBook
-
 	// daemonReady is closed when all startup steps have
 	// completed: wallet initialized, mailbox transport
 	// connected, and wallet-dependent actors started. Test

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -10,7 +10,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion uint = 10
+	LatestMigrationVersion uint = 11
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/db/sqlc/migrations/000011_exit_funding_addresses.down.sql
+++ b/db/sqlc/migrations/000011_exit_funding_addresses.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS exit_funding_addresses;

--- a/db/sqlc/migrations/000011_exit_funding_addresses.up.sql
+++ b/db/sqlc/migrations/000011_exit_funding_addresses.up.sql
@@ -1,0 +1,27 @@
+-- exit_funding_addresses stores the backing-wallet funding address handed
+-- out by an exit plan for one target VTXO outpoint. It is persisted so the
+-- same outpoint always maps to the same funding address across daemon
+-- restarts: without it a restart derives a brand-new HD receive address and
+-- demands a second deposit for the same VTXO (darepo-client#893).
+--
+-- Shipped as its own additive migration (rather than folded into
+-- 000007_unilateral_exit) because it only CREATEs a new standalone table, so
+-- existing deployments gain it without a schema reset.
+CREATE TABLE IF NOT EXISTS exit_funding_addresses (
+    -- target_outpoint_hash identifies the target VTXO transaction.
+    target_outpoint_hash BLOB NOT NULL,
+
+    -- target_outpoint_index identifies the target VTXO output index.
+    target_outpoint_index INTEGER NOT NULL CHECK (
+        target_outpoint_index >= 0
+    ),
+
+    -- funding_address is the backing-wallet receive address a user funds to
+    -- clear the exit shortfall for this outpoint.
+    funding_address TEXT NOT NULL,
+
+    -- created_at is the unix timestamp when the address was first derived.
+    created_at BIGINT NOT NULL,
+
+    PRIMARY KEY (target_outpoint_hash, target_outpoint_index)
+);

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -154,6 +154,13 @@ type CreditOperation struct {
 	UpdatedAt         int64
 }
 
+type ExitFundingAddress struct {
+	TargetOutpointHash  []byte
+	TargetOutpointIndex int32
+	FundingAddress      string
+	CreatedAt           int64
+}
+
 type InternalKey struct {
 	ID        int64
 	Pubkey    []byte

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -67,6 +67,8 @@ type Querier interface {
 	GetClientTreeTxidInfo(ctx context.Context, txid []byte) (ClientTreeTxid, error)
 	GetClientTreeTxids(ctx context.Context, arg GetClientTreeTxidsParams) ([]GetClientTreeTxidsRow, error)
 	GetCreditOperation(ctx context.Context, opID string) (CreditOperation, error)
+	// Exit funding address persistence queries (darepo-client#893).
+	GetExitFundingAddress(ctx context.Context, arg GetExitFundingAddressParams) (ExitFundingAddress, error)
 	GetInternalKeyByID(ctx context.Context, id int64) (InternalKey, error)
 	// Macaroon root key store queries.
 	GetMacaroonRootKey(ctx context.Context, id []byte) (Macaroon, error)
@@ -124,6 +126,7 @@ type Querier interface {
 	InsertClientLedgerEntry(ctx context.Context, arg InsertClientLedgerEntryParams) error
 	// Client tree txids queries.
 	InsertClientTreeTxid(ctx context.Context, arg InsertClientTreeTxidParams) error
+	InsertExitFundingAddress(ctx context.Context, arg InsertExitFundingAddressParams) error
 	InsertMacaroonRootKey(ctx context.Context, arg InsertMacaroonRootKeyParams) error
 	InsertOORPackageCheckpoint(ctx context.Context, arg InsertOORPackageCheckpointParams) error
 	// Round queries.

--- a/db/sqlc/queries/unilateral_exit.sql
+++ b/db/sqlc/queries/unilateral_exit.sql
@@ -42,3 +42,20 @@ SET status = $3,
 WHERE target_outpoint_hash = $1
   AND target_outpoint_index = $2
 ;
+
+-- Exit funding address persistence queries (darepo-client#893).
+
+-- name: GetExitFundingAddress :one
+SELECT * FROM exit_funding_addresses
+WHERE target_outpoint_hash = $1
+  AND target_outpoint_index = $2
+;
+
+-- name: InsertExitFundingAddress :exec
+INSERT INTO exit_funding_addresses (
+    target_outpoint_hash, target_outpoint_index, funding_address, created_at
+) VALUES (
+    $1, $2, $3, $4
+)
+ON CONFLICT (target_outpoint_hash, target_outpoint_index) DO NOTHING
+;

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -380,6 +380,25 @@ CREATE TABLE dead_letters (
     created_at BIGINT NOT NULL
 );
 
+CREATE TABLE exit_funding_addresses (
+    -- target_outpoint_hash identifies the target VTXO transaction.
+    target_outpoint_hash BLOB NOT NULL,
+
+    -- target_outpoint_index identifies the target VTXO output index.
+    target_outpoint_index INTEGER NOT NULL CHECK (
+        target_outpoint_index >= 0
+    ),
+
+    -- funding_address is the backing-wallet receive address a user funds to
+    -- clear the exit shortfall for this outpoint.
+    funding_address TEXT NOT NULL,
+
+    -- created_at is the unix timestamp when the address was first derived.
+    created_at BIGINT NOT NULL,
+
+    PRIMARY KEY (target_outpoint_hash, target_outpoint_index)
+);
+
 CREATE TABLE fsm_checkpoints (
     -- actor_id identifies the actor whose FSM state is checkpointed.
     actor_id TEXT PRIMARY KEY,

--- a/db/sqlc/unilateral_exit.sql.go
+++ b/db/sqlc/unilateral_exit.sql.go
@@ -10,6 +10,31 @@ import (
 	"database/sql"
 )
 
+const GetExitFundingAddress = `-- name: GetExitFundingAddress :one
+
+SELECT target_outpoint_hash, target_outpoint_index, funding_address, created_at FROM exit_funding_addresses
+WHERE target_outpoint_hash = $1
+  AND target_outpoint_index = $2
+`
+
+type GetExitFundingAddressParams struct {
+	TargetOutpointHash  []byte
+	TargetOutpointIndex int32
+}
+
+// Exit funding address persistence queries (darepo-client#893).
+func (q *Queries) GetExitFundingAddress(ctx context.Context, arg GetExitFundingAddressParams) (ExitFundingAddress, error) {
+	row := q.db.QueryRowContext(ctx, GetExitFundingAddress, arg.TargetOutpointHash, arg.TargetOutpointIndex)
+	var i ExitFundingAddress
+	err := row.Scan(
+		&i.TargetOutpointHash,
+		&i.TargetOutpointIndex,
+		&i.FundingAddress,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const GetUnilateralExitJob = `-- name: GetUnilateralExitJob :one
 SELECT target_outpoint_hash, target_outpoint_index, actor_id, status, trigger, last_error, sweep_txid, created_at, updated_at, exit_policy_kind, exit_policy_ref FROM unilateral_exit_jobs
 WHERE target_outpoint_hash = $1
@@ -38,6 +63,32 @@ func (q *Queries) GetUnilateralExitJob(ctx context.Context, arg GetUnilateralExi
 		&i.ExitPolicyRef,
 	)
 	return i, err
+}
+
+const InsertExitFundingAddress = `-- name: InsertExitFundingAddress :exec
+INSERT INTO exit_funding_addresses (
+    target_outpoint_hash, target_outpoint_index, funding_address, created_at
+) VALUES (
+    $1, $2, $3, $4
+)
+ON CONFLICT (target_outpoint_hash, target_outpoint_index) DO NOTHING
+`
+
+type InsertExitFundingAddressParams struct {
+	TargetOutpointHash  []byte
+	TargetOutpointIndex int32
+	FundingAddress      string
+	CreatedAt           int64
+}
+
+func (q *Queries) InsertExitFundingAddress(ctx context.Context, arg InsertExitFundingAddressParams) error {
+	_, err := q.db.ExecContext(ctx, InsertExitFundingAddress,
+		arg.TargetOutpointHash,
+		arg.TargetOutpointIndex,
+		arg.FundingAddress,
+		arg.CreatedAt,
+	)
+	return err
 }
 
 const ListNonTerminalUnilateralExitJobs = `-- name: ListNonTerminalUnilateralExitJobs :many

--- a/db/unilateral_exit_store.go
+++ b/db/unilateral_exit_store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/wire/v2"
@@ -118,6 +119,15 @@ type UnilateralExitStore interface {
 
 	MarkUnilateralExitJobTerminal(ctx context.Context,
 		arg sqlc.MarkUnilateralExitJobTerminalParams) error
+
+	GetExitFundingAddress(ctx context.Context,
+		arg sqlc.GetExitFundingAddressParams) (
+		sqlc.ExitFundingAddress,
+		error,
+	)
+
+	InsertExitFundingAddress(ctx context.Context,
+		arg sqlc.InsertExitFundingAddressParams) error
 }
 
 // BatchedUnilateralExitStore combines the query surface with transactions.
@@ -131,6 +141,13 @@ type BatchedUnilateralExitStore interface {
 type UnilateralExitPersistenceStore struct {
 	db    BatchedUnilateralExitStore
 	clock clock.Clock
+
+	// fundingMu serializes FundingAddress derivation so that concurrent
+	// misses on the same target do not each derive (and discard all but
+	// one) a fresh backing-wallet address, needlessly advancing the HD
+	// index. This restores the "polling a plan does not burn a wallet
+	// address" property the in-memory ExitFundingAddressBook used to hold.
+	fundingMu sync.Mutex
 }
 
 // NewUnilateralExitPersistenceStore creates a unilateral-exit store.
@@ -290,6 +307,102 @@ func (s *UnilateralExitPersistenceStore) MarkJobTerminal(ctx context.Context,
 	}
 
 	return s.db.ExecTx(ctx, WriteTxOption(), writeFn)
+}
+
+// FundingAddress returns the persisted exit funding address for target,
+// deriving and persisting a new one via newAddress on a miss. The derived
+// address is stable across daemon restarts because it is keyed by the target
+// VTXO outpoint, so polling an exit plan (or restarting the daemon) always
+// hands the user back the same address rather than demanding a fresh deposit
+// for the same VTXO (darepo-client#893).
+//
+// Derivation happens outside the DB transaction on purpose: newAddress reaches
+// into the backing wallet, which must not run under an open SQL write tx. The
+// INSERT uses ON CONFLICT DO NOTHING so a concurrent poller that wins the race
+// keeps its address; this reload-after-insert step returns whichever address
+// actually landed in the row.
+func (s *UnilateralExitPersistenceStore) FundingAddress(ctx context.Context,
+	target wire.OutPoint,
+	newAddress func(context.Context) (string, error)) (string, error) {
+
+	// Serialize check-derive-insert so a second concurrent miss observes
+	// the first caller's persisted row on re-read instead of deriving its
+	// own address. The derive still runs outside any SQL write tx.
+	s.fundingMu.Lock()
+	defer s.fundingMu.Unlock()
+
+	existing, err := s.lookupFundingAddress(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	if existing != "" {
+		return existing, nil
+	}
+
+	address, err := newAddress(ctx)
+	if err != nil {
+		return "", fmt.Errorf("derive funding address: %w", err)
+	}
+
+	writeFn := func(q UnilateralExitStore) error {
+		return q.InsertExitFundingAddress(
+			ctx, sqlc.InsertExitFundingAddressParams{
+				TargetOutpointHash:  target.Hash[:],
+				TargetOutpointIndex: int32(target.Index),
+				FundingAddress:      address,
+				CreatedAt:           s.clock.Now().Unix(),
+			},
+		)
+	}
+	if err := s.db.ExecTx(ctx, WriteTxOption(), writeFn); err != nil {
+		return "", fmt.Errorf("insert funding address: %w", err)
+	}
+
+	// Re-read so a concurrent insert that won the ON CONFLICT race wins
+	// the address too, rather than us returning a freshly derived address
+	// that never got persisted.
+	persisted, err := s.lookupFundingAddress(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	if persisted == "" {
+		return address, nil
+	}
+
+	return persisted, nil
+}
+
+// lookupFundingAddress returns the persisted funding address for target, or
+// the empty string when no row exists yet.
+func (s *UnilateralExitPersistenceStore) lookupFundingAddress(
+	ctx context.Context, target wire.OutPoint) (string, error) {
+
+	var address string
+	readFn := func(q UnilateralExitStore) error {
+		row, err := q.GetExitFundingAddress(
+			ctx, sqlc.GetExitFundingAddressParams{
+				TargetOutpointHash:  target.Hash[:],
+				TargetOutpointIndex: int32(target.Index),
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		address = row.FundingAddress
+
+		return nil
+	}
+
+	err := s.db.ExecTx(ctx, ReadTxOption(), readFn)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("get funding address: %w", err)
+	}
+
+	return address, nil
 }
 
 func jobRecordFromRow(row sqlc.UnilateralExitJob) (UnilateralExitJobRecord,

--- a/db/unilateral_exit_store_test.go
+++ b/db/unilateral_exit_store_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -33,6 +34,99 @@ func newUnilateralExitStoreForTest(
 	return NewUnilateralExitPersistenceStore(
 		exitDB, clock.NewDefaultClock(),
 	)
+}
+
+// exitStoreFromTestDB builds a unilateral-exit store over an already-open test
+// database handle. It lets a test instantiate two independent stores over the
+// same underlying DB to simulate a daemon restart (the second store holds no
+// in-memory state carried over from the first).
+func exitStoreFromTestDB(base *BaseDB) *UnilateralExitPersistenceStore {
+	exitDB := NewTransactionExecutor(
+		base,
+		func(tx *sql.Tx) UnilateralExitStore {
+			return base.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+
+	return NewUnilateralExitPersistenceStore(
+		exitDB, clock.NewDefaultClock(),
+	)
+}
+
+// TestExitFundingAddressStableAcrossRestart verifies that a persisted exit
+// funding address is stable for the same target VTXO outpoint across a
+// simulated daemon restart: the second store must return the already-derived
+// address without deriving a new one, and a different outpoint must still get
+// its own address (darepo-client#893).
+func TestExitFundingAddressStableAcrossRestart(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	testDB := NewTestDB(t)
+	store := exitStoreFromTestDB(testDB.BaseDB)
+
+	target := wire.OutPoint{
+		Hash: chainhash.Hash{
+			0xaa,
+			0x01,
+		},
+		Index: 3,
+	}
+
+	// First derivation persists a fresh address.
+	derived := 0
+	newAddress := func(context.Context) (string, error) {
+		derived++
+
+		return "bcrt1qfunding", nil
+	}
+
+	addr, err := store.FundingAddress(ctx, target, newAddress)
+	require.NoError(t, err)
+	require.Equal(t, "bcrt1qfunding", addr)
+	require.Equal(t, 1, derived)
+
+	// A second poll on the same store returns the cached address without
+	// re-deriving.
+	addr, err = store.FundingAddress(ctx, target, newAddress)
+	require.NoError(t, err)
+	require.Equal(t, "bcrt1qfunding", addr)
+	require.Equal(t, 1, derived)
+
+	// Simulate a restart: a brand-new store over the same DB must return
+	// the persisted address, NOT a freshly derived one. If it derived a
+	// new address the user would be asked to fund a second deposit for the
+	// same VTXO, which is the bug being fixed.
+	restarted := exitStoreFromTestDB(testDB.BaseDB)
+	failIfDerived := func(context.Context) (string, error) {
+		t.Fatal(
+			"restart derived a new funding address instead of " +
+				"reusing the persisted one",
+		)
+
+		return "", nil
+	}
+
+	addr, err = restarted.FundingAddress(ctx, target, failIfDerived)
+	require.NoError(t, err)
+	require.Equal(t, "bcrt1qfunding", addr)
+
+	// A different outpoint still gets its own distinct address.
+	other := wire.OutPoint{
+		Hash: chainhash.Hash{
+			0xbb,
+			0x02,
+		},
+		Index: 7,
+	}
+	otherAddress := func(context.Context) (string, error) {
+		return "bcrt1qother", nil
+	}
+
+	addr, err = restarted.FundingAddress(ctx, other, otherAddress)
+	require.NoError(t, err)
+	require.Equal(t, "bcrt1qother", addr)
 }
 
 // TestUnilateralExitStoreListNonTerminalJobs verifies that restore queries only

--- a/unroll/exit_plan.go
+++ b/unroll/exit_plan.go
@@ -1,9 +1,6 @@
 package unroll
 
 import (
-	"context"
-	"sync"
-
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/lightninglabs/darepo-client/txconfirm"
 	"github.com/lightninglabs/darepo-client/vtxo"
@@ -136,37 +133,4 @@ func ceilDivAmount(a, b btcutil.Amount) btcutil.Amount {
 	}
 
 	return (a + b - 1) / b
-}
-
-// ExitFundingAddressBook reuses a funding address for each target outpoint so
-// polling a plan does not advance the backing wallet address index.
-type ExitFundingAddressBook struct {
-	mu        sync.Mutex
-	addresses map[string]string
-}
-
-// Address returns the cached funding address for key or derives and stores a
-// new one with newAddress.
-func (b *ExitFundingAddressBook) Address(ctx context.Context, key string,
-	newAddress func(context.Context) (string, error)) (string, error) {
-
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if b.addresses == nil {
-		b.addresses = make(map[string]string)
-	}
-
-	if address := b.addresses[key]; address != "" {
-		return address, nil
-	}
-
-	address, err := newAddress(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	b.addresses[key] = address
-
-	return address, nil
 }

--- a/unroll/exit_plan_test.go
+++ b/unroll/exit_plan_test.go
@@ -1,7 +1,6 @@
 package unroll
 
 import (
-	"context"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
@@ -73,29 +72,6 @@ func TestPlanExitFundingShortfallCoversBalance(t *testing.T) {
 	// defaultRecoveryTxVBytes (2 * 200): total 710 sat. Minus the 100 sat
 	// confirmed balance, the shortfall is 610.
 	require.EqualValues(t, 610, plan.FundingShortfallSat)
-}
-
-// TestExitFundingAddressBookReusesCachedAddress verifies polling a plan for
-// the same target does not advance the underlying wallet address index.
-func TestExitFundingAddressBookReusesCachedAddress(t *testing.T) {
-	t.Parallel()
-
-	var book ExitFundingAddressBook
-	calls := 0
-	newAddress := func(context.Context) (string, error) {
-		calls++
-
-		return "bcrt1preallocated", nil
-	}
-
-	address, err := book.Address(t.Context(), "txid:0", newAddress)
-	require.NoError(t, err)
-	require.Equal(t, "bcrt1preallocated", address)
-
-	address, err = book.Address(t.Context(), "txid:0", newAddress)
-	require.NoError(t, err)
-	require.Equal(t, "bcrt1preallocated", address)
-	require.Equal(t, 1, calls)
 }
 
 func testExitPlanDescriptor(amount btcutil.Amount, paths int) *vtxo.Descriptor {


### PR DESCRIPTION
Fixes #893.

## Problem

`darepocli exit plan` derives a backing-wallet `funding_address` for a VTXO
and reports the amount to send there. The address was held only in an
in-memory map (`Server.exitFundingAddresses`), so every `darepod` restart
started empty and derived a **brand-new** address for the same VTXO. A user
who funded the first address and restarted was then shown a different address
and asked to deposit a second time for the same exit (#893).

## Fix

Persist the per-outpoint funding address so it is stable across restarts.

- New `exit_funding_addresses` table shipped as its own additive migration `000011_exit_funding_addresses` (only CREATEs a new standalone table, so existing deployments gain it without a schema reset). Queries added to `db/sqlc/queries/unilateral_exit.sql`; generated
  code via `make sqlc`.
- `UnilateralExitPersistenceStore.FundingAddress(ctx, target, newAddress)`:
  SELECT the persisted address; on miss, derive via the existing
  `NewWalletAddress` path (outside the SQL write tx) and
  `INSERT ... ON CONFLICT DO NOTHING` with a re-read, so a concurrent caller
  that wins the race keeps its address.
- `exitPlanFundingAddress` now goes through the store; the in-memory
  `ExitFundingAddressBook` and `Server.exitFundingAddresses` field are removed.

## The "not credited until restart" symptom (issue's second complaint)

The issue also reports that confirmed funds sent to the address were not
credited toward the shortfall until a restart. That is **not a separate
neutrino-visibility bug** — it is a downstream effect of the same cross-restart
address churn this PR fixes, and is resolved here. Verified along two axes:

- **Code:** the exit funding address is derived via `walletcore.NewAddress ->
  btcwallet.NewAddress`, which already calls `chainClient.NotifyReceived`
  (`btcwallet@v0.18.0/wallet/wallet.go:3326`) — the identical live-neutrino
  rescan registration boarding scripts use (`wallet/import.go:486`). The
  shortfall read (`ListWalletUnspent -> ListUnspentWitness`) passes
  `maxConfs=9999999` and is a pure wtxmgr read with no sync gate. The server
  "retry list unspent while syncing" patch touches only the boarding path, not
  this one.
- **Empirical:** a live regtest-bitcoind + neutrino integration test derives
  the exit funding address post-sync, deposits to it, mines confirmations, and
  observes the UTXO credited **live via `ListUnspentWitness`, no restart**
  (passes in ~7s). Pre-fix, the deposit credited live *within a single process*
  too — the only failure was cross-restart, which is exactly what persistence
  addresses.

## Testing

- `TestExitFundingAddressStableAcrossRestart`: two independent stores over the
  same DB (simulated restart) return the **same** address for one outpoint
  without re-deriving; a different outpoint gets its own address.
- `make sqlc` / `make fmt-changed` / `make lint-changed-local` (0 issues) /
  `go test ./db/ ./unroll/` / `darepod` build / `commitmsg-lint` all green.
- A live btcwbackend+neutrino integration test (opt-in, boots its own regtest
  bitcoind) confirming live crediting is available on a separate branch; happy
  to fold it in if a Docker-dependent integration test is wanted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)