### PR TITLE
rpc: Clean up wavewalletrpc comments surfaced in the docs site

### DIFF
--- a/rpc/wavewalletrpc/wallet.pb.go
+++ b/rpc/wavewalletrpc/wallet.pb.go
@@ -1760,13 +1760,6 @@ type ListRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// view selects which slice of wallet state to return. The default
 	// (LIST_VIEW_UNSPECIFIED) is treated as LIST_VIEW_ACTIVITY.
-	//
-	// WIRE-BREAKING CHANGE: this message intentionally renumbers the
-	// PR #440 fields (pending_only/kinds/limit/offset). wavewalletrpc has
-	// no deployed external consumers yet, so the cleaner shape with
-	// `view` at field 1 is preferred over a backwards-compatible
-	// append. Any binary built against PR #440's ListRequest must be
-	// recompiled.
 	View ListView `protobuf:"varint,1,opt,name=view,proto3,enum=wavewalletrpc.ListView" json:"view,omitempty"`
 	// pending_only filters the returned entries to those still in
 	// flight. Applies to the ACTIVITY view; ignored for VTXOS and
@@ -1868,13 +1861,6 @@ func (x *ListRequest) GetCursor() string {
 // discriminated by the requested view.
 type ListResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// WIRE-BREAKING CHANGE: PR #440 had
-	// `repeated WalletEntry entries = 1; uint32 total = 2;` at the top
-	// level. Those fields are now reachable as `body.activity.entries`
-	// and `body.activity.total`. wavewalletrpc has no deployed external
-	// consumers, so the cleaner oneof shape is preferred over
-	// reserving the old numbers.
-	//
 	// body discriminates the typed result by view. Callers should
 	// switch on the populated variant; an empty body indicates an
 	// empty result for the requested view.
@@ -2117,7 +2103,7 @@ func (x *VTXOInventory) GetTotal() uint32 {
 
 // WalletVTXO is the wallet-facing view of one VTXO. Internal lifecycle
 // detail (forfeiting flow, chain depth, etc.) is hidden; power-users can
-// reach the full shape via `ark vtxos list`.
+// reach the full shape via `wavecli ark vtxos list`.
 type WalletVTXO struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// outpoint is the VTXO's outpoint in "txid:index" format.
@@ -3504,8 +3490,9 @@ type ExitPlanEntry struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// outpoint is the previewed VTXO outpoint, formatted as "txid:index".
 	Outpoint string `protobuf:"bytes,1,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
-	// funding_address is empty when can_start is true (no shortfall, so no
-	// address is allocated).
+	// funding_address is a backing-wallet address the caller can fund to
+	// cover the fee shortfall this exit needs. It is empty when can_start
+	// is true (no shortfall, so no address is allocated).
 	FundingAddress string `protobuf:"bytes,2,opt,name=funding_address,json=fundingAddress,proto3" json:"funding_address,omitempty"`
 	// required_confirmations is the number of confirmations a
 	// backing-wallet UTXO must have before it can fund the unroll CPFP.

--- a/rpc/wavewalletrpc/wallet.proto
+++ b/rpc/wavewalletrpc/wallet.proto
@@ -527,13 +527,6 @@ message CreditReceive {
 message ListRequest {
     // view selects which slice of wallet state to return. The default
     // (LIST_VIEW_UNSPECIFIED) is treated as LIST_VIEW_ACTIVITY.
-    //
-    // WIRE-BREAKING CHANGE: this message intentionally renumbers the
-    // PR #440 fields (pending_only/kinds/limit/offset). wavewalletrpc has
-    // no deployed external consumers yet, so the cleaner shape with
-    // `view` at field 1 is preferred over a backwards-compatible
-    // append. Any binary built against PR #440's ListRequest must be
-    // recompiled.
     ListView view = 1;
 
     // pending_only filters the returned entries to those still in
@@ -565,13 +558,6 @@ message ListRequest {
 // ListResponse carries the typed result of WalletService.List as a oneof
 // discriminated by the requested view.
 message ListResponse {
-    // WIRE-BREAKING CHANGE: PR #440 had
-    // `repeated WalletEntry entries = 1; uint32 total = 2;` at the top
-    // level. Those fields are now reachable as `body.activity.entries`
-    // and `body.activity.total`. wavewalletrpc has no deployed external
-    // consumers, so the cleaner oneof shape is preferred over
-    // reserving the old numbers.
-    //
     // body discriminates the typed result by view. Callers should
     // switch on the populated variant; an empty body indicates an
     // empty result for the requested view.
@@ -622,7 +608,7 @@ message VTXOInventory {
 
 // WalletVTXO is the wallet-facing view of one VTXO. Internal lifecycle
 // detail (forfeiting flow, chain depth, etc.) is hidden; power-users can
-// reach the full shape via `ark vtxos list`.
+// reach the full shape via `wavecli ark vtxos list`.
 message WalletVTXO {
     // outpoint is the VTXO's outpoint in "txid:index" format.
     string outpoint = 1;
@@ -997,8 +983,9 @@ message ExitPlanEntry {
     // outpoint is the previewed VTXO outpoint, formatted as "txid:index".
     string outpoint = 1;
 
-    // funding_address is empty when can_start is true (no shortfall, so no
-    // address is allocated).
+    // funding_address is a backing-wallet address the caller can fund to
+    // cover the fee shortfall this exit needs. It is empty when can_start
+    // is true (no shortfall, so no address is allocated).
     string funding_address = 2;
 
     // required_confirmations is the number of confirmations a


### PR DESCRIPTION
## Summary

The Wavelength docs site generates its API reference from the comments in `wallet.proto`, so a few comments that were only ever meant for reviewers ended up published verbatim. I found these during the full site sweep in [wavelength-sdk#50](https://github.com/lightninglabs/wavelength-sdk/pull/50).

## Changes

- Drop the `WIRE-BREAKING CHANGE` notes from `ListRequest` and `ListResponse`. They document a renumbering decision made against PR #440 during review, which means nothing to someone reading the published API reference.
- Fix the CLI invocation on `WalletVTXO` to `wavecli ark vtxos list`. There's no `ark` binary for a reader to run.
- Expand the `ExitPlanEntry.funding_address` comment to say what the field is, not just when it's empty.

Comments only, no field numbers or types changed. The regenerated stubs are in a separate commit and carry nothing but the comment text.

## Testing

`make rpc` regenerates cleanly with only comment diffs. Nothing else to run.