### PR TITLE
wavecli: return onchain sends without blocking the CLI

### DIFF
--- a/cmd/wavecli/waveclicommands/cmd_send.go
+++ b/cmd/wavecli/waveclicommands/cmd_send.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -94,7 +95,10 @@ func newSendCmd() *cobra.Command {
 	cmd.Flags().Bool("no-wait", false,
 		"return as soon as the send is dispatched instead of blocking "+
 			"until it reaches a terminal state; by default send "+
-			"waits and Lightning sends print the payment preimage")
+			"waits and Lightning sends print the payment "+
+			"preimage. Onchain sends never block: they settle in "+
+			"a cooperative-leave round and always return a "+
+			"pending receipt")
 	cmd.Flags().Duration("wait-timeout", defaultSendWaitTimeout,
 		"while waiting: give up after this long and return the last "+
 			"observed status (0 waits indefinitely; ignored with "+
@@ -212,7 +216,26 @@ func walletSend(cmd *cobra.Command, args []string) error {
 					err)
 			}
 
-			if noWait, _ := cmd.Flags().GetBool("no-wait"); noWait {
+			// An onchain send settles by forfeiting its source
+			// VTXO into a cooperative-leave round and waiting for
+			// that round to confirm on chain, which can take many
+			// minutes. Blocking the CLI on that terminal state is a
+			// poor fit: there is no preimage to wait for the way a
+			// Lightning send has, and the funds are already
+			// committed the moment Send returns. So the onchain
+			// rail always returns a pending receipt rather than
+			// hanging, regardless of --no-wait.
+			noWait, _ := cmd.Flags().GetBool("no-wait")
+			onchain := prepareResp.GetRail() ==
+				wavewalletrpc.SendRail_SEND_RAIL_ONCHAIN
+
+			if noWait || onchain {
+				if onchain {
+					printOnchainPendingNotice(
+						cmd.ErrOrStderr(),
+						resp.GetEntry().GetId(),
+					)
+				}
 
 				// Without waiting there is no terminal state to
 				// summarize yet, so echo the dispatched entry
@@ -229,6 +252,27 @@ func walletSend(cmd *cobra.Command, args []string) error {
 			return waitForSendTerminal(cmd, resp.GetEntry())
 		},
 	)
+}
+
+// printOnchainPendingNotice writes a short human-readable explanation to stderr
+// after an onchain send is dispatched. The onchain rail never blocks to
+// terminal, so this notice sets expectations the compact JSON receipt on stdout
+// cannot: the send stays PENDING until its cooperative-leave round confirms,
+// and the residual returns as a fresh change VTXO at round seal-time (so a
+// mid-flight balance that looks drained by the whole source VTXO is expected,
+// not a loss).
+func printOnchainPendingNotice(out io.Writer, id string) {
+	fmt.Fprintln(
+		out, "Onchain send dispatched. It settles in the next "+
+			"cooperative-leave round, so it stays PENDING "+
+			"until that round confirms on chain; your change "+
+			"returns as a new VTXO once the round seals.",
+	)
+	if id != "" {
+		fmt.Fprintf(
+			out, "Track it with: wavecli activity inspect %s\n", id,
+		)
+	}
 }
 
 // waitForSendTerminal blocks until the dispatched send entry reaches a terminal

--- a/cmd/wavecli/waveclicommands/cmd_send_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_send_test.go
@@ -145,3 +145,28 @@ func TestEmptyNonEmpty(t *testing.T) {
 	require.Equal(t, "fallback", emptyNonEmpty("   ", "fallback"))
 	require.Equal(t, "reason", emptyNonEmpty("reason", "fallback"))
 }
+
+// TestPrintOnchainPendingNotice verifies the onchain dispatch notice explains
+// the PENDING/round-seal semantics and surfaces the inspect handle when an
+// entry id is known.
+func TestPrintOnchainPendingNotice(t *testing.T) {
+	var out bytes.Buffer
+	printOnchainPendingNotice(&out, "entry-123")
+
+	notice := out.String()
+	require.Contains(t, notice, "cooperative-leave round")
+	require.Contains(t, notice, "PENDING")
+	require.Contains(t, notice, "change returns as a new VTXO")
+	require.Contains(t, notice, "wavecli activity inspect entry-123")
+}
+
+// TestPrintOnchainPendingNoticeNoID verifies the inspect line is omitted when
+// the dispatched entry carried no id to poll on.
+func TestPrintOnchainPendingNoticeNoID(t *testing.T) {
+	var out bytes.Buffer
+	printOnchainPendingNotice(&out, "")
+
+	notice := out.String()
+	require.Contains(t, notice, "cooperative-leave round")
+	require.NotContains(t, notice, "activity inspect")
+}


### PR DESCRIPTION
In this PR, we fix the hung-CLI UX reported in #970, where `wavecli send
--onchain ...` sat silently after confirmation while the balance appeared
to drop by the entire source VTXO. The send was working the whole time,
the funds arrived a few minutes later, but from the terminal it looked
like a freeze and a loss.

The root of it is what "done" means per rail. By default `send` blocks
until the dispatched entry hits a terminal state, and for a Lightning
send that's the right call: the wait is short and it lets us print the
payment preimage, the proof the invoice was paid. An onchain send is a
different animal. It settles by forfeiting its source VTXO into a
cooperative-leave round, and the entry only reaches `COMPLETE` once that
round confirms on chain (see `decorateExitEntry` in `swapwallet/history.go`,
which flips the row to complete off the source VTXO reaching `FORFEITED`).
That's the next round forming plus an on-chain confirmation, easily many
minutes out, and there's no preimage worth waiting for. Blocking the CLI
on it just reads as a hang while the money is already committed.

## Rail-aware waiting

`PrepareSend` hands back the resolved rail before we ever dispatch (we
already print it in the confirm prompt), so by the time `Send` returns we
know it's onchain. In that case we skip the terminal wait entirely and
return the same compact pending receipt on stdout that `--no-wait`
produces, so the machine-readable contract is unchanged. Offchain sends
are untouched: they still block to terminal and print the preimage.

Alongside the receipt we print a short notice on stderr that the JSON
can't carry: the send stays `PENDING` until its round confirms, and the
residual comes back as a fresh change VTXO once the round seals. That last
line is the one that matters for #970, a mid-flight balance that looks
drained by the whole source VTXO is expected, not a loss, and the notice
points at `wavecli activity inspect <id>` to track it.

See the commit message for the full rationale.