### PR TITLE
docs: Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Lightning Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- add a root `LICENSE` containing the standard MIT license text
- identify Lightning Labs as the copyright holder for 2025-2026

## Rationale

The repository currently has no license file, and GitHub therefore cannot
identify any license for the project. Adding the MIT license makes the terms
for using, modifying, and distributing Wavelength explicit.

The grant and warranty language matches the MIT license used by
`lightninglabs/taproot-assets`. Only the copyright notice is adjusted to
Wavelength's project lifetime.

## Validation

- compared the license text with `lightninglabs/taproot-assets/LICENSE`
- `git diff --check origin/main...HEAD`
- `make commitmsg-lint range="origin/main..HEAD"`
