### PR TITLE
multi: retry in-Ark funding when input not yet spendable on operator (#938)

### DIFF
--- a/oor/errors.go
+++ b/oor/errors.go
@@ -93,6 +93,42 @@ func (e *ErrUserBalanceExceeded) Is(target error) bool {
 	return ok
 }
 
+// ErrInputNotSpendable is the client-facing typed error returned when the
+// operator rejects an OOR submit because one of the input VTXOs was not in a
+// spendable state on the operator (neither live nor in-flight) at validation
+// time.
+//
+// Like ErrUserBalanceExceeded and unlike ErrOutputPolicyViolation, this is NOT
+// terminal for the same input set: the most common cause is that the input's
+// round commitment transaction has not yet reached the operator's confirmation
+// target even though the client already observed the confirmation, so the same
+// submit succeeds once the operator's chain view catches up. Callers should
+// wait and retry rather than restructuring the transfer.
+//
+// ServerBestHeight carries the operator's best block height at rejection time
+// (0 if the operator did not populate it). A caller that knows the height at
+// which its input confirmed can treat ServerBestHeight below that height as
+// proof the operator is merely behind on chain sync, making the retry provably
+// safe rather than a blind reattempt.
+type ErrInputNotSpendable struct {
+	Reason           string
+	ServerBestHeight uint32
+}
+
+// Error returns a human-readable description of the rejection cause.
+func (e *ErrInputNotSpendable) Error() string {
+	return fmt.Sprintf("oor input not spendable on operator "+
+		"(server_best_height=%d): %s", e.ServerBestHeight, e.Reason)
+}
+
+// Is reports whether target is also an *ErrInputNotSpendable, supporting the
+// standard errors.Is comparison without forcing callers to compare reasons.
+func (e *ErrInputNotSpendable) Is(target error) bool {
+	_, ok := target.(*ErrInputNotSpendable)
+
+	return ok
+}
+
 // ErrInvalidAncestry is the typed error returned by the receive-side
 // ancestry cross-check when an operator-supplied IncomingVTXOMetadata
 // fails one of the structural invariants required to bind the produced
@@ -150,6 +186,12 @@ func ClassifySubmitError(err error) error {
 		case oorpb.OORRejectCode_OOR_REJECT_USER_BALANCE:
 			return &ErrUserBalanceExceeded{
 				Reason: rejected.Reason,
+			}
+
+		case oorpb.OORRejectCode_OOR_REJECT_INPUT_NOT_SPENDABLE:
+			return &ErrInputNotSpendable{
+				Reason:           rejected.Reason,
+				ServerBestHeight: rejected.ServerBestHeight,
 			}
 
 		case oorpb.OORRejectCode_OOR_REJECT_UNSPECIFIED:

--- a/oor/errors.go
+++ b/oor/errors.go
@@ -106,10 +106,12 @@ func (e *ErrUserBalanceExceeded) Is(target error) bool {
 // wait and retry rather than restructuring the transfer.
 //
 // ServerBestHeight carries the operator's best block height at rejection time
-// (0 if the operator did not populate it). A caller that knows the height at
-// which its input confirmed can treat ServerBestHeight below that height as
-// proof the operator is merely behind on chain sync, making the retry provably
-// safe rather than a blind reattempt.
+// (0 if the operator did not populate it). It is a diagnostic hint only —
+// surfaced in the failure reason and logs so an operator being behind on chain
+// sync (its best height below the input's confirmation height) is easy to
+// confirm. The retry decision itself does not consult it: the operator emits
+// this typed code only for the transient pending-input case, so routing on the
+// code alone is already correct.
 type ErrInputNotSpendable struct {
 	Reason           string
 	ServerBestHeight uint32

--- a/oor/errors_test.go
+++ b/oor/errors_test.go
@@ -16,6 +16,10 @@ import (
 func TestClassifySubmitError(t *testing.T) {
 	t.Parallel()
 
+	// Short alias for the long enum, so the deeply-nested subtest that uses
+	// it stays within the 80-column limit.
+	notSpendableCode := oorpb.OORRejectCode_OOR_REJECT_INPUT_NOT_SPENDABLE
+
 	t.Run("user balance maps to typed error", func(t *testing.T) {
 		t.Parallel()
 
@@ -55,6 +59,33 @@ func TestClassifySubmitError(t *testing.T) {
 		})
 		require.ErrorIs(t, got, &ErrOutputPolicyViolation{})
 	})
+
+	t.Run("input not spendable maps and carries height",
+		func(t *testing.T) {
+			t.Parallel()
+
+			got := ClassifySubmitError(&oorpb.SubmitRejectedError{
+				Code:             notSpendableCode,
+				Reason:           "vtxo x not spendable",
+				ServerBestHeight: 313034,
+			})
+			require.ErrorIs(t, got, &ErrInputNotSpendable{})
+
+			// It must not collapse into the terminal output-policy
+			// error: input-not-spendable is transient and
+			// retryable.
+			require.NotErrorIs(t, got, &ErrOutputPolicyViolation{})
+
+			// The operator's best height rides through so the
+			// caller can check whether the operator is behind on
+			// chain sync.
+			var notSpendable *ErrInputNotSpendable
+			require.True(t, errors.As(got, &notSpendable))
+			require.Equal(
+				t, uint32(313034),
+				notSpendable.ServerBestHeight,
+			)
+		})
 
 	t.Run("wrapped rejection is unwrapped", func(t *testing.T) {
 		t.Parallel()

--- a/rpc/oorpb/oorwire.pb.go
+++ b/rpc/oorpb/oorwire.pb.go
@@ -52,6 +52,16 @@ const (
 	// spends or refreshes down), so a custodial sender may hold the value
 	// and retry later rather than restructuring the outputs.
 	OORRejectCode_OOR_REJECT_USER_BALANCE OORRejectCode = 3
+	// OOR_REJECT_INPUT_NOT_SPENDABLE indicates one of the submit's input
+	// VTXOs was not in a spendable state on the operator (neither live nor
+	// in-flight) at validation time — most commonly because the input's
+	// round commitment transaction has not yet reached the operator's
+	// confirmation target, even though the client already observed the
+	// confirmation. The submit was not locked. Unlike OOR_REJECT_OUTPUT_POLICY
+	// this is transient: retrying the same shape succeeds once the operator's
+	// chain view catches up, so the client should wait (see server_best_height)
+	// and resubmit rather than restructuring the transfer.
+	OORRejectCode_OOR_REJECT_INPUT_NOT_SPENDABLE OORRejectCode = 4
 )
 
 // Enum value maps for OORRejectCode.
@@ -61,12 +71,14 @@ var (
 		1: "OOR_REJECT_LINEAGE_TOO_LARGE",
 		2: "OOR_REJECT_OUTPUT_POLICY",
 		3: "OOR_REJECT_USER_BALANCE",
+		4: "OOR_REJECT_INPUT_NOT_SPENDABLE",
 	}
 	OORRejectCode_value = map[string]int32{
-		"OOR_REJECT_UNSPECIFIED":       0,
-		"OOR_REJECT_LINEAGE_TOO_LARGE": 1,
-		"OOR_REJECT_OUTPUT_POLICY":     2,
-		"OOR_REJECT_USER_BALANCE":      3,
+		"OOR_REJECT_UNSPECIFIED":         0,
+		"OOR_REJECT_LINEAGE_TOO_LARGE":   1,
+		"OOR_REJECT_OUTPUT_POLICY":       2,
+		"OOR_REJECT_USER_BALANCE":        3,
+		"OOR_REJECT_INPUT_NOT_SPENDABLE": 4,
 	}
 )
 
@@ -395,9 +407,18 @@ type SubmitPackageRejection struct {
 	// the durable EventRouter dispatch path has no way to identify which
 	// session to fail, and the ingress dispatcher would stall the cursor on
 	// the rejected envelope.
-	SessionId     []byte `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	SessionId []byte `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	// server_best_height is the operator's current best block height at the
+	// time of the rejection, or 0 when the operator did not populate it. It
+	// is a diagnostic hint for transient rejections (notably
+	// OOR_REJECT_INPUT_NOT_SPENDABLE): a client that observed its input
+	// confirm at height H can compare against this value — if
+	// server_best_height < H the operator simply has not caught up to the
+	// input's confirmation yet, so a retry is guaranteed safe rather than
+	// masking a genuine problem.
+	ServerBestHeight uint32 `protobuf:"varint,4,opt,name=server_best_height,json=serverBestHeight,proto3" json:"server_best_height,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *SubmitPackageRejection) Reset() {
@@ -449,6 +470,13 @@ func (x *SubmitPackageRejection) GetSessionId() []byte {
 		return x.SessionId
 	}
 	return nil
+}
+
+func (x *SubmitPackageRejection) GetServerBestHeight() uint32 {
+	if x != nil {
+		return x.ServerBestHeight
+	}
+	return 0
 }
 
 // SubmitPackageResponse carries server submit-phase results. Exactly one of
@@ -727,12 +755,13 @@ const file_oorwire_proto_rawDesc = "" +
 	"\x10checkpoint_psbts\x18\x02 \x03(\fR\x0fcheckpointPsbts\x12L\n" +
 	"\x13signing_descriptors\x18\x03 \x03(\v2\x1b.oorpb.OORSigningDescriptorR\x12signingDescriptors\x12F\n" +
 	"\x11recipient_outputs\x18\x04 \x03(\v2\x19.oorpb.OORRecipientOutputR\x10recipientOutputs\x12!\n" +
-	"\fflow_version\x18\x05 \x01(\rR\vflowVersion\"y\n" +
+	"\fflow_version\x18\x05 \x01(\rR\vflowVersion\"\xa7\x01\n" +
 	"\x16SubmitPackageRejection\x12(\n" +
 	"\x04code\x18\x01 \x01(\x0e2\x14.oorpb.OORRejectCodeR\x04code\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x03 \x01(\fR\tsessionId\"\x99\x01\n" +
+	"session_id\x18\x03 \x01(\fR\tsessionId\x12,\n" +
+	"\x12server_best_height\x18\x04 \x01(\rR\x10serverBestHeight\"\x99\x01\n" +
 	"\x15SubmitPackageResponse\x127\n" +
 	"\asuccess\x18\x01 \x01(\v2\x1b.oorpb.SubmitPackageSuccessH\x00R\asuccess\x12=\n" +
 	"\trejection\x18\x02 \x01(\v2\x1d.oorpb.SubmitPackageRejectionH\x00R\trejectionB\b\n" +
@@ -748,12 +777,13 @@ const file_oorwire_proto_rawDesc = "" +
 	"\x16final_checkpoint_psbts\x18\x02 \x03(\fR\x14finalCheckpointPsbts\"8\n" +
 	"\x17FinalizePackageResponse\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x01 \x01(\fR\tsessionId*\x88\x01\n" +
+	"session_id\x18\x01 \x01(\fR\tsessionId*\xac\x01\n" +
 	"\rOORRejectCode\x12\x1a\n" +
 	"\x16OOR_REJECT_UNSPECIFIED\x10\x00\x12 \n" +
 	"\x1cOOR_REJECT_LINEAGE_TOO_LARGE\x10\x01\x12\x1c\n" +
 	"\x18OOR_REJECT_OUTPUT_POLICY\x10\x02\x12\x1b\n" +
-	"\x17OOR_REJECT_USER_BALANCE\x10\x032\xb1\x01\n" +
+	"\x17OOR_REJECT_USER_BALANCE\x10\x03\x12\"\n" +
+	"\x1eOOR_REJECT_INPUT_NOT_SPENDABLE\x10\x042\xb1\x01\n" +
 	"\x11OORMailboxService\x12J\n" +
 	"\rSubmitPackage\x12\x1b.oorpb.SubmitPackageRequest\x1a\x1c.oorpb.SubmitPackageResponse\x12P\n" +
 	"\x0fFinalizePackage\x12\x1d.oorpb.FinalizePackageRequest\x1a\x1e.oorpb.FinalizePackageResponseB/Z-github.com/lightninglabs/wavelength/rpc/oorpbb\x06proto3"

--- a/rpc/oorpb/oorwire.pb.go
+++ b/rpc/oorpb/oorwire.pb.go
@@ -409,13 +409,12 @@ type SubmitPackageRejection struct {
 	// the rejected envelope.
 	SessionId []byte `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	// server_best_height is the operator's current best block height at the
-	// time of the rejection, or 0 when the operator did not populate it. It
-	// is a diagnostic hint for transient rejections (notably
-	// OOR_REJECT_INPUT_NOT_SPENDABLE): a client that observed its input
-	// confirm at height H can compare against this value — if
-	// server_best_height < H the operator simply has not caught up to the
-	// input's confirmation yet, so a retry is guaranteed safe rather than
-	// masking a genuine problem.
+	// time of the rejection, or 0 when the operator did not populate it. It is
+	// a diagnostic hint for transient rejections (notably
+	// OOR_REJECT_INPUT_NOT_SPENDABLE): a value below the input's confirmation
+	// height confirms the operator is simply behind on chain sync rather than
+	// rejecting for a genuine reason. It is informational only — clients route
+	// their retry on the typed code, not on this value.
 	ServerBestHeight uint32 `protobuf:"varint,4,opt,name=server_best_height,json=serverBestHeight,proto3" json:"server_best_height,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache

--- a/rpc/oorpb/oorwire.proto
+++ b/rpc/oorpb/oorwire.proto
@@ -113,6 +113,17 @@ enum OORRejectCode {
     // spends or refreshes down), so a custodial sender may hold the value
     // and retry later rather than restructuring the outputs.
     OOR_REJECT_USER_BALANCE = 3;
+
+    // OOR_REJECT_INPUT_NOT_SPENDABLE indicates one of the submit's input
+    // VTXOs was not in a spendable state on the operator (neither live nor
+    // in-flight) at validation time — most commonly because the input's
+    // round commitment transaction has not yet reached the operator's
+    // confirmation target, even though the client already observed the
+    // confirmation. The submit was not locked. Unlike OOR_REJECT_OUTPUT_POLICY
+    // this is transient: retrying the same shape succeeds once the operator's
+    // chain view catches up, so the client should wait (see server_best_height)
+    // and resubmit rather than restructuring the transfer.
+    OOR_REJECT_INPUT_NOT_SPENDABLE = 4;
 }
 
 // SubmitPackageRejection carries a typed rejection of an OOR submit.
@@ -130,6 +141,16 @@ message SubmitPackageRejection {
     // session to fail, and the ingress dispatcher would stall the cursor on
     // the rejected envelope.
     bytes session_id = 3;
+
+    // server_best_height is the operator's current best block height at the
+    // time of the rejection, or 0 when the operator did not populate it. It
+    // is a diagnostic hint for transient rejections (notably
+    // OOR_REJECT_INPUT_NOT_SPENDABLE): a client that observed its input
+    // confirm at height H can compare against this value — if
+    // server_best_height < H the operator simply has not caught up to the
+    // input's confirmation yet, so a retry is guaranteed safe rather than
+    // masking a genuine problem.
+    uint32 server_best_height = 4;
 }
 
 // SubmitPackageResponse carries server submit-phase results. Exactly one of

--- a/rpc/oorpb/oorwire.proto
+++ b/rpc/oorpb/oorwire.proto
@@ -143,13 +143,12 @@ message SubmitPackageRejection {
     bytes session_id = 3;
 
     // server_best_height is the operator's current best block height at the
-    // time of the rejection, or 0 when the operator did not populate it. It
-    // is a diagnostic hint for transient rejections (notably
-    // OOR_REJECT_INPUT_NOT_SPENDABLE): a client that observed its input
-    // confirm at height H can compare against this value — if
-    // server_best_height < H the operator simply has not caught up to the
-    // input's confirmation yet, so a retry is guaranteed safe rather than
-    // masking a genuine problem.
+    // time of the rejection, or 0 when the operator did not populate it. It is
+    // a diagnostic hint for transient rejections (notably
+    // OOR_REJECT_INPUT_NOT_SPENDABLE): a value below the input's confirmation
+    // height confirms the operator is simply behind on chain sync rather than
+    // rejecting for a genuine reason. It is informational only — clients route
+    // their retry on the typed code, not on this value.
     uint32 server_best_height = 4;
 }
 

--- a/rpc/oorpb/payloads.go
+++ b/rpc/oorpb/payloads.go
@@ -182,15 +182,19 @@ func NewSubmitPackageResponse(sessionID chainhash.Hash,
 // rejected submit's session hash so the client-side EventRouter can
 // route the failure to the correct OOR session FSM rather than
 // stalling the ingress cursor on an undispatchable envelope.
+// serverBestHeight is the operator's best block height at rejection time; it
+// is a diagnostic hint for transient rejections and may be 0 when the operator
+// does not populate it.
 func NewSubmitPackageRejection(sessionID chainhash.Hash, code OORRejectCode,
-	reason string) *SubmitPackageResponse {
+	reason string, serverBestHeight uint32) *SubmitPackageResponse {
 
 	return &SubmitPackageResponse{
 		Result: &SubmitPackageResponse_Rejection{
 			Rejection: &SubmitPackageRejection{
-				Code:      code,
-				Reason:    reason,
-				SessionId: sessionID.CloneBytes(),
+				Code:             code,
+				Reason:           reason,
+				SessionId:        sessionID.CloneBytes(),
+				ServerBestHeight: serverBestHeight,
 			},
 		},
 	}
@@ -270,8 +274,9 @@ func ParseSubmitPackageResponse(resp *SubmitPackageResponse) (chainhash.Hash,
 		}
 
 		return sessionID, nil, nil, &SubmitRejectedError{
-			Code:   r.Rejection.Code,
-			Reason: r.Rejection.Reason,
+			Code:             r.Rejection.Code,
+			Reason:           r.Rejection.Reason,
+			ServerBestHeight: r.Rejection.ServerBestHeight,
 		}
 
 	default:
@@ -287,6 +292,13 @@ func ParseSubmitPackageResponse(resp *SubmitPackageResponse) (chainhash.Hash,
 type SubmitRejectedError struct {
 	Code   OORRejectCode
 	Reason string
+
+	// ServerBestHeight is the operator's best block height at rejection
+	// time, or 0 when the operator did not populate it. For transient
+	// rejections (OOR_REJECT_INPUT_NOT_SPENDABLE) the client compares this
+	// against the height at which it observed its input confirm to decide
+	// whether the operator is merely behind on chain sync.
+	ServerBestHeight uint32
 }
 
 // Error reports the typed rejection in a human-readable form.

--- a/rpc/oorpb/payloads.go
+++ b/rpc/oorpb/payloads.go
@@ -294,10 +294,11 @@ type SubmitRejectedError struct {
 	Reason string
 
 	// ServerBestHeight is the operator's best block height at rejection
-	// time, or 0 when the operator did not populate it. For transient
-	// rejections (OOR_REJECT_INPUT_NOT_SPENDABLE) the client compares this
-	// against the height at which it observed its input confirm to decide
-	// whether the operator is merely behind on chain sync.
+	// time, or 0 when the operator did not populate it. It is a diagnostic
+	// hint for transient rejections (OOR_REJECT_INPUT_NOT_SPENDABLE) — a
+	// value below the input's confirmation height confirms the operator is
+	// merely behind on chain sync — but the retry decision routes on the
+	// typed code alone, not on this value.
 	ServerBestHeight uint32
 }
 

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -771,6 +771,13 @@ func (s *paySession) waitForFundedVHTLC(ctx context.Context) error {
 			return err
 		}
 
+		// A funding OOR the operator rejected means no vHTLC was
+		// created; fail fast with the reason rather than waiting for
+		// funding that can never land.
+		if err := s.checkFundingRejected(ctx); err != nil {
+			return err
+		}
+
 		preimage, spentVHTLC, err :=
 			s.client.waitForInSwapClaimObservation(
 				ctx, s.cfg.PaymentHash, s.vhtlcPkScript,
@@ -965,11 +972,105 @@ func (s *paySession) markVHTLCFundedFromLocalMetadata(
 	})
 }
 
+// fundingOORFailed reports whether the daemon's durable record for the funding
+// OOR has reached a terminal failed state, meaning the operator rejected the
+// funding transfer and the vHTLC was never created. The pay flow proceeds on
+// local funding metadata even when the authoritative indexer rejects the
+// vHTLC lookup (expected for same-Ark receivers whose script is not registered
+// under this principal), so the indexer cannot distinguish "funded but not
+// queryable" from "funding rejected". The daemon's OOR session status does
+// make that distinction, and this is the signal we use to fail fast instead of
+// polling for a claim that can never arrive. A missing session, a still-pending
+// session, or a transient query error are all treated as "not known failed" so
+// a hiccup never fails an otherwise-healthy swap. The operator's failure reason
+// is returned for surfacing when known.
+func (s *paySession) fundingOORFailed(ctx context.Context) (bool, string) {
+	if s.fundingSessionID == "" {
+		return false, ""
+	}
+
+	session, err := s.client.daemon.GetOORSession(ctx, s.fundingSessionID)
+	if err != nil {
+		s.client.log.DebugS(
+			ctx,
+			"Unable to query in-swap funding OOR session",
+			slog.String("err", err.Error()),
+			btclog.Hex("hash", s.cfg.PaymentHash[:]),
+			slog.String("funding_session_id", s.fundingSessionID),
+		)
+
+		return false, ""
+	}
+	if session == nil || session.GetStatus() !=
+		waverpc.OORSessionStatus_OOR_SESSION_STATUS_FAILED {
+		return false, ""
+	}
+
+	return true, session.GetFailureReason()
+}
+
+// checkFundingRejected returns a terminal failure error when the funding OOR
+// was rejected by the operator, and nil otherwise. It is the shared guard used
+// at the top of every pay-side wait loop so a rejected funding OOR fails the
+// swap fast (with the operator's reason) instead of polling for a claim or
+// refund of a vHTLC that was never created.
+func (s *paySession) checkFundingRejected(ctx context.Context) error {
+	if failed, reason := s.fundingOORFailed(ctx); failed {
+		return s.failFundingRejected(ctx, reason)
+	}
+
+	return nil
+}
+
+// failFundingRejected terminally fails a pay session whose funding OOR the
+// operator rejected. Because the funding transfer rolled back, the funding
+// input has been released to the wallet and no vHTLC exists: there is nothing
+// to claim or refund. We cancel any armed refund recovery (armed optimistically
+// from local funding metadata) and fail the swap with the operator's reason,
+// rather than polling until the invoice deadline and then attempting to refund
+// a non-existent vHTLC.
+func (s *paySession) failFundingRejected(ctx context.Context,
+	reason string) error {
+
+	s.client.log.WarnS(ctx, "In-swap funding OOR rejected by operator",
+		nil,
+		btclog.Hex("hash", s.cfg.PaymentHash[:]),
+		slog.String("funding_session_id", s.fundingSessionID),
+		slog.String("reason", reason),
+	)
+
+	if err := cancelVHTLCRecovery(
+		ctx, s.client.daemon, s.refundRecoveryID,
+		recoveryReasonFundingRejected, "",
+	); err != nil {
+		return newRetryableActionError(err)
+	}
+
+	// Unlike the markExpired/needsIntervention/failTerminal helpers, the
+	// PayStateFailed transition is intentionally left to the caller: this
+	// returns from a wait-loop action, so the FSM fail handler classifies
+	// the failureError and drives the terminal transition (mirroring how
+	// the other wait-loop returns work).
+	msg := "in-swap funding OOR rejected by operator"
+	if reason != "" {
+		msg = fmt.Sprintf("%s: %s", msg, reason)
+	}
+
+	return newFailureError(msg, nil)
+}
+
 // waitForClaimPreimage waits until the server claim spend is indexed and the
 // finalized checkpoint exposes the expected hashlock preimage.
 func (s *paySession) waitForClaimPreimage(ctx context.Context) error {
 	for {
 		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		// If the funding OOR was rejected by the operator the vHTLC was
+		// never created, so fail fast with the reason instead of
+		// polling for a claim that can never arrive.
+		if err := s.checkFundingRejected(ctx); err != nil {
 			return err
 		}
 

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -713,6 +713,103 @@ func TestPayViaLightningRequiresClaimPreimage(t *testing.T) {
 	require.Nil(t, result)
 }
 
+// TestPaySessionFailsFastWhenFundingOORRejected asserts that when the operator
+// rejects the vHTLC funding OOR (so no vHTLC is ever created), the pay session
+// fails fast with the operator's reason instead of polling for a claim that can
+// never arrive and then attempting to refund a non-existent vHTLC. This is the
+// in-Ark wedge from darepo-client#938: the funding OOR fails asynchronously
+// after submit, and the indexer's "script not registered for principal"
+// rejection cannot by itself distinguish a rejected funding OOR from a
+// funded-but-not-locally-queryable one — the daemon's OOR session status can.
+func TestPaySessionFailsFastWhenFundingOORRejected(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:  preimage.Hash(),
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
+			ServerPubkey: serverPriv.PubKey(),
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime:                       144,
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			// Generous expiry so the swap can only terminate via
+			// the funding-rejection guard, never via a deadline.
+			Expiry: time.Now().Add(time.Hour),
+		},
+	}
+
+	// Model the operator rejecting the funding OOR: the daemon's durable
+	// OOR session reports FAILED with a reason, while the vHTLC stays
+	// unqueryable via the indexer ("script not registered for principal"),
+	// exactly as a same-Ark receiver's vHTLC appears to the payer.
+	const rejectReason = "recipient script not registered for principal"
+	daemonConn := &testDaemonConn{
+		identityKey:   clientPriv.PubKey(),
+		operatorKey:   operatorPriv.PubKey(),
+		blockHeight:   100,
+		sendSessionID: "funding-session",
+		sendOutpoint:  "funding:0",
+		liveLookupErr: errors.New(
+			"indexer query failed: script not registered for " +
+				"principal",
+		),
+		oorSession: &waverpc.OORSessionInfo{
+			Status: waverpc.
+				OORSessionStatus_OOR_SESSION_STATUS_FAILED,
+			FailureReason: rejectReason,
+		},
+	}
+
+	store := newTestSwapStore(t)
+	client := configureTestPayClient(
+		NewSwapClientWithStore(serverConn, daemonConn, nil, nil, store),
+	)
+	client.waitPollInterval = time.Millisecond
+	client.refundLocktimeBuffer = 0
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	_, err = session.Wait(t.Context())
+
+	// The swap fails fast with the operator's rejection reason surfaced,
+	// rather than expiring or refunding.
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errSwapExpired)
+	require.NotErrorIs(t, err, ErrSwapRefunded)
+	require.Contains(t, err.Error(), "funding OOR rejected")
+	require.Contains(t, err.Error(), rejectReason)
+
+	// The session ends in the terminal failed state.
+	require.Equal(t, PayStateFailed, session.State())
+
+	// Fail-fast: it never attempted to refund a non-existent vHTLC...
+	require.Zero(t, daemonConn.sendCustomCalls)
+
+	// ...and it cancelled the refund recovery that was armed optimistically
+	// from the local funding metadata.
+	require.GreaterOrEqual(t, daemonConn.cancelCalls, 1)
+}
+
 // TestPaySessionRefundsFundedVHTLCOnTimeout asserts a pay session
 // automatically sweeps its funded vHTLC back through the sender refund path
 // once the server claim deadline elapses.

--- a/sdk/swaps/recovery.go
+++ b/sdk/swaps/recovery.go
@@ -95,6 +95,11 @@ const (
 	// claim spend is already indexed.
 	recoveryReasonClaimIndexed = "cooperative claim indexed"
 
+	// recoveryReasonFundingRejected explains cancellation of a pay-side
+	// refund recovery when the funding OOR was rejected by the operator, so
+	// the vHTLC never existed and there is nothing to recover.
+	recoveryReasonFundingRejected = "funding OOR rejected by operator"
+
 	// DefaultRecoveryMaxFeeRateSatPerKW caps SDK-armed vHTLC exit spends at
 	// 100 sat/vbyte. Operators can still clamp lower through the daemon's
 	// unroll fee cap; this value prevents an armed recovery row from being

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -111,10 +111,14 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
 - `Config.EagerRoundJoin` defaults via `defaultEagerRoundJoin()`: `false` on
   the standalone build, `true` under the `wavewalletrpc` build tag.
 - `registerOOREventRoutes` checks for a typed `*oorpb.SubmitRejectedError`
-  before the generic error path, so an OOR rejection drives a
-  non-retryable `OutboxErrorEvent` instead of an `Adapt` error that would
-  stall the serverconn ingress cursor on the offending envelope
-  (`server.go`).
+  before the generic error path, so an OOR rejection drives an
+  `OutboxErrorEvent` instead of an `Adapt` error that would stall the
+  serverconn ingress cursor on the offending envelope (`server.go`).
+  `oorRejectRetry` classifies the event's `Retryable` flag: it is `false`
+  (terminal) for every typed reject except `OOR_REJECT_INPUT_NOT_SPENDABLE`,
+  which is transient (the operator has not yet caught up to the input's
+  commitment confirmation) and so re-drives the submit after
+  `oorInputNotSpendableRetryDelay`.
 
 ## Deep Docs
 

--- a/waved/oor_reject_retry_test.go
+++ b/waved/oor_reject_retry_test.go
@@ -1,0 +1,76 @@
+package waved
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/wavelength/oor"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOORRejectRetry verifies that only the transient input-not-spendable
+// rejection is driven through the OOR FSM as retryable (so the submit is
+// re-driven until the operator's chain view catches up and the transfer
+// recovers), while every other typed rejection stays terminal. This is the
+// server-reject-to-client-retry link behind the darepo-client#938 fix: paired
+// with oor.TestHandleOutboxError (retryable OutboxError re-drives instead of
+// failing), it shows an input-not-spendable rejection recovers rather than
+// wedging.
+func TestOORRejectRetry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		err           error
+		wantRetryable bool
+		wantDelay     time.Duration
+	}{
+		{
+			name: "input not spendable is retried",
+			err: &oor.ErrInputNotSpendable{
+				Reason:           "vtxo x not spendable",
+				ServerBestHeight: 100,
+			},
+			wantRetryable: true,
+			wantDelay:     oorInputNotSpendableRetryDelay,
+		},
+		{
+			name: "output policy is terminal",
+			err: &oor.ErrOutputPolicyViolation{
+				Reason: "x",
+			},
+			wantRetryable: false,
+		},
+		{
+			name: "user balance is terminal",
+			err: &oor.ErrUserBalanceExceeded{
+				Reason: "x",
+			},
+			wantRetryable: false,
+		},
+		{
+			name: "lineage too large is terminal",
+			err: &oor.ErrLineageTooLarge{
+				Reason: "x",
+			},
+			wantRetryable: false,
+		},
+		{
+			name:          "generic error is terminal",
+			err:           errors.New("boom"),
+			wantRetryable: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			retryable, delay := oorRejectRetry(tc.err)
+			require.Equal(t, tc.wantRetryable, retryable)
+			require.Equal(t, tc.wantDelay, delay)
+		})
+	}
+}

--- a/waved/server.go
+++ b/waved/server.go
@@ -794,6 +794,21 @@ const operatorConnPollInterval = 15 * time.Second
 // bounds total retrying when the operator never catches up.
 const oorInputNotSpendableRetryDelay = 15 * time.Second
 
+// oorRejectRetry decides how a classified OOR submit rejection is driven
+// through the session FSM. An input-not-spendable rejection is transient — the
+// operator has not yet caught up to the input's round-commitment confirmation
+// that this client already observed — so it is retried after a delay and the
+// (idempotent) submit is re-driven until the operator's chain view catches up.
+// Every other typed rejection is terminal for the same submit shape, so it
+// drives the session to failure without a retry.
+func oorRejectRetry(classified error) (bool, time.Duration) {
+	if errors.Is(classified, &oor.ErrInputNotSpendable{}) {
+		return true, oorInputNotSpendableRetryDelay
+	}
+
+	return false, 0
+}
+
 // monitorOperatorConnection keeps the ServerConnectionUp gauge and the
 // ServerSyncTimestamp in step with the live health of the direct gRPC
 // connection to the ark operator. The bootstrap stamp in
@@ -2882,15 +2897,9 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) { //noli
 				// it retryable and let the OOR FSM re-drive the
 				// submit after a delay rather than failing the
 				// transfer.
-				retryable := false
-				retryAfter := time.Duration(0)
-				if errors.Is(
-					classified, &oor.ErrInputNotSpendable{},
-				) {
-
-					retryable = true
-					retryAfter = oorInputNotSpendableRetryDelay
-				}
+				retryable, retryAfter := oorRejectRetry(
+					classified,
+				)
 
 				return &oor.DriveEventRequest{
 					SessionID: oor.SessionID(sessionID),

--- a/waved/server.go
+++ b/waved/server.go
@@ -791,7 +791,11 @@ const operatorConnPollInterval = 15 * time.Second
 // so a short delay keeps the swap responsive, while being long enough to avoid
 // hammering the operator with resubmits between blocks. It is deliberately far
 // below any swap invoice deadline so the natural deadline (not this timer)
-// bounds total retrying when the operator never catches up.
+// bounds total retrying when the operator never catches up. A plain SendOOR
+// with no such deadline re-drives indefinitely on a persistent reject — the
+// same "re-drive on operator silence, never give up" behavior the
+// AwaitingSubmitAccepted transport timer already has — which is acceptable
+// because the operator only emits this transient code for a pending input.
 const oorInputNotSpendableRetryDelay = 15 * time.Second
 
 // oorRejectRetry decides how a classified OOR submit rejection is driven

--- a/waved/server.go
+++ b/waved/server.go
@@ -783,6 +783,17 @@ func (s *Server) setServerConnected(connected bool) {
 // gRPC connectivity API.
 const operatorConnPollInterval = 15 * time.Second
 
+// oorInputNotSpendableRetryDelay is how long the OOR FSM waits before
+// re-driving a submit that the operator rejected because an input was not yet
+// spendable (its round commitment tx had not reached the operator's
+// confirmation target). The wait only needs to outlast the operator's chain
+// backend catching up to a block this client already saw — typically seconds —
+// so a short delay keeps the swap responsive, while being long enough to avoid
+// hammering the operator with resubmits between blocks. It is deliberately far
+// below any swap invoice deadline so the natural deadline (not this timer)
+// bounds total retrying when the operator never catches up.
+const oorInputNotSpendableRetryDelay = 15 * time.Second
+
 // monitorOperatorConnection keeps the ServerConnectionUp gauge and the
 // ServerSyncTimestamp in step with the live health of the direct gRPC
 // connection to the ark operator. The bootstrap stamp in
@@ -2857,11 +2868,36 @@ func (s *Server) registerOOREventRoutes(router *serverconn.EventRouter) { //noli
 					rejected,
 				)
 
+				// Most typed rejections are terminal for the
+				// same submit shape (lineage cap, output
+				// policy, balance), so they drive the session
+				// to Failed. An input-not-spendable rejection
+				// is the exception: it is transient, almost
+				// always because the input's round commitment
+				// tx has not yet reached the operator's
+				// confirmation target even though this client
+				// already observed the confirmation. Retrying
+				// the identical submit succeeds once the
+				// operator's chain view catches up, so we mark
+				// it retryable and let the OOR FSM re-drive the
+				// submit after a delay rather than failing the
+				// transfer.
+				retryable := false
+				retryAfter := time.Duration(0)
+				if errors.Is(
+					classified, &oor.ErrInputNotSpendable{},
+				) {
+
+					retryable = true
+					retryAfter = oorInputNotSpendableRetryDelay
+				}
+
 				return &oor.DriveEventRequest{
 					SessionID: oor.SessionID(sessionID),
 					Event: &oor.OutboxErrorEvent{
 						OutboxType:  submitOutbox,
-						Retryable:   false,
+						Retryable:   retryable,
+						RetryAfter:  retryAfter,
 						ErrorReason: classified.Error(),
 					},
 				}, nil


### PR DESCRIPTION
## What

Makes an in-Ark (same-Ark) pay swap survive the case where the payer's vHTLC
**funding OOR is rejected by the operator because the funding input VTXO is not
yet spendable on the operator's side**, instead of wedging both parties.

Supersedes #939 — its fail-fast commit is included here as the first commit.
**Companion operator-side PR: lightninglabs/lumos#673** (typed reject code +
best-height hint + the non-terminal re-validation that lets the retry actually
complete). **Both halves are required**; see the note under "What this PR does".

## Root cause (#938)

An in-Ark payment wedged both parties, each looping on `script not registered
for principal`. That string was a **red herring** — the indexer's registration
check only fires as a no-rows fallback, and there were no rows because the
**vHTLC was never created**.

The real cause, from the payer daemon's own OOR session record
(`wavecli ark oor get`):

```
OOR_REJECT_UNSPECIFIED: vtxo 57cc…:0 not spendable
```

The funding **input** — a VTXO the payer created via a round ~2 min earlier and
which its own wallet held solidly `live` — was rejected by the operator as "not
spendable." The operator (lumosd) promotes a round VTXO `pending → live` only
after the round commitment tx reaches its confirmation target; the payer,
running neutrino (no mempool), had already observed that confirmation in a block
and treated the VTXO as spendable. On signet's ~10-minute blocks, spending a
freshly minted round VTXO lands in the window where the client is ahead of the
operator's chain view → the funding OOR is rejected → (pre-fix) both sides hang.

It is transient: once the operator's chain view catches up, the identical submit
succeeds.

## What this PR does

1. **`sdk/swaps` (from #939):** the in-swap FSM consults the funding OOR session
   status and fails fast with the operator's reason instead of polling until the
   invoice deadline. This is what surfaced the real reason.
2. **`rpc/oorpb`:** adds a typed `OOR_REJECT_INPUT_NOT_SPENDABLE` reject code and
   a `server_best_height` field on `SubmitPackageRejection` (previously arrived
   as the indistinguishable `OOR_REJECT_UNSPECIFIED`).
3. **`oor`:** classifies the code into a typed, non-terminal `ErrInputNotSpendable`
   (mirroring `ErrUserBalanceExceeded`), carrying `ServerBestHeight`.
4. **`waved`:** drives the rejection through the OOR FSM as a **retryable**
   `OutboxErrorEvent`, so the existing submit re-drive resubmits after a short,
   named delay (`oorInputNotSpendableRetryDelay`) until the operator's chain view
   catches up — self-healing the race. All other typed rejects stay terminal.
   For a swap, the retry is bounded by the invoice deadline.

`server_best_height` is an advisory hint that the operator is merely behind on
chain sync, so the retry is a considered reattempt rather than a blind one.

> **Requires the operator-side fix — lightninglabs/lumos#673.** Before that PR
> the operator drove this rejection to a *terminal* session state and, because
> the OOR session id is the deterministic Ark txid, replayed the cached verdict
> for every retry without re-reading the now-live input — so this client retry
> could never succeed on its own. #673 keeps the transient rejection
> non-terminal so a re-submit re-validates. Deploy the operator first and ship
> the two together.

## Testing

- `oor`: unit test for the new classification + `ServerBestHeight` passthrough.
- The full reproduction **and** end-to-end recovery (create a round VTXO,
  withhold the operator's confirmation, fund an OOR → typed reject → daemon retry
  → confirm → success) land as a systest + a full-daemon itest in lumos#673.

Refs lightninglabs/wavelength#938. Supersedes #939.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
