### PR TITLE
sdk/swaps+swaprpc: settle credit-attach receives over the server-funded in-ark leg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,6 +249,7 @@ jobs:
           - unit-cover
           - unit tags="test_sqlite"
           - unit tags="test_postgres"
+          - unit-swapruntime
           - unit-race
 
     steps:

--- a/docs/credit_system.md
+++ b/docs/credit_system.md
@@ -122,6 +122,32 @@ The onion payload still validates against the Lightning invoice amount. Attached
 credits are Ark-side value added to the vHTLC, not part of the payer's
 Lightning invoice.
 
+A credit-assisted receive can settle over two rails, and the event that arrives
+tells the session which one fired:
+
+- **Lightning rail.** A remote payer pays the invoice over Lightning. The
+  server intercepts the HTLC and delivers an `OutSwapHtlcEvent` with onion
+  payloads, as above.
+- **Same-Ark rail.** The payer shares the Ark instance and pays through the
+  server's credit system. The server delivers a credit-shaped
+  `InArkHtlcEvent` instead: no onions, the same
+  `requested_amount_sat`/`attached_credit_sat` pair, and the server's own
+  funding key as the vHTLC sender.
+
+The session validates the same triplet on both rails and, in both cases, sends
+the out-swap acknowledgement before the server funds: the server funds the
+padded vHTLC only after the receiver durably accepted the event. This is the
+opposite of the legacy direct p2p rail (a plain in-ark payment with no credits
+involved), where the sender already funded the vHTLC and the session skips the
+acknowledgement because there is nothing left to gate.
+
+The client advertises this capability as `supports_in_ark_credit` on
+`RequestChannelId`. The server records the flag on the receive intent and only
+publishes credit-shaped in-ark events to receivers that set it; older clients
+keep receiving the Lightning rail only, and a same-Ark payment against them
+fails cleanly on the payer side instead of producing an event they would
+reject.
+
 ## Sends
 
 The public send API stays the same: callers use `PrepareSend`, display the
@@ -175,6 +201,40 @@ For a mixed payment, credits cover only the shortfall. For example, a wallet
 with a 1,000 sat vTXO and 200 sat of credits can pay a 1,200 sat invoice. The
 quote reserves 200 sat of credits and asks the wallet to fund the remaining
 amount through the normal pay flow, plus any swap fee.
+
+### Same-Ark Credit Pays
+
+When the invoice belongs to a credit-assisted receive on the same Ark
+instance, the `CREDIT` rail never touches Lightning. The server cannot pay
+such an invoice over Lightning at all — its route hints point back at the
+server's own virtual channel — so it settles the pay internally: it debits the
+payer's credit reservation, funds the receiver's padded vHTLC itself, and
+returns the receiver's claim preimage as the proof of payment.
+
+The wallet cannot tell the difference, and does not need to. The quote is a
+normal `CREDIT` quote (including the top-up flow when the account is short),
+`CreateInSwap` blocks until the receiver claims, and the response carries the
+preimage exactly like any other credit pay. The only observable change is that
+the call can wait on the receiver: if the receiver does not accept and claim
+before the RPC deadline, the pay returns a pending error while the settlement
+keeps running on the server, and a retried pay for the same invoice rejoins
+it.
+
+```mermaid
+sequenceDiagram
+    participant Payer as payer wallet
+    participant Server as swap server
+    participant Recv as receiver wallet
+
+    Payer->>Server: CreateInSwap(max_credit_sat)
+    Server->>Server: reserve payer credits
+    Server->>Recv: credit-shaped InArkHtlcEvent
+    Recv->>Server: AcknowledgeOutSwapHtlc
+    Server->>Recv: fund padded vHTLC (OOR)
+    Recv->>Recv: claim with invoice preimage
+    Server->>Server: debit payer, finalize receiver credits
+    Server-->>Payer: CREDIT settlement + preimage
+```
 
 ## Funding Credits
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ into specific topics below.
 | [oor_subsystem.md](oor_subsystem.md) | The OOR (out-of-round) subsystem: per-session actor model, the `oor_session_registry` single source of truth, the Read/Commit turn with its inline outbox switch, outgoing/incoming flows, crash recovery, and the per-session concurrency fix for issue #605 |
 | [fee_ledger.md](fee_ledger.md) | Client-side double-entry fee ledger: chart of accounts, per-flow walkthroughs, emission sites, replay safety |
 | [fee-change-model.md](fee-change-model.md) | Seal-time fee handshake (#270): change-output designation rules, 11-scenario catalogue, proto contract, CLI mapping |
-| [credit_system.md](credit_system.md) | Sat-native credit accounts for below-dust receives, credit-assisted receives, credit-backed sends, top-ups, and wavewalletdk integration, with mermaid diagrams |
+| [credit_system.md](credit_system.md) | Sat-native credit accounts for below-dust receives, credit-assisted receives, credit-backed sends (Lightning and same-Ark internal settlement), top-ups, and wavewalletdk integration, with mermaid diagrams |
 | [sdk_layered_architecture.md](sdk_layered_architecture.md) | SDK layering rationale: `sdk/ark` facade, remote vs. embedded modes, `sdk/swaps` future direction |
 | [swap_system.md](swap_system.md) | End-to-end swap walkthrough: vHTLC tree (collaborative vs. unilateral-exit leaves), receive (out-swap) and pay (in-swap) flows, the off-chain-first cancellation/timeout recovery ladder, same-Ark p2p detection, swap-server RPCs, and proof-gated indexer authorization, with mermaid diagrams |
 | [wavewalletdk_integration.md](wavewalletdk_integration.md) | Basic `wavewalletdk` integration flow, startup/config examples, swap accounting, and wrapper guidance |

--- a/sdk/swaps/AGENTS.md
+++ b/sdk/swaps/AGENTS.md
@@ -45,6 +45,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/swap
   plus `AckCursor` and an `Ack` hook.
 - `InArkHtlcEvent` — same-Ark vHTLC event (payment hash, amount,
   sender pubkey, vHTLC config, optional indexed outpoint/amount).
+  A credit-shaped event additionally carries `RequestedAmountSat` +
+  `AttachedCreditSat`: the swap server funds the padded vHTLC of a
+  credit-attach receive, the session validates the triplet like the
+  out-swap path, and (unlike the legacy direct p2p rail) still sends
+  the out-swap ACK that gates the server's funding.
 - `OutSwapHtlcNotification` — wraps a mailbox `OutSwapHtlcEvent`
   with `AckCursor` and `Ack`.
 - `IncomingVHTLCEventReceiver` — interface for receivers that

--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -45,6 +45,11 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/swap
   plus `AckCursor` and an `Ack` hook.
 - `InArkHtlcEvent` — same-Ark vHTLC event (payment hash, amount,
   sender pubkey, vHTLC config, optional indexed outpoint/amount).
+  A credit-shaped event additionally carries `RequestedAmountSat` +
+  `AttachedCreditSat`: the swap server funds the padded vHTLC of a
+  credit-attach receive, the session validates the triplet like the
+  out-swap path, and (unlike the legacy direct p2p rail) still sends
+  the out-swap ACK that gates the server's funding.
 - `OutSwapHtlcNotification` — wraps a mailbox `OutSwapHtlcEvent`
   with `AckCursor` and `Ack`.
 - `IncomingVHTLCEventReceiver` — interface for receivers that

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -495,6 +495,16 @@ type InArkHtlcEvent struct {
 
 	// VHTLCAmountSat is the indexed funded amount when known by the server.
 	VHTLCAmountSat int64
+
+	// RequestedAmountSat is the invoice amount for a credit-shaped event.
+	// When set together with AttachedCreditSat, AmountSat carries the
+	// padded vHTLC amount of a credit-attach receive plan and the funding
+	// sender is the swap server. Zero on legacy direct p2p events.
+	RequestedAmountSat uint64
+
+	// AttachedCreditSat is the reserved credit amount added to the vHTLC
+	// on top of RequestedAmountSat.
+	AttachedCreditSat uint64
 }
 
 // IncomingVHTLCNotification carries either a Lightning-backed out-swap event
@@ -675,9 +685,13 @@ type InSwapQuote struct {
 // without importing the server module.
 type SwapServerConn interface {
 	// RequestChannelID asks the server for a route hint for this swap.
+	// supportsInArkCredit advertises whether the wired event receiver can
+	// consume credit-shaped in-ark HTLC events; the server only routes a
+	// credit-attach receive through the in-ark leg when it is set.
 	RequestChannelID(ctx context.Context, vhtlcPubkey *btcec.PublicKey,
 		paymentHash lntypes.Hash, amountSat btcutil.Amount,
-		expirySeconds uint32) (*OutSwapQuote, error)
+		expirySeconds uint32,
+		supportsInArkCredit bool) (*OutSwapQuote, error)
 
 	// AcknowledgeOutSwapHTLC tells the server this receiver validated and
 	// durably accepted the out-swap HTLC event.

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -46,7 +46,8 @@ func NewRESTSwapServerConn(addr string,
 // Lightning-to-Ark receive flow.
 func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 	vhtlcPubkey *btcec.PublicKey, paymentHash lntypes.Hash,
-	amountSat btcutil.Amount, expirySeconds uint32) (*OutSwapQuote, error) {
+	amountSat btcutil.Amount, expirySeconds uint32,
+	supportsInArkCredit bool) (*OutSwapQuote, error) {
 
 	if vhtlcPubkey == nil {
 		return nil, fmt.Errorf("vHTLC pubkey must be provided")
@@ -63,7 +64,8 @@ func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 			PaymentHash: append(
 				[]byte(nil), paymentHash[:]...,
 			),
-			AmountSat: uint64(amountSat),
+			AmountSat:           uint64(amountSat),
+			SupportsInArkCredit: supportsInArkCredit,
 		},
 	)
 	if err != nil {
@@ -594,12 +596,14 @@ func inArkHtlcEventFromProto(event *swaprpc.InArkHtlcEvent) (*InArkHtlcEvent,
 	}
 
 	return &InArkHtlcEvent{
-		PaymentHash:    paymentHash,
-		AmountSat:      int64(event.GetAmountSat()),
-		SenderPubkey:   senderKey,
-		VHTLCConfig:    *cfg,
-		VHTLCOutpoint:  event.GetVhtlcOutpoint(),
-		VHTLCAmountSat: int64(event.GetVhtlcAmountSat()),
+		PaymentHash:        paymentHash,
+		AmountSat:          int64(event.GetAmountSat()),
+		SenderPubkey:       senderKey,
+		VHTLCConfig:        *cfg,
+		VHTLCOutpoint:      event.GetVhtlcOutpoint(),
+		VHTLCAmountSat:     int64(event.GetVhtlcAmountSat()),
+		RequestedAmountSat: event.GetRequestedAmountSat(),
+		AttachedCreditSat:  event.GetAttachedCreditSat(),
 	}, nil
 }
 

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -101,8 +101,8 @@ func (f *failAtExecDBTX) QueryRowContext(ctx context.Context, query string,
 
 // RequestChannelID is unused in these tests.
 func (c *testInSwapServerConn) RequestChannelID(_ context.Context,
-	_ *btcec.PublicKey, _ lntypes.Hash, _ btcutil.Amount, _ uint32) (
-	*OutSwapQuote, error) {
+	_ *btcec.PublicKey, _ lntypes.Hash, _ btcutil.Amount, _ uint32,
+	_ bool) (*OutSwapQuote, error) {
 
 	return nil, nil
 }

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -668,9 +668,18 @@ func (s *ReceiveSession) prepareInvoice(ctx context.Context) error {
 	// database. The session is persisted before the invoice is returned to
 	// the caller.
 	expiry := time.Duration(defaultReceiveExpirySeconds) * time.Second
+
+	// Only advertise the in-ark credit capability when the wired event
+	// receiver can actually pull in-ark events: this session validates
+	// credit-shaped events, but a receiver limited to the out-swap
+	// interface would never surface one, and an advertised-but-unservable
+	// capability would leave a same-Ark credit receive waiting out the
+	// invoice deadline.
+	_, supportsInArkCredit :=
+		s.client.outEvents.(IncomingVHTLCEventReceiver)
 	quote, err := s.client.server.RequestChannelID(
 		ctx, clientKey, paymentHash, s.amountSat,
-		defaultReceiveExpirySeconds,
+		defaultReceiveExpirySeconds, supportsInArkCredit,
 	)
 	if err != nil {
 		return fmt.Errorf("request channel ID: %w", err)
@@ -1143,7 +1152,14 @@ func (s *ReceiveSession) ackAcceptedHTLCEvent(ctx context.Context,
 // acknowledgeOutSwapHTLC records the receiver's durable event acceptance with
 // the swap server before clearing the local pending ACK marker.
 func (s *ReceiveSession) acknowledgeOutSwapHTLC(ctx context.Context) error {
-	if s.settlementType == SettlementTypeInArk {
+	// The legacy direct p2p rail has no server-side funding gate: the
+	// sender already funded the vHTLC before the event was published, so
+	// there is nothing to acknowledge. The credit-shaped in-ark leg is
+	// different: the swap server funds the padded vHTLC only after this
+	// ACK proves the receiver durably accepted the event, exactly like
+	// the Lightning out-swap rail.
+	if s.settlementType == SettlementTypeInArk &&
+		s.attachedCreditSat == 0 {
 		return nil
 	}
 	if s.client == nil || s.client.server == nil {
@@ -1194,6 +1210,38 @@ func (s *ReceiveSession) clearPendingHTLCAck(ctx context.Context) error {
 	})
 }
 
+// validateCreditShapedInArkEvent checks a swap-server-funded in-ark event
+// against the session's credit-attach route quote. Every field of the
+// (requested amount, attached credit, padded amount) triplet must match: the
+// event commits this session to a claim of the padded vHTLC, and the server
+// finalizes the receiver's attach reservation against that claim.
+func (s *ReceiveSession) validateCreditShapedInArkEvent(
+	event *InArkHtlcEvent) error {
+
+	if s.attachedCreditSat == 0 {
+		return fmt.Errorf("credit-shaped in-ark HTLC event with "+
+			"attached credit %d sat for a session without a "+
+			"credit-attach plan", event.AttachedCreditSat)
+	}
+	if event.RequestedAmountSat != uint64(s.amountSat) {
+		return fmt.Errorf("in-ark HTLC requested amount %d does not "+
+			"match invoice amount %d", event.RequestedAmountSat,
+			s.amountSat)
+	}
+	if event.AttachedCreditSat != s.attachedCreditSat {
+		return fmt.Errorf("in-ark HTLC attached credit %d does not "+
+			"match expected credit %d", event.AttachedCreditSat,
+			s.attachedCreditSat)
+	}
+	if event.AmountSat != int64(s.expectedVHTLCSat) {
+		return fmt.Errorf("in-ark HTLC amount %d does not match "+
+			"expected vHTLC amount %d", event.AmountSat,
+			s.expectedVHTLCSat)
+	}
+
+	return nil
+}
+
 // acceptInArkHtlcEvent validates a direct same-Ark vHTLC notification and
 // builds the policy that the receiver will later claim.
 func (s *ReceiveSession) acceptInArkHtlcEvent(ctx context.Context,
@@ -1209,47 +1257,60 @@ func (s *ReceiveSession) acceptInArkHtlcEvent(ctx context.Context,
 		)
 	}
 
-	// A session whose route quote attached credit (or padded the vHTLC
-	// above the invoice amount) cannot settle through the direct p2p
-	// vHTLC: the sender funds the receiver's script directly, so no
-	// output exists that could carry the server's custodial credit
-	// top-up. Accepting such an event would commit this session to the
-	// in-ark rail (which skips the out-swap ACK) and leave it polling a
-	// vHTLC that can never be funded, so fail fast instead.
-	if s.attachedCreditSat > 0 {
-		return s.failTerminal(
-			ctx, fmt.Sprintf("in-ark HTLC event conflicts with "+
-				"credit-attach receive plan: attached credit "+
-				"%d sat requires server-mediated settlement",
-				s.attachedCreditSat),
-			nil,
-			nil,
-		)
-	}
-	// Note that expectedVHTLCSat is not persisted directly: a restored
-	// session reconstructs it as requested+attachedCredit, so a padded
-	// quote with zero attached credit would lose its padding across a
-	// restart. No server produces that shape today; if one ever does, the
-	// expected amount needs its own column.
-	if s.expectedVHTLCSat != 0 &&
-		s.expectedVHTLCSat != uint64(s.amountSat) {
-		return s.failTerminal(
-			ctx, fmt.Sprintf("in-ark HTLC event conflicts with "+
-				"padded vHTLC receive plan: expected vHTLC "+
-				"%d sat does not match invoice amount %d sat",
-				s.expectedVHTLCSat, s.amountSat),
-			nil,
-			nil,
-		)
-	}
-	if event.AmountSat != int64(s.amountSat) {
-		return s.failTerminal(
-			ctx, fmt.Sprintf("in-ark HTLC amount %d does not "+
-				"match invoice amount %d", event.AmountSat,
-				s.amountSat),
-			nil,
-			nil,
-		)
+	if event.RequestedAmountSat > 0 || event.AttachedCreditSat > 0 {
+		// A credit-shaped event is the swap-server-funded in-ark leg
+		// of a credit-attach receive: amount_sat carries the padded
+		// vHTLC and the event must match the session's route quote
+		// triplet exactly.
+		if err := s.validateCreditShapedInArkEvent(event); err != nil {
+			return s.failTerminal(ctx, err.Error(), nil, nil)
+		}
+	} else {
+		// A legacy direct p2p event cannot settle a session whose
+		// route quote attached credit (or padded the vHTLC above the
+		// invoice amount): the sender funds the receiver's script
+		// directly, so no output exists that could carry the server's
+		// custodial credit top-up. Accepting such an event would
+		// commit this session to the in-ark rail and leave it polling
+		// a vHTLC that can never be funded, so fail fast instead.
+		if s.attachedCreditSat > 0 {
+			return s.failTerminal(
+				ctx, fmt.Sprintf("in-ark HTLC event "+
+					"conflicts with credit-attach "+
+					"receive plan: attached credit %d "+
+					"sat requires a credit-shaped event",
+					s.attachedCreditSat),
+				nil,
+				nil,
+			)
+		}
+		// Note that expectedVHTLCSat is not persisted directly: a
+		// restored session reconstructs it as requested plus
+		// attachedCredit, so a padded quote with zero attached credit
+		// would lose its padding across a restart. No server produces
+		// that shape today; if one ever does, the expected amount
+		// needs its own column.
+		if s.expectedVHTLCSat != 0 &&
+			s.expectedVHTLCSat != uint64(s.amountSat) {
+			return s.failTerminal(
+				ctx, fmt.Sprintf("in-ark HTLC event "+
+					"conflicts with padded vHTLC receive "+
+					"plan: expected vHTLC %d sat does "+
+					"not match invoice amount %d sat",
+					s.expectedVHTLCSat, s.amountSat),
+				nil,
+				nil,
+			)
+		}
+		if event.AmountSat != int64(s.amountSat) {
+			return s.failTerminal(
+				ctx, fmt.Sprintf("in-ark HTLC amount %d does "+
+					"not match invoice amount %d",
+					event.AmountSat, s.amountSat),
+				nil,
+				nil,
+			)
+		}
 	}
 	if event.SenderPubkey == nil {
 		return fmt.Errorf("in-ark HTLC sender pubkey is required")

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -903,6 +903,8 @@ type testSwapServerConn struct {
 	lastServerAckHash   lntypes.Hash
 	lastServerAckPubkey *btcec.PublicKey
 
+	lastSupportsInArkCredit bool
+
 	submitForfeitErr         error
 	submitForfeitCalls       int
 	lastSubmitForfeitPayload *ForfeitSignaturePayload
@@ -954,10 +956,11 @@ func (r *testIncomingEventReceiver) WaitIncomingVHTLC(context.Context,
 // a single path wrapping the lone configured hint.
 func (c *testSwapServerConn) RequestChannelID(_ context.Context,
 	vhtlcPubkey *btcec.PublicKey, _ lntypes.Hash, amountSat btcutil.Amount,
-	_ uint32) (*OutSwapQuote, error) {
+	_ uint32, supportsInArkCredit bool) (*OutSwapQuote, error) {
 
 	c.lastVhtlcPubkey = vhtlcPubkey
 	c.lastAmountSat = amountSat
+	c.lastSupportsInArkCredit = supportsInArkCredit
 
 	hintPaths := c.hintPaths
 	if hintPaths == nil {
@@ -4281,4 +4284,277 @@ func TestReceiveSessionClaimReturnsLastSendError(t *testing.T) {
 	require.ErrorContains(t, err, "claim vHTLC")
 	require.NotContains(t, err.Error(), "<nil>")
 	require.Equal(t, 2, daemonConn.sendCustomCalls)
+}
+
+// TestReceiveSessionAcksServerForCreditShapedInArkEvent verifies a
+// credit-shaped in-ark event (the swap-server-funded leg of a credit-attach
+// receive) is accepted against the session's route quote triplet and, unlike
+// the legacy direct p2p rail, still sends the out-swap server ACK that gates
+// the server's funding.
+func TestReceiveSessionAcksServerForCreditShapedInArkEvent(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage := lntypes.Preimage{0xa, 0xb, 0xc}
+	hash := preimage.Hash()
+	serverConn := &testSwapServerConn{}
+	daemonConn := &testDaemonConn{}
+	client := NewSwapClient(serverConn, daemonConn, nil, nil)
+
+	cfg := VHTLCConfig{
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+		SwapServerPubkey: serverPriv.PubKey().
+			SerializeCompressed(),
+	}
+
+	ackCalls := 0
+	client.outEvents = &testIncomingEventReceiver{
+		notification: &IncomingVHTLCNotification{
+			InArk: &InArkHtlcEvent{
+				PaymentHash:        hash,
+				AmountSat:          1_100,
+				RequestedAmountSat: 300,
+				AttachedCreditSat:  800,
+				SenderPubkey:       serverPriv.PubKey(),
+				VHTLCConfig:        cfg,
+			},
+			AckCursor: 25,
+			Ack: func(context.Context) error {
+				ackCalls++
+
+				return nil
+			},
+		},
+	}
+
+	session := &ReceiveSession{
+		client:            client,
+		amountSat:         300,
+		expectedVHTLCSat:  1_100,
+		attachedCreditSat: 800,
+		settlementType:    SettlementTypeMixed,
+		state:             ReceiveStateInvoiceCreated,
+		PaymentHash:       hash,
+		clientPubKey:      clientPriv.PubKey(),
+		operatorPubKey:    operatorPriv.PubKey(),
+	}
+
+	err = session.waitForHTLCEvent(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, session.State())
+	require.Equal(t, SettlementTypeInArk, session.settlementType)
+	require.Equal(t, 1, ackCalls)
+	require.Equal(t, 1, serverConn.serverAckCalls)
+	require.Zero(t, session.pendingHTLCAckCursor)
+
+	// The claim policy commits to the swap server as the vHTLC sender and
+	// the Ark operator in the server slot, identical to the out-swap
+	// shape.
+	expected, err := arkscript.NewVHTLCPolicy(arkscript.VHTLCOpts{
+		Sender:                serverPriv.PubKey(),
+		Receiver:              clientPriv.PubKey(),
+		Server:                operatorPriv.PubKey(),
+		PreimageHash:          hash,
+		RefundLocktime:        cfg.RefundLocktime,
+		UnilateralClaimDelay:  cfg.UnilateralClaimDelay,
+		UnilateralRefundDelay: cfg.UnilateralRefundDelay,
+		UnilateralRefundWithoutReceiverDelay: cfg.
+			UnilateralRefundWithoutReceiverDelay,
+	})
+	require.NoError(t, err)
+
+	expectedScript, err := expected.PkScript()
+	require.NoError(t, err)
+	require.Equal(t, expectedScript, session.vhtlcPkScript)
+}
+
+// TestAcceptInArkHtlcEventRejectsMismatchedCreditShape verifies every leg of
+// the credit-shaped triplet validation fails the session terminally on a
+// mismatch against the route quote.
+func TestAcceptInArkHtlcEventRejectsMismatchedCreditShape(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		attachedCreditSat uint64
+		expectedVHTLCSat  uint64
+		event             InArkHtlcEvent
+		wantReason        string
+	}{
+		{
+			name:              "requested amount mismatch",
+			attachedCreditSat: 500,
+			expectedVHTLCSat:  1_000,
+			event: InArkHtlcEvent{
+				AmountSat:          1_000,
+				RequestedAmountSat: 400,
+				AttachedCreditSat:  500,
+			},
+			wantReason: "requested amount 400 does not match",
+		},
+		{
+			name:              "attached credit mismatch",
+			attachedCreditSat: 500,
+			expectedVHTLCSat:  1_000,
+			event: InArkHtlcEvent{
+				AmountSat:          1_000,
+				RequestedAmountSat: 500,
+				AttachedCreditSat:  600,
+			},
+			wantReason: "attached credit 600 does not match",
+		},
+		{
+			name:              "padded amount mismatch",
+			attachedCreditSat: 500,
+			expectedVHTLCSat:  1_000,
+			event: InArkHtlcEvent{
+				AmountSat:          900,
+				RequestedAmountSat: 500,
+				AttachedCreditSat:  500,
+			},
+			wantReason: "does not match expected vHTLC amount",
+		},
+		{
+			name: "credit shape against plain session",
+			event: InArkHtlcEvent{
+				AmountSat:          1_000,
+				RequestedAmountSat: 500,
+				AttachedCreditSat:  500,
+			},
+			wantReason: "without a credit-attach plan",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			senderPriv, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			receiverPriv, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			operatorPriv, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			preimage := lntypes.Preimage{0xd, 0xe, 0xf}
+			hash := preimage.Hash()
+			session := &ReceiveSession{
+				client: &SwapClient{
+					daemon: &testDaemonConn{},
+					log:    btclog.Disabled,
+				},
+				amountSat:         btcutil.Amount(500),
+				attachedCreditSat: testCase.attachedCreditSat,
+				expectedVHTLCSat:  testCase.expectedVHTLCSat,
+				state:             ReceiveStateInvoiceCreated,
+				PaymentHash:       hash,
+				clientPubKey:      receiverPriv.PubKey(),
+				operatorPubKey:    operatorPriv.PubKey(),
+			}
+
+			event := testCase.event
+			event.PaymentHash = hash
+			event.SenderPubkey = senderPriv.PubKey()
+			event.VHTLCConfig = VHTLCConfig{
+				RefundLocktime:                       900,
+				UnilateralClaimDelay:                 5,
+				UnilateralRefundDelay:                6,
+				UnilateralRefundWithoutReceiverDelay: 7,
+				SwapServerPubkey: senderPriv.PubKey().
+					SerializeCompressed(),
+			}
+
+			err = session.acceptInArkHtlcEvent(
+				t.Context(), &event, 0,
+			)
+			require.ErrorContains(t, err, testCase.wantReason)
+			require.Equal(t, ReceiveStateFailed, session.State())
+		})
+	}
+}
+
+// TestRequestChannelIDAdvertisesInArkCreditByReceiver verifies the in-ark
+// credit capability is only advertised when the wired event receiver can
+// actually pull in-ark events; an out-swap-only receiver must not invite the
+// server onto a rail it can never surface.
+func TestRequestChannelIDAdvertisesInArkCreditByReceiver(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		outEvents OutSwapEventReceiver
+		want      bool
+	}{
+		{
+			name:      "incoming vhtlc receiver",
+			outEvents: &testIncomingEventReceiver{},
+			want:      true,
+		},
+		{
+			name:      "out-swap only receiver",
+			outEvents: &blockingOutSwapEventReceiver{},
+			want:      false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			clientPriv, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			serverPriv, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			creator := &testInvoiceCreator{
+				invoice: &invoices.Invoice{
+					PaymentRequest: []byte("lnrtest1swap"),
+				},
+			}
+			serverConn := &testSwapServerConn{
+				hint: &RouteHint{
+					NodeID: serverPriv.PubKey().
+						SerializeCompressed(),
+					ChannelID:       99,
+					FeeBaseMsat:     1,
+					FeePropPpm:      2,
+					CltvExpiryDelta: 40,
+				},
+			}
+			daemonConn := &testDaemonConn{
+				identityKey: clientPriv.PubKey(),
+				blockHeight: 100,
+			}
+
+			client := NewSwapClient(
+				serverConn, daemonConn, nil, creator,
+			)
+			client.outEvents = testCase.outEvents
+
+			_, err = client.StartReceiveViaLightning(
+				t.Context(), btcutil.Amount(42_000),
+			)
+			require.NoError(t, err)
+			require.Equal(
+				t, testCase.want,
+				serverConn.lastSupportsInArkCredit,
+			)
+		})
+	}
 }

--- a/sdk/swaps/rest_conn_test.go
+++ b/sdk/swaps/rest_conn_test.go
@@ -64,7 +64,7 @@ func TestRESTSwapServerConnRequestChannelID(t *testing.T) {
 	client := NewRESTSwapServerConn(server.URL)
 	quote, err := client.RequestChannelID(
 		t.Context(), clientPriv.PubKey(), lntypes.Hash{1},
-		btcutil.Amount(42_000), 30,
+		btcutil.Amount(42_000), 30, true,
 	)
 	require.NoError(t, err)
 	require.Len(t, quote.RouteHintPaths, 1)

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -964,7 +964,7 @@ func TestNewSwapServerClientsREST(t *testing.T) {
 
 	hint, err := clients.server.RequestChannelID(
 		t.Context(), clientPriv.PubKey(), lntypes.Hash{1},
-		btcutil.Amount(42_000), 30,
+		btcutil.Amount(42_000), 30, true,
 	)
 	require.NoError(t, err)
 	require.Len(t, hint.RouteHintPaths, 1)

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -285,9 +285,15 @@ type RequestChannelIdRequest struct {
 	// adding a separate auth identity.
 	PaymentHash []byte `protobuf:"bytes,3,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
 	// amount_sat is the exact invoice amount the payer should send.
-	AmountSat     uint64 `protobuf:"varint,4,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	AmountSat uint64 `protobuf:"varint,4,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// supports_in_ark_credit signals that this receiver can validate and
+	// acknowledge a credit-shaped in-ark HTLC event (one carrying
+	// requested_amount_sat and attached_credit_sat). The server records the
+	// capability on the receive intent and only routes a credit-attach
+	// receive through the swap-server-funded in-ark leg when it is set.
+	SupportsInArkCredit bool `protobuf:"varint,5,opt,name=supports_in_ark_credit,json=supportsInArkCredit,proto3" json:"supports_in_ark_credit,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *RequestChannelIdRequest) Reset() {
@@ -346,6 +352,13 @@ func (x *RequestChannelIdRequest) GetAmountSat() uint64 {
 		return x.AmountSat
 	}
 	return 0
+}
+
+func (x *RequestChannelIdRequest) GetSupportsInArkCredit() bool {
+	if x != nil {
+		return x.SupportsInArkCredit
+	}
+	return false
 }
 
 // RequestChannelIdResponse returns the route hint paths for one receive
@@ -859,8 +872,17 @@ type InArkHtlcEvent struct {
 	VhtlcOutpoint string `protobuf:"bytes,5,opt,name=vhtlc_outpoint,json=vhtlcOutpoint,proto3" json:"vhtlc_outpoint,omitempty"`
 	// vhtlc_amount_sat is the observed vHTLC amount in satoshis when known.
 	VhtlcAmountSat uint64 `protobuf:"varint,6,opt,name=vhtlc_amount_sat,json=vhtlcAmountSat,proto3" json:"vhtlc_amount_sat,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// requested_amount_sat is the invoice amount requested by the receiver.
+	// When set together with attached_credit_sat, amount_sat is the padded
+	// vHTLC amount of a credit-attach receive plan, mirroring
+	// OutSwapHtlcEvent. When zero, the event is a legacy direct p2p payment
+	// and amount_sat equals the invoice amount.
+	RequestedAmountSat uint64 `protobuf:"varint,7,opt,name=requested_amount_sat,json=requestedAmountSat,proto3" json:"requested_amount_sat,omitempty"`
+	// attached_credit_sat is the reserved credit amount added to the vHTLC
+	// on top of requested_amount_sat.
+	AttachedCreditSat uint64 `protobuf:"varint,8,opt,name=attached_credit_sat,json=attachedCreditSat,proto3" json:"attached_credit_sat,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *InArkHtlcEvent) Reset() {
@@ -931,6 +953,20 @@ func (x *InArkHtlcEvent) GetVhtlcOutpoint() string {
 func (x *InArkHtlcEvent) GetVhtlcAmountSat() uint64 {
 	if x != nil {
 		return x.VhtlcAmountSat
+	}
+	return 0
+}
+
+func (x *InArkHtlcEvent) GetRequestedAmountSat() uint64 {
+	if x != nil {
+		return x.RequestedAmountSat
+	}
+	return 0
+}
+
+func (x *InArkHtlcEvent) GetAttachedCreditSat() uint64 {
+	if x != nil {
+		return x.AttachedCreditSat
 	}
 	return 0
 }
@@ -2944,13 +2980,14 @@ var File_swap_proto protoreflect.FileDescriptor
 const file_swap_proto_rawDesc = "" +
 	"\n" +
 	"\n" +
-	"swap.proto\x12\aswaprpc\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb2\x01\n" +
+	"swap.proto\x12\aswaprpc\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe7\x01\n" +
 	"\x17RequestChannelIdRequest\x12%\n" +
 	"\x0eexpiry_seconds\x18\x01 \x01(\rR\rexpirySeconds\x12.\n" +
 	"\x13client_vhtlc_pubkey\x18\x02 \x01(\fR\x11clientVhtlcPubkey\x12!\n" +
 	"\fpayment_hash\x18\x03 \x01(\fR\vpaymentHash\x12\x1d\n" +
 	"\n" +
-	"amount_sat\x18\x04 \x01(\x04R\tamountSat\"\xbf\x03\n" +
+	"amount_sat\x18\x04 \x01(\x04R\tamountSat\x123\n" +
+	"\x16supports_in_ark_credit\x18\x05 \x01(\bR\x13supportsInArkCredit\"\xbf\x03\n" +
 	"\x18RequestChannelIdResponse\x12$\n" +
 	"\x0epayer_fee_msat\x18\x02 \x01(\x04R\fpayerFeeMsat\x120\n" +
 	"\x14requested_amount_sat\x18\x03 \x01(\x04R\x12requestedAmountSat\x120\n" +
@@ -2983,7 +3020,7 @@ const file_swap_proto_rawDesc = "" +
 	"\rout_swap_htlc\x18\x01 \x01(\v2\x19.swaprpc.OutSwapHtlcEventH\x00R\voutSwapHtlc\x129\n" +
 	"\vin_ark_htlc\x18\x02 \x01(\v2\x17.swaprpc.InArkHtlcEventH\x00R\tinArkHtlc\x12u\n" +
 	"\"out_swap_forfeit_signature_request\x18\x03 \x01(\v2'.swaprpc.OutSwapForfeitSignatureRequestH\x00R\x1eoutSwapForfeitSignatureRequestB\a\n" +
-	"\x05event\"\x81\x02\n" +
+	"\x05event\"\xe3\x02\n" +
 	"\x0eInArkHtlcEvent\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x1d\n" +
 	"\n" +
@@ -2991,7 +3028,9 @@ const file_swap_proto_rawDesc = "" +
 	"\rsender_pubkey\x18\x03 \x01(\fR\fsenderPubkey\x127\n" +
 	"\fvhtlc_config\x18\x04 \x01(\v2\x14.swaprpc.VHTLCConfigR\vvhtlcConfig\x12%\n" +
 	"\x0evhtlc_outpoint\x18\x05 \x01(\tR\rvhtlcOutpoint\x12(\n" +
-	"\x10vhtlc_amount_sat\x18\x06 \x01(\x04R\x0evhtlcAmountSat\"\xc5\x01\n" +
+	"\x10vhtlc_amount_sat\x18\x06 \x01(\x04R\x0evhtlcAmountSat\x120\n" +
+	"\x14requested_amount_sat\x18\a \x01(\x04R\x12requestedAmountSat\x12.\n" +
+	"\x13attached_credit_sat\x18\b \x01(\x04R\x11attachedCreditSat\"\xc5\x01\n" +
 	"\tRouteHint\x12\x17\n" +
 	"\anode_id\x18\x01 \x01(\fR\x06nodeId\x12\x1d\n" +
 	"\n" +

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -131,6 +131,13 @@ message RequestChannelIdRequest {
 
     // amount_sat is the exact invoice amount the payer should send.
     uint64 amount_sat = 4;
+
+    // supports_in_ark_credit signals that this receiver can validate and
+    // acknowledge a credit-shaped in-ark HTLC event (one carrying
+    // requested_amount_sat and attached_credit_sat). The server records the
+    // capability on the receive intent and only routes a credit-attach
+    // receive through the swap-server-funded in-ark leg when it is set.
+    bool supports_in_ark_credit = 5;
 }
 
 // RequestChannelIdResponse returns the route hint paths for one receive
@@ -282,6 +289,17 @@ message InArkHtlcEvent {
 
     // vhtlc_amount_sat is the observed vHTLC amount in satoshis when known.
     uint64 vhtlc_amount_sat = 6;
+
+    // requested_amount_sat is the invoice amount requested by the receiver.
+    // When set together with attached_credit_sat, amount_sat is the padded
+    // vHTLC amount of a credit-attach receive plan, mirroring
+    // OutSwapHtlcEvent. When zero, the event is a legacy direct p2p payment
+    // and amount_sat equals the invoice amount.
+    uint64 requested_amount_sat = 7;
+
+    // attached_credit_sat is the reserved credit amount added to the vHTLC
+    // on top of requested_amount_sat.
+    uint64 attached_credit_sat = 8;
 }
 
 // RouteHint describes one hop hint for a Lightning invoice route.


### PR DESCRIPTION
In this PR, we teach the receive session to settle a credit-attach receive over the swap-server-funded in-ark leg from swapdk-server#233 (as revised on that issue). It stacks on #991: that PR made a credit-bound session hard-reject any in-ark event, since the legacy direct p2p shape can never carry the server's custodial credit; this one relaxes that rejection into full triplet validation for the new credit-shaped events, so the payment actually settles instead of failing clean.

On the wire, `InArkHtlcEvent` grows `requested_amount_sat` and `attached_credit_sat`, mirroring `OutSwapHtlcEvent`: a credit-shaped event carries the padded vHTLC amount in `amount_sat` together with the invoice amount and the credit portion. `RequestChannelIdRequest` grows `supports_in_ark_credit`, which this client now always advertises; the server records it on the receive intent and only publishes credit-shaped events to receivers that set it, so deployed clients without this code never see an event shape they would reject.

The receiver validates the triplet exactly like the out-swap acceptance path (requested must match the invoice, attached credit must match the plan, amount must equal the padded vHTLC) and terminal-fails on any mismatch. The rail split also moves the ACK decision off the settlement type alone: the legacy p2p rail keeps skipping the out-swap server ACK (the sender funded before the event was published), while a credit-shaped session sends it, because the swap server funds the padded vHTLC only after the receiver durably accepted the event. The claim policy is unchanged in shape: the event's sender key (the swap server's funding key on this rail) fills the sender slot and the Ark operator stays in the server slot, so funding validation and the claim path work as they do for every other padded vHTLC.

The sender side needs no changes at all: sub-dust pays were already forced onto the credit rail with its auto top-up, and that is exactly the rail the server settles internally on the other side (lightninglabs/swapdk-server#234).

#991 is merged; this PR now sits directly on main. Supersedes #995, which GitHub closed un-reopenably when the stacked base branch was deleted at merge time.
