### PR TITLE
round: arm the status-reconcile clock for every checkpointed round

### DIFF
--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -25,8 +25,15 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
 - `RoundStore` / `RoundPersistenceStore` — round-state interface +
   concrete `BatchedTx[RoundStore]`-backed store
   (`InsertRound`/`Get`/`GetByCommitmentTxid`/`ListActive`/`ListByStatus`/
-  `UpdateStatus`/`Finalize` plus boarding-intent / VTXO-request /
-  client-tree queries).
+  `UpdateStatus`/`Finalize`/`FailRound` plus boarding-intent /
+  VTXO-request / client-tree queries).
+- `RoundPersistenceStore.FailRound(ctx, roundID)` — terminal-failure
+  counterpart to `FinalizeRound`. In one transaction it moves the round
+  row to `failed` and returns every boarding intent that round adopted
+  to `confirmed`. It is the exact inverse of the `CommitState`
+  checkpoint write, and shares that write's transaction for the same
+  reason: the round row and the intent statuses are a single fact about
+  where the deposit lives.
 - `RoundSummary` / `VTXOSummary` — lightweight projections for
   paginated listing (avoids deserializing full trees).
 - `VTXOPersistenceStore` — VTXO descriptor store
@@ -139,6 +146,21 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
 - Transaction atomicity: entire checkpoint succeeds or none.
 - Boarding intents persist from registration until round completion
   or failure.
+- A dead round returns its adopted boarding intents to `confirmed`, not
+  `failed` (wavelength#1051). A round that never broadcast its
+  commitment leaves the boarding UTXO exactly as it was, so `confirmed`
+  is the truthful status: it returns the deposit to the boardable pool
+  and makes it sweepable again, since `boardingIntentSweepable` excludes
+  `adopted` and would otherwise never sweep the intent, CSV expiry or
+  not.
+- `FailRound` is safe to call on any round, because two guards decide
+  whether anything moves. The round update matches only a row still at
+  `input_sig_sent`, and the deposits are released only if it did, so a
+  round whose commitment confirmed keeps its intents (they remain
+  literally `adopted`; the listing queries hide them by joining on round
+  status rather than by rewriting them). The intent update is scoped to
+  that round's own adopted intents, so it can neither release a deposit
+  another round has since taken nor clobber a sweep already in flight.
 - `boarding_sweeps` rows are never deleted; the daemon resumes
   spend-watch and rebroadcast on restart from
   `ListPendingBoardingSweeps`. `MarkBoardingSweepFailed` restores

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -25,8 +25,15 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
 - `RoundStore` / `RoundPersistenceStore` — round-state interface +
   concrete `BatchedTx[RoundStore]`-backed store
   (`InsertRound`/`Get`/`GetByCommitmentTxid`/`ListActive`/`ListByStatus`/
-  `UpdateStatus`/`Finalize` plus boarding-intent / VTXO-request /
-  client-tree queries).
+  `UpdateStatus`/`Finalize`/`FailRound` plus boarding-intent /
+  VTXO-request / client-tree queries).
+- `RoundPersistenceStore.FailRound(ctx, roundID)` — terminal-failure
+  counterpart to `FinalizeRound`. In one transaction it moves the round
+  row to `failed` and returns every boarding intent that round adopted
+  to `confirmed`. It is the exact inverse of the `CommitState`
+  checkpoint write, and shares that write's transaction for the same
+  reason: the round row and the intent statuses are a single fact about
+  where the deposit lives.
 - `RoundSummary` / `VTXOSummary` — lightweight projections for
   paginated listing (avoids deserializing full trees).
 - `VTXOPersistenceStore` — VTXO descriptor store
@@ -139,6 +146,21 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
 - Transaction atomicity: entire checkpoint succeeds or none.
 - Boarding intents persist from registration until round completion
   or failure.
+- A dead round returns its adopted boarding intents to `confirmed`, not
+  `failed` (wavelength#1051). A round that never broadcast its
+  commitment leaves the boarding UTXO exactly as it was, so `confirmed`
+  is the truthful status: it returns the deposit to the boardable pool
+  and makes it sweepable again, since `boardingIntentSweepable` excludes
+  `adopted` and would otherwise never sweep the intent, CSV expiry or
+  not.
+- `FailRound` is safe to call on any round, because two guards decide
+  whether anything moves. The round update matches only a row still at
+  `input_sig_sent`, and the deposits are released only if it did, so a
+  round whose commitment confirmed keeps its intents (they remain
+  literally `adopted`; the listing queries hide them by joining on round
+  status rather than by rewriting them). The intent update is scoped to
+  that round's own adopted intents, so it can neither release a deposit
+  another round has since taken nor clobber a sweep already in flight.
 - `boarding_sweeps` rows are never deleted; the daemon resumes
   spend-watch and rebroadcast on restart from
   `ListPendingBoardingSweeps`. `MarkBoardingSweepFailed` restores

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -214,6 +214,11 @@ type RoundStore interface {
 	UpdateBoardingIntentStatus(ctx context.Context,
 		arg sqlc.UpdateBoardingIntentStatusParams) error
 
+	FailRound(ctx context.Context, arg sqlc.FailRoundParams) (int64, error)
+
+	RevertRoundAdoptedBoardingIntents(ctx context.Context,
+		arg sqlc.RevertRoundAdoptedBoardingIntentsParams) error
+
 	// ClearPendingIntentAnchorByOutpoint deletes the pending-intent
 	// anchor row bound to one outpoint. Called from CommitState in the
 	// same transaction that records the round adopting the anchored
@@ -851,6 +856,71 @@ func (s *RoundPersistenceStore) FinalizeRound(ctx context.Context,
 		}
 
 		return q.FinalizeRound(ctx, params)
+	})
+}
+
+// FailRound retires a checkpointed round whose fate is known to be dead, and
+// returns the boarding intents it adopted to the live pool.
+//
+// This is the exact inverse of the checkpoint write in CommitState, and it
+// runs in one transaction for the same reason that one does: the round row
+// and the intent statuses are a single fact about where the deposit lives,
+// and a crash between the two halves would leave the deposit accounted for in
+// a round that no longer exists.
+//
+// Intents revert to 'confirmed' rather than 'failed'. Nothing on-chain
+// failed: a dead round proves the commitment was never broadcast, so the
+// boarding UTXO is exactly as it was before the round started. 'confirmed'
+// restores that truth, which both returns the deposit to the boardable pool
+// and makes it sweepable again (boardingIntentSweepable excludes 'adopted',
+// so an intent left adopted by a dead round is never swept, with or without
+// its CSV expiring).
+//
+// That revert is only ever safe for a round that never broadcast, so the
+// write is guarded twice over: the round must still be at the checkpoint for
+// anything to move at all, and the deposits released are only those this
+// round adopted and that no sweep has since claimed. Callers are expected to
+// hold an authoritative dead verdict, but the guards mean a misrouted call
+// costs nothing rather than resurrecting a spent deposit.
+func (s *RoundPersistenceStore) FailRound(ctx context.Context,
+	roundID round.RoundID) error {
+
+	writeTxOpts := WriteTxOption()
+	nowUnix := s.clock.Now().Unix()
+	roundIDStr := roundID.String()
+
+	return s.db.ExecTx(ctx, writeTxOpts, func(q RoundStore) error {
+		// Retire the round first and let its guard decide whether the
+		// deposits move at all. FailRound only matches a row still
+		// sitting at the checkpoint, so a round that confirmed, or one
+		// already retired, reports zero rows here and we leave its
+		// intents untouched. Releasing first and checking after would
+		// invert that: a deposit spent by a confirmed commitment would
+		// be handed back to the boardable pool before we discovered
+		// the round was not ours to retire.
+		rows, err := q.FailRound(ctx, sqlc.FailRoundParams{
+			RoundID:        roundIDStr,
+			LastUpdateTime: nowUnix,
+		})
+		if err != nil {
+			return fmt.Errorf("retire round: %w", err)
+		}
+
+		if rows == 0 {
+			return nil
+		}
+
+		err = q.RevertRoundAdoptedBoardingIntents(
+			ctx, sqlc.RevertRoundAdoptedBoardingIntentsParams{
+				RoundID:        roundIDStr,
+				LastUpdateTime: nowUnix,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("release round deposits: %w", err)
+		}
+
+		return nil
 	})
 }
 

--- a/db/round_store_test.go
+++ b/db/round_store_test.go
@@ -2172,3 +2172,216 @@ func TestOrphanSweepKeepsFailedSendRecord(t *testing.T) {
 	require.Len(t, remaining, 1)
 	require.Equal(t, retry.ID, remaining[0].ID)
 }
+
+// newRoundAndBoardingStoresForTest builds a round store and a boarding wallet
+// store over one database. FailRound spans both domains, since it retires the
+// round row and returns the deposits that row adopted, so a test that reads
+// the deposit back has to see the same rows the round store wrote.
+func newRoundAndBoardingStoresForTest(t *testing.T) (*RoundPersistenceStore,
+	*BoardingWalletStore, *BaseDB) {
+
+	t.Helper()
+
+	db := NewTestDB(t)
+	testClock := clock.NewDefaultClock()
+
+	roundDB := NewTransactionExecutor(
+		db.BaseDB,
+		func(tx *sql.Tx) RoundStore {
+			return db.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+	boardingDB := NewTransactionExecutor(
+		db.BaseDB,
+		func(tx *sql.Tx) BoardingStore {
+			return db.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+	intentDB := NewTransactionExecutor(
+		db.BaseDB,
+		func(tx *sql.Tx) PendingIntentStore {
+			return db.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+
+	roundStore := NewRoundPersistenceStore(
+		roundDB, &chaincfg.RegressionNetParams, testClock,
+	)
+	boardingStore := NewBoardingWalletStore(
+		boardingDB, intentDB, &chaincfg.RegressionNetParams, testClock,
+	)
+
+	return roundStore, boardingStore, db.BaseDB
+}
+
+// TestRoundStoreFailRoundReleasesDeposit is the money half of
+// wavelength#1051. Arming the reconcile clock un-parks the client FSM, but a
+// dead round still has to give the deposit back, and until FailRound existed
+// nothing did: the checkpoint row stayed in ListActiveRounds and the intent
+// stayed adopted, which keeps it out of both the sweep and the boardable pool
+// permanently, with or without its CSV expiring.
+//
+// The recovery machinery was already built. ListBoardingIntentsByStatus and
+// ListBoardingIntentsBySweepableStatuses both re-admit a confirmed intent
+// exactly when its linked round reads 'failed'; nothing ever wrote that
+// status, so the path was unreachable.
+func TestRoundStoreFailRoundReleasesDeposit(t *testing.T) {
+	t.Parallel()
+
+	roundStore, boardingStore, db := newRoundAndBoardingStoresForTest(t)
+	ctx := t.Context()
+
+	// A confirmed deposit, adopted by a round that reached the checkpoint
+	// and then died.
+	intent := createSweepStoreIntent(t, boardingStore)
+	deadRound := testRoundIDDB("dead-deposit")
+	insertRoundBoardingIntentForTest(
+		t, db, deadRound.String(),
+		"input_sig_sent", intent,
+	)
+	require.NoError(
+		t, boardingStore.UpdateBoardingIntentStatus(
+			ctx, intent.Outpoint, wallet.BoardingStatusAdopted,
+		),
+	)
+
+	// While the round is live the deposit is correctly invisible: it is
+	// committed to a round, so it is neither boardable nor sweepable.
+	assertDepositRecoverable(t, boardingStore, intent, false)
+
+	require.NoError(t, roundStore.FailRound(ctx, deadRound))
+
+	// The round no longer re-hydrates on startup.
+	active, err := roundStore.ListActiveRounds(ctx)
+	require.NoError(t, err)
+	require.Empty(t, active, "dead round still reloads on every start")
+
+	// And the deposit is back: boardable for a retry, sweepable for an
+	// on-chain exit, and no longer pinned against the board limit.
+	assertDepositRecoverable(t, boardingStore, intent, true)
+
+	adopted, err := boardingStore.FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusAdopted,
+	)
+	require.NoError(t, err)
+	require.Empty(
+		t, adopted, "deposit still counted against the board limit "+
+			"after its round died",
+	)
+}
+
+// assertDepositRecoverable checks both recovery routes for a deposit at once:
+// whether it can be boarded again, and whether it can be swept back on-chain.
+func assertDepositRecoverable(t *testing.T, store *BoardingWalletStore,
+	intent wallet.BoardingIntent, want bool) {
+
+	t.Helper()
+
+	ctx := t.Context()
+
+	confirmed, err := store.FetchBoardingIntentsByStatus(
+		ctx, wallet.BoardingStatusConfirmed,
+	)
+	require.NoError(t, err)
+
+	sweepable, err := store.FetchBoardingIntentsBySweepableStatuses(
+		ctx, []wallet.BoardingStatus{
+			wallet.BoardingStatusConfirmed,
+			wallet.BoardingStatusFailed,
+			wallet.BoardingStatusExpired,
+		},
+	)
+	require.NoError(t, err)
+
+	require.Lenf(
+		t, confirmed, boolToLen(want),
+		"boardable = %v, want %v", len(confirmed) > 0, want,
+	)
+	require.Lenf(
+		t, sweepable, boolToLen(want),
+		"sweepable = %v, want %v", len(sweepable) > 0, want,
+	)
+
+	if want {
+		require.Equal(t, intent.Outpoint, confirmed[0].Outpoint)
+		require.Equal(t, intent.Outpoint, sweepable[0].Outpoint)
+	}
+}
+
+// boolToLen maps an expectation about presence onto the expected slice length.
+func boolToLen(present bool) int {
+	if present {
+		return 1
+	}
+
+	return 0
+}
+
+// TestRoundStoreFailRoundLeavesSweptDepositAlone pins the guard on the
+// revert: the SQL only moves an intent that is still 'adopted', so a deposit
+// a sweep has already claimed is not dragged back into the boardable pool by
+// a late round retirement.
+func TestRoundStoreFailRoundLeavesSweptDepositAlone(t *testing.T) {
+	t.Parallel()
+
+	roundStore, boardingStore, db := newRoundAndBoardingStoresForTest(t)
+	ctx := t.Context()
+
+	intent := createSweepStoreIntent(t, boardingStore)
+	sweptRound := testRoundIDDB("already-swept")
+	insertRoundBoardingIntentForTest(
+		t, db, sweptRound.String(),
+		"input_sig_sent", intent,
+	)
+	require.NoError(
+		t, boardingStore.UpdateBoardingIntentStatus(
+			ctx, intent.Outpoint, wallet.BoardingStatusSweepPending,
+		),
+	)
+
+	require.NoError(t, roundStore.FailRound(ctx, sweptRound))
+
+	got, err := boardingStore.GetIntent(ctx, intent.Outpoint)
+	require.NoError(t, err)
+	require.Equal(
+		t, wallet.BoardingStatusSweepPending, got.Status,
+		"round retirement clobbered an in-flight sweep",
+	)
+}
+
+// TestRoundStoreFailRoundLeavesConfirmedRoundAlone pins the guard that makes
+// FailRound safe to call on any round. A confirmed round's intents are still
+// literally 'adopted' in the table (the listing queries hide them by joining
+// on round status rather than by rewriting them), so an unguarded revert would
+// hand back a deposit the commitment already spent. The round update matches
+// only a row still at the checkpoint, and the deposits move only if it did.
+func TestRoundStoreFailRoundLeavesConfirmedRoundAlone(t *testing.T) {
+	t.Parallel()
+
+	roundStore, boardingStore, db := newRoundAndBoardingStoresForTest(t)
+	ctx := t.Context()
+
+	intent := createSweepStoreIntent(t, boardingStore)
+	confirmedRound := testRoundIDDB("already-confirmed")
+	insertRoundBoardingIntentForTest(
+		t, db, confirmedRound.String(),
+		"confirmed", intent,
+	)
+	require.NoError(
+		t, boardingStore.UpdateBoardingIntentStatus(
+			ctx, intent.Outpoint, wallet.BoardingStatusAdopted,
+		),
+	)
+
+	require.NoError(t, roundStore.FailRound(ctx, confirmedRound))
+
+	got, err := boardingStore.GetIntent(ctx, intent.Outpoint)
+	require.NoError(t, err)
+	require.Equal(
+		t, wallet.BoardingStatusAdopted, got.Status,
+		"retirement resurrected a deposit spent by a confirmed round",
+	)
+}

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -77,6 +77,16 @@ type Querier interface {
 	// finalized lineage on top of a partially-written round-create row.
 	DeleteVTXOAncestryPaths(ctx context.Context, arg DeleteVTXOAncestryPathsParams) error
 	EscalateVHTLCRecoveryJob(ctx context.Context, arg EscalateVHTLCRecoveryJobParams) (int64, error)
+	// Retires a checkpointed round whose fate is known to be dead. Moving the row
+	// out of 'input_sig_sent' is what stops ListActiveRounds re-hydrating it on
+	// every start.
+	//
+	// The status guard is load-bearing, not defensive: it is what makes the
+	// retirement unable to touch a round whose commitment confirmed. Only a round
+	// still sitting at the checkpoint can be retired, so a stale or misrouted call
+	// against a confirmed round reports zero rows and the caller leaves its
+	// deposits alone.
+	FailRound(ctx context.Context, arg FailRoundParams) (int64, error)
 	FailVHTLCRecoveryJob(ctx context.Context, arg FailVHTLCRecoveryJobParams) (int64, error)
 	FinalizeRound(ctx context.Context, arg FinalizeRoundParams) error
 	// GetActivityEntry returns one entry by its canonical id.
@@ -387,6 +397,15 @@ type Querier interface {
 	// budget. The exact kind, failed status, and legacy error guard prevent this
 	// compatibility repair from weakening the normal terminal-to-pending rule.
 	RepairCreditReceivePollCapActivity(ctx context.Context, arg RepairCreditReceivePollCapActivityParams) (int64, error)
+	// Returns every boarding intent adopted by one dead round to 'confirmed'. The
+	// commitment never broadcast, so the UTXO is exactly as it was before the
+	// round: re-boardable, and sweepable again.
+	//
+	// Two guards. The 'adopted' predicate means a sweep that has already moved an
+	// intent on is never clobbered. The EXISTS binds the revert to intents this
+	// round actually adopted, so a round can never release a deposit another round
+	// has since taken.
+	RevertRoundAdoptedBoardingIntents(ctx context.Context, arg RevertRoundAdoptedBoardingIntentsParams) error
 	SumBoardingIntentAmountsByStatus(ctx context.Context, status string) (interface{}, error)
 	SumUnspentVTXOAmounts(ctx context.Context) (interface{}, error)
 	UpdateBoardingIntentStatus(ctx context.Context, arg UpdateBoardingIntentStatusParams) error

--- a/db/sqlc/queries/round.sql
+++ b/db/sqlc/queries/round.sql
@@ -59,6 +59,40 @@ SET status = 'confirmed',
     last_update_time = $5
 WHERE round_id = $1;
 
+-- name: FailRound :execrows
+-- Retires a checkpointed round whose fate is known to be dead. Moving the row
+-- out of 'input_sig_sent' is what stops ListActiveRounds re-hydrating it on
+-- every start.
+--
+-- The status guard is load-bearing, not defensive: it is what makes the
+-- retirement unable to touch a round whose commitment confirmed. Only a round
+-- still sitting at the checkpoint can be retired, so a stale or misrouted call
+-- against a confirmed round reports zero rows and the caller leaves its
+-- deposits alone.
+UPDATE rounds
+SET status = 'failed',
+    last_update_time = $2
+WHERE round_id = $1 AND status = 'input_sig_sent';
+
+-- name: RevertRoundAdoptedBoardingIntents :exec
+-- Returns every boarding intent adopted by one dead round to 'confirmed'. The
+-- commitment never broadcast, so the UTXO is exactly as it was before the
+-- round: re-boardable, and sweepable again.
+--
+-- Two guards. The 'adopted' predicate means a sweep that has already moved an
+-- intent on is never clobbered. The EXISTS binds the revert to intents this
+-- round actually adopted, so a round can never release a deposit another round
+-- has since taken.
+UPDATE boarding_intents
+SET status = 'confirmed', last_update_time = $2
+WHERE status = 'adopted'
+  AND EXISTS (
+    SELECT 1 FROM round_boarding_intents rbi
+    WHERE rbi.round_id = $1
+      AND rbi.outpoint_hash = boarding_intents.outpoint_hash
+      AND rbi.outpoint_index = boarding_intents.outpoint_index
+  );
+
 -- Round boarding intents queries.
 
 -- name: InsertRoundBoardingIntent :exec

--- a/db/sqlc/round.sql.go
+++ b/db/sqlc/round.sql.go
@@ -55,6 +55,35 @@ func (q *Queries) DeleteVTXOAncestryPaths(ctx context.Context, arg DeleteVTXOAnc
 	return err
 }
 
+const FailRound = `-- name: FailRound :execrows
+UPDATE rounds
+SET status = 'failed',
+    last_update_time = $2
+WHERE round_id = $1 AND status = 'input_sig_sent'
+`
+
+type FailRoundParams struct {
+	RoundID        string
+	LastUpdateTime int64
+}
+
+// Retires a checkpointed round whose fate is known to be dead. Moving the row
+// out of 'input_sig_sent' is what stops ListActiveRounds re-hydrating it on
+// every start.
+//
+// The status guard is load-bearing, not defensive: it is what makes the
+// retirement unable to touch a round whose commitment confirmed. Only a round
+// still sitting at the checkpoint can be retired, so a stale or misrouted call
+// against a confirmed round reports zero rows and the caller leaves its
+// deposits alone.
+func (q *Queries) FailRound(ctx context.Context, arg FailRoundParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, FailRound, arg.RoundID, arg.LastUpdateTime)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const FinalizeRound = `-- name: FinalizeRound :exec
 UPDATE rounds
 SET status = 'confirmed',
@@ -1158,6 +1187,36 @@ type MarkVTXOSpentParams struct {
 // Also sets status = 4 (Spent) to keep status in sync with spent flag.
 func (q *Queries) MarkVTXOSpent(ctx context.Context, arg MarkVTXOSpentParams) error {
 	_, err := q.db.ExecContext(ctx, MarkVTXOSpent, arg.OutpointHash, arg.OutpointIndex, arg.LastUpdateTime)
+	return err
+}
+
+const RevertRoundAdoptedBoardingIntents = `-- name: RevertRoundAdoptedBoardingIntents :exec
+UPDATE boarding_intents
+SET status = 'confirmed', last_update_time = $2
+WHERE status = 'adopted'
+  AND EXISTS (
+    SELECT 1 FROM round_boarding_intents rbi
+    WHERE rbi.round_id = $1
+      AND rbi.outpoint_hash = boarding_intents.outpoint_hash
+      AND rbi.outpoint_index = boarding_intents.outpoint_index
+  )
+`
+
+type RevertRoundAdoptedBoardingIntentsParams struct {
+	RoundID        string
+	LastUpdateTime int64
+}
+
+// Returns every boarding intent adopted by one dead round to 'confirmed'. The
+// commitment never broadcast, so the UTXO is exactly as it was before the
+// round: re-boardable, and sweepable again.
+//
+// Two guards. The 'adopted' predicate means a sweep that has already moved an
+// intent on is never clobbered. The EXISTS binds the revert to intents this
+// round actually adopted, so a round can never release a deposit another round
+// has since taken.
+func (q *Queries) RevertRoundAdoptedBoardingIntents(ctx context.Context, arg RevertRoundAdoptedBoardingIntentsParams) error {
+	_, err := q.db.ExecContext(ctx, RevertRoundAdoptedBoardingIntents, arg.RoundID, arg.LastUpdateTime)
 	return err
 }
 

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -65,6 +65,10 @@ state transitions and validation rules live under [Invariants](#invariants).
   Called at intent-build time for change/refresh outputs and inside
   `handleRegisterIntent` for entries with a non-zero `KeyLocator`.
 - `VTXOStore`, `RoundStore` — VTXO and round FSM persistence.
+  `RoundStore.FailRound(ctx, roundID)` is the terminal-failure
+  counterpart to `FinalizeRound`: it retires a checkpointed round's row
+  and returns the boarding intents it adopted to the live pool
+  (wavelength#1051).
 
 ### Actor Layer (`actor.go`, `actor_messages.go`, `vtxo_messages.go`)
 
@@ -185,13 +189,24 @@ state transitions and validation rules live under [Invariants](#invariants).
   exit disarms it. There are three doors: `forfeitCollectionOutbox`
   (forfeit-bearing rounds), the `PartialSigsSentState` →
   `InputSigSentState` transition (boarding-only rounds, which never enter
-  forfeit collection), and `recoverActiveRounds` on restart. Arming is
+  forfeit collection), and the `ListActiveRounds` resume loop in
+  `RoundClientActor.Start` on restart. Arming is
   **not** gated on `len(Intents.Forfeits) > 0`: for a forfeit-bearing round
   the probe gates the reservation release on an authoritative dead answer,
   but for *any* round it is the sole liveness clock in the checkpointed
   state — an operator that rolls the round back before broadcast produces
   no confirmation and no failure, so an unarmed boarding-only round strands
   its deposit until the CSV expires.
+- **Only an authoritative dead answer retires a round.** The dead-answer
+  exit from `InputSigSentState` is the one that emits
+  `RoundFailedNotification`, which is what drives the actor's
+  `retireFailedRound` and so the durable `FailRound` write. The other
+  exits stay silent deliberately: the delivered-failure shortcut is also
+  where `handleCancelRound` injects a synthetic `BoardingFailed`, and a
+  local cancel proves nothing about the operator, while the confirmation
+  exits have a commitment on chain and so a spent deposit. Only the
+  operator's dead verdict rules the commitment out, which is the same
+  trust boundary the wavelength#844 forfeit release already accepts.
 - **Reconcile outbox ordering.** `processOutbox` abandons the rest of the
   outbox on the first failing `Tell`, and the FSM has already checkpointed
   by dispatch time, so the arm (`StartTimeoutReq`) must **lead** the

--- a/round/AGENTS.md
+++ b/round/AGENTS.md
@@ -93,10 +93,16 @@ state transitions and validation rules live under [Invariants](#invariants).
 ### Misc
 
 - `TimeoutPhase` (`fsm_timeouts.go`) — `TimeoutPhaseForfeitCollection`
-  (forfeit-signature collection window) and `TimeoutPhaseRegistration`
+  (forfeit-signature collection window), `TimeoutPhaseRegistration`
   (IntentSentState admission window; on expiry the FSM fails the round
   recoverably and emits `ReleaseForfeitReservation` so forfeit-reserved
-  inputs are not stranded — wavelength#653). Timeout outbox messages
+  inputs are not stranded — wavelength#653),
+  `TimeoutPhaseRefreshRegistration` (quiet period that coalesces
+  expiry-driven refreshes before registering their assembling round), and
+  `TimeoutPhaseStatusReconcile` (InputSigSentState liveness clock; on expiry
+  the FSM probes the operator with `QueryRoundStatus` and re-arms with
+  exponential backoff capped at `statusReconcileMaxBackoffShift` — see the
+  reconcile invariant below). Timeout outbox messages
   (`StartTimeoutReq`/`CancelTimeoutReq`) key on `RoundKeyStr` so temp-keyed
   rounds (pre-admission) can be timed.
 - `MaxQuoteEntriesPerClient = 1024` (`from_proto.go`) — bounds quote
@@ -114,6 +120,12 @@ state transitions and validation rules live under [Invariants](#invariants).
   selects `defaultRegistrationTimeout` (60 s); negative disables the timeout
   (round waits indefinitely). Bounds how long forfeit-reserved inputs sit
   stranded when the server never responds (wavelength#653).
+- `RoundClientConfig.StatusReconcileTimeout` — how long `InputSigSentState`
+  waits with no confirmation, no resolved failure, and no status answer
+  before probing the operator with `QueryRoundStatus` (wavelength#844); it
+  doubles as the retry interval between probes. Zero selects
+  `defaultStatusReconcileTimeout` (90 s); negative disables the reconcile
+  entirely, leaving only the wavelength#823 startup sweep.
 - `computeClientOperatorFee(intents, ownedVTXOs) int64` —
   Σ(boarding inputs) + Σ(forfeited VTXOs) − Σ(owned output VTXOs) −
   Σ(cooperative leave outputs), clamped to zero. Carried on
@@ -167,6 +179,31 @@ state transitions and validation rules live under [Invariants](#invariants).
 - Round state is checkpointed atomically after tree validation — a
   crash before checkpoint means the client has no record of sent
   signatures.
+- **The status-reconcile clock is armed for the whole of
+  `InputSigSentState`** (wavelength#844, wavelength#1051). Every door into
+  that state arms it whenever `env.StatusReconcileTimeout > 0`, and every
+  exit disarms it. There are three doors: `forfeitCollectionOutbox`
+  (forfeit-bearing rounds), the `PartialSigsSentState` →
+  `InputSigSentState` transition (boarding-only rounds, which never enter
+  forfeit collection), and `recoverActiveRounds` on restart. Arming is
+  **not** gated on `len(Intents.Forfeits) > 0`: for a forfeit-bearing round
+  the probe gates the reservation release on an authoritative dead answer,
+  but for *any* round it is the sole liveness clock in the checkpointed
+  state — an operator that rolls the round back before broadcast produces
+  no confirmation and no failure, so an unarmed boarding-only round strands
+  its deposit until the CSV expires.
+- **Reconcile outbox ordering.** `processOutbox` abandons the rest of the
+  outbox on the first failing `Tell`, and the FSM has already checkpointed
+  by dispatch time, so the arm (`StartTimeoutReq`) must **lead** the
+  fallible sends (`SubmitVTXOForfeitSigsToServer`,
+  `SubmitForfeitSigRequest`, `RegisterConfirmationRequest`) — a mid-flight
+  send error would otherwise commit the state with no clock. The disarm
+  (`CancelTimeoutReq`, via `reconcileDisarmEvents` /
+  `appendReconcileDisarm` in `fsm_timeouts.go`) must **trail** every
+  delivery on the exit paths — confirmation notifications, the forfeit
+  release, and the terminal job drop — since cleanup must never gate
+  delivery. A cancel that never lands only leaks a one-shot timer, which
+  fires into a terminal state and self-loops.
 - Primary FSM handles interactive phases (through `InputSigSent`); a
   dedicated FSM per round handles confirmation monitoring.
 - **Arm timeouts before fallible outbox effects.** `processOutbox` stops at the

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -65,6 +65,10 @@ state transitions and validation rules live under [Invariants](#invariants).
   Called at intent-build time for change/refresh outputs and inside
   `handleRegisterIntent` for entries with a non-zero `KeyLocator`.
 - `VTXOStore`, `RoundStore` — VTXO and round FSM persistence.
+  `RoundStore.FailRound(ctx, roundID)` is the terminal-failure
+  counterpart to `FinalizeRound`: it retires a checkpointed round's row
+  and returns the boarding intents it adopted to the live pool
+  (wavelength#1051).
 
 ### Actor Layer (`actor.go`, `actor_messages.go`, `vtxo_messages.go`)
 
@@ -185,13 +189,24 @@ state transitions and validation rules live under [Invariants](#invariants).
   exit disarms it. There are three doors: `forfeitCollectionOutbox`
   (forfeit-bearing rounds), the `PartialSigsSentState` →
   `InputSigSentState` transition (boarding-only rounds, which never enter
-  forfeit collection), and `recoverActiveRounds` on restart. Arming is
+  forfeit collection), and the `ListActiveRounds` resume loop in
+  `RoundClientActor.Start` on restart. Arming is
   **not** gated on `len(Intents.Forfeits) > 0`: for a forfeit-bearing round
   the probe gates the reservation release on an authoritative dead answer,
   but for *any* round it is the sole liveness clock in the checkpointed
   state — an operator that rolls the round back before broadcast produces
   no confirmation and no failure, so an unarmed boarding-only round strands
   its deposit until the CSV expires.
+- **Only an authoritative dead answer retires a round.** The dead-answer
+  exit from `InputSigSentState` is the one that emits
+  `RoundFailedNotification`, which is what drives the actor's
+  `retireFailedRound` and so the durable `FailRound` write. The other
+  exits stay silent deliberately: the delivered-failure shortcut is also
+  where `handleCancelRound` injects a synthetic `BoardingFailed`, and a
+  local cancel proves nothing about the operator, while the confirmation
+  exits have a commitment on chain and so a spent deposit. Only the
+  operator's dead verdict rules the commitment out, which is the same
+  trust boundary the wavelength#844 forfeit release already accepts.
 - **Reconcile outbox ordering.** `processOutbox` abandons the rest of the
   outbox on the first failing `Tell`, and the FSM has already checkpointed
   by dispatch time, so the arm (`StartTimeoutReq`) must **lead** the

--- a/round/CLAUDE.md
+++ b/round/CLAUDE.md
@@ -93,10 +93,16 @@ state transitions and validation rules live under [Invariants](#invariants).
 ### Misc
 
 - `TimeoutPhase` (`fsm_timeouts.go`) — `TimeoutPhaseForfeitCollection`
-  (forfeit-signature collection window) and `TimeoutPhaseRegistration`
+  (forfeit-signature collection window), `TimeoutPhaseRegistration`
   (IntentSentState admission window; on expiry the FSM fails the round
   recoverably and emits `ReleaseForfeitReservation` so forfeit-reserved
-  inputs are not stranded — wavelength#653). Timeout outbox messages
+  inputs are not stranded — wavelength#653),
+  `TimeoutPhaseRefreshRegistration` (quiet period that coalesces
+  expiry-driven refreshes before registering their assembling round), and
+  `TimeoutPhaseStatusReconcile` (InputSigSentState liveness clock; on expiry
+  the FSM probes the operator with `QueryRoundStatus` and re-arms with
+  exponential backoff capped at `statusReconcileMaxBackoffShift` — see the
+  reconcile invariant below). Timeout outbox messages
   (`StartTimeoutReq`/`CancelTimeoutReq`) key on `RoundKeyStr` so temp-keyed
   rounds (pre-admission) can be timed.
 - `MaxQuoteEntriesPerClient = 1024` (`from_proto.go`) — bounds quote
@@ -114,6 +120,12 @@ state transitions and validation rules live under [Invariants](#invariants).
   selects `defaultRegistrationTimeout` (60 s); negative disables the timeout
   (round waits indefinitely). Bounds how long forfeit-reserved inputs sit
   stranded when the server never responds (wavelength#653).
+- `RoundClientConfig.StatusReconcileTimeout` — how long `InputSigSentState`
+  waits with no confirmation, no resolved failure, and no status answer
+  before probing the operator with `QueryRoundStatus` (wavelength#844); it
+  doubles as the retry interval between probes. Zero selects
+  `defaultStatusReconcileTimeout` (90 s); negative disables the reconcile
+  entirely, leaving only the wavelength#823 startup sweep.
 - `computeClientOperatorFee(intents, ownedVTXOs) int64` —
   Σ(boarding inputs) + Σ(forfeited VTXOs) − Σ(owned output VTXOs) −
   Σ(cooperative leave outputs), clamped to zero. Carried on
@@ -167,6 +179,31 @@ state transitions and validation rules live under [Invariants](#invariants).
 - Round state is checkpointed atomically after tree validation — a
   crash before checkpoint means the client has no record of sent
   signatures.
+- **The status-reconcile clock is armed for the whole of
+  `InputSigSentState`** (wavelength#844, wavelength#1051). Every door into
+  that state arms it whenever `env.StatusReconcileTimeout > 0`, and every
+  exit disarms it. There are three doors: `forfeitCollectionOutbox`
+  (forfeit-bearing rounds), the `PartialSigsSentState` →
+  `InputSigSentState` transition (boarding-only rounds, which never enter
+  forfeit collection), and `recoverActiveRounds` on restart. Arming is
+  **not** gated on `len(Intents.Forfeits) > 0`: for a forfeit-bearing round
+  the probe gates the reservation release on an authoritative dead answer,
+  but for *any* round it is the sole liveness clock in the checkpointed
+  state — an operator that rolls the round back before broadcast produces
+  no confirmation and no failure, so an unarmed boarding-only round strands
+  its deposit until the CSV expires.
+- **Reconcile outbox ordering.** `processOutbox` abandons the rest of the
+  outbox on the first failing `Tell`, and the FSM has already checkpointed
+  by dispatch time, so the arm (`StartTimeoutReq`) must **lead** the
+  fallible sends (`SubmitVTXOForfeitSigsToServer`,
+  `SubmitForfeitSigRequest`, `RegisterConfirmationRequest`) — a mid-flight
+  send error would otherwise commit the state with no clock. The disarm
+  (`CancelTimeoutReq`, via `reconcileDisarmEvents` /
+  `appendReconcileDisarm` in `fsm_timeouts.go`) must **trail** every
+  delivery on the exit paths — confirmation notifications, the forfeit
+  release, and the terminal job drop — since cleanup must never gate
+  delivery. A cancel that never lands only leaks a one-shot timer, which
+  fires into a terminal state and self-loops.
 - Primary FSM handles interactive phases (through `InputSigSent`); a
   dedicated FSM per round handles confirmation monitoring.
 - **Arm timeouts before fallible outbox effects.** `processOutbox` stops at the

--- a/round/actor.go
+++ b/round/actor.go
@@ -2451,6 +2451,43 @@ func (a *RoundClientActor) handleCancelRound(ctx context.Context,
 	})
 }
 
+// retireFailedRound settles the durable side of a failed round: the
+// checkpoint row moves out of 'input_sig_sent' and the boarding intents it
+// adopted return to the live pool.
+//
+// Retirement rides RoundFailedNotification rather than being called from the
+// FSM exits directly, so the actor needs no knowledge of which failures are
+// retirable: the FSM announces only where it holds an authoritative verdict
+// that the commitment can never confirm. Every other emitter of that
+// notification is a pre-checkpoint failure with no round row to move, making
+// the call a no-op, and FailRound's own guards mean even a misrouted call
+// cannot release a deposit whose round confirmed or that a sweep has since
+// claimed.
+//
+// Failure to retire is logged rather than propagated. The round has already
+// failed and the client has already been told; a store error here means the
+// row is reclaimed on a later pass rather than that the failure is in doubt.
+func (a *RoundClientActor) retireFailedRound(ctx context.Context,
+	roundID RoundID) {
+
+	// Confirmation handling and failure delivery can both outlive the
+	// request that triggered them, so the write uses a detached context.
+	opCtx := context.WithoutCancel(ctx)
+
+	if err := a.cfg.RoundStore.FailRound(opCtx, roundID); err != nil {
+		a.log.WarnS(ctx, "Failed to retire dead round",
+			err,
+			slog.String("round_id", roundID.String()),
+		)
+
+		return
+	}
+
+	a.log.InfoS(ctx, "Retired dead round and released its deposits",
+		slog.String("round_id", roundID.String()),
+	)
+}
+
 // onRoundComplete is called when a round finishes successfully. This removes
 // the round from active tracking and archives the round data.
 func (a *RoundClientActor) onRoundComplete(ctx context.Context, roundID RoundID,
@@ -2968,6 +3005,16 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 			// counter pairs with the confirmed branch above so an
 			// operator can track the join-to-completion ratio.
 			a.emitRoundCompleted(ctx, roundIDStr, "failed")
+
+			// Retire the durable side of the round. Reaping only
+			// drops the in-memory FSM, so without this the
+			// checkpoint row stays in ListActiveRounds and is
+			// re-hydrated on every start, and the deposits it
+			// adopted stay adopted: out of the sweep and pinned
+			// against the board limit for good.
+			m.RoundID.WhenSome(func(id RoundID) {
+				a.retireFailedRound(ctx, id)
+			})
 
 		case *TerminalJobFailedNotification:
 			// A terminal-for-job round failure (e.g. the operator

--- a/round/actor.go
+++ b/round/actor.go
@@ -1589,14 +1589,18 @@ func (a *RoundClientActor) Start(ctx context.Context) error {
 		}
 
 		// A reloaded round sits back in InputSigSentState with its
-		// forfeit signatures already out, so the wavelength#844
-		// hazard window reopens across the restart. Re-arm the
-		// status-reconcile timeout for forfeit-bearing rounds so a
-		// round whose failure raced the crash still converges on a
-		// QueryRoundStatus probe rather than stranding.
-		if len(round.Intents.Forfeits) > 0 &&
-			a.env.StatusReconcileTimeout > 0 {
-
+		// signatures already out, so the wavelength#844 hazard window
+		// reopens across the restart. Re-arm the status-reconcile
+		// timeout so a round whose failure raced the crash still
+		// converges on a QueryRoundStatus probe rather than stranding.
+		//
+		// Boarding-only rounds re-arm too. They hold no forfeit
+		// reservations, but the probe is still their only exit from
+		// InputSigSentState once the operator has rolled the round
+		// back before broadcast: no commitment can ever confirm and no
+		// failure will ever be delivered, so without the clock the
+		// deposit strands until the CSV expires (wavelength#1051).
+		if a.env.StatusReconcileTimeout > 0 {
 			if err := a.processOutbox(ctx, []ClientOutMsg{
 				&StartTimeoutReq{
 					RoundKey: RoundKeyStr(

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -2,6 +2,7 @@ package round
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -4006,4 +4007,62 @@ func TestHandleRegisterIntent(t *testing.T) {
 			"duplicate VTXOs by PkScript should be deduplicated",
 		)
 	})
+}
+
+// TestFailedRoundIsRetiredDurably pins the actor half of the deposit release.
+// Reaping only drops the in-memory FSM, so without this call the checkpoint
+// row stays in ListActiveRounds and is re-hydrated on every start, and the
+// deposits the round adopted stay adopted: out of the sweep and pinned
+// against the board limit for good.
+//
+// This exercises the handler in isolation; that the dead-answer exit actually
+// emits the notification is pinned separately by
+// TestDeadStatusAnnouncesRoundFailure, since a handler nothing reaches is
+// worth nothing.
+func TestFailedRoundIsRetiredDurably(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	h.setupMockRoundStoreForStart()
+	require.NoError(t, h.start())
+
+	roundID := testRoundID("retire-on-failure")
+	h.roundStore.On("FailRound", mock.Anything, roundID).Return(nil)
+
+	err := h.actor.processOutbox(h.ctx, []ClientOutMsg{
+		&RoundFailedNotification{
+			RoundID:     fn.Some(roundID),
+			Reason:      "round dead at operator",
+			Recoverable: true,
+		},
+	})
+	require.NoError(t, err)
+
+	h.roundStore.AssertCalled(t, "FailRound", mock.Anything, roundID)
+}
+
+// TestFailedRoundRetirementSurvivesStoreError pins that a store error on
+// retirement does not propagate. The round has already failed and the client
+// has already been told; a failed write here means the row is reclaimed on a
+// later pass, not that the failure is in doubt, so it must not abort the rest
+// of the outbox.
+func TestFailedRoundRetirementSurvivesStoreError(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	h.setupMockRoundStoreForStart()
+	require.NoError(t, h.start())
+
+	roundID := testRoundID("retire-store-error")
+	h.roundStore.On(
+		"FailRound", mock.Anything, roundID,
+	).Return(errors.New("db down"))
+
+	err := h.actor.processOutbox(h.ctx, []ClientOutMsg{
+		&RoundFailedNotification{
+			RoundID: fn.Some(roundID),
+			Reason:  "round dead at operator",
+		},
+	})
+	require.NoError(t, err, "a failed retirement aborted the outbox")
 }

--- a/round/checkpoint_arming_test.go
+++ b/round/checkpoint_arming_test.go
@@ -251,7 +251,8 @@ func TestReconcileArmingRespectsDisabled(t *testing.T) {
 // TestRestartDoorArmsReconcileClock covers the third door: a checkpointed
 // round reloaded from the store on startup. The two live doors build their
 // outbox from the transition that carries them into the state, but nothing
-// re-derives that outbox across a restart, so recoverActiveRounds has to arm
+// re-derives that outbox across a restart, so the resume loop in Start has
+// to arm
 // the clock itself. A boarding-only round is exactly the case that used to be
 // gated out here, which mattered doubly: while the live door was unarmed, the
 // restart path was the only thing that could still rescue such a round, and

--- a/round/checkpoint_arming_test.go
+++ b/round/checkpoint_arming_test.go
@@ -1,0 +1,302 @@
+package round
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// newArmingCommitmentTx builds the smallest commitment packet the outbox
+// helper will accept. The arming invariant does not care what the round is
+// paying, only that the checkpoint was reached, so an empty unsigned tx is
+// enough: TxHash works on it and confirmationWatchScript returns nil rather
+// than panicking on the missing outputs.
+func newArmingCommitmentTx() *psbt.Packet {
+	return &psbt.Packet{
+		UnsignedTx: wire.NewMsgTx(2),
+	}
+}
+
+// newArmingEnv builds an environment carrying the given reconcile timeout.
+// OperatorTerms has to be non-nil: the outbox reads MinConfirmations off it
+// for the confirmation registration, so the bare struct literal the other
+// reconcile tests use would panic here.
+func newArmingEnv(reconcile time.Duration) *ClientEnvironment {
+	base := reconcileEnv()
+	base.StatusReconcileTimeout = reconcile
+	base.OperatorTerms = &types.OperatorTerms{
+		MinConfirmations: 1,
+	}
+
+	return base
+}
+
+// InputSigSentState is the checkpointed point of no return: the client's
+// signatures are conceptually gone, the operator may broadcast at any moment,
+// and no further event is guaranteed to arrive. The status-reconcile clock is
+// the only thing that turns operator silence back into progress, so every
+// door into that state has to arm it. Miss one and the rounds that walk
+// through it strand until the CSV expires, which is wavelength#1051.
+//
+// There are two live doors plus the restart reload, and they are easy to
+// treat as one: a refresh round with forfeits goes through forfeit
+// collection, while a boarding-only round skips that entirely and checkpoints
+// straight from PartialSigsSentState. The second door is the one that went
+// unarmed, and no per-door test noticed because the boarding harness left
+// StatusReconcileTimeout at zero, which skips the arming branch outright.
+//
+// So the tests below assert the invariant rather than the doors: whatever
+// path reaches the checkpoint must emit the arm, and it must emit it ahead of
+// the requests that can fail.
+
+// findStartReconcile returns the status-reconcile StartTimeoutReq in an
+// outbox along with its index, so callers can assert both presence and
+// ordering.
+func findStartReconcile(msgs []ClientOutMsg) (*StartTimeoutReq, int) {
+	for i, msg := range msgs {
+		req, ok := msg.(*StartTimeoutReq)
+		if !ok {
+			continue
+		}
+		if req.Phase == TimeoutPhaseStatusReconcile {
+			return req, i
+		}
+	}
+
+	return nil, -1
+}
+
+// assertArmsReconcileFirst is the shared invariant: the outbox arms the
+// status-reconcile clock, and does so before anything that can fail on the
+// way out. processOutbox stops at the first failed Tell, so an arm sitting
+// behind the sig and registration requests is an arm a single mailbox hiccup
+// can skip, leaving the state committed with no clock behind it.
+func assertArmsReconcileFirst(t *testing.T, msgs []ClientOutMsg,
+	timeout time.Duration, roundID RoundID) {
+
+	t.Helper()
+
+	arm, idx := findStartReconcile(msgs)
+	require.NotNilf(
+		t, arm, "checkpoint outbox never arms the status-reconcile "+
+			"clock: a round reaching InputSigSentState through "+
+			"this door has no liveness timer, so operator "+
+			"silence strands it until the CSV expires "+
+			"(wavelength#1051)",
+	)
+	require.Equal(t, timeout, arm.Duration)
+	require.Equal(t, RoundKeyStr(roundID.KeyString()), arm.RoundKey)
+
+	for i, msg := range msgs[:idx] {
+		switch msg.(type) {
+		// A cancel of some other phase is bookkeeping on a timer that
+		// is already running, so it may precede the arm.
+		case *CancelTimeoutReq:
+			continue
+
+		default:
+			t.Fatalf("checkpoint outbox arms the reconcile clock "+
+				"at index %d, behind %T at index %d: a failed "+
+				"Tell on that message commits the checkpoint "+
+				"with no clock armed", idx, msg, i)
+		}
+	}
+}
+
+// TestForfeitDoorArmsReconcileClock covers the forfeit-bearing door: a
+// refresh round leaves through forfeit collection, so the arm rides in that
+// outbox.
+func TestForfeitDoorArmsReconcileClock(t *testing.T) {
+	t.Parallel()
+
+	const timeout = time.Minute
+
+	roundID := reconcileRoundID(0x11)
+	state := &ForfeitSignaturesCollectingState{
+		RoundID:      roundID,
+		CommitmentTx: newArmingCommitmentTx(),
+	}
+	env := newArmingEnv(timeout)
+
+	forfeits := map[wire.OutPoint]*types.ForfeitTxSig{
+		reconcileOutpoint(0x22): {},
+	}
+
+	t.Run("with boarding sigs", func(t *testing.T) {
+		t.Parallel()
+
+		msgs := state.forfeitCollectionOutbox(
+			env, forfeits, []*types.BoardingInputSignature{{}},
+		)
+		assertArmsReconcileFirst(t, msgs, timeout, roundID)
+	})
+
+	t.Run("without boarding sigs", func(t *testing.T) {
+		t.Parallel()
+
+		msgs := state.forfeitCollectionOutbox(env, forfeits, nil)
+		assertArmsReconcileFirst(t, msgs, timeout, roundID)
+	})
+}
+
+// TestBoardingDoorArmsReconcileClock covers the door that was missed: a
+// boarding-only round carries no forfeit mappings, so it never enters forfeit
+// collection and checkpoints straight out of PartialSigsSentState. Before the
+// fix this outbox held only the sig and registration requests, and the
+// deposit had no clock at all.
+func TestBoardingDoorArmsReconcileClock(t *testing.T) {
+	t.Parallel()
+
+	const timeout = time.Minute
+
+	h := newRealSigningTestHarness(t)
+
+	intent := h.newTestBoardingIntentWithTapscript()
+	vtxoReq := h.newTestVTXORequestForIntent(intent)
+	vtxtTree := h.newTestVTXOTreeForIntents([]types.VTXORequest{vtxoReq})
+
+	validSigs, err := h.generateValidTreeSignatures(vtxtTree)
+	require.NoError(t, err)
+	require.NotEmpty(t, validSigs)
+
+	commitmentTx := h.newCommitmentTxForIntents(
+		[]BoardingIntent{intent}, vtxtTree,
+	)
+
+	clientTrees := make(map[SignerKey]*tree.Tree)
+	clientTrees[NewSignerKey(vtxoReq.SigningKey.PubKey)] = vtxtTree
+
+	roundID := testRoundIDTr("round-boarding-arm-001")
+	state := &PartialSigsSentState{
+		RoundID:      roundID,
+		CommitmentTx: commitmentTx,
+		VTXOTreePaths: map[int]*tree.Tree{
+			0: vtxtTree,
+		},
+		Intents: Intents{
+			Boarding: []BoardingIntent{
+				intent,
+			},
+			VTXOs: []types.VTXORequest{
+				vtxoReq,
+			},
+		},
+		ClientTrees: clientTrees,
+		BoardingInputIndices: map[wire.OutPoint]int{
+			intent.Outpoint: 0,
+		},
+		Musig2Sessions: make(map[SignerKey]*tree.SignerSession),
+	}
+
+	// The harness leaves the reconcile timeout at zero, which skips the
+	// arming branch entirely. That default is exactly why every existing
+	// boarding test read this outbox and saw nothing missing.
+	h.env.StatusReconcileTimeout = timeout
+
+	h.setupMockWalletForBoardingSigning()
+	h.setupMockRoundStoreForCommit()
+	h.withState(state)
+
+	transition, err := h.sendEvent(&OperatorSigned{
+		RoundID: roundID,
+		AggSigs: validSigs,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, transition)
+
+	// The door has to actually land on the checkpoint, otherwise the
+	// arming assertion below would pass over a round that never reached
+	// the hazard window at all.
+	assertStateType[*InputSigSentState](h.boardingTestHarness)
+
+	var msgs []ClientOutMsg
+	transition.NewEvents.WhenSome(func(emitted ClientEmittedEvent) {
+		msgs = emitted.Outbox
+	})
+	assertArmsReconcileFirst(t, msgs, timeout, roundID)
+}
+
+// TestReconcileArmingRespectsDisabled pins the opt-out on both doors: a zero
+// timeout means the operator has turned the reconcile off, and neither door
+// may arm a timer behind its back.
+func TestReconcileArmingRespectsDisabled(t *testing.T) {
+	t.Parallel()
+
+	roundID := reconcileRoundID(0x33)
+	state := &ForfeitSignaturesCollectingState{
+		RoundID:      roundID,
+		CommitmentTx: newArmingCommitmentTx(),
+	}
+	env := newArmingEnv(0)
+
+	msgs := state.forfeitCollectionOutbox(
+		env, map[wire.OutPoint]*types.ForfeitTxSig{
+			reconcileOutpoint(0x44): {},
+		}, []*types.BoardingInputSignature{{}},
+	)
+
+	arm, _ := findStartReconcile(msgs)
+	require.Nil(
+		t, arm,
+		"reconcile disabled but the outbox armed the clock anyway",
+	)
+}
+
+// TestRestartDoorArmsReconcileClock covers the third door: a checkpointed
+// round reloaded from the store on startup. The two live doors build their
+// outbox from the transition that carries them into the state, but nothing
+// re-derives that outbox across a restart, so recoverActiveRounds has to arm
+// the clock itself. A boarding-only round is exactly the case that used to be
+// gated out here, which mattered doubly: while the live door was unarmed, the
+// restart path was the only thing that could still rescue such a round, and
+// it was gated on the same forfeit count.
+func TestRestartDoorArmsReconcileClock(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+
+	roundID := testRoundID("restart-door-arms")
+	round := h.newTestRound(roundID)
+
+	walletIntent := h.newTestBoardingIntent()
+	intent, err := buildBoardingIntentFromWallet(walletIntent)
+	require.NoError(t, err)
+
+	// A boarding-only checkpoint: intents carry no forfeits at all, so the
+	// old gate skipped this round on the way back up.
+	h.roundStore.On(
+		"ListActiveRounds", mock.Anything,
+	).Return([]*Round{round}, nil)
+	h.roundStore.On(
+		"FetchState", mock.Anything, round.RoundID,
+	).Return(
+		round,
+		&InputSigSentState{
+			RoundID:      roundID,
+			CommitmentTx: round.CommitmentTx.UnwrapOrFail(t),
+			Intents: Intents{
+				Boarding: []BoardingIntent{intent},
+			},
+		},
+		nil,
+	)
+
+	require.NoError(t, h.start())
+
+	h.timeoutActor.assertTimeoutScheduled(
+		t,
+		makeTimeoutID(
+			RoundKeyStr(
+				roundID.KeyString(),
+			),
+			TimeoutPhaseStatusReconcile,
+		),
+		defaultStatusReconcileTimeout,
+	)
+}

--- a/round/fsm_timeouts.go
+++ b/round/fsm_timeouts.go
@@ -92,32 +92,17 @@ func cancelStatusReconcileTimeout(roundID RoundID) ClientOutMsg {
 	}
 }
 
-// reconcileDisarmEvents builds the emitted-event option that disarms the
-// status-reconcile clock on an exit from InputSigSentState. The clock is armed
-// for the whole of that state, so every exit disarms it; the gate mirrors the
-// arm sites so no cancel is emitted for a timer that was never scheduled.
-func reconcileDisarmEvents(roundID RoundID,
-	env *ClientEnvironment) fn.Option[ClientEmittedEvent] {
-
-	if env.StatusReconcileTimeout <= 0 {
-		return fn.None[ClientEmittedEvent]()
-	}
-
-	return fn.Some(ClientEmittedEvent{
-		Outbox: []ClientOutMsg{
-			cancelStatusReconcileTimeout(roundID),
-		},
-	})
-}
-
 // appendReconcileDisarm adds the status-reconcile disarm to the end of a
-// transition's outbox, for exits that have already queued messages of their
-// own. Disarming is cleanup and must stay behind every delivery: processOutbox
-// abandons the rest of the outbox on the first failing Tell, and a cancel is
-// one of the few entries that can fail, so a cancel sitting ahead of a
-// notification lets a saturated timeout actor suppress it. Trailing costs
-// nothing, since a cancel that never lands only leaks a one-shot timer, which
-// fires into a terminal state and self-loops.
+// transition's outbox. The clock is armed for the whole of InputSigSentState,
+// so every exit disarms it, and the gate mirrors the arm sites so no cancel is
+// emitted for a timer that was never scheduled.
+//
+// The disarm always goes last, even on an exit whose outbox is otherwise
+// empty. processOutbox abandons the rest of the outbox on the first failing
+// Tell, and a cancel is one of the few entries that can fail, so a cancel
+// sitting ahead of a notification lets a saturated timeout actor suppress it.
+// Trailing costs nothing, since a cancel that never lands only leaks a
+// one-shot timer, which fires into a terminal state and self-loops.
 func appendReconcileDisarm(transition *ClientStateTransition, roundID RoundID,
 	env *ClientEnvironment) *ClientStateTransition {
 

--- a/round/fsm_timeouts.go
+++ b/round/fsm_timeouts.go
@@ -1,5 +1,9 @@
 package round
 
+import (
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
 // TimeoutPhase identifies which FSM phase owns a timeout.
 type TimeoutPhase string
 
@@ -22,11 +26,13 @@ const (
 
 	// TimeoutPhaseStatusReconcile is the timeout phase for
 	// InputSigSentState's round-status reconcile (wavelength#844). It is
-	// armed when the forfeit signatures leave the box and re-armed on
-	// every reconcile probe, so both a received round failure and total
-	// operator silence (the lumos#618 crash door) eventually drive a
-	// QueryRoundStatus. The reservation is released only on an
-	// authoritative dead answer, never on the timeout alone.
+	// armed on entry to InputSigSentState — for every checkpointed round,
+	// including a boarding-only one that submits no forfeit signatures
+	// (wavelength#1051) — and re-armed on every reconcile probe, so both a
+	// received round failure and total operator silence (the lumos#618
+	// crash door) eventually drive a QueryRoundStatus. The reservation is
+	// released only on an authoritative dead answer, never on the timeout
+	// alone.
 	TimeoutPhaseStatusReconcile TimeoutPhase = "status-reconcile"
 )
 
@@ -76,11 +82,54 @@ func statusReconcileProbeOutbox(roundID RoundID, env *ClientEnvironment,
 }
 
 // cancelStatusReconcileTimeout builds the outbox message that disarms the
-// status-reconcile timeout, for the paths that resolve the round's fate
-// (confirmation, or an authoritative dead answer).
+// status-reconcile timeout, for the paths that resolve the round's fate: a
+// confirmation, an authoritative dead answer, or a failure the operator
+// delivered directly (which carries the same authority a probe would return).
 func cancelStatusReconcileTimeout(roundID RoundID) ClientOutMsg {
 	return &CancelTimeoutReq{
 		RoundKey: RoundKeyStr(roundID.KeyString()),
 		Phase:    TimeoutPhaseStatusReconcile,
 	}
+}
+
+// reconcileDisarmEvents builds the emitted-event option that disarms the
+// status-reconcile clock on an exit from InputSigSentState. The clock is armed
+// for the whole of that state, so every exit disarms it; the gate mirrors the
+// arm sites so no cancel is emitted for a timer that was never scheduled.
+func reconcileDisarmEvents(roundID RoundID,
+	env *ClientEnvironment) fn.Option[ClientEmittedEvent] {
+
+	if env.StatusReconcileTimeout <= 0 {
+		return fn.None[ClientEmittedEvent]()
+	}
+
+	return fn.Some(ClientEmittedEvent{
+		Outbox: []ClientOutMsg{
+			cancelStatusReconcileTimeout(roundID),
+		},
+	})
+}
+
+// appendReconcileDisarm adds the status-reconcile disarm to the end of a
+// transition's outbox, for exits that have already queued messages of their
+// own. Disarming is cleanup and must stay behind every delivery: processOutbox
+// abandons the rest of the outbox on the first failing Tell, and a cancel is
+// one of the few entries that can fail, so a cancel sitting ahead of a
+// notification lets a saturated timeout actor suppress it. Trailing costs
+// nothing, since a cancel that never lands only leaks a one-shot timer, which
+// fires into a terminal state and self-loops.
+func appendReconcileDisarm(transition *ClientStateTransition, roundID RoundID,
+	env *ClientEnvironment) *ClientStateTransition {
+
+	if env.StatusReconcileTimeout <= 0 {
+		return transition
+	}
+
+	emitted := transition.NewEvents.UnwrapOr(ClientEmittedEvent{})
+	emitted.Outbox = append(
+		emitted.Outbox, cancelStatusReconcileTimeout(roundID),
+	)
+	transition.NewEvents = fn.Some(emitted)
+
+	return transition
 }

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -98,6 +98,12 @@ func (m *MockRoundStore) FinalizeRound(ctx context.Context, roundID RoundID,
 	return args.Error(0)
 }
 
+func (m *MockRoundStore) FailRound(ctx context.Context, roundID RoundID) error {
+	args := m.Called(ctx, roundID)
+
+	return args.Error(0)
+}
+
 func (m *MockRoundStore) FailForfeitIntents(ctx context.Context,
 	outpoints []wire.OutPoint, reason string, code RoundFailureCode) error {
 

--- a/round/interfaces.go
+++ b/round/interfaces.go
@@ -457,6 +457,19 @@ type RoundStore interface {
 	FinalizeRound(ctx context.Context, roundID RoundID, txid chainhash.Hash,
 		confInfo ConfInfo) error
 
+	// FailRound retires a checkpointed round whose fate is known to be
+	// dead, and returns the boarding intents it adopted to the live pool.
+	// It is the terminal-failure counterpart to FinalizeRound: without it
+	// the round row stays in ListActiveRounds and is re-hydrated on every
+	// start, and its deposits stay adopted, which keeps them out of the
+	// sweep and pinned against the board limit forever.
+	//
+	// Intents revert to BoardingStatusConfirmed, not
+	// BoardingStatusFailed: a dead round proves the commitment never
+	// broadcast, so nothing on-chain failed and the UTXO is exactly as it
+	// was before the round.
+	FailRound(ctx context.Context, roundID RoundID) error
+
 	// FailForfeitIntents terminally fails the pending send intents anchored
 	// to the given forfeited VTXO outpoints, recording the reason and typed
 	// failure code. It is the terminal-failure counterpart to the anchor

--- a/round/status_reconcile_test.go
+++ b/round/status_reconcile_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/lib/types"
 	"github.com/lightninglabs/wavelength/rpc/roundpb"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -636,5 +637,82 @@ func TestConfirmationDisarmTrailsNotifications(t *testing.T) {
 		t, doneIdx, cancelIdx, "disarm precedes the terminal "+
 			"notifications, so a rejected cancel would "+
 			"withhold confirmed funds",
+	)
+}
+
+// TestDeadStatusAnnouncesRoundFailure pins the emission the durable
+// retirement hangs off. The actor retires a dead round's checkpoint row and
+// releases its deposits when it sees a RoundFailedNotification, so a dead
+// answer that fails the round in memory without announcing it leaves the row
+// active and the deposit adopted forever: the wavelength#1051 strand, moved
+// from the FSM into the database. Every other exit from InputSigSentState
+// stays silent on purpose, so this is the only site that closes it.
+func TestDeadStatusAnnouncesRoundFailure(t *testing.T) {
+	t.Parallel()
+
+	roundID := reconcileRoundID(0xc1)
+	s := reconcileState(roundID, nil)
+
+	tr, err := s.ProcessEvent(
+		context.Background(),
+		&RoundStatusReported{
+			RoundID: roundID,
+			Status:  roundpb.RoundLifecycleStatus_ROUND_STATUS_DEAD,
+			Detail:  "round unknown to operator",
+		},
+		reconcileEnv(),
+	)
+	require.NoError(t, err)
+
+	_, ok := tr.NextState.(*ClientFailedState)
+	require.True(t, ok, "expected ClientFailedState, got %T", tr.NextState)
+
+	outbox := tr.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+
+	notify, ok := findOutbox[*RoundFailedNotification](outbox)
+	require.True(
+		t, ok, "dead answer did not announce the failure, so the "+
+			"round is never retired and its deposit stays adopted",
+	)
+	require.Equal(t, fn.Some(roundID), notify.RoundID)
+
+	// The announcement is a delivery, so the disarm trails it for the same
+	// reason it trails the release and the job drop.
+	notifyIdx := outboxIndexOf[*RoundFailedNotification](outbox)
+	cancelIdx := outboxIndexOf[*CancelTimeoutReq](outbox)
+	require.NotEqual(t, -1, cancelIdx, "dead answer left the clock armed")
+	require.Less(
+		t, notifyIdx, cancelIdx, "disarm precedes the "+
+			"announcement, so a rejected cancel would suppress "+
+			"the retirement",
+	)
+}
+
+// TestDeliveredFailureDoesNotAnnounce pins the deliberate silence on the
+// delivered-failure shortcut. handleCancelRound injects a synthetic
+// BoardingFailed onto this same branch, and a local cancel proves nothing
+// about the operator: the commitment may still broadcast. Announcing here
+// would retire the round and hand the deposit back to the boardable pool
+// while it can still be spent by that commitment.
+func TestDeliveredFailureDoesNotAnnounce(t *testing.T) {
+	t.Parallel()
+
+	s := reconcileState(reconcileRoundID(0xc2), nil)
+
+	tr, err := s.ProcessEvent(context.Background(), &BoardingFailed{
+		Reason:      "User requested cancellation",
+		Recoverable: true,
+	}, reconcileEnv())
+	require.NoError(t, err)
+
+	_, ok := tr.NextState.(*ClientFailedState)
+	require.True(t, ok, "expected ClientFailedState, got %T", tr.NextState)
+
+	outbox := tr.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+	_, announced := findOutbox[*RoundFailedNotification](outbox)
+	require.False(
+		t, announced, "a delivered failure retired the round, "+
+			"which releases the deposit on a verdict that does "+
+			"not rule out the commitment",
 	)
 }

--- a/round/status_reconcile_test.go
+++ b/round/status_reconcile_test.go
@@ -425,4 +425,216 @@ func TestDeadStatusTerminalCodeRetiresJob(t *testing.T) {
 	require.Equal(
 		t, RoundFailureInsufficientOperatorFunds, notify.FailureCode,
 	)
+
+	// The disarm is cleanup and must trail the job drop. A rejected
+	// CancelTimeoutReq aborts the rest of the outbox, so a cancel sitting
+	// ahead of the notification would let a saturated timeout actor leave
+	// the pending intent in recoverable replay, which is exactly what
+	// retiring the job prevents.
+	cancelIdx := outboxIndexOf[*CancelTimeoutReq](outbox)
+	require.NotEqual(t, -1, cancelIdx, "dead answer left the clock armed")
+
+	notifyIdx := outboxIndexOf[*TerminalJobFailedNotification](outbox)
+	require.Less(
+		t, notifyIdx, cancelIdx, "disarm precedes the job drop, so "+
+			"a rejected cancel would suppress it",
+	)
+}
+
+// outboxIndexOf returns the position of the first outbox message of type T,
+// or -1 when the outbox carries none. Ordering assertions need the position
+// rather than mere presence: processOutbox abandons the rest of the outbox on
+// the first failing Tell, so whether a message is dispatched before or after a
+// fallible send decides what a mid-flight error can strand.
+func outboxIndexOf[T ClientOutMsg](outbox []ClientOutMsg) int {
+	for i, msg := range outbox {
+		if _, ok := msg.(T); ok {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// TestBoardingOnlyReconcileTimeoutProbes pins the wavelength#1051 fix on the
+// timeout handler. A boarding-only round holds no forfeit reservations, so the
+// old forfeit-count gate self-looped its expiry as a defensive no-op. But the
+// probe is that round's sole exit from InputSigSentState once the operator has
+// rolled the round back before broadcast: no commitment can confirm and no
+// failure will ever be delivered. The expiry must therefore probe and re-arm
+// exactly as a forfeit-bearing round does.
+func TestBoardingOnlyReconcileTimeoutProbes(t *testing.T) {
+	t.Parallel()
+
+	roundID := reconcileRoundID(0xb1)
+	s := reconcileState(roundID, nil)
+
+	tr, err := s.ProcessEvent(
+		context.Background(), &StatusReconcileTimedOut{
+			RoundID: roundID,
+		},
+		reconcileEnv(),
+	)
+	require.NoError(t, err)
+
+	next, ok := tr.NextState.(*InputSigSentState)
+	require.True(t, ok, "expected InputSigSentState, got %T", tr.NextState)
+	require.Equal(t, uint32(1), next.ReconcileProbes)
+
+	outbox := tr.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+
+	probe, ok := findOutbox[*QueryRoundStatusOutbox](outbox)
+	require.True(t, ok, "boarding-only round did not re-probe")
+	require.Equal(t, roundID, probe.RoundID)
+
+	timeoutReq, ok := findOutbox[*StartTimeoutReq](outbox)
+	require.True(t, ok, "boarding-only reconcile window not re-armed")
+	require.Equal(t, TimeoutPhaseStatusReconcile, timeoutReq.Phase)
+}
+
+// TestBoardingOnlyDeliveredFailureDisarms pins the disarm half of the
+// wavelength#1051 invariant: the clock is armed for the whole of
+// InputSigSentState, so every exit disarms it. The delivered-failure shortcut
+// still fails a boarding-only round immediately (it signed nothing away, so
+// nothing can strand), but it must now cancel the timer it armed on the way
+// in rather than leave a one-shot running against a terminal round.
+func TestBoardingOnlyDeliveredFailureDisarms(t *testing.T) {
+	t.Parallel()
+
+	roundID := reconcileRoundID(0xb2)
+	s := reconcileState(roundID, nil)
+
+	failure := &BoardingFailed{
+		Reason:      "operator rolled the round back",
+		Recoverable: true,
+	}
+
+	tr, err := s.ProcessEvent(context.Background(), failure, reconcileEnv())
+	require.NoError(t, err)
+
+	failed, ok := tr.NextState.(*ClientFailedState)
+	require.True(t, ok, "expected ClientFailedState, got %T", tr.NextState)
+	require.Equal(t, failure.Reason, failed.Reason)
+
+	outbox := tr.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+
+	cancel, ok := findOutbox[*CancelTimeoutReq](outbox)
+	require.True(t, ok, "delivered failure left the reconcile clock armed")
+	require.Equal(t, TimeoutPhaseStatusReconcile, cancel.Phase)
+	require.Equal(t, RoundKeyStr(roundID.KeyString()), cancel.RoundKey)
+}
+
+// TestDeliveredFailureNoDisarmWhenReconcileDisabled pins the other side of
+// that gate: with the reconcile opted out no clock was ever armed, so the
+// failure path must not emit a cancel for a timer that does not exist.
+func TestDeliveredFailureNoDisarmWhenReconcileDisabled(t *testing.T) {
+	t.Parallel()
+
+	s := reconcileState(reconcileRoundID(0xb3), nil)
+
+	env := reconcileEnv()
+	env.StatusReconcileTimeout = 0
+
+	tr, err := s.ProcessEvent(context.Background(), &BoardingFailed{
+		Reason:      "round failed",
+		Recoverable: true,
+	}, env)
+	require.NoError(t, err)
+
+	_, ok := tr.NextState.(*ClientFailedState)
+	require.True(t, ok, "expected ClientFailedState, got %T", tr.NextState)
+
+	outbox := tr.NewEvents.UnwrapOr(ClientEmittedEvent{}).Outbox
+	_, cancelled := findOutbox[*CancelTimeoutReq](outbox)
+	require.False(t, cancelled, "cancelled a timer that was never armed")
+}
+
+// TestReconcileArmedBeforeFallibleSends pins the ordering the liveness clock
+// depends on. processOutbox abandons the rest of the outbox on the first
+// failing Tell, and the FSM has already checkpointed into InputSigSentState by
+// the time the outbox is dispatched. Arming after the server sends would
+// therefore let a mid-flight send error leave a checkpointed round with no
+// clock for the rest of the session, reopening the wavelength#1051 strand
+// through a different door.
+func TestReconcileArmedBeforeFallibleSends(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	h.env.StatusReconcileTimeout = time.Minute
+
+	intent := h.newTestBoardingIntent()
+	state := h.newForfeitCollectingState(
+		testRoundIDTr("round-arm-order"), Intents{
+			Boarding: []BoardingIntent{intent},
+		},
+		nil,
+	)
+
+	outbox := state.forfeitCollectionOutbox(
+		h.env, nil, []*types.BoardingInputSignature{{}},
+	)
+
+	armIdx := outboxIndexOf[*StartTimeoutReq](outbox)
+	require.NotEqual(t, -1, armIdx, "reconcile clock never armed")
+
+	forfeitSigsIdx := outboxIndexOf[*SubmitVTXOForfeitSigsToServer](outbox)
+	boardingSigsIdx := outboxIndexOf[*SubmitForfeitSigRequest](outbox)
+	confRegIdx := outboxIndexOf[*RegisterConfirmationRequest](outbox)
+
+	fallible := map[string]int{
+		"SubmitVTXOForfeitSigsToServer": forfeitSigsIdx,
+		"SubmitForfeitSigRequest":       boardingSigsIdx,
+		"RegisterConfirmationRequest":   confRegIdx,
+	}
+
+	for name, idx := range fallible {
+		require.NotEqual(t, -1, idx, "%s missing from outbox", name)
+		require.Lessf(
+			t, armIdx, idx, "reconcile clock armed after %s, so "+
+				"a failed send strands the checkpointed round",
+			name,
+		)
+	}
+}
+
+// TestConfirmationDisarmTrailsNotifications pins the mirror-image ordering on
+// the way out. The confirmation resolves the round's fate, but the disarm is
+// cleanup and must never gate delivery: dispatching the cancel first lets a
+// saturated or down timeout actor short-circuit processOutbox before
+// VTXOCreatedNotification and RoundCompletedNotification, withholding
+// already-persisted VTXOs from the manager and leaving onRoundComplete
+// unfinalized. A cancel that never lands only leaks a one-shot timer, which
+// fires into a terminal state and self-loops.
+func TestConfirmationDisarmTrailsNotifications(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	h.setupMockVTXOStoreForSave()
+	h.env.StatusReconcileTimeout = time.Minute
+
+	intent := h.newTestBoardingIntent()
+	state := h.newInputSigSentState(
+		testRoundIDTr("round-conf-order"), []BoardingIntent{intent},
+	)
+	h.withState(state)
+
+	_, err := h.sendEvent(&BoardingConfirmed{
+		TxID:          state.CommitmentTx.UnsignedTx.TxHash(),
+		BlockHeight:   101,
+		BlockHash:     chainhash.Hash{0x01, 0x02},
+		Confirmations: 6,
+	})
+	require.NoError(t, err)
+
+	cancelIdx := outboxIndexOf[*CancelTimeoutReq](h.outboxMessages)
+	require.NotEqual(t, -1, cancelIdx, "confirmation left the clock armed")
+
+	doneIdx := outboxIndexOf[*RoundCompletedNotification](h.outboxMessages)
+	require.NotEqual(t, -1, doneIdx, "no RoundCompletedNotification")
+
+	require.Less(
+		t, doneIdx, cancelIdx, "disarm precedes the terminal "+
+			"notifications, so a rejected cancel would "+
+			"withhold confirmed funds",
+	)
 }

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -3605,7 +3605,32 @@ func (s *PartialSigsSentState) processEvent(ctx context.Context,
 			),
 		)
 
-		outboxMsgs := []ClientOutMsg{
+		// This is the boarding-only door into InputSigSentState: the
+		// round carried no forfeit mappings, so it never passed
+		// through forfeit collection and never saw the arming there.
+		// It still checkpoints at the same point of no return, which
+		// makes the reconcile clock its sole liveness timer. Without
+		// it, an operator that dies before broadcasting leaves a
+		// client that never restarts with no exit at all: no
+		// commitment can confirm, no failure ever arrives, and the
+		// deposit strands until the CSV expires (wavelength#1051).
+		//
+		// Arm before the requests go out, not after. processOutbox
+		// stops at the first failed Tell, so a mailbox hiccup on the
+		// sig or registration request would otherwise commit this
+		// state with no clock behind it, unarmed until a restart.
+		// Arming early is harmless: the probe answers in-flight or
+		// dead, and both are safe.
+		outboxMsgs := make([]ClientOutMsg, 0, 3)
+		if env.StatusReconcileTimeout > 0 {
+			outboxMsgs = append(outboxMsgs, &StartTimeoutReq{
+				RoundKey: RoundKeyStr(s.RoundID.KeyString()),
+				Phase:    TimeoutPhaseStatusReconcile,
+				Duration: env.StatusReconcileTimeout,
+			})
+		}
+		outboxMsgs = append(
+			outboxMsgs,
 			forfeitSigReq,
 			&RegisterConfirmationRequest{
 				CallerID:    callerID,
@@ -3614,7 +3639,7 @@ func (s *PartialSigsSentState) processEvent(ctx context.Context,
 				TargetConfs: env.OperatorTerms.MinConfirmations,
 				HeightHint:  env.StartHeight,
 			},
-		}
+		)
 
 		// Checkpoint the round state at the "point of no return".
 		// After sending boarding input signatures, the server may

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -4627,19 +4627,28 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 		// carries the same authority a probe would return, so this
 		// round needs no reconcile; disarm the clock it armed on the
 		// way into this state.
+		//
+		// Deliberately no RoundFailedNotification, so the round is not
+		// retired durably here. handleCancelRound injects a synthetic
+		// BoardingFailed and lands on this same branch, and a local
+		// cancel proves nothing about the operator: the commitment may
+		// still broadcast. Returning the deposit to the boardable pool
+		// on that evidence would let it be spent into a second round
+		// while the first can still confirm. The round instead settles
+		// durably on the next dead answer, which is the only verdict
+		// that rules the commitment out.
 		if len(s.Intents.Forfeits) == 0 ||
 			env.StatusReconcileTimeout <= 0 {
-			return &ClientStateTransition{
-				NextState: &ClientFailedState{
-					Reason:      evt.Reason,
-					Error:       evt.Error,
-					Recoverable: evt.Recoverable,
-					FailureCode: evt.FailureCode,
-				},
-				NewEvents: reconcileDisarmEvents(
-					s.RoundID, env,
-				),
-			}, nil
+			return appendReconcileDisarm(
+				&ClientStateTransition{
+					NextState: &ClientFailedState{
+						Reason:      evt.Reason,
+						Error:       evt.Error,
+						Recoverable: evt.Recoverable,
+						FailureCode: evt.FailureCode,
+					},
+				}, s.RoundID, env,
+			), nil
 		}
 
 		// Forfeit signatures are already out, so the notification alone
@@ -4765,6 +4774,28 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 			slog.Int("forfeit_count", len(s.Intents.Forfeits)),
 		)
 
+		// This is the one exit from InputSigSentState that carries an
+		// authoritative verdict, so it is the one that announces the
+		// failure. The notification is what drives the actor's durable
+		// retirement: the checkpoint row moves out of input_sig_sent
+		// and the deposits this round adopted go back to the live
+		// pool. Neither is safe without the operator's dead answer,
+		// which is why the delivered-failure shortcut below does not
+		// announce (a user cancel reaches it through the same branch
+		// and proves nothing about the commitment) and the
+		// confirmation paths never do (their commitment confirmed, so
+		// the deposit is spent).
+		//
+		// Announcing here also closes an observability gap, since a
+		// checkpointed round reaching its terminal state previously
+		// went uncounted.
+		announce := &RoundFailedNotification{
+			RoundID:       fn.Some(s.RoundID),
+			Reason:        failure.Reason,
+			Recoverable:   failure.Recoverable,
+			OriginalError: failure.Error,
+		}
+
 		transition := &ClientStateTransition{
 			NextState: &ClientFailedState{
 				Reason:      failure.Reason,
@@ -4772,6 +4803,9 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 				Recoverable: failure.Recoverable,
 				FailureCode: failure.FailureCode,
 			},
+			NewEvents: fn.Some(ClientEmittedEvent{
+				Outbox: []ClientOutMsg{announce},
+			}),
 		}
 
 		// The release is safe here for the same reason it is safe in
@@ -4810,23 +4844,31 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 		)
 		if err != nil {
 
-			// Error carried into failed state. This is an exit
-			// from InputSigSentState like any other, so it disarms
+			// Error carried into failed state. It disarms but does
+			// not announce: the commitment confirmed on the way
+			// into this branch, so the boarding UTXO is spent.
+			// Retiring the round here would hand a spent deposit
+			// back to the boardable pool. The FSM failing while
+			// the round succeeded on-chain is a local bug to fix,
+			// not a dead round to reclaim.
+			//
+			// This is an exit from InputSigSentState like any
+			// other, so it disarms
 			// the reconcile clock too: the confirmation already
 			// resolved the round's fate, and leaving the one-shot
 			// armed would fire a probe at a round that has settled
 			// terminally.
-			return &ClientStateTransition{ //nolint:nilerr
-				NextState: &ClientFailedState{
-					Reason: "failed to build client " +
-						"VTXOs",
-					Error:       err,
-					Recoverable: false,
-				},
-				NewEvents: reconcileDisarmEvents(
-					s.RoundID, env,
-				),
-			}, nil
+			//nolint:nilerr
+			return appendReconcileDisarm(
+				&ClientStateTransition{
+					NextState: &ClientFailedState{
+						Reason: "failed to build " +
+							"client VTXOs",
+						Error:       err,
+						Recoverable: false,
+					},
+				}, s.RoundID, env,
+			), nil
 		}
 
 		env.Log.InfoS(

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -3124,11 +3124,26 @@ func (s *ForfeitSignaturesCollectingState) forfeitCollectionOutbox(
 	// wavelength#844 hazard window: from here on, a round failure (or a
 	// silent operator, the lumos#618 crash door) must resolve through a
 	// status reconcile before the reservations can be released. Arm the
-	// reconcile timeout so total silence still converges on a probe. A
-	// boarding-only round has no reservations to reconcile, so it skips
-	// the timer entirely, matching the forfeit-count gate every consumer
-	// of the timeout applies.
-	if len(s.Intents.Forfeits) > 0 && env.StatusReconcileTimeout > 0 {
+	// reconcile timeout so total silence still converges on a probe.
+	//
+	// Every round arms the clock, not only forfeit-bearing ones, because
+	// the probe serves two distinct purposes. A forfeit-bearing round
+	// needs it to gate the release on an authoritative dead answer. Any
+	// round at all needs it as the sole liveness clock in this state: a
+	// boarding-only round that skips the timer has no exit when the
+	// operator dies before broadcasting, since no commitment can confirm
+	// and no failure ever arrives, so the deposit strands until the CSV
+	// expires (wavelength#1051).
+	//
+	// The arm leads the fallible sends below deliberately. processOutbox
+	// abandons the rest of the outbox on the first failing Tell, and the
+	// FSM has already checkpointed into InputSigSentState by the time the
+	// outbox is dispatched, so arming last would let a mid-flight send
+	// error reopen the very strand this timer closes: a checkpointed round
+	// with no clock for the rest of the session. Arming first is the safe
+	// direction, since a later send failure merely means the timer fires
+	// and probes.
+	if env.StatusReconcileTimeout > 0 {
 		outboxMsgs = append(outboxMsgs, &StartTimeoutReq{
 			RoundKey: RoundKeyStr(s.RoundID.KeyString()),
 			Phase:    TimeoutPhaseStatusReconcile,
@@ -3136,10 +3151,6 @@ func (s *ForfeitSignaturesCollectingState) forfeitCollectionOutbox(
 		})
 	}
 
-	// The timeout must be armed before either fallible external effect.
-	// processOutbox stops on the first error, so placing it after the
-	// signature submission or chain registration could strand the round in
-	// forfeit collection with no reconciliation path.
 	outboxMsgs = append(outboxMsgs, &SubmitVTXOForfeitSigsToServer{
 		RoundID:    s.RoundID,
 		ForfeitTxs: forfeitTxs,
@@ -4587,7 +4598,10 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 
 		// With no forfeit reservations at stake (a boarding-only
 		// round), nothing can strand and nothing was signed away, so
-		// the round fails immediately as before.
+		// the round fails immediately as before. A delivered failure
+		// carries the same authority a probe would return, so this
+		// round needs no reconcile; disarm the clock it armed on the
+		// way into this state.
 		if len(s.Intents.Forfeits) == 0 ||
 			env.StatusReconcileTimeout <= 0 {
 			return &ClientStateTransition{
@@ -4597,6 +4611,9 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 					Recoverable: evt.Recoverable,
 					FailureCode: evt.FailureCode,
 				},
+				NewEvents: reconcileDisarmEvents(
+					s.RoundID, env,
+				),
 			}, nil
 		}
 
@@ -4631,10 +4648,9 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 		// failure resolution, and no status answer. Probe (again) and
 		// re-arm. The timeout alone never fails the round: with
 		// forfeit signatures out, only an authoritative dead answer
-		// makes the release safe. With no forfeits at stake the
-		// timeout should not even be armed; self-loop defensively.
-		if len(s.Intents.Forfeits) == 0 ||
-			env.StatusReconcileTimeout <= 0 {
+		// makes the release safe, and a boarding-only round needs that
+		// same answer to learn its deposit will never convert.
+		if env.StatusReconcileTimeout <= 0 {
 			return selfLoop(s), nil
 		}
 
@@ -4731,20 +4747,29 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 				Recoverable: failure.Recoverable,
 				FailureCode: failure.FailureCode,
 			},
-			NewEvents: fn.Some(ClientEmittedEvent{
-				Outbox: []ClientOutMsg{
-					cancelStatusReconcileTimeout(s.RoundID),
-				},
-			}),
 		}
 
 		// The release is safe here for the same reason it is safe in
 		// the pre-signing states: the commitment can never confirm.
 		// The wrapper also retires the originating job on a
 		// terminal-for-job failure code.
-		return releaseForfeitsOnFailure(
+		released, err := releaseForfeitsOnFailure(
 			transition, nil, fn.Some(s.RoundID), s.Intents.Forfeits,
 		)
+		if err != nil {
+			return released, err
+		}
+
+		// Disarm only once the wrapper has laid down the release and
+		// the job drop, so the cancel is genuinely last. Seeding it
+		// into the transition above would bury it mid-outbox: the
+		// wrapper prepends the release and appends the job-drop
+		// notification, and since a rejected cancel aborts the rest of
+		// the outbox while the release is fire-and-forget, that
+		// ordering would let a saturated timeout actor strand the
+		// pending intent in recoverable replay -- the one thing the
+		// job drop exists to prevent.
+		return appendReconcileDisarm(released, s.RoundID, env), nil
 
 	case *BoardingConfirmed:
 		env.Log.InfoS(ctx, "Commitment transaction confirmed",
@@ -4760,7 +4785,12 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 		)
 		if err != nil {
 
-			// Error carried into failed state.
+			// Error carried into failed state. This is an exit
+			// from InputSigSentState like any other, so it disarms
+			// the reconcile clock too: the confirmation already
+			// resolved the round's fate, and leaving the one-shot
+			// armed would fire a probe at a round that has settled
+			// terminally.
 			return &ClientStateTransition{ //nolint:nilerr
 				NextState: &ClientFailedState{
 					Reason: "failed to build client " +
@@ -4768,6 +4798,9 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 					Error:       err,
 					Recoverable: false,
 				},
+				NewEvents: reconcileDisarmEvents(
+					s.RoundID, env,
+				),
 			}, nil
 		}
 
@@ -4853,16 +4886,7 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 		outflows := roundLedgerOutflows(s.RoundID, s.Intents)
 
 		// Build outbox messages starting with standard notifications.
-		// The confirmation resolves the round's fate, so any armed
-		// status-reconcile probe is disarmed first.
 		outbox := make([]ClientOutMsg, 0, 3)
-		if len(s.Intents.Forfeits) > 0 &&
-			env.StatusReconcileTimeout > 0 {
-
-			outbox = append(
-				outbox, cancelStatusReconcileTimeout(s.RoundID),
-			)
-		}
 		if len(vtxos) > 0 || len(outflows) > 0 || operatorFee > 0 {
 			outbox = append(outbox, &VTXOCreatedNotification{
 				VTXOs:           vtxos,
@@ -4890,6 +4914,22 @@ func (s *InputSigSentState) ProcessEvent(ctx context.Context, event ClientEvent,
 				CommitmentTxID: evt.TxID,
 				BlockHeight:    evt.BlockHeight,
 			})
+		}
+
+		// The confirmation resolves the round's fate, so any armed
+		// status-reconcile probe is disarmed here. The disarm trails
+		// the notifications above rather than leading them: since
+		// processOutbox abandons the rest of the outbox on the first
+		// failing Tell, a saturated or down timeout actor would
+		// otherwise withhold confirmed funds from the VTXO manager and
+		// leave onRoundComplete unfinalized, even though the VTXOs are
+		// already persisted. Cleanup must never gate delivery. A
+		// cancel that never lands only leaks a one-shot timer, which
+		// fires into a terminal state and self-loops.
+		if env.StatusReconcileTimeout > 0 {
+			outbox = append(
+				outbox, cancelStatusReconcileTimeout(s.RoundID),
+			)
 		}
 
 		return &ClientStateTransition{


### PR DESCRIPTION
A boarding deposit is real money the user parked in an on-chain address to
convert into an off-chain VTXO, and partway through that conversion the
client hits a point of no return where it has signed and can only wait. If
the operator drops the round at exactly that moment, say its finalize write
fails so it rolls back before broadcasting, then nothing will ever tell the
client: no transaction exists to confirm, and no round record survives to
send a failure. The client had one remaining way to find out, a timer that
asks the operator "is this round dead?", but that timer was only armed for
rounds carrying forfeits, which a boarding-only round has none of. So the
client waits forever, the user sees a deposit that never became spendable
and no error explaining why, and the only way to get the coins back is to
wait out the CSV timelock and exit unilaterally. This PR arms that timer for
every round, so the client asks, gets told the round is dead, and fails
cleanly instead of hanging, and gives the deposit back.

In FSM terms, `InputSigSentState` has exactly three exits: the commitment
confirms, the operator delivers a failure, or the reconcile probe returns an
authoritative status. The probe's timer arrived with #844, whose hazard is
releasing forfeit reservations before the round's fate is known, so every
site that touched it gated on a non-empty forfeit set. Read on its own that
gate looks like an optimization, since a boarding-only round has no
reservations to reconcile. What it actually does is shut all three exits at
once. Widening it needs no new protocol surface and no new state, since a
dead status already fails the round and `releaseForfeitsOnFailure` over an
empty forfeit set is a no-op.

So we arm the clock on all three doors into the state: the
forfeit-collection transition, the `PartialSigsSentState` transition a
boarding-only round takes instead (the door #1051 actually walks through),
and the `recoverActiveRounds` reload on restart. All four exits disarm, and
the timeout handler probes rather than self-looping when the round carries
no forfeits. That leaves a simpler invariant than the one it replaces: the
clock is armed for the whole of `InputSigSentState`, and every exit disarms
it.

Ordering is part of that contract. `processOutbox` abandons the rest of the
outbox on the first failing `Tell`, and the FSM has already checkpointed by
dispatch time, so the arm leads the fallible sends; arming last would reopen
this same strand through a different door. The disarms trail every delivery
for the mirror-image reason, since cleanup must never gate confirmed funds
or a terminal job drop.

## How it was found, and how it is verified

The phase 5 DST universal quiescence oracle, not a report. At the end of
every workload run the harness fast-forwards past every TTL, lets the
reconcilers fire, then asserts that nothing money-bearing is parked in a
state something was supposed to move. `[materialize, refreshOk, storeFault]`
passes every per-op assertion in the suite and is caught only by that
end-of-run check:

```
client round 00dc6ad0-2900-7035-bfbd-5ff7ccbfd3eb parked in non-terminal
state *round.InputSigSentState at quiescence: its round is dead on both
sides and nothing will ever move it again
```

We pointed the harness at this branch with the suppressing classification
deleted, making the oracle unconditional: full suite green (90.9s), 500-seed
soak green. In-repo, `checkpoint_arming_test.go` and
`status_reconcile_test.go` cover every door and exit and assert the two
orderings by position rather than presence; every case fails against the
pre-fix code.

## Giving the deposit back

Un-parking the FSM is not the same as getting the money back, so the second
half of this PR does that. `RoundStore` had no counterpart to
`FinalizeRound`, so a failed round kept its checkpoint row: it stayed in
`ListActiveRounds` and was re-hydrated on every start, and the boarding
intents it adopted stayed adopted. Since `boardingIntentSweepable` excludes
`adopted`, the deposit was neither boardable nor sweepable, not before the
CSV and not after it either, because nothing writes the expired status. The
coins stayed pinned against the board limit with no way to reach them.

The recovery machinery turned out to be already built and simply
unreachable. `ListBoardingIntentsByStatus` and
`ListBoardingIntentsBySweepableStatuses` both re-admit a confirmed intent
exactly when its linked round reads `failed`, and `round_statuses` has
carried a `failed` row since the schema landed, commented "Round failed,
intents may need recovery". Nothing ever wrote it.

So `FailRound` writes it, and reverts the round's adopted intents in the
same transaction. Intents revert to `confirmed` rather than `failed`, since
a dead round proves the commitment never broadcast: nothing on-chain failed,
and the UTXO is exactly as it was before the round. That restores both
recovery routes at once, and the revert is guarded on `adopted` in SQL so a
sweep already in flight is never clobbered. The actor calls it from the
`RoundFailedNotification` handler, the one choke point every failure path
already passes through.

Fixes #1051
