### PR TITLE
wavewalletdk: rename swapdk-server references to swap server

### DIFF
--- a/sdk/wavewalletdk/embedded_config.go
+++ b/sdk/wavewalletdk/embedded_config.go
@@ -78,15 +78,15 @@ type Config struct {
 	// startup.
 	WalletBtcwalletFilterHeadersSource string
 
-	// SwapServerAddress is the swapdk-server address for the selected
+	// SwapServerAddress is the swap server address for the selected
 	// transport. Empty selects the daemon network+transport default.
 	SwapServerAddress string
 
-	// SwapServerTransport selects how the embedded daemon talks to
-	// swapdk-server. Empty defaults to gRPC.
+	// SwapServerTransport selects how the embedded daemon talks to the
+	// swap server. Empty defaults to gRPC.
 	SwapServerTransport Transport
 
-	// SwapServerTLSCertPath pins the swapdk-server TLS certificate.
+	// SwapServerTLSCertPath pins the swap server TLS certificate.
 	SwapServerTLSCertPath string
 
 	// SwapServerInsecure disables TLS for the swap server connection.


### PR DESCRIPTION
## Summary

Minor follow-up to #944. The `Config` field doc comments in `wavewalletdk` are surfaced on the API docs site via the `wavelength-sdk` repo, so this swaps the internal "swapdk-server" naming for the user-facing "swap server" in those comments.

These were caught in a sweep of the `wavelength-sdk` repo for renamed terms. Only the comments that flow into that repo were touched here. Other `swapdk` references in the codebase are left as-is to limit scope to the bare minimum needed.

## Changes

- Reword the `SwapServer*` field doc comments in `sdk/wavewalletdk/embedded_config.go` to say "swap server" instead of "swapdk-server".

## Testing

Comment-only change, no behavior affected.
