### PR TITLE
multi: purge legacy arkd name, repoint server refs to lumos

### DIFF
--- a/.claude/skills/waved-docker.md
+++ b/.claude/skills/waved-docker.md
@@ -24,18 +24,18 @@ docker run --rm waved:local \
     --lnd.host=<lnd-host>:10009 \
     --lnd.tlspath=/path/to/tls.cert \
     --lnd.macaroonpath=/path/to/admin.macaroon \
-    --server.host=<arkd-host>:7070 \
+    --server.host=<lumosd-host>:7070 \
     --server.insecure=true \
     --rpc.listenaddr=0.0.0.0:10029
 ```
 
 ## Running with Full Stack
 
-The server repo (`wavelength`) includes a `docker-compose.yml` that
-orchestrates the complete environment: bitcoind + 2x lnd + arkd + waved.
+The server repo (`lumos`) includes a `docker-compose.yml` that
+orchestrates the complete environment: bitcoind + 2x lnd + lumosd + waved.
 
 ```bash
-# From the wavelength (server) repo root:
+# From the lumos (server) repo root:
 docker-compose up -d --build
 ./scripts/docker-regtest-setup.sh
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /arkcli
-/arkd
 /wavecli
 bin/*
 **/test-artifacts

--- a/db/sqlite_open_wasm.go
+++ b/db/sqlite_open_wasm.go
@@ -115,7 +115,7 @@ func browserSQLiteFileName(name string) string {
 	normalized := filepath.ToSlash(filepath.Clean(name))
 	base := filepath.Base(normalized)
 	if base == "." || base == "/" || base == "" {
-		base = "arkd.db"
+		base = "waved.db"
 		normalized = base
 	}
 

--- a/db/store.go
+++ b/db/store.go
@@ -110,7 +110,7 @@ func DefaultConfig(dataDir string) *Config {
 // The default database file is placed under the provided data directory.
 func DefaultSqliteConfig(dataDir string) *SqliteConfig {
 	return &SqliteConfig{
-		DatabaseFileName: fmt.Sprintf("%s/arkd.db", dataDir),
+		DatabaseFileName: fmt.Sprintf("%s/waved.db", dataDir),
 		Synchronous:      defaultSqliteSynchronous,
 	}
 }
@@ -125,7 +125,7 @@ func DefaultPostgresConfig() *PostgresConfig {
 		Port:     5432,
 		User:     "postgres",
 		Password: "",
-		DBName:   "arkd",
+		DBName:   "waved",
 		// Use the default value for max open connections.
 		MaxOpenConnections: 0,
 

--- a/docs/RPC_MAILBOX_CONTRACT.md
+++ b/docs/RPC_MAILBOX_CONTRACT.md
@@ -2,9 +2,9 @@
 
 This document captures contract notes and design constraints for an
 RPC-over-mailbox transport. It is intended as a "scratchpad" companion to the
-implementation-ready spec tracked in `lightninglabs/wavelength`:
+implementation-ready spec tracked in `lightninglabs/lumos`:
 
-- Spec issue: https://github.com/lightninglabs/wavelength/issues/71
+- Spec issue: https://github.com/lightninglabs/lumos/issues/71
 - Durability reference (client-side): https://github.com/lightninglabs/wavelength/pull/48
 
 This document intentionally does not reference any private repositories,

--- a/docs/accounting_report.md
+++ b/docs/accounting_report.md
@@ -15,7 +15,7 @@ Point the command at the database file a SQLite daemon writes:
 
 ```shell
 go run ./internal/cmd/tools/accounting \
-    --backend sqlite --sqlite.dbfile ~/.waved/data/arkd.db
+    --backend sqlite --sqlite.dbfile ~/.waved/data/waved.db
 ```
 
 Against a Postgres daemon, pass the connection settings instead:
@@ -24,8 +24,8 @@ Against a Postgres daemon, pass the connection settings instead:
 go run ./internal/cmd/tools/accounting \
     --backend postgres \
     --postgres.host localhost --postgres.port 5432 \
-    --postgres.user arkd --postgres.password "$PGPASSWORD" \
-    --postgres.dbname arkd
+    --postgres.user waved --postgres.password "$PGPASSWORD" \
+    --postgres.dbname waved
 ```
 
 Stop the daemon before you run the report, or expect a snapshot that is one
@@ -43,7 +43,7 @@ uncommitted in-flight writes.
 | `--postgres.port` | `5432` | Postgres port. |
 | `--postgres.user` | `postgres` | Postgres user. |
 | `--postgres.password` | — | Postgres password. |
-| `--postgres.dbname` | `arkd` | Postgres database name. |
+| `--postgres.dbname` | `waved` | Postgres database name. |
 | `--postgres.ssl` | `false` | Require TLS for the Postgres connection. |
 | `--apply-migrations` | `false` | Run migrations before reporting. Off by default so the report leaves the schema untouched. |
 | `--format` | `text` | Output format: `text`, `json`, or `csv`. |

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -634,7 +634,7 @@ wave ark send inround --to bcrt1p... --amount 5000
 ```
 
 For per-client manual testing under the `arktest` harness, see
-`MANUAL_TESTING.md` at the server (wavelength) repo root.
+`MANUAL_TESTING.md` at the server (lumos) repo root.
 
 ## Password Handling
 

--- a/docs/fee-change-model.md
+++ b/docs/fee-change-model.md
@@ -8,7 +8,7 @@ It is the source-of-truth narrative for the implementation in:
 
 - [`client/round/transitions.go`](../round/transitions.go) —
   `designateChangeMarker`, `validateQuoteEchoes`, `evaluateQuote`.
-- `rounds/seal_time_fee_builder.go` (server/wavelength repo) —
+- `rounds/seal_time_fee_builder.go` (server/lumos repo) —
   `resolveChangeDesignation`, `computeSealTimeQuotes`,
   `quoteForClient`.
 - [`client/rpc/roundpb/round.proto`](../rpc/roundpb/round.proto) —

--- a/docs/seed_restore_recovery.md
+++ b/docs/seed_restore_recovery.md
@@ -92,7 +92,7 @@ under `pending_in_sat`. Once funds are boarded into VTXOs, they contribute to
 
 ## Local arktest Smoke
 
-The root `wavelength` repository contains the `arktest` manual harness. Use it when
+The root `lumos` repository contains the `arktest` manual harness. Use it when
 this client repo is checked out as the root repo's `client/` submodule.
 
 Build the manual harness and CLI binaries from the root repo:

--- a/docs/signet.md
+++ b/docs/signet.md
@@ -6,9 +6,9 @@ endpoint for the configured Bitcoin network and outbound transport.
 
 | Network config | Ark gRPC | Ark REST | Swap gRPC | Swap REST |
 |----------------|----------|----------|-----------|-----------|
-| `testnet` | `arkd.testnet.lightningcluster.com:443` | `https://arkd-rest.testnet.lightningcluster.com` | `swapd.testnet.lightningcluster.com:443` | `https://swapd-rest.testnet.lightningcluster.com` |
-| `testnet4` | `arkd-testnet4.testnet.lightningcluster.com:443` | `https://arkd-testnet4-rest.testnet.lightningcluster.com` | `swapd-testnet4.testnet.lightningcluster.com:443` | `https://swapd-testnet4-rest.testnet.lightningcluster.com` |
-| `signet` | `arkd-signet.staging.lightningcluster.com:443` | `https://arkd-signet-rest.staging.lightningcluster.com` | `swapd-signet.staging.lightningcluster.com:443` | `https://swapd-signet-rest.staging.lightningcluster.com` |
+| `testnet` | `lumosd.testnet.lightningcluster.com:443` | `https://lumosd-rest.testnet.lightningcluster.com` | `swapd.testnet.lightningcluster.com:443` | `https://swapd-rest.testnet.lightningcluster.com` |
+| `testnet4` | `lumosd-testnet4.testnet.lightningcluster.com:443` | `https://lumosd-testnet4-rest.testnet.lightningcluster.com` | `swapd-testnet4.testnet.lightningcluster.com:443` | `https://swapd-testnet4-rest.testnet.lightningcluster.com` |
+| `signet` | `lumosd-signet.staging.lightningcluster.com:443` | `https://lumosd-signet-rest.staging.lightningcluster.com` | `swapd-signet.staging.lightningcluster.com:443` | `https://swapd-signet-rest.staging.lightningcluster.com` |
 
 The daemon defaults both outbound transports to gRPC. Set the selectors to
 `rest` when the host cannot use native gRPC:

--- a/docs/swap_system.md
+++ b/docs/swap_system.md
@@ -24,7 +24,7 @@ A swap is a four-party affair, even though the user only ever sees two of them.
 |-------|-----------|----------------|
 | **The client** (`waved`) | The user's daemon. Holds the wallet, derives keys, drives the swap FSM. | This repo. |
 | **The swap server** (`swapd`) | The bridge between Lightning and Ark. Intercepts Lightning HTLCs, funds vHTLCs, pays invoices. | Operator infrastructure (separate repo). |
-| **The Ark operator** (`arkd`) | The Ark service provider. Runs rounds, and — crucially for us — runs **the indexer**, the authoritative record of which virtual outputs exist. | Operator infrastructure (separate repo). |
+| **The Ark operator** (`lumosd`) | The Ark service provider. Runs rounds, and — crucially for us — runs **the indexer**, the authoritative record of which virtual outputs exist. | Operator infrastructure (separate repo). |
 | **The counterparty** | A Lightning node paying the invoice, *or* another client of the same Ark. | Anywhere. |
 
 The single most important idea in this document is that the swap server and the
@@ -243,7 +243,7 @@ sequenceDiagram
     participant U as User / CLI
     participant C as Client (waved)
     participant S as swapd (swap server)
-    participant A as arkd + indexer
+    participant A as lumosd + indexer
     participant L as Lightning payer
 
     U->>C: wave recv --offchain --amt N
@@ -317,7 +317,7 @@ sequenceDiagram
     participant U as User / CLI
     participant C as Client (waved)
     participant S as swapd (swap server)
-    participant A as arkd + indexer
+    participant A as lumosd + indexer
     participant P as Lightning payee
 
     U->>C: wave send <invoice> --offchain
@@ -743,7 +743,7 @@ Everything the client asks of the **operator's indexer** (via the daemon) is a
 proof-gated query — chiefly `ListVTXOsByScripts`, reached through
 `FindLiveVTXOByPkScript` → `GetIndexedVTXOByPkScript`
 (waved/rpc_swap_lookup.go) → `indexer.ListVTXOsByScriptsTaproot`. The indexer
-is not part of `swapd`; it belongs to `arkd`. That separation — the swap server
+is not part of `swapd`; it belongs to `lumosd`. That separation — the swap server
 funds, but the operator's indexer witnesses — is the defining structure of the
 receive path.
 

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -1,5 +1,5 @@
 // Package harness provides a small, programmatic integration-test runner that
-// starts a regtest bitcoind and an lnd node in Docker, boots arkd in-process,
+// starts a regtest bitcoind and an lnd node in Docker, boots waved in-process,
 // and offers helpers for mining and funding. It also manages per-run artifacts
 // (data directories and logs), supports parallel test execution through
 // dynamic ports and per-run Docker networks, and guarantees clean teardown.
@@ -145,7 +145,7 @@ var (
 
 	harnessPostgres = flag.Bool(
 		"harness.postgres", false,
-		"if true, use PostgreSQL instead of SQLite for arkd",
+		"if true, use PostgreSQL instead of SQLite for waved",
 	)
 
 	artifactsBaseDirFlag = flag.String(
@@ -173,7 +173,7 @@ var (
 )
 
 // Harness spins up an ARK test environment using bitcoind and LND in Docker
-// and arkd in-process.
+// and waved in-process.
 type Harness struct {
 	T *testing.T
 
@@ -336,9 +336,9 @@ type Options struct {
 	// addition to the harness log file.
 	HarnessLogStdOut bool
 
-	// ArkdLogStdOut if true, also prints arkd logs to stdout in
-	// addition to the arkd log file.
-	ArkdLogStdOut bool
+	// WavedLogStdOut if true, also prints waved logs to stdout in
+	// addition to the waved log file.
+	WavedLogStdOut bool
 
 	// StartTapd if true, starts a tapd instance along with the harness.
 	// Default is false to speed up tests that don't need tapd.
@@ -471,7 +471,7 @@ func (h *Harness) BaseDir() string {
 	return h.artifactsDir
 }
 
-// Start launches bitcoind and lnd containers, initializes lnd, and boots arkd
+// Start launches bitcoind and lnd containers, initializes lnd, and boots waved
 // in-process.
 func (h *Harness) Start() {
 	h.T.Helper()
@@ -1366,7 +1366,7 @@ func (h *Harness) attemptStartBitcoind(containerName string) error {
 }
 
 // startElectrs launches an electrs container that serves an Esplora-compatible
-// HTTP API used by arkd and tests. It shares the bitcoind datadir to access
+// HTTP API used by waved and tests. It shares the bitcoind datadir to access
 // blocks and chainstate and connects to bitcoind over RPC inside the private
 // network.
 func (h *Harness) startElectrs() {
@@ -1474,7 +1474,7 @@ func (h *Harness) startElectrs() {
 	}, electrsReadyTimeout, pollInterval, "electrs HTTP not ready")
 }
 
-// startPostgres launches a postgres container for arkd to use instead of
+// startPostgres launches a postgres container for waved to use instead of
 // SQLite.
 func (h *Harness) startPostgres() {
 	// Remove any existing postgres container with the same name (from

--- a/internal/cmd/tools/accounting/AGENTS.md
+++ b/internal/cmd/tools/accounting/AGENTS.md
@@ -42,7 +42,7 @@ missing path instead of reporting against an empty database it just made.
   daemon does; `db/sqlc` generated read queries; `net/http` for optional fiat
   pricing.
 - **Depended on by**: operators running e.g.
-  `go run ./internal/cmd/tools/accounting --backend sqlite --sqlite.dbfile <arkd.db>`.
+  `go run ./internal/cmd/tools/accounting --backend sqlite --sqlite.dbfile <waved.db>`.
 
 ## Invariants
 

--- a/internal/cmd/tools/accounting/CLAUDE.md
+++ b/internal/cmd/tools/accounting/CLAUDE.md
@@ -42,7 +42,7 @@ missing path instead of reporting against an empty database it just made.
   daemon does; `db/sqlc` generated read queries; `net/http` for optional fiat
   pricing.
 - **Depended on by**: operators running e.g.
-  `go run ./internal/cmd/tools/accounting --backend sqlite --sqlite.dbfile <arkd.db>`.
+  `go run ./internal/cmd/tools/accounting --backend sqlite --sqlite.dbfile <waved.db>`.
 
 ## Invariants
 

--- a/internal/cmd/tools/accounting/main.go
+++ b/internal/cmd/tools/accounting/main.go
@@ -211,7 +211,7 @@ func parseFlags(args []string) (*config, error) {
 		postgresHost:   "localhost",
 		postgresPort:   5432,
 		postgresUser:   "postgres",
-		postgresDBName: "arkd",
+		postgresDBName: "waved",
 	}
 
 	fs := flag.NewFlagSet("accounting", flag.ContinueOnError)

--- a/internal/cmd/tools/accounting/main_test.go
+++ b/internal/cmd/tools/accounting/main_test.go
@@ -47,7 +47,7 @@ func TestOpenStoreValidatesBackend(t *testing.T) {
 // the seeded chart of accounts with no ledger entries. This exercises the
 // shared db opener, the read-only transaction, and the report assembly.
 func TestBuildReportReadsSeededAccounts(t *testing.T) {
-	dbFile := filepath.Join(t.TempDir(), "arkd.db")
+	dbFile := filepath.Join(t.TempDir(), "waved.db")
 
 	// Create and migrate a fresh database so the chart of accounts is
 	// seeded.

--- a/metrics/AGENTS.md
+++ b/metrics/AGENTS.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 Prometheus instrumentation for the wavelength daemon (`waved`). All
-metrics are namespaced under `waved_`. Mirrors the arkd **server** metrics
+metrics are namespaced under `waved_`. Mirrors the lumosd **server** metrics
 package (one directory up) in structure and collection strategy: an
 event-driven actor for lifecycle counters, plus a scrape-time collector for
 gauges that must stay fresh (VTXO inventory, wallet balance, chain tip, live

--- a/metrics/CLAUDE.md
+++ b/metrics/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 Prometheus instrumentation for the wavelength daemon (`waved`). All
-metrics are namespaced under `waved_`. Mirrors the arkd **server** metrics
+metrics are namespaced under `waved_`. Mirrors the lumosd **server** metrics
 package (one directory up) in structure and collection strategy: an
 event-driven actor for lifecycle counters, plus a scrape-time collector for
 gauges that must stay fresh (VTXO inventory, wallet balance, chain tip, live

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -3,7 +3,7 @@
 All wavelength **client** (`waved`) Prometheus metrics are namespaced under
 `waved_`. The namespace matches the daemon binary name and the `WAVED`
 config/env prefix, so client metrics group under the same identifier operators
-already use. This mirrors the arkd **server** metrics package (`arkd_`), one
+already use. This mirrors the lumosd **server** metrics package (`lumosd_`), one
 directory up, in both structure and collection strategy.
 
 Two collection strategies, same as the server:

--- a/metrics/actor.go
+++ b/metrics/actor.go
@@ -46,7 +46,7 @@ type ActorConfig struct {
 // event-driven Prometheus instrumentation. All lifecycle counters live
 // behind this single actor; subsystems Tell typed messages rather than
 // touching Prometheus directly, so every event-driven update happens in
-// one auditable place (matching the arkd server's MetricsActor).
+// one auditable place (matching the lumosd server's MetricsActor).
 type MetricsActor struct {
 	cfg ActorConfig
 	log btclog.Logger

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -55,7 +55,7 @@ type WalletBalance struct {
 }
 
 // SystemStatsQuerier is the full scrape-time data source the
-// SystemCollector reads. It mirrors the arkd server's querier so client
+// SystemCollector reads. It mirrors the lumosd server's querier so client
 // and server dashboards share query structure. Each method is queried
 // independently on every scrape; a method returning an error only
 // suppresses its own samples for that scrape, never the whole endpoint.

--- a/metrics/messages.go
+++ b/metrics/messages.go
@@ -9,7 +9,7 @@ import (
 // Msg is the sealed interface for all messages sent to the metrics
 // actor. Subsystem actors and the daemon send typed metric events here
 // instead of calling Prometheus directly, keeping all event-driven
-// instrumentation in one auditable place. This mirrors the arkd server's
+// instrumentation in one auditable place. This mirrors the lumosd server's
 // metrics actor design.
 type Msg interface {
 	actor.Message

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -118,7 +118,7 @@ var (
 	// outgoing OOR (async) transfers from the SendOOR call entry to its
 	// terminal outcome, labelled by status. The duration is measured at
 	// the call site and carried on the metric message so the metrics
-	// actor stays stateless. Buckets mirror the arkd server's OOR
+	// actor stays stateless. Buckets mirror the lumosd server's OOR
 	// transfer histogram for dashboard consistency.
 	OORTransferDurationSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -1488,7 +1488,7 @@ func TestWaitForVHTLCFallsBackToLocalVTXOOnUnregisteredScript(t *testing.T) {
 // unregisteredScriptIndexerErr returns the indexer rejection a receiver sees
 // while the swap server has funded the vHTLC but the operator's indexer has not
 // yet exposed a live VTXO row queryable under the receiver principal. The
-// string mirrors the wording the daemon surfaces from arkd so the classifier
+// string mirrors the wording the daemon surfaces from lumosd so the classifier
 // under test matches what production observes.
 func unregisteredScriptIndexerErr() error {
 	return status.Error(

--- a/waved/config.go
+++ b/waved/config.go
@@ -54,12 +54,12 @@ const (
 
 	// defaultTestnet3ServerGRPCHost is the public testnet3 Ark operator
 	// gRPC endpoint.
-	defaultTestnet3ServerGRPCHost = "arkd.testnet." +
+	defaultTestnet3ServerGRPCHost = "lumosd.testnet." +
 		"lightningcluster.com:443"
 
 	// defaultTestnet3ServerRESTHost is the public testnet3 Ark operator
 	// REST endpoint.
-	defaultTestnet3ServerRESTHost = "arkd-rest.testnet." +
+	defaultTestnet3ServerRESTHost = "lumosd-rest.testnet." +
 		"lightningcluster.com"
 
 	// defaultTestnet3SwapServerGRPCHost is the public testnet3 swap server
@@ -74,12 +74,12 @@ const (
 
 	// defaultTestnet4ServerGRPCHost is the public testnet4 Ark operator
 	// gRPC endpoint.
-	defaultTestnet4ServerGRPCHost = "arkd-testnet4.testnet." +
+	defaultTestnet4ServerGRPCHost = "lumosd-testnet4.testnet." +
 		"lightningcluster.com:443"
 
 	// defaultTestnet4ServerRESTHost is the public testnet4 Ark operator
 	// REST endpoint.
-	defaultTestnet4ServerRESTHost = "arkd-testnet4-rest.testnet." +
+	defaultTestnet4ServerRESTHost = "lumosd-testnet4-rest.testnet." +
 		"lightningcluster.com"
 
 	// defaultTestnet4SwapServerGRPCHost is the public testnet4 swap server
@@ -94,13 +94,13 @@ const (
 
 	// defaultSignetServerGRPCHost is the public signet Ark operator gRPC
 	// endpoint.
-	defaultSignetServerGRPCHost = "arkd-signet.staging." +
+	defaultSignetServerGRPCHost = "lumosd-signet.staging." +
 		"lightningcluster.com:443"
 
 	// defaultSignetServerRESTHost is the public signet Ark operator REST
 	// endpoint. The REST client adds the HTTPS scheme when the configured
 	// host is bare.
-	defaultSignetServerRESTHost = "arkd-signet-rest.staging." +
+	defaultSignetServerRESTHost = "lumosd-signet-rest.staging." +
 		"lightningcluster.com"
 
 	// defaultSignetSwapServerGRPCHost is the public signet swap server gRPC

--- a/waved/config.go
+++ b/waved/config.go
@@ -116,7 +116,7 @@ const (
 
 	// DefaultIndexerServerID is the canonical operator identifier used
 	// in signed indexer proofs.
-	DefaultIndexerServerID = "arkd"
+	DefaultIndexerServerID = "lumosd"
 
 	// DefaultRPCTimeout is the default timeout for RPC calls to lnd.
 	DefaultRPCTimeout = 30 * time.Second

--- a/waved/metrics.go
+++ b/waved/metrics.go
@@ -63,7 +63,7 @@ func (s *Server) startMetricsServer(ctx context.Context) error {
 
 	// Spawn a small pool of metrics actors that own all event-driven
 	// counters and register them under one service key, mirroring the
-	// arkd server's design. Lifecycle emission sites Tell through the
+	// lumosd server's design. Lifecycle emission sites Tell through the
 	// sink rather than touching Prometheus directly. The actors are
 	// in-memory (no durable mailbox): a dropped metric event is
 	// acceptable, and the actor system shutdown registered during

--- a/waved/server.go
+++ b/waved/server.go
@@ -153,7 +153,7 @@ const (
 	// remote mailbox IDs can be per-client routing endpoints (for
 	// auto-registration), while proof server ID is a logical operator
 	// identity shared by all clients.
-	indexerProofServerID = "arkd"
+	indexerProofServerID = "lumosd"
 
 	// MethodIncomingOOR is the routing method name for incoming
 	// OOR transfer notifications pushed by the server indexer.

--- a/waved/server_outbound_clients_test.go
+++ b/waved/server_outbound_clients_test.go
@@ -26,10 +26,10 @@ func TestConnectOperatorClientsREST(t *testing.T) {
 	tempDir := t.TempDir()
 	macaroonPath := filepath.Join(tempDir, "operator.macaroon")
 	newTestMacaroonService(
-		t, macaroonPath, "arkd",
+		t, macaroonPath, "lumosd",
 		map[string][]bakery.Op{
 			"/arkrpc.ArkService/GetInfo": {{
-				Entity: "arkd",
+				Entity: "lumosd",
 				Action: "client",
 			}},
 		},


### PR DESCRIPTION
In this PR, we purge the last of the legacy `arkd` daemon name from the
wavelength client. The catch is that `arkd` meant two different things in this
tree, so the rename is two-sided and each side maps to a different name.

Where `arkd` named **this client's own daemon and database** (the daemon has
long been `waved`), we finish the rename to `waved`: the default SQLite file and
Postgres database name, the accounting tool and its docs, and the harness
comments plus the `ArkdLogStdOut` field. For `.gitignore` we drop the stale
`/arkd` entry instead of renaming it to `/waved`, since the daemon now builds to
`./bin/waved` (already covered by `bin/*`) and a root-level `/waved` ignore would
shadow the tracked `waved/` source package.

Where `arkd` named the **separate Ark server operator daemon**, we repoint at
`lumosd`. The server repo (darepo) is being renamed to lumos with a `lumosd`
daemon in parallel, so we flip the public operator gRPC/REST host defaults for
testnet3/testnet4/signet from the `arkd.*` names to `lumosd.*` (leaving the
`swapd.*` swap-server hosts alone, since swapd is a different service), fix the
metrics package prose that mirrors the server's design (including the `arkd_` ->
`lumosd_` namespace mention, while our own client `waved_` namespace stays put),
and update the signet/swap-system docs and the operator-facing macaroon entity
strings in the outbound-clients test.

## Wire-match indexer server ID

The one rename here that carries a compatibility contract gets its own commit:
`DefaultIndexerServerID` and `indexerProofServerID` both go from `"arkd"` to
`"lumosd"`. This is the logical operator identity baked into signed indexer
proofs, compared as an opaque string during verification. The lumos server repo
is changing the same identifier to `"lumosd"` in parallel, so client and server
stay byte-identical on the wire. These host and server-ID changes are also
coordinated with the upcoming lightning-infra deploy PR that stands up the
`lumosd.*` endpoints.

## What stays

Ark the L2 protocol is deliberately untouched: `arkrpc`, `arkscript`, `sdk/ark`,
the `arktest` harness, "Ark rounds", "the Ark operator" (the role), and VTXO all
keep their names. Only the daemon name, the metrics-namespace reference, the
indexer server-ID string, and the operator hostnames change.

See each commit message for a detailed description w.r.t the incremental
changes. Build, lint (`make lint-changed-local`), and the touched package tests
(`db`, `metrics`, `waved`, accounting, `sdk/swaps`) all pass.
