### PR TITLE
sdk/swaps+swapwallet: reject credit-bound in-ark events, label credit top-ups

### DIFF
--- a/credit/messages.go
+++ b/credit/messages.go
@@ -336,6 +336,16 @@ type CreditOpSummary struct {
 	// WalletEntry transition. Always false for receive and redeem ops.
 	CreditOnly bool
 
+	// OORSessionID is the delegated Ark top-up OOR session id, when the
+	// operation funded credit through an OOR transfer. It lets the wallet
+	// activity view correlate the raw ledger row of the top-up transfer
+	// back to the credit operation it funded.
+	OORSessionID string
+
+	// TopupSat is the Ark top-up amount the operation funded to cover a
+	// pay shortfall, when known.
+	TopupSat int64
+
 	// LastError is the terminal failure reason, when failed.
 	LastError string
 }

--- a/credit/registry.go
+++ b/credit/registry.go
@@ -555,14 +555,16 @@ func (b *registryBehavior) handleList(ctx context.Context,
 		}
 
 		resp.Ops = append(resp.Ops, CreditOpSummary{
-			OpID:       rec.OpID,
-			OpKey:      rec.OpKey,
-			Kind:       rec.Kind,
-			State:      State(rec.State),
-			Pending:    !rec.Status.IsTerminal(),
-			AmountSat:  rec.AmountSat,
-			CreditOnly: creditOnly,
-			LastError:  rec.LastError,
+			OpID:         rec.OpID,
+			OpKey:        rec.OpKey,
+			Kind:         rec.Kind,
+			State:        State(rec.State),
+			Pending:      !rec.Status.IsTerminal(),
+			AmountSat:    rec.AmountSat,
+			CreditOnly:   creditOnly,
+			OORSessionID: rec.OORSessionID,
+			TopupSat:     rec.TopupSat,
+			LastError:    rec.LastError,
 		})
 	}
 

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -1208,6 +1208,40 @@ func (s *ReceiveSession) acceptInArkHtlcEvent(ctx context.Context,
 			nil,
 		)
 	}
+
+	// A session whose route quote attached credit (or padded the vHTLC
+	// above the invoice amount) cannot settle through the direct p2p
+	// vHTLC: the sender funds the receiver's script directly, so no
+	// output exists that could carry the server's custodial credit
+	// top-up. Accepting such an event would commit this session to the
+	// in-ark rail (which skips the out-swap ACK) and leave it polling a
+	// vHTLC that can never be funded, so fail fast instead.
+	if s.attachedCreditSat > 0 {
+		return s.failTerminal(
+			ctx, fmt.Sprintf("in-ark HTLC event conflicts with "+
+				"credit-attach receive plan: attached credit "+
+				"%d sat requires server-mediated settlement",
+				s.attachedCreditSat),
+			nil,
+			nil,
+		)
+	}
+	// Note that expectedVHTLCSat is not persisted directly: a restored
+	// session reconstructs it as requested+attachedCredit, so a padded
+	// quote with zero attached credit would lose its padding across a
+	// restart. No server produces that shape today; if one ever does, the
+	// expected amount needs its own column.
+	if s.expectedVHTLCSat != 0 &&
+		s.expectedVHTLCSat != uint64(s.amountSat) {
+		return s.failTerminal(
+			ctx, fmt.Sprintf("in-ark HTLC event conflicts with "+
+				"padded vHTLC receive plan: expected vHTLC "+
+				"%d sat does not match invoice amount %d sat",
+				s.expectedVHTLCSat, s.amountSat),
+			nil,
+			nil,
+		)
+	}
 	if event.AmountSat != int64(s.amountSat) {
 		return s.failTerminal(
 			ctx, fmt.Sprintf("in-ark HTLC amount %d does not "+

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightninglabs/wavelength/waverpc"
@@ -377,6 +378,95 @@ func TestAcceptInArkHtlcEventBuildsSenderReceiverPolicy(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedScript, session.vhtlcPkScript)
 	require.True(t, session.swapServerPubKey.IsEqual(senderPriv.PubKey()))
+}
+
+// TestAcceptInArkHtlcEventRejectsCreditBoundSession verifies a session whose
+// route quote attached credit (or padded the expected vHTLC above the invoice
+// amount) fails fast on an in-ark event instead of committing to the direct
+// p2p rail. The p2p vHTLC is funded entirely by the sender, so it can never
+// carry the server's custodial credit top-up; accepting the event would leave
+// the session polling a vHTLC that can never be funded while silently
+// skipping the out-swap ACK the server is waiting on.
+func TestAcceptInArkHtlcEventRejectsCreditBoundSession(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		attachedCreditSat uint64
+		expectedVHTLCSat  uint64
+		wantReason        string
+	}{
+		{
+			name:              "attached credit",
+			attachedCreditSat: 500,
+			expectedVHTLCSat:  1_000,
+			wantReason:        "credit-attach receive plan",
+		},
+		{
+			name:             "padded vhtlc plan",
+			expectedVHTLCSat: 1_000,
+			wantReason:       "padded vHTLC receive plan",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			senderPriv, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			receiverPriv, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			operatorPriv, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			preimage := lntypes.Preimage{4, 5, 6}
+			hash := preimage.Hash()
+			cfg := VHTLCConfig{
+				RefundLocktime:                       900,
+				UnilateralClaimDelay:                 5,
+				UnilateralRefundDelay:                6,
+				UnilateralRefundWithoutReceiverDelay: 7,
+				SwapServerPubkey: senderPriv.PubKey().
+					SerializeCompressed(),
+			}
+			session := &ReceiveSession{
+				client: &SwapClient{
+					daemon: &testDaemonConn{},
+					log:    btclog.Disabled,
+				},
+				amountSat:         btcutil.Amount(500),
+				attachedCreditSat: testCase.attachedCreditSat,
+				expectedVHTLCSat:  testCase.expectedVHTLCSat,
+				state:             ReceiveStateInvoiceCreated,
+				PaymentHash:       hash,
+				clientPubKey:      receiverPriv.PubKey(),
+				operatorPubKey:    operatorPriv.PubKey(),
+			}
+
+			err = session.acceptInArkHtlcEvent(
+				t.Context(), &InArkHtlcEvent{
+					PaymentHash:  hash,
+					AmountSat:    500,
+					SenderPubkey: senderPriv.PubKey(),
+					VHTLCConfig:  cfg,
+				}, 0,
+			)
+			require.ErrorContains(t, err, testCase.wantReason)
+			require.Equal(
+				t, ReceiveStateFailed, session.State(),
+			)
+
+			// The session must not have committed to the in-ark
+			// rail on the way down.
+			require.NotEqual(
+				t, SettlementTypeInArk, session.settlementType,
+			)
+		})
+	}
 }
 
 // TestReceiveSessionSkipsServerAckForSameArkHTLCEvent verifies the server ACK

--- a/swapwallet/credit_projector.go
+++ b/swapwallet/credit_projector.go
@@ -27,6 +27,10 @@ const creditProjectInterval = 5 * time.Second
 // emit so the projected terminal update lands on the same row.
 const creditCounterparty = "credit"
 
+// creditTopupPhaseLabel is the progress phase label stamped on the ledger row
+// of the Ark top-up transfer that funded a credit-backed pay.
+const creditTopupPhaseLabel = "credit_topup"
+
 // creditProjectorOwnsSwapSummary reports whether this wallet's durable credit
 // operation, rather than the generic swap monitor or history reconciler, owns
 // a swap activity row. CREDIT settlement identifies the rail, while the local

--- a/swapwallet/credit_topup_link_test.go
+++ b/swapwallet/credit_topup_link_test.go
@@ -1,0 +1,172 @@
+//go:build wavewalletrpc && swapruntime
+
+package swapwallet
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/wavelength/credit"
+	"github.com/lightninglabs/wavelength/ledger"
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/stretchr/testify/require"
+)
+
+// testTopupSessionID returns a deterministic 32-byte OOR session id and its
+// raw hex encoding.
+func testTopupSessionID(t *testing.T) ([]byte, string) {
+	t.Helper()
+
+	raw := make([]byte, chainhash.HashSize)
+	for i := range raw {
+		raw[i] = byte(i + 1)
+	}
+
+	return raw, hex.EncodeToString(raw)
+}
+
+// topupLedgerRow builds the OOR-send ledger row shape produced by a credit
+// top-up transfer.
+func topupLedgerRow(sessionID []byte, amountSat int64,
+) *waverpc.TransactionHistoryEntry {
+
+	return &waverpc.TransactionHistoryEntry{
+		Type:          "oor",
+		Subtype:       ledger.EventVTXOSent,
+		DebitAccount:  ledger.AccountTransfersOut,
+		CreditAccount: ledger.AccountVTXOBalance,
+		AmountSat:     amountSat,
+		SessionId:     sessionID,
+		EntryId:       46,
+	}
+}
+
+// TestCollectCreditTopupLinksLabelsTopupRow verifies the history merger can
+// resolve a credit pay operation from the raw ledger row of its top-up OOR
+// transfer, in either hex orientation, and relabels the entry so it no longer
+// reads as an unexplained outgoing transfer (issue #989).
+func TestCollectCreditTopupLinksLabelsTopupRow(t *testing.T) {
+	t.Parallel()
+
+	sessionID, sessionHex := testTopupSessionID(t)
+	const payHash = "f87105d14f3c955ea2253dd0dd81a80db71e6f098df97fd2" +
+		"c80350a6f0968338"
+
+	registry := &fakeCreditRegistry{
+		listResp: &credit.ListCreditOpsResponse{
+			Ops: []credit.CreditOpSummary{
+				{
+					OpID:         "op-topup",
+					OpKey:        "pay:" + payHash,
+					Kind:         credit.KindPay,
+					AmountSat:    500,
+					TopupSat:     1_000,
+					OORSessionID: sessionHex,
+				},
+				{
+					// A receive op with an OOR session
+					// must not produce a link.
+					OpID:         "op-recv",
+					OpKey:        "recv:aa",
+					Kind:         credit.KindReceive,
+					OORSessionID: "ff",
+				},
+			},
+		},
+	}
+
+	h := &history{
+		deps: &Deps{
+			CreditRegistry: registry,
+		},
+		runtime: &Runtime{},
+	}
+
+	links := h.collectCreditTopupLinks(t.Context())
+	require.NotEmpty(t, links)
+
+	// The receive op must not contribute a link despite carrying an OOR
+	// session id.
+	require.NotContains(t, links, "ff")
+
+	// The registry may have recorded either hex orientation of the
+	// session id; both must resolve.
+	reversed, err := chainhash.NewHash(sessionID)
+	require.NoError(t, err)
+	for _, key := range []string{sessionHex, reversed.String()} {
+		link, ok := links[strings.ToLower(key)]
+		require.True(t, ok, "missing link for %s", key)
+		require.Equal(t, payHash, link.paymentHash)
+		require.Equal(t, int64(1_000), link.topupSat)
+	}
+
+	row := topupLedgerRow(sessionID, 1_000)
+	link, ok := creditTopupLinkForRow(row, links)
+	require.True(t, ok)
+
+	entry, ok := walletEntryFromLedgerRow(row)
+	require.True(t, ok)
+	decorateCreditTopupEntry(entry, link)
+
+	require.Equal(t, creditCounterparty, entry.GetCounterparty())
+	require.Equal(
+		t, creditTopupPhaseLabel, entry.GetProgress().GetPhaseLabel(),
+	)
+	require.Equal(t, payHash, entry.GetProgress().GetPaymentHash())
+
+	// The amount stays the real VTXO outflow; the surplus above the paid
+	// amount remains represented by the credit balance, not the feed.
+	require.Equal(t, int64(-1_000), entry.GetAmountSat())
+}
+
+// TestCreditTopupLinkForRowIgnoresUnrelatedRows verifies non-top-up rows and
+// empty link sets never match.
+func TestCreditTopupLinkForRowIgnoresUnrelatedRows(t *testing.T) {
+	t.Parallel()
+
+	sessionID, sessionHex := testTopupSessionID(t)
+
+	// Index both hex orientations, mirroring collectCreditTopupLinks, so
+	// the shape checks below cannot pass merely because the display
+	// orientation is missing from the map.
+	reversed, err := chainhash.NewHash(sessionID)
+	require.NoError(t, err)
+	link := creditTopupLink{
+		paymentHash: "aa",
+		topupSat:    1_000,
+	}
+	links := map[string]creditTopupLink{
+		sessionHex:                         link,
+		strings.ToLower(reversed.String()): link,
+	}
+
+	// The matching send row resolves, so the negative cases below fail on
+	// shape or amount, not on the map contents.
+	_, ok := creditTopupLinkForRow(topupLedgerRow(sessionID, 1_000), links)
+	require.True(t, ok)
+
+	// A receive-shaped row with the same session id must not match.
+	recvRow := topupLedgerRow(sessionID, 1_000)
+	recvRow.Subtype = ledger.EventVTXOReceived
+	recvRow.DebitAccount = ledger.AccountVTXOBalance
+	recvRow.CreditAccount = ledger.AccountTransfersIn
+	_, ok = creditTopupLinkForRow(recvRow, links)
+	require.False(t, ok)
+
+	// A send row whose outflow does not equal the recorded top-up amount
+	// must not match: the session id resolved to an unrelated transfer.
+	_, ok = creditTopupLinkForRow(topupLedgerRow(sessionID, 900), links)
+	require.False(t, ok)
+
+	// A send row with an unknown session id must not match.
+	otherID := make([]byte, chainhash.HashSize)
+	otherID[0] = 0xff
+	_, ok = creditTopupLinkForRow(topupLedgerRow(otherID, 1_000), links)
+	require.False(t, ok)
+
+	// An empty link set short-circuits.
+	_, ok = creditTopupLinkForRow(topupLedgerRow(sessionID, 1_000), nil)
+	require.False(t, ok)
+}

--- a/swapwallet/history.go
+++ b/swapwallet/history.go
@@ -8,12 +8,14 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strconv"
 	"strings"
 
 	btcaddr "github.com/btcsuite/btcd/address/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/wavelength/credit"
 	"github.com/lightninglabs/wavelength/ledger"
 	"github.com/lightninglabs/wavelength/rpc/swapclientrpc"
 	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
@@ -34,6 +36,14 @@ import (
 type history struct {
 	deps    *Deps
 	runtime *Runtime
+
+	// creditTopupLinks memoizes the registry-derived top-up index for the
+	// lifetime of this history instance. A history is built once per
+	// derive call (and once per reproject pass, which pages deriveActivity
+	// in a loop), so the memo bounds the registry Ask to one per pass
+	// instead of one per page. Instances are used single-threaded.
+	creditTopupLinks    map[string]creditTopupLink
+	creditTopupLinksSet bool
 }
 
 // newHistory constructs the history merger.
@@ -437,6 +447,7 @@ func (h *history) deriveActivity(ctx context.Context,
 
 		ledgerEntries, err := h.collectLedgerEntries(
 			ctx, req.GetOffset(), limit, swapCorrelations,
+			h.collectCreditTopupLinks(ctx),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("collect ledger entries: %w",
@@ -1083,8 +1094,9 @@ func applyCooperativeLeaveForfeited(entry *wavewalletrpc.WalletEntry,
 // history returns no ledger rows because the daemon got Limit=limit
 // and Offset=0 and only the first `limit` rows ever came back.
 func (h *history) collectLedgerEntries(ctx context.Context, offset,
-	limit uint32, correlations swapOORCorrelations) (
-	[]*wavewalletrpc.WalletEntry, error) {
+	limit uint32, correlations swapOORCorrelations,
+	creditTopups map[string]creditTopupLink) ([]*wavewalletrpc.WalletEntry,
+	error) {
 
 	if h.deps.RPCServer == nil {
 		return nil, nil
@@ -1128,6 +1140,9 @@ func (h *history) collectLedgerEntries(ctx context.Context, offset,
 		entryID := t.GetEntryId()
 		if amount, ok := oorProjection.displayAmountByEntryID[entryID]; ok {
 			entry.AmountSat = amount
+		}
+		if link, ok := creditTopupLinkForRow(t, creditTopups); ok {
+			decorateCreditTopupEntry(entry, link)
 		}
 
 		out = append(out, entry)
@@ -1377,6 +1392,140 @@ func sessionInSet(set map[string]struct{}, session string) bool {
 	_, ok := set[session]
 
 	return ok
+}
+
+// creditTopupLink correlates one ledger OOR-send row to the credit pay
+// operation whose Ark top-up it funded.
+type creditTopupLink struct {
+	paymentHash string
+
+	// topupSat is the top-up amount recorded on the pay operation. A row
+	// only matches when its outflow equals this amount, so a session-id
+	// collision with an unrelated transfer cannot mislabel the feed.
+	topupSat int64
+}
+
+// collectCreditTopupLinks asks the credit registry for the durable operation
+// snapshot and indexes pay operations by their delegated top-up OOR session
+// id. The raw ledger row of a credit top-up otherwise surfaces as an
+// unexplained outgoing transfer (issue #989): the sats leave the VTXO balance
+// through a plain OOR send whose ledger row carries no hint that it funded
+// the credit account backing a sub-dust payment. Both hex orientations of
+// each session id are indexed so the lookup is independent of the display
+// convention the registry recorded. Transient registry errors degrade to an
+// unlabeled feed rather than failing the listing.
+func (h *history) collectCreditTopupLinks(
+	ctx context.Context) map[string]creditTopupLink {
+
+	if h.creditTopupLinksSet {
+		return h.creditTopupLinks
+	}
+	h.creditTopupLinksSet = true
+
+	if h.deps == nil || h.deps.CreditRegistry == nil {
+		return nil
+	}
+
+	resp, err := h.deps.CreditRegistry.Ask(
+		ctx, &credit.ListCreditOpsRequest{PendingOnly: false},
+	).Await(ctx).Unpack()
+	if err != nil {
+		h.deps.resolveLog().DebugS(
+			ctx,
+			"Credit top-up labeling skipped: registry list failed",
+			slog.String("err", err.Error()),
+		)
+
+		return nil
+	}
+	list, ok := resp.(*credit.ListCreditOpsResponse)
+	if !ok {
+		h.deps.resolveLog().DebugS(ctx,
+			"Credit top-up labeling skipped: unexpected registry "+
+				"response",
+			slog.String("response_type", fmt.Sprintf("%T", resp)),
+		)
+
+		return nil
+	}
+
+	out := make(map[string]creditTopupLink)
+	for i := range list.Ops {
+		op := list.Ops[i]
+		if op.Kind != credit.KindPay || op.OORSessionID == "" {
+			continue
+		}
+
+		link := creditTopupLink{
+			paymentHash: strings.TrimPrefix(op.OpKey, "pay:"),
+			topupSat:    op.TopupSat,
+		}
+
+		key := strings.ToLower(op.OORSessionID)
+		out[key] = link
+
+		raw, err := hex.DecodeString(key)
+		if err != nil || len(raw) != chainhash.HashSize {
+			continue
+		}
+		if hash, err := chainhash.NewHash(raw); err == nil {
+			out[strings.ToLower(hash.String())] = link
+		}
+	}
+
+	h.creditTopupLinks = out
+
+	return out
+}
+
+// creditTopupLinkForRow resolves the credit pay operation funded by one
+// ledger OOR-send row, when one exists.
+func creditTopupLinkForRow(row *waverpc.TransactionHistoryEntry,
+	links map[string]creditTopupLink) (creditTopupLink, bool) {
+
+	if len(links) == 0 {
+		return creditTopupLink{}, false
+	}
+
+	session, ok := oorSendSessionID(row)
+	if !ok {
+		return creditTopupLink{}, false
+	}
+
+	link, ok := links[strings.ToLower(session)]
+	if !ok {
+		return creditTopupLink{}, false
+	}
+
+	// The recorded top-up amount must match the row's outflow exactly; a
+	// mismatch means the session id resolved to an unrelated transfer.
+	if link.topupSat > 0 && row.GetAmountSat() != link.topupSat {
+		return creditTopupLink{}, false
+	}
+
+	return link, true
+}
+
+// decorateCreditTopupEntry relabels the ledger row of a credit top-up
+// transfer so it reads as the credit-funding leg of a payment instead of an
+// unexplained outgoing transfer. The amount is left untouched: the row
+// records the real VTXO outflow, while the surplus above the paid amount
+// remains visible as the wallet's credit balance.
+func decorateCreditTopupEntry(entry *wavewalletrpc.WalletEntry,
+	link creditTopupLink) {
+
+	if entry == nil {
+		return
+	}
+
+	entry.Counterparty = creditCounterparty
+	if entry.Progress == nil {
+		entry.Progress = &wavewalletrpc.WalletEntryProgress{}
+	}
+	entry.Progress.PhaseLabel = creditTopupPhaseLabel
+	if link.paymentHash != "" {
+		entry.Progress.PaymentHash = link.paymentHash
+	}
 }
 
 // oorSendSessionID extracts the session id from a ledger row that spends a VTXO


### PR DESCRIPTION
In this PR, we land the client-side half of the fix for #989 and the related "payment hodled by the swap server" deadlock (full RCA in the #989 comments). The server-side gate that stops offering the in-ark p2p path against credit-bound receive intents lands in swapdk-server#232; these are the wavelength pieces.

## Reject in-ark events on credit-bound receive sessions

A receive session whose route quote attached credit (or padded the expected vHTLC above the invoice amount) cannot settle through the direct p2p vHTLC: the sender funds the receiver's script directly, so no output exists that could carry the server's custodial credit top-up. The acceptance check previously compared only the event amount against the invoice amount, which still matches on a credit-attach plan since the attached credit lives in the vHTLC padding. The session would accept the event, switch to the in-ark rail (which intentionally skips the out-swap ACK), and poll a sub-floor vHTLC forever — the endless "script not registered for principal" debug spam from the report. The session now fails terminally with an explicit reason instead, surfacing the conflict immediately. The rejected envelope's mailbox cursor is deliberately left unacked: the mailbox is per payment hash and a failed session never pulls it again, so nothing redelivers.

## Label credit top-up transfers in wallet activity

Paying a sub-dust invoice routes through the swap server's credit account: the wallet first funds the account with an OOR at the operator's dust floor, then debits the invoice amount from the balance. The ledger row of that funding OOR surfaced as a bare outgoing transfer with no connection to the payment (the "unrecognized outgoing transfer ledger-46" from #989). The credit registry summary now carries the delegated top-up OOR session id, and the history merger relabels the matching ledger row: counterparty "credit", a "credit_topup" phase label, and the payment hash of the pay it funded. The amount is left untouched since the row records the real VTXO outflow; the surplus above the paid amount remains visible through Balance's existing credit_available_sat / credit_reserved_sat fields.