### PR TITLE
multi: asset tree wire format, codecs, and flow version V2 (M2.1)

### DIFF
--- a/db/tree_codec.go
+++ b/db/tree_codec.go
@@ -20,6 +20,8 @@ type (
 	tlvTreeBatchOutput   = tlv.TlvType1
 	tlvTreeSweepRoot     = tlv.TlvType2
 	tlvTreeRootNode      = tlv.TlvType3
+	tlvTreeAssetRef      = tlv.TlvType4
+	tlvTreeNodeSequence  = tlv.TlvType5
 )
 
 // Tree-decode safety bounds. The wire layer feeds DeserializeTree from
@@ -46,12 +48,15 @@ const (
 
 // TLV type aliases for Node serialization.
 type (
-	tlvNodeInput     = tlv.TlvType0
-	tlvNodeOutputs   = tlv.TlvType1
-	tlvNodeCoSigners = tlv.TlvType2
-	tlvNodeSignature = tlv.TlvType3
-	tlvNodeFinalKey  = tlv.TlvType4
-	tlvNodeChildren  = tlv.TlvType5
+	tlvNodeInput         = tlv.TlvType0
+	tlvNodeOutputs       = tlv.TlvType1
+	tlvNodeCoSigners     = tlv.TlvType2
+	tlvNodeSignature     = tlv.TlvType3
+	tlvNodeFinalKey      = tlv.TlvType4
+	tlvNodeChildren      = tlv.TlvType5
+	tlvNodeSigningTweak  = tlv.TlvType6
+	tlvNodeSealedPackage = tlv.TlvType7
+	tlvNodeAssetAmount   = tlv.TlvType8
 )
 
 // outpointRecord is a TLV record for wire.OutPoint. It implements
@@ -491,6 +496,16 @@ type tlvTree struct {
 	// RootNodeData is the serialized root node. Uses tlv.Blob (primitive
 	// []byte) directly.
 	RootNodeData tlv.RecordT[tlvTreeRootNode, tlv.Blob]
+
+	// AssetRef is the canonical string encoding of the asset carried by
+	// an asset-aware tree. Empty for Bitcoin-only trees.
+	AssetRef tlv.RecordT[tlvTreeAssetRef, tlv.Blob]
+
+	// NodeSequence is the input sequence shared by every node
+	// transaction of the tree. Zero selects the flow-V1 default; the
+	// value is tree-wide because it is consensus-visible through every
+	// node txid.
+	NodeSequence tlv.RecordT[tlvTreeNodeSequence, uint32]
 }
 
 // newTlvTree creates a new tlvTree with initialized RecordT fields.
@@ -506,22 +521,49 @@ func newTlvTree() *tlvTree {
 		RootNodeData: tlv.NewPrimitiveRecord[tlvTreeRootNode, tlv.Blob](
 			nil,
 		),
+		AssetRef: tlv.NewPrimitiveRecord[tlvTreeAssetRef, tlv.Blob](
+			nil,
+		),
+		NodeSequence: tlv.NewPrimitiveRecord[
+			tlvTreeNodeSequence, uint32,
+		](
+			0,
+		),
 	}
 }
 
-// EncodeRecords returns the TLV records for encoding.
+// EncodeRecords returns the TLV records for encoding. The asset and
+// sequence records are optional so Bitcoin-only flow-V1 blobs stay
+// byte-identical to those written before the records existed.
 func (t *tlvTree) EncodeRecords() []tlv.Record {
-	return []tlv.Record{
+	records := []tlv.Record{
 		t.BatchOutpoint.Record(),
 		t.BatchOutput.Record(),
 		t.SweepRoot.Record(),
 		t.RootNodeData.Record(),
 	}
+
+	if len(t.AssetRef.Val) > 0 {
+		records = append(records, t.AssetRef.Record())
+	}
+
+	if t.NodeSequence.Val != 0 {
+		records = append(records, t.NodeSequence.Record())
+	}
+
+	return records
 }
 
 // DecodeRecords returns the TLV records for decoding.
 func (t *tlvTree) DecodeRecords() []tlv.Record {
-	return t.EncodeRecords()
+	return []tlv.Record{
+		t.BatchOutpoint.Record(),
+		t.BatchOutput.Record(),
+		t.SweepRoot.Record(),
+		t.RootNodeData.Record(),
+		t.AssetRef.Record(),
+		t.NodeSequence.Record(),
+	}
 }
 
 // Encode serializes the tlvTree to a writer.
@@ -563,6 +605,18 @@ type tlvNode struct {
 
 	// Children is the serialized children data.
 	Children tlv.RecordT[tlvNodeChildren, childrenDataRecord]
+
+	// SigningTweak is the node's combined taproot tweak for asset-aware
+	// trees (optional).
+	SigningTweak tlv.RecordT[tlvNodeSigningTweak, tlv.Blob]
+
+	// SealedPackage is the node's sealed asset transfer package
+	// (optional).
+	SealedPackage tlv.RecordT[tlvNodeSealedPackage, tlv.Blob]
+
+	// AssetAmount is the subtree asset total carried by the node
+	// (optional).
+	AssetAmount tlv.RecordT[tlvNodeAssetAmount, uint64]
 }
 
 // newTlvNode creates a new tlvNode with initialized RecordT fields.
@@ -579,6 +633,21 @@ func newTlvNode() *tlvNode {
 		FinalKey:  tlv.NewRecordT[tlvNodeFinalKey](pubKeyRecord{}),
 		Children: tlv.NewRecordT[tlvNodeChildren](
 			childrenDataRecord{},
+		),
+		SigningTweak: tlv.NewPrimitiveRecord[
+			tlvNodeSigningTweak, tlv.Blob,
+		](
+			nil,
+		),
+		SealedPackage: tlv.NewPrimitiveRecord[
+			tlvNodeSealedPackage, tlv.Blob,
+		](
+			nil,
+		),
+		AssetAmount: tlv.NewPrimitiveRecord[
+			tlvNodeAssetAmount, uint64,
+		](
+			0,
 		),
 	}
 }
@@ -601,6 +670,18 @@ func (n *tlvNode) EncodeRecords() []tlv.Record {
 
 	records = append(records, n.Children.Record())
 
+	if len(n.SigningTweak.Val) > 0 {
+		records = append(records, n.SigningTweak.Record())
+	}
+
+	if len(n.SealedPackage.Val) > 0 {
+		records = append(records, n.SealedPackage.Record())
+	}
+
+	if n.AssetAmount.Val != 0 {
+		records = append(records, n.AssetAmount.Record())
+	}
+
 	return records
 }
 
@@ -615,6 +696,9 @@ func (n *tlvNode) DecodeRecords() []tlv.Record {
 		n.Signature.Record(),
 		n.FinalKey.Record(),
 		n.Children.Record(),
+		n.SigningTweak.Record(),
+		n.SealedPackage.Record(),
+		n.AssetAmount.Record(),
 	}
 }
 
@@ -662,9 +746,18 @@ func SerializeTree(t *tree.Tree) ([]byte, error) {
 	// Set SweepRoot.
 	tlvT.SweepRoot.Val = t.SweepTapscriptRoot
 
+	// Asset-aware trees persist their asset ref and node sequence at
+	// tree level; the sequence is tree-wide by invariant.
+	if t.AssetContext != nil {
+		tlvT.AssetRef.Val = []byte(t.AssetContext.AssetRef())
+	}
+	if t.Root != nil {
+		tlvT.NodeSequence.Val = t.Root.Sequence
+	}
+
 	// Serialize RootNode recursively.
 	if t.Root != nil {
-		rootData, err := serializeNode(t.Root)
+		rootData, err := serializeNode(t.Root, t.AssetContext)
 		if err != nil {
 			return nil, fmt.Errorf("serialize root node: %w", err)
 		}
@@ -708,21 +801,38 @@ func DeserializeTree(data []byte) (*tree.Tree, error) {
 
 	// Deserialize root node. Depth starts at 1 so a root with no
 	// children still counts as depth 1, matching the convention used
-	// by tree.Node.Depth.
+	// by tree.Node.Depth. Asset data collects into a context that is
+	// attached only when the blob actually carried any.
+	assetCtx := tree.NewAssetTreeContext()
+	assetCtx.SetAssetRef(string(tlvT.AssetRef.Val))
+
 	if len(tlvT.RootNodeData.Val) > 0 {
-		rootNode, err := deserializeNode(tlvT.RootNodeData.Val, 1)
+		rootNode, err := deserializeNode(
+			tlvT.RootNodeData.Val, 1, assetCtx,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("deserialize root node: %w", err)
 		}
 
+		if tlvT.NodeSequence.Val != 0 {
+			stampSequence(rootNode, tlvT.NodeSequence.Val)
+		}
+
 		t.Root = rootNode
+	}
+
+	if !assetCtx.IsEmpty() {
+		t.AssetContext = assetCtx
 	}
 
 	return t, nil
 }
 
 // serializeNode serializes a tree.Node to bytes using TLV encoding.
-func serializeNode(n *tree.Node) ([]byte, error) {
+// assetCtx contributes the node's asset records when non-nil.
+func serializeNode(n *tree.Node,
+	assetCtx *tree.AssetTreeContext) ([]byte, error) {
+
 	if n == nil {
 		return nil, fmt.Errorf("cannot serialize nil node")
 	}
@@ -748,8 +858,16 @@ func serializeNode(n *tree.Node) ([]byte, error) {
 		tlvN.FinalKey.Val.Key = n.FinalKey
 	}
 
+	// Set the asset records from the context, which keys them by the
+	// node's input outpoint.
+	if assetCtx != nil {
+		tlvN.SigningTweak.Val = assetCtx.SigningTweak(n.Input)
+		tlvN.SealedPackage.Val = assetCtx.SealedPackage(n.Input)
+		tlvN.AssetAmount.Val = assetCtx.NodeAssetAmount(n)
+	}
+
 	// Serialize children recursively.
-	childrenData, err := serializeChildren(n.Children)
+	childrenData, err := serializeChildren(n.Children, assetCtx)
 	if err != nil {
 		return nil, fmt.Errorf("serialize children: %w", err)
 	}
@@ -768,7 +886,9 @@ func serializeNode(n *tree.Node) ([]byte, error) {
 // encoding. depth is the current recursion depth (1 for the root) and
 // is enforced against MaxTreeDeserializeDepth to prevent untrusted
 // blobs from triggering goroutine stack overflow.
-func deserializeNode(data []byte, depth int) (*tree.Node, error) {
+func deserializeNode(data []byte, depth int,
+	assetCtx *tree.AssetTreeContext) (*tree.Node, error) {
+
 	if len(data) == 0 {
 		return nil, fmt.Errorf("cannot deserialize empty node data")
 	}
@@ -800,9 +920,26 @@ func deserializeNode(data []byte, depth int) (*tree.Node, error) {
 		n.FinalKey = tlvN.FinalKey.Val.Key
 	}
 
+	// Register the node's asset records with the context.
+	if assetCtx != nil {
+		if len(tlvN.SigningTweak.Val) > 0 {
+			assetCtx.SetSigningTweak(n.Input, tlvN.SigningTweak.Val)
+		}
+		if len(tlvN.SealedPackage.Val) > 0 {
+			assetCtx.SetSealedPackage(
+				n.Input, tlvN.SealedPackage.Val,
+			)
+		}
+		if tlvN.AssetAmount.Val != 0 {
+			assetCtx.SetNodeAssetAmount(n, tlvN.AssetAmount.Val)
+		}
+	}
+
 	// Deserialize children with depth+1 so a deep chain is rejected
 	// well before the goroutine stack grows.
-	children, err := deserializeChildren(tlvN.Children.Val.Data, depth+1)
+	children, err := deserializeChildren(
+		tlvN.Children.Val.Data, depth+1, assetCtx,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("deserialize children: %w", err)
 	}
@@ -812,8 +949,18 @@ func deserializeNode(data []byte, depth int) (*tree.Node, error) {
 	return n, nil
 }
 
+// stampSequence applies the tree-wide node sequence to every node.
+func stampSequence(n *tree.Node, sequence uint32) {
+	n.Sequence = sequence
+	for _, child := range n.Children {
+		stampSequence(child, sequence)
+	}
+}
+
 // serializeChildren serializes a map of children nodes.
-func serializeChildren(children map[uint32]*tree.Node) ([]byte, error) {
+func serializeChildren(children map[uint32]*tree.Node,
+	assetCtx *tree.AssetTreeContext) ([]byte, error) {
+
 	var buf bytes.Buffer
 	var scratch [8]byte
 
@@ -844,7 +991,7 @@ func serializeChildren(children map[uint32]*tree.Node) ([]byte, error) {
 		}
 
 		// Serialize the child node.
-		childData, err := serializeNode(child)
+		childData, err := serializeNode(child, assetCtx)
 		if err != nil {
 			return nil, fmt.Errorf("serialize child at index "+
 				"%d: %w", idx, err)
@@ -873,8 +1020,8 @@ func serializeChildren(children map[uint32]*tree.Node) ([]byte, error) {
 // the recursion depth at which these children sit (i.e. the parent's
 // depth+1) and is forwarded to deserializeNode so a deep linear chain
 // is rejected before the goroutine stack grows.
-func deserializeChildren(data []byte,
-	depth int) (map[uint32]*tree.Node, error) {
+func deserializeChildren(data []byte, depth int,
+	assetCtx *tree.AssetTreeContext) (map[uint32]*tree.Node, error) {
 
 	if len(data) == 0 {
 		return make(map[uint32]*tree.Node), nil
@@ -929,7 +1076,7 @@ func deserializeChildren(data []byte,
 		}
 
 		// Deserialize the child node.
-		child, err := deserializeNode(nodeData, depth)
+		child, err := deserializeNode(nodeData, depth, assetCtx)
 		if err != nil {
 			return nil, fmt.Errorf("deserialize child at index "+
 				"%d: %w", idx, err)

--- a/db/tree_codec_asset_test.go
+++ b/db/tree_codec_asset_test.go
@@ -1,0 +1,162 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/stretchr/testify/require"
+)
+
+// newAssetCodecTree builds a two-node asset-aware tree whose context
+// carries tweaks, sealed packages, and amounts, and whose nodes use the
+// flow-V2 sequence.
+func newAssetCodecTree(t *testing.T) *tree.Tree {
+	t.Helper()
+
+	key, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	rootInput := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("batch")),
+		Index: 1,
+	}
+	leafInput := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("root-tx")),
+		Index: 0,
+	}
+
+	leaf := &tree.Node{
+		Input: leafInput,
+		Outputs: []*wire.TxOut{
+			{
+				Value: 2_000,
+				PkScript: []byte{
+					0x51,
+				},
+			},
+		},
+		CoSigners: []*btcec.PublicKey{
+			key.PubKey(),
+		},
+		Children: make(map[uint32]*tree.Node),
+		Sequence: tree.SequenceV2,
+	}
+	root := &tree.Node{
+		Input: rootInput,
+		Outputs: []*wire.TxOut{
+			{
+				Value: 2_000,
+				PkScript: []byte{
+					0x52,
+				},
+			},
+		},
+		CoSigners: []*btcec.PublicKey{
+			key.PubKey(),
+		},
+		Children: map[uint32]*tree.Node{
+			0: leaf,
+		},
+		Sequence: tree.SequenceV2,
+	}
+
+	ctx := tree.NewAssetTreeContext()
+	ctx.SetAssetRef("group:cafe")
+	ctx.SetSigningTweak(rootInput, hashOf("t1"))
+	ctx.SetSigningTweak(leafInput, hashOf("t2"))
+	ctx.SetSealedPackage(rootInput, []byte{0xaa, 0xbb})
+	ctx.SetSealedPackage(leafInput, []byte{0xcc})
+	ctx.SetNodeAssetAmount(root, 700)
+	ctx.SetNodeAssetAmount(leaf, 700)
+
+	return &tree.Tree{
+		Root:          root,
+		BatchOutpoint: rootInput,
+		BatchOutput: &wire.TxOut{
+			Value: 2_000,
+			PkScript: []byte{
+				0x52,
+			},
+		},
+		SweepTapscriptRoot: hashOf("sweep"),
+		AssetContext:       ctx,
+	}
+}
+
+// TestTreeCodecAssetRoundTrip proves an asset-aware tree survives TLV
+// persistence: asset ref, per-node tweaks, sealed packages, subtree
+// amounts, and the tree-wide node sequence all round-trip.
+func TestTreeCodecAssetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := newAssetCodecTree(t)
+	ctx := original.AssetContext
+
+	data, err := SerializeTree(original)
+	require.NoError(t, err)
+
+	got, err := DeserializeTree(data)
+	require.NoError(t, err)
+	require.NotNil(t, got.AssetContext)
+	require.Equal(t, "group:cafe", got.AssetContext.AssetRef())
+
+	gotLeaf := got.Root.Children[0]
+	for _, input := range []wire.OutPoint{
+		got.Root.Input, gotLeaf.Input,
+	} {
+		require.Equal(
+			t, ctx.SigningTweak(input),
+			got.AssetContext.SigningTweak(input),
+		)
+		require.Equal(
+			t, ctx.SealedPackage(input),
+			got.AssetContext.SealedPackage(input),
+		)
+	}
+	require.EqualValues(
+		t, 700, got.AssetContext.NodeAssetAmount(got.Root),
+	)
+	require.EqualValues(
+		t, 700, got.AssetContext.NodeAssetAmount(gotLeaf),
+	)
+
+	// The tree-wide sequence is stamped back onto every node, so node
+	// txids are preserved across persistence.
+	require.Equal(t, tree.SequenceV2, got.Root.Sequence)
+	require.Equal(t, tree.SequenceV2, gotLeaf.Sequence)
+
+	wantTxID, err := original.Root.TXID()
+	require.NoError(t, err)
+	gotTxID, err := got.Root.TXID()
+	require.NoError(t, err)
+	require.Equal(t, wantTxID, gotTxID)
+}
+
+// TestTreeCodecBitcoinOnlyNoAssetContext proves Bitcoin-only trees do not
+// grow an asset context through persistence.
+func TestTreeCodecBitcoinOnlyNoAssetContext(t *testing.T) {
+	t.Parallel()
+
+	original := newAssetCodecTree(t)
+	original.AssetContext = nil
+	original.Root.Sequence = 0
+	original.Root.Children[0].Sequence = 0
+
+	data, err := SerializeTree(original)
+	require.NoError(t, err)
+
+	got, err := DeserializeTree(data)
+	require.NoError(t, err)
+	require.Nil(t, got.AssetContext)
+	require.Zero(t, got.Root.Sequence)
+}
+
+// hashOf returns a deterministic 32-byte slice for test fixtures.
+func hashOf(s string) []byte {
+	h := chainhash.HashH([]byte(s))
+
+	return h[:]
+}

--- a/db/tree_codec_test.go
+++ b/db/tree_codec_test.go
@@ -469,7 +469,7 @@ func TestTreeCodecRejectsHugeNumChildren(t *testing.T) {
 		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 	}
 
-	_, err := deserializeChildren(payload, 2)
+	_, err := deserializeChildren(payload, 2, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exceeds max")
 }

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/btcsuite/btcd/txscript/v2 v2.0.0
 	github.com/btcsuite/btcd/wire/v2 v2.0.0
 	github.com/lightninglabs/go-wasmsqlite v0.0.0-20260627090804-0dce68fc5287
-	github.com/lightninglabs/tap-sdk v0.1.1-0.20260805105923-942d5b16666e
+	github.com/lightninglabs/tap-sdk v0.1.1-0.20260805122215-1a976d08253a
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/btcsuite/btcd/txscript/v2 v2.0.0
 	github.com/btcsuite/btcd/wire/v2 v2.0.0
 	github.com/lightninglabs/go-wasmsqlite v0.0.0-20260627090804-0dce68fc5287
-	github.com/lightninglabs/tap-sdk v0.1.1-0.20260804174327-7ab9e063bdca
+	github.com/lightninglabs/tap-sdk v0.1.1-0.20260805105923-942d5b16666e
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1078,8 +1078,8 @@ github.com/lightninglabs/neutrino/cache v1.1.4 h1:KVtvUmBwYr7eKtjfjHG/q6/cQlcrjH
 github.com/lightninglabs/neutrino/cache v1.1.4/go.mod h1:ZqLzxghPggIRfNXeAZN1VtTKofMyK/ALI6niYsPH6OE=
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS/00EiEg0qp0FhehxnQfk3vv8U6Xt3nN+rTY=
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-github.com/lightninglabs/tap-sdk v0.1.1-0.20260805105923-942d5b16666e h1:FsgYh33l/m/N78djNHzVKO16Ok6qD4sWCGe7/BJ//2s=
-github.com/lightninglabs/tap-sdk v0.1.1-0.20260805105923-942d5b16666e/go.mod h1:RI0Z+A0ySP5itemPcUcSe8czEjczOzRk9IK6zaF9rnc=
+github.com/lightninglabs/tap-sdk v0.1.1-0.20260805122215-1a976d08253a h1:jaM9m51hL1SxqW3RruKInpZIaV7LV42wLCuIPv35VAc=
+github.com/lightninglabs/tap-sdk v0.1.1-0.20260805122215-1a976d08253a/go.mod h1:RI0Z+A0ySP5itemPcUcSe8czEjczOzRk9IK6zaF9rnc=
 github.com/lightninglabs/taproot-assets v0.7.1-0.20260804093026-95bd8d412bef h1:4vHoQMzUkpkPoNKHT+QdTUbWoWaz0T5CDx6CWsforXM=
 github.com/lightninglabs/taproot-assets v0.7.1-0.20260804093026-95bd8d412bef/go.mod h1:fm0WaNsDpP7jEgR9zMap3hpum7lXVDtjsi783MW9BxY=
 github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260804093026-95bd8d412bef h1:3uhbpFZUp3JwLxSlhdelA56g0dULFfcYlC6Q/wQICk0=

--- a/go.sum
+++ b/go.sum
@@ -1078,8 +1078,8 @@ github.com/lightninglabs/neutrino/cache v1.1.4 h1:KVtvUmBwYr7eKtjfjHG/q6/cQlcrjH
 github.com/lightninglabs/neutrino/cache v1.1.4/go.mod h1:ZqLzxghPggIRfNXeAZN1VtTKofMyK/ALI6niYsPH6OE=
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS/00EiEg0qp0FhehxnQfk3vv8U6Xt3nN+rTY=
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-github.com/lightninglabs/tap-sdk v0.1.1-0.20260804174327-7ab9e063bdca h1:JOr8vlpdR5c0H7/1H3SEvKG/plbT75GTV+zEWonugDM=
-github.com/lightninglabs/tap-sdk v0.1.1-0.20260804174327-7ab9e063bdca/go.mod h1:RI0Z+A0ySP5itemPcUcSe8czEjczOzRk9IK6zaF9rnc=
+github.com/lightninglabs/tap-sdk v0.1.1-0.20260805105923-942d5b16666e h1:FsgYh33l/m/N78djNHzVKO16Ok6qD4sWCGe7/BJ//2s=
+github.com/lightninglabs/tap-sdk v0.1.1-0.20260805105923-942d5b16666e/go.mod h1:RI0Z+A0ySP5itemPcUcSe8czEjczOzRk9IK6zaF9rnc=
 github.com/lightninglabs/taproot-assets v0.7.1-0.20260804093026-95bd8d412bef h1:4vHoQMzUkpkPoNKHT+QdTUbWoWaz0T5CDx6CWsforXM=
 github.com/lightninglabs/taproot-assets v0.7.1-0.20260804093026-95bd8d412bef/go.mod h1:fm0WaNsDpP7jEgR9zMap3hpum7lXVDtjsi783MW9BxY=
 github.com/lightninglabs/taproot-assets/taprpc v1.1.1-0.20260804093026-95bd8d412bef h1:3uhbpFZUp3JwLxSlhdelA56g0dULFfcYlC6Q/wQICk0=

--- a/lib/tree/CLAUDE.md
+++ b/lib/tree/CLAUDE.md
@@ -16,6 +16,8 @@ descriptors through branch nodes to the batch output.
 - `Structure` — Intermediate tree layout built by `BuildStructure` before materialization.
 - `StructureConfig` — Configuration for tree building (radix, partition weight function).
 - `SignerSession` — MuSig2 signing session for tree transactions, wrapping `input.MuSig2Signer`.
+- `AssetTreeContext` — side-car of an asset-aware tree (per-node signing tweaks, sealed packages, subtree amounts, asset ref), paired via `Tree.AssetContext`; amounts fall back to input-outpoint keying so extracted/deserialized clones resolve.
+- `Node.Sequence` / `SequenceV2` / `TxSequence()` — per-node input sequence; zero means the flow-V1 final sequence, `SequenceV2` is the RBF-signalling flow-V2 value. Consensus-visible (changes txids); tree-wide by invariant.
 - `Materializer` / `BTCMaterializer` — Interface and implementation for materializing tree nodes into actual Bitcoin transactions.
 - `TreeAssembler` — Two-pass builder (`BuildStructure` then `Materialize`) driven by `TreeConfig`.
 - `Queue[T]` — Generic queue used internally for BFS tree traversal.

--- a/lib/tree/asset_tree_context.go
+++ b/lib/tree/asset_tree_context.go
@@ -27,6 +27,11 @@ type AssetTreeContext struct {
 	// materializer to size the asset split at every branch.
 	amountsByNode map[*Node]uint64
 
+	// amountsByInput re-keys the subtree totals by input outpoint once
+	// materialization assigns inputs, so lookups survive path
+	// extraction (which clones nodes) and serialization.
+	amountsByInput map[wire.OutPoint]uint64
+
 	// tweaksByInput holds the taproot signing tweak for the node
 	// transaction spending each outpoint: the parent output's combined
 	// tapscript root, committing to both the sweep leaf and the asset
@@ -39,26 +44,42 @@ type AssetTreeContext struct {
 	// suffixes feed unroll publication and its authenticated summaries
 	// feed validation.
 	packagesByInput map[wire.OutPoint][]byte
+
+	// assetRef identifies the asset carried by every leaf of the tree,
+	// in its canonical string encoding (group key reference for grouped
+	// assets).
+	assetRef string
 }
 
 // NewAssetTreeContext returns an empty asset tree context.
 func NewAssetTreeContext() *AssetTreeContext {
 	return &AssetTreeContext{
 		amountsByNode:   make(map[*Node]uint64),
+		amountsByInput:  make(map[wire.OutPoint]uint64),
 		tweaksByInput:   make(map[wire.OutPoint][]byte),
 		packagesByInput: make(map[wire.OutPoint][]byte),
 	}
 }
 
-// SetNodeAssetAmount records the subtree asset total for a node.
+// SetNodeAssetAmount records the subtree asset total for a node. Nodes
+// that already carry their input outpoint are additionally indexed by it,
+// so the amount stays resolvable on extracted or deserialized clones.
 func (c *AssetTreeContext) SetNodeAssetAmount(node *Node, amount uint64) {
 	c.amountsByNode[node] = amount
+	if node.Input != (wire.OutPoint{}) {
+		c.amountsByInput[node.Input] = amount
+	}
 }
 
 // NodeAssetAmount returns the subtree asset total for a node, or zero when
-// the node carries no assets.
+// the node carries no assets. Node identity wins; clones resolve through
+// their input outpoint.
 func (c *AssetTreeContext) NodeAssetAmount(node *Node) uint64 {
-	return c.amountsByNode[node]
+	if amount, ok := c.amountsByNode[node]; ok {
+		return amount
+	}
+
+	return c.amountsByInput[node.Input]
 }
 
 // SetSigningTweak records the taproot signing tweak for the node
@@ -83,6 +104,24 @@ func (c *AssetTreeContext) SetSealedPackage(input wire.OutPoint, pkg []byte) {
 // transaction spending the given outpoint, or nil when none was recorded.
 func (c *AssetTreeContext) SealedPackage(input wire.OutPoint) []byte {
 	return c.packagesByInput[input]
+}
+
+// SetAssetRef records the canonical string encoding of the tree's asset.
+func (c *AssetTreeContext) SetAssetRef(ref string) {
+	c.assetRef = ref
+}
+
+// AssetRef returns the canonical string encoding of the tree's asset, or
+// the empty string when none was recorded.
+func (c *AssetTreeContext) AssetRef() string {
+	return c.assetRef
+}
+
+// IsEmpty reports whether the context carries no asset data at all.
+func (c *AssetTreeContext) IsEmpty() bool {
+	return len(c.amountsByNode) == 0 && len(c.amountsByInput) == 0 &&
+		len(c.tweaksByInput) == 0 && len(c.packagesByInput) == 0 &&
+		c.assetRef == ""
 }
 
 // TweakLookup adapts the context to the signer sessions: nodes whose input

--- a/lib/tree/batch.go
+++ b/lib/tree/batch.go
@@ -303,6 +303,53 @@ func BuildConnectorTree(batchOutpoint wire.OutPoint, batchOutput *wire.TxOut,
 func BuildBatchOutput(vtxos []VTXODescriptor, operatorMuSigKey *btcec.PublicKey,
 	sweepKey *btcec.PublicKey, sweepDelay uint32) (*wire.TxOut, error) {
 
+	spec, err := BuildBatchOutputSpec(
+		vtxos, operatorMuSigKey, sweepKey, sweepDelay,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return spec.Output, nil
+}
+
+// BatchOutputSpec is one batch output together with the taproot material
+// observers of the commitment transaction need: the untweaked MuSig2
+// aggregate and the sweep leaf. Taproot Asset exclusion proofs require
+// both on the PSBT output (BIP-371) to prove the output carries no asset
+// commitment.
+type BatchOutputSpec struct {
+	// Output is the batch output.
+	Output *wire.TxOut
+
+	// InternalKey is the untweaked MuSig2 aggregate of the operator and
+	// every leaf cosigner.
+	InternalKey *btcec.PublicKey
+
+	// SweepLeaf is the operator's timeout leaf: the output key's only
+	// tapscript commitment.
+	SweepLeaf txscript.TapLeaf
+}
+
+// TapTreeBytes serializes the output's tapscript tree in the BIP-371
+// PSBT_OUT_TAP_TREE encoding: one entry per leaf of depth, leaf version,
+// and length-prefixed script.
+func (s *BatchOutputSpec) TapTreeBytes() []byte {
+	var buf bytes.Buffer
+	buf.WriteByte(0) // Depth: the sweep leaf is the whole tree.
+	buf.WriteByte(byte(s.SweepLeaf.LeafVersion))
+	_ = wire.WriteVarInt(&buf, 0, uint64(len(s.SweepLeaf.Script)))
+	buf.Write(s.SweepLeaf.Script)
+
+	return buf.Bytes()
+}
+
+// BuildBatchOutputSpec builds one batch output and exposes its taproot
+// binding material.
+func BuildBatchOutputSpec(vtxos []VTXODescriptor,
+	operatorMuSigKey *btcec.PublicKey, sweepKey *btcec.PublicKey,
+	sweepDelay uint32) (*BatchOutputSpec, error) {
+
 	if len(vtxos) == 0 {
 		return nil, fmt.Errorf("batch output requires at least one " +
 			"VTXO")
@@ -378,9 +425,13 @@ func BuildBatchOutput(vtxos []VTXODescriptor, operatorMuSigKey *btcec.PublicKey,
 			err)
 	}
 
-	return &wire.TxOut{
-		Value:    int64(totalAmount),
-		PkScript: pkScript,
+	return &BatchOutputSpec{
+		Output: &wire.TxOut{
+			Value:    int64(totalAmount),
+			PkScript: pkScript,
+		},
+		InternalKey: aggKey.PreTweakedKey,
+		SweepLeaf:   sweepTapLeaf,
 	}, nil
 }
 

--- a/lib/tree/local_signing.go
+++ b/lib/tree/local_signing.go
@@ -1,0 +1,142 @@
+package tree
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// SignTreeLocally runs the complete MuSig2 tree-signing ceremony for a
+// tree whose cosigner keys are all held by one signer: one session per
+// cosigner, per-transaction nonce aggregation, partial signatures, and
+// final combination, submitted back onto the tree. The first cosigner
+// key must participate in every node (the operator's tree-signing key);
+// its sessions combine the partials.
+//
+// tweakLookup optionally overrides the taproot tweak per node; asset
+// trees pass AssetTreeContext.TweakLookup(), Bitcoin-only trees nil.
+func SignTreeLocally(t *Tree, signer input.MuSig2Signer,
+	cosignerKeys []*keychain.KeyDescriptor,
+	tweakLookup TaprootTweakLookup) error {
+
+	if len(cosignerKeys) == 0 {
+		return fmt.Errorf("at least one cosigner key is required")
+	}
+
+	sessions := make([]*SignerSession, 0, len(cosignerKeys))
+	cleanup := func() {
+		// Best effort: the ceremony error is the caller's signal,
+		// stale sessions only linger in the signer's memory.
+		for _, session := range sessions {
+			_ = session.Cleanup()
+		}
+	}
+
+	for _, key := range cosignerKeys {
+		session, err := t.NewTreeSignerSession(
+			signer, key, tweakLookup,
+		)
+		if err != nil {
+			cleanup()
+
+			return fmt.Errorf("session for cosigner %x: %w",
+				key.PubKey.SerializeCompressed(), err)
+		}
+		sessions = append(sessions, session)
+	}
+
+	// The first session must span the whole tree, since it combines
+	// every transaction's partials.
+	combinerIDs := sessions[0].SessionIDs()
+	if len(combinerIDs) != t.NumTx() {
+		cleanup()
+
+		return fmt.Errorf("first cosigner covers %d of %d tree "+
+			"transactions; it must participate in every node",
+			len(combinerIDs), t.NumTx())
+	}
+
+	// Phase 1: aggregate nonces per transaction across exactly the
+	// sessions whose paths include it.
+	noncesByTx := make(map[TxID][][musig2.PubNonceSize]byte)
+	for _, session := range sessions {
+		for txid, nonce := range session.GetNonces() {
+			noncesByTx[txid] = append(noncesByTx[txid], nonce)
+		}
+	}
+	aggByTx := make(map[TxID]Musig2PubNonce, len(noncesByTx))
+	for txid, nonces := range noncesByTx {
+		agg, err := musig2.AggregateNonces(nonces)
+		if err != nil {
+			cleanup()
+
+			return fmt.Errorf("aggregate nonces for %s: %w", txid,
+				err)
+		}
+		aggByTx[txid] = agg
+	}
+	for _, session := range sessions {
+		scoped := make(map[TxID]Musig2PubNonce)
+		for txid := range session.SessionIDs() {
+			scoped[txid] = aggByTx[txid]
+		}
+		if err := session.RegisterAggNonces(scoped); err != nil {
+			cleanup()
+
+			return fmt.Errorf("register aggregated nonces: %w", err)
+		}
+	}
+
+	// Phase 2: partial signatures from every session. The combiner's
+	// sessions must outlive their partials so the signer can fold in the
+	// other cosigners' shares below; every other session is done once it
+	// has signed.
+	partialsByTx := make(map[TxID][]*musig2.PartialSignature)
+	for i, session := range sessions {
+		partials, err := session.Signatures(i != 0)
+		if err != nil {
+			cleanup()
+
+			return fmt.Errorf("partial signatures: %w", err)
+		}
+		if i == 0 {
+			continue
+		}
+		for txid, partial := range partials {
+			partialsByTx[txid] = append(
+				partialsByTx[txid], partial,
+			)
+		}
+	}
+
+	finalSigs := make(map[TxID]*schnorr.Signature, len(combinerIDs))
+	for txid, sessionID := range combinerIDs {
+		sig, haveAll, err := signer.MuSig2CombineSig(
+			sessionID, partialsByTx[txid],
+		)
+		if err != nil {
+			cleanup()
+
+			return fmt.Errorf("combine signatures for %s: %w", txid,
+				err)
+		}
+		if !haveAll {
+			cleanup()
+
+			return fmt.Errorf("missing partial signatures for %s",
+				txid)
+		}
+		finalSigs[txid] = sig
+	}
+
+	if err := t.SubmitTreeSigs(finalSigs); err != nil {
+		cleanup()
+
+		return fmt.Errorf("submit tree signatures: %w", err)
+	}
+
+	return t.VerifySigned()
+}

--- a/lib/tree/local_signing_test.go
+++ b/lib/tree/local_signing_test.go
@@ -1,0 +1,253 @@
+package tree
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr/musig2"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// multiKeyMuSig2Signer models a wallet holding every cosigner key: one
+// mockMuSig2Signer per key, session creation dispatched on the key
+// locator index and everything else on the session owner recorded at
+// creation.
+type multiKeyMuSig2Signer struct {
+	byIndex map[uint32]*mockMuSig2Signer
+	owner   map[input.MuSig2SessionID]*mockMuSig2Signer
+}
+
+// newMultiKeyMuSig2Signer wires one single-key mock per private key; each
+// inner mock gets a disjoint session ID range so ownership stays
+// unambiguous.
+func newMultiKeyMuSig2Signer(
+	privKeys []*btcec.PrivateKey) *multiKeyMuSig2Signer {
+
+	signer := &multiKeyMuSig2Signer{
+		byIndex: make(map[uint32]*mockMuSig2Signer),
+		owner:   make(map[input.MuSig2SessionID]*mockMuSig2Signer),
+	}
+	for i, privKey := range privKeys {
+		inner := newMockMuSig2Signer(privKey)
+		inner.nextSessionID = i * 32
+		signer.byIndex[uint32(i)] = inner
+	}
+
+	return signer
+}
+
+// MuSig2CreateSession dispatches to the key named by the locator index.
+func (m *multiKeyMuSig2Signer) MuSig2CreateSession(
+	version input.MuSig2Version, keyLoc keychain.KeyLocator,
+	signers []*btcec.PublicKey, tweaks *input.MuSig2Tweaks,
+	otherNonces [][musig2.PubNonceSize]byte,
+	localNonces *musig2.Nonces) (*input.MuSig2SessionInfo, error) {
+
+	inner, ok := m.byIndex[keyLoc.Index]
+	if !ok {
+		return nil, fmt.Errorf("no key at locator index %d",
+			keyLoc.Index)
+	}
+
+	info, err := inner.MuSig2CreateSession(
+		version, keyLoc, signers, tweaks, otherNonces, localNonces,
+	)
+	if err != nil {
+		return nil, err
+	}
+	m.owner[info.SessionID] = inner
+
+	return info, nil
+}
+
+// sessionOwner resolves the inner mock a session was created on.
+func (m *multiKeyMuSig2Signer) sessionOwner(
+	sessionID input.MuSig2SessionID) (*mockMuSig2Signer, error) {
+
+	inner, ok := m.owner[sessionID]
+	if !ok {
+		return nil, fmt.Errorf("unknown session %x", sessionID)
+	}
+
+	return inner, nil
+}
+
+// MuSig2RegisterNonces delegates to the session's owner.
+func (m *multiKeyMuSig2Signer) MuSig2RegisterNonces(
+	sessionID input.MuSig2SessionID,
+	nonces [][musig2.PubNonceSize]byte) (bool, error) {
+
+	inner, err := m.sessionOwner(sessionID)
+	if err != nil {
+		return false, err
+	}
+
+	return inner.MuSig2RegisterNonces(sessionID, nonces)
+}
+
+// MuSig2RegisterCombinedNonce delegates to the session's owner.
+func (m *multiKeyMuSig2Signer) MuSig2RegisterCombinedNonce(
+	sessionID input.MuSig2SessionID,
+	aggNonce [musig2.PubNonceSize]byte) error {
+
+	inner, err := m.sessionOwner(sessionID)
+	if err != nil {
+		return err
+	}
+
+	return inner.MuSig2RegisterCombinedNonce(sessionID, aggNonce)
+}
+
+// MuSig2GetCombinedNonce delegates to the session's owner.
+func (m *multiKeyMuSig2Signer) MuSig2GetCombinedNonce(
+	sessionID input.MuSig2SessionID) ([musig2.PubNonceSize]byte, error) {
+
+	inner, err := m.sessionOwner(sessionID)
+	if err != nil {
+		return [musig2.PubNonceSize]byte{}, err
+	}
+
+	return inner.MuSig2GetCombinedNonce(sessionID)
+}
+
+// MuSig2Sign delegates to the session's owner.
+func (m *multiKeyMuSig2Signer) MuSig2Sign(sessionID input.MuSig2SessionID,
+	msg [32]byte, cleanup bool) (*musig2.PartialSignature, error) {
+
+	inner, err := m.sessionOwner(sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	return inner.MuSig2Sign(sessionID, msg, cleanup)
+}
+
+// MuSig2CombineSig delegates to the session's owner.
+func (m *multiKeyMuSig2Signer) MuSig2CombineSig(
+	sessionID input.MuSig2SessionID,
+	partialSigs []*musig2.PartialSignature) (*schnorr.Signature, bool,
+	error) {
+
+	inner, err := m.sessionOwner(sessionID)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return inner.MuSig2CombineSig(sessionID, partialSigs)
+}
+
+// MuSig2Cleanup delegates to the session's owner.
+func (m *multiKeyMuSig2Signer) MuSig2Cleanup(
+	sessionID input.MuSig2SessionID) error {
+
+	inner, err := m.sessionOwner(sessionID)
+	if err != nil {
+		return err
+	}
+
+	return inner.MuSig2Cleanup(sessionID)
+}
+
+// localSigningFixture builds a four-leaf VTXO tree plus a wallet holding the
+// operator and every leaf owner key, returning the descriptors in ceremony
+// order (operator first).
+func localSigningFixture(t *testing.T) (*Tree, input.MuSig2Signer,
+	[]*keychain.KeyDescriptor) {
+
+	t.Helper()
+
+	const numLeaves = 4
+
+	privKeys := make([]*btcec.PrivateKey, 0, numLeaves+1)
+	keyDescs := make([]*keychain.KeyDescriptor, 0, numLeaves+1)
+	for i := 0; i < numLeaves+1; i++ {
+		privKey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		privKeys = append(privKeys, privKey)
+		keyDescs = append(keyDescs, &keychain.KeyDescriptor{
+			KeyLocator: keychain.KeyLocator{
+				Family: 1,
+				Index:  uint32(i),
+			},
+			PubKey: privKey.PubKey(),
+		})
+	}
+	operatorKey := keyDescs[0].PubKey
+
+	sweepKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	vtxos := make([]VTXODescriptor, 0, numLeaves)
+	for _, ownerDesc := range keyDescs[1:] {
+		pkScript, err := txscript.PayToTaprootScript(ownerDesc.PubKey)
+		require.NoError(t, err)
+		vtxos = append(vtxos, VTXODescriptor{
+			PkScript:    pkScript,
+			Amount:      btcutil.Amount(5_000),
+			CoSignerKey: ownerDesc.PubKey,
+		})
+	}
+
+	batchOutpoint := wire.OutPoint{
+		Hash: chainhash.HashH([]byte("local_signing_commitment")),
+	}
+	batchOutput := &wire.TxOut{
+		Value:    int64(numLeaves) * 5_000,
+		PkScript: []byte("batch_script"),
+	}
+
+	built, err := BuildVTXOTree(
+		batchOutpoint, batchOutput, vtxos, operatorKey,
+		sweepKey.PubKey(), 144, 2,
+	)
+	require.NoError(t, err)
+
+	return built, newMultiKeyMuSig2Signer(privKeys), keyDescs
+}
+
+// TestSignTreeLocally runs the complete single-wallet ceremony over a
+// four-leaf tree and expects a fully verified tree.
+func TestSignTreeLocally(t *testing.T) {
+	t.Parallel()
+
+	built, signer, keyDescs := localSigningFixture(t)
+
+	require.NoError(t, SignTreeLocally(built, signer, keyDescs, nil))
+
+	// Every node ends up carrying a verified final signature.
+	require.NoError(t, built.VerifySigned())
+}
+
+// TestSignTreeLocallyRequiresTreeWideCombiner rejects a ceremony whose first
+// cosigner does not participate in every node.
+func TestSignTreeLocallyRequiresTreeWideCombiner(t *testing.T) {
+	t.Parallel()
+
+	built, signer, keyDescs := localSigningFixture(t)
+
+	// A leaf owner only covers its own path, so it cannot combine.
+	reordered := []*keychain.KeyDescriptor{
+		keyDescs[1], keyDescs[0], keyDescs[2], keyDescs[3],
+		keyDescs[4],
+	}
+	err := SignTreeLocally(built, signer, reordered, nil)
+	require.ErrorContains(t, err, "must participate in every node")
+}
+
+// TestSignTreeLocallyRequiresCosigners rejects an empty cosigner set.
+func TestSignTreeLocallyRequiresCosigners(t *testing.T) {
+	t.Parallel()
+
+	built, signer, _ := localSigningFixture(t)
+
+	err := SignTreeLocally(built, signer, nil, nil)
+	require.ErrorContains(t, err, "at least one cosigner key")
+}

--- a/lib/tree/node.go
+++ b/lib/tree/node.go
@@ -65,6 +65,13 @@ type Node struct {
 	// that must sign this node's input. This is cached to avoid repeated
 	// MuSig2 aggregations during signature verification.
 	FinalKey *btcec.PublicKey
+
+	// Sequence is the input sequence of this node's transaction. Zero
+	// selects the flow-V1 default (MaxTxInSequenceNum); V2 trees use an
+	// RBF-signalling sequence. Sequence is consensus-visible: it changes
+	// the node's txid and sighash, so every node of a tree must carry
+	// the same value.
+	Sequence uint32
 }
 
 // NewLeafNode creates a leaf node (transaction with leaf output).
@@ -281,6 +288,20 @@ func (n *Node) SetChildren(children map[uint32]*Node) {
 	n.Children = children
 }
 
+// SequenceV2 is the RBF-signalling input sequence carried by flow-V2
+// tree transactions. V1 trees use MaxTxInSequenceNum (final).
+const SequenceV2 = wire.MaxTxInSequenceNum - 2
+
+// TxSequence returns the input sequence of this node's transaction: the
+// node's explicit sequence when set, the flow-V1 default otherwise.
+func (n *Node) TxSequence() uint32 {
+	if n.Sequence != 0 {
+		return n.Sequence
+	}
+
+	return wire.MaxTxInSequenceNum
+}
+
 // ToTx converts the Node into its unsigned wire.MsgTx representation.
 func (n *Node) ToTx() (*wire.MsgTx, error) {
 	// Virtual transactions are V3 since they use ephemeral anchors.
@@ -289,7 +310,7 @@ func (n *Node) ToTx() (*wire.MsgTx, error) {
 	// Add the single, unsigned input.
 	tx.AddTxIn(&wire.TxIn{
 		PreviousOutPoint: n.Input,
-		Sequence:         wire.MaxTxInSequenceNum,
+		Sequence:         n.TxSequence(),
 	})
 
 	// Add all outputs.
@@ -528,6 +549,7 @@ func (n *Node) ExtractPathForCoSigners(targetKeys ...*btcec.PublicKey) (*Node,
 		Outputs:   n.Outputs,
 		Signature: n.Signature,
 		FinalKey:  n.FinalKey,
+		Sequence:  n.Sequence,
 		Children:  make(map[uint32]*Node),
 	}
 
@@ -623,6 +645,7 @@ func (n *Node) extractPathForIndicesRecursive(targetSet fn.Set[int],
 				Outputs:   n.Outputs,
 				Signature: n.Signature,
 				FinalKey:  n.FinalKey,
+				Sequence:  n.Sequence,
 				Children:  make(map[uint32]*Node),
 			}, currentIndex + 1, true
 		}
@@ -637,6 +660,7 @@ func (n *Node) extractPathForIndicesRecursive(targetSet fn.Set[int],
 		Outputs:   n.Outputs,
 		Signature: n.Signature,
 		FinalKey:  n.FinalKey,
+		Sequence:  n.Sequence,
 		Children:  make(map[uint32]*Node),
 	}
 

--- a/lib/tree/sequence_test.go
+++ b/lib/tree/sequence_test.go
@@ -1,0 +1,35 @@
+package tree
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNodeTxSequence pins both flow sequences: the zero value keeps the V1
+// final sequence, an explicit SequenceV2 signals RBF, and the two produce
+// different txids because the sequence is consensus-visible.
+func TestNodeTxSequence(t *testing.T) {
+	t.Parallel()
+
+	input := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("parent")),
+		Index: 0,
+	}
+	outputs := []*wire.TxOut{{Value: 1_000, PkScript: []byte{0x51}}}
+
+	v1 := &Node{Input: input, Outputs: outputs}
+	v2 := &Node{Input: input, Outputs: outputs, Sequence: SequenceV2}
+
+	require.Equal(t, wire.MaxTxInSequenceNum, v1.TxSequence())
+	require.Equal(t, SequenceV2, v2.TxSequence())
+	require.Equal(t, wire.MaxTxInSequenceNum-2, v2.TxSequence())
+
+	v1Tx, err := v1.ToTx()
+	require.NoError(t, err)
+	v2Tx, err := v2.ToTx()
+	require.NoError(t, err)
+	require.NotEqual(t, v1Tx.TxHash(), v2Tx.TxHash())
+}

--- a/lib/tree/signing_test.go
+++ b/lib/tree/signing_test.go
@@ -25,9 +25,7 @@ type mockMuSig2Signer struct {
 
 type mockSession struct {
 	info           *input.MuSig2SessionInfo
-	nonces         *musig2.Nonces
 	musigSession   *musig2.Session
-	otherNonces    [][66]byte
 	allNoncesKnown bool
 	combinedNonce  *[66]byte
 }
@@ -78,7 +76,12 @@ func (m *mockMuSig2Signer) MuSig2CreateSession(version input.MuSig2Version,
 		return nil, err
 	}
 
-	musigSession, err := ctx.NewSession()
+	// The session must sign with the same nonces we advertise in the
+	// session info below, so hand them to the session explicitly instead
+	// of letting NewSession generate a second, unrelated pair.
+	musigSession, err := ctx.NewSession(
+		musig2.WithPreGeneratedNonce(nonces),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -93,9 +96,7 @@ func (m *mockMuSig2Signer) MuSig2CreateSession(version input.MuSig2Version,
 			SessionID:   sessionID,
 			PublicNonce: nonces.PubNonce,
 		},
-		nonces:       nonces,
 		musigSession: musigSession,
-		otherNonces:  nil,
 	}
 
 	m.sessions[sessionID] = mockSess
@@ -138,13 +139,17 @@ func (m *mockMuSig2Signer) MuSig2RegisterCombinedNonce(
 	// Store the combined nonce.
 	session.combinedNonce = &aggNonce
 
-	// Register the aggregated nonce with the musig session.
-	haveAll, err := session.musigSession.RegisterPubNonce(aggNonce)
+	// Tree signing distributes only the pre-aggregated nonce, so install
+	// it directly. Registering it via RegisterPubNonce would treat the
+	// aggregate as one peer's nonce, double-counting our own share in the
+	// session's combined nonce and leaving haveAll false for any session
+	// with more than two signers.
+	err := session.musigSession.RegisterCombinedNonce(aggNonce)
 	if err != nil {
 		return err
 	}
 
-	session.allNoncesKnown = haveAll
+	session.allNoncesKnown = true
 
 	return nil
 }
@@ -1070,6 +1075,28 @@ func TestMusig2PubNonce(t *testing.T) {
 	})
 }
 
+// combinePartialSig folds one counterparty partial signature into the
+// signer's own session for the given transaction and returns the final
+// combined signature. Combining triggers btcd's internal verification of the
+// aggregate against the tweaked combined key, so this is the step that
+// surfaces nonce bookkeeping bugs a lone partial signature cannot reveal.
+func combinePartialSig(t *testing.T, signer *mockMuSig2Signer,
+	txSession *TxSignerSession,
+	partial *musig2.PartialSignature) *schnorr.Signature {
+
+	t.Helper()
+
+	finalSig, haveAll, err := signer.MuSig2CombineSig(
+		txSession.signSession.SessionID,
+		[]*musig2.PartialSignature{partial},
+	)
+	require.NoError(t, err)
+	require.True(t, haveAll)
+	require.NotNil(t, finalSig)
+
+	return finalSig
+}
+
 // TestFullSigningFlow tests the complete signing workflow.
 func TestFullSigningFlow(t *testing.T) {
 	t.Run("complete 2-party signing for single transaction",
@@ -1137,8 +1164,10 @@ func TestFullSigningFlow(t *testing.T) {
 			err = session2.RegisterAggNonces(aggNonceSet)
 			require.NoError(t, err)
 
-			// Phase 3: Generate partial signatures.
-			partialSigs1, err := session1.Signatures(true)
+			// Phase 3: Generate partial signatures. Signer 1
+			// skips cleanup so its session stays alive to act as
+			// the coordinator and combine both shares below.
+			partialSigs1, err := session1.Signatures(false)
 			require.NoError(t, err)
 			require.Len(t, partialSigs1, 1)
 			require.NotNil(t, partialSigs1[leafTXID])
@@ -1148,10 +1177,17 @@ func TestFullSigningFlow(t *testing.T) {
 			require.Len(t, partialSigs2, 1)
 			require.NotNil(t, partialSigs2[leafTXID])
 
-			// Note: In production, a coordinator would combine
-			// these partial signatures. For this test, we verify
-			// that the signing workflow completes successfully and
-			// generates partial signatures from both parties.
+			// Phase 4: Combine the partial signatures and verify
+			// the aggregate against the leaf's final taproot key.
+			txSession := session1.txs[leafTXID]
+			finalSig := combinePartialSig(
+				t, signer1, txSession, partialSigs2[leafTXID],
+			)
+			require.True(
+				t, finalSig.Verify(
+					txSession.sigHash[:], finalKey,
+				),
+			)
 		})
 
 	t.Run("complete 2-party signing for tree with multiple txs",
@@ -1264,8 +1300,10 @@ func TestFullSigningFlow(t *testing.T) {
 			err = session2.RegisterAggNonces(aggNonceSet)
 			require.NoError(t, err)
 
-			// Generate partial signatures for all txs.
-			partialSigs1, err := session1.Signatures(true)
+			// Generate partial signatures for all txs. Signer 1
+			// skips cleanup so its sessions stay alive to combine
+			// the shares for every transaction below.
+			partialSigs1, err := session1.Signatures(false)
 			require.NoError(t, err)
 			require.Len(t, partialSigs1, 3)
 
@@ -1273,14 +1311,32 @@ func TestFullSigningFlow(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, partialSigs2, 3)
 
-			// Verify all partial signatures were generated.
-			for txid := range session1.txs {
-				require.NotNil(t, partialSigs1[txid])
-				require.NotNil(t, partialSigs2[txid])
+			// Index each node's final key by transaction ID so
+			// every combined signature can be verified against
+			// the key its transaction actually commits to.
+			finalKeys := make(map[TxID]*btcec.PublicKey)
+			for node := range root.NodesIter() {
+				txid, err := node.TXID()
+				require.NoError(t, err)
+				finalKeys[txid] = node.FinalKey
 			}
 
-			// Note: In production, a coordinator would combine
-			// these partial signatures to create final
-			// signatures.
+			// Combine both shares for every transaction and
+			// verify each aggregate signature.
+			for txid, txSession := range session1.txs {
+				require.NotNil(t, partialSigs1[txid])
+				require.NotNil(t, partialSigs2[txid])
+
+				finalSig := combinePartialSig(
+					t, signer1, txSession,
+					partialSigs2[txid],
+				)
+				require.True(
+					t, finalSig.Verify(
+						txSession.sigHash[:],
+						finalKeys[txid],
+					),
+				)
+			}
 		})
 }

--- a/lib/tree/tree.go
+++ b/lib/tree/tree.go
@@ -41,6 +41,12 @@ type Tree struct {
 	// For VTXO trees, this is the operator's sweep script.
 	// For connector trees, this is nil (no sweep script).
 	SweepTapscriptRoot []byte
+
+	// AssetContext carries the per-node asset data of an asset-aware
+	// tree: signing tweaks and sealed packages keyed by node input
+	// outpoint. Nil for Bitcoin-only trees. Outpoint keying keeps the
+	// context valid across path extraction, which clones nodes.
+	AssetContext *AssetTreeContext
 }
 
 // NewTree constructs a transaction tree from the given leaves using BFS.
@@ -132,6 +138,7 @@ func (t *Tree) ExtractPathForCoSigners(targetKeys ...*btcec.PublicKey) (*Tree,
 		BatchOutpoint:      t.BatchOutpoint,
 		BatchOutput:        t.BatchOutput,
 		SweepTapscriptRoot: t.SweepTapscriptRoot,
+		AssetContext:       t.AssetContext,
 	}, nil
 }
 
@@ -164,6 +171,7 @@ func (t *Tree) ExtractPathForIndices(leafIndices ...int) (*Tree, error) {
 		BatchOutpoint:      t.BatchOutpoint,
 		BatchOutput:        t.BatchOutput,
 		SweepTapscriptRoot: t.SweepTapscriptRoot,
+		AssetContext:       t.AssetContext,
 	}, nil
 }
 

--- a/round/from_proto.go
+++ b/round/from_proto.go
@@ -203,6 +203,23 @@ func (e *CommitmentTxBuilt) FromProto(p proto.Message) error {
 	}
 	e.Tx = tx
 
+	// Validate the flow version before decoding trees: it decides the
+	// node sequence, which is consensus-visible through every node txid.
+	flowVersion := roundpb.FlowVersion(pb.GetFlowVersion())
+	if err := roundpb.ValidateFlowVersion(flowVersion); err != nil {
+		return fmt.Errorf("flow_version: %w", err)
+	}
+
+	treeOpts := e.TreeOpts
+	if flowVersion >= roundpb.FlowVersionV2 {
+		treeOpts = append(
+			append(
+				[]roundpb.TreeFromProtoOption(nil), treeOpts...,
+			),
+			roundpb.WithNodeSequence(tree.SequenceV2),
+		)
+	}
+
 	// Convert VTXO tree paths. Reject negative indices since they
 	// are semantically invalid as commitment tx output indices.
 	if pb.VtxoTreePaths != nil {
@@ -216,7 +233,7 @@ func (e *CommitmentTxBuilt) FromProto(p proto.Message) error {
 			}
 
 			t, treeErr := roundpb.TreeFromProto(
-				pt, e.TreeOpts...,
+				pt, treeOpts...,
 			)
 			if treeErr != nil {
 				return fmt.Errorf("vtxo_tree_paths[%d]: %w",
@@ -315,18 +332,8 @@ func (e *CommitmentTxBuilt) FromProto(p proto.Message) error {
 		e.ForfeitKey = key
 	}
 
-	// Record and validate the round flow version stamped by the operator.
-	// Fail closed on a version this build does not understand rather than
-	// joining a round conducted under unknown choreography rules. Versions
-	// are zero-indexed, so an omitted wire field reads as V1.
-	if err := roundpb.ValidateFlowVersion(
-		roundpb.FlowVersion(
-			pb.GetFlowVersion(),
-		),
-	); err != nil {
-		return err
-	}
-	e.FlowVersion = roundpb.FlowVersion(pb.GetFlowVersion())
+	// The flow version was validated before tree decoding; record it.
+	e.FlowVersion = flowVersion
 
 	return nil
 }

--- a/round/harness_test.go
+++ b/round/harness_test.go
@@ -1612,7 +1612,12 @@ func (r *realMuSig2Signer) MuSig2CreateSession(version input.MuSig2Version,
 		return nil, err
 	}
 
-	musigSession, err := ctx.NewSession()
+	// The session must sign with the same nonces we advertise in the
+	// session info below, so hand them to the session explicitly instead
+	// of letting NewSession generate a second, unrelated pair.
+	musigSession, err := ctx.NewSession(
+		musig2.WithPreGeneratedNonce(nonces),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1671,13 +1676,17 @@ func (r *realMuSig2Signer) MuSig2RegisterCombinedNonce(
 		return fmt.Errorf("session not found: %v", sessionID)
 	}
 
-	// Register the combined nonce as if it's from all other participants.
-	haveAll, err := session.musigSession.RegisterPubNonce(nonce)
+	// Tree signing distributes only the pre-aggregated nonce, so install
+	// it directly. Registering it via RegisterPubNonce would treat the
+	// aggregate as one peer's nonce, double-counting our own share in the
+	// session's combined nonce and leaving haveAll false for any session
+	// with more than two signers.
+	err := session.musigSession.RegisterCombinedNonce(nonce)
 	if err != nil {
 		return err
 	}
 
-	session.allNoncesKnown = haveAll
+	session.allNoncesKnown = true
 
 	return nil
 }

--- a/rpc/roundpb/CLAUDE.md
+++ b/rpc/roundpb/CLAUDE.md
@@ -29,9 +29,12 @@ All `*.pb.go` files are generated — never edit directly; regenerate with
   `PSBTFromBytes`/`ToBytes`, `MsgTxFromBytes`/`ToBytes`,
   `SchnorrSigFromBytes`/`ToBytes` — wire/proto ⇄ Go conversions for the
   round protocol's payload types.
-- `FlowVersion` / `FlowVersionV1` / `ValidateFlowVersion` — the per-round
-  choreography version stamped by the operator and validated by the
-  client; fails closed on any version this build does not understand.
+- `FlowVersion` / `FlowVersionV1` / `FlowVersionV2` /
+  `ValidateFlowVersion` — the per-round choreography version stamped by
+  the operator and validated by the client; fails closed on any version
+  this build does not understand. V2 rounds carry asset-aware trees and
+  use the RBF-signalling node sequence (`tree.SequenceV2`), applied at
+  deserialization via `WithNodeSequence`.
 
 `MethodSubmitForfeitSigs` and `MethodSubmitVTXOForfeitSigs` are distinct
 wire methods for two different payload types; see `round/CLAUDE.md` for
@@ -56,8 +59,8 @@ distinction.
   malicious server from encoding cycles or out-of-range references in a
   `VTXOTree` and DoS-ing tree traversal. Do not relax these checks.
 - `ValidateFlowVersion` must reject any `FlowVersion` other than the
-  versions this build implements (currently only `FlowVersionV1`); never
-  make it permissive by default.
+  versions this build implements (currently V1 and V2); never make it
+  permissive by default.
 
 ## Deep Docs
 

--- a/rpc/roundpb/convert.go
+++ b/rpc/roundpb/convert.go
@@ -239,12 +239,28 @@ func TreeToProto(t *tree.Tree) (*VTXOTree, error) {
 		return nil, err
 	}
 
-	return &VTXOTree{
+	pt := &VTXOTree{
 		Nodes:              nodes,
 		BatchOutpoint:      OutpointToProto(t.BatchOutpoint),
 		BatchOutput:        TxOutToProto(t.BatchOutput),
 		SweepTapscriptRoot: t.SweepTapscriptRoot,
-	}, nil
+	}
+
+	// Asset-aware trees carry their per-node asset data on the wire:
+	// the tree's asset reference, and each node's signing tweak and
+	// subtree asset amount. Sealed packages stay operator-side.
+	if t.AssetContext != nil {
+		pt.AssetRef = t.AssetContext.AssetRef()
+		for node, idx := range nodeIndex {
+			pn := nodes[idx]
+			pn.SigningTweak = t.AssetContext.SigningTweak(
+				node.Input,
+			)
+			pn.AssetAmount = t.AssetContext.NodeAssetAmount(node)
+		}
+	}
+
+	return pt, nil
 }
 
 // flattenNode recursively flattens a tree node into the nodes slice.
@@ -317,7 +333,8 @@ type TreeFromProtoOption func(*treeFromProtoConfig)
 // treeFromProtoConfig holds configurable validation parameters for
 // tree deserialization.
 type treeFromProtoConfig struct {
-	maxNodes int
+	maxNodes     int
+	nodeSequence uint32
 }
 
 // defaultTreeFromProtoConfig returns the default configuration.
@@ -332,6 +349,16 @@ func defaultTreeFromProtoConfig() treeFromProtoConfig {
 func WithMaxTreeNodes(maxNodes int) TreeFromProtoOption {
 	return func(cfg *treeFromProtoConfig) {
 		cfg.maxNodes = maxNodes
+	}
+}
+
+// WithNodeSequence sets the input sequence stamped on every deserialized
+// node. The sequence is consensus-visible (it changes node txids), so it is
+// derived from the round's flow version rather than carried per node on the
+// wire. Zero keeps the flow-V1 default.
+func WithNodeSequence(sequence uint32) TreeFromProtoOption {
+	return func(cfg *treeFromProtoConfig) {
+		cfg.nodeSequence = sequence
 	}
 }
 
@@ -369,6 +396,7 @@ func TreeFromProto(pt *VTXOTree,
 		if err != nil {
 			return nil, fmt.Errorf("node[%d]: %w", i, err)
 		}
+		node.Sequence = cfg.nodeSequence
 		goNodes[i] = node
 	}
 
@@ -414,9 +442,35 @@ func TreeFromProto(pt *VTXOTree,
 	// bypasses them. Without FinalKey, signature verification
 	// in VerifySigned will fail. Nodes without cosigners (e.g.
 	// certain connector nodes) are skipped.
-	for _, node := range goNodes {
+	// An asset-aware wire tree reconstructs its context alongside the
+	// nodes so verification and signing can consume the per-node data.
+	var assetCtx *tree.AssetTreeContext
+	if treeHasAssetData(pt) {
+		assetCtx = tree.NewAssetTreeContext()
+		assetCtx.SetAssetRef(pt.AssetRef)
+	}
+
+	for i, node := range goNodes {
+		pn := pt.Nodes[i]
+		if assetCtx != nil {
+			if len(pn.SigningTweak) > 0 {
+				assetCtx.SetSigningTweak(
+					node.Input, pn.SigningTweak,
+				)
+			}
+			assetCtx.SetNodeAssetAmount(node, pn.AssetAmount)
+		}
+
 		if len(node.CoSigners) == 0 {
 			continue
+		}
+
+		// The node's own tweak wins when present: asset-aware nodes
+		// commit a per-node asset root into their key, every other
+		// node uses the tree-wide sweep root.
+		taprootTweak := pt.SweepTapscriptRoot
+		if len(pn.SigningTweak) > 0 {
+			taprootTweak = pn.SigningTweak
 		}
 
 		// Copy cosigners before computing the final key
@@ -428,9 +482,7 @@ func TreeFromProto(pt *VTXOTree,
 		)
 		copy(csCopy, node.CoSigners)
 
-		fk, fkErr := tree.ComputeFinalKey(
-			csCopy, pt.SweepTapscriptRoot,
-		)
+		fk, fkErr := tree.ComputeFinalKey(csCopy, taprootTweak)
 		if fkErr != nil {
 			return nil, fmt.Errorf("compute final key: %w", fkErr)
 		}
@@ -453,7 +505,23 @@ func TreeFromProto(pt *VTXOTree,
 		BatchOutpoint:      batchOP,
 		BatchOutput:        batchOut,
 		SweepTapscriptRoot: pt.SweepTapscriptRoot,
+		AssetContext:       assetCtx,
 	}, nil
+}
+
+// treeHasAssetData reports whether a wire tree carries any asset-aware
+// fields.
+func treeHasAssetData(pt *VTXOTree) bool {
+	if pt.AssetRef != "" {
+		return true
+	}
+	for _, pn := range pt.Nodes {
+		if len(pn.SigningTweak) > 0 || pn.AssetAmount != 0 {
+			return true
+		}
+	}
+
+	return false
 }
 
 // treeNodeFromProto converts a single proto TreeNode to a tree.Node.

--- a/rpc/roundpb/convert_asset_test.go
+++ b/rpc/roundpb/convert_asset_test.go
@@ -1,0 +1,212 @@
+package roundpb
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/stretchr/testify/require"
+)
+
+// newAssetTestTree builds a two-node asset-aware tree with a populated
+// context: distinct signing tweaks per node input and subtree amounts.
+func newAssetTestTree(t *testing.T) *tree.Tree {
+	t.Helper()
+
+	rootKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	leafKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	rootInput := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("batch")),
+		Index: 0,
+	}
+	leafInput := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("root-tx")),
+		Index: 0,
+	}
+
+	leaf := &tree.Node{
+		Input: leafInput,
+		Outputs: []*wire.TxOut{
+			{
+				Value: 1_000,
+				PkScript: []byte{
+					0x51,
+				},
+			},
+			{
+				Value: 0,
+				PkScript: []byte{
+					0x51,
+					0x02,
+					0x4e,
+					0x73,
+				},
+			},
+		},
+		CoSigners: []*btcec.PublicKey{
+			leafKey.PubKey(), rootKey.PubKey(),
+		},
+		Children: make(map[uint32]*tree.Node),
+	}
+	root := &tree.Node{
+		Input: rootInput,
+		Outputs: []*wire.TxOut{
+			{
+				Value: 1_000,
+				PkScript: []byte{
+					0x52,
+				},
+			},
+			{
+				Value: 0,
+				PkScript: []byte{
+					0x51,
+					0x02,
+					0x4e,
+					0x73,
+				},
+			},
+		},
+		CoSigners: []*btcec.PublicKey{
+			leafKey.PubKey(), rootKey.PubKey(),
+		},
+		Children: map[uint32]*tree.Node{
+			0: leaf,
+		},
+	}
+
+	ctx := tree.NewAssetTreeContext()
+	ctx.SetAssetRef("group:deadbeef")
+	ctx.SetSigningTweak(rootInput, hashOf("t1"))
+	ctx.SetSigningTweak(leafInput, hashOf("t2"))
+	ctx.SetNodeAssetAmount(root, 500)
+	ctx.SetNodeAssetAmount(leaf, 500)
+
+	return &tree.Tree{
+		Root:          root,
+		BatchOutpoint: rootInput,
+		BatchOutput: &wire.TxOut{
+			Value: 1_000,
+			PkScript: []byte{
+				0x52,
+			},
+		},
+		SweepTapscriptRoot: hashOf("sweep"),
+		AssetContext:       ctx,
+	}
+}
+
+// TestTreeProtoAssetRoundTrip proves an asset-aware tree carries its
+// context over the wire: asset ref, per-node signing tweaks and amounts
+// survive the round trip, and node keys are recomputed with the per-node
+// tweak rather than the tree-wide sweep root.
+func TestTreeProtoAssetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := newAssetTestTree(t)
+	ctx := original.AssetContext
+
+	pb, err := TreeToProto(original)
+	require.NoError(t, err)
+	require.Equal(t, "group:deadbeef", pb.AssetRef)
+	require.Len(t, pb.Nodes, 2)
+	for _, pn := range pb.Nodes {
+		require.NotEmpty(t, pn.SigningTweak)
+		require.EqualValues(t, 500, pn.AssetAmount)
+	}
+
+	got, err := TreeFromProto(pb)
+	require.NoError(t, err)
+	require.NotNil(t, got.AssetContext)
+	require.Equal(t, "group:deadbeef", got.AssetContext.AssetRef())
+
+	require.Equal(
+		t, ctx.SigningTweak(original.Root.Input),
+		got.AssetContext.SigningTweak(got.Root.Input),
+	)
+	gotLeaf := got.Root.Children[0]
+	require.Equal(
+		t, ctx.SigningTweak(original.Root.Children[0].Input),
+		got.AssetContext.SigningTweak(gotLeaf.Input),
+	)
+	require.EqualValues(
+		t, 500, got.AssetContext.NodeAssetAmount(got.Root),
+	)
+	require.EqualValues(
+		t, 500, got.AssetContext.NodeAssetAmount(gotLeaf),
+	)
+
+	// The recomputed key must be the composed one: cosigners tweaked
+	// with the node's own tweak, not the sweep root.
+	wantKey, err := tree.ComputeFinalKey(
+		append(
+			[]*btcec.PublicKey(nil), got.Root.CoSigners...,
+		),
+		got.AssetContext.SigningTweak(got.Root.Input),
+	)
+	require.NoError(t, err)
+	require.True(t, wantKey.IsEqual(got.Root.FinalKey))
+}
+
+// TestTreeProtoBitcoinOnlyNoAssetContext proves Bitcoin-only trees stay
+// asset-free across the round trip.
+func TestTreeProtoBitcoinOnlyNoAssetContext(t *testing.T) {
+	t.Parallel()
+
+	original := newAssetTestTree(t)
+	original.AssetContext = nil
+
+	pb, err := TreeToProto(original)
+	require.NoError(t, err)
+	require.Empty(t, pb.AssetRef)
+	for _, pn := range pb.Nodes {
+		require.Empty(t, pn.SigningTweak)
+		require.Zero(t, pn.AssetAmount)
+	}
+
+	got, err := TreeFromProto(pb)
+	require.NoError(t, err)
+	require.Nil(t, got.AssetContext)
+}
+
+// TestTreeFromProtoNodeSequence proves the flow-version-derived sequence
+// stamps every node, and its absence keeps the V1 default.
+func TestTreeFromProtoNodeSequence(t *testing.T) {
+	t.Parallel()
+
+	pb, err := TreeToProto(newAssetTestTree(t))
+	require.NoError(t, err)
+
+	v1, err := TreeFromProto(pb)
+	require.NoError(t, err)
+	v2, err := TreeFromProto(pb, WithNodeSequence(tree.SequenceV2))
+	require.NoError(t, err)
+
+	v1Tx, err := v1.Root.ToTx()
+	require.NoError(t, err)
+	v2Tx, err := v2.Root.ToTx()
+	require.NoError(t, err)
+
+	require.Equal(t, wire.MaxTxInSequenceNum, v1Tx.TxIn[0].Sequence)
+	require.Equal(t, tree.SequenceV2, v2Tx.TxIn[0].Sequence)
+
+	// The sequence is consensus-visible: the txid must change.
+	require.NotEqual(t, v1Tx.TxHash(), v2Tx.TxHash())
+
+	// Every node is stamped, not only the root.
+	require.Equal(
+		t, tree.SequenceV2, v2.Root.Children[0].Sequence,
+	)
+}
+
+// hashOf returns a deterministic 32-byte slice for test fixtures.
+func hashOf(s string) []byte {
+	h := chainhash.HashH([]byte(s))
+
+	return h[:]
+}

--- a/rpc/roundpb/round.pb.go
+++ b/rpc/roundpb/round.pb.go
@@ -345,7 +345,15 @@ type TreeNode struct {
 	Amount int64 `protobuf:"varint,5,opt,name=amount,proto3" json:"amount,omitempty"`
 	// signature is the final aggregated MuSig2 schnorr signature (64 bytes)
 	// for the input. Empty if unsigned.
-	Signature     []byte `protobuf:"bytes,6,opt,name=signature,proto3" json:"signature,omitempty"`
+	Signature []byte `protobuf:"bytes,6,opt,name=signature,proto3" json:"signature,omitempty"`
+	// signing_tweak is the node's combined taproot tweak for asset-aware
+	// trees: the tapscript root committing to both the sweep leaf and the
+	// node's asset commitment root. Empty for Bitcoin-only trees, where the
+	// tree-wide sweep_tapscript_root applies instead.
+	SigningTweak []byte `protobuf:"bytes,7,opt,name=signing_tweak,json=signingTweak,proto3" json:"signing_tweak,omitempty"`
+	// asset_amount is the total asset amount carried by this node's
+	// subtree. Zero for Bitcoin-only trees.
+	AssetAmount   uint64 `protobuf:"varint,8,opt,name=asset_amount,json=assetAmount,proto3" json:"asset_amount,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -422,6 +430,20 @@ func (x *TreeNode) GetSignature() []byte {
 	return nil
 }
 
+func (x *TreeNode) GetSigningTweak() []byte {
+	if x != nil {
+		return x.SigningTweak
+	}
+	return nil
+}
+
+func (x *TreeNode) GetAssetAmount() uint64 {
+	if x != nil {
+		return x.AssetAmount
+	}
+	return 0
+}
+
 // VTXOTree is a flattened representation of a VTXO or connector tree.
 // The root node is always at index 0.
 type VTXOTree struct {
@@ -437,8 +459,12 @@ type VTXOTree struct {
 	// sweep_tapscript_root is the tapscript root hash for tweaking branch
 	// outputs. Empty for connector trees.
 	SweepTapscriptRoot []byte `protobuf:"bytes,4,opt,name=sweep_tapscript_root,json=sweepTapscriptRoot,proto3" json:"sweep_tapscript_root,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// asset_ref identifies the Taproot Asset carried by every leaf of this
+	// tree (group key reference for grouped assets). Empty for Bitcoin-only
+	// trees.
+	AssetRef      string `protobuf:"bytes,5,opt,name=asset_ref,json=assetRef,proto3" json:"asset_ref,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *VTXOTree) Reset() {
@@ -497,6 +523,13 @@ func (x *VTXOTree) GetSweepTapscriptRoot() []byte {
 		return x.SweepTapscriptRoot
 	}
 	return nil
+}
+
+func (x *VTXOTree) GetAssetRef() string {
+	if x != nil {
+		return x.AssetRef
+	}
+	return ""
 }
 
 // ConnectorLeafInfo contains information about a connector leaf assigned to a
@@ -2832,7 +2865,7 @@ const file_round_proto_rawDesc = "" +
 	"\foutput_index\x18\x02 \x01(\rR\voutputIndex\":\n" +
 	"\x05TxOut\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\x03R\x05value\x12\x1b\n" +
-	"\tpk_script\x18\x02 \x01(\fR\bpkScript\"\xaf\x02\n" +
+	"\tpk_script\x18\x02 \x01(\fR\bpkScript\"\xf7\x02\n" +
 	"\bTreeNode\x12(\n" +
 	"\x05input\x18\x01 \x01(\v2\x12.round.v1.OutpointR\x05input\x12)\n" +
 	"\aoutputs\x18\x02 \x03(\v2\x0f.round.v1.TxOutR\aoutputs\x12\x1d\n" +
@@ -2840,15 +2873,18 @@ const file_round_proto_rawDesc = "" +
 	"co_signers\x18\x03 \x03(\fR\tcoSigners\x12<\n" +
 	"\bchildren\x18\x04 \x03(\v2 .round.v1.TreeNode.ChildrenEntryR\bchildren\x12\x16\n" +
 	"\x06amount\x18\x05 \x01(\x03R\x06amount\x12\x1c\n" +
-	"\tsignature\x18\x06 \x01(\fR\tsignature\x1a;\n" +
+	"\tsignature\x18\x06 \x01(\fR\tsignature\x12#\n" +
+	"\rsigning_tweak\x18\a \x01(\fR\fsigningTweak\x12!\n" +
+	"\fasset_amount\x18\b \x01(\x04R\vassetAmount\x1a;\n" +
 	"\rChildrenEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\rR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\rR\x05value:\x028\x01\"\xd5\x01\n" +
+	"\x05value\x18\x02 \x01(\rR\x05value:\x028\x01\"\xf2\x01\n" +
 	"\bVTXOTree\x12(\n" +
 	"\x05nodes\x18\x01 \x03(\v2\x12.round.v1.TreeNodeR\x05nodes\x129\n" +
 	"\x0ebatch_outpoint\x18\x02 \x01(\v2\x12.round.v1.OutpointR\rbatchOutpoint\x122\n" +
 	"\fbatch_output\x18\x03 \x01(\v2\x0f.round.v1.TxOutR\vbatchOutput\x120\n" +
-	"\x14sweep_tapscript_root\x18\x04 \x01(\fR\x12sweepTapscriptRoot\"\xfe\x01\n" +
+	"\x14sweep_tapscript_root\x18\x04 \x01(\fR\x12sweepTapscriptRoot\x12\x1b\n" +
+	"\tasset_ref\x18\x05 \x01(\tR\bassetRef\"\xfe\x01\n" +
 	"\x11ConnectorLeafInfo\x127\n" +
 	"\rleaf_outpoint\x18\x01 \x01(\v2\x12.round.v1.OutpointR\fleafOutpoint\x120\n" +
 	"\vleaf_output\x18\x02 \x01(\v2\x0f.round.v1.TxOutR\n" +

--- a/rpc/roundpb/round.proto
+++ b/rpc/roundpb/round.proto
@@ -54,6 +54,16 @@ message TreeNode {
     // signature is the final aggregated MuSig2 schnorr signature (64 bytes)
     // for the input. Empty if unsigned.
     bytes signature = 6;
+
+    // signing_tweak is the node's combined taproot tweak for asset-aware
+    // trees: the tapscript root committing to both the sweep leaf and the
+    // node's asset commitment root. Empty for Bitcoin-only trees, where the
+    // tree-wide sweep_tapscript_root applies instead.
+    bytes signing_tweak = 7;
+
+    // asset_amount is the total asset amount carried by this node's
+    // subtree. Zero for Bitcoin-only trees.
+    uint64 asset_amount = 8;
 }
 
 // VTXOTree is a flattened representation of a VTXO or connector tree.
@@ -73,6 +83,11 @@ message VTXOTree {
     // sweep_tapscript_root is the tapscript root hash for tweaking branch
     // outputs. Empty for connector trees.
     bytes sweep_tapscript_root = 4;
+
+    // asset_ref identifies the Taproot Asset carried by every leaf of this
+    // tree (group key reference for grouped assets). Empty for Bitcoin-only
+    // trees.
+    string asset_ref = 5;
 }
 
 // --------------------------------------------------------------------------

--- a/rpc/roundpb/version.go
+++ b/rpc/roundpb/version.go
@@ -10,16 +10,24 @@ import "fmt"
 // it.
 type FlowVersion uint32
 
-// FlowVersionV1 is the only round flow version this build understands. It is
-// stamped when the operator creates the round and read back whenever the round
-// is loaded, so a future, genuinely different round flow can be introduced
-// additively without ambiguity about how an existing round was conducted.
-// Until that future version exists, every round is V1.
+// FlowVersionV1 is the original round flow version. It is stamped when the
+// operator creates the round and read back whenever the round is loaded, so a
+// future, genuinely different round flow can be introduced additively without
+// ambiguity about how an existing round was conducted.
 //
 // The versions are zero-indexed: V1 is the Go zero value, so an unstamped
 // object and an omitted wire field both read as V1 with no normalization step,
-// and a NOT NULL DEFAULT 0 column defaults to V1. V2 will be 1, and so on.
+// and a NOT NULL DEFAULT 0 column defaults to V1.
 const FlowVersionV1 FlowVersion = 0
+
+// FlowVersionV2 is the asset-aware round flow: trees may carry Taproot Asset
+// commitments (per-node signing tweaks on the wire), and every tree
+// transaction of the round -- asset-bearing or not -- uses the RBF-signalling
+// input sequence instead of the final one, which changes every node txid.
+const FlowVersionV2 FlowVersion = 1
+
+// latestFlowVersion is the newest round flow version this build understands.
+const latestFlowVersion = FlowVersionV2
 
 // ValidateFlowVersion fails closed on any round flow version this build does
 // not understand -- i.e. any value past the latest this build knows. It is the
@@ -28,9 +36,9 @@ const FlowVersionV1 FlowVersion = 0
 // version means the round was conducted under rules this software does not
 // implement, so it is rejected rather than acted upon.
 func ValidateFlowVersion(v FlowVersion) error {
-	if v != FlowVersionV1 {
+	if v > latestFlowVersion {
 		return fmt.Errorf("unknown round flow version %d (this build "+
-			"understands only version %d)", v, FlowVersionV1)
+			"understands up to version %d)", v, latestFlowVersion)
 	}
 
 	return nil

--- a/rpc/roundpb/version_test.go
+++ b/rpc/roundpb/version_test.go
@@ -6,15 +6,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestValidateFlowVersion proves the round flow-version guard: V1 (the
-// zero-indexed value 0) passes; any higher, unknown value is rejected so a
-// round conducted under rules this build does not understand is never acted
-// upon.
+// TestValidateFlowVersion proves the round flow-version guard: every version
+// up to the latest this build understands passes; any higher, unknown value
+// is rejected so a round conducted under rules this build does not understand
+// is never acted upon.
 func TestValidateFlowVersion(t *testing.T) {
 	t.Parallel()
 
 	require.NoError(t, ValidateFlowVersion(FlowVersionV1))
+	require.NoError(t, ValidateFlowVersion(FlowVersionV2))
 
-	require.Error(t, ValidateFlowVersion(FlowVersionV1+1))
+	require.Error(t, ValidateFlowVersion(latestFlowVersion+1))
 	require.Error(t, ValidateFlowVersion(99))
 }

--- a/tapassets/batch_anchor.go
+++ b/tapassets/batch_anchor.go
@@ -17,32 +17,32 @@ import (
 	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
 )
 
-// BatchAnchorSource identifies the confirmed asset tranche a commitment
+// BatchAnchorSource identifies the confirmed asset funding UTXO a commitment
 // transition spends: its proof, the Bitcoin outpoint anchoring it (which
 // must be an input of the anchor transaction), and the tapd-owned internal
 // key authorizing that input's key spend.
 type BatchAnchorSource struct {
-	// ProofFile is the tranche's complete confirmed proof file.
+	// ProofFile is the funding UTXO's complete confirmed proof file.
 	ProofFile []byte
 
 	// Witness is the caller-provided asset witness stack. Empty selects
-	// tapd's backend signer, for tranches whose asset script key is
+	// tapd's backend signer, for funding UTXOs whose asset script key is
 	// wallet-owned.
 	Witness [][]byte
 
-	// Verifier verifies the tranche proof when building each commit.
+	// Verifier verifies the funding UTXO proof when building each commit.
 	Verifier tapsdk.ConfirmedProofVerifier
 
-	// AnchorOutpoint is the Bitcoin outpoint anchoring the tranche.
+	// AnchorOutpoint is the Bitcoin outpoint anchoring the funding UTXO.
 	AnchorOutpoint wire.OutPoint
 
 	// AnchorInternalKey is the tapd anchor internal key that signs the
-	// tranche input's key spend.
+	// funding input's key spend.
 	AnchorInternalKey *btcec.PublicKey
 }
 
 // BatchAnchorRequest describes one asset batch output on a caller-funded
-// anchor transaction: the whole tranche moves into a single output whose
+// anchor transaction: the whole funding UTXO moves into a single output whose
 // taproot key is the cosigner aggregate tweaked with the combined tapscript
 // root. Full-value transitions produce no split commitment, so the derived
 // roots are independent of output reordering by the funding wallet.
@@ -50,11 +50,11 @@ type BatchAnchorRequest struct {
 	// AssetRef identifies the asset carried by the batch output.
 	AssetRef tapsdk.AssetRef
 
-	// Amount is the tranche's full asset amount; the batch output
+	// Amount is the funding UTXO's full asset amount; the batch output
 	// carries all of it.
 	Amount uint64
 
-	// Source identifies the tranche the transition spends.
+	// Source identifies the funding UTXO the transition spends.
 	Source BatchAnchorSource
 
 	// Cosigners aggregate into the batch output's internal key.
@@ -112,8 +112,8 @@ type BatchAnchorCommit struct {
 	PackageBytes []byte
 
 	// AnchorPSBT is the tapd-processed anchor PSBT. It carries tapd's
-	// signature for the tranche input; the caller signs its own funding
-	// inputs and finalizes.
+	// signature for the funding UTXO input; the caller signs its own
+	// funding inputs and finalizes.
 	AnchorPSBT []byte
 
 	// Script echoes the validated batch output derivation.
@@ -143,7 +143,7 @@ func NewBatchAnchorCommitter(wallet *tapsdk.Wallet) (*BatchAnchorCommitter,
 }
 
 // DeriveScript computes the composed batch output script before the anchor
-// transaction is funded. The template must already spend the tranche's
+// transaction is funded. The template must already spend the funding UTXO's
 // anchor outpoint and carry the batch output at its planned index; funding
 // later adds inputs and change but must not touch the derived script.
 func (c *BatchAnchorCommitter) DeriveScript(ctx context.Context,
@@ -297,10 +297,10 @@ func (c *BatchAnchorCommitter) buildRequest(req *BatchAnchorRequest,
 		return nil, nil, fmt.Errorf("batch asset amount is required")
 	}
 	if len(req.Source.ProofFile) == 0 {
-		return nil, nil, fmt.Errorf("tranche proof file is required")
+		return nil, nil, fmt.Errorf("funding proof file is required")
 	}
 	if req.Source.AnchorInternalKey == nil {
-		return nil, nil, fmt.Errorf("tranche anchor internal key is " +
+		return nil, nil, fmt.Errorf("funding anchor internal key is " +
 			"required")
 	}
 	if len(req.SweepLeaf.Script) == 0 {
@@ -311,17 +311,17 @@ func (c *BatchAnchorCommitter) buildRequest(req *BatchAnchorRequest,
 			"required")
 	}
 
-	// The anchor transaction must spend the tranche's anchor outpoint.
-	spendsTranche := false
+	// The anchor transaction must spend the funding UTXO's anchor outpoint.
+	spendsFunding := false
 	for _, txIn := range anchorTx.TxIn {
 		if txIn.PreviousOutPoint == req.Source.AnchorOutpoint {
-			spendsTranche = true
+			spendsFunding = true
 			break
 		}
 	}
-	if !spendsTranche {
+	if !spendsFunding {
 		return nil, nil, fmt.Errorf("anchor transaction does not "+
-			"spend the tranche anchor %s",
+			"spend the funding anchor %s",
 			req.Source.AnchorOutpoint)
 	}
 
@@ -350,7 +350,7 @@ func (c *BatchAnchorCommitter) buildRequest(req *BatchAnchorRequest,
 		schnorr.SerializePubKey(req.Source.AnchorInternalKey),
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("tranche anchor signer: %w", err)
+		return nil, nil, fmt.Errorf("funding anchor signer: %w", err)
 	}
 
 	request := &tapsdk.CustomAnchorRequest{
@@ -404,16 +404,16 @@ func (c *BatchAnchorCommitter) buildRequest(req *BatchAnchorRequest,
 	return request, internalKey, nil
 }
 
-// batchSigningPlans classifies every anchor input: the tranche input is a
+// batchSigningPlans classifies every anchor input: the funding UTXO input is a
 // tapd key spend, every other input is caller-signed funding.
-func batchSigningPlans(tx *wire.MsgTx, tranche wire.OutPoint,
+func batchSigningPlans(tx *wire.MsgTx, funding wire.OutPoint,
 	anchorSigner tapsdk.XOnlyPubKey) []tapsdk.CustomAnchorInputSigningPlan {
 
 	plans := make(
 		[]tapsdk.CustomAnchorInputSigningPlan, 0, len(tx.TxIn),
 	)
 	for idx, txIn := range tx.TxIn {
-		if txIn.PreviousOutPoint == tranche {
+		if txIn.PreviousOutPoint == funding {
 			plans = append(
 				plans, tapsdk.CustomAnchorInputSigningPlan{
 					InputIndex: uint32(idx),

--- a/tapassets/batch_anchor.go
+++ b/tapassets/batch_anchor.go
@@ -1,0 +1,528 @@
+package tapassets
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
+)
+
+// BatchAnchorSource identifies the confirmed asset tranche a commitment
+// transition spends: its proof, the Bitcoin outpoint anchoring it (which
+// must be an input of the anchor transaction), and the tapd-owned internal
+// key authorizing that input's key spend.
+type BatchAnchorSource struct {
+	// ProofFile is the tranche's complete confirmed proof file.
+	ProofFile []byte
+
+	// Witness is the caller-provided asset witness stack. Empty selects
+	// tapd's backend signer, for tranches whose asset script key is
+	// wallet-owned.
+	Witness [][]byte
+
+	// Verifier verifies the tranche proof when building each commit.
+	Verifier tapsdk.ConfirmedProofVerifier
+
+	// AnchorOutpoint is the Bitcoin outpoint anchoring the tranche.
+	AnchorOutpoint wire.OutPoint
+
+	// AnchorInternalKey is the tapd anchor internal key that signs the
+	// tranche input's key spend.
+	AnchorInternalKey *btcec.PublicKey
+}
+
+// BatchAnchorRequest describes one asset batch output on a caller-funded
+// anchor transaction: the whole tranche moves into a single output whose
+// taproot key is the cosigner aggregate tweaked with the combined tapscript
+// root. Full-value transitions produce no split commitment, so the derived
+// roots are independent of output reordering by the funding wallet.
+type BatchAnchorRequest struct {
+	// AssetRef identifies the asset carried by the batch output.
+	AssetRef tapsdk.AssetRef
+
+	// Amount is the tranche's full asset amount; the batch output
+	// carries all of it.
+	Amount uint64
+
+	// Source identifies the tranche the transition spends.
+	Source BatchAnchorSource
+
+	// Cosigners aggregate into the batch output's internal key.
+	Cosigners []*btcec.PublicKey
+
+	// SweepLeaf is the operator's timeout leaf, committed as the asset
+	// commitment's tapscript sibling.
+	SweepLeaf txscript.TapLeaf
+
+	// Digest scopes the batch output's deterministic OP_TRUE asset
+	// script key. The key must be identical in the pre-funding
+	// derivation and the commit, and the tree's root node spends it
+	// with a caller-provided OP_TRUE witness, matching every other
+	// tree output.
+	Digest tapsdk.Hash
+
+	// OutputIndex is the batch output's position in the anchor
+	// transaction.
+	OutputIndex uint32
+
+	// OutputValueSat is the batch output's Bitcoin value.
+	OutputValueSat int64
+}
+
+// BatchAnchorScript is the pre-funding derivation of the batch output: the
+// composed script the funding wallet must keep byte-identical, and the
+// binding material later phases sign and verify against.
+type BatchAnchorScript struct {
+	// PkScript is the composed batch output script.
+	PkScript []byte
+
+	// InternalKey is the untweaked cosigner aggregate.
+	InternalKey *btcec.PublicKey
+
+	// SigningTweak is the combined taproot tweak: the BIP-341 root over
+	// the sweep leaf and the asset commitment root.
+	SigningTweak []byte
+
+	// AssetRoot is the batch output's Taproot Asset commitment root.
+	AssetRoot tapsdk.Hash
+}
+
+// BatchAnchorCommit is the sealed commitment transition: the persistence
+// material and a ready root source for materializing the tree beneath the
+// still-unconfirmed batch output.
+type BatchAnchorCommit struct {
+	// PackageBytes is the sealed transfer package.
+	PackageBytes []byte
+
+	// AnchorPSBT is the tapd-processed anchor PSBT. It carries tapd's
+	// signature for the tranche input; the caller signs its own funding
+	// inputs and finalizes.
+	AnchorPSBT []byte
+
+	// Script echoes the validated batch output derivation.
+	Script BatchAnchorScript
+
+	// RootSource chains an asset tree's root node off the unconfirmed
+	// commitment transition through a compact proof path.
+	RootSource TreeRootAssetSource
+}
+
+// BatchAnchorCommitter derives and commits asset batch outputs against a
+// caller-funded anchor transaction.
+type BatchAnchorCommitter struct {
+	driver customAnchorDriver
+}
+
+// NewBatchAnchorCommitter returns a committer over the given tap-sdk
+// wallet.
+func NewBatchAnchorCommitter(wallet *tapsdk.Wallet) (*BatchAnchorCommitter,
+	error) {
+
+	if wallet == nil {
+		return nil, fmt.Errorf("tap-sdk wallet is required")
+	}
+
+	return &BatchAnchorCommitter{driver: &sdkDriver{wallet: wallet}}, nil
+}
+
+// DeriveScript computes the composed batch output script before the anchor
+// transaction is funded. The template must already spend the tranche's
+// anchor outpoint and carry the batch output at its planned index; funding
+// later adds inputs and change but must not touch the derived script.
+func (c *BatchAnchorCommitter) DeriveScript(ctx context.Context,
+	req *BatchAnchorRequest, template *psbt.Packet) (*BatchAnchorScript,
+	error) {
+
+	balanced, err := balanceTemplate(template)
+	if err != nil {
+		return nil, err
+	}
+
+	request, internalKey, err := c.buildRequest(req, balanced)
+	if err != nil {
+		return nil, err
+	}
+
+	previews, err := c.driver.Preview(ctx, request, req.Source.Verifier)
+	if err != nil {
+		return nil, fmt.Errorf("preview batch anchor: %w", err)
+	}
+
+	for _, preview := range previews {
+		if preview.anchorOutputIndex != req.OutputIndex {
+			continue
+		}
+
+		pkScript, err := composedScript(
+			internalKey, preview.merkleRoot,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return &BatchAnchorScript{
+			PkScript:     pkScript,
+			InternalKey:  internalKey,
+			SigningTweak: preview.merkleRoot[:],
+			AssetRoot:    preview.assetRoot,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("preview misses batch output %d",
+		req.OutputIndex)
+}
+
+// Commit seals the commitment transition against the final funded anchor
+// transaction and verifies fail-closed that tapd reproduced the derived
+// batch output byte-for-byte.
+func (c *BatchAnchorCommitter) Commit(ctx context.Context,
+	req *BatchAnchorRequest, funded *psbt.Packet,
+	derived *BatchAnchorScript) (*BatchAnchorCommit, error) {
+
+	if derived == nil || len(derived.PkScript) == 0 {
+		return nil, fmt.Errorf("derived batch anchor script is " +
+			"required")
+	}
+	finalTx := funded.UnsignedTx
+	if int(req.OutputIndex) >= len(finalTx.TxOut) {
+		return nil, fmt.Errorf("batch output %d exceeds anchor outputs",
+			req.OutputIndex)
+	}
+	if !bytes.Equal(
+		finalTx.TxOut[req.OutputIndex].PkScript, derived.PkScript,
+	) {
+		return nil, fmt.Errorf("funded anchor output %d does not "+
+			"carry the derived batch script", req.OutputIndex)
+	}
+
+	request, internalKey, err := c.buildRequest(req, funded)
+	if err != nil {
+		return nil, err
+	}
+
+	committed, err := c.driver.Commit(ctx, request, req.Source.Verifier)
+	if err != nil {
+		return nil, fmt.Errorf("commit batch anchor: %w", err)
+	}
+
+	if len(committed.outputs) != 1 {
+		return nil, fmt.Errorf("batch anchor committed %d "+
+			"outputs, want 1", len(committed.outputs))
+	}
+	out := committed.outputs[0]
+	if out.anchorOutputIndex != req.OutputIndex {
+		return nil, fmt.Errorf("batch anchor committed output index "+
+			"%d, want %d", out.anchorOutputIndex, req.OutputIndex)
+	}
+	if out.amount != req.Amount {
+		return nil, fmt.Errorf("batch anchor committed amount "+
+			"%d, want %d", out.amount, req.Amount)
+	}
+	if out.anchorValueSat != req.OutputValueSat {
+		return nil, fmt.Errorf("batch anchor committed value "+
+			"%d, want %d", out.anchorValueSat, req.OutputValueSat)
+	}
+	if !bytes.Equal(out.taprootMerkleRoot[:], derived.SigningTweak) {
+		return nil, fmt.Errorf("batch anchor merkle root diverged " +
+			"from the pre-funding derivation")
+	}
+	if out.taprootAssetRoot != derived.AssetRoot {
+		return nil, fmt.Errorf("batch anchor asset root diverged " +
+			"from the pre-funding derivation")
+	}
+
+	// The composed script must reproduce from the committed roots and
+	// stay byte-identical to both the derivation and the funded output.
+	pkScript, err := composedScript(internalKey, out.taprootMerkleRoot)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(pkScript, derived.PkScript) {
+		return nil, fmt.Errorf("committed batch output script does " +
+			"not reproduce the derived script")
+	}
+
+	// tapd must not have altered the funded transaction: the sealed
+	// anchor is byte-identical to what the caller funded.
+	committedPacket, err := psbtutil.Parse(committed.anchorPSBT)
+	if err != nil {
+		return nil, fmt.Errorf("parse committed anchor PSBT: %w", err)
+	}
+	if committedPacket.UnsignedTx.TxHash() != finalTx.TxHash() {
+		return nil, fmt.Errorf("committed anchor transaction " +
+			"diverged from the funded transaction")
+	}
+
+	rootSource, err := batchRootSource(req, out, finalTx, derived)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BatchAnchorCommit{
+		PackageBytes: append([]byte(nil), committed.packageBytes...),
+		AnchorPSBT:   append([]byte(nil), committed.anchorPSBT...),
+		Script:       *derived,
+		RootSource:   rootSource,
+	}, nil
+}
+
+// buildRequest assembles the caller-funded custom-anchor request shared by
+// derivation and commit.
+func (c *BatchAnchorCommitter) buildRequest(req *BatchAnchorRequest,
+	anchor *psbt.Packet) (*tapsdk.CustomAnchorRequest, *btcec.PublicKey,
+	error) {
+
+	anchorTx := anchor.UnsignedTx
+
+	if req.Amount == 0 {
+		return nil, nil, fmt.Errorf("batch asset amount is required")
+	}
+	if len(req.Source.ProofFile) == 0 {
+		return nil, nil, fmt.Errorf("tranche proof file is required")
+	}
+	if req.Source.AnchorInternalKey == nil {
+		return nil, nil, fmt.Errorf("tranche anchor internal key is " +
+			"required")
+	}
+	if len(req.SweepLeaf.Script) == 0 {
+		return nil, nil, fmt.Errorf("sweep leaf is required")
+	}
+	if req.Digest == (tapsdk.Hash{}) {
+		return nil, nil, fmt.Errorf("batch script key digest is " +
+			"required")
+	}
+
+	// The anchor transaction must spend the tranche's anchor outpoint.
+	spendsTranche := false
+	for _, txIn := range anchorTx.TxIn {
+		if txIn.PreviousOutPoint == req.Source.AnchorOutpoint {
+			spendsTranche = true
+			break
+		}
+	}
+	if !spendsTranche {
+		return nil, nil, fmt.Errorf("anchor transaction does not "+
+			"spend the tranche anchor %s",
+			req.Source.AnchorOutpoint)
+	}
+
+	internalKey, err := tree.ComputeInternalKey(req.Cosigners)
+	if err != nil {
+		return nil, nil, fmt.Errorf("aggregate batch cosigners: %w",
+			err)
+	}
+
+	anchorBytes, err := psbtutil.Serialize(anchor)
+	if err != nil {
+		return nil, nil, fmt.Errorf("serialize anchor PSBT: %w", err)
+	}
+
+	witnessPlan := tapsdk.CustomAssetWitnessPlan{
+		Mode: witnessBackendSigner,
+	}
+	if len(req.Source.Witness) != 0 {
+		witnessPlan = tapsdk.CustomAssetWitnessPlan{
+			Mode:  witnessCallerProvided,
+			Stack: cloneByteSlices(req.Source.Witness),
+		}
+	}
+
+	anchorSigner, err := tapsdk.ParseXOnlyPubKey(
+		schnorr.SerializePubKey(req.Source.AnchorInternalKey),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("tranche anchor signer: %w", err)
+	}
+
+	request := &tapsdk.CustomAnchorRequest{
+		Inputs: []tapsdk.CustomAssetInput{{
+			ID:       "batch-anchor-input",
+			AssetRef: req.AssetRef,
+			Amount:   req.Amount,
+			ProofFile: append(
+				[]byte(nil), req.Source.ProofFile...,
+			),
+			Witness: witnessPlan,
+		}},
+		Outputs: []tapsdk.CustomAssetOutput{{
+			ID:                "batch-anchor-output",
+			AssetRef:          req.AssetRef,
+			Amount:            req.Amount,
+			AnchorOutputIndex: req.OutputIndex,
+			AnchorValueSat:    uint64(req.OutputValueSat),
+			Script: tapsdk.CustomAssetScriptPlan{
+				Mode: tapsdk.CustomAssetScriptOPTrue,
+				OPTrue: &tapsdk.CustomAssetOPTrueScriptPlan{
+					InternalKey: tapsdk.KeyDescriptor{
+						RawKeyBytes: deterministicKey(
+							req.Digest,
+							"batch-anchor",
+						),
+					},
+				},
+			},
+			Anchor: anchorPlan(
+				internalKey, []txscript.TapLeaf{req.SweepLeaf},
+			),
+		}},
+		AnchorPSBT: anchorBytes,
+		Funding: tapsdk.CustomAnchorFundingPlan{
+			Mode: tapsdk.CustomAnchorFundingCallerFundedExact,
+			CallerFundedExact: &tapsdk.
+				CustomAnchorCallerFundedExact{},
+		},
+		PassiveAssets: tapsdk.CustomAnchorPassiveAssets{
+			Policy: tapsdk.CustomAnchorPassiveReject,
+		},
+		LossPolicy: tapsdk.CustomAnchorLossPolicy{
+			Mode: tapsdk.CustomAnchorLossReject,
+		},
+		SigningPlans: batchSigningPlans(
+			anchorTx, req.Source.AnchorOutpoint, anchorSigner,
+		),
+	}
+
+	return request, internalKey, nil
+}
+
+// batchSigningPlans classifies every anchor input: the tranche input is a
+// tapd key spend, every other input is caller-signed funding.
+func batchSigningPlans(tx *wire.MsgTx, tranche wire.OutPoint,
+	anchorSigner tapsdk.XOnlyPubKey) []tapsdk.CustomAnchorInputSigningPlan {
+
+	plans := make(
+		[]tapsdk.CustomAnchorInputSigningPlan, 0, len(tx.TxIn),
+	)
+	for idx, txIn := range tx.TxIn {
+		if txIn.PreviousOutPoint == tranche {
+			plans = append(
+				plans, tapsdk.CustomAnchorInputSigningPlan{
+					InputIndex: uint32(idx),
+					KeyPath: &tapsdk.
+						CustomAnchorKeyPathSigningPlan{
+						Signer: anchorSigner,
+					},
+				},
+			)
+
+			continue
+		}
+
+		plans = append(plans, tapsdk.CustomAnchorInputSigningPlan{
+			InputIndex: uint32(idx),
+			CallerSigned: &tapsdk.
+				CustomAnchorCallerSignedPlan{},
+		})
+	}
+
+	return plans
+}
+
+// batchRootSource assembles the compact-path root source chaining a tree
+// beneath the unconfirmed commitment transition.
+func batchRootSource(req *BatchAnchorRequest, out commitOutput,
+	finalTx *wire.MsgTx,
+	derived *BatchAnchorScript) (TreeRootAssetSource, error) {
+
+	path := &tapsdk.AssetProofPath{
+		Version: tapsdk.AssetProofPathVersionV0,
+		ConfirmedBaseProof: append(
+			[]byte(nil), req.Source.ProofFile...,
+		),
+		Steps: []tapsdk.AssetProofPathStep{{
+			TransitionProof: append(
+				[]byte(nil), out.proofBlob...,
+			),
+		}},
+	}
+
+	expected := &expectedUnconfirmedAnchor{
+		stepIndex:        0,
+		previousOutpoint: sdkOutpoint(req.Source.AnchorOutpoint),
+		anchorOutpoint:   out.anchorOutpoint,
+		transaction:      serializeTx(finalTx),
+	}
+
+	return TreeRootAssetSource{
+		proofPath: path,
+		Witness:   cloneByteSlices(out.opTrueWitness),
+		Verifier: &treePathVerifier{
+			base: req.Source.Verifier,
+			steps: []*expectedUnconfirmedAnchor{
+				expected,
+			},
+		},
+		expectedSteps: []*expectedUnconfirmedAnchor{
+			expected,
+		},
+		SigningTweak:  append([]byte(nil), derived.SigningTweak...),
+		BatchPkScript: append([]byte(nil), derived.PkScript...),
+	}, nil
+}
+
+// composedScript derives the P2TR script of the internal key tweaked with
+// the combined taproot root.
+func composedScript(internalKey *btcec.PublicKey,
+	merkleRoot tapsdk.Hash) ([]byte, error) {
+
+	outputKey := txscript.ComputeTaprootOutputKey(
+		internalKey, merkleRoot[:],
+	)
+
+	script, err := txscript.PayToTaprootScript(outputKey)
+	if err != nil {
+		return nil, fmt.Errorf("compose batch output script: %w", err)
+	}
+
+	return script, nil
+}
+
+// balanceTemplate appends a caller-signed funding stub covering the full
+// output value, so the pre-funding template passes the backend's balance
+// validation. The derived asset roots are independent of Bitcoin inputs
+// (full-value transitions carry no split commitment), so the stub never
+// influences the derivation and is absent from the funded transaction.
+func balanceTemplate(template *psbt.Packet) (*psbt.Packet, error) {
+	stubValue := int64(0)
+	for _, out := range template.UnsignedTx.TxOut {
+		stubValue += out.Value
+	}
+
+	tx := template.UnsignedTx.Copy()
+	tx.AddTxIn(wire.NewTxIn(&fundingStubOutpoint, nil, nil))
+
+	balanced, err := psbt.NewFromUnsignedTx(tx)
+	if err != nil {
+		return nil, fmt.Errorf("balance anchor template: %w", err)
+	}
+	copy(balanced.Inputs, template.Inputs)
+
+	stubScript, err := txscript.PayToTaprootScript(
+		txscript.ComputeTaprootKeyNoScript(&arkscript.ARKNUMSKey),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("funding stub script: %w", err)
+	}
+	balanced.Inputs[len(balanced.Inputs)-1].WitnessUtxo = &wire.TxOut{
+		Value:    stubValue,
+		PkScript: stubScript,
+	}
+
+	return balanced, nil
+}
+
+// fundingStubOutpoint is the synthetic outpoint of the derivation-time
+// funding stub. It never appears in a committed transaction.
+var fundingStubOutpoint = wire.OutPoint{
+	Hash: chainhash.HashH([]byte("wavelength/batch-anchor/funding-stub")),
+}

--- a/tapassets/batch_anchor.go
+++ b/tapassets/batch_anchor.go
@@ -331,7 +331,24 @@ func (c *BatchAnchorCommitter) buildRequest(req *BatchAnchorRequest,
 			err)
 	}
 
-	anchorBytes, err := psbtutil.Serialize(anchor)
+	// Hand tapd a copy with the funding input's caller metadata
+	// cleared: the operator packet carries a synthetic key-spend
+	// appearance for its funding wallet's weight estimator, but tapd
+	// resolves its own input and fills the real derivation material —
+	// which the wallet backing tapd later needs to sign the input.
+	sanitized, err := psbt.NewFromUnsignedTx(anchor.UnsignedTx.Copy())
+	if err != nil {
+		return nil, nil, fmt.Errorf("clone anchor PSBT: %w", err)
+	}
+	copy(sanitized.Inputs, anchor.Inputs)
+	copy(sanitized.Outputs, anchor.Outputs)
+	for idx, txIn := range sanitized.UnsignedTx.TxIn {
+		if txIn.PreviousOutPoint == req.Source.AnchorOutpoint {
+			sanitized.Inputs[idx] = psbt.PInput{}
+		}
+	}
+
+	anchorBytes, err := psbtutil.Serialize(sanitized)
 	if err != nil {
 		return nil, nil, fmt.Errorf("serialize anchor PSBT: %w", err)
 	}

--- a/tapassets/batch_anchor.go
+++ b/tapassets/batch_anchor.go
@@ -101,6 +101,13 @@ type BatchAnchorScript struct {
 // material and a ready root source for materializing the tree beneath the
 // still-unconfirmed batch output.
 type BatchAnchorCommit struct {
+	// AssetRef is the canonical string encoding of the committed asset.
+	AssetRef string
+
+	// OutputIndex is the batch output's position in the anchor
+	// transaction.
+	OutputIndex uint32
+
 	// PackageBytes is the sealed transfer package.
 	PackageBytes []byte
 
@@ -269,6 +276,8 @@ func (c *BatchAnchorCommitter) Commit(ctx context.Context,
 	}
 
 	return &BatchAnchorCommit{
+		AssetRef:     req.AssetRef.String(),
+		OutputIndex:  req.OutputIndex,
 		PackageBytes: append([]byte(nil), committed.packageBytes...),
 		AnchorPSBT:   append([]byte(nil), committed.anchorPSBT...),
 		Script:       *derived,

--- a/tapassets/batch_anchor_publish.go
+++ b/tapassets/batch_anchor_publish.go
@@ -1,0 +1,39 @@
+package tapassets
+
+import (
+	"context"
+	"fmt"
+
+	tapsdk "github.com/lightninglabs/tap-sdk"
+)
+
+// Publish verifies the exact finalized anchor PSBT against the sealed
+// package and hands both to tapd, completing the backend's transfer
+// bookkeeping: the funding UTXO leaves the inventory, the batch output
+// joins it, and proofs generate on confirmation. The commit recorded
+// external broadcast, so tapd logs without broadcasting.
+func (c *BatchAnchorCommitter) Publish(ctx context.Context, packageBytes,
+	finalPSBT []byte) error {
+
+	sdk, ok := c.driver.(*sdkDriver)
+	if !ok {
+		return fmt.Errorf("publish requires the tap-sdk driver")
+	}
+
+	var transfer tapsdk.CustomAnchorTransferPackage
+	if err := transfer.UnmarshalBinary(packageBytes); err != nil {
+		return fmt.Errorf("decode sealed transfer package: %w", err)
+	}
+	if err := transfer.VerifyFinalAnchorPSBT(finalPSBT); err != nil {
+		return fmt.Errorf("verify final anchor PSBT: %w", err)
+	}
+
+	_, err := sdk.wallet.PublishCustomAnchorTransfer(
+		ctx, &transfer, finalPSBT,
+	)
+	if err != nil {
+		return fmt.Errorf("publish batch anchor transfer: %w", err)
+	}
+
+	return nil
+}

--- a/tapassets/batch_anchor_test.go
+++ b/tapassets/batch_anchor_test.go
@@ -150,8 +150,8 @@ func newBatchAnchorFixture(t *testing.T) (*BatchAnchorCommitter,
 	)
 	require.NoError(t, err)
 
-	trancheOutpoint := wire.OutPoint{
-		Hash:  chainhash.HashH([]byte("tranche")),
+	fundingOutpoint := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("funding-utxo")),
 		Index: 1,
 	}
 	assetRef := tapsdk.AssetRefFromAssetID(
@@ -166,8 +166,8 @@ func newBatchAnchorFixture(t *testing.T) (*BatchAnchorCommitter,
 		AssetRef: assetRef,
 		Amount:   1_500,
 		Source: BatchAnchorSource{
-			ProofFile:         []byte("tranche-proof"),
-			AnchorOutpoint:    trancheOutpoint,
+			ProofFile:         []byte("funding-proof"),
+			AnchorOutpoint:    fundingOutpoint,
 			AnchorInternalKey: anchorKey.PubKey(),
 		},
 		Cosigners: []*btcec.PublicKey{
@@ -180,7 +180,7 @@ func newBatchAnchorFixture(t *testing.T) (*BatchAnchorCommitter,
 	}
 
 	template := wire.NewMsgTx(2)
-	template.AddTxIn(wire.NewTxIn(&trancheOutpoint, nil, nil))
+	template.AddTxIn(wire.NewTxIn(&fundingOutpoint, nil, nil))
 	template.AddTxOut(&wire.TxOut{
 		Value:    30_000,
 		PkScript: []byte{0x51},
@@ -414,15 +414,15 @@ func TestBatchAnchorRequestGuards(t *testing.T) {
 	committer, req, template := newBatchAnchorFixture(t)
 	ctx := context.Background()
 
-	// The template must spend the tranche anchor.
+	// The template must spend the funding anchor.
 	foreignTx := template.UnsignedTx.Copy()
 	foreignTx.TxIn[0].PreviousOutPoint.Index++
 	foreign, err := psbt.NewFromUnsignedTx(foreignTx)
 	require.NoError(t, err)
 	_, err = committer.DeriveScript(ctx, req, foreign)
-	require.ErrorContains(t, err, "does not spend the tranche anchor")
+	require.ErrorContains(t, err, "does not spend the funding anchor")
 
-	// The tranche proof is mandatory.
+	// The funding proof is mandatory.
 	broken := *req
 	broken.Source.ProofFile = nil
 	_, err = committer.DeriveScript(ctx, &broken, template)

--- a/tapassets/batch_anchor_test.go
+++ b/tapassets/batch_anchor_test.go
@@ -1,0 +1,436 @@
+package tapassets
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/lib/tree"
+	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBatchDriver fabricates deterministic previews and commits consistent
+// with the committer's fail-closed validation, with optional mutation
+// hooks for tamper cases.
+type fakeBatchDriver struct {
+	mutateCommit func(*commitResult)
+}
+
+// batchMerkleRoot is the fake's deterministic composed root for one
+// output.
+func batchMerkleRoot(input wire.OutPoint, index uint32) tapsdk.Hash {
+	seed := sha256.Sum256([]byte(fmt.Sprintf("batch/%s/%d", input, index)))
+
+	return tapsdk.Hash(seed)
+}
+
+// batchAssetRoot is the fake's deterministic asset commitment root.
+func batchAssetRoot(input wire.OutPoint, index uint32) tapsdk.Hash {
+	seed := sha256.Sum256([]byte(fmt.Sprintf("asset/%s/%d", input, index)))
+
+	return tapsdk.Hash(seed)
+}
+
+// Preview projects the deterministic roots for every requested output.
+func (f *fakeBatchDriver) Preview(_ context.Context,
+	request *tapsdk.CustomAnchorRequest, _ tapsdk.ConfirmedProofVerifier) (
+	[]commitmentPreview, error) {
+
+	template, err := parseAnchorTx(request.AnchorPSBT)
+	if err != nil {
+		return nil, err
+	}
+	input := template.TxIn[0].PreviousOutPoint
+
+	previews := make([]commitmentPreview, len(request.Outputs))
+	for i, out := range request.Outputs {
+		previews[i] = commitmentPreview{
+			logicalOutputID:   out.ID,
+			anchorOutputIndex: out.AnchorOutputIndex,
+			assetRoot: batchAssetRoot(
+				input, out.AnchorOutputIndex,
+			),
+			merkleRoot: batchMerkleRoot(
+				input, out.AnchorOutputIndex,
+			),
+		}
+	}
+
+	return previews, nil
+}
+
+// Commit echoes the request into a sealed-result projection with the same
+// deterministic roots the preview reported.
+func (f *fakeBatchDriver) Commit(_ context.Context,
+	request *tapsdk.CustomAnchorRequest, _ tapsdk.ConfirmedProofVerifier) (
+	*commitResult, error) {
+
+	template, err := parseAnchorTx(request.AnchorPSBT)
+	if err != nil {
+		return nil, err
+	}
+	input := template.TxIn[0].PreviousOutPoint
+
+	result := &commitResult{
+		fundingMode: tapsdk.CustomAnchorFundingCallerFundedExact,
+		anchorPSBT:  request.AnchorPSBT,
+	}
+	for _, out := range request.Outputs {
+		result.outputs = append(result.outputs, commitOutput{
+			anchorOutputIndex: out.AnchorOutputIndex,
+			anchorOutpoint: sdkOutpoint(wire.OutPoint{
+				Hash:  template.TxHash(),
+				Index: out.AnchorOutputIndex,
+			}),
+			anchorValueSat: int64(out.AnchorValueSat),
+			assetRef:       out.AssetRef,
+			amount:         out.Amount,
+			taprootMerkleRoot: batchMerkleRoot(
+				input, out.AnchorOutputIndex,
+			),
+			taprootAssetRoot: batchAssetRoot(
+				input, out.AnchorOutputIndex,
+			),
+			scriptMode: tapsdk.CustomAssetScriptOPTrue,
+			opTrueWitness: [][]byte{
+				{0x51},
+			},
+			proofBlob: []byte(fmt.Sprintf("batch-proof/%s", input)),
+		})
+	}
+	result.packageBytes = []byte(fmt.Sprintf("batch-package/%s", input))
+
+	if f.mutateCommit != nil {
+		f.mutateCommit(result)
+	}
+
+	return result, nil
+}
+
+// DecodePackage is unused by the batch anchor committer.
+func (f *fakeBatchDriver) DecodePackage([]byte) (*commitResult, error) {
+	return nil, fmt.Errorf("decode is not used by the batch committer")
+}
+
+// parseAnchorTx extracts the unsigned transaction from a serialized PSBT.
+func parseAnchorTx(anchorPSBT []byte) (*wire.MsgTx, error) {
+	packet, err := psbtutil.Parse(anchorPSBT)
+	if err != nil {
+		return nil, err
+	}
+
+	return packet.UnsignedTx, nil
+}
+
+// newBatchAnchorFixture builds a request, its template transaction, and a
+// committer over the fake driver.
+func newBatchAnchorFixture(t *testing.T) (*BatchAnchorCommitter,
+	*BatchAnchorRequest, *psbt.Packet) {
+
+	t.Helper()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	userKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	anchorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	sweepLeaf, err := arkscript.UnilateralCSVTimeoutTapLeaf(
+		operatorKey.PubKey(), 1008,
+	)
+	require.NoError(t, err)
+
+	trancheOutpoint := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("tranche")),
+		Index: 1,
+	}
+	assetRef := tapsdk.AssetRefFromAssetID(
+		tapsdk.AssetID(
+			chainhash.HashH(
+				[]byte("asset"),
+			),
+		),
+	)
+
+	req := &BatchAnchorRequest{
+		AssetRef: assetRef,
+		Amount:   1_500,
+		Source: BatchAnchorSource{
+			ProofFile:         []byte("tranche-proof"),
+			AnchorOutpoint:    trancheOutpoint,
+			AnchorInternalKey: anchorKey.PubKey(),
+		},
+		Cosigners: []*btcec.PublicKey{
+			operatorKey.PubKey(), userKey.PubKey(),
+		},
+		SweepLeaf:      sweepLeaf,
+		Digest:         tapsdk.Hash(chainhash.HashH([]byte("round"))),
+		OutputIndex:    0,
+		OutputValueSat: 30_000,
+	}
+
+	template := wire.NewMsgTx(2)
+	template.AddTxIn(wire.NewTxIn(&trancheOutpoint, nil, nil))
+	template.AddTxOut(&wire.TxOut{
+		Value:    30_000,
+		PkScript: []byte{0x51},
+	})
+
+	packet, err := psbt.NewFromUnsignedTx(template)
+	require.NoError(t, err)
+
+	return &BatchAnchorCommitter{driver: &fakeBatchDriver{}}, req, packet
+}
+
+// fundedFromTemplate simulates the funding wallet: extra fee input,
+// change output, and the derived script patched onto the batch output.
+func fundedFromTemplate(t *testing.T, template *psbt.Packet,
+	derived *BatchAnchorScript) *psbt.Packet {
+
+	t.Helper()
+
+	fundedTx := template.UnsignedTx.Copy()
+	fundedTx.TxOut[0].PkScript = append(
+		[]byte(nil), derived.PkScript...,
+	)
+	fundedTx.AddTxIn(
+		wire.NewTxIn(
+			&wire.OutPoint{
+				Hash:  chainhash.HashH([]byte("fee-input")),
+				Index: 0,
+			},
+			nil,
+			nil,
+		),
+	)
+	fundedTx.AddTxOut(&wire.TxOut{
+		Value:    5_000,
+		PkScript: []byte{0x52},
+	})
+
+	funded, err := psbt.NewFromUnsignedTx(fundedTx)
+	require.NoError(t, err)
+
+	return funded
+}
+
+// TestBatchAnchorDeriveAndCommit proves the pre-funding derivation and the
+// post-funding commit agree: the derived script reproduces from the
+// committed roots and the root source carries the compact path binding.
+func TestBatchAnchorDeriveAndCommit(t *testing.T) {
+	t.Parallel()
+
+	committer, req, template := newBatchAnchorFixture(t)
+	ctx := context.Background()
+
+	derived, err := committer.DeriveScript(ctx, req, template)
+	require.NoError(t, err)
+
+	// The derived script is the aggregate tweaked with the composed
+	// root.
+	wantInternal, err := tree.ComputeInternalKey(req.Cosigners)
+	require.NoError(t, err)
+	wantKey := txscript.ComputeTaprootOutputKey(
+		wantInternal, derived.SigningTweak,
+	)
+	wantScript, err := txscript.PayToTaprootScript(wantKey)
+	require.NoError(t, err)
+	require.Equal(t, wantScript, derived.PkScript)
+
+	funded := fundedFromTemplate(t, template, derived)
+
+	commit, err := committer.Commit(ctx, req, funded, derived)
+	require.NoError(t, err)
+	require.NotEmpty(t, commit.PackageBytes)
+	require.Equal(t, derived.PkScript, commit.Script.PkScript)
+	require.Equal(
+		t, derived.SigningTweak, commit.RootSource.SigningTweak,
+	)
+	require.Equal(t, derived.PkScript, commit.RootSource.BatchPkScript)
+
+	// The root source chains through a one-step compact path bound to
+	// the funded transaction.
+	path := commit.RootSource.proofPath
+	require.NotNil(t, path)
+	require.Equal(t, req.Source.ProofFile, path.ConfirmedBaseProof)
+	require.Len(t, path.Steps, 1)
+
+	require.Len(t, commit.RootSource.expectedSteps, 1)
+	step := commit.RootSource.expectedSteps[0]
+	require.Equal(
+		t, sdkOutpoint(req.Source.AnchorOutpoint),
+		step.previousOutpoint,
+	)
+	require.Equal(
+		t, serializeTx(funded.UnsignedTx), step.transaction,
+	)
+}
+
+// TestBatchAnchorCommitFailClosed proves every divergence between the
+// derivation, the funded transaction, and the committed result is
+// rejected.
+func TestBatchAnchorCommitFailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		corrupt func(req *BatchAnchorRequest, funded *psbt.Packet,
+			derived *BatchAnchorScript, fake *fakeBatchDriver)
+		wantErr string
+	}{
+		{
+			name: "funded output misses derived script",
+			corrupt: func(_ *BatchAnchorRequest,
+				funded *psbt.Packet, _ *BatchAnchorScript,
+				_ *fakeBatchDriver) {
+
+				funded.UnsignedTx.TxOut[0].PkScript = []byte{
+					0x53,
+				}
+			},
+			wantErr: "does not carry the derived batch script",
+		},
+		{
+			name: "committed merkle root diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[0].taprootMerkleRoot[0] ^= 1
+				}
+			},
+			wantErr: "merkle root diverged",
+		},
+		{
+			name: "committed asset root diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[0].taprootAssetRoot[0] ^= 1
+				}
+			},
+			wantErr: "asset root diverged",
+		},
+		{
+			name: "committed amount diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[0].amount--
+				}
+			},
+			wantErr: "committed amount",
+		},
+		{
+			name: "committed value diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs[0].anchorValueSat++
+				}
+			},
+			wantErr: "committed value",
+		},
+		{
+			name: "committed transaction diverges",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					packet, err := psbtutil.Parse(
+						r.anchorPSBT,
+					)
+					if err != nil {
+						panic(err)
+					}
+					packet.UnsignedTx.LockTime++
+					mutated, err := psbtutil.Serialize(
+						packet,
+					)
+					if err != nil {
+						panic(err)
+					}
+					r.anchorPSBT = mutated
+				}
+			},
+			wantErr: "diverged from the funded transaction",
+		},
+		{
+			name: "extra committed output",
+			corrupt: func(_ *BatchAnchorRequest, _ *psbt.Packet,
+				_ *BatchAnchorScript, fake *fakeBatchDriver) {
+
+				fake.mutateCommit = func(r *commitResult) {
+					r.outputs = append(
+						r.outputs, r.outputs[0],
+					)
+				}
+			},
+			wantErr: "want 1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			committer, req, template := newBatchAnchorFixture(t)
+			fake, ok := committer.driver.(*fakeBatchDriver)
+			require.True(t, ok)
+			ctx := context.Background()
+
+			derived, err := committer.DeriveScript(
+				ctx, req, template,
+			)
+			require.NoError(t, err)
+
+			funded := fundedFromTemplate(t, template, derived)
+			test.corrupt(req, funded, derived, fake)
+
+			_, err = committer.Commit(ctx, req, funded, derived)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+// TestBatchAnchorRequestGuards proves the request-level guards fire before
+// any driver call.
+func TestBatchAnchorRequestGuards(t *testing.T) {
+	t.Parallel()
+
+	committer, req, template := newBatchAnchorFixture(t)
+	ctx := context.Background()
+
+	// The template must spend the tranche anchor.
+	foreignTx := template.UnsignedTx.Copy()
+	foreignTx.TxIn[0].PreviousOutPoint.Index++
+	foreign, err := psbt.NewFromUnsignedTx(foreignTx)
+	require.NoError(t, err)
+	_, err = committer.DeriveScript(ctx, req, foreign)
+	require.ErrorContains(t, err, "does not spend the tranche anchor")
+
+	// The tranche proof is mandatory.
+	broken := *req
+	broken.Source.ProofFile = nil
+	_, err = committer.DeriveScript(ctx, &broken, template)
+	require.ErrorContains(t, err, "proof file is required")
+
+	// The asset amount is mandatory.
+	broken = *req
+	broken.Amount = 0
+	_, err = committer.DeriveScript(ctx, &broken, template)
+	require.ErrorContains(t, err, "asset amount is required")
+}

--- a/tapassets/tree_assembler.go
+++ b/tapassets/tree_assembler.go
@@ -105,6 +105,7 @@ func buildAssetTree(ctx context.Context, materializer *TreeMaterializer,
 	// The materializer reads subtree totals from the structure's
 	// context; rebind it so callers cannot desynchronize the two.
 	materializer.cfg.AssetContext = structure.AssetContext
+	structure.AssetContext.SetAssetRef(materializer.cfg.AssetRef.String())
 
 	err = tree.Materialize(
 		ctx, structure.Root, tree.MaterializeParams{
@@ -122,6 +123,7 @@ func buildAssetTree(ctx context.Context, materializer *TreeMaterializer,
 		BatchOutpoint:      req.BatchOutpoint,
 		BatchOutput:        req.BatchOutput,
 		SweepTapscriptRoot: sweepRoot[:],
+		AssetContext:       structure.AssetContext,
 	}
 	if err := built.Verify(); err != nil {
 		return nil, nil, fmt.Errorf("materialized tree is "+

--- a/tapassets/tree_e2e_test.go
+++ b/tapassets/tree_e2e_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	tapsdk "github.com/lightninglabs/tap-sdk"
@@ -29,6 +30,8 @@ import (
 	"github.com/lightninglabs/wavelength/lib/tx/psbtutil"
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -306,8 +309,8 @@ func TestAssetTreeE2E(t *testing.T) {
 	require.NoError(t, err)
 
 	batch := commitTreeBatchAnchor(
-		t, h, wallet, client, assetRef, exportRef, mintProof, 1_500,
-		rootCosigners, sweepLeaf,
+		t, h, wallet, client, assetRef, mintProof, 1_500, rootCosigners,
+		sweepLeaf,
 	)
 
 	// Build leaf policies and the anchor lookup keyed by owner.
@@ -342,18 +345,7 @@ func TestAssetTreeE2E(t *testing.T) {
 			return TreeLeafAnchor{}, fmt.Errorf("no leaf anchor " +
 				"for node")
 		},
-		Root: TreeRootAssetSource{
-			ProofFile: batch.proofFile,
-			Verifier: &proofInventoryVerifier{
-				client:    client,
-				assetRef:  assetRef,
-				amount:    1_500,
-				anchor:    sdkOutpoint(batch.outpoint),
-				assetRoot: batch.assetRoot,
-			},
-			SigningTweak:  batch.signingTweak,
-			BatchPkScript: batch.pkScript,
-		},
+		Root:   batch.commit.RootSource,
 		Digest: tapsdk.Hash(digest),
 	}
 
@@ -379,7 +371,9 @@ func TestAssetTreeE2E(t *testing.T) {
 	signAssetTree(t, built, assetCtx, operator, users)
 	require.NoError(t, built.VerifySigned())
 
-	// Confirm the batch anchor before unrolling on top of it.
+	// The tree was built and signed against the unconfirmed commitment
+	// transition; only now does the batch anchor hit the chain.
+	publishBatchAnchor(t, h, batch.commit)
 	h.GenerateAndWait(1)
 
 	// Force the entire tree on-chain, parent before child, through v3
@@ -387,31 +381,30 @@ func TestAssetTreeE2E(t *testing.T) {
 	publishTreePackages(t, h, built)
 }
 
-// treeE2EBatch bundles the committed batch anchor's binding material.
+// treeE2EBatch bundles the caller-funded batch anchor: the sealed commit
+// (with the tree root source), the batch outpoint, and the final funded
+// transaction awaiting broadcast.
 type treeE2EBatch struct {
-	outpoint     wire.OutPoint
-	output       *wire.TxOut
-	pkScript     []byte
-	signingTweak []byte
-	assetRoot    tapsdk.Hash
-	proofFile    []byte
+	commit   *BatchAnchorCommit
+	outpoint wire.OutPoint
+	output   *wire.TxOut
 }
 
-// commitTreeBatchAnchor anchors the minted asset beneath the tree's batch
-// output: a wallet-funded custom anchor whose output carries the MuSig2
-// aggregate internal key with the sweep leaf as tapscript sibling, signed
-// by the harness LND wallet, published through tapd, and confirmed.
+// commitTreeBatchAnchor commits the minted asset beneath the tree's batch
+// output on a caller-funded anchor transaction, mirroring the operator's
+// commitment-transaction flow: derive the composed script before funding,
+// fund with an LND wallet UTXO, then seal against the final transaction.
+// The transaction is not broadcast; the tree builds and signs first.
 func commitTreeBatchAnchor(t *testing.T, h *harness.Harness,
-	wallet *tapsdk.Wallet, client tapsdk.Client,
-	assetRef, exportRef tapsdk.AssetRef, mintProof []byte, amount uint64,
-	rootCosigners []*btcec.PublicKey,
+	wallet *tapsdk.Wallet, client tapsdk.Client, assetRef tapsdk.AssetRef,
+	mintProof []byte, amount uint64, rootCosigners []*btcec.PublicKey,
 	sweepLeaf txscript.TapLeaf) *treeE2EBatch {
 
 	t.Helper()
 	ctx := t.Context()
 
-	// Locate the mint anchor in tapd's inventory, mirroring the
-	// onboarding flow's input verification.
+	// Locate the mint anchor in tapd's inventory: the tranche the
+	// commitment transition spends.
 	verified, err := client.VerifyProof(ctx, mintProof)
 	require.NoError(t, err)
 	require.True(t, verified.Valid)
@@ -430,145 +423,132 @@ func commitTreeBatchAnchor(t *testing.T, h *harness.Harness,
 	}
 	require.NotNil(t, anchor, "mint anchor not in tapd inventory")
 
-	rootInternal, err := tree.ComputeInternalKey(rootCosigners)
-	require.NoError(t, err)
-
-	batchValue := int64(treeE2ELeafSats) * 3
-	anchorPSBT, err := onboardingAnchorPSBT(tip.Outpoint, batchValue)
-	require.NoError(t, err)
-
 	anchorInternalKey, err := btcec.ParsePubKey(anchor.InternalKey[:])
 	require.NoError(t, err)
-	anchorSigner, err := tapsdk.ParseXOnlyPubKey(
-		schnorr.SerializePubKey(anchorInternalKey),
-	)
-	require.NoError(t, err)
-
-	feeRate, err := tapsdk.NewFeeRateSatPerVByte(1)
-	require.NoError(t, err)
-
-	request := &tapsdk.CustomAnchorRequest{
-		Inputs: []tapsdk.CustomAssetInput{{
-			ID:        "tree-e2e-batch-input",
-			AssetRef:  assetRef,
-			Amount:    amount,
-			ProofFile: append([]byte(nil), mintProof...),
-			Witness: tapsdk.CustomAssetWitnessPlan{
-				Mode: tapsdk.CustomAssetWitnessBackendSigner,
-			},
-		}},
-		Outputs: []tapsdk.CustomAssetOutput{{
-			ID:                "tree-e2e-batch-output",
-			AssetRef:          assetRef,
-			Amount:            amount,
-			AnchorOutputIndex: 0,
-			AnchorValueSat:    uint64(batchValue),
-			Script: tapsdk.CustomAssetScriptPlan{
-				Mode:   tapsdk.CustomAssetScriptWallet,
-				Wallet: &tapsdk.CustomAssetWalletScriptPlan{},
-			},
-			Anchor: anchorPlan(
-				rootInternal, []txscript.TapLeaf{sweepLeaf},
-			),
-		}},
-		AnchorPSBT: anchorPSBT,
-		Funding: tapsdk.CustomAnchorFundingPlan{
-			Mode: tapsdk.CustomAnchorFundingWalletFunded,
-			WalletFunded: &tapsdk.CustomAnchorWalletFunding{
-				ChangeOutput: tapsdk.AnchorChangeOutput{
-					Mode: tapsdk.AnchorChangeOutputAdd,
-				},
-				Fee: tapsdk.AnchorFee{
-					Mode:    tapsdk.AnchorFeeSatPerVByte,
-					FeeRate: feeRate,
-				},
-				MaxFeeSat: 100_000,
-				CustomLockID: treeE2ELockID(
-					"tree-e2e-batch",
-				),
-			},
-		},
-		PassiveAssets: tapsdk.CustomAnchorPassiveAssets{
-			Policy: tapsdk.CustomAnchorPassiveReject,
-		},
-		LossPolicy: tapsdk.CustomAnchorLossPolicy{
-			Mode: tapsdk.CustomAnchorLossReject,
-		},
-		SigningPlans: []tapsdk.CustomAnchorInputSigningPlan{{
-			InputIndex: 0,
-			KeyPath: &tapsdk.CustomAnchorKeyPathSigningPlan{
-				Signer: anchorSigner,
-			},
-		}},
+	trancheOutpoint := wire.OutPoint{
+		Hash:  chainhash.Hash(tip.Outpoint.Txid),
+		Index: tip.Outpoint.Index,
 	}
 
-	driver := &sdkDriver{wallet: wallet}
-	committed, err := driver.CommitOnboarding(
-		ctx, request, &proofInventoryVerifier{
-			client:    client,
-			assetRef:  assetRef,
-			amount:    amount,
-			anchor:    tip.Outpoint,
-			assetRoot: anchor.TaprootAssetRoot,
+	batchValue := int64(treeE2ELeafSats) * 3
+	req := &BatchAnchorRequest{
+		AssetRef: assetRef,
+		Amount:   amount,
+		Source: BatchAnchorSource{
+			ProofFile: append([]byte(nil), mintProof...),
+			Verifier: &proofInventoryVerifier{
+				client:    client,
+				assetRef:  assetRef,
+				amount:    amount,
+				anchor:    tip.Outpoint,
+				assetRoot: anchor.TaprootAssetRoot,
+			},
+			AnchorOutpoint:    trancheOutpoint,
+			AnchorInternalKey: anchorInternalKey,
 		},
+		Cosigners:      rootCosigners,
+		SweepLeaf:      sweepLeaf,
+		Digest:         tapsdk.Hash(sha256.Sum256([]byte(t.Name()))),
+		OutputIndex:    0,
+		OutputValueSat: batchValue,
+	}
+
+	committer, err := NewBatchAnchorCommitter(wallet)
+	require.NoError(t, err)
+
+	// Derive the composed batch script against the pre-funding template.
+	templateTx := wire.NewMsgTx(2)
+	templateTx.AddTxIn(wire.NewTxIn(&trancheOutpoint, nil, nil))
+	placeholder, err := txscript.PayToTaprootScript(
+		txscript.ComputeTaprootKeyNoScript(&arkscript.ARKNUMSKey),
 	)
 	require.NoError(t, err)
-	require.Len(t, committed.outputs, 1)
-	out := committed.outputs[0]
+	templateTx.AddTxOut(&wire.TxOut{
+		Value:    batchValue,
+		PkScript: placeholder,
+	})
+	template, err := psbt.NewFromUnsignedTx(templateTx)
+	require.NoError(t, err)
 
-	// Sign the funded anchor with the harness LND wallet and publish
-	// through tapd.
-	packet, err := psbtutil.Parse(committed.anchorPSBT)
+	derived, err := committer.DeriveScript(ctx, req, template)
+	require.NoError(t, err)
+
+	// Fund deterministically with an LND wallet UTXO: the derived
+	// script lands on the batch output, change returns to the wallet.
+	lndUtxos, err := h.LND.WalletKit.ListUnspent(ctx, 1, 0x7fffffff)
+	require.NoError(t, err)
+	var feeUtxo *lnwallet.Utxo
+	for _, candidate := range lndUtxos {
+		if candidate.Value >= 1_000_000 {
+			feeUtxo = candidate
+			break
+		}
+	}
+	require.NotNil(t, feeUtxo, "no LND utxo large enough to fund")
+
+	// Change goes to a fresh P2WPKH address: tapd requires the taproot
+	// internal key of every non-asset P2TR output to build exclusion
+	// proofs, and segwit v0 outputs sidestep that requirement.
+	changeAddr, err := h.LND.WalletKit.NextAddr(
+		ctx, "", walletrpc.AddressType_WITNESS_PUBKEY_HASH, true,
+	)
+	require.NoError(t, err)
+	changeScript, err := txscript.PayToAddrScript(changeAddr)
+	require.NoError(t, err)
+
+	fundedTx := templateTx.Copy()
+	fundedTx.TxOut[0].PkScript = append([]byte(nil), derived.PkScript...)
+	fundedTx.AddTxIn(wire.NewTxIn(&feeUtxo.OutPoint, nil, nil))
+	change := int64(feeUtxo.Value) + anchor.AmtSat - batchValue -
+		treeE2EChildFee
+	require.Positive(t, change)
+	fundedTx.AddTxOut(&wire.TxOut{
+		Value:    change,
+		PkScript: changeScript,
+	})
+
+	funded, err := psbt.NewFromUnsignedTx(fundedTx)
+	require.NoError(t, err)
+	funded.Inputs[1].WitnessUtxo = &wire.TxOut{
+		Value:    int64(feeUtxo.Value),
+		PkScript: append([]byte(nil), feeUtxo.PkScript...),
+	}
+
+	commit, err := committer.Commit(ctx, req, funded, derived)
+	require.NoError(t, err)
+
+	return &treeE2EBatch{
+		commit: commit,
+		outpoint: wire.OutPoint{
+			Hash:  fundedTx.TxHash(),
+			Index: req.OutputIndex,
+		},
+		output: wire.NewTxOut(batchValue, derived.PkScript),
+	}
+}
+
+// publishBatchAnchor signs the funding input, finalizes, and broadcasts
+// the committed batch anchor transaction.
+func publishBatchAnchor(t *testing.T, h *harness.Harness,
+	commit *BatchAnchorCommit) {
+
+	t.Helper()
+	ctx := t.Context()
+
+	packet, err := psbtutil.Parse(commit.AnchorPSBT)
 	require.NoError(t, err)
 	signed, err := h.LND.WalletKit.SignPsbt(ctx, packet)
 	require.NoError(t, err)
 	finalized, _, err := h.LND.WalletKit.FinalizePsbt(ctx, signed, "")
 	require.NoError(t, err)
-	finalBytes, err := psbtutil.Serialize(finalized)
-	require.NoError(t, err)
 
+	finalTx, err := psbt.Extract(finalized)
+	require.NoError(t, err)
 	require.NoError(
-		t, driver.PublishOnboarding(
-			ctx, committed.packageBytes, finalBytes,
+		t, h.LND.WalletKit.PublishTransaction(
+			ctx, finalTx, "tree-e2e-batch-anchor",
 		),
 	)
-	h.GenerateAndWait(6)
-
-	committedPacket, err := psbtutil.Parse(committed.anchorPSBT)
-	require.NoError(t, err)
-	batchTx := committedPacket.UnsignedTx
-	outIndex := out.anchorOutputIndex
-	batchOutpoint := wire.OutPoint{
-		Hash:  chainhash.Hash(out.anchorOutpoint.Txid),
-		Index: out.anchorOutpoint.Index,
-	}
-
-	// Export and verify the batch anchor's proof once tapd has seen the
-	// confirmation.
-	var proofFile []byte
-	require.Eventually(t, func() bool {
-		exported, exportErr := client.ExportProof(
-			ctx, exportRef, out.scriptKey, &out.anchorOutpoint,
-		)
-		if exportErr != nil || exported == nil ||
-			len(exported.RawProofFile) == 0 {
-			return false
-		}
-		proofFile = exported.RawProofFile
-
-		return true
-	}, treeE2ETimeout, time.Second, "batch anchor proof never exported")
-
-	return &treeE2EBatch{
-		outpoint: batchOutpoint,
-		output: wire.NewTxOut(
-			batchValue, batchTx.TxOut[outIndex].PkScript,
-		),
-		pkScript:     batchTx.TxOut[outIndex].PkScript,
-		signingTweak: out.taprootMerkleRoot[:],
-		assetRoot:    out.taprootAssetRoot,
-		proofFile:    proofFile,
-	}
 }
 
 // treeE2ELeafAnchor compiles a standard VTXO policy for one leaf owner and
@@ -939,13 +919,6 @@ func exportTreeE2EProof(t *testing.T, client tapsdk.Client,
 	require.True(t, verified.Valid)
 
 	return exported.RawProofFile
-}
-
-// treeE2ELockID derives a deterministic wallet lock id.
-func treeE2ELockID(label string) []byte {
-	digest := sha256.Sum256([]byte(label))
-
-	return digest[:]
 }
 
 // keyHex returns the compressed hex encoding of a public key.

--- a/tapassets/tree_e2e_test.go
+++ b/tapassets/tree_e2e_test.go
@@ -291,7 +291,7 @@ func TestAssetTreeE2E(t *testing.T) {
 	require.True(t, record.AssetRef.IsGroupRef())
 
 	// Commits and verifiers identify the asset by its group-aware ref;
-	// proof exports address the tranche by issuance id.
+	// proof exports address the concrete issuance by its id.
 	assetRef := record.AssetRef
 	exportRef := tapsdk.AssetRefFromAssetID(record.Genesis.IssuanceID)
 	mintProof := exportTreeE2EProof(
@@ -403,7 +403,7 @@ func commitTreeBatchAnchor(t *testing.T, h *harness.Harness,
 	t.Helper()
 	ctx := t.Context()
 
-	// Locate the mint anchor in tapd's inventory: the tranche the
+	// Locate the mint anchor in tapd's inventory: the funding UTXO the
 	// commitment transition spends.
 	verified, err := client.VerifyProof(ctx, mintProof)
 	require.NoError(t, err)
@@ -425,7 +425,7 @@ func commitTreeBatchAnchor(t *testing.T, h *harness.Harness,
 
 	anchorInternalKey, err := btcec.ParsePubKey(anchor.InternalKey[:])
 	require.NoError(t, err)
-	trancheOutpoint := wire.OutPoint{
+	fundingOutpoint := wire.OutPoint{
 		Hash:  chainhash.Hash(tip.Outpoint.Txid),
 		Index: tip.Outpoint.Index,
 	}
@@ -443,7 +443,7 @@ func commitTreeBatchAnchor(t *testing.T, h *harness.Harness,
 				anchor:    tip.Outpoint,
 				assetRoot: anchor.TaprootAssetRoot,
 			},
-			AnchorOutpoint:    trancheOutpoint,
+			AnchorOutpoint:    fundingOutpoint,
 			AnchorInternalKey: anchorInternalKey,
 		},
 		Cosigners:      rootCosigners,
@@ -458,7 +458,7 @@ func commitTreeBatchAnchor(t *testing.T, h *harness.Harness,
 
 	// Derive the composed batch script against the pre-funding template.
 	templateTx := wire.NewMsgTx(2)
-	templateTx.AddTxIn(wire.NewTxIn(&trancheOutpoint, nil, nil))
+	templateTx.AddTxIn(wire.NewTxIn(&fundingOutpoint, nil, nil))
 	placeholder, err := txscript.PayToTaprootScript(
 		txscript.ComputeTaprootKeyNoScript(&arkscript.ARKNUMSKey),
 	)

--- a/tapassets/tree_leaf_anchor.go
+++ b/tapassets/tree_leaf_anchor.go
@@ -1,0 +1,51 @@
+package tapassets
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/lightninglabs/wavelength/lib/arkscript"
+)
+
+// StandardVTXOLeafAnchor compiles the standard VTXO policy for one leaf
+// owner and projects it into the materializer's leaf anchor shape: the
+// uncomposed policy script the Bitcoin template carries, plus the policy
+// material tapd needs to graft the asset commitment into the final key.
+func StandardVTXOLeafAnchor(owner, operator *btcec.PublicKey,
+	exitDelay uint32) (TreeLeafAnchor, error) {
+
+	encoded, err := arkscript.EncodeStandardVTXOTemplate(
+		owner, operator, exitDelay,
+	)
+	if err != nil {
+		return TreeLeafAnchor{}, fmt.Errorf("encode leaf policy: %w",
+			err)
+	}
+	template, err := arkscript.DecodePolicyTemplate(encoded)
+	if err != nil {
+		return TreeLeafAnchor{}, fmt.Errorf("decode leaf policy: %w",
+			err)
+	}
+	policy, err := template.Compile()
+	if err != nil {
+		return TreeLeafAnchor{}, fmt.Errorf("compile leaf policy: %w",
+			err)
+	}
+	pkScript, err := template.PkScript()
+	if err != nil {
+		return TreeLeafAnchor{}, fmt.Errorf("leaf policy script: %w",
+			err)
+	}
+
+	tapLeaves := make([]txscript.TapLeaf, len(policy.Leaves))
+	for idx := range policy.Leaves {
+		tapLeaves[idx] = policy.Leaves[idx].Leaf
+	}
+
+	return TreeLeafAnchor{
+		UncomposedPkScript: pkScript,
+		InternalKey:        policy.InternalKey,
+		TapLeaves:          tapLeaves,
+	}, nil
+}

--- a/tapassets/tree_materializer.go
+++ b/tapassets/tree_materializer.go
@@ -238,6 +238,10 @@ func (m *TreeMaterializer) MaterializeNode(ctx context.Context, node *tree.Node,
 		params.Input, committed.packageBytes,
 	)
 
+	// Re-register the subtree total now that the node carries its input,
+	// so the amount stays resolvable on extracted or deserialized clones.
+	m.cfg.AssetContext.SetNodeAssetAmount(node, amount)
+
 	return m.prepareChildren(
 		node, params.Input, source, committedTx, committed, outputSpecs,
 	)
@@ -315,7 +319,7 @@ func (m *TreeMaterializer) buildTemplate(node *tree.Node) (*psbt.Packet,
 	tx := wire.NewMsgTx(3)
 	tx.AddTxIn(&wire.TxIn{
 		PreviousOutPoint: node.Input,
-		Sequence:         wire.MaxTxInSequenceNum,
+		Sequence:         node.TxSequence(),
 	})
 
 	var specs []treeOutputSpec

--- a/tapassets/tree_materializer.go
+++ b/tapassets/tree_materializer.go
@@ -61,6 +61,16 @@ type TreeRootAssetSource struct {
 	// BatchPkScript is the batch output's final on-chain script, used
 	// to bind the root node's key material fail-closed.
 	BatchPkScript []byte
+
+	// expectedSteps bind the unconfirmed steps already inside ProofPath
+	// to their exact anchor transactions, so child paths extend from
+	// the right depth. Populated by BatchAnchorCommitter.
+	expectedSteps []*expectedUnconfirmedAnchor
+
+	// proofPath is the in-process form of ProofPath, set by
+	// BatchAnchorCommitter to skip a redundant decode-validate cycle.
+	// It wins over the serialized fields when present.
+	proofPath *tapsdk.AssetProofPath
 }
 
 // TreeMaterializerConfig configures asset tree materialization.
@@ -259,7 +269,7 @@ func (m *TreeMaterializer) resolveInput(input wire.OutPoint) (*assetSpendSource,
 		return handoff.source, handoff.amount,
 			handoff.signingTweak[:], handoff.pkScript, nil
 	}
-	m.currentSteps = nil
+	m.currentSteps = m.cfg.Root.expectedSteps
 
 	// No handoff means this is the root node spending the batch output.
 	root := m.cfg.Root
@@ -286,6 +296,9 @@ func (m *TreeMaterializer) resolveInput(input wire.OutPoint) (*assetSpendSource,
 		verifier: root.Verifier,
 	}
 	switch {
+	case root.proofPath != nil:
+		source.proofPath = root.proofPath.Clone()
+
 	case len(root.ProofFile) != 0:
 		source.proofFile = append([]byte(nil), root.ProofFile...)
 

--- a/tapassets/verifier_export.go
+++ b/tapassets/verifier_export.go
@@ -1,0 +1,28 @@
+package tapassets
+
+import (
+	"github.com/btcsuite/btcd/wire/v2"
+	tapsdk "github.com/lightninglabs/tap-sdk"
+)
+
+// InventoryVerifierClient is the slice of the tap-sdk client the inventory
+// verifier needs.
+type InventoryVerifierClient = proofInventoryClient
+
+// NewInventoryVerifier binds a confirmed proof to the operator's own tapd
+// inventory: the proof tip must match the expected asset, amount, and
+// anchor outpoint, and that anchor must appear in tapd's managed-UTXO
+// inventory with the expected Taproot Asset commitment root. Round
+// integrations use it to verify tranche proofs at plan and commit time.
+func NewInventoryVerifier(client InventoryVerifierClient,
+	assetRef tapsdk.AssetRef, amount uint64, anchor wire.OutPoint,
+	assetRoot tapsdk.Hash) tapsdk.ConfirmedProofVerifier {
+
+	return &proofInventoryVerifier{
+		client:    client,
+		assetRef:  assetRef,
+		amount:    amount,
+		anchor:    sdkOutpoint(anchor),
+		assetRoot: assetRoot,
+	}
+}

--- a/tapassets/verifier_export.go
+++ b/tapassets/verifier_export.go
@@ -13,7 +13,7 @@ type InventoryVerifierClient = proofInventoryClient
 // inventory: the proof tip must match the expected asset, amount, and
 // anchor outpoint, and that anchor must appear in tapd's managed-UTXO
 // inventory with the expected Taproot Asset commitment root. Round
-// integrations use it to verify tranche proofs at plan and commit time.
+// integrations use it to verify funding-UTXO proofs at plan and commit time.
 func NewInventoryVerifier(client InventoryVerifierClient,
 	assetRef tapsdk.AssetRef, amount uint64, anchor wire.OutPoint,
 	assetRoot tapsdk.Hash) tapsdk.ConfirmedProofVerifier {


### PR DESCRIPTION
Stacked on #1084. Client-side work for M2 of the round integration (execplan in lumos#744): milestone 1 (wire format, codecs, flow version) plus the milestone-2 batch-anchor machinery.

## Milestone 1 — wire format, codecs, flow version

- **Wire**: `TreeNode` gains `signing_tweak` (the node's combined taproot tweak committing to sweep leaf + asset commitment root) and `asset_amount` (subtree total); `VTXOTree` gains `asset_ref`. Bitcoin-only trees leave all three empty.
- **Proto codec**: `TreeFromProto` recomputes each node's `FinalKey` with the per-node tweak when present (sweep-root fallback otherwise) and rebuilds the `AssetTreeContext`; `TreeToProto` emits it. Sealed packages deliberately stay off the wire (operator persistence only).
- **Flow version V2**: `FlowVersionV2` added and accepted by the ingress guard. V2 gates the deferred `ToTx()` sequence change: node transactions move to the RBF-signalling `MaxTxInSequenceNum - 2` (`tree.SequenceV2`). The sequence is consensus-visible, so it is derived from the round's flow version at decode time (`WithNodeSequence`), and `CommitmentTxBuilt.FromProto` validates the version before decoding trees.
- **lib/tree**: `Node.Sequence` + `TxSequence()`, `Tree.AssetContext` pairing, input-outpoint fallback keying for subtree amounts so client-extracted paths (cloned nodes) still resolve them.
- **TLV codec**: optional records for per-node tweak/sealed-package/amount and tree-level asset-ref/sequence; Bitcoin-only flow-V1 blobs stay byte-identical.

## Milestone 2 — caller-funded batch anchors (`tapassets.BatchAnchorCommitter`)

This is the mechanism lumos's `buildCommitmentTx` will call: batch output scripts are fixed **before** `FundPsbt`, but the asset transition can only commit against the **final** funded transaction.

- `DeriveScript` previews the composed batch output script pre-funding (`Build` + `PreviewOutputCommitments` against a balance-stubbed template — no tapd mutation).
- `Commit` seals the transition against the funded transaction and verifies fail-closed: derived script byte-equal on the funded output, committed merkle/asset roots equal to the derivation, composed script reproducible from the committed roots, committed transaction byte-identical to the funded one.
- The batch output uses a deterministic OP_TRUE asset script key (backend-chosen wallet keys are re-derived per build and would diverge the roots), and the returned `TreeRootAssetSource` chains the tree beneath the **unconfirmed** commitment transition through a compact proof path, with every ancestor step byte-bound.
- Full-value single-tranche only, by design: split commitments bind the anchor output index, so only splitless transitions survive output reordering by the funding wallet.

The e2e now runs the exact round lifecycle against real tapd (~40s): mint → derive script → fund with an LND UTXO → sealed commit → **build + sign the whole tree on the unconfirmed commitment transition** → `VerifySigned` → broadcast → confirm → unroll via package relay.

Depends on tap-sdk#173 (`CallerSigned` signing-plan variant, pinned): lnd funding inputs on a caller-funded anchor were previously unclassifiable.

## Notes for the lumos integration

- tapd requires the taproot internal key of every non-asset P2TR output on the anchor transaction (exclusion proofs). lumos must attach `TaprootInternalKey` PSBT metadata for connector outputs and lnd change (lnd's FundPsbt populates its own change; connectors need explicit metadata), or use non-P2TR outputs.
- The batch-anchor digest scoping the OP_TRUE key must be known pre-funding (round ID, not the batch outpoint).
