### PR TITLE
docs: Document MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # wavelength
 
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 `wavelength` is a self-custodial Bitcoin wallet system written in Go. It
 unifies three layers that usually live in separate tools: an Ark client, a
 Lightning swap engine, and an on-chain wallet. All of it runs behind one
@@ -238,6 +240,4 @@ across minor versions.
 
 ## License
 
-A `LICENSE` file has not yet been published in this repository. Until one is
-added, treat the code as all-rights-reserved and contact the maintainers
-before redistributing.
+Wavelength is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- add an MIT license badge beneath the Wavelength heading
- replace the stale all-rights-reserved notice with a link to `LICENSE`

## Context

PR #1029 added the project's MIT license. The README still says that no
license has been published, so its guidance now contradicts the repository.
This follow-up makes the README accurately and visibly describe the merged
licensing terms.

## Validation

- `git diff --check origin/main...HEAD`
- verified that the linked root `LICENSE` exists on the branch
- `make commitmsg-lint range="origin/main..HEAD"`
