### PR TITLE
wavecli: Canonicalize flags to kebab case

### DIFF
--- a/cmd/wavecli/waveclicommands/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/AGENTS.md
@@ -34,7 +34,7 @@ unchanged).
 
 | Command | RPC | Description |
 |---------|-----|-------------|
-| `create` | `wavewalletrpc.Create` | Initialize a new wallet (proxies GenSeed + InitWallet). Password from stdin / WAVED_WALLET_PASSWORD / --wallet_password_file |
+| `create` | `wavewalletrpc.Create` | Initialize a new wallet (proxies GenSeed + InitWallet). Password from stdin / WAVED_WALLET_PASSWORD / --wallet-password-file |
 | `unlock` | `wavewalletrpc.Unlock` | Unlock an existing wallet (proxies UnlockWallet) |
 | `send <dest>` | `wavewalletrpc.Send` | Outbound payment. `--offchain` (default) for a BOLT-11 invoice via the swap subsystem; `--onchain` for an atomic on-chain send (`--sweep-all` drains). No prefix sniff |
 | `recv` | `wavewalletrpc.Recv` / `wavewalletrpc.Deposit` | Inbound. `--offchain` (default) returns a Lightning invoice; `--onchain` returns a boarding address |
@@ -106,6 +106,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   for daemons built without the wavewalletrpc tag.
 - `parseRequest()` — generic `--request-json`-or-flags proto request parser
   (consumed by `ark.*` commands).
+- `snakeToKebabFlags()` — global flag normalizer: help and schemas use
+  kebab-case while snake_case remains a silent compatibility alias.
 - `methodRegistry()` / `schemaMethod` / `schemaParam` —
   machine-readable schema for all CLI commands; shared source of
   truth for `schema` and MCP tool definitions. Built from the
@@ -115,7 +117,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   exposed RPC as a typed tool; split from `mcpServe` (which owns the
   daemon dial and stdio transport) so the tool surface is testable.
 - `readPassword()` — reads wallet password from
-  `WAVED_WALLET_PASSWORD` → `--wallet_password_file` → stdin → TTY.
+  `WAVED_WALLET_PASSWORD` → `--wallet-password-file` → stdin → TTY.
   **Never from CLI args.**
 - `validateDestination()` / `validateOutpoint()` /
   `validateFreeText()` — input hardening shared across the top-level
@@ -145,7 +147,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   the authoritative parse.
 - The wallet password is NEVER read from argv. The supported sources
   are `WAVED_WALLET_PASSWORD` (highest priority), then
-  `--wallet_password_file`, then piped stdin, then interactive prompt.
+  `--wallet-password-file`, then piped stdin, then interactive prompt.
 - JSON output (`stdout`) and diagnostic output (`stderr`) are kept on
   separate streams so shell pipelines can consume the JSON body while
   a human reading the terminal sees informative warnings.
@@ -161,7 +163,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   non-interactive stdin without `--yes` (same posture as `leave --all`
   and `recovery escalate`). The MCP tool enforces the same contract
   through its `yes` argument — no prompt exists there, so a bare real
-  refresh returns an immediate actionable error. `--dry_run` previews
+  refresh returns an immediate actionable error. `--dry-run` previews
   the itemized advisory estimate and never prompts. A failed estimate
   degrades to a "still charged the seal-time fee" warning and its
   total is absent on the wire (explicit proto presence) — it never

--- a/cmd/wavecli/waveclicommands/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/CLAUDE.md
@@ -34,7 +34,7 @@ unchanged).
 
 | Command | RPC | Description |
 |---------|-----|-------------|
-| `create` | `wavewalletrpc.Create` | Initialize a new wallet (proxies GenSeed + InitWallet). Password from stdin / WAVED_WALLET_PASSWORD / --wallet_password_file |
+| `create` | `wavewalletrpc.Create` | Initialize a new wallet (proxies GenSeed + InitWallet). Password from stdin / WAVED_WALLET_PASSWORD / --wallet-password-file |
 | `unlock` | `wavewalletrpc.Unlock` | Unlock an existing wallet (proxies UnlockWallet) |
 | `send <dest>` | `wavewalletrpc.Send` | Outbound payment. `--offchain` (default) for a BOLT-11 invoice via the swap subsystem; `--onchain` for an atomic on-chain send (`--sweep-all` drains). No prefix sniff |
 | `recv` | `wavewalletrpc.Recv` / `wavewalletrpc.Deposit` | Inbound. `--offchain` (default) returns a Lightning invoice; `--onchain` returns a boarding address |
@@ -106,6 +106,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   for daemons built without the wavewalletrpc tag.
 - `parseRequest()` — generic `--request-json`-or-flags proto request parser
   (consumed by `ark.*` commands).
+- `snakeToKebabFlags()` — global flag normalizer: help and schemas use
+  kebab-case while snake_case remains a silent compatibility alias.
 - `methodRegistry()` / `schemaMethod` / `schemaParam` —
   machine-readable schema for all CLI commands; shared source of
   truth for `schema` and MCP tool definitions. Built from the
@@ -115,7 +117,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   exposed RPC as a typed tool; split from `mcpServe` (which owns the
   daemon dial and stdio transport) so the tool surface is testable.
 - `readPassword()` — reads wallet password from
-  `WAVED_WALLET_PASSWORD` → `--wallet_password_file` → stdin → TTY.
+  `WAVED_WALLET_PASSWORD` → `--wallet-password-file` → stdin → TTY.
   **Never from CLI args.**
 - `validateDestination()` / `validateOutpoint()` /
   `validateFreeText()` — input hardening shared across the top-level
@@ -145,7 +147,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   the authoritative parse.
 - The wallet password is NEVER read from argv. The supported sources
   are `WAVED_WALLET_PASSWORD` (highest priority), then
-  `--wallet_password_file`, then piped stdin, then interactive prompt.
+  `--wallet-password-file`, then piped stdin, then interactive prompt.
 - JSON output (`stdout`) and diagnostic output (`stderr`) are kept on
   separate streams so shell pipelines can consume the JSON body while
   a human reading the terminal sees informative warnings.
@@ -161,7 +163,7 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   non-interactive stdin without `--yes` (same posture as `leave --all`
   and `recovery escalate`). The MCP tool enforces the same contract
   through its `yes` argument — no prompt exists there, so a bare real
-  refresh returns an immediate actionable error. `--dry_run` previews
+  refresh returns an immediate actionable error. `--dry-run` previews
   the itemized advisory estimate and never prompts. A failed estimate
   degrades to a "still charged the seal-time fee" warning and its
   total is absent on the wire (explicit proto presence) — it never

--- a/cmd/wavecli/waveclicommands/cmd_ark_send.go
+++ b/cmd/wavecli/waveclicommands/cmd_ark_send.go
@@ -64,7 +64,7 @@ func newArkSendInRoundCmd() *cobra.Command {
 	cmd.Flags().Int64Slice("amount", nil,
 		"amount(s) in sats (one per recipient, in --to + --pubkey "+
 			"order)")
-	cmd.Flags().Bool("dry_run", false, "validate without submitting")
+	cmd.Flags().Bool("dry-run", false, "validate without submitting")
 
 	return cmd
 }
@@ -82,7 +82,7 @@ func sendInRound(cmd *cobra.Command, _ []string) error {
 		addresses, _ := cmd.Flags().GetStringSlice("to")
 		pubkeyHexes, _ := cmd.Flags().GetStringSlice("pubkey")
 		amounts, _ := cmd.Flags().GetInt64Slice("amount")
-		dryRun, _ := cmd.Flags().GetBool("dry_run")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
 
 		if len(addresses)+len(pubkeyHexes) == 0 {
 			return fmt.Errorf("at least one --to or --pubkey is " +
@@ -181,8 +181,8 @@ func newArkSendOORCmd() *cobra.Command {
 	cmd.Flags().String("pubkey", "",
 		"recipient 32-byte x-only pubkey hex")
 	cmd.Flags().Int64("amount", 0, "amount in sats")
-	cmd.Flags().Bool("dry_run", false, "validate without initiating")
-	cmd.Flags().String("idempotency_key", "",
+	cmd.Flags().Bool("dry-run", false, "validate without initiating")
+	cmd.Flags().String("idempotency-key", "",
 		"caller-provided key for retrying the same OOR send intent")
 
 	cmd.MarkFlagsMutuallyExclusive("to", "pubkey")
@@ -203,8 +203,8 @@ func sendOOR(cmd *cobra.Command, _ []string) error {
 		address, _ := cmd.Flags().GetString("to")
 		pubKeyHex, _ := cmd.Flags().GetString("pubkey")
 		amount, _ := cmd.Flags().GetInt64("amount")
-		dryRun, _ := cmd.Flags().GetBool("dry_run")
-		idempotencyKey, _ := cmd.Flags().GetString("idempotency_key")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		idempotencyKey, _ := cmd.Flags().GetString("idempotency-key")
 
 		recipient, err := buildOORRecipientOutput(
 			address, pubKeyHex, amount,

--- a/cmd/wavecli/waveclicommands/cmd_create.go
+++ b/cmd/wavecli/waveclicommands/cmd_create.go
@@ -26,11 +26,11 @@ func newCreateCmd() *cobra.Command {
 			"supplied password.\n\n" +
 			"The wallet password is read from stdin / " +
 			"WAVED_WALLET_PASSWORD env / " +
-			"--wallet_password_file (never CLI args). The " +
+			"--wallet-password-file (never CLI args). The " +
 			"interactive password prompt asks for confirmation. " +
 			"The optional seed passphrase is read from " +
 			"WAVED_SEED_PASSPHRASE env / " +
-			"--seed_passphrase_file. The mnemonic is shown " +
+			"--seed-passphrase-file. The mnemonic is shown " +
 			"on stderr ONCE and is NOT included in the JSON " +
 			"response on stdout (the caller must capture it " +
 			"from stderr or pass --print-mnemonic-json to " +
@@ -41,9 +41,9 @@ func newCreateCmd() *cobra.Command {
 		RunE: walletCreate,
 	}
 
-	cmd.Flags().String("wallet_password_file", "",
+	cmd.Flags().String("wallet-password-file", "",
 		"path to file containing wallet password")
-	cmd.Flags().String("seed_passphrase_file", "",
+	cmd.Flags().String("seed-passphrase-file", "",
 		"path to file containing optional aezeed passphrase")
 	cmd.Flags().Bool("print-mnemonic-json", false,
 		"include the mnemonic in the JSON response on stdout "+
@@ -52,16 +52,9 @@ func newCreateCmd() *cobra.Command {
 		"import an existing mnemonic and recover Ark wallet state")
 	cmd.Flags().String("mnemonic-file", "",
 		"path to file containing an existing 24-word aezeed mnemonic")
-	cmd.Flags().String("mnemonic_file", "",
-		"path to file containing an existing 24-word aezeed mnemonic")
 	cmd.Flags().Uint32("recovery-window", 0,
 		"number of key indexes to scan per recovery family "+
 			"(default: daemon wallet.recoverywindow)")
-	cmd.Flags().Uint32("recovery_window", 0,
-		"number of key indexes to scan per recovery family "+
-			"(default: daemon wallet.recoverywindow)")
-	_ = cmd.Flags().MarkHidden("mnemonic_file")
-	_ = cmd.Flags().MarkHidden("recovery_window")
 
 	return cmd
 }
@@ -69,20 +62,8 @@ func newCreateCmd() *cobra.Command {
 // walletCreate implements the top-level `create` verb.
 func walletCreate(cmd *cobra.Command, _ []string) error {
 	recoverWallet, _ := cmd.Flags().GetBool("recover")
-	mnemonicFile, err := aliasedFlag(
-		cmd, "mnemonic-file", "mnemonic_file", cmd.Flags().GetString,
-	)
-	if err != nil {
-		return err
-	}
-
-	recoveryWindow, err := aliasedFlag(
-		cmd, "recovery-window", "recovery_window",
-		cmd.Flags().GetUint32,
-	)
-	if err != nil {
-		return err
-	}
+	mnemonicFile, _ := cmd.Flags().GetString("mnemonic-file")
+	recoveryWindow, _ := cmd.Flags().GetUint32("recovery-window")
 
 	switch {
 	case recoverWallet && mnemonicFile == "":
@@ -181,24 +162,4 @@ func readMnemonicFile(path string) ([]string, error) {
 	}
 
 	return words, nil
-}
-
-// aliasedFlag reads a flag with a hidden compatibility alias.
-func aliasedFlag[T any](cmd *cobra.Command, primary, alias string,
-	get func(string) (T, error)) (T, error) {
-
-	primaryChanged := cmd.Flags().Changed(primary)
-	aliasChanged := cmd.Flags().Changed(alias)
-	var zero T
-	switch {
-	case primaryChanged && aliasChanged:
-		return zero, fmt.Errorf("--%s and --%s cannot both be set",
-			primary, alias)
-
-	case aliasChanged:
-		return get(alias)
-
-	default:
-		return get(primary)
-	}
 }

--- a/cmd/wavecli/waveclicommands/cmd_fees.go
+++ b/cmd/wavecli/waveclicommands/cmd_fees.go
@@ -42,7 +42,7 @@ func newFeesEstimateCmd() *cobra.Command {
 			"To preview the fee for refreshing specific " +
 			"VTXOs without looking up their amounts and " +
 			"remaining lifetimes by hand, use `ark vtxos " +
-			"refresh --dry_run` instead: it resolves each " +
+			"refresh --dry-run` instead: it resolves each " +
 			"selected VTXO and returns a per-outpoint " +
 			"estimate.",
 		RunE: feesEstimate,

--- a/cmd/wavecli/waveclicommands/cmd_oor.go
+++ b/cmd/wavecli/waveclicommands/cmd_oor.go
@@ -2,11 +2,9 @@ package waveclicommands
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -39,24 +37,7 @@ func newOORGetCmd() *cobra.Command {
 	cmd.Flags().String("session-id", "",
 		"OOR session id to fetch")
 
-	// Accept the snake_case spelling (--session_id) as well as the
-	// registered kebab form. The RPC field, `oor list` JSON output, and the
-	// daemon logs all name this field session_id, so a user copying that
-	// name should not hit an "unknown flag" error (issue #900). This only
-	// adds an alias: every flag on this command (and the inherited global
-	// flags) is defined in kebab case, so folding underscores to dashes
-	// never renames an existing flag.
-	cmd.Flags().SetNormalizeFunc(snakeToKebabFlags)
-
 	return cmd
-}
-
-// snakeToKebabFlags folds a snake_case flag name onto its canonical kebab-case
-// spelling so both spellings resolve to the same flag. Apply it only to
-// commands whose flags are all defined in kebab case, where it acts purely as
-// an alias.
-func snakeToKebabFlags(_ *pflag.FlagSet, name string) pflag.NormalizedName {
-	return pflag.NormalizedName(strings.ReplaceAll(name, "_", "-"))
 }
 
 // newOORListCmd creates the oor list subcommand.

--- a/cmd/wavecli/waveclicommands/cmd_recv.go
+++ b/cmd/wavecli/waveclicommands/cmd_recv.go
@@ -45,7 +45,7 @@ func newRecvCmd() *cobra.Command {
 	cmd.Flags().String("memo", "",
 		"optional human-readable memo embedded in the offchain "+
 			"invoice")
-	cmd.Flags().Uint64("amt_hint", 0,
+	cmd.Flags().Uint64("amt-hint", 0,
 		"optional expected amount for --onchain (accounting only)")
 
 	return cmd
@@ -60,7 +60,7 @@ func walletRecv(cmd *cobra.Command, _ []string) error {
 
 	amt, _ := cmd.Flags().GetUint64("amt")
 	memo, _ := cmd.Flags().GetString("memo")
-	amtHint, _ := cmd.Flags().GetUint64("amt_hint")
+	amtHint, _ := cmd.Flags().GetUint64("amt-hint")
 
 	if err := invalidArgs(validateFreeText("--memo", memo)); err != nil {
 		return err

--- a/cmd/wavecli/waveclicommands/cmd_rounds.go
+++ b/cmd/wavecli/waveclicommands/cmd_rounds.go
@@ -82,7 +82,7 @@ func newRoundsJoinCmd() *cobra.Command {
 			"`ark vtxos refresh` and `ark vtxos leave` invoke " +
 			"this automatically on the caller's behalf. Use " +
 			"`join` directly only when one of those commands " +
-			"was passed `--no_join` to batch multiple intents " +
+			"was passed `--no-join` to batch multiple intents " +
 			"into the same round.",
 		RunE: roundsJoin,
 	}

--- a/cmd/wavecli/waveclicommands/cmd_send.go
+++ b/cmd/wavecli/waveclicommands/cmd_send.go
@@ -77,7 +77,7 @@ func newSendCmd() *cobra.Command {
 	cmd.Flags().Uint64("amt", 0,
 		"amount in satoshis (required for onchain unless "+
 			"--sweep-all; ignored for amount-bearing invoices)")
-	cmd.Flags().Uint64("max_fee", 0,
+	cmd.Flags().Uint64("max-fee", 0,
 		"max swap fee in satoshis for invoice (Lightning) sends; 0 "+
 			"lets the daemon default the cap to ~1% of the amount "+
 			"(with a small floor), so a normal payment routes "+
@@ -124,7 +124,7 @@ func walletSend(cmd *cobra.Command, args []string) error {
 	}
 
 	amt, _ := cmd.Flags().GetUint64("amt")
-	maxFee, _ := cmd.Flags().GetUint64("max_fee")
+	maxFee, _ := cmd.Flags().GetUint64("max-fee")
 	note, _ := cmd.Flags().GetString("note")
 	sweepAll, _ := cmd.Flags().GetBool("sweep-all")
 

--- a/cmd/wavecli/waveclicommands/cmd_unlock.go
+++ b/cmd/wavecli/waveclicommands/cmd_unlock.go
@@ -10,7 +10,7 @@ import (
 // newUnlockCmd builds the top-level `unlock` verb. It dials
 // wavewalletrpc.WalletService.Unlock which proxies
 // waverpc.UnlockWallet. The CLI reads the wallet password from
-// stdin / WAVED_WALLET_PASSWORD / --wallet_password_file (never CLI
+// stdin / WAVED_WALLET_PASSWORD / --wallet-password-file (never CLI
 // args) so secrets never enter argv.
 func newUnlockCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -19,14 +19,14 @@ func newUnlockCmd() *cobra.Command {
 		Long: "Opens the wallet database with its password and " +
 			"starts the wallet subsystem. The password is " +
 			"read from stdin / WAVED_WALLET_PASSWORD env var / " +
-			"--wallet_password_file (never CLI args).\n\n" +
+			"--wallet-password-file (never CLI args).\n\n" +
 			"Example:\n" +
 			"  echo -n 'hunter2hunter2' | wavecli unlock",
 		Args: cobra.NoArgs,
 		RunE: walletUnlock,
 	}
 
-	cmd.Flags().String("wallet_password_file", "",
+	cmd.Flags().String("wallet-password-file", "",
 		"path to file containing wallet password")
 
 	return cmd

--- a/cmd/wavecli/waveclicommands/cmd_vtxos.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos.go
@@ -57,7 +57,7 @@ func newVTXOsListCmd() *cobra.Command {
 		"filter by status: "+
 			strings.Join(validStatuses, ", "))
 
-	cmd.Flags().Int64("min_amount", 0,
+	cmd.Flags().Int64("min-amount", 0,
 		"minimum amount in sats")
 
 	addListOutputFlags(cmd, "VTXO")
@@ -76,7 +76,7 @@ func vtxosList(cmd *cobra.Command, _ []string) error {
 	req := &waverpc.ListVTXOsRequest{}
 	if err := parseRequest(cmd, req, func() error {
 		statusStr, _ := cmd.Flags().GetString("status")
-		minAmount, _ := cmd.Flags().GetInt64("min_amount")
+		minAmount, _ := cmd.Flags().GetInt64("min-amount")
 
 		if statusStr != "" {
 			statusFilter, ok := parseVTXOStatus(
@@ -145,7 +145,7 @@ func newVTXOsRefreshCmd() *cobra.Command {
 			"extending the VTXOs' expiry.\n\n" +
 			"A refresh is charged an operator fee, set by the " +
 			"server-issued quote at seal time. Pass " +
-			"`--dry_run` to preview an itemized advisory " +
+			"`--dry-run` to preview an itemized advisory " +
 			"estimate without queuing anything. An " +
 			"interactive refresh shows the estimate and asks " +
 			"for confirmation; pass `--yes` to skip the " +
@@ -155,11 +155,11 @@ func newVTXOsRefreshCmd() *cobra.Command {
 			"PendingRoundAssembly state. By default this " +
 			"command then issues `ark rounds join` on the " +
 			"caller's behalf so refresh is a one-shot " +
-			"operation. Pass `--no_join` to skip the join — " +
+			"operation. Pass `--no-join` to skip the join — " +
 			"useful for batching multiple refresh and/or " +
 			"leave RPCs into the same round (one shared " +
 			"change marker, one shared commitment fee). When " +
-			"`--no_join` is used, call `ark rounds join` " +
+			"`--no-join` is used, call `ark rounds join` " +
 			"explicitly once the batch is queued.",
 		RunE: vtxosRefresh,
 	}
@@ -170,14 +170,14 @@ func newVTXOsRefreshCmd() *cobra.Command {
 	cmd.Flags().Bool("all", false,
 		"refresh all live VTXOs")
 
-	cmd.Flags().Bool("dry_run", false,
+	cmd.Flags().Bool("dry-run", false,
 		"validate without queuing and preview the estimated "+
 			"operator fee")
 
 	cmd.Flags().Bool("yes", false,
 		"skip the interactive fee confirmation")
 
-	cmd.Flags().Bool("no_join", false,
+	cmd.Flags().Bool("no-join", false,
 		"skip the implicit `ark rounds join` follow-up so this "+
 			"refresh can batch with other queued intents")
 
@@ -233,7 +233,7 @@ func vtxosRefresh(cmd *cobra.Command, _ []string) error {
 			"outpoint",
 		)
 		all, _ := cmd.Flags().GetBool("all")
-		dryRun, _ := cmd.Flags().GetBool("dry_run")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
 
 		built, err := buildRefreshVTXOsRequest(
 			outpoints, all, dryRun,
@@ -303,7 +303,7 @@ func vtxosRefresh(cmd *cobra.Command, _ []string) error {
 		)
 	}
 
-	noJoin, _ := cmd.Flags().GetBool("no_join")
+	noJoin, _ := cmd.Flags().GetBool("no-join")
 
 	return maybeJoinNextRound(cmd, client, req.DryRun, noJoin)
 }
@@ -392,7 +392,7 @@ func summarizeRefreshFeeEstimate(est *waverpc.RefreshFeeEstimate) []string {
 // consent) or when req.DryRun is set (previewing, not spending).
 //
 // When stdin is not a TTY (agents, CI, pipelines), the function
-// refuses to prompt — the caller must pass --yes or --dry_run — so a
+// refuses to prompt — the caller must pass --yes or --dry-run — so a
 // non-interactive invocation is never blocked on a y/N it cannot
 // answer. Only on a TTY does it fetch the advisory estimate (via the
 // same RPC in dry-run form, through fetchPreview) and prompt, so the
@@ -419,7 +419,7 @@ func confirmRefreshIfNeeded(cmd *cobra.Command,
 		return PrintError(
 			"INVALID_ARGS", "refresh is charged an operator "+
 				"fee at seal time and requires --yes "+
-				"(explicit consent) or --dry_run (fee "+
+				"(explicit consent) or --dry-run (fee "+
 				"preview) on non-interactive stdin; "+
 				"refusing to prompt because an agent "+
 				"cannot respond to y/N",
@@ -527,11 +527,11 @@ func newVTXOsLeaveCmd() *cobra.Command {
 			"any queued refresh intents. By default this " +
 			"command then issues `ark rounds join` on the " +
 			"caller's behalf so leave is a one-shot " +
-			"operation. Pass `--no_join` to skip the join — " +
+			"operation. Pass `--no-join` to skip the join — " +
 			"useful for batching multiple leave and/or " +
 			"refresh RPCs into the same round (one shared " +
 			"change marker, one shared commitment fee). When " +
-			"`--no_join` is used, call `ark rounds join` " +
+			"`--no-join` is used, call `ark rounds join` " +
 			"explicitly once the batch is queued.",
 		RunE: vtxosLeave,
 	}
@@ -545,21 +545,21 @@ func newVTXOsLeaveCmd() *cobra.Command {
 	cmd.Flags().String("address", "",
 		"default on-chain destination address")
 
-	cmd.Flags().String("pk_script", "",
-		"default destination pk_script (hex); "+
+	cmd.Flags().String("pk-script", "",
+		"default destination pk-script (hex); "+
 			"alternative to --address")
 
 	cmd.Flags().StringToString("destination", nil,
 		"per-outpoint destination override: "+
 			"outpoint=addr or outpoint=script:<hex>")
 
-	cmd.Flags().Bool("dry_run", false,
+	cmd.Flags().Bool("dry-run", false,
 		"validate without queuing")
 
 	cmd.Flags().Bool("yes", false,
 		"skip interactive confirmation for --all")
 
-	cmd.Flags().Bool("no_join", false,
+	cmd.Flags().Bool("no-join", false,
 		"skip the implicit `ark rounds join` follow-up so this "+
 			"leave can batch with other queued intents")
 
@@ -581,11 +581,11 @@ func vtxosLeave(cmd *cobra.Command, _ []string) error {
 		outpoints, _ := cmd.Flags().GetStringSlice("outpoint")
 		all, _ := cmd.Flags().GetBool("all")
 		addr, _ := cmd.Flags().GetString("address")
-		pkScriptHex, _ := cmd.Flags().GetString("pk_script")
+		pkScriptHex, _ := cmd.Flags().GetString("pk-script")
 		destPairs, _ := cmd.Flags().GetStringToString(
 			"destination",
 		)
-		dryRun, _ := cmd.Flags().GetBool("dry_run")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
 
 		built, err := buildLeaveVTXOsRequest(
 			outpoints, all, addr, pkScriptHex, destPairs, dryRun,
@@ -622,7 +622,7 @@ func vtxosLeave(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	noJoin, _ := cmd.Flags().GetBool("no_join")
+	noJoin, _ := cmd.Flags().GetBool("no-join")
 
 	return maybeJoinNextRound(cmd, client, req.DryRun, noJoin)
 }
@@ -635,7 +635,7 @@ type autoJoinDecision struct {
 
 	// Notice is the stderr line that explains the decision so a
 	// human reading the terminal can see whether the round was
-	// auto-joined, deferred (--no_join), or skipped (--dry_run).
+	// auto-joined, deferred (--no-join), or skipped (--dry-run).
 	Notice string
 }
 
@@ -651,7 +651,7 @@ func decideAutoJoin(dryRun, noJoin bool) autoJoinDecision {
 
 	case noJoin:
 		return autoJoinDecision{
-			Notice: "--no_join set: intents queued; " +
+			Notice: "--no-join set: intents queued; " +
 				"run `ark rounds join` to commit",
 		}
 
@@ -659,15 +659,15 @@ func decideAutoJoin(dryRun, noJoin bool) autoJoinDecision {
 		return autoJoinDecision{
 			Join: true,
 			Notice: "auto-joined next round; " +
-				"pass --no_join to skip",
+				"pass --no-join to skip",
 		}
 	}
 }
 
 // maybeJoinNextRound issues the JoinNextRound RPC unless the caller
-// opted out via --no_join or asked for a dry run. The auto-join makes
+// opted out via --no-join or asked for a dry run. The auto-join makes
 // refresh / leave one-shot operations by default while preserving the
-// batched workflow via --no_join. A short status line goes to stderr so
+// batched workflow via --no-join. A short status line goes to stderr so
 // stdout JSON stays parseable by piped consumers.
 func maybeJoinNextRound(cmd *cobra.Command, client waverpc.DaemonServiceClient,
 	dryRun, noJoin bool) error {
@@ -737,10 +737,10 @@ func buildLeaveVTXOsRequest(outpoints []string, all bool, addr,
 		}
 	}
 
-	// Default destination: at most one of --address / --pk_script.
+	// Default destination: at most one of --address / --pk-script.
 	switch {
 	case addr != "" && pkScriptHex != "":
-		return nil, fmt.Errorf("--address and --pk_script are " +
+		return nil, fmt.Errorf("--address and --pk-script are " +
 			"mutually exclusive")
 
 	case addr != "":
@@ -753,7 +753,7 @@ func buildLeaveVTXOsRequest(outpoints []string, all bool, addr,
 	case pkScriptHex != "":
 		raw, err := hex.DecodeString(pkScriptHex)
 		if err != nil {
-			return nil, fmt.Errorf("invalid --pk_script hex: %w",
+			return nil, fmt.Errorf("invalid --pk-script hex: %w",
 				err)
 		}
 
@@ -793,7 +793,7 @@ func buildLeaveVTXOsRequest(outpoints []string, all bool, addr,
 	// validates outpoint strings, which we don't parse on the CLI
 	// side to avoid the btcd import weight).
 	if req.DefaultDestination == nil && len(req.Destinations) == 0 {
-		return nil, fmt.Errorf("either --address / --pk_script " +
+		return nil, fmt.Errorf("either --address / --pk-script " +
 			"(default destination) or --destination " +
 			"(per-outpoint overrides) is required")
 	}
@@ -842,7 +842,7 @@ func parseDestinationValue(raw string) (*waverpc.LeaveDestination, error) {
 //
 // When stdin is not a TTY (agents, CI, pipelines), the function
 // refuses to prompt: an interactive y/N read would block forever or
-// race against piped stdin. The caller must pass --yes or --dry_run
+// race against piped stdin. The caller must pass --yes or --dry-run
 // explicitly. Only when stdin IS a TTY does the function fall back
 // to the interactive prompt for ergonomics during operator use.
 func confirmLeaveAllIfNeeded(cmd *cobra.Command,
@@ -865,7 +865,7 @@ func confirmLeaveAllIfNeeded(cmd *cobra.Command,
 	if !stdinIsTTY(cmd) {
 		return PrintError(
 			"INVALID_ARGS", "--all requires --yes (explicit "+
-				"consent) or --dry_run (preview) on "+
+				"consent) or --dry-run (preview) on "+
 				"non-interactive stdin; refusing to prompt "+
 				"because an agent cannot respond to y/N",
 		)
@@ -882,7 +882,7 @@ var stdinIsTTY = defaultStdinIsTTY
 
 // defaultStdinIsTTY reports whether the y/N prompt is safe to drive
 // on the given command, returning true when the prompt may proceed
-// and false when the caller must pass --yes or --dry_run instead.
+// and false when the caller must pass --yes or --dry-run instead.
 //
 // Two paths return true (prompt is safe):
 //

--- a/cmd/wavecli/waveclicommands/cmd_vtxos_autojoin_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos_autojoin_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TestDecideAutoJoinDefault verifies that the default path (neither
-// --dry_run nor --no_join) opts in to the implicit JoinNextRound RPC.
+// --dry-run nor --no-join) opts in to the implicit JoinNextRound RPC.
 // This is the one-shot ergonomics fix: refresh / leave should not
 // require a follow-up `ark rounds join` for the common case.
 func TestDecideAutoJoinDefault(t *testing.T) {
@@ -16,11 +16,11 @@ func TestDecideAutoJoinDefault(t *testing.T) {
 	d := decideAutoJoin(false, false)
 	require.True(t, d.Join)
 	require.Contains(t, d.Notice, "auto-joined")
-	require.Contains(t, d.Notice, "--no_join")
+	require.Contains(t, d.Notice, "--no-join")
 }
 
 // TestDecideAutoJoinDryRunSkips verifies that a dry-run preview never
-// commits a round, regardless of --no_join. The notice tells the user
+// commits a round, regardless of --no-join. The notice tells the user
 // the join was skipped because of the dry run.
 func TestDecideAutoJoinDryRunSkips(t *testing.T) {
 	t.Parallel()
@@ -29,7 +29,7 @@ func TestDecideAutoJoinDryRunSkips(t *testing.T) {
 	require.False(t, d.Join)
 	require.Contains(t, d.Notice, "dry run")
 
-	// --no_join is redundant under --dry_run but must not flip
+	// --no-join is redundant under --dry-run but must not flip
 	// Join back on or cause a surprising notice.
 	d = decideAutoJoin(true, true)
 	require.False(t, d.Join)
@@ -37,7 +37,7 @@ func TestDecideAutoJoinDryRunSkips(t *testing.T) {
 }
 
 // TestDecideAutoJoinNoJoinDefers verifies the batching opt-out: with
-// --no_join the caller takes responsibility for invoking `ark rounds
+// --no-join the caller takes responsibility for invoking `ark rounds
 // join` explicitly, and the stderr notice points at that follow-up
 // command.
 func TestDecideAutoJoinNoJoinDefers(t *testing.T) {
@@ -45,6 +45,6 @@ func TestDecideAutoJoinNoJoinDefers(t *testing.T) {
 
 	d := decideAutoJoin(false, true)
 	require.False(t, d.Join)
-	require.Contains(t, d.Notice, "--no_join")
+	require.Contains(t, d.Notice, "--no-join")
 	require.Contains(t, d.Notice, "ark rounds join")
 }

--- a/cmd/wavecli/waveclicommands/cmd_vtxos_leave_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos_leave_test.go
@@ -90,7 +90,7 @@ func TestBuildLeaveVTXOsRequestAll(t *testing.T) {
 }
 
 // TestBuildLeaveVTXOsRequestPkScriptDefault verifies the
-// --pk_script alternative to --address: the default destination is
+// --pk-script alternative to --address: the default destination is
 // built from raw hex-decoded bytes.
 func TestBuildLeaveVTXOsRequestPkScriptDefault(t *testing.T) {
 	t.Parallel()
@@ -115,7 +115,7 @@ func TestBuildLeaveVTXOsRequestPkScriptDefault(t *testing.T) {
 }
 
 // TestBuildLeaveVTXOsRequestRejectsBothAddressAndPkScript locks in
-// the mutually-exclusive check on --address vs --pk_script for the
+// the mutually-exclusive check on --address vs --pk-script for the
 // default destination.
 func TestBuildLeaveVTXOsRequestRejectsBothAddressAndPkScript(t *testing.T) {
 	t.Parallel()
@@ -217,7 +217,7 @@ func TestBuildLeaveVTXOsRequestRejectsOutpointAndAll(t *testing.T) {
 }
 
 // TestBuildLeaveVTXOsRequestRejectsInvalidPkScriptHex locks in the
-// error path for a typo in --pk_script.
+// error path for a typo in --pk-script.
 func TestBuildLeaveVTXOsRequestRejectsInvalidPkScriptHex(t *testing.T) {
 	t.Parallel()
 
@@ -230,7 +230,7 @@ func TestBuildLeaveVTXOsRequestRejectsInvalidPkScriptHex(t *testing.T) {
 		false,
 	)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid --pk_script hex")
+	require.Contains(t, err.Error(), "invalid --pk-script hex")
 }
 
 // TestParseDestinationValueAddress verifies that a plain string is
@@ -304,7 +304,7 @@ func TestConfirmLeaveAllIfNeededJSONStillPrompts(t *testing.T) {
 
 	err := confirmLeaveAllIfNeeded(cmd, req)
 	require.Error(
-		t, err, "selection=all without --yes/--dry_run must abort "+
+		t, err, "selection=all without --yes/--dry-run must abort "+
 			"when stdin says 'n'",
 	)
 	require.Contains(t, err.Error(), "aborted by user")
@@ -328,10 +328,10 @@ func TestConfirmLeaveAllIfNeededAcceptsYes(t *testing.T) {
 
 // TestConfirmLeaveAllIfNeededNonTTYRefusesPrompt is the agent-cli
 // regression guard: when stdin is not a terminal (the production
-// agent / pipeline path), --all without --yes or --dry_run must NOT
+// agent / pipeline path), --all without --yes or --dry-run must NOT
 // hit the y/N prompt. Instead the function fails fast with an
 // INVALID_ARGS envelope so an agent gets exit code 2 and a clear
-// error directing it to pass --yes or --dry_run, rather than
+// error directing it to pass --yes or --dry-run, rather than
 // hanging on a read of a closed stdin.
 func TestConfirmLeaveAllIfNeededNonTTYRefusesPrompt(t *testing.T) {
 	// NOT t.Parallel() — we override the package-level

--- a/cmd/wavecli/waveclicommands/cmd_vtxos_refresh_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos_refresh_test.go
@@ -109,7 +109,7 @@ func TestConfirmRefreshYesFlagBypasses(t *testing.T) {
 
 // TestConfirmRefreshNonTTYRefusesPrompt is the agent-safety guard the
 // issue's acceptance criteria require: a non-interactive invocation
-// without --yes or --dry_run fails fast with an INVALID_ARGS envelope
+// without --yes or --dry-run fails fast with an INVALID_ARGS envelope
 // instead of blocking on a prompt an agent cannot answer.
 func TestConfirmRefreshNonTTYRefusesPrompt(t *testing.T) {
 	// NOT t.Parallel() — overrides the package-level stdinIsTTY
@@ -130,7 +130,7 @@ func TestConfirmRefreshNonTTYRefusesPrompt(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "--yes")
-	require.Contains(t, err.Error(), "--dry_run")
+	require.Contains(t, err.Error(), "--dry-run")
 	require.True(
 		t, ErrorWasPrinted(err),
 		"expected a printedError so main.go exits with the "+
@@ -612,7 +612,7 @@ func TestVTXOsRefreshWiringDeclineNeverDispatches(t *testing.T) {
 	require.Zero(t, fake.joinCalls)
 }
 
-// TestVTXOsRefreshWiringDryRunPrintsSummary verifies the --dry_run
+// TestVTXOsRefreshWiringDryRunPrintsSummary verifies the --dry-run
 // flag path end to end: one dry-run RPC, no join, no prompt, and the
 // stderr summary carries the estimate headline.
 func TestVTXOsRefreshWiringDryRunPrintsSummary(t *testing.T) {
@@ -638,7 +638,7 @@ func TestVTXOsRefreshWiringDryRunPrintsSummary(t *testing.T) {
 
 	cmd, out := newRefreshTestCmd(t, "" /* no stdin */)
 	require.NoError(t, cmd.Flags().Set("outpoint", "aa:0"))
-	require.NoError(t, cmd.Flags().Set("dry_run", "true"))
+	require.NoError(t, cmd.Flags().Set("dry-run", "true"))
 
 	require.NoError(t, vtxosRefresh(cmd, nil))
 	require.Len(t, fake.refreshReqs, 1)
@@ -667,7 +667,7 @@ func TestVTXOsRefreshWiringOldDaemonWarns(t *testing.T) {
 
 	cmd, out := newRefreshTestCmd(t, "" /* no stdin */)
 	require.NoError(t, cmd.Flags().Set("outpoint", "aa:0"))
-	require.NoError(t, cmd.Flags().Set("dry_run", "true"))
+	require.NoError(t, cmd.Flags().Set("dry-run", "true"))
 
 	require.NoError(t, vtxosRefresh(cmd, nil))
 	require.Contains(t, out.String(), "no fee estimate")

--- a/cmd/wavecli/waveclicommands/devrpc/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/devrpc/AGENTS.md
@@ -18,8 +18,8 @@ hand-written code.
   tree rooted at `dev`. Child commands are organized by service then method.
 - `methodDescription` — Agent-CLI schema dump for one method: `Method`,
   `Service`, `RequestType`, `ResponseType`, `ServerStreaming`, `Fields`.
-- `fieldDescription` — Flat schema row for one CLI flag: `Path`, `Type`,
-  `Repeated`, `OneofGroup`, `EnumValues`, `Description`.
+- `fieldDescription` — Flat schema row for one canonical kebab-case CLI flag:
+  `Path`, `Type`, `Repeated`, `OneofGroup`, `EnumValues`, `Description`.
 
 ## Design
 

--- a/cmd/wavecli/waveclicommands/devrpc/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/devrpc/CLAUDE.md
@@ -18,8 +18,8 @@ hand-written code.
   tree rooted at `dev`. Child commands are organized by service then method.
 - `methodDescription` — Agent-CLI schema dump for one method: `Method`,
   `Service`, `RequestType`, `ResponseType`, `ServerStreaming`, `Fields`.
-- `fieldDescription` — Flat schema row for one CLI flag: `Path`, `Type`,
-  `Repeated`, `OneofGroup`, `EnumValues`, `Description`.
+- `fieldDescription` — Flat schema row for one canonical kebab-case CLI flag:
+  `Path`, `Type`, `Repeated`, `OneofGroup`, `EnumValues`, `Description`.
 
 ## Design
 

--- a/cmd/wavecli/waveclicommands/devrpc/describe.go
+++ b/cmd/wavecli/waveclicommands/devrpc/describe.go
@@ -70,7 +70,7 @@ func describeMethod(service protoreflect.FullName, method rpcMethod,
 func describeBinder(b *fieldBinder) fieldDescription {
 	leaf := b.leaf()
 	row := fieldDescription{
-		Path:        b.flagName,
+		Path:        canonicalFlagPath(b.flagName),
 		Type:        describeKind(leaf, b.inputKind),
 		Repeated:    leaf.IsList(),
 		Description: descriptorComment(leaf),
@@ -101,6 +101,12 @@ func describeBinder(b *fieldBinder) fieldDescription {
 	}
 
 	return row
+}
+
+// canonicalFlagPath converts proto-style field names into the kebab-case
+// spelling registered by the generated CLI's global normalization function.
+func canonicalFlagPath(path string) string {
+	return strings.ReplaceAll(path, "_", "-")
 }
 
 // describeKind names the field's input kind in a way that matches

--- a/cmd/wavecli/waveclicommands/devrpc/describe_test.go
+++ b/cmd/wavecli/waveclicommands/devrpc/describe_test.go
@@ -38,18 +38,19 @@ func TestDevDescribeDumpsMethodSchema(t *testing.T) {
 	require.Equal(t, "waverpc.ListVTXOsResponse", desc.ResponseType)
 	require.False(t, desc.ServerStreaming)
 
-	// status_filter is an enum field — describe should surface
+	// status-filter is an enum field — describe should surface
 	// the enum value list so an agent doesn't have to grep proto
 	// sources for the legal names.
 	var statusField *fieldDescription
 	for i := range desc.Fields {
-		if desc.Fields[i].Path == "status_filter" {
+		require.NotContains(t, desc.Fields[i].Path, "_")
+		if desc.Fields[i].Path == "status-filter" {
 			statusField = &desc.Fields[i]
 
 			break
 		}
 	}
-	require.NotNil(t, statusField, "status_filter must appear in schema")
+	require.NotNil(t, statusField, "status-filter must appear in schema")
 	require.Equal(t, "enum", statusField.Type)
 	require.Contains(t, statusField.EnumValues, "VTXO_STATUS_LIVE")
 }

--- a/cmd/wavecli/waveclicommands/flag_normalization.go
+++ b/cmd/wavecli/waveclicommands/flag_normalization.go
@@ -1,0 +1,13 @@
+package waveclicommands
+
+import (
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// snakeToKebabFlags folds a snake_case flag name onto its canonical
+// kebab-case spelling so both forms resolve to the same flag.
+func snakeToKebabFlags(_ *pflag.FlagSet, name string) pflag.NormalizedName {
+	return pflag.NormalizedName(strings.ReplaceAll(name, "_", "-"))
+}

--- a/cmd/wavecli/waveclicommands/flag_normalization_test.go
+++ b/cmd/wavecli/waveclicommands/flag_normalization_test.go
@@ -1,0 +1,52 @@
+package waveclicommands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCanonicalFlagNamesUseKebabCase walks the real command tree so help and
+// schema-oriented callers never learn a snake_case CLI spelling.
+func TestCanonicalFlagNamesUseKebabCase(t *testing.T) {
+	t.Parallel()
+
+	root := newRootCmd(true)
+	var walk func(*cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		cmd.LocalNonPersistentFlags().VisitAll(func(flag *pflag.Flag) {
+			require.NotContainsf(
+				t, flag.Name, "_", "command %q flag %q is "+
+					"not kebab-case", cmd.CommandPath(),
+				flag.Name,
+			)
+		})
+		for _, child := range cmd.Commands() {
+			walk(child)
+		}
+	}
+	walk(root)
+}
+
+// TestSnakeCaseFlagsRemainAliases verifies normalization preserves scripts
+// that copied snake_case proto field names before launch.
+func TestSnakeCaseFlagsRemainAliases(t *testing.T) {
+	t.Parallel()
+
+	root := newRootCmd(false)
+	send := findRootCommand(t, root, "send")
+	require.NoError(t, send.Flags().Set("max_fee", "21"))
+
+	maxFee, err := send.Flags().GetUint64("max-fee")
+	require.NoError(t, err)
+	require.Equal(t, uint64(21), maxFee)
+
+	canonical := send.Flags().Lookup("max-fee")
+	alias := send.Flags().Lookup(strings.ReplaceAll(
+		canonical.Name, "-", "_",
+	))
+	require.Same(t, canonical, alias)
+}

--- a/cmd/wavecli/waveclicommands/flag_normalization_test.go
+++ b/cmd/wavecli/waveclicommands/flag_normalization_test.go
@@ -17,7 +17,7 @@ func TestCanonicalFlagNamesUseKebabCase(t *testing.T) {
 	root := newRootCmd(true)
 	var walk func(*cobra.Command)
 	walk = func(cmd *cobra.Command) {
-		cmd.LocalNonPersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
 			require.NotContainsf(
 				t, flag.Name, "_", "command %q flag %q is "+
 					"not kebab-case", cmd.CommandPath(),

--- a/cmd/wavecli/waveclicommands/mcp_wallet.go
+++ b/cmd/wavecli/waveclicommands/mcp_wallet.go
@@ -15,7 +15,7 @@ import (
 // operations carry secrets (wallet password, seed passphrase) that
 // must not transit the MCP protocol where they could leak into agent
 // logs or provider APIs. Wallet setup stays on the CLI's secret-input
-// ladder (WAVED_WALLET_PASSWORD env > --wallet_password_file > stdin
+// ladder (WAVED_WALLET_PASSWORD env > --wallet-password-file > stdin
 // > TTY prompt).
 //
 // Each tool maps gRPC Unimplemented to a clear "daemon was not built

--- a/cmd/wavecli/waveclicommands/oor_destination_test.go
+++ b/cmd/wavecli/waveclicommands/oor_destination_test.go
@@ -113,7 +113,7 @@ func TestMethodRegistrySendOORSchema(t *testing.T) {
 	require.Contains(t, paramNames, "to")
 	require.Contains(t, paramNames, "pubkey")
 	require.Contains(t, paramNames, "amount")
-	require.Contains(t, paramNames, "idempotency_key")
+	require.Contains(t, paramNames, "idempotency-key")
 }
 
 // TestMethodRegistryOORReceiveSchema verifies the public schema still exposes
@@ -139,8 +139,10 @@ func TestOORGetAcceptsSnakeCaseSessionID(t *testing.T) {
 		t.Run(spelling, func(t *testing.T) {
 			t.Parallel()
 
-			cmd := newOORGetCmd()
-			err := cmd.Flags().Parse([]string{spelling, "sess-1"})
+			root := newRootCmd(false)
+			cmd, _, err := root.Find([]string{"ark", "oor", "get"})
+			require.NoError(t, err)
+			err = cmd.Flags().Parse([]string{spelling, "sess-1"})
 			require.NoError(t, err)
 
 			got, err := cmd.Flags().GetString("session-id")

--- a/cmd/wavecli/waveclicommands/root.go
+++ b/cmd/wavecli/waveclicommands/root.go
@@ -186,6 +186,7 @@ func newRootCmd(devMode bool) *cobra.Command {
 	cmd.AddCommand(walletCmds...)
 	cmd.AddCommand(introspectionCmds...)
 	cmd.AddCommand(advancedCmds...)
+	cmd.SetGlobalNormalizationFunc(snakeToKebabFlags)
 
 	return cmd
 }

--- a/cmd/wavecli/waveclicommands/schema_registry.go
+++ b/cmd/wavecli/waveclicommands/schema_registry.go
@@ -41,9 +41,9 @@ type schemaMethod struct {
 	DryRunResponseType string `json:"dry_run_response_type,omitempty"`
 
 	// DryRun indicates whether the command supports --dry-run /
-	// --dry_run. Top-level wallet verbs use --dry-run (CLI-only
-	// validation, exits 10); ark.* commands use --dry_run that
-	// reaches the daemon's dry-run RPC field.
+	// --dry-run. Top-level wallet verbs use --dry-run (CLI-only
+	// validation, exits 10); ark.* commands use --dry-run that
+	// reaches the daemon's dry_run RPC field.
 	DryRun bool `json:"dry_run,omitempty"`
 
 	// JSONInput indicates the command accepts --request-json for raw proto
@@ -107,13 +107,13 @@ func walletAdminMethodRegistry() []schemaMethod {
 			Description: "Create a new wallet from a fresh seed",
 			Params: []schemaParam{
 				{
-					Name: "wallet_password_file",
+					Name: "wallet-password-file",
 					Type: "string",
 					Description: "path to file " +
 						"containing wallet password",
 				},
 				{
-					Name: "seed_passphrase_file",
+					Name: "seed-passphrase-file",
 					Type: "string",
 					Description: "path to file " +
 						"containing optional aezeed " +
@@ -136,7 +136,7 @@ func walletAdminMethodRegistry() []schemaMethod {
 			Description: "Unlock an existing wallet",
 			Params: []schemaParam{
 				{
-					Name: "wallet_password_file",
+					Name: "wallet-password-file",
 					Type: "string",
 					Description: "path to file " +
 						"containing wallet password",
@@ -186,7 +186,7 @@ func walletPaymentMethodRegistry() []schemaMethod {
 						"unless --sweep-all)",
 				},
 				{
-					Name: "max_fee",
+					Name: "max-fee",
 					Type: "uint64",
 					Description: "max fee in satoshis; " +
 						"zero uses daemon defaults",
@@ -256,7 +256,7 @@ func walletPaymentMethodRegistry() []schemaMethod {
 					Description: "optional invoice memo",
 				},
 				{
-					Name: "amt_hint",
+					Name: "amt-hint",
 					Type: "uint64",
 					Description: "optional expected " +
 						"deposit amount (--onchain)",
@@ -626,7 +626,7 @@ func arkVTXOMethodRegistry() []schemaMethod {
 					},
 				},
 				{
-					Name:        "min_amount",
+					Name:        "min-amount",
 					Type:        "int64",
 					Description: "minimum amount in sats",
 				},
@@ -638,9 +638,9 @@ func arkVTXOMethodRegistry() []schemaMethod {
 		{
 			Method: "ark.vtxos.refresh",
 			Description: "Queue VTXOs for refresh and join the " +
-				"next round (auto-joins unless --no_join). " +
+				"next round (auto-joins unless --no-join). " +
 				"Charged an operator fee at seal time; " +
-				"--dry_run previews an itemized estimate, " +
+				"--dry-run previews an itemized estimate, " +
 				"and a real refresh requires --yes on " +
 				"non-interactive stdin",
 			Params: []schemaParam{
@@ -662,7 +662,7 @@ func arkVTXOMethodRegistry() []schemaMethod {
 						"fee confirmation",
 				},
 				{
-					Name: "no_join",
+					Name: "no-join",
 					Type: "bool",
 					Description: "skip the implicit " +
 						"`ark rounds join` follow-up",
@@ -677,7 +677,7 @@ func arkVTXOMethodRegistry() []schemaMethod {
 			Method: "ark.vtxos.leave",
 			Description: "Queue VTXOs for cooperative leave " +
 				"(offboard) and join the next round " +
-				"(auto-joins unless --no_join)",
+				"(auto-joins unless --no-join)",
 			Params: []schemaParam{
 				{
 					Name: "outpoint",
@@ -697,7 +697,7 @@ func arkVTXOMethodRegistry() []schemaMethod {
 						"destination address",
 				},
 				{
-					Name: "pk_script",
+					Name: "pk-script",
 					Type: "string",
 					Description: "default destination " +
 						"pk_script (hex)",
@@ -716,7 +716,7 @@ func arkVTXOMethodRegistry() []schemaMethod {
 						"interactive confirmation",
 				},
 				{
-					Name: "no_join",
+					Name: "no-join",
 					Type: "bool",
 					Description: "skip the implicit " +
 						"`ark rounds join` follow-up",
@@ -777,7 +777,7 @@ func arkSendMethodRegistry() []schemaMethod {
 						"pk_script)",
 				},
 				{
-					Name: "pk_script",
+					Name: "pk-script",
 					Type: "string",
 					Description: "recipient raw " +
 						"pk_script hex (exactly one " +
@@ -791,7 +791,7 @@ func arkSendMethodRegistry() []schemaMethod {
 					Description: "amount in sats",
 				},
 				{
-					Name: "idempotency_key",
+					Name: "idempotency-key",
 					Type: "string",
 					Description: "stable caller intent " +
 						"key for retry-safe OOR sends",

--- a/cmd/wavecli/waveclicommands/wallet_password.go
+++ b/cmd/wavecli/waveclicommands/wallet_password.go
@@ -31,7 +31,7 @@ func zeroBytes(b []byte) {
 
 // readSeedPassphrase reads the optional aezeed seed passphrase from
 // the same sources used for the wallet password: WAVED_SEED_PASSPHRASE
-// env var, then --seed_passphrase_file flag. Returns an empty (not
+// env var, then --seed-passphrase-file flag. Returns an empty (not
 // nil) slice when neither source is set so the passphrase is genuinely
 // optional. The CLI does NOT accept the seed passphrase via argv —
 // `ps aux` and `/proc/<pid>/cmdline` would otherwise leak it.
@@ -40,7 +40,7 @@ func readSeedPassphrase(cmd *cobra.Command) ([]byte, error) {
 		return []byte(env), nil
 	}
 
-	path, _ := cmd.Flags().GetString("seed_passphrase_file")
+	path, _ := cmd.Flags().GetString("seed-passphrase-file")
 	if path == "" {
 		return []byte{}, nil
 	}
@@ -56,7 +56,7 @@ func readSeedPassphrase(cmd *cobra.Command) ([]byte, error) {
 }
 
 // readPassword reads the wallet password from one of these sources, in
-// priority order: WAVED_WALLET_PASSWORD env > --wallet_password_file
+// priority order: WAVED_WALLET_PASSWORD env > --wallet-password-file
 // flag > stdin pipe > interactive prompt. The env var is checked first
 // so that automated environments (such as the wavelengthtest REPL) can set
 // it without stdin races. The CLI never accepts passwords via argv.
@@ -85,8 +85,8 @@ func readWalletPassword(cmd *cobra.Command,
 		return []byte(envPass), nil
 	}
 
-	// Check --wallet_password_file flag.
-	passFile, _ := cmd.Flags().GetString("wallet_password_file")
+	// Check --wallet-password-file flag.
+	passFile, _ := cmd.Flags().GetString("wallet-password-file")
 	if passFile != "" {
 		// The file path is explicitly provided by the CLI user; a
 		// variable path is the intended API.

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -164,7 +164,7 @@ echo -n 'your_password' | wavecli create
 
 # Via password file
 wavecli create \
-  --wallet_password_file=/path/to/password_file
+  --wallet-password-file=/path/to/password_file
 
 # Interactive (prompts for password on TTY)
 wavecli create
@@ -293,6 +293,10 @@ wavecli
 | `--json` | `false` | Emit machine-readable JSON output |
 | `--request-json` | | Raw JSON request payload (overrides bespoke flags) |
 
+Flag names are canonical kebab-case in help and examples. Equivalent
+snake_case spellings remain silent compatibility aliases; proto JSON and MCP
+argument field names remain snake_case.
+
 ### `getinfo`
 
 Display daemon status information.
@@ -319,7 +323,7 @@ Allocate an inbound payment surface.
 | `--offchain` | bool | Returns a BOLT-11 invoice via the swap subsystem (default) |
 | `--onchain` | bool | Returns a fresh boarding address |
 | `--amt` | uint | Required for `--offchain`; ignored for `--onchain` |
-| `--amt_hint` | uint | Optional expected amount for `--onchain` (accounting only) |
+| `--amt-hint` | uint | Optional expected amount for `--onchain` (accounting only) |
 | `--memo` | string | Optional memo embedded in the offchain invoice |
 
 ```bash
@@ -366,7 +370,7 @@ List VTXOs known to the wallet with optional filters.
 | Flag | Type | Description |
 |------|------|-------------|
 | `--status` | string | Filter: live, pending_forfeit, forfeiting, forfeited, spent, unilateral_exit, failed, spending |
-| `--min_amount` | int64 | Minimum amount in sats |
+| `--min-amount` | int64 | Minimum amount in sats |
 | `--fields` | string | Comma-separated field names to include |
 | `--ndjson` | bool | Emit one JSON object per VTXO (newline-delimited) |
 
@@ -375,7 +379,7 @@ List VTXOs known to the wallet with optional filters.
 wavecli ark vtxos list
 
 # Live VTXOs above 10k sats, only outpoint and amount
-wavecli ark vtxos list --status live --min_amount 10000 \
+wavecli ark vtxos list --status live --min-amount 10000 \
   --fields outpoint,amount_sat
 
 # Streaming NDJSON for piping to jq
@@ -385,7 +389,7 @@ wavecli ark vtxos list --ndjson | jq '.amount_sat'
 ### `ark vtxos refresh`
 
 Queue VTXOs for refresh in the next round and (by default) join that
-round immediately. Pass `--no_join` to leave the intent queued in
+round immediately. Pass `--no-join` to leave the intent queued in
 `PendingRoundAssembly` so it can batch with subsequent refresh / leave
 RPCs; commit the batch later with `ark rounds join`.
 
@@ -403,7 +407,7 @@ already-connected wallets.
 
 A refresh is charged an operator fee (on-chain share + liquidity +
 margin), set by the server-issued quote at seal time and auto-accepted
-up to the daemon's `maxoperatorfeesat` cap. `--dry_run` previews an
+up to the daemon's `maxoperatorfeesat` cap. `--dry-run` previews an
 itemized advisory estimate for the selected VTXOs — per outpoint:
 amount, remaining lifetime, liquidity / on-chain / margin components —
 resolved entirely from the daemon's own view, with no manual amount or
@@ -417,28 +421,28 @@ seal-time quote and may differ from any estimate.
 
 An interactive real refresh shows the estimate and asks for
 confirmation. On non-interactive stdin (agents, pipelines) the command
-refuses to prompt: pass `--yes` (explicit consent) or `--dry_run`
+refuses to prompt: pass `--yes` (explicit consent) or `--dry-run`
 (preview). This mirrors the `leave --all` consent gate.
 
 | Flag | Type | Description |
 |------|------|-------------|
 | `--outpoint` | string[] | VTXO outpoint(s) to refresh (txid:index) |
 | `--all` | bool | Refresh all live VTXOs |
-| `--dry_run` | bool | Validate without queuing and preview the estimated fee |
+| `--dry-run` | bool | Validate without queuing and preview the estimated fee |
 | `--yes` | bool | Skip the interactive fee confirmation |
-| `--no_join` | bool | Skip the implicit `ark rounds join` follow-up |
+| `--no-join` | bool | Skip the implicit `ark rounds join` follow-up |
 
 ```bash
 # Preview the itemized fee estimate without queuing anything
-wavecli ark vtxos refresh --outpoint <txid:idx> --dry_run
+wavecli ark vtxos refresh --outpoint <txid:idx> --dry-run
 
 # Explicit outpoints (auto-joins the next round; prompts with the
 # estimate on a TTY, requires --yes when stdin is not interactive)
 wavecli ark vtxos refresh --outpoint <txid:idx> --yes
 
 # Batch with other intents — explicitly join later
-wavecli ark vtxos refresh --outpoint <txid:idx> --yes --no_join
-wavecli ark vtxos leave   --outpoint <txid:idx> --no_join \
+wavecli ark vtxos refresh --outpoint <txid:idx> --yes --no-join
+wavecli ark vtxos leave   --outpoint <txid:idx> --no-join \
   --address bcrt1p...
 wavecli ark rounds join
 ```
@@ -452,7 +456,7 @@ Send via in-round refresh (waits for next round to commit).
 | `--to` | string[] | Recipient address(es) (bech32m) |
 | `--pubkey` | string[] | Recipient x-only pubkey hex(es); paired after `--to` entries |
 | `--amount` | int64[] | Amount(s) in sats (one per recipient, `--to` then `--pubkey` order) |
-| `--dry_run` | bool | Validate without submitting |
+| `--dry-run` | bool | Validate without submitting |
 
 ```bash
 wavecli ark send inround --to bcrt1p... --amount 50000
@@ -480,13 +484,13 @@ Send via out-of-round transfer (immediate, through operator).
 | `--to` | string | Recipient address (one of `--to` / `--pubkey`) |
 | `--pubkey` | string | Recipient 32-byte x-only pubkey hex |
 | `--amount` | int64 | Amount in sats |
-| `--idempotency_key` | string | Caller-provided key for retry-safe sends |
-| `--dry_run` | bool | Validate without initiating |
+| `--idempotency-key` | string | Caller-provided key for retry-safe sends |
+| `--dry-run` | bool | Validate without initiating |
 
 ```bash
 wavecli ark send oor --pubkey <pubkey_xonly_hex> --amount 25000
 wavecli ark send oor --pubkey <hex> --amount 25000 \
-  --idempotency_key my-attempt-1
+  --idempotency-key my-attempt-1
 ```
 
 ### `send <invoice-or-address>` (wavewalletrpc)
@@ -507,7 +511,7 @@ pass `--force` or `--yes` to skip the confirmation prompt.
 | `--offchain` | bool | BOLT-11 dispatch via swap subsystem (default) |
 | `--onchain` | bool | Atomic onchain send via `SendOnChain` |
 | `--amt` | uint | Amount in sats (required for onchain unless `--sweep-all`) |
-| `--max_fee` | uint | Max swap fee in sats (invoice sends only) |
+| `--max-fee` | uint | Max swap fee in sats (invoice sends only) |
 | `--note` | string | Caller-supplied label |
 | `--sweep-all` | bool | Onchain only: drain wallet; `--amt` must be 0 |
 | `--force` / `--yes` | bool | Skip the interactive confirmation prompt |
@@ -681,7 +685,7 @@ Wallet passwords are never accepted as CLI arguments. The priority
 order for password resolution:
 
 1. **Environment variable** -- `WAVED_WALLET_PASSWORD=pass`
-2. **Password file** -- `--wallet_password_file=/path/to/file`
+2. **Password file** -- `--wallet-password-file=/path/to/file`
 3. **stdin pipe** -- `echo -n 'pass' | wavecli unlock`
 4. **Interactive prompt** -- prompted on TTY if none of the above
 

--- a/docs/dev_rpc_cli_builder.md
+++ b/docs/dev_rpc_cli_builder.md
@@ -42,7 +42,7 @@ Examples:
 ```shell
 wavecli dev waverpc.DaemonService GetInfo
 wavecli dev daemon getinfo
-wavecli dev daemon list-vtxos --status_filter live
+wavecli dev daemon list-vtxos --status-filter live
 wavecli dev swapclient start-pay --invoice <bolt11>
 ```
 
@@ -55,15 +55,19 @@ The runtime builds request messages dynamically from protobuf descriptors.
 Generated flags use proto field names so the command stays predictable and
 does not drift from the wire contract.
 
+Help and examples show kebab-case flag names. The corresponding snake_case
+spellings remain silent aliases, while field names inside JSON payloads stay
+snake_case to match proto JSON.
+
 Field handling rules:
 
-- Scalar fields become `--field_name`.
+- Scalar fields become canonical `--field-name` flags.
 - Boolean fields become normal Cobra bool flags.
-- Repeated scalar fields become repeatable `--field_name` flags.
+- Repeated scalar fields become repeatable `--field-name` flags.
 - Bytes fields accept hex strings, with or without a `0x` prefix.
 - Enums accept numeric values, full enum value names, or lower aliases.
 - Singular nested message fields are flattened with dotted flag names.
-- Repeated messages and maps stay JSON via `--field_name-json`.
+- Repeated messages and maps stay JSON via `--field-name-json`.
 - The global `--json` flag remains a raw protojson escape hatch and takes
   precedence over generated flags.
 
@@ -72,12 +76,12 @@ Flattening is deliberately bounded to singular messages. For example:
 ```shell
 wavecli dev daemon prepare-oor \
   --recipient.address bcrt1... \
-  --recipient.amount_sat 1000
+  --recipient.amount-sat 1000
 
 wavecli dev daemon refresh-vtxos \
   --outpoints.outpoints txid:0 \
   --outpoints.outpoints txid:1 \
-  --dry_run
+  --dry-run
 ```
 
 Repeated message fields are not flattened because indexed flags would need a
@@ -101,7 +105,7 @@ oneofs reached through flattened paths. These two flags conflict:
 But multiple fields under the same selected message are allowed:
 
 ```shell
---recipient.address bcrt1... --recipient.amount_sat 1000
+--recipient.address bcrt1... --recipient.amount-sat 1000
 ```
 
 Daemon-side validation remains authoritative. The generated command only


### PR DESCRIPTION
Addresses P0-6 of #997.

## What changed

- install one global snake-to-kebab flag normalizer on the real Cobra tree
- rename hand-written snake_case flags to canonical kebab-case
- remove `create`'s duplicate hidden `mnemonic_file` and `recovery_window` registrations
- canonicalize generated `dev` flags without changing proto JSON or MCP argument field names
- update schema parameter names, help text, examples, and agent guidance
- add a real-tree test that rejects canonical flag names containing underscores
- add compatibility tests proving snake_case resolves to the same flag object

## Concrete impact

Before, help and examples exposed three casing regimes, including `send --max_fee` beside `--sweep-all`, and `create` maintained bespoke duplicate flags. After this change, help/schema teach kebab-case everywhere. Existing snake_case invocations continue to parse silently, so automation does not need an immediate migration.

The compatibility aliases are parser-level aliases, not duplicate flags: defaults, changed-state, validation, and help now have one source of truth.

## Validation

- `make unit pkg=./cmd/wavecli/...`
- `go test ./cmd/wavecli/... -race`
- `make lint-changed-local`
- manual help checks for `send`, `create`, and generated `dev daemon list-vtxos`
- `make commitmsg-lint range="origin/main..HEAD"`
