### PR TITLE
build: bump version to v0.1.0

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -19,7 +19,7 @@ const (
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.
-	AppPreRelease = "rc4"
+	AppPreRelease = ""
 )
 
 var (


### PR DESCRIPTION
Final version bump for the **v0.1.0** release: drops the `-rc4` pre-release suffix in `build/version.go` so waved reports `0.1.0`.

The `v0.1.x-branch` release line already carries the full v0.1.0 content — including the mainnet notls/no-macaroons opt-in (#999) and the refresh-fee follow-ups (#1008–#1010). This is the finalizing tag bump; no functional change.

Part of the coordinated final-release set across lumos, wavelength, and swapdk-server. CI must be green before merge.