### PR TITLE
wavecli: make interactive input explicit

### DIFF
--- a/cmd/wavecli/waveclicommands/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/AGENTS.md
@@ -34,7 +34,7 @@ unchanged).
 
 | Command | RPC | Description |
 |---------|-----|-------------|
-| `create` | `wavewalletrpc.Create` | Initialize a new wallet (proxies GenSeed + InitWallet). Password from stdin / WAVED_WALLET_PASSWORD / --wallet-password-file |
+| `create` | `wavewalletrpc.Create` | Initialize a new wallet (proxies GenSeed + InitWallet). Password from WAVED_WALLET_PASSWORD / --wallet-password-file / explicit --password-stdin |
 | `unlock` | `wavewalletrpc.Unlock` | Unlock an existing wallet (proxies UnlockWallet) |
 | `send <dest>` | `wavewalletrpc.Send` | Outbound payment. `--offchain` (default) for a BOLT-11 invoice via the swap subsystem; `--onchain` for an atomic on-chain send (`--sweep-all` drains). No prefix sniff |
 | `recv` | `wavewalletrpc.Recv` / `wavewalletrpc.Deposit` | Inbound. `--offchain` (default) returns a Lightning invoice; `--onchain` returns a boarding address |
@@ -117,8 +117,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   exposed RPC as a typed tool; split from `mcpServe` (which owns the
   daemon dial and stdio transport) so the tool surface is testable.
 - `readPassword()` — reads wallet password from
-  `WAVED_WALLET_PASSWORD` → `--wallet-password-file` → stdin → TTY.
-  **Never from CLI args.**
+  `WAVED_WALLET_PASSWORD` → `--wallet-password-file` → explicit
+  `--password-stdin` → TTY. **Never implicitly from stdin or from CLI
+  args.**
 - `validateDestination()` / `validateOutpoint()` /
   `validateFreeText()` — input hardening shared across the top-level
   wallet verbs (reject control chars, query/fragment chars, malformed
@@ -147,7 +148,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   the authoritative parse.
 - The wallet password is NEVER read from argv. The supported sources
   are `WAVED_WALLET_PASSWORD` (highest priority), then
-  `--wallet-password-file`, then piped stdin, then interactive prompt.
+  `--wallet-password-file`, explicit `--password-stdin`, then an
+  interactive prompt.
+- Global `--no-input` and `CI=true` disable interactive prompts without
+  suppressing command output. Explicit password sources still work.
 - JSON output (`stdout`) and diagnostic output (`stderr`) are kept on
   separate streams so shell pipelines can consume the JSON body while
   a human reading the terminal sees informative warnings.

--- a/cmd/wavecli/waveclicommands/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/CLAUDE.md
@@ -34,7 +34,7 @@ unchanged).
 
 | Command | RPC | Description |
 |---------|-----|-------------|
-| `create` | `wavewalletrpc.Create` | Initialize a new wallet (proxies GenSeed + InitWallet). Password from stdin / WAVED_WALLET_PASSWORD / --wallet-password-file |
+| `create` | `wavewalletrpc.Create` | Initialize a new wallet (proxies GenSeed + InitWallet). Password from WAVED_WALLET_PASSWORD / --wallet-password-file / explicit --password-stdin |
 | `unlock` | `wavewalletrpc.Unlock` | Unlock an existing wallet (proxies UnlockWallet) |
 | `send <dest>` | `wavewalletrpc.Send` | Outbound payment. `--offchain` (default) for a BOLT-11 invoice via the swap subsystem; `--onchain` for an atomic on-chain send (`--sweep-all` drains). No prefix sniff |
 | `recv` | `wavewalletrpc.Recv` / `wavewalletrpc.Deposit` | Inbound. `--offchain` (default) returns a Lightning invoice; `--onchain` returns a boarding address |
@@ -117,8 +117,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   exposed RPC as a typed tool; split from `mcpServe` (which owns the
   daemon dial and stdio transport) so the tool surface is testable.
 - `readPassword()` — reads wallet password from
-  `WAVED_WALLET_PASSWORD` → `--wallet-password-file` → stdin → TTY.
-  **Never from CLI args.**
+  `WAVED_WALLET_PASSWORD` → `--wallet-password-file` → explicit
+  `--password-stdin` → TTY. **Never implicitly from stdin or from CLI
+  args.**
 - `validateDestination()` / `validateOutpoint()` /
   `validateFreeText()` — input hardening shared across the top-level
   wallet verbs (reject control chars, query/fragment chars, malformed
@@ -147,7 +148,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   the authoritative parse.
 - The wallet password is NEVER read from argv. The supported sources
   are `WAVED_WALLET_PASSWORD` (highest priority), then
-  `--wallet-password-file`, then piped stdin, then interactive prompt.
+  `--wallet-password-file`, explicit `--password-stdin`, then an
+  interactive prompt.
+- Global `--no-input` and `CI=true` disable interactive prompts without
+  suppressing command output. Explicit password sources still work.
 - JSON output (`stdout`) and diagnostic output (`stderr`) are kept on
   separate streams so shell pipelines can consume the JSON body while
   a human reading the terminal sees informative warnings.

--- a/cmd/wavecli/waveclicommands/cmd_create.go
+++ b/cmd/wavecli/waveclicommands/cmd_create.go
@@ -14,7 +14,7 @@ import (
 // exit) and dials wavewalletrpc.WalletService.Create which proxies
 // waverpc.GenSeed + waverpc.InitWallet under the hood. Both the
 // wallet password and the optional seed passphrase are read from
-// stdin / env var / file (never CLI args) so secrets never enter argv.
+// explicit non-argv sources so secrets never enter process listings.
 func newCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -24,9 +24,9 @@ func newCreateCmd() *cobra.Command {
 			"the caller can record it offline), and creates " +
 			"the wallet database encrypted under the " +
 			"supplied password.\n\n" +
-			"The wallet password is read from stdin / " +
-			"WAVED_WALLET_PASSWORD env / " +
-			"--wallet-password-file (never CLI args). The " +
+			"The wallet password is read from " +
+			"WAVED_WALLET_PASSWORD, --wallet-password-file, " +
+			"or explicit --password-stdin (never CLI args). The " +
 			"interactive password prompt asks for confirmation. " +
 			"The optional seed passphrase is read from " +
 			"WAVED_SEED_PASSPHRASE env / " +
@@ -36,13 +36,16 @@ func newCreateCmd() *cobra.Command {
 			"from stderr or pass --print-mnemonic-json to " +
 			"opt in to the machine-consumable form).\n\n" +
 			"Example:\n" +
-			"  echo -n 'hunter2hunter2' | wavecli create",
+			"  printf '%s\\n' 'hunter2hunter2' | " +
+			"wavecli create --password-stdin",
 		Args: cobra.NoArgs,
 		RunE: walletCreate,
 	}
 
 	cmd.Flags().String("wallet-password-file", "",
 		"path to file containing wallet password")
+	cmd.Flags().Bool("password-stdin", false,
+		"read one wallet password line from stdin")
 	cmd.Flags().String("seed-passphrase-file", "",
 		"path to file containing optional aezeed passphrase")
 	cmd.Flags().Bool("print-mnemonic-json", false,

--- a/cmd/wavecli/waveclicommands/cmd_recovery.go
+++ b/cmd/wavecli/waveclicommands/cmd_recovery.go
@@ -1,10 +1,8 @@
 package waveclicommands
 
 import (
-	"bufio"
 	"encoding/hex"
 	"fmt"
-	"strings"
 
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/spf13/cobra"
@@ -220,16 +218,17 @@ func confirmRecoveryEscalation(cmd *cobra.Command, recoveryID string) error {
 	if yes {
 		return nil
 	}
-	if !stdinIsTTY(cmd) {
+	if !canPrompt(cmd) {
 		return PrintError(
 			confirmationRequiredCode, "recovery escalate "+
 				"requires --yes (explicit consent) on "+
-				"non-interactive stdin; refusing to prompt "+
-				"because an agent cannot respond to y/N",
+				"non-interactive stdin or when input is "+
+				"disabled; refusing to prompt because an "+
+				"agent cannot respond to y/N",
 		)
 	}
 
-	out := cmd.OutOrStdout()
+	out := cmd.ErrOrStderr()
 	fmt.Fprintf(
 		out, "About to start on-chain vHTLC recovery for %s.\n",
 		recoveryID,
@@ -239,19 +238,8 @@ func confirmRecoveryEscalation(cmd *cobra.Command, recoveryID string) error {
 			"recovery status/list first to confirm cooperative "+
 			"settlement cannot safely continue.",
 	)
-	fmt.Fprint(out, "Start recovery? [y/N]: ")
 
-	reader := bufio.NewReader(cmd.InOrStdin())
-	answer, err := reader.ReadString('\n')
-	if err != nil {
-		return fmt.Errorf("read confirmation: %w", err)
-	}
-	answer = strings.TrimSpace(strings.ToLower(answer))
-	if answer != "y" && answer != "yes" {
-		return fmt.Errorf("aborted by user")
-	}
-
-	return nil
+	return promptConfirmation(cmd, "Start recovery? [y/N]: ")
 }
 
 // decodeRecoveryPreimage decodes an optional 32-byte preimage. Empty input maps

--- a/cmd/wavecli/waveclicommands/cmd_send.go
+++ b/cmd/wavecli/waveclicommands/cmd_send.go
@@ -1,7 +1,6 @@
 package waveclicommands
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -458,14 +457,14 @@ func confirmSendIfNeeded(cmd *cobra.Command,
 		return nil
 	}
 
-	if !stdinIsTTY(cmd) {
+	if !canPrompt(cmd) {
 		printSendPreview(cmd.ErrOrStderr(), resp)
 
 		return PrintError(
 			confirmationRequiredCode, "send requires --force "+
-				"or --yes on non-interactive stdin; "+
-				"refusing to prompt because an agent "+
-				"cannot respond to y/N",
+				"or --yes on non-interactive stdin or when "+
+				"input is disabled; refusing to prompt "+
+				"because an agent cannot respond to y/N",
 		)
 	}
 
@@ -475,22 +474,9 @@ func confirmSendIfNeeded(cmd *cobra.Command,
 func promptSendConfirmation(cmd *cobra.Command,
 	resp *wavewalletrpc.PrepareSendResponse) error {
 
-	out := cmd.ErrOrStderr()
-	printSendPreview(out, resp)
-	fmt.Fprint(out, "\nProceed? [y/N]: ")
+	printSendPreview(cmd.ErrOrStderr(), resp)
 
-	reader := bufio.NewReader(cmd.InOrStdin())
-	answer, err := reader.ReadString('\n')
-	if err != nil {
-		return fmt.Errorf("read confirmation: %w", err)
-	}
-
-	answer = strings.TrimSpace(strings.ToLower(answer))
-	if answer != "y" && answer != "yes" {
-		return fmt.Errorf("aborted by user")
-	}
-
-	return nil
+	return promptConfirmation(cmd, "\nProceed? [y/N]: ")
 }
 
 // printSendPreview writes the prepared amount, fee, rail, and destination

--- a/cmd/wavecli/waveclicommands/cmd_unlock.go
+++ b/cmd/wavecli/waveclicommands/cmd_unlock.go
@@ -9,25 +9,29 @@ import (
 
 // newUnlockCmd builds the top-level `unlock` verb. It dials
 // wavewalletrpc.WalletService.Unlock which proxies
-// waverpc.UnlockWallet. The CLI reads the wallet password from
-// stdin / WAVED_WALLET_PASSWORD / --wallet-password-file (never CLI
-// args) so secrets never enter argv.
+// waverpc.UnlockWallet. The CLI reads the wallet password from an
+// environment variable, file, explicit stdin, or a TTY prompt so the
+// secret never enters argv.
 func newUnlockCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unlock",
 		Short: "Unlock an existing wallet",
 		Long: "Opens the wallet database with its password and " +
 			"starts the wallet subsystem. The password is " +
-			"read from stdin / WAVED_WALLET_PASSWORD env var / " +
-			"--wallet-password-file (never CLI args).\n\n" +
+			"read from WAVED_WALLET_PASSWORD, " +
+			"--wallet-password-file, or explicit " +
+			"--password-stdin (never CLI args).\n\n" +
 			"Example:\n" +
-			"  echo -n 'hunter2hunter2' | wavecli unlock",
+			"  printf '%s\\n' 'hunter2hunter2' | " +
+			"wavecli unlock --password-stdin",
 		Args: cobra.NoArgs,
 		RunE: walletUnlock,
 	}
 
 	cmd.Flags().String("wallet-password-file", "",
 		"path to file containing wallet password")
+	cmd.Flags().Bool("password-stdin", false,
+		"read one wallet password line from stdin")
 
 	return cmd
 }

--- a/cmd/wavecli/waveclicommands/cmd_vtxos.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos.go
@@ -1,7 +1,6 @@
 package waveclicommands
 
 import (
-	"bufio"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -415,14 +414,14 @@ func confirmRefreshIfNeeded(cmd *cobra.Command,
 		return nil
 	}
 
-	if !stdinIsTTY(cmd) {
+	if !canPrompt(cmd) {
 		return PrintError(
 			confirmationRequiredCode, "refresh is charged an "+
 				"operator fee at seal time and requires "+
 				"--yes (explicit consent) or --dry-run "+
-				"(fee preview) on non-interactive stdin; "+
-				"refusing to prompt because an agent "+
-				"cannot respond to y/N",
+				"(fee preview) on non-interactive stdin or "+
+				"when input is disabled; refusing to prompt "+
+				"because an agent cannot respond to y/N",
 		)
 	}
 
@@ -495,20 +494,8 @@ func promptRefreshConfirmation(cmd *cobra.Command, lines []string) error {
 	for _, line := range lines {
 		fmt.Fprintln(out, line)
 	}
-	fmt.Fprint(out, "Proceed with refresh? [y/N]: ")
 
-	reader := bufio.NewReader(cmd.InOrStdin())
-	answer, err := reader.ReadString('\n')
-	if err != nil {
-		return fmt.Errorf("read confirmation: %w", err)
-	}
-
-	answer = strings.TrimSpace(strings.ToLower(answer))
-	if answer != "y" && answer != "yes" {
-		return fmt.Errorf("aborted by user")
-	}
-
-	return nil
+	return promptConfirmation(cmd, "Proceed with refresh? [y/N]: ")
 }
 
 // newVTXOsLeaveCmd creates the vtxos leave subcommand.
@@ -862,12 +849,13 @@ func confirmLeaveAllIfNeeded(cmd *cobra.Command,
 	// race agents whose stdin is closed / piped. The agent-cli
 	// skill lists interactive prompts as an anti-pattern; this
 	// guard is the explicit replacement.
-	if !stdinIsTTY(cmd) {
+	if !canPrompt(cmd) {
 		return PrintError(
 			confirmationRequiredCode, "--all requires --yes "+
 				"(explicit consent) or --dry-run (preview) "+
-				"on non-interactive stdin; refusing to "+
-				"prompt because an agent cannot respond to y/N",
+				"on non-interactive stdin or when input is "+
+				"disabled; refusing to prompt because an "+
+				"agent cannot respond to y/N",
 		)
 	}
 
@@ -925,18 +913,6 @@ func promptLeaveAllConfirmation(cmd *cobra.Command) error {
 		out, "About to queue ALL live VTXOs for cooperative leave. "+
 			"This moves funds on-chain.",
 	)
-	fmt.Fprint(out, "Proceed? [y/N]: ")
 
-	reader := bufio.NewReader(cmd.InOrStdin())
-	answer, err := reader.ReadString('\n')
-	if err != nil {
-		return fmt.Errorf("read confirmation: %w", err)
-	}
-
-	answer = strings.TrimSpace(strings.ToLower(answer))
-	if answer != "y" && answer != "yes" {
-		return fmt.Errorf("aborted by user")
-	}
-
-	return nil
+	return promptConfirmation(cmd, "Proceed? [y/N]: ")
 }

--- a/cmd/wavecli/waveclicommands/cmd_vtxos.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos.go
@@ -420,8 +420,8 @@ func confirmRefreshIfNeeded(cmd *cobra.Command,
 				"operator fee at seal time and requires "+
 				"--yes (explicit consent) or --dry-run "+
 				"(fee preview) on non-interactive stdin or "+
-				"when input is disabled; refusing to prompt "+
-				"because an agent cannot respond to y/N",
+				"when input is disabled; refusing to "+
+				"prompt because an agent cannot respond to y/N",
 		)
 	}
 
@@ -872,19 +872,9 @@ var stdinIsTTY = defaultStdinIsTTY
 // on the given command, returning true when the prompt may proceed
 // and false when the caller must pass --yes or --dry-run instead.
 //
-// Two paths return true (prompt is safe):
-//
-//  1. cmd.InOrStdin() returns something other than os.Stdin. Only
-//     tests and embedded harnesses install custom stdin via
-//     cmd.SetIn; production agents do not, so a custom reader is
-//     the caller's signal that they will drive the prompt
-//     themselves (e.g. by piping a scripted "y\n").
-//
-//  2. cmd.InOrStdin() is os.Stdin and os.Stdin is an actual terminal
-//     (per term.IsTerminal), i.e. a device where the operator can
-//     answer interactively.
-//
-// All other cases return false and the caller refuses to prompt. A
+// Only an actual terminal returns true. Embedded readers and buffers are
+// non-interactive streams just like shell pipes and require an explicit
+// approval/input flag. All other cases return false. A
 // character-device check is deliberately NOT used here: /dev/null and
 // a closed descriptor are both character devices yet are not
 // terminals, and those are the most common non-interactive stdin
@@ -892,11 +882,12 @@ var stdinIsTTY = defaultStdinIsTTY
 // would print a y/N prompt that immediately reads EOF, which is the
 // exact hang-then-fail the consent gate exists to prevent.
 func defaultStdinIsTTY(cmd *cobra.Command) bool {
-	if cmd.InOrStdin() != os.Stdin {
-		return true
+	inputFile, ok := cmd.InOrStdin().(*os.File)
+	if !ok {
+		return false
 	}
 
-	return term.IsTerminal(int(os.Stdin.Fd()))
+	return term.IsTerminal(int(inputFile.Fd()))
 }
 
 // promptLeaveAllConfirmation asks the operator to confirm a

--- a/cmd/wavecli/waveclicommands/cmd_vtxos_leave_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos_leave_test.go
@@ -287,7 +287,7 @@ func TestParseDestinationValueEmpty(t *testing.T) {
 // the y/N prompt. Before the fix the prompt lived inside the flag
 // callback and the JSON path silently bypassed it.
 func TestConfirmLeaveAllIfNeededJSONStillPrompts(t *testing.T) {
-	t.Parallel()
+	requireInteractiveStdin(t)
 
 	cmd, _ := newLeaveTestCmd(t, "n\n")
 
@@ -313,7 +313,7 @@ func TestConfirmLeaveAllIfNeededJSONStillPrompts(t *testing.T) {
 // TestConfirmLeaveAllIfNeededAcceptsYes verifies the prompt accepts
 // "y" and proceeds.
 func TestConfirmLeaveAllIfNeededAcceptsYes(t *testing.T) {
-	t.Parallel()
+	requireInteractiveStdin(t)
 
 	cmd, _ := newLeaveTestCmd(t, "y\n")
 
@@ -422,7 +422,7 @@ func TestConfirmLeaveAllIfNeededOutpointSelectionSkipsPrompt(t *testing.T) {
 // TestConfirmLeaveAllIfNeededRejectsBlankInput verifies that simply
 // pressing enter at the prompt aborts (default-N posture).
 func TestConfirmLeaveAllIfNeededRejectsBlankInput(t *testing.T) {
-	t.Parallel()
+	requireInteractiveStdin(t)
 
 	cmd, _ := newLeaveTestCmd(t, "\n")
 

--- a/cmd/wavecli/waveclicommands/cmd_vtxos_refresh_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos_refresh_test.go
@@ -144,7 +144,7 @@ func TestConfirmRefreshNonTTYRefusesPrompt(t *testing.T) {
 // interactive path consents to a number: the preview estimate is
 // printed before the prompt and "y" proceeds.
 func TestConfirmRefreshPromptShowsEstimateAndAcceptsYes(t *testing.T) {
-	t.Parallel()
+	requireInteractiveStdin(t)
 
 	cmd, out := newRefreshTestCmd(t, "y\n")
 
@@ -176,7 +176,7 @@ func TestConfirmRefreshPromptShowsEstimateAndAcceptsYes(t *testing.T) {
 // TestConfirmRefreshPromptRejectsNo verifies "n" aborts before any
 // dispatch, default-N posture included.
 func TestConfirmRefreshPromptRejectsNo(t *testing.T) {
-	t.Parallel()
+	requireInteractiveStdin(t)
 
 	for _, answer := range []string{"n\n", "\n"} {
 		cmd, _ := newRefreshTestCmd(t, answer)
@@ -196,7 +196,7 @@ func TestConfirmRefreshPromptRejectsNo(t *testing.T) {
 // the flow: the real dispatch would reject the same request shape, so
 // prompting the user to confirm it would be noise.
 func TestConfirmRefreshPreviewInvalidArgumentAborts(t *testing.T) {
-	t.Parallel()
+	requireInteractiveStdin(t)
 
 	cmd, _ := newRefreshTestCmd(t, "y\n")
 
@@ -218,7 +218,7 @@ func TestConfirmRefreshPreviewInvalidArgumentAborts(t *testing.T) {
 // with a warning instead of making refreshes unconfirmable — and the
 // warning says a fee still applies.
 func TestConfirmRefreshPreviewFailureStillPrompts(t *testing.T) {
-	t.Parallel()
+	requireInteractiveStdin(t)
 
 	cmd, out := newRefreshTestCmd(t, "y\n")
 
@@ -244,7 +244,7 @@ func TestConfirmRefreshPreviewFailureStillPrompts(t *testing.T) {
 // daemon behind a newer CLI) still yields a warning plus the prompt,
 // never a silent zero.
 func TestConfirmRefreshPreviewWithoutEstimateStillPrompts(t *testing.T) {
-	t.Parallel()
+	requireInteractiveStdin(t)
 
 	cmd, out := newRefreshTestCmd(t, "y\n")
 
@@ -597,6 +597,7 @@ func TestVTXOsRefreshWiringYesDispatchesOnce(t *testing.T) {
 // one dry-run fetch, zero real dispatches, zero joins.
 func TestVTXOsRefreshWiringDeclineNeverDispatches(t *testing.T) {
 	// NOT t.Parallel() — overrides getDaemonClient.
+	requireInteractiveStdin(t)
 
 	fake := &fakeRefreshDaemon{}
 	withFakeRefreshDaemon(t, fake)
@@ -682,6 +683,7 @@ func TestVTXOsRefreshWiringOldDaemonWarns(t *testing.T) {
 // so.
 func TestVTXOsRefreshWiringEmptyAllSkipsPrompt(t *testing.T) {
 	// NOT t.Parallel() — overrides getDaemonClient.
+	requireInteractiveStdin(t)
 
 	fake := &fakeRefreshDaemon{
 		previewResp: &waverpc.RefreshVTXOsResponse{

--- a/cmd/wavecli/waveclicommands/cmd_vtxos_tty_test.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos_tty_test.go
@@ -22,6 +22,18 @@ func withStdin(t *testing.T, f *os.File) {
 	})
 }
 
+// requireInteractiveStdin marks a sequential prompt test as interactive
+// without weakening production detection for embedded buffers and pipes.
+func requireInteractiveStdin(t *testing.T) {
+	t.Helper()
+
+	previous := stdinIsTTY
+	stdinIsTTY = func(*cobra.Command) bool { return true }
+	t.Cleanup(func() {
+		stdinIsTTY = previous
+	})
+}
+
 // TestDefaultStdinIsTTY pins the consent gate's non-interactive
 // detection. The gate refuses to prompt unless stdin is a real
 // terminal, so every non-terminal descriptor must report false — a
@@ -34,14 +46,14 @@ func TestDefaultStdinIsTTY(t *testing.T) {
 	// This test mutates the process-global os.Stdin, so it must not run
 	// in parallel with other tests that may read it.
 
-	// A custom reader installed via cmd.SetIn signals that the caller
-	// drives the prompt itself (tests, embedded harnesses), so the
-	// gate is allowed to proceed regardless of os.Stdin.
-	t.Run("custom reader proceeds", func(t *testing.T) {
+	// A custom reader is still a non-terminal stream. Embedded callers must
+	// opt into consuming it with the same explicit flags as shell
+	// pipelines.
+	t.Run("custom reader is not a tty", func(t *testing.T) {
 		cmd := &cobra.Command{}
 		cmd.SetIn(bytes.NewBufferString("y\n"))
 
-		require.True(t, defaultStdinIsTTY(cmd))
+		require.False(t, defaultStdinIsTTY(cmd))
 	})
 
 	// /dev/null is a character device but not a terminal: the

--- a/cmd/wavecli/waveclicommands/mcp_wallet.go
+++ b/cmd/wavecli/waveclicommands/mcp_wallet.go
@@ -15,8 +15,8 @@ import (
 // operations carry secrets (wallet password, seed passphrase) that
 // must not transit the MCP protocol where they could leak into agent
 // logs or provider APIs. Wallet setup stays on the CLI's secret-input
-// ladder (WAVED_WALLET_PASSWORD env > --wallet-password-file > stdin
-// > TTY prompt).
+// ladder (WAVED_WALLET_PASSWORD env > --wallet-password-file > explicit
+// --password-stdin > TTY prompt).
 //
 // Each tool maps gRPC Unimplemented to a clear "daemon was not built
 // with wavewalletrpc" error so an MCP consumer talking to a stub-build

--- a/cmd/wavecli/waveclicommands/prompt.go
+++ b/cmd/wavecli/waveclicommands/prompt.go
@@ -2,7 +2,9 @@ package waveclicommands
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -57,8 +59,11 @@ func promptConfirmation(cmd *cobra.Command, prompt string) error {
 
 	reader := bufio.NewReader(cmd.InOrStdin())
 	answer, err := reader.ReadString('\n')
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return fmt.Errorf("read confirmation: %w", err)
+	}
+	if errors.Is(err, io.EOF) && strings.TrimSpace(answer) == "" {
+		return fmt.Errorf("read confirmation: %w", io.EOF)
 	}
 
 	answer = strings.TrimSpace(strings.ToLower(answer))

--- a/cmd/wavecli/waveclicommands/prompt.go
+++ b/cmd/wavecli/waveclicommands/prompt.go
@@ -1,0 +1,70 @@
+package waveclicommands
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// inputDisabled reports whether the caller explicitly requested a
+// non-interactive invocation. CI=true has the same prompt-suppression
+// behavior as --no-input, but does not alter normal command output.
+func inputDisabled(cmd *cobra.Command) bool {
+	if cmd != nil {
+		noInput, err := cmd.Flags().GetBool("no-input")
+		if err == nil && noInput {
+			return true
+		}
+
+		root := cmd.Root()
+		if root != nil {
+			noInput, err = root.PersistentFlags().GetBool(
+				"no-input",
+			)
+			if err == nil && noInput {
+				return true
+			}
+		}
+	}
+
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("CI")), "true")
+}
+
+// canPrompt requires both an interactive input stream and permission
+// to prompt. Explicit confirmation flags remain the automation path.
+func canPrompt(cmd *cobra.Command) bool {
+	return !inputDisabled(cmd) && stdinIsTTY(cmd)
+}
+
+// writePrompt keeps all interactive diagnostics on stderr so stdout
+// remains safe for command results and machine-readable output.
+func writePrompt(cmd *cobra.Command, text string) error {
+	_, err := fmt.Fprint(cmd.ErrOrStderr(), text)
+
+	return err
+}
+
+// promptConfirmation writes one y/N question to stderr and reads one
+// answer from the command's configured stdin. Callers must check
+// canPrompt before invoking it.
+func promptConfirmation(cmd *cobra.Command, prompt string) error {
+	if err := writePrompt(cmd, prompt); err != nil {
+		return fmt.Errorf("write confirmation prompt: %w", err)
+	}
+
+	reader := bufio.NewReader(cmd.InOrStdin())
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read confirmation: %w", err)
+	}
+
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer != "y" && answer != "yes" {
+		return fmt.Errorf("aborted by user")
+	}
+
+	return nil
+}

--- a/cmd/wavecli/waveclicommands/prompt_test.go
+++ b/cmd/wavecli/waveclicommands/prompt_test.go
@@ -2,6 +2,7 @@ package waveclicommands
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 
@@ -24,8 +25,27 @@ func TestPromptConfirmationUsesStderr(t *testing.T) {
 	require.Equal(t, "Proceed? [y/N]: ", stderr.String())
 }
 
-func TestRecoveryPromptUsesStderr(t *testing.T) {
+func TestPromptConfirmationAcceptsAnswerAtEOF(t *testing.T) {
 	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader("yes"))
+
+	require.NoError(t, promptConfirmation(cmd, "Proceed? [y/N]: "))
+}
+
+func TestPromptConfirmationRejectsEmptyEOF(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader(""))
+
+	err := promptConfirmation(cmd, "Proceed? [y/N]: ")
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestRecoveryPromptUsesStderr(t *testing.T) {
+	requireInteractiveStdin(t)
 
 	cmd := newRecoveryEscalateCmd()
 	cmd.SetIn(strings.NewReader("yes\n"))

--- a/cmd/wavecli/waveclicommands/prompt_test.go
+++ b/cmd/wavecli/waveclicommands/prompt_test.go
@@ -1,0 +1,74 @@
+package waveclicommands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromptConfirmationUsesStderr(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader("yes\n"))
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	require.NoError(t, promptConfirmation(cmd, "Proceed? [y/N]: "))
+	require.Empty(t, stdout.String())
+	require.Equal(t, "Proceed? [y/N]: ", stderr.String())
+}
+
+func TestRecoveryPromptUsesStderr(t *testing.T) {
+	t.Parallel()
+
+	cmd := newRecoveryEscalateCmd()
+	cmd.SetIn(strings.NewReader("yes\n"))
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	require.NoError(t, confirmRecoveryEscalation(cmd, "recovery-1"))
+	require.Empty(t, stdout.String())
+	require.Contains(t, stderr.String(), "recovery-1")
+	require.Contains(t, stderr.String(), "Start recovery? [y/N]: ")
+}
+
+func TestNoInputSuppressesPrompts(t *testing.T) {
+	t.Parallel()
+
+	root := newRootCmd(false)
+	require.NoError(t, root.PersistentFlags().Set("no-input", "true"))
+
+	cmd, _, err := root.Find([]string{"send"})
+	require.NoError(t, err)
+	cmd.SetIn(strings.NewReader("yes\n"))
+
+	require.True(t, inputDisabled(cmd))
+	require.False(t, canPrompt(cmd))
+}
+
+func TestCISuppressesPromptsButNotOutput(t *testing.T) {
+	t.Setenv("CI", "true")
+
+	root := newRootCmd(false)
+	root.SetArgs([]string{"--help"})
+
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	require.NoError(t, root.Execute())
+	require.Contains(t, stdout.String(), "wavecli")
+	require.Contains(t, stdout.String(), "Wallet:")
+
+	cmd, _, err := root.Find([]string{"send"})
+	require.NoError(t, err)
+	cmd.SetIn(strings.NewReader("yes\n"))
+	require.True(t, inputDisabled(cmd))
+	require.False(t, canPrompt(cmd))
+}

--- a/cmd/wavecli/waveclicommands/root.go
+++ b/cmd/wavecli/waveclicommands/root.go
@@ -107,6 +107,10 @@ func newRootCmd(devMode bool) *cobra.Command {
 			"request input uses --request-json)",
 	)
 
+	pf.Bool(
+		"no-input", false, "never prompt or implicitly consume stdin",
+	)
+
 	pf.String(
 		"request-json", "", "raw JSON request payload (maps "+
 			"directly to the RPC request proto); when set, "+

--- a/cmd/wavecli/waveclicommands/schema_registry.go
+++ b/cmd/wavecli/waveclicommands/schema_registry.go
@@ -107,6 +107,12 @@ func walletAdminMethodRegistry() []schemaMethod {
 			Description: "Create a new wallet from a fresh seed",
 			Params: []schemaParam{
 				{
+					Name: "password-stdin",
+					Type: "bool",
+					Description: "read one wallet " +
+						"password line from stdin",
+				},
+				{
 					Name: "wallet-password-file",
 					Type: "string",
 					Description: "path to file " +
@@ -135,6 +141,12 @@ func walletAdminMethodRegistry() []schemaMethod {
 			Method:      "unlock",
 			Description: "Unlock an existing wallet",
 			Params: []schemaParam{
+				{
+					Name: "password-stdin",
+					Type: "bool",
+					Description: "read one wallet " +
+						"password line from stdin",
+				},
 				{
 					Name: "wallet-password-file",
 					Type: "string",

--- a/cmd/wavecli/waveclicommands/wallet_password.go
+++ b/cmd/wavecli/waveclicommands/wallet_password.go
@@ -105,20 +105,26 @@ func readWalletPassword(cmd *cobra.Command,
 	if passwordStdin {
 		scanner := bufio.NewScanner(cmd.InOrStdin())
 		if scanner.Scan() {
-			return []byte(scanner.Text()), nil
+			return append([]byte(nil), scanner.Bytes()...), nil
 		}
 		if err := scanner.Err(); err != nil {
 			return nil, fmt.Errorf("unable to read password from "+
 				"stdin: %w", err)
 		}
 
-		return nil, fmt.Errorf("unable to read password from stdin")
+		return nil, newCLIError(
+			ExitInvalidArgs, fmt.Errorf("--password-stdin was "+
+				"set but no password line was read from stdin"),
+		)
 	}
 
 	if !canPrompt(cmd) {
-		return nil, fmt.Errorf("wallet password input required: set " +
-			"WAVED_WALLET_PASSWORD, use --wallet-password-file, " +
-			"or explicitly pass --password-stdin")
+		return nil, newCLIError(
+			ExitInvalidArgs, fmt.Errorf("wallet password input "+
+				"required: set WAVED_WALLET_PASSWORD, use "+
+				"--wallet-password-file, or explicitly pass "+
+				"--password-stdin"),
+		)
 	}
 
 	readInteractive := func(prompt string) ([]byte, error) {
@@ -136,25 +142,17 @@ func readWalletPassword(cmd *cobra.Command,
 func readInteractivePassword(cmd *cobra.Command,
 	prompt string) ([]byte, error) {
 
-	if err := writePrompt(cmd, prompt); err != nil {
-		return nil, fmt.Errorf("write password prompt: %w", err)
-	}
-
 	input := cmd.InOrStdin()
 	output := cmd.ErrOrStderr()
 	inputFile, ok := input.(*os.File)
-	if !ok {
-		password, err := readMaskedPassword(input, output)
-		_, printErr := fmt.Fprintln(output)
-		if err != nil {
-			return nil, err
-		}
-		if printErr != nil {
-			return nil, fmt.Errorf("unable to finalize password "+
-				"prompt: %w", printErr)
-		}
+	if !ok || !term.IsTerminal(int(inputFile.Fd())) {
+		return nil, fmt.Errorf("interactive password input requires " +
+			"a terminal; use --password-stdin for an explicit " +
+			"stream")
+	}
 
-		return password, nil
+	if err := writePrompt(cmd, prompt); err != nil {
+		return nil, fmt.Errorf("write password prompt: %w", err)
 	}
 
 	// Interactive prompt (TTY).

--- a/cmd/wavecli/waveclicommands/wallet_password.go
+++ b/cmd/wavecli/waveclicommands/wallet_password.go
@@ -57,15 +57,14 @@ func readSeedPassphrase(cmd *cobra.Command) ([]byte, error) {
 
 // readPassword reads the wallet password from one of these sources, in
 // priority order: WAVED_WALLET_PASSWORD env > --wallet-password-file
-// flag > stdin pipe > interactive prompt. The env var is checked first
-// so that automated environments (such as the wavelengthtest REPL) can set
-// it without stdin races. The CLI never accepts passwords via argv.
+// flag > explicit --password-stdin > interactive prompt. The CLI never
+// consumes stdin implicitly or accepts passwords via argv.
 func readPassword(cmd *cobra.Command) ([]byte, error) {
 	return readWalletPassword(cmd, false)
 }
 
 // readPasswordConfirmed reads the wallet password with interactive
-// confirmation. Non-interactive sources (env, file, stdin pipe) stay
+// confirmation. Non-interactive sources (env, file, explicit stdin) stay
 // single-read so automated callers can continue to provide exactly one
 // secret.
 func readPasswordConfirmed(cmd *cobra.Command) ([]byte, error) {
@@ -102,31 +101,64 @@ func readWalletPassword(cmd *cobra.Command,
 		)), nil
 	}
 
-	// Check if stdin has data (piped input).
-	stat, _ := os.Stdin.Stat()
-	if (stat.Mode() & os.ModeCharDevice) == 0 {
-		scanner := bufio.NewScanner(os.Stdin)
+	passwordStdin, _ := cmd.Flags().GetBool("password-stdin")
+	if passwordStdin {
+		scanner := bufio.NewScanner(cmd.InOrStdin())
 		if scanner.Scan() {
 			return []byte(scanner.Text()), nil
+		}
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("unable to read password from "+
+				"stdin: %w", err)
 		}
 
 		return nil, fmt.Errorf("unable to read password from stdin")
 	}
 
-	if confirmInteractive {
-		return readConfirmedPassword(readInteractivePassword)
+	if !canPrompt(cmd) {
+		return nil, fmt.Errorf("wallet password input required: set " +
+			"WAVED_WALLET_PASSWORD, use --wallet-password-file, " +
+			"or explicitly pass --password-stdin")
 	}
 
-	return readInteractivePassword("Enter wallet password: ")
+	readInteractive := func(prompt string) ([]byte, error) {
+		return readInteractivePassword(cmd, prompt)
+	}
+	if confirmInteractive {
+		return readConfirmedPassword(readInteractive)
+	}
+
+	return readInteractive("Enter wallet password: ")
 }
 
 // readInteractivePassword reads one password from the controlling TTY
 // using the supplied prompt.
-func readInteractivePassword(prompt string) ([]byte, error) {
-	fmt.Fprint(os.Stderr, prompt)
+func readInteractivePassword(cmd *cobra.Command,
+	prompt string) ([]byte, error) {
+
+	if err := writePrompt(cmd, prompt); err != nil {
+		return nil, fmt.Errorf("write password prompt: %w", err)
+	}
+
+	input := cmd.InOrStdin()
+	output := cmd.ErrOrStderr()
+	inputFile, ok := input.(*os.File)
+	if !ok {
+		password, err := readMaskedPassword(input, output)
+		_, printErr := fmt.Fprintln(output)
+		if err != nil {
+			return nil, err
+		}
+		if printErr != nil {
+			return nil, fmt.Errorf("unable to finalize password "+
+				"prompt: %w", printErr)
+		}
+
+		return password, nil
+	}
 
 	// Interactive prompt (TTY).
-	fd := int(os.Stdin.Fd())
+	fd := int(inputFile.Fd())
 	oldState, err := term.MakeRaw(fd)
 	if err != nil {
 		return nil, fmt.Errorf("unable to configure terminal for "+
@@ -142,9 +174,9 @@ func readInteractivePassword(prompt string) ([]byte, error) {
 	}
 	defer restoreTerminal()
 
-	password, err := readMaskedPassword(os.Stdin, os.Stderr)
+	password, err := readMaskedPassword(input, output)
 	restoreTerminal()
-	_, printErr := fmt.Fprintln(os.Stderr)
+	_, printErr := fmt.Fprintln(output)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/wavecli/waveclicommands/wallet_password_test.go
+++ b/cmd/wavecli/waveclicommands/wallet_password_test.go
@@ -7,8 +7,65 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
+
+func TestReadPasswordRequiresExplicitStdin(t *testing.T) {
+	prev := stdinIsTTY
+	stdinIsTTY = func(*cobra.Command) bool { return false }
+	t.Cleanup(func() {
+		stdinIsTTY = prev
+	})
+
+	cmd := newUnlockCmd()
+	cmd.SetIn(strings.NewReader("secret\n"))
+
+	password, err := readPassword(cmd)
+	require.Nil(t, password)
+	require.ErrorContains(t, err, "--password-stdin")
+}
+
+func TestReadPasswordFromExplicitStdin(t *testing.T) {
+	t.Parallel()
+
+	cmd := newUnlockCmd()
+	cmd.SetIn(strings.NewReader("secret\nignored\n"))
+	require.NoError(t, cmd.Flags().Set("password-stdin", "true"))
+
+	password, err := readPassword(cmd)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secret"), password)
+}
+
+func TestNoInputAllowsExplicitPasswordSources(t *testing.T) {
+	t.Parallel()
+
+	root := newRootCmd(false)
+	require.NoError(t, root.PersistentFlags().Set("no-input", "true"))
+	cmd, _, err := root.Find([]string{"unlock"})
+	require.NoError(t, err)
+	cmd.SetIn(strings.NewReader("secret\n"))
+	require.NoError(t, cmd.Flags().Set("password-stdin", "true"))
+
+	password, err := readPassword(cmd)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secret"), password)
+}
+
+func TestNoInputRejectsPasswordPrompt(t *testing.T) {
+	t.Parallel()
+
+	root := newRootCmd(false)
+	require.NoError(t, root.PersistentFlags().Set("no-input", "true"))
+	cmd, _, err := root.Find([]string{"unlock"})
+	require.NoError(t, err)
+	cmd.SetIn(strings.NewReader("secret\n"))
+
+	password, err := readPassword(cmd)
+	require.Nil(t, password)
+	require.ErrorContains(t, err, "wallet password input required")
+}
 
 // TestReadMaskedPasswordMasksInput confirms each entered byte is
 // echoed as a single asterisk and the raw password is never written

--- a/cmd/wavecli/waveclicommands/wallet_password_test.go
+++ b/cmd/wavecli/waveclicommands/wallet_password_test.go
@@ -24,6 +24,7 @@ func TestReadPasswordRequiresExplicitStdin(t *testing.T) {
 	password, err := readPassword(cmd)
 	require.Nil(t, password)
 	require.ErrorContains(t, err, "--password-stdin")
+	require.Equal(t, ExitInvalidArgs, ExitCodeFor(err))
 }
 
 func TestReadPasswordFromExplicitStdin(t *testing.T) {
@@ -36,6 +37,17 @@ func TestReadPasswordFromExplicitStdin(t *testing.T) {
 	password, err := readPassword(cmd)
 	require.NoError(t, err)
 	require.Equal(t, []byte("secret"), password)
+}
+
+func TestInteractivePasswordRejectsEmbeddedReader(t *testing.T) {
+	t.Parallel()
+
+	cmd := newUnlockCmd()
+	cmd.SetIn(strings.NewReader("secret\n"))
+
+	password, err := readInteractivePassword(cmd, "Password: ")
+	require.Nil(t, password)
+	require.ErrorContains(t, err, "requires a terminal")
 }
 
 func TestNoInputAllowsExplicitPasswordSources(t *testing.T) {
@@ -65,6 +77,7 @@ func TestNoInputRejectsPasswordPrompt(t *testing.T) {
 	password, err := readPassword(cmd)
 	require.Nil(t, password)
 	require.ErrorContains(t, err, "wallet password input required")
+	require.Equal(t, ExitInvalidArgs, ExitCodeFor(err))
 }
 
 // TestReadMaskedPasswordMasksInput confirms each entered byte is

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -186,8 +186,8 @@ the only backup.
 # Via environment variable (recommended for automation)
 WAVED_WALLET_PASSWORD=your_password wavecli create
 
-# Via stdin pipe
-echo -n 'your_password' | wavecli create
+# Via explicit stdin (never consumed unless requested)
+printf '%s\n' 'your_password' | wavecli create --password-stdin
 
 # Via password file
 wavecli create \
@@ -713,8 +713,14 @@ order for password resolution:
 
 1. **Environment variable** -- `WAVED_WALLET_PASSWORD=pass`
 2. **Password file** -- `--wallet-password-file=/path/to/file`
-3. **stdin pipe** -- `echo -n 'pass' | wavecli unlock`
+3. **Explicit stdin** -- `printf '%s\n' 'pass' | wavecli unlock --password-stdin`
 4. **Interactive prompt** -- prompted on TTY if none of the above
+
+Plain piped stdin is never consumed as a password. Pass global `--no-input`
+when an invocation must never prompt or implicitly read input. `CI=true` also
+suppresses prompts while leaving stdout and stderr output unchanged. Explicit
+sources such as `--password-stdin`, a password file, or the environment remain
+available under `--no-input`.
 
 For production deployments, use the password file approach with
 restrictive file permissions (`chmod 600`).


### PR DESCRIPTION
Addresses P0-3 from #997.

Before:
- piped stdin was silently treated as a wallet password
- there was no global way to guarantee that a command would never prompt
- consent prompts implemented their own reads, and recovery prompts wrote to stdout
- CI environments had to manipulate stdin or pass command-specific flags to avoid prompts

After:
- global `--no-input` disables interactive prompts and implicit input
- `CI=true` applies the same prompt suppression without hiding stdout/stderr
- wallet passwords use the explicit priority: environment, password file, `--password-stdin`, then TTY prompt
- plain piped stdin is never consumed as a secret
- all y/N prompts use one helper and write to stderr
- create/unlock help, runtime schema, and operator docs describe the explicit stdin contract

Concrete consequence: agents can safely pipe data to commands without it being mistaken for a secret, can assert fully non-interactive behavior once, and can consume stdout without prompt contamination.

Validation:
- `make unit pkg=./cmd/wavecli/...`
- `go test ./cmd/wavecli/... -race`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`

This PR is independent from the other #997 slices and targets `main`.