### PR TITLE
Fail closed when the wasm wallet database can't persist to OPFS

### DIFF
--- a/db/sqlite_open_wasm.go
+++ b/db/sqlite_open_wasm.go
@@ -27,6 +27,14 @@ func openSQLiteDatabase(cfg SQLiteOpenConfig) (*SQLiteOpenResult, error) {
 	values.Set("vfs", wasmSQLiteVFS)
 	values.Set("mode", "rwc")
 
+	// A wallet-grade database silently degrading to the in-memory VFS
+	// would lose every write on page close, so fail closed when no
+	// persistent OPFS VFS can be opened. The most common trigger is
+	// another tab of the same origin holding the exclusive OPFS handles;
+	// failing here surfaces that as a clear locked-database error instead
+	// of a later migration failure against a throwaway database.
+	values.Set("require_persistent", "true")
+
 	pragmas := make([]string, 0, len(cfg.Pragmas)+1)
 	for _, pragma := range cfg.Pragmas {
 		switch strings.ToLower(pragma.Name) {
@@ -87,7 +95,7 @@ func openWASMSQLiteWithRetry(dsn string) (*sql.DB, error) {
 		}
 
 		_ = db.Close()
-		if !isWASMCantOpen(err) {
+		if !isWASMRetryableOpen(err) {
 			return nil, err
 		}
 
@@ -98,10 +106,16 @@ func openWASMSQLiteWithRetry(dsn string) (*sql.DB, error) {
 	return nil, lastErr
 }
 
-// isWASMCantOpen identifies the SQLite error returned while OPFS still holds a
-// file lock from a just-unloaded page runtime.
-func isWASMCantOpen(err error) bool {
+// isWASMRetryableOpen identifies the SQLite errors returned while OPFS still
+// holds a file lock from a just-unloaded page runtime: SQLITE_CANTOPEN while
+// the previous runtime's handles are still being torn down, and SQLITE_BUSY
+// now that require_persistent surfaces lock contention as an open failure
+// instead of an in-memory fallback. A tab whose lock holder never goes away
+// exhausts the retries and returns the locked-database error to the caller.
+func isWASMRetryableOpen(err error) bool {
 	return strings.Contains(err.Error(), "SQLITE_CANTOPEN") ||
+		strings.Contains(err.Error(), "SQLITE_BUSY") ||
+		strings.Contains(err.Error(), "database is locked") ||
 		strings.Contains(err.Error(), "unable to open database file")
 }
 

--- a/lwwallet/walletdb_wasm.go
+++ b/lwwallet/walletdb_wasm.go
@@ -93,7 +93,7 @@ func openWASMWalletDB(dbDir string) (walletdb.DB, error) {
 		if err == nil {
 			return db, nil
 		}
-		if !isWASMWalletCantOpen(err) {
+		if !isWASMWalletRetryableOpen(err) {
 			return nil, fmt.Errorf("open OPFS wallet database: %w",
 				err)
 		}
@@ -111,6 +111,12 @@ func wasmWalletDBDSN(dbDir string) string {
 	values.Set("file", wasmWalletDBFileName(dbDir))
 	values.Set("vfs", "opfs")
 	values.Set("mode", "rwc")
+
+	// The wallet database must never silently degrade to the in-memory
+	// VFS (every write would be lost on page close), so fail closed when
+	// no persistent OPFS VFS can be opened, e.g. while another tab of the
+	// same origin holds the exclusive OPFS handles.
+	values.Set("require_persistent", "true")
 	values.Set("busy_timeout", wasmWalletDBBusyTimeoutMS)
 	values.Set("journal_mode", "WAL")
 	values.Set(
@@ -142,9 +148,14 @@ func wasmWalletDBFileName(dbDir string) string {
 	return fmt.Sprintf(wasmWalletDBFileNamePattern, hasher.Sum64())
 }
 
-// isWASMWalletCantOpen identifies the SQLite error returned while OPFS still
-// holds the wallet database from a just-unloaded page runtime.
-func isWASMWalletCantOpen(err error) bool {
+// isWASMWalletRetryableOpen identifies the SQLite errors returned while OPFS
+// still holds the wallet database from a just-unloaded page runtime:
+// SQLITE_CANTOPEN while the previous runtime's handles are still being torn
+// down, and SQLITE_BUSY now that require_persistent surfaces lock contention
+// as an open failure instead of an in-memory fallback.
+func isWASMWalletRetryableOpen(err error) bool {
 	return strings.Contains(err.Error(), "SQLITE_CANTOPEN") ||
+		strings.Contains(err.Error(), "SQLITE_BUSY") ||
+		strings.Contains(err.Error(), "database is locked") ||
 		strings.Contains(err.Error(), "unable to open database file")
 }


### PR DESCRIPTION
## Summary

A second browser tab can't acquire the wallet database's exclusive OPFS handles, and the wasm SQLite worker used to treat that open failure as a cue to fall back to an in-memory database. The daemon then booted against a throwaway store and died much later inside migrations with an unrelated-looking `SQLITE_CANTOPEN`, while any writes that had already succeeded were doomed to vanish on page close. That's the raw trace behind lightninglabs/wavelength-sdk#48.

This makes the open fail closed instead: `require_persistent` on the DSN turns a missing persistent OPFS VFS into a real locked-database error at open time, so there's no silent in-memory downgrade and no confusing failure later in migrations.

## Changes

- Set `require_persistent=true` on both wasm SQLite DSNs: the generic db store (`db/sqlite_open_wasm.go`) and btcwallet's OPFS-backed walletdb (`lwwallet/walletdb_wasm.go`).
- Widen the open-retry predicate to `SQLITE_BUSY` and `database is locked` alongside the existing `SQLITE_CANTOPEN`, since contention now surfaces as an open failure rather than an in-memory fallback. The helpers are renamed `isWASM*RetryableOpen` to match.
- The retry budget still absorbs the brief handle-release race right after a reload. A lock holder that never goes away exhausts the retries and returns the locked error to the caller, where the SDK maps it to a typed `wallet_locked`.

## Testing

- Built the daemon to wasm and exercised the two-tab flow in the browser against a regtest stack: a second tab surfaces a locked-database error at open time instead of booting on an in-memory store, and a single tab (including a reload after the previous runtime releases its handles) still opens normally.

## Related

- Addresses the daemon half of lightninglabs/wavelength-sdk#48. The SDK PR adds the fast cross-tab detection (a Web Locks pre-check) and the typed `wallet_locked` mapping, and will cross-link here once it's open.
