### PR TITLE
unroll: cancel LND broadcast of a proof tx on terminal failure

### DIFF
--- a/chainbackends/lnd.go
+++ b/chainbackends/lnd.go
@@ -61,6 +61,13 @@ type TxBroadcaster interface {
 	// The label parameter is optional and may be used for wallet tracking.
 	PublishTransaction(ctx context.Context, tx *wire.MsgTx,
 		label string) error
+
+	// RemoveTransaction removes the transaction with the given hash, and
+	// any transactions that depend on it, from the wallet's store and its
+	// unconfirmed-rebroadcast set. It is used to abandon a transaction the
+	// caller no longer wants the wallet to keep rebroadcasting (e.g. a
+	// unilateral-exit proof tx whose job has terminally failed).
+	RemoveTransaction(ctx context.Context, txid chainhash.Hash) error
 }
 
 // PackageSubmitter atomically submits parent+child transaction packages.
@@ -236,6 +243,23 @@ func (b *LNDBackend) BroadcastTx(ctx context.Context, tx *wire.MsgTx,
 	b.logger(ctx).InfoS(ctx, "Transaction broadcast successfully",
 		btclog.Hex("txid", txHash[:]),
 	)
+
+	return nil
+}
+
+// RemoveTx removes a previously broadcast transaction from lnd's wallet so it
+// stops being rebroadcast. It satisfies the optional chainsource.TxRemover
+// capability; a caller that has abandoned a transaction (e.g. a terminally
+// failed unilateral-exit proof tx) uses it to stop lnd from perpetually
+// re-publishing a transaction that can never confirm.
+func (b *LNDBackend) RemoveTx(ctx context.Context, txid chainhash.Hash) error {
+	b.logger(ctx).InfoS(ctx, "Removing transaction from LND wallet",
+		btclog.Hex("txid", txid[:]),
+	)
+
+	if err := b.broadcaster.RemoveTransaction(ctx, txid); err != nil {
+		return fmt.Errorf("failed to remove transaction: %w", err)
+	}
 
 	return nil
 }

--- a/chainbackends/lnd_test.go
+++ b/chainbackends/lnd_test.go
@@ -93,6 +93,13 @@ func (s *stubBroadcaster) PublishTransaction(
 	return nil
 }
 
+func (s *stubBroadcaster) RemoveTransaction(
+	_ context.Context, _ chainhash.Hash,
+) error {
+
+	return nil
+}
+
 type stubPackageSubmitter struct {
 	result *btcjson.SubmitPackageResult
 	err    error

--- a/chainbackends/lndclient_adapters.go
+++ b/chainbackends/lndclient_adapters.go
@@ -49,6 +49,15 @@ func (b *LndClientTxBroadcaster) PublishTransaction(ctx context.Context,
 	return b.walletKit.PublishTransaction(ctx, tx, label)
 }
 
+// RemoveTransaction removes the transaction (and its descendants) from lnd's
+// wallet via the WalletKit RemoveTransaction RPC, stopping lnd from
+// rebroadcasting it.
+func (b *LndClientTxBroadcaster) RemoveTransaction(ctx context.Context,
+	txid chainhash.Hash) error {
+
+	return b.walletKit.RemoveTransaction(ctx, txid)
+}
+
 // Ensure LndClientTxBroadcaster implements TxBroadcaster.
 var _ TxBroadcaster = (*LndClientTxBroadcaster)(nil)
 

--- a/chainsource/backend.go
+++ b/chainsource/backend.go
@@ -134,6 +134,21 @@ type ChainBackend interface {
 	Stop() error
 }
 
+// TxRemover is an optional capability a ChainBackend may implement to remove a
+// previously broadcast transaction from the wallet, so the wallet stops
+// rebroadcasting it. A caller that has abandoned a transaction (e.g. a
+// unilateral-exit proof tx whose job terminally failed) uses it to stop a
+// full-node wallet from perpetually re-publishing a transaction that can never
+// confirm (wavelength#609). Backends without a rebroadcasting wallet (e.g. a
+// pure Esplora chain source) do not implement it; the chainsource actor treats
+// a RemoveTxRequest as a no-op for those.
+type TxRemover interface {
+	// RemoveTx removes the transaction with the given hash, and any
+	// transactions that depend on it, from the wallet's store and its
+	// unconfirmed-rebroadcast set.
+	RemoveTx(ctx context.Context, txid chainhash.Hash) error
+}
+
 // ConfRegistration encapsulates the channels and control functions for a
 // confirmation registration. This mirrors lnd's chainntnfs.ConfirmationEvent
 // structure but provides a backend-agnostic interface.

--- a/chainsource/broadcast_errors.go
+++ b/chainsource/broadcast_errors.go
@@ -37,7 +37,38 @@ var (
 		// Wallet-layer variants.
 		"output already spent",
 	}
+
+	// ignorableRemoveErrs lists error substrings returned when removing a
+	// transaction that the wallet does not (or no longer) knows about. The
+	// caller's goal -- the transaction is not in the wallet's rebroadcast
+	// set -- is already satisfied in that case, so the removal is treated
+	// as a success (wavelength#609).
+	ignorableRemoveErrs = []string{
+		"not found",
+		"unable to locate transaction",
+		"no such transaction",
+		"already confirmed",
+	}
 )
+
+// IsIgnorableRemoveError returns true when a transaction-removal error means
+// the transaction is already absent from the wallet's rebroadcast set (unknown,
+// already removed, or already confirmed), so the removal can be treated as a
+// success.
+func IsIgnorableRemoveError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := strings.ToLower(err.Error())
+	for _, substring := range ignorableRemoveErrs {
+		if strings.Contains(errStr, substring) {
+			return true
+		}
+	}
+
+	return false
+}
 
 // IsIgnorableBroadcastError returns true if the error is expected to happen
 // when broadcasting the same transaction multiple times.

--- a/chainsource/chainsource.go
+++ b/chainsource/chainsource.go
@@ -105,6 +105,9 @@ func (a *ChainSourceActor) Receive(actorCtx context.Context,
 	case *BroadcastTxRequest:
 		return a.handleBroadcastTx(actorCtx, m)
 
+	case *RemoveTxRequest:
+		return a.handleRemoveTx(actorCtx, m)
+
 	case *SubmitPackageRequest:
 		return a.handleSubmitPackage(actorCtx, m)
 
@@ -194,6 +197,50 @@ func (a *ChainSourceActor) handleTestMempoolAccept(ctx context.Context,
 	return fn.Ok[ChainSourceResp](&TestMempoolAcceptResponse{
 		Results: results,
 	})
+}
+
+// handleRemoveTx removes a previously broadcast transaction from the backend
+// wallet so it stops being rebroadcast. The removal is a capability the
+// backend opts into via TxRemover: a backend without a rebroadcasting wallet
+// (e.g. a pure Esplora chain source) does not implement it, and the request is
+// acknowledged as a no-op. A backend that reports the transaction as unknown
+// (already gone / never in the wallet) is likewise treated as success, since
+// the caller's goal -- the tx is not in the wallet's rebroadcast set -- is
+// already met (wavelength#609).
+func (a *ChainSourceActor) handleRemoveTx(ctx context.Context,
+	req *RemoveTxRequest) fn.Result[ChainSourceResp] {
+
+	remover, ok := a.cfg.Backend.(TxRemover)
+	if !ok {
+		a.logger(ctx).DebugS(ctx, "Backend does not support tx "+
+			"removal; treating RemoveTx as a no-op",
+			slog.String("txid", req.Txid.String()),
+		)
+
+		return fn.Ok[ChainSourceResp](&RemoveTxResponse{Txid: req.Txid})
+	}
+
+	if err := remover.RemoveTx(ctx, req.Txid); err != nil {
+		if IsIgnorableRemoveError(err) {
+			a.logger(ctx).DebugS(ctx, "RemoveTx returned "+
+				"ignorable error",
+				slog.String("txid", req.Txid.String()),
+				slog.String("remove_error", err.Error()),
+			)
+
+			return fn.Ok[ChainSourceResp](
+				&RemoveTxResponse{
+					Txid: req.Txid,
+				},
+			)
+		}
+
+		return fn.Err[ChainSourceResp](
+			fmt.Errorf("remove tx %s: %w", req.Txid, err),
+		)
+	}
+
+	return fn.Ok[ChainSourceResp](&RemoveTxResponse{Txid: req.Txid})
 }
 
 // handleBroadcastTx processes a transaction broadcast request by submitting

--- a/chainsource/chainsource_test.go
+++ b/chainsource/chainsource_test.go
@@ -3,6 +3,7 @@ package chainsource
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -374,6 +375,109 @@ func TestChainSourceActorBroadcastTx(t *testing.T) {
 	require.True(t, ok)
 	expectedHash := tx.TxHash()
 	require.Equal(t, expectedHash, broadcastResp.Txid)
+}
+
+// removerBackend is a mockBackend that also implements the optional TxRemover
+// capability, recording the txids it is asked to remove and optionally
+// returning a configured error.
+type removerBackend struct {
+	*mockBackend
+
+	mu      sync.Mutex
+	removed []chainhash.Hash
+	err     error
+}
+
+func (b *removerBackend) RemoveTx(_ context.Context,
+	txid chainhash.Hash) error {
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.removed = append(b.removed, txid)
+
+	return b.err
+}
+
+func (b *removerBackend) removedTxids() []chainhash.Hash {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return append([]chainhash.Hash(nil), b.removed...)
+}
+
+// TestChainSourceActorRemoveTx covers the RemoveTx handler: a backend that
+// implements TxRemover has the removal forwarded to it, an ignorable
+// "not found" error is treated as success, and a backend without the
+// capability treats the request as a no-op (wavelength#609).
+func TestChainSourceActorRemoveTx(t *testing.T) {
+	t.Parallel()
+
+	txid := chainhash.Hash{0x42}
+
+	newActor := func(t *testing.T, backend ChainBackend) actor.ActorRef[
+		ChainSourceMsg, ChainSourceResp] {
+
+		t.Helper()
+
+		system := actor.NewActorSystem()
+		t.Cleanup(func() { _ = system.Shutdown(t.Context()) })
+
+		chainSource := NewChainSourceActor(ChainSourceConfig{
+			Backend: backend,
+			System:  system,
+		})
+
+		return ChainSourceKey.Spawn(
+			system, "chainsource-removetx", chainSource,
+		)
+	}
+
+	t.Run("forwards to a capable backend", func(t *testing.T) {
+		t.Parallel()
+
+		backend := &removerBackend{mockBackend: newMockBackend()}
+		ref := newActor(t, backend)
+
+		resp, err := ref.Ask(
+			t.Context(), &RemoveTxRequest{Txid: txid},
+		).Await(t.Context()).Unpack()
+		require.NoError(t, err)
+		removeResp, ok := resp.(*RemoveTxResponse)
+		require.True(t, ok)
+		require.Equal(t, txid, removeResp.Txid)
+		require.Equal(t, []chainhash.Hash{txid}, backend.removedTxids())
+	})
+
+	t.Run("ignorable error is a success", func(t *testing.T) {
+		t.Parallel()
+
+		backend := &removerBackend{
+			mockBackend: newMockBackend(),
+			err: errors.New("transaction not found in " +
+				"wallet"),
+		}
+		ref := newActor(t, backend)
+
+		_, err := ref.Ask(
+			t.Context(), &RemoveTxRequest{Txid: txid},
+		).Await(t.Context()).Unpack()
+		require.NoError(t, err)
+	})
+
+	t.Run("no-op on a backend without the capability", func(t *testing.T) {
+		t.Parallel()
+
+		ref := newActor(t, newMockBackend())
+
+		resp, err := ref.Ask(
+			t.Context(), &RemoveTxRequest{Txid: txid},
+		).Await(t.Context()).Unpack()
+		require.NoError(t, err)
+		removeResp, ok := resp.(*RemoveTxResponse)
+		require.True(t, ok)
+		require.Equal(t, txid, removeResp.Txid)
+	})
 }
 
 // TestChainSourceActorSubmitPackage tests package submission through the

--- a/chainsource/messages.go
+++ b/chainsource/messages.go
@@ -175,6 +175,42 @@ func (m *BroadcastTxResponse) MessageType() string {
 // chainSourceRespSealed implements the sealed ChainSourceResp interface.
 func (m *BroadcastTxResponse) chainSourceRespSealed() {}
 
+// RemoveTxRequest asks the backend to remove a previously broadcast
+// transaction from the wallet so it stops being rebroadcast. It is a no-op on
+// backends that do not implement the optional TxRemover capability
+// (wavelength#609).
+type RemoveTxRequest struct {
+	actor.BaseMessage
+
+	// Txid is the hash of the transaction to remove.
+	Txid chainhash.Hash
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *RemoveTxRequest) MessageType() string {
+	return "RemoveTxRequest"
+}
+
+// chainSourceMsgSealed implements the sealed ChainSourceMsg interface.
+func (m *RemoveTxRequest) chainSourceMsgSealed() {}
+
+// RemoveTxResponse acknowledges a RemoveTxRequest.
+type RemoveTxResponse struct {
+	actor.BaseMessage
+
+	// Txid is the hash of the transaction that was removed (or the no-op
+	// target on a backend without the TxRemover capability).
+	Txid chainhash.Hash
+}
+
+// MessageType returns the message type identifier for logging and debugging.
+func (m *RemoveTxResponse) MessageType() string {
+	return "RemoveTxResponse"
+}
+
+// chainSourceRespSealed implements the sealed ChainSourceResp interface.
+func (m *RemoveTxResponse) chainSourceRespSealed() {}
+
 // SubmitPackageRequest requests atomic submission of a parent+child
 // transaction package. The parents must be in dependency order and the
 // child pays the package fee.

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/lib/pq v1.11.1
-	github.com/lightninglabs/lndclient v1.0.1-0.20260701212139-09c54915cfba
+	github.com/lightninglabs/lndclient v1.0.1-0.20260730152521-c255827dd83e
 	github.com/lightninglabs/loop v0.33.0-beta
 	github.com/lightninglabs/neutrino v0.18.0
 	github.com/lightninglabs/neutrino/cache v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -1046,8 +1046,8 @@ github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.4-0.20250610182311-2f1d46ef18b7 h1:373o5lNr1udAdhcf5+zq/0dYpRtkvYLl8Lk6wG7I0DY=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.4-0.20250610182311-2f1d46ef18b7/go.mod h1:bDnEKRN1u13NFBuy/C+bFLhxA5bfd3clT25y76QY0AM=
-github.com/lightninglabs/lndclient v1.0.1-0.20260701212139-09c54915cfba h1:PbtOHmA9P41mjWt7HDZDDzYshv8fmyhIBPkdOf8wKws=
-github.com/lightninglabs/lndclient v1.0.1-0.20260701212139-09c54915cfba/go.mod h1:DtZg/wz7YFXVCwOwYOJyWKQBnUp1NFg4RQdax3MSYbc=
+github.com/lightninglabs/lndclient v1.0.1-0.20260730152521-c255827dd83e h1:QdaQT0PQ+RjzpsqHHAQa44WoymcMCwMlxbI9S+PTme8=
+github.com/lightninglabs/lndclient v1.0.1-0.20260730152521-c255827dd83e/go.mod h1:DtZg/wz7YFXVCwOwYOJyWKQBnUp1NFg4RQdax3MSYbc=
 github.com/lightninglabs/loop v0.33.0-beta h1:cfs+JrnmKw+ANa09XFS/2Jjm9wxHq3CfAzh9B1ym3e0=
 github.com/lightninglabs/loop v0.33.0-beta/go.mod h1:uTcjRmEC4ni4lWrOdnIvI5pyY8XJ2wXSXSE12vwFgzk=
 github.com/lightninglabs/migrate/v4 v4.18.2-9023d66a-fork-pr-2 h1:eFjp1dIB2BhhQp/THKrjLdlYuPugO9UU4kDqu91OX/Q=

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -160,6 +160,17 @@ type behavior struct {
 	exitCostNotified           bool
 	abandonedBroadcastsRemoved bool
 
+	// failedBroadcastTxids records every txid txconfirm has reported as
+	// failed during this actor lifetime. It exists because applyFailedEvent
+	// strips the failing txid from PlannerState.InFlightTxids before it
+	// stamps FailReason, so by the time the terminal cleanup reads planner
+	// state the transaction that actually killed the job is no longer
+	// listed there — and that is precisely the transaction lnd is still
+	// rebroadcasting (wavelength#609). Kept in memory only: the registry
+	// restores non-terminal records, so a terminal job never re-runs the
+	// cleanup after a restart and has nothing to reload.
+	failedBroadcastTxids map[chainhash.Hash]struct{}
+
 	// requiredLockTime caches the exit policy's absolute nLockTime once the
 	// policy has been resolved (in startSweep). The standard timeout policy
 	// reports zero; a vHTLC refund-without-receiver policy reports the
@@ -292,6 +303,8 @@ func (b *behavior) dispatch(ctx context.Context, ax actor.Exec[unrollTx],
 		})
 
 	case *TxFailedMsg:
+		b.recordFailedBroadcast(m.Txid)
+
 		return b.handleEvent(ctx, ax, &TxFailedEvent{
 			Txid:   m.Txid,
 			Reason: b.failureReasonForTx(m.Txid, m.Reason),
@@ -923,6 +936,8 @@ func (b *behavior) ensureNodeConfirmed(ctx context.Context,
 	}
 
 	if ensureResp.State == txconfirm.TxStateFailed {
+		b.recordFailedBroadcast(txid)
+
 		return b.driveEvent(ctx, ax, &TxFailedEvent{
 			Txid: txid,
 			Reason: b.failureReasonForTx(
@@ -2216,6 +2231,24 @@ func (b *behavior) notifyRegistryIfTerminal(ctx context.Context) {
 	b.terminalNotified = true
 }
 
+// recordFailedBroadcast notes that txconfirm reported txid as failed, so the
+// terminal cleanup can still ask the wallet to drop it. The FSM removes a
+// failing txid from PlannerState.InFlightTxids as it stamps the failure, which
+// would otherwise hide the one transaction most in need of removal
+// (wavelength#609).
+//
+// A proof-node failure is terminal by construction: an operator-signed proof
+// node cannot be rebuilt or replaced, and txconfirm has already evicted the
+// transaction (TxStateFailed is terminal) and released its fee-input lease. So
+// the transaction is provably dead and nothing else is still working on it.
+func (b *behavior) recordFailedBroadcast(txid chainhash.Hash) {
+	if b.failedBroadcastTxids == nil {
+		b.failedBroadcastTxids = make(map[chainhash.Hash]struct{})
+	}
+
+	b.failedBroadcastTxids[txid] = struct{}{}
+}
+
 // removeAbandonedBroadcasts asks the chain backend to drop the job's
 // broadcast-but-unconfirmed transactions from the wallet after a terminal
 // failure, so a full-node wallet stops perpetually rebroadcasting a proof (or
@@ -2252,13 +2285,36 @@ func (b *behavior) removeAbandonedBroadcasts(ctx context.Context,
 	); sweepTxid != nil {
 
 		if _, dup := seen[*sweepTxid]; !dup {
+			seen[*sweepTxid] = struct{}{}
 			txids = append(txids, *sweepTxid)
 		}
+	}
+
+	// Finally, include every transaction txconfirm reported as failed. The
+	// FSM drops a failing txid from InFlightTxids as it stamps the failure,
+	// so this is the only place the rejected transaction — the one lnd is
+	// still rebroadcasting — reappears (wavelength#609). A confirmed
+	// transaction is still excluded: it is on-chain, never rebroadcast, and
+	// lnd refuses to remove it.
+	for txid := range b.failedBroadcastTxids {
+		if _, dup := seen[txid]; dup {
+			continue
+		}
+		if containsHash(job.PlannerState.ConfirmedTxids, txid) {
+			continue
+		}
+
+		seen[txid] = struct{}{}
+		txids = append(txids, txid)
 	}
 
 	if len(txids) == 0 {
 		return
 	}
+
+	// Map iteration is unordered; sort so the removal sequence (and the
+	// resulting log lines) are deterministic across runs.
+	sortHashes(txids)
 
 	// Fire the removals off the actor Receive goroutine. This cleanup is
 	// pure best-effort housekeeping — the terminal outcome is already

--- a/unroll/actor.go
+++ b/unroll/actor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"time"
 
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
@@ -151,12 +152,13 @@ type behavior struct {
 	session *Session
 	pending *actorCheckpoint
 
-	sweepTx           *wire.MsgTx
-	blockSubActive    bool
-	spendWatchActive  bool
-	proofSpendWatches map[wire.OutPoint]struct{}
-	terminalNotified  bool
-	exitCostNotified  bool
+	sweepTx                    *wire.MsgTx
+	blockSubActive             bool
+	spendWatchActive           bool
+	proofSpendWatches          map[wire.OutPoint]struct{}
+	terminalNotified           bool
+	exitCostNotified           bool
+	abandonedBroadcastsRemoved bool
 
 	// requiredLockTime caches the exit policy's absolute nLockTime once the
 	// policy has been resolved (in startSweep). The standard timeout policy
@@ -740,6 +742,13 @@ func safeTxOutPkScript(tx *wire.MsgTx, index uint32) ([]byte, error) {
 // back to this bounded lookback, preserving the pre-commitment-height
 // behaviour exactly.
 const proofNodeHeightHintLookback uint32 = 10000
+
+// removeAbandonedBroadcastTimeout bounds each best-effort wallet RemoveTx RPC
+// issued on the terminal-failure cleanup path. lnd's RemoveTransaction is a
+// fast local wallet mutation, so 30s is generous headroom for a heavily loaded
+// node while still guaranteeing that a hung or unresponsive backend cannot leak
+// the detached cleanup goroutine indefinitely (wavelength#609).
+const removeAbandonedBroadcastTimeout = 30 * time.Second
 
 // proofNodeHeightHint returns the earliest safe confirmation height hint for
 // proof-graph transactions given the actor's current best height. Roots and
@@ -2158,6 +2167,17 @@ func (b *behavior) notifyRegistryIfTerminal(ctx context.Context) {
 		return
 	}
 
+	// On a terminal failure, ask the wallet backend to drop the job's
+	// broadcast-but-unconfirmed transactions so a full-node wallet stops
+	// perpetually rebroadcasting a proof (or sweep) tx that can never
+	// confirm now that the exit has failed (wavelength#609). Gated by its
+	// own once-flag so it is independent of the registry handoff below and
+	// does not re-issue removals on every subsequent terminal tick.
+	if phase == PhaseFailed && !b.abandonedBroadcastsRemoved {
+		b.removeAbandonedBroadcasts(ctx, job)
+		b.abandonedBroadcastsRemoved = true
+	}
+
 	if b.cfg.RegistryRef == nil || b.terminalNotified {
 		return
 	}
@@ -2194,6 +2214,82 @@ func (b *behavior) notifyRegistryIfTerminal(ctx context.Context) {
 	}
 
 	b.terminalNotified = true
+}
+
+// removeAbandonedBroadcasts asks the chain backend to drop the job's
+// broadcast-but-unconfirmed transactions from the wallet after a terminal
+// failure, so a full-node wallet stops perpetually rebroadcasting a proof (or
+// sweep) transaction that can never confirm now that the exit has failed
+// (wavelength#609). Only in-flight (submitted, not yet confirmed) transactions
+// are removed; confirmed transactions are on-chain and are never rebroadcast.
+// The removal is best-effort: a failure is logged and does not affect the
+// terminal handoff, and a backend without the wallet-removal capability
+// (chainsource.TxRemover) treats the request as a no-op.
+func (b *behavior) removeAbandonedBroadcasts(ctx context.Context,
+	job *JobState) {
+
+	if b.cfg.ChainSource == nil || job == nil {
+		return
+	}
+
+	seen := make(map[chainhash.Hash]struct{})
+	txids := make(
+		[]chainhash.Hash, 0, len(job.PlannerState.InFlightTxids)+1,
+	)
+	for _, txid := range job.PlannerState.InFlightTxids {
+		if _, dup := seen[txid]; dup {
+			continue
+		}
+		seen[txid] = struct{}{}
+		txids = append(txids, txid)
+	}
+
+	// Include the sweep tx if it was broadcast (advanced past pending); a
+	// materialization failure leaves the sweep pending, so this is nil
+	// then.
+	if sweepTxid := effectiveSweepTxid(
+		job.PlannerState, b.sweepTx,
+	); sweepTxid != nil {
+
+		if _, dup := seen[*sweepTxid]; !dup {
+			txids = append(txids, *sweepTxid)
+		}
+	}
+
+	if len(txids) == 0 {
+		return
+	}
+
+	// Fire the removals off the actor Receive goroutine. This cleanup is
+	// pure best-effort housekeeping — the terminal outcome is already
+	// decided — so it must never sit in front of the terminal registry
+	// handoff below. A slow or hung lnd RemoveTransaction RPC on a
+	// synchronous Ask would otherwise wedge the actor's single Receive
+	// goroutine, stalling the terminal notification and every later message
+	// for this target. Detaching mirrors txconfirm's async wallet-lease
+	// release. Each op carries its own timeout so a stuck backend bounds
+	// the goroutine's lifetime, and cancellation is detached from the
+	// request ctx so a caller disconnect cannot suppress the cleanup.
+	chainSource := b.cfg.ChainSource
+	log := b.log
+	go func() {
+		for _, txid := range txids {
+			opCtx, cancel := context.WithTimeout(
+				context.WithoutCancel(ctx),
+				removeAbandonedBroadcastTimeout,
+			)
+			_, err := chainSource.Ask(
+				opCtx, &chainsource.RemoveTxRequest{Txid: txid},
+			).Await(opCtx).Unpack()
+			cancel()
+			if err != nil {
+				log.WarnS(opCtx, "Failed to remove abandoned "+
+					"broadcast on terminal failure", err,
+					slog.String("txid", txid.String()),
+				)
+			}
+		}
+	}()
 }
 
 // emitExitCostIfCompleted sends the final unilateral exit miner fee to the

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -407,15 +407,16 @@ type confReq = chainsource.RegisterConfRequest
 // fakeChainSourceRef is a minimal chainsource actor ref for sweep fee
 // estimation tests.
 type fakeChainSourceRef struct {
-	mu         sync.Mutex
-	bestHeight int32
-	feeRate    int64
-	feeErr     error
-	blockRef   actor.TellOnlyRef[chainsource.BlockEpoch]
-	spendRefs  map[wire.OutPoint]spendEventRef
-	spendRegs  []wire.OutPoint
-	confRefs   map[chainhash.Hash]confRef
-	confReqs   map[chainhash.Hash]*confReq
+	mu          sync.Mutex
+	bestHeight  int32
+	feeRate     int64
+	feeErr      error
+	blockRef    actor.TellOnlyRef[chainsource.BlockEpoch]
+	spendRefs   map[wire.OutPoint]spendEventRef
+	spendRegs   []wire.OutPoint
+	removedTxes []chainhash.Hash
+	confRefs    map[chainhash.Hash]confRef
+	confReqs    map[chainhash.Hash]*confReq
 }
 
 // spendEventRef is the fake chain-source spend notification actor reference.
@@ -496,6 +497,18 @@ func (f *fakeChainSourceRef) Ask(_ context.Context,
 		promise.Complete(
 			fn.Ok[chainsource.ChainSourceResp](
 				&chainsource.SubscribeBlocksResponse{},
+			),
+		)
+
+	case *chainsource.RemoveTxRequest:
+		f.mu.Lock()
+		f.removedTxes = append(f.removedTxes, msg.Txid)
+		f.mu.Unlock()
+		promise.Complete(
+			fn.Ok[chainsource.ChainSourceResp](
+				&chainsource.RemoveTxResponse{
+					Txid: msg.Txid,
+				},
 			),
 		)
 
@@ -641,6 +654,15 @@ func (f *fakeChainSourceRef) spendRegistrations() []wire.OutPoint {
 	defer f.mu.Unlock()
 
 	return append([]wire.OutPoint(nil), f.spendRegs...)
+}
+
+// removedTxSnapshot returns the txids the actor asked to remove from the wallet
+// via RemoveTxRequest.
+func (f *fakeChainSourceRef) removedTxSnapshot() []chainhash.Hash {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append([]chainhash.Hash(nil), f.removedTxes...)
 }
 
 // fakeSweepWallet is a minimal signer plus wallet-destination test double.
@@ -2451,6 +2473,115 @@ func TestExternalProofSpendTerminatesActor(t *testing.T) {
 	require.True(t, ok)
 	require.Contains(t, stateResp.FailReason, rootOutpoint.String())
 	require.Contains(t, stateResp.FailReason, "spent externally")
+}
+
+// TestTerminalFailureRemovesAbandonedBroadcasts verifies wavelength#609: when
+// an unroll job fails terminally, the actor asks the wallet backend to drop its
+// broadcast-but-unconfirmed transactions so a full-node wallet stops
+// perpetually rebroadcasting a proof tx that can never confirm.
+func TestTerminalFailureRemovesAbandonedBroadcasts(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	unrollActor, beh, _, _ := newActorHarness(t, proof, desc)
+
+	chainSource, ok := beh.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+
+	// The root proof tx is submitted (in-flight) on start. Wait for the
+	// target spend watch, then fail the job with an external spend of the
+	// target outpoint (case 4). A target spend, unlike a root-output spend,
+	// does not confirm the still-in-flight root.
+	target := proof.TargetOutpoint()
+	rootTxid := proof.RootTxids()[0]
+	require.Eventually(t, func() bool {
+		for _, outpoint := range chainSource.spendRegistrations() {
+			if outpoint == target {
+				return true
+			}
+		}
+
+		return false
+	}, testTimeout, 10*time.Millisecond)
+
+	chainSource.emitSpendForOutpoint(t, target, chainhash.Hash{0xee}, 101)
+
+	require.Eventually(t, func() bool {
+		stateResp, ok := mustAsk(
+			t, unrollActor.Ref(), &GetStateRequest{},
+		).(*GetStateResp)
+		require.True(t, ok)
+
+		return stateResp.Phase == PhaseFailed
+	}, testTimeout, 10*time.Millisecond)
+
+	// The in-flight root tx must have been removed from the wallet so a
+	// full-node wallet stops rebroadcasting it.
+	require.Eventually(t, func() bool {
+		for _, txid := range chainSource.removedTxSnapshot() {
+			if txid == rootTxid {
+				return true
+			}
+		}
+
+		return false
+	}, testTimeout, 10*time.Millisecond,
+		"terminal failure must remove the in-flight proof tx (#609)")
+}
+
+// TestAbandonedBroadcastRemovalSkipsConfirmedTxids verifies that the terminal
+// cleanup removes only in-flight (broadcast-but-unconfirmed) transactions and
+// never a confirmed one: a confirmed tx is on-chain, so removing it from the
+// wallet would be wrong (and lnd would reject it anyway).
+func TestAbandonedBroadcastRemovalSkipsConfirmedTxids(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	_, beh, _, _ := newActorHarness(t, proof, desc)
+
+	chainSource, ok := beh.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	inFlightTxid := chainhash.Hash{0xa1}
+	confirmedTxid := chainhash.Hash{0xc0}
+
+	job := &JobState{
+		PlannerState: unrollplan.State{
+			InFlightTxids: []chainhash.Hash{
+				inFlightTxid,
+			},
+			ConfirmedTxids: []chainhash.Hash{
+				confirmedTxid,
+			},
+		},
+	}
+
+	beh.removeAbandonedBroadcasts(context.Background(), job)
+
+	// The in-flight tx must be removed; the removal runs on a detached
+	// goroutine, so poll for it.
+	require.Eventually(t, func() bool {
+		for _, txid := range chainSource.removedTxSnapshot() {
+			if txid == inFlightTxid {
+				return true
+			}
+		}
+
+		return false
+	}, testTimeout, 10*time.Millisecond,
+		"in-flight tx must be removed on terminal failure (#609)")
+
+	// The confirmed tx must never be removed. Its absence is stable once
+	// the in-flight removal above has been observed.
+	for _, txid := range chainSource.removedTxSnapshot() {
+		require.NotEqual(
+			t, confirmedTxid, txid,
+			"a confirmed tx must never be removed from the wallet",
+		)
+	}
 }
 
 // TestConfirmedNodesAdvanceToSweep verifies that node confirmations move the

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -2533,6 +2533,57 @@ func TestTerminalFailureRemovesAbandonedBroadcasts(t *testing.T) {
 		"terminal failure must remove the in-flight proof tx (#609)")
 }
 
+// TestRejectedProofTxIsRemovedOnTerminalFailure covers wavelength#609's own
+// scenario: txconfirm hard-rejects a proof tx, which is the transaction lnd
+// keeps rebroadcasting from its wallet queue. The FSM strips that txid from
+// InFlightTxids as it stamps the failure, so removal must not be driven from
+// planner state alone — otherwise the one transaction that needs dropping is
+// the one transaction never dropped.
+//
+// This is the safest removal path there is: an operator-signed proof node
+// cannot be rebuilt or replaced, so the failure is terminal by construction,
+// and txconfirm has already evicted the tx (TxStateFailed is terminal) and
+// released its fee-input lease. Nothing else is still trying to land it.
+func TestRejectedProofTxIsRemovedOnTerminalFailure(t *testing.T) {
+	proof := buildLinearProof(t)
+	desc := testDescriptor(t, proof.TargetOutpoint(), proof.CSVDelay())
+	rootTxid := proof.RootTxids()[0]
+
+	unrollActor, beh, txconfirmRef, _ := newActorHarness(t, proof, desc)
+
+	chainSource, ok := beh.cfg.ChainSource.(*fakeChainSourceRef)
+	require.True(t, ok)
+
+	txconfirmRef.setImmediateFailed(rootTxid, "rejected")
+
+	mustAsk(t, unrollActor.Ref(), &StartUnrollRequest{
+		Height:  100,
+		Trigger: TriggerManual,
+	})
+
+	require.Eventually(t, func() bool {
+		stateResp, ok := mustAsk(
+			t, unrollActor.Ref(), &GetStateRequest{},
+		).(*GetStateResp)
+		require.True(t, ok)
+
+		return stateResp.Phase == PhaseFailed
+	}, testTimeout, 10*time.Millisecond)
+
+	// The rejected proof tx must be removed from the wallet even though the
+	// FSM already dropped it from InFlightTxids.
+	require.Eventually(t, func() bool {
+		for _, txid := range chainSource.removedTxSnapshot() {
+			if txid == rootTxid {
+				return true
+			}
+		}
+
+		return false
+	}, testTimeout, 10*time.Millisecond,
+		"the rejected proof tx must be removed from the wallet (#609)")
+}
+
 // TestAbandonedBroadcastRemovalSkipsConfirmedTxids verifies that the terminal
 // cleanup removes only in-flight (broadcast-but-unconfirmed) transactions and
 // never a confirmed one: a confirmed tx is on-chain, so removing it from the


### PR DESCRIPTION
Closes #609.

> Depends on lightninglabs/lndclient#284 (`WalletKit.RemoveTransaction`), now **merged** — this PR bumps `lndclient` to the merged master commit (no `replace`).

## Problem

After a unilateral-exit unroll job goes `FAILED`, **LND keeps rebroadcasting the rejecting proof tx from its own wallet queue every ~60s indefinitely** — the wavelength daemon has stopped touching the job, but the transaction (a zero-fee anchor parent that can never relay alone) stays in LND's rebroadcast set. Nothing tells LND to drop it.

## Fix

Give the unroll actor a way to abandon its broadcast transactions on terminal failure:

1. **`go.mod`** — bump `lndclient` to the master commit adding `WalletKit.RemoveTransaction`.
2. **`chainbackends`** — `TxBroadcaster` gains `RemoveTransaction`; `LNDBackend` exposes it as the optional `chainsource.TxRemover` capability, wrapping lnd's `WalletKit.RemoveTransaction` RPC.
3. **`chainsource`** — a `TxRemover` optional-capability interface + a `RemoveTxRequest` routed through the chain-source actor. The handler forwards to a capable backend and treats a backend **without** the capability (a pure Esplora chain source) or an already-absent tx as a **no-op success** — so callers request removal uniformly without knowing the backend, and no `ChainBackend` implementer/fake had to change.
4. **`unroll`** — on terminal `PhaseFailed`, the actor removes its in-flight (broadcast-but-unconfirmed) proof/sweep txids via `RemoveTxRequest`. Confirmed txs are left alone (on-chain, never rebroadcast). The removal runs once, is best-effort, and detaches cancellation like the terminal registry handoff.

**Backend scope:** the LND backend is fully covered. `lwwallet`/`btcwbackend` sit on btcwallet, which also rebroadcasts — but since they don't implement `TxRemover`, they no-op today; a btcwallet removal path is a scoped follow-up.

## Testing

- `chainsource`: `TestChainSourceActorRemoveTx` — forwards to a capable backend, treats an ignorable "not found" error as success, and no-ops on a backend without the capability.
- `unroll`: `TestTerminalFailureRemovesAbandonedBroadcasts` — a terminal failure removes the in-flight proof tx.

`chainsource` + `chainbackends` + `unroll` suites, `go build`, `gofmt`, and `lint-changed-local` are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

