### PR TITLE
multi: Schedule auto refreshes in free window

### DIFF
--- a/arkrpc/ark.pb.go
+++ b/arkrpc/ark.pb.go
@@ -248,8 +248,11 @@ type GetInfoResponse struct {
 	// entries are the operator's enabled, selectable versions; DISABLED
 	// entries are advertised only so clients learn a version was retired.
 	ArkVersionPolicies []*ArkVersionPolicy `protobuf:"bytes,22,rep,name=ark_version_policies,json=arkVersionPolicies,proto3" json:"ark_version_policies,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// The number of blocks before batch expiry in which a pure refresh
+	// qualifies for a complete fee waiver. Zero disables the waiver.
+	FreeRefreshWindowBlocks uint32 `protobuf:"varint,23,opt,name=free_refresh_window_blocks,json=freeRefreshWindowBlocks,proto3" json:"free_refresh_window_blocks,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *GetInfoResponse) Reset() {
@@ -413,6 +416,13 @@ func (x *GetInfoResponse) GetArkVersionPolicies() []*ArkVersionPolicy {
 		return x.ArkVersionPolicies
 	}
 	return nil
+}
+
+func (x *GetInfoResponse) GetFreeRefreshWindowBlocks() uint32 {
+	if x != nil {
+		return x.FreeRefreshWindowBlocks
+	}
+	return 0
 }
 
 // EstimateFeeRequest asks the server to estimate the fee for a
@@ -601,7 +611,7 @@ const file_ark_proto_rawDesc = "" +
 	"\x05State\x12\x15\n" +
 	"\x11STATE_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fSTATE_ACTIVE\x10\x01\x12\x12\n" +
-	"\x0eSTATE_DISABLED\x10\x02\"\x96\x06\n" +
+	"\x0eSTATE_DISABLED\x10\x02\"\xd3\x06\n" +
 	"\x0fGetInfoResponse\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x16\n" +
 	"\x06pubkey\x18\x02 \x01(\fR\x06pubkey\x12\x18\n" +
@@ -624,7 +634,8 @@ const file_ark_proto_rawDesc = "" +
 	"\x13min_vtxo_amount_sat\x18\x13 \x01(\x03R\x10minVtxoAmountSat\x12(\n" +
 	"\x10max_user_balance\x18\x14 \x01(\x03R\x0emaxUserBalance\x120\n" +
 	"\x14selected_ark_version\x18\x15 \x01(\rR\x12selectedArkVersion\x12J\n" +
-	"\x14ark_version_policies\x18\x16 \x03(\v2\x18.arkrpc.ArkVersionPolicyR\x12arkVersionPolicies\"\x7f\n" +
+	"\x14ark_version_policies\x18\x16 \x03(\v2\x18.arkrpc.ArkVersionPolicyR\x12arkVersionPolicies\x12;\n" +
+	"\x1afree_refresh_window_blocks\x18\x17 \x01(\rR\x17freeRefreshWindowBlocks\"\x7f\n" +
 	"\x12EstimateFeeRequest\x12\x1d\n" +
 	"\n" +
 	"amount_sat\x18\x01 \x01(\x03R\tamountSat\x12\x1f\n" +

--- a/arkrpc/ark.proto
+++ b/arkrpc/ark.proto
@@ -135,6 +135,10 @@ message GetInfoResponse {
     // entries are the operator's enabled, selectable versions; DISABLED
     // entries are advertised only so clients learn a version was retired.
     repeated ArkVersionPolicy ark_version_policies = 22;
+
+    // The number of blocks before batch expiry in which a pure refresh
+    // qualifies for a complete fee waiver. Zero disables the waiver.
+    uint32 free_refresh_window_blocks = 23;
 }
 
 // EstimateFeeRequest asks the server to estimate the fee for a

--- a/arkrpc/version_compat_test.go
+++ b/arkrpc/version_compat_test.go
@@ -67,6 +67,7 @@ func TestGetInfoResponseOldShapeDecodesZero(t *testing.T) {
 	// old shape never set them.
 	require.Zero(t, decoded.SelectedArkVersion)
 	require.Empty(t, decoded.ArkVersionPolicies)
+	require.Zero(t, decoded.FreeRefreshWindowBlocks)
 }
 
 // TestGetInfoVersionFieldsRoundTrip proves that the new versioning fields are
@@ -99,8 +100,9 @@ func TestGetInfoVersionFieldsRoundTrip(t *testing.T) {
 	}
 
 	resp := &GetInfoResponse{
-		Version:            "1.0.0",
-		SelectedArkVersion: 2,
+		Version:                 "1.0.0",
+		SelectedArkVersion:      2,
+		FreeRefreshWindowBlocks: 72,
 		ArkVersionPolicies: []*ArkVersionPolicy{
 			v1Policy,
 			v2Policy,
@@ -114,6 +116,9 @@ func TestGetInfoVersionFieldsRoundTrip(t *testing.T) {
 	require.NoError(t, proto.Unmarshal(respRaw, respDecoded))
 
 	require.Equal(t, uint32(2), respDecoded.SelectedArkVersion)
+	require.Equal(
+		t, uint32(72), respDecoded.FreeRefreshWindowBlocks,
+	)
 	require.Len(t, respDecoded.ArkVersionPolicies, 2)
 
 	first := respDecoded.ArkVersionPolicies[0]

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -394,7 +394,9 @@ keeps its normal earlier threshold and pays the quoted fee instead of weakening
 unilateral-exit safety. VTXOs that cross a safe boundary in the same block are
 coalesced into one automatic round registration.
 The daemon learns the window from its cached operator terms at bootstrap (and
-on later terms refreshes); an operator fee-schedule hot reload is not pushed to
+on later terms refreshes). When the cached boundary fires, it fetches a fresh
+`GetInfo` snapshot and rechecks the current window before reserving the VTXO.
+An operator fee-schedule hot reload is not pushed proactively to
 already-connected wallets.
 
 | Flag | Type | Description |

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -387,6 +387,16 @@ round immediately. Pass `--no_join` to leave the intent queued in
 `PendingRoundAssembly` so it can batch with subsequent refresh / leave
 RPCs; commit the batch later with `ark rounds join`.
 
+Automatic expiry handling delays to the advertised window boundary when doing
+so preserves the wallet's dynamic critical threshold and minimum cooperative
+retry buffer. If the operator configures a narrower, later window, the wallet
+keeps its normal earlier threshold and pays the quoted fee instead of weakening
+unilateral-exit safety. VTXOs that cross a safe boundary in the same block are
+coalesced into one automatic round registration.
+The daemon learns the window from its cached operator terms at bootstrap (and
+on later terms refreshes); an operator fee-schedule hot reload is not pushed to
+already-connected wallets.
+
 | Flag | Type | Description |
 |------|------|-------------|
 | `--outpoint` | string[] | VTXO outpoint(s) to refresh (txid:index) |

--- a/lib/types/AGENTS.md
+++ b/lib/types/AGENTS.md
@@ -29,7 +29,13 @@ server during round participation. These types are used across `round`, `vtxo`,
   `OperatorKey`, and `ExitDelay`. `TxProof fn.Option[proof.TxProof]` carries
   an optional SPV merkle inclusion proof for server-side verification of
   boarding UTXOs without requiring the server's own chain source.
-- `OperatorTerms` — Server-published round parameters (fee rates, expiry config, connector dust amount). `MaxOORLineageVBytes uint32` carries the operator-published cap on the cumulative on-chain vbytes a recipient must publish to claim a VTXO produced by an OOR submit unilaterally. Zero means no cap enforced server-side (clients fall back to a conservative local default).
+- `OperatorTerms` — Server-published round parameters (fee rates, expiry
+  config, connector dust amount). `FreeRefreshWindowBlocks uint32` advertises
+  the optional late-refresh fee-waiver window.
+  `MaxOORLineageVBytes uint32` carries the operator-published
+  cap on the cumulative on-chain vbytes a recipient must publish to claim a
+  VTXO produced by an OOR submit unilaterally. Zero means no cap enforced
+  server-side (clients fall back to a conservative local default).
 - `Ancestry` — One rooted commitment-tree fragment contributing ancestry to a VTXO (defined in `lib/types/ancestry.go`). Fields: `TreePath *tree.Tree` (extracted root-to-leaf path), `CommitmentTxID chainhash.Hash`, `InputIndices []uint32` (Ark tx input indices this fragment serves; empty for round-direct VTXOs), `TreeDepth uint32`. Round-direct VTXOs carry a single-element slice; cross-round multi-input OOR VTXOs carry one entry per distinct commitment tx.
 - `MaxAncestryTreeDepth([]Ancestry) int` — Returns the largest `TreeDepth` across a slice; drives worst-case unilateral-exit timing calculations.
 - `ClientBatchInfo` — Client's view of batch output info after tree construction.

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -71,6 +71,11 @@ type OperatorTerms struct {
 	// total input value and total output value.
 	MinOperatorFee btcutil.Amount
 
+	// FreeRefreshWindowBlocks is the number of blocks before batch expiry
+	// in which a pure refresh qualifies for a complete fee waiver. Zero
+	// disables the policy.
+	FreeRefreshWindowBlocks uint32
+
 	// MinConfirmations is the minimum confs required on boarding inputs.
 	MinConfirmations uint32
 

--- a/sdk/ark/AGENTS.md
+++ b/sdk/ark/AGENTS.md
@@ -67,8 +67,9 @@ transport, without duplicating Ark runtime behavior.
 - `WrapDaemonServer` owns only the private bufconn transport and gRPC
   server; it does not own the caller's `DaemonServer` runtime. `Close()`
   tears down only the private transport.
-- `ServerInfo` is a bootstrap-time operator-terms snapshot; refresh after
-  reconnect is not wired through yet.
+- `ServerInfo` is a bootstrap-time operator-terms snapshot, including the
+  advisory `FreeRefreshWindowBlocks`; refresh after reconnect is not wired
+  through yet.
 - Pre-1.0, some methods intentionally return `waverpc` protobuf types
   directly. Those passthrough APIs are not yet treated as stable SDK-owned
   models.

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -154,6 +154,10 @@ type ServerInfo struct {
 	// MinOperatorFee is the minimum operator fee in satoshis.
 	MinOperatorFee uint64
 
+	// FreeRefreshWindowBlocks is the operator-advertised late-lifetime
+	// window in which pure refreshes receive a fee waiver.
+	FreeRefreshWindowBlocks uint32
+
 	// MinConfirmations is the minimum confirmations required on boarding
 	// inputs.
 	MinConfirmations uint32
@@ -448,20 +452,23 @@ func (c *Client) GetInfo(ctx context.Context) (*Info, error) {
 	}
 
 	if resp.ServerInfo != nil {
+		serverInfo := resp.ServerInfo
+		freeRefreshWindow := serverInfo.FreeRefreshWindowBlocks
 		info.ServerInfo = &ServerInfo{
 			OperatorPubKey: bytes.Clone(
-				resp.ServerInfo.OperatorPubkey,
+				serverInfo.OperatorPubkey,
 			),
-			BoardingExitDelay: resp.ServerInfo.BoardingExitDelay,
-			VTXOExitDelay:     resp.ServerInfo.VtxoExitDelay,
-			DustLimit:         resp.ServerInfo.DustLimit,
-			MinVTXOAmountSat:  resp.ServerInfo.MinVtxoAmountSat,
-			MinBoardingAmount: resp.ServerInfo.MinBoardingAmount,
-			MaxVTXOAmount:     resp.ServerInfo.MaxVtxoAmount,
-			FeeRate:           resp.ServerInfo.FeeRate,
-			MinOperatorFee:    resp.ServerInfo.MinOperatorFee,
-			MinConfirmations:  resp.ServerInfo.MinConfirmations,
-			MaxUserBalance:    resp.ServerInfo.MaxUserBalance,
+			BoardingExitDelay:       serverInfo.BoardingExitDelay,
+			VTXOExitDelay:           serverInfo.VtxoExitDelay,
+			DustLimit:               serverInfo.DustLimit,
+			MinVTXOAmountSat:        serverInfo.MinVtxoAmountSat,
+			MinBoardingAmount:       serverInfo.MinBoardingAmount,
+			MaxVTXOAmount:           serverInfo.MaxVtxoAmount,
+			FeeRate:                 serverInfo.FeeRate,
+			MinOperatorFee:          serverInfo.MinOperatorFee,
+			FreeRefreshWindowBlocks: freeRefreshWindow,
+			MinConfirmations:        serverInfo.MinConfirmations,
+			MaxUserBalance:          serverInfo.MaxUserBalance,
 		}
 	}
 

--- a/sdk/ark/client_test.go
+++ b/sdk/ark/client_test.go
@@ -128,15 +128,16 @@ func newFakeDaemonService() *fakeDaemonService {
 				OperatorPubkey: mustDecodeHex(
 					testOperatorPubKeyHex,
 				),
-				BoardingExitDelay: 144,
-				VtxoExitDelay:     288,
-				DustLimit:         546,
-				MinVtxoAmountSat:  1234,
-				MinBoardingAmount: 10_000,
-				MaxVtxoAmount:     20_000,
-				FeeRate:           15,
-				MinOperatorFee:    20,
-				MinConfirmations:  2,
+				BoardingExitDelay:       144,
+				VtxoExitDelay:           288,
+				DustLimit:               546,
+				MinVtxoAmountSat:        1234,
+				MinBoardingAmount:       10_000,
+				MaxVtxoAmount:           20_000,
+				FeeRate:                 15,
+				MinOperatorFee:          20,
+				FreeRefreshWindowBlocks: 120,
+				MinConfirmations:        2,
 			},
 		},
 		listVtxosResp: &waverpc.ListVTXOsResponse{
@@ -606,6 +607,9 @@ func TestDialRemoteGetInfo(t *testing.T) {
 	)
 	require.Equal(t, uint64(20),
 		info.ServerInfo.MinOperatorFee,
+	)
+	require.Equal(t, uint32(120),
+		info.ServerInfo.FreeRefreshWindowBlocks,
 	)
 }
 

--- a/sdk/wavewalletdk/AGENTS.md
+++ b/sdk/wavewalletdk/AGENTS.md
@@ -45,7 +45,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/wave
   values seeded by `waved.DefaultConfig` or carried on a caller-owned
   `DaemonConfig`. First option: `WithEagerRoundJoinDisabled()` forces
   `daemonCfg.EagerRoundJoin = false`.
-- DTOs (wrapper-owned, isolated from proto enums): `Info`, `Balance`,
+- DTOs (wrapper-owned, isolated from proto enums): `Info` / `ServerInfo`
+  (including the advisory free-refresh window), `Balance`,
   `CreateWalletResult`, `UnlockWalletResult`, `ReceiveRequest`/`Result`
   (returns invoice + initial `Entry`), the two-step send DTOs
   `PrepareSendRequest`/`PrepareSendResult` and

--- a/sdk/wavewalletdk/client.go
+++ b/sdk/wavewalletdk/client.go
@@ -195,7 +195,7 @@ func (c *Client) GetInfo(ctx context.Context) (*Info, error) {
 		return nil, fmt.Errorf("get daemon info: %w", err)
 	}
 
-	return &Info{
+	info := &Info{
 		Version:         resp.GetVersion(),
 		Commit:          resp.GetCommit(),
 		Network:         resp.GetNetwork(),
@@ -204,7 +204,17 @@ func (c *Client) GetInfo(ctx context.Context) (*Info, error) {
 		WalletType:      resp.GetWalletType(),
 		WalletState:     WalletState(resp.GetWalletState()),
 		IdentityPubKey:  resp.GetIdentityPubkey(),
-	}, nil
+	}
+
+	if resp.ServerInfo != nil {
+		serverInfo := resp.ServerInfo
+		freeRefreshWindow := serverInfo.GetFreeRefreshWindowBlocks()
+		info.ServerInfo = &ServerInfo{
+			FreeRefreshWindowBlocks: freeRefreshWindow,
+		}
+	}
+
+	return info, nil
 }
 
 // CreateWallet creates or imports the embedded daemon wallet.

--- a/sdk/wavewalletdk/passkey_test.go
+++ b/sdk/wavewalletdk/passkey_test.go
@@ -23,6 +23,7 @@ type stubDaemonServer struct {
 
 	state         waverpc.WalletState
 	identity      string
+	freeWindow    uint32
 	initErr       error
 	unlockErr     error
 	initCalled    bool
@@ -39,7 +40,28 @@ func (s *stubDaemonServer) GetInfo(context.Context, *waverpc.GetInfoRequest) (
 	return &waverpc.GetInfoResponse{
 		WalletState:    s.state,
 		IdentityPubkey: s.identity,
+		ServerInfo: &waverpc.ServerInfo{
+			FreeRefreshWindowBlocks: s.freeWindow,
+		},
 	}, nil
+}
+
+// TestGetInfoExposesFreeRefreshWindow verifies the wallet-shaped facade does
+// not discard the operator hint used by automatic expiry refresh.
+func TestGetInfoExposesFreeRefreshWindow(t *testing.T) {
+	t.Parallel()
+
+	client := newStubClient(t, &stubDaemonServer{
+		state:      waverpc.WalletState_WALLET_STATE_READY,
+		freeWindow: 120,
+	})
+
+	info, err := client.GetInfo(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, info.ServerInfo)
+	require.Equal(
+		t, uint32(120), info.ServerInfo.FreeRefreshWindowBlocks,
+	)
 }
 
 // InitWallet records the import call and its request, then returns the

--- a/sdk/wavewalletdk/restclient_test.go
+++ b/sdk/wavewalletdk/restclient_test.go
@@ -18,7 +18,10 @@ func TestConnectREST(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, err := w.Write([]byte(`{
 				"network": "regtest",
-				"wallet_state": "WALLET_STATE_READY"
+				"wallet_state": "WALLET_STATE_READY",
+				"server_info": {
+					"free_refresh_window_blocks": 120
+				}
 			}`))
 			require.NoError(t, err)
 		},
@@ -40,4 +43,8 @@ func TestConnectREST(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "regtest", info.Network)
 	require.Equal(t, WalletStateReady, info.WalletState)
+	require.NotNil(t, info.ServerInfo)
+	require.Equal(
+		t, uint32(120), info.ServerInfo.FreeRefreshWindowBlocks,
+	)
 }

--- a/sdk/wavewalletdk/types.go
+++ b/sdk/wavewalletdk/types.go
@@ -88,6 +88,14 @@ type Info struct {
 	WalletType      string
 	WalletState     WalletState
 	IdentityPubKey  string
+	ServerInfo      *ServerInfo
+}
+
+// ServerInfo contains the operator policy hints needed by wallet hosts.
+type ServerInfo struct {
+	// FreeRefreshWindowBlocks is the late-lifetime window in which a
+	// pure refresh receives a fee waiver.
+	FreeRefreshWindowBlocks uint32
 }
 
 // WalletReady reports whether the daemon wallet is fully unlocked and

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -127,6 +127,9 @@ when the local wallet owns the receive script.
   boundary remains at least `MinRefreshBuffer` blocks above the dynamic
   critical threshold. An overly late window never weakens unilateral-exit or
   cooperative-retry safety; the wallet refreshes earlier and pays normally.
+- When the cached boundary fires, auto-refresh fetches fresh operator terms
+  before reserving the VTXO. A later still-safe boundary leaves the VTXO live;
+  a disabled or unsafe-late window preserves the ordinary paid refresh path.
 - Once ForfeitedState is reached, the old VTXO is unspendable; the new VTXO is available only after round confirmation.
 - SpendingState is persisted as VTXOStatusSpending and survives restarts.
 - OOR completion transitions VTXOs to SpentState through the VTXO actor FSM, not by direct store writes.

--- a/vtxo/AGENTS.md
+++ b/vtxo/AGENTS.md
@@ -123,6 +123,10 @@ when the local wallet owns the receive script.
 - VTXO actor state is the single source of truth for availability.
 - Forfeit transaction is not broadcast until the connector output's round confirms (atomic replacement).
 - Refresh is auto-triggered at configurable height before expiry.
+- Auto-refresh delays to an advertised fee-waiver boundary only when the
+  boundary remains at least `MinRefreshBuffer` blocks above the dynamic
+  critical threshold. An overly late window never weakens unilateral-exit or
+  cooperative-retry safety; the wallet refreshes earlier and pays normally.
 - Once ForfeitedState is reached, the old VTXO is unspendable; the new VTXO is available only after round confirmation.
 - SpendingState is persisted as VTXOStatusSpending and survives restarts.
 - OOR completion transitions VTXOs to SpentState through the VTXO actor FSM, not by direct store writes.

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -94,7 +94,9 @@ type VTXOActorConfig struct {
 	// FetchOperatorKey, when set, returns the operator's current
 	// long-term public key by issuing a fresh GetInfo round-trip to
 	// the operator at the moment of an auto-refresh emission. The
-	// fetched key is used to build the NEW VTXO output's policy
+	// production callback also refreshes the operator-terms cache, so the
+	// actor can recheck the current free-refresh window before reserving.
+	// The fetched key is used to build the NEW VTXO output's policy
 	// template; the input VTXO's stored operator key is intentionally
 	// not reused for the new output because VTXOs commit to their
 	// operator key for their entire lifetime, and the new output is a
@@ -166,17 +168,24 @@ func (a *VTXOActor) logger(ctx context.Context) btclog.Logger {
 func (a *VTXOActor) refreshOutputTemplate(ctx context.Context,
 	vtxo *Descriptor) ([]byte, error) {
 
+	return a.refreshOutputTemplateWithKey(ctx, vtxo, nil)
+}
+
+// refreshOutputTemplateWithKey returns the new output policy using a
+// pre-fetched operator key when one is available.
+func (a *VTXOActor) refreshOutputTemplateWithKey(ctx context.Context,
+	vtxo *Descriptor, currentKey *btcec.PublicKey) ([]byte, error) {
+
 	if a.cfg.FetchOperatorKey == nil {
 		return vtxo.EffectivePolicyTemplate()
 	}
 
-	currentKey, err := a.cfg.FetchOperatorKey(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("fetch current operator key: %w", err)
-	}
 	if currentKey == nil {
-		return nil, fmt.Errorf("fetch current operator key: nil key " +
-			"returned")
+		var err error
+		currentKey, err = a.fetchOperatorKey(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	rebuilt, err := vtxo.RefreshOutputTemplate(currentKey)
@@ -193,6 +202,77 @@ func (a *VTXOActor) refreshOutputTemplate(ctx context.Context,
 	}
 
 	return rebuilt, nil
+}
+
+// fetchOperatorKey fetches and validates the current operator key.
+func (a *VTXOActor) fetchOperatorKey(ctx context.Context) (*btcec.PublicKey,
+	error) {
+
+	currentKey, err := a.cfg.FetchOperatorKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetch current operator key: %w", err)
+	}
+	if currentKey == nil {
+		return nil, fmt.Errorf("fetch current operator key: nil key " +
+			"returned")
+	}
+
+	return currentKey, nil
+}
+
+// preflightAutoRefresh refreshes the operator terms when a cached threshold
+// first requests cooperative refresh. It returns deferRefresh when the fresh
+// response moves a still-safe waiver boundary later than the current block.
+func (a *VTXOActor) preflightAutoRefresh(ctx context.Context, event VTXOEvent) (
+	*btcec.PublicKey, bool, error) {
+
+	if a.cfg.FetchOperatorKey == nil {
+		return nil, false, nil
+	}
+
+	blockEvent, ok := event.(*BlockEpochEvent)
+	if !ok {
+		return nil, false, nil
+	}
+
+	liveState, ok := a.state.(*LiveState)
+	if !ok {
+		return nil, false, nil
+	}
+
+	status := a.env.ExpiryConfig.CheckExpiry(
+		liveState.VTXO, blockEvent.Height,
+	)
+	if status != ExpiryStatusNeedsRefresh {
+		return nil, false, nil
+	}
+
+	currentKey, err := a.fetchOperatorKey(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	blocksRemaining := BlocksUntilExpiry(
+		liveState.VTXO, blockEvent.Height,
+	)
+	refreshThreshold := a.env.ExpiryConfig.CalculateRefreshThreshold(
+		liveState.VTXO,
+	)
+	if blocksRemaining <= refreshThreshold {
+		return currentKey, false, nil
+	}
+
+	// The fresh window moved later while retaining the configured safety
+	// margin. Consume this epoch in LiveState and let the newly cached
+	// threshold trigger another preflight at the new boundary.
+	liveState.LastCheckedHeight = blockEvent.Height
+	a.logger(ctx).DebugS(ctx, "Deferring automatic refresh to latest "+
+		"operator window",
+		slog.Int("blocks_remaining", int(blocksRemaining)),
+		slog.Int("refresh_threshold", int(refreshThreshold)),
+	)
+
+	return currentKey, true, nil
 }
 
 // emitExitCost is the VTXO-actor entry point for unilateral-exit accounting.
@@ -309,6 +389,26 @@ func (a *VTXOActor) Receive(ctx context.Context,
 		)
 	}
 
+	refreshKey, deferRefresh, err := a.preflightAutoRefresh(
+		ctx, vtxoEvent,
+	)
+	if err != nil {
+		a.logger(ctx).WarnS(ctx, "Automatic refresh preflight failed",
+			err,
+			slog.String("outpoint", a.cfg.VTXO.Outpoint.String()),
+		)
+
+		return fn.Err[actormsg.VTXOActorResp](
+			fmt.Errorf("preflight automatic refresh: %w", err),
+		)
+	}
+	if deferRefresh {
+		return fn.Ok[actormsg.VTXOActorResp](VTXOActorResponse{
+			PriorState: a.state,
+			NewState:   a.state,
+		})
+	}
+
 	transition, err := a.state.ProcessEvent(ctx, vtxoEvent, a.env)
 	if err != nil {
 		a.logger(ctx).ErrorS(ctx, "VTXO FSM ProcessEvent failed",
@@ -354,7 +454,9 @@ func (a *VTXOActor) Receive(ctx context.Context,
 	// transition. If the durable write fails, callers must see an error
 	// and retries must re-drive the original state rather than observing
 	// a terminal state that never made it to disk.
-	if err := a.processOutbox(ctx, outbox); err != nil {
+	if err := a.processOutboxWithOperatorKey(
+		ctx, outbox, refreshKey,
+	); err != nil {
 		return fn.Err[actormsg.VTXOActorResp](err)
 	}
 
@@ -380,6 +482,14 @@ func (a *VTXOActor) Receive(ctx context.Context,
 func (a *VTXOActor) processOutbox(ctx context.Context,
 	outbox []VTXOOutMsg) error {
 
+	return a.processOutboxWithOperatorKey(ctx, outbox, nil)
+}
+
+// processOutboxWithOperatorKey routes outbox messages while reusing the key
+// fetched immediately before an automatic refresh transition.
+func (a *VTXOActor) processOutboxWithOperatorKey(ctx context.Context,
+	outbox []VTXOOutMsg, refreshKey *btcec.PublicKey) error {
+
 	// Persist status updates first so a DB failure causes Receive to
 	// return an error before applying the in-memory state transition.
 	for _, msg := range outbox {
@@ -404,8 +514,8 @@ func (a *VTXOActor) processOutbox(ctx context.Context,
 			// the round-specific message here since the VTXO
 			// actor has the descriptor data needed.
 			vtxo := a.cfg.VTXO
-			policyTemplate, err := a.refreshOutputTemplate(
-				ctx, vtxo,
+			policyTemplate, err := a.refreshOutputTemplateWithKey(
+				ctx, vtxo, refreshKey,
 			)
 			if err != nil {
 				// WarnS, not ErrorS: this can fail because

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -412,9 +412,8 @@ func (a *VTXOActor) processOutbox(ctx context.Context,
 				// the FetchOperatorKey callback returned an
 				// error (operator unreachable, fresh GetInfo
 				// timed out) — an external trigger, not an
-				// internal bug. The next expiry tick will
-				// retry; skipping this emission is the right
-				// local behavior.
+				// internal bug. Roll the durable reservation
+				// back below so the next expiry tick can retry.
 				a.logger(ctx).WarnS(
 					ctx,
 					"Failed to build refresh output "+
@@ -426,7 +425,24 @@ func (a *VTXOActor) processOutbox(ctx context.Context,
 					),
 				)
 
-				continue
+				rollbackErr := a.processStatusUpdate(
+					ctx, &VTXOStatusUpdate{
+						Outpoint:  vtxo.Outpoint,
+						NewStatus: VTXOStatusLive,
+					},
+				)
+				if rollbackErr != nil {
+					return errors.Join(
+						err, fmt.Errorf(
+							"roll back failed "+
+								"automatic "+
+								"refresh: %w",
+							rollbackErr),
+					)
+				}
+
+				return fmt.Errorf("build refresh output "+
+					"template: %w", err)
 			}
 
 			// Quote the operator fee for this VTXO so the

--- a/vtxo/actor_test.go
+++ b/vtxo/actor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/wire/v2"
@@ -458,6 +459,58 @@ func TestProcessOutboxForfeitRequestQuotesFee(t *testing.T) {
 		t, int64(vtxo.Amount), refreshReq.Amount,
 		"forfeit input Amount is unchanged by the quote",
 	)
+}
+
+// TestAutoRefreshOperatorLookupFailureRetries verifies a transient operator
+// lookup cannot strand a VTXO in PendingForfeit before any round request was
+// emitted. The actor restores Live durably and retries on the next block.
+func TestAutoRefreshOperatorLookupFailureRetries(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	desc := h.newTestDescriptor()
+	currentHeight := desc.BatchExpiry - 200
+	fetchErr := errors.New("operator unavailable")
+
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, desc.Outpoint,
+		VTXOStatusPendingForfeit,
+	).Return(nil).Twice()
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, desc.Outpoint, VTXOStatusLive,
+	).Return(nil).Once()
+
+	var attempts int
+	manager := newMockManagerRef(t)
+	actor := newRefreshTestActor(
+		h, desc, manager,
+		func(_ context.Context) (*btcec.PublicKey, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, fetchErr
+			}
+
+			return desc.OperatorKey, nil
+		},
+	)
+
+	result := actor.Receive(
+		h.ctx, h.newBlockEpochEvent(currentHeight),
+	)
+	_, err := result.Unpack()
+	require.ErrorIs(t, err, fetchErr)
+	require.IsType(t, &LiveState{}, actor.state)
+	require.Empty(t, manager.getMessages())
+
+	result = actor.Receive(
+		h.ctx, h.newBlockEpochEvent(currentHeight+1),
+	)
+	_, err = result.Unpack()
+	require.NoError(t, err)
+	require.IsType(t, &PendingForfeitState{}, actor.state)
+	require.Len(t, manager.getMessages(), 1)
+	require.Equal(t, 2, attempts)
+	h.store.AssertExpectations(t)
 }
 
 // TestProcessOutboxTerminatedNotification verifies that

--- a/vtxo/actor_test.go
+++ b/vtxo/actor_test.go
@@ -461,10 +461,10 @@ func TestProcessOutboxForfeitRequestQuotesFee(t *testing.T) {
 	)
 }
 
-// TestAutoRefreshOperatorLookupFailureRetries verifies a transient operator
-// lookup cannot strand a VTXO in PendingForfeit before any round request was
-// emitted. The actor restores Live durably and retries on the next block.
-func TestAutoRefreshOperatorLookupFailureRetries(t *testing.T) {
+// TestAutoRefreshTermsLookupFailureRetries verifies a transient GetInfo
+// failure leaves the VTXO live and retries on the next block without writing a
+// PendingForfeit reservation.
+func TestAutoRefreshTermsLookupFailureRetries(t *testing.T) {
 	t.Parallel()
 
 	h := newVTXOTestHarness(t)
@@ -475,9 +475,6 @@ func TestAutoRefreshOperatorLookupFailureRetries(t *testing.T) {
 	h.store.On(
 		"UpdateVTXOStatus", h.ctx, desc.Outpoint,
 		VTXOStatusPendingForfeit,
-	).Return(nil).Twice()
-	h.store.On(
-		"UpdateVTXOStatus", h.ctx, desc.Outpoint, VTXOStatusLive,
 	).Return(nil).Once()
 
 	var attempts int
@@ -511,6 +508,112 @@ func TestAutoRefreshOperatorLookupFailureRetries(t *testing.T) {
 	require.Len(t, manager.getMessages(), 1)
 	require.Equal(t, 2, attempts)
 	h.store.AssertExpectations(t)
+}
+
+// TestAutoRefreshRechecksFreeWindow verifies the actor confirms the current
+// operator window before reserving an automatic refresh input.
+func TestAutoRefreshRechecksFreeWindow(t *testing.T) {
+	t.Parallel()
+
+	t.Run("later safe boundary defers", func(t *testing.T) {
+		t.Parallel()
+
+		h := newVTXOTestHarness(t)
+		desc := h.newTestDescriptor()
+		desc.RelativeExpiry = 24
+
+		cachedWindow := uint32(120)
+		freshWindow := uint32(110)
+		cfg := DefaultExpiryConfig()
+		cfg.FreeRefreshWindow = func() uint32 {
+			return cachedWindow
+		}
+		h.withExpiryConfig(cfg)
+
+		h.store.On(
+			"UpdateVTXOStatus", h.ctx, desc.Outpoint,
+			VTXOStatusPendingForfeit,
+		).Return(nil).Once()
+
+		var fetches int
+		manager := newMockManagerRef(t)
+		actor := newRefreshTestActor(
+			h, desc, manager,
+			func(_ context.Context) (*btcec.PublicKey, error) {
+				fetches++
+				cachedWindow = freshWindow
+
+				return desc.OperatorKey, nil
+			},
+		)
+
+		result := actor.Receive(
+			h.ctx, h.newBlockEpochEvent(
+				desc.BatchExpiry-int32(120),
+			),
+		)
+		_, err := result.Unpack()
+		require.NoError(t, err)
+		require.IsType(t, &LiveState{}, actor.state)
+		require.Empty(t, manager.getMessages())
+		require.Equal(t, 1, fetches)
+
+		result = actor.Receive(
+			h.ctx, h.newBlockEpochEvent(
+				desc.BatchExpiry-int32(freshWindow),
+			),
+		)
+		_, err = result.Unpack()
+		require.NoError(t, err)
+		require.IsType(t, &PendingForfeitState{}, actor.state)
+		require.Len(t, manager.getMessages(), 1)
+		require.Equal(t, 2, fetches)
+		h.store.AssertExpectations(t)
+	})
+
+	t.Run("disabled window preserves paid refresh", func(t *testing.T) {
+		t.Parallel()
+
+		h := newVTXOTestHarness(t)
+		desc := h.newTestDescriptor()
+		desc.RelativeExpiry = 24
+
+		cachedWindow := uint32(120)
+		cfg := DefaultExpiryConfig()
+		cfg.FreeRefreshWindow = func() uint32 {
+			return cachedWindow
+		}
+		h.withExpiryConfig(cfg)
+
+		h.store.On(
+			"UpdateVTXOStatus", h.ctx, desc.Outpoint,
+			VTXOStatusPendingForfeit,
+		).Return(nil).Once()
+
+		var fetches int
+		manager := newMockManagerRef(t)
+		actor := newRefreshTestActor(
+			h, desc, manager,
+			func(_ context.Context) (*btcec.PublicKey, error) {
+				fetches++
+				cachedWindow = 0
+
+				return desc.OperatorKey, nil
+			},
+		)
+
+		result := actor.Receive(
+			h.ctx, h.newBlockEpochEvent(
+				desc.BatchExpiry-int32(120),
+			),
+		)
+		_, err := result.Unpack()
+		require.NoError(t, err)
+		require.IsType(t, &PendingForfeitState{}, actor.state)
+		require.Len(t, manager.getMessages(), 1)
+		require.Equal(t, 1, fetches)
+		h.store.AssertExpectations(t)
+	})
 }
 
 // TestProcessOutboxTerminatedNotification verifies that

--- a/vtxo/expiry.go
+++ b/vtxo/expiry.go
@@ -63,6 +63,13 @@ type ExpiryConfig struct {
 	// additional blocks needed for safe unilateral exit. Each tree level
 	// requires broadcasting and confirming an additional transaction.
 	TreeDepthMultiplier int32
+
+	// FreeRefreshWindow returns the operator-advertised number of blocks
+	// before batch expiry in which refresh fees are waived. A nil callback
+	// or zero window disables subsidy-aware scheduling. The callback lets a
+	// long-lived VTXO actor observe a refreshed operator-terms snapshot
+	// without weakening the local critical-expiry safety policy.
+	FreeRefreshWindow func() uint32
 }
 
 // DefaultExpiryConfig returns sensible defaults for expiry configuration.
@@ -104,30 +111,15 @@ func (c *ExpiryConfig) CheckExpiry(
 		return ExpiryStatusExpired
 	}
 
-	// Calculate dynamic threshold based on tree depth. Deeper trees need
-	// more time for unilateral exit since each level requires broadcasting
-	// a transaction and waiting for confirmation.
-	treeDepthBuffer := int32(vtxo.MaxTreeDepth()) * c.TreeDepthMultiplier
-
-	// Add CSV delay - after the VTXO appears on-chain, we need to wait
-	// for the relative timelock before we can spend via the unilateral
-	// path.
-	csvBuffer := int32(vtxo.RelativeExpiry)
-
-	// Total buffer needed for safe unilateral exit.
-	safeExitBuffer := treeDepthBuffer + csvBuffer
-
 	// Critical threshold: must have enough time for unilateral exit.
-	criticalThreshold := max(c.CriticalThresholdBlocks, safeExitBuffer)
+	criticalThreshold := c.CalculateCriticalThreshold(vtxo)
 
 	if blocksRemaining <= criticalThreshold {
 		return ExpiryStatusCritical
 	}
 
 	// Refresh threshold: should refresh well before critical.
-	refreshThreshold := max(
-		c.RefreshThresholdBlocks, criticalThreshold+c.MinRefreshBuffer,
-	)
+	refreshThreshold := c.CalculateRefreshThreshold(vtxo)
 
 	if blocksRemaining <= refreshThreshold {
 		return ExpiryStatusNeedsRefresh
@@ -180,8 +172,27 @@ func (c *ExpiryConfig) CalculateCriticalThreshold(vtxo *Descriptor) int32 {
 // CalculateRefreshThreshold returns the dynamic refresh threshold for a VTXO.
 func (c *ExpiryConfig) CalculateRefreshThreshold(vtxo *Descriptor) int32 {
 	criticalThreshold := c.CalculateCriticalThreshold(vtxo)
-
-	return max(
+	refreshThreshold := max(
 		c.RefreshThresholdBlocks, criticalThreshold+c.MinRefreshBuffer,
 	)
+
+	if c.FreeRefreshWindow == nil {
+		return refreshThreshold
+	}
+
+	windowBlocks := c.FreeRefreshWindow()
+	if windowBlocks == 0 ||
+		uint64(windowBlocks) >= uint64(refreshThreshold) {
+		return refreshThreshold
+	}
+
+	// Never trade away the configured retry buffer merely to chase a fee
+	// waiver. If the operator opens its free window later than the local
+	// safety floor, the wallet refreshes earlier and pays the normal fee.
+	safetyFloor := criticalThreshold + c.MinRefreshBuffer
+	if uint64(windowBlocks) < uint64(safetyFloor) {
+		return refreshThreshold
+	}
+
+	return int32(windowBlocks)
 }

--- a/vtxo/expiry_test.go
+++ b/vtxo/expiry_test.go
@@ -1,0 +1,97 @@
+package vtxo
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFreeRefreshWindowThreshold verifies that an advertised waiver delays
+// automatic refresh only when the local retry and unilateral-exit buffers
+// remain intact.
+func TestFreeRefreshWindowThreshold(t *testing.T) {
+	t.Parallel()
+
+	desc := &Descriptor{
+		BatchExpiry:    1_000,
+		RelativeExpiry: 24,
+		Ancestry: []Ancestry{{
+			TreeDepth: 2,
+		}},
+	}
+
+	tests := []struct {
+		name          string
+		window        uint32
+		wantThreshold int32
+	}{
+		{
+			name:          "disabled",
+			window:        0,
+			wantThreshold: 144,
+		},
+		{
+			name:          "safe delayed boundary",
+			window:        120,
+			wantThreshold: 120,
+		},
+		{
+			name:          "late window keeps safety floor",
+			window:        100,
+			wantThreshold: 144,
+		},
+		{
+			name:          "wide window keeps ordinary threshold",
+			window:        200,
+			wantThreshold: 144,
+		},
+		{
+			name:          "large window does not overflow",
+			window:        math.MaxUint32,
+			wantThreshold: 144,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := DefaultExpiryConfig()
+			cfg.FreeRefreshWindow = func() uint32 {
+				return test.window
+			}
+
+			require.Equal(
+				t, test.wantThreshold,
+				cfg.CalculateRefreshThreshold(desc),
+			)
+		})
+	}
+}
+
+// TestFreeRefreshWindowBoundary verifies the automatic expiry posture changes
+// on the first block inside a safe advertised window.
+func TestFreeRefreshWindowBoundary(t *testing.T) {
+	t.Parallel()
+
+	desc := &Descriptor{
+		BatchExpiry:    1_000,
+		RelativeExpiry: 24,
+		Ancestry: []Ancestry{{
+			TreeDepth: 2,
+		}},
+	}
+	cfg := DefaultExpiryConfig()
+	cfg.FreeRefreshWindow = func() uint32 {
+		return 120
+	}
+
+	require.Equal(
+		t, ExpiryStatusSafe, cfg.CheckExpiry(desc, 879),
+	)
+	require.Equal(
+		t, ExpiryStatusNeedsRefresh, cfg.CheckExpiry(desc, 880),
+	)
+}

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -120,7 +120,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
 - The VTXO manager reads `FreeRefreshWindowBlocks` from the latest cached
   operator terms on each expiry check. It delays automatic refresh to the
   window boundary only when the local dynamic critical threshold plus retry
-  buffer remains intact.
+  buffer remains intact. When that cached boundary fires, it fetches a fresh
+  `GetInfo` snapshot and rechecks the window before reserving the input.
 
 ## Deep Docs
 

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -115,6 +115,12 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   non-retryable `OutboxErrorEvent` instead of an `Adapt` error that would
   stall the serverconn ingress cursor on the offending envelope
   (`server.go`).
+- `operatorTermsFromResponse` and daemon `GetInfo` must preserve
+  `FreeRefreshWindowBlocks` end to end.
+- The VTXO manager reads `FreeRefreshWindowBlocks` from the latest cached
+  operator terms on each expiry check. It delays automatic refresh to the
+  window boundary only when the local dynamic critical threshold plus retry
+  buffer remains intact.
 
 ## Deep Docs
 

--- a/waved/operator_negotiation.go
+++ b/waved/operator_negotiation.go
@@ -58,18 +58,19 @@ func operatorTermsFromResponse(resp *arkrpc.GetInfoResponse) (
 	// global operator terms; they are delivered per round in the batch
 	// info, so GetInfo no longer carries them.
 	return &types.OperatorTerms{
-		PubKey:              pubKey,
-		BoardingExitDelay:   resp.BoardingExitDelay,
-		VTXOExitDelay:       resp.VtxoExitDelay,
-		DustLimit:           btcutil.Amount(resp.DustLimit),
-		MinVTXOAmount:       btcutil.Amount(minVTXOAmount),
-		MinBoardingAmount:   btcutil.Amount(resp.MinBoardingAmount),
-		MaxVTXOAmount:       btcutil.Amount(resp.MaxVtxoAmount),
-		FeeRate:             btcutil.Amount(resp.FeeRate),
-		MinOperatorFee:      btcutil.Amount(resp.MinOperatorFee),
-		MinConfirmations:    resp.MinConfirmations,
-		MaxOORLineageVBytes: resp.MaxOorLineageVbytes,
-		MaxUserBalance:      btcutil.Amount(resp.MaxUserBalance),
+		PubKey:                  pubKey,
+		BoardingExitDelay:       resp.BoardingExitDelay,
+		VTXOExitDelay:           resp.VtxoExitDelay,
+		DustLimit:               btcutil.Amount(resp.DustLimit),
+		MinVTXOAmount:           btcutil.Amount(minVTXOAmount),
+		MinBoardingAmount:       btcutil.Amount(resp.MinBoardingAmount),
+		MaxVTXOAmount:           btcutil.Amount(resp.MaxVtxoAmount),
+		FeeRate:                 btcutil.Amount(resp.FeeRate),
+		MinOperatorFee:          btcutil.Amount(resp.MinOperatorFee),
+		FreeRefreshWindowBlocks: resp.FreeRefreshWindowBlocks,
+		MinConfirmations:        resp.MinConfirmations,
+		MaxOORLineageVBytes:     resp.MaxOorLineageVbytes,
+		MaxUserBalance:          btcutil.Amount(resp.MaxUserBalance),
 	}, nil
 }
 

--- a/waved/operator_negotiation_test.go
+++ b/waved/operator_negotiation_test.go
@@ -6,10 +6,39 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/lib/types"
 	mailboxconn "github.com/lightninglabs/wavelength/mailbox/conn"
+	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
+
+// TestVTXOExpiryConfigUsesLatestTerms verifies long-lived VTXO actors observe
+// the latest cached free-refresh window instead of a bootstrap-only copy.
+func TestVTXOExpiryConfigUsesLatestTerms(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{}
+	cfg := server.vtxoExpiryConfig()
+	desc := &vtxo.Descriptor{
+		RelativeExpiry: 24,
+		Ancestry: []vtxo.Ancestry{{
+			TreeDepth: 2,
+		}},
+	}
+
+	require.Equal(t, int32(144), cfg.CalculateRefreshThreshold(desc))
+
+	server.storeOperatorTerms(&types.OperatorTerms{
+		FreeRefreshWindowBlocks: 120,
+	})
+	require.Equal(t, int32(120), cfg.CalculateRefreshThreshold(desc))
+
+	server.storeOperatorTerms(&types.OperatorTerms{
+		FreeRefreshWindowBlocks: 100,
+	})
+	require.Equal(t, int32(144), cfg.CalculateRefreshThreshold(desc))
+}
 
 // activeArkPolicy builds an ACTIVE policy for the given version, used to
 // populate the operator's advertised policy list in fake GetInfo responses.
@@ -57,6 +86,19 @@ func testOperatorPubKeyBytes(t *testing.T) []byte {
 	require.NoError(t, err)
 
 	return priv.PubKey().SerializeCompressed()
+}
+
+// TestOperatorTermsFreeRefreshWindow verifies GetInfo policy plumbing keeps
+// the late-refresh hint available to downstream wallet and RPC surfaces.
+func TestOperatorTermsFreeRefreshWindow(t *testing.T) {
+	t.Parallel()
+
+	terms, err := operatorTermsFromResponse(&arkrpc.GetInfoResponse{
+		Pubkey:                  testOperatorPubKeyBytes(t),
+		FreeRefreshWindowBlocks: 72,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint32(72), terms.FreeRefreshWindowBlocks)
 }
 
 // TestNegotiateArkBootstrapZeroSelection proves the client refuses to bootstrap

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -661,6 +661,8 @@ func (r *RPCServer) GetInfo(ctx context.Context, _ *waverpc.GetInfoRequest) (
 			MinVtxoAmountSat:  uint64(minVTXOAmount),
 			MaxUserBalance:    uint64(terms.MaxUserBalance),
 		}
+		resp.ServerInfo.FreeRefreshWindowBlocks =
+			terms.FreeRefreshWindowBlocks
 	}
 
 	return resp, nil

--- a/waved/rpc_server_test.go
+++ b/waved/rpc_server_test.go
@@ -944,16 +944,17 @@ func TestGetInfoIncludesServerInfo(t *testing.T) {
 	}
 	server.setServerConnected(true)
 	server.storeOperatorTerms(&types.OperatorTerms{
-		PubKey:            operatorPriv.PubKey(),
-		BoardingExitDelay: 144,
-		VTXOExitDelay:     288,
-		DustLimit:         btcutil.Amount(546),
-		MinVTXOAmount:     btcutil.Amount(1234),
-		MinBoardingAmount: btcutil.Amount(10_000),
-		MaxVTXOAmount:     btcutil.Amount(500_000),
-		FeeRate:           btcutil.Amount(12),
-		MinOperatorFee:    btcutil.Amount(34),
-		MinConfirmations:  2,
+		PubKey:                  operatorPriv.PubKey(),
+		BoardingExitDelay:       144,
+		VTXOExitDelay:           288,
+		DustLimit:               btcutil.Amount(546),
+		MinVTXOAmount:           btcutil.Amount(1234),
+		MinBoardingAmount:       btcutil.Amount(10_000),
+		MaxVTXOAmount:           btcutil.Amount(500_000),
+		FeeRate:                 btcutil.Amount(12),
+		MinOperatorFee:          btcutil.Amount(34),
+		FreeRefreshWindowBlocks: 72,
+		MinConfirmations:        2,
 	})
 	r := &RPCServer{server: server}
 
@@ -979,6 +980,9 @@ func TestGetInfoIncludesServerInfo(t *testing.T) {
 	)
 	require.Equal(t, uint64(12), resp.ServerInfo.FeeRate)
 	require.Equal(t, uint64(34), resp.ServerInfo.MinOperatorFee)
+	require.Equal(
+		t, uint32(72), resp.ServerInfo.FreeRefreshWindowBlocks,
+	)
 	require.Equal(t, uint32(2), resp.ServerInfo.MinConfirmations)
 }
 

--- a/waved/rpc_swap_lookup.go
+++ b/waved/rpc_swap_lookup.go
@@ -69,7 +69,9 @@ func (r *RPCServer) GetIndexedVTXOByPkScript(ctx context.Context,
 			"indexed VTXO expiry info", heightErr)
 	}
 
-	vtxo, err := indexedVTXOToProto(vtxos[0], currentHeight)
+	vtxo, err := indexedVTXOToProto(
+		vtxos[0], currentHeight, r.server.vtxoExpiryConfig(),
+	)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert indexed "+
 			"vtxo: %v", err)
@@ -169,8 +171,8 @@ func daemonStatusToIndexerStatus(status waverpc.VTXOStatus) (arkrpc.VTXOStatus,
 
 // indexedVTXOToProto converts an authoritative indexer VTXO into the daemon's
 // simplified VTXO response shape.
-func indexedVTXOToProto(vtxo *arkrpc.VTXO,
-	currentHeight int32) (*waverpc.VTXO, error) {
+func indexedVTXOToProto(vtxo *arkrpc.VTXO, currentHeight int32,
+	cfg *vtxo.ExpiryConfig) (*waverpc.VTXO, error) {
 
 	if vtxo == nil {
 		return nil, fmt.Errorf("vtxo must be provided")
@@ -228,7 +230,9 @@ func indexedVTXOToProto(vtxo *arkrpc.VTXO,
 			vtxo.GetOorFinalCheckpointPsbts(),
 		),
 		SpentByTxid: spentByTxid,
-		ExpiryInfo:  expiryInfoFromIndexedVTXO(vtxo, currentHeight),
+		ExpiryInfo: expiryInfoFromIndexedVTXO(
+			vtxo, currentHeight, cfg,
+		),
 	}, nil
 }
 

--- a/waved/rpc_vtxo_expiry.go
+++ b/waved/rpc_vtxo_expiry.go
@@ -94,7 +94,7 @@ func (r *RPCServer) getLocalVTXOExpiryInfo(ctx context.Context, outpoint string,
 
 	protoVTXO := descriptorToProto(desc)
 	protoVTXO.ExpiryInfo = expiryInfoFromDescriptor(
-		desc, currentHeight,
+		desc, currentHeight, r.server.vtxoExpiryConfig(),
 	)
 
 	return &waverpc.GetVTXOExpiryInfoResponse{
@@ -144,7 +144,9 @@ func (r *RPCServer) getIndexedVTXOExpiryInfo(ctx context.Context,
 		return &waverpc.GetVTXOExpiryInfoResponse{}, nil
 	}
 
-	protoVTXO, err := indexedVTXOToProto(vtxos[0], currentHeight)
+	protoVTXO, err := indexedVTXOToProto(
+		vtxos[0], currentHeight, r.server.vtxoExpiryConfig(),
+	)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert indexed "+
 			"vtxo: %v", err)
@@ -228,8 +230,8 @@ func (r *RPCServer) currentBlockHeight(ctx context.Context) (int32, error) {
 
 // expiryInfoFromDescriptor classifies a locally stored VTXO descriptor at the
 // supplied chain height.
-func expiryInfoFromDescriptor(desc *vtxo.Descriptor,
-	currentHeight int32) *waverpc.VTXOExpiryInfo {
+func expiryInfoFromDescriptor(desc *vtxo.Descriptor, currentHeight int32,
+	cfg *vtxo.ExpiryConfig) *waverpc.VTXOExpiryInfo {
 
 	if desc == nil {
 		return nil
@@ -242,13 +244,14 @@ func expiryInfoFromDescriptor(desc *vtxo.Descriptor,
 		),
 		uint32(desc.ChainDepth),
 		currentHeight,
+		cfg,
 	)
 }
 
 // expiryInfoFromIndexedVTXO classifies an indexer VTXO at the supplied chain
 // height using max tree depth across its ancestry paths.
-func expiryInfoFromIndexedVTXO(indexed *arkrpc.VTXO,
-	currentHeight int32) *waverpc.VTXOExpiryInfo {
+func expiryInfoFromIndexedVTXO(indexed *arkrpc.VTXO, currentHeight int32,
+	cfg *vtxo.ExpiryConfig) *waverpc.VTXOExpiryInfo {
 
 	if indexed == nil {
 		return nil
@@ -263,14 +266,15 @@ func expiryInfoFromIndexedVTXO(indexed *arkrpc.VTXO,
 
 	return expiryInfoFromTiming(
 		indexed.GetBatchExpiryHeight(), indexed.GetRelativeExpiry(),
-		maxTreeDepth, indexed.GetChainDepth(), currentHeight,
+		maxTreeDepth, indexed.GetChainDepth(), currentHeight, cfg,
 	)
 }
 
 // expiryInfoFromTiming classifies one VTXO from the timing inputs used by the
 // wallet expiry policy.
 func expiryInfoFromTiming(batchExpiry int32, relativeExpiry, maxTreeDepth,
-	chainDepth uint32, currentHeight int32) *waverpc.VTXOExpiryInfo {
+	chainDepth uint32, currentHeight int32,
+	cfg *vtxo.ExpiryConfig) *waverpc.VTXOExpiryInfo {
 
 	info := &waverpc.VTXOExpiryInfo{
 		CurrentHeight:  currentHeight,
@@ -293,7 +297,9 @@ func expiryInfoFromTiming(batchExpiry int32, relativeExpiry, maxTreeDepth,
 			TreeDepth: maxTreeDepth,
 		}},
 	}
-	cfg := vtxo.DefaultExpiryConfig()
+	if cfg == nil {
+		cfg = vtxo.DefaultExpiryConfig()
+	}
 
 	info.BlocksRemaining = vtxo.BlocksUntilExpiry(desc, currentHeight)
 	info.CriticalThresholdBlocks = cfg.CalculateCriticalThreshold(desc)

--- a/waved/rpc_vtxo_expiry_test.go
+++ b/waved/rpc_vtxo_expiry_test.go
@@ -32,7 +32,9 @@ func TestExpiryInfoFromDescriptorUsesDefaultThresholds(t *testing.T) {
 		ChainDepth: 2,
 	}
 
-	info := expiryInfoFromDescriptor(desc, 784)
+	info := expiryInfoFromDescriptor(
+		desc, 784, vtxo.DefaultExpiryConfig(),
+	)
 
 	require.Equal(
 		t, waverpc.
@@ -47,6 +49,27 @@ func TestExpiryInfoFromDescriptorUsesDefaultThresholds(t *testing.T) {
 	require.Equal(t, uint32(144), info.GetRelativeExpiry())
 	require.Equal(t, uint32(3), info.GetMaxTreeDepth())
 	require.Equal(t, uint32(2), info.GetChainDepth())
+}
+
+// TestExpiryInfoUsesFreeRefreshWindow verifies RPC expiry posture reports the
+// same safe delayed boundary used by the live VTXO manager.
+func TestExpiryInfoUsesFreeRefreshWindow(t *testing.T) {
+	t.Parallel()
+
+	cfg := vtxo.DefaultExpiryConfig()
+	cfg.FreeRefreshWindow = func() uint32 {
+		return 120
+	}
+
+	info := expiryInfoFromTiming(
+		1_000, 24, 2, 0, 880, cfg,
+	)
+	require.Equal(t, int32(120), info.GetRefreshThresholdBlocks())
+	require.Equal(
+		t, waverpc.
+			VTXOExpiryStatus_VTXO_EXPIRY_STATUS_NEEDS_REFRESH,
+		info.GetStatus(),
+	)
 }
 
 // TestExpiryInfoFromTimingClassifiesPostures verifies the boundary conditions
@@ -91,6 +114,7 @@ func TestExpiryInfoFromTimingClassifiesPostures(t *testing.T) {
 
 			info := expiryInfoFromTiming(
 				1000, 144, 3, 0, test.currentHeight,
+				vtxo.DefaultExpiryConfig(),
 			)
 
 			require.Equal(t, test.wantStatus, info.GetStatus())
@@ -117,7 +141,9 @@ func TestExpiryInfoFromIndexedVTXOUsesMaxAncestryPathDepth(t *testing.T) {
 		},
 	}
 
-	info := expiryInfoFromIndexedVTXO(indexed, 850)
+	info := expiryInfoFromIndexedVTXO(
+		indexed, 850, vtxo.DefaultExpiryConfig(),
+	)
 
 	require.Equal(
 		t, waverpc.

--- a/waved/server.go
+++ b/waved/server.go
@@ -649,6 +649,23 @@ func (s *Server) storeOperatorTerms(terms *types.OperatorTerms) {
 	s.operatorTerms.Store(terms)
 }
 
+// vtxoExpiryConfig returns the wallet expiry policy wired to the latest
+// cached operator terms. The operator hint may change after bootstrap, so the
+// callback resolves the atomic snapshot when each VTXO evaluates a block.
+func (s *Server) vtxoExpiryConfig() *vtxo.ExpiryConfig {
+	cfg := vtxo.DefaultExpiryConfig()
+	cfg.FreeRefreshWindow = func() uint32 {
+		terms := s.loadOperatorTerms()
+		if terms == nil {
+			return 0
+		}
+
+		return terms.FreeRefreshWindowBlocks
+	}
+
+	return cfg
+}
+
 // fetchCurrentOperatorPubKey issues a fresh GetInfo round-trip to the
 // operator and returns the operator's current long-term public key. The
 // daemon-startup OperatorTerms cache is also refreshed as a side effect so
@@ -4212,6 +4229,7 @@ func (s *Server) initVTXOManager(ctx context.Context,
 		ChainSource:              chainSourceRef,
 		ActorSystem:              s.actorSystem,
 		ChainParams:              s.chainParams,
+		ExpiryConfig:             s.vtxoExpiryConfig(),
 		Log:                      fn.Some(s.subLogger(vtxo.Subsystem)),
 		RoundActor:               roundActor,
 		LedgerSink:               fn.Some(ledgerSink),

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -1067,8 +1067,11 @@ type ServerInfo struct {
 	// cap locally on receive and boarding flows. A value of zero means
 	// no cap.
 	MaxUserBalance uint64 `protobuf:"varint,14,opt,name=max_user_balance,json=maxUserBalance,proto3" json:"max_user_balance,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// free_refresh_window_blocks is the operator's late-lifetime refresh
+	// waiver window. Zero disables the policy.
+	FreeRefreshWindowBlocks uint32 `protobuf:"varint,15,opt,name=free_refresh_window_blocks,json=freeRefreshWindowBlocks,proto3" json:"free_refresh_window_blocks,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *ServerInfo) Reset() {
@@ -1174,6 +1177,13 @@ func (x *ServerInfo) GetMinVtxoAmountSat() uint64 {
 func (x *ServerInfo) GetMaxUserBalance() uint64 {
 	if x != nil {
 		return x.MaxUserBalance
+	}
+	return 0
+}
+
+func (x *ServerInfo) GetFreeRefreshWindowBlocks() uint32 {
+	if x != nil {
+		return x.FreeRefreshWindowBlocks
 	}
 	return 0
 }
@@ -9900,7 +9910,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0fidentity_pubkey\x18\n" +
 	" \x01(\tR\x0eidentityPubkey\x124\n" +
 	"\vserver_info\x18\v \x01(\v2\x13.waverpc.ServerInfoR\n" +
-	"serverInfo\"\xcf\x03\n" +
+	"serverInfo\"\x8c\x04\n" +
 	"\n" +
 	"ServerInfo\x12'\n" +
 	"\x0foperator_pubkey\x18\x01 \x01(\fR\x0eoperatorPubkey\x12.\n" +
@@ -9915,7 +9925,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\x10min_operator_fee\x18\v \x01(\x04R\x0eminOperatorFee\x12+\n" +
 	"\x11min_confirmations\x18\f \x01(\rR\x10minConfirmations\x12-\n" +
 	"\x13min_vtxo_amount_sat\x18\r \x01(\x04R\x10minVtxoAmountSat\x12(\n" +
-	"\x10max_user_balance\x18\x0e \x01(\x04R\x0emaxUserBalance\"9\n" +
+	"\x10max_user_balance\x18\x0e \x01(\x04R\x0emaxUserBalance\x12;\n" +
+	"\x1afree_refresh_window_blocks\x18\x0f \x01(\rR\x17freeRefreshWindowBlocks\"9\n" +
 	"\x0eGenSeedRequest\x12'\n" +
 	"\x0fseed_passphrase\x18\x01 \x01(\fR\x0eseedPassphrase\"V\n" +
 	"\x0fGenSeedResponse\x12\x1a\n" +

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -405,6 +405,10 @@ message ServerInfo {
     // cap locally on receive and boarding flows. A value of zero means
     // no cap.
     uint64 max_user_balance = 14;
+
+    // free_refresh_window_blocks is the operator's late-lifetime refresh
+    // waiver window. Zero disables the policy.
+    uint32 free_refresh_window_blocks = 15;
 }
 
 message GenSeedRequest {


### PR DESCRIPTION
## What changed

- Carry `free_refresh_window_blocks` through Ark `GetInfo`, operator terms, daemon `GetInfo`, the native SDK, REST, and walletdk.
- Preserve the cached operator value when daemon `GetInfo` constructs wallet-facing `ServerInfo`.
- Delay automatic refresh to the advertised waiver boundary only when the wallet retains its unilateral-exit safety threshold and cooperative retry buffer.
- Read the latest cached operator terms for long-lived VTXO actors and retry preparation after transient operator lookup failures.
- Preserve ordinary earlier refresh behavior when the free window is disabled or too late to be safe.

## Scope

This PR contains no manual selection expansion, `RequireAll`, aggregate batch threshold, cohort, identity, or atomic batching changes. Those belong in a separate follow-up.

Paired with lightninglabs/lumos#675.

## Validation

- `go test ./arkrpc ./lib/types ./vtxo ./waved ./waverpc ./sdk/ark ./sdk/wavewalletdk`
- `make unit pkg=./waved case=TestGetInfoIncludesServerInfo timeout=5m`
- `make GOPATH="$(go env GOPATH)" lint-changed-local`
- `make commitmsg-lint range="d6202fb3..HEAD"`
- `make rpc`

The full `go test ./...` run hit two unrelated timing-sensitive tests; both passed on immediate isolated rerun.