### PR TITLE
txconfirm: fail closed at the max fee-rate cap on bump

### DIFF
--- a/txconfirm/actor.go
+++ b/txconfirm/actor.go
@@ -1318,8 +1318,24 @@ func (a *TxBroadcasterActor) handleBlockObserved(ctx context.Context,
 				// the FSM back to AwaitingConfirmation with an
 				// updated broadcast height so the next bump
 				// waits the full interval.
-				a.log.WarnS(ctx, "Fee bump failed, will retry",
-					err, "txid", entry.data.Txid)
+				//
+				// A cap-reached refusal is an expected
+				// steady-state condition -- the tx is
+				// intentionally parked at the configured max
+				// fee rate -- rather than a transient failure,
+				// so it is logged at debug to avoid emitting a
+				// warning every interval for the tx's whole
+				// lifetime (wavelength#403).
+				if errors.Is(err, ErrFeeRateCapReached) {
+					a.log.DebugS(ctx, "Fee bump held at the "+
+						"max fee rate cap; leaving tx at "+
+						"its last in-cap fee",
+						"txid", entry.data.Txid)
+				} else {
+					a.log.WarnS(ctx, "Fee bump failed, "+
+						"will retry", err,
+						"txid", entry.data.Txid)
+				}
 
 				progress := trackedTxProgress{
 					LastBroadcastHeight: fn.Some(

--- a/txconfirm/broadcaster.go
+++ b/txconfirm/broadcaster.go
@@ -110,6 +110,19 @@ var (
 	// this as a terminal broadcast failure.
 	ErrParentAlreadyBroadcast = errors.New("parent already broadcast by " +
 		"another path; cpfp child rejected")
+
+	// ErrFeeRateCapReached indicates that satisfying the BIP-125 Rule 4
+	// replacement floor (a strictly higher feerate than the prior
+	// submission) would push the package above the configured
+	// MaxFeeRateSatPerVByte ceiling. The estimator is clamped to the cap,
+	// but the replacement floor ratchets past it once a prior bump already
+	// sat at the cap, so we fail the bump closed rather than pay above the
+	// operator's safety limit. The prior submission stays live, so callers
+	// treat this as a benign no-op (Bumped=false): the tx keeps its last
+	// in-cap fee and can still confirm; only the over-cap replacement is
+	// refused (wavelength#403).
+	ErrFeeRateCapReached = errors.New("replacement feerate floor exceeds " +
+		"the configured max fee rate cap")
 )
 
 // txconfirmLockID is the package-scoped LockID used by CPFPBroadcaster
@@ -810,6 +823,24 @@ func (b *CPFPBroadcaster) broadcastWithCPFP(ctx context.Context, height int32,
 	feeRate, totalFee = b.applyReplacementFloor(
 		req.Tx, txid, feeRate, totalFee, childVSize,
 	)
+
+	// The estimator (and any operator target) is clamped to
+	// MaxFeeRateSatPerVByte, but the replacement floor above ratchets the
+	// feerate to prev.LastFeeRate + 1 to satisfy BIP-125 Rule 4 without
+	// re-checking that ceiling. Once a prior bump already sat at the cap,
+	// each subsequent bump would escalate one sat/vB above it indefinitely,
+	// making the wallet pay fees over the configured safety limit. The cap
+	// is a hard ceiling, so fail closed here rather than pay past it: no
+	// compliant replacement exists within the cap once the prior submission
+	// is already at it. The bump is a benign no-op -- the prior tx stays
+	// live and can still confirm at its last in-cap fee -- so the actor's
+	// fee-bump-error path recovers to AwaitingConfirmation and retries
+	// (wavelength#403).
+	if feeRate > b.cfg.MaxFeeRateSatPerVByte {
+		return nil, fmt.Errorf("%w: replacement requires %d sat/vB, "+
+			"above the %d sat/vB cap", ErrFeeRateCapReached,
+			feeRate, b.cfg.MaxFeeRateSatPerVByte)
+	}
 
 	// A funded parent may already pay the whole package target on its own
 	// (a flat-rate re-bump, or an operator target at or under the parent's

--- a/txconfirm/broadcaster_test.go
+++ b/txconfirm/broadcaster_test.go
@@ -959,6 +959,89 @@ func TestCPFPReselectsAfterPreciseFeeGrowth(t *testing.T) {
 	)
 }
 
+// TestCPFPBumpFailsClosedAtFeeRateCap reproduces wavelength#403: the BIP-125
+// Rule 4 replacement floor ratchets the feerate to prev+1 without re-checking
+// MaxFeeRateSatPerVByte, so once a prior bump sat at the cap every subsequent
+// bump would escalate one sat/vB above it -- forcing the wallet to pay fees
+// over the operator's configured safety limit. The bump must instead fail
+// closed with ErrFeeRateCapReached (a benign no-op that keeps the prior in-cap
+// submission live) rather than pay past the cap.
+func TestCPFPBumpFailsClosedAtFeeRateCap(t *testing.T) {
+	t.Parallel()
+
+	const feeCap = 10
+
+	parent := makeTestTx(true)
+	txid := parent.TxHash()
+
+	t.Run("prior at cap fails closed", func(t *testing.T) {
+		t.Parallel()
+
+		chain := newFakeChainSourceRef(100)
+
+		// Under the cap: the Rule 4 floor, not the estimator, is what
+		// pushes the replacement feerate over the ceiling.
+		chain.feeRate = 5
+
+		b := NewCPFPBroadcaster(BroadcasterConfig{
+			ChainSource:           chain,
+			Wallet:                &fakeWallet{},
+			MaxFeeRateSatPerVByte: feeCap,
+		})
+
+		// A prior submission already sitting at the cap: Rule 4 forces
+		// the next feerate to feeCap + 1.
+		b.parentStates[txid] = &parentBumpState{
+			LastFeeRate:    feeCap,
+			LastPackageFee: 1,
+		}
+
+		_, err := b.Submit(t.Context(), 100, &BroadcastRequest{
+			Tx: parent, Label: "cap-bump", IsFeeBump: true,
+		})
+		require.ErrorIs(t, err, ErrFeeRateCapReached)
+
+		// Nothing may go out at an over-cap fee -- neither a package
+		// submission nor a direct broadcast.
+		require.Zero(t, chain.packageCallCount())
+		require.Zero(t, chain.broadcastCallCount())
+	})
+
+	t.Run("prior below cap proceeds", func(t *testing.T) {
+		t.Parallel()
+
+		chain := newFakeChainSourceRef(100)
+		chain.feeRate = 5
+
+		// A large fee input so the CPFP child can actually be built.
+		w := &fakeWallet{
+			utxos: []*walletcore.Utxo{
+				makeWalletUTXOWithAmount(10_000_000, 0xcc),
+			},
+		}
+		b := NewCPFPBroadcaster(BroadcasterConfig{
+			ChainSource:           chain,
+			Wallet:                w,
+			MaxFeeRateSatPerVByte: feeCap,
+		})
+
+		// Prior submission well below the cap: the floor bumps to
+		// prev + 1 = 8, still under the cap, so the bump proceeds
+		// normally rather than being refused.
+		b.parentStates[txid] = &parentBumpState{
+			LastFeeRate:    7,
+			LastPackageFee: 1,
+		}
+
+		_, err := b.Submit(t.Context(), 100, &BroadcastRequest{
+			Tx: parent, Label: "ok-bump", IsFeeBump: true,
+		})
+		require.NoError(t, err)
+		require.NotErrorIs(t, err, ErrFeeRateCapReached)
+		require.Equal(t, 1, chain.packageCallCount())
+	})
+}
+
 // makeCheckpointShapedParent builds a v3/TRUC parent that mirrors a finalized
 // OOR checkpoint / fraud-response tx: its sole non-anchor input already carries
 // a real (pre-signed) taproot key-spend witness, it has a taproot checkpoint


### PR DESCRIPTION
Closes #403.

## Problem (validated scanner finding)

`EstimateFeeRate` (and any operator `BumpNow` target) is clamped to
`MaxFeeRateSatPerVByte`, but `applyReplacementFloor` then ratchets the
feerate to `prev.LastFeeRate + 1` to satisfy BIP-125 Rule 4 **without ever
re-checking that ceiling**. Once a prior bump already sits at the cap, each
subsequent bump escalates one sat/vB above it — and since `state.LastFeeRate`
is set to the (now over-cap) value each time, it ratchets indefinitely. A tx
that won't confirm (prolonged non-confirmation, or a backend driving block
events) then makes the wallet pay fees **above the configured safety limit**
instead of failing closed at the cap.

I validated this by reading the path: on a bump, `feeRate` from the
estimator is ≤ cap, but `applyReplacementFloor` returns `prev.LastFeeRate+1`,
which exceeds the cap once `prev.LastFeeRate == cap`, and `BuildCPFPChild`
then spends wallet UTXOs at the uncapped fee.

## Fix

After the replacement floor, refuse the bump when the required feerate
exceeds the cap (`ErrFeeRateCapReached`). No BIP-125-compliant replacement
exists within the cap once the prior submission is already at it, so failing
closed is the only way to honor the ceiling.

The refusal is a **benign no-op**: both the interval-paced and forced
(`BumpNow`) bump paths already treat a bump error as non-terminal — the prior
in-cap submission stays live and can still confirm at its last fee, and the
actor recovers to `AwaitingConfirmation` and retries. So no actor changes are
needed; the fix is self-contained in `broadcaster.go`. The cap only ever
binds on a bump — `applyReplacementFloor` is a pass-through on the first
submission, whose feerate is already clamped.

## Testing

`TestCPFPBumpFailsClosedAtFeeRateCap`:
- **prior at cap** → the bump returns `ErrFeeRateCapReached` and **no** package
  or direct broadcast goes out at an over-cap fee.
- **prior below cap** → the bump proceeds normally (package submitted), so the
  cap doesn't over-eagerly refuse.

Verified **RED on main** (disabling only the cap check lets the over-cap bump
submit) and **GREEN** with the fix. Full `txconfirm` suite + `lint-changed-local`
green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
