### PR TITLE
wavecli: define error and exit contract

### DIFF
--- a/cmd/wavecli/AGENTS.md
+++ b/cmd/wavecli/AGENTS.md
@@ -5,8 +5,8 @@
 Binary entry point for the `wavecli` CLI. `main` is a thin wrapper: it
 builds the root cobra command from `waveclicommands`, executes it, and
 maps any returned error onto a semantic process exit code (2=invalid args,
-3=auth, 4=not found, 10=dry-run) so scripting agents can branch on failure
-category without parsing stderr prose.
+3=auth, 4=not found, 5=confirmation required) so scripting agents can
+branch on failure category without parsing stderr prose.
 
 ## Relationships
 

--- a/cmd/wavecli/CLAUDE.md
+++ b/cmd/wavecli/CLAUDE.md
@@ -5,8 +5,8 @@
 Binary entry point for the `wavecli` CLI. `main` is a thin wrapper: it
 builds the root cobra command from `waveclicommands`, executes it, and
 maps any returned error onto a semantic process exit code (2=invalid args,
-3=auth, 4=not found, 10=dry-run) so scripting agents can branch on failure
-category without parsing stderr prose.
+3=auth, 4=not found, 5=confirmation required) so scripting agents can
+branch on failure category without parsing stderr prose.
 
 ## Relationships
 

--- a/cmd/wavecli/main.go
+++ b/cmd/wavecli/main.go
@@ -12,11 +12,11 @@ import (
 // main runs the wavecli root command and maps the returned error
 // onto a semantic exit code so agents can branch on the failure
 // category without parsing prose. See waveclicommands/exit_codes.go
-// for the full table (2=invalid args, 3=auth, 4=not found, 10=dry-run
-// passed). Any error that already carries the structured envelope set
-// by helpers like PrintError is treated as already-rendered; otherwise
-// we emit a normalized error envelope so stderr stays machine-readable
-// in every failure path.
+// for the full table (2=invalid args, 3=auth, 4=not found,
+// 5=confirmation required). Any error that already carries the
+// envelope set by helpers like PrintError is treated as already-rendered;
+// otherwise we emit a normalized error envelope so stderr stays
+// machine-readable in every failure path.
 func main() {
 	ctx, stop := signal.NotifyContext(
 		context.Background(), os.Interrupt, syscall.SIGTERM,

--- a/cmd/wavecli/waveclicommands/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/AGENTS.md
@@ -151,6 +151,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
 - JSON output (`stdout`) and diagnostic output (`stderr`) are kept on
   separate streams so shell pipelines can consume the JSON body while
   a human reading the terminal sees informative warnings.
+- Failure envelopes always include a stable `retryable` boolean and add
+  actionable `remediation` where the caller can recover. Invalid input exits
+  2, authentication failures 3, missing resources 4, and non-interactive
+  confirmation requirements 5. Successful dry runs exit 0.
 - `exit` defaults to a cooperative leave; it only starts a unilateral
   on-chain unroll when `--force-unroll-ack` matches the literal string
   `I_KNOW_WHAT_I_AM_DOING`, and that flag is mutually exclusive with

--- a/cmd/wavecli/waveclicommands/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/CLAUDE.md
@@ -151,6 +151,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
 - JSON output (`stdout`) and diagnostic output (`stderr`) are kept on
   separate streams so shell pipelines can consume the JSON body while
   a human reading the terminal sees informative warnings.
+- Failure envelopes always include a stable `retryable` boolean and add
+  actionable `remediation` where the caller can recover. Invalid input exits
+  2, authentication failures 3, missing resources 4, and non-interactive
+  confirmation requirements 5. Successful dry runs exit 0.
 - `exit` defaults to a cooperative leave; it only starts a unilateral
   on-chain unroll when `--force-unroll-ack` matches the literal string
   `I_KNOW_WHAT_I_AM_DOING`, and that flag is mutually exclusive with

--- a/cmd/wavecli/waveclicommands/client.go
+++ b/cmd/wavecli/waveclicommands/client.go
@@ -80,7 +80,8 @@ func getDaemonConn(cmd *cobra.Command) (*grpc.ClientConn, error) {
 			macaroonPath,
 		)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to load macaroon: %w",
+				err)
 		}
 
 		opts = append(opts, macaroonOpt)

--- a/cmd/wavecli/waveclicommands/cmd_ark.go
+++ b/cmd/wavecli/waveclicommands/cmd_ark.go
@@ -49,7 +49,7 @@ func newArkListTransactionsCmd() *cobra.Command {
 		Long: "Returns the daemon's unfiltered local transaction " +
 			"history (ledger + boarding sweeps) with full " +
 			"internal correlators. For the wallet-shaped view " +
-			"use `wavecli ark listtransactions`.",
+			"use `wavecli activity`.",
 		RunE: listTransactions,
 	}
 

--- a/cmd/wavecli/waveclicommands/cmd_exit.go
+++ b/cmd/wavecli/waveclicommands/cmd_exit.go
@@ -49,7 +49,7 @@ func newExitCmd() *cobra.Command {
 		"exact acknowledgement required to force unilateral unroll")
 	cmd.Flags().Bool("dry-run", false,
 		"validate inputs locally and print the preview without "+
-			"dispatching to the daemon; exits 10 on a valid "+
+			"dispatching to the daemon; exits 0 on a valid "+
 			"preview, non-zero on validation failure")
 
 	cmd.AddCommand(newExitStatusCmd())

--- a/cmd/wavecli/waveclicommands/cmd_inspect.go
+++ b/cmd/wavecli/waveclicommands/cmd_inspect.go
@@ -74,7 +74,10 @@ func validateInspectFormat(format string) error {
 		return nil
 
 	default:
-		return fmt.Errorf("unknown inspect format %q: expected json, "+
-			"expanded, or x", format)
+		return newCLIError(
+			ExitInvalidArgs,
+			fmt.Errorf("unknown inspect format %q: expected "+
+				"json, expanded, or x", format),
+		)
 	}
 }

--- a/cmd/wavecli/waveclicommands/cmd_recovery.go
+++ b/cmd/wavecli/waveclicommands/cmd_recovery.go
@@ -222,10 +222,10 @@ func confirmRecoveryEscalation(cmd *cobra.Command, recoveryID string) error {
 	}
 	if !stdinIsTTY(cmd) {
 		return PrintError(
-			"INVALID_ARGS", "recovery escalate requires --yes "+
-				"(explicit consent) on non-interactive "+
-				"stdin; refusing to prompt because an "+
-				"agent cannot respond to y/N",
+			confirmationRequiredCode, "recovery escalate "+
+				"requires --yes (explicit consent) on "+
+				"non-interactive stdin; refusing to prompt "+
+				"because an agent cannot respond to y/N",
 		)
 	}
 

--- a/cmd/wavecli/waveclicommands/cmd_send.go
+++ b/cmd/wavecli/waveclicommands/cmd_send.go
@@ -190,16 +190,8 @@ func walletSend(cmd *cobra.Command, args []string) error {
 			}
 
 			if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
-				if err := printWalletProto(
-					prepareResp,
-				); err != nil {
-					return err
-				}
-
-				return PrintError(
-					"DRY_RUN_OK", "dry-run validation "+
-						"passed; no funds were "+
-						"dispatched",
+				return printSendDryRunPreview(
+					cmd.OutOrStdout(), prepareResp,
 				)
 			}
 
@@ -297,8 +289,8 @@ func waitForSendTerminal(cmd *cobra.Command,
 	if id == "" {
 		return PrintError(
 			"WAIT_UNAVAILABLE", "send did not return an entry "+
-				"id to wait on; poll `da activity inspect "+
-				"<id>` manually",
+				"id to wait on; poll `wavecli activity "+
+				"inspect <id>` manually",
 		)
 	}
 
@@ -399,8 +391,8 @@ func waitForSendTerminal(cmd *cobra.Command,
 				case entryStatusComplete:
 					// On success collapse the verbose trace
 					// down to the compact summary; the full
-					// breakdown stays available via `da
-					// activity inspect <id>`.
+					// breakdown stays available via
+					// `wavecli activity inspect <id>`.
 					return printSendResult(
 						cmd.OutOrStdout(),
 						sendResultFromInspection(resp),
@@ -467,10 +459,13 @@ func confirmSendIfNeeded(cmd *cobra.Command,
 	}
 
 	if !stdinIsTTY(cmd) {
+		printSendPreview(cmd.ErrOrStderr(), resp)
+
 		return PrintError(
-			"INVALID_ARGS", "send requires --force or --yes on "+
-				"non-interactive stdin; refusing to prompt "+
-				"because an agent cannot respond to y/N",
+			confirmationRequiredCode, "send requires --force "+
+				"or --yes on non-interactive stdin; "+
+				"refusing to prompt because an agent "+
+				"cannot respond to y/N",
 		)
 	}
 
@@ -481,7 +476,26 @@ func promptSendConfirmation(cmd *cobra.Command,
 	resp *wavewalletrpc.PrepareSendResponse) error {
 
 	out := cmd.ErrOrStderr()
+	printSendPreview(out, resp)
+	fmt.Fprint(out, "\nProceed? [y/N]: ")
 
+	reader := bufio.NewReader(cmd.InOrStdin())
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read confirmation: %w", err)
+	}
+
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer != "y" && answer != "yes" {
+		return fmt.Errorf("aborted by user")
+	}
+
+	return nil
+}
+
+// printSendPreview writes the prepared amount, fee, rail, and destination
+// before either an interactive prompt or a non-interactive refusal.
+func printSendPreview(out io.Writer, resp *wavewalletrpc.PrepareSendResponse) {
 	fmt.Fprintf(out, "Send %d sats\n", sendPreviewHeadlineAmount(resp))
 	fmt.Fprintf(out, "Rail: %s\n", sendRailLabel(resp.GetRail()))
 	if resp.GetFeeKnown() {
@@ -512,20 +526,23 @@ func promptSendConfirmation(cmd *cobra.Command,
 	if warning := resp.GetWarning(); warning != "" {
 		fmt.Fprintf(out, "Warning: %s\n", warning)
 	}
-	fmt.Fprint(out, "\nProceed? [y/N]: ")
+}
 
-	reader := bufio.NewReader(cmd.InOrStdin())
-	answer, err := reader.ReadString('\n')
+// printSendDryRunPreview emits a successful preview with an explicit marker
+// and no error envelope.
+func printSendDryRunPreview(out io.Writer,
+	resp *wavewalletrpc.PrepareSendResponse) error {
+
+	body, err := walletProtoMarshal.Marshal(resp)
 	if err != nil {
-		return fmt.Errorf("read confirmation: %w", err)
+		return fmt.Errorf("marshal send dry-run preview: %w", err)
 	}
 
-	answer = strings.TrimSpace(strings.ToLower(answer))
-	if answer != "y" && answer != "yes" {
-		return fmt.Errorf("aborted by user")
-	}
+	_, err = fmt.Fprintf(
+		out, `{"dry_run":true,"preview":%s}`+"\n", body,
+	)
 
-	return nil
+	return err
 }
 
 func sendPreviewHeadlineAmount(resp *wavewalletrpc.PrepareSendResponse) int64 {

--- a/cmd/wavecli/waveclicommands/cmd_send_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_send_test.go
@@ -3,6 +3,7 @@ package waveclicommands
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -19,9 +20,18 @@ func TestConfirmSendIfNeededRefusesNonTTY(t *testing.T) {
 	})
 
 	cmd := newSendCmd()
-	err := confirmSendIfNeeded(cmd, &wavewalletrpc.PrepareSendResponse{})
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	err := confirmSendIfNeeded(cmd, &wavewalletrpc.PrepareSendResponse{
+		AmountSat: 21_000,
+		Rail: wavewalletrpc.
+			SendRail_SEND_RAIL_LIGHTNING,
+	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "non-interactive stdin")
+	require.Equal(t, ExitConfirmationRequired, ExitCodeFor(err))
+	require.Contains(t, stderr.String(), "Send 21000 sats")
+	require.Contains(t, stderr.String(), "Rail: Lightning")
 }
 
 func TestConfirmSendIfNeededForceSkipsPrompt(t *testing.T) {
@@ -128,6 +138,33 @@ func TestSendWaitErrorCode(t *testing.T) {
 	require.Equal(
 		t, "WAIT_TIMEOUT", sendWaitErrorCode(context.DeadlineExceeded),
 	)
+}
+
+func TestPrintSendDryRunPreviewIsSuccessfulJSON(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	err := printSendDryRunPreview(
+		&stdout, &wavewalletrpc.PrepareSendResponse{
+			AmountSat:      50_000,
+			ExpectedFeeSat: 123,
+			FeeKnown:       true,
+		},
+	)
+	require.NoError(t, err)
+
+	var preview struct {
+		DryRun  bool            `json:"dry_run"`
+		Preview json.RawMessage `json:"preview"`
+	}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &preview))
+	require.True(t, preview.DryRun)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(preview.Preview, &body))
+	require.Equal(t, "50000", body["amount_sat"])
+	require.Equal(t, "123", body["expected_fee_sat"])
+	require.Equal(t, true, body["fee_known"])
 }
 
 // TestSendWaitFlagDefaults verifies the wait family is wired with the expected

--- a/cmd/wavecli/waveclicommands/cmd_vtxos.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos.go
@@ -417,10 +417,10 @@ func confirmRefreshIfNeeded(cmd *cobra.Command,
 
 	if !stdinIsTTY(cmd) {
 		return PrintError(
-			"INVALID_ARGS", "refresh is charged an operator "+
-				"fee at seal time and requires --yes "+
-				"(explicit consent) or --dry-run (fee "+
-				"preview) on non-interactive stdin; "+
+			confirmationRequiredCode, "refresh is charged an "+
+				"operator fee at seal time and requires "+
+				"--yes (explicit consent) or --dry-run "+
+				"(fee preview) on non-interactive stdin; "+
 				"refusing to prompt because an agent "+
 				"cannot respond to y/N",
 		)
@@ -864,10 +864,10 @@ func confirmLeaveAllIfNeeded(cmd *cobra.Command,
 	// guard is the explicit replacement.
 	if !stdinIsTTY(cmd) {
 		return PrintError(
-			"INVALID_ARGS", "--all requires --yes (explicit "+
-				"consent) or --dry-run (preview) on "+
-				"non-interactive stdin; refusing to prompt "+
-				"because an agent cannot respond to y/N",
+			confirmationRequiredCode, "--all requires --yes "+
+				"(explicit consent) or --dry-run (preview) "+
+				"on non-interactive stdin; refusing to "+
+				"prompt because an agent cannot respond to y/N",
 		)
 	}
 

--- a/cmd/wavecli/waveclicommands/cmd_vtxos_leave_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos_leave_test.go
@@ -330,7 +330,7 @@ func TestConfirmLeaveAllIfNeededAcceptsYes(t *testing.T) {
 // regression guard: when stdin is not a terminal (the production
 // agent / pipeline path), --all without --yes or --dry-run must NOT
 // hit the y/N prompt. Instead the function fails fast with an
-// INVALID_ARGS envelope so an agent gets exit code 2 and a clear
+// confirmation-required envelope so an agent gets exit code 5 and a clear
 // error directing it to pass --yes or --dry-run, rather than
 // hanging on a read of a closed stdin.
 func TestConfirmLeaveAllIfNeededNonTTYRefusesPrompt(t *testing.T) {
@@ -358,8 +358,9 @@ func TestConfirmLeaveAllIfNeededNonTTYRefusesPrompt(t *testing.T) {
 	require.True(
 		t, ErrorWasPrinted(err),
 		"expected a printedError so main.go can exit with the "+
-			"INVALID_ARGS code",
+			"confirmation-required code",
 	)
+	require.Equal(t, ExitConfirmationRequired, ExitCodeFor(err))
 }
 
 // TestConfirmLeaveAllIfNeededYesFlagBypasses verifies the --yes flag

--- a/cmd/wavecli/waveclicommands/cmd_vtxos_refresh_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos_refresh_test.go
@@ -109,7 +109,7 @@ func TestConfirmRefreshYesFlagBypasses(t *testing.T) {
 
 // TestConfirmRefreshNonTTYRefusesPrompt is the agent-safety guard the
 // issue's acceptance criteria require: a non-interactive invocation
-// without --yes or --dry-run fails fast with an INVALID_ARGS envelope
+// without --yes or --dry-run fails fast with a confirmation-required envelope
 // instead of blocking on a prompt an agent cannot answer.
 func TestConfirmRefreshNonTTYRefusesPrompt(t *testing.T) {
 	// NOT t.Parallel() — overrides the package-level stdinIsTTY
@@ -134,8 +134,9 @@ func TestConfirmRefreshNonTTYRefusesPrompt(t *testing.T) {
 	require.True(
 		t, ErrorWasPrinted(err),
 		"expected a printedError so main.go exits with the "+
-			"INVALID_ARGS code",
+			"confirmation-required code",
 	)
+	require.Equal(t, ExitConfirmationRequired, ExitCodeFor(err))
 	require.False(t, previewed)
 }
 
@@ -565,6 +566,7 @@ func TestVTXOsRefreshWiringNonTTYNeverDispatches(t *testing.T) {
 	err := vtxosRefresh(cmd, nil)
 	require.Error(t, err)
 	require.True(t, ErrorWasPrinted(err))
+	require.Equal(t, ExitConfirmationRequired, ExitCodeFor(err))
 	require.Empty(
 		t, fake.refreshReqs, "the refusal must fire before any RPC",
 	)

--- a/cmd/wavecli/waveclicommands/error_format.go
+++ b/cmd/wavecli/waveclicommands/error_format.go
@@ -1,6 +1,7 @@
 package waveclicommands
 
 import (
+	"errors"
 	"io"
 	"strconv"
 	"strings"
@@ -11,9 +12,10 @@ import (
 )
 
 const (
-	defaultErrorCode = "EXECUTION_FAILED"
-	invalidArgsCode  = "INVALID_ARGS"
-	walletLockedCode = "WALLET_LOCKED"
+	defaultErrorCode         = "EXECUTION_FAILED"
+	invalidArgsCode          = "INVALID_ARGS"
+	walletLockedCode         = "WALLET_LOCKED"
+	confirmationRequiredCode = "CONFIRMATION_REQUIRED"
 )
 
 type commandError struct {
@@ -56,8 +58,23 @@ func formatCommandError(err error) commandError {
 		}
 	}
 
+	var cliErr *cliError
+	if errors.As(err, &cliErr) {
+		return commandError{
+			code:    cliCodeForExitCode(cliErr.code),
+			message: cliErr.err.Error(),
+		}
+	}
+
 	if waverpc.IsWalletNotReadyError(err) {
 		return formatWalletNotReadyError(err)
+	}
+
+	if credentialCode := credentialErrorCode(err); credentialCode != "" {
+		return commandError{
+			code:    credentialCode,
+			message: err.Error(),
+		}
 	}
 
 	if rpcErr, ok := parseRPCErrorChain(err.Error()); ok {
@@ -79,6 +96,95 @@ func formatCommandError(err error) commandError {
 		code:    defaultErrorCode,
 		message: err.Error(),
 	}
+}
+
+// cliCodeForExitCode maps explicit local classifications into the stable
+// public error-code vocabulary.
+func cliCodeForExitCode(exitCode int) string {
+	switch exitCode {
+	case ExitInvalidArgs:
+		return invalidArgsCode
+
+	case ExitAuthFailure:
+		return "AUTH_FAILURE"
+
+	case ExitNotFound:
+		return "NOT_FOUND"
+
+	case ExitConfirmationRequired:
+		return confirmationRequiredCode
+
+	default:
+		return defaultErrorCode
+	}
+}
+
+// credentialErrorCode recognizes local TLS and macaroon loading failures.
+func credentialErrorCode(err error) string {
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "tls cert") ||
+		strings.Contains(msg, "macaroon") {
+		return "AUTH_FAILURE"
+	}
+
+	return ""
+}
+
+// errorMetadata derives the stable retry and remediation contract from the
+// public error code. Message inspection is limited to local credential errors
+// that share AUTH_FAILURE but need different operator actions.
+func errorMetadata(code, message string) (bool, string) {
+	switch code {
+	case "UNAVAILABLE":
+		return true, "verify waved is running and --rpcserver points " +
+			"to it, then retry"
+
+	// DEADLINE_EXCEEDED, ABORTED, and WAIT_TIMEOUT can all fire after
+	// a fund-moving RPC has already been accepted by the daemon, so
+	// they are deliberately not retryable: a blind retry could
+	// double-spend. The remediation points at state inspection.
+	case "DEADLINE_EXCEEDED":
+		return false, "the request may already have been applied; " +
+			"check state (e.g. `wavecli activity`) before retrying"
+
+	case "ABORTED":
+		return false, "the request may already have been applied; " +
+			"check state before retrying"
+
+	case "RESOURCE_EXHAUSTED":
+		return true, "retry with backoff or reduce the request size"
+
+	case "WAIT_TIMEOUT":
+		return false, "inspect the returned activity id with " +
+			"`wavecli activity inspect <id>` before " +
+			"retrying the send"
+
+	case confirmationRequiredCode:
+		return false, "review the preview, then rerun with --yes " +
+			"to approve"
+
+	case "AUTH_FAILURE", "UNAUTHENTICATED", "PERMISSION_DENIED":
+		msg := strings.ToLower(message)
+		switch {
+		case strings.Contains(msg, "tls cert"):
+			return false, "verify --tlscertpath or start waved " +
+				"to create the certificate; use " +
+				"--no-tls only for trusted local " +
+				"development"
+
+		case strings.Contains(msg, "macaroon"):
+			return false, "verify --macaroonpath or start waved " +
+				"to create the macaroon; use " +
+				"--no-macaroons only for trusted " +
+				"local development"
+
+		default:
+			return false, "verify the daemon credentials and " +
+				"wallet state"
+		}
+	}
+
+	return false, ""
 }
 
 // formatWalletNotReadyError gives wallet lifecycle preconditions the

--- a/cmd/wavecli/waveclicommands/exit_codes.go
+++ b/cmd/wavecli/waveclicommands/exit_codes.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/lightninglabs/wavelength/waverpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -28,9 +29,10 @@ const (
 	// daemon (unknown round id, missing exit job, etc.).
 	ExitNotFound = 4
 
-	// ExitDryRunOK indicates a --dry-run invocation passed all local
-	// validation; no RPC was dispatched.
-	ExitDryRunOK = 10
+	// ExitConfirmationRequired indicates the command is valid but a
+	// fund-moving action needs explicit --yes approval in this
+	// non-interactive environment.
+	ExitConfirmationRequired = 5
 )
 
 // cliError wraps an underlying error with the exit code that main.go
@@ -78,6 +80,19 @@ func ExitCodeFor(err error) int {
 	var pe *printedError
 	if errors.As(err, &pe) {
 		return pe.ExitCode()
+	}
+
+	if credentialErrorCode(err) != "" {
+		return ExitAuthFailure
+	}
+
+	// Wallet lifecycle preconditions (locked / not created / syncing)
+	// map to the auth class so the process exit code agrees with the
+	// WALLET_LOCKED envelope formatCommandError emits; otherwise the
+	// gRPC FailedPrecondition mapping below would classify them as
+	// invalid args.
+	if waverpc.IsWalletNotReadyError(err) {
+		return ExitAuthFailure
 	}
 
 	// Map common gRPC status codes that the daemon returns onto the
@@ -154,10 +169,15 @@ var cobraArgErrorPrefixes = []string{
 	"unknown flag:",           // pflag: unrecognized flag
 	"unknown shorthand flag:", // pflag: unrecognized -x
 	"invalid argument",        // pflag: bad value for typed flag
-	"unknown command",         // cobra: unknown subcommand
-	"accepts ",                // cobra: ExactArgs/MaximumNArgs et al.
-	"requires at least",       // cobra: MinimumNArgs
-	"requires between",        // cobra: RangeArgs
-	"subcommand is required",  // cobra: NoArgs on a parent
+	// pflag: flag given without its value
+	"flag needs an argument:",
+	"bad flag syntax:",                // pflag: malformed flag token
+	"invalid --request-json payload:", // protojson: malformed raw request
+	"unknown command",                 // cobra: unknown subcommand
+	// cobra: ExactArgs/MaximumNArgs et al.
+	"accepts ",
+	"requires at least",      // cobra: MinimumNArgs
+	"requires between",       // cobra: RangeArgs
+	"subcommand is required", // cobra: NoArgs on a parent
 	"if any flags in the group",
 }

--- a/cmd/wavecli/waveclicommands/exit_codes_test.go
+++ b/cmd/wavecli/waveclicommands/exit_codes_test.go
@@ -2,8 +2,10 @@ package waveclicommands
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -14,10 +16,12 @@ import (
 func TestExitCodeForCLIError(t *testing.T) {
 	t.Parallel()
 
-	err := newCLIError(ExitDryRunOK, errors.New("preview"))
+	err := newCLIError(
+		ExitConfirmationRequired, errors.New("approval required"),
+	)
 
-	require.Equal(t, ExitDryRunOK, ExitCodeFor(err))
-	require.Equal(t, "preview", err.Error())
+	require.Equal(t, ExitConfirmationRequired, ExitCodeFor(err))
+	require.Equal(t, "approval required", err.Error())
 }
 
 // TestExitCodeForPrintedError verifies the printedError returned from
@@ -47,8 +51,8 @@ func TestExitCodeForPrintedError(t *testing.T) {
 			ExitNotFound,
 		},
 		{
-			"DRY_RUN_OK",
-			ExitDryRunOK,
+			confirmationRequiredCode,
+			ExitConfirmationRequired,
 		},
 		{
 			"SOMETHING_ELSE",
@@ -122,6 +126,40 @@ func TestExitCodeForNil(t *testing.T) {
 	require.False(t, ErrorWasPrinted(nil))
 }
 
+func TestExitCodeForCredentialLoadFailure(t *testing.T) {
+	t.Parallel()
+
+	cases := []error{
+		errors.New("unable to load TLS cert: file does not exist"),
+		errors.New("unable to load macaroon: file does not exist"),
+	}
+
+	for _, err := range cases {
+		require.Equal(t, ExitAuthFailure, ExitCodeFor(err))
+	}
+}
+
+// TestExitCodeForWalletNotReady verifies wallet lifecycle
+// preconditions exit with the auth code so the process status agrees
+// with the WALLET_LOCKED envelope, rather than the invalid-args code
+// the raw gRPC FailedPrecondition would otherwise produce.
+func TestExitCodeForWalletNotReady(t *testing.T) {
+	t.Parallel()
+
+	for _, state := range []string{
+		waverpc.WalletNotReadyStateLocked,
+		waverpc.WalletNotReadyStateNone,
+		waverpc.WalletNotReadyStateSyncing,
+	} {
+		err := waverpc.WalletNotReadyStateError("not ready", state)
+		require.Equal(t, ExitAuthFailure, ExitCodeFor(err))
+
+		// A wrapping fmt.Errorf must not lose the classification.
+		wrapped := fmt.Errorf("balance: %w", err)
+		require.Equal(t, ExitAuthFailure, ExitCodeFor(wrapped))
+	}
+}
+
 // TestExitCodeForCobraArgError covers the cobra/pflag pre-RunE
 // validation classifier. Each prefix the upstream libraries emit
 // must map onto ExitInvalidArgs so an agent that passes the wrong
@@ -134,6 +172,9 @@ func TestExitCodeForCobraArgError(t *testing.T) {
 		"unknown flag: --bogus",
 		"unknown shorthand flag: 'q' in -q",
 		"invalid argument \"foo\" for \"--amt\"",
+		"flag needs an argument: --amt",
+		"bad flag syntax: --=foo",
+		"invalid --request-json payload: unexpected token",
 		"unknown command \"shrug\" for \"wavecli\"",
 		"accepts 1 arg(s), received 0",
 		"requires at least 1 arg(s), received 0",
@@ -159,11 +200,11 @@ func TestIsCobraArgErrorSkipsClassifiedWrappers(t *testing.T) {
 	// A printedError whose message happens to start with a cobra
 	// prefix should still keep its own ExitCode.
 	pe := &printedError{
-		code: "DRY_RUN_OK",
+		code: confirmationRequiredCode,
 		msg:  "required flag(s) \"x\" not set",
 	}
 	require.False(t, IsCobraArgError(pe))
-	require.Equal(t, ExitDryRunOK, ExitCodeFor(pe))
+	require.Equal(t, ExitConfirmationRequired, ExitCodeFor(pe))
 
 	// A cliError wrapping a cobra-shaped message: the wrapper's
 	// explicit code wins.

--- a/cmd/wavecli/waveclicommands/json_input.go
+++ b/cmd/wavecli/waveclicommands/json_input.go
@@ -24,8 +24,11 @@ func parseRequest[T proto.Message](cmd *cobra.Command, req T,
 		if err := jsonUnmarshalOpts.Unmarshal(
 			[]byte(raw), req,
 		); err != nil {
-			return fmt.Errorf("invalid --request-json payload: %w",
-				err)
+			return newCLIError(
+				ExitInvalidArgs,
+				fmt.Errorf("invalid --request-json "+
+					"payload: %w", err),
+			)
 		}
 
 		return nil

--- a/cmd/wavecli/waveclicommands/root.go
+++ b/cmd/wavecli/waveclicommands/root.go
@@ -54,8 +54,8 @@ func newRootCmd(devMode bool) *cobra.Command {
 		Long: "wavecli is the command-line interface for " +
 			"the Ark protocol client daemon (waved). " +
 			"It issues gRPC calls to a running daemon " +
-			"and prints structured JSON output suitable " +
-			"for both human and agent consumption.",
+			"and prints command-appropriate human or " +
+			"machine-readable output.",
 		Version: build.Version(),
 		// Silence usage on errors so we control the error
 		// output format.
@@ -196,9 +196,11 @@ type errorEnvelope struct {
 }
 
 type errorPayload struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-	Details string `json:"details,omitempty"`
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Details     string `json:"details,omitempty"`
+	Remediation string `json:"remediation,omitempty"`
+	Retryable   bool   `json:"retryable"`
 }
 
 // PrintError writes a structured error to stderr in JSON format and
@@ -232,11 +234,24 @@ func printError(w io.Writer, code string, msg string) error {
 func printErrorDetails(w io.Writer, code string, msg string,
 	details string) error {
 
+	retryable, remediation := errorMetadata(code, msg)
+
+	return printErrorMetadata(
+		w, code, msg, details, remediation, retryable,
+	)
+}
+
+// printErrorMetadata writes one fully classified public error envelope.
+func printErrorMetadata(w io.Writer, code, msg, details, remediation string,
+	retryable bool) error {
+
 	data, err := json.MarshalIndent(errorEnvelope{
 		Error: errorPayload{
-			Code:    code,
-			Message: msg,
-			Details: details,
+			Code:        code,
+			Message:     msg,
+			Details:     details,
+			Remediation: remediation,
+			Retryable:   retryable,
 		},
 	}, "", "  ")
 	if err != nil {
@@ -278,8 +293,8 @@ func (e *printedError) ExitCode() int {
 	case "METHOD_NOT_FOUND", "NOT_FOUND":
 		return ExitNotFound
 
-	case "DRY_RUN_OK":
-		return ExitDryRunOK
+	case confirmationRequiredCode:
+		return ExitConfirmationRequired
 	}
 
 	return ExitGenericError

--- a/cmd/wavecli/waveclicommands/root_test.go
+++ b/cmd/wavecli/waveclicommands/root_test.go
@@ -26,7 +26,7 @@ func TestPrintErrorFormatsIndentedJSON(t *testing.T) {
 	encoded, err := json.Marshal(msg)
 	require.NoError(t, err)
 	expected := `{"error":{"code":"EXECUTION_FAILED","message":` +
-		string(encoded) + `}}`
+		string(encoded) + `,"retryable":false}}`
 	require.JSONEq(t, expected, buf.String())
 
 	require.Contains(t, buf.String(), "\n  \"error\": {\n")
@@ -55,7 +55,8 @@ func TestPrintCommandErrorPromotesNestedGRPCStatus(t *testing.T) {
 		"error": {
 			"code": "ALREADY_EXISTS",
 			"message": "receive intent already used",
-			"details": "` + details + `"
+			"details": "` + details + `",
+			"retryable": false
 		}
 	}`
 	require.JSONEq(t, expected, buf.String())
@@ -76,7 +77,8 @@ func TestPrintCommandErrorAddsStatusWrapperDetails(t *testing.T) {
 		"error": {
 			"code": "ALREADY_EXISTS",
 			"message": "receive intent already used",
-			"details": "send"
+			"details": "send",
+			"retryable": false
 		}
 	}`
 	require.JSONEq(t, expected, buf.String())
@@ -122,7 +124,8 @@ func TestPrintCommandErrorMapsWalletNotReadyToStateHint(t *testing.T) {
 			require.NoError(t, printCommandError(&buf, err))
 
 			const expectedTemplate = `{"error":{"code":` +
-				`"WALLET_LOCKED","message":%q}}`
+				`"WALLET_LOCKED","message":%q,` +
+				`"retryable":false}}`
 			expected := fmt.Sprintf(expectedTemplate, tc.msg)
 			require.JSONEq(t, expected, buf.String())
 		})
@@ -140,10 +143,130 @@ func TestPrintCommandErrorHandlesBareGRPCStatus(t *testing.T) {
 	expected := `{
 		"error": {
 			"code": "ALREADY_EXISTS",
-			"message": "receive intent already used"
+			"message": "receive intent already used",
+			"retryable": false
 		}
 	}`
 	require.JSONEq(t, expected, buf.String())
+}
+
+func TestPrintCommandErrorAddsRetryMetadata(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		code      codes.Code
+		retryable bool
+	}{
+		{
+			name:      "unavailable",
+			code:      codes.Unavailable,
+			retryable: true,
+		},
+		{
+			name:      "resource exhausted",
+			code:      codes.ResourceExhausted,
+			retryable: true,
+		},
+		// DEADLINE_EXCEEDED and ABORTED may fire after a fund-moving
+		// RPC was already accepted, so they carry remediation but are
+		// not retryable — a blind retry could double-spend.
+		{
+			name:      "deadline",
+			code:      codes.DeadlineExceeded,
+			retryable: false,
+		},
+		{
+			name:      "aborted",
+			code:      codes.Aborted,
+			retryable: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			err := status.Error(tc.code, "temporary failure")
+			require.NoError(t, printCommandError(&buf, err))
+
+			var envelope errorEnvelope
+			require.NoError(
+				t,
+				json.Unmarshal(
+					buf.Bytes(), &envelope,
+				),
+			)
+			require.Equal(t, tc.retryable, envelope.Error.Retryable)
+			require.NotEmpty(t, envelope.Error.Remediation)
+		})
+	}
+}
+
+func TestPrintCommandErrorClassifiesCredentialFailures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		err             error
+		remediationPart string
+	}{
+		{
+			name: "TLS certificate",
+			err: errors.New(
+				"unable to load TLS cert: file does not exist",
+			),
+			remediationPart: "--tlscertpath",
+		},
+		{
+			name: "macaroon",
+			err: errors.New(
+				"unable to load macaroon: file does not exist",
+			),
+			remediationPart: "--macaroonpath",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			require.NoError(t, printCommandError(&buf, tc.err))
+
+			var envelope errorEnvelope
+			require.NoError(
+				t,
+				json.Unmarshal(
+					buf.Bytes(), &envelope,
+				),
+			)
+			require.Equal(t, "AUTH_FAILURE", envelope.Error.Code)
+			require.False(t, envelope.Error.Retryable)
+			require.Contains(
+				t, envelope.Error.Remediation,
+				tc.remediationPart,
+			)
+		})
+	}
+}
+
+func TestPrintCommandErrorPreservesLocalClassification(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := newCLIError(
+		ExitInvalidArgs, errors.New("unknown output format \"yaml\""),
+	)
+	require.NoError(t, printCommandError(&buf, err))
+
+	var envelope errorEnvelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+	require.Equal(t, invalidArgsCode, envelope.Error.Code)
+	require.False(t, envelope.Error.Retryable)
 }
 
 func TestPrintCommandErrorLeavesPlainErrorsGeneric(t *testing.T) {
@@ -155,7 +278,8 @@ func TestPrintCommandErrorLeavesPlainErrorsGeneric(t *testing.T) {
 	expected := `{
 		"error": {
 			"code": "EXECUTION_FAILED",
-			"message": "boom"
+			"message": "boom",
+			"retryable": false
 		}
 	}`
 	require.JSONEq(t, expected, buf.String())
@@ -170,7 +294,8 @@ func TestPrintCommandErrorHandlesNilError(t *testing.T) {
 	expected := `{
 		"error": {
 			"code": "EXECUTION_FAILED",
-			"message": "unknown error"
+			"message": "unknown error",
+			"retryable": false
 		}
 	}`
 	require.JSONEq(t, expected, buf.String())

--- a/cmd/wavecli/waveclicommands/schema_registry.go
+++ b/cmd/wavecli/waveclicommands/schema_registry.go
@@ -40,10 +40,10 @@ type schemaMethod struct {
 	// dry-run mode when it differs from ResponseType.
 	DryRunResponseType string `json:"dry_run_response_type,omitempty"`
 
-	// DryRun indicates whether the command supports --dry-run /
-	// --dry-run. Top-level wallet verbs use --dry-run (CLI-only
-	// validation, exits 10); ark.* commands use --dry-run that
-	// reaches the daemon's dry_run RPC field.
+	// DryRun indicates whether the command supports --dry-run.
+	// Top-level wallet verbs use --dry-run (CLI-only validation,
+	// exits 0); ark.* commands use --dry-run that reaches the
+	// daemon's dry_run RPC field.
 	DryRun bool `json:"dry_run,omitempty"`
 
 	// JSONInput indicates the command accepts --request-json for raw proto
@@ -339,7 +339,7 @@ func walletQueryMethodRegistry() []schemaMethod {
 					Type: "bool",
 					Description: "CLI-side validation " +
 						"only; print the proto-JSON " +
-						"preview and exit 10 without " +
+						"preview and exit 0 without " +
 						"dispatching",
 				},
 			},

--- a/cmd/wavecli/waveclicommands/send_result.go
+++ b/cmd/wavecli/waveclicommands/send_result.go
@@ -13,7 +13,7 @@ import (
 // the verbose inspection trace down to the fields a caller actually needs: the
 // amount that left the wallet, the fee, and, for a Lightning send, the payment
 // preimage that proves the invoice was paid. The full ledger, VTXO, and swap
-// breakdown stays available on demand via `da activity inspect <id>`.
+// breakdown stays available on demand via `wavecli activity inspect <id>`.
 type sendResult struct {
 	// Status is the short terminal status label (e.g. COMPLETE, PENDING).
 	Status string `json:"status"`
@@ -48,7 +48,7 @@ type sendResult struct {
 	// VtxoOutpoint is the settling vHTLC/VTXO outpoint when known.
 	VtxoOutpoint string `json:"vtxo_outpoint,omitempty"`
 
-	// ID is the wallet entry id, the handle for `da activity inspect`.
+	// ID is the wallet entry id, the handle for `wavecli activity inspect`.
 	ID string `json:"id"`
 }
 

--- a/cmd/wavecli/waveclicommands/wallet_client.go
+++ b/cmd/wavecli/waveclicommands/wallet_client.go
@@ -124,26 +124,23 @@ func invalidArgs(err error) error {
 // walletDryRunPreview emits a structured preview of the RPC that would
 // have been dispatched. The fully-validated request body is included
 // so an agent staging a transaction can diff the proto-JSON against
-// what it intended. A DRY_RUN_OK printedError is returned so main.go
-// exits with code 10 — the agent-cli skill's "dry-run passed" marker —
-// without re-printing the envelope.
+// what it intended. A successful preview returns nil so dry runs compose with
+// shell success checks while the dry_run marker distinguishes the preview.
 func walletDryRunPreview(method string, req proto.Message) error {
 	body, err := walletProtoMarshal.Marshal(req)
 	if err != nil {
 		return fmt.Errorf("marshal dry-run preview: %w", err)
 	}
 
-	// stdout carries the machine-readable preview; main.go's DRY_RUN_OK
-	// stderr envelope carries the marker that the dry-run validated.
-	fmt.Fprintf(
+	// stdout carries the machine-readable success marker and preview.
+	// Propagate the write error so a failed redirect (disk full, closed
+	// pipe) does not report a successful preview it never delivered.
+	_, err = fmt.Fprintf(
 		os.Stdout, `{"dry_run":true,"method":%q,"validation":"passed",`+
 			`"body":%s}`+"\n", method, string(body),
 	)
 
-	return PrintError(
-		"DRY_RUN_OK",
-		"dry-run validation passed; no RPC was dispatched",
-	)
+	return err
 }
 
 // parseEntryKind maps a user-facing kind string to the proto enum used

--- a/cmd/wavecli/waveclicommands/wallet_table.go
+++ b/cmd/wavecli/waveclicommands/wallet_table.go
@@ -27,15 +27,21 @@ func validateListFormat(format string, view wavewalletrpc.ListView) error {
 
 	case "table", "expanded", "x":
 		if view != wavewalletrpc.ListView_LIST_VIEW_ACTIVITY {
-			return fmt.Errorf("--format %s applies only to "+
-				"activity output", format)
+			return newCLIError(
+				ExitInvalidArgs,
+				fmt.Errorf("--format %s applies only to "+
+					"activity output", format),
+			)
 		}
 
 		return nil
 
 	default:
-		return fmt.Errorf("unknown list format %q: expected json, "+
-			"table, expanded, or x", format)
+		return newCLIError(
+			ExitInvalidArgs,
+			fmt.Errorf("unknown list format %q: expected json, "+
+				"table, expanded, or x", format),
+		)
 	}
 }
 

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -50,6 +50,33 @@ Two options:
 
 See [wavewalletrpc_build.md](wavewalletrpc_build.md) for more.
 
+## Automation Contract
+
+Command results are written to stdout. Failures are written to stderr as one
+JSON envelope with stable `code`, `message`, and `retryable` fields, plus
+`details` and `remediation` when useful:
+
+```json
+{
+  "error": {
+    "code": "UNAVAILABLE",
+    "message": "connection refused",
+    "remediation": "verify waved is running and --rpcserver points to it, then retry",
+    "retryable": true
+  }
+}
+```
+
+The process exits with `2` for invalid arguments, `3` for authentication or
+authorization failures, `4` for missing resources, and `5` when a valid
+fund-moving command needs explicit confirmation on non-interactive stdin.
+Other failures exit with `1`. A successful `--dry-run` is a normal result: it
+prints a JSON preview containing `"dry_run": true` and exits with `0`.
+
+If `send` needs confirmation but stdin is not interactive, its prepared amount,
+fee, rail, and destination preview is written to stderr before the
+`CONFIRMATION_REQUIRED` envelope. Review it and rerun with `--yes`.
+
 ## Daemon Configuration
 
 `waved` supports two wallet backends: **lwwallet** (standalone,


### PR DESCRIPTION
Addresses P0-2 from #997.

Before:
- successful dry runs returned the non-zero code 10 and emitted an error envelope
- confirmation refusals were indistinguishable from malformed input (exit 2)
- local format/raw JSON failures and credential-loading failures had inconsistent codes
- send refused non-interactive callers before showing the prepared transaction
- error envelopes did not say whether retrying was safe or how to remediate common failures
- several help/error strings still referred to `da` or recommended `ark listtransactions` from itself

After:
- dry runs print a `dry_run: true` preview and exit 0
- non-interactive consent gates return `CONFIRMATION_REQUIRED` and exit 5
- malformed formats/raw JSON exit 2; TLS/macaroon loading failures exit 3
- send prints the amount, fee, rail, destination, and warnings before refusing
- envelopes always include `retryable` and add actionable `remediation` where useful
- stale command names and misleading root/help text are corrected

Concrete consequence: agents can branch on process status and JSON fields without parsing prose, can inspect exactly what a send would do before approving it, and can distinguish safe retries from required operator action.

Validation:
- `make unit pkg=./cmd/wavecli/...`
- `go test ./cmd/wavecli/... -race`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`

This is intentionally independent from the other #997 slices and targets `main`.