### PR TITLE
build: bump version to v0.1.1-rc1

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -15,11 +15,11 @@ const (
 	AppMinor uint = 1
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 0
+	AppPatch uint = 1
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.
-	AppPreRelease = ""
+	AppPreRelease = "rc1"
 )
 
 var (


### PR DESCRIPTION
## What changed

- Increment `build.AppPatch` from `0` to `1`.
- Set `build.AppPreRelease` to `rc1` so `waved` and `wavecli` report `0.1.1-rc1`.

## Why

The `v0.1.x-branch` release line now contains the latest `main` changes and the final selected backport. Because the delta since `v0.1.0` spans a broad set of subsystems, this creates a release candidate for integration and artifact testing before the final `v0.1.1` release.

After the RC has soaked successfully, the final version-bump PR only needs to clear `AppPreRelease`.

## Release workflow

No workflow changes are required. The reproducible release workflow and the mobile/WASM bindings workflow both trigger on `v0.1.1-rc1`. Each recognizes the `-rc1` suffix and marks a newly created draft release as a prerelease, regardless of which workflow creates it first.

## Validation

- `make fmt-changed`
- `go test ./build`
- `make build`
- `./bin/waved --version` -> `waved version 0.1.1-rc1`
- `./bin/wavecli --version` -> `wavecli version 0.1.1-rc1`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`