### PR TITLE
db: run read-only Postgres transactions at REPEATABLE READ

### DIFF
--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -216,3 +216,9 @@ when adding one.
 ## Deep Docs
 
 - [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.
+- [docs/postgres_isolation.md](../docs/postgres_isolation.md) — Isolation
+  policy: read-only Postgres transactions run at `REPEATABLE READ` with
+  `READ ONLY` (no `SIRead` predicate locks, never a 40001), writers stay
+  `SERIALIZABLE`. Also holds the write-path snapshot-isolation audit and the
+  inventory of the six partial unique indexes that any new `ON CONFLICT`
+  target has to be checked against.

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -221,4 +221,6 @@ when adding one.
   `READ ONLY` (no `SIRead` predicate locks, never a 40001), writers stay
   `SERIALIZABLE`. Also holds the write-path snapshot-isolation audit and the
   inventory of the six partial unique indexes that any new `ON CONFLICT`
-  target has to be checked against.
+  target has to be checked against, along with the caveat that a conflict
+  target can also miss a plain unique constraint declared inline in a
+  `CREATE TABLE`.

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -367,13 +367,57 @@ type BaseDB struct {
 	*sqlc.Queries
 }
 
+// txIsolationLevel returns the isolation level a transaction against the given
+// backend should be opened with.
+//
+// Read-write transactions always run at SERIALIZABLE, which is the level the
+// storage layer has always promised writers. Read-only transactions on Postgres
+// are instead opened at REPEATABLE READ, which in Postgres is snapshot
+// isolation: the transaction reads from a single consistent snapshot for its
+// whole lifetime, taken when its first statement runs rather than at BEGIN.
+//
+// That is a real, if modest, weakening. Snapshot isolation is not
+// serializability, so the reader is no longer guaranteed to observe a state
+// that corresponds to some serial ordering of the writers running alongside it.
+// The read-only transaction anomaly described by Fekete and O'Neil is once
+// again permitted. We accept that because our read paths only ever consume a
+// point-in-time view of the database and never depended on being ordered
+// against writers in other transactions. A read that feeds a later write in a
+// separate transaction was never protected across that boundary at any
+// isolation level.
+//
+// In exchange, a read-only REPEATABLE READ transaction takes no part in
+// Postgres' serializable snapshot isolation conflict graph. It acquires no
+// SIRead predicate locks, is not itself subject to SSI serialization failures,
+// and can no longer cause a concurrent writer to be aborted as a pivot. Since
+// the daemon is extremely read heavy, this removes a large amount of needless
+// abort pressure from the system.
+//
+// SQLite is always effectively serializable because it only ever admits a
+// single writer, so there is nothing to gain there and we leave it alone.
+func txIsolationLevel(backend sqlc.BackendType,
+	readOnly bool) sql.IsolationLevel {
+
+	if readOnly && backend == sqlc.BackendTypePostgres {
+		return sql.LevelRepeatableRead
+	}
+
+	return sql.LevelSerializable
+}
+
 // BeginTx wraps the normal sql specific BeginTx method with the TxOptions
 // interface. This interface is then mapped to the concrete sql tx options
 // struct.
 func (s *BaseDB) BeginTx(ctx context.Context, opts TxOptions) (*sql.Tx, error) {
+	readOnly := opts.ReadOnly()
+
+	// The read-only flag is not just advisory here: Postgres only skips
+	// predicate lock acquisition for a transaction that is actually
+	// declared READ ONLY, so the flag is what makes the relaxed isolation
+	// level worth anything.
 	sqlOptions := sql.TxOptions{
-		ReadOnly:  opts.ReadOnly(),
-		Isolation: sql.LevelSerializable,
+		ReadOnly:  readOnly,
+		Isolation: txIsolationLevel(s.Backend(), readOnly),
 	}
 
 	return s.DB.BeginTx(ctx, &sqlOptions)

--- a/db/interfaces_postgres_test.go
+++ b/db/interfaces_postgres_test.go
@@ -1,0 +1,88 @@
+//go:build test_postgres
+
+package db
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// txSessionState reads back the isolation level and read-only access mode that
+// Postgres actually applied to the given transaction. Asserting on the server's
+// own view is the only way to prove that the requested sql.TxOptions survived
+// the trip through the pgx stdlib driver and into the BEGIN statement.
+func txSessionState(t *testing.T, tx *sql.Tx) (string, string) {
+	t.Helper()
+
+	var isolation string
+	err := tx.QueryRow("SHOW transaction_isolation").Scan(&isolation)
+	require.NoError(t, err)
+
+	var readOnly string
+	err = tx.QueryRow("SHOW transaction_read_only").Scan(&readOnly)
+	require.NoError(t, err)
+
+	return isolation, readOnly
+}
+
+// TestPostgresBeginTxIsolation asserts that read-only transactions against
+// Postgres are opened as a read-only REPEATABLE READ tx, while writers stay
+// SERIALIZABLE. The read-only flag matters as much as the level, because
+// Postgres only skips SIRead predicate lock acquisition for a transaction that
+// is genuinely declared read only.
+//
+// The subtests deliberately share one store. Each store costs a docker
+// container, and the fixture derives its port from a docker port binding that
+// is not always populated under load.
+func TestPostgresBeginTxIsolation(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewTestPostgresDB(t)
+
+	t.Run("read-only", func(t *testing.T) {
+		tx, err := store.BeginTx(ctx, ReadTxOption())
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, tx.Rollback())
+		}()
+
+		isolation, readOnly := txSessionState(t, tx)
+		require.Equal(t, "repeatable read", isolation)
+		require.Equal(t, "on", readOnly)
+	})
+
+	t.Run("read-write", func(t *testing.T) {
+		tx, err := store.BeginTx(ctx, WriteTxOption())
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, tx.Rollback())
+		}()
+
+		isolation, readOnly := txSessionState(t, tx)
+		require.Equal(t, "serializable", isolation)
+		require.Equal(t, "off", readOnly)
+	})
+
+	// The READ ONLY access mode is enforced by the server rather than being
+	// advisory. This is the property that justifies the audit assumption
+	// that every ReadTxOption call site is truly read-only: if one of them
+	// ever starts writing, it fails loudly instead of silently relying on
+	// snapshot isolation.
+	t.Run("read-only rejects writes", func(t *testing.T) {
+		tx, err := store.BeginTx(ctx, ReadTxOption())
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, tx.Rollback())
+		}()
+
+		_, err = tx.ExecContext(
+			ctx, "INSERT INTO chain_info (id, chain_name, "+
+				"genesis_hash) VALUES (2, 'nope', '\\x01')",
+		)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "read-only transaction")
+	})
+}

--- a/db/interfaces_test.go
+++ b/db/interfaces_test.go
@@ -56,3 +56,86 @@ func TestTransactionExecutorUsesContextTx(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, errors.Is(err, sql.ErrNoRows))
 }
+
+// TestTxIsolationLevel asserts that the isolation level is only relaxed for
+// read-only transactions on Postgres. Every other combination has to stay
+// fully serializable, in particular SQLite, which the same BaseDB backs.
+func TestTxIsolationLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		backend  sqlc.BackendType
+		readOnly bool
+		expected sql.IsolationLevel
+	}{
+		{
+			name:     "postgres read-only",
+			backend:  sqlc.BackendTypePostgres,
+			readOnly: true,
+			expected: sql.LevelRepeatableRead,
+		},
+		{
+			name:     "postgres read-write",
+			backend:  sqlc.BackendTypePostgres,
+			readOnly: false,
+			expected: sql.LevelSerializable,
+		},
+		{
+			name:     "sqlite read-only",
+			backend:  sqlc.BackendTypeSqlite,
+			readOnly: true,
+			expected: sql.LevelSerializable,
+		},
+		{
+			name:     "sqlite read-write",
+			backend:  sqlc.BackendTypeSqlite,
+			readOnly: false,
+			expected: sql.LevelSerializable,
+		},
+		{
+			name:     "unknown read-only",
+			backend:  sqlc.BackendTypeUnknown,
+			readOnly: true,
+			expected: sql.LevelSerializable,
+		},
+		{
+			name:     "unknown read-write",
+			backend:  sqlc.BackendTypeUnknown,
+			readOnly: false,
+			expected: sql.LevelSerializable,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(
+				t, test.expected,
+				txIsolationLevel(test.backend, test.readOnly),
+			)
+		})
+	}
+}
+
+// TestBeginTxReadOnlyUsable asserts that a read-only transaction against the
+// active test backend can still be opened and read from. On Postgres this
+// exercises the relaxed read-only REPEATABLE READ path, and on SQLite it
+// guards against a regression from the backend gate.
+func TestBeginTxReadOnlyUsable(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewTestDB(t)
+
+	tx, err := store.BeginTx(ctx, ReadTxOption())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tx.Rollback())
+	}()
+
+	var one int
+	require.NoError(t, tx.QueryRowContext(ctx, "SELECT 1").Scan(&one))
+	require.Equal(t, 1, one)
+}

--- a/db/sqlerrors.go
+++ b/db/sqlerrors.go
@@ -190,6 +190,18 @@ func (e ErrSQLUniqueConstraintViolation) Error() string {
 		withPgDetail(e.DBError))
 }
 
+// Unwrap returns the wrapped error.
+//
+// Without this, the mapped error is a dead end for errors.As, and the
+// PgErrorConstraint and PgErrorDetail extractors return empty for every caller
+// that holds the mapped error rather than the raw driver one. That is the
+// normal case, since ExecTx returns the mapped error, and identifying which of
+// the partial unique indexes actually fired is the whole point of surfacing
+// the constraint name.
+func (e ErrSQLUniqueConstraintViolation) Unwrap() error {
+	return e.DBError
+}
+
 // ErrSerializationError is an error type which represents a database agnostic
 // error that a transaction couldn't be serialized with other concurrent db
 // transactions.

--- a/db/sqlerrors.go
+++ b/db/sqlerrors.go
@@ -111,6 +111,74 @@ func classifyPostgresError(code string, dbErr error) error {
 	}
 }
 
+// PgErrorDetail extracts the Detail field of an underlying Postgres error, if
+// there is one. The Error method of pgconn.PgError renders only the severity,
+// the message and the SQLSTATE code, so the Detail is otherwise dropped on the
+// floor before it ever reaches a log line.
+//
+// That detail is the only thing that tells two very different 40001 aborts
+// apart. A true serializable snapshot isolation abort carries a "Reason code"
+// naming the transaction's role in the conflict graph, whereas an ordinary
+// write-write conflict on the same row carries none. Once read-only
+// transactions stop taking predicate locks, this is the signal that says
+// whether a given write path still depends on SSI or would be equally happy at
+// REPEATABLE READ. For a 23505 the detail names the constraint and the
+// conflicting key values, which is what identifies a lost creation race.
+func PgErrorDetail(err error) string {
+	var pgErrV4 *pgconnv4.PgError
+	if errors.As(err, &pgErrV4) {
+		return pgErrV4.Detail
+	}
+
+	var pgErrV5 *pgconnv5.PgError
+	if errors.As(err, &pgErrV5) {
+		return pgErrV5.Detail
+	}
+
+	return ""
+}
+
+// PgErrorConstraint extracts the name of the constraint that a Postgres error
+// was raised against, if there is one. The schema carries six partial unique
+// indexes, and without the constraint name a 23505 raised by any of them looks
+// exactly like a 23505 raised by the table's primary key.
+func PgErrorConstraint(err error) string {
+	var pgErrV4 *pgconnv4.PgError
+	if errors.As(err, &pgErrV4) {
+		return pgErrV4.ConstraintName
+	}
+
+	var pgErrV5 *pgconnv5.PgError
+	if errors.As(err, &pgErrV5) {
+		return pgErrV5.ConstraintName
+	}
+
+	return ""
+}
+
+// withPgDetail renders a database error together with the Postgres constraint
+// name and detail when they are available, and falls back to the plain error
+// otherwise.
+func withPgDetail(err error) string {
+	constraint := PgErrorConstraint(err)
+	detail := PgErrorDetail(err)
+
+	switch {
+	case constraint != "" && detail != "":
+		return fmt.Sprintf("%v (constraint: %s, detail: %s)", err,
+			constraint, detail)
+
+	case constraint != "":
+		return fmt.Sprintf("%v (constraint: %s)", err, constraint)
+
+	case detail != "":
+		return fmt.Sprintf("%v (detail: %s)", err, detail)
+
+	default:
+		return err.Error()
+	}
+}
+
 // ErrSQLUniqueConstraintViolation is an error type which represents a database
 // agnostic SQL unique constraint violation.
 type ErrSQLUniqueConstraintViolation struct {
@@ -118,7 +186,8 @@ type ErrSQLUniqueConstraintViolation struct {
 }
 
 func (e ErrSQLUniqueConstraintViolation) Error() string {
-	return fmt.Sprintf("sql unique constraint violation: %v", e.DBError)
+	return fmt.Sprintf("sql unique constraint violation: %v",
+		withPgDetail(e.DBError))
 }
 
 // ErrSerializationError is an error type which represents a database agnostic
@@ -135,7 +204,7 @@ func (e ErrSerializationError) Unwrap() error {
 
 // Error returns the error message.
 func (e ErrSerializationError) Error() string {
-	return e.DBError.Error()
+	return withPgDetail(e.DBError)
 }
 
 // ErrDeadlockError is an error type which represents a database agnostic error
@@ -151,7 +220,22 @@ func (e ErrDeadlockError) Unwrap() error {
 
 // Error returns the error message.
 func (e ErrDeadlockError) Error() string {
-	return e.DBError.Error()
+	return withPgDetail(e.DBError)
+}
+
+// IsUniqueConstraintViolation returns true if the given error is a unique
+// constraint violation.
+//
+// This is deliberately not part of IsSerializationOrDeadlockError. A unique
+// violation is not safe to retry blindly, because a retry of a plain insert
+// that lost a creation race just loses it again. Callers that can lose such a
+// race need to either rephrase the insert as a no-op upsert or translate the
+// violation into a domain level "already exists", which is why the classifier
+// is exposed separately.
+func IsUniqueConstraintViolation(err error) bool {
+	var uniqueErr *ErrSQLUniqueConstraintViolation
+
+	return errors.As(err, &uniqueErr)
 }
 
 // IsSerializationError returns true if the given error is a serialization

--- a/db/sqlerrors_postgres_test.go
+++ b/db/sqlerrors_postgres_test.go
@@ -178,4 +178,94 @@ func TestPostgresConflictShapes(t *testing.T) {
 		require.Contains(t, mapped.Error(), "constraint:")
 		require.Contains(t, mapped.Error(), "chain_name")
 	})
+
+	// The limit of the shape above, and the reason the write-path audit
+	// splits the lost creation race in two. SSI only promotes a creation
+	// race to a retryable 40001 when the losing transaction read the
+	// contested key first, because that read is what leaves the SIRead
+	// predicate lock the conflict graph is built from. Two transactions
+	// that insert blind, with no preceding read, have no dependency for
+	// SSI to find, so the loser gets the same non-retryable 23505 at
+	// SERIALIZABLE that it would get at REPEATABLE READ.
+	//
+	// This is what says that a blind-write upsert whose ON CONFLICT target
+	// misses the index that can actually fire is exposed today, rather
+	// than being masked by SSI and unmasked by relaxing the level.
+	t.Run("serializable blind creation race", func(t *testing.T) {
+		txA := beginAt(t, ctx, store, sql.LevelSerializable)
+		txB := beginAt(t, ctx, store, sql.LevelSerializable)
+
+		const insertRow = "INSERT INTO chain_info (id, chain_name, " +
+			"genesis_hash) VALUES ($1, 'blind-race', '\\x01')"
+
+		_, err := txA.ExecContext(ctx, insertRow, 400)
+		require.NoError(t, err)
+
+		// txB blocks on the unique index until txA resolves.
+		errChan := make(chan error, 1)
+		go func() {
+			_, execErr := txB.ExecContext(ctx, insertRow, 401)
+			errChan <- execErr
+		}()
+
+		require.NoError(t, txA.Commit())
+
+		err = <-errChan
+		require.Error(t, err)
+
+		mapped := MapSQLError(err)
+
+		// Identical classification to the REPEATABLE READ case above,
+		// which is the whole point: SERIALIZABLE bought this path
+		// nothing, so relaxing the level costs it nothing.
+		require.False(t, IsSerializationOrDeadlockError(mapped))
+		require.True(t, IsUniqueConstraintViolation(mapped))
+		require.NotEmpty(t, PgErrorConstraint(err))
+	})
+
+	// The other half of the split: once the losing transaction reads the
+	// contested key before inserting it, SSI does see the dependency and
+	// reports a retryable 40001 carrying a pivot reason code. A read-check
+	// then insert really is masked by SERIALIZABLE today, and really would
+	// degrade to a bare 23505 at REPEATABLE READ.
+	t.Run("serializable read-check creation race", func(t *testing.T) {
+		txA := beginAt(t, ctx, store, sql.LevelSerializable)
+		txB := beginAt(t, ctx, store, sql.LevelSerializable)
+
+		const probe = "SELECT COUNT(*) FROM chain_info WHERE " +
+			"chain_name = 'checked-race'"
+		const insertRow = "INSERT INTO chain_info (id, chain_name, " +
+			"genesis_hash) VALUES ($1, 'checked-race', '\\x01')"
+
+		// Both transactions observe the absence of the key first,
+		// which is the read that takes the predicate lock.
+		var count int
+		require.NoError(
+			t, txA.QueryRowContext(ctx, probe).Scan(&count),
+		)
+		require.Zero(t, count)
+		require.NoError(
+			t, txB.QueryRowContext(ctx, probe).Scan(&count),
+		)
+		require.Zero(t, count)
+
+		_, err := txA.ExecContext(ctx, insertRow, 500)
+		require.NoError(t, err)
+
+		errChan := make(chan error, 1)
+		go func() {
+			_, execErr := txB.ExecContext(ctx, insertRow, 501)
+			errChan <- execErr
+		}()
+
+		require.NoError(t, txA.Commit())
+
+		err = <-errChan
+		require.Error(t, err)
+
+		mapped := MapSQLError(err)
+		require.True(t, IsSerializationOrDeadlockError(mapped))
+		require.False(t, IsUniqueConstraintViolation(mapped))
+		require.Contains(t, mapped.Error(), "Reason code")
+	})
 }

--- a/db/sqlerrors_postgres_test.go
+++ b/db/sqlerrors_postgres_test.go
@@ -1,0 +1,181 @@
+//go:build test_postgres
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// beginAt opens a raw transaction at an explicit isolation level, bypassing the
+// BaseDB policy so that a test can pit two specific levels against each other.
+func beginAt(t *testing.T, ctx context.Context, store *PostgresStore,
+	level sql.IsolationLevel) *sql.Tx {
+
+	t.Helper()
+
+	tx, err := store.DB.BeginTx(ctx, &sql.TxOptions{Isolation: level})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tx.Rollback()
+	})
+
+	return tx
+}
+
+// TestPostgresConflictShapes pins down the three conflict shapes that the
+// isolation work turns on, and asserts that our mapped errors carry enough
+// information to tell them apart in a log.
+//
+// The subtests share one store, and use disjoint id ranges so that they cannot
+// interfere. Each store costs a docker container, and the fixture derives its
+// port from a docker port binding that is not always populated under load.
+func TestPostgresConflictShapes(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewTestPostgresDB(t)
+
+	// A genuine SSI abort. Two serializable transactions each read the set
+	// of rows the other is about to write, which is the read-write
+	// dependency cycle that only predicate locks can see. Postgres reports
+	// the loser with a reason code naming its role as the pivot, and that
+	// reason code is the signal that a path genuinely depends on SSI.
+	t.Run("serializable pivot abort", func(t *testing.T) {
+		txA := beginAt(t, ctx, store, sql.LevelSerializable)
+		txB := beginAt(t, ctx, store, sql.LevelSerializable)
+
+		var count int
+		require.NoError(
+			t, txA.QueryRowContext(
+				ctx, "SELECT COUNT(*) FROM chain_info WHERE "+
+					"id > 100",
+			).Scan(&count),
+		)
+		require.NoError(
+			t, txB.QueryRowContext(
+				ctx, "SELECT COUNT(*) FROM chain_info WHERE "+
+					"id > 100",
+			).Scan(&count),
+		)
+
+		_, err := txA.ExecContext(
+			ctx, "INSERT INTO chain_info (id, chain_name, "+
+				"genesis_hash) VALUES (101, 'ssi-a', '\\x01')",
+		)
+		require.NoError(t, err)
+
+		_, err = txB.ExecContext(
+			ctx, "INSERT INTO chain_info (id, chain_name, "+
+				"genesis_hash) VALUES (102, 'ssi-b', '\\x02')",
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, txA.Commit())
+
+		err = txB.Commit()
+		require.Error(t, err)
+
+		mapped := MapSQLError(err)
+		require.True(t, IsSerializationOrDeadlockError(mapped))
+		require.NotEmpty(t, PgErrorDetail(err))
+		require.Contains(t, mapped.Error(), "Reason code")
+		require.Contains(t, mapped.Error(), "detail:")
+	})
+
+	// The load-bearing assumption behind the write-path audit: REPEATABLE
+	// READ still detects a write-write conflict on the same row and still
+	// reports it as a retryable 40001. This is what makes the "touch a
+	// shared row" remedy work as a replacement for an SSI dependency.
+	// Unlike the abort above, this one carries no reason code.
+	t.Run("repeatable read same-row conflict", func(t *testing.T) {
+		_, err := store.DB.ExecContext(
+			ctx, "INSERT INTO chain_info (id, chain_name, "+
+				"genesis_hash) VALUES (200, 'rr-seed', "+
+				"'\\x00')",
+		)
+		require.NoError(t, err)
+
+		txA := beginAt(t, ctx, store, sql.LevelRepeatableRead)
+		txB := beginAt(t, ctx, store, sql.LevelRepeatableRead)
+
+		// Force both snapshots to be taken before either write lands.
+		var seen int
+		require.NoError(
+			t, txA.QueryRowContext(
+				ctx, "SELECT id FROM chain_info WHERE id = 200",
+			).Scan(&seen),
+		)
+		require.NoError(
+			t, txB.QueryRowContext(
+				ctx, "SELECT id FROM chain_info WHERE id = 200",
+			).Scan(&seen),
+		)
+
+		_, err = txA.ExecContext(
+			ctx, "UPDATE chain_info SET chain_name = 'rr-a' "+
+				"WHERE id = 200",
+		)
+		require.NoError(t, err)
+		require.NoError(t, txA.Commit())
+
+		_, err = txB.ExecContext(
+			ctx, "UPDATE chain_info SET chain_name = 'rr-b' "+
+				"WHERE id = 200",
+		)
+		require.Error(t, err)
+		require.True(
+			t,
+			IsSerializationOrDeadlockError(
+				MapSQLError(err),
+			),
+		)
+		require.Empty(t, PgErrorDetail(err))
+	})
+
+	// The hazard that the isolation change introduces. Under SSI a lost
+	// creation race aborts with a retryable 40001, but under REPEATABLE
+	// READ the two inserts do not conflict in the graph at all and the
+	// loser instead gets a 23505 unique violation, which the retry loop
+	// correctly refuses to retry. Any insert that can race another insert
+	// of the same logical row therefore has to be a no-op upsert.
+	t.Run("repeatable read lost creation race", func(t *testing.T) {
+		txA := beginAt(t, ctx, store, sql.LevelRepeatableRead)
+		txB := beginAt(t, ctx, store, sql.LevelRepeatableRead)
+
+		const insertRow = "INSERT INTO chain_info (id, chain_name, " +
+			"genesis_hash) VALUES ($1, 'race', '\\x01')"
+
+		_, err := txA.ExecContext(ctx, insertRow, 300)
+		require.NoError(t, err)
+
+		// txB blocks on the unique index until txA resolves.
+		errChan := make(chan error, 1)
+		go func() {
+			_, execErr := txB.ExecContext(ctx, insertRow, 301)
+			errChan <- execErr
+		}()
+
+		require.NoError(t, txA.Commit())
+
+		err = <-errChan
+		require.Error(t, err)
+
+		mapped := MapSQLError(err)
+
+		// The decisive property: this is NOT classified as retryable,
+		// so a retry loop gives up on it.
+		require.False(t, IsSerializationOrDeadlockError(mapped))
+		require.True(t, IsUniqueConstraintViolation(mapped))
+
+		// The constraint name and detail together identify which index
+		// fired and on what key. The schema carries six partial unique
+		// indexes, so the constraint name is not redundant.
+		require.NotEmpty(t, PgErrorConstraint(err))
+		require.Contains(t, mapped.Error(), "constraint:")
+		require.Contains(t, mapped.Error(), "chain_name")
+	})
+}

--- a/db/sqlerrors_postgres_test.go
+++ b/db/sqlerrors_postgres_test.go
@@ -177,6 +177,13 @@ func TestPostgresConflictShapes(t *testing.T) {
 		require.NotEmpty(t, PgErrorConstraint(err))
 		require.Contains(t, mapped.Error(), "constraint:")
 		require.Contains(t, mapped.Error(), "chain_name")
+
+		// Extraction has to work through the mapped error too, not
+		// just the raw driver error. A caller downstream of ExecTx
+		// only ever sees the mapped one, so this is the path that
+		// actually gets used.
+		require.NotEmpty(t, PgErrorConstraint(mapped))
+		require.NotEmpty(t, PgErrorDetail(mapped))
 	})
 
 	// The limit of the shape above, and the reason the write-path audit

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ into specific topics below.
 | [commit-tooling.md](commit-tooling.md) | commit_message.py workflows for linting and rewording |
 | [testing-guide.md](testing-guide.md) | Coverage targets, test approaches, pre-commit checklist |
 | [go_workspace.md](go_workspace.md) | Multi-module Go workspace setup |
+| [postgres_isolation.md](postgres_isolation.md) | Postgres isolation policy: why read-only transactions run at `REPEATABLE READ` and writers stay `SERIALIZABLE`, operator notes on long-lived read transactions, the write-path snapshot-isolation audit, and the partial unique index inventory |
 | [policy_arkscript_review_guide.md](policy_arkscript_review_guide.md) | Policy-first arkscript reviewer guide |
 | [dev_rpc_cli_builder.md](dev_rpc_cli_builder.md) | Generated `wavecli dev` command builder and request flag rules |
 

--- a/docs/postgres_isolation.md
+++ b/docs/postgres_isolation.md
@@ -78,10 +78,13 @@ Any invariant enforced by reading a set, deciding from what is absent, and
 then writing becomes unsound, and the failure is usually silent rather than an
 error.
 
-An audit of all 64 write closures found roughly a dozen that genuinely depend
-on SSI. That is a far denser hit rate than the comparable audit in lnd, which
-found four such shapes across about 340 closures, and several of the sites
-here sit in fund-critical paths.
+An audit of all 64 write closures found fourteen sites of concern. Eleven of
+them genuinely depend on SSI and would break if the level were relaxed; the
+other three are blind-write creation races that SSI never protected in the
+first place, and so are reachable today. Even taking the eleven alone, that is
+a far denser hit rate than the comparable audit in lnd, which found four such
+shapes across about 340 closures, and several of the sites here sit in
+fund-critical paths.
 
 Two structural problems compound this. Under `REPEATABLE READ` the same-row
 `40001` becomes the only remaining conflict signal, but
@@ -92,43 +95,64 @@ when it joins an ambient actor transaction. That ambient path is the normal
 case for the ledger, audit, credit and activity stores. So today the signal
 that would have to absorb the change is not retried on the dominant code path.
 
-Separately, a lost creation race that SSI reports as a retryable `40001`
-becomes a `23505` unique violation under `REPEATABLE READ`, and the retry loop
-correctly refuses to retry it. Several write paths perform a plain insert that
-can lose such a race.
+Separately, a lost creation race can stop being a retryable `40001` and become
+a `23505` unique violation that the retry loop correctly refuses to retry.
+Several write paths perform a plain insert that can lose such a race.
+
+That last point only applies to half of them, and the distinction decides
+whether a given site is exposed today or only after a move. SSI promotes a
+creation race to `40001` only when the losing transaction read the contested
+key before inserting it, because that read is what leaves the `SIRead`
+predicate lock the conflict graph is built from. A transaction that inserts
+blind, with no preceding read of the key, gives SSI no dependency to find and
+already loses with a plain `23505` at `SERIALIZABLE`. Both halves are pinned by
+`TestPostgresConflictShapes` in
+[`db/sqlerrors_postgres_test.go`](../db/sqlerrors_postgres_test.go).
 
 ### No configuration knob
 
 lnd shipped an opt-in enum for the write isolation level. We deliberately do
-not, because a knob whose non-default setting silently enables about a dozen
-known anomalies is a loaded gun with a safety catch rather than a feature. The
-level should become configurable, or simply change, once the paths below are
+not, because a knob whose non-default setting silently enables eleven known
+anomalies is a loaded gun with a safety catch rather than a feature. The level
+should become configurable, or simply change, once the paths below are
 hardened, not before.
 
 ## Write-path audit results
 
 The classification below is what a move to `REPEATABLE READ` would have to
 address first. It is recorded here so the work does not have to be redone.
-Every one of these is currently masked by SSI, so none is a live bug today.
 
 Shapes: **A** is read-check-then-write or aggregate-then-write. **B** is a
 lost creation race that would surface as a non-retryable `23505`. **C** is
 write skew between two transactions that each read what the other writes.
 
+Shape **B** splits into two cases that read the same on the page but behave
+very differently, so the notes below say which one applies. A site that reads
+the contested key inside its transaction and then inserts is genuinely masked
+by SSI today: it loses with a retryable `40001` now and would lose with a bare
+`23505` under `REPEATABLE READ`. A site that inserts blind, without reading the
+key, was never masked at all, because SSI has no predicate lock to hang the
+dependency on. Those already lose with a `23505` at `SERIALIZABLE`, so the
+isolation level is not what protects them and relaxing it takes nothing away.
+Every **A** and **C** site, and every read-check **B** site, is currently
+masked by SSI and is not a live bug today. The blind **B** sites are reachable
+now, independently of this work.
+
 | Site | Shape | Note |
 |------|-------|------|
-| `RootKey` ([`db/macaroons.go`](../db/macaroons.go)) | B | Reads the key, and on a miss generates and plain-inserts a new one. Two racers insert different random keys and the loser gets a non-retryable `23505`. |
+| `RootKey` ([`db/macaroons.go`](../db/macaroons.go)) | B (read-check) | Reads the key, and on a miss generates and plain-inserts a new one. Two racers insert different random keys and the loser gets a non-retryable `23505`. Masked by SSI today. |
 | `upsertAncestryPaths` ([`db/ancestry_codec.go`](../db/ancestry_codec.go)), via `SaveVTXO` and `SaveVTXOs` | B | `InsertVTXOAncestryPath` is the only plain insert in its scope, and the round store and VTXO manager are designed to write the same outpoint. |
-| `ArmRecovery` ([`db/vhtlc_recovery_store.go`](../db/vhtlc_recovery_store.go)) | A + B | The whole idempotency contract is decided from two reads of absence, followed by an insert with no `ON CONFLICT`. |
+| `ArmRecovery` ([`db/vhtlc_recovery_store.go`](../db/vhtlc_recovery_store.go)) | A + B (read-check) | The whole idempotency contract is decided from two reads of absence, followed by an insert with no `ON CONFLICT`. Masked by SSI today. |
 | `MarkBoardingSweepInputSpent` ([`db/boarding_sweep_store.go`](../db/boarding_sweep_store.go)) | A | `CountUnresolvedBoardingSweepInputs == 0` gates the resolution cascade. Two racers on different inputs of one sweep can each skip it, leaving the sweep unresolved forever with no error. |
 | `MarkBoardingSweepFailed` (same file) | A | Rolls back intents from a snapshot of the input set; an input inserted after the snapshot survives in `pending` and permanently occupies the partial unique index. |
-| `CreatePendingBoardingSweep` (same file) | B | The `ON CONFLICT` target is the primary key, which does not cover `idx_boarding_sweep_inputs_active_outpoint`. |
+| `CreatePendingBoardingSweep` (same file) | B (blind) | The `ON CONFLICT` target is the primary key, which does not cover `idx_boarding_sweep_inputs_active_outpoint`. Nothing reads the outpoint in the transaction, so this already loses with a `23505` today. |
 | `CommitState` ([`db/round_store.go`](../db/round_store.go)) | A + C | The orphan sweeps delete on `NOT EXISTS` over `pending_intent_anchors`, inside the point-of-no-return round checkpoint. |
-| `UpsertPendingIntent` ([`db/pending_intent_store.go`](../db/pending_intent_store.go)) | C | The retention guard reads `pending_intents.status`, which a different transaction writes. |
+| `UpsertPendingIntent` ([`db/pending_intent_store.go`](../db/pending_intent_store.go)) | C | The orphan sweep runs `DeleteOrphanedPendingIntents`, whose `NOT EXISTS` anti-join over `pending_intent_anchors` can race a concurrent anchor insert and delete an intent that is no longer orphaned. Note that the `status <> 'failed'` guard in the same statement is *not* the exposure: that read and the failure path's write hit the same header row, so `REPEATABLE READ` still catches it as an ordinary write-write conflict. |
 | `FailForfeitIntents` ([`db/round_store.go`](../db/round_store.go)) | A | Selects its targets through a snapshot read of the anchor mapping. |
-| `UpsertOperation` ([`db/credit_operation_store.go`](../db/credit_operation_store.go)) | B | The `ON CONFLICT` target is `op_id`, which does not cover the partial unique `idx_credit_operations_op_key`. |
+| `UpsertOperation` ([`db/credit_operation_store.go`](../db/credit_operation_store.go)) | B (blind) | The `ON CONFLICT` target is `op_id`, which does not cover the partial unique `idx_credit_operations_op_key`. Blind write, so this already loses with a `23505` today. |
+| `UpsertSession` ([`db/oor_session_registry_store.go`](../db/oor_session_registry_store.go)) | B (blind) | Same shape: `UpsertOORSessionRegistry` targets `session_id`, which does not cover the partial unique `idx_oor_session_registry_idempotency_key`. Two sessions racing on one idempotency key have different session IDs, so the `DO UPDATE` never fires and the loser gets a `23505`. The `LookupActiveSessionByIdempotencyKey` probe runs in its own separate transaction, so the write is blind. |
 | `ProjectEntry` ([`db/activity_store.go`](../db/activity_store.go)) | A | Rescued only accidentally, because the projection happens to write the row it read. |
-| `UpsertBinding` ([`db/oor_artifact_store.go`](../db/oor_artifact_store.go)) | A | Preconditions on a `vtxos` row that this closure never writes. |
+| `UpsertBinding` ([`db/oor_artifact_store.go`](../db/oor_artifact_store.go)) | A + B (blind) | Preconditions on a `vtxos` row that this closure never writes. Separately, `oor_vtxo_bindings` declares `UNIQUE (session_id, output_index, link_kind)` on top of its primary key, and the `ON CONFLICT (outpoint_hash, outpoint_index, link_kind)` target does not cover it, so rebinding one session member to a different outpoint raises a `23505` rather than updating. That constraint is a full unique constraint, not a partial index, so it does not appear in the inventory below. |
 | `LeaseNextMessage` ([`db/actordelivery/store_impl.go`](../db/actordelivery/store_impl.go)) | A | The per-correlation-key FIFO anti-join is an absence check over a range. A weakening rather than a break, since SSI never guaranteed the ordering either. |
 
 The actor delivery store is otherwise clean. Its schema declares no unique
@@ -152,8 +176,19 @@ unique indexes, so any new `ON CONFLICT` needs checking against this list.
 | `idx_credit_operations_op_key` | `credit_operations` | `status != 2` |
 
 A targetless `ON CONFLICT DO NOTHING` arbitrates over every unique index,
-partial ones included, which is why the ledger and UTXO audit inserts are safe
-as written.
+partial ones included, which is why the ledger insert in
+[`db/sqlc/queries/fee_accounting.sql`](../db/sqlc/queries/fee_accounting.sql)
+is safe as written. The UTXO audit insert in
+[`db/sqlc/queries/utxo_audit.sql`](../db/sqlc/queries/utxo_audit.sql) is safe
+for a different reason: its target is spelled out, but it matches
+`idx_utxo_log_outpoint_event` exactly, and that index is total rather than
+partial.
+
+The list above covers partial indexes only, because those are the ones whose
+predicate can silently exclude a row. A conflict target can just as easily miss
+a plain unique constraint declared inline in a `CREATE TABLE`, which is what
+`UpsertBinding` does, so checking a new `ON CONFLICT` against this table alone
+is not sufficient.
 
 ## What would have to be true to move writers
 
@@ -161,7 +196,8 @@ as written.
    transaction path as well as the standalone one.
 2. Every **B** site is rephrased as a no-op upsert whose conflict target
    matches the index that can actually fire, or translates the violation into
-   a domain-level "already exists".
+   a domain-level "already exists". The blind **B** sites do not have to wait
+   for the move, since nothing is protecting them now.
 3. Every **A** and **C** site either folds its decision into a single SQL
    statement, takes an explicit row lock, or is made to touch a shared row so
    that an ordinary write-write conflict replaces the SSI dependency.

--- a/docs/postgres_isolation.md
+++ b/docs/postgres_isolation.md
@@ -1,0 +1,170 @@
+# Postgres transaction isolation
+
+This document records the isolation level policy for the Postgres backend,
+the reasoning behind it, and the audit that decided where the boundary sits.
+The policy itself lives in `txIsolationLevel` in
+[`db/interfaces.go`](../db/interfaces.go).
+
+## Current policy
+
+| Transaction | Postgres | SQLite |
+|-------------|----------|--------|
+| Read-only (`ReadTxOption`) | `REPEATABLE READ`, `READ ONLY` | `SERIALIZABLE` (ignored by the driver) |
+| Read-write (`WriteTxOption`) | `SERIALIZABLE` | `SERIALIZABLE` (ignored by the driver) |
+
+SQLite is deliberately left alone. It admits only a single writer, so it is
+already effectively serializable and there is nothing to gain. The modernc
+driver ignores the requested isolation level outright, so the gate documents
+intent rather than dodging an error.
+
+## Why read-only transactions run at REPEATABLE READ
+
+Under Postgres' serializable snapshot isolation, a `SERIALIZABLE` transaction
+takes `SIRead` predicate locks and joins the serialization conflict graph even
+when it only reads. Such a transaction can suffer a `40001` abort itself, and
+it can act as the pivot that causes a concurrent writer to be aborted.
+
+The daemon is overwhelmingly read heavy. A signet measurement found 2,035
+transaction commits per second with 99.6% of them changing no rows at all,
+against a Postgres instance sitting at 794m of a one core limit largely on
+predicate-lock bookkeeping.
+
+A read-only `REPEATABLE READ` transaction reads from a single consistent
+snapshot taken when its first statement runs, which is exactly what the read
+paths already consume. It takes no predicate locks, can never raise a
+serialization failure, and no longer appears in anyone else's conflict graph.
+
+The `READ ONLY` access mode is load bearing rather than decorative. Postgres
+only skips predicate lock acquisition for a transaction that is genuinely
+declared read only, so the isolation level alone would buy nothing.
+
+An audit of all 80 read-only call sites found no site that writes, and no site
+whose body depends on observing a concurrent commit part way through the
+transaction. Every polling loop in the tree sits outside its transaction and
+reopens per attempt, so no loop can pin a stale snapshot across polls.
+
+### Operator note on long-lived read transactions
+
+Some read transactions are long lived. The ancestry resolver in
+[`db/oor_unroll_resolver.go`](../db/oor_unroll_resolver.go) walks a tree, and
+several round and VTXO listings iterate large result sets. Each holds one
+snapshot for its whole duration, which has two consequences.
+
+Postgres cannot vacuum row versions still visible to an open snapshot, so a
+very slow read transaction delays cleanup and can bloat tables. Such a session
+also sits `idle in transaction` whenever the daemon is computing between
+queries, so `idle_in_transaction_session_timeout` must be generous enough to
+cover a full pass or Postgres will terminate the transaction mid-flight. The
+same caution applies to `statement_timeout`.
+
+None of these transactions perform network calls or actor sends while open,
+so their duration is bounded by database and CPU work rather than by a remote
+peer.
+
+## Why read-write transactions stay at SERIALIZABLE
+
+Moving writers to `REPEATABLE READ` would be a much larger change than it
+looks, and the measured upside is small. Both halves of that judgement matter.
+
+The upside is small because writers are a rounding error in the workload. If
+99.6% of transactions change nothing, then relaxing the remaining 0.4% cannot
+recover much of the predicate-lock cost that the read-only change already
+removes. The read side was the whole problem.
+
+The risk is large because snapshot isolation withdraws exactly the guarantee
+that several write paths lean on. Under `REPEATABLE READ` there are no
+predicate locks, so only write-write conflicts on the same row are detected.
+Any invariant enforced by reading a set, deciding from what is absent, and
+then writing becomes unsound, and the failure is usually silent rather than an
+error.
+
+An audit of all 64 write closures found roughly a dozen that genuinely depend
+on SSI. That is a far denser hit rate than the comparable audit in lnd, which
+found four such shapes across about 340 closures, and several of the sites
+here sit in fund-critical paths.
+
+Two structural problems compound this. Under `REPEATABLE READ` the same-row
+`40001` becomes the only remaining conflict signal, but
+`TxAwareActorDeliveryStore.ExecTx` in
+[`db/actordelivery/store_impl.go`](../db/actordelivery/store_impl.go) has no
+retry loop, and `TransactionExecutor.ExecTx` skips its own retry loop entirely
+when it joins an ambient actor transaction. That ambient path is the normal
+case for the ledger, audit, credit and activity stores. So today the signal
+that would have to absorb the change is not retried on the dominant code path.
+
+Separately, a lost creation race that SSI reports as a retryable `40001`
+becomes a `23505` unique violation under `REPEATABLE READ`, and the retry loop
+correctly refuses to retry it. Several write paths perform a plain insert that
+can lose such a race.
+
+### No configuration knob
+
+lnd shipped an opt-in enum for the write isolation level. We deliberately do
+not, because a knob whose non-default setting silently enables about a dozen
+known anomalies is a loaded gun with a safety catch rather than a feature. The
+level should become configurable, or simply change, once the paths below are
+hardened, not before.
+
+## Write-path audit results
+
+The classification below is what a move to `REPEATABLE READ` would have to
+address first. It is recorded here so the work does not have to be redone.
+Every one of these is currently masked by SSI, so none is a live bug today.
+
+Shapes: **A** is read-check-then-write or aggregate-then-write. **B** is a
+lost creation race that would surface as a non-retryable `23505`. **C** is
+write skew between two transactions that each read what the other writes.
+
+| Site | Shape | Note |
+|------|-------|------|
+| `RootKey` ([`db/macaroons.go`](../db/macaroons.go)) | B | Reads the key, and on a miss generates and plain-inserts a new one. Two racers insert different random keys and the loser gets a non-retryable `23505`. |
+| `upsertAncestryPaths` ([`db/ancestry_codec.go`](../db/ancestry_codec.go)), via `SaveVTXO` and `SaveVTXOs` | B | `InsertVTXOAncestryPath` is the only plain insert in its scope, and the round store and VTXO manager are designed to write the same outpoint. |
+| `ArmRecovery` ([`db/vhtlc_recovery_store.go`](../db/vhtlc_recovery_store.go)) | A + B | The whole idempotency contract is decided from two reads of absence, followed by an insert with no `ON CONFLICT`. |
+| `MarkBoardingSweepInputSpent` ([`db/boarding_sweep_store.go`](../db/boarding_sweep_store.go)) | A | `CountUnresolvedBoardingSweepInputs == 0` gates the resolution cascade. Two racers on different inputs of one sweep can each skip it, leaving the sweep unresolved forever with no error. |
+| `MarkBoardingSweepFailed` (same file) | A | Rolls back intents from a snapshot of the input set; an input inserted after the snapshot survives in `pending` and permanently occupies the partial unique index. |
+| `CreatePendingBoardingSweep` (same file) | B | The `ON CONFLICT` target is the primary key, which does not cover `idx_boarding_sweep_inputs_active_outpoint`. |
+| `CommitState` ([`db/round_store.go`](../db/round_store.go)) | A + C | The orphan sweeps delete on `NOT EXISTS` over `pending_intent_anchors`, inside the point-of-no-return round checkpoint. |
+| `UpsertPendingIntent` ([`db/pending_intent_store.go`](../db/pending_intent_store.go)) | C | The retention guard reads `pending_intents.status`, which a different transaction writes. |
+| `FailForfeitIntents` ([`db/round_store.go`](../db/round_store.go)) | A | Selects its targets through a snapshot read of the anchor mapping. |
+| `UpsertOperation` ([`db/credit_operation_store.go`](../db/credit_operation_store.go)) | B | The `ON CONFLICT` target is `op_id`, which does not cover the partial unique `idx_credit_operations_op_key`. |
+| `ProjectEntry` ([`db/activity_store.go`](../db/activity_store.go)) | A | Rescued only accidentally, because the projection happens to write the row it read. |
+| `UpsertBinding` ([`db/oor_artifact_store.go`](../db/oor_artifact_store.go)) | A | Preconditions on a `vtxos` row that this closure never writes. |
+| `LeaseNextMessage` ([`db/actordelivery/store_impl.go`](../db/actordelivery/store_impl.go)) | A | The per-correlation-key FIFO anti-join is an absence check over a range. A weakening rather than a break, since SSI never guaranteed the ordering either. |
+
+The actor delivery store is otherwise clean. Its schema declares no unique
+index other than primary keys, so the entire lost-creation-race class is
+structurally impossible there, and its claim queries all update the row their
+subquery selected, which stays safe under `REPEATABLE READ`.
+
+### Partial unique indexes
+
+A conflict target that does not match a partial index predicate will not fire,
+and the upsert silently degrades to a plain insert. The schema has six partial
+unique indexes, so any new `ON CONFLICT` needs checking against this list.
+
+| Index | Table | Predicate |
+|-------|-------|-----------|
+| `idx_boarding_sweep_inputs_active_outpoint` | `boarding_sweep_inputs` | `status IN ('pending', 'published')` |
+| `idx_oor_session_registry_idempotency_key` | `oor_session_registry` | `idempotency_key IS NOT NULL AND status != 2` |
+| `idx_client_ledger_idempotent_round` | `ledger_entries` | `round_id IS NOT NULL AND idempotency_key IS NULL` |
+| `idx_client_ledger_idempotent_session` | `ledger_entries` | `session_id IS NOT NULL` |
+| `idx_client_ledger_idempotent_key` | `ledger_entries` | `idempotency_key IS NOT NULL` |
+| `idx_credit_operations_op_key` | `credit_operations` | `status != 2` |
+
+A targetless `ON CONFLICT DO NOTHING` arbitrates over every unique index,
+partial ones included, which is why the ledger and UTXO audit inserts are safe
+as written.
+
+## What would have to be true to move writers
+
+1. The retry gap closes, so a same-row `40001` is retried on the ambient actor
+   transaction path as well as the standalone one.
+2. Every **B** site is rephrased as a no-op upsert whose conflict target
+   matches the index that can actually fire, or translates the violation into
+   a domain-level "already exists".
+3. Every **A** and **C** site either folds its decision into a single SQL
+   statement, takes an explicit row lock, or is made to touch a shared row so
+   that an ordinary write-write conflict replaces the SSI dependency.
+4. The `PgError` detail surfacing added alongside this work is used to confirm
+   from production logs which paths still abort with an SSI reason code, since
+   that is the direct evidence of a remaining dependency.


### PR DESCRIPTION
In this PR, we relax the transaction isolation level for read-only Postgres
transactions from `SERIALIZABLE` down to a read-only `REPEATABLE READ`, and
leave writers exactly where they are.

Today `BaseDB.BeginTx` hardcodes `sql.LevelSerializable` for every transaction
we open, reads included. Under Postgres' serializable snapshot isolation that
isn't free for a reader: a read-only `SERIALIZABLE` transaction still takes
`SIRead` predicate locks and still joins the serialization conflict graph, so it
can both eat a `40001` itself and act as the pivot that aborts a concurrent
writer. On a daemon as read heavy as ours, that's pure cost. A signet
measurement put us at 2,035 transaction commits per second with 99.6% of them
changing no rows at all, against a Postgres box sitting at 794m of a one core
limit largely on predicate-lock bookkeeping.

For a concrete version of that cost, the lumos client-connection ingress
long-poll is a read path paying the SSI toll for nothing at all. Each
`pullIteration` in `db/mailbox_store.go` opens a `ReadTxOption()` transaction
around `PullMailboxEnvelopes` and only ever runs a SELECT. The loop is
wake-driven rather than a fixed-rate poll, since it selects on a notify channel
that `Append` fires, so the poll timer is a fallback and not the mechanism. The
trouble was that the fallback interval was one second against a five second
wait window, and the knob for it was entirely unwired: `WithPullPollInterval`
had no production callers, there was no config field behind it, and the store
options builder never emitted it. So one second is flatly what ran on signet,
with no deployment able to have tuned it.

Worth stating the ordering, since the constant is moving. Before that fix, each
five second long-poll cost five read transactions, on the order of 290 per
second across the parked ingress loops in NobleSun's signet profile. Raising
the fallback above the wait window takes it to one per RPC, roughly 58 per
second. That change reduces how many of these transactions exist and this PR
reduces what each one costs, so the two compose rather than overlap, and
neither owns the combined win.

The first commit is the whole functional change, and it's deliberately
self-contained and independently landable. It follows
lightningnetwork/lnd#10997. The isolation choice funnels through a small
`txIsolationLevel` helper that gates on the `BackendType` that `BaseDB` already
carries, so SQLite is untouched. There's nothing to win there anyway, since
SQLite only ever admits a single writer and is effectively serializable already.

Worth calling out that we open these transactions as `READ ONLY` as well as at
the relaxed level, and the flag is doing at least as much work as the level is.
Postgres only skips predicate-lock acquisition for a transaction that is
genuinely declared read only, so the level on its own would buy us nothing. We
were already passing that flag through, which is why this lands as two lines.

The second commit surfaces the `ConstraintName` and `Detail` fields of a
`pgconn.PgError` in the message our mapped error types render. `PgError.Error`
prints only the severity, the message and the SQLSTATE, so both fields were
going on the floor before they reached a log line. The detail is the only thing
that tells two very different `40001` aborts apart: a true SSI abort carries a
reason code naming the transaction's role in the conflict graph, while an
ordinary write-write conflict on the same row carries no detail at all. Now that
readers no longer take predicate locks, that's the signal that says whether a
given write path still leans on SSI or would be equally happy at `REPEATABLE
READ`. The constraint name matters for a different reason, covered below.

The third commit is `docs/postgres_isolation.md`, which writes down the policy,
the operator caveats, and the audit that decided where the boundary sits.

See each commit message for a detailed description w.r.t the incremental
changes.

## Why writers stay at SERIALIZABLE

This one is the actual deliverable rather than a shortfall. The task was scoped
to go all the way and move writers too, and the audit came back saying we
shouldn't. Both halves of that judgement matter.

The upside is small. Writers are a rounding error in this workload. If 99.6% of
transactions change nothing, then relaxing the remaining 0.4% can't recover much
beyond what the read-only change already takes off the table. The read side was
the entire problem.

The risk is not small. An audit of all 64 write closures found fourteen sites of
concern. Eleven of those genuinely depend on the serialization graph and would
break if we relaxed the level, and several of them sit in fund-critical paths.
For calibration, the comparable audit in lnd found four such shapes across about
340 closures, so even counting the eleven alone our hit rate is far denser. The
full table lives in `docs/postgres_isolation.md` rather than here, classified
into three shapes: read-check-then-write, a lost creation race that surfaces as
a `23505`, and write skew.

Two structural blockers compound it. Under `REPEATABLE READ` the same-row
`40001` becomes the only conflict signal we have left, but
`TxAwareActorDeliveryStore.ExecTx` has no retry loop at all, and
`TransactionExecutor.ExecTx` skips its own whenever it joins an ambient actor
transaction, which is the normal case for the ledger, audit, credit and activity
stores. So the one signal that would have to absorb the change isn't retried on
the dominant code path. Separately, a lost creation race that SSI reports as a
retryable `40001` can become a `23505` unique violation under `REPEATABLE READ`,
and a retry loop correctly refuses to retry that.

The doc also inventories the six partial unique indexes in the schema, which is
useful well beyond this change. An `ON CONFLICT` target that doesn't match a
partial index predicate never arbitrates against that index, so the upsert
quietly degrades into a plain insert and you find out about it later.

Unlike lnd#10999 we don't add a configuration knob for the write level. A knob
whose non-default setting silently enables about a dozen known anomalies is a
loaded gun with a safety catch rather than a feature. It should become
configurable once those paths are hardened, and not before.

To be explicit about this, since the audit table reads like a bug list: this PR
doesn't break any of those sites. Writers keep talking to each other through the
full conflict graph exactly as before, because Postgres tracks dependencies only
among serializable transactions, and a read-only `REPEATABLE READ` transaction
was never able to protect a write in a different transaction anyway. The table
is a record of what would have to be fixed before writers could move, not of
what this change breaks.

The original draft went further and said that none of the audited sites is a
live bug today, on the grounds that SSI is masking all of them. An adversarial
pass over the table caught that, and it turns out to be half wrong in a way
worth knowing about. SSI promotes a lost creation race to a retryable `40001`
only when the losing transaction read the contested key before inserting it,
since that read is what leaves the predicate lock the conflict graph is built
from. Three of the fourteen sites insert blind, so there's no dependency for
SSI to find and they already lose with a bare `23505` at `SERIALIZABLE` today.
Those three are reachable now, independently of this work, and relaxing the
level would take nothing away from them. That's why the audit table now splits
shape B into read-check and blind, and why the count above is eleven rather than
fourteen. Both halves of the mechanism are pinned against a real Postgres in
`TestPostgresConflictShapes` rather than left as an argument. The remaining
eleven are genuinely masked today.

## What we're giving up

Snapshot isolation is not serializability, and this is a real if modest
weakening for readers. A read-only `REPEATABLE READ` transaction is no longer
guaranteed to observe a state corresponding to some serial ordering of the
writers running alongside it, so the read-only transaction anomaly described by
Fekete and O'Neil is once again permitted. The argument in the code comment is
that our read paths only ever consume a point-in-time view and never depended on
being ordered against writers in other transactions, and that a read feeding a
later write in a separate transaction was never protected across that boundary
at any isolation level. That claim is worth a reviewer checking rather than
taking at face value, since it's what the whole change rests on.

There's an operator consequence too, written up in the doc. A `REPEATABLE READ`
transaction pins its snapshot for its entire lifetime, and Postgres can't vacuum
row versions still visible to an open snapshot. Some of our read transactions
are long lived: the ancestry resolver walks a tree, and several round and VTXO
listings iterate large result sets. A slow one now delays cleanup and can bloat
tables, and it sits `idle in transaction` while the daemon computes between
queries, so `idle_in_transaction_session_timeout` and `statement_timeout` need
to be generous enough to cover a full pass. None of these hold a transaction
open across a network call or an actor send, so their duration is bounded by
database and CPU work rather than by a remote peer.

## What was and wasn't verified locally

The backend gate and the level selection are covered by a plain unit test that
runs everywhere. Everything that asserts on Postgres' own behaviour sits behind
the `test_postgres` build tag and wants a Docker Postgres, and those have been
run against a real fixture rather than left as an aspiration. They cover that
the requested options survive the pgx stdlib driver and reach the server as a
read-only `REPEATABLE READ` transaction, that the server rejects a write inside
one, that an SSI pivot abort carries a reason code, that a `REPEATABLE READ`
same-row conflict still raises a retryable `40001` with no detail, that a
`REPEATABLE READ` lost creation race raises a non-retryable `23505` instead,
and that under `SERIALIZABLE` the same race raises a `23505` when the loser
inserts blind but a `40001` with a pivot reason code when it reads first. The
isolation assertion reads back `SHOW transaction_isolation` and `SHOW
transaction_read_only`, so it's the server's own view of the transaction rather
than a restatement of what we asked for.

What isn't verified here: the signet numbers are a reported measurement rather
than something reproducible from this branch, and the write-path audit was
produced by reading code rather than by running anything against a live
database. The claim that no read path depends on cross-transaction
serializability is reasoned from the call sites in the same way, and isn't
something a test can pin down.

## Cross references

The retry gap named above is partly closed by #1053, which adds a retry loop to
the actor commit transaction. lightninglabs/lumos#718 and
lightninglabs/swapdk-server#265 are the incident this is meant to take pressure
off.
