### PR TITLE
chainfees: default test networks to hosted mempool instances

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -166,9 +166,12 @@ node required, but initial sync downloads block/filter headers.
 ```bash
 waved \
   --network=signet \
-  --wallet.type=btcwallet \
-  --wallet.feeurl=https://mempool.space/signet/api/v1/fees/recommended
+  --wallet.type=btcwallet
 ```
+
+`wallet.feeurl` resolves to the network-default `nodes.lightning.computer`
+fee-estimate endpoint when left empty; set it explicitly only to point at a
+custom `fee_by_block_target` JSON endpoint.
 
 The Ark and swap connections resolve from the configured public test network
 unless explicitly overridden. See [`docs/signet.md`](docs/signet.md) for the

--- a/chainfees/mempoolspace.go
+++ b/chainfees/mempoolspace.go
@@ -32,13 +32,16 @@ const (
 	// wall-clock time but not the number of bytes read.
 	maxMempoolSpaceResponseBytes = 64 << 10
 
+	// The test networks default to Lightning Labs-operated mempool
+	// instances, matching the lwwallet Esplora defaults; only mainnet uses
+	// the public mempool.space endpoint.
 	mempoolSpaceMainnetURL = "https://mempool.space/api/v1/fees/recommended"
-	mempoolSpaceTestnetURL = "https://mempool.space/testnet/api/v1/fees/" +
-		"recommended"
-	mempoolSpaceTestnet4URL = "https://mempool.space/testnet4/api/v1/fees" +
-		"/recommended"
-	mempoolSpaceSignetURL = "https://mempool.space/signet/api/v1/fees/" +
-		"recommended"
+	mempoolSpaceTestnetURL = "https://mempool-testnet3.testnet." +
+		"lightningcluster.com/api/v1/fees/recommended"
+	mempoolSpaceTestnet4URL = "https://mempool-testnet4.testnet." +
+		"lightningcluster.com/api/v1/fees/recommended"
+	mempoolSpaceSignetURL = "https://mempool-signet.testnet." +
+		"lightningcluster.com/api/v1/fees/recommended"
 )
 
 // MempoolSpaceConfig configures a MempoolSpaceEstimator.

--- a/sample-waved.conf
+++ b/sample-waved.conf
@@ -194,8 +194,10 @@
 # mempool.space estimate. Only applies to wallet.type=lnd.
 # feeestimation.mempoolspace.enabled=false
 
-# Override the network-default mempool.space recommended-fee endpoint. Must be
-# an absolute https URL. Empty uses the per-network default.
+# Override the network-default recommended-fee endpoint. Must be an absolute
+# https URL. Empty uses the per-network default: public mempool.space on
+# mainnet, Lightning Labs-operated mempool instances on testnet3, testnet4,
+# and signet.
 # feeestimation.mempoolspace.url=
 
 # Number of blocks after which unroll attempts a fee-bump rebroadcast. The zero


### PR DESCRIPTION
In this PR, we point the mempool.space fee estimator's testnet3, testnet4, and signet defaults at the Lightning Labs-operated mempool instances under `testnet.lightningcluster.com`. The lwwallet Esplora defaults already resolve to these instances, and docs/signet.md lists them as the intended endpoints, so the `chainfees` estimator was the last spot still hitting the public mempool.space test network endpoints. Mainnet keeps the public mempool.space default.

The hosted instances serve the same `/api/v1/fees/recommended` response shape (verified against both testnet3 and signet), so no parsing changes are needed. We also update the `sample-waved.conf` comment to spell out the per-network defaults.

While in there, we fix the btcwallet signet example in INSTALL.md: it pointed `--wallet.feeurl` at a mempool.space recommended-fee endpoint, but that flag feeds a `chainfee.SparseConfFeeSource`, which expects lnd's `fee_by_block_target` JSON shape and would fail to parse that response. Leaving the flag unset resolves the network-default `nodes.lightning.computer` endpoint instead.