### PR TITLE
wavecli: gate raw money movement

### DIFF
--- a/cmd/wavecli/waveclicommands/AGENTS.md
+++ b/cmd/wavecli/waveclicommands/AGENTS.md
@@ -45,7 +45,7 @@ unchanged).
 | `exit status --outpoint TXID:VOUT` | `wavewalletrpc.ExitStatus` | Query an exit/unroll job's status (proxies GetUnrollStatus) |
 | `exit summary` | `wavewalletrpc.ExitSummary` | Aggregate totals across all in-progress exits |
 | `exit plan --outpoint ...` | `wavewalletrpc.GetExitPlan` | Preview backing-wallet funding readiness for one or more exits |
-| `wallet-sweep --destination ADDR` | `wavewalletrpc.SweepWallet` | Preview, or with `--broadcast` publish, a sweep of confirmed backing-wallet UTXOs (boarding outputs excluded; see `ark sweep`) |
+| `wallet-sweep --destination ADDR` | `wavewalletrpc.SweepWallet` | Preview, or with `--broadcast --yes` publish, a sweep of confirmed backing-wallet UTXOs (boarding outputs excluded; see `ark sweep`) |
 
 ### Daemon introspection
 
@@ -67,10 +67,10 @@ who want direct access.
 | `ark rounds {get,join,list,watch}` | `GetRound` / (join) / `ListRounds` / `WatchRounds` | Round FSM state; `join` commits queued intents into the next round (`vtxos refresh`/`leave` call it automatically); `watch --max-events`/`--for` bounds streams for machines |
 | `ark oor {receive,get,list}` | `NewReceiveScript` / `GetOORSession` / `ListOORSessions` | OOR session inspection |
 | `ark board` | `Board` | Trigger boarding with confirmed UTXOs |
-| `ark sweep [list]` | `SweepBoardingUTXOs` / `ListBoardingSweeps` | Boarding-timeout sweeps |
+| `ark sweep [list]` | `SweepBoardingUTXOs` / `ListBoardingSweeps` | Boarding-timeout sweeps; broadcasting requires interactive approval or `--yes` |
 | `ark fees {estimate,history}` | `EstimateFee` / `GetFeeHistory` | Fee estimation and history |
 | `ark listtransactions` | `ListTransactions` | Raw paginated transaction history |
-| `ark send {inround,oor}` | `SendVTXO` / `SendOOR` | Raw in-round / OOR send (superseded by `send` for the wallet shape) |
+| `ark send {inround,oor}` | `SendVTXO` / `SendOOR` | Raw in-round / OOR send; real transfers require interactive approval or `--yes` |
 
 ### `recovery.*` advanced commands
 

--- a/cmd/wavecli/waveclicommands/CLAUDE.md
+++ b/cmd/wavecli/waveclicommands/CLAUDE.md
@@ -45,7 +45,7 @@ unchanged).
 | `exit status --outpoint TXID:VOUT` | `wavewalletrpc.ExitStatus` | Query an exit/unroll job's status (proxies GetUnrollStatus) |
 | `exit summary` | `wavewalletrpc.ExitSummary` | Aggregate totals across all in-progress exits |
 | `exit plan --outpoint ...` | `wavewalletrpc.GetExitPlan` | Preview backing-wallet funding readiness for one or more exits |
-| `wallet-sweep --destination ADDR` | `wavewalletrpc.SweepWallet` | Preview, or with `--broadcast` publish, a sweep of confirmed backing-wallet UTXOs (boarding outputs excluded; see `ark sweep`) |
+| `wallet-sweep --destination ADDR` | `wavewalletrpc.SweepWallet` | Preview, or with `--broadcast --yes` publish, a sweep of confirmed backing-wallet UTXOs (boarding outputs excluded; see `ark sweep`) |
 
 ### Daemon introspection
 
@@ -67,10 +67,10 @@ who want direct access.
 | `ark rounds {get,join,list,watch}` | `GetRound` / (join) / `ListRounds` / `WatchRounds` | Round FSM state; `join` commits queued intents into the next round (`vtxos refresh`/`leave` call it automatically); `watch --max-events`/`--for` bounds streams for machines |
 | `ark oor {receive,get,list}` | `NewReceiveScript` / `GetOORSession` / `ListOORSessions` | OOR session inspection |
 | `ark board` | `Board` | Trigger boarding with confirmed UTXOs |
-| `ark sweep [list]` | `SweepBoardingUTXOs` / `ListBoardingSweeps` | Boarding-timeout sweeps |
+| `ark sweep [list]` | `SweepBoardingUTXOs` / `ListBoardingSweeps` | Boarding-timeout sweeps; broadcasting requires interactive approval or `--yes` |
 | `ark fees {estimate,history}` | `EstimateFee` / `GetFeeHistory` | Fee estimation and history |
 | `ark listtransactions` | `ListTransactions` | Raw paginated transaction history |
-| `ark send {inround,oor}` | `SendVTXO` / `SendOOR` | Raw in-round / OOR send (superseded by `send` for the wallet shape) |
+| `ark send {inround,oor}` | `SendVTXO` / `SendOOR` | Raw in-round / OOR send; real transfers require interactive approval or `--yes` |
 
 ### `recovery.*` advanced commands
 

--- a/cmd/wavecli/waveclicommands/cmd_ark_send.go
+++ b/cmd/wavecli/waveclicommands/cmd_ark_send.go
@@ -65,18 +65,14 @@ func newArkSendInRoundCmd() *cobra.Command {
 		"amount(s) in sats (one per recipient, in --to + --pubkey "+
 			"order)")
 	cmd.Flags().Bool("dry-run", false, "validate without submitting")
+	cmd.Flags().Bool("yes", false,
+		"approve submitting the fund-moving transfer")
 
 	return cmd
 }
 
 // sendInRound executes the raw SendVTXO RPC.
 func sendInRound(cmd *cobra.Command, _ []string) error {
-	client, conn, err := getDaemonClient(cmd)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
 	req := &waverpc.SendVTXORequest{}
 	if err := parseRequest(cmd, req, func() error {
 		addresses, _ := cmd.Flags().GetStringSlice("to")
@@ -150,6 +146,25 @@ func sendInRound(cmd *cobra.Command, _ []string) error {
 	}); err != nil {
 		return err
 	}
+	if len(req.GetRecipients()) == 0 {
+		return newCLIError(
+			ExitInvalidArgs, fmt.Errorf("at least one recipient "+
+				"is required"),
+		)
+	}
+	if !req.GetDryRun() {
+		action := fmt.Sprintf("submit an in-round transfer to %d "+
+			"recipient(s)", len(req.GetRecipients()))
+		if err := confirmMoneyMovement(cmd, action); err != nil {
+			return err
+		}
+	}
+
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
 
 	ctx, cancel := rpcContext(cmd)
 	defer cancel()
@@ -182,6 +197,8 @@ func newArkSendOORCmd() *cobra.Command {
 		"recipient 32-byte x-only pubkey hex")
 	cmd.Flags().Int64("amount", 0, "amount in sats")
 	cmd.Flags().Bool("dry-run", false, "validate without initiating")
+	cmd.Flags().Bool("yes", false,
+		"approve initiating the fund-moving transfer")
 	cmd.Flags().String("idempotency-key", "",
 		"caller-provided key for retrying the same OOR send intent")
 
@@ -192,12 +209,6 @@ func newArkSendOORCmd() *cobra.Command {
 
 // sendOOR executes the raw SendOOR RPC.
 func sendOOR(cmd *cobra.Command, _ []string) error {
-	client, conn, err := getDaemonClient(cmd)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
 	req := &waverpc.SendOORRequest{}
 	if err := parseRequest(cmd, req, func() error {
 		address, _ := cmd.Flags().GetString("to")
@@ -221,6 +232,25 @@ func sendOOR(cmd *cobra.Command, _ []string) error {
 	}); err != nil {
 		return err
 	}
+	if len(req.GetRecipients()) == 0 {
+		return newCLIError(
+			ExitInvalidArgs, fmt.Errorf("at least one recipient "+
+				"is required"),
+		)
+	}
+	if !req.GetDryRun() {
+		action := fmt.Sprintf("initiate an out-of-round transfer of "+
+			"%d satoshis", req.GetRecipients()[0].GetAmountSat())
+		if err := confirmMoneyMovement(cmd, action); err != nil {
+			return err
+		}
+	}
+
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
 
 	ctx, cancel := rpcContext(cmd)
 	defer cancel()

--- a/cmd/wavecli/waveclicommands/cmd_mcp.go
+++ b/cmd/wavecli/waveclicommands/cmd_mcp.go
@@ -108,6 +108,20 @@ func checkMCPRefreshConsent(dryRun, yes bool) error {
 		"fee and queue the refresh")
 }
 
+// checkMCPSendConsent enforces the same money-movement gate on the raw
+// MCP send tools that the CLI applies via confirmMoneyMovement. MCP
+// cannot prompt, so a real send must carry yes:true; dry_run previews
+// stay ungated. Otherwise it returns immediately with an actionable
+// error telling the agent how to proceed.
+func checkMCPSendConsent(dryRun, yes bool) error {
+	if dryRun || yes {
+		return nil
+	}
+
+	return fmt.Errorf("this raw send moves funds; pass yes:true to " +
+		"approve, or dry_run:true to preview without dispatching")
+}
+
 // mcpResult builds a CallToolResult from a proto message response.
 func mcpResult(msg proto.Message) (*mcp.CallToolResult, error) {
 	opts := protojson.MarshalOptions{
@@ -365,14 +379,21 @@ func registerMCPSendTools(s *mcp.Server, client waverpc.DaemonServiceClient) {
 		AmountSat int64  `json:"amount_sat" jsonschema:"amount in sats"`
 	}
 	type sendInRoundArgs struct {
-		Recipients []sendRecipient `json:"recipients" jsonschema:"list of recipients"`                 //nolint:ll
-		DryRun     bool            `json:"dry_run,omitempty" jsonschema:"validate without submitting"` //nolint:ll
+		Recipients []sendRecipient `json:"recipients" jsonschema:"list of recipients"`                                            //nolint:ll
+		DryRun     bool            `json:"dry_run,omitempty" jsonschema:"validate without submitting"`                            //nolint:ll
+		Yes        bool            `json:"yes,omitempty" jsonschema:"approve the fund-moving transfer (required unless dry_run)"` //nolint:ll
 	}
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "ark.send.inround",
 		Description: "Send via in-round refresh",
 	}, func(ctx context.Context, req *mcp.CallToolRequest,
 		args sendInRoundArgs) (*mcp.CallToolResult, any, error) {
+
+		if err := checkMCPSendConsent(
+			args.DryRun, args.Yes,
+		); err != nil {
+			return nil, nil, err
+		}
 
 		outputs := make(
 			[]*waverpc.Output, 0,
@@ -410,6 +431,7 @@ func registerMCPSendTools(s *mcp.Server, client waverpc.DaemonServiceClient) {
 		PubKeyXOnlyHex string `json:"pubkey_xonly_hex,omitempty" jsonschema:"recipient 32-byte x-only pubkey hex (mutually exclusive with address)"` //nolint:ll
 		AmountSat      int64  `json:"amount_sat" jsonschema:"amount in sats"`                                                                        //nolint:ll
 		DryRun         bool   `json:"dry_run,omitempty" jsonschema:"validate without initiating"`                                                    //nolint:ll
+		Yes            bool   `json:"yes,omitempty" jsonschema:"approve the fund-moving transfer (required unless dry_run)"`                         //nolint:ll
 		IdempotencyKey string `json:"idempotency_key,omitempty" jsonschema:"stable caller intent key for retry-safe OOR sends"`                      //nolint:ll
 	}
 	mcp.AddTool(s, &mcp.Tool{
@@ -417,6 +439,12 @@ func registerMCPSendTools(s *mcp.Server, client waverpc.DaemonServiceClient) {
 		Description: "Send via out-of-round transfer",
 	}, func(ctx context.Context, req *mcp.CallToolRequest,
 		args sendOORArgs) (*mcp.CallToolResult, any, error) {
+
+		if err := checkMCPSendConsent(
+			args.DryRun, args.Yes,
+		); err != nil {
+			return nil, nil, err
+		}
 
 		recipient, err := buildOORRecipientOutput(
 			args.Address, args.PubKeyXOnlyHex, args.AmountSat,

--- a/cmd/wavecli/waveclicommands/cmd_sweep.go
+++ b/cmd/wavecli/waveclicommands/cmd_sweep.go
@@ -33,6 +33,8 @@ func newSweepCmd() *cobra.Command {
 		"boarding UTXO outpoint to sweep (txid:index); repeatable")
 	cmd.Flags().Bool("broadcast", false,
 		"broadcast aggregate sweep and track it until confirmed spent")
+	cmd.Flags().Bool("yes", false,
+		"approve broadcasting the fund-moving sweep")
 	cmd.Flags().Int64("fee-rate-sat-per-vbyte", 0,
 		"fee rate override in sat/vbyte; zero estimates by conf target")
 	cmd.Flags().Uint32("conf-target", 0,
@@ -71,14 +73,6 @@ func newSweepListCmd() *cobra.Command {
 
 // sweep executes the SweepBoardingUTXOs RPC and prints the result.
 func sweep(cmd *cobra.Command, _ []string) error {
-	client, conn, err := getDaemonClient(cmd)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = conn.Close()
-	}()
-
 	req := &waverpc.SweepBoardingUTXOsRequest{}
 	fromFlags := func() error {
 		outpoints, _ := cmd.Flags().GetStringSlice("outpoint")
@@ -110,6 +104,24 @@ func sweep(cmd *cobra.Command, _ []string) error {
 	if err := parseRequest(cmd, req, fromFlags); err != nil {
 		return err
 	}
+	if req.GetBroadcast() {
+		action := "broadcast a sweep of all mature boarding UTXOs"
+		if count := len(req.GetOutpoints()); count > 0 {
+			action = fmt.Sprintf("broadcast a sweep of %d "+
+				"selected boarding UTXO(s)", count)
+		}
+		if err := confirmMoneyMovement(cmd, action); err != nil {
+			return err
+		}
+	}
+
+	client, conn, err := getDaemonClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	ctx, cancel := rpcContext(cmd)
 	defer cancel()

--- a/cmd/wavecli/waveclicommands/cmd_sweep_wallet.go
+++ b/cmd/wavecli/waveclicommands/cmd_sweep_wallet.go
@@ -43,6 +43,8 @@ func newWalletSweepCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("destination")
 	cmd.Flags().Bool("broadcast", false,
 		"publish the sweep; omitted means preview only")
+	cmd.Flags().Bool("yes", false,
+		"approve broadcasting the fund-moving sweep")
 	cmd.Flags().Int64("fee-rate", 0,
 		"explicit fee rate in sat/vByte; zero estimates from the "+
 			"chain backend at --conf-target")
@@ -75,6 +77,13 @@ func walletSweep(cmd *cobra.Command, _ []string) error {
 		Broadcast:          broadcast,
 		FeeRateSatPerVbyte: feeRate,
 		ConfTarget:         confTarget,
+	}
+	if broadcast {
+		action := fmt.Sprintf("broadcast the backing-wallet "+
+			"sweep to %q", destination)
+		if err := confirmMoneyMovement(cmd, action); err != nil {
+			return err
+		}
 	}
 
 	return withWalletClient(

--- a/cmd/wavecli/waveclicommands/mcp_wallet_test.go
+++ b/cmd/wavecli/waveclicommands/mcp_wallet_test.go
@@ -327,3 +327,21 @@ func TestCheckMCPRefreshConsent(t *testing.T) {
 	require.Contains(t, err.Error(), "yes:true")
 	require.Contains(t, err.Error(), "operator fee")
 }
+
+// TestCheckMCPSendConsent pins the MCP raw-send money gate: a dry-run
+// preview and an approved send pass, a bare real send is refused with
+// an actionable error naming both paths — matching the consent the
+// CLI applies and the schema registry advertises for ark.send.*.
+func TestCheckMCPSendConsent(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, checkMCPSendConsent(true, false))
+	require.NoError(t, checkMCPSendConsent(false, true))
+	require.NoError(t, checkMCPSendConsent(true, true))
+
+	err := checkMCPSendConsent(false, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "yes:true")
+	require.Contains(t, err.Error(), "dry_run:true")
+	require.Contains(t, err.Error(), "moves funds")
+}

--- a/cmd/wavecli/waveclicommands/money_confirmation_test.go
+++ b/cmd/wavecli/waveclicommands/money_confirmation_test.go
@@ -1,0 +1,213 @@
+package waveclicommands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfirmMoneyMovementRequiresExplicitApproval verifies that automation
+// receives the stable error and exit code before a fund-moving action runs.
+func TestConfirmMoneyMovementRequiresExplicitApproval(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("yes", false, "")
+	cmd.SetIn(strings.NewReader(""))
+
+	err := confirmMoneyMovement(cmd, "broadcast the wallet sweep")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "broadcast the wallet sweep")
+	require.ErrorContains(t, err, "--yes")
+	require.Equal(t, ExitConfirmationRequired, ExitCodeFor(err))
+}
+
+// TestConfirmMoneyMovementAcceptsYes verifies the explicit automation path.
+func TestConfirmMoneyMovementAcceptsYes(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("yes", false, "")
+	require.NoError(t, cmd.Flags().Set("yes", "true"))
+
+	require.NoError(t, confirmMoneyMovement(cmd, "move funds"))
+}
+
+// TestConfirmMoneyMovementInteractivePrompt verifies the terminal path: on a
+// TTY without --yes, a "y" answer approves and any other answer aborts.
+func TestConfirmMoneyMovementInteractivePrompt(t *testing.T) {
+	// NOT t.Parallel(): overrides the package-level stdinIsTTY indirection.
+	prev := stdinIsTTY
+	stdinIsTTY = func(*cobra.Command) bool { return true }
+	t.Cleanup(func() { stdinIsTTY = prev })
+
+	newCmd := func(answer string) *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("yes", false, "")
+		cmd.SetIn(strings.NewReader(answer))
+		cmd.SetErr(&bytes.Buffer{})
+
+		return cmd
+	}
+
+	require.NoError(t, confirmMoneyMovement(newCmd("y\n"), "move funds"))
+
+	err := confirmMoneyMovement(newCmd("n\n"), "move funds")
+	require.ErrorContains(t, err, "aborted by user")
+}
+
+// TestMoneyMovingCommandsSkipGateOnPreview verifies preview paths (--dry-run
+// for ark sends, no --broadcast for sweeps) never hit the confirmation gate:
+// they flow past it toward the daemon dial rather than refusing with
+// CONFIRMATION_REQUIRED.
+func TestMoneyMovingCommandsSkipGateOnPreview(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cmd  func() *cobra.Command
+		run  func(*cobra.Command, []string) error
+		args map[string]string
+	}{
+		{
+			name: "wallet sweep preview",
+			cmd:  newWalletSweepCmd,
+			run:  walletSweep,
+			args: map[string]string{
+				"destination": "bcrt1ptestdestination",
+			},
+		},
+		{
+			name: "boarding sweep preview",
+			cmd:  newSweepCmd,
+			run:  sweep,
+			args: map[string]string{},
+		},
+		{
+			name: "in-round send dry-run",
+			cmd:  newArkSendInRoundCmd,
+			run:  sendInRound,
+			args: map[string]string{
+				"to":      "bcrt1ptestdestination",
+				"amount":  "1000",
+				"dry-run": "true",
+			},
+		},
+		{
+			name: "out-of-round send dry-run",
+			cmd:  newArkSendOORCmd,
+			run:  sendOOR,
+			args: map[string]string{
+				"to":      "bcrt1ptestdestination",
+				"amount":  "1000",
+				"dry-run": "true",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := test.cmd()
+			cmd.SetIn(strings.NewReader(""))
+			for name, value := range test.args {
+				require.NoError(t, cmd.Flags().Set(name, value))
+			}
+
+			// The preview path has no daemon, so it errors on dial
+			// — but it must NOT be the confirmation refusal.
+			err := test.run(cmd, nil)
+			require.NotEqual(
+				t, ExitConfirmationRequired, ExitCodeFor(err),
+			)
+		})
+	}
+}
+
+// TestSendOORRejectsEmptyRecipients guards the fix for the panic where the OOR
+// gate indexed recipients[0] on a --request-json payload that skipped flag
+// validation. It must now return the structured INVALID_ARGS error.
+func TestSendOORRejectsEmptyRecipients(t *testing.T) {
+	t.Parallel()
+
+	cmd := newArkSendOORCmd()
+	cmd.Flags().String("request-json", "", "")
+	require.NoError(t, cmd.Flags().Set("request-json", "{}"))
+	cmd.SetIn(strings.NewReader(""))
+
+	err := sendOOR(cmd, nil)
+	require.ErrorContains(t, err, "at least one recipient is required")
+	require.Equal(t, ExitInvalidArgs, ExitCodeFor(err))
+}
+
+// TestMoneyMovingCommandsGateBeforeDial exercises each newly protected command
+// with non-interactive stdin. A missing gate would continue into daemon setup
+// and return a connection error instead of CONFIRMATION_REQUIRED.
+func TestMoneyMovingCommandsGateBeforeDial(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cmd  func() *cobra.Command
+		run  func(*cobra.Command, []string) error
+		args map[string]string
+	}{
+		{
+			name: "wallet sweep broadcast",
+			cmd:  newWalletSweepCmd,
+			run:  walletSweep,
+			args: map[string]string{
+				"destination": "bcrt1ptestdestination",
+				"broadcast":   "true",
+			},
+		},
+		{
+			name: "boarding sweep broadcast",
+			cmd:  newSweepCmd,
+			run:  sweep,
+			args: map[string]string{
+				"broadcast": "true",
+			},
+		},
+		{
+			name: "in-round send",
+			cmd:  newArkSendInRoundCmd,
+			run:  sendInRound,
+			args: map[string]string{
+				"to":     "bcrt1ptestdestination",
+				"amount": "1000",
+			},
+		},
+		{
+			name: "out-of-round send",
+			cmd:  newArkSendOORCmd,
+			run:  sendOOR,
+			args: map[string]string{
+				"to":     "bcrt1ptestdestination",
+				"amount": "1000",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := test.cmd()
+			cmd.SetIn(strings.NewReader(""))
+			for name, value := range test.args {
+				require.NoError(t, cmd.Flags().Set(name, value))
+			}
+
+			err := test.run(cmd, nil)
+			require.Error(t, err)
+			require.Equal(
+				t, ExitConfirmationRequired, ExitCodeFor(err),
+			)
+		})
+	}
+}

--- a/cmd/wavecli/waveclicommands/prompt.go
+++ b/cmd/wavecli/waveclicommands/prompt.go
@@ -73,3 +73,26 @@ func promptConfirmation(cmd *cobra.Command, prompt string) error {
 
 	return nil
 }
+
+// confirmMoneyMovement requires explicit approval before a command crosses its
+// fund-moving boundary. Interactive users see the concrete action in a y/N
+// prompt; non-interactive callers receive the stable exit-5 contract.
+func confirmMoneyMovement(cmd *cobra.Command, action string) error {
+	yes, err := cmd.Flags().GetBool("yes")
+	if err != nil {
+		return fmt.Errorf("read --yes: %w", err)
+	}
+	if yes {
+		return nil
+	}
+
+	if !canPrompt(cmd) {
+		return PrintError(
+			confirmationRequiredCode,
+			fmt.Sprintf("%s; rerun with --yes to approve this "+
+				"fund-moving action", action),
+		)
+	}
+
+	return promptConfirmation(cmd, action+". Proceed? [y/N]: ")
+}

--- a/cmd/wavecli/waveclicommands/schema_registry.go
+++ b/cmd/wavecli/waveclicommands/schema_registry.go
@@ -625,6 +625,12 @@ func walletQueryMethodRegistry() []schemaMethod { //nolint:funlen
 						"omitted means preview only",
 				},
 				{
+					Name: "yes",
+					Type: "bool",
+					Description: "approve broadcasting " +
+						"the fund-moving sweep",
+				},
+				{
 					Name: "fee-rate",
 					Type: "int64",
 					Description: "explicit fee rate in " +
@@ -697,6 +703,12 @@ func arkBaseMethodRegistry() []schemaMethod {
 					Type: "bool",
 					Description: "broadcast aggregate " +
 						"sweep and track confirmation",
+				},
+				{
+					Name: "yes",
+					Type: "bool",
+					Description: "approve broadcasting " +
+						"the fund-moving sweep",
 				},
 				{
 					Name: "fee-rate-sat-per-vbyte",
@@ -988,6 +1000,12 @@ func arkSendMethodRegistry() []schemaMethod {
 					Description: "validate without " +
 						"submitting",
 				},
+				{
+					Name: "yes",
+					Type: "bool",
+					Description: "approve submitting " +
+						"the fund-moving transfer",
+				},
 			},
 			RequestType:  "SendVTXORequest",
 			ResponseType: "SendVTXOResponse",
@@ -1029,6 +1047,12 @@ func arkSendMethodRegistry() []schemaMethod {
 					Type: "bool",
 					Description: "validate without " +
 						"initiating",
+				},
+				{
+					Name: "yes",
+					Type: "bool",
+					Description: "approve initiating " +
+						"the fund-moving transfer",
 				},
 			},
 			RequestType:  "SendOORRequest",

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -288,16 +288,16 @@ wavecli
 ├── send                      — Lightning invoice / onchain leave (wavewalletrpc)
 ├── activity [inspect]        — unified wallet activity feed (wavewalletrpc)
 ├── exit {status|summary|plan} — cooperative leave by default, forced unroll (wavewalletrpc)
-├── wallet-sweep              — sweep backing wallet to a destination (wavewalletrpc)
+├── wallet-sweep              — preview a backing-wallet sweep; broadcast requires approval
 ├── mcp serve                 — MCP server for AI agents (wavewalletrpc)
 ├── schema                    — JSON dump of CLI methods
 ├── ark                       — power-user parent (hidden; no wavewalletrpc)
 │   ├── board                 — board confirmed boarding UTXOs
 │   ├── vtxos {list|refresh|leave}
 │   ├── oor {receive|get|list}
-│   ├── send {oor|inround}
+│   ├── send {oor|inround}    — real transfers require approval
 │   ├── rounds {get|list|join|watch}
-│   ├── sweep [list]
+│   ├── sweep [list]          — broadcast requires approval
 │   ├── fees {estimate|history}
 │   └── listtransactions
 ├── recovery {list|status|escalate|cancel} — daemon-owned vHTLC recovery rows (hidden)
@@ -323,6 +323,15 @@ wavecli
 Flag names are canonical kebab-case in help and examples. Equivalent
 snake_case spellings remain silent compatibility aliases; proto JSON and MCP
 argument field names remain snake_case.
+
+### Money-movement confirmation
+
+`wallet-sweep --broadcast`, `ark sweep --broadcast`, and real
+`ark send inround|oor` calls require a y/N confirmation on a terminal. Agents,
+pipelines, `--no-input`, and `CI=true` must pass the command-local `--yes`
+flag. Without it, the CLI describes the blocked action and returns
+`CONFIRMATION_REQUIRED` with exit code 5 before dialing the daemon. Preview and
+`--dry-run` paths never require approval.
 
 ### `getinfo`
 
@@ -484,9 +493,10 @@ Send via in-round refresh (waits for next round to commit).
 | `--pubkey` | string[] | Recipient x-only pubkey hex(es); paired after `--to` entries |
 | `--amount` | int64[] | Amount(s) in sats (one per recipient, `--to` then `--pubkey` order) |
 | `--dry-run` | bool | Validate without submitting |
+| `--yes` | bool | Approve submitting the real transfer without a prompt |
 
 ```bash
-wavecli ark send inround --to bcrt1p... --amount 50000
+wavecli ark send inround --to bcrt1p... --amount 50000 --yes
 
 # Multiple recipients
 wavecli ark send inround \
@@ -513,9 +523,10 @@ Send via out-of-round transfer (immediate, through operator).
 | `--amount` | int64 | Amount in sats |
 | `--idempotency-key` | string | Caller-provided key for retry-safe sends |
 | `--dry-run` | bool | Validate without initiating |
+| `--yes` | bool | Approve initiating the real transfer without a prompt |
 
 ```bash
-wavecli ark send oor --pubkey <pubkey_xonly_hex> --amount 25000
+wavecli ark send oor --pubkey <pubkey_xonly_hex> --amount 25000 --yes
 wavecli ark send oor --pubkey <hex> --amount 25000 \
   --idempotency-key my-attempt-1
 ```


### PR DESCRIPTION
Addresses the agreed minimal P0-4 scope from #997.

This is a stacked PR targeting #1026 because it reuses that PR's shared prompt and non-interactive-input contract. It should be rebased after #1025 and #1026 land; the small exit-5 mapping included here will then collapse into #1025's canonical error contract.

Before:
- `wallet-sweep --broadcast` and `ark sweep --broadcast` could publish without an approval boundary
- raw `ark send inround` and `ark send oor` could move funds without an approval boundary
- agents had no stable refusal code when approval was missing

After:
- those four real fund-moving paths require an interactive y/N confirmation or command-local `--yes`
- preview and `--dry_run` paths remain ungated
- non-interactive callers are refused before daemon dialing with a concrete action description, `CONFIRMATION_REQUIRED`, and exit code 5
- schemas and operator documentation advertise the approval flag
- `ark board` and `ark rounds join` remain intentionally ungated

This deliberately does not redesign the existing top-level `send --force` alias; that more debatable cleanup remains deferred.

Validation:
- `make unit pkg=./cmd/wavecli/...`
- `go test ./cmd/wavecli/... -race`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`

---

**Update (MCP parity):** in response to review, the raw-send MCP tools `ark.send.inround` / `ark.send.oor` now enforce the same consent as the CLI — a real send requires `yes:true` (or `dry_run:true` to preview), returning an actionable error otherwise, mirroring the existing `ark.vtxos.refresh` MCP gate (`checkMCPSendConsent`). This closes the gap where the MCP route could move funds unapproved and makes `schema`'s advertised `yes` argument truthful for these tools.
