### PR TITLE
unroll: Floor proof-node confirmation-watch at commitment height

### DIFF
--- a/arkrpc/indexer.pb.go
+++ b/arkrpc/indexer.pb.go
@@ -1493,9 +1493,13 @@ type AncestryPath struct {
 	// tree_depth is the depth of the served leaf within this fragment's
 	// tree. Worst-case unilateral-exit timing for the produced VTXO is
 	// max(tree_depth) across all AncestryPaths.
-	TreeDepth     uint32 `protobuf:"varint,4,opt,name=tree_depth,json=treeDepth,proto3" json:"tree_depth,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	TreeDepth uint32 `protobuf:"varint,4,opt,name=tree_depth,json=treeDepth,proto3" json:"tree_depth,omitempty"`
+	// commitment_height is the on-chain confirmation height of the commitment
+	// tx anchoring this fragment. Zero means unknown (legacy/unconfirmed),
+	// in which case the client falls back to a bounded lookback floor.
+	CommitmentHeight int32 `protobuf:"varint,5,opt,name=commitment_height,json=commitmentHeight,proto3" json:"commitment_height,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *AncestryPath) Reset() {
@@ -1552,6 +1556,13 @@ func (x *AncestryPath) GetInputIndices() []uint32 {
 func (x *AncestryPath) GetTreeDepth() uint32 {
 	if x != nil {
 		return x.TreeDepth
+	}
+	return 0
+}
+
+func (x *AncestryPath) GetCommitmentHeight() int32 {
+	if x != nil {
+		return x.CommitmentHeight
 	}
 	return 0
 }
@@ -2792,13 +2803,14 @@ const file_indexer_proto_rawDesc = "" +
 	"\x05nodes\x18\x01 \x03(\v2\x14.arkrpc.TreePathNodeR\x05nodes\x127\n" +
 	"\x0ebatch_outpoint\x18\x02 \x01(\v2\x10.arkrpc.OutPointR\rbatchOutpoint\x120\n" +
 	"\fbatch_output\x18\x03 \x01(\v2\r.arkrpc.TxOutR\vbatchOutput\x120\n" +
-	"\x14sweep_tapscript_root\x18\x04 \x01(\fR\x12sweepTapscriptRoot\"\xaa\x01\n" +
+	"\x14sweep_tapscript_root\x18\x04 \x01(\fR\x12sweepTapscriptRoot\"\xd7\x01\n" +
 	"\fAncestryPath\x12-\n" +
 	"\ttree_path\x18\x01 \x01(\v2\x10.arkrpc.TreePathR\btreePath\x12'\n" +
 	"\x0fcommitment_txid\x18\x02 \x01(\fR\x0ecommitmentTxid\x12#\n" +
 	"\rinput_indices\x18\x03 \x03(\rR\finputIndices\x12\x1d\n" +
 	"\n" +
-	"tree_depth\x18\x04 \x01(\rR\ttreeDepth\"\xaa\x01\n" +
+	"tree_depth\x18\x04 \x01(\rR\ttreeDepth\x12+\n" +
+	"\x11commitment_height\x18\x05 \x01(\x05R\x10commitmentHeight\"\xaa\x01\n" +
 	"\vScriptScope\x12\x1b\n" +
 	"\tpk_script\x18\x01 \x01(\fR\bpkScript\x12F\n" +
 	"\x0ftaproot_schnorr\x18\n" +

--- a/arkrpc/indexer.proto
+++ b/arkrpc/indexer.proto
@@ -312,6 +312,11 @@ message AncestryPath {
     // tree. Worst-case unilateral-exit timing for the produced VTXO is
     // max(tree_depth) across all AncestryPaths.
     uint32 tree_depth = 4;
+
+    // commitment_height is the on-chain confirmation height of the commitment
+    // tx anchoring this fragment. Zero means unknown (legacy/unconfirmed),
+    // in which case the client falls back to a bounded lookback floor.
+    int32 commitment_height = 5;
 }
 
 // ScriptScope selects a pkScript and carries a proof-of-control for that

--- a/db/ancestry_codec.go
+++ b/db/ancestry_codec.go
@@ -195,6 +195,7 @@ func upsertAncestryPaths(ctx context.Context, q ancestryStore,
 				InputIndices: encodeUint32SliceBE(
 					a.InputIndices,
 				),
+				CommitmentHeight: a.CommitmentHeight,
 			},
 		)
 		if err != nil {
@@ -315,6 +316,7 @@ func ancestryRowToDomain(row sqlc.VtxoAncestryPath,
 	copy(entry.CommitmentTxID[:], row.CommitmentTxid)
 
 	entry.TreeDepth = uint32(row.TreeDepth)
+	entry.CommitmentHeight = row.CommitmentHeight
 
 	indices, err := decodeUint32SliceBE(row.InputIndices)
 	if err != nil {

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -10,7 +10,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion uint = 12
+	LatestMigrationVersion uint = 13
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/db/sqlc/migrations/000013_ancestry_commitment_height.down.sql
+++ b/db/sqlc/migrations/000013_ancestry_commitment_height.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE vtxo_ancestry_paths DROP COLUMN commitment_height;

--- a/db/sqlc/migrations/000013_ancestry_commitment_height.up.sql
+++ b/db/sqlc/migrations/000013_ancestry_commitment_height.up.sql
@@ -1,0 +1,12 @@
+-- commitment_height is the on-chain confirmation height of the commitment tx
+-- anchoring this ancestry fragment. It is the tightest sound floor for the
+-- unroller's proof-node confirmation-watch height hint (nothing in a VTXO's
+-- proof graph confirms before its commitment tx).
+--
+-- Added as a forward migration (rather than folded into 000004_vtxos) so
+-- existing deployments gain the column without a schema reset. DEFAULT 0 means
+-- unknown: rows persisted before this column existed, and rows whose producer
+-- did not populate it, read back as 0 and make the unroller fall back to a
+-- bounded lookback floor.
+ALTER TABLE vtxo_ancestry_paths
+    ADD COLUMN commitment_height INTEGER NOT NULL DEFAULT 0;

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -456,6 +456,7 @@ type VtxoAncestryPath struct {
 	TreePath          []byte
 	TreeDepth         int32
 	InputIndices      []byte
+	CommitmentHeight  int32
 }
 
 type WalletUtxoLog struct {

--- a/db/sqlc/queries/round.sql
+++ b/db/sqlc/queries/round.sql
@@ -158,9 +158,10 @@ ON CONFLICT (outpoint_hash, outpoint_index) DO UPDATE SET
 -- DeleteVTXOAncestryPaths first.
 INSERT INTO vtxo_ancestry_paths (
     vtxo_outpoint_hash, vtxo_outpoint_index, path_order,
-    commitment_txid, tree_path, tree_depth, input_indices
+    commitment_txid, tree_path, tree_depth, input_indices,
+    commitment_height
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7
+    $1, $2, $3, $4, $5, $6, $7, $8
 );
 
 -- name: DeleteVTXOAncestryPaths :exec

--- a/db/sqlc/round.sql.go
+++ b/db/sqlc/round.sql.go
@@ -615,9 +615,10 @@ func (q *Queries) InsertVTXO(ctx context.Context, arg InsertVTXOParams) error {
 const InsertVTXOAncestryPath = `-- name: InsertVTXOAncestryPath :exec
 INSERT INTO vtxo_ancestry_paths (
     vtxo_outpoint_hash, vtxo_outpoint_index, path_order,
-    commitment_txid, tree_path, tree_depth, input_indices
+    commitment_txid, tree_path, tree_depth, input_indices,
+    commitment_height
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7
+    $1, $2, $3, $4, $5, $6, $7, $8
 )
 `
 
@@ -629,6 +630,7 @@ type InsertVTXOAncestryPathParams struct {
 	TreePath          []byte
 	TreeDepth         int32
 	InputIndices      []byte
+	CommitmentHeight  int32
 }
 
 // InsertVTXOAncestryPath inserts one ancestry tree fragment for a VTXO.
@@ -643,6 +645,7 @@ func (q *Queries) InsertVTXOAncestryPath(ctx context.Context, arg InsertVTXOAnce
 		arg.TreePath,
 		arg.TreeDepth,
 		arg.InputIndices,
+		arg.CommitmentHeight,
 	)
 	return err
 }
@@ -738,7 +741,7 @@ func (q *Queries) ListAllVTXOs(ctx context.Context) ([]Vtxo, error) {
 }
 
 const ListLiveVTXOAncestryPaths = `-- name: ListLiveVTXOAncestryPaths :many
-SELECT vap.vtxo_outpoint_hash, vap.vtxo_outpoint_index, vap.path_order, vap.commitment_txid, vap.tree_path, vap.tree_depth, vap.input_indices FROM vtxo_ancestry_paths vap
+SELECT vap.vtxo_outpoint_hash, vap.vtxo_outpoint_index, vap.path_order, vap.commitment_txid, vap.tree_path, vap.tree_depth, vap.input_indices, vap.commitment_height FROM vtxo_ancestry_paths vap
 JOIN vtxos v
   ON v.outpoint_hash = vap.vtxo_outpoint_hash
   AND v.outpoint_index = vap.vtxo_outpoint_index
@@ -769,6 +772,7 @@ func (q *Queries) ListLiveVTXOAncestryPaths(ctx context.Context) ([]VtxoAncestry
 			&i.TreePath,
 			&i.TreeDepth,
 			&i.InputIndices,
+			&i.CommitmentHeight,
 		); err != nil {
 			return nil, err
 		}
@@ -884,7 +888,7 @@ func (q *Queries) ListRoundsPaginated(ctx context.Context, arg ListRoundsPaginat
 }
 
 const ListUnspentVTXOAncestryPaths = `-- name: ListUnspentVTXOAncestryPaths :many
-SELECT vap.vtxo_outpoint_hash, vap.vtxo_outpoint_index, vap.path_order, vap.commitment_txid, vap.tree_path, vap.tree_depth, vap.input_indices FROM vtxo_ancestry_paths vap
+SELECT vap.vtxo_outpoint_hash, vap.vtxo_outpoint_index, vap.path_order, vap.commitment_txid, vap.tree_path, vap.tree_depth, vap.input_indices, vap.commitment_height FROM vtxo_ancestry_paths vap
 JOIN vtxos v
   ON v.outpoint_hash = vap.vtxo_outpoint_hash
   AND v.outpoint_index = vap.vtxo_outpoint_index
@@ -914,6 +918,7 @@ func (q *Queries) ListUnspentVTXOAncestryPaths(ctx context.Context) ([]VtxoAnces
 			&i.TreePath,
 			&i.TreeDepth,
 			&i.InputIndices,
+			&i.CommitmentHeight,
 		); err != nil {
 			return nil, err
 		}
@@ -984,7 +989,7 @@ func (q *Queries) ListUnspentVTXOs(ctx context.Context) ([]Vtxo, error) {
 }
 
 const ListVTXOAncestryPaths = `-- name: ListVTXOAncestryPaths :many
-SELECT vtxo_outpoint_hash, vtxo_outpoint_index, path_order, commitment_txid, tree_path, tree_depth, input_indices FROM vtxo_ancestry_paths
+SELECT vtxo_outpoint_hash, vtxo_outpoint_index, path_order, commitment_txid, tree_path, tree_depth, input_indices, commitment_height FROM vtxo_ancestry_paths
 WHERE vtxo_outpoint_hash = $1 AND vtxo_outpoint_index = $2
 ORDER BY path_order ASC
 `
@@ -1014,6 +1019,7 @@ func (q *Queries) ListVTXOAncestryPaths(ctx context.Context, arg ListVTXOAncestr
 			&i.TreePath,
 			&i.TreeDepth,
 			&i.InputIndices,
+			&i.CommitmentHeight,
 		); err != nil {
 			return nil, err
 		}
@@ -1029,7 +1035,7 @@ func (q *Queries) ListVTXOAncestryPaths(ctx context.Context, arg ListVTXOAncestr
 }
 
 const ListVTXOAncestryPathsByStatus = `-- name: ListVTXOAncestryPathsByStatus :many
-SELECT vap.vtxo_outpoint_hash, vap.vtxo_outpoint_index, vap.path_order, vap.commitment_txid, vap.tree_path, vap.tree_depth, vap.input_indices FROM vtxo_ancestry_paths vap
+SELECT vap.vtxo_outpoint_hash, vap.vtxo_outpoint_index, vap.path_order, vap.commitment_txid, vap.tree_path, vap.tree_depth, vap.input_indices, vap.commitment_height FROM vtxo_ancestry_paths vap
 JOIN vtxos v
   ON v.outpoint_hash = vap.vtxo_outpoint_hash
   AND v.outpoint_index = vap.vtxo_outpoint_index
@@ -1058,6 +1064,7 @@ func (q *Queries) ListVTXOAncestryPathsByStatus(ctx context.Context, status int3
 			&i.TreePath,
 			&i.TreeDepth,
 			&i.InputIndices,
+			&i.CommitmentHeight,
 		); err != nil {
 			return nil, err
 		}

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -1571,7 +1571,7 @@ CREATE TABLE vtxo_ancestry_paths (
     -- explicit value (empty length-prefixed slice for round-direct
     -- rows). A `DEFAULT X''` literal works on SQLite but is parsed by
     -- Postgres as a bit-string and rejected against the BYTEA column.
-    input_indices BLOB NOT NULL,
+    input_indices BLOB NOT NULL, commitment_height INTEGER NOT NULL DEFAULT 0,
 
     PRIMARY KEY (vtxo_outpoint_hash, vtxo_outpoint_index, path_order),
     FOREIGN KEY (vtxo_outpoint_hash, vtxo_outpoint_index)

--- a/lib/types/ancestry.go
+++ b/lib/types/ancestry.go
@@ -37,6 +37,13 @@ type Ancestry struct {
 	// tree. Worst-case unilateral-exit timing for the produced VTXO is
 	// max(TreeDepth) across all entries.
 	TreeDepth uint32
+
+	// CommitmentHeight is the on-chain confirmation height of the
+	// commitment tx anchoring this fragment. Zero means unknown (legacy
+	// persisted VTXOs, or an unconfirmed/not-yet-resolved commitment), in
+	// which case callers fall back to a bounded lookback floor rather than
+	// trusting this value.
+	CommitmentHeight int32
 }
 
 // MaxAncestryTreeDepth returns the largest TreeDepth across the given

--- a/unroll/AGENTS.md
+++ b/unroll/AGENTS.md
@@ -161,9 +161,24 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
 - `watchDeferredCheckpoint(ctx, txid, node)` — registers confirmation
   watch for fraud-triggered checkpoints while the actor waits for
   operator confirmation of the proof node.
-- `proofNodeHeightHint = 1` — height hint for proof-node
-  spend/confirmation watches (proof roots and intermediate ancestors
-  can confirm before the target VTXO's creation height).
+- `behavior.proofNodeConfHeightHint(ctx, txid)` — confirmation-watch height
+  floor for proof-graph nodes. Primary floor is `commitmentHeightFloor()`:
+  `min(Descriptor.Ancestry[i].CommitmentHeight)`, but only when EVERY fragment
+  has a known (>0) height — a single unknown fragment returns 0 and defers to
+  the fallback (a min over only the known fragments would not bound an unknown
+  fragment's ancestor). Nothing in a VTXO's proof graph confirms before its
+  commitment tx, so once all fragments are known this is a tight, provable
+  floor (min, never max — a lower floor only widens the safe rescan window).
+  When no commitment height is known (legacy persisted VTXOs, empty-ancestry
+  round VTXOs, or a server not yet populating `commitment_height`), it falls
+  back to `proofNodeHeightHint(currentHeight)` =
+  `max(1, currentHeight - proofNodeHeightHintLookback)` (10000 blocks) —
+  identical to the pre-commitment-height behaviour. Roots/intermediate
+  ancestors can confirm before the target VTXO's creation height, so the
+  fallback anchors to tip minus a lookback (never `CreatedHeight`), bounding
+  the neutrino historical rescan instead of scanning to genesis
+  (darepo-client#884). The fallback path warns when the VTXO's age exceeds the
+  lookback (the floor may then miss an already-confirmed ancestor).
 
 ## Relationships
 

--- a/unroll/CLAUDE.md
+++ b/unroll/CLAUDE.md
@@ -161,9 +161,24 @@ For field-level detail, use `go doc github.com/lightninglabs/darepo-client/unrol
 - `watchDeferredCheckpoint(ctx, txid, node)` — registers confirmation
   watch for fraud-triggered checkpoints while the actor waits for
   operator confirmation of the proof node.
-- `proofNodeHeightHint = 1` — height hint for proof-node
-  spend/confirmation watches (proof roots and intermediate ancestors
-  can confirm before the target VTXO's creation height).
+- `behavior.proofNodeConfHeightHint(ctx, txid)` — confirmation-watch height
+  floor for proof-graph nodes. Primary floor is `commitmentHeightFloor()`:
+  `min(Descriptor.Ancestry[i].CommitmentHeight)`, but only when EVERY fragment
+  has a known (>0) height — a single unknown fragment returns 0 and defers to
+  the fallback (a min over only the known fragments would not bound an unknown
+  fragment's ancestor). Nothing in a VTXO's proof graph confirms before its
+  commitment tx, so once all fragments are known this is a tight, provable
+  floor (min, never max — a lower floor only widens the safe rescan window).
+  When no commitment height is known (legacy persisted VTXOs, empty-ancestry
+  round VTXOs, or a server not yet populating `commitment_height`), it falls
+  back to `proofNodeHeightHint(currentHeight)` =
+  `max(1, currentHeight - proofNodeHeightHintLookback)` (10000 blocks) —
+  identical to the pre-commitment-height behaviour. Roots/intermediate
+  ancestors can confirm before the target VTXO's creation height, so the
+  fallback anchors to tip minus a lookback (never `CreatedHeight`), bounding
+  the neutrino historical rescan instead of scanning to genesis
+  (darepo-client#884). The fallback path warns when the VTXO's age exceeds the
+  lookback (the floor may then miss an already-confirmed ancestor).
 
 ## Relationships
 

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -657,6 +657,18 @@ func (b *behavior) currentHeight() int32 {
 	return b.pending.Height
 }
 
+// currentHeightHint returns the actor's last observed best height as an
+// unsigned value suitable for a confirmation-watch height hint, clamping any
+// non-positive height (e.g. an uninitialized job) to zero.
+func (b *behavior) currentHeightHint() uint32 {
+	h := b.currentHeight()
+	if h <= 0 {
+		return 0
+	}
+
+	return uint32(h)
+}
+
 // resolveExitSpendPolicy reconstructs the exit policy for this job.
 func (b *behavior) resolveExitSpendPolicy(ctx context.Context) (ExitSpendPolicy,
 	error) {
@@ -701,11 +713,156 @@ func safeTxOutPkScript(tx *wire.MsgTx, index uint32) ([]byte, error) {
 	return append([]byte(nil), tx.TxOut[index].PkScript...), nil
 }
 
-// proofNodeHeightHint is the earliest safe confirmation height hint for
-// proof-graph transactions. Roots and intermediate OOR checkpoint ancestors
-// can confirm before the target descriptor's CreatedHeight, so proof watches
-// must not use the target creation height as a lower bound.
-const proofNodeHeightHint uint32 = 1
+// proofNodeHeightHintLookback is the number of blocks below the actor's
+// current best height used as the confirmation-watch FALLBACK floor for
+// proof-graph transactions when no commitment height is known. A genesis
+// floor (height 1) forces neutrino's notifier to rescan every block from tip
+// to block 1 (one GetCFilter per block) when the watched tx never confirms,
+// which floods logs and never terminates (darepo-client#884). We therefore
+// bound the rescan window to a fixed lookback below the current height.
+//
+// The lookback MUST comfortably exceed the maximum batch lifetime plus the
+// worst-case tree-depth + CSV exit window, because proof roots and
+// intermediate OOR checkpoint ancestors can confirm well before the target
+// descriptor's CreatedHeight — using the creation height as the floor would
+// miss an ancestor that already confirmed. A generous operator-configured max
+// batch lifetime is on the order of one month (~4320 blocks at 144
+// blocks/day); 10000 blocks (~10 weeks) is a safe multiple that keeps the
+// floor below any ancestor's real confirmation height while still capping the
+// neutrino rescan at a bounded window instead of scanning to genesis.
+//
+// The primary, tight floor is the commitment-tx confirmation height carried
+// per fragment on Descriptor.Ancestry[i].CommitmentHeight: nothing in a
+// VTXO's proof graph can confirm before its commitment tx, so min() across
+// fragments is a provable lower bound for every proof ancestor. When that
+// height is unknown (zero) — legacy persisted VTXOs, empty-ancestry incoming
+// round VTXOs, or a server that does not yet populate the field — we fall
+// back to this bounded lookback, preserving the pre-commitment-height
+// behaviour exactly.
+const proofNodeHeightHintLookback uint32 = 10000
+
+// proofNodeHeightHint returns the earliest safe confirmation height hint for
+// proof-graph transactions given the actor's current best height. Roots and
+// intermediate OOR checkpoint ancestors can confirm before the target
+// descriptor's CreatedHeight, so proof watches must not use the target
+// creation height as a lower bound; instead we floor at a bounded lookback
+// below the current height (never below block 1). See
+// proofNodeHeightHintLookback for the sizing rationale. Callers that hold a
+// Descriptor should route through behavior.proofNodeConfHeightHint instead, so
+// the age-exceeds-lookback breadcrumb fires.
+func proofNodeHeightHint(currentHeight uint32) uint32 {
+	if currentHeight <= proofNodeHeightHintLookback {
+		return 1
+	}
+
+	return currentHeight - proofNodeHeightHintLookback
+}
+
+// commitmentHeightFloor returns the tight, provable confirmation-watch floor
+// derived from the target descriptor's ancestry: the minimum commitment
+// confirmation height across ALL fragments. It returns 0 (meaning "unknown,
+// use the fallback floor") unless every fragment carries a known positive
+// height.
+//
+// The all-or-nothing requirement is a soundness one. Nothing in a VTXO's proof
+// graph confirms before its commitment tx, so once every fragment's commitment
+// height is known their minimum is a provable lower bound for every proof
+// ancestor. But a min taken over only the known fragments would not bound an
+// unknown fragment, whose ancestor could have confirmed below that min and be
+// missed by the rescan. So a single unknown fragment defers the whole target
+// to the fallback. We take the min, never the max: a lower floor only widens
+// the (safe) rescan window; too high a floor can miss an ancestor.
+func (b *behavior) commitmentHeightFloor() int32 {
+	if b.desc == nil || len(b.desc.Ancestry) == 0 {
+		return 0
+	}
+
+	var lowest int32
+	for i := range b.desc.Ancestry {
+		h := b.desc.Ancestry[i].CommitmentHeight
+		if h <= 0 {
+			return 0
+		}
+
+		if lowest == 0 || h < lowest {
+			lowest = h
+		}
+	}
+
+	return lowest
+}
+
+// proofNodeConfHeightHint returns the confirmation-watch height floor for one
+// proof-graph node. When the target descriptor carries a known commitment
+// height it uses min(commitment height) across fragments as a tight, provable
+// floor (clamped to at least block 1). Otherwise it falls back to the bounded
+// lookback below the current height and leaves a breadcrumb when the target
+// VTXO is old enough that the fallback floor may have risen above a proof
+// ancestor's real confirmation height. On the fallback path the lookback keeps
+// the floor below every ancestor only while the VTXO's age (in blocks) stays
+// within proofNodeHeightHintLookback; past that the neutrino historical rescan
+// can start too late, miss the ancestor's confirmation, and silently stall the
+// exit — so we warn rather than fail.
+func (b *behavior) proofNodeConfHeightHint(ctx context.Context,
+	txid chainhash.Hash) uint32 {
+
+	// The floor is a per-target property (min over the whole ancestry), not
+	// per-node, so it is the same for every proof node. txid is used only
+	// for the fallback-path breadcrumb below, not to select a floor.
+
+	// Primary path: a known commitment height is the tightest sound floor.
+	// commitmentHeightFloor only returns positive values, so it is already
+	// clamped to at least block 1 (we never hand the notifier a zero
+	// height).
+	if floor := b.commitmentHeightFloor(); floor > 0 {
+		return uint32(floor)
+	}
+
+	// Fallback path: no commitment height known, so bound the rescan with
+	// the fixed lookback and warn if the VTXO is old enough that the floor
+	// may have risen above an ancestor's real confirmation height.
+	//
+	// currentHeightHint returns 0 only for an uninitialized job (no height
+	// observed yet), and proofNodeHeightHint(0) is the genesis floor (1) —
+	// the very rescan-to-genesis behaviour #884 fixes. That is not
+	// reachable on the real path: a proof watch is registered only while
+	// handling a Start/Resume/HeightUpdated event, all of which set
+	// b.pending.Height first, so currentHeightHint is non-zero here in
+	// practice.
+	currentHeight := b.currentHeightHint()
+	hint := proofNodeHeightHint(currentHeight)
+
+	// CreatedHeight is our proxy for the earliest proof-ancestor
+	// confirmation height. Once the VTXO's age reaches the lookback the
+	// floor sits at or above it, so an ancestor that confirmed earlier can
+	// escape the rescan window.
+	if b.desc != nil && b.desc.CreatedHeight > 0 {
+		age := int64(currentHeight) - int64(b.desc.CreatedHeight)
+		if age >= int64(proofNodeHeightHintLookback) {
+			b.log.WarnS(ctx, "Proof-node confirmation floor may "+
+				"exceed ancestor height; exit could stall",
+				nil,
+				slog.String(
+					"target_outpoint",
+					b.cfg.TargetOutpoint.String(),
+				),
+				slog.String("proof_txid", txid.String()),
+				slog.Int64("vtxo_age_blocks", age),
+				slog.Uint64(
+					"lookback",
+					uint64(proofNodeHeightHintLookback),
+				),
+				slog.Uint64("height_hint", uint64(hint)),
+				slog.Int64(
+					"created_height",
+					int64(b.desc.CreatedHeight),
+				),
+			)
+		}
+	}
+
+	return hint
+}
 
 // ensureNodeConfirmed hands one ready proof-graph node to txconfirm and
 // threads any immediate rejection back through the FSM.
@@ -739,11 +896,12 @@ func (b *behavior) ensureNodeConfirmed(ctx context.Context,
 		return err
 	}
 
+	heightHint := b.proofNodeConfHeightHint(ctx, txid)
 	resp, err := b.cfg.TxConfirmRef.Ask(ctx, &txconfirm.EnsureConfirmedReq{
 		Tx:                   node.Tx,
 		ConfirmationPkScript: pkScript,
 		Label:                "unroll-node-" + txid.String(),
-		HeightHint:           proofNodeHeightHint,
+		HeightHint:           heightHint,
 		Subscriber:           b.notificationRef(),
 	}).Await(ctx).Unpack()
 	if err != nil {
@@ -798,7 +956,7 @@ func (b *behavior) watchDeferredCheckpoint(ctx context.Context,
 		Txid:        &txidCopy,
 		PkScript:    append([]byte(nil), pkScript...),
 		TargetConfs: 1,
-		HeightHint:  proofNodeHeightHint,
+		HeightHint:  b.proofNodeConfHeightHint(ctx, txid),
 		NotifyActor: fn.Some(notifyRef),
 	}).Await(ctx).Unpack()
 	if err != nil {

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -1571,6 +1571,223 @@ func TestStartUnrollSubmitsInitialFrontier(t *testing.T) {
 	require.NotNil(t, checkpoint)
 }
 
+// TestProofNodeHeightHintBoundedBelowTip verifies that at a realistic mainnet
+// height the proof-node confirmation watch is floored a bounded lookback below
+// the current tip, not at genesis (block 1). A genesis floor makes neutrino
+// rescan every block to block 1 for a tx that never confirms
+// (darepo-client#884); the bounded floor caps the rescan window while staying
+// low enough that a proof ancestor confirming before the target's creation
+// height is still covered.
+func TestProofNodeHeightHintBoundedBelowTip(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, _, txconfirmRef, _ := newActorHarness(t, proof, desc)
+
+	// A mainnet-scale height comfortably above the lookback so the floor
+	// is (height - lookback), not the genesis clamp.
+	const startHeight uint32 = 850_000
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  int32(startHeight),
+		Trigger: TriggerManual,
+	})
+
+	require.Equal(t, 1, txconfirmRef.requestCount())
+	hint := txconfirmRef.lastRequest(t).HeightHint
+
+	// The hint must not be the genesis floor, and must be exactly the
+	// bounded lookback below the observed height.
+	require.Greater(t, hint, uint32(1))
+	require.Equal(t, startHeight-proofNodeHeightHintLookback, hint)
+}
+
+// TestProofNodeHeightHintClampsToGenesis verifies the helper never returns a
+// height below block 1, even when the current height is at or below the
+// configured lookback window.
+func TestProofNodeHeightHintClampsToGenesis(t *testing.T) {
+	require.Equal(t, uint32(1), proofNodeHeightHint(0))
+	require.Equal(t, uint32(1), proofNodeHeightHint(1))
+	require.Equal(
+		t, uint32(1), proofNodeHeightHint(proofNodeHeightHintLookback),
+	)
+	require.Equal(
+		t, uint32(1),
+		proofNodeHeightHint(proofNodeHeightHintLookback-1),
+	)
+	require.Equal(
+		t, uint32(2),
+		proofNodeHeightHint(proofNodeHeightHintLookback+2),
+	)
+}
+
+// TestCommitmentHeightFloor verifies the commitment-height floor helper: it
+// returns the smallest height only when every fragment carries a known
+// positive height, and returns 0 (defer to the fallback floor) when any
+// fragment is unknown or there is no ancestry.
+func TestCommitmentHeightFloor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		desc   *vtxo.Descriptor
+		expect int32
+	}{
+		{
+			name:   "nil descriptor",
+			desc:   nil,
+			expect: 0,
+		},
+		{
+			name:   "no ancestry",
+			desc:   &vtxo.Descriptor{},
+			expect: 0,
+		},
+		{
+			name: "single fragment",
+			desc: &vtxo.Descriptor{
+				Ancestry: []vtxo.Ancestry{
+					{
+						CommitmentHeight: 500,
+					},
+				},
+			},
+			expect: 500,
+		},
+		{
+			name: "multi fragment picks min",
+			desc: &vtxo.Descriptor{
+				Ancestry: []vtxo.Ancestry{
+					{
+						CommitmentHeight: 900,
+					},
+					{
+						CommitmentHeight: 400,
+					},
+					{
+						CommitmentHeight: 700,
+					},
+				},
+			},
+			expect: 400,
+		},
+		{
+			name: "any unknown fragment falls through",
+			desc: &vtxo.Descriptor{
+				Ancestry: []vtxo.Ancestry{
+					{
+						CommitmentHeight: 0,
+					},
+					{
+						CommitmentHeight: 600,
+					},
+					{
+						CommitmentHeight: 0,
+					},
+				},
+			},
+			expect: 0,
+		},
+		{
+			name: "all zero falls through",
+			desc: &vtxo.Descriptor{
+				Ancestry: []vtxo.Ancestry{
+					{
+						CommitmentHeight: 0,
+					},
+					{
+						CommitmentHeight: 0,
+					},
+				},
+			},
+			expect: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := &behavior{desc: tc.desc, log: btclog.Disabled}
+			require.Equal(t, tc.expect, b.commitmentHeightFloor())
+		})
+	}
+}
+
+// TestProofNodeHeightHintUsesCommitmentHeight verifies that when the target
+// descriptor carries known commitment heights the proof-node confirmation
+// watch is floored at min(commitment height) across fragments — a tight,
+// provable floor — rather than the bounded lookback.
+func TestProofNodeHeightHintUsesCommitmentHeight(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+
+	// Two fragments with distinct known commitment heights; the lower one
+	// (min) must win. Both sit well below the current tip so the value is
+	// clearly the commitment floor, not the lookback.
+	const (
+		startHeight uint32 = 850_000
+		lowHeight   int32  = 700_000
+		highHeight  int32  = 800_000
+	)
+	desc.Ancestry = []vtxo.Ancestry{
+		{
+			CommitmentHeight: highHeight,
+		},
+		{
+			CommitmentHeight: lowHeight,
+		},
+	}
+
+	unrollActor, _, txconfirmRef, _ := newActorHarness(t, proof, desc)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  int32(startHeight),
+		Trigger: TriggerManual,
+	})
+
+	require.Equal(t, 1, txconfirmRef.requestCount())
+	hint := txconfirmRef.lastRequest(t).HeightHint
+
+	// The tight commitment floor is used, not the lookback floor.
+	require.Equal(t, uint32(lowHeight), hint)
+	require.NotEqual(t, startHeight-proofNodeHeightHintLookback, hint)
+}
+
+// TestProofNodeHeightHintFallsBackWithoutCommitmentHeight verifies that when
+// no fragment carries a commitment height (legacy/absent server field) the
+// hint falls back to exactly the bounded lookback floor — identical to the
+// pre-commitment-height behaviour.
+func TestProofNodeHeightHintFallsBackWithoutCommitmentHeight(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+
+	// Ancestry present but all commitment heights unknown (zero): the floor
+	// must fall back to the lookback, just like today.
+	desc.Ancestry = []vtxo.Ancestry{
+		{
+			CommitmentHeight: 0,
+		},
+		{
+			CommitmentHeight: 0,
+		},
+	}
+
+	const startHeight uint32 = 850_000
+
+	unrollActor, _, txconfirmRef, _ := newActorHarness(t, proof, desc)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  int32(startHeight),
+		Trigger: TriggerManual,
+	})
+
+	require.Equal(t, 1, txconfirmRef.requestCount())
+	hint := txconfirmRef.lastRequest(t).HeightHint
+
+	require.Equal(t, startHeight-proofNodeHeightHintLookback, hint)
+}
+
 // TestFraudTriggerDefersReadyCheckpoint verifies fraud-triggered recovery
 // watches a ready checkpoint before asking txconfirm to broadcast it.
 func TestFraudTriggerDefersReadyCheckpoint(t *testing.T) {

--- a/vtxo/incoming_ancestry.go
+++ b/vtxo/incoming_ancestry.go
@@ -71,10 +71,11 @@ func AncestryFromRPC(paths []*arkrpc.AncestryPath) ([]Ancestry, error) {
 		}
 
 		out = append(out, Ancestry{
-			TreePath:       treePath,
-			CommitmentTxID: commitmentTxID,
-			InputIndices:   slices.Clone(p.GetInputIndices()),
-			TreeDepth:      p.GetTreeDepth(),
+			TreePath:         treePath,
+			CommitmentTxID:   commitmentTxID,
+			InputIndices:     slices.Clone(p.GetInputIndices()),
+			TreeDepth:        p.GetTreeDepth(),
+			CommitmentHeight: p.GetCommitmentHeight(),
 		})
 	}
 


### PR DESCRIPTION
Fixes #884. Combines what were previously two stacked PRs (the bounded-lookback stopgap #911 and the commitment-height fix) into one, since the lookback is now just the fallback within the same logic. Companion server PR: lightninglabs/darepo#666.

## Problem

A unilateral exit registers a confirmation watch per proof-graph node. Using a
genesis (height 1) hint made neutrino rescan **every block from tip to genesis**
when a proof tx never confirmed — flooding logs (800 kB → 80 MB in minutes) and
never terminating, since the v3/TRUC exit tx is rejected by signet peers
(darepo-client#884).

## Fix

Floor the hint at `min(commitment_height)` across the VTXO's ancestry fragments.
Nothing in a proof graph can confirm before its commitment tx, so the
commitment's on-chain confirmation height is the **tightest sound lower bound**.

- **Proto:** new `commitment_height` on `arkrpc.AncestryPath`.
- **Ingest:** `CommitmentHeight` on `lib/types.Ancestry`, populated at the single
  `AncestryFromRPC` choke-point.
- **DB:** persisted on `vtxo_ancestry_paths` via a **forward `ALTER ... ADD
  COLUMN` migration (`000012`)** — existing deployments gain the column without
  a schema reset (`LatestMigrationVersion` → 12).
- **unroll:** `proofNodeConfHeightHint` floors at `min(commitmentHeight)`.

The server supplies the height (already resolved as `RoundRow.ConfirmationHeight`,
previously discarded before the wire) in darepo#666.

## Fallback (why this is safe to merge before the server PR)

When no fragment carries a commitment height — legacy rows (column defaults to
0), empty-ancestry incoming VTXOs, or any producer that didn't set it — the hint
falls back to a **bounded lookback below the current tip**
(`proofNodeHeightHintLookback`, 10k blocks). That caps the rescan window without
depending on chain data. Until the server populates the field, behaviour is
exactly this lookback (the former #911 stopgap). The age-exceeds-lookback `WarnS`
now fires only on the fallback path.

## Testing

- `TestMinCommitmentHeight`, `TestProofNodeHeightHintUsesCommitmentHeight`,
  `TestProofNodeHeightHintFallsBackWithoutCommitmentHeight`, plus the existing
  bounded-lookback tests.
- `make rpc` / `sqlc` / `fmt-changed` / `lint-changed-local` (0 issues) /
  `unit pkg=unroll db vtxo lib/types` / `check-migration-version` /
  `commitmsg-lint`: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)