### PR TITLE
swapclientserver: scope reconnect waiting

### DIFF
--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -30,6 +30,7 @@ import (
 	sdkark "github.com/lightninglabs/wavelength/sdk/ark"
 	"github.com/lightninglabs/wavelength/sdk/swaps"
 	"github.com/lightninglabs/wavelength/serverconn"
+	"github.com/lightninglabs/wavelength/swaprpc"
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightninglabs/wavelength/waved"
 	"github.com/lightningnetwork/lnd/invoices"
@@ -872,14 +873,11 @@ func (d *daemonAuthOnlyInvoiceCreator) CreateInvoiceWithKeyRouteHintPaths(
 func swapServerDialOptions(cfg *waved.SwapConfig, addr string,
 	clientCerts clientTLSCertProvider) ([]grpc.DialOption, error) {
 
-	// The daemon may start before its configured swap server listener is
-	// accepting connections. WaitForReady prevents that stale startup
-	// refusal from failing the first swap RPC; user RPCs remain bounded by
-	// their request context, and background resume RPCs are bounded by the
-	// daemon root context so they keep waiting until swapd returns or the
-	// daemon shuts down.
-	waitForReadyOpt := grpc.WithDefaultCallOptions(
-		grpc.WaitForReady(true),
+	// Swap operations wait for the configured server to reconnect, while
+	// best-effort reads fail fast so they cannot consume an enclosing
+	// wallet RPC's entire deadline.
+	waitForReadyInterceptorOpt := grpc.WithChainUnaryInterceptor(
+		swapServerWaitForReadyInterceptor,
 	)
 
 	switch {
@@ -895,7 +893,7 @@ func swapServerDialOptions(cfg *waved.SwapConfig, addr string,
 			grpc.WithTransportCredentials(
 				credentials.NewTLS(tlsCfg),
 			),
-			waitForReadyOpt,
+			waitForReadyInterceptorOpt,
 		}, nil
 
 	case useInsecureSwapServerTransport(cfg, addr):
@@ -903,7 +901,7 @@ func swapServerDialOptions(cfg *waved.SwapConfig, addr string,
 			grpc.WithTransportCredentials(
 				insecure.NewCredentials(),
 			),
-			waitForReadyOpt,
+			waitForReadyInterceptorOpt,
 		}, nil
 
 	default:
@@ -918,8 +916,46 @@ func swapServerDialOptions(cfg *waved.SwapConfig, addr string,
 			grpc.WithTransportCredentials(
 				credentials.NewTLS(tlsCfg),
 			),
-			waitForReadyOpt,
+			waitForReadyInterceptorOpt,
 		}, nil
+	}
+}
+
+// swapServerWaitForReadyInterceptor applies reconnect waiting only to swap
+// operations that create or advance protocol state. User operations remain
+// bounded by their request context, while background resume operations remain
+// bounded by the daemon root context. Read-only quotes and credit snapshots
+// retain gRPC's fail-fast behavior.
+func swapServerWaitForReadyInterceptor(ctx context.Context, method string, req,
+	reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption) error {
+
+	if swapServerOperationWaitsForReady(method) {
+		opts = append(opts, grpc.WaitForReady(true))
+	}
+
+	return invoker(ctx, method, req, reply, cc, opts...)
+}
+
+// swapServerOperationWaitsForReady reports whether an unavailable swap server
+// should delay the RPC until the caller's context expires or the server
+// reconnects.
+func swapServerOperationWaitsForReady(method string) bool {
+	switch method {
+	case swaprpc.SwapService_RequestChannelId_FullMethodName,
+		swaprpc.SwapService_CreateInSwap_FullMethodName,
+		swaprpc.SwapService_CreateCredit_FullMethodName,
+		swaprpc.SwapService_RedeemCredit_FullMethodName,
+		swaprpc.SwapService_AuthorizeInSwapRefund_FullMethodName,
+		swaprpc.SwapService_AcknowledgeOutSwapHtlc_FullMethodName,
+		swaprpc.SwapService_SignInSwapForfeit_FullMethodName,
+		swaprpc.SwapService_SubmitOutSwapForfeitSignature_FullMethodName:
+		return true
+
+	default:
+		// Future RPCs fail fast until their retry and recovery
+		// semantics are explicitly classified above.
+		return false
 	}
 }
 

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -1104,6 +1104,127 @@ func TestSwapServerClientsWaitForLateGRPCServer(t *testing.T) {
 	}
 }
 
+// TestSwapServerClientsBestEffortReadsFailFast verifies optional read-only
+// calls do not consume their parent wallet RPC's deadline while swapd is
+// unavailable.
+func TestSwapServerClientsBestEffortReadsFailFast(t *testing.T) {
+	t.Parallel()
+
+	addr := reserveLoopbackAddr(t)
+	clients, err := newSwapServerClients(
+		&waved.SwapConfig{
+			ServerTransport: waved.RPCTransportGRPC,
+			ServerInsecure:  true,
+		},
+		addr, func(context.Context, string) (string, error) {
+			return "auth", nil
+		}, nil,
+	)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, clients.cleanup())
+	}()
+
+	creditClient, ok := clients.server.(interface {
+		ListCredits(context.Context, []byte,
+			uint32) (*swaps.CreditSnapshot, error)
+	})
+	require.True(t, ok)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	_, err = creditClient.ListCredits(ctx, []byte{1, 2, 3}, 10)
+	require.Error(t, err)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+	require.NoError(t, ctx.Err())
+}
+
+// TestSwapServerOperationWaitsForReady verifies the reconnect policy includes
+// protocol operations while excluding read-only and unrelated RPCs.
+func TestSwapServerOperationWaitsForReady(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		method string
+		wait   bool
+	}{
+		{
+			name: "request channel ID",
+			method: swaprpc.
+				SwapService_RequestChannelId_FullMethodName,
+			wait: true,
+		},
+		{
+			name:   "create in swap",
+			method: swaprpc.SwapService_CreateInSwap_FullMethodName,
+			wait:   true,
+		},
+		{
+			name:   "create credit",
+			method: swaprpc.SwapService_CreateCredit_FullMethodName,
+			wait:   true,
+		},
+		{
+			name:   "redeem credit",
+			method: swaprpc.SwapService_RedeemCredit_FullMethodName,
+			wait:   true,
+		},
+		{
+			name: "authorize refund",
+			method: swaprpc.
+				SwapService_AuthorizeInSwapRefund_FullMethodName,
+			wait: true,
+		},
+		{
+			name: "acknowledge out swap",
+			method: swaprpc.
+				SwapService_AcknowledgeOutSwapHtlc_FullMethodName,
+			wait: true,
+		},
+		{
+			name: "sign in swap forfeit",
+			method: swaprpc.
+				SwapService_SignInSwapForfeit_FullMethodName,
+			wait: true,
+		},
+		{
+			name: "submit out swap forfeit",
+			method: swaprpc.
+				SwapService_SubmitOutSwapForfeitSignature_FullMethodName,
+			wait: true,
+		},
+		{
+			name:   "quote in swap",
+			method: swaprpc.SwapService_QuoteInSwap_FullMethodName,
+		},
+		{
+			name:   "list credits",
+			method: swaprpc.SwapService_ListCredits_FullMethodName,
+		},
+		{
+			name:   "mailbox",
+			method: "/mailboxrpc.MailboxService/Pull",
+		},
+		{
+			name:   "future swap method",
+			method: "/swaprpc.SwapService/FutureOperation",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(
+				t, testCase.wait,
+				swapServerOperationWaitsForReady(
+					testCase.method,
+				),
+			)
+		})
+	}
+}
+
 // reserveLoopbackAddr returns an unused TCP address and closes its temporary
 // listener so the test client can observe a connection refusal.
 func reserveLoopbackAddr(t *testing.T) string {


### PR DESCRIPTION
## Problem

The daemon configures one gRPC channel for swapd. PR #949 made that entire channel use `WaitForReady(true)` so a state-changing swap RPC can survive swapd starting or reconnecting after the daemon.

That channel-wide policy also changed optional read-only calls. In particular, `swapwallet.Service.fetchBalance` first obtains the Ark balance and then calls `ListCredits` as an optional enrichment. The wallet deliberately ignores a failed credit read and can return the Ark balance alone. With the global wait-for-ready option, however, an unavailable swapd makes `ListCredits` consume the parent request's full deadline. The already-computed balance can no longer be returned because the wallet RPC context has expired.

This surfaced in swapdk-server PR #228 as `TestWalletBalanceSurfacesUnilateralExit` failing its first balance request with `DeadlineExceeded`.

## Changes

- Replace the channel-wide default call option with a unary client interceptor.
- Apply wait-for-ready to RPCs that create or advance swap and credit protocol state.
- Keep `QuoteInSwap`, `ListCredits`, mailbox calls, and unknown methods fail-fast.
- Preserve the reconnect behavior from #949 for `CreateInSwap` and the other durable protocol operations.

## Policy

Wait for swapd to become ready:

- `RequestChannelId`
- `CreateInSwap`
- `CreateCredit`
- `RedeemCredit`
- `AuthorizeInSwapRefund`
- `AcknowledgeOutSwapHtlc`
- `SignInSwapForfeit`
- `SubmitOutSwapForfeitSignature`

Fail fast when swapd is unavailable:

- `QuoteInSwap`
- `ListCredits`
- mailbox RPCs
- unknown future RPCs, until their retry semantics are chosen explicitly

## Tests

- Added an unavailable-server regression proving `ListCredits` returns `Unavailable` before its context expires.
- Added a table test that locks down the method-level reconnect policy.
- Preserved and reran the #949 regression proving `CreateInSwap` waits through a late server start.
- Reran the exact downstream failure against swapdk-server PR #228:

  `TestWalletBalanceSurfacesUnilateralExit` passed in 37.2 seconds.

- `go test -tags='swapruntime' ./swapclientserver -count=1`
- `make fmt-changed-check base=origin/main`
- `make lint-local`
- `make commitmsg-lint range=origin/main..HEAD`

Fixes #951.
