### PR TITLE
mobile-bindings: Attach WASM runtime to releases

### DIFF
--- a/.github/workflows/mobile-bindings.yml
+++ b/.github/workflows/mobile-bindings.yml
@@ -5,8 +5,9 @@ name: Mobile Bindings
 # compile the whole embedded daemon for every ABI) run only on a tag push, so
 # routine merges do not trigger them. Two tag namespaces drive the heavy build:
 # a `mobile-v*` tag for a mobile-only cut (artifacts only), and a `v*` release
-# tag, which additionally attaches the built `.aar` / `.xcframework` to the
-# GitHub release for that tag (see the `publish` job).
+# tag, which additionally attaches the built `.aar`, `.xcframework`, and
+# browser WASM runtime archive to the GitHub release for that tag (see the
+# `publish` job).
 on:
   push:
     tags:
@@ -165,19 +166,59 @@ jobs:
           if-no-files-found: error
 
   ########################################################################
-  # Attach the built bindings to the GitHub release — v* tags only.
+  # Browser WASM runtime — tag builds only (mobile-v* or v*).
+  ########################################################################
+  wasm:
+    name: Build browser WASM runtime
+    if: startsWith(github.ref, 'refs/tags/mobile-v') || startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build browser WASM runtime
+        run: make wasm-wallet
+
+      - name: Package browser WASM runtime
+        run: |
+          tar -czf Wavewalletdk.wasm.tar.gz -C bin/wasm \
+            wavewalletdk.wasm \
+            wavewalletdk.wasm.gz \
+            wasm_exec.js \
+            sqlite-bridge.js \
+            sqlite-worker.js \
+            sqlite3.js \
+            sqlite3.wasm \
+            sqlite3-opfs-async-proxy.js
+
+      - name: Upload browser WASM runtime
+        uses: actions/upload-artifact@v4
+        with:
+          name: Wavewalletdk-wasm
+          path: Wavewalletdk.wasm.tar.gz
+          if-no-files-found: error
+
+  ########################################################################
+  # Attach the built bindings and WASM runtime to the GitHub release — v*
+  # tags only.
   #
   # A `mobile-v*` tag stops at the artifact uploads above; only a real
   # release tag (`v*`) publishes the bindings as release assets so that
   # wavelength-sdk (packages/react-native/scripts/fetch-bindings.sh) can
   # download a stable set instead of building from a sibling checkout. The
-  # wasm runtime asset set is published separately to the hosted bucket via
-  # `make wasm-publish` (it is not a GitHub release asset).
+  # browser WASM archive is also attached for release distribution; the web
+  # consumer continues to use the separately hosted bucket populated by
+  # `make wasm-publish`.
   ########################################################################
   publish:
     name: Attach bindings to release
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [android, ios]
+    needs: [android, ios, wasm]
     runs-on: ubuntu-latest
     concurrency:
       group: release-${{ github.ref }}
@@ -197,6 +238,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Wavewalletdk-xcframework
+          path: dist
+
+      - name: Download browser WASM runtime
+        uses: actions/download-artifact@v4
+        with:
+          name: Wavewalletdk-wasm
           path: dist
 
       - name: Publish bindings to the GitHub release
@@ -221,7 +268,7 @@ jobs:
           if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             if ! gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
                 --draft --title "$TAG" --verify-tag $prerelease \
-                --notes "Provisional draft created by CI to attach the mobile gomobile bindings. The release build workflow attaches the reproducible \`waved\`/\`wavecli\` archives and manifest; maintainers add signatures and publish the release (see docs/release.md)."; then
+                --notes "Provisional draft created by CI to attach the Android, iOS, and browser WASM bindings. The release build workflow attaches the reproducible \`waved\`/\`wavecli\` archives and manifest; maintainers add signatures and publish the release (see docs/release.md)."; then
               # The release workflow may have created the draft between our
               # view and create calls. Only tolerate failure if it exists now.
               gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
@@ -230,4 +277,5 @@ jobs:
 
           gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber \
             dist/Wavewalletdk.aar \
-            dist/Wavewalletdk.xcframework.tar.gz
+            dist/Wavewalletdk.xcframework.tar.gz \
+            dist/Wavewalletdk.wasm.tar.gz

--- a/docs/release.md
+++ b/docs/release.md
@@ -71,12 +71,11 @@ build deliberately avoids. Neither is part of the signed manifest.
 ### Browser wasm runtime → hosted bucket
 
 The wasm wallet runtime (`wavewalletdk.wasm`, its gzip, `wasm_exec.js`, and
-the go-wasmsqlite worker assets) is pure Go with no CGO, but the SDK's web app
-serves it from a hosted bucket rather than a GitHub release: it fetches
-`<base>/<version>/<file>` at deploy time, where `<version>` is the SDK's
-`RUNTIME_MANIFEST_VERSION` and must equal the release tag. Publish it at tag
-time with the release manager's own `gcloud` credentials (no CI service
-account is wired for the bucket):
+the go-wasmsqlite worker assets) is pure Go with no CGO. The SDK's web app
+serves it from a hosted bucket and fetches `<base>/<version>/<file>` at deploy
+time, where `<version>` is the SDK's `RUNTIME_MANIFEST_VERSION` and must equal
+the release tag. Publish it at tag time with the release manager's own
+`gcloud` credentials (no CI service account is wired for the bucket):
 
 ```shell
 $  gcloud auth login            # once, if not already authenticated
@@ -89,18 +88,25 @@ front (`https://staging.lightning.engineering/walletdk/<TAG>/<file>`). The
 file list lives in `scripts/publish-wasm-assets.sh` and must stay in sync with
 the SDK's `RUNTIME_ASSET_FILES`.
 
+The Mobile Bindings workflow also runs `make wasm-wallet` for release tags,
+packages the complete runtime asset set as `Wavewalletdk.wasm.tar.gz`, and
+attaches that archive to the GitHub release. The archive makes the exact CI
+build available with the Android and iOS bindings, but it does not replace the
+hosted-bucket step required by the web app.
+
 ### Mobile bindings → GitHub release assets
 
 The gomobile bindings (`Wavewalletdk.aar`, `Wavewalletdk.xcframework`) depend
 on the Android NDK and Xcode, so they are built in CI and attached to the
 draft GitHub release automatically. The Mobile Bindings workflow
 (`.github/workflows/mobile-bindings.yml`) runs on every `v*` tag: it
-cross-compiles both bindings and its `publish` job creates a draft release for
-the tag if one does not exist yet, then uploads `Wavewalletdk.aar` and
-`Wavewalletdk.xcframework.tar.gz` as release assets. `wavelength-sdk`'s
-`packages/react-native` consumes these instead of building from a sibling
-checkout. No manual step is required beyond pushing the tag to publish the
-bindings.
+cross-compiles both mobile bindings, builds the browser WASM runtime, and its
+`publish` job creates a draft release for the tag if one does not exist yet.
+It then uploads `Wavewalletdk.aar`, `Wavewalletdk.xcframework.tar.gz`, and
+`Wavewalletdk.wasm.tar.gz` as release assets. `wavelength-sdk`'s
+`packages/react-native` consumes the mobile bindings instead of building from
+a sibling checkout. No manual step is required beyond pushing the tag to
+publish the GitHub release assets.
 
 The Release Build and Mobile Bindings workflows can finish in either order.
 They both target the same draft and create it only when absent, so re-runs do


### PR DESCRIPTION
## Summary

- build the existing browser WASM runtime in the Mobile Bindings workflow on `mobile-v*` and release tag pushes
- package the exact eight-file runtime set as `Wavewalletdk.wasm.tar.gz`
- upload the archive as a workflow artifact and attach it to GitHub releases beside the Android and iOS bindings
- retain `make wasm-publish` as the separate hosted-bucket path used by the web consumer
- document the CI archive and its relationship to hosted bucket publication

## Why

Wavelength already has `make wasm-wallet` and `make wasm-publish`, but no GitHub Actions job builds the browser runtime and no WASM artifact is attached to releases. Release managers therefore cannot retrieve the CI-produced WASM asset set alongside the Android and iOS outputs.

The hosted bucket remains necessary because the web SDK fetches versioned individual files with web-specific content types. The release archive is an additional distribution and audit artifact, not a replacement for that deployment path.

## Validation

- `make wasm-wallet`
- packaged and inspected `Wavewalletdk.wasm.tar.gz`; it contains exactly the eight runtime files and is 39 MiB locally
- `actionlint v1.7.12 .github/workflows/mobile-bindings.yml`
- parsed `.github/workflows/mobile-bindings.yml` as YAML
- `make fmt-changed`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`
- `git diff --check`

`make doc-check` still reports nine pre-existing `CLAUDE.md`/`AGENTS.md` pair divergences on `origin/main`; this PR does not touch those files.
