### PR TITLE
wavecli: Wire process signals into command context

### DIFF
--- a/cmd/wavecli/main.go
+++ b/cmd/wavecli/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/lightninglabs/wavelength/cmd/wavecli/waveclicommands"
 )
@@ -15,9 +18,14 @@ import (
 // we emit a normalized error envelope so stderr stays machine-readable
 // in every failure path.
 func main() {
+	ctx, stop := signal.NotifyContext(
+		context.Background(), os.Interrupt, syscall.SIGTERM,
+	)
+
 	root := waveclicommands.NewRootCmd()
 
-	err := root.Execute()
+	err := root.ExecuteContext(ctx)
+	stop()
 	if err == nil {
 		return
 	}

--- a/cmd/wavecli/waveclicommands/cmd_send.go
+++ b/cmd/wavecli/waveclicommands/cmd_send.go
@@ -3,6 +3,7 @@ package waveclicommands
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -326,8 +327,18 @@ func waitForSendTerminal(cmd *cobra.Command,
 			cmd.OutOrStdout(), sendResultFromEntry(lastEntry),
 		)
 	}
-	timeoutErr := func() error {
+	waitErr := func() error {
 		emitReceipt()
+		if sendWaitErrorCode(ctx.Err()) == "CANCELED" {
+			return PrintError(
+				"CANCELED",
+				fmt.Sprintf(
+					"canceled while waiting for %s; "+
+						"last phase: %s", id,
+					emptyDash(lastPhase),
+				),
+			)
+		}
 
 		return PrintError(
 			"WAIT_TIMEOUT",
@@ -354,7 +365,7 @@ func waitForSendTerminal(cmd *cobra.Command,
 					// timeout, not a hard failure: report
 					// the last phase the user saw.
 					if ctx.Err() != nil {
-						return timeoutErr()
+						return waitErr()
 					}
 
 					// The send itself was accepted, so
@@ -410,13 +421,23 @@ func waitForSendTerminal(cmd *cobra.Command,
 
 				select {
 				case <-ctx.Done():
-					return timeoutErr()
+					return waitErr()
 
 				case <-ticker.C:
 				}
 			}
 		},
 	)
+}
+
+// sendWaitErrorCode distinguishes caller cancellation from expiration of the
+// explicit settlement-wait deadline.
+func sendWaitErrorCode(err error) string {
+	if errors.Is(err, context.Canceled) {
+		return "CANCELED"
+	}
+
+	return "WAIT_TIMEOUT"
 }
 
 // emptyNonEmpty returns value when it is non-empty after trimming, otherwise

--- a/cmd/wavecli/waveclicommands/cmd_send_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_send_test.go
@@ -2,6 +2,7 @@ package waveclicommands
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 
@@ -118,6 +119,15 @@ func TestPromptSendConfirmationDefaultsNo(t *testing.T) {
 
 	err := promptSendConfirmation(cmd, &wavewalletrpc.PrepareSendResponse{})
 	require.ErrorContains(t, err, "aborted by user")
+}
+
+// TestSendWaitErrorCode verifies that a process signal is not reported as an
+// expiration of the independent settlement-wait deadline.
+func TestSendWaitErrorCode(t *testing.T) {
+	require.Equal(t, "CANCELED", sendWaitErrorCode(context.Canceled))
+	require.Equal(
+		t, "WAIT_TIMEOUT", sendWaitErrorCode(context.DeadlineExceeded),
+	)
 }
 
 // TestSendWaitFlagDefaults verifies the wait family is wired with the expected


### PR DESCRIPTION
Addresses P0-10 of #997.

## What changed

- create a process context canceled by SIGINT or SIGTERM
- execute the Cobra tree with `ExecuteContext`
- release signal resources immediately after command execution
- distinguish caller cancellation from expiration of the independent send settlement-wait deadline

## Why

Cobra commands already use `cmd.Context()` in several paths, but the root command previously used `Execute()`, so Ctrl-C and termination signals never reached that context. A canceled send wait also previously surfaced the misleading `WAIT_TIMEOUT` code; it now reports `CANCELED` while preserving the pending receipt.

## Stack context

This PR intentionally contains only P0-10's process wiring. The wider conversion of remaining `context.Background()` RPC calls—including `ark rounds watch`—is #1022, the first P1 item from #997. The two should merge together in that order; duplicating the sweep here would make both reviews describe the same change.

## Concrete impact

Signals now cancel cooperative RPC/stream code, and interrupted send waits no longer claim that their independent five-minute settlement deadline expired. #1022 completes cancellation propagation for the remaining daemon calls and adds a hard second boundary for finite RPCs.

## Validation

- `make unit pkg=./cmd/wavecli/...`
- `go test ./cmd/wavecli/... -race`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`
