### PR TITLE
wavecli: Fix refresh consent gate misdetecting non-TTY stdin

### DIFF
--- a/cmd/wavecli/waveclicommands/cmd_vtxos.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -868,22 +869,23 @@ var stdinIsTTY = defaultStdinIsTTY
 //     the caller's signal that they will drive the prompt
 //     themselves (e.g. by piping a scripted "y\n").
 //
-//  2. cmd.InOrStdin() is os.Stdin and os.Stdin reports a character
-//     device, i.e. an actual terminal where the operator can answer
-//     interactively.
+//  2. cmd.InOrStdin() is os.Stdin and os.Stdin is an actual terminal
+//     (per term.IsTerminal), i.e. a device where the operator can
+//     answer interactively.
 //
-// All other cases (os.Stdin is a pipe / file, Stat fails) return
-// false and the caller refuses to prompt.
+// All other cases return false and the caller refuses to prompt. A
+// character-device check is deliberately NOT used here: /dev/null and
+// a closed descriptor are both character devices yet are not
+// terminals, and those are the most common non-interactive stdin
+// shapes for agents, CI, and systemd units. Treating them as a TTY
+// would print a y/N prompt that immediately reads EOF, which is the
+// exact hang-then-fail the consent gate exists to prevent.
 func defaultStdinIsTTY(cmd *cobra.Command) bool {
 	if cmd.InOrStdin() != os.Stdin {
 		return true
 	}
-	stat, err := os.Stdin.Stat()
-	if err != nil {
-		return false
-	}
 
-	return (stat.Mode() & os.ModeCharDevice) != 0
+	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
 // promptLeaveAllConfirmation asks the operator to confirm a

--- a/cmd/wavecli/waveclicommands/cmd_vtxos_tty_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos_tty_test.go
@@ -1,0 +1,88 @@
+package waveclicommands
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// withStdin swaps os.Stdin for the duration of the test and restores it
+// afterwards so a case can drive defaultStdinIsTTY against a concrete
+// descriptor (a real terminal is not available under `go test`).
+func withStdin(t *testing.T, f *os.File) {
+	t.Helper()
+
+	prev := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() {
+		os.Stdin = prev
+	})
+}
+
+// TestDefaultStdinIsTTY pins the consent gate's non-interactive
+// detection. The gate refuses to prompt unless stdin is a real
+// terminal, so every non-terminal descriptor must report false — a
+// character-device check alone was not enough, because /dev/null and a
+// closed descriptor are both character devices yet are the most common
+// non-interactive agent/CI stdin shapes. Misreading either as a TTY
+// prints a y/N prompt that immediately reads EOF, the exact failure the
+// gate exists to prevent.
+func TestDefaultStdinIsTTY(t *testing.T) {
+	// This test mutates the process-global os.Stdin, so it must not run
+	// in parallel with other tests that may read it.
+
+	// A custom reader installed via cmd.SetIn signals that the caller
+	// drives the prompt itself (tests, embedded harnesses), so the
+	// gate is allowed to proceed regardless of os.Stdin.
+	t.Run("custom reader proceeds", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.SetIn(bytes.NewBufferString("y\n"))
+
+		require.True(t, defaultStdinIsTTY(cmd))
+	})
+
+	// /dev/null is a character device but not a terminal: the
+	// regression case. It must be refused, not prompted.
+	t.Run("dev null is not a tty", func(t *testing.T) {
+		devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = devNull.Close() })
+
+		withStdin(t, devNull)
+
+		cmd := &cobra.Command{}
+		require.False(t, defaultStdinIsTTY(cmd))
+	})
+
+	// A pipe (the shell `echo | wavecli` shape) is not a terminal.
+	t.Run("pipe is not a tty", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = r.Close()
+			_ = w.Close()
+		})
+
+		withStdin(t, r)
+
+		cmd := &cobra.Command{}
+		require.False(t, defaultStdinIsTTY(cmd))
+	})
+
+	// A closed descriptor (the `wavecli 0<&-` shape) cannot be a
+	// terminal and its Fd ioctl fails, so it too must be refused.
+	t.Run("closed descriptor is not a tty", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		_ = w.Close()
+		require.NoError(t, r.Close())
+
+		withStdin(t, r)
+
+		cmd := &cobra.Command{}
+		require.False(t, defaultStdinIsTTY(cmd))
+	})
+}


### PR DESCRIPTION
In this PR, we fix a bug found while manually testing #987 on the arktest
regtest harness: the refresh consent gate treats `/dev/null` and other
non-terminal character devices as an interactive terminal, so a real
refresh on that stdin prints a `y/N` prompt and then dies on EOF instead
of refusing cleanly.

## The bug

#987 gates a real `ark vtxos refresh` on explicit consent: an interactive
TTY prompts, `--yes` skips the prompt for scripted use, and
non-interactive stdin must refuse with an actionable `INVALID_ARGS` error
directing the caller to `--yes` or `--dry_run`, so an agent is never
blocked on a `y/N` it cannot answer. The refusal is driven by
`defaultStdinIsTTY`, which reported any character device as a terminal.

But `/dev/null` and a closed descriptor -- the most common
non-interactive stdin shapes for agents, CI, and systemd units -- are
character devices that are not terminals. On those, the gate printed the
prompt and then failed with `read confirmation: EOF` (`EXECUTION_FAILED`,
exit 1), the exact hang-then-fail the gate exists to prevent. Only a pipe
(`echo | wavecli`) was refused cleanly.

Observed on the live daemon:

| stdin | before | after |
|---|---|---|
| pipe | `INVALID_ARGS`, exit 2 | `INVALID_ARGS`, exit 2 |
| `/dev/null` | prompt then EOF, exit 1 | `INVALID_ARGS`, exit 2 |
| closed (`0<&-`) | prompt then EOF, exit 1 | `INVALID_ARGS`, exit 2 |

## The fix

We detect a real terminal with `term.IsTerminal` instead of the
character-device heuristic. Every non-terminal stdin now refuses with the
actionable message; the custom-reader path (embedded harnesses that drive
the prompt themselves) is unchanged. The same detector backs the
`leave --all`, `recovery escalate`, and `send` confirmations, so all four
consent gates are fixed at once.

`defaultStdinIsTTY` had no direct test -- the suite stubs the
`stdinIsTTY` indirection, which is how the heuristic shipped. A
regression test now exercises the real function against `/dev/null`, a
pipe, and a closed descriptor (and fails on the old char-device check).

## Validation

- `go test -race -run TestDefaultStdinIsTTY ./cmd/wavecli/waveclicommands/`
- Full refresh/leave/confirm suite under `-race`
- Live re-test against the arktest daemon (table above)
- `make fmt-changed-check`, `make lint-changed-local` (0 issues),
  `make commitmsg-lint`

Found while manually testing #987.
