### PR TITLE
lwwallet: reduce browser wallet public KDF cost

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -236,3 +236,6 @@ replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-d
 
 // Use local baselib for development and CI.
 replace github.com/lightninglabs/wavelength/baselib => ./baselib
+
+// Use the independent creation KDF API until btcwallet PR #1298 merges.
+replace github.com/btcsuite/btcwallet => github.com/Roasbeef/btcwallet v0.0.0-20260724000651-fa5ec465bbf7

--- a/go.sum
+++ b/go.sum
@@ -611,6 +611,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/Roasbeef/btcwallet v0.0.0-20260724000651-fa5ec465bbf7 h1:YU1tt+gw8Fl1O9UHi9MP7OkhZGtnbmvYYEjBp+UQHE4=
+github.com/Roasbeef/btcwallet v0.0.0-20260724000651-fa5ec465bbf7/go.mod h1:1ZMc1EEskov+AKKv4kCMZqN8BwVh9rpXwEyxbeWy2A4=
 github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344 h1:cDVUiFo+npB0ZASqnw4q90ylaVAbnYyx0JYqK4YcGok=
 github.com/Yawning/aez v0.0.0-20211027044916-e49e68abd344/go.mod h1:9pIqrY6SXNL8vjRQE5Hd/OL5GyK/9MrGUWs87z/eFfk=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
@@ -658,8 +660,6 @@ github.com/btcsuite/btclog v1.0.0 h1:sEkpKJMmfGiyZjADwEIgB1NSwMyfdD1FB8v6+w1T0Ns
 github.com/btcsuite/btclog v1.0.0/go.mod h1:w7xnGOhwT3lmrS4H3b/D1XAXxvh+tbhUm8xeHN2y3TQ=
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b h1:MQ+Q6sDy37V1wP1Yu79A5KqJutolqUGwA99UZWQDWZM=
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b/go.mod h1:XItGUfVOxotJL8kkuk2Hj3EVow5KCugXl3wWfQ6K0AE=
-github.com/btcsuite/btcwallet v0.18.0 h1:VSRClNLT7NX0wmJEGALz3jOZRRjWPpUdp7VI1Akie1o=
-github.com/btcsuite/btcwallet v0.18.0/go.mod h1:1ZMc1EEskov+AKKv4kCMZqN8BwVh9rpXwEyxbeWy2A4=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.4.0 h1:oIkGj32YK1CvWaJGlVwZA1f+y/KVHkfrd2PoST0ZpQs=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.4.0/go.mod h1:sGrBjcqQ8UPexuRajFs72+o544CJn3Pavv/5H0VAWVk=
 github.com/btcsuite/btcwallet/wallet/txrules v1.3.0 h1:D5aGMwWIxdqek3xEJs4eOdMoh6iga2EI2xSlaXCdnNo=

--- a/lwwallet/wallet.go
+++ b/lwwallet/wallet.go
@@ -155,7 +155,7 @@ func New(cfg Config) (*Wallet, error) {
 		walletcore.DefaultBlockCacheSize,
 	)
 
-	loaderOptions, loaderCleanup, err := newWalletLoaderOptions(cfg)
+	baseWallet, loaderOptions, loaderCleanup, err := newWalletBootstrap(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("create wallet loader options: %w", err)
 	}
@@ -170,6 +170,7 @@ func New(cfg Config) (*Wallet, error) {
 		CoinType:       coinType,
 		RecoveryWindow: cfg.RecoveryWindow,
 		LoaderOptions:  loaderOptions,
+		Wallet:         baseWallet,
 	}, blockCache)
 	if err != nil {
 		// On failure the wallet never adopted the loader's
@@ -179,7 +180,6 @@ func New(cfg Config) (*Wallet, error) {
 
 		return nil, fmt.Errorf("create btcwallet: %w", err)
 	}
-
 	// Create the keyring from btcwallet's internal wallet. This
 	// provides HD key derivation using the same m/1017'/coinType'
 	// scope as LND.

--- a/lwwallet/walletdb_native.go
+++ b/lwwallet/walletdb_native.go
@@ -5,8 +5,22 @@ package lwwallet
 import (
 	"time"
 
+	base "github.com/btcsuite/btcwallet/wallet"
 	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
 )
+
+// newWalletBootstrap leaves wallet creation and opening to lnd's native
+// btcwallet loader.
+func newWalletBootstrap(cfg Config) (*base.Wallet, []btcwallet.LoaderOption,
+	func(), error) {
+
+	opts, cleanup, err := newWalletLoaderOptions(cfg)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return nil, opts, cleanup, nil
+}
 
 // newWalletLoaderOptions returns the native btcwallet bbolt loader
 // options. The cleanup func is a no-op: the local database is opened

--- a/lwwallet/walletdb_wasm.go
+++ b/lwwallet/walletdb_wasm.go
@@ -11,9 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	base "github.com/btcsuite/btcwallet/wallet"
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/lightninglabs/go-wasmsqlite"
 	"github.com/lightninglabs/wavelength/internal/sqlbase"
+	"github.com/lightninglabs/wavelength/walletcore"
 	"github.com/lightningnetwork/lnd/lnwallet/btcwallet"
 )
 
@@ -25,6 +28,61 @@ const (
 	wasmWalletDBMaxConnections  = 1
 	wasmWalletDBFileNamePattern = "/wallet-%016x.db"
 )
+
+var browserPublicScrypt = waddrmgr.ScryptOptions{
+	N: 16,
+	R: 8,
+	P: 1,
+}
+
+// newWalletBootstrap opens the browser wallet directly so Wavelength can
+// select independent public and private KDF profiles. The public passphrase is
+// fixed and protects non-secret metadata, so it uses the fast profile. The
+// private passphrase keeps btcwallet's default profile.
+func newWalletBootstrap(cfg Config) (*base.Wallet,
+	[]btcwallet.LoaderOption, func(), error) {
+
+	opts, cleanup, err := newWalletLoaderOptions(cfg)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	loader, err := btcwallet.NewWalletLoader(
+		cfg.ChainParams, cfg.RecoveryWindow, opts...,
+	)
+	if err != nil {
+		cleanup()
+
+		return nil, nil, nil, err
+	}
+	err = loader.SetCreateScryptOptions(
+		&browserPublicScrypt,
+		&waddrmgr.DefaultScryptOptions,
+	)
+	if err != nil {
+		cleanup()
+
+		return nil, nil, nil, err
+	}
+
+	var wallet *base.Wallet
+	if cfg.Seed != nil {
+		wallet, err = loader.CreateNewWallet(
+			walletcore.PublicWalletPassphrase, cfg.WalletPassword,
+			cfg.Seed, cfg.Birthday,
+		)
+	} else {
+		wallet, err = loader.OpenExistingWallet(
+			walletcore.PublicWalletPassphrase, false,
+		)
+	}
+	if err != nil {
+		cleanup()
+
+		return nil, nil, nil, err
+	}
+
+	return wallet, nil, cleanup, nil
+}
 
 // newWalletLoaderOptions opens btcwallet through an OPFS-backed SQLite
 // walletdb implementation for browser builds. The cleanup func closes


### PR DESCRIPTION
## Summary

In this PR, we reduce browser wallet create and unlock time by configuring
independent scrypt profiles for btcwallet's public and private master keys.
The fixed `lwwallet` public passphrase protects public wallet metadata, so its
creation profile uses `N=16`. The user-supplied private passphrase keeps
btcwallet's default `N=262144` profile.

The change is limited to the WASM wallet bootstrap. Native builds retain their
existing loader path, existing browser databases retain their persisted KDF
parameters, and only newly created browser wallets receive the faster public
profile.

The latest five-run browser benchmark with
`lightninglabs/wavelength-sdk#53` measured:

- Runtime ready p95: 276 ms.
- WASM load and instantiate p95: 138 ms.
- Wallet create total p95: 1,886 ms.
- Wallet unlock total p95: 669 ms.
- Performance budget violations: 0.

## Technical Notes

This PR temporarily replaces `github.com/btcsuite/btcwallet` with the exact
fork commit from `btcsuite/btcwallet#1298`. The replace directive and fork
checksums can be removed once that PR merges and Wavelength advances to the
upstream commit.

The private KDF is selected explicitly rather than relying on an implicit
default. This keeps the security boundary visible in the call site.

## Steps to Test

```bash
go test ./lwwallet
GOOS=js GOARCH=wasm go test -exec=true ./lwwallet
make lint-changed-local base=origin/main
```

For the browser benchmark:

```bash
WAVELENGTH_DIR=/path/to/wavelength \
  pnpm --dir /path/to/wavelength-sdk \
  --filter web-wallet-demo run wasm:local

pnpm --dir /path/to/wavelength-sdk perf:web
```

## Related Issues and Pull Requests

- Depends on btcsuite/btcwallet#1298.
- Supports lightninglabs/wavelength-sdk#53.
