### PR TITLE
wallet: cap per-round boarding fanout to bound nonce signing (#858)

### DIFF
--- a/wallet/board_limits.go
+++ b/wallet/board_limits.go
@@ -26,6 +26,27 @@ const minChangeFloor = btcutil.Amount(330)
 // minting oversized or unboundedly many outputs.
 const maxBoardOutputs = 1000
 
+// DefaultMaxVTXOsPerBoardRound bounds how many VTXO outputs a single boarding
+// round mints. Boarding signs one MuSig2 nonce per VTXO — an O(N) step the
+// operator collects within a bounded round window — so a balance whose
+// per-VTXO split (MaxUserBalance / MaxVTXOAmount) needs many hundreds of
+// pieces can overrun that window; the round fails "recoverable", the deposit
+// never converts, and every retry re-issues the same oversized shape and
+// re-fails, stranding the deposit (wavelength#858).
+//
+// 128 keeps the per-round signing work well inside a typical window even on
+// the slowest (serial-signing) backend (~5s at the ~38ms/nonce observed on
+// signet). The clipped remainder returns as a change leave output paying a
+// fresh boarding script, which re-confirms on-chain as a new boarding intent
+// ready to board again. That next board is driven the same way any board is:
+// automatically on the next confirmation under WithEagerRoundJoin, or by the
+// operator's/host's usual board trigger otherwise — so a large balance clears
+// over a handful of rounds rather than stranding on one oversized shape. It is
+// a deliberately conservative default because the operator does not advertise
+// its nonce-collection deadline; tune it with WithMaxVTXOsPerBoardRound for a
+// tighter or looser window.
+const DefaultMaxVTXOsPerBoardRound uint32 = 128
+
 var (
 	// ErrBoardingCapReached is returned when the operator's maximum
 	// user balance leaves no usable headroom to board any of the
@@ -102,7 +123,8 @@ type boardingClamp struct {
 // change output could neither be created in the batch transaction nor
 // re-boarded later.
 func clampBoardingAmount(total btcutil.Amount, targetCount uint32, maxVTXO,
-	headroom, floor btcutil.Amount) (*boardingClamp, error) {
+	headroom, floor btcutil.Amount,
+	perRoundVTXOCap uint32) (*boardingClamp, error) {
 
 	if total <= 0 {
 		return nil, fmt.Errorf("boarding balance must be positive")
@@ -117,6 +139,35 @@ func clampBoardingAmount(total btcutil.Amount, targetCount uint32, maxVTXO,
 		boardAmt = headroom
 		cappedByHeadroom = true
 	}
+
+	// Cap the per-round fanout so the client's O(N) nonce signing stays
+	// inside the operator's nonce-collection window. A balance whose split
+	// (MaxUserBalance / MaxVTXOAmount) would need more than perRoundVTXOCap
+	// pieces can overrun that window and strand the deposit
+	// (wavelength#858), so board at most the cap's worth of max-size VTXOs
+	// and let the remainder return as change to re-board next round. This
+	// reuses the change-routing below, and bounds minByMax at or under the
+	// cap. Zero disables the per-round cap; it needs a per-VTXO maximum to
+	// size a piece.
+	if perRoundVTXOCap > 0 && maxVTXO > 0 {
+		cap64 := int64(perRoundVTXOCap)
+		perRoundMax := cap64 * int64(maxVTXO)
+
+		// Clip only when the bound is trustworthy and spendable. The
+		// division check skips an overflowed multiply. Requiring
+		// perRoundMax >= floor keeps the clipped board above dust and
+		// preserves error attribution: on an absurdly small per-VTXO
+		// max (maxVTXO < floor) the clip is skipped, so the switch
+		// below reports ErrMaxVTXOBelowFloor, not a misleading
+		// below-floor error against the full balance.
+		if perRoundMax/cap64 == int64(maxVTXO) &&
+			perRoundMax >= int64(floor) &&
+			int64(boardAmt) > perRoundMax {
+
+			boardAmt = btcutil.Amount(perRoundMax)
+		}
+	}
+
 	switch {
 	case boardAmt <= 0:
 		// Headroom is zero or negative: the wallet is already at or
@@ -215,6 +266,24 @@ func clampBoardingAmount(total btcutil.Amount, targetCount uint32, maxVTXO,
 				count = uint32(maxByFloor)
 			}
 
+			// Cap the piece count at the per-round budget so the
+			// O(N) nonce signing stays inside the operator's
+			// collection window (wavelength#858). Clipping boardAmt
+			// alone does NOT bound the count: the window above
+			// honors the caller's targetCount up to maxByFloor, so
+			// a large requested count with a small floor could
+			// still mint far more than the cap's worth of
+			// sub-maximum pieces. The boardAmt clip guarantees
+			// perRoundMax = cap * maxVTXO, hence minByMax <= cap,
+			// so capping here never drops count below minByMax; and
+			// since count stays <= maxByFloor the (now fewer,
+			// larger) pieces remain within [floor, maxVTXO].
+			if perRoundVTXOCap > 0 &&
+				count > perRoundVTXOCap {
+
+				count = perRoundVTXOCap
+			}
+
 		// Infeasible even at the fewest pieces the maximum allows:
 		// boardAmt cannot be divided into whole [floor, maxVTXO]
 		// pieces. Board as many full maximum-size VTXOs as fit and
@@ -293,8 +362,19 @@ func (a *Ark) applyBoardingLimits(ctx context.Context, total btcutil.Amount,
 		floor = minChangeFloor
 	}
 
+	// Resolve the per-round VTXO cap, defaulting when unset so the
+	// per-VTXO-maximum-driven fanout is always bounded (wavelength#858).
+	// The cap engages only when the operator advertises a per-VTXO maximum;
+	// with no per-VTXO max the split is instead bounded by the caller's
+	// target count and the dust floor, which is not the #858 vector.
+	perRoundCap := a.maxVTXOsPerBoardRound
+	if perRoundCap == 0 {
+		perRoundCap = DefaultMaxVTXOsPerBoardRound
+	}
+
 	clamp, err := clampBoardingAmount(
 		total, targetCount, terms.MaxVTXOAmount, headroom, floor,
+		perRoundCap,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/wallet/board_limits_test.go
+++ b/wallet/board_limits_test.go
@@ -211,7 +211,7 @@ func TestClampBoardingAmount(t *testing.T) {
 
 			clamp, err := clampBoardingAmount(
 				tc.total, tc.targetCount, tc.maxVTXO,
-				tc.headroom, dust,
+				tc.headroom, dust, 0,
 			)
 			if tc.wantErr != nil {
 				require.ErrorIs(t, err, tc.wantErr)
@@ -255,6 +255,111 @@ func TestClampBoardingAmount(t *testing.T) {
 	}
 }
 
+// TestClampBoardingAmountPerRoundCap locks the wavelength#858 fix: the
+// per-round VTXO cap bounds the fanout the operator's per-VTXO maximum would
+// otherwise force, routing the excess to change instead of minting a
+// round-window-overrunning number of pieces on a single boarding round.
+func TestClampBoardingAmountPerRoundCap(t *testing.T) {
+	t.Parallel()
+
+	const (
+		floor   = btcutil.Amount(1_000)
+		bigCap  = btcutil.Amount(1 << 50)
+		maxVTXO = btcutil.Amount(200_000)
+
+		// MaxUserBalance / MaxVTXOAmount = 100_000_000 / 200_000 = 500
+		// pieces — the fanout that stranded the deposit on signet.
+		total = btcutil.Amount(100_000_000)
+
+		roundCap = uint32(128)
+	)
+
+	// Baseline: with the cap disabled the operator terms force the full
+	// 500-piece fanout (the bug), with nothing returned as change.
+	uncapped, err := clampBoardingAmount(
+		total, 0, maxVTXO, bigCap, floor, 0,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint32(500), uncapped.VTXOCount)
+	require.Equal(t, btcutil.Amount(0), uncapped.Change)
+
+	// Capped: board at most roundCap max-size VTXOs; the remainder returns
+	// as change to re-board next round.
+	capped, err := clampBoardingAmount(
+		total, 0, maxVTXO, bigCap, floor, roundCap,
+	)
+	require.NoError(t, err)
+	require.Equal(t, roundCap, capped.VTXOCount)
+	require.Equal(
+		t, btcutil.Amount(int64(roundCap)*int64(maxVTXO)),
+		capped.BoardAmount,
+	)
+	require.Equal(t, total-capped.BoardAmount, capped.Change)
+	require.Equal(t, btcutil.Amount(0), capped.DustToFee)
+
+	// Conservation holds under the cap.
+	require.Equal(
+		t, total, capped.BoardAmount+capped.Change+capped.DustToFee,
+	)
+
+	// The change remainder re-boards, and each re-board is again capped, so
+	// boarding converges over a handful of rounds rather than looping on
+	// one oversized shape.
+	next, err := clampBoardingAmount(
+		capped.Change, 0, maxVTXO, bigCap, floor, roundCap,
+	)
+	require.NoError(t, err)
+	require.LessOrEqual(t, next.VTXOCount, roundCap)
+
+	// A cap that is not binding (fewer pieces needed than the cap) leaves
+	// the split untouched — no spurious change.
+	small := btcutil.Amount(10 * int64(maxVTXO))
+	nonBinding, err := clampBoardingAmount(
+		small, 0, maxVTXO, bigCap, floor, roundCap,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint32(10), nonBinding.VTXOCount)
+	require.Equal(t, btcutil.Amount(0), nonBinding.Change)
+
+	// A total just above the per-round max lands the clipped remainder
+	// sub-floor, so the change-shift fires on top of the cap clip: the
+	// board shrinks to hold the change at exactly the floor, the count
+	// stays at or under the cap, and value is still conserved.
+	perRoundMax := btcutil.Amount(int64(roundCap) * int64(maxVTXO))
+	overCap := perRoundMax + floor/2
+	shifted, err := clampBoardingAmount(
+		overCap, 0, maxVTXO, bigCap, floor, roundCap,
+	)
+	require.NoError(t, err)
+	require.Equal(t, floor, shifted.Change)
+	require.LessOrEqual(t, shifted.VTXOCount, roundCap)
+	require.Equal(
+		t, overCap,
+		shifted.BoardAmount+shifted.Change+shifted.DustToFee,
+	)
+
+	// A large caller-supplied target count must ALSO be capped, not just
+	// the boarded amount. Here the balance (50 max-size VTXOs' worth) sits
+	// below perRoundMax, so the amount is NOT clipped at all — yet a
+	// requested 500-way split with a small floor would, without the count
+	// cap, mint 500 sub-maximum pieces and overrun the round window.
+	// Clipping the amount alone would miss this; the count cap is what
+	// bounds it. Each of the (now 128) pieces stays a valid [floor,
+	// maxVTXO] output and value is fully conserved with no change.
+	belowPerRoundMax := btcutil.Amount(50 * int64(maxVTXO))
+	targetDriven, err := clampBoardingAmount(
+		belowPerRoundMax, 500, maxVTXO, bigCap, floor, roundCap,
+	)
+	require.NoError(t, err)
+	require.Equal(t, roundCap, targetDriven.VTXOCount)
+	require.Equal(t, belowPerRoundMax, targetDriven.BoardAmount)
+	require.Equal(t, btcutil.Amount(0), targetDriven.Change)
+	pieceValue := int64(targetDriven.BoardAmount) /
+		int64(targetDriven.VTXOCount)
+	require.GreaterOrEqual(t, pieceValue, int64(floor))
+	require.LessOrEqual(t, pieceValue, int64(maxVTXO))
+}
+
 // TestClampBoardingAmountInvariants fuzzes the boarding clamp + split over
 // random operator limits and asserts the dust-safety invariants for every
 // accepted board: value is conserved, no VTXO piece lands below the floor or
@@ -295,8 +400,16 @@ func TestClampBoardingAmountInvariants(t *testing.T) {
 
 		targetCount := rapid.Uint32Range(0, 4_000).Draw(rt, "count")
 
+		// A per-round cap of zero disables the cap; otherwise it ranges
+		// from tight to loose. The clamp invariants (conservation,
+		// piece bounds) must hold regardless of the cap.
+		perRoundCap := rapid.Uint32Range(0, 4_000).Draw(
+			rt, "perRoundCap",
+		)
+
 		clamp, err := clampBoardingAmount(
 			total, targetCount, maxVTXO, headroom, floor,
+			perRoundCap,
 		)
 		if err != nil {
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -228,6 +228,15 @@ type Ark struct {
 	// defaultTipTickInterval at Start time.
 	tipTickInterval time.Duration
 
+	// maxVTXOsPerBoardRound caps how many VTXO outputs a single boarding
+	// round mints, bounding the client's O(N) per-VTXO nonce signing so it
+	// stays within the operator's nonce-collection window. A boarding
+	// balance that would need more pieces boards the excess as a change
+	// leave output that re-boards over the next rounds, so a large deposit
+	// is not stranded by a round that overruns the window (wavelength#858).
+	// Zero falls back to DefaultMaxVTXOsPerBoardRound.
+	maxVTXOsPerBoardRound uint32
+
 	// latestKnownTip is the most recent chain tip observed via a
 	// BlockEpochNotification Tell. The block-epoch handler stores into
 	// this atomic ptr with no other work, so a burst of N notifications
@@ -421,6 +430,20 @@ func WithClock(clk clock.Clock) ArkOption {
 func WithEagerRoundJoin(enabled bool) ArkOption {
 	return func(a *Ark) {
 		a.eagerRoundJoin = enabled
+	}
+}
+
+// WithMaxVTXOsPerBoardRound overrides how many VTXO outputs a single boarding
+// round may mint. The default (DefaultMaxVTXOsPerBoardRound) bounds the
+// client's per-round O(N) nonce-signing work so a large boarding balance does
+// not overrun the operator's nonce-collection window and strand the deposit
+// (wavelength#858); the clipped remainder re-boards over successive rounds via
+// a change leave output. Set a lower value for an operator with a tighter
+// round window, or higher when the backend signs nonces fast enough. Zero
+// falls back to the default.
+func WithMaxVTXOsPerBoardRound(n uint32) ArkOption {
+	return func(a *Ark) {
+		a.maxVTXOsPerBoardRound = n
 	}
 }
 


### PR DESCRIPTION
## Problem

Auto-boarding a large deposit can strand it. A confirmed boarding balance is
split into VTXO pieces sized by the operator's per-VTXO maximum, so under terms
like `MaxUserBalance / MaxVTXOAmount = 500` a single board mints ~500 outputs.
Boarding signs one MuSig2 nonce per VTXO — an O(N) step the operator collects
within a bounded round window — so that fanout overruns the window on signet.
The round fails **recoverable**, the deposit never converts to VTXOs, and the
board-intent replayer re-issues the **identical** 500-piece shape on every
retry (and every restart), so it re-fails forever. Liveness, not funds — the
deposit sits in `pending_in_sat` with an empty VTXO list.

## Fix

Cap the per-round fanout at a configurable `DefaultMaxVTXOsPerBoardRound` (128)
inside `clampBoardingAmount`: board at most the cap's worth of max-size VTXOs
and route the remainder to the **existing** change leave output, which re-boards
over successive rounds. Because it reuses the change-routing already there, the
split's `minByMax` lands ≤ cap automatically and value is conserved.

128 keeps per-round signing well inside a typical window even on the slowest
serial-signing backend (~5s at the ~38ms/nonce observed on signet) while still
boarding a large balance in a handful of rounds. Tunable via
`WithMaxVTXOsPerBoardRound` for a tighter/looser operator window.

## Testing

- New `TestClampBoardingAmountPerRoundCap`: the exact 500-piece signet scenario
  — asserts the uncapped path still forces 500 (the bug), the capped path mints
  128 with the remainder as change, conservation holds, the change re-boards
  again capped (convergence), and a non-binding cap leaves the split untouched.
- Extended the existing rapid fuzz to draw a per-round cap and re-assert the
  clamp invariants (conservation, `[floor, maxVTXO]` piece bounds) hold with it.
- Full `wallet` suite green; daemon build, `fmt-changed`, `lint-changed-local`
  clean.

## Scope

This is the proactive cap (root-cause). The operator doesn't advertise its
nonce-collection deadline, so the cap is a conservative local assumption; a
**reactive back-off** that shrinks the target on a nonce-collection-timeout
failure code (plumbed through `RoundFailedNotification`) is the natural
follow-up for operators with an unusually tight window.

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)
