### PR TITLE
build: bump version to v0.1.1-rc2

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -19,7 +19,7 @@ const (
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.
-	AppPreRelease = "rc1"
+	AppPreRelease = "rc2"
 )
 
 var (


### PR DESCRIPTION
## What changed

- Advance the Wavelength prerelease version from `v0.1.1-rc1` to `v0.1.1-rc2`.

## Why

The `v0.1.x-branch` release line received additional backports after RC1, including the wallet start-block and sweep-all documentation fixes. RC2 gives builds from the updated release branch a distinct version.

## Impact

`waved` and `wavecli` now report `0.1.1-rc2`. The existing release workflows already recognize RC tags as prereleases, so no workflow changes are needed.

## Validation

- `make fmt-changed`
- `go test ./build`
- `make build`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`
- Confirmed both built binaries report `0.1.1-rc2`

Full CI will run on the PR.