### PR TITLE
multi: add non-blocking TryTell and bound timeout actor delivery

### DIFF
--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -11,8 +11,8 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `Actor[M, R]` — Generic actor with typed message `M` and response `R`. Processes messages sequentially from its mailbox.
 - `ActorBehavior[M, R]` — Interface that actors implement: `Start`, `Receive`, `Stop`.
 - `ActorConfig[M, R]` — Configuration for actor creation (behavior, mailbox, codec, delivery store).
-- `ActorRef[M, R]` — Typed reference for sending messages to an actor (`Tell`, `Ask`).
-- `TellOnlyRef[M]` — Fire-and-forget reference (no response type).
+- `ActorRef[M, R]` — Typed reference for sending messages to an actor (`Tell`, `TryTell`, `Ask`).
+- `TellOnlyRef[M]` — Fire-and-forget reference (no response type): `Tell` blocks for mailbox room, `TryTell` never does.
 - `ActorSystem` — Container managing actor lifecycles, registration, and
   shutdown. `DeadLetters() ActorRef[Message, any]` returns the dead-letter
   outlet configured via `ActorConfig.DLO`.
@@ -104,6 +104,12 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `RestartMessage` has `RestartPriority` (MaxInt32) ensuring it is processed before all other messages on recovery.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.
 - `Mailbox.Send` returns the exact failure error (`ErrMailboxClosed`, `ErrActorTerminated`, `context.Canceled`, `context.DeadlineExceeded`) rather than a boolean; `Tell` and `Ask` propagate this directly to callers.
+- **Never `Tell` from inside a receive goroutine without a bound.** A blocking
+  send into a full peer mailbox parks the whole receive loop, and if the peer
+  is waiting on that actor the pair deadlocks. Use `TryTell`, which returns
+  `ErrMailboxFull` immediately so the caller can drop, stash, or reschedule
+  the message. A `context.WithTimeout` around `Tell` is the weaker option: it
+  burns the entire deadline against a peer that is already wedged.
 - During daemon teardown, the underlying DB is closed before every actor's lease loop has wound down. The lease loop uses `isExpectedShutdownErr` to demote these "database is closed" errors to debug level; real operational errors still surface as warnings because neither the actor context nor the outer context is done in those cases.
 - **Per-correlation-key FIFO claim.** Two messages in the same mailbox that
   share a non-empty `CorrelationKey()` are processed in emission order

--- a/baselib/actor/AGENTS.md
+++ b/baselib/actor/AGENTS.md
@@ -12,7 +12,7 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `ActorBehavior[M, R]` — Interface that actors implement: `Start`, `Receive`, `Stop`.
 - `ActorConfig[M, R]` — Configuration for actor creation (behavior, mailbox, codec, delivery store).
 - `ActorRef[M, R]` — Typed reference for sending messages to an actor (`Tell`, `TryTell`, `Ask`).
-- `TellOnlyRef[M]` — Fire-and-forget reference (no response type): `Tell` blocks for mailbox room, `TryTell` never does.
+- `TellOnlyRef[M]` — Fire-and-forget reference (no response type). `Tell` blocks for mailbox room, `TryTell` never does.
 - `ActorSystem` — Container managing actor lifecycles, registration, and
   shutdown. `DeadLetters() ActorRef[Message, any]` returns the dead-letter
   outlet configured via `ActorConfig.DLO`.

--- a/baselib/actor/CLAUDE.md
+++ b/baselib/actor/CLAUDE.md
@@ -11,8 +11,8 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `Actor[M, R]` — Generic actor with typed message `M` and response `R`. Processes messages sequentially from its mailbox.
 - `ActorBehavior[M, R]` — Interface that actors implement: `Start`, `Receive`, `Stop`.
 - `ActorConfig[M, R]` — Configuration for actor creation (behavior, mailbox, codec, delivery store).
-- `ActorRef[M, R]` — Typed reference for sending messages to an actor (`Tell`, `Ask`).
-- `TellOnlyRef[M]` — Fire-and-forget reference (no response type).
+- `ActorRef[M, R]` — Typed reference for sending messages to an actor (`Tell`, `TryTell`, `Ask`).
+- `TellOnlyRef[M]` — Fire-and-forget reference (no response type): `Tell` blocks for mailbox room, `TryTell` never does.
 - `ActorSystem` — Container managing actor lifecycles, registration, and
   shutdown. `DeadLetters() ActorRef[Message, any]` returns the dead-letter
   outlet configured via `ActorConfig.DLO`.
@@ -104,6 +104,12 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `RestartMessage` has `RestartPriority` (MaxInt32) ensuring it is processed before all other messages on recovery.
 - Transaction context (`WithTx`/`RequireTx`) enables same-DB-transaction joining between actors and their callers.
 - `Mailbox.Send` returns the exact failure error (`ErrMailboxClosed`, `ErrActorTerminated`, `context.Canceled`, `context.DeadlineExceeded`) rather than a boolean; `Tell` and `Ask` propagate this directly to callers.
+- **Never `Tell` from inside a receive goroutine without a bound.** A blocking
+  send into a full peer mailbox parks the whole receive loop, and if the peer
+  is waiting on that actor the pair deadlocks. Use `TryTell`, which returns
+  `ErrMailboxFull` immediately so the caller can drop, stash, or reschedule
+  the message. A `context.WithTimeout` around `Tell` is the weaker option: it
+  burns the entire deadline against a peer that is already wedged.
 - During daemon teardown, the underlying DB is closed before every actor's lease loop has wound down. The lease loop uses `isExpectedShutdownErr` to demote these "database is closed" errors to debug level; real operational errors still surface as warnings because neither the actor context nor the outer context is done in those cases.
 - **Per-correlation-key FIFO claim.** Two messages in the same mailbox that
   share a non-empty `CorrelationKey()` are processed in emission order

--- a/baselib/actor/CLAUDE.md
+++ b/baselib/actor/CLAUDE.md
@@ -12,7 +12,7 @@ crash-safe at-least-once delivery with exactly-once deduplication.
 - `ActorBehavior[M, R]` — Interface that actors implement: `Start`, `Receive`, `Stop`.
 - `ActorConfig[M, R]` — Configuration for actor creation (behavior, mailbox, codec, delivery store).
 - `ActorRef[M, R]` — Typed reference for sending messages to an actor (`Tell`, `TryTell`, `Ask`).
-- `TellOnlyRef[M]` — Fire-and-forget reference (no response type): `Tell` blocks for mailbox room, `TryTell` never does.
+- `TellOnlyRef[M]` — Fire-and-forget reference (no response type). `Tell` blocks for mailbox room, `TryTell` never does.
 - `ActorSystem` — Container managing actor lifecycles, registration, and
   shutdown. `DeadLetters() ActorRef[Message, any]` returns the dead-letter
   outlet configured via `ActorConfig.DLO`.

--- a/baselib/actor/README.md
+++ b/baselib/actor/README.md
@@ -235,6 +235,15 @@ There are two main ways to send messages using an `ActorRef`:
     two deadlock. The context is only consulted for an immediate cancellation
     check, so attaching a deadline to `TryTell` buys nothing.
 
+    Two cautions for durable targets. Their queue has no capacity, so they
+    never report `ErrMailboxFull`; a slow database write surfaces as a wrapped
+    `context.DeadlineExceeded` instead, which is why a retry decision should
+    test for the terminal errors (`ErrActorTerminated`, `ErrMailboxClosed`)
+    rather than for `ErrMailboxFull`. And unlike `Tell`, a durable `TryTell`
+    does not carry the caller's transaction into the enqueue, so a message
+    sent inside a commit closure can outlive a rolled back transaction. Keep
+    durable enqueues that must be atomic on `Tell`.
+
 3.  **Ask (Request-Response)**: Used when you need a response from the actor.
     This returns a `Future[R]`, which represents the eventual reply.
 

--- a/baselib/actor/README.md
+++ b/baselib/actor/README.md
@@ -215,7 +215,27 @@ There are two main ways to send messages using an `ActorRef`:
     operation if, for example, the actor's mailbox is full and the send would
     block for too long.
 
-2.  **Ask (Request-Response)**: Used when you need a response from the actor.
+2.  **TryTell (Non-Blocking Fire-and-Forget)**: Same as `Tell`, except that a
+    target with no mailbox room reports `ErrMailboxFull` right away instead of
+    waiting for space.
+
+    ```go
+    err := actorRef.TryTell(ctx, requestMsg)
+    switch {
+    case errors.Is(err, actor.ErrMailboxFull):
+        // The peer is behind. Drop, stash, or reschedule the message; do
+        // not wait for it.
+    case err != nil:
+        // The target is terminated or its mailbox is closed.
+    }
+    ```
+    Reach for this whenever the sender is itself inside a receive goroutine.
+    A blocking `Tell` there parks the sender's own message processing on the
+    peer's backlog, and if the peer is waiting on a reply from the sender the
+    two deadlock. The context is only consulted for an immediate cancellation
+    check, so attaching a deadline to `TryTell` buys nothing.
+
+3.  **Ask (Request-Response)**: Used when you need a response from the actor.
     This returns a `Future[R]`, which represents the eventual reply.
 
     ```go

--- a/baselib/actor/actor.go
+++ b/baselib/actor/actor.go
@@ -373,6 +373,53 @@ func (ref *actorRefImpl[M, R]) Tell(ctx context.Context, msg M) error {
 	return nil
 }
 
+// TryTell enqueues a message only if the mailbox can take it immediately,
+// returning ErrMailboxFull rather than waiting for room. Callers that run
+// inside another actor's receive loop use this so a backlogged target cannot
+// stall their own message processing.
+func (ref *actorRefImpl[M, R]) TryTell(ctx context.Context, msg M) error {
+	logger(ctx).TraceS(ctx, "Sending TryTell message",
+		"actor_id", ref.actor.id,
+		"msg_type", msg.MessageType())
+
+	// A caller that has already given up should not have its message
+	// enqueued. This is the only way the context participates: TrySend
+	// itself never waits, so there is nothing for a deadline to interrupt.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// As with Tell, this is fire-and-forget delivery, so the caller's
+	// database transaction must not ride along into the receiving actor's
+	// turn.
+	sendCtx := WithoutTx(ctx)
+
+	env := envelope[M, R]{
+		message:   msg,
+		promise:   nil,
+		callerCtx: sendCtx,
+	}
+	if err := ref.actor.mailbox.TrySend(env); err != nil {
+		// A terminated actor will never drain its mailbox, so the
+		// message is dead and belongs in the DLO. A full mailbox is
+		// transient by comparison and stays the caller's problem.
+		if errors.Is(err, ErrActorTerminated) {
+			logger(ctx).DebugS(
+				ctx,
+				"TryTell failed, routing to DLO",
+				"actor_id", ref.actor.id,
+				"msg_type", msg.MessageType(),
+			)
+
+			ref.trySendToDLO(msg)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
 // Ask sends a message and returns a Future for the response. The Future will be
 // completed with the actor's reply or an error if the operation fails (e.g.,
 // context cancellation before send).

--- a/baselib/actor/durable_actor.go
+++ b/baselib/actor/durable_actor.go
@@ -1535,6 +1535,51 @@ func (ref *durableActorRefImpl[M, R]) Tell(ctx context.Context, msg M) error {
 	return nil
 }
 
+// TryTell enqueues a message only if the durable mailbox can take it right
+// away. The enqueue is a database write, so the mailbox bounds the attempt
+// with its own short deadline instead of returning instantaneously; what the
+// caller is guaranteed is that it will never park waiting on a backlogged
+// consumer.
+func (ref *durableActorRefImpl[M, R]) TryTell(ctx context.Context,
+	msg M) error {
+
+	logger(ctx).TraceS(ctx, "Sending TryTell to durable actor",
+		"actor_id", ref.actor.id,
+		"msg_type", msg.MessageType())
+
+	// A caller that has already given up should not have its message
+	// persisted.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	env := envelope[M, R]{
+		message:   msg,
+		promise:   nil,
+		callerCtx: ctx,
+	}
+
+	if err := ref.actor.mailbox.TrySend(env); err != nil {
+		if errors.Is(err, ErrActorTerminated) {
+			logger(ctx).DebugS(
+				ctx,
+				"TryTell failed, routing to DLO",
+				"actor_id", ref.actor.id,
+				"msg_type", msg.MessageType(),
+			)
+
+			// Use context.Background() since the actor is
+			// terminated and the original context might already be
+			// cancelled.
+			ref.trySendToDLO(context.Background(), msg)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
 // Ask sends a message and returns a Future for the response.
 func (ref *durableActorRefImpl[M, R]) Ask(ctx context.Context,
 	msg M) Future[R] {

--- a/baselib/actor/durable_actor.go
+++ b/baselib/actor/durable_actor.go
@@ -1539,7 +1539,15 @@ func (ref *durableActorRefImpl[M, R]) Tell(ctx context.Context, msg M) error {
 // away. The enqueue is a database write, so the mailbox bounds the attempt
 // with its own short deadline instead of returning instantaneously; what the
 // caller is guaranteed is that it will never park waiting on a backlogged
-// consumer.
+// consumer. A durable queue has no capacity, so this never reports
+// ErrMailboxFull: a database too slow to answer inside that deadline shows up
+// as a wrapped context.DeadlineExceeded instead.
+//
+// Unlike Tell, this does not carry the caller's transaction into the enqueue.
+// The mailbox runs its bounded write on its own background context, so the
+// row commits on its own regardless of what the caller's transaction does.
+// Stripping the transaction here makes that explicit rather than leaving a
+// transaction in the envelope that the write will not honour.
 func (ref *durableActorRefImpl[M, R]) TryTell(ctx context.Context,
 	msg M) error {
 
@@ -1556,7 +1564,7 @@ func (ref *durableActorRefImpl[M, R]) TryTell(ctx context.Context,
 	env := envelope[M, R]{
 		message:   msg,
 		promise:   nil,
-		callerCtx: ctx,
+		callerCtx: WithoutTx(ctx),
 	}
 
 	if err := ref.actor.mailbox.TrySend(env); err != nil {

--- a/baselib/actor/interface.go
+++ b/baselib/actor/interface.go
@@ -145,6 +145,23 @@ type TellOnlyRef[M Message] interface {
 	// stopped, or mailbox full). For durable mailboxes, a nil error
 	// indicates the message was durably persisted.
 	Tell(ctx context.Context, msg M) error
+
+	// TryTell enqueues a message only if the target can accept it right
+	// now. It never parks the calling goroutine, which is what makes it
+	// safe to call from inside another actor's receive loop: a backed up
+	// peer can no longer freeze the sender. A mailbox at capacity returns
+	// ErrMailboxFull, leaving the message in the caller's hands to drop,
+	// stash, or reschedule for a later retry.
+	//
+	// The context is consulted only for an immediate cancellation check.
+	// TryTell never waits on it, so attaching a deadline buys nothing.
+	// Every other failure matches Tell: ErrActorTerminated once the
+	// target has stopped, ErrMailboxClosed once its mailbox is closed.
+	//
+	// A durable mailbox enqueues through a database write, so its
+	// "immediate" attempt is bounded by a short internal deadline rather
+	// than being strictly instantaneous.
+	TryTell(ctx context.Context, msg M) error
 }
 
 // ActorRef is a reference to an actor that supports both "tell" and "ask"

--- a/baselib/actor/interface.go
+++ b/baselib/actor/interface.go
@@ -158,9 +158,40 @@ type TellOnlyRef[M Message] interface {
 	// Every other failure matches Tell: ErrActorTerminated once the
 	// target has stopped, ErrMailboxClosed once its mailbox is closed.
 	//
-	// A durable mailbox enqueues through a database write, so its
-	// "immediate" attempt is bounded by a short internal deadline rather
-	// than being strictly instantaneous.
+	// Durable targets behave differently in three ways that callers must
+	// plan for.
+	//
+	// First, a durable queue has no capacity, so a durable ref never
+	// returns ErrMailboxFull. What it returns under load is the failure
+	// of a bounded database write, because the enqueue is a write that
+	// the mailbox bounds with a short internal deadline rather than
+	// completing instantaneously. That is usually a wrapped
+	// context.DeadlineExceeded, but the identity is the driver's to
+	// choose and some report a deadline as an error of their own. A
+	// caller that only retries on ErrMailboxFull therefore discards
+	// durable messages the moment the database slows down, and one that
+	// keys off the deadline instead is only slightly better off. Decide
+	// by exclusion: retry on anything that is not ErrActorTerminated or
+	// ErrMailboxClosed.
+	//
+	// Second, a durable TryTell drops the caller's database transaction:
+	// the mailbox performs its bounded write on its own background
+	// context, so the row is committed independently. Tell, by contrast,
+	// carries the caller's transaction into the enqueue so the message
+	// and the caller's state change land atomically. Swapping Tell for
+	// TryTell inside a commit closure therefore breaks that atomicity
+	// silently, and the message can survive a rolled back transaction.
+	// Keep durable enqueues that must be atomic on Tell. On a
+	// single-writer store such as SQLite the swap does not even buy a
+	// working send: the independent write waits on the writer the caller
+	// is still holding, so every attempt burns its whole deadline and
+	// fails.
+	//
+	// Third, retrying a failed durable TryTell is at-least-once. A write
+	// that misses the mailbox's deadline may still commit, and the retry
+	// enqueues under a fresh message ID, so nothing deduplicates the two
+	// rows and the consumer sees the message twice. Anything retried
+	// into a durable target has to be idempotent.
 	TryTell(ctx context.Context, msg M) error
 }
 

--- a/baselib/actor/map_input_ref.go
+++ b/baselib/actor/map_input_ref.go
@@ -43,6 +43,15 @@ func (m *MapInputRef[In, Out]) Tell(ctx context.Context, msg In) error {
 	return m.targetRef.Tell(ctx, transformed)
 }
 
+// TryTell transforms the incoming message using mapFn and hands it to the
+// target's non-blocking send, so a wrapped ref stays as backpressure-friendly
+// as the ref it wraps.
+func (m *MapInputRef[In, Out]) TryTell(ctx context.Context, msg In) error {
+	transformed := m.mapFn(msg)
+
+	return m.targetRef.TryTell(ctx, transformed)
+}
+
 // ID returns a composite identifier incorporating the target's ID.
 func (m *MapInputRef[In, Out]) ID() string {
 	return fmt.Sprintf("map-input->%s", m.targetRef.ID())
@@ -96,6 +105,21 @@ func (m *FilterMapInputRef[In, Out]) Tell(ctx context.Context, msg In) error {
 	}
 
 	return m.targetRef.Tell(ctx, transformed)
+}
+
+// TryTell transforms the incoming message using mapFn and hands it to the
+// target's non-blocking send. A message the transform drops reports success,
+// mirroring Tell: a dropped event is a normal outcome here, not a failure the
+// caller should retry.
+func (m *FilterMapInputRef[In, Out]) TryTell(ctx context.Context,
+	msg In) error {
+
+	transformed, ok := m.mapFn(msg)
+	if !ok {
+		return nil
+	}
+
+	return m.targetRef.TryTell(ctx, transformed)
 }
 
 // ID returns a composite identifier incorporating the target's ID.

--- a/baselib/actor/map_ref.go
+++ b/baselib/actor/map_ref.go
@@ -79,6 +79,20 @@ func (m *MapRef[In, Out, InR, OutR]) Tell(ctx context.Context, msg In) error {
 	return m.targetRef.Tell(ctx, transformed)
 }
 
+// TryTell transforms the incoming message using mapInput and hands it to the
+// target's non-blocking send. A transform failure is reported before the
+// target is touched at all.
+func (m *MapRef[In, Out, InR, OutR]) TryTell(ctx context.Context,
+	msg In) error {
+
+	transformed, err := m.mapInput(msg)
+	if err != nil {
+		return fmt.Errorf("map input: %w", err)
+	}
+
+	return m.targetRef.TryTell(ctx, transformed)
+}
+
 // Ask transforms the incoming message using mapInput, forwards it to the
 // target reference, and transforms the response using mapOutput.
 func (m *MapRef[In, Out, InR, OutR]) Ask(

--- a/baselib/actor/outbox_publisher_test.go
+++ b/baselib/actor/outbox_publisher_test.go
@@ -134,6 +134,12 @@ func (r *mockActorRef) Tell(ctx context.Context, msg Message) error {
 	return r.system.tellError
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (r *mockActorRef) TryTell(ctx context.Context, msg Message) error {
+	return r.Tell(ctx, msg)
+}
+
 func (r *mockActorRef) Ask(ctx context.Context, msg Message) Future[any] {
 	promise := NewPromise[any]()
 	promise.Complete(fn.Err[any](errors.New("Ask not supported in mock")))

--- a/baselib/actor/router.go
+++ b/baselib/actor/router.go
@@ -117,6 +117,25 @@ func (r *Router[M, R]) Tell(ctx context.Context, msg M) error {
 	return selectedActor.Tell(ctx, msg)
 }
 
+// TryTell selects an actor with the routing strategy and attempts a
+// non-blocking send to it. Note that the strategy still consumes its turn even
+// when the selected actor's mailbox is full, so a caller retrying a full send
+// may well land on a different actor.
+func (r *Router[M, R]) TryTell(ctx context.Context, msg M) error {
+	selectedActor, err := r.getActor()
+	if err != nil {
+		// If no actors are available for the service, and a DLO is
+		// configured, forward the message there.
+		if errors.Is(err, ErrNoActorsAvailable) && r.dlo != nil {
+			_ = r.dlo.TryTell(context.Background(), msg)
+		}
+
+		return err
+	}
+
+	return selectedActor.TryTell(ctx, msg)
+}
+
 // Ask sends a message to one of the actors managed by the router, selected by
 // the routing strategy, and returns a Future for the response. If no actors are
 // available (ErrNoActorsAvailable), the Future will be completed with this

--- a/baselib/actor/tell_only_ref_test_helper.go
+++ b/baselib/actor/tell_only_ref_test_helper.go
@@ -36,6 +36,23 @@ func (c *ChannelTellOnlyRef[M]) Tell(ctx context.Context, msg M) error {
 	}
 }
 
+// TryTell sends the message to the internal channel only if it has room,
+// returning ErrMailboxFull otherwise. Tests use this to model a wedged
+// recipient without any timing dependency.
+func (c *ChannelTellOnlyRef[M]) TryTell(ctx context.Context, msg M) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	select {
+	case c.msgs <- msg:
+		return nil
+
+	default:
+		return ErrMailboxFull
+	}
+}
+
 // ID returns the reference ID.
 func (c *ChannelTellOnlyRef[M]) ID() string {
 	return c.id

--- a/baselib/actor/try_tell_test.go
+++ b/baselib/actor/try_tell_test.go
@@ -2,10 +2,12 @@ package actor
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -229,4 +231,217 @@ func TestTryTellThroughMapInputRef(t *testing.T) {
 
 	err := wrapped.TryTell(t.Context(), newTestMsg("overflow"))
 	require.ErrorIs(t, err, ErrMailboxFull)
+}
+
+// TestTryTellThroughFilterMapInputRef verifies the filtering wrapper reports
+// a dropped message as success (there is nothing to retry) while still
+// surfacing the target's backpressure for messages it does forward.
+func TestTryTellThroughFilterMapInputRef(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	a, _ := wedgedActor(t, h)
+
+	wrapped := NewFilterMapInputRef(
+		a.Ref(), func(msg *testMsg) (*testMsg, bool) {
+			return msg, msg.data != "dropped"
+		},
+	)
+
+	// A message the transform drops never reaches the full mailbox.
+	require.NoError(t, wrapped.TryTell(t.Context(), newTestMsg("dropped")))
+
+	// One it forwards reports the target's answer unchanged.
+	err := wrapped.TryTell(t.Context(), newTestMsg("forwarded"))
+	require.ErrorIs(t, err, ErrMailboxFull)
+}
+
+// TestTryTellThroughMapRef verifies the ask-capable wrapper forwards the
+// non-blocking send, and that a transform failure is reported before the
+// target is touched at all.
+func TestTryTellThroughMapRef(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	a, _ := wedgedActor(t, h)
+
+	transformErr := errors.New("bad input")
+	failing := NewMapRef(
+		a.Ref(),
+		func(msg *testMsg) (*testMsg, error) {
+			return nil, transformErr
+		},
+		func(r string) string { return r },
+	)
+
+	err := failing.TryTell(t.Context(), newTestMsg("unmapped"))
+	require.ErrorIs(t, err, transformErr)
+	require.NotErrorIs(t, err, ErrMailboxFull)
+
+	forwarding := NewMapRef(
+		a.Ref(),
+		func(msg *testMsg) (*testMsg, error) { return msg, nil },
+		func(r string) string { return r },
+	)
+
+	err = forwarding.TryTell(t.Context(), newTestMsg("forwarded"))
+	require.ErrorIs(t, err, ErrMailboxFull)
+}
+
+// TestTryTellThroughRouter verifies the router reports the selected actor's
+// backpressure, and reports its own inability to select one when the service
+// key has no registrations. The latter is transient by design, so callers
+// must not read it as a permanent failure.
+func TestTryTellThroughRouter(t *testing.T) {
+	t.Parallel()
+
+	h := newRouterTestHarness(t)
+	key := NewServiceKey[*testMsg, string]("try-tell-router")
+
+	router := NewRouter(
+		h.receptionist, key, NewRoundRobinStrategy[*testMsg, string](),
+		nil,
+	)
+
+	// With nothing registered there is no actor to try.
+	err := router.TryTell(t.Context(), newTestMsg("unrouted"))
+	require.ErrorIs(t, err, ErrNoActorsAvailable)
+
+	// With a wedged actor registered, the router surfaces the mailbox
+	// answer rather than its own.
+	a, _ := wedgedActor(t, h.actorTestHarness)
+	require.NoError(
+		t,
+		RegisterWithReceptionist(
+			h.receptionist, key, a.Ref(),
+		),
+	)
+
+	err = router.TryTell(t.Context(), newTestMsg("routed"))
+	require.ErrorIs(t, err, ErrMailboxFull)
+}
+
+// slowEnqueueStore wraps a delivery store and holds every enqueue until it is
+// released, modelling a database too busy to answer promptly.
+type slowEnqueueStore struct {
+	*mockDeliveryStore
+
+	release chan struct{}
+}
+
+// newSlowEnqueueStore returns a store whose enqueues park until released.
+func newSlowEnqueueStore() *slowEnqueueStore {
+	return &slowEnqueueStore{
+		mockDeliveryStore: newMockDeliveryStore(),
+		release:           make(chan struct{}),
+	}
+}
+
+// EnqueueMessage waits for the test to release it, for the caller's context
+// to expire, whichever comes first.
+func (s *slowEnqueueStore) EnqueueMessage(ctx context.Context,
+	params EnqueueParams) error {
+
+	select {
+	case <-s.release:
+		return s.mockDeliveryStore.EnqueueMessage(ctx, params)
+
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// TestDurableTryTellPersists verifies the success path of the durable
+// implementation: the message is written to the store, just as Tell writes it.
+func TestDurableTryTellPersists(t *testing.T) {
+	t.Parallel()
+
+	store := newMockDeliveryStore()
+	cfg := DefaultDurableActorConfig(
+		"durable-try-tell",
+		newMockBehavior(
+			fn.Ok(42),
+		),
+		store,
+		newActorTestCodec(),
+	)
+	a := NewDurableActor(cfg).UnwrapOrFail(t)
+
+	msg := &actorTestMsg{
+		Value:   tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(7)),
+		Payload: tlv.NewPrimitiveRecord[tlv.TlvType2]([]byte("try")),
+	}
+	require.NoError(t, a.Ref().TryTell(t.Context(), msg))
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Len(t, store.messages, 1)
+}
+
+// TestDurableTryTellSlowWriteIsNotMailboxFull pins the semantics that make
+// the durable implementation the odd one out. Its queue has no capacity, so
+// it never reports a full mailbox; a database that cannot answer inside the
+// mailbox's internal deadline shows up as a deadline instead. A caller that
+// only retries ErrMailboxFull silently discards durable messages exactly when
+// the database is struggling, which is when losing them hurts most.
+func TestDurableTryTellSlowWriteIsNotMailboxFull(t *testing.T) {
+	t.Parallel()
+
+	store := newSlowEnqueueStore()
+	defer close(store.release)
+
+	cfg := DefaultDurableActorConfig(
+		"durable-slow-write",
+		newMockBehavior(
+			fn.Ok(42),
+		),
+		store,
+		newActorTestCodec(),
+	)
+	a := NewDurableActor(cfg).UnwrapOrFail(t)
+
+	msg := &actorTestMsg{
+		Value:   tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(9)),
+		Payload: tlv.NewPrimitiveRecord[tlv.TlvType2]([]byte("slow")),
+	}
+
+	err := a.Ref().TryTell(t.Context(), msg)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NotErrorIs(t, err, ErrMailboxFull)
+
+	// The caller's own context is untouched: the deadline that expired
+	// belongs to the mailbox, not to them.
+	require.NoError(t, t.Context().Err())
+}
+
+// TestDurableTryTellTerminatedActor verifies the durable ref still reports
+// the terminal error that tells a caller to stop retrying.
+func TestDurableTryTellTerminatedActor(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultDurableActorConfig(
+		"durable-terminated",
+		newMockBehavior(
+			fn.Ok(42),
+		),
+		newMockDeliveryStore(),
+		newActorTestCodec(),
+	)
+	a := NewDurableActor(cfg).UnwrapOrFail(t)
+
+	a.Start()
+	a.Stop()
+
+	msg := &actorTestMsg{
+		Value:   tlv.NewPrimitiveRecord[tlv.TlvType1](uint64(11)),
+		Payload: tlv.NewPrimitiveRecord[tlv.TlvType2]([]byte("dead")),
+	}
+
+	require.Eventually(t, func() bool {
+		return errors.Is(
+			a.Ref().TryTell(t.Context(), msg),
+			ErrActorTerminated,
+		)
+	}, time.Second, 10*time.Millisecond)
 }

--- a/baselib/actor/try_tell_test.go
+++ b/baselib/actor/try_tell_test.go
@@ -1,0 +1,232 @@
+package actor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// wedgeBehavior parks inside Receive until it is released, which lets a test
+// hold an actor's only processing goroutine hostage and fill its mailbox.
+type wedgeBehavior struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+// newWedgeBehavior creates a behavior that signals on started when its first
+// message lands and stays inside Receive until release is closed.
+func newWedgeBehavior() *wedgeBehavior {
+	return &wedgeBehavior{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+}
+
+// Receive signals that processing began and blocks until the test releases it
+// or the actor shuts down.
+func (b *wedgeBehavior) Receive(actorCtx context.Context,
+	_ *testMsg) fn.Result[string] {
+
+	select {
+	case b.started <- struct{}{}:
+	default:
+	}
+
+	select {
+	case <-b.release:
+	case <-actorCtx.Done():
+	}
+
+	return fn.Ok("wedged")
+}
+
+// wedgedActor returns a started actor whose behavior is parked inside Receive
+// with its mailbox filled to capacity, so the next send has nowhere to go.
+func wedgedActor(t *testing.T, h *actorTestHarness) (*Actor[*testMsg, string],
+	*wedgeBehavior) {
+
+	t.Helper()
+
+	beh := newWedgeBehavior()
+	a := h.newActor("wedged-"+t.Name(), beh, 1)
+	ref := a.Ref()
+
+	// The first message is pulled off the channel and parks the process
+	// loop, which frees the single buffer slot again.
+	require.NoError(t, ref.Tell(t.Context(), newTestMsg("park")))
+	select {
+	case <-beh.started:
+	case <-time.After(time.Second):
+		t.Fatal("behavior never started processing")
+	}
+
+	// This second message occupies the buffer. Nothing will drain it while
+	// the behavior stays parked.
+	require.NoError(t, ref.Tell(t.Context(), newTestMsg("fill")))
+
+	t.Cleanup(func() {
+		close(beh.release)
+	})
+
+	return a, beh
+}
+
+// TestTryTellFullMailboxFailsFast verifies that a send into a mailbox at
+// capacity reports ErrMailboxFull immediately instead of parking the caller,
+// which is the whole point of the method: a receive goroutine may call it
+// without risking a deadlock against a wedged peer.
+func TestTryTellFullMailboxFailsFast(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	a, _ := wedgedActor(t, h)
+
+	start := time.Now()
+	err := a.Ref().TryTell(t.Context(), newTestMsg("overflow"))
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, ErrMailboxFull)
+
+	// The bound is deliberately far looser than anything TryTell should
+	// need, because a loaded CI box can deschedule us mid-call and a
+	// tight bound would flake on that rather than on the behavior. It
+	// still catches the regression this method exists to prevent: a
+	// blocking send here would never return at all, since nothing drains
+	// the mailbox until the test ends.
+	require.Less(t, elapsed, time.Second)
+}
+
+// TestTryTellDoesNotBurnCallerDeadline contrasts the two sends against the
+// same wedged actor. Tell spends the caller's entire deadline waiting for
+// room; TryTell gives the message straight back. This is the difference that
+// let a full peer mailbox stall a sender's receive goroutine.
+func TestTryTellDoesNotBurnCallerDeadline(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	a, _ := wedgedActor(t, h)
+
+	const deadline = 200 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(t.Context(), deadline)
+	defer cancel()
+
+	start := time.Now()
+	err := a.Ref().Tell(ctx, newTestMsg("blocking"))
+	blockingElapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.GreaterOrEqual(t, blockingElapsed, deadline)
+
+	start = time.Now()
+	err = a.Ref().TryTell(t.Context(), newTestMsg("non-blocking"))
+	tryElapsed := time.Since(start)
+
+	require.ErrorIs(t, err, ErrMailboxFull)
+	require.Less(t, tryElapsed, blockingElapsed)
+}
+
+// TestTryTellDelivers verifies the success path: a mailbox with room accepts
+// the message and the behavior processes it.
+func TestTryTellDelivers(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	beh := newEchoBehavior(t, 0)
+	a := h.newActor("try-tell-delivers", beh, 4)
+
+	replies := make(chan string, 1)
+	msg := newTestMsgWithReply("payload", replies)
+
+	require.NoError(t, a.Ref().TryTell(t.Context(), msg))
+
+	select {
+	case got := <-replies:
+		require.Equal(t, "payload", got)
+
+	case <-time.After(time.Second):
+		t.Fatal("message was never processed")
+	}
+}
+
+// TestTryTellTerminatedActor verifies a stopped actor reports
+// ErrActorTerminated and that the undeliverable message still reaches the dead
+// letter office, matching what Tell does on the same path.
+func TestTryTellTerminatedActor(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	beh := newEchoBehavior(t, 0)
+	a := h.newActor("try-tell-terminated", beh, 4)
+
+	a.Stop()
+
+	// Stop only cancels the actor's context; wait until the mailbox
+	// actually rejects sends before asserting on the error.
+	msg := newTestMsg("after-stop")
+	require.Eventually(t, func() bool {
+		return a.Ref().TryTell(t.Context(), msg) != nil
+	}, time.Second, 10*time.Millisecond)
+
+	require.ErrorIs(
+		t,
+		a.Ref().TryTell(t.Context(), msg),
+		ErrActorTerminated,
+	)
+	h.assertDLOMessage(msg)
+}
+
+// TestTryTellClosedMailbox verifies a closed mailbox reports ErrMailboxClosed
+// rather than the full or terminated sentinels, so callers can tell a
+// transient backlog apart from a permanently gone recipient.
+func TestTryTellClosedMailbox(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	beh := newEchoBehavior(t, 0)
+	a := h.newActor("try-tell-closed", beh, 4)
+
+	a.mailbox.Close()
+
+	err := a.Ref().TryTell(t.Context(), newTestMsg("after-close"))
+	require.ErrorIs(t, err, ErrMailboxClosed)
+}
+
+// TestTryTellCancelledCaller verifies the context is honoured as an immediate
+// cancellation check: a caller that already gave up does not get its message
+// enqueued.
+func TestTryTellCancelledCaller(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	beh := newEchoBehavior(t, 0)
+	a := h.newActor("try-tell-cancelled", beh, 4)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := a.Ref().TryTell(ctx, newTestMsg("cancelled"))
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestTryTellThroughMapInputRef verifies a wrapped ref stays as
+// backpressure-friendly as the ref it wraps: the full-mailbox sentinel
+// survives the transform instead of being swallowed or turned into a block.
+func TestTryTellThroughMapInputRef(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	a, _ := wedgedActor(t, h)
+
+	wrapped := NewMapInputRef(
+		a.Ref(), func(msg *testMsg) *testMsg {
+			return msg
+		},
+	)
+
+	err := wrapped.TryTell(t.Context(), newTestMsg("overflow"))
+	require.ErrorIs(t, err, ErrMailboxFull)
+}

--- a/fraud/actor_test.go
+++ b/fraud/actor_test.go
@@ -42,6 +42,14 @@ func (f *fakeChainSourceRef) Tell(context.Context,
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (f *fakeChainSourceRef) TryTell(ctx context.Context,
+	msg chainsource.ChainSourceMsg) error {
+
+	return f.Tell(ctx, msg)
+}
+
 // Ask records spend registration requests.
 func (f *fakeChainSourceRef) Ask(_ context.Context,
 	msg chainsource.ChainSourceMsg,
@@ -142,6 +150,14 @@ func (f *fakeManagerRef) ID() string {
 // Tell is unused by these tests.
 func (f *fakeManagerRef) Tell(context.Context, vtxo.ManagerMsg) error {
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (f *fakeManagerRef) TryTell(ctx context.Context,
+	msg vtxo.ManagerMsg) error {
+
+	return f.Tell(ctx, msg)
 }
 
 // Ask records force-unroll requests.

--- a/oor/registry_test.go
+++ b/oor/registry_test.go
@@ -45,6 +45,14 @@ func (r *recordingTellRef) Tell(_ context.Context, msg OORDurableMsg) error {
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (r *recordingTellRef) TryTell(ctx context.Context,
+	msg OORDurableMsg) error {
+
+	return r.Tell(ctx, msg)
+}
+
 // recordingActorRef extends recordingTellRef with an Ask that completes from
 // the recorder's configured admission result, modeling a child's first turn.
 type recordingActorRef struct {

--- a/oor/session_actor_flow_test.go
+++ b/oor/session_actor_flow_test.go
@@ -106,6 +106,14 @@ func (r *recordingManagerRef) Tell(_ context.Context,
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (r *recordingManagerRef) TryTell(ctx context.Context,
+	msg vtxo.ManagerMsg) error {
+
+	return r.Tell(ctx, msg)
+}
+
 func (r *recordingManagerRef) recorded() []vtxo.ManagerMsg {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/oor/session_actor_test.go
+++ b/oor/session_actor_test.go
@@ -1163,6 +1163,14 @@ func (fakeServerConnRef) Tell(context.Context, serverconn.ServerConnMsg) error {
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (r fakeServerConnRef) TryTell(ctx context.Context,
+	msg serverconn.ServerConnMsg) error {
+
+	return r.Tell(ctx, msg)
+}
+
 // recordingServerConnRef captures every transport Tell so a test can assert
 // the turn delivered (or withheld) its transport into the serverconn durable
 // actor.
@@ -1183,6 +1191,14 @@ func (r *recordingServerConnRef) Tell(_ context.Context,
 	r.msgs = append(r.msgs, msg)
 
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (r *recordingServerConnRef) TryTell(ctx context.Context,
+	msg serverconn.ServerConnMsg) error {
+
+	return r.Tell(ctx, msg)
 }
 
 func (r *recordingServerConnRef) recorded() []serverconn.ServerConnMsg {
@@ -1206,6 +1222,14 @@ func (r failingServerConnRef) Tell(context.Context,
 	serverconn.ServerConnMsg) error {
 
 	return r.err
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (r failingServerConnRef) TryTell(ctx context.Context,
+	msg serverconn.ServerConnMsg) error {
+
+	return r.Tell(ctx, msg)
 }
 
 // TestSessionActorTerminalCommitNotifiesRegistry verifies a turn that commits
@@ -1288,6 +1312,14 @@ func (s *recordingLedgerSink) Tell(_ context.Context,
 	s.toldInCommit = append(s.toldInCommit, *s.inCommit)
 
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (s *recordingLedgerSink) TryTell(ctx context.Context,
+	msg ledger.LedgerMsg) error {
+
+	return s.Tell(ctx, msg)
 }
 
 // commitTrackingExec flags when the commit closure is running so tests can
@@ -1483,6 +1515,14 @@ func (r *recordingTimeoutRef) Tell(_ context.Context, msg timeout.Msg) error {
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (r *recordingTimeoutRef) TryTell(ctx context.Context,
+	msg timeout.Msg) error {
+
+	return r.Tell(ctx, msg)
+}
+
 // scheduled returns a copy of the recorded timeout messages.
 func (r *recordingTimeoutRef) scheduled() []timeout.Msg {
 	r.mu.Lock()
@@ -1500,6 +1540,14 @@ func (fakeExpiredRef) ID() string {
 
 func (fakeExpiredRef) Tell(context.Context, *timeout.ExpiredMsg) error {
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (r fakeExpiredRef) TryTell(ctx context.Context,
+	msg *timeout.ExpiredMsg) error {
+
+	return r.Tell(ctx, msg)
 }
 
 // TestSessionActorResumeMetadataBackoff verifies resuming an incoming session

--- a/round/actor.go
+++ b/round/actor.go
@@ -841,12 +841,10 @@ func (a *RoundClientActor) createRoundFSMFromDB(ctx context.Context,
 		OwnedScriptChecker:     a.cfg.OwnedScriptChecker,
 	}
 	fsmCfg := ClientStateMachineCfg{
-		Logger: fsmLogger,
-		ErrorReporter: newContextErrorReporter(
-			a.lifecycleCtx(ctx), fsmPrefix,
-		),
-		InitialState: state,
-		Env:          env,
+		Logger:        fsmLogger,
+		ErrorReporter: newLoggerErrorReporter(fsmLogger),
+		InitialState:  state,
+		Env:           env,
 	}
 	fsm := protofsm.NewStateMachine(fsmCfg)
 	a.startRoundFSM(ctx, &fsm)
@@ -915,12 +913,10 @@ func (a *RoundClientActor) createNewRound(ctx context.Context) (*RoundFSM,
 		OwnedScriptChecker:     a.cfg.OwnedScriptChecker,
 	}
 	fsmCfg := ClientStateMachineCfg{
-		Logger: fsmLogger,
-		ErrorReporter: newContextErrorReporter(
-			a.lifecycleCtx(ctx), fsmPrefix,
-		),
-		InitialState: &Idle{},
-		Env:          env,
+		Logger:        fsmLogger,
+		ErrorReporter: newLoggerErrorReporter(fsmLogger),
+		InitialState:  &Idle{},
+		Env:           env,
 	}
 	fsm := protofsm.NewStateMachine(fsmCfg)
 	a.startRoundFSM(ctx, &fsm)

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -1014,11 +1014,10 @@ func (h *actorTestHarness) setupRoundInInputSigSentState(
 	}
 
 	// Create a new FSM starting in InputSigSentState.
-	errReporter := newContextErrorReporter(
-		h.ctx, roundID.LogPrefix(),
-	)
+	fsmLogger := h.actor.log.WithPrefix(roundID.LogPrefix())
+	errReporter := newLoggerErrorReporter(fsmLogger)
 	fsmCfg := ClientStateMachineCfg{
-		Logger:        h.actor.log.WithPrefix(roundID.LogPrefix()),
+		Logger:        fsmLogger,
 		ErrorReporter: errReporter,
 		InitialState:  initialState,
 		Env:           h.actor.env,
@@ -1086,11 +1085,10 @@ func (h *actorTestHarness) setupRoundInForfeitCollectingState(roundID RoundID) {
 		),
 	}
 
-	errReporter := newContextErrorReporter(
-		h.ctx, roundID.LogPrefix(),
-	)
+	fsmLogger := h.actor.log.WithPrefix(roundID.LogPrefix())
+	errReporter := newLoggerErrorReporter(fsmLogger)
 	fsmCfg := ClientStateMachineCfg{
-		Logger:        h.actor.log.WithPrefix(roundID.LogPrefix()),
+		Logger:        fsmLogger,
 		ErrorReporter: errReporter,
 		InitialState:  initialState,
 		Env:           h.actor.env,
@@ -1120,11 +1118,10 @@ func (h *actorTestHarness) setupRoundInIntentSentState() TempRoundKey {
 		Intents: Intents{},
 	}
 
-	errReporter := newContextErrorReporter(
-		h.ctx, tempKey.LogPrefix(),
-	)
+	fsmLogger := h.actor.log.WithPrefix(tempKey.LogPrefix())
+	errReporter := newLoggerErrorReporter(fsmLogger)
 	fsmCfg := ClientStateMachineCfg{
-		Logger:        h.actor.log.WithPrefix(tempKey.LogPrefix()),
+		Logger:        fsmLogger,
 		ErrorReporter: errReporter,
 		InitialState:  initialState,
 		Env:           h.actor.env,
@@ -1152,11 +1149,10 @@ func (h *actorTestHarness) injectRoundInState(roundID RoundID,
 
 	h.t.Helper()
 
-	errReporter := newContextErrorReporter(
-		h.ctx, roundID.LogPrefix(),
-	)
+	fsmLogger := h.actor.log.WithPrefix(roundID.LogPrefix())
+	errReporter := newLoggerErrorReporter(fsmLogger)
 	fsmCfg := ClientStateMachineCfg{
-		Logger:        h.actor.log.WithPrefix(roundID.LogPrefix()),
+		Logger:        fsmLogger,
 		ErrorReporter: errReporter,
 		InitialState:  initialState,
 		Env:           h.actor.env,

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -79,6 +79,14 @@ func (m *mockServerConnRef) Tell(
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (m *mockServerConnRef) TryTell(ctx context.Context,
+	msg serverconn.ServerConnMsg) error {
+
+	return m.Tell(ctx, msg)
+}
+
 func (m *mockServerConnRef) clearMessages() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -157,6 +165,14 @@ func (m *mockChainSourceRef) Tell(
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (m *mockChainSourceRef) TryTell(ctx context.Context,
+	msg chainsource.ChainSourceMsg) error {
+
+	return m.Tell(ctx, msg)
+}
+
 // Ask implements actor.ActorRef for the mock. It returns a BestHeightResponse
 // for height queries.
 func (m *mockChainSourceRef) Ask(
@@ -221,6 +237,14 @@ func (m *mockWalletActorRef) Tell(_ context.Context,
 	_ = msg
 
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (m *mockWalletActorRef) TryTell(ctx context.Context,
+	msg wallet.WalletMsg) error {
+
+	return m.Tell(ctx, msg)
 }
 
 func (m *mockWalletActorRef) Ask(_ context.Context,
@@ -323,6 +347,14 @@ func (m *mockSelfRef) Tell(
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (m *mockSelfRef) TryTell(ctx context.Context,
+	msg actormsg.RoundReceivable) error {
+
+	return m.Tell(ctx, msg)
+}
+
 // waitForMessage blocks until a message arrives or the timeout expires,
 // enabling synchronous test assertions on asynchronous actor messages.
 func (m *mockSelfRef) waitForMessage(timeout time.Duration) (
@@ -386,6 +418,12 @@ func (m *mockTimeoutActor) Tell(_ context.Context, msg timeout.Msg) error {
 	}
 
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (m *mockTimeoutActor) TryTell(ctx context.Context, msg timeout.Msg) error {
+	return m.Tell(ctx, msg)
 }
 
 // assertTimeoutScheduled verifies a timeout was scheduled.
@@ -457,6 +495,14 @@ func (m *mockVTXOManagerRef) Tell(_ context.Context, msg VTXOManagerMsg) error {
 	m.messages = append(m.messages, msg)
 
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (m *mockVTXOManagerRef) TryTell(ctx context.Context,
+	msg VTXOManagerMsg) error {
+
+	return m.Tell(ctx, msg)
 }
 
 // assertVTXOCreatedReceived verifies a VTXOCreatedNotification was received.

--- a/round/actor_test.go
+++ b/round/actor_test.go
@@ -72,7 +72,7 @@ func TestRoundFSMOutlivesCreationRequest(t *testing.T) {
 	state := &lifecycleProbeState{ctxErr: make(chan error, 1)}
 	fsm := protofsm.NewStateMachine(ClientStateMachineCfg{
 		Logger:        btclog.Disabled,
-		ErrorReporter: newContextErrorReporter(t.Context(), "probe"),
+		ErrorReporter: newLoggerErrorReporter(btclog.Disabled),
 		InitialState:  state,
 		Env:           &ClientEnvironment{},
 	})

--- a/round/log.go
+++ b/round/log.go
@@ -3,40 +3,38 @@ package round
 import (
 	"context"
 
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/baselib/protofsm"
-	"github.com/lightninglabs/wavelength/build"
 )
 
 // Subsystem defines the logging code for this subsystem.
 const Subsystem = "ROND"
 
-// contextErrorReporter implements protofsm.ErrorReporter by logging errors
-// using a logger from the context with a specific prefix.
+// loggerErrorReporter implements protofsm.ErrorReporter by logging errors to
+// the logger it was handed at construction.
 //
-// The context is stored in the struct because
-// protofsm.ErrorReporter.ReportError does not accept a context parameter. The
-// stored context is only used for extracting the logger, not for cancellation
-// or deadlines.
-//
-//nolint:containedctx
-type contextErrorReporter struct {
-	ctx    context.Context
-	prefix string
+// The logger is held rather than resolved from a context because the context
+// an FSM runs under is the round actor's lifecycle context, which descends
+// from context.Background() and so carries no logger at all. Resolving from
+// it sent every FSM error to btclog.Disabled: the code looked observable and
+// was not.
+type loggerErrorReporter struct {
+	log btclog.Logger
 }
 
-// newContextErrorReporter creates an error reporter that logs using the logger
-// from the given context with the specified prefix.
-func newContextErrorReporter(ctx context.Context,
-	prefix string) *contextErrorReporter {
-
-	return &contextErrorReporter{ctx: ctx, prefix: prefix}
+// newLoggerErrorReporter creates an error reporter that logs to the given
+// logger. Callers pass the same prefixed logger they give the FSM itself, so
+// an FSM error lands beside the transitions that led to it.
+func newLoggerErrorReporter(log btclog.Logger) *loggerErrorReporter {
+	return &loggerErrorReporter{log: log}
 }
 
-// ReportError logs the error using the context logger with structured logging.
-func (r *contextErrorReporter) ReportError(err error) {
-	logger := build.LoggerFromContext(r.ctx).WithPrefix(r.prefix)
-	logger.ErrorS(r.ctx, "FSM error", err)
+// ReportError logs the error using structured logging.
+func (r *loggerErrorReporter) ReportError(err error) {
+	// ReportError takes no context, and the FSM's own context carries
+	// nothing worth propagating here, so the log call gets a bare one.
+	r.log.ErrorS(context.Background(), "FSM error", err)
 }
 
-// Compile-time check that contextErrorReporter implements ErrorReporter.
-var _ protofsm.ErrorReporter = (*contextErrorReporter)(nil)
+// Compile-time check that loggerErrorReporter implements ErrorReporter.
+var _ protofsm.ErrorReporter = (*loggerErrorReporter)(nil)

--- a/round/log_test.go
+++ b/round/log_test.go
@@ -1,0 +1,39 @@
+package round
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestErrorReporterLogsThroughInjectedLogger is the regression test for FSM
+// errors being invisible in a running daemon. The reporter used to resolve its
+// logger from a stored context, and the context a round FSM runs under is the
+// actor's lifecycle context, which descends from context.Background() and
+// carries no logger at all. Every "FSM error" therefore went to
+// btclog.Disabled. Reporting now writes to the logger the reporter was built
+// with, so this test fails the moment that goes back to a context lookup.
+func TestErrorReporterLogsThroughInjectedLogger(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	handler := btclog.NewDefaultHandler(&buf, btclog.WithNoTimestamp())
+	handler.SetLevel(btclog.LevelError)
+
+	log := btclog.NewSLogger(handler).WithPrefix("(round=deadbeef)")
+
+	reporter := newLoggerErrorReporter(log)
+	reporter.ReportError(errors.New("tree signature mismatch"))
+
+	logged := buf.String()
+	require.Contains(t, logged, "FSM error")
+	require.Contains(t, logged, "tree signature mismatch")
+
+	// The prefix the caller baked into the logger has to survive, since
+	// that is what ties an FSM error to the round that produced it.
+	require.Contains(t, logged, "(round=deadbeef)")
+}

--- a/serverconn/event_router_test.go
+++ b/serverconn/event_router_test.go
@@ -232,6 +232,12 @@ func (r *stoppedRef) Tell(context.Context, *helloStartedMsg) error {
 	return r.tellErr
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (r *stoppedRef) TryTell(ctx context.Context, msg *helloStartedMsg) error {
+	return r.Tell(ctx, msg)
+}
+
 func (r *stoppedRef) Ask(context.Context,
 	*helloStartedMsg) actor.Future[struct{}] {
 

--- a/swapwallet/credit_fake_test.go
+++ b/swapwallet/credit_fake_test.go
@@ -39,6 +39,14 @@ func (f *fakeCreditRegistry) Tell(context.Context, credit.CreditMsg) error {
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (f *fakeCreditRegistry) TryTell(ctx context.Context,
+	msg credit.CreditMsg) error {
+
+	return f.Tell(ctx, msg)
+}
+
 // Ask records pay admissions and resolves with the configured response.
 func (f *fakeCreditRegistry) Ask(_ context.Context,
 	msg credit.CreditMsg) actor.Future[credit.CreditResp] {

--- a/systest/txconfirm_reorg_test.go
+++ b/systest/txconfirm_reorg_test.go
@@ -53,6 +53,14 @@ func (r *recordingNotificationRef) Tell(_ context.Context,
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (r *recordingNotificationRef) TryTell(ctx context.Context,
+	msg txconfirm.Notification) error {
+
+	return r.Tell(ctx, msg)
+}
+
 // await pulls the next notification or fails the test on timeout.
 func (r *recordingNotificationRef) await(t *testing.T) txconfirm.Notification {
 	t.Helper()

--- a/timeout/AGENTS.md
+++ b/timeout/AGENTS.md
@@ -10,7 +10,7 @@ timeouts and recurring ticks, delivering `ExpiredMsg` /
 
 - `Actor` — Holds `oneshots`/`recurring` entry maps; all state mutation
   happens single-threadedly inside `Receive`. Clock callbacks never
-  touch actor state directly — they self-Tell an internal fire message
+  touch actor state directly — they self-signal an internal fire message
   (`internalTimerFired`/`internalTickFired`) carrying a generation
   token, so stale fires racing a Cancel/reschedule are dropped.
 - `Clock` — Interface (`Now`, `AfterFunc`) abstracting the time source;
@@ -43,6 +43,18 @@ timeouts and recurring ticks, delivering `ExpiredMsg` /
   re-arming loop would starve the mailbox).
 - Recurring ticks are "fixed-delay" (next fire = handler-finish +
   interval), not `time.Ticker`'s fixed-rate-with-drops.
+- **The receive goroutine never blocks on a callback.** This actor is a
+  process-wide singleton, so one backlogged requester parking it would
+  freeze every timer in the daemon. Delivery uses `TryTell`; a full
+  mailbox keeps the entry (the only copy of the reminder) and re-arms
+  the same fire on a backoff doubling from 1s to 30s. Callers must
+  therefore tolerate a late, possibly reordered callback. A callback
+  that is terminated or closed gets no retry chain and its entry is
+  released.
+- **Clock goroutines never block on the actor's own mailbox.** A fire
+  that finds no room re-arms itself after `selfSignalRetry` instead of
+  parking, so at most one fire is outstanding per entry no matter how
+  far behind the actor runs.
 - Callers must call `Start(ref)` with the actor's own registered ref
   before any request is delivered; calling `Receive` directly without
   a mailbox in front breaks the self-tell model.

--- a/timeout/AGENTS.md
+++ b/timeout/AGENTS.md
@@ -10,9 +10,12 @@ timeouts and recurring ticks, delivering `ExpiredMsg` /
 
 - `Actor` — Holds `oneshots`/`recurring` entry maps; all state mutation
   happens single-threadedly inside `Receive`. Clock callbacks never
-  touch actor state directly — they self-signal an internal fire message
+  touch actor state directly. They self-signal an internal fire message
   (`internalTimerFired`/`internalTickFired`) carrying a generation
   token, so stale fires racing a Cancel/reschedule are dropped.
+- `Config` / `NewActorWithConfig` — Optional clock and logger. Daemons
+  use this constructor; `NewActor` and `NewActorWithClock` are the
+  logger-less shorthands for tests.
 - `Clock` — Interface (`Now`, `AfterFunc`) abstracting the time source;
   `RealClock` is the production impl, tests inject a fake via
   `NewActorWithClock`.
@@ -45,19 +48,60 @@ timeouts and recurring ticks, delivering `ExpiredMsg` /
   interval), not `time.Ticker`'s fixed-rate-with-drops.
 - **The receive goroutine never blocks on a callback.** This actor is a
   process-wide singleton, so one backlogged requester parking it would
-  freeze every timer in the daemon. Delivery uses `TryTell`; a full
-  mailbox keeps the entry (the only copy of the reminder) and re-arms
-  the same fire on a backoff doubling from 1s to 30s. Callers must
-  therefore tolerate a late, possibly reordered callback. A callback
-  that is terminated or closed gets no retry chain and its entry is
-  released.
+  freeze every timer in the daemon. Delivery uses `TryTell`; a failed
+  delivery keeps the entry (the only copy of the reminder) and re-arms
+  the same fire on a backoff that doubles from 1s and flattens out at
+  30s. A recurring entry whose interval is shorter than that 1s base
+  starts the doubling from its own interval instead, so one hiccup does
+  not stretch a 100ms ticker to a full second. Only the starting point
+  moves: the 30s ceiling applies to recurring entries too, so a consumer
+  that stays unreachable does back off well past its own cadence. That
+  is deliberate, since every attempt against a durable callback is a
+  bounded database write, and retrying a 100ms ticker at 100ms forever
+  would hammer the store it is already struggling with. Callers must
+  therefore tolerate a late, possibly reordered callback.
+- **This invariant is load-bearing for every scheduler.** `round`
+  (`actor.go`), `oor` (`session_actor.go`) and `credit` (`op_actor.go`)
+  all issue a *blocking* `Tell` into this actor's mailbox from inside
+  their own receive loops. That is safe only because this actor's
+  `Receive` never blocks, so its mailbox always drains. Add a blocking
+  call anywhere inside `Receive` and the original incident shape is back:
+  scheduler parked on the timeout mailbox, timeout actor parked on a
+  scheduler.
+- **Only `ErrActorTerminated` and `ErrMailboxClosed` are terminal.**
+  Everything else is retried. Durable callbacks never report a full
+  mailbox; a slow database surfaces as a wrapped `DeadlineExceeded`, and
+  a `Router` target reports `ErrNoActorsAvailable` while its actor is
+  being replaced. Treating either as permanent silently discards timers
+  that nothing re-derives.
 - **Clock goroutines never block on the actor's own mailbox.** A fire
   that finds no room re-arms itself after `selfSignalRetry` instead of
   parking, so at most one fire is outstanding per entry no matter how
   far behind the actor runs.
+- **Daemons must inject a logger** via `NewActorWithConfig`. An actor's
+  lifecycle context descends from `context.Background()`, so a logger
+  resolved from the receive context alone is always `btclog.Disabled`
+  and every diagnostic this actor writes is invisible in production.
 - Callers must call `Start(ref)` with the actor's own registered ref
   before any request is delivered; calling `Receive` directly without
   a mailbox in front breaks the self-tell model.
+
+## Gotchas
+
+- **Prefer a dedicated instance over the shared singleton for durable
+  callbacks.** `waved/server.go` registers a shared `timeout` actor,
+  while OOR and credit each register their own. A durable callback's
+  delivery is a database write, so handing one to the shared instance
+  puts every other subsystem's timer behind that write's latency, and
+  behind its retry backoff when the database is slow.
+- **Recurring ticks carry the original `FiredAt` across a retry.** A
+  tick delayed by backoff reports when its timer fired, not when
+  delivery succeeded. A consumer computing `deadline = FiredAt +
+  interval` can therefore conclude the deadline already passed the
+  moment it receives a retried tick. No in-repo consumer does this
+  (wavelength has no recurring-tick caller), but lumos does use the
+  recurring scheduler, so its consumers need checking before the pin
+  bumps.
 
 ## Deep Docs
 

--- a/timeout/CLAUDE.md
+++ b/timeout/CLAUDE.md
@@ -10,7 +10,7 @@ timeouts and recurring ticks, delivering `ExpiredMsg` /
 
 - `Actor` — Holds `oneshots`/`recurring` entry maps; all state mutation
   happens single-threadedly inside `Receive`. Clock callbacks never
-  touch actor state directly — they self-Tell an internal fire message
+  touch actor state directly — they self-signal an internal fire message
   (`internalTimerFired`/`internalTickFired`) carrying a generation
   token, so stale fires racing a Cancel/reschedule are dropped.
 - `Clock` — Interface (`Now`, `AfterFunc`) abstracting the time source;
@@ -43,6 +43,18 @@ timeouts and recurring ticks, delivering `ExpiredMsg` /
   re-arming loop would starve the mailbox).
 - Recurring ticks are "fixed-delay" (next fire = handler-finish +
   interval), not `time.Ticker`'s fixed-rate-with-drops.
+- **The receive goroutine never blocks on a callback.** This actor is a
+  process-wide singleton, so one backlogged requester parking it would
+  freeze every timer in the daemon. Delivery uses `TryTell`; a full
+  mailbox keeps the entry (the only copy of the reminder) and re-arms
+  the same fire on a backoff doubling from 1s to 30s. Callers must
+  therefore tolerate a late, possibly reordered callback. A callback
+  that is terminated or closed gets no retry chain and its entry is
+  released.
+- **Clock goroutines never block on the actor's own mailbox.** A fire
+  that finds no room re-arms itself after `selfSignalRetry` instead of
+  parking, so at most one fire is outstanding per entry no matter how
+  far behind the actor runs.
 - Callers must call `Start(ref)` with the actor's own registered ref
   before any request is delivered; calling `Receive` directly without
   a mailbox in front breaks the self-tell model.

--- a/timeout/CLAUDE.md
+++ b/timeout/CLAUDE.md
@@ -10,9 +10,12 @@ timeouts and recurring ticks, delivering `ExpiredMsg` /
 
 - `Actor` — Holds `oneshots`/`recurring` entry maps; all state mutation
   happens single-threadedly inside `Receive`. Clock callbacks never
-  touch actor state directly — they self-signal an internal fire message
+  touch actor state directly. They self-signal an internal fire message
   (`internalTimerFired`/`internalTickFired`) carrying a generation
   token, so stale fires racing a Cancel/reschedule are dropped.
+- `Config` / `NewActorWithConfig` — Optional clock and logger. Daemons
+  use this constructor; `NewActor` and `NewActorWithClock` are the
+  logger-less shorthands for tests.
 - `Clock` — Interface (`Now`, `AfterFunc`) abstracting the time source;
   `RealClock` is the production impl, tests inject a fake via
   `NewActorWithClock`.
@@ -45,19 +48,60 @@ timeouts and recurring ticks, delivering `ExpiredMsg` /
   interval), not `time.Ticker`'s fixed-rate-with-drops.
 - **The receive goroutine never blocks on a callback.** This actor is a
   process-wide singleton, so one backlogged requester parking it would
-  freeze every timer in the daemon. Delivery uses `TryTell`; a full
-  mailbox keeps the entry (the only copy of the reminder) and re-arms
-  the same fire on a backoff doubling from 1s to 30s. Callers must
-  therefore tolerate a late, possibly reordered callback. A callback
-  that is terminated or closed gets no retry chain and its entry is
-  released.
+  freeze every timer in the daemon. Delivery uses `TryTell`; a failed
+  delivery keeps the entry (the only copy of the reminder) and re-arms
+  the same fire on a backoff that doubles from 1s and flattens out at
+  30s. A recurring entry whose interval is shorter than that 1s base
+  starts the doubling from its own interval instead, so one hiccup does
+  not stretch a 100ms ticker to a full second. Only the starting point
+  moves: the 30s ceiling applies to recurring entries too, so a consumer
+  that stays unreachable does back off well past its own cadence. That
+  is deliberate, since every attempt against a durable callback is a
+  bounded database write, and retrying a 100ms ticker at 100ms forever
+  would hammer the store it is already struggling with. Callers must
+  therefore tolerate a late, possibly reordered callback.
+- **This invariant is load-bearing for every scheduler.** `round`
+  (`actor.go`), `oor` (`session_actor.go`) and `credit` (`op_actor.go`)
+  all issue a *blocking* `Tell` into this actor's mailbox from inside
+  their own receive loops. That is safe only because this actor's
+  `Receive` never blocks, so its mailbox always drains. Add a blocking
+  call anywhere inside `Receive` and the original incident shape is back:
+  scheduler parked on the timeout mailbox, timeout actor parked on a
+  scheduler.
+- **Only `ErrActorTerminated` and `ErrMailboxClosed` are terminal.**
+  Everything else is retried. Durable callbacks never report a full
+  mailbox; a slow database surfaces as a wrapped `DeadlineExceeded`, and
+  a `Router` target reports `ErrNoActorsAvailable` while its actor is
+  being replaced. Treating either as permanent silently discards timers
+  that nothing re-derives.
 - **Clock goroutines never block on the actor's own mailbox.** A fire
   that finds no room re-arms itself after `selfSignalRetry` instead of
   parking, so at most one fire is outstanding per entry no matter how
   far behind the actor runs.
+- **Daemons must inject a logger** via `NewActorWithConfig`. An actor's
+  lifecycle context descends from `context.Background()`, so a logger
+  resolved from the receive context alone is always `btclog.Disabled`
+  and every diagnostic this actor writes is invisible in production.
 - Callers must call `Start(ref)` with the actor's own registered ref
   before any request is delivered; calling `Receive` directly without
   a mailbox in front breaks the self-tell model.
+
+## Gotchas
+
+- **Prefer a dedicated instance over the shared singleton for durable
+  callbacks.** `waved/server.go` registers a shared `timeout` actor,
+  while OOR and credit each register their own. A durable callback's
+  delivery is a database write, so handing one to the shared instance
+  puts every other subsystem's timer behind that write's latency, and
+  behind its retry backoff when the database is slow.
+- **Recurring ticks carry the original `FiredAt` across a retry.** A
+  tick delayed by backoff reports when its timer fired, not when
+  delivery succeeded. A consumer computing `deadline = FiredAt +
+  interval` can therefore conclude the deadline already passed the
+  moment it receives a retried tick. No in-repo consumer does this
+  (wavelength has no recurring-tick caller), but lumos does use the
+  recurring scheduler, so its consumers need checking before the pin
+  bumps.
 
 ## Deep Docs
 

--- a/timeout/actor.go
+++ b/timeout/actor.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/baselib/actor"
 	"github.com/lightningnetwork/lnd/fn/v2"
 )
@@ -141,6 +142,11 @@ type Actor struct {
 	// in tests.
 	clock Clock
 
+	// log is the logger injected by the daemon. It is btclog.Disabled
+	// when the caller supplied none, in which case the actor falls back
+	// to the context logger.
+	log btclog.Logger
+
 	// self is the actor's reference to its own mailbox. Set by Start
 	// after the actor system has registered the behavior. Clock
 	// callbacks run in separate goroutines, so Start publishes the ref
@@ -160,22 +166,45 @@ type Actor struct {
 	recurring map[ID]*recurringEntry
 }
 
+// Config carries the timeout actor's optional dependencies.
+type Config struct {
+	// Clock is the time source. Defaults to RealClock; tests pass a fake
+	// clock to drive scheduling deterministically.
+	Clock fn.Option[Clock]
+
+	// Log is the logger the actor writes to. Daemons should always set
+	// it: without it the actor's diagnostics only reach a logger carried
+	// on the request context, which the actor's own receive loop does not
+	// have.
+	Log fn.Option[btclog.Logger]
+}
+
+// NewActorWithConfig creates a timeout actor from an explicit config. This is
+// the constructor daemons should use, because it is the only one that can
+// inject a logger.
+func NewActorWithConfig(cfg Config) *Actor {
+	return &Actor{
+		clock:     cfg.Clock.UnwrapOr(RealClock{}),
+		log:       cfg.Log.UnwrapOr(btclog.Disabled),
+		oneshots:  make(map[ID]*oneshotEntry),
+		recurring: make(map[ID]*recurringEntry),
+	}
+}
+
 // NewActor creates a new timeout actor backed by the real wall clock.
 // The returned actor must be wired to its mailbox via Start before any
 // schedule request is delivered.
 func NewActor() *Actor {
-	return NewActorWithClock(RealClock{})
+	return NewActorWithConfig(Config{})
 }
 
 // NewActorWithClock creates a new timeout actor that uses the supplied
 // clock. Tests use this constructor with a fake clock to drive
 // scheduling deterministically.
 func NewActorWithClock(clock Clock) *Actor {
-	return &Actor{
-		clock:     clock,
-		oneshots:  make(map[ID]*oneshotEntry),
-		recurring: make(map[ID]*recurringEntry),
-	}
+	return NewActorWithConfig(Config{
+		Clock: fn.Some(clock),
+	})
 }
 
 // Start attaches the actor's self-reference. Production callers obtain
@@ -216,8 +245,19 @@ func (a *Actor) loadSelf() (actor.TellOnlyRef[Msg], bool) {
 // fires coalesce into one outstanding timer rather than a growing pile
 // of parked senders.
 func (a *Actor) signalSelf(msg Msg) {
+	// Fires that arrive before Start wired the self-ref have nowhere to
+	// go. That only happens in direct tests or a miswired daemon, so say
+	// so rather than dropping the timer in silence.
 	self, ok := a.loadSelf()
 	if !ok {
+		bgCtx := context.Background()
+
+		a.logger(bgCtx).DebugS(
+			bgCtx,
+			"Dropping timer fire, actor self-ref not set",
+			slog.String("msg_type", msg.MessageType()),
+		)
+
 		return
 	}
 
@@ -385,7 +425,7 @@ func (a *Actor) handleTimerFired(ctx context.Context,
 	case terminalDelivery(err):
 		delete(a.oneshots, m.ID)
 
-		logger(ctx).WarnS(ctx, "Dropping expired timeout, callback "+
+		a.logger(ctx).WarnS(ctx, "Dropping expired timeout, callback "+
 			"unreachable", err,
 			slog.String("timeout_id", string(m.ID)),
 			slog.String("callback", entry.callback.ID()),
@@ -412,7 +452,7 @@ func (a *Actor) retryOneshot(ctx context.Context, id ID, entry *oneshotEntry,
 	entry.attempts++
 	delay := retryDelay(entry.attempts)
 
-	logger(ctx).WarnS(ctx, "Timeout callback delivery failed, retrying",
+	a.logger(ctx).WarnS(ctx, "Timeout callback delivery failed, retrying",
 		cause,
 		slog.String("timeout_id", string(id)),
 		slog.String("callback", entry.callback.ID()),
@@ -476,7 +516,7 @@ func (a *Actor) handleTickFired(ctx context.Context,
 	case terminalDelivery(err):
 		delete(a.recurring, m.ID)
 
-		logger(ctx).WarnS(ctx, "Stopping recurring tick, callback "+
+		a.logger(ctx).WarnS(ctx, "Stopping recurring tick, callback "+
 			"unreachable", err,
 			slog.String("tick_id", string(m.ID)),
 			slog.String("callback", entry.callback.ID()),
@@ -489,7 +529,7 @@ func (a *Actor) handleTickFired(ctx context.Context,
 		entry.attempts++
 		delay := tickRetryDelay(entry.interval, entry.attempts)
 
-		logger(ctx).WarnS(ctx, "Tick callback delivery failed, "+
+		a.logger(ctx).WarnS(ctx, "Tick callback delivery failed, "+
 			"retrying", err,
 			slog.String("tick_id", string(m.ID)),
 			slog.String("callback", entry.callback.ID()),

--- a/timeout/actor.go
+++ b/timeout/actor.go
@@ -21,11 +21,6 @@ const (
 	// long stall still gets its reminder reasonably promptly.
 	retryMaxDelay = 30 * time.Second
 
-	// maxRetryShift bounds the doubling exponent so the shift below can
-	// never overflow the duration. Every attempt past it waits
-	// retryMaxDelay.
-	maxRetryShift = 5
-
 	// selfSignalRetry is how long a clock goroutine waits before
 	// re-offering a timer fire that the actor's own mailbox had no room
 	// for. It is short because an internal fire is the actor's own work,
@@ -34,25 +29,61 @@ const (
 	selfSignalRetry = 50 * time.Millisecond
 )
 
-// retryDelay returns how long to wait before delivery attempt n, doubling
-// from retryBaseDelay and flattening out at retryMaxDelay.
-func retryDelay(attempt int) time.Duration {
-	// Attempts are one-based, and a zero would turn the shift below into a
-	// negative one, which panics.
+// terminalDelivery reports whether a failed delivery is permanent. Only a
+// stopped actor and a closed mailbox qualify, because those are end states
+// that no amount of waiting reverses. Everything else is treated as passing
+// and retried: a full mailbox, a slow write behind a durable mailbox
+// surfacing as a deadline, and a router that momentarily has no actor
+// registered are all conditions the requester recovers from. Guessing the
+// other way round means silently discarding a reminder nobody will re-derive.
+func terminalDelivery(err error) bool {
+	return errors.Is(err, actor.ErrActorTerminated) ||
+		errors.Is(err, actor.ErrMailboxClosed)
+}
+
+// backoffDelay returns the delay before attempt n of a delivery that keeps
+// failing, doubling from base and flattening out at retryMaxDelay. The
+// doubling runs as a loop that returns at the cap, so no attempt count can
+// overflow the duration.
+func backoffDelay(base time.Duration, attempt int) time.Duration {
+	// A non-positive base would make the loop below spin forever, and a
+	// zero-th attempt has no doubling to do.
+	if base <= 0 {
+		base = retryBaseDelay
+	}
 	if attempt < 1 {
-		return retryBaseDelay
+		return base
 	}
 
-	if attempt > maxRetryShift {
-		return retryMaxDelay
-	}
-
-	delay := retryBaseDelay << (attempt - 1)
-	if delay > retryMaxDelay {
-		return retryMaxDelay
+	delay := base
+	for range attempt - 1 {
+		delay *= 2
+		if delay >= retryMaxDelay {
+			return retryMaxDelay
+		}
 	}
 
 	return delay
+}
+
+// retryDelay returns how long to wait before one-shot delivery attempt n.
+func retryDelay(attempt int) time.Duration {
+	return backoffDelay(retryBaseDelay, attempt)
+}
+
+// tickRetryDelay returns how long to wait before recurring delivery attempt
+// n. A ticker faster than the standard base starts its doubling from its own
+// interval instead, so a single transient failure does not stretch a 100ms
+// ticker to a full second; anything slower than the base keeps it.
+//
+// Only the starting point moves. The doubling and the retryMaxDelay ceiling
+// apply to a recurring entry exactly as they do to a one-shot, so a consumer
+// that stays unreachable ends up retrying well past its own cadence. That is
+// deliberate rather than an oversight: every attempt against a durable
+// callback is a bounded database write, and re-offering a 100ms tick every
+// 100ms forever would hammer the store it is already struggling with.
+func tickRetryDelay(interval time.Duration, attempt int) time.Duration {
+	return backoffDelay(min(interval, retryBaseDelay), attempt)
 }
 
 // oneshotEntry tracks a one-shot timeout scheduled via
@@ -154,8 +185,13 @@ func NewActorWithClock(clock Clock) *Actor {
 // ActorSystem) inject a synchronous self-ref via newSyncSelfRef.
 //
 // Start must be called before any ScheduleTimeoutRequest or
-// ScheduleRecurringTickRequest is delivered. It is safe to call once
-// only — subsequent calls overwrite the self-ref.
+// ScheduleRecurringTickRequest is delivered, and is meant to be called
+// once. The ref is published through an atomic.Value, so a second call
+// carrying the same concrete type replaces the first, while one
+// carrying a different concrete type panics. Nothing in the daemon
+// restarts an actor with a different ref implementation, but a test
+// swapping a real ref for a synchronous one mid-life would find that
+// edge.
 func (a *Actor) Start(self actor.TellOnlyRef[Msg]) {
 	a.self.Store(self)
 }
@@ -193,7 +229,7 @@ func (a *Actor) signalSelf(msg Msg) {
 	// The actor is stopped or its mailbox closed. The fire has nowhere to
 	// go and no amount of waiting will change that, so let the chain end
 	// here.
-	if !errors.Is(err, actor.ErrMailboxFull) {
+	if terminalDelivery(err) {
 		return
 	}
 
@@ -344,14 +380,9 @@ func (a *Actor) handleTimerFired(ctx context.Context,
 	case err == nil:
 		delete(a.oneshots, m.ID)
 
-	// The requester is merely behind. Keep the entry, which is the only
-	// copy of this reminder, and re-arm the same fire later.
-	case errors.Is(err, actor.ErrMailboxFull):
-		a.retryOneshot(ctx, m.ID, entry)
-
 	// The requester is gone for good, so there is nobody left to remind
 	// and no backoff that would change that.
-	default:
+	case terminalDelivery(err):
 		delete(a.oneshots, m.ID)
 
 		logger(ctx).WarnS(ctx, "Dropping expired timeout, callback "+
@@ -359,6 +390,11 @@ func (a *Actor) handleTimerFired(ctx context.Context,
 			slog.String("timeout_id", string(m.ID)),
 			slog.String("callback", entry.callback.ID()),
 		)
+
+	// Anything else is a passing failure. Keep the entry, which is the
+	// only copy of this reminder, and re-arm the same fire later.
+	default:
+		a.retryOneshot(ctx, m.ID, entry, err)
 	}
 
 	return fn.Ok[Resp](&AckResponse{
@@ -366,16 +402,18 @@ func (a *Actor) handleTimerFired(ctx context.Context,
 	})
 }
 
-// retryOneshot re-arms an expiry whose callback had no room for it. The
+// retryOneshot re-arms an expiry whose callback could not take it. The
 // entry keeps its generation so the re-armed fire still matches on
 // arrival, and the new timer handle is recorded on the entry so a
 // Cancel or reschedule can stop the retry chain.
-func (a *Actor) retryOneshot(ctx context.Context, id ID, entry *oneshotEntry) {
+func (a *Actor) retryOneshot(ctx context.Context, id ID, entry *oneshotEntry,
+	cause error) {
+
 	entry.attempts++
 	delay := retryDelay(entry.attempts)
 
-	logger(ctx).WarnS(ctx, "Timeout callback mailbox full, retrying "+
-		"delivery", actor.ErrMailboxFull,
+	logger(ctx).WarnS(ctx, "Timeout callback delivery failed, retrying",
+		cause,
 		slog.String("timeout_id", string(id)),
 		slog.String("callback", entry.callback.ID()),
 		slog.Int("attempt", entry.attempts),
@@ -433,15 +471,26 @@ func (a *Actor) handleTickFired(ctx context.Context,
 		//nolint:contextcheck // timer is owned by timeout actor
 		a.armRecurring(m.ID, entry.gen, entry.interval)
 
-	// The consumer is behind. Hold the tick and come back for it rather
-	// than dropping it on the floor.
-	case errors.Is(err, actor.ErrMailboxFull):
+	// A ticker with no reachable consumer is pure overhead, so stop the
+	// chain instead of re-arming into a dead actor forever.
+	case terminalDelivery(err):
+		delete(a.recurring, m.ID)
+
+		logger(ctx).WarnS(ctx, "Stopping recurring tick, callback "+
+			"unreachable", err,
+			slog.String("tick_id", string(m.ID)),
+			slog.String("callback", entry.callback.ID()),
+		)
+
+	// The consumer could not take this tick. Hold it and come back for
+	// it rather than dropping it on the floor.
+	default:
 		entry.pending = tick
 		entry.attempts++
-		delay := retryDelay(entry.attempts)
+		delay := tickRetryDelay(entry.interval, entry.attempts)
 
-		logger(ctx).WarnS(ctx, "Tick callback mailbox full, retrying "+
-			"delivery", err,
+		logger(ctx).WarnS(ctx, "Tick callback delivery failed, "+
+			"retrying", err,
 			slog.String("tick_id", string(m.ID)),
 			slog.String("callback", entry.callback.ID()),
 			slog.Int("attempt", entry.attempts),
@@ -450,17 +499,6 @@ func (a *Actor) handleTickFired(ctx context.Context,
 
 		//nolint:contextcheck // timer is owned by timeout actor
 		a.armRecurring(m.ID, entry.gen, delay)
-
-	// A ticker with no reachable consumer is pure overhead, so stop the
-	// chain instead of re-arming into a dead actor forever.
-	default:
-		delete(a.recurring, m.ID)
-
-		logger(ctx).WarnS(ctx, "Stopping recurring tick, callback "+
-			"unreachable", err,
-			slog.String("tick_id", string(m.ID)),
-			slog.String("callback", entry.callback.ID()),
-		)
 	}
 
 	return fn.Ok[Resp](&AckResponse{

--- a/timeout/actor.go
+++ b/timeout/actor.go
@@ -2,13 +2,51 @@ package timeout
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"sync/atomic"
 	"time"
 
 	"github.com/lightninglabs/wavelength/baselib/actor"
 	"github.com/lightningnetwork/lnd/fn/v2"
 )
+
+const (
+	// retryBaseDelay is how long the actor waits before re-attempting a
+	// callback delivery that found the requester's mailbox full.
+	retryBaseDelay = time.Second
+
+	// retryMaxDelay caps the backoff so a requester that recovers after a
+	// long stall still gets its reminder reasonably promptly.
+	retryMaxDelay = 30 * time.Second
+
+	// maxRetryShift bounds the doubling exponent so the shift below can
+	// never overflow the duration. Every attempt past it waits
+	// retryMaxDelay.
+	maxRetryShift = 5
+)
+
+// retryDelay returns how long to wait before delivery attempt n, doubling
+// from retryBaseDelay and flattening out at retryMaxDelay.
+func retryDelay(attempt int) time.Duration {
+	// Attempts are one-based, and a zero would turn the shift below into a
+	// negative one, which panics.
+	if attempt < 1 {
+		return retryBaseDelay
+	}
+
+	if attempt > maxRetryShift {
+		return retryMaxDelay
+	}
+
+	delay := retryBaseDelay << (attempt - 1)
+	if delay > retryMaxDelay {
+		return retryMaxDelay
+	}
+
+	return delay
+}
 
 // oneshotEntry tracks a one-shot timeout scheduled via
 // ScheduleTimeoutRequest. The generation counter lets a stale fire that
@@ -18,6 +56,12 @@ type oneshotEntry struct {
 	timer    Stoppable
 	gen      uint64
 	callback actor.TellOnlyRef[*ExpiredMsg]
+
+	// attempts counts how many times delivery to callback has been tried
+	// and found its mailbox full. It only drives the backoff: the entry
+	// itself is the single copy of the reminder and survives every retry,
+	// so a slow requester costs one entry, not one per attempt.
+	attempts int
 }
 
 // recurringEntry tracks a recurring tick scheduled via
@@ -29,6 +73,16 @@ type recurringEntry struct {
 	gen      uint64
 	interval time.Duration
 	callback actor.TellOnlyRef[*TickFiredMsg]
+
+	// attempts counts consecutive failed deliveries of pending, resetting
+	// to zero as soon as a tick lands.
+	attempts int
+
+	// pending holds a tick the callback could not accept yet. Holding the
+	// message rather than rebuilding it means a retried tick still reports
+	// the instant its timer fired, not the instant delivery finally
+	// succeeded.
+	pending *TickFiredMsg
 }
 
 // Actor is the timeout scheduling actor. It manages one-shot timers and
@@ -107,6 +161,19 @@ func (a *Actor) loadSelf() (actor.TellOnlyRef[Msg], bool) {
 	return self, ok
 }
 
+// signalSelf hands an internal fire message to the actor's own mailbox.
+// It runs on a clock goroutine, so it must not touch actor state
+// directly: the state mutation happens when Receive picks the message
+// up.
+func (a *Actor) signalSelf(msg Msg) {
+	self, ok := a.loadSelf()
+	if !ok {
+		return
+	}
+
+	_ = self.Tell(context.Background(), msg)
+}
+
 // Receive processes incoming messages.
 func (a *Actor) Receive(ctx context.Context, msg Msg) fn.Result[Resp] {
 	switch m := msg.(type) {
@@ -142,17 +209,12 @@ func (a *Actor) handleSchedule(_ context.Context,
 	id := req.ID
 
 	// AfterFunc fires from the clock's own goroutine; it must not touch
-	// any actor state directly. Instead it Tells an internalTimerFired
+	// any actor state directly. Instead it signals an internalTimerFired
 	// message back into self, where Receive will deliver the
 	// user-visible ExpiredMsg single-threadedly.
 	//nolint:contextcheck // timer callback outlives scheduling actor turn
 	timer := a.clock.AfterFunc(req.Duration, func() {
-		self, ok := a.loadSelf()
-		if !ok {
-			return
-		}
-
-		_ = self.Tell(context.Background(), &internalTimerFired{
+		a.signalSelf(&internalTimerFired{
 			ID:  id,
 			Gen: gen,
 		})
@@ -202,7 +264,7 @@ func (a *Actor) handleScheduleRecurring(_ context.Context,
 		callback: req.Callback,
 	}
 
-	//nolint:contextcheck // recurring timer is owned by timeout actor
+	//nolint:contextcheck // timer is owned by timeout actor
 	a.armRecurring(req.ID, gen, req.Interval)
 
 	return fn.Ok[Resp](&AckResponse{
@@ -225,6 +287,12 @@ func (a *Actor) handleCancel(_ context.Context,
 // handleTimerFired delivers a one-shot expiry to its callback. Stale
 // fires (cancelled or rescheduled before the timer ran) are dropped via
 // the generation check.
+//
+// Delivery is non-blocking on purpose. The timeout actor is a
+// process-wide singleton shared by every subsystem, so parking this
+// goroutine on one backlogged requester would freeze every other timer
+// in the daemon. A requester that cannot take the message right now has
+// its expiry re-armed on a backoff instead.
 func (a *Actor) handleTimerFired(ctx context.Context,
 	m *internalTimerFired) fn.Result[Resp] {
 
@@ -235,20 +303,73 @@ func (a *Actor) handleTimerFired(ctx context.Context,
 		})
 	}
 
-	delete(a.oneshots, m.ID)
-
-	_ = entry.callback.Tell(ctx, &ExpiredMsg{
+	err := entry.callback.TryTell(ctx, &ExpiredMsg{
 		ID: m.ID,
 	})
+
+	switch {
+	// The reminder landed, so the entry has done its job.
+	case err == nil:
+		delete(a.oneshots, m.ID)
+
+	// The requester is merely behind. Keep the entry, which is the only
+	// copy of this reminder, and re-arm the same fire later.
+	case errors.Is(err, actor.ErrMailboxFull):
+		a.retryOneshot(ctx, m.ID, entry)
+
+	// The requester is gone for good, so there is nobody left to remind
+	// and no backoff that would change that.
+	default:
+		delete(a.oneshots, m.ID)
+
+		logger(ctx).WarnS(ctx, "Dropping expired timeout, callback "+
+			"unreachable", err,
+			slog.String("timeout_id", string(m.ID)),
+			slog.String("callback", entry.callback.ID()),
+		)
+	}
 
 	return fn.Ok[Resp](&AckResponse{
 		Success: true,
 	})
 }
 
+// retryOneshot re-arms an expiry whose callback had no room for it. The
+// entry keeps its generation so the re-armed fire still matches on
+// arrival, and the new timer handle is recorded on the entry so a
+// Cancel or reschedule can stop the retry chain.
+func (a *Actor) retryOneshot(ctx context.Context, id ID, entry *oneshotEntry) {
+	entry.attempts++
+	delay := retryDelay(entry.attempts)
+
+	logger(ctx).WarnS(ctx, "Timeout callback mailbox full, retrying "+
+		"delivery", actor.ErrMailboxFull,
+		slog.String("timeout_id", string(id)),
+		slog.String("callback", entry.callback.ID()),
+		slog.Int("attempt", entry.attempts),
+		slog.Duration("retry_in", delay),
+	)
+
+	gen := entry.gen
+
+	//nolint:contextcheck // retry timer outlives this actor turn
+	entry.timer = a.clock.AfterFunc(delay, func() {
+		a.signalSelf(&internalTimerFired{
+			ID:  id,
+			Gen: gen,
+		})
+	})
+}
+
 // handleTickFired delivers a recurring-tick fire to its callback and
 // re-arms the next one-shot. Stale fires (cancelled or replaced before
 // the timer ran) are dropped via the generation check.
+//
+// As with one-shot expiries, delivery never blocks. A tick the consumer
+// cannot take is held on the entry and retried on a backoff, which also
+// stretches the cadence for as long as the consumer stays behind. That
+// is the intended backpressure: a slow consumer slows its own ticker
+// rather than the whole daemon's timers.
 func (a *Actor) handleTickFired(ctx context.Context,
 	m *internalTickFired) fn.Result[Resp] {
 
@@ -259,13 +380,56 @@ func (a *Actor) handleTickFired(ctx context.Context,
 		})
 	}
 
-	_ = entry.callback.Tell(ctx, &TickFiredMsg{
-		ID:      m.ID,
-		FiredAt: m.FiredAt,
-	})
+	// A retry re-delivers the tick that could not land earlier, so the
+	// consumer still sees the instant its timer fired.
+	tick := entry.pending
+	if tick == nil {
+		tick = &TickFiredMsg{
+			ID:      m.ID,
+			FiredAt: m.FiredAt,
+		}
+	}
 
-	//nolint:contextcheck // recurring timer is owned by timeout actor
-	a.armRecurring(m.ID, entry.gen, entry.interval)
+	err := entry.callback.TryTell(ctx, tick)
+
+	switch {
+	// The tick landed, so the cadence resumes from a clean slate.
+	case err == nil:
+		entry.pending = nil
+		entry.attempts = 0
+
+		//nolint:contextcheck // timer is owned by timeout actor
+		a.armRecurring(m.ID, entry.gen, entry.interval)
+
+	// The consumer is behind. Hold the tick and come back for it rather
+	// than dropping it on the floor.
+	case errors.Is(err, actor.ErrMailboxFull):
+		entry.pending = tick
+		entry.attempts++
+		delay := retryDelay(entry.attempts)
+
+		logger(ctx).WarnS(ctx, "Tick callback mailbox full, retrying "+
+			"delivery", err,
+			slog.String("tick_id", string(m.ID)),
+			slog.String("callback", entry.callback.ID()),
+			slog.Int("attempt", entry.attempts),
+			slog.Duration("retry_in", delay),
+		)
+
+		//nolint:contextcheck // timer is owned by timeout actor
+		a.armRecurring(m.ID, entry.gen, delay)
+
+	// A ticker with no reachable consumer is pure overhead, so stop the
+	// chain instead of re-arming into a dead actor forever.
+	default:
+		delete(a.recurring, m.ID)
+
+		logger(ctx).WarnS(ctx, "Stopping recurring tick, callback "+
+			"unreachable", err,
+			slog.String("tick_id", string(m.ID)),
+			slog.String("callback", entry.callback.ID()),
+		)
+	}
 
 	return fn.Ok[Resp](&AckResponse{
 		Success: true,
@@ -280,12 +444,7 @@ func (a *Actor) handleTickFired(ctx context.Context,
 // gen check on arrival.
 func (a *Actor) armRecurring(id ID, gen uint64, d time.Duration) {
 	timer := a.clock.AfterFunc(d, func() {
-		self, ok := a.loadSelf()
-		if !ok {
-			return
-		}
-
-		_ = self.Tell(context.Background(), &internalTickFired{
+		a.signalSelf(&internalTickFired{
 			ID:      id,
 			Gen:     gen,
 			FiredAt: a.clock.Now(),

--- a/timeout/actor.go
+++ b/timeout/actor.go
@@ -25,6 +25,13 @@ const (
 	// never overflow the duration. Every attempt past it waits
 	// retryMaxDelay.
 	maxRetryShift = 5
+
+	// selfSignalRetry is how long a clock goroutine waits before
+	// re-offering a timer fire that the actor's own mailbox had no room
+	// for. It is short because an internal fire is the actor's own work,
+	// and the mailbox only stays full for as long as the actor is behind
+	// on its queue.
+	selfSignalRetry = 50 * time.Millisecond
 )
 
 // retryDelay returns how long to wait before delivery attempt n, doubling
@@ -165,13 +172,38 @@ func (a *Actor) loadSelf() (actor.TellOnlyRef[Msg], bool) {
 // It runs on a clock goroutine, so it must not touch actor state
 // directly: the state mutation happens when Receive picks the message
 // up.
+//
+// The send never blocks. A blocking one would leave a goroutine parked
+// per timer fire for as long as the actor stayed backed up, which is a
+// slow leak triggered by exactly the situation the actor is trying to
+// work through. Instead a full mailbox re-arms the fire, so pending
+// fires coalesce into one outstanding timer rather than a growing pile
+// of parked senders.
 func (a *Actor) signalSelf(msg Msg) {
 	self, ok := a.loadSelf()
 	if !ok {
 		return
 	}
 
-	_ = self.Tell(context.Background(), msg)
+	err := self.TryTell(context.Background(), msg)
+	if err == nil {
+		return
+	}
+
+	// The actor is stopped or its mailbox closed. The fire has nowhere to
+	// go and no amount of waiting will change that, so let the chain end
+	// here.
+	if !errors.Is(err, actor.ErrMailboxFull) {
+		return
+	}
+
+	// The retry handle is deliberately not recorded on the entry: we are
+	// off the receive goroutine, where touching actor state would race.
+	// A Cancel landing in the meantime is still honoured, because the
+	// generation check drops the fire when it finally arrives.
+	a.clock.AfterFunc(selfSignalRetry, func() {
+		a.signalSelf(msg)
+	})
 }
 
 // Receive processes incoming messages.

--- a/timeout/actor_backpressure_test.go
+++ b/timeout/actor_backpressure_test.go
@@ -1,6 +1,7 @@
 package timeout
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -9,7 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -882,4 +885,42 @@ func TestSelfSignalRetriesUntilMailboxDrains(t *testing.T) {
 	fired, ok := self.AwaitMessage(time.Second)
 	require.True(t, ok, "deferred fire never arrived")
 	require.Equal(t, "internalTimerFired", fired.MessageType())
+}
+
+// TestActorLogsThroughInjectedLogger is the regression test for the actor's
+// diagnostics being invisible in production. An actor's receive loop runs on a
+// context descended from context.Background(), so a logger resolved from ctx
+// alone is always disabled. Only the injected one reaches an operator.
+func TestActorLogsThroughInjectedLogger(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	handler := btclog.NewDefaultHandler(&buf, btclog.WithNoTimestamp())
+	handler.SetLevel(btclog.LevelWarn)
+
+	clock := newFakeClock(startEpoch)
+	a := NewActorWithConfig(Config{
+		Clock: fn.Some[Clock](clock),
+		Log:   fn.Some(btclog.NewSLogger(handler)),
+	})
+	a.Start(newSyncSelfRef(a))
+
+	cb := newWedgeableCallbackRef("wedged-requester", actor.ErrMailboxFull)
+
+	// t.Context() carries no logger, so anything that reaches the buffer
+	// got there through the injected one.
+	res := a.Receive(t.Context(), &ScheduleTimeoutRequest{
+		ID:       "logged",
+		Duration: 50 * time.Millisecond,
+		Callback: cb,
+	})
+	require.True(t, res.IsOk())
+
+	clock.Advance(50 * time.Millisecond)
+
+	logged := buf.String()
+	require.Contains(t, logged, "Timeout callback delivery failed")
+	require.Contains(t, logged, "wedged-requester")
+	require.Contains(t, logged, "logged")
 }

--- a/timeout/actor_backpressure_test.go
+++ b/timeout/actor_backpressure_test.go
@@ -1,0 +1,459 @@
+package timeout
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/stretchr/testify/require"
+)
+
+// wedgeableCallbackRef stands in for a requester whose mailbox has filled up.
+// While wedged, every non-blocking send is refused; releasing it makes the
+// next attempt succeed.
+type wedgeableCallbackRef struct {
+	mu sync.Mutex
+
+	id       string
+	wedged   bool
+	err      error
+	attempts int
+	msgs     []ExpiredMsg
+}
+
+// newWedgeableCallbackRef returns a callback that refuses deliveries with err
+// until release is called.
+func newWedgeableCallbackRef(id string, err error) *wedgeableCallbackRef {
+	return &wedgeableCallbackRef{
+		id:     id,
+		wedged: true,
+		err:    err,
+	}
+}
+
+// ID returns the callback identifier.
+func (w *wedgeableCallbackRef) ID() string { return w.id }
+
+// Tell records the message unconditionally. The timeout actor must never
+// reach for this path, so a test that sees a message arrive here has caught a
+// regression back to blocking delivery.
+func (w *wedgeableCallbackRef) Tell(_ context.Context, msg *ExpiredMsg) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.msgs = append(w.msgs, *msg)
+
+	return nil
+}
+
+// TryTell refuses the delivery while wedged and records it once released.
+func (w *wedgeableCallbackRef) TryTell(_ context.Context,
+	msg *ExpiredMsg) error {
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.attempts++
+
+	if w.wedged {
+		return w.err
+	}
+
+	w.msgs = append(w.msgs, *msg)
+
+	return nil
+}
+
+// release lets subsequent deliveries through.
+func (w *wedgeableCallbackRef) release() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.wedged = false
+}
+
+// snapshot returns the messages delivered so far and the number of delivery
+// attempts made.
+func (w *wedgeableCallbackRef) snapshot() ([]ExpiredMsg, int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return append([]ExpiredMsg{}, w.msgs...), w.attempts
+}
+
+// wedgeableTickRef is the recurring-tick counterpart of
+// wedgeableCallbackRef.
+type wedgeableTickRef struct {
+	mu sync.Mutex
+
+	id       string
+	wedged   bool
+	attempts int
+	msgs     []TickFiredMsg
+}
+
+// newWedgeableTickRef returns a tick callback that refuses deliveries until
+// release is called.
+func newWedgeableTickRef(id string) *wedgeableTickRef {
+	return &wedgeableTickRef{
+		id:     id,
+		wedged: true,
+	}
+}
+
+// ID returns the callback identifier.
+func (w *wedgeableTickRef) ID() string { return w.id }
+
+// Tell records the tick unconditionally; the actor must not use this path.
+func (w *wedgeableTickRef) Tell(_ context.Context, msg *TickFiredMsg) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.msgs = append(w.msgs, *msg)
+
+	return nil
+}
+
+// TryTell refuses the tick while wedged and records it once released.
+func (w *wedgeableTickRef) TryTell(_ context.Context, msg *TickFiredMsg) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.attempts++
+
+	if w.wedged {
+		return actor.ErrMailboxFull
+	}
+
+	w.msgs = append(w.msgs, *msg)
+
+	return nil
+}
+
+// release lets subsequent ticks through.
+func (w *wedgeableTickRef) release() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.wedged = false
+}
+
+// snapshot returns the ticks delivered so far and the attempt count.
+func (w *wedgeableTickRef) snapshot() ([]TickFiredMsg, int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return append([]TickFiredMsg{}, w.msgs...), w.attempts
+}
+
+// TestRetryDelayBackoff verifies the backoff doubles from the base delay and
+// then flattens at the cap, including for attempt counts large enough to
+// overflow a naive shift.
+func TestRetryDelayBackoff(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, retryBaseDelay, retryDelay(0))
+	require.Equal(t, time.Second, retryDelay(1))
+	require.Equal(t, 2*time.Second, retryDelay(2))
+	require.Equal(t, 4*time.Second, retryDelay(3))
+	require.Equal(t, 8*time.Second, retryDelay(4))
+	require.Equal(t, 16*time.Second, retryDelay(5))
+	require.Equal(t, retryMaxDelay, retryDelay(6))
+	require.Equal(t, retryMaxDelay, retryDelay(1000))
+}
+
+// TestTimeoutRetriesWedgedCallback verifies an expiry that cannot be
+// delivered is held and re-armed on a growing backoff, then delivered intact
+// once the requester drains. Nothing is lost and nothing is duplicated.
+func TestTimeoutRetriesWedgedCallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := newFakeClock(startEpoch)
+	a := newTestActor(clock)
+	cb := newWedgeableCallbackRef("wedged", actor.ErrMailboxFull)
+
+	res := a.Receive(ctx, &ScheduleTimeoutRequest{
+		ID:       "retried",
+		Duration: 50 * time.Millisecond,
+		Callback: cb,
+	})
+	require.True(t, res.IsOk())
+
+	// First fire: the requester has no room, so the entry survives with a
+	// retry armed one second out.
+	clock.Advance(50 * time.Millisecond)
+
+	msgs, attempts := cb.snapshot()
+	require.Empty(t, msgs)
+	require.Equal(t, 1, attempts)
+	require.Len(t, a.oneshots, 1)
+
+	// Nothing happens before the backoff elapses.
+	clock.Advance(500 * time.Millisecond)
+
+	_, attempts = cb.snapshot()
+	require.Equal(t, 1, attempts)
+
+	// Second attempt, still wedged. The next retry doubles to two
+	// seconds, so a one second advance is not enough to trigger a third.
+	clock.Advance(500 * time.Millisecond)
+	clock.Advance(time.Second)
+
+	msgs, attempts = cb.snapshot()
+	require.Empty(t, msgs)
+	require.Equal(t, 2, attempts)
+
+	// Once the requester drains, the held expiry lands on the next retry.
+	cb.release()
+	clock.Advance(2 * time.Second)
+
+	msgs, attempts = cb.snapshot()
+	require.Len(t, msgs, 1)
+	require.Equal(t, ID("retried"), msgs[0].ID)
+	require.Equal(t, 3, attempts)
+
+	// The reminder is discharged, so no entry and no timer outlive it.
+	require.Empty(t, a.oneshots)
+
+	clock.Advance(time.Minute)
+
+	msgs, _ = cb.snapshot()
+	require.Len(t, msgs, 1)
+}
+
+// TestTimeoutRetryStaysCancellable verifies a held expiry is still owned by
+// its ID: cancelling it stops the retry chain instead of leaving a reminder
+// that fires long after the requester asked for it to go away.
+func TestTimeoutRetryStaysCancellable(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := newFakeClock(startEpoch)
+	a := newTestActor(clock)
+	cb := newWedgeableCallbackRef("wedged", actor.ErrMailboxFull)
+
+	res := a.Receive(ctx, &ScheduleTimeoutRequest{
+		ID:       "cancelled",
+		Duration: 50 * time.Millisecond,
+		Callback: cb,
+	})
+	require.True(t, res.IsOk())
+
+	clock.Advance(50 * time.Millisecond)
+	require.Len(t, a.oneshots, 1)
+
+	res = a.Receive(ctx, &CancelTimeoutRequest{ID: "cancelled"})
+	require.True(t, res.IsOk())
+	require.Empty(t, a.oneshots)
+
+	// Even a healthy requester hears nothing more about a cancelled
+	// timeout.
+	cb.release()
+	clock.Advance(time.Minute)
+
+	msgs, attempts := cb.snapshot()
+	require.Empty(t, msgs)
+	require.Equal(t, 1, attempts)
+}
+
+// TestTimeoutDropsUnreachableCallback verifies a permanently gone requester
+// does not earn a retry chain: there is nothing a backoff could fix, so the
+// entry is released.
+func TestTimeoutDropsUnreachableCallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := newFakeClock(startEpoch)
+	a := newTestActor(clock)
+	cb := newWedgeableCallbackRef("dead", actor.ErrActorTerminated)
+
+	res := a.Receive(ctx, &ScheduleTimeoutRequest{
+		ID:       "dropped",
+		Duration: 50 * time.Millisecond,
+		Callback: cb,
+	})
+	require.True(t, res.IsOk())
+
+	clock.Advance(50 * time.Millisecond)
+	require.Empty(t, a.oneshots)
+
+	clock.Advance(time.Minute)
+
+	msgs, attempts := cb.snapshot()
+	require.Empty(t, msgs)
+	require.Equal(t, 1, attempts)
+}
+
+// TestTickRetryPreservesFireInstant verifies a tick the consumer could not
+// take is held rather than dropped, and that the retry reports when the timer
+// actually fired instead of when delivery finally succeeded.
+func TestTickRetryPreservesFireInstant(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := newFakeClock(startEpoch)
+	a := newTestActor(clock)
+	cb := newWedgeableTickRef("wedged-tick")
+
+	res := a.Receive(ctx, &ScheduleRecurringTickRequest{
+		ID:       "tick",
+		Interval: 100 * time.Millisecond,
+		Callback: cb,
+	})
+	require.True(t, res.IsOk())
+
+	firedAt := startEpoch.Add(100 * time.Millisecond)
+
+	clock.Advance(100 * time.Millisecond)
+
+	msgs, attempts := cb.snapshot()
+	require.Empty(t, msgs)
+	require.Equal(t, 1, attempts)
+
+	// The retry replaces the cadence while the consumer is behind, so no
+	// second tick piles up during the backoff window.
+	cb.release()
+	clock.Advance(time.Second)
+
+	msgs, attempts = cb.snapshot()
+	require.Len(t, msgs, 1)
+	require.Equal(t, 2, attempts)
+	require.Equal(t, firedAt, msgs[0].FiredAt)
+
+	// With the consumer drained, the ticker resumes its normal interval.
+	clock.Advance(100 * time.Millisecond)
+
+	msgs, _ = cb.snapshot()
+	require.Len(t, msgs, 2)
+	require.True(t, msgs[1].FiredAt.After(msgs[0].FiredAt))
+}
+
+// blockingCallbackRef parks any blocking send until the test releases it,
+// while reporting a full mailbox to the non-blocking one. It models the
+// production shape that wedged the daemon: a requester whose mailbox is full
+// and stays full.
+type blockingCallbackRef struct {
+	id      string
+	release chan struct{}
+	once    sync.Once
+
+	mu       sync.Mutex
+	attempts int
+}
+
+// newBlockingCallbackRef creates a callback whose Tell never returns until
+// released.
+func newBlockingCallbackRef(id string) *blockingCallbackRef {
+	return &blockingCallbackRef{
+		id:      id,
+		release: make(chan struct{}),
+	}
+}
+
+// ID returns the callback identifier.
+func (b *blockingCallbackRef) ID() string { return b.id }
+
+// Tell parks the caller until the test releases it.
+func (b *blockingCallbackRef) Tell(ctx context.Context, _ *ExpiredMsg) error {
+	b.count()
+
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+	}
+
+	return nil
+}
+
+// TryTell reports the mailbox as full without ever parking.
+func (b *blockingCallbackRef) TryTell(_ context.Context, _ *ExpiredMsg) error {
+	b.count()
+
+	return actor.ErrMailboxFull
+}
+
+// count records a delivery attempt.
+func (b *blockingCallbackRef) count() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.attempts++
+}
+
+// attemptCount returns how many deliveries have been attempted.
+func (b *blockingCallbackRef) attemptCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.attempts
+}
+
+// stop releases any parked sender.
+func (b *blockingCallbackRef) stop() {
+	b.once.Do(func() {
+		close(b.release)
+	})
+}
+
+// TestTimeoutActorStaysResponsiveWhileCallbackWedged is the regression test
+// for the daemon-wide timer freeze. The timeout actor is a process-wide
+// singleton, so if one wedged requester can park its receive goroutine, every
+// other subsystem's timers stop with it. Here a wedged callback must not stop
+// the actor from accepting and firing an unrelated timeout.
+func TestTimeoutActorStaysResponsiveWhileCallbackWedged(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	behavior := NewActor()
+	host := actor.NewActor(actor.ActorConfig[Msg, Resp]{
+		ID:          "timeout-responsive",
+		Behavior:    behavior,
+		MailboxSize: 8,
+	})
+	host.Start()
+	t.Cleanup(host.Stop)
+
+	behavior.Start(host.Ref())
+
+	wedged := newBlockingCallbackRef("wedged")
+	t.Cleanup(wedged.stop)
+
+	require.NoError(
+		t,
+		host.Ref().Tell(ctx, &ScheduleTimeoutRequest{
+			ID:       "wedged",
+			Duration: 10 * time.Millisecond,
+			Callback: wedged,
+		},
+		),
+	)
+
+	// Wait until the actor has tried to hand the expiry over. From this
+	// point on, a blocking delivery would have the receive goroutine
+	// parked for good.
+	require.Eventually(t, func() bool {
+		return wedged.attemptCount() > 0
+	}, 5*time.Second, 5*time.Millisecond)
+
+	// The actor must still accept new work.
+	askCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	healthy := actor.NewChannelTellOnlyRef[*ExpiredMsg]("healthy", 1)
+	schedule := &ScheduleTimeoutRequest{
+		ID:       "healthy",
+		Duration: 10 * time.Millisecond,
+		Callback: healthy,
+	}
+
+	res := host.Ref().Ask(askCtx, schedule).Await(askCtx)
+	require.True(t, res.IsOk(), "schedule was not acknowledged")
+
+	// And it must still fire the timers it accepted.
+	_, ok := healthy.AwaitMessage(5 * time.Second)
+	require.True(t, ok, "timer never fired while a callback was wedged")
+}

--- a/timeout/actor_backpressure_test.go
+++ b/timeout/actor_backpressure_test.go
@@ -2,6 +2,8 @@ package timeout
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -456,4 +458,111 @@ func TestTimeoutActorStaysResponsiveWhileCallbackWedged(t *testing.T) {
 	// And it must still fire the timers it accepted.
 	_, ok := healthy.AwaitMessage(5 * time.Second)
 	require.True(t, ok, "timer never fired while a callback was wedged")
+}
+
+// goroutineFloor samples the process goroutine count a few times and returns
+// the smallest reading, which filters out the short-lived goroutines a timer
+// fire spawns and leaves only the ones that are actually parked.
+func goroutineFloor() int {
+	floor := runtime.NumGoroutine()
+	for range 10 {
+		time.Sleep(5 * time.Millisecond)
+
+		if n := runtime.NumGoroutine(); n < floor {
+			floor = n
+		}
+	}
+
+	return floor
+}
+
+// TestSelfSignalDoesNotLeakGoroutines verifies that timer fires landing on a
+// backed up actor coalesce instead of stacking parked senders. A blocking
+// self-tell leaked one goroutine per fire for as long as the actor stayed
+// behind, which is precisely when timers fire fastest.
+func TestSelfSignalDoesNotLeakGoroutines(t *testing.T) {
+	// Deliberately not parallel: this test counts goroutines
+	// process-wide.
+	ctx := t.Context()
+
+	a := NewActor()
+
+	// A self-ref whose mailbox is full and stays full, so every internal
+	// fire meets a target that will not take it.
+	wedgedSelf := actor.NewChannelTellOnlyRef[Msg]("wedged-self", 1)
+	require.NoError(t, wedgedSelf.TryTell(ctx, &internalTimerFired{}))
+
+	a.Start(wedgedSelf)
+
+	t.Cleanup(func() {
+		// Drain the queued fires so the retry chains find room and
+		// end, rather than spinning for the rest of the run.
+		for {
+			select {
+			case <-wedgedSelf.Messages():
+			case <-time.After(100 * time.Millisecond):
+				return
+			}
+		}
+	})
+
+	callback := actor.NewChannelTellOnlyRef[*ExpiredMsg]("callback", 1)
+
+	before := goroutineFloor()
+
+	const timers = 40
+
+	for i := range timers {
+		res := a.Receive(ctx, &ScheduleTimeoutRequest{
+			ID:       ID(fmt.Sprintf("leak-%d", i)),
+			Duration: 5 * time.Millisecond,
+			Callback: callback,
+		})
+		require.True(t, res.IsOk())
+	}
+
+	// Long enough for every timer to fire and retry several times over.
+	time.Sleep(300 * time.Millisecond)
+
+	after := goroutineFloor()
+
+	require.Less(
+		t, after, before+timers/2,
+		"timer fires parked goroutines on the wedged mailbox",
+	)
+}
+
+// TestSelfSignalRetriesUntilMailboxDrains verifies the coalesced fire is a
+// deferral and not a drop: once the actor's own mailbox has room again, the
+// fire it could not accept arrives.
+func TestSelfSignalRetriesUntilMailboxDrains(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := newFakeClock(startEpoch)
+	a := NewActorWithClock(clock)
+
+	self := actor.NewChannelTellOnlyRef[Msg]("full-self", 1)
+	require.NoError(t, self.TryTell(ctx, &internalTimerFired{}))
+
+	a.Start(self)
+
+	res := a.Receive(ctx, &ScheduleTimeoutRequest{
+		ID:       "deferred",
+		Duration: 50 * time.Millisecond,
+		Callback: newMockCallbackRef(t, "callback"),
+	})
+	require.True(t, res.IsOk())
+
+	// The fire finds no room, so it is re-armed rather than dropped or
+	// parked.
+	clock.Advance(50 * time.Millisecond)
+
+	// Make room and let the retry run.
+	<-self.Messages()
+	clock.Advance(selfSignalRetry)
+
+	fired, ok := self.AwaitMessage(time.Second)
+	require.True(t, ok, "deferred fire never arrived")
+	require.Equal(t, "internalTimerFired", fired.MessageType())
 }

--- a/timeout/actor_backpressure_test.go
+++ b/timeout/actor_backpressure_test.go
@@ -2,6 +2,7 @@ package timeout
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"sync"
@@ -92,16 +93,19 @@ type wedgeableTickRef struct {
 
 	id       string
 	wedged   bool
+	err      error
 	attempts int
 	msgs     []TickFiredMsg
 }
 
-// newWedgeableTickRef returns a tick callback that refuses deliveries until
-// release is called.
+// newWedgeableTickRef returns a tick callback that refuses deliveries with a
+// full mailbox until release is called. Tests override err to model a
+// different failure.
 func newWedgeableTickRef(id string) *wedgeableTickRef {
 	return &wedgeableTickRef{
 		id:     id,
 		wedged: true,
+		err:    actor.ErrMailboxFull,
 	}
 }
 
@@ -126,7 +130,7 @@ func (w *wedgeableTickRef) TryTell(_ context.Context, msg *TickFiredMsg) error {
 	w.attempts++
 
 	if w.wedged {
-		return actor.ErrMailboxFull
+		return w.err
 	}
 
 	w.msgs = append(w.msgs, *msg)
@@ -164,6 +168,311 @@ func TestRetryDelayBackoff(t *testing.T) {
 	require.Equal(t, 16*time.Second, retryDelay(5))
 	require.Equal(t, retryMaxDelay, retryDelay(6))
 	require.Equal(t, retryMaxDelay, retryDelay(1000))
+}
+
+// TestTickRetryDelayStartsFromInterval verifies that a fast ticker starts its
+// backoff from its own cadence rather than jumping to the one second base,
+// while a ticker slower than that base keeps the standard backoff. It is the
+// starting point that moves and nothing else: the doubling and the 30s
+// ceiling apply to a recurring entry exactly as they do to a one-shot, so a
+// consumer that stays unreachable backs off well past its own interval.
+func TestTickRetryDelayStartsFromInterval(t *testing.T) {
+	t.Parallel()
+
+	const fast = 100 * time.Millisecond
+
+	require.Equal(t, fast, tickRetryDelay(fast, 1))
+	require.Equal(t, 2*fast, tickRetryDelay(fast, 2))
+	require.Equal(t, 4*fast, tickRetryDelay(fast, 3))
+
+	// The ceiling is the global one, not the interval. A ticker whose
+	// consumer stays unreachable ends up far slower than its configured
+	// cadence, which is the point: every attempt against a durable
+	// callback is a bounded database write.
+	require.Equal(t, retryMaxDelay, tickRetryDelay(fast, 1000))
+	require.Greater(t, tickRetryDelay(fast, 1000), fast)
+
+	// A slow ticker is already slower than the base, so nothing is
+	// capped and it behaves exactly like a one-shot retry.
+	const slow = time.Minute
+
+	require.Equal(t, retryBaseDelay, tickRetryDelay(slow, 1))
+	require.Equal(t, 2*retryBaseDelay, tickRetryDelay(slow, 2))
+
+	// A nonsensical interval must not spin the doubling loop.
+	require.Equal(t, retryBaseDelay, tickRetryDelay(0, 1))
+}
+
+// TestTimeoutRetriesTransientFailures is the regression test for treating
+// every non-terminal delivery error as permanent. Durable callbacks (OOR
+// session retries, credit polls) never report a full mailbox: their enqueue
+// is a database write that surfaces a deadline when the database is slow, and
+// a Router reports that it momentarily has no actor. Discarding the reminder
+// in those cases is worse than what the old blocking send did, because
+// nothing re-derives it until the daemon restarts.
+func TestTimeoutRetriesTransientFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "mailbox full",
+			err:  actor.ErrMailboxFull,
+		},
+		{
+			// What a durable mailbox returns when the write does
+			// not finish inside its internal deadline.
+			name: "slow durable write",
+			err: fmt.Errorf("enqueue message: %w",
+				context.DeadlineExceeded),
+		},
+		{
+			// What a Router returns before its target registers,
+			// or while the target is being replaced.
+			name: "no actors available",
+			err:  actor.ErrNoActorsAvailable,
+		},
+		{
+			name: "unknown transport failure",
+			err:  errors.New("connection reset"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			clock := newFakeClock(startEpoch)
+			a := newTestActor(clock)
+			cb := newWedgeableCallbackRef("transient", tc.err)
+
+			res := a.Receive(ctx, &ScheduleTimeoutRequest{
+				ID:       "transient",
+				Duration: 50 * time.Millisecond,
+				Callback: cb,
+			})
+			require.True(t, res.IsOk())
+
+			// The failure must not consume the reminder.
+			clock.Advance(50 * time.Millisecond)
+
+			msgs, attempts := cb.snapshot()
+			require.Empty(t, msgs)
+			require.Equal(t, 1, attempts)
+			require.Len(t, a.oneshots, 1)
+
+			// Once the requester recovers, the held reminder is
+			// delivered on the next retry.
+			cb.release()
+			clock.Advance(retryBaseDelay)
+
+			msgs, _ = cb.snapshot()
+			require.Len(t, msgs, 1)
+			require.Equal(t, ID("transient"), msgs[0].ID)
+			require.Empty(t, a.oneshots)
+		})
+	}
+}
+
+// TestTimeoutDropsTerminalCallbacks verifies the two errors that really are
+// end states release the entry instead of retrying into a corpse forever.
+func TestTimeoutDropsTerminalCallbacks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "actor terminated",
+			err:  actor.ErrActorTerminated,
+		},
+		{
+			name: "mailbox closed",
+			err:  actor.ErrMailboxClosed,
+		},
+		{
+			name: "wrapped terminal error",
+			err: fmt.Errorf("deliver expiry: %w",
+				actor.ErrActorTerminated),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			clock := newFakeClock(startEpoch)
+			a := newTestActor(clock)
+			cb := newWedgeableCallbackRef("terminal", tc.err)
+
+			res := a.Receive(ctx, &ScheduleTimeoutRequest{
+				ID:       "terminal",
+				Duration: 50 * time.Millisecond,
+				Callback: cb,
+			})
+			require.True(t, res.IsOk())
+
+			clock.Advance(50 * time.Millisecond)
+			require.Empty(t, a.oneshots)
+
+			// No retry chain outlives the entry.
+			clock.Advance(time.Minute)
+
+			msgs, attempts := cb.snapshot()
+			require.Empty(t, msgs)
+			require.Equal(t, 1, attempts)
+		})
+	}
+}
+
+// TestTickRetriesTransientFailure verifies the recurring path shares the
+// one-shot verdict: a transient failure holds the tick and retries, and only
+// a terminal one stops the ticker.
+func TestTickRetriesTransientFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := newFakeClock(startEpoch)
+	a := newTestActor(clock)
+	cb := newWedgeableTickRef("slow-db-tick")
+	cb.err = fmt.Errorf("enqueue message: %w", context.DeadlineExceeded)
+
+	res := a.Receive(ctx, &ScheduleRecurringTickRequest{
+		ID:       "tick",
+		Interval: time.Second,
+		Callback: cb,
+	})
+	require.True(t, res.IsOk())
+
+	clock.Advance(time.Second)
+
+	msgs, attempts := cb.snapshot()
+	require.Empty(t, msgs)
+	require.Equal(t, 1, attempts)
+	require.Len(t, a.recurring, 1)
+
+	cb.release()
+	clock.Advance(retryBaseDelay)
+
+	msgs, _ = cb.snapshot()
+	require.Len(t, msgs, 1)
+	require.Equal(t, startEpoch.Add(time.Second), msgs[0].FiredAt)
+}
+
+// TestTickStopsOnTerminalCallback verifies a ticker whose consumer is gone
+// releases its entry rather than re-arming forever.
+func TestTickStopsOnTerminalCallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := newFakeClock(startEpoch)
+	a := newTestActor(clock)
+	cb := newWedgeableTickRef("dead-tick")
+	cb.err = actor.ErrActorTerminated
+
+	res := a.Receive(ctx, &ScheduleRecurringTickRequest{
+		ID:       "tick",
+		Interval: time.Second,
+		Callback: cb,
+	})
+	require.True(t, res.IsOk())
+
+	clock.Advance(time.Second)
+	require.Empty(t, a.recurring)
+
+	clock.Advance(time.Minute)
+
+	msgs, attempts := cb.snapshot()
+	require.Empty(t, msgs)
+	require.Equal(t, 1, attempts)
+}
+
+// TestRescheduleSupersedesArmedRetry verifies a fresh schedule for an ID with
+// a retry in flight wins outright: the old reminder never lands, and the new
+// one fires on its own duration.
+func TestRescheduleSupersedesArmedRetry(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := newFakeClock(startEpoch)
+	a := newTestActor(clock)
+	cb := newWedgeableCallbackRef("wedged", actor.ErrMailboxFull)
+
+	res := a.Receive(ctx, &ScheduleTimeoutRequest{
+		ID:       "resched",
+		Duration: 50 * time.Millisecond,
+		Callback: cb,
+	})
+	require.True(t, res.IsOk())
+
+	clock.Advance(50 * time.Millisecond)
+	require.Len(t, a.oneshots, 1)
+
+	// Re-scheduling the same ID replaces the entry, which stops the armed
+	// retry and resets the attempt count with it.
+	healthy := newWedgeableCallbackRef("healthy", actor.ErrMailboxFull)
+	healthy.release()
+
+	res = a.Receive(ctx, &ScheduleTimeoutRequest{
+		ID:       "resched",
+		Duration: 10 * time.Second,
+		Callback: healthy,
+	})
+	require.True(t, res.IsOk())
+
+	// The old retry instant passes without waking the old callback.
+	cb.release()
+	clock.Advance(5 * time.Second)
+
+	msgs, _ := cb.snapshot()
+	require.Empty(t, msgs)
+
+	msgs, _ = healthy.snapshot()
+	require.Empty(t, msgs)
+
+	// The replacement fires on its own schedule.
+	clock.Advance(5 * time.Second)
+
+	msgs, _ = healthy.snapshot()
+	require.Len(t, msgs, 1)
+	require.Empty(t, a.oneshots)
+}
+
+// TestCancelDuringRecurringRetry verifies a cancel lands even while a tick is
+// held for retry: the ticker stops and the held tick is never delivered.
+func TestCancelDuringRecurringRetry(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := newFakeClock(startEpoch)
+	a := newTestActor(clock)
+	cb := newWedgeableTickRef("wedged-tick")
+
+	res := a.Receive(ctx, &ScheduleRecurringTickRequest{
+		ID:       "tick",
+		Interval: time.Second,
+		Callback: cb,
+	})
+	require.True(t, res.IsOk())
+
+	clock.Advance(time.Second)
+	require.Len(t, a.recurring, 1)
+
+	res = a.Receive(ctx, &CancelTimeoutRequest{ID: "tick"})
+	require.True(t, res.IsOk())
+	require.Empty(t, a.recurring)
+
+	cb.release()
+	clock.Advance(time.Minute)
+
+	msgs, attempts := cb.snapshot()
+	require.Empty(t, msgs)
+	require.Equal(t, 1, attempts)
 }
 
 // TestTimeoutRetriesWedgedCallback verifies an expiry that cannot be
@@ -315,14 +624,22 @@ func TestTickRetryPreservesFireInstant(t *testing.T) {
 	require.Empty(t, msgs)
 	require.Equal(t, 1, attempts)
 
+	// The retry base is capped at the interval, so the second attempt
+	// comes one interval later rather than a full second later.
+	clock.Advance(100 * time.Millisecond)
+
+	msgs, attempts = cb.snapshot()
+	require.Empty(t, msgs)
+	require.Equal(t, 2, attempts)
+
 	// The retry replaces the cadence while the consumer is behind, so no
 	// second tick piles up during the backoff window.
 	cb.release()
-	clock.Advance(time.Second)
+	clock.Advance(200 * time.Millisecond)
 
 	msgs, attempts = cb.snapshot()
 	require.Len(t, msgs, 1)
-	require.Equal(t, 2, attempts)
+	require.Equal(t, 3, attempts)
 	require.Equal(t, firedAt, msgs[0].FiredAt)
 
 	// With the consumer drained, the ticker resumes its normal interval.

--- a/timeout/actor_test.go
+++ b/timeout/actor_test.go
@@ -45,6 +45,12 @@ func (m *mockCallbackRef) Tell(_ context.Context, msg *ExpiredMsg) error {
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (m *mockCallbackRef) TryTell(ctx context.Context, msg *ExpiredMsg) error {
+	return m.Tell(ctx, msg)
+}
+
 // getMessages returns a copy of all received messages.
 func (m *mockCallbackRef) getMessages() []ExpiredMsg {
 	m.mu.Lock()

--- a/timeout/clock_test.go
+++ b/timeout/clock_test.go
@@ -174,6 +174,12 @@ func (s *syncSelfRef) Tell(ctx context.Context, msg Msg) error {
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (s *syncSelfRef) TryTell(ctx context.Context, msg Msg) error {
+	return s.Tell(ctx, msg)
+}
+
 // newTestActor constructs an Actor wired to a synchronous self-ref so
 // internal AfterFunc callbacks loop back into Receive on the same
 // goroutine that drove the schedule.
@@ -213,6 +219,14 @@ func (m *mockTickCallback) Tell(_ context.Context, msg *TickFiredMsg) error {
 	m.messages = append(m.messages, *msg)
 
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (m *mockTickCallback) TryTell(ctx context.Context,
+	msg *TickFiredMsg) error {
+
+	return m.Tell(ctx, msg)
 }
 
 // count returns how many tick messages have arrived.

--- a/timeout/log.go
+++ b/timeout/log.go
@@ -1,0 +1,17 @@
+package timeout
+
+import (
+	"context"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/build"
+)
+
+// Subsystem defines the logging code for this subsystem.
+const Subsystem = "TMOT"
+
+// logger resolves the logger attached to ctx, falling back to
+// btclog.Disabled when no logger was wired into the actor runtime.
+func logger(ctx context.Context) btclog.Logger {
+	return build.LoggerFromContext(ctx)
+}

--- a/timeout/log.go
+++ b/timeout/log.go
@@ -10,8 +10,20 @@ import (
 // Subsystem defines the logging code for this subsystem.
 const Subsystem = "TMOT"
 
-// logger resolves the logger attached to ctx, falling back to
-// btclog.Disabled when no logger was wired into the actor runtime.
-func logger(ctx context.Context) btclog.Logger {
+// logger returns the logger the actor was configured with, falling back to
+// whatever the calling context carries.
+//
+// The injected logger is the one that actually works in the daemon. An
+// actor's lifecycle context descends from context.Background() rather than
+// from the actor system's logger-carrying context, so a receive loop that
+// resolves its logger from ctx alone writes every line to btclog.Disabled.
+// Everything this actor reports about failed deliveries would then be
+// invisible in a running daemon, which is exactly when someone needs to read
+// it.
+func (a *Actor) logger(ctx context.Context) btclog.Logger {
+	if a.log != btclog.Disabled {
+		return a.log
+	}
+
 	return build.LoggerFromContext(ctx)
 }

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -147,12 +147,16 @@ func (b *blockingNotifyRef) Tell(ctx context.Context, _ Notification) error {
 	return ctx.Err()
 }
 
-// TryTell delegates to Tell, which is all this double needs: no test
-// drives the non-blocking path through it.
-func (b *blockingNotifyRef) TryTell(ctx context.Context,
-	msg Notification) error {
+// TryTell reports a full mailbox. Delegating to Tell would park the caller
+// on b.release, which is precisely what a non-blocking send promises never to
+// do; a subscriber that cannot be sent to without blocking is one whose
+// mailbox is full, so that is what this double reports.
+func (b *blockingNotifyRef) TryTell(_ context.Context, _ Notification) error {
+	b.mu.Lock()
+	b.attempts++
+	b.mu.Unlock()
 
-	return b.Tell(ctx, msg)
+	return actor.ErrMailboxFull
 }
 
 // attemptsCount returns the number of attempted notifications.
@@ -220,12 +224,13 @@ func (d *deferringNotifyRef) Tell(_ context.Context, n Notification) error {
 	return nil
 }
 
-// TryTell delegates to Tell, which is all this double needs: no test
-// drives the non-blocking path through it.
-func (d *deferringNotifyRef) TryTell(ctx context.Context,
-	msg Notification) error {
-
-	return d.Tell(ctx, msg)
+// TryTell refuses to guess. This double exists to model a Tell that completes
+// long after the caller's deadline, which has no non-blocking equivalent:
+// answering "full" would lose the deferred completion the tests turn on, and
+// delegating to Tell would park a caller that was promised it would not be.
+// A test that routes here needs a different double.
+func (d *deferringNotifyRef) TryTell(_ context.Context, _ Notification) error {
+	panic("deferringNotifyRef does not model TryTell")
 }
 
 // waitStarted blocks until the first Tell has begun, so the test can

--- a/txconfirm/actor_test.go
+++ b/txconfirm/actor_test.go
@@ -147,6 +147,14 @@ func (b *blockingNotifyRef) Tell(ctx context.Context, _ Notification) error {
 	return ctx.Err()
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (b *blockingNotifyRef) TryTell(ctx context.Context,
+	msg Notification) error {
+
+	return b.Tell(ctx, msg)
+}
+
 // attemptsCount returns the number of attempted notifications.
 func (b *blockingNotifyRef) attemptsCount() int {
 	b.mu.Lock()
@@ -212,6 +220,14 @@ func (d *deferringNotifyRef) Tell(_ context.Context, n Notification) error {
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (d *deferringNotifyRef) TryTell(ctx context.Context,
+	msg Notification) error {
+
+	return d.Tell(ctx, msg)
+}
+
 // waitStarted blocks until the first Tell has begun, so the test can
 // release after the actor-side timeout has fired.
 func (d *deferringNotifyRef) waitStarted(t *testing.T) {
@@ -268,6 +284,14 @@ func (r *contextInspectNotifyRef) Tell(ctx context.Context,
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (r *contextInspectNotifyRef) TryTell(ctx context.Context,
+	msg Notification) error {
+
+	return r.Tell(ctx, msg)
+}
+
 // snapshot returns the inspected context values and delivered messages.
 func (r *contextInspectNotifyRef) snapshot() (bool, error, []Notification) {
 	r.mu.Lock()
@@ -300,6 +324,12 @@ func (r *retryNotifyRef) Tell(ctx context.Context, msg Notification) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (r *retryNotifyRef) TryTell(ctx context.Context, msg Notification) error {
+	return r.Tell(ctx, msg)
 }
 
 // attemptsCount returns the number of attempted notifications.
@@ -380,6 +410,14 @@ func (f *fakeChainSourceRef) Tell(_ context.Context,
 	_ chainsource.ChainSourceMsg) error {
 
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (f *fakeChainSourceRef) TryTell(ctx context.Context,
+	msg chainsource.ChainSourceMsg) error {
+
+	return f.Tell(ctx, msg)
 }
 
 // Ask handles the chainsource request synchronously and returns an already

--- a/txconfirm/broadcaster_test.go
+++ b/txconfirm/broadcaster_test.go
@@ -44,6 +44,14 @@ func (s *staticChainSourceRef) Tell(_ context.Context,
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (s *staticChainSourceRef) TryTell(ctx context.Context,
+	msg chainsource.ChainSourceMsg) error {
+
+	return s.Tell(ctx, msg)
+}
+
 // Ask handles the chainsource request synchronously and returns an already
 // completed future.
 func (s *staticChainSourceRef) Ask(ctx context.Context,
@@ -287,6 +295,14 @@ func (f *failingNotifyRef) ID() string {
 // Tell always returns an error.
 func (f *failingNotifyRef) Tell(_ context.Context, _ Notification) error {
 	return fmt.Errorf("notify failed")
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (f *failingNotifyRef) TryTell(ctx context.Context,
+	msg Notification) error {
+
+	return f.Tell(ctx, msg)
 }
 
 // testMappedMsg is a small actor message used to cover MapNotification.

--- a/unroll/actor_test.go
+++ b/unroll/actor_test.go
@@ -159,6 +159,14 @@ func (f *fakeTxConfirmRef) Tell(context.Context, txconfirm.Msg) error {
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (f *fakeTxConfirmRef) TryTell(ctx context.Context,
+	msg txconfirm.Msg) error {
+
+	return f.Tell(ctx, msg)
+}
+
 // Ask records the request and returns an awaiting-confirmation response.
 func (f *fakeTxConfirmRef) Ask(_ context.Context,
 	msg txconfirm.Msg) actor.Future[txconfirm.Resp] {
@@ -442,6 +450,14 @@ func (f *fakeChainSourceRef) Tell(_ context.Context,
 	}
 
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (f *fakeChainSourceRef) TryTell(ctx context.Context,
+	msg chainsource.ChainSourceMsg) error {
+
+	return f.Tell(ctx, msg)
 }
 
 // Ask returns fixed fee-estimate responses.

--- a/unroll/registry.go
+++ b/unroll/registry.go
@@ -42,6 +42,12 @@ const (
 	// terminalChildDrainTimeout bounds the cleanup probe used before
 	// stopping a terminal child actor.
 	terminalChildDrainTimeout = 30 * time.Second
+
+	// selfTellRetry is how long the registry waits before re-offering a
+	// message to its own mailbox that had no room for it. It is short
+	// because the mailbox only stays full for as long as the registry is
+	// behind on its own queue.
+	selfTellRetry = 50 * time.Millisecond
 )
 
 // RegistryRecord stores the coarse control-plane view of one unroll target.
@@ -1602,13 +1608,43 @@ func (r *registryBehavior) persistRecordAsync(target wire.OutPoint, attempt int,
 			result.Err = err.Error()
 		}
 
-		_ = r.selfRef.Tell(context.Background(), result)
+		r.tellSelf(result)
 	}()
+}
+
+// tellSelf hands a message to the registry's own mailbox without ever parking
+// the caller.
+//
+// A blocking send here is a deadlock waiting to happen, because most callers
+// are the registry's own receive goroutine: with the mailbox full, the send
+// waits for room that only the sender itself could make. The rest are
+// detached goroutines, where a blocking send instead parks one goroutine per
+// event for as long as the registry stays behind.
+//
+// A mailbox with no room therefore re-arms the send on a short delay. This is
+// all the registry's own follow-up work, so deferring beats dropping, and a
+// stopped registry ends the chain since no delay repairs a closed mailbox.
+func (r *registryBehavior) tellSelf(msg RegistryMsg) {
+	err := r.selfRef.TryTell(context.Background(), msg)
+	if err == nil {
+		return
+	}
+
+	if errors.Is(err, actor.ErrActorTerminated) ||
+		errors.Is(err, actor.ErrMailboxClosed) {
+		return
+	}
+
+	// The retry runs off the registry goroutine, so it must not touch
+	// registry state; re-offering the same message is the whole of it.
+	time.AfterFunc(selfTellRetry, func() {
+		r.tellSelf(msg)
+	})
 }
 
 // requestPersist enqueues one immediate persistence attempt for the target.
 func (r *registryBehavior) requestPersist(target wire.OutPoint, attempt int) {
-	_ = r.selfRef.Tell(context.Background(), &persistActiveRecordMsg{
+	r.tellSelf(&persistActiveRecordMsg{
 		Outpoint: target,
 		Attempt:  attempt,
 	})
@@ -1621,11 +1657,10 @@ func (r *registryBehavior) schedulePersistRetry(target wire.OutPoint,
 	delay := persistRetryDelay(attempt)
 
 	time.AfterFunc(delay, func() {
-		msg := &persistActiveRecordMsg{
+		r.tellSelf(&persistActiveRecordMsg{
 			Outpoint: target,
 			Attempt:  attempt,
-		}
-		_ = r.selfRef.Tell(context.Background(), msg)
+		})
 	})
 }
 

--- a/unroll/registry_exit_test.go
+++ b/unroll/registry_exit_test.go
@@ -41,6 +41,14 @@ func (c *captureExitObserver) Tell(_ context.Context,
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (c *captureExitObserver) TryTell(ctx context.Context,
+	msg vtxo.ManagerMsg) error {
+
+	return c.Tell(ctx, msg)
+}
+
 // notifications returns a copy of the captured notifications.
 func (c *captureExitObserver) notifications() []*vtxo.ExitOutcomeNotification {
 	c.mu.Lock()

--- a/unroll/registry_self_tell_test.go
+++ b/unroll/registry_self_tell_test.go
@@ -1,0 +1,174 @@
+package unroll
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/stretchr/testify/require"
+)
+
+// wedgeableRegistryRef is a self-ref double that models a registry mailbox
+// with no room. Tell parks the caller until the test ends, which is what the
+// real mailbox does when it is full; TryTell reports the configured error
+// until the test lets a send through.
+type wedgeableRegistryRef struct {
+	mu sync.Mutex
+
+	// tryErr is returned by the next TryTell. Once failures runs out it
+	// is cleared, so the send after that succeeds.
+	tryErr error
+
+	// failures is how many more times TryTell reports tryErr.
+	failures int
+
+	// tryCalls counts every TryTell, delivered or not.
+	tryCalls int
+
+	// delivered holds the messages TryTell accepted.
+	delivered []RegistryMsg
+}
+
+// ID identifies the double in log lines.
+func (w *wedgeableRegistryRef) ID() string {
+	return "wedged-registry"
+}
+
+// Tell blocks forever, standing in for a send into a mailbox that nothing is
+// draining. Any caller that reaches this has reintroduced the bug.
+func (w *wedgeableRegistryRef) Tell(ctx context.Context, _ RegistryMsg) error {
+	<-ctx.Done()
+
+	return ctx.Err()
+}
+
+// TryTell reports the configured failure until the test's budget runs out,
+// then accepts the message.
+func (w *wedgeableRegistryRef) TryTell(_ context.Context,
+	msg RegistryMsg) error {
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.tryCalls++
+
+	if w.failures > 0 {
+		w.failures--
+
+		return w.tryErr
+	}
+
+	w.delivered = append(w.delivered, msg)
+
+	return nil
+}
+
+// counts returns the number of attempted and delivered sends.
+func (w *wedgeableRegistryRef) counts() (int, int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.tryCalls, len(w.delivered)
+}
+
+// newSelfTellRegistry builds the bare registry behavior these tests need. The
+// self-tell path touches no registry state, so nothing else has to be wired.
+func newSelfTellRegistry(ref *wedgeableRegistryRef) *registryBehavior {
+	return &registryBehavior{
+		log:     btclog.Disabled,
+		selfRef: ref,
+	}
+}
+
+// TestRegistryRequestPersistDoesNotBlock is the deadlock regression test.
+// requestPersist runs on the registry's own receive goroutine, so a blocking
+// send into its own full mailbox waits for room that only the parked
+// goroutine could make: the registry wedges until shutdown. The call has to
+// return whether or not the mailbox had room.
+func TestRegistryRequestPersistDoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	ref := &wedgeableRegistryRef{
+		tryErr: actor.ErrMailboxFull,
+
+		// Fail every attempt for the duration of the test, so nothing
+		// but a non-blocking send can let this call return.
+		failures: 1 << 30,
+	}
+	r := newSelfTellRegistry(ref)
+
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+
+		r.requestPersist(wire.OutPoint{Index: 7}, 0)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("requestPersist parked on a full self-mailbox")
+	}
+}
+
+// TestRegistrySelfTellRetriesUntilDelivered pins the other half of the
+// contract: not blocking must not mean dropping. The registry's persistence
+// messages are its own follow-up work, and nothing else re-derives them, so a
+// send that finds no room has to come back for it.
+func TestRegistrySelfTellRetriesUntilDelivered(t *testing.T) {
+	t.Parallel()
+
+	ref := &wedgeableRegistryRef{
+		tryErr:   actor.ErrMailboxFull,
+		failures: 2,
+	}
+	r := newSelfTellRegistry(ref)
+
+	r.requestPersist(wire.OutPoint{Index: 9}, 3)
+
+	require.Eventually(t, func() bool {
+		_, delivered := ref.counts()
+
+		return delivered == 1
+	}, 5*time.Second, 10*time.Millisecond)
+
+	attempts, _ := ref.counts()
+	require.Equal(t, 3, attempts)
+
+	ref.mu.Lock()
+	defer ref.mu.Unlock()
+
+	// The retry has to carry the original message, not a fresh one: the
+	// attempt count drives the store's backoff.
+	msg, ok := ref.delivered[0].(*persistActiveRecordMsg)
+	require.True(t, ok)
+	require.Equal(t, 3, msg.Attempt)
+	require.Equal(t, uint32(9), msg.Outpoint.Index)
+}
+
+// TestRegistrySelfTellStopsOnTerminal verifies that a registry which is gone
+// for good ends the retry chain. No delay repairs a terminated actor, so
+// retrying one just burns timers until the process exits.
+func TestRegistrySelfTellStopsOnTerminal(t *testing.T) {
+	t.Parallel()
+
+	ref := &wedgeableRegistryRef{
+		tryErr:   actor.ErrActorTerminated,
+		failures: 1 << 30,
+	}
+	r := newSelfTellRegistry(ref)
+
+	r.requestPersist(wire.OutPoint{Index: 11}, 0)
+
+	// Well past several retry delays, so a live chain would have shown up
+	// as further attempts.
+	time.Sleep(10 * selfTellRetry)
+
+	attempts, delivered := ref.counts()
+	require.Equal(t, 1, attempts)
+	require.Zero(t, delivered)
+}

--- a/unroll/registry_test.go
+++ b/unroll/registry_test.go
@@ -301,6 +301,14 @@ func (f *fakeRegistryChainSourceRef) Tell(_ context.Context,
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (f *fakeRegistryChainSourceRef) TryTell(ctx context.Context,
+	msg chainsource.ChainSourceMsg) error {
+
+	return f.Tell(ctx, msg)
+}
+
 // Ask returns fixed best-height and fee-estimate responses.
 func (f *fakeRegistryChainSourceRef) Ask(_ context.Context,
 	msg chainsource.ChainSourceMsg,
@@ -506,6 +514,12 @@ func (r *terminalDrainRef) Tell(context.Context, Msg) error {
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (r *terminalDrainRef) TryTell(ctx context.Context, msg Msg) error {
+	return r.Tell(ctx, msg)
+}
+
 func (r *terminalDrainRef) Ask(ctx context.Context,
 	msg Msg) actor.Future[Resp] {
 
@@ -552,6 +566,14 @@ func (n noopRegistryTellRef) ID() string {
 
 func (n noopRegistryTellRef) Tell(context.Context, RegistryMsg) error {
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (n noopRegistryTellRef) TryTell(ctx context.Context,
+	msg RegistryMsg) error {
+
+	return n.Tell(ctx, msg)
 }
 
 // TestRegistryEnsureDedupesSameTarget verifies that the registry creates one

--- a/vtxo/actor_test.go
+++ b/vtxo/actor_test.go
@@ -32,6 +32,14 @@ func (n noopChainSourceRef) Tell(_ context.Context,
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (n noopChainSourceRef) TryTell(ctx context.Context,
+	msg chainsource.ChainSourceMsg) error {
+
+	return n.Tell(ctx, msg)
+}
+
 func (n noopChainSourceRef) Ask(_ context.Context,
 	msg chainsource.ChainSourceMsg,
 ) actor.Future[chainsource.ChainSourceResp] {
@@ -78,6 +86,14 @@ func (c *cancelSensitiveChainResolverRef) Tell(ctx context.Context,
 	c.seen <- err
 
 	return err
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (c *cancelSensitiveChainResolverRef) TryTell(ctx context.Context,
+	msg ExpiringNotification) error {
+
+	return c.Tell(ctx, msg)
 }
 
 var _ actor.ActorRef[

--- a/vtxo/chain_resolver.go
+++ b/vtxo/chain_resolver.go
@@ -73,3 +73,24 @@ func (l *LazyChainResolver) Tell(ctx context.Context,
 
 	return t.Tell(ctx, msg)
 }
+
+// TryTell forwards the message to the real target without blocking. Before
+// the target is wired the notification is buffered, which never blocks
+// either, so this path is safe to call from a receive goroutine.
+func (l *LazyChainResolver) TryTell(ctx context.Context,
+	msg ExpiringNotification) error {
+
+	l.mu.Lock()
+	t := l.target
+	if t == nil {
+		l.buffered = append(l.buffered, bufferedNotification{
+			msg: msg,
+		})
+		l.mu.Unlock()
+
+		return nil
+	}
+	l.mu.Unlock()
+
+	return t.TryTell(ctx, msg)
+}

--- a/vtxo/harness_test.go
+++ b/vtxo/harness_test.go
@@ -803,6 +803,14 @@ func (m *mockRoundActorRef) Tell(
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (m *mockRoundActorRef) TryTell(ctx context.Context,
+	msg actormsg.RoundReceivable) error {
+
+	return m.Tell(ctx, msg)
+}
+
 // getMessages returns all captured messages.
 func (m *mockRoundActorRef) getMessages() []actormsg.RoundReceivable {
 	m.mu.Lock()
@@ -838,6 +846,12 @@ func (m *mockManagerRef) Tell(_ context.Context, msg ManagerMsg) error {
 	m.messages = append(m.messages, msg)
 
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (m *mockManagerRef) TryTell(ctx context.Context, msg ManagerMsg) error {
+	return m.Tell(ctx, msg)
 }
 
 func (m *mockManagerRef) getMessages() []ManagerMsg {
@@ -880,6 +894,14 @@ func (m *mockChainResolverRef) Tell(
 	m.messages = append(m.messages, msg)
 
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (m *mockChainResolverRef) TryTell(ctx context.Context,
+	msg ExpiringNotification) error {
+
+	return m.Tell(ctx, msg)
 }
 
 // getMessages returns all captured messages.

--- a/vtxo/manager_admission_test.go
+++ b/vtxo/manager_admission_test.go
@@ -54,6 +54,14 @@ func (m *mockVTXOActorRef) Tell(_ context.Context,
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (m *mockVTXOActorRef) TryTell(ctx context.Context,
+	msg actormsg.VTXOActorMsg) error {
+
+	return m.Tell(ctx, msg)
+}
+
 // Ask processes the event through the real FSM state and returns a
 // completed Future with the result.
 func (m *mockVTXOActorRef) Ask(ctx context.Context,
@@ -120,6 +128,14 @@ func (c *capturingManagerRef) Tell(_ context.Context, msg ManagerMsg) error {
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (c *capturingManagerRef) TryTell(ctx context.Context,
+	msg ManagerMsg) error {
+
+	return c.Tell(ctx, msg)
+}
+
 // captured returns a snapshot of the recorded messages.
 func (c *capturingManagerRef) captured() []ManagerMsg {
 	c.mu.Lock()
@@ -148,6 +164,14 @@ func (b *blockingVTXOActorRef) Tell(_ context.Context,
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (b *blockingVTXOActorRef) TryTell(ctx context.Context,
+	msg actormsg.VTXOActorMsg) error {
+
+	return b.Tell(ctx, msg)
+}
+
 // Ask returns a future that remains pending until the await context ends.
 func (b *blockingVTXOActorRef) Ask(_ context.Context,
 	_ actormsg.VTXOActorMsg) actor.Future[actormsg.VTXOActorResp] {
@@ -172,6 +196,14 @@ func (f failingChainSourceRef) Tell(_ context.Context,
 	_ chainsource.ChainSourceMsg) error {
 
 	return nil
+}
+
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (f failingChainSourceRef) TryTell(ctx context.Context,
+	msg chainsource.ChainSourceMsg) error {
+
+	return f.Tell(ctx, msg)
 }
 
 // Ask returns a failed future for every chain-source request.

--- a/vtxo/manager_expiry_reconcile_test.go
+++ b/vtxo/manager_expiry_reconcile_test.go
@@ -31,6 +31,14 @@ func (b *bestHeightRef) Tell(_ context.Context,
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (b *bestHeightRef) TryTell(ctx context.Context,
+	msg chainsource.ChainSourceMsg) error {
+
+	return b.Tell(ctx, msg)
+}
+
 // Ask returns the configured best height.
 func (b *bestHeightRef) Ask(_ context.Context,
 	msg chainsource.ChainSourceMsg,

--- a/waved/credit_registry.go
+++ b/waved/credit_registry.go
@@ -28,7 +28,9 @@ func (s *Server) initCreditRegistry(ctx context.Context) error {
 	// OOR timeout actor. When a per-operation poll timer fires, the
 	// callback ref maps the expiry into a ResumeCreditOpRequest told to the
 	// registry.
-	creditTimeoutBehavior := timeout.NewActor()
+	creditTimeoutBehavior := timeout.NewActorWithConfig(timeout.Config{
+		Log: fn.Some(s.subLogger(timeout.Subsystem)),
+	})
 	creditTimeoutKey := actor.NewServiceKey[timeout.Msg, timeout.Resp](
 		"credit-timeout",
 	)

--- a/waved/logging.go
+++ b/waved/logging.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lightninglabs/wavelength/oor"
 	"github.com/lightninglabs/wavelength/round"
 	"github.com/lightninglabs/wavelength/serverconn"
+	"github.com/lightninglabs/wavelength/timeout"
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightninglabs/wavelength/wallet"
 	lndbuild "github.com/lightningnetwork/lnd/build"
@@ -33,6 +34,7 @@ var allSubsystems = []string{
 	lwwallet.Subsystem,
 	btcwbackend.Subsystem,
 	serverconn.Subsystem,
+	timeout.Subsystem,
 	chainbackends.Subsystem,
 	chainbackends.LndClientSubsystem,
 	chainfees.Subsystem,

--- a/waved/rpc_oor_idempotency_test.go
+++ b/waved/rpc_oor_idempotency_test.go
@@ -1211,6 +1211,14 @@ func (f *fakeOORServerConn) Tell(context.Context,
 	return nil
 }
 
+// TryTell delegates to Tell, which is all this double needs: no test
+// drives the non-blocking path through it.
+func (f *fakeOORServerConn) TryTell(ctx context.Context,
+	msg serverconn.ServerConnMsg) error {
+
+	return f.Tell(ctx, msg)
+}
+
 // noopOORHandler is an oor.OutboxHandler stub used to satisfy the registry
 // constructor's required-dep check in tests that exercise the RPC idempotency
 // pre-flight rather than the incoming receive path.

--- a/waved/server.go
+++ b/waved/server.go
@@ -5991,6 +5991,13 @@ func (f *faultyUnrollTxConfirm) Tell(ctx context.Context,
 	return f.inner.Tell(ctx, msg)
 }
 
+// TryTell forwards non-blocking fire-and-forget messages to the real actor.
+func (f *faultyUnrollTxConfirm) TryTell(ctx context.Context,
+	msg txconfirm.Msg) error {
+
+	return f.inner.TryTell(ctx, msg)
+}
+
 // Ask rejects confirmation requests with a failed state and forwards
 // everything else to the real actor.
 func (f *faultyUnrollTxConfirm) Ask(ctx context.Context,

--- a/waved/server.go
+++ b/waved/server.go
@@ -1235,7 +1235,9 @@ func (s *Server) run(ctx context.Context, shutdownFn func()) error {
 	// timer scheduling for any subsystem that needs deadlines.
 	// Start receives the registered ref so the actor's clock-driven
 	// fire callbacks can self-tell through the actor system mailbox.
-	timeoutBehavior := timeout.NewActor()
+	timeoutBehavior := timeout.NewActorWithConfig(timeout.Config{
+		Log: fn.Some(s.subLogger(timeout.Subsystem)),
+	})
 	timeoutRef := actor.RegisterWithSystem(
 		s.actorSystem, "timeout",
 		actor.NewServiceKey[timeout.Msg, timeout.Resp]("timeout"),
@@ -4513,7 +4515,9 @@ func (s *Server) initOORActor(ctx context.Context,
 	// AfterFunc callbacks self-tell through a real mailbox; the
 	// signing handler holds the ActorRef and Tells schedule requests
 	// rather than calling Receive directly.
-	oorTimeoutBehavior := timeout.NewActor()
+	oorTimeoutBehavior := timeout.NewActorWithConfig(timeout.Config{
+		Log: fn.Some(s.subLogger(timeout.Subsystem)),
+	})
 	oorTimeoutKey := actor.NewServiceKey[timeout.Msg, timeout.Resp](
 		"oor-timeout",
 	)


### PR DESCRIPTION
In this PR, we close out the wavelength side of the actor deadlock fixed in
[lumos#734](https://github.com/lightninglabs/lumos/pull/734): two actors
wedged in production for 8.5 hours because a receive goroutine blocked on an
unbounded Tell into a full peer mailbox while that peer awaited an Ask back
with no deadline. lumos bounded its sends with context timeouts as a stopgap,
but both root causes live in this repo: the ref interface hides the
non-blocking send the mailbox already implements, and the timeout actor
(a process-wide singleton in lumosd, carrying every subsystem's timers)
delivers callbacks with unbounded sends from its single receive goroutine.
See each commit message for a detailed description w.r.t the incremental
changes.

## TryTell on the refs

The mailbox layer has had a non-blocking TrySend all along; only the
`TellOnlyRef`/`ActorRef` surface hid it. We add `TryTell(ctx, msg) error`:
it never parks the calling goroutine, a full mailbox returns `ErrMailboxFull`
so the caller can drop, stash, or schedule a retry, and everything else
matches Tell. This is deliberately a hard interface method rather than an
optional capability check: the bug class being fixed is a silent fallback to
a blocking send, and we want the compiler to name every implementer rather
than letting one quietly keep the old behavior. Downstream, that means the
next lumos pin bump breaks its ref mocks until they grow a one-line
delegation, and in exchange lumos can replace the context.WithTimeout
wrappers from #734 with TryTell for a strictly better failure mode: fail in
nanoseconds instead of burning the deadline against a wedged peer.

One implementation deserves a close read: the durable ref's TryTell is a DB
write bounded at 100ms, never returns `ErrMailboxFull` (the queue is an
unbounded table), and drops the caller's transaction, so swapping Tell for
TryTell inside a commit closure silently breaks the atomic-enqueue
guarantee. The interface doc spells all three departures out, and the
durable path has its own tests pinning them.

## The timeout actor never blocks, and never drops

Callback delivery now goes through TryTell from the receive loop. A delivery
that fails for any non-terminal reason (full mailbox, a slow durable write, a
router with no registered targets) requeues the same fire into the actor's
own timer wheel with doubling backoff, 1s base capped at 30s, one entry per
outstanding reminder no matter how many retries it takes. Only a dead target
(actor terminated, mailbox closed) releases the entry. Nothing is ever
silently dropped: the trade is bounded memory, unbounded time, and a Warn
per attempt naming the target. The clock path coalesces timer fires through
a non-blocking self-signal instead of stacking one parked goroutine per fire
against a backed-up mailbox.

This also fixes a pre-existing cancellation race: the old code deleted the
entry before delivering, so a Cancel racing a fire could not actually stop
it. Entries now live until delivered, so Cancel owns the retry chain too.

Two contract notes for consumers. A recurring tick delivered late carries
its original FiredAt, and a slow consumer stretches its own cadence rather
than accumulating ticks; we checked the one production consumer (lumos's
rounds actor) and it discards FiredAt entirely, treating a tick as a
stateless poll, so the pin bump is safe on this axis. And the timeout actor
now carries a config-injected logger registered as the TMOT subsystem;
before this, its delivery-failure logs resolved to a disabled logger and the
entire failure mode was invisible in a running daemon.

## Testing

The regression tests are mutation-verified: reverting delivery to a blocking
Tell freezes the receive loop and fails the responsiveness test, and
reverting the self-signal to a blocking Tell leaks one goroutine per timer
fire and fails the leak test. The retry state machine is covered against the
adversarial interleavings (cancel during an armed retry, reschedule
superseding an armed retry, terminal vs transient errors on both the oneshot
and recurring paths), and every TryTell implementation, including the
durable, router, and wrapper refs, has its semantics pinned. Full suites
pass with -race across baselib, timeout, and every downstream package whose
test doubles grew the new method.


## Two more instances of the same shapes

An adversarial pass over the finished branch went looking for other live
instances of what we just fixed, and turned up one of each. Both are
pre-existing, and both are small enough to fold in here rather than leave
next to a change whose whole point is that these shapes are bugs.

The unroll registry had the blocking-send shape in its worst form. Its
`requestPersist` enqueues a persistence attempt by Telling the registry's own
mailbox, and all but one of its callers run on the registry's receive
goroutine. The send is unbounded, the mailbox holds 64, and the context is a
background one, so a registry that ever falls behind parks the single
goroutine that could drain it and waits for room that only it could make.
That is not the slow leak the timeout actor had, it is a wedge that nothing
short of shutdown clears. The two detached-goroutine self-sends alongside it
have the milder version. All three now use TryTell and re-arm, and the
deadlock test is mutation-verified: put the blocking Tell back and it hangs.

The round FSM had the invisible-logger shape. Its error reporter resolved
through `build.LoggerFromContext` on the actor's lifecycle context, which
descends from `context.Background()`, so every "FSM error" landed in
`btclog.Disabled` exactly like the timeout actor's delivery failures did.
Both construction sites already build a prefixed `fsmLogger` for the FSM
itself, so the reporter just takes that.

Two findings from the same pass are filed rather than fixed here, because
they are wider than this change: #1086 (the actor framework's own per-actor
diagnostics resolve to a disabled logger) and #1087 (the residual blocking
Tells on the serverconn ingress and unroll late-admission paths).
