### PR TITLE
db: close PostgreSQL test fixture pools

### DIFF
--- a/db/postgres_fixture.go
+++ b/db/postgres_fixture.go
@@ -32,7 +32,6 @@ var testPgFixtureSem = make(chan struct{}, testPgFixtureParallelism)
 // TestPgFixture is a test fixture that starts a Postgres 15 instance in a
 // docker container.
 type TestPgFixture struct {
-	db       *sql.DB
 	pool     *dockertest.Pool
 	resource *dockertest.Resource
 	host     string
@@ -104,19 +103,19 @@ func NewTestPgFixture(t testing.TB, expiry time.Duration,
 	// might not be ready to accept connections yet.
 	pool.MaxWait = 120 * time.Second
 
-	var testDB *sql.DB
-	err = pool.Retry(func() error {
-		testDB, err = sql.Open("postgres", databaseURL)
-		if err != nil {
-			return err
-		}
+	// Keep one readiness pool for the full retry window. Opening a new pool
+	// on every attempt leaves the replaced pools and their connection
+	// opener goroutines alive for the rest of the test process.
+	testDB, err := sql.Open("postgres", databaseURL)
+	require.NoError(t, err)
+	defer func() {
+		_ = testDB.Close()
+	}()
 
-		return testDB.Ping()
-	})
+	err = pool.Retry(testDB.Ping)
 	require.NoError(t, err, "Could not connect to docker")
 
 	// Now fill in the rest of the fixture.
-	fixture.db = testDB
 	fixture.pool = pool
 	fixture.resource = resource
 

--- a/db/postgres_test_helpers.go
+++ b/db/postgres_test_helpers.go
@@ -30,11 +30,19 @@ func NewTestPostgresDB(t testing.TB) *PostgresStore {
 	log := btclog.Disabled
 
 	sqlFixture := NewTestPgFixture(t, DefaultPostgresFixtureLifetime, true)
+
+	// Cleanups run in reverse order. Register the fixture first so the
+	// store pool registered below is closed before its container is
+	// removed.
+	t.Cleanup(func() {
+		sqlFixture.TearDown(t)
+	})
+
 	store, err := NewPostgresStore(sqlFixture.GetConfig(), log)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		sqlFixture.TearDown(t)
+		require.NoError(t, store.DB.Close())
 	})
 
 	return store
@@ -54,6 +62,14 @@ func NewTestPostgresDBWithVersion(t testing.TB, version uint) *PostgresStore {
 	log := btclog.Disabled
 
 	sqlFixture := NewTestPgFixture(t, DefaultPostgresFixtureLifetime, true)
+
+	// Cleanups run in reverse order. Register the fixture first so the
+	// store pool registered below is closed before its container is
+	// removed.
+	t.Cleanup(func() {
+		sqlFixture.TearDown(t)
+	})
+
 	storeCfg := sqlFixture.GetConfig()
 	storeCfg.SkipMigrations = true
 
@@ -64,7 +80,7 @@ func NewTestPostgresDBWithVersion(t testing.TB, version uint) *PostgresStore {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		sqlFixture.TearDown(t)
+		require.NoError(t, store.DB.Close())
 	})
 
 	return store

--- a/db/postgres_test_helpers_test.go
+++ b/db/postgres_test_helpers_test.go
@@ -1,0 +1,23 @@
+//go:build test_postgres
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewTestPostgresDBClosesStore verifies that the common fixture helper
+// closes its connection pool before tearing down the Postgres container.
+func TestNewTestPostgresDBClosesStore(t *testing.T) {
+	var store *PostgresStore
+
+	t.Run("fixture lifetime", func(t *testing.T) {
+		store = NewTestPostgresDB(t)
+		require.NoError(t, store.DB.Ping())
+	})
+
+	require.NotNil(t, store)
+	require.EqualError(t, store.DB.Ping(), "sql: database is closed")
+}


### PR DESCRIPTION
Addresses the PostgreSQL fixture half of #841.

## Root cause

The common PostgreSQL unit-test helpers removed each Docker container without closing the migrated store's `sql.DB` pool. Fixture readiness also opened a new `sql.DB` on every retry and retained the replaced pools. Across the parallel `db` suite, stale pools and their connection-management goroutines accumulated after their containers disappeared, destabilizing later fixture startup and migration. The resulting tests then failed against databases missing varying tables with `SQLSTATE 42P01`.

## Fix

- Reuse one readiness pool for a fixture's full retry window and close it when readiness completes.
- Register migrated store cleanup after container cleanup so Go's LIFO cleanup order closes the pool before removing the container.
- Apply the same lifecycle to latest-version and explicit-version migration helpers.
- Add `TestNewTestPostgresDBClosesStore` to verify the common helper closes its pool at the end of its fixture lifetime.

## Validation

- `go test -tags='dev test_postgres nolog' ./db -run '^$'`
- `make unit tags=test_sqlite pkg=db timeout=5m`
- `make lint-changed-local`
- `make fmt-changed-check`
- `make tidy-module-check`
- `make commitmsg-lint range=origin/main..HEAD`

The PostgreSQL runtime test could not be executed on the local arktest Docker host because its Docker data volume is full (`initdb: could not create directory ... No space left on device`). Existing arktest containers and data were left untouched; CI is expected to run the PostgreSQL lifecycle test.