### PR TITLE
sdk/swaps: fail in-swap fast when funding OOR is rejected

### DIFF
--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -771,6 +771,13 @@ func (s *paySession) waitForFundedVHTLC(ctx context.Context) error {
 			return err
 		}
 
+		// A funding OOR the operator rejected means no vHTLC was
+		// created; fail fast with the reason rather than waiting for
+		// funding that can never land.
+		if err := s.checkFundingRejected(ctx); err != nil {
+			return err
+		}
+
 		preimage, spentVHTLC, err :=
 			s.client.waitForInSwapClaimObservation(
 				ctx, s.cfg.PaymentHash, s.vhtlcPkScript,
@@ -965,11 +972,105 @@ func (s *paySession) markVHTLCFundedFromLocalMetadata(
 	})
 }
 
+// fundingOORFailed reports whether the daemon's durable record for the funding
+// OOR has reached a terminal failed state, meaning the operator rejected the
+// funding transfer and the vHTLC was never created. The pay flow proceeds on
+// local funding metadata even when the authoritative indexer rejects the
+// vHTLC lookup (expected for same-Ark receivers whose script is not registered
+// under this principal), so the indexer cannot distinguish "funded but not
+// queryable" from "funding rejected". The daemon's OOR session status does
+// make that distinction, and this is the signal we use to fail fast instead of
+// polling for a claim that can never arrive. A missing session, a still-pending
+// session, or a transient query error are all treated as "not known failed" so
+// a hiccup never fails an otherwise-healthy swap. The operator's failure reason
+// is returned for surfacing when known.
+func (s *paySession) fundingOORFailed(ctx context.Context) (bool, string) {
+	if s.fundingSessionID == "" {
+		return false, ""
+	}
+
+	session, err := s.client.daemon.GetOORSession(ctx, s.fundingSessionID)
+	if err != nil {
+		s.client.log.DebugS(
+			ctx,
+			"Unable to query in-swap funding OOR session",
+			slog.String("err", err.Error()),
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+			slog.String("funding_session_id", s.fundingSessionID),
+		)
+
+		return false, ""
+	}
+	if session == nil || session.GetStatus() !=
+		daemonrpc.OORSessionStatus_OOR_SESSION_STATUS_FAILED {
+		return false, ""
+	}
+
+	return true, session.GetFailureReason()
+}
+
+// checkFundingRejected returns a terminal failure error when the funding OOR
+// was rejected by the operator, and nil otherwise. It is the shared guard used
+// at the top of every pay-side wait loop so a rejected funding OOR fails the
+// swap fast (with the operator's reason) instead of polling for a claim or
+// refund of a vHTLC that was never created.
+func (s *paySession) checkFundingRejected(ctx context.Context) error {
+	if failed, reason := s.fundingOORFailed(ctx); failed {
+		return s.failFundingRejected(ctx, reason)
+	}
+
+	return nil
+}
+
+// failFundingRejected terminally fails a pay session whose funding OOR the
+// operator rejected. Because the funding transfer rolled back, the funding
+// input has been released to the wallet and no vHTLC exists: there is nothing
+// to claim or refund. We cancel any armed refund recovery (armed optimistically
+// from local funding metadata) and fail the swap with the operator's reason,
+// rather than polling until the invoice deadline and then attempting to refund
+// a non-existent vHTLC.
+func (s *paySession) failFundingRejected(ctx context.Context,
+	reason string) error {
+
+	s.client.log.WarnS(ctx, "In-swap funding OOR rejected by operator",
+		nil,
+		btclog.Hex("hash", s.cfg.PaymentHash[:]),
+		slog.String("funding_session_id", s.fundingSessionID),
+		slog.String("reason", reason),
+	)
+
+	if err := cancelVHTLCRecovery(
+		ctx, s.client.daemon, s.refundRecoveryID,
+		recoveryReasonFundingRejected, "",
+	); err != nil {
+		return newRetryableActionError(err)
+	}
+
+	// Unlike the markExpired/needsIntervention/failTerminal helpers, the
+	// PayStateFailed transition is intentionally left to the caller: this
+	// returns from a wait-loop action, so the FSM fail handler classifies
+	// the failureError and drives the terminal transition (mirroring how
+	// the other wait-loop returns work).
+	msg := "in-swap funding OOR rejected by operator"
+	if reason != "" {
+		msg = fmt.Sprintf("%s: %s", msg, reason)
+	}
+
+	return newFailureError(msg, nil)
+}
+
 // waitForClaimPreimage waits until the server claim spend is indexed and the
 // finalized checkpoint exposes the expected hashlock preimage.
 func (s *paySession) waitForClaimPreimage(ctx context.Context) error {
 	for {
 		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		// If the funding OOR was rejected by the operator the vHTLC was
+		// never created, so fail fast with the reason instead of
+		// polling for a claim that can never arrive.
+		if err := s.checkFundingRejected(ctx); err != nil {
 			return err
 		}
 

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -713,6 +713,103 @@ func TestPayViaLightningRequiresClaimPreimage(t *testing.T) {
 	require.Nil(t, result)
 }
 
+// TestPaySessionFailsFastWhenFundingOORRejected asserts that when the operator
+// rejects the vHTLC funding OOR (so no vHTLC is ever created), the pay session
+// fails fast with the operator's reason instead of polling for a claim that can
+// never arrive and then attempting to refund a non-existent vHTLC. This is the
+// in-Ark wedge from darepo-client#938: the funding OOR fails asynchronously
+// after submit, and the indexer's "script not registered for principal"
+// rejection cannot by itself distinguish a rejected funding OOR from a
+// funded-but-not-locally-queryable one — the daemon's OOR session status can.
+func TestPaySessionFailsFastWhenFundingOORRejected(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:  preimage.Hash(),
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
+			ServerPubkey: serverPriv.PubKey(),
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime:                       144,
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			// Generous expiry so the swap can only terminate via
+			// the funding-rejection guard, never via a deadline.
+			Expiry: time.Now().Add(time.Hour),
+		},
+	}
+
+	// Model the operator rejecting the funding OOR: the daemon's durable
+	// OOR session reports FAILED with a reason, while the vHTLC stays
+	// unqueryable via the indexer ("script not registered for principal"),
+	// exactly as a same-Ark receiver's vHTLC appears to the payer.
+	const rejectReason = "recipient script not registered for principal"
+	daemonConn := &testDaemonConn{
+		identityKey:   clientPriv.PubKey(),
+		operatorKey:   operatorPriv.PubKey(),
+		blockHeight:   100,
+		sendSessionID: "funding-session",
+		sendOutpoint:  "funding:0",
+		liveLookupErr: errors.New(
+			"indexer query failed: script not registered for " +
+				"principal",
+		),
+		oorSession: &daemonrpc.OORSessionInfo{
+			Status: daemonrpc.
+				OORSessionStatus_OOR_SESSION_STATUS_FAILED,
+			FailureReason: rejectReason,
+		},
+	}
+
+	store := newTestSwapStore(t)
+	client := configureTestPayClient(
+		NewSwapClientWithStore(serverConn, daemonConn, nil, nil, store),
+	)
+	client.waitPollInterval = time.Millisecond
+	client.refundLocktimeBuffer = 0
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	_, err = session.Wait(t.Context())
+
+	// The swap fails fast with the operator's rejection reason surfaced,
+	// rather than expiring or refunding.
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errSwapExpired)
+	require.NotErrorIs(t, err, ErrSwapRefunded)
+	require.Contains(t, err.Error(), "funding OOR rejected")
+	require.Contains(t, err.Error(), rejectReason)
+
+	// The session ends in the terminal failed state.
+	require.Equal(t, PayStateFailed, session.State())
+
+	// Fail-fast: it never attempted to refund a non-existent vHTLC...
+	require.Zero(t, daemonConn.sendCustomCalls)
+
+	// ...and it cancelled the refund recovery that was armed optimistically
+	// from the local funding metadata.
+	require.GreaterOrEqual(t, daemonConn.cancelCalls, 1)
+}
+
 // TestPaySessionRefundsFundedVHTLCOnTimeout asserts a pay session
 // automatically sweeps its funded vHTLC back through the sender refund path
 // once the server claim deadline elapses.

--- a/sdk/swaps/recovery.go
+++ b/sdk/swaps/recovery.go
@@ -95,6 +95,11 @@ const (
 	// claim spend is already indexed.
 	recoveryReasonClaimIndexed = "cooperative claim indexed"
 
+	// recoveryReasonFundingRejected explains cancellation of a pay-side
+	// refund recovery when the funding OOR was rejected by the operator, so
+	// the vHTLC never existed and there is nothing to recover.
+	recoveryReasonFundingRejected = "funding OOR rejected by operator"
+
 	// DefaultRecoveryMaxFeeRateSatPerKW caps SDK-armed vHTLC exit spends at
 	// 100 sat/vbyte. Operators can still clamp lower through the daemon's
 	// unroll fee cap; this value prevents an armed recovery row from being


### PR DESCRIPTION
## What this fixes

Partial fix for #938 (in-Ark swap wedge). This is the **client-side
robustness half**: it converts an opaque, eventual two-sided wedge into a
fast, clearly-attributed failure. It does **not** change why the operator
rejects a same-Ark funding OOR — that's the separate server/completion track
(see "Scope" below).

## Root cause (payer side)

The pay (in-swap) flow marks the vHTLC "funded from local OOR metadata" as
soon as the funding OOR is **submitted**, not when the operator **accepts**
it, and it deliberately tolerates the authoritative indexer rejecting the
vHTLC lookup with `script not registered for principal` (expected for a
same-Ark receiver whose script isn't registered under this principal).

But the funding OOR can be **rejected asynchronously after submit**: the OOR
session transitions to `Failed` and the funding input is released back to the
wallet, so **no vHTLC is ever created**. In the #938 logs:

```
13:46:53.292  DRPD  OOR transfer submitted
13:46:53.295  SWAP  "In-swap vHTLC funded from local OOR metadata"   ← optimistic
13:46:53.352  SWAP  Pay refund recovery armed
13:46:53.712  OORC  OutboxErrorEvent → state Failed                  ← operator rejected
13:46:53.714  VTXO  57cc7e4d…:0 SpendReleased → LiveState            ← input returned, unspent
```

The payer never noticed the `Failed`: it polled for a claim preimage that
could never arrive until the invoice deadline, then tried to refund a vHTLC
that doesn't exist. The receiver waited for the same non-existent vHTLC. Both
sides wedged. The indexer's "unregistered" rejection can't distinguish a
*rejected* funding OOR from a *funded-but-unqueryable* one — but the daemon's
durable **OOR session status** can.

## The change

In the funding/claim wait loops (`waitForFundedVHTLC`, `waitForClaimPreimage`),
poll the funding OOR session via `GetOORSession` — the same signal the
cooperative-refund path already uses. If it reports **`FAILED`**:
- cancel the optimistically-armed refund recovery, and
- fail the swap with the operator's `FailureReason` surfaced,

instead of polling to the deadline and attempting to refund a non-existent
vHTLC.

Only an explicit `FAILED` status fails the swap. A missing session, a still-
`PENDING` session, or a transient query error all preserve the existing
behaviour, so a healthy swap is never affected (and the intentional
"proceed on local metadata when the indexer rejects" path for in-Ark is
untouched).

**Funds are not at risk**: a rejected funding OOR releases the input back to
the wallet (unspent), so there is nothing to refund — this only turns an
eventual, opaque wedge into a fast, attributed failure.

## Test

`TestPaySessionFailsFastWhenFundingOORRejected` models the exact scenario:
funding OOR submitted, indexer rejects the vHTLC lookup as unregistered, and
the daemon's OOR session reports `FAILED`. It asserts the swap ends
`PayStateFailed` with the operator's reason surfaced, **never attempts a
refund** (`sendCustomCalls == 0`), and cancels the armed recovery.

Verified this is a genuine repro: with the guard disabled the test **hangs
and times out** (the wedge); with the guard it fails in ~0.1s.

`make lint-changed-local` → 0 issues; `make commitmsg-lint` → OK; full
`sdk/swaps` suite green.

## Scope (explicitly out)

- **Why the operator rejects a same-Ark funding OOR** — opaque client-side
  (the `OutboxErrorEvent` carries no reason; `GetOORSession` does, which this
  PR now surfaces). Root-causing that needs the operator/`arkd` side and a
  reproduction that captures the rejection reason. Tracked as the #938
  server/completion track.
- The **receiver** path already terminates at the invoice deadline (it is
  deadline-bounded, not an infinite hang) and has no signal for the payer's
  funding failure, so it is unchanged here.

Refs #938.
