### PR TITLE
mailboxrpc: honor the operator's retry-after hint

### DIFF
--- a/mailbox/rpc/CLAUDE.md
+++ b/mailbox/rpc/CLAUDE.md
@@ -30,14 +30,19 @@ and server-side routing need without including any transport implementation.
   handing every attempt the same `RPCOptions.IdempotencyKey`. The key is
   minted once at the logical-call boundary (random, not a payload digest, so
   two identical concurrent reads stay distinct). Only `ResourceExhausted` is
-  retried, after a jittered exponential backoff; a cancelled or expired
+  retried, after the operator's retry-after hint when the shed response names
+  one and a jittered exponential backoff otherwise; a cancelled or expired
   context never re-sends.
-- `RetryPolicy` — `MaxAttempts` / `BaseDelay` / `MaxDelay`; the zero value
-  selects the package defaults (4 attempts, 200 ms base, 5 s cap), which
-  mirror `serverconn/mailboxpull`'s backoff shape.
+- `RetryPolicy` — `MaxAttempts` / `BaseDelay` / `MaxDelay` / `MaxRetryAfter`;
+  the zero value selects the package defaults (4 attempts, 200 ms base, 5 s
+  cap, 30 s retry-after ceiling). The first three mirror
+  `serverconn/mailboxpull`'s backoff shape.
 - `NewIdempotencyKey` — Mints one 16-byte hex key per logical request.
 - `IsShedError` — Reports whether an error (wrapped or not) is the operator's
   explicit `ResourceExhausted` shed answer.
+- `RetryAfter` — Reads the operator's retry-after hint off an error, carried
+  as a `google.rpc.RetryInfo` detail on the gRPC status (so it rides the
+  existing `HeaderGRPCStatusB64` round trip, with no new wire contract).
 - `EncodeErrorHeaders` / `DecodeErrorHeaders` — Round-trip a gRPC `error` as a
   base64-encoded `google.rpc.Status` under the `HeaderGRPCStatusB64` envelope
   header, so a failed handler call can surface a typed error across the
@@ -68,6 +73,10 @@ and server-side routing need without including any transport implementation.
 - A `KIND_RESPONSE` envelope carrying `HeaderGRPCStatusB64` signals a failed
   RPC; receivers must decode it via `DecodeErrorHeaders` before attempting to
   unmarshal the body.
+- A retry-after hint is an untrusted number from the operator. `backoffFor`
+  clamps it to `RetryPolicy.MaxRetryAfter` and ignores a non-positive or
+  malformed one, so a buggy or hostile operator cannot park a client
+  indefinitely by naming an absurd delay.
 
 ## Deep Docs
 

--- a/mailbox/rpc/retry.go
+++ b/mailbox/rpc/retry.go
@@ -9,6 +9,7 @@ import (
 	mrand "math/rand/v2"
 	"time"
 
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -35,6 +36,17 @@ const (
 
 	// DefaultRetryMaxDelay caps the exponential growth of the backoff.
 	DefaultRetryMaxDelay = 5 * time.Second
+
+	// DefaultMaxRetryAfter caps how long an operator-supplied retry-after
+	// hint may hold a caller back.
+	//
+	// The hint is a number chosen by the other side of the connection, so
+	// honoring it unbounded would let a buggy or hostile operator park
+	// every client of the fleet for as long as it liked by naming an
+	// absurd delay. Thirty seconds is comfortably past any honest token
+	// bucket's refill interval and comfortably short of an outage, so a
+	// hint above it is a bug or an attack either way.
+	DefaultMaxRetryAfter = 30 * time.Second
 )
 
 // NewIdempotencyKey mints the idempotency key for a single logical RPC.
@@ -70,6 +82,12 @@ type RetryPolicy struct {
 	// MaxDelay caps the exponential backoff delay. A non-positive value
 	// selects DefaultRetryMaxDelay.
 	MaxDelay time.Duration
+
+	// MaxRetryAfter caps an operator-supplied retry-after hint, which is
+	// otherwise preferred over the computed backoff. A non-positive value
+	// selects DefaultMaxRetryAfter. Lower it when the caller must stay
+	// responsive no matter how long the operator asks it to wait.
+	MaxRetryAfter time.Duration
 }
 
 // normalize replaces non-positive fields with their defaults so the retry loop
@@ -83,6 +101,9 @@ func (p RetryPolicy) normalize() RetryPolicy {
 	}
 	if p.MaxDelay <= 0 {
 		p.MaxDelay = DefaultRetryMaxDelay
+	}
+	if p.MaxRetryAfter <= 0 {
+		p.MaxRetryAfter = DefaultMaxRetryAfter
 	}
 
 	return p
@@ -104,6 +125,73 @@ func (p RetryPolicy) retryDelay(attempt int) time.Duration {
 	}
 
 	return time.Duration(delay * (0.5 + mrand.Float64()*0.5)) //nolint:gosec
+}
+
+// backoffFor returns how long to wait before the attempt following the given
+// one-based attempt, preferring the operator's retry-after hint over the
+// locally computed backoff. It must be called on a normalized policy.
+//
+// The hint is better information than anything this side can compute: it
+// comes from the very token bucket that shed the request, so a caller that
+// honors it comes back exactly when it can be served rather than guessing,
+// returning early, and getting shed again. Guessing is expensive here because
+// an operator answers only the first shed in each window; every retry that
+// lands too early is dropped in silence and teaches the caller nothing.
+//
+// It is still an untrusted number, so it is clamped to MaxRetryAfter. An
+// absent, malformed, or non-positive hint falls through to the jittered
+// exponential backoff, unchanged.
+//
+// The clamped hint is used as given, without the jitter the computed backoff
+// carries, because the hint is derived from the caller's own per-client
+// bucket rather than from a schedule shared across the fleet. Two callers
+// honoring their own hints do not wake together, so there is no herd for
+// jitter to break up.
+func (p RetryPolicy) backoffFor(attempt int, err error) time.Duration {
+	hint, ok := RetryAfter(err)
+	if !ok || hint <= 0 {
+		return p.retryDelay(attempt)
+	}
+
+	if hint > p.MaxRetryAfter {
+		return p.MaxRetryAfter
+	}
+
+	return hint
+}
+
+// RetryAfter returns the retry-after hint the operator attached to err, and
+// whether there was one at all.
+//
+// The hint rides as a standard google.rpc.RetryInfo detail on the gRPC
+// status, which the mailbox already carries end to end in the response's
+// error header, so reading it needs no new wire contract. Most errors carry
+// no hint: only an operator that both sheds a request and can name a deadline
+// annotates one.
+func RetryAfter(err error) (time.Duration, bool) {
+	st, ok := status.FromError(err)
+	if !ok {
+		return 0, false
+	}
+
+	for _, detail := range st.Details() {
+		// A detail this side cannot resolve comes back as an error
+		// rather than a message, so an unknown or corrupt entry is
+		// skipped rather than trusted.
+		info, ok := detail.(*errdetails.RetryInfo)
+		if !ok {
+			continue
+		}
+
+		delay := info.GetRetryDelay()
+		if delay == nil || !delay.IsValid() {
+			continue
+		}
+
+		return delay.AsDuration(), true
+	}
+
+	return 0, false
 }
 
 // IsShedError reports whether err is the operator's explicit "I am shedding
@@ -128,11 +216,13 @@ func IsShedError(err error) bool {
 // logical call, the key lets the operator collapse a retry storm back into the
 // single unit of work it really is.
 //
-// Only an explicit ResourceExhausted is retried, and only after a jittered
-// backoff. A context that is cancelled or past its deadline is never retried:
-// the caller has already given up, and another send would only queue work
-// nobody is left to receive. Callers that want per-attempt deadlines should
-// derive them inside call from the context Retry passes in.
+// Only an explicit ResourceExhausted is retried, and only after a backoff:
+// the operator's retry-after hint when the shed response names one, and a
+// jittered exponential delay otherwise. A context that is cancelled or past
+// its deadline is never retried: the caller has already given up, and another
+// send would only queue work nobody is left to receive. Callers that want
+// per-attempt deadlines should derive them inside call from the context Retry
+// passes in.
 func Retry(ctx context.Context, policy RetryPolicy,
 	call func(context.Context, RPCOptions) error) error {
 
@@ -188,7 +278,7 @@ func RetryWithKey(ctx context.Context, policy RetryPolicy, key string,
 		}
 
 		if err := waitBackoff(
-			ctx, policy.retryDelay(attempt),
+			ctx, policy.backoffFor(attempt, lastErr),
 		); err != nil {
 			return lastErr
 		}

--- a/mailbox/rpc/retry_test.go
+++ b/mailbox/rpc/retry_test.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // fastRetryPolicy returns a policy with the production shape but millisecond
@@ -252,6 +254,255 @@ func TestIsShedError(t *testing.T) {
 		IsShedError(
 			status.Error(codes.DeadlineExceeded, "too slow"),
 		),
+	)
+}
+
+// shedWithHint builds the operator's shed answer carrying retryAfter as a
+// google.rpc.RetryInfo detail, which is the shape the indexer actually puts
+// on the wire.
+func shedWithHint(t *testing.T, retryAfter *durationpb.Duration) error {
+	t.Helper()
+
+	st, err := status.New(
+		codes.ResourceExhausted, "rate limited",
+	).WithDetails(&errdetails.RetryInfo{
+		RetryDelay: retryAfter,
+	})
+	require.NoError(t, err)
+
+	return st.Err()
+}
+
+// timeShedRetry drives one retry to exhaustion against a shed answer and
+// returns how long the single backoff between the two attempts took.
+func timeShedRetry(t *testing.T, policy RetryPolicy, shed error) time.Duration {
+	t.Helper()
+
+	var calls int
+	start := time.Now()
+	err := Retry(
+		context.Background(), policy,
+		func(_ context.Context, _ RPCOptions) error {
+			calls++
+
+			return shed
+		},
+	)
+	elapsed := time.Since(start)
+
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.Equal(t, 2, calls)
+
+	return elapsed
+}
+
+// TestRetryAfterExtractsHint pins the decoding of the operator's retry-after
+// hint, including the wrapped case: callers wrap transport errors with
+// context before they reach a retry boundary, and a hint lost to wrapping is
+// a hint nobody honors.
+func TestRetryAfterExtractsHint(t *testing.T) {
+	t.Parallel()
+
+	hinted := shedWithHint(t, durationpb.New(750*time.Millisecond))
+
+	got, ok := RetryAfter(hinted)
+	require.True(t, ok)
+	require.Equal(t, 750*time.Millisecond, got)
+
+	got, ok = RetryAfter(fmt.Errorf("list VTXOs: %w", hinted))
+	require.True(t, ok)
+	require.Equal(t, 750*time.Millisecond, got)
+
+	// Everything without a hint reports absence rather than a zero
+	// duration the caller might mistake for "retry immediately".
+	_, ok = RetryAfter(nil)
+	require.False(t, ok)
+
+	_, ok = RetryAfter(errors.New("boom"))
+	require.False(t, ok)
+
+	_, ok = RetryAfter(
+		status.Error(codes.ResourceExhausted, "rate limited"),
+	)
+	require.False(t, ok)
+
+	_, ok = RetryAfter(shedWithHint(t, nil))
+	require.False(t, ok)
+
+	// A duration outside the protobuf range is malformed, not a very
+	// long wait.
+	_, ok = RetryAfter(
+		shedWithHint(
+			t, &durationpb.Duration{
+				Seconds: 1 << 60,
+			},
+		),
+	)
+	require.False(t, ok)
+}
+
+// TestRetryPrefersLongerServerHint pins that the operator's hint wins over a
+// shorter computed backoff. The hint comes from the bucket that shed the
+// request, so returning before it elapses only earns another shed, and the
+// next one is dropped in silence.
+func TestRetryPrefersLongerServerHint(t *testing.T) {
+	t.Parallel()
+
+	const hint = 60 * time.Millisecond
+
+	policy := RetryPolicy{
+		MaxAttempts:   2,
+		BaseDelay:     time.Millisecond,
+		MaxDelay:      2 * time.Millisecond,
+		MaxRetryAfter: time.Minute,
+	}
+
+	elapsed := timeShedRetry(
+		t, policy,
+		shedWithHint(
+			t, durationpb.New(
+				hint,
+			),
+		),
+	)
+
+	// The computed backoff caps at 2ms, so anything at or past the hint
+	// can only have come from the hint.
+	require.GreaterOrEqual(t, elapsed, hint)
+}
+
+// TestRetryPrefersShorterServerHint pins that the preference runs both ways:
+// an operator that says it will be ready sooner than the client's guess is
+// believed, so a brief throttle does not cost a full exponential backoff.
+func TestRetryPrefersShorterServerHint(t *testing.T) {
+	t.Parallel()
+
+	policy := RetryPolicy{
+		MaxAttempts:   2,
+		BaseDelay:     500 * time.Millisecond,
+		MaxDelay:      time.Second,
+		MaxRetryAfter: time.Minute,
+	}
+
+	elapsed := timeShedRetry(
+		t, policy,
+		shedWithHint(
+			t, durationpb.New(
+				5*time.Millisecond,
+			),
+		),
+	)
+
+	// The jitter floors the computed backoff at half the base, so
+	// finishing well under 250ms can only have come from the hint.
+	require.Less(t, elapsed, 250*time.Millisecond)
+}
+
+// TestRetryClampsHostileServerHint pins the bound on trust. The hint is a
+// number chosen by the other side, so a buggy or hostile operator must not be
+// able to park a client for a century by naming one.
+func TestRetryClampsHostileServerHint(t *testing.T) {
+	t.Parallel()
+
+	const maxRetryAfter = 40 * time.Millisecond
+
+	policy := RetryPolicy{
+		MaxAttempts:   2,
+		BaseDelay:     time.Millisecond,
+		MaxDelay:      2 * time.Millisecond,
+		MaxRetryAfter: maxRetryAfter,
+	}
+
+	elapsed := timeShedRetry(
+		t, policy,
+		shedWithHint(
+			t, durationpb.New(
+				100*365*24*time.Hour,
+			),
+		),
+	)
+
+	// The wait is the ceiling, not the century the operator asked for and
+	// not the computed backoff it displaced.
+	require.GreaterOrEqual(t, elapsed, maxRetryAfter)
+	require.Less(t, elapsed, time.Second)
+}
+
+// TestRetryIgnoresNonPositiveHint pins that a hint of zero or less does not
+// collapse the backoff into a hot loop. An operator that names no real wait
+// leaves the client on its own jittered schedule, which is the behavior a
+// hint-free shed already gets.
+func TestRetryIgnoresNonPositiveHint(t *testing.T) {
+	t.Parallel()
+
+	policy := RetryPolicy{
+		MaxAttempts:   2,
+		BaseDelay:     100 * time.Millisecond,
+		MaxDelay:      time.Second,
+		MaxRetryAfter: time.Minute,
+	}
+
+	for _, hint := range []time.Duration{0, -time.Hour} {
+		t.Run(hint.String(), func(t *testing.T) {
+			t.Parallel()
+
+			elapsed := timeShedRetry(
+				t, policy,
+				shedWithHint(
+					t, durationpb.New(hint),
+				),
+			)
+
+			// Half the base delay is the floor the jitter can
+			// produce, so reaching it proves the computed backoff
+			// still ran.
+			require.GreaterOrEqual(
+				t, elapsed, 50*time.Millisecond,
+			)
+		})
+	}
+}
+
+// TestRetryFallsBackWithoutHint pins that a shed answer carrying no hint backs
+// off exactly as it did before, so the hint is an addition to the policy
+// rather than a replacement for it.
+func TestRetryFallsBackWithoutHint(t *testing.T) {
+	t.Parallel()
+
+	policy := RetryPolicy{
+		MaxAttempts:   2,
+		BaseDelay:     100 * time.Millisecond,
+		MaxDelay:      time.Second,
+		MaxRetryAfter: time.Minute,
+	}
+
+	elapsed := timeShedRetry(
+		t, policy,
+		status.Error(codes.ResourceExhausted, "rate limited"),
+	)
+
+	require.GreaterOrEqual(t, elapsed, 50*time.Millisecond)
+	require.Less(t, elapsed, time.Second)
+}
+
+// TestRetryPolicyNormalizesMaxRetryAfter pins that a caller with no opinion on
+// the clamp still gets one. A zero ceiling read literally would mean every
+// hint is absurd, and a missing ceiling would mean none of them are.
+func TestRetryPolicyNormalizesMaxRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t, DefaultMaxRetryAfter,
+		RetryPolicy{}.normalize().MaxRetryAfter,
+	)
+	require.Equal(
+		t, DefaultMaxRetryAfter,
+		RetryPolicy{MaxRetryAfter: -time.Second}.
+			normalize().MaxRetryAfter,
+	)
+	require.Equal(
+		t, time.Second, RetryPolicy{MaxRetryAfter: time.Second}.
+			normalize().MaxRetryAfter,
 	)
 }
 


### PR DESCRIPTION
In this PR, we teach the mailbox retry helper to wait as long as the operator
asks when it sheds a request, instead of falling back on a delay we picked
ourselves.

`Retry` already backs off on `ResourceExhausted` with jittered exponential
backoff, which is the right shape when we know nothing. But the operator does
know something: its rate limiter can say exactly when the next token arrives.
The lumos side now attaches that as a `google.rpc.RetryInfo` detail
(lightninglabs/lumos#726), and this reads it. A client that returns too early
gets shed again, and because the operator can only afford to answer roughly one
shed per second, that second shed is silent, so the client burns a full deadline
learning nothing. Honoring the hint is what turns an ongoing loop into a single
wasted round trip.

The hint rides on the status detail rather than an envelope header on purpose.
`DecodeErrorHeaders` already reconstructs the status, so `RetryAfter` reads it
off the error the retry loop is already holding. A bare header would never reach
here: the `call` closure returns only an `error`, and the transport drops the
rest of the headers, so we would have had to plumb them through the facade for
this one field.

## Treating the hint as untrusted

A retry-after is a number from someone else, so `backoffFor` does not take it at
face value. Three cases, each deliberately different rather than folded together:

An absurd but well-formed hint, say a hundred years, is clamped to
`RetryPolicy.MaxRetryAfter` (30s by default) instead of ignored. A hostile or
buggy operator gets to slow us down, which is its right, but not to park us
forever.

A malformed hint, meaning a duration outside the protobuf range or a detail we
cannot resolve, is treated as no hint at all and falls through to the computed
backoff. Garbage should not be honored, and it should not be clamped either,
because clamping garbage silently invents a number.

A non-positive hint is also treated as no hint. This one matters most: honoring
a zero would collapse the backoff into a hot loop aimed at a server that just
told us it is overloaded, which is worse than having no hint at all.

The clamped hint is used without jitter, which is a departure from the computed
path. Jitter exists to break up a fleet-wide schedule, and there is no fleet-wide
schedule here: the hint comes from the caller's own per-client bucket, so two
clients already get different values. Jittering downward would just return early
and defeat the point.

`TestRetryClampsHostileServerHint` holds the ceiling. Deleting the clamp makes it
hang past its timeout rather than fail an assertion, which is the honest
signature of what the bug would be.

## A rebase note

This began stacked on the idempotency-key work in #1056, now merged. Rebasing it
onto main hit one conflict: that branch deleted `DefaultRetryPolicy` as dead
code, and this branch had added `MaxRetryAfter` to it. We kept the deletion, and
dropped the one test assertion that called it. The property it checked, that the
default ceiling is applied, is already asserted two lines above through
`RetryPolicy{}.normalize()`, which is the documented zero-value contract and the
thing production actually goes through.

## Scope

This is the client half of a cheap interim, not a fix. The underlying problem is
that a shed response costs a durable mailbox write, which is why the operator
rate-limits how often it can afford to answer at all. Removing that constraint
needs a non-durable delivery class, tracked in #1054. Until then this makes the
answers we do get more useful, and it does nothing for the sheds that stay
silent.

`go test ./mailbox/... -race`, `make fmt-changed`, `make lint-changed-local`
(0 issues) and `make commitmsg-lint` are all clean.