### PR TITLE
lwwallet: speed up sync by bypassing the linear block scan

### DIFF
--- a/lwwallet/AGENTS.md
+++ b/lwwallet/AGENTS.md
@@ -45,6 +45,16 @@ base logic with the neutrino-backed `btcwbackend` sibling via the extracted
 - `EsploraChainService` — `chain.Interface` adapter over `EsploraClient`,
   driven by a shared `TipPoller`. Feeds btcwallet's internal address-credit
   pipeline. Constructor: `NewEsploraChainService(esplora, tipPoller, logger)`.
+- Start-block discovery (`start_block.go`) — resolves where a new or
+  restored wallet begins scanning from the Esplora address index instead of
+  from the seed birthday, and writes it into `waddrmgr` as a *verified*
+  birthday block before `BtcWallet.Start()`. Entry point:
+  `Wallet.stampStartBlock`. Left to itself btcwallet binary searches block
+  timestamps (`locateBirthdayBlock`), which bottoms out at genesis for any
+  birthday older than the chain and then walks every block to the tip.
+  Discovery instead derives each active key scope's receive/change scripts
+  through btcwallet's own scoped key managers, probes `/scripthash/:h` under
+  the configured gap limit, and takes the earliest confirmed height.
 - `BoardingBackendAdapter` — Embeds `walletcore.BoardingBackendBase` for
   shared key derivation/script import; implements `wallet.BoardingBackend`
   and `wallet.OutputLeaser`. Queries Esplora directly for UTXOs (bypasses
@@ -79,6 +89,31 @@ base logic with the neutrino-backed `btcwbackend` sibling via the extracted
   (known limitation; acceptable for confirmation-target use cases).
 - LRU caches only hold immutable, hash-addressed data; a verified hash prevents
   a compromised Esplora endpoint from injecting arbitrary cache entries.
+- `scriptHashHex` hex-encodes the SHA256 digest in its natural byte order.
+  Esplora's REST API differs from the Electrum wire protocol here, which
+  reverses it, and a wrong order fails silently because the API answers an
+  unknown script hash with an empty result rather than an error.
+- Start-block discovery only ever stamps a wallet that has no birthday block
+  at all, and never moves the sync cursor backwards. Once btcwallet has
+  recorded a birthday block it owns the cursor.
+- A discovery failure is non-fatal: the wallet still starts and btcwallet
+  falls back to its own timestamp search, just slowly. Discovery refuses to
+  stamp rather than stamping on partial information, because a short walk
+  finds fewer used scripts, which raises the height it reports and moves the
+  stamp toward the tip: the direction that loses funds.
+- Start-block discovery trusts the Esplora index. That holds for a single
+  self-consistent instance, but a load-balanced public endpoint can serve a
+  current tip and a still-syncing script index from different backends, and
+  partial history is indistinguishable from an unused script. A restore in
+  that window stamps above its own funds permanently, since the stamp is
+  written verified. Point `EsploraURL` at an endpoint you control.
+- `FilterBlocks` and `Rescan` also trust successful script-history responses
+  to be complete. Errors, truncated pagination, and block-identity conflicts
+  fall back to full block scans, but an empty response is indistinguishable
+  from a script with no activity. If the tip is current while the script index
+  lags, btcwallet can advance `PutSyncedTo` past unindexed activity
+  permanently. Avoid load-balanced public endpoints; point `EsploraURL` at a
+  self-consistent instance you control.
 - UTXO enumeration queries Esplora directly rather than btcwallet's internal
   UTXO set, because btcwallet does not credit-mark non-default scope outputs.
 - `Stop()` explicitly closes btcwallet's internal database to prevent resource

--- a/lwwallet/CLAUDE.md
+++ b/lwwallet/CLAUDE.md
@@ -107,6 +107,13 @@ base logic with the neutrino-backed `btcwbackend` sibling via the extracted
   partial history is indistinguishable from an unused script. A restore in
   that window stamps above its own funds permanently, since the stamp is
   written verified. Point `EsploraURL` at an endpoint you control.
+- `FilterBlocks` and `Rescan` also trust successful script-history responses
+  to be complete. Errors, truncated pagination, and block-identity conflicts
+  fall back to full block scans, but an empty response is indistinguishable
+  from a script with no activity. If the tip is current while the script index
+  lags, btcwallet can advance `PutSyncedTo` past unindexed activity
+  permanently. Avoid load-balanced public endpoints; point `EsploraURL` at a
+  self-consistent instance you control.
 - UTXO enumeration queries Esplora directly rather than btcwallet's internal
   UTXO set, because btcwallet does not credit-mark non-default scope outputs.
 - `Stop()` explicitly closes btcwallet's internal database to prevent resource

--- a/lwwallet/chain_backend_reorg_test.go
+++ b/lwwallet/chain_backend_reorg_test.go
@@ -49,6 +49,11 @@ type fakeChain struct {
 	// heights simulates chain advance.
 	blocks map[int32]*fakeBlock
 
+	// blocksByHash retains replaced blocks for content-addressed header
+	// requests that were already in flight when a reorg changed the
+	// canonical height map.
+	blocksByHash map[chainhash.Hash]*fakeBlock
+
 	// txStatus is the response to /tx/<txid>/status.
 	txStatus map[chainhash.Hash]esploraTxStatus
 
@@ -80,9 +85,10 @@ type fakeBlock struct {
 	timestamp int64
 }
 
-// newFakeChain seeds a fakeChain with a single block at the given
-// tip height. tag is mixed into the block hash so independent
-// fakeChains in parallel tests produce distinct hashes.
+// newFakeChain seeds a connected fake chain through the given tip height.
+// tag is mixed into every block hash so independent fake chains in parallel
+// tests produce distinct hashes. Keeping the recent ancestors available is
+// part of the Esplora contract the tip poller's startup seed relies on.
 func newFakeChain(t *testing.T, tip int32, tag string) *fakeChain {
 	t.Helper()
 
@@ -90,6 +96,7 @@ func newFakeChain(t *testing.T, tip int32, tag string) *fakeChain {
 		t:             t,
 		tip:           tip,
 		blocks:        make(map[int32]*fakeBlock),
+		blocksByHash:  make(map[chainhash.Hash]*fakeBlock),
 		txStatus:      make(map[chainhash.Hash]esploraTxStatus),
 		rawTx:         make(map[chainhash.Hash][]byte),
 		outspends:     make(map[wire.OutPoint]esploraOutspend),
@@ -97,7 +104,15 @@ func newFakeChain(t *testing.T, tip int32, tag string) *fakeChain {
 		failRawHeader: make(map[chainhash.Hash]struct{}),
 	}
 
-	c.blocks[tip] = c.mintBlock(tip, chainhash.Hash{}, tag)
+	var prev chainhash.Hash
+	for height := int32(0); height <= tip; height++ {
+		block := c.mintBlock(
+			height, prev, fmt.Sprintf("%s-%d", tag, height),
+		)
+		c.blocks[height] = block
+		c.blocksByHash[block.hash] = block
+		prev = block.hash
+	}
 
 	return c
 }
@@ -151,6 +166,7 @@ func (c *fakeChain) replaceTip(tag string) *fakeBlock {
 
 	blk := c.mintBlock(c.tip, prevHash, tag)
 	c.blocks[c.tip] = blk
+	c.blocksByHash[blk.hash] = blk
 
 	return blk
 }
@@ -165,6 +181,7 @@ func (c *fakeChain) extend(tag string) *fakeBlock {
 	blk := c.mintBlock(c.tip+1, tipBlk.hash, tag)
 	c.tip++
 	c.blocks[c.tip] = blk
+	c.blocksByHash[blk.hash] = blk
 
 	return blk
 }
@@ -185,6 +202,7 @@ func (c *fakeChain) rewriteFrom(start int32, tagPrefix string) {
 		blk := c.mintBlock(h, prev,
 			fmt.Sprintf("%s-%d", tagPrefix, h))
 		c.blocks[h] = blk
+		c.blocksByHash[blk.hash] = blk
 		prev = blk.hash
 	}
 }
@@ -304,12 +322,14 @@ func (c *fakeChain) serveBlockReq(w http.ResponseWriter, _ *http.Request,
 		return
 	}
 
-	var found *fakeBlock
-	for _, b := range c.blocks {
-		if b.hash == *hash {
-			found = b
+	found := c.blocksByHash[*hash]
+	if found == nil {
+		for _, block := range c.blocks {
+			if block.hash == *hash {
+				found = block
 
-			break
+				break
+			}
 		}
 	}
 	if found == nil {
@@ -824,13 +844,83 @@ func TestChainBackendSpendReorgSkipsTransientStatusFailure(t *testing.T) {
 	require.Equal(t, statePositive, state)
 }
 
+// TestTipPollerStartDoesNotBlockOnSeedWalk pins the reason the seed walk
+// is asynchronous: it is historySize-1 sequential Esplora round trips, and
+// Start() gates the whole wallet (btcwallet and the chain backend are
+// started after it in Wallet.Start). On a mobile connection at ~145ms per
+// fetch the default history of 100 turned a foreground resume into ~15s of
+// dead time.
+//
+// The test injects a per-fetch delay and asserts Start() returns in well
+// under the time the full walk needs. Inline seeding would take at least
+// historySize-1 delays.
+func TestTipPollerStartDoesNotBlockOnSeedWalk(t *testing.T) {
+	t.Parallel()
+
+	const (
+		fetchDelay  = 120 * time.Millisecond
+		historySize = 6
+	)
+
+	chain := newFakeChain(t, 100, "seed-100")
+	chain.mu.Lock()
+	var prev chainhash.Hash
+	for h := int32(94); h <= 100; h++ {
+		blk := chain.mintBlock(h, prev, fmt.Sprintf("seed-%d", h))
+		chain.blocks[h] = blk
+		prev = blk.hash
+	}
+	chain.mu.Unlock()
+
+	// Delay only the content-addressed raw-header lookups the seed walk
+	// makes; the initial tip fetch stays fast so the measurement isolates
+	// the walk.
+	inner := chain.handler()
+	slow := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/header") {
+			time.Sleep(fetchDelay)
+		}
+		inner.ServeHTTP(w, r)
+	})
+	srv := httptest.NewServer(slow)
+	t.Cleanup(srv.Close)
+
+	esplora := NewEsploraClient(srv.URL, btclog.Disabled)
+	tipPoller := NewTipPollerWithConfig(
+		esplora, time.Hour, historySize, btclog.Disabled,
+	)
+
+	start := time.Now()
+	require.NoError(t, tipPoller.Start())
+	elapsed := time.Since(start)
+	t.Cleanup(tipPoller.Stop)
+
+	// Inline seeding would cost (historySize-1) * fetchDelay = 600ms.
+	// Allow generous headroom for the one tip fetch and CI scheduling
+	// while still failing decisively if the walk is back on the
+	// critical path.
+	require.Less(
+		t, elapsed, time.Duration(historySize-1)*fetchDelay/2,
+		"Start must not wait on the seed walk",
+	)
+
+	// The walk still completes, just off the startup path.
+	require.Eventually(t, func() bool {
+		tipPoller.mu.Lock()
+		defer tipPoller.mu.Unlock()
+		_, ok := tipPoller.hashAtHeightLocked(95)
+
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "seed walk never completed")
+}
+
 // TestTipPollerSeedsHashHistoryOnStart pins the property that the
-// poller seeds its recent-hash ring back through historySize-1
-// heights at Start. Without this, a fresh poller would only ever
-// cache the initial tip, leaving any reorg-event consumer with an
-// incomplete disconnected set for reorgs deeper than 1 block but
-// within the configured history. The chain.Interface consumer
-// (EsploraChainService) depends on a complete disconnected set to
+// poller seeds its recent-hash ring back through historySize-1 heights
+// before its asynchronous poll loop begins. Without this,
+// a fresh poller would only ever cache the initial tip, leaving any
+// reorg-event consumer with an incomplete disconnected set for reorgs
+// deeper than 1 block but within the configured history. The chain.Interface
+// consumer (EsploraChainService) depends on a complete disconnected set to
 // emit a BlockDisconnected for every height btcwallet must roll
 // back.
 func TestTipPollerSeedsHashHistoryOnStart(t *testing.T) {
@@ -841,9 +931,9 @@ func TestTipPollerSeedsHashHistoryOnStart(t *testing.T) {
 	// pre-populated with {97, 98, 99, 100}.
 	chain := newFakeChain(t, 100, "seed-100")
 	// fakeChain only populates the tip block; the test needs lower
-	// heights in the response. Extend backwards by minting blocks
-	// at 99, 98, 97 with the correct PrevBlock chain so the
-	// poller's seed walk resolves each height.
+	// heights in the response. Extend backwards by minting blocks at 99,
+	// 98, 97 with the correct PrevBlock chain so the poller's seed walk can
+	// follow raw headers back from the tip snapshot.
 	chain.mu.Lock()
 	var prev chainhash.Hash
 	for h := int32(97); h <= 100; h++ {
@@ -863,6 +953,19 @@ func TestTipPollerSeedsHashHistoryOnStart(t *testing.T) {
 	)
 	require.NoError(t, tipPoller.Start())
 	t.Cleanup(tipPoller.Stop)
+
+	// The seed walk is asynchronous: it is historySize-1 sequential
+	// Esplora round trips, which must not gate Start because Start
+	// gates the whole wallet. Wait for the ring to reach the deepest
+	// height before rewriting the chain, or the reorg races the seed
+	// and the observed fork point is nondeterministic.
+	require.Eventually(t, func() bool {
+		tipPoller.mu.Lock()
+		defer tipPoller.mu.Unlock()
+		_, ok := tipPoller.hashAtHeightLocked(97)
+
+		return ok
+	}, 5*time.Second, 5*time.Millisecond, "seed walk never filled the ring")
 
 	reorgSub, err := tipPoller.SubscribeReorgs()
 	require.NoError(t, err)

--- a/lwwallet/chain_backend_test.go
+++ b/lwwallet/chain_backend_test.go
@@ -84,12 +84,11 @@ func TestChainBackendBlockNotification(t *testing.T) {
 		blockHdrs         = make(map[int32]*wire.BlockHeader)
 	)
 
-	// Pre-generate real chained block headers so the tip poller's
-	// PrevBlock continuity check during advance can resolve the raw
-	// header endpoint with a header that actually links back to the
-	// previous height.
+	// Pre-generate the retained history plus the blocks this test mines.
+	// The poll loop starts only after its startup history is complete, and
+	// every later raw-header continuity check must link to its predecessor.
 	var prevHash chainhash.Hash
-	for h := int32(100); h <= 103; h++ {
+	for h := int32(0); h <= 103; h++ {
 		hdr := mintStubHeader(h, prevHash)
 		blockHdrs[h] = hdr
 		hash := hdr.BlockHash()

--- a/lwwallet/esplora_chain.go
+++ b/lwwallet/esplora_chain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 
@@ -229,15 +230,51 @@ func (s *EsploraChainService) IsCurrent() bool {
 	return true
 }
 
-// FilterBlocks scans a batch of blocks for transactions relevant to
-// the provided addresses and watched outpoints. For each block in the
-// request, the full block is fetched and every transaction is checked
-// for outputs matching external/internal addresses and inputs spending
-// watched outpoints. Returns the first block containing any match.
+// FilterBlocks reports the first block in the batch containing a
+// transaction relevant to the given addresses or watched outpoints.
+//
+// It answers from the Esplora address index rather than by downloading
+// blocks. The block-scanning shape of chain.Interface is a poor fit for
+// an indexed backend: btcwallet's recovery loop calls this once per
+// matching block while it expands its gap-limit horizon, so a per-block
+// implementation costs one full block download per block in the range —
+// on a restore-from-seed that is the entire chain since the wallet's
+// birthday, twice over (recovery here, then the catch-up rescan).
+//
+// Nothing in the FilterBlocksRequest/Response contract requires reading
+// blocks: the caller asks which of *these* addresses appear in *this*
+// range and where the earliest such block is. That is a history lookup
+// per address, which is what an index is for. Matching itself still goes
+// through filterBlock on the candidate transactions, so the semantics of
+// what counts as a match are identical to the scanning path.
 func (s *EsploraChainService) FilterBlocks(req *chain.FilterBlocksRequest) (
 	*chain.FilterBlocksResponse, error) {
 
 	ctx := s.requestContext()
+
+	if len(req.Blocks) == 0 {
+		return nil, nil
+	}
+
+	// Index the requested range by height. Results from the address
+	// index are clamped to this set: it is the caller's view of the
+	// chain, and the live index can report a height the caller has not
+	// asked about (or one a reorg has since retracted).
+	type blockSlot struct {
+		batchIdx uint32
+		meta     wtxmgr.BlockMeta
+	}
+	slots := make(map[int32]blockSlot, len(req.Blocks))
+	minHeight := req.Blocks[0].Height
+	for i, meta := range req.Blocks {
+		slots[meta.Height] = blockSlot{
+			batchIdx: uint32(i),
+			meta:     meta,
+		}
+		if meta.Height < minHeight {
+			minHeight = meta.Height
+		}
+	}
 
 	// Build a pkScript lookup table from the address sets so we
 	// can efficiently match transaction outputs.
@@ -269,10 +306,212 @@ func (s *EsploraChainService) FilterBlocks(req *chain.FilterBlocksRequest) (
 		}
 	}
 
-	for batchIdx, blockMeta := range req.Blocks {
-		block, err := s.esplora.GetRawBlock(
-			ctx, blockMeta.Hash,
+	// Probe every script the caller cares about. The watched outpoints'
+	// addresses are probed too but deliberately kept out of
+	// addrScripts: a transaction spending a watched outpoint is
+	// relevant even when it pays none of the derived addresses, yet the
+	// outpoint's own address must not be reported as a *found* address
+	// or it would push the recovery horizon on evidence the caller did
+	// not ask about.
+	probes := make(map[string]struct{}, len(addrScripts))
+	for script := range addrScripts {
+		probes[script] = struct{}{}
+	}
+	for _, addr := range req.WatchedOutPoints {
+		pkScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return s.fallbackFilterBlocks(
+				ctx, req, addrScripts, fmt.Errorf("derive "+
+					"watched outpoint script: %w", err),
+			)
+		}
+		probes[string(pkScript)] = struct{}{}
+	}
+
+	// Collect candidate txids per requested height. Every indexed block
+	// identity is checked against the caller's canonical batch before its
+	// transactions are trusted.
+	candidates := make(map[int32]map[chainhash.Hash]struct{})
+	for script := range probes {
+		refs, err := s.scriptHistoryToHeight(
+			ctx, []byte(script), minHeight,
 		)
+		if err != nil {
+			return s.fallbackFilterBlocks(
+				ctx, req, addrScripts, err,
+			)
+		}
+
+		for _, ref := range refs {
+			if !ref.Status.Confirmed {
+				continue
+			}
+
+			height, blockHash, err := indexedBlock(ref)
+			if err != nil {
+				return s.fallbackFilterBlocks(
+					ctx, req, addrScripts, err,
+				)
+			}
+
+			slot, wanted := slots[height]
+			if !wanted {
+				continue
+			}
+			if blockHash != slot.meta.Hash {
+				err := fmt.Errorf("indexed block mismatch at "+
+					"%d: got %s, want %s", height,
+					blockHash, slot.meta.Hash)
+
+				return s.fallbackFilterBlocks(
+					ctx, req, addrScripts, err,
+				)
+			}
+
+			txid, err := chainhash.NewHashFromStr(ref.Txid)
+			if err != nil {
+				err := fmt.Errorf("parse history txid %q: %w",
+					ref.Txid, err)
+
+				return s.fallbackFilterBlocks(
+					ctx, req, addrScripts, err,
+				)
+			}
+
+			if candidates[height] == nil {
+				candidates[height] = make(
+					map[chainhash.Hash]struct{},
+				)
+			}
+			candidates[height][*txid] = struct{}{}
+		}
+	}
+
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	// The caller trims its batch past the returned block, so candidates
+	// must be tested from lowest to highest. An indexed history entry can
+	// still be a false candidate, notably a funding transaction for a
+	// watched-outpoint script that does not itself spend the outpoint.
+	heights := make([]int32, 0, len(candidates))
+	for height := range candidates {
+		heights = append(heights, height)
+	}
+	sort.Slice(heights, func(i, j int) bool {
+		return heights[i] < heights[j]
+	})
+
+	for _, height := range heights {
+		slot := slots[height]
+		block := &wire.MsgBlock{}
+		for txid := range candidates[height] {
+			tx, err := s.esplora.GetRawTx(ctx, txid)
+			if err != nil {
+				err := fmt.Errorf("get history tx %s: %w", txid,
+					err)
+
+				return s.fallbackFilterBlocks(
+					ctx, req, addrScripts, err,
+				)
+			}
+			block.Transactions = append(block.Transactions, tx)
+		}
+
+		ordered, err := sortTxsByDependency(block.Transactions)
+		if err != nil {
+			return s.fallbackFilterBlocks(
+				ctx, req, addrScripts, err,
+			)
+		}
+		block.Transactions = ordered
+
+		resp := s.filterBlock(
+			block, slot.meta, slot.batchIdx, addrScripts,
+			req.WatchedOutPoints,
+		)
+		if resp != nil {
+			return resp, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// scriptHistoryToHeight returns the script's confirmed history, paging
+// back until it reaches minHeight or runs out.
+//
+// Esplora returns history newest-first, 25 confirmed entries per page, so
+// an address with a long history needs paging to reach an old recovery
+// batch. The page budget bounds a pathological address (an exchange hot
+// wallet someone pasted a key from) rather than walking forever.
+func (s *EsploraChainService) scriptHistoryToHeight(ctx context.Context,
+	pkScript []byte, minHeight int32) ([]esploraScriptTx, error) {
+
+	var (
+		all      []esploraScriptTx
+		lastSeen string
+	)
+
+	for range maxScriptTxPages {
+		refs, err := s.esplora.GetScriptChainTxs(
+			ctx, pkScript, lastSeen,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("get script history: %w", err)
+		}
+		if len(refs) == 0 {
+			return all, nil
+		}
+
+		all = append(all, refs...)
+		last := refs[len(refs)-1]
+		if int32(last.Status.BlockHeight) < minHeight {
+			return all, nil
+		}
+		if last.Txid == lastSeen {
+			return nil, fmt.Errorf("script history pagination did "+
+				"not advance past %s", lastSeen)
+		}
+
+		lastSeen = last.Txid
+	}
+
+	return nil, errHistoryTooLong
+}
+
+// fallbackFilterBlocks scans the requested blocks when the address index
+// cannot safely and completely answer the query.
+func (s *EsploraChainService) fallbackFilterBlocks(ctx context.Context,
+	req *chain.FilterBlocksRequest, addrScripts map[string]addressMatch,
+	indexErr error) (*chain.FilterBlocksResponse, error) {
+
+	if ctx.Err() != nil {
+		return nil, indexErr
+	}
+
+	s.log.WarnS(ctx, "Address index filter failed; scanning blocks",
+		indexErr,
+	)
+
+	resp, err := s.filterBlocksFromBlocks(ctx, req, addrScripts)
+	if err != nil {
+		return nil, fmt.Errorf("address index failed (%v), block "+
+			"scan: %w", indexErr, err)
+	}
+
+	return resp, nil
+}
+
+// filterBlocksFromBlocks implements FilterBlocks by downloading and
+// scanning each requested block in order.
+func (s *EsploraChainService) filterBlocksFromBlocks(ctx context.Context,
+	req *chain.FilterBlocksRequest, addrScripts map[string]addressMatch) (
+	*chain.FilterBlocksResponse, error) {
+
+	for batchIdx, blockMeta := range req.Blocks {
+		block, err := s.esplora.GetRawBlock(ctx, blockMeta.Hash)
 		if err != nil {
 			return nil, fmt.Errorf("get block %s: %w",
 				blockMeta.Hash, err)
@@ -282,13 +521,99 @@ func (s *EsploraChainService) FilterBlocks(req *chain.FilterBlocksRequest) (
 			block, blockMeta, uint32(batchIdx), addrScripts,
 			req.WatchedOutPoints,
 		)
-
 		if resp != nil {
 			return resp, nil
 		}
 	}
 
 	return nil, nil
+}
+
+// indexedBlock validates and returns one history entry's block identity.
+func indexedBlock(ref esploraScriptTx) (int32, chainhash.Hash, error) {
+	var none chainhash.Hash
+
+	if !ref.Status.Confirmed {
+		return 0, none, fmt.Errorf("history tx %s is unconfirmed",
+			ref.Txid)
+	}
+
+	height := int32(ref.Status.BlockHeight)
+	if int64(height) != ref.Status.BlockHeight || height < 0 {
+		return 0, none, fmt.Errorf("history tx %s has invalid "+
+			"height %d", ref.Txid, ref.Status.BlockHeight)
+	}
+
+	blockHash, err := chainhash.NewHashFromStr(ref.Status.BlockHash)
+	if err != nil {
+		return 0, none, fmt.Errorf("parse history block hash %q: %w",
+			ref.Status.BlockHash, err)
+	}
+
+	return height, *blockHash, nil
+}
+
+// sortTxsByDependency orders a transaction set so every in-set parent
+// precedes its children. Esplora history order and Go map iteration do not
+// preserve the block order btcwallet relies on when crediting and spending
+// wallet outputs in the same block.
+func sortTxsByDependency(txs []*wire.MsgTx) ([]*wire.MsgTx, error) {
+	byHash := make(map[chainhash.Hash]*wire.MsgTx, len(txs))
+	for _, tx := range txs {
+		txHash := tx.TxHash()
+		if _, ok := byHash[txHash]; ok {
+			return nil, fmt.Errorf("duplicate transaction %s",
+				txHash)
+		}
+		byHash[txHash] = tx
+	}
+
+	indegree := make(map[chainhash.Hash]int, len(txs))
+	children := make(map[chainhash.Hash][]chainhash.Hash)
+	for txHash, tx := range byHash {
+		for _, txIn := range tx.TxIn {
+			parent := txIn.PreviousOutPoint.Hash
+			if _, ok := byHash[parent]; !ok {
+				continue
+			}
+
+			indegree[txHash]++
+			children[parent] = append(children[parent], txHash)
+		}
+	}
+
+	ready := make([]chainhash.Hash, 0, len(txs))
+	for txHash := range byHash {
+		if indegree[txHash] == 0 {
+			ready = append(ready, txHash)
+		}
+	}
+	sort.Slice(ready, func(i, j int) bool {
+		return ready[i].String() < ready[j].String()
+	})
+
+	ordered := make([]*wire.MsgTx, 0, len(txs))
+	for len(ready) > 0 {
+		txHash := ready[0]
+		ready = ready[1:]
+		ordered = append(ordered, byHash[txHash])
+
+		for _, child := range children[txHash] {
+			indegree[child]--
+			if indegree[child] == 0 {
+				ready = append(ready, child)
+			}
+		}
+		sort.Slice(ready, func(i, j int) bool {
+			return ready[i].String() < ready[j].String()
+		})
+	}
+
+	if len(ordered) != len(txs) {
+		return nil, fmt.Errorf("transaction dependency cycle")
+	}
+
+	return ordered, nil
 }
 
 // addressMatch pairs an address's key scope and index with whether
@@ -482,6 +807,28 @@ func (s *EsploraChainService) Rescan(startHash *chainhash.Hash,
 	// asynchronously. See method doc for deadlock rationale.
 	var pending []interface{}
 
+	// Ask the address index which transactions in this range are
+	// relevant, instead of downloading every block and scanning it.
+	// The wallet still needs a notification per height to advance its
+	// sync state (waddrmgr's PutSyncedTo requires the previous height's
+	// hash to exist, so heights cannot be skipped), but the block
+	// *bodies* are what cost real bandwidth on a long rescan — a 4MB
+	// block per height versus a handful of history lookups for the
+	// whole range.
+	relevantByHeight, err := s.rescanRelevantTxs(
+		ctx, addrScripts, outpoints, startHeight, tipHeight,
+	)
+	if err != nil {
+		if ctx.Err() != nil {
+			return err
+		}
+
+		s.log.WarnS(ctx, "Address index rescan failed; scanning blocks",
+			err,
+		)
+		relevantByHeight = nil
+	}
+
 	// Walk each block from start to tip.
 	for height := startHeight; height <= tipHeight; height++ {
 		blockHash, err := s.esplora.GetBlockHashByHeight(
@@ -490,13 +837,6 @@ func (s *EsploraChainService) Rescan(startHash *chainhash.Hash,
 		if err != nil {
 			return fmt.Errorf("get block hash at %d: %w", height,
 				err)
-		}
-
-		block, err := s.esplora.GetRawBlock(
-			ctx, blockHash,
-		)
-		if err != nil {
-			return fmt.Errorf("get block at %d: %w", height, err)
 		}
 
 		blockHeader, err := s.esplora.GetBlockHeader(
@@ -515,16 +855,46 @@ func (s *EsploraChainService) Rescan(startHash *chainhash.Hash,
 			Time: time.Unix(blockHeader.Timestamp, 0),
 		}
 
-		// Filter transactions in this block.
-		var relevantTxs []*wtxmgr.TxRecord
-		for _, tx := range block.Transactions {
-			if !s.txMatchesRescan(
-				tx, addrScripts, outpoints,
-			) {
+		// Build records for whatever the index attributed to this
+		// canonical block. An inconsistent index answer falls back to
+		// the original full-block scan. An empty answer is trusted; see
+		// the package invariant documenting the index-completeness
+		// boundary.
+		var matchedTxs []*wire.MsgTx
+		indexed, hasIndexed := relevantByHeight[height]
+		scanBlock := relevantByHeight == nil
+		if hasIndexed && indexed.blockHash != blockHash {
+			s.log.WarnS(ctx, "Indexed rescan block mismatch; "+
+				"scanning block", fmt.Errorf("got %s, want %s",
+				indexed.blockHash, blockHash),
+				slog.Int("height", int(height)),
+			)
+			scanBlock = true
+		}
 
-				continue
+		if scanBlock {
+			block, err := s.esplora.GetRawBlock(ctx, blockHash)
+			if err != nil {
+				return fmt.Errorf("get block at %d: %w", height,
+					err)
 			}
 
+			for _, tx := range block.Transactions {
+				if !s.txMatchesRescan(
+					tx, addrScripts, outpoints,
+				) {
+
+					continue
+				}
+
+				matchedTxs = append(matchedTxs, tx)
+			}
+		} else if hasIndexed {
+			matchedTxs = indexed.txs
+		}
+
+		var relevantTxs []*wtxmgr.TxRecord
+		for _, tx := range matchedTxs {
 			rec, err := wtxmgr.NewTxRecordFromMsgTx(
 				tx, blockMeta.Time,
 			)
@@ -576,6 +946,132 @@ func (s *EsploraChainService) Rescan(startHash *chainhash.Hash,
 	}()
 
 	return nil
+}
+
+// indexedBlockTxs groups relevant transactions by the indexed block hash
+// they were confirmed in.
+type indexedBlockTxs struct {
+	blockHash chainhash.Hash
+	txs       []*wire.MsgTx
+}
+
+// rescanRelevantTxs returns, grouped by block height, every confirmed
+// transaction between startHeight and tipHeight that pays to one of
+// addrScripts or spends one of outpoints.
+//
+// It probes the address index rather than reading blocks. The scripts
+// behind the watched outpoints are probed too: a transaction spending one
+// is relevant even when it pays none of the rescanned addresses, and
+// Esplora lists a transaction in the history of every script it touches,
+// including those it spends from.
+//
+// Results are clamped to [startHeight, tipHeight] — the index is live and
+// can report a height outside the range the caller asked to rescan.
+func (s *EsploraChainService) rescanRelevantTxs(ctx context.Context,
+	addrScripts map[string]struct{},
+	outpoints map[wire.OutPoint]btcaddr.Address,
+	startHeight, tipHeight int32) (map[int32]indexedBlockTxs, error) {
+
+	probes := make(map[string]struct{}, len(addrScripts))
+	for script := range addrScripts {
+		probes[script] = struct{}{}
+	}
+	for _, addr := range outpoints {
+		pkScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return nil, fmt.Errorf("derive watched outpoint "+
+				"script: %w", err)
+		}
+		probes[string(pkScript)] = struct{}{}
+	}
+
+	// Deduplicate across scripts: one transaction commonly touches
+	// several of the wallet's own scripts, and it must be reported once.
+	type indexedLocation struct {
+		height    int32
+		blockHash chainhash.Hash
+	}
+	seen := make(map[chainhash.Hash]indexedLocation)
+	byHeight := make(map[int32]indexedBlockTxs)
+
+	for script := range probes {
+		refs, err := s.scriptHistoryToHeight(
+			ctx, []byte(script), startHeight,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, ref := range refs {
+			if !ref.Status.Confirmed {
+				continue
+			}
+
+			height, blockHash, err := indexedBlock(ref)
+			if err != nil {
+				return nil, err
+			}
+			if height < startHeight || height > tipHeight {
+				continue
+			}
+
+			txid, err := chainhash.NewHashFromStr(ref.Txid)
+			if err != nil {
+				return nil, fmt.Errorf("parse history txid "+
+					"%q: %w", ref.Txid, err)
+			}
+			location := indexedLocation{
+				height:    height,
+				blockHash: blockHash,
+			}
+			if previous, dup := seen[*txid]; dup {
+				if previous != location {
+					return nil, fmt.Errorf("history tx %s "+
+						"has conflicting block "+
+						"locations", txid)
+				}
+
+				continue
+			}
+			seen[*txid] = location
+
+			tx, err := s.esplora.GetRawTx(ctx, *txid)
+			if err != nil {
+				return nil, fmt.Errorf("get rescan tx %s: %w",
+					txid, err)
+			}
+
+			// The index says this script appears in the tx; keep
+			// the authoritative match check so what lands in the
+			// wallet is exactly what the scanning path would have
+			// accepted.
+			if !s.txMatchesRescan(tx, addrScripts, outpoints) {
+				continue
+			}
+
+			indexed := byHeight[height]
+			if len(indexed.txs) > 0 &&
+				indexed.blockHash != blockHash {
+				return nil, fmt.Errorf("history height %d has "+
+					"conflicting block hashes", height)
+			}
+			indexed.blockHash = blockHash
+			indexed.txs = append(indexed.txs, tx)
+			byHeight[height] = indexed
+		}
+	}
+
+	for height, indexed := range byHeight {
+		ordered, err := sortTxsByDependency(indexed.txs)
+		if err != nil {
+			return nil, fmt.Errorf("order indexed txs at %d: %w",
+				height, err)
+		}
+		indexed.txs = ordered
+		byHeight[height] = indexed
+	}
+
+	return byHeight, nil
 }
 
 // txMatchesRescan checks whether a transaction matches any of the

--- a/lwwallet/esplora_filterblocks_test.go
+++ b/lwwallet/esplora_filterblocks_test.go
@@ -1,0 +1,1077 @@
+package lwwallet
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	btcaddr "github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeIndex is an Esplora stand-in that serves only the endpoints the
+// index-native FilterBlocks uses: scripthash history and raw tx. It
+// deliberately serves **no** block endpoint, so a FilterBlocks that falls
+// back to downloading blocks fails loudly instead of passing quietly.
+type fakeIndex struct {
+	mu sync.Mutex
+
+	// history maps a scripthash hex to its confirmed history, newest
+	// first, exactly as Esplora orders it.
+	history map[string][]esploraScriptTx
+
+	// txs maps a txid string to the raw transaction.
+	txs map[string]*wire.MsgTx
+
+	// blocks and heights hold canonical block fixtures for fallback and
+	// Rescan tests.
+	blocks  map[string]*wire.MsgBlock
+	heights map[int32]string
+
+	// blockFetches counts hits on any block endpoint. The whole point
+	// of the change is that this stays zero.
+	blockFetches int
+
+	// rawBlockFetches counts block-body downloads separately from the
+	// small metadata requests Rescan always makes.
+	rawBlockFetches int
+
+	// pages caps entries per history response, mirroring Esplora's 25.
+	pages int
+}
+
+// unsupportedAddress implements btcaddr.Address with a destination type that
+// txscript.PayToAddrScript deliberately rejects.
+type unsupportedAddress struct{}
+
+// String returns the test address label.
+func (unsupportedAddress) String() string {
+	return "unsupported"
+}
+
+// EncodeAddress returns the test address label.
+func (unsupportedAddress) EncodeAddress() string {
+	return "unsupported"
+}
+
+// ScriptAddress returns no standard script payload.
+func (unsupportedAddress) ScriptAddress() []byte {
+	return nil
+}
+
+// IsForNet reports that the synthetic address is network agnostic.
+func (unsupportedAddress) IsForNet(*chaincfg.Params) bool {
+	return true
+}
+
+func newFakeIndex() *fakeIndex {
+	return &fakeIndex{
+		history: make(map[string][]esploraScriptTx),
+		txs:     make(map[string]*wire.MsgTx),
+		blocks:  make(map[string]*wire.MsgBlock),
+		heights: make(map[int32]string),
+		pages:   25,
+	}
+}
+
+// addTx records a transaction as confirmed at height for every script it
+// pays to, and (when spending is simulated) for the scripts named in
+// alsoCredit — Esplora lists a transaction in the history of every script
+// it touches, including the ones it spends *from*.
+func (f *fakeIndex) addTx(t *testing.T, tx *wire.MsgTx, height int64,
+	blockHash chainhash.Hash, alsoCredit ...[]byte) {
+
+	t.Helper()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	txid := tx.TxHash()
+	f.txs[txid.String()] = tx
+
+	ref := esploraScriptTx{
+		Txid: txid.String(),
+		Status: esploraStatus{
+			Confirmed:   true,
+			BlockHeight: height,
+			BlockHash:   blockHash.String(),
+		},
+	}
+
+	scripts := make([][]byte, 0, len(tx.TxOut)+len(alsoCredit))
+	for _, out := range tx.TxOut {
+		scripts = append(scripts, out.PkScript)
+	}
+	scripts = append(scripts, alsoCredit...)
+
+	for _, script := range scripts {
+		h := scriptHashHex(script)
+		// Newest first.
+		f.history[h] = append([]esploraScriptTx{ref}, f.history[h]...)
+	}
+}
+
+// addBlock records a canonical block fixture and returns its metadata.
+func (f *fakeIndex) addBlock(t *testing.T, height int32,
+	txs ...*wire.MsgTx) wtxmgr.BlockMeta {
+
+	t.Helper()
+
+	blockTime := time.Unix(1_700_000_000+int64(height), 0)
+	block := &wire.MsgBlock{
+		Header: wire.BlockHeader{
+			Version:   2,
+			Timestamp: blockTime,
+			Nonce:     uint32(height),
+		},
+		Transactions: txs,
+	}
+	if len(txs) > 0 {
+		block.Header.MerkleRoot = txs[0].TxHash()
+	}
+	blockHash := block.BlockHash()
+
+	f.mu.Lock()
+	f.blocks[blockHash.String()] = block
+	f.heights[height] = blockHash.String()
+	f.mu.Unlock()
+
+	return wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Hash:   blockHash,
+			Height: height,
+		},
+		Time: blockTime,
+	}
+}
+
+func (f *fakeIndex) serve(t *testing.T) *EsploraChainService {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+
+			path := r.URL.Path
+			switch {
+			case strings.HasPrefix(path, "/scripthash/") &&
+				strings.Contains(path, "/txs"):
+
+				parts := strings.Split(path, "/")
+				hash := parts[2]
+				refs := f.history[hash]
+
+				// /txs/chain/:txid pages after that txid.
+				if idx := strings.Index(
+					path, "/chain/",
+				); idx >= 0 {
+
+					after := path[idx+len("/chain/"):]
+					for i, ref := range refs {
+						if ref.Txid == after {
+							refs = refs[i+1:]
+
+							break
+						}
+					}
+				}
+				if len(refs) > f.pages {
+					refs = refs[:f.pages]
+				}
+				require.NoError(
+					t, json.NewEncoder(w).Encode(refs),
+				)
+
+			case strings.HasPrefix(path, "/tx/") &&
+				strings.HasSuffix(path, "/raw"):
+
+				txid := strings.TrimSuffix(
+					strings.TrimPrefix(path, "/tx/"),
+					"/raw",
+				)
+				tx, ok := f.txs[txid]
+				if !ok {
+					w.WriteHeader(http.StatusNotFound)
+
+					return
+				}
+				var buf bytes.Buffer
+				require.NoError(t, tx.Serialize(&buf))
+				_, err := w.Write(buf.Bytes())
+				require.NoError(t, err)
+
+			case path == "/blocks/tip/height":
+				var tip int32
+				for height := range f.heights {
+					if height > tip {
+						tip = height
+					}
+				}
+				_, err := fmt.Fprint(w, tip)
+				require.NoError(t, err)
+
+			case strings.HasPrefix(path, "/block-height/"):
+				f.blockFetches++
+				height, err := strconv.ParseInt(
+					strings.TrimPrefix(
+						path, "/block-height/",
+					),
+					10,
+					32,
+				)
+				require.NoError(t, err)
+				hash, ok := f.heights[int32(height)]
+				if !ok {
+					w.WriteHeader(http.StatusNotFound)
+
+					return
+				}
+				_, err = fmt.Fprint(w, hash)
+				require.NoError(t, err)
+
+			case strings.HasPrefix(path, "/block/") &&
+				strings.HasSuffix(path, "/raw"):
+
+				f.blockFetches++
+				f.rawBlockFetches++
+				hash := strings.TrimSuffix(
+					strings.TrimPrefix(path, "/block/"),
+					"/raw",
+				)
+				block, ok := f.blocks[hash]
+				if !ok {
+					w.WriteHeader(http.StatusNotFound)
+
+					return
+				}
+				var buf bytes.Buffer
+				require.NoError(t, block.Serialize(&buf))
+				_, err := w.Write(buf.Bytes())
+				require.NoError(t, err)
+
+			case strings.HasPrefix(path, "/block/"):
+				f.blockFetches++
+				hash := strings.TrimPrefix(path, "/block/")
+				block, ok := f.blocks[hash]
+				if !ok {
+					w.WriteHeader(http.StatusNotFound)
+
+					return
+				}
+				var height int32
+				for candidate, blockHash := range f.heights {
+					if blockHash == hash {
+						height = candidate
+						break
+					}
+				}
+				timestamp := block.Header.Timestamp.Unix()
+				require.NoError(
+					t,
+					json.NewEncoder(
+						w).Encode(
+						esploraBlock{
+							ID:        hash,
+							Height:    height,
+							Timestamp: timestamp,
+						},
+					),
+				)
+
+			case strings.HasPrefix(path, "/block"):
+				f.blockFetches++
+				w.WriteHeader(http.StatusInternalServerError)
+
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		},
+	))
+	t.Cleanup(srv.Close)
+
+	esplora := NewEsploraClient(srv.URL, btclog.Disabled)
+
+	return &EsploraChainService{
+		esplora:       esplora,
+		log:           btclog.Disabled,
+		notifications: make(chan interface{}, 100),
+		runCtx:        t.Context(),
+		quit:          make(chan struct{}),
+	}
+}
+
+// testScript derives a deterministic p2wkh script and its address.
+func testScript(t *testing.T, seed byte) ([]byte, btcaddr.Address) {
+	t.Helper()
+
+	hash := make([]byte, 20)
+	for i := range hash {
+		hash[i] = seed
+	}
+	addr, err := btcaddr.NewAddressWitnessPubKeyHash(
+		hash, &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	script, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	return script, addr
+}
+
+func blockMetaAt(height int32, seed byte) wtxmgr.BlockMeta {
+	var h chainhash.Hash
+	h[0] = seed
+
+	return wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Height: height,
+			Hash:   h,
+		},
+		Time: time.Unix(1_700_000_000+int64(height), 0),
+	}
+}
+
+func payTo(script []byte, value int64) *wire.MsgTx {
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Index: 0xffffffff},
+	})
+	tx.AddTxOut(wire.NewTxOut(value, script))
+
+	return tx
+}
+
+// TestFilterBlocksUsesIndexNotBlocks pins the core property: the response
+// is derived from the address index and no block is ever downloaded. The
+// fake serves 500 on any block endpoint, so a regression to per-block
+// scanning fails rather than silently costing a round trip per block.
+func TestFilterBlocksUsesIndexNotBlocks(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	script, addr := testScript(t, 0x01)
+
+	meta := blockMetaAt(200, 0xaa)
+	tx := payTo(script, 50_000)
+	idx.addTx(t, tx, 200, meta.Hash)
+
+	svc := idx.serve(t)
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 1}
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks: []wtxmgr.BlockMeta{
+			blockMetaAt(199, 0xa9), meta, blockMetaAt(201, 0xab),
+		},
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{
+			{Scope: scope, Index: 7}: addr,
+		},
+		InternalAddrs:    map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.EqualValues(
+		t, 1, resp.BatchIndex,
+		"must point at the matching block's index within the request",
+	)
+	require.Equal(t, int32(200), resp.BlockMeta.Height)
+	require.Contains(t, resp.FoundExternalAddrs, scope)
+	require.Contains(t, resp.FoundExternalAddrs[scope], uint32(7))
+	require.Len(t, resp.RelevantTxns, 1)
+	require.Equal(t, tx.TxHash(), resp.RelevantTxns[0].TxHash())
+
+	require.Zero(
+		t, idx.blockFetches, "FilterBlocks must not download blocks",
+	)
+}
+
+// TestFilterBlocksFindsFullySpentAddress is the case a UTXO-based probe
+// gets wrong. The address received and then spent everything, so it has no
+// UTXOs — but BIP44 discovery must still count it as used, or the horizon
+// stops expanding and funds further along the branch are never found.
+func TestFilterBlocksFindsFullySpentAddress(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	script, addr := testScript(t, 0x02)
+
+	fundMeta := blockMetaAt(300, 0xb0)
+	fund := payTo(script, 80_000)
+	idx.addTx(t, fund, 300, fundMeta.Hash)
+
+	// Spend every output back out again; the script keeps a history
+	// entry for the spending tx but owns no UTXO afterwards.
+	spendMeta := blockMetaAt(301, 0xb1)
+	spend := wire.NewMsgTx(2)
+	fundHash := fund.TxHash()
+	spend.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: fundHash, Index: 0},
+	})
+	other, _ := testScript(t, 0x03)
+	spend.AddTxOut(wire.NewTxOut(70_000, other))
+	idx.addTx(t, spend, 301, spendMeta.Hash, script)
+
+	svc := idx.serve(t)
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 1}
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks: []wtxmgr.BlockMeta{fundMeta, spendMeta},
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{
+			{Scope: scope, Index: 3}: addr,
+		},
+		InternalAddrs:    map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{},
+	})
+	require.NoError(t, err)
+	require.NotNil(
+		t, resp, "a fully spent address is still a used address",
+	)
+	require.Equal(t, int32(300), resp.BlockMeta.Height)
+	require.Contains(t, resp.FoundExternalAddrs[scope], uint32(3))
+}
+
+// TestFilterBlocksReturnsLowestMatchingBlock pins the ordering the
+// recovery loop depends on. The caller trims its batch past the returned
+// index, so returning a later match would skip discovery in the blocks
+// between and under-expand the horizon.
+func TestFilterBlocksReturnsLowestMatchingBlock(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	early, earlyAddr := testScript(t, 0x11)
+	late, lateAddr := testScript(t, 0x12)
+
+	earlyMeta := blockMetaAt(400, 0xc0)
+	lateMeta := blockMetaAt(410, 0xc1)
+
+	// Register the later block first so the result cannot depend on
+	// insertion or map order.
+	idx.addTx(t, payTo(late, 10_000), 410, lateMeta.Hash)
+	idx.addTx(t, payTo(early, 20_000), 400, earlyMeta.Hash)
+
+	svc := idx.serve(t)
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 1}
+	blocks := []wtxmgr.BlockMeta{
+		blockMetaAt(399, 0xbf), earlyMeta,
+		blockMetaAt(405, 0xc5), lateMeta,
+	}
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks: blocks,
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{
+			{Scope: scope, Index: 1}: earlyAddr,
+			{Scope: scope, Index: 2}: lateAddr,
+		},
+		InternalAddrs:    map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, int32(400), resp.BlockMeta.Height)
+	require.EqualValues(t, 1, resp.BatchIndex)
+}
+
+// TestFilterBlocksIgnoresHeightsOutsideRequest pins the clamp. The index
+// is live and can report a height the caller did not ask about — a block
+// mined since the batch was built, or one a reorg has retracted. Reporting
+// it would attribute a transaction to a block the wallet has no record of.
+func TestFilterBlocksIgnoresHeightsOutsideRequest(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	script, addr := testScript(t, 0x21)
+
+	// Only history is at 900; the request covers 500-502.
+	outside := blockMetaAt(900, 0xd9)
+	idx.addTx(t, payTo(script, 5_000), 900, outside.Hash)
+
+	svc := idx.serve(t)
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 1}
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks: []wtxmgr.BlockMeta{
+			blockMetaAt(500, 0xd0), blockMetaAt(501, 0xd1),
+			blockMetaAt(502, 0xd2),
+		},
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{
+			{Scope: scope, Index: 0}: addr,
+		},
+		InternalAddrs:    map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{},
+	})
+	require.NoError(t, err)
+	require.Nil(
+		t, resp, "a match outside the requested range must not be "+
+			"reported; nil is the contract's batch-complete signal",
+	)
+}
+
+// TestFilterBlocksSkipsUnconfirmed pins that mempool entries are dropped.
+// FilterBlocks is a confirmed-only path, and an unconfirmed entry carries
+// height 0, which would otherwise be attributed to whatever block sits at
+// that index.
+func TestFilterBlocksSkipsUnconfirmed(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	script, addr := testScript(t, 0x31)
+
+	tx := payTo(script, 1_000)
+	txid := tx.TxHash()
+	idx.txs[txid.String()] = tx
+	idx.history[scriptHashHex(script)] = []esploraScriptTx{{
+		Txid: txid.String(),
+		Status: esploraStatus{
+			Confirmed: false,
+		},
+	}}
+
+	svc := idx.serve(t)
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 1}
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks: []wtxmgr.BlockMeta{blockMetaAt(0, 0xe0)},
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{
+			{Scope: scope, Index: 0}: addr,
+		},
+		InternalAddrs:    map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{},
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp, "unconfirmed history must not match a block")
+}
+
+// TestFilterBlocksEmptyBatch pins the trivial contract case: no blocks
+// means no match, and no requests at all.
+func TestFilterBlocksEmptyBatch(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	svc := idx.serve(t)
+
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{})
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.Zero(t, idx.blockFetches)
+}
+
+// TestFilterBlocksPagesHistory pins the paging walk. Esplora returns 25
+// confirmed entries per page; an address whose recent history is longer
+// than that would otherwise never reveal its older, in-range activity.
+func TestFilterBlocksPagesHistory(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	idx.pages = 5
+	script, addr := testScript(t, 0x41)
+
+	// Add the oldest entry first, then the recent entries in ascending
+	// order. addTx prepends, leaving the history newest-first with the
+	// target three pages back.
+	target := blockMetaAt(1_000, 0xf0)
+	idx.addTx(t, payTo(script, 999), 1_000, target.Hash)
+	for i := 0; i < 11; i++ {
+		h := int64(1_100 + i)
+		meta := blockMetaAt(int32(h), byte(0x80+i))
+		idx.addTx(t, payTo(script, int64(1_000+i)), h, meta.Hash)
+	}
+
+	// Newest-first ordering: the oldest entry must be last.
+	require.Equal(
+		t, 12, len(idx.history[scriptHashHex(script)]),
+		"fixture should hold every entry",
+	)
+
+	svc := idx.serve(t)
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 1}
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks: []wtxmgr.BlockMeta{target},
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{
+			{Scope: scope, Index: 5}: addr,
+		},
+		InternalAddrs:    map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{},
+	})
+	require.NoError(t, err)
+	require.NotNil(
+		t, resp,
+		"in-range history beyond the first page must still be found",
+	)
+	require.Equal(t, int32(1_000), resp.BlockMeta.Height)
+	require.Contains(t, resp.FoundExternalAddrs[scope], uint32(5))
+}
+
+// TestFilterBlocksFindsWatchedOutpointSpend pins that a transaction
+// spending a watched outpoint is found even when it pays none of the
+// derived addresses — and that the outpoint's own address is not reported
+// as a found address, which would push the recovery horizon on evidence
+// the caller never asked about.
+func TestFilterBlocksFindsWatchedOutpointSpend(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	watchedScript, watchedAddr := testScript(t, 0x51)
+	strangerScript, _ := testScript(t, 0x52)
+
+	fund := payTo(watchedScript, 40_000)
+	fundHash := fund.TxHash()
+
+	spendMeta := blockMetaAt(600, 0xe6)
+	spend := wire.NewMsgTx(2)
+	spend.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: fundHash, Index: 0},
+	})
+	spend.AddTxOut(wire.NewTxOut(30_000, strangerScript))
+	idx.addTx(t, spend, 600, spendMeta.Hash, watchedScript)
+
+	svc := idx.serve(t)
+
+	watched := wire.OutPoint{Hash: fundHash, Index: 0}
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks:        []wtxmgr.BlockMeta{spendMeta},
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		InternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{
+			watched: watchedAddr,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp, "a watched-outpoint spend is relevant")
+	require.Contains(t, resp.FoundOutPoints, watched)
+	require.Empty(
+		t, resp.FoundExternalAddrs, "the watched outpoint's "+
+			"address must not be reported as a discovered address",
+	)
+	require.Zero(t, idx.blockFetches)
+}
+
+// TestFilterBlocksPagesEntireBoundaryHeight verifies that pagination cannot
+// stop while more entries may remain at the request's minimum height.
+func TestFilterBlocksPagesEntireBoundaryHeight(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	idx.pages = 2
+	ownedScript, ownedAddr := testScript(t, 0x53)
+	otherScript, _ := testScript(t, 0x54)
+	meta := blockMetaAt(650, 0xe7)
+
+	fund := payTo(ownedScript, 50_000)
+	outpoint := wire.OutPoint{Hash: fund.TxHash(), Index: 0}
+	spend := wire.NewMsgTx(2)
+	spend.AddTxIn(&wire.TxIn{PreviousOutPoint: outpoint})
+	spend.AddTxOut(wire.NewTxOut(40_000, otherScript))
+
+	// addTx prepends history. Add the true spend first so two false
+	// candidates at the same height fill the first page ahead of it.
+	idx.addTx(t, spend, 650, meta.Hash, ownedScript)
+	idx.addTx(t, payTo(ownedScript, 2_000), 650, meta.Hash)
+	idx.addTx(t, payTo(ownedScript, 1_000), 650, meta.Hash)
+
+	svc := idx.serve(t)
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks:        []wtxmgr.BlockMeta{meta},
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		InternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{
+			outpoint: ownedAddr,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, spend.TxHash(), resp.RelevantTxns[0].TxHash())
+	require.Zero(t, idx.blockFetches)
+}
+
+// TestFilterBlocksFallsBackForUnsupportedOutpointAddress preserves the old
+// block-scanning behavior when an outpoint address cannot become a probe
+// script.
+func TestFilterBlocksFallsBackForUnsupportedOutpointAddress(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	otherScript, _ := testScript(t, 0x55)
+	var previous chainhash.Hash
+	previous[0] = 0x55
+	outpoint := wire.OutPoint{Hash: previous, Index: 1}
+	spend := wire.NewMsgTx(2)
+	spend.AddTxIn(&wire.TxIn{PreviousOutPoint: outpoint})
+	spend.AddTxOut(wire.NewTxOut(40_000, otherScript))
+	meta := idx.addBlock(t, 660, spend)
+
+	svc := idx.serve(t)
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks:        []wtxmgr.BlockMeta{meta},
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		InternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{
+			outpoint: unsupportedAddress{},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, spend.TxHash(), resp.RelevantTxns[0].TxHash())
+	require.Equal(t, 1, idx.rawBlockFetches)
+}
+
+// TestFilterBlocksCancellationSkipsFallback exercises the lifecycle-context
+// guard that prevents a canceled chain service from starting a block scan.
+func TestFilterBlocksCancellationSkipsFallback(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	script, addr := testScript(t, 0x56)
+	tx := payTo(script, 50_000)
+	meta := idx.addBlock(t, 670, tx)
+	idx.addTx(t, tx, 670, meta.Hash)
+
+	svc := idx.serve(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	svc.runCtx = ctx
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 1}
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks: []wtxmgr.BlockMeta{meta},
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{
+			{Scope: scope, Index: 0}: addr,
+		},
+		InternalAddrs:    map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{},
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, resp)
+	require.Zero(t, idx.rawBlockFetches)
+}
+
+// TestFilterBlocksContinuesAfterFalseCandidate covers a history entry that
+// touches a watched-outpoint script without spending the watched outpoint.
+// The matcher must continue to the later, actual spend rather than treating
+// the earliest index candidate as the answer for the whole batch.
+func TestFilterBlocksContinuesAfterFalseCandidate(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	ownedScript, ownedAddr := testScript(t, 0x61)
+	otherScript, _ := testScript(t, 0x62)
+
+	fundMeta := blockMetaAt(700, 0x71)
+	fund := payTo(ownedScript, 50_000)
+	idx.addTx(t, fund, 700, fundMeta.Hash)
+
+	spendMeta := blockMetaAt(701, 0x72)
+	spend := wire.NewMsgTx(2)
+	outpoint := wire.OutPoint{Hash: fund.TxHash(), Index: 0}
+	spend.AddTxIn(&wire.TxIn{PreviousOutPoint: outpoint})
+	spend.AddTxOut(wire.NewTxOut(40_000, otherScript))
+	idx.addTx(t, spend, 701, spendMeta.Hash, ownedScript)
+
+	svc := idx.serve(t)
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks:        []wtxmgr.BlockMeta{fundMeta, spendMeta},
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		InternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{
+			outpoint: ownedAddr,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, int32(701), resp.BlockMeta.Height)
+	require.Contains(t, resp.FoundOutPoints, outpoint)
+	require.Zero(t, idx.blockFetches)
+}
+
+// TestFilterBlocksOrdersParentsBeforeChildren ensures index and map order
+// cannot make btcwallet process a same-block child before its wallet-owned
+// parent.
+func TestFilterBlocksOrdersParentsBeforeChildren(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	script, addr := testScript(t, 0x63)
+	meta := blockMetaAt(710, 0x73)
+
+	parent := payTo(script, 50_000)
+	child := wire.NewMsgTx(2)
+	child.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  parent.TxHash(),
+			Index: 0,
+		},
+	})
+	child.AddTxOut(wire.NewTxOut(40_000, script))
+
+	// Add the parent last so the index returns it before the child and
+	// neither insertion order nor map order already satisfies the test.
+	idx.addTx(t, child, 710, meta.Hash)
+	idx.addTx(t, parent, 710, meta.Hash)
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 1}
+	svc := idx.serve(t)
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks: []wtxmgr.BlockMeta{meta},
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{
+			{Scope: scope, Index: 0}: addr,
+		},
+		InternalAddrs:    map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.RelevantTxns, 2)
+	require.Equal(t, parent.TxHash(), resp.RelevantTxns[0].TxHash())
+	require.Equal(t, child.TxHash(), resp.RelevantTxns[1].TxHash())
+}
+
+// TestFilterBlocksFallsBackAfterHistoryCap ensures a long script history
+// never becomes a successful partial answer. Once the page budget is
+// exhausted, FilterBlocks must scan the canonical requested block.
+func TestFilterBlocksFallsBackAfterHistoryCap(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	idx.pages = 1
+	script, addr := testScript(t, 0x64)
+	targetTx := payTo(script, 50_000)
+	target := idx.addBlock(t, 720, targetTx)
+	idx.addTx(t, targetTx, 720, target.Hash)
+
+	for i := int32(0); i <= maxScriptTxPages; i++ {
+		height := 800 + i
+		meta := blockMetaAt(height, byte(i))
+		idx.addTx(
+			t,
+			payTo(
+				script, int64(1_000+i),
+			),
+			int64(height),
+			meta.Hash,
+		)
+	}
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 1}
+	svc := idx.serve(t)
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks: []wtxmgr.BlockMeta{target},
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{
+			{Scope: scope, Index: 0}: addr,
+		},
+		InternalAddrs:    map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, target.Hash, resp.BlockMeta.Hash)
+	require.Equal(t, 1, idx.rawBlockFetches)
+}
+
+// TestFilterBlocksFallsBackOnBlockMismatch ensures a same-height history
+// entry from an orphaned block is never attributed to the canonical block.
+func TestFilterBlocksFallsBackOnBlockMismatch(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	script, addr := testScript(t, 0x65)
+	tx := payTo(script, 50_000)
+	canonical := idx.addBlock(t, 730, tx)
+	orphan := blockMetaAt(730, 0x7f)
+	idx.addTx(t, tx, 730, orphan.Hash)
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 1}
+	svc := idx.serve(t)
+	resp, err := svc.FilterBlocks(&chain.FilterBlocksRequest{
+		Blocks: []wtxmgr.BlockMeta{canonical},
+		ExternalAddrs: map[waddrmgr.ScopedIndex]btcaddr.Address{
+			{Scope: scope, Index: 0}: addr,
+		},
+		InternalAddrs:    map[waddrmgr.ScopedIndex]btcaddr.Address{},
+		WatchedOutPoints: map[wire.OutPoint]btcaddr.Address{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, canonical.Hash, resp.BlockMeta.Hash)
+	require.Equal(t, 1, idx.rawBlockFetches)
+}
+
+// TestRescanUsesIndexAndOrdersDependencies exercises the public Rescan
+// contract. It must emit the filtered notification before BlockConnected,
+// avoid block bodies on a consistent index, and preserve transaction
+// dependency order.
+func TestRescanUsesIndexAndOrdersDependencies(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	script, addr := testScript(t, 0x66)
+	parent := payTo(script, 50_000)
+	child := wire.NewMsgTx(2)
+	child.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  parent.TxHash(),
+			Index: 0,
+		},
+	})
+	child.AddTxOut(wire.NewTxOut(40_000, script))
+	meta := idx.addBlock(t, 740, parent, child)
+	idx.addTx(t, child, 740, meta.Hash)
+	idx.addTx(t, parent, 740, meta.Hash)
+
+	svc := idx.serve(t)
+	require.NoError(
+		t,
+		svc.Rescan(
+			&meta.Hash, []btcaddr.Address{addr},
+			map[wire.OutPoint]btcaddr.Address{},
+		),
+	)
+
+	filtered := requireNotification[chain.FilteredBlockConnected](
+		t, svc.notifications,
+	)
+	require.Equal(t, meta.Hash, filtered.Block.Hash)
+	require.Len(t, filtered.RelevantTxs, 2)
+	require.Equal(t, parent.TxHash(), filtered.RelevantTxs[0].Hash)
+	require.Equal(t, child.TxHash(), filtered.RelevantTxs[1].Hash)
+
+	connected := requireNotification[chain.BlockConnected](
+		t, svc.notifications,
+	)
+	require.Equal(t, meta.Hash, wtxmgr.BlockMeta(connected).Hash)
+	require.Zero(t, idx.rawBlockFetches)
+}
+
+// TestRescanFallsBackOnBlockMismatch verifies that Rescan checks indexed
+// block identity and scans the canonical block when history describes an
+// orphan at the same height.
+func TestRescanFallsBackOnBlockMismatch(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	script, addr := testScript(t, 0x67)
+	tx := payTo(script, 50_000)
+	canonical := idx.addBlock(t, 750, tx)
+	orphan := blockMetaAt(750, 0x7e)
+	idx.addTx(t, tx, 750, orphan.Hash)
+
+	svc := idx.serve(t)
+	require.NoError(
+		t,
+		svc.Rescan(
+			&canonical.Hash, []btcaddr.Address{addr},
+			map[wire.OutPoint]btcaddr.Address{},
+		),
+	)
+
+	filtered := requireNotification[chain.FilteredBlockConnected](
+		t, svc.notifications,
+	)
+	require.Equal(t, canonical.Hash, filtered.Block.Hash)
+	require.Len(t, filtered.RelevantTxs, 1)
+	require.Equal(t, tx.TxHash(), filtered.RelevantTxs[0].Hash)
+	require.Equal(t, 1, idx.rawBlockFetches)
+}
+
+// TestRescanFallsBackForUnsupportedOutpointAddress verifies that an address
+// which cannot become an index probe does not hide an outpoint spend.
+func TestRescanFallsBackForUnsupportedOutpointAddress(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	otherScript, _ := testScript(t, 0x68)
+	var previous chainhash.Hash
+	previous[0] = 0x68
+	outpoint := wire.OutPoint{Hash: previous, Index: 2}
+	spend := wire.NewMsgTx(2)
+	spend.AddTxIn(&wire.TxIn{PreviousOutPoint: outpoint})
+	spend.AddTxOut(wire.NewTxOut(40_000, otherScript))
+	meta := idx.addBlock(t, 760, spend)
+
+	svc := idx.serve(t)
+	require.NoError(
+		t,
+		svc.Rescan(
+			&meta.Hash, nil, map[wire.OutPoint]btcaddr.Address{
+				outpoint: unsupportedAddress{},
+			},
+		),
+	)
+
+	filtered := requireNotification[chain.FilteredBlockConnected](
+		t, svc.notifications,
+	)
+	require.Len(t, filtered.RelevantTxs, 1)
+	require.Equal(t, spend.TxHash(), filtered.RelevantTxs[0].Hash)
+	require.Equal(t, 1, idx.rawBlockFetches)
+}
+
+// TestRescanTrustsEmptyIndex documents the unavoidable completeness boundary:
+// a successful empty history is treated as authoritative, so Rescan advances
+// without downloading a block that contains unindexed wallet activity.
+func TestRescanTrustsEmptyIndex(t *testing.T) {
+	t.Parallel()
+
+	idx := newFakeIndex()
+	script, addr := testScript(t, 0x69)
+	tx := payTo(script, 50_000)
+	meta := idx.addBlock(t, 770, tx)
+
+	// Deliberately omit idx.addTx. The canonical block contains the wallet
+	// transaction, but the otherwise healthy index reports empty history.
+	svc := idx.serve(t)
+	require.NoError(
+		t,
+		svc.Rescan(
+			&meta.Hash, []btcaddr.Address{addr},
+			map[wire.OutPoint]btcaddr.Address{},
+		),
+	)
+
+	filtered := requireNotification[chain.FilteredBlockConnected](
+		t, svc.notifications,
+	)
+	require.Empty(t, filtered.RelevantTxs)
+	require.Zero(t, idx.rawBlockFetches)
+}
+
+// requireNotification waits for a notification of the requested concrete
+// type and fails with a bounded timeout.
+func requireNotification[T any](t *testing.T,
+	notifications <-chan interface{}) T {
+
+	t.Helper()
+
+	select {
+	case notification := <-notifications:
+		typed, ok := notification.(T)
+		require.True(t, ok, "unexpected notification %T", notification)
+
+		return typed
+
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "notification timeout")
+
+		var zero T
+
+		return zero
+	}
+}

--- a/lwwallet/tip_poller.go
+++ b/lwwallet/tip_poller.go
@@ -12,12 +12,22 @@ import (
 	"github.com/btcsuite/btclog/v2"
 )
 
-// DefaultHashHistorySize is the default upper bound on entries retained
-// in the TipPoller's bounded height -> hash history map. It is sized to
-// at least twice the conventional Bitcoin reorg-safety depth (6) so a
-// reorg at finality depth still has its disconnected hashes available
-// for walk-back, with headroom. Configurable via NewTipPollerWithConfig.
-const DefaultHashHistorySize = 100
+const (
+	// DefaultHashHistorySize is the default upper bound on entries retained
+	// in the TipPoller's bounded height -> hash history map. It is sized to
+	// at least twice the conventional Bitcoin reorg-safety depth (6) so a
+	// reorg at finality depth still has its disconnected hashes available
+	// for walk-back, with headroom. Configurable via
+	// NewTipPollerWithConfig.
+	DefaultHashHistorySize = 100
+
+	// seedRetryInitialBackoff and seedRetryMaxBackoff bound how quickly a
+	// transient raw-header failure is retried before polling begins. The
+	// retry continues until the history is complete or Stop cancels runCtx;
+	// only the delay is bounded.
+	seedRetryInitialBackoff = 100 * time.Millisecond
+	seedRetryMaxBackoff     = 5 * time.Second
+)
 
 // TipBlock describes a newly detected block emitted by TipPoller.
 // Each subscriber receives one TipBlock per advance: when the tip
@@ -122,6 +132,13 @@ type TipPoller struct {
 	pollInterval time.Duration
 	log          btclog.Logger
 
+	// runCtx and runCancel are owned by the poller and bound every
+	// Esplora request made by its background work. Stop cancels the
+	// context before waiting, so an in-flight seed or poll request cannot
+	// hold shutdown open indefinitely.
+	runCtx    context.Context //nolint:containedctx
+	runCancel context.CancelFunc
+
 	// historySize caps the bounded height -> hash history map that
 	// lets the poller resolve old-chain hashes during reorg walk-back.
 	historySize int
@@ -193,12 +210,15 @@ func NewTipPollerWithConfig(esplora *EsploraClient, pollInterval time.Duration,
 	if historySize <= 0 {
 		historySize = DefaultHashHistorySize
 	}
+	runCtx, runCancel := context.WithCancel(context.Background())
 
 	return &TipPoller{
 		esplora:      esplora,
 		pollInterval: pollInterval,
 		historySize:  historySize,
 		log:          log,
+		runCtx:       runCtx,
+		runCancel:    runCancel,
 		events:       NewEventServer[*TipBlock](log),
 		reorgs:       NewEventServer[*ReorgEvent](log),
 		chain:        NewEventServer[*ChainEvent](log),
@@ -239,7 +259,7 @@ func (t *TipPoller) Start() error {
 		t.mu.Unlock()
 	}
 
-	height, err := t.esplora.GetTipHeight(context.Background())
+	height, err := t.esplora.GetTipHeight(t.runCtx)
 	if err != nil {
 		resetStarted()
 
@@ -247,7 +267,7 @@ func (t *TipPoller) Start() error {
 	}
 
 	hash, err := t.esplora.GetBlockHashByHeight(
-		context.Background(), height,
+		t.runCtx, height,
 	)
 	if err != nil {
 		resetStarted()
@@ -263,14 +283,12 @@ func (t *TipPoller) Start() error {
 	// tested path never reads `tipTime`.
 	var tipTime time.Time
 	header, hdrErr := t.esplora.GetBlockHeader(
-		context.Background(), hash,
+		t.runCtx, hash,
 	)
 	if hdrErr == nil {
 		tipTime = time.Unix(header.Timestamp, 0)
 	} else {
-		t.log.WarnS(
-			context.Background(),
-			"Tip poller initial header fetch failed",
+		t.log.WarnS(t.runCtx, "Tip poller initial header fetch failed",
 			hdrErr,
 			slog.String("hash", hash.String()),
 		)
@@ -299,16 +317,9 @@ func (t *TipPoller) Start() error {
 		return fmt.Errorf("start chain event server: %w", err)
 	}
 
-	// Seed recentHashes by walking back historySize-1 heights so a
-	// reorg whose disconnected range extends below the seeded tip
-	// but within the configured history can still resolve every
-	// disconnected hash from the cache. Without this, a fresh
-	// poller would only ever cache the initial tip, leaving a
-	// downstream chain.Interface consumer unable to enumerate every
-	// hash btcwallet must roll back on a multi-block reorg below
-	// the seeded tip. The walk-back is best-effort: a single
-	// per-height fetch failure ends the seed loop early; the next
-	// poll tick still drives the cache forward as the chain grows.
+	// Publish the tip before anything else: this is what Start()'s
+	// callers actually wait for. See seedHashHistory for the rest of
+	// the ring.
 	t.mu.Lock()
 	t.tipHeight = height
 	t.tipHash = hash
@@ -316,30 +327,27 @@ func (t *TipPoller) Start() error {
 	t.recordHashLocked(height, hash)
 	t.mu.Unlock()
 
-	for h := height - 1; h > height-int32(t.historySize) && h >= 0; h-- {
-		liveHash, err := t.esplora.GetBlockHashByHeight(
-			context.Background(), h,
-		)
-		if err != nil {
-			t.log.WarnS(
-				context.Background(),
-				"Tip poller history seed fetch failed",
-				err,
-				slog.Int("height", int(h)),
-			)
+	// The walk-back runs in the background rather than inline: it is
+	// historySize-1 sequential Esplora round trips (99 by default),
+	// which on a mobile connection is ~15s of dead time before
+	// Start() returns — and Start() gates the whole wallet, since
+	// btcwallet and the chain backend are started after it. Nothing
+	// reads the seeded ring until pollLoop observes a reorg. The poll
+	// loop therefore starts only after the seed finishes, preventing a
+	// reorg from consuming a partially populated ring. Both phases share
+	// one component-owned goroutine and lifecycle context.
+	t.wg.Add(1)
+	go func() {
+		defer t.wg.Done()
 
-			break
+		if !t.seedHashHistoryWithRetry(height, hash) {
+			return
 		}
 
-		t.mu.Lock()
-		t.recordHashLocked(h, liveHash)
-		t.mu.Unlock()
-	}
+		t.pollLoop()
+	}()
 
-	t.wg.Add(1)
-	go t.pollLoop()
-
-	t.log.InfoS(context.Background(), "Tip poller started",
+	t.log.InfoS(t.runCtx, "Tip poller started",
 		slog.Int("tip_height", int(height)),
 		slog.String("tip_hash", hash.String()),
 	)
@@ -347,11 +355,84 @@ func (t *TipPoller) Start() error {
 	return nil
 }
 
-// Stop signals the polling goroutine to exit, waits for it to
-// drain, and tears down the event server. Stop is idempotent; the
-// second call returns immediately after the first has finished.
+// seedHashHistory walks back from tipHeight filling the recent-hash ring
+// so a reorg whose disconnected range extends below the seeded tip can
+// still resolve every disconnected hash from the cache. Without it, a
+// fresh poller would only ever cache the initial tip, leaving a
+// downstream chain.Interface consumer unable to enumerate every hash
+// btcwallet must roll back on a multi-block reorg below that tip.
+//
+// The walk follows PrevBlock links from the tip snapshot rather than live
+// height lookups. That keeps the ring on one chain if a reorg happens while
+// the asynchronous seed is in flight.
+func (t *TipPoller) seedHashHistory(tipHeight int32,
+	tipHash chainhash.Hash) error {
+
+	lowest := tipHeight - int32(t.historySize)
+	currentHash := tipHash
+	for h := tipHeight - 1; h > lowest && h >= 0; h-- {
+		header, err := t.esplora.GetRawBlockHeader(
+			t.runCtx, currentHash,
+		)
+		if err != nil {
+			return fmt.Errorf("get seed header %s for height "+
+				"%d: %w", currentHash, h, err)
+		}
+
+		currentHash = header.PrevBlock
+		t.mu.Lock()
+		t.recordHashLocked(h, currentHash)
+		t.mu.Unlock()
+	}
+
+	return nil
+}
+
+// seedHashHistoryWithRetry completes the startup history before handing the
+// component-owned goroutine to pollLoop. A capped exponential delay avoids a
+// tight retry loop while preserving the invariant that polling never observes
+// a partially seeded ring.
+func (t *TipPoller) seedHashHistoryWithRetry(tipHeight int32,
+	tipHash chainhash.Hash) bool {
+
+	backoff := seedRetryInitialBackoff
+	for {
+		err := t.seedHashHistory(tipHeight, tipHash)
+		if err == nil {
+			return true
+		}
+		if t.runCtx.Err() != nil {
+			return false
+		}
+
+		t.log.WarnS(
+			t.runCtx,
+			"Tip poller history seed failed; retrying",
+			err,
+			slog.Duration("retry_delay", backoff),
+		)
+
+		timer := time.NewTimer(backoff)
+		select {
+		case <-timer.C:
+		case <-t.runCtx.Done():
+			timer.Stop()
+
+			return false
+		}
+
+		backoff *= 2
+		if backoff > seedRetryMaxBackoff {
+			backoff = seedRetryMaxBackoff
+		}
+	}
+}
+
+// Stop signals the polling goroutine to exit, waits for it to drain, and
+// tears down the event servers. Stop is idempotent.
 func (t *TipPoller) Stop() {
 	t.stopOnce.Do(func() {
+		t.runCancel()
 		close(t.quit)
 	})
 
@@ -362,7 +443,7 @@ func (t *TipPoller) Stop() {
 	// its subscriber handler.
 	if err := t.events.Stop(); err != nil {
 		t.log.WarnS(
-			context.Background(),
+			t.runCtx,
 			"Tip poller event server stop returned error",
 			err,
 		)
@@ -370,7 +451,7 @@ func (t *TipPoller) Stop() {
 
 	if err := t.reorgs.Stop(); err != nil {
 		t.log.WarnS(
-			context.Background(),
+			t.runCtx,
 			"Tip poller reorg event server stop returned error",
 			err,
 		)
@@ -378,7 +459,7 @@ func (t *TipPoller) Stop() {
 
 	if err := t.chain.Stop(); err != nil {
 		t.log.WarnS(
-			context.Background(),
+			t.runCtx,
 			"Tip poller chain event server stop returned error",
 			err,
 		)
@@ -529,8 +610,6 @@ func (t *TipPoller) hashAtHeightLocked(height int32) (chainhash.Hash, bool) {
 // gap from the cached tip to the new tip emitting one TipBlock per
 // step.
 func (t *TipPoller) pollLoop() {
-	defer t.wg.Done()
-
 	ticker := time.NewTicker(t.pollInterval)
 	defer ticker.Stop()
 
@@ -566,10 +645,10 @@ func (t *TipPoller) pollLoop() {
 // cycle so subscribers never see an out-of-order event; the next
 // tick re-attempts from the same starting point.
 func (t *TipPoller) poll() {
-	newHeight, err := t.esplora.GetTipHeight(context.Background())
+	newHeight, err := t.esplora.GetTipHeight(t.runCtx)
 	if err != nil {
 		t.log.WarnS(
-			context.Background(),
+			t.runCtx,
 			"Tip poller GetTipHeight failed",
 			err,
 		)
@@ -604,11 +683,11 @@ func (t *TipPoller) poll() {
 		// orphaning reorg to a shorter chain would be silently
 		// ignored until the new chain grew past our stale tip.
 		newTipHash, err := t.esplora.GetBlockHashByHeight(
-			context.Background(), newHeight,
+			t.runCtx, newHeight,
 		)
 		if err != nil {
 			t.log.WarnS(
-				context.Background(),
+				t.runCtx,
 				"Tip poller shorter-chain hash check failed",
 				err,
 				slog.Int("height", int(newHeight)),
@@ -630,7 +709,7 @@ func (t *TipPoller) poll() {
 		// re-check next tick rather than walk a pruned history.
 		case !haveCached:
 			t.log.WarnS(
-				context.Background(),
+				t.runCtx,
 				"Tip poller remote tip below retained "+
 					"history floor; ignoring",
 				fmt.Errorf("history floor exceeded"),
@@ -661,11 +740,11 @@ func (t *TipPoller) poll() {
 		// height we have a same-height reorg; if it matches
 		// the chain has not moved.
 		newTipHash, err := t.esplora.GetBlockHashByHeight(
-			context.Background(), newHeight,
+			t.runCtx, newHeight,
 		)
 		if err != nil {
 			t.log.WarnS(
-				context.Background(),
+				t.runCtx,
 				"Tip poller same-height hash check failed",
 				err,
 				slog.Int("height", int(newHeight)),
@@ -697,7 +776,7 @@ func (t *TipPoller) poll() {
 // broadcast, including when a reorg lands midway through a multi-block
 // catch-up walk.
 func (t *TipPoller) advance(oldHeight, newHeight int32) {
-	t.log.DebugS(context.Background(), "Tip poller advancing",
+	t.log.DebugS(t.runCtx, "Tip poller advancing",
 		slog.Int("old_height", int(oldHeight)),
 		slog.Int("new_height", int(newHeight)),
 	)
@@ -707,7 +786,7 @@ func (t *TipPoller) advance(oldHeight, newHeight int32) {
 	t.mu.Unlock()
 	if !ok {
 		t.log.WarnS(
-			context.Background(),
+			t.runCtx,
 			"Tip poller advance starts below retained history",
 			fmt.Errorf("history floor exceeded"),
 			slog.Int("old_height", int(oldHeight)),
@@ -718,11 +797,11 @@ func (t *TipPoller) advance(oldHeight, newHeight int32) {
 
 	for height := oldHeight + 1; height <= newHeight; height++ {
 		hash, err := t.esplora.GetBlockHashByHeight(
-			context.Background(), height,
+			t.runCtx, height,
 		)
 		if err != nil {
 			t.log.WarnS(
-				context.Background(),
+				t.runCtx,
 				"Tip poller GetBlockHashByHeight failed",
 				err,
 				slog.Int("height", int(height)),
@@ -732,11 +811,11 @@ func (t *TipPoller) advance(oldHeight, newHeight int32) {
 		}
 
 		header, err := t.esplora.GetBlockHeader(
-			context.Background(), hash,
+			t.runCtx, hash,
 		)
 		if err != nil {
 			t.log.WarnS(
-				context.Background(),
+				t.runCtx,
 				"Tip poller GetBlockHeader failed",
 				err,
 				slog.String("hash", hash.String()),
@@ -749,14 +828,14 @@ func (t *TipPoller) advance(oldHeight, newHeight int32) {
 		// height would miss a reorg that lands after an earlier block
 		// in this catch-up walk has already been broadcast.
 		rawHdr, err := t.esplora.GetRawBlockHeader(
-			context.Background(), hash,
+			t.runCtx, hash,
 		)
 		if err != nil {
 			// Without the raw header we cannot prove that this
 			// block connects to the last one subscribers saw.
 			// Abort without advancing; the next tick retries.
 			t.log.WarnS(
-				context.Background(),
+				t.runCtx,
 				"Tip poller raw header fetch failed; aborting "+
 					"cycle",
 				err,
@@ -771,11 +850,11 @@ func (t *TipPoller) advance(oldHeight, newHeight int32) {
 			// actual current tip and let handleReorg disconnect any
 			// earlier blocks this iteration already broadcast.
 			tipHash, tipErr := t.esplora.GetBlockHashByHeight(
-				context.Background(), newHeight,
+				t.runCtx, newHeight,
 			)
 			if tipErr != nil {
 				t.log.WarnS(
-					context.Background(),
+					t.runCtx,
 					"Tip poller reorg tip fetch failed",
 					tipErr,
 					slog.Int("height", int(newHeight)),
@@ -830,9 +909,7 @@ func (t *TipPoller) broadcastTipBlock(event *TipBlock) bool {
 	t.mu.Unlock()
 
 	if tipErr != nil {
-		t.log.WarnS(
-			context.Background(),
-			"Tip poller send update failed",
+		t.log.WarnS(t.runCtx, "Tip poller send update failed",
 			tipErr,
 			slog.Int("height", int(event.Height)),
 		)
@@ -841,9 +918,7 @@ func (t *TipPoller) broadcastTipBlock(event *TipBlock) bool {
 	}
 
 	if chainErr != nil {
-		t.log.WarnS(
-			context.Background(),
-			"Tip poller chain stream send failed",
+		t.log.WarnS(t.runCtx, "Tip poller chain stream send failed",
 			chainErr,
 			slog.Int("height", int(event.Height)),
 		)
@@ -862,7 +937,7 @@ func (t *TipPoller) broadcastTipBlock(event *TipBlock) bool {
 // as TipBlock events in ascending height order so consumers can
 // re-check registrations against each new block.
 func (t *TipPoller) handleReorg(newTipHeight int32, newTipHash chainhash.Hash) {
-	t.log.InfoS(context.Background(), "Tip poller detected reorg",
+	t.log.InfoS(t.runCtx, "Tip poller detected reorg",
 		slog.Int("new_tip_height", int(newTipHeight)),
 		slog.String("new_tip_hash", newTipHash.String()),
 	)
@@ -905,11 +980,11 @@ func (t *TipPoller) handleReorg(newTipHeight int32, newTipHash chainhash.Hash) {
 		// slice capacity.
 		if probeHeight > cachedTipHeight {
 			liveHash, err := t.esplora.GetBlockHashByHeight(
-				context.Background(), probeHeight,
+				t.runCtx, probeHeight,
 			)
 			if err != nil {
 				t.log.WarnS(
-					context.Background(),
+					t.runCtx,
 					"Tip poller reorg walk-back failed",
 					err,
 					slog.Int("height", int(probeHeight)),
@@ -928,31 +1003,37 @@ func (t *TipPoller) handleReorg(newTipHeight int32, newTipHash chainhash.Hash) {
 		t.mu.Unlock()
 
 		if !haveCached {
-			// We never broadcast a block at this height
-			// (typically because it's older than our
-			// retained history's start, e.g. on a fresh
-			// poller that only ever cached the initial
-			// tip). Treat probeHeight as the fork point:
-			// anything at or below it is not part of our
-			// old broadcast set, so it cannot be
-			// "disconnected" from a downstream consumer's
-			// point of view. The live hash at this height
-			// is not a new connected block we owe
-			// subscribers either; only blocks strictly
-			// above probeHeight that we previously
-			// broadcast (and that have now changed) form
-			// the reorg boundary.
-			forkHeight = probeHeight
+			// The height exactly at cutoff is the expected
+			// boundary below the retained ring. Preserve the
+			// bounded deep-reorg signal for consumers that
+			// re-query their registrations canonically.
+			if probeHeight == cutoff {
+				forkHeight = probeHeight
 
-			break
+				break
+			}
+
+			// Any gap above cutoff means the startup seed was
+			// incomplete. Guessing that the gap is the fork
+			// point would emit only a suffix of an otherwise
+			// recoverable reorg and leave btcwallet on an
+			// impossible mixed history. Fail closed and retry.
+			t.log.WarnS(
+				t.runCtx,
+				"Tip poller reorg history is incomplete",
+				fmt.Errorf("missing cached block hash"),
+				slog.Int("height", int(probeHeight)),
+			)
+
+			return
 		}
 
 		liveHash, err := t.esplora.GetBlockHashByHeight(
-			context.Background(), probeHeight,
+			t.runCtx, probeHeight,
 		)
 		if err != nil {
 			t.log.WarnS(
-				context.Background(),
+				t.runCtx,
 				"Tip poller reorg walk-back failed",
 				err,
 				slog.Int("height", int(probeHeight)),
@@ -983,7 +1064,7 @@ func (t *TipPoller) handleReorg(newTipHeight int32, newTipHash chainhash.Hash) {
 		// is a developer / operator problem, not a
 		// productionally recoverable condition.
 		t.log.WarnS(
-			context.Background(),
+			t.runCtx,
 			"Tip poller reorg deeper than retained history; "+
 				"giving up walk-back",
 			fmt.Errorf("history exhausted"),
@@ -1030,11 +1111,11 @@ func (t *TipPoller) handleReorg(newTipHeight int32, newTipHash chainhash.Hash) {
 	for _, h := range connectedHeights {
 		hash := connectedByHeight[h]
 		header, err := t.esplora.GetBlockHeader(
-			context.Background(), hash,
+			t.runCtx, hash,
 		)
 		if err != nil {
 			t.log.WarnS(
-				context.Background(),
+				t.runCtx,
 				"Tip poller reorg header fetch failed",
 				err,
 				slog.String("hash", hash.String()),
@@ -1065,7 +1146,7 @@ func (t *TipPoller) handleReorg(newTipHeight int32, newTipHash chainhash.Hash) {
 		Connected:    connected,
 	}
 
-	t.log.InfoS(context.Background(), "Tip poller emitting reorg",
+	t.log.InfoS(t.runCtx, "Tip poller emitting reorg",
 		slog.Int("fork_height", int(forkHeight)),
 		slog.Int("disconnected", len(disconnected)),
 		slog.Int("connected", len(connected)),
@@ -1073,7 +1154,7 @@ func (t *TipPoller) handleReorg(newTipHeight int32, newTipHash chainhash.Hash) {
 
 	if err := t.reorgs.SendUpdate(reorgEvent); err != nil {
 		t.log.WarnS(
-			context.Background(),
+			t.runCtx,
 			"Tip poller reorg send failed",
 			err,
 		)
@@ -1093,9 +1174,7 @@ func (t *TipPoller) handleReorg(newTipHeight int32, newTipHash chainhash.Hash) {
 		&ChainEvent{Reorg: reorgEvent},
 	); err != nil {
 
-		t.log.WarnS(
-			context.Background(),
-			"Tip poller chain reorg send failed",
+		t.log.WarnS(t.runCtx, "Tip poller chain reorg send failed",
 			err,
 		)
 

--- a/lwwallet/tip_poller_reorg_test.go
+++ b/lwwallet/tip_poller_reorg_test.go
@@ -3,6 +3,7 @@ package lwwallet
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -65,6 +66,8 @@ func (c *stubChain) reorgTo(t *testing.T, forkHeight, newTip, gen int32) {
 		c.blocks[h] = hdr
 		hash := hdr.BlockHash()
 		c.hashAt[h] = hash
+		c.allBlocks[hash] = hdr
+		c.heightByHash[hash] = h
 		prev = hash
 	}
 
@@ -356,4 +359,211 @@ func TestTipPollerReorgDuringMultiBlockAdvance(t *testing.T) {
 	}
 
 	requireTipEventually(t, tp, 112)
+}
+
+// TestTipPollerDoesNotPollWithPartialSeed reproduces a reorg racing the
+// asynchronous startup walk. The poll loop must wait for the old-chain ring
+// to be complete, and the walk must remain anchored to the original tip even
+// after height lookups switch to the replacement chain.
+func TestTipPollerDoesNotPollWithPartialSeed(t *testing.T) {
+	chain := newStubChain(100)
+	chain.mu.Lock()
+	old99 := chain.hashAt[99]
+	oldDisconnected := []chainhash.Hash{
+		chain.hashAt[98], chain.hashAt[99], chain.hashAt[100],
+	}
+	chain.mu.Unlock()
+
+	seedBlocked := make(chan struct{})
+	release := make(chan struct{})
+	var (
+		blockedOnce sync.Once
+		releaseOnce sync.Once
+	)
+	releaseSeed := func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+	}
+	defer releaseSeed()
+
+	baseHandler := stubEsploraHandler(t, chain)
+	blockedPath := "/block/" + old99.String() + "/header"
+	srv := mockEsploraServer(
+		t, http.HandlerFunc(func(w http.ResponseWriter,
+			r *http.Request) {
+
+			if r.URL.Path == blockedPath {
+				blockedOnce.Do(func() {
+					close(seedBlocked)
+				})
+
+				select {
+				case <-release:
+				case <-r.Context().Done():
+					return
+				}
+			}
+
+			baseHandler(w, r)
+		}),
+	)
+
+	tp := NewTipPollerWithConfig(
+		NewEsploraClient(srv.URL, btclog.Disabled), 10*time.Millisecond,
+		4, btclog.Disabled,
+	)
+	require.NoError(t, tp.Start())
+	t.Cleanup(tp.Stop)
+
+	reorgSub, err := tp.SubscribeReorgs()
+	require.NoError(t, err)
+	defer reorgSub.Cancel()
+
+	select {
+	case <-seedBlocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("seed walk did not reach the blocked old-chain header")
+	}
+
+	chain.reorgTo(t, 97, 100, 1)
+
+	select {
+	case event := <-reorgSub.Updates():
+		t.Fatalf("poll emitted reorg from partial seed: %+v", event)
+
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseSeed()
+
+	select {
+	case event := <-reorgSub.Updates():
+		require.NotNil(t, event)
+		require.Equal(t, int32(97), event.ForkHeight)
+		require.Equal(t, oldDisconnected, event.Disconnected)
+
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for complete startup reorg")
+	}
+}
+
+// TestTipPollerRetriesHistorySeed verifies that one transient raw-header
+// failure cannot leave a permanent gap in the retained ring. Polling begins
+// only after the retry reconstructs the complete old-chain snapshot.
+func TestTipPollerRetriesHistorySeed(t *testing.T) {
+	chain := newStubChain(100)
+	chain.mu.Lock()
+	old99 := chain.hashAt[99]
+	oldDisconnected := []chainhash.Hash{
+		chain.hashAt[98], chain.hashAt[99], chain.hashAt[100],
+	}
+	chain.mu.Unlock()
+
+	seedFailed := make(chan struct{})
+	var failOnce sync.Once
+	baseHandler := stubEsploraHandler(t, chain)
+	failingPath := "/block/" + old99.String() + "/header"
+	srv := mockEsploraServer(
+		t, http.HandlerFunc(func(w http.ResponseWriter,
+			r *http.Request) {
+
+			fail := false
+			if r.URL.Path == failingPath {
+				failOnce.Do(func() {
+					fail = true
+					close(seedFailed)
+				})
+			}
+			if fail {
+				http.Error(
+					w, "transient failure",
+					http.StatusInternalServerError,
+				)
+
+				return
+			}
+
+			baseHandler(w, r)
+		}),
+	)
+
+	tp := NewTipPollerWithConfig(
+		NewEsploraClient(srv.URL, btclog.Disabled), 10*time.Millisecond,
+		4, btclog.Disabled,
+	)
+	require.NoError(t, tp.Start())
+	t.Cleanup(tp.Stop)
+
+	reorgSub, err := tp.SubscribeReorgs()
+	require.NoError(t, err)
+	defer reorgSub.Cancel()
+
+	select {
+	case <-seedFailed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("seed walk did not hit the transient failure")
+	}
+
+	chain.reorgTo(t, 97, 100, 1)
+
+	select {
+	case event := <-reorgSub.Updates():
+		require.NotNil(t, event)
+		require.Equal(t, int32(97), event.ForkHeight)
+		require.Equal(t, oldDisconnected, event.Disconnected)
+
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for reorg after seed retry")
+	}
+}
+
+// TestTipPollerStopCancelsSeedRequest ensures the component-owned lifecycle
+// context releases an in-flight startup seed request during shutdown.
+func TestTipPollerStopCancelsSeedRequest(t *testing.T) {
+	chain := newStubChain(100)
+	seedRequested := make(chan struct{})
+	var requestedOnce sync.Once
+
+	baseHandler := stubEsploraHandler(t, chain)
+	srv := mockEsploraServer(
+		t, http.HandlerFunc(func(w http.ResponseWriter,
+			r *http.Request) {
+
+			if strings.HasSuffix(r.URL.Path, "/header") {
+				requestedOnce.Do(func() {
+					close(seedRequested)
+				})
+				<-r.Context().Done()
+
+				return
+			}
+
+			baseHandler(w, r)
+		}),
+	)
+
+	tp := NewTipPollerWithConfig(
+		NewEsploraClient(srv.URL, btclog.Disabled), time.Hour, 4,
+		btclog.Disabled,
+	)
+	require.NoError(t, tp.Start())
+
+	select {
+	case <-seedRequested:
+	case <-time.After(2 * time.Second):
+		t.Fatal("seed request did not start")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		tp.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not cancel the seed request")
+	}
 }

--- a/lwwallet/tip_poller_test.go
+++ b/lwwallet/tip_poller_test.go
@@ -34,6 +34,12 @@ type stubChain struct {
 
 	// hashAt[h] is the chainhash.Hash for height h.
 	hashAt map[int32]chainhash.Hash
+
+	// allBlocks retains headers by hash after a reorg. Esplora's
+	// content-addressed block routes can still answer an in-flight request
+	// for the old chain even after height lookups move to the new chain.
+	allBlocks    map[chainhash.Hash]*wire.BlockHeader
+	heightByHash map[chainhash.Hash]int32
 }
 
 // mintStubHeader builds a deterministic wire.BlockHeader for a given
@@ -60,9 +66,11 @@ func mintStubHeader(height int32, prev chainhash.Hash) *wire.BlockHeader {
 
 func newStubChain(tipHeight int32) *stubChain {
 	c := &stubChain{
-		tipHeight: tipHeight,
-		blocks:    make(map[int32]*wire.BlockHeader),
-		hashAt:    make(map[int32]chainhash.Hash),
+		tipHeight:    tipHeight,
+		blocks:       make(map[int32]*wire.BlockHeader),
+		hashAt:       make(map[int32]chainhash.Hash),
+		allBlocks:    make(map[chainhash.Hash]*wire.BlockHeader),
+		heightByHash: make(map[chainhash.Hash]int32),
 	}
 
 	var prev chainhash.Hash
@@ -71,6 +79,8 @@ func newStubChain(tipHeight int32) *stubChain {
 		c.blocks[h] = hdr
 		hash := hdr.BlockHash()
 		c.hashAt[h] = hash
+		c.allBlocks[hash] = hdr
+		c.heightByHash[hash] = h
 		prev = hash
 	}
 
@@ -90,6 +100,8 @@ func (c *stubChain) advance(t *testing.T, n int32) {
 		c.blocks[h] = hdr
 		hash := hdr.BlockHash()
 		c.hashAt[h] = hash
+		c.allBlocks[hash] = hdr
+		c.heightByHash[hash] = h
 		prev = hash
 	}
 
@@ -152,21 +164,12 @@ func stubEsploraHandler(t *testing.T, chain *stubChain) http.HandlerFunc {
 			h, err := chainhash.NewHashFromStr(hashStr)
 			require.NoError(t, err)
 
-			// Find the height for this hash so we can
-			// craft a header whose BlockHash actually
-			// matches.
-			var height int32 = -1
 			chain.mu.Lock()
-			for hh, hash := range chain.hashAt {
-				if hash == *h {
-					height = hh
-
-					break
-				}
-			}
+			height, ok := chain.heightByHash[*h]
+			hdr := chain.allBlocks[*h]
 			chain.mu.Unlock()
 
-			if height < 0 {
+			if !ok || hdr == nil {
 				http.Error(w, "not found",
 					http.StatusNotFound)
 
@@ -184,17 +187,6 @@ func stubEsploraHandler(t *testing.T, chain *stubChain) http.HandlerFunc {
 
 			case "/header":
 				// Raw 80-byte header, hex-encoded.
-				chain.mu.Lock()
-				hdr := chain.blocks[height]
-				chain.mu.Unlock()
-				if hdr == nil {
-					http.Error(
-						w, "not found",
-						http.StatusNotFound,
-					)
-
-					return
-				}
 				var buf bytes.Buffer
 				require.NoError(t, hdr.Serialize(&buf))
 				_, _ = fmt.Fprint(


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/wavelength/issues/1073 and is complementary to https://github.com/lightninglabs/wavelength/pull/1076.

Implements three different speedups:
 - On `TipPoller.Start()`, fetching the 99 recent block hashes synchronously blocks the whole wallet startup -> moved to background.
 - In `EsploraChainService.FilterBlocks`, since we're already talking to an address indexer, we can bypass the sequential `s.esplora.GetRawBlock()` calls by looking up the history of the addresses to scan.
 - On `EsploraChainService.Rescan()` we do the same by fetching the whole history of the addresses in question.