### PR TITLE
lib: asset-aware Ark tree primitives (M1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	github.com/lightninglabs/loop v0.33.0-beta
 	github.com/lightninglabs/neutrino v0.18.0
 	github.com/lightninglabs/neutrino/cache v1.1.4
-	github.com/lightninglabs/taproot-assets v0.7.1-0.20260729123750-e798aabc7f20
-	github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260729123750-e798aabc7f20 // indirect
+	github.com/lightninglabs/taproot-assets v0.7.1-0.20260804093026-95bd8d412bef
+	github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260804093026-95bd8d412bef // indirect
 	github.com/lightninglabs/wavelength/baselib v0.0.0-00010101000000-000000000000
 	github.com/lightningnetwork/lightning-onion v1.4.0
 	github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260630214209-40c64f9db30d

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/btcsuite/btcd/txscript/v2 v2.0.0
 	github.com/btcsuite/btcd/wire/v2 v2.0.0
 	github.com/lightninglabs/go-wasmsqlite v0.0.0-20260627090804-0dce68fc5287
-	github.com/lightninglabs/tap-sdk v0.1.1-0.20260803083718-078e401f418d
+	github.com/lightninglabs/tap-sdk v0.1.1-0.20260804174327-7ab9e063bdca
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1078,8 +1078,8 @@ github.com/lightninglabs/neutrino/cache v1.1.4 h1:KVtvUmBwYr7eKtjfjHG/q6/cQlcrjH
 github.com/lightninglabs/neutrino/cache v1.1.4/go.mod h1:ZqLzxghPggIRfNXeAZN1VtTKofMyK/ALI6niYsPH6OE=
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS/00EiEg0qp0FhehxnQfk3vv8U6Xt3nN+rTY=
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-github.com/lightninglabs/tap-sdk v0.1.1-0.20260803083718-078e401f418d h1:cPbjG7fqblZw0Ji4aJ4G+/GrV16UjqZv2nNv7K4tz8E=
-github.com/lightninglabs/tap-sdk v0.1.1-0.20260803083718-078e401f418d/go.mod h1:RI0Z+A0ySP5itemPcUcSe8czEjczOzRk9IK6zaF9rnc=
+github.com/lightninglabs/tap-sdk v0.1.1-0.20260804174327-7ab9e063bdca h1:JOr8vlpdR5c0H7/1H3SEvKG/plbT75GTV+zEWonugDM=
+github.com/lightninglabs/tap-sdk v0.1.1-0.20260804174327-7ab9e063bdca/go.mod h1:RI0Z+A0ySP5itemPcUcSe8czEjczOzRk9IK6zaF9rnc=
 github.com/lightninglabs/taproot-assets v0.7.1-0.20260804093026-95bd8d412bef h1:4vHoQMzUkpkPoNKHT+QdTUbWoWaz0T5CDx6CWsforXM=
 github.com/lightninglabs/taproot-assets v0.7.1-0.20260804093026-95bd8d412bef/go.mod h1:fm0WaNsDpP7jEgR9zMap3hpum7lXVDtjsi783MW9BxY=
 github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260804093026-95bd8d412bef h1:3uhbpFZUp3JwLxSlhdelA56g0dULFfcYlC6Q/wQICk0=

--- a/go.sum
+++ b/go.sum
@@ -1080,10 +1080,10 @@ github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 github.com/lightninglabs/tap-sdk v0.1.1-0.20260803083718-078e401f418d h1:cPbjG7fqblZw0Ji4aJ4G+/GrV16UjqZv2nNv7K4tz8E=
 github.com/lightninglabs/tap-sdk v0.1.1-0.20260803083718-078e401f418d/go.mod h1:RI0Z+A0ySP5itemPcUcSe8czEjczOzRk9IK6zaF9rnc=
-github.com/lightninglabs/taproot-assets v0.7.1-0.20260729123750-e798aabc7f20 h1:UAT9Gyakh2BdelcgATIoC8X8gOL/Kaq0myk+J6MFTIU=
-github.com/lightninglabs/taproot-assets v0.7.1-0.20260729123750-e798aabc7f20/go.mod h1:fm0WaNsDpP7jEgR9zMap3hpum7lXVDtjsi783MW9BxY=
-github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260729123750-e798aabc7f20 h1:kf8jqYz9YS9aN25X5H8NSImc+UQzFXVZxDboEzCxfJU=
-github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260729123750-e798aabc7f20/go.mod h1:RkBWxHKN8JpPtoa/yBK5qZW5svz5pR9GAOT2rUP7oOI=
+github.com/lightninglabs/taproot-assets v0.7.1-0.20260804093026-95bd8d412bef h1:4vHoQMzUkpkPoNKHT+QdTUbWoWaz0T5CDx6CWsforXM=
+github.com/lightninglabs/taproot-assets v0.7.1-0.20260804093026-95bd8d412bef/go.mod h1:fm0WaNsDpP7jEgR9zMap3hpum7lXVDtjsi783MW9BxY=
+github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260804093026-95bd8d412bef h1:3uhbpFZUp3JwLxSlhdelA56g0dULFfcYlC6Q/wQICk0=
+github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260804093026-95bd8d412bef/go.mod h1:RkBWxHKN8JpPtoa/yBK5qZW5svz5pR9GAOT2rUP7oOI=
 github.com/lightningnetwork/lightning-onion v1.4.0 h1:qWE1icOH4AKXRcq1KCzt6P/TesqptgBTP++V7wowTc0=
 github.com/lightningnetwork/lightning-onion v1.4.0/go.mod h1:YDPkvVTVQ6FBBE6Yj93tDd7zA3iTSrryi9xq46i7bKE=
 github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260630214209-40c64f9db30d h1:mDcB9mwuwJXRbDmxps6mBgGs318Iz5ZbOrt0ieEx0os=

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -2879,6 +2879,17 @@ func tapdSyncedToChain(ctx context.Context, addr, tlsPath,
 	return info.SyncedToChain
 }
 
+// TapdTLSCertPath returns the shared tapd instance's TLS certificate
+// path.
+func (h *Harness) TapdTLSCertPath() string {
+	return h.tapdTLSCert
+}
+
+// TapdMacaroonPath returns the shared tapd instance's admin macaroon path.
+func (h *Harness) TapdMacaroonPath() string {
+	return h.tapdMacaroon
+}
+
 // waitForTapdReady waits until tapd's GetInfo RPC responds and reports that
 // tapd is synced to chain.
 func (h *Harness) waitForTapdReady() {

--- a/lib/tree/asset_tree_context.go
+++ b/lib/tree/asset_tree_context.go
@@ -1,0 +1,128 @@
+package tree
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/btcsuite/btcd/wire/v2"
+)
+
+// AssetTreeContext carries the Taproot Asset side of an asset-aware tree
+// through construction, signing, and persistence, keeping the shared Node
+// and Tree types asset-agnostic.
+//
+// Entries live in two keying phases. During structure building, nodes have
+// no inputs yet, so per-node asset amounts are keyed by node identity.
+// Materialization assigns every node its input outpoint and records
+// signing tweaks and sealed packages keyed by that outpoint: unlike node
+// pointers, outpoints survive path extraction (which clones nodes) and
+// serialization, so everything a signer, validator, or store needs is
+// outpoint-addressed.
+//
+// The context is the mutable side-car of an otherwise immutable published
+// *Tree: builders write it, later phases only read it.
+type AssetTreeContext struct {
+	// amountsByNode holds the subtree asset total per node, keyed by
+	// node identity. Populated by the structure pass, consumed by the
+	// materializer to size the asset split at every branch.
+	amountsByNode map[*Node]uint64
+
+	// tweaksByInput holds the taproot signing tweak for the node
+	// transaction spending each outpoint: the parent output's combined
+	// tapscript root, committing to both the sweep leaf and the asset
+	// commitment root.
+	tweaksByInput map[wire.OutPoint][]byte
+
+	// packagesByInput holds the serialized sealed transfer package of
+	// the node transaction spending each outpoint. The package is the
+	// authoritative record of the node's asset transition: its proof
+	// suffixes feed unroll publication and its authenticated summaries
+	// feed validation.
+	packagesByInput map[wire.OutPoint][]byte
+}
+
+// NewAssetTreeContext returns an empty asset tree context.
+func NewAssetTreeContext() *AssetTreeContext {
+	return &AssetTreeContext{
+		amountsByNode:   make(map[*Node]uint64),
+		tweaksByInput:   make(map[wire.OutPoint][]byte),
+		packagesByInput: make(map[wire.OutPoint][]byte),
+	}
+}
+
+// SetNodeAssetAmount records the subtree asset total for a node.
+func (c *AssetTreeContext) SetNodeAssetAmount(node *Node, amount uint64) {
+	c.amountsByNode[node] = amount
+}
+
+// NodeAssetAmount returns the subtree asset total for a node, or zero when
+// the node carries no assets.
+func (c *AssetTreeContext) NodeAssetAmount(node *Node) uint64 {
+	return c.amountsByNode[node]
+}
+
+// SetSigningTweak records the taproot signing tweak for the node
+// transaction spending the given outpoint.
+func (c *AssetTreeContext) SetSigningTweak(input wire.OutPoint, tweak []byte) {
+	c.tweaksByInput[input] = append([]byte(nil), tweak...)
+}
+
+// SigningTweak returns the signing tweak recorded for the node transaction
+// spending the given outpoint, or nil when none was recorded.
+func (c *AssetTreeContext) SigningTweak(input wire.OutPoint) []byte {
+	return c.tweaksByInput[input]
+}
+
+// SetSealedPackage records the serialized sealed transfer package of the
+// node transaction spending the given outpoint.
+func (c *AssetTreeContext) SetSealedPackage(input wire.OutPoint, pkg []byte) {
+	c.packagesByInput[input] = append([]byte(nil), pkg...)
+}
+
+// SealedPackage returns the sealed transfer package recorded for the node
+// transaction spending the given outpoint, or nil when none was recorded.
+func (c *AssetTreeContext) SealedPackage(input wire.OutPoint) []byte {
+	return c.packagesByInput[input]
+}
+
+// TweakLookup adapts the context to the signer sessions: nodes whose input
+// has a recorded tweak sign with it, every other node falls back to the
+// tree-wide sweep root.
+func (c *AssetTreeContext) TweakLookup() TaprootTweakLookup {
+	return func(node *Node) []byte {
+		return c.SigningTweak(node.Input)
+	}
+}
+
+// aggregateAssetAmounts folds per-leaf asset amounts into subtree totals
+// for every node, bottom-up, rejecting uint64 overflow.
+func aggregateAssetAmounts(node *Node, leafAssets map[*Node]uint64,
+	ctx *AssetTreeContext) (uint64, error) {
+
+	if len(node.Children) == 0 {
+		amount := leafAssets[node]
+		ctx.SetNodeAssetAmount(node, amount)
+
+		return amount, nil
+	}
+
+	var total uint64
+	for _, child := range node.Children {
+		childAmount, err := aggregateAssetAmounts(
+			child, leafAssets, ctx,
+		)
+		if err != nil {
+			return 0, err
+		}
+
+		if childAmount > math.MaxUint64-total {
+			return 0, fmt.Errorf("asset amount overflow " +
+				"aggregating subtree totals")
+		}
+		total += childAmount
+	}
+
+	ctx.SetNodeAssetAmount(node, total)
+
+	return total, nil
+}

--- a/lib/tree/asset_tree_context_test.go
+++ b/lib/tree/asset_tree_context_test.go
@@ -1,0 +1,151 @@
+package tree
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// assetTestLeaves returns n leaf descriptors with distinct owners carrying
+// the given asset amounts.
+func assetTestLeaves(t *testing.T, amounts ...uint64) []LeafDescriptor {
+	t.Helper()
+
+	leaves := make([]LeafDescriptor, len(amounts))
+	for i, amount := range amounts {
+		_, owner := createTestKey(t)
+		leaves[i] = LeafDescriptor{
+			PkScript: []byte{
+				0x51,
+				byte(i),
+			},
+			Amount:      10_000,
+			CoSignerKey: owner,
+			AssetAmount: amount,
+		}
+	}
+
+	return leaves
+}
+
+// TestBuildStructureAssetAggregation ensures the structure pass folds
+// per-leaf asset amounts into subtree totals on the asset context, and that
+// BTC-only trees keep a nil context so nothing changes for them.
+func TestBuildStructureAssetAggregation(t *testing.T) {
+	t.Parallel()
+
+	_, operatorKey := createTestKey(t)
+	cfg := StructureConfig{OperatorKey: operatorKey, Radix: 2}
+
+	t.Run("btc-only trees have no asset context", func(t *testing.T) {
+		t.Parallel()
+
+		structure, err := BuildStructure(
+			assetTestLeaves(t, 0, 0, 0), cfg,
+		)
+		require.NoError(t, err)
+		require.Nil(t, structure.AssetContext)
+	})
+
+	t.Run("subtree totals cover every node", func(t *testing.T) {
+		t.Parallel()
+
+		structure, err := BuildStructure(
+			assetTestLeaves(t, 800, 200, 500), cfg,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, structure.AssetContext)
+
+		assetCtx := structure.AssetContext
+		require.EqualValues(
+			t, 1_500, assetCtx.NodeAssetAmount(structure.Root),
+		)
+
+		// Every node's total must equal the sum of its children,
+		// and each leaf must carry one of the input amounts.
+		var leafTotal uint64
+		for node := range structure.Root.NodesIter() {
+			if len(node.Children) == 0 {
+				leafTotal += assetCtx.NodeAssetAmount(node)
+				continue
+			}
+
+			var childSum uint64
+			for _, child := range node.Children {
+				childSum += assetCtx.NodeAssetAmount(child)
+			}
+			require.Equal(
+				t, childSum, assetCtx.NodeAssetAmount(node),
+			)
+		}
+		require.EqualValues(t, 1_500, leafTotal)
+	})
+
+	t.Run("mixed asset and btc leaves", func(t *testing.T) {
+		t.Parallel()
+
+		structure, err := BuildStructure(
+			assetTestLeaves(t, 300, 0), cfg,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, structure.AssetContext)
+		require.EqualValues(
+			t, 300,
+			structure.AssetContext.NodeAssetAmount(structure.Root),
+		)
+	})
+
+	t.Run("overflow rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := BuildStructure(
+			assetTestLeaves(t, math.MaxUint64, 1), cfg,
+		)
+		require.ErrorContains(t, err, "overflow")
+	})
+}
+
+// TestAssetTreeContextTweakLookup ensures the context's lookup feeds signer
+// sessions by input outpoint and defensively copies stored bytes.
+func TestAssetTreeContextTweakLookup(t *testing.T) {
+	t.Parallel()
+
+	assetCtx := NewAssetTreeContext()
+	input := wire.OutPoint{Index: 3}
+	input.Hash[0] = 0xAB
+
+	tweak := bytes.Repeat([]byte{0x07}, 32)
+	assetCtx.SetSigningTweak(input, tweak)
+	tweak[0] = 0xFF
+
+	lookup := assetCtx.TweakLookup()
+	got := lookup(&Node{Input: input})
+	require.Equal(t, bytes.Repeat([]byte{0x07}, 32), got)
+	require.Nil(t, lookup(&Node{Input: wire.OutPoint{Index: 9}}))
+
+	pkg := []byte{0x01, 0x02}
+	assetCtx.SetSealedPackage(input, pkg)
+	pkg[0] = 0xEE
+	require.Equal(
+		t, []byte{0x01, 0x02}, assetCtx.SealedPackage(input),
+	)
+}
+
+// TestAssetTreeContextAmountsByIdentity ensures build-phase amounts are
+// keyed by node identity, not by content.
+func TestAssetTreeContextAmountsByIdentity(t *testing.T) {
+	t.Parallel()
+
+	assetCtx := NewAssetTreeContext()
+	_, key := createTestKey(t)
+	nodeA := &Node{CoSigners: []*btcec.PublicKey{key}}
+	nodeB := &Node{CoSigners: []*btcec.PublicKey{key}}
+
+	assetCtx.SetNodeAssetAmount(nodeA, 42)
+	require.EqualValues(t, 42, assetCtx.NodeAssetAmount(nodeA))
+	require.Zero(t, assetCtx.NodeAssetAmount(nodeB))
+}

--- a/lib/tree/leaf.go
+++ b/lib/tree/leaf.go
@@ -19,4 +19,9 @@ type LeafDescriptor struct {
 	// CoSignerKey is the public key of the leaf owner who must participate
 	// in signing this leaf's transaction along with the operator.
 	CoSignerKey *btcec.PublicKey
+
+	// AssetAmount is the number of Taproot Asset units carried by the
+	// leaf output, in addition to its Amount in satoshis (the asset's
+	// carrier value). Zero means a Bitcoin-only leaf.
+	AssetAmount uint64
 }

--- a/lib/tree/node.go
+++ b/lib/tree/node.go
@@ -216,6 +216,29 @@ func NewBranchNode(input wire.OutPoint, groups [][]LeafDescriptor,
 	}, nil
 }
 
+// ComputeInternalKey computes the MuSig2 aggregate key of the given
+// cosigners without any taproot tweak. Asset-aware materialization hands
+// this untweaked key to tapd, which applies the combined tapscript/asset
+// commitment tweak itself when deriving the anchor output key.
+func ComputeInternalKey(cosigners []*btcec.PublicKey) (*btcec.PublicKey,
+	error) {
+
+	if len(cosigners) == 0 {
+		return nil, fmt.Errorf("no cosigners provided")
+	}
+
+	if len(cosigners) == 1 {
+		return cosigners[0], nil
+	}
+
+	aggKey, _, _, err := musig2.AggregateKeys(cosigners, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate keys: %w", err)
+	}
+
+	return aggKey.PreTweakedKey, nil
+}
+
 // ComputeFinalKey computes the final aggregated public key for signing.
 // This is a helper function that aggregates the cosigners and applies the
 // taproot tweak with the given sweep tapscript root. It handles both

--- a/lib/tree/signing.go
+++ b/lib/tree/signing.go
@@ -169,13 +169,23 @@ type SignerSession struct {
 	txs map[TxID]*TxSignerSession
 }
 
+// TaprootTweakLookup returns the taproot tweak to sign a given node with,
+// or nil to fall back to the tree-wide default. Asset-aware trees commit a
+// per-node Taproot Asset root into each output key, so their signing tweak
+// varies per node instead of being the single sweep tapscript root.
+type TaprootTweakLookup func(node *Node) []byte
+
 // NewSignerSession creates a new signing session for a tree. It
 // automatically extracts the path for the given signer and creates sessions
 // for each transaction in that path.
+//
+// tweakLookup optionally overrides the taproot tweak per node; when nil, or
+// when it returns an empty tweak for a node, sweepTapscriptRoot is used.
+// BTC-only trees pass nil.
 func NewSignerSession(signer input.MuSig2Signer,
 	signerKey *keychain.KeyDescriptor, sweepTapscriptRoot []byte,
-	prevOuts txscript.PrevOutputFetcher,
-	tree *Node) (*SignerSession, error) {
+	prevOuts txscript.PrevOutputFetcher, tree *Node,
+	tweakLookup TaprootTweakLookup) (*SignerSession, error) {
 
 	// Validate inputs.
 	if signer == nil {
@@ -207,8 +217,18 @@ func NewSignerSession(signer input.MuSig2Signer,
 			return fmt.Errorf("failed to create tx: %w", err)
 		}
 
+		// The lookup wins when it names a tweak for this node; the
+		// tree-wide sweep root stays the default for every other
+		// node.
+		taprootTweak := sweepTapscriptRoot
+		if tweakLookup != nil {
+			if nodeTweak := tweakLookup(node); len(nodeTweak) > 0 {
+				taprootTweak = nodeTweak
+			}
+		}
+
 		session, err := node.NewTxSignerSession(
-			signer, sweepTapscriptRoot, signerKey, prevOuts,
+			signer, taprootTweak, signerKey, prevOuts,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create tx session: %w",
@@ -318,4 +338,16 @@ func (s *SignerSession) Signatures(cleanup bool) (
 	}
 
 	return sigs, nil
+}
+
+// SessionIDs returns the MuSig2 session ID for each transaction managed by
+// this signer, keyed by txid. Higher-level coordinators use these to combine
+// partial signatures across signers.
+func (s *SignerSession) SessionIDs() map[TxID]input.MuSig2SessionID {
+	ids := make(map[TxID]input.MuSig2SessionID, len(s.txs))
+	for txid, txSession := range s.txs {
+		ids[txid] = txSession.signSession.SessionID
+	}
+
+	return ids
 }

--- a/lib/tree/signing_test.go
+++ b/lib/tree/signing_test.go
@@ -515,7 +515,7 @@ func TestSignerSession(t *testing.T) {
 		sweepRoot := make([]byte, 32)
 
 		session, err := NewSignerSession(
-			signer, keyDesc, sweepRoot, fetcher, root,
+			signer, keyDesc, sweepRoot, fetcher, root, nil,
 		)
 		require.NoError(t, err)
 		require.NotNil(t, session)
@@ -547,7 +547,7 @@ func TestSignerSession(t *testing.T) {
 		sweepRoot := make([]byte, 32)
 
 		session, err := NewSignerSession(
-			signer, keyDesc, sweepRoot, fetcher, leaf,
+			signer, keyDesc, sweepRoot, fetcher, leaf, nil,
 		)
 		require.Error(t, err)
 		require.Nil(t, session)
@@ -572,7 +572,7 @@ func TestSignerSession(t *testing.T) {
 		sweepRoot := make([]byte, 32)
 
 		session, err := NewSignerSession(
-			signer, keyDesc, sweepRoot, fetcher, leaf,
+			signer, keyDesc, sweepRoot, fetcher, leaf, nil,
 		)
 		require.NoError(t, err)
 
@@ -608,7 +608,7 @@ func TestSignerSession(t *testing.T) {
 			sweepRoot := make([]byte, 32)
 
 			session, err := NewSignerSession(
-				signer, keyDesc, sweepRoot, fetcher, leaf,
+				signer, keyDesc, sweepRoot, fetcher, leaf, nil,
 			)
 			require.NoError(t, err)
 
@@ -665,12 +665,12 @@ func TestSignerSession(t *testing.T) {
 
 		// Create sessions for both signers.
 		session1, err := NewSignerSession(
-			signer1, keyDesc1, sweepRoot, fetcher, leaf,
+			signer1, keyDesc1, sweepRoot, fetcher, leaf, nil,
 		)
 		require.NoError(t, err)
 
 		session2, err := NewSignerSession(
-			signer2, keyDesc2, sweepRoot, fetcher, leaf,
+			signer2, keyDesc2, sweepRoot, fetcher, leaf, nil,
 		)
 		require.NoError(t, err)
 
@@ -725,7 +725,7 @@ func TestSignerSession(t *testing.T) {
 		sweepRoot := make([]byte, 32)
 
 		session, err := NewSignerSession(
-			signer, keyDesc, sweepRoot, fetcher, leaf,
+			signer, keyDesc, sweepRoot, fetcher, leaf, nil,
 		)
 		require.NoError(t, err)
 
@@ -804,7 +804,7 @@ func TestSignerSessionCleanup(t *testing.T) {
 		keyDesc := &keychain.KeyDescriptor{PubKey: pubKey}
 
 		session, err := NewSignerSession(
-			signer, keyDesc, make([]byte, 32), fetcher, tree,
+			signer, keyDesc, make([]byte, 32), fetcher, tree, nil,
 		)
 		require.NoError(t, err)
 		require.Len(t, session.txs, 2)
@@ -827,7 +827,7 @@ func TestSignerSessionCleanup(t *testing.T) {
 		keyDesc := &keychain.KeyDescriptor{PubKey: pubKey}
 
 		session, err := NewSignerSession(
-			signer, keyDesc, make([]byte, 32), fetcher, tree,
+			signer, keyDesc, make([]byte, 32), fetcher, tree, nil,
 		)
 		require.ErrorContains(
 			t, err, "injected session creation failure",
@@ -927,7 +927,7 @@ func TestSignerSessionMultiTx(t *testing.T) {
 		sweepRoot := make([]byte, 32)
 
 		session, err := NewSignerSession(
-			signer, keyDesc, sweepRoot, fetcher, root,
+			signer, keyDesc, sweepRoot, fetcher, root, nil,
 		)
 		require.NoError(t, err)
 
@@ -966,7 +966,7 @@ func TestSignerSessionMultiTx(t *testing.T) {
 		sweepRoot := make([]byte, 32)
 
 		session, err := NewSignerSession(
-			signer, keyDesc, sweepRoot, fetcher, leaf,
+			signer, keyDesc, sweepRoot, fetcher, leaf, nil,
 		)
 		require.NoError(t, err)
 
@@ -1106,11 +1106,13 @@ func TestFullSigningFlow(t *testing.T) {
 
 			session1, err := NewSignerSession(
 				signer1, keyDesc1, sweepRoot, fetcher, leaf,
+				nil,
 			)
 			require.NoError(t, err)
 
 			session2, err := NewSignerSession(
 				signer2, keyDesc2, sweepRoot, fetcher, leaf,
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -1221,11 +1223,13 @@ func TestFullSigningFlow(t *testing.T) {
 
 			session1, err := NewSignerSession(
 				signer1, keyDesc1, sweepRoot, fetcher, root,
+				nil,
 			)
 			require.NoError(t, err)
 
 			session2, err := NewSignerSession(
 				signer2, keyDesc2, sweepRoot, fetcher, root,
+				nil,
 			)
 			require.NoError(t, err)
 

--- a/lib/tree/signing_tweak_test.go
+++ b/lib/tree/signing_tweak_test.go
@@ -1,0 +1,189 @@
+package tree
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingMuSig2Signer wraps the mock signer and captures the taproot
+// tweak of every created session, so tests can assert which tweak each
+// node was signed with.
+type recordingMuSig2Signer struct {
+	*mockMuSig2Signer
+
+	tweaks [][]byte
+}
+
+// MuSig2CreateSession records the session's taproot tweak before
+// delegating to the wrapped mock.
+func (r *recordingMuSig2Signer) MuSig2CreateSession(version input.MuSig2Version,
+	keyLoc keychain.KeyLocator, signers []*btcec.PublicKey,
+	tweaks *input.MuSig2Tweaks, otherNonces [][musig2.PubNonceSize]byte,
+	localNonces *musig2.Nonces) (*input.MuSig2SessionInfo, error) {
+
+	r.tweaks = append(
+		r.tweaks,
+		append(
+			[]byte(nil), tweaks.TaprootTweak...,
+		),
+	)
+
+	return r.mockMuSig2Signer.MuSig2CreateSession(
+		version, keyLoc, signers, tweaks, otherNonces, localNonces,
+	)
+}
+
+// containsTweak reports whether the recorded tweaks include the given one.
+func containsTweak(recorded [][]byte, want []byte) bool {
+	for _, tweak := range recorded {
+		if bytes.Equal(tweak, want) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// newTweakTestPath builds a two-node root→leaf path where the given signer
+// cosigns every node, returning the root and the outpoints identifying each
+// node for lookup keying.
+func newTweakTestPath(t *testing.T, pubKey *btcec.PublicKey) (*Node,
+	wire.OutPoint, wire.OutPoint) {
+
+	t.Helper()
+
+	leaf := createSimpleLeaf(
+		"tweak-leaf", 1_000, []*btcec.PublicKey{pubKey},
+	)
+	root := createSimpleLeaf(
+		"tweak-root", 1_000, []*btcec.PublicKey{pubKey},
+	)
+	root.Children = map[uint32]*Node{0: leaf}
+
+	rootTXID, err := root.TXID()
+	require.NoError(t, err)
+	leaf.Input = wire.OutPoint{Hash: rootTXID, Index: 0}
+
+	return root, root.Input, leaf.Input
+}
+
+// TestSignerSessionTweakLookup ensures a tweak lookup overrides the signing
+// tweak per node, keyed by the node's input outpoint (path extraction clones
+// nodes, so pointer identity cannot be used), and that nodes the lookup does
+// not cover fall back to the sweep tapscript root.
+func TestSignerSessionTweakLookup(t *testing.T) {
+	t.Parallel()
+
+	privKey, pubKey := createTestKey(t)
+	sweepRoot := bytes.Repeat([]byte{0x01}, 32)
+	rootTweak := bytes.Repeat([]byte{0xAA}, 32)
+	leafTweak := bytes.Repeat([]byte{0xBB}, 32)
+
+	t.Run("lookup covers every node", func(t *testing.T) {
+		t.Parallel()
+
+		root, rootOutpoint, leafOutpoint := newTweakTestPath(t, pubKey)
+		tweaksByInput := map[wire.OutPoint][]byte{
+			rootOutpoint: rootTweak,
+			leafOutpoint: leafTweak,
+		}
+
+		signer := &recordingMuSig2Signer{
+			mockMuSig2Signer: newMockMuSig2Signer(privKey),
+		}
+		fetcher, err := root.PrevOutputFetcher(
+			&wire.TxOut{
+				Value: 5_000,
+			},
+		)
+		require.NoError(t, err)
+
+		session, err := NewSignerSession(
+			signer, &keychain.KeyDescriptor{PubKey: pubKey},
+			sweepRoot, fetcher, root,
+			func(node *Node) []byte {
+				return tweaksByInput[node.Input]
+			},
+		)
+		require.NoError(t, err)
+		require.Len(t, session.SessionIDs(), 2)
+
+		require.Len(t, signer.tweaks, 2)
+		require.True(t, containsTweak(signer.tweaks, rootTweak))
+		require.True(t, containsTweak(signer.tweaks, leafTweak))
+		require.False(t, containsTweak(signer.tweaks, sweepRoot))
+	})
+
+	t.Run("uncovered node falls back to sweep root", func(t *testing.T) {
+		t.Parallel()
+
+		root, rootOutpoint, _ := newTweakTestPath(t, pubKey)
+		tweaksByInput := map[wire.OutPoint][]byte{
+			rootOutpoint: rootTweak,
+		}
+
+		signer := &recordingMuSig2Signer{
+			mockMuSig2Signer: newMockMuSig2Signer(privKey),
+		}
+		fetcher, err := root.PrevOutputFetcher(
+			&wire.TxOut{
+				Value: 5_000,
+			},
+		)
+		require.NoError(t, err)
+
+		_, err = NewSignerSession(
+			signer, &keychain.KeyDescriptor{PubKey: pubKey},
+			sweepRoot, fetcher, root,
+			func(node *Node) []byte {
+				return tweaksByInput[node.Input]
+			},
+		)
+		require.NoError(t, err)
+
+		require.Len(t, signer.tweaks, 2)
+		require.True(t, containsTweak(signer.tweaks, rootTweak))
+		require.True(t, containsTweak(signer.tweaks, sweepRoot))
+	})
+}
+
+// TestComputeInternalKey pins the relationship between the untweaked
+// aggregate key and the tweaked final key: applying the taproot tweak to
+// the internal key must yield exactly ComputeFinalKey's result, since tapd
+// derives anchor output keys from the internal key we hand it.
+func TestComputeInternalKey(t *testing.T) {
+	t.Parallel()
+
+	_, err := ComputeInternalKey(nil)
+	require.ErrorContains(t, err, "no cosigners")
+
+	_, single := createTestKey(t)
+	got, err := ComputeInternalKey([]*btcec.PublicKey{single})
+	require.NoError(t, err)
+	require.True(t, single.IsEqual(got))
+
+	cosigners := make([]*btcec.PublicKey, 3)
+	for i := range cosigners {
+		_, cosigners[i] = createTestKey(t)
+	}
+	tweak := bytes.Repeat([]byte{0x42}, 32)
+
+	internal, err := ComputeInternalKey(cosigners)
+	require.NoError(t, err)
+	final, err := ComputeFinalKey(cosigners, tweak)
+	require.NoError(t, err)
+
+	derived := txscript.ComputeTaprootOutputKey(internal, tweak)
+	require.Equal(
+		t, final.SerializeCompressed()[1:],
+		derived.SerializeCompressed()[1:],
+	)
+}

--- a/lib/tree/tree.go
+++ b/lib/tree/tree.go
@@ -311,8 +311,13 @@ func (t *Tree) PrettyPrint() string {
 // NewTreeSignerSession creates a TreeSignerSession for this tree.
 // This is a convenience wrapper that sets up the session with the tree's
 // context.
+//
+// tweakLookup optionally supplies per-node taproot tweaks (asset-aware
+// trees); BTC-only trees pass nil to sign every node with the tree's sweep
+// tapscript root.
 func (t *Tree) NewTreeSignerSession(wallet input.MuSig2Signer,
-	signerKey *keychain.KeyDescriptor) (*SignerSession, error) {
+	signerKey *keychain.KeyDescriptor, tweakLookup TaprootTweakLookup) (
+	*SignerSession, error) {
 
 	// Create prev output fetcher.
 	prevOutFetcher, err := t.Root.PrevOutputFetcher(t.BatchOutput)
@@ -323,6 +328,7 @@ func (t *Tree) NewTreeSignerSession(wallet input.MuSig2Signer,
 
 	return NewSignerSession(
 		wallet, signerKey, t.SweepTapscriptRoot, prevOutFetcher, t.Root,
+		tweakLookup,
 	)
 }
 

--- a/lib/tree/tree_structure.go
+++ b/lib/tree/tree_structure.go
@@ -26,6 +26,11 @@ type Structure struct {
 	// Root is the root node of the tree structure.
 	Root *Node
 
+	// AssetContext holds subtree asset totals when any leaf carries a
+	// Taproot Asset amount; nil for BTC-only trees. Later phases
+	// (materialization, signing) extend it with outpoint-keyed entries.
+	AssetContext *AssetTreeContext
+
 	// LeafScriptMap maps leaf node pointers to their output scripts
 	// (pkscript). This is populated during structure building and used by
 	// the BTC materializer. We keep BTC leaf data out of Node to keep the
@@ -62,18 +67,36 @@ func BuildStructure(leaves []LeafDescriptor,
 	// Create leaf scripts map for BTC path (maps leaf nodes to pkscripts).
 	leafScripts := make(map[*Node][]byte)
 
+	// Track per-leaf asset amounts so subtree totals can be folded after
+	// the shape is built. Nil stays nil for BTC-only trees.
+	leafAssets := make(map[*Node]uint64)
+
 	// Build recursively from leaves up.
 	root, err := buildStructureRecursive(
 		leaves, cfg.OperatorKey, cfg.Radix, weightFn, leafScripts,
+		leafAssets,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Structure{
+	structure := &Structure{
 		Root:          root,
 		LeafScriptMap: leafScripts,
-	}, nil
+	}
+
+	if len(leafAssets) > 0 {
+		assetCtx := NewAssetTreeContext()
+		if _, err := aggregateAssetAmounts(
+			root, leafAssets, assetCtx,
+		); err != nil {
+			return nil, err
+		}
+
+		structure.AssetContext = assetCtx
+	}
+
+	return structure, nil
 }
 
 // buildStructureRecursive recursively builds the tree structure. For a single
@@ -81,11 +104,14 @@ func BuildStructure(leaves []LeafDescriptor,
 // creates a branch node with children built recursively.
 func buildStructureRecursive(leaves []LeafDescriptor,
 	operatorKey *btcec.PublicKey, radix int, weightFn PartitionWeightFunc,
-	leafScripts map[*Node][]byte) (*Node, error) {
+	leafScripts map[*Node][]byte,
+	leafAssets map[*Node]uint64) (*Node, error) {
 
 	// Base case: single leaf becomes a leaf node.
 	if len(leaves) == 1 {
-		return buildLeafStructure(leaves[0], operatorKey, leafScripts)
+		return buildLeafStructure(
+			leaves[0], operatorKey, leafScripts, leafAssets,
+		)
 	}
 
 	// Partition leaves into groups.
@@ -103,6 +129,7 @@ func buildStructureRecursive(leaves []LeafDescriptor,
 
 		child, err := buildStructureRecursive(
 			group, operatorKey, radix, weightFn, leafScripts,
+			leafAssets,
 		)
 		if err != nil {
 			return nil, err
@@ -135,7 +162,8 @@ func buildStructureRecursive(leaves []LeafDescriptor,
 // buildLeafStructure creates the structure for a leaf node and populates
 // the leafScripts map (for BTC trees).
 func buildLeafStructure(leaf LeafDescriptor, operatorKey *btcec.PublicKey,
-	leafScripts map[*Node][]byte) (*Node, error) {
+	leafScripts map[*Node][]byte,
+	leafAssets map[*Node]uint64) (*Node, error) {
 
 	if leaf.CoSignerKey == nil {
 		return nil, fmt.Errorf("leaf cosigner key cannot be nil")
@@ -160,6 +188,10 @@ func buildLeafStructure(leaf LeafDescriptor, operatorKey *btcec.PublicKey,
 	// This keeps BTC and asset concerns separate.
 	if leafScripts != nil && len(leaf.PkScript) > 0 {
 		leafScripts[node] = leaf.PkScript
+	}
+
+	if leafAssets != nil && leaf.AssetAmount > 0 {
+		leafAssets[node] = leaf.AssetAmount
 	}
 
 	return node, nil

--- a/round/forfeit_release_on_failure_test.go
+++ b/round/forfeit_release_on_failure_test.go
@@ -764,7 +764,7 @@ func (h *realSigningTestHarness) newUnaggregatedSignerSession(
 
 	session, err := tree.NewSignerSession(
 		h.clientSigner, &vtxoReq.SigningKey,
-		vtxtTree.SweepTapscriptRoot, prevOutFetcher, vtxtTree.Root,
+		vtxtTree.SweepTapscriptRoot, prevOutFetcher, vtxtTree.Root, nil,
 	)
 	require.NoError(h.t, err)
 

--- a/round/signing_executor.go
+++ b/round/signing_executor.go
@@ -28,6 +28,11 @@ type CreateSignerSessionJob struct {
 	// SweepTapscriptRoot tweaks the VTXO tree key-spend path.
 	SweepTapscriptRoot []byte
 
+	// TweakLookup optionally overrides the taproot tweak per node.
+	// Asset-aware trees commit a per-node asset root into each output
+	// key; nil signs every node with SweepTapscriptRoot.
+	TweakLookup tree.TaprootTweakLookup
+
 	// PrevOuts provides the outputs spent by transactions in the path.
 	PrevOuts txscript.PrevOutputFetcher
 
@@ -101,6 +106,7 @@ func NewSigningExecutor(maxWorkers int) SigningExecutor {
 			return tree.NewSignerSession(
 				job.Signer, &job.SigningKey,
 				job.SweepTapscriptRoot, job.PrevOuts, job.Root,
+				job.TweakLookup,
 			)
 		},
 		getNonces: func(

--- a/tapassets/tree_assembler.go
+++ b/tapassets/tree_assembler.go
@@ -1,0 +1,132 @@
+package tapassets
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/lib/tree"
+)
+
+// AssetTreeRequest describes one asset-aware VTXO tree to build beneath a
+// batch output.
+type AssetTreeRequest struct {
+	// Leaves are the tree's VTXO leaves; every leaf must carry a
+	// non-zero asset amount.
+	Leaves []tree.LeafDescriptor
+
+	// OperatorKey participates in every node's cosigner set.
+	OperatorKey *btcec.PublicKey
+
+	// Radix is the maximum number of children per branch node.
+	Radix int
+
+	// BatchOutpoint is the batch output the root node spends.
+	BatchOutpoint wire.OutPoint
+
+	// BatchOutput is the batch output itself. Its value must equal the
+	// sum of the leaf amounts: node transactions are zero fee.
+	BatchOutput *wire.TxOut
+
+	// AssetAmount is the total asset amount carried by the batch
+	// output; the leaf amounts must sum to it exactly.
+	AssetAmount uint64
+}
+
+// BuildAssetTree builds and materializes one asset-aware VTXO tree: pass 1
+// shapes the tree and folds subtree asset totals, pass 2 commits one asset
+// transition per node through tap-sdk. The returned tree and context must
+// stay paired: the context carries the per-node signing tweaks and sealed
+// packages the tree's transactions depend on.
+func BuildAssetTree(ctx context.Context, cfg TreeMaterializerConfig,
+	req AssetTreeRequest) (*tree.Tree, *tree.AssetTreeContext, error) {
+
+	materializer, err := NewTreeMaterializer(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return buildAssetTree(ctx, materializer, req)
+}
+
+// buildAssetTree runs both passes against an already-constructed
+// materializer.
+func buildAssetTree(ctx context.Context, materializer *TreeMaterializer,
+	req AssetTreeRequest) (*tree.Tree, *tree.AssetTreeContext, error) {
+
+	if req.BatchOutput == nil {
+		return nil, nil, fmt.Errorf("batch output is required")
+	}
+	if req.Radix < 2 {
+		return nil, nil, fmt.Errorf("radix must be at least 2, got %d",
+			req.Radix)
+	}
+
+	var (
+		btcTotal   btcutil.Amount
+		assetTotal uint64
+	)
+	for idx := range req.Leaves {
+		leaf := &req.Leaves[idx]
+		if leaf.AssetAmount == 0 {
+			return nil, nil, fmt.Errorf("leaf %d carries no "+
+				"asset amount", idx)
+		}
+		btcTotal += leaf.Amount
+		assetTotal += leaf.AssetAmount
+	}
+	if btcTotal != btcutil.Amount(req.BatchOutput.Value) {
+		return nil, nil, fmt.Errorf("leaf amounts %d do not consume "+
+			"the batch output value %d", btcTotal,
+			req.BatchOutput.Value)
+	}
+	if assetTotal != req.AssetAmount {
+		return nil, nil, fmt.Errorf("leaf asset amounts %d do not "+
+			"consume the batch asset amount %d", assetTotal,
+			req.AssetAmount)
+	}
+
+	structure, err := tree.BuildStructure(req.Leaves,
+		tree.StructureConfig{
+			OperatorKey: req.OperatorKey,
+			Radix:       req.Radix,
+		},
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	if structure == nil || structure.AssetContext == nil {
+		return nil, nil, fmt.Errorf("asset tree structure has no " +
+			"asset context")
+	}
+
+	// The materializer reads subtree totals from the structure's
+	// context; rebind it so callers cannot desynchronize the two.
+	materializer.cfg.AssetContext = structure.AssetContext
+
+	err = tree.Materialize(
+		ctx, structure.Root, tree.MaterializeParams{
+			Input: req.BatchOutpoint,
+		},
+		materializer,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sweepRoot := materializer.cfg.SweepLeaf.TapHash()
+	built := &tree.Tree{
+		Root:               structure.Root,
+		BatchOutpoint:      req.BatchOutpoint,
+		BatchOutput:        req.BatchOutput,
+		SweepTapscriptRoot: sweepRoot[:],
+	}
+	if err := built.Verify(); err != nil {
+		return nil, nil, fmt.Errorf("materialized tree is "+
+			"inconsistent: %w", err)
+	}
+
+	return built, structure.AssetContext, nil
+}

--- a/tapassets/tree_e2e_test.go
+++ b/tapassets/tree_e2e_test.go
@@ -229,27 +229,17 @@ type treeE2EParticipant struct {
 	signer *localTreeSigner
 }
 
-// newTreeE2EParticipant creates a participant with a fresh even-Y key.
-// tap-sdk declares MuSig2 participants as x-only keys (implicitly even-Y),
-// so tree signing keys — ephemeral by design — use the even-Y convention
-// to keep the full-key signing aggregate equal to the x-only validation
-// aggregate.
+// newTreeE2EParticipant creates a participant with a fresh key.
 func newTreeE2EParticipant(t *testing.T) *treeE2EParticipant {
 	t.Helper()
 
-	for {
-		priv, err := btcec.NewPrivateKey()
-		require.NoError(t, err)
-		pub := priv.PubKey()
-		if pub.SerializeCompressed()[0] != 0x02 {
-			continue
-		}
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
 
-		return &treeE2EParticipant{
-			priv:   priv,
-			pub:    pub,
-			signer: newLocalTreeSigner(priv),
-		}
+	return &treeE2EParticipant{
+		priv:   priv,
+		pub:    priv.PubKey(),
+		signer: newLocalTreeSigner(priv),
 	}
 }
 

--- a/tapassets/tree_e2e_test.go
+++ b/tapassets/tree_e2e_test.go
@@ -1,0 +1,964 @@
+package tapassets
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	btcaddr "github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	tapgrpc "github.com/lightninglabs/tap-sdk/grpc"
+	"github.com/lightninglabs/wavelength/harness"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	treeE2ETimeout   = 60 * time.Second
+	treeE2ELeafSats  = btcutil.Amount(10_000)
+	treeE2EExitDelay = 144
+	treeE2ESweepCSV  = 1008
+	treeE2EChildFee  = int64(5_000)
+)
+
+// localTreeSigner is an in-process input.MuSig2Signer over one private
+// key, mirroring lib/tree's test signer so the e2e can run the real
+// multi-party signing ceremony without lnd signers.
+type localTreeSigner struct {
+	privKey       *btcec.PrivateKey
+	sessions      map[input.MuSig2SessionID]*localTreeSession
+	nextSessionID int
+}
+
+type localTreeSession struct {
+	info         *input.MuSig2SessionInfo
+	musigSession *musig2.Session
+	allNonces    bool
+}
+
+func newLocalTreeSigner(privKey *btcec.PrivateKey) *localTreeSigner {
+	return &localTreeSigner{
+		privKey:  privKey,
+		sessions: make(map[input.MuSig2SessionID]*localTreeSession),
+	}
+}
+
+// MuSig2CreateSession opens a real MuSig2 session over the signer's key.
+func (l *localTreeSigner) MuSig2CreateSession(_ input.MuSig2Version,
+	_ keychain.KeyLocator, signers []*btcec.PublicKey,
+	tweaks *input.MuSig2Tweaks, _ [][musig2.PubNonceSize]byte,
+	localNonces *musig2.Nonces) (*input.MuSig2SessionInfo, error) {
+
+	nonces := localNonces
+	if nonces == nil {
+		fresh, err := musig2.GenNonces(
+			musig2.WithPublicKey(
+				l.privKey.PubKey(),
+			),
+			musig2.WithNonceSecretKeyAux(l.privKey),
+		)
+		if err != nil {
+			return nil, err
+		}
+		nonces = fresh
+	}
+
+	ctxOpts := []musig2.ContextOption{
+		musig2.WithKnownSigners(signers),
+	}
+	if tweaks != nil && len(tweaks.TaprootTweak) > 0 {
+		ctxOpts = append(
+			ctxOpts,
+			musig2.WithTaprootTweakCtx(tweaks.TaprootTweak),
+		)
+	}
+
+	musigCtx, err := musig2.NewContext(l.privKey, true, ctxOpts...)
+	if err != nil {
+		return nil, err
+	}
+	session, err := musigCtx.NewSession(
+		musig2.WithPreGeneratedNonce(nonces),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionID := input.MuSig2SessionID{byte(l.nextSessionID)}
+	l.nextSessionID++
+
+	l.sessions[sessionID] = &localTreeSession{
+		info: &input.MuSig2SessionInfo{
+			SessionID:   sessionID,
+			PublicNonce: nonces.PubNonce,
+		},
+		musigSession: session,
+	}
+
+	return l.sessions[sessionID].info, nil
+}
+
+// MuSig2RegisterNonces registers other signers' individual nonces.
+func (l *localTreeSigner) MuSig2RegisterNonces(id input.MuSig2SessionID,
+	nonces [][musig2.PubNonceSize]byte) (bool, error) {
+
+	session, ok := l.sessions[id]
+	if !ok {
+		return false, fmt.Errorf("session not found")
+	}
+
+	var (
+		haveAll bool
+		err     error
+	)
+	for _, nonce := range nonces {
+		haveAll, err = session.musigSession.RegisterPubNonce(nonce)
+		if err != nil {
+			return false, err
+		}
+	}
+	session.allNonces = haveAll
+
+	return haveAll, nil
+}
+
+// MuSig2RegisterCombinedNonce registers the aggregated nonce directly:
+// tree signing shares only the per-transaction aggregate, never the
+// individual nonces.
+func (l *localTreeSigner) MuSig2RegisterCombinedNonce(id input.MuSig2SessionID,
+	agg [musig2.PubNonceSize]byte) error {
+
+	session, ok := l.sessions[id]
+	if !ok {
+		return fmt.Errorf("session not found")
+	}
+
+	err := session.musigSession.RegisterCombinedNonce(agg)
+	if err != nil {
+		return err
+	}
+	session.allNonces = true
+
+	return nil
+}
+
+// MuSig2Sign produces the local partial signature.
+func (l *localTreeSigner) MuSig2Sign(id input.MuSig2SessionID, msg [32]byte,
+	_ bool) (*musig2.PartialSignature, error) {
+
+	session, ok := l.sessions[id]
+	if !ok {
+		return nil, fmt.Errorf("session not found")
+	}
+	if !session.allNonces {
+		return nil, fmt.Errorf("not all nonces registered")
+	}
+
+	return session.musigSession.Sign(msg)
+}
+
+// MuSig2CombineSig folds other signers' partial signatures into the final
+// schnorr signature.
+func (l *localTreeSigner) MuSig2CombineSig(id input.MuSig2SessionID,
+	partials []*musig2.PartialSignature) (*schnorr.Signature, bool, error) {
+
+	session, ok := l.sessions[id]
+	if !ok {
+		return nil, false, fmt.Errorf("session not found")
+	}
+
+	var (
+		haveAll bool
+		err     error
+	)
+	for _, partial := range partials {
+		haveAll, err = session.musigSession.CombineSig(partial)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	if !haveAll {
+		return nil, false, fmt.Errorf("missing partial signatures")
+	}
+
+	finalSig := session.musigSession.FinalSig()
+	if finalSig == nil {
+		return nil, false, fmt.Errorf("final signature is invalid")
+	}
+
+	return finalSig, true, nil
+}
+
+// MuSig2GetCombinedNonce is unused by the tree signing ceremony.
+func (l *localTreeSigner) MuSig2GetCombinedNonce(id input.MuSig2SessionID) (
+	[musig2.PubNonceSize]byte, error) {
+
+	return [musig2.PubNonceSize]byte{}, fmt.Errorf("not used")
+}
+
+// MuSig2Cleanup drops a session.
+func (l *localTreeSigner) MuSig2Cleanup(id input.MuSig2SessionID) error {
+	delete(l.sessions, id)
+
+	return nil
+}
+
+// treeE2EParticipant bundles one signer's key material.
+type treeE2EParticipant struct {
+	priv   *btcec.PrivateKey
+	pub    *btcec.PublicKey
+	signer *localTreeSigner
+}
+
+// newTreeE2EParticipant creates a participant with a fresh even-Y key.
+// tap-sdk declares MuSig2 participants as x-only keys (implicitly even-Y),
+// so tree signing keys — ephemeral by design — use the even-Y convention
+// to keep the full-key signing aggregate equal to the x-only validation
+// aggregate.
+func newTreeE2EParticipant(t *testing.T) *treeE2EParticipant {
+	t.Helper()
+
+	for {
+		priv, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		pub := priv.PubKey()
+		if pub.SerializeCompressed()[0] != 0x02 {
+			continue
+		}
+
+		return &treeE2EParticipant{
+			priv:   priv,
+			pub:    pub,
+			signer: newLocalTreeSigner(priv),
+		}
+	}
+}
+
+// TestAssetTreeE2E builds, signs, and unrolls a complete asset-aware VTXO
+// tree against a real tapd: mint a grouped asset, anchor it beneath a
+// MuSig2 batch output, materialize a three-leaf tree of tapd-committed
+// transitions, run the multi-party signing ceremony, verify every
+// signature, and force the whole tree on-chain through v3 package relay.
+func TestAssetTreeE2E(t *testing.T) {
+	image := os.Getenv("ARK_ITEST_TAPD_IMAGE")
+	if image == "" {
+		t.Skip("set ARK_ITEST_TAPD_IMAGE to run the asset tree e2e")
+	}
+
+	opts := harness.DefaultOptions()
+	opts.GroupName = t.Name()
+	opts.StartTapd = true
+	opts.TapdImage = image
+
+	h := harness.NewHarness(t, &opts)
+	t.Cleanup(h.Stop)
+	h.Start()
+	h.FundOperatorLND(2 * btcutil.SatoshiPerBitcoin)
+
+	client, err := tapgrpc.NewClient(&tapgrpc.Config{
+		Host:     net.JoinHostPort("127.0.0.1", h.TapdGRPCPort),
+		Network:  tapsdk.NetworkRegtest,
+		TLS:      tapgrpc.TLSFromPath(h.TapdTLSCertPath()),
+		Macaroon: tapsdk.MacaroonFromPath(h.TapdMacaroonPath()),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	wallet := tapsdk.NewWallet(client, tapsdk.NetworkRegtest)
+
+	operator := newTreeE2EParticipant(t)
+	users := []*treeE2EParticipant{
+		newTreeE2EParticipant(t),
+		newTreeE2EParticipant(t),
+		newTreeE2EParticipant(t),
+	}
+	amounts := []uint64{800, 200, 500}
+
+	// Mint 1,500 grouped units and export + verify the issuance proof.
+	record := mintTreeE2EAsset(t, h, client, 1_500)
+	require.True(t, record.AssetRef.IsGroupRef())
+
+	// Commits and verifiers identify the asset by its group-aware ref;
+	// proof exports address the tranche by issuance id.
+	assetRef := record.AssetRef
+	exportRef := tapsdk.AssetRefFromAssetID(record.Genesis.IssuanceID)
+	mintProof := exportTreeE2EProof(
+		t, client, exportRef, record.ScriptKey.PubKey, nil,
+	)
+
+	// The batch output aggregates operator and every leaf owner, with
+	// the operator sweep leaf as the asset commitment's sibling.
+	rootCosigners := tree.UniqueCosigners([]*btcec.PublicKey{
+		operator.pub, users[0].pub, users[1].pub, users[2].pub,
+	})
+	sweepLeaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(
+		operator.pub, treeE2ESweepCSV,
+	)
+	require.NoError(t, err)
+
+	batch := commitTreeBatchAnchor(
+		t, h, wallet, client, assetRef, exportRef, mintProof, 1_500,
+		rootCosigners, sweepLeaf,
+	)
+
+	// Build leaf policies and the anchor lookup keyed by owner.
+	leaves := make([]tree.LeafDescriptor, len(users))
+	anchorsByOwner := make(map[string]TreeLeafAnchor, len(users))
+	for i, user := range users {
+		leafAnchor, pkScript := treeE2ELeafAnchor(
+			t, user.pub, operator.pub,
+		)
+		anchorsByOwner[keyHex(user.pub)] = leafAnchor
+		leaves[i] = tree.LeafDescriptor{
+			PkScript:    pkScript,
+			Amount:      treeE2ELeafSats,
+			CoSignerKey: user.pub,
+			AssetAmount: amounts[i],
+		}
+	}
+
+	digest := sha256.Sum256([]byte(batch.outpoint.String()))
+	cfg := TreeMaterializerConfig{
+		Wallet:    wallet,
+		AssetRef:  assetRef,
+		SweepLeaf: sweepLeaf,
+		LeafAnchor: func(node *tree.Node) (TreeLeafAnchor, error) {
+			for _, cosigner := range node.CoSigners {
+				anchor, ok := anchorsByOwner[keyHex(cosigner)]
+				if ok {
+					return anchor, nil
+				}
+			}
+
+			return TreeLeafAnchor{}, fmt.Errorf("no leaf anchor " +
+				"for node")
+		},
+		Root: TreeRootAssetSource{
+			ProofFile: batch.proofFile,
+			Verifier: &proofInventoryVerifier{
+				client:    client,
+				assetRef:  assetRef,
+				amount:    1_500,
+				anchor:    sdkOutpoint(batch.outpoint),
+				assetRoot: batch.assetRoot,
+			},
+			SigningTweak:  batch.signingTweak,
+			BatchPkScript: batch.pkScript,
+		},
+		Digest: tapsdk.Hash(digest),
+	}
+
+	// The context is created inside BuildAssetTree; the config field is
+	// rebound there.
+	cfg.AssetContext = tree.NewAssetTreeContext()
+
+	built, assetCtx, err := BuildAssetTree(
+		t.Context(), cfg, AssetTreeRequest{
+			Leaves:        leaves,
+			OperatorKey:   operator.pub,
+			Radix:         2,
+			BatchOutpoint: batch.outpoint,
+			BatchOutput:   batch.output,
+			AssetAmount:   1_500,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 3, built.NumLeaves())
+	require.Equal(t, 5, built.NumTx())
+
+	// Multi-party signing ceremony, then verify every signature.
+	signAssetTree(t, built, assetCtx, operator, users)
+	require.NoError(t, built.VerifySigned())
+
+	// Confirm the batch anchor before unrolling on top of it.
+	h.GenerateAndWait(1)
+
+	// Force the entire tree on-chain, parent before child, through v3
+	// package relay with a chained fee input.
+	publishTreePackages(t, h, built)
+}
+
+// treeE2EBatch bundles the committed batch anchor's binding material.
+type treeE2EBatch struct {
+	outpoint     wire.OutPoint
+	output       *wire.TxOut
+	pkScript     []byte
+	signingTweak []byte
+	assetRoot    tapsdk.Hash
+	proofFile    []byte
+}
+
+// commitTreeBatchAnchor anchors the minted asset beneath the tree's batch
+// output: a wallet-funded custom anchor whose output carries the MuSig2
+// aggregate internal key with the sweep leaf as tapscript sibling, signed
+// by the harness LND wallet, published through tapd, and confirmed.
+func commitTreeBatchAnchor(t *testing.T, h *harness.Harness,
+	wallet *tapsdk.Wallet, client tapsdk.Client,
+	assetRef, exportRef tapsdk.AssetRef, mintProof []byte, amount uint64,
+	rootCosigners []*btcec.PublicKey,
+	sweepLeaf txscript.TapLeaf) *treeE2EBatch {
+
+	t.Helper()
+	ctx := t.Context()
+
+	// Locate the mint anchor in tapd's inventory, mirroring the
+	// onboarding flow's input verification.
+	verified, err := client.VerifyProof(ctx, mintProof)
+	require.NoError(t, err)
+	require.True(t, verified.Valid)
+	tip := verified.DecodedProof
+
+	utxos, err := client.ListUtxos(ctx, &tapsdk.ListUtxosRequest{
+		IncludeLeased: true,
+	})
+	require.NoError(t, err)
+	var anchor *tapsdk.ManagedUtxo
+	for _, candidate := range utxos {
+		if candidate != nil && candidate.OutPoint == tip.Outpoint {
+			anchor = candidate
+			break
+		}
+	}
+	require.NotNil(t, anchor, "mint anchor not in tapd inventory")
+
+	rootInternal, err := tree.ComputeInternalKey(rootCosigners)
+	require.NoError(t, err)
+
+	batchValue := int64(treeE2ELeafSats) * 3
+	anchorPSBT, err := onboardingAnchorPSBT(tip.Outpoint, batchValue)
+	require.NoError(t, err)
+
+	anchorInternalKey, err := btcec.ParsePubKey(anchor.InternalKey[:])
+	require.NoError(t, err)
+	anchorSigner, err := tapsdk.ParseXOnlyPubKey(
+		schnorr.SerializePubKey(anchorInternalKey),
+	)
+	require.NoError(t, err)
+
+	feeRate, err := tapsdk.NewFeeRateSatPerVByte(1)
+	require.NoError(t, err)
+
+	request := &tapsdk.CustomAnchorRequest{
+		Inputs: []tapsdk.CustomAssetInput{{
+			ID:        "tree-e2e-batch-input",
+			AssetRef:  assetRef,
+			Amount:    amount,
+			ProofFile: append([]byte(nil), mintProof...),
+			Witness: tapsdk.CustomAssetWitnessPlan{
+				Mode: tapsdk.CustomAssetWitnessBackendSigner,
+			},
+		}},
+		Outputs: []tapsdk.CustomAssetOutput{{
+			ID:                "tree-e2e-batch-output",
+			AssetRef:          assetRef,
+			Amount:            amount,
+			AnchorOutputIndex: 0,
+			AnchorValueSat:    uint64(batchValue),
+			Script: tapsdk.CustomAssetScriptPlan{
+				Mode:   tapsdk.CustomAssetScriptWallet,
+				Wallet: &tapsdk.CustomAssetWalletScriptPlan{},
+			},
+			Anchor: anchorPlan(
+				rootInternal, []txscript.TapLeaf{sweepLeaf},
+			),
+		}},
+		AnchorPSBT: anchorPSBT,
+		Funding: tapsdk.CustomAnchorFundingPlan{
+			Mode: tapsdk.CustomAnchorFundingWalletFunded,
+			WalletFunded: &tapsdk.CustomAnchorWalletFunding{
+				ChangeOutput: tapsdk.AnchorChangeOutput{
+					Mode: tapsdk.AnchorChangeOutputAdd,
+				},
+				Fee: tapsdk.AnchorFee{
+					Mode:    tapsdk.AnchorFeeSatPerVByte,
+					FeeRate: feeRate,
+				},
+				MaxFeeSat: 100_000,
+				CustomLockID: treeE2ELockID(
+					"tree-e2e-batch",
+				),
+			},
+		},
+		PassiveAssets: tapsdk.CustomAnchorPassiveAssets{
+			Policy: tapsdk.CustomAnchorPassiveReject,
+		},
+		LossPolicy: tapsdk.CustomAnchorLossPolicy{
+			Mode: tapsdk.CustomAnchorLossReject,
+		},
+		SigningPlans: []tapsdk.CustomAnchorInputSigningPlan{{
+			InputIndex: 0,
+			KeyPath: &tapsdk.CustomAnchorKeyPathSigningPlan{
+				Signer: anchorSigner,
+			},
+		}},
+	}
+
+	driver := &sdkDriver{wallet: wallet}
+	committed, err := driver.CommitOnboarding(
+		ctx, request, &proofInventoryVerifier{
+			client:    client,
+			assetRef:  assetRef,
+			amount:    amount,
+			anchor:    tip.Outpoint,
+			assetRoot: anchor.TaprootAssetRoot,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, committed.outputs, 1)
+	out := committed.outputs[0]
+
+	// Sign the funded anchor with the harness LND wallet and publish
+	// through tapd.
+	packet, err := psbtutil.Parse(committed.anchorPSBT)
+	require.NoError(t, err)
+	signed, err := h.LND.WalletKit.SignPsbt(ctx, packet)
+	require.NoError(t, err)
+	finalized, _, err := h.LND.WalletKit.FinalizePsbt(ctx, signed, "")
+	require.NoError(t, err)
+	finalBytes, err := psbtutil.Serialize(finalized)
+	require.NoError(t, err)
+
+	require.NoError(
+		t, driver.PublishOnboarding(
+			ctx, committed.packageBytes, finalBytes,
+		),
+	)
+	h.GenerateAndWait(6)
+
+	committedPacket, err := psbtutil.Parse(committed.anchorPSBT)
+	require.NoError(t, err)
+	batchTx := committedPacket.UnsignedTx
+	outIndex := out.anchorOutputIndex
+	batchOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash(out.anchorOutpoint.Txid),
+		Index: out.anchorOutpoint.Index,
+	}
+
+	// Export and verify the batch anchor's proof once tapd has seen the
+	// confirmation.
+	var proofFile []byte
+	require.Eventually(t, func() bool {
+		exported, exportErr := client.ExportProof(
+			ctx, exportRef, out.scriptKey, &out.anchorOutpoint,
+		)
+		if exportErr != nil || exported == nil ||
+			len(exported.RawProofFile) == 0 {
+			return false
+		}
+		proofFile = exported.RawProofFile
+
+		return true
+	}, treeE2ETimeout, time.Second, "batch anchor proof never exported")
+
+	return &treeE2EBatch{
+		outpoint: batchOutpoint,
+		output: wire.NewTxOut(
+			batchValue, batchTx.TxOut[outIndex].PkScript,
+		),
+		pkScript:     batchTx.TxOut[outIndex].PkScript,
+		signingTweak: out.taprootMerkleRoot[:],
+		assetRoot:    out.taprootAssetRoot,
+		proofFile:    proofFile,
+	}
+}
+
+// treeE2ELeafAnchor compiles a standard VTXO policy for one leaf owner and
+// projects it into the materializer's leaf anchor shape.
+func treeE2ELeafAnchor(t *testing.T, owner, operator *btcec.PublicKey) (
+	TreeLeafAnchor, []byte) {
+
+	t.Helper()
+
+	encoded, err := arkscript.EncodeStandardVTXOTemplate(
+		owner, operator, treeE2EExitDelay,
+	)
+	require.NoError(t, err)
+	template, err := arkscript.DecodePolicyTemplate(encoded)
+	require.NoError(t, err)
+	policy, err := template.Compile()
+	require.NoError(t, err)
+	pkScript, err := template.PkScript()
+	require.NoError(t, err)
+
+	tapLeaves := make([]txscript.TapLeaf, len(policy.Leaves))
+	for idx := range policy.Leaves {
+		tapLeaves[idx] = policy.Leaves[idx].Leaf
+	}
+
+	return TreeLeafAnchor{
+		UncomposedPkScript: pkScript,
+		InternalKey:        policy.InternalKey,
+		TapLeaves:          tapLeaves,
+	}, pkScript
+}
+
+// signAssetTree runs the full multi-party MuSig2 ceremony: one signer
+// session per participant, nonce aggregation per transaction, partial
+// signatures, and final combination submitted back onto the tree.
+func signAssetTree(t *testing.T, built *tree.Tree,
+	assetCtx *tree.AssetTreeContext, operator *treeE2EParticipant,
+	users []*treeE2EParticipant) {
+
+	t.Helper()
+
+	lookup := assetCtx.TweakLookup()
+	participants := append([]*treeE2EParticipant{operator}, users...)
+
+	sessions := make([]*tree.SignerSession, len(participants))
+	for i, participant := range participants {
+		session, err := built.NewTreeSignerSession(
+			participant.signer, &keychain.KeyDescriptor{
+				PubKey: participant.pub,
+			},
+			lookup,
+		)
+		require.NoError(t, err)
+		sessions[i] = session
+	}
+
+	// Phase 1: aggregate nonces per transaction across exactly the
+	// signers whose paths include it.
+	noncesByTx := make(map[tree.TxID][][musig2.PubNonceSize]byte)
+	for _, session := range sessions {
+		for txid, nonce := range session.GetNonces() {
+			noncesByTx[txid] = append(noncesByTx[txid], nonce)
+		}
+	}
+	aggByTx := make(map[tree.TxID]tree.Musig2PubNonce, len(noncesByTx))
+	for txid, nonces := range noncesByTx {
+		agg, err := musig2.AggregateNonces(nonces)
+		require.NoError(t, err)
+		aggByTx[txid] = agg
+	}
+	for _, session := range sessions {
+		scoped := make(map[tree.TxID]tree.Musig2PubNonce)
+		for txid := range session.SessionIDs() {
+			scoped[txid] = aggByTx[txid]
+		}
+		require.NoError(t, session.RegisterAggNonces(scoped))
+	}
+
+	// Phase 2: partial signatures from everyone; the operator's session
+	// spans every node and combines the others' partials.
+	partialsByTx := make(map[tree.TxID][]*musig2.PartialSignature)
+	for i, session := range sessions {
+		partials, err := session.Signatures(false)
+		require.NoError(t, err)
+
+		// The operator's own partial is already inside its session.
+		if i == 0 {
+			continue
+		}
+		for txid, partial := range partials {
+			partialsByTx[txid] = append(
+				partialsByTx[txid], partial,
+			)
+		}
+	}
+
+	operatorIDs := sessions[0].SessionIDs()
+	finalSigs := make(map[tree.TxID]*schnorr.Signature, len(operatorIDs))
+	for txid, sessionID := range operatorIDs {
+		sig, haveAll, err := operator.signer.MuSig2CombineSig(
+			sessionID, partialsByTx[txid],
+		)
+		require.NoError(t, err)
+		require.True(t, haveAll)
+		finalSigs[txid] = sig
+	}
+
+	require.NoError(t, built.SubmitTreeSigs(finalSigs))
+}
+
+// esploraTxOut looks up one output of a transaction through the harness's
+// electrs HTTP endpoint.
+func esploraTxOut(t *testing.T, h *harness.Harness, txid string,
+	pkScript []byte) (uint32, int64) {
+
+	t.Helper()
+
+	var (
+		index uint32
+		value int64
+	)
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(h.EsploraURL + "/tx/" + txid)
+		if err != nil || resp.StatusCode != http.StatusOK {
+			return false
+		}
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+
+		var decoded struct {
+			Vout []struct {
+				ScriptPubKey string `json:"scriptpubkey"`
+				Value        int64  `json:"value"`
+			} `json:"vout"`
+		}
+		if json.NewDecoder(resp.Body).Decode(&decoded) != nil {
+			return false
+		}
+		for i, out := range decoded.Vout {
+			script, err := hex.DecodeString(out.ScriptPubKey)
+			if err != nil {
+				continue
+			}
+			if bytes.Equal(script, pkScript) {
+				index = uint32(i)
+				value = out.Value
+
+				return true
+			}
+		}
+
+		return false
+	}, treeE2ETimeout, time.Second, "esplora never indexed %s", txid)
+
+	return index, value
+}
+
+// publishTreePackages broadcasts every node transaction parent-first via
+// v3 package relay, funding each package's fees through a chained P2WPKH
+// input.
+func publishTreePackages(t *testing.T, h *harness.Harness, built *tree.Tree) {
+	t.Helper()
+
+	// Fund a throwaway fee key whose change chains across packages.
+	feeKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	feeHash := btcaddr.Hash160(feeKey.PubKey().SerializeCompressed())
+	feeAddr, err := btcaddr.NewAddressWitnessPubKeyHash(
+		feeHash, &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+	feeScript, err := txscript.PayToAddrScript(feeAddr)
+	require.NoError(t, err)
+
+	fundingTxid := h.Faucet(feeAddr.String(), 1_000_000)
+	h.GenerateAndWait(1)
+	feeIndex, feeValue := esploraTxOut(t, h, fundingTxid, feeScript)
+	fundingHash, err := chainhash.NewHashFromStr(fundingTxid)
+	require.NoError(t, err)
+	feeOutpoint := wire.OutPoint{Hash: *fundingHash, Index: feeIndex}
+
+	bitcoind, err := h.BitcoindClient()
+	require.NoError(t, err)
+
+	var publish func(node *tree.Node)
+	publish = func(node *tree.Node) {
+		parentTx, err := node.ToSignedTx()
+		require.NoError(t, err)
+
+		child, changeValue := buildTreeFeeChild(
+			t, parentTx, feeOutpoint, feeValue, feeKey, feeScript,
+		)
+
+		result, err := bitcoind.SubmitPackage(
+			[]*wire.MsgTx{parentTx}, child, nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		for wtxid, txResult := range result.TxResults {
+			require.Empty(
+				t, txResult.Error, "package tx %s rejected",
+				wtxid,
+			)
+		}
+
+		h.GenerateAndWait(1)
+
+		feeOutpoint = wire.OutPoint{
+			Hash:  child.TxHash(),
+			Index: 0,
+		}
+		feeValue = changeValue
+
+		for _, idx := range sortedChildIndices(node.Children) {
+			publish(node.Children[idx])
+		}
+	}
+	publish(built.Root)
+}
+
+// buildTreeFeeChild spends the parent's P2A anchor plus the chained fee
+// input into a single change output, signing the fee input.
+func buildTreeFeeChild(t *testing.T, parent *wire.MsgTx,
+	feeOutpoint wire.OutPoint, feeValue int64, feeKey *btcec.PrivateKey,
+	feeScript []byte) (*wire.MsgTx, int64) {
+
+	t.Helper()
+
+	anchorIndex := len(parent.TxOut) - 1
+	anchorOutpoint := wire.OutPoint{
+		Hash:  parent.TxHash(),
+		Index: uint32(anchorIndex),
+	}
+
+	child := wire.NewMsgTx(3)
+	child.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: anchorOutpoint,
+		Sequence:         wire.MaxTxInSequenceNum - 2,
+	})
+	child.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: feeOutpoint,
+		Sequence:         wire.MaxTxInSequenceNum - 2,
+	})
+	changeValue := feeValue - treeE2EChildFee
+	require.Greater(t, changeValue, int64(1_000))
+	child.AddTxOut(wire.NewTxOut(changeValue, feeScript))
+
+	prevOuts := txscript.NewMultiPrevOutFetcher(
+		map[wire.OutPoint]*wire.TxOut{
+			anchorOutpoint: parent.TxOut[anchorIndex],
+			feeOutpoint:    wire.NewTxOut(feeValue, feeScript),
+		},
+	)
+	hashes := txscript.NewTxSigHashes(child, prevOuts)
+	witness, err := txscript.WitnessSignature(
+		child, hashes, 1, feeValue, feeScript, txscript.SigHashAll,
+		feeKey, true,
+	)
+	require.NoError(t, err)
+	child.TxIn[1].Witness = witness
+
+	// The P2A anchor input needs no witness: it is anyone-can-spend.
+	return child, changeValue
+}
+
+// mintTreeE2EAsset mints and finalizes a grouped fungible asset.
+func mintTreeE2EAsset(t *testing.T, h *harness.Harness, client tapsdk.Client,
+	amount uint64) *tapsdk.AssetRecord {
+
+	t.Helper()
+	ctx := t.Context()
+
+	batch, err := client.MintAsset(ctx, &tapsdk.MintAssetRequest{
+		Asset: &tapsdk.MintAsset{
+			AssetType:     tapsdk.AssetTypeFungible,
+			AssetVersion:  tapsdk.AssetVersionV1,
+			Name:          "TREE",
+			InitialSupply: amount,
+			AllowIssuance: true,
+		},
+		ShortResponse: true,
+	})
+	require.NoError(t, err)
+
+	_, err = client.FinalizeBatch(ctx, &tapsdk.FinalizeBatchRequest{
+		ShortResponse: true,
+	})
+	require.NoError(t, err)
+
+	waitTreeE2EBatchState(t, client, batch.BatchKey,
+		func(state tapsdk.BatchState) bool {
+			return state == tapsdk.BatchStateBroadcast ||
+				state == tapsdk.BatchStateConfirmed ||
+				state == tapsdk.BatchStateFinalized
+		},
+	)
+	h.GenerateAndWait(6)
+	waitTreeE2EBatchState(t, client, batch.BatchKey,
+		func(state tapsdk.BatchState) bool {
+			return state == tapsdk.BatchStateFinalized
+		},
+	)
+
+	var record *tapsdk.AssetRecord
+	require.Eventually(t, func() bool {
+		records, listErr := client.ListAssetRecords(
+			ctx, &tapsdk.ListAssetsRequest{},
+		)
+		if listErr != nil {
+			return false
+		}
+		for _, candidate := range records {
+			if candidate != nil &&
+				candidate.Genesis.Tag == "TREE" &&
+				candidate.Amount == amount {
+
+				record = candidate
+
+				return true
+			}
+		}
+
+		return false
+	}, treeE2ETimeout, time.Second, "minted asset never visible")
+
+	return record
+}
+
+// waitTreeE2EBatchState polls the mint batch until it reaches the wanted
+// state.
+func waitTreeE2EBatchState(t *testing.T, client tapsdk.Client,
+	batchKey tapsdk.PubKey, ready func(tapsdk.BatchState) bool) {
+
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		batches, err := client.ListBatches(
+			t.Context(), &tapsdk.ListBatchesRequest{
+				BatchKey: &batchKey,
+			},
+		)
+		if err != nil || len(batches) != 1 || batches[0] == nil {
+			return false
+		}
+
+		return ready(batches[0].Batch.State)
+	}, treeE2ETimeout, time.Second, "mint batch state never reached")
+}
+
+// exportTreeE2EProof exports and sanity-verifies a proof file.
+func exportTreeE2EProof(t *testing.T, client tapsdk.Client,
+	assetRef tapsdk.AssetRef, scriptKey tapsdk.PubKey,
+	outpoint *tapsdk.Outpoint) []byte {
+
+	t.Helper()
+
+	exported, err := client.ExportProof(
+		t.Context(), assetRef, scriptKey, outpoint,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, exported.RawProofFile)
+
+	verified, err := client.VerifyProof(
+		t.Context(), exported.RawProofFile,
+	)
+	require.NoError(t, err)
+	require.True(t, verified.Valid)
+
+	return exported.RawProofFile
+}
+
+// treeE2ELockID derives a deterministic wallet lock id.
+func treeE2ELockID(label string) []byte {
+	digest := sha256.Sum256([]byte(label))
+
+	return digest[:]
+}
+
+// keyHex returns the compressed hex encoding of a public key.
+func keyHex(key *btcec.PublicKey) string {
+	return hex.EncodeToString(key.SerializeCompressed())
+}

--- a/tapassets/tree_materializer.go
+++ b/tapassets/tree_materializer.go
@@ -1,0 +1,662 @@
+package tapassets
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
+)
+
+// TreeLeafAnchor describes how one leaf VTXO output is built: the
+// uncomposed policy script the Bitcoin template carries before tapd grafts
+// the asset commitment in, and the policy's tapscript material tapd needs
+// to compose the final anchor key.
+type TreeLeafAnchor struct {
+	// UncomposedPkScript is the leaf policy's P2TR script without any
+	// asset commitment.
+	UncomposedPkScript []byte
+
+	// InternalKey is the leaf policy's taproot internal key.
+	InternalKey *btcec.PublicKey
+
+	// TapLeaves are the complete policy leaves, in canonical order.
+	TapLeaves []txscript.TapLeaf
+}
+
+// TreeRootAssetSource identifies the asset spent by the tree's root node:
+// the batch output's asset units. The proof source describes the batch
+// anchor (a confirmed proof file, or a compact path when the batch output
+// itself is still unconfirmed), and the witness is the batch output's
+// OP_TRUE asset witness.
+type TreeRootAssetSource struct {
+	// ProofFile is a complete confirmed proof file for the batch
+	// anchor. Exactly one of ProofFile and ProofPath must be set.
+	ProofFile []byte
+
+	// ProofPath is a serialized compact proof path for an unconfirmed
+	// batch anchor.
+	ProofPath []byte
+
+	// Witness is the caller-provided asset witness stack authorizing
+	// the batch output's asset spend.
+	Witness [][]byte
+
+	// Verifier verifies the proof source when building each commit.
+	Verifier tapsdk.ConfirmedProofVerifier
+
+	// SigningTweak is the batch output's combined taproot tweak, used
+	// to sign the root node transaction.
+	SigningTweak []byte
+
+	// BatchPkScript is the batch output's final on-chain script, used
+	// to bind the root node's key material fail-closed.
+	BatchPkScript []byte
+}
+
+// TreeMaterializerConfig configures asset tree materialization.
+type TreeMaterializerConfig struct {
+	// Wallet is the tap-sdk wallet used to commit node transitions.
+	Wallet *tapsdk.Wallet
+
+	// AssetRef is the asset carried by every leaf of this tree.
+	AssetRef tapsdk.AssetRef
+
+	// AssetContext receives per-node signing tweaks and sealed
+	// packages, keyed by node input outpoint. Its subtree amounts must
+	// already be populated by the structure pass.
+	AssetContext *tree.AssetTreeContext
+
+	// SweepLeaf is the operator's timeout sweep leaf carried by every
+	// branch output as the asset commitment's tapscript sibling.
+	SweepLeaf txscript.TapLeaf
+
+	// LeafAnchor returns the anchor material for a leaf node.
+	LeafAnchor func(node *tree.Node) (TreeLeafAnchor, error)
+
+	// Root identifies the asset spent by the root node.
+	Root TreeRootAssetSource
+
+	// Digest scopes the deterministic OP_TRUE script keys of this
+	// tree's outputs.
+	Digest tapsdk.Hash
+}
+
+// nodeAssetHandoff carries everything a child node commit needs from its
+// materialized parent.
+type nodeAssetHandoff struct {
+	source       *assetSpendSource
+	amount       uint64
+	signingTweak tapsdk.Hash
+	pkScript     []byte
+}
+
+// TreeMaterializer implements tree.Materializer for asset-aware trees: it
+// commits one tap-sdk custom-anchor transition per node, top-down, letting
+// tapd graft the asset commitment into every output key while this side
+// pins the Bitcoin topology byte-for-byte.
+type TreeMaterializer struct {
+	cfg      TreeMaterializerConfig
+	driver   customAnchorDriver
+	handoffs map[wire.OutPoint]*nodeAssetHandoff
+}
+
+// NewTreeMaterializer returns a materializer for one asset tree.
+func NewTreeMaterializer(cfg TreeMaterializerConfig) (*TreeMaterializer,
+	error) {
+
+	if cfg.Wallet == nil {
+		return nil, fmt.Errorf("tap-sdk wallet is required")
+	}
+	if cfg.AssetContext == nil {
+		return nil, fmt.Errorf("asset tree context is required")
+	}
+	if cfg.LeafAnchor == nil {
+		return nil, fmt.Errorf("leaf anchor resolver is required")
+	}
+	if len(cfg.SweepLeaf.Script) == 0 {
+		return nil, fmt.Errorf("sweep leaf is required")
+	}
+
+	return &TreeMaterializer{
+		cfg: cfg,
+		driver: &sdkDriver{
+			wallet: cfg.Wallet,
+		},
+		handoffs: make(map[wire.OutPoint]*nodeAssetHandoff),
+	}, nil
+}
+
+// MaterializeNode commits the asset transition of one tree node and fills
+// in its Bitcoin transaction data.
+func (m *TreeMaterializer) MaterializeNode(ctx context.Context, node *tree.Node,
+	params tree.MaterializeParams) (map[uint32]tree.MaterializeParams,
+	error) {
+
+	node.Input = params.Input
+
+	source, amount, tweak, spentPkScript, err := m.resolveInput(
+		params.Input,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Bind the node's key material to the output it spends before any
+	// external call: the MuSig2 aggregate of the node's cosigners,
+	// tweaked with the recorded signing tweak, must reproduce the spent
+	// output's script exactly.
+	finalKey, err := boundFinalKey(node.CoSigners, tweak, spentPkScript)
+	if err != nil {
+		return nil, fmt.Errorf("node %s: %w", params.Input, err)
+	}
+
+	template, outputSpecs, err := m.buildTemplate(node)
+	if err != nil {
+		return nil, fmt.Errorf("node %s: %w", params.Input, err)
+	}
+
+	committed, err := m.commitNode(
+		ctx, node, params.Input, source, amount, template, outputSpecs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("node %s: %w", params.Input, err)
+	}
+
+	committedTx, err := m.validateCommit(
+		params.Input, amount, template, outputSpecs, committed,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("node %s: %w", params.Input, err)
+	}
+
+	// The committed transaction is authoritative: its outputs carry the
+	// asset commitments every descendant binds to.
+	node.Outputs = committedTx.TxOut
+	node.FinalKey = finalKey
+
+	m.cfg.AssetContext.SetSigningTweak(params.Input, tweak)
+	m.cfg.AssetContext.SetSealedPackage(
+		params.Input, committed.packageBytes,
+	)
+
+	return m.prepareChildren(
+		node, params.Input, source, committedTx, committed, outputSpecs,
+	)
+}
+
+// resolveInput returns the asset spend source and binding material for the
+// node transaction spending the given outpoint.
+func (m *TreeMaterializer) resolveInput(input wire.OutPoint) (*assetSpendSource,
+	uint64, []byte, []byte, error) {
+
+	if handoff, ok := m.handoffs[input]; ok {
+		delete(m.handoffs, input)
+
+		return handoff.source, handoff.amount,
+			handoff.signingTweak[:], handoff.pkScript, nil
+	}
+
+	// No handoff means this is the root node spending the batch output.
+	root := m.cfg.Root
+	if len(root.SigningTweak) == 0 || len(root.BatchPkScript) == 0 {
+		return nil, 0, nil, nil, fmt.Errorf("root asset source is " +
+			"incomplete")
+	}
+
+	source := &assetSpendSource{
+		witness: tapsdk.CustomAssetWitnessPlan{
+			Mode:  witnessCallerProvided,
+			Stack: cloneByteSlices(root.Witness),
+		},
+		verifier: root.Verifier,
+	}
+	switch {
+	case len(root.ProofFile) != 0:
+		source.proofFile = append([]byte(nil), root.ProofFile...)
+
+	case len(root.ProofPath) != 0:
+		var path tapsdk.AssetProofPath
+		if err := path.UnmarshalBinary(root.ProofPath); err != nil {
+			return nil, 0, nil, nil, fmt.Errorf("decode root "+
+				"proof path: %w", err)
+		}
+		source.proofPath = &path
+
+	default:
+		return nil, 0, nil, nil, fmt.Errorf("root proof source is " +
+			"empty")
+	}
+
+	// The root input's asset amount is authenticated by the proof
+	// verifier at commit time; children instead carry their parent's
+	// authenticated output amount, checked against the output total.
+	return source, 0, root.SigningTweak, root.BatchPkScript, nil
+}
+
+// buildTemplate constructs the node's Bitcoin transaction template with
+// uncomposed output scripts, and describes each asset output for the
+// commit request.
+func (m *TreeMaterializer) buildTemplate(node *tree.Node) (*psbt.Packet,
+	[]treeOutputSpec, error) {
+
+	indices := sortedChildIndices(node.Children)
+
+	tx := wire.NewMsgTx(3)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: node.Input,
+		Sequence:         wire.MaxTxInSequenceNum,
+	})
+
+	var specs []treeOutputSpec
+	if len(indices) == 0 {
+		anchor, err := m.cfg.LeafAnchor(node)
+		if err != nil {
+			return nil, nil, err
+		}
+		leafAmount := m.cfg.AssetContext.NodeAssetAmount(node)
+		if leafAmount == 0 {
+			return nil, nil, fmt.Errorf("leaf carries no asset " +
+				"amount")
+		}
+
+		tx.AddTxOut(
+			wire.NewTxOut(
+				int64(node.Amount), anchor.UncomposedPkScript,
+			),
+		)
+		specs = append(specs, treeOutputSpec{
+			index:       0,
+			assetAmount: leafAmount,
+			btcValue:    int64(node.Amount),
+			internalKey: anchor.InternalKey,
+			tapLeaves:   anchor.TapLeaves,
+		})
+	}
+
+	for _, idx := range indices {
+		child := node.Children[idx]
+		childAmount := m.cfg.AssetContext.NodeAssetAmount(child)
+		if childAmount == 0 {
+			return nil, nil, fmt.Errorf("child %d carries no "+
+				"asset amount", idx)
+		}
+
+		internalKey, err := tree.ComputeInternalKey(child.CoSigners)
+		if err != nil {
+			return nil, nil, err
+		}
+		uncomposed, err := tree.ComputeFinalKey(
+			child.CoSigners, m.sweepRoot(),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		uncomposedScript, err := txscript.PayToTaprootScript(
+			uncomposed,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		tx.AddTxOut(
+			wire.NewTxOut(
+				int64(child.Amount), uncomposedScript,
+			),
+		)
+		specs = append(specs, treeOutputSpec{
+			index:       idx,
+			assetAmount: childAmount,
+			btcValue:    int64(child.Amount),
+			internalKey: internalKey,
+			tapLeaves:   []txscript.TapLeaf{m.cfg.SweepLeaf},
+		})
+	}
+
+	// Zero-fee node transactions carry a trailing P2A output for
+	// broadcast-time fee bumping.
+	tx.AddTxOut(arkscript.AnchorOutput())
+
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return packet, specs, nil
+}
+
+// treeOutputSpec describes one asset output of a node transaction.
+type treeOutputSpec struct {
+	index       uint32
+	assetAmount uint64
+	btcValue    int64
+	internalKey *btcec.PublicKey
+	tapLeaves   []txscript.TapLeaf
+}
+
+// sweepRoot returns the tap hash of the operator sweep leaf.
+func (m *TreeMaterializer) sweepRoot() []byte {
+	hash := m.cfg.SweepLeaf.TapHash()
+
+	return hash[:]
+}
+
+// commitNode assembles and commits the node's custom-anchor request.
+func (m *TreeMaterializer) commitNode(ctx context.Context, node *tree.Node,
+	input wire.OutPoint, source *assetSpendSource, amount uint64,
+	template *psbt.Packet, specs []treeOutputSpec) (*commitResult, error) {
+
+	anchorBytes, err := psbtutil.Serialize(template)
+	if err != nil {
+		return nil, err
+	}
+
+	// The node input's total asset amount is the sum of its outputs:
+	// tree transitions never burn or mint.
+	var total uint64
+	for _, spec := range specs {
+		total += spec.assetAmount
+	}
+	if amount != 0 && amount != total {
+		return nil, fmt.Errorf("input amount %d does not match output "+
+			"total %d", amount, total)
+	}
+
+	assetInput, err := source.customInput(
+		"wavelength-tree-node", m.cfg.AssetRef, total,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	outputs := make([]tapsdk.CustomAssetOutput, len(specs))
+	for i, spec := range specs {
+		opTrueKey := deterministicKey(
+			m.cfg.Digest, fmt.Sprintf("tree/%s/%d", input,
+				spec.index),
+		)
+		outputs[i] = tapsdk.CustomAssetOutput{
+			ID: fmt.Sprintf(
+				"wavelength-tree-out-%d", spec.index,
+			),
+			AssetRef:          m.cfg.AssetRef,
+			Amount:            spec.assetAmount,
+			AnchorOutputIndex: spec.index,
+			AnchorValueSat:    uint64(spec.btcValue),
+			Script: tapsdk.CustomAssetScriptPlan{
+				Mode: tapsdk.CustomAssetScriptOPTrue,
+				OPTrue: &tapsdk.CustomAssetOPTrueScriptPlan{
+					InternalKey: tapsdk.KeyDescriptor{
+						RawKeyBytes: opTrueKey,
+					},
+				},
+			},
+			Anchor: anchorPlan(spec.internalKey, spec.tapLeaves),
+		}
+	}
+
+	request := &tapsdk.CustomAnchorRequest{
+		Inputs: []tapsdk.CustomAssetInput{
+			assetInput,
+		},
+		Outputs:    outputs,
+		AnchorPSBT: anchorBytes,
+		Funding:    callerFundedExact(),
+		PassiveAssets: tapsdk.CustomAnchorPassiveAssets{
+			Policy: tapsdk.CustomAnchorPassiveReject,
+		},
+		LossPolicy: tapsdk.CustomAnchorLossPolicy{
+			Mode: tapsdk.CustomAnchorLossReject,
+		},
+		SigningPlans: []tapsdk.CustomAnchorInputSigningPlan{
+			musig2SigningPlan(0, node.CoSigners),
+		},
+	}
+
+	return m.driver.Commit(ctx, request, source.verifier)
+}
+
+// validateCommit binds the sealed result to the exact template: the
+// committed transaction may differ only in the asset outputs' scripts,
+// which must reproduce from each output's internal key and authenticated
+// merkle root.
+func (m *TreeMaterializer) validateCommit(input wire.OutPoint, amount uint64,
+	template *psbt.Packet, specs []treeOutputSpec,
+	committed *commitResult) (*wire.MsgTx, error) {
+
+	if committed.fundingMode !=
+		tapsdk.CustomAnchorFundingCallerFundedExact {
+		return nil, fmt.Errorf("unexpected funding mode %d",
+			committed.fundingMode)
+	}
+	if committed.actualFeeSat != 0 {
+		return nil, fmt.Errorf("node transactions must be zero "+
+			"fee, got %d", committed.actualFeeSat)
+	}
+	if len(committed.inputs) != 1 {
+		return nil, fmt.Errorf("expected one asset input, got %d",
+			len(committed.inputs))
+	}
+	if committed.inputs[0].anchorOutpoint != sdkOutpoint(input) {
+		return nil, fmt.Errorf("asset input outpoint mismatch")
+	}
+	if len(committed.outputs) != len(specs) {
+		return nil, fmt.Errorf("expected %d asset outputs, got %d",
+			len(specs), len(committed.outputs))
+	}
+
+	arkTx, err := psbtutil.Parse(committed.anchorPSBT)
+	if err != nil {
+		return nil, err
+	}
+	committedTx := arkTx.UnsignedTx
+
+	// Rebuild the expected transaction from the template by patching
+	// only the asset outputs' scripts with the committed composed
+	// scripts, then require byte equality: any other divergence means
+	// the backend changed topology behind our back.
+	expected := template.UnsignedTx.Copy()
+	byIndex := make(map[uint32]*commitOutput, len(committed.outputs))
+	for i := range committed.outputs {
+		out := &committed.outputs[i]
+		byIndex[out.anchorOutputIndex] = out
+	}
+
+	for _, spec := range specs {
+		out, ok := byIndex[spec.index]
+		if !ok {
+			return nil, fmt.Errorf("committed result misses "+
+				"output %d", spec.index)
+		}
+		if out.amount != spec.assetAmount {
+			return nil, fmt.Errorf("output %d asset amount "+
+				"%d, want %d", spec.index, out.amount,
+				spec.assetAmount)
+		}
+		if out.anchorValueSat != spec.btcValue {
+			return nil, fmt.Errorf("output %d carrier value "+
+				"%d, want %d", spec.index, out.anchorValueSat,
+				spec.btcValue)
+		}
+		if out.scriptMode != tapsdk.CustomAssetScriptOPTrue {
+			return nil, fmt.Errorf("output %d script mode %d is "+
+				"not OP_TRUE", spec.index, out.scriptMode)
+		}
+		if len(out.opTrueWitness) == 0 || len(out.proofBlob) == 0 {
+			return nil, fmt.Errorf("output %d misses witness or "+
+				"proof material", spec.index)
+		}
+		if out.taprootMerkleRoot == (tapsdk.Hash{}) {
+			return nil, fmt.Errorf("output %d misses its "+
+				"merkle root", spec.index)
+		}
+
+		// The composed script must reproduce from the declared
+		// internal key and the authenticated combined root.
+		composedKey := txscript.ComputeTaprootOutputKey(
+			spec.internalKey, out.taprootMerkleRoot[:],
+		)
+		composedScript, err := txscript.PayToTaprootScript(
+			composedKey,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if int(spec.index) >= len(committedTx.TxOut) {
+			return nil, fmt.Errorf("committed tx misses output %d",
+				spec.index)
+		}
+		if !bytes.Equal(
+			committedTx.TxOut[spec.index].PkScript, composedScript,
+		) {
+			return nil, fmt.Errorf("output %d script does not "+
+				"reproduce from its merkle root", spec.index)
+		}
+
+		expected.TxOut[spec.index].PkScript = composedScript
+	}
+
+	var expectedBuf, committedBuf bytes.Buffer
+	if err := expected.Serialize(&expectedBuf); err != nil {
+		return nil, err
+	}
+	if err := committedTx.Serialize(&committedBuf); err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(expectedBuf.Bytes(), committedBuf.Bytes()) {
+		return nil, fmt.Errorf("committed transaction diverges from " +
+			"the node template")
+	}
+
+	return committedTx, nil
+}
+
+// prepareChildren derives each child's spend source and binding material
+// from the committed parent.
+func (m *TreeMaterializer) prepareChildren(node *tree.Node, input wire.OutPoint,
+	source *assetSpendSource, committedTx *wire.MsgTx,
+	committed *commitResult, specs []treeOutputSpec) (
+	map[uint32]tree.MaterializeParams, error) {
+
+	childParams := make(
+		map[uint32]tree.MaterializeParams, len(node.Children),
+	)
+	if len(node.Children) == 0 {
+		return childParams, nil
+	}
+
+	byIndex := make(map[uint32]*commitOutput, len(committed.outputs))
+	for i := range committed.outputs {
+		out := &committed.outputs[i]
+		byIndex[out.anchorOutputIndex] = out
+	}
+
+	serializedTx := serializeTx(committedTx)
+	txid := committedTx.TxHash()
+
+	for idx := range node.Children {
+		out, ok := byIndex[idx]
+		if !ok {
+			return nil, fmt.Errorf("committed result misses child "+
+				"output %d", idx)
+		}
+
+		childInput := wire.OutPoint{Hash: txid, Index: idx}
+		transitionInput, verifier, err := source.appendTransition(
+			out.proofBlob, out.opTrueWitness,
+			&expectedUnconfirmedAnchor{
+				previousOutpoint: sdkOutpoint(input),
+				anchorOutpoint:   out.anchorOutpoint,
+				transaction: append(
+					[]byte(nil), serializedTx...,
+				),
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("child %d: %w", idx, err)
+		}
+
+		m.handoffs[childInput] = &nodeAssetHandoff{
+			source: &assetSpendSource{
+				proofPath: transitionInput.ProofPath,
+				witness:   transitionInput.Witness,
+				verifier:  verifier,
+			},
+			amount:       out.amount,
+			signingTweak: out.taprootMerkleRoot,
+			pkScript: append(
+				[]byte(nil), committedTx.TxOut[idx].PkScript...,
+			),
+		}
+		childParams[idx] = tree.MaterializeParams{Input: childInput}
+	}
+
+	return childParams, nil
+}
+
+// boundFinalKey recomputes the spent output's key from the node's
+// cosigners and signing tweak and requires it to reproduce the spent
+// output's script exactly.
+func boundFinalKey(cosigners []*btcec.PublicKey, tweak,
+	spentPkScript []byte) (*btcec.PublicKey, error) {
+
+	internalKey, err := tree.ComputeInternalKey(cosigners)
+	if err != nil {
+		return nil, err
+	}
+	finalKey := txscript.ComputeTaprootOutputKey(internalKey, tweak)
+
+	script, err := txscript.PayToTaprootScript(finalKey)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(script, spentPkScript) {
+		return nil, fmt.Errorf("cosigners and signing tweak do not " +
+			"reproduce the spent output script")
+	}
+
+	return finalKey, nil
+}
+
+// musig2SigningPlan declares the MuSig2 aggregate key spend of one anchor
+// input.
+func musig2SigningPlan(index uint32,
+	cosigners []*btcec.PublicKey) tapsdk.CustomAnchorInputSigningPlan {
+
+	participants := make([]tapsdk.XOnlyPubKey, 0, len(cosigners))
+	for _, cosigner := range cosigners {
+		key, _ := tapsdk.ParseXOnlyPubKey(
+			schnorr.SerializePubKey(cosigner),
+		)
+		participants = append(participants, key)
+	}
+
+	return tapsdk.CustomAnchorInputSigningPlan{
+		InputIndex: index,
+		MuSig2: &tapsdk.CustomAnchorMuSig2SigningPlan{
+			Participants: participants,
+		},
+	}
+}
+
+// sortedChildIndices returns a node's child indices in ascending order.
+func sortedChildIndices(children map[uint32]*tree.Node) []uint32 {
+	indices := make([]uint32, 0, len(children))
+	for idx := range children {
+		indices = append(indices, idx)
+	}
+	sort.Slice(indices, func(i, j int) bool {
+		return indices[i] < indices[j]
+	})
+
+	return indices
+}

--- a/tapassets/tree_materializer.go
+++ b/tapassets/tree_materializer.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
@@ -720,11 +719,9 @@ func musig2SigningPlan(index uint32, cosigners []*btcec.PublicKey,
 		) < 0
 	})
 
-	participants := make([]tapsdk.XOnlyPubKey, 0, len(sorted))
+	participants := make([]tapsdk.PubKey, 0, len(sorted))
 	for _, cosigner := range sorted {
-		key, _ := tapsdk.ParseXOnlyPubKey(
-			schnorr.SerializePubKey(cosigner),
-		)
+		key, _ := tapsdk.ParsePubKey(cosigner.SerializeCompressed())
 		participants = append(participants, key)
 	}
 

--- a/tapassets/tree_materializer.go
+++ b/tapassets/tree_materializer.go
@@ -48,7 +48,8 @@ type TreeRootAssetSource struct {
 	ProofPath []byte
 
 	// Witness is the caller-provided asset witness stack authorizing
-	// the batch output's asset spend.
+	// the batch output's asset spend. Empty selects tapd's backend
+	// signer, for batch outputs whose asset script key is wallet-owned.
 	Witness [][]byte
 
 	// Verifier verifies the proof source when building each commit.
@@ -91,10 +92,55 @@ type TreeMaterializerConfig struct {
 	Digest tapsdk.Hash
 }
 
+// treePathVerifier binds every unconfirmed step of a node's compact proof
+// path to the exact ancestor transaction the materializer committed.
+// Unlike the OOR verifiers, which bind only the newest step, tree paths
+// grow one step per level and every level is materializer-authored, so
+// each one is checked byte-for-byte.
+type treePathVerifier struct {
+	base  tapsdk.ConfirmedProofVerifier
+	steps []*expectedUnconfirmedAnchor
+}
+
+// VerifyConfirmedProof delegates the confirmed base to the batch anchor's
+// verifier.
+func (v *treePathVerifier) VerifyConfirmedProof(ctx context.Context,
+	proofFile []byte) (*tapsdk.ConfirmedProofVerification, error) {
+
+	return v.base.VerifyConfirmedProof(ctx, proofFile)
+}
+
+// VerifyUnconfirmedAnchor requires the step to match the recorded ancestor
+// transaction at its exact position.
+func (v *treePathVerifier) VerifyUnconfirmedAnchor(_ context.Context,
+	transition tapsdk.UnconfirmedAnchorVerification) error {
+
+	if int(transition.StepIndex) >= len(v.steps) {
+		return fmt.Errorf("unexpected unconfirmed proof step %d",
+			transition.StepIndex)
+	}
+	expected := v.steps[transition.StepIndex]
+	if transition.PreviousAnchorOutpoint != expected.previousOutpoint {
+		return fmt.Errorf("step %d previous outpoint mismatch",
+			transition.StepIndex)
+	}
+	if transition.AnchorOutpoint != expected.anchorOutpoint {
+		return fmt.Errorf("step %d anchor outpoint mismatch",
+			transition.StepIndex)
+	}
+	if !bytes.Equal(transition.AnchorTransaction, expected.transaction) {
+		return fmt.Errorf("step %d anchor transaction mismatch",
+			transition.StepIndex)
+	}
+
+	return nil
+}
+
 // nodeAssetHandoff carries everything a child node commit needs from its
 // materialized parent.
 type nodeAssetHandoff struct {
 	source       *assetSpendSource
+	steps        []*expectedUnconfirmedAnchor
 	amount       uint64
 	signingTweak tapsdk.Hash
 	pkScript     []byte
@@ -108,6 +154,10 @@ type TreeMaterializer struct {
 	cfg      TreeMaterializerConfig
 	driver   customAnchorDriver
 	handoffs map[wire.OutPoint]*nodeAssetHandoff
+
+	// currentSteps are the expected unconfirmed anchors of the node
+	// being materialized, extended per child in prepareChildren.
+	currentSteps []*expectedUnconfirmedAnchor
 }
 
 // NewTreeMaterializer returns a materializer for one asset tree.
@@ -201,10 +251,12 @@ func (m *TreeMaterializer) resolveInput(input wire.OutPoint) (*assetSpendSource,
 
 	if handoff, ok := m.handoffs[input]; ok {
 		delete(m.handoffs, input)
+		m.currentSteps = handoff.steps
 
 		return handoff.source, handoff.amount,
 			handoff.signingTweak[:], handoff.pkScript, nil
 	}
+	m.currentSteps = nil
 
 	// No handoff means this is the root node spending the batch output.
 	root := m.cfg.Root
@@ -213,11 +265,21 @@ func (m *TreeMaterializer) resolveInput(input wire.OutPoint) (*assetSpendSource,
 			"incomplete")
 	}
 
-	source := &assetSpendSource{
-		witness: tapsdk.CustomAssetWitnessPlan{
+	// An empty witness stack selects the backend signer: the batch
+	// output's asset script key is a tapd wallet key, so tapd signs the
+	// root transition itself. Tree-internal outputs are OP_TRUE and
+	// always hand their witness stacks forward explicitly.
+	witnessPlan := tapsdk.CustomAssetWitnessPlan{
+		Mode: witnessBackendSigner,
+	}
+	if len(root.Witness) != 0 {
+		witnessPlan = tapsdk.CustomAssetWitnessPlan{
 			Mode:  witnessCallerProvided,
 			Stack: cloneByteSlices(root.Witness),
-		},
+		}
+	}
+	source := &assetSpendSource{
+		witness:  witnessPlan,
 		verifier: root.Verifier,
 	}
 	switch {
@@ -360,6 +422,8 @@ func (m *TreeMaterializer) commitNode(ctx context.Context, node *tree.Node,
 		return nil, err
 	}
 
+	sessionContext := []byte(input.String())
+
 	// The node input's total asset amount is the sum of its outputs:
 	// tree transitions never burn or mint.
 	var total uint64
@@ -418,7 +482,7 @@ func (m *TreeMaterializer) commitNode(ctx context.Context, node *tree.Node,
 			Mode: tapsdk.CustomAnchorLossReject,
 		},
 		SigningPlans: []tapsdk.CustomAnchorInputSigningPlan{
-			musig2SigningPlan(0, node.CoSigners),
+			musig2SigningPlan(0, node.CoSigners, sessionContext),
 		},
 	}
 
@@ -571,26 +635,37 @@ func (m *TreeMaterializer) prepareChildren(node *tree.Node, input wire.OutPoint,
 		}
 
 		childInput := wire.OutPoint{Hash: txid, Index: idx}
-		transitionInput, verifier, err := source.appendTransition(
-			out.proofBlob, out.opTrueWitness,
-			&expectedUnconfirmedAnchor{
-				previousOutpoint: sdkOutpoint(input),
-				anchorOutpoint:   out.anchorOutpoint,
-				transaction: append(
-					[]byte(nil), serializedTx...,
-				),
-			},
+		expected := &expectedUnconfirmedAnchor{
+			previousOutpoint: sdkOutpoint(input),
+			anchorOutpoint:   out.anchorOutpoint,
+			transaction:      append([]byte(nil), serializedTx...),
+		}
+		transitionInput, _, err := source.appendTransition(
+			out.proofBlob, out.opTrueWitness, expected,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("child %d: %w", idx, err)
 		}
 
+		// The child's path carries every ancestor transition, so
+		// its verifier binds every step, not only the newest one.
+		childSteps := make(
+			[]*expectedUnconfirmedAnchor, len(m.currentSteps),
+			len(m.currentSteps)+1,
+		)
+		copy(childSteps, m.currentSteps)
+		childSteps = append(childSteps, expected)
+
 		m.handoffs[childInput] = &nodeAssetHandoff{
 			source: &assetSpendSource{
 				proofPath: transitionInput.ProofPath,
 				witness:   transitionInput.Witness,
-				verifier:  verifier,
+				verifier: &treePathVerifier{
+					base:  m.cfg.Root.Verifier,
+					steps: childSteps,
+				},
 			},
+			steps:        childSteps,
 			amount:       out.amount,
 			signingTweak: out.taprootMerkleRoot,
 			pkScript: append(
@@ -628,12 +703,25 @@ func boundFinalKey(cosigners []*btcec.PublicKey, tweak,
 }
 
 // musig2SigningPlan declares the MuSig2 aggregate key spend of one anchor
-// input.
-func musig2SigningPlan(index uint32,
-	cosigners []*btcec.PublicKey) tapsdk.CustomAnchorInputSigningPlan {
+// input. The session context distinguishes signing sessions; the spent
+// outpoint is unique per node and public by construction.
+func musig2SigningPlan(index uint32, cosigners []*btcec.PublicKey,
+	sessionContext []byte) tapsdk.CustomAnchorInputSigningPlan {
 
-	participants := make([]tapsdk.XOnlyPubKey, 0, len(cosigners))
-	for _, cosigner := range cosigners {
+	// The aggregate internal key sorts cosigners before aggregation, and
+	// the backend aggregates participants in declared order, so declare
+	// them pre-sorted for the two derivations to agree.
+	sorted := make([]*btcec.PublicKey, len(cosigners))
+	copy(sorted, cosigners)
+	sort.Slice(sorted, func(i, j int) bool {
+		return bytes.Compare(
+			sorted[i].SerializeCompressed(),
+			sorted[j].SerializeCompressed(),
+		) < 0
+	})
+
+	participants := make([]tapsdk.XOnlyPubKey, 0, len(sorted))
+	for _, cosigner := range sorted {
 		key, _ := tapsdk.ParseXOnlyPubKey(
 			schnorr.SerializePubKey(cosigner),
 		)
@@ -643,7 +731,8 @@ func musig2SigningPlan(index uint32,
 	return tapsdk.CustomAnchorInputSigningPlan{
 		InputIndex: index,
 		MuSig2: &tapsdk.CustomAnchorMuSig2SigningPlan{
-			Participants: participants,
+			Participants:   participants,
+			SessionContext: sessionContext,
 		},
 	}
 }

--- a/tapassets/tree_materializer_test.go
+++ b/tapassets/tree_materializer_test.go
@@ -459,3 +459,52 @@ func TestTreeMaterializerRejectsTamperedCommit(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildAssetTree drives both passes through the assembler and checks
+// the conservation guards.
+func TestBuildAssetTree(t *testing.T) {
+	t.Parallel()
+
+	f := newTreeMaterializerFixture(t, 800, 200, 500)
+
+	req := AssetTreeRequest{
+		Leaves:        assemblerLeaves(t, 800, 200, 500),
+		OperatorKey:   f.structure.Root.CoSigners[0],
+		Radix:         2,
+		BatchOutpoint: f.batch,
+		BatchOutput:   f.batchOut,
+		AssetAmount:   1_500,
+	}
+
+	short := req
+	short.AssetAmount = 1_499
+	_, _, err := buildAssetTree(t.Context(), f.mat, short)
+	require.ErrorContains(t, err, "batch asset amount")
+
+	wrongValue := req
+	wrongValue.BatchOutput = wire.NewTxOut(29_999, f.batchOut.PkScript)
+	_, _, err = buildAssetTree(t.Context(), f.mat, wrongValue)
+	require.ErrorContains(t, err, "batch output value")
+}
+
+// assemblerLeaves rebuilds leaf descriptors matching the fixture's BTC
+// amounts for assembler-level tests.
+func assemblerLeaves(t *testing.T, amounts ...uint64) []tree.LeafDescriptor {
+	t.Helper()
+
+	leaves := make([]tree.LeafDescriptor, len(amounts))
+	for i, amount := range amounts {
+		_, owner := createTestPubKey(t)
+		leaves[i] = tree.LeafDescriptor{
+			PkScript: []byte{
+				0x51,
+				byte(i),
+			},
+			Amount:      10_000,
+			CoSignerKey: owner,
+			AssetAmount: amount,
+		}
+	}
+
+	return leaves
+}

--- a/tapassets/tree_materializer_test.go
+++ b/tapassets/tree_materializer_test.go
@@ -1,0 +1,461 @@
+package tapassets
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTreeDriver fabricates deterministic commit results consistent with
+// the materializer's fail-closed validation: composed output scripts derive
+// from each requested internal key and a merkle root seeded by the input
+// outpoint, so a whole tree materializes without tapd.
+type fakeTreeDriver struct {
+	commits int
+
+	// mutate optionally corrupts a result before returning it.
+	mutate func(request *tapsdk.CustomAnchorRequest, result *commitResult)
+}
+
+// merkleRootFor derives the fake's deterministic merkle root for one
+// output.
+func merkleRootFor(input wire.OutPoint, index uint32) tapsdk.Hash {
+	seed := sha256.Sum256([]byte(fmt.Sprintf("root/%s/%d", input, index)))
+
+	return tapsdk.Hash(seed)
+}
+
+// Preview is unused by the tree materializer.
+func (f *fakeTreeDriver) Preview(context.Context, *tapsdk.CustomAnchorRequest,
+	tapsdk.ConfirmedProofVerifier) ([]commitmentPreview, error) {
+
+	return nil, fmt.Errorf("preview is not used by tree materialization")
+}
+
+// Commit echoes the request into a sealed-result projection, composing
+// each asset output's script exactly the way tapd would.
+func (f *fakeTreeDriver) Commit(_ context.Context,
+	request *tapsdk.CustomAnchorRequest, _ tapsdk.ConfirmedProofVerifier) (
+	*commitResult, error) {
+
+	f.commits++
+
+	template, err := psbtutil.Parse(request.AnchorPSBT)
+	if err != nil {
+		return nil, err
+	}
+	committedTx := template.UnsignedTx.Copy()
+	input := committedTx.TxIn[0].PreviousOutPoint
+
+	result := &commitResult{
+		fundingMode: tapsdk.CustomAnchorFundingCallerFundedExact,
+		inputs: []commitInput{{
+			anchorOutpoint: sdkOutpoint(input),
+			assetRef:       request.Inputs[0].AssetRef,
+			amount:         request.Inputs[0].Amount,
+		}},
+	}
+
+	for _, out := range request.Outputs {
+		merkleRoot := merkleRootFor(input, out.AnchorOutputIndex)
+
+		internalKey, err := btcec.ParsePubKey(
+			out.Anchor.InternalKey.PubKey[:],
+		)
+		if err != nil {
+			return nil, err
+		}
+		composed := txscript.ComputeTaprootOutputKey(
+			internalKey, merkleRoot[:],
+		)
+		composedScript, err := txscript.PayToTaprootScript(composed)
+		if err != nil {
+			return nil, err
+		}
+		committedTx.TxOut[out.AnchorOutputIndex].PkScript =
+			composedScript
+
+		result.outputs = append(result.outputs, commitOutput{
+			anchorOutputIndex: out.AnchorOutputIndex,
+			anchorOutpoint: sdkOutpoint(wire.OutPoint{
+				Hash:  committedTx.TxHash(),
+				Index: out.AnchorOutputIndex,
+			}),
+			anchorValueSat:    int64(out.AnchorValueSat),
+			assetRef:          out.AssetRef,
+			amount:            out.Amount,
+			taprootMerkleRoot: merkleRoot,
+			scriptMode:        tapsdk.CustomAssetScriptOPTrue,
+			opTrueWitness:     [][]byte{{0x51}},
+			proofBlob: []byte(
+				fmt.Sprintf("proof/%s/%d", input,
+					out.AnchorOutputIndex),
+			),
+		})
+	}
+
+	// Re-derive per-output anchor outpoints now that every script (and
+	// therefore the txid) is final.
+	txid := committedTx.TxHash()
+	for i := range result.outputs {
+		result.outputs[i].anchorOutpoint = sdkOutpoint(wire.OutPoint{
+			Hash:  txid,
+			Index: result.outputs[i].anchorOutputIndex,
+		})
+	}
+
+	committedPacket, err := psbtutil.Parse(request.AnchorPSBT)
+	if err != nil {
+		return nil, err
+	}
+	committedPacket.UnsignedTx = committedTx
+	anchorBytes, err := psbtutil.Serialize(committedPacket)
+	if err != nil {
+		return nil, err
+	}
+	result.anchorPSBT = anchorBytes
+	result.packageBytes = []byte(fmt.Sprintf("package/%s", input))
+
+	if f.mutate != nil {
+		f.mutate(request, result)
+	}
+
+	return result, nil
+}
+
+// DecodePackage is unused by the tree materializer.
+func (f *fakeTreeDriver) DecodePackage([]byte) (*commitResult, error) {
+	return nil, fmt.Errorf("decode is not used by tree materialization")
+}
+
+// treeMaterializerFixture bundles a built structure with a materializer
+// wired to the fake driver.
+type treeMaterializerFixture struct {
+	structure *tree.Structure
+	mat       *TreeMaterializer
+	driver    *fakeTreeDriver
+	batch     wire.OutPoint
+	batchOut  *wire.TxOut
+	rootTweak []byte
+}
+
+// newTreeMaterializerFixture builds a three-leaf asset tree structure and a
+// materializer whose root source binds to a synthetic batch output.
+func newTreeMaterializerFixture(t *testing.T,
+	amounts ...uint64) *treeMaterializerFixture {
+
+	t.Helper()
+
+	_, operatorKey := createTestPubKey(t)
+	leaves := make([]tree.LeafDescriptor, len(amounts))
+	for i, amount := range amounts {
+		_, owner := createTestPubKey(t)
+		leaves[i] = tree.LeafDescriptor{
+			PkScript: []byte{
+				0x51,
+				byte(i),
+			},
+			Amount:      10_000,
+			CoSignerKey: owner,
+			AssetAmount: amount,
+		}
+	}
+
+	structure, err := tree.BuildStructure(leaves, tree.StructureConfig{
+		OperatorKey: operatorKey,
+		Radix:       2,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, structure.AssetContext)
+
+	sweepLeaf := txscript.NewBaseTapLeaf([]byte{0x51, 0xB2})
+
+	// The batch output script must reproduce from the root cosigners
+	// and the root signing tweak, mirroring a real batch commit.
+	rootTweak := bytes.Repeat([]byte{0x0C}, 32)
+	rootInternal, err := tree.ComputeInternalKey(
+		structure.Root.CoSigners,
+	)
+	require.NoError(t, err)
+	batchKey := txscript.ComputeTaprootOutputKey(rootInternal, rootTweak)
+	batchScript, err := txscript.PayToTaprootScript(batchKey)
+	require.NoError(t, err)
+
+	batchOutpoint := wire.OutPoint{Hash: chainhash.Hash{0xBA}, Index: 1}
+
+	driver := &fakeTreeDriver{}
+	assetRef := tapsdk.AssetRefFromAssetID(tapsdk.AssetID{0xAA})
+
+	mat := &TreeMaterializer{
+		cfg: TreeMaterializerConfig{
+			AssetRef:     assetRef,
+			AssetContext: structure.AssetContext,
+			SweepLeaf:    sweepLeaf,
+			LeafAnchor: func(node *tree.Node) (TreeLeafAnchor,
+				error) {
+
+				_, leafInternal := createTestPubKey(t)
+				script, err := txscript.PayToTaprootScript(
+					leafInternal,
+				)
+				if err != nil {
+					return TreeLeafAnchor{}, err
+				}
+
+				return TreeLeafAnchor{
+					UncomposedPkScript: script,
+					InternalKey:        leafInternal,
+					TapLeaves: []txscript.TapLeaf{
+						txscript.NewBaseTapLeaf(
+							[]byte{0x51},
+						),
+					},
+				}, nil
+			},
+			Root: TreeRootAssetSource{
+				ProofFile: []byte{
+					0x01,
+				},
+				Witness: [][]byte{
+					{
+						0x51,
+					},
+				},
+				SigningTweak:  rootTweak,
+				BatchPkScript: batchScript,
+			},
+			Digest: tapsdk.Hash{
+				0xD1,
+			},
+		},
+		driver:   driver,
+		handoffs: make(map[wire.OutPoint]*nodeAssetHandoff),
+	}
+
+	return &treeMaterializerFixture{
+		structure: structure,
+		mat:       mat,
+		driver:    driver,
+		batch:     batchOutpoint,
+		batchOut:  wire.NewTxOut(30_000, batchScript),
+		rootTweak: rootTweak,
+	}
+}
+
+// createTestPubKey returns a fresh keypair for fixtures.
+func createTestPubKey(t *testing.T) (*btcec.PrivateKey, *btcec.PublicKey) {
+	t.Helper()
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return priv, priv.PubKey()
+}
+
+// TestTreeMaterializerBuildsAssetTree materializes a full three-leaf tree
+// against the fake driver and checks every binding the design relies on.
+func TestTreeMaterializerBuildsAssetTree(t *testing.T) {
+	t.Parallel()
+
+	f := newTreeMaterializerFixture(t, 800, 200, 500)
+
+	err := tree.Materialize(
+		t.Context(), f.structure.Root, tree.MaterializeParams{
+			Input: f.batch,
+		},
+		f.mat,
+	)
+	require.NoError(t, err)
+
+	// One commit per node: 3 leaves at radix 2 form 5 transactions.
+	require.Equal(t, 5, f.driver.commits)
+
+	// The materialized tree must be structurally consistent: every
+	// child input references its parent output.
+	built := &tree.Tree{
+		Root:          f.structure.Root,
+		BatchOutpoint: f.batch,
+		BatchOutput:   f.batchOut,
+	}
+	require.NoError(t, built.Verify())
+
+	assetCtx := f.structure.AssetContext
+	require.Equal(t, f.rootTweak, assetCtx.SigningTweak(f.batch))
+
+	for node := range f.structure.Root.NodesIter() {
+		// Every node carries its committed outputs plus the P2A
+		// anchor, its bound final key, and its recorded material.
+		require.NotEmpty(t, node.Outputs)
+		require.NotNil(t, node.FinalKey)
+		require.NotEmpty(t, assetCtx.SigningTweak(node.Input))
+		require.NotEmpty(t, assetCtx.SealedPackage(node.Input))
+
+		expectedOutputs := len(node.Children) + 1
+		if len(node.Children) == 0 {
+			expectedOutputs = 2
+		}
+		require.Len(t, node.Outputs, expectedOutputs)
+
+		// Children sign with their parent output's merkle root.
+		for idx, child := range node.Children {
+			require.Equal(
+				t, merkleRootFor(node.Input, idx),
+				tapsdk.Hash(
+					assetCtx.SigningTweak(
+						child.Input,
+					),
+				),
+			)
+		}
+	}
+
+	// The root's final key must reproduce the batch output script.
+	rootScript, err := txscript.PayToTaprootScript(
+		f.structure.Root.FinalKey,
+	)
+	require.NoError(t, err)
+	require.Equal(t, f.batchOut.PkScript, rootScript)
+}
+
+// TestTreeMaterializerRejectsZeroAmountChild ensures a subtree without
+// asset units fails closed instead of committing an empty transition.
+func TestTreeMaterializerRejectsZeroAmountChild(t *testing.T) {
+	t.Parallel()
+
+	f := newTreeMaterializerFixture(t, 800, 0)
+
+	err := tree.Materialize(
+		t.Context(), f.structure.Root, tree.MaterializeParams{
+			Input: f.batch,
+		},
+		f.mat,
+	)
+	require.ErrorContains(t, err, "carries no asset amount")
+}
+
+// TestTreeMaterializerRejectsUnknownInput ensures a node whose input has
+// no recorded handoff (and is not the root) fails closed.
+func TestTreeMaterializerRejectsUnknownInput(t *testing.T) {
+	t.Parallel()
+
+	f := newTreeMaterializerFixture(t, 800, 200)
+	f.mat.cfg.Root = TreeRootAssetSource{}
+
+	err := tree.Materialize(
+		t.Context(), f.structure.Root, tree.MaterializeParams{
+			Input: f.batch,
+		},
+		f.mat,
+	)
+	require.ErrorContains(t, err, "root asset source is incomplete")
+}
+
+// TestTreeMaterializerRejectsTamperedCommit ensures every deviation of the
+// committed result from the pinned template fails closed.
+func TestTreeMaterializerRejectsTamperedCommit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(*tapsdk.CustomAnchorRequest, *commitResult)
+		wantErr string
+	}{
+		{
+			name: "nonzero fee",
+			mutate: func(_ *tapsdk.CustomAnchorRequest,
+				result *commitResult) {
+
+				result.actualFeeSat = 10
+			},
+			wantErr: "must be zero fee",
+		},
+		{
+			name: "input outpoint drift",
+			mutate: func(_ *tapsdk.CustomAnchorRequest,
+				result *commitResult) {
+
+				result.inputs[0].anchorOutpoint.Index++
+			},
+			wantErr: "outpoint mismatch",
+		},
+		{
+			name: "script mode downgrade",
+			mutate: func(_ *tapsdk.CustomAnchorRequest,
+				result *commitResult) {
+
+				result.outputs[0].scriptMode =
+					tapsdk.CustomAssetScriptWallet
+			},
+			wantErr: "not OP_TRUE",
+		},
+		{
+			name: "merkle root drift",
+			mutate: func(_ *tapsdk.CustomAnchorRequest,
+				result *commitResult) {
+
+				result.outputs[0].taprootMerkleRoot[0] ^= 1
+			},
+			wantErr: "does not reproduce",
+		},
+		{
+			name: "asset amount drift",
+			mutate: func(_ *tapsdk.CustomAnchorRequest,
+				result *commitResult) {
+
+				result.outputs[0].amount++
+			},
+			wantErr: "asset amount",
+		},
+		{
+			name: "topology drift",
+			mutate: func(_ *tapsdk.CustomAnchorRequest,
+				result *commitResult) {
+
+				packet, err := psbtutil.Parse(
+					result.anchorPSBT,
+				)
+				if err != nil {
+					panic(err)
+				}
+				packet.UnsignedTx.TxOut[len(
+					packet.UnsignedTx.TxOut,
+				)-1].Value = 1
+				encoded, err := psbtutil.Serialize(packet)
+				if err != nil {
+					panic(err)
+				}
+				result.anchorPSBT = encoded
+			},
+			wantErr: "diverges from the node template",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTreeMaterializerFixture(t, 800, 200)
+			f.driver.mutate = test.mutate
+
+			err := tree.Materialize(
+				t.Context(), f.structure.Root,
+				tree.MaterializeParams{
+					Input: f.batch,
+				},
+				f.mat,
+			)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
Stacked on #1062. First milestone (M1) of the asset-tree convergence plan: asset materialization for the two-pass tree pipeline, built on tap-sdk custom anchors, with an end-to-end acceptance test against a real tapd.

## What this adds

- `tree: support per-node signing tweaks` — optional per-node taproot tweak lookup in the signer sessions (asset trees commit a per-node asset root into each output key), the untweaked MuSig2 aggregate (`ComputeInternalKey`) that tapd derives anchor keys from, and `SessionIDs` for signature aggregation. Includes a pinned invariant test that `ComputeTaprootOutputKey(internalKey, tweak)` equals `ComputeFinalKey(cosigners, tweak)`.
- `tree: carry asset amounts through structure building` — `LeafDescriptor.AssetAmount` and `AssetTreeContext`: subtree asset totals folded bottom-up during the structure pass, per-node signing tweaks and sealed packages keyed by input outpoint after materialization (survives path extraction, which clones nodes).
- `tapassets: materialize asset trees via tap-sdk` — `TreeMaterializer` implements `tree.Materializer`: one sealed custom-anchor commit per node, top-down. Every node's key material is bound fail-closed in both directions (cosigners + tweak must reproduce the spent script before the commit; tapd's composed outputs must reproduce our template byte-for-byte after it). Child spends chain through compact proof paths with a `treePathVerifier` that binds **every** unconfirmed step to the exact ancestor transaction the materializer committed — trees grow one step per level, unlike OOR's single-step paths.
- `tapassets: assemble asset trees end to end` — `BuildAssetTree`: conservation guards (leaf sats == batch value, leaf assets == batch asset amount), structure pass, materialization, `tree.Verify()`.
- `multi: add asset tree e2e against real tapd` — the M1 acceptance gate (see below).

## E2E acceptance test

`TestAssetTreeE2E` (guarded by `ARK_ITEST_TAPD_IMAGE`) runs the full lifecycle against a real tapd:

1. Mint a grouped asset and anchor it beneath a MuSig2 batch output (operator + users aggregate, sweep leaf as tapscript sibling), confirmed on-chain via the onboarding driver.
2. Materialize a three-leaf asset tree beneath the batch output: every node is a tapd-committed sealed transition, leaves carry standard VTXO policies with the asset commitment grafted in.
3. Run the real multi-party MuSig2 signing ceremony (per-participant sessions over extracted paths, per-transaction nonce aggregation, partial signature combination) and `VerifySigned()` the whole tree.
4. Unroll the entire tree on-chain through v3 package relay + P2A CPFP fee children, node by node, and confirm every level.

Runs in ~45s locally:

```
ARK_ITEST_TAPD_IMAGE=<tapd image> go test ./tapassets/ -run TestAssetTreeE2E -v
```

## Notes for reviewers

- Node transactions are zero-fee (batch value flows through unchanged); fees come from P2A anchors at unroll time. Commits use `CallerFundedExact`, so tapd contributes no inputs and the Bitcoin topology is pinned exactly.
- MuSig2 signing plans declare participants pre-sorted by compressed serialization because tap-sdk aggregates participants in declared order while the tree aggregate sorts. tap-sdk also parses participants as x-only keys (implicitly even-Y), so the e2e generates even-Y ephemeral tree keys. Follow-up for M2: tap-sdk should accept 33-byte participants so arbitrary cosigner keys work without the even-Y convention.
- The `ToTx()` sequence change and flow-version bump for tree-node transactions are deliberately deferred to M2 (round FSM integration), per the convergence plan.
