### PR TITLE
swaps: bind out-swap acknowledgements to vHTLC terms

### DIFF
--- a/cmd/wavecli/waveclicommands/devrpc/registry_generated.go
+++ b/cmd/wavecli/waveclicommands/devrpc/registry_generated.go
@@ -332,6 +332,13 @@ func generatedRegistry() []serviceSpec {
 					Output:   "waverpc.ListVHTLCRecoveriesResponse",
 					Comments: "ListVHTLCRecoveries returns all durable recovery rows for operator\ninspection. Armed rows are dormant; callers must use\nEscalateVHTLCRecovery to start costly on-chain recovery.",
 				},
+				{
+					Name:     "SignOutSwapHtlcAck",
+					Aliases:  []string{"sign-out-swap-htlc-ack"},
+					Input:    "waverpc.SignOutSwapHtlcAckRequest",
+					Output:   "waverpc.SignOutSwapHtlcAckResponse",
+					Comments: "SignOutSwapHtlcAck signs the accepted terms of an out-swap vHTLC with\nthe daemon identity key.",
+				},
 			},
 		},
 		{

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -433,6 +433,19 @@ func (c *DaemonServiceClient) ReceiveAuthECDH(ctx context.Context,
 	return out, err
 }
 
+// SignOutSwapHtlcAck signs accepted out-swap vHTLC terms.
+func (c *DaemonServiceClient) SignOutSwapHtlcAck(ctx context.Context,
+	in *waverpc.SignOutSwapHtlcAckRequest, _ ...grpc.CallOption) (
+	*waverpc.SignOutSwapHtlcAckResponse, error) {
+
+	out := new(waverpc.SignOutSwapHtlcAckResponse)
+	err := c.client.Post(
+		ctx, "/v1/daemon/sign-out-swap-htlc-ack", in, out,
+	)
+
+	return out, err
+}
+
 // GetIndexedVTXOByPkScript looks up one indexed VTXO by pkScript.
 func (c *DaemonServiceClient) GetIndexedVTXOByPkScript(ctx context.Context,
 	in *waverpc.GetIndexedVTXOByPkScriptRequest, _ ...grpc.CallOption) (

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -495,6 +496,33 @@ func (c *Client) IdentityPubKey(ctx context.Context) (*btcec.PublicKey, error) {
 	}
 
 	return parseHexPubKey(info.IdentityPubKey, "identity")
+}
+
+// SignOutSwapHTLCAck asks the daemon identity key to sign accepted out-swap
+// vHTLC terms.
+func (c *Client) SignOutSwapHTLCAck(ctx context.Context,
+	paymentHash lntypes.Hash, amountSat uint64, vhtlcPkScript []byte) (
+	*schnorr.Signature, error) {
+
+	resp, err := c.daemon.SignOutSwapHtlcAck(
+		ctx, &waverpc.SignOutSwapHtlcAckRequest{
+			PaymentHash:   paymentHash[:],
+			AmountSat:     amountSat,
+			VhtlcPkScript: append([]byte(nil), vhtlcPkScript...),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign out-swap HTLC acknowledgement: %w",
+			err)
+	}
+
+	sig, err := schnorr.ParseSignature(resp.GetSignature())
+	if err != nil {
+		return nil, fmt.Errorf("parse out-swap HTLC "+
+			"acknowledgement: %w", err)
+	}
+
+	return sig, nil
 }
 
 // OperatorPubKey parses and returns the operator public key from the daemon's

--- a/sdk/ark/client_test.go
+++ b/sdk/ark/client_test.go
@@ -20,7 +20,9 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	btcecdsa "github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/wavelength/swaprpc"
 	"github.com/lightninglabs/wavelength/waved"
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -48,6 +50,7 @@ type fakeDaemonService struct {
 	lastExpiryInfoReq  *waverpc.GetVTXOExpiryInfoRequest
 	lastIndexedOORReq  *waverpc.GetIndexedOORSessionByTxidRequest
 	lastSendOORReq     *waverpc.SendOORRequest
+	lastOutSwapAckReq  *waverpc.SignOutSwapHtlcAckRequest
 }
 
 const (
@@ -250,6 +253,17 @@ func compressedPubKeyHex(scalar byte) string {
 func fakeReceiveAuthPrivKey() *btcec.PrivateKey {
 	privKeyBytes := make([]byte, 32)
 	privKeyBytes[len(privKeyBytes)-1] = 4
+
+	privKey, _ := btcec.PrivKeyFromBytes(privKeyBytes)
+
+	return privKey
+}
+
+// fakeIdentityPrivKey returns the deterministic identity key advertised by
+// the fake daemon.
+func fakeIdentityPrivKey() *btcec.PrivateKey {
+	privKeyBytes := make([]byte, 32)
+	privKeyBytes[len(privKeyBytes)-1] = 1
 
 	privKey, _ := btcec.PrivKeyFromBytes(privKeyBytes)
 
@@ -464,6 +478,31 @@ func (f *fakeDaemonService) ReceiveAuthECDH(context.Context,
 
 	return &waverpc.ReceiveAuthECDHResponse{
 		SharedSecret: bytes.Repeat([]byte{0x55}, 32),
+	}, nil
+}
+
+// SignOutSwapHtlcAck signs accepted vHTLC terms with the fake identity key.
+func (f *fakeDaemonService) SignOutSwapHtlcAck(_ context.Context,
+	req *waverpc.SignOutSwapHtlcAckRequest) (
+	*waverpc.SignOutSwapHtlcAckResponse, error) {
+
+	f.mu.Lock()
+	f.lastOutSwapAckReq = req
+	f.mu.Unlock()
+
+	var paymentHash lntypes.Hash
+	copy(paymentHash[:], req.GetPaymentHash())
+	digest := swaprpc.OutSwapHTLCAckDigest(
+		fakeIdentityPrivKey().PubKey(), paymentHash, req.GetAmountSat(),
+		req.GetVhtlcPkScript(),
+	)
+	sig, err := schnorr.Sign(fakeIdentityPrivKey(), digest[:])
+	if err != nil {
+		return nil, err
+	}
+
+	return &waverpc.SignOutSwapHtlcAckResponse{
+		Signature: sig.Serialize(),
 	}, nil
 }
 
@@ -900,6 +939,29 @@ func TestDialRemotePolicyHelpers(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotEmpty(t, compactSig)
+
+	ackHash := lntypes.Hash{4, 5, 6}
+	ackScript := []byte{0x51, 0x20, 0xaa}
+	ackSig, err := client.SignOutSwapHTLCAck(
+		context.Background(), ackHash, 42_000, ackScript,
+	)
+	require.NoError(t, err)
+	ackDigest := swaprpc.OutSwapHTLCAckDigest(
+		fakeIdentityPrivKey().PubKey(), ackHash, 42_000, ackScript,
+	)
+	require.True(
+		t,
+		ackSig.Verify(
+			ackDigest[:], fakeIdentityPrivKey().PubKey(),
+		),
+	)
+
+	service.mu.Lock()
+	ackReq := service.lastOutSwapAckReq
+	service.mu.Unlock()
+	require.Equal(t, ackHash[:], ackReq.GetPaymentHash())
+	require.Equal(t, uint64(42_000), ackReq.GetAmountSat())
+	require.Equal(t, ackScript, ackReq.GetVhtlcPkScript())
 
 	remotePriv, err := btcec.NewPrivateKey()
 	require.NoError(t, err)

--- a/sdk/swaps/client.go
+++ b/sdk/swaps/client.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btclog/v2"
@@ -699,7 +700,8 @@ type SwapServerConn interface {
 	// AcknowledgeOutSwapHTLC tells the server this receiver validated and
 	// durably accepted the out-swap HTLC event.
 	AcknowledgeOutSwapHTLC(ctx context.Context, paymentHash lntypes.Hash,
-		vhtlcPubkey *btcec.PublicKey) error
+		vhtlcPubkey *btcec.PublicKey,
+		ackSignature *schnorr.Signature) error
 
 	// CreateInSwap initiates an Ark->LN swap on the server.
 	CreateInSwap(ctx context.Context, invoice string, maxFeeSat uint64,
@@ -788,6 +790,12 @@ type DaemonConn interface {
 
 	// IdentityPubKey returns the client's identity pubkey.
 	IdentityPubKey(ctx context.Context) (*btcec.PublicKey, error)
+
+	// SignOutSwapHTLCAck signs accepted out-swap vHTLC terms with the
+	// daemon identity key.
+	SignOutSwapHTLCAck(ctx context.Context, paymentHash lntypes.Hash,
+		amountSat uint64,
+		vhtlcPkScript []byte) (*schnorr.Signature, error)
 
 	// OperatorPubKey returns the Ark operator's pubkey.
 	OperatorPubKey(ctx context.Context) (*btcec.PublicKey, error)

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -7,6 +7,7 @@ import (
 	"math"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/lightninglabs/wavelength/rpc/restclient"
 	"github.com/lightninglabs/wavelength/swaprpc"
@@ -110,10 +111,14 @@ func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 // AcknowledgeOutSwapHTLC tells the swap server this receiver validated and
 // durably accepted the out-swap HTLC event.
 func (g *GRPCSwapServerConn) AcknowledgeOutSwapHTLC(ctx context.Context,
-	paymentHash lntypes.Hash, vhtlcPubkey *btcec.PublicKey) error {
+	paymentHash lntypes.Hash, vhtlcPubkey *btcec.PublicKey,
+	ackSignature *schnorr.Signature) error {
 
 	if vhtlcPubkey == nil {
 		return fmt.Errorf("vHTLC pubkey must be provided")
+	}
+	if ackSignature == nil {
+		return fmt.Errorf("acknowledgement signature must be provided")
 	}
 
 	_, err := g.client.AcknowledgeOutSwapHtlc(
@@ -121,7 +126,9 @@ func (g *GRPCSwapServerConn) AcknowledgeOutSwapHTLC(ctx context.Context,
 			PaymentHash: append(
 				[]byte(nil), paymentHash[:]...,
 			),
-			ClientVhtlcPubkey: vhtlcPubkey.SerializeCompressed(),
+			ClientVhtlcPubkey: vhtlcPubkey.
+				SerializeCompressed(),
+			AcknowledgementSignature: ackSignature.Serialize(),
 		},
 	)
 	if err != nil {

--- a/sdk/swaps/grpc_conn_test.go
+++ b/sdk/swaps/grpc_conn_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/lightninglabs/wavelength/swaprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
@@ -196,10 +197,12 @@ func TestAcknowledgeOutSwapHTLCPreservesStatusCode(t *testing.T) {
 
 	pubkey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
+	ackSig, err := schnorr.Sign(pubkey, make([]byte, 32))
+	require.NoError(t, err)
 
 	hash := lntypes.Hash{1, 2, 3}
 	err = conn.AcknowledgeOutSwapHTLC(
-		context.Background(), hash, pubkey.PubKey(),
+		context.Background(), hash, pubkey.PubKey(), ackSig,
 	)
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
@@ -207,6 +210,10 @@ func TestAcknowledgeOutSwapHTLCPreservesStatusCode(t *testing.T) {
 	require.Equal(
 		t, pubkey.PubKey().SerializeCompressed(),
 		client.lastAckReq.GetClientVhtlcPubkey(),
+	)
+	require.Equal(
+		t, ackSig.Serialize(),
+		client.lastAckReq.GetAcknowledgementSignature(),
 	)
 }
 
@@ -221,9 +228,28 @@ func TestAcknowledgeOutSwapHTLCRejectsMissingPubkey(t *testing.T) {
 	}
 
 	err := conn.AcknowledgeOutSwapHTLC(
-		context.Background(), lntypes.Hash{}, nil,
+		context.Background(), lntypes.Hash{}, nil, nil,
 	)
 	require.ErrorContains(t, err, "vHTLC pubkey must be provided")
+	require.Nil(t, client.lastAckReq)
+}
+
+// TestAcknowledgeOutSwapHTLCRejectsMissingSignature verifies incomplete local
+// acknowledgement state is rejected before sending the request.
+func TestAcknowledgeOutSwapHTLCRejectsMissingSignature(t *testing.T) {
+	t.Parallel()
+
+	client := &testSwapServiceClient{}
+	conn := &GRPCSwapServerConn{
+		client: client,
+	}
+	pubkey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	err = conn.AcknowledgeOutSwapHTLC(
+		context.Background(), lntypes.Hash{}, pubkey.PubKey(), nil,
+	)
+	require.ErrorContains(t, err, "signature must be provided")
 	require.Nil(t, client.lastAckReq)
 }
 

--- a/sdk/swaps/in_swap_test.go
+++ b/sdk/swaps/in_swap_test.go
@@ -109,7 +109,7 @@ func (c *testInSwapServerConn) RequestChannelID(_ context.Context,
 
 // AcknowledgeOutSwapHTLC is unused in these tests.
 func (c *testInSwapServerConn) AcknowledgeOutSwapHTLC(context.Context,
-	lntypes.Hash, *btcec.PublicKey) error {
+	lntypes.Hash, *btcec.PublicKey, *schnorr.Signature) error {
 
 	return nil
 }

--- a/sdk/swaps/out_swap.go
+++ b/sdk/swaps/out_swap.go
@@ -1168,9 +1168,33 @@ func (s *ReceiveSession) acknowledgeOutSwapHTLC(ctx context.Context) error {
 	if s.clientPubKey == nil {
 		return fmt.Errorf("client vHTLC pubkey is not configured")
 	}
+	if s.client.daemon == nil {
+		return fmt.Errorf("client daemon connection is not configured")
+	}
+	if len(s.vhtlcPkScript) == 0 {
+		return fmt.Errorf("vHTLC pkScript is not configured")
+	}
+
+	amountSat := s.expectedVHTLCSat
+	if amountSat == 0 {
+		if s.amountSat <= 0 {
+			return fmt.Errorf("vHTLC amount is not configured")
+		}
+
+		amountSat = uint64(s.amountSat)
+	}
+	ackSignature, err := s.client.daemon.SignOutSwapHTLCAck(
+		ctx, s.PaymentHash, amountSat, s.vhtlcPkScript,
+	)
+	if err != nil {
+		return newRetryableActionError(
+			fmt.Errorf("sign out-swap HTLC acknowledgement: %w",
+				err),
+		)
+	}
 
 	if err := s.client.server.AcknowledgeOutSwapHTLC(
-		ctx, s.PaymentHash, s.clientPubKey,
+		ctx, s.PaymentHash, s.clientPubKey, ackSignature,
 	); err != nil {
 
 		err = fmt.Errorf("acknowledge out-swap HTLC: %w", err)

--- a/sdk/swaps/out_swap_test.go
+++ b/sdk/swaps/out_swap_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
+	"github.com/lightninglabs/wavelength/swaprpc"
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/lightningnetwork/lnd/invoices"
@@ -620,6 +621,92 @@ func TestReceiveSessionAcksServerForCreditAssistedOutSwap(t *testing.T) {
 			clientPriv.PubKey(),
 		),
 	)
+	require.NotNil(t, serverConn.lastServerAckSig)
+	require.Equal(t, 1, daemonConn.ackSignCalls)
+	require.Equal(t, hash, daemonConn.lastAckSignHash)
+	require.Equal(t, uint64(1_100), daemonConn.lastAckSignAmount)
+	require.Equal(t, session.vhtlcPkScript, daemonConn.lastAckSignScript)
+	require.Zero(t, session.pendingHTLCAckCursor)
+}
+
+// TestReceiveSessionAcksServerForCreditAssistedInArk verifies the
+// swap-server-funded in-ark leg does not take the direct p2p ACK bypass.
+func TestReceiveSessionAcksServerForCreditAssistedInArk(t *testing.T) {
+	t.Parallel()
+
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	operatorPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serverPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	preimage := lntypes.Preimage{0x0a, 0x0b, 0x0c}
+	hash := preimage.Hash()
+	serverConn := &testSwapServerConn{}
+	daemonConn := &testDaemonConn{}
+	client := NewSwapClient(serverConn, daemonConn, nil, nil)
+
+	cfg := VHTLCConfig{
+		RefundLocktime:                       144,
+		UnilateralClaimDelay:                 12,
+		UnilateralRefundDelay:                24,
+		UnilateralRefundWithoutReceiverDelay: 36,
+		SwapServerPubkey: serverPriv.PubKey().
+			SerializeCompressed(),
+	}
+
+	ackCalls := 0
+	client.outEvents = &testIncomingEventReceiver{
+		notification: &IncomingVHTLCNotification{
+			InArk: &InArkHtlcEvent{
+				PaymentHash:        hash,
+				AmountSat:          1_100,
+				RequestedAmountSat: 300,
+				AttachedCreditSat:  800,
+				SenderPubkey:       serverPriv.PubKey(),
+				VHTLCConfig:        cfg,
+			},
+			AckCursor: 25,
+			Ack: func(context.Context) error {
+				ackCalls++
+
+				return nil
+			},
+		},
+	}
+
+	session := &ReceiveSession{
+		client:            client,
+		amountSat:         300,
+		expectedVHTLCSat:  1_100,
+		attachedCreditSat: 800,
+		state:             ReceiveStateInvoiceCreated,
+		PaymentHash:       hash,
+		clientPubKey:      clientPriv.PubKey(),
+		operatorPubKey:    operatorPriv.PubKey(),
+	}
+
+	err = session.waitForHTLCEvent(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, ReceiveStateHTLCEventAccepted, session.State())
+	require.Equal(t, SettlementTypeInArk, session.settlementType)
+	require.Equal(t, 1, ackCalls)
+	require.Equal(t, 1, serverConn.serverAckCalls)
+	require.Equal(t, hash, serverConn.lastServerAckHash)
+	require.True(
+		t,
+		serverConn.lastServerAckPubkey.IsEqual(
+			clientPriv.PubKey(),
+		),
+	)
+	require.NotNil(t, serverConn.lastServerAckSig)
+	require.Equal(t, 1, daemonConn.ackSignCalls)
+	require.Equal(t, hash, daemonConn.lastAckSignHash)
+	require.Equal(t, uint64(1_100), daemonConn.lastAckSignAmount)
+	require.Equal(t, session.vhtlcPkScript, daemonConn.lastAckSignScript)
 	require.Zero(t, session.pendingHTLCAckCursor)
 }
 
@@ -902,6 +989,7 @@ type testSwapServerConn struct {
 	lastAmountSat       btcutil.Amount
 	lastServerAckHash   lntypes.Hash
 	lastServerAckPubkey *btcec.PublicKey
+	lastServerAckSig    *schnorr.Signature
 
 	lastSupportsInArkCredit bool
 
@@ -1028,11 +1116,13 @@ func (c *testSwapServerConn) AckOutSwapHtlc(_ context.Context, _ lntypes.Hash,
 
 // AcknowledgeOutSwapHTLC records the server-side durable acceptance ACK.
 func (c *testSwapServerConn) AcknowledgeOutSwapHTLC(_ context.Context,
-	paymentHash lntypes.Hash, vhtlcPubkey *btcec.PublicKey) error {
+	paymentHash lntypes.Hash, vhtlcPubkey *btcec.PublicKey,
+	ackSignature *schnorr.Signature) error {
 
 	c.serverAckCalls++
 	c.lastServerAckHash = paymentHash
 	c.lastServerAckPubkey = vhtlcPubkey
+	c.lastServerAckSig = ackSignature
 	if len(c.serverAckErrs) > 0 {
 		err := c.serverAckErrs[0]
 		c.serverAckErrs = c.serverAckErrs[1:]
@@ -1733,6 +1823,11 @@ type testDaemonConn struct {
 	signForfeitErr    error
 	signForfeitCalls  int
 	lastSignForfeit   *waverpc.SignVTXOForfeitRequest
+	ackSignErr        error
+	ackSignCalls      int
+	lastAckSignHash   lntypes.Hash
+	lastAckSignAmount uint64
+	lastAckSignScript []byte
 }
 
 // BlockHeight returns the configured best block height.
@@ -1992,6 +2087,28 @@ func (d *testDaemonConn) IdentityPubKey(context.Context) (*btcec.PublicKey,
 	error) {
 
 	return d.identityKey, nil
+}
+
+// SignOutSwapHTLCAck signs accepted terms with a deterministic test key.
+func (d *testDaemonConn) SignOutSwapHTLCAck(_ context.Context,
+	paymentHash lntypes.Hash, amountSat uint64, vhtlcPkScript []byte) (
+	*schnorr.Signature, error) {
+
+	d.ackSignCalls++
+	d.lastAckSignHash = paymentHash
+	d.lastAckSignAmount = amountSat
+	d.lastAckSignScript = bytes.Clone(vhtlcPkScript)
+	if d.ackSignErr != nil {
+		return nil, d.ackSignErr
+	}
+
+	keyBytes := sha256.Sum256([]byte("test out-swap ack identity"))
+	privKey, _ := btcec.PrivKeyFromBytes(keyBytes[:])
+	digest := swaprpc.OutSwapHTLCAckDigest(
+		privKey.PubKey(), paymentHash, amountSat, vhtlcPkScript,
+	)
+
+	return schnorr.Sign(privKey, digest[:])
 }
 
 // OperatorPubKey returns the configured operator key.
@@ -2675,6 +2792,10 @@ func TestReceiveSessionResumesAfterAckedHTLCEvent(t *testing.T) {
 	require.True(
 		t, session.clientPubKey.IsEqual(serverConn.lastServerAckPubkey),
 	)
+	require.NotNil(t, serverConn.lastServerAckSig)
+	require.Equal(t, 1, daemonConn.ackSignCalls)
+	require.Equal(t, uint64(42_000), daemonConn.lastAckSignAmount)
+	require.Equal(t, session.vhtlcPkScript, daemonConn.lastAckSignScript)
 	require.Zero(t, session.pendingHTLCAckCursor)
 
 	resumeServer := &testSwapServerConn{

--- a/swaprpc/out_swap_ack.go
+++ b/swaprpc/out_swap_ack.go
@@ -1,0 +1,50 @@
+package swaprpc
+
+import (
+	"encoding/binary"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightningnetwork/lnd/lntypes"
+)
+
+const (
+	// OutSwapHTLCAckTag is the BIP-340 domain separator for receiver
+	// acknowledgements of accepted out-swap vHTLC terms. The committed
+	// vHTLC P2TR script binds the swap sender and Ark operator keys through
+	// the vHTLC policy, preventing reuse across servers with different
+	// keys.
+	OutSwapHTLCAckTag = "out-swap-htlc-ack-v1"
+)
+
+// OutSwapHTLCAckMessage returns the canonical message committed to by an
+// out-swap vHTLC acknowledgement signature.
+func OutSwapHTLCAckMessage(receiverKey *btcec.PublicKey,
+	paymentHash lntypes.Hash, amountSat uint64,
+	vhtlcPkScript []byte) []byte {
+
+	keyBytes := receiverKey.SerializeCompressed()
+	msg := make(
+		[]byte, 0, len(keyBytes)+len(paymentHash)+8+len(vhtlcPkScript),
+	)
+	msg = append(msg, keyBytes...)
+	msg = append(msg, paymentHash[:]...)
+	msg = binary.BigEndian.AppendUint64(msg, amountSat)
+	msg = append(msg, vhtlcPkScript...)
+
+	return msg
+}
+
+// OutSwapHTLCAckDigest returns the tagged digest for an out-swap vHTLC
+// acknowledgement signature.
+func OutSwapHTLCAckDigest(receiverKey *btcec.PublicKey,
+	paymentHash lntypes.Hash, amountSat uint64,
+	vhtlcPkScript []byte) [32]byte {
+
+	msg := OutSwapHTLCAckMessage(
+		receiverKey, paymentHash, amountSat, vhtlcPkScript,
+	)
+	hash := chainhash.TaggedHash([]byte(OutSwapHTLCAckTag), msg)
+
+	return *hash
+}

--- a/swaprpc/out_swap_ack_test.go
+++ b/swaprpc/out_swap_ack_test.go
@@ -1,0 +1,103 @@
+package swaprpc
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOutSwapHTLCAckDigestBindsTerms verifies every accepted vHTLC term is
+// committed by the acknowledgement digest.
+func TestOutSwapHTLCAckDigestBindsTerms(t *testing.T) {
+	t.Parallel()
+
+	receiverKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	otherKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	paymentHash := lntypes.Hash{1, 2, 3}
+	amountSat := uint64(42_000)
+	pkScript := []byte{0x51, 0x20, 0x01}
+	digest := OutSwapHTLCAckDigest(
+		receiverKey.PubKey(), paymentHash, amountSat, pkScript,
+	)
+
+	tests := []struct {
+		name        string
+		receiverKey *btcec.PublicKey
+		paymentHash lntypes.Hash
+		amountSat   uint64
+		pkScript    []byte
+	}{
+		{
+			name:        "receiver key",
+			receiverKey: otherKey.PubKey(),
+			paymentHash: paymentHash,
+			amountSat:   amountSat,
+			pkScript:    pkScript,
+		},
+		{
+			name:        "payment hash",
+			receiverKey: receiverKey.PubKey(),
+			paymentHash: lntypes.Hash{
+				4,
+				5,
+				6,
+			},
+			amountSat: amountSat,
+			pkScript:  pkScript,
+		},
+		{
+			name:        "amount",
+			receiverKey: receiverKey.PubKey(),
+			paymentHash: paymentHash,
+			amountSat:   amountSat + 1,
+			pkScript:    pkScript,
+		},
+		{
+			name:        "pkScript",
+			receiverKey: receiverKey.PubKey(),
+			paymentHash: paymentHash,
+			amountSat:   amountSat,
+			pkScript: []byte{
+				0x51,
+				0x20,
+				0x02,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			mutated := OutSwapHTLCAckDigest(
+				test.receiverKey, test.paymentHash,
+				test.amountSat, test.pkScript,
+			)
+			require.NotEqual(t, digest, mutated)
+		})
+	}
+}
+
+// TestOutSwapHTLCAckDigestSignature verifies the canonical digest can be
+// signed and verified with the receiver identity key.
+func TestOutSwapHTLCAckDigestSignature(t *testing.T) {
+	t.Parallel()
+
+	receiverKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	digest := OutSwapHTLCAckDigest(
+		receiverKey.PubKey(), lntypes.Hash{1}, 42_000,
+		[]byte{0x51, 0x20, 0x01},
+	)
+	sig, err := schnorr.Sign(receiverKey, digest[:])
+	require.NoError(t, err)
+	require.True(t, sig.Verify(digest[:], receiverKey.PubKey()))
+}

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -492,8 +492,11 @@ type AcknowledgeOutSwapHtlcRequest struct {
 	// registered. The server checks it against the persisted out-swap before
 	// treating the acknowledgement as valid.
 	ClientVhtlcPubkey []byte `protobuf:"bytes,2,opt,name=client_vhtlc_pubkey,json=clientVhtlcPubkey,proto3" json:"client_vhtlc_pubkey,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// acknowledgement_signature is the receiver's BIP-340 signature over
+	// the accepted vHTLC terms.
+	AcknowledgementSignature []byte `protobuf:"bytes,3,opt,name=acknowledgement_signature,json=acknowledgementSignature,proto3" json:"acknowledgement_signature,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *AcknowledgeOutSwapHtlcRequest) Reset() {
@@ -536,6 +539,13 @@ func (x *AcknowledgeOutSwapHtlcRequest) GetPaymentHash() []byte {
 func (x *AcknowledgeOutSwapHtlcRequest) GetClientVhtlcPubkey() []byte {
 	if x != nil {
 		return x.ClientVhtlcPubkey
+	}
+	return nil
+}
+
+func (x *AcknowledgeOutSwapHtlcRequest) GetAcknowledgementSignature() []byte {
+	if x != nil {
+		return x.AcknowledgementSignature
 	}
 	return nil
 }
@@ -2996,10 +3006,11 @@ const file_swap_proto_rawDesc = "" +
 	"\x10vhtlc_amount_sat\x18\x06 \x01(\x04R\x0evhtlcAmountSat\x12$\n" +
 	"\x0edust_limit_sat\x18\a \x01(\x04R\fdustLimitSat\x12@\n" +
 	"\x0fsettlement_type\x18\b \x01(\x0e2\x17.swaprpc.SettlementTypeR\x0esettlementType\x12@\n" +
-	"\x10route_hint_paths\x18\t \x03(\v2\x16.swaprpc.RouteHintPathR\x0erouteHintPathsJ\x04\b\x01\x10\x02R\x0froute_hint_path\"r\n" +
+	"\x10route_hint_paths\x18\t \x03(\v2\x16.swaprpc.RouteHintPathR\x0erouteHintPathsJ\x04\b\x01\x10\x02R\x0froute_hint_path\"\xaf\x01\n" +
 	"\x1dAcknowledgeOutSwapHtlcRequest\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12.\n" +
-	"\x13client_vhtlc_pubkey\x18\x02 \x01(\fR\x11clientVhtlcPubkey\" \n" +
+	"\x13client_vhtlc_pubkey\x18\x02 \x01(\fR\x11clientVhtlcPubkey\x12;\n" +
+	"\x19acknowledgement_signature\x18\x03 \x01(\fR\x18acknowledgementSignature\" \n" +
 	"\x1eAcknowledgeOutSwapHtlcResponse\"\xbe\x02\n" +
 	"\x10OutSwapHtlcEvent\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x1d\n" +

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -194,6 +194,10 @@ message AcknowledgeOutSwapHtlcRequest {
     // registered. The server checks it against the persisted out-swap before
     // treating the acknowledgement as valid.
     bytes client_vhtlc_pubkey = 2;
+
+    // acknowledgement_signature is the receiver's BIP-340 signature over
+    // the accepted vHTLC terms.
+    bytes acknowledgement_signature = 3;
 }
 
 // AcknowledgeOutSwapHtlcResponse is empty on success.

--- a/waved/rpc_auth.go
+++ b/waved/rpc_auth.go
@@ -116,6 +116,7 @@ func newWavedRPCPermissions() map[string][]bakery.Op {
 		"NewReceiveScript", "ReceiveAuthKey", "SignReceiveAuthMessage",
 		"SignReceiveAuthMessageCompact", "ReceiveAuthECDH",
 	)
+	grant(daemon, entitySwap, "write", "SignOutSwapHtlcAck")
 	grant(
 		daemon, entityOOR, "read", "GetIndexedOORSessionByTxid",
 		"ListOORSessions", "GetOORSession",

--- a/waved/rpc_auth_test.go
+++ b/waved/rpc_auth_test.go
@@ -52,6 +52,7 @@ func TestWavedRPCPermissionsMapsMutatingMethods(t *testing.T) {
 		waverpc.DaemonService_ReceiveAuthKey_FullMethodName,
 		waverpc.DaemonService_RefreshVTXOs_FullMethodName,
 		waverpc.DaemonService_SignReceiveAuthMessage_FullMethodName,
+		waverpc.DaemonService_SignOutSwapHtlcAck_FullMethodName,
 		fullDaemonMethod("SubmitForfeitParticipantSignatures"),
 	} {
 		ops, ok := wavedRPCPermissions[fullMethod]

--- a/waved/rpc_wallet.go
+++ b/waved/rpc_wallet.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/wavelength/btcwbackend"
 	"github.com/lightninglabs/wavelength/lwwallet"
+	"github.com/lightninglabs/wavelength/swaprpc"
 	"github.com/lightninglabs/wavelength/walletcore"
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -104,6 +105,56 @@ func (r *RPCServer) ReceiveAuthECDH(ctx context.Context,
 
 	return &waverpc.ReceiveAuthECDHResponse{
 		SharedSecret: sharedSecret[:],
+	}, nil
+}
+
+// SignOutSwapHtlcAck signs accepted out-swap vHTLC terms with the daemon
+// identity key.
+func (r *RPCServer) SignOutSwapHtlcAck(ctx context.Context,
+	req *waverpc.SignOutSwapHtlcAckRequest) (
+	*waverpc.SignOutSwapHtlcAckResponse, error) {
+
+	if len(req.GetPaymentHash()) != lntypes.HashSize {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"payment_hash must be %d bytes", lntypes.HashSize)
+	}
+	if req.GetAmountSat() == 0 {
+		return nil, status.Error(
+			codes.InvalidArgument, "amount_sat must be positive",
+		)
+	}
+	if len(req.GetVhtlcPkScript()) == 0 {
+		return nil, status.Error(
+			codes.InvalidArgument,
+			"vhtlc_pk_script must be provided",
+		)
+	}
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+	if r.server.clientKeyDesc.PubKey == nil {
+		return nil, status.Error(
+			codes.FailedPrecondition, "identity key is not ready",
+		)
+	}
+
+	var paymentHash lntypes.Hash
+	copy(paymentHash[:], req.GetPaymentHash())
+	msg := swaprpc.OutSwapHTLCAckMessage(
+		r.server.clientKeyDesc.PubKey, paymentHash, req.GetAmountSat(),
+		req.GetVhtlcPkScript(),
+	)
+	sig, err := r.server.signTaggedSchnorr(
+		ctx, msg, []byte(swaprpc.OutSwapHTLCAckTag),
+		"out-swap HTLC acknowledgement",
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "sign out-swap HTLC "+
+			"acknowledgement: %v", err)
+	}
+
+	return &waverpc.SignOutSwapHtlcAckResponse{
+		Signature: sig.Serialize(),
 	}, nil
 }
 

--- a/waved/rpc_wallet_test.go
+++ b/waved/rpc_wallet_test.go
@@ -1,6 +1,7 @@
 package waved
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,12 +10,117 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/lwwallet"
+	"github.com/lightninglabs/wavelength/swaprpc"
+	"github.com/lightninglabs/wavelength/waverpc"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// TestSignOutSwapHtlcAckValidatesTerms verifies malformed acknowledgement
+// terms are rejected before wallet signing is attempted.
+func TestSignOutSwapHtlcAckValidatesTerms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		req  *waverpc.SignOutSwapHtlcAckRequest
+	}{
+		{
+			name: "payment hash",
+			req: &waverpc.SignOutSwapHtlcAckRequest{
+				AmountSat: 42_000,
+				VhtlcPkScript: []byte{
+					0x51,
+				},
+			},
+		},
+		{
+			name: "amount",
+			req: &waverpc.SignOutSwapHtlcAckRequest{
+				PaymentHash: make([]byte, 32),
+				VhtlcPkScript: []byte{
+					0x51,
+				},
+			},
+		},
+		{
+			name: "pkScript",
+			req: &waverpc.SignOutSwapHtlcAckRequest{
+				PaymentHash: make([]byte, 32),
+				AmountSat:   42_000,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := &RPCServer{}
+			_, err := server.SignOutSwapHtlcAck(
+				context.Background(), test.req,
+			)
+			require.Equal(
+				t, codes.InvalidArgument, status.Code(err),
+			)
+		})
+	}
+}
+
+// TestSignOutSwapHtlcAckSignsTerms verifies the daemon signs the canonical
+// acknowledgement digest with its wallet identity key.
+func TestSignOutSwapHtlcAckSignsTerms(t *testing.T) {
+	t.Parallel()
+
+	wallet := newFundedLwWallet(t)
+	keyLocator := keychain.KeyLocator{
+		Family: keychain.KeyFamilyNodeKey,
+		Index:  0,
+	}
+	keyDesc, err := wallet.KeyRing().DeriveKey(keyLocator)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToTaprootScript(keyDesc.PubKey)
+	require.NoError(t, err)
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+	rpcServer := &RPCServer{
+		server: &Server{
+			walletReady:   walletReady,
+			clientKeyDesc: keyDesc,
+			lwWallet:      fn.Some(wallet),
+		},
+	}
+
+	paymentHash := lntypes.Hash{0x01, 0x02, 0x03}
+	const amountSat = uint64(42_000)
+	resp, err := rpcServer.SignOutSwapHtlcAck(
+		t.Context(), &waverpc.SignOutSwapHtlcAckRequest{
+			PaymentHash:   paymentHash[:],
+			AmountSat:     amountSat,
+			VhtlcPkScript: pkScript,
+		},
+	)
+	require.NoError(t, err)
+
+	sig, err := schnorr.ParseSignature(resp.GetSignature())
+	require.NoError(t, err)
+	digest := swaprpc.OutSwapHTLCAckDigest(
+		keyDesc.PubKey, paymentHash, amountSat, pkScript,
+	)
+	require.True(t, sig.Verify(digest[:], keyDesc.PubKey))
+}
 
 // TestWrongPassphraseErrorMapping pins the wrong-password
 // classification that UnlockWallet relies on to return

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -10186,6 +10186,114 @@ func (x *VHTLCRecoveryStatus) GetUnilateralRefundWithoutReceiverDelay() int32 {
 	return 0
 }
 
+type SignOutSwapHtlcAckRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// payment_hash is the 32-byte Lightning payment hash.
+	PaymentHash []byte `protobuf:"bytes,1,opt,name=payment_hash,json=paymentHash,proto3" json:"payment_hash,omitempty"`
+	// amount_sat is the accepted vHTLC output amount.
+	AmountSat uint64 `protobuf:"varint,2,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
+	// vhtlc_pk_script is the accepted vHTLC output script.
+	VhtlcPkScript []byte `protobuf:"bytes,3,opt,name=vhtlc_pk_script,json=vhtlcPkScript,proto3" json:"vhtlc_pk_script,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignOutSwapHtlcAckRequest) Reset() {
+	*x = SignOutSwapHtlcAckRequest{}
+	mi := &file_daemon_proto_msgTypes[119]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignOutSwapHtlcAckRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignOutSwapHtlcAckRequest) ProtoMessage() {}
+
+func (x *SignOutSwapHtlcAckRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[119]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignOutSwapHtlcAckRequest.ProtoReflect.Descriptor instead.
+func (*SignOutSwapHtlcAckRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{119}
+}
+
+func (x *SignOutSwapHtlcAckRequest) GetPaymentHash() []byte {
+	if x != nil {
+		return x.PaymentHash
+	}
+	return nil
+}
+
+func (x *SignOutSwapHtlcAckRequest) GetAmountSat() uint64 {
+	if x != nil {
+		return x.AmountSat
+	}
+	return 0
+}
+
+func (x *SignOutSwapHtlcAckRequest) GetVhtlcPkScript() []byte {
+	if x != nil {
+		return x.VhtlcPkScript
+	}
+	return nil
+}
+
+type SignOutSwapHtlcAckResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// signature is the 64-byte BIP-340 Schnorr signature.
+	Signature     []byte `protobuf:"bytes,1,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignOutSwapHtlcAckResponse) Reset() {
+	*x = SignOutSwapHtlcAckResponse{}
+	mi := &file_daemon_proto_msgTypes[120]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignOutSwapHtlcAckResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignOutSwapHtlcAckResponse) ProtoMessage() {}
+
+func (x *SignOutSwapHtlcAckResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[120]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignOutSwapHtlcAckResponse.ProtoReflect.Descriptor instead.
+func (*SignOutSwapHtlcAckResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{120}
+}
+
+func (x *SignOutSwapHtlcAckResponse) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
 var File_daemon_proto protoreflect.FileDescriptor
 
 const file_daemon_proto_rawDesc = "" +
@@ -10884,7 +10992,14 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0frefund_locktime\x18\x16 \x01(\x05R\x0erefundLocktime\x124\n" +
 	"\x16unilateral_claim_delay\x18\x17 \x01(\x05R\x14unilateralClaimDelay\x126\n" +
 	"\x17unilateral_refund_delay\x18\x18 \x01(\x05R\x15unilateralRefundDelay\x12V\n" +
-	"(unilateral_refund_without_receiver_delay\x18\x19 \x01(\x05R$unilateralRefundWithoutReceiverDelay*\x8d\x01\n" +
+	"(unilateral_refund_without_receiver_delay\x18\x19 \x01(\x05R$unilateralRefundWithoutReceiverDelay\"\x85\x01\n" +
+	"\x19SignOutSwapHtlcAckRequest\x12!\n" +
+	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x1d\n" +
+	"\n" +
+	"amount_sat\x18\x02 \x01(\x04R\tamountSat\x12&\n" +
+	"\x0fvhtlc_pk_script\x18\x03 \x01(\fR\rvhtlcPkScript\":\n" +
+	"\x1aSignOutSwapHtlcAckResponse\x12\x1c\n" +
+	"\tsignature\x18\x01 \x01(\fR\tsignature*\x8d\x01\n" +
 	"\vWalletState\x12\x1c\n" +
 	"\x18WALLET_STATE_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11WALLET_STATE_NONE\x10\x01\x12\x17\n" +
@@ -10974,7 +11089,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1eVHTLC_RECOVERY_STATE_COMPLETED\x10\t\x12\"\n" +
 	"\x1eVHTLC_RECOVERY_STATE_CANCELLED\x10\n" +
 	"\x12\x1f\n" +
-	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\xd2\x1e\n" +
+	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\xb1\x1f\n" +
 	"\rDaemonService\x12<\n" +
 	"\aGetInfo\x12\x17.waverpc.GetInfoRequest\x1a\x18.waverpc.GetInfoResponse\x12<\n" +
 	"\aGenSeed\x12\x17.waverpc.GenSeedRequest\x1a\x18.waverpc.GenSeedResponse\x12E\n" +
@@ -11026,7 +11141,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\x15EscalateVHTLCRecovery\x12%.waverpc.EscalateVHTLCRecoveryRequest\x1a&.waverpc.EscalateVHTLCRecoveryResponse\x12`\n" +
 	"\x13CancelVHTLCRecovery\x12#.waverpc.CancelVHTLCRecoveryRequest\x1a$.waverpc.CancelVHTLCRecoveryResponse\x12i\n" +
 	"\x16GetVHTLCRecoveryStatus\x12&.waverpc.GetVHTLCRecoveryStatusRequest\x1a'.waverpc.GetVHTLCRecoveryStatusResponse\x12`\n" +
-	"\x13ListVHTLCRecoveries\x12#.waverpc.ListVHTLCRecoveriesRequest\x1a$.waverpc.ListVHTLCRecoveriesResponseB-Z+github.com/lightninglabs/wavelength/waverpcb\x06proto3"
+	"\x13ListVHTLCRecoveries\x12#.waverpc.ListVHTLCRecoveriesRequest\x1a$.waverpc.ListVHTLCRecoveriesResponse\x12]\n" +
+	"\x12SignOutSwapHtlcAck\x12\".waverpc.SignOutSwapHtlcAckRequest\x1a#.waverpc.SignOutSwapHtlcAckResponseB-Z+github.com/lightninglabs/wavelength/waverpcb\x06proto3"
 
 var (
 	file_daemon_proto_rawDescOnce sync.Once
@@ -11041,7 +11157,7 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 120)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 122)
 var file_daemon_proto_goTypes = []any{
 	(WalletState)(0),                                               // 0: waverpc.WalletState
 	(VTXOStatus)(0),                                                // 1: waverpc.VTXOStatus
@@ -11173,7 +11289,9 @@ var file_daemon_proto_goTypes = []any{
 	(*ListVHTLCRecoveriesRequest)(nil),                             // 127: waverpc.ListVHTLCRecoveriesRequest
 	(*ListVHTLCRecoveriesResponse)(nil),                            // 128: waverpc.ListVHTLCRecoveriesResponse
 	(*VHTLCRecoveryStatus)(nil),                                    // 129: waverpc.VHTLCRecoveryStatus
-	nil,                                                            // 130: waverpc.LeaveVTXOsRequest.DestinationsEntry
+	(*SignOutSwapHtlcAckRequest)(nil),                              // 130: waverpc.SignOutSwapHtlcAckRequest
+	(*SignOutSwapHtlcAckResponse)(nil),                             // 131: waverpc.SignOutSwapHtlcAckResponse
+	nil,                                                            // 132: waverpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
 	0,   // 0: waverpc.GetInfoResponse.wallet_state:type_name -> waverpc.WalletState
@@ -11210,7 +11328,7 @@ var file_daemon_proto_depIdxs = []int32{
 	72,  // 31: waverpc.SubmitForfeitParticipantSignaturesRequest.signatures:type_name -> waverpc.ForfeitParticipantSignature
 	60,  // 32: waverpc.LeaveVTXOsRequest.outpoints:type_name -> waverpc.OutpointSelection
 	75,  // 33: waverpc.LeaveVTXOsRequest.default_destination:type_name -> waverpc.LeaveDestination
-	130, // 34: waverpc.LeaveVTXOsRequest.destinations:type_name -> waverpc.LeaveVTXOsRequest.DestinationsEntry
+	132, // 34: waverpc.LeaveVTXOsRequest.destinations:type_name -> waverpc.LeaveVTXOsRequest.DestinationsEntry
 	75,  // 35: waverpc.SendOnChainRequest.destination:type_name -> waverpc.LeaveDestination
 	85,  // 36: waverpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> waverpc.BoardingSweepOutput
 	88,  // 37: waverpc.BoardingSweep.inputs:type_name -> waverpc.BoardingSweepInput
@@ -11290,53 +11408,55 @@ var file_daemon_proto_depIdxs = []int32{
 	123, // 111: waverpc.DaemonService.CancelVHTLCRecovery:input_type -> waverpc.CancelVHTLCRecoveryRequest
 	125, // 112: waverpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> waverpc.GetVHTLCRecoveryStatusRequest
 	127, // 113: waverpc.DaemonService.ListVHTLCRecoveries:input_type -> waverpc.ListVHTLCRecoveriesRequest
-	12,  // 114: waverpc.DaemonService.GetInfo:output_type -> waverpc.GetInfoResponse
-	15,  // 115: waverpc.DaemonService.GenSeed:output_type -> waverpc.GenSeedResponse
-	17,  // 116: waverpc.DaemonService.InitWallet:output_type -> waverpc.InitWalletResponse
-	19,  // 117: waverpc.DaemonService.UnlockWallet:output_type -> waverpc.UnlockWalletResponse
-	21,  // 118: waverpc.DaemonService.GetBalance:output_type -> waverpc.GetBalanceResponse
-	26,  // 119: waverpc.DaemonService.ListVTXOs:output_type -> waverpc.ListVTXOsResponse
-	28,  // 120: waverpc.DaemonService.NewAddress:output_type -> waverpc.NewAddressResponse
-	30,  // 121: waverpc.DaemonService.NewReceiveScript:output_type -> waverpc.NewReceiveScriptResponse
-	32,  // 122: waverpc.DaemonService.ReceiveAuthKey:output_type -> waverpc.ReceiveAuthKeyResponse
-	34,  // 123: waverpc.DaemonService.SignReceiveAuthMessage:output_type -> waverpc.SignReceiveAuthMessageResponse
-	36,  // 124: waverpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> waverpc.SignReceiveAuthMessageCompactResponse
-	38,  // 125: waverpc.DaemonService.ReceiveAuthECDH:output_type -> waverpc.ReceiveAuthECDHResponse
-	40,  // 126: waverpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> waverpc.GetIndexedVTXOByPkScriptResponse
-	42,  // 127: waverpc.DaemonService.GetVTXOExpiryInfo:output_type -> waverpc.GetVTXOExpiryInfoResponse
-	44,  // 128: waverpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> waverpc.GetIndexedOORSessionByTxidResponse
-	47,  // 129: waverpc.DaemonService.SendVTXO:output_type -> waverpc.SendVTXOResponse
-	51,  // 130: waverpc.DaemonService.SendOOR:output_type -> waverpc.SendOORResponse
-	54,  // 131: waverpc.DaemonService.PrepareOOR:output_type -> waverpc.PrepareOORResponse
-	56,  // 132: waverpc.DaemonService.SignOORCustomInput:output_type -> waverpc.SignOORCustomInputResponse
-	58,  // 133: waverpc.DaemonService.SignVTXOForfeit:output_type -> waverpc.SignVTXOForfeitResponse
-	62,  // 134: waverpc.DaemonService.RefreshVTXOs:output_type -> waverpc.RefreshVTXOsResponse
-	68,  // 135: waverpc.DaemonService.RefreshCustomVTXOs:output_type -> waverpc.RefreshCustomVTXOsResponse
-	71,  // 136: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:output_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsResponse
-	74,  // 137: waverpc.DaemonService.SubmitForfeitParticipantSignatures:output_type -> waverpc.SubmitForfeitParticipantSignaturesResponse
-	77,  // 138: waverpc.DaemonService.LeaveVTXOs:output_type -> waverpc.LeaveVTXOsResponse
-	79,  // 139: waverpc.DaemonService.SendOnChain:output_type -> waverpc.SendOnChainResponse
-	81,  // 140: waverpc.DaemonService.Board:output_type -> waverpc.BoardResponse
-	83,  // 141: waverpc.DaemonService.JoinNextRound:output_type -> waverpc.JoinNextRoundResponse
-	86,  // 142: waverpc.DaemonService.SweepBoardingUTXOs:output_type -> waverpc.SweepBoardingUTXOsResponse
-	90,  // 143: waverpc.DaemonService.ListBoardingSweeps:output_type -> waverpc.ListBoardingSweepsResponse
-	96,  // 144: waverpc.DaemonService.ListRounds:output_type -> waverpc.ListRoundsResponse
-	95,  // 145: waverpc.DaemonService.GetRound:output_type -> waverpc.GetRoundResponse
-	98,  // 146: waverpc.DaemonService.WatchRounds:output_type -> waverpc.WatchRoundsResponse
-	101, // 147: waverpc.DaemonService.ListOORSessions:output_type -> waverpc.ListOORSessionsResponse
-	103, // 148: waverpc.DaemonService.GetOORSession:output_type -> waverpc.GetOORSessionResponse
-	105, // 149: waverpc.DaemonService.EstimateFee:output_type -> waverpc.EstimateFeeResponse
-	108, // 150: waverpc.DaemonService.GetFeeHistory:output_type -> waverpc.GetFeeHistoryResponse
-	111, // 151: waverpc.DaemonService.ListTransactions:output_type -> waverpc.ListTransactionsResponse
-	113, // 152: waverpc.DaemonService.Unroll:output_type -> waverpc.UnrollResponse
-	118, // 153: waverpc.DaemonService.GetUnrollStatus:output_type -> waverpc.GetUnrollStatusResponse
-	120, // 154: waverpc.DaemonService.ArmVHTLCRecovery:output_type -> waverpc.ArmVHTLCRecoveryResponse
-	122, // 155: waverpc.DaemonService.EscalateVHTLCRecovery:output_type -> waverpc.EscalateVHTLCRecoveryResponse
-	124, // 156: waverpc.DaemonService.CancelVHTLCRecovery:output_type -> waverpc.CancelVHTLCRecoveryResponse
-	126, // 157: waverpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> waverpc.GetVHTLCRecoveryStatusResponse
-	128, // 158: waverpc.DaemonService.ListVHTLCRecoveries:output_type -> waverpc.ListVHTLCRecoveriesResponse
-	114, // [114:159] is the sub-list for method output_type
-	69,  // [69:114] is the sub-list for method input_type
+	130, // 114: waverpc.DaemonService.SignOutSwapHtlcAck:input_type -> waverpc.SignOutSwapHtlcAckRequest
+	12,  // 115: waverpc.DaemonService.GetInfo:output_type -> waverpc.GetInfoResponse
+	15,  // 116: waverpc.DaemonService.GenSeed:output_type -> waverpc.GenSeedResponse
+	17,  // 117: waverpc.DaemonService.InitWallet:output_type -> waverpc.InitWalletResponse
+	19,  // 118: waverpc.DaemonService.UnlockWallet:output_type -> waverpc.UnlockWalletResponse
+	21,  // 119: waverpc.DaemonService.GetBalance:output_type -> waverpc.GetBalanceResponse
+	26,  // 120: waverpc.DaemonService.ListVTXOs:output_type -> waverpc.ListVTXOsResponse
+	28,  // 121: waverpc.DaemonService.NewAddress:output_type -> waverpc.NewAddressResponse
+	30,  // 122: waverpc.DaemonService.NewReceiveScript:output_type -> waverpc.NewReceiveScriptResponse
+	32,  // 123: waverpc.DaemonService.ReceiveAuthKey:output_type -> waverpc.ReceiveAuthKeyResponse
+	34,  // 124: waverpc.DaemonService.SignReceiveAuthMessage:output_type -> waverpc.SignReceiveAuthMessageResponse
+	36,  // 125: waverpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> waverpc.SignReceiveAuthMessageCompactResponse
+	38,  // 126: waverpc.DaemonService.ReceiveAuthECDH:output_type -> waverpc.ReceiveAuthECDHResponse
+	40,  // 127: waverpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> waverpc.GetIndexedVTXOByPkScriptResponse
+	42,  // 128: waverpc.DaemonService.GetVTXOExpiryInfo:output_type -> waverpc.GetVTXOExpiryInfoResponse
+	44,  // 129: waverpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> waverpc.GetIndexedOORSessionByTxidResponse
+	47,  // 130: waverpc.DaemonService.SendVTXO:output_type -> waverpc.SendVTXOResponse
+	51,  // 131: waverpc.DaemonService.SendOOR:output_type -> waverpc.SendOORResponse
+	54,  // 132: waverpc.DaemonService.PrepareOOR:output_type -> waverpc.PrepareOORResponse
+	56,  // 133: waverpc.DaemonService.SignOORCustomInput:output_type -> waverpc.SignOORCustomInputResponse
+	58,  // 134: waverpc.DaemonService.SignVTXOForfeit:output_type -> waverpc.SignVTXOForfeitResponse
+	62,  // 135: waverpc.DaemonService.RefreshVTXOs:output_type -> waverpc.RefreshVTXOsResponse
+	68,  // 136: waverpc.DaemonService.RefreshCustomVTXOs:output_type -> waverpc.RefreshCustomVTXOsResponse
+	71,  // 137: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:output_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsResponse
+	74,  // 138: waverpc.DaemonService.SubmitForfeitParticipantSignatures:output_type -> waverpc.SubmitForfeitParticipantSignaturesResponse
+	77,  // 139: waverpc.DaemonService.LeaveVTXOs:output_type -> waverpc.LeaveVTXOsResponse
+	79,  // 140: waverpc.DaemonService.SendOnChain:output_type -> waverpc.SendOnChainResponse
+	81,  // 141: waverpc.DaemonService.Board:output_type -> waverpc.BoardResponse
+	83,  // 142: waverpc.DaemonService.JoinNextRound:output_type -> waverpc.JoinNextRoundResponse
+	86,  // 143: waverpc.DaemonService.SweepBoardingUTXOs:output_type -> waverpc.SweepBoardingUTXOsResponse
+	90,  // 144: waverpc.DaemonService.ListBoardingSweeps:output_type -> waverpc.ListBoardingSweepsResponse
+	96,  // 145: waverpc.DaemonService.ListRounds:output_type -> waverpc.ListRoundsResponse
+	95,  // 146: waverpc.DaemonService.GetRound:output_type -> waverpc.GetRoundResponse
+	98,  // 147: waverpc.DaemonService.WatchRounds:output_type -> waverpc.WatchRoundsResponse
+	101, // 148: waverpc.DaemonService.ListOORSessions:output_type -> waverpc.ListOORSessionsResponse
+	103, // 149: waverpc.DaemonService.GetOORSession:output_type -> waverpc.GetOORSessionResponse
+	105, // 150: waverpc.DaemonService.EstimateFee:output_type -> waverpc.EstimateFeeResponse
+	108, // 151: waverpc.DaemonService.GetFeeHistory:output_type -> waverpc.GetFeeHistoryResponse
+	111, // 152: waverpc.DaemonService.ListTransactions:output_type -> waverpc.ListTransactionsResponse
+	113, // 153: waverpc.DaemonService.Unroll:output_type -> waverpc.UnrollResponse
+	118, // 154: waverpc.DaemonService.GetUnrollStatus:output_type -> waverpc.GetUnrollStatusResponse
+	120, // 155: waverpc.DaemonService.ArmVHTLCRecovery:output_type -> waverpc.ArmVHTLCRecoveryResponse
+	122, // 156: waverpc.DaemonService.EscalateVHTLCRecovery:output_type -> waverpc.EscalateVHTLCRecoveryResponse
+	124, // 157: waverpc.DaemonService.CancelVHTLCRecovery:output_type -> waverpc.CancelVHTLCRecoveryResponse
+	126, // 158: waverpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> waverpc.GetVHTLCRecoveryStatusResponse
+	128, // 159: waverpc.DaemonService.ListVHTLCRecoveries:output_type -> waverpc.ListVHTLCRecoveriesResponse
+	131, // 160: waverpc.DaemonService.SignOutSwapHtlcAck:output_type -> waverpc.SignOutSwapHtlcAckResponse
+	115, // [115:161] is the sub-list for method output_type
+	69,  // [69:115] is the sub-list for method input_type
 	69,  // [69:69] is the sub-list for extension type_name
 	69,  // [69:69] is the sub-list for extension extendee
 	0,   // [0:69] is the sub-list for field type_name
@@ -11379,7 +11499,7 @@ func file_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      11,
-			NumMessages:   120,
+			NumMessages:   122,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/waverpc/daemon.pb.gw.go
+++ b/waverpc/daemon.pb.gw.go
@@ -1246,6 +1246,33 @@ func local_request_DaemonService_ListVHTLCRecoveries_0(ctx context.Context, mars
 	return msg, metadata, err
 }
 
+func request_DaemonService_SignOutSwapHtlcAck_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SignOutSwapHtlcAckRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.SignOutSwapHtlcAck(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_DaemonService_SignOutSwapHtlcAck_0(ctx context.Context, marshaler runtime.Marshaler, server DaemonServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SignOutSwapHtlcAckRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.SignOutSwapHtlcAck(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterDaemonServiceHandlerServer registers the http handlers for service DaemonService to "mux".
 // UnaryRPC     :call DaemonServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -2139,6 +2166,26 @@ func RegisterDaemonServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_ListVHTLCRecoveries_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_SignOutSwapHtlcAck_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/waverpc.DaemonService/SignOutSwapHtlcAck", runtime.WithHTTPPathPattern("/v1/daemon/sign-out-swap-htlc-ack"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_DaemonService_SignOutSwapHtlcAck_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_SignOutSwapHtlcAck_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	return nil
 }
@@ -2944,6 +2991,23 @@ func RegisterDaemonServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_ListVHTLCRecoveries_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_SignOutSwapHtlcAck_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/waverpc.DaemonService/SignOutSwapHtlcAck", runtime.WithHTTPPathPattern("/v1/daemon/sign-out-swap-htlc-ack"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_DaemonService_SignOutSwapHtlcAck_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_SignOutSwapHtlcAck_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -2993,6 +3057,7 @@ var (
 	pattern_DaemonService_CancelVHTLCRecovery_0                            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "cancel-vhtlc-recovery"}, ""))
 	pattern_DaemonService_GetVHTLCRecoveryStatus_0                         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "get-vhtlc-recovery-status"}, ""))
 	pattern_DaemonService_ListVHTLCRecoveries_0                            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "list-vhtlc-recoveries"}, ""))
+	pattern_DaemonService_SignOutSwapHtlcAck_0                             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "sign-out-swap-htlc-ack"}, ""))
 )
 
 var (
@@ -3041,4 +3106,5 @@ var (
 	forward_DaemonService_CancelVHTLCRecovery_0                            = runtime.ForwardResponseMessage
 	forward_DaemonService_GetVHTLCRecoveryStatus_0                         = runtime.ForwardResponseMessage
 	forward_DaemonService_ListVHTLCRecoveries_0                            = runtime.ForwardResponseMessage
+	forward_DaemonService_SignOutSwapHtlcAck_0                             = runtime.ForwardResponseMessage
 )

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -261,6 +261,11 @@ service DaemonService {
     // EscalateVHTLCRecovery to start costly on-chain recovery.
     rpc ListVHTLCRecoveries (ListVHTLCRecoveriesRequest)
         returns (ListVHTLCRecoveriesResponse);
+
+    // SignOutSwapHtlcAck signs the accepted terms of an out-swap vHTLC with
+    // the daemon identity key.
+    rpc SignOutSwapHtlcAck (SignOutSwapHtlcAckRequest)
+        returns (SignOutSwapHtlcAckResponse);
 }
 
 // WalletState mirrors the daemon's in-process wallet lifecycle enum:
@@ -2818,4 +2823,20 @@ message VHTLCRecoveryStatus {
     // unilateral_refund_without_receiver_delay is the Ark CSV delay for the
     // unilateral refund leaf recorded on the recovery row.
     int32 unilateral_refund_without_receiver_delay = 25;
+}
+
+message SignOutSwapHtlcAckRequest {
+    // payment_hash is the 32-byte Lightning payment hash.
+    bytes payment_hash = 1;
+
+    // amount_sat is the accepted vHTLC output amount.
+    uint64 amount_sat = 2;
+
+    // vhtlc_pk_script is the accepted vHTLC output script.
+    bytes vhtlc_pk_script = 3;
+}
+
+message SignOutSwapHtlcAckResponse {
+    // signature is the 64-byte BIP-340 Schnorr signature.
+    bytes signature = 1;
 }

--- a/waverpc/daemon.yaml
+++ b/waverpc/daemon.yaml
@@ -39,6 +39,9 @@ http:
     - selector: waverpc.DaemonService.ReceiveAuthECDH
       post: /v1/daemon/receive-auth-ecdh
       body: "*"
+    - selector: waverpc.DaemonService.SignOutSwapHtlcAck
+      post: /v1/daemon/sign-out-swap-htlc-ack
+      body: "*"
     - selector: waverpc.DaemonService.GetIndexedVTXOByPkScript
       post: /v1/daemon/get-indexed-vtxo-by-pk-script
       body: "*"

--- a/waverpc/daemon_grpc.pb.go
+++ b/waverpc/daemon_grpc.pb.go
@@ -64,6 +64,7 @@ const (
 	DaemonService_CancelVHTLCRecovery_FullMethodName                            = "/waverpc.DaemonService/CancelVHTLCRecovery"
 	DaemonService_GetVHTLCRecoveryStatus_FullMethodName                         = "/waverpc.DaemonService/GetVHTLCRecoveryStatus"
 	DaemonService_ListVHTLCRecoveries_FullMethodName                            = "/waverpc.DaemonService/ListVHTLCRecoveries"
+	DaemonService_SignOutSwapHtlcAck_FullMethodName                             = "/waverpc.DaemonService/SignOutSwapHtlcAck"
 )
 
 // DaemonServiceClient is the client API for DaemonService service.
@@ -259,6 +260,9 @@ type DaemonServiceClient interface {
 	// inspection. Armed rows are dormant; callers must use
 	// EscalateVHTLCRecovery to start costly on-chain recovery.
 	ListVHTLCRecoveries(ctx context.Context, in *ListVHTLCRecoveriesRequest, opts ...grpc.CallOption) (*ListVHTLCRecoveriesResponse, error)
+	// SignOutSwapHtlcAck signs the accepted terms of an out-swap vHTLC with
+	// the daemon identity key.
+	SignOutSwapHtlcAck(ctx context.Context, in *SignOutSwapHtlcAckRequest, opts ...grpc.CallOption) (*SignOutSwapHtlcAckResponse, error)
 }
 
 type daemonServiceClient struct {
@@ -728,6 +732,16 @@ func (c *daemonServiceClient) ListVHTLCRecoveries(ctx context.Context, in *ListV
 	return out, nil
 }
 
+func (c *daemonServiceClient) SignOutSwapHtlcAck(ctx context.Context, in *SignOutSwapHtlcAckRequest, opts ...grpc.CallOption) (*SignOutSwapHtlcAckResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SignOutSwapHtlcAckResponse)
+	err := c.cc.Invoke(ctx, DaemonService_SignOutSwapHtlcAck_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // DaemonServiceServer is the server API for DaemonService service.
 // All implementations must embed UnimplementedDaemonServiceServer
 // for forward compatibility.
@@ -921,6 +935,9 @@ type DaemonServiceServer interface {
 	// inspection. Armed rows are dormant; callers must use
 	// EscalateVHTLCRecovery to start costly on-chain recovery.
 	ListVHTLCRecoveries(context.Context, *ListVHTLCRecoveriesRequest) (*ListVHTLCRecoveriesResponse, error)
+	// SignOutSwapHtlcAck signs the accepted terms of an out-swap vHTLC with
+	// the daemon identity key.
+	SignOutSwapHtlcAck(context.Context, *SignOutSwapHtlcAckRequest) (*SignOutSwapHtlcAckResponse, error)
 	mustEmbedUnimplementedDaemonServiceServer()
 }
 
@@ -1065,6 +1082,9 @@ func (UnimplementedDaemonServiceServer) GetVHTLCRecoveryStatus(context.Context, 
 }
 func (UnimplementedDaemonServiceServer) ListVHTLCRecoveries(context.Context, *ListVHTLCRecoveriesRequest) (*ListVHTLCRecoveriesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListVHTLCRecoveries not implemented")
+}
+func (UnimplementedDaemonServiceServer) SignOutSwapHtlcAck(context.Context, *SignOutSwapHtlcAckRequest) (*SignOutSwapHtlcAckResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SignOutSwapHtlcAck not implemented")
 }
 func (UnimplementedDaemonServiceServer) mustEmbedUnimplementedDaemonServiceServer() {}
 func (UnimplementedDaemonServiceServer) testEmbeddedByValue()                       {}
@@ -1890,6 +1910,24 @@ func _DaemonService_ListVHTLCRecoveries_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_SignOutSwapHtlcAck_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SignOutSwapHtlcAckRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).SignOutSwapHtlcAck(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_SignOutSwapHtlcAck_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).SignOutSwapHtlcAck(ctx, req.(*SignOutSwapHtlcAckRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // DaemonService_ServiceDesc is the grpc.ServiceDesc for DaemonService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -2072,6 +2110,10 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListVHTLCRecoveries",
 			Handler:    _DaemonService_ListVHTLCRecoveries_Handler,
+		},
+		{
+			MethodName: "SignOutSwapHtlcAck",
+			Handler:    _DaemonService_SignOutSwapHtlcAck_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/waverpc/daemon_mailboxrpc.pb.go
+++ b/waverpc/daemon_mailboxrpc.pb.go
@@ -114,6 +114,8 @@ type DaemonServiceMailboxServer interface {
 	GetVHTLCRecoveryStatus(ctx context.Context, req *GetVHTLCRecoveryStatusRequest) (*GetVHTLCRecoveryStatusResponse, error)
 	// ListVHTLCRecoveries handles ListVHTLCRecoveries.
 	ListVHTLCRecoveries(ctx context.Context, req *ListVHTLCRecoveriesRequest) (*ListVHTLCRecoveriesResponse, error)
+	// SignOutSwapHtlcAck handles SignOutSwapHtlcAck.
+	SignOutSwapHtlcAck(ctx context.Context, req *SignOutSwapHtlcAckRequest) (*SignOutSwapHtlcAckResponse, error)
 }
 
 // RegisterDaemonServiceMailboxServer registers handlers for DaemonService.
@@ -567,6 +569,16 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.ListVHTLCRecoveries(ctx, req)
+	})
+	r.Handle("waverpc.DaemonService", "SignOutSwapHtlcAck", func() proto.Message {
+		return &SignOutSwapHtlcAckRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*SignOutSwapHtlcAckRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.SignOutSwapHtlcAck(ctx, req)
 	})
 }
 
@@ -1598,6 +1610,29 @@ func (c *DaemonServiceMailboxClient) ListVHTLCRecoveries(ctx context.Context, re
 	}
 
 	resp := new(ListVHTLCRecoveriesResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// SignOutSwapHtlcAck calls the SignOutSwapHtlcAck RPC.
+func (c *DaemonServiceMailboxClient) SignOutSwapHtlcAck(ctx context.Context, req *SignOutSwapHtlcAckRequest, opts ...rpc.RPCOptions) (*SignOutSwapHtlcAckResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "waverpc.DaemonService",
+		Method:  "SignOutSwapHtlcAck",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(SignOutSwapHtlcAckResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What this does

Adds an explicit, signed acknowledgement for out-swap vHTLC terms.

- Defines a domain-tagged digest over the receiver key, payment hash, amount, and vHTLC script.
- Adds a purpose-specific daemon RPC that signs only this acknowledgement shape.
- Carries the signature through the swap SDK after the receive event is durably recorded.
- Keeps mailbox delivery acknowledgements independent from swap lifecycle acceptance.

The committed P2TR script binds the swap sender and Ark operator keys through the vHTLC policy, preventing reuse against a server with different policy keys.

## Commit structure

1. `swaprpc: bind out-swap acknowledgement terms`
2. `waved: sign out-swap acknowledgement terms`
3. `swaps: attach out-swap acknowledgement proofs`

## Compatibility

The protobuf field and daemon RPC are additive. Consumers can adopt the signed acknowledgement before enforcing it at the service boundary.

## Verification

- canonical digest tests that vary every committed term;
- a wallet-backed daemon sign-and-verify test that pins the tag and field ordering;
- standard, resumed, credit-assisted Lightning, and credit-assisted in-Ark receive paths;
- `go test ./...`;
- `go test -race ./swaprpc ./sdk/ark ./sdk/swaps ./waved`;
- `make fmt-check`;
- `make lint-local`;
- `make commitmsg-lint range=origin/main..HEAD`.
