### PR TITLE
wavewalletrpc: fix the sweep_all doc comment's flag spelling

### DIFF
--- a/rpc/wavewalletrpc/wallet.pb.go
+++ b/rpc/wavewalletrpc/wallet.pb.go
@@ -5478,7 +5478,7 @@ type OnchainAddressRequest struct {
 	// address is the bech32 onchain address originally issued or targeted.
 	Address string `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
 	// sweep_all marks an onchain send that drained the selected VTXOs
-	// entirely (wavecli send --send-all). A sweep's pending amount is the
+	// entirely (wavecli send --sweep-all). A sweep's pending amount is the
 	// gross outflow with the operator fee still baked in (the fee is only
 	// known once the leave round seals), so completion uses this marker to
 	// net the settled fee back out of the displayed amount. Bounded sends

--- a/rpc/wavewalletrpc/wallet.proto
+++ b/rpc/wavewalletrpc/wallet.proto
@@ -1599,7 +1599,7 @@ message OnchainAddressRequest {
     string address = 1;
 
     // sweep_all marks an onchain send that drained the selected VTXOs
-    // entirely (wavecli send --send-all). A sweep's pending amount is the
+    // entirely (wavecli send --sweep-all). A sweep's pending amount is the
     // gross outflow with the operator fee still baked in (the fee is only
     // known once the leave round seals), so completion uses this marker to
     // net the settled fee back out of the displayed amount. Bounded sends


### PR DESCRIPTION
## Summary

The `OnchainAddressRequest.sweep_all` doc comment tells readers to use `wavecli send --send-all`, but the flag the CLI registers is `--sweep-all`. Anyone copying the invocation from the comment (or from the API reference the SDK generates from it) hits an unknown-flag error.

This corrects the spelling in `wallet.proto` and regenerates the stubs with `make rpc`. Comment-only, no wire or behavior change.

Flagged by review on the SDK sync PR (lightninglabs/wavelength-sdk#65), where the typo surfaces in the generated API reference data. It would be good to backport this to `v0.1.x-branch` so the next `v0.1.1` tag carries the fix and the SDK picks it up at its next pin bump.
