### PR TITLE
swapwallet: harden credit activity projection

### DIFF
--- a/db/activity_store.go
+++ b/db/activity_store.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
+	"reflect"
 
 	"github.com/lightninglabs/wavelength/db/sqlc"
 	"github.com/lightningnetwork/lnd/clock"
@@ -15,7 +17,7 @@ import (
 // append-only activity_events transition log.
 type ActivityStore interface {
 	UpsertActivityEntry(ctx context.Context,
-		arg sqlc.UpsertActivityEntryParams) error
+		arg sqlc.UpsertActivityEntryParams) (int64, error)
 
 	AppendActivityEvent(ctx context.Context,
 		arg sqlc.AppendActivityEventParams) (int64, error)
@@ -57,33 +59,75 @@ type BatchedActivityStore interface {
 // Empty BLOB handles MUST be passed as nil, never a zero-length slice, to avoid
 // the Postgres BYTEA `x”` pitfall. ConfirmationHeight is nil until known.
 type ActivityProjection struct {
-	CanonicalID   string
-	Kind          int64
-	Status        int64
-	AmountSat     int64
-	FeeSat        int64
-	Counterparty  string
-	Note          string
-	Phase         int64
-	PhaseLabel    string
-	FailureCode   int64
+	// CanonicalID is the stable identity used to update one activity row.
+	CanonicalID string
+
+	// Kind identifies the wallet activity category.
+	Kind int64
+
+	// Status is the lifecycle state being projected.
+	Status int64
+
+	// AmountSat is the signed activity amount in satoshis.
+	AmountSat int64
+
+	// FeeSat is the activity fee in satoshis.
+	FeeSat int64
+
+	// Counterparty identifies the activity destination or source.
+	Counterparty string
+
+	// Note is immutable user-facing context attached at admission.
+	Note string
+
+	// Phase identifies the current detailed lifecycle phase.
+	Phase int64
+
+	// PhaseLabel is the display label for Phase.
+	PhaseLabel string
+
+	// FailureCode identifies a terminal activity failure.
+	FailureCode int64
+
+	// FailureReason describes a terminal activity failure.
 	FailureReason string
 
-	PaymentHash        []byte
-	Txid               []byte
-	ConfirmationHeight *int64
-	VtxoOutpoint       string
+	// PendingStatus identifies the pending enum value used to reject stale
+	// terminal-to-pending transitions.
+	PendingStatus int64
 
+	// PaymentHash correlates Lightning and credit payment activity.
+	PaymentHash []byte
+
+	// Txid identifies an on-chain activity transaction.
+	Txid []byte
+
+	// ConfirmationHeight is the on-chain confirmation height when known.
+	ConfirmationHeight *int64
+
+	// VtxoOutpoint identifies the Ark VTXO affected by this activity.
+	VtxoOutpoint string
+
+	// SwapSessionID correlates activity with its swap session.
 	SwapSessionID []byte
-	LedgerTxid    []byte
-	BoardingAddr  []byte
-	RequestJSON   string
+
+	// LedgerTxid correlates activity with its credit ledger transaction.
+	LedgerTxid []byte
+
+	// BoardingAddr is the on-chain address used for a boarding deposit.
+	BoardingAddr []byte
+
+	// RequestJSON preserves the immutable activity request snapshot.
+	RequestJSON string
 
 	// EntryJSON is the protojson snapshot of the WalletEntry emitted at
 	// this transition, stored verbatim on the activity_events row.
 	EntryJSON string
 
+	// CreatedAtUnix is the activity creation timestamp in Unix seconds.
 	CreatedAtUnix int64
+
+	// UpdatedAtUnix is the lifecycle update timestamp in Unix seconds.
 	UpdatedAtUnix int64
 }
 
@@ -153,7 +197,7 @@ func (s *ActivityPersistenceStore) ProjectEntry(ctx context.Context,
 			return err
 		}
 
-		if err := q.UpsertActivityEntry(
+		rows, err := q.UpsertActivityEntry(
 			ctx, sqlc.UpsertActivityEntryParams{
 				CanonicalID:   p.CanonicalID,
 				Kind:          p.Kind,
@@ -178,9 +222,14 @@ func (s *ActivityPersistenceStore) ProjectEntry(ctx context.Context,
 				RequestJson:   p.RequestJSON,
 				CreatedAtUnix: createdAt,
 				UpdatedAtUnix: updatedAt,
+				PendingStatus: p.PendingStatus,
 			},
-		); err != nil {
+		)
+		if err != nil {
 			return err
+		}
+		if rows == 0 {
+			return nil
 		}
 
 		seq, err := q.AppendActivityEvent(
@@ -317,10 +366,16 @@ func (s *ActivityPersistenceStore) PullEvents(ctx context.Context, cursor int64,
 // e, i.e. whether it represents a genuine lifecycle transition. It mirrors the
 // UpsertActivityEntry semantics: scalar lifecycle columns overwrite directly,
 // while an empty note and the settlement/correlation handles preserve their
-// stored values. request_json and entry_json are deliberately NOT compared:
-// protojson output is not byte-stable, so comparing it would report spurious
-// changes; the request is immutable per operation anyway.
+// stored values. RequestJSON is compared semantically because a later rich
+// projection may be the first source of immutable invoice context. EntryJSON
+// is not compared because it is the event representation of the effective row,
+// not an independently mutable current-state field.
 func (p ActivityProjection) changesRow(e sqlc.ActivityEntry) bool {
+	if p.PendingStatus != 0 && p.Status == p.PendingStatus &&
+		e.Status != p.PendingStatus {
+		return false
+	}
+
 	if p.Kind != e.Kind ||
 		p.Status != e.Status ||
 		p.AmountSat != e.AmountSat ||
@@ -334,6 +389,9 @@ func (p ActivityProjection) changesRow(e sqlc.ActivityEntry) bool {
 		return true
 	}
 	if p.Note != "" && p.Note != e.Note {
+		return true
+	}
+	if jsonValueChanges(p.RequestJSON, e.RequestJson) {
 		return true
 	}
 
@@ -353,6 +411,26 @@ func (p ActivityProjection) changesRow(e sqlc.ActivityEntry) bool {
 	}
 
 	return false
+}
+
+// jsonValueChanges reports whether a non-empty JSON projection changes the
+// stored semantic value. Empty input preserves the current value. Malformed
+// input falls back to exact comparison so corruption is never hidden as a
+// change-suppressed no-op.
+func jsonValueChanges(next, stored string) bool {
+	if next == "" || next == stored {
+		return false
+	}
+
+	var nextValue, storedValue any
+	if err := json.Unmarshal([]byte(next), &nextValue); err != nil {
+		return next != stored
+	}
+	if err := json.Unmarshal([]byte(stored), &storedValue); err != nil {
+		return next != stored
+	}
+
+	return !reflect.DeepEqual(nextValue, storedValue)
 }
 
 // blobChanges reports whether a COALESCEd blob handle changes the stored value:

--- a/db/activity_store_test.go
+++ b/db/activity_store_test.go
@@ -37,15 +37,16 @@ func projected(_ int64, err error) error {
 // sampleProjection returns a populated projection for the given canonical id.
 func sampleProjection(id string) ActivityProjection {
 	return ActivityProjection{
-		CanonicalID:  id,
-		Kind:         1, // send
-		Status:       1, // pending
-		AmountSat:    -1000,
-		FeeSat:       10,
-		Counterparty: "cp",
-		Note:         "note",
-		Phase:        2,
-		PhaseLabel:   "funding",
+		CanonicalID:   id,
+		Kind:          1, // send
+		Status:        1, // pending
+		AmountSat:     -1000,
+		FeeSat:        10,
+		Counterparty:  "cp",
+		Note:          "note",
+		Phase:         2,
+		PhaseLabel:    "funding",
+		PendingStatus: 1,
 		PaymentHash: []byte{
 			0xaa,
 			0xbb,
@@ -88,6 +89,77 @@ func TestActivityStoreProjectInsertsEntryAndEvent(t *testing.T) {
 	require.Len(t, events, 1)
 	require.Equal(t, "a", events[0].CanonicalID)
 	require.EqualValues(t, 1, events[0].Status)
+}
+
+// TestActivityStoreRejectsTerminalRegression verifies a stale pending write
+// cannot overwrite a terminal row or append a backward lifecycle event.
+func TestActivityStoreRejectsTerminalRegression(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActivityStoreForTest(t)
+
+	pending := sampleProjection("ordered")
+	_, err := store.ProjectEntry(ctx, pending)
+	require.NoError(t, err)
+
+	complete := pending
+	complete.Status = 2
+	complete.Phase = 3
+	complete.EntryJSON = `{"id":"ordered","status":"complete"}`
+	complete.UpdatedAtUnix = 200
+	_, err = store.ProjectEntry(ctx, complete)
+	require.NoError(t, err)
+
+	staleSeq, err := store.ProjectEntry(ctx, pending)
+	require.NoError(t, err)
+	require.Zero(t, staleSeq)
+
+	row, err := store.GetEntry(ctx, "ordered")
+	require.NoError(t, err)
+	require.EqualValues(t, 2, row.Status)
+	require.EqualValues(t, 3, row.Phase)
+
+	events, err := store.PullEvents(ctx, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+}
+
+// TestActivityStoreRequestOnlyEnrichment verifies immutable request context is
+// allowed to enrich an otherwise unchanged sparse row exactly once.
+func TestActivityStoreRequestOnlyEnrichment(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := newActivityStoreForTest(t)
+
+	sparse := sampleProjection("request-context")
+	sparse.RequestJSON = ""
+	_, err := store.ProjectEntry(ctx, sparse)
+	require.NoError(t, err)
+
+	rich := sparse
+	rich.RequestJSON = `{"lightningInvoice":{"invoice":"lnbc1"}}`
+	rich.EntryJSON = `{"id":"request-context","request":` +
+		`{"lightningInvoice":{"invoice":"lnbc1"}}}`
+	richSeq, err := store.ProjectEntry(ctx, rich)
+	require.NoError(t, err)
+	require.Positive(t, richSeq)
+
+	row, err := store.GetEntry(ctx, "request-context")
+	require.NoError(t, err)
+	require.JSONEq(t, rich.RequestJSON, row.RequestJson)
+
+	semanticallyEqual := rich
+	semanticallyEqual.RequestJSON = `{ "lightningInvoice": {` +
+		`"invoice": "lnbc1" } }`
+	equalSeq, err := store.ProjectEntry(ctx, semanticallyEqual)
+	require.NoError(t, err)
+	require.Zero(t, equalSeq)
+
+	events, err := store.PullEvents(ctx, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
 }
 
 // TestActivityStoreCountByStatus verifies CountByStatus returns a full,

--- a/db/sqlc/activity_log.sql.go
+++ b/db/sqlc/activity_log.sql.go
@@ -275,7 +275,7 @@ func (q *Queries) PullActivityEvents(ctx context.Context, arg PullActivityEvents
 	return items, nil
 }
 
-const UpsertActivityEntry = `-- name: UpsertActivityEntry :exec
+const UpsertActivityEntry = `-- name: UpsertActivityEntry :execrows
 
 INSERT INTO activity_entries (
     canonical_id, kind, status, amount_sat, fee_sat, counterparty, note,
@@ -310,6 +310,8 @@ ON CONFLICT (canonical_id) DO UPDATE SET
     boarding_addr   = COALESCE(EXCLUDED.boarding_addr, activity_entries.boarding_addr),
     request_json    = COALESCE(NULLIF(EXCLUDED.request_json, ''), activity_entries.request_json),
     updated_at_unix = EXCLUDED.updated_at_unix
+WHERE activity_entries.status = $22
+    OR EXCLUDED.status <> $22
 `
 
 type UpsertActivityEntryParams struct {
@@ -334,6 +336,7 @@ type UpsertActivityEntryParams struct {
 	RequestJson        string
 	CreatedAtUnix      int64
 	UpdatedAtUnix      int64
+	PendingStatus      int64
 }
 
 // Canonical activity log queries. activity_entries is the current-state
@@ -345,8 +348,8 @@ type UpsertActivityEntryParams struct {
 // the row keeps its position in the created-ordered feed. The settlement and
 // correlation handles are COALESCEd so an early projection that does not yet
 // know a txid never clobbers one a later projection already recorded.
-func (q *Queries) UpsertActivityEntry(ctx context.Context, arg UpsertActivityEntryParams) error {
-	_, err := q.db.ExecContext(ctx, UpsertActivityEntry,
+func (q *Queries) UpsertActivityEntry(ctx context.Context, arg UpsertActivityEntryParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, UpsertActivityEntry,
 		arg.CanonicalID,
 		arg.Kind,
 		arg.Status,
@@ -368,6 +371,10 @@ func (q *Queries) UpsertActivityEntry(ctx context.Context, arg UpsertActivityEnt
 		arg.RequestJson,
 		arg.CreatedAtUnix,
 		arg.UpdatedAtUnix,
+		arg.PendingStatus,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -343,7 +343,7 @@ type Querier interface {
 	// the row keeps its position in the created-ordered feed. The settlement and
 	// correlation handles are COALESCEd so an early projection that does not yet
 	// know a txid never clobbers one a later projection already recorded.
-	UpsertActivityEntry(ctx context.Context, arg UpsertActivityEntryParams) error
+	UpsertActivityEntry(ctx context.Context, arg UpsertActivityEntryParams) (int64, error)
 	UpsertChainInfo(ctx context.Context, arg UpsertChainInfoParams) error
 	// Credit operations control-plane queries.
 	UpsertCreditOperation(ctx context.Context, arg UpsertCreditOperationParams) error

--- a/db/sqlc/queries/activity_log.sql
+++ b/db/sqlc/queries/activity_log.sql
@@ -2,7 +2,7 @@
 -- projection read by List; activity_events is the append-only transition log
 -- read by a resumable SubscribeWallet. See docs/canonical_activity_log_design.md.
 
--- name: UpsertActivityEntry :exec
+-- name: UpsertActivityEntry :execrows
 -- UpsertActivityEntry inserts the activity row or advances it in place. On
 -- conflict the mutable lifecycle columns are overwritten with the new
 -- projection and updated_at_unix is bumped, but created_at_unix is preserved so
@@ -41,7 +41,9 @@ ON CONFLICT (canonical_id) DO UPDATE SET
     ledger_txid     = COALESCE(EXCLUDED.ledger_txid, activity_entries.ledger_txid),
     boarding_addr   = COALESCE(EXCLUDED.boarding_addr, activity_entries.boarding_addr),
     request_json    = COALESCE(NULLIF(EXCLUDED.request_json, ''), activity_entries.request_json),
-    updated_at_unix = EXCLUDED.updated_at_unix;
+    updated_at_unix = EXCLUDED.updated_at_unix
+WHERE activity_entries.status = sqlc.arg(pending_status)
+    OR EXCLUDED.status <> sqlc.arg(pending_status);
 
 -- name: AppendActivityEvent :one
 -- AppendActivityEvent records one immutable lifecycle-transition row and

--- a/swapwallet/credit_projector.go
+++ b/swapwallet/credit_projector.go
@@ -3,6 +3,7 @@
 package swapwallet
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -26,15 +27,95 @@ const creditProjectInterval = 5 * time.Second
 // emit so the projected terminal update lands on the same row.
 const creditCounterparty = "credit"
 
-// creditProjectorOwnsSwapSummary reports whether the durable credit operation,
-// rather than the generic swap monitor or history reconciler, owns a swap's
-// wallet activity row. Credit-only SDK swaps persist a zero Ark funding amount,
-// while the credit operation retains the invoice principal. The server emits
-// CREDIT only for a fully credit-funded invoice; partial credit funding emits
-// MIXED and remains owned by the generic swap lifecycle.
-func creditProjectorOwnsSwapSummary(summary *swapclientrpc.SwapSummary) bool {
-	return summary != nil && summary.GetSettlementType() == swapclientrpc.
-		SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT
+// creditProjectorOwnsSwapSummary reports whether this wallet's durable credit
+// operation, rather than the generic swap monitor or history reconciler, owns
+// a swap activity row. CREDIT settlement identifies the rail, while the local
+// ownership set proves the operation was admitted through this wallet's credit
+// registry.
+func (r *Runtime) creditProjectorOwnsSwapSummary(
+	summary *swapclientrpc.SwapSummary) bool {
+
+	if summary == nil || summary.GetSettlementType() != swapclientrpc.
+		SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT {
+		return false
+	}
+
+	r.creditOwnerMu.RLock()
+	defer r.creditOwnerMu.RUnlock()
+
+	_, ok := r.creditOwnedSwaps[summary.GetPaymentHash()]
+
+	return ok
+}
+
+// markCreditProjectorOwned records a successfully admitted local credit-only
+// pay so subsequent swap summaries cannot claim its activity row.
+func (r *Runtime) markCreditProjectorOwned(paymentHash string) {
+	if paymentHash == "" {
+		return
+	}
+
+	r.creditOwnerMu.Lock()
+	defer r.creditOwnerMu.Unlock()
+
+	r.creditOwnedSwaps[paymentHash] = struct{}{}
+}
+
+// recordCreditProjectorOwnership adds credit-only pay operations from a full
+// durable registry snapshot. Ownership is monotonic because operations remain
+// durable after terminal settlement; merging also preserves an admission
+// marker while that operation is concurrently becoming visible to the poll.
+func (r *Runtime) recordCreditProjectorOwnership(ops []credit.CreditOpSummary) {
+	r.creditOwnerMu.Lock()
+	defer r.creditOwnerMu.Unlock()
+
+	for _, op := range ops {
+		if op.Kind != credit.KindPay || !op.CreditOnly {
+			continue
+		}
+
+		paymentHash := strings.TrimPrefix(op.OpKey, "pay:")
+		if paymentHash != "" && paymentHash != op.OpKey {
+			r.creditOwnedSwaps[paymentHash] = struct{}{}
+		}
+	}
+}
+
+// restoreCreditProjectorOwnership synchronously reconstructs wallet-local
+// credit activity ownership during the wallet-ready resume phase. It runs
+// before activity backfill and the live monitor start, closing the restart
+// window in which a credit-only SDK swap could otherwise project its zero Ark
+// funding amount before the asynchronous credit poll sees the durable op.
+func (r *Runtime) restoreCreditProjectorOwnership(ctx context.Context) {
+	if r.deps.CreditRegistry == nil {
+		return
+	}
+
+	resp, err := r.deps.CreditRegistry.Ask(
+		ctx, &credit.ListCreditOpsRequest{PendingOnly: false},
+	).Await(ctx).Unpack()
+	if err != nil {
+		r.deps.resolveLog().WarnS(
+			ctx,
+			"Credit ownership restore failed",
+			err,
+		)
+
+		return
+	}
+
+	list, ok := resp.(*credit.ListCreditOpsResponse)
+	if !ok {
+		r.deps.resolveLog().WarnS(
+			ctx,
+			"Credit ownership restore got unexpected response",
+			fmt.Errorf("got %T", resp),
+		)
+
+		return
+	}
+
+	r.recordCreditProjectorOwnership(list.Ops)
 }
 
 // startCreditProjectorLoop spawns the background goroutine that projects
@@ -114,6 +195,7 @@ func (r *Runtime) pollCreditOps(projected map[string]credit.State) {
 
 		return
 	}
+	r.recordCreditProjectorOwnership(list.Ops)
 
 	for i := range list.Ops {
 		op := list.Ops[i]
@@ -127,18 +209,6 @@ func (r *Runtime) pollCreditOps(projected map[string]credit.State) {
 			continue
 		}
 
-		projected[op.OpID] = op.State
-
-		// A terminal op clears wallet-local pending tracking so the
-		// deadline watcher stops ageing the row; a still-pending op is
-		// re-tracked so it survives a restart and appears in List
-		// snapshots even though the runtime's pending map is in-memory.
-		if op.State.IsTerminal() {
-			r.clearPending(entry.GetId())
-		} else {
-			r.trackPendingEntryWithoutTimeout(entry)
-		}
-
 		// Project the credit row into the canonical activity log before
 		// fanning it out. Credit-only sends reach the feed only through
 		// this poll (never Runtime.emit from the swap monitor), so
@@ -147,7 +217,20 @@ func (r *Runtime) pollCreditOps(projected map[string]credit.State) {
 		// class of bug). The store suppresses no-op re-projections, so
 		// the coarse re-poll of unchanged terminal rows appends no
 		// duplicate events.
-		r.projectAndEmit(r.rootCtx, entry)
+		if _, err := r.projectEmitLocked(r.rootCtx, entry); err != nil {
+			continue
+		}
+
+		projected[op.OpID] = op.State
+
+		// Advance in-memory tracking only after the durable projection
+		// succeeds. A failed write remains eligible for the next poll
+		// and cannot strand an unchanged terminal operation.
+		if op.State.IsTerminal() {
+			r.clearPending(entry.GetId())
+		} else {
+			r.trackPendingEntryWithoutTimeout(entry)
+		}
 	}
 }
 

--- a/swapwallet/credit_projector_test.go
+++ b/swapwallet/credit_projector_test.go
@@ -3,9 +3,11 @@
 package swapwallet
 
 import (
+	"context"
 	"testing"
 
 	"github.com/lightninglabs/wavelength/credit"
+	"github.com/lightninglabs/wavelength/rpc/swapclientrpc"
 	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
 	"github.com/stretchr/testify/require"
 )
@@ -92,6 +94,16 @@ func TestCreditProjectorProjectsOwnedTerminals(t *testing.T) {
 	ch := runtime.subscribe()
 	projected := make(map[string]credit.State)
 	runtime.pollCreditOps(projected)
+	require.True(
+		t,
+		runtime.creditProjectorOwnsSwapSummary(
+			&swapclientrpc.SwapSummary{
+				PaymentHash: payHashHex,
+				SettlementType: swapclientrpc.
+					SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT,
+			},
+		),
+	)
 
 	got := drainEntries(ch)
 	require.Len(t, got, 2)
@@ -133,6 +145,40 @@ func TestCreditProjectorProjectsOwnedTerminals(t *testing.T) {
 	// A second poll with unchanged state emits nothing.
 	runtime.pollCreditOps(projected)
 	require.Empty(t, drainEntries(ch))
+}
+
+// TestResumeAllRestoresCreditOwnershipBeforeMonitor verifies the wallet-ready
+// resume phase rebuilds durable credit ownership before startup backfill and
+// live monitoring can derive a zero-amount SDK swap row.
+func TestResumeAllRestoresCreditOwnershipBeforeMonitor(t *testing.T) {
+	t.Parallel()
+
+	reg := &fakeCreditRegistry{
+		listResp: &credit.ListCreditOpsResponse{
+			Ops: []credit.CreditOpSummary{{
+				OpID:       "op-restart-pay",
+				OpKey:      "pay:" + payHashHex,
+				Kind:       credit.KindPay,
+				State:      credit.StateCompleted,
+				CreditOnly: true,
+			}},
+		},
+	}
+	runtime := newRuntime(t.Context(), &Deps{CreditRegistry: reg})
+	t.Cleanup(runtime.stop)
+
+	runtime.resumeAll(t.Context())
+
+	require.True(
+		t,
+		runtime.creditProjectorOwnsSwapSummary(
+			&swapclientrpc.SwapSummary{
+				PaymentHash: payHashHex,
+				SettlementType: swapclientrpc.
+					SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT,
+			},
+		),
+	)
 }
 
 // TestCreditProjectorWritesToStore asserts the projector persists the credit
@@ -257,4 +303,47 @@ func TestCreditProjectorTracksPendingForRestart(t *testing.T) {
 		t, wavewalletrpc.EntryStatus_ENTRY_STATUS_PENDING,
 		snapshot[0].GetStatus(),
 	)
+}
+
+// TestCreditProjectorRetriesFailedTerminalProjection verifies a transient
+// activity-store failure does not memoize terminal state or clear pending
+// tracking before the next poll durably records the transition.
+func TestCreditProjectorRetriesFailedTerminalProjection(t *testing.T) {
+	t.Parallel()
+
+	reg := &fakeCreditRegistry{
+		listResp: &credit.ListCreditOpsResponse{
+			Ops: []credit.CreditOpSummary{{
+				OpID:       "op-pay",
+				OpKey:      "pay:" + payHashHex,
+				Kind:       credit.KindPay,
+				State:      credit.StateCompleted,
+				CreditOnly: true,
+				AmountSat:  500,
+			}},
+		},
+	}
+	store := &fakeActivityProjector{err: context.DeadlineExceeded}
+	runtime := newRuntime(t.Context(), &Deps{
+		CreditRegistry: reg,
+		ActivityStore:  store,
+	})
+	t.Cleanup(runtime.stop)
+	runtime.trackPendingEntryWithoutTimeout(&wavewalletrpc.WalletEntry{
+		Id:     payHashHex,
+		Kind:   wavewalletrpc.EntryKind_ENTRY_KIND_SEND,
+		Status: wavewalletrpc.EntryStatus_ENTRY_STATUS_PENDING,
+	})
+
+	projected := make(map[string]credit.State)
+	runtime.pollCreditOps(projected)
+	require.NotContains(t, projected, "op-pay")
+	require.Len(t, runtime.pendingSnapshot(), 1)
+	require.Zero(t, store.count())
+
+	store.err = nil
+	runtime.pollCreditOps(projected)
+	require.Equal(t, credit.StateCompleted, projected["op-pay"])
+	require.Empty(t, runtime.pendingSnapshot())
+	require.Equal(t, 1, store.count())
 }

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -612,7 +612,9 @@ func (h *history) collectSwapEntries(ctx context.Context) (
 		// and retains the invoice principal, so derived history must
 		// not race that projector during startup backfill or periodic
 		// reconcile.
-		if creditProjectorOwnsSwapSummary(s) {
+		if h.runtime != nil &&
+			h.runtime.creditProjectorOwnsSwapSummary(s) {
+
 			continue
 		}
 

--- a/swapwallet/monitor.go
+++ b/swapwallet/monitor.go
@@ -186,7 +186,7 @@ func (r *Runtime) fanOutSwapUpdate(
 	// Letting the generic swap monitor project the SDK row would race the
 	// credit projector and temporarily overwrite a one-satoshi SEND with a
 	// zero-satoshi terminal row.
-	if creditProjectorOwnsSwapSummary(summary) {
+	if r.creditProjectorOwnsSwapSummary(summary) {
 		return nil
 	}
 

--- a/swapwallet/monitor_test.go
+++ b/swapwallet/monitor_test.go
@@ -100,18 +100,45 @@ func TestMonitorLoopFansOutSwapUpdates(t *testing.T) {
 	)
 }
 
-// TestMonitorLoopSkipsCreditOnlySwaps asserts that a completed credit-only
-// SDK swap row cannot overwrite the activity row owned by the durable credit
-// projector. The SDK row records Ark funding amount, which is zero for a
-// fully credit-funded payment, while the credit operation retains the invoice
-// principal used by wallet activity.
-func TestMonitorLoopSkipsCreditOnlySwaps(t *testing.T) {
+// TestMonitorLoopDoesNotInferCreditOwnershipFromRail verifies a CREDIT swap
+// created through the public swap RPC remains visible when this wallet has no
+// matching locally admitted credit operation.
+func TestMonitorLoopDoesNotInferCreditOwnershipFromRail(t *testing.T) {
 	t.Parallel()
 
 	store := &fakeActivityProjector{}
 	r := newRuntime(t.Context(), &Deps{ActivityStore: store})
 	defer r.stop()
 
+	sub := r.subscribe()
+	err := r.fanOutSwapUpdate(&swapclientrpc.SubscribeSwapsResponse{
+		Swap: &swapclientrpc.SwapSummary{
+			PaymentHash: "credit-only",
+			Direction: swapclientrpc.
+				SwapDirection_SWAP_DIRECTION_PAY,
+			State: swapclientrpc.
+				SwapState_SWAP_STATE_COMPLETED,
+			AmountSat: 0,
+			SettlementType: swapclientrpc.
+				SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, drainEntries(sub), 1)
+	require.Equal(t, 1, store.count())
+}
+
+// TestMonitorLoopSkipsLocallyOwnedCreditSwap asserts a completed credit-only
+// SDK swap cannot overwrite the row owned by this wallet's durable credit
+// operation.
+func TestMonitorLoopSkipsLocallyOwnedCreditSwap(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeActivityProjector{}
+	r := newRuntime(t.Context(), &Deps{ActivityStore: store})
+	defer r.stop()
+
+	r.markCreditProjectorOwned("credit-only")
 	sub := r.subscribe()
 	err := r.fanOutSwapUpdate(&swapclientrpc.SubscribeSwapsResponse{
 		Swap: &swapclientrpc.SwapSummary{

--- a/swapwallet/projector.go
+++ b/swapwallet/projector.go
@@ -4,7 +4,9 @@ package swapwallet
 
 import (
 	"context"
+	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -12,22 +14,26 @@ import (
 	"github.com/lightninglabs/wavelength/db/sqlc"
 	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 // project writes one emitted WalletEntry into the canonical activity log: it
 // upserts the current-state row and appends the transition event, atomically.
-// It returns the event_seq assigned to the appended transition with a nil error
-// on success, (0, nil) when the projection was intentionally skipped (no store,
-// no id, or a change-suppressed no-op), and (0, err) when the durable write
-// failed. A caller stamps a live update with the returned seq and can gate a
-// follow-up side effect on the row actually landing. When no store is wired
-// (tests, or a build without a database) projection is a no-op and the legacy
-// derive-on-read path continues unchanged.
+// It returns the event_seq and effective entry assigned to the appended
+// transition with a nil error on success, (0, entry, nil) when projection is
+// intentionally skipped because no store or canonical id exists, (0,
+// effectiveEntry, nil) for a change-suppressed no-op, and (0, nil, err) when
+// the durable write failed. The effective entry carries immutable context
+// merged from the current durable row, so persisted and live snapshots agree.
+// A caller stamps a live update with the returned seq and can gate a follow-up
+// side effect on the row actually landing. When no store is wired, projection
+// is a no-op and the legacy derive-on-read path continues unchanged.
 func (r *Runtime) project(ctx context.Context,
-	entry *wavewalletrpc.WalletEntry) (int64, error) {
+	entry *wavewalletrpc.WalletEntry) (int64, *wavewalletrpc.WalletEntry,
+	error) {
 
 	if r.deps == nil || r.deps.ActivityStore == nil {
-		return 0, nil
+		return 0, entry, nil
 	}
 
 	// A row with no canonical id cannot be keyed; skip it, matching the
@@ -39,15 +45,33 @@ func (r *Runtime) project(ctx context.Context,
 	if entry.GetId() == "" ||
 		entry.GetId() == syntheticBoardingUnconfirmedID ||
 		isUnconfirmedBoardingOverlay(entry) {
-		return 0, nil
+		return 0, entry, nil
 	}
 
-	projection, err := entryToProjection(entry)
+	effectiveEntry := proto.Clone(entry).(*wavewalletrpc.WalletEntry)
+	existingRow, err := r.deps.ActivityStore.GetEntry(ctx, entry.GetId())
+	switch {
+	case err == nil:
+		existingEntry, err := rowToWalletEntry(existingRow)
+		if err != nil {
+			return 0, nil, fmt.Errorf("decode existing "+
+				"activity row: %w", err)
+		}
+		effectiveEntry = mergeActivityContext(
+			existingEntry, effectiveEntry,
+		)
+
+	case errors.Is(err, sql.ErrNoRows):
+	default:
+		return 0, nil, fmt.Errorf("read existing activity row: %w", err)
+	}
+
+	projection, err := entryToProjection(effectiveEntry)
 	if err != nil {
 		r.deps.resolveLog().WarnS(ctx, "Activity projection skipped: "+
 			"encode failed", err)
 
-		return 0, err
+		return 0, nil, err
 	}
 
 	seq, err := r.deps.ActivityStore.ProjectEntry(ctx, projection)
@@ -56,10 +80,52 @@ func (r *Runtime) project(ctx context.Context,
 			err,
 		)
 
-		return 0, err
+		return 0, nil, err
 	}
 
-	return seq, nil
+	return seq, effectiveEntry, nil
+}
+
+// mergeActivityContext carries immutable request and correlation context from
+// the durable current row into a later sparse lifecycle projection. The next
+// projection remains authoritative for mutable status, amount, phase, and
+// failure fields.
+func mergeActivityContext(
+	existing, next *wavewalletrpc.WalletEntry) *wavewalletrpc.WalletEntry {
+
+	if next.GetNote() == "" {
+		next.Note = existing.GetNote()
+	}
+	if next.GetRequest() == nil && existing.GetRequest() != nil {
+		next.Request =
+			proto.Clone(existing.GetRequest()).(*wavewalletrpc.WalletEntryRequest)
+	}
+	if next.GetCreatedAtUnix() == 0 {
+		next.CreatedAtUnix = existing.GetCreatedAtUnix()
+	}
+
+	existingProgress := existing.GetProgress()
+	if existingProgress == nil {
+		return next
+	}
+	if next.Progress == nil {
+		next.Progress = &wavewalletrpc.WalletEntryProgress{}
+	}
+	if next.Progress.GetPaymentHash() == "" {
+		next.Progress.PaymentHash = existingProgress.GetPaymentHash()
+	}
+	if next.Progress.GetTxid() == "" {
+		next.Progress.Txid = existingProgress.GetTxid()
+	}
+	if next.Progress.GetConfirmationHeight() == 0 {
+		next.Progress.ConfirmationHeight =
+			existingProgress.GetConfirmationHeight()
+	}
+	if next.Progress.GetVtxoOutpoint() == "" {
+		next.Progress.VtxoOutpoint = existingProgress.GetVtxoOutpoint()
+	}
+
+	return next
 }
 
 // isUnconfirmedBoardingOverlay identifies the address-scoped live row without
@@ -102,14 +168,14 @@ func (r *Runtime) projectEmitLocked(ctx context.Context,
 	r.projectMu.Lock()
 	defer r.projectMu.Unlock()
 
-	seq, err := r.project(ctx, entry)
+	seq, effectiveEntry, err := r.project(ctx, entry)
 
 	switch {
 	case r.deps == nil || r.deps.ActivityStore == nil:
-		r.emit(0, entry)
+		r.emit(0, effectiveEntry)
 
 	case seq > 0:
-		r.emit(seq, entry)
+		r.emit(seq, effectiveEntry)
 	}
 
 	return seq, err
@@ -320,17 +386,20 @@ func entryToProjection(entry *wavewalletrpc.WalletEntry) (db.ActivityProjection,
 	}
 
 	return db.ActivityProjection{
-		CanonicalID:        entry.GetId(),
-		Kind:               int64(entry.GetKind()),
-		Status:             int64(entry.GetStatus()),
-		AmountSat:          entry.GetAmountSat(),
-		FeeSat:             entry.GetFeeSat(),
-		Counterparty:       entry.GetCounterparty(),
-		Note:               entry.GetNote(),
-		Phase:              int64(progress.GetPhase()),
-		PhaseLabel:         progress.GetPhaseLabel(),
-		FailureCode:        int64(entry.GetFailureCode()),
-		FailureReason:      entry.GetFailureReason(),
+		CanonicalID:   entry.GetId(),
+		Kind:          int64(entry.GetKind()),
+		Status:        int64(entry.GetStatus()),
+		AmountSat:     entry.GetAmountSat(),
+		FeeSat:        entry.GetFeeSat(),
+		Counterparty:  entry.GetCounterparty(),
+		Note:          entry.GetNote(),
+		Phase:         int64(progress.GetPhase()),
+		PhaseLabel:    progress.GetPhaseLabel(),
+		FailureCode:   int64(entry.GetFailureCode()),
+		FailureReason: entry.GetFailureReason(),
+		PendingStatus: int64(
+			wavewalletrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		),
 		PaymentHash:        hexBytesOrNil(progress.GetPaymentHash()),
 		Txid:               hexBytesOrNil(progress.GetTxid()),
 		ConfirmationHeight: confHeight,

--- a/swapwallet/projector_test.go
+++ b/swapwallet/projector_test.go
@@ -4,6 +4,7 @@ package swapwallet
 
 import (
 	"context"
+	"database/sql"
 	"sync"
 	"testing"
 	"time"
@@ -48,6 +49,14 @@ func (f *fakeActivityProjector) ProjectEntry(_ context.Context,
 	// Return a positive, increasing seq so projectAndEmit treats each
 	// successful projection as a real transition worth emitting.
 	return int64(len(f.projected)), nil
+}
+
+// GetEntry reports no existing row. Tests that need durable merge behavior use
+// a real ActivityPersistenceStore.
+func (f *fakeActivityProjector) GetEntry(context.Context, string) (
+	sqlc.ActivityEntry, error) {
+
+	return sqlc.ActivityEntry{}, sql.ErrNoRows
 }
 
 func (f *fakeActivityProjector) count() int {
@@ -298,6 +307,181 @@ func TestProjectAndEmitStoreErrorDoesNotEmit(t *testing.T) {
 		t, drainEntries(ch),
 		"a failed projection must not be emitted",
 	)
+}
+
+// TestProjectAndEmitPreservesImmutableContext verifies a sparse terminal
+// projection emits and records the effective row enriched by the original
+// memo, invoice request, and receive payment hash.
+func TestProjectAndEmitPreservesImmutableContext(t *testing.T) {
+	t.Parallel()
+
+	history, store := newStoreListFixture(t)
+	runtime := history.runtime
+	sub := runtime.subscribe()
+	t.Cleanup(func() { runtime.unsubscribe(sub) })
+
+	pending := &wavewalletrpc.WalletEntry{
+		Id:            "credit-receive",
+		Kind:          wavewalletrpc.EntryKind_ENTRY_KIND_RECV,
+		Status:        wavewalletrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		AmountSat:     1,
+		Note:          "one sat",
+		CreatedAtUnix: 100,
+		UpdatedAtUnix: 100,
+		Request: &wavewalletrpc.WalletEntryRequest{
+			Request: &wavewalletrpc.WalletEntryRequest_LightningInvoice{
+				LightningInvoice: &wavewalletrpc.
+					LightningInvoiceRequest{
+					Invoice:     "lnbc1receive",
+					PaymentHash: "aabbcc",
+				},
+			},
+		},
+		Progress: &wavewalletrpc.WalletEntryProgress{
+			Phase: wavewalletrpc.
+				WalletEntryPhase_WALLET_ENTRY_PHASE_WAITING_FOR_PAYMENT,
+			PaymentHash: "aabbcc",
+		},
+	}
+	runtime.projectAndEmit(t.Context(), pending)
+	_ = recvEntry(t, sub)
+
+	terminal := &wavewalletrpc.WalletEntry{
+		Id:            pending.GetId(),
+		Kind:          pending.GetKind(),
+		Status:        wavewalletrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		AmountSat:     pending.GetAmountSat(),
+		UpdatedAtUnix: 200,
+		Progress: &wavewalletrpc.WalletEntryProgress{
+			Phase: wavewalletrpc.
+				WalletEntryPhase_WALLET_ENTRY_PHASE_CONFIRMED,
+		},
+	}
+	runtime.projectAndEmit(t.Context(), terminal)
+
+	live := recvEntry(t, sub)
+	require.Equal(t, "one sat", live.GetNote())
+	require.Equal(
+		t, "lnbc1receive",
+		live.GetRequest().GetLightningInvoice().GetInvoice(),
+	)
+	require.Equal(t, "aabbcc", live.GetProgress().GetPaymentHash())
+
+	events, err := store.PullEvents(t.Context(), 0, 10)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+
+	var replayed wavewalletrpc.WalletEntry
+	require.NoError(
+		t,
+		protojson.Unmarshal(
+			[]byte(events[1].EntryJson), &replayed,
+		),
+	)
+	require.Equal(t, "one sat", replayed.GetNote())
+	require.Equal(
+		t, "lnbc1receive",
+		replayed.GetRequest().GetLightningInvoice().GetInvoice(),
+	)
+	require.Equal(t, "aabbcc", replayed.GetProgress().GetPaymentHash())
+}
+
+// TestProjectAndEmitTerminalBeatsStalePending models a credit child completing
+// before the router writes its initial pending row. The stale pending
+// projection must neither overwrite the terminal row nor emit a backward live
+// event.
+func TestProjectAndEmitTerminalBeatsStalePending(t *testing.T) {
+	t.Parallel()
+
+	history, store := newStoreListFixture(t)
+	runtime := history.runtime
+	sub := runtime.subscribe()
+	t.Cleanup(func() { runtime.unsubscribe(sub) })
+
+	terminal := &wavewalletrpc.WalletEntry{
+		Id:            "fast-credit-pay",
+		Kind:          wavewalletrpc.EntryKind_ENTRY_KIND_SEND,
+		Status:        wavewalletrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		AmountSat:     -1,
+		CreatedAtUnix: 100,
+		UpdatedAtUnix: 200,
+		Progress: &wavewalletrpc.WalletEntryProgress{
+			Phase: wavewalletrpc.
+				WalletEntryPhase_WALLET_ENTRY_PHASE_CONFIRMED,
+		},
+	}
+	runtime.projectAndEmit(t.Context(), terminal)
+	require.Equal(
+		t, wavewalletrpc.EntryStatus_ENTRY_STATUS_COMPLETE,
+		recvEntry(t, sub).GetStatus(),
+	)
+
+	stalePending := proto.Clone(terminal).(*wavewalletrpc.WalletEntry)
+	stalePending.Status = wavewalletrpc.EntryStatus_ENTRY_STATUS_PENDING
+	stalePending.UpdatedAtUnix = 100
+	stalePending.Progress.Phase = wavewalletrpc.
+		WalletEntryPhase_WALLET_ENTRY_PHASE_SETTLING
+	runtime.projectAndEmit(t.Context(), stalePending)
+	require.Empty(t, drainEntries(sub))
+
+	row, err := store.GetEntry(t.Context(), terminal.GetId())
+	require.NoError(t, err)
+	require.EqualValues(
+		t, wavewalletrpc.EntryStatus_ENTRY_STATUS_COMPLETE, row.Status,
+	)
+
+	events, err := store.PullEvents(t.Context(), 0, 10)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+}
+
+// TestProjectAndEmitEnrichesRequestWithoutMemo verifies an invoice request can
+// enrich a sparse row even when memo is empty and no mutable lifecycle field
+// changes.
+func TestProjectAndEmitEnrichesRequestWithoutMemo(t *testing.T) {
+	t.Parallel()
+
+	history, store := newStoreListFixture(t)
+	runtime := history.runtime
+	sub := runtime.subscribe()
+	t.Cleanup(func() { runtime.unsubscribe(sub) })
+
+	sparse := &wavewalletrpc.WalletEntry{
+		Id:            "request-only",
+		Kind:          wavewalletrpc.EntryKind_ENTRY_KIND_RECV,
+		Status:        wavewalletrpc.EntryStatus_ENTRY_STATUS_PENDING,
+		AmountSat:     1,
+		CreatedAtUnix: 100,
+		UpdatedAtUnix: 100,
+	}
+	runtime.projectAndEmit(t.Context(), sparse)
+	_ = recvEntry(t, sub)
+
+	rich := proto.Clone(sparse).(*wavewalletrpc.WalletEntry)
+	rich.Request = &wavewalletrpc.WalletEntryRequest{
+		Request: &wavewalletrpc.WalletEntryRequest_LightningInvoice{
+			LightningInvoice: &wavewalletrpc.LightningInvoiceRequest{
+				Invoice:     "lnbc1requestonly",
+				PaymentHash: "aabbcc",
+			},
+		},
+	}
+	runtime.projectAndEmit(t.Context(), rich)
+
+	live := recvEntry(t, sub)
+	require.Empty(t, live.GetNote())
+	require.Equal(
+		t, "lnbc1requestonly",
+		live.GetRequest().GetLightningInvoice().GetInvoice(),
+	)
+
+	row, err := store.GetEntry(t.Context(), rich.GetId())
+	require.NoError(t, err)
+	require.NotEmpty(t, row.RequestJson)
+
+	events, err := store.PullEvents(t.Context(), 0, 10)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
 }
 
 // TestProjectAndEmitSkipsEphemeralBoardingRow verifies the synthetic

--- a/swapwallet/reconciler_test.go
+++ b/swapwallet/reconciler_test.go
@@ -187,6 +187,7 @@ func TestReconcileSkipsCreditOnlySwapRows(t *testing.T) {
 	swap := runtime.deps.SwapService.(*fakeSwapService)
 
 	const paymentHash = "credit-payment-hash"
+	runtime.markCreditProjectorOwned(paymentHash)
 	runtime.project(ctx, &wavewalletrpc.WalletEntry{
 		Id:            paymentHash,
 		Kind:          wavewalletrpc.EntryKind_ENTRY_KIND_SEND,

--- a/swapwallet/router.go
+++ b/swapwallet/router.go
@@ -296,6 +296,7 @@ func (r *router) sendCreditInvoiceIntent(ctx context.Context,
 	}
 
 	opKey := "pay:" + hex.EncodeToString(paymentHash[:])
+	paymentHashHex := hex.EncodeToString(paymentHash[:])
 	resp, err := r.deps.CreditRegistry.Ask(ctx, &credit.StartCreditPayRequest{
 		OpKey:        opKey,
 		Invoice:      intent.invoice,
@@ -312,6 +313,9 @@ func (r *router) sendCreditInvoiceIntent(ctx context.Context,
 	if _, ok := resp.(*credit.StartCreditResponse); !ok {
 		return nil, fmt.Errorf("unexpected credit pay response %T",
 			resp)
+	}
+	if creditOnly {
+		r.runtime.markCreditProjectorOwned(paymentHashHex)
 	}
 
 	// Emit a pending entry keyed by the payment hash. A mixed pay's swap

--- a/swapwallet/router_test.go
+++ b/swapwallet/router_test.go
@@ -505,6 +505,16 @@ func TestRouterSendInvoiceHandsCreditPayToRegistry(t *testing.T) {
 	require.Equal(t, invoice, reg.lastPay.Invoice)
 	require.Equal(t, uint64(500_000), reg.lastPay.MaxCreditSat)
 	require.True(t, reg.lastPay.CreditOnly)
+	require.True(
+		t,
+		r.runtime.creditProjectorOwnsSwapSummary(
+			&swapclientrpc.SwapSummary{
+				PaymentHash: paymentHash,
+				SettlementType: swapclientrpc.
+					SwapSettlementType_SWAP_SETTLEMENT_TYPE_CREDIT,
+			},
+		),
+	)
 
 	// The router no longer drives the top-up or pay inline.
 	require.Zero(t, swap.createCreditCalls)

--- a/swapwallet/runtime.go
+++ b/swapwallet/runtime.go
@@ -64,6 +64,17 @@ type Runtime struct {
 	// cursor would advance past it and drop it silently.
 	projectMu sync.Mutex
 
+	// creditOwnerMu guards creditOwnedSwaps.
+	creditOwnerMu sync.RWMutex
+
+	// creditOwnedSwaps contains payment hashes admitted through this
+	// wallet's credit registry. Settlement rail alone cannot establish
+	// activity ownership because callers may invoke the public swap RPC
+	// directly without creating a matching local credit operation. The set
+	// intentionally retains every durable credit-only pay for the process
+	// lifetime so ownership remains monotonic with the durable registry.
+	creditOwnedSwaps map[string]struct{}
+
 	// subsMu guards subscribers.
 	subsMu sync.Mutex
 
@@ -125,6 +136,7 @@ func newRuntime(parent context.Context, deps *Deps) *Runtime {
 		),
 		pending:           make(map[string]pendingEntry),
 		overlay:           make(map[string]overlayStatus),
+		creditOwnedSwaps:  make(map[string]struct{}),
 		rehydratePageSize: defaultRehydratePageSize,
 	}
 }
@@ -153,6 +165,12 @@ func (r *Runtime) start() {
 // additional wallet-managed pending tables.
 func (r *Runtime) resumeAll(ctx context.Context) {
 	log := r.deps.resolveLog()
+
+	// Restore credit activity ownership before backfill or the live monitor
+	// can observe SDK swap summaries. A credit-only SDK row carries zero
+	// Ark funding amount, so deriving it before ownership is known would
+	// append and briefly emit an incorrect zero-value transition.
+	r.restoreCreditProjectorOwnership(ctx)
 
 	// Restore wallet-local PENDING EXIT rows from the store into the
 	// in-memory pending map before anything else. This keeps the

--- a/waved/config.go
+++ b/waved/config.go
@@ -765,6 +765,12 @@ type ActivityStore interface {
 	ProjectEntry(ctx context.Context,
 		p db.ActivityProjection) (int64, error)
 
+	// GetEntry returns the current durable projection for one canonical id.
+	// The live projector uses it to retain immutable request context in a
+	// later sparse lifecycle event.
+	GetEntry(ctx context.Context,
+		canonicalID string) (sqlc.ActivityEntry, error)
+
 	// ListEntries returns up to limit current-state rows newest-first,
 	// starting after the (cursorCreated, cursorID) keyset. A cursorCreated
 	// of 0 starts from the newest row.


### PR DESCRIPTION
## Summary

This follow-up addresses every correctness finding from sputn1ck’s post-merge review of #950.

The activity store now treats terminal state as monotonic, emits the same enriched snapshot it persisted, and recognizes request-only enrichment. Credit activity suppression now requires explicit wallet-local ownership instead of relying on the server settlement rail alone, while durable polling retries terminal projection after transient store failures.

## Commit structure

### activity: Preserve monotonic rich projections

- rejects stale PENDING projections once an activity row is terminal;
- makes the state guard part of the SQL upsert so concurrent writers cannot race around an in-memory check;
- loads and merges immutable note, request, creation, and correlation context before persistence;
- appends and emits the effective merged snapshot rather than a sparse terminal input;
- compares request JSON semantically so request-only enrichment is durable;
- returns the affected-row count from the SQL upsert and suppresses events for rejected backward transitions; and
- documents every exported ActivityProjection field and the effective-entry return contract.

### swapwallet: Track credit activity ownership

- records credit-only swaps admitted through this wallet’s durable credit registry;
- reconstructs ownership from durable credit operations after restart;
- suppresses the generic swap summary only when both CREDIT settlement and local ownership are present;
- preserves public StartPay CREDIT activity when no wallet-local credit operation owns it; and
- advances the projector memo and clears pending tracking only after a successful durable projection, so transient store errors are retried.

## Races covered

A fast internal settlement may project COMPLETE before the router writes its initial PENDING row. The SQL transition guard now leaves COMPLETE authoritative and does not append a stale event.

A sparse terminal credit projection may race a rich pending receive or pay projection. The projector now merges immutable context before both the current-row upsert and event append, keeping live and replayed events identical.

A terminal store write may fail transiently. Polling now retains the prior memo and pending marker until the durable write succeeds, allowing the unchanged terminal operation to be retried on the next poll.

## Validation

- make fmt-changed-check base=origin/main
- make sqlc-check
- make commitmsg-lint range=origin/main..HEAD
- go test ./db -count=1
- go test -tags="swapruntime wavewalletrpc" ./swapwallet -count=1
- make lint-local

All checks pass locally, including all 71 configured linters.

Follow-up to #950.