### PR TITLE
tools: Add semantic actor framework analyzer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,12 @@ linters:
   default: all
   settings:
     custom:
+      framework:
+        type: "module"
+        description: >-
+          Semantic checks for durable actor messages, actor transaction
+          lifecycles, and protofsm transition tables.
+
       ll:
         type: "module"
         description: "Custom lll linter with log line exclusion."

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -3,8 +3,8 @@
 ## Purpose
 
 Build-tooling package: pins Go tool dependencies (`tools.go`) and hosts
-`linters/`, a custom golangci-lint plugin enforcing an 80-column line
-limit that is tab- and log-call-aware.
+`linters/`, custom golangci-lint plugins enforcing the project line-length
+policy and semantic actor/protofsm invariants.
 
 ## Key Types
 
@@ -17,11 +17,14 @@ limit that is tab- and log-call-aware.
 - `linters.New(settings)` — Plugin constructor golangci-lint calls via
   `.custom-gcl.yml`; fills default line length (80), tab width (8),
   and log regex when unset.
+- `linters.FrameworkPlugin` — Type-aware analyzer for durable actor TLV
+  schemas, protofsm transition tables, detached Ask lifetimes, and actor
+  transaction deadlocks.
 
 ## Relationships
 
 - **Depends on**: `golangci-lint`/`plugin-module-register`,
-  `golang.org/x/tools/go/analysis` (analyzer framework).
+  `golang.org/x/tools/go/analysis` (analyzer framework), and its SSA pass.
 - **Depended on by**: `make lint` / `make lint-changed` /
   `make install-custom-gcl` (builds `custom-gcl` per
   `.custom-gcl.yml`, which registers this module as a plugin).

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -3,8 +3,8 @@
 ## Purpose
 
 Build-tooling package: pins Go tool dependencies (`tools.go`) and hosts
-`linters/`, a custom golangci-lint plugin enforcing an 80-column line
-limit that is tab- and log-call-aware.
+`linters/`, custom golangci-lint plugins enforcing the project line-length
+policy and semantic actor/protofsm invariants.
 
 ## Key Types
 
@@ -17,11 +17,14 @@ limit that is tab- and log-call-aware.
 - `linters.New(settings)` — Plugin constructor golangci-lint calls via
   `.custom-gcl.yml`; fills default line length (80), tab width (8),
   and log regex when unset.
+- `linters.FrameworkPlugin` — Type-aware analyzer for durable actor TLV
+  schemas, protofsm transition tables, detached Ask lifetimes, and actor
+  transaction deadlocks.
 
 ## Relationships
 
 - **Depends on**: `golangci-lint`/`plugin-module-register`,
-  `golang.org/x/tools/go/analysis` (analyzer framework).
+  `golang.org/x/tools/go/analysis` (analyzer framework), and its SSA pass.
 - **Depended on by**: `make lint` / `make lint-changed` /
   `make install-custom-gcl` (builds `custom-gcl` per
   `.custom-gcl.yml`, which registers this module as a plugin).

--- a/tools/linters/actor_effects.go
+++ b/tools/linters/actor_effects.go
@@ -1,0 +1,221 @@
+package linters
+
+import (
+	"go/types"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+type effect uint32
+
+const (
+	effectAwaitActor effect = 1 << iota
+	effectStrippedActorSend
+	effectOpenIndependentWrite
+	effectStage
+	effectCommit
+)
+
+type effectFact struct {
+	Flags uint32
+}
+
+// AFact marks effectFact as an analysis fact.
+func (*effectFact) AFact() {}
+
+func (c *frameworkChecker) buildEffects() {
+	c.effects = make(map[*ssa.Function]effect)
+	c.functions = make(map[*types.Func]*ssa.Function)
+	edges := make(map[*ssa.Function][]*ssa.Function)
+
+	for _, function := range c.ssa.SrcFuncs {
+		if obj, ok := function.Object().(*types.Func); ok {
+			c.functions[obj.Origin()] = function
+		}
+
+		for _, block := range function.Blocks {
+			for _, instruction := range block.Instrs {
+				call, ok := instruction.(ssa.CallInstruction)
+				if !ok {
+					continue
+				}
+
+				common := call.Common()
+				obj := callObject(common)
+				c.effects[function] |= directCallEffect(obj)
+				if (objectIs(obj, actorPackagePath, "Ask") ||
+					objectIs(obj, actorPackagePath, "Tell")) &&
+					valueIsWithoutTx(
+						callArgument(common, obj, 0),
+						make(map[ssa.Value]bool),
+					) {
+
+					c.effects[function] |= effectStrippedActorSend
+				}
+
+				callee := common.StaticCallee()
+				if callee != nil && callee.Pkg == c.ssa.Pkg {
+					edges[function] = append(
+						edges[function], callee,
+					)
+					continue
+				}
+
+				fn, ok := obj.(*types.Func)
+				if !ok || fn.Pkg() == nil ||
+					fn.Pkg() == c.pass.Pkg {
+
+					continue
+				}
+
+				var fact effectFact
+				if c.pass.ImportObjectFact(fn.Origin(), &fact) {
+					c.effects[function] |= effect(
+						fact.Flags,
+					)
+				}
+			}
+		}
+	}
+
+	changed := true
+	for changed {
+		changed = false
+		for caller, callees := range edges {
+			before := c.effects[caller]
+			for _, callee := range callees {
+				c.effects[caller] |= c.effects[callee]
+			}
+			if c.effects[caller] != before {
+				changed = true
+			}
+		}
+	}
+
+	for function, flags := range c.effects {
+		obj, ok := function.Object().(*types.Func)
+		if !ok || obj.Pkg() != c.pass.Pkg || flags == 0 {
+			continue
+		}
+
+		c.pass.ExportObjectFact(obj.Origin(), &effectFact{
+			Flags: uint32(flags),
+		})
+	}
+}
+
+func directCallEffect(obj types.Object) effect {
+	switch {
+	case objectIs(obj, actorPackagePath, "Await"):
+		return effectAwaitActor
+
+	case objectIs(obj, actorPackagePath, "Stage"):
+		return effectStage
+
+	case objectIs(obj, actorPackagePath, "Commit"):
+		return effectCommit
+
+	case objectIs(obj, "database/sql", "Begin") ||
+		objectIs(obj, "database/sql", "BeginTx"):
+		return effectOpenIndependentWrite
+	}
+
+	return 0
+}
+
+func callObject(common *ssa.CallCommon) types.Object {
+	if common.IsInvoke() {
+		return common.Method.Origin()
+	}
+
+	callee := common.StaticCallee()
+	if callee == nil {
+		return nil
+	}
+
+	obj, ok := callee.Object().(*types.Func)
+	if !ok {
+		return nil
+	}
+
+	return obj.Origin()
+}
+
+func functionFromValue(value ssa.Value) *ssa.Function {
+	switch value := value.(type) {
+	case *ssa.Function:
+		return value
+
+	case *ssa.MakeClosure:
+		function, _ := value.Fn.(*ssa.Function)
+
+		return function
+
+	case *ssa.MakeInterface:
+		return functionFromValue(value.X)
+
+	case *ssa.ChangeInterface:
+		return functionFromValue(value.X)
+	}
+
+	return nil
+}
+
+func callArgument(common *ssa.CallCommon, obj types.Object,
+	parameter int) ssa.Value {
+
+	index := parameter
+	if !common.IsInvoke() {
+		fn, ok := obj.(*types.Func)
+		if ok {
+			signature, _ := fn.Type().(*types.Signature)
+			if signature != nil && signature.Recv() != nil {
+				index++
+			}
+		}
+	}
+
+	if index < 0 || index >= len(common.Args) {
+		return nil
+	}
+
+	return common.Args[index]
+}
+
+func valueIsWithoutTx(value ssa.Value, seen map[ssa.Value]bool) bool {
+	if value == nil || seen[value] {
+		return false
+	}
+	seen[value] = true
+
+	switch value := value.(type) {
+	case *ssa.Call:
+		return objectIs(
+			callObject(
+				value.Common(),
+			),
+			actorPackagePath, "WithoutTx",
+		)
+
+	case *ssa.ChangeInterface:
+		return valueIsWithoutTx(value.X, seen)
+
+	case *ssa.ChangeType:
+		return valueIsWithoutTx(value.X, seen)
+
+	case *ssa.Convert:
+		return valueIsWithoutTx(value.X, seen)
+
+	case *ssa.Extract:
+		return valueIsWithoutTx(value.Tuple, seen)
+
+	case *ssa.Phi:
+		for _, edge := range value.Edges {
+			if valueIsWithoutTx(edge, seen) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/tools/linters/actor_lifecycle.go
+++ b/tools/linters/actor_lifecycle.go
@@ -1,0 +1,262 @@
+package linters
+
+import (
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+type contextState uint8
+
+const (
+	contextUnbounded contextState = 1 << iota
+	contextBounded
+)
+
+func (c *frameworkChecker) checkActorLifecycle() {
+	c.inspect.Preorder(
+		[]ast.Node{(*ast.CallExpr)(nil)},
+		func(node ast.Node) {
+			call := node.(*ast.CallExpr)
+			if !productionFile(c.pass, call.Pos()) {
+				return
+			}
+
+			if objectIs(
+				c.calledObject(call), actorPackagePath,
+				"AllowConcurrentClassicBehavior",
+			) {
+
+				c.report(
+					call.Pos(),
+					"ALC002", "AllowConcurrentClassicBeh"+
+						"avior is a test-only "+
+						"escape hatch and cannot "+
+						"be used in production code",
+				)
+			}
+		},
+	)
+
+	for _, function := range c.ssa.SrcFuncs {
+		if !isTxBehaviorReceive(function) ||
+			!productionFile(c.pass, function.Pos()) {
+
+			continue
+		}
+
+		flags := c.effects[function]
+		if flags&effectStage != 0 && flags&effectCommit == 0 {
+			c.report(
+				function.Pos(),
+				"ALC003", "TxBehavior.Receive stages "+
+					"durable state but never commits "+
+					"message consumption",
+			)
+		}
+	}
+
+	c.inspect.Preorder(
+		[]ast.Node{(*ast.FuncDecl)(nil), (*ast.FuncLit)(nil)},
+		func(node ast.Node) {
+			if !productionFile(c.pass, node.Pos()) {
+				return
+			}
+
+			switch function := node.(type) {
+			case *ast.FuncDecl:
+				if function.Body != nil {
+					c.checkDetachedAskContexts(
+						function.Body,
+					)
+				}
+
+			case *ast.FuncLit:
+				c.checkDetachedAskContexts(function.Body)
+			}
+		},
+	)
+}
+
+func isTxBehaviorReceive(function *ssa.Function) bool {
+	obj, ok := function.Object().(*types.Func)
+	if !ok || obj.Name() != "Receive" {
+		return false
+	}
+
+	signature, ok := obj.Type().(*types.Signature)
+	if !ok {
+		return false
+	}
+
+	params := signature.Params()
+	for i := 0; i < params.Len(); i++ {
+		if typeIs(params.At(i).Type(), actorPackagePath, "Exec") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *frameworkChecker) checkDetachedAskContexts(body *ast.BlockStmt) {
+	states := make(map[types.Object]contextState)
+	assignments := collectContextAssignments(body)
+
+	for range 8 {
+		changed := false
+		for _, assignment := range assignments {
+			if assignment.apply(c, states) {
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
+	walkFunctionBody(body, func(node ast.Node) {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !objectIs(
+			c.calledObject(call), actorPackagePath, "OnComplete",
+		) || len(call.Args) == 0 {
+			return
+		}
+
+		state := c.contextState(call.Args[0], states)
+		if state&contextUnbounded == 0 {
+			return
+		}
+
+		c.report(
+			call.Args[0].Pos(),
+			"ALC001", "DetachedAsk.CallerCtx must be wrapped "+
+				"with context.WithTimeout or "+
+				"context.WithDeadline before OnComplete",
+		)
+	})
+}
+
+type contextAssignment struct {
+	lhs ast.Expr
+	rhs ast.Expr
+}
+
+func (a contextAssignment) apply(c *frameworkChecker,
+	states map[types.Object]contextState) bool {
+
+	obj := rootObject(c.pass.TypesInfo, a.lhs)
+	if obj == nil {
+		return false
+	}
+
+	state := c.contextState(a.rhs, states)
+	if state == 0 || states[obj]|state == states[obj] {
+		return false
+	}
+
+	states[obj] |= state
+
+	return true
+}
+
+func collectContextAssignments(body *ast.BlockStmt) []contextAssignment {
+	var assignments []contextAssignment
+	walkFunctionBody(body, func(node ast.Node) {
+		switch node := node.(type) {
+		case *ast.AssignStmt:
+			if len(node.Rhs) == 1 && len(node.Lhs) > 1 {
+				assignments = append(
+					assignments, contextAssignment{
+						lhs: node.Lhs[0],
+						rhs: node.Rhs[0],
+					},
+				)
+
+				return
+			}
+
+			for i := 0; i < len(node.Lhs) && i < len(node.Rhs); i++ {
+				assignments = append(
+					assignments, contextAssignment{
+						lhs: node.Lhs[i],
+						rhs: node.Rhs[i],
+					},
+				)
+			}
+
+		case *ast.ValueSpec:
+			for i := 0; i < len(node.Names) && i < len(node.Values); i++ {
+				assignments = append(
+					assignments, contextAssignment{
+						lhs: node.Names[i],
+						rhs: node.Values[i],
+					},
+				)
+			}
+		}
+	})
+
+	return assignments
+}
+
+func (c *frameworkChecker) contextState(expr ast.Expr,
+	states map[types.Object]contextState) contextState {
+
+	switch expr := expr.(type) {
+	case *ast.Ident:
+		return states[rootObject(c.pass.TypesInfo, expr)]
+
+	case *ast.ParenExpr:
+		return c.contextState(expr.X, states)
+
+	case *ast.SelectorExpr:
+		selection := c.pass.TypesInfo.Selections[expr]
+		if selection != nil && objectIs(
+			selection.Obj(), actorPackagePath, "CallerCtx",
+		) {
+			return contextUnbounded
+		}
+
+		return states[rootObject(c.pass.TypesInfo, expr)]
+
+	case *ast.CallExpr:
+		if len(expr.Args) == 0 {
+			return 0
+		}
+
+		obj := c.calledObject(expr)
+		parent := c.contextState(expr.Args[0], states)
+		if objectIs(obj, "context", "WithTimeout") ||
+			objectIs(obj, "context", "WithDeadline") {
+
+			if parent != 0 {
+				return contextBounded
+			}
+		}
+
+		if obj != nil && obj.Pkg() != nil &&
+			(obj.Pkg().Path() == "context" ||
+				obj.Pkg().Path() == actorPackagePath) {
+			return parent
+		}
+	}
+
+	return 0
+}
+
+func walkFunctionBody(body *ast.BlockStmt, visit func(ast.Node)) {
+	ast.Inspect(body, func(node ast.Node) bool {
+		if node == nil {
+			return true
+		}
+		if _, nested := node.(*ast.FuncLit); nested {
+			return false
+		}
+
+		visit(node)
+
+		return true
+	})
+}

--- a/tools/linters/actor_tlv.go
+++ b/tools/linters/actor_tlv.go
@@ -1,0 +1,276 @@
+package linters
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/types"
+)
+
+func (c *frameworkChecker) checkActorTLV() {
+	tlvMessage := c.lookupType(actorPackagePath, "TLVMessage")
+	if tlvMessage == nil {
+		return
+	}
+
+	tlvInterface, ok :=
+		types.Unalias(tlvMessage).Underlying().(*types.Interface)
+	if !ok {
+		return
+	}
+	tlvInterface.Complete()
+
+	typeIDs := make(map[*types.TypeName]uint64)
+	constructors := make(map[*types.Func]types.Type)
+
+	for _, file := range c.pass.Files {
+		for _, declaration := range file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Body == nil {
+				continue
+			}
+
+			if function.Recv == nil {
+				if result := returnedConcreteType(
+					c.pass.TypesInfo, function.Body,
+				); result != nil {
+
+					obj, _ :=
+						c.pass.TypesInfo.Defs[function.Name].(*types.Func)
+					if obj != nil {
+						constructors[obj.Origin()] = result
+					}
+				}
+				continue
+			}
+
+			receiver := c.pass.TypesInfo.TypeOf(
+				function.Recv.List[0].Type,
+			)
+			if !implementsInterface(receiver, tlvInterface) {
+				continue
+			}
+
+			if function.Name.Name == "TLVType" {
+				if id, ok := returnedConstantUint(
+					c.pass.TypesInfo, function.Body,
+				); ok {
+
+					typeIDs[namedTypeObject(receiver)] = id
+				}
+			}
+
+			if function.Name.Name == "Encode" ||
+				function.Name.Name == "Decode" {
+
+				c.checkTLVMethodEncoding(function)
+			}
+		}
+	}
+
+	for _, file := range c.pass.Files {
+		for _, declaration := range file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Body == nil ||
+				!productionFile(c.pass, function.Pos()) {
+
+				continue
+			}
+
+			c.checkCodecRegistrations(
+				function.Body, typeIDs, constructors,
+			)
+		}
+	}
+}
+
+func implementsInterface(t types.Type, iface *types.Interface) bool {
+	if t == nil {
+		return false
+	}
+
+	if types.Implements(t, iface) {
+		return true
+	}
+
+	if _, pointer := t.(*types.Pointer); !pointer {
+		return types.Implements(types.NewPointer(t), iface)
+	}
+
+	return false
+}
+
+func returnedConstantUint(info *types.Info,
+	body *ast.BlockStmt) (uint64, bool) {
+
+	var (
+		result uint64
+		found  bool
+		valid  = true
+	)
+	walkFunctionBody(body, func(node ast.Node) {
+		statement, ok := node.(*ast.ReturnStmt)
+		if !ok || len(statement.Results) != 1 {
+			return
+		}
+
+		value := info.Types[statement.Results[0]].Value
+		if value == nil {
+			valid = false
+
+			return
+		}
+		id, ok := constant.Uint64Val(value)
+		if !ok || found && id != result {
+			valid = false
+
+			return
+		}
+
+		result = id
+		found = true
+	})
+
+	return result, found && valid
+}
+
+func returnedConcreteType(info *types.Info, body *ast.BlockStmt) types.Type {
+	var result types.Type
+	walkFunctionBody(body, func(node ast.Node) {
+		statement, ok := node.(*ast.ReturnStmt)
+		if !ok || len(statement.Results) != 1 {
+			return
+		}
+
+		candidate := info.TypeOf(statement.Results[0])
+		if namedTypeObject(candidate) == nil {
+			return
+		}
+
+		if result == nil {
+			result = candidate
+
+			return
+		}
+
+		if namedTypeObject(result) != namedTypeObject(candidate) {
+			result = nil
+		}
+	})
+
+	return result
+}
+
+func (c *frameworkChecker) checkTLVMethodEncoding(function *ast.FuncDecl) {
+	if !productionFile(c.pass, function.Pos()) {
+		return
+	}
+
+	walkFunctionBody(function.Body, func(node ast.Node) {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || len(call.Args) < 3 {
+			return
+		}
+
+		obj := c.calledObject(call)
+		if !objectIs(obj, "encoding/binary", "Read") &&
+			!objectIs(obj, "encoding/binary", "Write") {
+			return
+		}
+
+		c.report(
+			call.Pos(),
+			"ATL001", "durable actor message uses fixed-layout "+
+				"binary encoding; encode top-level fields "+
+				"with tlv.NewStream",
+		)
+	})
+}
+
+func (c *frameworkChecker) checkCodecRegistrations(body *ast.BlockStmt,
+	typeIDs map[*types.TypeName]uint64,
+	constructors map[*types.Func]types.Type) {
+
+	seen := make(map[types.Object]map[uint64]ast.Expr)
+	walkFunctionBody(body, func(node ast.Node) {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || len(call.Args) < 2 {
+			return
+		}
+
+		obj := c.calledObject(call)
+		if !objectIs(obj, actorPackagePath, "Register") &&
+			!objectIs(obj, actorPackagePath, "MustRegister") {
+			return
+		}
+
+		id, ok := constantUint(c.pass.TypesInfo, call.Args[0])
+		if !ok {
+			return
+		}
+
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if ok {
+			receiver := rootObject(c.pass.TypesInfo, selector.X)
+			if receiver != nil {
+				if seen[receiver] == nil {
+					seen[receiver] = make(
+						map[uint64]ast.Expr,
+					)
+				}
+				if _, duplicate := seen[receiver][id]; duplicate {
+					c.report(
+						call.Args[0].Pos(),
+						"ATL003", "message codec "+
+							"registers the "+
+							"same TLV type "+
+							"more than once",
+					)
+				} else {
+					seen[receiver][id] = call.Args[0]
+				}
+			}
+		}
+
+		messageType := c.constructorType(call.Args[1], constructors)
+		messageObj := namedTypeObject(messageType)
+		expected, known := typeIDs[messageObj]
+		if !known || expected == id {
+			return
+		}
+
+		c.report(
+			call.Args[0].Pos(),
+			"ATL002", "message codec registration ID does not "+
+				"match the constructor message's TLVType",
+		)
+	})
+}
+
+func constantUint(info *types.Info, expr ast.Expr) (uint64, bool) {
+	value := info.Types[expr].Value
+	if value == nil {
+		return 0, false
+	}
+
+	return constant.Uint64Val(value)
+}
+
+func (c *frameworkChecker) constructorType(expr ast.Expr,
+	constructors map[*types.Func]types.Type) types.Type {
+
+	switch expr := expr.(type) {
+	case *ast.FuncLit:
+		return returnedConcreteType(c.pass.TypesInfo, expr.Body)
+
+	case *ast.Ident, *ast.SelectorExpr, *ast.IndexExpr,
+		*ast.IndexListExpr:
+
+		obj := rootObject(c.pass.TypesInfo, expr)
+		fn, ok := obj.(*types.Func)
+		if ok {
+			return constructors[fn.Origin()]
+		}
+	}
+
+	return nil
+}

--- a/tools/linters/actor_transactions.go
+++ b/tools/linters/actor_transactions.go
@@ -1,0 +1,305 @@
+package linters
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/types"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+func (c *frameworkChecker) checkActorTransactions() {
+	for _, function := range c.ssa.SrcFuncs {
+		if !productionFile(c.pass, function.Pos()) {
+			continue
+		}
+
+		for _, block := range function.Blocks {
+			for _, instruction := range block.Instrs {
+				call, ok := instruction.(ssa.CallInstruction)
+				if !ok {
+					continue
+				}
+
+				common := call.Common()
+				obj := callObject(common)
+				if !isWriterTransaction(common, obj) {
+					continue
+				}
+
+				callback := functionFromValue(
+					common.Args[len(common.Args)-1],
+				)
+				if callback == nil {
+					continue
+				}
+
+				flags := c.effects[callback]
+				if flags&effectAwaitActor != 0 {
+					c.report(
+						common.Pos(),
+						"ATX001", "writer "+
+							"transaction "+
+							"callback waits on "+
+							"an actor future; "+
+							"perform the "+
+							"Ask/Await between "+
+							"Stage or Read and "+
+							"Commit",
+					)
+				}
+				if flags&effectStrippedActorSend != 0 {
+					c.report(
+						common.Pos(),
+						"ATX003", "writer "+
+							"transaction "+
+							"callback sends "+
+							"with "+
+							"actor.WithoutTx; "+
+							"the independent "+
+							"durable enqueue "+
+							"can wait on the "+
+							"held writer",
+					)
+				}
+				if flags&effectOpenIndependentWrite != 0 {
+					c.report(
+						common.Pos(),
+						"ATX004", "writer "+
+							"transaction "+
+							"callback opens an "+
+							"independent "+
+							"sql.DB transaction",
+					)
+				}
+				if callbackEscapesTxContext(callback) {
+					c.report(
+						common.Pos(),
+						"ATX005", "transaction "+
+							"context escapes "+
+							"its callback lifetime",
+					)
+				}
+			}
+		}
+	}
+
+	c.checkClassicDurableBehaviors()
+}
+
+func isWriterTransaction(common *ssa.CallCommon, obj types.Object) bool {
+	if objectIs(obj, actorPackagePath, "Commit") ||
+		objectIs(obj, actorPackagePath, "Stage") {
+		return len(common.Args) > 0
+	}
+
+	if !objectIs(obj, actorPackagePath, "ExecTx") ||
+		len(common.Args) == 0 {
+		return false
+	}
+
+	readOnly := callArgument(common, obj, 1)
+	constantValue, ok := readOnly.(*ssa.Const)
+	if !ok || constantValue.Value == nil ||
+		constantValue.Value.Kind() != constant.Bool {
+		return false
+	}
+
+	return !constant.BoolVal(constantValue.Value)
+}
+
+func callbackEscapesTxContext(function *ssa.Function) bool {
+	if len(function.Params) == 0 {
+		return false
+	}
+
+	txCtx := function.Params[0]
+	for _, block := range function.Blocks {
+		for _, instruction := range block.Instrs {
+			switch instruction := instruction.(type) {
+			case *ssa.Go:
+				if callUsesValue(instruction.Common(), txCtx) {
+					return true
+				}
+
+			case *ssa.Return:
+				for _, result := range instruction.Results {
+					if valueDependsOnContext(
+						result, txCtx,
+						make(map[ssa.Value]bool),
+					) {
+						return true
+					}
+				}
+
+			case ssa.CallInstruction:
+				common := instruction.Common()
+				obj := callObject(common)
+				if !objectIs(
+					obj, actorPackagePath, "OnComplete",
+				) &&
+					!objectIs(
+						obj, actorPackagePath,
+						"ThenApply",
+					) {
+
+					continue
+				}
+
+				ctx := callArgument(common, obj, 0)
+				if valueDependsOnContext(
+					ctx, txCtx, make(map[ssa.Value]bool),
+				) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func callUsesValue(common *ssa.CallCommon, source ssa.Value) bool {
+	for _, arg := range common.Args {
+		if valueDependsOnContext(
+			arg, source, make(map[ssa.Value]bool),
+		) {
+			return true
+		}
+	}
+
+	if closure, ok := common.Value.(*ssa.MakeClosure); ok {
+		for _, binding := range closure.Bindings {
+			if valueDependsOnContext(
+				binding, source, make(map[ssa.Value]bool),
+			) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func valueDependsOnContext(value, source ssa.Value,
+	seen map[ssa.Value]bool) bool {
+
+	if value == nil || seen[value] {
+		return false
+	}
+	if value == source {
+		return true
+	}
+	seen[value] = true
+
+	switch value := value.(type) {
+	case *ssa.Call:
+		obj := callObject(value.Common())
+		if objectIs(obj, actorPackagePath, "WithoutTx") {
+			return false
+		}
+		if obj == nil || obj.Pkg() == nil ||
+			obj.Pkg().Path() != "context" {
+			return false
+		}
+
+		ctx := callArgument(value.Common(), obj, 0)
+
+		return valueDependsOnContext(ctx, source, seen)
+
+	case *ssa.ChangeInterface:
+		return valueDependsOnContext(value.X, source, seen)
+
+	case *ssa.ChangeType:
+		return valueDependsOnContext(value.X, source, seen)
+
+	case *ssa.Convert:
+		return valueDependsOnContext(value.X, source, seen)
+
+	case *ssa.Extract:
+		return valueDependsOnContext(value.Tuple, source, seen)
+
+	case *ssa.MakeInterface:
+		return valueDependsOnContext(value.X, source, seen)
+
+	case *ssa.Phi:
+		for _, edge := range value.Edges {
+			if valueDependsOnContext(edge, source, seen) {
+				return true
+			}
+		}
+
+	case *ssa.MakeClosure:
+		for _, binding := range value.Bindings {
+			if valueDependsOnContext(binding, source, seen) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (c *frameworkChecker) checkClassicDurableBehaviors() {
+	c.inspect.Preorder(
+		[]ast.Node{(*ast.CallExpr)(nil)},
+		func(node ast.Node) {
+			call := node.(*ast.CallExpr)
+			if !productionFile(c.pass, call.Pos()) {
+				return
+			}
+
+			obj := c.calledObject(call)
+			var behavior ast.Expr
+			switch {
+			case objectIs(
+				obj, actorPackagePath,
+				"DefaultDurableActorConfig",
+			) && len(call.Args) > 1:
+
+				behavior = call.Args[1]
+
+			case objectIs(
+				obj, actorPackagePath, "NewClassicBehavior",
+			) && len(call.Args) > 0:
+
+				behavior = call.Args[0]
+
+			default:
+				return
+			}
+
+			method, _, _ := types.LookupFieldOrMethod(
+				c.pass.TypesInfo.TypeOf(behavior), true,
+				c.pass.Pkg, "Receive",
+			)
+			fn, ok := method.(*types.Func)
+			if !ok || c.effectForObject(fn)&effectAwaitActor == 0 {
+				return
+			}
+
+			c.report(
+				behavior.Pos(),
+				"ATX002", "classic durable behavior may "+
+					"await an actor while its implicit "+
+					"writer transaction is held; "+
+					"migrate it to the "+
+					"Read/Stage/Commit behavior",
+			)
+		},
+	)
+}
+
+func (c *frameworkChecker) effectForObject(function *types.Func) effect {
+	function = function.Origin()
+	if local := c.functions[function]; local != nil {
+		return c.effects[local]
+	}
+
+	var fact effectFact
+	if c.pass.ImportObjectFact(function, &fact) {
+		return effect(fact.Flags)
+	}
+
+	return 0
+}

--- a/tools/linters/framework.go
+++ b/tools/linters/framework.go
@@ -1,0 +1,195 @@
+package linters
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"github.com/golangci/plugin-module-register/register"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/buildssa"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/types/typeutil"
+)
+
+const (
+	frameworkLinterName = "framework"
+
+	actorPackagePath    = "github.com/lightninglabs/wavelength/baselib/actor"
+	protoFSMPackagePath = "github.com/lightninglabs/wavelength/baselib/" +
+		"protofsm"
+)
+
+// FrameworkPlugin provides semantic checks for the actor and protofsm
+// frameworks.
+type FrameworkPlugin struct{}
+
+// NewFramework creates the framework plugin.
+func NewFramework(any) (register.LinterPlugin, error) {
+	return &FrameworkPlugin{}, nil
+}
+
+// BuildAnalyzers creates the framework analyzer.
+func (f *FrameworkPlugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
+	return []*analysis.Analyzer{frameworkAnalyzer}, nil
+}
+
+// GetLoadMode requests the type information needed by the framework checks.
+func (f *FrameworkPlugin) GetLoadMode() string {
+	return register.LoadModeTypesInfo
+}
+
+var frameworkAnalyzer = &analysis.Analyzer{
+	Name: frameworkLinterName,
+	Doc:  "checks actor and protofsm semantic invariants",
+	Requires: []*analysis.Analyzer{
+		inspect.Analyzer,
+		buildssa.Analyzer,
+	},
+	FactTypes: []analysis.Fact{
+		new(effectFact),
+	},
+	Run: runFramework,
+}
+
+type frameworkChecker struct {
+	pass      *analysis.Pass
+	inspect   *inspector.Inspector
+	ssa       *buildssa.SSA
+	effects   map[*ssa.Function]effect
+	functions map[*types.Func]*ssa.Function
+}
+
+func runFramework(pass *analysis.Pass) (any, error) {
+	checker := &frameworkChecker{
+		pass:    pass,
+		inspect: pass.ResultOf[inspect.Analyzer].(*inspector.Inspector),
+		ssa:     pass.ResultOf[buildssa.Analyzer].(*buildssa.SSA),
+	}
+
+	checker.buildEffects()
+	checker.checkActorTransactions()
+	checker.checkActorLifecycle()
+	checker.checkActorTLV()
+	checker.checkProtoFSMTables()
+
+	return nil, nil
+}
+
+func (c *frameworkChecker) report(pos token.Pos, code, message string) {
+	c.pass.Reportf(pos, "%s: %s", code, message)
+}
+
+func (c *frameworkChecker) calledObject(call *ast.CallExpr) types.Object {
+	return typeutil.Callee(c.pass.TypesInfo, call)
+}
+
+func objectIs(obj types.Object, packagePath, name string) bool {
+	return obj != nil && obj.Pkg() != nil &&
+		obj.Pkg().Path() == packagePath && obj.Name() == name
+}
+
+func namedTypeObject(t types.Type) *types.TypeName {
+	if t == nil {
+		return nil
+	}
+
+	t = types.Unalias(t)
+	if pointer, ok := t.(*types.Pointer); ok {
+		t = types.Unalias(pointer.Elem())
+	}
+
+	named, ok := t.(*types.Named)
+	if !ok {
+		return nil
+	}
+
+	return named.Origin().Obj()
+}
+
+func typeIs(t types.Type, packagePath, name string) bool {
+	obj := namedTypeObject(t)
+	if obj == nil {
+		return false
+	}
+
+	return objectIs(obj, packagePath, name)
+}
+
+func (c *frameworkChecker) lookupType(packagePath, name string) types.Type {
+	var pkg *types.Package
+	if c.pass.Pkg.Path() == packagePath {
+		pkg = c.pass.Pkg
+	} else {
+		for _, imported := range c.pass.Pkg.Imports() {
+			if imported.Path() == packagePath {
+				pkg = imported
+				break
+			}
+		}
+	}
+	if pkg == nil {
+		return nil
+	}
+
+	obj := pkg.Scope().Lookup(name)
+	if obj == nil {
+		return nil
+	}
+
+	return obj.Type()
+}
+
+func productionFile(pass *analysis.Pass, pos token.Pos) bool {
+	name := pass.Fset.PositionFor(pos, false).Filename
+
+	return !strings.HasSuffix(name, "_test.go")
+}
+
+func fieldValue(lit *ast.CompositeLit, name string) ast.Expr {
+	for _, elt := range lit.Elts {
+		field, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+
+		ident, ok := field.Key.(*ast.Ident)
+		if ok && ident.Name == name {
+			return field.Value
+		}
+	}
+
+	return nil
+}
+
+func rootObject(info *types.Info, expr ast.Expr) types.Object {
+	switch expr := expr.(type) {
+	case *ast.Ident:
+		if obj := info.Uses[expr]; obj != nil {
+			return obj
+		}
+
+		return info.Defs[expr]
+
+	case *ast.ParenExpr:
+		return rootObject(info, expr.X)
+
+	case *ast.SelectorExpr:
+		return rootObject(info, expr.X)
+
+	case *ast.IndexExpr:
+		return rootObject(info, expr.X)
+
+	case *ast.IndexListExpr:
+		return rootObject(info, expr.X)
+	}
+
+	return nil
+}
+
+func init() {
+	register.Plugin(frameworkLinterName, NewFramework)
+}

--- a/tools/linters/framework_test.go
+++ b/tools/linters/framework_test.go
@@ -1,0 +1,16 @@
+package linters
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+// TestFrameworkAnalyzer checks the framework-specific semantic invariants.
+func TestFrameworkAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	analysistest.Run(
+		t, analysistest.TestData(), frameworkAnalyzer, "frameworktest",
+	)
+}

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -4,5 +4,10 @@ go 1.26.0
 
 require (
 	github.com/golangci/plugin-module-register v0.1.2
-	golang.org/x/tools v0.32.0
+	golang.org/x/tools v0.42.0
+)
+
+require (
+	golang.org/x/mod v0.33.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
 )

--- a/tools/linters/go.sum
+++ b/tools/linters/go.sum
@@ -1,4 +1,10 @@
 github.com/golangci/plugin-module-register v0.1.2 h1:e5WM6PO6NIAEcij3B053CohVp3HIYbzSuP53UAYgOpg=
 github.com/golangci/plugin-module-register v0.1.2/go.mod h1:1+QGTsKBvAIvPvoY/os+G5eoqxWn70HYDm2uvUyGuVw=
-golang.org/x/tools v0.32.0 h1:Q7N1vhpkQv7ybVzLFtTjvQya2ewbwNDZzUgfXGqtMWU=
-golang.org/x/tools v0.32.0/go.mod h1:ZxrU41P/wAbZD8EDa6dDCa6XfpkhJ7HFMjHJXfBDu8s=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
+golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
+golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=

--- a/tools/linters/protofsm.go
+++ b/tools/linters/protofsm.go
@@ -1,0 +1,258 @@
+package linters
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/types"
+)
+
+type parsedTransition struct {
+	event       string
+	toState     string
+	eventPos    ast.Expr
+	toStatePos  ast.Expr
+	description ast.Expr
+	terminal    bool
+}
+
+type parsedState struct {
+	from        string
+	fromPos     ast.Expr
+	transitions []parsedTransition
+}
+
+func (c *frameworkChecker) checkProtoFSMTables() {
+	c.inspect.Preorder([]ast.Node{(*ast.CompositeLit)(nil)},
+		func(node ast.Node) {
+			literal := node.(*ast.CompositeLit)
+			if !productionFile(c.pass, literal.Pos()) ||
+				!typeIs(
+					c.pass.TypesInfo.TypeOf(literal),
+					protoFSMPackagePath, "TransitionTable",
+				) {
+				return
+			}
+
+			c.checkProtoFSMTable(literal)
+		},
+	)
+}
+
+func (c *frameworkChecker) checkProtoFSMTable(table *ast.CompositeLit) {
+	machineName := fieldValue(table, "MachineName")
+	if value, ok := constantString(c.pass.TypesInfo, machineName); !ok ||
+		value == "" {
+
+		pos := table.Pos()
+		if machineName != nil {
+			pos = machineName.Pos()
+		}
+		c.report(
+			pos, "PFS004", "protofsm transition table must "+
+				"have a non-empty MachineName",
+		)
+	}
+
+	states := c.parseStates(fieldValue(table, "States"))
+	stateRows := make(map[string]parsedState)
+
+	for _, state := range states {
+		if previous, duplicate := stateRows[state.from]; duplicate {
+			_ = previous
+			c.report(
+				state.fromPos.Pos(),
+				"PFS001", "protofsm transition table "+
+					"contains duplicate rows for the "+
+					"same state type",
+			)
+		} else if state.from != "" {
+			stateRows[state.from] = state
+		}
+
+		transitions := make(map[string]bool)
+		for _, transition := range state.transitions {
+			key := transition.event + "->" + transition.toState
+			if transition.event != "" && transition.toState != "" &&
+				transitions[key] {
+
+				c.report(
+					transition.eventPos.Pos(),
+					"PFS002", "protofsm state contains "+
+						"duplicate event-to-state "+
+						"transition entries",
+				)
+			}
+			transitions[key] = true
+
+			description, ok := constantString(
+				c.pass.TypesInfo, transition.description,
+			)
+			if !ok || description == "" {
+				pos := transition.eventPos.Pos()
+				if transition.description != nil {
+					pos = transition.description.Pos()
+				}
+				c.report(
+					pos, "PFS003", "protofsm "+
+						"transition must have a "+
+						"non-empty Description",
+				)
+			}
+
+		}
+	}
+
+	terminalStates := make(map[string]bool)
+	for stateType, row := range stateRows {
+		if len(row.transitions) == 0 {
+			continue
+		}
+
+		terminal := true
+		for _, transition := range row.transitions {
+			if transition.toState != stateType ||
+				!transition.terminal {
+
+				terminal = false
+				break
+			}
+		}
+		terminalStates[stateType] = terminal
+	}
+
+	for _, row := range states {
+		for _, transition := range row.transitions {
+			if !terminalStates[transition.toState] ||
+				transition.terminal {
+
+				continue
+			}
+
+			c.report(
+				transition.toStatePos.Pos(),
+				"PFS005", "transition to a terminal "+
+					"self-loop state must set IsTerminal",
+			)
+		}
+	}
+}
+
+func (c *frameworkChecker) parseStates(expr ast.Expr) []parsedState {
+	literal, ok := unparen(expr).(*ast.CompositeLit)
+	if !ok {
+		return nil
+	}
+
+	states := make([]parsedState, 0, len(literal.Elts))
+	for _, element := range literal.Elts {
+		row, ok := unparen(element).(*ast.CompositeLit)
+		if !ok {
+			continue
+		}
+
+		from := fieldValue(row, "FromState")
+		if from == nil {
+			continue
+		}
+
+		state := parsedState{
+			from:    expressionTypeKey(c.pass.TypesInfo, from),
+			fromPos: from,
+		}
+
+		transitions, ok := unparen(
+			fieldValue(row, "Transitions"),
+		).(*ast.CompositeLit)
+		if ok {
+			for _, element := range transitions.Elts {
+				entry, ok :=
+					unparen(element).(*ast.CompositeLit)
+				if !ok {
+					continue
+				}
+
+				event := fieldValue(entry, "Event")
+				toState := fieldValue(entry, "ToState")
+				if event == nil || toState == nil {
+					continue
+				}
+
+				terminal, _ := constantBool(
+					c.pass.TypesInfo,
+					fieldValue(entry, "IsTerminal"),
+				)
+				state.transitions = append(
+					state.transitions, parsedTransition{
+						event: expressionTypeKey(
+							c.pass.TypesInfo, event,
+						),
+						toState: expressionTypeKey(
+							c.pass.TypesInfo,
+							toState,
+						),
+						eventPos:   event,
+						toStatePos: toState,
+						description: fieldValue(
+							entry, "Description",
+						),
+						terminal: terminal,
+					},
+				)
+			}
+		}
+
+		states = append(states, state)
+	}
+
+	return states
+}
+
+func unparen(expr ast.Expr) ast.Expr {
+	for {
+		paren, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			return expr
+		}
+		expr = paren.X
+	}
+}
+
+func expressionTypeKey(info *types.Info, expr ast.Expr) string {
+	t := info.TypeOf(expr)
+	if t == nil {
+		return ""
+	}
+
+	return types.TypeString(
+		types.Unalias(t),
+		func(pkg *types.Package) string {
+			return pkg.Path()
+		},
+	)
+}
+
+func constantString(info *types.Info, expr ast.Expr) (string, bool) {
+	if expr == nil {
+		return "", false
+	}
+
+	value := info.Types[expr].Value
+	if value == nil || value.Kind() != constant.String {
+		return "", false
+	}
+
+	return constant.StringVal(value), true
+}
+
+func constantBool(info *types.Info, expr ast.Expr) (bool, bool) {
+	if expr == nil {
+		return false, false
+	}
+
+	value := info.Types[expr].Value
+	if value == nil || value.Kind() != constant.Bool {
+		return false, false
+	}
+
+	return constant.BoolVal(value), true
+}

--- a/tools/linters/testdata/src/frameworktest/framework.go
+++ b/tools/linters/testdata/src/frameworktest/framework.go
@@ -1,0 +1,204 @@
+package frameworktest
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"io"
+	"time"
+
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/baselib/protofsm"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+const badMessageType tlv.Type = 7
+
+type badMessage struct{}
+
+func (*badMessage) TLVType() tlv.Type {
+	return badMessageType
+}
+
+func (*badMessage) Encode(w io.Writer) error {
+	payload := struct{ Value uint64 }{}
+
+	return binary.Write( // want "ATL001: durable actor message uses fixed-layout binary encoding"
+		w, binary.BigEndian, payload,
+	)
+}
+
+func (*badMessage) Decode(r io.Reader) error {
+	payload := struct{ Value uint64 }{}
+
+	return binary.Read( // want "ATL001: durable actor message uses fixed-layout binary encoding"
+		r, binary.BigEndian, &payload,
+	)
+}
+
+func badCodec() *actor.MessageCodec {
+	codec := actor.NewMessageCodec()
+	codec.MustRegister(
+		8, // want "ATL002: message codec registration ID does not match"
+		func() actor.TLVMessage { return &badMessage{} },
+	)
+	codec.MustRegister(
+		8, // want "ATL003: message codec registers the same TLV type" "ATL002: message codec registration ID does not match"
+		func() actor.TLVMessage { return &badMessage{} },
+	)
+
+	return codec
+}
+
+type stateA struct{}
+type stateB struct{}
+type stateTerminal struct{}
+type eventA struct{}
+type eventB struct{}
+
+var badTable = protofsm.TransitionTable[any, any, any]{
+	MachineName: "", // want "PFS004: protofsm transition table must have a non-empty MachineName"
+	States: []protofsm.StateTransitions[any, any, any]{
+		{
+			FromState: &stateA{},
+			Transitions: []protofsm.TransitionEntry[any, any, any]{
+				{
+					Event:       &eventA{},
+					ToState:     &stateTerminal{},
+					Description: "", // want "PFS003: protofsm transition must have a non-empty Description"
+					IsTerminal:  true,
+				},
+				{
+					Event:       &eventA{}, // want "PFS002: protofsm state contains duplicate event-to-state"
+					ToState:     &stateTerminal{},
+					Description: "duplicate event",
+					IsTerminal:  true,
+				},
+			},
+		},
+		{
+			FromState: &stateA{}, // want "PFS001: protofsm transition table contains duplicate rows"
+			Transitions: []protofsm.TransitionEntry[any, any, any]{
+				{
+					Event:       &eventB{},
+					ToState:     &stateA{},
+					Description: "duplicate row",
+				},
+			},
+		},
+		{
+			FromState: &stateTerminal{},
+			Transitions: []protofsm.TransitionEntry[any, any, any]{
+				{
+					Event:       &eventB{},
+					ToState:     &stateTerminal{},
+					Description: "terminal self-loop",
+					IsTerminal:  true,
+				},
+			},
+		},
+		{
+			FromState: &stateB{},
+			Transitions: []protofsm.TransitionEntry[any, any, any]{
+				{
+					Event:       &eventB{},
+					ToState:     &stateTerminal{}, // want "PFS005: transition to a terminal self-loop state must set IsTerminal"
+					Description: "forgot terminal marker",
+				},
+			},
+		},
+	},
+}
+
+func unboundedDetachedAsk(future actor.Future[int],
+	detached actor.DetachedAsk[int]) {
+
+	future.OnComplete(
+		detached.CallerCtx, // want "ALC001: DetachedAsk.CallerCtx must be wrapped"
+		func(error) {},
+	)
+
+	boundedCtx, cancel := context.WithTimeout(
+		detached.CallerCtx, time.Second,
+	)
+	defer cancel()
+	future.OnComplete(boundedCtx, func(error) {})
+}
+
+func forbiddenClassicPool(cfg actor.DurableActorConfig[int, error]) {
+	_ = cfg.AllowConcurrentClassicBehavior() // want "ALC002: AllowConcurrentClassicBehavior is a test-only escape hatch"
+}
+
+type store struct{}
+
+type stagedBehavior struct{}
+
+func (*stagedBehavior) Receive( // want "ALC003: TxBehavior.Receive stages durable state but never commits" Receive:"&\\{8\\}"
+	ctx context.Context, _ int, ax actor.Exec[store]) error {
+
+	return ax.Stage(ctx, func(context.Context, store) error {
+		return nil
+	})
+}
+
+func writerDeadlock(ctx context.Context, ax actor.Exec[store], // want writerDeadlock:"&\\{16\\}"
+	ref actor.ActorRef[int, int], db *sql.DB) error {
+
+	return ax.Commit( // want "ATX001: writer transaction callback waits on an actor future" "ATX003: writer transaction callback sends with actor.WithoutTx" "ATX004: writer transaction callback opens an independent sql.DB transaction" "ATX005: transaction context escapes its callback lifetime"
+		ctx, func(txCtx context.Context, _ store) error {
+			_ = ref.Ask(txCtx, 1).Await(txCtx)
+			_ = ref.Tell(actor.WithoutTx(txCtx), 1)
+			_, _ = db.BeginTx(txCtx, nil)
+			ref.Ask(txCtx, 1).OnComplete(txCtx, func(error) {})
+
+			return nil
+		},
+	)
+}
+
+func awaitHelper(ctx context.Context, // want awaitHelper:"&\\{1\\}"
+	ref actor.ActorRef[int, int]) error {
+
+	return ref.Ask(ctx, 1).Await(ctx)
+}
+
+func indirectWriterDeadlock(ctx context.Context, // want indirectWriterDeadlock:"&\\{16\\}"
+	ax actor.Exec[store], ref actor.ActorRef[int, int]) error {
+
+	return ax.Commit( // want "ATX001: writer transaction callback waits on an actor future"
+		ctx, func(txCtx context.Context, _ store) error {
+			return awaitHelper(txCtx, ref)
+		},
+	)
+}
+
+func safeTransactionPhases(ctx context.Context, ax actor.Exec[store], // want safeTransactionPhases:"&\\{25\\}"
+	ref actor.ActorRef[int, int]) error {
+
+	if err := ax.Stage(ctx, func(txCtx context.Context, _ store) error {
+		return ref.Tell(txCtx, 1)
+	}); err != nil {
+		return err
+	}
+
+	_ = ref.Ask(ctx, 1).Await(ctx)
+
+	return ax.Commit(ctx, func(context.Context, store) error {
+		return nil
+	})
+}
+
+type classicBehavior struct {
+	ref actor.ActorRef[int, error]
+}
+
+func (b *classicBehavior) Receive(ctx context.Context, msg int) error { // want Receive:"&\\{1\\}"
+	return b.ref.Ask(ctx, msg).Await(ctx)
+}
+
+func badClassicConfig(codec *actor.MessageCodec) {
+	_ = actor.DefaultDurableActorConfig(
+		"classic", &classicBehavior{}, // want "ATX002: classic durable behavior may await an actor"
+		nil, codec,
+	)
+}

--- a/tools/linters/testdata/src/github.com/lightninglabs/wavelength/baselib/actor/actor.go
+++ b/tools/linters/testdata/src/github.com/lightninglabs/wavelength/baselib/actor/actor.go
@@ -1,0 +1,89 @@
+package actor
+
+import (
+	"context"
+	"io"
+
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+type TLVMessage interface {
+	TLVType() tlv.Type
+	Encode(io.Writer) error
+	Decode(io.Reader) error
+}
+
+type MessageCodec struct{}
+
+func NewMessageCodec() *MessageCodec {
+	return &MessageCodec{}
+}
+
+func (*MessageCodec) Register(tlv.Type, func() TLVMessage) error {
+	return nil
+}
+
+func (*MessageCodec) MustRegister(tlv.Type, func() TLVMessage) {}
+
+type Future[T any] struct{}
+
+func (Future[T]) Await(context.Context) error {
+	return nil
+}
+
+func (Future[T]) OnComplete(context.Context, func(error)) {}
+
+func (Future[T]) ThenApply(context.Context, func(T) T) Future[T] {
+	return Future[T]{}
+}
+
+type ActorRef[M, R any] struct{}
+
+func (ActorRef[M, R]) Ask(context.Context, M) Future[R] {
+	return Future[R]{}
+}
+
+func (ActorRef[M, R]) Tell(context.Context, M) error {
+	return nil
+}
+
+type Exec[S any] interface {
+	Read(context.Context, func(context.Context, S) error) error
+	Stage(context.Context, func(context.Context, S) error) error
+	Commit(context.Context, func(context.Context, S) error) error
+}
+
+type ActorBehavior[M, R any] interface {
+	Receive(context.Context, M) R
+}
+
+type DurableActorConfig[M, R any] struct{}
+
+func DefaultDurableActorConfig[M, R any](string, ActorBehavior[M, R],
+	any, *MessageCodec) DurableActorConfig[M, R] {
+
+	return DurableActorConfig[M, R]{}
+}
+
+func NewClassicBehavior[M, R any](
+	behavior ActorBehavior[M, R]) ActorBehavior[M, R] {
+
+	return behavior
+}
+
+func (DurableActorConfig[M, R]) AllowConcurrentClassicBehavior() DurableActorConfig[M, R] {
+
+	return DurableActorConfig[M, R]{}
+}
+
+type DetachedAsk[R any] struct {
+	CallerCtx context.Context
+}
+
+func DetachAskPromise[R any](context.Context) (DetachedAsk[R], bool) {
+	return DetachedAsk[R]{}, true
+}
+
+func WithoutTx(ctx context.Context) context.Context {
+	return ctx
+}

--- a/tools/linters/testdata/src/github.com/lightninglabs/wavelength/baselib/protofsm/protofsm.go
+++ b/tools/linters/testdata/src/github.com/lightninglabs/wavelength/baselib/protofsm/protofsm.go
@@ -1,0 +1,19 @@
+package protofsm
+
+type TransitionEntry[S, E, M any] struct {
+	Event       E
+	ToState     S
+	Description string
+	EmitsOutbox []M
+	IsTerminal  bool
+}
+
+type StateTransitions[S, E, M any] struct {
+	FromState   S
+	Transitions []TransitionEntry[S, E, M]
+}
+
+type TransitionTable[S, E, M any] struct {
+	MachineName string
+	States      []StateTransitions[S, E, M]
+}

--- a/tools/linters/testdata/src/github.com/lightningnetwork/lnd/tlv/tlv.go
+++ b/tools/linters/testdata/src/github.com/lightningnetwork/lnd/tlv/tlv.go
@@ -1,0 +1,21 @@
+package tlv
+
+import "io"
+
+type Type uint64
+
+type Record struct{}
+
+type Stream struct{}
+
+func NewStream(...Record) (*Stream, error) {
+	return &Stream{}, nil
+}
+
+func (*Stream) Encode(io.Writer) error {
+	return nil
+}
+
+func (*Stream) Decode(io.Reader) error {
+	return nil
+}


### PR DESCRIPTION
## What changed

- add a typed `framework` golangci-lint plugin alongside the existing `ll` plugin
- validate durable actor TLV registrations and reject top-level fixed-layout binary message encodings
- validate protofsm table identity, duplicate rows/edges, descriptions, and terminal markers
- require detached Ask continuations to bound `CallerCtx` and keep the concurrent-classic escape test-only
- use SSA effect summaries to reject actor waits, stripped-context sends, independent SQL transactions, and transaction-context escapes while a writer is held
- enable the plugin in the existing Wavelength lint CI job

The transaction analysis deliberately models “writer held” separately from “context carries a transaction.” That distinction catches both historical mailbox failure modes: waiting on an Ask whose durable enqueue is still uncommitted, and stripping the transaction before an enqueue that then tries to acquire a second writer.

## Diagnostics

- `ATL001-ATL003`: durable TLV encoding and codec registration
- `PFS001-PFS005`: protofsm transition-table invariants
- `ALC001-ALC003`: detached Ask and durable actor lifecycle
- `ATX001-ATX005`: actor transaction/deadlock boundaries

## Validation

- `GOWORK=off go test ./...` in `tools/linters`
- `GOWORK=off go vet ./...` in `tools/linters`
- full framework-only scan of the Wavelength tree: 0 issues
- `GOGC=50 make lint-local workers=4`: 0 issues
- `GOWORK=off go test ./...`
- `make tidy-module-check`
- `make fmt-changed-check`
- `make commitmsg-lint range='origin/main..HEAD'`
