### PR TITLE
txconfirm: carry the confirming block hash on TxConfirmed

### DIFF
--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -265,6 +265,7 @@ type confirmationObservedMsg struct {
 	actor.BaseMessage
 	txid        chainhash.Hash
 	blockHeight int32
+	blockHash   chainhash.Hash
 	numConfs    uint32
 }
 
@@ -1075,13 +1076,17 @@ func (a *TxBroadcasterActor) handleConfirmationObserved(ctx context.Context,
 	// a reorg), but we tolerate it by re-delivering TxConfirmed rather
 	// than failing the FSM.
 	if state == TxStateConfirmed {
-		a.notifyConfirmed(ctx, entry, msg.blockHeight, msg.numConfs)
+		a.notifyConfirmed(
+			ctx, entry, msg.blockHeight, msg.blockHash,
+			msg.numConfs,
+		)
 
 		return
 	}
 
 	if err := a.advanceTrackedTxFSM(ctx, entry, &trackedTxConfirmed{
 		BlockHeight: msg.blockHeight,
+		BlockHash:   msg.blockHash,
 	}); err != nil {
 
 		a.log.WarnS(ctx, "Failed to confirm tracked tx FSM",
@@ -1090,7 +1095,9 @@ func (a *TxBroadcasterActor) handleConfirmationObserved(ctx context.Context,
 		return
 	}
 
-	a.notifyConfirmed(ctx, entry, msg.blockHeight, msg.numConfs)
+	a.notifyConfirmed(
+		ctx, entry, msg.blockHeight, msg.blockHash, msg.numConfs,
+	)
 }
 
 // handleConfirmationReorged moves a Confirmed tracked txid back into
@@ -1200,6 +1207,7 @@ func (a *TxBroadcasterActor) handleConfirmationDone(ctx context.Context,
 		return
 	}
 	confirmHeight, _ := trackedTxConfirmHeight(fsmState)
+	confirmBlockHash, _ := trackedTxConfirmBlockHash(fsmState)
 
 	if err := a.advanceTrackedTxFSM(
 		ctx, entry, &trackedTxFinalized{},
@@ -1215,7 +1223,7 @@ func (a *TxBroadcasterActor) handleConfirmationDone(ctx context.Context,
 	// acknowledged the terminal TxFinalized notification. Failed
 	// deliveries leave the entry in place so retryLifecycleNotifications
 	// can resend on a later actor tick.
-	if !a.notifyFinalized(ctx, entry, confirmHeight) {
+	if !a.notifyFinalized(ctx, entry, confirmHeight, confirmBlockHash) {
 		return
 	}
 
@@ -1355,6 +1363,7 @@ func (a *TxBroadcasterActor) attachExistingSubscriber(
 		txConfirmed := &TxConfirmed{
 			Txid:        entry.data.Txid,
 			BlockHeight: confirmHeight,
+			BlockHash:   state.ConfirmBlockHash,
 			NumConfs:    entry.data.TargetConfs,
 		}
 
@@ -1611,6 +1620,7 @@ func (a *TxBroadcasterActor) registerConfWatch(ctx context.Context,
 			return &confirmationObservedMsg{
 				txid:        event.Txid,
 				blockHeight: event.BlockHeight,
+				blockHash:   event.BlockHash,
 				numConfs:    event.NumConfs,
 			}
 		},
@@ -1902,12 +1912,16 @@ func (a *TxBroadcasterActor) retryLifecycleNotifications(ctx context.Context,
 		// no retry tracking; they are skipped here. Returning false
 		// keeps the entry alive — the caller never evicts on
 		// Confirmed, only on terminal states.
-		a.retryConfirmedRedelivery(ctx, entry, state.ConfirmHeight)
+		a.retryConfirmedRedelivery(
+			ctx, entry, state.ConfirmHeight, state.ConfirmBlockHash,
+		)
 
 		return false
 
 	case *trackedTxStateFinalized:
-		return a.notifyFinalized(ctx, entry, state.ConfirmHeight)
+		return a.notifyFinalized(
+			ctx, entry, state.ConfirmHeight, state.ConfirmBlockHash,
+		)
 
 	case *trackedTxStateFailed:
 		reason, _ := trackedTxFailureReason(state)
@@ -1930,7 +1944,8 @@ func (a *TxBroadcasterActor) retryLifecycleNotifications(ctx context.Context,
 // later TxReorged / TxFinalized on this entry — eviction is
 // reserved for the truly terminal Finalized / Failed states.
 func (a *TxBroadcasterActor) retryConfirmedRedelivery(ctx context.Context,
-	entry *trackedTx, confirmHeight int32) {
+	entry *trackedTx, confirmHeight int32,
+	confirmBlockHash chainhash.Hash) {
 
 	for id, subscriber := range entry.subscribers {
 		if !subscriber.pendingConfirmed {
@@ -1940,6 +1955,7 @@ func (a *TxBroadcasterActor) retryConfirmedRedelivery(ctx context.Context,
 		txConfirmed := &TxConfirmed{
 			Txid:        entry.data.Txid,
 			BlockHeight: confirmHeight,
+			BlockHash:   confirmBlockHash,
 			NumConfs:    entry.data.TargetConfs,
 		}
 		if a.notifyOneConfirmed(
@@ -2061,12 +2077,14 @@ func (a *TxBroadcasterActor) handleTerminalNotifyResult(ctx context.Context,
 // happens only on TxFinalized / TxFailed acknowledgment, which is
 // when the reorg-aware lifecycle reaches a truly terminal state.
 func (a *TxBroadcasterActor) notifyConfirmed(ctx context.Context,
-	entry *trackedTx, blockHeight int32, numConfs uint32) {
+	entry *trackedTx, blockHeight int32, blockHash chainhash.Hash,
+	numConfs uint32) {
 
 	for id, subscriber := range entry.subscribers {
 		txConfirmed := &TxConfirmed{
 			Txid:        entry.data.Txid,
 			BlockHeight: blockHeight,
+			BlockHash:   blockHash,
 			NumConfs:    numConfs,
 		}
 
@@ -2204,7 +2222,8 @@ func (a *TxBroadcasterActor) notifyReversibleAsync(ctx context.Context,
 // re-TxConfirmed can recover the authoritative confirmation height
 // without an out-of-band lookup.
 func (a *TxBroadcasterActor) notifyFinalized(ctx context.Context,
-	entry *trackedTx, confirmHeight int32) bool {
+	entry *trackedTx, confirmHeight int32,
+	confirmBlockHash chainhash.Hash) bool {
 
 	// Seal the entry so any in-flight reversible delivery skips its Tell
 	// rather than trailing this terminal notification into a subscriber's
@@ -2218,6 +2237,7 @@ func (a *TxBroadcasterActor) notifyFinalized(ctx context.Context,
 				&TxConfirmed{
 					Txid:        entry.data.Txid,
 					BlockHeight: confirmHeight,
+					BlockHash:   confirmBlockHash,
 					NumConfs:    entry.data.TargetConfs,
 				},
 			) {

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -1063,7 +1063,7 @@ func TestLateFinalizedSubscriberRetrySkipsConfirmed(t *testing.T) {
 	require.True(
 		t,
 		behavior.notifyFinalized(
-			t.Context(), entry, confirmHeight,
+			t.Context(), entry, confirmHeight, chainhash.Hash{},
 		),
 	)
 	notification, ok := sub.awaitMessage(testTimeout)

--- a/txconfirm/fsm_types.go
+++ b/txconfirm/fsm_types.go
@@ -154,6 +154,9 @@ func (e *trackedTxFeeBumpStarted) trackedTxEventSealed() {}
 type trackedTxConfirmed struct {
 	// BlockHeight is the block height where the tx confirmed.
 	BlockHeight int32
+
+	// BlockHash is the hash of the block the tx confirmed in.
+	BlockHash chainhash.Hash
 }
 
 // trackedTxEventSealed marks trackedTxConfirmed as a tracked-tx event.
@@ -332,6 +335,21 @@ func trackedTxConfirmHeight(state trackedTxState) (int32, bool) {
 
 	default:
 		return 0, false
+	}
+}
+
+// trackedTxConfirmBlockHash returns the state's confirmation block hash if
+// the transaction has already confirmed.
+func trackedTxConfirmBlockHash(state trackedTxState) (chainhash.Hash, bool) {
+	switch s := state.(type) {
+	case *trackedTxStateConfirmed:
+		return s.ConfirmBlockHash, true
+
+	case *trackedTxStateFinalized:
+		return s.ConfirmBlockHash, true
+
+	default:
+		return chainhash.Hash{}, false
 	}
 }
 

--- a/txconfirm/messages.go
+++ b/txconfirm/messages.go
@@ -311,6 +311,9 @@ type TxConfirmed struct {
 	// BlockHeight is the block height where the transaction confirmed.
 	BlockHeight int32
 
+	// BlockHash is the hash of the block the transaction confirmed in.
+	BlockHash chainhash.Hash
+
 	// NumConfs is the confirmation count reported by the backend.
 	NumConfs uint32
 }

--- a/txconfirm/states.go
+++ b/txconfirm/states.go
@@ -3,6 +3,8 @@ package txconfirm
 import (
 	"context"
 	"fmt"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
 )
 
 // trackedTxStateNew is the initial tracked-tx FSM state.
@@ -114,6 +116,7 @@ func (s *trackedTxStateBroadcasting) ProcessEvent(_ context.Context,
 				trackedTxData:     s.trackedTxData,
 				trackedTxProgress: s.trackedTxProgress,
 				ConfirmHeight:     e.BlockHeight,
+				ConfirmBlockHash:  e.BlockHash,
 			},
 		}, nil
 
@@ -172,6 +175,7 @@ func (s *trackedTxStateAwaitingConfirmation) ProcessEvent(_ context.Context,
 				trackedTxData:     s.trackedTxData,
 				trackedTxProgress: s.trackedTxProgress,
 				ConfirmHeight:     event.BlockHeight,
+				ConfirmBlockHash:  event.BlockHash,
 			},
 		}, nil
 
@@ -232,6 +236,7 @@ func (s *trackedTxStateFeeBumping) ProcessEvent(_ context.Context,
 				trackedTxData:     s.trackedTxData,
 				trackedTxProgress: s.trackedTxProgress,
 				ConfirmHeight:     e.BlockHeight,
+				ConfirmBlockHash:  e.BlockHash,
 			},
 		}, nil
 
@@ -259,6 +264,9 @@ type trackedTxStateConfirmed struct {
 
 	// ConfirmHeight is the block height where the tx confirmed.
 	ConfirmHeight int32
+
+	// ConfirmBlockHash is the hash of the block the tx confirmed in.
+	ConfirmBlockHash chainhash.Hash
 }
 
 // String returns a human-readable representation of the confirmed state.
@@ -297,6 +305,7 @@ func (s *trackedTxStateConfirmed) ProcessEvent(_ context.Context,
 				trackedTxData:     s.trackedTxData,
 				trackedTxProgress: s.trackedTxProgress,
 				ConfirmHeight:     s.ConfirmHeight,
+				ConfirmBlockHash:  s.ConfirmBlockHash,
 			},
 		}, nil
 
@@ -314,6 +323,10 @@ type trackedTxStateFinalized struct {
 	// ConfirmHeight is the block height where the tx confirmed before
 	// being finalized.
 	ConfirmHeight int32
+
+	// ConfirmBlockHash is the hash of the block the tx confirmed in
+	// before being finalized.
+	ConfirmBlockHash chainhash.Hash
 }
 
 // String returns a human-readable representation of the finalized state.


### PR DESCRIPTION
In this PR, we thread the confirming block's hash through the
tracked-transaction lifecycle so a `TxConfirmed` notification carries it
alongside the confirmation height. Today a subscriber that wants to book the
confirmation into its own state only gets the height, and has to reach back out
to the chain to recover which block the tx actually landed in.

The chainsource `ConfirmationEvent` already surfaces the block hash, so we
capture it on the internal `confirmationObservedMsg`, persist it on the
confirmed and finalized tracked-tx states as `ConfirmBlockHash`, and stamp it
onto every `TxConfirmed` we emit. That includes the redelivery path (for
subscribers whose first delivery timed out) and the finalize-replay path, so a
late or replayed notification carries the same hash as the initial one.

This is the base for a companion lumos change that drives the round FSM directly
off the txconfirm signal. To move a round into its confirmed state that code
needs the block hash, not just the height, and pulling it back out of the chain
after the fact would be a needless round trip.

No behavioral change to existing subscribers: the field is additive, and the
height/numConfs semantics are untouched.
