### PR TITLE
Gracefully degrade sub-dust credit receive failures (#1041)

### DIFF
--- a/credit/config.go
+++ b/credit/config.go
@@ -329,6 +329,18 @@ type RegistryConfig struct {
 	// and reap. Zero falls back to DefaultAdmitTimeout.
 	AdmitTimeout time.Duration
 
+	// ReceiveAdmitTimeout bounds the synchronous CreateCredit call made by
+	// a sub-dust receive admission. It is separate from (and shorter than)
+	// AdmitTimeout because a receive is an interactive wallet call: the
+	// caller is blocked waiting for the invoice, and a healthy swap server
+	// answers CreateCredit about as fast as RequestChannelId (sub-second).
+	// A long bound therefore just turns an operator whose credit subsystem
+	// is unresponsive into a silent multi-second hang (wavelength#1041). No
+	// durable operation row is written until CreateCredit succeeds, so
+	// timing out here leaves no orphaned client state. Zero falls back to
+	// DefaultReceiveAdmitTimeout.
+	ReceiveAdmitTimeout time.Duration
+
 	// AutoRedeem configures the wallet-owned auto-redeem policy.
 	AutoRedeem AutoRedeemConfig
 
@@ -377,6 +389,14 @@ const (
 	// DefaultAdmitTimeout bounds the synchronous server work an admission
 	// performs on the supervisor goroutine.
 	DefaultAdmitTimeout = 30 * time.Second
+
+	// DefaultReceiveAdmitTimeout bounds the synchronous CreateCredit call
+	// for a sub-dust receive admission. 15s is generous headroom over a
+	// healthy swap server's sub-second CreateCredit latency while failing
+	// an unresponsive credit subsystem in half the time of the general
+	// AdmitTimeout, so an interactive receive does not hang the full 30s
+	// before surfacing the actionable ErrCreditReceiveUnavailable error.
+	DefaultReceiveAdmitTimeout = 15 * time.Second
 
 	// DefaultMaxAwaitingPolls bounds how many reconciliation polls a single
 	// awaiting state (top-up funding or credit-pay settlement) may take

--- a/credit/registry.go
+++ b/credit/registry.go
@@ -91,11 +91,18 @@ func NewRegistry(cfg RegistryConfig) (*Registry, error) {
 	if cfg.PollInterval <= 0 {
 		cfg.PollInterval = DefaultPollInterval
 	}
+	if cfg.ReceiveAdmitTimeout <= 0 {
+		// Preserve the original AdmitTimeout override for embedders
+		// that configured the receive CreateCredit call before the
+		// dedicated timeout existed.
+		if cfg.AdmitTimeout > 0 {
+			cfg.ReceiveAdmitTimeout = cfg.AdmitTimeout
+		} else {
+			cfg.ReceiveAdmitTimeout = DefaultReceiveAdmitTimeout
+		}
+	}
 	if cfg.AdmitTimeout <= 0 {
 		cfg.AdmitTimeout = DefaultAdmitTimeout
-	}
-	if cfg.ReceiveAdmitTimeout <= 0 {
-		cfg.ReceiveAdmitTimeout = DefaultReceiveAdmitTimeout
 	}
 
 	earmark := &atomic.Pointer[EarmarkFunc]{}
@@ -406,10 +413,10 @@ func (b *registryBehavior) admit(ctx context.Context, msg CreditMsg,
 //
 // This is the one server round-trip an admission makes on the supervisor
 // goroutine, which serializes every admission, resume, and reap. It is bounded
-// by AdmitTimeout so one slow or hung receive cannot head-of-line-block the
-// whole subsystem; on timeout the synchronous caller retries under the same
-// stable op key, and CreateCredit is idempotent, so the retry reuses the same
-// invoice.
+// by ReceiveAdmitTimeout so one slow or hung receive cannot
+// head-of-line-block the whole subsystem; on timeout the synchronous caller
+// retries under the same stable op key, and CreateCredit is idempotent, so the
+// retry reuses the same invoice.
 func (b *registryBehavior) createReceiveInvoice(ctx context.Context,
 	rec *db.CreditOperationRecord, memo string) error {
 

--- a/credit/registry.go
+++ b/credit/registry.go
@@ -94,6 +94,9 @@ func NewRegistry(cfg RegistryConfig) (*Registry, error) {
 	if cfg.AdmitTimeout <= 0 {
 		cfg.AdmitTimeout = DefaultAdmitTimeout
 	}
+	if cfg.ReceiveAdmitTimeout <= 0 {
+		cfg.ReceiveAdmitTimeout = DefaultReceiveAdmitTimeout
+	}
 
 	earmark := &atomic.Pointer[EarmarkFunc]{}
 	if cfg.AutoRedeem.EarmarkedSat != nil {
@@ -415,7 +418,7 @@ func (b *registryBehavior) createReceiveInvoice(ctx context.Context,
 		return fmt.Errorf("get identity pubkey: %w", err)
 	}
 
-	callCtx, cancel := context.WithTimeout(ctx, b.cfg.AdmitTimeout)
+	callCtx, cancel := context.WithTimeout(ctx, b.cfg.ReceiveAdmitTimeout)
 	defer cancel()
 
 	res, err := b.cfg.Server.CreateCredit(
@@ -423,6 +426,16 @@ func (b *registryBehavior) createReceiveInvoice(ctx context.Context,
 		uint64(rec.AmountSat), memo,
 	)
 	if err != nil {
+		// Log at the exact failure site: this is the single synchronous
+		// swap-server round-trip a sub-dust receive makes, and when the
+		// operator's credit subsystem is unresponsive it is otherwise
+		// completely invisible (wavelength#1041).
+		b.logger(ctx).WarnS(ctx, "Credit receive CreateCredit failed",
+			err,
+			slog.String("op_key", rec.OpKey),
+			slog.Int64("amount_sat", rec.AmountSat),
+		)
+
 		return fmt.Errorf("create receive credit: %w", err)
 	}
 	if res.State.IsTerminalFailure() {

--- a/credit/registry_test.go
+++ b/credit/registry_test.go
@@ -47,6 +47,59 @@ func waitForState(t *testing.T, store Store, opID string, want State) {
 	}, 5*time.Second, 20*time.Millisecond)
 }
 
+// TestRegistryReceiveAdmitTimeoutFallback verifies that the dedicated receive
+// timeout preserves the legacy AdmitTimeout override while using its shorter
+// default for callers that left both fields unset.
+func TestRegistryReceiveAdmitTimeoutFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		admit   time.Duration
+		receive time.Duration
+		want    time.Duration
+	}{
+		{
+			name: "default",
+			want: DefaultReceiveAdmitTimeout,
+		},
+		{
+			name:  "legacy override",
+			admit: 7 * time.Second,
+			want:  7 * time.Second,
+		},
+		{
+			name:    "dedicated override",
+			admit:   7 * time.Second,
+			receive: 3 * time.Second,
+			want:    3 * time.Second,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			registry, err := NewRegistry(RegistryConfig{
+				Store:               newFakeStore(),
+				DeliveryStore:       newTestDelivery(t),
+				Server:              newFakeServer(),
+				Daemon:              newFakeDaemon(),
+				AdmitTimeout:        test.admit,
+				ReceiveAdmitTimeout: test.receive,
+			})
+			require.NoError(t, err)
+			t.Cleanup(registry.Stop)
+
+			require.Equal(
+				t, test.want,
+				registry.behavior.cfg.ReceiveAdmitTimeout,
+			)
+		})
+	}
+}
+
 // TestRegistryPayNoTopupEndToEnd drives the full stack: a registry admission
 // durably pre-writes the row, spawns the per-operation child, and the child
 // drives the FSM to completion through the real durable mailbox.

--- a/rpc/wavewalletrpc/failure_reasons.go
+++ b/rpc/wavewalletrpc/failure_reasons.go
@@ -24,4 +24,12 @@ const (
 	ReasonSwapBackendUnavailable = "SWAP_BACKEND_UNAVAILABLE"
 	ReasonAmountExceedsVTXOLimit = "AMOUNT_EXCEEDS_VTXO_LIMIT"
 	ReasonBalanceLimitExceeded   = "BALANCE_LIMIT_EXCEEDED"
+
+	// ReasonCreditReceiveUnavailable tags a sub-dust receive that was
+	// routed to the operator's credit subsystem but which the swap server
+	// did not complete (it timed out or errored). It is distinct from
+	// SWAP_BACKEND_UNAVAILABLE so clients can tell "the whole swap backend
+	// is down" apart from "this operator does not (currently) serve
+	// sub-dust credit receives, try an amount at or above the dust limit".
+	ReasonCreditReceiveUnavailable = "CREDIT_RECEIVE_UNAVAILABLE"
 )

--- a/sdk/wavewalletdk/errmap.go
+++ b/sdk/wavewalletdk/errmap.go
@@ -14,14 +14,15 @@ import (
 // match with errors.Is. The reason strings come from wavewalletrpc so the
 // client and the daemon-side mapper share one source of truth.
 var reasonToSentinel = map[string]error{
-	wavewalletrpc.ReasonInvalidDestination:     ErrInvalidDestination,
-	wavewalletrpc.ReasonInvalidSendIntent:      ErrInvalidSendIntent,
-	wavewalletrpc.ReasonAmountRequired:         ErrAmountRequired,
-	wavewalletrpc.ReasonAmountInvalid:          ErrAmountInvalid,
-	wavewalletrpc.ReasonUnsupportedKind:        ErrUnsupportedKind,
-	wavewalletrpc.ReasonSwapBackendUnavailable: ErrSwapBackendUnavailable,
-	wavewalletrpc.ReasonAmountExceedsVTXOLimit: ErrAmountExceedsVTXOLimit,
-	wavewalletrpc.ReasonBalanceLimitExceeded:   ErrBalanceLimitExceeded,
+	wavewalletrpc.ReasonInvalidDestination:       ErrInvalidDestination,
+	wavewalletrpc.ReasonInvalidSendIntent:        ErrInvalidSendIntent,
+	wavewalletrpc.ReasonAmountRequired:           ErrAmountRequired,
+	wavewalletrpc.ReasonAmountInvalid:            ErrAmountInvalid,
+	wavewalletrpc.ReasonUnsupportedKind:          ErrUnsupportedKind,
+	wavewalletrpc.ReasonSwapBackendUnavailable:   ErrSwapBackendUnavailable,
+	wavewalletrpc.ReasonAmountExceedsVTXOLimit:   ErrAmountExceedsVTXOLimit,
+	wavewalletrpc.ReasonBalanceLimitExceeded:     ErrBalanceLimitExceeded,
+	wavewalletrpc.ReasonCreditReceiveUnavailable: ErrCreditReceiveUnavailable, //nolint:ll
 }
 
 // sentinelForReason looks up the SDK sentinel for a daemon failure reason.

--- a/sdk/wavewalletdk/errmap_roundtrip_test.go
+++ b/sdk/wavewalletdk/errmap_roundtrip_test.go
@@ -64,6 +64,11 @@ var reasonContract = []struct {
 		swapwallet.ErrBalanceLimitExceeded, ErrBalanceLimitExceeded,
 		codes.FailedPrecondition,
 	},
+	{
+		wavewalletrpc.ReasonCreditReceiveUnavailable,
+		swapwallet.ErrCreditReceiveUnavailable, ErrCreditReceiveUnavailable,
+		codes.Unavailable,
+	},
 }
 
 // TestSentinelMessageParity guards against drift between the daemon's

--- a/sdk/wavewalletdk/errors.go
+++ b/sdk/wavewalletdk/errors.go
@@ -77,4 +77,15 @@ var (
 	// balance.
 	ErrBalanceLimitExceeded = errors.New("amount would exceed the " +
 		"maximum allowed wallet balance")
+
+	// ErrCreditReceiveUnavailable reports that a sub-dust receive was
+	// routed to the operator's credit subsystem but the swap server did not
+	// complete the credit request (it timed out or errored). It is distinct
+	// from ErrSwapBackendUnavailable so callers can tell "the whole swap
+	// backend is down" apart from "this operator does not (currently) serve
+	// sub-dust credit receives; retry at or above the dust limit". The
+	// message MUST match the daemon-side swapwallet sentinel verbatim
+	// (TestSentinelMessageParity enforces this).
+	ErrCreditReceiveUnavailable = errors.New("sub-dust receive via the " +
+		"operator credit subsystem is unavailable")
 )

--- a/swapwallet/errors.go
+++ b/swapwallet/errors.go
@@ -58,4 +58,13 @@ var (
 	// the cap.
 	ErrBalanceLimitExceeded = errors.New("amount would exceed the " +
 		"maximum allowed wallet balance")
+
+	// ErrCreditReceiveUnavailable is returned when a sub-dust receive is
+	// routed to the operator's credit subsystem but the swap server does
+	// not complete the credit request (it times out or errors). It maps to
+	// a gRPC Unavailable status so the failure is distinguishable from an
+	// opaque DEADLINE_EXCEEDED; the wrapped message carries the amount, the
+	// dust limit, and the guidance to receive at least the dust amount.
+	ErrCreditReceiveUnavailable = errors.New("sub-dust receive via the " +
+		"operator credit subsystem is unavailable")
 )

--- a/swapwallet/errors_grpc.go
+++ b/swapwallet/errors_grpc.go
@@ -70,6 +70,17 @@ var sentinelMappings = []sentinelMapping{
 		ErrBalanceLimitExceeded, codes.FailedPrecondition,
 		wavewalletrpc.ReasonBalanceLimitExceeded,
 	},
+
+	// A sub-dust receive whose credit request the swap server never
+	// completes is Unavailable (a function of operator/server state, not a
+	// malformed argument), carrying its own dedicated
+	// CREDIT_RECEIVE_UNAVAILABLE reason so clients can tell it apart from a
+	// wholesale swap-backend outage. The point is to replace the opaque
+	// DEADLINE_EXCEEDED with a typed, actionable status.
+	{
+		ErrCreditReceiveUnavailable, codes.Unavailable,
+		wavewalletrpc.ReasonCreditReceiveUnavailable,
+	},
 }
 
 // statusSwapBackendUnavailable returns the canonical gRPC status for a missing

--- a/swapwallet/errors_grpc_test.go
+++ b/swapwallet/errors_grpc_test.go
@@ -57,6 +57,7 @@ func TestSentinelMappingsCoverage(t *testing.T) {
 		ErrUnsupportedKind,
 		ErrAmountExceedsVTXOLimit,
 		ErrBalanceLimitExceeded,
+		ErrCreditReceiveUnavailable,
 		ErrWalletNotReady,
 	}
 

--- a/swapwallet/recv.go
+++ b/swapwallet/recv.go
@@ -5,10 +5,12 @@ package swapwallet
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/lightninglabs/wavelength/baselib/actor"
 	"github.com/lightninglabs/wavelength/credit"
 	"github.com/lightninglabs/wavelength/rpc/swapclientrpc"
 	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
@@ -202,6 +204,20 @@ func (r *receiver) recvCredit(ctx context.Context,
 		},
 	).Await(ctx).Unpack()
 	if err != nil {
+		// Preserve caller-owned cancellation and local shutdown. A
+		// canceled RPC, or a credit registry actor that is itself
+		// terminating during daemon shutdown, says nothing about the
+		// operator's credit subsystem: the operator never actually
+		// rejected the receive. Neither must leave a durable FAILED row
+		// for the caller, so return the underlying error unchanged
+		// instead of mapping it to the operator-blaming sentinel below.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		if errors.Is(err, actor.ErrActorTerminated) {
+			return nil, err
+		}
+
 		// A sub-dust receive that the swap server never completes must
 		// not vanish silently (wavelength#1041): log it, record a
 		// FAILED activity row, and return a typed, actionable error

--- a/swapwallet/recv.go
+++ b/swapwallet/recv.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/lightninglabs/wavelength/credit"
@@ -62,15 +63,36 @@ func (r *receiver) Recv(ctx context.Context, req *wavewalletrpc.RecvRequest) (
 	}
 	if dustLimit > 0 && amt < dustLimit {
 		availableCreditSat, err := r.availableCreditSat(ctx)
-		if err != nil {
-			return r.recvCredit(ctx, req, amt)
-		}
-		if amt > ^uint64(0)-availableCreditSat ||
-			amt+availableCreditSat < dustLimit {
-			return r.recvCredit(ctx, req, amt)
-		}
+		switch {
+		case err != nil:
+			// Credit balance lookup failed; still route to credit
+			// (a fresh wallet has no credits anyway), but log the
+			// decision so the sub-dust path is not silent.
+			r.deps.resolveLog().InfoS(ctx, "Routing sub-dust "+
+				"receive to credit subsystem",
+				slog.Uint64("amt_sat", amt),
+				slog.Uint64("dust_limit_sat", dustLimit),
+				slog.String("credit_balance", "unavailable"))
 
-		plannedVHTLCSat = amt + availableCreditSat
+			return r.recvCredit(ctx, req, amt, dustLimit)
+
+		case amt > ^uint64(0)-availableCreditSat ||
+			amt+availableCreditSat < dustLimit:
+
+			r.deps.resolveLog().InfoS(ctx, "Routing sub-dust "+
+				"receive to credit subsystem",
+				slog.Uint64("amt_sat", amt),
+				slog.Uint64("dust_limit_sat", dustLimit),
+				slog.Uint64(
+					"available_credit_sat",
+					availableCreditSat,
+				))
+
+			return r.recvCredit(ctx, req, amt, dustLimit)
+
+		default:
+			plannedVHTLCSat = amt + availableCreditSat
+		}
 	}
 
 	// Enforce the operator's per-VTXO and total-balance limits before a
@@ -159,7 +181,7 @@ func (r *receiver) availableCreditSat(ctx context.Context) (uint64, error) {
 // (inbound receives carry no double-spend risk that would need cross-call
 // dedup).
 func (r *receiver) recvCredit(ctx context.Context,
-	req *wavewalletrpc.RecvRequest, amt uint64) (
+	req *wavewalletrpc.RecvRequest, amt, dustLimit uint64) (
 	*wavewalletrpc.RecvResponse, error) {
 
 	if r.deps.CreditRegistry == nil {
@@ -180,7 +202,29 @@ func (r *receiver) recvCredit(ctx context.Context,
 		},
 	).Await(ctx).Unpack()
 	if err != nil {
-		return nil, fmt.Errorf("start credit receive: %w", err)
+		// A sub-dust receive that the swap server never completes must
+		// not vanish silently (wavelength#1041): log it, record a
+		// FAILED activity row, and return a typed, actionable error
+		// instead of the opaque underlying deadline/RPC error.
+		r.deps.resolveLog().WarnS(ctx, "Sub-dust credit receive failed",
+			err,
+			slog.Uint64("amt_sat", amt),
+			slog.Uint64("dust_limit_sat", dustLimit),
+		)
+
+		r.projectFailedCreditReceive(ctx, req, "recv:"+keyID, amt)
+
+		// Return only the typed sentinel + actionable guidance. The
+		// underlying swap-server error is deliberately NOT wrapped into
+		// the returned error: it is a gRPC status (often
+		// DeadlineExceeded from the credit AdmitTimeout), and wrapping
+		// it would let the error-mapping interceptor pass that raw code
+		// through instead of the typed Unavailable. The underlying
+		// cause is logged above.
+		return nil, fmt.Errorf("%w: the operator did not complete the "+
+			"credit request for %d sat and may not support "+
+			"sub-dust receives; receive at least %d sat instead",
+			ErrCreditReceiveUnavailable, amt, dustLimit)
 	}
 
 	start, ok := resp.(*credit.StartCreditResponse)
@@ -208,6 +252,43 @@ func (r *receiver) recvCredit(ctx context.Context,
 			PaymentHash: paymentHashHex,
 		},
 	}, nil
+}
+
+// projectFailedCreditReceive records a terminal FAILED activity row for a
+// sub-dust credit receive whose admission never completed. Without it a failed
+// attempt leaves no trace at all (the success path is the only place that
+// projects a row), so the user has no evidence the receive was attempted
+// (wavelength#1041).
+func (r *receiver) projectFailedCreditReceive(ctx context.Context,
+	req *wavewalletrpc.RecvRequest, id string, amt uint64) {
+
+	now := nowUnix()
+	entry := &wavewalletrpc.WalletEntry{
+		Id:            id,
+		Kind:          wavewalletrpc.EntryKind_ENTRY_KIND_RECV,
+		Status:        wavewalletrpc.EntryStatus_ENTRY_STATUS_FAILED,
+		AmountSat:     int64(amt),
+		Counterparty:  "credit",
+		CreatedAtUnix: now,
+		UpdatedAtUnix: now,
+		Note:          req.GetMemo(),
+		FailureReason: "credit receive unavailable",
+		// Classify the row with a stable, machine-readable code so
+		// clients can branch on it without parsing the free-text
+		// reason. This mirrors how the credit projector tags a terminal
+		// credit-op failure (ENTRY_FAILURE_CODE_FAILED): the receive
+		// reached a terminal, non-actionable failure.
+		FailureCode: failureCodePtr(
+			wavewalletrpc.EntryFailureCode_ENTRY_FAILURE_CODE_FAILED,
+		),
+		Progress: &wavewalletrpc.WalletEntryProgress{
+			Phase: wavewalletrpc.
+				WalletEntryPhase_WALLET_ENTRY_PHASE_FAILED,
+			PhaseLabel: "failed",
+		},
+	}
+
+	r.runtime.projectAndEmit(context.WithoutCancel(ctx), entry)
 }
 
 func creditReceiveEntry(req *wavewalletrpc.RecvRequest, opID, invoice,

--- a/swapwallet/recv_test.go
+++ b/swapwallet/recv_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // newRecvFixture builds a receiver fixture using the same fake plumbing
@@ -188,6 +190,85 @@ func TestRecvBelowDustHandsToCreditRegistry(t *testing.T) {
 	require.Equal(t, "tiny", projection.Note)
 	require.NotEmpty(t, projection.RequestJSON)
 	require.Equal(t, []byte{0xab, 0xcd}, projection.PaymentHash)
+}
+
+// TestRecvCreditFailureIsTypedAndRecorded locks the wavelength#1041 fix: when a
+// sub-dust receive is routed to the credit subsystem and the swap server never
+// completes the credit request (here a DeadlineExceeded, the exact symptom seen
+// on signet), the failure must (1) surface as the typed
+// ErrCreditReceiveUnavailable with actionable guidance rather than an opaque
+// deadline error, (2) NOT leak the underlying DeadlineExceeded code through the
+// error-mapping interceptor -- it must map to Unavailable, and (3) leave a
+// FAILED activity row so the attempt is not silent.
+func TestRecvCreditFailureIsTypedAndRecorded(t *testing.T) {
+	t.Parallel()
+
+	const (
+		dustLimit = uint64(1_000)
+		amt       = uint64(999)
+	)
+
+	swap := &fakeSwapService{}
+	rpc := &fakeRPCServer{
+		getInfoResp: &waverpc.GetInfoResponse{
+			ServerInfo: &waverpc.ServerInfo{
+				DustLimit: dustLimit,
+			},
+		},
+	}
+	reg := &fakeCreditRegistry{
+		// Mirror the live signet symptom: the credit Ask resolves with
+		// a gRPC DeadlineExceeded status (the credit admit timeout
+		// firing).
+		err: status.Error(
+			codes.DeadlineExceeded, "context deadline exceeded",
+		),
+	}
+	store := &fakeActivityProjector{}
+	deps := &Deps{
+		SwapService:    swap,
+		RPCServer:      rpc,
+		CreditRegistry: reg,
+		ActivityStore:  store,
+	}
+	runtime := newRuntime(t.Context(), deps)
+	t.Cleanup(runtime.stop)
+	receiver := newReceiver(deps, runtime)
+
+	_, err := receiver.Recv(t.Context(), &wavewalletrpc.RecvRequest{
+		AmtSat: amt,
+		Memo:   "tiny",
+	})
+
+	// (1) The failure is the typed sentinel carrying actionable guidance:
+	// the requested amount and the dust floor to retry at or above.
+	require.ErrorIs(t, err, ErrCreditReceiveUnavailable)
+	require.Contains(t, err.Error(), "999")
+	require.Contains(t, err.Error(), "1000")
+	require.Equal(t, 1, reg.receiveCalls)
+	require.Equal(t, 0, swap.startReceiveCalls)
+
+	// (2) The returned error must NOT carry the underlying DeadlineExceeded
+	// status: once mapped by the interceptor it is Unavailable, so a client
+	// sees a distinct, retriable-elsewhere code rather than an opaque
+	// deadline. This is the crux of the #1041 fix.
+	mapped := mapSentinel(err)
+	require.Equal(t, codes.Unavailable, status.Code(mapped))
+
+	// (3) A FAILED activity row was projected so the attempt leaves a
+	// trace, keyed to the credit counterparty and the requested amount.
+	require.Equal(t, 1, store.count())
+	row := store.lastProjection()
+	require.Equal(
+		t, int64(wavewalletrpc.EntryStatus_ENTRY_STATUS_FAILED),
+		row.Status,
+	)
+	require.Equal(
+		t, int64(wavewalletrpc.EntryKind_ENTRY_KIND_RECV), row.Kind,
+	)
+	require.Equal(t, "credit", row.Counterparty)
+	require.Equal(t, int64(amt), row.AmountSat)
+	require.NotEmpty(t, row.FailureReason)
 }
 
 // TestRecvDustLimitLookupFailureFallsBackOpen asserts that advisory dust

--- a/swapwallet/recv_test.go
+++ b/swapwallet/recv_test.go
@@ -3,8 +3,10 @@
 package swapwallet
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/lightninglabs/wavelength/credit"
 	"github.com/lightninglabs/wavelength/rpc/swapclientrpc"
@@ -269,6 +271,69 @@ func TestRecvCreditFailureIsTypedAndRecorded(t *testing.T) {
 	require.Equal(t, "credit", row.Counterparty)
 	require.Equal(t, int64(amt), row.AmountSat)
 	require.NotEmpty(t, row.FailureReason)
+}
+
+// TestRecvCreditCallerContextIsPreserved asserts that caller cancellation is
+// not reclassified as an operator credit outage or persisted as a failed
+// receive attempt.
+func TestRecvCreditCallerContextIsPreserved(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want error
+		ctx  func(*testing.T) context.Context
+	}{
+		{
+			name: "canceled",
+			want: context.Canceled,
+			ctx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+
+				return ctx
+			},
+		},
+		{
+			name: "deadline exceeded",
+			want: context.DeadlineExceeded,
+			ctx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithDeadline(
+					t.Context(),
+					time.Now().Add(-time.Second),
+				)
+				t.Cleanup(cancel)
+
+				return ctx
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			registry := &fakeCreditRegistry{err: test.want}
+			store := &fakeActivityProjector{}
+			deps := &Deps{
+				CreditRegistry: registry,
+				ActivityStore:  store,
+			}
+			runtime := newRuntime(t.Context(), deps)
+			t.Cleanup(runtime.stop)
+			receiver := newReceiver(deps, runtime)
+
+			_, err := receiver.recvCredit(
+				test.ctx(t), &wavewalletrpc.RecvRequest{
+					Memo: "tiny",
+				}, 999, 1_000,
+			)
+			require.ErrorIs(t, err, test.want)
+			require.Equal(t, 1, registry.receiveCalls)
+			require.Equal(t, 0, store.count())
+		})
+	}
 }
 
 // TestRecvDustLimitLookupFailureFallsBackOpen asserts that advisory dust


### PR DESCRIPTION
## Problem

A sub-dust offchain receive (`recv --offchain --amt <dust>`) routes to the
operator credit subsystem. When the swap server does not complete the credit
request, the receive hung ~30s, then failed with an opaque `DEADLINE_EXCEEDED`,
left no daemon log, and recorded no activity row (#1041).

## What this does (client-side graceful degradation)

- **Faster, dedicated timeout** — a separate `ReceiveAdmitTimeout` (default 15s)
  for the interactive receive-admission path, instead of reusing the 30s general
  `AdmitTimeout`.
- **Typed, actionable error** — the failure maps to a gRPC `Unavailable` status
  carrying the new `CREDIT_RECEIVE_UNAVAILABLE` reason, with a message telling
  the user to receive at least the dust amount instead of leaking the raw
  deadline code.
- **Visible attempt** — a FAILED activity row is projected and the failure is
  logged at the routing site.
- **SDK reconstruction** — `wavewalletdk` turns the new reason back into an
  `errors.Is`-able `ErrCreditReceiveUnavailable` sentinel; the round-trip
  contract test covers it.

## Scope

This is the client half: it degrades gracefully so the user gets a fast, typed,
visible failure. The server-side root cause (the swap server not completing
`CreateCredit`) is addressed in the companion PR
lightninglabs/swapdk-server#242.

## Testing

- New `TestRecvCreditFailureIsTypedAndRecorded` reproduces the failure and locks
  all three guarantees (typed `Unavailable`, no leaked deadline, FAILED row).
- `swapwallet`, `credit`, and `sdk/wavewalletdk` suites green; `fmt` and local
  lint clean.
- Validated end to end against live signet.

Addresses #1041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
