### PR TITLE
waved: fetch personalized terms after bootstrap

### DIFF
--- a/systest/send_vtxo_test.go
+++ b/systest/send_vtxo_test.go
@@ -282,11 +282,12 @@ func (s *fakeMailboxServer) replyWithOperatorInfo(ctx context.Context,
 	}
 
 	responseEnv := &mailboxpb.Envelope{
-		ProtocolVersion: env.ProtocolVersion,
-		Sender:          s.operatorMailbox,
-		Recipient:       env.Rpc.ReplyTo,
-		CreatedAtUnixMs: time.Now().UnixMilli(),
-		Body:            body,
+		ProtocolVersion:    env.ProtocolVersion,
+		ArkProtocolVersion: env.ArkProtocolVersion,
+		Sender:             s.operatorMailbox,
+		Recipient:          env.Rpc.ReplyTo,
+		CreatedAtUnixMs:    time.Now().UnixMilli(),
+		Body:               body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			Service:       env.Rpc.Service,

--- a/waved/operator_negotiation_test.go
+++ b/waved/operator_negotiation_test.go
@@ -2,15 +2,19 @@ package waved
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/wavelength/arkrpc"
 	"github.com/lightninglabs/wavelength/lib/types"
 	mailboxconn "github.com/lightninglabs/wavelength/mailbox/conn"
+	mailboxrpc "github.com/lightninglabs/wavelength/mailbox/rpc"
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 // TestVTXOExpiryConfigUsesLatestTerms verifies long-lived VTXO actors observe
@@ -53,8 +57,9 @@ func activeArkPolicy(version uint32) *arkrpc.ArkVersionPolicy {
 // canned GetInfo response, used to drive the bootstrap negotiation without a
 // real transport.
 type stubArkServiceClient struct {
-	resp *arkrpc.GetInfoResponse
-	err  error
+	resp  *arkrpc.GetInfoResponse
+	err   error
+	calls int
 }
 
 // GetInfo returns the canned response.
@@ -62,11 +67,58 @@ func (s *stubArkServiceClient) GetInfo(_ context.Context,
 	_ *arkrpc.GetInfoRequest, _ ...grpc.CallOption) (
 	*arkrpc.GetInfoResponse, error) {
 
+	s.calls++
+
 	if s.err != nil {
 		return nil, s.err
 	}
 
 	return s.resp, nil
+}
+
+// stubMailboxRPCClient returns a canned GetInfo response while recording the
+// request sent through the generated mailbox client.
+type stubMailboxRPCClient struct {
+	resp   *arkrpc.GetInfoResponse
+	method mailboxrpc.ServiceMethod
+	req    *arkrpc.GetInfoRequest
+	calls  int
+	await  func(context.Context, proto.Message) error
+}
+
+// SendRPC records the request and returns a stable correlation ID.
+func (s *stubMailboxRPCClient) SendRPC(_ context.Context,
+	method mailboxrpc.ServiceMethod, req proto.Message,
+	_ mailboxrpc.RPCOptions) (mailboxrpc.SendResult, error) {
+
+	typedReq, ok := req.(*arkrpc.GetInfoRequest)
+	if !ok {
+		return mailboxrpc.SendResult{}, fmt.Errorf("unexpected "+
+			"request type: %T", req)
+	}
+
+	s.calls++
+	s.method = method
+	s.req = &arkrpc.GetInfoRequest{
+		SupportedArkVersions: append(
+			[]uint32(nil), typedReq.SupportedArkVersions...,
+		),
+	}
+
+	return mailboxrpc.SendResult{CorrelationID: "get-info"}, nil
+}
+
+// AwaitRPC copies the canned response into the generated client's target.
+func (s *stubMailboxRPCClient) AwaitRPC(ctx context.Context, _ string,
+	resp proto.Message) error {
+
+	if s.await != nil {
+		return s.await(ctx, resp)
+	}
+
+	proto.Merge(resp, s.resp)
+
+	return nil
 }
 
 // EstimateFee is unused by these tests.
@@ -165,6 +217,146 @@ func TestFetchOperatorTermsRefreshPinsVersion(t *testing.T) {
 
 	// The runtime version must be unchanged by a refresh.
 	require.Equal(t, uint32(1), srv.arkProtocolVersion)
+}
+
+// TestRefreshAuthenticatedOperatorTermsUsesMailbox verifies that the
+// post-bootstrap refresh replaces anonymous policy with the terms resolved for
+// the daemon's authenticated mailbox identity.
+func TestRefreshAuthenticatedOperatorTermsUsesMailbox(t *testing.T) {
+	t.Parallel()
+
+	pubKey := testOperatorPubKeyBytes(t)
+	direct := &stubArkServiceClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             pubKey,
+			SelectedArkVersion: 1,
+			MaxVtxoAmount:      200_000,
+		},
+	}
+	mailbox := &stubMailboxRPCClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             pubKey,
+			SelectedArkVersion: 1,
+			MaxVtxoAmount:      5_000_000,
+		},
+	}
+
+	srv := &Server{
+		arkClient:          direct,
+		ark:                arkrpc.NewArkServiceMailboxClient(mailbox),
+		arkProtocolVersion: 1,
+	}
+	srv.storeOperatorTerms(&types.OperatorTerms{
+		MaxVTXOAmount: 200_000,
+	})
+	srv.setServerConnected(true)
+
+	err := srv.refreshAuthenticatedOperatorTerms(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 0, direct.calls)
+	require.Equal(t, 1, mailbox.calls)
+	require.Equal(t, "arkrpc.ArkService", mailbox.method.Service)
+	require.Equal(t, "GetInfo", mailbox.method.Method)
+	require.Equal(t, []uint32{1}, mailbox.req.SupportedArkVersions)
+	require.NotNil(t, srv.loadOperatorTerms().PubKey)
+	require.True(t, srv.hasPersonalizedLimits.Load())
+	require.EqualValues(
+		t, 5_000_000, srv.loadOperatorTerms().MaxVTXOAmount,
+	)
+}
+
+// TestFetchCurrentOperatorPubKeyPreservesPersonalizedLimits verifies that a
+// later anonymous key refresh cannot replace the policy learned through the
+// authenticated startup refresh.
+func TestFetchCurrentOperatorPubKeyPreservesPersonalizedLimits(t *testing.T) {
+	t.Parallel()
+
+	freshPubKey := testOperatorPubKeyBytes(t)
+	direct := &stubArkServiceClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             freshPubKey,
+			SelectedArkVersion: 1,
+			MaxVtxoAmount:      200_000,
+			MaxUserBalance:     100_000_000,
+		},
+	}
+	srv := &Server{
+		arkClient:          direct,
+		arkProtocolVersion: 1,
+	}
+	srv.hasPersonalizedLimits.Store(true)
+	srv.storeOperatorTerms(&types.OperatorTerms{
+		MaxVTXOAmount:  5_000_000,
+		MaxUserBalance: 150_000_000,
+	})
+
+	pubKey, err := srv.fetchCurrentOperatorPubKey(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, freshPubKey, pubKey.SerializeCompressed())
+	require.Equal(t, 1, direct.calls)
+	require.EqualValues(
+		t, 5_000_000, srv.loadOperatorTerms().MaxVTXOAmount,
+	)
+	require.EqualValues(
+		t, 150_000_000, srv.loadOperatorTerms().MaxUserBalance,
+	)
+}
+
+// TestFetchCurrentOperatorPubKeyUpdatesGlobalLimits verifies an ordinary
+// client can learn global policy changes from a later direct GetInfo.
+func TestFetchCurrentOperatorPubKeyUpdatesGlobalLimits(t *testing.T) {
+	t.Parallel()
+
+	direct := &stubArkServiceClient{
+		resp: &arkrpc.GetInfoResponse{
+			Pubkey:             testOperatorPubKeyBytes(t),
+			SelectedArkVersion: 1,
+			MaxVtxoAmount:      500_000,
+			MaxUserBalance:     200_000_000,
+		},
+	}
+	srv := &Server{
+		arkClient:          direct,
+		arkProtocolVersion: 1,
+	}
+	srv.storeOperatorTerms(&types.OperatorTerms{
+		MaxVTXOAmount:  200_000,
+		MaxUserBalance: 100_000_000,
+	})
+
+	_, err := srv.fetchCurrentOperatorPubKey(t.Context())
+	require.NoError(t, err)
+	require.False(t, srv.hasPersonalizedLimits.Load())
+	require.EqualValues(
+		t, 500_000, srv.loadOperatorTerms().MaxVTXOAmount,
+	)
+	require.EqualValues(
+		t, 200_000_000, srv.loadOperatorTerms().MaxUserBalance,
+	)
+}
+
+// TestRefreshAuthenticatedOperatorTermsHonorsDeadline verifies a stalled
+// mailbox response returns when the caller's startup deadline expires.
+func TestRefreshAuthenticatedOperatorTermsHonorsDeadline(t *testing.T) {
+	t.Parallel()
+
+	mailbox := &stubMailboxRPCClient{
+		await: func(ctx context.Context, _ proto.Message) error {
+			<-ctx.Done()
+
+			return ctx.Err()
+		},
+	}
+	srv := &Server{
+		ark: arkrpc.NewArkServiceMailboxClient(mailbox),
+	}
+	srv.setServerConnected(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	err := srv.refreshAuthenticatedOperatorTerms(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 // TestFetchOperatorTermsRefreshRejectsRenegotiation proves a refresh that

--- a/waved/server.go
+++ b/waved/server.go
@@ -310,6 +310,17 @@ type Server struct {
 	// concurrent GetInfo RPC reads.
 	operatorTerms atomic.Pointer[types.OperatorTerms]
 
+	// operatorTermsUpdateMu serializes the authenticated terms refresh
+	// with direct operator-key refreshes. Readers continue to use the
+	// atomic snapshot above without taking this lock.
+	operatorTermsUpdateMu sync.Mutex
+
+	// hasPersonalizedLimits records whether the authenticated terms differ
+	// from the anonymous policy. Direct GetInfo responses may replace
+	// global limits, but must not overwrite policy resolved for this
+	// identity.
+	hasPersonalizedLimits atomic.Bool
+
 	// arkProtocolVersion is the Ark protocol version negotiated during
 	// bootstrap and bound to the mailbox runtime for its lifetime. Later
 	// refresh-only GetInfo calls pin this version and never change it; a
@@ -677,9 +688,22 @@ func (s *Server) vtxoExpiryConfig() *vtxo.ExpiryConfig {
 func (s *Server) fetchCurrentOperatorPubKey(ctx context.Context) (
 	*btcec.PublicKey, error) {
 
+	s.operatorTermsUpdateMu.Lock()
+	defer s.operatorTermsUpdateMu.Unlock()
+
 	terms, err := s.fetchOperatorTerms(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fetch operator terms: %w", err)
+	}
+
+	// Direct GetInfo does not carry a mailbox identity, so retain the
+	// personalized limits learned through the authenticated startup
+	// refresh while updating the operator's shared terms.
+	if s.hasPersonalizedLimits.Load() {
+		if cached := s.loadOperatorTerms(); cached != nil {
+			terms.MaxVTXOAmount = cached.MaxVTXOAmount
+			terms.MaxUserBalance = cached.MaxUserBalance
+		}
 	}
 
 	// Refresh the cache so unrelated readers (e.g. GetInfo) reflect the
@@ -799,6 +823,11 @@ func (s *Server) setServerConnected(connected bool) {
 // between detecting an operator outage promptly and not busy-polling the
 // gRPC connectivity API.
 const operatorConnPollInterval = 15 * time.Second
+
+// operatorTermsRefreshTimeout bounds the authenticated startup GetInfo. The
+// refresh remains fatal because starting with anonymous policy can size a
+// Board incorrectly, but a stalled mailbox must not hang startup forever.
+const operatorTermsRefreshTimeout = 30 * time.Second
 
 // oorTransientRejectRetryDelay is how long the OOR FSM waits before re-driving
 // a submit that the operator rejected with a transient code. The wait only
@@ -1507,6 +1536,26 @@ func (s *Server) startWalletReadyServices(ctx context.Context,
 
 	if err := s.startMailboxIngress(ctx); err != nil {
 		return err
+	}
+
+	// The bootstrap GetInfo call cannot use the mailbox identity because
+	// the runtime does not exist yet. Refresh the cached terms now that
+	// authenticated mailbox ingress is running, before a recovered Board
+	// intent can size its outputs from the anonymous bootstrap limits.
+	refreshCtx, refreshCancel := context.WithTimeout(
+		ctx, operatorTermsRefreshTimeout,
+	)
+	refreshErr := s.refreshAuthenticatedOperatorTerms(refreshCtx)
+	refreshCancel()
+	if refreshErr != nil {
+		return refreshErr
+	}
+
+	if err := s.replayPendingIntents(
+		ctx, s.walletRef.UnsafeFromSome(),
+	); err != nil {
+
+		s.log.WarnS(ctx, "Failed to replay pending intents", err)
 	}
 
 	if err := s.runWalletReadyHooks(ctx); err != nil {
@@ -2403,22 +2452,6 @@ func (s *Server) startWalletDependentActors(ctx context.Context,
 	}
 
 	// -------------------------------------------------------
-	// 13b. Replay any persisted Board RPC the user issued before the
-	//      last shutdown. Like resumeBoardingSweeps, this Ask MUST run
-	//      AFTER the round-client actor has registered with the
-	//      receptionist (step 11) — the replay's downstream
-	//      TriggerBoardMsg dispatch goes through the actor system,
-	//      and a Tell against an unresolved service key is a silent
-	//      drop. Driving the replay from wallet.Ark.Start would race
-	//      the registration and leave the recovered Board orphaned.
-	// -------------------------------------------------------
-	if err := s.replayPendingIntents(ctx, walletRef); err != nil {
-		s.log.WarnS(ctx, "Failed to replay pending intents",
-			err,
-		)
-	}
-
-	// -------------------------------------------------------
 	// 14. Register the OOR client actor.
 	// -------------------------------------------------------
 	if err := s.initOORActor(ctx, vtxoManagerRef); err != nil {
@@ -2440,11 +2473,12 @@ func (s *Server) startWalletDependentActors(ctx context.Context,
 	return nil
 }
 
-// replayPendingIntents Asks the wallet actor to replay any persisted
-// user intent (Board, SendOnChain, ...) across daemon restart. Called
-// once during startup, after the round-client actor has registered
-// with the receptionist, so the wallet's replayers can resolve the
-// round actor via the service-key router without racing.
+// replayPendingIntents Asks the wallet actor to replay any persisted user
+// intent (Board, SendOnChain, ...) across daemon restart. Called once during
+// startup, after the round-client actor has registered and authenticated
+// operator terms have replaced the anonymous bootstrap snapshot, so the
+// wallet's replayers can resolve the round actor without racing and size a
+// recovered Board from the caller's effective policy.
 //
 // A failure here does not block daemon startup: a fresh RPC by the
 // user overwrites the pending intents, and a future restart re-tries
@@ -4612,17 +4646,12 @@ func mapRoundVTXOManagerMsg(msg round.VTXOManagerMsg) vtxo.ManagerMsg {
 	return mapped
 }
 
-// fetchOperatorTerms refreshes the operator's terms from the Ark server via a
-// direct ArkService.GetInfo RPC. It is refresh-only: it is NOT a negotiation.
+// fetchOperatorTerms refreshes the operator's shared terms over the direct
+// ArkService connection. It is refresh-only: it is NOT a negotiation.
 // connectAndBootstrapMailbox is the sole owner of Ark protocol version
 // selection, so this call pins the runtime-bound version by sending it as the
 // singleton supported list and rejects any response that selects a different
 // or zero version. It never mutates the runtime version.
-//
-// This must not depend on mailbox ingress: a restarted client can already have
-// queued server-push envelopes in its mailbox targeting actors that have not
-// yet been registered, so using the mailbox transport here can deadlock
-// round/OOR bootstrap behind redelivery of those pending events.
 //
 // The terms include the operator pubkey, sweep delay, VTXO exit delay,
 // forfeit script, dust limit, and fee rate.
@@ -4639,11 +4668,23 @@ func (s *Server) fetchOperatorTerms(ctx context.Context) (*types.OperatorTerms,
 	boundVersion := s.arkProtocolVersion
 
 	resp, err := client.GetInfo(ctx, &arkrpc.GetInfoRequest{
-		SupportedArkVersions: []uint32{boundVersion},
+		SupportedArkVersions: []uint32{
+			boundVersion,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("GetInfo RPC: %w", err)
 	}
+
+	return s.operatorTermsFromRefreshResponse(ctx, resp)
+}
+
+// operatorTermsFromRefreshResponse validates that a refresh kept the
+// runtime-bound protocol version, then parses the returned terms.
+func (s *Server) operatorTermsFromRefreshResponse(ctx context.Context,
+	resp *arkrpc.GetInfoResponse) (*types.OperatorTerms, error) {
+
+	boundVersion := s.arkProtocolVersion
 
 	// A refresh that selects a different version is a terminal
 	// compatibility failure: the runtime is bound for its lifetime, so the
@@ -4661,6 +4702,51 @@ func (s *Server) fetchOperatorTerms(ctx context.Context) (*types.OperatorTerms,
 	}
 
 	return operatorTermsFromResponse(resp)
+}
+
+// refreshAuthenticatedOperatorTerms replaces the anonymous bootstrap terms
+// with the policy resolved for this daemon's authenticated mailbox identity.
+// It must run only after mailbox ingress starts, otherwise a unary response
+// cannot be delivered to the waiting facade.
+func (s *Server) refreshAuthenticatedOperatorTerms(ctx context.Context) error {
+	s.operatorTermsUpdateMu.Lock()
+	defer s.operatorTermsUpdateMu.Unlock()
+
+	if !s.isServerConnected() {
+		return fmt.Errorf("mailbox ingress not running")
+	}
+	if s.ark == nil {
+		return fmt.Errorf("authenticated operator client not " +
+			"initialized")
+	}
+
+	resp, err := s.ark.GetInfo(ctx, &arkrpc.GetInfoRequest{
+		SupportedArkVersions: []uint32{s.arkProtocolVersion},
+	})
+	if err != nil {
+		return fmt.Errorf("authenticated GetInfo RPC: %w", err)
+	}
+
+	terms, err := s.operatorTermsFromRefreshResponse(ctx, resp)
+	if err != nil {
+		return fmt.Errorf("validate authenticated operator terms: %w",
+			err)
+	}
+
+	// Only protect the personalized fields from later anonymous refreshes
+	// when authentication actually changed their values. Standard clients
+	// can therefore continue to learn global limit updates at runtime.
+	if anonymous := s.loadOperatorTerms(); anonymous != nil {
+		s.hasPersonalizedLimits.Store(
+			terms.MaxVTXOAmount != anonymous.MaxVTXOAmount ||
+				terms.MaxUserBalance !=
+					anonymous.MaxUserBalance,
+		)
+	}
+
+	s.storeOperatorTerms(terms)
+
+	return nil
 }
 
 // deriveIdentityKeyEarly derives the client's identity key before the


### PR DESCRIPTION
## Change

- Keep the direct `GetInfo` bootstrap responsible for protocol selection and the operator key.
- Once mailbox ingress is running, fetch terms through the authenticated mailbox and replace the anonymous bootstrap snapshot.
- Bound that startup refresh to 30 seconds and keep it fatal so the daemon never becomes ready with known-wrong Board sizing policy.
- Replay persisted Board intents only after the authenticated terms are cached.
- Preserve cached VTXO and balance limits only when authentication resolved personalized policy; ordinary clients continue learning global updates.
- Serialize authenticated and direct terms refreshes so they cannot publish out-of-order snapshots.

## Why

The bootstrap request runs before the mailbox runtime exists, so it has no mailbox identity. An operator with per-client policy therefore returns global limits during bootstrap, and the daemon can size a Board from the wrong VTXO ceiling.

The new synchronization point runs after every mailbox dispatch target is registered. This allows the unary response and any queued server events to be processed safely, while ensuring new and recovered Board requests observe the effective policy for this daemon identity. A finite deadline keeps a stalled mailbox from hanging startup indefinitely.

Later shared-term lookups remain on the direct connection. This avoids introducing a re-entrant mailbox dependency in handlers that may themselves run from mailbox ingress. Direct operator-key refreshes retain personalized fields without making ordinary clients' global limits stale.

## Verification

- `make fmt-changed`
- `make lint-changed-local`
- `go test ./... -count=1`
- `go test -race ./waved -run 'Test(FetchCurrentOperatorPubKey|RefreshAuthenticatedOperatorTerms)' -count=1`
- `make commitmsg-lint range="origin/main..HEAD"`

The SQLite system-test fixture now echoes the negotiated Ark protocol version in its fake authenticated `GetInfo` response. The exact system test could not complete locally because Docker hung while starting bitcoind; fresh CI will exercise that path.

Fixes #1030
