### PR TITLE
multi: Register authenticated provisional lineage end to end

### DIFF
--- a/arkrpc/indexer.pb.go
+++ b/arkrpc/indexer.pb.go
@@ -1498,8 +1498,16 @@ type AncestryPath struct {
 	// tx anchoring this fragment. Zero means unknown (legacy/unconfirmed),
 	// in which case the client falls back to a bounded lookback floor.
 	CommitmentHeight int32 `protobuf:"varint,5,opt,name=commitment_height,json=commitmentHeight,proto3" json:"commitment_height,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// commitment_tx is the serialized commitment transaction. Its hash must
+	// equal commitment_txid and tree_path.batch_outpoint.txid.
+	CommitmentTx []byte `protobuf:"bytes,6,opt,name=commitment_tx,json=commitmentTx,proto3" json:"commitment_tx,omitempty"`
+	// commitment_inputs contains one previous-output record for every actual
+	// commitment transaction input, in transaction input order.
+	CommitmentInputs []*CommitmentInputEvidence `protobuf:"bytes,7,rep,name=commitment_inputs,json=commitmentInputs,proto3" json:"commitment_inputs,omitempty"`
+	// commitment_csv_expiry_delta is the batch sweep delay in blocks.
+	CommitmentCsvExpiryDelta int32 `protobuf:"varint,8,opt,name=commitment_csv_expiry_delta,json=commitmentCsvExpiryDelta,proto3" json:"commitment_csv_expiry_delta,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *AncestryPath) Reset() {
@@ -1567,6 +1575,83 @@ func (x *AncestryPath) GetCommitmentHeight() int32 {
 	return 0
 }
 
+func (x *AncestryPath) GetCommitmentTx() []byte {
+	if x != nil {
+		return x.CommitmentTx
+	}
+	return nil
+}
+
+func (x *AncestryPath) GetCommitmentInputs() []*CommitmentInputEvidence {
+	if x != nil {
+		return x.CommitmentInputs
+	}
+	return nil
+}
+
+func (x *AncestryPath) GetCommitmentCsvExpiryDelta() int32 {
+	if x != nil {
+		return x.CommitmentCsvExpiryDelta
+	}
+	return 0
+}
+
+// CommitmentInputEvidence binds one commitment input to the full previous
+// output needed for authenticated conflict observation.
+type CommitmentInputEvidence struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// outpoint must equal the corresponding commitment transaction input.
+	Outpoint *OutPoint `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
+	// prev_out supplies the value and pkScript of the spent output.
+	PrevOut       *TxOut `protobuf:"bytes,2,opt,name=prev_out,json=prevOut,proto3" json:"prev_out,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CommitmentInputEvidence) Reset() {
+	*x = CommitmentInputEvidence{}
+	mi := &file_indexer_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CommitmentInputEvidence) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CommitmentInputEvidence) ProtoMessage() {}
+
+func (x *CommitmentInputEvidence) ProtoReflect() protoreflect.Message {
+	mi := &file_indexer_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CommitmentInputEvidence.ProtoReflect.Descriptor instead.
+func (*CommitmentInputEvidence) Descriptor() ([]byte, []int) {
+	return file_indexer_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *CommitmentInputEvidence) GetOutpoint() *OutPoint {
+	if x != nil {
+		return x.Outpoint
+	}
+	return nil
+}
+
+func (x *CommitmentInputEvidence) GetPrevOut() *TxOut {
+	if x != nil {
+		return x.PrevOut
+	}
+	return nil
+}
+
 // ScriptScope selects a pkScript and carries a proof-of-control for that
 // script.
 //
@@ -1590,7 +1675,7 @@ type ScriptScope struct {
 
 func (x *ScriptScope) Reset() {
 	*x = ScriptScope{}
-	mi := &file_indexer_proto_msgTypes[19]
+	mi := &file_indexer_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1602,7 +1687,7 @@ func (x *ScriptScope) String() string {
 func (*ScriptScope) ProtoMessage() {}
 
 func (x *ScriptScope) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[19]
+	mi := &file_indexer_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1615,7 +1700,7 @@ func (x *ScriptScope) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScriptScope.ProtoReflect.Descriptor instead.
 func (*ScriptScope) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{19}
+	return file_indexer_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ScriptScope) GetPkScript() []byte {
@@ -1735,7 +1820,7 @@ type VTXO struct {
 
 func (x *VTXO) Reset() {
 	*x = VTXO{}
-	mi := &file_indexer_proto_msgTypes[20]
+	mi := &file_indexer_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1747,7 +1832,7 @@ func (x *VTXO) String() string {
 func (*VTXO) ProtoMessage() {}
 
 func (x *VTXO) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[20]
+	mi := &file_indexer_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1760,7 +1845,7 @@ func (x *VTXO) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VTXO.ProtoReflect.Descriptor instead.
 func (*VTXO) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{20}
+	return file_indexer_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *VTXO) GetOutpoint() *OutPoint {
@@ -1906,7 +1991,7 @@ type ListVTXOsByScriptsRequest struct {
 
 func (x *ListVTXOsByScriptsRequest) Reset() {
 	*x = ListVTXOsByScriptsRequest{}
-	mi := &file_indexer_proto_msgTypes[21]
+	mi := &file_indexer_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1918,7 +2003,7 @@ func (x *ListVTXOsByScriptsRequest) String() string {
 func (*ListVTXOsByScriptsRequest) ProtoMessage() {}
 
 func (x *ListVTXOsByScriptsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[21]
+	mi := &file_indexer_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1931,7 +2016,7 @@ func (x *ListVTXOsByScriptsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVTXOsByScriptsRequest.ProtoReflect.Descriptor instead.
 func (*ListVTXOsByScriptsRequest) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{21}
+	return file_indexer_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ListVTXOsByScriptsRequest) GetScripts() []*ScriptScope {
@@ -1977,7 +2062,7 @@ type ListVTXOsByScriptsResponse struct {
 
 func (x *ListVTXOsByScriptsResponse) Reset() {
 	*x = ListVTXOsByScriptsResponse{}
-	mi := &file_indexer_proto_msgTypes[22]
+	mi := &file_indexer_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1989,7 +2074,7 @@ func (x *ListVTXOsByScriptsResponse) String() string {
 func (*ListVTXOsByScriptsResponse) ProtoMessage() {}
 
 func (x *ListVTXOsByScriptsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[22]
+	mi := &file_indexer_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2002,7 +2087,7 @@ func (x *ListVTXOsByScriptsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVTXOsByScriptsResponse.ProtoReflect.Descriptor instead.
 func (*ListVTXOsByScriptsResponse) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{22}
+	return file_indexer_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ListVTXOsByScriptsResponse) GetVtxos() []*VTXO {
@@ -2029,7 +2114,7 @@ type GetOORSessionByTxidRequest struct {
 
 func (x *GetOORSessionByTxidRequest) Reset() {
 	*x = GetOORSessionByTxidRequest{}
-	mi := &file_indexer_proto_msgTypes[23]
+	mi := &file_indexer_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2041,7 +2126,7 @@ func (x *GetOORSessionByTxidRequest) String() string {
 func (*GetOORSessionByTxidRequest) ProtoMessage() {}
 
 func (x *GetOORSessionByTxidRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[23]
+	mi := &file_indexer_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2054,7 +2139,7 @@ func (x *GetOORSessionByTxidRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionByTxidRequest.ProtoReflect.Descriptor instead.
 func (*GetOORSessionByTxidRequest) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{23}
+	return file_indexer_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetOORSessionByTxidRequest) GetScript() *ScriptScope {
@@ -2081,7 +2166,7 @@ type GetOORSessionByTxidResponse struct {
 
 func (x *GetOORSessionByTxidResponse) Reset() {
 	*x = GetOORSessionByTxidResponse{}
-	mi := &file_indexer_proto_msgTypes[24]
+	mi := &file_indexer_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2093,7 +2178,7 @@ func (x *GetOORSessionByTxidResponse) String() string {
 func (*GetOORSessionByTxidResponse) ProtoMessage() {}
 
 func (x *GetOORSessionByTxidResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[24]
+	mi := &file_indexer_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2106,7 +2191,7 @@ func (x *GetOORSessionByTxidResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOORSessionByTxidResponse.ProtoReflect.Descriptor instead.
 func (*GetOORSessionByTxidResponse) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{24}
+	return file_indexer_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetOORSessionByTxidResponse) GetArkPsbt() []byte {
@@ -2142,7 +2227,7 @@ type TreeNode struct {
 
 func (x *TreeNode) Reset() {
 	*x = TreeNode{}
-	mi := &file_indexer_proto_msgTypes[25]
+	mi := &file_indexer_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2154,7 +2239,7 @@ func (x *TreeNode) String() string {
 func (*TreeNode) ProtoMessage() {}
 
 func (x *TreeNode) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[25]
+	mi := &file_indexer_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2167,7 +2252,7 @@ func (x *TreeNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TreeNode.ProtoReflect.Descriptor instead.
 func (*TreeNode) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{25}
+	return file_indexer_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *TreeNode) GetTxid() []byte {
@@ -2213,7 +2298,7 @@ type TreeEdge struct {
 
 func (x *TreeEdge) Reset() {
 	*x = TreeEdge{}
-	mi := &file_indexer_proto_msgTypes[26]
+	mi := &file_indexer_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2225,7 +2310,7 @@ func (x *TreeEdge) String() string {
 func (*TreeEdge) ProtoMessage() {}
 
 func (x *TreeEdge) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[26]
+	mi := &file_indexer_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2238,7 +2323,7 @@ func (x *TreeEdge) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TreeEdge.ProtoReflect.Descriptor instead.
 func (*TreeEdge) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{26}
+	return file_indexer_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *TreeEdge) GetParentTxid() []byte {
@@ -2274,7 +2359,7 @@ type GetSubtreeByScriptsRequest struct {
 
 func (x *GetSubtreeByScriptsRequest) Reset() {
 	*x = GetSubtreeByScriptsRequest{}
-	mi := &file_indexer_proto_msgTypes[27]
+	mi := &file_indexer_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2286,7 +2371,7 @@ func (x *GetSubtreeByScriptsRequest) String() string {
 func (*GetSubtreeByScriptsRequest) ProtoMessage() {}
 
 func (x *GetSubtreeByScriptsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[27]
+	mi := &file_indexer_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2299,7 +2384,7 @@ func (x *GetSubtreeByScriptsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSubtreeByScriptsRequest.ProtoReflect.Descriptor instead.
 func (*GetSubtreeByScriptsRequest) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{27}
+	return file_indexer_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GetSubtreeByScriptsRequest) GetScripts() []*ScriptScope {
@@ -2330,7 +2415,7 @@ type GetSubtreeByScriptsResponse struct {
 
 func (x *GetSubtreeByScriptsResponse) Reset() {
 	*x = GetSubtreeByScriptsResponse{}
-	mi := &file_indexer_proto_msgTypes[28]
+	mi := &file_indexer_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2342,7 +2427,7 @@ func (x *GetSubtreeByScriptsResponse) String() string {
 func (*GetSubtreeByScriptsResponse) ProtoMessage() {}
 
 func (x *GetSubtreeByScriptsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[28]
+	mi := &file_indexer_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2355,7 +2440,7 @@ func (x *GetSubtreeByScriptsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSubtreeByScriptsResponse.ProtoReflect.Descriptor instead.
 func (*GetSubtreeByScriptsResponse) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{28}
+	return file_indexer_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *GetSubtreeByScriptsResponse) GetVtxos() []*VTXO {
@@ -2394,7 +2479,7 @@ type VTXOEvent struct {
 
 func (x *VTXOEvent) Reset() {
 	*x = VTXOEvent{}
-	mi := &file_indexer_proto_msgTypes[29]
+	mi := &file_indexer_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2406,7 +2491,7 @@ func (x *VTXOEvent) String() string {
 func (*VTXOEvent) ProtoMessage() {}
 
 func (x *VTXOEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[29]
+	mi := &file_indexer_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2419,7 +2504,7 @@ func (x *VTXOEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VTXOEvent.ProtoReflect.Descriptor instead.
 func (*VTXOEvent) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{29}
+	return file_indexer_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *VTXOEvent) GetEventId() uint64 {
@@ -2470,7 +2555,7 @@ type ListVTXOEventsByScriptsRequest struct {
 
 func (x *ListVTXOEventsByScriptsRequest) Reset() {
 	*x = ListVTXOEventsByScriptsRequest{}
-	mi := &file_indexer_proto_msgTypes[30]
+	mi := &file_indexer_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2482,7 +2567,7 @@ func (x *ListVTXOEventsByScriptsRequest) String() string {
 func (*ListVTXOEventsByScriptsRequest) ProtoMessage() {}
 
 func (x *ListVTXOEventsByScriptsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[30]
+	mi := &file_indexer_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2495,7 +2580,7 @@ func (x *ListVTXOEventsByScriptsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVTXOEventsByScriptsRequest.ProtoReflect.Descriptor instead.
 func (*ListVTXOEventsByScriptsRequest) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{30}
+	return file_indexer_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ListVTXOEventsByScriptsRequest) GetScripts() []*ScriptScope {
@@ -2529,7 +2614,7 @@ type ListVTXOEventsByScriptsResponse struct {
 
 func (x *ListVTXOEventsByScriptsResponse) Reset() {
 	*x = ListVTXOEventsByScriptsResponse{}
-	mi := &file_indexer_proto_msgTypes[31]
+	mi := &file_indexer_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2541,7 +2626,7 @@ func (x *ListVTXOEventsByScriptsResponse) String() string {
 func (*ListVTXOEventsByScriptsResponse) ProtoMessage() {}
 
 func (x *ListVTXOEventsByScriptsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[31]
+	mi := &file_indexer_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2554,7 +2639,7 @@ func (x *ListVTXOEventsByScriptsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListVTXOEventsByScriptsResponse.ProtoReflect.Descriptor instead.
 func (*ListVTXOEventsByScriptsResponse) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{31}
+	return file_indexer_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ListVTXOEventsByScriptsResponse) GetEvents() []*VTXOEvent {
@@ -2608,7 +2693,7 @@ type IncomingVTXOEvent struct {
 
 func (x *IncomingVTXOEvent) Reset() {
 	*x = IncomingVTXOEvent{}
-	mi := &file_indexer_proto_msgTypes[32]
+	mi := &file_indexer_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2620,7 +2705,7 @@ func (x *IncomingVTXOEvent) String() string {
 func (*IncomingVTXOEvent) ProtoMessage() {}
 
 func (x *IncomingVTXOEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_indexer_proto_msgTypes[32]
+	mi := &file_indexer_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2633,7 +2718,7 @@ func (x *IncomingVTXOEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IncomingVTXOEvent.ProtoReflect.Descriptor instead.
 func (*IncomingVTXOEvent) Descriptor() ([]byte, []int) {
-	return file_indexer_proto_rawDescGZIP(), []int{32}
+	return file_indexer_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *IncomingVTXOEvent) GetEventId() uint64 {
@@ -2803,14 +2888,20 @@ const file_indexer_proto_rawDesc = "" +
 	"\x05nodes\x18\x01 \x03(\v2\x14.arkrpc.TreePathNodeR\x05nodes\x127\n" +
 	"\x0ebatch_outpoint\x18\x02 \x01(\v2\x10.arkrpc.OutPointR\rbatchOutpoint\x120\n" +
 	"\fbatch_output\x18\x03 \x01(\v2\r.arkrpc.TxOutR\vbatchOutput\x120\n" +
-	"\x14sweep_tapscript_root\x18\x04 \x01(\fR\x12sweepTapscriptRoot\"\xd7\x01\n" +
+	"\x14sweep_tapscript_root\x18\x04 \x01(\fR\x12sweepTapscriptRoot\"\x89\x03\n" +
 	"\fAncestryPath\x12-\n" +
 	"\ttree_path\x18\x01 \x01(\v2\x10.arkrpc.TreePathR\btreePath\x12'\n" +
 	"\x0fcommitment_txid\x18\x02 \x01(\fR\x0ecommitmentTxid\x12#\n" +
 	"\rinput_indices\x18\x03 \x03(\rR\finputIndices\x12\x1d\n" +
 	"\n" +
 	"tree_depth\x18\x04 \x01(\rR\ttreeDepth\x12+\n" +
-	"\x11commitment_height\x18\x05 \x01(\x05R\x10commitmentHeight\"\xaa\x01\n" +
+	"\x11commitment_height\x18\x05 \x01(\x05R\x10commitmentHeight\x12#\n" +
+	"\rcommitment_tx\x18\x06 \x01(\fR\fcommitmentTx\x12L\n" +
+	"\x11commitment_inputs\x18\a \x03(\v2\x1f.arkrpc.CommitmentInputEvidenceR\x10commitmentInputs\x12=\n" +
+	"\x1bcommitment_csv_expiry_delta\x18\b \x01(\x05R\x18commitmentCsvExpiryDelta\"q\n" +
+	"\x17CommitmentInputEvidence\x12,\n" +
+	"\boutpoint\x18\x01 \x01(\v2\x10.arkrpc.OutPointR\boutpoint\x12(\n" +
+	"\bprev_out\x18\x02 \x01(\v2\r.arkrpc.TxOutR\aprevOut\"\xaa\x01\n" +
 	"\vScriptScope\x12\x1b\n" +
 	"\tpk_script\x18\x01 \x01(\fR\bpkScript\x12F\n" +
 	"\x0ftaproot_schnorr\x18\n" +
@@ -2944,7 +3035,7 @@ func file_indexer_proto_rawDescGZIP() []byte {
 }
 
 var file_indexer_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_indexer_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_indexer_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_indexer_proto_goTypes = []any{
 	(VTXOStatus)(0),                                // 0: arkrpc.VTXOStatus
 	(VTXOEventType)(0),                             // 1: arkrpc.VTXOEventType
@@ -2968,21 +3059,22 @@ var file_indexer_proto_goTypes = []any{
 	(*TreePathNode)(nil),                           // 19: arkrpc.TreePathNode
 	(*TreePath)(nil),                               // 20: arkrpc.TreePath
 	(*AncestryPath)(nil),                           // 21: arkrpc.AncestryPath
-	(*ScriptScope)(nil),                            // 22: arkrpc.ScriptScope
-	(*VTXO)(nil),                                   // 23: arkrpc.VTXO
-	(*ListVTXOsByScriptsRequest)(nil),              // 24: arkrpc.ListVTXOsByScriptsRequest
-	(*ListVTXOsByScriptsResponse)(nil),             // 25: arkrpc.ListVTXOsByScriptsResponse
-	(*GetOORSessionByTxidRequest)(nil),             // 26: arkrpc.GetOORSessionByTxidRequest
-	(*GetOORSessionByTxidResponse)(nil),            // 27: arkrpc.GetOORSessionByTxidResponse
-	(*TreeNode)(nil),                               // 28: arkrpc.TreeNode
-	(*TreeEdge)(nil),                               // 29: arkrpc.TreeEdge
-	(*GetSubtreeByScriptsRequest)(nil),             // 30: arkrpc.GetSubtreeByScriptsRequest
-	(*GetSubtreeByScriptsResponse)(nil),            // 31: arkrpc.GetSubtreeByScriptsResponse
-	(*VTXOEvent)(nil),                              // 32: arkrpc.VTXOEvent
-	(*ListVTXOEventsByScriptsRequest)(nil),         // 33: arkrpc.ListVTXOEventsByScriptsRequest
-	(*ListVTXOEventsByScriptsResponse)(nil),        // 34: arkrpc.ListVTXOEventsByScriptsResponse
-	(*IncomingVTXOEvent)(nil),                      // 35: arkrpc.IncomingVTXOEvent
-	nil,                                            // 36: arkrpc.TreePathNode.ChildrenEntry
+	(*CommitmentInputEvidence)(nil),                // 22: arkrpc.CommitmentInputEvidence
+	(*ScriptScope)(nil),                            // 23: arkrpc.ScriptScope
+	(*VTXO)(nil),                                   // 24: arkrpc.VTXO
+	(*ListVTXOsByScriptsRequest)(nil),              // 25: arkrpc.ListVTXOsByScriptsRequest
+	(*ListVTXOsByScriptsResponse)(nil),             // 26: arkrpc.ListVTXOsByScriptsResponse
+	(*GetOORSessionByTxidRequest)(nil),             // 27: arkrpc.GetOORSessionByTxidRequest
+	(*GetOORSessionByTxidResponse)(nil),            // 28: arkrpc.GetOORSessionByTxidResponse
+	(*TreeNode)(nil),                               // 29: arkrpc.TreeNode
+	(*TreeEdge)(nil),                               // 30: arkrpc.TreeEdge
+	(*GetSubtreeByScriptsRequest)(nil),             // 31: arkrpc.GetSubtreeByScriptsRequest
+	(*GetSubtreeByScriptsResponse)(nil),            // 32: arkrpc.GetSubtreeByScriptsResponse
+	(*VTXOEvent)(nil),                              // 33: arkrpc.VTXOEvent
+	(*ListVTXOEventsByScriptsRequest)(nil),         // 34: arkrpc.ListVTXOEventsByScriptsRequest
+	(*ListVTXOEventsByScriptsResponse)(nil),        // 35: arkrpc.ListVTXOEventsByScriptsResponse
+	(*IncomingVTXOEvent)(nil),                      // 36: arkrpc.IncomingVTXOEvent
+	nil,                                            // 37: arkrpc.TreePathNode.ChildrenEntry
 }
 var file_indexer_proto_depIdxs = []int32{
 	4,  // 0: arkrpc.RegisterReceiveScriptRequest.taproot_schnorr:type_name -> arkrpc.TaprootSchnorrProof
@@ -2996,55 +3088,58 @@ var file_indexer_proto_depIdxs = []int32{
 	15, // 8: arkrpc.OORRecipientEvent.ancestor_packages:type_name -> arkrpc.OORSessionPackage
 	17, // 9: arkrpc.TreePathNode.input:type_name -> arkrpc.OutPoint
 	18, // 10: arkrpc.TreePathNode.outputs:type_name -> arkrpc.TxOut
-	36, // 11: arkrpc.TreePathNode.children:type_name -> arkrpc.TreePathNode.ChildrenEntry
+	37, // 11: arkrpc.TreePathNode.children:type_name -> arkrpc.TreePathNode.ChildrenEntry
 	19, // 12: arkrpc.TreePath.nodes:type_name -> arkrpc.TreePathNode
 	17, // 13: arkrpc.TreePath.batch_outpoint:type_name -> arkrpc.OutPoint
 	18, // 14: arkrpc.TreePath.batch_output:type_name -> arkrpc.TxOut
 	20, // 15: arkrpc.AncestryPath.tree_path:type_name -> arkrpc.TreePath
-	4,  // 16: arkrpc.ScriptScope.taproot_schnorr:type_name -> arkrpc.TaprootSchnorrProof
-	5,  // 17: arkrpc.ScriptScope.bip322:type_name -> arkrpc.BIP322Proof
-	17, // 18: arkrpc.VTXO.outpoint:type_name -> arkrpc.OutPoint
-	0,  // 19: arkrpc.VTXO.status:type_name -> arkrpc.VTXOStatus
-	21, // 20: arkrpc.VTXO.ancestry_paths:type_name -> arkrpc.AncestryPath
-	22, // 21: arkrpc.ListVTXOsByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
-	0,  // 22: arkrpc.ListVTXOsByScriptsRequest.status_filter:type_name -> arkrpc.VTXOStatus
-	23, // 23: arkrpc.ListVTXOsByScriptsResponse.vtxos:type_name -> arkrpc.VTXO
-	22, // 24: arkrpc.GetOORSessionByTxidRequest.script:type_name -> arkrpc.ScriptScope
-	17, // 25: arkrpc.TreeNode.input:type_name -> arkrpc.OutPoint
-	22, // 26: arkrpc.GetSubtreeByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
-	23, // 27: arkrpc.GetSubtreeByScriptsResponse.vtxos:type_name -> arkrpc.VTXO
-	28, // 28: arkrpc.GetSubtreeByScriptsResponse.nodes:type_name -> arkrpc.TreeNode
-	29, // 29: arkrpc.GetSubtreeByScriptsResponse.edges:type_name -> arkrpc.TreeEdge
-	1,  // 30: arkrpc.VTXOEvent.type:type_name -> arkrpc.VTXOEventType
-	17, // 31: arkrpc.VTXOEvent.outpoint:type_name -> arkrpc.OutPoint
-	0,  // 32: arkrpc.VTXOEvent.status:type_name -> arkrpc.VTXOStatus
-	22, // 33: arkrpc.ListVTXOEventsByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
-	32, // 34: arkrpc.ListVTXOEventsByScriptsResponse.events:type_name -> arkrpc.VTXOEvent
-	1,  // 35: arkrpc.IncomingVTXOEvent.type:type_name -> arkrpc.VTXOEventType
-	17, // 36: arkrpc.IncomingVTXOEvent.outpoint:type_name -> arkrpc.OutPoint
-	0,  // 37: arkrpc.IncomingVTXOEvent.status:type_name -> arkrpc.VTXOStatus
-	2,  // 38: arkrpc.IncomingVTXOEvent.origin:type_name -> arkrpc.VTXOOrigin
-	3,  // 39: arkrpc.IndexerService.RegisterReceiveScript:input_type -> arkrpc.RegisterReceiveScriptRequest
-	8,  // 40: arkrpc.IndexerService.ListMyReceiveScripts:input_type -> arkrpc.ListMyReceiveScriptsRequest
-	7,  // 41: arkrpc.IndexerService.UnregisterReceiveScript:input_type -> arkrpc.UnregisterReceiveScriptRequest
-	12, // 42: arkrpc.IndexerService.ListOORRecipientEventsByScript:input_type -> arkrpc.ListOORRecipientEventsByScriptRequest
-	24, // 43: arkrpc.IndexerService.ListVTXOsByScripts:input_type -> arkrpc.ListVTXOsByScriptsRequest
-	26, // 44: arkrpc.IndexerService.GetOORSessionByTxid:input_type -> arkrpc.GetOORSessionByTxidRequest
-	30, // 45: arkrpc.IndexerService.GetSubtreeByScripts:input_type -> arkrpc.GetSubtreeByScriptsRequest
-	33, // 46: arkrpc.IndexerService.ListVTXOEventsByScripts:input_type -> arkrpc.ListVTXOEventsByScriptsRequest
-	6,  // 47: arkrpc.IndexerService.RegisterReceiveScript:output_type -> arkrpc.RegisterReceiveScriptResponse
-	9,  // 48: arkrpc.IndexerService.ListMyReceiveScripts:output_type -> arkrpc.ListMyReceiveScriptsResponse
-	11, // 49: arkrpc.IndexerService.UnregisterReceiveScript:output_type -> arkrpc.UnregisterReceiveScriptResponse
-	13, // 50: arkrpc.IndexerService.ListOORRecipientEventsByScript:output_type -> arkrpc.ListOORRecipientEventsByScriptResponse
-	25, // 51: arkrpc.IndexerService.ListVTXOsByScripts:output_type -> arkrpc.ListVTXOsByScriptsResponse
-	27, // 52: arkrpc.IndexerService.GetOORSessionByTxid:output_type -> arkrpc.GetOORSessionByTxidResponse
-	31, // 53: arkrpc.IndexerService.GetSubtreeByScripts:output_type -> arkrpc.GetSubtreeByScriptsResponse
-	34, // 54: arkrpc.IndexerService.ListVTXOEventsByScripts:output_type -> arkrpc.ListVTXOEventsByScriptsResponse
-	47, // [47:55] is the sub-list for method output_type
-	39, // [39:47] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	39, // [39:39] is the sub-list for extension extendee
-	0,  // [0:39] is the sub-list for field type_name
+	22, // 16: arkrpc.AncestryPath.commitment_inputs:type_name -> arkrpc.CommitmentInputEvidence
+	17, // 17: arkrpc.CommitmentInputEvidence.outpoint:type_name -> arkrpc.OutPoint
+	18, // 18: arkrpc.CommitmentInputEvidence.prev_out:type_name -> arkrpc.TxOut
+	4,  // 19: arkrpc.ScriptScope.taproot_schnorr:type_name -> arkrpc.TaprootSchnorrProof
+	5,  // 20: arkrpc.ScriptScope.bip322:type_name -> arkrpc.BIP322Proof
+	17, // 21: arkrpc.VTXO.outpoint:type_name -> arkrpc.OutPoint
+	0,  // 22: arkrpc.VTXO.status:type_name -> arkrpc.VTXOStatus
+	21, // 23: arkrpc.VTXO.ancestry_paths:type_name -> arkrpc.AncestryPath
+	23, // 24: arkrpc.ListVTXOsByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
+	0,  // 25: arkrpc.ListVTXOsByScriptsRequest.status_filter:type_name -> arkrpc.VTXOStatus
+	24, // 26: arkrpc.ListVTXOsByScriptsResponse.vtxos:type_name -> arkrpc.VTXO
+	23, // 27: arkrpc.GetOORSessionByTxidRequest.script:type_name -> arkrpc.ScriptScope
+	17, // 28: arkrpc.TreeNode.input:type_name -> arkrpc.OutPoint
+	23, // 29: arkrpc.GetSubtreeByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
+	24, // 30: arkrpc.GetSubtreeByScriptsResponse.vtxos:type_name -> arkrpc.VTXO
+	29, // 31: arkrpc.GetSubtreeByScriptsResponse.nodes:type_name -> arkrpc.TreeNode
+	30, // 32: arkrpc.GetSubtreeByScriptsResponse.edges:type_name -> arkrpc.TreeEdge
+	1,  // 33: arkrpc.VTXOEvent.type:type_name -> arkrpc.VTXOEventType
+	17, // 34: arkrpc.VTXOEvent.outpoint:type_name -> arkrpc.OutPoint
+	0,  // 35: arkrpc.VTXOEvent.status:type_name -> arkrpc.VTXOStatus
+	23, // 36: arkrpc.ListVTXOEventsByScriptsRequest.scripts:type_name -> arkrpc.ScriptScope
+	33, // 37: arkrpc.ListVTXOEventsByScriptsResponse.events:type_name -> arkrpc.VTXOEvent
+	1,  // 38: arkrpc.IncomingVTXOEvent.type:type_name -> arkrpc.VTXOEventType
+	17, // 39: arkrpc.IncomingVTXOEvent.outpoint:type_name -> arkrpc.OutPoint
+	0,  // 40: arkrpc.IncomingVTXOEvent.status:type_name -> arkrpc.VTXOStatus
+	2,  // 41: arkrpc.IncomingVTXOEvent.origin:type_name -> arkrpc.VTXOOrigin
+	3,  // 42: arkrpc.IndexerService.RegisterReceiveScript:input_type -> arkrpc.RegisterReceiveScriptRequest
+	8,  // 43: arkrpc.IndexerService.ListMyReceiveScripts:input_type -> arkrpc.ListMyReceiveScriptsRequest
+	7,  // 44: arkrpc.IndexerService.UnregisterReceiveScript:input_type -> arkrpc.UnregisterReceiveScriptRequest
+	12, // 45: arkrpc.IndexerService.ListOORRecipientEventsByScript:input_type -> arkrpc.ListOORRecipientEventsByScriptRequest
+	25, // 46: arkrpc.IndexerService.ListVTXOsByScripts:input_type -> arkrpc.ListVTXOsByScriptsRequest
+	27, // 47: arkrpc.IndexerService.GetOORSessionByTxid:input_type -> arkrpc.GetOORSessionByTxidRequest
+	31, // 48: arkrpc.IndexerService.GetSubtreeByScripts:input_type -> arkrpc.GetSubtreeByScriptsRequest
+	34, // 49: arkrpc.IndexerService.ListVTXOEventsByScripts:input_type -> arkrpc.ListVTXOEventsByScriptsRequest
+	6,  // 50: arkrpc.IndexerService.RegisterReceiveScript:output_type -> arkrpc.RegisterReceiveScriptResponse
+	9,  // 51: arkrpc.IndexerService.ListMyReceiveScripts:output_type -> arkrpc.ListMyReceiveScriptsResponse
+	11, // 52: arkrpc.IndexerService.UnregisterReceiveScript:output_type -> arkrpc.UnregisterReceiveScriptResponse
+	13, // 53: arkrpc.IndexerService.ListOORRecipientEventsByScript:output_type -> arkrpc.ListOORRecipientEventsByScriptResponse
+	26, // 54: arkrpc.IndexerService.ListVTXOsByScripts:output_type -> arkrpc.ListVTXOsByScriptsResponse
+	28, // 55: arkrpc.IndexerService.GetOORSessionByTxid:output_type -> arkrpc.GetOORSessionByTxidResponse
+	32, // 56: arkrpc.IndexerService.GetSubtreeByScripts:output_type -> arkrpc.GetSubtreeByScriptsResponse
+	35, // 57: arkrpc.IndexerService.ListVTXOEventsByScripts:output_type -> arkrpc.ListVTXOEventsByScriptsResponse
+	50, // [50:58] is the sub-list for method output_type
+	42, // [42:50] is the sub-list for method input_type
+	42, // [42:42] is the sub-list for extension type_name
+	42, // [42:42] is the sub-list for extension extendee
+	0,  // [0:42] is the sub-list for field type_name
 }
 
 func init() { file_indexer_proto_init() }
@@ -3064,7 +3159,7 @@ func file_indexer_proto_init() {
 		(*ListOORRecipientEventsByScriptRequest_TaprootSchnorr)(nil),
 		(*ListOORRecipientEventsByScriptRequest_Bip322)(nil),
 	}
-	file_indexer_proto_msgTypes[19].OneofWrappers = []any{
+	file_indexer_proto_msgTypes[20].OneofWrappers = []any{
 		(*ScriptScope_TaprootSchnorr)(nil),
 		(*ScriptScope_Bip322)(nil),
 	}
@@ -3074,7 +3169,7 @@ func file_indexer_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_indexer_proto_rawDesc), len(file_indexer_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   34,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/arkrpc/indexer.proto
+++ b/arkrpc/indexer.proto
@@ -317,6 +317,27 @@ message AncestryPath {
     // tx anchoring this fragment. Zero means unknown (legacy/unconfirmed),
     // in which case the client falls back to a bounded lookback floor.
     int32 commitment_height = 5;
+
+    // commitment_tx is the serialized commitment transaction. Its hash must
+    // equal commitment_txid and tree_path.batch_outpoint.txid.
+    bytes commitment_tx = 6;
+
+    // commitment_inputs contains one previous-output record for every actual
+    // commitment transaction input, in transaction input order.
+    repeated CommitmentInputEvidence commitment_inputs = 7;
+
+    // commitment_csv_expiry_delta is the batch sweep delay in blocks.
+    int32 commitment_csv_expiry_delta = 8;
+}
+
+// CommitmentInputEvidence binds one commitment input to the full previous
+// output needed for authenticated conflict observation.
+message CommitmentInputEvidence {
+    // outpoint must equal the corresponding commitment transaction input.
+    OutPoint outpoint = 1;
+
+    // prev_out supplies the value and pkScript of the spent output.
+    TxOut prev_out = 2;
 }
 
 // ScriptScope selects a pkScript and carries a proof-of-control for that

--- a/batchcanon/admission_test.go
+++ b/batchcanon/admission_test.go
@@ -285,8 +285,17 @@ func TestGetBatchReadsUnderLock(t *testing.T) {
 	h.fireConfirmed(t, txid, 101, testBatchTxid(0xf3))
 	h.fireSpend(t, input, txid, 101)
 
-	// Swap in the lock-asserting store after setup (the actor is now idle,
-	// so there is no concurrent reader of cfg.Store).
+	// Drain the actor before swapping cfg.Store. The mailbox is FIFO and
+	// single-threaded, so this Ask is answered only after every prior
+	// message — including the spend observation that reads cfg.Store on the
+	// actor goroutine — has been fully processed. Without this the bare
+	// field swap below races that read.
+	h.mgrRef.Ask(t.Context(), &QueryLineageRequest{
+		BatchTxIDs: []chainhash.Hash{txid},
+	}).Await(t.Context())
+
+	// Swap in the lock-asserting store; the actor is now idle, so there is
+	// no concurrent reader of cfg.Store.
 	var reads int
 	h.mgr.cfg.Store = storeLockAsserter{
 		Store: h.store, mu: &h.mgr.mu, t: t, reads: &reads,

--- a/batchcanon/admission_test.go
+++ b/batchcanon/admission_test.go
@@ -1,7 +1,9 @@
 package batchcanon
 
 import (
+	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/btcsuite/btcd/chainhash/v2"
@@ -151,4 +153,146 @@ func TestAdmissionFailsClosedOnObservationPersistenceError(t *testing.T) {
 		t, oldToken.Lineage[0].Revision,
 		recovered.Token.Lineage[0].Revision,
 	)
+}
+
+// TestWiredGateFailsClosedViaManagerOverlay proves the WIRED admission gate —
+// which the VTXO manager drives through Manager.GetBatch / LineageBlocked, not
+// the actor QueryLineage path — fails closed after a reorg observation whose
+// durable write failed. Without the manager's GetBatch overlay the gate would
+// read the stale durable row (still Ready) and admit a VTXO whose commitment
+// just left the best chain.
+func TestWiredGateFailsClosedViaManagerOverlay(t *testing.T) {
+	t.Parallel()
+
+	h := newManagerHarness(t, 100)
+	txid := testBatchTxid(0xd7)
+	input := testOutpoint(0xd8, 0)
+	h.registerBatch(t, &RegisterBatchRequest{
+		BatchTxID:            txid,
+		ConfirmationPkScript: []byte{0x51, 0x20, 0xd7},
+		ConsumedInputs:       []ConsumedInput{ci(input)},
+	})
+	h.fireConfirmed(t, txid, 101, testBatchTxid(0xe1))
+	h.fireSpend(t, input, txid, 101)
+
+	// The chain events above are async Tells flowing through the mock
+	// chainsource into the manager actor. Ask the actor (serialized after
+	// them) to synchronize before each direct GetBatch/LineageBlocked call
+	// so the wired-path assertions are not racing that delivery.
+	sync := func() *QueryLineageResponse {
+		t.Helper()
+		resp, err := h.mgrRef.Ask(
+			t.Context(), &QueryLineageRequest{
+				BatchTxIDs: []chainhash.Hash{txid},
+			},
+		).Await(t.Context()).Unpack()
+		require.NoError(t, err)
+		lineage, ok := resp.(*QueryLineageResponse)
+		require.True(t, ok)
+
+		return lineage
+	}
+	require.Equal(t, AvailableProvisional, sync().Availability)
+
+	// Baseline: the wired gate (LineageBlocked over the manager as Reader)
+	// admits the usable provisional lineage.
+	blocked, avail, err := LineageBlocked(t.Context(), h.mgr, txid)
+	require.NoError(t, err)
+	require.False(t, blocked)
+	require.Equal(t, AvailableProvisional, avail)
+
+	// A reorg observation whose durable write fails leaves the durable row
+	// stale (still Ready), but the in-memory overlay knows better.
+	h.store.setApplyError(errors.New("injected durable write failure"))
+	h.fireConfReorged(t, txid)
+
+	// The actor path already fails closed here (it reads the same overlay);
+	// this also synchronizes the reorg before the direct GetBatch below.
+	require.Equal(t, LineageReconciling, sync().Availability)
+
+	durable, err := h.store.GetBatch(t.Context(), txid)
+	require.NoError(t, err)
+	require.True(
+		t, durable.Ready(),
+		"precondition: the durable row stays stale-usable after "+
+			"the failed write",
+	)
+
+	// The wired gate reads through Manager.GetBatch, whose overlay forces
+	// the stale-ready row not-ready, so admission fails closed.
+	overlaid, err := h.mgr.GetBatch(t.Context(), txid)
+	require.NoError(t, err)
+	require.False(
+		t, overlaid.Ready(),
+		"manager overlay must force the stale-ready row not-ready",
+	)
+
+	blocked, avail, err = LineageBlocked(t.Context(), h.mgr, txid)
+	require.NoError(t, err)
+	require.True(t, blocked, "wired gate must refuse admission")
+	require.Equal(t, LineageReconciling, avail)
+}
+
+// storeLockAsserter wraps a Store and fails the test if a durable GetBatch runs
+// without the manager mutex held. Since Receive holds m.mu for the whole of
+// message processing (including the reorg persist), a read taken under the same
+// lock is linearized with the watch snapshot: a reorg cannot land between the
+// read and the snapshot. TryLock returns false only when the mutex is already
+// held, so this deterministically distinguishes the fixed read-under-lock path
+// from the racy read-outside-lock path.
+type storeLockAsserter struct {
+	Store
+
+	mu    *sync.Mutex
+	t     *testing.T
+	reads *int
+}
+
+func (s storeLockAsserter) GetBatch(ctx context.Context, txid chainhash.Hash) (
+	*Record, error) {
+
+	*s.reads++
+	if s.mu.TryLock() {
+		s.mu.Unlock()
+		s.t.Fatal(
+			"GetBatch durable read ran WITHOUT holding m.mu — " +
+				"the read must be linearized with the " +
+				"watch snapshot under one lock, or a " +
+				"concurrent reorg persist can slip between " +
+				"them",
+		)
+	}
+
+	return s.Store.GetBatch(ctx, txid)
+}
+
+// TestGetBatchReadsUnderLock pins the fix for the overlay stale-read race: the
+// durable store read must run under the same m.mu as the watch snapshot, so a
+// reorg that persists a complete ReorgedOut@(r+1) snapshot cannot interleave
+// between a Provisional@r read and the overlay decision and leave the stale
+// record admissible.
+func TestGetBatchReadsUnderLock(t *testing.T) {
+	t.Parallel()
+
+	h := newManagerHarness(t, 100)
+	txid := testBatchTxid(0xf1)
+	input := testOutpoint(0xf2, 0)
+	h.registerBatch(t, &RegisterBatchRequest{
+		BatchTxID:            txid,
+		ConfirmationPkScript: []byte{0x51, 0x20, 0xf1},
+		ConsumedInputs:       []ConsumedInput{ci(input)},
+	})
+	h.fireConfirmed(t, txid, 101, testBatchTxid(0xf3))
+	h.fireSpend(t, input, txid, 101)
+
+	// Swap in the lock-asserting store after setup (the actor is now idle,
+	// so there is no concurrent reader of cfg.Store).
+	var reads int
+	h.mgr.cfg.Store = storeLockAsserter{
+		Store: h.store, mu: &h.mgr.mu, t: t, reads: &reads,
+	}
+
+	_, err := h.mgr.GetBatch(t.Context(), txid)
+	require.NoError(t, err)
+	require.Positive(t, reads, "the durable read must have executed")
 }

--- a/batchcanon/manager.go
+++ b/batchcanon/manager.go
@@ -327,6 +327,9 @@ func validateRegistration(req *RegisterBatchRequest,
 	if len(req.ConfirmationPkScript) == 0 {
 		return fmt.Errorf("batch confirmation pkScript is required")
 	}
+	if req.CSVExpiryDelta <= 0 {
+		return fmt.Errorf("batch CSV expiry delta must be positive")
+	}
 	if len(req.ConsumedInputs) == 0 {
 		return fmt.Errorf("batch must register every consumed input")
 	}

--- a/batchcanon/manager.go
+++ b/batchcanon/manager.go
@@ -1053,10 +1053,53 @@ func observationComplete(w *batchWatch) bool {
 	return true
 }
 
+// GetBatch implements batchcanon.Reader with the manager's in-memory overlay so
+// the wired admission gate fails closed the instant a reorg/conflict
+// observation cannot be persisted. The gate reads availability through this
+// method; when an in-memory watch is not ready — most importantly after an
+// ApplyObservation write failed in persistObservation — the returned record is
+// forced not-ready, so LineageAvailability derives LineageReconciling (never
+// usable) even though the stale durable row still reads ready. The overlay only
+// ever downgrades ready->not-ready, never the reverse, so it is strictly
+// fail-closed. Without it the gate would admit a VTXO whose commitment just
+// left the best chain until a restart durably reconciled the row.
+//
+// The durable read and the watch snapshot are taken under the SAME m.mu that
+// Receive holds for the whole of message processing, so they observe one
+// consistent point in time relative to any concurrent persist. Reading the
+// store outside the lock races a reorg that lands between the read and the
+// snapshot: the read returns Provisional@r, the reorg then persists a complete
+// ReorgedOut@(r+1) snapshot (leaving w.ready=true), and the overlay below would
+// not downgrade the already-read stale record — admitting it.
+func (m *Manager) GetBatch(ctx context.Context, txid chainhash.Hash) (*Record,
+	error) {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	record, err := m.cfg.Store.GetBatch(ctx, txid)
+	if err != nil {
+		return nil, err
+	}
+
+	if w, watched := m.watches[txid]; watched && !w.ready &&
+		record.Ready() {
+
+		notReady := *record
+		notReady.ReadyGeneration = fn.None[uint64]()
+
+		return &notReady, nil
+	}
+
+	return record, nil
+}
+
 // persistObservation atomically writes the complete in-memory view. On any
-// error the manager's overlay closes admission immediately, even if the old
-// durable row was usable; restart reconciliation closes it durably before
-// re-arming watches.
+// error the in-memory watch is marked not-ready; the wired admission gate reads
+// through Manager.GetBatch, whose overlay forces such a batch not-ready even
+// though the stale durable row still reads ready, so admission closes
+// immediately. Restart reconciliation then closes it durably before re-arming
+// watches.
 func (m *Manager) persistObservation(ctx context.Context, w *batchWatch) {
 	inputs := make([]InputObservation, 0, len(w.inputs))
 	for outpoint, input := range w.inputs {

--- a/batchcanon/manager.go
+++ b/batchcanon/manager.go
@@ -214,6 +214,9 @@ func (m *Manager) Receive(ctx context.Context,
 	case *inputSpendDoneMsg:
 		m.handleInputSpendDone(ctx, v)
 
+	case *ConsumerForfeitPersistedMsg:
+		m.handleConsumerForfeitPersisted(ctx, v.ConsumerBatch)
+
 	default:
 		return fn.Err[ManagerResp](
 			fmt.Errorf("unknown batchcanon message: %T", msg),
@@ -1358,6 +1361,36 @@ func (m *Manager) redriveConsumersForCreator(ctx context.Context,
 	}
 
 	return nil
+}
+
+// handleConsumerForfeitPersisted redrives terminal consumer-edge resolution for
+// a batch whose consumed-VTXO forfeiture marker has just become durable. It is
+// the event-driven complement to the restart-time redrive
+// (redriveTerminalConsumerLifecycles): when a consumer batch reaches a terminal
+// state before its ForfeitedBy(consumer) marker exists, the original resolution
+// defers on the revision compare-and-swap, and no further batchcanon event is
+// guaranteed. The marker's arrival is exactly the evidence change that can now
+// let the terminal restore succeed. Resolution is gated on the consumer being
+// Ready and terminal, so a not-yet-final consumer (the common case, since the
+// marker is usually written well before finality) is a harmless no-op.
+func (m *Manager) handleConsumerForfeitPersisted(ctx context.Context,
+	consumerBatch chainhash.Hash) {
+
+	record, err := m.cfg.Store.GetBatch(ctx, consumerBatch)
+	if err != nil {
+		// No record yet (or a transient read error): the restart-time
+		// redrive remains the backstop, so treat this as a no-op.
+		m.logger(ctx).DebugS(ctx, "No batch record to redrive on "+
+			"forfeit persist",
+			slog.String("batch", consumerBatch.String()))
+
+		return
+	}
+	if !record.Ready() || !terminalState(record.State) {
+		return
+	}
+
+	m.handleConsumerLifecycle(ctx, consumerBatch, record.State)
 }
 
 // releaseSpendWatches unregisters the per-input spend watches for a batch,

--- a/batchcanon/manager_provisional_consumer_test.go
+++ b/batchcanon/manager_provisional_consumer_test.go
@@ -111,13 +111,13 @@ func TestManagerRestoresForfeitedVTXOOnConflictFinalized(t *testing.T) {
 	require.Empty(t, remaining, "edges must be cleared after restore")
 }
 
-// TestConsumerForfeitPersistedRedrivesDeferredEdge proves the R14 ordering
-// fix: when a consumer batch reaches ConflictFinalized BEFORE its
-// ForfeitedBy(consumer) marker is durable, the terminal restore compare-and-swap
-// defers and no further batchcanon event is guaranteed -- the consumed VTXO
-// would stay stranded until restart. Once MarkForfeited persists the marker,
-// the VTXO actor sends ConsumerForfeitPersistedMsg, which redrives resolution
-// and restores the VTXO without a restart.
+// TestConsumerForfeitPersistedRedrivesDeferredEdge proves the R14 ordering fix:
+// when a consumer batch reaches ConflictFinalized BEFORE its
+// ForfeitedBy(consumer) marker is durable, the terminal restore
+// compare-and-swap defers and no further batchcanon event is guaranteed -- the
+// consumed VTXO would stay stranded until restart. Once MarkForfeited persists
+// the marker, the VTXO actor sends ConsumerForfeitPersistedMsg, which redrives
+// resolution and restores the VTXO without a restart.
 func TestConsumerForfeitPersistedRedrivesDeferredEdge(t *testing.T) {
 	t.Parallel()
 

--- a/batchcanon/manager_provisional_consumer_test.go
+++ b/batchcanon/manager_provisional_consumer_test.go
@@ -111,6 +111,153 @@ func TestManagerRestoresForfeitedVTXOOnConflictFinalized(t *testing.T) {
 	require.Empty(t, remaining, "edges must be cleared after restore")
 }
 
+// TestConsumerForfeitPersistedRedrivesDeferredEdge proves the R14 ordering
+// fix: when a consumer batch reaches ConflictFinalized BEFORE its
+// ForfeitedBy(consumer) marker is durable, the terminal restore compare-and-swap
+// defers and no further batchcanon event is guaranteed -- the consumed VTXO
+// would stay stranded until restart. Once MarkForfeited persists the marker,
+// the VTXO actor sends ConsumerForfeitPersistedMsg, which redrives resolution
+// and restores the VTXO without a restart.
+func TestConsumerForfeitPersistedRedrivesDeferredEdge(t *testing.T) {
+	t.Parallel()
+
+	rec := &restoreRecorder{}
+	h := newManagerHarnessWithRestore(t, 100, rec.restore)
+
+	// The forfeiture marker is not yet durable: the terminal restore CAS
+	// must defer (as the real revision CAS would).
+	h.store.setDeferConsumerEdges(true)
+
+	consumerBatch := testBatchTxid(0xd2)
+	creatorBatch := testBatchTxid(0xd1)
+	forfeitedVTXO := testOutpoint(0xb1, 0)
+	consumedInput := testOutpoint(0x2e, 1)
+	creatorInput := testOutpoint(0x2d, 1)
+
+	h.registerBatch(t, &RegisterBatchRequest{
+		BatchTxID:            creatorBatch,
+		ConfirmationPkScript: []byte{0x51, 0x20, 0xd1},
+		ConsumedInputs:       []ConsumedInput{ci(creatorInput)},
+	})
+	h.fireConfirmed(t, creatorBatch, 100, testBatchTxid(0xa0))
+	h.fireSpend(t, creatorInput, creatorBatch, 100)
+
+	h.registerBatch(t, &RegisterBatchRequest{
+		BatchTxID:            consumerBatch,
+		ConfirmationPkScript: []byte{0x51, 0x20, 0xd2},
+		ConsumedInputs:       []ConsumedInput{ci(consumedInput)},
+		ConsumedVTXOs: []ConsumerEdge{
+			{
+				ConsumedVTXO:     forfeitedVTXO,
+				ExpectedRevision: 2,
+				CreatorLineage: []chainhash.Hash{
+					creatorBatch,
+				},
+			},
+		},
+	})
+
+	// Drive the consumer to ConflictFinalized while the marker is absent.
+	// Resolution runs but defers: the edge stays pending, nothing restored.
+	h.fireConfirmed(t, consumerBatch, 101, testBatchTxid(0xa1))
+	h.fireSpend(t, consumedInput, testBatchTxid(0x8e), 102)
+	h.fireSpendDone(t, consumedInput)
+	require.Equal(
+		t, StateConflictFinalized,
+		h.state(t, consumerBatch).Record.State,
+	)
+	require.Empty(
+		t, rec.outpoints(),
+		"restore must defer while the forfeiture marker is absent",
+	)
+	pending, err := h.store.ListPendingConsumerEdges(
+		t.Context(), consumerBatch,
+	)
+	require.NoError(t, err)
+	require.Len(
+		t, pending, 1, "the deferred edge must remain pending",
+	)
+
+	// The forfeiture marker becomes durable (MarkForfeited). The VTXO actor
+	// sends ConsumerForfeitPersistedMsg, redriving resolution.
+	h.store.setDeferConsumerEdges(false)
+	_, err = h.mgrRef.Ask(
+		t.Context(),
+		&ConsumerForfeitPersistedMsg{ConsumerBatch: consumerBatch},
+	).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	require.Equal(
+		t, []wire.OutPoint{forfeitedVTXO}, rec.outpoints(),
+		"redrive after the marker persists must restore the VTXO "+
+			"without a restart",
+	)
+	remaining, err := h.store.ListPendingConsumerEdges(
+		t.Context(), consumerBatch,
+	)
+	require.NoError(t, err)
+	require.Empty(t, remaining, "edge must be cleared after redrive")
+}
+
+// TestConsumerForfeitPersistedIgnoresNonTerminalConsumer proves the redrive is
+// gated on the consumer being terminal: a marker persisted while the consumer
+// is still provisional must NOT prematurely resolve the reverse edge (the
+// forfeit's fate is undecided), leaving it pending for a later terminal event.
+func TestConsumerForfeitPersistedIgnoresNonTerminalConsumer(t *testing.T) {
+	t.Parallel()
+
+	rec := &restoreRecorder{}
+	h := newManagerHarnessWithRestore(t, 100, rec.restore)
+
+	consumerBatch := testBatchTxid(0xe2)
+	creatorBatch := testBatchTxid(0xe1)
+	forfeitedVTXO := testOutpoint(0xc1, 0)
+	consumedInput := testOutpoint(0x3e, 1)
+	creatorInput := testOutpoint(0x3d, 1)
+
+	h.registerBatch(t, &RegisterBatchRequest{
+		BatchTxID:            creatorBatch,
+		ConfirmationPkScript: []byte{0x51, 0x20, 0xe1},
+		ConsumedInputs:       []ConsumedInput{ci(creatorInput)},
+	})
+	h.fireConfirmed(t, creatorBatch, 100, testBatchTxid(0x90))
+	h.fireSpend(t, creatorInput, creatorBatch, 100)
+
+	h.registerBatch(t, &RegisterBatchRequest{
+		BatchTxID:            consumerBatch,
+		ConfirmationPkScript: []byte{0x51, 0x20, 0xe2},
+		ConsumedInputs:       []ConsumedInput{ci(consumedInput)},
+		ConsumedVTXOs: []ConsumerEdge{
+			{
+				ConsumedVTXO:     forfeitedVTXO,
+				ExpectedRevision: 2,
+				CreatorLineage: []chainhash.Hash{
+					creatorBatch,
+				},
+			},
+		},
+	})
+
+	// The consumer is only provisionally confirmed (not terminal). A marker
+	// persist redrive must be a no-op: the edge stays pending, no restore.
+	h.fireConfirmed(t, consumerBatch, 101, testBatchTxid(0x91))
+	_, err := h.mgrRef.Ask(
+		t.Context(),
+		&ConsumerForfeitPersistedMsg{ConsumerBatch: consumerBatch},
+	).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
+	require.Empty(
+		t, rec.outpoints(),
+		"a non-terminal consumer must not resolve its reverse edge",
+	)
+	pending, err := h.store.ListPendingConsumerEdges(
+		t.Context(), consumerBatch,
+	)
+	require.NoError(t, err)
+	require.Len(t, pending, 1, "edge must remain pending until terminal")
+}
+
 // TestManagerClearsForfeitEdgesOnFinalized proves the other half of the
 // lifecycle: when the consumer batch becomes canonical and final, the forfeit
 // is permanent, so the reverse-dependency edges are dropped WITHOUT restoring.

--- a/batchcanon/manager_test.go
+++ b/batchcanon/manager_test.go
@@ -751,6 +751,9 @@ func (h *managerHarness) registerBatch(t *testing.T,
 	if len(req.ConfirmationPkScript) == 0 {
 		req.ConfirmationPkScript = []byte{0x51}
 	}
+	if req.CSVExpiryDelta <= 0 {
+		req.CSVExpiryDelta = 144
+	}
 	if len(req.ConsumedInputs) == 0 {
 		req.ConsumedInputs = []ConsumedInput{ci(wire.OutPoint{
 			Hash: req.BatchTxID,

--- a/batchcanon/manager_test.go
+++ b/batchcanon/manager_test.go
@@ -28,6 +28,13 @@ type fakeStore struct {
 	records   map[chainhash.Hash]*Record
 	consumers map[chainhash.Hash][]ConsumerEdge
 	applyErr  error
+
+	// deferConsumerEdges, when true, makes ResolveConsumerEdge report
+	// ConsumerEdgeDeferred without consuming the edge, modelling the real
+	// store's revision compare-and-swap deferring because the
+	// ForfeitedBy(consumer) marker is not yet persisted. Clearing it
+	// simulates the marker becoming durable so a redrive can resolve.
+	deferConsumerEdges bool
 }
 
 func newFakeStore() *fakeStore {
@@ -328,6 +335,12 @@ func (s *fakeStore) setApplyError(err error) {
 	s.applyErr = err
 }
 
+func (s *fakeStore) setDeferConsumerEdges(defer_ bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deferConsumerEdges = defer_
+}
+
 func (s *fakeStore) UpsertBatch(_ context.Context, r *Record) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -478,6 +491,12 @@ func (s *fakeStore) ResolveConsumerEdge(_ context.Context, edge ConsumerEdge,
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Model the revision compare-and-swap deferring while the forfeiture
+	// marker is not yet durable: the edge stays pending for a later redrive.
+	if s.deferConsumerEdges {
+		return ConsumerEdgeDeferred, nil
+	}
 
 	edges := s.consumers[edge.ConsumerBatch]
 	for i, pending := range edges {

--- a/batchcanon/manager_test.go
+++ b/batchcanon/manager_test.go
@@ -493,7 +493,8 @@ func (s *fakeStore) ResolveConsumerEdge(_ context.Context, edge ConsumerEdge,
 	defer s.mu.Unlock()
 
 	// Model the revision compare-and-swap deferring while the forfeiture
-	// marker is not yet durable: the edge stays pending for a later redrive.
+	// marker is not yet durable: the edge stays pending for a later
+	// redrive.
 	if s.deferConsumerEdges {
 		return ConsumerEdgeDeferred, nil
 	}

--- a/batchcanon/messages.go
+++ b/batchcanon/messages.go
@@ -221,6 +221,30 @@ func (m *ackResponse) MessageType() string {
 
 func (m *ackResponse) managerRespSealed() {}
 
+// ConsumerForfeitPersistedMsg tells the manager that a VTXO's forfeiture
+// marker for the given consumer batch has been durably persisted. It closes an
+// ordering race: a consumer batch can become terminally ConflictFinalized
+// (driving restoreProvisionalConsumers) before the ForfeitedBy(consumer)
+// business-revision marker is written, in which case the terminal restore
+// compare-and-swap finds the consumed VTXO at the wrong revision and defers.
+// No further batchcanon event is then guaranteed on the consumer, so the
+// consumed VTXO would stay stranded until the next restart redrive. The VTXO
+// actor sends this the moment MarkForfeited succeeds so resolution can make
+// progress on the newly-durable evidence.
+type ConsumerForfeitPersistedMsg struct {
+	actor.BaseMessage
+
+	// ConsumerBatch is the batch tx into which the VTXO was forfeited.
+	ConsumerBatch chainhash.Hash
+}
+
+// MessageType returns the message type identifier.
+func (m *ConsumerForfeitPersistedMsg) MessageType() string {
+	return "batchcanon.ConsumerForfeitPersistedMsg"
+}
+
+func (m *ConsumerForfeitPersistedMsg) managerMsgSealed() {}
+
 // batchConfirmedMsg is the internal re-wrap of a chainsource ConfirmationEvent
 // for a watched batch tx.
 type batchConfirmedMsg struct {

--- a/batchcanon/record.go
+++ b/batchcanon/record.go
@@ -1,10 +1,73 @@
 package batchcanon
 
 import (
+	"bytes"
+	"fmt"
+
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 )
+
+// BatchEvidence is the authenticated, behavior-free description of one
+// commitment transaction required to register and observe its canonicality.
+// Receive paths carry this separately from the VTXOs that depend on it so one
+// batch can be reused across multi-parent OOR lineage.
+type BatchEvidence struct {
+	// BatchTxID is the hash of BatchTx.
+	BatchTxID chainhash.Hash
+
+	// BatchTx is the serialized commitment transaction.
+	BatchTx []byte
+
+	// BatchOutputIndex selects the commitment output anchoring the tree.
+	BatchOutputIndex uint32
+
+	// ConfirmationPkScript is the selected commitment output script.
+	ConfirmationPkScript []byte
+
+	// CSVExpiryDelta is the batch sweep delay in blocks.
+	CSVExpiryDelta int32
+
+	// ConsumedInputs binds every actual transaction input to its previous
+	// output value and script.
+	ConsumedInputs []ConsumedInput
+}
+
+// RegisterRequest builds an actor request that adds the supplied local VTXOs
+// as dependents of this evidence without mutating the evidence itself.
+func (e BatchEvidence) RegisterRequest(
+	dependentVTXOs []wire.OutPoint) *RegisterBatchRequest {
+
+	inputs := make([]ConsumedInput, len(e.ConsumedInputs))
+	for i := range e.ConsumedInputs {
+		inputs[i] = e.ConsumedInputs[i]
+		inputs[i].PkScript = bytes.Clone(e.ConsumedInputs[i].PkScript)
+	}
+
+	return &RegisterBatchRequest{
+		BatchTxID:            e.BatchTxID,
+		BatchTx:              bytes.Clone(e.BatchTx),
+		BatchOutputIndex:     e.BatchOutputIndex,
+		ConfirmationPkScript: bytes.Clone(e.ConfirmationPkScript),
+		CSVExpiryDelta:       e.CSVExpiryDelta,
+		ConsumedInputs:       inputs,
+		DependentVTXOs: append(
+			[]wire.OutPoint(nil), dependentVTXOs...,
+		),
+	}
+}
+
+// Validate checks the internal transaction, output, and input bindings. The
+// manager repeats these checks at the durable registration boundary.
+func (e BatchEvidence) Validate() error {
+	req := e.RegisterRequest(nil)
+	if err := validateRegistration(req, false); err != nil {
+		return fmt.Errorf("invalid batch evidence: %w", err)
+	}
+
+	return nil
+}
 
 // Record is the durable canonicality view of one batch (commitment)
 // transaction, keyed by its txid. It bundles the interpreted State, the

--- a/batchcanon/record.go
+++ b/batchcanon/record.go
@@ -69,6 +69,11 @@ func (e BatchEvidence) Validate() error {
 	return nil
 }
 
+// Equal reports whether both values carry identical immutable watch evidence.
+func (e BatchEvidence) Equal(other BatchEvidence) bool {
+	return equalBatchEvidence(e, other)
+}
+
 // Record is the durable canonicality view of one batch (commitment)
 // transaction, keyed by its txid. It bundles the interpreted State, the
 // current confirmation observation, the recompute inputs for effective

--- a/batchcanon/record.go
+++ b/batchcanon/record.go
@@ -26,6 +26,11 @@ type BatchEvidence struct {
 	// ConfirmationPkScript is the selected commitment output script.
 	ConfirmationPkScript []byte
 
+	// WatchHeightHint is the earliest height from which watches must scan.
+	// Indexer-sourced evidence uses the observed commitment height; locally
+	// produced evidence uses the round's pre-broadcast start height.
+	WatchHeightHint uint32
+
 	// CSVExpiryDelta is the batch sweep delay in blocks.
 	CSVExpiryDelta int32
 
@@ -50,6 +55,7 @@ func (e BatchEvidence) RegisterRequest(
 		BatchTx:              bytes.Clone(e.BatchTx),
 		BatchOutputIndex:     e.BatchOutputIndex,
 		ConfirmationPkScript: bytes.Clone(e.ConfirmationPkScript),
+		WatchHeightHint:      e.WatchHeightHint,
 		CSVExpiryDelta:       e.CSVExpiryDelta,
 		ConsumedInputs:       inputs,
 		DependentVTXOs: append(

--- a/batchcanon/registration_validation_test.go
+++ b/batchcanon/registration_validation_test.go
@@ -37,6 +37,13 @@ func TestValidateRegistrationBindsSerializedEvidence(t *testing.T) {
 			want: "hash does not match",
 		},
 		{
+			name: "non-positive CSV expiry delta",
+			mutate: func(req *RegisterBatchRequest) {
+				req.CSVExpiryDelta = 0
+			},
+			want: "CSV expiry delta must be positive",
+		},
+		{
 			name: "trailing transaction bytes",
 			mutate: func(req *RegisterBatchRequest) {
 				req.BatchTx = append(req.BatchTx, 0)
@@ -128,6 +135,7 @@ func validRegistrationRequest(t *testing.T) *RegisterBatchRequest {
 		BatchTx:              raw.Bytes(),
 		BatchOutputIndex:     1,
 		ConfirmationPkScript: watchScript,
+		CSVExpiryDelta:       144,
 		ConsumedInputs: []ConsumedInput{
 			{
 				Outpoint: inputA,

--- a/batchcanon/rpc_evidence.go
+++ b/batchcanon/rpc_evidence.go
@@ -17,7 +17,13 @@ func EvidenceFromAncestryPaths(paths []*arkrpc.AncestryPath) ([]BatchEvidence,
 
 	evidence := make([]BatchEvidence, 0, len(paths))
 	seen := make(map[chainhash.Hash]int, len(paths))
+	missing := false
 	for i, path := range paths {
+		if !ancestryEvidencePresent(path) {
+			missing = true
+			continue
+		}
+
 		item, err := evidenceFromAncestryPath(path)
 		if err != nil {
 			return nil, fmt.Errorf("ancestry path %d: %w", i, err)
@@ -36,8 +42,22 @@ func EvidenceFromAncestryPaths(paths []*arkrpc.AncestryPath) ([]BatchEvidence,
 		seen[item.BatchTxID] = len(evidence)
 		evidence = append(evidence, item)
 	}
+	if missing && len(evidence) != 0 {
+		return nil, fmt.Errorf("batch evidence must be supplied for " +
+			"every ancestry path")
+	}
 
 	return evidence, nil
+}
+
+// ancestryEvidencePresent distinguishes an older indexer that omits the whole
+// additive evidence extension from a malformed partial extension. When no
+// path supplies evidence the receive remains rollout-compatible; the
+// fail-closed admission gate will keep its unregistered lineage unusable.
+func ancestryEvidencePresent(path *arkrpc.AncestryPath) bool {
+	return path != nil && (len(path.GetCommitmentTx()) != 0 ||
+		len(path.GetCommitmentInputs()) != 0 ||
+		path.GetCommitmentCsvExpiryDelta() != 0)
 }
 
 // evidenceFromAncestryPath binds the transport fields to the serialized

--- a/batchcanon/rpc_evidence.go
+++ b/batchcanon/rpc_evidence.go
@@ -154,16 +154,17 @@ func evidenceFromAncestryPath(path *arkrpc.AncestryPath) (BatchEvidence,
 
 		// TRUST BOUNDARY: the input outpoint and ordering are
 		// authenticated against the commitment tx's own TxIn above, but
-		// the previous-output value and pkScript below are taken from the
-		// indexer as-is and only sanity-checked for shape (non-negative
-		// value, non-empty script). They are NOT proven against chain
-		// truth here. This matters because the pkScript later keys the
-		// reorg-aware spend notifier for conflict detection: a wrong
-		// script would silently arm the watch on the wrong output and
-		// miss an invalidation-driven restore. Proving each prevout
-		// against the chain (or an authenticated ancestry proof) is the
-		// receive-path authentication slice tracked separately; until it
-		// lands, these fields are trusted-from-indexer, not authenticated.
+		// the previous-output value and pkScript below are taken from
+		// the indexer as-is and only sanity-checked for shape
+		// (non-negative value, non-empty script). They are NOT proven
+		// against chain truth here. This matters because the pkScript
+		// later keys the reorg-aware spend notifier for conflict
+		// detection: a wrong script would silently arm the watch on the
+		// wrong output and miss an invalidation-driven restore. Proving
+		// each prevout against the chain (or an authenticated ancestry
+		// proof) is the receive-path authentication slice tracked
+		// separately; until it lands, these fields are
+		// trusted-from-indexer, not authenticated.
 		prevOut := input.GetPrevOut()
 		if prevOut.GetValue() < 0 {
 			return BatchEvidence{}, fmt.Errorf("commitment input "+

--- a/batchcanon/rpc_evidence.go
+++ b/batchcanon/rpc_evidence.go
@@ -73,6 +73,10 @@ func evidenceFromAncestryPath(path *arkrpc.AncestryPath) (BatchEvidence,
 	if err != nil {
 		return BatchEvidence{}, err
 	}
+	if path.GetCommitmentHeight() < 0 {
+		return BatchEvidence{}, fmt.Errorf("commitment height must " +
+			"not be negative")
+	}
 
 	treePath := path.GetTreePath()
 	if treePath == nil || treePath.GetBatchOutpoint() == nil ||
@@ -182,6 +186,7 @@ func evidenceFromAncestryPath(path *arkrpc.AncestryPath) (BatchEvidence,
 		BatchTx:              bytes.Clone(rawTx),
 		BatchOutputIndex:     outputIndex,
 		ConfirmationPkScript: bytes.Clone(actualOutput.PkScript),
+		WatchHeightHint:      uint32(path.GetCommitmentHeight()),
 		CSVExpiryDelta:       path.GetCommitmentCsvExpiryDelta(),
 		ConsumedInputs:       consumedInputs,
 	}
@@ -218,6 +223,7 @@ func equalBatchEvidence(a, b BatchEvidence) bool {
 	if a.BatchTxID != b.BatchTxID ||
 		a.BatchOutputIndex != b.BatchOutputIndex ||
 		a.CSVExpiryDelta != b.CSVExpiryDelta ||
+		a.WatchHeightHint != b.WatchHeightHint ||
 		!bytes.Equal(a.BatchTx, b.BatchTx) ||
 		!bytes.Equal(a.ConfirmationPkScript, b.ConfirmationPkScript) ||
 		len(a.ConsumedInputs) != len(b.ConsumedInputs) {

--- a/batchcanon/rpc_evidence.go
+++ b/batchcanon/rpc_evidence.go
@@ -1,0 +1,220 @@
+package batchcanon
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/arkrpc"
+)
+
+// EvidenceFromAncestryPaths authenticates the canonicality evidence carried
+// by indexer ancestry paths. Multiple tree fragments may name the same
+// commitment, but their shared evidence must be byte-for-byte consistent.
+func EvidenceFromAncestryPaths(paths []*arkrpc.AncestryPath) ([]BatchEvidence,
+	error) {
+
+	evidence := make([]BatchEvidence, 0, len(paths))
+	seen := make(map[chainhash.Hash]int, len(paths))
+	for i, path := range paths {
+		item, err := evidenceFromAncestryPath(path)
+		if err != nil {
+			return nil, fmt.Errorf("ancestry path %d: %w", i, err)
+		}
+
+		if existing, ok := seen[item.BatchTxID]; ok {
+			if !equalBatchEvidence(evidence[existing], item) {
+				return nil, fmt.Errorf("ancestry path %d "+
+					"conflicts with evidence for "+
+					"commitment %s", i, item.BatchTxID)
+			}
+
+			continue
+		}
+
+		seen[item.BatchTxID] = len(evidence)
+		evidence = append(evidence, item)
+	}
+
+	return evidence, nil
+}
+
+// evidenceFromAncestryPath binds the transport fields to the serialized
+// transaction, its selected tree output, and every actual input prevout.
+func evidenceFromAncestryPath(path *arkrpc.AncestryPath) (BatchEvidence,
+	error) {
+
+	if path == nil {
+		return BatchEvidence{}, fmt.Errorf("path must be provided")
+	}
+
+	commitmentTxID, err := arkrpc.AncestryCommitmentTxID(path)
+	if err != nil {
+		return BatchEvidence{}, err
+	}
+
+	treePath := path.GetTreePath()
+	if treePath == nil || treePath.GetBatchOutpoint() == nil ||
+		treePath.GetBatchOutput() == nil {
+		return BatchEvidence{}, fmt.Errorf("tree path batch output " +
+			"evidence must be provided")
+	}
+
+	batchOutpoint := treePath.GetBatchOutpoint()
+	if len(batchOutpoint.GetTxid()) != chainhash.HashSize ||
+		!bytes.Equal(batchOutpoint.GetTxid(), commitmentTxID[:]) {
+		return BatchEvidence{}, fmt.Errorf("tree path batch outpoint " +
+			"does not match commitment txid")
+	}
+
+	rawTx := path.GetCommitmentTx()
+	reader := bytes.NewReader(rawTx)
+	tx := wire.NewMsgTx(2)
+	if err := tx.Deserialize(reader); err != nil {
+		return BatchEvidence{}, fmt.Errorf("decode commitment "+
+			"transaction: %w", err)
+	}
+	if reader.Len() != 0 {
+		return BatchEvidence{}, fmt.Errorf("commitment transaction "+
+			"has %d trailing bytes", reader.Len())
+	}
+	if tx.TxHash() != commitmentTxID {
+		return BatchEvidence{}, fmt.Errorf("commitment transaction " +
+			"hash does not match commitment txid")
+	}
+
+	outputIndex := batchOutpoint.GetVout()
+	if uint64(outputIndex) >= uint64(len(tx.TxOut)) {
+		return BatchEvidence{}, fmt.Errorf("commitment output index "+
+			"%d is out of range", outputIndex)
+	}
+
+	claimedOutput := treePath.GetBatchOutput()
+	actualOutput := tx.TxOut[outputIndex]
+	if claimedOutput.GetValue() < 0 ||
+		claimedOutput.GetValue() != actualOutput.Value ||
+		!bytes.Equal(
+			claimedOutput.GetPkScript(), actualOutput.PkScript,
+		) {
+		return BatchEvidence{}, fmt.Errorf("tree path batch output "+
+			"does not match commitment transaction output %d",
+			outputIndex)
+	}
+
+	inputEvidence := path.GetCommitmentInputs()
+	if len(inputEvidence) != len(tx.TxIn) {
+		return BatchEvidence{}, fmt.Errorf("commitment transaction "+
+			"has %d inputs, evidence has %d", len(tx.TxIn),
+			len(inputEvidence))
+	}
+
+	consumedInputs := make([]ConsumedInput, len(inputEvidence))
+	for i, input := range inputEvidence {
+		if input == nil || input.GetOutpoint() == nil ||
+			input.GetPrevOut() == nil {
+			return BatchEvidence{}, fmt.Errorf("commitment input "+
+				"%d evidence must be provided", i)
+		}
+
+		outpoint, err := rpcOutpoint(input.GetOutpoint())
+		if err != nil {
+			return BatchEvidence{}, fmt.Errorf("commitment input "+
+				"%d: %w", i, err)
+		}
+		if outpoint != tx.TxIn[i].PreviousOutPoint {
+			return BatchEvidence{}, fmt.Errorf("commitment input "+
+				"%d outpoint does not match transaction input",
+				i)
+		}
+
+		// TRUST BOUNDARY: the input outpoint and ordering are
+		// authenticated against the commitment tx's own TxIn above, but
+		// the previous-output value and pkScript below are taken from the
+		// indexer as-is and only sanity-checked for shape (non-negative
+		// value, non-empty script). They are NOT proven against chain
+		// truth here. This matters because the pkScript later keys the
+		// reorg-aware spend notifier for conflict detection: a wrong
+		// script would silently arm the watch on the wrong output and
+		// miss an invalidation-driven restore. Proving each prevout
+		// against the chain (or an authenticated ancestry proof) is the
+		// receive-path authentication slice tracked separately; until it
+		// lands, these fields are trusted-from-indexer, not authenticated.
+		prevOut := input.GetPrevOut()
+		if prevOut.GetValue() < 0 {
+			return BatchEvidence{}, fmt.Errorf("commitment input "+
+				"%d has negative previous output value", i)
+		}
+		if len(prevOut.GetPkScript()) == 0 {
+			return BatchEvidence{}, fmt.Errorf("commitment input "+
+				"%d has no previous output pkScript", i)
+		}
+
+		consumedInputs[i] = ConsumedInput{
+			Outpoint: outpoint,
+			Value:    prevOut.GetValue(),
+			PkScript: bytes.Clone(prevOut.GetPkScript()),
+		}
+	}
+
+	evidence := BatchEvidence{
+		BatchTxID:            commitmentTxID,
+		BatchTx:              bytes.Clone(rawTx),
+		BatchOutputIndex:     outputIndex,
+		ConfirmationPkScript: bytes.Clone(actualOutput.PkScript),
+		CSVExpiryDelta:       path.GetCommitmentCsvExpiryDelta(),
+		ConsumedInputs:       consumedInputs,
+	}
+	if evidence.CSVExpiryDelta <= 0 {
+		return BatchEvidence{}, fmt.Errorf("commitment CSV expiry " +
+			"delta must be positive")
+	}
+	if err := evidence.Validate(); err != nil {
+		return BatchEvidence{}, err
+	}
+
+	return evidence, nil
+}
+
+// rpcOutpoint decodes the raw-hash outpoint encoding used by arkrpc.
+func rpcOutpoint(outpoint *arkrpc.OutPoint) (wire.OutPoint, error) {
+	if len(outpoint.GetTxid()) != chainhash.HashSize {
+		return wire.OutPoint{}, fmt.Errorf("invalid outpoint txid "+
+			"length %d", len(outpoint.GetTxid()))
+	}
+
+	var txid chainhash.Hash
+	copy(txid[:], outpoint.GetTxid())
+
+	return wire.OutPoint{
+		Hash:  txid,
+		Index: outpoint.GetVout(),
+	}, nil
+}
+
+// equalBatchEvidence compares immutable evidence from duplicate ancestry
+// fragments while ignoring slice ownership.
+func equalBatchEvidence(a, b BatchEvidence) bool {
+	if a.BatchTxID != b.BatchTxID ||
+		a.BatchOutputIndex != b.BatchOutputIndex ||
+		a.CSVExpiryDelta != b.CSVExpiryDelta ||
+		!bytes.Equal(a.BatchTx, b.BatchTx) ||
+		!bytes.Equal(a.ConfirmationPkScript, b.ConfirmationPkScript) ||
+		len(a.ConsumedInputs) != len(b.ConsumedInputs) {
+		return false
+	}
+
+	for i := range a.ConsumedInputs {
+		aInput := a.ConsumedInputs[i]
+		bInput := b.ConsumedInputs[i]
+		if aInput.Outpoint != bInput.Outpoint ||
+			aInput.Value != bInput.Value ||
+			!bytes.Equal(
+				aInput.PkScript, bInput.PkScript,
+			) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/batchcanon/rpc_evidence_test.go
+++ b/batchcanon/rpc_evidence_test.go
@@ -25,6 +25,7 @@ func TestEvidenceFromAncestryPaths(t *testing.T) {
 		t, valid.GetCommitmentCsvExpiryDelta(),
 		evidence[0].CSVExpiryDelta,
 	)
+	require.Equal(t, uint32(87), evidence[0].WatchHeightHint)
 	require.Len(t, evidence[0].ConsumedInputs, 2)
 
 	tests := []struct {
@@ -75,6 +76,13 @@ func TestEvidenceFromAncestryPaths(t *testing.T) {
 				path.CommitmentInputs[0].PrevOut.PkScript = nil
 			},
 			want: "input 0 has no previous output pkScript",
+		},
+		{
+			name: "negative commitment height",
+			mutate: func(path *arkrpc.AncestryPath) {
+				path.CommitmentHeight = -1
+			},
+			want: "commitment height must not be negative",
 		},
 		{
 			name: "non-positive CSV expiry",
@@ -174,8 +182,9 @@ func validRPCBatchEvidence(t *testing.T) *arkrpc.AncestryPath {
 	txid := tx.TxHash()
 
 	return &arkrpc.AncestryPath{
-		CommitmentTxid: append([]byte(nil), txid[:]...),
-		CommitmentTx:   raw.Bytes(),
+		CommitmentTxid:   append([]byte(nil), txid[:]...),
+		CommitmentHeight: 87,
+		CommitmentTx:     raw.Bytes(),
 		CommitmentInputs: []*arkrpc.CommitmentInputEvidence{
 			{
 				Outpoint: rpcTestOutpoint(inputA),

--- a/batchcanon/rpc_evidence_test.go
+++ b/batchcanon/rpc_evidence_test.go
@@ -122,6 +122,28 @@ func TestEvidenceFromDuplicateAncestryPaths(t *testing.T) {
 	require.ErrorContains(t, err, "conflicts with evidence")
 }
 
+// TestEvidenceFromLegacyAncestryPaths keeps the additive RPC extension
+// rollout-compatible while rejecting mixed evidence coverage.
+func TestEvidenceFromLegacyAncestryPaths(t *testing.T) {
+	t.Parallel()
+
+	legacy := validRPCBatchEvidence(t)
+	legacy.CommitmentTx = nil
+	legacy.CommitmentInputs = nil
+	legacy.CommitmentCsvExpiryDelta = 0
+
+	evidence, err := EvidenceFromAncestryPaths(
+		[]*arkrpc.AncestryPath{legacy},
+	)
+	require.NoError(t, err)
+	require.Empty(t, evidence)
+
+	_, err = EvidenceFromAncestryPaths([]*arkrpc.AncestryPath{
+		legacy, validRPCBatchEvidence(t),
+	})
+	require.ErrorContains(t, err, "supplied for every ancestry path")
+}
+
 // cloneRPCBatchEvidence makes independently mutable table-test evidence.
 func cloneRPCBatchEvidence(t *testing.T,
 	path *arkrpc.AncestryPath) *arkrpc.AncestryPath {

--- a/batchcanon/rpc_evidence_test.go
+++ b/batchcanon/rpc_evidence_test.go
@@ -1,0 +1,201 @@
+package batchcanon
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestEvidenceFromAncestryPaths proves the receive trust boundary binds all
+// server-supplied fields to the serialized commitment transaction.
+func TestEvidenceFromAncestryPaths(t *testing.T) {
+	t.Parallel()
+
+	valid := validRPCBatchEvidence(t)
+	evidence, err := EvidenceFromAncestryPaths(
+		[]*arkrpc.AncestryPath{valid},
+	)
+	require.NoError(t, err)
+	require.Len(t, evidence, 1)
+	require.Equal(
+		t, valid.GetCommitmentCsvExpiryDelta(),
+		evidence[0].CSVExpiryDelta,
+	)
+	require.Len(t, evidence[0].ConsumedInputs, 2)
+
+	tests := []struct {
+		name   string
+		mutate func(*arkrpc.AncestryPath)
+		want   string
+	}{
+		{
+			name: "commitment txid mismatch",
+			mutate: func(path *arkrpc.AncestryPath) {
+				path.CommitmentTxid[0] ^= 1
+			},
+			want: "batch outpoint does not match commitment txid",
+		},
+		{
+			name: "serialized transaction mismatch",
+			mutate: func(path *arkrpc.AncestryPath) {
+				path.CommitmentTx[len(path.CommitmentTx)-1] ^= 1
+			},
+			want: "transaction hash does not match",
+		},
+		{
+			name: "tree output value mismatch",
+			mutate: func(path *arkrpc.AncestryPath) {
+				path.TreePath.BatchOutput.Value++
+			},
+			want: "batch output does not match",
+		},
+		{
+			name: "missing input",
+			mutate: func(path *arkrpc.AncestryPath) {
+				path.CommitmentInputs =
+					path.CommitmentInputs[:1]
+			},
+			want: "transaction has 2 inputs, evidence has 1",
+		},
+		{
+			name: "input order mismatch",
+			mutate: func(path *arkrpc.AncestryPath) {
+				inputs := path.CommitmentInputs
+				inputs[0], inputs[1] = inputs[1], inputs[0]
+			},
+			want: "input 0 outpoint does not match",
+		},
+		{
+			name: "missing previous output script",
+			mutate: func(path *arkrpc.AncestryPath) {
+				path.CommitmentInputs[0].PrevOut.PkScript = nil
+			},
+			want: "input 0 has no previous output pkScript",
+		},
+		{
+			name: "non-positive CSV expiry",
+			mutate: func(path *arkrpc.AncestryPath) {
+				path.CommitmentCsvExpiryDelta = 0
+			},
+			want: "CSV expiry delta must be positive",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := cloneRPCBatchEvidence(t, valid)
+			test.mutate(path)
+			_, err := EvidenceFromAncestryPaths(
+				[]*arkrpc.AncestryPath{path},
+			)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+// TestEvidenceFromDuplicateAncestryPaths allows same-commitment multi-leaf
+// ancestry only when its shared commitment evidence agrees.
+func TestEvidenceFromDuplicateAncestryPaths(t *testing.T) {
+	t.Parallel()
+
+	first := validRPCBatchEvidence(t)
+	second := cloneRPCBatchEvidence(t, first)
+	second.TreeDepth++
+
+	evidence, err := EvidenceFromAncestryPaths(
+		[]*arkrpc.AncestryPath{first, second},
+	)
+	require.NoError(t, err)
+	require.Len(t, evidence, 1)
+
+	second.CommitmentInputs[0].PrevOut.Value++
+	_, err = EvidenceFromAncestryPaths(
+		[]*arkrpc.AncestryPath{first, second},
+	)
+	require.ErrorContains(t, err, "conflicts with evidence")
+}
+
+// cloneRPCBatchEvidence makes independently mutable table-test evidence.
+func cloneRPCBatchEvidence(t *testing.T,
+	path *arkrpc.AncestryPath) *arkrpc.AncestryPath {
+
+	t.Helper()
+
+	cloned, ok := proto.Clone(path).(*arkrpc.AncestryPath)
+	require.True(t, ok)
+
+	return cloned
+}
+
+// validRPCBatchEvidence returns complete evidence for a two-input commitment
+// whose second output anchors the supplied tree fragment.
+func validRPCBatchEvidence(t *testing.T) *arkrpc.AncestryPath {
+	t.Helper()
+
+	inputA := testOutpoint(0x11, 1)
+	inputB := testOutpoint(0x22, 2)
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(wire.NewTxIn(&inputA, nil, nil))
+	tx.AddTxIn(wire.NewTxIn(&inputB, nil, nil))
+	tx.AddTxOut(wire.NewTxOut(500, []byte{0x51}))
+	tx.AddTxOut(wire.NewTxOut(1_000, []byte{0x51, 0x20, 0xaa}))
+
+	var raw bytes.Buffer
+	require.NoError(t, tx.Serialize(&raw))
+	txid := tx.TxHash()
+
+	return &arkrpc.AncestryPath{
+		CommitmentTxid: append([]byte(nil), txid[:]...),
+		CommitmentTx:   raw.Bytes(),
+		CommitmentInputs: []*arkrpc.CommitmentInputEvidence{
+			{
+				Outpoint: rpcTestOutpoint(inputA),
+				PrevOut: &arkrpc.TxOut{
+					Value: 700,
+					PkScript: []byte{
+						0x51,
+					},
+				},
+			},
+			{
+				Outpoint: rpcTestOutpoint(inputB),
+				PrevOut: &arkrpc.TxOut{
+					Value: 900,
+					PkScript: []byte{
+						0x00,
+						0x14,
+						0x01,
+					},
+				},
+			},
+		},
+		CommitmentCsvExpiryDelta: 144,
+		TreePath: &arkrpc.TreePath{
+			BatchOutpoint: &arkrpc.OutPoint{
+				Txid: append([]byte(nil), txid[:]...),
+				Vout: 1,
+			},
+			BatchOutput: &arkrpc.TxOut{
+				Value: tx.TxOut[1].Value,
+				PkScript: append(
+					[]byte(nil), tx.TxOut[1].PkScript...,
+				),
+			},
+		},
+	}
+}
+
+// rpcTestOutpoint maps one wire outpoint into the indexer transport shape.
+func rpcTestOutpoint(outpoint wire.OutPoint) *arkrpc.OutPoint {
+	return &arkrpc.OutPoint{
+		Txid: append([]byte(nil), outpoint.Hash[:]...),
+		Vout: outpoint.Index,
+	}
+}

--- a/cmd/wavecli/waveclicommands/cmd_balance.go
+++ b/cmd/wavecli/waveclicommands/cmd_balance.go
@@ -9,8 +9,8 @@ import (
 
 // newBalanceCmd builds the top-level `balance` verb. It dials
 // wavewalletrpc.WalletService.Balance which returns the unified shape
-// (confirmed_sat, pending_in_sat, pending_out_sat) the wallet layer
-// projects onto every backend.
+// (confirmed_sat, pending_in_sat, pending_out_sat, and
+// temporarily_unavailable_sat) the wallet layer projects onto every backend.
 func newBalanceCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "balance",
@@ -19,7 +19,9 @@ func newBalanceCmd() *cobra.Command {
 			"spendable VTXOs (confirmed_sat), in-flight " +
 			"inbound (pending_in_sat: boarding + receive), " +
 			"and in-flight outbound (pending_out_sat: send + " +
-			"exit) — all in satoshis.\n\n" +
+			"exit), plus VTXOs temporarily blocked by lineage " +
+			"canonicality (temporarily_unavailable_sat) — all in " +
+			"satoshis.\n\n" +
 			"Example:\n" +
 			"  wavecli balance",
 		Args: cobra.NoArgs,

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -1868,6 +1868,9 @@ func (s *RoundPersistenceStore) dbVTXOToDomainVTXO(ctx context.Context,
 		CommitmentTxID: commitmentTxID,
 		BatchExpiry:    dbVTXO.BatchExpiry,
 		CreatedHeight:  dbVTXO.CreatedHeight,
+		BusinessRevision: uint64(
+			dbVTXO.BusinessRevision,
+		),
 	}, nil
 }
 

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -158,6 +158,7 @@ const (
 	batchEvidencePkScriptRecordType    tlv.Type = 7
 	batchEvidenceCSVDeltaRecordType    tlv.Type = 9
 	batchEvidenceInputsRecordType      tlv.Type = 11
+	batchEvidenceWatchHeightRecordType tlv.Type = 13
 )
 
 const (
@@ -742,6 +743,7 @@ func encodeBatchEvidence(evidence batchcanon.BatchEvidence) ([]byte, error) {
 	outputIndex := evidence.BatchOutputIndex
 	pkScript := evidence.ConfirmationPkScript
 	csvDelta := uint32(evidence.CSVExpiryDelta)
+	watchHeight := evidence.WatchHeightHint
 	inputs, err := encodeBatchEvidenceInputs(evidence.ConsumedInputs)
 	if err != nil {
 		return nil, err
@@ -761,6 +763,9 @@ func encodeBatchEvidence(evidence batchcanon.BatchEvidence) ([]byte, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			batchEvidenceInputsRecordType, &inputs,
+		),
+		tlv.MakePrimitiveRecord(
+			batchEvidenceWatchHeightRecordType, &watchHeight,
 		),
 	)
 	if err != nil {
@@ -786,6 +791,7 @@ func decodeBatchEvidence(raw []byte,
 		pkScript    []byte
 		csvDelta    uint32
 		inputs      []byte
+		watchHeight uint32
 	)
 
 	stream, err := tlv.NewStream(
@@ -802,6 +808,9 @@ func decodeBatchEvidence(raw []byte,
 		),
 		tlv.MakePrimitiveRecord(
 			batchEvidenceInputsRecordType, &inputs,
+		),
+		tlv.MakePrimitiveRecord(
+			batchEvidenceWatchHeightRecordType, &watchHeight,
 		),
 	)
 	if err != nil {
@@ -836,6 +845,7 @@ func decodeBatchEvidence(raw []byte,
 		BatchTx:              bytes.Clone(tx),
 		BatchOutputIndex:     outputIndex,
 		ConfirmationPkScript: bytes.Clone(pkScript),
+		WatchHeightHint:      watchHeight,
 		CSVExpiryDelta:       decodedCSVDelta,
 		ConsumedInputs:       consumedInputs,
 	}

--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/batchcanon"
 	clientdb "github.com/lightninglabs/wavelength/db"
 	"github.com/lightninglabs/wavelength/lib/tree"
 	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
@@ -147,6 +148,22 @@ const (
 	incomingMetadataMatchCreatedHeightRecordType  tlv.Type = 13
 	incomingMetadataMatchAncestryPathsRecordType  tlv.Type = 17
 	incomingMetadataMatchOperatorKeyRecordType    tlv.Type = 19
+	incomingMetadataMatchBatchEvidenceRecordType  tlv.Type = 23
+)
+
+const (
+	batchEvidenceTxIDRecordType        tlv.Type = 1
+	batchEvidenceTxRecordType          tlv.Type = 3
+	batchEvidenceOutputIndexRecordType tlv.Type = 5
+	batchEvidencePkScriptRecordType    tlv.Type = 7
+	batchEvidenceCSVDeltaRecordType    tlv.Type = 9
+	batchEvidenceInputsRecordType      tlv.Type = 11
+)
+
+const (
+	batchEvidenceInputOutpointRecordType tlv.Type = 1
+	batchEvidenceInputValueRecordType    tlv.Type = 3
+	batchEvidenceInputPkScriptRecordType tlv.Type = 5
 )
 
 type startTransferPayload struct {
@@ -663,6 +680,271 @@ func decodeUint32List(raw []byte) ([]uint32, error) {
 	return out, nil
 }
 
+// encodeBatchEvidenceList encodes each immutable evidence item as its own TLV
+// stream so future additive fields remain replay-compatible.
+func encodeBatchEvidenceList(evidence []batchcanon.BatchEvidence) ([]byte,
+	error) {
+
+	blobs := make([][]byte, 0, len(evidence))
+	for i := range evidence {
+		raw, err := encodeBatchEvidence(evidence[i])
+		if err != nil {
+			return nil, fmt.Errorf("encode batch evidence %d: %w",
+				i, err)
+		}
+
+		blobs = append(blobs, raw)
+	}
+
+	return encodeLengthPrefixedBlobList(blobs)
+}
+
+// decodeBatchEvidenceList decodes and validates durable evidence before it is
+// returned to the receive FSM.
+func decodeBatchEvidenceList(raw []byte,
+	limits ReceiveLimits) ([]batchcanon.BatchEvidence, error) {
+
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	blobs, err := decodeLengthPrefixedBlobListWithLimits(raw, limits)
+	if err != nil {
+		return nil, err
+	}
+
+	evidence := make([]batchcanon.BatchEvidence, 0, len(blobs))
+	for i := range blobs {
+		item, err := decodeBatchEvidence(blobs[i], limits)
+		if err != nil {
+			return nil, fmt.Errorf("decode batch evidence %d: %w",
+				i, err)
+		}
+
+		evidence = append(evidence, item)
+	}
+
+	return evidence, nil
+}
+
+// encodeBatchEvidence serializes one batch's authenticated watch inputs.
+func encodeBatchEvidence(evidence batchcanon.BatchEvidence) ([]byte, error) {
+	if err := evidence.Validate(); err != nil {
+		return nil, err
+	}
+	if evidence.CSVExpiryDelta <= 0 {
+		return nil, fmt.Errorf("batch evidence CSV expiry delta must " +
+			"be positive")
+	}
+
+	txid := evidence.BatchTxID[:]
+	tx := evidence.BatchTx
+	outputIndex := evidence.BatchOutputIndex
+	pkScript := evidence.ConfirmationPkScript
+	csvDelta := uint32(evidence.CSVExpiryDelta)
+	inputs, err := encodeBatchEvidenceInputs(evidence.ConsumedInputs)
+	if err != nil {
+		return nil, err
+	}
+
+	stream, err := tlv.NewStream(
+		tlv.MakePrimitiveRecord(batchEvidenceTxIDRecordType, &txid),
+		tlv.MakePrimitiveRecord(batchEvidenceTxRecordType, &tx),
+		tlv.MakePrimitiveRecord(
+			batchEvidenceOutputIndexRecordType, &outputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			batchEvidencePkScriptRecordType, &pkScript,
+		),
+		tlv.MakePrimitiveRecord(
+			batchEvidenceCSVDeltaRecordType, &csvDelta,
+		),
+		tlv.MakePrimitiveRecord(
+			batchEvidenceInputsRecordType, &inputs,
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := stream.Encode(&buf); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// decodeBatchEvidence reconstructs one evidence item from its TLV stream.
+func decodeBatchEvidence(raw []byte,
+	limits ReceiveLimits) (batchcanon.BatchEvidence, error) {
+
+	var (
+		txid        []byte
+		tx          []byte
+		outputIndex uint32
+		pkScript    []byte
+		csvDelta    uint32
+		inputs      []byte
+	)
+
+	stream, err := tlv.NewStream(
+		tlv.MakePrimitiveRecord(batchEvidenceTxIDRecordType, &txid),
+		tlv.MakePrimitiveRecord(batchEvidenceTxRecordType, &tx),
+		tlv.MakePrimitiveRecord(
+			batchEvidenceOutputIndexRecordType, &outputIndex,
+		),
+		tlv.MakePrimitiveRecord(
+			batchEvidencePkScriptRecordType, &pkScript,
+		),
+		tlv.MakePrimitiveRecord(
+			batchEvidenceCSVDeltaRecordType, &csvDelta,
+		),
+		tlv.MakePrimitiveRecord(
+			batchEvidenceInputsRecordType, &inputs,
+		),
+	)
+	if err != nil {
+		return batchcanon.BatchEvidence{}, err
+	}
+
+	reader := bytes.NewReader(raw)
+	if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
+		return batchcanon.BatchEvidence{}, err
+	}
+	if len(txid) != chainhash.HashSize {
+		return batchcanon.BatchEvidence{}, fmt.Errorf("batch " +
+			"evidence txid must be provided")
+	}
+
+	decodedCSVDelta, err := uint32ToInt32(
+		csvDelta, "batch evidence CSV expiry delta",
+	)
+	if err != nil {
+		return batchcanon.BatchEvidence{}, err
+	}
+
+	consumedInputs, err := decodeBatchEvidenceInputs(inputs, limits)
+	if err != nil {
+		return batchcanon.BatchEvidence{}, err
+	}
+
+	var decodedTxID chainhash.Hash
+	copy(decodedTxID[:], txid)
+	evidence := batchcanon.BatchEvidence{
+		BatchTxID:            decodedTxID,
+		BatchTx:              bytes.Clone(tx),
+		BatchOutputIndex:     outputIndex,
+		ConfirmationPkScript: bytes.Clone(pkScript),
+		CSVExpiryDelta:       decodedCSVDelta,
+		ConsumedInputs:       consumedInputs,
+	}
+	if evidence.CSVExpiryDelta <= 0 {
+		return batchcanon.BatchEvidence{}, fmt.Errorf("batch " +
+			"evidence CSV expiry delta must be positive")
+	}
+	if err := evidence.Validate(); err != nil {
+		return batchcanon.BatchEvidence{}, err
+	}
+
+	return evidence, nil
+}
+
+// encodeBatchEvidenceInputs serializes every previous output as a nested TLV
+// record, preserving transaction-input order.
+func encodeBatchEvidenceInputs(inputs []batchcanon.ConsumedInput) ([]byte,
+	error) {
+
+	blobs := make([][]byte, 0, len(inputs))
+	for i := range inputs {
+		input := inputs[i]
+		if input.Value < 0 {
+			return nil, fmt.Errorf("batch evidence input %d has "+
+				"negative value", i)
+		}
+
+		outpoint := outPointBytes(input.Outpoint)
+		value := uint64(input.Value)
+		pkScript := input.PkScript
+		stream, err := tlv.NewStream(
+			tlv.MakePrimitiveRecord(
+				batchEvidenceInputOutpointRecordType, &outpoint,
+			),
+			tlv.MakePrimitiveRecord(
+				batchEvidenceInputValueRecordType, &value,
+			),
+			tlv.MakePrimitiveRecord(
+				batchEvidenceInputPkScriptRecordType, &pkScript,
+			),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		var buf bytes.Buffer
+		if err := stream.Encode(&buf); err != nil {
+			return nil, err
+		}
+		blobs = append(blobs, buf.Bytes())
+	}
+
+	return encodeLengthPrefixedBlobList(blobs)
+}
+
+// decodeBatchEvidenceInputs decodes the ordered previous-output records.
+func decodeBatchEvidenceInputs(raw []byte,
+	limits ReceiveLimits) ([]batchcanon.ConsumedInput, error) {
+
+	blobs, err := decodeLengthPrefixedBlobListWithLimits(raw, limits)
+	if err != nil {
+		return nil, err
+	}
+
+	inputs := make([]batchcanon.ConsumedInput, 0, len(blobs))
+	for i := range blobs {
+		var (
+			outpoint []byte
+			value    uint64
+			pkScript []byte
+		)
+		stream, err := tlv.NewStream(
+			tlv.MakePrimitiveRecord(
+				batchEvidenceInputOutpointRecordType, &outpoint,
+			),
+			tlv.MakePrimitiveRecord(
+				batchEvidenceInputValueRecordType, &value,
+			),
+			tlv.MakePrimitiveRecord(
+				batchEvidenceInputPkScriptRecordType, &pkScript,
+			),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		reader := bytes.NewReader(blobs[i])
+		if _, err := stream.DecodeWithParsedTypes(reader); err != nil {
+			return nil, err
+		}
+		decodedOutpoint, err := parseOutPointBytes(outpoint)
+		if err != nil {
+			return nil, err
+		}
+		if value > math.MaxInt64 {
+			return nil, fmt.Errorf("batch evidence input %d value "+
+				"overflows int64", i)
+		}
+
+		inputs = append(inputs, batchcanon.ConsumedInput{
+			Outpoint: decodedOutpoint,
+			Value:    int64(value),
+			PkScript: bytes.Clone(pkScript),
+		})
+	}
+
+	return inputs, nil
+}
+
 func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 	outputIndex := match.OutputIndex
 	roundID := []byte(match.Metadata.RoundID)
@@ -673,6 +955,12 @@ func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 	operatorKey := encodeOptionalPubKey(match.Metadata.OperatorKey)
 
 	ancestryBytes, err := encodeAncestryList(match.Metadata.Ancestry)
+	if err != nil {
+		return nil, err
+	}
+	batchEvidence, err := encodeBatchEvidenceList(
+		match.Metadata.BatchEvidence,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -708,6 +996,10 @@ func encodeIncomingMetadataMatch(match IncomingMetadataMatch) ([]byte, error) {
 			incomingMetadataMatchOperatorKeyRecordType,
 			&operatorKey,
 		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchBatchEvidenceRecordType,
+			&batchEvidence,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -737,6 +1029,7 @@ func decodeIncomingMetadataMatchWithLimits(raw []byte,
 		createdHeight  uint32
 		ancestryBytes  []byte
 		operatorKey    []byte
+		batchEvidence  []byte
 	)
 
 	records := []tlv.Record{
@@ -769,6 +1062,10 @@ func decodeIncomingMetadataMatchWithLimits(raw []byte,
 		tlv.MakePrimitiveRecord(
 			incomingMetadataMatchOperatorKeyRecordType,
 			&operatorKey,
+		),
+		tlv.MakePrimitiveRecord(
+			incomingMetadataMatchBatchEvidenceRecordType,
+			&batchEvidence,
 		),
 	}
 
@@ -820,6 +1117,13 @@ func decodeIncomingMetadataMatchWithLimits(raw []byte,
 		return IncomingMetadataMatch{}, err
 	}
 
+	decodedEvidence, err := decodeBatchEvidenceList(
+		batchEvidence, limits,
+	)
+	if err != nil {
+		return IncomingMetadataMatch{}, err
+	}
+
 	var decodedCommitmentTxID chainhash.Hash
 	copy(decodedCommitmentTxID[:], commitmentTxID)
 
@@ -833,6 +1137,7 @@ func decodeIncomingMetadataMatchWithLimits(raw []byte,
 			CreatedHeight:  decodedCreatedHeight,
 			OperatorKey:    decodedOperatorKey,
 			Ancestry:       ancestry,
+			BatchEvidence:  decodedEvidence,
 		},
 	}, nil
 }

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/batchcanon"
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/stretchr/testify/require"
 )
@@ -498,7 +499,9 @@ func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
 	t.Parallel()
 
 	sessionID := SessionID(chainhash.Hash{10, 10, 10})
-	commitmentTxID := chainhash.Hash{11, 11, 11}
+	evidence := testIncomingBatchEvidence(t, 0x11)
+	evidenceList := []batchcanon.BatchEvidence{evidence}
+	commitmentTxID := evidence.BatchTxID
 	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
@@ -518,6 +521,7 @@ func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
 						CommitmentTxID: commitmentTxID,
 						TreeDepth:      0,
 					}},
+					BatchEvidence: evidenceList,
 				},
 			}},
 		},
@@ -553,6 +557,8 @@ func TestDriveEventRequestRoundTripIncomingMetadataResolvedEvent(t *testing.T) {
 		t, commitmentTxID, match.Metadata.Ancestry[0].CommitmentTxID,
 	)
 	require.Nil(t, match.Metadata.Ancestry[0].TreePath)
+	require.Len(t, match.Metadata.BatchEvidence, 1)
+	require.True(t, evidence.Equal(match.Metadata.BatchEvidence[0]))
 }
 
 // TestDriveEventRequestRoundTripIncomingAckSentEvent asserts

--- a/oor/incoming_batch_registration.go
+++ b/oor/incoming_batch_registration.go
@@ -1,0 +1,138 @@
+package oor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/batchcanon"
+)
+
+// BatchRegistrar durably registers authenticated batch evidence and arms its
+// reorg-aware watches before an incoming VTXO can be exposed.
+type BatchRegistrar interface {
+	RegisterBatch(context.Context, *batchcanon.RegisterBatchRequest) error
+}
+
+// RegisterIncomingBatchEvidence registers every distinct commitment named by
+// the resolved metadata. Replays merge the same dependent VTXOs idempotently.
+func RegisterIncomingBatchEvidence(ctx context.Context,
+	registrar BatchRegistrar, sessionID SessionID,
+	matches []IncomingMetadataMatch) error {
+
+	type pendingRegistration struct {
+		evidence   batchcanon.BatchEvidence
+		dependents []wire.OutPoint
+	}
+
+	registrations := make(map[chainhash.Hash]*pendingRegistration)
+	order := make([]chainhash.Hash, 0)
+	outputs := make(map[uint32]struct{}, len(matches))
+	for i := range matches {
+		match := matches[i]
+		if _, duplicate := outputs[match.OutputIndex]; duplicate {
+			return fmt.Errorf("incoming metadata output %d is "+
+				"duplicated", match.OutputIndex)
+		}
+		outputs[match.OutputIndex] = struct{}{}
+
+		if err := validateIncomingEvidenceCoverage(
+			match.Metadata,
+		); err != nil {
+			return fmt.Errorf("incoming metadata output %d: %w",
+				match.OutputIndex, err)
+		}
+
+		dependent := wire.OutPoint{
+			Hash:  chainhash.Hash(sessionID),
+			Index: match.OutputIndex,
+		}
+		for _, evidence := range match.Metadata.BatchEvidence {
+			existing, ok := registrations[evidence.BatchTxID]
+			if !ok {
+				registrations[evidence.BatchTxID] =
+					&pendingRegistration{
+						evidence: evidence,
+						dependents: []wire.OutPoint{
+							dependent,
+						},
+					}
+				order = append(order, evidence.BatchTxID)
+
+				continue
+			}
+
+			if !existing.evidence.Equal(evidence) {
+				return fmt.Errorf("conflicting evidence for "+
+					"commitment %s", evidence.BatchTxID)
+			}
+			existing.dependents = append(
+				existing.dependents, dependent,
+			)
+		}
+	}
+
+	if len(registrations) == 0 {
+		return nil
+	}
+	if registrar == nil {
+		return fmt.Errorf("batch registrar must be provided")
+	}
+
+	for _, txid := range order {
+		registration := registrations[txid]
+		request := registration.evidence.RegisterRequest(
+			registration.dependents,
+		)
+		if err := registrar.RegisterBatch(ctx, request); err != nil {
+			return fmt.Errorf("register commitment %s: %w", txid,
+				err)
+		}
+	}
+
+	return nil
+}
+
+// validateIncomingEvidenceCoverage binds optional evidence to every distinct
+// commitment in the metadata. A completely absent extension remains compatible
+// with older indexers and naturally stays blocked when the fail-closed gate is
+// active.
+func validateIncomingEvidenceCoverage(meta IncomingVTXOMetadata) error {
+	if len(meta.BatchEvidence) == 0 {
+		return nil
+	}
+
+	ancestry := make(map[chainhash.Hash]struct{}, len(meta.Ancestry))
+	for _, fragment := range meta.Ancestry {
+		ancestry[fragment.CommitmentTxID] = struct{}{}
+	}
+
+	seen := make(map[chainhash.Hash]struct{}, len(meta.BatchEvidence))
+	for i, evidence := range meta.BatchEvidence {
+		if err := evidence.Validate(); err != nil {
+			return fmt.Errorf("batch evidence %d: %w", i, err)
+		}
+		if evidence.CSVExpiryDelta <= 0 {
+			return fmt.Errorf("batch evidence %d has non-positive "+
+				"CSV expiry delta", i)
+		}
+		if _, ok := ancestry[evidence.BatchTxID]; !ok {
+			return fmt.Errorf("batch evidence %d names commitment "+
+				"%s outside ancestry", i, evidence.BatchTxID)
+		}
+		if _, duplicate := seen[evidence.BatchTxID]; duplicate {
+			return fmt.Errorf("batch evidence %d duplicates "+
+				"commitment %s", i, evidence.BatchTxID)
+		}
+
+		seen[evidence.BatchTxID] = struct{}{}
+	}
+
+	if len(seen) != len(ancestry) {
+		return fmt.Errorf("batch evidence covers %d of %d ancestry "+
+			"commitments", len(seen), len(ancestry))
+	}
+
+	return nil
+}

--- a/oor/incoming_batch_registration.go
+++ b/oor/incoming_batch_registration.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/batchcanon"
+	"github.com/lightninglabs/wavelength/vtxo"
 )
 
 // BatchRegistrar durably registers authenticated batch evidence and arms its
@@ -15,11 +17,74 @@ type BatchRegistrar interface {
 	RegisterBatch(context.Context, *batchcanon.RegisterBatchRequest) error
 }
 
+// BaseCoinInputs returns the committed base-VTXO outpoints the received coin
+// ultimately descends from, across the full OOR checkpoint/ark chain (F-H1
+// terminator). Each finalized checkpoint has exactly one input; a prevout that
+// spends an ancestor package's ark output is an intermediate OOR hop, so it is
+// skipped — the BASE checkpoints, whose prevouts are the actual commitment-tree
+// leaves, spend no ancestor output. This makes the ancestry bind work uniformly
+// for single-hop AND multi-hop receives: the returned outpoints must each be an
+// authenticated ancestry leaf. Malformed checkpoints (no input) are skipped;
+// upstream ValidateFinalizePackage guarantees well-formed, matched checkpoints,
+// and a fully-empty result fails the bind closed.
+func BaseCoinInputs(rootCheckpoints []*psbt.Packet,
+	ancestors []PackageArtifact) []wire.OutPoint {
+
+	ancestorSessions := make(map[SessionID]struct{}, len(ancestors))
+	for _, a := range ancestors {
+		ancestorSessions[a.SessionID] = struct{}{}
+	}
+
+	var base []wire.OutPoint
+	collect := func(checkpoints []*psbt.Packet) {
+		for _, cp := range checkpoints {
+			if cp == nil || cp.UnsignedTx == nil ||
+				len(cp.UnsignedTx.TxIn) == 0 {
+
+				continue
+			}
+			prevOut := cp.UnsignedTx.TxIn[0].PreviousOutPoint
+			if _, ok := ancestorSessions[SessionID(
+				prevOut.Hash,
+			)]; ok {
+				continue
+			}
+			base = append(base, prevOut)
+		}
+	}
+
+	collect(rootCheckpoints)
+	for _, a := range ancestors {
+		collect(a.FinalCheckpointPSBTs)
+	}
+
+	return base
+}
+
+// IncomingLineageVerifier cryptographically binds a received VTXO's ancestry to
+// the commitments the client is about to watch: it proves each ancestry tree is
+// a genuine, operator-signed descent from its authenticated commitment output
+// (vtxo.VerifyOORAncestryLineage). It is injected rather than called directly so
+// registration-logic tests, which use mock (unsigned) trees, can leave it nil;
+// production wiring always supplies the real verifier. A nil verifier skips the
+// binding.
+type IncomingLineageVerifier func(ancestry []vtxo.Ancestry,
+	evidence []batchcanon.BatchEvidence, chainDepth int,
+	coinInputs []wire.OutPoint) error
+
 // RegisterIncomingBatchEvidence registers every distinct commitment named by
 // the resolved metadata. Replays merge the same dependent VTXOs idempotently.
+// When verifyLineage is non-nil, each match's ancestry is cryptographically
+// bound to its authenticated commitments before any watch is armed (F-H1); a
+// failure fails closed, so no reorg watch is registered on an unverified
+// commitment. coinInputs are the ark tx's real spent outpoints (the checkpoint
+// prevouts), shared across matches: a single-hop receive's ancestry must
+// account for them so a decoy commitment tree cannot be watched in place of the
+// coin's true lineage.
 func RegisterIncomingBatchEvidence(ctx context.Context,
 	registrar BatchRegistrar, sessionID SessionID,
-	matches []IncomingMetadataMatch) error {
+	matches []IncomingMetadataMatch, coinInputs []wire.OutPoint,
+	verifyLineage IncomingLineageVerifier) error {
 
 	type pendingRegistration struct {
 		evidence   batchcanon.BatchEvidence
@@ -42,6 +107,28 @@ func RegisterIncomingBatchEvidence(ctx context.Context,
 		); err != nil {
 			return fmt.Errorf("incoming metadata output %d: %w",
 				match.OutputIndex, err)
+		}
+
+		// Bind the received VTXO's ancestry to its authenticated
+		// commitments before any watch is armed: prove each ancestry
+		// tree is a genuine, operator-signed descent from its
+		// authenticated commitment output, so a malicious indexer
+		// cannot name a real-but-decoy commitment for the client to
+		// watch (F-H1). Only when evidence is present: an absent
+		// evidence extension arms no watch (older-indexer / pre-gate
+		// compatibility, handled above), so there is nothing to bind
+		// and the receive degrades rather than failing. Fail-closed
+		// otherwise.
+		if verifyLineage != nil && len(match.Metadata.BatchEvidence) > 0 {
+			if err := verifyLineage(
+				match.Metadata.Ancestry,
+				match.Metadata.BatchEvidence,
+				match.Metadata.ChainDepth, coinInputs,
+			); err != nil {
+				return fmt.Errorf("incoming metadata output "+
+					"%d: bind lineage: %w",
+					match.OutputIndex, err)
+			}
 		}
 
 		dependent := wire.OutPoint{

--- a/oor/incoming_batch_registration.go
+++ b/oor/incoming_batch_registration.go
@@ -47,6 +47,7 @@ func BaseCoinInputs(rootCheckpoints []*psbt.Packet,
 			if _, ok := ancestorSessions[SessionID(
 				prevOut.Hash,
 			)]; ok {
+
 				continue
 			}
 			base = append(base, prevOut)
@@ -64,10 +65,10 @@ func BaseCoinInputs(rootCheckpoints []*psbt.Packet,
 // IncomingLineageVerifier cryptographically binds a received VTXO's ancestry to
 // the commitments the client is about to watch: it proves each ancestry tree is
 // a genuine, operator-signed descent from its authenticated commitment output
-// (vtxo.VerifyOORAncestryLineage). It is injected rather than called directly so
-// registration-logic tests, which use mock (unsigned) trees, can leave it nil;
-// production wiring always supplies the real verifier. A nil verifier skips the
-// binding.
+// (vtxo.VerifyOORAncestryLineage). It is injected rather than called directly
+// so registration-logic tests, which use mock (unsigned) trees, can leave it
+// nil; production wiring always supplies the real verifier. A nil verifier
+// skips the binding.
 type IncomingLineageVerifier func(ancestry []vtxo.Ancestry,
 	evidence []batchcanon.BatchEvidence, chainDepth int,
 	coinInputs []wire.OutPoint) error
@@ -119,7 +120,9 @@ func RegisterIncomingBatchEvidence(ctx context.Context,
 		// compatibility, handled above), so there is nothing to bind
 		// and the receive degrades rather than failing. Fail-closed
 		// otherwise.
-		if verifyLineage != nil && len(match.Metadata.BatchEvidence) > 0 {
+		if verifyLineage != nil &&
+			len(match.Metadata.BatchEvidence) > 0 {
+
 			if err := verifyLineage(
 				match.Metadata.Ancestry,
 				match.Metadata.BatchEvidence,

--- a/oor/incoming_batch_registration_test.go
+++ b/oor/incoming_batch_registration_test.go
@@ -49,6 +49,7 @@ func TestRegisterIncomingBatchEvidence(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, registrar.requests, 1)
+	require.Equal(t, uint32(87), registrar.requests[0].WatchHeightHint)
 	require.Equal(t, []wire.OutPoint{
 		{
 			Hash:  chainhash.Hash(sessionID),
@@ -135,7 +136,8 @@ func testIncomingBatchEvidence(t *testing.T,
 		ConfirmationPkScript: append(
 			[]byte(nil), tx.TxOut[0].PkScript...,
 		),
-		CSVExpiryDelta: 144,
+		WatchHeightHint: 87,
+		CSVExpiryDelta:  144,
 		ConsumedInputs: []batchcanon.ConsumedInput{{
 			Outpoint: input,
 			Value:    1_500,

--- a/oor/incoming_batch_registration_test.go
+++ b/oor/incoming_batch_registration_test.go
@@ -1,0 +1,147 @@
+package oor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/batchcanon"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingBatchRegistrar struct {
+	requests []*batchcanon.RegisterBatchRequest
+	err      error
+}
+
+// RegisterBatch records one awaited registration for test assertions.
+func (r *recordingBatchRegistrar) RegisterBatch(_ context.Context,
+	request *batchcanon.RegisterBatchRequest) error {
+
+	if r.err != nil {
+		return r.err
+	}
+
+	r.requests = append(r.requests, request)
+
+	return nil
+}
+
+// TestRegisterIncomingBatchEvidence proves same-batch recipient metadata is
+// registered once with every dependent output before materialization.
+func TestRegisterIncomingBatchEvidence(t *testing.T) {
+	t.Parallel()
+
+	evidence := testIncomingBatchEvidence(t, 0x44)
+	sessionID := SessionID(chainhash.Hash{0xaa})
+	registrar := &recordingBatchRegistrar{}
+	matches := []IncomingMetadataMatch{
+		incomingEvidenceMatch(1, evidence),
+		incomingEvidenceMatch(3, evidence),
+	}
+
+	err := RegisterIncomingBatchEvidence(
+		context.Background(), registrar, sessionID, matches,
+	)
+	require.NoError(t, err)
+	require.Len(t, registrar.requests, 1)
+	require.Equal(t, []wire.OutPoint{
+		{
+			Hash:  chainhash.Hash(sessionID),
+			Index: 1,
+		},
+		{
+			Hash:  chainhash.Hash(sessionID),
+			Index: 3,
+		},
+	}, registrar.requests[0].DependentVTXOs)
+}
+
+// TestRegisterIncomingBatchEvidenceFailClosed rejects incomplete coverage and
+// propagates registration failure before a VTXO can be persisted.
+func TestRegisterIncomingBatchEvidenceFailClosed(t *testing.T) {
+	t.Parallel()
+
+	evidence := testIncomingBatchEvidence(t, 0x55)
+	metadata := incomingEvidenceMatch(1, evidence)
+	metadata.Metadata.Ancestry = append(
+		metadata.Metadata.Ancestry, vtxo.Ancestry{
+			CommitmentTxID: chainhash.Hash{0x99},
+		},
+	)
+
+	err := RegisterIncomingBatchEvidence(
+		context.Background(), &recordingBatchRegistrar{}, SessionID{},
+		[]IncomingMetadataMatch{metadata},
+	)
+	require.ErrorContains(t, err, "covers 1 of 2")
+
+	registrationErr := errors.New("watch arm failed")
+	err = RegisterIncomingBatchEvidence(
+		context.Background(), &recordingBatchRegistrar{
+			err: registrationErr,
+		}, SessionID{}, []IncomingMetadataMatch{
+			incomingEvidenceMatch(1, evidence),
+		},
+	)
+	require.ErrorIs(t, err, registrationErr)
+}
+
+// incomingEvidenceMatch builds one output's ancestry/evidence metadata.
+func incomingEvidenceMatch(outputIndex uint32,
+	evidence batchcanon.BatchEvidence) IncomingMetadataMatch {
+
+	return IncomingMetadataMatch{
+		OutputIndex: outputIndex,
+		Metadata: IncomingVTXOMetadata{
+			CommitmentTxID: evidence.BatchTxID,
+			Ancestry: []vtxo.Ancestry{{
+				CommitmentTxID: evidence.BatchTxID,
+			}},
+			BatchEvidence: []batchcanon.BatchEvidence{
+				evidence,
+			},
+		},
+	}
+}
+
+// testIncomingBatchEvidence creates complete evidence for one commitment.
+func testIncomingBatchEvidence(t *testing.T,
+	seed byte) batchcanon.BatchEvidence {
+
+	t.Helper()
+
+	input := wire.OutPoint{
+		Hash: chainhash.Hash{
+			seed,
+		},
+		Index: 2,
+	}
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(wire.NewTxIn(&input, nil, nil))
+	tx.AddTxOut(wire.NewTxOut(1_000, []byte{0x51, seed}))
+
+	var raw bytes.Buffer
+	require.NoError(t, tx.Serialize(&raw))
+
+	return batchcanon.BatchEvidence{
+		BatchTxID:        tx.TxHash(),
+		BatchTx:          raw.Bytes(),
+		BatchOutputIndex: 0,
+		ConfirmationPkScript: append(
+			[]byte(nil), tx.TxOut[0].PkScript...,
+		),
+		CSVExpiryDelta: 144,
+		ConsumedInputs: []batchcanon.ConsumedInput{{
+			Outpoint: input,
+			Value:    1_500,
+			PkScript: []byte{
+				0x51,
+			},
+		}},
+	}
+}

--- a/oor/incoming_batch_registration_test.go
+++ b/oor/incoming_batch_registration_test.go
@@ -107,7 +107,9 @@ func TestRegisterIncomingBatchEvidenceVerifiesLineage(t *testing.T) {
 		nil, vtxo.VerifyOORAncestryLineage,
 	)
 	require.ErrorContains(t, err, "bind lineage")
-	require.Empty(t, registrar.requests, "no watch armed on binding failure")
+	require.Empty(
+		t, registrar.requests, "no watch armed on binding failure",
+	)
 }
 
 // incomingEvidenceMatch builds one output's ancestry/evidence metadata.

--- a/oor/incoming_batch_registration_test.go
+++ b/oor/incoming_batch_registration_test.go
@@ -45,7 +45,7 @@ func TestRegisterIncomingBatchEvidence(t *testing.T) {
 	}
 
 	err := RegisterIncomingBatchEvidence(
-		context.Background(), registrar, sessionID, matches,
+		context.Background(), registrar, sessionID, matches, nil, nil,
 	)
 	require.NoError(t, err)
 	require.Len(t, registrar.requests, 1)
@@ -77,7 +77,7 @@ func TestRegisterIncomingBatchEvidenceFailClosed(t *testing.T) {
 
 	err := RegisterIncomingBatchEvidence(
 		context.Background(), &recordingBatchRegistrar{}, SessionID{},
-		[]IncomingMetadataMatch{metadata},
+		[]IncomingMetadataMatch{metadata}, nil, nil,
 	)
 	require.ErrorContains(t, err, "covers 1 of 2")
 
@@ -87,9 +87,27 @@ func TestRegisterIncomingBatchEvidenceFailClosed(t *testing.T) {
 			err: registrationErr,
 		}, SessionID{}, []IncomingMetadataMatch{
 			incomingEvidenceMatch(1, evidence),
-		},
+		}, nil, nil,
 	)
 	require.ErrorIs(t, err, registrationErr)
+}
+
+// TestRegisterIncomingBatchEvidenceVerifiesLineage proves the injected lineage
+// verifier is actually invoked and fails the registration closed: the real
+// verifier rejects the mock (nil-tree) ancestry, so no watch is armed.
+func TestRegisterIncomingBatchEvidenceVerifiesLineage(t *testing.T) {
+	t.Parallel()
+
+	evidence := testIncomingBatchEvidence(t, 0x66)
+	registrar := &recordingBatchRegistrar{}
+
+	err := RegisterIncomingBatchEvidence(
+		context.Background(), registrar, SessionID{},
+		[]IncomingMetadataMatch{incomingEvidenceMatch(0, evidence)},
+		nil, vtxo.VerifyOORAncestryLineage,
+	)
+	require.ErrorContains(t, err, "bind lineage")
+	require.Empty(t, registrar.requests, "no watch armed on binding failure")
 }
 
 // incomingEvidenceMatch builds one output's ancestry/evidence metadata.

--- a/oor/incoming_metadata_query.go
+++ b/oor/incoming_metadata_query.go
@@ -7,6 +7,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/batchcanon"
 	"github.com/lightninglabs/wavelength/vtxo"
 )
 
@@ -165,6 +166,14 @@ func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (IncomingVTXOMetadata,
 			"paths: %w", err)
 	}
 
+	evidence, err := batchcanon.EvidenceFromAncestryPaths(
+		candidate.GetAncestryPaths(),
+	)
+	if err != nil {
+		return IncomingVTXOMetadata{}, fmt.Errorf("convert batch "+
+			"evidence: %w", err)
+	}
+
 	operatorKey, err := incomingOperatorKeyFromRPC(
 		candidate.GetOperatorPubkey(),
 	)
@@ -183,6 +192,7 @@ func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (IncomingVTXOMetadata,
 		CreatedHeight:  candidate.GetCreatedHeight(),
 		OperatorKey:    operatorKey,
 		Ancestry:       ancestry,
+		BatchEvidence:  evidence,
 	}, nil
 }
 

--- a/oor/incoming_vtxo.go
+++ b/oor/incoming_vtxo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/batchcanon"
 	clientdb "github.com/lightninglabs/wavelength/db"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightninglabs/wavelength/lib/tree"
@@ -62,6 +63,12 @@ type IncomingVTXOMetadata struct {
 	// commitment tx. Each entry carries its own TreePath, CommitmentTxID,
 	// InputIndices, and TreeDepth.
 	Ancestry []vtxo.Ancestry
+
+	// BatchEvidence authenticates every distinct commitment named by
+	// Ancestry and supplies the inputs required for reorg-aware conflict
+	// watches. Same-commitment multi-leaf ancestry shares one evidence
+	// item.
+	BatchEvidence []batchcanon.BatchEvidence
 }
 
 // IncomingVTXOConfig describes how to materialize an Ark tx output into a

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -94,6 +94,11 @@ type LocalPersistenceOutboxHandler struct {
 	// Store is the VTXO store to update.
 	Store vtxo.VTXOStore
 
+	// BatchRegistrar registers authenticated lineage before synchronous
+	// callers materialize incoming VTXOs. Durable actors register outside
+	// their commit transaction before invoking this handler.
+	BatchRegistrar BatchRegistrar
+
 	// PackageStore persists finalized OOR package artifacts and local
 	// outpoint bindings.
 	PackageStore PackagePersistence
@@ -161,6 +166,15 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 	err := h.validateMaterializeIncoming(ctx, msg)
 	if err != nil {
 		return nil, err
+	}
+	if !hasActorDBTx(ctx) {
+		err := RegisterIncomingBatchEvidence(
+			ctx, h.BatchRegistrar, msg.SessionID,
+			msg.MetadataMatches,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return h.materializeIncoming(ctx, msg, !hasActorDBTx(ctx))

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -99,6 +99,12 @@ type LocalPersistenceOutboxHandler struct {
 	// their commit transaction before invoking this handler.
 	BatchRegistrar BatchRegistrar
 
+	// IncomingLineageVerifier cryptographically binds a received VTXO's
+	// ancestry to its authenticated commitments before any reorg watch is
+	// armed (F-H1). Nil skips the binding; production wires
+	// vtxo.VerifyOORAncestryLineage.
+	IncomingLineageVerifier IncomingLineageVerifier
+
 	// PackageStore persists finalized OOR package artifacts and local
 	// outpoint bindings.
 	PackageStore PackagePersistence
@@ -171,6 +177,10 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 		err := RegisterIncomingBatchEvidence(
 			ctx, h.BatchRegistrar, msg.SessionID,
 			msg.MetadataMatches,
+			BaseCoinInputs(
+				msg.FinalCheckpointPSBTs, msg.AncestorPackages,
+			),
+			h.IncomingLineageVerifier,
 		)
 		if err != nil {
 			return nil, err

--- a/oor/local_persistence_handler.go
+++ b/oor/local_persistence_handler.go
@@ -176,8 +176,7 @@ func (h *LocalPersistenceOutboxHandler) handleMaterializeIncoming(
 	if !hasActorDBTx(ctx) {
 		err := RegisterIncomingBatchEvidence(
 			ctx, h.BatchRegistrar, msg.SessionID,
-			msg.MetadataMatches,
-			BaseCoinInputs(
+			msg.MetadataMatches, BaseCoinInputs(
 				msg.FinalCheckpointPSBTs, msg.AncestorPackages,
 			),
 			h.IncomingLineageVerifier,

--- a/oor/registry.go
+++ b/oor/registry.go
@@ -77,6 +77,7 @@ type OORRegistryConfig struct {
 	Log                  fn.Option[btclog.Logger]
 	Signer               input.Signer
 	IncomingHandler      OutboxHandler
+	BatchRegistrar       BatchRegistrar
 	RegistryStore        SessionRegistryStore
 	DeliveryStore        actor.DeliveryStore
 	ServerConn           actor.TellOnlyRef[serverconn.ServerConnMsg]
@@ -1602,6 +1603,7 @@ func (r *oorRegistryBehavior) childConfig(sessionID SessionID,
 		Log:                     r.cfg.Log,
 		Signer:                  r.cfg.Signer,
 		IncomingHandler:         r.cfg.IncomingHandler,
+		BatchRegistrar:          r.cfg.BatchRegistrar,
 		RegistryStore:           r.cfg.RegistryStore,
 		DeliveryStore:           r.cfg.DeliveryStore,
 		ServerConn:              r.cfg.ServerConn,

--- a/oor/registry.go
+++ b/oor/registry.go
@@ -74,25 +74,29 @@ const detachedWaitTimeout = 5 * time.Minute
 // the registry's own wiring is a per-session dependency forwarded verbatim into
 // each child actor via childConfig.
 type OORRegistryConfig struct {
-	Log                  fn.Option[btclog.Logger]
-	Signer               input.Signer
-	IncomingHandler      OutboxHandler
-	BatchRegistrar       BatchRegistrar
-	RegistryStore        SessionRegistryStore
-	DeliveryStore        actor.DeliveryStore
-	ServerConn           actor.TellOnlyRef[serverconn.ServerConnMsg]
-	VTXOManager          actor.TellOnlyRef[vtxo.ManagerMsg]
-	SpendCompleter       SpendCompleter
-	SpendReleaser        SpendReleaser
-	ReservationStore     ReservationStore
-	PackageStore         PackagePersistence
-	VTXOStore            vtxo.VTXOStore
-	LedgerSink           fn.Option[ledger.Sink]
-	IncomingVTXOObserver IncomingVTXONotifier
-	Limits               ReceiveLimits
-	TimeoutActor         actor.TellOnlyRef[timeout.Msg]
-	CallbackRef          actor.TellOnlyRef[*timeout.ExpiredMsg]
-	ActorSystem          actor.SystemContext
+	Log             fn.Option[btclog.Logger]
+	Signer          input.Signer
+	IncomingHandler OutboxHandler
+	BatchRegistrar  BatchRegistrar
+	// IncomingLineageVerifier binds a received VTXO's ancestry to its
+	// authenticated commitments before any reorg watch is armed (F-H1); nil
+	// skips it. Threaded into each session's SessionActorConfig.
+	IncomingLineageVerifier IncomingLineageVerifier
+	RegistryStore           SessionRegistryStore
+	DeliveryStore           actor.DeliveryStore
+	ServerConn              actor.TellOnlyRef[serverconn.ServerConnMsg]
+	VTXOManager             actor.TellOnlyRef[vtxo.ManagerMsg]
+	SpendCompleter          SpendCompleter
+	SpendReleaser           SpendReleaser
+	ReservationStore        ReservationStore
+	PackageStore            PackagePersistence
+	VTXOStore               vtxo.VTXOStore
+	LedgerSink              fn.Option[ledger.Sink]
+	IncomingVTXOObserver    IncomingVTXONotifier
+	Limits                  ReceiveLimits
+	TimeoutActor            actor.TellOnlyRef[timeout.Msg]
+	CallbackRef             actor.TellOnlyRef[*timeout.ExpiredMsg]
+	ActorSystem             actor.SystemContext
 
 	// Clock is the deterministic time source forwarded into every session
 	// FSM Environment. When nil, sessions default to a real clock.
@@ -1604,6 +1608,7 @@ func (r *oorRegistryBehavior) childConfig(sessionID SessionID,
 		Signer:                  r.cfg.Signer,
 		IncomingHandler:         r.cfg.IncomingHandler,
 		BatchRegistrar:          r.cfg.BatchRegistrar,
+		IncomingLineageVerifier: r.cfg.IncomingLineageVerifier,
 		RegistryStore:           r.cfg.RegistryStore,
 		DeliveryStore:           r.cfg.DeliveryStore,
 		ServerConn:              r.cfg.ServerConn,

--- a/oor/session_actor.go
+++ b/oor/session_actor.go
@@ -48,6 +48,10 @@ type SessionActorConfig struct {
 	// Its writes join the turn transaction via the request context.
 	IncomingHandler OutboxHandler
 
+	// BatchRegistrar registers authenticated lineage before incoming VTXO
+	// materialization is staged into the actor's database transaction.
+	BatchRegistrar BatchRegistrar
+
 	// RegistryStore is the single source of truth for this session's
 	// durable state. The actor writes its snapshot here inside Commit
 	// (joining the turn transaction) and the registry reads it for restore
@@ -934,6 +938,13 @@ func (b *sessionBehavior) driveOutboxEvents(ctx context.Context,
 		// snapshot after the commit work runs.
 		case *MaterializeIncomingVTXOsRequest:
 			materialize := m
+			if err := RegisterIncomingBatchEvidence(
+				ctx, b.cfg.BatchRegistrar, b.sessionID,
+				materialize.MetadataMatches,
+			); err != nil {
+				return err
+			}
+
 			b.logger(ctx).DebugS(ctx, "Staging incoming VTXO "+
 				"materialization for commit",
 				slog.String(

--- a/oor/session_actor.go
+++ b/oor/session_actor.go
@@ -946,8 +946,7 @@ func (b *sessionBehavior) driveOutboxEvents(ctx context.Context,
 			materialize := m
 			if err := RegisterIncomingBatchEvidence(
 				ctx, b.cfg.BatchRegistrar, b.sessionID,
-				materialize.MetadataMatches,
-				BaseCoinInputs(
+				materialize.MetadataMatches, BaseCoinInputs(
 					materialize.FinalCheckpointPSBTs,
 					materialize.AncestorPackages,
 				),

--- a/oor/session_actor.go
+++ b/oor/session_actor.go
@@ -52,6 +52,12 @@ type SessionActorConfig struct {
 	// materialization is staged into the actor's database transaction.
 	BatchRegistrar BatchRegistrar
 
+	// IncomingLineageVerifier cryptographically binds a received VTXO's
+	// ancestry to its authenticated commitments before any reorg watch is
+	// armed (F-H1). Nil skips the binding (harness paths); production wires
+	// vtxo.VerifyOORAncestryLineage.
+	IncomingLineageVerifier IncomingLineageVerifier
+
 	// RegistryStore is the single source of truth for this session's
 	// durable state. The actor writes its snapshot here inside Commit
 	// (joining the turn transaction) and the registry reads it for restore
@@ -941,6 +947,11 @@ func (b *sessionBehavior) driveOutboxEvents(ctx context.Context,
 			if err := RegisterIncomingBatchEvidence(
 				ctx, b.cfg.BatchRegistrar, b.sessionID,
 				materialize.MetadataMatches,
+				BaseCoinInputs(
+					materialize.FinalCheckpointPSBTs,
+					materialize.AncestorPackages,
+				),
+				b.cfg.IncomingLineageVerifier,
 			); err != nil {
 				return err
 			}

--- a/round/actor.go
+++ b/round/actor.go
@@ -370,6 +370,10 @@ type RoundClientConfig struct {
 	// VTXOStore persists off-chain balance.
 	VTXOStore VTXOStore
 
+	// BatchRegistrar installs authenticated commitment evidence before the
+	// round exposes newly created VTXOs. Nil is allowed in focused tests.
+	BatchRegistrar RoundBatchRegistrar
+
 	// OperatorTerms contains the operator's parameters.
 	OperatorTerms *types.OperatorTerms
 
@@ -509,17 +513,16 @@ func NewRoundClientActor(cfg *RoundClientConfig) fn.Result[*RoundClientActor] {
 	// (e.g., lib.NewTreeSignerSession, signing helpers). StartHeight is set
 	// to 0 here and will be set per-round when FSMs are created.
 	env := &ClientEnvironment{
-		RoundStore:      cfg.RoundStore,
-		VTXOStore:       cfg.VTXOStore,
-		Wallet:          cfg.Wallet,
-		SigningExecutor: cfg.SigningExecutor,
-		OperatorTerms:   cfg.OperatorTerms,
-		ChainParams:     cfg.ChainParams,
-		MaxOperatorFee:  cfg.MaxOperatorFee,
-		AutoRefreshFeeFloor: cfg.
-			AutoRefreshFeeFloor,
-		AutoRefreshFeeRatePPM: cfg.
-			AutoRefreshFeeRatePPM,
+		RoundStore:             cfg.RoundStore,
+		VTXOStore:              cfg.VTXOStore,
+		BatchRegistrar:         cfg.BatchRegistrar,
+		Wallet:                 cfg.Wallet,
+		SigningExecutor:        cfg.SigningExecutor,
+		OperatorTerms:          cfg.OperatorTerms,
+		ChainParams:            cfg.ChainParams,
+		MaxOperatorFee:         cfg.MaxOperatorFee,
+		AutoRefreshFeeFloor:    cfg.AutoRefreshFeeFloor,
+		AutoRefreshFeeRatePPM:  cfg.AutoRefreshFeeRatePPM,
 		Log:                    actorLog,
 		DisableJoinRequestAuth: cfg.DisableJoinRequestAuth,
 		OwnedScriptChecker:     cfg.OwnedScriptChecker,
@@ -925,17 +928,16 @@ func (a *RoundClientActor) createRoundFSMFromDB(ctx context.Context,
 	fsmLogger := a.log.WithPrefix(fsmPrefix)
 
 	env := &ClientEnvironment{
-		RoundStore:      a.cfg.RoundStore,
-		VTXOStore:       a.cfg.VTXOStore,
-		Wallet:          a.cfg.Wallet,
-		SigningExecutor: a.env.SigningExecutor,
-		OperatorTerms:   a.cfg.OperatorTerms,
-		ChainParams:     a.cfg.ChainParams,
-		MaxOperatorFee:  a.cfg.MaxOperatorFee,
-		AutoRefreshFeeFloor: a.cfg.
-			AutoRefreshFeeFloor,
-		AutoRefreshFeeRatePPM: a.cfg.
-			AutoRefreshFeeRatePPM,
+		RoundStore:             a.cfg.RoundStore,
+		VTXOStore:              a.cfg.VTXOStore,
+		BatchRegistrar:         a.cfg.BatchRegistrar,
+		Wallet:                 a.cfg.Wallet,
+		SigningExecutor:        a.env.SigningExecutor,
+		OperatorTerms:          a.cfg.OperatorTerms,
+		ChainParams:            a.cfg.ChainParams,
+		MaxOperatorFee:         a.cfg.MaxOperatorFee,
+		AutoRefreshFeeFloor:    a.cfg.AutoRefreshFeeFloor,
+		AutoRefreshFeeRatePPM:  a.cfg.AutoRefreshFeeRatePPM,
 		Log:                    fsmLogger,
 		StartHeight:            startHeight,
 		QueryBestHeight:        a.queryBestHeight,
@@ -1001,17 +1003,16 @@ func (a *RoundClientActor) createNewRound(ctx context.Context) (*RoundFSM,
 	fsmLogger := a.log.WithPrefix(fsmPrefix)
 
 	env := &ClientEnvironment{
-		RoundStore:      a.cfg.RoundStore,
-		VTXOStore:       a.cfg.VTXOStore,
-		Wallet:          a.cfg.Wallet,
-		SigningExecutor: a.env.SigningExecutor,
-		OperatorTerms:   a.cfg.OperatorTerms,
-		ChainParams:     a.cfg.ChainParams,
-		MaxOperatorFee:  a.cfg.MaxOperatorFee,
-		AutoRefreshFeeFloor: a.cfg.
-			AutoRefreshFeeFloor,
-		AutoRefreshFeeRatePPM: a.cfg.
-			AutoRefreshFeeRatePPM,
+		RoundStore:             a.cfg.RoundStore,
+		VTXOStore:              a.cfg.VTXOStore,
+		BatchRegistrar:         a.cfg.BatchRegistrar,
+		Wallet:                 a.cfg.Wallet,
+		SigningExecutor:        a.env.SigningExecutor,
+		OperatorTerms:          a.cfg.OperatorTerms,
+		ChainParams:            a.cfg.ChainParams,
+		MaxOperatorFee:         a.cfg.MaxOperatorFee,
+		AutoRefreshFeeFloor:    a.cfg.AutoRefreshFeeFloor,
+		AutoRefreshFeeRatePPM:  a.cfg.AutoRefreshFeeRatePPM,
 		Log:                    fsmLogger,
 		StartHeight:            startHeight,
 		QueryBestHeight:        a.queryBestHeight,

--- a/round/batch_registration_test.go
+++ b/round/batch_registration_test.go
@@ -1,0 +1,193 @@
+package round
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/batchcanon"
+	"github.com/lightninglabs/wavelength/lib/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type testRoundBatchRegistrar struct {
+	register func(context.Context, *batchcanon.RegisterBatchRequest) error
+}
+
+func (t *testRoundBatchRegistrar) RegisterBatch(ctx context.Context,
+	req *batchcanon.RegisterBatchRequest) error {
+
+	return t.register(ctx, req)
+}
+
+// TestInputSigSentRegistersBatchBeforeExposure verifies the confirmation path
+// durably registers complete commitment evidence before it saves any VTXO.
+func TestInputSigSentRegistersBatchBeforeExposure(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+	state := h.newInputSigSentState(
+		testRoundIDTr("round-register-batch"), []BoardingIntent{intent},
+	)
+	state.SweepDelay = 1008
+	h.withState(state)
+
+	var (
+		registered   bool
+		saved        bool
+		registration *batchcanon.RegisterBatchRequest
+	)
+	h.vtxoStore.On(
+		"SaveVTXOs", mock.Anything, mock.Anything,
+	).Run(func(mock.Arguments) {
+		require.True(t, registered, "VTXOs saved before registration")
+		saved = true
+	}).Return(nil)
+	h.env.BatchRegistrar = &testRoundBatchRegistrar{
+		register: func(_ context.Context,
+			req *batchcanon.RegisterBatchRequest) error {
+
+			require.False(
+				t, saved, "registration ran after VTXO save",
+			)
+			registered = true
+			registration = req
+
+			return nil
+		},
+	}
+
+	commitmentTx := state.CommitmentTx.UnsignedTx
+	_, err := h.sendEvent(&BoardingConfirmed{
+		TxID:        commitmentTx.TxHash(),
+		BlockHeight: 101,
+	})
+	require.NoError(t, err)
+	require.True(t, registered)
+	require.True(t, saved)
+	require.NotNil(t, registration)
+	require.Equal(t, commitmentTx.TxHash(), registration.BatchTxID)
+	require.Equal(t, uint32(0), registration.BatchOutputIndex)
+	require.Equal(t, int32(1008), registration.CSVExpiryDelta)
+	require.Equal(
+		t, commitmentTx.TxOut[0].PkScript,
+		registration.ConfirmationPkScript,
+	)
+	require.Len(t, registration.ConsumedInputs, 1)
+	require.Equal(
+		t, commitmentTx.TxIn[0].PreviousOutPoint,
+		registration.ConsumedInputs[0].Outpoint,
+	)
+	require.Equal(
+		t, state.CommitmentTx.Inputs[0].WitnessUtxo.Value,
+		registration.ConsumedInputs[0].Value,
+	)
+	require.Equal(
+		t, state.CommitmentTx.Inputs[0].WitnessUtxo.PkScript,
+		registration.ConsumedInputs[0].PkScript,
+	)
+	require.Len(t, registration.DependentVTXOs, 1)
+	require.Empty(t, registration.ConsumedVTXOs)
+
+	var decoded wire.MsgTx
+	require.NoError(
+		t,
+		decoded.Deserialize(
+			bytes.NewReader(registration.BatchTx),
+		),
+	)
+	require.Equal(t, commitmentTx.TxHash(), decoded.TxHash())
+}
+
+// TestRoundBatchRegistrationBindsRefreshConsumer verifies a refresh edge uses
+// the exact next lifecycle revision and the full distinct creator lineage.
+func TestRoundBatchRegistrationBindsRefreshConsumer(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+	state := h.newInputSigSentState(
+		testRoundIDTr("round-register-refresh"),
+		[]BoardingIntent{intent},
+	)
+	forfeitedOutpoint := h.newTestOutpoint()
+	creatorA := chainhash.HashH([]byte("creator-a"))
+	creatorB := chainhash.HashH([]byte("creator-b"))
+	state.ForfeitedVTXOs = []wire.OutPoint{forfeitedOutpoint}
+	h.withState(state)
+
+	h.setupMockVTXOStoreForSave()
+	h.vtxoStore.On(
+		"GetVTXO", mock.Anything, forfeitedOutpoint,
+	).Return(&ClientVTXO{
+		Outpoint:         forfeitedOutpoint,
+		CommitmentTxID:   creatorA,
+		BusinessRevision: 7,
+		Ancestry: []types.Ancestry{
+			{CommitmentTxID: creatorA},
+			{CommitmentTxID: creatorB},
+		},
+	}, nil)
+
+	var registration *batchcanon.RegisterBatchRequest
+	h.env.BatchRegistrar = &testRoundBatchRegistrar{
+		register: func(_ context.Context,
+			req *batchcanon.RegisterBatchRequest) error {
+
+			registration = req
+
+			return nil
+		},
+	}
+
+	batchTxID := state.CommitmentTx.UnsignedTx.TxHash()
+	_, err := h.sendEvent(&BoardingConfirmed{
+		TxID:        batchTxID,
+		BlockHeight: 101,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, registration)
+	require.Len(t, registration.ConsumedVTXOs, 1)
+
+	edge := registration.ConsumedVTXOs[0]
+	require.Equal(t, forfeitedOutpoint, edge.ConsumedVTXO)
+	require.Equal(t, batchTxID, edge.ConsumerBatch)
+	require.Equal(t, uint64(8), edge.ExpectedRevision)
+	require.Equal(
+		t, []chainhash.Hash{creatorA, creatorB}, edge.CreatorLineage,
+	)
+}
+
+// TestInputSigSentRegistrationFailureDoesNotExposeVTXOs verifies a failed
+// registration leaves the fail-closed boundary intact.
+func TestInputSigSentRegistrationFailureDoesNotExposeVTXOs(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	intent := h.newTestBoardingIntent()
+	state := h.newInputSigSentState(
+		testRoundIDTr("round-register-failure"),
+		[]BoardingIntent{intent},
+	)
+	h.withState(state)
+
+	h.env.BatchRegistrar = &testRoundBatchRegistrar{
+		register: func(context.Context,
+			*batchcanon.RegisterBatchRequest) error {
+
+			return errors.New("registration unavailable")
+		},
+	}
+
+	_, err := h.sendEvent(&BoardingConfirmed{
+		TxID:        state.CommitmentTx.UnsignedTx.TxHash(),
+		BlockHeight: 101,
+	})
+	require.ErrorContains(t, err, "registration unavailable")
+	h.vtxoStore.AssertNotCalled(t, "SaveVTXOs")
+}

--- a/round/batch_registration_test.go
+++ b/round/batch_registration_test.go
@@ -74,6 +74,7 @@ func TestInputSigSentRegistersBatchBeforeExposure(t *testing.T) {
 	require.Equal(t, commitmentTx.TxHash(), registration.BatchTxID)
 	require.Equal(t, uint32(0), registration.BatchOutputIndex)
 	require.Equal(t, int32(1008), registration.CSVExpiryDelta)
+	require.Equal(t, h.env.StartHeight, registration.WatchHeightHint)
 	require.Equal(
 		t, commitmentTx.TxOut[0].PkScript,
 		registration.ConfirmationPkScript,

--- a/round/fsm_environment.go
+++ b/round/fsm_environment.go
@@ -24,6 +24,10 @@ type ClientEnvironment struct {
 	// VTXOStore provides persistence for off-chain balance.
 	VTXOStore VTXOStore
 
+	// BatchRegistrar installs complete commitment evidence before VTXOs are
+	// persisted and exposed. Nil preserves focused test behavior.
+	BatchRegistrar RoundBatchRegistrar
+
 	// Wallet provides signing capabilities for round participation.
 	Wallet ClientWallet
 

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/google/uuid"
 	"github.com/lightninglabs/wavelength/baselib/protofsm"
+	"github.com/lightninglabs/wavelength/batchcanon"
 	"github.com/lightninglabs/wavelength/lib/tree"
 	"github.com/lightninglabs/wavelength/lib/types"
 	"github.com/lightninglabs/wavelength/rpc/roundpb"
@@ -533,6 +534,20 @@ type ClientVTXO struct {
 	// CreatedHeight is the block height at which the commitment
 	// transaction was confirmed. Populated at confirmation time.
 	CreatedHeight int32
+
+	// BusinessRevision is the persisted lifecycle revision. A refresh
+	// registration binds the next revision, which is installed when this
+	// VTXO becomes forfeited by the new commitment transaction.
+	BusinessRevision uint64
+}
+
+// RoundBatchRegistrar installs authenticated commitment evidence before a
+// round exposes any VTXOs derived from that commitment.
+type RoundBatchRegistrar interface {
+	// RegisterBatch validates, persists, and starts observing one complete
+	// batch registration.
+	RegisterBatch(ctx context.Context,
+		req *batchcanon.RegisterBatchRequest) error
 }
 
 // OwnedScriptChecker determines whether a pkScript belongs to the local

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -19,6 +19,7 @@ import (
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/batchcanon"
 	"github.com/lightninglabs/wavelength/ledger"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightninglabs/wavelength/lib/tree"
@@ -4566,6 +4567,155 @@ func buildClientVTXOs(ctx context.Context, checker OwnedScriptChecker,
 	return vtxos, nil
 }
 
+// batchOutputIndex returns the commitment output used for the batch
+// confirmation watch. It mirrors confirmationWatchScript so the persisted
+// evidence binds the same output the chain backend observes.
+func batchOutputIndex(commitmentTx *wire.MsgTx,
+	vtxoTrees map[int]*tree.Tree) (uint32, error) {
+
+	if commitmentTx == nil || len(commitmentTx.TxOut) == 0 {
+		return 0, fmt.Errorf("commitment transaction has no outputs")
+	}
+
+	idx := 0
+	if len(vtxoTrees) > 0 {
+		idx = -1
+		for outputIdx := range vtxoTrees {
+			if idx == -1 || outputIdx < idx {
+				idx = outputIdx
+			}
+		}
+	}
+	if idx < 0 || idx >= len(commitmentTx.TxOut) {
+		return 0, fmt.Errorf("batch output index %d is out of range",
+			idx)
+	}
+
+	return uint32(idx), nil
+}
+
+// creatorLineage returns every distinct commitment transaction that must
+// remain canonical for a VTXO to exist.
+func creatorLineage(vtxo *ClientVTXO) ([]chainhash.Hash, error) {
+	lineage := make([]chainhash.Hash, 0, len(vtxo.Ancestry)+1)
+	seen := make(map[chainhash.Hash]struct{}, len(vtxo.Ancestry)+1)
+	add := func(txid chainhash.Hash) {
+		if txid == (chainhash.Hash{}) {
+			return
+		}
+		if _, ok := seen[txid]; ok {
+			return
+		}
+		seen[txid] = struct{}{}
+		lineage = append(lineage, txid)
+	}
+
+	add(vtxo.CommitmentTxID)
+	for _, ancestor := range vtxo.Ancestry {
+		add(ancestor.CommitmentTxID)
+	}
+	if len(lineage) == 0 {
+		return nil, fmt.Errorf("VTXO %s has no creator lineage",
+			vtxo.Outpoint)
+	}
+
+	return lineage, nil
+}
+
+// roundBatchRegistration builds complete authenticated batch evidence from
+// the commitment PSBT retained by the round FSM. Every actual transaction
+// input is paired with its WitnessUtxo, and refresh inputs additionally bind
+// the exact next lifecycle revision plus their complete creator lineage.
+func roundBatchRegistration(ctx context.Context, state *InputSigSentState,
+	vtxos []*ClientVTXO, batchTxID chainhash.Hash,
+	store VTXOStore) (*batchcanon.RegisterBatchRequest, error) {
+
+	if state.CommitmentTx == nil || state.CommitmentTx.UnsignedTx == nil {
+		return nil, fmt.Errorf("commitment PSBT is missing")
+	}
+
+	commitmentTx := state.CommitmentTx.UnsignedTx
+	if commitmentTx.TxHash() != batchTxID {
+		return nil, fmt.Errorf("confirmed txid %s does not match "+
+			"commitment transaction %s", batchTxID,
+			commitmentTx.TxHash())
+	}
+	if len(state.CommitmentTx.Inputs) != len(commitmentTx.TxIn) {
+		return nil, fmt.Errorf("commitment PSBT has %d input records "+
+			"for %d transaction inputs",
+			len(state.CommitmentTx.Inputs), len(commitmentTx.TxIn))
+	}
+
+	consumedInputs := make(
+		[]batchcanon.ConsumedInput, 0, len(commitmentTx.TxIn),
+	)
+	for idx, txIn := range commitmentTx.TxIn {
+		prevOut := state.CommitmentTx.Inputs[idx].WitnessUtxo
+		if prevOut == nil {
+			return nil, fmt.Errorf("commitment input %d (%s) has "+
+				"no WitnessUtxo", idx, txIn.PreviousOutPoint)
+		}
+		consumedInputs = append(
+			consumedInputs, batchcanon.ConsumedInput{
+				Outpoint: txIn.PreviousOutPoint,
+				Value:    prevOut.Value,
+				PkScript: bytes.Clone(prevOut.PkScript),
+			},
+		)
+	}
+
+	dependentVTXOs := make([]wire.OutPoint, 0, len(vtxos))
+	for _, vtxo := range vtxos {
+		dependentVTXOs = append(dependentVTXOs, vtxo.Outpoint)
+	}
+
+	consumerEdges := make(
+		[]batchcanon.ConsumerEdge, 0, len(state.ForfeitedVTXOs),
+	)
+	for _, outpoint := range state.ForfeitedVTXOs {
+		consumedVTXO, err := store.GetVTXO(ctx, outpoint)
+		if err != nil {
+			return nil, fmt.Errorf("load forfeited VTXO %s: %w",
+				outpoint, err)
+		}
+		lineage, err := creatorLineage(consumedVTXO)
+		if err != nil {
+			return nil, err
+		}
+		consumerEdges = append(consumerEdges, batchcanon.ConsumerEdge{
+			ConsumedVTXO:     outpoint,
+			ConsumerBatch:    batchTxID,
+			ExpectedRevision: consumedVTXO.BusinessRevision + 1,
+			CreatorLineage:   lineage,
+		})
+	}
+
+	outputIdx, err := batchOutputIndex(
+		commitmentTx, state.VTXOTreePaths,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var serializedTx bytes.Buffer
+	if err := commitmentTx.Serialize(&serializedTx); err != nil {
+		return nil, fmt.Errorf("serialize commitment transaction: %w",
+			err)
+	}
+
+	return &batchcanon.RegisterBatchRequest{
+		BatchTxID:        batchTxID,
+		BatchTx:          serializedTx.Bytes(),
+		BatchOutputIndex: outputIdx,
+		ConfirmationPkScript: bytes.Clone(
+			commitmentTx.TxOut[outputIdx].PkScript,
+		),
+		CSVExpiryDelta: int32(state.SweepDelay),
+		ConsumedInputs: consumedInputs,
+		DependentVTXOs: dependentVTXOs,
+		ConsumedVTXOs:  consumerEdges,
+	}, nil
+}
+
 // ProcessEvent for InputSigSentState.
 //
 //nolint:funlen
@@ -4815,6 +4965,28 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 			cv.CreatedHeight = evt.BlockHeight
 			for i := range cv.Ancestry {
 				cv.Ancestry[i].CommitmentTxID = evt.TxID
+			}
+		}
+
+		// Register the complete commitment and logical consumer lineage
+		// before persisting any VTXO derived from it. The admission
+		// gate is fail-closed, so a registration failure leaves the
+		// round at its pre-exposure checkpoint and no new liquidity
+		// becomes selectable.
+		if env.BatchRegistrar != nil {
+			opCtx := context.WithoutCancel(ctx)
+			registration, err := roundBatchRegistration(
+				opCtx, s, vtxos, evt.TxID, env.VTXOStore,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("build batch "+
+					"registration: %w", err)
+			}
+			if err := env.BatchRegistrar.RegisterBatch(
+				opCtx, registration,
+			); err != nil {
+				return nil, fmt.Errorf("register batch before "+
+					"VTXO exposure: %w", err)
 			}
 		}
 

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -4627,8 +4627,8 @@ func creatorLineage(vtxo *ClientVTXO) ([]chainhash.Hash, error) {
 // input is paired with its WitnessUtxo, and refresh inputs additionally bind
 // the exact next lifecycle revision plus their complete creator lineage.
 func roundBatchRegistration(ctx context.Context, state *InputSigSentState,
-	vtxos []*ClientVTXO, batchTxID chainhash.Hash,
-	store VTXOStore) (*batchcanon.RegisterBatchRequest, error) {
+	vtxos []*ClientVTXO, batchTxID chainhash.Hash, store VTXOStore,
+	watchHeightHint uint32) (*batchcanon.RegisterBatchRequest, error) {
 
 	if state.CommitmentTx == nil || state.CommitmentTx.UnsignedTx == nil {
 		return nil, fmt.Errorf("commitment PSBT is missing")
@@ -4709,10 +4709,11 @@ func roundBatchRegistration(ctx context.Context, state *InputSigSentState,
 		ConfirmationPkScript: bytes.Clone(
 			commitmentTx.TxOut[outputIdx].PkScript,
 		),
-		CSVExpiryDelta: int32(state.SweepDelay),
-		ConsumedInputs: consumedInputs,
-		DependentVTXOs: dependentVTXOs,
-		ConsumedVTXOs:  consumerEdges,
+		WatchHeightHint: watchHeightHint,
+		CSVExpiryDelta:  int32(state.SweepDelay),
+		ConsumedInputs:  consumedInputs,
+		DependentVTXOs:  dependentVTXOs,
+		ConsumedVTXOs:   consumerEdges,
 	}, nil
 }
 
@@ -4977,6 +4978,7 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 			opCtx := context.WithoutCancel(ctx)
 			registration, err := roundBatchRegistration(
 				opCtx, s, vtxos, evt.TxID, env.VTXOStore,
+				env.StartHeight,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("build batch "+

--- a/rpc/wavewalletrpc/wallet.pb.go
+++ b/rpc/wavewalletrpc/wallet.pb.go
@@ -3242,8 +3242,12 @@ type BalanceResponse struct {
 	// credit_reserved_sat is the server-authoritative in-flight credit
 	// reservation amount.
 	CreditReservedSat uint64 `protobuf:"varint,5,opt,name=credit_reserved_sat,json=creditReservedSat,proto3" json:"credit_reserved_sat,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// temporarily_unavailable_sat is owned VTXO value that cannot be
+	// spent while its batch lineage is in reorg/conflict limbo or is being
+	// reconciled. It returns to confirmed_sat if canonicality recovers.
+	TemporarilyUnavailableSat int64 `protobuf:"varint,6,opt,name=temporarily_unavailable_sat,json=temporarilyUnavailableSat,proto3" json:"temporarily_unavailable_sat,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
 }
 
 func (x *BalanceResponse) Reset() {
@@ -3307,6 +3311,13 @@ func (x *BalanceResponse) GetCreditAvailableSat() uint64 {
 func (x *BalanceResponse) GetCreditReservedSat() uint64 {
 	if x != nil {
 		return x.CreditReservedSat
+	}
+	return 0
+}
+
+func (x *BalanceResponse) GetTemporarilyUnavailableSat() int64 {
+	if x != nil {
+		return x.TemporarilyUnavailableSat
 	}
 	return 0
 }
@@ -5897,13 +5908,14 @@ const file_wallet_proto_rawDesc = "" +
 	"\x0fDepositResponse\x12'\n" +
 	"\x0fonchain_address\x18\x01 \x01(\tR\x0eonchainAddress\x120\n" +
 	"\x05entry\x18\x02 \x01(\v2\x1a.wavewalletrpc.WalletEntryR\x05entry\"\x10\n" +
-	"\x0eBalanceRequest\"\xe6\x01\n" +
+	"\x0eBalanceRequest\"\xa6\x02\n" +
 	"\x0fBalanceResponse\x12#\n" +
 	"\rconfirmed_sat\x18\x01 \x01(\x03R\fconfirmedSat\x12$\n" +
 	"\x0epending_in_sat\x18\x02 \x01(\x03R\fpendingInSat\x12&\n" +
 	"\x0fpending_out_sat\x18\x03 \x01(\x03R\rpendingOutSat\x120\n" +
 	"\x14credit_available_sat\x18\x04 \x01(\x04R\x12creditAvailableSat\x12.\n" +
-	"\x13credit_reserved_sat\x18\x05 \x01(\x04R\x11creditReservedSat\"\x0f\n" +
+	"\x13credit_reserved_sat\x18\x05 \x01(\x04R\x11creditReservedSat\x12>\n" +
+	"\x1btemporarily_unavailable_sat\x18\x06 \x01(\x03R\x19temporarilyUnavailableSat\"\x0f\n" +
 	"\rStatusRequest\"\xbb\x01\n" +
 	"\x0eStatusResponse\x12\x14\n" +
 	"\x05ready\x18\x01 \x01(\bR\x05ready\x12\x1a\n" +

--- a/rpc/wavewalletrpc/wallet.pb.go
+++ b/rpc/wavewalletrpc/wallet.pb.go
@@ -3243,8 +3243,9 @@ type BalanceResponse struct {
 	// reservation amount.
 	CreditReservedSat uint64 `protobuf:"varint,5,opt,name=credit_reserved_sat,json=creditReservedSat,proto3" json:"credit_reserved_sat,omitempty"`
 	// temporarily_unavailable_sat is owned VTXO value that cannot be
-	// spent while its batch lineage is in reorg/conflict limbo or is being
-	// reconciled. It returns to confirmed_sat if canonicality recovers.
+	// spent while its batch lineage is unseen, unregistered, in
+	// reorg/conflict limbo, or being reconciled. It returns to confirmed_sat
+	// if canonicality recovers.
 	TemporarilyUnavailableSat int64 `protobuf:"varint,6,opt,name=temporarily_unavailable_sat,json=temporarilyUnavailableSat,proto3" json:"temporarily_unavailable_sat,omitempty"`
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache

--- a/rpc/wavewalletrpc/wallet.proto
+++ b/rpc/wavewalletrpc/wallet.proto
@@ -935,6 +935,11 @@ message BalanceResponse {
     // credit_reserved_sat is the server-authoritative in-flight credit
     // reservation amount.
     uint64 credit_reserved_sat = 5;
+
+    // temporarily_unavailable_sat is owned VTXO value that cannot be
+    // spent while its batch lineage is in reorg/conflict limbo or is being
+    // reconciled. It returns to confirmed_sat if canonicality recovers.
+    int64 temporarily_unavailable_sat = 6;
 }
 
 // StatusRequest is the empty request for WalletService.Status.

--- a/rpc/wavewalletrpc/wallet.proto
+++ b/rpc/wavewalletrpc/wallet.proto
@@ -937,8 +937,9 @@ message BalanceResponse {
     uint64 credit_reserved_sat = 5;
 
     // temporarily_unavailable_sat is owned VTXO value that cannot be
-    // spent while its batch lineage is in reorg/conflict limbo or is being
-    // reconciled. It returns to confirmed_sat if canonicality recovers.
+    // spent while its batch lineage is unseen, unregistered, in
+    // reorg/conflict limbo, or being reconciled. It returns to confirmed_sat
+    // if canonicality recovers.
     int64 temporarily_unavailable_sat = 6;
 }
 

--- a/sdk/wavewalletdk/convert.go
+++ b/sdk/wavewalletdk/convert.go
@@ -666,13 +666,15 @@ func balanceFromProto(balance *wavewalletrpc.BalanceResponse) Balance {
 	if balance == nil {
 		return Balance{}
 	}
+	temporarilyUnavailable := balance.GetTemporarilyUnavailableSat()
 
 	return Balance{
-		ConfirmedSat:       balance.GetConfirmedSat(),
-		PendingInSat:       balance.GetPendingInSat(),
-		PendingOutSat:      balance.GetPendingOutSat(),
-		CreditAvailableSat: balance.GetCreditAvailableSat(),
-		CreditReservedSat:  balance.GetCreditReservedSat(),
+		ConfirmedSat:              balance.GetConfirmedSat(),
+		PendingInSat:              balance.GetPendingInSat(),
+		PendingOutSat:             balance.GetPendingOutSat(),
+		TemporarilyUnavailableSat: temporarilyUnavailable,
+		CreditAvailableSat:        balance.GetCreditAvailableSat(),
+		CreditReservedSat:         balance.GetCreditReservedSat(),
 	}
 }
 

--- a/sdk/wavewalletdk/types.go
+++ b/sdk/wavewalletdk/types.go
@@ -154,11 +154,12 @@ type OpenWalletResult struct {
 
 // Balance is the wallet-level balance view.
 type Balance struct {
-	ConfirmedSat       int64
-	PendingInSat       int64
-	PendingOutSat      int64
-	CreditAvailableSat uint64
-	CreditReservedSat  uint64
+	ConfirmedSat              int64
+	PendingInSat              int64
+	PendingOutSat             int64
+	TemporarilyUnavailableSat int64
+	CreditAvailableSat        uint64
+	CreditReservedSat         uint64
 }
 
 // DepositRequest creates a tracked boarding address.

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -592,7 +592,8 @@ func (s *Service) fetchBalance(ctx context.Context) (
 	// sweep plus both in-flight VTXO buckets. confirmed_sat is VTXO-live
 	// only.
 	resp := &wavewalletrpc.BalanceResponse{
-		ConfirmedSat: bal.GetVtxoBalanceSat(),
+		ConfirmedSat:              bal.GetVtxoBalanceSat(),
+		TemporarilyUnavailableSat: bal.GetVtxoTemporarilyUnavailableSat(),
 		PendingInSat: bal.GetBoardingConfirmedSat() +
 			bal.GetBoardingUnconfirmedSat() +
 			bal.GetBoardingAdoptedSat(),

--- a/swapwallet/service_test.go
+++ b/swapwallet/service_test.go
@@ -232,11 +232,13 @@ func TestServiceBalanceProjectsDaemonGetBalance(t *testing.T) {
 
 	svc, _, rpc := newServiceFixture(t)
 	rpc.getBalanceResp = &waverpc.GetBalanceResponse{
-		VtxoBalanceSat:          75_000,
-		BoardingConfirmedSat:    100_000,
-		BoardingUnconfirmedSat:  20_000,
-		BoardingAdoptedSat:      15_000,
-		TotalConfirmedSat:       175_000, // ignored by the mapping
+		VtxoBalanceSat:                75_000,
+		VtxoTemporarilyUnavailableSat: 42_000,
+		BoardingConfirmedSat:          100_000,
+		BoardingUnconfirmedSat:        20_000,
+		BoardingAdoptedSat:            15_000,
+		// ignored by the mapping
+		TotalConfirmedSat:       175_000,
 		BoardingPendingSweepSat: 5_000,
 		VtxoPendingSat:          8_000,
 		VtxoUnilateralExitSat:   3_000,
@@ -247,6 +249,9 @@ func TestServiceBalanceProjectsDaemonGetBalance(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, int64(75_000), resp.GetConfirmedSat())
+	require.Equal(
+		t, int64(42_000), resp.GetTemporarilyUnavailableSat(),
+	)
 	require.Equal(t, int64(135_000), resp.GetPendingInSat())
 
 	// 5_000 + 8_000 + 3_000.

--- a/systest/batch_canonicality_gate_test.go
+++ b/systest/batch_canonicality_gate_test.go
@@ -201,6 +201,9 @@ func TestBatchCanonicalityGateBlocksReorgedVTXO(t *testing.T) {
 	h.Harness.Generate(1)
 	awaitBatchUsable(ctx, t, bcRef, batchTxid)
 
+	assertCanonicalityBalance(
+		ctx, t, vtxoStore, canonStore, f2VTXOAmount, 0,
+	)
 	assertVTXOSelected(ctx, t, vtxoRef, outpoint)
 	t.Logf(
 		"batch Provisional (1 conf): coin selection admitted %s",
@@ -236,6 +239,9 @@ func TestBatchCanonicalityGateBlocksReorgedVTXO(t *testing.T) {
 			"reorged out: the only candidate is gated out, "+
 			"leaving no liquidity",
 	)
+	assertCanonicalityBalance(
+		ctx, t, vtxoStore, canonStore, 0, f2VTXOAmount,
+	)
 	t.Logf(
 		"batch ReorgedOut: coin selection correctly excluded %s",
 		outpoint,
@@ -249,10 +255,34 @@ func TestBatchCanonicalityGateBlocksReorgedVTXO(t *testing.T) {
 	h.Harness.Generate(1)
 	awaitBatchUsable(ctx, t, bcRef, batchTxid)
 
+	assertCanonicalityBalance(
+		ctx, t, vtxoStore, canonStore, f2VTXOAmount, 0,
+	)
 	assertVTXOSelected(ctx, t, vtxoRef, outpoint)
 	t.Logf(
 		"batch reconfirmed Provisional: coin selection admitted %s",
 		outpoint,
+	)
+}
+
+// assertCanonicalityBalance checks the exact classification consumed by the
+// daemon's GetBalance RPC against the real durable canonicality store.
+func assertCanonicalityBalance(ctx context.Context, t *testing.T,
+	store *db.VTXOPersistenceStore, reader batchcanon.Reader,
+	wantSpendable, wantUnavailable btcutil.Amount) {
+
+	t.Helper()
+
+	descs, err := store.ListLiveVTXOs(ctx)
+	require.NoError(t, err, "list balance VTXOs")
+	spendable, unavailable, err := vtxo.ClassifyCanonicalityBalance(
+		ctx, descs, reader,
+	)
+	require.NoError(t, err, "classify canonicality-aware balance")
+	require.Equal(t, wantSpendable, spendable, "spendable balance")
+	require.Equal(
+		t, wantUnavailable, unavailable,
+		"temporarily unavailable balance",
 	)
 }
 

--- a/systest/boarding_sweep_reorg_test.go
+++ b/systest/boarding_sweep_reorg_test.go
@@ -103,10 +103,9 @@ func (r *recordingBoardingSweepRef) await(
 // proves the chainsource finality-depth synthesizer fires after the
 // reorg-safety horizon, which is the same wire that would deliver
 // BoardingSweepTxStatusFinalized to the wallet handler. Including a
-// dedicated Finalized assertion here would require mining to the
-// 31-confirmation terminal boundary without exercising any
-// boarding-sweep-specific code
-// path that the unit tests in
+// dedicated Finalized assertion here would require mining to H+1
+// confirmations (31 only under the current default H=30) without exercising
+// any boarding-sweep-specific code path that the unit tests in
 // wallet/boarding_sweep_actor_test.go::TestSweepTxNotificationFinalizedIsBenign
 // do not already cover.
 //

--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -257,6 +257,22 @@ type trackedTx struct {
 	// Tell and skips if the entry has sealed. It is atomic because it is
 	// read off the actor goroutine; only the actor goroutine writes it.
 	sealed atomic.Bool
+
+	// confReorgEpoch counts how many times this tx's confirmation has been
+	// reorged out. It is folded into the terminal-notification idempotency
+	// key (terminalNotifyKey) so a re-confirmation after a reorg is
+	// delivered afresh instead of being suppressed by the durable
+	// subscriber's dedup as a duplicate of the pre-reorg confirmation. It
+	// is incremented on the actor goroutine in handleConfirmationReorged.
+	confReorgEpoch uint64
+
+	// lastConfirmHeight is the height of the most recent observed
+	// confirmation. It is also folded into the terminal-notification key so
+	// a re-confirmation at a new height is distinguished across a process
+	// restart (which reconstructs the entry with confReorgEpoch reset to
+	// zero). Set on the actor goroutine whenever a confirmation is fanned
+	// out.
+	lastConfirmHeight int32
 }
 
 // confirmationObservedMsg routes a chainsource confirmation callback back into
@@ -1127,6 +1143,15 @@ func (a *TxBroadcasterActor) handleConfirmationReorged(ctx context.Context,
 	if state != TxStateConfirmed {
 		return
 	}
+
+	// Advance the reorg epoch so the re-confirmation that follows this
+	// reorg carries a fresh terminal-notification idempotency key. Without
+	// this, the re-confirmed TxConfirmed reuses the pre-reorg key and the
+	// durable subscriber's dedup drops it as a duplicate, stranding a
+	// reorg-aware consumer (e.g. an in-progress unilateral exit) that
+	// rolled its state back on the TxReorged and is now waiting for the
+	// confirmation to re-drive.
+	entry.confReorgEpoch++
 
 	if err := a.advanceTrackedTxFSM(
 		ctx, entry, &trackedTxReorged{},
@@ -2096,6 +2121,11 @@ func (a *TxBroadcasterActor) notifyConfirmed(ctx context.Context,
 	entry *trackedTx, blockHeight int32, blockHash chainhash.Hash,
 	numConfs uint32) {
 
+	// Record the height of this confirmation so terminal notifications key
+	// their idempotency on it (see terminalNotifyKey); a re-confirmation at
+	// a new height is then delivered rather than deduped.
+	entry.lastConfirmHeight = blockHeight
+
 	for id, subscriber := range entry.subscribers {
 		txConfirmed := &TxConfirmed{
 			Txid:        entry.data.Txid,
@@ -2353,7 +2383,21 @@ func (a *TxBroadcasterActor) notifyOneTerminal(ctx context.Context,
 	kind string, deliver func(context.Context) error) bool {
 
 	subscriberID := subscriber.ID()
-	inflightKey := terminalNotifyKey(txid, subscriberID, kind)
+
+	// Fold the entry's reorg epoch and last confirmation height into the
+	// idempotency key so a re-confirmation after a reorg is not suppressed
+	// as a duplicate by the durable subscriber's dedup. A missing entry
+	// (already evicted) keeps the zero values, which is fine: terminal
+	// delivery for an evicted entry is a one-shot with no reorg to follow.
+	var epoch uint64
+	var height int32
+	if entry, ok := a.tracked[txid]; ok {
+		epoch = entry.confReorgEpoch
+		height = entry.lastConfirmHeight
+	}
+	inflightKey := terminalNotifyKey(
+		txid, subscriberID, kind, epoch, height,
+	)
 	if _, ok := a.terminalNotifyInflight[inflightKey]; ok {
 		return false
 	}
@@ -2430,13 +2474,17 @@ func (a *TxBroadcasterActor) completeTerminalNotifyAsync(inflightKey string,
 	}()
 }
 
-// terminalNotifyKey returns the stable idempotency key for one terminal
-// subscriber notification.
-func terminalNotifyKey(txid chainhash.Hash, subscriberID string,
-	kind string) string {
+// terminalNotifyKey returns the idempotency key for one terminal subscriber
+// notification. The key is stable across genuine retries of the same delivery
+// (same epoch and height) so a durable subscriber dedups them, but it changes
+// across a reorg-and-reconfirmation: epoch increments on every reorg and height
+// tracks the confirmation block, so a re-confirmed TxConfirmed is delivered
+// afresh rather than being suppressed as a duplicate of the pre-reorg one.
+func terminalNotifyKey(txid chainhash.Hash, subscriberID, kind string,
+	epoch uint64, height int32) string {
 
-	return fmt.Sprintf("txconfirm-terminal-%s-%s-%s", kind, txid,
-		subscriberID)
+	return fmt.Sprintf("txconfirm-terminal-%s-%s-%s-e%d-h%d", kind, txid,
+		subscriberID, epoch, height)
 }
 
 // terminalNotifyContext isolates subscriber notification from txconfirm's actor

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -1190,7 +1190,9 @@ func TestTerminalNotificationTimeoutDoesNotBlockActor(t *testing.T) {
 	require.Less(t, time.Since(start), testTimeout)
 	require.True(t, <-started)
 
-	key := terminalNotifyKey(txid, sub.ID(), "finalized")
+	// No tracked entry is registered in this test, so notifyOneTerminal
+	// falls back to the zero reorg epoch / height when building the key.
+	key := terminalNotifyKey(txid, sub.ID(), "finalized", 0, 0)
 	_, inflight := behavior.terminalNotifyInflight[key]
 	require.True(t, inflight)
 	require.Equal(t, 1, sub.attemptsCount())
@@ -2248,4 +2250,134 @@ func TestInitialConfirmedAsyncDeliveryRetainsSubscriber(t *testing.T) {
 		"TxReorged never reached subscriber whose initial TxConfirmed "+
 			"completed via the async path — handleTerminalNotify"+
 			"Result probably evicted it on completion")
+}
+
+// outboxCapturingRef records the OutboxID (terminal-notification idempotency
+// key) the actor stamps on each delivery, so a test can assert the key changes
+// across a reorg-and-reconfirmation.
+type outboxCapturingRef struct {
+	id  string
+	mu  sync.Mutex
+	got []struct {
+		notification Notification
+		outboxID     string
+	}
+}
+
+func newOutboxCapturingRef(id string) *outboxCapturingRef {
+	return &outboxCapturingRef{id: id}
+}
+
+// ID returns the subscriber id.
+func (r *outboxCapturingRef) ID() string { return r.id }
+
+// Tell records the delivered notification together with the OutboxID visible
+// on its context.
+func (r *outboxCapturingRef) Tell(ctx context.Context, msg Notification) error {
+	oid, _ := actor.OutboxIDFromContext(ctx)
+
+	r.mu.Lock()
+	r.got = append(r.got, struct {
+		notification Notification
+		outboxID     string
+	}{msg, oid})
+	r.mu.Unlock()
+
+	return nil
+}
+
+// TryTell mirrors Tell for the non-blocking TellOnlyRef contract; the capturing
+// ref never applies backpressure, so it simply delegates.
+func (r *outboxCapturingRef) TryTell(ctx context.Context,
+	msg Notification) error {
+
+	return r.Tell(ctx, msg)
+}
+
+// confirmedOutboxIDs returns the OutboxIDs of every TxConfirmed delivery seen.
+func (r *outboxCapturingRef) confirmedOutboxIDs() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var ids []string
+	for _, d := range r.got {
+		if _, ok := d.notification.(*TxConfirmed); ok {
+			ids = append(ids, d.outboxID)
+		}
+	}
+
+	return ids
+}
+
+// TestConfirmationReorgReconfirmDeliversFreshKey is a regression test for the
+// unilateral-exit stall found in live reorg testing (see the txconfirm
+// confReorgEpoch field): when a confirmed tx is reorged out and reconfirms, the
+// re-confirmation must carry a NEW terminal-notification idempotency key.
+// Otherwise a durable subscriber's dedup drops it as a duplicate of the
+// pre-reorg confirmation and the subscriber (e.g. an in-progress unilateral
+// exit) never re-drives.
+func TestConfirmationReorgReconfirmDeliversFreshKey(t *testing.T) {
+	chain := newFakeChainSourceRef(100)
+	tx := makeTestTx(false)
+	txid := tx.TxHash()
+
+	ref, _ := newTestActor(t, Config{ChainSource: chain})
+
+	sub := newOutboxCapturingRef("unroll-sub")
+
+	// Initial ensure -> first confirmation via the terminal delivery path.
+	resp := mustEnsure(t, ref.Ref(), &EnsureConfirmedReq{
+		Tx:         tx,
+		Subscriber: sub,
+	})
+	require.True(t, resp.Created)
+
+	chain.emitConfirmation(t, txid, 105)
+	mustEventually(t, func() bool {
+		return len(sub.confirmedOutboxIDs()) == 1
+	}, "expected first TxConfirmed")
+
+	// Reorg the confirmation out.
+	chain.emitConfReorged(t, txid)
+
+	// The reorg-aware consumer re-submits the same tx on rollback, which
+	// re-arms the terminal delivery path for the next confirmation exactly
+	// as the unroll actor does.
+	mustEventually(t, func() bool {
+		resp, err := ref.Ref().Ask(t.Context(), &EnsureConfirmedReq{
+			Tx:         tx,
+			Subscriber: sub,
+		}).Await(t.Context()).Unpack()
+		if err != nil {
+			return false
+		}
+		typed, ok := resp.(*EnsureConfirmedResp)
+
+		return ok && typed.State == TxStateAwaitingConfirmation
+	}, "expected entry back in AwaitingConfirmation after reorg")
+
+	// Re-confirmation at the SAME height as before. Keying on height alone
+	// would not distinguish this from the pre-reorg confirmation, so a
+	// fresh key here proves the reorg epoch is the load-bearing component
+	// (a real reorg can re-mine a tx at the same height on the winning
+	// branch).
+	chain.emitConfirmation(t, txid, 105)
+	mustEventually(t, func() bool {
+		return len(sub.confirmedOutboxIDs()) == 2
+	}, "expected re-confirmation TxConfirmed after reorg")
+
+	ids := sub.confirmedOutboxIDs()
+	require.Len(t, ids, 2)
+	require.NotEmpty(
+		t, ids[0], "first confirmation must use the terminal key",
+	)
+	require.NotEmpty(
+		t, ids[1], "re-confirmation must use the terminal key",
+	)
+	require.NotEqual(
+		t, ids[0], ids[1], "re-confirmation after a reorg must "+
+			"carry a fresh idempotency key so a durable "+
+			"subscriber does not dedup it as a duplicate of "+
+			"the pre-reorg confirmation",
+	)
 }

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -945,7 +945,8 @@ func (a *VTXOActor) processStatusUpdate(ctx context.Context,
 	// this marker existed (the consumer batch reached ConflictFinalized
 	// first). Best-effort: on failure the restart-time redrive remains the
 	// backstop, so we log rather than fail the status write. Skipped when
-	// no consuming batch is recorded (a plain forfeit with no reverse edge).
+	// no consuming batch is recorded (a plain forfeit with no reverse
+	// edge).
 	if m.NewStatus == VTXOStatusForfeited &&
 		a.cfg.NotifyForfeitPersisted != nil &&
 		m.ConsumerBatchTxID != (chainhash.Hash{}) {
@@ -957,8 +958,10 @@ func (a *VTXOActor) processStatusUpdate(ctx context.Context,
 			a.logger(ctx).WarnS(ctx, "Failed to redrive consumer "+
 				"edge after forfeit persist", err,
 				slog.String("outpoint", m.Outpoint.String()),
-				slog.String("consumer_batch",
-					m.ConsumerBatchTxID.String()))
+				slog.String(
+					"consumer_batch",
+					m.ConsumerBatchTxID.String(),
+				))
 		}
 	}
 

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/baselib/actor"
@@ -79,6 +80,16 @@ type VTXOActorConfig struct {
 	// The VTXO actor routes round-bound signals through the manager
 	// rather than holding a direct round actor reference.
 	Manager actor.TellOnlyRef[ManagerMsg]
+
+	// NotifyForfeitPersisted, when set, is invoked after a VTXO's
+	// forfeiture marker is durably persisted (MarkForfeited), passing the
+	// consuming batch. It lets the batch canonicality manager redrive a
+	// terminal consumer-edge resolution that deferred because it ran before
+	// the marker existed, closing the race that would otherwise strand the
+	// consumed VTXO until restart. Optional: nil disables the redrive
+	// (harness paths and deployments without batch canonicality).
+	NotifyForfeitPersisted func(ctx context.Context,
+		consumerBatch chainhash.Hash) error
 
 	// LedgerSink is an optional reference to the client-side
 	// ledger accounting actor. The VTXO actor does not know the
@@ -927,6 +938,28 @@ func (a *VTXOActor) processStatusUpdate(ctx context.Context,
 
 		return fmt.Errorf("persist vtxo status %s to %s: %w",
 			m.Outpoint, m.NewStatus, err)
+	}
+
+	// A forfeiture marker just became durable. Redrive any terminal
+	// consumer-edge resolution that may have deferred because it ran before
+	// this marker existed (the consumer batch reached ConflictFinalized
+	// first). Best-effort: on failure the restart-time redrive remains the
+	// backstop, so we log rather than fail the status write. Skipped when
+	// no consuming batch is recorded (a plain forfeit with no reverse edge).
+	if m.NewStatus == VTXOStatusForfeited &&
+		a.cfg.NotifyForfeitPersisted != nil &&
+		m.ConsumerBatchTxID != (chainhash.Hash{}) {
+
+		if err := a.cfg.NotifyForfeitPersisted(
+			ctx, m.ConsumerBatchTxID,
+		); err != nil {
+
+			a.logger(ctx).WarnS(ctx, "Failed to redrive consumer "+
+				"edge after forfeit persist", err,
+				slog.String("outpoint", m.Outpoint.String()),
+				slog.String("consumer_batch",
+					m.ConsumerBatchTxID.String()))
+		}
 	}
 
 	return nil

--- a/vtxo/filter.go
+++ b/vtxo/filter.go
@@ -1,6 +1,12 @@
 package vtxo
 
-import "github.com/btcsuite/btcd/btcutil/v2"
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/lightninglabs/wavelength/batchcanon"
+)
 
 // FilterOptions specifies the criteria for filtering a set of VTXO
 // descriptors. A zero-value FilterOptions matches everything.
@@ -92,4 +98,43 @@ func SumPendingBalance(descs []*Descriptor) btcutil.Amount {
 	}
 
 	return total
+}
+
+// ClassifyCanonicalityBalance separates lifecycle-live VTXOs into value that
+// can be spent now and value temporarily blocked by lineage canonicality. A
+// terminally invalidated lineage contributes to neither balance: it is no
+// longer wallet liquidity and belongs in history or recovery diagnostics.
+// A nil reader preserves the legacy behavior while the canonicality gate is
+// disabled.
+func ClassifyCanonicalityBalance(ctx context.Context, descs []*Descriptor,
+	reader batchcanon.Reader) (btcutil.Amount, btcutil.Amount, error) {
+
+	if reader == nil {
+		return SumSpendableBalance(descs), 0, nil
+	}
+
+	var spendable, unavailable btcutil.Amount
+	for _, desc := range descs {
+		if desc == nil || desc.Status != VTXOStatusLive {
+			continue
+		}
+
+		availability, err := batchcanon.LineageAvailability(
+			ctx, reader, LineageCommitmentTxIDs(desc)...,
+		)
+		if err != nil {
+			return 0, 0, fmt.Errorf("lineage availability for "+
+				"%s: %w", desc.Outpoint, err)
+		}
+
+		switch {
+		case availability.Usable():
+			spendable += desc.Amount
+
+		case availability != batchcanon.Invalidated:
+			unavailable += desc.Amount
+		}
+	}
+
+	return spendable, unavailable, nil
 }

--- a/vtxo/incoming_ancestry.go
+++ b/vtxo/incoming_ancestry.go
@@ -121,8 +121,8 @@ func AncestryFromRPC(paths []*arkrpc.AncestryPath) ([]Ancestry, error) {
 // VTXO script, so the proven lineage actually terminates at this coin. Genuine
 // trees satisfy (3) by construction (each parent output IS PayToTaproot of its
 // child's aggregate), so this never false-rejects a real receive; and it is
-// key-identity-agnostic (never demands a specific key), so it does not depend on
-// the operator identity key (which is NOT the tree's per-round signing key).
+// key-identity-agnostic (never demands a specific key), so it does not depend
+// on the operator identity key (which is NOT the tree's per-round signing key).
 func VerifyReceivedVTXOBinding(ancestry []Ancestry, vtxoScript []byte) error {
 	if len(vtxoScript) == 0 {
 		return fmt.Errorf("missing pkScript for received-VTXO binding")
@@ -143,6 +143,7 @@ func VerifyReceivedVTXOBinding(ancestry []Ancestry, vtxoScript []byte) error {
 			if len(leaf.Outputs) > 0 && bytes.Equal(
 				leaf.Outputs[0].PkScript, vtxoScript,
 			) {
+
 				paysReceivedVTXO = true
 			}
 		}
@@ -211,10 +212,9 @@ func VerifyOORAncestryLineage(ancestry []Ancestry,
 			!bytes.Equal(
 				tp.BatchOutput.PkScript, e.ConfirmationPkScript,
 			) {
-
-			return fmt.Errorf("ancestry path %d: tree batch output "+
-				"does not match the authenticated commitment "+
-				"output", i)
+			return fmt.Errorf("ancestry path %d: tree batch "+
+				"output does not match the authenticated "+
+				"commitment output", i)
 		}
 
 		if err := verifyAuthenticatedTree(tp); err != nil {
@@ -231,9 +231,9 @@ func VerifyOORAncestryLineage(ancestry []Ancestry,
 		}
 	}
 
-	// chainDepth is intentionally not consulted: it is indexer-supplied, and
-	// trusting it would let an attacker skip the bind by claiming a deeper
-	// chain. The bind is unconditional.
+	// chainDepth is intentionally not consulted: it is indexer-supplied,
+	// and trusting it would let an attacker skip the bind by claiming a
+	// deeper chain. The bind is unconditional.
 	_ = chainDepth
 
 	return bindCoinInputsToLeaves(leafTxids, coinInputs)
@@ -241,12 +241,12 @@ func VerifyOORAncestryLineage(ancestry []Ancestry,
 
 // bindCoinInputsToLeaves enforces the terminator: every coin input (checkpoint
 // prevout) must be produced by an authenticated ancestry leaf, so a
-// genuine-but-unrelated commitment tree cannot be watched in place of the coin's
-// real lineage. The bind is UNCONDITIONAL and never keys off the indexer-
-// supplied chain depth: trusting that value would let an attacker claim a deeper
-// chain to skip the check on a single-hop coin. coinInputs come from the
-// co-signed checkpoint PSBTs (the coin's real spent outpoints), so a decoy
-// ancestry — whose leaves are not the coin's actual inputs — is rejected.
+// genuine-but-unrelated commitment tree cannot be watched in place of the
+// coin's real lineage. The bind is UNCONDITIONAL and never keys off the
+// indexer- supplied chain depth: trusting that value would let an attacker
+// claim a deeper chain to skip the check on a single-hop coin. coinInputs come
+// from the co-signed checkpoint PSBTs (the coin's real spent outpoints), so a
+// decoy ancestry — whose leaves are not the coin's actual inputs — is rejected.
 func bindCoinInputsToLeaves(leafTxids map[chainhash.Hash]struct{},
 	coinInputs []wire.OutPoint) error {
 
@@ -256,8 +256,8 @@ func bindCoinInputsToLeaves(leafTxids map[chainhash.Hash]struct{},
 	}
 	for _, in := range coinInputs {
 		if _, ok := leafTxids[in.Hash]; !ok {
-			return fmt.Errorf("coin input %s is not produced by any "+
-				"authenticated ancestry leaf", in)
+			return fmt.Errorf("coin input %s is not produced by "+
+				"any authenticated ancestry leaf", in)
 		}
 	}
 
@@ -275,16 +275,16 @@ func verifyAuthenticatedTree(tp *tree.Tree) error {
 		return fmt.Errorf("structure: %w", err)
 	}
 
-	// The prevout fetcher maps each node's input to the output it spends: the
-	// authenticated batch output for the root, and the parent's output for
-	// every child.
+	// The prevout fetcher maps each node's input to the output it spends:
+	// the authenticated batch output for the root, and the parent's output
+	// for every child.
 	fetcher, err := tp.Root.PrevOutputFetcher(tp.BatchOutput)
 	if err != nil {
 		return fmt.Errorf("prevouts: %w", err)
 	}
 
-	// (2)+(3): recompute each node's aggregate key and require it to equal the
-	// taproot key of the output it spends. The root is pinned to the
+	// (2)+(3): recompute each node's aggregate key and require it to equal
+	// the taproot key of the output it spends. The root is pinned to the
 	// authenticated commitment output; the cascade pins the rest.
 	if err := tp.Root.ForEach(func(n *tree.Node) error {
 		finalKey, err := tree.ComputeFinalKey(
@@ -302,7 +302,6 @@ func verifyAuthenticatedTree(tp *tree.Tree) error {
 		prevOut := fetcher.FetchPrevOutput(n.Input)
 		if prevOut == nil ||
 			!bytes.Equal(wantScript, prevOut.PkScript) {
-
 			return fmt.Errorf("node aggregate key does not match " +
 				"the output it spends")
 		}

--- a/vtxo/incoming_ancestry.go
+++ b/vtxo/incoming_ancestry.go
@@ -1,10 +1,16 @@
 package vtxo
 
 import (
+	"bytes"
 	"fmt"
 	"slices"
 
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/batchcanon"
+	"github.com/lightninglabs/wavelength/lib/tree"
 )
 
 // MaxAncestryPaths bounds the per-VTXO ancestry slice the indexer is
@@ -80,4 +86,237 @@ func AncestryFromRPC(paths []*arkrpc.AncestryPath) ([]Ancestry, error) {
 	}
 
 	return out, nil
+}
+
+// VerifyReceivedVTXOBinding cryptographically binds a received in-round VTXO to
+// the commitment(s) the client will watch for reorg safety. It PRESUMES the
+// caller has already authenticated each tree's batch output against the real
+// commitment transaction (batchcanon.EvidenceFromAncestryPaths: the commitment
+// tx self-authenticates via tx.TxHash()==commitmentTxID, and its output at the
+// batch index is matched byte-for-byte). That makes each tree's BatchOutput the
+// real PayToTaproot(round key) — the on-chain anchor this proof leans on.
+//
+// Without this, the indexer's ancestry is trusted for shape only, so a
+// malicious indexer could name a decoy commitment (real, deeply-buried, never
+// reorging) and have the client watch it while the VTXO's true lineage silently
+// leaves the chain. Running tree signature verification ALONE does not close
+// that: signatures verify against a per-node aggregate key recomputed from the
+// tree's own (attacker-supplied) cosigners, so an attacker signs a fabricated
+// tree with their own keys and passes. The load-bearing check here is (3): each
+// node's aggregate key must equal the taproot key of the output it spends. At
+// the root that output is the authenticated commitment output, so the root key
+// is pinned to the real round key (unforgeable); taproot's SIGHASH_DEFAULT
+// commits to each tx's outputs, so that pin cascades down to every leaf.
+//
+// For each ancestry tree it proves:
+//  1. structure — root spends BatchOutpoint, children reference parent txids
+//     (tree.Verify);
+//  2. FinalKey — recomputed per node from its cosigners + the sweep tapscript
+//     root (reconstruction drops it);
+//  3. key-to-output binding — PayToTaproot(node key) == pkScript of the output
+//     the node spends, anchored at the root by the authenticated batch output;
+//  4. signatures — every node validly signed (tree.VerifySigned).
+//
+// It then requires that some leaf of an authenticated tree pays the received
+// VTXO script, so the proven lineage actually terminates at this coin. Genuine
+// trees satisfy (3) by construction (each parent output IS PayToTaproot of its
+// child's aggregate), so this never false-rejects a real receive; and it is
+// key-identity-agnostic (never demands a specific key), so it does not depend on
+// the operator identity key (which is NOT the tree's per-round signing key).
+func VerifyReceivedVTXOBinding(ancestry []Ancestry, vtxoScript []byte) error {
+	if len(vtxoScript) == 0 {
+		return fmt.Errorf("missing pkScript for received-VTXO binding")
+	}
+
+	paysReceivedVTXO := false
+	for i := range ancestry {
+		tp := ancestry[i].TreePath
+		if tp == nil || tp.Root == nil {
+			return fmt.Errorf("ancestry path %d has no tree", i)
+		}
+
+		if err := verifyAuthenticatedTree(tp); err != nil {
+			return fmt.Errorf("ancestry path %d: %w", i, err)
+		}
+
+		for _, leaf := range tp.Root.GetLeafNodes() {
+			if len(leaf.Outputs) > 0 && bytes.Equal(
+				leaf.Outputs[0].PkScript, vtxoScript,
+			) {
+				paysReceivedVTXO = true
+			}
+		}
+	}
+
+	if !paysReceivedVTXO {
+		return fmt.Errorf("no authenticated ancestry tree pays the " +
+			"received VTXO script")
+	}
+
+	return nil
+}
+
+// VerifyOORAncestryLineage cryptographically binds an OOR-received VTXO's
+// commitment lineage to the reorg watches the client is about to arm. Like the
+// in-round binding it proves each ancestry tree is a genuine, operator-signed
+// descent from its authenticated commitment output (verifyAuthenticatedTree),
+// closing the same decoy-commitment gap. It differs in the anchor and the
+// terminator:
+//
+//   - Anchor: OOR incoming metadata can be a durable replay, so rather than
+//     trust the reconstructed tree's own batch output it re-anchors on the
+//     caller-validated BatchEvidence — the tree's batch outpoint and output
+//     script must equal the authenticated evidence for that commitment before
+//     the key-to-output cascade is meaningful.
+//   - Terminator: an OOR output is an ark-tx output, not a commitment-tree
+//     leaf, so it does NOT require a leaf to pay the received VTXO. Instead it
+//     binds the coin's real inputs to the watched lineage: the received coin's
+//     ark tx spends, via its checkpoints, the committed base VTXOs, and each
+//     checkpoint's prevout (a coinInput) must be produced by an authenticated
+//     ancestry leaf. This closes the genuine-but-unrelated (decoy) commitment
+//     variant: a real tree from an unrelated round has no leaf producing the
+//     coin's actual inputs. It is applied only when chainDepth == 1 (a single
+//     OOR hop, so the checkpoint prevouts ARE the committed leaves); for
+//     chainDepth > 1 the coin's direct inputs are prior OOR VTXOs whose
+//     connection to these commitments runs through intermediate hops the
+//     recipient does not hold, so the strict bind is not locally verifiable and
+//     only the authenticated-tree check (forged-tree variant) applies there.
+func VerifyOORAncestryLineage(ancestry []Ancestry,
+	evidence []batchcanon.BatchEvidence, chainDepth int,
+	coinInputs []wire.OutPoint) error {
+
+	byCommitment := make(
+		map[chainhash.Hash]batchcanon.BatchEvidence, len(evidence),
+	)
+	for _, e := range evidence {
+		byCommitment[e.BatchTxID] = e
+	}
+
+	// The set of committed base-VTXO txids the authenticated trees produce.
+	leafTxids := make(map[chainhash.Hash]struct{})
+
+	for i := range ancestry {
+		tp := ancestry[i].TreePath
+		if tp == nil || tp.Root == nil || tp.BatchOutput == nil {
+			return fmt.Errorf("ancestry path %d has no tree", i)
+		}
+
+		e, ok := byCommitment[tp.BatchOutpoint.Hash]
+		if !ok {
+			return fmt.Errorf("ancestry path %d: no authenticated "+
+				"evidence for commitment %s", i,
+				tp.BatchOutpoint.Hash)
+		}
+		if tp.BatchOutpoint.Index != e.BatchOutputIndex ||
+			!bytes.Equal(
+				tp.BatchOutput.PkScript, e.ConfirmationPkScript,
+			) {
+
+			return fmt.Errorf("ancestry path %d: tree batch output "+
+				"does not match the authenticated commitment "+
+				"output", i)
+		}
+
+		if err := verifyAuthenticatedTree(tp); err != nil {
+			return fmt.Errorf("ancestry path %d: %w", i, err)
+		}
+
+		for _, leaf := range tp.Root.GetLeafNodes() {
+			txid, err := leaf.TXID()
+			if err != nil {
+				return fmt.Errorf("ancestry path %d: leaf "+
+					"txid: %w", i, err)
+			}
+			leafTxids[txid] = struct{}{}
+		}
+	}
+
+	// chainDepth is intentionally not consulted: it is indexer-supplied, and
+	// trusting it would let an attacker skip the bind by claiming a deeper
+	// chain. The bind is unconditional.
+	_ = chainDepth
+
+	return bindCoinInputsToLeaves(leafTxids, coinInputs)
+}
+
+// bindCoinInputsToLeaves enforces the terminator: every coin input (checkpoint
+// prevout) must be produced by an authenticated ancestry leaf, so a
+// genuine-but-unrelated commitment tree cannot be watched in place of the coin's
+// real lineage. The bind is UNCONDITIONAL and never keys off the indexer-
+// supplied chain depth: trusting that value would let an attacker claim a deeper
+// chain to skip the check on a single-hop coin. coinInputs come from the
+// co-signed checkpoint PSBTs (the coin's real spent outpoints), so a decoy
+// ancestry — whose leaves are not the coin's actual inputs — is rejected.
+func bindCoinInputsToLeaves(leafTxids map[chainhash.Hash]struct{},
+	coinInputs []wire.OutPoint) error {
+
+	if len(coinInputs) == 0 {
+		return fmt.Errorf("OOR receive has no coin inputs to bind " +
+			"against ancestry")
+	}
+	for _, in := range coinInputs {
+		if _, ok := leafTxids[in.Hash]; !ok {
+			return fmt.Errorf("coin input %s is not produced by any "+
+				"authenticated ancestry leaf", in)
+		}
+	}
+
+	return nil
+}
+
+// verifyAuthenticatedTree proves a tree whose BatchOutput is already
+// authenticated is genuine: valid structure, every node's aggregate key equals
+// the taproot key of the output it spends, and every node validly signed.
+func verifyAuthenticatedTree(tp *tree.Tree) error {
+	// (1) Structural integrity: root spends BatchOutpoint, and each child's
+	// input references its parent's real txid:index. This makes the prevout
+	// fetched below genuinely the parent's output.
+	if err := tp.Verify(); err != nil {
+		return fmt.Errorf("structure: %w", err)
+	}
+
+	// The prevout fetcher maps each node's input to the output it spends: the
+	// authenticated batch output for the root, and the parent's output for
+	// every child.
+	fetcher, err := tp.Root.PrevOutputFetcher(tp.BatchOutput)
+	if err != nil {
+		return fmt.Errorf("prevouts: %w", err)
+	}
+
+	// (2)+(3): recompute each node's aggregate key and require it to equal the
+	// taproot key of the output it spends. The root is pinned to the
+	// authenticated commitment output; the cascade pins the rest.
+	if err := tp.Root.ForEach(func(n *tree.Node) error {
+		finalKey, err := tree.ComputeFinalKey(
+			n.CoSigners, tp.SweepTapscriptRoot,
+		)
+		if err != nil {
+			return fmt.Errorf("recompute final key: %w", err)
+		}
+		n.FinalKey = finalKey
+
+		wantScript, err := txscript.PayToTaprootScript(finalKey)
+		if err != nil {
+			return fmt.Errorf("derive taproot script: %w", err)
+		}
+		prevOut := fetcher.FetchPrevOutput(n.Input)
+		if prevOut == nil ||
+			!bytes.Equal(wantScript, prevOut.PkScript) {
+
+			return fmt.Errorf("node aggregate key does not match " +
+				"the output it spends")
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// (4) Every node's signature must verify. Given (3), an attacker cannot
+	// forge these without the real round's keys.
+	if err := tp.VerifySigned(); err != nil {
+		return fmt.Errorf("signatures: %w", err)
+	}
+
+	return nil
 }

--- a/vtxo/incoming_ancestry_binding_test.go
+++ b/vtxo/incoming_ancestry_binding_test.go
@@ -1,0 +1,290 @@
+package vtxo
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/batchcanon"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/stretchr/testify/require"
+)
+
+func bindingKey(t *testing.T) *btcec.PublicKey {
+	t.Helper()
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return priv.PubKey()
+}
+
+// taprootScript returns PayToTaproot(ComputeFinalKey([keys...], sweepRoot)) — the
+// output script a genuine tree node commits its children to.
+func taprootScript(t *testing.T, sweepRoot []byte,
+	keys ...*btcec.PublicKey) []byte {
+
+	t.Helper()
+	finalKey, err := tree.ComputeFinalKey(keys, sweepRoot)
+	require.NoError(t, err)
+	script, err := txscript.PayToTaprootScript(finalKey)
+	require.NoError(t, err)
+
+	return script
+}
+
+// oneLeafTree builds a structurally-valid single-leaf VTXO tree whose root
+// spends `batchOutput` (the authenticated commitment output) and whose leaf pays
+// vtxoScript, cosigned by operator+owner. It is UNSIGNED (NewTree does not sign).
+func oneLeafTree(t *testing.T, commitment chainhash.Hash, sweepRoot []byte,
+	operator, owner *btcec.PublicKey, batchOutput *wire.TxOut,
+	vtxoScript []byte) *tree.Tree {
+
+	t.Helper()
+	leaves := []tree.LeafDescriptor{{
+		PkScript:    vtxoScript,
+		Amount:      1000,
+		CoSignerKey: owner,
+	}}
+	tr, err := tree.NewTree(
+		wire.OutPoint{Hash: commitment}, batchOutput, leaves,
+		operator, sweepRoot, 2,
+	)
+	require.NoError(t, err)
+
+	return tr
+}
+
+// TestBindingRejectsForeignKeys is THE bypass-defense assertion. An attacker
+// fabricates an internally-consistent tree signed with THEIR OWN keys (so a bare
+// signature check would pass) whose leaf carries the victim's public script. But
+// the batch output is authenticated to the REAL commitment output = a taproot
+// key the attacker does not control. The key-to-output binding rejects it: the
+// root's recomputed aggregate key does not match the authenticated output it
+// spends. This is the single check that closes the "signs with own keys" hole.
+func TestBindingRejectsForeignKeys(t *testing.T) {
+	t.Parallel()
+
+	sweepRoot := make([]byte, 32)
+	var commitment chainhash.Hash
+	commitment[0] = 0xab
+	vtxoScript := []byte("victim_vtxo_script")
+
+	// The authenticated commitment output belongs to the REAL round key.
+	realOperator := bindingKey(t)
+	realOwner := bindingKey(t)
+	authedOutput := &wire.TxOut{
+		Value:    1000,
+		PkScript: taprootScript(t, sweepRoot, realOperator, realOwner),
+	}
+
+	// The attacker's tree uses keys THEY control, but its root spends the
+	// authenticated (real-key) output.
+	attackerOperator := bindingKey(t)
+	attackerOwner := bindingKey(t)
+	tr := oneLeafTree(
+		t, commitment, sweepRoot, attackerOperator, attackerOwner,
+		authedOutput, vtxoScript,
+	)
+
+	err := VerifyReceivedVTXOBinding(
+		[]Ancestry{{TreePath: tr, CommitmentTxID: commitment}},
+		vtxoScript,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match the output it spends")
+}
+
+// TestBindingUnsignedGenuineTreeFailsOnlyAtSignatures proves the key-to-output
+// binding does NOT false-reject a genuine tree: a structurally-genuine tree
+// whose batch output IS PayToTaproot(its own root key) passes structure and the
+// key binding, and is rejected only because it is unsigned. This is the negative
+// control for the check in TestBindingRejectsForeignKeys and shows genuine trees
+// clear steps 1-3 (so the accept path — validated end-to-end against real signed
+// trees in itests — is not blocked by this check).
+func TestBindingUnsignedGenuineTreeFailsOnlyAtSignatures(t *testing.T) {
+	t.Parallel()
+
+	sweepRoot := make([]byte, 32)
+	var commitment chainhash.Hash
+	commitment[0] = 0xcd
+	vtxoScript := []byte("genuine_vtxo_script")
+
+	operator := bindingKey(t)
+	owner := bindingKey(t)
+	// Genuine: the batch output the root spends IS PayToTaproot(root key).
+	genuineOutput := &wire.TxOut{
+		Value:    1000,
+		PkScript: taprootScript(t, sweepRoot, operator, owner),
+	}
+	tr := oneLeafTree(
+		t, commitment, sweepRoot, operator, owner, genuineOutput,
+		vtxoScript,
+	)
+
+	err := VerifyReceivedVTXOBinding(
+		[]Ancestry{{TreePath: tr, CommitmentTxID: commitment}},
+		vtxoScript,
+	)
+	require.Error(t, err)
+	require.Contains(
+		t, err.Error(), "signatures",
+		"a genuine-structured tree must clear structure + key binding "+
+			"and fail only on the missing signatures",
+	)
+	require.NotContains(t, err.Error(), "does not match the output")
+}
+
+// TestOORLineageRejectsForeignKeys is the OOR bypass-defense. The attacker's
+// tree spends the authenticated commitment output (so the evidence anchor
+// passes) but its nodes are signed with the attacker's own keys: the
+// key-to-output binding rejects it, exactly as on the in-round path.
+func TestOORLineageRejectsForeignKeys(t *testing.T) {
+	t.Parallel()
+
+	sweepRoot := make([]byte, 32)
+	var commitment chainhash.Hash
+	commitment[0] = 0xab
+
+	realOperator := bindingKey(t)
+	realOwner := bindingKey(t)
+	authedScript := taprootScript(t, sweepRoot, realOperator, realOwner)
+	evidence := []batchcanon.BatchEvidence{{
+		BatchTxID:            commitment,
+		BatchOutputIndex:     0,
+		ConfirmationPkScript: authedScript,
+	}}
+
+	// Root spends the authenticated (real-key) output, but the tree is the
+	// attacker's, cosigned with keys THEY hold.
+	attackerOperator := bindingKey(t)
+	attackerOwner := bindingKey(t)
+	tr := oneLeafTree(
+		t, commitment, sweepRoot, attackerOperator, attackerOwner,
+		&wire.TxOut{Value: 1000, PkScript: authedScript},
+		[]byte("input_vtxo_script"),
+	)
+
+	err := VerifyOORAncestryLineage(
+		[]Ancestry{{TreePath: tr, CommitmentTxID: commitment}},
+		evidence, 0, nil,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match the output it spends")
+}
+
+// TestOORLineageRejectsEvidenceMismatch proves the evidence anchor: an
+// internally-consistent attacker tree rooted at an output whose script the
+// attacker controls is rejected because it does not equal the authenticated
+// commitment output the client will watch.
+func TestOORLineageRejectsEvidenceMismatch(t *testing.T) {
+	t.Parallel()
+
+	sweepRoot := make([]byte, 32)
+	var commitment chainhash.Hash
+	commitment[0] = 0xab
+
+	// The authenticated commitment output belongs to the real round key.
+	realScript := taprootScript(t, sweepRoot, bindingKey(t), bindingKey(t))
+	evidence := []batchcanon.BatchEvidence{{
+		BatchTxID:            commitment,
+		BatchOutputIndex:     0,
+		ConfirmationPkScript: realScript,
+	}}
+
+	// The attacker's fully-self-consistent tree is rooted at THEIR key's
+	// output (so its own key-to-output binding would hold), but that is not
+	// the authenticated commitment output.
+	attackerOperator := bindingKey(t)
+	attackerOwner := bindingKey(t)
+	attackerScript := taprootScript(
+		t, sweepRoot, attackerOperator, attackerOwner,
+	)
+	tr := oneLeafTree(
+		t, commitment, sweepRoot, attackerOperator, attackerOwner,
+		&wire.TxOut{Value: 1000, PkScript: attackerScript},
+		[]byte("input_vtxo_script"),
+	)
+
+	err := VerifyOORAncestryLineage(
+		[]Ancestry{{TreePath: tr, CommitmentTxID: commitment}},
+		evidence, 0, nil,
+	)
+	require.Error(t, err)
+	require.Contains(
+		t, err.Error(), "does not match the authenticated commitment",
+	)
+}
+
+// TestOORLineageRejectsMissingEvidence proves fail-closed when a watched
+// commitment has no authenticated evidence.
+func TestOORLineageRejectsMissingEvidence(t *testing.T) {
+	t.Parallel()
+
+	sweepRoot := make([]byte, 32)
+	var commitment, other chainhash.Hash
+	commitment[0] = 0xab
+	other[0] = 0xcd
+
+	tr := oneLeafTree(
+		t, commitment, sweepRoot, bindingKey(t), bindingKey(t),
+		&wire.TxOut{Value: 1000, PkScript: []byte{0x51}},
+		[]byte("x"),
+	)
+	evidence := []batchcanon.BatchEvidence{{BatchTxID: other}}
+
+	err := VerifyOORAncestryLineage(
+		[]Ancestry{{TreePath: tr, CommitmentTxID: commitment}},
+		evidence, 0, nil,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no authenticated evidence")
+}
+
+// TestBindingRejectsEmptyScript and no-tree guard the input contract.
+func TestBindingRejectsEmptyScript(t *testing.T) {
+	t.Parallel()
+
+	require.Error(t, VerifyReceivedVTXOBinding(nil, nil))
+
+	var commitment chainhash.Hash
+	require.Error(t, VerifyReceivedVTXOBinding(
+		[]Ancestry{{TreePath: nil, CommitmentTxID: commitment}},
+		[]byte("s"),
+	))
+}
+
+// TestBindCoinInputsToLeaves covers the single-hop OOR terminator's matching
+// logic directly (the surrounding tree verification needs signed fixtures,
+// exercised end-to-end by the OOR receive itests).
+func TestBindCoinInputsToLeaves(t *testing.T) {
+	t.Parallel()
+
+	var a, b chainhash.Hash
+	a[0] = 0xa1
+	b[0] = 0xb2
+	leaves := map[chainhash.Hash]struct{}{a: {}, b: {}}
+
+	op := func(h chainhash.Hash, i uint32) wire.OutPoint {
+		return wire.OutPoint{Hash: h, Index: i}
+	}
+
+	// Single-hop: every coin input produced by a leaf -> accept.
+	require.NoError(t, bindCoinInputsToLeaves(
+		leaves, []wire.OutPoint{op(a, 0), op(b, 1)},
+	))
+
+	// Single-hop: a coin input NOT produced by any leaf (decoy lineage) ->
+	// reject. This is the fail-open the terminator closes.
+	var decoy chainhash.Hash
+	decoy[0] = 0xcc
+	err := bindCoinInputsToLeaves(
+		leaves, []wire.OutPoint{op(a, 0), op(decoy, 0)},
+	)
+	require.ErrorContains(t, err, "not produced by any authenticated")
+
+	// No coin inputs -> fail closed (an OOR receive always has checkpoint
+	// inputs; their absence means the coin's lineage cannot be bound).
+	require.Error(t, bindCoinInputsToLeaves(leaves, nil))
+}

--- a/vtxo/incoming_ancestry_binding_test.go
+++ b/vtxo/incoming_ancestry_binding_test.go
@@ -20,8 +20,8 @@ func bindingKey(t *testing.T) *btcec.PublicKey {
 	return priv.PubKey()
 }
 
-// taprootScript returns PayToTaproot(ComputeFinalKey([keys...], sweepRoot)) — the
-// output script a genuine tree node commits its children to.
+// taprootScript returns PayToTaproot(ComputeFinalKey([keys...], sweepRoot)) —
+// the output script a genuine tree node commits its children to.
 func taprootScript(t *testing.T, sweepRoot []byte,
 	keys ...*btcec.PublicKey) []byte {
 
@@ -35,8 +35,9 @@ func taprootScript(t *testing.T, sweepRoot []byte,
 }
 
 // oneLeafTree builds a structurally-valid single-leaf VTXO tree whose root
-// spends `batchOutput` (the authenticated commitment output) and whose leaf pays
-// vtxoScript, cosigned by operator+owner. It is UNSIGNED (NewTree does not sign).
+// spends `batchOutput` (the authenticated commitment output) and whose leaf
+// pays vtxoScript, cosigned by operator+owner. It is UNSIGNED (NewTree does not
+// sign).
 func oneLeafTree(t *testing.T, commitment chainhash.Hash, sweepRoot []byte,
 	operator, owner *btcec.PublicKey, batchOutput *wire.TxOut,
 	vtxoScript []byte) *tree.Tree {
@@ -48,8 +49,14 @@ func oneLeafTree(t *testing.T, commitment chainhash.Hash, sweepRoot []byte,
 		CoSignerKey: owner,
 	}}
 	tr, err := tree.NewTree(
-		wire.OutPoint{Hash: commitment}, batchOutput, leaves,
-		operator, sweepRoot, 2,
+		wire.OutPoint{
+			Hash: commitment,
+		},
+		batchOutput,
+		leaves,
+		operator,
+		sweepRoot,
+		2,
 	)
 	require.NoError(t, err)
 
@@ -57,12 +64,13 @@ func oneLeafTree(t *testing.T, commitment chainhash.Hash, sweepRoot []byte,
 }
 
 // TestBindingRejectsForeignKeys is THE bypass-defense assertion. An attacker
-// fabricates an internally-consistent tree signed with THEIR OWN keys (so a bare
-// signature check would pass) whose leaf carries the victim's public script. But
-// the batch output is authenticated to the REAL commitment output = a taproot
-// key the attacker does not control. The key-to-output binding rejects it: the
-// root's recomputed aggregate key does not match the authenticated output it
-// spends. This is the single check that closes the "signs with own keys" hole.
+// fabricates an internally-consistent tree signed with THEIR OWN keys (so a
+// bare signature check would pass) whose leaf carries the victim's public
+// script. But the batch output is authenticated to the REAL commitment output =
+// a taproot key the attacker does not control. The key-to-output binding
+// rejects it: the root's recomputed aggregate key does not match the
+// authenticated output it spends. This is the single check that closes the
+// "signs with own keys" hole.
 func TestBindingRejectsForeignKeys(t *testing.T) {
 	t.Parallel()
 
@@ -89,7 +97,9 @@ func TestBindingRejectsForeignKeys(t *testing.T) {
 	)
 
 	err := VerifyReceivedVTXOBinding(
-		[]Ancestry{{TreePath: tr, CommitmentTxID: commitment}},
+		[]Ancestry{
+			{TreePath: tr, CommitmentTxID: commitment},
+		},
 		vtxoScript,
 	)
 	require.Error(t, err)
@@ -99,10 +109,10 @@ func TestBindingRejectsForeignKeys(t *testing.T) {
 // TestBindingUnsignedGenuineTreeFailsOnlyAtSignatures proves the key-to-output
 // binding does NOT false-reject a genuine tree: a structurally-genuine tree
 // whose batch output IS PayToTaproot(its own root key) passes structure and the
-// key binding, and is rejected only because it is unsigned. This is the negative
-// control for the check in TestBindingRejectsForeignKeys and shows genuine trees
-// clear steps 1-3 (so the accept path — validated end-to-end against real signed
-// trees in itests — is not blocked by this check).
+// key binding, and is rejected only because it is unsigned. This is the
+// negative control for the check in TestBindingRejectsForeignKeys and shows
+// genuine trees clear steps 1-3 (so the accept path — validated end-to-end
+// against real signed trees in itests — is not blocked by this check).
 func TestBindingUnsignedGenuineTreeFailsOnlyAtSignatures(t *testing.T) {
 	t.Parallel()
 
@@ -124,14 +134,17 @@ func TestBindingUnsignedGenuineTreeFailsOnlyAtSignatures(t *testing.T) {
 	)
 
 	err := VerifyReceivedVTXOBinding(
-		[]Ancestry{{TreePath: tr, CommitmentTxID: commitment}},
+		[]Ancestry{
+			{TreePath: tr, CommitmentTxID: commitment},
+		},
 		vtxoScript,
 	)
 	require.Error(t, err)
 	require.Contains(
-		t, err.Error(), "signatures",
-		"a genuine-structured tree must clear structure + key binding "+
-			"and fail only on the missing signatures",
+		t, err.Error(),
+		"signatures", "a genuine-structured tree must clear "+
+			"structure + key binding and fail only on the "+
+			"missing signatures",
 	)
 	require.NotContains(t, err.Error(), "does not match the output")
 }
@@ -162,13 +175,20 @@ func TestOORLineageRejectsForeignKeys(t *testing.T) {
 	attackerOwner := bindingKey(t)
 	tr := oneLeafTree(
 		t, commitment, sweepRoot, attackerOperator, attackerOwner,
-		&wire.TxOut{Value: 1000, PkScript: authedScript},
+		&wire.TxOut{
+			Value:    1000,
+			PkScript: authedScript,
+		},
 		[]byte("input_vtxo_script"),
 	)
 
 	err := VerifyOORAncestryLineage(
-		[]Ancestry{{TreePath: tr, CommitmentTxID: commitment}},
-		evidence, 0, nil,
+		[]Ancestry{
+			{TreePath: tr, CommitmentTxID: commitment},
+		},
+		evidence,
+		0,
+		nil,
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "does not match the output it spends")
@@ -203,17 +223,25 @@ func TestOORLineageRejectsEvidenceMismatch(t *testing.T) {
 	)
 	tr := oneLeafTree(
 		t, commitment, sweepRoot, attackerOperator, attackerOwner,
-		&wire.TxOut{Value: 1000, PkScript: attackerScript},
+		&wire.TxOut{
+			Value:    1000,
+			PkScript: attackerScript,
+		},
 		[]byte("input_vtxo_script"),
 	)
 
 	err := VerifyOORAncestryLineage(
-		[]Ancestry{{TreePath: tr, CommitmentTxID: commitment}},
-		evidence, 0, nil,
+		[]Ancestry{
+			{TreePath: tr, CommitmentTxID: commitment},
+		},
+		evidence,
+		0,
+		nil,
 	)
 	require.Error(t, err)
 	require.Contains(
-		t, err.Error(), "does not match the authenticated commitment",
+		t, err.Error(),
+		"does not match the authenticated commitment",
 	)
 }
 
@@ -229,14 +257,21 @@ func TestOORLineageRejectsMissingEvidence(t *testing.T) {
 
 	tr := oneLeafTree(
 		t, commitment, sweepRoot, bindingKey(t), bindingKey(t),
-		&wire.TxOut{Value: 1000, PkScript: []byte{0x51}},
+		&wire.TxOut{
+			Value:    1000,
+			PkScript: []byte{0x51},
+		},
 		[]byte("x"),
 	)
 	evidence := []batchcanon.BatchEvidence{{BatchTxID: other}}
 
 	err := VerifyOORAncestryLineage(
-		[]Ancestry{{TreePath: tr, CommitmentTxID: commitment}},
-		evidence, 0, nil,
+		[]Ancestry{
+			{TreePath: tr, CommitmentTxID: commitment},
+		},
+		evidence,
+		0,
+		nil,
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no authenticated evidence")
@@ -249,10 +284,15 @@ func TestBindingRejectsEmptyScript(t *testing.T) {
 	require.Error(t, VerifyReceivedVTXOBinding(nil, nil))
 
 	var commitment chainhash.Hash
-	require.Error(t, VerifyReceivedVTXOBinding(
-		[]Ancestry{{TreePath: nil, CommitmentTxID: commitment}},
-		[]byte("s"),
-	))
+	require.Error(
+		t,
+		VerifyReceivedVTXOBinding(
+			[]Ancestry{
+				{TreePath: nil, CommitmentTxID: commitment},
+			},
+			[]byte("s"),
+		),
+	)
 }
 
 // TestBindCoinInputsToLeaves covers the single-hop OOR terminator's matching
@@ -271,9 +311,12 @@ func TestBindCoinInputsToLeaves(t *testing.T) {
 	}
 
 	// Single-hop: every coin input produced by a leaf -> accept.
-	require.NoError(t, bindCoinInputsToLeaves(
-		leaves, []wire.OutPoint{op(a, 0), op(b, 1)},
-	))
+	require.NoError(
+		t,
+		bindCoinInputsToLeaves(
+			leaves, []wire.OutPoint{op(a, 0), op(b, 1)},
+		),
+	)
 
 	// Single-hop: a coin input NOT produced by any leaf (decoy lineage) ->
 	// reject. This is the fail-open the terminator closes.

--- a/vtxo/incoming_ancestry_resolver.go
+++ b/vtxo/incoming_ancestry_resolver.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/batchcanon"
 	"github.com/lightninglabs/wavelength/internal/indexerlimits"
 )
 
@@ -87,9 +88,18 @@ func ResolveIncomingAncestry(ctx context.Context, query IncomingAncestryQuery,
 					"convert ancestry paths: %w", err)
 			}
 
+			evidence, err := batchcanon.EvidenceFromAncestryPaths(
+				candidate.GetAncestryPaths(),
+			)
+			if err != nil {
+				return IncomingVTXOExtras{}, fmt.Errorf(
+					"convert batch evidence: %w", err)
+			}
+
 			return IncomingVTXOExtras{
 				Ancestry:      ancestry,
 				CreatedHeight: candidate.GetCreatedHeight(),
+				BatchEvidence: evidence,
 			}, nil
 		}
 

--- a/vtxo/incoming_batch_registration.go
+++ b/vtxo/incoming_batch_registration.go
@@ -1,0 +1,71 @@
+package vtxo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/batchcanon"
+)
+
+// registerIncomingBatchEvidence awaits registration for every distinct
+// commitment before the descriptor becomes visible to persistence or actors.
+func registerIncomingBatchEvidence(ctx context.Context,
+	registrar IncomingBatchRegistrar, desc *Descriptor,
+	evidence []batchcanon.BatchEvidence) error {
+
+	if len(evidence) == 0 {
+		return nil
+	}
+	if registrar == nil {
+		return fmt.Errorf("incoming batch registrar must be provided")
+	}
+	if desc == nil {
+		return fmt.Errorf("incoming VTXO descriptor must be provided")
+	}
+
+	ancestry := make(map[chainhash.Hash]struct{}, len(desc.Ancestry))
+	for _, fragment := range desc.Ancestry {
+		ancestry[fragment.CommitmentTxID] = struct{}{}
+	}
+	seen := make(map[chainhash.Hash]struct{}, len(evidence))
+	for i := range evidence {
+		item := evidence[i]
+		if err := item.Validate(); err != nil {
+			return fmt.Errorf("incoming batch evidence %d: %w", i,
+				err)
+		}
+		if item.CSVExpiryDelta <= 0 {
+			return fmt.Errorf("incoming batch evidence %d has "+
+				"non-positive CSV expiry delta", i)
+		}
+		if _, ok := ancestry[item.BatchTxID]; !ok {
+			return fmt.Errorf("incoming batch evidence %d names "+
+				"commitment %s outside ancestry", i,
+				item.BatchTxID)
+		}
+		if _, duplicate := seen[item.BatchTxID]; duplicate {
+			return fmt.Errorf("incoming batch evidence %d "+
+				"duplicates commitment %s", i, item.BatchTxID)
+		}
+		seen[item.BatchTxID] = struct{}{}
+	}
+	if len(seen) != len(ancestry) {
+		return fmt.Errorf("incoming batch evidence covers %d of %d "+
+			"ancestry commitments", len(seen), len(ancestry))
+	}
+
+	dependent := []wire.OutPoint{desc.Outpoint}
+	for i := range evidence {
+		item := evidence[i]
+		if err := registrar.RegisterBatch(
+			ctx, item.RegisterRequest(dependent),
+		); err != nil {
+			return fmt.Errorf("register incoming commitment %s: %w",
+				item.BatchTxID, err)
+		}
+	}
+
+	return nil
+}

--- a/vtxo/incoming_batch_registration_test.go
+++ b/vtxo/incoming_batch_registration_test.go
@@ -1,0 +1,105 @@
+package vtxo
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/batchcanon"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingIncomingRegistrar struct {
+	requests []*batchcanon.RegisterBatchRequest
+	err      error
+}
+
+// RegisterBatch records one incoming lineage registration.
+func (r *recordingIncomingRegistrar) RegisterBatch(_ context.Context,
+	request *batchcanon.RegisterBatchRequest) error {
+
+	if r.err != nil {
+		return r.err
+	}
+	r.requests = append(r.requests, request)
+
+	return nil
+}
+
+// TestRegisterIncomingBatchEvidence proves the descriptor outpoint is bound as
+// a dependent and registration failures stop the receive path.
+func TestRegisterIncomingBatchEvidence(t *testing.T) {
+	t.Parallel()
+
+	evidence := testIncomingEvidence(t)
+	desc := &Descriptor{
+		Outpoint: wire.OutPoint{
+			Hash: chainhash.Hash{
+				0xaa,
+			},
+			Index: 3,
+		},
+		Ancestry: []Ancestry{{
+			CommitmentTxID: evidence.BatchTxID,
+		}},
+	}
+	registrar := &recordingIncomingRegistrar{}
+	require.NoError(
+		t,
+		registerIncomingBatchEvidence(
+			context.Background(), registrar, desc,
+			[]batchcanon.BatchEvidence{evidence},
+		),
+	)
+	require.Len(t, registrar.requests, 1)
+	require.Equal(
+		t, []wire.OutPoint{desc.Outpoint},
+		registrar.requests[0].DependentVTXOs,
+	)
+
+	wantErr := errors.New("registration failed")
+	err := registerIncomingBatchEvidence(
+		context.Background(), &recordingIncomingRegistrar{
+			err: wantErr,
+		},
+		desc,
+		[]batchcanon.BatchEvidence{evidence},
+	)
+	require.ErrorIs(t, err, wantErr)
+}
+
+// testIncomingEvidence creates complete evidence for one commitment.
+func testIncomingEvidence(t *testing.T) batchcanon.BatchEvidence {
+	t.Helper()
+
+	input := wire.OutPoint{
+		Hash: chainhash.Hash{
+			0x11,
+		},
+		Index: 1,
+	}
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(wire.NewTxIn(&input, nil, nil))
+	tx.AddTxOut(wire.NewTxOut(1_000, []byte{0x51, 0x20, 0x22}))
+
+	var raw bytes.Buffer
+	require.NoError(t, tx.Serialize(&raw))
+
+	return batchcanon.BatchEvidence{
+		BatchTxID:            tx.TxHash(),
+		BatchTx:              raw.Bytes(),
+		BatchOutputIndex:     0,
+		ConfirmationPkScript: bytes.Clone(tx.TxOut[0].PkScript),
+		CSVExpiryDelta:       144,
+		ConsumedInputs: []batchcanon.ConsumedInput{{
+			Outpoint: input,
+			Value:    2_000,
+			PkScript: []byte{
+				0x51,
+			},
+		}},
+	}
+}

--- a/vtxo/incoming_handler.go
+++ b/vtxo/incoming_handler.go
@@ -202,6 +202,12 @@ func (h *IncomingVTXOHandler) emitReceived(ctx context.Context, status string) {
 }
 
 // Receive processes IncomingVTXOEvent messages.
+// The incoming-VTXO dispatch is a single flat switch over event kinds; adding
+// provisional-lineage registration pushed it a few lines past the length limit,
+// but splitting the switch would obscure the 1:1 event->handler mapping without
+// reducing real complexity.
+//
+//nolint:funlen
 func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 	msg IncomingVTXOMsg) fn.Result[IncomingVTXOResp] {
 

--- a/vtxo/incoming_handler.go
+++ b/vtxo/incoming_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
 	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/batchcanon"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightninglabs/wavelength/metrics"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
@@ -93,6 +94,16 @@ type IncomingVTXOExtras struct {
 	// to which block its round commit confirmed in, or sweep
 	// scheduling has no reference point).
 	CreatedHeight int32
+
+	// BatchEvidence authenticates every distinct commitment in Ancestry and
+	// supplies the subjects needed for canonicality watches.
+	BatchEvidence []batchcanon.BatchEvidence
+}
+
+// IncomingBatchRegistrar durably registers authenticated lineage before an
+// incoming descriptor is persisted or sent to the VTXO manager.
+type IncomingBatchRegistrar interface {
+	RegisterBatch(context.Context, *batchcanon.RegisterBatchRequest) error
 }
 
 // IncomingAncestryFetcher resolves the per-VTXO metadata the
@@ -136,6 +147,9 @@ type IncomingVTXOHandlerConfig struct {
 	// a non-nil implementation to keep the unilateral exit path
 	// usable for received VTXOs (see bug-3 in BUGS_FOUND.md).
 	AncestryFetcher IncomingAncestryFetcher
+
+	// BatchRegistrar registers fetched evidence before VTXO exposure.
+	BatchRegistrar IncomingBatchRegistrar
 
 	// MetricsSink is an optional reference to the client-side metrics
 	// actor. When set, the handler emits OORTransferReceivedMsg once
@@ -351,6 +365,7 @@ func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 		RelativeExpiry: evt.RelativeExpiry,
 		Status:         VTXOStatusLive,
 	}
+	var batchEvidence []batchcanon.BatchEvidence
 
 	// Resolve ancestry before persisting so the descriptor lands
 	// with full unilateral-exit material from the first write. The
@@ -377,7 +392,17 @@ func (h *IncomingVTXOHandler) Receive(ctx context.Context,
 		} else {
 			desc.Ancestry = extras.Ancestry
 			desc.CreatedHeight = extras.CreatedHeight
+			batchEvidence = extras.BatchEvidence
 		}
+	}
+
+	if err := registerIncomingBatchEvidence(
+		ctx, h.cfg.BatchRegistrar, desc, batchEvidence,
+	); err != nil {
+
+		h.emitReceived(ctx, "failed")
+
+		return fn.Err[IncomingVTXOResp](err)
 	}
 
 	// Persist the VTXO. A save failure signals a database or

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -2274,10 +2274,6 @@ func (m *Manager) exactSpendUnavailableError(ctx context.Context,
 		ErrInsufficientSpendableFunds, op, desc.Status)
 }
 
-// insufficientLiquidityError distinguishes a true spendable-funds shortfall
-// from liquidity that is present but unavailable because another operation has
-// already moved it out of LiveState.
-// lineageCommitmentTxids returns the deduped set of commitment txids in a
 // LineageCommitmentTxIDs returns the deduped set of commitment txids in a
 // VTXO's lineage: its direct commitment tx plus every distinct cross-commitment
 // ancestor batch recorded in its ancestry. A round-direct or same-commitment

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -117,7 +117,8 @@ type ManagerConfig struct {
 	// any terminal consumer edge for that batch, closing the race where the
 	// consumer became terminally conflict-finalized before the forfeiture
 	// marker existed (so the earlier resolution deferred and would strand
-	// the consumed VTXO until restart, lumos#454). Nil disables the redrive.
+	// the consumed VTXO until restart, lumos#454). Nil disables the
+	// redrive.
 	RedriveConsumerForfeit func(ctx context.Context,
 		consumerBatch chainhash.Hash) error
 
@@ -1042,13 +1043,16 @@ func (m *Manager) handleForceUnroll(ctx context.Context,
 	// proof/sweep side effects for funding that may have left the chain.
 	// Fraud response routes straight into this path, so without the gate a
 	// missing/reorged-lineage VTXO could still trigger a unilateral exit.
-	// Both objectively-invalidated and reversibly-limbo lineage are refused;
-	// the derived availability is surfaced so the caller can tell them apart.
+	// Both objectively-invalidated and reversibly-limbo lineage are
+	// refused; the derived availability is surfaced so the caller can tell
+	// them apart.
 	if m.cfg.BatchCanonicality != nil {
 		desc, err := m.cfg.Store.GetVTXO(ctx, req.Outpoint)
 		if err != nil {
-			return fn.Err[ManagerResp](fmt.Errorf("load vtxo for "+
-				"unroll lineage gate %s: %w", req.Outpoint, err))
+			return fn.Err[ManagerResp](
+				fmt.Errorf("load vtxo for unroll lineage "+
+					"gate %s: %w", req.Outpoint, err),
+			)
 		}
 
 		blocked, avail, err := batchcanon.LineageBlocked(
@@ -1056,13 +1060,18 @@ func (m *Manager) handleForceUnroll(ctx context.Context,
 			LineageCommitmentTxIDs(desc)...,
 		)
 		if err != nil {
-			return fn.Err[ManagerResp](fmt.Errorf("unroll lineage "+
-				"gate %s: %w", req.Outpoint, err))
+			return fn.Err[ManagerResp](
+				fmt.Errorf("unroll lineage gate %s: %w",
+					req.Outpoint, err),
+			)
 		}
 		if blocked {
-			return fn.Err[ManagerResp](fmt.Errorf("refusing force-"+
-				"unroll of %s: batch lineage is not admissible "+
-				"(availability=%s)", req.Outpoint, avail))
+			return fn.Err[ManagerResp](
+				fmt.Errorf("refusing force-unroll of %s: "+
+					"batch lineage is not admissible "+
+					"(availability=%s)", req.Outpoint,
+					avail),
+			)
 		}
 	}
 

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -109,7 +109,7 @@ type ManagerConfig struct {
 	// gate. Because the reducer is fail-closed, the gate must only be
 	// activated once the batch producers (round, OOR) register their
 	// batches, or every unregistered VTXO is excluded.
-	BatchCanonicality batchcanon.Store
+	BatchCanonicality batchcanon.Reader
 
 	// Log is an optional logger for this manager instance. If None, the
 	// manager falls back to extracting a logger from context via
@@ -1023,6 +1023,38 @@ func (m *Manager) handleVTXOsMaterialized(ctx context.Context,
 // the FSM silently self-looped on a terminal state.
 func (m *Manager) handleForceUnroll(ctx context.Context,
 	req *ForceUnrollRequest) fn.Result[ManagerResp] {
+
+	// Gate the unroll point of no return on the VTXO's batch lineage, the
+	// same fail-closed check coin selection and forfeit selection apply: a
+	// VTXO whose lineage is not a ready, confirmed member of the canonical
+	// chain (reorged-out/limbo, conflict-invalidated, or fail-closed
+	// missing/reconciling) must not enter UnilateralExitState and create
+	// proof/sweep side effects for funding that may have left the chain.
+	// Fraud response routes straight into this path, so without the gate a
+	// missing/reorged-lineage VTXO could still trigger a unilateral exit.
+	// Both objectively-invalidated and reversibly-limbo lineage are refused;
+	// the derived availability is surfaced so the caller can tell them apart.
+	if m.cfg.BatchCanonicality != nil {
+		desc, err := m.cfg.Store.GetVTXO(ctx, req.Outpoint)
+		if err != nil {
+			return fn.Err[ManagerResp](fmt.Errorf("load vtxo for "+
+				"unroll lineage gate %s: %w", req.Outpoint, err))
+		}
+
+		blocked, avail, err := batchcanon.LineageBlocked(
+			ctx, m.cfg.BatchCanonicality,
+			LineageCommitmentTxIDs(desc)...,
+		)
+		if err != nil {
+			return fn.Err[ManagerResp](fmt.Errorf("unroll lineage "+
+				"gate %s: %w", req.Outpoint, err))
+		}
+		if blocked {
+			return fn.Err[ManagerResp](fmt.Errorf("refusing force-"+
+				"unroll of %s: batch lineage is not admissible "+
+				"(availability=%s)", req.Outpoint, avail))
+		}
+	}
 
 	actorRef, ok := m.actors[req.Outpoint]
 	if !ok {
@@ -2226,6 +2258,7 @@ func (m *Manager) exactSpendUnavailableError(ctx context.Context,
 // from liquidity that is present but unavailable because another operation has
 // already moved it out of LiveState.
 // lineageCommitmentTxids returns the deduped set of commitment txids in a
+// LineageCommitmentTxIDs returns the deduped set of commitment txids in a
 // VTXO's lineage: its direct commitment tx plus every distinct cross-commitment
 // ancestor batch recorded in its ancestry. A round-direct or same-commitment
 // OOR VTXO yields one txid; a cross-commitment multi-input OOR VTXO (born from
@@ -2233,7 +2266,11 @@ func (m *Manager) exactSpendUnavailableError(ctx context.Context,
 // batch. The direct commitment txid is included even when the ancestry slice is
 // empty (e.g. an incoming VTXO materialized without its commitment tree) so the
 // gate still governs the leaf by its batch. The zero hash is skipped.
-func lineageCommitmentTxids(desc *Descriptor) []chainhash.Hash {
+func LineageCommitmentTxIDs(desc *Descriptor) []chainhash.Hash {
+	if desc == nil {
+		return nil
+	}
+
 	seen := make(map[chainhash.Hash]struct{}, len(desc.Ancestry)+1)
 	txids := make([]chainhash.Hash, 0, len(desc.Ancestry)+1)
 
@@ -2283,7 +2320,7 @@ func (m *Manager) gateUnavailableLineage(ctx context.Context,
 
 		blocked, avail, err := batchcanon.LineageBlocked(
 			ctx, m.cfg.BatchCanonicality,
-			lineageCommitmentTxids(desc)...,
+			LineageCommitmentTxIDs(desc)...,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("lineage gate %s: %w",
@@ -2304,6 +2341,9 @@ func (m *Manager) gateUnavailableLineage(ctx context.Context,
 	return kept, nil
 }
 
+// insufficientLiquidityError distinguishes a true spendable-funds shortfall
+// from liquidity that is present but unavailable because another operation has
+// already moved it out of LiveState.
 func (m *Manager) insufficientLiquidityError(ctx context.Context,
 	liveCandidates []*Descriptor, p reserveParams) error {
 

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -111,6 +111,16 @@ type ManagerConfig struct {
 	// batches, or every unregistered VTXO is excluded.
 	BatchCanonicality batchcanon.Reader
 
+	// RedriveConsumerForfeit, when set, is invoked (via the VTXO actor)
+	// after a VTXO's forfeiture marker is durably persisted, passing the
+	// consuming batch. It asks the batch canonicality manager to re-resolve
+	// any terminal consumer edge for that batch, closing the race where the
+	// consumer became terminally conflict-finalized before the forfeiture
+	// marker existed (so the earlier resolution deferred and would strand
+	// the consumed VTXO until restart, lumos#454). Nil disables the redrive.
+	RedriveConsumerForfeit func(ctx context.Context,
+		consumerBatch chainhash.Hash) error
+
 	// Log is an optional logger for this manager instance. If None, the
 	// manager falls back to extracting a logger from context via
 	// LoggerFromContext, or uses btclog.Disabled if no logger is found.
@@ -1929,6 +1939,7 @@ func (m *Manager) spawnVTXOActor(ctx context.Context, vtxo *Descriptor) (
 		RefreshFeeQuoter:         m.cfg.RefreshFeeQuoter,
 		FetchOperatorKey:         m.cfg.FetchOperatorKey,
 		ForfeitParticipantSigner: m.cfg.ForfeitParticipantSigner,
+		NotifyForfeitPersisted:   m.cfg.RedriveConsumerForfeit,
 	}
 
 	vtxoActor := NewVTXOActor(ctx, actorCfg)

--- a/vtxo/manager_force_unroll_test.go
+++ b/vtxo/manager_force_unroll_test.go
@@ -1,14 +1,28 @@
 package vtxo
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/batchcanon"
 	"github.com/lightninglabs/wavelength/lib/actormsg"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
 )
+
+// failClosedReader is a batchcanon.Reader that reports every batch as
+// not-found, so any lineage derives to the fail-closed LineageReconciling
+// availability (never usable).
+type failClosedReader struct{}
+
+func (failClosedReader) GetBatch(context.Context, chainhash.Hash) (
+	*batchcanon.Record, error) {
+
+	return nil, batchcanon.ErrBatchNotFound
+}
 
 // TestHandleForceUnrollLiveActorTransitions verifies the manager drives a live
 // VTXO actor into UnilateralExitState on a ForceUnrollRequest, so fraud and
@@ -35,6 +49,36 @@ func TestHandleForceUnrollLiveActorTransitions(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, forceResp.Accepted)
 	require.IsType(t, &UnilateralExitState{}, ref.state)
+}
+
+// TestHandleForceUnrollGatedOnUnavailableLineage verifies the unroll point of
+// no return is fail-closed: a VTXO whose batch lineage is not admissible (here
+// fail-closed missing lineage) is refused rather than entering
+// UnilateralExitState and creating proof/sweep side effects. Fraud response
+// routes through this same path, so the gate protects it too.
+func TestHandleForceUnrollGatedOnUnavailableLineage(t *testing.T) {
+	t.Parallel()
+
+	vtxo := makeDescriptor(t, 50_000, 13)
+	store := &MockVTXOStore{}
+	mgr := &Manager{
+		cfg: &ManagerConfig{
+			Store:             store,
+			BatchCanonicality: failClosedReader{},
+		},
+		actors: make(map[wire.OutPoint]VTXOActorRef),
+	}
+
+	store.On("GetVTXO", t.Context(), vtxo.Outpoint).Return(vtxo, nil)
+
+	resp := mgr.Receive(t.Context(), &actormsg.ForceUnrollRequest{
+		Outpoint: vtxo.Outpoint,
+		Trigger:  actormsg.UnrollTriggerFraudSpend,
+	})
+	_, err := resp.Unpack()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not admissible")
+	store.AssertExpectations(t)
 }
 
 // TestHandleForceUnrollAbsentActorNoDescriptor verifies that a force-unroll for

--- a/waved/batch_canonicality.go
+++ b/waved/batch_canonicality.go
@@ -1,0 +1,33 @@
+package waved
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/batchcanon"
+)
+
+// roundBatchRegistrar adapts the batch-canonicality actor's request/response
+// API to the narrow synchronous seam used by the round FSM.
+type roundBatchRegistrar struct {
+	ref actor.ActorRef[batchcanon.ManagerMsg, batchcanon.ManagerResp]
+}
+
+// RegisterBatch waits until the complete registration is durable and its
+// watches are armed. Returning before that point would let the round expose a
+// VTXO whose lineage is still unknown to the fail-closed admission gate.
+func (r *roundBatchRegistrar) RegisterBatch(ctx context.Context,
+	req *batchcanon.RegisterBatchRequest) error {
+
+	resp, err := r.ref.Ask(ctx, req).Await(ctx).Unpack()
+	if err != nil {
+		return err
+	}
+	if _, ok := resp.(*batchcanon.RegisterBatchResponse); !ok {
+		return fmt.Errorf("unexpected batch registration response %T",
+			resp)
+	}
+
+	return nil
+}

--- a/waved/batch_canonicality.go
+++ b/waved/batch_canonicality.go
@@ -8,16 +8,16 @@ import (
 	"github.com/lightninglabs/wavelength/batchcanon"
 )
 
-// roundBatchRegistrar adapts the batch-canonicality actor's request/response
-// API to the narrow synchronous seam used by the round FSM.
-type roundBatchRegistrar struct {
+// batchRegistrar adapts the batch-canonicality actor's request/response API to
+// the narrow synchronous seam used by round and OOR receive paths.
+type batchRegistrar struct {
 	ref actor.ActorRef[batchcanon.ManagerMsg, batchcanon.ManagerResp]
 }
 
 // RegisterBatch waits until the complete registration is durable and its
 // watches are armed. Returning before that point would let the round expose a
 // VTXO whose lineage is still unknown to the fail-closed admission gate.
-func (r *roundBatchRegistrar) RegisterBatch(ctx context.Context,
+func (r *batchRegistrar) RegisterBatch(ctx context.Context,
 	req *batchcanon.RegisterBatchRequest) error {
 
 	resp, err := r.ref.Ask(ctx, req).Await(ctx).Unpack()

--- a/waved/incoming_ancestry_fetcher.go
+++ b/waved/incoming_ancestry_fetcher.go
@@ -62,10 +62,31 @@ func incomingAncestryFetcher(idx *indexer.Client,
 			)
 		}
 
-		return vtxo.ResolveIncomingAncestry(
+		extras, err := vtxo.ResolveIncomingAncestry(
 			ctx, query, outpoint, pkScript,
 			vtxo.DefaultIncomingAncestryIndexPageSize,
 			uint64(oor.DefaultMaxVTXOMatches),
 		)
+		if err != nil {
+			return vtxo.IncomingVTXOExtras{}, err
+		}
+
+		// ResolveIncomingAncestry has authenticated each tree's batch
+		// output against its real commitment tx
+		// (EvidenceFromAncestryPaths). Now cryptographically bind the
+		// received VTXO to that authenticated lineage (F-H1): prove it
+		// is a genuine, operator-signed leaf of the commitment we will
+		// watch, not a decoy the indexer named. A failure surfaces as a
+		// fetch failure, and the handler then persists the VTXO without
+		// ancestry (fail closed -- no reorg watch armed on an unverified
+		// commitment; exit material restored by a later backfill).
+		if err := vtxo.VerifyReceivedVTXOBinding(
+			extras.Ancestry, pkScript,
+		); err != nil {
+			return vtxo.IncomingVTXOExtras{}, fmt.Errorf(
+				"bind received vtxo to commitment: %w", err)
+		}
+
+		return extras, nil
 	}, nil
 }

--- a/waved/incoming_ancestry_fetcher.go
+++ b/waved/incoming_ancestry_fetcher.go
@@ -78,13 +78,14 @@ func incomingAncestryFetcher(idx *indexer.Client,
 		// is a genuine, operator-signed leaf of the commitment we will
 		// watch, not a decoy the indexer named. A failure surfaces as a
 		// fetch failure, and the handler then persists the VTXO without
-		// ancestry (fail closed -- no reorg watch armed on an unverified
-		// commitment; exit material restored by a later backfill).
+		// ancestry (fail closed -- no reorg watch armed on an
+		// unverified commitment; exit material restored by a later
+		// backfill).
 		if err := vtxo.VerifyReceivedVTXOBinding(
 			extras.Ancestry, pkScript,
 		); err != nil {
-			return vtxo.IncomingVTXOExtras{}, fmt.Errorf(
-				"bind received vtxo to commitment: %w", err)
+			return vtxo.IncomingVTXOExtras{}, fmt.Errorf("bind "+
+				"received vtxo to commitment: %w", err)
 		}
 
 		return extras, nil

--- a/waved/incoming_metadata.go
+++ b/waved/incoming_metadata.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/batchcanon"
 	"github.com/lightninglabs/wavelength/build"
 	"github.com/lightninglabs/wavelength/indexer"
 	"github.com/lightninglabs/wavelength/internal/indexerlimits"
@@ -257,6 +258,14 @@ func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (oor.IncomingVTXOMetadata,
 			"ancestry paths: %w", err)
 	}
 
+	evidence, err := batchcanon.EvidenceFromAncestryPaths(
+		candidate.GetAncestryPaths(),
+	)
+	if err != nil {
+		return oor.IncomingVTXOMetadata{}, fmt.Errorf("convert batch "+
+			"evidence: %w", err)
+	}
+
 	var commitmentTxID chainhash.Hash
 	copy(commitmentTxID[:], candidate.GetCommitmentTxid())
 
@@ -267,5 +276,6 @@ func incomingMetadataFromRPC(candidate *arkrpc.VTXO) (oor.IncomingVTXOMetadata,
 		ChainDepth:     int(candidate.GetChainDepth()),
 		CreatedHeight:  candidate.GetCreatedHeight(),
 		Ancestry:       ancestry,
+		BatchEvidence:  evidence,
 	}, nil
 }

--- a/waved/rpc_balance_test.go
+++ b/waved/rpc_balance_test.go
@@ -8,11 +8,204 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/batchcanon"
 	"github.com/lightninglabs/wavelength/db"
 	"github.com/lightninglabs/wavelength/lib/actormsg"
 	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
 )
+
+// balanceCanonReader is a focused canonicality reader for balance tests.
+type balanceCanonReader struct {
+	records map[chainhash.Hash]*batchcanon.Record
+	err     error
+}
+
+// GetBatch returns the seeded record or canonical not-found result.
+func (r *balanceCanonReader) GetBatch(_ context.Context, txid chainhash.Hash) (
+	*batchcanon.Record, error) {
+
+	if r.err != nil {
+		return nil, r.err
+	}
+	record, ok := r.records[txid]
+	if !ok {
+		return nil, batchcanon.ErrBatchNotFound
+	}
+
+	return record, nil
+}
+
+// readyBalanceRecord builds the minimum ready record required by an
+// availability query. Its immutable transaction bytes are irrelevant to this
+// read-only test; registration validation covers their bindings separately.
+func readyBalanceRecord(txid chainhash.Hash,
+	state batchcanon.State) *batchcanon.Record {
+
+	return &batchcanon.Record{
+		BatchTxID: txid,
+		BatchTx: []byte{
+			1,
+		},
+		RegistrationStage:     batchcanon.RegistrationComplete,
+		ObservationGeneration: 1,
+		ReadyGeneration:       fn.Some(uint64(1)),
+		State:                 state,
+		ConfirmationPkScript: []byte{
+			1,
+		},
+		ConsumedInputs: []batchcanon.ConsumedInput{{
+			PkScript: []byte{
+				1,
+			},
+		}},
+	}
+}
+
+// balanceDescriptor builds a lifecycle-live VTXO under one batch.
+func balanceDescriptor(i byte, amount btcutil.Amount,
+	batch chainhash.Hash) *vtxo.Descriptor {
+
+	return &vtxo.Descriptor{
+		Outpoint: wire.OutPoint{
+			Hash:  chainhash.HashH([]byte{i}),
+			Index: uint32(i),
+		},
+		Amount:         amount,
+		CommitmentTxID: batch,
+		Status:         vtxo.VTXOStatusLive,
+	}
+}
+
+// TestCanonicalityAwareVTXOBalance verifies the user-visible balance excludes
+// unusable lineage while preserving reversible value in the temporary bucket.
+func TestCanonicalityAwareVTXOBalance(t *testing.T) {
+	t.Parallel()
+
+	batch := func(label string) chainhash.Hash {
+		return chainhash.HashH([]byte(label))
+	}
+	finalBatch := batch("final")
+	provisionalBatch := batch("provisional")
+	reorgBatch := batch("reorg")
+	conflictBatch := batch("conflict")
+	unseenBatch := batch("unseen")
+	reconcilingBatch := batch("reconciling")
+	invalidBatch := batch("invalid")
+
+	reader := &balanceCanonReader{
+		records: map[chainhash.Hash]*batchcanon.Record{
+			finalBatch: readyBalanceRecord(
+				finalBatch, batchcanon.StateFinalized,
+			),
+			provisionalBatch: readyBalanceRecord(
+				provisionalBatch, batchcanon.StateProvisional,
+			),
+			reorgBatch: readyBalanceRecord(
+				reorgBatch, batchcanon.StateReorgedOut,
+			),
+			conflictBatch: readyBalanceRecord(
+				conflictBatch,
+				batchcanon.StateConflictProvisional,
+			),
+			unseenBatch: readyBalanceRecord(
+				unseenBatch, batchcanon.StateUnseen,
+			),
+			reconcilingBatch: {
+				BatchTxID: reconcilingBatch,
+			},
+			invalidBatch: readyBalanceRecord(
+				invalidBatch, batchcanon.StateConflictFinalized,
+			),
+		},
+	}
+
+	descs := []*vtxo.Descriptor{
+		balanceDescriptor(1, 10_000, finalBatch),
+		balanceDescriptor(2, 20_000, provisionalBatch),
+		balanceDescriptor(3, 30_000, reorgBatch),
+		balanceDescriptor(4, 40_000, conflictBatch),
+		balanceDescriptor(5, 50_000, unseenBatch),
+		balanceDescriptor(6, 60_000, reconcilingBatch),
+		balanceDescriptor(7, 70_000, invalidBatch),
+	}
+
+	spendable, unavailable, err := vtxo.ClassifyCanonicalityBalance(
+		t.Context(), descs, reader,
+	)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(30_000), spendable)
+	require.Equal(t, btcutil.Amount(180_000), unavailable)
+}
+
+// TestCanonicalityAwareVTXOBalanceUsesWorstParent verifies that any unusable
+// parent moves the full multi-parent VTXO into the temporary bucket.
+func TestCanonicalityAwareVTXOBalanceUsesWorstParent(t *testing.T) {
+	t.Parallel()
+
+	finalBatch := chainhash.HashH([]byte("final"))
+	reorgBatch := chainhash.HashH([]byte("reorg"))
+	reader := &balanceCanonReader{
+		records: map[chainhash.Hash]*batchcanon.Record{
+			finalBatch: readyBalanceRecord(
+				finalBatch, batchcanon.StateFinalized,
+			),
+			reorgBatch: readyBalanceRecord(
+				reorgBatch, batchcanon.StateReorgedOut,
+			),
+		},
+	}
+	desc := balanceDescriptor(1, 25_000, finalBatch)
+	desc.Ancestry = []vtxo.Ancestry{{
+		CommitmentTxID: reorgBatch,
+	}}
+
+	spendable, unavailable, err := vtxo.ClassifyCanonicalityBalance(
+		t.Context(), []*vtxo.Descriptor{desc}, reader,
+	)
+	require.NoError(t, err)
+	require.Zero(t, spendable)
+	require.Equal(t, btcutil.Amount(25_000), unavailable)
+}
+
+// TestCanonicalityAwareVTXOBalanceLegacy preserves the behavior-neutral path
+// used while the canonicality gate is disabled.
+func TestCanonicalityAwareVTXOBalanceLegacy(t *testing.T) {
+	t.Parallel()
+
+	desc := balanceDescriptor(
+		1, 25_000,
+		chainhash.HashH(
+			[]byte("batch"),
+		),
+	)
+	spendable, unavailable, err := vtxo.ClassifyCanonicalityBalance(
+		t.Context(), []*vtxo.Descriptor{desc}, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(25_000), spendable)
+	require.Zero(t, unavailable)
+}
+
+// TestCanonicalityAwareVTXOBalancePropagatesReaderError ensures a broken
+// authority cannot be presented to the user as a zero or spendable balance.
+func TestCanonicalityAwareVTXOBalancePropagatesReaderError(t *testing.T) {
+	t.Parallel()
+
+	desc := balanceDescriptor(
+		1, 25_000,
+		chainhash.HashH(
+			[]byte("batch"),
+		),
+	)
+	_, _, err := vtxo.ClassifyCanonicalityBalance(
+		t.Context(), []*vtxo.Descriptor{desc}, &balanceCanonReader{
+			err: errors.New("reader unavailable"),
+		},
+	)
+	require.ErrorContains(t, err, "reader unavailable")
+}
 
 // fakeExitJobLookup is an in-memory exitJobLookup. A missing outpoint returns
 // db.ErrUnilateralExitJobNotFound, mirroring the real store.

--- a/waved/rpc_oor_custom_input_test.go
+++ b/waved/rpc_oor_custom_input_test.go
@@ -13,12 +13,15 @@ import (
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
+	"github.com/lightninglabs/wavelength/batchcanon"
 	"github.com/lightninglabs/wavelength/chainsource"
 	"github.com/lightninglabs/wavelength/db"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
 	"github.com/lightninglabs/wavelength/oor"
+	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/mock"
@@ -34,6 +37,44 @@ type customOORRPCFixture struct {
 	claimPath  *arkscript.SpendPath
 	clientPriv *btcec.PrivateKey
 	outpoint   wire.OutPoint
+}
+
+type customInputCanonReader struct {
+	records map[chainhash.Hash]*batchcanon.Record
+}
+
+func (r *customInputCanonReader) GetBatch(_ context.Context,
+	txid chainhash.Hash) (*batchcanon.Record, error) {
+
+	record, ok := r.records[txid]
+	if !ok {
+		return nil, batchcanon.ErrBatchNotFound
+	}
+
+	return record, nil
+}
+
+func readyCustomInputBatch(txid chainhash.Hash,
+	state batchcanon.State) *batchcanon.Record {
+
+	return &batchcanon.Record{
+		BatchTxID: txid,
+		BatchTx: []byte{
+			1,
+		},
+		RegistrationStage:     batchcanon.RegistrationComplete,
+		ObservationGeneration: 1,
+		ReadyGeneration:       fn.Some(uint64(1)),
+		State:                 state,
+		ConfirmationPkScript: []byte{
+			1,
+		},
+		ConsumedInputs: []batchcanon.ConsumedInput{{
+			PkScript: []byte{
+				1,
+			},
+		}},
+	}
 }
 
 func newCustomOORRPCFixture(t *testing.T) *customOORRPCFixture {
@@ -200,6 +241,84 @@ func TestRequireCustomSpendsMature(t *testing.T) {
 				t, status.Convert(err).Message(),
 				test.wantContains,
 			)
+		})
+	}
+}
+
+// TestRequireCustomInputLineage proves explicit OOR inputs cannot bypass the
+// fail-closed batch gate used by wallet-selected inputs.
+func TestRequireCustomInputLineage(t *testing.T) {
+	t.Parallel()
+
+	txid := chainhash.Hash{1}
+	desc := &vtxo.Descriptor{
+		Outpoint: wire.OutPoint{
+			Hash: chainhash.Hash{
+				2,
+			},
+		},
+		CommitmentTxID: txid,
+	}
+	input := []oor.TransferInput{{VTXO: desc}}
+
+	tests := []struct {
+		name     string
+		record   *batchcanon.Record
+		wantCode codes.Code
+	}{
+		{
+			name: "provisional",
+			record: readyCustomInputBatch(
+				txid, batchcanon.StateProvisional,
+			),
+			wantCode: codes.OK,
+		},
+		{
+			name: "reorged",
+			record: readyCustomInputBatch(
+				txid, batchcanon.StateReorgedOut,
+			),
+			wantCode: codes.Unavailable,
+		},
+		{
+			name: "invalidated",
+			record: readyCustomInputBatch(
+				txid, batchcanon.StateConflictFinalized,
+			),
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name:     "missing",
+			wantCode: codes.Unavailable,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			records := make(map[chainhash.Hash]*batchcanon.Record)
+			if test.record != nil {
+				records[txid] = test.record
+			}
+
+			rpcServer := &RPCServer{server: &Server{
+				batchCanonStore: &customInputCanonReader{
+					records: records,
+				},
+			}}
+			err := rpcServer.requireCustomInputLineage(
+				t.Context(), input,
+			)
+
+			if test.wantCode == codes.OK {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Equal(t, test.wantCode, status.Code(err))
 		})
 	}
 }

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/batchcanon"
 	"github.com/lightninglabs/wavelength/btcwbackend"
 	"github.com/lightninglabs/wavelength/build"
 	"github.com/lightninglabs/wavelength/db"
@@ -318,6 +319,48 @@ func classifyCustomOORInputs(inputs []*waverpc.CustomOORInput) ([]wire.OutPoint,
 	}
 
 	return outpoints, hasManaged, nil
+}
+
+// requireCustomInputLineage applies the same fail-closed lineage gate used by
+// wallet coin selection to caller-supplied OOR inputs. Custom inputs bypass the
+// VTXO manager's selector, so without this check a reorged-out VTXO could still
+// reach checkpoint signing through the explicit-input path.
+func (r *RPCServer) requireCustomInputLineage(ctx context.Context,
+	inputs []oor.TransferInput) error {
+
+	if r.server == nil || r.server.batchCanonStore == nil {
+		return nil
+	}
+
+	for i := range inputs {
+		desc := inputs[i].VTXO
+		if desc == nil {
+			return status.Errorf(codes.Internal, "custom input %d "+
+				"has no VTXO descriptor", i)
+		}
+
+		blocked, availability, err := batchcanon.LineageBlocked(
+			ctx, r.server.batchCanonStore,
+			vtxo.LineageCommitmentTxIDs(desc)...,
+		)
+		if err != nil {
+			return status.Errorf(codes.Internal, "query custom "+
+				"input %s lineage: %v", desc.Outpoint, err)
+		}
+		if !blocked {
+			continue
+		}
+
+		code := codes.Unavailable
+		if availability == batchcanon.Invalidated {
+			code = codes.FailedPrecondition
+		}
+
+		return status.Errorf(code, "custom input %s lineage is %s",
+			desc.Outpoint, availability)
+	}
+
+	return nil
 }
 
 type oorChangeRecipientBuilder func(context.Context,
@@ -3225,13 +3268,12 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		// actor future actually completes.
 		release, err := r.reserveCustomInputs(customOutpoints)
 		if err != nil {
-			return nil, status.Errorf(codes.Aborted, "custom "+
-				"input double-use: %v", err)
+			return nil, err
 		}
 		customInputsRelease = release
 		releaseCustomInputs = true
 		defer func() {
-			if releaseCustomInputs && customInputsRelease != nil {
+			if releaseCustomInputs {
 				customInputsRelease()
 			}
 		}()
@@ -3247,6 +3289,11 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "build "+
 				"custom inputs: %v", err)
+		}
+		if err := r.requireCustomInputLineage(
+			ctx, selectedInputs,
+		); err != nil {
+			return nil, err
 		}
 		err = r.requireCustomSpendsMature(ctx, selectedInputs)
 		if err != nil {

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -3255,6 +3255,12 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		releaseCustomInputs bool
 	)
 
+	// The custom-input path threads reservation, build, fail-closed lineage
+	// gating and maturity checks that must stay in this branch; the
+	// emergent nesting after the canonicality gate landed is inherent to
+	// the ordered validation, not accidental structure.
+	//
+	//nolint:nestif
 	if len(req.CustomInputs) > 0 && !exactManagedInputs {
 		phaseStart = time.Now()
 		// Explicit custom inputs bypass wallet selection and build

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -861,7 +861,15 @@ func (r *RPCServer) GetBalance(ctx context.Context,
 			return nil, status.Errorf(codes.Internal, "fetch vtxo "+
 				"balance: %v", err)
 		}
-		resp.VtxoBalanceSat = int64(vtxo.SumSpendableBalance(liveVTXOs))
+		spendable, unavailable, err := vtxo.ClassifyCanonicalityBalance(
+			ctx, liveVTXOs, r.server.batchCanonStore,
+		)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "classify "+
+				"vtxo canonicality: %v", err)
+		}
+		resp.VtxoBalanceSat = int64(spendable)
+		resp.VtxoTemporarilyUnavailableSat = int64(unavailable)
 		resp.VtxoPendingSat = int64(vtxo.SumPendingBalance(liveVTXOs))
 
 		// Exiting VTXOs aren't in ListLiveVTXOs; query them directly.

--- a/waved/server.go
+++ b/waved/server.go
@@ -427,7 +427,9 @@ type Server struct {
 	// are born so each lineage batch gets reorg-aware conf/spend watches
 	// (producer registration lands in a follow-up). None until
 	// initBatchCanonicality registers the manager.
-	batchCanonRef fn.Option[actor.TellOnlyRef[batchcanon.ManagerMsg]]
+	batchCanonRef fn.Option[actor.ActorRef[
+		batchcanon.ManagerMsg, batchcanon.ManagerResp,
+	]]
 
 	serverConn        *grpc.ClientConn
 	arkClient         arkrpc.ArkServiceClient
@@ -4350,8 +4352,22 @@ func (s *Server) initRoundActor(ctx context.Context,
 		SigningExecutor: round.NewSigningExecutor(
 			signingWorkers,
 		),
-		RoundStore:     roundStore,
-		VTXOStore:      roundStore,
+		RoundStore: roundStore,
+		VTXOStore:  roundStore,
+		BatchRegistrar: fn.MapOptionZ(
+			s.batchCanonRef,
+			func(
+				ref actor.ActorRef[
+					batchcanon.ManagerMsg,
+					batchcanon.ManagerResp,
+				],
+			) round.RoundBatchRegistrar {
+
+				return &roundBatchRegistrar{
+					ref: ref,
+				}
+			},
+		),
 		OperatorTerms:  operatorTerms,
 		ServerConn:     s.runtime.TellRef(),
 		ChainSource:    chainSourceRef,
@@ -4484,7 +4500,9 @@ func (s *Server) initBatchCanonicality(ctx context.Context,
 			err)
 	}
 
-	s.batchCanonRef = fn.Some[actor.TellOnlyRef[batchcanon.ManagerMsg]](
+	s.batchCanonRef = fn.Some[actor.ActorRef[
+		batchcanon.ManagerMsg, batchcanon.ManagerResp,
+	]](
 		mgrRef,
 	)
 

--- a/waved/server.go
+++ b/waved/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
@@ -4589,14 +4590,31 @@ func (s *Server) initVTXOManager(ctx context.Context,
 	ledgerSink := ledger.NewSink(s.actorSystem)
 
 	manager := vtxo.NewManager(&vtxo.ManagerConfig{
-		Store:                    vtxoStore,
-		ReservationStore:         reservationStore,
-		Wallet:                   vtxoWallet,
-		ChainSource:              chainSourceRef,
-		ActorSystem:              s.actorSystem,
-		ChainParams:              s.chainParams,
-		ExpiryConfig:             s.vtxoExpiryConfig(),
-		BatchCanonicality:        s.batchCanonStore,
+		Store:             vtxoStore,
+		ReservationStore:  reservationStore,
+		Wallet:            vtxoWallet,
+		ChainSource:       chainSourceRef,
+		ActorSystem:       s.actorSystem,
+		ChainParams:       s.chainParams,
+		ExpiryConfig:      s.vtxoExpiryConfig(),
+		BatchCanonicality: s.batchCanonStore,
+		RedriveConsumerForfeit: func(ctx context.Context,
+			consumerBatch chainhash.Hash) error {
+
+			// After a forfeiture marker is persisted, ask the batch
+			// canonicality manager to re-resolve any terminal
+			// consumer edge that deferred because it ran before the
+			// marker existed. No-op when canonicality is disabled.
+			if s.batchCanonRef.IsNone() {
+				return nil
+			}
+
+			return s.batchCanonRef.UnsafeFromSome().Tell(
+				ctx, &batchcanon.ConsumerForfeitPersistedMsg{
+					ConsumerBatch: consumerBatch,
+				},
+			)
+		},
 		Log:                      fn.Some(s.subLogger(vtxo.Subsystem)),
 		RoundActor:               roundActor,
 		LedgerSink:               fn.Some(ledgerSink),

--- a/waved/server.go
+++ b/waved/server.go
@@ -4781,12 +4781,13 @@ func (s *Server) initOORActor(ctx context.Context,
 	// delegate of the local-persistence handler for retry scheduling.
 
 	outboxHandler := &oor.LocalPersistenceOutboxHandler{
-		Next:           signingHandler,
-		Store:          vtxoStore,
-		BatchRegistrar: incomingBatchRegistrar,
-		PackageStore:   packageStore,
-		OperatorKey:    operatorTerms.PubKey,
-		ExitDelay:      operatorTerms.VTXOExitDelay,
+		Next:                    signingHandler,
+		Store:                   vtxoStore,
+		BatchRegistrar:          incomingBatchRegistrar,
+		IncomingLineageVerifier: vtxo.VerifyOORAncestryLineage,
+		PackageStore:            packageStore,
+		OperatorKey:             operatorTerms.PubKey,
+		ExitDelay:               operatorTerms.VTXOExitDelay,
 		NotifyIncomingVTXOs: func(ctx context.Context,
 			descs []*vtxo.Descriptor) error {
 
@@ -4840,20 +4841,22 @@ func (s *Server) initOORActor(ctx context.Context,
 	s.oorSessionStore = registryStore
 
 	s.oorRegistry, err = oor.NewOORRegistryActor(oor.OORRegistryConfig{
-		Log:              fn.Some(s.subLogger(oor.Subsystem)),
-		Signer:           oorSigner,
-		IncomingHandler:  outboxHandler,
-		BatchRegistrar:   incomingBatchRegistrar,
-		RegistryStore:    registryStore,
-		DeliveryStore:    s.deliveryStore,
-		ServerConn:       s.runtime.TellRef(),
-		VTXOManager:      vtxoManagerRef,
-		SpendCompleter:   s.oorCompleteSpend,
-		SpendReleaser:    s.oorReleaseSpend,
-		ReservationStore: reservationStore,
-		PackageStore:     packageStore,
-		VTXOStore:        vtxoStore,
-		LedgerSink:       fn.Some(ledger.NewSink(s.actorSystem)),
+		Log:             fn.Some(s.subLogger(oor.Subsystem)),
+		Signer:          oorSigner,
+		IncomingHandler: outboxHandler,
+		BatchRegistrar:  incomingBatchRegistrar,
+
+		IncomingLineageVerifier: vtxo.VerifyOORAncestryLineage,
+		RegistryStore:           registryStore,
+		DeliveryStore:           s.deliveryStore,
+		ServerConn:              s.runtime.TellRef(),
+		VTXOManager:             vtxoManagerRef,
+		SpendCompleter:          s.oorCompleteSpend,
+		SpendReleaser:           s.oorReleaseSpend,
+		ReservationStore:        reservationStore,
+		PackageStore:            packageStore,
+		VTXOStore:               vtxoStore,
+		LedgerSink:              fn.Some(ledger.NewSink(s.actorSystem)),
 		IncomingVTXOObserver: func(ctx context.Context,
 			descs []*vtxo.Descriptor) error {
 

--- a/waved/server.go
+++ b/waved/server.go
@@ -4902,6 +4902,7 @@ func (s *Server) initOORActor(ctx context.Context,
 			VTXOStore:       incomingVTXOStore,
 			VTXOManager:     vtxoManagerRef,
 			AncestryFetcher: ancestryFetcher,
+			BatchRegistrar:  incomingBatchRegistrar,
 			MetricsSink:     s.metricsSink,
 		},
 	)

--- a/waved/server.go
+++ b/waved/server.go
@@ -420,7 +420,7 @@ type Server struct {
 	// VTXO coin-selection reorg-safety gate (lumos#454). It is threaded
 	// into the VTXO manager only when Config.BatchCanonicalityGate is set;
 	// a nil store leaves the gate dormant. Read lazily at admission time.
-	batchCanonStore batchcanon.Store
+	batchCanonStore batchcanon.Reader
 
 	// batchCanonRef is the BatchCanonicalityManager actor ref. The round
 	// and OOR producers will Tell it a RegisterBatchRequest as their VTXOs

--- a/waved/server.go
+++ b/waved/server.go
@@ -4509,8 +4509,14 @@ func (s *Server) initBatchCanonicality(ctx context.Context,
 	// Only activate the VTXO admission gate when explicitly enabled. The
 	// gate is fail-closed, so threading the store before producers register
 	// their batches would strand all liquidity (see the config field doc).
+	//
+	// Thread the manager (not the raw durable store) so admission reads go
+	// through its in-memory overlay: a reorg/conflict observation whose
+	// durable write failed still closes admission immediately, instead of
+	// leaving the stale durable row admissible until a restart (see
+	// Manager.GetBatch).
 	if s.cfg.BatchCanonicalityGate {
-		s.batchCanonStore = canonStore
+		s.batchCanonStore = mgr
 	}
 
 	s.log.InfoS(ctx, "Batch canonicality manager registered and started",

--- a/waved/server.go
+++ b/waved/server.go
@@ -4363,7 +4363,7 @@ func (s *Server) initRoundActor(ctx context.Context,
 				],
 			) round.RoundBatchRegistrar {
 
-				return &roundBatchRegistrar{
+				return &batchRegistrar{
 					ref: ref,
 				}
 			},
@@ -4744,17 +4744,25 @@ func (s *Server) initOORActor(ctx context.Context,
 		TimeoutActor: oorTimeoutRef,
 	}
 	oorKey := oor.NewServiceKey()
+	var incomingBatchRegistrar oor.BatchRegistrar
+	s.batchCanonRef.WhenSome(func(ref actor.ActorRef[
+		batchcanon.ManagerMsg, batchcanon.ManagerResp,
+	]) {
+
+		incomingBatchRegistrar = &batchRegistrar{ref: ref}
+	})
 
 	// The per-session OOR actors handle wallet signing inline, so there is
 	// no separate signing-effect actor. signingHandler remains the Next
 	// delegate of the local-persistence handler for retry scheduling.
 
 	outboxHandler := &oor.LocalPersistenceOutboxHandler{
-		Next:         signingHandler,
-		Store:        vtxoStore,
-		PackageStore: packageStore,
-		OperatorKey:  operatorTerms.PubKey,
-		ExitDelay:    operatorTerms.VTXOExitDelay,
+		Next:           signingHandler,
+		Store:          vtxoStore,
+		BatchRegistrar: incomingBatchRegistrar,
+		PackageStore:   packageStore,
+		OperatorKey:    operatorTerms.PubKey,
+		ExitDelay:      operatorTerms.VTXOExitDelay,
 		NotifyIncomingVTXOs: func(ctx context.Context,
 			descs []*vtxo.Descriptor) error {
 
@@ -4811,6 +4819,7 @@ func (s *Server) initOORActor(ctx context.Context,
 		Log:              fn.Some(s.subLogger(oor.Subsystem)),
 		Signer:           oorSigner,
 		IncomingHandler:  outboxHandler,
+		BatchRegistrar:   incomingBatchRegistrar,
 		RegistryStore:    registryStore,
 		DeliveryStore:    s.deliveryStore,
 		ServerConn:       s.runtime.TellRef(),

--- a/waved/wallet_recovery.go
+++ b/waved/wallet_recovery.go
@@ -639,7 +639,13 @@ func (r *RPCServer) recoveryOORHandler(
 		Store:        r.server.vtxoStore,
 		PackageStore: packageStore,
 		OperatorKey:  terms.PubKey,
-		ExitDelay:    terms.VTXOExitDelay,
+
+		// No BatchRegistrar is wired here, so no reorg watch is armed on
+		// this path today; wire the lineage verifier defensively anyway
+		// so that if a registrar is ever added the F-H1 bind cannot be
+		// silently bypassed (fail-open).
+		IncomingLineageVerifier: vtxo.VerifyOORAncestryLineage,
+		ExitDelay:               terms.VTXOExitDelay,
 		NotifyIncomingVTXOs: func(ctx context.Context,
 			descs []*vtxo.Descriptor) error {
 

--- a/waved/wallet_recovery.go
+++ b/waved/wallet_recovery.go
@@ -640,10 +640,10 @@ func (r *RPCServer) recoveryOORHandler(
 		PackageStore: packageStore,
 		OperatorKey:  terms.PubKey,
 
-		// No BatchRegistrar is wired here, so no reorg watch is armed on
-		// this path today; wire the lineage verifier defensively anyway
-		// so that if a registrar is ever added the F-H1 bind cannot be
-		// silently bypassed (fail-open).
+		// No BatchRegistrar is wired here, so no reorg watch is armed
+		// on this path today; wire the lineage verifier defensively
+		// anyway so that if a registrar is ever added the F-H1 bind
+		// cannot be silently bypassed (fail-open).
 		IncomingLineageVerifier: vtxo.VerifyOORAncestryLineage,
 		ExitDelay:               terms.VTXOExitDelay,
 		NotifyIncomingVTXOs: func(ctx context.Context,

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -1674,9 +1674,10 @@ type GetBalanceResponse struct {
 	VtxoUnilateralExitSat int64 `protobuf:"varint,10,opt,name=vtxo_unilateral_exit_sat,json=vtxoUnilateralExitSat,proto3" json:"vtxo_unilateral_exit_sat,omitempty"`
 	// vtxo_temporarily_unavailable_sat is the value of lifecycle-live
 	// VTXOs whose canonicality lineage is currently unusable but not
-	// terminally invalidated. This includes reorg/conflict limbo and
-	// lineage reconciliation. It is excluded from vtxo_balance_sat and
-	// total_confirmed_sat and returns there if the lineage recovers.
+	// terminally invalidated. This includes unseen or unregistered lineage,
+	// reorg/conflict limbo, and lineage reconciliation. It is excluded from
+	// vtxo_balance_sat and total_confirmed_sat and returns there if the
+	// lineage recovers.
 	VtxoTemporarilyUnavailableSat int64 `protobuf:"varint,11,opt,name=vtxo_temporarily_unavailable_sat,json=vtxoTemporarilyUnavailableSat,proto3" json:"vtxo_temporarily_unavailable_sat,omitempty"`
 	unknownFields                 protoimpl.UnknownFields
 	sizeCache                     protoimpl.SizeCache

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -1672,8 +1672,14 @@ type GetBalanceResponse struct {
 	// total_confirmed_sat; reappears under onchain_wallet_confirmed_sat
 	// once the sweep confirms.
 	VtxoUnilateralExitSat int64 `protobuf:"varint,10,opt,name=vtxo_unilateral_exit_sat,json=vtxoUnilateralExitSat,proto3" json:"vtxo_unilateral_exit_sat,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// vtxo_temporarily_unavailable_sat is the value of lifecycle-live
+	// VTXOs whose canonicality lineage is currently unusable but not
+	// terminally invalidated. This includes reorg/conflict limbo and
+	// lineage reconciliation. It is excluded from vtxo_balance_sat and
+	// total_confirmed_sat and returns there if the lineage recovers.
+	VtxoTemporarilyUnavailableSat int64 `protobuf:"varint,11,opt,name=vtxo_temporarily_unavailable_sat,json=vtxoTemporarilyUnavailableSat,proto3" json:"vtxo_temporarily_unavailable_sat,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
 }
 
 func (x *GetBalanceResponse) Reset() {
@@ -1772,6 +1778,13 @@ func (x *GetBalanceResponse) GetVtxoPendingSat() int64 {
 func (x *GetBalanceResponse) GetVtxoUnilateralExitSat() int64 {
 	if x != nil {
 		return x.VtxoUnilateralExitSat
+	}
+	return 0
+}
+
+func (x *GetBalanceResponse) GetVtxoTemporarilyUnavailableSat() int64 {
+	if x != nil {
+		return x.VtxoTemporarilyUnavailableSat
 	}
 	return 0
 }
@@ -10473,7 +10486,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0fwallet_password\x18\x01 \x01(\fR\x0ewalletPassword\"?\n" +
 	"\x14UnlockWalletResponse\x12'\n" +
 	"\x0fidentity_pubkey\x18\x01 \x01(\tR\x0eidentityPubkey\"\x13\n" +
-	"\x11GetBalanceRequest\"\x9f\x04\n" +
+	"\x11GetBalanceRequest\"\xe8\x04\n" +
 	"\x12GetBalanceResponse\x124\n" +
 	"\x16boarding_confirmed_sat\x18\x01 \x01(\x03R\x14boardingConfirmedSat\x128\n" +
 	"\x18boarding_unconfirmed_sat\x18\x02 \x01(\x03R\x16boardingUnconfirmedSat\x12(\n" +
@@ -10485,7 +10498,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\x14boarding_adopted_sat\x18\b \x01(\x03R\x12boardingAdoptedSat\x12(\n" +
 	"\x10vtxo_pending_sat\x18\t \x01(\x03R\x0evtxoPendingSat\x127\n" +
 	"\x18vtxo_unilateral_exit_sat\x18\n" +
-	" \x01(\x03R\x15vtxoUnilateralExitSat\"\x9e\x03\n" +
+	" \x01(\x03R\x15vtxoUnilateralExitSat\x12G\n" +
+	" vtxo_temporarily_unavailable_sat\x18\v \x01(\x03R\x1dvtxoTemporarilyUnavailableSat\"\x9e\x03\n" +
 	"\x0eVTXOExpiryInfo\x121\n" +
 	"\x06status\x18\x01 \x01(\x0e2\x19.waverpc.VTXOExpiryStatusR\x06status\x12%\n" +
 	"\x0ecurrent_height\x18\x02 \x01(\x05R\rcurrentHeight\x12!\n" +

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -569,9 +569,10 @@ message GetBalanceResponse {
 
     // vtxo_temporarily_unavailable_sat is the value of lifecycle-live
     // VTXOs whose canonicality lineage is currently unusable but not
-    // terminally invalidated. This includes reorg/conflict limbo and
-    // lineage reconciliation. It is excluded from vtxo_balance_sat and
-    // total_confirmed_sat and returns there if the lineage recovers.
+    // terminally invalidated. This includes unseen or unregistered lineage,
+    // reorg/conflict limbo, and lineage reconciliation. It is excluded from
+    // vtxo_balance_sat and total_confirmed_sat and returns there if the
+    // lineage recovers.
     int64 vtxo_temporarily_unavailable_sat = 11;
 }
 

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -566,6 +566,13 @@ message GetBalanceResponse {
     // total_confirmed_sat; reappears under onchain_wallet_confirmed_sat
     // once the sweep confirms.
     int64 vtxo_unilateral_exit_sat = 10;
+
+    // vtxo_temporarily_unavailable_sat is the value of lifecycle-live
+    // VTXOs whose canonicality lineage is currently unusable but not
+    // terminally invalidated. This includes reorg/conflict limbo and
+    // lineage reconciliation. It is excluded from vtxo_balance_sat and
+    // total_confirmed_sat and returns there if the lineage recovers.
+    int64 vtxo_temporarily_unavailable_sat = 11;
 }
 
 // VTXOStatus represents the lifecycle state of a virtual transaction


### PR DESCRIPTION
## What this PR does

Connects the real VTXO creation and receipt paths to the `batchcanon` authority
introduced by #980. Without this PR the authority exists but production paths do
not consistently feed it.

It handles three production sources:

1. Locally received round VTXOs.
2. OOR-received VTXOs.
3. Explicit custom VTXOs supplied as OOR inputs.

The indexer ancestry response supplies the serialized commitment transaction,
ordered commitment prevouts, CSV-delay evidence, and the parent lineage required
to validate a received VTXO. The recipient treats that response as **untrusted**
and authenticates: the commitment txid, the referenced output, every commitment
input, the input prevouts and their ordering, and the relationship between the
received VTXO and the supplied batch.

Registration happens **before** the VTXO is saved or exposed:

```mermaid
sequenceDiagram
    participant R as OOR receiver
    participant I as Indexer
    participant B as batchcanon
    participant V as VTXO store

    R->>I: Request ancestry
    I-->>R: Commitment, prevouts, and lineage
    R->>R: Authenticate evidence
    R->>B: Register complete lineage
    B-->>R: Registration durable
    R->>V: Materialize and save VTXO
```

Once registered, the client responds to later reorgs using its local chain
watches; it does not requery the indexer.

Wallet reporting uses the same authority: a lifecycle-live VTXO whose lineage is
reorged, conflicted, unseen, or still reconciling is excluded from spendable
balance and included in `temporarily_unavailable_sat`. Terminally invalidated
value is excluded from both buckets.

## Review focus

- Treat the indexer response as an untrusted input — are all bindings checked?
- Are every TxIn and ordered prevout included and authenticated?
- Is registration durably complete before exposure?
- Are retries idempotent across every crash boundary?
- Does legacy or incomplete evidence fail closed?

---
_Full design & diagrams: `REORG_SAFETY_PR_REVIEW_GUIDE.md` §4.3. Overall
architecture and PR stack: [lumos#454](https://github.com/lightninglabs/lumos/issues/454)._
