### PR TITLE
btcwbackend: await neutrino sync before starting notifier

### DIFF
--- a/btcwbackend/chain_backend.go
+++ b/btcwbackend/chain_backend.go
@@ -67,6 +67,25 @@ type ChainBackend struct {
 	// stopOnce ensures Stop() logic runs exactly once, preventing
 	// double-close panics on the hint DB and notifier.
 	stopOnce sync.Once
+
+	// quit is closed by Stop() to unblock a Start() that is still
+	// waiting for the neutrino backend to become current, so shutdown
+	// during the initial sync wait does not hang.
+	quit chan struct{}
+
+	// startStopMu serializes the notifier/fee-estimator start-vs-stop
+	// transition. Start() only starts them, and Stop() only reads
+	// notifierStarted to decide whether to tear them down, while
+	// holding this lock. Without it, a Stop() racing the moment the
+	// backend becomes current could observe notifierStarted=false,
+	// skip teardown, and then let Start() start (and leak) the
+	// subsystems after Stop() has already returned.
+	startStopMu sync.Mutex
+
+	// notifierStarted records whether Start() started the notifier and
+	// fee estimator, so Stop() knows whether to tear them down. Guarded
+	// by startStopMu.
+	notifierStarted bool
 }
 
 // NewChainBackend creates a new neutrino-backed chain backend. The
@@ -126,6 +145,7 @@ func NewChainBackend(svc *NeutrinoService, feeURL string,
 		feeEstimator: feeEstimator,
 		hintDB:       hintDB,
 		Log:          fn.Some(logger),
+		quit:         make(chan struct{}),
 	}, nil
 }
 
@@ -142,8 +162,38 @@ func (b *ChainBackend) logger(ctx context.Context) btclog.Logger {
 	return b.Log.UnwrapOr(build.LoggerFromContext(ctx))
 }
 
-// Start initializes the chain backend by starting the notifier and
-// fee estimator.
+// Chain-sync wait tuning. The neutrino notifier snapshots its
+// block-epoch rescan start height from the chain service's best block
+// exactly once, at notifier.Start(). Starting it before the backend
+// has synced its block/filter headers anchors that snapshot far behind
+// the tip, condemning the notifier to a slow, fragile historical
+// rescan; so Start() blocks until IsCurrent first. These are named
+// consts (not literals) so the cadence can be tuned in one place.
+const (
+	// chainSyncPollInterval is how often Start() re-checks whether the
+	// neutrino backend has become current while waiting to start the
+	// notifier. Header/filter-header sync (what IsCurrent gates on)
+	// typically completes within tens of seconds, so a 1s cadence is
+	// responsive without busy-looping.
+	chainSyncPollInterval = time.Second
+
+	// chainSyncLogInterval bounds how often Start() emits a progress
+	// log line while waiting for sync. Matches the daemon's neutrino
+	// sync-wait heartbeat so operators see roughly one line every 30s
+	// rather than per-poll spam.
+	chainSyncLogInterval = 30 * time.Second
+)
+
+// errChainBackendStopped is returned by Start() when the backend is
+// stopped (via Stop closing quit) before the neutrino service becomes
+// current, so a caller racing shutdown gets a clear signal instead of
+// a nil error paired with a half-started backend.
+var errChainBackendStopped = errors.New("chain backend stopped before " +
+	"neutrino became current")
+
+// Start initializes the chain backend. It first waits for the neutrino
+// backend to become current (see the chain-sync tuning consts for why)
+// and then starts the notifier and fee estimator.
 func (b *ChainBackend) Start() error {
 	b.startOnce.Do(func() {
 		b.logger(context.TODO()).InfoS(
@@ -151,7 +201,34 @@ func (b *ChainBackend) Start() error {
 			"Starting neutrino chain backend",
 		)
 
+		// Gate notifier start on the backend being current so the
+		// notifier's one-shot rescan start height is the real chain
+		// tip, not a stale mid-sync height.
+		if !b.awaitChainCurrent(context.TODO()) {
+			b.startErr = errChainBackendStopped
+
+			return
+		}
+
+		// Take startStopMu to make "not stopped -> start subsystems ->
+		// mark started" atomic against a concurrent Stop(). Re-check
+		// quit under the lock: if Stop() already fired while we were
+		// waiting above, bail without starting anything, so we never
+		// leak a notifier/fee estimator past a completed Stop().
+		b.startStopMu.Lock()
+
+		select {
+		case <-b.quit:
+			b.startStopMu.Unlock()
+			b.startErr = errChainBackendStopped
+
+			return
+
+		default:
+		}
+
 		if err := b.notifier.Start(); err != nil {
+			b.startStopMu.Unlock()
 			b.startErr = fmt.Errorf("start notifier: %w", err)
 
 			return
@@ -159,10 +236,17 @@ func (b *ChainBackend) Start() error {
 
 		if err := b.feeEstimator.Start(); err != nil {
 			_ = b.notifier.Stop()
+			b.startStopMu.Unlock()
 			b.startErr = fmt.Errorf("start fee estimator: %w", err)
 
 			return
 		}
+
+		// Record that the notifier and fee estimator are up so Stop()
+		// knows to tear them down (and, conversely, skips them when a
+		// shutdown interrupts the sync wait above).
+		b.notifierStarted = true
+		b.startStopMu.Unlock()
 
 		b.logger(context.TODO()).InfoS(
 			context.TODO(),
@@ -171,6 +255,69 @@ func (b *ChainBackend) Start() error {
 	})
 
 	return b.startErr
+}
+
+// awaitChainCurrent blocks until the neutrino backend has synced its
+// block and filter headers (IsCurrent) or Stop() closes b.quit. It
+// emits a progress log line at roughly chainSyncLogInterval cadence
+// while waiting. It returns false only if the backend was stopped
+// before it became current. ctx is used only for logging: the wait is
+// intentionally cancellable solely via Stop() (b.quit), matching the
+// backend's shutdown model, not via ctx cancellation.
+func (b *ChainBackend) awaitChainCurrent(ctx context.Context) bool {
+	if b.neutrinoCS.IsCurrent() {
+		return true
+	}
+
+	b.logger(ctx).InfoS(ctx, "Waiting for neutrino backend to sync "+
+		"before starting block notifier")
+
+	logEvery := int(chainSyncLogInterval / chainSyncPollInterval)
+
+	return waitUntilCurrent(
+		b.neutrinoCS.IsCurrent, b.quit, chainSyncPollInterval,
+		func(attempt int) {
+			if logEvery > 0 && attempt%logEvery == 0 {
+				b.logger(ctx).InfoS(ctx, "Still waiting for "+
+					"neutrino backend to sync before "+
+					"starting block notifier")
+			}
+		},
+	)
+}
+
+// waitUntilCurrent blocks until isCurrent reports true or quit is
+// closed, polling at pollInterval. onWait, if non-nil, is invoked after
+// each poll that still reports not-current with a 1-based attempt
+// counter, letting callers throttle progress logging without this
+// helper needing a clock. Returns true if the backend became current,
+// false if quit fired first. Split out from Start so the wait logic is
+// unit-testable without a live neutrino service.
+func waitUntilCurrent(isCurrent func() bool, quit <-chan struct{},
+	pollInterval time.Duration, onWait func(attempt int)) bool {
+
+	if isCurrent() {
+		return true
+	}
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for attempt := 1; ; attempt++ {
+		select {
+		case <-quit:
+			return false
+
+		case <-ticker.C:
+			if isCurrent() {
+				return true
+			}
+
+			if onWait != nil {
+				onWait(attempt)
+			}
+		}
+	}
 }
 
 // Stop shuts down the chain backend by stopping the notifier, fee
@@ -184,18 +331,42 @@ func (b *ChainBackend) Stop() error {
 			"Stopping neutrino chain backend",
 		)
 
+		// Unblock a Start() still waiting for the backend to become
+		// current so shutdown doesn't hang on the sync wait. Close
+		// before taking startStopMu so any Start() that has not yet
+		// entered its critical section observes the closed quit once
+		// it acquires the lock and skips starting the subsystems.
+		close(b.quit)
+
+		// Read notifierStarted under startStopMu so we serialize
+		// against a Start() that is mid-transition: either it has
+		// already finished (we observe true and tear down) or it has
+		// not yet started the subsystems (it will observe the closed
+		// quit above and bail). startOnce/stopOnce guarantee each body
+		// runs once, so no further Start() can start them after this.
+		b.startStopMu.Lock()
+		notifierStarted := b.notifierStarted
+		b.startStopMu.Unlock()
+
 		var errs []error
 
-		if err := b.notifier.Stop(); err != nil {
-			errs = append(
-				errs, fmt.Errorf("stop notifier: %w", err),
-			)
-		}
+		// Only tear down the notifier and fee estimator if Start()
+		// actually started them; a shutdown during the pre-notifier
+		// sync wait leaves them unstarted.
+		if notifierStarted {
+			if err := b.notifier.Stop(); err != nil {
+				errs = append(
+					errs, fmt.Errorf("stop notifier: %w",
+						err),
+				)
+			}
 
-		if err := b.feeEstimator.Stop(); err != nil {
-			errs = append(
-				errs, fmt.Errorf("stop fee estimator: %w", err),
-			)
+			if err := b.feeEstimator.Stop(); err != nil {
+				errs = append(
+					errs, fmt.Errorf("stop fee "+
+						"estimator: %w", err),
+				)
+			}
 		}
 
 		if err := b.hintDB.Close(); err != nil {

--- a/btcwbackend/chain_backend_test.go
+++ b/btcwbackend/chain_backend_test.go
@@ -3,6 +3,7 @@ package btcwbackend
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/wire/v2"
@@ -89,3 +90,72 @@ func TestSubmitPackageRejectsPackageErrors(t *testing.T) {
 }
 
 var _ chainbackends.PackageSubmitter = (*stubPackageSubmitter)(nil)
+
+// TestWaitUntilCurrentAlreadyCurrent verifies that when the backend is
+// already current, the wait returns immediately without consuming a
+// tick — the steady-state (restart against an already-synced neutrino)
+// must not be delayed.
+func TestWaitUntilCurrentAlreadyCurrent(t *testing.T) {
+	t.Parallel()
+
+	var onWaitCalls int
+
+	// A huge poll interval guarantees the return came from the
+	// fast-path check, not from a ticker firing.
+	got := waitUntilCurrent(
+		func() bool { return true }, make(chan struct{}), time.Hour,
+		func(int) { onWaitCalls++ },
+	)
+
+	require.True(t, got)
+	require.Zero(t, onWaitCalls)
+}
+
+// TestWaitUntilCurrentBecomesCurrent verifies that the wait keeps
+// polling until the backend reports current, then returns true. This is
+// the fix's core behavior: the notifier is held back until neutrino has
+// synced. It also asserts onWait fires once per not-current poll so
+// progress logging is driven correctly.
+func TestWaitUntilCurrentBecomesCurrent(t *testing.T) {
+	t.Parallel()
+
+	// Report not-current on the first two checks (the pre-loop check
+	// and the first tick), then current on the third.
+	var calls int
+	isCurrent := func() bool {
+		calls++
+
+		return calls >= 3
+	}
+
+	var onWaitCalls int
+	got := waitUntilCurrent(
+		isCurrent, make(chan struct{}), time.Millisecond,
+		func(int) { onWaitCalls++ },
+	)
+
+	require.True(t, got)
+	require.Equal(t, 3, calls)
+
+	// onWait fires only after the single not-current tick (the
+	// pre-loop check and the final current tick don't invoke it).
+	require.Equal(t, 1, onWaitCalls)
+}
+
+// TestWaitUntilCurrentStopsOnQuit verifies that closing quit unblocks a
+// wait for a backend that never becomes current, so daemon shutdown
+// during the initial sync wait cannot hang.
+func TestWaitUntilCurrentStopsOnQuit(t *testing.T) {
+	t.Parallel()
+
+	quit := make(chan struct{})
+	close(quit)
+
+	// Never current + a huge poll interval: the only way this returns
+	// is via the closed quit channel.
+	got := waitUntilCurrent(
+		func() bool { return false }, quit, time.Hour, nil,
+	)
+
+	require.False(t, got)
+}

--- a/darepod/server.go
+++ b/darepod/server.go
@@ -1962,22 +1962,24 @@ func (s *Server) startBtcwallet(ctx context.Context, seed []byte,
 		return fmt.Errorf("create btcwallet: %w", err)
 	}
 
+	// Register the wallet and its chain backend before the blocking
+	// Start() below. Start() now waits for neutrino to become current
+	// before starting the block notifier, which can take tens of
+	// seconds on a fresh daemon. If the daemon shuts down during that
+	// wait, the deferred cleanup must be able to reach
+	// ChainBackend.Stop() — the only thing that unblocks the wait — so
+	// s.chainBackend has to be set first. w.ChainBackend() is valid
+	// before Start(), and w.Start() starts this same backend internally.
+	s.btcwWallet = fn.Some(w)
+	if s.chainBackend == nil {
+		s.chainBackend = w.ChainBackend()
+	}
+
 	if err := w.Start(); err != nil {
 		return fmt.Errorf("start btcwallet: %w", err)
 	}
 
-	s.btcwWallet = fn.Some(w)
 	s.refreshProofKeyBackend()
-
-	// Initialize the chain backend if it was deferred at startup
-	// because the wallet was not yet available.
-	if s.chainBackend == nil {
-		s.chainBackend = w.ChainBackend()
-
-		if err := s.chainBackend.Start(); err != nil {
-			return fmt.Errorf("start chain backend: %w", err)
-		}
-	}
 
 	// Refresh the RPC clients once the wallet is available so the
 	// indexer client picks up the wallet-backed identity key and


### PR DESCRIPTION
## What went wrong

On a neutrino-backed (`btcwallet`) daemon, a boarding UTXO
(`54c5fff2…:1`, 50k sat on signet) was funded but never detected by the
client: it never registered a boarding intent, never joined a round,
and the operator was never contacted. This is **not** a server-side
rejection — the client never got far enough to ask.

Root cause is a **start-ordering bug** between the neutrino block
notifier and neutrino's chain sync.

The neutrino block notifier snapshots its block-epoch rescan **start
height** from the chain service's best block **exactly once**, inside
`notifier.Start()`
([`lnd/chainntnfs/neutrinonotify/neutrino.go`](https://github.com/lightningnetwork/lnd/blob/master/chainntnfs/neutrinonotify/neutrino.go), `startNotifier()`):

```go
// We'll start the auto-rescan from this point...
startingPoint, err := n.p2pNode.BestBlock()
...
rescanOptions := []neutrino.RescanOption{ neutrino.StartBlock(startingPoint), ... }
n.chainView = neutrino.NewRescan(...); _ = n.chainView.Start()
```

`ChainBackend.Start()` was invoked from `Wallet.Start()` as soon as the
wallet unlocked. On a fresh daemon that happens seconds after startup —
**before** neutrino has synced its block/filter headers — so
`BestBlock()` returns a height far behind the tip. The notifier is then
anchored there and can only reach the tip via a slow, block-by-block
**historical rescan**, rather than tracking the tip.

### Timeline from the incident log (`#936`)

| time (07-10) | event |
|---|---|
| `11:59:35` | chain backend + notifier started, **while neutrino is still header-syncing** → rescan anchored ≈ height **2000** |
| `12:00:02` | neutrino: "Fully caught up with cfheaders at height **312608**" |
| `12:00:15` | boarding wallet actor started (daemon marked ready on `btcwallet.IsSynced`) |
| `12:01:16` | last chain tip the wallet ever processed: height **2730** (the notifier's historical rescan, still crawling) |
| `12:01:22` | boarding address imported → notifier's historical rescan **stalls and never advances again** |
| … 3 days … | neutrino downloads filters to **313020**, but the wallet's tip stays frozen at **2730**; the deposit (near the real tip) is never seen |

Because the wallet's chain tip froze, every tip-tick short-circuited,
`ListUnspent` never ran again, and the boarding UTXO was never detected.

A key subtlety that hid the problem: daemon readiness is gated on
`btcwallet.IsSynced()` (true at ~312608), but boarding-UTXO detection
depends on the **notifier's** block-epoch feed, which is decoupled and
was stuck at 2730. So the daemon reported "ready" and accepted boarding
while its block feed was ~310k blocks behind.

> Note on calibration: the premature-start → historical-rescan chain is
> proven from the log + the upstream snapshot code above. The
> *permanent stall* of that historical rescan is observed in this
> incident and is most likely a neutrino robustness weakness under
> concurrent query load (the notifier's historical rescan racing
> btcwallet's recovery rescan + the address import on one shared
> `ChainService`). This PR removes the fragile condition rather than
> depending on the exact stall mechanism.

## The fix

Gate `notifier.Start()` on the neutrino backend reporting `IsCurrent()`
before starting it, so the notifier's one-shot start-height snapshot is
the real chain tip instead of a stale mid-sync height. With the notifier
anchored at the tip, a boarding deposit confirming near the tip is seen
within a block and boarding proceeds normally — and the fragile
historical-rescan-during-sync window never exists.

`IsCurrent()` gates on **block headers == filter headers and synced**
(`blockManager.IsFullySynced`), which completes in tens of seconds and
does **not** wait for the slow filter-body download — so the wait is
short in practice. It polls on a named-const cadence (1s) with a 30s
progress heartbeat (matching the daemon's existing neutrino sync-wait
logging), and is unblocked by `Stop()` so shutdown during the wait
cannot hang. `Stop()` only tears down the notifier/fee estimator if
`Start()` actually started them.

## Testing

New unit tests in `btcwbackend/chain_backend_test.go` cover the wait
logic (extracted as `waitUntilCurrent` so it is testable without a live
neutrino service):

- `TestWaitUntilCurrentAlreadyCurrent` — already-synced returns
  immediately (no delay on the common restart-against-synced case).
- `TestWaitUntilCurrentBecomesCurrent` — holds back until the backend
  reports current, then proceeds (the core fix behavior).
- `TestWaitUntilCurrentStopsOnQuit` — a never-syncing backend unblocks
  on shutdown (no hang).

`make lint-changed-local` → 0 issues; `make commitmsg-lint` → OK.

Fixes #936.
