### PR TITLE
darepocli: accept snake_case --session_id on ark oor get

### DIFF
--- a/cmd/darepocli/darepoclicommands/cmd_oor.go
+++ b/cmd/darepocli/darepoclicommands/cmd_oor.go
@@ -3,9 +3,11 @@ package darepoclicommands
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -38,7 +40,24 @@ func newOORGetCmd() *cobra.Command {
 	cmd.Flags().String("session-id", "",
 		"OOR session id to fetch")
 
+	// Accept the snake_case spelling (--session_id) as well as the
+	// registered kebab form. The RPC field, `oor list` JSON output, and the
+	// daemon logs all name this field session_id, so a user copying that
+	// name should not hit an "unknown flag" error (issue #900). This only
+	// adds an alias: every flag on this command (and the inherited global
+	// flags) is defined in kebab case, so folding underscores to dashes
+	// never renames an existing flag.
+	cmd.Flags().SetNormalizeFunc(snakeToKebabFlags)
+
 	return cmd
+}
+
+// snakeToKebabFlags folds a snake_case flag name onto its canonical kebab-case
+// spelling so both spellings resolve to the same flag. Apply it only to
+// commands whose flags are all defined in kebab case, where it acts purely as
+// an alias.
+func snakeToKebabFlags(_ *pflag.FlagSet, name string) pflag.NormalizedName {
+	return pflag.NormalizedName(strings.ReplaceAll(name, "_", "-"))
 }
 
 // newOORListCmd creates the oor list subcommand.

--- a/cmd/darepocli/darepoclicommands/oor_destination_test.go
+++ b/cmd/darepocli/darepoclicommands/oor_destination_test.go
@@ -126,6 +126,30 @@ func TestMethodRegistryOORReceiveSchema(t *testing.T) {
 	require.Equal(t, "NewReceiveScriptResponse", method.ResponseType)
 }
 
+// TestOORGetAcceptsSnakeCaseSessionID verifies the oor get command resolves
+// both the registered kebab flag (--session-id) and the snake_case spelling
+// (--session_id) used by the JSON output and daemon logs to the same value
+// (issue #900).
+func TestOORGetAcceptsSnakeCaseSessionID(t *testing.T) {
+	t.Parallel()
+
+	for _, spelling := range []string{"--session-id", "--session_id"} {
+		spelling := spelling
+
+		t.Run(spelling, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := newOORGetCmd()
+			err := cmd.Flags().Parse([]string{spelling, "sess-1"})
+			require.NoError(t, err)
+
+			got, err := cmd.Flags().GetString("session-id")
+			require.NoError(t, err)
+			require.Equal(t, "sess-1", got)
+		})
+	}
+}
+
 // findSchemaMethod locates a method entry in the CLI schema registry.
 func findSchemaMethod(t *testing.T, methodName string) schemaMethod {
 	t.Helper()


### PR DESCRIPTION
Fixes #900.

`ark oor get` registered only the kebab flag `--session-id`, so passing
`--session_id` errored with "unknown flag" — even though the RPC field,
`ark oor list` JSON output, and the daemon logs all name it `session_id`. A
user copying that field name straight from the output hit a dead end.

Install a flag-name normalization on the command that folds snake_case onto
the canonical kebab spelling, so `--session_id` and `--session-id` resolve to
the same flag. Scoped to this command, whose flags (and the inherited global
flags) are all defined in kebab case, so it only adds an alias and never
renames an underscore-defined flag. The schema registry keeps its existing
kebab spelling.

## Testing

- Added `TestOORGetAcceptsSnakeCaseSessionID` (both spellings resolve to the
  same value).
- `darepoclicommands` package passes; `fmt-changed`, `lint-changed-local`, and
  `commitmsg-lint` clean.

---

Note: this PR originally also bundled fixes for #922 and #923, but those are
already addressed by @darioAnongba's #925 with an equivalent approach, so those
two commits were dropped here. This PR now covers only #900.