### PR TITLE
harness: add watch-only LND test nodes

### DIFF
--- a/harness/harness.go
+++ b/harness/harness.go
@@ -38,6 +38,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/taprpc"
 	"github.com/lightninglabs/wavelength/chain"
 	lnrpc "github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
@@ -2356,6 +2357,17 @@ func (h *Harness) startLND() *LndInstance {
 func (h *Harness) startLNDInstance(name, dataDir string,
 	requireInterceptor bool, chainBackend string) *LndInstance {
 
+	return h.startLNDInstanceWithOptions(
+		name, dataDir, requireInterceptor, chainBackend, false, nil,
+	)
+}
+
+// startLNDInstanceWithOptions starts an lnd container whose wallet can either
+// use the harness's automatic seed or be initialized explicitly by the caller.
+func (h *Harness) startLNDInstanceWithOptions(name, dataDir string,
+	requireInterceptor bool, chainBackend string, manualWalletInit bool,
+	extraArgs []string) *LndInstance {
+
 	h.T.Helper()
 
 	require.NoError(h.T, os.MkdirAll(dataDir, 0o755))
@@ -2369,6 +2381,8 @@ func (h *Harness) startLNDInstance(name, dataDir string,
 		image:              imageRepo(h.opts.LNDImage),
 		tag:                imageTag(h.opts.LNDImage),
 		requireInterceptor: requireInterceptor,
+		manualWalletInit:   manualWalletInit,
+		extraArgs:          extraArgs,
 		chainBackend:       chainBackend,
 	})
 
@@ -2542,6 +2556,132 @@ func (h *Harness) StartAdditionalLNDWithBackend(name,
 	h.extraLNDs[name] = inst
 
 	return inst
+}
+
+// StartAdditionalWatchOnlyLND launches an lnd node backed by a separate remote
+// signer. The signer retains the private wallet state while the returned node
+// imports its account xpubs and handles normal wallet and channel RPCs.
+func (h *Harness) StartAdditionalWatchOnlyLND(name string) *LndInstance {
+	h.T.Helper()
+
+	if name == "" {
+		name = fmt.Sprintf("lnd-watch-only-%d", len(h.extraLNDs)+1)
+	}
+	if _, exists := h.extraLNDs[name]; exists {
+		h.T.Fatalf("LND instance %s already exists", name)
+	}
+
+	signerName := name + "-signer"
+	signer := h.StartAdditionalLND(signerName)
+
+	ctx, cancel := context.WithTimeout(h.T.Context(), defaultTimeout)
+	defer cancel()
+
+	accounts, err := signer.Client.WalletKit.ListAccounts(
+		ctx, "", walletrpc.AddressType_UNKNOWN,
+	)
+	require.NoError(h.T, err, "export %s wallet accounts", signerName)
+	watchOnlyAccounts, err := walletrpc.AccountsToWatchOnly(accounts)
+	require.NoError(
+		h.T, err, "convert %s accounts to watch-only", signerName,
+	)
+
+	dataDir := filepath.Join(h.artifactsDir, name)
+	remoteSignerDir := filepath.Join(dataDir, "remote-signer")
+	require.NoError(h.T, os.MkdirAll(remoteSignerDir, 0o700))
+
+	remoteTLSPath := filepath.Join(remoteSignerDir, "tls.cert")
+	remoteMacaroonPath := filepath.Join(
+		remoteSignerDir, "admin.macaroon",
+	)
+	copyFile(h.T, signer.TLSCert, remoteTLSPath, 0o600)
+	copyFile(h.T, signer.Macaroon, remoteMacaroonPath, 0o600)
+
+	inst := h.startLNDInstanceWithOptions(
+		name, dataDir, false, LNDChainBackendBitcoind, true,
+		[]string{
+			"--remotesigner.enable",
+			fmt.Sprintf("--remotesigner.rpchost=%s:10009",
+				signer.ContainerName),
+			"--remotesigner.tlscertpath=" +
+				"/data/remote-signer/tls.cert",
+			"--remotesigner.macaroonpath=" +
+				"/data/remote-signer/admin.macaroon",
+		},
+	)
+	h.initWatchOnlyLND(inst, watchOnlyAccounts)
+	h.initAndWaitLNDInstance(inst)
+	h.extraLNDs[name] = inst
+
+	return inst
+}
+
+// initWatchOnlyLND imports account xpubs while lnd is serving only its wallet
+// unlocker RPC. The remote signer flags are already active at this point.
+func (h *Harness) initWatchOnlyLND(inst *LndInstance,
+	accounts []*lnrpc.WatchOnlyAccount) {
+
+	h.T.Helper()
+
+	tlsCert, err := loadClientTLSCredentials(inst.TLSCert)
+	require.NoError(h.T, err, "load %s TLS credentials", inst.Name)
+
+	addr := net.JoinHostPort("127.0.0.1", inst.GRPCPort)
+	conn, err := grpc.NewClient(
+		addr, grpc.WithTransportCredentials(tlsCert),
+	)
+	require.NoError(h.T, err, "connect to %s wallet unlocker", inst.Name)
+	defer conn.Close()
+
+	stateClient := lnrpc.NewStateClient(conn)
+	require.Eventually(
+		h.T, func() bool {
+			const checkTimeout = 5 * time.Second
+
+			ctx, cancel := context.WithTimeout(
+				h.T.Context(), checkTimeout,
+			)
+			defer cancel()
+
+			resp, err := stateClient.GetState(
+				ctx, &lnrpc.GetStateRequest{},
+			)
+			if err != nil {
+				return false
+			}
+
+			return resp.State == lnrpc.WalletState_NON_EXISTING
+		},
+		lndStartupTimeout, time.Second,
+		fmt.Sprintf("%s wallet not ready for initialization",
+			inst.Name),
+	)
+
+	ctx, cancel := context.WithTimeout(h.T.Context(), defaultTimeout)
+	defer cancel()
+
+	_, err = lnrpc.NewWalletUnlockerClient(conn).InitWallet(
+		ctx, &lnrpc.InitWalletRequest{
+			WalletPassword: []byte("itestpassword"),
+			WatchOnly: &lnrpc.WatchOnly{
+				Accounts: accounts,
+			},
+		},
+	)
+	require.NoError(h.T, err, "initialize %s watch-only wallet", inst.Name)
+}
+
+// copyFile copies a small credential file without retaining broader source
+// directory access inside the watch-only container.
+func copyFile(t *testing.T, source, destination string, mode os.FileMode) {
+	t.Helper()
+
+	contents, err := os.ReadFile(source)
+	require.NoError(t, err, "read %s", source)
+	require.NoError(
+		t, os.WriteFile(destination, contents, mode),
+		"write %s", destination,
+	)
 }
 
 // GetAdditionalLND returns a previously started extra LND instance by name.

--- a/harness/harness_test.go
+++ b/harness/harness_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2"
 	_ "github.com/lib/pq"
 	"github.com/lightninglabs/wavelength/harness"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -514,4 +515,44 @@ func TestHarnessMultiNode(t *testing.T) {
 	)
 
 	t.Log("Successfully verified multi-node setup and channel creation")
+}
+
+// TestHarnessWatchOnlyLND verifies that the harness provisions a usable
+// watch-only wallet with the standard lnd account-family range.
+func TestHarnessWatchOnlyLND(t *testing.T) {
+	ParallelN(t)
+
+	opts := harness.DefaultOptions()
+	opts.GroupName = t.Name()
+
+	h := harness.NewHarness(t, &opts)
+	t.Cleanup(h.Stop)
+	h.Start()
+
+	watchOnly := h.StartAdditionalWatchOnlyLND("watch-only")
+	signer := h.GetAdditionalLND("watch-only-signer")
+
+	watchOnlyInfo, err := watchOnly.Client.Client.GetInfo(t.Context())
+	require.NoError(t, err, "get watch-only node info")
+	signerInfo, err := signer.Client.Client.GetInfo(t.Context())
+	require.NoError(t, err, "get remote signer node info")
+	require.Equal(
+		t, signerInfo.IdentityPubkey, watchOnlyInfo.IdentityPubkey,
+	)
+
+	_, err = watchOnly.Client.WalletKit.DeriveNextKey(
+		t.Context(),
+		int32(
+			keychain.KeyFamily(100),
+		),
+	)
+	require.NoError(t, err, "derive imported watch-only family")
+
+	_, err = watchOnly.Client.WalletKit.DeriveNextKey(
+		t.Context(),
+		int32(
+			keychain.KeyFamily(9999),
+		),
+	)
+	require.ErrorContains(t, err, "watching-only")
 }

--- a/harness/tapd_harness.go
+++ b/harness/tapd_harness.go
@@ -80,6 +80,14 @@ type lndConfig struct {
 	// sets it.
 	requireInterceptor bool
 
+	// manualWalletInit leaves lnd at the wallet unlocker so the caller can
+	// initialize a restored or watch-only wallet through RPC.
+	manualWalletInit bool
+
+	// extraArgs supplies role-specific lnd flags, such as the remote signer
+	// endpoint used by a watch-only node.
+	extraArgs []string
+
 	// chainBackend selects lnd's chain backend: LNDChainBackendBitcoind
 	// (default) or LNDChainBackendNeutrino. Neutrino backs lnd via SPV over
 	// the regtest bitcoind's P2P + compact filters, exercising lnd's native
@@ -167,12 +175,15 @@ func (h *Harness) startLNDContainer(cfg lndConfig) *dockertest.Resource {
 		"--listen=0.0.0.0:9735",
 		fmt.Sprintf("--tlsextradomain=%s", lndName),
 		fmt.Sprintf("--tlsextraip=%s", lndName),
-		"--noseedbackup",
 		"--nobootstrap",
 		"--accept-keysend",
 		"--protocol.option-scid-alias",
 		"--protocol.zero-conf",
 	}
+	if !cfg.manualWalletInit {
+		cmd = append(cmd, "--noseedbackup")
+	}
+	cmd = append(cmd, cfg.extraArgs...)
 
 	// The swap node must retain and replay held HTLCs across an interceptor
 	// disconnect rather than resuming (and thus failing) them, which is


### PR DESCRIPTION
## Problem

The Docker integration harness initializes every LND with `--noseedbackup`. That is convenient for ordinary test nodes, but it prevents integration tests from exercising the production watch-only plus remote-signer wallet shape. Tests could only mock the watch-only account-family boundary.

## Change

- Allow an LND container to remain at the wallet unlocker for explicit initialization.
- Add `StartAdditionalWatchOnlyLND`, which starts a separate signing LND, exports its account xpubs, initializes the returned node as watch-only, and connects it to the signer over the harness Docker network.
- Copy only the signer TLS certificate and admin macaroon into the watch-only node instead of mounting the signer data directory.
- Add a Docker-backed harness test that verifies both nodes share an identity, family `100` derives successfully, and an unimported family such as `9999` fails with LND’s real `watching-only` error.

Existing harness users retain the automatic `--noseedbackup` behavior.

## Validation

- `go test -tags=itest ./harness -run '^TestHarnessWatchOnlyLND$' -v -count=1 -timeout=10m`
- `go test ./harness -run '^$' -tags=itest`
- `make lint-changed-local`
- `make tidy-module-check`
- `make commitmsg-lint commit=HEAD`
- `git diff --check`