### PR TITLE
build: bump version to v0.1.0-rc3

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -15,11 +15,11 @@ const (
 	AppMinor uint = 1
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 99
+	AppPatch uint = 0
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.
-	AppPreRelease = ""
+	AppPreRelease = "rc3"
 )
 
 var (


### PR DESCRIPTION
In this PR, we bump `v0.1.x-branch` to `v0.1.0-rc3` ahead of tagging the
third release candidate.

`v0.1.x-branch` was force-reset to `main` first, to pick up the
`darepo-client` -> `wavelength` rename (and everything else that landed
since rc2). The branch carried nothing but the rc2 version bump, and its
old tip is pinned forever by the `v0.1.0-rc2` tag, so nothing was lost.

`main` stays at `0.1.99`, the dev marker for the v0.1 series.

## Testing

`go test ./build/...` passes, and `waved --version` reports
`waved version 0.1.0-rc3`, which is what `scripts/release.sh check-tag`
matches against the tag name at tagging time.