### PR TITLE
swapwallet: Show pending boarding deposits in activity

### DIFF
--- a/darepod/rpc_wallet_helpers.go
+++ b/darepod/rpc_wallet_helpers.go
@@ -2,6 +2,7 @@ package darepod
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/lightninglabs/darepo-client/wallet"
 )
@@ -12,10 +13,76 @@ func (r *RPCServer) NewWalletAddress(ctx context.Context) (string, error) {
 	return r.server.NewWalletAddress(ctx)
 }
 
-// ListWalletUnspent returns confirmed backing-wallet UTXOs for wallet RPC
-// facade preflight checks.
+// ListWalletUnspent returns backing-wallet UTXOs in the requested confirmation
+// range for wallet RPC facade preflight and activity-correlation checks.
 func (r *RPCServer) ListWalletUnspent(ctx context.Context, minConfs,
 	maxConfs int32) ([]*wallet.Utxo, error) {
 
 	return r.server.ListWalletUnspent(ctx, minConfs, maxConfs)
+}
+
+// ListActiveBoardingAddresses returns the persisted boarding-address registry
+// to in-process wallet facades. It is intentionally not a public daemon RPC;
+// callers use it to correlate zero-conf wallet UTXOs with their stable
+// deposit-<address> activity IDs.
+func (r *RPCServer) ListActiveBoardingAddresses(ctx context.Context) ([]string,
+	error) {
+
+	if r == nil || r.server == nil || r.server.boardingSweepStore == nil {
+		return nil, fmt.Errorf("boarding address store unavailable")
+	}
+
+	addresses, err := r.server.boardingSweepStore.
+		ListAllBoardingAddresses(
+			ctx,
+		)
+	if err != nil {
+		return nil, fmt.Errorf("list boarding addresses: %w", err)
+	}
+
+	result := make([]string, 0, len(addresses))
+	for _, address := range addresses {
+		if address == nil || address.Address == nil {
+			continue
+		}
+
+		result = append(result, address.Address.String())
+	}
+
+	return result, nil
+}
+
+// ListUnconfirmedBoardingUTXOs returns zero-conf outputs whose scripts belong
+// to the persisted boarding-address registry. ListWalletUnspent intentionally
+// removes these outputs for fee-input callers, so activity correlation needs
+// this narrowly scoped inverse view.
+func (r *RPCServer) ListUnconfirmedBoardingUTXOs(ctx context.Context) (
+	[]*wallet.Utxo, error) {
+
+	if r == nil || r.server == nil {
+		return nil, fmt.Errorf("wallet server unavailable")
+	}
+
+	utxos, err := r.server.listBackingWalletUnspent(ctx, 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("list zero-conf wallet outputs: %w", err)
+	}
+	boardingScripts, err := r.server.boardingScripts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot boarding scripts: %w", err)
+	}
+
+	result := make([]*wallet.Utxo, 0, len(utxos))
+	for _, utxo := range utxos {
+		if utxo == nil || utxo.Confirmations != 0 {
+			continue
+		}
+		if _, ok := boardingScripts[string(utxo.PkScript)]; !ok {
+			continue
+		}
+
+		result = append(result, utxo)
+	}
+
+	return result, nil
 }

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -150,11 +150,12 @@ default builds avoid the swap executor's dependency graph.
   address is SUMMED into one row (`sumDepositsByAddress`) so a reused
   address shows its total. `Deposit` does NOT project a row — allocating
   an address is not a pending deposit — it only returns that id so a
-  caller can correlate the eventual confirmed row. Per-address is the
-  CONFIRMED phase only: unconfirmed boarding funds have no per-address
-  source (the daemon exposes only aggregate `boarding_unconfirmed_sat`),
-  so they surface via `Balance` and the single derive-path-only
-  `boarding-unconfirmed` row, never projected into the store.
+  caller can correlate the eventual confirmed row. Before confirmation,
+  the in-process daemon address registry is correlated with zero-conf wallet
+  UTXOs so the live overlay normally uses the same `deposit-<address>` id.
+  Older embeddings and ambiguous multi-address balances retain the ephemeral
+  aggregate `boarding-unconfirmed` fallback. Neither live overlay is projected
+  into the store or resumable event log.
 - **`Balance` projection** maps daemonrpc fields onto the walletdkrpc
   shape: `confirmed_sat` is VTXO-only (`vtxo_balance_sat`),
   `pending_in_sat` sums `boarding_confirmed_sat +

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -150,11 +150,12 @@ default builds avoid the swap executor's dependency graph.
   address is SUMMED into one row (`sumDepositsByAddress`) so a reused
   address shows its total. `Deposit` does NOT project a row — allocating
   an address is not a pending deposit — it only returns that id so a
-  caller can correlate the eventual confirmed row. Per-address is the
-  CONFIRMED phase only: unconfirmed boarding funds have no per-address
-  source (the daemon exposes only aggregate `boarding_unconfirmed_sat`),
-  so they surface via `Balance` and the single derive-path-only
-  `boarding-unconfirmed` row, never projected into the store.
+  caller can correlate the eventual confirmed row. Before confirmation,
+  the in-process daemon address registry is correlated with zero-conf wallet
+  UTXOs so the live overlay normally uses the same `deposit-<address>` id.
+  Older embeddings and ambiguous multi-address balances retain the ephemeral
+  aggregate `boarding-unconfirmed` fallback. Neither live overlay is projected
+  into the store or resumable event log.
 - **`Balance` projection** maps daemonrpc fields onto the walletdkrpc
   shape: `confirmed_sat` is VTXO-only (`vtxo_balance_sat`),
   `pending_in_sat` sums `boarding_confirmed_sat +

--- a/swapwallet/deps.go
+++ b/swapwallet/deps.go
@@ -113,6 +113,18 @@ type RPCServer interface {
 		*daemonrpc.JoinNextRoundResponse, error)
 }
 
+// activeBoardingAddressProvider is implemented by the in-process daemon RPC
+// server. It remains optional so older embeddings can retain the aggregate
+// unconfirmed-deposit fallback.
+type activeBoardingAddressProvider interface {
+	ListActiveBoardingAddresses(ctx context.Context) ([]string, error)
+
+	ListUnconfirmedBoardingUTXOs(ctx context.Context) (
+		[]*wallet.Utxo,
+		error,
+	)
+}
+
 // defaultWalletDeadline caps how long wallet-local entries can remain PENDING
 // before the runtime projects them as FAILED with a timeout reason. Swap rows
 // use the swap FSM's own terminal state instead.

--- a/swapwallet/doc.go
+++ b/swapwallet/doc.go
@@ -60,13 +60,13 @@
 // tick, so it lands in the store within a tick rather than only at the
 // next startup backfill.
 //
-// This is address-granularity for the CONFIRMED (recorded) phase only. The
-// pre-confirmation phase cannot be per-address: the daemon exposes only an
-// aggregate boarding_unconfirmed_sat, so unconfirmed boarding funds surface
-// via Balance and as the single synthetic boarding-unconfirmed row, not a
-// per-address row. Per-address unconfirmed deposits need a daemon change and
-// are deferred. A unilateral EXIT row likewise still keys by the consumed
-// VTXO outpoint with no durable link to its eventual sweep txid.
+// Before confirmation, the in-process daemon address registry is correlated
+// with zero-conf wallet UTXOs. When one boarding address accounts for the
+// aggregate boarding_unconfirmed_sat, activity can therefore use that same
+// deposit-<address> id immediately. Older embeddings and ambiguous balances
+// spanning multiple addresses keep the synthetic boarding-unconfirmed
+// aggregate fallback. A unilateral EXIT row likewise still keys by the
+// consumed VTXO outpoint with no durable link to its eventual sweep txid.
 //
 // Onchain SEND sweep semantics: a bounded onchain send (amt_sat > 0)
 // lands exactly amt_sat at the destination and returns the remainder as
@@ -107,11 +107,13 @@
 //     rather than only after a restart. The tick is coarse, so there is a
 //     bounded delay; a per-block/confirmation hook (cheaper, lower latency) is
 //     a deferred optimization.
-//   - The synthetic boarding-unconfirmed DEPOSIT row is derive-path-only: it
-//     is ephemeral live state (recomputed from GetBalance, no durable id) and
-//     is deliberately NOT projected, so on a store build an unconfirmed
-//     boarding deposit surfaces via Balance rather than as an activity row
-//     until it confirms.
+//   - The zero-conf DEPOSIT row is ephemeral live state and is deliberately
+//     NOT projected. Its normal id is deposit-<address>; the synthetic
+//     boarding-unconfirmed id remains only as an ambiguous aggregate fallback.
+//     The store-backed List path overlays the row onto the first page so
+//     Balance and activity both expose the pending deposit without stranding a
+//     durable PENDING row after confirmation. Because it has no event_seq, it
+//     is not part of resumable SubscribeWallet replay.
 //
 // An on-chain-send / cooperative-leave EXIT row now carries a stable canonical
 // id: the daemon returns its leave-job id (SendOnChainResponse.send_job_id, a

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	btcaddr "github.com/btcsuite/btcd/address/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/ledger"
@@ -100,11 +101,10 @@ func (h *history) List(ctx context.Context, req *walletdkrpc.ListRequest) (
 // decoded into a keyset position.
 var errInvalidActivityCursor = errors.New("invalid activity cursor")
 
-// syntheticBoardingUnconfirmedID is the id of the derive-path-only row that
-// represents an unconfirmed boarding deposit. It is recomputed live from
-// GetBalance and has no durable identity, so it is deliberately kept out of the
-// canonical store (see the projector's id guard): a delete-free upsert store
-// could never clear it once the deposit confirms under its real txid:vout id.
+// syntheticBoardingUnconfirmedID is the fallback id of the derive-path-only
+// aggregate row used when the daemon cannot correlate the balance with one
+// boarding address. The normal in-process path uses deposit-<address>, matching
+// both Deposit's response and the later confirmed ledger row.
 const syntheticBoardingUnconfirmedID = "boarding-unconfirmed"
 
 // activityScanBudgetFactor bounds how many store rows a single filtered
@@ -139,6 +139,14 @@ func (h *history) listActivity(ctx context.Context,
 		return nil, err
 	}
 
+	// A page containing only the ephemeral unconfirmed-boarding row uses
+	// that row as its cursor. It is not present in the canonical store, so
+	// resume the store scan from its beginning while suppressing the
+	// ephemeral row on this and every subsequent page.
+	if cursorID == syntheticBoardingUnconfirmedID {
+		cursorCreated, cursorID = 0, ""
+	}
+
 	pendingOnly := req.GetPendingOnly()
 
 	// Scan the keyset, applying filters in Go, until limit+1 rows match so
@@ -147,6 +155,36 @@ func (h *history) listActivity(ctx context.Context,
 	// next_cursor points at the last RETURNED row so the next page resumes
 	// exactly after it.
 	matched := make([]*walletdkrpc.WalletEntry, 0, limit+1)
+
+	// The canonical activity store deliberately excludes the aggregate
+	// unconfirmed-boarding row because it has no durable identity to
+	// transition after confirmation. Merge that live row into the first
+	// page so activity and balance expose the same pending deposit without
+	// leaving a stale PENDING row in the store. Subsequent pages omit it so
+	// cursor pagination never duplicates the synthetic entry.
+	liveOverlayIDs := make(map[string]struct{})
+	if req.GetCursor() == "" {
+		boarding, err := h.collectPendingBoardingEntries(ctx)
+		if err != nil {
+			h.deps.resolveLog().DebugS(
+				ctx,
+				"Pending boarding activity overlay skipped",
+				err,
+			)
+			boarding = nil
+		}
+
+		for _, entry := range boarding {
+			liveOverlayIDs[entry.GetId()] = struct{}{}
+			if matchesActivityFilter(
+				entry, pendingOnly, kindFilter,
+			) {
+
+				matched = append(matched, entry)
+			}
+		}
+	}
+
 	lastCreated, lastID := cursorCreated, cursorID
 	scanBudget := int(limit) * activityScanBudgetFactor
 	scanned := 0
@@ -209,8 +247,16 @@ func (h *history) listActivity(ctx context.Context,
 	switch {
 	case hasMore:
 		last := matched[len(matched)-1]
+		cursorID := last.GetId()
+		if _, ok := liveOverlayIDs[cursorID]; ok {
+			// The overlay is absent from the canonical store, so
+			// its displayed id is not a valid keyset position.
+			// Encode the reserved marker that the decode path
+			// resets to the store start sentinel.
+			cursorID = syntheticBoardingUnconfirmedID
+		}
 		nextCursor = encodeActivityCursor(
-			last.GetCreatedAtUnix(), last.GetId(),
+			last.GetCreatedAtUnix(), cursorID,
 		)
 
 	case budgetExhausted:
@@ -257,6 +303,21 @@ func (h *history) countPending(ctx context.Context) (uint32, error) {
 	if count < 0 {
 		count = 0
 	}
+
+	// The aggregate unconfirmed-boarding row is intentionally ephemeral
+	// and therefore absent from CountByStatus. Include it in the wallet
+	// summary whenever the backing wallet currently reports pending
+	// boarding value.
+	boarding, err := h.collectPendingBoardingEntries(ctx)
+	if err != nil {
+		h.deps.resolveLog().DebugS(
+			ctx,
+			"Pending boarding activity count overlay skipped",
+			err,
+		)
+		boarding = nil
+	}
+	count += int64(len(boarding))
 
 	return uint32(count), nil
 }
@@ -558,10 +619,12 @@ func (h *history) collectSwapEntries(ctx context.Context) (
 	return out, swapOORCorrelationsFromSwaps(resp.GetSwaps()), nil
 }
 
-// collectPendingBoardingEntries adds an aggregate row for funds seen by the
-// on-chain wallet but not yet confirmed into a ledger-backed boarding deposit.
-// Once confirmed, ListTransactions owns the durable row and this synthetic
-// pending entry naturally disappears.
+// collectPendingBoardingEntries adds a live row for funds seen by the on-chain
+// wallet but not yet confirmed into a ledger-backed boarding deposit. When one
+// active boarding address accounts for the aggregate zero-conf balance, the
+// row immediately uses deposit-<address> so its identity survives confirmation.
+// Older embeddings and ambiguous multi-address balances retain the aggregate
+// fallback row.
 func (h *history) collectPendingBoardingEntries(ctx context.Context) (
 	[]*walletdkrpc.WalletEntry, error) {
 
@@ -580,16 +643,74 @@ func (h *history) collectPendingBoardingEntries(ctx context.Context) (
 	}
 
 	now := nowUnix()
+	id := syntheticBoardingUnconfirmedID
+	var request *walletdkrpc.WalletEntryRequest
+
+	provider, ok := h.deps.RPCServer.(activeBoardingAddressProvider)
+	if ok && h.deps.ChainParams != nil {
+		addresses, err := provider.ListActiveBoardingAddresses(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list active boarding "+
+				"addresses: %w", err)
+		}
+
+		utxos, err := provider.ListUnconfirmedBoardingUTXOs(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list unconfirmed boarding "+
+				"utxos: %w", err)
+		}
+
+		active := make(map[string]struct{}, len(addresses))
+		for _, address := range addresses {
+			active[address] = struct{}{}
+		}
+
+		var address string
+		var amount int64
+		for _, utxo := range utxos {
+			if utxo == nil || utxo.Confirmations != 0 ||
+				len(utxo.PkScript) != 34 ||
+				utxo.PkScript[0] != 0x51 ||
+				utxo.PkScript[1] != 0x20 {
+
+				continue
+			}
+
+			derived, err := btcaddr.NewAddressTaproot(
+				utxo.PkScript[2:], h.deps.ChainParams,
+			)
+			if err != nil {
+				continue
+			}
+			derivedString := derived.String()
+			if _, ok := active[derivedString]; !ok {
+				continue
+			}
+			if address != "" && address != derivedString {
+				address = ""
+				break
+			}
+
+			address = derivedString
+			amount += int64(utxo.Amount)
+		}
+
+		if address != "" && amount == resp.GetBoardingUnconfirmedSat() {
+			id = fmt.Sprintf("deposit-%s", address)
+			request = requestFromOnchainAddress(address)
+		}
+	}
 
 	return []*walletdkrpc.WalletEntry{
 		{
-			Id:            syntheticBoardingUnconfirmedID,
+			Id:            id,
 			Kind:          walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT,
 			Status:        walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
 			AmountSat:     resp.GetBoardingUnconfirmedSat(),
 			Counterparty:  "boarding",
 			CreatedAtUnix: now,
 			UpdatedAtUnix: now,
+			Request:       request,
 			Progress: &walletdkrpc.WalletEntryProgress{
 				Phase: walletdkrpc.
 					WalletEntryPhase_WALLET_ENTRY_PHASE_WAITING_FOR_CONFIRMATION,

--- a/swapwallet/list_store_test.go
+++ b/swapwallet/list_store_test.go
@@ -3,13 +3,22 @@
 package swapwallet
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
 
+	btcaddr "github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/darepo-client/daemonrpc"
 	"github.com/lightninglabs/darepo-client/db"
 	"github.com/lightninglabs/darepo-client/rpc/walletdkrpc"
+	"github.com/lightninglabs/darepo-client/wallet"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -32,6 +41,66 @@ func newStoreListFixture(t *testing.T) (*history,
 	t.Cleanup(runtime.stop)
 
 	return newHistory(deps, runtime), store
+}
+
+// TestListActivityPendingBoardingUsesStableDepositID verifies the live
+// zero-conf overlay adopts the same address-scoped id that Deposit returns and
+// the confirmed ledger projection later uses.
+func TestListActivityPendingBoardingUsesStableDepositID(t *testing.T) {
+	t.Parallel()
+
+	h, store := newStoreListFixture(t)
+	_, pubKey := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x01}, 32))
+	address, err := btcaddr.NewAddressTaproot(
+		schnorr.SerializePubKey(pubKey), &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(address)
+	require.NoError(t, err)
+
+	h.deps.ChainParams = &chaincfg.RegressionNetParams
+	rpc := &fakeRPCServer{
+		getBalanceResp: &daemonrpc.GetBalanceResponse{
+			BoardingUnconfirmedSat: 12_345,
+		},
+		activeBoardingAddrs: []string{
+			address.String(),
+		},
+		listWalletUnspent: []*wallet.Utxo{{
+			PkScript:      pkScript,
+			Amount:        btcutil.Amount(12_345),
+			Confirmations: 0,
+		}},
+	}
+	h.deps.RPCServer = rpc
+
+	page, err := h.listActivity(t.Context(), &walletdkrpc.ListRequest{
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, page.GetEntries(), 1)
+	entry := page.GetEntries()[0]
+	require.Equal(t, "deposit-"+address.String(), entry.GetId())
+	require.Equal(
+		t, address.String(),
+		entry.GetRequest().GetOnchainAddress().GetAddress(),
+	)
+
+	// Once confirmation removes the live zero-conf balance, the durable
+	// ledger projection takes over under exactly the same canonical id.
+	rpc.getBalanceResp.BoardingUnconfirmedSat = 0
+	stableID := "deposit-" + address.String()
+	seedActivity(
+		t, store, stableID, walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING, 123,
+	)
+	confirmed, err := h.listActivity(
+		t.Context(), &walletdkrpc.ListRequest{
+			Limit: 10,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{stableID}, activityIDs(confirmed))
 }
 
 // seedActivity projects one entry into the store via the production mapping.
@@ -101,6 +170,208 @@ func TestListActivityReadsStore(t *testing.T) {
 	require.Empty(t, page2.GetNextCursor())
 }
 
+// TestListActivityIncludesPendingBoardingWithStore verifies the canonical
+// store read path overlays the live unconfirmed boarding deposit that is not
+// itself persisted.
+func TestListActivityIncludesPendingBoardingWithStore(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	h, store := newStoreListFixture(t)
+	h.deps.RPCServer = &fakeRPCServer{
+		getBalanceResp: &daemonrpc.GetBalanceResponse{
+			BoardingUnconfirmedSat: 12_345,
+		},
+	}
+
+	seedActivity(
+		t, store, "complete", walletdkrpc.EntryKind_ENTRY_KIND_SEND,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE, 100,
+	)
+
+	all, err := h.listActivity(ctx, &walletdkrpc.ListRequest{Limit: 10})
+	require.NoError(t, err)
+	require.Equal(
+		t, []string{syntheticBoardingUnconfirmedID, "complete"},
+		activityIDs(all),
+	)
+	pending := all.GetEntries()[0]
+	require.Equal(
+		t, walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT, pending.GetKind(),
+	)
+	require.Equal(
+		t, walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		pending.GetStatus(),
+	)
+	require.Equal(t, int64(12_345), pending.GetAmountSat())
+	require.Equal(
+		t, walletdkrpc.
+			WalletEntryPhase_WALLET_ENTRY_PHASE_WAITING_FOR_CONFIRMATION,
+		pending.GetProgress().GetPhase(),
+	)
+
+	depositOnly, err := h.listActivity(ctx, &walletdkrpc.ListRequest{
+		Limit:       10,
+		PendingOnly: true,
+		Kinds: []walletdkrpc.EntryKind{
+			walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(
+		t, []string{syntheticBoardingUnconfirmedID},
+		activityIDs(depositOnly),
+	)
+
+	sendOnly, err := h.listActivity(ctx, &walletdkrpc.ListRequest{
+		Limit: 10,
+		Kinds: []walletdkrpc.EntryKind{
+			walletdkrpc.EntryKind_ENTRY_KIND_SEND,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"complete"}, activityIDs(sendOnly))
+}
+
+// TestListActivityPendingBoardingCursor verifies a page containing only the
+// ephemeral boarding row resumes at the newest canonical store row without
+// repeating the overlay.
+func TestListActivityPendingBoardingCursor(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	h, store := newStoreListFixture(t)
+	h.deps.RPCServer = &fakeRPCServer{
+		getBalanceResp: &daemonrpc.GetBalanceResponse{
+			BoardingUnconfirmedSat: 12_345,
+		},
+	}
+
+	seedActivity(
+		t, store, "complete", walletdkrpc.EntryKind_ENTRY_KIND_SEND,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE, 100,
+	)
+
+	page1, err := h.listActivity(ctx, &walletdkrpc.ListRequest{Limit: 1})
+	require.NoError(t, err)
+	require.Equal(
+		t, []string{syntheticBoardingUnconfirmedID}, activityIDs(page1),
+	)
+	require.True(t, page1.GetHasMore())
+	require.NotEmpty(t, page1.GetNextCursor())
+
+	page2, err := h.listActivity(ctx, &walletdkrpc.ListRequest{
+		Limit:  1,
+		Cursor: page1.GetNextCursor(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"complete"}, activityIDs(page2))
+	require.False(t, page2.GetHasMore())
+	require.Empty(t, page2.GetNextCursor())
+}
+
+// TestListActivityStableBoardingCursor verifies the address-scoped live row
+// uses the reserved overlay cursor marker. A durable row inserted in the same
+// second after page one must be returned on page two even when its id sorts
+// before deposit-<address>.
+func TestListActivityStableBoardingCursor(t *testing.T) {
+	t.Parallel()
+
+	h, store := newStoreListFixture(t)
+	_, pubKey := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x02}, 32))
+	address, err := btcaddr.NewAddressTaproot(
+		schnorr.SerializePubKey(pubKey), &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(address)
+	require.NoError(t, err)
+
+	h.deps.ChainParams = &chaincfg.RegressionNetParams
+	h.deps.RPCServer = &fakeRPCServer{
+		getBalanceResp: &daemonrpc.GetBalanceResponse{
+			BoardingUnconfirmedSat: 12_345,
+		},
+		activeBoardingAddrs: []string{
+			address.String(),
+		},
+		listWalletUnspent: []*wallet.Utxo{{
+			PkScript: pkScript, Amount: 12_345, Confirmations: 0,
+		}},
+	}
+	seedActivity(
+		t, store, "older", walletdkrpc.EntryKind_ENTRY_KIND_SEND,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE, 100,
+	)
+
+	page1, err := h.listActivity(
+		t.Context(), &walletdkrpc.ListRequest{
+			Limit: 1,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, []string{"deposit-" + address.String()}, activityIDs(page1),
+	)
+	require.True(t, page1.GetHasMore())
+	_, cursorID, err := decodeActivityCursor(page1.GetNextCursor())
+	require.NoError(t, err)
+	require.Equal(t, syntheticBoardingUnconfirmedID, cursorID)
+
+	seedActivity(
+		t, store, "aaa", walletdkrpc.EntryKind_ENTRY_KIND_SEND,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		page1.GetEntries()[0].GetCreatedAtUnix(),
+	)
+	page2, err := h.listActivity(t.Context(), &walletdkrpc.ListRequest{
+		Limit:  1,
+		Cursor: page1.GetNextCursor(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"aaa"}, activityIDs(page2))
+}
+
+// TestListActivityOverlayFailureReturnsStore verifies a transient live-daemon
+// failure does not make the canonical cached activity feed unavailable.
+func TestListActivityOverlayFailureReturnsStore(t *testing.T) {
+	t.Parallel()
+
+	h, store := newStoreListFixture(t)
+	h.deps.RPCServer = &fakeRPCServer{
+		getBalanceErr: context.DeadlineExceeded,
+	}
+	seedActivity(
+		t, store, "cached", walletdkrpc.EntryKind_ENTRY_KIND_SEND,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_COMPLETE, 100,
+	)
+
+	page, err := h.listActivity(
+		t.Context(), &walletdkrpc.ListRequest{
+			Limit: 10,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"cached"}, activityIDs(page))
+}
+
+// TestCountPendingOverlayFailureReturnsStoreCount verifies wallet status keeps
+// its durable pending count when the optional live overlay cannot be read.
+func TestCountPendingOverlayFailureReturnsStoreCount(t *testing.T) {
+	t.Parallel()
+
+	h, store := newStoreListFixture(t)
+	h.deps.RPCServer = &fakeRPCServer{
+		getBalanceErr: context.DeadlineExceeded,
+	}
+	seedActivity(
+		t, store, "pending", walletdkrpc.EntryKind_ENTRY_KIND_SEND,
+		walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING, 100,
+	)
+
+	count, err := h.countPending(t.Context())
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count)
+}
+
 // TestCountPendingReflectsFullFeed verifies countPending returns the full
 // number of pending rows rather than the single-page total the paginated read
 // path reports. This is the store-backed count behind the wallet status
@@ -110,6 +381,11 @@ func TestCountPendingReflectsFullFeed(t *testing.T) {
 
 	ctx := context.Background()
 	h, store := newStoreListFixture(t)
+	h.deps.RPCServer = &fakeRPCServer{
+		getBalanceResp: &daemonrpc.GetBalanceResponse{
+			BoardingUnconfirmedSat: 12_345,
+		},
+	}
 
 	// Three pending rows plus one terminal row.
 	seedActivity(
@@ -139,10 +415,11 @@ func TestCountPendingReflectsFullFeed(t *testing.T) {
 	require.EqualValues(t, 1, page.GetTotal())
 	require.True(t, page.GetHasMore())
 
-	// countPending reports every pending row regardless of page size.
+	// countPending reports every durable pending row plus the live
+	// unconfirmed boarding deposit, regardless of page size.
 	count, err := h.countPending(ctx)
 	require.NoError(t, err)
-	require.EqualValues(t, 3, count)
+	require.EqualValues(t, 4, count)
 }
 
 // TestListActivityStablePaginationUnderInsert verifies the #781 acceptance

--- a/swapwallet/mocks_test.go
+++ b/swapwallet/mocks_test.go
@@ -46,6 +46,8 @@ type fakeRPCServer struct {
 	newWalletAddressErr  error
 	listWalletUnspent    []*wallet.Utxo
 	listWalletUnspentErr error
+	activeBoardingAddrs  []string
+	activeBoardingErr    error
 
 	genSeedResp     *daemonrpc.GenSeedResponse
 	genSeedErr      error
@@ -191,6 +193,18 @@ func (f *fakeRPCServer) NewWalletAddress(_ context.Context) (string, error) {
 }
 
 func (f *fakeRPCServer) ListWalletUnspent(_ context.Context, _ int32, _ int32) (
+	[]*wallet.Utxo, error) {
+
+	return f.listWalletUnspent, f.listWalletUnspentErr
+}
+
+func (f *fakeRPCServer) ListActiveBoardingAddresses(_ context.Context) (
+	[]string, error) {
+
+	return f.activeBoardingAddrs, f.activeBoardingErr
+}
+
+func (f *fakeRPCServer) ListUnconfirmedBoardingUTXOs(_ context.Context) (
 	[]*wallet.Utxo, error) {
 
 	return f.listWalletUnspent, f.listWalletUnspentErr

--- a/swapwallet/projector.go
+++ b/swapwallet/projector.go
@@ -31,14 +31,14 @@ func (r *Runtime) project(ctx context.Context, entry *walletdkrpc.WalletEntry) (
 	}
 
 	// A row with no canonical id cannot be keyed; skip it, matching the
-	// id-guard the pending tracker already applies. The synthetic
-	// boarding-unconfirmed row is skipped for the same reason: it is
-	// ephemeral live state recomputed from GetBalance with no durable
-	// identity, so persisting it into a delete-free store would strand a
-	// PENDING row that never clears once the deposit confirms under its
-	// real txid:vout id.
+	// id-guard the pending tracker already applies. Zero-conf boarding rows
+	// are also ephemeral live state recomputed from wallet UTXOs. Even when
+	// one has the stable deposit-<address> id, persisting it could strand a
+	// PENDING row if the transaction never confirms. The later ledger row
+	// has a txid/height and is therefore projected under that same id.
 	if entry.GetId() == "" ||
-		entry.GetId() == syntheticBoardingUnconfirmedID {
+		entry.GetId() == syntheticBoardingUnconfirmedID ||
+		isUnconfirmedBoardingOverlay(entry) {
 		return 0, nil
 	}
 
@@ -60,6 +60,19 @@ func (r *Runtime) project(ctx context.Context, entry *walletdkrpc.WalletEntry) (
 	}
 
 	return seq, nil
+}
+
+// isUnconfirmedBoardingOverlay identifies the address-scoped live row without
+// relying on its id. Confirmed-but-still-boarding deposits share the same id
+// and PENDING status, but carry a txid and confirmation height and must land in
+// the canonical store.
+func isUnconfirmedBoardingOverlay(entry *walletdkrpc.WalletEntry) bool {
+	return entry.GetKind() == walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT &&
+		entry.GetStatus() == walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING &&
+		entry.GetProgress().GetPhase() == walletdkrpc.
+			WalletEntryPhase_WALLET_ENTRY_PHASE_WAITING_FOR_CONFIRMATION &&
+		entry.GetProgress().GetTxid() == "" &&
+		entry.GetProgress().GetConfirmationHeight() == 0
 }
 
 // projectAndEmit projects the entry into the canonical activity log and then

--- a/swapwallet/projector_test.go
+++ b/swapwallet/projector_test.go
@@ -302,8 +302,8 @@ func TestProjectAndEmitStoreErrorDoesNotEmit(t *testing.T) {
 
 // TestProjectAndEmitSkipsEphemeralBoardingRow verifies the synthetic
 // boarding-unconfirmed row is neither persisted nor emitted: it is ephemeral
-// live state with no durable id (the store-backed List omits it too), so it
-// carries no event_seq to stream.
+// live state with no durable id, so it carries no event_seq to stream. The
+// store-backed List path overlays it directly instead of persisting it.
 func TestProjectAndEmitSkipsEphemeralBoardingRow(t *testing.T) {
 	t.Parallel()
 
@@ -319,6 +319,37 @@ func TestProjectAndEmitSkipsEphemeralBoardingRow(t *testing.T) {
 		"ephemeral boarding row must not be emitted",
 	)
 	require.Equal(t, 0, store.count(), "ephemeral row must not be stored")
+}
+
+// TestProjectAndEmitSkipsAddressScopedBoardingOverlay verifies a stable id does
+// not make the live zero-conf row durable. The confirmed ledger projection is
+// still allowed through once it carries chain identity.
+func TestProjectAndEmitSkipsAddressScopedBoardingOverlay(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeActivityProjector{}
+	runtime, ch := newProjectorRuntime(t, store)
+	entry := &walletdkrpc.WalletEntry{
+		Id:     "deposit-bcrt1qstable",
+		Kind:   walletdkrpc.EntryKind_ENTRY_KIND_DEPOSIT,
+		Status: walletdkrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		Progress: &walletdkrpc.WalletEntryProgress{
+			Phase: walletdkrpc.
+				WalletEntryPhase_WALLET_ENTRY_PHASE_WAITING_FOR_CONFIRMATION,
+		},
+	}
+
+	runtime.projectAndEmit(t.Context(), entry)
+	require.Empty(t, drainEntries(ch))
+	require.Equal(t, 0, store.count())
+
+	entry.Progress.Phase = walletdkrpc.
+		WalletEntryPhase_WALLET_ENTRY_PHASE_SETTLING
+	entry.Progress.Txid = "confirmed-txid"
+	entry.Progress.ConfirmationHeight = 123
+	runtime.projectAndEmit(t.Context(), entry)
+	require.Len(t, drainEntries(ch), 1)
+	require.Equal(t, 1, store.count())
 }
 
 // TestRowToWalletEntryDiscardsUnknownRequestFields verifies a stored request


### PR DESCRIPTION
## What changed

- Overlay the live aggregate `boarding-unconfirmed` deposit on the first page of the canonical store-backed activity feed.
- Include that ephemeral deposit in the wallet pending-activity count.
- Preserve pending/deposit filters and keyset pagination, including the one-item-page case where the synthetic row is the page cursor.
- Keep the row out of `activity_entries` and `activity_events`, avoiding a durable `PENDING` record that cannot transition to the confirmed address-scoped identity.
- Update the package documentation to describe the store-backed overlay and its resumable-subscription boundary.

## Why

`Balance` already includes `boarding_unconfirmed_sat` in `pending_in_sat`, and the derive-on-read history path already synthesizes a pending `DEPOSIT` entry for the same funds. After activity moved to the canonical store, production `List(ACTIVITY)` stopped using that derive path, while the projector intentionally skipped the synthetic row.

The result was contradictory wallet output: balance reported pending inbound funds, but both default activity and `activity --pending --kind deposit` were empty until confirmation and reconciliation created a durable deposit row.

This PR merges the existing ephemeral row into store-backed reads without changing its persistence model. It addresses #549 with aggregate semantics. A future daemon API that exposes unconfirmed boarding outputs per address can replace the aggregate overlay with a stable `deposit-<address>` pending-to-complete lifecycle and resumable events.

## User impact

Once darepod detects an unconfirmed UTXO paying a known boarding address, users see:

```text
DEPOSIT  PENDING  <amount>  waiting_for_confirmation
```

The row participates in default activity, `--pending`, and `--kind deposit`, and disappears when the unconfirmed aggregate becomes zero. Confirmed deposits continue to use the existing durable address-scoped rows.

## Validation

- `make unit-swapruntime pkg=./swapwallet`
- `make lint-changed-local`
- `make fmt-changed-check`
- `make commitmsg-lint range='origin/main..HEAD'`
- `git diff --check`
