### PR TITLE
multi: reclaim exits whose source batch was swept

### DIFF
--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -273,8 +273,9 @@ type Querier interface {
 	// Status 1 = Completed, 2 = Failed (anchored to Go iota in
 	// db/oor_session_registry_store.go OORSessionStatus).
 	ListNonTerminalOORSessionRegistry(ctx context.Context) ([]OorSessionRegistry, error)
-	// Status 4 = Completed, 5 = Failed, 7 = FailedRecoverable (anchored to Go
-	// iota in db/unilateral_exit_store.go UnilateralExitJobStatus).
+	// Status 4 = Completed, 5 = Failed, 7 = FailedRecoverable, 8 =
+	// FailedConflicted (anchored to Go iota in db/unilateral_exit_store.go
+	// UnilateralExitJobStatus). All four are terminal and excluded from restore.
 	ListNonTerminalUnilateralExitJobs(ctx context.Context) ([]UnilateralExitJob, error)
 	ListNonTerminalVHTLCRecoveryJobs(ctx context.Context) ([]VhtlcRecoveryJob, error)
 	ListOORPackageCheckpoints(ctx context.Context, sessionID []byte) ([]OorPackageCheckpoint, error)

--- a/db/sqlc/queries/unilateral_exit.sql
+++ b/db/sqlc/queries/unilateral_exit.sql
@@ -26,10 +26,11 @@ WHERE target_outpoint_hash = $1
 ;
 
 -- name: ListNonTerminalUnilateralExitJobs :many
--- Status 4 = Completed, 5 = Failed, 7 = FailedRecoverable (anchored to Go
--- iota in db/unilateral_exit_store.go UnilateralExitJobStatus).
+-- Status 4 = Completed, 5 = Failed, 7 = FailedRecoverable, 8 =
+-- FailedConflicted (anchored to Go iota in db/unilateral_exit_store.go
+-- UnilateralExitJobStatus). All four are terminal and excluded from restore.
 SELECT * FROM unilateral_exit_jobs
-WHERE status NOT IN (4, 5, 7)
+WHERE status NOT IN (4, 5, 7, 8)
 ORDER BY created_at ASC
 ;
 

--- a/db/sqlc/unilateral_exit.sql.go
+++ b/db/sqlc/unilateral_exit.sql.go
@@ -93,12 +93,13 @@ func (q *Queries) InsertExitFundingAddress(ctx context.Context, arg InsertExitFu
 
 const ListNonTerminalUnilateralExitJobs = `-- name: ListNonTerminalUnilateralExitJobs :many
 SELECT target_outpoint_hash, target_outpoint_index, actor_id, status, trigger, last_error, sweep_txid, created_at, updated_at, exit_policy_kind, exit_policy_ref FROM unilateral_exit_jobs
-WHERE status NOT IN (4, 5, 7)
+WHERE status NOT IN (4, 5, 7, 8)
 ORDER BY created_at ASC
 `
 
-// Status 4 = Completed, 5 = Failed, 7 = FailedRecoverable (anchored to Go
-// iota in db/unilateral_exit_store.go UnilateralExitJobStatus).
+// Status 4 = Completed, 5 = Failed, 7 = FailedRecoverable, 8 =
+// FailedConflicted (anchored to Go iota in db/unilateral_exit_store.go
+// UnilateralExitJobStatus). All four are terminal and excluded from restore.
 func (q *Queries) ListNonTerminalUnilateralExitJobs(ctx context.Context) ([]UnilateralExitJob, error) {
 	rows, err := q.db.QueryContext(ctx, ListNonTerminalUnilateralExitJobs)
 	if err != nil {

--- a/db/unilateral_exit_store.go
+++ b/db/unilateral_exit_store.go
@@ -60,13 +60,26 @@ const (
 	// the exit has begun on-chain) so boot-time reconciliation can decide
 	// whether to recover the VTXO (wavelength#602).
 	UnilateralExitJobStatusFailedRecoverable
+
+	// UnilateralExitJobStatusFailedConflicted means the job failed
+	// terminally because a confirmed foreign spend conflicts with the
+	// recovery tree — the operator swept a source batch commitment output
+	// the exit depends on, so the exit can never complete. Unlike a plain
+	// Failed job, boot-time reconciliation must retire the target VTXO out
+	// of unilateral-exit (clearing it from pending balance) rather than
+	// leaving it pending forever, and unlike a recoverable failure it must
+	// NOT roll the VTXO back to live: the coin is provably gone
+	// (wavelength#1050). Appended after the original enum so existing rows'
+	// numeric meaning never shifts.
+	UnilateralExitJobStatusFailedConflicted
 )
 
 // IsTerminal reports whether the control-plane job status is terminal.
 func (s UnilateralExitJobStatus) IsTerminal() bool {
 	return s == UnilateralExitJobStatusCompleted ||
 		s == UnilateralExitJobStatusFailed ||
-		s == UnilateralExitJobStatusFailedRecoverable
+		s == UnilateralExitJobStatusFailedRecoverable ||
+		s == UnilateralExitJobStatusFailedConflicted
 }
 
 // UnilateralExitJobTrigger records what started an exit job.

--- a/db/unilateral_exit_store.go
+++ b/db/unilateral_exit_store.go
@@ -65,12 +65,11 @@ const (
 	// terminally because a confirmed foreign spend conflicts with the
 	// recovery tree — the operator swept a source batch commitment output
 	// the exit depends on, so the exit can never complete. Unlike a plain
-	// Failed job, boot-time reconciliation must retire the target VTXO out
-	// of unilateral-exit (clearing it from pending balance) rather than
-	// leaving it pending forever, and unlike a recoverable failure it must
-	// NOT roll the VTXO back to live: the coin is provably gone
-	// (wavelength#1050). Appended after the original enum so existing rows'
-	// numeric meaning never shifts.
+	// Failed job, boot-time reconciliation routes a standard-policy VTXO
+	// to expired reclaim. Its old lineage cannot be spent, but its value
+	// remains recoverable through a refresh, not a direct rollback to live.
+	// Recovery-only targets stay in exit under their owning subsystem.
+	// Appended after the original enum so existing rows keep their meaning.
 	UnilateralExitJobStatusFailedConflicted
 )
 

--- a/lib/recovery/proof.go
+++ b/lib/recovery/proof.go
@@ -447,6 +447,68 @@ func (p *Proof) RootTxids() []chainhash.Hash {
 	return append([]chainhash.Hash(nil), p.layers[0]...)
 }
 
+// RootExternalInputs returns the outpoints consumed by root transactions that
+// are NOT themselves produced by any node in this proof — the external funding
+// inputs the whole recovery graph hangs off of. For a round-direct VTXO this is
+// the batch/commitment output the tree root spends; for an OOR-chained or
+// multi-input fan-in VTXO it is every distinct commitment output rooting a
+// local lineage fragment.
+//
+// These are exactly the outpoints a competing party (an operator sweeping an
+// expired batch, a fraud spend) can consume out from under the exit: a
+// confirmed foreign spend of any one of them makes every root that depends on
+// it — and therefore the whole proof — permanently unbroadcastable. Callers arm
+// spend watches on them so such a conflict fails the exit terminally instead of
+// spinning forever on a tree that can never confirm (wavelength#1050).
+//
+// The result is deduplicated and sorted deterministically (by hash then index)
+// so two proofs built from the same node set yield identical output regardless
+// of map iteration order.
+func (p *Proof) RootExternalInputs() []wire.OutPoint {
+	seen := make(map[wire.OutPoint]struct{})
+	external := make([]wire.OutPoint, 0)
+
+	for _, rootTxid := range p.RootTxids() {
+		root, ok := p.nodes[rootTxid]
+		if !ok || root.Tx == nil {
+			continue
+		}
+
+		for _, txIn := range root.Tx.TxIn {
+			if txIn == nil {
+				continue
+			}
+
+			outpoint := txIn.PreviousOutPoint
+
+			// An input produced by another node is an in-graph
+			// dependency, not an external funding input.
+			if _, isNode := p.nodes[outpoint.Hash]; isNode {
+				continue
+			}
+
+			if _, dup := seen[outpoint]; dup {
+				continue
+			}
+
+			seen[outpoint] = struct{}{}
+			external = append(external, outpoint)
+		}
+	}
+
+	sort.Slice(external, func(i, j int) bool {
+		if c := bytes.Compare(
+			external[i].Hash[:], external[j].Hash[:],
+		); c != 0 {
+			return c < 0
+		}
+
+		return external[i].Index < external[j].Index
+	})
+
+	return external
+}
+
 // Layer returns the topological layer index for the requested txid. Layer 0
 // is the set of roots; the target node's layer is always the maximum layer
 // index.

--- a/lib/recovery/proof_accessors_test.go
+++ b/lib/recovery/proof_accessors_test.go
@@ -1,6 +1,7 @@
 package recovery
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/btcsuite/btcd/chainhash/v2"
@@ -166,4 +167,51 @@ func TestProofAccessors(t *testing.T) {
 
 	_, err = proof.ChildTxids(chainhash.Hash{0xff})
 	require.ErrorContains(t, err, "unknown txid")
+}
+
+// TestProofRootExternalInputs verifies that RootExternalInputs returns exactly
+// the external funding inputs of the proof's root transactions — the outpoints
+// a competing spend can conflict with — deduplicated, deterministically
+// ordered, and excluding in-graph (node-produced) inputs.
+func TestProofRootExternalInputs(t *testing.T) {
+	// Two independent roots (a fan-in lineage), each spending its own
+	// external commitment output, feeding one target.
+	rootA := makeProofTx('a', nil)
+	rootB := makeProofTx('b', nil)
+	target := makeProofTx('t', []wire.OutPoint{
+		{Hash: rootA.TxHash(), Index: 0},
+		{Hash: rootB.TxHash(), Index: 0},
+	})
+
+	proof, err := NewProof(
+		wire.OutPoint{
+			Hash: target.TxHash(),
+		},
+		5, &Node{
+			Kind: NodeKindTree,
+			Tx:   rootA,
+		}, &Node{
+			Kind: NodeKindTree,
+			Tx:   rootB,
+		}, &Node{
+			Kind: NodeKindArk,
+			Tx:   target,
+		},
+	)
+	require.NoError(t, err)
+
+	// makeProofTx seeds a root's external input at {Hash{tag,0xff}, tag}.
+	wantA := wire.OutPoint{Hash: chainhash.Hash{'a', 0xff}, Index: 'a'}
+	wantB := wire.OutPoint{Hash: chainhash.Hash{'b', 0xff}, Index: 'b'}
+
+	got := proof.RootExternalInputs()
+
+	// Both roots' external inputs are present; the target's in-graph inputs
+	// (produced by rootA/rootB) are excluded.
+	require.Len(t, got, 2)
+	require.Contains(t, got, wantA)
+	require.Contains(t, got, wantB)
+
+	// Deterministic ordering: sorted by hash bytes then index.
+	require.True(t, bytes.Compare(got[0].Hash[:], got[1].Hash[:]) <= 0)
 }

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -181,10 +181,21 @@ type behavior struct {
 	// if an older durable notification reaches the actor first.
 	restoredCheckpointPending bool
 
-	blockSubActive             bool
-	spendWatchActive           bool
-	proofSpendWatches          map[wire.OutPoint]struct{}
-	proofNodeFloorWarned       bool
+	blockSubActive       bool
+	spendWatchActive     bool
+	proofSpendWatches    map[wire.OutPoint]struct{}
+	proofNodeFloorWarned bool
+
+	// sourceSpendWatches tracks the external (non-proof) funding outpoints
+	// the recovery roots hang off of — the round batch/commitment outputs.
+	// A confirmed foreign spend of one of these (an operator sweeping an
+	// expired batch) makes the whole proof unbroadcastable, so we watch
+	// them to fail the exit terminally instead of materializing forever
+	// (wavelength#1050). Membership also lets handleSpendObserved recognise
+	// a source conflict and report it distinctly from a generic external
+	// spend.
+	sourceSpendWatches map[wire.OutPoint]struct{}
+
 	terminalNotified           bool
 	exitCostNotified           bool
 	abandonedBroadcastsRemoved bool
@@ -407,6 +418,7 @@ func (b *behavior) OnStop(ctx context.Context) error {
 	b.unsubscribeBlocks(ctx)
 	b.unregisterSpendWatch(ctx)
 	b.unregisterProofSpendWatches(ctx)
+	b.unregisterSourceSpendWatches(ctx)
 
 	if b.session != nil && b.session.FSM != nil {
 		b.session.FSM.Stop()
@@ -1418,6 +1430,12 @@ func (b *behavior) ensureLoaded(ctx context.Context) error {
 		return err
 	}
 
+	// Arming the source-commitment watches is best-effort and never blocks
+	// loading: the exit still materializes without them, they only add the
+	// swept-source conflict detection on top, so a registration failure is
+	// logged inside rather than surfaced here.
+	b.ensureSourceSpendWatches(ctx)
+
 	state, err := b.currentState()
 	if err != nil {
 		return err
@@ -1803,6 +1821,166 @@ func (b *behavior) proofSpendCallerID(outpoint wire.OutPoint) string {
 		b.cfg.TargetOutpoint.String(), outpoint.String())
 }
 
+// ensureSourceSpendWatches registers spend watches on the external funding
+// inputs of the recovery roots — the round batch/commitment outputs the whole
+// proof hangs off of. Unlike the proof-node watches (which watch outputs
+// consumed by in-proof children to catch a parent confirmation), these watch
+// the outpoints an adversary can consume out from under us: once the operator
+// sweeps an expired batch commitment output, every recovery transaction that
+// spends it is permanently invalid, so the exit can never complete. Without a
+// watch the job would sit in materialization forever because txconfirm never
+// gives up on a no-mempool transaction (wavelength#1050).
+//
+// A foreign spend of one of these routes through handleSpendObserved case 4
+// and fails the job; a spend by our own root routes through case 2 as a
+// benign parent-confirmation signal, so watching them is safe in both
+// outcomes. Arming is best-effort: a per-outpoint registration failure is
+// logged and skipped rather than failing the whole load, since the exit still
+// functions (just without swept-source detection for that outpoint).
+func (b *behavior) ensureSourceSpendWatches(ctx context.Context) {
+	if b.proof == nil {
+		return
+	}
+
+	external := b.proof.RootExternalInputs()
+	if len(external) == 0 {
+		return
+	}
+
+	if b.sourceSpendWatches == nil {
+		b.sourceSpendWatches = make(map[wire.OutPoint]struct{})
+	}
+
+	// The batch outputs carry the pkScript that neutrino needs to match a
+	// spend in the BIP-158 block filter (lwwallet detects by outpoint
+	// alone). It rides along on the descriptor ancestry when known; an
+	// unknown script still arms an outpoint-only watch, which covers the
+	// Esplora backend.
+	scripts := b.sourcePkScripts()
+
+	for _, outpoint := range external {
+		if outpoint == b.cfg.TargetOutpoint {
+			continue
+		}
+		if _, ok := b.sourceSpendWatches[outpoint]; ok {
+			continue
+		}
+
+		notifyRef := chainsource.MapSpendEvent(
+			b.selfRef,
+			func(event chainsource.SpendEvent) Msg {
+				return &SpendObservedMsg{
+					Outpoint:       event.Outpoint,
+					SpendingTxid:   event.SpendingTxid,
+					SpendingHeight: event.SpendingHeight,
+				}
+			},
+		)
+
+		// The batch output cannot be spent before its own commitment tx
+		// confirms, so the min-commitment-height floor (or the bounded
+		// lookback fallback) is a sound, tight rescan hint.
+		req := &chainsource.RegisterSpendRequest{
+			CallerID: b.sourceSpendCallerID(outpoint),
+			Outpoint: &outpoint,
+			HeightHint: b.proofNodeConfHeightHint(
+				ctx, outpoint.Hash,
+			),
+			NotifyActor: fn.Some(notifyRef),
+		}
+		if script := scripts[outpoint]; len(script) > 0 {
+			req.PkScript = script
+		} else {
+			// No batch output script resolved for this source
+			// outpoint, so the watch is outpoint-only. That is fine
+			// for Esplora/lwwallet (they match a spend by
+			// outpoint), but a neutrino backend matches spends via
+			// the prevout script in the BIP-158 block filter, so it
+			// cannot detect this sweep -- the swept-source conflict
+			// would go undetected on neutrino. Leave a breadcrumb
+			// so a stuck exit is diagnosable rather than silently
+			// degraded.
+			b.log.DebugS(ctx, "Source spend watch armed without a "+
+				"pkScript; swept-source detection is "+
+				"outpoint-only and will not match on a "+
+				"neutrino backend",
+				slog.String(
+					"source_outpoint", outpoint.String(),
+				),
+			)
+		}
+
+		_, err := b.cfg.ChainSource.Ask(ctx, req).Await(ctx).Unpack()
+		if err != nil {
+			b.log.WarnS(ctx, "Failed to arm source-commitment "+
+				"spend watch; swept-source conflict may go "+
+				"undetected", err,
+				slog.String(
+					"source_outpoint", outpoint.String(),
+				),
+			)
+
+			continue
+		}
+
+		b.sourceSpendWatches[outpoint] = struct{}{}
+	}
+}
+
+// sourcePkScripts maps each known batch/commitment outpoint to its output
+// script, drawn from the target descriptor's ancestry. The batch output is the
+// tree root's external input, so its script is exactly what a source spend
+// watch needs. Fragments without a resolved tree path (e.g. an empty-ancestry
+// legacy descriptor) simply contribute no entry, leaving those watches
+// outpoint-only.
+func (b *behavior) sourcePkScripts() map[wire.OutPoint][]byte {
+	if b.desc == nil {
+		return nil
+	}
+
+	scripts := make(map[wire.OutPoint][]byte)
+	for i := range b.desc.Ancestry {
+		tp := b.desc.Ancestry[i].TreePath
+		if tp == nil || tp.BatchOutput == nil {
+			continue
+		}
+
+		scripts[tp.BatchOutpoint] = tp.BatchOutput.PkScript
+	}
+
+	return scripts
+}
+
+// unregisterSourceSpendWatches cancels all source-commitment spend watches on
+// stop.
+func (b *behavior) unregisterSourceSpendWatches(ctx context.Context) {
+	for outpoint := range b.sourceSpendWatches {
+		err := b.cfg.ChainSource.Tell(
+			ctx, &chainsource.UnregisterSpendRequest{
+				CallerID: b.sourceSpendCallerID(outpoint),
+				Outpoint: &outpoint,
+			},
+		)
+		if err != nil {
+			b.log.WarnS(ctx, "Failed to unregister source spend "+
+				"watch", err,
+				slog.String("outpoint", outpoint.String()),
+			)
+
+			continue
+		}
+
+		delete(b.sourceSpendWatches, outpoint)
+	}
+}
+
+// sourceSpendCallerID returns the stable source-commitment spend-watch
+// registration ID.
+func (b *behavior) sourceSpendCallerID(outpoint wire.OutPoint) string {
+	return fmt.Sprintf("unroll-source-spend.%s.%s",
+		b.cfg.TargetOutpoint.String(), outpoint.String())
+}
+
 // handleSpendObserved processes a chainsource spend notification on the
 // target or proof-node outpoint. Spend watches are a safety net — they fire
 // when a proof output is consumed on chain, and we have to classify what we
@@ -1885,6 +2063,24 @@ func (b *behavior) handleSpendObserved(ctx context.Context,
 	if msg.Outpoint != (wire.OutPoint{}) {
 		spentOutpoint = msg.Outpoint
 	}
+
+	// A spend of one of the roots' external funding inputs is a
+	// source-batch conflict: the operator swept the commitment output our
+	// recovery tree depends on, so the exit is provably impossible rather
+	// than merely slow. Report it with a message the user can act on
+	// (wavelength#1050).
+	if _, isSource := b.sourceSpendWatches[spentOutpoint]; isSource {
+		reason := fmt.Sprintf("source batch %s was swept by the "+
+			"operator (tx %s at height %d); unilateral exit is no "+
+			"longer possible", spentOutpoint, msg.SpendingTxid,
+			msg.SpendingHeight)
+
+		return b.handleEvent(ctx, ax, &FailEvent{
+			Reason:   reason,
+			Conflict: true,
+		})
+	}
+
 	reason := fmt.Sprintf("watched outpoint %s spent externally by tx %s "+
 		"at height %d", spentOutpoint, msg.SpendingTxid,
 		msg.SpendingHeight)
@@ -2322,6 +2518,7 @@ func (b *behavior) notifyRegistryIfTerminal(ctx context.Context) {
 		FailReason:          job.FailReason,
 		HadOnChainFootprint: jobHadOnChainFootprint(job),
 		ExitPolicyKind:      b.exitPolicyKind(),
+		Conflicted:          job.Conflicted,
 	}
 
 	if sweepTxid := effectiveSweepTxid(

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -518,6 +518,10 @@ func (b *behavior) driveEvent(ctx context.Context, ax actor.Exec[unrollTx],
 		return err
 	}
 
+	// Fresh starts need the staged height before choosing a historical scan
+	// hint. Restored exits also register while loading their checkpoint.
+	b.ensureSourceSpendWatches(ctx)
+
 	if err := b.routeOutbox(ctx, ax, outbox); err != nil {
 		b.routeRetryPending = true
 
@@ -1838,7 +1842,7 @@ func (b *behavior) proofSpendCallerID(outpoint wire.OutPoint) string {
 // logged and skipped rather than failing the whole load, since the exit still
 // functions (just without swept-source detection for that outpoint).
 func (b *behavior) ensureSourceSpendWatches(ctx context.Context) {
-	if b.proof == nil {
+	if b.proof == nil || b.currentHeightHint() == 0 {
 		return
 	}
 
@@ -2642,13 +2646,50 @@ func (b *behavior) removeAbandonedBroadcasts(ctx context.Context,
 	// the goroutine's lifetime, and cancellation is detached from the
 	// request ctx so a caller disconnect cannot suppress the cleanup.
 	chainSource := b.cfg.ChainSource
+	txConfirmRef := b.cfg.TxConfirmRef
+	subscriberID := b.notificationRef().ID()
+	conflicted := job.Conflicted
 	log := b.log
 	go func() {
 		for _, txid := range txids {
 			opCtx, cancel := context.WithTimeout(
-				context.WithoutCancel(ctx),
+				actor.WithoutTx(
+					context.WithoutCancel(ctx),
+				),
 				removeAbandonedBroadcastTimeout,
 			)
+
+			// A source conflict terminates unroll independently of
+			// txconfirm. Removing wallet transactions alone leaves
+			// its CPFP retries and fee-input leases alive. Cancel
+			// only this exit's interest before wallet removal:
+			// another exit may still need an unswept root shared by
+			// both proof graphs.
+			if conflicted {
+				resp, err := txConfirmRef.Ask(
+					opCtx, &txconfirm.CancelInterestReq{
+						Txid:         txid,
+						SubscriberID: subscriberID,
+					},
+				).Await(opCtx).Unpack()
+				if err != nil {
+					cancel()
+					log.WarnS(opCtx, "Failed to cancel conflicted "+
+						"exit broadcast interest", err,
+						slog.String(
+							"txid", txid.String(),
+						),
+					)
+
+					continue
+				}
+				res, ok := resp.(*txconfirm.CancelInterestResp)
+				if !ok || res.RemainingSubscribers != 0 {
+					cancel()
+
+					continue
+				}
+			}
 			_, err := chainSource.Ask(
 				opCtx, &chainsource.RemoveTxRequest{Txid: txid},
 			).Await(opCtx).Unpack()

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -1825,6 +1825,19 @@ func (b *behavior) proofSpendCallerID(outpoint wire.OutPoint) string {
 		b.cfg.TargetOutpoint.String(), outpoint.String())
 }
 
+// sourceSpendHeightHint bounds source-input spend scans independently of the
+// proof-node fallback alert. These watches also detect our own root confirming,
+// which may happen before batch expiry; using expiry would miss that evidence.
+// The commitment floor, or the supported network's deployment floor, covers
+// both spends without attributing a proof-node alert to a commitment txid.
+func (b *behavior) sourceSpendHeightHint() uint32 {
+	if floor := b.commitmentHeightFloor(); floor > 0 {
+		return uint32(floor)
+	}
+
+	return b.legacyProofScanFloor(b.currentHeightHint())
+}
+
 // ensureSourceSpendWatches registers spend watches on the external funding
 // inputs of the recovery roots — the round batch/commitment outputs the whole
 // proof hangs off of. Unlike the proof-node watches (which watch outputs
@@ -1881,15 +1894,12 @@ func (b *behavior) ensureSourceSpendWatches(ctx context.Context) {
 			},
 		)
 
-		// The batch output cannot be spent before its own commitment tx
-		// confirms, so the min-commitment-height floor (or the bounded
-		// lookback fallback) is a sound, tight rescan hint.
+		// Use the source-specific floor without consuming a proof-node
+		// fallback alert or mislabeling this commitment as a proof tx.
 		req := &chainsource.RegisterSpendRequest{
-			CallerID: b.sourceSpendCallerID(outpoint),
-			Outpoint: &outpoint,
-			HeightHint: b.proofNodeConfHeightHint(
-				ctx, outpoint.Hash,
-			),
+			CallerID:    b.sourceSpendCallerID(outpoint),
+			Outpoint:    &outpoint,
+			HeightHint:  b.sourceSpendHeightHint(),
 			NotifyActor: fn.Some(notifyRef),
 		}
 		if script := scripts[outpoint]; len(script) > 0 {

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -2156,6 +2156,80 @@ func TestProofNodeHeightHintWarnsOncePerActor(t *testing.T) {
 	require.Contains(t, buf.String(), "[WRN]")
 }
 
+// TestSourceSpendHeightHintKeepsProofAlerts checks that source scans retain
+// pre-expiry confirmation evidence without consuming proof-node alerts.
+func TestSourceSpendHeightHintKeepsProofAlerts(t *testing.T) {
+	cases := []struct {
+		name       string
+		heights    []int32
+		deployment uint32
+		want       uint32
+	}{
+		{
+			"known",
+			[]int32{
+				80,
+				90,
+			},
+			50,
+			80,
+		},
+		{
+			"partial",
+			[]int32{
+				80,
+				0,
+			},
+			50,
+			50,
+		},
+		{
+			"legacy",
+			nil,
+			50,
+			50,
+		},
+		{
+			"futureFloor",
+			nil,
+			300,
+			1,
+		},
+		{
+			"unknown",
+			nil,
+			0,
+			1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			desc := &vtxo.Descriptor{BatchExpiry: 150}
+			for _, height := range tc.heights {
+				desc.Ancestry = append(
+					desc.Ancestry, vtxo.Ancestry{
+						CommitmentHeight: height,
+					},
+				)
+			}
+			b := &behavior{
+				cfg: Config{
+					LegacyProofScanFloor: tc.deployment,
+				},
+				desc: desc, pending: &actorCheckpoint{
+					Height: 200,
+				},
+			}
+			require.Equal(t, tc.want, b.sourceSpendHeightHint())
+			require.False(t, b.proofNodeFloorWarned)
+			require.Less(
+				t, b.sourceSpendHeightHint(), uint32(150),
+				"our own root may have confirmed before expiry",
+			)
+		})
+	}
+}
+
 // TestProofNodeHeightHintLogsBoundedFallbackAtInfo verifies a configured,
 // network deployment floor is routine compatibility handling, not an operator
 // warning.
@@ -2185,6 +2259,10 @@ func TestProofNodeHeightHintLogsBoundedFallbackAtInfo(t *testing.T) {
 	)
 	require.Contains(t, buf.String(), "[INF]")
 	require.NotContains(t, buf.String(), "[WRN]")
+	require.Contains(
+		t, buf.String(), proof.RootTxids()[0].String(),
+		"fallback alert must identify a proof node, not a source",
+	)
 
 	// Source watches must also use the configured deployment floor. On a
 	// fresh exit, registering before Start stages its height would select

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -2185,6 +2185,18 @@ func TestProofNodeHeightHintLogsBoundedFallbackAtInfo(t *testing.T) {
 	)
 	require.Contains(t, buf.String(), "[INF]")
 	require.NotContains(t, buf.String(), "[WRN]")
+
+	// Source watches must also use the configured deployment floor. On a
+	// fresh exit, registering before Start stages its height would select
+	// genesis even though the configured floor is valid.
+	chainRef, ok := behavior.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+	for _, source := range proof.RootExternalInputs() {
+		require.Equal(
+			t, uint32(800_000),
+			chainRef.spendRequest(t, source).HeightHint,
+		)
+	}
 }
 
 // TestFraudTriggerDefersReadyCheckpoint verifies fraud-triggered recovery

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lightninglabs/wavelength/ledger"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightninglabs/wavelength/lib/recovery"
+	"github.com/lightninglabs/wavelength/lib/tree"
 	"github.com/lightninglabs/wavelength/txconfirm"
 	"github.com/lightninglabs/wavelength/unrollplan"
 	"github.com/lightninglabs/wavelength/vtxo"
@@ -459,6 +460,7 @@ type fakeChainSourceRef struct {
 	spendRefs   map[wire.OutPoint]spendEventRef
 	spendRegs   []wire.OutPoint
 	spendReqs   map[wire.OutPoint]*spendReq
+	spendScrpt  map[wire.OutPoint][]byte
 	removedTxes []chainhash.Hash
 	confRefs    map[chainhash.Hash]confRef
 	confReqs    map[chainhash.Hash]*confReq
@@ -585,6 +587,9 @@ func (f *fakeChainSourceRef) Ask(_ context.Context,
 		if msg.Outpoint != nil {
 			outpoint = *msg.Outpoint
 		}
+		if f.spendScrpt == nil {
+			f.spendScrpt = make(map[wire.OutPoint][]byte)
+		}
 		f.spendRefs[outpoint] = msg.NotifyActor.UnwrapOr(nil)
 		f.spendRegs = append(f.spendRegs, outpoint)
 		if f.spendReqs == nil {
@@ -595,6 +600,9 @@ func (f *fakeChainSourceRef) Ask(_ context.Context,
 		reqCopy.Outpoint = &outpointCopy
 		reqCopy.PkScript = append([]byte(nil), msg.PkScript...)
 		f.spendReqs[outpoint] = &reqCopy
+		f.spendScrpt[outpoint] = append(
+			[]byte(nil), msg.PkScript...,
+		)
 		f.mu.Unlock()
 		promise.Complete(
 			fn.Ok[chainsource.ChainSourceResp](
@@ -764,6 +772,15 @@ func (f *fakeChainSourceRef) removedTxSnapshot() []chainhash.Hash {
 	defer f.mu.Unlock()
 
 	return append([]chainhash.Hash(nil), f.removedTxes...)
+}
+
+// spendPkScript returns the pkScript a spend watch was registered with for the
+// given outpoint, or nil if none was registered or it was outpoint-only.
+func (f *fakeChainSourceRef) spendPkScript(outpoint wire.OutPoint) []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append([]byte(nil), f.spendScrpt[outpoint]...)
 }
 
 // fakeSweepWallet is a minimal signer plus wallet-destination test double.
@@ -2987,6 +3004,182 @@ func TestAbandonedBroadcastRemovalSkipsConfirmedTxids(t *testing.T) {
 			"a confirmed tx must never be removed from the wallet",
 		)
 	}
+}
+
+// sourceOutpoint is the external funding input the linear test proof's root
+// spends — the round batch/commitment output the recovery tree hangs off of.
+var sourceOutpoint = wire.OutPoint{Hash: chainhash.Hash{1}, Index: 0}
+
+// TestSourceSpendWatchArmed verifies the fix's core mechanism: on
+// materialization the actor arms a spend watch on the roots' external funding
+// input (the batch commitment output), which nothing watched before
+// wavelength#1050 — leaving a swept-source exit stuck in materialization
+// forever.
+func TestSourceSpendWatchArmed(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, beh, _, _ := newActorHarness(t, proof, desc)
+
+	chainSource, ok := beh.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+
+	require.Eventually(t, func() bool {
+		for _, outpoint := range chainSource.spendRegistrations() {
+			if outpoint == sourceOutpoint {
+				return true
+			}
+		}
+
+		return false
+	}, testTimeout, 10*time.Millisecond)
+}
+
+// TestSourceSpendWatchCarriesBatchPkScript verifies the source watch is armed
+// WITH the batch output's pkScript when the descriptor ancestry carries it.
+// This matters for neutrino: it matches a spend via the prevout script in the
+// BIP-158 block filter, so an outpoint-only watch would silently miss the sweep
+// (lwwallet/Esplora match by outpoint alone, so they are unaffected). The other
+// source-watch tests use an empty-ancestry descriptor and so only exercise the
+// outpoint; this one pins the script ride-along.
+func TestSourceSpendWatchCarriesBatchPkScript(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+
+	// Give the descriptor an ancestry fragment whose batch outpoint is the
+	// proof root's external funding input (sourceOutpoint), carrying a
+	// distinctive pkScript that must ride along on the spend watch.
+	batchScript := []byte{txscript.OP_1, 0xab, 0xcd, 0xef}
+	desc.Ancestry = []vtxo.Ancestry{{
+		TreePath: &tree.Tree{
+			BatchOutpoint: sourceOutpoint,
+			BatchOutput: &wire.TxOut{
+				Value:    90_000,
+				PkScript: batchScript,
+			},
+		},
+	}}
+
+	unrollActor, beh, _, _ := newActorHarness(t, proof, desc)
+
+	chainSource, ok := beh.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+
+	require.Eventually(t, func() bool {
+		return chainSource.spendPkScript(sourceOutpoint) != nil
+	}, testTimeout, 10*time.Millisecond)
+
+	require.Equal(
+		t, batchScript, chainSource.spendPkScript(sourceOutpoint),
+		"source watch must carry the batch output pkScript so a "+
+			"neutrino BIP-158 filter can match the sweep",
+	)
+}
+
+// TestSweptSourceFailsActor reproduces wavelength#1050: once the operator
+// sweeps the source batch commitment output (a foreign spend of the roots'
+// external input), the exit is provably impossible, so the actor must fail
+// terminally with a source-conflict reason rather than materialize forever.
+func TestSweptSourceFailsActor(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, beh, _, _ := newActorHarness(t, proof, desc)
+
+	chainSource, ok := beh.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+
+	require.Eventually(t, func() bool {
+		for _, outpoint := range chainSource.spendRegistrations() {
+			if outpoint == sourceOutpoint {
+				return true
+			}
+		}
+
+		return false
+	}, testTimeout, 10*time.Millisecond)
+
+	// The operator's expired-batch sweep is a foreign tx (not one of our
+	// proof nodes) consuming the batch commitment output.
+	operatorSweep := chainhash.Hash{0xaa}
+	chainSource.emitSpendForOutpoint(t, sourceOutpoint, operatorSweep, 101)
+
+	require.Eventually(t, func() bool {
+		stateResp, ok := mustAsk(
+			t, unrollActor.Ref(), &GetStateRequest{},
+		).(*GetStateResp)
+		require.True(t, ok)
+
+		return stateResp.Phase == PhaseFailed
+	}, testTimeout, 10*time.Millisecond)
+
+	stateResp, ok := mustAsk(
+		t, unrollActor.Ref(), &GetStateRequest{},
+	).(*GetStateResp)
+	require.True(t, ok)
+	require.Contains(t, stateResp.FailReason, "source batch")
+	require.Contains(t, stateResp.FailReason, "swept")
+	require.Contains(t, stateResp.FailReason, sourceOutpoint.String())
+	require.Contains(t, stateResp.FailReason, operatorSweep.String())
+}
+
+// TestOwnRootSpendOfSourceConfirms guards the benign side of the source watch:
+// when OUR own root spends the batch output (the exit winning the race), the
+// spend notification must be read as a parent confirmation, never as a
+// source-conflict failure.
+func TestOwnRootSpendOfSourceConfirms(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, beh, txconfirmRef, _ := newActorHarness(t, proof, desc)
+
+	chainSource, ok := beh.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+
+	require.Eventually(t, func() bool {
+		for _, outpoint := range chainSource.spendRegistrations() {
+			if outpoint == sourceOutpoint {
+				return true
+			}
+		}
+
+		return false
+	}, testTimeout, 10*time.Millisecond)
+
+	// Our own root tx spends the batch output: a parent confirmation, not a
+	// conflict. The actor should advance to requesting the target rather
+	// than failing.
+	rootTxid := proof.RootTxids()[0]
+	chainSource.emitSpendForOutpoint(t, sourceOutpoint, rootTxid, 101)
+
+	require.Eventually(t, func() bool {
+		return txconfirmRef.requestCountForTxid(
+			proof.TargetOutpoint().Hash,
+		) == 1
+	}, testTimeout, 10*time.Millisecond)
+
+	stateResp, ok := mustAsk(
+		t, unrollActor.Ref(), &GetStateRequest{},
+	).(*GetStateResp)
+	require.True(t, ok)
+	require.NotEqual(t, PhaseFailed, stateResp.Phase)
 }
 
 // TestConfirmedNodesAdvanceToSweep verifies that node confirmations move the

--- a/unroll/conflicted_restart_test.go
+++ b/unroll/conflicted_restart_test.go
@@ -371,6 +371,16 @@ func testSweptSourceRestart(t *testing.T, shared bool) {
 
 		return err == nil && coin.Status == vtxo.VTXOStatusExpired
 	}, 5*time.Second, 10*time.Millisecond)
+	// Replay through the real manager and its now-expired child, as when
+	// terminal handoff is re-driven after a crash. No error or fresh status
+	// transition should prevent the following epoch from reclaiming.
+	_, err = managerRef.Ask(t.Context(), &vtxo.ExitOutcomeNotification{
+		Outpoint: target,
+		Outcome:  vtxo.ExitOutcomeConflicted,
+		Reason:   "replayed source conflict",
+	}).Await(t.Context()).Unpack()
+	require.NoError(t, err)
+
 	// The expired actor is not spendable but must survive to request
 	// refresh.
 	live, err := vtxos.ListLiveVTXOs(t.Context())

--- a/unroll/conflicted_restart_test.go
+++ b/unroll/conflicted_restart_test.go
@@ -1,0 +1,463 @@
+package unroll
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/chainsource"
+	"github.com/lightninglabs/wavelength/db"
+	"github.com/lightninglabs/wavelength/db/actordelivery"
+	"github.com/lightninglabs/wavelength/lib/actormsg"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/recovery"
+	"github.com/lightninglabs/wavelength/round"
+	"github.com/lightninglabs/wavelength/txconfirm"
+	"github.com/lightninglabs/wavelength/unrollplan"
+	"github.com/lightninglabs/wavelength/vtxo"
+	"github.com/lightningnetwork/lnd/clock"
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// sweptSourceChain replays a historical source spend at registration, as the
+// lightweight backend does when an exit resumes after the operator swept.
+type sweptSourceChain struct {
+	*fakeChainSourceRef
+	source     wire.OutPoint
+	blocksMu   sync.Mutex
+	blocks     map[string]actor.TellOnlyRef[chainsource.BlockEpoch]
+	broadcasts atomic.Int32
+}
+
+// Ask retains all block subscribers and delivers historical spend evidence.
+func (c *sweptSourceChain) Ask(ctx context.Context,
+	msg chainsource.ChainSourceMsg,
+) actor.Future[chainsource.ChainSourceResp] {
+
+	if _, ok := msg.(*chainsource.BroadcastTxRequest); ok {
+		c.broadcasts.Add(1)
+	}
+	if req, ok := msg.(*chainsource.SubscribeBlocksRequest); ok {
+		c.blocksMu.Lock()
+		c.blocks[req.CallerID] = req.NotifyActor.UnwrapOr(nil)
+		c.blocksMu.Unlock()
+	}
+	future := c.fakeChainSourceRef.Ask(ctx, msg)
+	if req, ok := msg.(*chainsource.RegisterSpendRequest); ok &&
+		req.Outpoint != nil && *req.Outpoint == c.source {
+
+		// The durable callback may precede the registry's Resume
+		// message. Registration belongs to the actor, not this request
+		// context.
+		req.NotifyActor.WhenSome(func(ref spendEventRef) {
+			_ = ref.Tell(
+				context.WithoutCancel(ctx),
+				chainsource.SpendEvent{
+					Outpoint:       c.source,
+					SpendingTxid:   chainhash.Hash{0xaa},
+					SpendingHeight: 119,
+				},
+			)
+		})
+	}
+
+	return future
+}
+
+// emitBlock sends an epoch to every registered component, including txconfirm.
+func (c *sweptSourceChain) emitBlock(t *testing.T, height int32) {
+	t.Helper()
+	c.blocksMu.Lock()
+	refs := make(
+		[]actor.TellOnlyRef[chainsource.BlockEpoch], 0, len(c.blocks),
+	)
+	for _, ref := range c.blocks {
+		refs = append(refs, ref)
+	}
+	c.blocksMu.Unlock()
+	for _, ref := range refs {
+		// A terminal child's stale test registration may already be
+		// stopped.
+		_ = ref.Tell(
+			t.Context(), chainsource.BlockEpoch{
+				Height: height,
+			},
+		)
+	}
+}
+
+// reclaimRound captures only the client-to-round boundary; it does not pretend
+// to execute the operator's issuance protocol.
+type reclaimRound struct {
+	requests chan actormsg.RoundReceivable
+}
+
+// ID identifies the test round boundary.
+func (r *reclaimRound) ID() string { return "reclaim-round" }
+
+// Tell captures automatic refresh requests.
+func (r *reclaimRound) Tell(ctx context.Context,
+	msg actormsg.RoundReceivable) error {
+
+	select {
+	case r.requests <- msg:
+		return nil
+
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// TryTell implements the nonblocking notification surface.
+func (r *reclaimRound) TryTell(ctx context.Context,
+	msg actormsg.RoundReceivable) error {
+
+	select {
+	case r.requests <- msg:
+		return nil
+
+	case <-ctx.Done():
+		return ctx.Err()
+
+	default:
+		return actor.ErrMailboxFull
+	}
+}
+
+// anchoredMergeProof gives the two-root fixture real CPFP anchor semantics so
+// the production broadcaster retries its unfunded packages instead of treating
+// them as terminal direct-broadcast errors.
+func anchoredMergeProof(t *testing.T) *recovery.Proof {
+	t.Helper()
+	old := buildMergeProof(t)
+	target, _ := old.Node(old.TargetOutpoint().Hash)
+	targetTx := target.Tx.Copy()
+	var nodes []*recovery.Node
+	for _, txid := range old.RootTxids() {
+		node, _ := old.Node(txid)
+		tx := node.Tx.Copy()
+		tx.Version = 3
+		tx.AddTxOut(
+			&wire.TxOut{
+				PkScript: arkscript.AnchorPkScript,
+			},
+		)
+		for _, in := range targetTx.TxIn {
+			if in.PreviousOutPoint.Hash == txid {
+				in.PreviousOutPoint.Hash = tx.TxHash()
+			}
+		}
+		nodes = append(
+			nodes, &recovery.Node{
+				Kind: recovery.NodeKindTree,
+				Tx:   tx,
+			},
+		)
+	}
+	nodes = append(
+		nodes, &recovery.Node{
+			Kind: recovery.NodeKindTree,
+			Tx:   targetTx,
+		},
+	)
+	proof, err := recovery.NewProof(
+		wire.OutPoint{
+			Hash: targetTx.TxHash(),
+		},
+		2,
+		nodes...,
+	)
+	require.NoError(t, err)
+
+	return proof
+}
+
+// TestSweptSourceRestoresPersistedExit exercises the upgrade boundary using
+// production delivery, VTXO and registry stores, durable unroll actors, the
+// shared broadcaster and a fresh VTXO manager with no actor for the exit.
+func TestSweptSourceRestoresPersistedExit(t *testing.T) {
+	t.Run(
+		"exclusive",
+		func(t *testing.T) { testSweptSourceRestart(t, false) },
+	)
+	t.Run(
+		"sharedRoot",
+		func(t *testing.T) { testSweptSourceRestart(t, true) },
+	)
+}
+
+// otherExitInterest represents another exit that still needs a shared root.
+type otherExitInterest struct{}
+
+// ID is distinct from the restored unroll actor's subscriber identity.
+func (otherExitInterest) ID() string { return "other-exit" }
+
+// Tell accepts broadcaster notifications for the other exit.
+func (otherExitInterest) Tell(context.Context, txconfirm.Notification) error {
+	return nil
+}
+
+// TryTell never blocks.
+func (otherExitInterest) TryTell(context.Context,
+	txconfirm.Notification) error {
+
+	return nil
+}
+
+// testSweptSourceRestart also checks that cleanup respects shared ownership.
+func testSweptSourceRestart(t *testing.T, shared bool) {
+	t.Helper()
+	proof := anchoredMergeProof(t)
+	target := proof.TargetOutpoint()
+	desc := testDescriptor(t, target, proof.CSVDelay())
+	desc.RoundID = "swept-source-restart"
+	desc.BatchExpiry = 110
+	desc.CreatedHeight = 1
+	desc.Status = vtxo.VTXOStatusUnilateralExit
+	policy, err := arkscript.EncodeStandardVTXOTemplate(
+		desc.ClientKey.PubKey, desc.OperatorKey, proof.CSVDelay(),
+	)
+	require.NoError(t, err)
+	desc.PolicyTemplate = policy
+	sqlDB := db.NewTestDB(t)
+	clk := clock.NewDefaultClock()
+	stores := db.NewStore(
+		sqlDB.DB, sqlDB.Queries, sqlDB.Backend(), btclog.Disabled,
+	)
+	vtxos := stores.NewVTXOStore(clk)
+	require.NoError(t, vtxos.SaveVTXO(t.Context(), desc))
+	require.NoError(
+		t,
+		vtxos.UpdateVTXOStatus(
+			t.Context(), target, vtxo.VTXOStatusUnilateralExit,
+		),
+	)
+	delivery, err := actordelivery.NewTxAwareDeliveryStoreFromDB(
+		sqlDB.DB, sqlDB.Backend(), clk, btclog.Disabled,
+	)
+	require.NoError(t, err)
+	exitStore := stores.NewUnilateralExitStore(clk)
+	registryStore := &DBRegistryStore{UEStore: exitStore}
+	actorID := actorIDForTarget(target)
+	// No conflict record is encoded: this is the pre-1065 checkpoint shape.
+	raw, err := encodeCheckpoint(&actorCheckpoint{
+		Version: checkpointVersion, Height: 100, Started: true,
+		Trigger: TriggerCriticalExpiry,
+		State:   unrollplan.State{InFlightTxids: proof.RootTxids()},
+	})
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		delivery.SaveCheckpoint(
+			t.Context(), actor.CheckpointParams{
+				ActorID:   actorID,
+				StateType: checkpointStateType,
+				StateData: raw,
+				Version:   checkpointVersion,
+			},
+		),
+	)
+	require.NoError(
+		t,
+		registryStore.UpsertRecord(
+			t.Context(), RegistryRecord{
+				TargetOutpoint: target,
+				ActorID:        actorID,
+				Phase:          PhaseMaterializing,
+				Trigger:        TriggerCriticalExpiry,
+			},
+		),
+	)
+	chain := &sweptSourceChain{
+		fakeChainSourceRef: &fakeChainSourceRef{
+			bestHeight: 120,
+		},
+		source: sourceOutpoint,
+		blocks: make(
+			map[string]actor.TellOnlyRef[chainsource.BlockEpoch],
+		),
+	}
+	system := actor.NewActorSystem()
+	t.Cleanup(
+		func() {
+			require.NoError(
+				t,
+				system.Shutdown(
+					context.Background(),
+				),
+			)
+		},
+	)
+	roundRef := &reclaimRound{
+		requests: make(chan actormsg.RoundReceivable, 8),
+	}
+	manager := vtxo.NewManager(&vtxo.ManagerConfig{
+		Store: vtxos, ActorSystem: system, ChainSource: chain,
+		ChainParams:  &chaincfg.RegressionNetParams,
+		ExpiryConfig: vtxo.DefaultExpiryConfig(), RoundActor: roundRef,
+	})
+	managerKey := actor.NewServiceKey[vtxo.ManagerMsg, vtxo.ManagerResp](
+		"reclaim-manager",
+	)
+	managerRef := managerKey.Spawn(system, "reclaim-manager", manager)
+	require.NoError(t, manager.Start(t.Context(), managerRef))
+	count, err := managerRef.
+		Ask(t.Context(), &vtxo.GetActiveVTXOCountRequest{}).
+		Await(t.Context()).
+		Unpack()
+	require.NoError(t, err)
+	active, ok := count.(*vtxo.GetActiveVTXOCountResponse)
+	require.True(t, ok)
+	require.Zero(t, active.Count)
+	txBehavior := txconfirm.NewTxBroadcasterActor(txconfirm.Config{
+		ChainSource: chain, FeeBumpIntervalBlocks: 1,
+	})
+	txActor := actor.NewActor(actor.ActorConfig[
+		txconfirm.Msg,
+		txconfirm.Resp,
+	]{
+		ID: "restart-txconfirm", Behavior: txBehavior, MailboxSize: 64,
+	})
+	txBehavior.SetSelfRef(txActor.TellRef())
+	txActor.Start()
+	t.Cleanup(txActor.Stop)
+	var sharedTxid chainhash.Hash
+	if shared {
+		for _, txid := range proof.RootTxids() {
+			node, _ := proof.Node(txid)
+			if node.Tx.TxIn[0].PreviousOutPoint == sourceOutpoint {
+				continue
+			}
+			sharedTxid = txid
+			_, err := txActor.Ref().Ask(
+				t.Context(), &txconfirm.EnsureConfirmedReq{
+					Tx:         node.Tx,
+					Subscriber: otherExitInterest{},
+				},
+			).Await(t.Context()).Unpack()
+			require.NoError(t, err)
+		}
+	}
+	observer := fn.Some[actor.TellOnlyRef[vtxo.ManagerMsg]](managerRef)
+	registry := NewUnrollRegistryActor(
+		RegistryConfig{
+			Store:            registryStore,
+			DeliveryStore:    delivery,
+			ProofAssembler:   &mockProofAssembler{proof: proof},
+			VTXOStore:        vtxos,
+			TxConfirmRef:     txActor.Ref(),
+			ChainSource:      chain,
+			Wallet:           &fakeSweepWallet{},
+			VTXOExitObserver: observer,
+		},
+	)
+	t.Cleanup(registry.Stop)
+	require.NoError(t, registry.RestoreNonTerminal(t.Context()))
+	require.Eventually(t, func() bool {
+		record, err := registryStore.GetRecord(t.Context(), target)
+
+		return err == nil && record != nil && record.ConflictedFailure
+	}, 5*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		coin, err := vtxos.GetVTXO(t.Context(), target)
+
+		return err == nil && coin.Status == vtxo.VTXOStatusExpired
+	}, 5*time.Second, 10*time.Millisecond)
+	// The expired actor is not spendable but must survive to request
+	// refresh.
+	live, err := vtxos.ListLiveVTXOs(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, live)
+	chain.emitBlock(t, 121)
+	select {
+	case msg := <-roundRef.requests:
+		req, ok := msg.(*round.RefreshVTXORequest)
+		require.True(t, ok, "unexpected round request %T", msg)
+		require.Equal(t, target, req.VTXOOutpoint)
+		require.True(t, req.Automatic)
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("restored conflicted exit did not request refresh")
+	}
+	// Cleanup must remove only this unroll's broadcaster interests. A root
+	// with another owner must remain tracked and must not be
+	// wallet-removed.
+	wantRemoved := len(proof.RootTxids())
+	if shared {
+		wantRemoved--
+	}
+	require.Eventually(t, func() bool {
+		return len(chain.removedTxSnapshot()) == wantRemoved
+	}, 5*time.Second, 10*time.Millisecond)
+	// Drain the broadcaster after detached cleanup before probing
+	// ownership.
+	for _, txid := range proof.RootTxids() {
+		require.Eventually(t, func() bool {
+			resp, err := txActor.Ref().Ask(
+				t.Context(), &txconfirm.CancelInterestReq{
+					Txid:         txid,
+					SubscriberID: "not-a-subscriber",
+				},
+			).Await(t.Context()).Unpack()
+			if err != nil {
+				return false
+			}
+			want := 0
+			if shared && txid == sharedTxid {
+				want = 1
+			}
+
+			result, ok := resp.(*txconfirm.CancelInterestResp)
+
+			return ok && result.RemainingSubscribers == want
+		}, 5*time.Second, 10*time.Millisecond)
+	}
+	before := chain.broadcasts.Load()
+	chain.emitBlock(t, 122)
+	for _, txid := range proof.RootTxids() {
+		resp, err := txActor.Ref().Ask(
+			t.Context(), &txconfirm.CancelInterestReq{
+				Txid: txid, SubscriberID: "not-a-subscriber",
+			},
+		).Await(t.Context()).Unpack()
+		require.NoError(t, err)
+		result, ok := resp.(*txconfirm.CancelInterestResp)
+		require.True(t, ok)
+		require.False(
+			t, result.StoppedTracking,
+			"conflicted root still tracked after terminal cleanup",
+		)
+	}
+	if shared {
+		require.NotContains(t, chain.removedTxSnapshot(), sharedTxid)
+		require.Equal(
+			t, before+1, chain.broadcasts.Load(),
+			"only the other exit's root should retry",
+		)
+	} else {
+		require.Equal(
+			t, before, chain.broadcasts.Load(),
+			"abandoned roots retried after reclaim",
+		)
+	}
+	registry.Stop()
+	checkpoint, err := delivery.LoadCheckpoint(t.Context(), actorID)
+	require.NoError(t, err)
+	require.NotNil(t, checkpoint)
+	decoded, err := decodeCheckpoint(checkpoint.StateData)
+	require.NoError(t, err)
+	require.True(t, decoded.Conflicted)
+
+	// Terminal conflict rows must not resume on subsequent daemon starts.
+	records, err := registryStore.ListNonTerminalRecords(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, records)
+}

--- a/unroll/db_store.go
+++ b/unroll/db_store.go
@@ -145,6 +145,8 @@ func recordFromDB(job db.UnilateralExitJobRecord) RegistryRecord {
 		SweepTxid:     sweepTxidFromBytes(job.SweepTxid),
 		RecoverableFailure: job.Status ==
 			db.UnilateralExitJobStatusFailedRecoverable,
+		ConflictedFailure: job.Status ==
+			db.UnilateralExitJobStatusFailedConflicted,
 	}
 }
 
@@ -196,8 +198,15 @@ func registryExitPolicy(record RegistryRecord,
 
 // statusForRecord maps a registry record into the DB status enum, routing a
 // recoverable (no-footprint) failure to the distinct FailedRecoverable status
-// so it round-trips back to RecoverableFailure=true on the next read.
+// and a source-batch conflict to the distinct FailedConflicted status, so each
+// round-trips back to the matching flag on the next read. A conflict takes
+// precedence: it is never a recoverable no-footprint failure, and boot-time
+// reconciliation must retire the coin rather than relive it (wavelength#1050).
 func statusForRecord(record RegistryRecord) db.UnilateralExitJobStatus {
+	if record.Phase == PhaseFailed && record.ConflictedFailure {
+		return db.UnilateralExitJobStatusFailedConflicted
+	}
+
 	if record.Phase == PhaseFailed && record.RecoverableFailure {
 		return db.UnilateralExitJobStatusFailedRecoverable
 	}
@@ -254,7 +263,8 @@ func phaseFromDB(status db.UnilateralExitJobStatus) Phase {
 		return PhaseCompleted
 
 	case db.UnilateralExitJobStatusFailed,
-		db.UnilateralExitJobStatusFailedRecoverable:
+		db.UnilateralExitJobStatusFailedRecoverable,
+		db.UnilateralExitJobStatusFailedConflicted:
 		return PhaseFailed
 
 	default:

--- a/unroll/db_store.go
+++ b/unroll/db_store.go
@@ -106,27 +106,23 @@ func (s *DBRegistryStore) ListNonTerminalRecords(ctx context.Context) (
 }
 
 // MarkTerminal marks one target terminal in the unilateral-exit job table.
-// recoverable selects UnilateralExitJobStatusFailedRecoverable over the
-// plain Failed status for a no-footprint failure so boot-time reconciliation
-// can roll the VTXO back to live (wavelength#602).
+// Both failure classifications use the same mapping as UpsertRecord, so a
+// terminal update cannot lose the distinction between recovery and reclaim.
 func (s *DBRegistryStore) MarkTerminal(ctx context.Context,
-	target wire.OutPoint, phase Phase, recoverable bool, failReason string,
-	sweepTxid *chainhash.Hash) error {
+	record RegistryRecord) error {
 
 	if s == nil || s.UEStore == nil {
 		return fmt.Errorf("unilateral-exit store must be provided")
 	}
 
-	status := statusForRecord(RegistryRecord{
-		Phase:              phase,
-		RecoverableFailure: recoverable,
-	})
+	status := statusForRecord(record)
 	if !status.IsTerminal() {
-		return fmt.Errorf("phase %s is not terminal", phase)
+		return fmt.Errorf("phase %s is not terminal", record.Phase)
 	}
 
 	return s.UEStore.MarkJobTerminal(
-		ctx, target, status, failReason, sweepTxidBytes(sweepTxid),
+		ctx, record.TargetOutpoint, status, record.FailReason,
+		sweepTxidBytes(record.SweepTxid),
 	)
 }
 
@@ -201,7 +197,8 @@ func registryExitPolicy(record RegistryRecord,
 // and a source-batch conflict to the distinct FailedConflicted status, so each
 // round-trips back to the matching flag on the next read. A conflict takes
 // precedence: it is never a recoverable no-footprint failure, and boot-time
-// reconciliation must retire the coin rather than relive it (wavelength#1050).
+// reconciliation must reclaim through refresh rather than relive the old
+// lineage (wavelength#1050).
 func statusForRecord(record RegistryRecord) db.UnilateralExitJobStatus {
 	if record.Phase == PhaseFailed && record.ConflictedFailure {
 		return db.UnilateralExitJobStatusFailedConflicted

--- a/unroll/db_store_test.go
+++ b/unroll/db_store_test.go
@@ -113,6 +113,49 @@ func TestRecoverableFailureDBRoundTrip(t *testing.T) {
 	})
 }
 
+// TestConflictedFailureDBRoundTrip pins the mapping for a source-batch
+// conflict: it persists as the dedicated FailedConflicted status, decodes back
+// to ConflictedFailure=true (and NOT RecoverableFailure), and stays terminal.
+// Boot-time reconciliation relies on this to retire the coin out of pending
+// rather than relive it (wavelength#1050).
+func TestConflictedFailureDBRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rec := RegistryRecord{
+		Phase:             PhaseFailed,
+		ConflictedFailure: true,
+	}
+	status := statusForRecord(rec)
+	require.Equal(
+		t, db.UnilateralExitJobStatusFailedConflicted, status,
+	)
+	require.True(t, status.IsTerminal())
+
+	got := recordFromDB(db.UnilateralExitJobRecord{Status: status})
+	require.Equal(t, PhaseFailed, got.Phase)
+	require.True(t, got.ConflictedFailure)
+	require.False(t, got.RecoverableFailure)
+}
+
+// TestConflictTakesPrecedenceOverRecoverable guards the classification order:
+// a record flagged both conflicted and recoverable (the child never sets both,
+// but the store must fail safe) maps to FailedConflicted so the coin is retired
+// rather than relived.
+func TestConflictTakesPrecedenceOverRecoverable(t *testing.T) {
+	t.Parallel()
+
+	rec := RegistryRecord{
+		Phase:              PhaseFailed,
+		ConflictedFailure:  true,
+		RecoverableFailure: true,
+	}
+
+	require.Equal(
+		t, db.UnilateralExitJobStatusFailedConflicted,
+		statusForRecord(rec),
+	)
+}
+
 // TestTriggerDBRoundTrip pins the StartTrigger↔UnilateralExitJobTrigger
 // mapping so FraudSpend rows round-trip through a dedicated constant
 // rather than silently decoding as TriggerManual.

--- a/unroll/db_store_test.go
+++ b/unroll/db_store_test.go
@@ -3,9 +3,83 @@ package unroll
 import (
 	"testing"
 
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/db"
+	"github.com/lightningnetwork/lnd/clock"
 	"github.com/stretchr/testify/require"
 )
+
+// TestMarkTerminalPreservesOutcome exercises the production SQL update path,
+// including conflict precedence and the metadata a terminal update must retain.
+func TestMarkTerminalPreservesOutcome(t *testing.T) {
+	sqlDB := db.NewTestDB(t)
+	stores := db.NewStore(
+		sqlDB.DB, sqlDB.Queries, sqlDB.Backend(), btclog.Disabled,
+	)
+	exitStore := stores.NewUnilateralExitStore(clock.NewDefaultClock())
+	store := &DBRegistryStore{UEStore: exitStore}
+	cases := []struct {
+		name        string
+		phase       Phase
+		recoverable bool
+		conflicted  bool
+		want        db.UnilateralExitJobStatus
+	}{
+		{"completed", PhaseCompleted, false, false,
+			db.UnilateralExitJobStatusCompleted},
+		{"failed", PhaseFailed, false, false,
+			db.UnilateralExitJobStatusFailed},
+		{"recoverable", PhaseFailed, true, false,
+			db.UnilateralExitJobStatusFailedRecoverable},
+		{"conflicted", PhaseFailed, false, true,
+			db.UnilateralExitJobStatusFailedConflicted},
+		{"conflictWins", PhaseFailed, true, true,
+			db.UnilateralExitJobStatusFailedConflicted},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			target := wire.OutPoint{
+				Hash: chainhash.Hash{
+					byte(i + 1),
+				},
+			}
+			err := store.UpsertRecord(t.Context(), RegistryRecord{
+				TargetOutpoint: target,
+				ActorID:        "persisted-child",
+				Phase:          PhaseMaterializing,
+				Trigger:        TriggerCriticalExpiry,
+			})
+			require.NoError(t, err)
+			sweep := chainhash.Hash{0x55}
+			err = store.MarkTerminal(t.Context(), RegistryRecord{
+				TargetOutpoint:     target,
+				Phase:              tc.phase,
+				RecoverableFailure: tc.recoverable,
+				ConflictedFailure:  tc.conflicted,
+				FailReason:         "terminal reason",
+				SweepTxid:          &sweep,
+			})
+			require.NoError(t, err)
+			// A fresh adapter reads only the durable result.
+			restarted := &DBRegistryStore{UEStore: exitStore}
+			got, err := restarted.GetRecord(t.Context(), target)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.Equal(t, tc.want, statusForRecord(*got))
+			require.Equal(t, "persisted-child", got.ActorID)
+			require.Equal(t, TriggerCriticalExpiry, got.Trigger)
+			require.Equal(t, "terminal reason", got.FailReason)
+			require.Equal(t, &sweep, got.SweepTxid)
+			records, err := restarted.ListNonTerminalRecords(
+				t.Context(),
+			)
+			require.NoError(t, err)
+			require.Empty(t, records)
+		})
+	}
+}
 
 // TestPhaseDBRoundTrip pins the Phase<->UnilateralExitJobStatus mapping so
 // schema drift or table-entry reshuffles fail loudly rather than silently

--- a/unroll/fsm_logic.go
+++ b/unroll/fsm_logic.go
@@ -101,6 +101,7 @@ func processEventWithJob(ctx context.Context, job *JobState, event Event,
 
 	case *FailEvent:
 		nextJob.FailReason = e.Reason
+		nextJob.Conflicted = e.Conflict
 
 	case *StartEvent:
 		if e.Height > nextJob.Height {

--- a/unroll/fsm_types.go
+++ b/unroll/fsm_types.go
@@ -100,6 +100,15 @@ type JobState struct {
 	// FailReason records a terminal failure reason, if any.
 	FailReason string
 
+	// Conflicted marks a terminal failure that was caused by a confirmed
+	// spend conflicting with the recovery tree — the operator swept a
+	// source batch commitment output the exit depends on (wavelength#1050).
+	// It is persisted so the terminal handoff to the VTXO manager stays
+	// classified as a conflict (retire the coin out of pending, do not
+	// relive it) even if the child crashes after the failure checkpoint but
+	// before the registry records it.
+	Conflicted bool
+
 	// SweepAttempts counts sweep build or broadcast failures so the actor
 	// can retry up to maxSweepAttempts before giving up.
 	SweepAttempts int
@@ -120,6 +129,7 @@ func (j *JobState) Copy() *JobState {
 		PlannerState:        copyPlannerState(j.PlannerState),
 		DeferredCheckpoints: deferred,
 		FailReason:          j.FailReason,
+		Conflicted:          j.Conflicted,
 		SweepAttempts:       j.SweepAttempts,
 	}
 
@@ -217,6 +227,14 @@ func (e *SweepBroadcastedEvent) eventSealed() {}
 type FailEvent struct {
 	// Reason is the stable human-readable failure reason.
 	Reason string
+
+	// Conflict marks the failure as a source-batch conflict: a confirmed
+	// foreign spend consumed a commitment output the recovery tree depends
+	// on, so the exit is provably impossible (wavelength#1050). It is
+	// carried into JobState.Conflicted so the terminal handoff retires the
+	// VTXO out of pending rather than leaving it exit-pending or reliving
+	// it.
+	Conflict bool
 }
 
 // eventSealed marks FailEvent as an FSM event.

--- a/unroll/fsm_types.go
+++ b/unroll/fsm_types.go
@@ -104,8 +104,8 @@ type JobState struct {
 	// spend conflicting with the recovery tree — the operator swept a
 	// source batch commitment output the exit depends on (wavelength#1050).
 	// It is persisted so the terminal handoff to the VTXO manager stays
-	// classified as a conflict (retire the coin out of pending, do not
-	// relive it) even if the child crashes after the failure checkpoint but
+	// classified as a conflict (expired reclaim, not live recovery) even
+	// if the child crashes after the failure checkpoint but
 	// before the registry records it.
 	Conflicted bool
 
@@ -231,9 +231,8 @@ type FailEvent struct {
 	// Conflict marks the failure as a source-batch conflict: a confirmed
 	// foreign spend consumed a commitment output the recovery tree depends
 	// on, so the exit is provably impossible (wavelength#1050). It is
-	// carried into JobState.Conflicted so the terminal handoff retires the
-	// VTXO out of pending rather than leaving it exit-pending or reliving
-	// it.
+	// carried into JobState.Conflicted so the terminal handoff routes the
+	// VTXO to expired reclaim rather than reliving its old lineage.
 	Conflict bool
 }
 

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -86,10 +86,9 @@ type RegistryRecord struct {
 	// ConflictedFailure is set on a terminal failure caused by a confirmed
 	// spend conflicting with the recovery tree (the operator swept a source
 	// batch commitment output the exit depends on). It is persisted as a
-	// distinct DB status so boot-time reconciliation retires the target
-	// VTXO out of unilateral-exit (FAILED) — clearing it from pending
-	// balance — rather than leaving it pending forever or reliving it
-	// (wavelength#1050).
+	// distinct DB status so boot-time reconciliation routes standard-policy
+	// VTXOs to expired reclaim, rather than leaving them in exit forever or
+	// making their old lineage spendable again (wavelength#1050).
 	ConflictedFailure bool
 }
 
@@ -111,12 +110,10 @@ type RegistryStore interface {
 	// ListNonTerminalRecords returns all targets that still need restore.
 	ListNonTerminalRecords(ctx context.Context) ([]RegistryRecord, error)
 
-	// MarkTerminal persists one terminal target state. recoverable marks a
-	// no-footprint failure that boot-time reconciliation may roll back to
-	// live.
-	MarkTerminal(ctx context.Context, target wire.OutPoint, phase Phase,
-		recoverable bool, failReason string,
-		sweepTxid *chainhash.Hash) error
+	// MarkTerminal updates only the terminal outcome fields of an existing
+	// target. The record carries both failure classifications so boot-time
+	// reconciliation can distinguish live recovery from expired reclaim.
+	MarkTerminal(ctx context.Context, record RegistryRecord) error
 }
 
 // RegistryConfig configures the thin unroll registry actor.
@@ -827,8 +824,7 @@ func (r *registryBehavior) failAdmittedChild(ctx context.Context,
 	}, record.ExitPolicyKind)
 
 	markErr := r.cfg.Store.MarkTerminal(
-		context.WithoutCancel(ctx), target, PhaseFailed, true,
-		err.Error(), nil,
+		context.WithoutCancel(ctx), record,
 	)
 	if markErr != nil {
 		r.log.WarnS(ctx, "Failed to mark admitted unroll child "+
@@ -987,11 +983,9 @@ func (r *registryBehavior) handleTerminated(ctx context.Context,
 
 	// A terminal failure with no on-chain footprint is recoverable: the
 	// VTXO never left off-chain custody, so it can be rolled back to live.
-	// A source-batch conflict is a distinct, non-recoverable terminal: the
-	// coin is provably gone, so it must be retired out of pending rather
-	// than relived (wavelength#1050). The child never sets both at once,
-	// but a conflict is not a no-footprint failure, so it is never
-	// recoverable.
+	// A source-batch conflict instead requires expired reclaim: the old
+	// lineage cannot be spent, even if none of our exit transactions
+	// confirmed. Conflict therefore takes precedence over live recovery.
 	conflicted := req.Phase == PhaseFailed && req.Conflicted
 	recoverable := req.Phase == PhaseFailed && !req.HadOnChainFootprint &&
 		!conflicted
@@ -1063,8 +1057,8 @@ func (r *registryBehavior) handleTerminated(ctx context.Context,
 //     so the VTXO is still live from the operator's perspective. Ask the
 //     manager to roll it back to live (ExitOutcomeRecoverable).
 //   - PhaseFailed from a source-batch conflict: a confirmed spend consumed a
-//     commitment output the exit depends on, so the coin is provably gone.
-//     Ask the manager to retire it out of pending (ExitOutcomeConflicted).
+//     commitment output the exit depends on. Ask the manager to route a
+//     standard-policy coin to expired reclaim (ExitOutcomeConflicted).
 //   - PhaseCompleted: the exit was swept and confirmed on-chain, so ask the
 //     manager to retire the VTXO to spent (ExitOutcomeConfirmed).
 //   - PhaseFailed with an on-chain footprint but no conflict: the exit has
@@ -1091,8 +1085,9 @@ func (r *registryBehavior) notifyVTXOExit(ctx context.Context,
 
 	case req.Phase == PhaseFailed && req.Conflicted:
 		// A confirmed conflicting spend defeated the exit (the operator
-		// swept a source batch commitment output). Retire the coin out
-		// of pending rather than relive it (wavelength#1050).
+		// swept a source batch commitment output). Reclaim through a
+		// refresh rather than reliving the old lineage
+		// (wavelength#1050).
 		outcome = vtxo.ExitOutcomeConflicted
 
 	case req.Phase == PhaseFailed && !req.HadOnChainFootprint:

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -82,6 +82,15 @@ type RegistryRecord struct {
 	// reconciliation can recover a VTXO whose recovery notification was
 	// lost before the manager applied it (wavelength#602).
 	RecoverableFailure bool
+
+	// ConflictedFailure is set on a terminal failure caused by a confirmed
+	// spend conflicting with the recovery tree (the operator swept a source
+	// batch commitment output the exit depends on). It is persisted as a
+	// distinct DB status so boot-time reconciliation retires the target
+	// VTXO out of unilateral-exit (FAILED) — clearing it from pending
+	// balance — rather than leaving it pending forever or reliving it
+	// (wavelength#1050).
+	ConflictedFailure bool
 }
 
 // IsTerminal reports whether the record reached a terminal phase.
@@ -978,7 +987,14 @@ func (r *registryBehavior) handleTerminated(ctx context.Context,
 
 	// A terminal failure with no on-chain footprint is recoverable: the
 	// VTXO never left off-chain custody, so it can be rolled back to live.
-	recoverable := req.Phase == PhaseFailed && !req.HadOnChainFootprint
+	// A source-batch conflict is a distinct, non-recoverable terminal: the
+	// coin is provably gone, so it must be retired out of pending rather
+	// than relived (wavelength#1050). The child never sets both at once,
+	// but a conflict is not a no-footprint failure, so it is never
+	// recoverable.
+	conflicted := req.Phase == PhaseFailed && req.Conflicted
+	recoverable := req.Phase == PhaseFailed && !req.HadOnChainFootprint &&
+		!conflicted
 
 	record := RegistryRecord{
 		TargetOutpoint:     req.Outpoint,
@@ -987,6 +1003,7 @@ func (r *registryBehavior) handleTerminated(ctx context.Context,
 		FailReason:         req.FailReason,
 		SweepTxid:          copyHash(req.SweepTxid),
 		RecoverableFailure: recoverable,
+		ConflictedFailure:  conflicted,
 	}
 
 	if cached, ok := r.pending[req.Outpoint]; ok {
@@ -995,6 +1012,7 @@ func (r *registryBehavior) handleTerminated(ctx context.Context,
 		record.FailReason = req.FailReason
 		record.SweepTxid = copyHash(req.SweepTxid)
 		record.RecoverableFailure = recoverable
+		record.ConflictedFailure = conflicted
 		if record.ActorID == "" {
 			record.ActorID = req.ActorID
 		}
@@ -1044,10 +1062,13 @@ func (r *registryBehavior) handleTerminated(ctx context.Context,
 //   - PhaseFailed with no on-chain footprint: the unroll never broadcast,
 //     so the VTXO is still live from the operator's perspective. Ask the
 //     manager to roll it back to live (ExitOutcomeRecoverable).
+//   - PhaseFailed from a source-batch conflict: a confirmed spend consumed a
+//     commitment output the exit depends on, so the coin is provably gone.
+//     Ask the manager to retire it out of pending (ExitOutcomeConflicted).
 //   - PhaseCompleted: the exit was swept and confirmed on-chain, so ask the
 //     manager to retire the VTXO to spent (ExitOutcomeConfirmed).
-//   - PhaseFailed with an on-chain footprint: the exit has begun on-chain;
-//     leave the VTXO in unilateral-exit (no notification).
+//   - PhaseFailed with an on-chain footprint but no conflict: the exit has
+//     begun on-chain; leave the VTXO in unilateral-exit (no notification).
 //
 // Delivery is best-effort: a failed Tell is logged, not retried. This is the
 // fast runtime path; the durable backstop is the VTXO manager's startup
@@ -1067,6 +1088,12 @@ func (r *registryBehavior) notifyVTXOExit(ctx context.Context,
 	switch {
 	case req.Phase == PhaseCompleted:
 		outcome = vtxo.ExitOutcomeConfirmed
+
+	case req.Phase == PhaseFailed && req.Conflicted:
+		// A confirmed conflicting spend defeated the exit (the operator
+		// swept a source batch commitment output). Retire the coin out
+		// of pending rather than relive it (wavelength#1050).
+		outcome = vtxo.ExitOutcomeConflicted
 
 	case req.Phase == PhaseFailed && !req.HadOnChainFootprint:
 		outcome = vtxo.ExitOutcomeRecoverable
@@ -1753,7 +1780,8 @@ func sameRegistryRecord(a, b RegistryRecord) bool {
 		a.ExitPolicyRef != b.ExitPolicyRef ||
 		a.Phase != b.Phase ||
 		a.FailReason != b.FailReason ||
-		a.RecoverableFailure != b.RecoverableFailure {
+		a.RecoverableFailure != b.RecoverableFailure ||
+		a.ConflictedFailure != b.ConflictedFailure {
 		return false
 	}
 

--- a/unroll/registry_exit_test.go
+++ b/unroll/registry_exit_test.go
@@ -214,6 +214,46 @@ func TestRegistryForwardsCompletionAsConfirmed(t *testing.T) {
 	require.Equal(t, vtxo.ExitOutcomeConfirmed, notes[0].Outcome)
 }
 
+// TestRegistryForwardsSourceConflictAsConflicted verifies a terminal failure
+// flagged as a source-batch conflict is forwarded as ExitOutcomeConflicted —
+// even though it has an on-chain footprint — so the VTXO manager retires the
+// coin out of pending rather than leaving it exit-pending forever
+// (wavelength#1050). It also pins the durable record to ConflictedFailure so a
+// restart reconciles the same outcome.
+func TestRegistryForwardsSourceConflictAsConflicted(t *testing.T) {
+	target := wire.OutPoint{Hash: chainhash.Hash{5}, Index: 0}
+	behavior, observer := newExitObserverRegistry(target)
+
+	const reason = "source batch was swept by the operator; unilateral " +
+		"exit is no longer possible"
+	_, err := behavior.handleTerminated(t.Context(), &UnrollTerminatedMsg{
+		Outpoint:   target,
+		ActorID:    actorIDForTarget(target),
+		Phase:      PhaseFailed,
+		FailReason: reason,
+		// A conflict has broadcast the doomed root, so it bears a
+		// footprint — yet it must still be forwarded (not held in
+		// exit).
+		HadOnChainFootprint: true,
+		Conflicted:          true,
+	}).Unpack()
+	require.NoError(t, err)
+
+	notes := observer.notifications()
+	require.Len(t, notes, 1)
+	require.Equal(t, target, notes[0].Outpoint)
+	require.Equal(t, vtxo.ExitOutcomeConflicted, notes[0].Outcome)
+	require.Equal(t, reason, notes[0].Reason)
+
+	// The durable record is classified conflicted (and not recoverable), so
+	// boot-time reconciliation retires the coin rather than reliving it.
+	// The record→DB-status mapping itself is pinned in db_store_test.go.
+	persisted, ok := behavior.pending[target]
+	require.True(t, ok)
+	require.True(t, persisted.ConflictedFailure)
+	require.False(t, persisted.RecoverableFailure)
+}
+
 // TestRegistryRecoversCleanFailureEndToEnd is the in-process integration test
 // for the wavelength#602 recovery path. Unlike the unit tests above (which
 // call handleTerminated directly with a synthetic UnrollTerminatedMsg), this

--- a/unroll/registry_exit_test.go
+++ b/unroll/registry_exit_test.go
@@ -545,9 +545,12 @@ func TestRegistryReadmitsTargetAfterRecoverableFailureAcrossRestart(
 	// FailedRecoverable terminal record on disk, with no in-memory registry
 	// state (the process restarted). Boot reconciliation has already rolled
 	// the VTXO back to live; this stale record is the only artifact left.
-	err := store.MarkTerminal(
-		t.Context(), target, PhaseFailed, true, "min relay fee", nil,
-	)
+	err := store.MarkTerminal(t.Context(), RegistryRecord{
+		TargetOutpoint:     target,
+		Phase:              PhaseFailed,
+		RecoverableFailure: true,
+		FailReason:         "min relay fee",
+	})
 	require.NoError(t, err)
 
 	seeded, err := store.GetRecord(t.Context(), target)

--- a/unroll/registry_messages.go
+++ b/unroll/registry_messages.go
@@ -169,6 +169,14 @@ type UnrollTerminatedMsg struct {
 	// recovery-only target is held in exit rather than relived as a live
 	// coin on a recoverable failure (wavelength#602).
 	ExitPolicyKind ExitPolicyKind
+
+	// Conflicted reports that the terminal failure was a source-batch
+	// conflict — a confirmed foreign spend consumed a commitment output the
+	// recovery tree depends on, so the exit is provably impossible
+	// (wavelength#1050). The registry maps it to ExitOutcomeConflicted so
+	// the VTXO manager retires the coin out of pending (FAILED) rather than
+	// leaving it exit-pending forever or reliving it as live.
+	Conflicted bool
 }
 
 // MessageType returns the stable message type identifier.

--- a/unroll/registry_messages.go
+++ b/unroll/registry_messages.go
@@ -174,8 +174,8 @@ type UnrollTerminatedMsg struct {
 	// conflict — a confirmed foreign spend consumed a commitment output the
 	// recovery tree depends on, so the exit is provably impossible
 	// (wavelength#1050). The registry maps it to ExitOutcomeConflicted so
-	// the VTXO manager retires the coin out of pending (FAILED) rather than
-	// leaving it exit-pending forever or reliving it as live.
+	// the VTXO manager routes standard-policy coins to expired reclaim,
+	// keeping the actor alive without making the old lineage spendable.
 	Conflicted bool
 }
 

--- a/unroll/registry_test.go
+++ b/unroll/registry_test.go
@@ -84,20 +84,20 @@ func (s *memRegistryStore) ListNonTerminalRecords(_ context.Context) (
 }
 
 // MarkTerminal records one terminal phase.
-func (s *memRegistryStore) MarkTerminal(_ context.Context, target wire.OutPoint,
-	phase Phase, recoverable bool, failReason string,
-	sweepTxid *chainhash.Hash) error {
+func (s *memRegistryStore) MarkTerminal(_ context.Context,
+	terminal RegistryRecord) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record := s.records[target]
-	record.TargetOutpoint = target
-	record.Phase = phase
-	record.RecoverableFailure = recoverable
-	record.FailReason = failReason
-	record.SweepTxid = copyHash(sweepTxid)
-	s.records[target] = record
+	record := s.records[terminal.TargetOutpoint]
+	record.TargetOutpoint = terminal.TargetOutpoint
+	record.Phase = terminal.Phase
+	record.RecoverableFailure = terminal.RecoverableFailure
+	record.ConflictedFailure = terminal.ConflictedFailure
+	record.FailReason = terminal.FailReason
+	record.SweepTxid = copyHash(terminal.SweepTxid)
+	s.records[terminal.TargetOutpoint] = record
 
 	return nil
 }

--- a/unroll/snapshot.go
+++ b/unroll/snapshot.go
@@ -93,6 +93,13 @@ const (
 	// checkpointExitPolicyRefRecordType carries the policy-specific
 	// durable-state reference.
 	checkpointExitPolicyRefRecordType tlv.Type = 21
+
+	// checkpointConflictedRecordType is optional; present (a 1-byte true)
+	// only when the terminal failure was a source-batch conflict — the
+	// operator swept a commitment output the exit depends on. It is omitted
+	// entirely when false so a non-conflicted checkpoint encodes to the
+	// same bytes it did before this field existed (wavelength#1050).
+	checkpointConflictedRecordType tlv.Type = 23
 )
 
 // actorCheckpoint is the durable checkpoint shape for one VTXO unroll actor.
@@ -106,6 +113,7 @@ type actorCheckpoint struct {
 	ExitPolicyRef       string
 	SweepTx             *wire.MsgTx
 	Fail                string
+	Conflicted          bool
 	SweepAttempts       int
 	DeferredCheckpoints []DeferredCheckpoint
 }
@@ -226,6 +234,19 @@ func encodeCheckpoint(value *actorCheckpoint) ([]byte, error) {
 		)
 	}
 
+	// Conflicted (type 23) is the highest record type, so it is appended
+	// last to keep records in the ascending order tlv.NewStream requires.
+	// It is emitted only when true, so a non-conflicted checkpoint is
+	// byte-for- byte identical to one written before this field existed.
+	if value.Conflicted {
+		conflicted := uint8(1)
+		records = append(
+			records, tlv.MakePrimitiveRecord(
+				checkpointConflictedRecordType, &conflicted,
+			),
+		)
+	}
+
 	stream, err := tlv.NewStream(records...)
 	if err != nil {
 		return nil, fmt.Errorf("create checkpoint stream: %w", err)
@@ -266,6 +287,7 @@ func decodeCheckpoint(raw []byte) (*actorCheckpoint, error) {
 		deferredBytes []byte
 		policyKind    []byte
 		policyRef     []byte
+		conflicted    uint8
 	)
 
 	stream, err := tlv.NewStream(
@@ -301,6 +323,9 @@ func decodeCheckpoint(raw []byte) (*actorCheckpoint, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			checkpointExitPolicyRefRecordType, &policyRef,
+		),
+		tlv.MakePrimitiveRecord(
+			checkpointConflictedRecordType, &conflicted,
 		),
 	)
 	if err != nil {
@@ -356,6 +381,10 @@ func decodeCheckpoint(raw []byte) (*actorCheckpoint, error) {
 
 	if _, ok := parsed[checkpointFailRecordType]; ok {
 		checkpoint.Fail = string(failBytes)
+	}
+
+	if _, ok := parsed[checkpointConflictedRecordType]; ok {
+		checkpoint.Conflicted = conflicted != 0
 	}
 
 	if _, ok := parsed[checkpointDeferredCheckpointsRecordType]; ok {

--- a/unroll/snapshot_test.go
+++ b/unroll/snapshot_test.go
@@ -111,6 +111,24 @@ func TestCheckpointCodecRoundTripHandcrafted(t *testing.T) {
 				}},
 			},
 		},
+		{
+			name: "failed_conflicted",
+			checkpoint: &actorCheckpoint{
+				Version: checkpointVersion,
+				Height:  314626,
+				Started: true,
+				Trigger: TriggerManual,
+				State: unrollplan.State{
+					InFlightTxids: []chainhash.Hash{
+						targetTxid,
+					},
+				},
+				Fail: "source batch swept by the operator; " +
+					"unilateral exit is no longer possible",
+				Conflicted:    true,
+				SweepAttempts: 0,
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -133,6 +151,37 @@ func TestCheckpointCodecRoundTripHandcrafted(t *testing.T) {
 			)
 		})
 	}
+}
+
+// TestCheckpointConflictedRecordOmittedWhenFalse guards backward
+// compatibility: a non-conflicted checkpoint must encode without the
+// conflicted record, so it is byte-identical to one written before the field
+// existed. Only a true value adds the record (wavelength#1050).
+func TestCheckpointConflictedRecordOmittedWhenFalse(t *testing.T) {
+	base := &actorCheckpoint{
+		Version: checkpointVersion,
+		Height:  100,
+		Started: true,
+		Trigger: TriggerManual,
+		State:   unrollplan.State{},
+		Fail:    "some failure",
+	}
+
+	notConflicted, err := encodeCheckpoint(base)
+	require.NoError(t, err)
+
+	base.Conflicted = true
+	conflicted, err := encodeCheckpoint(base)
+	require.NoError(t, err)
+
+	// The false encoding omits the record entirely; the true encoding is
+	// strictly longer by exactly that record.
+	require.Less(t, len(notConflicted), len(conflicted))
+
+	// The false encoding round-trips to Conflicted=false.
+	decoded, err := decodeCheckpoint(notConflicted)
+	require.NoError(t, err)
+	require.False(t, decoded.Conflicted)
 }
 
 // TestCheckpointCodecVersionMismatch verifies that a checkpoint encoded with
@@ -572,6 +621,7 @@ func requireCheckpointEqual(t *testing.T, want, got *actorCheckpoint) {
 	require.Equal(t, want.Started, got.Started)
 	require.Equal(t, want.Trigger, got.Trigger)
 	require.Equal(t, want.Fail, got.Fail)
+	require.Equal(t, want.Conflicted, got.Conflicted)
 	require.Equal(t, want.SweepAttempts, got.SweepAttempts)
 	require.ElementsMatch(
 		t, want.DeferredCheckpoints, got.DeferredCheckpoints,

--- a/unroll/state_snapshot.go
+++ b/unroll/state_snapshot.go
@@ -39,6 +39,7 @@ func checkpointFromState(state State, sweepTx *wire.MsgTx) *actorCheckpoint {
 		checkpoint.State.Sweep.Txid = fn.Some(*sweepTxid)
 	}
 	checkpoint.Fail = job.FailReason
+	checkpoint.Conflicted = job.Conflicted
 	checkpoint.SweepAttempts = job.SweepAttempts
 
 	return checkpoint
@@ -109,6 +110,7 @@ func stateFromCheckpoint(checkpoint *actorCheckpoint) State {
 		PlannerState:        copyPlannerState(checkpoint.State),
 		DeferredCheckpoints: deferred,
 		FailReason:          checkpoint.Fail,
+		Conflicted:          checkpoint.Conflicted,
 		SweepAttempts:       checkpoint.SweepAttempts,
 	}
 

--- a/vtxo/actor.go
+++ b/vtxo/actor.go
@@ -1126,11 +1126,9 @@ func statusToState(ctx context.Context, vtxo *Descriptor, store VTXOStore,
 
 	case VTXOStatusExpired:
 		// Non-terminal: the actor is restored so the VTXO can still be
-		// forfeited into a round to recover its value.
-		return &ExpiredState{
-			VTXO:           vtxo,
-			ObservedHeight: vtxo.CreatedHeight,
-		}
+		// forfeited into a round to recover its value. The observation
+		// height is not persisted; creation height cannot substitute.
+		return &ExpiredState{VTXO: vtxo}
 
 	case VTXOStatusPendingForfeit:
 		return &PendingForfeitState{VTXO: vtxo, RequestedAtHeight: 0}

--- a/vtxo/actor_test.go
+++ b/vtxo/actor_test.go
@@ -1034,6 +1034,26 @@ func TestStatusToStateSpent(t *testing.T) {
 	require.True(t, spentState.IsTerminal())
 }
 
+// TestStatusToStateExpiredKeepsHeightUnknown prevents a restart from claiming
+// that expiry was observed at the VTXO's much earlier creation height.
+func TestStatusToStateExpiredKeepsHeightUnknown(t *testing.T) {
+	h := newVTXOTestHarness(t)
+	desc := h.newTestDescriptor()
+	desc.Status = VTXOStatusExpired
+	state := statusToState(h.ctx, desc, h.store, btclog.Disabled)
+	expired, ok := state.(*ExpiredState)
+	require.True(t, ok)
+	require.Zero(t, expired.ObservedHeight)
+
+	// Replayed conflict delivery is harmless before the first epoch.
+	transition, err := expired.ProcessEvent(
+		h.ctx, &ExitConflictedEvent{}, nil,
+	)
+	require.NoError(t, err)
+	require.Same(t, expired, transition.NextState)
+	require.True(t, transition.NewEvents.IsNone())
+}
+
 // TestStatusToStatePendingForfeit verifies statusToState returns
 // PendingForfeitState for VTXOs persisted as VTXOStatusPendingForfeit.
 // This validates that cooperative-claim reservations survive restarts.

--- a/vtxo/events.go
+++ b/vtxo/events.go
@@ -213,16 +213,14 @@ func (e *ExitConfirmedEvent) MessageType() string {
 // ExitConflictedEvent is delivered to a VTXO actor in UnilateralExitState when
 // the downstream unroll job terminated because a confirmed foreign spend
 // conflicts with the recovery tree — the operator swept a source batch
-// commitment output the exit depends on (wavelength#1050). The VTXO is retired
-// to the terminal FailedState and the actor is reaped: the exit is provably
-// impossible, so the coin must leave pending balance and read as FAILED, but it
-// must NOT roll back to live (as a clean recoverable failure would) because the
-// operator has taken the underlying output.
+// commitment output the exit depends on (wavelength#1050). The VTXO moves to
+// the non-terminal ExpiredState: its old lineage is unusable, but the actor
+// stays alive to recover the value through an ordinary refresh. It must not
+// return directly to LiveState as a clean, no-footprint exit failure would.
 type ExitConflictedEvent struct {
 	actor.BaseMessage
 
-	// Reason explains the conflict, for logging and the failed VTXO's audit
-	// trail.
+	// Reason explains why the exit failed and the VTXO needs reclaim.
 	Reason string
 }
 

--- a/vtxo/events.go
+++ b/vtxo/events.go
@@ -209,3 +209,27 @@ func (e *ExitConfirmedEvent) VTXOActorMsg() {}
 func (e *ExitConfirmedEvent) MessageType() string {
 	return "ExitConfirmedEvent"
 }
+
+// ExitConflictedEvent is delivered to a VTXO actor in UnilateralExitState when
+// the downstream unroll job terminated because a confirmed foreign spend
+// conflicts with the recovery tree — the operator swept a source batch
+// commitment output the exit depends on (wavelength#1050). The VTXO is retired
+// to the terminal FailedState and the actor is reaped: the exit is provably
+// impossible, so the coin must leave pending balance and read as FAILED, but it
+// must NOT roll back to live (as a clean recoverable failure would) because the
+// operator has taken the underlying output.
+type ExitConflictedEvent struct {
+	actor.BaseMessage
+
+	// Reason explains the conflict, for logging and the failed VTXO's audit
+	// trail.
+	Reason string
+}
+
+// VTXOActorMsg implements actormsg.VTXOActorMsg marker interface.
+func (e *ExitConflictedEvent) VTXOActorMsg() {}
+
+// MessageType returns the message type for logging.
+func (e *ExitConflictedEvent) MessageType() string {
+	return "ExitConflictedEvent"
+}

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -1440,7 +1440,7 @@ func (m *Manager) confirmExitedVTXO(ctx context.Context,
 	return fn.Ok[ManagerResp](&ExitOutcomeResp{})
 }
 
-// conflictExitedVTXO retires a VTXO to the terminal FailedState after its
+// conflictExitedVTXO routes a VTXO to expired reclaim after its
 // unilateral exit was defeated by a confirmed conflicting spend — the operator
 // swept a source batch commitment output the recovery tree depends on, so the
 // unilateral exit is provably impossible (wavelength#1050). The operator can

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -1276,6 +1276,9 @@ func (m *Manager) handleExitOutcome(ctx context.Context,
 	case ExitOutcomeConfirmed:
 		return m.confirmExitedVTXO(ctx, req)
 
+	case ExitOutcomeConflicted:
+		return m.conflictExitedVTXO(ctx, req)
+
 	default:
 		return fn.Err[ManagerResp](
 			fmt.Errorf("unknown exit outcome: %d", req.Outcome),
@@ -1433,6 +1436,102 @@ func (m *Manager) confirmExitedVTXO(ctx context.Context,
 			fmt.Errorf("persist spent status: %w", err),
 		)
 	}
+
+	return fn.Ok[ManagerResp](&ExitOutcomeResp{})
+}
+
+// conflictExitedVTXO retires a VTXO to the terminal FailedState after its
+// unilateral exit was defeated by a confirmed conflicting spend — the operator
+// swept a source batch commitment output the recovery tree depends on, so the
+// unilateral exit is provably impossible (wavelength#1050). The operator can
+// only sweep that output past batch expiry, so the coin is expired, not lost:
+// its value is still recoverable through the ordinary refresh path
+// (wavelength#1000). Unlike confirmExitedVTXO the exit did NOT succeed, and
+// unlike a terminal failure the value is NOT gone — so the VTXO is routed to
+// the non-terminal ExpiredState (quarantined from coin selection, reclaimed by
+// the next block epoch) rather than the terminal FailedState. When the actor is
+// alive it drives the ExitConflictedEvent through the FSM; otherwise it
+// re-materializes an expired actor from the persisted descriptor so a daemon
+// that restarted mid-exit still reclaims the coin.
+func (m *Manager) conflictExitedVTXO(ctx context.Context,
+	req *ExitOutcomeNotification) fn.Result[ManagerResp] {
+
+	// A recovery-only target (a non-standard exit policy, e.g. a vHTLC
+	// refund) must never be reclaimed into the live coin set: it is a
+	// swap-contract output, not spendable wallet liquidity, so refreshing
+	// it into a round would be wrong. Hold it in UnilateralExit and let the
+	// owning recovery subsystem decide the terminal outcome, mirroring
+	// recoverExitedVTXO's recovery-only guard.
+	if req.ExitPolicyKind.Valid() {
+		m.logger(ctx).InfoS(ctx, "Holding recovery-only VTXO in exit "+
+			"after source-batch conflict",
+			slog.String("outpoint", req.Outpoint.String()),
+			slog.String(
+				"exit_policy_kind", string(req.ExitPolicyKind),
+			),
+			slog.String("reason", req.Reason),
+		)
+
+		return fn.Ok[ManagerResp](&ExitOutcomeResp{})
+	}
+
+	if actorRef, ok := m.actors[req.Outpoint]; ok {
+		_, err := m.askVTXOActor(ctx, actorRef, &ExitConflictedEvent{
+			Reason: req.Reason,
+		}).Unpack()
+		if err != nil {
+			return fn.Err[ManagerResp](
+				fmt.Errorf("ask exit-conflicted: %w", err),
+			)
+		}
+
+		return fn.Ok[ManagerResp](&ExitOutcomeResp{})
+	}
+
+	// No live actor: re-materialize one in ExpiredState from the persisted
+	// descriptor. This covers the restart case where an exiting VTXO was
+	// not part of the live-recovery set, so no actor was spawned at Start.
+	// Only act on a VTXO still in the exit state so a re-delivered conflict
+	// cannot stomp a VTXO that has since been reissued or recovered.
+	descriptor, err := m.cfg.Store.GetVTXO(ctx, req.Outpoint)
+	if err != nil {
+		return fn.Err[ManagerResp](
+			fmt.Errorf("load vtxo for conflict: %w", err),
+		)
+	}
+	if descriptor == nil || descriptor.Status != VTXOStatusUnilateralExit {
+		return fn.Ok[ManagerResp](&ExitOutcomeResp{})
+	}
+
+	// Spawn the expired actor BEFORE persisting the status flip, mirroring
+	// recoverExitedVTXO: the actor is what drives the reclaim, so if we
+	// persisted Expired first and the spawn then failed, the VTXO would be
+	// expired in the DB with nothing reclaiming it until the next restart.
+	// A failed status write is re-converged by boot reconciliation (the
+	// VTXO stays in unilateral-exit on disk, so the next boot re-drives
+	// this).
+	descriptor.Status = VTXOStatusExpired
+
+	ref, err := m.spawnVTXOActor(ctx, descriptor)
+	if err != nil {
+		return fn.Err[ManagerResp](
+			fmt.Errorf("respawn conflicted vtxo actor: %w", err),
+		)
+	}
+	m.actors[req.Outpoint] = ref
+
+	if err := m.cfg.Store.UpdateVTXOStatus(
+		ctx, req.Outpoint, VTXOStatusExpired,
+	); err != nil {
+		return fn.Err[ManagerResp](
+			fmt.Errorf("persist expired status: %w", err),
+		)
+	}
+
+	m.logger(ctx).InfoS(ctx, "Routed conflicted exit to expired reclaim",
+		slog.String("outpoint", req.Outpoint.String()),
+		slog.String("reason", req.Reason),
+	)
 
 	return fn.Ok[ManagerResp](&ExitOutcomeResp{})
 }

--- a/vtxo/manager_exit_test.go
+++ b/vtxo/manager_exit_test.go
@@ -84,6 +84,127 @@ func TestHandleExitOutcomeConfirmedDrivesActorToSpent(t *testing.T) {
 	)
 }
 
+// TestHandleExitOutcomeConflictedDrivesActorToExpired verifies a source-batch
+// conflict drives the live actor's FSM to the non-terminal ExpiredState — not
+// back to live (as a recoverable failure would), not to spent, and not to a
+// terminal Failed — so the coin is quarantined from coin selection but stays
+// reclaimable through the ordinary refresh path (wavelength#1050 / #1000).
+func TestHandleExitOutcomeConflictedDrivesActorToExpired(t *testing.T) {
+	t.Parallel()
+
+	vtxo := makeDescriptor(t, 30_745, 1)
+	mgr, _, ref := newExitTestManager(t, vtxo, &UnilateralExitState{
+		VTXO:   vtxo,
+		Reason: "manual unroll",
+	})
+
+	resp := mgr.Receive(t.Context(), &ExitOutcomeNotification{
+		Outpoint: vtxo.Outpoint,
+		Outcome:  ExitOutcomeConflicted,
+		Reason:   "source batch swept by the operator",
+	})
+	_, err := resp.Unpack()
+	require.NoError(t, err)
+
+	require.IsType(
+		t, &ExpiredState{}, ref.state,
+		"conflicted outcome should route the actor to expired reclaim",
+	)
+}
+
+// TestHandleExitOutcomeConflictedHoldsRecoveryOnlyTarget verifies that a
+// source-batch conflict does NOT reclaim a recovery-only target (a non-standard
+// exit policy, e.g. a vHTLC refund) into the wallet: refreshing a swap-contract
+// output would be wrong, so the live actor is held in UnilateralExitState and
+// the owning recovery subsystem decides the terminal outcome.
+func TestHandleExitOutcomeConflictedHoldsRecoveryOnlyTarget(t *testing.T) {
+	t.Parallel()
+
+	vtxo := makeDescriptor(t, 1_799, 8)
+	mgr, _, ref := newExitTestManager(t, vtxo, &UnilateralExitState{
+		VTXO:   vtxo,
+		Reason: "vhtlc recovery",
+	})
+
+	resp := mgr.Receive(t.Context(), &ExitOutcomeNotification{
+		Outpoint:       vtxo.Outpoint,
+		Outcome:        ExitOutcomeConflicted,
+		Reason:         "source batch swept by the operator",
+		ExitPolicyKind: actormsg.ExitPolicyVHTLCRefundWithoutReceiver,
+	})
+	_, err := resp.Unpack()
+	require.NoError(t, err)
+
+	require.IsType(
+		t, &UnilateralExitState{}, ref.state,
+		"recovery-only target must not be reclaimed via refresh",
+	)
+}
+
+// TestHandleExitOutcomeConflictedNoActorHoldsRecoveryOnlyTarget verifies the
+// store-fallback path also holds a recovery-only target: with no live actor,
+// the conflicted outcome must not load the descriptor or spawn/persist. The
+// guard short-circuits before any store access.
+func TestHandleExitOutcomeConflictedNoActorHoldsRecoveryOnlyTarget(
+	t *testing.T) {
+
+	t.Parallel()
+
+	vtxo := makeDescriptor(t, 1_799, 10)
+	vtxo.Status = VTXOStatusUnilateralExit
+	store := &MockVTXOStore{}
+	mgr := &Manager{
+		cfg: &ManagerConfig{
+			Store: store,
+		},
+		actors: make(map[wire.OutPoint]VTXOActorRef),
+	}
+
+	resp := mgr.Receive(t.Context(), &ExitOutcomeNotification{
+		Outpoint:       vtxo.Outpoint,
+		Outcome:        ExitOutcomeConflicted,
+		ExitPolicyKind: actormsg.ExitPolicyVHTLCRefundWithoutReceiver,
+	})
+	_, err := resp.Unpack()
+	require.NoError(t, err)
+
+	store.AssertNotCalled(t, "GetVTXO")
+	store.AssertNotCalled(t, "UpdateVTXOStatus")
+}
+
+// TestHandleExitOutcomeConflictedNoActorSkipsNonExiting verifies the
+// idempotency guard on the store-fallback path: a re-delivered conflict for a
+// VTXO that has since moved off the exit state (e.g. already reissued or
+// recovered) is a no-op — it must not spawn an actor or overwrite the status.
+func TestHandleExitOutcomeConflictedNoActorSkipsNonExiting(t *testing.T) {
+	t.Parallel()
+
+	vtxo := makeDescriptor(t, 30_745, 9)
+	vtxo.Status = VTXOStatusLive
+	store := &MockVTXOStore{}
+	mgr := &Manager{
+		cfg: &ManagerConfig{
+			Store: store,
+		},
+		actors: make(map[wire.OutPoint]VTXOActorRef),
+	}
+
+	// The conflict path loads the descriptor to guard against reclaiming a
+	// VTXO that has since moved off the exit state.
+	store.On("GetVTXO", t.Context(), vtxo.Outpoint).Return(vtxo, nil)
+
+	resp := mgr.Receive(t.Context(), &ExitOutcomeNotification{
+		Outpoint: vtxo.Outpoint,
+		Outcome:  ExitOutcomeConflicted,
+		Reason:   "source batch swept by the operator",
+	})
+	_, err := resp.Unpack()
+	require.NoError(t, err)
+
+	store.AssertExpectations(t)
+	store.AssertNotCalled(t, "UpdateVTXOStatus")
+}
+
 // TestHandleExitOutcomeRecoverableHoldsRecoveryOnlyTarget verifies that a
 // recoverable exit failure does NOT relive a recovery-only target (a
 // non-standard exit policy, e.g. a vHTLC refund) into the live coin set: the

--- a/vtxo/messages.go
+++ b/vtxo/messages.go
@@ -182,6 +182,18 @@ const (
 	// confirmed on-chain, so the VTXO should be retired to the terminal
 	// SpentState.
 	ExitOutcomeConfirmed
+
+	// ExitOutcomeConflicted indicates the unilateral exit is provably
+	// impossible because a confirmed foreign spend conflicts with the
+	// recovery tree — the operator swept a source batch commitment output
+	// the exit depends on (wavelength#1050). The exit did NOT succeed
+	// (unlike ExitOutcomeConfirmed), but the coin is NOT lost: the operator
+	// can only sweep that output past batch expiry, so the VTXO is expired
+	// and its value is still recoverable through the ordinary refresh path
+	// (wavelength#1000). The VTXO manager routes it to the non-terminal
+	// ExpiredState — quarantined from coin selection, reclaimed by the next
+	// block epoch — rather than retiring it to a terminal FailedState.
+	ExitOutcomeConflicted
 )
 
 // String returns a human-readable label for the exit outcome.
@@ -192,6 +204,9 @@ func (o ExitOutcome) String() string {
 
 	case ExitOutcomeConfirmed:
 		return "confirmed"
+
+	case ExitOutcomeConflicted:
+		return "conflicted"
 
 	default:
 		return "unknown"

--- a/vtxo/states.go
+++ b/vtxo/states.go
@@ -276,6 +276,8 @@ type ExpiredState struct {
 	VTXO *Descriptor
 
 	// ObservedHeight is the chain height at which expiry was established.
+	// Zero means unknown until the next block epoch, as after restart or
+	// a conflict outcome that carries no observation height.
 	ObservedHeight int32
 }
 

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -1619,10 +1619,12 @@ func (s *UnilateralExitState) ProcessEvent(ctx context.Context, event VTXOEvent,
 			slog.String("reason", evt.Reason),
 		)
 
+		// The outcome carries no observation height. Leave it unknown
+		// until a block epoch arrives instead of reusing exit
+		// admission.
 		return &VTXOStateTransition{
 			NextState: &ExpiredState{
-				VTXO:           s.VTXO,
-				ObservedHeight: s.LastCheckedHeight,
+				VTXO: s.VTXO,
 			},
 			NewEvents: fn.Some(VTXOEmittedEvent{
 				Outbox: []VTXOOutMsg{
@@ -1799,7 +1801,7 @@ func (s *ExpiredState) ProcessEvent(ctx context.Context, event VTXOEvent,
 		}, nil
 
 	case *SpendReleasedEvent, *SpendCompletedEvent, *ForfeitReleasedEvent,
-		*ExitFailedEvent, *ExitConfirmedEvent:
+		*ExitFailedEvent, *ExitConfirmedEvent, *ExitConflictedEvent:
 		// Stale events from a path that ran before this VTXO expired.
 		// An expired VTXO is long-lived, so these can arrive well
 		// after the fact; absorbing them keeps the actor alive without

--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -113,13 +113,14 @@ func (s *LiveState) ProcessEvent(ctx context.Context, event VTXOEvent,
 	case *ForceUnrollEvent:
 		return s.handleForceUnroll(ctx, evt)
 
-	case *ExitFailedEvent, *ExitConfirmedEvent:
+	case *ExitFailedEvent, *ExitConfirmedEvent, *ExitConflictedEvent:
 		// A duplicate or stale exit-outcome event for a VTXO that is
 		// already live (e.g. boot reconciliation re-delivering a
 		// recovery that already landed). Idempotent no-op: the VTXO is
-		// live, which is the recovered state. ExitConfirmedEvent should
-		// never reach a live VTXO, but ignoring it is safer than
-		// retiring a live coin to spent on a stray signal.
+		// live, which is the recovered state. ExitConfirmedEvent and
+		// ExitConflictedEvent should never reach a live VTXO, but
+		// ignoring them is safer than retiring a live coin on a stray
+		// signal.
 		return &VTXOStateTransition{
 			NextState: s,
 		}, nil
@@ -1494,7 +1495,7 @@ func (s *ForfeitedState) ProcessEvent(_ context.Context, _ VTXOEvent,
 // alive to observe the outcome: a clean failure rolls the VTXO back to
 // LiveState, an on-chain confirmation retires it to the terminal
 // SpentState, and everything else self-loops while the exit is in flight.
-func (s *UnilateralExitState) ProcessEvent(_ context.Context, event VTXOEvent,
+func (s *UnilateralExitState) ProcessEvent(ctx context.Context, event VTXOEvent,
 	_ *VTXOEnvironment) (*VTXOStateTransition, error) {
 
 	switch evt := event.(type) {
@@ -1571,6 +1572,63 @@ func (s *UnilateralExitState) ProcessEvent(_ context.Context, event VTXOEvent,
 						VTXOOutpoint: s.VTXO.Outpoint,
 						FinalState:   "Spent",
 						Reason:       "exit confirmed",
+					},
+				},
+			}),
+		}, nil
+
+	case *ExitConflictedEvent:
+		// A confirmed foreign spend conflicts with the recovery tree
+		// (the operator swept a source batch commitment output the exit
+		// depends on): the unilateral exit is provably impossible. The
+		// operator can only sweep that output past batch expiry, so the
+		// coin is expired, not lost — its value is still recoverable
+		// through the ordinary refresh path (wavelength#1000). Route it
+		// to the non-terminal ExpiredState rather than the terminal
+		// FailedState: this quarantines the value from coin selection
+		// (its lineage is dead) while the next block epoch drives the
+		// cooperative reclaim. Unlike ExitConfirmedEvent this did not
+		// spend our coin, and unlike a terminal failure the value is
+		// recoverable, so — like the recoverable ExitFailedEvent — the
+		// actor stays alive and emits no terminated notification
+		// (wavelength#1050).
+		//
+		// Soundness of the ExpiredState landing: ExpiredState's
+		// block-epoch handler rolls a VTXO back to LiveState when
+		// CheckExpiry reports it is NOT expired — a relive that must
+		// never happen to a dead-lineage coin. It provably cannot fire
+		// for a conflicted coin. The operator can only spend a batch
+		// commitment output past that batch's expiry, and a VTXO's
+		// BatchExpiry is the most-restrictive expiry across every
+		// contributing commitment (the operator-supplied value the
+		// client trusts here as everywhere: see
+		// oor.IncomingVTXOMetadata.BatchExpiry, "most-restrictive
+		// across all contributing rounds"). So the confirmed spend we
+		// just observed proves currentHeight >= swept-source expiry >=
+		// this VTXO's BatchExpiry, i.e. CheckExpiry reports Expired at
+		// this height and every height after it. The rollback branch is
+		// therefore unreachable for a conflicted coin and the only exit
+		// from ExpiredState is the cooperative reclaim, across restarts
+		// too (a respawn re-enters ExpiredState at a height that is
+		// still past BatchExpiry). Pinned by
+		// TestUnilateralExitConflictReclaimsWhenExpired.
+		build.LoggerFromContext(ctx).WithPrefix(Subsystem).InfoS(
+			ctx, "Source-batch conflict: routing exit to expired "+
+				"reclaim",
+			slog.String("outpoint", s.VTXO.Outpoint.String()),
+			slog.String("reason", evt.Reason),
+		)
+
+		return &VTXOStateTransition{
+			NextState: &ExpiredState{
+				VTXO:           s.VTXO,
+				ObservedHeight: s.LastCheckedHeight,
+			},
+			NewEvents: fn.Some(VTXOEmittedEvent{
+				Outbox: []VTXOOutMsg{
+					&VTXOStatusUpdate{
+						Outpoint:  s.VTXO.Outpoint,
+						NewStatus: VTXOStatusExpired,
 					},
 				},
 			}),

--- a/vtxo/transitions_test.go
+++ b/vtxo/transitions_test.go
@@ -503,6 +503,101 @@ func TestUnilateralExitConfirms(t *testing.T) {
 	require.Equal(t, "Spent", term.FinalState)
 }
 
+// TestUnilateralExitConflicts verifies that an ExitConflictedEvent routes the
+// VTXO to the non-terminal ExpiredState (not back to live, not to spent, not to
+// a terminal Failed) and emits NO VTXOTerminatedNotification, so the actor
+// stays alive to reclaim the coin. This is the swept-source path: the operator
+// can only sweep the source batch past expiry, so the coin is expired, not
+// lost, and is recoverable through the ordinary refresh path
+// (wavelength#1050 / #1000).
+func TestUnilateralExitConflicts(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	h.withState(&UnilateralExitState{
+		VTXO:              vtxo,
+		Reason:            "manual unroll",
+		LastCheckedHeight: 200,
+	})
+
+	h.store.On(
+		"UpdateVTXOStatus", h.ctx, vtxo.Outpoint, VTXOStatusExpired,
+	).Return(nil)
+
+	const reason = "source batch swept by the operator; unilateral exit " +
+		"is no longer possible"
+	_, err := h.sendEvent(&ExitConflictedEvent{Reason: reason})
+	require.NoError(t, err)
+
+	expired := assertState[*ExpiredState](h)
+	require.Equal(t, int32(200), expired.ObservedHeight)
+	update := assertOutboxContains[*VTXOStatusUpdate](h)
+	require.Equal(t, VTXOStatusExpired, update.NewStatus)
+	// No terminated notification: ExpiredState is non-terminal so the actor
+	// survives to drive the reclaim.
+	assertOutboxLacks[*VTXOTerminatedNotification](h)
+}
+
+// TestUnilateralExitConflictReclaimsWhenExpired pins the soundness of routing a
+// source-batch conflict to ExpiredState (wavelength#1050): the following block
+// epoch must drive the cooperative reclaim and must NEVER roll the coin back to
+// LiveState. ExpiredState's block-epoch handler relives a coin when CheckExpiry
+// reports it is not expired; that branch is unreachable for a conflicted coin
+// because the operator can only sweep a source batch output past its expiry and
+// BatchExpiry is the most-restrictive expiry across the VTXO's contributing
+// commitments — so the conflict is always observed at height >= BatchExpiry.
+// This test exercises that guaranteed condition and asserts the reclaim, not a
+// relive.
+func TestUnilateralExitConflictReclaimsWhenExpired(t *testing.T) {
+	t.Parallel()
+
+	h := newVTXOTestHarness(t)
+	vtxo := h.newTestDescriptor()
+
+	// The default test descriptor has BatchExpiry = 1000. A source-batch
+	// sweep can only confirm past that height, so the conflict — and every
+	// block epoch after it — is observed at a height already past expiry.
+	const conflictHeight = 1005
+
+	h.withState(&UnilateralExitState{
+		VTXO:              vtxo,
+		Reason:            "manual unroll",
+		LastCheckedHeight: conflictHeight,
+	})
+
+	// The conflict routes the coin to the non-terminal ExpiredState.
+	_, err := h.sendEvent(&ExitConflictedEvent{
+		Reason: "source batch swept by the operator",
+	})
+	require.NoError(t, err)
+	require.IsType(t, &ExpiredState{}, h.currentState)
+
+	// The next block epoch, still past BatchExpiry, must drive the
+	// cooperative reclaim (ForfeitRequest -> PendingForfeit) rather than
+	// relive the dead-lineage coin as spendable.
+	_, err = h.sendEvent(h.newBlockEpochEvent(conflictHeight))
+	require.NoError(t, err)
+
+	// PendingForfeitState (not LiveState) proves the coin was reclaimed,
+	// not relived, and a ForfeitRequest was dispatched to start the
+	// refresh.
+	assertState[*PendingForfeitState](h)
+	assertOutboxContains[*ForfeitRequest](h)
+
+	// Belt-and-suspenders: no Live status update was ever emitted, so the
+	// coin never re-entered the spendable set.
+	for _, msg := range h.outboxMessages {
+		if u, ok := msg.(*VTXOStatusUpdate); ok {
+			require.NotEqual(
+				t, VTXOStatusLive, u.NewStatus,
+				"conflicted coin must never be relived to Live",
+			)
+		}
+	}
+}
+
 // TestUnilateralExitSelfLoopsWhileExiting verifies that truly inert events
 // received while the exit is in flight (block epochs, resume) leave the VTXO
 // in UnilateralExitState and emit nothing: the exit is already at the chain

--- a/vtxo/transitions_test.go
+++ b/vtxo/transitions_test.go
@@ -532,7 +532,10 @@ func TestUnilateralExitConflicts(t *testing.T) {
 	require.NoError(t, err)
 
 	expired := assertState[*ExpiredState](h)
-	require.Equal(t, int32(200), expired.ObservedHeight)
+	require.Zero(
+		t, expired.ObservedHeight,
+		"exit admission is not an observation of expiry",
+	)
 	update := assertOutboxContains[*VTXOStatusUpdate](h)
 	require.Equal(t, VTXOStatusExpired, update.NewStatus)
 	// No terminated notification: ExpiredState is non-terminal so the actor
@@ -572,7 +575,16 @@ func TestUnilateralExitConflictReclaimsWhenExpired(t *testing.T) {
 		Reason: "source batch swept by the operator",
 	})
 	require.NoError(t, err)
-	require.IsType(t, &ExpiredState{}, h.currentState)
+	expired := assertState[*ExpiredState](h)
+	require.Zero(t, expired.ObservedHeight)
+
+	// A replay after the status write must neither error nor repeat the
+	// outbox effects. This also models an Expired actor restored at boot.
+	effects := len(h.outboxMessages)
+	_, err = h.sendEvent(&ExitConflictedEvent{Reason: "replayed conflict"})
+	require.NoError(t, err)
+	require.Same(t, expired, h.currentState)
+	require.Len(t, h.outboxMessages, effects)
 
 	// The next block epoch, still past BatchExpiry, must drive the
 	// cooperative reclaim (ForfeitRequest -> PendingForfeit) rather than
@@ -583,7 +595,8 @@ func TestUnilateralExitConflictReclaimsWhenExpired(t *testing.T) {
 	// PendingForfeitState (not LiveState) proves the coin was reclaimed,
 	// not relived, and a ForfeitRequest was dispatched to start the
 	// refresh.
-	assertState[*PendingForfeitState](h)
+	pending := assertState[*PendingForfeitState](h)
+	require.Equal(t, int32(conflictHeight), pending.RequestedAtHeight)
 	assertOutboxContains[*ForfeitRequest](h)
 
 	// Belt-and-suspenders: no Live status update was ever emitted, so the

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -5907,12 +5907,14 @@ func unrollJobStatusToProto(
 	case db.UnilateralExitJobStatusCompleted:
 		return waverpc.UnrollJobStatus_UNROLL_JOB_STATUS_COMPLETED
 
-	// Both terminal failure flavours surface as FAILED to clients. The
-	// recoverable variant is an internal distinction used by boot-time
-	// reconciliation to roll a no-footprint failure back to live; the
-	// user-visible job still failed.
+	// All terminal failure flavours surface as FAILED to clients. The
+	// recoverable and conflicted variants are internal distinctions used by
+	// boot-time reconciliation (roll a no-footprint failure back to live;
+	// retire a source-batch conflict out of pending); the user-visible job
+	// still failed.
 	case db.UnilateralExitJobStatusFailed,
-		db.UnilateralExitJobStatusFailedRecoverable:
+		db.UnilateralExitJobStatusFailedRecoverable,
+		db.UnilateralExitJobStatusFailedConflicted:
 		return waverpc.UnrollJobStatus_UNROLL_JOB_STATUS_FAILED
 
 	default:

--- a/waved/server.go
+++ b/waved/server.go
@@ -4697,6 +4697,15 @@ func resolveExitOutcome(ctx context.Context,
 			),
 		}), nil
 
+	case db.UnilateralExitJobStatusFailedConflicted:
+		return fn.Some(vtxo.ExitOutcomeResolution{
+			Outcome: vtxo.ExitOutcomeConflicted,
+			Reason:  job.LastError,
+			ExitPolicyKind: actormsg.ExitPolicyKind(
+				job.ExitPolicyKind,
+			),
+		}), nil
+
 	default:
 		return fn.None[vtxo.ExitOutcomeResolution](), nil
 	}


### PR DESCRIPTION
Closes #1050.

## Problem

A unilateral-exit job could sit in `EXIT_JOB_STATUS_MATERIALIZING`
forever after the Ark operator swept a source batch commitment output.
The confirmed sweep double-spends the recovery-tree root, so the exit can
never complete — but `txconfirm` never gives up on a no-mempool tx, so
the job never failed. The VTXO stayed `EXIT / PENDING`, its amount stayed
in `pending_out_sat`, and `phase_detail` kept implying progress. Nothing
watched the batch commitment output the tree root spends, so the conflict
was invisible to the client.

## Fix

**Detect** (`recovery` + `unroll`) — `Proof.RootExternalInputs()` returns
the roots' external funding inputs (the batch commitment outpoints; one
per contributing commitment for OOR/fan-in VTXOs). The unroll actor arms
a spend watch on each, supplying the batch output's pkScript from the
descriptor ancestry for neutrino BIP-158 filter matching. A confirmed
foreign spend routes the exit job to a terminal `ExitOutcomeConflicted`;
our own root spending the same output reads as a benign parent
confirmation, so the watch is safe both ways. Arming is best-effort and
never blocks materialization.

**Reclaim** (`unroll` → `vtxo`) — the operator can only sweep the batch
commitment output *past batch expiry*, so a swept source means the VTXO
is **expired, not lost**: its value is still recoverable through the
ordinary refresh path (#1000). So rather than retiring the coin to a
terminal `Failed` state, the VTXO manager routes it to the non-terminal
**`ExpiredState`** — quarantined from coin selection because its lineage
is dead, but reclaimed by the next block epoch through a cooperative
forfeit, exactly like a naturally-expired VTXO. The unroll *job* still
terminates as conflicted (the unilateral exit genuinely died); only the
coin's fate differs. A recovery-only target (a non-standard exit policy
such as a vHTLC refund) is **held in exit** instead, since a swap-contract
output must not be reclaimed as spendable wallet liquidity.

### Why not terminal `Failed`?

An earlier revision of this PR retired the coin to `Failed`, on the
assumption that a swept source meant the funds were gone. That strands
recoverable value: post-#1000 the client reclaims expired VTXOs through
the normal refresh protocol with no sweep-confirmation gate
(`TestSweepIntegrationReclaimWithoutObservingSweep`), so a swept source
batch is precisely the condition that reclaim handles. Thanks to @sputn1ck
for catching this.

## Testing

- `vtxo`: `TestUnilateralExitConflicts` (routes to `ExpiredState`, emits no
  terminated notification), `TestHandleExitOutcomeConflictedDrivesActorToExpired`,
  and recovery-only / non-exiting guard tests on the manager fallback path.
- `recovery`: `RootExternalInputs` returns/dedups/sorts root external inputs.
- Full `vtxo` + `waved` + `unroll` suites green; `make fmt-changed` +
  `make lint-changed-local` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
