### PR TITLE
waved: fix public swap server gRPC hostname to match cert SAN

### DIFF
--- a/docs/signet.md
+++ b/docs/signet.md
@@ -6,9 +6,9 @@ endpoint for the configured Bitcoin network and outbound transport.
 
 | Network config | Ark gRPC | Ark REST | Swap gRPC | Swap REST |
 |----------------|----------|----------|-----------|-----------|
-| `testnet` | `test.wavelength.lightning.finance:443` | `https://test.wavelength-rest.lightning.finance` | `test.swap.wavelength.lightning.finance:443` | `https://test.swapd-rest.lightning.finance` |
+| `testnet` | `test.wavelength.lightning.finance:443` | `https://test.wavelength-rest.lightning.finance` | `swap.test.wavelength.lightning.finance:443` | `https://test.swapd-rest.lightning.finance` |
 | `testnet4` | `lumosd-testnet4.testnet.lightningcluster.com:443` | `https://test4.wavelength-rest.lightning.finance` | `swapd-testnet4.testnet.lightningcluster.com:443` | `https://test4.swapd-rest.lightning.finance` |
-| `signet` | `signet.wavelength.lightning.finance:443` | `https://signet.wavelength-rest.lightning.finance` | `signet.swap.wavelength.lightning.finance:443` | `https://signet.swapd-rest.lightning.finance` |
+| `signet` | `signet.wavelength.lightning.finance:443` | `https://signet.wavelength-rest.lightning.finance` | `swap.signet.wavelength.lightning.finance:443` | `https://signet.swapd-rest.lightning.finance` |
 
 The daemon defaults both outbound transports to gRPC. Set the selectors to
 `rest` when the host cannot use native gRPC:

--- a/waved/config.go
+++ b/waved/config.go
@@ -66,7 +66,7 @@ const (
 
 	// defaultTestnet3SwapServerGRPCHost is the public testnet3 swap server
 	// gRPC endpoint.
-	defaultTestnet3SwapServerGRPCHost = "test.swap.wavelength." +
+	defaultTestnet3SwapServerGRPCHost = "swap.test.wavelength." +
 		"lightning.finance:443"
 
 	// defaultTestnet3SwapServerRESTHost is the public testnet3 swap server
@@ -110,7 +110,7 @@ const (
 
 	// defaultSignetSwapServerGRPCHost is the public signet swap server gRPC
 	// endpoint.
-	defaultSignetSwapServerGRPCHost = "signet.swap.wavelength." +
+	defaultSignetSwapServerGRPCHost = "swap.signet.wavelength." +
 		"lightning.finance:443"
 
 	// defaultSignetSwapServerRESTHost is the public signet swap server REST


### PR DESCRIPTION
## Summary

In this PR, we fix the default testnet3 and signet swap server gRPC hostnames introduced in #960. They landed as `<network>.swap.wavelength.lightning.finance`, but the TLS cert we actually serve is issued for `swap.<network>.wavelength.lightning.finance`, e.g. `swap.signet.wavelength.lightning.finance` for signet. A client dialing the old default fails the TLS handshake with a hostname mismatch.

We swap the label order in `defaultTestnet3SwapServerGRPCHost` and `defaultSignetSwapServerGRPCHost` to match the cert's SAN, and update `docs/signet.md` so the published endpoint table stays in sync. The REST hosts and the testnet4 raw cluster hostname are untouched, they were never on the `swap.wavelength.lightning.finance` cert to begin with.

## Test plan

- [x] `go build ./waved/...`
- [x] `go test ./waved/... -run 'TestConfigEndpointDefaults|TestConfigValidateAcceptsSupportedNetworks'`
- [x] `make commitmsg-lint range="origin/main..HEAD"`