### PR TITLE
waved+swapclientserver: add gRPC keepalive to long-lived daemon connections

### DIFF
--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -41,6 +41,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 )
 
@@ -868,6 +869,18 @@ func (d *daemonAuthOnlyInvoiceCreator) CreateInvoiceWithKeyRouteHintPaths(
 	)
 }
 
+// swapServerKeepaliveParams bounds how long the swap-server connection can
+// sit on a network path that silently drops packets (a stale conntrack entry
+// after swapdk-server restarts, a NAT timeout, etc.) before gRPC notices and
+// re-dials. Without an explicit keepalive, grpc-go never pings an idle
+// connection, so a peer that vanishes without sending a TCP RST can leave the
+// channel reporting READY indefinitely while every RPC on it hangs.
+var swapServerKeepaliveParams = keepalive.ClientParameters{
+	Time:                30 * time.Second,
+	Timeout:             10 * time.Second,
+	PermitWithoutStream: true,
+}
+
 // swapServerDialOptions maps daemon swap config into gRPC transport options
 // for swapdk-server.
 func swapServerDialOptions(cfg *waved.SwapConfig, addr string,
@@ -879,6 +892,7 @@ func swapServerDialOptions(cfg *waved.SwapConfig, addr string,
 	waitForReadyInterceptorOpt := grpc.WithChainUnaryInterceptor(
 		swapServerWaitForReadyInterceptor,
 	)
+	keepaliveOpt := grpc.WithKeepaliveParams(swapServerKeepaliveParams)
 
 	switch {
 	case cfg.ServerTLSCertPath != "":
@@ -894,6 +908,7 @@ func swapServerDialOptions(cfg *waved.SwapConfig, addr string,
 				credentials.NewTLS(tlsCfg),
 			),
 			waitForReadyInterceptorOpt,
+			keepaliveOpt,
 		}, nil
 
 	case useInsecureSwapServerTransport(cfg, addr):
@@ -902,6 +917,7 @@ func swapServerDialOptions(cfg *waved.SwapConfig, addr string,
 				insecure.NewCredentials(),
 			),
 			waitForReadyInterceptorOpt,
+			keepaliveOpt,
 		}, nil
 
 	default:
@@ -917,6 +933,7 @@ func swapServerDialOptions(cfg *waved.SwapConfig, addr string,
 				credentials.NewTLS(tlsCfg),
 			),
 			waitForReadyInterceptorOpt,
+			keepaliveOpt,
 		}, nil
 	}
 }

--- a/waved/server.go
+++ b/waved/server.go
@@ -80,6 +80,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -2666,12 +2667,26 @@ func (s *Server) connectLnd(ctx context.Context) (*lndclient.GrpcLndServices,
 	})
 }
 
+// operatorKeepaliveParams bounds how long the operator connection can sit on
+// a network path that silently drops packets (a stale conntrack entry after
+// the operator restarts, a NAT timeout, etc.) before gRPC notices and
+// re-dials. Without an explicit keepalive, grpc-go never pings an idle
+// connection, so a peer that vanishes without sending a TCP RST can leave the
+// channel reporting READY indefinitely while every RPC on it hangs.
+var operatorKeepaliveParams = keepalive.ClientParameters{
+	Time:                30 * time.Second,
+	Timeout:             10 * time.Second,
+	PermitWithoutStream: true,
+}
+
 // dialServer establishes a gRPC connection to the ark operator's mailbox
 // edge server. When TLSCertPath is set, the connection uses a custom cert
 // pool anchored to that certificate. When Insecure is set, TLS is disabled
 // entirely (for regtest/development only).
 func (s *Server) dialServer() (*grpc.ClientConn, error) {
-	var dialOpts []grpc.DialOption
+	dialOpts := []grpc.DialOption{
+		grpc.WithKeepaliveParams(operatorKeepaliveParams),
+	}
 
 	// Instrument the operator connection with client-side gRPC metrics
 	// (per-method request count, error rate, handling-time histograms).


### PR DESCRIPTION
## Summary

In this PR, we add client-side gRPC keepalive to waved's two long-lived outbound daemon connections: `dialServer`'s connection to the ark operator's mailbox edge server, and `swapServerDialOptions`' connection to swapdk-server. Neither had any keepalive configured, and grpc-go doesn't ping an idle channel unless you tell it to, so a connection that goes silently stale (a restart on the other end that doesn't produce a TCP RST on our side, a NAT/conntrack timeout, whatever) just sits there reporting READY forever while every RPC on it hangs.

That gap is what turned a routine `lumosd` restart into an extended signet outage, tracked in wavelength#1041. The reported symptom was `recv --offchain` hanging for 30s and failing with `DEADLINE_EXCEEDED` on any sub-dust amount, but the actual mechanism was worse than the ticket title suggested. We traced it end to end with pprof goroutine dumps on the live cluster: swapd's per-operation credit actors were blocked inside `fundingLanded` calling out to waved with no context timeout, waved's own `AwaitRPC` was blocked waiting on a reply from lumosd that never arrived, and because that stuck call sat on the same single-threaded credit registry actor that admits every new `CreateCredit` request, the whole credit subsystem wedged, not just sub-dust receives. Every account, every amount, every funding source, until a process restart cleared it.

We checked lumosd's own metrics and durable mailbox tables and it wasn't broadly failing (`ListVTXOsByScripts` had completed 34k+ times cleanly, sub-8ms). Two specific requests just vanished after `lumosd-signet` restarted 13h into a connection that predated it by another 11h, with no error and no trace on either side. That's consistent with the connection surviving the restart in a state where it looks alive but silently drops traffic, which is exactly the class of failure client-side keepalive exists to catch.

## The fix

30s ping interval, 10s timeout, `PermitWithoutStream: true` so the check runs between RPCs and not just while one's in flight. That's comfortably inside the timeouts callers already build around these clients, so a dead connection gets caught and re-dialed well before anything upstream notices.

`swapclientserver`'s connection to swapdk-server isn't the one implicated in #1041, it's the same long-lived, unprotected pattern, so we're closing it here rather than waiting for its own incident.

## Related

This is one leg of a three-repo fix. `swapdk-server` and `lumos` need a matching server-side `grpc.KeepaliveEnforcementPolicy` (their default `MinTime: 5m` would otherwise answer these 30s pings with `GOAWAY too_many_pings` and thrash the connection instead of letting this fix do its job):

- [lumos#699](https://github.com/lightninglabs/lumos/pull/699)
- [swapdk-server#245](https://github.com/lightninglabs/swapdk-server/pull/245)

We're not touching the credit registry's missing per-call timeout or its blocking-mailbox head-of-line issue here, those are real and tracked separately, but they need a fresh process restart regardless of what the network does, so they're out of scope for this PR.
