### PR TITLE
multi: bound transient OOR submit-reject retries + USER_BALANCE

### DIFF
--- a/oor/CLAUDE.md
+++ b/oor/CLAUDE.md
@@ -72,8 +72,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/oor.<Sym
   actor's DB transaction; both phase-1 hint resolution and phase-2
   authoritative metadata lookup go through durable `serverconn` query
   messages and return as fresh events.
-- Snapshots are versioned per direction (`OutgoingSnapshot.Version = 4`,
-  `IncomingSnapshot.Version = 1`); restore rejects a zero version.
+- Snapshots are versioned per direction (`OutgoingSnapshot.Version = 5`,
+  `IncomingSnapshot.Version = 1`); restore rejects a zero version. Outgoing
+  v5 adds the `FirstRejectUnixNanos` record (bounded transient submit-reject
+  retry window); a pre-v5 snapshot decodes it to 0 (a fresh window).
 - `StartTransferRequest.IdempotencyKey` dedup relies on a partial UNIQUE
   index on `oor_session_registry` (at most one live-or-completed row per
   key); a failed session never blocks a keyed retry.

--- a/oor/interfaces.go
+++ b/oor/interfaces.go
@@ -3,9 +3,11 @@ package oor
 import (
 	"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/lightninglabs/wavelength/baselib/protofsm"
+	"github.com/lightningnetwork/lnd/clock"
 )
 
 // StateTransition is a type alias for the verbose protofsm.StateTransition type
@@ -60,9 +62,66 @@ func (id SessionID) LogPrefix() string {
 type Environment struct {
 	// SessionID identifies this FSM instance.
 	SessionID SessionID
+
+	// Clock supplies the current time to transitions that need to reason
+	// about elapsed wall-clock time (e.g. the bounded transient
+	// submit-reject retry window). It is injected rather than read from
+	// time.Now() so transitions stay deterministic under test. A nil clock
+	// defaults to a real clock via Now(), so a directly-constructed
+	// Environment (e.g. in a unit test) still advances time.
+	Clock clock.Clock
+
+	// MaxTransientSubmitRetry bounds the cumulative wall-clock time the
+	// outgoing FSM keeps re-driving a transient submit rejection while
+	// awaiting submit acceptance before failing the session terminally. A
+	// zero value disables the bound (unbounded, legacy behavior), which is
+	// what a directly-constructed Environment without a configured cap
+	// gets.
+	MaxTransientSubmitRetry time.Duration
 }
 
 // Name returns the unique identifier for this FSM instance.
 func (e *Environment) Name() string {
 	return fmt.Sprintf("oor_transfer_fsm_%s", e.SessionID)
+}
+
+// Now returns the environment's current time. It defaults to a real clock when
+// no clock was injected so a directly-constructed Environment still advances
+// time, keeping the FSM usable without explicit clock wiring in tests.
+func (e *Environment) Now() time.Time {
+	if e == nil || e.Clock == nil {
+		return clock.NewDefaultClock().Now()
+	}
+
+	return e.Clock.Now()
+}
+
+// EnvConfig carries the deterministic-time clock and transient submit-reject
+// retry budget injected into a session FSM Environment at construction. A nil
+// Clock defaults to a real clock so callers that do not inject one (tests,
+// simple harnesses) still work; a zero MaxTransientSubmitRetry leaves the retry
+// bound disabled.
+type EnvConfig struct {
+	// Clock is the deterministic time source for the session FSM.
+	Clock clock.Clock
+
+	// MaxTransientSubmitRetry is the cumulative retry-window cap for
+	// transient submit rejections.
+	MaxTransientSubmitRetry time.Duration
+}
+
+// newEnvironment builds a session FSM Environment from this config, defaulting
+// a nil clock to a real clock so the returned Environment always has a usable
+// time source.
+func (c EnvConfig) newEnvironment(sessionID SessionID) *Environment {
+	clk := c.Clock
+	if clk == nil {
+		clk = clock.NewDefaultClock()
+	}
+
+	return &Environment{
+		SessionID:               sessionID,
+		Clock:                   clk,
+		MaxTransientSubmitRetry: c.MaxTransientSubmitRetry,
+	}
 }

--- a/oor/outgoing_snapshot.go
+++ b/oor/outgoing_snapshot.go
@@ -92,6 +92,15 @@ type OutgoingSnapshot struct {
 	// IdempotencyKey identifies the caller intent that created this
 	// outgoing session, when one was provided.
 	IdempotencyKey string
+
+	// FirstRejectUnixNanos is the Unix-nanosecond timestamp of the first
+	// transient submit rejection observed in the AwaitingSubmitAccepted
+	// (OutgoingPhaseSubmitSent) phase. It bounds the cumulative transient
+	// submit-reject retry window across restarts. Zero means no transient
+	// reject has been seen yet; it is also the value a pre-v5 snapshot
+	// (which lacks the record) restores to, preserving a fresh retry
+	// window.
+	FirstRejectUnixNanos int64
 }
 
 // NewOutgoingSnapshot exports an outgoing transfer FSM state into a snapshot.
@@ -107,7 +116,11 @@ func NewOutgoingSnapshot(sessionID SessionID,
 	}
 
 	snap := &OutgoingSnapshot{
-		Version:   4,
+		// Version 5 adds the FirstRejectUnixNanos record (bounded
+		// transient submit-reject retry window). Restore stays
+		// backward-compatible: a pre-v5 snapshot lacks the record and
+		// decodes FirstRejectUnixNanos to 0 (a fresh window).
+		Version:   5,
 		SessionID: sessionID,
 	}
 
@@ -146,20 +159,11 @@ func NewOutgoingSnapshot(sessionID SessionID,
 		// resilient to later refactors in the PSBT builder.
 		snap.Phase = OutgoingPhaseSubmitSent
 		snap.IdempotencyKey = s.IdempotencyKey
+		snap.FirstRejectUnixNanos = s.FirstRejectUnixNanos
 
-		ark, err := psbtutil.Serialize(s.ArkPSBT)
-		if err != nil {
-			return nil, err
-		}
-		snap.ArkPSBT = ark
-
-		cps, err := serializePSBTSlice(s.CheckpointPSBTs)
-		if err != nil {
-			return nil, err
-		}
-		snap.CheckpointPSBTs = cps
-		err = assignTransferInputSnapshots(snap, s.TransferInputs)
-		if err != nil {
+		if err := assignPSBTArtifacts(
+			snap, s.ArkPSBT, s.CheckpointPSBTs, s.TransferInputs,
+		); err != nil {
 			return nil, err
 		}
 
@@ -172,19 +176,10 @@ func NewOutgoingSnapshot(sessionID SessionID,
 		snap.Phase = OutgoingPhaseCoSigned
 		snap.IdempotencyKey = s.IdempotencyKey
 
-		ark, err := psbtutil.Serialize(s.ArkPSBT)
-		if err != nil {
-			return nil, err
-		}
-		snap.ArkPSBT = ark
-
-		cps, err := serializePSBTSlice(s.CoSignedCheckpointPSBTs)
-		if err != nil {
-			return nil, err
-		}
-		snap.CheckpointPSBTs = cps
-		err = assignTransferInputSnapshots(snap, s.TransferInputs)
-		if err != nil {
+		if err := assignPSBTArtifacts(
+			snap, s.ArkPSBT, s.CoSignedCheckpointPSBTs,
+			s.TransferInputs,
+		); err != nil {
 			return nil, err
 		}
 
@@ -194,19 +189,10 @@ func NewOutgoingSnapshot(sessionID SessionID,
 		snap.Phase = OutgoingPhaseFinalizeSent
 		snap.IdempotencyKey = s.IdempotencyKey
 
-		ark, err := psbtutil.Serialize(s.ArkPSBT)
-		if err != nil {
-			return nil, err
-		}
-		snap.ArkPSBT = ark
-
-		cps, err := serializePSBTSlice(s.FinalCheckpointPSBTs)
-		if err != nil {
-			return nil, err
-		}
-		snap.CheckpointPSBTs = cps
-		err = assignTransferInputSnapshots(snap, s.TransferInputs)
-		if err != nil {
+		if err := assignPSBTArtifacts(
+			snap, s.ArkPSBT, s.FinalCheckpointPSBTs,
+			s.TransferInputs,
+		); err != nil {
 			return nil, err
 		}
 
@@ -242,8 +228,12 @@ func NewOutgoingSnapshot(sessionID SessionID,
 }
 
 // NewSessionFromSnapshot restores an outgoing transfer session from a snapshot.
-func NewSessionFromSnapshot(ctx context.Context,
-	snapshot *OutgoingSnapshot) (*Session, error) {
+//
+// envCfg injects the deterministic clock and the bounded transient
+// submit-reject retry budget into the restored FSM Environment so a session
+// resumed after a restart keeps the same retry-window semantics as a fresh one.
+func NewSessionFromSnapshot(ctx context.Context, snapshot *OutgoingSnapshot,
+	envCfg EnvConfig) (*Session, error) {
 
 	if snapshot == nil {
 		return nil, fmt.Errorf("snapshot must be provided")
@@ -254,7 +244,7 @@ func NewSessionFromSnapshot(ctx context.Context,
 		return nil, err
 	}
 
-	env := &Environment{SessionID: snapshot.SessionID}
+	env := envCfg.newEnvironment(snapshot.SessionID)
 	baseLogger := logger(ctx)
 
 	fsmCfg := StateMachineCfg{
@@ -331,10 +321,11 @@ func OutgoingStateFromSnapshot(snapshot *OutgoingSnapshot) (State, error) {
 		}
 
 		return &AwaitingSubmitAccepted{
-			ArkPSBT:         ark,
-			CheckpointPSBTs: cps,
-			TransferInputs:  inputs,
-			IdempotencyKey:  snapshot.IdempotencyKey,
+			ArkPSBT:              ark,
+			CheckpointPSBTs:      cps,
+			TransferInputs:       inputs,
+			IdempotencyKey:       snapshot.IdempotencyKey,
+			FirstRejectUnixNanos: snapshot.FirstRejectUnixNanos,
 		}, nil
 
 	case OutgoingPhaseCoSigned:
@@ -437,6 +428,28 @@ func snapshotTransferInputs(inputs []TransferInput) ([]*TransferInputSnapshot,
 	}
 
 	return out, nil
+}
+
+// assignPSBTArtifacts serializes the Ark PSBT and the given checkpoint PSBTs
+// onto the snapshot and records the portable transfer-input encoding. This is
+// the artifact set every submit-through-finalize outgoing phase persists, so it
+// is factored out to keep NewOutgoingSnapshot's per-phase cases short.
+func assignPSBTArtifacts(snap *OutgoingSnapshot, ark *psbt.Packet,
+	checkpoints []*psbt.Packet, inputs []TransferInput) error {
+
+	arkRaw, err := psbtutil.Serialize(ark)
+	if err != nil {
+		return err
+	}
+	snap.ArkPSBT = arkRaw
+
+	cps, err := serializePSBTSlice(checkpoints)
+	if err != nil {
+		return err
+	}
+	snap.CheckpointPSBTs = cps
+
+	return assignTransferInputSnapshots(snap, inputs)
 }
 
 // assignTransferInputSnapshots stores transfer inputs and their portable

--- a/oor/outgoing_snapshot_codec.go
+++ b/oor/outgoing_snapshot_codec.go
@@ -23,6 +23,12 @@ const (
 	// snapshotIdempotencyKeyRecordType stores the optional caller-provided
 	// OOR send idempotency key.
 	snapshotIdempotencyKeyRecordType tlv.Type = 21
+
+	// snapshotFirstRejectNanosRecordType stores the Unix-nanosecond start
+	// of the bounded transient submit-reject retry window (snapshot version
+	// 5+). A pre-v5 snapshot omits this record, so it decodes to 0 (a fresh
+	// window) rather than failing.
+	snapshotFirstRejectNanosRecordType tlv.Type = 23
 )
 
 func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
@@ -50,6 +56,7 @@ func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
 	retryAfterNanos := uint64(snapshot.RetryAfter)
 	failReason := []byte(snapshot.FailReason)
 	idempotencyKey := []byte(snapshot.IdempotencyKey)
+	firstRejectNanos := uint64(snapshot.FirstRejectUnixNanos)
 
 	version := uint64(snapshot.Version)
 	records := []tlv.Record{
@@ -73,6 +80,9 @@ func encodeOutgoingSnapshot(snapshot *OutgoingSnapshot) ([]byte, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotIdempotencyKeyRecordType, &idempotencyKey,
+		),
+		tlv.MakePrimitiveRecord(
+			snapshotFirstRejectNanosRecordType, &firstRejectNanos,
 		),
 	}
 
@@ -108,6 +118,7 @@ func decodeOutgoingSnapshotWithLimits(raw []byte,
 		retryAfterNanos    uint64
 		failReasonRaw      []byte
 		idempotencyKeyRaw  []byte
+		firstRejectNanos   uint64
 	)
 
 	records := []tlv.Record{
@@ -131,6 +142,9 @@ func decodeOutgoingSnapshotWithLimits(raw []byte,
 		),
 		tlv.MakePrimitiveRecord(
 			snapshotIdempotencyKeyRecordType, &idempotencyKeyRaw,
+		),
+		tlv.MakePrimitiveRecord(
+			snapshotFirstRejectNanosRecordType, &firstRejectNanos,
 		),
 	}
 
@@ -185,6 +199,13 @@ func decodeOutgoingSnapshotWithLimits(raw []byte,
 		return nil, err
 	}
 
+	decodedFirstReject, err := uint64ToInt64(
+		firstRejectNanos, "snapshot first_reject nanos",
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &OutgoingSnapshot{
 		Version:                decodedVersion,
 		SessionID:              sessionID,
@@ -195,6 +216,7 @@ func decodeOutgoingSnapshotWithLimits(raw []byte,
 		RetryAfter:             decodedRetryAfter,
 		FailReason:             string(failReasonRaw),
 		IdempotencyKey:         string(idempotencyKeyRaw),
+		FirstRejectUnixNanos:   decodedFirstReject,
 	}, nil
 }
 

--- a/oor/outgoing_snapshot_codec_test.go
+++ b/oor/outgoing_snapshot_codec_test.go
@@ -76,6 +76,53 @@ func TestOutgoingSnapshotTLVRoundTrip(t *testing.T) {
 	require.Equal(t, snapshot, decoded)
 }
 
+// TestOutgoingSnapshotFirstRejectRoundTrip asserts a version-5 submit-sent
+// snapshot carrying a non-zero FirstRejectUnixNanos serializes and restores it
+// so the bounded transient submit-reject retry window survives a restart.
+func TestOutgoingSnapshotFirstRejectRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	snapshot := &OutgoingSnapshot{
+		Version:   5,
+		SessionID: SessionID(chainhash.Hash{1, 2, 3}),
+		Phase:     OutgoingPhaseSubmitSent,
+		ArkPSBT: []byte{
+			1,
+			2,
+			3,
+			4,
+		},
+		FirstRejectUnixNanos: 1_700_000_000_123_456_789,
+	}
+
+	raw, err := encodeOutgoingSnapshot(snapshot)
+	require.NoError(t, err)
+
+	decoded, err := decodeOutgoingSnapshot(raw)
+	require.NoError(t, err)
+	require.Equal(
+		t, int64(1_700_000_000_123_456_789),
+		decoded.FirstRejectUnixNanos,
+	)
+	require.Equal(t, snapshot, decoded)
+}
+
+// TestOutgoingSnapshotV4RestoresZeroFirstReject asserts a legacy version-4
+// snapshot (which lacks the FirstRejectUnixNanos record) decodes without error
+// and restores FirstRejectUnixNanos to 0 (a fresh retry window), preserving
+// backward compatibility.
+func TestOutgoingSnapshotV4RestoresZeroFirstReject(t *testing.T) {
+	t.Parallel()
+
+	raw, err := encodeSnapshotRawForDecodeTest(4, 0)
+	require.NoError(t, err)
+
+	decoded, err := decodeOutgoingSnapshot(raw)
+	require.NoError(t, err)
+	require.Equal(t, uint8(4), decoded.Version)
+	require.Zero(t, decoded.FirstRejectUnixNanos)
+}
+
 func TestRestoreSnapshotPayloadTLVRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/oor/receive_session.go
+++ b/oor/receive_session.go
@@ -42,14 +42,17 @@ func NewReceiveSession(ctx context.Context, ark *psbt.Packet,
 	)
 
 	return newReceiveSessionWithState(
-		ctx, sessionID, &ReceiveIdle{},
+		ctx, sessionID, &ReceiveIdle{}, EnvConfig{},
 	)
 }
 
 // newReceiveSessionWithState creates an incoming-transfer FSM session with
-// the provided initial receive state.
+// the provided initial receive state. envCfg injects the deterministic clock
+// and retry budget into the FSM Environment; the incoming FSM does not read the
+// retry budget today, but the clock is threaded for consistency with the
+// outgoing path and to keep transitions deterministic.
 func newReceiveSessionWithState(ctx context.Context, sessionID SessionID,
-	state SessionState) (*ReceiveSession, error) {
+	state SessionState, envCfg EnvConfig) (*ReceiveSession, error) {
 
 	if sessionID == (SessionID{}) {
 		return nil, fmt.Errorf("session id must be provided")
@@ -59,7 +62,7 @@ func newReceiveSessionWithState(ctx context.Context, sessionID SessionID,
 		return nil, fmt.Errorf("state must be provided")
 	}
 
-	env := &Environment{SessionID: sessionID}
+	env := envCfg.newEnvironment(sessionID)
 
 	baseLogger := logger(ctx)
 

--- a/oor/receive_snapshot.go
+++ b/oor/receive_snapshot.go
@@ -171,9 +171,10 @@ func NewIncomingSnapshot(sessionID SessionID,
 }
 
 // NewReceiveSessionFromSnapshot restores an incoming receive session from a
-// durable snapshot.
+// durable snapshot. envCfg injects the deterministic clock and retry budget
+// into the restored FSM Environment.
 func NewReceiveSessionFromSnapshot(ctx context.Context,
-	snapshot *IncomingSnapshot) (*ReceiveSession, error) {
+	snapshot *IncomingSnapshot, envCfg EnvConfig) (*ReceiveSession, error) {
 
 	if snapshot == nil {
 		return nil, fmt.Errorf("snapshot must be provided")
@@ -185,7 +186,7 @@ func NewReceiveSessionFromSnapshot(ctx context.Context,
 	}
 
 	return newReceiveSessionWithState(
-		ctx, snapshot.SessionID, state,
+		ctx, snapshot.SessionID, state, envCfg,
 	)
 }
 

--- a/oor/registry.go
+++ b/oor/registry.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lightninglabs/wavelength/serverconn"
 	"github.com/lightninglabs/wavelength/timeout"
 	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightningnetwork/lnd/clock"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/input"
 )
@@ -85,6 +86,25 @@ type OORRegistryConfig struct {
 	TimeoutActor         actor.TellOnlyRef[timeout.Msg]
 	CallbackRef          actor.TellOnlyRef[*timeout.ExpiredMsg]
 	ActorSystem          actor.SystemContext
+
+	// Clock is the deterministic time source forwarded into every session
+	// FSM Environment. When nil, sessions default to a real clock.
+	Clock clock.Clock
+
+	// MaxTransientSubmitRetry bounds the cumulative retry window an
+	// outgoing session keeps re-driving a transient submit rejection before
+	// failing terminally. Zero disables the bound (unbounded, legacy
+	// behavior).
+	MaxTransientSubmitRetry time.Duration
+}
+
+// envConfig returns the FSM Environment config (clock + transient submit-reject
+// retry budget) the registry forwards into every session it builds.
+func (r *oorRegistryBehavior) envConfig() EnvConfig {
+	return EnvConfig{
+		Clock:                   r.cfg.Clock,
+		MaxTransientSubmitRetry: r.cfg.MaxTransientSubmitRetry,
+	}
 }
 
 // OORRegistryActor is the thin coordinator over per-session OOR actors. It
@@ -576,6 +596,7 @@ func (r *oorRegistryBehavior) handleStartTransfer(ctx context.Context,
 	// daemon's lifetime (one leak per outgoing admission otherwise).
 	session, _, err := NewSessionWithIdempotencyKey(
 		ctx, req.Policy, req.Inputs, req.Recipients, req.IdempotencyKey,
+		r.envConfig(),
 	)
 	if err != nil {
 		return fn.Err[ActorResp](err)
@@ -1460,26 +1481,28 @@ func (r *oorRegistryBehavior) childConfig(sessionID SessionID,
 	direction clientdb.OORSessionDirection) SessionActorConfig {
 
 	return SessionActorConfig{
-		SessionID:            sessionID,
-		Direction:            direction,
-		Log:                  r.cfg.Log,
-		Signer:               r.cfg.Signer,
-		IncomingHandler:      r.cfg.IncomingHandler,
-		RegistryStore:        r.cfg.RegistryStore,
-		DeliveryStore:        r.cfg.DeliveryStore,
-		ServerConn:           r.cfg.ServerConn,
-		VTXOManager:          r.cfg.VTXOManager,
-		SpendCompleter:       r.cfg.SpendCompleter,
-		SpendReleaser:        r.cfg.SpendReleaser,
-		ReservationStore:     r.cfg.ReservationStore,
-		PackageStore:         r.cfg.PackageStore,
-		VTXOStore:            r.cfg.VTXOStore,
-		LedgerSink:           r.cfg.LedgerSink,
-		IncomingVTXOObserver: r.cfg.IncomingVTXOObserver,
-		Limits:               normalizeReceiveLimits(r.cfg.Limits),
-		TimeoutActor:         r.cfg.TimeoutActor,
-		CallbackRef:          r.cfg.CallbackRef,
-		Registry:             r.selfRef,
+		SessionID:               sessionID,
+		Direction:               direction,
+		Log:                     r.cfg.Log,
+		Signer:                  r.cfg.Signer,
+		IncomingHandler:         r.cfg.IncomingHandler,
+		RegistryStore:           r.cfg.RegistryStore,
+		DeliveryStore:           r.cfg.DeliveryStore,
+		ServerConn:              r.cfg.ServerConn,
+		VTXOManager:             r.cfg.VTXOManager,
+		SpendCompleter:          r.cfg.SpendCompleter,
+		SpendReleaser:           r.cfg.SpendReleaser,
+		ReservationStore:        r.cfg.ReservationStore,
+		PackageStore:            r.cfg.PackageStore,
+		VTXOStore:               r.cfg.VTXOStore,
+		LedgerSink:              r.cfg.LedgerSink,
+		IncomingVTXOObserver:    r.cfg.IncomingVTXOObserver,
+		Limits:                  normalizeReceiveLimits(r.cfg.Limits),
+		TimeoutActor:            r.cfg.TimeoutActor,
+		CallbackRef:             r.cfg.CallbackRef,
+		Registry:                r.selfRef,
+		Clock:                   r.cfg.Clock,
+		MaxTransientSubmitRetry: r.cfg.MaxTransientSubmitRetry,
 	}
 }
 

--- a/oor/registry_test.go
+++ b/oor/registry_test.go
@@ -1653,7 +1653,7 @@ func TestOORRegistryStartTransferNoKeyActiveDedup(t *testing.T) {
 
 	// Learn the deterministic session id the same way admission does.
 	session, _, err := NewSessionWithIdempotencyKey(
-		ctx, req.Policy, req.Inputs, req.Recipients, "",
+		ctx, req.Policy, req.Inputs, req.Recipients, "", EnvConfig{},
 	)
 	require.NoError(t, err)
 
@@ -1715,7 +1715,7 @@ func TestOORRegistryStartTransferDropsPhantomResident(t *testing.T) {
 	}
 
 	session, _, err := NewSessionWithIdempotencyKey(
-		ctx, req.Policy, req.Inputs, req.Recipients, "",
+		ctx, req.Policy, req.Inputs, req.Recipients, "", EnvConfig{},
 	)
 	require.NoError(t, err)
 

--- a/oor/session.go
+++ b/oor/session.go
@@ -36,23 +36,27 @@ func NewSession(ctx context.Context, policy arkscript.CheckpointPolicy,
 	inputs []TransferInput, outputs []oortx.RecipientOutput) (*Session,
 	[]OutboxEvent, error) {
 
-	return NewSessionWithIdempotencyKey(ctx, policy, inputs, outputs, "")
+	return NewSessionWithIdempotencyKey(
+		ctx, policy, inputs, outputs, "", EnvConfig{},
+	)
 }
 
 // NewSessionWithIdempotencyKey creates a new outgoing OOR transfer session
-// tagged with a caller-provided idempotency key.
+// tagged with a caller-provided idempotency key. envCfg injects the
+// deterministic clock and the bounded transient submit-reject retry budget into
+// the FSM Environment.
 func NewSessionWithIdempotencyKey(ctx context.Context,
 	policy arkscript.CheckpointPolicy, inputs []TransferInput,
-	outputs []oortx.RecipientOutput, idempotencyKey string) (*Session,
-	[]OutboxEvent, error) {
+	outputs []oortx.RecipientOutput, idempotencyKey string,
+	envCfg EnvConfig) (*Session, []OutboxEvent, error) {
 
 	logger(ctx).DebugS(ctx, "Creating new OOR session",
 		slog.Int("num_inputs", len(inputs)),
 		slog.Int("num_outputs", len(outputs)),
 	)
 
-	env := &Environment{}
 	startupID := SessionID{}
+	env := envCfg.newEnvironment(startupID)
 
 	baseLogger := logger(ctx)
 

--- a/oor/session_actor.go
+++ b/oor/session_actor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lightninglabs/wavelength/serverconn"
 	"github.com/lightninglabs/wavelength/timeout"
 	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightningnetwork/lnd/clock"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/input"
 )
@@ -120,6 +121,26 @@ type SessionActorConfig struct {
 	// commits a terminal snapshot, so the coordinator can reap the child.
 	// When nil, terminal sessions stay resident until shutdown.
 	Registry actor.TellOnlyRef[OORDurableMsg]
+
+	// Clock is the deterministic time source injected into every session
+	// FSM Environment this actor builds. When nil, the FSM defaults to a
+	// real clock so the actor still works without explicit wiring.
+	Clock clock.Clock
+
+	// MaxTransientSubmitRetry bounds the cumulative wall-clock time an
+	// outgoing session keeps re-driving a transient submit rejection while
+	// awaiting submit acceptance before failing terminally. Zero disables
+	// the bound (unbounded, legacy behavior).
+	MaxTransientSubmitRetry time.Duration
+}
+
+// envConfig returns the FSM Environment config (clock + transient submit-reject
+// retry budget) this actor injects into every session it builds or restores.
+func (b *sessionBehavior) envConfig() EnvConfig {
+	return EnvConfig{
+		Clock:                   b.cfg.Clock,
+		MaxTransientSubmitRetry: b.cfg.MaxTransientSubmitRetry,
+	}
 }
 
 // OORSessionActor wraps one durable per-session OOR actor.
@@ -1242,7 +1263,9 @@ func (b *sessionBehavior) restore(ctx context.Context) error {
 
 	switch record.Direction {
 	case clientdb.OORSessionDirectionOutgoing:
-		session, err := outgoingSessionFromRecord(ctx, *record)
+		session, err := outgoingSessionFromRecord(
+			ctx, *record, b.envConfig(),
+		)
 		if err != nil {
 			return err
 		}
@@ -1252,7 +1275,7 @@ func (b *sessionBehavior) restore(ctx context.Context) error {
 
 	case clientdb.OORSessionDirectionIncoming:
 		session, err := incomingSessionFromRecord(
-			ctx, *record, b.cfg.Limits,
+			ctx, *record, b.cfg.Limits, b.envConfig(),
 		)
 		if err != nil {
 			return err

--- a/oor/session_actor_flow_test.go
+++ b/oor/session_actor_flow_test.go
@@ -131,6 +131,7 @@ func TestSessionActorIncomingMaterializeFullFlow(t *testing.T) {
 			ArkPSBT:              ark,
 			FinalCheckpointPSBTs: checkpoints,
 		},
+		EnvConfig{},
 	)
 	require.NoError(t, err)
 
@@ -345,7 +346,9 @@ func TestSessionActorIncomingReloadsAfterFailedCommit(t *testing.T) {
 		},
 	}
 
-	session, err := newReceiveSessionWithState(ctx, sid, notified)
+	session, err := newReceiveSessionWithState(
+		ctx, sid, notified, EnvConfig{},
+	)
 	require.NoError(t, err)
 
 	b := &sessionBehavior{
@@ -1121,6 +1124,7 @@ func TestSessionActorMetadataQueryEmptyRecipientsFailsTerminally(t *testing.T) {
 		ctx, sid, &ReceiveNotified{
 			SessionID: sid,
 		},
+		EnvConfig{},
 	)
 	require.NoError(t, err)
 
@@ -1179,6 +1183,7 @@ func TestSessionActorMetadataQueryTransientErrorRetries(t *testing.T) {
 		ctx, sid, &ReceiveNotified{
 			SessionID: sid,
 		},
+		EnvConfig{},
 	)
 	require.NoError(t, err)
 

--- a/oor/session_actor_handlers.go
+++ b/oor/session_actor_handlers.go
@@ -54,6 +54,7 @@ func (b *sessionBehavior) handleStartTransfer(ctx context.Context,
 
 	session, outbox, err := NewSessionWithIdempotencyKey(
 		ctx, req.Policy, req.Inputs, req.Recipients, req.IdempotencyKey,
+		b.envConfig(),
 	)
 	if err != nil {
 		return fn.Err[ActorResp](err)
@@ -563,7 +564,7 @@ func (b *sessionBehavior) handleResolveIncomingTransfer(ctx context.Context,
 				[]byte(nil), req.RecipientPkScript...,
 			),
 			RecipientEventID: req.RecipientEventID,
-		},
+		}, b.envConfig(),
 	)
 	if err != nil {
 		return fn.Err[ActorResp](err)

--- a/oor/session_actor_test.go
+++ b/oor/session_actor_test.go
@@ -161,7 +161,7 @@ func finalizeBehavior(t *testing.T, registry SessionRegistryStore,
 	)
 	require.NoError(t, err)
 
-	session, err := NewSessionFromSnapshot(ctx, snapshot)
+	session, err := NewSessionFromSnapshot(ctx, snapshot, EnvConfig{})
 	require.NoError(t, err)
 
 	b := &sessionBehavior{
@@ -347,7 +347,7 @@ func TestSessionActorDedupRaceRedeliversThenDedups(t *testing.T) {
 	registryRef := &recordingTellRef{id: "oor-registry", rec: rec}
 
 	build := func() *sessionBehavior {
-		s, serr := NewSessionFromSnapshot(ctx, snapshot)
+		s, serr := NewSessionFromSnapshot(ctx, snapshot, EnvConfig{})
 		require.NoError(t, serr)
 
 		return &sessionBehavior{
@@ -481,6 +481,7 @@ func TestSessionActorResolveResumeDrivesGiveUp(t *testing.T) {
 				RecipientPkScript: []byte{0x51, 0x20, 0xaa},
 				ResolveAttempts:   attempts,
 			},
+			EnvConfig{},
 		)
 		require.NoError(t, err)
 
@@ -543,6 +544,7 @@ func TestSessionActorResolveBootResumeNoAmplify(t *testing.T) {
 			RecipientPkScript: []byte{0x51, 0x20, 0xaa},
 			ResolveAttempts:   5,
 		},
+		EnvConfig{},
 	)
 	require.NoError(t, err)
 
@@ -593,6 +595,7 @@ func TestSessionActorNotifiedResumeDrivesGiveUp(t *testing.T) {
 				FinalCheckpointPSBTs: checkpoints,
 				MetadataAttempts:     attempts,
 			},
+			EnvConfig{},
 		)
 		require.NoError(t, err)
 
@@ -663,6 +666,7 @@ func TestSessionActorNotifiedBootResumeNoAmplify(t *testing.T) {
 			FinalCheckpointPSBTs: checkpoints,
 			MetadataAttempts:     4,
 		},
+		EnvConfig{},
 	)
 	require.NoError(t, err)
 
@@ -1087,6 +1091,7 @@ func TestSessionActorStopFSMReapsGoroutine(t *testing.T) {
 		ctx, sid, &ReceiveResolving{
 			SessionID: sid,
 		},
+		EnvConfig{},
 	)
 	require.NoError(t, err)
 	require.True(t, session.FSM.IsRunning())
@@ -1119,12 +1124,14 @@ func TestSessionActorSetFSMStopsPrevious(t *testing.T) {
 		ctx, sid, &ReceiveResolving{
 			SessionID: sid,
 		},
+		EnvConfig{},
 	)
 	require.NoError(t, err)
 	next, err := newReceiveSessionWithState(
 		ctx, sid, &ReceiveResolving{
 			SessionID: sid,
 		},
+		EnvConfig{},
 	)
 	require.NoError(t, err)
 
@@ -1516,6 +1523,7 @@ func TestSessionActorResumeMetadataBackoff(t *testing.T) {
 			FinalCheckpointPSBTs: checkpoints,
 			MetadataAttempts:     3,
 		},
+		EnvConfig{},
 	)
 	require.NoError(t, err)
 
@@ -1587,6 +1595,7 @@ func TestSessionActorRetryArmsOnlyAfterCommit(t *testing.T) {
 				FinalCheckpointPSBTs: checkpoints,
 				MetadataAttempts:     2,
 			},
+			EnvConfig{},
 		)
 		require.NoError(t, err)
 
@@ -1780,7 +1789,7 @@ func TestSessionActorFinalizeReloadsAfterSpendFailure(t *testing.T) {
 	snapshot, err := NewOutgoingSnapshot(sessionID, awaiting)
 	require.NoError(t, err)
 
-	session, err := NewSessionFromSnapshot(ctx, snapshot)
+	session, err := NewSessionFromSnapshot(ctx, snapshot, EnvConfig{})
 	require.NoError(t, err)
 
 	// The completer fails the first spend and succeeds the second, modeling

--- a/oor/session_registry_bridge.go
+++ b/oor/session_registry_bridge.go
@@ -169,24 +169,27 @@ func incomingRegistryRecord(sessionID SessionID,
 }
 
 // outgoingSessionFromRecord rebuilds a live outgoing session from a registry
-// record's snapshot blob.
+// record's snapshot blob. envCfg injects the deterministic clock and the
+// transient submit-reject retry budget into the restored FSM Environment.
 func outgoingSessionFromRecord(ctx context.Context,
-	record clientdb.OORSessionRegistryRecord) (*Session, error) {
+	record clientdb.OORSessionRegistryRecord,
+	envCfg EnvConfig) (*Session, error) {
 
 	snapshot, err := decodeOutgoingSnapshot(record.SnapshotData)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewSessionFromSnapshot(ctx, snapshot)
+	return NewSessionFromSnapshot(ctx, snapshot, envCfg)
 }
 
 // incomingSessionFromRecord rebuilds a live incoming session from a registry
 // record's snapshot blob, enforcing the configured receive limits during
-// decode.
+// decode. envCfg injects the deterministic clock and retry budget into the
+// restored FSM Environment.
 func incomingSessionFromRecord(ctx context.Context,
-	record clientdb.OORSessionRegistryRecord,
-	limits ReceiveLimits) (*ReceiveSession, error) {
+	record clientdb.OORSessionRegistryRecord, limits ReceiveLimits,
+	envCfg EnvConfig) (*ReceiveSession, error) {
 
 	snapshot, err := decodeIncomingSnapshotWithLimits(
 		record.SnapshotData, limits,
@@ -195,5 +198,5 @@ func incomingSessionFromRecord(ctx context.Context,
 		return nil, err
 	}
 
-	return NewReceiveSessionFromSnapshot(ctx, snapshot)
+	return NewReceiveSessionFromSnapshot(ctx, snapshot, envCfg)
 }

--- a/oor/states.go
+++ b/oor/states.go
@@ -100,6 +100,13 @@ type AwaitingSubmitAccepted struct {
 	// IdempotencyKey identifies the caller intent that created this
 	// outgoing session, when provided.
 	IdempotencyKey string
+
+	// FirstRejectUnixNanos is the Unix-nanosecond timestamp of the first
+	// transient submit rejection observed while awaiting submit acceptance,
+	// used to bound the cumulative retry window. Zero means no transient
+	// reject has been seen yet (a fresh retry window). It is carried on the
+	// state (and persisted in the snapshot) so the bound survives restarts.
+	FirstRejectUnixNanos int64
 }
 
 // String returns a human-readable representation of AwaitingSubmitAccepted.

--- a/oor/submit_retry_budget_test.go
+++ b/oor/submit_retry_budget_test.go
@@ -1,0 +1,228 @@
+package oor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestSubmitState builds a deterministic AwaitingSubmitAccepted state with a
+// single reserved input, so the transient submit-reject retry-budget tests can
+// assert both the reschedule-within-budget and the terminal-past-budget paths
+// (the latter must release the reserved pre-point-of-no-return input).
+func newTestSubmitState(t *testing.T) (*AwaitingSubmitAccepted, wire.OutPoint) {
+	t.Helper()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	policy := arkscript.CheckpointPolicy{
+		OperatorKey: operatorKey.PubKey(),
+		CSVDelay:    10,
+	}
+
+	inputValue := btcutil.Amount(10_000)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	inputs := []TransferInput{
+		newTestTransferInput(
+			t, clientKey, policy.OperatorKey, wire.OutPoint{
+				Hash:  [32]byte{0x01},
+				Index: 0,
+			}, inputValue,
+		),
+	}
+
+	recipients := []oortx.RecipientOutput{{
+		PkScript: newTestTaprootPkScript(t, clientKey.PubKey()),
+		Value:    inputValue,
+	}}
+
+	ark, checkpoints, err := buildSubmitPackage(policy, inputs, recipients)
+	require.NoError(t, err)
+
+	return &AwaitingSubmitAccepted{
+		ArkPSBT:         ark,
+		CheckpointPSBTs: checkpoints,
+		TransferInputs:  inputs,
+	}, inputs[0].VTXO.Outpoint
+}
+
+// TestHandleSubmitOutboxErrorReschedulesWithinBudget asserts that a retryable
+// submit-reject error inside the retry budget keeps the FSM in
+// AwaitingSubmitAccepted, emits a ScheduleRetryRequest, and records/advances
+// the retry-window start using the injected clock rather than time.Now().
+func TestHandleSubmitOutboxErrorReschedulesWithinBudget(t *testing.T) {
+	t.Parallel()
+
+	current, _ := newTestSubmitState(t)
+
+	start := time.Unix(1_700_000_000, 0)
+	clk := clock.NewTestClock(start)
+	env := &Environment{
+		Clock:                   clk,
+		MaxTransientSubmitRetry: time.Hour,
+	}
+
+	// First retryable reject: opens the window at the clock's current time
+	// and reschedules with the requested delay.
+	transition, err := handleSubmitOutboxError(
+		env, current, &OutboxErrorEvent{
+			OutboxType:  "submit",
+			Retryable:   true,
+			RetryAfter:  15 * time.Second,
+			ErrorReason: "input not spendable",
+		},
+	)
+	require.NoError(t, err)
+
+	next, ok := transition.NextState.(*AwaitingSubmitAccepted)
+	require.True(t, ok)
+	require.Equal(t, start.UnixNano(), next.FirstRejectUnixNanos)
+
+	// The source state must not be mutated in place.
+	require.Zero(t, current.FirstRejectUnixNanos)
+
+	emitted := transition.NewEvents.UnwrapOr(EmittedEvent{})
+	require.Len(t, emitted.Outbox, 1)
+	schedule, ok := emitted.Outbox[0].(*ScheduleRetryRequest)
+	require.True(t, ok)
+	require.Equal(t, 15*time.Second, schedule.After)
+
+	// Advance the clock but stay within the budget: a subsequent reject
+	// carries the ORIGINAL window start forward (it does not reset it) and
+	// keeps rescheduling.
+	clk.SetTime(start.Add(30 * time.Minute))
+	transition, err = handleSubmitOutboxError(
+		env, next, &OutboxErrorEvent{
+			OutboxType:  "submit",
+			Retryable:   true,
+			RetryAfter:  15 * time.Second,
+			ErrorReason: "input not spendable",
+		},
+	)
+	require.NoError(t, err)
+
+	next2, ok := transition.NextState.(*AwaitingSubmitAccepted)
+	require.True(t, ok)
+	require.Equal(t, start.UnixNano(), next2.FirstRejectUnixNanos)
+	require.Len(t, transition.NewEvents.UnwrapOr(EmittedEvent{}).Outbox, 1)
+}
+
+// TestHandleSubmitOutboxErrorGivesUpPastBudget asserts that once the injected
+// clock is past the retry budget, the next retryable submit-reject drives the
+// session to terminal Failed and releases the reserved pre-point-of-no-return
+// input, rather than scheduling another retry.
+func TestHandleSubmitOutboxErrorGivesUpPastBudget(t *testing.T) {
+	t.Parallel()
+
+	current, outpoint := newTestSubmitState(t)
+
+	start := time.Unix(1_700_000_000, 0)
+	// The window opened at start; the clock is now well past the budget.
+	current.FirstRejectUnixNanos = start.UnixNano()
+
+	clk := clock.NewTestClock(start.Add(2 * time.Hour))
+	env := &Environment{
+		Clock:                   clk,
+		MaxTransientSubmitRetry: time.Hour,
+	}
+
+	transition, err := handleSubmitOutboxError(
+		env, current, &OutboxErrorEvent{
+			OutboxType:  "submit",
+			Retryable:   true,
+			RetryAfter:  15 * time.Second,
+			ErrorReason: "user balance exceeded",
+		},
+	)
+	require.NoError(t, err)
+
+	failed, ok := transition.NextState.(*Failed)
+	require.True(t, ok)
+	require.Contains(t, failed.Reason, "retry budget")
+	require.Contains(t, failed.Reason, "user balance exceeded")
+
+	// Pre-point-of-no-return: the reserved input is released back to the
+	// spendable set instead of waiting for a restart sweep.
+	emitted := transition.NewEvents.UnwrapOr(EmittedEvent{})
+	require.Len(t, emitted.Outbox, 1)
+	release, ok := emitted.Outbox[0].(*ReleaseInputsRequest)
+	require.True(t, ok)
+	require.Equal(t, []wire.OutPoint{outpoint}, release.Outpoints)
+}
+
+// TestHandleSubmitOutboxErrorUnboundedNeverGivesUp asserts a zero budget
+// preserves the legacy unbounded behavior: a retryable reject always
+// reschedules and never fails, no matter how far the clock has advanced.
+func TestHandleSubmitOutboxErrorUnboundedNeverGivesUp(t *testing.T) {
+	t.Parallel()
+
+	current, _ := newTestSubmitState(t)
+
+	start := time.Unix(1_700_000_000, 0)
+	current.FirstRejectUnixNanos = start.UnixNano()
+
+	clk := clock.NewTestClock(start.Add(1000 * time.Hour))
+	env := &Environment{
+		Clock: clk,
+		// Zero budget: unbounded.
+		MaxTransientSubmitRetry: 0,
+	}
+
+	transition, err := handleSubmitOutboxError(
+		env, current, &OutboxErrorEvent{
+			OutboxType:  "submit",
+			Retryable:   true,
+			RetryAfter:  15 * time.Second,
+			ErrorReason: "input not spendable",
+		},
+	)
+	require.NoError(t, err)
+
+	_, ok := transition.NextState.(*AwaitingSubmitAccepted)
+	require.True(t, ok)
+	require.Len(t, transition.NewEvents.UnwrapOr(EmittedEvent{}).Outbox, 1)
+}
+
+// TestHandleSubmitOutboxErrorNonRetryableTerminal asserts a non-retryable
+// submit error still fails terminally and releases pre-PONR inputs, unchanged
+// from the shared handleOutboxError path.
+func TestHandleSubmitOutboxErrorNonRetryableTerminal(t *testing.T) {
+	t.Parallel()
+
+	current, outpoint := newTestSubmitState(t)
+
+	env := &Environment{
+		Clock:                   clock.NewTestClock(time.Unix(1, 0)),
+		MaxTransientSubmitRetry: time.Hour,
+	}
+
+	transition, err := handleSubmitOutboxError(
+		env, current, &OutboxErrorEvent{
+			OutboxType:  "submit",
+			Retryable:   false,
+			ErrorReason: "output policy violation",
+		},
+	)
+	require.NoError(t, err)
+
+	failed, ok := transition.NextState.(*Failed)
+	require.True(t, ok)
+	require.Equal(t, "output policy violation", failed.Reason)
+
+	emitted := transition.NewEvents.UnwrapOr(EmittedEvent{})
+	require.Len(t, emitted.Outbox, 1)
+	release, ok := emitted.Outbox[0].(*ReleaseInputsRequest)
+	require.True(t, ok)
+	require.Equal(t, []wire.OutPoint{outpoint}, release.Outpoints)
+}

--- a/oor/transitions.go
+++ b/oor/transitions.go
@@ -277,7 +277,6 @@ func (s *AwaitingSubmitAccepted) ProcessEvent(ctx context.Context, event Event,
 	env *Environment) (*StateTransition, error) {
 
 	_ = ctx
-	_ = env
 
 	switch evt := event.(type) {
 	case *SubmitAcceptedEvent:
@@ -334,7 +333,7 @@ func (s *AwaitingSubmitAccepted) ProcessEvent(ctx context.Context, event Event,
 		}, nil
 
 	case *OutboxErrorEvent:
-		return handleOutboxError(env, s, evt)
+		return handleSubmitOutboxError(env, s, evt)
 
 	case *FailEvent:
 		return &StateTransition{
@@ -578,6 +577,98 @@ func handleOutboxError(env *Environment, current State,
 
 	return &StateTransition{
 		NextState: current,
+		NewEvents: fn.Some(EmittedEvent{
+			Outbox: []OutboxEvent{
+				&ScheduleRetryRequest{
+					After:  after,
+					Reason: evt.ErrorReason,
+				},
+			},
+		}),
+	}, nil
+}
+
+// handleSubmitOutboxError derives the retry-or-fail transition for an outbox
+// error while the outgoing session is awaiting submit acceptance.
+//
+// Unlike the generic handleOutboxError, a retryable error here is bounded by a
+// configurable cumulative retry window (env.MaxTransientSubmitRetry). The
+// operator's transient submit rejections (INPUT_NOT_SPENDABLE and USER_BALANCE)
+// are re-driven on the actor's fixed retry cadence, but only until the window
+// since the first reject elapses. Once the budget is exhausted the session
+// fails terminally via the same path handleOutboxError uses for non-retryable
+// errors (which releases the reserved pre-point-of-no-return input VTXOs), so a
+// genuinely-stuck input or a never-draining UserBalance recipient gives up
+// instead of retrying forever. A zero budget keeps the legacy unbounded
+// behavior, so a directly-constructed Environment without a configured cap
+// still retries as before. Non-retryable errors keep handleOutboxError's
+// immediate-terminal behavior.
+//
+// The transition never calls time.Now() directly: the current time comes from
+// env.Now() so the FSM stays deterministic under an injected clock. The
+// retry-window start is carried forward on the returned state (and persisted in
+// the snapshot) so the bound survives restarts.
+func handleSubmitOutboxError(env *Environment, current *AwaitingSubmitAccepted,
+	evt *OutboxErrorEvent) (*StateTransition, error) {
+
+	if evt == nil {
+		return nil, fmt.Errorf("outbox error event must be provided")
+	}
+
+	// Non-retryable errors are terminal immediately. Reuse the shared
+	// handler so the pre-point-of-no-return input release stays identical.
+	if !evt.Retryable {
+		return handleOutboxError(env, current, evt)
+	}
+
+	// env is non-nil on every protofsm ProcessEvent turn, but both reads
+	// stay nil-safe (env.Now defaults to a real clock; the cap defaults to
+	// 0 = unbounded) so directly-constructed test envs still work. Read the
+	// configured cap first, then the clock, so the two agree on nil-safety.
+	var maxRetry time.Duration
+	if env != nil {
+		maxRetry = env.MaxTransientSubmitRetry
+	}
+
+	now := env.Now()
+
+	// If the retry window has already opened and its cumulative elapsed
+	// time exceeds the configured budget, give up: fail terminally through
+	// the same path a non-retryable error takes (releasing pre-PONR
+	// inputs), noting the exhausted budget, the elapsed duration, and the
+	// last reject reason. A zero budget disables this bound entirely.
+	if maxRetry > 0 && current.FirstRejectUnixNanos != 0 {
+		elapsed := now.Sub(time.Unix(0, current.FirstRejectUnixNanos))
+		if elapsed > maxRetry {
+			reason := fmt.Sprintf("submit retry budget of %s "+
+				"exhausted after %s; last reject: %s", maxRetry,
+				elapsed, evt.ErrorReason)
+
+			return handleOutboxError(
+				env, current, &OutboxErrorEvent{
+					OutboxType:  evt.OutboxType,
+					Retryable:   false,
+					ErrorReason: reason,
+				},
+			)
+		}
+	}
+
+	// Still within budget (or unbounded): open the retry window on the
+	// first reject and carry it forward on subsequent rejects, then
+	// schedule the retry exactly as the unbounded path does.
+	next := *current
+	if next.FirstRejectUnixNanos == 0 {
+		next.FirstRejectUnixNanos = now.UnixNano()
+	}
+
+	after := evt.RetryAfter
+	if after == 0 {
+		after = defaultRetryDelay
+	}
+
+	return &StateTransition{
+		NextState: &next,
 		NewEvents: fn.Some(EmittedEvent{
 			Outbox: []OutboxEvent{
 				&ScheduleRetryRequest{

--- a/sample-waved.conf
+++ b/sample-waved.conf
@@ -289,6 +289,11 @@
 # Safety cap on mailbox address-script bytes.
 # oor.limits.maxmailboxscriptbytes=10000
 
+# Cap on how long waved keeps re-driving a transient OOR submit rejection
+# (an input not yet spendable on the operator, or a recipient over its
+# balance cap) before giving up. Zero uses the package default of 1h.
+# oor.maxsubmitretry=1h0m0s
+
 # Optional bitcoind RPC address for submitpackage support.
 # bitcoind.host=
 

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -115,10 +115,16 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   `OutboxErrorEvent` instead of an `Adapt` error that would stall the
   serverconn ingress cursor on the offending envelope (`server.go`).
   `oorRejectRetry` classifies the event's `Retryable` flag: it is `false`
-  (terminal) for every typed reject except `OOR_REJECT_INPUT_NOT_SPENDABLE`,
-  which is transient (the operator has not yet caught up to the input's
-  commitment confirmation) and so re-drives the submit after
-  `oorInputNotSpendableRetryDelay`.
+  (terminal) for every typed reject except the two transient codes,
+  `OOR_REJECT_INPUT_NOT_SPENDABLE` (the operator has not yet caught up to the
+  input's commitment confirmation) and `OOR_REJECT_USER_BALANCE` (the
+  recipient mailbox is over its balance cap), which re-drive the submit after
+  `oorTransientRejectRetryDelay`. That retry is now bounded: the FSM's
+  `AwaitingSubmitAccepted` transition (`handleSubmitOutboxError` in
+  `oor/transitions.go`) gives up terminally once the cumulative retry window
+  exceeds `OORConfig.MaxTransientSubmitRetry` (default 1h), persisting the
+  window start (`FirstRejectUnixNanos`) in the outgoing snapshot (version 5)
+  so the bound survives restarts.
 
 ## Deep Docs
 

--- a/waved/config.go
+++ b/waved/config.go
@@ -522,7 +522,26 @@ func (c *Config) MempoolSpaceFeeURL() string {
 type OORConfig struct {
 	// Limits configures advanced incoming OOR receive safety caps.
 	Limits *OORLimitsConfig `mapstructure:"limits"`
+
+	// MaxTransientSubmitRetry bounds the cumulative wall-clock time the OOR
+	// FSM keeps re-driving a transient submit rejection
+	// (OOR_REJECT_INPUT_NOT_SPENDABLE or OOR_REJECT_USER_BALANCE) while
+	// awaiting submit acceptance before failing the session terminally. A
+	// zero value selects defaultMaxTransientSubmitRetry; a negative value
+	// is rejected by Config.Validate. The config key is shortened to
+	// "maxsubmitretry" so the tagged field line stays within 80 columns.
+	MaxTransientSubmitRetry time.Duration `mapstructure:"maxsubmitretry"`
 }
+
+// defaultMaxTransientSubmitRetry is the default cap on how long waved keeps
+// re-driving a transient OOR submit rejection before giving up. It must outlast
+// a several-block operator confirmation catch-up at the
+// oorTransientRejectRetryDelay (15s) retry cadence: ~6 mainnet blocks at
+// ~10 min/block is ~60 min, so a normal INPUT_NOT_SPENDABLE (the operator's
+// chain view simply lagging a block this client already saw) always clears well
+// within the window, while a genuinely-stuck input or a never-draining
+// USER_BALANCE recipient gives up after the cap instead of retrying forever.
+const defaultMaxTransientSubmitRetry = time.Hour
 
 // OORLimitsConfig configures advanced incoming OOR receive safety caps.
 type OORLimitsConfig struct {
@@ -557,7 +576,19 @@ func defaultOORConfig() *OORConfig {
 			MaxMailboxItems:       limits.MaxMailboxItems,
 			MaxMailboxScriptBytes: limits.MaxMailboxScriptBytes,
 		},
+		MaxTransientSubmitRetry: defaultMaxTransientSubmitRetry,
 	}
+}
+
+// OORMaxTransientSubmitRetry returns the cumulative retry-window cap for
+// transient OOR submit rejections, falling back to the default when the OOR
+// config is absent or left unset.
+func (c *Config) OORMaxTransientSubmitRetry() time.Duration {
+	if c == nil || c.OOR == nil || c.OOR.MaxTransientSubmitRetry <= 0 {
+		return defaultMaxTransientSubmitRetry
+	}
+
+	return c.OOR.MaxTransientSubmitRetry
 }
 
 // OORReceiveLimits returns the incoming OOR receive limits configured for this
@@ -1151,6 +1182,16 @@ func (c *Config) Validate() error {
 	}
 	if err := validateOORLimitsConfig(c.OOR.Limits); err != nil {
 		return err
+	}
+
+	// A negative retry window is a misconfiguration; a zero value selects
+	// the default so operators do not have to spell out the cap.
+	if c.OOR.MaxTransientSubmitRetry < 0 {
+		return fmt.Errorf("oor.maxsubmitretry must not be "+
+			"negative: got %s", c.OOR.MaxTransientSubmitRetry)
+	}
+	if c.OOR.MaxTransientSubmitRetry == 0 {
+		c.OOR.MaxTransientSubmitRetry = defaultMaxTransientSubmitRetry
 	}
 
 	// Validate wallet config.

--- a/waved/config_oor_retry_test.go
+++ b/waved/config_oor_retry_test.go
@@ -1,0 +1,50 @@
+package waved
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigValidateRejectsNegativeMaxTransientSubmitRetry asserts a negative
+// transient submit-reject retry window is a misconfiguration and is rejected.
+func TestConfigValidateRejectsNegativeMaxTransientSubmitRetry(t *testing.T) {
+	t.Parallel()
+
+	cfg := validOORLimitsTestConfig()
+	cfg.OOR.MaxTransientSubmitRetry = -time.Second
+
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "oor.maxsubmitretry")
+}
+
+// TestConfigValidateDefaultsMaxTransientSubmitRetry asserts a zero (unset)
+// transient submit-reject retry window is defaulted rather than left disabled.
+func TestConfigValidateDefaultsMaxTransientSubmitRetry(t *testing.T) {
+	t.Parallel()
+
+	cfg := validOORLimitsTestConfig()
+	cfg.OOR.MaxTransientSubmitRetry = 0
+
+	require.NoError(t, cfg.Validate())
+	require.Equal(
+		t, defaultMaxTransientSubmitRetry,
+		cfg.OOR.MaxTransientSubmitRetry,
+	)
+}
+
+// TestConfigValidateAcceptsPositiveMaxTransientSubmitRetry asserts an explicit
+// positive window is preserved through validation.
+func TestConfigValidateAcceptsPositiveMaxTransientSubmitRetry(t *testing.T) {
+	t.Parallel()
+
+	cfg := validOORLimitsTestConfig()
+	cfg.OOR.MaxTransientSubmitRetry = 90 * time.Minute
+
+	require.NoError(t, cfg.Validate())
+	require.Equal(
+		t, 90*time.Minute, cfg.OOR.MaxTransientSubmitRetry,
+	)
+}

--- a/waved/oor_reject_retry_test.go
+++ b/waved/oor_reject_retry_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestOORRejectRetry verifies that only the transient input-not-spendable
-// rejection is driven through the OOR FSM as retryable (so the submit is
-// re-driven until the operator's chain view catches up and the transfer
-// recovers), while every other typed rejection stays terminal. This is the
-// server-reject-to-client-retry link behind the darepo-client#938 fix: paired
-// with oor.TestHandleOutboxError (retryable OutboxError re-drives instead of
-// failing), it shows an input-not-spendable rejection recovers rather than
+// TestOORRejectRetry verifies that the two transient rejections
+// (input-not-spendable and user-balance-exceeded) are driven through the OOR
+// FSM as retryable (so the submit is re-driven — bounded by the FSM's
+// cumulative retry-window cap — until the transient condition clears and the
+// transfer recovers), while every other typed rejection stays terminal. This is
+// the server-reject-to-client-retry link behind the darepo-client#938 fix:
+// paired with oor.TestHandleOutboxError (retryable OutboxError re-drives
+// instead of failing), it shows a transient rejection recovers rather than
 // wedging.
 func TestOORRejectRetry(t *testing.T) {
 	t.Parallel()
@@ -33,7 +34,7 @@ func TestOORRejectRetry(t *testing.T) {
 				ServerBestHeight: 100,
 			},
 			wantRetryable: true,
-			wantDelay:     oorInputNotSpendableRetryDelay,
+			wantDelay:     oorTransientRejectRetryDelay,
 		},
 		{
 			name: "output policy is terminal",
@@ -43,11 +44,12 @@ func TestOORRejectRetry(t *testing.T) {
 			wantRetryable: false,
 		},
 		{
-			name: "user balance is terminal",
+			name: "user balance is retried",
 			err: &oor.ErrUserBalanceExceeded{
 				Reason: "x",
 			},
-			wantRetryable: false,
+			wantRetryable: true,
+			wantDelay:     oorTransientRejectRetryDelay,
 		},
 		{
 			name: "lineage too large is terminal",

--- a/waved/server.go
+++ b/waved/server.go
@@ -783,34 +783,45 @@ func (s *Server) setServerConnected(connected bool) {
 // gRPC connectivity API.
 const operatorConnPollInterval = 15 * time.Second
 
-// oorInputNotSpendableRetryDelay is how long the OOR FSM waits before
-// re-driving a submit that the operator rejected because an input was not yet
-// spendable (its round commitment tx had not reached the operator's
-// confirmation target). The wait only needs to outlast the operator's chain
-// backend catching up to a block this client already saw — typically seconds —
-// so a short delay keeps the swap responsive, while being long enough to avoid
-// hammering the operator with resubmits between blocks. It is deliberately far
-// below any swap invoice deadline so the natural deadline (not this timer)
-// bounds total retrying when the operator never catches up. A plain SendOOR
-// with no such deadline re-drives indefinitely on a persistent reject — the
-// same "re-drive on operator silence, never give up" behavior the
-// AwaitingSubmitAccepted transport timer already has — which is acceptable
-// because the operator only emits this transient code for a pending input.
-const oorInputNotSpendableRetryDelay = 15 * time.Second
+// oorTransientRejectRetryDelay is how long the OOR FSM waits before re-driving
+// a submit that the operator rejected with a transient code. The wait only
+// needs to outlast the transient condition clearing — the operator's chain
+// backend catching up to a block this client already saw, or the recipient's
+// mailbox balance draining — typically seconds to a few minutes, so a short
+// delay keeps the swap responsive while being long enough to avoid hammering
+// the operator with resubmits between blocks. The (idempotent) submit is
+// re-driven on this cadence, but the total retrying is now bounded by the
+// OORConfig.MaxTransientSubmitRetry cumulative-window cap enforced in the FSM
+// (see handleSubmitOutboxError), so a genuinely-stuck input or a never-draining
+// recipient balance gives up instead of retrying forever.
+const oorTransientRejectRetryDelay = 15 * time.Second
 
 // oorRejectRetry decides how a classified OOR submit rejection is driven
-// through the session FSM. An input-not-spendable rejection is transient — the
-// operator has not yet caught up to the input's round-commitment confirmation
-// that this client already observed — so it is retried after a delay and the
-// (idempotent) submit is re-driven until the operator's chain view catches up.
-// Every other typed rejection is terminal for the same submit shape, so it
-// drives the session to failure without a retry.
+// through the session FSM. Two typed rejections are transient and retried on
+// the oorTransientRejectRetryDelay cadence (bounded by the FSM's cumulative
+// retry-window cap):
+//
+//   - ErrInputNotSpendable: the operator has not yet caught up to the input's
+//     round-commitment confirmation that this client already observed, so the
+//     same submit succeeds once its chain view catches up.
+//   - ErrUserBalanceExceeded: the recipient mailbox's aggregate balance is over
+//     the operator's cap, so the same-shape resubmit succeeds once the
+//     recipient's balance drops.
+//
+// Every other typed rejection (lineage-too-large, output-policy, and
+// unspecified) is terminal for the same submit shape, so it drives the session
+// to failure without a retry.
 func oorRejectRetry(classified error) (bool, time.Duration) {
-	if errors.Is(classified, &oor.ErrInputNotSpendable{}) {
-		return true, oorInputNotSpendableRetryDelay
-	}
+	switch {
+	case errors.Is(classified, &oor.ErrInputNotSpendable{}):
+		return true, oorTransientRejectRetryDelay
 
-	return false, 0
+	case errors.Is(classified, &oor.ErrUserBalanceExceeded{}):
+		return true, oorTransientRejectRetryDelay
+
+	default:
+		return false, 0
+	}
 }
 
 // monitorOperatorConnection keeps the ServerConnectionUp gauge and the
@@ -4437,6 +4448,12 @@ func (s *Server) initOORActor(ctx context.Context,
 		TimeoutActor: oorTimeoutRef,
 		CallbackRef:  oorCallbackRef,
 		ActorSystem:  s.actorSystem,
+
+		// Share the daemon's single clock so the FSM's bounded
+		// transient submit-reject retry window is deterministic and
+		// testable, and inject the configured retry-budget cap.
+		Clock:                   s.clk,
+		MaxTransientSubmitRetry: s.cfg.OORMaxTransientSubmitRetry(),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## What

Follow-up to #938 / #943. Bounds the transient OOR submit-reject retry and
extends retryable recovery to `OOR_REJECT_USER_BALANCE`.

## Why

The daemon retries a transient OOR submit rejection by re-driving the submit
through the OOR FSM. That retry was **unbounded** — it re-drove every 15s
(`oorTransientRejectRetryDelay`) forever on a plain send. It was safe only
because `INPUT_NOT_SPENDABLE` self-resolves in ~1 block; a genuinely-stuck input
(a dropped/reorged commitment tx, an abandoned round) would spin resubmits
forever. And `USER_BALANCE` — documented as "hold and retry later; a same-shape
resubmit can succeed once the recipient's balance drops" — was kept terminal
precisely because auto-retrying it unboundedly would spin against a maybe-never
event.

## What this PR does

1. **Configurable max-duration bound.** `OORConfig.MaxTransientSubmitRetry`
   (default `1h`; `0` disables the bound) caps how long the
   `AwaitingSubmitAccepted` state keeps re-driving before failing the session
   terminally and releasing the pre-point-of-no-return input locks. The window
   start is persisted in the outgoing snapshot (`Version 4→5`; a pre-v5 snapshot
   decodes the absent record to `0`, a fresh window) so the bound survives a
   daemon restart. The transition reads a clock injected via the FSM
   `Environment` rather than `time.Now()`, so it stays deterministic under test;
   the clock and the cap are threaded from `waved`'s `OORConfig` through the
   registry and session-actor construction paths.
2. **`USER_BALANCE` is now bounded-retryable.** `oorRejectRetry` classifies both
   `OOR_REJECT_INPUT_NOT_SPENDABLE` and `OOR_REJECT_USER_BALANCE` as transient,
   each capped by the same window. `LineageTooLarge` / `OutputPolicy` stay
   terminal (they require the client to restructure the transfer into a new
   session).

## Companion

Paired with an operator-side lumos PR that keeps `USER_BALANCE` non-terminal so
the retry re-validates (the #938 server fix already does this for
`INPUT_NOT_SPENDABLE`). Both are needed for `USER_BALANCE` recovery end to end;
this client change is safe to merge first (an un-updated operator simply keeps
failing the retry terminally, same as today).

## Testing

- FSM (`oor`): within-budget reschedule carries the window forward; over-budget
  → terminal fail + input release; zero-budget → unbounded (legacy).
- Snapshot round-trip: v5 persists/restores the window start; a v4 snapshot
  restores `0` without error.
- `oorRejectRetry`: both transient codes retryable, others terminal.
- Config validation: `0` → default, negative rejected.
- `go build`, `go test ./oor/... ./waved/...`, and `custom-gcl` lint (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
