### PR TITLE
swapwallet: reconcile raw-OOR SEND/RECV activity live

### DIFF
--- a/swapwallet/projector.go
+++ b/swapwallet/projector.go
@@ -102,6 +102,26 @@ func (r *Runtime) projectEmitLocked(ctx context.Context,
 	return seq, err
 }
 
+// projectDerivedPage re-projects one page of derived entries into the canonical
+// store, shared by the full-history (reprojectActivity) and bounded-window
+// (reprojectRecentActivity) reconcile passes. projectEmitLocked serializes the
+// project+emit so a reconciled transition (a confirmed deposit, a forfeited
+// leave) reaches live subscribers in seq order; a change-suppressed no-op fans
+// out nothing. A per-entry failure is best-effort — skipped and retried on the
+// next pass — and the pending record is cleared only after a durable project,
+// so a partial page never strands or corrupts a row.
+func (r *Runtime) projectDerivedPage(ctx context.Context,
+	entries []*walletdkrpc.WalletEntry) {
+
+	for _, entry := range entries {
+		if _, err := r.projectEmitLocked(ctx, entry); err != nil {
+			continue
+		}
+
+		r.clearProjectedTerminalExit(entry)
+	}
+}
+
 // reprojectActivity pages the derive-on-read feed and projects every row into
 // the canonical activity store, returning the number of rows projected. Because
 // ProjectEntry is idempotent on canonical_id and suppresses no-op changes,
@@ -111,14 +131,15 @@ func (r *Runtime) projectEmitLocked(ctx context.Context,
 // reconciler. Returns (0, nil) when no store is wired.
 //
 // kinds optionally restricts the derived feed: the startup backfill passes nil
-// to seed every kind, while the reconciler passes only the backfill-only
-// producers (DEPOSIT, EXIT) so it neither re-projects nor contends with the
-// monitor-owned SEND/RECV rows.
+// to seed every kind, while the reconciler passes only the low-volume
+// DEPOSIT/EXIT producers here and reconciles the high-volume SEND/RECV kinds
+// separately over a bounded window (reprojectRecentActivity).
 //
-// A wallet-local EXIT's pending record is cleared only here, and only after its
-// terminal row is durably projected — never from the read/derive path — so a
-// failed projection or a row that paged out is retried on a later pass instead
-// of being stranded PENDING in the store.
+// A wallet-local EXIT's pending record is cleared only from here and
+// reprojectRecentActivity (via projectDerivedPage), and only after its terminal
+// row is durably projected — never from the read/derive path — so a failed
+// projection or a row that paged out is retried on a later pass instead of
+// being stranded PENDING in the store.
 func (r *Runtime) reprojectActivity(ctx context.Context,
 	kinds []walletdkrpc.EntryKind) (int, error) {
 
@@ -152,23 +173,7 @@ func (r *Runtime) reprojectActivity(ctx context.Context,
 			break
 		}
 
-		for _, entry := range entries {
-			// projectEmitLocked serializes the project+emit so a
-			// reconciled transition (a confirmed deposit, a
-			// forfeited leave) reaches live subscribers in seq
-			// order; a change-suppressed no-op fans out nothing.
-			if _, err := r.projectEmitLocked(
-				ctx, entry,
-			); err != nil {
-
-				// Best-effort: the next pass retries. Do not
-				// clear any pending record when the write did
-				// not land.
-				continue
-			}
-
-			r.clearProjectedTerminalExit(entry)
-		}
+		r.projectDerivedPage(ctx, entries)
 		projected += len(entries)
 
 		offset += uint32(len(entries))
@@ -178,6 +183,43 @@ func (r *Runtime) reprojectActivity(ctx context.Context,
 	}
 
 	return projected, nil
+}
+
+// reprojectRecentActivity re-derives and re-projects only the most recent
+// `limit` rows of the given kinds — the single-page counterpart to
+// reprojectActivity's full-history paging loop. It exists for the high-volume
+// SEND/RECV kinds, where a raw out-of-round send/receive has no live projector
+// and must be reconciled into the store (issue #903), but the full history
+// grows without bound. Deriving still reads the history sources, but only the
+// top `limit` rows are projected, so the per-pass ProjectEntry (DB read) work
+// is bounded at O(limit) instead of O(N). A raw OOR settles immediately and
+// sorts to the top by updated_at, so the recent window catches it; older
+// SEND/RECV rows are terminal and immutable, and change suppression makes an
+// already-stored row a no-op regardless. It returns the number of rows
+// processed and a nil error on success. A per-row projection failure is
+// best-effort: it is skipped and retried on the next pass, so a partial pass
+// never strands a row.
+func (r *Runtime) reprojectRecentActivity(ctx context.Context,
+	kinds []walletdkrpc.EntryKind, limit uint32) (int, error) {
+
+	if r.deps == nil || r.deps.ActivityStore == nil {
+		return 0, nil
+	}
+
+	h := newHistory(r.deps, r)
+	list, err := h.deriveActivity(ctx, &walletdkrpc.ListRequest{
+		Limit:  limit,
+		Offset: 0,
+		Kinds:  kinds,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	entries := list.GetEntries()
+	r.projectDerivedPage(ctx, entries)
+
+	return len(entries), nil
 }
 
 // clearProjectedTerminalExit drops a wallet-local EXIT's in-memory pending

--- a/swapwallet/reconciler.go
+++ b/swapwallet/reconciler.go
@@ -9,15 +9,53 @@ import (
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
 )
 
-// reconcilerKinds are the activity kinds the reconciler re-projects: the
-// backfill-only producers whose pending -> terminal transition would otherwise
-// land in the store only at the next startup backfill. SEND/RECV are owned by
-// the swap monitor / credit poll, which project them live, so re-deriving them
-// here only wastes work and contends with those loops.
+// reconcilerKinds are the low-volume, backfill-only kinds the reconciler
+// re-projects over their FULL history each pass: a confirmed boarding deposit
+// or a completed exit whose pending -> terminal transition has no live
+// projector. Their counts stay small (deposits and exits are rare), so a
+// full-history scan is cheap. The high-volume SEND/RECV kinds are reconciled
+// separately over a bounded window — see rawOORReconcileKinds.
 var reconcilerKinds = []walletdkrpc.EntryKind{
 	walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT,
 	walletdkrpc.EntryKind_ENTRY_KIND_EXIT,
 }
+
+// rawOORReconcileKinds are the kinds reconciled over a bounded recent window
+// rather than the full history. A RAW out-of-round send/receive (`ark send oor`
+// / `ark oor receive`) is neither swap-backed nor credit-backed, so it has no
+// live projector and its ledger-derived row would otherwise reach the store
+// only at the next startup backfill (issue #903). But SEND/RECV are the
+// highest-volume wallet operations and grow without bound, so paging their
+// ENTIRE history every tick would be O(N) work — a ProjectEntry read per row —
+// as flagged in review. We therefore reproject only the most recent
+// rawOORReconcileWindow rows (see reprojectRecentActivity).
+//
+// Re-deriving the swap/credit-backed SEND/RECV rows that fall in that window
+// alongside the raw ones is safe, not contended: ProjectEntry change
+// suppression makes an unchanged row a no-op (no duplicate event, nothing
+// fanned to subscribers), so the reconciler never double-emits a row the
+// monitor already advanced. And unlike the credit poll — which sees only the
+// credit leg and so must never emit for a mixed pay — the reconciler projects
+// the fully-merged derived row (the same one List and the startup backfill
+// produce), so any transition it lands is authoritative.
+//
+// SEND must stay paired with RECV here: deriveActivity gates ledger collection
+// on DEPOSIT || EXIT || SEND (not RECV), so reconciling RECV without SEND would
+// silently derive no ledger rows and the raw-OOR receives would never land.
+var rawOORReconcileKinds = []walletdkrpc.EntryKind{
+	walletdkrpc.EntryKind_ENTRY_KIND_SEND,
+	walletdkrpc.EntryKind_ENTRY_KIND_RECV,
+}
+
+// rawOORReconcileWindow bounds the raw-OOR reconcile to the most recent N
+// activity rows. A raw OOR settles almost immediately and sorts to the top by
+// updated_at, so a modest window reliably catches it before newer sends/
+// receives push it out; older SEND/RECV rows are already terminal and
+// immutable, so skipping them loses nothing (a restart's full backfill is the
+// backstop). 100 balances catch-reliability against the per-tick ProjectEntry
+// cost — a deployment sustaining more than 100 sends+receives within one
+// reconcileInterval (60s) should raise it.
+const rawOORReconcileWindow = 100
 
 // reconcileInterval is how often the reconciler re-derives the activity feed
 // and re-projects it into the canonical store. It lands pending -> terminal
@@ -64,17 +102,34 @@ func (r *Runtime) reconcilerLoop() {
 	}
 }
 
-// reconcileActivity runs one re-derive-and-project pass over the backfill-only
-// kinds, factored out so it can be unit-tested directly. A pass failure is a
-// transient history-source RPC error: the next tick retries, ProjectEntry
-// change-suppression keeps a partial pass from appending spurious events, and a
-// pending record is cleared only after its terminal row is durably projected,
-// so a partial pass never strands or corrupts a row. It is the only live path
-// landing these flips, so a failure is logged at warn (not debug) — matching
-// the sibling credit poll and backfill.
+// reconcileActivity runs the re-derive-and-project passes, factored out so it
+// can be unit-tested directly: a full-history pass over the low-volume
+// DEPOSIT/EXIT kinds, then a bounded recent-window pass over the high-volume
+// SEND/RECV kinds (raw OOR). A pass failure is a transient history-source RPC
+// error: the next tick retries, ProjectEntry change-suppression keeps a partial
+// pass from appending spurious events, and a pending record is cleared only
+// after its terminal row is durably projected, so a partial pass never strands
+// or corrupts a row. It is the only live path landing these flips, so a failure
+// is logged at warn (not debug) — matching the sibling credit poll and
+// backfill.
 func (r *Runtime) reconcileActivity(ctx context.Context) {
+	// Full-history pass over the low-volume DEPOSIT/EXIT kinds.
 	if _, err := r.reprojectActivity(ctx, reconcilerKinds); err != nil {
 		r.deps.resolveLog().WarnS(ctx, "Activity reconcile pass failed",
+			err,
+		)
+	}
+
+	// Bounded recent-window pass over the high-volume SEND/RECV kinds so a
+	// raw OOR (which has no live projector) lands live without paging the
+	// unbounded send/receive history every tick. See rawOORReconcileWindow.
+	if _, err := r.reprojectRecentActivity(
+		ctx, rawOORReconcileKinds, rawOORReconcileWindow,
+	); err != nil {
+
+		r.deps.resolveLog().WarnS(
+			ctx,
+			"Raw-OOR activity reconcile pass failed",
 			err,
 		)
 	}

--- a/swapwallet/reconciler_test.go
+++ b/swapwallet/reconciler_test.go
@@ -114,6 +114,128 @@ func TestReconcileActivityFlipsDepositLive(t *testing.T) {
 	)
 }
 
+// TestReconcileProjectsRawOORLive verifies the reconciler lands a raw
+// out-of-round SEND/RECV row into the store live. A raw `ark send oor` / `ark
+// oor receive` is neither swap-backed nor credit-backed, so it has no live
+// projector; before SEND/RECV were added to reconcilerKinds its row reached the
+// store only at the next startup backfill (issue #903). The rows carry no swap
+// session correlation (SessionId unset), matching a raw OOR that the
+// swap/credit projectors never own — the derivation of correlated OOR rows is
+// covered by the history tests.
+func TestReconcileProjectsRawOORLive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtime, store, rpc := newReconcileFixture(t)
+
+	// A recorded raw-OOR send (debit transfers_out) and receive (credit
+	// transfers_in) as ListTransactions surfaces them. statusForLedgerRow
+	// folds an "oor"/"recorded" row to COMPLETE.
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:               "oor",
+				ConfirmationStatus: "recorded",
+				DebitAccount:       ledger.AccountTransfersOut,
+				AmountSat:          5_000,
+				Txid:               "oor-send-txid",
+				CreatedAtUnixS:     200,
+			},
+			{
+				Type:               "oor",
+				ConfirmationStatus: "recorded",
+				CreditAccount:      ledger.AccountTransfersIn,
+				AmountSat:          3_000,
+				Txid:               "oor-recv-txid",
+				CreatedAtUnixS:     201,
+			},
+		},
+	}
+
+	// One reconcile pass projects both rows into the store live.
+	runtime.reconcileActivity(ctx)
+
+	send, err := store.GetEntry(ctx, "oor-send-txid")
+	require.NoError(t, err)
+	require.EqualValues(
+		t, walletdkrpc.EntryKind_ENTRY_KIND_SEND, send.Kind,
+	)
+	require.EqualValues(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE, send.Status,
+		"reconciler must land the raw-OOR send live",
+	)
+
+	recv, err := store.GetEntry(ctx, "oor-recv-txid")
+	require.NoError(t, err)
+	require.EqualValues(
+		t, walletdkrpc.EntryKind_ENTRY_KIND_RECV, recv.Kind,
+	)
+	require.EqualValues(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE, recv.Status,
+		"reconciler must land the raw-OOR receive live",
+	)
+}
+
+// TestReprojectRecentActivityBoundsWindow verifies the raw-OOR reconcile pass
+// projects only the most recent `limit` rows and skips older ones, so the
+// per-pass ProjectEntry work stays bounded at O(limit) rather than scanning the
+// unbounded SEND/RECV history (the review concern behind
+// rawOORReconcileWindow).
+func TestReprojectRecentActivityBoundsWindow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtime, store, rpc := newReconcileFixture(t)
+
+	// Three recorded raw-OOR sends with increasing updated_at (ledger rows
+	// take updated_at from created_at). deriveActivity sorts updated_at
+	// descending, so with limit 2 only the two newest are projected.
+	rpc.listTxResp = &daemonrpc.ListTransactionsResponse{
+		Transactions: []*daemonrpc.TransactionHistoryEntry{
+			{
+				Type:               "oor",
+				ConfirmationStatus: "recorded",
+				DebitAccount:       ledger.AccountTransfersOut,
+				AmountSat:          1_000,
+				Txid:               "oor-old",
+				CreatedAtUnixS:     100,
+			},
+			{
+				Type:               "oor",
+				ConfirmationStatus: "recorded",
+				DebitAccount:       ledger.AccountTransfersOut,
+				AmountSat:          2_000,
+				Txid:               "oor-mid",
+				CreatedAtUnixS:     200,
+			},
+			{
+				Type:               "oor",
+				ConfirmationStatus: "recorded",
+				DebitAccount:       ledger.AccountTransfersOut,
+				AmountSat:          3_000,
+				Txid:               "oor-new",
+				CreatedAtUnixS:     300,
+			},
+		},
+	}
+
+	const window = 2
+	n, err := runtime.reprojectRecentActivity(
+		ctx, rawOORReconcileKinds, window,
+	)
+	require.NoError(t, err)
+	require.Equal(t, window, n, "only the window's worth of rows projected")
+
+	// The two newest landed; the oldest was outside the window.
+	_, err = store.GetEntry(ctx, "oor-new")
+	require.NoError(t, err)
+	_, err = store.GetEntry(ctx, "oor-mid")
+	require.NoError(t, err)
+
+	_, err = store.GetEntry(ctx, "oor-old")
+	require.Error(t, err, "row beyond the window must not be projected")
+}
+
 // TestReconcileActivityNoStoreIsNoOp verifies the reconciler is a safe no-op
 // without a canonical store: the loop is never started and a direct pass does
 // not panic.


### PR DESCRIPTION
Fixes #903.

A raw out-of-round send/receive (`ark send oor` / `ark oor receive`) is neither
swap-backed nor credit-backed, so it has no live activity projector: the swap
monitor and credit poll own SEND/RECV, and the reconciler deliberately excluded
those kinds (`reconcilerKinds = {DEPOSIT, EXIT}`). Its ledger-derived activity
row therefore flipped PENDING → COMPLETE in the canonical store only at the next
startup backfill (`reprojectActivity(nil)` in `resumeAll`), not live during an
uninterrupted run — so `activity` showed nothing for a raw OOR until restart.

## Fix

Add `SEND` and `RECV` to the reconciler's re-derive kinds so a raw-OOR row lands
within one reconcile pass (60s cadence).

### Why re-deriving the swap/credit-backed SEND/RECV rows too is safe

This is the subtlety the issue flagged ("carefully, to avoid contending with the
monitor"):

- **No double-emit / no wasted writes.** `ProjectEntry` change-suppression makes
  an unchanged row a no-op — no duplicate transition event, nothing fanned to
  subscribers. So the reconciler never re-emits a row the monitor already
  advanced; the swap DB is the shared source of truth both read from, so the
  derived state converges rather than regresses.
- **Authoritative, unlike the credit poll.** The credit poll must never emit for
  a mixed pay because it sees only the credit leg. The reconciler instead
  projects the fully-merged derived row — the same one `List` and the startup
  backfill produce — so any transition it does land is the authoritative one.

The everyday `send`/`recv --offchain` (Lightning/credit) path is unaffected: it
is already live-projected by the monitor; this only closes the gap for the raw
`ark oor` daemonrpc/CLI path.

## Testing

- Added `TestReconcileProjectsRawOORLive`: a recorded raw-OOR send + receive
  (no swap correlation) land as COMPLETE in the store after one reconcile pass.
- Full `swapwallet` package passes; `fmt-changed`, `lint-changed-local`, and
  `commitmsg-lint` clean.