### PR TITLE
waved: switch testnet defaults to lightning.finance CNAMEs

### DIFF
--- a/btcwbackend/defaults.go
+++ b/btcwbackend/defaults.go
@@ -1,0 +1,41 @@
+package btcwbackend
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+)
+
+const (
+	// DefaultFeeURLMainnet is the default chainfee.SparseConfFeeSource
+	// endpoint for mainnet.
+	DefaultFeeURLMainnet = "https://nodes.lightning.computer/fees/v1/" +
+		"btc-fee-estimates.json"
+
+	// DefaultFeeURLTestnet is the default chainfee.SparseConfFeeSource
+	// endpoint shared by testnet3, testnet4, and signet.
+	DefaultFeeURLTestnet = "https://nodes.lightning.computer/fees/v1/" +
+		"btctestnet-fee-estimates.json"
+)
+
+// DefaultFeeURL returns the default chainfee.SparseConfFeeSource endpoint
+// for params, or an error if the network has no public endpoint.
+func DefaultFeeURL(params *chaincfg.Params) (string, error) {
+	if params == nil {
+		return "", fmt.Errorf("chain params are required")
+	}
+
+	switch {
+	case params.Net == wire.MainNet:
+		return DefaultFeeURLMainnet, nil
+
+	case params.Net == wire.TestNet3, params.Net == wire.TestNet4,
+		params.Name == chaincfg.SigNetParams.Name:
+		return DefaultFeeURLTestnet, nil
+
+	default:
+		return "", fmt.Errorf("no default fee URL for network %q",
+			params.Name)
+	}
+}

--- a/btcwbackend/defaults_test.go
+++ b/btcwbackend/defaults_test.go
@@ -1,0 +1,76 @@
+package btcwbackend
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultFeeURL verifies mainnet resolves to the mainnet
+// nodes.lightning.computer endpoint, testnet3/testnet4/signet share the
+// testnet endpoint, and unsupported networks error out instead of silently
+// returning an empty URL.
+func TestDefaultFeeURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		params  *chaincfg.Params
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "mainnet",
+			params: &chaincfg.MainNetParams,
+			want:   DefaultFeeURLMainnet,
+		},
+		{
+			name:   "testnet3",
+			params: &chaincfg.TestNet3Params,
+			want:   DefaultFeeURLTestnet,
+		},
+		{
+			name:   "testnet4",
+			params: &chaincfg.TestNet4Params,
+			want:   DefaultFeeURLTestnet,
+		},
+		{
+			name:   "signet",
+			params: &chaincfg.SigNetParams,
+			want:   DefaultFeeURLTestnet,
+		},
+		{
+			name:    "regtest has no default",
+			params:  &chaincfg.RegressionNetParams,
+			wantErr: true,
+		},
+		{
+			name:    "simnet has no default",
+			params:  &chaincfg.SimNetParams,
+			wantErr: true,
+		},
+		{
+			name:    "nil params",
+			params:  nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := DefaultFeeURL(tc.params)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -97,8 +97,8 @@ waved \
 | `--logdir` | `~/.waved/logs/<network>` | Directory for persistent daemon logs |
 | `--allow-mainnet` | `false` | Required to run on mainnet (safety guard) |
 | `--wallet.type` | `lwwallet` | Wallet backend: `lwwallet`, `lnd`, or `btcwallet` |
-| `--wallet.esploraurl` | | Esplora REST API URL (lwwallet only) |
-| `--wallet.feeurl` | | Fee-estimate JSON endpoint URL (btcwallet only) |
+| `--wallet.esploraurl` | network default | Esplora REST API URL (lwwallet only); required on regtest/simnet, see [docs/signet.md](signet.md) |
+| `--wallet.feeurl` | network default | Fee-estimate JSON endpoint URL (btcwallet only); required on regtest/simnet, see [docs/signet.md](signet.md) |
 | `--wallet.btcwallet_blockheaderssource` | | Block header import source for btcwallet fast sync |
 | `--wallet.btcwallet_filterheaderssource` | | Filter header import source for btcwallet fast sync |
 | `--wallet.pollinterval` | `30s` | Esplora poll interval (lwwallet only) |

--- a/docs/signet.md
+++ b/docs/signet.md
@@ -18,8 +18,7 @@ waved \
   --network=signet \
   --server.transport=rest \
   --swap.servertransport=rest \
-  --wallet.type=lwwallet \
-  --wallet.esploraurl=https://your-signet-esplora.example/api
+  --wallet.type=lwwallet
 ```
 
 All public endpoints use publicly trusted TLS certificates. Leave
@@ -33,6 +32,23 @@ through its raw cluster hostname; a friendly-domain CNAME will follow once
 the certificate work in
 [lightning-infra#3517](https://github.com/lightninglabs/lightning-infra/pull/3517)
 lands.
+
+## Wallet Chain Data and Fee Estimation
+
+`wallet.esploraurl` (lwwallet) and `wallet.feeurl` (btcwallet) also resolve
+network defaults when left empty:
+
+| Network config | lwwallet Esplora URL | btcwallet fee URL |
+|----------------|-----------------------|--------------------|
+| `mainnet` | `https://mempool.space/api` | `https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json` |
+| `testnet` | `https://mempool.space/testnet/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |
+| `testnet4` | `https://mempool.space/testnet4/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |
+| `signet` | `https://mempool.space/signet/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |
+
+`regtest` and `simnet` have no public default for either field; a local dev
+stack must set `wallet.esploraurl` or `wallet.feeurl` explicitly, as in the
+local test-network example below. An explicit value always overrides the
+network default on every network, including mainnet.
 
 ## Config Resolution
 

--- a/docs/signet.md
+++ b/docs/signet.md
@@ -6,9 +6,9 @@ endpoint for the configured Bitcoin network and outbound transport.
 
 | Network config | Ark gRPC | Ark REST | Swap gRPC | Swap REST |
 |----------------|----------|----------|-----------|-----------|
-| `testnet` | `test.wavelength.lightning.finance:443` | `https://test.wavelength-rest.lightning.finance` | `swap.test.wavelength.lightning.finance:443` | `https://test.swapd-rest.lightning.finance` |
+| `testnet` | `test.wavelength.lightning.finance:443` | `https://test.wavelength-rest.lightning.finance` | `test.swap.wavelength.lightning.finance:443` | `https://test.swapd-rest.lightning.finance` |
 | `testnet4` | `lumosd-testnet4.testnet.lightningcluster.com:443` | `https://test4.wavelength-rest.lightning.finance` | `swapd-testnet4.testnet.lightningcluster.com:443` | `https://test4.swapd-rest.lightning.finance` |
-| `signet` | `signet.wavelength.lightning.finance:443` | `https://signet.wavelength-rest.lightning.finance` | `swap.signet.wavelength.lightning.finance:443` | `https://signet.swapd-rest.lightning.finance` |
+| `signet` | `signet.wavelength.lightning.finance:443` | `https://signet.wavelength-rest.lightning.finance` | `signet.swap.wavelength.lightning.finance:443` | `https://signet.swapd-rest.lightning.finance` |
 
 The daemon defaults both outbound transports to gRPC. Set the selectors to
 `rest` when the host cannot use native gRPC:

--- a/docs/signet.md
+++ b/docs/signet.md
@@ -41,9 +41,9 @@ network defaults when left empty:
 | Network config | lwwallet Esplora URL | btcwallet fee URL |
 |----------------|-----------------------|--------------------|
 | `mainnet` | `https://mempool.space/api` | `https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json` |
-| `testnet` | `https://mempool.space/testnet/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |
-| `testnet4` | `https://mempool.space/testnet4/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |
-| `signet` | `https://mempool.space/signet/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |
+| `testnet` | `https://mempool-testnet3.testnet.lightningcluster.com/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |
+| `testnet4` | `https://mempool-testnet4.testnet.lightningcluster.com/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |
+| `signet` | `https://mempool-signet.testnet.lightningcluster.com/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |
 
 `regtest` and `simnet` have no public default for either field; a local dev
 stack must set `wallet.esploraurl` or `wallet.feeurl` explicitly, as in the

--- a/docs/signet.md
+++ b/docs/signet.md
@@ -6,9 +6,9 @@ endpoint for the configured Bitcoin network and outbound transport.
 
 | Network config | Ark gRPC | Ark REST | Swap gRPC | Swap REST |
 |----------------|----------|----------|-----------|-----------|
-| `testnet` | `lumosd.testnet.lightningcluster.com:443` | `https://lumosd-rest.testnet.lightningcluster.com` | `swapd.testnet.lightningcluster.com:443` | `https://swapd-rest.testnet.lightningcluster.com` |
-| `testnet4` | `lumosd-testnet4.testnet.lightningcluster.com:443` | `https://lumosd-testnet4-rest.testnet.lightningcluster.com` | `swapd-testnet4.testnet.lightningcluster.com:443` | `https://swapd-testnet4-rest.testnet.lightningcluster.com` |
-| `signet` | `lumosd-signet.staging.lightningcluster.com:443` | `https://lumosd-signet-rest.staging.lightningcluster.com` | `swapd-signet.staging.lightningcluster.com:443` | `https://swapd-signet-rest.staging.lightningcluster.com` |
+| `testnet` | `test.wavelength.lightning.finance:443` | `https://test.wavelength-rest.lightning.finance` | `swap.test.wavelength.lightning.finance:443` | `https://test.swapd-rest.lightning.finance` |
+| `testnet4` | `lumosd-testnet4.testnet.lightningcluster.com:443` | `https://test4.wavelength-rest.lightning.finance` | `swapd-testnet4.testnet.lightningcluster.com:443` | `https://test4.swapd-rest.lightning.finance` |
+| `signet` | `signet.wavelength.lightning.finance:443` | `https://signet.wavelength-rest.lightning.finance` | `swap.signet.wavelength.lightning.finance:443` | `https://signet.swapd-rest.lightning.finance` |
 
 The daemon defaults both outbound transports to gRPC. Set the selectors to
 `rest` when the host cannot use native gRPC:
@@ -27,9 +27,10 @@ All public endpoints use publicly trusted TLS certificates. Leave
 certificate paths empty so the clients use the system certificate pool. The
 swap endpoint is consumed only by builds that include `swapruntime`.
 
-The testnet4 REST gateways are live. The testnet4 gRPC hostnames are already
-the deployment names, but their public NLBs remain disabled until the
-certificate work in
+The testnet4 REST gateways are live behind their friendly-domain CNAMEs. The
+testnet4 gRPC endpoint's public NLB remains disabled, so it is still reached
+through its raw cluster hostname; a friendly-domain CNAME will follow once
+the certificate work in
 [lightning-infra#3517](https://github.com/lightninglabs/lightning-infra/pull/3517)
 lands.
 

--- a/lwwallet/defaults.go
+++ b/lwwallet/defaults.go
@@ -1,0 +1,53 @@
+package lwwallet
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+)
+
+const (
+	// DefaultEsploraURLMainnet is the public mempool.space
+	// Esplora-compatible REST API for mainnet.
+	DefaultEsploraURLMainnet = "https://mempool.space/api"
+
+	// DefaultEsploraURLTestnet3 is the public mempool.space
+	// Esplora-compatible REST API for testnet3.
+	DefaultEsploraURLTestnet3 = "https://mempool.space/testnet/api"
+
+	// DefaultEsploraURLTestnet4 is the public mempool.space
+	// Esplora-compatible REST API for testnet4.
+	DefaultEsploraURLTestnet4 = "https://mempool.space/testnet4/api"
+
+	// DefaultEsploraURLSignet is the public mempool.space
+	// Esplora-compatible REST API for signet.
+	DefaultEsploraURLSignet = "https://mempool.space/signet/api"
+)
+
+// DefaultEsploraURL returns the public mempool.space Esplora-compatible REST
+// API endpoint for params, or an error if the network has no public
+// endpoint.
+func DefaultEsploraURL(params *chaincfg.Params) (string, error) {
+	if params == nil {
+		return "", fmt.Errorf("chain params are required")
+	}
+
+	switch {
+	case params.Net == wire.MainNet:
+		return DefaultEsploraURLMainnet, nil
+
+	case params.Net == wire.TestNet3:
+		return DefaultEsploraURLTestnet3, nil
+
+	case params.Net == wire.TestNet4:
+		return DefaultEsploraURLTestnet4, nil
+
+	case params.Name == chaincfg.SigNetParams.Name:
+		return DefaultEsploraURLSignet, nil
+
+	default:
+		return "", fmt.Errorf("no default esplora URL for network %q",
+			params.Name)
+	}
+}

--- a/lwwallet/defaults.go
+++ b/lwwallet/defaults.go
@@ -12,22 +12,24 @@ const (
 	// Esplora-compatible REST API for mainnet.
 	DefaultEsploraURLMainnet = "https://mempool.space/api"
 
-	// DefaultEsploraURLTestnet3 is the public mempool.space
-	// Esplora-compatible REST API for testnet3.
-	DefaultEsploraURLTestnet3 = "https://mempool.space/testnet/api"
+	// DefaultEsploraURLTestnet3 is the Esplora-compatible REST API for
+	// testnet3, backed by a Lightning Labs-operated mempool instance.
+	DefaultEsploraURLTestnet3 = "https://mempool-testnet3.testnet." +
+		"lightningcluster.com/api"
 
-	// DefaultEsploraURLTestnet4 is the public mempool.space
-	// Esplora-compatible REST API for testnet4.
-	DefaultEsploraURLTestnet4 = "https://mempool.space/testnet4/api"
+	// DefaultEsploraURLTestnet4 is the Esplora-compatible REST API for
+	// testnet4, backed by a Lightning Labs-operated mempool instance.
+	DefaultEsploraURLTestnet4 = "https://mempool-testnet4.testnet." +
+		"lightningcluster.com/api"
 
-	// DefaultEsploraURLSignet is the public mempool.space
-	// Esplora-compatible REST API for signet.
-	DefaultEsploraURLSignet = "https://mempool.space/signet/api"
+	// DefaultEsploraURLSignet is the Esplora-compatible REST API for
+	// signet, backed by a Lightning Labs-operated mempool instance.
+	DefaultEsploraURLSignet = "https://mempool-signet.testnet." +
+		"lightningcluster.com/api"
 )
 
-// DefaultEsploraURL returns the public mempool.space Esplora-compatible REST
-// API endpoint for params, or an error if the network has no public
-// endpoint.
+// DefaultEsploraURL returns the default Esplora-compatible REST API endpoint
+// for params, or an error if the network has no default endpoint.
 func DefaultEsploraURL(params *chaincfg.Params) (string, error) {
 	if params == nil {
 		return "", fmt.Errorf("chain params are required")

--- a/lwwallet/defaults_test.go
+++ b/lwwallet/defaults_test.go
@@ -1,0 +1,75 @@
+package lwwallet
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultEsploraURL verifies each supported network resolves to its
+// public mempool.space Esplora endpoint, and unsupported networks error out
+// instead of silently returning an empty URL.
+func TestDefaultEsploraURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		params  *chaincfg.Params
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "mainnet",
+			params: &chaincfg.MainNetParams,
+			want:   DefaultEsploraURLMainnet,
+		},
+		{
+			name:   "testnet3",
+			params: &chaincfg.TestNet3Params,
+			want:   DefaultEsploraURLTestnet3,
+		},
+		{
+			name:   "testnet4",
+			params: &chaincfg.TestNet4Params,
+			want:   DefaultEsploraURLTestnet4,
+		},
+		{
+			name:   "signet",
+			params: &chaincfg.SigNetParams,
+			want:   DefaultEsploraURLSignet,
+		},
+		{
+			name:    "regtest has no default",
+			params:  &chaincfg.RegressionNetParams,
+			wantErr: true,
+		},
+		{
+			name:    "simnet has no default",
+			params:  &chaincfg.SimNetParams,
+			wantErr: true,
+		},
+		{
+			name:    "nil params",
+			params:  nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := DefaultEsploraURL(tc.params)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/waved/config.go
+++ b/waved/config.go
@@ -13,10 +13,12 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/btcwbackend"
 	"github.com/lightninglabs/wavelength/chainbackends"
 	"github.com/lightninglabs/wavelength/credit"
 	"github.com/lightninglabs/wavelength/db"
 	"github.com/lightninglabs/wavelength/db/sqlc"
+	"github.com/lightninglabs/wavelength/lwwallet"
 	mailboxpb "github.com/lightninglabs/wavelength/mailbox/pb"
 	"github.com/lightninglabs/wavelength/metrics"
 	"github.com/lightninglabs/wavelength/oor"
@@ -1031,8 +1033,10 @@ type WalletConfig struct {
 	Type string `mapstructure:"type"`
 
 	// EsploraURL is the base URL of the Esplora REST API used by the
-	// lwwallet backend for chain data. Required when Type is
-	// "lwwallet".
+	// lwwallet backend for chain data. Only used when Type is
+	// "lwwallet". Empty falls back to the public mempool.space
+	// endpoint for the configured network; regtest and simnet have
+	// no default and must set this explicitly.
 	EsploraURL string `mapstructure:"esploraurl"`
 
 	// PollInterval controls how often the lwwallet backend polls the
@@ -1077,8 +1081,11 @@ type WalletConfig struct {
 	BtcwalletDataDir string `mapstructure:"btcwallet_datadir"`
 
 	// FeeURL is the URL for the fee estimation API endpoint used by
-	// the btcwallet/neutrino backend. Required on mainnet since
-	// neutrino has no mempool visibility.
+	// the btcwallet/neutrino backend, since neutrino has no mempool
+	// visibility. Empty falls back to the default
+	// nodes.lightning.computer endpoint for the configured network;
+	// regtest and simnet have no default and must set this
+	// explicitly.
 	FeeURL string `mapstructure:"feeurl"`
 
 	// PersistFilters controls whether neutrino writes compact block
@@ -1198,45 +1205,8 @@ func (c *Config) Validate() error {
 	}
 
 	// Validate wallet config.
-	if c.Wallet == nil {
-		return fmt.Errorf("wallet config is required")
-	}
-
-	switch c.Wallet.Type {
-	case WalletTypeLnd:
-		// LND backend requires a valid lnd connection config.
-		if c.Lnd == nil {
-			return fmt.Errorf("lnd config is required when " +
-				"wallet.type is lnd")
-		}
-		if c.Lnd.Host == "" {
-			return fmt.Errorf("lnd host is required when " +
-				"wallet.type is lnd")
-		}
-
-	case WalletTypeLwwallet:
-		// Lightweight wallet requires an Esplora URL for
-		// chain data.
-		if c.Wallet.EsploraURL == "" {
-			return fmt.Errorf("wallet.esploraurl is required " +
-				"when wallet.type is lwwallet")
-		}
-
-	case WalletTypeBtcwallet:
-		// Neutrino has no mempool visibility, so fee estimation
-		// always requires an external API regardless of network.
-		if c.Wallet.FeeURL == "" {
-			return fmt.Errorf("wallet.feeurl is required when " +
-				"wallet.type is btcwallet")
-		}
-		err := c.Wallet.validateBtcwalletHeadersImportConfig()
-		if err != nil {
-			return err
-		}
-
-	default:
-		return fmt.Errorf("unknown wallet type %q, valid values: lnd, "+
-			"lwwallet, btcwallet", c.Wallet.Type)
+	if err := c.validateWalletConfig(); err != nil {
+		return err
 	}
 
 	// The mempool.space fee provider only composes with the lnd backend's
@@ -1305,6 +1275,77 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("swap vhtlc recovery max fee rate " +
 				"must be positive")
 		}
+	}
+
+	return nil
+}
+
+// validateWalletConfig validates the wallet backend selection, filling in
+// network-default Esplora/fee URLs for the lwwallet and btcwallet backends
+// when left empty.
+func (c *Config) validateWalletConfig() error {
+	if c.Wallet == nil {
+		return fmt.Errorf("wallet config is required")
+	}
+
+	switch c.Wallet.Type {
+	case WalletTypeLnd:
+		// LND backend requires a valid lnd connection config.
+		if c.Lnd == nil {
+			return fmt.Errorf("lnd config is required when " +
+				"wallet.type is lnd")
+		}
+		if c.Lnd.Host == "" {
+			return fmt.Errorf("lnd host is required when " +
+				"wallet.type is lnd")
+		}
+
+	case WalletTypeLwwallet:
+		// Lightweight wallet requires an Esplora URL for chain
+		// data. An empty value falls back to the public
+		// mempool.space endpoint for networks that have one;
+		// regtest and simnet still require it explicitly.
+		if c.Wallet.EsploraURL == "" {
+			chainParams, err := networkToChainParams(c.Network)
+			if err != nil {
+				return err
+			}
+			esploraURL, err := lwwallet.DefaultEsploraURL(
+				chainParams,
+			)
+			if err != nil {
+				return fmt.Errorf("wallet.esploraurl is " +
+					"required when wallet.type is lwwallet")
+			}
+			c.Wallet.EsploraURL = esploraURL
+		}
+
+	case WalletTypeBtcwallet:
+		// Neutrino has no mempool visibility, so fee estimation
+		// always requires an external API. An empty value falls
+		// back to the default nodes.lightning.computer endpoint
+		// for networks that have one; regtest and simnet still
+		// require it explicitly.
+		if c.Wallet.FeeURL == "" {
+			chainParams, err := networkToChainParams(c.Network)
+			if err != nil {
+				return err
+			}
+			feeURL, err := btcwbackend.DefaultFeeURL(chainParams)
+			if err != nil {
+				return fmt.Errorf("wallet.feeurl is required " +
+					"when wallet.type is btcwallet")
+			}
+			c.Wallet.FeeURL = feeURL
+		}
+		err := c.Wallet.validateBtcwalletHeadersImportConfig()
+		if err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf("unknown wallet type %q, valid values: lnd, "+
+			"lwwallet, btcwallet", c.Wallet.Type)
 	}
 
 	return nil

--- a/waved/config.go
+++ b/waved/config.go
@@ -64,7 +64,7 @@ const (
 
 	// defaultTestnet3SwapServerGRPCHost is the public testnet3 swap server
 	// gRPC endpoint.
-	defaultTestnet3SwapServerGRPCHost = "swap.test.wavelength." +
+	defaultTestnet3SwapServerGRPCHost = "test.swap.wavelength." +
 		"lightning.finance:443"
 
 	// defaultTestnet3SwapServerRESTHost is the public testnet3 swap server
@@ -108,7 +108,7 @@ const (
 
 	// defaultSignetSwapServerGRPCHost is the public signet swap server gRPC
 	// endpoint.
-	defaultSignetSwapServerGRPCHost = "swap.signet.wavelength." +
+	defaultSignetSwapServerGRPCHost = "signet.swap.wavelength." +
 		"lightning.finance:443"
 
 	// defaultSignetSwapServerRESTHost is the public signet swap server REST

--- a/waved/config.go
+++ b/waved/config.go
@@ -54,65 +54,68 @@ const (
 
 	// defaultTestnet3ServerGRPCHost is the public testnet3 Ark operator
 	// gRPC endpoint.
-	defaultTestnet3ServerGRPCHost = "lumosd.testnet." +
-		"lightningcluster.com:443"
+	defaultTestnet3ServerGRPCHost = "test.wavelength." +
+		"lightning.finance:443"
 
 	// defaultTestnet3ServerRESTHost is the public testnet3 Ark operator
 	// REST endpoint.
-	defaultTestnet3ServerRESTHost = "lumosd-rest.testnet." +
-		"lightningcluster.com"
+	defaultTestnet3ServerRESTHost = "test.wavelength-rest." +
+		"lightning.finance"
 
 	// defaultTestnet3SwapServerGRPCHost is the public testnet3 swap server
 	// gRPC endpoint.
-	defaultTestnet3SwapServerGRPCHost = "swapd.testnet." +
-		"lightningcluster.com:443"
+	defaultTestnet3SwapServerGRPCHost = "swap.test.wavelength." +
+		"lightning.finance:443"
 
 	// defaultTestnet3SwapServerRESTHost is the public testnet3 swap server
 	// REST endpoint.
-	defaultTestnet3SwapServerRESTHost = "swapd-rest.testnet." +
-		"lightningcluster.com"
+	defaultTestnet3SwapServerRESTHost = "test.swapd-rest." +
+		"lightning.finance"
 
 	// defaultTestnet4ServerGRPCHost is the public testnet4 Ark operator
-	// gRPC endpoint.
+	// gRPC endpoint. No friendly-domain CNAME exists yet; the public NLB
+	// stays behind the raw cluster hostname until the certificate work
+	// in lightning-infra#3517 lands.
 	defaultTestnet4ServerGRPCHost = "lumosd-testnet4.testnet." +
 		"lightningcluster.com:443"
 
 	// defaultTestnet4ServerRESTHost is the public testnet4 Ark operator
 	// REST endpoint.
-	defaultTestnet4ServerRESTHost = "lumosd-testnet4-rest.testnet." +
-		"lightningcluster.com"
+	defaultTestnet4ServerRESTHost = "test4.wavelength-rest." +
+		"lightning.finance"
 
 	// defaultTestnet4SwapServerGRPCHost is the public testnet4 swap server
-	// gRPC endpoint.
+	// gRPC endpoint. No friendly-domain CNAME exists yet; see
+	// defaultTestnet4ServerGRPCHost.
 	defaultTestnet4SwapServerGRPCHost = "swapd-testnet4.testnet." +
 		"lightningcluster.com:443"
 
 	// defaultTestnet4SwapServerRESTHost is the public testnet4 swap server
 	// REST endpoint.
-	defaultTestnet4SwapServerRESTHost = "swapd-testnet4-rest.testnet." +
-		"lightningcluster.com"
+	defaultTestnet4SwapServerRESTHost = "test4.swapd-rest." +
+		"lightning.finance"
 
 	// defaultSignetServerGRPCHost is the public signet Ark operator gRPC
 	// endpoint.
-	defaultSignetServerGRPCHost = "lumosd-signet.staging." +
-		"lightningcluster.com:443"
+	defaultSignetServerGRPCHost = "signet.wavelength." +
+		"lightning.finance:443"
 
 	// defaultSignetServerRESTHost is the public signet Ark operator REST
 	// endpoint. The REST client adds the HTTPS scheme when the configured
 	// host is bare.
-	defaultSignetServerRESTHost = "lumosd-signet-rest.staging." +
-		"lightningcluster.com"
+	defaultSignetServerRESTHost = "signet.wavelength-rest." +
+		"lightning.finance"
 
 	// defaultSignetSwapServerGRPCHost is the public signet swap server gRPC
 	// endpoint.
-	defaultSignetSwapServerGRPCHost = "swapd-signet.staging." +
-		"lightningcluster.com:443"
+	defaultSignetSwapServerGRPCHost = "swap.signet.wavelength." +
+		"lightning.finance:443"
 
 	// defaultSignetSwapServerRESTHost is the public signet swap server REST
 	// endpoint. The REST client adds the HTTPS scheme when the configured
 	// host is bare.
-	defaultSignetSwapServerRESTHost = "swapd-signet-rest.staging." +
-		"lightningcluster.com"
+	defaultSignetSwapServerRESTHost = "signet.swapd-rest." +
+		"lightning.finance"
 
 	// DefaultIndexerServerID is the canonical operator identifier used
 	// in signed indexer proofs.

--- a/waved/config.go
+++ b/waved/config.go
@@ -1034,9 +1034,9 @@ type WalletConfig struct {
 
 	// EsploraURL is the base URL of the Esplora REST API used by the
 	// lwwallet backend for chain data. Only used when Type is
-	// "lwwallet". Empty falls back to the public mempool.space
-	// endpoint for the configured network; regtest and simnet have
-	// no default and must set this explicitly.
+	// "lwwallet". Empty falls back to the network-default endpoint
+	// (see lwwallet.DefaultEsploraURL); regtest and simnet have no
+	// default and must set this explicitly.
 	EsploraURL string `mapstructure:"esploraurl"`
 
 	// PollInterval controls how often the lwwallet backend polls the
@@ -1302,9 +1302,9 @@ func (c *Config) validateWalletConfig() error {
 
 	case WalletTypeLwwallet:
 		// Lightweight wallet requires an Esplora URL for chain
-		// data. An empty value falls back to the public
-		// mempool.space endpoint for networks that have one;
-		// regtest and simnet still require it explicitly.
+		// data. An empty value falls back to the network-default
+		// endpoint for networks that have one; regtest and simnet
+		// still require it explicitly.
 		if c.Wallet.EsploraURL == "" {
 			chainParams, err := networkToChainParams(c.Network)
 			if err != nil {

--- a/waved/config_network_test.go
+++ b/waved/config_network_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/wavelength/btcwbackend"
+	"github.com/lightninglabs/wavelength/lwwallet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,6 +71,158 @@ func TestConfigValidateAllowsTestnet4InsecureRPC(t *testing.T) {
 	cfg.RPC.NoMacaroons = true
 
 	require.NoError(t, cfg.Validate())
+}
+
+// TestConfigValidateWalletDefaults verifies Validate fills in the
+// network-default Esplora/fee URL for the lwwallet and btcwallet backends
+// when left empty, and still requires an explicit value on networks with no
+// public default (regtest, simnet).
+func TestConfigValidateWalletDefaults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lwwallet defaults per network", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			network string
+			want    string
+		}{
+			{
+				network: "testnet",
+				want:    lwwallet.DefaultEsploraURLTestnet3,
+			},
+			{
+				network: "testnet4",
+				want:    lwwallet.DefaultEsploraURLTestnet4,
+			},
+			{
+				network: "signet",
+				want:    lwwallet.DefaultEsploraURLSignet,
+			},
+		}
+
+		for _, tc := range tests {
+			tc := tc
+			t.Run(tc.network, func(t *testing.T) {
+				t.Parallel()
+
+				cfg := DefaultConfig()
+				cfg.Network = tc.network
+
+				require.NoError(t, cfg.Validate())
+				require.Equal(t, tc.want, cfg.Wallet.EsploraURL)
+			})
+		}
+	})
+
+	t.Run("lwwallet mainnet default", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultConfig()
+		cfg.Network = "mainnet"
+		cfg.AllowMainnet = true
+
+		require.NoError(t, cfg.Validate())
+		require.Equal(
+			t, lwwallet.DefaultEsploraURLMainnet,
+			cfg.Wallet.EsploraURL,
+		)
+	})
+
+	t.Run(
+		"lwwallet regtest and simnet require explicit URL",
+		func(t *testing.T) {
+			t.Parallel()
+
+			for _, network := range []string{"regtest", "simnet"} {
+				network := network
+				t.Run(network, func(t *testing.T) {
+					t.Parallel()
+
+					cfg := DefaultConfig()
+					cfg.Network = network
+
+					require.ErrorContains(
+						t, cfg.Validate(),
+						"wallet.esploraurl",
+					)
+				})
+			}
+		},
+	)
+
+	t.Run("btcwallet defaults per network", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			network string
+			want    string
+		}{
+			{
+				network: "testnet",
+				want:    btcwbackend.DefaultFeeURLTestnet,
+			},
+			{
+				network: "testnet4",
+				want:    btcwbackend.DefaultFeeURLTestnet,
+			},
+			{
+				network: "signet",
+				want:    btcwbackend.DefaultFeeURLTestnet,
+			},
+		}
+
+		for _, tc := range tests {
+			tc := tc
+			t.Run(tc.network, func(t *testing.T) {
+				t.Parallel()
+
+				cfg := DefaultConfig()
+				cfg.Network = tc.network
+				cfg.Wallet.Type = WalletTypeBtcwallet
+
+				require.NoError(t, cfg.Validate())
+				require.Equal(t, tc.want, cfg.Wallet.FeeURL)
+			})
+		}
+	})
+
+	t.Run("btcwallet mainnet default", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := DefaultConfig()
+		cfg.Network = "mainnet"
+		cfg.AllowMainnet = true
+		cfg.Wallet.Type = WalletTypeBtcwallet
+
+		require.NoError(t, cfg.Validate())
+		require.Equal(
+			t, btcwbackend.DefaultFeeURLMainnet, cfg.Wallet.FeeURL,
+		)
+	})
+
+	t.Run(
+		"btcwallet regtest and simnet require explicit URL",
+		func(t *testing.T) {
+			t.Parallel()
+
+			for _, network := range []string{"regtest", "simnet"} {
+				network := network
+				t.Run(network, func(t *testing.T) {
+					t.Parallel()
+
+					cfg := DefaultConfig()
+					cfg.Network = network
+					cfg.Wallet.Type = WalletTypeBtcwallet
+
+					require.ErrorContains(
+						t, cfg.Validate(),
+						"wallet.feeurl",
+					)
+				})
+			}
+		},
+	)
 }
 
 // TestConfigEndpointDefaults verifies the config resolves each empty endpoint


### PR DESCRIPTION
## Summary

In this PR, we point the built-in testnet3 and signet endpoint defaults at the new lightning.finance friendly domains instead of the raw lightningcluster.com cluster hostnames, and add per-network defaults for the lwwallet and btcwallet chain-data/fee-estimation endpoints so they no longer hard-require an explicit flag on the public networks.

Ops has set up CNAMEs like `test.wavelength.lightning.finance` and `signet.swap.wavelength.lightning.finance` that resolve to the same backing NLBs, so clients no longer need to know the internal cluster naming scheme to reach the public test networks. testnet4's gRPC endpoints keep their raw cluster hostnames for now, since the public NLB behind them is still disabled pending the certificate work in lightning-infra#3517; the testnet4 REST gateways already have friendly-domain CNAMEs and pick those up here.

`wallet.esploraurl` (lwwallet) and `wallet.feeurl` (btcwallet) also default per network now instead of erroring when empty: lwwallet falls back to the public mempool.space Esplora API, and btcwallet falls back to nodes.lightning.computer's fee-estimates endpoint (the same JSON schema `chainfee.SparseConfFeeSource` expects; mempool.space doesn't serve that shape). Neither lnd nor lightning-infra had an actual default for the fee URL to borrow, since production testnet/signet deployments there run the lnd wallet backend, not btcwallet/neutrino. regtest and simnet keep the old hard-required behavior for both fields, since they have no public default.

## Mapping

| Old (lightningcluster.com) | New (lightning.finance) |
|---|---|
| `lumosd.testnet.lightningcluster.com` | `test.wavelength.lightning.finance` |
| `lumosd-signet.staging.lightningcluster.com` | `signet.wavelength.lightning.finance` |
| `swapd.testnet.lightningcluster.com` | `test.swap.wavelength.lightning.finance` |
| `swapd-signet.staging.lightningcluster.com` | `signet.swap.wavelength.lightning.finance` |
| `lumosd-rest.testnet.lightningcluster.com` | `test.wavelength-rest.lightning.finance` |
| `lumosd-testnet4-rest.testnet.lightningcluster.com` | `test4.wavelength-rest.lightning.finance` |
| `lumosd-signet-rest.staging.lightningcluster.com` | `signet.wavelength-rest.lightning.finance` |
| `swapd-rest.testnet.lightningcluster.com` | `test.swapd-rest.lightning.finance` |
| `swapd-testnet4-rest.testnet.lightningcluster.com` | `test4.swapd-rest.lightning.finance` |
| `swapd-signet-rest.staging.lightningcluster.com` | `signet.swapd-rest.lightning.finance` |

## Wallet defaults

| Network config | lwwallet Esplora URL | btcwallet fee URL |
|---|---|---|
| `mainnet` | `https://mempool.space/api` | `https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json` |
| `testnet` | `https://mempool.space/testnet/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |
| `testnet4` | `https://mempool.space/testnet4/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |
| `signet` | `https://mempool.space/signet/api` | `https://nodes.lightning.computer/fees/v1/btctestnet-fee-estimates.json` |

## Test plan

- [x] `go build` across all touched packages, native and `GOOS=js GOARCH=wasm`
- [x] `make lint-changed-local` (0 issues)
- [x] `TestConfigEndpointDefaults` / `TestConfigEndpointDefaultsPreserveOverrides` / `TestConfigValidateAcceptsSupportedNetworks` / `TestConfigValidateAllowsTestnet4InsecureRPC` / `TestConfigValidateWalletDefaults` pass
- [x] `TestDefaultEsploraURL` (lwwallet) / `TestDefaultFeeURL` (btcwbackend) pass
- [x] `make commitmsg-lint`
- [x] DNS resolution manually verified for all 10 lightning.finance CNAMEs against 1.1.1.1/8.8.8.8