### PR TITLE
db: Make pending-intent test verification use sqlc queries

### DIFF
--- a/db/round_store_test.go
+++ b/db/round_store_test.go
@@ -1774,33 +1774,23 @@ func TestFailForfeitIntentsMarksSendFailed(t *testing.T) {
 
 	// The failed intent's header is retained (not deleted) with the reason
 	// and typed code, so the failure is a durable, correlatable record.
-	var (
-		status     string
-		failReason sql.NullString
-		failCode   int64
-	)
-	row := baseDB.QueryRowContext(ctx,
-		`SELECT status, failure_reason, failure_code
-		 FROM pending_intents WHERE intent_id = ?`,
-		failing.ID[:],
-	)
-	require.NoError(t, row.Scan(&status, &failReason, &failCode))
-	require.Equal(t, "failed", status)
-	require.True(t, failReason.Valid)
-	require.Equal(t, reason, failReason.String)
+	failed, err := baseDB.Queries.GetPendingIntentByID(ctx, failing.ID[:])
+	require.NoError(t, err)
+	require.Equal(t, "failed", failed.Status)
+	require.True(t, failed.FailureReason.Valid)
+	require.Equal(t, reason, failed.FailureReason.String)
 	require.Equal(
-		t, int64(round.RoundFailureInsufficientOperatorFunds), failCode,
+		t, int32(round.RoundFailureInsufficientOperatorFunds),
+		failed.FailureCode,
 	)
 
 	// The failed intent's anchors are retained so the record stays
 	// correlatable by its consumed outpoints.
-	var anchorCount int
-	require.NoError(t, baseDB.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM pending_intent_anchors `+
-			`WHERE intent_id = ?`,
-		failing.ID[:],
-	).Scan(&anchorCount))
-	require.Equal(t, 2, anchorCount)
+	anchorCount, err := baseDB.Queries.CountPendingIntentAnchorsByIntentID(
+		ctx, failing.ID[:],
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, anchorCount)
 
 	// Idempotent: re-failing the same outpoints is a no-op (status guard).
 	require.NoError(
@@ -1810,15 +1800,10 @@ func TestFailForfeitIntentsMarksSendFailed(t *testing.T) {
 			round.RoundFailureUnknown,
 		),
 	)
-	row = baseDB.QueryRowContext(
-		ctx,
-		`SELECT failure_reason FROM pending_intents `+
-			`WHERE intent_id = ?`,
-		failing.ID[:],
-	)
-	require.NoError(t, row.Scan(&failReason))
+	failed, err = baseDB.Queries.GetPendingIntentByID(ctx, failing.ID[:])
+	require.NoError(t, err)
 	require.Equal(
-		t, reason, failReason.String,
+		t, reason, failed.FailureReason.String,
 		"a repeat fail must not overwrite the original reason",
 	)
 }
@@ -1895,20 +1880,15 @@ func TestRepersistFailedSendIntentRearmsReplay(t *testing.T) {
 
 	// The status and failure fields must be cleared so no stale failure
 	// leaks onto the re-armed record.
-	var (
-		status     string
-		failReason sql.NullString
-		failCode   int64
+	armed, err := baseDB.Queries.GetPendingIntentByID(ctx, intent.ID[:])
+	require.NoError(t, err)
+	require.Equal(t, "pending", armed.Status)
+	require.False(
+		t, armed.FailureReason.Valid, "failure reason must be cleared",
 	)
-	row := baseDB.QueryRowContext(ctx,
-		`SELECT status, failure_reason, failure_code
-		 FROM pending_intents WHERE intent_id = ?`,
-		intent.ID[:],
+	require.Equal(
+		t, int32(0), armed.FailureCode, "failure code must be cleared",
 	)
-	require.NoError(t, row.Scan(&status, &failReason, &failCode))
-	require.Equal(t, "pending", status)
-	require.False(t, failReason.Valid, "failure reason must be cleared")
-	require.Equal(t, int64(0), failCode, "failure code must be cleared")
 }
 
 // TestOrphanSweepKeepsFailedSendRecord verifies that the durable failed record
@@ -1987,27 +1967,19 @@ func TestOrphanSweepKeepsFailedSendRecord(t *testing.T) {
 
 	// The failed record must survive the sweep: both its header (status and
 	// reason) and its send detail are retained.
-	var (
-		status     string
-		failReason sql.NullString
-	)
-	row := baseDB.QueryRowContext(ctx,
-		`SELECT status, failure_reason
-		 FROM pending_intents WHERE intent_id = ?`,
-		failing.ID[:],
-	)
-	require.NoError(t, row.Scan(&status, &failReason))
+	failed, err := baseDB.Queries.GetPendingIntentByID(ctx, failing.ID[:])
+	require.NoError(t, err)
 	require.Equal(
-		t, "failed", status, "failed header must survive the sweep",
+		t, "failed", failed.Status,
+		"failed header must survive the sweep",
 	)
-	require.Equal(t, reason, failReason.String)
+	require.Equal(t, reason, failed.FailureReason.String)
 
-	var detailCount int
-	require.NoError(t, baseDB.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM pending_send_intents WHERE intent_id = ?`,
-		failing.ID[:],
-	).Scan(&detailCount))
-	require.Equal(
+	detailCount, err := baseDB.Queries.CountPendingSendIntentsByIntentID(
+		ctx, failing.ID[:],
+	)
+	require.NoError(t, err)
+	require.EqualValues(
 		t, 1, detailCount, "failed send detail must survive the sweep",
 	)
 

--- a/db/sqlc/pending_intents.sql.go
+++ b/db/sqlc/pending_intents.sql.go
@@ -25,6 +25,33 @@ func (q *Queries) ClearPendingIntentAnchorByOutpoint(ctx context.Context, arg Cl
 	return err
 }
 
+const CountPendingIntentAnchorsByIntentID = `-- name: CountPendingIntentAnchorsByIntentID :one
+SELECT COUNT(*) FROM pending_intent_anchors
+WHERE intent_id = $1
+`
+
+// Count the anchors retained for one intent (a failed intent keeps its
+// anchors so it stays correlatable by its consumed outpoints).
+func (q *Queries) CountPendingIntentAnchorsByIntentID(ctx context.Context, intentID []byte) (int64, error) {
+	row := q.db.QueryRowContext(ctx, CountPendingIntentAnchorsByIntentID, intentID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const CountPendingSendIntentsByIntentID = `-- name: CountPendingSendIntentsByIntentID :one
+SELECT COUNT(*) FROM pending_send_intents
+WHERE intent_id = $1
+`
+
+// Count the send-detail rows retained for one intent.
+func (q *Queries) CountPendingSendIntentsByIntentID(ctx context.Context, intentID []byte) (int64, error) {
+	row := q.db.QueryRowContext(ctx, CountPendingSendIntentsByIntentID, intentID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const DeleteOrphanedPendingBoardIntents = `-- name: DeleteOrphanedPendingBoardIntents :exec
 DELETE FROM pending_board_intents
 WHERE NOT EXISTS (
@@ -155,6 +182,27 @@ DELETE FROM pending_send_intents
 func (q *Queries) DeletePendingSendIntentsAll(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, DeletePendingSendIntentsAll)
 	return err
+}
+
+const GetPendingIntentByID = `-- name: GetPendingIntentByID :one
+SELECT status, failure_reason, failure_code
+FROM pending_intents
+WHERE intent_id = $1
+`
+
+type GetPendingIntentByIDRow struct {
+	Status        string
+	FailureReason sql.NullString
+	FailureCode   int32
+}
+
+// Fetch one intent header by id, exposing the terminal-failure columns so
+// callers (and tests) can assert send-failure state without raw SQL.
+func (q *Queries) GetPendingIntentByID(ctx context.Context, intentID []byte) (GetPendingIntentByIDRow, error) {
+	row := q.db.QueryRowContext(ctx, GetPendingIntentByID, intentID)
+	var i GetPendingIntentByIDRow
+	err := row.Scan(&i.Status, &i.FailureReason, &i.FailureCode)
+	return i, err
 }
 
 const ListPendingBoardIntents = `-- name: ListPendingBoardIntents :many

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -23,6 +23,11 @@ type Querier interface {
 	CountActivityEntriesByStatus(ctx context.Context, status int64) (int64, error)
 	CountBoardingIntentsByStatus(ctx context.Context, status string) (int64, error)
 	CountClientLedgerEntries(ctx context.Context) (int64, error)
+	// Count the anchors retained for one intent (a failed intent keeps its
+	// anchors so it stays correlatable by its consumed outpoints).
+	CountPendingIntentAnchorsByIntentID(ctx context.Context, intentID []byte) (int64, error)
+	// Count the send-detail rows retained for one intent.
+	CountPendingSendIntentsByIntentID(ctx context.Context, intentID []byte) (int64, error)
 	CountUnresolvedBoardingSweepInputs(ctx context.Context, txid []byte) (int64, error)
 	CountUnspentVTXOs(ctx context.Context) (int64, error)
 	// CountVTXOsByStatus returns the count of VTXOs with the specified status.
@@ -87,6 +92,9 @@ type Querier interface {
 	GetOORVTXOBindingByOutpoint(ctx context.Context, arg GetOORVTXOBindingByOutpointParams) (OorVtxoBinding, error)
 	GetOORVTXOBindingByOutpointAndKind(ctx context.Context, arg GetOORVTXOBindingByOutpointAndKindParams) (OorVtxoBinding, error)
 	GetOwnedReceiveScript(ctx context.Context, pkScript []byte) (OwnedReceiveScript, error)
+	// Fetch one intent header by id, exposing the terminal-failure columns so
+	// callers (and tests) can assert send-failure state without raw SQL.
+	GetPendingIntentByID(ctx context.Context, intentID []byte) (GetPendingIntentByIDRow, error)
 	GetRound(ctx context.Context, roundID string) (Round, error)
 	GetRoundBoardingIntents(ctx context.Context, roundID string) ([]RoundBoardingIntent, error)
 	GetRoundByCommitmentTxid(ctx context.Context, commitmentTxid []byte) (Round, error)

--- a/db/sqlc/queries/pending_intents.sql
+++ b/db/sqlc/queries/pending_intents.sql
@@ -167,3 +167,21 @@ DELETE FROM pending_send_intents;
 -- name: DeletePendingIntentsByKind :exec
 DELETE FROM pending_intents
 WHERE kind = $1;
+
+-- name: GetPendingIntentByID :one
+-- Fetch one intent header by id, exposing the terminal-failure columns so
+-- callers (and tests) can assert send-failure state without raw SQL.
+SELECT status, failure_reason, failure_code
+FROM pending_intents
+WHERE intent_id = $1;
+
+-- name: CountPendingIntentAnchorsByIntentID :one
+-- Count the anchors retained for one intent (a failed intent keeps its
+-- anchors so it stays correlatable by its consumed outpoints).
+SELECT COUNT(*) FROM pending_intent_anchors
+WHERE intent_id = $1;
+
+-- name: CountPendingSendIntentsByIntentID :one
+-- Count the send-detail rows retained for one intent.
+SELECT COUNT(*) FROM pending_send_intents
+WHERE intent_id = $1;


### PR DESCRIPTION
## Problem

`main` is red on `test_postgres`. The send-failure tests added in
[#915](https://github.com/lightninglabs/darepo-client/pull/915)
(`TestFailForfeitIntentsMarksSendFailed`, `TestOrphanSweepKeepsFailedSendRecord`,
`TestRepersistFailedSendIntentRearmsReplay`) verified `pending_intents` state
with raw `baseDB.QueryRowContext` calls using SQLite `?` placeholders:

```go
`SELECT status, failure_reason, failure_code FROM pending_intents WHERE intent_id = ?`
```

The pgx stdlib driver does not rewrite `?` → `$N`, so on postgres `intent_id = ?`
parses `?` as a dangling operator and errors with `syntax error at end of input
(SQLSTATE 42601)`. The tests passed on sqlite/unit-cover and failed only on
`test_postgres`. It also violated the repo rule *"never write raw SQL in Go."*

## Fix

Rather than patch the placeholders, move the reads into the sqlc CRUD layer and
have the tests call the generated methods — no raw SQL, and portable by
construction (sqlc emits the correct placeholder per dialect):

- Add `GetPendingIntentByID`, `CountPendingIntentAnchorsByIntentID`, and
  `CountPendingSendIntentsByIntentID` to `db/sqlc/queries/pending_intents.sql`.
- Route the six raw verification queries in `round_store_test.go` through
  `baseDB.Queries.*`; drop the raw SQL entirely.

## Testing

- `make unit pkg=db tags="test_postgres" case=<each of the three>` — all pass.
- `make unit pkg=db` (sqlite) — pass.
- `make lint-changed-local` — 0 issues; `commitmsg-lint` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)