### PR TITLE
wavecli: reconcile schema with live surfaces

### DIFF
--- a/cmd/wavecli/waveclicommands/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/AGENTS.md
@@ -114,6 +114,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   `walletAdmin`/`walletPayment`/`walletQuery`/`arkBase`/`arkVTXO`/
   `arkSend`/`arkObservable` sub-registries. MCP-only methods use
   `mcp_only`; tools whose arguments differ from the CLI use `mcp_params`.
+- `schema_parity_test.go` walks the real cobra tree and an in-memory real MCP
+  server. Every visible local flag on the curated wallet/ark surface must
+  match the registry name and type, and `MCPTool` must match the exact live
+  tool set.
 - `buildMCPServer()` — constructs the MCP server and registers every
   exposed RPC as a typed tool; split from `mcpServe` (which owns the
   daemon dial and stdio transport) so the tool surface is testable.

--- a/cmd/wavecli/waveclicommands/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/CLAUDE.md
@@ -114,6 +114,10 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/cmd/wave
   `walletAdmin`/`walletPayment`/`walletQuery`/`arkBase`/`arkVTXO`/
   `arkSend`/`arkObservable` sub-registries. MCP-only methods use
   `mcp_only`; tools whose arguments differ from the CLI use `mcp_params`.
+- `schema_parity_test.go` walks the real cobra tree and an in-memory real MCP
+  server. Every visible local flag on the curated wallet/ark surface must
+  match the registry name and type, and `MCPTool` must match the exact live
+  tool set.
 - `buildMCPServer()` — constructs the MCP server and registers every
   exposed RPC as a typed tool; split from `mcpServe` (which owns the
   daemon dial and stdio transport) so the tool surface is testable.

--- a/cmd/wavecli/waveclicommands/cmd_schema.go
+++ b/cmd/wavecli/waveclicommands/cmd_schema.go
@@ -16,7 +16,8 @@ func newSchemaCmd() *cobra.Command {
 		Long: "Returns the full method signature for a " +
 			"CLI command as machine-readable JSON: " +
 			"params, types, required fields, enum " +
-			"values, request/response types. Use " +
+			"values, request/response types, side effects, " +
+			"and output-schema id/version. Use " +
 			"--all to dump every method.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: schemaRun,

--- a/cmd/wavecli/waveclicommands/schema_parity_test.go
+++ b/cmd/wavecli/waveclicommands/schema_parity_test.go
@@ -1,0 +1,165 @@
+package waveclicommands
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaRegistryMatchesCobraTree(t *testing.T) {
+	t.Parallel()
+
+	root := newRootCmd(true)
+	registry := methodRegistry()
+	byMethod := make(map[string]schemaMethod, len(registry))
+
+	for _, method := range registry {
+		require.NotContains(t, byMethod, method.Method)
+		byMethod[method.Method] = method
+		require.NotEmpty(t, method.OutputSchemaID)
+		require.Equal(t, uint32(1), method.OutputSchemaVersion)
+
+		if method.MCPOnly {
+			continue
+		}
+
+		cmd, _, err := root.Find(strings.Split(method.Method, "."))
+		require.NoError(t, err, method.Method)
+		require.Equal(
+			t, schemaFlagTypes(method), commandFlagTypes(cmd),
+			method.Method,
+		)
+	}
+
+	walkCommands(root, func(cmd *cobra.Command) {
+		method, covered := coveredSchemaMethod(cmd)
+		if !covered {
+			return
+		}
+
+		require.Contains(
+			t, byMethod, method, "covered cobra command %q "+
+				"lacks schema", cmd.CommandPath(),
+		)
+	})
+}
+
+func TestSchemaRegistryMatchesMCPTools(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server := buildMCPServer(nil, nil)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	defer serverSession.Close()
+
+	client := mcp.NewClient(
+		&mcp.Implementation{
+			Name:    "schema-parity",
+			Version: "0",
+		},
+		nil,
+	)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer clientSession.Close()
+
+	tools, err := clientSession.ListTools(ctx, nil)
+	require.NoError(t, err)
+
+	actual := make(map[string]bool, len(tools.Tools))
+	for _, tool := range tools.Tools {
+		actual[tool.Name] = true
+	}
+
+	expected := make(map[string]bool)
+	for _, method := range methodRegistry() {
+		if method.MCPTool {
+			expected[method.Method] = true
+		}
+	}
+
+	require.Equal(t, expected, actual)
+}
+
+func schemaFlagTypes(method schemaMethod) map[string]string {
+	flags := make(map[string]string)
+	for _, param := range method.Params {
+		if param.Positional {
+			continue
+		}
+
+		flags[param.Name] = schemaParamFlagType(param)
+	}
+
+	return flags
+}
+
+func schemaParamFlagType(param schemaParam) string {
+	if param.FlagType != "" {
+		return param.FlagType
+	}
+
+	switch param.Type {
+	case "enum":
+		return "string"
+
+	case "string[]":
+		return "stringSlice"
+
+	case "int64[]":
+		return "int64Slice"
+
+	case "map[string]string":
+		return "stringToString"
+
+	default:
+		return param.Type
+	}
+}
+
+func commandFlagTypes(cmd *cobra.Command) map[string]string {
+	flags := make(map[string]string)
+	cmd.LocalNonPersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Hidden || flag.Name == "help" {
+			return
+		}
+
+		flags[flag.Name] = flag.Value.Type()
+	})
+
+	return flags
+}
+
+func walkCommands(cmd *cobra.Command, visit func(*cobra.Command)) {
+	visit(cmd)
+	for _, child := range cmd.Commands() {
+		walkCommands(child, visit)
+	}
+}
+
+func coveredSchemaMethod(cmd *cobra.Command) (string, bool) {
+	path := strings.TrimPrefix(cmd.CommandPath(), "wavecli ")
+	method := strings.ReplaceAll(path, " ", ".")
+
+	if strings.HasPrefix(path, "ark ") {
+		return method, cmd.RunE != nil
+	}
+
+	switch method {
+	case "create", "unlock", "send", "recv", "activity", "balance",
+		"exit", "wallet-sweep", "getinfo", "activity.inspect",
+		"exit.status", "exit.summary", "exit.plan":
+		return method, true
+
+	default:
+		return "", false
+	}
+}

--- a/cmd/wavecli/waveclicommands/schema_registry.go
+++ b/cmd/wavecli/waveclicommands/schema_registry.go
@@ -1,5 +1,7 @@
 package waveclicommands
 
+import "strings"
+
 // schemaParam describes a single parameter for a CLI command / RPC
 // method.
 type schemaParam struct {
@@ -9,6 +11,11 @@ type schemaParam struct {
 	// Type is the parameter type (string, int64, bool, enum, etc.).
 	Type string `json:"type"`
 
+	// FlagType records the exact pflag type when Type intentionally uses a
+	// friendlier schema spelling, for example repeatable StringArray
+	// values.
+	FlagType string `json:"flag_type,omitempty"`
+
 	// Description explains what the parameter does.
 	Description string `json:"description,omitempty"`
 
@@ -17,6 +24,9 @@ type schemaParam struct {
 
 	// Values lists valid values for enum-typed parameters.
 	Values []string `json:"values,omitempty"`
+
+	// Positional marks command arguments that are not cobra flags.
+	Positional bool `json:"positional,omitempty"`
 }
 
 // schemaMethod describes a single CLI command / RPC method.
@@ -63,6 +73,15 @@ type schemaMethod struct {
 	// MCPOnly indicates that Method is discoverable only through MCP and
 	// has no corresponding Cobra command.
 	MCPOnly bool `json:"mcp_only,omitempty"`
+
+	// SideEffect reports whether invoking the method can change wallet or
+	// daemon state. It is always emitted so agents need not infer defaults.
+	SideEffect bool `json:"side_effect"`
+
+	// OutputSchemaID and OutputSchemaVersion identify the additive output
+	// contract for this command without wrapping the proto JSON response.
+	OutputSchemaID      string `json:"output_schema_id"`
+	OutputSchemaVersion uint32 `json:"output_schema_version"`
 }
 
 // methodRegistry returns the full schema for all wavecli commands.
@@ -79,7 +98,30 @@ func methodRegistry() []schemaMethod {
 	out = append(out, arkSendMethodRegistry()...)
 	out = append(out, arkObservableMethodRegistry()...)
 
+	for i := range out {
+		out[i].OutputSchemaID = "wavecli." +
+			strings.ReplaceAll(out[i].Method, ".", "-") + ".output"
+		out[i].OutputSchemaVersion = 1
+		out[i].SideEffect = schemaMethodHasSideEffect(out[i].Method)
+	}
+
 	return out
+}
+
+// schemaMethodHasSideEffect keeps the coarse safety label explicit and small.
+// Preview-only and query methods are false; methods that allocate, queue,
+// dispatch, unlock, or broadcast are true.
+func schemaMethodHasSideEffect(method string) bool {
+	switch method {
+	case "create", "unlock", "send", "recv", "exit", "wallet-sweep",
+		"ark.sweep", "ark.board", "ark.rounds.join",
+		"ark.oor.newaddress", "ark.oor.receive", "ark.vtxos.refresh",
+		"ark.vtxos.leave", "ark.send.inround", "ark.send.oor":
+		return true
+
+	default:
+		return false
+	}
 }
 
 // listOutputParams returns the standard agent-CLI output-shape
@@ -140,6 +182,26 @@ func walletAdminMethodRegistry() []schemaMethod {
 						"in the JSON response on " +
 						"stdout (default: stderr only)",
 				},
+				{
+					Name: "recover",
+					Type: "bool",
+					Description: "recover from an " +
+						"existing " +
+						"mnemonic",
+				},
+				{
+					Name: "mnemonic-file",
+					Type: "string",
+					Description: "path to an existing " +
+						"24-word aezeed mnemonic",
+				},
+				{
+					Name: "recovery-window",
+					Type: "uint32",
+					Description: "key indexes to scan " +
+						"per " +
+						"recovery family",
+				},
 			},
 			RequestType:  "CreateRequest",
 			ResponseType: "CreateResponse",
@@ -173,6 +235,28 @@ func walletAdminMethodRegistry() []schemaMethod {
 			RequestType:  "GetInfoRequest",
 			ResponseType: "GetInfoResponse",
 			JSONInput:    true,
+			MCPTool:      true,
+		},
+		{
+			Method: "daemon.balance",
+			Description: "Display the raw daemon balance " +
+				"breakdown",
+			Params:       nil,
+			RequestType:  "GetBalanceRequest",
+			ResponseType: "GetBalanceResponse",
+			JSONInput:    false,
+			MCPTool:      true,
+			MCPOnly:      true,
+		},
+		{
+			Method:       "ark.oor.newaddress",
+			Description:  "Generate a new boarding address",
+			Params:       nil,
+			RequestType:  "NewAddressRequest",
+			ResponseType: "NewAddressResponse",
+			JSONInput:    false,
+			MCPTool:      true,
+			MCPOnly:      true,
 		},
 	}
 }
@@ -185,6 +269,14 @@ func walletPaymentMethodRegistry() []schemaMethod {
 			Method:      "send",
 			Description: "Send a payment (offchain or onchain)",
 			Params: []schemaParam{
+				{
+					Name: "destination",
+					Type: "string",
+					Description: "invoice or on-chain " +
+						"address",
+					Required:   true,
+					Positional: true,
+				},
 				{
 					Name: "offchain",
 					Type: "bool",
@@ -239,6 +331,26 @@ func walletPaymentMethodRegistry() []schemaMethod {
 					Name:        "yes",
 					Type:        "bool",
 					Description: "alias for force",
+				},
+				{
+					Name: "no-wait",
+					Type: "bool",
+					Description: "return after dispatch " +
+						"instead " +
+						"of waiting for settlement",
+				},
+				{
+					Name: "wait-timeout",
+					Type: "duration",
+					Description: "maximum settlement " +
+						"wait; " +
+						"zero waits indefinitely",
+				},
+				{
+					Name: "wait-poll-interval",
+					Type: "duration",
+					Description: "settlement status poll " +
+						"interval",
 				},
 			},
 			RequestType:        "PrepareSendRequest",
@@ -351,7 +463,8 @@ func walletPaymentMethodRegistry() []schemaMethod {
 
 // walletQueryMethodRegistry returns the wallet query verbs (activity,
 // balance, exit, exit.status, activity.inspect).
-func walletQueryMethodRegistry() []schemaMethod {
+func walletQueryMethodRegistry() []schemaMethod { //nolint:funlen
+
 	return []schemaMethod{
 		{
 			Method:      "activity",
@@ -374,9 +487,9 @@ func walletQueryMethodRegistry() []schemaMethod {
 						"daemon default",
 				},
 				{
-					Name:        "offset",
-					Type:        "uint32",
-					Description: "pagination offset",
+					Name:        "cursor",
+					Type:        "string",
+					Description: "activity page token",
 				},
 				{
 					Name:        "format",
@@ -421,6 +534,19 @@ func walletQueryMethodRegistry() []schemaMethod {
 						"preview and exit 0 without " +
 						"dispatching",
 				},
+				{
+					Name: "onchain-address",
+					Type: "string",
+					Description: "cooperative leave " +
+						"destination",
+				},
+				{
+					Name: "force-unroll-ack",
+					Type: "string",
+					Description: "exact acknowledgement " +
+						"for " +
+						"unilateral unroll",
+				},
 			},
 			RequestType:  "ExitRequest",
 			ResponseType: "ExitResponse",
@@ -438,6 +564,13 @@ func walletQueryMethodRegistry() []schemaMethod {
 					Required: true,
 					Description: "VTXO outpoint " +
 						"(txid:vout)",
+				},
+				{
+					Name: "detailed",
+					Type: "bool",
+					Description: "include tree, CSV, and " +
+						"fee " +
+						"progress",
 				},
 			},
 			RequestType:  "ExitStatusRequest",
@@ -463,6 +596,7 @@ func walletQueryMethodRegistry() []schemaMethod {
 				{
 					Name:     "outpoint",
 					Type:     "string[]",
+					FlagType: "stringArray",
 					Required: true,
 					Description: "VTXO outpoint " +
 						"(txid:vout); repeatable",
@@ -471,7 +605,6 @@ func walletQueryMethodRegistry() []schemaMethod {
 			RequestType:  "GetExitPlanRequest",
 			ResponseType: "GetExitPlanResponse",
 			JSONInput:    false,
-			MCPTool:      true,
 		},
 		{
 			Method: "wallet-sweep",
@@ -508,7 +641,6 @@ func walletQueryMethodRegistry() []schemaMethod {
 			RequestType:  "SweepWalletRequest",
 			ResponseType: "SweepWalletResponse",
 			JSONInput:    false,
-			MCPTool:      true,
 		},
 		{
 			Method: "activity.inspect",
@@ -520,6 +652,7 @@ func walletQueryMethodRegistry() []schemaMethod {
 					Type:        "string",
 					Required:    true,
 					Description: "WalletEntry id",
+					Positional:  true,
 				},
 				{
 					Name: "ledger-limit",
@@ -566,19 +699,19 @@ func arkBaseMethodRegistry() []schemaMethod {
 						"sweep and track confirmation",
 				},
 				{
-					Name: "fee_rate_sat_per_vbyte",
+					Name: "fee-rate-sat-per-vbyte",
 					Type: "int64",
 					Description: "fee rate override; " +
 						"zero estimates by target",
 				},
 				{
-					Name: "conf_target",
+					Name: "conf-target",
 					Type: "uint32",
 					Description: "confirmation target; " +
 						"zero uses default",
 				},
 				{
-					Name: "sweep_address",
+					Name: "sweep-address",
 					Type: "string",
 					Description: "optional destination; " +
 						"empty uses wallet address",
@@ -601,13 +734,13 @@ func arkBaseMethodRegistry() []schemaMethod {
 						"external_resolved, or failed",
 				},
 				{
-					Name: "page_size",
+					Name: "page-size",
 					Type: "uint32",
 					Description: "maximum sweeps to " +
 						"return; zero uses default",
 				},
 				{
-					Name: "page_token",
+					Name: "page-token",
 					Type: "string",
 					Description: "token from a previous " +
 						"sweep list response",
@@ -675,6 +808,7 @@ func arkBaseMethodRegistry() []schemaMethod {
 			RequestType:  "NewReceiveScriptRequest",
 			ResponseType: "NewReceiveScriptResponse",
 			JSONInput:    true,
+			MCPTool:      true,
 		},
 	}
 }
@@ -713,6 +847,7 @@ func arkVTXOMethodRegistry() []schemaMethod {
 			RequestType:  "ListVTXOsRequest",
 			ResponseType: "ListVTXOsResponse",
 			JSONInput:    true,
+			MCPTool:      true,
 		},
 		{
 			Method: "ark.vtxos.refresh",
@@ -741,6 +876,11 @@ func arkVTXOMethodRegistry() []schemaMethod {
 						"fee confirmation",
 				},
 				{
+					Name:        "dry-run",
+					Type:        "bool",
+					Description: "preview without queuing",
+				},
+				{
 					Name: "no-join",
 					Type: "bool",
 					Description: "skip the implicit " +
@@ -751,6 +891,7 @@ func arkVTXOMethodRegistry() []schemaMethod {
 			ResponseType: "RefreshVTXOsResponse",
 			DryRun:       true,
 			JSONInput:    true,
+			MCPTool:      true,
 		},
 		{
 			Method: "ark.vtxos.leave",
@@ -795,6 +936,11 @@ func arkVTXOMethodRegistry() []schemaMethod {
 						"interactive confirmation",
 				},
 				{
+					Name:        "dry-run",
+					Type:        "bool",
+					Description: "preview without queuing",
+				},
+				{
 					Name: "no-join",
 					Type: "bool",
 					Description: "skip the implicit " +
@@ -805,6 +951,7 @@ func arkVTXOMethodRegistry() []schemaMethod {
 			ResponseType: "LeaveVTXOsResponse",
 			DryRun:       true,
 			JSONInput:    true,
+			MCPTool:      true,
 		},
 	}
 }
@@ -820,21 +967,33 @@ func arkSendMethodRegistry() []schemaMethod {
 				{
 					Name:        "to",
 					Type:        "string[]",
-					Required:    true,
 					Description: "recipient address(es)",
+				},
+				{
+					Name: "pubkey",
+					Type: "string[]",
+					Description: "recipient x-only " +
+						"public key(s)",
 				},
 				{
 					Name:     "amount",
 					Type:     "int64[]",
 					Required: true,
 					Description: "amount(s) in sats " +
-						"(one per --to)",
+						"(one per recipient)",
+				},
+				{
+					Name: "dry-run",
+					Type: "bool",
+					Description: "validate without " +
+						"submitting",
 				},
 			},
 			RequestType:  "SendVTXORequest",
 			ResponseType: "SendVTXOResponse",
 			DryRun:       true,
 			JSONInput:    true,
+			MCPTool:      true,
 		},
 		{
 			Method:      "ark.send.oor",
@@ -844,24 +1003,14 @@ func arkSendMethodRegistry() []schemaMethod {
 					Name: "to",
 					Type: "string",
 					Description: "recipient address " +
-						"(exactly one of to, pubkey, " +
-						"or pk_script)",
+						"(exactly one of to or pubkey)",
 				},
 				{
 					Name: "pubkey",
 					Type: "string",
 					Description: "recipient 32-byte " +
 						"x-only pubkey hex (exactly " +
-						"one of to, pubkey, or " +
-						"pk_script)",
-				},
-				{
-					Name: "pk-script",
-					Type: "string",
-					Description: "recipient raw " +
-						"pk_script hex (exactly one " +
-						"of to, pubkey, or " +
-						"pk_script)",
+						"one of to or pubkey)",
 				},
 				{
 					Name:        "amount",
@@ -875,11 +1024,18 @@ func arkSendMethodRegistry() []schemaMethod {
 					Description: "stable caller intent " +
 						"key for retry-safe OOR sends",
 				},
+				{
+					Name: "dry-run",
+					Type: "bool",
+					Description: "validate without " +
+						"initiating",
+				},
 			},
 			RequestType:  "SendOORRequest",
 			ResponseType: "SendOORResponse",
 			DryRun:       true,
 			JSONInput:    true,
+			MCPTool:      true,
 		},
 	}
 }

--- a/cmd/wavecli/waveclicommands/schema_registry_ark_observable.go
+++ b/cmd/wavecli/waveclicommands/schema_registry_ark_observable.go
@@ -49,6 +49,16 @@ func arkObservableMutateMethodRegistry() []schemaMethod {
 			ResponseType: "BoardResponse",
 			JSONInput:    true,
 		},
+		{
+			Method: "ark.rounds.join",
+			Description: "Commit queued intents and join the " +
+				"next " +
+				"round",
+			Params:       nil,
+			RequestType:  "JoinNextRoundRequest",
+			ResponseType: "JoinNextRoundResponse",
+			JSONInput:    false,
+		},
 	}
 }
 
@@ -184,7 +194,22 @@ func arkObservableSingletonMethodRegistry() []schemaMethod {
 		{
 			Method:      "ark.rounds.watch",
 			Description: "Stream round state updates",
-			Params:      nil,
+			Params: []schemaParam{
+				{
+					Name: "max-events",
+					Type: "uint32",
+					Description: "stop after this many " +
+						"updates; 0 has no " +
+						"event-count limit",
+				},
+				{
+					Name: "for",
+					Type: "duration",
+					Description: "watch for this " +
+						"duration instead of the " +
+						"global --timeout",
+				},
+			},
 			RequestType: "WatchRoundsRequest",
 			ResponseType: "RoundStateUpdate (server " +
 				"stream)",

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -642,6 +642,12 @@ wavecli schema ark.vtxos.list
 wavecli schema --all
 ```
 
+Every schema entry includes a stable `output_schema_id` and
+`output_schema_version`, plus a `side_effect` boolean and whether the same
+method is exposed through MCP. The unit suite walks the real cobra command
+tree and the live MCP tool list, so a declared flag or tool cannot silently
+drift from the executable surface.
+
 ### `mcp serve` (wavewalletrpc)
 
 Start an MCP (Model Context Protocol) server on stdio for AI agent


### PR DESCRIPTION
Addresses P0-7 from #997 with the intentionally small reconciliation-and-ratchet approach.

Before:
- `schema --all` advertised wrong names/types, phantom fields, missing flags/commands, and incorrect MCP exposure
- output contracts had no per-command identifier/version or side-effect label
- registry drift could recur without CI noticing

After:
- reconciles the confirmed drift: activity cursor, OOR destination shape, MCP flags, MCP-only `daemon.balance`/`ark.oor.newaddress`, send wait flags, exit/create/dry-run/in-round parameters, and the missing rounds join entry
- every entry emits `output_schema_id`, `output_schema_version: 1`, and `side_effect`
- one focused unit test walks the real cobra tree and an in-memory real MCP server, comparing visible flag names/types, covered command presence, and the exact MCP tool set

Concrete consequence: agents can trust the runtime manifest for command construction and safety classification, while future drift fails the ordinary unit suite.

Merge order: this PR must merge last after all selected surface changes (#1021 through #1027), then be rebased once so the ratchet records the final combined surface. In particular, #1022 adds watch bounds and #1026 adds non-interactive input flags that the final manifest must include. It is deliberately a draft until that final rebase.

Validation on current main:
- `make unit pkg=./cmd/wavecli/...`
- `go test ./cmd/wavecli/... -race`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`