### PR TITLE
waved: fix mailbox-compat test tempdir cleanup flake under -race

### DIFF
--- a/waved/mailbox_ingress_compat_test.go
+++ b/waved/mailbox_ingress_compat_test.go
@@ -116,7 +116,17 @@ func TestStartMailboxIngressConcurrentIncompatible(t *testing.T) {
 	s := newCompatTestServer(t, permanentPullEdge{})
 
 	s.runtime.StartEgress()
-	defer s.runtime.Stop()
+
+	// StopAndWait (not the fire-and-forget Stop) so the durable egress
+	// actor's goroutine has fully exited before the t.Cleanup chain closes
+	// and removes the shared SQLite DB. Stop only cancels the actor context
+	// and returns immediately, leaving the egress loop free to keep issuing
+	// queries against the handle while cleanup runs; an in-flight
+	// connection re-materializes the WAL/-shm sidecar files, so the tempdir
+	// RemoveAll then fails with "directory not empty".
+	defer func() {
+		require.NoError(t, s.runtime.StopAndWait(t.Context()))
+	}()
 
 	// StartIngress itself succeeds; the ingress goroutine then transitions.
 	require.NoError(t, s.startMailboxIngress(t.Context()))
@@ -135,7 +145,12 @@ func TestStartMailboxIngressAlreadyIncompatible(t *testing.T) {
 	s := newCompatTestServer(t, okPullEdge{})
 
 	s.runtime.StartEgress()
-	defer s.runtime.Stop()
+
+	// Drain the durable egress actor before the shared SQLite DB is torn
+	// down by t.Cleanup; see the note in the concurrent-incompatible test.
+	defer func() {
+		require.NoError(t, s.runtime.StopAndWait(t.Context()))
+	}()
 
 	// Mark incompatible up front; the callback clears server_connected.
 	s.runtime.MarkIncompatible(


### PR DESCRIPTION
## Problem

The `unit-race` job intermittently fails with:

```
--- FAIL: TestStartMailboxIngressConcurrentIncompatible
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat .../001: directory not empty
```

(seen e.g. in the run for #895, but the test and code are on `main` and the
flake is not reorg-related). Despite running under `-race`, this is not a
data-race report — Go's `t.TempDir()` calls `t.Errorf` when its `RemoveAll`
fails, which fails the test.

## Root cause

`TestStartMailboxIngressConcurrentIncompatible` and
`TestStartMailboxIngressAlreadyIncompatible` start the durable serverconn
egress actor with `StartEgress()` but tore it down with a deferred,
fire-and-forget `runtime.Stop()`. `DurableActor.Stop()` only cancels the
actor context and returns immediately (`a.stopOnce.Do(func(){ a.cancel() })`);
only `StopAndWait`/`Wait` block on `a.done`.

So the teardown ordering was:

1. `defer Stop()` — signals cancel, returns instantly
2. `t.Cleanup`: `DB.Close()`
3. `t.Cleanup`: `os.RemoveAll(tempdir)`

The egress goroutine kept issuing queries against the shared SQLite handle
during steps 2–3. An in-flight connection re-materializes the WAL/`-shm`
sidecar files, so `RemoveAll`'s final `rmdir` races and fails with
`directory not empty`.

## Fix

Switch both tests to `StopAndWait(context.Background())` in the deferred
teardown so the egress goroutine has fully drained before the DB is closed
and the temp dir removed. Test-only change.

## Verification

- Before: `-count=300 -cpu=4 -race` failed dozens of times.
- After: passes cleanly across 1000+ iterations.
- `go vet`, `make fmt-changed`, `make lint-changed-local` (0 issues) all pass.

## Note (separate, pre-existing)

While stressing this I observed a distinct, much rarer data race originating
at `baselib/actor/durable_actor.go:508` (the egress worker goroutine) — ~1 in
several thousand iterations, identical on `main` and the reorg branches and
untouched by this change. It is orthogonal to the reported cleanup flake and
worth a separate investigation; I could not reliably reproduce it to capture a
full trace.