### PR TITLE
multi: add a REST transport option for the lnd wallet backend

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -368,3 +368,55 @@ jobs:
             **/test-artifacts/
           retention-days: 5
           if-no-files-found: ignore
+
+  ##########################################
+  # system tests over the lnd REST backend
+  ##########################################
+  systest-lnd-rest:
+    name: Run system tests (lnd REST backend)
+    runs-on: [self-hosted]
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Fetch and rebase on ${{ github.base_ref }}
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/rebase
+
+      - name: Setup go ${{ env.GO_VERSION }}
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: '${{ env.GO_VERSION }}'
+          key-prefix: systest
+
+      - name: Run systest over the lnd REST transport
+        # ARK_SYSTEST_LND_TRANSPORT=rest points every daemon built by the
+        # directed-send fixture at lnd's REST gateway instead of gRPC, so the
+        # send / OOR / on-chain / refresh / leave / vHTLC-recovery flows
+        # exercise the lndrest wallet backend end to end (its signer,
+        # walletkit, chainkit, and streaming chain-notifier). The case filter
+        # selects exactly those fixture-driven flows; the other systests do
+        # not use the lnd backend, so re-running them here would add nothing.
+        # A single db backend (sqlite) suffices as the wallet transport is
+        # orthogonal to the DB. The sudo/env and 30m-timeout rationale matches
+        # the systest job above.
+        run: sudo env "PATH=$PATH" "GOPATH=$GOPATH" "ARK_SYSTEST_LND_TRANSPORT=rest" make systest-verbose case='Send|LNDREST|Stranded|VHTLCRecovery' SYSTEST_TIMEOUT=30m
+
+      - name: Fix artifact permissions
+        if: always()
+        run: |
+          # Fix permissions for test artifacts (created in package directories)
+          find . -type d -name "test-artifacts" -exec sudo chown -R "$(id -u):$(id -g)" {} + || true
+          find . -type d -name "test-artifacts" -exec sudo chmod -R a+r {} + || true
+
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: systest-artifacts-lnd-rest-${{ github.run_id }}
+          path: |
+            **/test-artifacts/
+          retention-days: 5
+          if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -429,13 +429,19 @@ SYSTEST_TAGS := systest $(SYSTEST_DB_TAG)
 # typically plenty.
 SYSTEST_TIMEOUT ?= 10m
 
-systest: #? Run system integration tests. Use db=postgres for PostgreSQL.
-	@$(call print, "Running system integration tests (db=$(or $(db),sqlite)).")
-	$(GOTEST) -tags "$(SYSTEST_TAGS)" -v ./systest/... -timeout $(SYSTEST_TIMEOUT)
+# Optional test-name filter for systest, mirroring the `case=` param on the
+# unit target. Empty by default so the whole suite runs; set it to scope a run
+# (e.g. the lnd-REST CI job below runs only the REST-safe send/OOR flows).
+# Usage: make systest case=TestSendVTXOEndToEnd
+SYSTEST_RUN := $(if $(case),-run "$(case)",)
 
-systest-verbose: #? Run system integration tests with verbose logging. Use db=postgres for PostgreSQL.
+systest: #? Run system integration tests. Use db=postgres for PostgreSQL, case=<TestName> to filter.
+	@$(call print, "Running system integration tests (db=$(or $(db),sqlite)).")
+	$(GOTEST) -tags "$(SYSTEST_TAGS)" -v ./systest/... -timeout $(SYSTEST_TIMEOUT) $(SYSTEST_RUN)
+
+systest-verbose: #? Run system integration tests with verbose logging. Use db=postgres for PostgreSQL, case=<TestName> to filter.
 	@$(call print, "Running system integration tests with verbose logging (db=$(or $(db),sqlite)).")
-	$(GOTEST) -tags "$(SYSTEST_TAGS)" -v ./systest/... -timeout $(SYSTEST_TIMEOUT) -harness.logstdout
+	$(GOTEST) -tags "$(SYSTEST_TAGS)" -v ./systest/... -timeout $(SYSTEST_TIMEOUT) $(SYSTEST_RUN) -harness.logstdout
 
 # ============
 # RPC GENERATION

--- a/cmd/waved/main.go
+++ b/cmd/waved/main.go
@@ -111,7 +111,15 @@ func newRootCmd() *cobra.Command {
 	)
 
 	// LND connection flags.
-	f.String("lnd.host", cfg.Lnd.Host, "lnd gRPC address")
+	f.String(
+		"lnd.host", cfg.Lnd.Host, "lnd endpoint: a host:port gRPC "+
+			"address for lnd.transport=grpc, or an HTTP "+
+			"gateway base URL for lnd.transport=rest",
+	)
+	f.String(
+		"lnd.transport", cfg.Lnd.Transport,
+		"lnd RPC transport: grpc or rest",
+	)
 	f.String(
 		"lnd.tlspath", cfg.Lnd.TLSPath, "path to lnd TLS certificate",
 	)

--- a/lndbackend/client_wallet.go
+++ b/lndbackend/client_wallet.go
@@ -31,7 +31,7 @@ import (
 // background context for all RPC calls. The underlying gRPC deadline
 // from the lndclient dial options still applies.
 type ClientWallet struct {
-	signer    lndclient.SignerClient
+	signer    Signer
 	walletKit lndclient.WalletKitClient
 
 	// Log is an optional logger for this wallet. If None, the wallet falls
@@ -39,116 +39,70 @@ type ClientWallet struct {
 	Log fn.Option[btclog.Logger]
 }
 
+// Signer is the transport-agnostic signing surface the ClientWallet needs. It
+// is the full lndclient.SignerClient plus a locator-forwarding SignOutputRaw
+// so the family-6/index-0 identity signing path works over any lnd transport.
+// The gRPC lndclient signer gains the extra method via grpcLocatorSigner (which
+// forwards through the raw client); the REST signer implements it directly, so
+// the REST transport never has to expose a raw gRPC client.
+type Signer interface {
+	lndclient.SignerClient
+
+	// SignOutputRawWithLocator mirrors SignOutputRaw but always forwards
+	// the key locator when one is available, including family/index pairs
+	// with a zero component such as lnd's node key at family 6 index 0.
+	SignOutputRawWithLocator(ctx context.Context, tx *wire.MsgTx,
+		signDescriptors []*lndclient.SignDescriptor,
+		prevOutputs []*wire.TxOut) ([][]byte, error)
+}
+
 // NewClientWallet creates a new ClientWallet from the lndclient signer
-// and wallet kit clients.
+// and wallet kit clients. A signer that already implements the locator-aware
+// Signer interface (the REST backend) is used directly; a plain gRPC
+// lndclient.SignerClient is wrapped so the locator-forwarding path routes
+// through its raw client.
 func NewClientWallet(
 	signer lndclient.SignerClient,
 	walletKit lndclient.WalletKitClient,
 ) *ClientWallet {
 
 	return &ClientWallet{
-		signer:    signer,
+		signer:    asLocatorSigner(signer),
 		walletKit: walletKit,
 	}
 }
 
-// logger returns the configured logger, falling back to the context logger.
-func (c *ClientWallet) logger(ctx context.Context) btclog.Logger {
-	return c.Log.UnwrapOr(build.LoggerFromContext(ctx))
-}
-
-// Compile-time check that ClientWallet satisfies the interface
-// expected by round.RoundClientConfig.Wallet. We can't import the
-// round package here (that would create a cycle), so we check against
-// input.Signer which is the signing half of round.ClientWallet.
-//
-// NOTE: Full round.ClientWallet check (which adds DeriveNextKey and
-// MuSig2* methods) is omitted to avoid the import cycle. Any drift
-// will surface as a compile error in waved/server.go where
-// ClientWallet is passed to the round config.
-var _ input.Signer = (*ClientWallet)(nil)
-
-// DeriveNextKey derives the next key in the specified key family via
-// lnd's WalletKit RPC. This is used by the round actor to generate
-// fresh VTXO signing keys for each round.
-func (c *ClientWallet) DeriveNextKey(ctx context.Context,
-	family keychain.KeyFamily) (*keychain.KeyDescriptor, error) {
-
-	c.logger(ctx).DebugS(ctx, "Deriving next key via client wallet",
-		slog.Int("key_family", int(family)),
-	)
-
-	keyDesc, err := c.walletKit.DeriveNextKey(ctx, int32(family))
-	if err != nil {
-		return nil, fmt.Errorf("derive next key: %w", err)
+// asLocatorSigner promotes a plain lndclient signer to the locator-aware Signer
+// interface, returning it unchanged when it already satisfies Signer.
+func asLocatorSigner(signer lndclient.SignerClient) Signer {
+	if ls, ok := signer.(Signer); ok {
+		return ls
 	}
 
-	c.logger(ctx).DebugS(ctx, "Derived next key via client wallet",
-		slog.Int("key_family", int(family)),
-		slog.Int("key_index", int(keyDesc.Index)),
-	)
-
-	return keyDesc, nil
+	return &grpcLocatorSigner{SignerClient: signer}
 }
 
-// SignOutputRaw generates a schnorr/ECDSA signature for a single input
-// of the provided transaction according to the sign descriptor. The
-// call is forwarded to lnd's remote signer via gRPC.
-func (c *ClientWallet) SignOutputRaw(tx *wire.MsgTx,
-	signDesc *input.SignDescriptor) (input.Signature, error) {
-
-	c.logger(context.TODO()).DebugS(
-		context.TODO(),
-		"Signing output raw via LND remote signer",
-		slog.Int("input_index", signDesc.InputIndex),
-		slog.String("sign_method", signDesc.SignMethod.String()),
-	)
-
-	lndDesc := inputDescToLndclient(signDesc)
-
-	// Collect prevouts for taproot sighash computation. When the
-	// caller provides a PrevOutputFetcher we extract every input's
-	// previous output; otherwise we fall back to the single output
-	// in the sign descriptor.
-	prevOuts := prevOutputsFromDesc(tx, signDesc)
-
-	sigs, err := c.signOutputRawWithLocator(
-		context.Background(), tx, []*lndclient.SignDescriptor{
-			lndDesc,
-		}, prevOuts,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("sign output raw: %w", err)
-	}
-
-	if len(sigs) == 0 {
-		return nil, fmt.Errorf("no signatures returned")
-	}
-
-	c.logger(context.TODO()).DebugS(
-		context.TODO(),
-		"Signed output raw successfully",
-		slog.Int("input_index", signDesc.InputIndex),
-		slog.Int("sig_len", len(sigs[0])),
-	)
-
-	return parseSigBytes(sigs[0], signDesc.SignMethod)
+// grpcLocatorSigner adapts a raw gRPC lndclient signer to the Signer interface
+// by implementing SignOutputRawWithLocator through the raw signrpc client,
+// preserving the locator-forwarding behavior on the gRPC transport.
+type grpcLocatorSigner struct {
+	lndclient.SignerClient
 }
 
-// signOutputRawWithLocator mirrors lndclient.SignOutputRaw but always includes
-// the key locator when one is available, including family/index zero pairs
-// such as LND's node key at family 6 index 0.
+// SignOutputRawWithLocator mirrors lndclient.SignOutputRaw but always includes
+// the key locator when one is available, including family/index zero pairs such
+// as lnd's node key at family 6 index 0.
 //
 // TODO(wavelength): drop this helper and go back to lndclient.SignOutputRaw
 // once upstream forwards the key locator on SignOutputRaw for descriptors whose
 // KeyLocator has Family != 0 but Index == 0. The current helper in lndclient
 // omits the locator in that case, which breaks signing for the family-6/index-0
 // identity path used by the indexer proof signer.
-func (c *ClientWallet) signOutputRawWithLocator(ctx context.Context,
+func (g *grpcLocatorSigner) SignOutputRawWithLocator(ctx context.Context,
 	tx *wire.MsgTx, signDescriptors []*lndclient.SignDescriptor,
 	prevOutputs []*wire.TxOut) ([][]byte, error) {
 
-	rpcCtx, timeout, rawClient := c.signer.RawClientWithMacAuth(ctx)
+	rpcCtx, timeout, rawClient := g.RawClientWithMacAuth(ctx)
 	rpcCtx, cancel := context.WithTimeout(rpcCtx, timeout)
 	defer cancel()
 
@@ -227,6 +181,89 @@ func (c *ClientWallet) signOutputRawWithLocator(ctx context.Context,
 	}
 
 	return resp.RawSigs, nil
+}
+
+// logger returns the configured logger, falling back to the context logger.
+func (c *ClientWallet) logger(ctx context.Context) btclog.Logger {
+	return c.Log.UnwrapOr(build.LoggerFromContext(ctx))
+}
+
+// Compile-time check that ClientWallet satisfies the interface
+// expected by round.RoundClientConfig.Wallet. We can't import the
+// round package here (that would create a cycle), so we check against
+// input.Signer which is the signing half of round.ClientWallet.
+//
+// NOTE: Full round.ClientWallet check (which adds DeriveNextKey and
+// MuSig2* methods) is omitted to avoid the import cycle. Any drift
+// will surface as a compile error in waved/server.go where
+// ClientWallet is passed to the round config.
+var _ input.Signer = (*ClientWallet)(nil)
+
+// DeriveNextKey derives the next key in the specified key family via
+// lnd's WalletKit RPC. This is used by the round actor to generate
+// fresh VTXO signing keys for each round.
+func (c *ClientWallet) DeriveNextKey(ctx context.Context,
+	family keychain.KeyFamily) (*keychain.KeyDescriptor, error) {
+
+	c.logger(ctx).DebugS(ctx, "Deriving next key via client wallet",
+		slog.Int("key_family", int(family)),
+	)
+
+	keyDesc, err := c.walletKit.DeriveNextKey(ctx, int32(family))
+	if err != nil {
+		return nil, fmt.Errorf("derive next key: %w", err)
+	}
+
+	c.logger(ctx).DebugS(ctx, "Derived next key via client wallet",
+		slog.Int("key_family", int(family)),
+		slog.Int("key_index", int(keyDesc.Index)),
+	)
+
+	return keyDesc, nil
+}
+
+// SignOutputRaw generates a schnorr/ECDSA signature for a single input
+// of the provided transaction according to the sign descriptor. The
+// call is forwarded to lnd's remote signer via gRPC.
+func (c *ClientWallet) SignOutputRaw(tx *wire.MsgTx,
+	signDesc *input.SignDescriptor) (input.Signature, error) {
+
+	c.logger(context.TODO()).DebugS(
+		context.TODO(),
+		"Signing output raw via LND remote signer",
+		slog.Int("input_index", signDesc.InputIndex),
+		slog.String("sign_method", signDesc.SignMethod.String()),
+	)
+
+	lndDesc := inputDescToLndclient(signDesc)
+
+	// Collect prevouts for taproot sighash computation. When the
+	// caller provides a PrevOutputFetcher we extract every input's
+	// previous output; otherwise we fall back to the single output
+	// in the sign descriptor.
+	prevOuts := prevOutputsFromDesc(tx, signDesc)
+
+	sigs, err := c.signer.SignOutputRawWithLocator(
+		context.Background(), tx, []*lndclient.SignDescriptor{
+			lndDesc,
+		}, prevOuts,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign output raw: %w", err)
+	}
+
+	if len(sigs) == 0 {
+		return nil, fmt.Errorf("no signatures returned")
+	}
+
+	c.logger(context.TODO()).DebugS(
+		context.TODO(),
+		"Signed output raw successfully",
+		slog.Int("input_index", signDesc.InputIndex),
+		slog.Int("sig_len", len(sigs[0])),
+	)
+
+	return parseSigBytes(sigs[0], signDesc.SignMethod)
 }
 
 // ComputeInputScript generates a complete input script (witness) for

--- a/lndrest/chainkit.go
+++ b/lndrest/chainkit.go
@@ -1,0 +1,125 @@
+package lndrest
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
+)
+
+// ChainKit REST paths, taken from lnd's chainrpc grpc-gateway pattern vars.
+// These are GET endpoints whose request fields bind from the query string.
+const (
+	pathGetBlock       = "/v2/chainkit/block"
+	pathGetBlockHeader = "/v2/chainkit/blockheader"
+	pathGetBestBlock   = "/v2/chainkit/bestblock"
+	pathGetBlockHash   = "/v2/chainkit/blockhash"
+)
+
+// chainKitClient implements lndclient.ChainKitClient over lnd's REST gateway.
+type chainKitClient struct {
+	conn *conn
+}
+
+// A compile-time check that chainKitClient satisfies the lndclient interface.
+var _ lndclient.ChainKitClient = (*chainKitClient)(nil)
+
+// RawClientWithMacAuth is required by the ServiceClient interface but returns a
+// nil raw client: the REST backend has no gRPC client to expose.
+func (s *chainKitClient) RawClientWithMacAuth(parentCtx context.Context) (
+	context.Context, time.Duration, chainrpc.ChainKitClient) {
+
+	return parentCtx, s.conn.timeout, nil
+}
+
+// queryPath appends url-encoded query parameters to a base path.
+func queryPath(base string, params url.Values) string {
+	if len(params) == 0 {
+		return base
+	}
+
+	return base + "?" + params.Encode()
+}
+
+// hashQuery builds the block_hash query parameter. grpc-gateway decodes bytes
+// query parameters as base64, so the hash is standard-base64 encoded.
+func hashQuery(hash chainhash.Hash) url.Values {
+	params := url.Values{}
+	params.Set("block_hash", base64.StdEncoding.EncodeToString(hash[:]))
+
+	return params
+}
+
+// GetBlock returns the full block for the given hash.
+func (s *chainKitClient) GetBlock(ctx context.Context, hash chainhash.Hash) (
+	*wire.MsgBlock, error) {
+
+	resp := &chainrpc.GetBlockResponse{}
+	path := queryPath(pathGetBlock, hashQuery(hash))
+	if err := s.conn.get(ctx, path, resp); err != nil {
+		return nil, err
+	}
+
+	return decodeBlock(resp.RawBlock)
+}
+
+// GetBlockHeader returns the header for the given block hash.
+func (s *chainKitClient) GetBlockHeader(ctx context.Context,
+	hash chainhash.Hash) (*wire.BlockHeader, error) {
+
+	resp := &chainrpc.GetBlockHeaderResponse{}
+	path := queryPath(pathGetBlockHeader, hashQuery(hash))
+	if err := s.conn.get(ctx, path, resp); err != nil {
+		return nil, err
+	}
+
+	header := &wire.BlockHeader{}
+	if err := header.Deserialize(
+		bytes.NewReader(resp.RawBlockHeader),
+	); err != nil {
+		return nil, err
+	}
+
+	return header, nil
+}
+
+// GetBestBlock returns the best block hash and its height.
+func (s *chainKitClient) GetBestBlock(ctx context.Context) (chainhash.Hash,
+	int32, error) {
+
+	resp := &chainrpc.GetBestBlockResponse{}
+	if err := s.conn.get(ctx, pathGetBestBlock, resp); err != nil {
+		return chainhash.Hash{}, 0, err
+	}
+
+	var blockHash chainhash.Hash
+	copy(blockHash[:], resp.BlockHash)
+
+	return blockHash, resp.BlockHeight, nil
+}
+
+// GetBlockHash returns the hash of the block at the given height.
+func (s *chainKitClient) GetBlockHash(ctx context.Context, blockHeight int64) (
+	chainhash.Hash, error) {
+
+	params := url.Values{}
+	params.Set("block_height", strconv.FormatInt(blockHeight, 10))
+
+	resp := &chainrpc.GetBlockHashResponse{}
+	path := queryPath(pathGetBlockHash, params)
+	if err := s.conn.get(ctx, path, resp); err != nil {
+		return chainhash.Hash{}, err
+	}
+
+	var blockHash chainhash.Hash
+	copy(blockHash[:], resp.BlockHash)
+
+	return blockHash, nil
+}

--- a/lndrest/chainnotifier.go
+++ b/lndrest/chainnotifier.go
@@ -1,0 +1,348 @@
+package lndrest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/wavelength/rpc/restclient"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
+)
+
+// ChainNotifier REST paths, taken from lnd's chainrpc grpc-gateway pattern
+// vars. These are POST server-streaming endpoints.
+const (
+	pathRegisterConfs  = "/v2/chainnotifier/register/confirmations"
+	pathRegisterSpends = "/v2/chainnotifier/register/spends"
+	pathRegisterBlocks = "/v2/chainnotifier/register/blocks"
+)
+
+// chainNotifierClient implements lndclient.ChainNotifierClient over lnd's REST
+// gateway. Each registration opens a grpc-gateway server stream and forwards
+// decoded events onto the channel-returning shape lndclient exposes; a
+// background goroutine reads the stream until the caller cancels the context
+// it registered with, which tears the underlying HTTP stream down.
+type chainNotifierClient struct {
+	conn *conn
+}
+
+// A compile-time check that chainNotifierClient satisfies the interface.
+var _ lndclient.ChainNotifierClient = (*chainNotifierClient)(nil)
+
+// RawClientWithMacAuth is required by the ServiceClient interface but returns a
+// nil raw client: the REST backend has no gRPC client to expose.
+func (s *chainNotifierClient) RawClientWithMacAuth(parentCtx context.Context) (
+	context.Context, time.Duration, chainrpc.ChainNotifierClient) {
+
+	return parentCtx, s.conn.timeout, nil
+}
+
+// RegisterBlockEpochNtfn streams block heights as they are connected.
+func (s *chainNotifierClient) RegisterBlockEpochNtfn(ctx context.Context) (
+	chan int32, chan error, error) {
+
+	resp, err := s.conn.stream( //nolint:bodyclose // stream owns body
+		ctx, pathRegisterBlocks, &chainrpc.BlockEpoch{},
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stream := restclient.NewStreamClient(
+		resp, "RegisterBlockEpochNtfn",
+		func() *chainrpc.BlockEpoch { return &chainrpc.BlockEpoch{} },
+	)
+
+	blockEpochChan := make(chan int32)
+	blockErrorChan := make(chan error, 1)
+
+	go func() {
+		for {
+			epoch, err := stream.Recv()
+			if err != nil {
+				blockErrorChan <- err
+
+				return
+			}
+
+			select {
+			case blockEpochChan <- int32(epoch.Height):
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return blockEpochChan, blockErrorChan, nil
+}
+
+// RegisterConfirmationsNtfn streams confirmation events for a script/txid.
+func (s *chainNotifierClient) RegisterConfirmationsNtfn(ctx context.Context,
+	txid *chainhash.Hash, pkScript []byte, numConfs, heightHint int32,
+	optFuncs ...lndclient.NotifierOption) (chan *chainntnfs.TxConfirmation,
+	chan error, error) {
+
+	opts := lndclient.DefaultNotifierOptions()
+	for _, optFunc := range optFuncs {
+		optFunc(opts)
+	}
+
+	var txidSlice []byte
+	if txid != nil {
+		txidSlice = txid[:]
+	}
+
+	req := &chainrpc.ConfRequest{
+		Script:       pkScript,
+		NumConfs:     uint32(numConfs),
+		HeightHint:   uint32(heightHint),
+		Txid:         txidSlice,
+		IncludeBlock: opts.IncludeBlock,
+	}
+	resp, err := s.conn.stream( //nolint:bodyclose // stream owns body
+		ctx, pathRegisterConfs, req,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stream := restclient.NewStreamClient(
+		resp, "RegisterConfirmationsNtfn",
+		func() *chainrpc.ConfEvent { return &chainrpc.ConfEvent{} },
+	)
+
+	confChan := make(chan *chainntnfs.TxConfirmation, 1)
+	errChan := make(chan error, 1)
+
+	go s.forwardConfEvents(ctx, stream, opts, confChan, errChan)
+
+	return confChan, errChan, nil
+}
+
+// forwardConfEvents reads confirmation events off the stream and forwards them
+// onto confChan, mirroring lndclient's own event handling.
+func (s *chainNotifierClient) forwardConfEvents(ctx context.Context,
+	stream *restclient.StreamClient[chainrpc.ConfEvent],
+	opts *lndclient.NotifierOptions,
+	confChan chan *chainntnfs.TxConfirmation, errChan chan error) {
+
+	for {
+		confEvent, err := stream.Recv()
+		if err != nil {
+			errChan <- err
+
+			return
+		}
+
+		switch c := confEvent.Event.(type) {
+		case *chainrpc.ConfEvent_Conf:
+			tx, err := decodeTx(c.Conf.RawTx)
+			if err != nil {
+				errChan <- err
+
+				return
+			}
+
+			var block *wire.MsgBlock
+			if opts.IncludeBlock {
+				block, err = decodeBlock(c.Conf.RawBlock)
+				if err != nil {
+					errChan <- err
+
+					return
+				}
+			}
+
+			blockHash, err := chainhash.NewHash(c.Conf.BlockHash)
+			if err != nil {
+				errChan <- err
+
+				return
+			}
+
+			conf := &chainntnfs.TxConfirmation{
+				BlockHeight: c.Conf.BlockHeight,
+				BlockHash:   blockHash,
+				Tx:          tx,
+				TxIndex:     c.Conf.TxIndex,
+				Block:       block,
+			}
+
+			select {
+			case confChan <- conf:
+			case <-ctx.Done():
+				return
+			}
+
+			// In re-org aware mode we keep listening for the new
+			// confirmation after a re-org; otherwise we are done.
+			if opts.ReOrgChan == nil {
+				return
+			}
+
+		case *chainrpc.ConfEvent_Reorg:
+			if opts.ReOrgChan != nil {
+				select {
+				case opts.ReOrgChan <- struct{}{}:
+				case <-ctx.Done():
+					return
+				}
+			}
+
+		case nil:
+			errChan <- fmt.Errorf("conf event empty")
+
+			return
+
+		default:
+			errChan <- fmt.Errorf("conf event has unexpected type")
+
+			return
+		}
+	}
+}
+
+// RegisterSpendNtfn streams spend events for an outpoint/script.
+func (s *chainNotifierClient) RegisterSpendNtfn(ctx context.Context,
+	outpoint *wire.OutPoint, pkScript []byte, heightHint int32,
+	optFuncs ...lndclient.NotifierOption) (chan *chainntnfs.SpendDetail,
+	chan error, error) {
+
+	opts := lndclient.DefaultNotifierOptions()
+	for _, optFunc := range optFuncs {
+		optFunc(opts)
+	}
+	if opts.IncludeBlock {
+		return nil, nil, fmt.Errorf("option IncludeBlock is not " +
+			"supported by RegisterSpendNtfn")
+	}
+
+	var rpcOutpoint *chainrpc.Outpoint
+	if outpoint != nil {
+		rpcOutpoint = &chainrpc.Outpoint{
+			Hash:  outpoint.Hash[:],
+			Index: outpoint.Index,
+		}
+	}
+
+	req := &chainrpc.SpendRequest{
+		HeightHint: uint32(heightHint),
+		Outpoint:   rpcOutpoint,
+		Script:     pkScript,
+	}
+	resp, err := s.conn.stream( //nolint:bodyclose // stream owns body
+		ctx, pathRegisterSpends, req,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stream := restclient.NewStreamClient(
+		resp, "RegisterSpendNtfn",
+		func() *chainrpc.SpendEvent { return &chainrpc.SpendEvent{} },
+	)
+
+	spendChan := make(chan *chainntnfs.SpendDetail, 1)
+	errChan := make(chan error, 1)
+
+	go s.forwardSpendEvents(ctx, stream, opts, spendChan, errChan)
+
+	return spendChan, errChan, nil
+}
+
+// forwardSpendEvents reads spend events off the stream and forwards them onto
+// spendChan, mirroring lndclient's own event handling.
+func (s *chainNotifierClient) forwardSpendEvents(ctx context.Context,
+	stream *restclient.StreamClient[chainrpc.SpendEvent],
+	opts *lndclient.NotifierOptions, spendChan chan *chainntnfs.SpendDetail,
+	errChan chan error) {
+
+	for {
+		spendEvent, err := stream.Recv()
+		if err != nil {
+			errChan <- err
+
+			return
+		}
+
+		switch c := spendEvent.Event.(type) {
+		case *chainrpc.SpendEvent_Spend:
+			spend, err := spendDetailFromRPC(
+				ctx, c.Spend, spendChan,
+			)
+			if err != nil {
+				errChan <- err
+
+				return
+			}
+			if spend {
+				// Not re-org aware: one spend is terminal.
+				if opts.ReOrgChan == nil {
+					return
+				}
+			}
+
+		case *chainrpc.SpendEvent_Reorg:
+			if opts.ReOrgChan != nil {
+				select {
+				case opts.ReOrgChan <- struct{}{}:
+				case <-ctx.Done():
+					return
+				}
+			}
+
+		case nil:
+			errChan <- fmt.Errorf("spend event empty")
+
+			return
+
+		default:
+			errChan <- fmt.Errorf("spend event has unexpected type")
+
+			return
+		}
+	}
+}
+
+// spendDetailFromRPC decodes a spend detail and forwards it onto spendChan,
+// returning true once the spend was delivered (or the context was cancelled
+// while delivering).
+func spendDetailFromRPC(ctx context.Context, d *chainrpc.SpendDetails,
+	spendChan chan *chainntnfs.SpendDetail) (bool, error) {
+
+	outpointHash, err := chainhash.NewHash(d.SpendingOutpoint.Hash)
+	if err != nil {
+		return false, err
+	}
+	txHash, err := chainhash.NewHash(d.SpendingTxHash)
+	if err != nil {
+		return false, err
+	}
+	tx, err := decodeTx(d.RawSpendingTx)
+	if err != nil {
+		return false, err
+	}
+
+	spend := &chainntnfs.SpendDetail{
+		SpentOutPoint: &wire.OutPoint{
+			Hash:  *outpointHash,
+			Index: d.SpendingOutpoint.Index,
+		},
+		SpenderTxHash:     txHash,
+		SpenderInputIndex: d.SpendingInputIndex,
+		SpendingTx:        tx,
+		SpendingHeight:    int32(d.SpendingHeight),
+	}
+
+	select {
+	case spendChan <- spend:
+		return true, nil
+
+	case <-ctx.Done():
+		return true, nil
+	}
+}

--- a/lndrest/codec.go
+++ b/lndrest/codec.go
@@ -1,0 +1,47 @@
+package lndrest
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+)
+
+// encodeTx serializes a transaction with witness data, matching the raw tx
+// encoding lnd's RPCs expect.
+func encodeTx(tx *wire.MsgTx) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := tx.BtcEncode(&buf, 0, wire.WitnessEncoding); err != nil {
+		return nil, fmt.Errorf("serialize tx: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// decodeTx deserializes raw witness-encoded transaction bytes.
+func decodeTx(rawTx []byte) (*wire.MsgTx, error) {
+	tx := &wire.MsgTx{}
+	if err := tx.BtcDecode(
+		bytes.NewReader(rawTx), 0, wire.WitnessEncoding,
+	); err != nil {
+		return nil, fmt.Errorf("deserialize tx: %w", err)
+	}
+
+	return tx, nil
+}
+
+// decodeBlock deserializes a raw block.
+func decodeBlock(rawBlock []byte) (*wire.MsgBlock, error) {
+	block := &wire.MsgBlock{}
+	if err := block.Deserialize(bytes.NewReader(rawBlock)); err != nil {
+		return nil, fmt.Errorf("deserialize block: %w", err)
+	}
+
+	return block, nil
+}
+
+// btcAmount converts a satoshi count into a btcutil.Amount.
+func btcAmount(sats int64) btcutil.Amount {
+	return btcutil.Amount(sats)
+}

--- a/lndrest/lightning.go
+++ b/lndrest/lightning.go
@@ -1,0 +1,101 @@
+package lndrest
+
+import (
+	"context"
+	"encoding/hex"
+	"time"
+
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/lnrpc"
+)
+
+// Lightning REST paths, taken from lnd's grpc-gateway pattern vars. Both are
+// GET endpoints with no request body.
+const (
+	pathGetInfo       = "/v1/getinfo"
+	pathWalletBalance = "/v1/balance/blockchain"
+)
+
+// lightningClient implements the small slice of lndclient.LightningClient the
+// wallet backend uses (GetInfo for node metadata at connect time, and
+// WalletBalance for the on-chain balance surface) over lnd's REST gateway.
+//
+// The full LightningClient interface has ~45 methods, none of the rest of
+// which the daemon calls in lnd mode. Rather than hand-stub every one with its
+// exotic parameter types, the interface is embedded (nil): the two used methods
+// are overridden below, and any unused method is simply never invoked. This
+// mirrors the way lndclient's own clients embed their generated service
+// interface.
+type lightningClient struct {
+	lndclient.LightningClient
+
+	conn *conn
+}
+
+// A compile-time check that lightningClient satisfies the lndclient interface.
+var _ lndclient.LightningClient = (*lightningClient)(nil)
+
+// RawClientWithMacAuth is required by the ServiceClient interface but returns a
+// nil raw client: the REST backend has no gRPC client to expose.
+func (s *lightningClient) RawClientWithMacAuth(parentCtx context.Context) (
+	context.Context, time.Duration, lnrpc.LightningClient) {
+
+	return parentCtx, s.conn.timeout, nil
+}
+
+// WalletBalance returns the node's on-chain wallet balance.
+func (s *lightningClient) WalletBalance(ctx context.Context) (
+	*lndclient.WalletBalance, error) {
+
+	resp := &lnrpc.WalletBalanceResponse{}
+	if err := s.conn.get(ctx, pathWalletBalance, resp); err != nil {
+		return nil, err
+	}
+
+	return &lndclient.WalletBalance{
+		Confirmed:   btcAmount(resp.ConfirmedBalance),
+		Unconfirmed: btcAmount(resp.UnconfirmedBalance),
+	}, nil
+}
+
+// GetInfo returns basic information about the connected lnd node. Only the
+// fields the daemon reads (alias, identity pubkey, network, sync/version
+// metadata) are populated; fields requiring extra parsing (color, best block
+// hash) are left zero-valued since no caller consumes them over this path.
+func (s *lightningClient) GetInfo(ctx context.Context) (*lndclient.Info,
+	error) {
+
+	resp := &lnrpc.GetInfoResponse{}
+	if err := s.conn.get(ctx, pathGetInfo, resp); err != nil {
+		return nil, err
+	}
+
+	pubKey, err := hex.DecodeString(resp.IdentityPubkey)
+	if err != nil {
+		return nil, err
+	}
+	var pubKeyArray [33]byte
+	copy(pubKeyArray[:], pubKey)
+
+	var network string
+	if len(resp.Chains) > 0 {
+		network = resp.Chains[0].Network
+	}
+
+	return &lndclient.Info{
+		Version:             resp.Version,
+		CommitHash:          resp.CommitHash,
+		BlockHeight:         resp.BlockHeight,
+		BestHeaderTimeStamp: time.Unix(resp.BestHeaderTimestamp, 0),
+		IdentityPubkey:      pubKeyArray,
+		Alias:               resp.Alias,
+		Network:             network,
+		Uris:                resp.Uris,
+		SyncedToChain:       resp.SyncedToChain,
+		SyncedToGraph:       resp.SyncedToGraph,
+		ActiveChannels:      resp.NumActiveChannels,
+		InactiveChannels:    resp.NumInactiveChannels,
+		PendingChannels:     resp.NumPendingChannels,
+		NumPeers:            resp.NumPeers,
+	}, nil
+}

--- a/lndrest/lndrest.go
+++ b/lndrest/lndrest.go
@@ -67,9 +67,18 @@ type Config struct {
 	// defaultRPCTimeout.
 	RPCTimeout time.Duration
 
-	// ChainParams identifies the active network. It is used for address
-	// decoding and is also cross-checked against lnd's reported network.
+	// ChainParams identifies the active network and is used for address
+	// decoding.
 	ChainParams *chaincfg.Params
+
+	// Network is the configured network in lnd's naming convention
+	// ("mainnet", "testnet", "testnet4", "regtest", "simnet", "signet").
+	// It is cross-checked against the network lnd reports from GetInfo.
+	// This is deliberately not derived from ChainParams.Name: btcd's
+	// chaincfg calls the testnet3 network "testnet3" whereas lnd reports it
+	// as "testnet", so comparing against ChainParams.Name would spuriously
+	// reject a correctly-configured testnet node. Empty disables the check.
+	Network string
 }
 
 // conn is the shared REST transport used by every lndrest sub-client. It wraps
@@ -201,12 +210,10 @@ func New(ctx context.Context, cfg Config) (*Backend, error) {
 			err)
 	}
 
-	if info.Network != "" && info.Network != cfg.ChainParams.Name {
+	if err := networkMismatch(info.Network, cfg.Network); err != nil {
 		httpClient.CloseIdleConnections()
 
-		return nil, fmt.Errorf("lndrest: lnd network %q does not "+
-			"match configured network %q", info.Network,
-			cfg.ChainParams.Name)
+		return nil, err
 	}
 
 	services.NodeAlias = info.Alias
@@ -216,6 +223,27 @@ func New(ctx context.Context, cfg Config) (*Backend, error) {
 		services: services,
 		conn:     c,
 	}, nil
+}
+
+// networkMismatch reports a non-nil error when the network lnd reports from
+// GetInfo does not match the configured network. Both values use lnd's naming
+// convention ("mainnet", "testnet", "testnet4", "regtest", "simnet",
+// "signet"). Comparing in this convention (rather than against
+// chaincfg.Params.Name) is what makes testnet work: lnd reports the testnet3
+// network as "testnet", while chaincfg names it "testnet3". An empty value on
+// either side disables the check (lnd omitted the chain, or no network was
+// configured).
+func networkMismatch(lndNetwork, configured string) error {
+	if lndNetwork == "" || configured == "" {
+		return nil
+	}
+
+	if lndNetwork != configured {
+		return fmt.Errorf("lndrest: lnd network %q does not match "+
+			"configured network %q", lndNetwork, configured)
+	}
+
+	return nil
 }
 
 // baseURL returns the REST base URL for the configured lnd host. lnd serves

--- a/lndrest/lndrest.go
+++ b/lndrest/lndrest.go
@@ -1,0 +1,277 @@
+// Package lndrest provides REST implementations of the lndclient service
+// interfaces the waved wallet backend uses, so the daemon can talk to lnd over
+// its grpc-gateway HTTP/JSON interface instead of native gRPC. It reuses the
+// shared rpc/restclient transport (HTTP + protoJSON + streaming) and speaks to
+// lnd's published REST paths (the pattern_* routes generated into lnd's
+// *.pb.gw.go files) using the lnd proto request/response types for marshaling.
+//
+// Only the method surface the wallet backend actually exercises is
+// implemented; every other interface method returns errUnsupportedOverREST so
+// an unexpected caller fails loudly rather than silently misbehaving.
+package lndrest
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/wavelength/rpc/restclient"
+	"github.com/lightningnetwork/lnd/routing/route"
+	"google.golang.org/protobuf/proto"
+)
+
+// defaultRPCTimeout bounds each unary REST call to lnd. It mirrors the daemon's
+// DefaultRPCTimeout so a REST-backed backend behaves like the gRPC one when the
+// caller leaves the timeout unset; streaming notification calls deliberately
+// bypass it since they are long-lived.
+const defaultRPCTimeout = 30 * time.Second
+
+// macaroonHeader is the HTTP header lnd's REST gateway reads the hex-encoded
+// macaroon from for request authentication. lnd matches it case-insensitively;
+// the canonical form is used so it round-trips cleanly through net/http.
+const macaroonHeader = "Grpc-Metadata-Macaroon"
+
+// errUnsupportedOverREST is returned by interface methods the REST backend does
+// not implement. The wallet backend never calls these; the stubs exist only to
+// satisfy the wide lndclient interfaces, and returning a clear error means an
+// unexpected new caller fails loudly instead of silently misbehaving.
+var errUnsupportedOverREST = fmt.Errorf("lnd method not supported over the " +
+	"REST transport")
+
+// Config parameterizes a REST-backed lnd connection.
+type Config struct {
+	// Host is the lnd REST gateway endpoint. A bare host:port is assumed to
+	// be TLS (https) since lnd serves REST over TLS by default; supply an
+	// explicit http:// scheme to talk to a gateway with REST TLS disabled.
+	Host string
+
+	// TLSPath is the path to lnd's TLS certificate. When set it anchors a
+	// dedicated cert pool; when empty the system cert pool is used (which
+	// only works if lnd's cert is publicly trusted).
+	TLSPath string
+
+	// MacaroonPath is the path to the macaroon authorizing the used RPCs.
+	// It is required: unlike the gRPC lndclient, the REST path cannot
+	// resolve lnd's per-network default macaroon location on its own.
+	MacaroonPath string
+
+	// RPCTimeout bounds each unary REST call. Zero selects
+	// defaultRPCTimeout.
+	RPCTimeout time.Duration
+
+	// ChainParams identifies the active network. It is used for address
+	// decoding and is also cross-checked against lnd's reported network.
+	ChainParams *chaincfg.Params
+}
+
+// conn is the shared REST transport used by every lndrest sub-client. It wraps
+// the rpc/restclient transport with the per-call timeout policy and the active
+// chain params needed for address decoding.
+type conn struct {
+	rc      *restclient.Client
+	http    *http.Client
+	timeout time.Duration
+	params  *chaincfg.Params
+}
+
+// post issues one unary POST call, applying the per-call timeout.
+func (c *conn) post(ctx context.Context, path string,
+	in, out proto.Message) error {
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	return c.rc.Post(ctx, path, in, out)
+}
+
+// get issues one unary GET call, applying the per-call timeout. The path must
+// already carry any query string the endpoint binds its request from.
+func (c *conn) get(ctx context.Context, path string, out proto.Message) error {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	return c.rc.Get(ctx, path, out)
+}
+
+// stream opens one server-streaming call. It deliberately does not apply the
+// per-call timeout: notification streams are long-lived and are torn down by
+// the caller cancelling the supplied context instead.
+func (c *conn) stream(ctx context.Context, path string, in proto.Message) (
+	*http.Response, error) {
+
+	return c.rc.Stream(ctx, path, in)
+}
+
+// Backend is a REST-backed lnd connection. It satisfies the daemon's lnd
+// services seam by exposing a populated *lndclient.LndServices whose subsystem
+// clients are the REST implementations in this package.
+type Backend struct {
+	services *lndclient.LndServices
+	conn     *conn
+}
+
+// Services returns the populated lndclient service payload backed by REST.
+func (b *Backend) Services() *lndclient.LndServices {
+	return b.services
+}
+
+// Close releases the idle HTTP connections held by the REST transport. Active
+// notification streams are owned by their callers and are torn down when those
+// callers cancel the context they registered with.
+func (b *Backend) Close() {
+	b.conn.http.CloseIdleConnections()
+}
+
+// New dials lnd over REST, verifies connectivity via a GetInfo round-trip, and
+// returns a Backend whose lndclient service fields are REST implementations.
+// The GetInfo response seeds NodeAlias/NodePubkey (and validates the reported
+// network) exactly as the gRPC lndclient does at connect time.
+func New(ctx context.Context, cfg Config) (*Backend, error) {
+	if cfg.ChainParams == nil {
+		return nil, fmt.Errorf("lndrest: chain params are required")
+	}
+	if cfg.MacaroonPath == "" {
+		return nil, fmt.Errorf("lndrest: lnd.macaroonpath is " +
+			"required for the REST transport")
+	}
+
+	macHex, err := readMacaroonHex(cfg.MacaroonPath)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient, err := newHTTPClient(cfg.TLSPath)
+	if err != nil {
+		return nil, err
+	}
+
+	timeout := cfg.RPCTimeout
+	if timeout == 0 {
+		timeout = defaultRPCTimeout
+	}
+
+	rc := restclient.New(
+		baseURL(cfg.Host), restclient.WithHTTPClient(httpClient),
+		restclient.WithHeader(macaroonHeader, macHex),
+	)
+	c := &conn{
+		rc:      rc,
+		http:    httpClient,
+		timeout: timeout,
+		params:  cfg.ChainParams,
+	}
+
+	// Populate the service payload with the REST implementations. The
+	// wallet backend reads these interface fields; the concrete types live
+	// in the sibling files in this package.
+	services := &lndclient.LndServices{
+		Signer: &signerClient{
+			conn: c,
+		},
+		WalletKit: &walletKitClient{
+			conn: c,
+		},
+		ChainKit: &chainKitClient{
+			conn: c,
+		},
+		ChainNotifier: &chainNotifierClient{
+			conn: c,
+		},
+		Client: &lightningClient{
+			conn: c,
+		},
+		ChainParams: cfg.ChainParams,
+	}
+
+	// A GetInfo round-trip both proves the connection works and seeds the
+	// node metadata the daemon reads off the services payload.
+	info, err := services.Client.GetInfo(ctx)
+	if err != nil {
+		httpClient.CloseIdleConnections()
+
+		return nil, fmt.Errorf("lndrest: initial GetInfo failed: %w",
+			err)
+	}
+
+	if info.Network != "" && info.Network != cfg.ChainParams.Name {
+		httpClient.CloseIdleConnections()
+
+		return nil, fmt.Errorf("lndrest: lnd network %q does not "+
+			"match configured network %q", info.Network,
+			cfg.ChainParams.Name)
+	}
+
+	services.NodeAlias = info.Alias
+	services.NodePubkey = route.Vertex(info.IdentityPubkey)
+
+	return &Backend{
+		services: services,
+		conn:     c,
+	}, nil
+}
+
+// baseURL returns the REST base URL for the configured lnd host. lnd serves
+// REST over TLS by default, so a schemeless host is treated as https rather
+// than relying on the restclient loopback heuristic (which would pick http for
+// a localhost lnd and fail the TLS handshake). An explicit scheme is honored so
+// operators running lnd with REST TLS disabled can still opt into http.
+func baseURL(host string) string {
+	if strings.HasPrefix(host, "http://") ||
+		strings.HasPrefix(host, "https://") {
+		return host
+	}
+
+	return "https://" + host
+}
+
+// readMacaroonHex reads the macaroon file and returns its hex encoding for the
+// Grpc-Metadata-macaroon header.
+func readMacaroonHex(path string) (string, error) {
+	//nolint:gosec // The macaroon path is operator-supplied configuration.
+	macBytes, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("lndrest: read macaroon %q: %w", path,
+			err)
+	}
+
+	return hex.EncodeToString(macBytes), nil
+}
+
+// newHTTPClient builds the HTTP client used for every REST call. When a TLS
+// certificate path is supplied it anchors a dedicated cert pool so lnd's
+// self-signed certificate is trusted; otherwise the system cert pool is used.
+func newHTTPClient(tlsPath string) (*http.Client, error) {
+	tlsCfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if tlsPath != "" {
+		//nolint:gosec // The TLS cert path is operator-supplied config.
+		certBytes, err := os.ReadFile(tlsPath)
+		if err != nil {
+			return nil, fmt.Errorf("lndrest: read lnd TLS cert "+
+				"%q: %w", tlsPath, err)
+		}
+
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(certBytes) {
+			return nil, fmt.Errorf("lndrest: parse lnd TLS cert %q",
+				tlsPath)
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsCfg,
+		},
+	}, nil
+}

--- a/lndrest/lndrest_test.go
+++ b/lndrest/lndrest_test.go
@@ -195,3 +195,33 @@ func decodeBody(t *testing.T, r *http.Request, out proto.Message) {
 	require.NoError(t, err)
 	require.NoError(t, protojson.Unmarshal(body, out))
 }
+
+// TestNetworkMismatch verifies the lnd-vs-configured network check compares in
+// lnd's naming convention rather than against chaincfg.Params.Name. The
+// regression it guards is testnet3: lnd reports that network as "testnet"
+// while chaincfg names it "testnet3", so a raw comparison against
+// ChainParams.Name would spuriously reject a correctly-configured testnet
+// node.
+func TestNetworkMismatch(t *testing.T) {
+	t.Parallel()
+
+	// The bug guard: waved configures the testnet3 network as "testnet"
+	// (lnd's convention) and lnd also reports "testnet", so the two must
+	// match -- even though chaincfg calls this same network "testnet3".
+	require.Equal(t, "testnet3", chaincfg.TestNet3Params.Name)
+	require.NoError(t, networkMismatch("testnet", "testnet"))
+
+	// The other networks match directly on both sides.
+	require.NoError(t, networkMismatch("mainnet", "mainnet"))
+	require.NoError(t, networkMismatch("regtest", "regtest"))
+	require.NoError(t, networkMismatch("signet", "signet"))
+
+	// An empty value on either side disables the check (lnd omitted the
+	// chain, or no network was configured).
+	require.NoError(t, networkMismatch("", "mainnet"))
+	require.NoError(t, networkMismatch("testnet", ""))
+
+	// A genuine cross-network misconfiguration is still caught.
+	require.Error(t, networkMismatch("testnet", "mainnet"))
+	require.Error(t, networkMismatch("regtest", "testnet"))
+}

--- a/lndrest/lndrest_test.go
+++ b/lndrest/lndrest_test.go
@@ -1,0 +1,197 @@
+package lndrest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/lightninglabs/wavelength/rpc/restclient"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+const testMacHex = "0a0b6465616462656566"
+
+// newTestConn builds a conn pointed at the test server. The server URL carries
+// an http:// scheme so the REST transport talks plaintext to httptest.
+func newTestConn(srvURL string) *conn {
+	rc := restclient.New(
+		srvURL, restclient.WithHeader(macaroonHeader, testMacHex),
+	)
+
+	return &conn{
+		rc:      rc,
+		http:    http.DefaultClient,
+		timeout: 5 * time.Second,
+		params:  &chaincfg.RegressionNetParams,
+	}
+}
+
+// writeProtoJSON marshals a proto message as the grpc-gateway unary response
+// body would.
+func writeProtoJSON(t *testing.T, w http.ResponseWriter, msg proto.Message) {
+	t.Helper()
+
+	body, err := protojson.Marshal(msg)
+	require.NoError(t, err)
+
+	_, err = w.Write(body)
+	require.NoError(t, err)
+}
+
+// TestWalletKitDeriveKey checks that DeriveKey POSTs to the right path with the
+// macaroon header and locator body, and decodes the returned key descriptor.
+func TestWalletKitDeriveKey(t *testing.T) {
+	t.Parallel()
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	pubBytes := priv.PubKey().SerializeCompressed()
+
+	loc := keychain.KeyLocator{Family: 6, Index: 3}
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodPost, r.Method)
+				require.Equal(t, pathDeriveKey, r.URL.Path)
+				require.Equal(
+					t, testMacHex,
+					r.Header.Get(macaroonHeader),
+				)
+
+				var reqMsg signrpc.KeyLocator
+				decodeBody(t, r, &reqMsg)
+				require.Equal(t, int32(6), reqMsg.KeyFamily)
+				require.Equal(t, int32(3), reqMsg.KeyIndex)
+
+				writeProtoJSON(t, w, &signrpc.KeyDescriptor{
+					RawKeyBytes: pubBytes,
+					KeyLoc: &signrpc.KeyLocator{
+						KeyFamily: 6,
+						KeyIndex:  3,
+					},
+				})
+			},
+		),
+	)
+	defer srv.Close()
+
+	client := &walletKitClient{conn: newTestConn(srv.URL)}
+	desc, err := client.DeriveKey(context.Background(), &loc)
+	require.NoError(t, err)
+	require.Equal(t, loc, desc.KeyLocator)
+	require.Equal(t, pubBytes, desc.PubKey.SerializeCompressed())
+}
+
+// TestChainKitGetBlockHash checks that GetBlockHash issues a GET to the right
+// path with the block height bound as a query parameter, and decodes the hash.
+func TestChainKitGetBlockHash(t *testing.T) {
+	t.Parallel()
+
+	var wantHash [32]byte
+	for i := range wantHash {
+		wantHash[i] = byte(i + 1)
+	}
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodGet, r.Method)
+				require.Equal(t, pathGetBlockHash, r.URL.Path)
+				require.Equal(
+					t, "42",
+					r.URL.Query().Get("block_height"),
+				)
+
+				writeProtoJSON(
+					t, w, &chainrpc.GetBlockHashResponse{
+						BlockHash: wantHash[:],
+					},
+				)
+			},
+		),
+	)
+	defer srv.Close()
+
+	client := &chainKitClient{conn: newTestConn(srv.URL)}
+	hash, err := client.GetBlockHash(context.Background(), 42)
+	require.NoError(t, err)
+	require.Equal(t, wantHash[:], hash[:])
+}
+
+// TestChainNotifierBlockEpoch checks that RegisterBlockEpochNtfn opens the
+// streaming endpoint and forwards each streamed block height onto the returned
+// channel using the grpc-gateway {"result": ...} chunk shape.
+func TestChainNotifierBlockEpoch(t *testing.T) {
+	t.Parallel()
+
+	heights := []uint32{100, 101}
+
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodPost, r.Method)
+			require.Equal(t, pathRegisterBlocks, r.URL.Path)
+
+			flusher, ok := w.(http.Flusher)
+			require.True(t, ok)
+
+			for _, h := range heights {
+				epoch := &chainrpc.BlockEpoch{Height: h}
+				body, err := protojson.Marshal(epoch)
+				require.NoError(t, err)
+
+				_, err = fmt.Fprintf(
+					w, `{"result":%s}`+"\n", body,
+				)
+				require.NoError(t, err)
+				flusher.Flush()
+			}
+
+			// Keep the stream open until the client cancels so the
+			// reader observes clean events rather than a racing
+			// EOF.
+			<-r.Context().Done()
+		},
+	))
+	defer srv.Close()
+
+	client := &chainNotifierClient{conn: newTestConn(srv.URL)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	epochChan, errChan, err := client.RegisterBlockEpochNtfn(ctx)
+	require.NoError(t, err)
+
+	for _, want := range heights {
+		select {
+		case got := <-epochChan:
+			require.Equal(t, int32(want), got)
+
+		case err := <-errChan:
+			t.Fatalf("unexpected stream error: %v", err)
+
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for block epoch")
+		}
+	}
+}
+
+// decodeBody decodes the JSON request body into a proto message.
+func decodeBody(t *testing.T, r *http.Request, out proto.Message) {
+	t.Helper()
+
+	body, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+	require.NoError(t, protojson.Unmarshal(body, out))
+}

--- a/lndrest/signer.go
+++ b/lndrest/signer.go
@@ -1,0 +1,481 @@
+package lndrest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
+)
+
+// Signer REST paths, taken from lnd's signrpc grpc-gateway pattern vars.
+const (
+	pathSignOutputRaw     = "/v2/signer/signraw"
+	pathComputeInputScr   = "/v2/signer/inputscript"
+	pathSignMessage       = "/v2/signer/signmessage"
+	pathDeriveSharedKey   = "/v2/signer/sharedkey"
+	pathMuSig2CreateSess  = "/v2/signer/musig2/createsession"
+	pathMuSig2RegNonces   = "/v2/signer/musig2/registernonces"
+	pathMuSig2RegCombined = "/v2/signer/musig2/registercombinednonce"
+	pathMuSig2GetCombined = "/v2/signer/musig2/getcombinednonce"
+	pathMuSig2Sign        = "/v2/signer/musig2/sign"
+	pathMuSig2CombineSig  = "/v2/signer/musig2/combinesig"
+	pathMuSig2Cleanup     = "/v2/signer/musig2/cleanup"
+)
+
+// signerClient implements lndclient.SignerClient over lnd's REST gateway. It
+// also exposes SignOutputRawWithLocator so the wallet backend's locator-aware
+// signing path works over REST without touching a raw gRPC client.
+type signerClient struct {
+	conn *conn
+}
+
+// A compile-time check that signerClient satisfies the lndclient interface.
+var _ lndclient.SignerClient = (*signerClient)(nil)
+
+// RawClientWithMacAuth is required by the lndclient ServiceClient interface but
+// has no meaning over REST: there is no raw gRPC client to hand back. It
+// returns a nil client; the locator-aware signing path uses
+// SignOutputRawWithLocator instead, so this is never dereferenced.
+func (s *signerClient) RawClientWithMacAuth(parentCtx context.Context) (
+	context.Context, time.Duration, signrpc.SignerClient) {
+
+	return parentCtx, s.conn.timeout, nil
+}
+
+// marshalSignDescriptors converts lndclient sign descriptors into their signrpc
+// counterparts, mirroring lndclient's own marshalling. When fullDescriptor is
+// true the key locator is forwarded whenever either component is non-zero
+// (fixing the family-6/index-0 identity path); otherwise only one of the raw
+// public key or the locator is populated, matching lndclient's partial form.
+func marshalSignDescriptors(signDescriptors []*lndclient.SignDescriptor,
+	fullDescriptor bool) ([]*signrpc.SignDescriptor, error) {
+
+	rpcSignDescs := make([]*signrpc.SignDescriptor, len(signDescriptors))
+	for i, signDesc := range signDescriptors {
+		if signDesc == nil {
+			return nil, fmt.Errorf("sign descriptor %d is nil", i)
+		}
+		if signDesc.Output == nil {
+			return nil, fmt.Errorf("sign descriptor %d has "+
+				"no output", i)
+		}
+
+		keyDesc := &signrpc.KeyDescriptor{}
+		loc := signDesc.KeyDesc.KeyLocator
+		switch {
+		// Full form: forward the pubkey and, whenever any locator
+		// component is set, the locator too.
+		case fullDescriptor:
+			if signDesc.KeyDesc.PubKey != nil {
+				keyDesc.RawKeyBytes = signDesc.KeyDesc.PubKey.
+					SerializeCompressed()
+			}
+			if loc.Family != 0 || loc.Index != 0 {
+				keyDesc.KeyLoc = &signrpc.KeyLocator{
+					KeyFamily: int32(loc.Family),
+					KeyIndex:  int32(loc.Index),
+				}
+			}
+
+		// Partial form: either the pubkey or the locator, not both.
+		case signDesc.KeyDesc.PubKey != nil:
+			keyDesc.RawKeyBytes = signDesc.KeyDesc.PubKey.
+				SerializeCompressed()
+
+		default:
+			keyDesc.KeyLoc = &signrpc.KeyLocator{
+				KeyFamily: int32(loc.Family),
+				KeyIndex:  int32(loc.Index),
+			}
+		}
+
+		var doubleTweak []byte
+		if signDesc.DoubleTweak != nil {
+			doubleTweak = signDesc.DoubleTweak.Serialize()
+		}
+
+		rpcSignDescs[i] = &signrpc.SignDescriptor{
+			WitnessScript: signDesc.WitnessScript,
+			SignMethod: lndclient.MarshalSignMethod(
+				signDesc.SignMethod,
+			),
+			Output: &signrpc.TxOut{
+				PkScript: signDesc.Output.PkScript,
+				Value:    signDesc.Output.Value,
+			},
+			Sighash:     uint32(signDesc.HashType),
+			InputIndex:  int32(signDesc.InputIndex),
+			KeyDesc:     keyDesc,
+			SingleTweak: signDesc.SingleTweak,
+			DoubleTweak: doubleTweak,
+			TapTweak:    signDesc.TapTweak,
+		}
+	}
+
+	return rpcSignDescs, nil
+}
+
+// marshalTxOut converts previous outputs into their signrpc counterparts.
+func marshalTxOut(outputs []*wire.TxOut) []*signrpc.TxOut {
+	rpcOutputs := make([]*signrpc.TxOut, len(outputs))
+	for i, output := range outputs {
+		if output == nil {
+			continue
+		}
+
+		rpcOutputs[i] = &signrpc.TxOut{
+			PkScript: output.PkScript,
+			Value:    output.Value,
+		}
+	}
+
+	return rpcOutputs
+}
+
+// signOutputRaw is the shared implementation of the SignOutputRaw variants.
+func (s *signerClient) signOutputRaw(ctx context.Context, tx *wire.MsgTx,
+	signDescriptors []*lndclient.SignDescriptor, prevOutputs []*wire.TxOut,
+	fullDescriptor bool) ([][]byte, error) {
+
+	txRaw, err := encodeTx(tx)
+	if err != nil {
+		return nil, err
+	}
+	rpcSignDescs, err := marshalSignDescriptors(
+		signDescriptors, fullDescriptor,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	req := &signrpc.SignReq{
+		RawTxBytes:  txRaw,
+		SignDescs:   rpcSignDescs,
+		PrevOutputs: marshalTxOut(prevOutputs),
+	}
+	resp := &signrpc.SignResp{}
+	if err := s.conn.post(ctx, pathSignOutputRaw, req, resp); err != nil {
+		return nil, err
+	}
+
+	return resp.RawSigs, nil
+}
+
+// SignOutputRaw generates signatures for the given inputs/outputs.
+func (s *signerClient) SignOutputRaw(ctx context.Context, tx *wire.MsgTx,
+	signDescriptors []*lndclient.SignDescriptor,
+	prevOutputs []*wire.TxOut) ([][]byte, error) {
+
+	return s.signOutputRaw(ctx, tx, signDescriptors, prevOutputs, false)
+}
+
+// SignOutputRawKeyLocator is the locator-forwarding variant of SignOutputRaw.
+func (s *signerClient) SignOutputRawKeyLocator(ctx context.Context,
+	tx *wire.MsgTx, signDescriptors []*lndclient.SignDescriptor,
+	prevOutputs []*wire.TxOut) ([][]byte, error) {
+
+	return s.signOutputRaw(ctx, tx, signDescriptors, prevOutputs, true)
+}
+
+// SignOutputRawWithLocator is the transport-agnostic seam the wallet backend
+// uses to always forward the key locator. Over REST this is simply
+// SignOutputRaw with the full descriptor, so no raw gRPC client is needed.
+func (s *signerClient) SignOutputRawWithLocator(ctx context.Context,
+	tx *wire.MsgTx, signDescriptors []*lndclient.SignDescriptor,
+	prevOutputs []*wire.TxOut) ([][]byte, error) {
+
+	return s.signOutputRaw(ctx, tx, signDescriptors, prevOutputs, true)
+}
+
+// ComputeInputScript generates complete input scripts for the given inputs.
+func (s *signerClient) ComputeInputScript(ctx context.Context, tx *wire.MsgTx,
+	signDescriptors []*lndclient.SignDescriptor,
+	prevOutputs []*wire.TxOut) ([]*input.Script, error) {
+
+	txRaw, err := encodeTx(tx)
+	if err != nil {
+		return nil, err
+	}
+	rpcSignDescs, err := marshalSignDescriptors(signDescriptors, false)
+	if err != nil {
+		return nil, err
+	}
+
+	req := &signrpc.SignReq{
+		RawTxBytes:  txRaw,
+		SignDescs:   rpcSignDescs,
+		PrevOutputs: marshalTxOut(prevOutputs),
+	}
+	resp := &signrpc.InputScriptResp{}
+	if err := s.conn.post(ctx, pathComputeInputScr, req, resp); err != nil {
+		return nil, err
+	}
+
+	inputScripts := make([]*input.Script, 0, len(resp.InputScripts))
+	for _, inputScript := range resp.InputScripts {
+		inputScripts = append(inputScripts, &input.Script{
+			SigScript: inputScript.SigScript,
+			Witness:   inputScript.Witness,
+		})
+	}
+
+	return inputScripts, nil
+}
+
+// SignMessage signs a message with the key at the locator, applying any option
+// mutators (e.g. Schnorr signing with a tag) to the request before sending.
+func (s *signerClient) SignMessage(ctx context.Context, msg []byte,
+	locator keychain.KeyLocator, opts ...lndclient.SignMessageOption) (
+	[]byte, error) {
+
+	req := &signrpc.SignMessageReq{
+		Msg: msg,
+		KeyLoc: &signrpc.KeyLocator{
+			KeyFamily: int32(locator.Family),
+			KeyIndex:  int32(locator.Index),
+		},
+	}
+	for _, opt := range opts {
+		opt(req)
+	}
+
+	resp := &signrpc.SignMessageResp{}
+	if err := s.conn.post(ctx, pathSignMessage, req, resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Signature, nil
+}
+
+// VerifyMessage is not used by the wallet backend and is unsupported over REST.
+func (s *signerClient) VerifyMessage(_ context.Context, _, _ []byte, _ [33]byte,
+	_ ...lndclient.VerifyMessageOption) (bool, error) {
+
+	return false, errUnsupportedOverREST
+}
+
+// DeriveSharedKey performs ECDH between the ephemeral key and the located key.
+func (s *signerClient) DeriveSharedKey(ctx context.Context,
+	ephemeralPubKey *btcec.PublicKey, keyLocator *keychain.KeyLocator) (
+	[32]byte, error) {
+
+	req := &signrpc.SharedKeyRequest{
+		EphemeralPubkey: ephemeralPubKey.SerializeCompressed(),
+	}
+	if keyLocator != nil {
+		req.KeyLoc = &signrpc.KeyLocator{
+			KeyFamily: int32(keyLocator.Family),
+			KeyIndex:  int32(keyLocator.Index),
+		}
+	}
+
+	resp := &signrpc.SharedKeyResponse{}
+	if err := s.conn.post(ctx, pathDeriveSharedKey, req, resp); err != nil {
+		return [32]byte{}, err
+	}
+
+	var sharedKey [32]byte
+	copy(sharedKey[:], resp.SharedKey)
+
+	return sharedKey, nil
+}
+
+// marshalMuSig2Version maps the input MuSig2 version enum to the RPC enum,
+// mirroring lndclient's own mapping.
+func marshalMuSig2Version(version input.MuSig2Version) (signrpc.MuSig2Version,
+	error) {
+
+	switch version {
+	case input.MuSig2Version040:
+		return signrpc.MuSig2Version_MUSIG2_VERSION_V040, nil
+
+	case input.MuSig2Version100RC2:
+		return signrpc.MuSig2Version_MUSIG2_VERSION_V100RC2, nil
+
+	default:
+		return signrpc.MuSig2Version_MUSIG2_VERSION_UNDEFINED,
+			fmt.Errorf("invalid MuSig2 version %v", version)
+	}
+}
+
+// MuSig2CreateSession creates a new MuSig2 signing session.
+func (s *signerClient) MuSig2CreateSession(ctx context.Context,
+	version input.MuSig2Version, signerLoc *keychain.KeyLocator,
+	signers [][]byte, opts ...lndclient.MuSig2SessionOpts) (
+	*input.MuSig2SessionInfo, error) {
+
+	rpcVersion, err := marshalMuSig2Version(version)
+	if err != nil {
+		return nil, err
+	}
+
+	req := &signrpc.MuSig2SessionRequest{
+		KeyLoc: &signrpc.KeyLocator{
+			KeyFamily: int32(signerLoc.Family),
+			KeyIndex:  int32(signerLoc.Index),
+		},
+		AllSignerPubkeys: signers,
+		Version:          rpcVersion,
+	}
+	for _, opt := range opts {
+		opt(req)
+	}
+
+	resp := &signrpc.MuSig2SessionResponse{}
+	if err := s.conn.post(
+		ctx, pathMuSig2CreateSess, req, resp,
+	); err != nil {
+		return nil, err
+	}
+
+	combinedKey, err := schnorr.ParsePubKey(resp.CombinedKey)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse combined key: %w", err)
+	}
+
+	session := &input.MuSig2SessionInfo{
+		CombinedKey:   combinedKey,
+		HaveAllNonces: resp.HaveAllNonces,
+	}
+
+	if len(resp.LocalPublicNonces) != musig2.PubNonceSize {
+		return nil, fmt.Errorf("unexpected local nonce size: %d",
+			len(resp.LocalPublicNonces))
+	}
+	copy(session.PublicNonce[:], resp.LocalPublicNonces)
+
+	if len(resp.SessionId) != 32 {
+		return nil, fmt.Errorf("unexpected session ID length: %d",
+			len(resp.SessionId))
+	}
+	copy(session.SessionID[:], resp.SessionId)
+
+	return session, nil
+}
+
+// noncesToBytes flattens fixed-size public nonces into a byte-slice slice.
+func noncesToBytes(nonces [][musig2.PubNonceSize]byte) [][]byte {
+	nonceBytes := make([][]byte, len(nonces))
+	for i := range nonces {
+		nonceBytes[i] = nonces[i][:]
+	}
+
+	return nonceBytes
+}
+
+// MuSig2RegisterNonces registers additional public nonces for a session.
+func (s *signerClient) MuSig2RegisterNonces(ctx context.Context,
+	sessionID [32]byte, nonces [][66]byte) (bool, error) {
+
+	req := &signrpc.MuSig2RegisterNoncesRequest{
+		SessionId:               sessionID[:],
+		OtherSignerPublicNonces: noncesToBytes(nonces),
+	}
+
+	resp := &signrpc.MuSig2RegisterNoncesResponse{}
+	if err := s.conn.post(ctx, pathMuSig2RegNonces, req, resp); err != nil {
+		return false, err
+	}
+
+	return resp.HaveAllNonces, nil
+}
+
+// MuSig2Sign creates the local partial signature for the message digest.
+func (s *signerClient) MuSig2Sign(ctx context.Context, sessionID [32]byte,
+	message [32]byte, cleanup bool) ([]byte, error) {
+
+	req := &signrpc.MuSig2SignRequest{
+		SessionId:     sessionID[:],
+		MessageDigest: message[:],
+		Cleanup:       cleanup,
+	}
+
+	resp := &signrpc.MuSig2SignResponse{}
+	if err := s.conn.post(ctx, pathMuSig2Sign, req, resp); err != nil {
+		return nil, err
+	}
+
+	return resp.LocalPartialSignature, nil
+}
+
+// MuSig2CombineSig combines partial signatures, returning the final signature
+// once every participant has registered.
+func (s *signerClient) MuSig2CombineSig(ctx context.Context, sessionID [32]byte,
+	otherPartialSigs [][]byte) (bool, []byte, error) {
+
+	req := &signrpc.MuSig2CombineSigRequest{
+		SessionId:              sessionID[:],
+		OtherPartialSignatures: otherPartialSigs,
+	}
+
+	resp := &signrpc.MuSig2CombineSigResponse{}
+	if err := s.conn.post(
+		ctx, pathMuSig2CombineSig, req, resp,
+	); err != nil {
+		return false, nil, err
+	}
+
+	return resp.HaveAllSignatures, resp.FinalSignature, nil
+}
+
+// MuSig2Cleanup removes a session from lnd's memory.
+func (s *signerClient) MuSig2Cleanup(ctx context.Context,
+	sessionID [32]byte) error {
+
+	req := &signrpc.MuSig2CleanupRequest{
+		SessionId: sessionID[:],
+	}
+
+	return s.conn.post(
+		ctx, pathMuSig2Cleanup, req, &signrpc.MuSig2CleanupResponse{},
+	)
+}
+
+// MuSig2RegisterCombinedNonce registers a pre-aggregated combined nonce.
+func (s *signerClient) MuSig2RegisterCombinedNonce(ctx context.Context,
+	sessionID [32]byte, combinedNonce [66]byte) error {
+
+	req := &signrpc.MuSig2RegisterCombinedNonceRequest{
+		SessionId:           sessionID[:],
+		CombinedPublicNonce: combinedNonce[:],
+	}
+
+	return s.conn.post(
+		ctx, pathMuSig2RegCombined, req,
+		&signrpc.MuSig2RegisterCombinedNonceResponse{},
+	)
+}
+
+// MuSig2GetCombinedNonce retrieves the combined nonce for a session.
+func (s *signerClient) MuSig2GetCombinedNonce(ctx context.Context,
+	sessionID [32]byte) ([66]byte, error) {
+
+	req := &signrpc.MuSig2GetCombinedNonceRequest{
+		SessionId: sessionID[:],
+	}
+
+	resp := &signrpc.MuSig2GetCombinedNonceResponse{}
+	if err := s.conn.post(
+		ctx, pathMuSig2GetCombined, req, resp,
+	); err != nil {
+		return [66]byte{}, err
+	}
+
+	if len(resp.CombinedPublicNonce) != 66 {
+		return [66]byte{}, fmt.Errorf("unexpected combined nonce "+
+			"size: %d", len(resp.CombinedPublicNonce))
+	}
+
+	var combinedNonce [66]byte
+	copy(combinedNonce[:], resp.CombinedPublicNonce)
+
+	return combinedNonce, nil
+}

--- a/lndrest/walletkit.go
+++ b/lndrest/walletkit.go
@@ -1,0 +1,494 @@
+package lndrest
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	btcaddr "github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/signrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+)
+
+// WalletKit REST paths, taken from lnd's walletrpc grpc-gateway pattern vars.
+const (
+	pathDeriveKey      = "/v2/wallet/key"
+	pathDeriveNextKey  = "/v2/wallet/key/next"
+	pathNextAddr       = "/v2/wallet/address/next"
+	pathListUnspent    = "/v2/wallet/utxos"
+	pathLeaseOutput    = "/v2/wallet/utxos/lease"
+	pathReleaseOutput  = "/v2/wallet/utxos/release"
+	pathImportTapscr   = "/v2/wallet/tapscript/import"
+	pathPublishTx      = "/v2/wallet/tx"
+	pathGetTransaction = "/v2/wallet/tx"
+	pathEstimateFee    = "/v2/wallet/estimatefee"
+)
+
+// walletKitClient implements lndclient.WalletKitClient over lnd's REST gateway.
+type walletKitClient struct {
+	conn *conn
+}
+
+// A compile-time check that walletKitClient satisfies the lndclient interface.
+var _ lndclient.WalletKitClient = (*walletKitClient)(nil)
+
+// RawClientWithMacAuth is required by the ServiceClient interface but returns a
+// nil raw client: the REST backend has no gRPC client to expose.
+func (m *walletKitClient) RawClientWithMacAuth(parentCtx context.Context) (
+	context.Context, time.Duration, walletrpc.WalletKitClient) {
+
+	return parentCtx, m.conn.timeout, nil
+}
+
+// ListUnspent returns wallet UTXOs with a confirmation count in the range.
+func (m *walletKitClient) ListUnspent(ctx context.Context, minConfs,
+	maxConfs int32, opts ...lndclient.ListUnspentOption) ([]*lnwallet.Utxo,
+	error) {
+
+	req := &walletrpc.ListUnspentRequest{
+		MinConfs: minConfs,
+		MaxConfs: maxConfs,
+	}
+	for _, opt := range opts {
+		opt(req)
+	}
+
+	resp := &walletrpc.ListUnspentResponse{}
+	if err := m.conn.post(ctx, pathListUnspent, req, resp); err != nil {
+		return nil, err
+	}
+
+	utxos := make([]*lnwallet.Utxo, 0, len(resp.Utxos))
+	for _, utxo := range resp.Utxos {
+		var addrType lnwallet.AddressType
+		switch utxo.AddressType {
+		case lnrpc.AddressType_WITNESS_PUBKEY_HASH:
+			addrType = lnwallet.WitnessPubKey
+
+		case lnrpc.AddressType_NESTED_PUBKEY_HASH:
+			addrType = lnwallet.NestedWitnessPubKey
+
+		case lnrpc.AddressType_TAPROOT_PUBKEY:
+			addrType = lnwallet.TaprootPubkey
+
+		default:
+			return nil, fmt.Errorf("invalid utxo address type %v",
+				utxo.AddressType)
+		}
+
+		pkScript, err := hex.DecodeString(utxo.PkScript)
+		if err != nil {
+			return nil, err
+		}
+
+		opHash, err := chainhash.NewHash(utxo.Outpoint.TxidBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		utxos = append(utxos, &lnwallet.Utxo{
+			AddressType:   addrType,
+			Value:         btcAmount(utxo.AmountSat),
+			Confirmations: utxo.Confirmations,
+			PkScript:      pkScript,
+			OutPoint: wire.OutPoint{
+				Hash:  *opHash,
+				Index: utxo.Outpoint.OutputIndex,
+			},
+		})
+	}
+
+	return utxos, nil
+}
+
+// LeaseOutput locks an output for the given lease duration.
+func (m *walletKitClient) LeaseOutput(ctx context.Context, lockID wtxmgr.LockID,
+	op wire.OutPoint, leaseTime time.Duration) (time.Time, error) {
+
+	req := &walletrpc.LeaseOutputRequest{
+		Id: lockID[:],
+		Outpoint: &lnrpc.OutPoint{
+			TxidBytes:   op.Hash[:],
+			OutputIndex: op.Index,
+		},
+		ExpirationSeconds: uint64(leaseTime.Seconds()),
+	}
+
+	resp := &walletrpc.LeaseOutputResponse{}
+	if err := m.conn.post(ctx, pathLeaseOutput, req, resp); err != nil {
+		return time.Time{}, err
+	}
+
+	return time.Unix(int64(resp.Expiration), 0), nil
+}
+
+// ReleaseOutput unlocks a previously leased output.
+func (m *walletKitClient) ReleaseOutput(ctx context.Context,
+	lockID wtxmgr.LockID, op wire.OutPoint) error {
+
+	req := &walletrpc.ReleaseOutputRequest{
+		Id: lockID[:],
+		Outpoint: &lnrpc.OutPoint{
+			TxidBytes:   op.Hash[:],
+			OutputIndex: op.Index,
+		},
+	}
+
+	return m.conn.post(
+		ctx, pathReleaseOutput, req, &walletrpc.ReleaseOutputResponse{},
+	)
+}
+
+// DeriveNextKey derives the next unused key in the given family.
+func (m *walletKitClient) DeriveNextKey(ctx context.Context, family int32) (
+	*keychain.KeyDescriptor, error) {
+
+	req := &walletrpc.KeyReq{
+		KeyFamily: family,
+	}
+
+	resp := &signrpc.KeyDescriptor{}
+	if err := m.conn.post(ctx, pathDeriveNextKey, req, resp); err != nil {
+		return nil, err
+	}
+
+	key, err := btcec.ParsePubKey(resp.RawKeyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &keychain.KeyDescriptor{
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamily(resp.KeyLoc.KeyFamily),
+			Index:  uint32(resp.KeyLoc.KeyIndex),
+		},
+		PubKey: key,
+	}, nil
+}
+
+// DeriveKey derives the key at the given locator.
+func (m *walletKitClient) DeriveKey(ctx context.Context,
+	in *keychain.KeyLocator) (*keychain.KeyDescriptor, error) {
+
+	req := &signrpc.KeyLocator{
+		KeyFamily: int32(in.Family),
+		KeyIndex:  int32(in.Index),
+	}
+
+	resp := &signrpc.KeyDescriptor{}
+	if err := m.conn.post(ctx, pathDeriveKey, req, resp); err != nil {
+		return nil, err
+	}
+
+	key, err := btcec.ParsePubKey(resp.RawKeyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &keychain.KeyDescriptor{
+		KeyLocator: *in,
+		PubKey:     key,
+	}, nil
+}
+
+// NextAddr returns a fresh wallet address of the requested type.
+func (m *walletKitClient) NextAddr(ctx context.Context, accountName string,
+	addressType walletrpc.AddressType, change bool) (btcaddr.Address,
+	error) {
+
+	req := &walletrpc.AddrRequest{
+		Account: accountName,
+		Type:    addressType,
+		Change:  change,
+	}
+
+	resp := &walletrpc.AddrResponse{}
+	if err := m.conn.post(ctx, pathNextAddr, req, resp); err != nil {
+		return nil, err
+	}
+
+	return btcaddr.DecodeAddress(resp.Addr, nil)
+}
+
+// GetTransaction returns wallet details for the given txid.
+func (m *walletKitClient) GetTransaction(ctx context.Context,
+	txid chainhash.Hash) (lndclient.Transaction, error) {
+
+	// GetTransaction is a GET endpoint that binds its txid from the query
+	// string, so encode it there rather than in a body.
+	query := url.Values{}
+	query.Set("txid", txid.String())
+	path := pathGetTransaction + "?" + query.Encode()
+
+	resp := &lnrpc.Transaction{}
+	if err := m.conn.get(ctx, path, resp); err != nil {
+		return lndclient.Transaction{}, err
+	}
+
+	return unmarshalTransaction(resp)
+}
+
+// unmarshalTransaction converts an lnrpc.Transaction into lndclient's shape,
+// mirroring lndclient's own conversion.
+func unmarshalTransaction(rpcTx *lnrpc.Transaction) (lndclient.Transaction,
+	error) {
+
+	rawTx, err := hex.DecodeString(rpcTx.RawTxHex)
+	if err != nil {
+		return lndclient.Transaction{}, err
+	}
+
+	tx, err := decodeTx(rawTx)
+	if err != nil {
+		return lndclient.Transaction{}, err
+	}
+
+	return lndclient.Transaction{
+		Tx:                tx,
+		TxHash:            tx.TxHash().String(),
+		Timestamp:         time.Unix(rpcTx.TimeStamp, 0),
+		Amount:            btcAmount(rpcTx.Amount),
+		Fee:               btcAmount(rpcTx.TotalFees),
+		Confirmations:     rpcTx.NumConfirmations,
+		Label:             rpcTx.Label,
+		BlockHash:         rpcTx.BlockHash,
+		BlockHeight:       rpcTx.BlockHeight,
+		OutputDetails:     rpcTx.OutputDetails,
+		PreviousOutpoints: rpcTx.PreviousOutpoints,
+	}, nil
+}
+
+// PublishTransaction broadcasts the transaction with an optional label.
+func (m *walletKitClient) PublishTransaction(ctx context.Context,
+	tx *wire.MsgTx, label string) error {
+
+	txRaw, err := encodeTx(tx)
+	if err != nil {
+		return err
+	}
+
+	req := &walletrpc.Transaction{
+		TxHex: txRaw,
+		Label: label,
+	}
+
+	return m.conn.post(
+		ctx, pathPublishTx, req, &walletrpc.PublishResponse{},
+	)
+}
+
+// EstimateFeeRate estimates the fee rate (sat/kw) for the confirmation target.
+func (m *walletKitClient) EstimateFeeRate(ctx context.Context,
+	confTarget int32) (chainfee.SatPerKWeight, error) {
+
+	// The confirmation target is bound as a path parameter on this GET
+	// endpoint, so it is appended to the path rather than sent as a body.
+	path := pathEstimateFee + "/" + strconv.FormatInt(int64(confTarget), 10)
+
+	resp := &walletrpc.EstimateFeeResponse{}
+	if err := m.conn.get(ctx, path, resp); err != nil {
+		return 0, err
+	}
+
+	return chainfee.SatPerKWeight(resp.SatPerKw), nil
+}
+
+// ImportTaprootScript imports a taproot script as a watch-only address.
+func (m *walletKitClient) ImportTaprootScript(ctx context.Context,
+	tapscript *waddrmgr.Tapscript) (btcaddr.Address, error) {
+
+	if tapscript == nil {
+		return nil, fmt.Errorf("invalid tapscript")
+	}
+
+	rpcReq, err := marshalTapscriptImport(tapscript)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &walletrpc.ImportTapscriptResponse{}
+	if err := m.conn.post(ctx, pathImportTapscr, rpcReq, resp); err != nil {
+		return nil, fmt.Errorf("import tapscript into lnd: %w", err)
+	}
+
+	addr, err := btcaddr.DecodeAddress(resp.P2TrAddress, m.conn.params)
+	if err != nil {
+		return nil, fmt.Errorf("parse imported p2tr addr: %w", err)
+	}
+
+	return addr, nil
+}
+
+// marshalTapscriptImport converts a waddrmgr tapscript into the walletrpc
+// import request, mirroring lndclient's own marshalling across the four
+// tapscript representations.
+func marshalTapscriptImport(tapscript *waddrmgr.Tapscript) (
+	*walletrpc.ImportTapscriptRequest, error) {
+
+	var (
+		rpcReq    = &walletrpc.ImportTapscriptRequest{}
+		ctrlBlock = tapscript.ControlBlock
+	)
+
+	switch tapscript.Type {
+	case waddrmgr.TapscriptTypeFullTree:
+		rpcReq.InternalPublicKey = schnorr.SerializePubKey(
+			ctrlBlock.InternalKey,
+		)
+
+		rpcLeaves := make([]*walletrpc.TapLeaf, len(tapscript.Leaves))
+		for idx, leaf := range tapscript.Leaves {
+			rpcLeaves[idx] = &walletrpc.TapLeaf{
+				LeafVersion: uint32(leaf.LeafVersion),
+				Script:      leaf.Script,
+			}
+		}
+		rpcReq.Script = &walletrpc.ImportTapscriptRequest_FullTree{
+			FullTree: &walletrpc.TapscriptFullTree{
+				AllLeaves: rpcLeaves,
+			},
+		}
+
+	case waddrmgr.TapscriptTypePartialReveal:
+		rpcReq.InternalPublicKey = schnorr.SerializePubKey(
+			ctrlBlock.InternalKey,
+		)
+		rpcReq.Script = &walletrpc.ImportTapscriptRequest_PartialReveal{
+			PartialReveal: &walletrpc.TapscriptPartialReveal{
+				RevealedLeaf: &walletrpc.TapLeaf{
+					LeafVersion: uint32(
+						ctrlBlock.LeafVersion,
+					),
+					Script: tapscript.RevealedScript,
+				},
+				FullInclusionProof: ctrlBlock.InclusionProof,
+			},
+		}
+
+	case waddrmgr.TaprootKeySpendRootHash:
+		rpcReq.InternalPublicKey = schnorr.SerializePubKey(
+			ctrlBlock.InternalKey,
+		)
+		rpcReq.Script = &walletrpc.ImportTapscriptRequest_RootHashOnly{
+			RootHashOnly: tapscript.RootHash,
+		}
+
+	case waddrmgr.TaprootFullKeyOnly:
+		rpcReq.InternalPublicKey = schnorr.SerializePubKey(
+			tapscript.FullOutputKey,
+		)
+		rpcReq.Script = &walletrpc.ImportTapscriptRequest_FullKeyOnly{
+			FullKeyOnly: true,
+		}
+
+	default:
+		return nil, fmt.Errorf("invalid tapscript type <%d>",
+			tapscript.Type)
+	}
+
+	return rpcReq, nil
+}
+
+// The methods below are part of the lndclient.WalletKitClient interface but are
+// not used by the waved wallet backend. They are stubbed to fail loudly if an
+// unexpected caller reaches them over the REST transport.
+
+// ListLeases is unsupported over REST.
+func (m *walletKitClient) ListLeases(_ context.Context) (
+	[]lndclient.LeaseDescriptor, error) {
+
+	return nil, errUnsupportedOverREST
+}
+
+// SubmitPackage is unsupported over REST.
+func (m *walletKitClient) SubmitPackage(_ context.Context, _ []*wire.MsgTx,
+	_ *chainfee.SatPerVByte) (*lndclient.SubmitPackageResult, error) {
+
+	return nil, errUnsupportedOverREST
+}
+
+// SendOutputs is unsupported over REST.
+func (m *walletKitClient) SendOutputs(_ context.Context, _ []*wire.TxOut,
+	_ chainfee.SatPerKWeight, _ string) (*wire.MsgTx, error) {
+
+	return nil, errUnsupportedOverREST
+}
+
+// MinRelayFee is unsupported over REST.
+func (m *walletKitClient) MinRelayFee(_ context.Context) (
+	chainfee.SatPerKWeight, error) {
+
+	return 0, errUnsupportedOverREST
+}
+
+// ListSweeps is unsupported over REST.
+func (m *walletKitClient) ListSweeps(_ context.Context, _ int32) ([]string,
+	error) {
+
+	return nil, errUnsupportedOverREST
+}
+
+// ListSweepsVerbose is unsupported over REST.
+func (m *walletKitClient) ListSweepsVerbose(_ context.Context, _ int32) (
+	[]lnwallet.TransactionDetail, error) {
+
+	return nil, errUnsupportedOverREST
+}
+
+// BumpFee is unsupported over REST.
+func (m *walletKitClient) BumpFee(_ context.Context, _ wire.OutPoint,
+	_ chainfee.SatPerKWeight, _ ...lndclient.BumpFeeOption) error {
+
+	return errUnsupportedOverREST
+}
+
+// ListAccounts is unsupported over REST.
+func (m *walletKitClient) ListAccounts(_ context.Context, _ string,
+	_ walletrpc.AddressType) ([]*walletrpc.Account, error) {
+
+	return nil, errUnsupportedOverREST
+}
+
+// FundPsbt is unsupported over REST.
+func (m *walletKitClient) FundPsbt(_ context.Context,
+	_ *walletrpc.FundPsbtRequest) (*psbt.Packet, int32,
+	[]*walletrpc.UtxoLease, error) {
+
+	return nil, 0, nil, errUnsupportedOverREST
+}
+
+// SignPsbt is unsupported over REST.
+func (m *walletKitClient) SignPsbt(_ context.Context, _ *psbt.Packet) (
+	*psbt.Packet, error) {
+
+	return nil, errUnsupportedOverREST
+}
+
+// FinalizePsbt is unsupported over REST.
+func (m *walletKitClient) FinalizePsbt(_ context.Context, _ *psbt.Packet,
+	_ string) (*psbt.Packet, *wire.MsgTx, error) {
+
+	return nil, nil, errUnsupportedOverREST
+}
+
+// ImportPublicKey is unsupported over REST.
+func (m *walletKitClient) ImportPublicKey(_ context.Context, _ *btcec.PublicKey,
+	_ lnwallet.AddressType) error {
+
+	return errUnsupportedOverREST
+}

--- a/lndrest/walletkit.go
+++ b/lndrest/walletkit.go
@@ -222,7 +222,11 @@ func (m *walletKitClient) NextAddr(ctx context.Context, accountName string,
 		return nil, err
 	}
 
-	return btcaddr.DecodeAddress(resp.Addr, nil)
+	// Decode against the configured chain params so a network-mismatched
+	// address is rejected, matching ImportTaprootScript below (bech32/
+	// bech32m HRPs are self-describing, but pinning the network is
+	// defense-in-depth and keeps the two decode sites consistent).
+	return btcaddr.DecodeAddress(resp.Addr, m.conn.params)
 }
 
 // GetTransaction returns wallet details for the given txid.

--- a/rpc/restclient/client.go
+++ b/rpc/restclient/client.go
@@ -120,6 +120,29 @@ func (c *Client) Post(ctx context.Context, path string, in proto.Message,
 		return err
 	}
 
+	return c.doUnary(req, out)
+}
+
+// Get sends one unary grpc-gateway GET request and unmarshals the response.
+// The path must already carry any query string the endpoint binds its request
+// fields from, since a GET request carries no body. This is required for
+// grpc-gateway services (such as lnd's ChainKit and Lightning services) that
+// expose read RPCs over HTTP GET rather than POST.
+func (c *Client) Get(ctx context.Context, path string,
+	out proto.Message) error {
+
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.doUnary(req, out)
+}
+
+// doUnary executes a prepared unary HTTP request and decodes the JSON response
+// into out, mapping any gateway HTTP error into a gRPC status error. It is the
+// shared response-handling core of Post and Get.
+func (c *Client) doUnary(req *http.Request, out proto.Message) error {
 	//nolint:gosec // The caller explicitly configures the gateway URL.
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/sample-waved.conf
+++ b/sample-waved.conf
@@ -89,8 +89,13 @@
 # it to a loopback or firewalled address only.
 # metrics.listen=
 
-# lnd gRPC address.
+# lnd endpoint. For the grpc transport this is a host:port gRPC address; for
+# the rest transport it is an HTTP gateway base URL (for example
+# https://localhost:8080).
 # lnd.host=localhost:10009
+
+# lnd RPC transport: grpc (native gRPC) or rest (lnd's HTTP/JSON gateway).
+# lnd.transport=grpc
 
 # Path to lnd's TLS certificate. Empty uses the default lnd location.
 # lnd.tlspath=

--- a/systest/lnd_rest_test.go
+++ b/systest/lnd_rest_test.go
@@ -1,0 +1,47 @@
+//go:build systest
+
+package systest
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/wavelength/waved"
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLNDRESTBackendListVTXO exercises the lnd wallet backend over the REST
+// transport end to end: it stands up a full waved daemon whose LndConfig
+// selects the rest transport pointed at the harness lnd REST gateway, then
+// verifies the daemon connects (GetInfo over REST seeds the node identity) and
+// serves the seeded live VTXO through its wallet surface.
+//
+// This complements the gRPC-backed send/receive coverage: it proves the REST
+// adapter's connect path (GetInfo), the lnd chain backend wired over REST
+// (block-epoch notifications + fee estimation), and the daemon reaching
+// readiness while backed by REST rather than gRPC.
+func TestLNDRESTBackendListVTXO(t *testing.T) {
+	ParallelN(t)
+
+	fixture := newDirectedSendFixture(t, func(cfg *waved.Config) {
+		cfg.Lnd.Transport = waved.RPCTransportREST
+	})
+
+	// The daemon reached readiness in launch(); confirm the REST GetInfo
+	// round-trip populated the lnd node identity on the daemon status.
+	info, err := fixture.client.GetInfo(
+		t.Context(), &waverpc.GetInfoRequest{},
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, info.LndIdentityPubkey)
+
+	// The seeded live VTXO must be visible through the REST-backed wallet.
+	vtxos := listAllVTXOs(t, fixture.client)
+	require.Len(t, vtxos, 1)
+	require.Equal(
+		t, waverpc.VTXOStatus_VTXO_STATUS_LIVE, vtxos[0].Status,
+	)
+
+	vtxoInfo := findVTXOByOutpoint(vtxos, fixture.seededOutpoint)
+	require.NotNil(t, vtxoInfo)
+}

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -57,6 +57,16 @@ const (
 
 	// testDustLimitSat is the fake operator dust limit used by the test.
 	testDustLimitSat = int64(546)
+
+	// systestLNDTransportEnv is the environment variable that selects the
+	// lnd wallet transport for every daemon built by
+	// newDirectedSendFixture. When set to the REST transport value it
+	// defaults the whole directed-send/OOR suite onto the lnd REST backend
+	// (a per-test config mutator still overrides it), so CI can rerun the
+	// signing-capable send/OOR flows against REST-backed lnd without
+	// duplicating the test bodies. Unset (or "grpc") keeps the historical
+	// gRPC path, so local `make systest` behaviour is unchanged.
+	systestLNDTransportEnv = "ARK_SYSTEST_LND_TRANSPORT"
 )
 
 // fakeMailboxServer implements just enough of the operator mailbox edge for the
@@ -590,6 +600,14 @@ func newDirectedSendFixture(t *testing.T,
 	cfg.RPC.Gateway.ListenAddr = newLoopbackAddr(t)
 	cfg.RPC.NoTLS = true
 	cfg.RPC.NoMacaroons = true
+
+	// Default the lnd transport from the environment so a CI job can rerun
+	// the signing-capable send/OOR flows over REST without a per-test
+	// mutator. Applied before the mutators below so an explicit per-test
+	// mutator still wins.
+	if os.Getenv(systestLNDTransportEnv) == string(waved.RPCTransportREST) {
+		cfg.Lnd.Transport = waved.RPCTransportREST
+	}
 
 	for _, mutate := range cfgMutators {
 		mutate(cfg)

--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -595,6 +595,17 @@ func newDirectedSendFixture(t *testing.T,
 		mutate(cfg)
 	}
 
+	// When a mutator opts the lnd backend into the REST transport, point
+	// the host at the harness lnd REST gateway port (8080) instead of the
+	// gRPC port set above. The TLS cert and macaroon paths are unchanged;
+	// the lndrest client reads the same files and reaches lnd's
+	// grpc-gateway over HTTPS.
+	if cfg.Lnd.Transport == waved.RPCTransportREST {
+		cfg.Lnd.Host = net.JoinHostPort(
+			"localhost", h.Harness.LNDRestPort,
+		)
+	}
+
 	seededOutpoint := seedLiveVTXO(
 		t, cfg, operatorPriv.PubKey(),
 		btcutil.Amount(testSeededAmountSat),

--- a/waved/boarding_sweep.go
+++ b/waved/boarding_sweep.go
@@ -34,12 +34,12 @@ func (s *Server) newSweepWallet() (unroll.SweepWallet, error) {
 			return nil, fmt.Errorf("lnd wallet not initialized")
 		}
 
-		lndSvc := s.lnd.UnsafeFromSome()
+		services := s.lnd.UnsafeFromSome().Services()
 		clientWallet := lndbackend.NewClientWallet(
-			lndSvc.Signer, lndSvc.WalletKit,
+			services.Signer, services.WalletKit,
 		)
 		boardingBackend := lndbackend.NewBoardingBackend(
-			lndSvc.WalletKit, lndSvc.ChainKit,
+			services.WalletKit, services.ChainKit,
 		)
 
 		return &lndUnrollWallet{

--- a/waved/config.go
+++ b/waved/config.go
@@ -1315,6 +1315,16 @@ func (c *Config) validateWalletConfig() error {
 			return err
 		}
 
+		// The REST transport cannot resolve lnd's per-network default
+		// macaroon path on its own (unlike the gRPC lndclient), so it
+		// must be given explicitly. Fail here at config-validation time
+		// rather than later at connect time.
+		if c.Lnd.Transport == RPCTransportREST &&
+			c.Lnd.MacaroonPath == "" {
+			return fmt.Errorf("lnd.macaroonpath is required when " +
+				"lnd.transport is rest")
+		}
+
 	case WalletTypeLwwallet:
 		// Lightweight wallet requires an Esplora URL for chain
 		// data. An empty value falls back to the network-default

--- a/waved/config.go
+++ b/waved/config.go
@@ -877,8 +877,17 @@ type MailboxEdgeFactory func(
 
 // LndConfig holds connection parameters for the backing lnd node.
 type LndConfig struct {
-	// Host is the network address of the lnd gRPC interface.
+	// Host is the lnd endpoint. Its meaning follows Transport: a
+	// host:port gRPC address for grpc, or an HTTP gateway base URL (for
+	// example https://localhost:8080) for rest. The REST client infers the
+	// scheme when the configured host is bare (loopback -> http, otherwise
+	// https).
 	Host string `mapstructure:"host"`
+
+	// Transport selects how the daemon talks to lnd: grpc uses the native
+	// gRPC lndclient, rest uses lnd's grpc-gateway HTTP/JSON interface.
+	// Empty values default to gRPC to preserve the historical behavior.
+	Transport string `mapstructure:"transport"`
 
 	// TLSPath is the path to lnd's TLS certificate file. If empty, the
 	// default lnd TLS cert location is used.
@@ -1116,6 +1125,7 @@ func DefaultConfig() *Config {
 		DebugLevel: DefaultDebugLevel,
 		Lnd: &LndConfig{
 			Host:       DefaultLndHost,
+			Transport:  RPCTransportGRPC,
 			RPCTimeout: DefaultRPCTimeout,
 		},
 		Server: &ServerConfig{
@@ -1298,6 +1308,11 @@ func (c *Config) validateWalletConfig() error {
 		if c.Lnd.Host == "" {
 			return fmt.Errorf("lnd host is required when " +
 				"wallet.type is lnd")
+		}
+		if err := validateRPCTransport(
+			"lnd.transport", c.Lnd.Transport,
+		); err != nil {
+			return err
 		}
 
 	case WalletTypeLwwallet:

--- a/waved/config_lnd_transport_test.go
+++ b/waved/config_lnd_transport_test.go
@@ -7,35 +7,42 @@ import (
 )
 
 // TestConfigValidateLndTransport asserts the lnd.transport selector: an empty
-// value and "grpc" both mean gRPC and are accepted, "rest" is accepted, and any
-// other value is rejected with an lnd.transport-scoped error.
+// value and "grpc" both mean gRPC and are accepted, "rest" is accepted (but
+// requires lnd.macaroonpath, since REST cannot resolve the per-network default
+// path), and any other value is rejected with an lnd.transport-scoped error.
 func TestConfigValidateLndTransport(t *testing.T) {
 	t.Parallel()
 
+	const macPath = "/tmp/admin.macaroon"
+
 	cases := []struct {
-		name      string
-		transport string
-		wantErr   bool
+		name            string
+		transport       string
+		macaroonPath    string
+		wantErrContains string
 	}{
 		{
 			name:      "empty defaults to grpc",
 			transport: "",
-			wantErr:   false,
 		},
 		{
 			name:      "grpc",
 			transport: RPCTransportGRPC,
-			wantErr:   false,
 		},
 		{
-			name:      "rest",
-			transport: RPCTransportREST,
-			wantErr:   false,
+			name:         "rest with macaroon",
+			transport:    RPCTransportREST,
+			macaroonPath: macPath,
 		},
 		{
-			name:      "unknown",
-			transport: "http2",
-			wantErr:   true,
+			name:            "rest without macaroon",
+			transport:       RPCTransportREST,
+			wantErrContains: "lnd.macaroonpath",
+		},
+		{
+			name:            "unknown",
+			transport:       "http2",
+			wantErrContains: "lnd.transport",
 		},
 	}
 
@@ -48,13 +55,13 @@ func TestConfigValidateLndTransport(t *testing.T) {
 			cfg.Wallet.Type = WalletTypeLnd
 			cfg.Lnd.Host = "127.0.0.1:10009"
 			cfg.Lnd.Transport = tc.transport
+			cfg.Lnd.MacaroonPath = tc.macaroonPath
 
 			err := cfg.Validate()
-			if tc.wantErr {
+			if tc.wantErrContains != "" {
 				require.Error(t, err)
 				require.Contains(
-					t, err.Error(),
-					"lnd.transport",
+					t, err.Error(), tc.wantErrContains,
 				)
 
 				return

--- a/waved/config_lnd_transport_test.go
+++ b/waved/config_lnd_transport_test.go
@@ -1,0 +1,75 @@
+package waved
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigValidateLndTransport asserts the lnd.transport selector: an empty
+// value and "grpc" both mean gRPC and are accepted, "rest" is accepted, and any
+// other value is rejected with an lnd.transport-scoped error.
+func TestConfigValidateLndTransport(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		transport string
+		wantErr   bool
+	}{
+		{
+			name:      "empty defaults to grpc",
+			transport: "",
+			wantErr:   false,
+		},
+		{
+			name:      "grpc",
+			transport: RPCTransportGRPC,
+			wantErr:   false,
+		},
+		{
+			name:      "rest",
+			transport: RPCTransportREST,
+			wantErr:   false,
+		},
+		{
+			name:      "unknown",
+			transport: "http2",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := DefaultConfig()
+			cfg.Network = "regtest"
+			cfg.Wallet.Type = WalletTypeLnd
+			cfg.Lnd.Host = "127.0.0.1:10009"
+			cfg.Lnd.Transport = tc.transport
+
+			err := cfg.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(
+					t, err.Error(),
+					"lnd.transport",
+				)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestDefaultConfigLndTransportGRPC locks in the default: DefaultConfig selects
+// the gRPC transport so an operator building from defaults keeps the historical
+// behavior.
+func TestDefaultConfigLndTransportGRPC(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, RPCTransportGRPC, DefaultConfig().Lnd.Transport)
+}

--- a/waved/lnd_services.go
+++ b/waved/lnd_services.go
@@ -1,0 +1,40 @@
+package waved
+
+import (
+	"github.com/lightninglabs/lndclient"
+)
+
+// lndServices is the seam over a connected lnd backend. Both the native gRPC
+// lndclient (via grpcLndServices) and the REST-backed lndrest backend satisfy
+// it, so the daemon can talk to lnd over either transport without the rest of
+// the server branching on the concrete connection type. It exposes the shared
+// *lndclient.LndServices payload (Signer / WalletKit / ChainKit /
+// ChainNotifier / Client plus ChainParams / NodeAlias / NodePubkey) and the
+// resource-releasing Close.
+type lndServices interface {
+	// Services returns the populated lndclient service payload. Callers
+	// read the interface-typed subsystem clients (Signer, WalletKit,
+	// ChainKit, ChainNotifier, Client) and the connection metadata
+	// (ChainParams, NodeAlias, NodePubkey) from it.
+	Services() *lndclient.LndServices
+
+	// Close releases the resources held by the backend (the gRPC
+	// connection for the native path, streaming goroutines for REST).
+	Close()
+}
+
+// grpcLndServices adapts the native gRPC *lndclient.GrpcLndServices to the
+// lndServices seam. GrpcLndServices embeds LndServices by value and already
+// has Close, so the only method it lacks is the Services accessor, which
+// returns the address of the embedded payload.
+type grpcLndServices struct {
+	*lndclient.GrpcLndServices
+}
+
+// Services returns the embedded lndclient service payload.
+func (g *grpcLndServices) Services() *lndclient.LndServices {
+	return &g.GrpcLndServices.LndServices
+}
+
+// A compile-time check that grpcLndServices satisfies the lndServices seam.
+var _ lndServices = (*grpcLndServices)(nil)

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -24,7 +24,6 @@ import (
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
-	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/wavelength/baselib/actor"
 	"github.com/lightninglabs/wavelength/btcwbackend"
 	"github.com/lightninglabs/wavelength/build"
@@ -553,16 +552,17 @@ func (r *RPCServer) GetInfo(ctx context.Context, _ *waverpc.GetInfoRequest) (
 
 	// Populate lnd fields if connected.
 	r.server.lnd.WhenSome(
-		func(lndSvc *lndclient.GrpcLndServices) {
+		func(lndSvc lndServices) {
+			services := lndSvc.Services()
 			resp.LndIdentityPubkey =
-				lndSvc.NodePubkey.String()
-			resp.LndAlias = lndSvc.NodeAlias
+				services.NodePubkey.String()
+			resp.LndAlias = services.NodeAlias
 
 			// Fetch the current best block height from
 			// the chain backend via lnd's ChainKit
 			// interface.
 			_, height, err :=
-				lndSvc.ChainKit.GetBestBlock(ctx)
+				services.ChainKit.GetBestBlock(ctx)
 			if err != nil {
 				r.server.log.WarnS(
 					ctx,
@@ -937,11 +937,11 @@ type onchainWalletConfirmedFetcher func(
 func (r *RPCServer) walletBalanceFetchers() []onchainWalletConfirmedFetcher {
 	var fetchers []onchainWalletConfirmedFetcher
 
-	r.server.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
+	r.server.lnd.WhenSome(func(lndSvc lndServices) {
 		fetchers = append(fetchers, func(ctx context.Context) (
 			btcutil.Amount, error) {
 
-			wb, err := lndSvc.Client.WalletBalance(ctx)
+			wb, err := lndSvc.Services().Client.WalletBalance(ctx)
 			if err != nil {
 				return 0, fmt.Errorf("lnd wallet balance: %w",
 					err)
@@ -1022,9 +1022,9 @@ func (r *RPCServer) metricsWalletBalance(ctx context.Context) (int64, int64,
 		found                  bool
 		qErr                   error
 	)
-	r.server.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
+	r.server.lnd.WhenSome(func(lndSvc lndServices) {
 		found = true
-		wb, balErr := lndSvc.Client.WalletBalance(ctx)
+		wb, balErr := lndSvc.Services().Client.WalletBalance(ctx)
 		if balErr != nil {
 			qErr = fmt.Errorf("lnd wallet balance: %w", balErr)
 
@@ -1075,9 +1075,9 @@ func (r *RPCServer) metricsBlockHeight(ctx context.Context) (int64, error) {
 		found  bool
 		qErr   error
 	)
-	r.server.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
+	r.server.lnd.WhenSome(func(lndSvc lndServices) {
 		found = true
-		_, h, hErr := lndSvc.ChainKit.GetBestBlock(ctx)
+		_, h, hErr := lndSvc.Services().ChainKit.GetBestBlock(ctx)
 		if hErr != nil {
 			qErr = fmt.Errorf("lnd best block: %w", hErr)
 

--- a/waved/rpc_vtxo_expiry.go
+++ b/waved/rpc_vtxo_expiry.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/wavelength/arkrpc"
 	"github.com/lightninglabs/wavelength/indexer"
 	"github.com/lightninglabs/wavelength/vtxo"
@@ -194,8 +193,9 @@ func (r *RPCServer) currentBlockHeight(ctx context.Context) (int32, error) {
 		found  bool
 	)
 
-	r.server.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
-		_, bestHeight, bestErr := lndSvc.ChainKit.GetBestBlock(ctx)
+	r.server.lnd.WhenSome(func(lndSvc lndServices) {
+		chainKit := lndSvc.Services().ChainKit
+		_, bestHeight, bestErr := chainKit.GetBestBlock(ctx)
 		if bestErr != nil {
 			err = fmt.Errorf("fetch lnd best block: %w", bestErr)
 

--- a/waved/rpc_wallet.go
+++ b/waved/rpc_wallet.go
@@ -128,9 +128,9 @@ func (r *RPCServer) deriveReceiveAuthKey(ctx context.Context,
 				"connected")
 		}
 
-		lndSvc := r.server.lnd.UnsafeFromSome()
+		services := r.server.lnd.UnsafeFromSome().Services()
 
-		base, err = lndSvc.Signer.DeriveSharedKey(
+		base, err = services.Signer.DeriveSharedKey(
 			ctx, lndclient.SharedKeyNUMS,
 			lndclient.SharedKeyLocator,
 		)
@@ -480,8 +480,8 @@ func (r *RPCServer) deriveIdentityPubkey(ctx context.Context) (string, error) {
 			return "", fmt.Errorf("lnd wallet not connected")
 		}
 
-		lndSvc := r.server.lnd.UnsafeFromSome()
-		desc, err = lndSvc.WalletKit.DeriveKey(ctx, &loc)
+		services := r.server.lnd.UnsafeFromSome().Services()
+		desc, err = services.WalletKit.DeriveKey(ctx, &loc)
 
 	case WalletTypeLwwallet:
 		// GetInfo is intentionally callable before InitWallet /

--- a/waved/server.go
+++ b/waved/server.go
@@ -45,6 +45,7 @@ import (
 	"github.com/lightninglabs/wavelength/lib/recovery"
 	"github.com/lightninglabs/wavelength/lib/types"
 	"github.com/lightninglabs/wavelength/lndbackend"
+	"github.com/lightninglabs/wavelength/lndrest"
 	"github.com/lightninglabs/wavelength/lwwallet"
 	mailboxpb "github.com/lightninglabs/wavelength/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/wavelength/mailbox/rpc"
@@ -209,9 +210,11 @@ type Server struct {
 	// off.
 	metricsSink fn.Option[metrics.Sink]
 
-	// lnd holds the lndclient connection when wallet.type is "lnd".
-	// It is None in lwwallet mode.
-	lnd fn.Option[*lndclient.GrpcLndServices]
+	// lnd holds the connected lnd backend when wallet.type is "lnd". The
+	// concrete implementation is either the native gRPC lndclient
+	// (grpcLndServices) or the REST-backed lndrest backend, selected by
+	// lnd.transport. It is None in lwwallet/btcwallet mode.
+	lnd fn.Option[lndServices]
 
 	// lwWallet holds the lightweight wallet instance when
 	// wallet.type is "lwwallet". It is None in lnd mode.
@@ -1541,19 +1544,20 @@ func (s *Server) initLndBackend(ctx context.Context) error {
 	s.log.InfoS(ctx, "Connecting to lnd",
 		"host", s.cfg.Lnd.Host)
 
-	lndServices, err := s.connectLnd(ctx)
+	lndSvc, err := s.connectLnd(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to connect to lnd: %w", err)
 	}
-	s.lnd = fn.Some(lndServices)
+	s.lnd = fn.Some(lndSvc)
 	s.refreshProofKeyBackend()
 
 	// Use lnd's chain params as the authoritative source.
-	s.chainParams = lndServices.ChainParams
+	services := lndSvc.Services()
+	s.chainParams = services.ChainParams
 
 	s.log.InfoS(ctx, "Connected to lnd",
-		"alias", lndServices.NodeAlias,
-		"pubkey", lndServices.NodePubkey,
+		"alias", services.NodeAlias,
+		"pubkey", services.NodePubkey,
 	)
 
 	// In lnd mode the wallet is immediately ready.
@@ -1569,9 +1573,9 @@ func (s *Server) refreshProofKeyBackend() {
 	switch s.cfg.Wallet.Type {
 	case WalletTypeLnd:
 		if s.lnd.IsSome() {
-			lndSvc := s.lnd.UnsafeFromSome()
+			services := s.lnd.UnsafeFromSome().Services()
 			s.proofKeyBackend = lndbackend.NewProofKeyBackend(
-				lndSvc.WalletKit, lndSvc.Signer,
+				services.WalletKit, services.Signer,
 			)
 
 			return
@@ -2224,10 +2228,10 @@ func (s *Server) initChainBackend(ctx context.Context) error {
 
 	switch s.cfg.Wallet.Type {
 	case WalletTypeLnd:
-		lndSvc := s.lnd.UnsafeFromSome()
+		services := s.lnd.UnsafeFromSome().Services()
 		notifier := chainbackends.NewLndClientChainNotifier(
 			chainbackends.LndClientChainNotifierConfig{
-				LND: &lndSvc.LndServices,
+				LND: services,
 				Log: fn.Some(
 					s.subLogger(
 						chainbackends.
@@ -2236,14 +2240,14 @@ func (s *Server) initChainBackend(ctx context.Context) error {
 				),
 			},
 		)
-		feeEstimator, err := s.lndFeeEstimator(ctx, lndSvc.WalletKit)
+		feeEstimator, err := s.lndFeeEstimator(ctx, services.WalletKit)
 		if err != nil {
 			return fmt.Errorf("create lnd fee estimator: %w", err)
 		}
 		backend := chainbackends.NewLNDBackend(
 			notifier, feeEstimator,
 			chainbackends.NewLndClientTxBroadcaster(
-				lndSvc.WalletKit,
+				services.WalletKit,
 			),
 		)
 		backend.Log = fn.Some(s.subLogger(chainbackends.Subsystem))
@@ -2259,7 +2263,7 @@ func (s *Server) initChainBackend(ctx context.Context) error {
 
 		default:
 			backend.SetPackageSubmitter(
-				lndsubmitter.New(lndSvc.WalletKit),
+				lndsubmitter.New(services.WalletKit),
 			)
 		}
 
@@ -2598,11 +2602,23 @@ func (s *Server) applyDebugLevel() error {
 	return nil
 }
 
-// connectLnd establishes a connection to the lnd node using the lndclient
-// SDK. The call blocks until lnd is fully synced and the wallet is unlocked.
-func (s *Server) connectLnd(ctx context.Context) (*lndclient.GrpcLndServices,
-	error) {
+// connectLnd establishes a connection to the lnd node over the configured
+// transport, returning the transport-agnostic lndServices seam. It dispatches
+// to the native gRPC lndclient or the REST-backed lndrest backend based on
+// cfg.Lnd.Transport (empty defaults to gRPC).
+func (s *Server) connectLnd(ctx context.Context) (lndServices, error) {
+	switch s.cfg.Lnd.Transport {
+	case RPCTransportREST:
+		return s.connectLndREST(ctx)
 
+	default:
+		return s.connectLndGRPC(ctx)
+	}
+}
+
+// connectLndGRPC connects to lnd using the native gRPC lndclient SDK. The call
+// blocks until lnd is fully synced and the wallet is unlocked.
+func (s *Server) connectLndGRPC(ctx context.Context) (lndServices, error) {
 	network, err := networkToLndclient(s.cfg.Network)
 	if err != nil {
 		return nil, err
@@ -2613,7 +2629,7 @@ func (s *Server) connectLnd(ctx context.Context) (*lndclient.GrpcLndServices,
 		rpcTimeout = DefaultRPCTimeout
 	}
 
-	return lndclient.NewLndServices(&lndclient.LndServicesConfig{
+	grpcSvc, err := lndclient.NewLndServices(&lndclient.LndServicesConfig{
 		LndAddress:            s.cfg.Lnd.Host,
 		Network:               network,
 		CustomMacaroonPath:    s.cfg.Lnd.MacaroonPath,
@@ -2622,6 +2638,30 @@ func (s *Server) connectLnd(ctx context.Context) (*lndclient.GrpcLndServices,
 		BlockUntilUnlocked:    true,
 		CallerCtx:             ctx,
 		RPCTimeout:            rpcTimeout,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &grpcLndServices{GrpcLndServices: grpcSvc}, nil
+}
+
+// connectLndREST connects to lnd over its grpc-gateway HTTP/JSON interface via
+// the lndrest backend. Unlike the gRPC path it does not block on chain sync or
+// wallet unlock; the initial GetInfo round-trip inside lndrest.New both proves
+// connectivity and seeds the node metadata.
+func (s *Server) connectLndREST(ctx context.Context) (lndServices, error) {
+	rpcTimeout := s.cfg.Lnd.RPCTimeout
+	if rpcTimeout == 0 {
+		rpcTimeout = DefaultRPCTimeout
+	}
+
+	return lndrest.New(ctx, lndrest.Config{
+		Host:         s.cfg.Lnd.Host,
+		TLSPath:      s.cfg.Lnd.TLSPath,
+		MacaroonPath: s.cfg.Lnd.MacaroonPath,
+		RPCTimeout:   rpcTimeout,
+		ChainParams:  s.chainParams,
 	})
 }
 
@@ -3895,9 +3935,9 @@ func (s *Server) initWalletActor(ctx context.Context,
 	var boardingBackend wallet.BoardingBackend
 	switch s.cfg.Wallet.Type {
 	case WalletTypeLnd:
-		lndSvc := s.lnd.UnsafeFromSome()
+		services := s.lnd.UnsafeFromSome().Services()
 		backend := lndbackend.NewBoardingBackend(
-			lndSvc.WalletKit, lndSvc.ChainKit,
+			services.WalletKit, services.ChainKit,
 		)
 		backend.Log = fn.Some(s.subLogger(lndbackend.Subsystem))
 		boardingBackend = backend
@@ -4050,9 +4090,9 @@ func (s *Server) initRoundActor(ctx context.Context,
 	var clientWallet round.ClientWallet
 	switch s.cfg.Wallet.Type {
 	case WalletTypeLnd:
-		lndSvc := s.lnd.UnsafeFromSome()
+		services := s.lnd.UnsafeFromSome().Services()
 		lndWallet := lndbackend.NewClientWallet(
-			lndSvc.Signer, lndSvc.WalletKit,
+			services.Signer, services.WalletKit,
 		)
 		lndWallet.Log = fn.Some(s.subLogger(lndbackend.Subsystem))
 		clientWallet = lndWallet
@@ -4198,9 +4238,9 @@ func (s *Server) initVTXOManager(ctx context.Context,
 	var vtxoWallet vtxo.VTXOWallet
 	switch s.cfg.Wallet.Type {
 	case WalletTypeLnd:
-		lndSvc := s.lnd.UnsafeFromSome()
+		services := s.lnd.UnsafeFromSome().Services()
 		lndWallet := lndbackend.NewClientWallet(
-			lndSvc.Signer, lndSvc.WalletKit,
+			services.Signer, services.WalletKit,
 		)
 		lndWallet.Log = fn.Some(s.subLogger(lndbackend.Subsystem))
 		vtxoWallet = lndWallet
@@ -4547,9 +4587,9 @@ func (s *Server) initOORActor(ctx context.Context,
 func (s *Server) oorSigner() (input.Signer, error) {
 	switch s.cfg.Wallet.Type {
 	case WalletTypeLnd:
-		lndSvc := s.lnd.UnsafeFromSome()
+		services := s.lnd.UnsafeFromSome().Services()
 		lndWallet := lndbackend.NewClientWallet(
-			lndSvc.Signer, lndSvc.WalletKit,
+			services.Signer, services.WalletKit,
 		)
 		lndWallet.Log = fn.Some(s.subLogger(lndbackend.Subsystem))
 
@@ -4654,8 +4694,8 @@ func (s *Server) deriveIdentityKeyEarly(ctx context.Context) error {
 		btcwErr error
 	)
 
-	s.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
-		desc, err := lndSvc.WalletKit.DeriveKey(ctx,
+	s.lnd.WhenSome(func(lndSvc lndServices) {
+		desc, err := lndSvc.Services().WalletKit.DeriveKey(ctx,
 			&keychain.KeyLocator{
 				Family: identityKeyFamily,
 				Index:  0,
@@ -4805,11 +4845,14 @@ func (s *Server) signTaggedSchnorr(ctx context.Context, msg, tag []byte,
 	// In LND mode, use lnd's tagged Schnorr signing RPC. We pass the
 	// raw message and tag so LND computes the BIP-340 tagged hash
 	// internally, avoiding double-hashing.
-	s.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
+	s.lnd.WhenSome(func(lndSvc lndServices) {
 		var rawSig []byte
-		rawSig, err = lndSvc.Signer.SignMessage(
-			ctx, msg, s.clientKeyDesc.KeyLocator,
-			lndclient.SignSchnorr(nil), withSchnorrTag(tag),
+		rawSig, err = lndSvc.Services().Signer.SignMessage(
+			ctx,
+			msg,
+			s.clientKeyDesc.KeyLocator,
+			lndclient.SignSchnorr(nil),
+			withSchnorrTag(tag),
 		)
 		if err != nil {
 			err = fmt.Errorf("lnd sign %s: %w", opName, err)
@@ -5341,12 +5384,12 @@ func (s *Server) initUnrollSubsystem(ctx context.Context,
 
 	switch s.cfg.Wallet.Type {
 	case WalletTypeLnd:
-		lndSvc := s.lnd.UnsafeFromSome()
+		services := s.lnd.UnsafeFromSome().Services()
 		clientWallet := lndbackend.NewClientWallet(
-			lndSvc.Signer, lndSvc.WalletKit,
+			services.Signer, services.WalletKit,
 		)
 		boardingBackend := lndbackend.NewBoardingBackend(
-			lndSvc.WalletKit, lndSvc.ChainKit,
+			services.WalletKit, services.ChainKit,
 		)
 		w := &lndUnrollWallet{
 			ClientWallet:    clientWallet,

--- a/waved/server.go
+++ b/waved/server.go
@@ -2662,6 +2662,7 @@ func (s *Server) connectLndREST(ctx context.Context) (lndServices, error) {
 		MacaroonPath: s.cfg.Lnd.MacaroonPath,
 		RPCTimeout:   rpcTimeout,
 		ChainParams:  s.chainParams,
+		Network:      s.cfg.Network,
 	})
 }
 

--- a/waved/wallet_testhooks.go
+++ b/waved/wallet_testhooks.go
@@ -19,9 +19,9 @@ func (s *Server) NewWalletAddress(ctx context.Context) (string, error) {
 	}
 
 	if s.lnd.IsSome() {
-		lndSvc := s.lnd.UnsafeFromSome()
+		services := s.lnd.UnsafeFromSome().Services()
 
-		addr, err := lndSvc.WalletKit.NextAddr(
+		addr, err := services.WalletKit.NextAddr(
 			ctx, lnwallet.DefaultAccountName,
 			walletrpc.AddressType_TAPROOT_PUBKEY, false,
 		)
@@ -96,9 +96,9 @@ func (s *Server) listBackingWalletUnspent(ctx context.Context, minConfs,
 	maxConfs int32) ([]*wallet.Utxo, error) {
 
 	if s.lnd.IsSome() {
-		lndSvc := s.lnd.UnsafeFromSome()
+		services := s.lnd.UnsafeFromSome().Services()
 		backend := lndbackend.NewBoardingBackend(
-			lndSvc.WalletKit, lndSvc.ChainKit,
+			services.WalletKit, services.ChainKit,
 		)
 
 		utxos, err := backend.ListUnspent(ctx, minConfs, maxConfs)


### PR DESCRIPTION
## What

Add a **REST transport option for the lnd wallet backend**, plus a CI
configuration that exercises it. Today `waved`'s lnd backend connects over
gRPC only (via `lndclient`, which has no REST mode). Set `lnd.transport=rest`
to talk to lnd over its grpc-gateway REST interface instead.

## Why

The lnd backend was gRPC-only, and a reviewer asked whether it could also run
over REST. lnd already exposes every subserver method the backend uses over
its grpc-gateway REST interface — signer (including MuSig2), walletkit,
chainkit, and the streaming chain-notifier — so a REST backend is a matter of
adapting the existing `rpc/restclient` plumbing to the `lndclient` interfaces
rather than a fork away from it.

## What this PR does

**`lndrest` (new package):** REST implementations of the `lndclient`
`SignerClient`, `WalletKitClient`, `ChainKitClient`, `ChainNotifierClient`
(server-streaming), and the slice of `LightningClient` the daemon actually
uses (`GetInfo` / `WalletBalance`), built on the existing `rpc/restclient`
HTTP + server-stream helpers. Methods the daemon never calls in lnd mode
return `errUnsupportedOverREST`.

**`waved`:** `s.lnd` is abstracted behind an `lndServices` seam so either a
gRPC (`*lndclient.GrpcLndServices`) or REST (`*lndrest.Backend`) backend drops
in; `connectLnd` branches on `lnd.transport`. New `LndConfig.Transport`
(default `grpc`) + `lnd.transport` flag + `sample-waved.conf` entry. `Host` is
reinterpreted per transport (`host:port` for gRPC, an HTTPS base URL for
REST). `transport=rest` requires `lnd.macaroonpath`, since the per-network
default macaroon path cannot be resolved over REST.

**`lndbackend`:** the locator-aware `SignOutputRaw` is routed through a narrow
`Signer` interface so the gRPC path keeps its raw-client behavior and the REST
signer sets the key locator directly (no raw gRPC client).

## Testing / CI

- **Unit:** config validation + the REST adapters (unary and streaming) in
  `lndrest`.
- **systest:** `TestLNDRESTBackendListVTXO` stands up a REST-backed daemon
  against the harness lnd REST gateway and lists a seeded VTXO (connect +
  chain backend, end to end).
- **New CI job `systest-lnd-rest`:** reruns the signing-capable directed-send
  flows over REST via `ARK_SYSTEST_LND_TRANSPORT=rest`
  (`case='Send|LNDREST|Stranded|VHTLCRecovery'`) — send / OOR / on-chain /
  refresh / leave / vHTLC-recovery — so the signer, walletkit, chainkit, and
  streaming chain-notifier are exercised over REST rather than just gRPC. All
  eight fixture-driven flows pass over REST locally, and the daemon log
  confirms it connects to lnd's REST gateway port rather than gRPC.

## Notes / follow-ups

- Unlike the gRPC path, `connectLndREST` does **not** block on chain-sync /
  wallet-unlock (`connectLndGRPC` sets `BlockUntilChainSynced` /
  `BlockUntilUnlocked`). It proved reliable across the REST systests, but
  matching the gRPC sync gate (poll `GetInfo` until `synced_to_chain`, bounded
  by a configurable timeout) would be the safer parity and is a natural
  follow-up.
- `lndrest`'s `LightningClient` embeds a nil `lndclient.LightningClient`, so an
  unexpected `LightningClient` call would nil-panic; those methods are
  unreachable in lnd mode today.
- A real-daemon itest (in the operator repo) driving OOR/refresh over a
  REST-backed client would extend signing coverage against a real operator,
  once this lands and the submodule is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
