### PR TITLE
swapwallet: project pending recv + fill failed-row failure_reason

### DIFF
--- a/swapwallet/normalize.go
+++ b/swapwallet/normalize.go
@@ -61,6 +61,10 @@ func swapEntryFromSummary(s *swapclientrpc.SwapSummary, note string,
 		kind = kindFromSwapDirection(s.GetDirection())
 	}
 
+	// Derive reason and code from one classification so a terminal failure
+	// never carries a code without a human-readable reason.
+	failureCode := failureCodeFromSwapState(s.GetState(), s.GetPending())
+
 	entry := &walletdkrpc.WalletEntry{
 		Id:            s.GetPaymentHash(),
 		Kind:          kind,
@@ -70,14 +74,10 @@ func swapEntryFromSummary(s *swapclientrpc.SwapSummary, note string,
 		CreatedAtUnix: s.GetCreatedAtUnix(),
 		UpdatedAtUnix: s.GetUpdatedAtUnix(),
 		Note:          entryNote(note, s.GetInvoice()),
-		FailureReason: failureReasonFromTerminal(s.GetTerminalReason()),
+		FailureReason: failureReason(s.GetTerminalReason(), failureCode),
 		Request:       requestFromSwapSummary(s, counterparty, kind),
 		Progress:      progressFromSwapSummary(s),
-		FailureCode: failureCodePtr(
-			failureCodeFromSwapState(
-				s.GetState(), s.GetPending(),
-			),
-		),
+		FailureCode:   failureCodePtr(failureCode),
 	}
 
 	// Render amount with the wallet's signed-amount convention: positive
@@ -306,6 +306,41 @@ func failureCodePtr(
 // check.
 func failureReasonFromTerminal(reason string) string {
 	return strings.TrimSpace(reason)
+}
+
+// failureReason prefers the SDK terminal reason and falls back to a stable
+// default for the classified code, so a failed row never renders empty. A
+// non-failure row (unspecified code, empty terminal) stays blank.
+func failureReason(terminal string, code walletdkrpc.EntryFailureCode) string {
+	if r := failureReasonFromTerminal(terminal); r != "" {
+		return r
+	}
+
+	return defaultFailureReason(code)
+}
+
+// defaultFailureReason maps a failure code to a short reason for when the swap
+// FSM supplied no terminal string. The unspecified code stays blank.
+func defaultFailureReason(code walletdkrpc.EntryFailureCode) string {
+	switch code {
+	case walletdkrpc.EntryFailureCode_ENTRY_FAILURE_CODE_TIMED_OUT:
+		return "timed_out"
+
+	case walletdkrpc.EntryFailureCode_ENTRY_FAILURE_CODE_EXPIRED:
+		return "invoice expired"
+
+	case walletdkrpc.EntryFailureCode_ENTRY_FAILURE_CODE_REFUNDED:
+		return "refunded"
+
+	case walletdkrpc.EntryFailureCode_ENTRY_FAILURE_CODE_NEEDS_INTERVENTION:
+		return "needs intervention"
+
+	case walletdkrpc.EntryFailureCode_ENTRY_FAILURE_CODE_FAILED:
+		return "failed"
+
+	default:
+		return ""
+	}
 }
 
 // entryNote prefers the explicit caller note when the submit path still has

--- a/swapwallet/normalize_test.go
+++ b/swapwallet/normalize_test.go
@@ -236,6 +236,90 @@ func TestFailureReasonFromTerminal(t *testing.T) {
 	)
 }
 
+// TestDefaultFailureReason maps each classified failure code to its fallback
+// reason and leaves the unspecified (non-failure) code blank.
+func TestDefaultFailureReason(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		code walletdkrpc.EntryFailureCode
+		want string
+	}{
+		{
+			fcEnum("TIMED_OUT"),
+			"timed_out",
+		},
+		{
+			fcEnum("EXPIRED"),
+			"invoice expired",
+		},
+		{
+			fcEnum("REFUNDED"),
+			"refunded",
+		},
+		{
+			fcEnum("NEEDS_INTERVENTION"),
+			"needs intervention",
+		},
+		{
+			fcEnum("FAILED"),
+			"failed",
+		},
+		{
+			unspecCode,
+			"",
+		},
+	}
+	for _, tc := range cases {
+		require.Equal(
+			t, tc.want, defaultFailureReason(tc.code),
+			"code=%v", tc.code,
+		)
+	}
+}
+
+// TestSwapEntryFromSummaryFailureReason confirms a terminal-failure row always
+// carries a reason: the SDK terminal reason wins, else a code-keyed default
+// fills the gap; a happy-path row stays blank.
+func TestSwapEntryFromSummaryFailureReason(t *testing.T) {
+	t.Parallel()
+
+	expired := swapEntryFromSummary(
+		&swapclientrpc.SwapSummary{
+			PaymentHash: "hash-expired",
+			Direction: swapclientrpc.
+				SwapDirection_SWAP_DIRECTION_RECEIVE,
+			State: swapclientrpc.SwapState_SWAP_STATE_EXPIRED,
+		}, "", "", walletdkrpc.EntryKind_ENTRY_KIND_UNSPECIFIED,
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_FAILED,
+		expired.GetStatus(),
+	)
+	require.Equal(t, "invoice expired", expired.GetFailureReason())
+	require.Equal(
+		t, walletdkrpc.EntryFailureCode_ENTRY_FAILURE_CODE_EXPIRED,
+		expired.GetFailureCode(),
+	)
+
+	failed := swapEntryFromSummary(
+		&swapclientrpc.SwapSummary{
+			PaymentHash:    "hash-failed",
+			State:          swapclientrpc.SwapState_SWAP_STATE_FAILED,
+			TerminalReason: "server rejected swap",
+		}, "", "", walletdkrpc.EntryKind_ENTRY_KIND_UNSPECIFIED,
+	)
+	require.Equal(t, "server rejected swap", failed.GetFailureReason())
+
+	done := swapEntryFromSummary(
+		&swapclientrpc.SwapSummary{
+			PaymentHash: "hash-done",
+			State:       swapclientrpc.SwapState_SWAP_STATE_COMPLETED,
+		}, "", "", walletdkrpc.EntryKind_ENTRY_KIND_UNSPECIFIED,
+	)
+	require.Empty(t, done.GetFailureReason())
+}
+
 // TestEntryNotePrefersExplicitNote confirms the immediate submit path keeps
 // the user's memo even before the persisted invoice summary is read back.
 func TestEntryNotePrefersExplicitNote(t *testing.T) {

--- a/swapwallet/recv.go
+++ b/swapwallet/recv.go
@@ -112,6 +112,11 @@ func (r *receiver) Recv(ctx context.Context, req *walletdkrpc.RecvRequest) (
 		walletdkrpc.EntryKind_ENTRY_KIND_RECV,
 	)
 
+	// Project the pending row on dispatch so it is visible immediately,
+	// not only once the monitor's async projection lands. project (not
+	// projectAndEmit): the monitor owns the swap-backed row's live emit.
+	r.runtime.project(context.WithoutCancel(ctx), entry)
+
 	return &walletdkrpc.RecvResponse{
 		Invoice: startResp.GetInvoice(),
 		Entry:   entry,

--- a/swapwallet/recv_test.go
+++ b/swapwallet/recv_test.go
@@ -74,6 +74,47 @@ func TestRecvDispatchesStartReceive(t *testing.T) {
 	)
 }
 
+// TestRecvProjectsPendingEntry confirms a swap-backed RECV projects its
+// pending row on dispatch, keyed by payment hash, before Recv returns.
+func TestRecvProjectsPendingEntry(t *testing.T) {
+	t.Parallel()
+
+	r, swap := newRecvFixture(t)
+	store := &fakeActivityProjector{}
+	r.deps.ActivityStore = store
+	swap.startReceiveResp = &swapclientrpc.StartReceiveResponse{
+		PaymentHash: "abc123",
+		Invoice:     "lnbc1invoice",
+		Swap: &swapclientrpc.SwapSummary{
+			PaymentHash: "abc123",
+			Direction: swapclientrpc.
+				SwapDirection_SWAP_DIRECTION_RECEIVE,
+			Pending: true,
+		},
+	}
+
+	resp, err := r.Recv(t.Context(), &walletdkrpc.RecvRequest{
+		AmtSat: 50_000,
+		Memo:   "coffee",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "abc123", resp.GetEntry().GetId())
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		resp.GetEntry().GetStatus(),
+	)
+
+	require.Equal(t, 1, store.count())
+	require.True(
+		t, store.ids()["abc123"],
+		"pending recv must be projected by payment hash on dispatch",
+	)
+	require.Equal(
+		t, int64(walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING),
+		store.lastProjection().Status, "projected row must be PENDING",
+	)
+}
+
 // TestRecvBelowDustHandsToCreditRegistry asserts a sub-dust receive is handed
 // to the durable credit registry, which returns the server-owned invoice
 // synchronously, instead of the wallet calling CreateCredit inline.


### PR DESCRIPTION
In this PR, we fix two activity-feed coherence bugs surfaced during manual signet testing of the walletdk verbs.

**Pending receive was invisible in the feed (fixes #922).** A swap-backed `recv` builds its pending `WalletEntry` and returns it, but never wrote it to the canonical activity store, so `activity` / `activity --pending --kind recv` showed nothing until the swap monitor projected a later transition. On signet the row only appeared once the receive expired. The SEND path already projects its pending row on dispatch (`router.go`); RECV was the odd one out. We mirror the send path: after `StartReceive` succeeds we `project` the pending row store-only (the monitor still owns the swap-backed row's live emit, so we don't `projectAndEmit` and double-fan), off a cancel-safe context. The sub-dust credit-receive branch returns earlier and is owned by the credit poll, so it's untouched.

**Failed rows had no reason (fixes #923).** A terminal-failure swap the FSM left without a terminal-reason string (notably an expired invoice) rendered as `FAILED` with an empty `failure_reason`, even though `failure_code` was correctly `EXPIRED`. We classify the failure once and, when the FSM supplies no reason, fall back to a stable default keyed on the failure code (`EXPIRED` -> "invoice expired", `REFUNDED` -> "refunded", etc.). Non-failure rows stay blank, so the `failure_reason != ""` means-failed convention holds. The existing `TestFailureCodeMatchesFailedStatus` drift guard now transitively guarantees every FAILED row also carries a reason.

Both are small and swapwallet-local. A third finding from the same audit — completed cooperative-leave EXIT rows missing the settling txid/height (#924) — is a cross-package change (new daemonrpc field + sqlc query + daemon plumbing) and will land separately.

See each commit for the incremental change.
