### PR TITLE
swaps: cancel recovery when refund spend seen before index

### DIFF
--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -1616,6 +1616,25 @@ func (s *paySession) markRefunded(ctx context.Context,
 		slog.String("spender", spentVHTLC.SpentByTxID),
 	)
 
+	// The refund spend is on-chain, so the daemon-owned recovery armed at
+	// funding time is no longer needed. Cancel it before recording the
+	// terminal state, mirroring markRefundOutputIndexed and
+	// markRefundSessionCompleted so a refund that completes via the spent
+	// vHTLC observation (e.g. when the refund output has not been indexed
+	// yet) does not leave a dangling armed recovery row behind.
+	//
+	// This is the unilateral refund-without-receiver (timeout) path, so the
+	// spend is not a cooperative settlement: pass an empty cooperative txid
+	// like every other cancel call site. A non-empty value would have to be
+	// a canonical txid or the daemon rejects the cancel, which our
+	// retryable wrapping would then retry forever.
+	if err := cancelVHTLCRecovery(
+		ctx, s.client.daemon, s.refundRecoveryID,
+		recoveryReasonRefundSpendObserved, "",
+	); err != nil {
+		return newRetryableActionError(err)
+	}
+
 	return s.mutateAndPersist(ctx, func() error {
 		if spentVHTLC.Outpoint != "" {
 			s.vhtlcOutpoint = spentVHTLC.Outpoint

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/psbt/v2"
@@ -762,8 +763,10 @@ func TestPaySessionRefundsFundedVHTLCOnTimeout(t *testing.T) {
 			AmountSat: testInSwapAmountSat,
 		},
 		receiveInfo: &ReceiveInfo{
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
-			PkScript:    refundScript,
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
+			PkScript: refundScript,
 		},
 		spendOnCustom: true,
 	}
@@ -858,8 +861,10 @@ func TestPaySessionCooperativeRefundsBeforeTimeout(t *testing.T) {
 			AmountSat: testInSwapAmountSat,
 		},
 		receiveInfo: &ReceiveInfo{
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
-			PkScript:    refundScript,
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
+			PkScript: refundScript,
 		},
 		spendOnCustom: true,
 	}
@@ -963,8 +968,10 @@ func TestPaySessionCooperativeRefundUsesLocalFundingMetadata(t *testing.T) {
 		sendSessionID: "refund-session",
 		sendOutpoint:  "funding:0",
 		receiveInfo: &ReceiveInfo{
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
-			PkScript:    refundScript,
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
+			PkScript: refundScript,
 		},
 		spendOnCustom: true,
 	}
@@ -1068,8 +1075,10 @@ func TestPaySessionCooperativeRefundWaitsForOutputBeforeTerminal(t *testing.T) {
 		sendSessionID: "refund-session",
 		sendOutpoint:  "funding:0",
 		receiveInfo: &ReceiveInfo{
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
-			PkScript:    refundScript,
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
+			PkScript: refundScript,
 		},
 	}
 	daemonConn.liveLookupHook = func(call int) (*VTXOInfo, error) {
@@ -1180,8 +1189,10 @@ func TestPaySessionCooperativeRefundIgnoresServerUnavailable(t *testing.T) {
 			AmountSat: testInSwapAmountSat,
 		},
 		receiveInfo: &ReceiveInfo{
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
-			PkScript:    refundScript,
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
+			PkScript: refundScript,
 		},
 	}
 
@@ -1279,8 +1290,10 @@ func TestPaySessionCooperativeRefundKeepsAcceptedSessionOnPersistFailure(
 			AmountSat: testInSwapAmountSat,
 		},
 		receiveInfo: &ReceiveInfo{
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
-			PkScript:    refundScript,
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
+			PkScript: refundScript,
 		},
 	}
 
@@ -1396,8 +1409,10 @@ func TestPaySessionResumeAfterAcceptedRefundFindsOutput(t *testing.T) {
 			AmountSat: testInSwapAmountSat,
 		},
 		receiveInfo: &ReceiveInfo{
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
-			PkScript:    refundScript,
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
+			PkScript: refundScript,
 		},
 		spendOnCustom: true,
 	}
@@ -1547,8 +1562,10 @@ func TestPaySessionResumeAfterAcceptedRefundUsesSpentVHTLCFallback(
 			AmountSat: testInSwapAmountSat,
 		},
 		receiveInfo: &ReceiveInfo{
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
-			PkScript:    refundScript,
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
+			PkScript: refundScript,
 		},
 		spendOnCustom: true,
 	}
@@ -1751,8 +1768,10 @@ func TestPaySessionRefundsWhenRefundLocktimePassesBeforeClaim(t *testing.T) {
 			AmountSat: testInSwapAmountSat,
 		},
 		receiveInfo: &ReceiveInfo{
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
-			PkScript:    refundScript,
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
+			PkScript: refundScript,
 		},
 		spendOnCustom: true,
 	}
@@ -1808,6 +1827,110 @@ func TestPaySessionRefundsWhenRefundLocktimePassesBeforeClaim(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, PayStateRefunded, resumed.State())
 	require.Equal(t, "refund-session", resumed.refundSessionID)
+}
+
+// TestPaySessionRefundCancelsRecoveryWhenSpendObservedBeforeIndex asserts that
+// when a timeout refund completes via the spent vHTLC observation (the refund
+// output has not yet been indexed as a live VTXO), the pay session still
+// cancels the recovery that was armed at funding time. Otherwise the
+// daemon-owned recovery row would be left dangling after the swap is refunded.
+func TestPaySessionRefundCancelsRecoveryWhenSpendObservedBeforeIndex(
+	t *testing.T) {
+
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	refundScript, err := txscript.PayToTaprootScript(clientPriv.PubKey())
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:  preimage.Hash(),
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
+			ServerPubkey: serverPriv.PubKey(),
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime:                       100,
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			Expiry: time.Now().Add(time.Minute),
+		},
+	}
+
+	daemonConn := &testDaemonConn{
+		identityKey:   clientPriv.PubKey(),
+		operatorKey:   operatorPriv.PubKey(),
+		blockHeight:   99,
+		sendSessionID: "refund-session",
+		vhtlc: &VTXOInfo{
+			Outpoint:  "funding:0",
+			AmountSat: testInSwapAmountSat,
+		},
+		receiveInfo: &ReceiveInfo{
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
+			PkScript: refundScript,
+		},
+		spendOnCustom: true,
+
+		// Observe the vHTLC spend but never index the refund output, so
+		// the refund completes through markRefunded rather than
+		// markRefundOutputIndexed.
+		skipLiveOnCustom: true,
+	}
+
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	client.waitPollInterval = time.Millisecond
+	client.refundLocktimeBuffer = 0
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	err = session.runUntil(t.Context(), PayStateWaitingForClaim)
+	require.NoError(t, err)
+	require.Equal(t, PayStateWaitingForClaim, session.State())
+
+	daemonConn.blockHeight = 100
+
+	_, err = session.Wait(t.Context())
+	require.ErrorIs(t, err, ErrSwapRefunded)
+	require.Equal(t, 1, daemonConn.sendCustomCalls)
+	require.Equal(t, 1, daemonConn.armRecoveryCalls)
+
+	// The armed recovery must be cancelled even though the terminal state
+	// was reached via the spent vHTLC observation.
+	require.Equal(t, 1, daemonConn.cancelCalls)
+	require.Equal(
+		t, recoveryReasonRefundSpendObserved,
+		daemonConn.lastCancel.GetReason(),
+	)
+
+	// The unilateral timeout refund is not a cooperative settlement, so no
+	// cooperative txid is reported (a non-txid value would be rejected by
+	// the daemon).
+	require.Empty(t, daemonConn.lastCancel.GetCooperativeTxid())
 }
 
 // TestPaySessionResumeFromStore asserts the SDK can reload a persisted pay
@@ -2294,8 +2417,10 @@ func TestPaySessionRefundsAmountMismatch(t *testing.T) {
 			AmountSat: 41_999,
 		},
 		receiveInfo: &ReceiveInfo{
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
-			PkScript:    refundScript,
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
+			PkScript: refundScript,
 		},
 		sendSessionID: "refund-session",
 		spendOnCustom: true,

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -1604,6 +1604,7 @@ type testDaemonConn struct {
 	spentLookupErr    error
 	spentLookupBlock  time.Duration
 	spendOnCustom     bool
+	skipLiveOnCustom  bool
 	sendPolicyCalls   int
 	sendCustomCalls   int
 	oorSessionCalls   int
@@ -1674,8 +1675,12 @@ func (d *testDaemonConn) SendOORWithCustomInputs(_ context.Context,
 		}
 		d.vhtlc = nil
 
+		// skipLiveOnCustom models indexer lag: the vHTLC spend is
+		// observable but the created refund output is not yet indexed
+		// as a live VTXO, forcing the refund to complete via the spent
+		// vHTLC observation path.
 		pubKey, err := schnorr.ParsePubKey(recipientPubKey)
-		if err == nil {
+		if err == nil && !d.skipLiveOnCustom {
 			pkScript, scriptErr := txscript.PayToTaprootScript(
 				pubKey,
 			)
@@ -2075,7 +2080,7 @@ func (d *testDaemonConn) AllocateReceiveScript(context.Context, string) (
 
 		return &ReceiveInfo{
 			PkScript:    pkScript,
-			PubKeyXOnly: d.identityKey.X().Bytes(),
+			PubKeyXOnly: schnorr.SerializePubKey(d.identityKey),
 		}, nil
 	}
 
@@ -2138,7 +2143,9 @@ func TestReceiveSessionWaitClaimsVHTLC(t *testing.T) {
 			PkScript: []byte{
 				0x51,
 			},
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
 		},
 		sendSessionID: "claim-session",
 	}
@@ -2368,7 +2375,9 @@ func TestReceiveSessionResumeFromStore(t *testing.T) {
 			PkScript: []byte{
 				0x51,
 			},
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
 		},
 		sendSessionID: "claim-session",
 	}
@@ -3360,7 +3369,9 @@ func TestReceiveSessionWaitReconcilesBeforeExpiry(t *testing.T) {
 			PkScript: []byte{
 				0x51,
 			},
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
 		},
 		sendSessionID: "claim-session",
 	}
@@ -3425,7 +3436,9 @@ func TestReceiveSessionClaimBeforeHTLCEventFailsClearly(t *testing.T) {
 			PkScript: []byte{
 				0x51,
 			},
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
 		},
 		sendSessionID: "claim-session",
 	}
@@ -3495,7 +3508,9 @@ func TestReceiveSessionClaimFailsOnAmountMismatch(t *testing.T) {
 			PkScript: []byte{
 				0x51,
 			},
-			PubKeyXOnly: clientPriv.PubKey().X().Bytes(),
+			PubKeyXOnly: schnorr.SerializePubKey(
+				clientPriv.PubKey(),
+			),
 		},
 		sendSessionID: "claim-session",
 	}
@@ -3565,7 +3580,9 @@ func TestReceiveSessionFreshClaimBoundsSpentLookup(t *testing.T) {
 			PkScript: []byte{
 				0x51,
 			},
-			PubKeyXOnly: receiverPriv.PubKey().X().Bytes(),
+			PubKeyXOnly: schnorr.SerializePubKey(
+				receiverPriv.PubKey(),
+			),
 		},
 		sendSessionID:  "claim-session",
 		spentLookupErr: context.DeadlineExceeded,
@@ -3666,7 +3683,9 @@ func TestReceiveSessionClaimFollowsRefreshedLiveVHTLC(t *testing.T) {
 			PkScript: []byte{
 				0x51,
 			},
-			PubKeyXOnly: receiverPriv.PubKey().X().Bytes(),
+			PubKeyXOnly: schnorr.SerializePubKey(
+				receiverPriv.PubKey(),
+			),
 		},
 		sendSessionID: "claim-session",
 		liveByPkScript: map[string]*VTXOInfo{
@@ -3758,7 +3777,9 @@ func TestReceiveSessionFreshClaimBoundsSpentLookupGRPCDeadline(t *testing.T) {
 			PkScript: []byte{
 				0x51,
 			},
-			PubKeyXOnly: receiverPriv.PubKey().X().Bytes(),
+			PubKeyXOnly: schnorr.SerializePubKey(
+				receiverPriv.PubKey(),
+			),
 		},
 		sendSessionID: "claim-session",
 		spentLookupErr: fmt.Errorf(
@@ -3840,7 +3861,9 @@ func TestReceiveSessionClaimRejectsAfterRefundLocktime(t *testing.T) {
 			PkScript: []byte{
 				0x51,
 			},
-			PubKeyXOnly: receiverPriv.PubKey().X().Bytes(),
+			PubKeyXOnly: schnorr.SerializePubKey(
+				receiverPriv.PubKey(),
+			),
 		},
 		sendSessionID: "claim-session",
 	}
@@ -3917,7 +3940,9 @@ func TestReceiveSessionClaimRecoveryCompletionWinsAfterRefundLocktime(
 			PkScript: []byte{
 				0x51,
 			},
-			PubKeyXOnly: receiverPriv.PubKey().X().Bytes(),
+			PubKeyXOnly: schnorr.SerializePubKey(
+				receiverPriv.PubKey(),
+			),
 		},
 		statusResp: &daemonrpc.GetVHTLCRecoveryStatusResponse{
 			Found: true,
@@ -4144,7 +4169,9 @@ func TestReceiveSessionClaimReturnsLastSendError(t *testing.T) {
 			PkScript: []byte{
 				0x51,
 			},
-			PubKeyXOnly: receiverPriv.PubKey().X().Bytes(),
+			PubKeyXOnly: schnorr.SerializePubKey(
+				receiverPriv.PubKey(),
+			),
 		},
 		sendCustomErr: sendErr,
 	}
@@ -4156,7 +4183,9 @@ func TestReceiveSessionClaimReturnsLastSendError(t *testing.T) {
 	_, err = client.claimReceiveVHTLC(
 		t.Context(), preimage.Hash(), preimage, policy, policyTemplate,
 		pkScript, "funding:0", 42_000,
-		receiverPriv.PubKey().X().Bytes(),
+		schnorr.SerializePubKey(
+			receiverPriv.PubKey(),
+		),
 	)
 	require.ErrorIs(t, err, sendErr)
 	require.ErrorContains(t, err, "claim vHTLC")

--- a/sdk/swaps/recovery.go
+++ b/sdk/swaps/recovery.go
@@ -82,6 +82,11 @@ const (
 	recoveryReasonRefundSessionCompleted = "cooperative refund session " +
 		"completed"
 
+	// recoveryReasonRefundSpendObserved explains cancellation when the pay
+	// side observes the vHTLC spent by the refund before the refund output
+	// itself is indexed.
+	recoveryReasonRefundSpendObserved = "cooperative refund spend observed"
+
 	// recoveryReasonClaimAccepted explains cancellation when the daemon
 	// accepted the cooperative claim OOR.
 	recoveryReasonClaimAccepted = "cooperative claim accepted"


### PR DESCRIPTION
Fixes #874.

## What was flaky

`TestPaySessionRefundsWhenRefundLocktimePassesBeforeClaim` (`sdk/swaps`)
intermittently failed the final `require.Equal(t, 1, daemonConn.cancelCalls)`
(saw `0`), only in the `unit-cover` job.

## Root cause — not a timing race

The FSM refund path is fully synchronous, so the `-cover` async-ordering
theory in the issue doesn't hold. The real cause is a per-key data bug in the
test fixtures:

The mocks built the refund destination x-only key with
`clientPriv.PubKey().X().Bytes()`. `PublicKey.X()` returns a `*big.Int`, and
`big.Int.Bytes()` **strips leading zero bytes**, so ~1/256 of randomly
generated keys produced a `<32`-byte slice (measured ≈ 19/5000). The daemon
mock then failed `schnorr.ParsePubKey` on that slice and never indexed the
refund output, so the refund completed through `markRefunded` (spent vHTLC
observed) instead of `markRefundOutputIndexed`. Each CI job draws a fresh
random key, so the bad draw happened to land in `unit-cover` that run and
passed everywhere else — nothing to do with coverage instrumentation.

## The real bug this surfaced

`markRefunded`, unlike its siblings `markRefundOutputIndexed` and
`markRefundSessionCompleted`, transitioned to `Refunded` **without cancelling
the recovery** armed at funding time. This is a genuine production bug: the
refund can legitimately complete via the spent-vHTLC observation when the
refund output has not been indexed yet, leaving a **dangling armed recovery
row** behind. This PR cancels it there too.

## Changes

- `in_swap.go` / `recovery.go`: `markRefunded` cancels the armed recovery
  before going terminal (new `recoveryReasonRefundSpendObserved`).
- Fixtures: build x-only keys with `schnorr.SerializePubKey` (always
  zero-padded to 32 bytes) so the tests are deterministic — all 23
  `.X().Bytes()` sites replaced; none remain in the repo.
- New regression test
  `TestPaySessionRefundCancelsRecoveryWhenSpendObservedBeforeIndex` forces the
  spend-before-index path (new `skipLiveOnCustom` mock knob) and asserts the
  recovery is cancelled. Verified it fails without the production fix
  (`expected 1, actual 0`) and passes with it.

## Verification

Full `sdk/swaps` suite passes; refund tests pass 10× under `-cover`;
`go build`/`vet` clean; `make lint-changed-local` reports 0 issues.
