### PR TITLE
build: bump version to v0.1.0-rc4

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -15,11 +15,11 @@ const (
 	AppMinor uint = 1
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 99
+	AppPatch uint = 0
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.
-	AppPreRelease = ""
+	AppPreRelease = "rc4"
 )
 
 var (


### PR DESCRIPTION
In this PR, we cut the `v0.1.0-rc4` release candidate.

To avoid a long stack of individual backport PRs, the `v0.1.x` release
branch was fast-forwarded to match `main`, so it now carries every
post-rc3 change (including the reorg-aware chain observation work) with no
per-PR cherry-picks. This commit stamps the release version on top:
`AppPatch` back to `0` and `AppPreRelease` set to `rc4`.

Only `build/version.go` changes here. Cutting this once CI is green on the
branch.