### PR TITLE
sdk/swaps: prevent duplicate in-swap vHTLC funding

### DIFF
--- a/oor/actor_durable_message.go
+++ b/oor/actor_durable_message.go
@@ -30,6 +30,17 @@ const (
 	// startPayloadIdempotencyKeyType stores the optional caller-provided
 	// OOR send idempotency key.
 	startPayloadIdempotencyKeyType tlv.Type = 5
+
+	// Type 6 is deliberately unused. New backward-compatible records use
+	// odd TLV types so older readers can safely ignore them.
+
+	// startPayloadAdmissionDeadlineType stores the optional absolute
+	// admission deadline as Unix nanoseconds.
+	startPayloadAdmissionDeadlineType tlv.Type = 7
+)
+
+const (
+	lookupTransferIdempotencyKeyRecordType tlv.Type = 1
 )
 
 const (
@@ -139,11 +150,12 @@ const (
 )
 
 type startTransferPayload struct {
-	OperatorPubKey []byte
-	CSVDelay       uint32
-	Inputs         []*TransferInputSnapshot
-	Recipients     []recipientPayload
-	IdempotencyKey string
+	OperatorPubKey             []byte
+	CSVDelay                   uint32
+	Inputs                     []*TransferInputSnapshot
+	Recipients                 []recipientPayload
+	IdempotencyKey             string
+	AdmissionDeadlineUnixNanos int64
 }
 
 type recipientPayload struct {
@@ -173,6 +185,7 @@ func encodeStartTransferPayload(payload startTransferPayload) ([]byte, error) {
 	operatorKey := payload.OperatorPubKey
 	csvDelay := payload.CSVDelay
 	idempotencyKey := []byte(payload.IdempotencyKey)
+	admissionDeadline := uint64(payload.AdmissionDeadlineUnixNanos)
 
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(
@@ -189,6 +202,9 @@ func encodeStartTransferPayload(payload startTransferPayload) ([]byte, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			startPayloadIdempotencyKeyType, &idempotencyKey,
+		),
+		tlv.MakePrimitiveRecord(
+			startPayloadAdmissionDeadlineType, &admissionDeadline,
 		),
 	}
 
@@ -222,6 +238,7 @@ func decodeStartTransferPayloadWithLimits(raw []byte,
 		inputsRaw   []byte
 		recipients  []byte
 		idKey       []byte
+		deadline    uint64
 	)
 
 	records := []tlv.Record{
@@ -238,6 +255,9 @@ func decodeStartTransferPayloadWithLimits(raw []byte,
 			startPayloadRecipientsRecordType, &recipients,
 		),
 		tlv.MakePrimitiveRecord(startPayloadIdempotencyKeyType, &idKey),
+		tlv.MakePrimitiveRecord(
+			startPayloadAdmissionDeadlineType, &deadline,
+		),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -265,12 +285,55 @@ func decodeStartTransferPayloadWithLimits(raw []byte,
 	}
 
 	return startTransferPayload{
-		OperatorPubKey: operatorKey,
-		CSVDelay:       csvDelay,
-		Inputs:         inputs,
-		Recipients:     recipientsPayload,
-		IdempotencyKey: string(idKey),
+		OperatorPubKey:             operatorKey,
+		CSVDelay:                   csvDelay,
+		Inputs:                     inputs,
+		Recipients:                 recipientsPayload,
+		IdempotencyKey:             string(idKey),
+		AdmissionDeadlineUnixNanos: int64(deadline),
 	}, nil
+}
+
+func encodeLookupTransferPayload(idempotencyKey string) ([]byte, error) {
+	key := []byte(idempotencyKey)
+	stream, err := tlv.NewStream(
+		tlv.MakePrimitiveRecord(
+			lookupTransferIdempotencyKeyRecordType, &key,
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := stream.Encode(&buf); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func decodeLookupTransferPayload(raw []byte) (string, error) {
+	var key []byte
+	stream, err := tlv.NewStream(
+		tlv.MakePrimitiveRecord(
+			lookupTransferIdempotencyKeyRecordType, &key,
+		),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := stream.DecodeWithParsedTypes(
+		bytes.NewReader(raw),
+	); err != nil {
+		return "", err
+	}
+	if len(key) == 0 {
+		return "", fmt.Errorf("idempotency key must be provided")
+	}
+
+	return string(key), nil
 }
 
 func encodeRecipientPayloads(payloads []recipientPayload) ([]byte, error) {

--- a/oor/actor_durable_message_test.go
+++ b/oor/actor_durable_message_test.go
@@ -63,7 +63,8 @@ func TestStartTransferPayloadTLVRoundTrip(t *testing.T) {
 				ValueSat: 321,
 			},
 		},
-		IdempotencyKey: "funding-key-1",
+		IdempotencyKey:             "funding-key-1",
+		AdmissionDeadlineUnixNanos: 1_700_000_000_123_456_789,
 	}
 
 	raw, err := encodeStartTransferPayload(payload)
@@ -78,8 +79,29 @@ func TestStartTransferPayloadTLVRoundTrip(t *testing.T) {
 	require.Equal(t, payload.CSVDelay, decoded.CSVDelay)
 	require.Equal(t, payload.Recipients, decoded.Recipients)
 	require.Equal(t, payload.IdempotencyKey, decoded.IdempotencyKey)
+	require.Equal(
+		t, payload.AdmissionDeadlineUnixNanos,
+		decoded.AdmissionDeadlineUnixNanos,
+	)
 	require.Len(t, decoded.Inputs, 1)
 	require.Equal(t, payload.Inputs[0], decoded.Inputs[0])
+}
+
+// TestLookupTransferRequestRoundTrip verifies a read-only keyed reconciliation
+// request survives the durable registry mailbox codec.
+func TestLookupTransferRequestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	msg := &LookupTransferRequest{
+		IdempotencyKey: "in-swap-funding:001122",
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.Encode(&buf))
+
+	var decoded LookupTransferRequest
+	require.NoError(t, decoded.Decode(&buf))
+	require.Equal(t, msg.IdempotencyKey, decoded.IdempotencyKey)
 }
 
 // TestListSessionsRequestRoundTrip verifies the durable status-query message

--- a/oor/actor_messages.go
+++ b/oor/actor_messages.go
@@ -45,6 +45,10 @@ const (
 	// in the durable OOR actor mailbox.
 	ListSessionsRequestTLVType tlv.Type = 0x7017
 
+	// LookupTransferRequestTLVType identifies read-only idempotency-key
+	// reconciliation requests.
+	LookupTransferRequestTLVType tlv.Type = 0x7018
+
 	// SessionTerminalNotificationTLVType identifies
 	// SessionTerminalNotification messages sent from a per-session child
 	// to the registry coordinator after a terminal commit.
@@ -107,6 +111,11 @@ type StartTransferRequest struct {
 	// retries. Empty preserves the historical deterministic-session
 	// behavior.
 	IdempotencyKey string
+
+	// AdmissionDeadlineUnixNanos is the latest wall-clock time at which a
+	// new transfer may be admitted. Existing keyed winners remain readable
+	// after this deadline. Zero leaves admission unbounded.
+	AdmissionDeadlineUnixNanos int64
 }
 
 // MessageType returns the type of this message.
@@ -125,9 +134,12 @@ func (m *StartTransferRequest) TLVType() tlv.Type {
 // Encode serializes the message to the provided writer.
 func (m *StartTransferRequest) Encode(w io.Writer) error {
 	payload := startTransferPayload{
-		CSVDelay:       m.Policy.CSVDelay,
-		IdempotencyKey: m.IdempotencyKey,
-		Recipients:     make([]recipientPayload, 0, len(m.Recipients)),
+		CSVDelay:                   m.Policy.CSVDelay,
+		IdempotencyKey:             m.IdempotencyKey,
+		AdmissionDeadlineUnixNanos: m.AdmissionDeadlineUnixNanos,
+		Recipients: make(
+			[]recipientPayload, 0, len(m.Recipients),
+		),
 		Inputs: make(
 			[]*TransferInputSnapshot, 0, len(m.Inputs),
 		),
@@ -192,6 +204,7 @@ func (m *StartTransferRequest) Decode(r io.Reader) error {
 		CSVDelay:    payload.CSVDelay,
 	}
 	m.IdempotencyKey = payload.IdempotencyKey
+	m.AdmissionDeadlineUnixNanos = payload.AdmissionDeadlineUnixNanos
 
 	m.Inputs = make([]TransferInput, 0, len(payload.Inputs))
 	for i := range payload.Inputs {
@@ -238,6 +251,81 @@ func (m *StartTransferResponse) MessageType() string {
 
 // actorRespSealed marks this as implementing the sealed ActorResp interface.
 func (m *StartTransferResponse) actorRespSealed() {}
+
+// LookupTransferRequest asks the registry to reconcile one idempotency key
+// without admitting a transfer. The request is serialized through the registry
+// mailbox so it observes admissions already accepted by that actor.
+type LookupTransferRequest struct {
+	actor.BaseMessage
+
+	// IdempotencyKey identifies the caller intent to reconcile.
+	IdempotencyKey string
+}
+
+// MessageType returns the type of this message.
+func (m *LookupTransferRequest) MessageType() string {
+	return "LookupTransferRequest"
+}
+
+// actorMsgSealed marks this as implementing the sealed ActorMsg interface.
+func (m *LookupTransferRequest) actorMsgSealed() {}
+
+// TLVType returns the unique TLV type identifier for this message.
+func (m *LookupTransferRequest) TLVType() tlv.Type {
+	return LookupTransferRequestTLVType
+}
+
+// Encode serializes the message to the provided writer.
+func (m *LookupTransferRequest) Encode(w io.Writer) error {
+	if m == nil || m.IdempotencyKey == "" {
+		return fmt.Errorf("idempotency key must be provided")
+	}
+
+	raw, err := encodeLookupTransferPayload(m.IdempotencyKey)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(raw)
+
+	return err
+}
+
+// Decode deserializes the message from the provided reader.
+func (m *LookupTransferRequest) Decode(r io.Reader) error {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	m.IdempotencyKey, err = decodeLookupTransferPayload(raw)
+
+	return err
+}
+
+// LookupTransferResponse reports whether an idempotency-key winner exists or
+// is still being admitted. Found and Pending are mutually exclusive.
+type LookupTransferResponse struct {
+	actor.BaseMessage
+
+	// SessionID identifies the durable winner or in-flight admission.
+	SessionID SessionID
+
+	// Found is true when a durable active winner exists.
+	Found bool
+
+	// Pending is true while an accepted admission has not committed its
+	// durable session row yet.
+	Pending bool
+}
+
+// MessageType returns the type of this message.
+func (m *LookupTransferResponse) MessageType() string {
+	return "LookupTransferResponse"
+}
+
+// actorRespSealed marks this as implementing the sealed ActorResp interface.
+func (m *LookupTransferResponse) actorRespSealed() {}
 
 // SessionDirection is a filter for listing locally known OOR sessions.
 type SessionDirection uint8

--- a/oor/outgoing_snapshot.go
+++ b/oor/outgoing_snapshot.go
@@ -103,6 +103,29 @@ type OutgoingSnapshot struct {
 	FirstRejectUnixNanos int64
 }
 
+// OutgoingSnapshotRecipients extracts the canonical Ark recipients from one
+// durable outgoing snapshot. Callers use this to recover response metadata for
+// an idempotent replay without rebuilding the transfer or selecting new wallet
+// inputs.
+func OutgoingSnapshotRecipients(raw []byte) ([]ArkRecipientOutput, error) {
+	snapshot, err := decodeOutgoingSnapshot(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode outgoing snapshot: %w", err)
+	}
+
+	ark, err := psbtutil.Parse(snapshot.ArkPSBT)
+	if err != nil {
+		return nil, fmt.Errorf("parse outgoing Ark PSBT: %w", err)
+	}
+
+	recipients, err := ExtractArkRecipients(ark)
+	if err != nil {
+		return nil, fmt.Errorf("extract outgoing recipients: %w", err)
+	}
+
+	return recipients, nil
+}
+
 // NewOutgoingSnapshot exports an outgoing transfer FSM state into a snapshot.
 func NewOutgoingSnapshot(sessionID SessionID,
 	state State) (*OutgoingSnapshot, error) {

--- a/oor/outgoing_snapshot_test.go
+++ b/oor/outgoing_snapshot_test.go
@@ -135,6 +135,15 @@ func TestSnapshotRetryMetadataRoundTrip(t *testing.T) {
 	raw, err := encodeOutgoingSnapshot(snapshot)
 	require.NoError(t, err)
 
+	snapshotRecipients, err := OutgoingSnapshotRecipients(raw)
+	require.NoError(t, err)
+	require.Len(t, snapshotRecipients, 1)
+	require.Equal(t, uint32(0), snapshotRecipients[0].OutputIndex)
+	require.Equal(t, inputValue, snapshotRecipients[0].Value)
+	require.Equal(
+		t, recipients[0].PkScript, snapshotRecipients[0].PkScript,
+	)
+
 	decoded, err := decodeOutgoingSnapshot(raw)
 	require.NoError(t, err)
 

--- a/oor/registry.go
+++ b/oor/registry.go
@@ -39,6 +39,12 @@ var errIncomingAdmissionCapped = errors.New("incoming OOR admission " +
 var errSelfTransferDeferred = errors.New("outgoing session still active for " +
 	"incoming hint")
 
+// ErrOutgoingAdmissionExpired is returned when a new outgoing transfer reaches
+// the durable admission boundary at or after its caller-supplied deadline.
+// Existing keyed winners are looked up before this check and remain readable.
+var ErrOutgoingAdmissionExpired = errors.New("outgoing OOR admission " +
+	"deadline reached")
+
 // selfHintRedeliveryBackoff is the flat redelivery backoff for a deferred
 // self-transfer hint's durable delivery. The terminal-reap redrive is the
 // fast path, so the durable copy only needs to cover a crash or a missed
@@ -234,11 +240,14 @@ func NewOORRegistryActor(cfg OORRegistryConfig) (*OORRegistryActor, error) {
 	cfg.Limits = normalizeReceiveLimits(cfg.Limits)
 
 	behavior := &oorRegistryBehavior{
-		cfg:        cfg,
-		log:        cfg.Log.UnwrapOr(btclog.Disabled),
-		active:     make(map[SessionID]*OORSessionActor),
-		activeDirs: make(map[SessionID]clientdb.OORSessionDirection),
-		incoming:   make(map[SessionID]struct{}),
+		cfg:    cfg,
+		log:    cfg.Log.UnwrapOr(btclog.Disabled),
+		active: make(map[SessionID]*OORSessionActor),
+		activeDirs: make(
+			map[SessionID]clientdb.OORSessionDirection,
+		),
+		incoming:            make(map[SessionID]struct{}),
+		pendingOutgoingKeys: make(map[string]SessionID),
 		parkedSelfHints: make(
 			map[SessionID]*ResolveIncomingTransferRequest,
 		),
@@ -338,6 +347,17 @@ type oorRegistryBehavior struct {
 	// non-incoming delete is a no-op). The cap defends against an operator
 	// pinning unbounded children by streaming unanswered incoming hints.
 	incoming map[SessionID]struct{}
+
+	// pendingOutgoingKeys tracks keyed admissions that the registry
+	// accepted and forwarded to a child but whose durable session row may
+	// not have committed yet. A read-only lookup arriving behind that
+	// registry turn must report Pending rather than a false authoritative
+	// miss. This map is intentionally a same-boot witness: restart restores
+	// children exclusively from non-terminal registry rows, never from a
+	// row-less child mailbox. A crash before the child's first commit
+	// therefore leaves no resumable transfer, while that first commit makes
+	// the registry row the durable witness before any funding can progress.
+	pendingOutgoingKeys map[string]SessionID
 
 	// selfRef is the registry's own tell-only reference, handed to each
 	// child so it can report a terminal commit for reaping.
@@ -453,6 +473,9 @@ func (r *oorRegistryBehavior) Receive(ctx context.Context, msg OORDurableMsg,
 
 	case *ListSessionsRequest:
 		return r.handleListSessions(ctx, m)
+
+	case *LookupTransferRequest:
+		return r.handleLookupTransfer(ctx, m)
 	}
 
 	// Clear any handoff staged by a prior turn so a dispatch that stages a
@@ -564,6 +587,7 @@ func (r *oorRegistryBehavior) handleStartTransfer(ctx context.Context,
 		)
 		switch {
 		case err == nil:
+			delete(r.pendingOutgoingKeys, req.IdempotencyKey)
 			r.logger(ctx).InfoS(ctx, "Idempotency-key dedup hit; "+
 				"returning existing OOR session",
 				slog.String(
@@ -584,10 +608,28 @@ func (r *oorRegistryBehavior) handleStartTransfer(ctx context.Context,
 			return fn.Err[ActorResp](err)
 		}
 
+		pendingID, pending := r.pendingOutgoingKeys[req.IdempotencyKey]
+		if pending {
+			if _, active := r.active[pendingID]; active {
+				return fn.Ok[ActorResp](&StartTransferResponse{
+					SessionID: pendingID,
+					Existing:  true,
+				})
+			}
+
+			delete(r.pendingOutgoingKeys, req.IdempotencyKey)
+		}
+
 		r.logger(ctx).DebugS(ctx, "Idempotency-key dedup miss; "+
 			"admitting fresh OOR session",
 			slog.String("idempotency_key", req.IdempotencyKey),
 		)
+	}
+
+	if admissionDeadlineReached(
+		r.registryNow(), req.AdmissionDeadlineUnixNanos,
+	) {
+		return fn.Err[ActorResp](ErrOutgoingAdmissionExpired)
 	}
 
 	// Build the deterministic session to learn its id. This FSM is
@@ -663,6 +705,14 @@ func (r *oorRegistryBehavior) handleStartTransfer(ctx context.Context,
 		slog.Int("num_recipients", len(req.Recipients)),
 	)
 
+	if req.IdempotencyKey != "" {
+		if r.pendingOutgoingKeys == nil {
+			r.pendingOutgoingKeys = make(map[string]SessionID)
+		}
+
+		r.pendingOutgoingKeys[req.IdempotencyKey] = sessionID
+	}
+
 	// Forward the admission to the child: the Ask persists the request in
 	// the child's durable mailbox so the forward survives a crash. The
 	// caller-promise handoff (detach + continuation wiring, or the inline
@@ -678,6 +728,67 @@ func (r *oorRegistryBehavior) handleStartTransfer(ctx context.Context,
 	}
 
 	return fn.Ok[ActorResp](&StartTransferResponse{SessionID: sessionID})
+}
+
+// handleLookupTransfer reconciles one key without building a transfer or
+// selecting inputs. The registry mailbox orders this read behind admissions it
+// has already accepted; pendingOutgoingKeys covers the child-commit handoff
+// where the durable row is not visible yet.
+func (r *oorRegistryBehavior) handleLookupTransfer(ctx context.Context,
+	req *LookupTransferRequest) fn.Result[ActorResp] {
+
+	if req == nil || req.IdempotencyKey == "" {
+		return fn.Err[ActorResp](
+			fmt.Errorf("idempotency key must be provided"),
+		)
+	}
+
+	record, err := r.cfg.RegistryStore.LookupActiveSessionByIdempotencyKey(
+		ctx, req.IdempotencyKey,
+	)
+	switch {
+	case err == nil:
+		delete(r.pendingOutgoingKeys, req.IdempotencyKey)
+
+		return fn.Ok[ActorResp](&LookupTransferResponse{
+			SessionID: SessionID(record.SessionID),
+			Found:     true,
+		})
+
+	case !errors.Is(err, clientdb.ErrOORSessionNotFound):
+		return fn.Err[ActorResp](err)
+	}
+
+	sessionID, pending := r.pendingOutgoingKeys[req.IdempotencyKey]
+	if !pending {
+		return fn.Ok[ActorResp](&LookupTransferResponse{})
+	}
+	if _, active := r.active[sessionID]; !active {
+		delete(r.pendingOutgoingKeys, req.IdempotencyKey)
+
+		return fn.Ok[ActorResp](&LookupTransferResponse{})
+	}
+
+	return fn.Ok[ActorResp](&LookupTransferResponse{
+		SessionID: sessionID,
+		Pending:   true,
+	})
+}
+
+func (r *oorRegistryBehavior) registryNow() time.Time {
+	if r.cfg.Clock != nil {
+		return r.cfg.Clock.Now()
+	}
+
+	return time.Now()
+}
+
+func admissionDeadlineReached(now time.Time, deadlineUnixNanos int64) bool {
+	if deadlineUnixNanos <= 0 {
+		return false
+	}
+
+	return !now.Before(time.Unix(0, deadlineUnixNanos))
 }
 
 // completeAdmissionHandoff settles the caller's promise for an outgoing
@@ -1466,6 +1577,11 @@ func (r *oorRegistryBehavior) dropChild(sessionID SessionID,
 	delete(r.active, sessionID)
 	delete(r.activeDirs, sessionID)
 	delete(r.incoming, sessionID)
+	for key, pendingID := range r.pendingOutgoingKeys {
+		if pendingID == sessionID {
+			delete(r.pendingOutgoingKeys, key)
+		}
+	}
 }
 
 // spawn creates one durable per-session actor from the shared child config.

--- a/oor/registry_test.go
+++ b/oor/registry_test.go
@@ -16,6 +16,7 @@ import (
 	clientdb "github.com/lightninglabs/wavelength/db"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
+	"github.com/lightningnetwork/lnd/clock"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/stretchr/testify/require"
@@ -144,6 +145,9 @@ func newTestRegistryBehavior(store SessionRegistryStore) (*oorRegistryBehavior,
 		active:     make(map[SessionID]*OORSessionActor),
 		activeDirs: make(map[SessionID]clientdb.OORSessionDirection),
 		incoming:   make(map[SessionID]struct{}),
+		pendingOutgoingKeys: make(
+			map[string]SessionID,
+		),
 	}
 	b.spawnFunc = func(id SessionID, dir clientdb.OORSessionDirection) (
 		*OORSessionActor, error) {
@@ -278,6 +282,97 @@ func TestOORRegistryStartTransferDedup(t *testing.T) {
 	require.True(t, resp.Existing)
 	require.Equal(t, existing, resp.SessionID)
 	require.Equal(t, 0, rec.spawns)
+}
+
+// TestOORRegistryAdmissionDeadline verifies a new transfer cannot cross its
+// caller-owned admission deadline, while an existing key winner remains
+// readable after the same cutoff.
+func TestOORRegistryAdmissionDeadline(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0)
+	store := newFakeRegistryStore()
+	b, rec := newTestRegistryBehavior(store)
+	b.cfg.Clock = clock.NewTestClock(now)
+
+	const key = "deadline-key"
+	expired := b.handleStartTransfer(t.Context(), &StartTransferRequest{
+		IdempotencyKey:             key,
+		AdmissionDeadlineUnixNanos: now.Add(-time.Second).UnixNano(),
+	})
+	require.True(t, expired.IsErr())
+	require.ErrorIs(t, expired.Err(), ErrOutgoingAdmissionExpired)
+	require.Equal(t, 0, rec.spawns)
+
+	existing := oorSessionID(0x12)
+	upsertRegistryRow(
+		t, store, existing, clientdb.OORSessionDirectionOutgoing,
+		"submit_sent", key, clientdb.OORSessionStatusPending,
+	)
+
+	replay := b.handleStartTransfer(t.Context(), &StartTransferRequest{
+		IdempotencyKey:             key,
+		AdmissionDeadlineUnixNanos: now.Add(-time.Second).UnixNano(),
+	})
+	require.True(t, replay.IsOk(), replay.Err())
+
+	resp, ok := replay.UnwrapOr(nil).(*StartTransferResponse)
+	require.True(t, ok)
+	require.True(t, resp.Existing)
+	require.Equal(t, existing, resp.SessionID)
+	require.Equal(t, 0, rec.spawns)
+}
+
+// TestOORRegistryLookupTransfer distinguishes a durable winner, an accepted
+// child admission that has not committed its row, and an authoritative miss.
+func TestOORRegistryLookupTransfer(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeRegistryStore()
+	b, _ := newTestRegistryBehavior(store)
+
+	const key = "lookup-key"
+	missing := b.handleLookupTransfer(t.Context(), &LookupTransferRequest{
+		IdempotencyKey: key,
+	})
+	require.True(t, missing.IsOk(), missing.Err())
+
+	missingResp, ok := missing.UnwrapOr(nil).(*LookupTransferResponse)
+	require.True(t, ok)
+	require.False(t, missingResp.Found)
+	require.False(t, missingResp.Pending)
+
+	pendingID := oorSessionID(0x13)
+	b.pendingOutgoingKeys[key] = pendingID
+	b.active[pendingID] = &OORSessionActor{}
+
+	pending := b.handleLookupTransfer(t.Context(), &LookupTransferRequest{
+		IdempotencyKey: key,
+	})
+	require.True(t, pending.IsOk(), pending.Err())
+
+	pendingResp, ok := pending.UnwrapOr(nil).(*LookupTransferResponse)
+	require.True(t, ok)
+	require.False(t, pendingResp.Found)
+	require.True(t, pendingResp.Pending)
+	require.Equal(t, pendingID, pendingResp.SessionID)
+
+	upsertRegistryRow(
+		t, store, pendingID, clientdb.OORSessionDirectionOutgoing,
+		"submit_sent", key, clientdb.OORSessionStatusPending,
+	)
+
+	found := b.handleLookupTransfer(t.Context(), &LookupTransferRequest{
+		IdempotencyKey: key,
+	})
+	require.True(t, found.IsOk(), found.Err())
+
+	foundResp, ok := found.UnwrapOr(nil).(*LookupTransferResponse)
+	require.True(t, ok)
+	require.True(t, foundResp.Found)
+	require.False(t, foundResp.Pending)
+	require.Equal(t, pendingID, foundResp.SessionID)
+	require.NotContains(t, b.pendingOutgoingKeys, key)
 }
 
 // TestOORRegistryStartTransferRetryAfterFailure verifies a failed keyed

--- a/oor/session_actor_handlers.go
+++ b/oor/session_actor_handlers.go
@@ -52,6 +52,11 @@ func (b *sessionBehavior) handleStartTransfer(ctx context.Context,
 		})
 	}
 
+	now := b.envConfig().newEnvironment(b.sessionID).Now()
+	if admissionDeadlineReached(now, req.AdmissionDeadlineUnixNanos) {
+		return fn.Err[ActorResp](ErrOutgoingAdmissionExpired)
+	}
+
 	session, outbox, err := NewSessionWithIdempotencyKey(
 		ctx, req.Policy, req.Inputs, req.Recipients, req.IdempotencyKey,
 		b.envConfig(),

--- a/oor/shared.go
+++ b/oor/shared.go
@@ -64,6 +64,12 @@ func newOORActorCodec(limits ReceiveLimits) *actor.MessageCodec {
 	codec.MustRegister(ListSessionsRequestTLVType, func() actor.TLVMessage {
 		return &ListSessionsRequest{}
 	})
+	codec.MustRegister(
+		LookupTransferRequestTLVType,
+		func() actor.TLVMessage {
+			return &LookupTransferRequest{}
+		},
+	)
 	codec.MustRegister(DriveEventRequestTLVType, func() actor.TLVMessage {
 		return &DriveEventRequest{limits: limits}
 	})

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -927,6 +927,20 @@ type OORSendResult struct {
 	RecipientOutpoint string
 }
 
+// OORSendOptions controls idempotent admission and read-only reconciliation.
+type OORSendOptions struct {
+	// IdempotencyKey identifies one caller intent across retries.
+	IdempotencyKey string
+
+	// AdmissionDeadline is the latest time Waved may admit a new transfer.
+	// Existing keyed winners remain readable after this time.
+	AdmissionDeadline time.Time
+
+	// ExistingOnly returns an existing keyed winner or NotFound without
+	// selecting inputs or admitting a transfer.
+	ExistingOnly bool
+}
+
 // SendOORWithPolicy sends one OOR transfer to a semantic policy-backed
 // destination and returns the resulting OOR session id.
 func (c *Client) SendOORWithPolicy(ctx context.Context, amountSat int64,
@@ -975,6 +989,24 @@ func (c *Client) SendOORWithPolicyAndKeyDetails(ctx context.Context,
 	amountSat int64, recipientPolicyTemplate []byte,
 	idempotencyKey string) (*OORSendResult, error) {
 
+	return c.SendOORWithPolicyOptionsDetails(
+		ctx, amountSat, recipientPolicyTemplate, OORSendOptions{
+			IdempotencyKey: idempotencyKey,
+		},
+	)
+}
+
+// SendOORWithPolicyOptionsDetails sends or reconciles one semantic
+// policy-backed OOR transfer under explicit admission options.
+func (c *Client) SendOORWithPolicyOptionsDetails(ctx context.Context,
+	amountSat int64, recipientPolicyTemplate []byte, opts OORSendOptions) (
+	*OORSendResult, error) {
+
+	var admissionDeadlineUnixNanos int64
+	if !opts.AdmissionDeadline.IsZero() {
+		admissionDeadlineUnixNanos = opts.AdmissionDeadline.UnixNano()
+	}
+
 	resp, err := c.SendOOR(ctx, &waverpc.SendOORRequest{
 		Recipients: []*waverpc.Output{
 			{
@@ -987,7 +1019,9 @@ func (c *Client) SendOORWithPolicyAndKeyDetails(ctx context.Context,
 				AmountSat: amountSat,
 			},
 		},
-		IdempotencyKey: idempotencyKey,
+		IdempotencyKey:             opts.IdempotencyKey,
+		AdmissionDeadlineUnixNanos: admissionDeadlineUnixNanos,
+		ExistingOnly:               opts.ExistingOnly,
 	})
 	if err != nil {
 		return nil, err

--- a/sdk/ark/client_test.go
+++ b/sdk/ark/client_test.go
@@ -724,6 +724,18 @@ func TestDialRemotePolicyHelpers(t *testing.T) {
 	require.Equal(t, "session-123", oorResult.SessionID)
 	require.Equal(t, "session-123:0", oorResult.RecipientOutpoint)
 
+	admissionDeadline := time.Unix(1_700_000_000, 123)
+	oorResult, err = client.SendOORWithPolicyOptionsDetails(
+		context.Background(), 42_000, []byte{0xaa, 0xbb},
+		OORSendOptions{
+			IdempotencyKey:    "funding-key",
+			AdmissionDeadline: admissionDeadline,
+			ExistingOnly:      true,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "session-123", oorResult.SessionID)
+
 	service.mu.Lock()
 	policyReq := service.lastSendOORReq
 	service.mu.Unlock()
@@ -737,6 +749,12 @@ func TestDialRemotePolicyHelpers(t *testing.T) {
 		t, []byte{0xaa, 0xbb},
 		policyReq.GetRecipients()[0].GetPolicyTemplate(),
 	)
+	require.Equal(t, "funding-key", policyReq.GetIdempotencyKey())
+	require.Equal(
+		t, admissionDeadline.UnixNano(),
+		policyReq.GetAdmissionDeadlineUnixNanos(),
+	)
+	require.True(t, policyReq.GetExistingOnly())
 
 	sessionID, err = client.SendOORWithCustomInputs(
 		context.Background(), []byte{0x11, 0x22}, 21_000,

--- a/sdk/swaps/AGENTS.md
+++ b/sdk/swaps/AGENTS.md
@@ -114,7 +114,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/swap
 ## Sends / Receives
 
 Both FSMs tick via `loopfsm.StateMachine.SendEvent(ctx, OnAdvance,
-nil)`. Pay calls `DaemonConn.SendOORWithPolicyDetails` to fund and
+nil)`. Pay calls `DaemonConn.SendOORWithPolicyAndKeyDetails` with the
+stable `in-swap-funding:<payment_hash>` key to fund and
 `SendOORWithCustomInputs` to refund. Receive calls
 `SendOORWithCustomInputs` to claim via the preimage spend path.
 
@@ -132,6 +133,10 @@ result into an `IncomingVHTLCNotification`.
 - OOR session IDs must be persisted before transitioning; failure
   wraps in `newRetryableActionError` so the FSM retries rather than
   advancing past a durable boundary.
+- Pay-side funding transport failures and incomplete replay metadata remain
+  retryable in `FundingInitiated`. Every retry uses the same payment-scoped OOR
+  key, and the exact recipient outpoint is required before funding metadata is
+  persisted or refund recovery is armed.
 - The store is optional — both `NewSwapClient` and
   `NewSwapClientWithStore` are valid; `persist()` is a no-op when
   `store == nil`.

--- a/sdk/swaps/AGENTS.md
+++ b/sdk/swaps/AGENTS.md
@@ -114,8 +114,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/swap
 ## Sends / Receives
 
 Both FSMs tick via `loopfsm.StateMachine.SendEvent(ctx, OnAdvance,
-nil)`. Pay calls `DaemonConn.SendOORWithPolicyAndKeyDetails` with the
-stable `in-swap-funding:<payment_hash>` key to fund and
+nil)`. Pay calls `DaemonConn.SendOORWithPolicyOptionsDetails` with the
+stable `in-swap-funding:<payment_hash>` key and buffered admission
+deadline to fund and
 `SendOORWithCustomInputs` to refund. Receive calls
 `SendOORWithCustomInputs` to claim via the preimage spend path.
 
@@ -137,6 +138,10 @@ result into an `IncomingVHTLCNotification`.
   retryable in `FundingInitiated`. Every retry uses the same payment-scoped OOR
   key, and the exact recipient outpoint is required before funding metadata is
   persisted or refund recovery is armed.
+- Once the buffered funding admission deadline closes, pay-side retries set
+  `ExistingOnly`: an existing keyed winner is recovered and protected, a
+  daemon `NotFound` expires the swap, and unavailable or pending results remain
+  retryable. A post-deadline reconciliation must never admit a new vHTLC.
 - The store is optional — both `NewSwapClient` and
   `NewSwapClientWithStore` are valid; `persist()` is a no-op when
   `store == nil`.

--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -114,7 +114,8 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/swap
 ## Sends / Receives
 
 Both FSMs tick via `loopfsm.StateMachine.SendEvent(ctx, OnAdvance,
-nil)`. Pay calls `DaemonConn.SendOORWithPolicyDetails` to fund and
+nil)`. Pay calls `DaemonConn.SendOORWithPolicyAndKeyDetails` with the
+stable `in-swap-funding:<payment_hash>` key to fund and
 `SendOORWithCustomInputs` to refund. Receive calls
 `SendOORWithCustomInputs` to claim via the preimage spend path.
 
@@ -132,6 +133,10 @@ result into an `IncomingVHTLCNotification`.
 - OOR session IDs must be persisted before transitioning; failure
   wraps in `newRetryableActionError` so the FSM retries rather than
   advancing past a durable boundary.
+- Pay-side funding transport failures and incomplete replay metadata remain
+  retryable in `FundingInitiated`. Every retry uses the same payment-scoped OOR
+  key, and the exact recipient outpoint is required before funding metadata is
+  persisted or refund recovery is armed.
 - The store is optional — both `NewSwapClient` and
   `NewSwapClientWithStore` are valid; `persist()` is a no-op when
   `store == nil`.

--- a/sdk/swaps/CLAUDE.md
+++ b/sdk/swaps/CLAUDE.md
@@ -114,8 +114,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/sdk/swap
 ## Sends / Receives
 
 Both FSMs tick via `loopfsm.StateMachine.SendEvent(ctx, OnAdvance,
-nil)`. Pay calls `DaemonConn.SendOORWithPolicyAndKeyDetails` with the
-stable `in-swap-funding:<payment_hash>` key to fund and
+nil)`. Pay calls `DaemonConn.SendOORWithPolicyOptionsDetails` with the
+stable `in-swap-funding:<payment_hash>` key and buffered admission
+deadline to fund and
 `SendOORWithCustomInputs` to refund. Receive calls
 `SendOORWithCustomInputs` to claim via the preimage spend path.
 
@@ -137,6 +138,10 @@ result into an `IncomingVHTLCNotification`.
   retryable in `FundingInitiated`. Every retry uses the same payment-scoped OOR
   key, and the exact recipient outpoint is required before funding metadata is
   persisted or refund recovery is armed.
+- Once the buffered funding admission deadline closes, pay-side retries set
+  `ExistingOnly`: an existing keyed winner is recovered and protected, a
+  daemon `NotFound` expires the swap, and unavailable or pending results remain
+  retryable. A post-deadline reconciliation must never admit a new vHTLC.
 - The store is optional — both `NewSwapClient` and
   `NewSwapClientWithStore` are valid; `persist()` is a no-op when
   `store == nil`.

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -163,6 +163,9 @@ type CreditRedemption struct {
 // OORSendResult contains daemon metadata for an accepted OOR transfer.
 type OORSendResult = sdkark.OORSendResult
 
+// OORSendOptions controls idempotent daemon admission and reconciliation.
+type OORSendOptions = sdkark.OORSendOptions
+
 // SwapSummary is the stable list view for one persisted swap session.
 type SwapSummary struct {
 	// Direction identifies whether this is a pay or receive session.
@@ -744,11 +747,11 @@ type DaemonConn interface {
 	// BlockHeight returns the daemon's best known chain height.
 	BlockHeight(ctx context.Context) (uint32, error)
 
-	// SendOORWithPolicyAndKeyDetails sends an OOR transfer to a semantic
-	// policy-backed destination under a caller-owned idempotency key.
-	SendOORWithPolicyAndKeyDetails(ctx context.Context, amountSat int64,
+	// SendOORWithPolicyOptionsDetails sends or reconciles an OOR transfer
+	// under caller-owned idempotency and admission options.
+	SendOORWithPolicyOptionsDetails(ctx context.Context, amountSat int64,
 		recipientPolicyTemplate []byte,
-		idempotencyKey string) (*OORSendResult, error)
+		opts OORSendOptions) (*OORSendResult, error)
 
 	// SendOORWithCustomInputs sends an OOR with custom inputs into one
 	// standard pubkey-backed Ark receive destination.

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -744,10 +744,11 @@ type DaemonConn interface {
 	// BlockHeight returns the daemon's best known chain height.
 	BlockHeight(ctx context.Context) (uint32, error)
 
-	// SendOORWithPolicyDetails sends an OOR transfer to a semantic
-	// policy-backed destination.
-	SendOORWithPolicyDetails(ctx context.Context, amountSat int64,
-		recipientPolicyTemplate []byte) (*OORSendResult, error)
+	// SendOORWithPolicyAndKeyDetails sends an OOR transfer to a semantic
+	// policy-backed destination under a caller-owned idempotency key.
+	SendOORWithPolicyAndKeyDetails(ctx context.Context, amountSat int64,
+		recipientPolicyTemplate []byte,
+		idempotencyKey string) (*OORSendResult, error)
 
 	// SendOORWithCustomInputs sends an OOR with custom inputs into one
 	// standard pubkey-backed Ark receive destination.

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -692,9 +692,7 @@ func (s *paySession) createSwap(ctx context.Context) error {
 // wall-clock funding deadline is effectively exhausted or the vHTLC refund
 // locktime is already imminent.
 func (s *paySession) ensureFundingStillSafe(ctx context.Context) error {
-	now := s.client.currentTime()
-	if !s.cfg.Expiry.IsZero() &&
-		!now.Add(s.client.fundingExpiryBuffer).Before(s.cfg.Expiry) {
+	if s.fundingAdmissionClosed() {
 		return s.markExpired(
 			ctx, fmt.Sprintf("funding deadline %s is too close "+
 				"or already reached", s.cfg.Expiry),
@@ -718,6 +716,24 @@ func (s *paySession) ensureFundingStillSafe(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// fundingAdmissionDeadline returns the wall-clock cutoff shared with Waved.
+// The local safety buffer closes admission before the swap's hard expiry so a
+// newly accepted vHTLC still has time to propagate and be reconciled.
+func (s *paySession) fundingAdmissionDeadline() time.Time {
+	if s == nil || s.cfg == nil || s.cfg.Expiry.IsZero() {
+		return time.Time{}
+	}
+
+	return s.cfg.Expiry.Add(-s.client.fundingExpiryBuffer)
+}
+
+func (s *paySession) fundingAdmissionClosed() bool {
+	deadline := s.fundingAdmissionDeadline()
+
+	return !deadline.IsZero() &&
+		!s.client.currentTime().Before(deadline)
 }
 
 // fundOrAdoptVHTLC reconciles already-indexed state before submitting funding,
@@ -842,8 +858,16 @@ func (s *paySession) waitForFundedVHTLC(ctx context.Context) error {
 			})
 		}
 
-		if err := s.ensureFundingStillSafe(ctx); err != nil {
-			return err
+		// Once admission closes, a FundingInitiated session is
+		// ambiguous: the original detached OOR may have committed even
+		// when its RPC response was lost. Skip terminal expiry here and
+		// issue a read-only keyed reconciliation below. Waved's
+		// matching admission deadline guarantees that a NotFound
+		// response cannot later turn into a fresh transfer.
+		if !s.fundingAdmissionClosed() {
+			if err := s.ensureFundingStillSafe(ctx); err != nil {
+				return err
+			}
 		}
 
 		if err := s.ensureFundingSubmitted(ctx, false); err != nil {
@@ -868,9 +892,13 @@ func (s *paySession) waitForFundedVHTLC(ctx context.Context) error {
 					)
 				}
 
-				return s.mutateAndPersist(ctx, func() error {
-					return s.transition(payEventExpired)
-				})
+				// The ambiguity grace can span the hard swap
+				// expiry. Never let that timer bypass
+				// authoritative keyed reconciliation: force an
+				// immediate existing-only probe, which either
+				// recovers the winner, expires on NotFound, or
+				// remains retryable.
+				return s.ensureFundingSubmitted(ctx, true)
 			}
 
 			return err
@@ -903,11 +931,24 @@ func (s *paySession) ensureFundingSubmitted(ctx context.Context,
 		}
 	}
 
-	result, err := s.client.daemon.SendOORWithPolicyAndKeyDetails(
-		ctx, s.cfg.AmountSat, s.vhtlcPolicyTemplate,
-		inSwapFundingIdempotencyKey(s.cfg.PaymentHash),
+	existingOnly := s.fundingAdmissionClosed()
+	result, err := s.client.daemon.SendOORWithPolicyOptionsDetails(
+		ctx, s.cfg.AmountSat, s.vhtlcPolicyTemplate, OORSendOptions{
+			IdempotencyKey: inSwapFundingIdempotencyKey(
+				s.cfg.PaymentHash,
+			),
+			AdmissionDeadline: s.fundingAdmissionDeadline(),
+			ExistingOnly:      existingOnly,
+		},
 	)
 	if err != nil {
+		if existingOnly && status.Code(err) == codes.NotFound {
+			return s.markExpired(
+				ctx, "funding admission closed with no "+
+					"accepted OOR transfer",
+			)
+		}
+
 		// A retry can race with a funding attempt that was accepted but
 		// not yet observed by this SDK instance. Reconcile once before
 		// surfacing the send failure.

--- a/sdk/swaps/in_swap.go
+++ b/sdk/swaps/in_swap.go
@@ -24,6 +24,13 @@ const (
 	refundLocktimeMaxPollInterval = time.Minute
 )
 
+// inSwapFundingIdempotencyKey derives the daemon-side OOR identity for one
+// Ark-to-Lightning vHTLC funding intent. The payment hash is the durable swap
+// identity, so this format must remain stable across process restarts.
+func inSwapFundingIdempotencyKey(hash lntypes.Hash) string {
+	return fmt.Sprintf("in-swap-funding:%s", hash.String())
+}
+
 // PayState identifies the client-side lifecycle state of an Ark-to-Lightning
 // pay flow.
 type PayState uint8
@@ -842,6 +849,16 @@ func (s *paySession) waitForFundedVHTLC(ctx context.Context) error {
 		if err := s.ensureFundingSubmitted(ctx, false); err != nil {
 			return err
 		}
+		if s.state == PayStateVHTLCFunded {
+
+			// A keyed replay can recover the original outpoint and
+			// advance the durable state without waiting for the
+			// authoritative indexer. Return control to the FSM so
+			// it can enter WaitingForClaim instead of remaining
+			// inside the FundingInitiated action after its state
+			// already changed.
+			return nil
+		}
 
 		if err := s.waitForNextPoll(ctx); err != nil {
 			if errors.Is(err, errSwapExpired) {
@@ -886,8 +903,9 @@ func (s *paySession) ensureFundingSubmitted(ctx context.Context,
 		}
 	}
 
-	result, err := s.client.daemon.SendOORWithPolicyDetails(
+	result, err := s.client.daemon.SendOORWithPolicyAndKeyDetails(
 		ctx, s.cfg.AmountSat, s.vhtlcPolicyTemplate,
+		inSwapFundingIdempotencyKey(s.cfg.PaymentHash),
 	)
 	if err != nil {
 		// A retry can race with a funding attempt that was accepted but
@@ -912,11 +930,32 @@ func (s *paySession) ensureFundingSubmitted(ctx context.Context,
 			})
 		}
 
-		return fmt.Errorf("fund vHTLC: %w", err)
+		// Any transport-level send failure is ambiguous: the daemon can
+		// durably accept the detached OOR before this RPC loses its
+		// response. Keep FundingInitiated retryable so the next attempt
+		// replays the same payment-scoped key instead of terminalizing
+		// a potentially funded swap.
+		return newRetryableActionError(
+			fmt.Errorf("fund vHTLC: %w", err),
+		)
 	}
 	if result == nil || result.SessionID == "" {
-		return fmt.Errorf("fund vHTLC: daemon returned empty OOR " +
-			"session id")
+		return newRetryableActionError(
+			fmt.Errorf("fund vHTLC: daemon returned empty OOR " +
+				"session id"),
+		)
+	}
+	if result.RecipientOutpoint == "" {
+
+		// Do not persist a session without the exact vHTLC output. The
+		// payment-hash key makes another call a read-only replay of
+		// this funding intent, while persisting incomplete metadata
+		// could strand same-Ark swaps whose script is not queryable
+		// through the payer's authoritative indexer principal.
+		return newRetryableActionError(
+			fmt.Errorf("fund vHTLC: daemon returned empty " +
+				"recipient outpoint"),
+		)
 	}
 
 	s.client.log.InfoS(ctx, "In-swap vHTLC funding submitted",
@@ -930,9 +969,6 @@ func (s *paySession) ensureFundingSubmitted(ctx context.Context,
 		s.cfg.AmountSat,
 	); err != nil {
 		return newRetryableActionError(err)
-	}
-	if result.RecipientOutpoint == "" {
-		return nil
 	}
 
 	return s.markVHTLCFundedFromLocalMetadata(ctx)

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -2583,8 +2583,9 @@ func TestPaySessionFundingReplayAfterLostResponse(t *testing.T) {
 	resumedClient.waitPollInterval = time.Millisecond
 	resumedClient.fundingResumeGracePeriod = grace
 	resumedClient.now = func() time.Time {
-		return start.Add(2 * grace)
+		return start.Add(time.Minute)
 	}
+	resumedClient.fundingResumeGracePeriod = 2 * time.Minute
 
 	resumed, err := resumedClient.ResumePayViaLightning(
 		t.Context(), preimage.Hash(),
@@ -2607,12 +2608,114 @@ func TestPaySessionFundingReplayAfterLostResponse(t *testing.T) {
 	require.EqualValues(t, testInSwapAmountSat, resumed.vhtlcAmount)
 	require.Len(t, accepted, 1)
 	require.Equal(t, 3, daemonConn.sendPolicyCalls)
+	require.Equal(t, 1, daemonConn.armRecoveryCalls)
 
 	wantKey := inSwapFundingIdempotencyKey(preimage.Hash())
 	require.Equal(
 		t, []string{wantKey, wantKey, wantKey},
 		daemonConn.sendPolicyKeys,
 	)
+	require.Len(t, daemonConn.sendPolicyOpts, 3)
+	require.False(t, daemonConn.sendPolicyOpts[0].ExistingOnly)
+	require.True(t, daemonConn.sendPolicyOpts[1].ExistingOnly)
+	require.True(t, daemonConn.sendPolicyOpts[2].ExistingOnly)
+	for _, opts := range daemonConn.sendPolicyOpts {
+		require.Equal(
+			t, start.Add(55*time.Second), opts.AdmissionDeadline,
+		)
+	}
+}
+
+// TestPaySessionExpiresAfterAuthoritativeFundingMiss verifies an ambiguous
+// FundingInitiated session only expires after Waved authoritatively reports
+// that no transfer won the key. The post-deadline call must be read-only so
+// recovering a stale session can never create an already-expired vHTLC.
+func TestPaySessionExpiresAfterAuthoritativeFundingMiss(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	start := time.Unix(1_700_000_000, 0)
+	serverConn := &testInSwapServerConn{
+		cfg: testInSwapConfig(
+			serverPriv.PubKey(), preimage, start.Add(time.Minute),
+		),
+	}
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+		blockHeight: 100,
+		sendPolicyHook: func(int, string) (*OORSendResult, error) {
+			return nil, status.Error(
+				codes.NotFound, "no accepted funding transfer",
+			)
+		},
+	}
+
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	client.now = func() time.Time { return start }
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	err = session.mutateAndPersist(t.Context(), func() error {
+		return session.transition(payEventFundingInitiated)
+	})
+	require.NoError(t, err)
+
+	resumedClient := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	resumedClient.now = func() time.Time {
+		return start.Add(time.Minute)
+	}
+	resumedClient.fundingResumeGracePeriod = 2 * time.Minute
+
+	resumed, err := resumedClient.ResumePayViaLightning(
+		t.Context(), preimage.Hash(),
+	)
+	require.NoError(t, err)
+
+	_, err = resumed.Wait(t.Context())
+	require.ErrorIs(t, err, errSwapExpired)
+	require.Equal(t, PayStateExpired, resumed.State())
+	require.Empty(t, resumed.fundingSessionID)
+	require.Empty(t, resumed.vhtlcOutpoint)
+	require.Equal(t, 0, daemonConn.armRecoveryCalls)
+	require.Equal(t, 1, daemonConn.sendPolicyCalls)
+	require.Equal(
+		t,
+		inSwapFundingIdempotencyKey(
+			preimage.Hash(),
+		),
+		daemonConn.sendPolicyOpts[0].IdempotencyKey,
+	)
+	require.Equal(
+		t, start.Add(55*time.Second),
+		daemonConn.sendPolicyOpts[0].AdmissionDeadline,
+	)
+	require.True(t, daemonConn.sendPolicyOpts[0].ExistingOnly)
 }
 
 // TestPaySessionRefundsAmountMismatch asserts the client preserves mismatch

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -630,6 +630,7 @@ func TestPayViaLightningReturnsClaimPreimage(t *testing.T) {
 		identityKey:   clientPriv.PubKey(),
 		operatorKey:   operatorPriv.PubKey(),
 		sendSessionID: "funding-session",
+		sendOutpoint:  "funding-session:0",
 		spentVTXO: &VTXOInfo{
 			SpentByTxID: "0123456789abcdef0123456789abcdef" +
 				"0123456789abcdef0123456789abcdef",
@@ -658,6 +659,10 @@ func TestPayViaLightningReturnsClaimPreimage(t *testing.T) {
 	require.Equal(t, "funding-session", result.FundingSessionID)
 	require.EqualValues(t, testInSwapFeeSat, result.FeeSat)
 	require.NotEmpty(t, daemonConn.lastSendPolicy)
+	require.Equal(
+		t, []string{inSwapFundingIdempotencyKey(preimage.Hash())},
+		daemonConn.sendPolicyKeys,
+	)
 }
 
 // TestPayViaLightningRequiresClaimPreimage asserts the pay FSM never treats an
@@ -699,6 +704,7 @@ func TestPayViaLightningRequiresClaimPreimage(t *testing.T) {
 		identityKey:   clientPriv.PubKey(),
 		operatorKey:   operatorPriv.PubKey(),
 		sendSessionID: "funding-session",
+		sendOutpoint:  "funding-session:0",
 	}
 
 	client := configureTestPayClient(
@@ -2071,6 +2077,7 @@ func TestPaySessionResumeFromStore(t *testing.T) {
 		identityKey:   clientPriv.PubKey(),
 		operatorKey:   operatorPriv.PubKey(),
 		sendSessionID: "funding-session",
+		sendOutpoint:  "funding-session:0",
 	}
 
 	client := configureTestPayClient(
@@ -2157,6 +2164,7 @@ func TestPaySessionCancelDoesNotPersistFailed(t *testing.T) {
 		identityKey:   clientPriv.PubKey(),
 		operatorKey:   operatorPriv.PubKey(),
 		sendSessionID: "funding-session",
+		sendOutpoint:  "funding-session:0",
 	}
 
 	client := configureTestPayClient(
@@ -2321,6 +2329,7 @@ func TestPaySessionResumeFundingGraceSkipsImmediateResend(t *testing.T) {
 		identityKey:   clientPriv.PubKey(),
 		operatorKey:   operatorPriv.PubKey(),
 		sendSessionID: "funding-session",
+		sendOutpoint:  "funding-session:0",
 	}
 
 	client := configureTestPayClient(
@@ -2412,6 +2421,7 @@ func TestPaySessionResumeFundingGraceEventuallyRetries(t *testing.T) {
 		identityKey:   clientPriv.PubKey(),
 		operatorKey:   operatorPriv.PubKey(),
 		sendSessionID: "funding-session",
+		sendOutpoint:  "funding-session:0",
 	}
 
 	client := configureTestPayClient(
@@ -2449,22 +2459,160 @@ func TestPaySessionResumeFundingGraceEventuallyRetries(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	waitCtx, cancel := context.WithTimeout(
-		t.Context(), 5*time.Millisecond,
-	)
-	defer cancel()
-
-	_, err = resumed.Wait(waitCtx)
-	require.ErrorIs(t, err, context.DeadlineExceeded)
+	err = resumed.runUntil(t.Context(), PayStateWaitingForClaim)
+	require.NoError(t, err)
 	require.Equal(t, 1, daemonConn.sendPolicyCalls)
-	require.Equal(t, PayStateFundingInitiated, resumed.State())
+	require.Equal(t, PayStateWaitingForClaim, resumed.State())
+	require.Equal(
+		t, []string{inSwapFundingIdempotencyKey(preimage.Hash())},
+		daemonConn.sendPolicyKeys,
+	)
 
 	reloaded, err := resumedClient.ResumePayViaLightning(
 		t.Context(), preimage.Hash(),
 	)
 	require.NoError(t, err)
 	require.Equal(t, "funding-session", reloaded.fundingSessionID)
-	require.Equal(t, PayStateFundingInitiated, reloaded.State())
+	require.Equal(t, "funding-session:0", reloaded.vhtlcOutpoint)
+	require.Equal(t, PayStateWaitingForClaim, reloaded.State())
+}
+
+// TestPaySessionFundingReplayAfterLostResponse verifies an accepted funding
+// OOR whose RPC response is lost is recovered under the same payment-scoped
+// idempotency key. The resumed SDK must obtain the original session/outpoint;
+// it must not create a second daemon-side funding intent.
+func TestPaySessionFundingReplayAfterLostResponse(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSwapStore(t)
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage, err := NewPreimage()
+	require.NoError(t, err)
+	invoice := testValidPayInvoice(t, preimage)
+
+	start := time.Unix(1_700_000_000, 0)
+	grace := 10 * time.Millisecond
+	serverConn := &testInSwapServerConn{
+		cfg: &InSwapConfig{
+			PaymentHash:  preimage.Hash(),
+			AmountSat:    testInSwapAmountSat,
+			FeeSat:       testInSwapFeeSat,
+			ServerPubkey: serverPriv.PubKey(),
+			VHTLCConfig: VHTLCConfig{
+				RefundLocktime:                       200,
+				UnilateralClaimDelay:                 12,
+				UnilateralRefundDelay:                24,
+				UnilateralRefundWithoutReceiverDelay: 36,
+			},
+			Expiry: start.Add(time.Minute),
+		},
+	}
+
+	accepted := make(map[string]*OORSendResult)
+	daemonConn := &testDaemonConn{
+		identityKey: clientPriv.PubKey(),
+		operatorKey: operatorPriv.PubKey(),
+		blockHeight: 100,
+	}
+	daemonConn.sendPolicyHook = func(call int, idempotencyKey string) (
+		*OORSendResult, error) {
+
+		if result, ok := accepted[idempotencyKey]; ok {
+			resultCopy := *result
+			if call == 2 {
+				// Model the daemon finding the keyed winner
+				// before its snapshot metadata can be returned.
+				// The SDK must retain FundingInitiated and
+				// replay, not persist a session that it cannot
+				// safely refund.
+				resultCopy.RecipientOutpoint = ""
+			}
+
+			return &resultCopy, nil
+		}
+
+		accepted[idempotencyKey] = &OORSendResult{
+			SessionID:         "funding-session",
+			RecipientOutpoint: "funding-session:0",
+		}
+
+		// Model Waved durably accepting the OOR before the caller's
+		// deadline wins the response race.
+		return nil, status.Error(
+			codes.DeadlineExceeded,
+			"funding accepted but response lost",
+		)
+	}
+
+	client := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	client.waitPollInterval = time.Millisecond
+	client.fundingResumeGracePeriod = grace
+	client.now = func() time.Time { return start }
+
+	session, err := client.StartPayViaLightning(
+		t.Context(), invoice, testInSwapFeeSat,
+	)
+	require.NoError(t, err)
+
+	_, err = session.Wait(t.Context())
+	require.ErrorContains(t, err, "funding accepted but response lost")
+	require.Equal(t, PayStateFundingInitiated, session.State())
+	require.Empty(t, session.fundingSessionID)
+	require.Empty(t, session.vhtlcOutpoint)
+	require.Len(t, accepted, 1)
+	require.Equal(t, 1, daemonConn.sendPolicyCalls)
+
+	resumedClient := configureTestPayClient(
+		NewSwapClientWithStore(
+			serverConn, daemonConn, nil, nil, store,
+		),
+	)
+	resumedClient.waitPollInterval = time.Millisecond
+	resumedClient.fundingResumeGracePeriod = grace
+	resumedClient.now = func() time.Time {
+		return start.Add(2 * grace)
+	}
+
+	resumed, err := resumedClient.ResumePayViaLightning(
+		t.Context(), preimage.Hash(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, PayStateFundingInitiated, resumed.State())
+
+	err = resumed.runUntil(t.Context(), PayStateWaitingForClaim)
+	require.ErrorContains(t, err, "empty recipient outpoint")
+	require.Equal(t, PayStateFundingInitiated, resumed.State())
+	require.Empty(t, resumed.fundingSessionID)
+	require.Empty(t, resumed.vhtlcOutpoint)
+	require.Len(t, accepted, 1)
+	require.Equal(t, 2, daemonConn.sendPolicyCalls)
+
+	err = resumed.runUntil(t.Context(), PayStateWaitingForClaim)
+	require.NoError(t, err)
+	require.Equal(t, "funding-session", resumed.fundingSessionID)
+	require.Equal(t, "funding-session:0", resumed.vhtlcOutpoint)
+	require.EqualValues(t, testInSwapAmountSat, resumed.vhtlcAmount)
+	require.Len(t, accepted, 1)
+	require.Equal(t, 3, daemonConn.sendPolicyCalls)
+
+	wantKey := inSwapFundingIdempotencyKey(preimage.Hash())
+	require.Equal(
+		t, []string{wantKey, wantKey, wantKey},
+		daemonConn.sendPolicyKeys,
+	)
 }
 
 // TestPaySessionRefundsAmountMismatch asserts the client preserves mismatch
@@ -2728,12 +2876,7 @@ func TestPaySessionNeedsInterventionOnSpentWithoutPreimage(t *testing.T) {
 		operatorKey:   operatorPriv.PubKey(),
 		blockHeight:   100,
 		sendSessionID: "funding-session",
-		spentVTXO: &VTXOInfo{
-			Outpoint:    "funding:0",
-			AmountSat:   testInSwapAmountSat,
-			SpentByTxID: "deadbeef",
-		},
-		indexedPackage: &OORPackageInfo{},
+		sendOutpoint:  "funding:0",
 	}
 
 	client := configureTestPayClient(
@@ -2747,6 +2890,23 @@ func TestPaySessionNeedsInterventionOnSpentWithoutPreimage(t *testing.T) {
 		t.Context(), invoice, testInSwapFeeSat,
 	)
 	require.NoError(t, err)
+
+	err = session.runUntil(t.Context(), PayStateWaitingForClaim)
+	require.NoError(t, err)
+
+	// This case exercises an unattributed spend before any local refund
+	// destination exists. The ordinary funding path allocates that
+	// destination while arming recovery, so clear it to preserve the
+	// anomaly this regression is specifically about.
+	session.refundReceivePubKey = nil
+	session.refundReceiveScript = nil
+
+	daemonConn.spentVTXO = &VTXOInfo{
+		Outpoint:    "funding:0",
+		AmountSat:   testInSwapAmountSat,
+		SpentByTxID: "deadbeef",
+	}
+	daemonConn.indexedPackage = &OORPackageInfo{}
 
 	_, err = session.Wait(t.Context())
 	require.ErrorContains(t, err, "spent without claim preimage")

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -1668,6 +1668,9 @@ func TestWaitForVHTLCExpiresOnPersistentUnregisteredScript(t *testing.T) {
 	require.Equal(t, 1, daemonConn.liveLookupCalls)
 }
 
+type testSendPolicyHook func(call int, idempotencyKey string) (
+	*OORSendResult, error)
+
 type testDaemonConn struct {
 	identityKey       *btcec.PublicKey
 	operatorKey       *btcec.PublicKey
@@ -1688,6 +1691,7 @@ type testDaemonConn struct {
 	preparedOOR       *PreparedOOR
 	prepareOOREErr    error
 	sendPolicyErr     error
+	sendPolicyHook    testSendPolicyHook
 	sendCustomErr     error
 	oorSession        *waverpc.OORSessionInfo
 	oorSessionErr     error
@@ -1699,6 +1703,7 @@ type testDaemonConn struct {
 	spendOnCustom     bool
 	skipLiveOnCustom  bool
 	sendPolicyCalls   int
+	sendPolicyKeys    []string
 	sendCustomCalls   int
 	oorSessionCalls   int
 	liveLookupCalls   int
@@ -1734,14 +1739,20 @@ func (d *testDaemonConn) BlockHeight(context.Context) (uint32, error) {
 	return d.blockHeight, nil
 }
 
-// SendOORWithPolicyDetails records the requested output policy template.
-func (d *testDaemonConn) SendOORWithPolicyDetails(_ context.Context, _ int64,
-	recipientPolicyTemplate []byte) (*OORSendResult, error) {
+// SendOORWithPolicyAndKeyDetails records the requested output policy template
+// and caller-owned idempotency key.
+func (d *testDaemonConn) SendOORWithPolicyAndKeyDetails(_ context.Context,
+	_ int64, recipientPolicyTemplate []byte, idempotencyKey string) (
+	*OORSendResult, error) {
 
 	d.sendPolicyCalls++
+	d.sendPolicyKeys = append(d.sendPolicyKeys, idempotencyKey)
 	d.lastSendPolicy = append(
 		[]byte(nil), recipientPolicyTemplate...,
 	)
+	if d.sendPolicyHook != nil {
+		return d.sendPolicyHook(d.sendPolicyCalls, idempotencyKey)
+	}
 
 	if d.sendPolicyErr != nil {
 		return nil, d.sendPolicyErr

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -1704,6 +1704,7 @@ type testDaemonConn struct {
 	skipLiveOnCustom  bool
 	sendPolicyCalls   int
 	sendPolicyKeys    []string
+	sendPolicyOpts    []OORSendOptions
 	sendCustomCalls   int
 	oorSessionCalls   int
 	liveLookupCalls   int
@@ -1739,19 +1740,20 @@ func (d *testDaemonConn) BlockHeight(context.Context) (uint32, error) {
 	return d.blockHeight, nil
 }
 
-// SendOORWithPolicyAndKeyDetails records the requested output policy template
-// and caller-owned idempotency key.
-func (d *testDaemonConn) SendOORWithPolicyAndKeyDetails(_ context.Context,
-	_ int64, recipientPolicyTemplate []byte, idempotencyKey string) (
+// SendOORWithPolicyOptionsDetails records the requested output policy template
+// and caller-owned admission options.
+func (d *testDaemonConn) SendOORWithPolicyOptionsDetails(_ context.Context,
+	_ int64, recipientPolicyTemplate []byte, opts OORSendOptions) (
 	*OORSendResult, error) {
 
 	d.sendPolicyCalls++
-	d.sendPolicyKeys = append(d.sendPolicyKeys, idempotencyKey)
+	d.sendPolicyKeys = append(d.sendPolicyKeys, opts.IdempotencyKey)
+	d.sendPolicyOpts = append(d.sendPolicyOpts, opts)
 	d.lastSendPolicy = append(
 		[]byte(nil), recipientPolicyTemplate...,
 	)
 	if d.sendPolicyHook != nil {
-		return d.sendPolicyHook(d.sendPolicyCalls, idempotencyKey)
+		return d.sendPolicyHook(d.sendPolicyCalls, opts.IdempotencyKey)
 	}
 
 	if d.sendPolicyErr != nil {

--- a/waved/rpc_oor_idempotency_test.go
+++ b/waved/rpc_oor_idempotency_test.go
@@ -695,6 +695,10 @@ func TestSendOORReturnsExistingIdempotencyKeyBeforeWalletSelection(
 	secondResp, err := rpcServer.SendOOR(ctx, &waverpc.SendOORRequest{
 		Recipients:     []*waverpc.Output{recipient},
 		IdempotencyKey: idempotencyKey,
+		AdmissionDeadlineUnixNanos: time.Now().
+			Add(-time.Second).
+			UnixNano(),
+		ExistingOnly: true,
 	})
 	require.NoError(t, err)
 	require.Equal(t, firstResp.SessionId, secondResp.SessionId)
@@ -703,6 +707,24 @@ func TestSendOORReturnsExistingIdempotencyKeyBeforeWalletSelection(
 	)
 	require.Equal(t, 1, testWallet.selectCount())
 	require.Empty(t, testWallet.unlockBatches())
+
+	_, err = rpcServer.SendOOR(ctx, &waverpc.SendOORRequest{
+		Recipients:     []*waverpc.Output{recipient},
+		IdempotencyKey: "missing-existing-only-key",
+		ExistingOnly:   true,
+	})
+	require.Equal(t, codes.NotFound, status.Code(err))
+	require.Equal(t, 1, testWallet.selectCount())
+
+	_, err = rpcServer.SendOOR(ctx, &waverpc.SendOORRequest{
+		Recipients:     []*waverpc.Output{recipient},
+		IdempotencyKey: "expired-admission-key",
+		AdmissionDeadlineUnixNanos: time.Now().
+			Add(-time.Second).
+			UnixNano(),
+	})
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	require.Equal(t, 1, testWallet.selectCount())
 }
 
 // TestSendOORUnlocksSelectedInputsForExistingSession verifies the daemon

--- a/waved/rpc_oor_idempotency_test.go
+++ b/waved/rpc_oor_idempotency_test.go
@@ -698,7 +698,9 @@ func TestSendOORReturnsExistingIdempotencyKeyBeforeWalletSelection(
 	})
 	require.NoError(t, err)
 	require.Equal(t, firstResp.SessionId, secondResp.SessionId)
-	require.Empty(t, secondResp.RecipientOutpoints)
+	require.Equal(
+		t, firstResp.RecipientOutpoints, secondResp.RecipientOutpoints,
+	)
 	require.Equal(t, 1, testWallet.selectCount())
 	require.Empty(t, testWallet.unlockBatches())
 }

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -2937,6 +2937,19 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		return nil, err
 	}
 
+	if req.GetExistingOnly() && req.GetIdempotencyKey() == "" {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"existing_only requires idempotency_key")
+	}
+	if req.GetExistingOnly() && req.GetDryRun() {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"existing_only cannot be combined with dry_run")
+	}
+	if req.GetAdmissionDeadlineUnixNanos() < 0 {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"admission_deadline_unix_nanos must not be negative")
+	}
+
 	if req.GetIdempotencyKey() != "" && !req.DryRun {
 		phaseStart := time.Now()
 		key := req.GetIdempotencyKey()
@@ -2978,6 +2991,44 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 					),
 			}, nil
 		}
+
+		if req.GetExistingOnly() {
+			sessionID, found, pending, err :=
+				r.lookupOutgoingOORSessionByIdempotencyKey(
+					ctx, key,
+				)
+			if err != nil {
+				return nil, err
+			}
+			if !found && !pending {
+				return nil, status.Errorf(codes.NotFound,
+					"no active OOR transfer for "+
+						"idempotency key")
+			}
+
+			replayStatus := "pending"
+			var recipientOutpoints []string
+			if found {
+				replayStatus = "submitted"
+				recipientOutpoints = r.
+					resolveExistingOORRecipientOutpoints(
+						ctx, sessionID,
+						requestRecipients,
+					)
+			}
+
+			return &waverpc.SendOORResponse{
+				Status:             replayStatus,
+				SessionId:          sessionID.String(),
+				RecipientOutpoints: recipientOutpoints,
+			}, nil
+		}
+	}
+
+	if deadline := req.GetAdmissionDeadlineUnixNanos(); deadline > 0 &&
+		!time.Now().Before(time.Unix(0, deadline)) {
+		return nil, status.Errorf(codes.FailedPrecondition, "OOR "+
+			"admission deadline reached")
 	}
 
 	// Fetch operator terms for the checkpoint policy.
@@ -3196,6 +3247,8 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		Inputs:         selectedInputs,
 		Recipients:     recipients,
 		IdempotencyKey: req.GetIdempotencyKey(),
+		AdmissionDeadlineUnixNanos: req.
+			GetAdmissionDeadlineUnixNanos(),
 	}
 
 	phaseStart = time.Now()
@@ -3206,6 +3259,13 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 
 	oorResp, err := oorResult.Unpack()
 	if err != nil {
+		if errors.Is(err, oor.ErrOutgoingAdmissionExpired) {
+			r.unlockSelectedVTXOsBestEffort(ctx, locked)
+
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"OOR admission deadline reached")
+		}
+
 		if isAwaitContextError(ctx, err) {
 			releaseCustomInputs = false
 			r.cleanupSubmittedOORStart(
@@ -3879,6 +3939,40 @@ func (r *RPCServer) findOutgoingOORSessionByIdempotencyKey(ctx context.Context,
 	return oor.SessionID(record.SessionID), true, nil
 }
 
+// lookupOutgoingOORSessionByIdempotencyKey serializes a read-only key probe
+// through the registry actor. This observes admissions already accepted by the
+// registry, including the child-commit handoff where the durable row is not yet
+// visible, without selecting inputs or admitting a transfer.
+func (r *RPCServer) lookupOutgoingOORSessionByIdempotencyKey(
+	ctx context.Context, idempotencyKey string) (oor.SessionID, bool, bool,
+	error) {
+
+	if r.server.actorSystem == nil {
+		return oor.SessionID{}, false, false, status.Errorf(
+			codes.Internal, "actor system not initialized")
+	}
+
+	ref := oor.NewServiceKey().Ref(r.server.actorSystem)
+	result := ref.Ask(ctx, &oor.LookupTransferRequest{
+		IdempotencyKey: idempotencyKey,
+	}).Await(ctx)
+	resp, err := result.Unpack()
+	if err != nil {
+		return oor.SessionID{}, false, false, status.Errorf(
+			codes.Internal, "OOR idempotency reconciliation "+
+				"failed: %v", err)
+	}
+
+	lookup, ok := resp.(*oor.LookupTransferResponse)
+	if !ok {
+		return oor.SessionID{}, false, false, status.Errorf(
+			codes.Internal, "unexpected OOR lookup response "+
+				"type: %T", resp)
+	}
+
+	return lookup.SessionID, lookup.Found, lookup.Pending, nil
+}
+
 // resolveExistingOORRecipientOutpoints maps a keyed replay's requested
 // recipients onto the original transfer snapshot. The snapshot is the only
 // trustworthy source here: a retry can select different inputs and create a
@@ -3888,7 +3982,9 @@ func (r *RPCServer) findOutgoingOORSessionByIdempotencyKey(ctx context.Context,
 // Recovery is best-effort at the generic SendOOR boundary. The stable session
 // id is still returned when local snapshot metadata cannot be read, while
 // higher-level callers that require an outpoint can fail closed and retry the
-// same key.
+// same key. A decoded snapshot produces one positional result per request
+// recipient; an unresolved or ambiguous recipient keeps an empty string at
+// that index.
 func (r *RPCServer) resolveExistingOORRecipientOutpoints(ctx context.Context,
 	sessionID oor.SessionID, requestRecipients []*waverpc.Output) []string {
 

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -2963,11 +2963,19 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 			// initiated.
 			//
 			// This fast path returns before resolving the current
-			// request, so the recipient outpoint is intentionally
-			// omitted. Full request replay below can recompute it.
+			// request or selecting wallet inputs. Recover recipient
+			// outpoints from the original durable snapshot instead
+			// of rebuilding the transfer. A caller recovering from
+			// a lost response needs both the stable session id and
+			// the original output location to resume safely.
 			return &waverpc.SendOORResponse{
 				Status:    "submitted",
 				SessionId: sessionID.String(),
+				RecipientOutpoints: r.
+					resolveExistingOORRecipientOutpoints(
+						ctx, sessionID,
+						requestRecipients,
+					),
 			}, nil
 		}
 	}
@@ -3238,9 +3246,21 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		r.unlockSelectedVTXOsBestEffort(ctx, locked)
 	}
 
-	recipientOutpoints := r.resolveOORRecipientOutpoints(
-		ctx, resp.SessionID, recipients, requestOORRecipients,
-	)
+	var recipientOutpoints []string
+	if resp.Existing && req.GetIdempotencyKey() != "" {
+		// The actor can discover a keyed winner after this RPC already
+		// selected inputs. Resolve against that winner's durable
+		// package; the fresh selection may have produced a different
+		// change output and therefore a different canonical output
+		// order.
+		recipientOutpoints = r.resolveExistingOORRecipientOutpoints(
+			ctx, resp.SessionID, requestRecipients,
+		)
+	} else {
+		recipientOutpoints = r.resolveOORRecipientOutpoints(
+			ctx, resp.SessionID, recipients, requestOORRecipients,
+		)
+	}
 	r.server.log.InfoS(ctx, "OOR transfer submitted",
 		slog.String("session_id", resp.SessionID.String()),
 		slog.Bool("existing_session", resp.Existing),
@@ -3857,6 +3877,92 @@ func (r *RPCServer) findOutgoingOORSessionByIdempotencyKey(ctx context.Context,
 	}
 
 	return oor.SessionID(record.SessionID), true, nil
+}
+
+// resolveExistingOORRecipientOutpoints maps a keyed replay's requested
+// recipients onto the original transfer snapshot. The snapshot is the only
+// trustworthy source here: a retry can select different inputs and create a
+// different change output even though the OOR actor correctly returns the
+// first idempotency-key winner.
+//
+// Recovery is best-effort at the generic SendOOR boundary. The stable session
+// id is still returned when local snapshot metadata cannot be read, while
+// higher-level callers that require an outpoint can fail closed and retry the
+// same key.
+func (r *RPCServer) resolveExistingOORRecipientOutpoints(ctx context.Context,
+	sessionID oor.SessionID, requestRecipients []*waverpc.Output) []string {
+
+	store := r.server.oorSessionStore
+	if store == nil || len(requestRecipients) == 0 {
+		return nil
+	}
+
+	record, err := store.GetSession(
+		ctx, chainhash.Hash(sessionID),
+	)
+	if err != nil {
+		r.server.log.WarnS(ctx, "Unable to load existing OOR "+
+			"snapshot", err,
+			slog.String("session_id", sessionID.String()))
+
+		return nil
+	}
+
+	recipients, err := oor.OutgoingSnapshotRecipients(record.SnapshotData)
+	if err != nil {
+		r.server.log.WarnS(ctx, "Unable to decode existing OOR "+
+			"recipients", err,
+			slog.String("session_id", sessionID.String()))
+
+		return nil
+	}
+
+	sessionHash := chainhash.Hash(sessionID)
+	outpoints := make([]string, len(requestRecipients))
+	for i, requestRecipient := range requestRecipients {
+		pkScript, err := r.resolveOutputPkScript(ctx, requestRecipient)
+		if err != nil {
+			r.server.log.WarnS(ctx, "Unable to resolve replayed OOR "+
+				"recipient", err,
+				slog.String("session_id", sessionID.String()),
+				slog.Int("recipient_index", i))
+
+			continue
+		}
+
+		var (
+			outputIndex uint32
+			matches     int
+		)
+		requestAmount := btcutil.Amount(requestRecipient.GetAmountSat())
+		for _, recipient := range recipients {
+			if recipient.Value != requestAmount ||
+				!bytes.Equal(recipient.PkScript, pkScript) {
+
+				continue
+			}
+
+			outputIndex = recipient.OutputIndex
+			matches++
+		}
+
+		if matches != 1 {
+			r.server.log.WarnS(ctx, "Unable to match replayed OOR "+
+				"recipient to durable snapshot", nil,
+				slog.String("session_id", sessionID.String()),
+				slog.Int("recipient_index", i),
+				slog.Int("matches", matches))
+
+			continue
+		}
+
+		outpoints[i] = wire.OutPoint{
+			Hash:  sessionHash,
+			Index: outputIndex,
+		}.String()
+	}
+
+	return outpoints
 }
 
 // buildOORChangeRecipient allocates and registers a wallet-owned receive

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -3540,8 +3540,18 @@ type SendOORRequest struct {
 	// allows the daemon to return the existing local OOR session instead
 	// of creating a duplicate transfer.
 	IdempotencyKey string `protobuf:"bytes,4,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// admission_deadline_unix_nanos is the latest wall-clock time at which
+	// the daemon may admit a new transfer for this request. An existing
+	// idempotency-key winner may still be returned after the deadline. Zero
+	// leaves admission unbounded.
+	AdmissionDeadlineUnixNanos int64 `protobuf:"varint,5,opt,name=admission_deadline_unix_nanos,json=admissionDeadlineUnixNanos,proto3" json:"admission_deadline_unix_nanos,omitempty"`
+	// existing_only restricts an idempotent request to read-only
+	// reconciliation. The daemon returns an existing winner or NotFound and
+	// never selects inputs or admits a new transfer. This requires a non-empty
+	// idempotency_key.
+	ExistingOnly  bool `protobuf:"varint,6,opt,name=existing_only,json=existingOnly,proto3" json:"existing_only,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SendOORRequest) Reset() {
@@ -3600,6 +3610,20 @@ func (x *SendOORRequest) GetIdempotencyKey() string {
 		return x.IdempotencyKey
 	}
 	return ""
+}
+
+func (x *SendOORRequest) GetAdmissionDeadlineUnixNanos() int64 {
+	if x != nil {
+		return x.AdmissionDeadlineUnixNanos
+	}
+	return 0
+}
+
+func (x *SendOORRequest) GetExistingOnly() bool {
+	if x != nil {
+		return x.ExistingOnly
+	}
+	return false
 }
 
 // CustomOORInput specifies a VTXO to spend with an explicit semantic policy
@@ -10344,14 +10368,16 @@ const file_daemon_proto_rawDesc = "" +
 	"\bround_id\x18\x02 \x01(\tR\aroundId\x12(\n" +
 	"\x10total_amount_sat\x18\x03 \x01(\x03R\x0etotalAmountSat\x12*\n" +
 	"\x11change_amount_sat\x18\x04 \x01(\x03R\x0fchangeAmountSat\x12%\n" +
-	"\x0eselected_count\x18\x05 \x01(\x05R\rselectedCount\"\xc1\x01\n" +
+	"\x0eselected_count\x18\x05 \x01(\x05R\rselectedCount\"\xa9\x02\n" +
 	"\x0eSendOORRequest\x12/\n" +
 	"\n" +
 	"recipients\x18\x01 \x03(\v2\x0f.waverpc.OutputR\n" +
 	"recipients\x12\x17\n" +
 	"\adry_run\x18\x02 \x01(\bR\x06dryRun\x12<\n" +
 	"\rcustom_inputs\x18\x03 \x03(\v2\x17.waverpc.CustomOORInputR\fcustomInputs\x12'\n" +
-	"\x0fidempotency_key\x18\x04 \x01(\tR\x0eidempotencyKey\"\x8b\x02\n" +
+	"\x0fidempotency_key\x18\x04 \x01(\tR\x0eidempotencyKey\x12A\n" +
+	"\x1dadmission_deadline_unix_nanos\x18\x05 \x01(\x03R\x1aadmissionDeadlineUnixNanos\x12#\n" +
+	"\rexisting_only\x18\x06 \x01(\bR\fexistingOnly\"\x8b\x02\n" +
 	"\x0eCustomOORInput\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x120\n" +
 	"\x14vtxo_policy_template\x18\x02 \x01(\fR\x12vtxoPolicyTemplate\x12\x1d\n" +

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -998,6 +998,18 @@ message SendOORRequest {
     // allows the daemon to return the existing local OOR session instead
     // of creating a duplicate transfer.
     string idempotency_key = 4;
+
+    // admission_deadline_unix_nanos is the latest wall-clock time at which
+    // the daemon may admit a new transfer for this request. An existing
+    // idempotency-key winner may still be returned after the deadline. Zero
+    // leaves admission unbounded.
+    int64 admission_deadline_unix_nanos = 5;
+
+    // existing_only restricts an idempotent request to read-only
+    // reconciliation. The daemon returns an existing winner or NotFound and
+    // never selects inputs or admits a new transfer. This requires a non-empty
+    // idempotency_key.
+    bool existing_only = 6;
 }
 
 // CustomOORInput specifies a VTXO to spend with an explicit semantic policy


### PR DESCRIPTION
## Problem

The pay-side swap FSM persists `FundingInitiated` before asking Waved to
fund the vHTLC. Waved deliberately continues an accepted OOR transfer after
the caller context ends, so an RPC deadline or process crash can lose the
response even though the transfer was accepted.

The SDK previously retried that request without an idempotency key after its
restart grace period. The retry could select different wallet inputs and fund
the same vHTLC a second time. Besides consuming extra liquidity, every extra
output must be recovered before the receiver can sweep it.

There is a second ambiguity at the funding cutoff. A response can be lost
before the SDK persists either the session ID or recipient outpoint. If the
SDK terminally expires that swap without first reconciling the accepted key,
the funded vHTLC is stranded and refund recovery is never armed. Conversely,
a normal keyed retry after expiry must not be allowed to admit a fresh,
already-expired transfer.

## Fix

This PR makes the funding intent and its recovery metadata durable across the
whole client/Waved boundary:

* derive one stable `in-swap-funding:<payment_hash>` idempotency key and use it
  for the initial submission, same-process retries, and restart recovery;
* recover the original recipient outpoint from Waved's durable OOR snapshot
  when a keyed replay finds an existing transfer;
* carry the swap's buffered funding cutoff into Waved as an admission
  deadline, enforced at the durable registry and child admission boundaries;
* add an `existing_only` reconciliation mode that never selects wallet inputs
  and never admits a new transfer;
* serialize a reconciliation miss through the registry actor and report an
  accepted-but-not-yet-committed admission as pending rather than absent;
* require both the session ID and exact recipient outpoint before persisting
  funding completion or arming refund recovery; and
* treat unavailable or incomplete reconciliation results as retryable.

Before the cutoff, the stable key may admit exactly one transfer. At or after
the cutoff, the SDK uses the same request in read-only mode:

* a committed winner returns its original outpoint and arms refund recovery;
* a pending admission remains retryable;
* an unavailable daemon remains retryable; and
* `NotFound` is authoritative because Waved will no longer admit that intent,
  so the swap can safely transition to `Expired`.

The resulting invariant is that one payment hash addresses at most one active
or completed OOR funding intent. A lost response can repeat the lookup across
the expiry boundary, but it cannot create another transfer or strand a known
winner without recovery.

## Commit structure

1. `waved: recover keyed OOR recipient outpoints`
   exposes durable recipient recovery and covers both the preflight and
   actor-race replay paths.
2. `sdk/swaps: key in-swap vHTLC funding`
   applies the stable key and fail-closed retry behavior to the pay FSM.
3. `waved: add deadline-bound OOR reconciliation`
   adds the admission deadline, read-only lookup, and pending handoff state.
4. `sdk/swaps: reconcile funding after expiry`
   routes the funding cutoff and hard-expiry timer through authoritative
   reconciliation.

## Testing

The accepted-response-lost regression now crosses the funding cutoff and a
restart ambiguity grace longer than the swap itself. It verifies that an
incomplete first reconciliation stays retryable, a later reconciliation
recovers the original outpoint, only one daemon-side intent was accepted, and
exactly one refund recovery job is armed.

The authoritative-miss regression resumes a `FundingInitiated` swap for which
no transfer was accepted. It verifies that the SDK makes one existing-only
lookup after expiry and persists `Expired` only after Waved returns
`NotFound`.

Additional validation:

* `go test ./oor ./sdk/ark ./sdk/swaps ./waved -count=1 -timeout=10m`
* race-enabled expiry reconciliation regressions in `sdk/swaps`
* race-enabled admission deadline and lookup tests in `oor`
* race-enabled existing-only and expired request tests in `waved`
* `make lint-changed-local base=origin/main`
* `make fmt-changed-check base=origin/main`
* `make commitmsg-lint range=origin/main..HEAD`
* `git diff --check origin/main...HEAD`
