### PR TITLE
release: Publish wasm runtime and mobile bindings on release

### DIFF
--- a/.github/workflows/mobile-bindings.yml
+++ b/.github/workflows/mobile-bindings.yml
@@ -2,12 +2,19 @@ name: Mobile Bindings
 
 # The mobile binding package compiles on every relevant PR (a fast, host-tagged
 # build), but the expensive gomobile .aar / .xcframework builds (which cross
-# compile the whole embedded daemon for every ABI) run only when a
-# `mobile-v*` tag is pushed, so routine merges do not trigger them.
+# compile the whole embedded daemon for every ABI) run only on a tag push, so
+# routine merges do not trigger them. Two tag namespaces drive the heavy build:
+# a `mobile-v*` tag for a mobile-only cut (artifacts only), and a `v*` release
+# tag, which additionally attaches the built `.aar` / `.xcframework` to the
+# GitHub release for that tag (see the `publish` job).
 on:
   push:
     tags:
       - "mobile-v*"
+      # Anchored to a digit so only real release tags (v0.1.0, v1.2.3-rc1)
+      # trigger the heavy build and the release-creating publish job, not any
+      # stray `v`-prefixed tag (e.g. `vendor-x`).
+      - "v[0-9]*"
   pull_request:
     paths:
       - "sdk/wavewalletdk/**"
@@ -54,11 +61,11 @@ jobs:
         run: go test -tags="${MOBILE_TAGS}" ./sdk/wavewalletdk/mobile/...
 
   ########################################################################
-  # Android .aar — tag builds only.
+  # Android .aar — tag builds only (mobile-v* or v*).
   ########################################################################
   android:
     name: Build Android .aar
-    if: startsWith(github.ref, 'refs/tags/mobile-v')
+    if: startsWith(github.ref, 'refs/tags/mobile-v') || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
@@ -105,11 +112,11 @@ jobs:
           if-no-files-found: error
 
   ########################################################################
-  # iOS .xcframework — tag builds only (macOS runner for Xcode).
+  # iOS .xcframework — tag builds only, mobile-v* or v* (macOS for Xcode).
   ########################################################################
   ios:
     name: Build iOS .xcframework
-    if: startsWith(github.ref, 'refs/tags/mobile-v')
+    if: startsWith(github.ref, 'refs/tags/mobile-v') || startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
     steps:
       - name: Git checkout
@@ -142,3 +149,69 @@ jobs:
           name: Wavewalletdk-xcframework
           path: Wavewalletdk.xcframework.tar.gz
           if-no-files-found: error
+
+  ########################################################################
+  # Attach the built bindings to the GitHub release — v* tags only.
+  #
+  # A `mobile-v*` tag stops at the artifact uploads above; only a real
+  # release tag (`v*`) publishes the bindings as release assets so that
+  # wavelength-sdk (packages/react-native/scripts/fetch-bindings.sh) can
+  # download a stable set instead of building from a sibling checkout. The
+  # wasm runtime asset set is published separately to the hosted bucket via
+  # `make wasm-publish` (it is not a GitHub release asset).
+  ########################################################################
+  publish:
+    name: Attach bindings to release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [android, ios]
+    runs-on: ubuntu-latest
+    permissions:
+      # Publishing release assets requires write access to repository
+      # contents; the rest of this workflow only needs read.
+      contents: write
+    steps:
+      - name: Download .aar
+        uses: actions/download-artifact@v4
+        with:
+          name: Wavewalletdk-aar
+          path: dist
+
+      - name: Download .xcframework
+        uses: actions/download-artifact@v4
+        with:
+          name: Wavewalletdk-xcframework
+          path: dist
+
+      - name: Publish bindings to the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # Pre-releases (rc / alpha / beta tags) must not be flagged as the
+          # latest stable release.
+          prerelease=""
+          case "$TAG" in
+            *-rc*|*-alpha*|*-beta*) prerelease="--prerelease" ;;
+          esac
+
+          # Create the release on first publish for this tag. A release
+          # manager also cuts the signed waved/wavecli manifest onto this same
+          # release (see docs/release.md); this CI job usually wins the race
+          # since the gomobile builds finish before the manual manifest flow.
+          # We therefore seed a deliberately provisional note (rather than
+          # --generate-notes, which would read as a finished changelog) so it
+          # is obvious the release manager still has to finalize the title/notes
+          # and attach the binaries. This only creates when absent, and the
+          # upload below clobbers, so re-runs are idempotent. --verify-tag
+          # refuses to invent a release for a tag that does not exist.
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG" --verify-tag $prerelease \
+              --notes "Provisional release created by CI to attach the mobile gomobile bindings. The release manager finalizes the notes and attaches the signed \`waved\`/\`wavecli\` binaries + manifest (see docs/release.md)."
+          fi
+
+          gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber \
+            dist/Wavewalletdk.aar \
+            dist/Wavewalletdk.xcframework.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY: unit unit-cover unit-race unit-swapruntime check-go-version build install clean release
 .PHONY: release-install cross-release-install docker-release
 .PHONY: build build-swapruntime build-swapclient build-wavewalletrpc rpc install install-swapruntime install-wavewalletrpc help clean-networks
-.PHONY: mobile mobile-android mobile-ios wasm-wallet
+.PHONY: mobile mobile-android mobile-ios wasm-wallet wasm-publish
 .PHONY: systest systest-verbose
 .PHONY: commitmsg-lint commitmsg-fmt commitmsg-reword
 
@@ -499,6 +499,13 @@ wasm-wallet: #? Build the wavewalletdk browser wasm blob + runtime assets into b
 	# copies writable so re-runs (and callers staging the bundle) aren't
 	# blocked by a read-only destination.
 	chmod -R u+w $(WASM_WALLET_OUT)
+
+wasm-publish: #? Build + upload the wasm runtime asset set to the hosted bucket (tag=<version> bucket=gs://...)
+	@if [ -z "$(tag)" ]; then echo "Must specify tag=<version> (e.g. tag=v0.1.0)!"; exit 1; fi
+	@case "$(bucket)" in "") echo "Must specify bucket=<gs://...> destination root!"; exit 1;; gs://*) ;; *) echo "bucket must be a gs:// URI (got: $(bucket))"; exit 1;; esac
+	@$(MAKE) wasm-wallet
+	@$(call print, "Publishing wasm runtime assets to bucket.")
+	./scripts/publish-wasm-assets.sh "$(tag)" "$(bucket)" "$(WASM_WALLET_OUT)"
 
 install: #? Build and install binaries to GOPATH/bin
 	@$(call print, "Installing binaries.")

--- a/docs/release.md
+++ b/docs/release.md
@@ -49,6 +49,54 @@ archives of the release binaries (`waved` and `wavecli`) for each
 supported operating system and architecture, and a manifest file containing
 the hash of each archive.
 
+## Publishing the wasm and mobile binding assets
+
+The reproducible manifest covers `waved` and `wavecli` only. Two auxiliary
+asset sets that downstream consumers (notably `wavelength-sdk`) depend on are
+published out of band, because they need host toolchains the reproducible
+build deliberately avoids. Neither is part of the signed manifest.
+
+### Browser wasm runtime → hosted bucket
+
+The wasm wallet runtime (`wavewalletdk.wasm`, its gzip, `wasm_exec.js`, and
+the go-wasmsqlite worker assets) is pure Go with no CGO, but the SDK's web app
+serves it from a hosted bucket rather than a GitHub release: it fetches
+`<base>/<version>/<file>` at deploy time, where `<version>` is the SDK's
+`RUNTIME_MANIFEST_VERSION` and must equal the release tag. Publish it at tag
+time with the release manager's own `gcloud` credentials (no CI service
+account is wired for the bucket):
+
+```shell
+$  gcloud auth login            # once, if not already authenticated
+$  make wasm-publish tag=<TAG> bucket=gs://<runtime-assets-bucket>
+```
+
+This builds the runtime (`make wasm-wallet`) and uploads the asset set to
+`gs://<runtime-assets-bucket>/<TAG>/`, which the SDK reads through its HTTPS
+front (`https://staging.lightning.engineering/walletdk/<TAG>/<file>`). The
+file list lives in `scripts/publish-wasm-assets.sh` and must stay in sync with
+the SDK's `RUNTIME_ASSET_FILES`.
+
+### Mobile bindings → GitHub release assets
+
+The gomobile bindings (`Wavewalletdk.aar`, `Wavewalletdk.xcframework`) depend
+on the Android NDK and Xcode, so they are built in CI and attached to the
+GitHub release automatically. The Mobile Bindings workflow
+(`.github/workflows/mobile-bindings.yml`) runs on every `v*` tag: it
+cross-compiles both bindings and its `publish` job creates the release for the
+tag if one does not exist yet, then uploads `Wavewalletdk.aar` and
+`Wavewalletdk.xcframework.tar.gz` as release assets. `wavelength-sdk`'s
+`packages/react-native` consumes these instead of building from a sibling
+checkout. No manual step is required beyond pushing the tag to publish the
+bindings.
+
+Because the gomobile builds are fast, this `publish` job usually creates the
+GitHub release *before* you finish the reproducible manifest flow above. When
+it does, it seeds a deliberately provisional release note. Treat that release
+as a placeholder: once your signed manifest is ready, finalize the release
+title and notes and attach the `waved`/`wavecli` archives and
+`manifest-<TAG>.txt(.sig)` to that same release.
+
 ## Verifying a Release
 
 Third parties can independently run the release process and verify that all

--- a/docs/wavewalletdk_mobile.md
+++ b/docs/wavewalletdk_mobile.md
@@ -141,10 +141,20 @@ devices). The generated Java package is `engineering.lightning.wavewalletdk`.
 > The embedded build pulls in `btcwallet`/`neutrino`/`lnd`, so the `.aar` is
 > large. Measure binary size before shipping.
 
+### Publishing
+
+The commands above are for local development. On a `v*` release tag, CI builds
+both bindings and attaches `Wavewalletdk.aar` and
+`Wavewalletdk.xcframework.tar.gz` to the GitHub release automatically (see the
+`publish` job in [`mobile-bindings.yml`](../.github/workflows/mobile-bindings.yml)).
+The browser wasm runtime is published separately to the hosted bucket via
+`make wasm-publish`. Both flows are documented in
+[`docs/release.md`](release.md#publishing-the-wasm-and-mobile-binding-assets).
+
 ## Sample app
 
 The sample Android app (and, later, iOS app + idiomatic Kotlin/Swift wrappers)
-lives in a separate repo: **[lightninglabs/damobile](https://github.com/lightninglabs/damobile)**.
+lives in a separate repo: **[lightninglabs/wavelength-mobile](https://github.com/lightninglabs/wavelength-mobile)**.
 It consumes the `.aar` this repo produces via a `scripts/fetch-aar.sh` that
 calls `make mobile-android` against a sibling `wavelength` checkout. See that
 repo's README and `docs/signet.md` for the end-to-end run (emulator, signet

--- a/scripts/publish-wasm-assets.sh
+++ b/scripts/publish-wasm-assets.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# publish-wasm-assets.sh uploads the browser wasm runtime asset set to the
+# hosted bucket that the wavelength-sdk web app pulls from. The assets are
+# placed under a per-version directory (<bucket>/<version>/<file>) so that
+# each daemon build gets a unique, immutable URL and a browser can never
+# serve a stale cached runtime. This layout matches the consumer side in
+# wavelength-sdk (apps/web-wallet-demo/scripts/fetch-runtime-assets.sh), which
+# fetches <RUNTIME_ASSETS_BASE_URL>/<RUNTIME_MANIFEST_VERSION>/<file>.
+#
+# Auth is intentionally left to the caller's ambient gcloud credentials
+# (gcloud auth login / application-default). No CI service account is wired
+# for the bucket: releases are cut by a release manager at tag time, who runs
+# this from a machine already authenticated to the project that owns the
+# bucket.
+#
+# Usage:
+#   scripts/publish-wasm-assets.sh <version> <gcs-bucket-uri> [<asset-dir>]
+#
+# Example:
+#   scripts/publish-wasm-assets.sh v0.1.0 gs://my-walletdk-assets
+#
+# The public read URL the SDK points at is:
+#   https://staging.lightning.engineering/walletdk/<version>/<file>
+#
+# <asset-dir> defaults to bin/wasm, where `make wasm-wallet` writes the built
+# runtime. The `make wasm-publish` target builds first, then invokes this.
+
+set -euo pipefail
+
+# The runtime asset set. This list is the source of truth on the publishing
+# side; it must stay in sync with the wavelength-sdk consumer, specifically
+# RUNTIME_ASSET_FILES in packages/web/src/runtime-manifest.ts and the FILES
+# array in apps/web-wallet-demo/scripts/fetch-runtime-assets.sh.
+FILES=(
+  wavewalletdk.wasm
+  wavewalletdk.wasm.gz
+  wasm_exec.js
+  sqlite-bridge.js
+  sqlite-worker.js
+  sqlite3.js
+  sqlite3.wasm
+  sqlite3-opfs-async-proxy.js
+)
+
+function usage() {
+  echo "usage: $0 <version> <gcs-bucket-uri> [<asset-dir>]" >&2
+  echo "  <version>        version segment, e.g. v0.1.0 (must match the SDK's" >&2
+  echo "                   RUNTIME_MANIFEST_VERSION)" >&2
+  echo "  <gcs-bucket-uri> destination bucket root, e.g. gs://my-walletdk-assets" >&2
+  echo "  <asset-dir>      built asset directory (default: bin/wasm)" >&2
+  exit 1
+}
+
+version=${1:-}
+bucket=${2:-}
+asset_dir=${3:-bin/wasm}
+
+if [[ -z "${version// }" || -z "${bucket// }" ]]; then
+  usage
+fi
+
+# Normalize: strip a trailing slash from the bucket, and tolerate a bucket
+# that already includes the version segment (a common copy-paste slip that
+# would otherwise silently nest <version>/<version>/).
+bucket=${bucket%/}
+if [[ "$bucket" == */"$version" ]]; then
+  echo "warning: bucket ends with /$version; treating the parent as the root" >&2
+  bucket=${bucket%/"$version"}
+fi
+
+# Catch a malformed bucket (missing gs://, or a plain path) with an actionable
+# message here rather than a generic gcloud error mid-publish.
+if [[ "$bucket" != gs://* ]]; then
+  echo "error: bucket must be a gs:// URI (got: $bucket)" >&2
+  exit 1
+fi
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "error: gcloud CLI not found; install the Google Cloud SDK and run" >&2
+  echo "       'gcloud auth login' before publishing." >&2
+  exit 1
+fi
+
+# Fail early with an actionable message if the build outputs are missing,
+# rather than letting gcloud report a per-file not-found halfway through.
+missing=0
+for f in "${FILES[@]}"; do
+  if [[ ! -s "$asset_dir/$f" ]]; then
+    echo "error: missing or empty asset: $asset_dir/$f" >&2
+    missing=1
+  fi
+done
+if [[ "$missing" -ne 0 ]]; then
+  echo "build the runtime first: make wasm-wallet" >&2
+  exit 1
+fi
+
+dest="$bucket/$version"
+
+# Fail fast on an expired/missing gcloud session or an unreachable bucket,
+# rather than surfacing it on the first upload — which (see the immutability
+# note below) could leave the version prefix half-published. Listing the bucket
+# root exercises auth and access in one cheap call.
+if ! gcloud storage ls "$bucket/" >/dev/null 2>&1; then
+  echo "error: cannot list $bucket/ — run 'gcloud auth login' and confirm the" >&2
+  echo "       bucket exists and your account has access." >&2
+  exit 1
+fi
+
+# Each <bucket>/<version>/ prefix is meant to be immutable: the SDK derives the
+# URL from the pinned version, and browsers cache it indefinitely. Refuse to
+# overwrite an already-published version unless the caller explicitly sets
+# FORCE=1, so an accidental re-run can't silently replace bytes clients have
+# already cached.
+if gcloud storage ls "$dest/" 2>/dev/null | grep -q .; then
+  if [[ "${FORCE:-}" != "1" ]]; then
+    echo "error: $dest/ already has objects; refusing to overwrite an" >&2
+    echo "       already-published (immutable) version. Re-run with FORCE=1" >&2
+    echo "       only if you are deliberately replacing this version." >&2
+    exit 1
+  fi
+  echo "warning: $dest/ already populated; FORCE=1 set, overwriting." >&2
+fi
+
+echo "Publishing ${#FILES[@]} runtime assets to $dest/"
+
+# Upload each file explicitly (rather than a recursive copy of the directory)
+# so we publish exactly the manifest set and never leak stray files that a
+# previous build may have left in the asset dir.
+#
+# Set Content-Type explicitly per extension. A bucket that serves
+# wavewalletdk.wasm as application/octet-stream makes a browser's
+# WebAssembly.instantiateStreaming reject the module, and gcloud's guess from
+# the local MIME database is unreliable. We never set Content-Encoding:
+# wavewalletdk.wasm.gz is a pre-gzipped payload the consumer fetches and stores
+# verbatim, so it is labelled application/gzip (its true type) rather than
+# application/wasm — the latter without Content-Encoding: gzip would hand a
+# browser gzip bytes as if they were a raw module.
+for f in "${FILES[@]}"; do
+  echo " - $f"
+  case "$f" in
+    *.wasm.gz) content_type=application/gzip ;;
+    *.wasm)    content_type=application/wasm ;;
+    *.js)      content_type=text/javascript ;;
+    *)         content_type= ;;
+  esac
+  if [[ -n "$content_type" ]]; then
+    gcloud storage cp --content-type="$content_type" "$asset_dir/$f" "$dest/$f"
+  else
+    gcloud storage cp "$asset_dir/$f" "$dest/$f"
+  fi
+done
+
+# Per-file cp is not atomic across the set, so a mid-loop failure (auth expiry,
+# a transient error) could leave the version prefix partially published and
+# silently serving 404s for the missing files. Re-list the prefix and confirm
+# every file landed before declaring success.
+echo "Verifying the published set..."
+remote_list="$(gcloud storage ls "$dest/" 2>/dev/null || true)"
+verify_missing=0
+for f in "${FILES[@]}"; do
+  if ! printf '%s\n' "$remote_list" | grep -qxF "$dest/$f"; then
+    echo "error: $f is not present at $dest/ after upload" >&2
+    verify_missing=1
+  fi
+done
+if [[ "$verify_missing" -ne 0 ]]; then
+  echo "publish incomplete — re-run (with FORCE=1) to finish the set." >&2
+  exit 1
+fi
+
+echo "Done. Public read URL base: $dest/ (via the bucket's HTTPS front)."


### PR DESCRIPTION
## Motivation

Closes #1012. The release build covers `waved` and `wavecli`, but the two
asset sets that `wavelength-sdk` depends on aren't published anywhere stable:
the browser wasm runtime is built only via `make wasm-wallet` locally, and the
gomobile bindings live as expiring CI artifacts under a separate `mobile-v*`
tag. Downstream consumers have had to build them by hand or scrape a CI run.

This PR wires both into the release process, along the split the issue
sketched: the wasm runtime goes to the hosted bucket the SDK already reads
from, and the mobile bindings become GitHub release assets on `v*` tags.

## What's in here

**wasm runtime → hosted bucket (`make wasm-publish`).** The SDK's web app
fetches the runtime at `<base>/<version>/<file>`, where the version segment is
its `RUNTIME_MANIFEST_VERSION` and must equal the release tag. Rather than
plumbing a GCP key into CI (the bucket has no CI writer wired), the new target
uploads with the release manager's own `gcloud` credentials at tag time:

```shell
make wasm-publish tag=<TAG> bucket=gs://<runtime-assets-bucket>
```

It builds via `wasm-wallet`, then uploads exactly the manifest file set to
`gs://<bucket>/<TAG>/`. The file list in `scripts/publish-wasm-assets.sh` is
the source of truth on the publishing side and tracks the SDK's
`RUNTIME_ASSET_FILES`. Assets go up as raw bytes with no content-encoding
transform, since `wavewalletdk.wasm.gz` is a pre-gzipped payload the consumer
stores verbatim.

**mobile bindings → GitHub release assets.** The Mobile Bindings workflow now
builds the `.aar`/`.xcframework` on `v*` tags too (not just `mobile-v*`), and a
new `publish` job attaches `Wavewalletdk.aar` and `Wavewalletdk.xcframework.tar.gz`
to the release for the tag. It creates the release when one doesn't exist yet,
so a tag push alone is enough, but stays compatible with a release manager
cutting the signed release out of band: the create is skipped when the release
already exists and the upload clobbers, so re-runs are idempotent. rc/alpha/beta
tags publish as pre-releases. Only the `publish` job carries `contents: write`.

**docs.** `docs/release.md` gains a section on both flows, and the mobile guide
picks up a pointer plus the `damobile` → `wavelength-mobile` repo rename.

## Notes

- The wasm publish is deliberately manual/local, per the decision to use local
  gcloud auth at the final tag rather than adding CI GCP credentials.
- A companion PR on `wavelength-mobile` repoints its fetch scripts at the new
  release assets and catches up the stale `darepo-client`/`darepod`/`Walletdk`
  naming.

## Testing

- `make wasm-publish` dry-run and guards verified; the built `bin/wasm/` set
  matches the script's file list exactly.
- `mobile-bindings.yml` passes YAML validation.
- All three commits pass `make commitmsg-lint`.
