### PR TITLE
ci: Add release build workflow

### DIFF
--- a/.github/workflows/mobile-bindings.yml
+++ b/.github/workflows/mobile-bindings.yml
@@ -179,6 +179,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [android, ios]
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       # Publishing release assets requires write access to repository
       # contents; the rest of this workflow only needs read.
@@ -203,27 +206,26 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Pre-releases (rc / alpha / beta tags) must not be flagged as the
-          # latest stable release.
+          # Release candidates must not be flagged as the latest stable
+          # release.
           prerelease=""
           case "$TAG" in
-            *-rc*|*-alpha*|*-beta*) prerelease="--prerelease" ;;
+            *-rc*) prerelease="--prerelease" ;;
           esac
 
-          # Create the release on first publish for this tag. A release
-          # manager also cuts the signed waved/wavecli manifest onto this same
-          # release (see docs/release.md); this CI job usually wins the race
-          # since the gomobile builds finish before the manual manifest flow.
-          # We therefore seed a deliberately provisional note (rather than
-          # --generate-notes, which would read as a finished changelog) so it
-          # is obvious the release manager still has to finalize the title/notes
-          # and attach the binaries. This only creates when absent, and the
-          # upload below clobbers, so re-runs are idempotent. --verify-tag
-          # refuses to invent a release for a tag that does not exist.
+          # Create a draft release on first publish for this tag. The release
+          # build workflow uploads the waved/wavecli archives and manifest to
+          # this same draft. Either workflow may win the race, so this creates
+          # only when absent and the upload below clobbers existing assets.
+          # --verify-tag refuses to invent a release for a missing tag.
           if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
-              --title "$TAG" --verify-tag $prerelease \
-              --notes "Provisional release created by CI to attach the mobile gomobile bindings. The release manager finalizes the notes and attaches the signed \`waved\`/\`wavecli\` binaries + manifest (see docs/release.md)."
+            if ! gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
+                --draft --title "$TAG" --verify-tag $prerelease \
+                --notes "Provisional draft created by CI to attach the mobile gomobile bindings. The release build workflow attaches the reproducible \`waved\`/\`wavecli\` archives and manifest; maintainers add signatures and publish the release (see docs/release.md)."; then
+              # The release workflow may have created the draft between our
+              # view and create calls. Only tolerate failure if it exists now.
+              gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
+            fi
           fi
 
           gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,104 @@
+name: Release build
+
+on:
+  push:
+    tags:
+      - "v[0-9]*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  # If you change this please also update GO_VERSION in the Makefile and
+  # make/builder.Dockerfile.
+  GO_VERSION: 1.26.0
+
+jobs:
+  main:
+    name: Release build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Clean up space
+        uses: ./.github/actions/cleanup-space
+
+      - name: Setup Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: "false"
+
+      - name: Set release metadata
+        run: |
+          set -euo pipefail
+
+          echo "RELEASE_VERSION=${GITHUB_REF_NAME}" >> "${GITHUB_ENV}"
+          case "${GITHUB_REF_NAME}" in
+            *-rc*) prerelease=true ;;
+            *) prerelease=false ;;
+          esac
+          echo "IS_PRERELEASE=${prerelease}" >> "${GITHUB_ENV}"
+
+      - name: Build release for all architectures
+        run: make docker-release tag="${RELEASE_VERSION}"
+
+      - name: Create draft release
+        uses: lightninglabs/gh-actions/action-gh-release@c7149b6a7818d1c39b36b69e727569897b6f2c5a
+        with:
+          name: wavelength ${{ env.RELEASE_VERSION }}
+          draft: true
+          prerelease: ${{ env.IS_PRERELEASE }}
+          fail_on_unmatched_files: true
+          files: |
+            wavelength-${{ env.RELEASE_VERSION }}/*
+          body: |
+            This draft contains the reproducible `waved` and `wavecli`
+            archives and their manifest. Before publishing it, maintainers
+            must sign `manifest-${{ env.RELEASE_VERSION }}.txt` and attach the
+            detached `manifest-<username>-${{ env.RELEASE_VERSION }}.sig`
+            signatures.
+
+            # Verifying the release
+
+            Use the repository's verification helper to check the signatures
+            and the downloaded binary or archive:
+
+            ```shell
+            ./scripts/verify-install.sh ${{ env.RELEASE_VERSION }} <path>
+            ```
+
+            The binaries are built with Go ${{ env.GO_VERSION }}. Linux users
+            can reproduce all archives with:
+
+            ```shell
+            make release tag=${{ env.RELEASE_VERSION }}
+            ```
+
+            On macOS and other BSD platforms, use the pinned Docker builder:
+
+            ```shell
+            make docker-release tag=${{ env.RELEASE_VERSION }}
+            ```
+
+            See the [reproducible build guide](https://github.com/lightninglabs/wavelength/blob/${{ env.RELEASE_VERSION }}/docs/release.md)
+            for the complete signing and verification process.
+
+            # Release notes
+
+            TODO
+
+            # Contributors
+
+            TODO

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ PKG := github.com/lightninglabs/wavelength
 TOOLS_DIR := tools
 
 GOCC ?= go
+DOCKER ?= docker
+IS_PODMAN := $(shell $(DOCKER) --version 2>/dev/null | \
+	grep -qi podman && echo 1 || echo 0)
 
 GOIMPORTS_PKG := github.com/rinchsan/gosimports/cmd/gosimports
 GOLINT_PKG := github.com/golangci/golangci-lint/v2/cmd/golangci-lint
@@ -173,15 +176,18 @@ VERSION_TAG = $(tag)
 VERSION_CHECK = ./scripts/release.sh check-tag "$(VERSION_TAG)"
 endif
 
-DOCKER_RELEASE_HELPER = docker run \
-  -it \
-  --rm \
-  --user $(shell id -u):$(shell id -g) \
-  -v $(shell pwd):/tmp/build/wavelength \
+# Rootless Podman remaps the host UID/GID, while Docker uses them to keep
+# generated release artifacts owned by the invoking user.
+ifeq ($(IS_PODMAN),1)
+DOCKER_RELEASE_USER_ARGS = --user=0:0
+else
+DOCKER_RELEASE_USER_ARGS = --user $(shell id -u):$(shell id -g)
+endif
+
+DOCKER_RELEASE_ARGS = --rm $(DOCKER_RELEASE_USER_ARGS) \
   -v $(shell bash -c "$(GOCC) env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
   -v $(shell bash -c "$(GOCC) env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
-  -e SKIP_VERSION_CHECK \
-  wavelength-release-helper
+  -e SKIP_VERSION_CHECK
 
 # ============
 # DEPENDENCIES
@@ -561,11 +567,15 @@ docker-release: #? Same as release but within a docker container to support repr
 	@$(call print, "Building release helper docker image.")
 	if [ "$(tag)" = "" ]; then echo "Must specify tag=<commit_or_tag>!"; exit 1; fi
 
-	docker build -t wavelength-release-helper -f make/builder.Dockerfile make/
+	$(DOCKER) build -t wavelength-release-helper \
+		-f make/builder.Dockerfile make/
 
 	# Run the actual compilation inside the docker image. We pass in all
 	# flags that we might want to overwrite in manual tests.
-	$(DOCKER_RELEASE_HELPER) make release tag="$(tag)" sys="$(sys)" COMMIT="$(COMMIT)"
+	$(DOCKER) run $(DOCKER_RELEASE_ARGS) \
+		-v $(shell pwd):/tmp/build/wavelength \
+		wavelength-release-helper \
+		make release tag="$(tag)" sys="$(sys)" COMMIT="$(COMMIT)"
 
 # ============
 # CLEANUP

--- a/docs/release.md
+++ b/docs/release.md
@@ -49,6 +49,18 @@ archives of the release binaries (`waved` and `wavecli`) for each
 supported operating system and architecture, and a manifest file containing
 the hash of each archive.
 
+## Publishing a Release
+
+Pushing a `v*` tag starts the Release Build workflow
+(`.github/workflows/release.yaml`). It runs `make docker-release` with the
+builder image pinned by this repository, then uploads the archives, source
+bundle, vendored dependencies, and manifest to a draft GitHub release. Release
+candidate tags are marked as prereleases.
+
+The release stays a draft until maintainers have signed the manifest and
+uploaded the detached signatures described below. This keeps unsigned assets
+from being presented as a finished release.
+
 ## Publishing the wasm and mobile binding assets
 
 The reproducible manifest covers `waved` and `wavecli` only. Two auxiliary
@@ -81,21 +93,19 @@ the SDK's `RUNTIME_ASSET_FILES`.
 
 The gomobile bindings (`Wavewalletdk.aar`, `Wavewalletdk.xcframework`) depend
 on the Android NDK and Xcode, so they are built in CI and attached to the
-GitHub release automatically. The Mobile Bindings workflow
+draft GitHub release automatically. The Mobile Bindings workflow
 (`.github/workflows/mobile-bindings.yml`) runs on every `v*` tag: it
-cross-compiles both bindings and its `publish` job creates the release for the
-tag if one does not exist yet, then uploads `Wavewalletdk.aar` and
+cross-compiles both bindings and its `publish` job creates a draft release for
+the tag if one does not exist yet, then uploads `Wavewalletdk.aar` and
 `Wavewalletdk.xcframework.tar.gz` as release assets. `wavelength-sdk`'s
 `packages/react-native` consumes these instead of building from a sibling
 checkout. No manual step is required beyond pushing the tag to publish the
 bindings.
 
-Because the gomobile builds are fast, this `publish` job usually creates the
-GitHub release *before* you finish the reproducible manifest flow above. When
-it does, it seeds a deliberately provisional release note. Treat that release
-as a placeholder: once your signed manifest is ready, finalize the release
-title and notes and attach the `waved`/`wavecli` archives and
-`manifest-<TAG>.txt(.sig)` to that same release.
+The Release Build and Mobile Bindings workflows can finish in either order.
+They both target the same draft and create it only when absent, so re-runs do
+not create competing releases. Once the manifest is signed, finalize the title
+and notes, attach the signatures, and publish that draft.
 
 ## Verifying a Release
 

--- a/docs/release_branch_management.md
+++ b/docs/release_branch_management.md
@@ -80,6 +80,9 @@ git push <upstream-remote> v0.1.0
 The helper verifies that HEAD is in sync with the upstream release branch and
 that `build/version.go` matches the requested tag before creating the signed
 tag, then prints the exact push command to run as the final maintainer step.
+Pushing the tag starts the Release Build and Mobile Bindings workflows, which
+populate a draft GitHub release. Sign the generated manifest and publish the
+draft by following [`docs/release.md`](release.md#publishing-a-release).
 
 ### Release Candidate Cycle (optional)
 

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -1,11 +1,12 @@
 # If you change this please also update GO_VERSION in the Makefile (then run
 # `make lint` to see where else it needs to be updated as well).
-FROM golang:1.26.0-bookworm
+FROM golang:1.26.0-bookworm@sha256:2a0ba12e116687098780d3ce700f9ce3cb340783779646aafbabed748fa6677c
 
-MAINTAINER Olaoluwa Osuntokun <laolu32@gmail.com>
+LABEL maintainer="Olaoluwa Osuntokun <laolu32@gmail.com>"
 
 # Golang build related environment variables that are static and used for all
 # architectures/OSes.
+ENV GODEBUG=netdns=cgo
 ENV CGO_ENABLED=0
 
 # Set up cache directories. Those will be mounted from the host system to


### PR DESCRIPTION
## Summary

- adapt Taproot Assets' tag-triggered release workflow to Wavelength
- build reproducible `waved`/`wavecli` assets through `make docker-release` and upload them to a draft GitHub release
- make the Docker helper noninteractive, support rootless Podman ownership, and pin the builder image by digest
- mark only release-candidate (`-rc`) tags as prereleases; stable tags remain regular releases
- coordinate the Mobile Bindings workflow with the same draft release
- document the automated draft, signing, and publication flow

## Taproot Assets adaptation

This follows [Taproot Assets' release workflow](https://github.com/lightninglabs/taproot-assets/blob/main/.github/workflows/release.yaml): validate the version tag, build in the repository's release container, and upload the result to a draft release.

The implementation retains Wavelength's stricter `v<digit>*` tag trigger, pinned action revision, and release-script validation. Wavelength does not use alpha or beta tags in its release process, so only `-rc` tags set GitHub's prerelease flag.

The existing `make docker-release` target is made suitable for hosted CI by removing the TTY requirement. It also adopts Taproot Assets' Docker/Podman user handling and cache mounts. The Go builder base image is pinned by digest for reproducibility.

## Release safety

The existing mobile job could create a public provisional release before the signed manifest was ready. Both tag workflows now create or reuse the same draft release. The mobile create path also tolerates the race where the release workflow creates the draft between its lookup and create calls.

## Validation

- `actionlint v1.7.12 .github/workflows/release.yaml .github/workflows/mobile-bindings.yml`
- parsed both workflow files as YAML
- built `make/builder.Dockerfile` and verified Go 1.26.0 inside the resulting container
- dry-ran `make docker-release tag=v0.0.0-test sys=linux-amd64`
- verified `make docker-release` rejects a missing `tag`
- `make fmt-changed`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`
- `git diff --check`

`make doc-check` reaches nine pre-existing `CLAUDE.md`/`AGENTS.md` synchronization failures in unchanged packages; this PR does not modify those files.
