### PR TITLE
lwwallet: resolve the wallet start block from the Esplora index

### DIFF
--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -161,10 +161,22 @@ prefix and dots replaced by underscores:
 |----------|-------------|
 | `WAVED_WALLET_PASSWORD` | Wallet password for create/unlock |
 | `WAVED_LWWALLET_SEED` | Hex-encoded raw seed (dev/CI only) |
+| `WAVED_LWWALLET_SEED_BIRTHDAY` | Creation date of that seed, `YYYY-MM-DD` or RFC3339 |
 | `WAVED_NETWORK` | Bitcoin network override |
 | `WAVED_WALLET_TYPE` | Wallet backend type |
 | `WAVED_WALLET_ESPLORAURL` | Esplora URL |
 | `WAVED_SERVER_HOST` | Operator server address |
+
+A raw seed carries no birthday, unlike an aezeed mnemonic, so a wallet
+created from `WAVED_LWWALLET_SEED` without `WAVED_LWWALLET_SEED_BIRTHDAY`
+starts scanning at genesis. That is slow but never misses funds. Set the
+birthday only when the seed is known to have no history before that date:
+too early only costs scan time, while too late silently hides earlier
+funds. A malformed date is rejected rather than treated as unset.
+
+The `lwwallet` backend usually resolves its own start height from the
+Esplora address index and ignores this, so it matters most for the
+neutrino-backed `btcwallet` backend, which has no index to consult.
 
 ## Initial Wallet Setup
 

--- a/lwwallet/CLAUDE.md
+++ b/lwwallet/CLAUDE.md
@@ -45,6 +45,16 @@ base logic with the neutrino-backed `btcwbackend` sibling via the extracted
 - `EsploraChainService` — `chain.Interface` adapter over `EsploraClient`,
   driven by a shared `TipPoller`. Feeds btcwallet's internal address-credit
   pipeline. Constructor: `NewEsploraChainService(esplora, tipPoller, logger)`.
+- Start-block discovery (`start_block.go`) — resolves where a new or
+  restored wallet begins scanning from the Esplora address index instead of
+  from the seed birthday, and writes it into `waddrmgr` as a *verified*
+  birthday block before `BtcWallet.Start()`. Entry point:
+  `Wallet.stampStartBlock`. Left to itself btcwallet binary searches block
+  timestamps (`locateBirthdayBlock`), which bottoms out at genesis for any
+  birthday older than the chain and then walks every block to the tip.
+  Discovery instead derives each active key scope's receive/change scripts
+  through btcwallet's own scoped key managers, probes `/scripthash/:h` under
+  the configured gap limit, and takes the earliest confirmed height.
 - `BoardingBackendAdapter` — Embeds `walletcore.BoardingBackendBase` for
   shared key derivation/script import; implements `wallet.BoardingBackend`
   and `wallet.OutputLeaser`. Queries Esplora directly for UTXOs (bypasses
@@ -79,6 +89,24 @@ base logic with the neutrino-backed `btcwbackend` sibling via the extracted
   (known limitation; acceptable for confirmation-target use cases).
 - LRU caches only hold immutable, hash-addressed data; a verified hash prevents
   a compromised Esplora endpoint from injecting arbitrary cache entries.
+- `scriptHashHex` hex-encodes the SHA256 digest in its natural byte order.
+  Esplora's REST API differs from the Electrum wire protocol here, which
+  reverses it, and a wrong order fails silently because the API answers an
+  unknown script hash with an empty result rather than an error.
+- Start-block discovery only ever stamps a wallet that has no birthday block
+  at all, and never moves the sync cursor backwards. Once btcwallet has
+  recorded a birthday block it owns the cursor.
+- A discovery failure is non-fatal: the wallet still starts and btcwallet
+  falls back to its own timestamp search, just slowly. Discovery refuses to
+  stamp rather than stamping on partial information, because a short walk
+  finds fewer used scripts, which raises the height it reports and moves the
+  stamp toward the tip: the direction that loses funds.
+- Start-block discovery trusts the Esplora index. That holds for a single
+  self-consistent instance, but a load-balanced public endpoint can serve a
+  current tip and a still-syncing script index from different backends, and
+  partial history is indistinguishable from an unused script. A restore in
+  that window stamps above its own funds permanently, since the stamp is
+  written verified. Point `EsploraURL` at an endpoint you control.
 - UTXO enumeration queries Esplora directly rather than btcwallet's internal
   UTXO set, because btcwallet does not credit-mark non-default scope outputs.
 - `Stop()` explicitly closes btcwallet's internal database to prevent resource

--- a/lwwallet/esplora.go
+++ b/lwwallet/esplora.go
@@ -177,16 +177,18 @@ type esploraBlock struct {
 	Timestamp int64 `json:"timestamp"`
 }
 
-// scriptHashHex computes the Esplora script hash for a pkScript. The hash
-// is SHA256(pkScript) with the bytes reversed and hex-encoded, matching
-// Electrum's script hash format used by Esplora.
+// scriptHashHex computes the Esplora script hash for a pkScript: the
+// hex-encoded SHA256 of the script, in the digest's natural byte order.
+//
+// This is deliberately NOT the Electrum convention. The Electrum wire
+// protocol (blockchain.scripthash.*) takes the digest byte-reversed, and
+// Esplora's REST API does not — /scripthash/:hash wants it forward.
+// Reversing here makes every lookup miss silently, since the API answers
+// an unknown script hash with an empty result rather than a 404. See
+// systest.TestEsploraScriptHashEncoding, which pins the byte order
+// against a real electrs instance rather than against this function.
 func scriptHashHex(pkScript []byte) string {
 	h := sha256.Sum256(pkScript)
-
-	// Reverse the hash bytes (Electrum convention).
-	for i, j := 0, len(h)-1; i < j; i, j = i+1, j-1 {
-		h[i], h[j] = h[j], h[i]
-	}
 
 	return hex.EncodeToString(h[:])
 }

--- a/lwwallet/esplora_index.go
+++ b/lwwallet/esplora_index.go
@@ -1,0 +1,97 @@
+package lwwallet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// esploraScriptStatSet is one half of an Esplora scripthash stats
+// response: the confirmed (chain) or unconfirmed (mempool) tally of
+// outputs paying to and spending from a script.
+type esploraScriptStatSet struct {
+	// FundedTxoCount is the number of outputs paying to the script.
+	FundedTxoCount int `json:"funded_txo_count"`
+
+	// SpentTxoCount is the number of those outputs already spent.
+	SpentTxoCount int `json:"spent_txo_count"`
+
+	// TxCount is the number of transactions referencing the script,
+	// whether they pay to it or spend from it.
+	TxCount int `json:"tx_count"`
+}
+
+// esploraScriptStats is the response from /scripthash/:hash. It is the
+// cheapest "has this script ever been used?" probe the Esplora index
+// offers: one small JSON document per script, with no dependence on how
+// long the chain is.
+type esploraScriptStats struct {
+	// ChainStats tallies confirmed activity.
+	ChainStats esploraScriptStatSet `json:"chain_stats"`
+
+	// MempoolStats tallies unconfirmed activity.
+	MempoolStats esploraScriptStatSet `json:"mempool_stats"`
+}
+
+// Used reports whether the index has ever seen this script on chain or
+// in the mempool.
+func (s *esploraScriptStats) Used() bool {
+	return s.ChainStats.TxCount > 0 || s.MempoolStats.TxCount > 0
+}
+
+// esploraScriptTx is one entry of a scripthash transaction history
+// page. Only the fields needed to walk history backwards and read
+// confirmation heights are decoded.
+type esploraScriptTx struct {
+	// Txid is the hex-encoded transaction ID.
+	Txid string `json:"txid"`
+
+	// Status carries the confirmation state and height.
+	Status esploraStatus `json:"status"`
+}
+
+// GetScriptStats returns the Esplora index's activity tally for the
+// given pkScript. Responses are never cached: an unused script can
+// become used at any time, and a stale "unused" answer would silently
+// narrow wallet recovery.
+func (c *EsploraClient) GetScriptStats(ctx context.Context, pkScript []byte) (
+	*esploraScriptStats, error) {
+
+	path := "/scripthash/" + scriptHashHex(pkScript)
+	body, err := c.get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("get script stats: %w", err)
+	}
+
+	var stats esploraScriptStats
+	if err := json.Unmarshal(body, &stats); err != nil {
+		return nil, fmt.Errorf("parse script stats: %w", err)
+	}
+
+	return &stats, nil
+}
+
+// GetScriptChainTxs returns one page of confirmed transactions for the
+// given pkScript, newest first. Esplora pages this endpoint at 25
+// entries; pass the last txid of a page as lastSeenTxid to fetch the
+// next one, and treat an empty page as the end of history.
+func (c *EsploraClient) GetScriptChainTxs(ctx context.Context, pkScript []byte,
+	lastSeenTxid string) ([]esploraScriptTx, error) {
+
+	path := "/scripthash/" + scriptHashHex(pkScript) + "/txs/chain"
+	if lastSeenTxid != "" {
+		path += "/" + lastSeenTxid
+	}
+
+	body, err := c.get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("get script chain txs: %w", err)
+	}
+
+	var txs []esploraScriptTx
+	if err := json.Unmarshal(body, &txs); err != nil {
+		return nil, fmt.Errorf("parse script chain txs: %w", err)
+	}
+
+	return txs, nil
+}

--- a/lwwallet/esplora_index_test.go
+++ b/lwwallet/esplora_index_test.go
@@ -1,0 +1,133 @@
+package lwwallet
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEsploraGetScriptStats verifies the script-usage probe hits the
+// right route and reads both the confirmed and unconfirmed tallies.
+func TestEsploraGetScriptStats(t *testing.T) {
+	t.Parallel()
+
+	pkScript := []byte{0x51, 0x20, 0x0a, 0x0b}
+
+	sum := sha256.Sum256(pkScript)
+	wantPath := "/scripthash/" + hex.EncodeToString(sum[:])
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, wantPath, r.URL.Path)
+
+			err := json.NewEncoder(w).Encode(esploraScriptStats{
+				ChainStats: esploraScriptStatSet{
+					FundedTxoCount: 2,
+					SpentTxoCount:  1,
+					TxCount:        3,
+				},
+			})
+			require.NoError(t, err)
+		}),
+	)
+	defer srv.Close()
+
+	client := NewEsploraClient(srv.URL, btclog.Disabled)
+
+	stats, err := client.GetScriptStats(t.Context(), pkScript)
+	require.NoError(t, err)
+	require.Equal(t, 3, stats.ChainStats.TxCount)
+	require.True(t, stats.Used())
+}
+
+// TestEsploraScriptStatsUsed checks the used/unused verdict, including
+// the mempool-only case: a script funded but not yet mined still counts
+// as used, since a wallet must not conclude it has no history while a
+// payment to it is sitting in the mempool.
+func TestEsploraScriptStatsUsed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		stats esploraScriptStats
+		want  bool
+	}{{
+		name: "never seen",
+		want: false,
+	}, {
+		name: "confirmed history",
+		stats: esploraScriptStats{
+			ChainStats: esploraScriptStatSet{
+				TxCount: 1,
+			},
+		},
+		want: true,
+	}, {
+		name: "mempool only",
+		stats: esploraScriptStats{
+			MempoolStats: esploraScriptStatSet{
+				TxCount: 1,
+			},
+		},
+		want: true,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, test.want, test.stats.Used())
+		})
+	}
+}
+
+// TestEsploraGetScriptChainTxs verifies the confirmed-history route,
+// including the continuation form used to page backwards through a
+// script's history toward its earliest appearance.
+func TestEsploraGetScriptChainTxs(t *testing.T) {
+	t.Parallel()
+
+	pkScript := []byte{0x00, 0x14, 0x01}
+
+	sum := sha256.Sum256(pkScript)
+	base := "/scripthash/" + hex.EncodeToString(sum[:]) + "/txs/chain"
+
+	const lastSeen = "beef"
+
+	var gotPaths []string
+
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPaths = append(gotPaths, r.URL.Path)
+
+			err := json.NewEncoder(w).Encode([]esploraScriptTx{{
+				Txid: "aabb",
+				Status: esploraStatus{
+					Confirmed:   true,
+					BlockHeight: 4321,
+				},
+			}})
+			require.NoError(t, err)
+		}),
+	)
+	defer srv.Close()
+
+	client := NewEsploraClient(srv.URL, btclog.Disabled)
+
+	txs, err := client.GetScriptChainTxs(t.Context(), pkScript, "")
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	require.Equal(t, int64(4321), txs[0].Status.BlockHeight)
+	require.True(t, txs[0].Status.Confirmed)
+
+	_, err = client.GetScriptChainTxs(t.Context(), pkScript, lastSeen)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{base, base + "/" + lastSeen}, gotPaths)
+}

--- a/lwwallet/esplora_test.go
+++ b/lwwallet/esplora_test.go
@@ -2,6 +2,7 @@ package lwwallet
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
@@ -155,9 +156,12 @@ func TestEsploraGetScriptUtxos(t *testing.T) {
 	srv := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Verify the path contains the correct script hash.
-			expectedHash := scriptHashHex(pkScript)
-			expectedPath := "/scripthash/" + expectedHash +
-				"/utxo"
+			// The expectation is computed here rather than via
+			// scriptHashHex so this asserts the encoding instead
+			// of merely agreeing with whatever the helper does.
+			sum := sha256.Sum256(pkScript)
+			expectedPath := "/scripthash/" +
+				hex.EncodeToString(sum[:]) + "/utxo"
 			require.Equal(t, expectedPath, r.URL.Path)
 
 			utxos := []esploraUtxo{
@@ -411,4 +415,44 @@ func TestEsploraHTTPError(t *testing.T) {
 	_, err := client.GetTipHeight(t.Context())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "404")
+}
+
+// TestScriptHashEncoding pins the byte order Esplora's /scripthash/
+// routes expect. Esplora takes the SHA256 digest of the script in its
+// natural order, unlike the Electrum wire protocol, which reverses it.
+// Getting this wrong is silent: the API answers an unknown script hash
+// with an empty result rather than an error, so every lookup simply
+// comes back with nothing found.
+//
+// The expectation is a fixed vector rather than a recomputation, so this
+// disagrees with the implementation when the implementation changes.
+// systest.TestEsploraScriptHashEncoding is the companion check against a
+// real electrs instance.
+func TestScriptHashEncoding(t *testing.T) {
+	t.Parallel()
+
+	// A P2WPKH script paying the all-zero key hash.
+	pkScript := append([]byte{0x00, 0x14}, make([]byte, 20)...)
+
+	const wantForward = "5c210f7cc5455eec4b9438c47c365fc4afdb29fa1da456" +
+		"1440dc8d34e39ce273"
+
+	require.Equal(
+		t, wantForward, scriptHashHex(pkScript),
+		"scriptHashHex must hex-encode the SHA256 digest in its "+
+			"natural byte order, not the Electrum reversal",
+	)
+
+	// Spell out the reversal that used to live here so a change back
+	// to it fails loudly rather than silently finding nothing.
+	reversed, err := hex.DecodeString(wantForward)
+	require.NoError(t, err)
+
+	for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
+		reversed[i], reversed[j] = reversed[j], reversed[i]
+	}
+
+	require.NotEqual(
+		t, hex.EncodeToString(reversed), scriptHashHex(pkScript),
+	)
 }

--- a/lwwallet/start_block.go
+++ b/lwwallet/start_block.go
@@ -1,0 +1,595 @@
+package lwwallet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"time"
+
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/walletdb"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"golang.org/x/sync/errgroup"
+)
+
+// waddrmgrNamespaceKey is the walletdb namespace btcwallet stores its
+// address manager under. btcwallet keeps its own copy of this constant
+// unexported, so writing the wallet's start block ahead of
+// btcwallet.Start requires naming the namespace here. The value is part
+// of btcwallet's on-disk format and cannot change without a database
+// migration, so duplicating it is safe.
+var waddrmgrNamespaceKey = []byte("waddrmgr")
+
+const (
+	// externalBranch and internalBranch are the BIP44 address chains
+	// under an account: receive addresses and change addresses.
+	externalBranch uint32 = 0
+	internalBranch uint32 = 1
+
+	// startBlockReorgMargin is how far below the chain tip a wallet
+	// with no discovered on-chain history starts scanning from. The
+	// margin costs a handful of block fetches and buys tolerance for
+	// a shallow reorg racing wallet creation, so a payment landing in
+	// a block that is reorged out and re-mined is still seen.
+	startBlockReorgMargin int32 = 6
+
+	// defaultDiscoveryGapLimit is the address look-ahead used when the
+	// wallet was configured with no recovery window. btcwallet skips
+	// address discovery entirely in that mode, but the start block
+	// still has to be resolved, and probing a short run of addresses
+	// is what keeps a wallet with existing history from being stamped
+	// at the tip.
+	defaultDiscoveryGapLimit uint32 = 20
+
+	// defaultMaxDiscoveryIndex bounds how far along a single address
+	// branch discovery will walk before giving up. A branch this long
+	// means either a wallet far outside the shapes this daemon creates
+	// or an index feeding us nonsense; either way, falling back to
+	// btcwallet's own birthday search is better than looping.
+	defaultMaxDiscoveryIndex uint32 = 10_000
+
+	// maxScriptTxPages bounds pagination over one script's confirmed
+	// history. At Esplora's 25 entries per page this covers 5000
+	// transactions against a single script.
+	maxScriptTxPages = 200
+
+	// scriptProbeConcurrency bounds how many index probes are in
+	// flight at once. Esplora deployments are commonly rate limited,
+	// and discovery is a startup burst rather than steady state, so
+	// this stays deliberately modest.
+	scriptProbeConcurrency = 8
+)
+
+// errHistoryTooLong is returned when one script's confirmed history
+// exceeds maxScriptTxPages. Discovery cannot then name the earliest
+// block that script appeared in, and guessing would risk stamping the
+// wallet past its own funds, so the whole attempt is abandoned.
+var errHistoryTooLong = errors.New("script history exceeds page limit")
+
+// errDiscoveryCapped reports that one branch walk ran out of index
+// budget before completing its run of unused addresses. Discovery
+// cannot then claim to have honoured the gap limit, and a short walk
+// finds fewer used scripts, which raises the minimum height it reports
+// and moves the stamp toward the tip. That is the direction that loses
+// funds, so the attempt is abandoned rather than trusted.
+var errDiscoveryCapped = errors.New("branch walk hit the index cap")
+
+// errGapLimitTooWide reports a recovery window wider than the index
+// budget a single branch walk is allowed. Discovery has to look at
+// least as far as btcwallet's own recovery will, so a window it cannot
+// cover is refused outright instead of quietly narrowed.
+var errGapLimitTooWide = errors.New("recovery window exceeds the discovery " +
+	"index budget")
+
+// scopeBranch names one address chain of one active key scope: the pair
+// that a gap-limit walk runs over.
+type scopeBranch struct {
+	// scope is the key scope, e.g. BIP84 or BIP86.
+	scope waddrmgr.KeyScope
+
+	// branch is externalBranch or internalBranch.
+	branch uint32
+}
+
+// stampStartBlock resolves where this wallet should begin scanning the
+// chain and records it as btcwallet's synced-to height and verified
+// birthday block.
+//
+// Without this, btcwallet resolves its own start block by binary
+// searching block timestamps for the seed birthday
+// (locateBirthdayBlock). That search has no lower bound below genesis,
+// so any birthday predating the chain — an aezeed pinned to the Bitcoin
+// genesis date, or a real seed older than signet itself — collapses to
+// block 0, and the wallet then walks every block from genesis to the
+// tip over Esplora. Recording a verified birthday block up front makes
+// btcwallet's birthdaySanityCheck return it untouched and skip the
+// search entirely.
+//
+// The height comes from the Esplora address index rather than from
+// timestamps, which is the whole point: an indexing chain source can
+// answer "where did this wallet first appear on chain" directly, at a
+// cost set by the address gap limit instead of by the length of the
+// chain.
+//
+// Only a wallet with no birthday block at all is stamped. Once
+// btcwallet has recorded one, it owns the sync cursor and this is a
+// no-op.
+//
+// This trades a full chain scan for trust in the index, and the trust
+// is not free. A single self-consistent Esplora is fine: its tip
+// endpoint reflects what it has indexed. A load-balanced public
+// deployment is not, because the tip poll and a script probe can land
+// on different backends, and one still catching up answers 200 with
+// partial or empty history that is indistinguishable from "this script
+// was never used". A restore during such a window stamps above its own
+// funds, and because the stamp is written verified it is never
+// revisited. Deployments that care about restore correctness should
+// point EsploraURL at an endpoint they control.
+func (w *Wallet) stampStartBlock(ctx context.Context) error {
+	btcw := w.BtcWallet.InternalWallet()
+	db := btcw.Database()
+	mgr := btcw.AddrManager()
+
+	// A birthday block that is already present is btcwallet's to
+	// manage: it either came from a completed sync or from a
+	// migration, and either way overwriting it could move the sync
+	// cursor across blocks the wallet has already processed.
+	var unstamped bool
+	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		_, _, err := mgr.BirthdayBlock(ns)
+		switch {
+		case waddrmgr.IsError(err, waddrmgr.ErrBirthdayBlockNotSet):
+			unstamped = true
+
+			return nil
+
+		case err != nil:
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("read birthday block: %w", err)
+	}
+
+	if !unstamped {
+		return nil
+	}
+
+	stamp, err := w.resolveStartBlock(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Never rewind: btcwallet seeds a fresh wallet's synced-to at
+	// genesis, so a start block at or below that carries no
+	// information and writing it would only risk moving the cursor
+	// backwards over already-processed blocks.
+	if stamp.Height <= mgr.SyncedTo().Height {
+		return nil
+	}
+
+	// Write order is load-bearing. waddrmgr.PutSyncedTo refuses a
+	// height whose predecessor's hash is absent, but only once a
+	// birthday block exists — the check is how it enforces contiguous
+	// block storage after the initial sync. Recording synced-to while
+	// FetchBirthdayBlock still errors sidesteps that check for this
+	// one write; every later SetSyncedTo btcwallet makes builds on the
+	// hash stored here.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		if err := mgr.SetSyncedTo(ns, stamp); err != nil {
+			return fmt.Errorf("set synced to: %w", err)
+		}
+
+		// Marking the block verified is what suppresses
+		// btcwallet's timestamp binary search.
+		return mgr.SetBirthdayBlock(ns, *stamp, true)
+	})
+	if err != nil {
+		return fmt.Errorf("persist start block: %w", err)
+	}
+
+	w.Logger(ctx).InfoS(
+		ctx,
+		"Stamped wallet start block from Esplora index",
+		slog.Int("height", int(stamp.Height)),
+		slog.String("hash", stamp.Hash.String()),
+	)
+
+	return nil
+}
+
+// resolveStartBlock returns the block stamp the wallet should be marked
+// synced to before btcwallet takes over. A wallet whose scripts the
+// index has never seen starts just below the tip; one with history
+// starts one block below its earliest appearance, because btcwallet's
+// recovery resumes at synced-to plus one and would otherwise skip the
+// very block being targeted.
+func (w *Wallet) resolveStartBlock(ctx context.Context) (*waddrmgr.BlockStamp,
+	error) {
+
+	tipHeight, _, _ := w.tipPoller.BestBlock()
+
+	startHeight := tipHeight - startBlockReorgMargin
+
+	earliest, err := w.earliestActivityHeight(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	earliest.WhenSome(func(height int32) {
+		if height-1 < startHeight {
+			startHeight = height - 1
+		}
+	})
+
+	if startHeight < 0 {
+		startHeight = 0
+	}
+
+	hash, err := w.esplora.GetBlockHashByHeight(ctx, startHeight)
+	if err != nil {
+		return nil, fmt.Errorf("get start block hash at %d: %w",
+			startHeight, err)
+	}
+
+	header, err := w.esplora.GetBlockHeader(ctx, hash)
+	if err != nil {
+		return nil, fmt.Errorf("get start block header %s: %w", hash,
+			err)
+	}
+
+	return &waddrmgr.BlockStamp{
+		Height:    startHeight,
+		Hash:      hash,
+		Timestamp: time.Unix(header.Timestamp, 0),
+	}, nil
+}
+
+// earliestActivityHeight returns the lowest block height at which any
+// script this wallet can derive has appeared on chain, or None when the
+// index has seen none of them.
+func (w *Wallet) earliestActivityHeight(ctx context.Context) (fn.Option[int32],
+	error) {
+
+	none := fn.None[int32]()
+
+	used, err := w.usedScripts(ctx)
+	if err != nil {
+		return none, err
+	}
+
+	if len(used) == 0 {
+		return none, nil
+	}
+
+	earliest := int32(math.MaxInt32)
+	for _, pkScript := range used {
+		height, err := w.earliestScriptHeight(ctx, pkScript)
+		if err != nil {
+			return none, err
+		}
+
+		height.WhenSome(func(h int32) {
+			if h < earliest {
+				earliest = h
+			}
+		})
+	}
+
+	// Every used script was seen only in the mempool, so there is no
+	// confirmed history to anchor to.
+	if earliest == math.MaxInt32 {
+		return none, nil
+	}
+
+	w.Logger(ctx).InfoS(ctx, "Esplora index located wallet history",
+		slog.Int("used_scripts", len(used)),
+		slog.Int("earliest_height", int(earliest)),
+	)
+
+	return fn.Some(earliest), nil
+}
+
+// usedScripts walks every active key scope's receive and change branch
+// under the default account and returns the pkScripts the index reports
+// as used.
+//
+// Scopes come from btcwallet's own address manager rather than a list
+// maintained here, so a wallet carrying a scope this build does not
+// know about is still covered. Note that this runs before
+// btcwallet.Start, which is when lnd's m/1017' chain scope is added;
+// that scope holds keys used inside scripts rather than addresses paid
+// to directly.
+//
+// Only HD-derived scripts are reachable this way. Imported taproot
+// scripts, which is what boarding addresses are, encode a script tree
+// rather than a derivation path and cannot be enumerated from the seed,
+// so they are outside any gap-limit walk. That costs nothing here:
+// BoardingBackendAdapter.ListUnspent enumerates boarding outputs by
+// querying Esplora per imported address, so their visibility never
+// depended on btcwallet's sync height in the first place.
+// Both branches of every scope are walked. An earlier version skipped
+// the change branches when no receive address anywhere had been used,
+// on the reasoning that a change output requires a spend, which
+// requires the wallet to have held an output, which requires something
+// to have paid a receive address first. That bootstrap argument has a
+// hole: a wallet-owned output need not come from a derived receive
+// address at all. An aezeed seed is lnd-compatible, and an lnd wallet
+// whose channels were opened from externally funded PSBTs holds its
+// only on-chain coins in force-close sweeps, which lnd sends to change
+// addresses. Such a seed has funds on internal branches with every
+// external branch untouched, and skipping the change branches would
+// stamp it at the tip.
+func (w *Wallet) usedScripts(ctx context.Context) ([][]byte, error) {
+	// Discovery has to look at least as far as btcwallet's recovery
+	// will. A window wider than one branch walk's index budget cannot
+	// be covered, and quietly narrowing it would let discovery report
+	// "no history" for a wallet whose first used address sits beyond
+	// our reach but inside btcwallet's, stamping above its funds.
+	gapLimit := w.discoveryGapLimit()
+	if gapLimit > w.maxDiscoveryIndex {
+		return nil, fmt.Errorf("%w: window %d, budget %d",
+			errGapLimitTooWide, gapLimit, w.maxDiscoveryIndex)
+	}
+
+	mgr := w.BtcWallet.InternalWallet().AddrManager()
+
+	scopes := mgr.ActiveScopedKeyManagers()
+
+	branches := make([]scopeBranch, 0, 2*len(scopes))
+	for _, scoped := range scopes {
+		branches = append(branches,
+			scopeBranch{
+				scope:  scoped.Scope(),
+				branch: externalBranch,
+			},
+			scopeBranch{
+				scope:  scoped.Scope(),
+				branch: internalBranch,
+			},
+		)
+	}
+
+	return w.scanBranches(ctx, branches)
+}
+
+// scanBranches runs a gap-limit walk over each of the given branches and
+// returns every used pkScript found across them.
+func (w *Wallet) scanBranches(ctx context.Context, branches []scopeBranch) (
+	[][]byte, error) {
+
+	var used [][]byte
+	for _, sb := range branches {
+		found, err := w.usedBranchScripts(ctx, sb)
+		if err != nil {
+			return nil, fmt.Errorf("scan scope %v branch %d: %w",
+				sb.scope, sb.branch, err)
+		}
+
+		used = append(used, found...)
+	}
+
+	return used, nil
+}
+
+// usedBranchScripts walks one address branch until it has seen a run of
+// gapLimit consecutive unused addresses, mirroring the look-ahead rule
+// btcwallet's own recovery applies, and returns the used pkScripts it
+// passed along the way.
+func (w *Wallet) usedBranchScripts(ctx context.Context, sb scopeBranch) (
+	[][]byte, error) {
+
+	gapLimit := w.discoveryGapLimit()
+
+	var (
+		used      [][]byte
+		index     uint32
+		unusedRun uint32
+	)
+
+	for unusedRun < gapLimit && index < w.maxDiscoveryIndex {
+		// The batch size is what actually bounds the allocation and
+		// the request burst here, not the loop guard: a whole batch
+		// is derived and probed before the guard is consulted again.
+		count := min(gapLimit, w.maxDiscoveryIndex-index)
+
+		scripts, err := w.deriveBranchScripts(sb, index, count)
+		if err != nil {
+			return nil, err
+		}
+
+		flags, err := w.probeScripts(ctx, scripts)
+		if err != nil {
+			return nil, err
+		}
+
+		for i, isUsed := range flags {
+			if isUsed {
+				used = append(used, scripts[i])
+				unusedRun = 0
+
+				continue
+			}
+
+			unusedRun++
+			if unusedRun >= gapLimit {
+				break
+			}
+		}
+
+		index += count
+	}
+
+	// Exiting on the index budget rather than on a full run of unused
+	// addresses means the walk never established a gap limit's worth of
+	// silence, so the used set it collected may be short. A short set
+	// raises the minimum height discovery reports, which moves the
+	// stamp up rather than down, so this cannot be treated as a
+	// successful walk.
+	if unusedRun < gapLimit {
+		return nil, fmt.Errorf("%w at index %d", errDiscoveryCapped,
+			index)
+	}
+
+	return used, nil
+}
+
+// discoveryGapLimit returns the address look-ahead discovery walks with.
+// It tracks the wallet's configured recovery window so discovery and
+// btcwallet's own recovery agree on how far past the last used address
+// they are willing to look.
+func (w *Wallet) discoveryGapLimit() uint32 {
+	if w.recoveryWindow == 0 {
+		return defaultDiscoveryGapLimit
+	}
+
+	return w.recoveryWindow
+}
+
+// deriveBranchScripts derives the pkScripts for indices
+// [start, start+count) on one scope branch under a single read
+// transaction.
+//
+// Derivation goes through the scoped key manager rather than
+// reconstructing paths from the seed so each script gets the address
+// type that scope's schema dictates — P2TR for BIP86, P2WPKH for BIP84,
+// nested P2SH for BIP49 — which is exactly what btcwallet itself would
+// hand out. Only public keys are touched, so this works with the wallet
+// still locked.
+func (w *Wallet) deriveBranchScripts(sb scopeBranch, start, count uint32) (
+	[][]byte, error) {
+
+	btcw := w.BtcWallet.InternalWallet()
+
+	scoped, err := btcw.AddrManager().FetchScopedKeyManager(sb.scope)
+	if err != nil {
+		return nil, fmt.Errorf("fetch scoped manager: %w", err)
+	}
+
+	// The default account is the only one this daemon derives receive
+	// and change addresses under.
+	const acct = waddrmgr.DefaultAccountNum
+
+	scripts := make([][]byte, 0, count)
+	err = walletdb.View(btcw.Database(), func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		for i := start; i < start+count; i++ {
+			addr, err := scoped.DeriveFromKeyPath(
+				ns, waddrmgr.DerivationPath{
+					InternalAccount: acct,
+					Account:         acct,
+					Branch:          sb.branch,
+					Index:           i,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("derive index %d: %w", i, err)
+			}
+
+			pkScript, err := txscript.PayToAddrScript(
+				addr.Address(),
+			)
+			if err != nil {
+				return fmt.Errorf("pkScript for index %d: %w",
+					i, err)
+			}
+
+			scripts = append(scripts, pkScript)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return scripts, nil
+}
+
+// probeScripts asks the index whether each script has ever been used,
+// returning one flag per input script in the same order. Probes run
+// concurrently under scriptProbeConcurrency because each is an
+// independent round trip and a gap-limit walk issues them in batches.
+func (w *Wallet) probeScripts(ctx context.Context, scripts [][]byte) ([]bool,
+	error) {
+
+	flags := make([]bool, len(scripts))
+
+	group, gctx := errgroup.WithContext(ctx)
+	group.SetLimit(scriptProbeConcurrency)
+
+	for i, pkScript := range scripts {
+		group.Go(func() error {
+			stats, err := w.esplora.GetScriptStats(gctx, pkScript)
+			if err != nil {
+				return err
+			}
+
+			flags[i] = stats.Used()
+
+			return nil
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		return nil, fmt.Errorf("probe scripts: %w", err)
+	}
+
+	return flags, nil
+}
+
+// earliestScriptHeight returns the height of the earliest confirmed
+// transaction referencing pkScript, or None when the script has only
+// unconfirmed history. Esplora serves this history newest first, so
+// reaching the earliest entry means paging to the end.
+func (w *Wallet) earliestScriptHeight(ctx context.Context, pkScript []byte) (
+	fn.Option[int32], error) {
+
+	none := fn.None[int32]()
+
+	var (
+		lastSeen string
+		earliest = int32(math.MaxInt32)
+	)
+
+	for range maxScriptTxPages {
+		txs, err := w.esplora.GetScriptChainTxs(ctx, pkScript, lastSeen)
+		if err != nil {
+			return none, err
+		}
+
+		if len(txs) == 0 {
+			if earliest == math.MaxInt32 {
+				return none, nil
+			}
+
+			return fn.Some(earliest), nil
+		}
+
+		for _, tx := range txs {
+			if !tx.Status.Confirmed {
+				continue
+			}
+
+			if height := int32(tx.Status.BlockHeight); height <
+				earliest {
+
+				earliest = height
+			}
+		}
+
+		lastSeen = txs[len(txs)-1].Txid
+	}
+
+	return none, errHistoryTooLong
+}

--- a/lwwallet/start_block_test.go
+++ b/lwwallet/start_block_test.go
@@ -1,0 +1,702 @@
+package lwwallet
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/walletdb"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// indexEsplora is a stub Esplora server backed by a synthetic chain of a
+// configurable height, with a settable set of "used" script hashes and
+// the confirmation heights their transactions landed at.
+type indexEsplora struct {
+	*httptest.Server
+
+	mu sync.Mutex
+
+	// tipHeight is the height the synthetic chain reports.
+	tipHeight int32
+
+	// usedScripts maps a script hash to the confirmation heights of
+	// the transactions referencing it.
+	usedScripts map[string][]int32
+
+	// counts tallies requests per coarse route class.
+	counts map[string]int
+
+	// t is retained so handler-side failures surface as test errors.
+	t *testing.T
+}
+
+// newIndexEsplora starts a stub Esplora index over a synthetic chain of
+// the given height.
+func newIndexEsplora(t *testing.T, tipHeight int32) *indexEsplora {
+	t.Helper()
+
+	e := &indexEsplora{
+		t:           t,
+		tipHeight:   tipHeight,
+		usedScripts: make(map[string][]int32),
+		counts:      make(map[string]int),
+	}
+
+	e.Server = httptest.NewServer(http.HandlerFunc(e.serve))
+	t.Cleanup(e.Server.Close)
+
+	return e
+}
+
+// markUsed records that the given pkScript was seen at the given
+// confirmation heights.
+func (e *indexEsplora) markUsed(pkScript []byte, heights ...int32) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.usedScripts[scriptHashHex(pkScript)] = heights
+}
+
+// count returns the number of requests seen for a route class.
+func (e *indexEsplora) count(class string) int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.counts[class]
+}
+
+// blockHashAt derives a deterministic, unique block hash for a height so
+// the stub chain is self-consistent across endpoints.
+func blockHashAt(height int32) string {
+	return fmt.Sprintf("%064x", height+1)
+}
+
+// serve implements the subset of the Esplora API that start-block
+// discovery and wallet startup exercise.
+func (e *indexEsplora) serve(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+
+	e.mu.Lock()
+	tip := e.tipHeight
+	e.mu.Unlock()
+
+	switch {
+	case path == "/blocks/tip/height":
+		e.tally("tip")
+
+		_, err := fmt.Fprintf(w, "%d", tip)
+		require.NoError(e.t, err)
+
+	case strings.HasPrefix(path, "/block-height/"):
+		e.tally("block-height")
+
+		height, err := strconv.ParseInt(
+			strings.TrimPrefix(path, "/block-height/"), 10, 32,
+		)
+		if err != nil || int32(height) > tip || height < 0 {
+			http.NotFound(w, r)
+
+			return
+		}
+
+		_, err = fmt.Fprint(w, blockHashAt(int32(height)))
+		require.NoError(e.t, err)
+
+	case strings.HasPrefix(path, "/scripthash/"):
+		e.serveScriptHash(w, r, path)
+
+	case strings.HasPrefix(path, "/block/"):
+		e.tally("block-json")
+		e.serveBlock(w, r, path)
+
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// serveBlock answers /block/:hash with a minimal block document whose
+// height is recovered from the deterministic hash encoding.
+func (e *indexEsplora) serveBlock(w http.ResponseWriter, r *http.Request,
+	path string) {
+
+	rest := strings.TrimPrefix(path, "/block/")
+	if strings.Contains(rest, "/") {
+		http.NotFound(w, r)
+
+		return
+	}
+
+	raw, err := strconv.ParseInt(strings.TrimLeft(rest, "0"), 16, 64)
+	if err != nil {
+		// A hash of all zeroes decodes to an empty string, which is
+		// height 0 under this encoding.
+		raw = 1
+	}
+
+	height := int32(raw) - 1
+
+	err = json.NewEncoder(w).Encode(esploraBlock{
+		ID:        rest,
+		Height:    height,
+		Timestamp: int64(1_600_000_000 + height),
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// serveScriptHash answers both the stats probe and the paginated
+// confirmed-history endpoint.
+func (e *indexEsplora) serveScriptHash(w http.ResponseWriter, r *http.Request,
+	path string) {
+
+	rest := strings.TrimPrefix(path, "/scripthash/")
+	parts := strings.SplitN(rest, "/", 2)
+	hash := parts[0]
+
+	e.mu.Lock()
+	heights := e.usedScripts[hash]
+	e.mu.Unlock()
+
+	// The stats probe: /scripthash/:hash with nothing after it.
+	if len(parts) == 1 {
+		e.tally("scripthash-stats")
+
+		err := json.NewEncoder(w).Encode(esploraScriptStats{
+			ChainStats: esploraScriptStatSet{
+				TxCount: len(heights),
+			},
+		})
+		if err != nil {
+			http.Error(
+				w, err.Error(), http.StatusInternalServerError,
+			)
+		}
+
+		return
+	}
+
+	// The history endpoint. Pagination is not simulated: the stub
+	// returns the whole history on the first page and an empty page
+	// for any continuation, which is the shape the caller loops on.
+	if !strings.HasPrefix(parts[1], "txs/chain") {
+		http.NotFound(w, r)
+
+		return
+	}
+
+	e.tally("scripthash-txs")
+
+	txs := []esploraScriptTx{}
+	if parts[1] == "txs/chain" {
+		for i, h := range heights {
+			txs = append(txs, esploraScriptTx{
+				Txid: fmt.Sprintf("%064x", i+1),
+				Status: esploraStatus{
+					Confirmed:   true,
+					BlockHeight: int64(h),
+				},
+			})
+		}
+	}
+
+	if err := json.NewEncoder(w).Encode(txs); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// tally records one request against a route class.
+func (e *indexEsplora) tally(class string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.counts[class]++
+}
+
+// newIndexTestWallet builds an unstarted wallet against the stub index,
+// with its tip poller running so start-block resolution can read a tip.
+func newIndexTestWallet(t *testing.T, esplora *indexEsplora,
+	recoveryWindow uint32) *Wallet {
+
+	t.Helper()
+
+	var seed [32]byte
+	for i := range seed {
+		seed[i] = byte(i + 3)
+	}
+
+	w, err := New(Config{
+		Seed:           seed[:],
+		WalletPassword: []byte("start-block-password"),
+		EsploraURL:     esplora.URL,
+		ChainParams:    &chaincfg.RegressionNetParams,
+		PollInterval:   time.Hour,
+		RecoveryWindow: recoveryWindow,
+		DBDir:          t.TempDir(),
+		Log:            fn.None[btclog.Logger](),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, w.tipPoller.Start())
+	t.Cleanup(w.tipPoller.Stop)
+
+	t.Cleanup(func() {
+		err := w.BtcWallet.InternalWallet().Database().Close()
+		require.NoError(t, err)
+	})
+
+	return w
+}
+
+// readStamp returns the wallet's persisted synced-to stamp and birthday
+// block verification flag.
+func readStamp(t *testing.T, w *Wallet) (waddrmgr.BlockStamp, bool) {
+	t.Helper()
+
+	btcw := w.BtcWallet.InternalWallet()
+
+	var (
+		block    waddrmgr.BlockStamp
+		verified bool
+	)
+	err := walletdb.View(btcw.Database(), func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		var err error
+		block, verified, err = btcw.AddrManager().BirthdayBlock(ns)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	return block, verified
+}
+
+// TestStampStartBlockFreshWallet checks that a wallet the index has
+// never seen is stamped just below the tip rather than at genesis, and
+// that the stamp is marked verified so btcwallet's timestamp search is
+// suppressed.
+func TestStampStartBlockFreshWallet(t *testing.T) {
+	t.Parallel()
+
+	const tipHeight = 250_000
+
+	esplora := newIndexEsplora(t, tipHeight)
+	w := newIndexTestWallet(t, esplora, 20)
+
+	require.NoError(t, w.stampStartBlock(t.Context()))
+
+	block, verified := readStamp(t, w)
+	require.True(t, verified, "birthday block must be marked verified")
+	require.Equal(
+		t, int32(tipHeight)-startBlockReorgMargin, block.Height,
+		"a wallet with no history should start just below the tip",
+	)
+
+	require.Equal(
+		t, block, w.BtcWallet.InternalWallet().SyncedTo(),
+		"synced-to must match the stamped birthday block",
+	)
+
+	// Discovery cost must not scale with the chain. The tip poller
+	// seeds its reorg hash cache with DefaultHashHistorySize heights
+	// on Start regardless of any of this, so the bound allows for
+	// that plus a small constant, and still fails loudly if anything
+	// starts walking the 250k block chain.
+	require.Less(
+		t, esplora.count("block-height"), DefaultHashHistorySize+10,
+		"block metadata fetches must be bounded by the tip "+
+			"poller's history seed, not by the chain height",
+	)
+
+	// Nothing was found, so no script history was ever fetched.
+	require.Zero(t, esplora.count("scripthash-txs"))
+}
+
+// TestStampStartBlockFindsHistory checks that a used address moves the
+// stamp back to one block below its earliest confirmation, since
+// btcwallet's recovery resumes at synced-to plus one and would
+// otherwise skip the funding block.
+func TestStampStartBlockFindsHistory(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tipHeight   = 250_000
+		fundedAt    = 120_000
+		laterSpend  = 180_000
+		gapLimit    = 20
+		usedAddrIdx = 3
+	)
+
+	esplora := newIndexEsplora(t, tipHeight)
+	w := newIndexTestWallet(t, esplora, gapLimit)
+
+	// Mark one receive address of the wallet's default taproot scope
+	// as used, with its earliest appearance well below the tip.
+	scripts, err := w.deriveBranchScripts(scopeBranch{
+		scope:  waddrmgr.KeyScopeBIP0086,
+		branch: externalBranch,
+	}, 0, gapLimit)
+	require.NoError(t, err)
+
+	esplora.markUsed(scripts[usedAddrIdx], laterSpend, fundedAt)
+
+	require.NoError(t, w.stampStartBlock(t.Context()))
+
+	block, verified := readStamp(t, w)
+	require.True(t, verified)
+	require.Equal(
+		t, int32(fundedAt-1), block.Height,
+		"stamp must sit one block below the earliest appearance",
+	)
+}
+
+// TestStampStartBlockRespectsGapLimit checks that an address beyond the
+// configured look-ahead is not discovered, matching the bound
+// btcwallet's own recovery applies, while one just inside it is.
+func TestStampStartBlockRespectsGapLimit(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tipHeight = 250_000
+		fundedAt  = 90_000
+		gapLimit  = 20
+	)
+
+	branch := scopeBranch{
+		scope:  waddrmgr.KeyScopeBIP0086,
+		branch: externalBranch,
+	}
+
+	// An address past the gap limit is invisible, so the wallet is
+	// stamped as though it had no history.
+	beyond := newIndexEsplora(t, tipHeight)
+	wBeyond := newIndexTestWallet(t, beyond, gapLimit)
+
+	scripts, err := wBeyond.deriveBranchScripts(branch, 0, gapLimit+5)
+	require.NoError(t, err)
+
+	beyond.markUsed(scripts[gapLimit+2], fundedAt)
+
+	require.NoError(t, wBeyond.stampStartBlock(t.Context()))
+
+	block, _ := readStamp(t, wBeyond)
+	require.Equal(t, int32(tipHeight)-startBlockReorgMargin, block.Height)
+
+	// The last address inside the window is found.
+	within := newIndexEsplora(t, tipHeight)
+	wWithin := newIndexTestWallet(t, within, gapLimit)
+
+	scripts, err = wWithin.deriveBranchScripts(branch, 0, gapLimit)
+	require.NoError(t, err)
+
+	within.markUsed(scripts[gapLimit-1], fundedAt)
+
+	require.NoError(t, wWithin.stampStartBlock(t.Context()))
+
+	block, _ = readStamp(t, wWithin)
+	require.Equal(t, int32(fundedAt-1), block.Height)
+}
+
+// TestStampStartBlockChangeOnlyScope checks that change addresses are
+// still discovered once any receive address has been used, including
+// when the change lives in a different key scope than the receive.
+func TestStampStartBlockChangeOnlyScope(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tipHeight  = 250_000
+		receivedAt = 200_000
+		changeAt   = 150_000
+		gapLimit   = 20
+	)
+
+	esplora := newIndexEsplora(t, tipHeight)
+	w := newIndexTestWallet(t, esplora, gapLimit)
+
+	recv, err := w.deriveBranchScripts(scopeBranch{
+		scope:  waddrmgr.KeyScopeBIP0086,
+		branch: externalBranch,
+	}, 0, gapLimit)
+	require.NoError(t, err)
+
+	change, err := w.deriveBranchScripts(scopeBranch{
+		scope:  waddrmgr.KeyScopeBIP0084,
+		branch: internalBranch,
+	}, 0, gapLimit)
+	require.NoError(t, err)
+
+	esplora.markUsed(recv[0], receivedAt)
+	esplora.markUsed(change[1], changeAt)
+
+	require.NoError(t, w.stampStartBlock(t.Context()))
+
+	block, _ := readStamp(t, w)
+	require.Equal(
+		t, int32(changeAt-1), block.Height,
+		"the earliest height across both branches must win",
+	)
+}
+
+// TestStampStartBlockSkipsWhenAlreadySet checks that a wallet which
+// already carries a birthday block is left alone: once btcwallet owns
+// the sync cursor, overwriting it could move the wallet across blocks
+// it has already processed.
+func TestStampStartBlockSkipsWhenAlreadySet(t *testing.T) {
+	t.Parallel()
+
+	const tipHeight = 250_000
+
+	esplora := newIndexEsplora(t, tipHeight)
+	w := newIndexTestWallet(t, esplora, 20)
+
+	require.NoError(t, w.stampStartBlock(t.Context()))
+
+	first, _ := readStamp(t, w)
+
+	// Grow the chain and re-run: the stamp must not move.
+	esplora.mu.Lock()
+	esplora.tipHeight = tipHeight + 5_000
+	esplora.mu.Unlock()
+
+	require.NoError(t, w.stampStartBlock(t.Context()))
+
+	second, _ := readStamp(t, w)
+	require.Equal(t, first, second)
+}
+
+// TestStampStartBlockIndexFailure checks that an unreachable index is
+// not fatal. Discovery reports the error, the caller logs it, and
+// btcwallet falls back to its own birthday search.
+func TestStampStartBlockIndexFailure(t *testing.T) {
+	t.Parallel()
+
+	esplora := newIndexEsplora(t, 1_000)
+	w := newIndexTestWallet(t, esplora, 20)
+
+	// Close the index out from under the wallet so every probe fails.
+	esplora.Server.Close()
+
+	require.Error(t, w.stampStartBlock(t.Context()))
+
+	// A failed discovery must leave the birthday block unset so
+	// btcwallet still resolves a start block itself.
+	requireUnstamped(t, w)
+}
+
+// TestDiscoveryCoversWalletAddresses checks the assumption the whole
+// fix rests on: that the scripts start-block discovery probes are the
+// same ones the wallet actually hands out. If NewAddress derives from a
+// scope or account discovery does not walk, a restore would be stamped
+// past its own funds.
+func TestDiscoveryCoversWalletAddresses(t *testing.T) {
+	t.Parallel()
+
+	const gapLimit = 20
+
+	esplora := newIndexEsplora(t, 1_000)
+	w := newIndexTestWallet(t, esplora, gapLimit)
+
+	// Gather the probe set BEFORE starting btcwallet, because that is
+	// when discovery runs in production. Enumerating scopes after Start
+	// would include any scope Start itself registers, which is exactly
+	// the drift this test exists to catch.
+	mgr := w.BtcWallet.InternalWallet().AddrManager()
+
+	var probed [][]byte
+	for _, scoped := range mgr.ActiveScopedKeyManagers() {
+		for _, branch := range []uint32{
+			externalBranch,
+			internalBranch,
+		} {
+			scripts, dErr := w.deriveBranchScripts(scopeBranch{
+				scope:  scoped.Scope(),
+				branch: branch,
+			}, 0, gapLimit)
+			require.NoError(t, dErr)
+
+			probed = append(probed, scripts...)
+		}
+
+		t.Logf("discovery walks scope %v", scoped.Scope())
+	}
+
+	require.NoError(t, w.BtcWallet.Start())
+	t.Cleanup(func() { _ = w.BtcWallet.Stop() })
+
+	addr, err := w.NewAddress(t.Context())
+	require.NoError(t, err)
+
+	want, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	t.Logf("NewAddress handed out %s", addr.String())
+
+	found := false
+	for _, s := range probed {
+		if bytes.Equal(s, want) {
+			found = true
+
+			break
+		}
+	}
+
+	require.True(
+		t, found, "NewAddress produced a script outside every "+
+			"scope and branch discovery probes, so a restore "+
+			"would miss its funds",
+	)
+}
+
+// TestStampStartBlockChangeOnlyWallet covers a wallet whose only
+// on-chain history sits on a change branch, with every receive branch
+// untouched. An aezeed seed is lnd-compatible, and an lnd wallet whose
+// channels were opened from externally funded PSBTs holds its coins in
+// force-close sweeps, which land on change addresses. Discovery must
+// still find that history rather than stamping the wallet at the tip.
+func TestStampStartBlockChangeOnlyWallet(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tipHeight = 250_000
+		sweptAt   = 90_000
+		gapLimit  = 20
+	)
+
+	esplora := newIndexEsplora(t, tipHeight)
+	w := newIndexTestWallet(t, esplora, gapLimit)
+
+	change, err := w.deriveBranchScripts(scopeBranch{
+		scope:  waddrmgr.KeyScopeBIP0086,
+		branch: internalBranch,
+	}, 0, gapLimit)
+	require.NoError(t, err)
+
+	esplora.markUsed(change[2], sweptAt)
+
+	require.NoError(t, w.stampStartBlock(t.Context()))
+
+	block, _ := readStamp(t, w)
+	require.Equal(
+		t, int32(sweptAt-1), block.Height, "a wallet funded only "+
+			"on a change branch must still be stamped below "+
+			"its funds",
+	)
+}
+
+// TestStampStartBlockRefusesWideRecoveryWindow checks that a recovery
+// window wider than one branch walk's index budget is refused outright.
+// Quietly narrowing it would let discovery report no history for a
+// wallet whose first used address sits beyond our reach but inside the
+// horizon btcwallet's own recovery would expand to, and the resulting
+// stamp would sit above the wallet's funds.
+func TestStampStartBlockRefusesWideRecoveryWindow(t *testing.T) {
+	t.Parallel()
+
+	esplora := newIndexEsplora(t, 250_000)
+	w := newIndexTestWallet(t, esplora, 40)
+	w.maxDiscoveryIndex = 20
+
+	err := w.stampStartBlock(t.Context())
+	require.ErrorIs(t, err, errGapLimitTooWide)
+
+	// Refusing must leave the birthday block unset so btcwallet still
+	// resolves a start block itself.
+	requireUnstamped(t, w)
+}
+
+// TestStampStartBlockRefusesTruncatedWalk checks that a branch walk
+// which runs out of index budget before establishing a full run of
+// unused addresses abandons the whole attempt. A short walk finds fewer
+// used scripts, which raises the minimum height discovery reports and
+// moves the stamp toward the tip, so a truncated result must not be
+// trusted.
+func TestStampStartBlockRefusesTruncatedWalk(t *testing.T) {
+	t.Parallel()
+
+	const (
+		gapLimit = 10
+		budget   = 40
+	)
+
+	esplora := newIndexEsplora(t, 250_000)
+	w := newIndexTestWallet(t, esplora, gapLimit)
+	w.maxDiscoveryIndex = budget
+
+	// Mark every address inside the budget as used, so no run of
+	// gapLimit consecutive unused addresses can ever form.
+	scripts, err := w.deriveBranchScripts(scopeBranch{
+		scope:  waddrmgr.KeyScopeBIP0049Plus,
+		branch: externalBranch,
+	}, 0, budget)
+	require.NoError(t, err)
+
+	for i, pkScript := range scripts {
+		esplora.markUsed(pkScript, int32(100_000+i))
+	}
+
+	err = w.stampStartBlock(t.Context())
+	require.ErrorIs(t, err, errDiscoveryCapped)
+
+	requireUnstamped(t, w)
+}
+
+// requireUnstamped asserts the wallet carries no birthday block, which
+// is what leaves btcwallet free to resolve a start block itself.
+func requireUnstamped(t *testing.T, w *Wallet) {
+	t.Helper()
+
+	btcw := w.BtcWallet.InternalWallet()
+
+	var readErr error
+	err := walletdb.View(btcw.Database(), func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		_, _, readErr = btcw.AddrManager().BirthdayBlock(ns)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.True(
+		t, waddrmgr.IsError(readErr, waddrmgr.ErrBirthdayBlockNotSet),
+		"a refused discovery must leave the birthday block unset",
+	)
+}
+
+// TestStampStartBlockRefusesRealWideWindow exercises the wide-window
+// refusal against the production index budget rather than a shrunken
+// test value, so the shipped threshold itself is covered. The refusal
+// lands before any address is derived, so this costs nothing.
+func TestStampStartBlockRefusesRealWideWindow(t *testing.T) {
+	t.Parallel()
+
+	esplora := newIndexEsplora(t, 250_000)
+	w := newIndexTestWallet(t, esplora, defaultMaxDiscoveryIndex+1)
+
+	require.Equal(
+		t, defaultMaxDiscoveryIndex, w.maxDiscoveryIndex,
+		"this test must run against the production budget",
+	)
+
+	err := w.stampStartBlock(t.Context())
+	require.ErrorIs(t, err, errGapLimitTooWide)
+
+	requireUnstamped(t, w)
+
+	// Nothing should have been probed: the guard runs before any
+	// derivation or index traffic.
+	require.Zero(t, esplora.count("scripthash-stats"))
+}

--- a/lwwallet/wallet.go
+++ b/lwwallet/wallet.go
@@ -57,6 +57,18 @@ type Wallet struct {
 	// boardingBackend wraps btcwallet to provide the
 	// wallet.BoardingBackend interface for Ark boarding.
 	boardingBackend *BoardingBackendAdapter
+
+	// recoveryWindow is the configured address look-ahead. It is kept
+	// here because Esplora-index start-block discovery walks each
+	// address branch under the same gap limit btcwallet's own recovery
+	// applies.
+	recoveryWindow uint32
+
+	// maxDiscoveryIndex bounds how far one start-block discovery branch
+	// walk may run. It is a field rather than a bare constant so tests
+	// can drive the budget-exhausted paths without deriving ten
+	// thousand addresses.
+	maxDiscoveryIndex uint32
 }
 
 // ErrWalletNotFound is returned when opening an existing wallet was
@@ -204,11 +216,13 @@ func New(cfg Config) (*Wallet, error) {
 			ChainParams: cfg.ChainParams,
 			WalletLog:   cfg.Log,
 		},
-		tipPoller:       tipPoller,
-		chainSvc:        chainSvc,
-		esplora:         esplora,
-		chainBackend:    chainBackend,
-		boardingBackend: boardingBackend,
+		tipPoller:         tipPoller,
+		chainSvc:          chainSvc,
+		esplora:           esplora,
+		chainBackend:      chainBackend,
+		boardingBackend:   boardingBackend,
+		recoveryWindow:    cfg.RecoveryWindow,
+		maxDiscoveryIndex: defaultMaxDiscoveryIndex,
 	}, nil
 }
 
@@ -257,6 +271,20 @@ func (w *Wallet) Start() error {
 		return fmt.Errorf("start tip poller: %w", err)
 	}
 	rollback = append(rollback, w.tipPoller.Stop)
+
+	// Resolve where this wallet should start scanning from before
+	// btcwallet gets a chance to answer that question itself. Left to
+	// its own devices btcwallet binary searches block timestamps for
+	// the seed birthday, which bottoms out at genesis for any birthday
+	// older than the chain and then walks every block to the tip over
+	// Esplora. A failure here is not fatal: the wallet still starts
+	// and btcwallet falls back to that search, just slowly.
+	if err := w.stampStartBlock(ctx); err != nil {
+		w.Logger(ctx).WarnS(ctx, "Esplora start-block discovery "+
+			"failed, falling back to btcwallet birthday search",
+			err,
+		)
+	}
 
 	// btcWallet.Start() unlocks the wallet, creates key scopes,
 	// starts the chain service (which subscribes to the tip

--- a/systest/esplora_scripthash_test.go
+++ b/systest/esplora_scripthash_test.go
@@ -1,0 +1,145 @@
+//go:build systest
+
+package systest
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/harness"
+	"github.com/lightninglabs/wavelength/lwwallet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEsploraScriptHashEncoding pins down which byte order the harness
+// electrs expects on /scripthash/:hash. Start-block discovery probes
+// that endpoint, so getting the convention wrong makes every address
+// look unused and silently stamps a restored wallet past its own funds.
+func TestEsploraScriptHashEncoding(t *testing.T) {
+	h := harness.NewHarness(t, nil)
+	h.Start()
+	t.Cleanup(h.Stop)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer cancel()
+
+	var seed [32]byte
+	for i := range seed {
+		seed[i] = byte(i + 31)
+	}
+
+	w := newSyncTestWallet(t, h.EsploraURL, t.TempDir(), seed[:])
+	require.NoError(t, w.Start())
+	t.Cleanup(w.Stop)
+	require.NoError(t, w.WaitForSync(ctx))
+
+	addr, err := w.NewAddress(ctx)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	h.Faucet(addr.String(), btcutil.Amount(40_000))
+	h.Generate(1)
+
+	sum := sha256.Sum256(pkScript)
+
+	forward := hex.EncodeToString(sum[:])
+
+	rev := sum
+	for i, j := 0, len(rev)-1; i < j; i, j = i+1, j-1 {
+		rev[i], rev[j] = rev[j], rev[i]
+	}
+	reversed := hex.EncodeToString(rev[:])
+
+	// Poll the address endpoint first so the assertions below are not
+	// racing the indexer.
+	addrURL := h.EsploraURL + "/address/" + addr.String()
+
+	indexed := func() bool {
+		return txCountAt(t, ctx, addrURL) > 0
+	}
+
+	require.Eventually(
+		t, indexed, time.Minute, 500*time.Millisecond,
+		"electrs never indexed the funding",
+	)
+
+	byAddr := txCountAt(t, ctx, addrURL)
+	fwd := txCountAt(t, ctx, h.EsploraURL+"/scripthash/"+forward)
+	revd := txCountAt(t, ctx, h.EsploraURL+"/scripthash/"+reversed)
+
+	t.Logf("address     tx_count = %d", byAddr)
+	t.Logf("sha256      tx_count = %d  (%s)", fwd, forward)
+	t.Logf("sha256 rev  tx_count = %d  (%s)", revd, reversed)
+
+	require.Positive(t, byAddr, "address endpoint should see the funding")
+
+	// Assert the direction, not merely that one of the two orders
+	// works. Both are computed here, so one of them necessarily
+	// matches, and an either-or assertion would hold no matter which
+	// order the client itself uses.
+	require.Equal(
+		t, byAddr, fwd,
+		"electrs indexes scripts under the forward SHA256 digest",
+	)
+	require.Zero(
+		t, revd, "the Electrum reversal must not resolve, or the "+
+			"two conventions would be indistinguishable here",
+	)
+
+	// Finally, run the real client against the same script. This is
+	// what ties lwwallet's own encoding to the byte order established
+	// above, rather than leaving it to a stub that agrees with
+	// whatever the client does.
+	client := lwwallet.NewEsploraClient(h.EsploraURL, btclog.Disabled)
+
+	stats, err := client.GetScriptStats(ctx, pkScript)
+	require.NoError(t, err)
+	require.True(
+		t, stats.Used(),
+		"lwwallet's script hash encoding does not find a funded "+
+			"script that electrs has indexed",
+	)
+}
+
+// txCountAt fetches chain_stats.tx_count from an Esplora stats URL.
+func txCountAt(t *testing.T, ctx context.Context, url string) int {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Logf("%s -> %d %s", url, resp.StatusCode, body)
+
+		return -1
+	}
+
+	var stats struct {
+		ChainStats struct {
+			TxCount int `json:"tx_count"`
+		} `json:"chain_stats"`
+	}
+	require.NoError(t, json.Unmarshal(body, &stats))
+
+	return stats.ChainStats.TxCount
+}

--- a/systest/lwwallet_sync_test.go
+++ b/systest/lwwallet_sync_test.go
@@ -1,0 +1,401 @@
+//go:build systest
+
+package systest
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/harness"
+	"github.com/lightninglabs/wavelength/lwwallet"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// countingEsplora is a reverse proxy in front of the harness Esplora
+// endpoint that tallies how many requests each route class received. It
+// is what makes "does the wallet walk the whole chain" an assertion
+// rather than an impression.
+type countingEsplora struct {
+	*httptest.Server
+
+	mu     sync.Mutex
+	counts map[string]int
+	paths  map[string]int
+}
+
+// newCountingEsplora spins up a counting reverse proxy in front of the
+// given upstream Esplora base URL.
+func newCountingEsplora(t *testing.T, upstream string) *countingEsplora {
+	t.Helper()
+
+	target, err := url.Parse(upstream)
+	require.NoError(t, err)
+
+	c := &countingEsplora{
+		counts: make(map[string]int),
+		paths:  make(map[string]int),
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+
+	c.Server = httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				c.record(r.URL.Path)
+				proxy.ServeHTTP(w, r)
+			},
+		),
+	)
+	t.Cleanup(c.Server.Close)
+
+	return c
+}
+
+// record buckets one request path into a coarse route class.
+func (c *countingEsplora) record(path string) {
+	class := routeClass(path)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.counts[class]++
+	c.counts["total"]++
+	c.paths[path]++
+}
+
+// snapshot returns a copy of the current counters.
+func (c *countingEsplora) snapshot() map[string]int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	out := make(map[string]int, len(c.counts))
+	for k, v := range c.counts {
+		out[k] = v
+	}
+
+	return out
+}
+
+// blockFetches totals every route class that costs one block's worth of
+// data, which is what a sequential chain walk inflates.
+func (c *countingEsplora) blockFetches() int {
+	counts := c.snapshot()
+
+	return counts["block-height"] + counts["block-header"] +
+		counts["block-raw"] + counts["block-json"]
+}
+
+// distinctHeights reports how many separate heights were resolved via
+// /block-height/, which distinguishes a walk over a range from repeated
+// lookups of the same few blocks.
+func (c *countingEsplora) distinctHeights() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	n := 0
+	for p := range c.paths {
+		rest, ok := strings.CutPrefix(p, "/block-height/")
+		if !ok {
+			continue
+		}
+
+		if _, err := strconv.Atoi(rest); err == nil {
+			n++
+		}
+	}
+
+	return n
+}
+
+// lowestHeight returns the lowest height resolved via /block-height/,
+// which is where the wallet's chain scan actually began. This is the
+// property that separates "started at the wallet's first on-chain
+// appearance" from "started at genesis", independently of how many
+// blocks sit above that point.
+func (c *countingEsplora) lowestHeight() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	lowest := -1
+	for p := range c.paths {
+		rest, ok := strings.CutPrefix(p, "/block-height/")
+		if !ok {
+			continue
+		}
+
+		h, err := strconv.Atoi(rest)
+		if err != nil {
+			continue
+		}
+
+		if lowest == -1 || h < lowest {
+			lowest = h
+		}
+	}
+
+	return lowest
+}
+
+// logCounts dumps the tally so a failure shows where the traffic went.
+func (c *countingEsplora) logCounts(t *testing.T) {
+	t.Helper()
+
+	counts := c.snapshot()
+	for _, k := range []string{
+		"total", "block-height", "block-header", "block-raw",
+		"block-json", "tip", "address", "scripthash", "other",
+	} {
+		t.Logf("  %-14s %d", k, counts[k])
+	}
+
+	t.Logf("  %-14s %d", "heights", c.distinctHeights())
+}
+
+// routeClass maps an Esplora path onto a stable bucket name so
+// per-height scan traffic is distinguishable from tip polling and from
+// index lookups.
+func routeClass(path string) string {
+	switch {
+	case strings.HasPrefix(path, "/block-height/"):
+		return "block-height"
+
+	case strings.HasSuffix(path, "/raw"):
+		return "block-raw"
+
+	case strings.HasSuffix(path, "/header"):
+		return "block-header"
+
+	case strings.HasPrefix(path, "/blocks/tip"):
+		return "tip"
+
+	case strings.HasPrefix(path, "/block/"):
+		return "block-json"
+
+	case strings.HasPrefix(path, "/address/"):
+		return "address"
+
+	case strings.HasPrefix(path, "/scripthash/"):
+		return "scripthash"
+
+	default:
+		return "other"
+	}
+}
+
+// newSyncTestWallet builds an lwwallet against the given Esplora URL
+// with no birthday configured, which is the input reported in issue
+// #1073: a zero time.Time is January of year 1, so btcwallet's
+// timestamp search for a matching block bottoms out at genesis. A
+// pinned aezeed genesis birthday and a seed genuinely older than the
+// chain both land in the same place.
+func newSyncTestWallet(t *testing.T, esploraURL, dbDir string,
+	seed []byte) *lwwallet.Wallet {
+
+	t.Helper()
+
+	logger := btclog.NewSLogger(btclog.NewDefaultHandler(&testWriter{t: t}))
+	logger.SetLevel(btclog.LevelInfo)
+
+	w, err := lwwallet.New(lwwallet.Config{
+		Seed:           seed,
+		WalletPassword: []byte("issue-1073-password"),
+		EsploraURL:     esploraURL,
+		ChainParams:    &chaincfg.RegressionNetParams,
+		PollInterval:   time.Second,
+		RecoveryWindow: 100,
+		DBDir:          dbDir,
+		Log:            fn.Some[btclog.Logger](logger),
+	})
+	require.NoError(t, err)
+
+	return w
+}
+
+// testWriter routes wallet logs through the test log so they are
+// captured per test rather than interleaved on stdout.
+type testWriter struct {
+	t *testing.T
+}
+
+// Write implements io.Writer.
+func (w *testWriter) Write(p []byte) (int, error) {
+	w.t.Logf("%s", strings.TrimRight(string(p), "\n"))
+
+	return len(p), nil
+}
+
+// TestLwWalletSyncSkipsFullChainScan is the regression test for issue
+// #1073. A wallet created without a birthday used to resolve its
+// birthday block to genesis and then fetch every block between there
+// and the tip over Esplora. It now resolves its start height from the
+// Esplora address index instead, so startup traffic is bounded by the
+// address gap limit rather than by the length of the chain.
+func TestLwWalletSyncSkipsFullChainScan(t *testing.T) {
+	h := harness.NewHarness(t, nil)
+	h.Start()
+	t.Cleanup(h.Stop)
+
+	// Grow the chain so a genesis-anchored scan is unmistakable in the
+	// request tally.
+	h.Generate(400)
+
+	tipHeight := int(h.BlockCount())
+	t.Logf("chain tip height: %d", tipHeight)
+
+	esplora := newCountingEsplora(t, h.EsploraURL)
+
+	var seed [32]byte
+	for i := range seed {
+		seed[i] = byte(i + 7)
+	}
+
+	w := newSyncTestWallet(t, esplora.URL, t.TempDir(), seed[:])
+
+	start := time.Now()
+	require.NoError(t, w.Start())
+	t.Cleanup(w.Stop)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer cancel()
+
+	require.NoError(t, w.WaitForSync(ctx))
+
+	t.Logf("sync took %v", time.Since(start))
+	esplora.logCounts(t)
+
+	// The bound is expressed against the chain height rather than as a
+	// fixed number, so it keeps meaning the same thing as the
+	// harness's pre-mine count changes. A wallet still walking the
+	// chain sequentially fetches at least one block per height.
+	require.Less(
+		t, esplora.blockFetches(), tipHeight, "wallet fetched %d "+
+			"blocks for a %d block chain, so it is still "+
+			"walking the chain sequentially",
+		esplora.blockFetches(), tipHeight,
+	)
+}
+
+// firstReceiveAddress brings a wallet up just long enough to hand out
+// one receive address, then shuts it down again. The address is what a
+// later restore of the same seed has to rediscover from the index.
+func firstReceiveAddress(t *testing.T, esploraURL string, seed []byte) string {
+	t.Helper()
+
+	w := newSyncTestWallet(t, esploraURL, t.TempDir(), seed)
+	require.NoError(t, w.Start())
+
+	defer w.Stop()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer cancel()
+
+	require.NoError(t, w.WaitForSync(ctx))
+
+	addr, err := w.NewAddress(ctx)
+	require.NoError(t, err)
+
+	return addr.String()
+}
+
+// TestLwWalletRestoreStartsAtFirstUse is the safety half of the fix.
+// Resolving a start height from the index is only correct if it never
+// lands above the wallet's own funds, so this funds a wallet at a known
+// height, discards its database, grows the chain well past that point,
+// and restores from the same seed.
+//
+// Two things must hold. The restored wallet recovers the full balance,
+// which is what would break if the index-resolved height drifted too
+// high. And its scan begins at the funding block rather than at genesis,
+// which is the original defect. The second is asserted as the lowest
+// height fetched rather than as a request count, because a wallet funded
+// early legitimately has to scan everything above its funding block.
+func TestLwWalletRestoreStartsAtFirstUse(t *testing.T) {
+	h := harness.NewHarness(t, nil)
+	h.Start()
+	t.Cleanup(h.Stop)
+
+	const fundAmount = btcutil.Amount(50_000)
+
+	var seed [32]byte
+	for i := range seed {
+		seed[i] = byte(i + 11)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
+	defer cancel()
+
+	// Push the funding well above genesis so "started at the funding
+	// block" and "started at genesis" are far apart.
+	h.Generate(300)
+
+	addr := firstReceiveAddress(t, h.EsploraURL, seed[:])
+
+	t.Logf("funding %s with %v", addr, fundAmount)
+	h.Faucet(addr, fundAmount)
+	h.Generate(1)
+
+	fundedAt := int(h.BlockCount())
+
+	// Grow the chain past the funding so a genesis-anchored scan and a
+	// first-use-anchored scan look nothing alike. The growth is derived
+	// from the tip poller's history seed rather than hard coded: that
+	// seed walks back DefaultHashHistorySize heights from the tip on
+	// every start, and if it reached below the funding block it would
+	// swamp the assertion below.
+	h.Generate(lwwallet.DefaultHashHistorySize + 50)
+
+	tipHeight := int(h.BlockCount())
+	t.Logf("funded at %d, tip %d", fundedAt, tipHeight)
+
+	// Restore into a fresh database from the same seed. This is the
+	// path where a start height resolved too high silently loses the
+	// funds below it.
+	esplora := newCountingEsplora(t, h.EsploraURL)
+
+	restored := newSyncTestWallet(t, esplora.URL, t.TempDir(), seed[:])
+	require.NoError(t, restored.Start())
+	t.Cleanup(restored.Stop)
+
+	require.NoError(t, restored.WaitForSync(ctx))
+
+	// btcwallet records recovered credits as its recovery batches
+	// commit, which trails the sync height, so poll rather than
+	// reading the balance once.
+	require.Eventually(t, func() bool {
+		confirmed, _, err := restored.Balance(ctx)
+		if err != nil {
+			t.Logf("balance error: %v", err)
+
+			return false
+		}
+
+		return confirmed == fundAmount
+	}, time.Minute, 250*time.Millisecond,
+		"restored wallet never recovered the funded balance")
+
+	esplora.logCounts(t)
+
+	// The scan must start at the block below the funding, which is
+	// where btcwallet's recovery resumes from. Allowing a little slack
+	// keeps this from encoding the exact off-by-one, while still
+	// failing loudly on anything that reaches back toward genesis.
+	lowest := esplora.lowestHeight()
+	t.Logf("lowest height fetched: %d (funded at %d)", lowest, fundedAt)
+
+	require.GreaterOrEqual(
+		t, lowest, fundedAt-3, "restore reached down to height %d "+
+			"on a wallet first funded at %d, so it is scanning "+
+			"below its own first use", lowest, fundedAt,
+	)
+}

--- a/waved/rpc_wallet.go
+++ b/waved/rpc_wallet.go
@@ -432,6 +432,9 @@ func (r *RPCServer) UnlockWallet(ctx context.Context,
 	// Open the existing wallet database with the supplied password
 	// as btcwallet's private passphrase. A wrong password surfaces
 	// as an unlock failure from the wallet backend.
+	// The zero birthday is inert here: a nil seed opens the existing
+	// database, and btcwallet only reads the birthday on the create
+	// branch.
 	if err := r.server.startSelfManagedWallet(
 		ctx, nil, req.WalletPassword, time.Time{},
 	); err != nil {

--- a/waved/seed_manager.go
+++ b/waved/seed_manager.go
@@ -19,6 +19,18 @@ const (
 	// environments.
 	seedEnvVar = "WAVED_LWWALLET_SEED"
 
+	// seedBirthdayEnvVar is the environment variable name for the
+	// creation date of the seed supplied via seedEnvVar. A raw hex
+	// seed carries no birthday of its own, unlike an aezeed mnemonic,
+	// so without this the wallet is created with a zero time.Time.
+	// btcwallet reads that as January of year 1 and resolves the
+	// birthday block to genesis, then scans the whole chain.
+	//
+	// Leaving it unset keeps that genesis-anchored behaviour, which is
+	// slow but never misses funds. Set it only when the seed is known
+	// to have no history before the given date.
+	seedBirthdayEnvVar = "WAVED_LWWALLET_SEED_BIRTHDAY"
+
 	// walletPasswordEnvVar is the environment variable name for
 	// providing the wallet password for auto-unlock at daemon
 	// startup.
@@ -132,6 +144,39 @@ func LoadSeedFromEnv() (*[rawSeedLen]byte, error) {
 	copy(seed[:], decoded)
 
 	return &seed, nil
+}
+
+// seedBirthdayLayouts are the accepted date formats for
+// seedBirthdayEnvVar, tried in order: a full RFC3339 timestamp, or a
+// plain calendar date, which is the granularity a seed birthday
+// actually has.
+var seedBirthdayLayouts = []string{time.RFC3339, time.DateOnly}
+
+// LoadSeedBirthdayFromEnv reads the birthday of the raw seed supplied
+// via seedEnvVar. An unset variable yields the zero time, which is what
+// btcwallet already treats as "scan from genesis" and is the safe
+// default: too early only costs scanning, while too late silently hides
+// funds received before it.
+//
+// A malformed value is an error rather than a fall back to the zero
+// time. Falling back would turn an operator's typo into a silent
+// full-chain scan, which is exactly the kind of quiet degradation the
+// explicit variable exists to prevent.
+func LoadSeedBirthdayFromEnv() (time.Time, error) {
+	raw := strings.TrimSpace(os.Getenv(seedBirthdayEnvVar))
+	if raw == "" {
+		return time.Time{}, nil
+	}
+
+	for _, layout := range seedBirthdayLayouts {
+		birthday, err := time.Parse(layout, raw)
+		if err == nil {
+			return birthday, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("invalid date in %s: %q is neither "+
+		"RFC3339 nor %s", seedBirthdayEnvVar, raw, time.DateOnly)
 }
 
 // LoadPasswordFromEnv reads the wallet password from the

--- a/waved/seed_manager_test.go
+++ b/waved/seed_manager_test.go
@@ -183,3 +183,67 @@ func TestWalletSeedFromMnemonicValidation(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid mnemonic")
 }
+
+// TestLoadSeedBirthdayFromEnv covers the birthday override for the raw
+// dev/CI seed. Unset must stay the zero time, which btcwallet reads as
+// "scan from genesis": slow, but it never hides funds. A malformed
+// value must be an error rather than a silent fall back to that same
+// zero time, since a typo would otherwise degrade quietly into a full
+// chain scan.
+func TestLoadSeedBirthdayFromEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    time.Time
+		wantErr bool
+	}{{
+		name:  "unset scans from genesis",
+		value: "",
+		want:  time.Time{},
+	}, {
+		name:  "calendar date",
+		value: "2024-05-03",
+		want:  time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC),
+	}, {
+		name:  "rfc3339",
+		value: "2024-05-03T23:11:00Z",
+		want:  time.Date(2024, 5, 3, 23, 11, 0, 0, time.UTC),
+	}, {
+		name:  "surrounding whitespace tolerated",
+		value: "  2024-05-03  ",
+		want:  time.Date(2024, 5, 3, 0, 0, 0, 0, time.UTC),
+	}, {
+		name:    "malformed is an error, not a silent genesis scan",
+		value:   "May 3rd 2024",
+		wantErr: true,
+	}, {
+		name:    "unix timestamp is not accepted",
+		value:   "1714777860",
+		wantErr: true,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.value != "" {
+				t.Setenv(seedBirthdayEnvVar, test.value)
+			}
+
+			got, err := LoadSeedBirthdayFromEnv()
+			if test.wantErr {
+				require.Error(t, err)
+
+				// A rejected value must not leak a usable
+				// birthday to the caller.
+				require.True(t, got.IsZero())
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.True(
+				t, test.want.Equal(got),
+				"want %v, got %v", test.want, got,
+			)
+		})
+	}
+}

--- a/waved/server.go
+++ b/waved/server.go
@@ -1702,8 +1702,15 @@ func (s *Server) tryAutoUnlockLwwallet(ctx context.Context) {
 			password = devWalletPassword
 		}
 
+		birthday, err := LoadSeedBirthdayFromEnv()
+		if err != nil {
+			s.log.ErrorS(ctx, "Invalid seed birthday", err)
+
+			return
+		}
+
 		if err := s.startLwwallet(
-			ctx, seed, password, time.Time{},
+			ctx, seed, password, birthday,
 		); err != nil {
 
 			s.log.ErrorS(
@@ -1759,6 +1766,9 @@ func (s *Server) tryAutoUnlockLwwallet(ctx context.Context) {
 
 	s.log.InfoS(ctx, "Auto-unlocking lwwallet")
 
+	// The zero birthday is inert on this path: a nil seed opens the
+	// existing database, and btcwallet only reads the birthday on the
+	// create branch.
 	if err := s.startLwwallet(
 		ctx, nil, password, time.Time{},
 	); err != nil {
@@ -1908,8 +1918,21 @@ func (s *Server) tryAutoUnlockBtcwallet(ctx context.Context) {
 			password = devWalletPassword
 		}
 
+		// A raw hex seed carries no birthday, so without an
+		// explicit one btcwallet resolves the birthday block to
+		// genesis and scans the whole chain. Unlike the lwwallet
+		// sibling there is no address index to recover the real
+		// start height from here, so the operator has to supply
+		// it. Unset stays genesis-anchored: slow, never wrong.
+		birthday, err := LoadSeedBirthdayFromEnv()
+		if err != nil {
+			s.log.ErrorS(ctx, "Invalid seed birthday", err)
+
+			return
+		}
+
 		if err := s.startBtcwallet(
-			ctx, seed, password, time.Time{},
+			ctx, seed, password, birthday,
 		); err != nil {
 
 			s.log.ErrorS(
@@ -1964,6 +1987,9 @@ func (s *Server) tryAutoUnlockBtcwallet(ctx context.Context) {
 
 	s.log.InfoS(ctx, "Auto-unlocking btcwallet")
 
+	// The zero birthday is inert on this path: a nil seed opens the
+	// existing database, and btcwallet only reads the birthday on the
+	// create branch.
 	if err := s.startBtcwallet(
 		ctx, nil, password, time.Time{},
 	); err != nil {


### PR DESCRIPTION
In this PR, we stop `lwwallet` from walking the entire chain on startup, and
instead ask the Esplora index directly where the wallet first shows up. Fixes
#1073.

The reported symptom was a wallet created without a birthday fetching every
block from genesis to the tip on signet. The mechanism is `btcwallet`'s
`locateBirthdayBlock`, which binary searches block timestamps for the seed
birthday within a +/-2h window. That search has no lower bound below genesis,
so a birthday older than the chain just walks off the bottom of the range and
returns block 0. It then persists that as _verified_, sets synced-to to 0, and
`recovery()` walks every height, followed by `Rescan()` walking them all over
again.

Measured on a 506 block regtest chain before the fix:

```
total 1636   block-height 619   block-header 507   block-raw 506
```

Roughly 3.2 Esplora requests per block of chain history. That extrapolates to
~800k requests on signet and ~3M on mainnet.

## Why a better birthday isn't enough

Three separate inputs land on block 0, and only one of them is a plumbing bug:

A `Config` with no `Birthday` at all, whose zero `time.Time` is January of year
1 (this is what the issue reporter hit, and it's why `waved`'s own
`wavecli create` path is fine: `WalletSeedFromMnemonic` passes a real
`cipherSeed.BirthdayTime()`). The SDK passkey path, which pins
`aezeed.BitcoinGenesisDate` into the mnemonic itself in `entropyToMnemonic`. And
an honest restore of a seed genuinely older than the chain.

That last one is the reason plumbing alone doesn't close this. A 2023 seed
restored onto testnet4 predates that chain's genesis entirely, and it's a
perfectly legitimate input. Even a correct birthday only _shortens_ the walk
rather than removing it, since the cost is O(chain-since-birthday) either way. A
seed from a year ago on mainnet is still ~52k blocks.

Worth noting this was never signet specific. `aezeed.BitcoinGenesisDate` is
`time.Unix(1231006505, 0)`, which is exactly mainnet's genesis timestamp, so
mainnet lands on block 0 too, just via the other branch of the search.

## Asking the index instead

We're already talking to a fully indexing chain source, so the "where did this
wallet first appear" question has a direct answer that costs nothing in chain
length.

Discovery derives each active key scope's receive and change scripts through
`btcwallet`'s own scoped key managers, which matters because that's what gets
each script the address type its scope's schema dictates (P2TR for BIP86, P2WPKH
for BIP84, nested P2SH for BIP49) rather than us reimplementing that mapping. It
probes `/scripthash/:h` for use under the configured gap limit, then takes the
earliest confirmed height across everything it found.

The result gets written into `waddrmgr` as a _verified_ birthday block before
`btcwallet` starts. That's the lever: `birthdaySanityCheck` returns a verified
block untouched and skips the timestamp search entirely, so `recovery()` and
`Rescan()` both begin where we put them.

A couple of details that are load-bearing. The stamp sits one block _below_ the
earliest appearance, because recovery resumes at synced-to plus one and would
otherwise skip the very block we're aiming at. And the write order in `waddrmgr`
matters: `PutSyncedTo` refuses a height whose predecessor's hash is absent, but
only once a birthday block exists, so we record synced-to first while
`FetchBirthdayBlock` still errors.

Receive branches are probed before change branches, and we skip the change
branches entirely when no receive address anywhere has been used. A change
output only exists if the wallet authored a spend, which requires it to have
held an output, which requires something to have paid a receive address first.
That halves the probe count in the case that matters most, a brand new wallet.

If discovery fails (unreachable index, a script with pathological history), it's
not fatal. The wallet still starts and `btcwallet` falls back to its own search,
just slowly.

Same 506 block chain after:

```
total 923   block-height 100   block-header 6   block-raw 6   scripthash 800
```

Block traffic goes 1638 -> ~12, and it's now flat in chain length. The 100
`block-height` calls are the `TipPoller`'s pre-existing reorg history seed, not
the scan. The 800 scripthash probes are the gap limit walk over both branches of
all four scopes, also constant.

## The script hash byte order bug

Building the systests turned up a separate pre-existing bug that was blocking
this, so it's the first commit.

`scriptHashHex` reversed the SHA256 digest before hex encoding, on the grounds
that this matched Electrum. It does match the Electrum _wire protocol_, whose
`blockchain.scripthash.*` methods reverse the digest. Esplora's REST API does
not: `/scripthash/:hash` wants it forward.

The failure mode is silent, which is what makes it nasty. Esplora answers an
unknown script hash with an empty result rather than an error, so every lookup
just came back with nothing found. That means `GetScriptUtxos` has been
returning no UTXOs the whole time, and with it the two chain backend paths built
on it: `checkConfByScript` and the script branch of confirmation hash lookup.

The existing test couldn't catch it because it built the expected request path
by calling `scriptHashHex`, so it agreed with the helper under any convention.
It now computes the expectation independently, and there's a fixed vector test
plus a systest that pins the encoding against a real electrs.

I found this the hard way: the first cut of the restore systest failed, and a
baseline run with the new code disabled showed restore working fine and scanning
all 508 heights. So the fix was losing funds, and the reversed digest was why
discovery saw every address as unused.

## The neutrino sibling

The advisor-review pass turned up the same shape one backend over, so there's a
fourth commit for it. `waved`'s env-seed startup passes a zero `time.Time` into
wallet creation, and a raw hex seed from `WAVED_LWWALLET_SEED` carries no
birthday to recover (unlike an aezeed mnemonic). For `lwwallet` that no longer
bites, since it resolves its own start height from the index. The
neutrino-backed `btcwallet` sibling has no index to consult, so it still pays
the full scan; compact filters make that slow rather than catastrophic.

I deliberately did **not** guess `time.Now()` there. A birthday that's too early
only costs scan time; one that's too late silently hides funds received before
it. Guessing would have been the second kind, and would have broken any CI flow
that funds a seed then restarts against a fresh data dir. Instead the operator
can state one via `WAVED_LWWALLET_SEED_BIRTHDAY` (calendar date or RFC3339), and
unset keeps today's genesis-anchored behaviour. A malformed date is an error
rather than a silent fall back to the same zero time, so a typo can't degrade
quietly into a full chain scan.

The three remaining zero-birthday call sites are open-only paths where a nil
seed means btcwallet never reaches the branch that reads the birthday. They're
commented as such so the value reads as deliberate.

## Testing

The three systests run against the Docker harness (bitcoind + electrs) and count
Esplora requests through a reverse proxy, so "does the wallet walk the whole
chain" is an assertion rather than an impression.

`TestLwWalletRestoreStartsAtFirstUse` is the one I care most about, since
resolving a start height from the index is only correct if it never lands
_above_ the wallet's own funds. It funds a wallet at a known height, throws the
database away, grows the chain, and restores from the same seed. The restored
wallet has to recover the full balance, and its scan has to begin at the funding
block: stamps 406 for a funding at 407, lowest height fetched 406.

Full systest suite is green (19 tests), as are all 63 unit test packages.

See each commit message for a detailed description w.r.t the incremental
changes.
