### PR TITLE
swapwallet: preserve credit-owned activity context

### DIFF
--- a/db/activity_store.go
+++ b/db/activity_store.go
@@ -316,9 +316,8 @@ func (s *ActivityPersistenceStore) PullEvents(ctx context.Context, cursor int64,
 // changesRow reports whether the projection would alter the current-state row
 // e, i.e. whether it represents a genuine lifecycle transition. It mirrors the
 // UpsertActivityEntry semantics: scalar lifecycle columns overwrite directly,
-// while the settlement/correlation handles are COALESCEd (a nil projection
-// value preserves the stored one, so it is a change only when non-nil AND
-// different). request_json and entry_json are deliberately NOT compared:
+// while an empty note and the settlement/correlation handles preserve their
+// stored values. request_json and entry_json are deliberately NOT compared:
 // protojson output is not byte-stable, so comparing it would report spurious
 // changes; the request is immutable per operation anyway.
 func (p ActivityProjection) changesRow(e sqlc.ActivityEntry) bool {
@@ -327,12 +326,14 @@ func (p ActivityProjection) changesRow(e sqlc.ActivityEntry) bool {
 		p.AmountSat != e.AmountSat ||
 		p.FeeSat != e.FeeSat ||
 		p.Counterparty != e.Counterparty ||
-		p.Note != e.Note ||
 		p.Phase != e.Phase ||
 		p.PhaseLabel != e.PhaseLabel ||
 		p.FailureCode != e.FailureCode ||
 		p.FailureReason != e.FailureReason ||
 		p.VtxoOutpoint != e.VtxoOutpoint {
+		return true
+	}
+	if p.Note != "" && p.Note != e.Note {
 		return true
 	}
 

--- a/db/activity_store_test.go
+++ b/db/activity_store_test.go
@@ -51,6 +51,7 @@ func sampleProjection(id string) ActivityProjection {
 			0xbb,
 			0xcc,
 		},
+		RequestJSON:   `{"lightningInvoice":{"invoice":"lnbc1"}}`,
 		EntryJSON:     `{"id":"` + id + `"}`,
 		CreatedAtUnix: 100,
 		UpdatedAtUnix: 100,
@@ -192,6 +193,8 @@ func TestActivityStoreReProjectUpdatesInPlace(t *testing.T) {
 	next.CreatedAtUnix = 0
 	next.PaymentHash = nil
 	next.Txid = []byte{0x11, 0x22}
+	next.Note = ""
+	next.RequestJSON = ""
 	require.NoError(t, projected(store.ProjectEntry(ctx, next)))
 
 	entry, err := store.GetEntry(ctx, "a")
@@ -207,6 +210,11 @@ func TestActivityStoreReProjectUpdatesInPlace(t *testing.T) {
 		"nil payment hash must not clobber the stored value",
 	)
 	require.Equal(t, []byte{0x11, 0x22}, entry.Txid)
+	require.Equal(t, "note", entry.Note)
+	require.Equal(
+		t, `{"lightningInvoice":{"invoice":"lnbc1"}}`,
+		entry.RequestJson,
+	)
 
 	events, err := store.PullEvents(ctx, 0, 10)
 	require.NoError(t, err)

--- a/db/sqlc/activity_log.sql.go
+++ b/db/sqlc/activity_log.sql.go
@@ -296,7 +296,7 @@ ON CONFLICT (canonical_id) DO UPDATE SET
     amount_sat     = EXCLUDED.amount_sat,
     fee_sat        = EXCLUDED.fee_sat,
     counterparty   = EXCLUDED.counterparty,
-    note           = EXCLUDED.note,
+    note           = COALESCE(NULLIF(EXCLUDED.note, ''), activity_entries.note),
     phase          = EXCLUDED.phase,
     phase_label    = EXCLUDED.phase_label,
     failure_code   = EXCLUDED.failure_code,
@@ -308,7 +308,7 @@ ON CONFLICT (canonical_id) DO UPDATE SET
     swap_session_id = COALESCE(EXCLUDED.swap_session_id, activity_entries.swap_session_id),
     ledger_txid     = COALESCE(EXCLUDED.ledger_txid, activity_entries.ledger_txid),
     boarding_addr   = COALESCE(EXCLUDED.boarding_addr, activity_entries.boarding_addr),
-    request_json    = EXCLUDED.request_json,
+    request_json    = COALESCE(NULLIF(EXCLUDED.request_json, ''), activity_entries.request_json),
     updated_at_unix = EXCLUDED.updated_at_unix
 `
 

--- a/db/sqlc/queries/activity_log.sql
+++ b/db/sqlc/queries/activity_log.sql
@@ -28,7 +28,7 @@ ON CONFLICT (canonical_id) DO UPDATE SET
     amount_sat     = EXCLUDED.amount_sat,
     fee_sat        = EXCLUDED.fee_sat,
     counterparty   = EXCLUDED.counterparty,
-    note           = EXCLUDED.note,
+    note           = COALESCE(NULLIF(EXCLUDED.note, ''), activity_entries.note),
     phase          = EXCLUDED.phase,
     phase_label    = EXCLUDED.phase_label,
     failure_code   = EXCLUDED.failure_code,
@@ -40,7 +40,7 @@ ON CONFLICT (canonical_id) DO UPDATE SET
     swap_session_id = COALESCE(EXCLUDED.swap_session_id, activity_entries.swap_session_id),
     ledger_txid     = COALESCE(EXCLUDED.ledger_txid, activity_entries.ledger_txid),
     boarding_addr   = COALESCE(EXCLUDED.boarding_addr, activity_entries.boarding_addr),
-    request_json    = EXCLUDED.request_json,
+    request_json    = COALESCE(NULLIF(EXCLUDED.request_json, ''), activity_entries.request_json),
     updated_at_unix = EXCLUDED.updated_at_unix;
 
 -- name: AppendActivityEvent :one

--- a/swapwallet/credit_projector.go
+++ b/swapwallet/credit_projector.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/lightninglabs/wavelength/credit"
+	"github.com/lightninglabs/wavelength/rpc/swapclientrpc"
 	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
 )
 
@@ -24,6 +25,17 @@ const creditProjectInterval = 5 * time.Second
 // credit-backed rows, matching the pending entries the router and receiver
 // emit so the projected terminal update lands on the same row.
 const creditCounterparty = "credit"
+
+// creditProjectorOwnsSwapSummary reports whether the durable credit operation,
+// rather than the generic swap monitor or history reconciler, owns a swap's
+// wallet activity row. Credit-only SDK swaps persist a zero Ark funding amount,
+// while the credit operation retains the invoice principal. The server emits
+// CREDIT only for a fully credit-funded invoice; partial credit funding emits
+// MIXED and remains owned by the generic swap lifecycle.
+func creditProjectorOwnsSwapSummary(summary *swapclientrpc.SwapSummary) bool {
+	return summary != nil && summary.GetSettlementType() == swapclientrpc.
+		SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT
+}
 
 // startCreditProjectorLoop spawns the background goroutine that projects
 // durable credit-operation terminal state onto wallet rows. It is a no-op when

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -607,6 +607,15 @@ func (h *history) collectSwapEntries(ctx context.Context) (
 
 	out := make([]*wavewalletrpc.WalletEntry, 0, len(resp.GetSwaps()))
 	for _, s := range resp.GetSwaps() {
+		// A credit-only pay's SDK swap row records a zero Ark funding
+		// amount. Its durable credit operation owns the activity row
+		// and retains the invoice principal, so derived history must
+		// not race that projector during startup backfill or periodic
+		// reconcile.
+		if creditProjectorOwnsSwapSummary(s) {
+			continue
+		}
+
 		// The wallet layer does not surface vHTLC outpoints or
 		// session IDs; counterparty for swaps is the payment hash
 		// (truncated). History lists swaps in both directions; let

--- a/swapwallet/monitor.go
+++ b/swapwallet/monitor.go
@@ -179,6 +179,17 @@ func (r *Runtime) fanOutSwapUpdate(
 		return nil
 	}
 
+	// Credit-only pays also have a durable SDK swap row, but that row's
+	// amount is the Ark funding amount, which is zero when credits cover
+	// the full invoice. The durable credit operation owns the wallet
+	// activity lifecycle for this rail and retains the invoice principal.
+	// Letting the generic swap monitor project the SDK row would race the
+	// credit projector and temporarily overwrite a one-satoshi SEND with a
+	// zero-satoshi terminal row.
+	if creditProjectorOwnsSwapSummary(summary) {
+		return nil
+	}
+
 	// The monitor consumes summaries for swaps in both directions, so we
 	// let direction-derivation pick the kind here (callers that need a
 	// pinned kind — router.sendInvoice and recv.go — pass it explicitly).

--- a/swapwallet/monitor_test.go
+++ b/swapwallet/monitor_test.go
@@ -100,6 +100,36 @@ func TestMonitorLoopFansOutSwapUpdates(t *testing.T) {
 	)
 }
 
+// TestMonitorLoopSkipsCreditOnlySwaps asserts that a completed credit-only
+// SDK swap row cannot overwrite the activity row owned by the durable credit
+// projector. The SDK row records Ark funding amount, which is zero for a
+// fully credit-funded payment, while the credit operation retains the invoice
+// principal used by wallet activity.
+func TestMonitorLoopSkipsCreditOnlySwaps(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeActivityProjector{}
+	r := newRuntime(t.Context(), &Deps{ActivityStore: store})
+	defer r.stop()
+
+	sub := r.subscribe()
+	err := r.fanOutSwapUpdate(&swapclientrpc.SubscribeSwapsResponse{
+		Swap: &swapclientrpc.SwapSummary{
+			PaymentHash: "credit-only",
+			Direction: swapclientrpc.
+				SwapDirection_SWAP_DIRECTION_PAY,
+			State: swapclientrpc.
+				SwapState_SWAP_STATE_COMPLETED,
+			AmountSat: 0,
+			SettlementType: swapclientrpc.
+				SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT,
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, drainEntries(sub))
+	require.Zero(t, store.count())
+}
+
 // TestMonitorLoopLeavesSwapPendingToFSM confirms a swap row fanned out from
 // the monitor reaches subscribers under its payment_hash id, but is not aged by
 // the wallet-level deadline tracker even before its direction is populated.

--- a/swapwallet/reconciler_test.go
+++ b/swapwallet/reconciler_test.go
@@ -176,6 +176,54 @@ func TestReconcileProjectsRawOORLive(t *testing.T) {
 	)
 }
 
+// TestReconcileSkipsCreditOnlySwapRows asserts the periodic SEND/RECV
+// reconciler cannot overwrite a credit-projector-owned activity row with the
+// credit SDK swap's zero Ark funding amount.
+func TestReconcileSkipsCreditOnlySwapRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtime, store, _ := newReconcileFixture(t)
+	swap := runtime.deps.SwapService.(*fakeSwapService)
+
+	const paymentHash = "credit-payment-hash"
+	runtime.project(ctx, &wavewalletrpc.WalletEntry{
+		Id:            paymentHash,
+		Kind:          wavewalletrpc.EntryKind_ENTRY_KIND_SEND,
+		Status:        wavewalletrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		AmountSat:     -1,
+		Counterparty:  creditCounterparty,
+		CreatedAtUnix: 100,
+		UpdatedAtUnix: 100,
+		Progress: &wavewalletrpc.WalletEntryProgress{
+			Phase: wavewalletrpc.
+				WalletEntryPhase_WALLET_ENTRY_PHASE_CONFIRMED,
+		},
+	})
+
+	swap.listSwapsResp = &swapclientrpc.ListSwapsResponse{
+		Swaps: []*swapclientrpc.SwapSummary{
+			{
+				PaymentHash: paymentHash,
+				Direction: swapclientrpc.
+					SwapDirection_SWAP_DIRECTION_PAY,
+				State: swapclientrpc.
+					SwapState_SWAP_STATE_COMPLETED,
+				AmountSat: 0,
+				SettlementType: swapclientrpc.
+					SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT,
+			},
+		},
+	}
+
+	runtime.reconcileActivity(ctx)
+
+	entry, err := store.GetEntry(ctx, paymentHash)
+	require.NoError(t, err)
+	require.Equal(t, int64(-1), entry.AmountSat)
+	require.Equal(t, creditCounterparty, entry.Counterparty)
+}
+
 // TestReprojectRecentActivityBoundsWindow verifies the raw-OOR reconcile pass
 // projects only the most recent `limit` rows and skips older ones, so the
 // per-pass ProjectEntry work stays bounded at O(limit) rather than scanning the

--- a/swapwallet/recv.go
+++ b/swapwallet/recv.go
@@ -196,6 +196,8 @@ func (r *receiver) recvCredit(ctx context.Context,
 	entry := creditReceiveEntry(
 		req, start.OpID, start.Invoice, paymentHashHex, amt,
 	)
+	r.runtime.trackPendingEntryWithoutTimeout(entry)
+	r.runtime.projectAndEmit(context.WithoutCancel(ctx), entry)
 
 	return &wavewalletrpc.RecvResponse{
 		Invoice: start.Invoice,

--- a/swapwallet/recv_test.go
+++ b/swapwallet/recv_test.go
@@ -143,6 +143,7 @@ func TestRecvBelowDustHandsToCreditRegistry(t *testing.T) {
 		SwapService:    swap,
 		RPCServer:      rpc,
 		CreditRegistry: reg,
+		ActivityStore:  &fakeActivityProjector{},
 	}
 	runtime := newRuntime(t.Context(), deps)
 	t.Cleanup(runtime.stop)
@@ -179,6 +180,14 @@ func TestRecvBelowDustHandsToCreditRegistry(t *testing.T) {
 			WalletEntryPhase_WALLET_ENTRY_PHASE_WAITING_FOR_PAYMENT,
 		resp.GetEntry().GetProgress().GetPhase(),
 	)
+	store := deps.ActivityStore.(*fakeActivityProjector)
+	require.Equal(t, 1, store.count())
+	projection := store.lastProjection()
+	require.Equal(t, "cr_recv", projection.CanonicalID)
+	require.Equal(t, int64(500), projection.AmountSat)
+	require.Equal(t, "tiny", projection.Note)
+	require.NotEmpty(t, projection.RequestJSON)
+	require.Equal(t, []byte{0xab, 0xcd}, projection.PaymentHash)
 }
 
 // TestRecvDustLimitLookupFailureFallsBackOpen asserts that advisory dust

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -504,6 +504,7 @@ func TestRouterSendInvoiceHandsCreditPayToRegistry(t *testing.T) {
 	require.Equal(t, uint64(1_000), reg.lastPay.TopupSat)
 	require.Equal(t, invoice, reg.lastPay.Invoice)
 	require.Equal(t, uint64(500_000), reg.lastPay.MaxCreditSat)
+	require.True(t, reg.lastPay.CreditOnly)
 
 	// The router no longer drives the top-up or pay inline.
 	require.Zero(t, swap.createCreditCalls)


### PR DESCRIPTION
## Summary

Preserve accurate wallet activity for fully credit-funded payments and credit
receives.

This is the client-side companion to
[swapdk-server #228](https://github.com/lightninglabs/swapdk-server/pull/228),
which settles invoices owned by the same swap server directly in its credit
ledger.

## Production symptom

During a manual one-satoshi credit payment, the wallet initially projected the
correct completed activity:

```text
KIND  STATUS    AMOUNT  FEE  PHASE
SEND  COMPLETE  -1      0    confirmed
```

The generic SDK swap row records Ark funding rather than invoice principal.
For a fully credit-funded payment that amount is zero. The live swap monitor,
and independently the periodic history reconciler, could therefore replace
the correct credit-owned row with a zero-value terminal row.

Credit receives had a second context problem. `Receive` returned a rich
pending entry, but did not project it before terminal credit state arrived.
The completed row could consequently lose the receive memo, original invoice
request, and payment hash.

## Implementation

### Preserve credit activity ownership

Credit-only swap summaries are now recognized by their settlement type. The
generic swap monitor and derived-history reconciliation both skip these rows,
leaving the durable credit projector as the sole owner of their wallet
activity lifecycle.

This avoids both observed races:

- an immediate overwrite from the live swap subscription; and
- a delayed overwrite from the periodic reconciliation loop.

### Persist receive context

A newly created credit receive is now tracked and projected immediately. This
persists its operation ID, positive amount, memo, invoice request, and payment
hash before the asynchronous terminal update.

Terminal projections do not need to repeat immutable request context. Activity
upserts therefore retain the stored note and request when an update supplies
an empty value. The in-memory change detector mirrors the SQL upsert semantics
so it does not emit a false lifecycle change.

## Commit structure

1. `swapwallet: preserve credit activity ownership`
   protects live monitoring and periodic reconciliation.
2. `swapwallet: persist credit receive context`
   projects pending receives and preserves immutable context.

Each commit is independently focused and carries its corresponding regression
coverage.

## Validation

- `make sqlc-check`
- `make unit tags='swapruntime wavewalletrpc'`
- `make lint-local`
- focused monitor, reconciler, receive, and activity-store tests
- swapdk-server `TestWaveWalletDKOneSatCreditPaymentMatrix`

The server integration matrix gives Alice and Bob one external Lightning
receive each, runs two one-satoshi internal transfers in each direction, then
has both users pay an external one-satoshi Lightning invoice. It verifies
terminal status, signed amounts, fees, receive memo, invoice request, and
payment hash.

## Dependency

The code is useful independently as activity-projection hardening, but the
end-to-end same-server payment path is introduced by swapdk-server #228. That
PR should update its client gitlink to the merge commit from this PR before it
merges.
