### PR TITLE
wavecli: Separate JSON input from output

### DIFF
--- a/cmd/wavecli/waveclicommands/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/AGENTS.md
@@ -38,7 +38,7 @@ unchanged).
 | `unlock` | `wavewalletrpc.Unlock` | Unlock an existing wallet (proxies UnlockWallet) |
 | `send <dest>` | `wavewalletrpc.Send` | Outbound payment. `--offchain` (default) for a BOLT-11 invoice via the swap subsystem; `--onchain` for an atomic on-chain send (`--sweep-all` drains). No prefix sniff |
 | `recv` | `wavewalletrpc.Recv` / `wavewalletrpc.Deposit` | Inbound. `--offchain` (default) returns a Lightning invoice; `--onchain` returns a boarding address |
-| `activity` | `wavewalletrpc.List` | Unified wallet activity view. Defaults to table output; `--format json` returns structured JSON. `--pending` and `--kind` narrow rows |
+| `activity` | `wavewalletrpc.List` | Unified wallet activity view. Defaults to table output; global `--json` or `--format json` returns structured JSON. `--pending` and `--kind` narrow rows |
 | `activity inspect <id>` | `wavewalletrpc.InspectActivity` | Correlated swap/VTXO/ledger detail for one activity entry |
 | `balance` | `wavewalletrpc.Balance` | Flat balance (confirmed_sat, pending_in_sat, pending_out_sat) |
 | `exit --outpoint TXID:VOUT` | `wavewalletrpc.Exit` | Queue a cooperative leave by default; unilateral unroll only fires with `--force-unroll-ack I_KNOW_WHAT_I_AM_DOING` |
@@ -104,7 +104,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
 - `withWalletClient()` — maps `codes.Unimplemented` to
   `errWalletRPCDisabled` (with a pointer to `docs/wavewalletrpc_build.md`)
   for daemons built without the wavewalletrpc tag.
-- `parseRequest()` — generic JSON-or-flags proto request parser
+- `parseRequest()` — generic `--request-json`-or-flags proto request parser
   (consumed by `ark.*` commands).
 - `methodRegistry()` / `schemaMethod` / `schemaParam` —
   machine-readable schema for all CLI commands; shared source of

--- a/cmd/wavecli/waveclicommands/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/CLAUDE.md
@@ -38,7 +38,7 @@ unchanged).
 | `unlock` | `wavewalletrpc.Unlock` | Unlock an existing wallet (proxies UnlockWallet) |
 | `send <dest>` | `wavewalletrpc.Send` | Outbound payment. `--offchain` (default) for a BOLT-11 invoice via the swap subsystem; `--onchain` for an atomic on-chain send (`--sweep-all` drains). No prefix sniff |
 | `recv` | `wavewalletrpc.Recv` / `wavewalletrpc.Deposit` | Inbound. `--offchain` (default) returns a Lightning invoice; `--onchain` returns a boarding address |
-| `activity` | `wavewalletrpc.List` | Unified wallet activity view. Defaults to table output; `--format json` returns structured JSON. `--pending` and `--kind` narrow rows |
+| `activity` | `wavewalletrpc.List` | Unified wallet activity view. Defaults to table output; global `--json` or `--format json` returns structured JSON. `--pending` and `--kind` narrow rows |
 | `activity inspect <id>` | `wavewalletrpc.InspectActivity` | Correlated swap/VTXO/ledger detail for one activity entry |
 | `balance` | `wavewalletrpc.Balance` | Flat balance (confirmed_sat, pending_in_sat, pending_out_sat) |
 | `exit --outpoint TXID:VOUT` | `wavewalletrpc.Exit` | Queue a cooperative leave by default; unilateral unroll only fires with `--force-unroll-ack I_KNOW_WHAT_I_AM_DOING` |
@@ -104,7 +104,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
 - `withWalletClient()` — maps `codes.Unimplemented` to
   `errWalletRPCDisabled` (with a pointer to `docs/wavewalletrpc_build.md`)
   for daemons built without the wavewalletrpc tag.
-- `parseRequest()` — generic JSON-or-flags proto request parser
+- `parseRequest()` — generic `--request-json`-or-flags proto request parser
   (consumed by `ark.*` commands).
 - `methodRegistry()` / `schemaMethod` / `schemaParam` —
   machine-readable schema for all CLI commands; shared source of

--- a/cmd/wavecli/waveclicommands/cmd_inspect.go
+++ b/cmd/wavecli/waveclicommands/cmd_inspect.go
@@ -31,6 +31,10 @@ func newActivityInspectCmd() *cobra.Command {
 func inspectActivity(cmd *cobra.Command, args []string) error {
 	ledgerLimit, _ := cmd.Flags().GetUint32("ledger-limit")
 	format, _ := cmd.Flags().GetString("format")
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	if jsonOutput {
+		format = "json"
+	}
 	if err := validateInspectFormat(format); err != nil {
 		return err
 	}

--- a/cmd/wavecli/waveclicommands/cmd_list.go
+++ b/cmd/wavecli/waveclicommands/cmd_list.go
@@ -49,6 +49,10 @@ func walletActivity(cmd *cobra.Command, _ []string) error {
 	limit, _ := cmd.Flags().GetUint32("limit")
 	cursor, _ := cmd.Flags().GetString("cursor")
 	format, _ := cmd.Flags().GetString("format")
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	if jsonOutput {
+		format = "json"
+	}
 
 	if err := validateListFormat(
 		format, wavewalletrpc.ListView_LIST_VIEW_ACTIVITY,
@@ -82,6 +86,17 @@ func walletActivity(cmd *cobra.Command, _ []string) error {
 
 			switch format {
 			case "", "table":
+				if !stdoutIsTTY() {
+					fmt.Fprintln(
+						cmd.ErrOrStderr(),
+						"hint: stdout is not a "+
+							"TTY; use --json "+
+							"for "+
+							"machine-readable "+
+							"output",
+					)
+				}
+
 				if err := printWalletActivityTable(
 					resp,
 				); err != nil {

--- a/cmd/wavecli/waveclicommands/cmd_sweep.go
+++ b/cmd/wavecli/waveclicommands/cmd_sweep.go
@@ -132,13 +132,19 @@ func sweepList(cmd *cobra.Command, _ []string) error {
 		_ = conn.Close()
 	}()
 
-	statusFilter, _ := cmd.Flags().GetString("status")
-	pageSize, _ := cmd.Flags().GetUint32("page-size")
-	pageToken, _ := cmd.Flags().GetString("page-token")
-	req := &waverpc.ListBoardingSweepsRequest{
-		Status:    statusFilter,
-		PageSize:  pageSize,
-		PageToken: pageToken,
+	req := &waverpc.ListBoardingSweepsRequest{}
+	if err := parseRequest(cmd, req, func() error {
+		statusFilter, _ := cmd.Flags().GetString("status")
+		pageSize, _ := cmd.Flags().GetUint32("page-size")
+		pageToken, _ := cmd.Flags().GetString("page-token")
+
+		req.Status = statusFilter
+		req.PageSize = pageSize
+		req.PageToken = pageToken
+
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	ctx, cancel := rpcContext(cmd)

--- a/cmd/wavecli/waveclicommands/cmd_vtxos.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos.go
@@ -387,7 +387,7 @@ func summarizeRefreshFeeEstimate(est *waverpc.RefreshFeeEstimate) []string {
 // consent: every refresh is charged an operator fee at seal time, and
 // before this gate the CLI queued the refresh without ever mentioning
 // it (#986). The check runs after parseRequest returns so it covers
-// both the flag-driven path and the --json path, mirroring
+// both the flag-driven path and the --request-json path, mirroring
 // confirmLeaveAllIfNeeded. Skip when --yes is set (explicit scripted
 // consent) or when req.DryRun is set (previewing, not spending).
 //
@@ -833,7 +833,7 @@ func parseDestinationValue(raw string) (*waverpc.LeaveDestination, error) {
 // confirmLeaveAllIfNeeded gates dispatch on an explicit confirmation
 // when the resolved request selects all VTXOs. The check runs after
 // parseRequest returns so it covers both the flag-driven path and the
-// --json path; previously the prompt lived inside the flag callback
+// --request-json path; previously the prompt lived inside the flag callback
 // and an agent piping `{"all":true,...}` would silently skip the gate
 // that the bespoke-flag path enforced. Skip when --yes is set
 // (explicit scripted consent), when req.DryRun is set (just

--- a/cmd/wavecli/waveclicommands/cmd_vtxos_leave_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos_leave_test.go
@@ -282,7 +282,7 @@ func TestParseDestinationValueEmpty(t *testing.T) {
 }
 
 // TestConfirmLeaveAllIfNeededJSONStillPrompts is the C-1 regression
-// guard: a request whose `selection.all` was set via the --json input
+// guard: a request whose `selection.all` was set via the --request-json input
 // path (i.e. without ever entering the flag callback) must still hit
 // the y/N prompt. Before the fix the prompt lived inside the flag
 // callback and the JSON path silently bypassed it.

--- a/cmd/wavecli/waveclicommands/devrpc/command.go
+++ b/cmd/wavecli/waveclicommands/devrpc/command.go
@@ -135,12 +135,13 @@ func runMethod(cmd *cobra.Command, cfg Config, service protoreflect.FullName,
 	}
 
 	req := dynamicpb.NewMessage(method.input)
-	rawJSON, _ := cmd.Flags().GetString("json")
+	rawJSON, _ := cmd.Flags().GetString("request-json")
 	if rawJSON != "" {
 		if err := jsonUnmarshalOpts.Unmarshal(
 			[]byte(rawJSON), req,
 		); err != nil {
-			return fmt.Errorf("invalid --json payload: %w", err)
+			return fmt.Errorf("invalid --request-json payload: %w",
+				err)
 		}
 	} else {
 		if err := populateRequest(cmd, req, binders); err != nil {

--- a/cmd/wavecli/waveclicommands/devrpc/command_test.go
+++ b/cmd/wavecli/waveclicommands/devrpc/command_test.go
@@ -353,10 +353,12 @@ func TestDevCmdAcceptsRawJSONRequest(t *testing.T) {
 	cmd, cleanup := newTestDevCmd(t, server, &out)
 	defer cleanup()
 
-	cmd.PersistentFlags().String("json", "", "raw JSON request payload")
+	cmd.PersistentFlags().String(
+		"request-json", "", "raw JSON request payload",
+	)
 	cmd.SetArgs([]string{
 		"daemon", "list-vtxos",
-		"--json", `{"status_filter":"VTXO_STATUS_SPENT"}`,
+		"--request-json", `{"status_filter":"VTXO_STATUS_SPENT"}`,
 		"--min_amount_sat", "10",
 	})
 	if err := cmd.Execute(); err != nil {
@@ -372,8 +374,8 @@ func TestDevCmdAcceptsRawJSONRequest(t *testing.T) {
 		t.Fatalf("status filter = %v", server.listReq.StatusFilter)
 	}
 	if server.listReq.MinAmountSat != 0 {
-		t.Fatalf("expected --json to ignore flags, min amount = %v",
-			server.listReq.MinAmountSat)
+		t.Fatalf("expected --request-json to ignore flags, min "+
+			"amount = %v", server.listReq.MinAmountSat)
 	}
 }
 

--- a/cmd/wavecli/waveclicommands/json_input.go
+++ b/cmd/wavecli/waveclicommands/json_input.go
@@ -8,9 +8,9 @@ import (
 )
 
 // parseRequest populates the given proto request from either the
-// --json flag (raw JSON payload, agent-first path) or from bespoke
+// --request-json flag (raw JSON payload, agent-first path) or from bespoke
 // CLI flags via the fromFlags callback (human-first path). When
-// --json is provided, fromFlags is never called.
+// --request-json is provided, fromFlags is never called.
 //
 // This gives agents a zero-translation-loss input path: they can
 // pass the full RPC request payload as JSON, mapping directly to
@@ -19,12 +19,13 @@ import (
 func parseRequest[T proto.Message](cmd *cobra.Command, req T,
 	fromFlags func() error) error {
 
-	raw, _ := cmd.Flags().GetString("json")
+	raw, _ := cmd.Flags().GetString("request-json")
 	if raw != "" {
 		if err := jsonUnmarshalOpts.Unmarshal(
 			[]byte(raw), req,
 		); err != nil {
-			return fmt.Errorf("invalid --json payload: %w", err)
+			return fmt.Errorf("invalid --request-json payload: %w",
+				err)
 		}
 
 		return nil

--- a/cmd/wavecli/waveclicommands/json_input_test.go
+++ b/cmd/wavecli/waveclicommands/json_input_test.go
@@ -1,0 +1,61 @@
+package waveclicommands
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRootJSONFlagsHaveDistinctDirections pins the pre-launch contract that
+// --json controls output while --request-json supplies raw request input.
+func TestRootJSONFlagsHaveDistinctDirections(t *testing.T) {
+	t.Parallel()
+
+	root := newRootCmd(false)
+	jsonFlag := root.PersistentFlags().Lookup("json")
+	require.NotNil(t, jsonFlag)
+	require.Equal(t, "bool", jsonFlag.Value.Type())
+
+	requestFlag := root.PersistentFlags().Lookup("request-json")
+	require.NotNil(t, requestFlag)
+	require.Equal(t, "string", requestFlag.Value.Type())
+}
+
+// TestParseRequestUsesRequestJSON verifies raw input wins over bespoke flags
+// under the unambiguous request-side flag name.
+func TestParseRequestUsesRequestJSON(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("request-json", "", "")
+	require.NoError(t, cmd.Flags().Set(
+		"request-json", `{"round_id":"from-json"}`,
+	))
+
+	req := &waverpc.GetRoundRequest{}
+	flagsCalled := false
+	err := parseRequest(cmd, req, func() error {
+		flagsCalled = true
+		req.RoundId = "from-flags"
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.False(t, flagsCalled)
+	require.Equal(t, "from-json", req.GetRoundId())
+}
+
+// TestParseRequestNamesInvalidInputFlag keeps error remediation precise for
+// agents migrating from the old overloaded --json spelling.
+func TestParseRequestNamesInvalidInputFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("request-json", "", "")
+	require.NoError(t, cmd.Flags().Set("request-json", `{`))
+
+	err := parseRequest(cmd, &waverpc.GetRoundRequest{}, nil)
+	require.ErrorContains(t, err, "invalid --request-json payload")
+}

--- a/cmd/wavecli/waveclicommands/root.go
+++ b/cmd/wavecli/waveclicommands/root.go
@@ -102,10 +102,15 @@ func newRootCmd(devMode bool) *cobra.Command {
 		"maximum duration for each daemon RPC; 0 disables the deadline",
 	)
 
+	pf.Bool(
+		"json", false, "emit machine-readable JSON output (raw "+
+			"request input uses --request-json)",
+	)
+
 	pf.String(
-		"json", "", "raw JSON request payload (maps directly to "+
-			"the RPC request proto); when set, bespoke flags "+
-			"are ignored",
+		"request-json", "", "raw JSON request payload (maps "+
+			"directly to the RPC request proto); when set, "+
+			"bespoke flags are ignored",
 	)
 
 	// The visible face is two groups: the everyday Wallet verbs and

--- a/cmd/wavecli/waveclicommands/schema_registry.go
+++ b/cmd/wavecli/waveclicommands/schema_registry.go
@@ -46,9 +46,9 @@ type schemaMethod struct {
 	// reaches the daemon's dry-run RPC field.
 	DryRun bool `json:"dry_run,omitempty"`
 
-	// JSONInput indicates the command accepts --json for raw proto
+	// JSONInput indicates the command accepts --request-json for raw proto
 	// payloads.
-	JSONInput bool `json:"json_input"`
+	JSONInput bool `json:"request_json_input"`
 
 	// MCPTool indicates the method is exposed as an MCP tool with
 	// the same name. False means it is CLI-only (create / unlock

--- a/cmd/wavecli/waveclicommands/wallet_table.go
+++ b/cmd/wavecli/waveclicommands/wallet_table.go
@@ -9,7 +9,14 @@ import (
 	"time"
 
 	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
+	"golang.org/x/term"
 )
+
+// stdoutIsTTY is indirect so output-contract tests can exercise the pipe and
+// terminal paths without depending on the test runner's file descriptors.
+var stdoutIsTTY = func() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
 
 // validateListFormat rejects presentation formats that do not apply to the
 // selected list view.

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -290,7 +290,8 @@ wavecli
 | `--no-tls` | `false` | Disable TLS (regtest / dev); requires `--no-macaroons` |
 | `--no-macaroons` | `false` | Disable macaroon auth (required alongside `--no-tls`) |
 | `--timeout` | `30s` | Maximum duration for each finite daemon RPC; `0` disables the deadline. Live watches use their stream-specific bounds. |
-| `--json` | | Raw JSON request payload (overrides bespoke flags) |
+| `--json` | `false` | Emit machine-readable JSON output |
+| `--request-json` | | Raw JSON request payload (overrides bespoke flags) |
 
 ### `getinfo`
 
@@ -462,7 +463,7 @@ wavecli ark send inround \
   --to bcrt1p...addr2 --amount 30000
 
 # Via JSON input
-wavecli ark send inround --json '{
+wavecli ark send inround --request-json '{
   "recipients": [
     {"address":"bcrt1p...","amount_sat":50000},
     {"address":"bcrt1p...","amount_sat":30000}
@@ -586,6 +587,7 @@ The merged wallet activity feed: send / recv / deposit / exit history.
 wavecli activity
 wavecli activity --pending --kind send,recv
 wavecli activity --format json
+wavecli activity --json
 wavecli activity --cursor <next_cursor>
 wavecli activity inspect <id>
 ```


### PR DESCRIPTION
Addresses P0-1 of #997.

## What changed

- make global `--json` a boolean machine-output flag
- move raw proto request input to `--request-json`, including generated `dev` RPCs
- make `activity` and `activity inspect` honor global `--json`
- keep activity table bytes identical on terminals and pipes; add only a one-line stderr hint for an unformatted pipe
- make `ark sweep list` parse raw request JSON instead of silently ignoring it
- rename schema metadata from `json_input` to `request_json_input`
- update CLI documentation and regression tests

## Concrete impact

Before, the conventionally machine-output-looking `--json` flag was raw input, so agent-generated commands could fail or alter requests. `ark sweep list --json ...` was worse: it silently ignored the payload. After this change, output and input directions are unambiguous and raw sweep-list requests either work or fail loudly.

This is intentionally breaking before launch for scripts that used `--json '{...}'`; the replacement is a spelling-only migration to `--request-json '{...}'`.

## Validation

- `make unit pkg=./cmd/wavecli/...`
- `go test ./cmd/wavecli/... -race`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`

