### PR TITLE
docs: fix stale instructions in the waved Docker and CLI skills

### DIFF
--- a/.claude/skills/waved-docker.md
+++ b/.claude/skills/waved-docker.md
@@ -18,7 +18,7 @@ The Dockerfile uses a multi-stage build:
 ## Running Standalone
 
 ```bash
-docker run --rm waved:local \
+docker run --rm -p 10029:10029 waved:local \
     --network=regtest \
     --wallet.type=lnd \
     --lnd.host=<lnd-host>:10009 \
@@ -28,6 +28,13 @@ docker run --rm waved:local \
     --server.insecure=true \
     --rpc.listenaddr=0.0.0.0:10029
 ```
+
+Two legs of transport security get confused here, so keep them apart.
+`--server.insecure` is the **outbound** leg, waved dialing the Ark operator.
+waved's **own** RPC listener is governed by `--rpc.notls` and
+`--rpc.no-macaroons`, and neither is set above, so the daemon serves TLS with
+macaroon auth and writes both credentials under the network's data directory
+(`/root/.waved/data/regtest/`). Setting one leg says nothing about the other.
 
 ## Running with Full Stack
 
@@ -44,18 +51,35 @@ docker-compose up -d --build
 
 | Flag | Default | Purpose |
 |------|---------|---------|
-| `--network` | `mainnet` | Bitcoin network (use `regtest` for dev) |
-| `--wallet.type` | `lwwallet` | Wallet backend (`lnd` or `lwwallet`) |
+| `--network` | `mainnet` | Bitcoin network (mainnet, testnet, testnet4, regtest, simnet, signet); use `regtest` for dev |
+| `--wallet.type` | `lwwallet` | Wallet backend (`lnd`, `lwwallet`, or `btcwallet`) |
 | `--lnd.host` | `localhost:10009` | LND gRPC address |
 | `--lnd.tlspath` | | Path to LND TLS cert |
 | `--lnd.macaroonpath` | | Path to LND admin macaroon |
-| `--server.host` | `localhost:10010` | Ark operator server address |
-| `--server.insecure` | `false` | Disable TLS for server connection |
+| `--server.host` | (per-network) | Ark operator address; see below |
+| `--server.transport` | `grpc` | Ark operator RPC transport (`grpc` or `rest`) |
+| `--server.insecure` | `false` | Disable TLS for the outbound server connection (dev only) |
 | `--rpc.listenaddr` | `localhost:10029` | Daemon gRPC listen address |
-| `--debuglevel` | `info` | Log verbosity (trace/debug/info/warn/error) |
+| `--rpc.notls` | `false` | Disable TLS on the daemon's own RPC listener (dev only) |
+| `--rpc.no-macaroons` | `false` | Disable macaroon auth on the daemon's RPC listener (dev only) |
+| `--debuglevel` | `info` | Log verbosity (trace/debug/info/warn/error/critical) |
+
+`--server.host` has no baked-in default. When it is empty the address is
+resolved from a network+transport table at startup: `localhost:10010` on
+mainnet, regtest, and simnet, and the Lightning Labs deployment on testnet,
+testnet4, and signet. Running on mainnet at all also requires
+`--allow-mainnet`, and pairing mainnet with `--rpc.notls` or
+`--rpc.no-macaroons` requires `--allow-insecure-mainnet` on top of that.
+
+`--server.localmailboxid` and `--server.remotemailboxid` no longer exist.
+The daemon derives both mailbox identifiers itself, and passing either one
+now aborts startup with `unknown flag: --server.localmailboxid`. Anything
+still handing those to waved (lumos's `docker-compose.yml` on `master`
+included) needs them deleted, not renamed.
 
 Environment variables use `WAVED_` prefix with dots replaced by underscores:
-`WAVED_NETWORK=regtest`, `WAVED_WALLET_TYPE=lnd`, etc.
+`WAVED_NETWORK=regtest`, `WAVED_WALLET_TYPE=lnd`, `WAVED_DEBUGLEVEL=trace`,
+etc.
 
 ## CLI Access
 

--- a/.claude/skills/waved-docker.md
+++ b/.claude/skills/waved-docker.md
@@ -83,14 +83,61 @@ etc.
 
 ## CLI Access
 
+`wavecli --network` defaults to `mainnet`, and it is what derives the default
+TLS cert and macaroon paths under the data directory. A regtest daemon keeps
+both under `data/regtest/`, so point a bare `wavecli` at one and it goes
+looking in the wrong place and gives up before it ever dials:
+
+```
+unable to load TLS cert: open /root/.waved/data/mainnet/tls.cert: no such file or directory
+```
+
+`--network=regtest` is the whole fix on a stock daemon, which serves TLS with
+macaroon auth and has the matching credentials sitting right there on disk:
+
 ```bash
 # Inside the container:
-docker exec ark-client wavecli --rpcserver=localhost:10029 getinfo
-docker exec ark-client wavecli --rpcserver=localhost:10029 balance
+docker exec ark-client wavecli --network=regtest \
+    --rpcserver=localhost:10029 getinfo
+
+docker exec ark-client wavecli --network=regtest \
+    --rpcserver=localhost:10029 balance
 
 # Interactive shell:
 docker exec -it ark-client /bin/sh
 ```
+
+`--rpcserver=localhost:10029` is already the default, so it can be dropped.
+`--network=regtest` cannot.
+
+### When the daemon runs plaintext
+
+A daemon started with `--rpc.notls --rpc.no-macaroons` needs the matching
+`--no-tls --no-macaroons` on the client. Those two travel as a pair: pass
+`--no-tls` on its own and gRPC refuses to put per-RPC credentials on a
+plaintext link (`the credentials require transport level security`).
+
+With both set, wavecli reads nothing off disk at all, so `--network` stops
+mattering for the connection. It is still worth passing so the same command
+survives the daemon flipping back to TLS.
+
+Do not reach for these by reflex. Against a stock TLS daemon they fail with
+`error reading server preface: EOF`, which reads like a dead daemon rather
+than a client too eager to speak plaintext.
+
+### Connection errors and what they actually mean
+
+Getting this half-right produces six distinct errors, none of which say
+"you have a flag wrong":
+
+| Error | Cause |
+|-------|-------|
+| `unable to load TLS cert: open .../data/mainnet/tls.cert: no such file...` | wavecli is on the default `--network=mainnet` and looked for the cert in the wrong directory. Pass `--network=regtest`. |
+| `read macaroon: open .../data/mainnet/admin.macaroon: no such file...` | Same cause, one step later: `--no-tls` silenced the cert lookup but the macaroon path is still mainnet. Pass `--network=regtest` or `--no-macaroons`. |
+| `error reading server preface: EOF` | A `--no-tls` client against a TLS listener. Drop `--no-tls`. |
+| `authentication handshake failed: tls: first record does not look like a TLS handshake` | The reverse: a TLS client against a `--rpc.notls` daemon. Add `--no-tls`. |
+| `grpc: the credentials require transport level security` | `--no-tls` without `--no-macaroons`. gRPC will not ship per-RPC credentials over a plaintext link, so the two dev flags travel as a pair. |
+| `expected 1 macaroon, got 0` | The reverse of that: `--no-macaroons` against a daemon that still enforces them, so the connection is fine but the call carries no credential. Drop `--no-macaroons`, or turn enforcement off on the daemon with `--rpc.no-macaroons`. Adding `--macaroonpath` alongside `--no-macaroons` does nothing: `client.go` only reads the path when macaroons are enabled. |
 
 ## Logs
 

--- a/.claude/skills/waved-docker.md
+++ b/.claude/skills/waved-docker.md
@@ -57,11 +57,30 @@ macaroon auth and writes both credentials under the network's data directory
 The server repo (`lumos`) includes a `docker-compose.yml` that
 orchestrates the complete environment: bitcoind + 2x lnd + lumosd + waved.
 
+Two prerequisites bite on a fresh lumos clone, and neither is optional:
+
+1. **`LND_SOURCE` must point at an lnd source tree.** The `lnd-server` and
+   `lnd-client` services build from it, so compose refuses to even
+   interpolate the file without it: `required variable LND_SOURCE is
+   missing a value: Set LND_SOURCE to the path of your lnd source tree`.
+2. **lumos's `client` submodule must be initialized.** That submodule *is*
+   this repo, and both images reach into it: the lumosd Dockerfile copies
+   `client/go.mod`, `client/go.sum`, and `client/baselib/go.sum`, and the
+   `waved` service builds with `context: ./client`. Left uninitialized, the
+   lumosd build dies on `"/client/baselib/go.sum": not found` and the waved
+   build on `failed to read dockerfile: open Dockerfile: no such file or
+   directory`.
+
 ```bash
 # From the lumos (server) repo root:
-docker-compose up -d --build
+git submodule update --init --recursive
+export LND_SOURCE=/path/to/lnd
+docker compose up -d --build
 ./scripts/docker-regtest-setup.sh
 ```
+
+Use `docker compose` (the v2 subcommand), not the standalone
+`docker-compose` binary, which is no longer shipped with Docker Desktop.
 
 ## Configuration Flags
 
@@ -210,9 +229,13 @@ Outside Docker the equivalent is `make build-wavewalletrpc`. See
 # Follow container logs (stdout).
 docker logs -f ark-client
 
-# With docker-compose:
-docker-compose logs -f waved
+# With compose, by service name (the container is named ark-client):
+docker compose logs -f waved
 
 # Increase verbosity:
-# Set WAVED_DEBUG=trace in docker-compose.yml or pass --debuglevel=trace
+#   - daemon env var:  WAVED_DEBUGLEVEL=trace
+#   - daemon flag:     --debuglevel=trace
+#   - lumos compose:   WAVED_DEBUG=trace, which is a compose interpolation
+#     variable feeding --debuglevel=${WAVED_DEBUG:-debug}, not a waved
+#     env var. Setting WAVED_DEBUG on the daemon directly does nothing.
 ```

--- a/.claude/skills/waved-docker.md
+++ b/.claude/skills/waved-docker.md
@@ -15,6 +15,22 @@ The Dockerfile uses a multi-stage build:
 1. Builder stage: compiles `waved` and `wavecli` from source
 2. Runtime stage: minimal alpine image with the two binaries
 
+The builder compiles with the **default tag set**, so the `waved` in the
+image has neither `swapruntime` nor `wavewalletrpc` linked in. That is fine
+for the raw Ark RPCs, but it costs you the everyday wallet verbs.
+
+To get them, pass the tags through the `GOTAGS` build argument. It takes the
+same space-separated value as the Makefile's `tags=` parameter, and the two
+tags are required together:
+
+```bash
+docker build --build-arg GOTAGS="wavewalletrpc swapruntime" -t waved:wallet .
+```
+
+`GOTAGS` defaults to empty, so a plain `docker build` keeps producing the
+default tag set. See
+[Wallet verbs need a wavewalletrpc daemon](#wallet-verbs-need-a-wavewalletrpc-daemon).
+
 ## Running Standalone
 
 ```bash
@@ -138,6 +154,55 @@ Getting this half-right produces six distinct errors, none of which say
 | `authentication handshake failed: tls: first record does not look like a TLS handshake` | The reverse: a TLS client against a `--rpc.notls` daemon. Add `--no-tls`. |
 | `grpc: the credentials require transport level security` | `--no-tls` without `--no-macaroons`. gRPC will not ship per-RPC credentials over a plaintext link, so the two dev flags travel as a pair. |
 | `expected 1 macaroon, got 0` | The reverse of that: `--no-macaroons` against a daemon that still enforces them, so the connection is fine but the call carries no credential. Drop `--no-macaroons`, or turn enforcement off on the daemon with `--rpc.no-macaroons`. Adding `--macaroonpath` alongside `--no-macaroons` does nothing: `client.go` only reads the path when macaroons are enabled. |
+
+### Wallet verbs need a wavewalletrpc daemon
+
+The eight top-level wallet verbs (`create`, `unlock`, `send`, `recv`,
+`activity`, `balance`, `exit`, `wallet-sweep`), the `mcp` server's wallet
+tools, and `activity inspect` all ride on `wavewalletrpc.WalletService`.
+That service only exists in a daemon built with **both** the `wavewalletrpc`
+and `swapruntime` tags. Either one alone is not enough:
+`cmd/waved/wavewalletrpc_stub.go` is built under
+`!wavewalletrpc || !swapruntime`, and the stub registers nothing. Against a
+default-tag daemon, which is what an unqualified `docker build` and therefore
+lumos's compose produce, they all fail with:
+
+```
+daemon was not built with -tags wavewalletrpc; rebuild with `make build-wavewalletrpc` or see docs/wavewalletrpc_build.md
+```
+
+This is not a broken stack. `wavecli` registers the verbs unconditionally so
+the CLI surface never shifts under an agent; the gating is entirely
+daemon-side, and the CLI maps the gRPC `Unimplemented` back to that message.
+
+Working against a default-tag daemon:
+
+- `getinfo`, `schema`, and `mcp` (the introspection group).
+- The `ark` subtree, which is the raw waverpc surface: `ark vtxos list`,
+  `ark listtransactions`, `ark sweep list`, `ark send inround`, and friends.
+- The `recovery` subtree. Like `ark`, it rides on `waverpc.DaemonService`,
+  which every build registers.
+- `dev daemon *`, the generated view of that same always-present service.
+
+`dev` is not all-or-nothing, though. It is a generated registry spanning
+several services, so a default-tag daemon answers `dev daemon *` and refuses
+the rest: `dev wallet *` and `dev wallet-inspection *` come back
+`UNIMPLEMENTED: unknown service wavewalletrpc.WalletService`, and
+`dev swapclient *` reports `daemon was built without swapruntime support`.
+
+The `ark`, `recovery`, and `dev` subtrees are hidden from `--help` unless
+`WAVELENGTH_DEV=1` is set. That only changes CLI visibility, which is a
+separate question from whether the daemon serves the RPC behind them.
+
+To get the wallet verbs in a container, rebuild the image with the tags:
+
+```bash
+docker build --build-arg GOTAGS="wavewalletrpc swapruntime" -t waved:wallet .
+```
+
+Then point the compose `waved` service at that image, or run it directly.
+Outside Docker the equivalent is `make build-wavewalletrpc`. See
+[`docs/wavewalletrpc_build.md`](../../docs/wavewalletrpc_build.md).
 
 ## Logs
 

--- a/.claude/skills/waved.md
+++ b/.claude/skills/waved.md
@@ -74,7 +74,25 @@ and `--rpc.no-macaroons`, which are covered below.
 ## CLI Quick Reference
 
 All commands connect to the daemon at `--rpcserver` (default
-`localhost:10029`). Use `--no-tls` for regtest.
+`localhost:10029`). Every example below passes `--network=regtest`, which is
+not optional: it defaults to `mainnet` and is what derives the default TLS
+cert and macaroon paths, so without it wavecli reads from the wrong data
+directory and fails before dialing:
+
+```
+unable to load TLS cert: open ~/.waved/data/mainnet/tls.cert: no such file or directory
+```
+
+That is all a stock daemon needs, since it serves TLS with macaroon auth and
+the credentials are already on disk under `~/.waved/data/regtest/`.
+
+If the daemon was started with `--rpc.notls --rpc.no-macaroons`, add the
+matching `--no-tls --no-macaroons`. Those two travel as a pair: `--no-tls`
+alone fails with `grpc: the credentials require transport level security`,
+because gRPC will not ship per-RPC credentials over a plaintext link. With
+both set nothing is read off disk, so `--network` no longer matters for the
+connection. Against a stock TLS daemon they instead produce `error reading
+server preface: EOF`, so do not pass them by default.
 
 The CLI surface is three tiers:
 
@@ -92,38 +110,38 @@ verbs return a structured error pointing at `docs/wavewalletrpc_build.md`.
 
 ```bash
 # Status
-wavecli getinfo --no-tls
+wavecli --network=regtest getinfo
 
 # Create + unlock (password from env, never argv).
-WAVED_WALLET_PASSWORD=testpass wavecli create --no-tls
-WAVED_WALLET_PASSWORD=testpass wavecli unlock --no-tls
+WAVED_WALLET_PASSWORD=testpass wavecli --network=regtest create
+WAVED_WALLET_PASSWORD=testpass wavecli --network=regtest unlock
 
 # Balance: confirmed_sat / pending_in_sat / pending_out_sat
-wavecli balance --no-tls
+wavecli --network=regtest balance
 
 # Receive: offchain (invoice) or onchain (boarding address)
-wavecli recv --offchain --amt 5000 --memo "coffee" --no-tls
-wavecli recv --onchain --no-tls
+wavecli --network=regtest recv --offchain --amt 5000 --memo "coffee"
+wavecli --network=regtest recv --onchain
 
 # Send: --offchain (default) = invoice; --onchain = cooperative leave.
 # The CLI does NOT sniff the destination string; pick the direction
 # explicitly.
-wavecli send lnbcrt... --offchain --no-tls
-wavecli send bcrt1... --onchain --amt 1000 --no-tls
-wavecli send bcrt1... --onchain --sweep-all --no-tls
+wavecli --network=regtest send lnbcrt... --offchain
+wavecli --network=regtest send bcrt1... --onchain --amt 1000
+wavecli --network=regtest send bcrt1... --onchain --sweep-all
 
 # Activity: merged send/recv/deposit/exit feed.
-wavecli activity --no-tls                            # all activity
-wavecli activity --pending --kind send,recv --no-tls # filter
-wavecli activity --format json --no-tls              # JSON output
+wavecli --network=regtest activity                            # all activity
+wavecli --network=regtest activity --pending --kind send,recv # filter
+wavecli --network=regtest activity --format json              # JSON output
 # VTXO inventory and on-chain history are not part of the activity feed;
 # use the `ark` subtree: `ark vtxos list` (live VTXOs),
 # `ark listtransactions` (raw tx / onchain history),
 # `ark sweep list` (boarding-timeout sweep records).
 
 # Exit: trigger and query a unilateral exit (unroll).
-wavecli exit --outpoint TXID:VOUT --no-tls
-wavecli exit status --outpoint TXID:VOUT --no-tls
+wavecli --network=regtest exit --outpoint TXID:VOUT
+wavecli --network=regtest exit status --outpoint TXID:VOUT
 ```
 
 ### Advanced (`ark.*`) commands
@@ -133,22 +151,22 @@ surfaces the raw waverpc methods underlying them.
 
 ```bash
 # Raw VTXO inventory + lifecycle
-wavecli ark vtxos list --no-tls
-wavecli ark vtxos list --status live --min_amount 10000 --no-tls
+wavecli --network=regtest ark vtxos list
+wavecli --network=regtest ark vtxos list --status live --min_amount 10000
 # A real refresh is fee-gated: preview with --dry_run, consent with
 # --yes (required on non-interactive stdin).
-wavecli ark vtxos refresh --all --dry_run --no-tls
-wavecli ark vtxos refresh --all --yes --no-tls
+wavecli --network=regtest ark vtxos refresh --all --dry_run
+wavecli --network=regtest ark vtxos refresh --all --yes
 
 # Raw transaction history (the wallet-shaped feed is `activity`)
-wavecli ark listtransactions --no-tls
+wavecli --network=regtest ark listtransactions
 
 # Raw send paths
-wavecli ark send inround --to tb1p... --amount 50000 --no-tls
-wavecli ark send oor --to tb1p... --amount 25000 --no-tls
+wavecli --network=regtest ark send inround --to tb1p... --amount 50000
+wavecli --network=regtest ark send oor --to tb1p... --amount 25000
 
 # JSON input for complex requests
-wavecli ark send inround --no-tls --json '{
+wavecli --network=regtest ark send inround --json '{
   "recipients": [
     {"address": "tb1p...", "amount_sat": 50000},
     {"address": "tb1p...", "amount_sat": 30000}
@@ -173,13 +191,13 @@ stay out of `argv`.
 
 ```bash
 # Env var
-WAVED_WALLET_PASSWORD=pass wavecli unlock --no-tls
+WAVED_WALLET_PASSWORD=pass wavecli --network=regtest unlock
 
 # File
-wavecli unlock --wallet_password_file=/tmp/pass --no-tls
+wavecli --network=regtest unlock --wallet_password_file=/tmp/pass
 
 # Pipe
-echo -n 'pass' | wavecli unlock --no-tls
+echo -n 'pass' | wavecli --network=regtest unlock
 ```
 
 ## Regtest Workflow
@@ -188,14 +206,14 @@ echo -n 'pass' | wavecli unlock --no-tls
 2. Start waved in lwwallet mode (see above) built with
    `make build-wavewalletrpc`.
 3. Create + unlock the wallet via CLI:
-   `WAVED_WALLET_PASSWORD=testpass wavecli create --no-tls`
-   `WAVED_WALLET_PASSWORD=testpass wavecli unlock --no-tls`
-4. Get a boarding address: `wavecli recv --onchain --no-tls`
+   `WAVED_WALLET_PASSWORD=testpass wavecli --network=regtest create`
+   `WAVED_WALLET_PASSWORD=testpass wavecli --network=regtest unlock`
+4. Get a boarding address: `wavecli --network=regtest recv --onchain`
 5. Fund it: `bitcoin-cli sendtoaddress <addr> 0.01`
 6. Mine a block: `bitcoin-cli generatetoaddress 1 <miner_addr>`
-7. Check balance: `wavecli balance --no-tls`
+7. Check balance: `wavecli --network=regtest balance`
 8. List VTXOs (once boarding completes):
-   `wavecli ark vtxos list --no-tls`
+   `wavecli --network=regtest ark vtxos list`
 
 ## Environment Variables
 
@@ -221,4 +239,9 @@ prefix, dots replaced by underscores (e.g., `WAVED_SERVER_HOST`).
 | `--offchain and --onchain are mutually exclusive` | Pick one direction on `send` / `recv` |
 | `GenSeed: lwwallet mode only` | Switch daemon to `--wallet.type=lwwallet` |
 | `unknown flag: --server.localmailboxid` | Mailbox IDs are daemon-derived now; delete the flag |
-| TLS errors | Use `--no-tls` for regtest, or set `--tlscertpath` |
+| `unable to load TLS cert: .../data/mainnet/tls.cert: no such file...` | wavecli is on the default `--network=mainnet`. Pass `--network=regtest` |
+| `read macaroon: .../data/mainnet/admin.macaroon: no such file...` | Same cause one step later. Pass `--network=regtest` or `--no-macaroons` |
+| `error reading server preface: EOF` | A `--no-tls` client against a TLS listener. Drop `--no-tls` |
+| `tls: first record does not look like a TLS handshake` | The reverse: TLS client against a `--rpc.notls` daemon. Add `--no-tls` |
+| `grpc: the credentials require transport level security` | `--no-tls` without `--no-macaroons`; the two dev flags travel as a pair |
+| `expected 1 macaroon, got 0` | `--no-macaroons` against a daemon that still enforces them. Drop `--no-macaroons`, or turn enforcement off with `--rpc.no-macaroons` on the daemon. Adding `--macaroonpath` alone does nothing: it is only read when macaroons are enabled |

--- a/.claude/skills/waved.md
+++ b/.claude/skills/waved.md
@@ -6,8 +6,19 @@
 operator server via a mailbox transport, manages VTXOs (virtual
 transaction outputs), and exposes a gRPC API for wallet operations.
 
-`wavecli` is the CLI for driving the daemon. Output is always JSON.
-All commands accept `--json` for raw proto-JSON request payloads.
+`wavecli` is the CLI for driving the daemon. Almost everything it prints is
+already JSON, so an agent can parse the default output: `getinfo`, `balance`,
+`recv`, `send`, the `ark` verbs and the rest all render through one
+`printJSON` helper with no format switch at all.
+
+Two commands are the exception, and they are the only two that read the
+global `--json` bool: `activity` (default `--format table`) and `activity
+inspect` (default `--format expanded`). For those, pass `--json` (or
+`--format json`) to get machine-readable output. Passing `--json` anywhere
+else is silently inert.
+
+Input is a separate flag: `--request-json` takes a raw proto-JSON request
+payload.
 
 ## Building
 
@@ -119,9 +130,16 @@ The CLI surface is three tiers:
    surface. Backed by `wavewalletrpc.WalletService`, which needs the
    `wavewalletrpc` **and** `swapruntime` tags together (build with
    `make build-wavewalletrpc`, which sets both).
-2. **Daemon introspection at root** — `getinfo`, `schema`, `mcp`, `dev`.
-3. **Advanced subtrees** — `ark.*` (raw waverpc) and `swap.*`
-   (`swapruntime` build only).
+2. **Daemon introspection at root**: `getinfo`, `schema`, `mcp`.
+3. **Advanced subtrees**: `ark.*` (raw waverpc), `recovery.*` (daemon-owned
+   vHTLC recovery rows), and `dev.*` (generated low-level daemon RPCs). The
+   old `swap.*` subtree is gone; `wavecli swap ...` now exits with
+   `unknown command "swap" for "wavecli"`.
+
+The advanced subtrees are hidden from `--help` unless `WAVELENGTH_DEV=1` is
+set. That only changes CLI visibility: they are registered and dispatchable
+either way, which is separate from whether the daemon serves the RPC behind
+them.
 
 If the daemon is built without the tags, the eight top-level verbs return a
 structured error pointing at `docs/wavewalletrpc_build.md`. Tier 2 and the
@@ -191,10 +209,10 @@ surfaces the raw waverpc methods underlying them.
 ```bash
 # Raw VTXO inventory + lifecycle
 wavecli --network=regtest ark vtxos list
-wavecli --network=regtest ark vtxos list --status live --min_amount 10000
-# A real refresh is fee-gated: preview with --dry_run, consent with
+wavecli --network=regtest ark vtxos list --status live --min-amount 10000
+# A real refresh is fee-gated: preview with --dry-run, consent with
 # --yes (required on non-interactive stdin).
-wavecli --network=regtest ark vtxos refresh --all --dry_run
+wavecli --network=regtest ark vtxos refresh --all --dry-run
 wavecli --network=regtest ark vtxos refresh --all --yes
 
 # Raw transaction history (the wallet-shaped feed is `activity`)
@@ -204,8 +222,9 @@ wavecli --network=regtest ark listtransactions
 wavecli --network=regtest ark send inround --to tb1p... --amount 50000
 wavecli --network=regtest ark send oor --to tb1p... --amount 25000
 
-# JSON input for complex requests
-wavecli --network=regtest ark send inround --json '{
+# Raw JSON request payloads use --request-json, not --json (which is the
+# output-format bool, and inert on this command).
+wavecli --network=regtest ark send inround --request-json '{
   "recipients": [
     {"address": "tb1p...", "amount_sat": 50000},
     {"address": "tb1p...", "amount_sat": 30000}
@@ -213,30 +232,42 @@ wavecli --network=regtest ark send inround --json '{
 }'
 ```
 
+Flag names are canonically kebab-case (`--min-amount`, `--dry-run`,
+`--wallet-password-file`). A global normalizer folds the snake_case spelling
+onto the same flag, so older `--min_amount` style invocations still work.
+
 ### Password Input (Never as CLI args)
 
-Priority order (matches `readPassword` in `wallet_password.go`):
-1. `WAVED_WALLET_PASSWORD` env var (highest priority — wins even
-   when stdin is also piped, so automated REPLs do not race).
-2. `--wallet_password_file` flag (file is read and the trailing
+Priority order (matches `readWalletPassword` in `wallet_password.go`):
+1. `WAVED_WALLET_PASSWORD` env var (highest priority, so callers with
+   something already on stdin do not have to fight over it).
+2. `--wallet-password-file` flag (file is read and the trailing
    newline is stripped).
-3. Piped stdin (non-TTY).
+3. `--password-stdin`, which must be passed explicitly.
 4. Interactive TTY prompt (lowest priority).
 
-The optional aezeed seed passphrase is read with the same priority,
-from `WAVED_SEED_PASSPHRASE` and `--seed_passphrase_file`. The
-seed passphrase is NOT accepted via CLI args either — both secrets
-stay out of `argv`.
+Stdin is never consumed implicitly. A bare pipe with no
+`--password-stdin` is an error, not a fallback:
+
+```
+wallet password input required: set WAVED_WALLET_PASSWORD, use
+--wallet-password-file, or explicitly pass --password-stdin
+```
+
+The optional aezeed seed passphrase is read from
+`WAVED_SEED_PASSPHRASE`, then `--seed-passphrase-file`. The seed
+passphrase is NOT accepted via CLI args either, so both secrets stay out
+of `argv`.
 
 ```bash
 # Env var
 WAVED_WALLET_PASSWORD=pass wavecli --network=regtest unlock
 
 # File
-wavecli --network=regtest unlock --wallet_password_file=/tmp/pass
+wavecli --network=regtest unlock --wallet-password-file=/tmp/pass
 
-# Pipe
-echo -n 'pass' | wavecli --network=regtest unlock
+# Pipe, which needs the explicit opt-in
+echo -n 'pass' | wavecli --network=regtest unlock --password-stdin
 ```
 
 ## Regtest Workflow
@@ -262,12 +293,17 @@ against a default-tag build.
 | Variable | Description |
 |----------|-------------|
 | `WAVED_WALLET_PASSWORD` | Wallet password for create/unlock |
+| `WAVED_SEED_PASSPHRASE` | Optional aezeed seed passphrase for create |
 | `WAVED_NETWORK` | Bitcoin network override |
 | `WAVED_WALLET_TYPE` | Wallet backend type override |
 | `WAVED_WALLET_ESPLORAURL` | Esplora URL override |
+| `WAVED_DEBUGLEVEL` | Log verbosity override (the daemon flag is `--debuglevel`) |
+| `WAVELENGTH_DEV` | Set to `1` to reveal the `ark` / `recovery` / `dev` subtrees in `wavecli --help` |
 
 All daemon config flags can be set via env vars with the `WAVED_`
 prefix, dots replaced by underscores (e.g., `WAVED_SERVER_HOST`).
+`WAVELENGTH_DEV` is the one exception: it is a `wavecli` help-visibility
+toggle, not daemon config.
 
 ## Troubleshooting
 
@@ -280,7 +316,9 @@ prefix, dots replaced by underscores (e.g., `WAVED_SERVER_HOST`).
 | `--sweep-all requires --amt=0` | On `send --onchain`: pass `--sweep-all` for "drain wallet", or set `--amt N` |
 | `--offchain and --onchain are mutually exclusive` | Pick one direction on `send` / `recv` |
 | `GenSeed: lwwallet mode only` | Switch daemon to `--wallet.type=lwwallet` |
+| `wallet password input required: ...` | Stdin is never read implicitly. Use `WAVED_WALLET_PASSWORD`, `--wallet-password-file`, or an explicit `--password-stdin` |
 | `unknown flag: --server.localmailboxid` | Mailbox IDs are daemon-derived now; delete the flag |
+| `unknown command "swap" for "wavecli"` | The `swap` subtree was retired; use the wallet verbs or `ark.*` |
 | `unable to load TLS cert: .../data/mainnet/tls.cert: no such file...` | wavecli is on the default `--network=mainnet`. Pass `--network=regtest` |
 | `read macaroon: .../data/mainnet/admin.macaroon: no such file...` | Same cause one step later. Pass `--network=regtest` or `--no-macaroons` |
 | `error reading server preface: EOF` | A `--no-tls` client against a TLS listener. Drop `--no-tls` |

--- a/.claude/skills/waved.md
+++ b/.claude/skills/waved.md
@@ -29,8 +29,6 @@ make unit pkg=waved  # run unit tests for a package
   --wallet.esploraurl=http://localhost:3000 \
   --server.host=localhost:10010 \
   --server.insecure \
-  --server.localmailboxid=client1 \
-  --server.remotemailboxid=server \
   --rpc.listenaddr=localhost:10029
 ```
 
@@ -59,10 +57,19 @@ WAVED_WALLET_PASSWORD=testpass ./bin/waved \
   --lnd.macaroonpath=~/.lnd/data/chain/bitcoin/regtest/admin.macaroon \
   --server.host=localhost:10010 \
   --server.insecure \
-  --server.localmailboxid=client1 \
-  --server.remotemailboxid=server \
   --rpc.listenaddr=localhost:10029
 ```
+
+`--server.localmailboxid` and `--server.remotemailboxid` used to appear in
+both of the above. They are gone: the daemon derives its mailbox identifiers
+itself, and passing either one now aborts startup with
+`unknown flag: --server.localmailboxid`.
+
+Neither example disables transport security on waved's own listener, so both
+daemons serve TLS with macaroon auth and drop the credentials under
+`~/.waved/data/regtest/`. `--server.insecure` is the outbound leg to the
+operator and does not change that; the listener is governed by `--rpc.notls`
+and `--rpc.no-macaroons`, which are covered below.
 
 ## CLI Quick Reference
 
@@ -213,4 +220,5 @@ prefix, dots replaced by underscores (e.g., `WAVED_SERVER_HOST`).
 | `--sweep-all requires --amt=0` | On `send --onchain`: pass `--sweep-all` for "drain wallet", or set `--amt N` |
 | `--offchain and --onchain are mutually exclusive` | Pick one direction on `send` / `recv` |
 | `GenSeed: lwwallet mode only` | Switch daemon to `--wallet.type=lwwallet` |
+| `unknown flag: --server.localmailboxid` | Mailbox IDs are daemon-derived now; delete the flag |
 | TLS errors | Use `--no-tls` for regtest, or set `--tlscertpath` |

--- a/.claude/skills/waved.md
+++ b/.claude/skills/waved.md
@@ -12,11 +12,30 @@ All commands accept `--json` for raw proto-JSON request payloads.
 ## Building
 
 ```bash
-make build          # produces bin/waved and bin/wavecli
+make build          # produces bin/waved and bin/wavecli, default tag set
 make install        # installs to $GOPATH/bin
 make lint           # run linter
 make unit pkg=waved  # run unit tests for a package
 ```
+
+`make build` uses the **default tag set**, which leaves out both
+`swapruntime` and `wavewalletrpc`. That is enough for the raw Ark RPCs but
+not for the everyday wallet verbs, which need the two tags together, so most
+local work wants:
+
+```bash
+make build-wavewalletrpc    # -tags "wavewalletrpc swapruntime"
+make install-wavewalletrpc  # same, into $GOPATH/bin
+```
+
+In Docker the same thing is a build argument:
+
+```bash
+docker build --build-arg GOTAGS="wavewalletrpc swapruntime" -t waved:wallet .
+```
+
+Full detail on the tags and what each one turns on:
+[`docs/wavewalletrpc_build.md`](../../docs/wavewalletrpc_build.md).
 
 ## Starting the Daemon
 
@@ -35,8 +54,8 @@ make unit pkg=waved  # run unit tests for a package
 Then create and unlock the wallet:
 
 ```bash
-# Create (password via env var for automation). Build with wavewalletrpc:
-#   make build-wavewalletrpc
+# Create (password via env var for automation). Needs a daemon built with
+# make build-wavewalletrpc.
 WAVED_WALLET_PASSWORD=testpass wavecli create --no-tls
 
 # Or auto-unlock at startup:
@@ -96,20 +115,38 @@ server preface: EOF`, so do not pass them by default.
 
 The CLI surface is three tiers:
 
-1. **Seven top-level wallet verbs (implicit, no parent)** — the everyday
-   surface. Backed by `wavewalletrpc.WalletService` (build with
-   `make build-wavewalletrpc`).
+1. **Eight top-level wallet verbs (implicit, no parent)**: the everyday
+   surface. Backed by `wavewalletrpc.WalletService`, which needs the
+   `wavewalletrpc` **and** `swapruntime` tags together (build with
+   `make build-wavewalletrpc`, which sets both).
 2. **Daemon introspection at root** — `getinfo`, `schema`, `mcp`, `dev`.
 3. **Advanced subtrees** — `ark.*` (raw waverpc) and `swap.*`
    (`swapruntime` build only).
 
-If the daemon is built without the `wavewalletrpc` tag, the seven top-level
-verbs return a structured error pointing at `docs/wavewalletrpc_build.md`.
+If the daemon is built without the tags, the eight top-level verbs return a
+structured error pointing at `docs/wavewalletrpc_build.md`. Tier 2 and the
+`ark` and `recovery` subtrees are unaffected, since they ride on
+`waverpc.DaemonService`, which every build registers.
+
+`dev.*` is the one tier-3 subtree that is not all-or-nothing: it is a
+generated registry spanning six services, so availability is per service.
+
+| `dev` service | Default-tag daemon |
+|---|---|
+| `dev daemon` (`waverpc.DaemonService`) | works |
+| `dev wallet` (`wavewalletrpc.WalletService`) | `UNIMPLEMENTED: unknown service wavewalletrpc.WalletService` |
+| `dev wallet-inspection` (`wavewalletrpc.WalletInspectionService`) | same, for `WalletInspectionService` |
+| `dev swapclient` (`swapclientrpc.SwapClientService`) | `daemon was built without swapruntime support; rebuild waved with tags="swapruntime"` |
+
+The two `wavewalletrpc` services need both tags:
+`cmd/waved/wavewalletrpc_stub.go` is built under
+`!wavewalletrpc || !swapruntime`, so either tag alone still gets the stub,
+which registers nothing.
 
 ### Top-level wallet verbs
 
 ```bash
-# Status
+# Status (works against any daemon build)
 wavecli --network=regtest getinfo
 
 # Create + unlock (password from env, never argv).
@@ -143,6 +180,8 @@ wavecli --network=regtest activity --format json              # JSON output
 wavecli --network=regtest exit --outpoint TXID:VOUT
 wavecli --network=regtest exit status --outpoint TXID:VOUT
 ```
+
+Every verb in this block except `getinfo` needs a `wavewalletrpc` daemon.
 
 ### Advanced (`ark.*`) commands
 
@@ -215,6 +254,9 @@ echo -n 'pass' | wavecli --network=regtest unlock
 8. List VTXOs (once boarding completes):
    `wavecli --network=regtest ark vtxos list`
 
+Steps 3, 4, and 7 need a `wavewalletrpc` daemon (step 2). Only step 8 works
+against a default-tag build.
+
 ## Environment Variables
 
 | Variable | Description |
@@ -234,7 +276,7 @@ prefix, dots replaced by underscores (e.g., `WAVED_SERVER_HOST`).
 | `connection refused` | Daemon not running or wrong `--rpcserver` |
 | `wallet not ready` | Run `wavecli unlock` first |
 | `wallet already exists` | Wallet was already created; use `unlock` |
-| `daemon was not built with -tags wavewalletrpc` | Rebuild with `make build-wavewalletrpc`; the seven top-level verbs require the wavewalletrpc tag |
+| `daemon was not built with -tags wavewalletrpc` | Rebuild the **daemon** with `make build-wavewalletrpc` (both tags); all eight top-level wallet verbs plus the `mcp` wallet tools need them. `getinfo`, `schema`, `ark.*`, `recovery.*` and `dev daemon *` do not, so a default-tag daemon is not a broken one |
 | `--sweep-all requires --amt=0` | On `send --onchain`: pass `--sweep-all` for "drain wallet", or set `--amt N` |
 | `--offchain and --onchain are mutually exclusive` | Pick one direction on `send` / `recv` |
 | `GenSeed: lwwallet mode only` | Switch daemon to `--wallet.type=lwwallet` |

--- a/.claude/skills/waved.md
+++ b/.claude/skills/waved.md
@@ -1,4 +1,4 @@
-# waved / wavecli — Ark Client Daemon
+# waved / wavecli: Ark Client Daemon
 
 ## Overview
 
@@ -50,7 +50,7 @@ Full detail on the tags and what each one turns on:
 
 ## Starting the Daemon
 
-### lwwallet Mode (Standalone — No lnd Required)
+### lwwallet Mode (Standalone, No lnd Required)
 
 ```bash
 ./bin/waved \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,22 @@
 # Usage:
 #   docker build -t waved:local .
 #   docker run waved:local --network=regtest --wallet.type=lnd --lnd.host=lnd:10009
+#
+# The default build uses the default tag set, which excludes the swap and
+# wallet RPC subservers. To get the everyday wallet verbs (balance, send,
+# recv, activity, ...) the daemon needs both optional tags:
+#
+#   docker build --build-arg GOTAGS="wavewalletrpc swapruntime" -t waved:wallet .
 
 # --- Builder ---
 FROM golang:1.26.0-alpine AS builder
+
+# Optional Go build tags, taking the same space-separated value as the
+# Makefile's tags= parameter (see build-wavewalletrpc). Empty by default so an
+# unqualified `docker build` keeps producing the default tag set: no existing
+# image silently grows a wallet RPC surface. Note that wavewalletrpc requires
+# swapruntime alongside it; the pair is what the daemon checks.
+ARG GOTAGS=""
 
 RUN apk add --no-cache git
 
@@ -25,9 +38,10 @@ RUN go mod download
 # Copy full source (including baselib/ for replace directive).
 COPY . .
 
-# Build both binaries with CGO disabled for a static binary.
-RUN CGO_ENABLED=0 go build -trimpath -o /out/waved ./cmd/waved
-RUN CGO_ENABLED=0 go build -trimpath -o /out/wavecli ./cmd/wavecli
+# Build both binaries with CGO disabled for a static binary. Both get the same
+# tag set, mirroring the Makefile's build target.
+RUN CGO_ENABLED=0 go build -trimpath -tags="${GOTAGS}" -o /out/waved ./cmd/waved
+RUN CGO_ENABLED=0 go build -trimpath -tags="${GOTAGS}" -o /out/wavecli ./cmd/wavecli
 
 # --- Runtime ---
 FROM alpine:3.21


### PR DESCRIPTION
In this PR, we fix the stale instructions in the `waved-docker` and `waved`
skills, and give the Dockerfile a way to build with the optional tags so the
advice in those skills is actually reachable from a container.

The short version: the docker skill's two headline `wavecli` examples could
not connect at all, the one that could would still have failed on a missing
build tag, the full-stack section skipped both of the prerequisites that stop
a fresh clone, and there was no supported way to build an image whose `waved`
serves the wallet verbs.

See each commit message for the detailed description w.r.t the incremental
changes.

## docker: a GOTAGS build argument

Both `go build` lines were hard-coded with no `-tags`, so every image this
Dockerfile produced carried the default tag set. That is the reason `wavecli
balance` can never work against the compose regtest stack: lumos builds waved
from this Dockerfile, so the wallet RPC subserver is not linked in.

`GOTAGS` takes the same space-separated value as the Makefile's `tags=`
parameter, matching `make build-wavewalletrpc` rather than inventing a second
spelling. It defaults to empty, so nobody's existing image silently grows a
wallet RPC surface.

Verified both ways, same Dockerfile, two daemons on spare ports:

```
$ docker build --build-arg GOTAGS="wavewalletrpc swapruntime" -t waved:wallet .
$ wavecli balance                       # against that image
{
  "confirmed_sat": "0",
  "pending_in_sat": "0",
  "pending_out_sat": "0",
  "credit_available_sat": "0",
  "credit_reserved_sat": "0"
}
```

```
$ docker build -t waved:default .       # no --build-arg
$ wavecli balance                       # against that image
{
  "error": {
    "code": "EXECUTION_FAILED",
    "message": "daemon was not built with -tags wavewalletrpc; rebuild with `make build-wavewalletrpc` or see docs/wavewalletrpc_build.md"
  }
}
```

The tagged daemon also ran the swap DB migrations at startup and accepted
`wavecli create`, so `swapruntime` really is linked in and not just tolerated.

The default really is byte-for-byte the old behavior, at the level that
matters:

```
$ go list -f '{{.GoFiles}}' ./cmd/waved                        # no -tags flag
[main.go swapruntime_stub.go wavewalletrpc_stub.go]
$ go list -tags="" -f '{{.GoFiles}}' ./cmd/waved               # what GOTAGS defaults to
[main.go swapruntime_stub.go wavewalletrpc_stub.go]
$ go list -tags="wavewalletrpc swapruntime" -f '{{.GoFiles}}' ./cmd/waved
[main.go swapruntime.go wavewalletrpc.go]
```

Both binaries get the tags, mirroring the Makefile's build target.
`cmd/wavecli` has no tag-gated files today, so it is a no-op there, but
keeping them in step avoids a surprise if that changes.

## The wavecli examples could not connect

The docker skill offered these:

```
docker exec ark-client wavecli --rpcserver=localhost:10029 getinfo
docker exec ark-client wavecli --rpcserver=localhost:10029 balance
```

Both die before opening a socket. `--network` defaults to `mainnet` and is
what derives the default TLS cert and macaroon paths, so on a regtest daemon
wavecli goes looking in a directory that does not exist:

```
unable to load TLS cert: open /root/.waved/data/mainnet/tls.cert: no such file or directory
```

`--network=regtest` is the whole fix, because a stock waved serves TLS with
macaroon auth and has already written both credentials into that directory:

```
$ ls /root/.waved/data/regtest/
admin.macaroon  readonly.macaroon  tls.cert  tls.key

$ wavecli --network=regtest --rpcserver=localhost:10099 getinfo
{ "version": "0.1.99", "network": "regtest", "wallet_type": "lwwallet", ... }
```

So that is what every example in both skills now uses: `--network=regtest`
and nothing else, which is the configuration a reader following the Quick
Start actually has.

`--no-tls --no-macaroons` is still covered, but as a conditional: what to
pass **when the daemon was started with the matching `--rpc.notls
--rpc.no-macaroons`**. Two things worth keeping about that pair: they travel
together (`--no-tls` alone fails with `grpc: the credentials require
transport level security`), and with both set wavecli reads nothing off disk,
so `--network` stops mattering for the connection. The docs also warn against
reaching for them by reflex, since against a stock daemon they give `error
reading server preface: EOF`.

## The balance command needs both build tags

The docker skill listed `balance` right under `getinfo` as if they were
equivalent, which leaves a reader thinking the stack is broken. It is not.
The split, from `docs/wavewalletrpc_build.md`, the Makefile targets, and the
build tags under `cmd/`:

**Needs `wavewalletrpc` and `swapruntime` together:** the eight top-level
wallet verbs (`create`, `unlock`, `send`, `recv`, `activity`, `balance`,
`exit`, `wallet-sweep`), `activity inspect`, and the `mcp` server's wallet
tools. All route through `withWalletClient` /
`withWalletInspectionClient` in `cmd/wavecli/waveclicommands/wallet_client.go`.
Either tag alone is not enough: `cmd/waved/wavewalletrpc_stub.go` builds
under `!wavewalletrpc || !swapruntime` and registers nothing.

**Works on a default-tag daemon:** `getinfo`, `schema`, `mcp`, plus the `ark`
and `recovery` subtrees, both of which ride on `waverpc.DaemonService`.

`dev` needed more care than a subtree-wide verdict, since its generated
registry spans six services. Verified per service against a default-tag
daemon:

| `dev` service | Default-tag daemon |
|---|---|
| `dev daemon get-info` | real JSON |
| `dev wallet balance` | `UNIMPLEMENTED: unknown service wavewalletrpc.WalletService` |
| `dev wallet-inspection InspectActivity` | `UNIMPLEMENTED: unknown service wavewalletrpc.WalletInspectionService` |
| `dev swapclient list-swaps` | `daemon was built without swapruntime support` |

The gating is entirely daemon-side: `cmd/wavecli` carries no build tags, so
wavecli always registers the verbs (deliberately, so the CLI surface never
shifts under an agent) and maps the gRPC `Unimplemented` back to that
message. The fix is always to rebuild the daemon, never the CLI.

The verb count was also off by one. There are eight, not seven;
`wallet-sweep` joined the group and the prose never caught up.

## The full-stack section skipped two hard prerequisites

`LND_SOURCE` is required; compose will not even interpolate the file without
it:

```
$ env -u LND_SOURCE docker compose config
error while interpolating services.lnd-server.build.context: required variable
LND_SOURCE is missing a value: Set LND_SOURCE to the path of your lnd source tree
```

lumos's `client` submodule has to be initialized too. That submodule is this
repo, and both images reach into it: lumosd's Dockerfile copies
`client/go.mod`, `client/go.sum`, and `client/baselib/go.sum`, while the
`waved` service builds with `context: ./client`. Uninitialized, the lumosd
build dies on `"/client/baselib/go.sum": not found` and the waved build on
the empty context (`failed to read dockerfile: open Dockerfile: no such file
or directory`).

We also switch the compose invocations to `docker compose`; the standalone
hyphenated binary is not shipped with Docker Desktop any more, so the old
spelling is a plain command-not-found.

## The flag table

Validated row by row against `waved --help`. Two rows were wrong and one
incomplete:

- `--server.host` was documented with a `localhost:10010` default. The flag
  has no baked-in default; an empty value resolves from a network+transport
  table at startup (`defaultNetworkEndpoints` in `waved/config.go`), and only
  mainnet, regtest, and simnet land on `localhost:10010`.
- `--wallet.type` listed only `lnd` and `lwwallet`. There are three:
  `unknown wallet type "nosuchwallet", valid values: lnd, lwwallet, btcwallet`.
- `--debuglevel` was missing `critical`.

Removed flags check out:

```
$ waved --network=regtest --server.localmailboxid=client1
Error: unknown flag: --server.localmailboxid
```

`waved/server.go` derives both mailbox identifiers internally now.
`--rpc.notls` and `--rpc.no-macaroons` join the table, and the prose pins
down what they do relative to `--server.insecure` (outbound leg to the
operator, versus waved's own listener), since conflating those is what
produces the confusing handshake errors.

## Other stale claims found along the way

All in `waved.md`, same class of bug:

- The JSON story was backwards. `--request-json` carries the payload, and
  `--json` is an output bool that exactly two commands read: `activity` and
  `activity inspect`, the only two with a `--format` flag. Everything else
  renders through `printJSON` with no switch, so an agent can parse the
  default output almost everywhere and `--json` is inert outside those two.
- Piped stdin is no longer an implicit password source. The order is env var,
  then `--wallet-password-file`, then an explicit `--password-stdin`, then the
  interactive prompt, so the documented `echo -n 'pass' | wavecli unlock`
  fails with `wallet password input required`.
- The `swap.*` subtree is gone: `wavecli swap list` returns `unknown command
  "swap" for "wavecli"`. `recovery.*` was undocumented and `dev.*` was filed
  under introspection rather than advanced.
- `--macaroonpath` is inert while `--no-macaroons` is set
  (`client.go:78`: `if !noMacaroons && macaroonPath != ""`), so the
  `expected 1 macaroon, got 0` remedy now says to drop `--no-macaroons` or
  disable enforcement on the daemon, and names the trap.

## How the two daemon configurations were verified

Each error row was checked against the daemon config it applies to, not
generalized from one stack. Both daemons were ones I started myself on spare
ports, off the regtest stack's docker network.

| Invocation | Default-config waved (TLS + macaroons) |
|---|---|
| no `--network` | `unable to load TLS cert: .../data/mainnet/tls.cert: no such file` |
| `--network=regtest` | real JSON |
| `--network=regtest --no-tls --no-macaroons` | `error reading server preface: EOF` |
| `--network=regtest --no-macaroons` | `expected 1 macaroon, got 0` |

| Invocation | Plaintext waved (`--rpc.notls --rpc.no-macaroons`) |
|---|---|
| `--network=regtest` | `tls: first record does not look like a TLS handshake` |
| `--network=regtest --no-tls` | `grpc: the credentials require transport level security` |
| `--network=regtest --no-tls --no-macaroons` | real JSON |

## What is verified from source rather than a running binary

`--request-json` and `--password-stdin` come from `root.go`,
`json_input.go`, and `wallet_password.go` on `main`. The pre-existing
`waved:local` image predates both, and I did not rebuild a third image just
for them.

I ran `balance`, `activity`, and `recv --onchain` against a default-tag
daemon and got the build-tag error from each, and did not fire `send`,
`wallet-sweep`, or `exit` at a live stack; they gate through the same
`withWalletClient` helper.

`--lnd.host=<lnd-host>:10009` is left as-is in the standalone example. That
is lnd's default gRPC port and the flag default; lumos's compose happens to
use `10010`.

## Follow-up

lumos's `docker-compose.yml` on `master` still passes the removed mailbox
flags (`--server.localmailboxid=client-01`,
`--server.remotemailboxid=server-01` on the `waved` service), which is a hard
startup failure against a current client. Already handled on the in-flight
`fix/docker-regtest-stack` branch, which drops both. That branch could also
point the `waved` service at a `GOTAGS`-built image now that this PR adds the
argument, which would make `balance` work out of the box on the regtest
stack.
