### PR TITLE
wavecli: Bound daemon RPC execution

### DIFF
--- a/cmd/wavecli/waveclicommands/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/AGENTS.md
@@ -97,8 +97,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   registered.
 - `getDaemonConn()` / `getDaemonClient()` — TLS-by-default daemon
   gRPC dial; `--no-tls` opts out for local dev.
-- `rpcContext()` — derives a cancellable daemon-RPC context with the global
-  `--timeout` deadline (30 seconds by default; zero disables it).
+- `rpcContext()` — derives a cancellable finite daemon-RPC context with the
+  global `--timeout` deadline (30 seconds by default; zero disables it).
+  Deliberately live streams such as `ark rounds watch` instead use `--for`,
+  `--max-events`, or caller cancellation.
 - `withWalletClient()` — maps `codes.Unimplemented` to
   `errWalletRPCDisabled` (with a pointer to `docs/wavewalletrpc_build.md`)
   for daemons built without the wavewalletrpc tag.

--- a/cmd/wavecli/waveclicommands/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/AGENTS.md
@@ -64,7 +64,7 @@ who want direct access.
 | Command | RPC | Description |
 |---------|-----|-------------|
 | `ark vtxos {list,refresh,leave}` | `ListVTXOs` / `RefreshVTXOs` / `LeaveVTXOs` | VTXO inventory and lifecycle |
-| `ark rounds {get,join,list,watch}` | `GetRound` / (join) / `ListRounds` / `WatchRounds` | Round FSM state; `join` commits queued intents into the next round (`vtxos refresh`/`leave` call it automatically) |
+| `ark rounds {get,join,list,watch}` | `GetRound` / (join) / `ListRounds` / `WatchRounds` | Round FSM state; `join` commits queued intents into the next round (`vtxos refresh`/`leave` call it automatically); `watch --max-events`/`--for` bounds streams for machines |
 | `ark oor {receive,get,list}` | `NewReceiveScript` / `GetOORSession` / `ListOORSessions` | OOR session inspection |
 | `ark board` | `Board` | Trigger boarding with confirmed UTXOs |
 | `ark sweep [list]` | `SweepBoardingUTXOs` / `ListBoardingSweeps` | Boarding-timeout sweeps |
@@ -97,6 +97,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   registered.
 - `getDaemonConn()` / `getDaemonClient()` — TLS-by-default daemon
   gRPC dial; `--no-tls` opts out for local dev.
+- `rpcContext()` — derives a cancellable daemon-RPC context with the global
+  `--timeout` deadline (30 seconds by default; zero disables it).
 - `withWalletClient()` — maps `codes.Unimplemented` to
   `errWalletRPCDisabled` (with a pointer to `docs/wavewalletrpc_build.md`)
   for daemons built without the wavewalletrpc tag.

--- a/cmd/wavecli/waveclicommands/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/CLAUDE.md
@@ -97,8 +97,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   registered.
 - `getDaemonConn()` / `getDaemonClient()` — TLS-by-default daemon
   gRPC dial; `--no-tls` opts out for local dev.
-- `rpcContext()` — derives a cancellable daemon-RPC context with the global
-  `--timeout` deadline (30 seconds by default; zero disables it).
+- `rpcContext()` — derives a cancellable finite daemon-RPC context with the
+  global `--timeout` deadline (30 seconds by default; zero disables it).
+  Deliberately live streams such as `ark rounds watch` instead use `--for`,
+  `--max-events`, or caller cancellation.
 - `withWalletClient()` — maps `codes.Unimplemented` to
   `errWalletRPCDisabled` (with a pointer to `docs/wavewalletrpc_build.md`)
   for daemons built without the wavewalletrpc tag.

--- a/cmd/wavecli/waveclicommands/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/CLAUDE.md
@@ -64,7 +64,7 @@ who want direct access.
 | Command | RPC | Description |
 |---------|-----|-------------|
 | `ark vtxos {list,refresh,leave}` | `ListVTXOs` / `RefreshVTXOs` / `LeaveVTXOs` | VTXO inventory and lifecycle |
-| `ark rounds {get,join,list,watch}` | `GetRound` / (join) / `ListRounds` / `WatchRounds` | Round FSM state; `join` commits queued intents into the next round (`vtxos refresh`/`leave` call it automatically) |
+| `ark rounds {get,join,list,watch}` | `GetRound` / (join) / `ListRounds` / `WatchRounds` | Round FSM state; `join` commits queued intents into the next round (`vtxos refresh`/`leave` call it automatically); `watch --max-events`/`--for` bounds streams for machines |
 | `ark oor {receive,get,list}` | `NewReceiveScript` / `GetOORSession` / `ListOORSessions` | OOR session inspection |
 | `ark board` | `Board` | Trigger boarding with confirmed UTXOs |
 | `ark sweep [list]` | `SweepBoardingUTXOs` / `ListBoardingSweeps` | Boarding-timeout sweeps |
@@ -97,6 +97,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   registered.
 - `getDaemonConn()` / `getDaemonClient()` — TLS-by-default daemon
   gRPC dial; `--no-tls` opts out for local dev.
+- `rpcContext()` — derives a cancellable daemon-RPC context with the global
+  `--timeout` deadline (30 seconds by default; zero disables it).
 - `withWalletClient()` — maps `codes.Unimplemented` to
   `errWalletRPCDisabled` (with a pointer to `docs/wavewalletrpc_build.md`)
   for daemons built without the wavewalletrpc tag.

--- a/cmd/wavecli/waveclicommands/cmd_ark.go
+++ b/cmd/wavecli/waveclicommands/cmd_ark.go
@@ -117,7 +117,10 @@ func listTransactions(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.ListTransactions(cmd.Context(), req)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.ListTransactions(ctx, req)
 	if err != nil {
 		return fmt.Errorf("ListTransactions RPC failed: %w", err)
 	}

--- a/cmd/wavecli/waveclicommands/cmd_ark_send.go
+++ b/cmd/wavecli/waveclicommands/cmd_ark_send.go
@@ -151,7 +151,10 @@ func sendInRound(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.SendVTXO(cmd.Context(), req)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.SendVTXO(ctx, req)
 	if err != nil {
 		if feeErr := mapFeeError(err); feeErr != nil {
 			return feeErr
@@ -219,7 +222,10 @@ func sendOOR(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.SendOOR(cmd.Context(), req)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.SendOOR(ctx, req)
 	if err != nil {
 		return fmt.Errorf("SendOOR RPC failed: %w", err)
 	}

--- a/cmd/wavecli/waveclicommands/cmd_balance.go
+++ b/cmd/wavecli/waveclicommands/cmd_balance.go
@@ -31,8 +31,11 @@ func newBalanceCmd() *cobra.Command {
 func walletBalance(cmd *cobra.Command, _ []string) error {
 	return withWalletClient(
 		cmd, func(c wavewalletrpc.WalletServiceClient) error {
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
 			resp, err := c.Balance(
-				cmd.Context(), &wavewalletrpc.BalanceRequest{},
+				ctx, &wavewalletrpc.BalanceRequest{},
 			)
 			if err != nil {
 				return fmt.Errorf("balance: %w", err)

--- a/cmd/wavecli/waveclicommands/cmd_board.go
+++ b/cmd/wavecli/waveclicommands/cmd_board.go
@@ -1,7 +1,6 @@
 package waveclicommands
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/lightninglabs/wavelength/waverpc"
@@ -58,7 +57,10 @@ func board(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.Board(context.Background(), req)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.Board(ctx, req)
 	if err != nil {
 		// Map well-known server-side fee rejections to a
 		// concise CLI message. Fall through to the generic

--- a/cmd/wavecli/waveclicommands/cmd_create.go
+++ b/cmd/wavecli/waveclicommands/cmd_create.go
@@ -119,8 +119,11 @@ func walletCreate(cmd *cobra.Command, _ []string) error {
 
 	return withWalletClient(
 		cmd, func(c wavewalletrpc.WalletServiceClient) error {
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
 			resp, err := c.Create(
-				cmd.Context(), &wavewalletrpc.CreateRequest{
+				ctx, &wavewalletrpc.CreateRequest{
 					WalletPassword: password,
 					SeedPassphrase: seedPassphrase,
 					Mnemonic:       mnemonic,

--- a/cmd/wavecli/waveclicommands/cmd_exit.go
+++ b/cmd/wavecli/waveclicommands/cmd_exit.go
@@ -103,7 +103,10 @@ func walletExit(cmd *cobra.Command, _ []string) error {
 
 	return withWalletClient(
 		cmd, func(c wavewalletrpc.WalletServiceClient) error {
-			resp, err := c.Exit(cmd.Context(), req)
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
+			resp, err := c.Exit(ctx, req)
 			if err != nil {
 				return fmt.Errorf("exit: %w", err)
 			}
@@ -158,8 +161,11 @@ func walletExitStatus(cmd *cobra.Command, _ []string) error {
 
 	return withWalletClient(
 		cmd, func(c wavewalletrpc.WalletServiceClient) error {
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
 			resp, err := c.ExitStatus(
-				cmd.Context(),
+				ctx,
 				&wavewalletrpc.ExitStatusRequest{
 					Outpoint: outpoint,
 					Detailed: detailed,
@@ -200,9 +206,11 @@ func newExitSummaryCmd() *cobra.Command {
 func walletExitSummary(cmd *cobra.Command, _ []string) error {
 	return withWalletClient(
 		cmd, func(c wavewalletrpc.WalletServiceClient) error {
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
 			resp, err := c.ExitSummary(
-				cmd.Context(),
-				&wavewalletrpc.ExitSummaryRequest{},
+				ctx, &wavewalletrpc.ExitSummaryRequest{},
 			)
 			if err != nil {
 				return fmt.Errorf("exit summary: %w", err)
@@ -256,8 +264,11 @@ func walletExitPlan(cmd *cobra.Command, _ []string) error {
 
 	return withWalletClient(
 		cmd, func(c wavewalletrpc.WalletServiceClient) error {
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
 			resp, err := c.GetExitPlan(
-				cmd.Context(),
+				ctx,
 				&wavewalletrpc.GetExitPlanRequest{
 					Outpoints: outpoints,
 				},

--- a/cmd/wavecli/waveclicommands/cmd_fees.go
+++ b/cmd/wavecli/waveclicommands/cmd_fees.go
@@ -1,7 +1,6 @@
 package waveclicommands
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -113,9 +112,10 @@ func feesEstimate(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.EstimateFee(
-		context.Background(), req,
-	)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.EstimateFee(ctx, req)
 	if err != nil {
 		return fmt.Errorf("EstimateFee RPC failed: %w", err)
 	}
@@ -179,9 +179,10 @@ func feesHistory(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.GetFeeHistory(
-		context.Background(), req,
-	)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.GetFeeHistory(ctx, req)
 	if err != nil {
 		return fmt.Errorf("GetFeeHistory RPC failed: %w", err)
 	}

--- a/cmd/wavecli/waveclicommands/cmd_getinfo.go
+++ b/cmd/wavecli/waveclicommands/cmd_getinfo.go
@@ -1,7 +1,6 @@
 package waveclicommands
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/lightninglabs/wavelength/waverpc"
@@ -35,7 +34,10 @@ func getInfo(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.GetInfo(context.Background(), req)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.GetInfo(ctx, req)
 	if err != nil {
 		return fmt.Errorf("GetInfo RPC failed: %w", err)
 	}

--- a/cmd/wavecli/waveclicommands/cmd_inspect.go
+++ b/cmd/wavecli/waveclicommands/cmd_inspect.go
@@ -42,7 +42,10 @@ func inspectActivity(cmd *cobra.Command, args []string) error {
 
 	return withWalletInspectionClient(
 		cmd, func(c wavewalletrpc.WalletInspectionServiceClient) error {
-			resp, err := c.InspectActivity(cmd.Context(), req)
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
+			resp, err := c.InspectActivity(ctx, req)
 			if err != nil {
 				return fmt.Errorf("activity inspect: %w", err)
 			}

--- a/cmd/wavecli/waveclicommands/cmd_list.go
+++ b/cmd/wavecli/waveclicommands/cmd_list.go
@@ -72,7 +72,10 @@ func walletActivity(cmd *cobra.Command, _ []string) error {
 
 	return withWalletClient(
 		cmd, func(c wavewalletrpc.WalletServiceClient) error {
-			resp, err := c.List(cmd.Context(), req)
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
+			resp, err := c.List(ctx, req)
 			if err != nil {
 				return fmt.Errorf("activity: %w", err)
 			}

--- a/cmd/wavecli/waveclicommands/cmd_oor.go
+++ b/cmd/wavecli/waveclicommands/cmd_oor.go
@@ -1,7 +1,6 @@
 package waveclicommands
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -118,7 +117,10 @@ func oorGet(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.GetOORSession(context.Background(), req)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.GetOORSession(ctx, req)
 	if err != nil {
 		return fmt.Errorf("GetOORSession RPC failed: %w", err)
 	}
@@ -163,7 +165,10 @@ func oorList(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.ListOORSessions(context.Background(), req)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.ListOORSessions(ctx, req)
 	if err != nil {
 		return fmt.Errorf("ListOORSessions RPC failed: %w", err)
 	}
@@ -196,9 +201,10 @@ func oorReceive(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.NewReceiveScript(
-		context.Background(), req,
-	)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.NewReceiveScript(ctx, req)
 	if err != nil {
 		return fmt.Errorf("NewReceiveScript RPC failed: %w", err)
 	}

--- a/cmd/wavecli/waveclicommands/cmd_recovery.go
+++ b/cmd/wavecli/waveclicommands/cmd_recovery.go
@@ -54,8 +54,11 @@ func newRecoveryListCmd() *cobra.Command {
 			includeTerminal, _ := cmd.Flags().GetBool(
 				"include-terminal",
 			)
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
 			resp, err := client.ListVHTLCRecoveries(
-				cmd.Context(),
+				ctx,
 				&waverpc.ListVHTLCRecoveriesRequest{
 					IncludeTerminal: includeTerminal,
 				},
@@ -88,8 +91,11 @@ func newRecoveryStatusCmd() *cobra.Command {
 			}
 			defer conn.Close()
 
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
 			resp, err := client.GetVHTLCRecoveryStatus(
-				cmd.Context(),
+				ctx,
 				&waverpc.GetVHTLCRecoveryStatusRequest{
 					RecoveryId: args[0],
 				},
@@ -132,8 +138,11 @@ func newRecoveryEscalateCmd() *cobra.Command {
 				return err
 			}
 
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
 			resp, err := client.EscalateVHTLCRecovery(
-				cmd.Context(),
+				ctx,
 				&waverpc.EscalateVHTLCRecoveryRequest{
 					RecoveryId:    args[0],
 					Reason:        reason,
@@ -176,8 +185,11 @@ func newRecoveryCancelCmd() *cobra.Command {
 			reason, _ := cmd.Flags().GetString("reason")
 			txid, _ := cmd.Flags().GetString("cooperative-txid")
 
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
 			resp, err := client.CancelVHTLCRecovery(
-				cmd.Context(),
+				ctx,
 				&waverpc.CancelVHTLCRecoveryRequest{
 					RecoveryId:      args[0],
 					Reason:          reason,

--- a/cmd/wavecli/waveclicommands/cmd_recv.go
+++ b/cmd/wavecli/waveclicommands/cmd_recv.go
@@ -76,9 +76,12 @@ func walletRecv(cmd *cobra.Command, _ []string) error {
 
 	return withWalletClient(
 		cmd, func(c wavewalletrpc.WalletServiceClient) error {
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
 			if offchain {
 				resp, err := c.Recv(
-					cmd.Context(),
+					ctx,
 					&wavewalletrpc.RecvRequest{
 						AmtSat: amt,
 						Memo:   memo,
@@ -93,7 +96,7 @@ func walletRecv(cmd *cobra.Command, _ []string) error {
 			}
 
 			resp, err := c.Deposit(
-				cmd.Context(),
+				ctx,
 				&wavewalletrpc.DepositRequest{
 					AmtSatHint: amtHint,
 				},

--- a/cmd/wavecli/waveclicommands/cmd_rounds.go
+++ b/cmd/wavecli/waveclicommands/cmd_rounds.go
@@ -89,7 +89,7 @@ func newRoundsJoinCmd() *cobra.Command {
 
 // newRoundsWatchCmd creates the 'rounds watch' subcommand.
 func newRoundsWatchCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "watch",
 		Short: "Stream round state updates",
 		Long: "Opens a server-streaming connection " +
@@ -97,6 +97,13 @@ func newRoundsWatchCmd() *cobra.Command {
 			"as they occur. Press Ctrl-C to stop.",
 		RunE: roundsWatch,
 	}
+
+	cmd.Flags().Uint32("max-events", 0,
+		"stop after this many updates; 0 has no event-count limit")
+	cmd.Flags().Duration("for", 0,
+		"watch for this duration instead of the global --timeout")
+
+	return cmd
 }
 
 // roundsGet executes the GetRound RPC and prints the result.
@@ -121,7 +128,10 @@ func roundsGet(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.GetRound(context.Background(), req)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.GetRound(ctx, req)
 	if err != nil {
 		return fmt.Errorf("GetRound RPC failed: %w", err)
 	}
@@ -170,7 +180,10 @@ func roundsList(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.ListRounds(context.Background(), req)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.ListRounds(ctx, req)
 	if err != nil {
 		return fmt.Errorf("ListRounds RPC failed: %w", err)
 	}
@@ -200,7 +213,10 @@ func roundsJoin(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.JoinNextRound(cmd.Context(), req)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.JoinNextRound(ctx, req)
 	if err != nil {
 		return fmt.Errorf("JoinNextRound RPC failed: %w", err)
 	}
@@ -211,30 +227,54 @@ func roundsJoin(cmd *cobra.Command, _ []string) error {
 // roundsWatch executes the WatchRounds streaming RPC and prints
 // each state update as it arrives.
 func roundsWatch(cmd *cobra.Command, _ []string) error {
+	maxEvents, _ := cmd.Flags().GetUint32("max-events")
+	watchFor, _ := cmd.Flags().GetDuration("for")
+	if watchFor < 0 {
+		return invalidArgs(fmt.Errorf("--for must be non-negative"))
+	}
+
 	client, conn, err := getDaemonClient(cmd)
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
 
-	stream, err := client.WatchRounds(
-		context.Background(), &waverpc.WatchRoundsRequest{},
-	)
+	ctx, cancel := rpcContext(cmd)
+	if watchFor > 0 {
+		cancel()
+		ctx, cancel = context.WithTimeout(cmd.Context(), watchFor)
+	}
+	defer cancel()
+
+	stream, err := client.WatchRounds(ctx, &waverpc.WatchRoundsRequest{})
 	if err != nil {
 		return fmt.Errorf("WatchRounds RPC failed: %w", err)
 	}
 
+	var events uint32
 	for {
 		resp, err := stream.Recv()
 		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {
+			if errors.Is(ctx.Err(), context.Canceled) ||
+				(watchFor > 0 && errors.Is(
+					ctx.Err(), context.DeadlineExceeded,
+				)) {
+				return nil
+			}
+
 			return fmt.Errorf("stream error: %w", err)
 		}
 
 		if err := printJSON(resp); err != nil {
 			return err
+		}
+
+		events++
+		if maxEvents > 0 && events >= maxEvents {
+			return nil
 		}
 	}
 }

--- a/cmd/wavecli/waveclicommands/cmd_rounds.go
+++ b/cmd/wavecli/waveclicommands/cmd_rounds.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/spf13/cobra"
@@ -239,11 +240,7 @@ func roundsWatch(cmd *cobra.Command, _ []string) error {
 	}
 	defer conn.Close()
 
-	ctx, cancel := rpcContext(cmd)
-	if watchFor > 0 {
-		cancel()
-		ctx, cancel = context.WithTimeout(cmd.Context(), watchFor)
-	}
+	ctx, cancel := roundsWatchContext(cmd, watchFor)
 	defer cancel()
 
 	stream, err := client.WatchRounds(ctx, &waverpc.WatchRoundsRequest{})
@@ -277,6 +274,20 @@ func roundsWatch(cmd *cobra.Command, _ []string) error {
 			return nil
 		}
 	}
+}
+
+// roundsWatchContext keeps an unbounded watch alive until caller cancellation
+// unless the caller supplies the stream-specific --for limit. The global RPC
+// timeout applies to finite daemon calls, not to a deliberately live stream.
+func roundsWatchContext(cmd *cobra.Command,
+	watchFor time.Duration) (context.Context, context.CancelFunc) {
+
+	parent := commandContext(cmd)
+	if watchFor > 0 {
+		return context.WithTimeout(parent, watchFor)
+	}
+
+	return context.WithCancel(parent)
 }
 
 // parseRoundStateFilter converts a CLI state filter into the proto enum.

--- a/cmd/wavecli/waveclicommands/cmd_send.go
+++ b/cmd/wavecli/waveclicommands/cmd_send.go
@@ -181,7 +181,9 @@ func walletSend(cmd *cobra.Command, args []string) error {
 
 	return withWalletClient(
 		cmd, func(c wavewalletrpc.WalletServiceClient) error {
-			prepareResp, err := c.PrepareSend(cmd.Context(), req)
+			prepareCtx, cancelPrepare := rpcContext(cmd)
+			prepareResp, err := c.PrepareSend(prepareCtx, req)
+			cancelPrepare()
 			if err != nil {
 				return fmt.Errorf("prepare send: %w", err)
 			}
@@ -206,11 +208,13 @@ func walletSend(cmd *cobra.Command, args []string) error {
 			}
 
 			intentID := prepareResp.GetSendIntentId()
+			sendCtx, cancelSend := rpcContext(cmd)
 			resp, err := c.Send(
-				cmd.Context(), &wavewalletrpc.SendRequest{
+				sendCtx, &wavewalletrpc.SendRequest{
 					SendIntentId: intentID,
 				},
 			)
+			cancelSend()
 			if err != nil {
 				return fmt.Errorf("send prepared intent: %w",
 					err)

--- a/cmd/wavecli/waveclicommands/cmd_send.go
+++ b/cmd/wavecli/waveclicommands/cmd_send.go
@@ -352,7 +352,9 @@ func waitForSendTerminal(cmd *cobra.Command,
 				req := &wavewalletrpc.InspectActivityRequest{
 					Id: id,
 				}
-				resp, err := c.InspectActivity(ctx, req)
+				pollCtx, cancel := rpcContextFrom(cmd, ctx)
+				resp, err := c.InspectActivity(pollCtx, req)
+				cancel()
 				if err != nil {
 					// A deadline hit while polling is a
 					// timeout, not a hard failure: report

--- a/cmd/wavecli/waveclicommands/cmd_sweep.go
+++ b/cmd/wavecli/waveclicommands/cmd_sweep.go
@@ -1,7 +1,6 @@
 package waveclicommands
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -112,7 +111,10 @@ func sweep(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.SweepBoardingUTXOs(context.Background(), req)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.SweepBoardingUTXOs(ctx, req)
 	if err != nil {
 		return fmt.Errorf("SweepBoardingUTXOs RPC failed: %w", err)
 	}
@@ -139,7 +141,10 @@ func sweepList(cmd *cobra.Command, _ []string) error {
 		PageToken: pageToken,
 	}
 
-	resp, err := client.ListBoardingSweeps(context.Background(), req)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.ListBoardingSweeps(ctx, req)
 	if err != nil {
 		return fmt.Errorf("ListBoardingSweeps RPC failed: %w", err)
 	}

--- a/cmd/wavecli/waveclicommands/cmd_sweep_wallet.go
+++ b/cmd/wavecli/waveclicommands/cmd_sweep_wallet.go
@@ -79,7 +79,10 @@ func walletSweep(cmd *cobra.Command, _ []string) error {
 
 	return withWalletClient(
 		cmd, func(c wavewalletrpc.WalletServiceClient) error {
-			resp, err := c.SweepWallet(cmd.Context(), req)
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
+			resp, err := c.SweepWallet(ctx, req)
 			if err != nil {
 				return fmt.Errorf("wallet sweep: %w", err)
 			}

--- a/cmd/wavecli/waveclicommands/cmd_unlock.go
+++ b/cmd/wavecli/waveclicommands/cmd_unlock.go
@@ -42,8 +42,11 @@ func walletUnlock(cmd *cobra.Command, _ []string) error {
 
 	return withWalletClient(
 		cmd, func(c wavewalletrpc.WalletServiceClient) error {
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
 			resp, err := c.Unlock(
-				cmd.Context(), &wavewalletrpc.UnlockRequest{
+				ctx, &wavewalletrpc.UnlockRequest{
 					WalletPassword: password,
 				},
 			)

--- a/cmd/wavecli/waveclicommands/cmd_vtxos.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos.go
@@ -104,10 +104,10 @@ func vtxosList(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// cmd.Context() carries Ctrl+C / SIGTERM so the RPC actually
-	// cancels when the user interrupts the CLI. context.Background()
-	// here would orphan the request until the daemon responded.
-	resp, err := client.ListVTXOs(cmd.Context(), req)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.ListVTXOs(ctx, req)
 	if err != nil {
 		return fmt.Errorf("ListVTXOs RPC failed: %w", err)
 	}
@@ -256,15 +256,19 @@ func vtxosRefresh(cmd *cobra.Command, _ []string) error {
 		cmd, req, func(preview *waverpc.RefreshVTXOsRequest) (
 			*waverpc.RefreshVTXOsResponse, error) {
 
-			return client.RefreshVTXOs(cmd.Context(), preview)
+			ctx, cancel := rpcContext(cmd)
+			defer cancel()
+
+			return client.RefreshVTXOs(ctx, preview)
 		},
 	); err != nil {
 		return err
 	}
 
-	resp, err := client.RefreshVTXOs(
-		cmd.Context(), req,
-	)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.RefreshVTXOs(ctx, req)
 	if err != nil {
 		return fmt.Errorf("RefreshVTXOs RPC failed: %w", err)
 	}
@@ -606,9 +610,10 @@ func vtxosLeave(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	resp, err := client.LeaveVTXOs(
-		cmd.Context(), req,
-	)
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	resp, err := client.LeaveVTXOs(ctx, req)
 	if err != nil {
 		return fmt.Errorf("LeaveVTXOs RPC failed: %w", err)
 	}
@@ -670,8 +675,11 @@ func maybeJoinNextRound(cmd *cobra.Command, client waverpc.DaemonServiceClient,
 	decision := decideAutoJoin(dryRun, noJoin)
 
 	if decision.Join {
+		ctx, cancel := rpcContext(cmd)
+		defer cancel()
+
 		resp, err := client.JoinNextRound(
-			cmd.Context(), &waverpc.JoinNextRoundRequest{},
+			ctx, &waverpc.JoinNextRoundRequest{},
 		)
 		if err != nil {
 			return fmt.Errorf("auto-join next round failed: %w",

--- a/cmd/wavecli/waveclicommands/devrpc/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/devrpc/AGENTS.md
@@ -11,7 +11,8 @@ hand-written code.
 ## Key Types
 
 - `Config` — Integration glue: `GetConn(cmd) → *grpc.ClientConn` (dial
-  function), `PrintJSON(proto.Message) error` (output sink),
+  function), `RPCContext(cmd) → (context.Context, CancelFunc)` (bounded RPC
+  lifetime), `PrintJSON(proto.Message) error` (output sink), and
   `MapRPCError(error) error` (error humanization).
 - `NewDevCmd(cfg) *cobra.Command` — Creates the generated dev RPC command
   tree rooted at `dev`. Child commands are organized by service then method.

--- a/cmd/wavecli/waveclicommands/devrpc/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/devrpc/CLAUDE.md
@@ -11,7 +11,8 @@ hand-written code.
 ## Key Types
 
 - `Config` — Integration glue: `GetConn(cmd) → *grpc.ClientConn` (dial
-  function), `PrintJSON(proto.Message) error` (output sink),
+  function), `RPCContext(cmd) → (context.Context, CancelFunc)` (bounded RPC
+  lifetime), `PrintJSON(proto.Message) error` (output sink), and
   `MapRPCError(error) error` (error humanization).
 - `NewDevCmd(cfg) *cobra.Command` — Creates the generated dev RPC command
   tree rooted at `dev`. Child commands are organized by service then method.

--- a/cmd/wavecli/waveclicommands/devrpc/command.go
+++ b/cmd/wavecli/waveclicommands/devrpc/command.go
@@ -154,17 +154,23 @@ func runMethod(cmd *cobra.Command, cfg Config, service protoreflect.FullName,
 	}
 	defer conn.Close()
 
+	ctx := cmd.Context()
+	cancel := func() {}
+	if cfg.RPCContext != nil {
+		ctx, cancel = cfg.RPCContext(cmd)
+	}
+	defer cancel()
+
 	fullMethod := "/" + string(service) + "/" + string(method.spec.Name)
 	if method.spec.ServerStreaming {
 		return runServerStream(
-			cmd.Context(), cfg, conn, fullMethod, method.output,
-			req,
+			ctx, cfg, conn, fullMethod, method.output, req,
 		)
 	}
 
 	resp := dynamicpb.NewMessage(method.output)
 	if err := conn.Invoke(
-		cmd.Context(), fullMethod, req, resp,
+		ctx, fullMethod, req, resp,
 	); err != nil {
 		return mapRPCError(cfg, err)
 	}

--- a/cmd/wavecli/waveclicommands/devrpc/types.go
+++ b/cmd/wavecli/waveclicommands/devrpc/types.go
@@ -1,6 +1,8 @@
 package devrpc
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
@@ -20,6 +22,9 @@ type Config struct {
 
 	// MapRPCError maps low-level gRPC errors into user-facing CLI errors.
 	MapRPCError func(error) error
+
+	// RPCContext derives the bounded context for one daemon RPC.
+	RPCContext func(*cobra.Command) (context.Context, context.CancelFunc)
 }
 
 type serviceSpec struct {

--- a/cmd/wavecli/waveclicommands/root.go
+++ b/cmd/wavecli/waveclicommands/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/lightninglabs/wavelength/build"
 	"github.com/lightninglabs/wavelength/cmd/wavecli/waveclicommands/devrpc"
@@ -15,7 +16,8 @@ import (
 
 const (
 	// defaultRPCServer is the default gRPC endpoint for the daemon.
-	defaultRPCServer = "localhost:10029"
+	defaultRPCServer  = "localhost:10029"
+	defaultRPCTimeout = 30 * time.Second
 
 	// groupWallet, groupIntrospection, and groupAdvanced are the cobra
 	// command-group IDs that shape the default --help face.
@@ -30,7 +32,7 @@ const (
 )
 
 // NewRootCmd creates the top-level cobra command for wavecli. Global
-// flags (--rpcserver, --format, --tlscertpath, --macaroonpath, --no-tls) are
+// flags (--rpcserver, --timeout, --tlscertpath, --macaroonpath, --no-tls) are
 // registered here and made available to all subcommands via PersistentFlags.
 //
 // The advanced subtrees (ark / dev / recovery) are hidden from the default
@@ -95,6 +97,11 @@ func newRootCmd(devMode bool) *cobra.Command {
 			"for daemon connection (dev/regtest)",
 	)
 
+	pf.Duration(
+		"timeout", defaultRPCTimeout,
+		"maximum duration for each daemon RPC; 0 disables the deadline",
+	)
+
 	pf.String(
 		"json", "", "raw JSON request payload (maps directly to "+
 			"the RPC request proto); when set, bespoke flags "+
@@ -147,6 +154,7 @@ func newRootCmd(devMode bool) *cobra.Command {
 				GetConn:     getDaemonConn,
 				PrintJSON:   printJSON,
 				MapRPCError: mapSwapRuntimeRPCError,
+				RPCContext:  rpcContext,
 			},
 		),
 	}

--- a/cmd/wavecli/waveclicommands/rpc_context.go
+++ b/cmd/wavecli/waveclicommands/rpc_context.go
@@ -11,10 +11,14 @@ import (
 // RPC timeout. A zero timeout disables the deadline while preserving signal
 // and caller cancellation.
 func rpcContext(cmd *cobra.Command) (context.Context, context.CancelFunc) {
-	parent := cmd.Context()
-	if parent == nil {
-		parent = context.Background()
-	}
+	return rpcContextFrom(cmd, commandContext(cmd))
+}
+
+// rpcContextFrom returns a child of parent bounded by the global RPC timeout.
+// It lets multi-step commands apply the per-RPC bound inside their separate
+// overall operation deadline.
+func rpcContextFrom(cmd *cobra.Command,
+	parent context.Context) (context.Context, context.CancelFunc) {
 
 	rawTimeout, err := cliStringFlag(cmd, "timeout")
 	if err != nil {
@@ -22,12 +26,20 @@ func rpcContext(cmd *cobra.Command) (context.Context, context.CancelFunc) {
 	}
 
 	timeout, err := time.ParseDuration(rawTimeout)
-	if err != nil {
-		return context.WithCancel(parent)
-	}
-	if timeout <= 0 {
+	if err != nil || timeout <= 0 {
 		return context.WithCancel(parent)
 	}
 
 	return context.WithTimeout(parent, timeout)
+}
+
+// commandContext returns the command's caller-owned context or a background
+// context for direct command invocations that did not install one.
+func commandContext(cmd *cobra.Command) context.Context {
+	parent := cmd.Context()
+	if parent == nil {
+		parent = context.Background()
+	}
+
+	return parent
 }

--- a/cmd/wavecli/waveclicommands/rpc_context.go
+++ b/cmd/wavecli/waveclicommands/rpc_context.go
@@ -1,0 +1,33 @@
+package waveclicommands
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// rpcContext returns a child of the command context bounded by the global
+// RPC timeout. A zero timeout disables the deadline while preserving signal
+// and caller cancellation.
+func rpcContext(cmd *cobra.Command) (context.Context, context.CancelFunc) {
+	parent := cmd.Context()
+	if parent == nil {
+		parent = context.Background()
+	}
+
+	rawTimeout, err := cliStringFlag(cmd, "timeout")
+	if err != nil {
+		return context.WithCancel(parent)
+	}
+
+	timeout, err := time.ParseDuration(rawTimeout)
+	if err != nil {
+		return context.WithCancel(parent)
+	}
+	if timeout <= 0 {
+		return context.WithCancel(parent)
+	}
+
+	return context.WithTimeout(parent, timeout)
+}

--- a/cmd/wavecli/waveclicommands/rpc_context_test.go
+++ b/cmd/wavecli/waveclicommands/rpc_context_test.go
@@ -44,6 +44,25 @@ func TestRPCContextAllowsDisablingTimeout(t *testing.T) {
 	require.ErrorIs(t, ctx.Err(), context.Canceled)
 }
 
+// TestRPCContextFromBoundsOneStep verifies that a multi-step command can apply
+// the global timeout to one RPC without replacing its overall parent context.
+func TestRPCContextFromBoundsOneStep(t *testing.T) {
+	t.Parallel()
+
+	cmd := findRootCommand(t, newRootCmd(false), "getinfo")
+	parent, parentCancel := context.WithCancel(t.Context())
+	defer parentCancel()
+
+	ctx, cancel := rpcContextFrom(cmd, parent)
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok)
+	require.WithinDuration(
+		t, time.Now().Add(defaultRPCTimeout), deadline, time.Second,
+	)
+}
+
 // TestRoundsWatchBounds verifies the streaming command exposes deterministic
 // duration and event-count completion controls for machine callers.
 func TestRoundsWatchBounds(t *testing.T) {
@@ -58,4 +77,15 @@ func TestRoundsWatchBounds(t *testing.T) {
 	watchFor, err := cmd.Flags().GetDuration("for")
 	require.NoError(t, err)
 	require.Zero(t, watchFor)
+
+	cmd.SetContext(t.Context())
+	ctx, cancel := roundsWatchContext(cmd, watchFor)
+	defer cancel()
+	_, ok := ctx.Deadline()
+	require.False(t, ok)
+
+	ctx, cancel = roundsWatchContext(cmd, time.Second)
+	defer cancel()
+	_, ok = ctx.Deadline()
+	require.True(t, ok)
 }

--- a/cmd/wavecli/waveclicommands/rpc_context_test.go
+++ b/cmd/wavecli/waveclicommands/rpc_context_test.go
@@ -1,0 +1,61 @@
+package waveclicommands
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRPCContextUsesDefaultTimeout verifies that daemon RPCs are bounded even
+// when callers do not provide an explicit timeout.
+func TestRPCContextUsesDefaultTimeout(t *testing.T) {
+	t.Parallel()
+
+	cmd := findRootCommand(t, newRootCmd(false), "getinfo")
+	cmd.SetContext(t.Context())
+
+	ctx, cancel := rpcContext(cmd)
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok)
+	require.WithinDuration(
+		t, time.Now().Add(defaultRPCTimeout), deadline, time.Second,
+	)
+}
+
+// TestRPCContextAllowsDisablingTimeout verifies that long-running callers can
+// opt out while still retaining normal command cancellation.
+func TestRPCContextAllowsDisablingTimeout(t *testing.T) {
+	t.Parallel()
+
+	root := newRootCmd(false)
+	cmd := findRootCommand(t, root, "getinfo")
+	cmd.SetContext(t.Context())
+	require.NoError(t, root.PersistentFlags().Set("timeout", "0"))
+
+	ctx, cancel := rpcContext(cmd)
+	_, ok := ctx.Deadline()
+	require.False(t, ok)
+
+	cancel()
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
+// TestRoundsWatchBounds verifies the streaming command exposes deterministic
+// duration and event-count completion controls for machine callers.
+func TestRoundsWatchBounds(t *testing.T) {
+	t.Parallel()
+
+	cmd := newRoundsWatchCmd()
+
+	maxEvents, err := cmd.Flags().GetUint32("max-events")
+	require.NoError(t, err)
+	require.Zero(t, maxEvents)
+
+	watchFor, err := cmd.Flags().GetDuration("for")
+	require.NoError(t, err)
+	require.Zero(t, watchFor)
+}

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -289,6 +289,7 @@ wavecli
 | `--macaroonpath` | | Explicit admin macaroon path (overrides `--datadir`) |
 | `--no-tls` | `false` | Disable TLS (regtest / dev); requires `--no-macaroons` |
 | `--no-macaroons` | `false` | Disable macaroon auth (required alongside `--no-tls`) |
+| `--timeout` | `30s` | Maximum duration for each daemon RPC; `0` disables the deadline |
 | `--json` | | Raw JSON request payload (overrides bespoke flags) |
 
 ### `getinfo`

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -289,7 +289,7 @@ wavecli
 | `--macaroonpath` | | Explicit admin macaroon path (overrides `--datadir`) |
 | `--no-tls` | `false` | Disable TLS (regtest / dev); requires `--no-macaroons` |
 | `--no-macaroons` | `false` | Disable macaroon auth (required alongside `--no-tls`) |
-| `--timeout` | `30s` | Maximum duration for each daemon RPC; `0` disables the deadline |
+| `--timeout` | `30s` | Maximum duration for each finite daemon RPC; `0` disables the deadline. Live watches use their stream-specific bounds. |
 | `--json` | | Raw JSON request payload (overrides bespoke flags) |
 
 ### `getinfo`


### PR DESCRIPTION
Addresses the first P1 item in #997. This is independent of the P0-10 signal-context PR; both compose through Cobra's command context.

## What changed

- add global `--timeout` with a 30-second default and `0` opt-out for finite daemon RPCs
- derive every hand-written daemon RPC and generated `dev` RPC from a bounded command context
- remove all production `context.Background()` RPC calls
- apply the global timeout separately to every send-status poll inside the independent settlement wait
- add `ark rounds watch --max-events` and `--for`
- keep `ark rounds watch` unbounded by default because it is deliberately live; `--for`, `--max-events`, signals, or caller cancellation bound it explicitly
- treat an explicit `--for` expiry or cancellation as clean stream completion
- document and test the timeout contract

`mcp serve` remains intentionally long-lived; individual MCP invocations already receive their host-supplied contexts.

## Concrete impact

Before, several finite commands could wait forever, generated low-level RPCs had no deadline, and one stalled status poll could consume the full settlement wait. After this change, finite daemon RPCs and individual settlement polls default to a 30-second deadline, while deliberately live streams retain explicit stream-specific bounds.

The 30-second default is therefore not applied blindly to every command lifetime: it bounds finite RPC calls, not MCP serving or an unbounded `rounds watch`.

## Validation

- `make unit pkg=./cmd/wavecli/...`
- `go test ./cmd/wavecli/... -race`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`
