### PR TITLE
multi: allow ancestry fragments to share a commitment txid

### DIFF
--- a/db/ancestry_codec.go
+++ b/db/ancestry_codec.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/neutrino/cache"
 	"github.com/lightninglabs/neutrino/cache/lru"
@@ -135,15 +134,17 @@ func (c *ancestryTreeCache) getOrDecode(treePath []byte) (*tree.Tree, error) {
 // matches the round-create path where the VTXO manager has not yet
 // filled in finalized lineage.
 //
-// The function performs three defensive checks before any row is
-// inserted: the slice is at most maxAncestryRowsPerVTXO long, every
-// CommitmentTxID is pairwise distinct, and (implicitly, by deriving
-// path_order from the loop index) path_order is a contiguous run
-// starting at 0. These constraints are also enforced at the schema
-// level (UNIQUE on commitment_txid, CHECK on path_order), but
-// surfacing them in Go means a future caller bypassing
-// BuildIncomingVTXODescriptor sees a clear error rather than a
-// constraint violation hidden behind sqlc plumbing.
+// The function bounds the slice at maxAncestryRowsPerVTXO and derives
+// path_order from the loop index (a contiguous run starting at 0); row
+// identity is the PRIMARY KEY (..., path_order). It does NOT enforce any
+// cross-fragment commitment/input uniqueness: distinct leaves of one
+// commitment tree share a commitment_txid (wavelength#969), and a
+// synthesized recovery-target descriptor aggregates fragments from several
+// roots whose per-root input indices are not comparable, so both are
+// legitimate here. The structural invariant that each input descends from a
+// commitment through exactly one leaf is enforced upstream at the incoming
+// boundary (validateIncomingAncestry), the only producer for which
+// per-fragment input indices share a single frame of reference.
 func upsertAncestryPaths(ctx context.Context, q ancestryStore,
 	outpointHash []byte, outpointIndex int32,
 	ancestry []vtxo.Ancestry) error {
@@ -151,15 +152,6 @@ func upsertAncestryPaths(ctx context.Context, q ancestryStore,
 	if len(ancestry) > maxAncestryRowsPerVTXO {
 		return fmt.Errorf("ancestry has %d rows, max %d", len(ancestry),
 			maxAncestryRowsPerVTXO)
-	}
-
-	seen := make(map[chainhash.Hash]struct{}, len(ancestry))
-	for i, a := range ancestry {
-		if _, dup := seen[a.CommitmentTxID]; dup {
-			return fmt.Errorf("ancestry[%d] duplicate "+
-				"commitment_txid %s", i, a.CommitmentTxID)
-		}
-		seen[a.CommitmentTxID] = struct{}{}
 	}
 
 	err := q.DeleteVTXOAncestryPaths(

--- a/db/ancestry_codec_test.go
+++ b/db/ancestry_codec_test.go
@@ -67,16 +67,28 @@ func (f *fakeAncestryStore) ListUnspentVTXOAncestryPaths(_ context.Context) (
 // supplied slice carries two entries with the same commitment txid.
 // The schema-level UNIQUE would also reject this, but the in-Go
 // check produces a clearer error and avoids a half-applied delete.
-func TestUpsertAncestryPathsRejectsDuplicateCommitment(t *testing.T) {
+func TestUpsertAncestryPathsAllowsSharedCommitment(t *testing.T) {
 	t.Parallel()
 
+	// wavelength#969: two fragments may share a commitment txid when they
+	// serve different leaves -- an OOR VTXO whose Ark tx spent two coins
+	// from the same commitment tree, or a synthesized recovery target that
+	// aggregates fragments from several roots. The old per-commitment
+	// uniqueness wrongly rejected this and stranded OOR change VTXOs; the
+	// codec now persists both fragments (row identity is path_order).
 	commit := chainhash.Hash{0xaa}
 	ancestry := []vtxo.Ancestry{
 		{
 			CommitmentTxID: commit,
+			InputIndices: []uint32{
+				0,
+			},
 		},
 		{
 			CommitmentTxID: commit,
+			InputIndices: []uint32{
+				1,
+			},
 		},
 	}
 
@@ -84,10 +96,9 @@ func TestUpsertAncestryPathsRejectsDuplicateCommitment(t *testing.T) {
 	err := upsertAncestryPaths(
 		t.Context(), store, make([]byte, 32), 0, ancestry,
 	)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "duplicate commitment_txid")
-	require.False(t, store.deleted, "delete must not run before validation")
-	require.Empty(t, store.inserts)
+	require.NoError(t, err)
+	require.True(t, store.deleted)
+	require.Len(t, store.inserts, 2)
 }
 
 // TestUpsertAncestryPathsRejectsTooManyRows ensures the Go-side row-

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -10,7 +10,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion uint = 13
+	LatestMigrationVersion uint = 14
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/db/sqlc/migrations/000014_ancestry_shared_commitment.down.sql
+++ b/db/sqlc/migrations/000014_ancestry_shared_commitment.down.sql
@@ -1,0 +1,43 @@
+-- Reverse 000014: rebuild vtxo_ancestry_paths with the original
+-- UNIQUE(vtxo_outpoint_hash, vtxo_outpoint_index, commitment_txid) restored.
+--
+-- NOTE: this down migration fails if any VTXO has since persisted two ancestry
+-- fragments that share a commitment_txid (the shared-commitment case that
+-- 000014 enables). That is expected: a database that has used the relaxed
+-- schema cannot be forced back onto the stricter invariant without dropping
+-- data.
+CREATE TABLE vtxo_ancestry_paths_old (
+    vtxo_outpoint_hash BLOB NOT NULL,
+    vtxo_outpoint_index INTEGER NOT NULL,
+    path_order INTEGER NOT NULL,
+    commitment_txid BLOB NOT NULL,
+    tree_path BLOB NOT NULL,
+    tree_depth INTEGER NOT NULL,
+    input_indices BLOB NOT NULL,
+    commitment_height INTEGER NOT NULL DEFAULT 0,
+
+    PRIMARY KEY (vtxo_outpoint_hash, vtxo_outpoint_index, path_order),
+    FOREIGN KEY (vtxo_outpoint_hash, vtxo_outpoint_index)
+        REFERENCES vtxos(outpoint_hash, outpoint_index)
+        ON DELETE CASCADE,
+
+    UNIQUE (vtxo_outpoint_hash, vtxo_outpoint_index, commitment_txid),
+
+    CHECK (path_order >= 0 AND path_order < 64)
+);
+
+INSERT INTO vtxo_ancestry_paths_old (
+    vtxo_outpoint_hash, vtxo_outpoint_index, path_order, commitment_txid,
+    tree_path, tree_depth, input_indices, commitment_height
+)
+SELECT
+    vtxo_outpoint_hash, vtxo_outpoint_index, path_order, commitment_txid,
+    tree_path, tree_depth, input_indices, commitment_height
+FROM vtxo_ancestry_paths;
+
+DROP TABLE vtxo_ancestry_paths;
+
+ALTER TABLE vtxo_ancestry_paths_old RENAME TO vtxo_ancestry_paths;
+
+CREATE INDEX idx_vtxo_ancestry_paths_vtxo
+    ON vtxo_ancestry_paths(vtxo_outpoint_hash, vtxo_outpoint_index);

--- a/db/sqlc/migrations/000014_ancestry_shared_commitment.up.sql
+++ b/db/sqlc/migrations/000014_ancestry_shared_commitment.up.sql
@@ -1,0 +1,53 @@
+-- wavelength#969: an OOR Ark tx may spend two input VTXOs that both descend
+-- from the same commitment tx but sit at different leaves -- e.g. the change
+-- VTXO of a send that consumed two coins from one round. The produced VTXO
+-- then legitimately carries two ancestry fragments with the same
+-- commitment_txid but distinct leaves (each needs its own root->leaf path) and
+-- distinct Ark input indices.
+--
+-- The original UNIQUE(vtxo_outpoint_hash, vtxo_outpoint_index, commitment_txid)
+-- forbade that: persisting such a VTXO failed, and the receive path rejected
+-- the change before it could be credited, dropping the sender's balance to
+-- zero. Row identity is already provided by the PRIMARY KEY (..., path_order),
+-- and redundant/malformed fragments are now rejected in Go on the
+-- (commitment, input index) pair (upsertAncestryPaths / validateIncomingAncestry),
+-- so this schema-level uniqueness is both wrong and unnecessary.
+--
+-- SQLite cannot drop an inline constraint, so the table is rebuilt without the
+-- UNIQUE. Nothing references vtxo_ancestry_paths as a foreign-key parent, so
+-- the rebuild is safe with foreign_keys=ON (the table is a pure child of
+-- vtxos). commitment_height (added in 000013) is folded in inline here.
+CREATE TABLE vtxo_ancestry_paths_new (
+    vtxo_outpoint_hash BLOB NOT NULL,
+    vtxo_outpoint_index INTEGER NOT NULL,
+    path_order INTEGER NOT NULL,
+    commitment_txid BLOB NOT NULL,
+    tree_path BLOB NOT NULL,
+    tree_depth INTEGER NOT NULL,
+    input_indices BLOB NOT NULL,
+    commitment_height INTEGER NOT NULL DEFAULT 0,
+
+    PRIMARY KEY (vtxo_outpoint_hash, vtxo_outpoint_index, path_order),
+    FOREIGN KEY (vtxo_outpoint_hash, vtxo_outpoint_index)
+        REFERENCES vtxos(outpoint_hash, outpoint_index)
+        ON DELETE CASCADE,
+
+    -- path_order must be a small non-negative ordinal (see 000004).
+    CHECK (path_order >= 0 AND path_order < 64)
+);
+
+INSERT INTO vtxo_ancestry_paths_new (
+    vtxo_outpoint_hash, vtxo_outpoint_index, path_order, commitment_txid,
+    tree_path, tree_depth, input_indices, commitment_height
+)
+SELECT
+    vtxo_outpoint_hash, vtxo_outpoint_index, path_order, commitment_txid,
+    tree_path, tree_depth, input_indices, commitment_height
+FROM vtxo_ancestry_paths;
+
+DROP TABLE vtxo_ancestry_paths;
+
+ALTER TABLE vtxo_ancestry_paths_new RENAME TO vtxo_ancestry_paths;
+
+CREATE INDEX idx_vtxo_ancestry_paths_vtxo
+    ON vtxo_ancestry_paths(vtxo_outpoint_hash, vtxo_outpoint_index);

--- a/db/sqlc/schemas/generated_schema.sql
+++ b/db/sqlc/schemas/generated_schema.sql
@@ -1537,62 +1537,22 @@ CREATE TABLE vhtlc_recovery_jobs (
     UNIQUE(swap_id, action, vtxo_txid, vtxo_vout)
 );
 
-CREATE TABLE vtxo_ancestry_paths (
-    -- vtxo_outpoint_hash and vtxo_outpoint_index identify the parent VTXO
-    -- in the vtxos table.
+CREATE TABLE "vtxo_ancestry_paths" (
     vtxo_outpoint_hash BLOB NOT NULL,
     vtxo_outpoint_index INTEGER NOT NULL,
-
-    -- path_order is the deterministic ordinal of this fragment within
-    -- the parent VTXO's ancestry, starting at 0. Persists the order
-    -- chosen by the indexer (typically grouped by commitment_txid) so
-    -- the unroller's broadcast plan is reproducible across restarts.
     path_order INTEGER NOT NULL,
-
-    -- commitment_txid is the 32-byte commitment tx hash anchoring this
-    -- fragment. Distinct rows for one VTXO must have distinct
-    -- commitment_txids.
     commitment_txid BLOB NOT NULL,
-
-    -- tree_path is the TLV-encoded extracted tree.Tree fragment from the
-    -- batch root to the input VTXO leaf served by this fragment.
     tree_path BLOB NOT NULL,
-
-    -- tree_depth is the depth of the served leaf within this fragment's
-    -- tree. Worst-case unilateral-exit timing for the parent VTXO is
-    -- max(tree_depth) across all fragments.
     tree_depth INTEGER NOT NULL,
-
-    -- input_indices is a length-prefixed BE-uint32 list of Ark tx input
-    -- indices (within the OOR Ark tx that produced the parent VTXO)
-    -- that this fragment serves. Empty for round-direct VTXOs.
-    --
-    -- No SQL-level DEFAULT here: INSERT statements always pass an
-    -- explicit value (empty length-prefixed slice for round-direct
-    -- rows). A `DEFAULT X''` literal works on SQLite but is parsed by
-    -- Postgres as a bit-string and rejected against the BYTEA column.
-    input_indices BLOB NOT NULL, commitment_height INTEGER NOT NULL DEFAULT 0,
+    input_indices BLOB NOT NULL,
+    commitment_height INTEGER NOT NULL DEFAULT 0,
 
     PRIMARY KEY (vtxo_outpoint_hash, vtxo_outpoint_index, path_order),
     FOREIGN KEY (vtxo_outpoint_hash, vtxo_outpoint_index)
         REFERENCES vtxos(outpoint_hash, outpoint_index)
         ON DELETE CASCADE,
 
-    -- A VTXO must not carry two ancestry rows for the same commitment
-    -- tx. Distinct fragments must anchor at distinct commitments
-    -- (per the Ancestry contract); enforcing it at the schema level
-    -- means a future caller bypassing BuildIncomingVTXODescriptor
-    -- still cannot persist a malformed VTXO that would later trip a
-    -- "conflicting proof node" deep inside addProofNode at unilateral
-    -- exit time.
-    UNIQUE (vtxo_outpoint_hash, vtxo_outpoint_index, commitment_txid),
-
-    -- path_order must be a small non-negative ordinal. The active
-    -- fragment-count cap (MaxAncestryFragments) is well under 64;
-    -- this CHECK guards against a caller persisting a row at a
-    -- nonsense ordinal (e.g. negative, or a uint32 round-trip from
-    -- malformed wire data) without coupling the schema to the exact
-    -- runtime cap.
+    -- path_order must be a small non-negative ordinal (see 000004).
     CHECK (path_order >= 0 AND path_order < 64)
 );
 

--- a/oor/incoming_vtxo.go
+++ b/oor/incoming_vtxo.go
@@ -285,10 +285,15 @@ func standardTapscriptIfApplicable(template *arkscript.PolicyTemplate) (
 //     VTXO. BuildIncomingVTXODescriptor normalizes that matching fragment
 //     to Ancestry[0] after validation.
 //
-//   - Each fragment's CommitmentTxID is unique within the slice. Per
-//     the Ancestry contract distinct fragments must anchor to distinct
-//     commitments; a duplicate either indicates a malformed operator
-//     response or a malicious attempt to inflate vbyte cost.
+//   - No two fragments re-cover the same input under the same commitment
+//     txid. A given input's lineage through a given commitment resolves
+//     to exactly one leaf, so a repeated (commitment, input) pair is a
+//     redundant or malformed fragment. Two fragments may still share a
+//     commitment txid when they serve different inputs (an OOR VTXO whose
+//     Ark tx spent two coins from the same commitment tree at different
+//     leaves -- wavelength#969), and one input may appear under several
+//     commitments (a chained receive), so uniqueness is enforced on the
+//     (commitment, input) pair, not the commitment txid alone.
 //
 //   - Each fragment carries a non-nil TreePath. A nil path is unusable
 //     for proof assembly and would be caught by the unroller; we surface
@@ -321,6 +326,16 @@ func standardTapscriptIfApplicable(template *arkscript.PolicyTemplate) (
 //     point the user is racing a CSV with no way to recover. We reject
 //     at the receive boundary so the bad indexer response fails before
 //     any funds are credited.
+//
+// commitInputKey identifies one (commitment tx, ark input index) pair. It is
+// the uniqueness key for ancestry fragments: a given input descends from a
+// given commitment through exactly one leaf, so the same pair may not be
+// covered by more than one fragment. See validateIncomingAncestry.
+type commitInputKey struct {
+	commitment chainhash.Hash
+	input      uint32
+}
+
 func validateIncomingAncestry(meta IncomingVTXOMetadata,
 	arkTxInputCount uint32) error {
 
@@ -335,23 +350,24 @@ func validateIncomingAncestry(meta IncomingVTXOMetadata,
 	// declared input count; we only set entries after the per-fragment
 	// range check has passed, so out-of-range writes are impossible.
 	covered := make([]bool, arkTxInputCount)
-	seen := make(map[chainhash.Hash]struct{}, len(meta.Ancestry))
+
+	// seenCommitInputs tracks the (commitment txid, ark input index) pairs
+	// already claimed by a fragment. A given Ark tx input descends from a
+	// given commitment tx through exactly one leaf, so the same pair
+	// appearing under two fragments is a redundant or malformed fragment.
+	// We deliberately key on the pair, not the commitment txid alone: two
+	// fragments legitimately share a commitment txid when they serve
+	// different inputs -- e.g. an OOR change VTXO whose Ark tx spent two
+	// input VTXOs that both descend from the same commitment tx but sit at
+	// different leaves, so each needs its own root->leaf path
+	// (wavelength#969) -- and a single input may likewise appear under
+	// several commitments for a chained receive.
+	seenCommitInputs := make(map[commitInputKey]struct{})
 	hasPrimary := false
 	for i, frag := range meta.Ancestry {
 		if frag.CommitmentTxID == meta.CommitmentTxID {
 			hasPrimary = true
 		}
-
-		if _, dup := seen[frag.CommitmentTxID]; dup {
-			return &ErrInvalidAncestry{
-				Reason: fmt.Sprintf(
-					"fragment %d carries duplicate "+
-						"commitment txid %s", i,
-					frag.CommitmentTxID,
-				),
-			}
-		}
-		seen[frag.CommitmentTxID] = struct{}{}
 
 		if frag.TreePath == nil {
 			return &ErrInvalidAncestry{
@@ -443,6 +459,30 @@ func validateIncomingAncestry(meta IncomingVTXOMetadata,
 			}
 			seenInFragment[idx] = struct{}{}
 			covered[idx] = true
+
+			// A given input's lineage through a given commitment
+			// resolves to exactly one leaf, so the same
+			// (commitment, input) pair under two fragments is a
+			// redundant or malformed fragment. Fragments sharing
+			// only the commitment (different inputs) or only the
+			// input (different commitments) are both legitimate;
+			// see seenCommitInputs above.
+			pair := commitInputKey{
+				commitment: frag.CommitmentTxID,
+				input:      idx,
+			}
+			if _, ok := seenCommitInputs[pair]; ok {
+				return &ErrInvalidAncestry{
+					Reason: fmt.Sprintf(
+						"fragment %d re-covers "+
+							"input %d already "+
+							"served under "+
+							"commitment %s", i,
+						idx, frag.CommitmentTxID,
+					),
+				}
+			}
+			seenCommitInputs[pair] = struct{}{}
 		}
 	}
 

--- a/oor/incoming_vtxo_test.go
+++ b/oor/incoming_vtxo_test.go
@@ -340,12 +340,18 @@ func TestBuildIncomingVTXODescriptorRejectsInvalidAncestry(t *testing.T) {
 			wantReason: "tree path batch outpoint hash",
 		},
 		{
-			name: "duplicate commitment txid across fragments",
+			// An exact-duplicate fragment re-covers the same input
+			// under the same commitment, which the (commitment,
+			// input) uniqueness rule rejects as redundant. Two
+			// fragments that share only the commitment (serving
+			// different inputs) are allowed -- see the coverage
+			// test's "two inputs share a commitment" case.
+			name: "redundant duplicate fragment",
 			mutate: func(m *IncomingVTXOMetadata) {
 				dup := m.Ancestry[0]
 				m.Ancestry = append(m.Ancestry, dup)
 			},
-			wantReason: "duplicate commitment txid",
+			wantReason: "re-covers input",
 		},
 		{
 			name: "nil tree path",
@@ -492,6 +498,23 @@ func TestValidateIncomingAncestryInputCoverage(t *testing.T) {
 			ancestry: []vtxo.Ancestry{
 				fragment(primary, 0),
 				fragment(secondary, 0),
+			},
+		},
+		{
+			// Regression for wavelength#969: an OOR tx that spends
+			// two input VTXOs which both descend from the SAME
+			// commitment tx (different leaves) yields a change VTXO
+			// whose ancestry has two fragments carrying the same
+			// commitment txid but distinct input indices. This is
+			// legitimate -- each leaf needs its own root->leaf path
+			// -- and must validate. The old per-commitment dedup
+			// wrongly rejected it, stranding the change and
+			// dropping the sender's balance to zero.
+			name:            "two inputs share a commitment",
+			arkTxInputCount: 2,
+			ancestry: []vtxo.Ancestry{
+				fragment(primary, 0),
+				fragment(primary, 1),
 			},
 		},
 		{

--- a/waved/vhtlc_recovery_target.go
+++ b/waved/vhtlc_recovery_target.go
@@ -592,26 +592,26 @@ func recoveryUint32(value int32, label string) (uint32, error) {
 	return uint32(value), nil
 }
 
-// recoveryAncestry clones and de-duplicates ancestry fragments from the root
-// descriptors. Distinct roots may share a commitment fragment, so
-// de-duplication keeps the synthesized target descriptor compact and
-// deterministic.
+// recoveryAncestry collects the ancestry fragments from the root descriptors
+// into the synthesized target's ancestry, preserving every fragment.
+//
+// It must NOT de-duplicate by commitment txid: distinct roots that both
+// descend from the same commitment tx contribute different leaves (each a
+// distinct root->leaf path), so collapsing by commitment would silently drop a
+// leaf and leave the recovery target unable to prove that input on-chain at
+// unilateral-exit time (wavelength#969). The roots are already de-duplicated
+// by outpoint in loadRootDescriptors and a VTXO is spent at most once, so no
+// two roots share a leaf and the concatenation carries no true duplicates; the
+// unroller's proof assembler deduplicates shared upstream tree nodes when it
+// builds the exit.
 func recoveryAncestry(roots []*vtxo.Descriptor) []vtxo.Ancestry {
-	seen := make(map[chainhash.Hash]struct{})
 	var ancestry []vtxo.Ancestry
 	for _, root := range roots {
 		if root == nil {
 			continue
 		}
 
-		for _, fragment := range root.Ancestry {
-			if _, ok := seen[fragment.CommitmentTxID]; ok {
-				continue
-			}
-			seen[fragment.CommitmentTxID] = struct{}{}
-
-			ancestry = append(ancestry, fragment)
-		}
+		ancestry = append(ancestry, root.Ancestry...)
 	}
 
 	return ancestry

--- a/waved/vhtlc_recovery_target_test.go
+++ b/waved/vhtlc_recovery_target_test.go
@@ -1,0 +1,61 @@
+package waved
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	lib_tree "github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecoveryAncestryPreservesSharedCommitmentLeaves is a regression for
+// wavelength#969. recoveryAncestry aggregates the ancestry fragments of a
+// recovery target's roots. When two roots both descend from the same
+// commitment tx they contribute distinct leaves (each its own root->leaf
+// path), and every fragment is required to prove the target on-chain. The
+// previous commitment-keyed de-duplication silently dropped the second
+// same-commitment fragment, so the synthesized recovery target could not
+// unilaterally exit that input. Every fragment must survive.
+func TestRecoveryAncestryPreservesSharedCommitmentLeaves(t *testing.T) {
+	t.Parallel()
+
+	commit := chainhash.Hash{0x0b, 0x17}
+
+	frag := func(input uint32) vtxo.Ancestry {
+		return vtxo.Ancestry{
+			TreePath: &lib_tree.Tree{
+				Root: &lib_tree.Node{},
+				BatchOutpoint: wire.OutPoint{
+					Hash: commit,
+				},
+			},
+			CommitmentTxID: commit,
+			InputIndices: []uint32{
+				input,
+			},
+			TreeDepth: 1,
+		}
+	}
+
+	// Two roots anchored at the same commitment but at different leaves --
+	// the shape of change from a send that consumed two coins from one
+	// round.
+	rootA := &vtxo.Descriptor{Ancestry: []vtxo.Ancestry{frag(0)}}
+	rootB := &vtxo.Descriptor{Ancestry: []vtxo.Ancestry{frag(1)}}
+
+	got := recoveryAncestry([]*vtxo.Descriptor{rootA, rootB})
+	require.Len(t, got, 2, "both same-commitment leaves must survive")
+	require.Equal(t, commit, got[0].CommitmentTxID)
+	require.Equal(t, commit, got[1].CommitmentTxID)
+
+	// A nil root is skipped without panicking or dropping real fragments.
+	require.Len(
+		t,
+		recoveryAncestry(
+			[]*vtxo.Descriptor{rootA, nil, rootB},
+		),
+		2,
+	)
+}


### PR DESCRIPTION
Fixes #969.

## Symptom

A user sent a 2101-sat Lightning payment that succeeded, but their balance
then dropped to **zero**. The activity log showed the expected `-2101` send
plus an "unrecognized" `-3438` debit, and the daemon logged:

```
[WRN] OORC: Session commit failed err="invalid incoming VTXO ancestry:
fragment 1 carries duplicate commitment txid 0b17fc13..."
```

## Root cause

The send's coin-selection picked **two VTXOs that both descend from the same
commitment tx** (`0b17fc13…`), totalling 3438 sats, to pay 2101 (→ 1337
change). The OOR Ark tx spent both; the **self-change VTXO's ancestry**
therefore legitimately carries **two fragments with the same commitment txid
but different leaves** — each input VTXO sits at a different leaf of that one
commitment tree, so each needs its own root→leaf path.

Several client layers assumed *one ancestry fragment per commitment tx* and
either rejected or silently dropped the second fragment. The self-change
materialization was rejected outright, so the 1337 change was never credited
and the balance fell to zero (the `-3438` entry is the OOR input debit; the
missing `+1337` change credit is the lost balance).

An audit of every ancestry consumer found the wrong invariant in exactly four
places (everything else — unroll proof assembly, fraud watch, the TLV codec,
the DB read path — already iterates per-fragment and keys by tree-node/outpoint
hashes, so it is safe):

## Fix

Relax the invariant to key on the **(commitment txid, ark input index)** pair
rather than the commitment alone. A given input descends from a given
commitment through exactly one leaf, so a repeated pair is redundant/malformed,
but distinct leaves of one commitment (different inputs) are legitimate.

- **`oor` `validateIncomingAncestry`** — rejects only a repeated
  `(commitment, input)` pair; accepts distinct leaves of one commitment. This
  is the correct invariant at the incoming boundary, where all fragments of a
  single OOR tx share one input-index frame of reference.
- **`db`** — drop the `UNIQUE(vtxo_outpoint_hash, vtxo_outpoint_index,
  commitment_txid)` schema constraint via a table rebuild (migration `000014`;
  SQLite has no `DROP CONSTRAINT`, and the rebuild is dialect-portable). Row
  identity is already the `PRIMARY KEY (…, path_order)`. `upsertAncestryPaths`
  drops its mirror dedup: the codec also persists synthesized vHTLC
  recovery-target descriptors that aggregate fragments across roots (whose
  per-root input indices aren't comparable), so cross-fragment uniqueness can't
  live at this layer — it stays at the incoming boundary above.
- **`waved` `recoveryAncestry`** — no longer de-duplicates root fragments by
  commitment txid. That silently dropped a divergent leaf and left the
  synthesized vHTLC recovery target unable to prove that input on-chain (a
  latent fund-safety bug at unilateral-exit time). Roots are already deduped by
  outpoint upstream, so concatenation carries no true duplicates.

This is client-only: the operator/indexer already produces correct per-leaf
fragments (the client received two, then rejected them).

## Testing

- **Reproduction (unit):** `TestValidateIncomingAncestryInputCoverage/
  two_inputs_share_a_commitment` fails on `main` with the exact issue error and
  passes with the fix.
- `validateIncomingAncestry` still rejects a genuinely redundant duplicate
  fragment; `upsertAncestryPaths` persists shared-commitment fragments;
  `recoveryAncestry` preserves every leaf (regression for the silent drop).
- Full `oor` + `db` suites pass (sqlite); `make sqlc` regenerates the
  consolidated schema (the `UNIQUE` is gone).

## Notes

- **Fix-forward only.** This prevents new occurrences; recovering change VTXOs
  that were already stranded before the fix (like the reporter's 1337 sats) is
  tracked separately. In principle a fixed client that re-queries the indexer
  and re-materializes should recover it on its own — to be confirmed.
- A real-daemon end-to-end test (two same-commitment inputs → send → assert the
  change materializes) is a good follow-up; the current systest fixture seeds a
  single VTXO, so the reproduction here is at the unit/validation layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
