### PR TITLE
actordelivery: retry serialization failures in the durable actor commit tx

### DIFF
--- a/db/actordelivery/store_impl.go
+++ b/db/actordelivery/store_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -1624,11 +1625,50 @@ func (s *TxActorDeliveryStore) CleanupExpired(ctx context.Context) error {
 // Compile-time check that TxActorDeliveryStore implements actor.DeliveryStore.
 var _ actor.DeliveryStore = (*TxActorDeliveryStore)(nil)
 
+// txRetryConfig governs how ExecTx replays a transaction that failed with a
+// retryable error.
+type txRetryConfig struct {
+	// numRetries is the number of attempts ExecTx makes before it gives up
+	// and returns ErrRetriesExceeded.
+	numRetries int
+
+	// backoff returns how long to wait before the given retry attempt.
+	backoff func(attempt int) time.Duration
+}
+
+// defaultTxRetryConfig returns the retry settings ExecTx uses unless a caller
+// overrides them. They deliberately match the ones db.TransactionExecutor
+// applies to every other transaction in the codebase.
+func defaultTxRetryConfig() *txRetryConfig {
+	return &txRetryConfig{
+		numRetries: db.DefaultNumTxRetries,
+		backoff:    db.RandRetryDelay,
+	}
+}
+
+// TxRetryOption customizes the retry behavior of a TxAwareActorDeliveryStore.
+type TxRetryOption func(*txRetryConfig)
+
+// WithTxRetries sets how many attempts ExecTx makes before giving up.
+func WithTxRetries(numRetries int) TxRetryOption {
+	return func(c *txRetryConfig) {
+		c.numRetries = numRetries
+	}
+}
+
+// WithTxRetryBackoff sets the delay schedule ExecTx waits out between attempts.
+func WithTxRetryBackoff(backoff func(attempt int) time.Duration) TxRetryOption {
+	return func(c *txRetryConfig) {
+		c.backoff = backoff
+	}
+}
+
 // TxAwareActorDeliveryStore extends Store with transaction
 // execution support for atomic multi-operation workflows.
 type TxAwareActorDeliveryStore struct {
 	*Store
 	querier db.BatchedQuerier
+	retry   *txRetryConfig
 }
 
 // NewTxAwareActorDeliveryStore creates a new transaction-aware delivery store.
@@ -1636,11 +1676,18 @@ func NewTxAwareActorDeliveryStore(
 	db BatchedActorDeliveryQueries,
 	querier db.BatchedQuerier,
 	clock clock.Clock,
+	opts ...TxRetryOption,
 ) *TxAwareActorDeliveryStore {
+
+	retry := defaultTxRetryConfig()
+	for _, opt := range opts {
+		opt(retry)
+	}
 
 	return &TxAwareActorDeliveryStore{
 		Store:   NewStore(db, clock),
 		querier: querier,
+		retry:   retry,
 	}
 }
 
@@ -1648,6 +1695,22 @@ func NewTxAwareActorDeliveryStore(
 // a context with the transaction attached (via WithTx) and a transaction-scoped
 // DeliveryStore. All operations within the function participate in the same
 // transaction.
+//
+// This is the transaction the durable actor framework commits every message
+// turn in, so it carries the ack, the mailbox enqueues the behavior asked for,
+// and the processed marker together. On Postgres those enqueues contend with
+// the consumers' predicate reads, which under SERIALIZABLE surfaces as a 40001
+// abort. We replay the whole transaction on that class of error rather than
+// letting it out, because the alternative is a nack that both burns one of the
+// message's finite delivery attempts and drops any response the turn owed a
+// client.
+//
+// NOTE: fn may run more than once. Replay imposes no requirement the framework
+// did not already have: the pre-existing answer to a failed commit is a nack
+// and a redelivery, which re-runs the same behavior against the same in-memory
+// actor. What replay must not do is re-apply an effect that escaped the
+// transaction, so callers must keep side effects that are not durable writes
+// out of fn and place them after ExecTx returns.
 func (s *TxAwareActorDeliveryStore) ExecTx(
 	ctx context.Context, readOnly bool, fn actor.TxFunc,
 ) error {
@@ -1659,9 +1722,45 @@ func (s *TxAwareActorDeliveryStore) ExecTx(
 		txOpts = db.WriteTxOption()
 	}
 
+	var lastErr error
+	for attempt := 0; attempt < s.retry.numRetries; attempt++ {
+		err := s.execTxAttempt(ctx, txOpts, fn)
+		if err == nil {
+			return nil
+		}
+
+		// Anything the transaction cannot shake off by running again
+		// belongs to the caller.
+		if !db.IsRetryableTxError(err) {
+			return err
+		}
+
+		lastErr = err
+
+		// Back off before replaying so that a set of transactions that
+		// conflicted once does not line up and conflict again. The
+		// budget is bounded well inside the message lease, so a turn
+		// cannot retry its way past its own lease expiry.
+		select {
+		case <-time.After(s.retry.backoff(attempt)):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return fmt.Errorf("%w: %w", db.ErrRetriesExceeded, lastErr)
+}
+
+// execTxAttempt runs a single attempt of the transaction body, from BeginTx
+// through commit and the post-commit wakes. Every attempt gets a fresh
+// transaction, a fresh transaction-scoped store, and fresh enqueue bookkeeping,
+// so a replay cannot inherit anything the rolled-back attempt recorded.
+func (s *TxAwareActorDeliveryStore) execTxAttempt(ctx context.Context,
+	txOpts db.TxOptions, fn actor.TxFunc) error {
+
 	tx, err := s.querier.BeginTx(ctx, txOpts)
 	if err != nil {
-		return err
+		return db.MapSQLError(err)
 	}
 
 	defer func() {
@@ -1687,11 +1786,11 @@ func (s *TxAwareActorDeliveryStore) ExecTx(
 
 	// Execute the function with the transaction-scoped store.
 	if err := fn(txCtx, txStore); err != nil {
-		return err
+		return db.MapSQLError(err)
 	}
 
 	if err := tx.Commit(); err != nil {
-		return err
+		return db.MapSQLError(err)
 	}
 
 	if outboxEnqueued {

--- a/db/actordelivery/store_impl.go
+++ b/db/actordelivery/store_impl.go
@@ -1650,8 +1650,17 @@ func defaultTxRetryConfig() *txRetryConfig {
 type TxRetryOption func(*txRetryConfig)
 
 // WithTxRetries sets how many attempts ExecTx makes before giving up.
+//
+// A budget below one is raised to one. Taking it literally would skip the loop
+// body entirely, so ExecTx would report that it exhausted its retries without
+// ever having run the transaction, and the caller's work would be silently
+// dropped rather than attempted and failed.
 func WithTxRetries(numRetries int) TxRetryOption {
 	return func(c *txRetryConfig) {
+		if numRetries < 1 {
+			numRetries = 1
+		}
+
 		c.numRetries = numRetries
 	}
 }
@@ -1712,6 +1721,15 @@ func NewTxAwareActorDeliveryStore(
 // transaction, so callers must keep side effects that are not durable writes
 // out of fn and place them after ExecTx returns. See the retry loop for why
 // that matters to a caller whose fn is slow enough to outlast its lease.
+//
+// NOTE: serverconn's runFoldedDispatch does not satisfy that contract yet. It
+// calls dispatchBatch inside fn, and the mux-bridged routes there terminate in
+// a network send, so a retryable error raised after the send replays it. The
+// path was already at-least-once, since a failed fold nacks and the batch is
+// re-pulled, and the operator absorbs the duplicate by correlation ID. Retrying
+// in place makes that happen up to numRetries times per turn instead of once,
+// which is why moving the send out of the transaction is the fix rather than a
+// tidiness follow-up. Until it lands, this is the one known in-tree exception.
 func (s *TxAwareActorDeliveryStore) ExecTx(
 	ctx context.Context, readOnly bool, fn actor.TxFunc,
 ) error {

--- a/db/actordelivery/store_impl.go
+++ b/db/actordelivery/store_impl.go
@@ -1710,7 +1710,8 @@ func NewTxAwareActorDeliveryStore(
 // and a redelivery, which re-runs the same behavior against the same in-memory
 // actor. What replay must not do is re-apply an effect that escaped the
 // transaction, so callers must keep side effects that are not durable writes
-// out of fn and place them after ExecTx returns.
+// out of fn and place them after ExecTx returns. See the retry loop for why
+// that matters to a caller whose fn is slow enough to outlast its lease.
 func (s *TxAwareActorDeliveryStore) ExecTx(
 	ctx context.Context, readOnly bool, fn actor.TxFunc,
 ) error {
@@ -1737,10 +1738,26 @@ func (s *TxAwareActorDeliveryStore) ExecTx(
 
 		lastErr = err
 
+		// The last attempt has nothing left to wait for.
+		if attempt == s.retry.numRetries-1 {
+			break
+		}
+
 		// Back off before replaying so that a set of transactions that
-		// conflicted once does not line up and conflict again. The
-		// budget is bounded well inside the message lease, so a turn
-		// cannot retry its way past its own lease expiry.
+		// conflicted once does not line up and conflict again.
+		//
+		// NOTE: the backoff alone is bounded (~13s at the default
+		// budget), but the total time spent here also includes one
+		// execution of fn per attempt, and fn runs the actor behavior.
+		// A slow behavior can therefore push a turn past its own
+		// message lease, and this path starts no heartbeat to extend
+		// it: only the non-transactional paths do. Durable state
+		// survives that, since the fenced ack of whichever worker lost
+		// the lease fails and nacks rather than committing, but any
+		// effect the behavior has outside the transaction would run
+		// twice. Behaviors that both take seconds and act outside the
+		// transaction should carry a lease long enough to cover the
+		// retry budget.
 		select {
 		case <-time.After(s.retry.backoff(attempt)):
 		case <-ctx.Done():

--- a/db/actordelivery/store_tx_retry_test.go
+++ b/db/actordelivery/store_tx_retry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -185,6 +186,36 @@ func TestExecTxGivesUpAfterRetryBudget(t *testing.T) {
 	// error, otherwise an operator only learns that something was retried
 	// and never what the conflict was.
 	require.True(t, db.IsSerializationError(err))
+}
+
+// TestExecTxRetryBudgetFloor asserts that a nonsensical budget still runs the
+// transaction once. Taking a zero or negative budget literally would skip the
+// loop entirely and report exhausted retries for work that was never attempted,
+// which loses the caller's transaction instead of failing it.
+func TestExecTxRetryBudgetFloor(t *testing.T) {
+	t.Parallel()
+
+	for _, budget := range []int{0, -1} {
+		t.Run(fmt.Sprintf("budget %d", budget), func(t *testing.T) {
+			t.Parallel()
+
+			store := newRetryTestStore(t, WithTxRetries(budget))
+
+			var attempts int
+			err := store.ExecTx(
+				context.Background(), false,
+				func(context.Context,
+					actor.DeliveryStore) error {
+
+					attempts++
+
+					return nil
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, 1, attempts)
+		})
+	}
 }
 
 // TestExecTxStopsRetryingOnContextCancel asserts that a cancelled context ends

--- a/db/actordelivery/store_tx_retry_test.go
+++ b/db/actordelivery/store_tx_retry_test.go
@@ -1,0 +1,291 @@
+package actordelivery
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/jackc/pgerrcode"
+	pgconnv5 "github.com/jackc/pgx/v5/pgconn"
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/db"
+	adsqlc "github.com/lightninglabs/wavelength/db/actordelivery/sqlc"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/stretchr/testify/require"
+)
+
+// noBackoff removes the retry delay so the retry tests do not have to sit
+// through the production backoff schedule.
+func noBackoff(int) time.Duration {
+	return 0
+}
+
+// newRetryTestStore builds a transaction-aware store with the given retry
+// options applied on top of a zero backoff.
+func newRetryTestStore(t *testing.T,
+	opts ...TxRetryOption) *TxAwareActorDeliveryStore {
+
+	t.Helper()
+
+	testDB := db.NewTestDB(t)
+	actorQueries := adsqlc.New(testDB.DB)
+
+	actorDB := db.NewTransactionExecutor(
+		testDB.BaseDB,
+		func(tx *sql.Tx) ActorDeliveryQueries {
+			return actorQueries.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+
+	allOpts := append(
+		[]TxRetryOption{WithTxRetryBackoff(noBackoff)}, opts...,
+	)
+
+	return NewTxAwareActorDeliveryStore(
+		actorDB, testDB.BaseDB,
+		clock.NewTestClock(
+			time.Now(),
+		),
+		allOpts...,
+	)
+}
+
+// pgErr builds a postgres driver error carrying the given SQLSTATE, which is
+// what the production classifier in db.MapSQLError keys off.
+func pgErr(code string) error {
+	return &pgconnv5.PgError{
+		Code:     code,
+		Message:  "synthetic " + code,
+		Severity: "ERROR",
+	}
+}
+
+// TestExecTxRetriesSerializationFailure asserts that a serialization failure
+// raised inside the transaction body is replayed rather than surfaced. This is
+// the conflict the durable actor egress path hits on Postgres when concurrent
+// turns enqueue into mailboxes that their consumers are concurrently scanning.
+func TestExecTxRetriesSerializationFailure(t *testing.T) {
+	t.Parallel()
+
+	store := newRetryTestStore(t)
+
+	var attempts int
+	err := store.ExecTx(
+		context.Background(), false,
+		func(context.Context, actor.DeliveryStore) error {
+			attempts++
+			if attempts < 3 {
+				return pgErr(pgerrcode.SerializationFailure)
+			}
+
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 3, attempts, "body should have been replayed twice")
+}
+
+// TestExecTxRetriesAbortedTransaction asserts that the aborted-transaction
+// state is replayed too. A caller that logs and swallows its own serialization
+// failure leaves the transaction poisoned, so the next statement reports 25P02
+// instead of the 40001 underneath it. Keying only on 40001 would miss the very
+// shape that dropped a client-owed response in production.
+func TestExecTxRetriesAbortedTransaction(t *testing.T) {
+	t.Parallel()
+
+	store := newRetryTestStore(t)
+
+	var attempts int
+	err := store.ExecTx(
+		context.Background(), false,
+		func(context.Context, actor.DeliveryStore) error {
+			attempts++
+			if attempts < 2 {
+				return pgErr(pgerrcode.InFailedSQLTransaction)
+			}
+
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts, "body should have been replayed once")
+}
+
+// TestExecTxDoesNotRetryPlainErrors asserts that an error the transaction
+// cannot shake off by running again is handed straight back to the caller,
+// unretried. Replaying those would only multiply the work behind a failure
+// that is going to happen every time.
+func TestExecTxDoesNotRetryPlainErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "opaque error",
+			err:  errors.New("behavior rejected the message"),
+		},
+		{
+			name: "unique violation",
+			err:  pgErr(pgerrcode.UniqueViolation),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newRetryTestStore(t)
+
+			var attempts int
+			err := store.ExecTx(
+				context.Background(), false,
+				func(context.Context,
+					actor.DeliveryStore) error {
+
+					attempts++
+
+					return test.err
+				},
+			)
+			require.Error(t, err)
+			require.Equal(t, 1, attempts, "should not have retried")
+		})
+	}
+}
+
+// TestExecTxGivesUpAfterRetryBudget asserts that a conflict which never clears
+// exhausts a bounded budget and then reports ErrRetriesExceeded. The bound is
+// what keeps a turn from retrying its way past its own message lease.
+func TestExecTxGivesUpAfterRetryBudget(t *testing.T) {
+	t.Parallel()
+
+	const budget = 4
+
+	store := newRetryTestStore(t, WithTxRetries(budget))
+
+	var attempts int
+	err := store.ExecTx(
+		context.Background(), false,
+		func(context.Context, actor.DeliveryStore) error {
+			attempts++
+
+			return pgErr(pgerrcode.SerializationFailure)
+		},
+	)
+	require.ErrorIs(t, err, db.ErrRetriesExceeded)
+	require.Equal(t, budget, attempts)
+
+	// The failure that drove the retries must survive in the returned
+	// error, otherwise an operator only learns that something was retried
+	// and never what the conflict was.
+	require.True(t, db.IsSerializationError(err))
+}
+
+// TestExecTxStopsRetryingOnContextCancel asserts that a cancelled context ends
+// the retry loop instead of waiting out the remaining budget. Shutdown must not
+// have to block on a conflict that no longer matters.
+func TestExecTxStopsRetryingOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	// Use the real backoff so the loop actually has a delay to be
+	// interrupted during.
+	store := newRetryTestStore(
+		t, WithTxRetryBackoff(func(int) time.Duration {
+			return time.Hour
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var attempts int
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- store.ExecTx(
+			ctx, false,
+			func(context.Context, actor.DeliveryStore) error {
+				attempts++
+				cancel()
+
+				return pgErr(pgerrcode.SerializationFailure)
+			},
+		)
+	}()
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, 1, attempts)
+
+	case <-time.After(30 * time.Second):
+		t.Fatal("ExecTx did not abandon its backoff on cancellation")
+	}
+}
+
+// TestExecTxCommitsReplayedWork asserts that work performed by a replayed body
+// is actually durable. The retry rolls the first attempt back, so the row the
+// caller sees afterwards must be the one the winning attempt wrote.
+func TestExecTxCommitsReplayedWork(t *testing.T) {
+	t.Parallel()
+
+	store := newRetryTestStore(t)
+
+	mailboxID := generateTestID()
+	ctx := context.Background()
+
+	var attempts int
+	err := store.ExecTx(
+		ctx, false,
+		func(txCtx context.Context, txStore actor.DeliveryStore) error {
+			attempts++
+
+			err := txStore.EnqueueMessage(
+				txCtx, actor.EnqueueParams{
+					ID:          generateTestID(),
+					MailboxID:   mailboxID,
+					MessageType: "test.Message",
+					Payload:     []byte("replayed"),
+					AvailableAt: time.
+						Now().
+						Add(-time.Minute),
+					MaxAttempts: 3,
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			// Fail the first attempt after the enqueue so the
+			// rollback has something to undo.
+			if attempts < 2 {
+				return pgErr(pgerrcode.SerializationFailure)
+			}
+
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts)
+
+	// The winning attempt's enqueue must be durable.
+	msg, err := store.LeaseNextMessage(
+		ctx, mailboxID, generateTestID(), time.Minute,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	require.Equal(t, []byte("replayed"), msg.Payload)
+
+	// And it must be the only one: the rolled-back attempt also enqueued,
+	// so a replay that leaked its predecessor's writes would leave a
+	// duplicate behind here.
+	dup, err := store.LeaseNextMessage(
+		ctx, mailboxID, generateTestID(), time.Minute,
+	)
+	require.NoError(t, err)
+	require.Nil(t, dup, "rolled-back enqueue survived the replay")
+}

--- a/db/actordelivery/store_tx_retry_test.go
+++ b/db/actordelivery/store_tx_retry_test.go
@@ -244,12 +244,20 @@ func TestExecTxCommitsReplayedWork(t *testing.T) {
 		func(txCtx context.Context, txStore actor.DeliveryStore) error {
 			attempts++
 
+			// Tag the payload per attempt so the assertions below
+			// identify which attempt's row survived, not merely
+			// that one did.
+			payload := []byte("replayed")
+			if attempts < 2 {
+				payload = []byte("rolled-back")
+			}
+
 			err := txStore.EnqueueMessage(
 				txCtx, actor.EnqueueParams{
 					ID:          generateTestID(),
 					MailboxID:   mailboxID,
 					MessageType: "test.Message",
-					Payload:     []byte("replayed"),
+					Payload:     payload,
 					AvailableAt: time.
 						Now().
 						Add(-time.Minute),

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -175,6 +175,16 @@ func (t *txExecutorOptions) randRetryDelay(attempt int) time.Duration {
 	return actualDelay
 }
 
+// RandRetryDelay returns the default randomized backoff for the given retry
+// attempt, doubling with each attempt and capped at DefaultMaxRetryDelay.
+//
+// This exists so that transaction executors outside this type, such as the
+// durable actor framework's commit transaction, can back off on exactly the
+// same schedule instead of growing a second copy of the policy.
+func RandRetryDelay(attempt int) time.Duration {
+	return defaultTxExecutorOptions().randRetryDelay(attempt)
+}
+
 // TxExecutorOption is a functional option that allows us to pass in optional
 // argument when creating the executor.
 type TxExecutorOption func(*txExecutorOptions)

--- a/db/sqlerrors.go
+++ b/db/sqlerrors.go
@@ -99,6 +99,18 @@ func classifyPostgresError(code string, dbErr error) error {
 			DBError: dbErr,
 		}
 
+	// A statement was issued against a transaction that an earlier failure
+	// already aborted. Postgres rejects every further command until the
+	// block ends, so this code is never the root cause, only its echo. The
+	// root cause is frequently a serialization failure that an intervening
+	// caller logged and swallowed, which leaves the retry layer looking at
+	// 25P02 instead of the 40001 underneath it. Rolling back and replaying
+	// the transaction is the only way forward either way.
+	case pgerrcode.InFailedSQLTransaction:
+		return &ErrAbortedTransaction{
+			DBError: dbErr,
+		}
+
 	// Handle schema error.
 	case pgerrcode.UndefinedColumn, pgerrcode.UndefinedTable:
 		return &ErrSchemaError{
@@ -154,6 +166,23 @@ func (e ErrDeadlockError) Error() string {
 	return e.DBError.Error()
 }
 
+// ErrAbortedTransaction is an error type which represents a database agnostic
+// error that a statement was issued against a transaction that an earlier
+// failure had already aborted.
+type ErrAbortedTransaction struct {
+	DBError error
+}
+
+// Unwrap returns the wrapped error.
+func (e ErrAbortedTransaction) Unwrap() error {
+	return e.DBError
+}
+
+// Error returns the error message.
+func (e ErrAbortedTransaction) Error() string {
+	return e.DBError.Error()
+}
+
 // IsSerializationError returns true if the given error is a serialization
 // error.
 func IsSerializationError(err error) bool {
@@ -169,10 +198,33 @@ func IsDeadlockError(err error) bool {
 	return errors.As(err, &deadlockError)
 }
 
+// IsAbortedTransactionError returns true if the given error reports that the
+// transaction the statement ran in had already been aborted.
+func IsAbortedTransactionError(err error) bool {
+	var abortedTx *ErrAbortedTransaction
+
+	return errors.As(err, &abortedTx)
+}
+
 // IsSerializationOrDeadlockError returns true if the given error is either a
 // deadlock error or a serialization error.
 func IsSerializationOrDeadlockError(err error) bool {
 	return IsDeadlockError(err) || IsSerializationError(err)
+}
+
+// IsRetryableTxError returns true if the given error means the transaction it
+// came from can be replayed from the top with a reasonable chance of a
+// different outcome.
+//
+// This is a superset of IsSerializationOrDeadlockError: it also covers the
+// aborted-transaction state, which is what a caller that logs and swallows a
+// serialization failure leaves behind for the next statement to trip over.
+// Retrying on that echo costs a bounded number of replays when the underlying
+// failure turns out to be deterministic, and recovers the transaction when it
+// does not.
+func IsRetryableTxError(err error) bool {
+	return IsSerializationOrDeadlockError(err) ||
+		IsAbortedTransactionError(err)
 }
 
 // ErrSchemaError is an error type which represents a database agnostic error


### PR DESCRIPTION
In this PR, we give the durable actor framework's commit transaction the same
serialization-retry loop that `db.TransactionExecutor` applies to every other
transaction in the codebase. Fixes #701.

`TxAwareActorDeliveryStore.ExecTx` was a bare `BeginTx`, run the body, `Commit`,
with a deferred `Rollback` and nothing else. That's the transaction every actor
message turn commits in, so it carries the ack, the mailbox enqueues the
behavior asked for, and the processed marker together. On postgres those
enqueues contend with the consumers' predicate reads (the self-referential `NOT
EXISTS` anti-join in `PeekNextMailboxMessage`), and under `SERIALIZABLE` that
contention comes back as a 40001 abort. SQLite never sees it, since writers
serialize at `BEGIN` under `_txlock=immediate`.

The cost of not retrying is bigger than it looks. The framework's answer to a
failed commit is to nack, which burns one of the message's finite delivery
attempts *and* drops whatever response the turn owed a client. So a burst of
concurrent turns can lose a client-visible response to what was only contention
underneath. That's not hypothetical: it's the operator half of the signet
incident in lightninglabs/lumos#718, which fed the fund loss in
lightninglabs/swapdk-server#265. Note that `lumos` vendors this exact file
(`replace github.com/lightninglabs/wavelength => ./client`, byte-identical,
sha `f137f566`), so this is the same code, not just the same bug shape.

## The 25P02 wrinkle

Worth calling out because it changes what the fix has to cover, and it's the
one part reviewers should push on hardest.

`classifyPostgresError` only knew about 40001 and 40P01. 25P02, the state
postgres puts a transaction into once an earlier statement in it has failed,
fell through to the default branch and came back as an opaque "unknown postgres
error". A retry loop keyed only on 40001 would therefore not have fixed the
production path at all, because lumos swallows its 40001 in `pushResponse` and
what actually surfaces is the 25P02 from the following `MarkProcessed`.

This isn't incident-only. A 6h sample of live signet `lumosd` (master-ece44a1,
current pod, nobody driving concurrent bursts) shows it at background rate:

```
lumosd:  11 x SQLSTATE 40001
          3 x SQLSTATE 25P02
swapd:    0
waved:    0

All three 25P02, identical shape:
  [WRN] OORS: Durable actor Tell message failed
  err="current transaction is aborted, commands ignored until end of
       transaction block (SQLSTATE 25P02)"
  msg_type=FinalizeOORRequest attempts=0 effective_attempts=1
```

Every one of them is on `FinalizeOORRequest`, the same actor path and same
`msg_type` as the 16:29 incident lines in lumos#718. That's the concrete path
`ErrAbortedTransaction` has to cover. (Thanks to NobleSun for the measurement.)

Worth being precise about the ratio, since the naive reading overstates one
thing and understates another. The two 16:29 25P02s are each preceded within
~10ms by a 40001 on the *same* session: the `Failed to push OOR response`
40001 and the `Tell message failed` 25P02 are one conflict surfacing twice,
once classified and once not. So the classifier gap isn't a separate ~21% of
events. It's the second half of the same event, and it's the half that carries
the actor turn.

## Why the retry has to happen server-side

The log trace for those events settles a question I'd otherwise have hand-waved,
and it goes the unhelpful way. Taking `oor(d7afcea8)`, the session already cited
in lumos#718:

```
16:29:03.334  Recipients notified          num_recipients=2
16:29:03.334  State transition AwaitingRecipientsNotifyState -> FinalizedState
16:29:03.334  Session finalized
16:29:03.345  [WRN] Failed to push OOR response via clientconn   err=40001
16:29:03.351  [WRN] Durable actor Tell message failed            err=25P02
16:29:05.751  Processing finalize request  num_checkpoints=1   <- CLIENT re-sends
16:29:05.751  State transition FinalizedState -> FinalizedState  <- idempotent no-op
16:29:05.948  Lease loop exiting on shutdown
16:29:05.948  Durable actor terminated
```

Two other sessions repeat this byte for byte, with 2.0s and 1.4s gaps.

The part that matters for this PR: **the effect commits before the response is
lost.** `Recipients notified` and the `FinalizedState` transition both land ~11ms
*before* the 40001. The ledger side is durable and only the response to the
requester is gone. That's precisely the precondition for swapdk-server#265:
lumos holds the recipient VTXO, the requester never learns the outpoint, and
swapd fails the swap at deadline having already funded it.

The other part: **the server never retried its own response.** There's no second
push attempt logged. What looks like recovery is the *client* timing out and
re-sending 1.4 to 3.0s later, and the actor terminates ~200ms after that second
pass. So the nack-and-redelivery path people (me included) assume is the safety
net did not run here. An in-process retry is the only server-side mechanism that
would have kept the response.

I'll be careful about what this does *not* show: the `Session finalized` line is
emitted on both the notify path and the idempotent no-op branch, so the logs
can't tell us whether that second pass actually pushed a response. Something
recovered these three, since the sessions are finalized and the VTXOs went on to
be spent. I'm claiming the effect-before-response ordering and the absence of a
server-side retry, not that the response was or wasn't eventually delivered.

So we classify it, and add `IsRetryableTxError` alongside the existing
predicate. 25P02 is never a root cause, only its echo, and the only thing to do
with a poisoned transaction is redo it. We add a new predicate rather than
widening `IsSerializationOrDeadlockError` in place so callers asking
specifically whether they lost a serialization race still get an honest answer
to that narrower question.

The tradeoff, stated concretely because it's the one thing here that costs
something: when the swallowed root cause is deterministic (say a unique
violation), every replay re-fails and the final error is `ErrRetriesExceeded`
wrapping the 25P02 echo, so the true cause still never surfaces. Worst case to
reach the dead-letter queue is ~10 in-process replays per delivery times 10
delivery attempts with a 10s nack between them, so on the order of minutes and
~100 behavior executions for a message that was never going to succeed. Bounded,
no correctness loss, and only on an already-failing path, but real. Failing fast
wouldn't have surfaced the true cause either, since the swallower ate it. The
actual fix is to stop swallowing in the offending caller; this makes the
framework robust to callers that do.

A useful side effect: 25P02 in the logs is a swallowed-error marker. Anywhere
it shows up, some caller ate a real error.

## On the body running more than once

`fn` may now run more than once, which means the actor behavior re-runs. This
imposes no requirement the framework didn't already have: the pre-existing
answer to a failed commit is `delivery.Nack`, and a redelivered message re-runs
the same behavior against the same in-memory actor instance. So behaviors must
already tolerate re-execution after a rolled-back transaction. In-process replay
is that same re-entrancy contract, just faster and without consuming a delivery
attempt.

To head off an apparent contradiction with the section above: that's a claim
about the framework's design contract, which is what governs whether replay is
*safe*. It is not a claim that redelivery reliably *runs*. The trace shows it
didn't in those three cases, because the actor terminated first. Those are two
different questions, and the second one is precisely why the in-process retry is
worth having.

Every attempt gets a fresh transaction, a fresh transaction-scoped store, and
fresh enqueue bookkeeping, so a replay can't inherit anything a rolled-back
attempt recorded. `TestExecTxCommitsReplayedWork` pins that down: it enqueues
from inside the body, fails the first attempt, and asserts exactly one message
survives. What a replay must *not* do is re-apply an effect that escaped the
transaction, so that contract is spelled out in the doc comment.

On the lease interaction, an earlier version of this PR claimed the budget stays
"bounded well inside" the 30s lease. That overstated it and is now corrected in
the code comment. The *backoff* is bounded, ~13s at the default budget, but the
wall time also includes one execution of `fn` per attempt, and `fn` runs the
behavior. This path also starts no heartbeat to extend the lease: only
`processWithoutTransaction` and `processWithExec` do. So a behavior taking
seconds per attempt can retry past its own lease. Durable state survives that,
because the losing worker's fenced ack fails and nacks rather than committing,
but an effect the behavior has *outside* the transaction would run twice. It's a
pre-existing gap that the loop widens, and the comment now says so rather than
implying a guarantee we don't have.

## Independent review

A Fable 5 reviewer went over this adversarially before I opened it up: invariant
verification, simplification, and a hunt for other live instances of the two bug
shapes fixed here.

It confirmed the replay-safety argument by tracing every live `fn` the loop can
replay (`processInTransaction`, `execCore`, the outbox `deliver` closure, and
`runFoldedDispatch`) and found no accumulator, promise, or registry that
survives a rolled-back attempt. Notably `handleResultInTx` builds a fresh
`txDelivery` per invocation, and `AdvanceDispatch` is a monotonic max, so the
one cross-attempt mutation is idempotent. It also confirmed the synthetic
`*pgconn.PgError` in the tests takes exactly the production classification path,
and that the old `IsSerializationOrDeadlockError` path is genuinely untouched.

Three findings I acted on, in the last commit: the overstated lease claim above,
a wasted backoff after the final attempt, and a replay test that wrote the same
payload on both attempts so its payload assertion proved only that *a* row
survived rather than *which*.

The variant hunt came back empty for both shapes across `db/`,
`db/actordelivery/`, `baselib/actor/` and `serverconn/`, which is the answer I
wanted: the only other `BeginTx` is a test fixture helper, and the log-and-
swallow instances that exist run on non-transactional paths where they can't
poison anything.

Residual gap it flagged and I'm not closing here: a real 40001 surfacing from
`tx.Commit()` rather than from `fn` goes through the same `MapSQLError` call but
is not separately exercised. One `make systest db=postgres` run would close it.

## What this does not fix

Two things, and I'd rather flag them than let the PR read as more complete than
it is.

First, #701 proposed `FOR UPDATE SKIP LOCKED` on `LeaseNextMailboxMessage` as
the "more surgical" alternative. That would not have addressed lightninglabs/lumos#718: different
query, different conflict. The lumos conflict is on the response `INSERT`
against `PeekNextMailboxMessage`'s anti-join, and the OOR session actor is
leaseless with `NumWorkers=1`. Only the retry loop covers both.

Second, and more important: `runFoldedDispatch` (`serverconn/ingress.go:615`)
holds this very `ExecTx` write transaction open across a gRPC round trip, via
`dispatchBatch` into `handleInboundRPC` and `edge.Send` at
`waved/server.go:3546`. That's a much larger SSI conflict window than anything
retrying can paper over, and unlike the retry gap it hits SQLite too, since it
pins the single global writer lock for the duration of a network RTT with no
conflict required. There's precedent for the fix in the same file:
`ingress.go:587-595` documents moving waiter-backed responses out of the
transaction for exactly this reason, and the durable dispatch path never got
the same treatment. That fix is in progress separately.

So this PR absorbs the conflicts. It doesn't stop manufacturing them. Two
follow-ups are underway that do: moving the dispatch IO out of the write
transaction, and the isolation work (read-only transactions to `REPEATABLE
READ`, plus an audit of the write paths to establish which genuinely need SSI,
following the ground covered by lightningnetwork/lnd#10997, #10998 and #10999).
I'd expect the retry budget here to look over-provisioned once those land, and
that's the right direction to be wrong in.

## Testing

Six tests in `db/actordelivery/store_tx_retry_test.go`, driven with synthetic
postgres driver errors so the real classifier in `db.MapSQLError` is what's
under test rather than a stub. They cover: 40001 replayed, 25P02 replayed,
unrelated errors and unique violations not replayed, the budget bounded and
reporting `ErrRetriesExceeded` with the driving failure still wrapped inside,
cancellation abandoning the backoff, and replayed work committing exactly once.

`make unit pkg=db`, `make unit pkg=baselib/actor`, `make lint-changed-local`
(0 issues), and `make commitmsg-lint` all pass. See each commit message for
detail on the incremental changes.




