### PR TITLE
serverconn+round: never park the ingress path, make backpressure visible

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,7 +87,7 @@ package may import from a higher layer.
 
 | Package | Purpose |
 |---------|---------|
-| [`p-models`](p-models/) | Executable P formal models and Go conformance bridge for distributed-systems properties (durable mailbox, Read/Commit fence) |
+| [`p-models`](p-models/) | Executable P formal models and Go conformance bridge for distributed-systems properties (durable mailbox, Read/Commit fence, ingress deferral and redrive) |
 | [`p-models/durableactor/bridge`](p-models/durableactor/bridge/) | Go conformance harness: replays P model mailbox traces against the real `db/actordelivery` store |
 | [`harness`](harness/) | Docker-based Bitcoin/LND integration test environment |
 | [`systest`](systest/) | System-level end-to-end tests |

--- a/baselib/actor/bounded_delivery.go
+++ b/baselib/actor/bounded_delivery.go
@@ -1,0 +1,165 @@
+package actor
+
+import (
+	"context"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// NonParkingTeller is implemented by every reference in this package and is
+// how a reference answers the question "deliver this without ever parking me"
+// for the target it actually resolves at send time.
+//
+// The interface exists because the reference, not the caller, knows two
+// things the decision depends on: what kind of mailbox the concrete target
+// has, and which target a send-time-resolving reference (a Router, or a
+// transform wrapping one) picks for this particular message. A Router key
+// can hold both a bounded and a durable actor at once; any answer computed
+// before selection can disagree with the target the message is handed to,
+// and picking the wrong primitive for a durable target is the expensive
+// direction (see TellWithoutParking). Making the reference decide and
+// deliver in one step is what keeps the answer and the delivery consistent.
+type NonParkingTeller[M Message] interface {
+	// TellWithoutParkingTo delivers msg to whichever target this
+	// reference resolves for it, choosing Tell or TryTell by that
+	// target's own mailbox. The result carries whether the delivery
+	// escaped the caller's transaction: true means a successful TryTell
+	// hand-off into an in-memory mailbox, which is already visible to
+	// the receiving actor and cannot be rolled back, so a caller whose
+	// transaction may run more than once must not send it a second
+	// time. False means nothing escaped: a Tell enqueue joins whatever
+	// transaction the caller's context carries and is undone with it, a
+	// filtering transform may have dropped the message, and an errored
+	// result delivered nothing at all.
+	TellWithoutParkingTo(ctx context.Context, msg M) fn.Result[bool]
+}
+
+// TellWithoutParking delivers msg to ref with one guarantee the plain Tell
+// cannot make: the calling goroutine is never parked waiting for room in the
+// target's mailbox. A bounded in-memory target is sent to with TryTell, so a
+// full mailbox comes back as ErrMailboxFull for the caller to stash, redrive,
+// or fail on. Everything else keeps Tell. The result carries whether the
+// delivery escaped the caller's transaction, exactly as documented on
+// NonParkingTeller.
+//
+// The split is what makes this safe to call from a goroutine that must stay
+// live, and from inside a database transaction. A durable target must keep
+// Tell there: TryTell performs its write on its own background context, which
+// drops the caller's transaction and, on a single-writer store such as
+// SQLite, cannot even complete while the caller still holds the writer. A
+// bounded in-memory target has the opposite problem — its Send is a blocking
+// channel send with no bound at all — and TryTell is the only way to keep the
+// caller moving.
+//
+// A reference this package does not recognise keeps the plain Tell. That is
+// the conservative direction: Tell is the primitive that carries a durable
+// enqueue into the caller's transaction, and guessing the other way would
+// silently break that atomicity for a reference implemented elsewhere.
+//
+// Callers must handle ErrMailboxFull. Treating it as a delivery failure and
+// dropping the message converts backpressure into silent message loss, which
+// for an at-least-once transport is worse than the stall it replaces.
+func TellWithoutParking[M Message](ctx context.Context, ref TellOnlyRef[M],
+	msg M) fn.Result[bool] {
+
+	if teller, ok := ref.(NonParkingTeller[M]); ok {
+		return teller.TellWithoutParkingTo(ctx, msg)
+	}
+
+	return fn.NewResult(false, ref.Tell(ctx, msg))
+}
+
+// TellWithoutParkingTo sends with TryTell when the actor runs on the
+// fixed-capacity channel mailbox, which is what every actor started through
+// NewActor gets, and with Tell otherwise. Only the channel mailbox's Send can
+// park the caller waiting for the receiver to make room.
+func (ref *actorRefImpl[M, R]) TellWithoutParkingTo(ctx context.Context,
+	msg M) fn.Result[bool] {
+
+	if _, bounded := ref.actor.mailbox.(*ChannelMailbox[M, R]); bounded {
+		return fn.NewResult(true, ref.TryTell(ctx, msg))
+	}
+
+	return fn.NewResult(false, ref.Tell(ctx, msg))
+}
+
+// TellWithoutParkingTo keeps the plain Tell: a durable mailbox has no
+// capacity, so its enqueue waits on a database write inside the caller's
+// transaction instead of on the receiving actor draining its queue.
+func (ref *durableActorRefImpl[M, R]) TellWithoutParkingTo(ctx context.Context,
+	msg M) fn.Result[bool] {
+
+	return fn.NewResult(false, ref.Tell(ctx, msg))
+}
+
+// TellWithoutParkingTo resolves the router's target the same way Tell does
+// and then makes the bounded-or-not decision against that one reference, so
+// the primitive always matches the actor the message is handed to.
+//
+// Selection consumes a routing turn exactly once, as a Tell through the
+// router would. A resolution failure is handed back to the router's own Tell
+// rather than returned directly, so the dead-letter fallback for an empty key
+// keeps working.
+func (r *Router[M, R]) TellWithoutParkingTo(ctx context.Context,
+	msg M) fn.Result[bool] {
+
+	selected, err := r.getActor()
+	if err != nil {
+		return fn.NewResult(false, r.Tell(ctx, msg))
+	}
+
+	return TellWithoutParking[M](ctx, selected, msg)
+}
+
+// TellWithoutParkingTo transforms the message and lets the wrapped reference
+// make the delivery decision, so a transform in front of a router does not
+// flatten the router's per-target answer. A transform failure is reported
+// before the target is touched at all, matching Tell and TryTell.
+func (m *MapRef[In, Out, InR, OutR]) TellWithoutParkingTo(ctx context.Context,
+	msg In) fn.Result[bool] {
+
+	transformed, err := m.mapInput(msg)
+	if err != nil {
+		return fn.Errf[bool]("map input: %w", err)
+	}
+
+	return TellWithoutParking[Out](ctx, m.targetRef, transformed)
+}
+
+// TellWithoutParkingTo transforms the message and lets the wrapped reference
+// make the delivery decision, for the same reason as MapRef's.
+func (m *MapInputRef[In, Out]) TellWithoutParkingTo(ctx context.Context,
+	msg In) fn.Result[bool] {
+
+	return TellWithoutParking[Out](ctx, m.targetRef, m.mapFn(msg))
+}
+
+// TellWithoutParkingTo transforms the message and lets the wrapped reference
+// make the delivery decision. A dropped message reports false with no error:
+// it reached no mailbox, so nothing escaped the caller's transaction and
+// there is nothing for a retrying caller to suppress.
+func (m *FilterMapInputRef[In, Out]) TellWithoutParkingTo(ctx context.Context,
+	msg In) fn.Result[bool] {
+
+	transformed, ok := m.mapFn(msg)
+	if !ok {
+		return fn.Ok(false)
+	}
+
+	return TellWithoutParking[Out](ctx, m.targetRef, transformed)
+}
+
+// Compile-time interface checks. Every reference implementation in this
+// package answers the non-parking delivery question itself, so
+// TellWithoutParking never has to fall back to its conservative default for
+// an in-tree target.
+var (
+	_ NonParkingTeller[Message]    = (*actorRefImpl[Message, any])(nil)
+	_ NonParkingTeller[TLVMessage] = (*durableActorRefImpl[TLVMessage,
+		any])(nil)
+	_ NonParkingTeller[Message] = (*Router[Message, any])(nil)
+	_ NonParkingTeller[Message] = (*MapRef[Message, Message, any, any])(nil)
+	_ NonParkingTeller[Message] = (*MapInputRef[Message, Message])(nil)
+	_ NonParkingTeller[Message] = (*FilterMapInputRef[Message,
+		Message])(nil)
+)

--- a/baselib/actor/bounded_delivery_test.go
+++ b/baselib/actor/bounded_delivery_test.go
@@ -1,0 +1,286 @@
+package actor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTellWithoutParkingFailsFastOnFullMailbox verifies the property the helper
+// exists for: a caller that must stay live gets ErrMailboxFull back from a
+// bounded target instead of parking on it. The contrast with Tell is what the
+// wedge was made of — Tell on this same reference never returns while the
+// target stays parked.
+func TestTellWithoutParkingFailsFastOnFullMailbox(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	a, _ := wedgedActor(t, h)
+
+	start := time.Now()
+	outsideTx, err := TellWithoutParking[*testMsg](
+		t.Context(), a.Ref(), newTestMsg("overflow"),
+	).Unpack()
+
+	require.ErrorIs(t, err, ErrMailboxFull)
+
+	// A refused hand-off delivered nothing, so nothing escaped the
+	// caller's transaction and there is nothing to suppress on a retry.
+	require.False(t, outsideTx)
+
+	// The bound is loose for the same reason as the TryTell tests: a loaded
+	// CI box can deschedule us mid-call. It still catches the regression,
+	// because a blocking send here would never return at all.
+	require.Less(t, time.Since(start), time.Second)
+}
+
+// TestTellWithoutParkingDelivers verifies the success path is ordinary
+// delivery.
+func TestTellWithoutParkingDelivers(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	beh := newEchoBehavior(t, 0)
+	a := h.newActor("tell-without-parking-delivers", beh, 4)
+
+	replies := make(chan string, 1)
+	msg := newTestMsgWithReply("payload", replies)
+
+	outsideTx, err := TellWithoutParking[*testMsg](
+		t.Context(), a.Ref(), msg,
+	).Unpack()
+	require.NoError(t, err)
+
+	// The reported flag is what a caller inside a transaction reads to know
+	// the hand-off is NOT covered by its commit, so it has to be true for a
+	// bounded in-memory target.
+	require.True(t, outsideTx)
+
+	select {
+	case got := <-replies:
+		require.Equal(t, "payload", got)
+
+	case <-time.After(time.Second):
+		t.Fatal("message was never processed")
+	}
+}
+
+// TestTellWithoutParkingClassifiesByTarget pins the classification by
+// observing which primitive actually runs for each reference shape that
+// reaches the helper from the ingress path, rather than by asking a
+// capability question. The durable direction is the expensive one to get
+// wrong — a durable enqueue swapped onto TryTell leaves the caller's
+// transaction behind, so it can survive a rollback.
+func TestTellWithoutParkingClassifiesByTarget(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+
+	// A full bounded target is the discriminator: only the TryTell path can
+	// report ErrMailboxFull, and only the Tell path could park. Every
+	// transform wrapper must route a bounded target through TryTell.
+	// FilterMapInputRef is the one that was missing the delegation: a
+	// wrapper that does not answer falls back to the blocking Tell path and
+	// reinstates the wedge with no deferral metric and no log.
+	full, _ := wedgedActor(t, h)
+
+	mapInput := NewMapInputRef(
+		TellOnlyRef[*testMsg](
+			full.Ref(),
+		),
+		func(m *testMsg) *testMsg { return m },
+	)
+	filterMap := NewFilterMapInputRef(
+		TellOnlyRef[*testMsg](
+			full.Ref(),
+		),
+		func(m *testMsg) (*testMsg, bool) { return m, true },
+	)
+	mapRef := NewMapRef(
+		ActorRef[*testMsg, string](
+			full.Ref(),
+		),
+		func(m *testMsg) (*testMsg, error) { return m, nil },
+		func(r string) string { return r },
+	)
+
+	wrappers := map[string]TellOnlyRef[*testMsg]{
+		"direct":            full.Ref(),
+		"map-input":         mapInput,
+		"filter-map":        filterMap,
+		"map-bidirectional": mapRef,
+	}
+	for name, ref := range wrappers {
+		outsideTx, err := TellWithoutParking[*testMsg](
+			t.Context(), ref, newTestMsg("classify"),
+		).Unpack()
+		// ErrMailboxFull is itself the classification: only the
+		// TryTell path can report it, and the Tell path would have
+		// parked instead. The refused hand-off delivered nothing, so
+		// the result carries false.
+		require.ErrorIs(
+			t, err, ErrMailboxFull, "%s: a full bounded target "+
+				"must surface ErrMailboxFull, not park or "+
+				"deliver", name,
+		)
+		require.False(t, outsideTx, name)
+	}
+
+	// A reference this package does not recognise keeps the plain Tell:
+	// that is the conservative default that protects a durable enqueue's
+	// transaction atomicity.
+	unknown := &unboundedTestRef{}
+	outsideTx, err := TellWithoutParking[*testMsg](
+		t.Context(), unknown, newTestMsg("conservative"),
+	).Unpack()
+	require.NoError(t, err)
+	require.False(t, outsideTx)
+	require.Equal(t, 1, unknown.tells)
+	require.Zero(t, unknown.tryTells)
+
+	// A router with nothing registered resolves no target and falls back to
+	// its own Tell, which reports the empty key immediately instead of
+	// parking.
+	system := NewActorSystem()
+	t.Cleanup(func() {
+		require.NoError(t, system.Shutdown(context.Background()))
+	})
+
+	key := NewServiceKey[*testMsg, string]("bounded-classification-key")
+	router := key.Ref(system)
+
+	start := time.Now()
+	err = TellWithoutParking[*testMsg](
+		t.Context(), router, newTestMsg("empty-key"),
+	).Err()
+	require.Error(t, err)
+	require.Less(t, time.Since(start), time.Second)
+}
+
+// unboundedTestRef stands in for a reference whose enqueue is a database write
+// rather than a fixed-capacity mailbox: it is not a NonParkingTeller, the way
+// an externally implemented reference would not be, and records which
+// primitive was used on it. The real durable ref cannot be used here because
+// its TryTell needs a store, and the point being pinned is the choice of
+// primitive, not the write.
+type unboundedTestRef struct {
+	tells    int
+	tryTells int
+}
+
+// Tell records a blocking enqueue.
+func (r *unboundedTestRef) Tell(context.Context, *testMsg) error {
+	r.tells++
+
+	return nil
+}
+
+// TryTell records a non-blocking enqueue, which for a durable target is the
+// wrong primitive: it drops the caller's transaction.
+func (r *unboundedTestRef) TryTell(context.Context, *testMsg) error {
+	r.tryTells++
+
+	return nil
+}
+
+// Ask is unused by these tests and completes immediately.
+func (r *unboundedTestRef) Ask(context.Context, *testMsg) Future[string] {
+	promise := NewPromise[string]()
+	promise.Complete(fn.Ok(""))
+
+	return promise.Future()
+}
+
+// ID identifies the double.
+func (r *unboundedTestRef) ID() string {
+	return "unbounded-test-ref"
+}
+
+// TestTellWithoutParkingResolvesRouterTarget pins the coherence between the
+// delivery decision and the target it sends to.
+//
+// A Router's send picks ONE target round-robin, while its key can carry both
+// a bounded actor and a durable one at once. Deciding the primitive from any
+// set-wide answer puts roughly half of the deliveries through the durable
+// ref's TryTell — which abandons the caller's transaction, does its write on
+// a 100ms background context that cannot complete while the caller holds a
+// single-writer database, and comes back as a wrapped DeadlineExceeded rather
+// than ErrMailboxFull. The ingress loop would read that as a hard dispatch
+// failure, roll back, never advance, and report no deferral: total deafness
+// with the wrong diagnosis. So the primitive has to be chosen against the
+// resolved target, not the set.
+func TestTellWithoutParkingResolvesRouterTarget(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+
+	system := NewActorSystem()
+	t.Cleanup(func() {
+		require.NoError(t, system.Shutdown(context.Background()))
+	})
+
+	key := NewServiceKey[*testMsg, string]("mixed-registration-key")
+
+	// One bounded actor and one unbounded reference under the same key. The
+	// receptionist accepts this: registration is an append-only slice and
+	// only the message and response type names are checked.
+	bounded := h.newActor("mixed-bounded", newEchoBehavior(t, 0), 4)
+	unbounded := &unboundedTestRef{}
+
+	require.NoError(
+		t,
+		RegisterWithReceptionist(
+			system.Receptionist(), key, bounded.Ref(),
+		),
+	)
+	require.NoError(
+		t,
+		RegisterWithReceptionist(
+			system.Receptionist(), key, unbounded,
+		),
+	)
+
+	router := key.Ref(system)
+
+	// Two sends cover both targets, whichever order round-robin visits them
+	// in. Neither may reach the unbounded reference through TryTell.
+	for range 2 {
+		require.NoError(
+			t, TellWithoutParking[*testMsg](
+				t.Context(), router, newTestMsg("mixed"),
+			).Err(),
+		)
+	}
+
+	require.Zero(
+		t, unbounded.tryTells,
+		"a durable target was delivered to with TryTell",
+	)
+	require.Equal(t, 1, unbounded.tells)
+
+	// The same has to hold through a transform in front of the router,
+	// since that is how several ingress routes are wired.
+	wrapped := NewMapInputRef(
+		TellOnlyRef[*testMsg](router),
+		func(m *testMsg) *testMsg { return m },
+	)
+
+	for range 2 {
+		require.NoError(
+			t, TellWithoutParking[*testMsg](
+				t.Context(), wrapped, newTestMsg(
+					"mixed-wrapped",
+				),
+			).Err(),
+		)
+	}
+
+	require.Zero(
+		t, unbounded.tryTells, "a durable target behind a "+
+			"transform was delivered to with TryTell",
+	)
+	require.Equal(t, 2, unbounded.tells)
+}

--- a/baselib/protofsm/state_machine.go
+++ b/baselib/protofsm/state_machine.go
@@ -17,6 +17,15 @@ const (
 	// pollInterval is the interval at which we'll poll the SendWhen
 	// predicate if specified.
 	pollInterval = time.Millisecond * 100
+
+	// DefaultStateQueryTimeout bounds a state query that the caller did not
+	// bound itself. A query is answered from driveMachine's top-level
+	// select, so it is only ever slow when the machine is mid-transition,
+	// and a caller reading state has no use for an answer that arrives
+	// after the transition it was racing has finished. Callers with a
+	// context of their own should pass it to CurrentStateWithContext
+	// instead.
+	DefaultStateQueryTimeout = time.Second
 )
 
 var (
@@ -317,9 +326,20 @@ func (s *StateMachine[InternalEvent, OutboxEvent, Env]) Receive(
 	return future.Await(ctx)
 }
 
-// CurrentState returns the current state of the state machine.
+// CurrentState returns the current state of the state machine, waiting up to
+// DefaultStateQueryTimeout for the machine to answer.
+//
+// A caller that has a context to spend should prefer CurrentStateWithContext,
+// so the query also ends when the caller does. This variant deliberately runs
+// on a plain timer rather than deriving a context from context.Background: a
+// derived context inside this shared generic makes contextcheck flag every
+// no-arg caller in every consuming package, and this wrapper exists precisely
+// for the call sites that have no context to pass.
 func (s *StateMachine[InternalEvent, OutboxEvent, Env]) CurrentState() (
 	State[InternalEvent, OutboxEvent, Env], error) {
+
+	timer := time.NewTimer(DefaultStateQueryTimeout)
+	defer timer.Stop()
 
 	query := stateQuery[InternalEvent, OutboxEvent, Env]{
 		CurrentState: make(
@@ -327,11 +347,71 @@ func (s *StateMachine[InternalEvent, OutboxEvent, Env]) CurrentState() (
 		),
 	}
 
-	if !fn.SendOrQuit(s.stateQuery, query, s.quit) {
+	// Both halves share the single timer, mirroring the shared deadline
+	// the context variant gets from WithTimeout.
+	select {
+	case s.stateQuery <- query:
+	case <-timer.C:
+		return nil, context.DeadlineExceeded
+
+	case <-s.quit:
 		return nil, ErrStateMachineShutdown
 	}
 
-	return fn.RecvOrTimeout(query.CurrentState, time.Second)
+	select {
+	case state := <-query.CurrentState:
+		return state, nil
+
+	case <-timer.C:
+		return nil, context.DeadlineExceeded
+
+	case <-s.quit:
+		return nil, ErrStateMachineShutdown
+	}
+}
+
+// CurrentStateWithContext returns the current state of the state machine,
+// giving up when ctx is done.
+//
+// Both halves of the exchange are bounded, and the request half is the one that
+// matters: driveMachine serves state queries only from its top-level select, so
+// it is deaf to them for as long as it is inside a transition, and the request
+// channel is unbuffered. A send with no escape therefore parks the caller for
+// the full duration of whatever ProcessEvent the machine is running — which for
+// a transition doing network or signing work is unbounded. Selecting on ctx is
+// what turns that park into an error the caller can degrade on.
+func (s *StateMachine[InternalEvent, OutboxEvent, Env]) CurrentStateWithContext(
+	ctx context.Context) (State[InternalEvent, OutboxEvent, Env], error) {
+
+	query := stateQuery[InternalEvent, OutboxEvent, Env]{
+		CurrentState: make(
+			chan State[InternalEvent, OutboxEvent, Env], 1,
+		),
+	}
+
+	select {
+	case s.stateQuery <- query:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+
+	case <-s.quit:
+		return nil, ErrStateMachineShutdown
+	}
+
+	// Once the query is accepted the reply is immediate: driveMachine
+	// writes it into the buffered reply channel from the same select arm
+	// that took the query. The wait is bounded anyway, so a machine that
+	// stops in between cannot park the caller either.
+	select {
+	case state := <-query.CurrentState:
+		return state, nil
+
+	case <-ctx.Done():
+		return nil, ctx.Err()
+
+	case <-s.quit:
+		return nil, ErrStateMachineShutdown
+	}
 }
 
 // StateSubscriber represents an active subscription to be notified of new

--- a/baselib/protofsm/state_query_test.go
+++ b/baselib/protofsm/state_query_test.go
@@ -1,0 +1,173 @@
+package protofsm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// queryTestEnv is the empty environment for the state query tests. Environment
+// has no methods, so nothing is needed beyond a distinct type.
+type queryTestEnv struct{}
+
+// queryTestState is a state whose transition parks until the test releases it.
+// It models the real hazard: a transition that does network, signing, or
+// database work while a caller elsewhere wants to read the machine's state.
+type queryTestState struct {
+	// entered is closed by ProcessEvent once the transition has begun, so
+	// the test can query the machine at the exact moment the driver is
+	// deaf.
+	entered chan struct{}
+
+	// release unblocks the transition.
+	release chan struct{}
+}
+
+// ProcessEvent signals that the transition started, then parks until released.
+func (s *queryTestState) ProcessEvent(ctx context.Context, _ struct{},
+	_ *queryTestEnv) (*StateTransition[
+	struct{},
+	struct{},
+	*queryTestEnv,
+], error) {
+
+	close(s.entered)
+
+	select {
+	case <-s.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	return &StateTransition[struct{}, struct{}, *queryTestEnv]{
+		NextState: s,
+	}, nil
+}
+
+// IsTerminal implements State.
+func (s *queryTestState) IsTerminal() bool { return false }
+
+// String implements State.
+func (s *queryTestState) String() string { return "QueryTestState" }
+
+// queryTestReporter is a no-op ErrorReporter.
+type queryTestReporter struct{}
+
+// ReportError implements ErrorReporter.
+func (queryTestReporter) ReportError(error) {}
+
+// newQueryTestMachine returns a started machine parked in a transition, plus
+// the state that gates it.
+func newQueryTestMachine(t *testing.T) (*StateMachine[
+	struct{},
+	struct{},
+	*queryTestEnv,
+], *queryTestState) {
+
+	t.Helper()
+
+	state := &queryTestState{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+
+	machine := NewStateMachine(StateMachineCfg[struct{}, struct{},
+		*queryTestEnv]{
+		Logger:        btclog.Disabled,
+		ErrorReporter: queryTestReporter{},
+		InitialState:  state,
+		Env:           &queryTestEnv{},
+	})
+
+	machine.Start(t.Context())
+	t.Cleanup(machine.Stop)
+
+	// Drive the machine into the parked transition.
+	machine.SendEvent(t.Context(), struct{}{})
+
+	select {
+	case <-state.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("state machine never entered the transition")
+	}
+
+	return &machine, state
+}
+
+// TestCurrentStateDoesNotParkWhileMachineIsInTransition is the regression test
+// for a state query with no escape. The request channel is unbuffered and
+// driveMachine serves it only from its top-level select, so a query issued
+// while the machine is inside a transition used to park the caller for the
+// whole duration of that transition — unbounded, since a transition may do
+// network or signing work. For a caller that is itself an actor's single
+// receive goroutine, that park is how one slow FSM took the whole actor down.
+//
+// The query must come back with an error instead. Failing fast is the point:
+// the callers of this are all reads that can degrade.
+func TestCurrentStateDoesNotParkWhileMachineIsInTransition(t *testing.T) {
+	t.Parallel()
+
+	machine, state := newQueryTestMachine(t)
+
+	// The default bound applies to a caller that brought no context of its
+	// own, so this must come back rather than wait for the transition. The
+	// query runs on its own goroutine so a regression fails the test
+	// instead of hanging the package: an unbounded park has no other
+	// symptom.
+	queried := make(chan error, 1)
+	go func() {
+		_, err := machine.CurrentState()
+
+		queried <- err
+	}()
+
+	select {
+	case err := <-queried:
+		require.Error(t, err)
+
+	case <-time.After(5 * time.Second):
+		t.Fatal(
+			"CurrentState parked while the machine was in a " +
+				"transition",
+		)
+	}
+
+	// A caller with its own context gets its own bound, and gets it back as
+	// its own error.
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := machine.CurrentStateWithContext(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// Once the transition finishes, the same query is answered.
+	close(state.release)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		observed, err := machine.CurrentState()
+		if !assert.NoError(c, err) {
+			return
+		}
+
+		assert.Equal(c, "QueryTestState", observed.String())
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestCurrentStateWithContextHonoursCallerCancel pins that a caller which gives
+// up before the machine answers gets its own cancellation back, rather than
+// waiting out the default bound.
+func TestCurrentStateWithContextHonoursCallerCancel(t *testing.T) {
+	t.Parallel()
+
+	machine, _ := newQueryTestMachine(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := machine.CurrentStateWithContext(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/db/actordelivery/store_impl.go
+++ b/db/actordelivery/store_impl.go
@@ -1722,14 +1722,16 @@ func NewTxAwareActorDeliveryStore(
 // out of fn and place them after ExecTx returns. See the retry loop for why
 // that matters to a caller whose fn is slow enough to outlast its lease.
 //
-// NOTE: serverconn's runFoldedDispatch does not satisfy that contract yet. It
-// calls dispatchBatch inside fn, and the mux-bridged routes there terminate in
-// a network send, so a retryable error raised after the send replays it. The
-// path was already at-least-once, since a failed fold nacks and the batch is
-// re-pulled, and the operator absorbs the duplicate by correlation ID. Retrying
-// in place makes that happen up to numRetries times per turn instead of once,
-// which is why moving the send out of the transaction is the fix rather than a
-// tidiness follow-up. Until it lands, this is the one known in-tree exception.
+// NOTE: serverconn's runFoldedDispatch is the one caller that has to work at
+// this contract rather than simply satisfying it, because the inbound envelopes
+// it dispatches inside fn do not all end in a durable write. The network sends
+// are hoisted: a mux-bridged route's request is served before the transaction
+// opens, so a replay cannot repeat it. What remains inside fn is delivery into
+// a bounded in-memory mailbox, which is not in the transaction either and
+// cannot be rolled back — so that path records the event_seq of every hand-off
+// in a set that lives outside the closure and skips it on a replay. See
+// serverconn/dispatch_replay.go. Any new effect placed inside that fold needs
+// the same treatment or it will run once per attempt.
 func (s *TxAwareActorDeliveryStore) ExecTx(
 	ctx context.Context, readOnly bool, fn actor.TxFunc,
 ) error {

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -109,6 +109,63 @@ polling the direct gRPC connection's transport state every 15s.
 | `waved_server_connection_up` | gauge | — | daemon (connection watcher) | `1` when the direct gRPC connection to the ark operator is `Ready`, `0` otherwise (transient failure, idle, shutdown). |
 | `waved_server_sync_timestamp_seconds` | gauge | — | daemon (connection watcher) | Unix timestamp of the last poll that observed the operator connection in the `Ready` **transport** state. This is transport liveness, not a completed application round-trip — an idle-but-`Ready` link keeps the stamp fresh. A stale value signals lost transport contact. |
 
+## Ingress Liveness (`serverconn`)
+
+Set directly by the connector's ingress loop, for the same reason the two gauges
+above are set by the daemon: the connector owns no metrics sink, and the ingress
+goroutine is precisely the one that must not take a new actor edge to report that
+it is alive.
+
+The loop is the process's only consumer of the server mailbox, so when it stalls
+the client goes deaf to the operator while read-only RPCs keep answering — a pod
+that looks healthy and has stopped hearing about rounds. Nothing else in the
+process observes that: the connector's other timestamp is outbound-only, and
+`GetInfo`'s `server_connected` is stamped once at startup and never cleared on a
+stall.
+
+| Metric | Type | Labels | Source | Description |
+|--------|------|--------|--------|-------------|
+| `waved_serverconn_last_ingress_poll_timestamp_seconds` | gauge | — | connector (ingress loop) | Unix timestamp of the last `Pull` that returned to the ingress loop, including an empty long-poll. Fresh at the long-poll cadence on an idle client, so staleness means the loop goroutine itself is gone. |
+| `waved_serverconn_last_ingress_event_timestamp_seconds` | gauge | — | connector (ingress loop) | Unix timestamp of the last pulled batch the loop delivered and committed, including a partial commit made while backpressure held the rest. Only advances on real traffic, so on its own it cannot tell an idle client from a wedged one; a fresh poll stamp with a stale event stamp says the loop is running but dispatch is not getting through. |
+| `waved_serverconn_ingress_dispatch_deferred_total` | counter | `service`, `method` | connector (ingress loop) | Redrives a full target actor mailbox turned away, by the route of the envelope that was refused. One increment per re-pull that could not deliver, **not** one per queued envelope: the loop meets the full mailbox once and stops there, so the envelopes behind the first are never attempted. Nothing is lost — the refused envelope is unacknowledged and re-pulled after a short backoff — but a rate that does not fall back to zero means a local actor has stopped draining. |
+
+### Alerting
+
+There are two distinct failures here and they need different expressions.
+
+**The loop is gone** (panic, or a park somewhere the fix below does not cover):
+
+```
+time() - waved_serverconn_last_ingress_poll_timestamp_seconds > 300
+  and waved_server_connection_up == 1
+```
+
+**A local actor has stopped draining**, which is the wedge this instrumentation
+was added for. Poll staleness cannot see it: the loop keeps polling and keeps
+this gauge fresh the whole time the target is wedged, deliberately, so that the
+two failures stay separable. Key on the deferral counter instead:
+
+```
+rate(waved_serverconn_ingress_dispatch_deferred_total[10m]) > 0
+```
+
+for 5m, which distinguishes a target that briefly filled up (deferrals stop) from
+one that has stopped entirely (they do not). The corroborating reading is a
+**fresh** poll stamp with a **stale** event stamp:
+
+```
+time() - waved_serverconn_last_ingress_poll_timestamp_seconds < 60
+  and time() - waved_serverconn_last_ingress_event_timestamp_seconds > 300
+```
+
+That pair is subject to false positives on a genuinely idle client, so it is a
+diagnostic to read next to the counter rather than a page on its own.
+
+Both gauges are unlabelled, which assumes one connector per process — true today
+(`waved/server.go` constructs exactly one). A second one would silently make each
+gauge the max of the two and the first alert blind; add a `mailbox_id` label
+before that happens.
+
 ## gRPC Client Metrics
 
 Per-method **client-side** metrics for calls `waved` makes to the ark
@@ -141,6 +198,9 @@ metrics.
 - **Event-driven**: add a message type to `messages.go`, handle it in
   `actor.go:Receive`, define the metric in `metrics.go`, register it in
   `allCollectors()`, and `Tell` it from the call site via `Server.emitMetric`.
+  The exception is a metric that reports on the health of a goroutine which must
+  not acquire new dependencies to do so (the liveness gauges above): those are
+  defined in `metrics.go`, registered in `allCollectors()`, and set directly.
 - **Scrape-driven**: add a method to `SystemStatsQuerier` in `collector.go`,
   implement it in the `waved` `systemStatsAdapter`, add a descriptor, and emit
   it from a `Collect` sub-method (each group is queried independently so a

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -102,6 +102,73 @@ var (
 		},
 	)
 
+	// ServerConnLastIngressPollTimestamp records the Unix time of the last
+	// Pull that returned to the connector's ingress loop. That loop is the
+	// process's only consumer of the server mailbox, so this is the
+	// liveness signal for the loop itself: an idle client keeps it fresh at
+	// the long-poll cadence, and a loop that has parked or died stops
+	// updating it immediately.
+	//
+	// It answers "is the loop still looping", which is narrower than "is
+	// the client still hearing the operator". A target actor that has
+	// stopped draining leaves this gauge fresh — the loop keeps polling and
+	// re-pulling the envelope it cannot deliver — and shows up on
+	// ServerConnIngressDeferredTotal instead. Keeping the two separable is
+	// the reason this is stamped before dispatch rather than after.
+	//
+	// It is set directly by serverconn rather than through the metrics
+	// actor, for the same reason as the two gauges above: the connector
+	// owns no metrics sink, and the ingress loop is precisely the goroutine
+	// that must not acquire a new actor edge to report that it is alive.
+	ServerConnLastIngressPollTimestamp = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name: "serverconn_last_ingress_poll_timestamp_" +
+				"seconds",
+			Help: "Unix timestamp of the last Pull that returned " +
+				"to the connector ingress loop.",
+		},
+	)
+
+	// ServerConnLastIngressEventTimestamp records the Unix time of the last
+	// pulled batch the ingress loop delivered and committed. Unlike the
+	// poll gauge it only advances on real inbound traffic, so on its own it
+	// cannot tell an idle client from a wedged one; read together, a fresh
+	// poll stamp with a stale event stamp says the loop is running but
+	// dispatch is not getting through.
+	ServerConnLastIngressEventTimestamp = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name: "serverconn_last_ingress_event_timestamp_" +
+				"seconds",
+			Help: "Unix timestamp of the last inbound envelope " +
+				"batch the connector ingress loop committed.",
+		},
+	)
+
+	// ServerConnIngressDeferredTotal counts the redrives a full target
+	// mailbox turned away, labelled by the route of the envelope that was
+	// refused. A non-zero rate means a local actor has stopped keeping up
+	// with the server; a rate that does not fall back to zero means it has
+	// stopped entirely, and this is the only signal that fires for that —
+	// the poll gauge above stays fresh throughout, because the loop is
+	// still looping.
+	//
+	// It counts refused redrives rather than refused envelopes because
+	// those are the only refusals that exist: the loop stops at the first
+	// envelope the target will not take, so whatever is queued behind it is
+	// never attempted and cannot be counted.
+	ServerConnIngressDeferredTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "serverconn_ingress_dispatch_deferred_total",
+			Help: "Ingress redrives refused by a full target " +
+				"actor mailbox, by the refused envelope's " +
+				"route.",
+		},
+		[]string{"service", "method"},
+	)
+
 	// BackgroundTaskErrorsTotal counts errors hit by daemon-owned
 	// background tasks (sync loops, watchers), labelled by task so
 	// operators can locate a failing subsystem.
@@ -163,6 +230,9 @@ func allCollectors() []prometheus.Collector {
 		BoardingEventsTotal,
 		ServerSyncTimestamp,
 		ServerConnectionUp,
+		ServerConnLastIngressPollTimestamp,
+		ServerConnLastIngressEventTimestamp,
+		ServerConnIngressDeferredTotal,
 		BackgroundTaskErrorsTotal,
 		GRPCClientMetrics,
 	}

--- a/p-models/AGENTS.md
+++ b/p-models/AGENTS.md
@@ -6,14 +6,16 @@ Executable P-language state-machine models plus Go bridge tests, used to
 check concurrency and crash-recovery invariants that plain unit tests
 struggle to cover across independent actors. Currently models the durable
 actor mailbox (correlation-key FIFO claim, lease/ack/nack, Stage/Commit
-exactly-once).
+exactly-once) and the connection actor's ingress dispatch pipeline (cursor
+fold, deferral and redrive against bounded in-memory mailboxes).
 
 ## Key Types
 
 - `durableactor/` — the P model project (`infra.pproj`) and its traces for
   the durable mailbox: enqueue idempotence, per-mailbox/priority/order lease
   selection, per-correlation-key FIFO blocking, ack/nack/lease-expiry/
-  dead-letter, and Stage/Commit replay-safety.
+  dead-letter, Stage/Commit replay-safety, and the connection actor's ingress
+  cursor fold and dispatch deferral against bounded in-memory mailboxes.
 - `durableactor/bridge` — Go package (`mailbox_trace.go` +
   `crash_restart_test.go`, `outbox_fold_test.go`) that replays checked-in
   traces against the real `db/actordelivery` store, keeping the model

--- a/p-models/CLAUDE.md
+++ b/p-models/CLAUDE.md
@@ -6,14 +6,16 @@ Executable P-language state-machine models plus Go bridge tests, used to
 check concurrency and crash-recovery invariants that plain unit tests
 struggle to cover across independent actors. Currently models the durable
 actor mailbox (correlation-key FIFO claim, lease/ack/nack, Stage/Commit
-exactly-once).
+exactly-once) and the connection actor's ingress dispatch pipeline (cursor
+fold, deferral and redrive against bounded in-memory mailboxes).
 
 ## Key Types
 
 - `durableactor/` — the P model project (`infra.pproj`) and its traces for
   the durable mailbox: enqueue idempotence, per-mailbox/priority/order lease
   selection, per-correlation-key FIFO blocking, ack/nack/lease-expiry/
-  dead-letter, and Stage/Commit replay-safety.
+  dead-letter, Stage/Commit replay-safety, and the connection actor's ingress
+  cursor fold and dispatch deferral against bounded in-memory mailboxes.
 - `durableactor/bridge` — Go package (`mailbox_trace.go` +
   `crash_restart_test.go`, `outbox_fold_test.go`) that replays checked-in
   traces against the real `db/actordelivery` store, keeping the model

--- a/p-models/README.md
+++ b/p-models/README.md
@@ -20,7 +20,9 @@ single regression test for the exact SQL row sequence.
 ## Layout
 
 - `durableactor/` models the durable actor mailbox and the
-  per-correlation-key FIFO claim contract.
+  per-correlation-key FIFO claim contract, plus the connection actor's
+  ingress cursor fold and its dispatch deferral against bounded in-memory
+  mailboxes.
 - `durableactor/bridge/` replays checked-in traces against the real Go
   `db/actordelivery` store so the model stays connected to the shipped
   implementation.
@@ -49,9 +51,30 @@ be overtaken by a later same-key successor. The new rule,
 for the same mailbox and correlation key blocks later same-key rows, even when
 the predecessor is leased or waiting for retry.
 
+## Ingress Dispatch
+
+The ingress models cover the connection actor's pull-dispatch-checkpoint loop,
+which is where an envelope stops being a mailbox row and becomes a delivery to
+a local actor.
+
+`durableactor/src/ingress_fold.p` states the cursor contract: the persisted
+cursor may never cover an envelope whose local enqueue did not durably commit.
+
+`durableactor/src/ingress_deferral.p` states the delivery contract the fold
+model abstracts away. The dispatch table has four kinds of destination and
+only one of them is transactional, so a rollback undoes some deliveries and
+not others — and one of the destinations is a fixed-capacity in-memory mailbox
+that can refuse a message outright. The model says a full target must produce
+a deferral rather than a blocking send, that the committed cursor stops at the
+undelivered envelope, that a replayed transaction body does not re-send what
+it already handed over, and that a request answered ahead of the commit is
+answered at most once per process lifetime however many times the redrive
+re-pulls it. The pre-fix implementation is reachable through a configuration
+profile, so each fix has a counterexample test case that removes it and fails.
+
 ## Running
 
-Run the current green suite with:
+Run the whole suite with:
 
 ```shell
 ./p-models/scripts/check.sh
@@ -60,11 +83,14 @@ Run the current green suite with:
 That script:
 
 1. compiles `p-models/durableactor/infra.pproj`;
-2. runs the default P testcase, `tcMailboxCorrelationKeyFIFO`;
-3. runs `go test ./p-models/durableactor/bridge`.
+2. runs every green test case, each of which must find zero bugs;
+3. runs every counterexample test case, each of which must find the bug it
+   exists to catch — a clean run there fails the script, because a model that
+   no longer detects its own failure mode is worthless;
+4. runs `go test ./p-models/durableactor/bridge`.
 
-To demonstrate that the model would have found the original same-key reorder
-bug, run the intentional negative testcase:
+To see one of the counterexamples on its own, for instance the original
+same-key reorder:
 
 ```shell
 p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll \
@@ -74,8 +100,7 @@ p check PGenerated/PChecker/net8.0/MailboxInfraModels.dll \
 ```
 
 That check runs the ideal same-key FIFO property against the legacy claim rule
-and should report one bug. The default `check.sh` suite does not run this
-negative testcase because it is expected to fail.
+and should report one bug.
 
 ## Adding Models
 

--- a/p-models/durableactor/AGENTS.md
+++ b/p-models/durableactor/AGENTS.md
@@ -5,8 +5,10 @@
 Executable P model of the durable actor mailbox: durable enqueue, lease
 ownership, retry/backoff, ack/nack token validation, dead-letter, per-
 correlation-key FIFO, the Read/Commit exactly-once consume step, the Stage
-persist-before-broadcast primitive, and the CDC outbox/ingress folds. Treated
-as the ideal specification the Go implementation must conform to.
+persist-before-broadcast primitive, the CDC outbox/ingress folds, and the
+ingress dispatch deferral that keeps a full in-memory mailbox from parking the
+only mailbox puller. Treated as the ideal specification the Go implementation
+must conform to.
 
 ## Key Types
 
@@ -19,9 +21,22 @@ as the ideal specification the Go implementation must conform to.
 - `IngressCursorCoversOnlyCommittedEnvelopes` (`src/ingress_fold.p`) — spec
   monitor guarding the connection-actor ingress cursor: the persisted cursor
   must never cover an envelope whose local enqueue did not commit.
+- `IngressPipelineSpec` (`src/ingress_deferral.p`) — machine modeling the
+  ingress dispatch pipeline over its four destination kinds (durable target,
+  bounded in-memory target, hoisted nonTx request, waiter response), with the
+  redrive clamp, the served-request watermark, the per-invocation
+  `deliveredOutsideTx` record, store retries, and crash-restart.
+  `IngressPipelineConfig` selects the production profile or one of the three
+  pre-fix profiles.
 - Safety/liveness monitors (`src/mailbox_fifo.p`): `SameKeyFIFOClaimsRespectLiveHead`,
   `MailboxKeyedWorkEventuallyDrains`, `LeaseFencedCommitAppliesEffectAtMostOnce`,
   `StagedEffectAppliedAtMostOnceUnderReplay`, `CheckpointAdvancesMonotonically`.
+- Safety/liveness monitors (`src/ingress_deferral.p`):
+  `IngressCursorCoversOnlyHandledEnvelopes`,
+  `IngressMemoryTargetNoTxScopedDuplicate`,
+  `IngressMemoryTargetAtLeastOnceBounded`,
+  `IngressNonTxRequestServedOncePerIncarnation`, `IngressWriterNeverParks`,
+  `IngressBacklogEventuallyDrains`.
 
 ## Relationships
 
@@ -35,7 +50,11 @@ as the ideal specification the Go implementation must conform to.
 
 - Keep the default P test case green; put intentional known-bad checks in a
   separate "Counterexample" test case (`test/mailbox_fifo_test.p`,
-  `test/ingress_fold_test.p`).
+  `test/ingress_fold_test.p`, `test/ingress_deferral_test.p`).
+- A known-bad behavior belongs in a profile field the production test case
+  does NOT set, not in a hand-written counterexample driver: flipping one
+  field is what proves the green suite and the counterexample check the same
+  code path.
 - `0` is the model's NULL correlation key; non-zero keys are per-lane FIFO
   domains scoped by mailbox id.
 - Every safety/liveness monitor above is opt-in per test case (`assert <spec>

--- a/p-models/durableactor/CLAUDE.md
+++ b/p-models/durableactor/CLAUDE.md
@@ -5,8 +5,10 @@
 Executable P model of the durable actor mailbox: durable enqueue, lease
 ownership, retry/backoff, ack/nack token validation, dead-letter, per-
 correlation-key FIFO, the Read/Commit exactly-once consume step, the Stage
-persist-before-broadcast primitive, and the CDC outbox/ingress folds. Treated
-as the ideal specification the Go implementation must conform to.
+persist-before-broadcast primitive, the CDC outbox/ingress folds, and the
+ingress dispatch deferral that keeps a full in-memory mailbox from parking the
+only mailbox puller. Treated as the ideal specification the Go implementation
+must conform to.
 
 ## Key Types
 
@@ -19,9 +21,22 @@ as the ideal specification the Go implementation must conform to.
 - `IngressCursorCoversOnlyCommittedEnvelopes` (`src/ingress_fold.p`) — spec
   monitor guarding the connection-actor ingress cursor: the persisted cursor
   must never cover an envelope whose local enqueue did not commit.
+- `IngressPipelineSpec` (`src/ingress_deferral.p`) — machine modeling the
+  ingress dispatch pipeline over its four destination kinds (durable target,
+  bounded in-memory target, hoisted nonTx request, waiter response), with the
+  redrive clamp, the served-request watermark, the per-invocation
+  `deliveredOutsideTx` record, store retries, and crash-restart.
+  `IngressPipelineConfig` selects the production profile or one of the three
+  pre-fix profiles.
 - Safety/liveness monitors (`src/mailbox_fifo.p`): `SameKeyFIFOClaimsRespectLiveHead`,
   `MailboxKeyedWorkEventuallyDrains`, `LeaseFencedCommitAppliesEffectAtMostOnce`,
   `StagedEffectAppliedAtMostOnceUnderReplay`, `CheckpointAdvancesMonotonically`.
+- Safety/liveness monitors (`src/ingress_deferral.p`):
+  `IngressCursorCoversOnlyHandledEnvelopes`,
+  `IngressMemoryTargetNoTxScopedDuplicate`,
+  `IngressMemoryTargetAtLeastOnceBounded`,
+  `IngressNonTxRequestServedOncePerIncarnation`, `IngressWriterNeverParks`,
+  `IngressBacklogEventuallyDrains`.
 
 ## Relationships
 
@@ -35,7 +50,11 @@ as the ideal specification the Go implementation must conform to.
 
 - Keep the default P test case green; put intentional known-bad checks in a
   separate "Counterexample" test case (`test/mailbox_fifo_test.p`,
-  `test/ingress_fold_test.p`).
+  `test/ingress_fold_test.p`, `test/ingress_deferral_test.p`).
+- A known-bad behavior belongs in a profile field the production test case
+  does NOT set, not in a hand-written counterexample driver: flipping one
+  field is what proves the green suite and the counterexample check the same
+  code path.
 - `0` is the model's NULL correlation key; non-zero keys are per-lane FIFO
   domains scoped by mailbox id.
 - Every safety/liveness monitor above is opt-in per test case (`assert <spec>

--- a/p-models/durableactor/README.md
+++ b/p-models/durableactor/README.md
@@ -85,6 +85,53 @@ two ways it can go wrong: the unstable profile re-derives a fresh broadcast id
 on replay (a second distinct broadcast), and the unfenced profile lets the stale
 consumer overwrite a newer checkpoint with an older level (a regression).
 
+### Ingress dispatch deferral and redrive
+
+`src/ingress_deferral.p` models the connection actor's ingress dispatch
+pipeline (`serverconn/ingress.go`, `dispatch_deferral.go`,
+`dispatch_replay.go`). Where `src/ingress_fold.p` treats every dispatch as a
+durable enqueue that lives and dies with the write transaction, this model
+takes the four destinations apart, because only one of them is transactional:
+
+| Kind | When it lands | Survives a rollback |
+|---|---|---|
+| `IngressDurableTarget` | inside the write transaction | no |
+| `IngressMemoryTarget` | `TryTell` into a fixed-capacity mailbox, from inside the transaction but not in it | yes |
+| `IngressNonTxRequest` | answered over the network before the transaction opens | yes, and it left the process |
+| `IngressWaiterResponse` | handed to a live in-memory waiter before the transaction | yes |
+
+The bounded in-memory target is the one that can refuse. A full mailbox
+defers: the cursor commits at the deferred envelope's own sequence number, so
+the prefix is acked and the deferred envelope is not, and the redrive re-pulls
+from there with the batch clamped and the served-request watermark applied.
+
+`IngressPipelineConfig` is the profile switch that makes the model falsifiable.
+The production profile is `(NonParkingDeferral, track_tx_deliveries = true,
+served_watermark = true)`; each counterexample flips exactly one field:
+
+- `ParkingBlockingSend` is the shipped bug — a blocking send into a full
+  fixed-capacity mailbox from inside the write transaction, which parks the
+  process's only mailbox puller with the database's single writer held, and
+  logs nothing.
+- `track_tx_deliveries = false` removes `deliveredOutsideTx`, so a store that
+  replays its transaction body after a retryable error hands the same envelope
+  to the bounded target once per attempt. The durable half replays harmlessly
+  because the rollback undid it; the `TryTell` does not.
+- `served_watermark = false` removes `redriveState.servedNonTxSeq`, so a
+  hoisted request that sits in the pull window while an unrelated actor stays
+  wedged is answered once per backoff cycle.
+
+The model states the residual honestly rather than asserting it away: a nonTx
+request is answered ahead of the commit, so a crash in between genuinely
+repeats it. `IngressNonTxRequestServedOncePerIncarnation` keys on the process
+incarnation for exactly that reason, and rejects only a repeat within one
+lifetime.
+
+It also declines to flatter the implementation. Removing the redrive clamp
+while keeping the watermark breaks no property here, because the second answer
+the clamp would prevent is the one the watermark suppresses. The clamp earns
+its place as a bound on repeated work, not as a second safety net.
+
 ### Spec monitors
 
 P does **not** activate spec monitors globally; each test case attaches the
@@ -132,6 +179,40 @@ ones it wants with `assert <spec> in { ... }`.
   the negative `tcMailboxStaleStageRegressesCounterexample` runs the unfenced
   profile with no in-machine assertion, so the checkpoint regression is raised
   solely by this monitor — the lost-update the lease fence prevents.
+- `IngressCursorCoversOnlyCommittedEnvelopes` is the ingress cursor contract:
+  a persisted cursor never covers an envelope whose local enqueue did not
+  commit. `tcIngressFoldNoLoss` checks it; the two negatives
+  `tcIngressEagerCursorCounterexample` and
+  `tcIngressCheckpointFirstCounterexample` run the two ordering bugs it exists
+  to catch.
+- `IngressCursorCoversOnlyHandledEnvelopes` is its delivery-side companion,
+  strengthened to cover the three non-transactional paths as well: the
+  committed cursor may only cover envelopes some target actually received.
+  This is what rejects a cursor running past an envelope a full mailbox
+  refused, which is how backpressure turns into loss.
+- `IngressMemoryTargetNoTxScopedDuplicate` and
+  `IngressMemoryTargetAtLeastOnceBounded` bound the duplicates. The first says
+  a bounded in-memory target never sees an envelope twice within one folded
+  dispatch, however many times the store replays the transaction body; the
+  second says redelivery across redrives and crashes happens at most once per
+  epoch, so the duplicate count is bounded by how many times the loop went
+  around. Both catch the missing `deliveredOutsideTx` record independently,
+  via `tcIngressUntrackedRetryDuplicateCounterexample` and
+  `tcIngressMonitorCatchesRetryDuplicate`.
+- `IngressNonTxRequestServedOncePerIncarnation` bounds the one delivery that
+  leaves the process before the commit. Removing the watermark
+  (`tcIngressUnwatermarkedServeCounterexample`) gets a second answer sent to a
+  request the operator had already had answered.
+- `IngressWriterNeverParks` is the headline property: delivery into a bounded
+  in-memory mailbox must never block the ingress goroutine, because it is the
+  process's only consumer of the remote mailbox and it holds the database's
+  single writer while it works. `tcIngressParkedWriterCounterexample` reaches
+  the park on the first full mailbox.
+- `IngressBacklogEventuallyDrains` is the progress half: deferring must delay
+  the stream, never stop it. `tcIngressDeferralLiveness` checks it holds, and
+  `tcIngressParkedWriterStarvesCounterexample` runs the same wedge under it so
+  the failure also shows up the way an operator sees it — the cursor stops
+  advancing and the stream never drains.
 
 The Go bridge in `bridge/` replays JSON model traces from `traces/` against the real
 `db/actordelivery` SQLite store. This keeps the P model tied to the SQL claim
@@ -163,8 +244,9 @@ Two representational details matter when writing P scenarios or bridge traces:
 ./p-models/scripts/check.sh
 ```
 
-The script compiles `durableactor/infra.pproj`, checks
-`tcMailboxCorrelationKeyFIFO`, then runs the Go bridge tests.
+The script compiles `durableactor/infra.pproj`, runs every green test case
+and every counterexample test case, then runs the Go bridge tests. A
+counterexample that finds no bug fails the script.
 
 To demonstrate that the model would have found the original bug, run:
 

--- a/p-models/durableactor/infra.pproj
+++ b/p-models/durableactor/infra.pproj
@@ -3,8 +3,10 @@
 <InputFiles>
 <PFile>src/mailbox_fifo.p</PFile>
 <PFile>src/ingress_fold.p</PFile>
+<PFile>src/ingress_deferral.p</PFile>
 <PFile>test/mailbox_fifo_test.p</PFile>
 <PFile>test/ingress_fold_test.p</PFile>
+<PFile>test/ingress_deferral_test.p</PFile>
 </InputFiles>
 <OutputDir>PGenerated</OutputDir>
 </Project>

--- a/p-models/durableactor/src/ingress_deferral.p
+++ b/p-models/durableactor/src/ingress_deferral.p
@@ -1,0 +1,800 @@
+// ingress_deferral.p - Ingress dispatch deferral and redrive specification.
+//
+// ingress_fold.p pins down the cursor half of the connection actor's ingress
+// loop: the persisted cursor may never cover an envelope whose local enqueue
+// did not commit. This model pins down the delivery half, which the fold
+// model deliberately abstracted away by treating every dispatch as a durable
+// enqueue that lives and dies with the transaction.
+//
+// It does not. The dispatch table has four kinds of destination, and only one
+// of them is transactional:
+//
+//   * A DURABLE target is enqueued inside the write transaction, so its
+//     delivery commits with the cursor and rolls back with it.
+//
+//   * An IN-MEMORY target is a fixed-capacity actor mailbox. It is delivered
+//     to with TryTell, so the send never parks, but the delivery is NOT in
+//     the transaction: the target may have processed the message before the
+//     transaction even tries to commit, and a rollback does not take it back.
+//     A full mailbox is refused, which is a deferral rather than a failure.
+//
+//   * A nonTx REQUEST is answered over the network BEFORE the transaction
+//     opens, because a round trip must never run under the writer lock. The
+//     response is externally visible and cannot be recalled.
+//
+//   * A WAITER RESPONSE is handed to a live in-memory unary waiter, also
+//     before the transaction and for the same reason.
+//
+// The contract this model states:
+//
+//   * No acked loss. The committed cursor may only cover envelopes that were
+//     actually handled by one of the four paths. A deferral therefore commits
+//     the prefix and stops AT the undelivered envelope, so the redrive
+//     re-pulls it.
+//
+//   * No transaction-scoped duplicate. The store may run the transaction body
+//     more than once before it commits (a retryable SQLITE_BUSY or Postgres
+//     40001). The durable enqueues replay harmlessly because the rollback
+//     undid them; the TryTells do not, so a per-invocation record of what was
+//     already handed over suppresses the repeat.
+//
+//   * Bounded at-least-once. Across redrives and crashes an in-memory target
+//     may see an envelope again, because redelivery is the documented
+//     recovery, but at most once per redrive/crash epoch. Any more than that
+//     is duplicate work the loop created for itself.
+//
+//   * A nonTx request is served at most once per process incarnation. The
+//     serve happens ahead of the commit, so a crash in between genuinely can
+//     repeat it: that residual is accepted and encoded, not asserted away.
+//     What is NOT accepted is one serve per backoff cycle for as long as an
+//     unrelated actor stays wedged, which is what the loop does without the
+//     clamp and the served watermark.
+//
+//   * The writer never parks. A full in-memory mailbox must produce a
+//     deferral, never a blocking send, and above all never a blocking send
+//     from inside the write transaction.
+//
+//   * Progress. If the in-memory target eventually keeps up, the cursor
+//     eventually reaches the end of the stream.
+//
+// The pre-fix implementation is reachable through IngressPipelineConfig, so
+// the model can be shown to catch the bugs it exists for rather than merely
+// agreeing with the fixed code. Three independent knobs, three failures:
+// ParkingBlockingSend wedges the writer, a cleared track_tx_deliveries
+// duplicates in-memory deliveries across store retries, and a cleared
+// served_watermark re-answers a request once per backoff cycle.
+//
+// Two things are deliberately out of scope. The straggler re-fold (a waiter
+// that vanishes between the split peek and the delivery, so its response
+// folds back into the durable batch) is a cursor-ordering property, which is
+// exactly what ingress_fold.p already covers. And a park is terminal here:
+// the model exists to show the park is reachable at all, so it stops at the
+// first one rather than modeling what would release it.
+
+// IngressDispatchMode selects how a delivery to a FULL bounded in-memory
+// mailbox behaves.
+//
+//   * NonParkingDeferral (production): the send is refused, the envelope is
+//     left undelivered and unacked, and the loop commits the prefix before it
+//     and re-pulls from the deferred envelope after a backoff.
+//
+//   * ParkingBlockingSend (counterexample): the send blocks until the target
+//     drains, which on the folded path means the process's only mailbox
+//     puller is parked with the database's single writer held. This is the
+//     shipped behavior that made a deployed client go permanently deaf with
+//     nothing logged.
+enum IngressDispatchMode {
+    NonParkingDeferral,
+    ParkingBlockingSend
+}
+
+// IngressEnvelopeKind is the destination class of an envelope, which is what
+// decides whether its delivery is inside the transaction, survives a
+// rollback, or is visible outside the process entirely.
+enum IngressEnvelopeKind {
+    IngressDurableTarget,
+    IngressMemoryTarget,
+    IngressNonTxRequest,
+    IngressWaiterResponse
+}
+
+// IngressStepResult reports what one pull-dispatch-commit cycle did, so the
+// driver can decide what to do next without reaching into the pipeline's
+// state.
+enum IngressStepResult {
+    // IngressStepCommitted: the whole clamped batch was handled and the
+    // cursor advanced past it.
+    IngressStepCommitted,
+
+    // IngressStepDeferred: a full in-memory mailbox stopped the batch. The
+    // prefix committed and the cursor sits on the undelivered envelope.
+    IngressStepDeferred,
+
+    // IngressStepRolledBack: the transaction failed outright, so nothing
+    // committed and the cursor did not move.
+    IngressStepRolledBack,
+
+    // IngressStepParked: a blocking send met a full mailbox and the ingress
+    // goroutine is wedged. Only reachable under ParkingBlockingSend.
+    IngressStepParked,
+
+    // IngressStepDrained: the cursor already passed the end of the stream.
+    IngressStepDrained
+}
+
+// IngressPipelineConfig selects the implementation profile under test. The
+// production profile is (NonParkingDeferral, true, true); each of the three
+// counterexamples flips exactly one field.
+type IngressPipelineConfig = (
+    // mode selects the deferral or the pre-fix blocking send.
+    mode: IngressDispatchMode,
+
+    // track_tx_deliveries is the per-invocation record of what was already
+    // handed to a bounded mailbox (deliveredOutsideTx). Cleared, a store that
+    // replays its transaction body hands the same envelope over once per
+    // attempt.
+    track_tx_deliveries: bool,
+
+    // served_watermark is the highest already-answered nonTx request
+    // (redriveState.servedNonTxSeq). Cleared, a request that sits in the pull
+    // window while a deferral is outstanding is answered again on every
+    // redrive.
+    served_watermark: bool,
+
+    // capacity is the bounded in-memory mailbox's size.
+    capacity: int
+);
+
+// IngressStepReq drives one pull-dispatch-commit cycle.
+type IngressStepReq = (
+    reply_to: machine,
+
+    // batch is how many envelopes the pull asks for, before the redrive
+    // clamp narrows it.
+    batch: int,
+
+    // attempts is how many times the store runs the transaction body. Every
+    // attempt but the last rolls back, modeling a retryable store error.
+    attempts: int,
+
+    // commits is whether the final attempt commits. False is the fold that
+    // fails outright: nothing durable lands and the cursor does not move,
+    // while any TryTell the body already did stands.
+    commits: bool
+);
+
+// IngressDrainReq models the target actor catching up on its own mailbox.
+type IngressDrainReq = (
+    reply_to: machine,
+    count: int
+);
+
+event eIngressStep: IngressStepReq;
+event eIngressDrain: IngressDrainReq;
+// eIngressCrash models the whole client process going down and coming back.
+// Its payload is the reply target, unwrapped: a one-field request record
+// would carry no more information than the machine reference itself.
+event eIngressCrash: machine;
+
+// eIngressStepResp answers every pipeline request with the outcome and the
+// committed cursor.
+event eIngressStepResp: (IngressStepResult, int);
+
+// eIngressEnvelopeHandled announces that an envelope reached its destination
+// by whichever of the four paths owns it: a committed durable enqueue, a
+// TryTell a bounded mailbox accepted, a nonTx request answered over the
+// network, or a response handed to a live waiter. It carries (pipeline, seq).
+// A rolled-back durable enqueue is NOT handled, which is the whole point of
+// announcing on commit rather than on dispatch.
+event eIngressEnvelopeHandled: (machine, int);
+
+// eIngressCursorCommitted announces a durably committed exclusive cursor,
+// carrying (pipeline, cursor).
+event eIngressCursorCommitted: (machine, int);
+
+// eIngressMemoryDelivered announces a TryTell that a bounded in-memory
+// mailbox accepted, carrying (pipeline, seq, fold, epoch). fold is the
+// invocation of the folded dispatch it happened in, which is the scope the
+// per-invocation record covers; epoch is the redrive/crash cycle, which is
+// the scope the at-least-once bound is stated over.
+event eIngressMemoryDelivered: (machine, int, int, int);
+
+// eIngressNonTxServed announces a hoisted request answered over the network,
+// carrying (pipeline, seq, incarnation). The incarnation is the process
+// lifetime: a repeat within one incarnation is the bug, a repeat across a
+// restart is the accepted residual of serving ahead of the commit.
+event eIngressNonTxServed: (machine, int, int);
+
+// eIngressWriterParked announces a blocking send that met a full mailbox,
+// carrying (pipeline, seq). Under the production profile it is unreachable.
+event eIngressWriterParked: (machine, int);
+
+// eIngressBacklogArrived and eIngressBacklogDrained feed the progress
+// monitor: one arrival per envelope in the stream, one drain per envelope the
+// committed cursor passes. They are kept distinct from the delivery events so
+// the safety cases, which intentionally end with the stream unfinished, leave
+// the liveness monitor inert in its cold start state.
+event eIngressBacklogArrived;
+event eIngressBacklogDrained;
+
+// IngressStreamTotal is the number of envelopes on the remote mailbox. The
+// stream is small on purpose: every property here is about the ORDER of a
+// deferral relative to the other three delivery paths, not about volume, and
+// a short stream keeps the schedule count CI can afford meaningful.
+fun IngressStreamTotal(): int {
+    return 5;
+}
+
+// IngressStreamKind is the remote mailbox's ordered stream. The layout is
+// chosen so that one deferral exercises every interaction that matters:
+//
+//   1: in-memory target  - fills the bounded mailbox
+//   2: durable target    - the prefix that must still commit under a deferral
+//   3: in-memory target  - the deferral point, behind a full mailbox
+//   4: nonTx request     - PAST the deferral point, so it is answered
+//                          optimistically while the cursor stops short of it
+//                          and it stays in the pull window across redrives
+//   5: waiter response   - delivered in-memory ahead of the transaction
+//
+// Envelope 4 sitting after envelope 3 is the load-bearing part: it is the
+// only arrangement in which the redrive clamp and the served watermark are
+// both needed, and dropping either one repeats a network answer.
+fun IngressStreamKind(eventSeq: int): IngressEnvelopeKind {
+    if (eventSeq == 1 || eventSeq == 3) {
+        return IngressMemoryTarget;
+    }
+
+    if (eventSeq == 2) {
+        return IngressDurableTarget;
+    }
+
+    if (eventSeq == 4) {
+        return IngressNonTxRequest;
+    }
+
+    return IngressWaiterResponse;
+}
+
+fun IngressMinInt(a: int, b: int): int {
+    if (a < b) {
+        return a;
+    }
+
+    return b;
+}
+
+// IngressDeferredCursor is the cursor to commit when a full mailbox stopped a
+// batch partway. The deferred envelope's own sequence number is exactly where
+// the exclusive cursor belongs: everything ahead of it has been handled by
+// the time the deferral is raised, and the deferred envelope itself has not.
+// The cursor never moves backwards, so a re-pull of already-committed
+// envelopes cannot rewind it.
+fun IngressDeferredCursor(deferredSeq: int, pullCursor: int): int {
+    if (deferredSeq <= pullCursor) {
+        return pullCursor;
+    }
+
+    return deferredSeq;
+}
+
+// IngressPipelineSpec is the idealized ingress dispatch pipeline: the remote
+// mailbox's ordered stream, the loop's committed cursor and its loop-local
+// redrive state, and the one bounded in-memory mailbox every deferral in this
+// model comes from.
+//
+// It is a single machine rather than a puller plus a target actor because the
+// properties under test are all about what ONE goroutine does in what order.
+// The real ingress loop is a single dedicated goroutine with no pool, so
+// interleaving a second puller would model a concurrency that does not exist.
+// The target actor's independence is captured by eIngressDrain instead: the
+// driver decides when it catches up, including never.
+machine IngressPipelineSpec {
+    var mode: IngressDispatchMode;
+    var trackTxDeliveries: bool;
+    var servedWatermark: bool;
+    var capacity: int;
+    var total: int;
+
+    // cursor is the durable exclusive pull cursor: the only state that
+    // survives a crash.
+    var cursor: int;
+
+    // occupancy is how full the bounded in-memory mailbox is.
+    var occupancy: int;
+
+    // deferredSeq and servedSeq are redriveState: loop-local, lost on
+    // restart, and the two things that keep a redrive from repeating the
+    // previous cycle's work.
+    var deferredSeq: int;
+    var servedSeq: int;
+
+    // incarnation counts process lifetimes, epoch counts redrive-or-crash
+    // cycles, and fold counts folded-dispatch invocations. Each is the scope
+    // of one duplicate-suppression contract.
+    var incarnation: int;
+    var epoch: int;
+    var fold: int;
+
+    // parked records that a blocking send wedged the loop. It is sticky: the
+    // model stops at the first park rather than modeling recovery.
+    var parked: bool;
+
+    // txDelivered is deliveredOutsideTx: the envelopes this fold invocation
+    // already handed to the bounded mailbox. It is reset per invocation on
+    // purpose. A record that spanned invocations would suppress the FIRST
+    // delivery of an envelope whose earlier cycle rolled back after the
+    // TryTell, trading a benign duplicate for a silent loss.
+    var txDelivered: map[int, bool];
+
+    // drainedSeq remembers which envelopes the progress monitor has already
+    // been told about, so a cursor that advances twice does not announce the
+    // same envelope twice.
+    var drainedSeq: map[int, bool];
+
+    start state Active {
+        entry (cfg: IngressPipelineConfig) {
+            var s: int;
+
+            mode = cfg.mode;
+            trackTxDeliveries = cfg.track_tx_deliveries;
+            servedWatermark = cfg.served_watermark;
+            capacity = cfg.capacity;
+            total = IngressStreamTotal();
+
+            cursor = 1;
+            incarnation = 1;
+
+            s = 1;
+            while (s <= total) {
+                announce eIngressBacklogArrived;
+                s = s + 1;
+            }
+        }
+
+        on eIngressStep do (req: IngressStepReq) {
+            var result: IngressStepResult;
+
+            result = RunStep(req.batch, req.attempts, req.commits);
+            send req.reply_to, eIngressStepResp, (result, cursor);
+        }
+
+        on eIngressDrain do (req: IngressDrainReq) {
+            var n: int;
+
+            // The target actor works through its own mailbox. Nothing here
+            // releases a park: a parked loop stays parked, because the model
+            // stops at the first one.
+            n = req.count;
+            while (n > 0 && occupancy > 0) {
+                occupancy = occupancy - 1;
+                n = n - 1;
+            }
+
+            send req.reply_to, eIngressStepResp,
+                (IngressStepDrained, cursor);
+        }
+
+        on eIngressCrash do (replyTo: machine) {
+            // A restart rebuilds from the committed cursor and nothing else.
+            // Every piece of loop-local state goes, and so does the target
+            // actor's in-memory mailbox, because the whole process went down
+            // with it. That is also why a crash is the one thing that clears
+            // a wedged target: it is the operator's restart-fixes-it.
+            incarnation = incarnation + 1;
+            epoch = epoch + 1;
+            deferredSeq = 0;
+            servedSeq = 0;
+            occupancy = 0;
+            txDelivered = default(map[int, bool]);
+
+            send replyTo, eIngressStepResp, (IngressStepDrained, cursor);
+        }
+    }
+
+    // RunStep is one turn of the pull-dispatch-commit loop: pull a batch from
+    // the cursor, narrow it to what a previous deferral left outstanding, do
+    // the pre-transaction work, then run the transaction body until the store
+    // stops retrying it.
+    fun RunStep(batch: int, attempts: int, commits: bool): IngressStepResult {
+        var pullEnd: int;
+        var nextCursor: int;
+        var clampEnd: int;
+        var attempt: int;
+        var deferredAt: int;
+        var committing: bool;
+
+        if (parked) {
+            return IngressStepParked;
+        }
+
+        if (cursor > total) {
+            return IngressStepDrained;
+        }
+
+        fold = fold + 1;
+
+        pullEnd = IngressMinInt(cursor + batch - 1, total);
+        nextCursor = pullEnd + 1;
+
+        // Clamp a redriven batch to the envelopes at or before the one a full
+        // mailbox turned away last cycle. Nothing past it can commit until it
+        // is delivered, so handling the rest again is pure duplicate effort —
+        // and for a nonTx request that duplicate effort is a second answer
+        // sent to the operator. A batch with nothing at or before the
+        // deferred envelope is left whole: that envelope is no longer on the
+        // mailbox, so there is nothing left to protect, and clamping to an
+        // empty batch would let the cursor advance over envelopes nobody
+        // dispatched.
+        //
+        // The clamp and the served watermark overlap here, and the model says
+        // so rather than flattering both: with the watermark in place,
+        // removing the clamp breaks no property above, because the second
+        // answer it would allow is the one the watermark suppresses. The
+        // clamp earns its place as a bound on repeated WORK — a redrive that
+        // re-walks the whole window every backoff cycle for as long as a
+        // target stays wedged — and as the guard that still holds if a future
+        // hoisted route needs per-envelope state the watermark cannot
+        // summarize.
+        if (deferredSeq != 0) {
+            clampEnd = IngressMinInt(pullEnd, deferredSeq);
+            if (clampEnd >= cursor && clampEnd < pullEnd) {
+                pullEnd = clampEnd;
+                nextCursor = deferredSeq + 1;
+            }
+        }
+
+        RunPreTx(pullEnd);
+
+        // The record is created out here, OUTSIDE the transaction, so a
+        // replayed body can see what the previous attempt already handed to
+        // the bounded mailbox and skip it.
+        txDelivered = default(map[int, bool]);
+
+        deferredAt = 0;
+        attempt = 1;
+        while (attempt <= attempts) {
+            committing = commits && attempt == attempts;
+            deferredAt = RunTxBody(pullEnd, nextCursor, committing);
+
+            if (parked) {
+                return IngressStepParked;
+            }
+
+            attempt = attempt + 1;
+        }
+
+        if (!commits) {
+            // The fold failed outright. The cursor did not move and the
+            // loop-local deferral state is untouched, so the next cycle
+            // re-pulls the same window.
+            epoch = epoch + 1;
+
+            return IngressStepRolledBack;
+        }
+
+        if (deferredAt != 0) {
+            deferredSeq = deferredAt;
+            epoch = epoch + 1;
+
+            return IngressStepDeferred;
+        }
+
+        deferredSeq = 0;
+
+        return IngressStepCommitted;
+    }
+
+    // RunPreTx does the half of the fold that happens with no transaction
+    // open, because neither part of it may run under the writer lock: a
+    // waiter is an RPC caller sitting on a deadline, and a hoisted request is
+    // a full network round trip.
+    //
+    // Both are irrevocable. A response has left the process by the time the
+    // transaction opens, which is why the cursor commit that follows can only
+    // ever repeat them, never take them back.
+    fun RunPreTx(pullEnd: int) {
+        var s: int;
+        var kind: IngressEnvelopeKind;
+
+        s = cursor;
+        while (s <= pullEnd) {
+            kind = IngressStreamKind(s);
+
+            if (kind == IngressWaiterResponse) {
+                announce eIngressEnvelopeHandled, (this, s);
+            } else if (kind == IngressNonTxRequest) {
+                // Already answered by an earlier cycle of this episode. The
+                // cursor has not passed it yet, so the mailbox keeps handing
+                // it back; answering again would send the operator a second
+                // response to a request it has already had answered.
+                if (!(servedWatermark && s <= servedSeq)) {
+                    announce eIngressNonTxServed, (this, s, incarnation);
+                    announce eIngressEnvelopeHandled, (this, s);
+                }
+
+                if (s > servedSeq) {
+                    servedSeq = s;
+                }
+            }
+
+            s = s + 1;
+        }
+    }
+
+    // RunTxBody is one attempt at the write transaction: the durable prefix,
+    // the TryTells into the bounded mailbox, and the cursor commit. It
+    // returns the sequence number a full mailbox turned away, or zero.
+    //
+    // The asymmetry between the two target kinds is the whole model. A
+    // durable enqueue is only observable when the attempt commits, because a
+    // rolled-back attempt undid it. A TryTell is observable the moment it is
+    // accepted, because it was never in the transaction to begin with.
+    fun RunTxBody(pullEnd: int, nextCursor: int, commit: bool): int {
+        var s: int;
+        var kind: IngressEnvelopeKind;
+        var cursorForCommit: int;
+        var deferredAt: int;
+
+        cursorForCommit = nextCursor;
+        deferredAt = 0;
+
+        s = cursor;
+        while (s <= pullEnd && deferredAt == 0) {
+            kind = IngressStreamKind(s);
+
+            if (kind == IngressDurableTarget) {
+                if (commit) {
+                    announce eIngressEnvelopeHandled, (this, s);
+                }
+            } else if (kind == IngressMemoryTarget) {
+                if (!(trackTxDeliveries && (s in txDelivered))) {
+                    if (occupancy < capacity) {
+                        occupancy = occupancy + 1;
+                        txDelivered[s] = true;
+
+                        announce eIngressMemoryDelivered,
+                            (this, s, fold, epoch);
+                        announce eIngressEnvelopeHandled, (this, s);
+                    } else if (mode == ParkingBlockingSend) {
+                        // The pre-fix path: a blocking send into a full
+                        // fixed-capacity mailbox, from inside the write
+                        // transaction. The only ingress goroutine in the
+                        // process is now wedged with the single writer held,
+                        // and nothing logs.
+                        parked = true;
+                        announce eIngressWriterParked, (this, s);
+
+                        return 0;
+                    } else {
+                        // Backpressure, not a failed batch: the envelope is
+                        // intact on the remote mailbox and the loop re-pulls
+                        // it. Commit up to it and stop, because acking past
+                        // an event that never reached its actor is how
+                        // backpressure turns into a lost round event.
+                        deferredAt = s;
+                        cursorForCommit = IngressDeferredCursor(s, cursor);
+                    }
+                }
+            }
+
+            s = s + 1;
+        }
+
+        if (commit) {
+            cursor = cursorForCommit;
+
+            AnnounceDrainedBelow(cursor);
+            announce eIngressCursorCommitted, (this, cursor);
+        }
+
+        return deferredAt;
+    }
+
+    // AnnounceDrainedBelow tells the progress monitor about every envelope
+    // the committed cursor has now passed, once each.
+    fun AnnounceDrainedBelow(c: int) {
+        var s: int;
+
+        s = 1;
+        while (s < c) {
+            if (!(s in drainedSeq)) {
+                drainedSeq[s] = true;
+                announce eIngressBacklogDrained;
+            }
+
+            s = s + 1;
+        }
+    }
+}
+
+// IngressCursorCoversOnlyHandledEnvelopes is the no-acked-loss safety
+// property, and the reason the deferral commits the prefix instead of the
+// batch. Whenever a cursor c is committed, every envelope below it must have
+// been handled by one of the four delivery paths. A violation means the loop
+// acked an envelope nobody received, and the remote mailbox is then free to
+// garbage-collect it: the round event is gone for good.
+//
+// This is the delivery-side companion to
+// IngressCursorCoversOnlyCommittedEnvelopes in ingress_fold.p, which states
+// the same shape for the transactional half alone. The strengthening is that
+// "handled" here also covers the three paths that are NOT in the transaction,
+// so the monitor rejects a cursor that ran past an envelope a full mailbox
+// refused — the way backpressure turns into loss.
+spec IngressCursorCoversOnlyHandledEnvelopes observes
+    eIngressEnvelopeHandled, eIngressCursorCommitted {
+
+    var handled: map[(machine, int), bool];
+
+    start state Monitoring {
+        on eIngressEnvelopeHandled do (h: (machine, int)) {
+            handled[h] = true;
+        }
+
+        on eIngressCursorCommitted do (c: (machine, int)) {
+            var s: int;
+
+            s = 1;
+            while (s < c.1) {
+                assert (c.0, s) in handled,
+                    "committed cursor covers an envelope that no target "+
+                    "ever received (acked loss)";
+                s = s + 1;
+            }
+        }
+    }
+}
+
+// IngressMemoryTargetNoTxScopedDuplicate is the safety contract for the
+// per-invocation delivery record. A bounded in-memory target must not receive
+// the same envelope twice within ONE folded dispatch, no matter how many
+// times the store replays the transaction body.
+//
+// The failure it catches is invisible in production by construction: the
+// final attempt commits, the loop reports success, and the target quietly
+// processed the same round event once per retry. The store retries up to ten
+// times, so a contended writer turns one event into ten deliveries with
+// nothing logged.
+spec IngressMemoryTargetNoTxScopedDuplicate observes eIngressMemoryDelivered {
+    var delivered: map[(machine, int, int), bool];
+
+    start state Monitoring {
+        on eIngressMemoryDelivered do (d: (machine, int, int, int)) {
+            var key: (machine, int, int);
+
+            key = (d.0, d.1, d.2);
+
+            assert !(key in delivered),
+                "a bounded in-memory target received the same envelope "+
+                "twice within one folded dispatch (a replayed transaction "+
+                "body re-sent it)";
+
+            delivered[key] = true;
+        }
+    }
+}
+
+// IngressMemoryTargetAtLeastOnceBounded states the delivery bound the design
+// actually promises. Redelivery to an in-memory target is expected: the
+// cursor has not moved, the remote mailbox keeps handing the envelope back,
+// and the target has to absorb it. What is promised is that it happens at
+// most once per redrive-or-crash epoch, so the duplicate count is bounded by
+// how many times the loop went around rather than by how many internal steps
+// each cycle took.
+//
+// The monitor states that as a strictly increasing epoch per envelope, which
+// is stronger than counting: it rejects a second delivery in the SAME cycle
+// however the cycle produced it, whether from a replayed transaction body or
+// from a batch dispatched twice within one turn.
+spec IngressMemoryTargetAtLeastOnceBounded observes eIngressMemoryDelivered {
+    var lastEpoch: map[(machine, int), int];
+
+    start state Monitoring {
+        on eIngressMemoryDelivered do (d: (machine, int, int, int)) {
+            var key: (machine, int);
+
+            key = (d.0, d.1);
+
+            if (key in lastEpoch) {
+                assert d.3 > lastEpoch[key],
+                    "a bounded in-memory target received the same envelope "+
+                    "twice in one redrive epoch (at-least-once became "+
+                    "unbounded)";
+            }
+
+            lastEpoch[key] = d.3;
+        }
+    }
+}
+
+// IngressNonTxRequestServedOncePerIncarnation is the bound on the one thing
+// on this path that leaves the process before the commit. Hoisting a request
+// out of the transaction moves its answer ahead of the cursor, so a crash in
+// between leaves the cursor unmoved and the request is answered a second time
+// on the re-pull. That residual is REAL and is encoded here rather than
+// asserted away: the monitor keys on the process incarnation, so a repeat
+// after a restart is permitted by construction.
+//
+// What the monitor does reject is a repeat WITHIN one incarnation. Without
+// the redrive clamp and the served watermark, a request that sits in the pull
+// window while an unrelated actor stays wedged is answered once per backoff
+// cycle, indefinitely — a crash-bounded exposure turned into an unbounded
+// one. Everything hoisted today is a read, so the duplicate is merely waste;
+// the routes queued to be hoisted next are state-changing ones where it is
+// not.
+spec IngressNonTxRequestServedOncePerIncarnation observes eIngressNonTxServed {
+    var served: map[(machine, int, int), bool];
+
+    start state Monitoring {
+        on eIngressNonTxServed do (r: (machine, int, int)) {
+            var key: (machine, int, int);
+
+            key = (r.0, r.1, r.2);
+
+            assert !(key in served),
+                "a hoisted nonTx request was answered twice in one process "+
+                "incarnation (the redrive re-served it)";
+
+            served[key] = true;
+        }
+    }
+}
+
+// IngressWriterNeverParks is the headline safety property, and the one the
+// whole path was rebuilt for. Delivery into a bounded in-memory mailbox must
+// never block the ingress goroutine, because that goroutine is the process's
+// only consumer of the remote mailbox and, on the folded path, it holds the
+// database's single writer while it works.
+//
+// A park is therefore not a slowdown. It is a permanently deaf client that
+// still answers read RPCs, still reports healthy, and logs nothing — the
+// exact shape of two production incidents. The production profile cannot
+// reach the announcement at all; the ParkingBlockingSend profile reaches it
+// on the first full mailbox.
+spec IngressWriterNeverParks observes eIngressWriterParked {
+    start state Monitoring {
+        on eIngressWriterParked do (p: (machine, int)) {
+            assert false,
+                "ingress dispatch parked on a full in-memory mailbox: the "+
+                "only mailbox puller is wedged, holding the write "+
+                "transaction";
+        }
+    }
+}
+
+// IngressBacklogEventuallyDrains is the progress half of the trade-off.
+// Deferring rather than blocking is only the right answer if backpressure
+// DELAYS the stream instead of stopping it: a target that eventually keeps up
+// must let the cursor eventually reach the end.
+//
+// The pipeline announces one arrival per envelope at startup and one drain
+// per envelope the committed cursor passes, so a run that leaves the cursor
+// short leaves the monitor hot. A parked writer never commits again and never
+// drains anything, which is how the same wedge shows up here as a liveness
+// failure rather than a safety one.
+spec IngressBacklogEventuallyDrains observes
+    eIngressBacklogArrived, eIngressBacklogDrained {
+
+    var outstanding: int;
+
+    start cold state Idle {
+        ignore eIngressBacklogDrained;
+
+        on eIngressBacklogArrived do {
+            outstanding = outstanding + 1;
+            goto Draining;
+        }
+    }
+
+    hot state Draining {
+        on eIngressBacklogArrived do {
+            outstanding = outstanding + 1;
+        }
+
+        on eIngressBacklogDrained do {
+            outstanding = outstanding - 1;
+            if (outstanding == 0) {
+                goto Idle;
+            }
+        }
+    }
+}

--- a/p-models/durableactor/test/ingress_deferral_test.p
+++ b/p-models/durableactor/test/ingress_deferral_test.p
@@ -1,0 +1,344 @@
+// ingress_deferral_test.p - Ingress deferral and redrive specification tests.
+
+// TestIngressDeferral_BoundedMailboxRedriveNoLoss drives the production
+// profile through everything the ingress loop cannot control: how much of the
+// stream each pull asks for, how many times the store replays the transaction
+// body before it commits, whether the fold commits at all, whether the target
+// actor drains its bounded mailbox, and whether the whole client crashes
+// between two turns.
+//
+// The contract is that no interleaving of those may ack an envelope nobody
+// received, hand a bounded target the same envelope twice in one cycle, or
+// answer a hoisted request twice in one process lifetime — and that once the
+// target keeps up, the cursor reaches the end of the stream.
+//
+// The fault budget is what makes the run finite. While it lasts the driver
+// may skip a drain, crash, or fail a fold; once it is spent the target always
+// keeps up, so the loop is guaranteed to finish and the closing assertion is
+// a real progress check rather than a bound on patience.
+machine TestIngressDeferral_BoundedMailboxRedriveNoLoss {
+    var pipeline: IngressPipelineSpec;
+
+    start state Init {
+        entry {
+            var resp: (IngressStepResult, int);
+            var faultBudget: int;
+            var cycles: int;
+            var batch: int;
+            var attempts: int;
+            var commits: bool;
+            var total: int;
+            var capacity: int;
+
+            total = IngressStreamTotal();
+
+            // The target's mailbox is deliberately explored at both sizes the
+            // stream can tell apart, because the two expose different halves
+            // of the contract. At one it fills on the first in-memory
+            // envelope, so every deferral, redrive, and recovery is reachable.
+            // At two it only fills when something redelivers, so a replayed
+            // transaction body producing a second copy shows up as a
+            // duplicate rather than hiding behind a deferral.
+            capacity = 1;
+            if ($) {
+                capacity = 2;
+            }
+
+            pipeline = new IngressPipelineSpec((
+                mode = NonParkingDeferral,
+                track_tx_deliveries = true,
+                served_watermark = true,
+                capacity = capacity
+            ));
+
+            resp = (IngressStepCommitted, 1);
+            faultBudget = 2;
+            cycles = 0;
+
+            while (resp.1 <= total && cycles < 16) {
+                cycles = cycles + 1;
+
+                // The target actor either keeps up or does not. Not keeping
+                // up is what fills the bounded mailbox and produces the
+                // backpressure episode.
+                if (faultBudget > 0 && $) {
+                    faultBudget = faultBudget - 1;
+                } else {
+                    send pipeline, eIngressDrain, (
+                        reply_to = this, count = 2
+                    );
+                    receive { case eIngressStepResp:
+                        (r0: (IngressStepResult, int)) { resp = r0; }
+                    }
+                }
+
+                // Crash the whole client between two turns. The committed
+                // cursor is the only survivor: the redrive clamp, the served
+                // watermark, and the target's mailbox all go.
+                if (faultBudget > 0 && $) {
+                    faultBudget = faultBudget - 1;
+
+                    send pipeline, eIngressCrash, this;
+                    receive { case eIngressStepResp:
+                        (r1: (IngressStepResult, int)) { resp = r1; }
+                    }
+                }
+
+                batch = 1;
+                if ($) {
+                    batch = 2;
+                } else if ($) {
+                    batch = 3;
+                }
+
+                // A second attempt is the store replaying its transaction
+                // body after a retryable error. The durable half of the first
+                // attempt rolled back; the TryTells it already did did not.
+                attempts = 1;
+                if ($) {
+                    attempts = 2;
+                }
+
+                commits = true;
+                if (faultBudget > 0 && $) {
+                    faultBudget = faultBudget - 1;
+                    commits = false;
+                }
+
+                send pipeline, eIngressStep, (
+                    reply_to = this,
+                    batch = batch,
+                    attempts = attempts,
+                    commits = commits
+                );
+                receive { case eIngressStepResp:
+                    (r2: (IngressStepResult, int)) { resp = r2; }
+                }
+            }
+
+            assert resp.1 > total,
+                "ingress redrive never reached the end of the stream even "+
+                "though the target caught up";
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// TestIngressDeferral_ParkingSendWedgesWriterCounterexample reproduces the
+// shipped bug. The batch fills the cap-one mailbox at envelope 1 and meets it
+// full at envelope 3, and the pre-fix profile answers that with a blocking
+// send from inside the write transaction. The only ingress goroutine in the
+// process is wedged there forever, holding the single writer, with nothing
+// logged.
+//
+// There is no in-machine assertion: the park is raised solely by
+// IngressWriterNeverParks, and the same run leaves
+// IngressBacklogEventuallyDrains hot because a parked loop never commits
+// another cursor.
+machine TestIngressDeferral_ParkingSendWedgesWriterCounterexample {
+    var pipeline: IngressPipelineSpec;
+
+    start state Init {
+        entry {
+            var resp: (IngressStepResult, int);
+
+            pipeline = new IngressPipelineSpec((
+                mode = ParkingBlockingSend,
+                track_tx_deliveries = true,
+                served_watermark = true,
+                capacity = 1
+            ));
+
+            send pipeline, eIngressStep, (
+                reply_to = this, batch = 3, attempts = 1, commits = true
+            );
+            receive { case eIngressStepResp:
+                (r0: (IngressStepResult, int)) { resp = r0; }
+            }
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// TestIngressDeferral_UntrackedRetryDuplicatesCounterexample reproduces the
+// duplicate the per-invocation delivery record prevents. The store replays
+// its transaction body once before committing, and without the record the
+// second attempt hands envelope 1 to the bounded target again. The durable
+// half replays harmlessly because the rollback undid it; the TryTell does
+// not, because it was never in the transaction.
+//
+// The mailbox is given room for both copies on purpose: the bug under test is
+// the duplicate, not the backpressure, and a cap-one mailbox would turn the
+// second delivery into a deferral and hide it.
+machine TestIngressDeferral_UntrackedRetryDuplicatesCounterexample {
+    var pipeline: IngressPipelineSpec;
+
+    start state Init {
+        entry {
+            var resp: (IngressStepResult, int);
+
+            pipeline = new IngressPipelineSpec((
+                mode = NonParkingDeferral,
+                track_tx_deliveries = false,
+                served_watermark = true,
+                capacity = 3
+            ));
+
+            send pipeline, eIngressStep, (
+                reply_to = this, batch = 3, attempts = 2, commits = true
+            );
+            receive { case eIngressStepResp:
+                (r0: (IngressStepResult, int)) { resp = r0; }
+            }
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// TestIngressDeferral_UnwatermarkedServeDuplicatesCounterexample reproduces
+// the duplicate the served watermark prevents, in the only arrangement that
+// produces it: a hoisted request sitting PAST the envelope a full mailbox
+// turned away.
+//
+// Turn one answers envelope 4 optimistically — the answer has to precede the
+// commit — but the fold defers at envelope 3, so the cursor stops at 3 and
+// envelope 4 stays in the pull window. Turn two is clamped to the deferred
+// envelope, so envelope 4 is not even looked at; that is the clamp doing its
+// half. Turn three finally pulls envelope 4 again, and with no watermark the
+// operator gets a second answer to a request it already had answered. While
+// the target stayed wedged this repeats once per backoff cycle, forever.
+machine TestIngressDeferral_UnwatermarkedServeDuplicatesCounterexample {
+    var pipeline: IngressPipelineSpec;
+
+    start state Init {
+        entry {
+            var resp: (IngressStepResult, int);
+
+            pipeline = new IngressPipelineSpec((
+                mode = NonParkingDeferral,
+                track_tx_deliveries = true,
+                served_watermark = false,
+                capacity = 1
+            ));
+
+            // Turn one: answer envelope 4, defer at envelope 3, commit the
+            // cursor at 3.
+            send pipeline, eIngressStep, (
+                reply_to = this, batch = 5, attempts = 1, commits = true
+            );
+            receive { case eIngressStepResp:
+                (r0: (IngressStepResult, int)) { resp = r0; }
+            }
+
+            // The target catches up, so the redrive can get past envelope 3.
+            send pipeline, eIngressDrain, (reply_to = this, count = 1);
+            receive { case eIngressStepResp:
+                (r1: (IngressStepResult, int)) { resp = r1; }
+            }
+
+            // Turn two: clamped to envelope 3, which now fits. The cursor
+            // reaches 4.
+            send pipeline, eIngressStep, (
+                reply_to = this, batch = 5, attempts = 1, commits = true
+            );
+            receive { case eIngressStepResp:
+                (r2: (IngressStepResult, int)) { resp = r2; }
+            }
+
+            // Turn three: envelope 4 is pulled again, and with no watermark
+            // it is answered a second time in the same incarnation.
+            send pipeline, eIngressStep, (
+                reply_to = this, batch = 5, attempts = 1, commits = true
+            );
+            receive { case eIngressStepResp:
+                (r3: (IngressStepResult, int)) { resp = r3; }
+            }
+
+            goto Done;
+        }
+    }
+
+    state Done {}
+}
+
+// tcIngressDeferralNoLoss checks the four safety contracts together against
+// the production profile: no envelope is acked without being handled, a
+// bounded target never sees an envelope twice in one folded dispatch or twice
+// in one redrive epoch, a hoisted request is answered once per process
+// lifetime, and the writer never parks.
+test tcIngressDeferralNoLoss
+    [main=TestIngressDeferral_BoundedMailboxRedriveNoLoss]:
+  assert IngressCursorCoversOnlyHandledEnvelopes,
+         IngressMemoryTargetNoTxScopedDuplicate,
+         IngressMemoryTargetAtLeastOnceBounded,
+         IngressNonTxRequestServedOncePerIncarnation,
+         IngressWriterNeverParks in
+  { IngressPipelineSpec,
+    TestIngressDeferral_BoundedMailboxRedriveNoLoss };
+
+// tcIngressDeferralLiveness checks the progress half: deferring on a full
+// mailbox must delay the stream, never stop it, so a target that eventually
+// keeps up lets the cursor reach the end.
+test tcIngressDeferralLiveness
+    [main=TestIngressDeferral_BoundedMailboxRedriveNoLoss]:
+  assert IngressBacklogEventuallyDrains in
+  { IngressPipelineSpec,
+    TestIngressDeferral_BoundedMailboxRedriveNoLoss };
+
+// tcIngressParkedWriterCounterexample runs the pre-fix blocking send with no
+// in-machine assertion, so the wedge is raised solely by
+// IngressWriterNeverParks. It is expected to find a bug.
+test tcIngressParkedWriterCounterexample
+    [main=TestIngressDeferral_ParkingSendWedgesWriterCounterexample]:
+  assert IngressWriterNeverParks in
+  { IngressPipelineSpec,
+    TestIngressDeferral_ParkingSendWedgesWriterCounterexample };
+
+// tcIngressParkedWriterStarvesCounterexample runs the same wedge under the
+// progress monitor instead, so the failure shows up the way an operator sees
+// it: the cursor stops advancing and the stream never drains. It is expected
+// to find a bug.
+test tcIngressParkedWriterStarvesCounterexample
+    [main=TestIngressDeferral_ParkingSendWedgesWriterCounterexample]:
+  assert IngressBacklogEventuallyDrains in
+  { IngressPipelineSpec,
+    TestIngressDeferral_ParkingSendWedgesWriterCounterexample };
+
+// tcIngressUntrackedRetryDuplicateCounterexample runs a replayed transaction
+// body with no per-invocation delivery record and no in-machine assertion, so
+// the duplicate is raised solely by IngressMemoryTargetNoTxScopedDuplicate. It
+// is expected to find a bug.
+test tcIngressUntrackedRetryDuplicateCounterexample
+    [main=TestIngressDeferral_UntrackedRetryDuplicatesCounterexample]:
+  assert IngressMemoryTargetNoTxScopedDuplicate in
+  { IngressPipelineSpec,
+    TestIngressDeferral_UntrackedRetryDuplicatesCounterexample };
+
+// tcIngressMonitorCatchesRetryDuplicate runs the same replay under the
+// at-least-once bound instead, proving the duplicate is caught a second,
+// independent way: two deliveries in one redrive epoch. It is expected to
+// find a bug.
+test tcIngressMonitorCatchesRetryDuplicate
+    [main=TestIngressDeferral_UntrackedRetryDuplicatesCounterexample]:
+  assert IngressMemoryTargetAtLeastOnceBounded in
+  { IngressPipelineSpec,
+    TestIngressDeferral_UntrackedRetryDuplicatesCounterexample };
+
+// tcIngressUnwatermarkedServeCounterexample runs the redrive with no served
+// watermark and no in-machine assertion, so the second answer is raised
+// solely by IngressNonTxRequestServedOncePerIncarnation. It is expected to
+// find a bug.
+test tcIngressUnwatermarkedServeCounterexample
+    [main=TestIngressDeferral_UnwatermarkedServeDuplicatesCounterexample]:
+  assert IngressNonTxRequestServedOncePerIncarnation in
+  { IngressPipelineSpec,
+    TestIngressDeferral_UnwatermarkedServeDuplicatesCounterexample };

--- a/p-models/scripts/check.sh
+++ b/p-models/scripts/check.sh
@@ -151,6 +151,46 @@ check_green tcOutboxFold
 # completes the outbox without a durable enqueue loses the message.
 check_negative tcOutboxSplitWriteCounterexample 1
 
+# The ingress cursor fold must never persist a cursor covering an envelope
+# whose local enqueue did not commit, under nondeterministic batch sizes,
+# rolled-back commits, and crash-restarts.
+check_green tcIngressFoldNoLoss
+
+# The two ways the fold's ordering can be broken must both be caught by the
+# IngressCursorCoversOnlyCommittedEnvelopes monitor: keeping an eagerly
+# advanced in-memory cursor after a rollback, and checkpointing the cursor in
+# its own commit ahead of the enqueues.
+check_negative tcIngressEagerCursorCounterexample 1
+check_negative tcIngressCheckpointFirstCounterexample 1
+
+# Ingress dispatch into a BOUNDED in-memory mailbox: a full target must defer
+# rather than park, the committed cursor must stop at the undelivered
+# envelope, a replayed transaction body must not re-send what it already
+# handed over, and a hoisted request must be answered once per process
+# lifetime however many times the redrive re-pulls it.
+check_green tcIngressDeferralNoLoss
+
+# Deferring must delay the stream, never stop it: once the target keeps up the
+# cursor reaches the end.
+check_green tcIngressDeferralLiveness
+
+# The pre-fix blocking send must be caught two independent ways: as a safety
+# violation by IngressWriterNeverParks, and as the starvation an operator
+# actually sees by IngressBacklogEventuallyDrains.
+check_negative tcIngressParkedWriterCounterexample 1
+check_negative tcIngressParkedWriterStarvesCounterexample 1
+
+# Dropping the per-invocation delivery record must be caught two independent
+# ways: as a duplicate within one folded dispatch, and as two deliveries in
+# one redrive epoch.
+check_negative tcIngressUntrackedRetryDuplicateCounterexample 1
+check_negative tcIngressMonitorCatchesRetryDuplicate 1
+
+# Dropping the served watermark must be caught by
+# IngressNonTxRequestServedOncePerIncarnation: a redrive answers a hoisted
+# request the operator has already had answered.
+check_negative tcIngressUnwatermarkedServeCounterexample 1
+
 echo ""
 echo "=== Go Bridge Conformance ==="
 go test ./p-models/durableactor/bridge

--- a/round/actor.go
+++ b/round/actor.go
@@ -63,6 +63,34 @@ const defaultRegistrationTimeout = 60 * time.Second
 // between unanswered probes.
 const defaultStatusReconcileTimeout = 90 * time.Second
 
+// defaultWalletAskTimeout bounds every Ask this actor makes into the wallet
+// actor. Both actors are single-goroutine loops that Ask each other — the
+// wallet asks the round actor from handleRefreshVTXOs, handleLeaveVTXOs and
+// friends — so an unbounded Ask in this direction closes a circular wait that
+// nothing can break: each loop sits on the other's promise with no timer
+// anywhere in the cycle, and because a board trigger arrives by Tell there is
+// no caller deadline to fall back on either. Bounding this side is enough to
+// break the cycle, since whichever side gives up frees its loop to serve the
+// other's message.
+//
+// Unlike wallet.replayRoundRegisterTimeout, the bounded context keeps its
+// parent rather than detaching with WithoutCancel: the parent here is the
+// actor's own lifecycle context, so keeping it preserves the shutdown escape
+// instead of removing it.
+//
+// NOTE: 30s is chosen to match the wallet's own replay budget so a wallet that
+// is slow rather than wedged still gets its answer through, and it is the same
+// number the boot-time registration Ask in Start uses. The cost is paid on this
+// actor's single receive loop, which every inbound round route funnels through:
+// while an Ask is outstanding the mailbox does not drain, and once it fills the
+// connector's ingress loop defers and re-pulls
+// (serverconn.ErrDispatchDeferred), so this constant is one of the things that
+// CAUSES the backpressure the connector now handles. Shortening it trades a
+// longer wallet stall for a shorter deaf window; the reverse direction is still
+// unbounded at four of six wallet-to-round call sites, so the cycle is broken
+// by this side alone and that asymmetry is deliberate.
+const defaultWalletAskTimeout = 30 * time.Second
+
 // defaultRefreshRegistrationDelay is the quiet period used to coalesce
 // expiry-driven refreshes before registering their round. Block epochs can
 // make several VTXO actors request refreshes back-to-back; registering the
@@ -417,6 +445,12 @@ type RoundClientConfig struct {
 	// A negative value disables the timeout (rounds wait indefinitely for
 	// admission), which restores the pre-#653 behavior.
 	RegistrationTimeout time.Duration
+
+	// WalletAskTimeout bounds every Ask this actor makes into the wallet
+	// actor, which is what keeps the two single-goroutine loops from
+	// parking on each other forever. If zero or negative,
+	// defaultWalletAskTimeout is used.
+	WalletAskTimeout time.Duration
 
 	// StatusReconcileTimeout bounds how long a forfeit-bearing round sits
 	// in InputSigSentState — forfeit signatures out, no confirmation, no
@@ -1024,11 +1058,55 @@ func (a *RoundClientActor) createNewRound(ctx context.Context) (*RoundFSM,
 	return roundFSM, nil
 }
 
+// fsmState returns a round FSM's current state, bounded so this actor's receive
+// loop can never be parked by a transition that is still running. The FSM
+// answers state queries only between transitions, so a query is a read that has
+// to be allowed to fail; every caller below degrades on the error instead of
+// waiting for it to succeed.
+//
+// The bound is derived from the caller's context rather than replacing it, so a
+// query also ends when the actor is stopped — and so a caller that already
+// bounded a whole scan of FSMs keeps its own, shorter deadline. See
+// fsmScanContext.
+func fsmState(ctx context.Context, fsm *ClientStateMachine) (
+	protofsm.State[ClientEvent, ClientOutMsg, *ClientEnvironment], error) {
+
+	queryCtx, cancel := context.WithTimeout(
+		ctx, protofsm.DefaultStateQueryTimeout,
+	)
+	defer cancel()
+
+	return fsm.CurrentStateWithContext(queryCtx)
+}
+
+// fsmScanContext bounds a whole pass over the tracked rounds with ONE deadline,
+// which every caller below that scans a.rounds must use.
+//
+// A per-FSM bound does not compose: the scans are over a map whose size is not
+// tightly bounded (recovery rounds are never reaped, and failed ones linger
+// until the next assembly), and several handlers scan more than once per
+// message, so a per-FSM second turns into len(a.rounds) seconds — on the single
+// receive loop that gates every inbound round route in the process, and through
+// the connector's shared cursor, the whole inbound plane. One shared deadline
+// makes a scan cost at most DefaultStateQueryTimeout no matter how many rounds
+// are tracked.
+//
+// The trade-off is that an FSM early in the scan which is slow to answer can
+// consume the budget and leave later ones reporting a deadline instead of a
+// state. That is the same outcome those rounds already get when they are the
+// slow one, and every caller treats an unreadable state as "skip this round",
+// so the failure mode is a round not considered for this message rather than a
+// wrong answer. Spending a bounded amount of the receive loop is worth more
+// than reading every FSM.
+func fsmScanContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, protofsm.DefaultStateQueryTimeout)
+}
+
 // roundInState returns a predicate that checks if a RoundFSM is in the
 // specified state type.
-func roundInState[S ClientState]() fn.Pred[*RoundFSM] {
+func roundInState[S ClientState](ctx context.Context) fn.Pred[*RoundFSM] {
 	return func(r *RoundFSM) bool {
-		state, err := r.FSM.CurrentState()
+		state, err := fsmState(ctx, r.FSM)
 		if err != nil {
 			return false
 		}
@@ -1042,18 +1120,25 @@ func roundInState[S ClientState]() fn.Pred[*RoundFSM] {
 // It prioritizes PendingRoundAssembly (which already has boarding inputs)
 // over Idle rounds. This ensures VTXOs are attached to rounds that have
 // inputs, preventing registration failures from empty input sets.
-func (a *RoundClientActor) findAssemblingRound() *RoundFSM {
+func (a *RoundClientActor) findAssemblingRound(ctx context.Context) *RoundFSM {
 	rounds := slices.Collect(maps.Values(a.rounds))
+
+	// Both filters below are one logical scan and share one deadline: this
+	// runs on the receive loop, and it queries every tracked round twice.
+	scanCtx, cancel := fsmScanContext(ctx)
+	defer cancel()
 
 	// Prefer rounds that already have boarding intents.
 	if assembling := fn.Filter(
-		rounds, roundInState[*PendingRoundAssembly](),
+		rounds, roundInState[*PendingRoundAssembly](scanCtx),
 	); len(assembling) > 0 {
 		return assembling[0]
 	}
 
 	// Fall back to idle rounds.
-	if idle := fn.Filter(rounds, roundInState[*Idle]()); len(idle) > 0 {
+	if idle := fn.Filter(
+		rounds, roundInState[*Idle](scanCtx),
+	); len(idle) > 0 {
 		return idle[0]
 	}
 
@@ -1073,15 +1158,19 @@ func (a *RoundClientActor) findAssemblingRound() *RoundFSM {
 // when no round matches AND also when more than one candidate
 // matches (ambiguous re-key), so the caller can log and fail rather
 // than silently route into the wrong FSM.
-func (a *RoundClientActor) findRoundByOutpoints(
+func (a *RoundClientActor) findRoundByOutpoints(ctx context.Context,
 	boardingOutpoints, vtxoOutpoints []wire.OutPoint) *RoundFSM {
 
 	boardingSet := fn.NewSet(boardingOutpoints...)
 	vtxoSet := fn.NewSet(vtxoOutpoints...)
 
+	// One deadline for the whole scan; see fsmScanContext.
+	scanCtx, cancel := fsmScanContext(ctx)
+	defer cancel()
+
 	var match *RoundFSM
 	for _, roundFSM := range a.rounds {
-		state, err := roundFSM.FSM.CurrentState()
+		state, err := fsmState(scanCtx, roundFSM.FSM)
 		if err != nil {
 			continue
 		}
@@ -1276,7 +1365,7 @@ func (a *RoundClientActor) replayCheckpointedServerMessages(
 	ctx context.Context, roundFSM *RoundFSM,
 ) error {
 
-	state, err := roundFSM.FSM.CurrentState()
+	state, err := fsmState(ctx, roundFSM.FSM)
 	if err != nil {
 		return fmt.Errorf("get current state: %w", err)
 	}
@@ -1328,13 +1417,22 @@ func (a *RoundClientActor) OnStop(ctx context.Context) error {
 		slog.Int("rounds", len(a.rounds)),
 	)
 
+	// The state reads across this loop share one deadline, so the stop
+	// budget is spent on the cleanup rather than on the queries. With a
+	// per-FSM bound, five mid-transition rounds exhausted the framework's
+	// whole 5s OnStop budget on reads alone and left nothing for the MuSig2
+	// session cleanup that this method exists to perform — which is the
+	// external-signer state that leaks across a restart if it is skipped.
+	scanCtx, cancel := fsmScanContext(ctx)
+	defer cancel()
+
 	// Stop all round FSMs.
 	for keyStr, roundFSM := range a.rounds {
 		a.log.DebugS(ctx, "Stopping round FSM",
 			slog.String("key", string(keyStr)),
 		)
 
-		state, err := roundFSM.FSM.CurrentState()
+		state, err := fsmState(scanCtx, roundFSM.FSM)
 		if err == nil {
 			clientState, ok := state.(ClientState)
 			if !ok {
@@ -1416,10 +1514,20 @@ func (a *RoundClientActor) Start(ctx context.Context) error {
 		MinConf:       fn.Some(a.cfg.OperatorTerms.MinConfirmations),
 	}
 
-	future := a.cfg.WalletActor.Ask(ctx, regReq)
-	result := future.Await(ctx)
-	if result.IsErr() {
-		return fmt.Errorf("register with wallet: %w", result.Err())
+	// Bounded like every other Ask into the wallet: a wallet that never
+	// answers must fail the start with a diagnosable error instead of
+	// hanging daemon startup with no output.
+	//
+	// NOTE: this shares the steady-state budget rather than taking a longer
+	// one of its own, which is the deliberate trade: a wallet still
+	// replaying intents past 30s at boot turns a slow start into a failed
+	// start and a restart, instead of a silent hang. Nothing is left
+	// half-initialized — initRoundActor propagates the error and the daemon
+	// refuses to come up — and the registration is a read that the next
+	// attempt redoes. If boot replay ever grows past this, it wants its own
+	// longer startup constant, not a longer steady-state one.
+	if _, err := a.askWallet(ctx, regReq); err != nil {
+		return fmt.Errorf("register with wallet: %w", err)
 	}
 
 	a.log.InfoS(
@@ -1623,7 +1731,7 @@ func (a *RoundClientActor) handleWalletBoardingConfirmed(ctx context.Context,
 	// Find an existing assembling round (Idle or PendingRoundAssembly) or
 	// create a new one. This allows multiple boarding confirmations to
 	// accumulate in the same round.
-	roundFSM := a.findAssemblingRound()
+	roundFSM := a.findAssemblingRound(ctx)
 	if roundFSM == nil {
 		roundFSM, err = a.createNewRound(ctx)
 		if err != nil {
@@ -1762,7 +1870,7 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 	// Find an existing assembling round (Idle or PendingRoundAssembly) or
 	// create a new one. This allows VTXOs to join a round that already has
 	// boarding intents being assembled.
-	roundFSM := a.findAssemblingRound()
+	roundFSM := a.findAssemblingRound(ctx)
 	if roundFSM == nil {
 		roundFSM, err = a.createNewRound(ctx)
 		if err != nil {
@@ -1808,7 +1916,7 @@ func (a *RoundClientActor) handleVTXORequestsReceived(ctx context.Context,
 	// Find an existing assembling round (Idle or PendingRoundAssembly) or
 	// create a new one. This allows VTXOs to join a round that already has
 	// boarding intents being assembled.
-	roundFSM := a.findAssemblingRound()
+	roundFSM := a.findAssemblingRound(ctx)
 	if roundFSM == nil {
 		var err error
 		roundFSM, err = a.createNewRound(ctx)
@@ -1897,7 +2005,8 @@ func (a *RoundClientActor) handleRoundJoined(ctx context.Context,
 	// boarding outpoints, but this will be extended for VTXO operations
 	// (forfeit, leave, refresh) when implemented.
 	roundFSM := a.findRoundByOutpoints(
-		event.AcceptedBoardingOutpoints, event.AcceptedVTXOOutpoints,
+		ctx, event.AcceptedBoardingOutpoints,
+		event.AcceptedVTXOOutpoints,
 	)
 	if roundFSM == nil {
 		return fn.Err[actormsg.RoundActorResp](
@@ -2217,8 +2326,12 @@ func (a *RoundClientActor) handleGetState(ctx context.Context,
 
 	states := make(map[string]FSMStateInfo)
 
+	// One deadline for the whole scan; see fsmScanContext.
+	scanCtx, cancel := fsmScanContext(ctx)
+	defer cancel()
+
 	for keyStr, roundFSM := range a.rounds {
-		roundState, err := roundFSM.FSM.CurrentState()
+		roundState, err := fsmState(scanCtx, roundFSM.FSM)
 		if err != nil {
 			a.log.WarnS(ctx, "Failed to get FSM state for round",
 				err,
@@ -2380,8 +2493,12 @@ func (a *RoundClientActor) onRoundComplete(ctx context.Context, roundID RoundID,
 // broadcast and is awaiting confirmation — in-flight work, not a settled
 // failure.
 func (a *RoundClientActor) reapFailedRounds(ctx context.Context) {
+	// One deadline for the whole scan; see fsmScanContext.
+	scanCtx, cancel := fsmScanContext(ctx)
+	defer cancel()
+
 	for keyStr, roundFSM := range a.rounds {
-		state, err := roundFSM.FSM.CurrentState()
+		state, err := fsmState(scanCtx, roundFSM.FSM)
 		if err != nil {
 			continue
 		}
@@ -2488,7 +2605,7 @@ func (a *RoundClientActor) handleTimeout(ctx context.Context,
 	var timeoutEvt ClientEvent
 	switch phase {
 	case TimeoutPhaseRefreshRegistration:
-		state, stateErr := roundFSM.FSM.CurrentState()
+		state, stateErr := fsmState(ctx, roundFSM.FSM)
 		if stateErr != nil {
 			return fn.Err[actormsg.RoundActorResp](
 				fmt.Errorf("read round state for automatic "+
@@ -2787,7 +2904,7 @@ func (a *RoundClientActor) processOutbox(ctx context.Context,
 			}
 
 			// Get the current state to extract commitment tx info.
-			state, err := roundFSM.FSM.CurrentState()
+			state, err := fsmState(ctx, roundFSM.FSM)
 			if err != nil {
 				return fmt.Errorf("failed to get state: %w",
 					err)
@@ -3188,7 +3305,7 @@ func (a *RoundClientActor) handleRefreshVTXOCohortRequest(
 	// Feeding an IntentPackage to IntentSentState would self-loop
 	// silently, discarding the intent.
 	var err error
-	roundFSM := a.findAssemblingRound()
+	roundFSM := a.findAssemblingRound(ctx)
 	if roundFSM == nil {
 		roundFSM, err = a.createNewRound(ctx)
 		if err != nil {
@@ -3291,7 +3408,7 @@ func (a *RoundClientActor) handleRegisterIntent(ctx context.Context,
 	// temp-key status, which includes rounds in IntentSentState.
 	// Feeding an IntentPackage to IntentSentState would self-loop
 	// silently, discarding the intent.
-	roundFSM := a.findAssemblingRound()
+	roundFSM := a.findAssemblingRound(ctx)
 	if roundFSM == nil {
 		var err error
 		roundFSM, err = a.createNewRound(ctx)
@@ -3416,6 +3533,39 @@ func (a *RoundClientActor) handleForfeitSignatureResponse(ctx context.Context,
 	return fn.Ok[actormsg.RoundActorResp](nil)
 }
 
+// askWallet sends an Ask to the wallet actor and waits for the reply under
+// walletAskTimeout. The one bounded context covers both halves of the exchange,
+// because Ask blocks on the wallet's mailbox before it hands back a Future: a
+// deadline applied only to Await bounds the reply and leaves the enqueue
+// unbounded, which is the half that a wedged wallet actor stalls.
+//
+// A timeout is logged here rather than only at the call site: the callers that
+// return the error are handling a Tell-delivered message, and the actor
+// framework drops a Tell handler's error without logging it, so this is the
+// only place the cycle-breaking event becomes visible.
+func (a *RoundClientActor) askWallet(ctx context.Context,
+	msg wallet.WalletMsg) (wallet.WalletResp, error) {
+
+	timeout := a.cfg.WalletAskTimeout
+	if timeout <= 0 {
+		timeout = defaultWalletAskTimeout
+	}
+
+	askCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	resp, err := a.cfg.WalletActor.Ask(askCtx, msg).Await(askCtx).Unpack()
+	if errors.Is(err, context.DeadlineExceeded) {
+		a.log.ErrorS(ctx, "Wallet actor did not answer in time; "+
+			"giving up to keep the round actor live", err,
+			slog.String("msg_type", msg.MessageType()),
+			slog.String("timeout", timeout.String()),
+		)
+	}
+
+	return resp, err
+}
+
 // handleTriggerBoard processes a board request forwarded from the wallet actor.
 // It registers the VTXO output amounts into a round FSM and then triggers
 // IntentRequested to kick off the round join flow. This combines the
@@ -3433,9 +3583,14 @@ func (a *RoundClientActor) handleTriggerBoard(ctx context.Context,
 	// Resolve the boarding inputs before minting any VTXO owner keys, so a
 	// redundant trigger short-circuits without advancing the wallet key
 	// ring or registering owned scripts for outputs we never send.
-	confirmedBoarding, err := a.cfg.WalletActor.Ask(
+	//
+	// The Ask is bounded, and the same bounded context is passed to both
+	// Ask and Await: the enqueue inside Ask is itself a blocking mailbox
+	// send, so a deadline on Await alone would leave the wait unbounded
+	// whenever the wallet's mailbox is the thing that is full.
+	confirmedBoarding, err := a.askWallet(
 		ctx, &wallet.GetConfirmedBoardingIntentsRequest{},
-	).Await(ctx).Unpack()
+	)
 	if err != nil {
 		return fn.Err[actormsg.RoundActorResp](
 			fmt.Errorf("fetch confirmed boarding intents: %w", err),
@@ -3535,7 +3690,7 @@ func (a *RoundClientActor) handleTriggerBoard(ctx context.Context,
 	)
 
 	// Find an existing assembling round or create a new one.
-	roundFSM := a.findAssemblingRound()
+	roundFSM := a.findAssemblingRound(ctx)
 	if roundFSM == nil {
 		roundFSM, err = a.createNewRound(ctx)
 		if err != nil {

--- a/round/actor_harness_test.go
+++ b/round/actor_harness_test.go
@@ -214,6 +214,29 @@ type mockWalletActorRef struct {
 
 	// confirmedIntents are returned to TriggerBoard recovery queries.
 	confirmedIntents []wallet.BoardingIntent
+
+	// askGate, when non-nil, holds every Ask until it is closed or the
+	// caller's context ends. See blockAsk.
+	askGate chan struct{}
+}
+
+// blockAsk makes every subsequent Ask park as a wallet actor with a wedged
+// receive loop would, and returns the func that lets them through again.
+//
+// The gate honors the Ask context, which is the whole point: a real mailbox
+// send escapes on the caller's context, so a caller that bounds its Ask gets
+// its deadline back instead of parking. A gate that ignored the context would
+// model a mailbox that does not exist.
+func (m *mockWalletActorRef) blockAsk() func() {
+	gate := make(chan struct{})
+
+	m.mu.Lock()
+	m.askGate = gate
+	m.mu.Unlock()
+
+	return sync.OnceFunc(func() {
+		close(gate)
+	})
 }
 
 func newMockWalletActorRef(t *testing.T) *mockWalletActorRef {
@@ -247,8 +270,20 @@ func (m *mockWalletActorRef) TryTell(ctx context.Context,
 	return m.Tell(ctx, msg)
 }
 
-func (m *mockWalletActorRef) Ask(_ context.Context,
+func (m *mockWalletActorRef) Ask(ctx context.Context,
 	msg wallet.WalletMsg) actor.Future[wallet.WalletResp] {
+
+	m.mu.Lock()
+	gate := m.askGate
+	m.mu.Unlock()
+
+	if gate != nil {
+		select {
+		case <-gate:
+		case <-ctx.Done():
+			return newErrFuture[wallet.WalletResp](ctx.Err())
+		}
+	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -543,6 +578,12 @@ type immediateFuture[T any] struct {
 
 func newImmediateFuture[T any](val T) actor.Future[T] {
 	return &immediateFuture[T]{result: fn.Ok(val)}
+}
+
+// newErrFuture returns an already-failed future, which is what a real ActorRef
+// hands back when the send could not be completed.
+func newErrFuture[T any](err error) actor.Future[T] {
+	return &immediateFuture[T]{result: fn.Err[T](err)}
 }
 
 func (f *immediateFuture[T]) Await(_ context.Context) fn.Result[T] {

--- a/round/actor_wallet_ask_test.go
+++ b/round/actor_wallet_ask_test.go
@@ -1,0 +1,77 @@
+package round
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/lightninglabs/wavelength/lib/actormsg"
+	"github.com/lightninglabs/wavelength/wallet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTriggerBoardDoesNotParkOnStalledWallet is the regression test for the
+// round-actor half of a circular wait between two single-goroutine actors. The
+// wallet actor Asks the round actor from its refresh, leave and send handlers,
+// and the round actor Asked the wallet back with no deadline on either the
+// enqueue or the reply. Interleave a board trigger with any of those and both
+// receive loops sit on the other's promise with no timer anywhere in the cycle.
+//
+// A board trigger arrives by Tell, so there is no caller deadline to fall back
+// on: the bound has to come from the round actor itself. The test asserts that
+// the handler returns rather than parks, and that it returns the deadline so
+// the failure is attributable.
+func TestTriggerBoardDoesNotParkOnStalledWallet(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+
+	// Shorten the production bound so the test does not have to wait it
+	// out.
+	h.actor.cfg.WalletAskTimeout = 50 * time.Millisecond
+
+	release := h.walletActor.blockAsk()
+	defer release()
+
+	// Run the turn on its own goroutine: the regression is an unbounded
+	// park, which would otherwise hang the package instead of failing.
+	done := make(chan error, 1)
+	go func() {
+		done <- h.receive(&actormsg.TriggerBoardMsg{
+			Amounts: []btcutil.Amount{49_000},
+		}).Err()
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("round actor parked on the stalled wallet actor")
+	}
+}
+
+// TestWalletAskRecoversAfterStall pins that the bound is a timeout and not a
+// latch: once the wallet answers again, the same Ask succeeds.
+func TestWalletAskRecoversAfterStall(t *testing.T) {
+	t.Parallel()
+
+	h := newActorTestHarness(t)
+	h.actor.cfg.WalletAskTimeout = 50 * time.Millisecond
+
+	release := h.walletActor.blockAsk()
+
+	_, err := h.actor.askWallet(
+		h.ctx, &wallet.GetConfirmedBoardingIntentsRequest{},
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	release()
+
+	resp, err := h.actor.askWallet(
+		h.ctx, &wallet.GetConfirmedBoardingIntentsRequest{},
+	)
+	require.NoError(t, err)
+	require.IsType(t, &wallet.GetConfirmedBoardingIntentsResponse{}, resp)
+}

--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -95,4 +95,5 @@ background ingress polling with event routing.
 - [docs/mailbox_architecture.md](../docs/mailbox_architecture.md) — Three-layer mailbox system.
 - [docs/mailbox_transport_serverconn_clientconn.md](../docs/mailbox_transport_serverconn_clientconn.md) — Transport split between serverconn (client-side) and clientconn (server-side).
 - [docs/durable_actor_architecture.md](../docs/durable_actor_architecture.md) — Durable actor internals.
+- [p-models/durableactor/README.md](../p-models/durableactor/README.md) — P models of the ingress cursor fold and of the dispatch deferral/redrive against bounded in-memory mailboxes.
 - [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -107,4 +107,5 @@ background ingress polling with event routing.
 - [docs/mailbox_architecture.md](../docs/mailbox_architecture.md) — Three-layer mailbox system.
 - [docs/mailbox_transport_serverconn_clientconn.md](../docs/mailbox_transport_serverconn_clientconn.md) — Transport split between serverconn (client-side) and clientconn (server-side).
 - [docs/durable_actor_architecture.md](../docs/durable_actor_architecture.md) — Durable actor internals.
+- [p-models/durableactor/README.md](../p-models/durableactor/README.md) — P models of the ingress cursor fold and of the dispatch deferral/redrive against bounded in-memory mailboxes.
 - [ARCHITECTURE.md](../ARCHITECTURE.md) — System-wide package map.

--- a/serverconn/dispatch_deferral.go
+++ b/serverconn/dispatch_deferral.go
@@ -1,0 +1,235 @@
+package serverconn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/metrics"
+)
+
+// ErrDispatchDeferred marks an inbound envelope that could not be handed to its
+// target actor because the target's in-memory mailbox was full. It is not a
+// dispatch failure: the envelope is intact, unacknowledged, and the ingress
+// loop re-pulls it after a backoff, so the cursor never passes an event that
+// was not delivered.
+//
+// The error exists so the ingress loop can tell backpressure apart from a real
+// dispatch error. Both back off, but only backpressure is expected to clear on
+// its own, and only backpressure means a local actor — not the operator — is
+// the thing that stopped making progress.
+var ErrDispatchDeferred = errors.New("serverconn: ingress dispatch deferred")
+
+// deferredDispatchError carries the identity of a deferred delivery so the
+// ingress loop can name the target that stopped draining. Everything in it is
+// known at the dispatcher, and nothing else on the ingress path can reconstruct
+// it: by the time the error reaches the loop, the envelope has been consumed.
+type deferredDispatchError struct {
+	// service and method are the envelope's route.
+	service string
+	method  string
+
+	// target is the ID of the actor reference whose mailbox was full.
+	target string
+
+	// eventSeq is the sequence number of the undelivered envelope, which is
+	// also the cursor the next pull resumes from.
+	eventSeq uint64
+
+	// err is the underlying delivery error, always wrapping
+	// actor.ErrMailboxFull.
+	err error
+}
+
+// Error implements the error interface.
+func (e *deferredDispatchError) Error() string {
+	return fmt.Sprintf("deferred %s/%s event_seq=%d to actor %q: %v",
+		e.service, e.method, e.eventSeq, e.target, e.err)
+}
+
+// Unwrap exposes both the sentinel and the underlying mailbox error, so
+// errors.Is matches ErrDispatchDeferred for the loop's classification and
+// actor.ErrMailboxFull for anything that cares about the cause.
+func (e *deferredDispatchError) Unwrap() []error {
+	return []error{ErrDispatchDeferred, e.err}
+}
+
+// deferDispatch builds the deferral error for an envelope that a full mailbox
+// turned away.
+func deferDispatch(service, method, target string, eventSeq uint64,
+	err error) *deferredDispatchError {
+
+	return &deferredDispatchError{
+		service:  service,
+		method:   method,
+		target:   target,
+		eventSeq: eventSeq,
+		err:      err,
+	}
+}
+
+// deliverToActor hands an adapted message to its target actor without ever
+// parking the ingress goroutine. A bounded in-memory target is sent to with
+// TryTell and a full mailbox comes back as a deferral; a durable target keeps
+// the blocking Tell, which is bounded by its own write and has to stay inside
+// the caller's transaction to commit atomically with the cursor.
+//
+// This is the fix for the wedge that made a deployed client go deaf: the round
+// client and the incoming-VTXO handler are registered with the default
+// fixed-capacity mailbox, and the ingress loop used to deliver to them with a
+// blocking Tell that had no deadline, from inside the folded write transaction.
+// A target that stopped draining therefore parked the process's only mailbox
+// puller forever, with the database's single writer held, and nothing logged.
+//
+// A TryTell delivery is the one thing here that outlives a rolled-back
+// transaction, so it is recorded on the way out and suppressed on the way back
+// in: the fold's store may run its body again after a retryable error, and
+// without this the target would receive the same event once per attempt with
+// nothing logged either. See deliveredOutsideTx.
+func deliverToActor[M actor.Message, R any](ctx context.Context,
+	ref actor.ActorRef[M, R], msg M, service, method string,
+	eventSeq uint64) error {
+
+	replayed := deliveredOutsideTxFrom(ctx)
+	if replayed.seen(eventSeq) {
+		return nil
+	}
+
+	outsideTx, err := actor.TellWithoutParking[M](ctx, ref, msg).Unpack()
+	if errors.Is(err, actor.ErrMailboxFull) {
+		return deferDispatch(service, method, ref.ID(), eventSeq, err)
+	}
+	if err != nil {
+		return err
+	}
+
+	if outsideTx {
+		replayed.mark(eventSeq)
+	}
+
+	return nil
+}
+
+// deferralLogInterval bounds how often an open backpressure episode re-states
+// itself in the log. One line per re-pull is the storm that would bury the
+// signal, but one line for the whole episode is how a permanent wedge ends up
+// with a single record that can age out of retention before anyone looks — the
+// exact shape of the two incidents this path was added for. Re-stating on an
+// interval keeps a persistent episode continuously visible while staying two
+// orders of magnitude below the redrive rate.
+const deferralLogInterval = 30 * time.Second
+
+// deferralEpisode is the ingress loop's own state for one backpressure episode,
+// carried on that single goroutine's stack because it is the only place that
+// sees every dispatch outcome in order. It exists to throttle the log without
+// losing the episode's shape: when it started, how many redrives it has taken,
+// and when it ended.
+type deferralEpisode struct {
+	// open is true between the first deferral of an episode and the next
+	// fully successful dispatch.
+	open bool
+
+	// deferrals counts the redrives this episode has turned away, including
+	// the first.
+	deferrals int
+
+	// startedAt is when the episode's first deferral was seen, so the
+	// closing line can state how long the target was backed up.
+	startedAt time.Time
+
+	// lastLoggedAt is when this episode last wrote a line, which is what
+	// deferralLogInterval throttles against.
+	lastLoggedAt time.Time
+}
+
+// noteDispatchDeferral reports whether err is a deferred dispatch, returning
+// the deferral when it is and nil when it is not. A deferral is always counted;
+// it is logged on the first one of an episode and then at most once per
+// deferralLogInterval, because a target that has stopped draining defers again
+// on every re-pull. clearDispatchDeferral closes the episode.
+//
+// The level splits by how long the episode has lasted. A brief deferral is
+// ordinary backpressure that the deferred counter already captures, so the
+// episode's opening line is a warning, per the repo rule that error level is
+// for internal bugs rather than external triggers. An episode still open a
+// full deferralLogInterval later means the target has stopped draining, which
+// is exactly the stuck-receive-loop bug class this path exists to expose, so
+// the interval re-logs escalate to error level. Before this path existed the
+// only log here was a Trace inside the mailbox, which is why two production
+// incidents produced no evidence at all.
+func (a *ServerConnectionActor) noteDispatchDeferral(ctx context.Context,
+	err error, episode *deferralEpisode) *deferredDispatchError {
+
+	var deferral *deferredDispatchError
+	if !errors.As(err, &deferral) {
+		return nil
+	}
+
+	// The counter counts redrives turned away, not envelopes: the loop
+	// meets the full mailbox once per re-pull and stops there, so the
+	// envelopes queued behind the first are never attempted and cannot be
+	// counted.
+	metrics.ServerConnIngressDeferredTotal.WithLabelValues(
+		deferral.service, deferral.method,
+	).Inc()
+
+	now := time.Now()
+
+	first := !episode.open
+	if first {
+		episode.open = true
+		episode.deferrals = 0
+		episode.startedAt = now
+	}
+
+	episode.deferrals++
+
+	if !first && now.Sub(episode.lastLoggedAt) < deferralLogInterval {
+		return deferral
+	}
+
+	episode.lastLoggedAt = now
+
+	logFn := a.log.WarnS
+	if !first {
+		logFn = a.log.ErrorS
+	}
+	logFn(
+		ctx, "Ingress dispatch deferred: target mailbox full, "+
+			"re-pulling after backoff", err,
+		slog.String("mailbox_id", a.cfg.LocalMailboxID),
+		slog.String("service", deferral.service),
+		slog.String("method", deferral.method),
+		slog.String("target_actor", deferral.target),
+		slog.Uint64("event_seq", deferral.eventSeq),
+		slog.Int("episode_deferrals", episode.deferrals),
+		slog.String("episode_age", now.Sub(episode.startedAt).String()),
+	)
+
+	return deferral
+}
+
+// clearDispatchDeferral closes an open backpressure episode, so the next one is
+// logged again and an operator reading the log can bound how long the target
+// was backed up.
+func (a *ServerConnectionActor) clearDispatchDeferral(ctx context.Context,
+	episode *deferralEpisode) {
+
+	if !episode.open {
+		return
+	}
+
+	deferrals := episode.deferrals
+	age := time.Since(episode.startedAt)
+
+	*episode = deferralEpisode{}
+
+	a.log.InfoS(ctx, "Ingress dispatch backpressure cleared",
+		slog.String("mailbox_id", a.cfg.LocalMailboxID),
+		slog.Int("episode_deferrals", deferrals),
+		slog.String("episode_duration", age.String()),
+	)
+}

--- a/serverconn/dispatch_replay.go
+++ b/serverconn/dispatch_replay.go
@@ -1,0 +1,86 @@
+package serverconn
+
+import (
+	"context"
+)
+
+// deliveredOutsideTx records the envelopes one folded dispatch has already
+// handed to a bounded in-memory mailbox, so a transaction that runs its body
+// again does not hand them over twice.
+//
+// The need for it comes from where those deliveries land. A durable enqueue
+// joins the fold's write transaction and is undone with it, so replaying the
+// body replays the enqueue exactly once in net effect. A TryTell into an
+// in-memory mailbox is not in the transaction at all: the target actor may have
+// processed the message before the transaction even tries to commit. The
+// production store retries its transaction body on a retryable error
+// (SQLITE_BUSY, Postgres 40001/40P01) up to ten times, and every one of those
+// attempts used to re-send the whole durable partition's in-memory half —
+// invisibly, since the final attempt commits and the loop reports success.
+//
+// Only one goroutine ever dispatches ingress, so this needs no lock, and it is
+// scoped to a single runFoldedDispatch call: across re-pulls the cursor has not
+// moved, redelivery is the documented at-least-once behaviour, and the target
+// mailbox is the thing that has to absorb it. Do not widen the record beyond
+// one invocation: a cross-cycle set would suppress the FIRST delivery of an
+// envelope whose earlier cycle rolled back after the TryTell, which trades a
+// benign duplicate for a silent loss.
+type deliveredOutsideTx struct {
+	// seqs holds the event_seq of every envelope delivered by TryTell so
+	// far in this folded dispatch.
+	seqs map[uint64]struct{}
+}
+
+// deliveredOutsideTxKey is the context key for the in-flight record. It is a
+// distinct empty struct type so nothing else can collide with it.
+type deliveredOutsideTxKey struct{}
+
+// withDeliveredOutsideTx attaches a fresh record to ctx. The context is the
+// only channel available: the dispatcher signature is fixed at the wiring
+// boundary (EnvelopeDispatcher), and the delivery happens below it inside the
+// store's transaction body.
+func withDeliveredOutsideTx(ctx context.Context) context.Context {
+	tracker := &deliveredOutsideTx{
+		seqs: make(map[uint64]struct{}),
+	}
+
+	return context.WithValue(ctx, deliveredOutsideTxKey{}, tracker)
+}
+
+// deliveredOutsideTxFrom returns the record attached to ctx, or nil when there
+// is none. A nil record answers every question safely, so callers on paths that
+// never install one (the legacy non-transactional dispatch, and dispatchers
+// driven directly by tests) need no special case.
+func deliveredOutsideTxFrom(ctx context.Context) *deliveredOutsideTx {
+	tracker, _ := ctx.Value(deliveredOutsideTxKey{}).(*deliveredOutsideTx)
+
+	return tracker
+}
+
+// seen reports whether the envelope at eventSeq was already delivered outside
+// the transaction during this folded dispatch.
+func (d *deliveredOutsideTx) seen(eventSeq uint64) bool {
+	if d == nil || eventSeq == 0 {
+		return false
+	}
+
+	_, ok := d.seqs[eventSeq]
+
+	return ok
+}
+
+// mark records an out-of-transaction delivery of the envelope at eventSeq.
+//
+// A zero eventSeq is not recorded. The mailbox assigns event_seq from 1
+// (mailbox.proto: cursors are event_seq comparisons and zero is the
+// never-acked sentinel), so a zero here means the envelope was never stamped by
+// a server, and keying on it would let two unstamped envelopes in one batch
+// alias onto each other. Suppressing a duplicate is worth less than never
+// suppressing a first delivery.
+func (d *deliveredOutsideTx) mark(eventSeq uint64) {
+	if d == nil || eventSeq == 0 {
+		return
+	}
+
+	d.seqs[eventSeq] = struct{}{}
+}

--- a/serverconn/doc.go
+++ b/serverconn/doc.go
@@ -38,7 +38,26 @@
 // Inbound KIND_REQUEST and KIND_EVENT envelopes are routed via a
 // map[ServiceMethod]EnvelopeDispatcher configured at wiring time. Each
 // dispatcher is a closure that captures a ServiceKey reference for the target
-// actor and calls Tell to durably enqueue the message.
+// actor and hands the message to it.
+//
+// Not every target is durable, which the dispatch contract has to account for.
+// The round client and the incoming-VTXO handler are ordinary actors with
+// fixed-capacity in-memory mailboxes, so a delivery to them can be refused for
+// want of room. Those deliveries use TryTell and a refusal comes back as
+// ErrDispatchDeferred: the cursor stops at the undelivered envelope and the
+// loop re-pulls it after a backoff, which is what keeps a slow actor from
+// becoming a lost event. A blocking Tell there instead would park the process's
+// only mailbox puller for as long as the target took to drain, with the write
+// transaction open. See deliverToActor.
+//
+// Known residual: one strictly-ordered cursor feeds every inbound route, so an
+// actor that stops draining still stops delivery on ALL of them. What the
+// deferral changes is the blast radius and the diagnosis — the database writer
+// is no longer pinned, read paths keep working, and the stall is now counted
+// (ServerConnIngressDeferredTotal) and logged instead of being invisible — not
+// the head-of-line coupling itself. Removing that would take a per-target
+// deferral queue with its own cursor, which is a larger change than this one
+// and has to preserve per-lane event_seq ordering to be worth doing.
 //
 // KIND_RESPONSE envelopes are delivered to in-memory response waiters via the
 // response registry. This is not durable — if the process crashes, callers'

--- a/serverconn/event_router.go
+++ b/serverconn/event_router.go
@@ -47,10 +47,12 @@ type EventRouteConfig[M actor.Message, R any] struct {
 	// provide the unmarshal target.
 	NewEvent func() proto.Message
 
-	// Key is the ServiceKey for the target durable actor. The router
-	// calls key.Ref(system).Tell(ctx, msg) for each dispatched event,
-	// which persists the message to the actor's durable mailbox before
-	// returning nil.
+	// Key is the ServiceKey for the target actor. The router hands each
+	// dispatched event to key.Ref(system) and returns nil once the target
+	// has accepted it: for a durable target that means the message was
+	// persisted, and for one with a fixed-capacity in-memory mailbox it
+	// means the mailbox had room. A full in-memory mailbox comes back as
+	// ErrDispatchDeferred rather than parking the ingress loop.
 	Key actor.ServiceKey[M, R]
 
 	// Adapt converts the deserialized proto.Message to the actor message
@@ -67,11 +69,14 @@ type EventRouteConfig[M actor.Message, R any] struct {
 	ResolveKey func(M) (actor.ServiceKey[M, R], bool)
 }
 
-// EventRouter maps inbound KIND_REQUEST and KIND_EVENT envelope routes to
-// typed durable actor mailboxes via ServiceKey.
+// EventRouter maps inbound KIND_REQUEST and KIND_EVENT envelope routes to typed
+// actor mailboxes via ServiceKey.
 //
-// EventRouter resolves target actors through the actor system's Receptionist,
-// guaranteeing durable delivery before returning from each dispatch call.
+// EventRouter resolves target actors through the actor system's Receptionist
+// and does not return from a dispatch call until the target has accepted the
+// message, or has refused it for want of mailbox room. It never waits for room:
+// its sole caller is the ingress loop, whose one goroutine feeds every inbound
+// route in the process.
 //
 // At wiring time, callers call AddRoute for each (service, method) pair they
 // want to handle, then pass AsDispatcherMap() to ConnectorConfig.Dispatchers.
@@ -129,7 +134,7 @@ type InboundEventRouteConfig[M InboundActorMessage, R any] struct {
 	// Method is the protobuf method name (e.g., "HelloStarted").
 	Method string
 
-	// Key is the ServiceKey for the target durable actor.
+	// Key is the ServiceKey for the target actor.
 	Key actor.ServiceKey[M, R]
 
 	// NewEvent must return a fresh zero-value proto.Message for the
@@ -251,12 +256,19 @@ func AddEnvelopeRoute[M actor.Message, R any](r *EventRouter,
 					system.Receptionist(), key,
 				)
 				if len(refs) > 0 {
-					return refs[0].Tell(ctx, actorMsg)
+					return deliverToActor(
+						ctx, refs[0], actorMsg,
+						cfg.Service, cfg.Method,
+						env.EventSeq,
+					)
 				}
 			}
 		}
 
-		return actorKey.Ref(system).Tell(ctx, actorMsg)
+		return deliverToActor(
+			ctx, actorKey.Ref(system), actorMsg, cfg.Service,
+			cfg.Method, env.EventSeq,
+		)
 	}
 
 	serviceMethod := mailboxrpc.ServiceMethod{

--- a/serverconn/ingress.go
+++ b/serverconn/ingress.go
@@ -3,8 +3,10 @@ package serverconn
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/lightninglabs/wavelength/baselib/actor"
 	mailboxconn "github.com/lightninglabs/wavelength/mailbox/conn"
@@ -12,6 +14,30 @@ import (
 	mailboxrpc "github.com/lightninglabs/wavelength/mailbox/rpc"
 	"github.com/lightninglabs/wavelength/serverconn/mailboxpull"
 )
+
+// redriveState is what the ingress loop remembers across the re-pulls of one
+// backpressure episode. Both fields exist to keep a redrive from repeating work
+// the previous cycle already did: the loop re-pulls the same window every
+// backoff cycle for as long as a target stays wedged, and the pre-transaction
+// half of a folded dispatch is not idempotent from the operator's point of
+// view.
+type redriveState struct {
+	// deferredSeq is the event_seq of the envelope a full mailbox turned
+	// away last cycle, or zero when no deferral is outstanding. It clamps
+	// the next redrive to the envelopes at or before it: nothing past it
+	// can commit until that one is delivered, so handling the rest again is
+	// pure duplicate effort.
+	deferredSeq uint64
+
+	// servedNonTxSeq is the highest event_seq of a hoisted request this
+	// loop has already answered over the network. A request beyond the
+	// cursor a deferred cycle commits is served optimistically — the send
+	// has to precede the commit, or a crash in between would advance the
+	// cursor past a request nobody answered — and it then stays in the pull
+	// window until the cursor reaches it. This watermark is what makes that
+	// one serve instead of one per cycle.
+	servedNonTxSeq uint64
+}
 
 // ingressLoop is the main pull-dispatch-ack loop. It runs in its own
 // goroutine, started from ServerConnectionActor.StartIngress. The loop:
@@ -44,6 +70,30 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 	txStore, txOK := a.cfg.Store.(actor.TxAwareDeliveryStore)
 	var ackDirty bool
 
+	// episode tracks an open backpressure episode, so a target that has
+	// stopped draining is logged on an interval rather than on every
+	// re-pull. It lives here, on the single ingress goroutine's stack,
+	// because that is the only place that sees every dispatch outcome in
+	// order.
+	var episode deferralEpisode
+
+	// deferFailCount is the redrive schedule for backpressure, kept apart
+	// from the transport failCount above because the two failures want
+	// opposite cadences. A black-holed connection should be retried slowly;
+	// a full local mailbox should be redriven as soon as it might have
+	// room, because the redrive is the only thing draining the client's
+	// inbound backlog. Sharing one counter made a recovering target drain
+	// at one pull per RetryMaxDelay.
+	var deferFailCount int
+
+	// redrive is what this loop remembers about a deferred cycle so the
+	// next one does not repeat its work. It lives here for the same reason
+	// as episode: only this goroutine sees every dispatch outcome in order.
+	// A fresh ingressLoop starts with a fresh one, which is the right scope
+	// — after a restart the cursor is the only surviving state and
+	// redelivery is the documented behaviour.
+	var redrive redriveState
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -65,72 +115,14 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 		}
 
 		// Step 2: Pull a batch of envelopes from the remote mailbox.
-		envelopes, nextCursor, err := a.pullBatch(
-			ctx, state.PullCursor,
+		envelopes, nextCursor, exit, retry := a.pullPhase(
+			ctx, &state, &ackDirty, &failCount,
 		)
-		if err != nil {
-			if isIngressShutdownErr(ctx, err) {
-				a.logIngressExit(ctx)
-
-				return
-			}
-
-			// A permanent version error is terminal: stop the loop
-			// rather than retrying forever.
-			if a.checkPermanentStatus(ctx, err) {
-				return
-			}
-
-			a.log.WarnS(ctx, "Pull failed, retrying",
-				err,
-				slog.Uint64("cursor", state.PullCursor),
-			)
-
-			a.sleepBackoff(ctx, &failCount)
-
+		if exit {
+			return
+		} else if retry {
 			continue
 		}
-
-		if len(envelopes) == 0 {
-			// Long-poll returned empty. Flush a dirty ack
-			// watermark while the connection is idle so a
-			// restart does not re-ack forever.
-			if ackDirty {
-				if err := a.saveCheckpoint(
-					ctx, state,
-				); err != nil {
-
-					// Back off on a failing checkpoint
-					// store rather than retrying at the
-					// bare long-poll cadence, mirroring the
-					// ack-path policy above. ackDirty stays
-					// set so the next attempt re-flushes.
-					a.log.WarnS(ctx,
-						"Failed to flush ack "+
-							"checkpoint while idle",
-						err)
-
-					a.sleepBackoff(ctx, &failCount)
-
-					continue
-				}
-
-				ackDirty = false
-			}
-
-			// Reset fail count and loop again immediately — the
-			// long-poll timeout already provides the delay.
-			failCount = 0
-
-			continue
-		}
-
-		a.log.TraceS(
-			ctx, "Pulled envelopes",
-			slog.Int("count", len(envelopes)),
-			slog.Uint64("cursor", state.PullCursor),
-			slog.Uint64("next_cursor", nextCursor),
-		)
 
 		// Step 3 (transactional path): deliver in-memory responses
 		// outside the transaction, then fold the durable dispatches
@@ -138,8 +130,48 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 		if txOK {
 			newState, foldErr := a.runFoldedDispatch(
 				ctx, txStore, envelopes, nextCursor, state,
+				&redrive,
 			)
 			if foldErr != nil {
+				// A full target mailbox is backpressure, not a
+				// failure. The commit still covered the prefix
+				// that was delivered, so the advanced state is
+				// adopted and the re-pull resumes at the
+				// undelivered envelope instead of redelivering
+				// everything ahead of it.
+				deferral := a.noteDispatchDeferral(
+					ctx, foldErr, &episode,
+				)
+				if deferral != nil {
+					// A cursor that moved means the last
+					// redrive delivered part of the
+					// backlog, which is progress and not a
+					// failure to back off from: the
+					// schedule starts over so a draining
+					// target is redriven promptly instead
+					// of at the ceiling. It also means
+					// events ARE getting through, so the
+					// traffic gauge is stamped for the
+					// partial commit.
+					if newState.PullCursor >
+						state.PullCursor {
+
+						deferFailCount = 0
+
+						markIngressEvent()
+					}
+
+					state = newState
+					ackDirty = false
+					redrive.deferredSeq = deferral.eventSeq
+
+					a.sleepDeferralBackoff(
+						ctx, &deferFailCount,
+					)
+
+					continue
+				}
+
 				// A permanent inbound version mismatch is
 				// terminal: stop the loop WITHOUT advancing the
 				// cursor so the offending envelope is preserved
@@ -168,6 +200,11 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 			state = newState
 			ackDirty = false
 			failCount = 0
+			deferFailCount = 0
+			redrive.deferredSeq = 0
+
+			a.clearDispatchDeferral(ctx, &episode)
+			markIngressEvent()
 
 			continue
 		}
@@ -179,18 +216,38 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 			ctx, envelopes, nextCursor,
 		)
 		if dispatchErr != nil {
+			// A full target mailbox is backpressure rather than a
+			// dispatch failure, and it gets its own throttled log
+			// instead of one line per re-pull. The partial advance
+			// below is the same in either case: the cursor stops at
+			// the undelivered envelope.
+			//
+			// This path needs no deferredSeq clamp. It dispatches
+			// the batch strictly in order and stops at the
+			// deferral, so nothing past the undelivered envelope is
+			// ever touched to begin with.
+			deferred := a.noteDispatchDeferral(
+				ctx, dispatchErr, &episode,
+			) != nil
+
 			// A permanent inbound version mismatch is terminal:
 			// stop the loop WITHOUT advancing the cursor so the
 			// offending envelope is preserved for a future
 			// compatible restart, and never acknowledged.
-			if a.checkPermanentStatus(ctx, dispatchErr) {
+			if !deferred && a.checkPermanentStatus(
+				ctx, dispatchErr,
+			) {
 				return
 			}
 
-			a.log.WarnS(ctx, "Dispatch failed",
-				dispatchErr,
-				slog.Uint64("committed_to", committedCursor),
-			)
+			if !deferred {
+				a.log.WarnS(ctx, "Dispatch failed",
+					dispatchErr,
+					slog.Uint64(
+						"committed_to", committedCursor,
+					),
+				)
+			}
 
 			// Even on partial failure, advance state past the
 			// last committed envelope so we don't re-dispatch
@@ -200,9 +257,9 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 			// consistent with batchNextCursor on the success
 			// path.
 			nextCursor := committedCursor + 1
-			if committedCursor > 0 &&
-				nextCursor > state.PullCursor {
-
+			progressed := committedCursor > 0 &&
+				nextCursor > state.PullCursor
+			if progressed {
 				state.AdvanceDispatch(nextCursor)
 				state.PullCursor = nextCursor
 
@@ -215,6 +272,23 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 							"after partial dispatch",
 						cpErr)
 				}
+			}
+
+			// Backpressure gets the short redrive schedule, and a
+			// redrive that delivered part of the backlog resets it;
+			// a real dispatch failure keeps the transport schedule.
+			// The reasoning is the same as on the folded path
+			// above.
+			if deferred {
+				if progressed {
+					deferFailCount = 0
+
+					markIngressEvent()
+				}
+
+				a.sleepDeferralBackoff(ctx, &deferFailCount)
+
+				continue
 			}
 
 			a.sleepBackoff(ctx, &failCount)
@@ -240,6 +314,10 @@ func (a *ServerConnectionActor) ingressLoop(ctx context.Context,
 		}
 
 		failCount = 0
+		deferFailCount = 0
+
+		a.clearDispatchDeferral(ctx, &episode)
+		markIngressEvent()
 	}
 }
 
@@ -310,6 +388,89 @@ func (a *ServerConnectionActor) ackPhase(ctx context.Context, state *AckState,
 	*failCount = 0
 
 	return false, false
+}
+
+// pullPhase pulls the next batch of envelopes from the remote mailbox and
+// absorbs the two outcomes that are not a batch to dispatch: a failed pull and
+// an empty long-poll. It mutates state, ackDirty and failCount in place and
+// returns (envelopes, nextCursor, exit, retry) on the same convention as
+// ackPhase — exit is true when the loop must stop (local shutdown or a
+// permanent version error), and retry is true when the caller should continue
+// without dispatching. Both booleans are false only when envelopes holds a
+// non-empty batch, and any backoff a retry needs has already been slept here.
+func (a *ServerConnectionActor) pullPhase(ctx context.Context, state *AckState,
+	ackDirty *bool, failCount *int) ([]*mailboxpb.Envelope, uint64, bool,
+	bool) {
+
+	envelopes, nextCursor, err := a.pullBatch(ctx, state.PullCursor)
+	if err != nil {
+		if isIngressShutdownErr(ctx, err) {
+			a.logIngressExit(ctx)
+
+			return nil, 0, true, false
+		}
+
+		// A permanent version error is terminal: stop the loop rather
+		// than retrying forever.
+		if a.checkPermanentStatus(ctx, err) {
+			return nil, 0, true, false
+		}
+
+		a.log.WarnS(ctx, "Pull failed, retrying",
+			err,
+			slog.Uint64("cursor", state.PullCursor),
+		)
+
+		a.sleepBackoff(ctx, failCount)
+
+		return nil, 0, false, true
+	}
+
+	// The pull returned, so the one goroutine that consumes the remote
+	// mailbox is still running its loop. Stamping here rather than after
+	// dispatch is what lets a staleness alert separate a parked ingress
+	// goroutine from a client that simply has no traffic: an idle client
+	// keeps this gauge fresh at the long-poll cadence, and a parked one
+	// stops updating it immediately.
+	markIngressPoll()
+
+	if len(envelopes) == 0 {
+		// Long-poll returned empty. Flush a dirty ack watermark while
+		// the connection is idle so a restart does not re-ack forever.
+		if *ackDirty {
+			if err := a.saveCheckpoint(ctx, *state); err != nil {
+				// Back off on a failing checkpoint store rather
+				// than retrying at the bare long-poll cadence,
+				// mirroring the ack-path policy in ackPhase.
+				// ackDirty stays set so the next attempt
+				// re-flushes.
+				a.log.WarnS(ctx,
+					"Failed to flush ack checkpoint "+
+						"while idle", err)
+
+				a.sleepBackoff(ctx, failCount)
+
+				return nil, 0, false, true
+			}
+
+			*ackDirty = false
+		}
+
+		// Reset fail count and loop again immediately — the long-poll
+		// timeout already provides the delay.
+		*failCount = 0
+
+		return nil, 0, false, true
+	}
+
+	a.log.TraceS(
+		ctx, "Pulled envelopes",
+		slog.Int("count", len(envelopes)),
+		slog.Uint64("cursor", state.PullCursor),
+		slog.Uint64("next_cursor", nextCursor),
+	)
+
+	return envelopes, nextCursor, false, false
 }
 
 // logIngressExit emits the common ingress shutdown log line.
@@ -627,9 +788,16 @@ func (a *ServerConnectionActor) loadCheckpoint(ctx context.Context) (AckState,
 // and folds any straggler whose waiter disappeared back into the durable
 // transaction, so a durable response enqueue never commits outside the
 // cursor fold even if the peek was stale.
+//
+// redrive carries what the previous cycle of a backpressure episode already
+// did. It matters because the pre-transaction work runs over the WHOLE pulled
+// batch: with the cursor stalled at a wedged target, every hoisted request in
+// the window would otherwise be served again on every redrive, forever. See
+// redriveState.
 func (a *ServerConnectionActor) runFoldedDispatch(ctx context.Context,
 	txStore actor.TxAwareDeliveryStore, envelopes []*mailboxpb.Envelope,
-	nextCursor uint64, state AckState) (AckState, error) {
+	nextCursor uint64, state AckState, redrive *redriveState) (AckState,
+	error) {
 
 	// Validate the whole pulled batch against the bound version pair up
 	// front. Only the durable partition is validated inside dispatchBatch,
@@ -643,6 +811,13 @@ func (a *ServerConnectionActor) runFoldedDispatch(ctx context.Context,
 			return state, err
 		}
 	}
+
+	// Validation covers the pulled batch; everything after it works on the
+	// clamped one, so a redrive repeats no pre-transaction work it already
+	// did.
+	envelopes, nextCursor = clampToDeferred(
+		envelopes, nextCursor, redrive.deferredSeq,
+	)
 
 	responses, nonTx, durables := splitIngressEnvelopes(
 		envelopes, a.hasResponseWaiter, a.isNonTxRequest,
@@ -662,27 +837,64 @@ func (a *ServerConnectionActor) runFoldedDispatch(ctx context.Context,
 	}
 
 	// Serve the hoisted inbound requests with no transaction open. A
-	// failure here returns before the fold, so the cursor does not move
-	// and the batch is re-pulled whole.
-	if err := a.dispatchNonTxRequests(ctx, nonTx); err != nil {
+	// failure here returns before the fold, so the cursor does not move and
+	// the batch is re-pulled; the requests already answered are not served
+	// again, because the watermark that records them advanced before the
+	// failure.
+	if err := a.dispatchNonTxRequests(ctx, nonTx, redrive); err != nil {
 		return state, err
 	}
 
-	newState := state
+	// The durable partition's in-memory half (a TryTell into a bounded
+	// mailbox) is the one delivery below that a rolled-back transaction
+	// does not undo, and the production store replays its body on a
+	// retryable error. The record is created out here, OUTSIDE the closure,
+	// so a replay can see what the previous attempt already handed over and
+	// skip it. Everything else in the closure derives from the caller's
+	// state and is safe to redo.
+	ctx = withDeliveredOutsideTx(ctx)
+
+	var (
+		newState AckState
+		deferral *deferredDispatchError
+	)
 	err := txStore.ExecTx(ctx, false, func(txCtx context.Context,
 		store actor.DeliveryStore) error {
 
+		// Derive both outputs from the caller's state on every attempt,
+		// so a store that runs the closure more than once cannot fold a
+		// previous attempt's advance into this one.
+		newState = state
+		deferral = nil
+
+		cursor := nextCursor
 		if len(durables) > 0 {
 			_, dispatchErr := a.dispatchBatch(
 				txCtx, durables, nextCursor,
 			)
-			if dispatchErr != nil {
+
+			// A full target mailbox is backpressure, not a failed
+			// batch: the envelope is intact on the remote mailbox
+			// and the loop re-pulls it. Commit up to the
+			// undelivered envelope and stop there, because acking
+			// past an event that never reached its actor is how
+			// backpressure would turn into a lost round event.
+			//
+			// Nothing to adjust when the whole partition went out:
+			// the cursor already covers the batch.
+			switch {
+			case errors.As(dispatchErr, &deferral):
+				cursor = deferredCursor(
+					deferral.eventSeq, state.PullCursor,
+				)
+
+			case dispatchErr != nil:
 				return dispatchErr
 			}
 		}
 
-		newState.AdvanceDispatch(nextCursor)
-		newState.PullCursor = nextCursor
+		newState.AdvanceDispatch(cursor)
+		newState.PullCursor = cursor
 
 		return a.saveCheckpointTo(txCtx, store, newState)
 	})
@@ -690,7 +902,82 @@ func (a *ServerConnectionActor) runFoldedDispatch(ctx context.Context,
 		return state, err
 	}
 
+	// The prefix and the watermark committed together; the deferral is
+	// reported so the loop backs off instead of pulling straight into the
+	// same full mailbox.
+	if deferral != nil {
+		return newState, deferral
+	}
+
 	return newState, nil
+}
+
+// deferredCursor returns the cursor to commit when a full mailbox stopped a
+// batch partway. deferredSeq is the undelivered envelope's own event_seq, and
+// that is exactly where the exclusive cursor belongs: everything ahead of it in
+// the batch has been fully handled by the time the deferral is raised — waiter
+// responses delivered and hoisted requests served before the transaction
+// opened, the durable prefix enqueued inside it, unroutable envelopes
+// skip-warned — while the deferred envelope itself has not been delivered and
+// must be re-pulled. Committing here therefore acks everything before it and
+// nothing at or after it, and the next pull starts on the envelope that has to
+// be retried.
+//
+// Stopping one past the last DELIVERED envelope instead would be safe but not
+// sufficient: any hoisted request sitting between it and the deferred envelope
+// would come back in every redrive's pull window and be served again on each
+// one.
+//
+// The cursor never goes backwards, which keeps a re-pull of already-committed
+// envelopes from rewinding it. A zero deferredSeq is impossible — the mailbox
+// assigns event_seq from 1, and zero is the never-acked cursor sentinel — but
+// it is treated as "do not move" rather than trusted, because reading it as a
+// cursor is the one arithmetic here that could ack an undelivered envelope.
+func deferredCursor(deferredSeq, pullCursor uint64) uint64 {
+	if deferredSeq == 0 || deferredSeq <= pullCursor {
+		return pullCursor
+	}
+
+	return deferredSeq
+}
+
+// clampToDeferred restricts a redriven batch to the envelopes at or before the
+// event_seq that a full mailbox turned away last cycle, returning the batch to
+// process and the exclusive cursor that covers it.
+//
+// The clamp is what keeps a redrive from repeating work. The pre-transaction
+// steps — waiter delivery and the hoisted request round trips — run over the
+// whole batch before the transaction opens, but the cursor stops at the
+// deferred envelope, so everything behind it stays inside the pull window for
+// as long as the target stays wedged. Without the clamp each of those envelopes
+// is re-handled once per backoff cycle, indefinitely: for a hoisted request
+// that is a duplicate local serve plus a duplicate response sent to the
+// operator, and the routes waiting to be hoisted next are state-changing ones
+// where a duplicate is not free.
+//
+// A batch with nothing at or before deferredSeq is returned whole. That means
+// the envelope the last cycle could not deliver is no longer on the mailbox, so
+// there is nothing left to protect, and clamping to an empty batch would
+// instead let the caller advance the cursor over envelopes it never dispatched.
+func clampToDeferred(envelopes []*mailboxpb.Envelope, nextCursor,
+	deferredSeq uint64) ([]*mailboxpb.Envelope, uint64) {
+
+	if deferredSeq == 0 {
+		return envelopes, nextCursor
+	}
+
+	clamped := make([]*mailboxpb.Envelope, 0, len(envelopes))
+	for _, env := range envelopes {
+		if env.EventSeq <= deferredSeq {
+			clamped = append(clamped, env)
+		}
+	}
+
+	if len(clamped) == 0 || len(clamped) == len(envelopes) {
+		return envelopes, nextCursor
+	}
+
+	return clamped, deferredSeq + 1
 }
 
 // splitIngressEnvelopes partitions a pulled batch into the three ways an
@@ -770,6 +1057,12 @@ func splitIngressEnvelopes(envelopes []*mailboxpb.Envelope,
 // such as WalletService.SignVTXO or RoundService.SubmitNonces, needs its own
 // idempotency before it is added to NonTxRoutes, because correlation-ID dedup
 // on the operator does not make a second signature harmless.
+//
+// That exposure is bounded, and keeping it bounded is load-bearing. A crash or
+// a failed fold can repeat a serve; a stalled cursor cannot. Backpressure
+// re-pulls the same window every backoff cycle, so without redriveState's
+// watermark and clamp one wedged local actor would turn a single queued request
+// into one serve per cycle, indefinitely.
 func (a *ServerConnectionActor) isNonTxRequest(
 	env *mailboxpb.Envelope,
 ) bool {
@@ -858,15 +1151,28 @@ func (a *ServerConnectionActor) resolvesToNonTxDispatcher(
 // and sends the KIND_RESPONSE back over the edge, so this is where the network
 // round trip that used to sit inside the fold now happens.
 //
-// A failure stops the batch and surfaces to the caller, which leaves the
-// cursor where it was and re-pulls. Requests already served earlier in the
-// batch are then served a second time; that is the same at-least-once exposure
-// the legacy dispatch path has always had, and the operator demultiplexes the
-// duplicate response by correlation ID.
+// A failure stops the batch and surfaces to the caller, which leaves the cursor
+// where it was and re-pulls. Requests this loop already answered are not served
+// again on that re-pull: redrive.servedNonTxSeq remembers how far the serving
+// got, which is what keeps a stalled cursor from turning one queued request
+// into one operator round trip per backoff cycle. The watermark is per ingress
+// goroutine, so a restart still redelivers — that is the same at-least-once
+// exposure the legacy dispatch path has always had, and the operator
+// demultiplexes the duplicate response by correlation ID.
 func (a *ServerConnectionActor) dispatchNonTxRequests(ctx context.Context,
-	envelopes []*mailboxpb.Envelope) error {
+	envelopes []*mailboxpb.Envelope, redrive *redriveState) error {
 
 	for _, env := range envelopes {
+		// Already answered by an earlier cycle of this episode. The
+		// cursor has not passed it yet, so the mailbox keeps handing it
+		// back; serving it again would send the operator a second
+		// response to a request it has already had answered.
+		if env.EventSeq != 0 &&
+			env.EventSeq <= redrive.servedNonTxSeq {
+
+			continue
+		}
+
 		key := mailboxrpc.ServiceMethod{
 			Service: env.Rpc.Service,
 			Method:  env.Rpc.Method,
@@ -892,6 +1198,13 @@ func (a *ServerConnectionActor) dispatchNonTxRequests(ctx context.Context,
 
 		if err := dispatcher(ctx, env); err != nil {
 			return err
+		}
+
+		// Only a serve that returned records the watermark: a failed
+		// one may not have reached the operator, so it has to be
+		// retried rather than suppressed.
+		if env.EventSeq > redrive.servedNonTxSeq {
+			redrive.servedNonTxSeq = env.EventSeq
 		}
 	}
 
@@ -1009,4 +1322,41 @@ func (a *ServerConnectionActor) backoffConfig() mailboxpull.BackoffConfig {
 		BaseDelay: a.cfg.RetryBaseDelay,
 		MaxDelay:  a.cfg.RetryMaxDelay,
 	}
+}
+
+// maxDeferralDelay caps the redrive delay during a backpressure episode. It is
+// deliberately far below RetryMaxDelay, because the two delays are waiting for
+// different things. A transport retry waits for a remote endpoint, where a long
+// ceiling is politeness. A backpressure redrive waits for a local actor to
+// drain one mailbox turn, and the redrive is the only thing that moves the
+// client's inbound backlog: at the transport ceiling a recovered target drains
+// at one pull window per 30s, which is slower than the round client's own 60s
+// registration and 90s reconcile deadlines and would fail rounds that had
+// already put forfeit signatures on the wire.
+//
+// Half a second is chosen to be longer than any single mailbox turn a healthy
+// actor takes, so a briefly busy target is not hammered, and short enough that
+// a backlog of several pull windows still drains in seconds. The configured
+// RetryMaxDelay still applies when it is SHORTER, so a deployment (or a test)
+// that wants a tighter schedule keeps it.
+const maxDeferralDelay = 500 * time.Millisecond
+
+// sleepDeferralBackoff sleeps before redriving a deferred dispatch, on the
+// backpressure schedule rather than the transport one.
+func (a *ServerConnectionActor) sleepDeferralBackoff(ctx context.Context,
+	failCount *int) {
+
+	cfg := a.backoffConfig()
+	if cfg.MaxDelay <= 0 || cfg.MaxDelay > maxDeferralDelay {
+		cfg.MaxDelay = maxDeferralDelay
+	}
+
+	// A base delay above the ceiling would make the very first redrive wait
+	// longer than the ceiling allows, since the schedule starts at the
+	// base.
+	if cfg.BaseDelay > cfg.MaxDelay {
+		cfg.BaseDelay = cfg.MaxDelay
+	}
+
+	mailboxpull.Sleep(ctx, cfg, failCount)
 }

--- a/serverconn/ingress_backpressure_test.go
+++ b/serverconn/ingress_backpressure_test.go
@@ -1,0 +1,661 @@
+package serverconn
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	mailboxpb "github.com/lightninglabs/wavelength/mailbox/pb"
+	mailboxrpc "github.com/lightninglabs/wavelength/mailbox/rpc"
+	"github.com/lightninglabs/wavelength/metrics"
+	"github.com/lightninglabs/wavelength/serverconn/hellotestpb"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+const (
+	// stormMailboxCapacity is the target actor's mailbox capacity. It is
+	// small only so the test is fast: the wedge it reproduces is
+	// capacity-independent, and production runs the same code with the
+	// default 100.
+	stormMailboxCapacity = 4
+
+	// stormEnvelopes is how many events the storm pushes. It has to exceed
+	// the mailbox capacity by enough that the dispatch loop is still
+	// holding undelivered envelopes when it gives up.
+	stormEnvelopes = 12
+)
+
+// stalledBehavior is a real actor behavior that parks its receive turn until
+// the test releases it, then records every message it processes. It stands in
+// for a round client actor parked on any of the many unbounded waits it has: an
+// FSM transition, an un-deadlined Ask into the wallet or chain source, or a
+// state query on a machine mid-transition.
+type stalledBehavior struct {
+	// release gates the first receive turn. Closing it lets the actor
+	// drain.
+	release chan struct{}
+
+	mu sync.Mutex
+
+	// delivered records the session ID of every processed message, in
+	// processing order, so the test can assert exactly-once delivery.
+	delivered []string
+}
+
+// newStalledBehavior returns a behavior that parks until released.
+func newStalledBehavior() *stalledBehavior {
+	return &stalledBehavior{
+		release: make(chan struct{}),
+	}
+}
+
+// Receive parks until the test releases the actor, then records the message.
+func (b *stalledBehavior) Receive(ctx context.Context,
+	msg *helloStartedMsg) fn.Result[struct{}] {
+
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+		return fn.Err[struct{}](ctx.Err())
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.delivered = append(b.delivered, msg.SessionID)
+
+	return fn.Ok(struct{}{})
+}
+
+// observed returns a copy of the processed session IDs.
+func (b *stalledBehavior) observed() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return append([]string(nil), b.delivered...)
+}
+
+// stormConfig describes the traffic a storm harness seeds and the schedule its
+// ingress loop runs on. The zero value is the tight-schedule wedge the original
+// regression test uses.
+type stormConfig struct {
+	// route is the service name of the wedged target. It is unique per test
+	// so the deferral counter assertion reads only this test's label
+	// series.
+	route string
+
+	// events is how many KIND_EVENT envelopes to seed on that route.
+	events int
+
+	// hoistedAfter seeds one hoisted KIND_REQUEST per entry, after that
+	// many wedged events. The target accepts stormMailboxCapacity+1 events
+	// before it defers (its mailbox plus the one held in the parked receive
+	// turn), so an entry at or below that lands the request's event_seq
+	// BELOW the envelope that defers and an entry above it lands ABOVE.
+	// Both sides have to be covered: they were re-served by different
+	// arithmetic.
+	hoistedAfter []int
+
+	// retryBaseDelay and retryMaxDelay override the connector's backoff.
+	// Zero leaves the millisecond-scale schedule that keeps the wedge tests
+	// fast; a test that asserts on RECOVERY timing has to set production
+	// values, because a 10ms ceiling hides the schedule entirely.
+	retryBaseDelay time.Duration
+	retryMaxDelay  time.Duration
+}
+
+// stormHarness is a connector wired the way the daemon wires its round route: a
+// real actor system, a real fixed-capacity mailbox, a real EventRouter route,
+// and a store that models the single global database writer. Nothing on the
+// edge under test is faked, because a mocked actor reference is exactly what
+// would make this test vacuous — the bug lives in the mailbox.
+type stormHarness struct {
+	conn     *ServerConnectionActor
+	store    *writerLockStore
+	mailbox  *inMemoryMailbox
+	behavior *stalledBehavior
+
+	// service and method name the wedged route.
+	service string
+	method  string
+
+	// hoistedService and hoistedMethod name a marked non-transactional
+	// route, whose dispatcher stands in for the mux bridge: it answers the
+	// operator over the network rather than enqueuing anything.
+	hoistedService string
+	hoistedMethod  string
+
+	// hoistedServes counts how many times that dispatcher ran, which is the
+	// count a redrive must not multiply.
+	hoistedServes atomic.Int64
+}
+
+// newStormHarness builds the connector, registers the stalled actor, and seeds
+// the remote mailbox with count events on the actor's route.
+func newStormHarness(t *testing.T, route string, count int) *stormHarness {
+	t.Helper()
+
+	return newStormHarnessWith(t, stormConfig{
+		route:  route,
+		events: count,
+	})
+}
+
+// newStormHarnessWith is newStormHarness with the traffic and schedule spelled
+// out.
+func newStormHarnessWith(t *testing.T, cfg stormConfig) *stormHarness {
+	t.Helper()
+
+	system := actor.NewActorSystemWithConfig(actor.SystemConfig{
+		MailboxCapacity: stormMailboxCapacity,
+	})
+	t.Cleanup(func() {
+		require.NoError(t, system.Shutdown(context.Background()))
+	})
+
+	h := &stormHarness{
+		store:          newWriterLockStore(),
+		mailbox:        newInMemoryMailbox(),
+		behavior:       newStalledBehavior(),
+		service:        cfg.route,
+		method:         "HelloStarted",
+		hoistedService: cfg.route + ".Hoisted",
+		hoistedMethod:  "GetInfo",
+	}
+
+	// Register the target through the ordinary path, so it gets a genuine
+	// ChannelMailbox at the configured capacity rather than a test double.
+	key := actor.NewServiceKey[*helloStartedMsg, struct{}](cfg.route)
+	key.Spawn(system, "stalled-target", h.behavior)
+
+	router := NewEventRouter(system)
+	AddRoute(router, EventRouteConfig[*helloStartedMsg, struct{}]{
+		Service: h.service,
+		Method:  h.method,
+		NewEvent: func() proto.Message {
+			return &hellotestpb.HelloStartedEvent{}
+		},
+		Key: key,
+		Adapt: func(p proto.Message) (*helloStartedMsg, error) {
+			m := &helloStartedMsg{}
+
+			return m, m.FromProto(p)
+		},
+	})
+
+	connCfg := newTestConnectorConfig(h.mailbox, nil)
+	connCfg.MailboxProtocolVersion = 1
+	connCfg.ArkProtocolVersion = 1
+	connCfg.Store = h.store
+	connCfg.Dispatchers = router.AsDispatcherMap()
+
+	// Wire the hoisted route by hand, the way the daemon marks its
+	// mux-bridged routes: a dispatcher that does IO and no enqueue, plus
+	// the NonTxRoutes mark that pulls it out of the fold.
+	hoistedRoute := mailboxrpc.ServiceMethod{
+		Service: h.hoistedService,
+		Method:  h.hoistedMethod,
+	}
+	connCfg.Dispatchers[hoistedRoute] = func(context.Context,
+		*mailboxpb.Envelope) error {
+
+		h.hoistedServes.Add(1)
+
+		return nil
+	}
+	connCfg.NonTxRoutes = RouteSet{
+		hoistedRoute: {},
+	}
+
+	// Keep the retry schedule tight by default: the loop is expected to
+	// back off on every deferral, and a wedge test should not wait out a
+	// production backoff to observe the next attempt.
+	connCfg.RetryBaseDelay = time.Millisecond
+	connCfg.RetryMaxDelay = 10 * time.Millisecond
+	if cfg.retryBaseDelay > 0 {
+		connCfg.RetryBaseDelay = cfg.retryBaseDelay
+	}
+	if cfg.retryMaxDelay > 0 {
+		connCfg.RetryMaxDelay = cfg.retryMaxDelay
+	}
+
+	h.conn = NewServerConnectionActor(connCfg)
+
+	for i := range cfg.events {
+		for _, at := range cfg.hoistedAfter {
+			if at == i {
+				h.seedHoisted(t)
+			}
+		}
+
+		h.seed(t, fmt.Sprintf("s-%d", i))
+	}
+
+	for _, at := range cfg.hoistedAfter {
+		if at >= cfg.events {
+			h.seedHoisted(t)
+		}
+	}
+
+	return h
+}
+
+// eventEnvelope builds one KIND_EVENT envelope for the harness route. The
+// mailbox assigns the event_seq on send; a direct dispatch caller sets seq
+// itself.
+func (h *stormHarness) eventEnvelope(t *testing.T, sessionID string,
+	seq uint64) *mailboxpb.Envelope {
+
+	t.Helper()
+
+	body, err := anypb.New(&hellotestpb.HelloStartedEvent{
+		SessionId: sessionID,
+	})
+	require.NoError(t, err)
+
+	env := nonTxTestEnvelope(
+		mailboxpb.RpcMeta_KIND_EVENT, h.service, h.method, seq,
+	)
+	env.Recipient = "client-1"
+	env.Body = body
+
+	return env
+}
+
+// seed pushes one KIND_EVENT envelope for the harness route onto the client's
+// remote mailbox.
+func (h *stormHarness) seed(t *testing.T, sessionID string) {
+	t.Helper()
+
+	status := h.mailbox.send(h.eventEnvelope(t, sessionID, 0))
+	require.True(t, status.Ok)
+}
+
+// seedHoisted pushes one KIND_REQUEST envelope for the marked route onto the
+// client's remote mailbox.
+func (h *stormHarness) seedHoisted(t *testing.T) {
+	t.Helper()
+
+	env := nonTxTestEnvelope(
+		mailboxpb.RpcMeta_KIND_REQUEST, h.hoistedService,
+		h.hoistedMethod, 0,
+	)
+	env.Recipient = "client-1"
+
+	status := h.mailbox.send(env)
+	require.True(t, status.Ok)
+}
+
+// run starts the ingress loop and returns a cancel func plus a channel that
+// closes when the loop has returned.
+func (h *stormHarness) run(t *testing.T) (context.CancelFunc, chan struct{}) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	h.conn.wg.Add(1)
+	go func() {
+		defer close(done)
+
+		h.conn.ingressLoop(ctx, AckState{})
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("ingress loop did not exit")
+		}
+	})
+
+	return cancel, done
+}
+
+// deferrals reads this harness route's deferral counter.
+func (h *stormHarness) deferrals() float64 {
+	return testutil.ToFloat64(
+		metrics.ServerConnIngressDeferredTotal.WithLabelValues(
+			h.service, h.method,
+		),
+	)
+}
+
+// TestIngressStormDoesNotWedgeOnFullRoundMailbox is the regression test for the
+// wedge that made a deployed client go silently deaf to round events.
+//
+// The ingress loop is the process's only consumer of the server mailbox, and it
+// used to deliver into the round client's fixed-capacity in-memory mailbox with
+// a blocking Tell, on a context with no deadline, from inside the folded write
+// transaction. A target that stopped draining therefore parked that one
+// goroutine forever with the database's single writer held, while read-only
+// RPCs kept answering — a healthy-looking pod that had stopped hearing the
+// operator.
+//
+// The test asserts the properties rather than timing them: the writer lock must
+// not be held while the target is stalled, the loop must keep taking turns, no
+// envelope may be acknowledged before it is delivered, and every envelope must
+// still arrive exactly once after the target drains.
+func TestIngressStormDoesNotWedgeOnFullRoundMailbox(t *testing.T) {
+	t.Parallel()
+
+	h := newStormHarness(t, "storm.v1.HelloService", stormEnvelopes)
+	_, _ = h.run(t)
+
+	// The loop must reach a state where it has stopped dispatching but has
+	// NOT parked: every transaction it opened has closed, and the modeled
+	// global writer is free. Before the fix the last thing in the log is a
+	// tx-open with no matching tx-close, because the loop is parked inside
+	// ChannelMailbox.Send with the writer held.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		observed := h.store.observed()
+		if !assert.NotEmpty(c, observed) {
+			return
+		}
+
+		assert.Equal(
+			c, "tx-close", observed[len(observed)-1],
+			"loop is parked inside the write transaction",
+		)
+		assert.False(
+			c, h.store.writerHeld(),
+			"the modeled global writer is still held",
+		)
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Backpressure has to be visible. This is the observability half of the
+	// fix: the old path's only log was a mailbox-level Trace, which is why
+	// two incidents produced no evidence.
+	require.Eventually(t, func() bool {
+		return h.deferrals() > 0
+	}, 5*time.Second, 10*time.Millisecond,
+		"no dispatch deferral was recorded")
+
+	// The ack watermark must stop short of the envelopes that were never
+	// handed over. Acking past an undelivered event is how backpressure
+	// would turn into a lost round event, and it is what leaves nothing for
+	// the redelivery below to find.
+	//
+	// The most the mailbox can have taken is its capacity, plus the one
+	// message the stalled actor is holding in its receive turn; the cursor
+	// is exclusive, so one more than that. Sequence numbers are dense from
+	// 1.
+	const maxAcked = stormMailboxCapacity + 2
+
+	acked := h.mailbox.getAckedUpTo("client-1")
+	require.LessOrEqual(t, acked, uint64(maxAcked))
+	require.Less(t, acked, uint64(stormEnvelopes+1))
+
+	// Release the target. Everything the storm pushed must arrive, exactly
+	// once and in order, including the envelopes that were deferred.
+	close(h.behavior.release)
+
+	want := make([]string, 0, stormEnvelopes)
+	for i := range stormEnvelopes {
+		want = append(want, fmt.Sprintf("s-%d", i))
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Len(
+			c, h.behavior.observed(), stormEnvelopes,
+			"deferred envelopes were never redelivered",
+		)
+	}, 10*time.Second, 10*time.Millisecond)
+
+	require.Equal(t, want, h.behavior.observed())
+}
+
+// TestIngressRedriveDoesNotReplayHoistedRequests pins the cost of the redrive
+// itself.
+//
+// Redrive-in-place is now the steady state of a wedged target, and the two
+// pre-transaction steps of a folded dispatch — waiter delivery, and the hoisted
+// KIND_REQUEST round trips — run over the whole pulled batch before the
+// transaction opens. The cursor stops at the undelivered envelope, so without a
+// clamp every hoisted request in the pull window is served again on every
+// backoff cycle, forever: a duplicate local serve plus a duplicate
+// KIND_RESPONSE to the operator, starting exactly when the client is already in
+// trouble. The routes queued to be hoisted next (WalletService.SignVTXO,
+// RoundService.SubmitNonces) are ones where a duplicate is a second signature,
+// not a wasted read.
+//
+// The assertion is a count, not a timing: however many redrives the wedge
+// produces, each hoisted request is served at most once, and exactly once by
+// the time the backlog drains.
+func TestIngressRedriveDoesNotReplayHoistedRequests(t *testing.T) {
+	t.Parallel()
+
+	// One request lands below the envelope that defers and one above it.
+	// The two were re-served by different arithmetic: the one below stayed
+	// inside the pull window because the cursor stopped one past the last
+	// DELIVERED envelope rather than at the deferred one, and the one above
+	// because the pre-transaction pass never looked at where the cursor had
+	// stopped.
+	const hoistedRequests = 2
+
+	h := newStormHarnessWith(t, stormConfig{
+		route:  "storm-hoist.v1.HelloService",
+		events: stormEnvelopes,
+		hoistedAfter: []int{
+			stormMailboxCapacity + 1, stormEnvelopes,
+		},
+	})
+	_, _ = h.run(t)
+
+	// Wait for a number of redrives well above the number of hoisted
+	// requests, so a per-cycle replay could not hide inside the bound
+	// below.
+	const redrives = 10
+
+	require.Eventually(t, func() bool {
+		return h.deferrals() >= redrives
+	}, 10*time.Second, 10*time.Millisecond,
+		"the wedge did not produce enough redrives to be conclusive")
+
+	require.LessOrEqual(
+		t, h.hoistedServes.Load(), int64(hoistedRequests),
+		"a hoisted request was served more than once while the "+
+			"target was wedged",
+	)
+
+	// Draining must not change the accounting either: every hoisted request
+	// is served, and none of them twice.
+	close(h.behavior.release)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Len(c, h.behavior.observed(), stormEnvelopes)
+	}, 10*time.Second, 10*time.Millisecond)
+
+	require.Equal(
+		t, int64(hoistedRequests), h.hoistedServes.Load(),
+		"hoisted requests were not served exactly once each",
+	)
+}
+
+// TestIngressBackpressureRecoversPromptly pins the redrive CADENCE, which the
+// other tests in this file deliberately cannot see: they run on a 1ms/10ms
+// schedule so the wedge is fast to reproduce, and that override hides the whole
+// question of how long recovery takes.
+//
+// This one runs on the production schedule. The failure it guards against is
+// backpressure sharing the transport backoff: the deferral path increments the
+// same fail count on every re-pull and, without a reset on progress, saturates
+// at RetryMaxDelay (30s) and stays there. A recovered target then drains at one
+// pull window per 30s, which is slower than the round client's own 60s
+// registration and 90s reconcile deadlines — so backpressure that has already
+// cleared still fails rounds, after forfeit signatures are on the wire.
+//
+// The trigger is a COUNT of redrives, not a wall-clock rate, so the assertion
+// does not encode a schedule of its own: the point is what happens to recovery
+// after the schedule has had time to ratchet, whenever that is. (A rate
+// assertion would also be blunted by ackPhase, which resets the shared fail
+// count on any cycle with an ack outstanding, so the pre-fix ramp only takes
+// hold once the cursor stops advancing — which is exactly the steady state of a
+// wedge.)
+func TestIngressBackpressureRecoversPromptly(t *testing.T) {
+	t.Parallel()
+
+	defaults := DefaultConnectorConfig()
+
+	h := newStormHarnessWith(t, stormConfig{
+		route:          "storm-recover.v1.HelloService",
+		events:         stormEnvelopes,
+		retryBaseDelay: defaults.RetryBaseDelay,
+		retryMaxDelay:  defaults.RetryMaxDelay,
+	})
+	_, _ = h.run(t)
+
+	// Enough redrives that an uncapped doubling schedule is at its 30s
+	// ceiling by now. The window is generous because the schedule under
+	// test is the thing being measured, not this wait.
+	const redrives = 10
+
+	require.Eventually(t, func() bool {
+		return h.deferrals() >= redrives
+	}, time.Minute, 10*time.Millisecond,
+		"the wedge did not produce enough redrives to be conclusive")
+
+	// The target recovers. Everything still queued has to arrive within a
+	// few redrives, not within a few transport ceilings. At the 30s ceiling
+	// the very next redrive alone overruns this window.
+	close(h.behavior.release)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Len(
+			c, h.behavior.observed(), stormEnvelopes, "the "+
+				"backlog did not drain promptly after the "+
+				"target recovered",
+		)
+	}, 5*time.Second, 20*time.Millisecond)
+}
+
+// replayingStore models the production store's response to a retryable
+// transaction error: it rolls the attempt back and runs the whole body again,
+// up to ten times. Whatever the body wrote is discarded by the rollback;
+// whatever it did OUTSIDE the transaction is not, which is the asymmetry this
+// test is about.
+type replayingStore struct {
+	*writerLockStore
+
+	// replays is how many rolled-back attempts to run before the one that
+	// commits.
+	replays int
+}
+
+// ExecTx runs the body replays+1 times, each in its own modeled transaction.
+func (s *replayingStore) ExecTx(ctx context.Context, readOnly bool,
+	fn actor.TxFunc) error {
+
+	for range s.replays {
+		if err := s.writerLockStore.ExecTx(
+			ctx, readOnly, fn,
+		); err != nil {
+			return err
+		}
+	}
+
+	return s.writerLockStore.ExecTx(ctx, readOnly, fn)
+}
+
+// TestFoldedDispatchDoesNotReplayInMemoryDeliveries pins the one effect inside
+// the fold that a rolled-back transaction does not undo.
+//
+// A durable enqueue is a write in the fold's transaction, so replaying the body
+// after a retryable error (SQLITE_BUSY, Postgres 40001) is a no-op in net
+// effect. A delivery into a bounded in-memory mailbox is not in the transaction
+// at all: the target actor can have processed the message before the
+// transaction even tries to commit. Every attempt therefore used to re-deliver
+// the whole durable partition's in-memory half, up to ten times, and then
+// report success — no log, no metric, no way to tell from the outside.
+func TestFoldedDispatchDoesNotReplayInMemoryDeliveries(t *testing.T) {
+	t.Parallel()
+
+	const events = 3
+
+	h := newStormHarnessWith(t, stormConfig{
+		route:  "storm-replay.v1.HelloService",
+		events: 0,
+	})
+
+	// The target drains normally here. The property under test is how many
+	// times the fold hands a message over, not what happens when it will
+	// not take one.
+	close(h.behavior.release)
+
+	store := &replayingStore{
+		writerLockStore: h.store,
+		replays:         2,
+	}
+
+	envelopes := make([]*mailboxpb.Envelope, 0, events)
+	for i := range events {
+		envelopes = append(
+			envelopes,
+			h.eventEnvelope(
+				t, fmt.Sprintf("r-%d", i), uint64(i+1),
+			),
+		)
+	}
+
+	newState, err := h.conn.runFoldedDispatch(
+		t.Context(), store, envelopes, events+1, AckState{},
+		&redriveState{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(events+1), newState.PullCursor)
+
+	want := []string{"r-0", "r-1", "r-2"}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, want, h.behavior.observed())
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Three replays of a three-envelope batch would be nine deliveries. The
+	// mailbox is draining, so any duplicate would show up here rather than
+	// being lost to a full mailbox.
+	require.Never(t, func() bool {
+		return len(h.behavior.observed()) > events
+	}, 300*time.Millisecond, 20*time.Millisecond)
+}
+
+// TestIngressCancelReleasesStalledDispatch pins the shutdown escape while a
+// target is stalled. The loop must return on context cancellation even though
+// the target has never drained a single message, and it must do so without
+// waiting for the target: a shutdown that hangs on a wedged actor is the same
+// unbounded wait in a different place.
+func TestIngressCancelReleasesStalledDispatch(t *testing.T) {
+	t.Parallel()
+
+	h := newStormHarness(t, "storm-cancel.v1.HelloService", stormEnvelopes)
+	cancel, done := h.run(t)
+
+	// Wait until the loop has actually met the full mailbox, so the
+	// cancellation lands on a loop that is mid-backpressure rather than one
+	// that has not started yet.
+	require.Eventually(t, func() bool {
+		return h.deferrals() > 0
+	}, 5*time.Second, 10*time.Millisecond,
+		"no dispatch deferral was recorded")
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal(
+			"ingress loop did not exit while the target was " +
+				"stalled",
+		)
+	}
+}

--- a/serverconn/ingress_deferral_property_test.go
+++ b/serverconn/ingress_deferral_property_test.go
@@ -1,0 +1,1232 @@
+package serverconn
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/wavelength/baselib/actor"
+	mailboxpb "github.com/lightninglabs/wavelength/mailbox/pb"
+	mailboxrpc "github.com/lightninglabs/wavelength/mailbox/rpc"
+	"github.com/lightninglabs/wavelength/serverconn/hellotestpb"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"pgregory.net/rapid"
+)
+
+// drawAscendingEventSeqs draws a strictly ascending event_seq run starting at
+// or after 1, the way a mailbox stamps a pulled window. Gaps are allowed
+// because a pull filters by recipient, so a client's window is ascending but
+// not necessarily dense.
+func drawAscendingEventSeqs(rt *rapid.T, maxCount int) []uint64 {
+	count := rapid.IntRange(0, maxCount).Draw(rt, "envelope_count")
+
+	seqs := make([]uint64, 0, count)
+
+	seq := uint64(0)
+	for range count {
+		seq += uint64(rapid.IntRange(1, 3).Draw(rt, "seq_gap"))
+		seqs = append(seqs, seq)
+	}
+
+	return seqs
+}
+
+// TestClampToDeferred_CursorSafety_Property pins the clamp that keeps a redrive
+// from repeating a previous cycle's pre-transaction work.
+//
+// The clamp is on the cursor's critical path: it returns both the batch the
+// fold will process and the exclusive cursor that batch commits, so a clamp
+// that returned a cursor covering an envelope it dropped would ack an event no
+// dispatcher ever saw. The state space is the cross product of batch shape,
+// gap layout and where in (or outside) the batch the deferral fell, which is
+// exactly the shape example-based tests sample thinly.
+func TestClampToDeferred_CursorSafety_Property(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		seqs := drawAscendingEventSeqs(rt, 8)
+
+		envelopes := make([]*mailboxpb.Envelope, 0, len(seqs))
+		input := make(map[uint64]bool, len(seqs))
+		for _, seq := range seqs {
+			envelopes = append(envelopes, eventEnvelope(seq))
+			input[seq] = true
+		}
+
+		var last uint64
+		if len(seqs) > 0 {
+			last = seqs[len(seqs)-1]
+		}
+
+		// The mailbox returns the exclusive cursor one past the last
+		// envelope it handed over; the slack covers a server that
+		// skipped trailing envelopes the client cannot see.
+		slack := rapid.IntRange(0, 2).Draw(rt, "cursor_slack")
+		nextCursor := last + 1 + uint64(slack)
+
+		// The deferral is drawn from inside the batch, from a gap, and
+		// from past its end, which is the case where the envelope that
+		// wedged the last cycle is no longer on the mailbox.
+		deferredSeq := rapid.Uint64Range(0, last+2).Draw(
+			rt, "deferred_seq",
+		)
+
+		clamped, cursor := clampToDeferred(
+			envelopes, nextCursor, deferredSeq,
+		)
+
+		// The clamp only ever drops envelopes: it never reorders the
+		// batch and never invents an envelope that was not pulled.
+		kept := make(map[uint64]bool, len(clamped))
+		var prevSeq uint64
+		for i, env := range clamped {
+			if i > 0 && env.EventSeq <= prevSeq {
+				rt.Fatalf("clamp reordered event_seq %d "+
+					"after %d", env.EventSeq, prevSeq)
+			}
+			if !input[env.EventSeq] {
+				rt.Fatalf("clamp invented event_seq %d",
+					env.EventSeq)
+			}
+
+			prevSeq = env.EventSeq
+			kept[env.EventSeq] = true
+		}
+
+		// CURSOR SAFETY: an exclusive cursor acks every event_seq below
+		// it, so nothing the clamp dropped may sit below the cursor it
+		// returned. This is the one arithmetic here that can ack an
+		// envelope no dispatcher will ever see.
+		for _, env := range envelopes {
+			if kept[env.EventSeq] {
+				continue
+			}
+
+			if env.EventSeq < cursor {
+				rt.Fatalf("clamp cursor %d covers dropped "+
+					"event_seq %d", cursor, env.EventSeq)
+			}
+		}
+
+		// The converse keeps the clamp useful rather than merely safe:
+		// the cursor has to cover everything the clamp kept, or the
+		// caller could not commit the batch it was handed.
+		for _, env := range clamped {
+			if env.EventSeq >= cursor {
+				rt.Fatalf("clamp cursor %d does not cover "+
+					"kept event_seq %d", cursor,
+					env.EventSeq)
+			}
+		}
+
+		// The clamp narrows the window; it never widens it past what
+		// the pull actually returned.
+		if cursor > nextCursor {
+			rt.Fatalf("clamp cursor %d ran past pull cursor %d",
+				cursor, nextCursor)
+		}
+
+		// A cleared deferral is the identity, which is what an
+		// unwedged loop runs on every batch.
+		if deferredSeq == 0 && (len(clamped) != len(envelopes) ||
+			cursor != nextCursor) {
+
+			rt.Fatalf("clamp with no deferral changed the batch")
+		}
+
+		// Re-clamping is a fixed point. A wedged target is redriven
+		// with the same deferredSeq for as long as it stays wedged, so
+		// a clamp that kept narrowing would walk the cursor backwards
+		// over cycles.
+		again, againCursor := clampToDeferred(
+			clamped, cursor, deferredSeq,
+		)
+		if len(again) != len(clamped) || againCursor != cursor {
+			rt.Fatalf("clamp is not idempotent: %d/%d then %d/%d",
+				len(clamped), cursor, len(again), againCursor)
+		}
+	})
+}
+
+// TestDeferredCursor_NeverAcksDeferred_Property pins the cursor the fold
+// commits when a full mailbox stops a batch partway.
+//
+// deferredCursor is four lines, and all four are load-bearing: it is the only
+// place the loop turns "this envelope was refused" into "everything before it
+// is acked". Off by one in either direction is a bug with no local symptom —
+// one too high silently drops a round event, one too low replays a hoisted
+// request on every redrive of the episode.
+func TestDeferredCursor_NeverAcksDeferred_Property(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		pullCursor := rapid.Uint64Range(0, 64).Draw(rt, "pull_cursor")
+		deferredSeq := rapid.Uint64Range(0, 64).Draw(
+			rt, "deferred_seq",
+		)
+
+		cursor := deferredCursor(deferredSeq, pullCursor)
+
+		// The cursor never goes backwards, so a re-pull of already
+		// committed envelopes cannot rewind it.
+		if cursor < pullCursor {
+			rt.Fatalf("deferred cursor %d rewound past %d", cursor,
+				pullCursor)
+		}
+
+		// It is always one of its two inputs: the function either holds
+		// the cursor where it was or moves it exactly onto the
+		// undelivered envelope. Anything else would be arithmetic
+		// nobody can bound.
+		if cursor != pullCursor && cursor != deferredSeq {
+			rt.Fatalf("deferred cursor %d is neither %d nor %d",
+				cursor, pullCursor, deferredSeq)
+		}
+
+		// CURSOR SAFETY: the deferred envelope was refused by its
+		// target, so it must never fall below the committed cursor.
+		// The carve-out is a cursor that was already past it, where an
+		// earlier cycle committed the envelope and nothing can be
+		// un-acked.
+		if deferredSeq >= pullCursor && cursor > deferredSeq {
+			rt.Fatalf("deferred cursor %d acked undelivered "+
+				"event_seq %d", cursor, deferredSeq)
+		}
+
+		// A zero event_seq is never trusted as a cursor: the mailbox
+		// stamps from 1, so a zero means the envelope was never stamped
+		// by a server.
+		if deferredSeq == 0 && cursor != pullCursor {
+			rt.Fatalf("zero deferredSeq moved the cursor to %d",
+				cursor)
+		}
+	})
+}
+
+// TestSplitAndMerge_PreserveOrder_Property pins the per-target ordering
+// contract of the two functions that reshape a pulled batch before it is
+// dispatched. splitIngressEnvelopes fans the batch into three delivery paths
+// and mergeEnvelopesByEventSeq folds the vanished-waiter stragglers back into
+// the durable one; between them they must lose nothing, duplicate nothing, and
+// leave every partition in event_seq order, because the durable partition's
+// order is the order the target actor's lane sees.
+func TestSplitAndMerge_PreserveOrder_Property(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		seqs := drawAscendingEventSeqs(rt, 8)
+
+		// Each envelope independently rolls whether it is a response
+		// with a live waiter, a hoisted request, or an ordinary durable
+		// event, so the partition is exercised in every mixture.
+		envelopes := make([]*mailboxpb.Envelope, 0, len(seqs))
+		waiters := make(map[uint64]bool, len(seqs))
+		hoisted := make(map[uint64]bool, len(seqs))
+		for _, seq := range seqs {
+			kind := rapid.IntRange(0, 2).Draw(rt, "kind")
+
+			switch kind {
+			case 0:
+				corrID := "corr-" + strconv.FormatUint(seq, 10)
+				envelopes = append(
+					envelopes,
+					responseEnvelope(corrID, seq),
+				)
+				waiters[seq] = rapid.Bool().Draw(
+					rt, "waiter_live",
+				)
+
+			case 1:
+				envelopes = append(
+					envelopes, requestEnvelope(
+						deferPropHoistedService,
+						deferPropHoistedMethod, seq,
+					),
+				)
+				hoisted[seq] = true
+
+			default:
+				envelopes = append(
+					envelopes, eventEnvelope(seq),
+				)
+			}
+		}
+
+		live := make(map[CorrelationID]bool, len(waiters))
+		for seq, ok := range waiters {
+			corrID := "corr-" + strconv.FormatUint(seq, 10)
+			live[CorrelationID(corrID)] = ok
+		}
+
+		hasWaiter := func(id CorrelationID) bool {
+			return live[id]
+		}
+		isNonTx := func(env *mailboxpb.Envelope) bool {
+			return hoisted[env.EventSeq]
+		}
+
+		responses, nonTx, durables := splitIngressEnvelopes(
+			envelopes, hasWaiter, isNonTx,
+		)
+
+		// The three partitions cover the batch exactly once each.
+		total := len(responses) + len(nonTx) + len(durables)
+		if total != len(envelopes) {
+			rt.Fatalf("split changed the batch size: %d -> %d",
+				len(envelopes), total)
+		}
+
+		seen := make(map[uint64]int, len(envelopes))
+		for _, part := range [][]*mailboxpb.Envelope{
+			responses, nonTx, durables,
+		} {
+
+			requireAscending(rt, part)
+
+			for _, env := range part {
+				seen[env.EventSeq]++
+			}
+		}
+		for _, seq := range seqs {
+			if seen[seq] != 1 {
+				rt.Fatalf("event_seq %d appears in %d "+
+					"partitions", seq, seen[seq])
+			}
+		}
+
+		// Any subset of the responses can come back as a straggler when
+		// its waiter vanishes between the split peek and the delivery.
+		// Folding them back has to restore a single ascending lane.
+		var stragglers []*mailboxpb.Envelope
+		for _, env := range responses {
+			if rapid.Bool().Draw(rt, "waiter_vanished") {
+				stragglers = append(stragglers, env)
+			}
+		}
+
+		merged := mergeEnvelopesByEventSeq(durables, stragglers)
+		requireAscending(rt, merged)
+
+		if len(merged) != len(durables)+len(stragglers) {
+			rt.Fatalf("merge changed the batch size: %d + %d -> %d",
+				len(durables), len(stragglers), len(merged))
+		}
+	})
+}
+
+// requireAscending fails the property when a partition is not in ascending
+// event_seq order.
+func requireAscending(rt *rapid.T, envelopes []*mailboxpb.Envelope) {
+	for i := 1; i < len(envelopes); i++ {
+		if envelopes[i].EventSeq <= envelopes[i-1].EventSeq {
+			rt.Fatalf("partition out of order at %d: %d after %d",
+				i, envelopes[i].EventSeq,
+				envelopes[i-1].EventSeq)
+		}
+	}
+}
+
+// deferralBackoffSlack is how much a measured sleep may overshoot its ceiling
+// before the property fails. The assertion is a ceiling, not a stopwatch: a
+// loaded CI box can deschedule the test goroutine for a while after the timer
+// fires, and only a bound that ignores that noise is worth having.
+const deferralBackoffSlack = 250 * time.Millisecond
+
+// TestSleepDeferralBackoff_BoundedDelay_Property pins the redrive schedule's
+// ceiling.
+//
+// The redrive is the only thing that moves a wedged client's inbound backlog,
+// so its delay is bounded by maxDeferralDelay rather than by the transport's
+// RetryMaxDelay: at the transport ceiling a recovered target drains one pull
+// window per 30s, which is slower than the round client's own deadlines. A
+// deployment that configures something TIGHTER than the backpressure cap keeps
+// it, so the bound is the minimum of the two, and both directions have to hold
+// for every schedule rather than for the two the example tests pick.
+func TestSleepDeferralBackoff_BoundedDelay_Property(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		// Most draws use a millisecond-scale schedule, where the
+		// configured ceiling is the binding one and a full sleep costs
+		// nothing. A saturated draw is the only way to show that
+		// maxDeferralDelay binds a schedule whose own ceiling is far
+		// above it, and showing that means sleeping most of it, so it
+		// is drawn rarely.
+		saturated := rapid.IntRange(0, 15).Draw(rt, "saturated") == 0
+
+		baseMs := rapid.IntRange(1, 8).Draw(rt, "base_ms")
+		maxMs := rapid.IntRange(1, 20).Draw(rt, "max_ms")
+		attempt := rapid.IntRange(0, 4).Draw(rt, "attempt")
+
+		cfg := newTestConnectorConfig(
+			newInMemoryMailbox(), newMemCheckpointStore(),
+		)
+		cfg.RetryBaseDelay = time.Duration(baseMs) * time.Millisecond
+		cfg.RetryMaxDelay = time.Duration(maxMs) * time.Millisecond
+
+		if saturated {
+			// A base above the ceiling and a transport ceiling far
+			// above the backpressure cap: nothing but
+			// maxDeferralDelay can bound this sleep.
+			cfg.RetryBaseDelay = 5 * time.Second
+			cfg.RetryMaxDelay = 30 * time.Second
+		}
+
+		conn := NewServerConnectionActor(cfg)
+
+		ceiling := cfg.RetryMaxDelay
+		if ceiling <= 0 || ceiling > maxDeferralDelay {
+			ceiling = maxDeferralDelay
+		}
+
+		failCount := attempt
+
+		start := time.Now()
+		conn.sleepDeferralBackoff(context.Background(), &failCount)
+		elapsed := time.Since(start)
+
+		if elapsed > ceiling+deferralBackoffSlack {
+			rt.Fatalf("deferral backoff slept %s with base %s and "+
+				"max %s, ceiling is %s", elapsed,
+				cfg.RetryBaseDelay, cfg.RetryMaxDelay, ceiling)
+		}
+
+		// The schedule advances by exactly one attempt per redrive.
+		// The count is the loop's own, kept apart from the transport
+		// one, and a redrive that skipped or double-counted would
+		// silently move the whole episode onto a different curve.
+		if failCount != attempt+1 {
+			rt.Fatalf("deferral fail count went %d -> %d", attempt,
+				failCount)
+		}
+	})
+}
+
+// Property-test routes. Each names one of the three ways an inbound envelope
+// reaches its destination, so a generated batch can mix all of them in one
+// pull window.
+const (
+	// deferPropService and deferPropMethod name the route whose target is
+	// a real actor behind a real fixed-capacity mailbox. This is the route
+	// that defers.
+	deferPropService = "deferprop.v1.HelloService"
+	deferPropMethod  = "HelloStarted"
+
+	// deferPropHoistedService and deferPropHoistedMethod name a marked
+	// non-transactional route, whose dispatcher stands in for the mux
+	// bridge: it answers the operator over the network and enqueues
+	// nothing.
+	deferPropHoistedService = "deferprop.v1.DaemonService"
+	deferPropHoistedMethod  = "GetInfo"
+
+	// deferPropUnaryService and deferPropUnaryMethod name the route the
+	// waiter-backed responses arrive on. It has no dispatcher, because a
+	// response with a live waiter never reaches the dispatch table.
+	deferPropUnaryService = "deferprop.v1.UnaryService"
+	deferPropUnaryMethod  = "Echo"
+)
+
+// errDeferPropServe is the injected failure of a hoisted request's round trip
+// to the operator, which is the one error that can stop a folded dispatch
+// before its transaction ever opens.
+var errDeferPropServe = errors.New("deferprop: send RPC response failed")
+
+// deferPropKind is how a generated envelope is meant to be delivered.
+type deferPropKind uint8
+
+const (
+	// deferPropDurable is a KIND_EVENT for the in-memory target actor,
+	// dispatched inside the folded write transaction.
+	deferPropDurable deferPropKind = iota
+
+	// deferPropHoisted is a KIND_REQUEST on a marked route, served before
+	// the transaction opens.
+	deferPropHoisted
+
+	// deferPropWaiter is a KIND_RESPONSE with a live in-memory waiter,
+	// delivered before the transaction opens.
+	deferPropWaiter
+)
+
+// gatedBehavior is a real actor behavior whose receive turn the test holds
+// shut. It stands in for any of the unbounded waits a round client actor can
+// park on, and unlike stalledBehavior its gate can be reopened and shut again,
+// which is what lets one property run toggle the target's mailbox between full
+// and drained across redrive cycles.
+type gatedBehavior struct {
+	mu sync.Mutex
+
+	// openCh is closed while the gate is open. A shut gate replaces it
+	// with a fresh open channel, so a receive turn that has not started
+	// yet blocks on the new one.
+	openCh chan struct{}
+
+	// delivered records the session ID of every processed message, in
+	// processing order, so the test can compare the target's lane against
+	// the deliveries the fold actually made.
+	delivered []string
+}
+
+// newGatedBehavior returns a behavior whose gate starts shut.
+func newGatedBehavior() *gatedBehavior {
+	return &gatedBehavior{
+		openCh: make(chan struct{}),
+	}
+}
+
+// Receive parks until the gate opens, then records the message. Cancellation
+// is honoured so the actor system can shut down while the gate is still shut.
+func (b *gatedBehavior) Receive(ctx context.Context,
+	msg *helloStartedMsg) fn.Result[struct{}] {
+
+	b.mu.Lock()
+	gate := b.openCh
+	b.mu.Unlock()
+
+	select {
+	case <-gate:
+	case <-ctx.Done():
+		return fn.Err[struct{}](ctx.Err())
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.delivered = append(b.delivered, msg.SessionID)
+
+	return fn.Ok(struct{}{})
+}
+
+// open lets the target drain.
+func (b *gatedBehavior) open() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	select {
+	case <-b.openCh:
+	default:
+		close(b.openCh)
+	}
+}
+
+// shut wedges the target again, so the next redrive meets a mailbox that fills
+// up.
+func (b *gatedBehavior) shut() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	select {
+	case <-b.openCh:
+		b.openCh = make(chan struct{})
+
+	default:
+	}
+}
+
+// count returns how many messages the target has processed.
+func (b *gatedBehavior) count() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return len(b.delivered)
+}
+
+// observed returns a copy of the processed session IDs.
+func (b *gatedBehavior) observed() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return append([]string(nil), b.delivered...)
+}
+
+// deferPropHarness is a connector wired the way the daemon wires its round
+// route — a real actor system, a real fixed-capacity mailbox, a real
+// EventRouter route and a store that models the single global writer — plus
+// the bookkeeping a property run needs to hold the fold to its contract.
+//
+// Nothing on the path under test is faked. The two dispatchers the harness
+// installs wrap or stand beside the real ones and only OBSERVE what they did,
+// so the model the invariants are checked against is built out of the
+// production pipeline's own outcomes rather than out of a second
+// implementation of it.
+type deferPropHarness struct {
+	conn     *ServerConnectionActor
+	system   *actor.ActorSystem
+	store    *writerLockStore
+	behavior *gatedBehavior
+
+	// envelopes is the generated window, in ascending event_seq order, and
+	// kinds says how each of them is meant to be delivered.
+	envelopes []*mailboxpb.Envelope
+	kinds     map[uint64]deferPropKind
+
+	// waiters holds one live in-memory waiter per waiter-backed response.
+	waiters map[uint64]actor.Future[*mailboxpb.Envelope]
+
+	// cycle is the index of the redrive cycle currently running. It is
+	// what turns "delivered twice" into the two questions that have
+	// different answers: twice inside one folded dispatch is the
+	// deliveredOutsideTx regression, twice across cycles is documented
+	// at-least-once behaviour.
+	cycle int
+
+	// failHoisted makes every hoisted serve in the current cycle fail.
+	failHoisted bool
+
+	// durableAccepted records the envelopes whose dispatcher returned nil,
+	// meaning the target's mailbox took them.
+	durableAccepted map[uint64]bool
+
+	// durableTellCycle is the last cycle in which an envelope was actually
+	// handed to the mailbox rather than suppressed as an in-flight
+	// replay.
+	durableTellCycle map[uint64]int
+
+	// expectedLog is the session IDs the target must process, in the order
+	// the fold handed them over. expectedSeq and expectedCycle carry the
+	// event_seq and the cycle of each of those hand-offs.
+	expectedLog   []string
+	expectedSeq   []uint64
+	expectedCycle []int
+
+	// hoistedServed counts the SUCCESSFUL serves of each hoisted request,
+	// which is the count a redrive must not multiply.
+	hoistedServed map[uint64]int
+
+	// dupInFold records an envelope handed to the mailbox twice inside one
+	// folded dispatch.
+	dupInFold []uint64
+
+	// deferrals counts the redrives a full mailbox turned away, so the
+	// test can prove the run was not vacuous.
+	deferrals int
+}
+
+// deferPropCorrID is the correlation ID of the waiter-backed response at
+// event_seq seq.
+func deferPropCorrID(seq uint64) CorrelationID {
+	return CorrelationID("deferprop-" + strconv.FormatUint(seq, 10))
+}
+
+// deferPropEventEnvelope builds the KIND_EVENT envelope for the in-memory
+// target's route. The session ID is the event_seq, so the target's processed
+// lane can be compared against the deliveries the fold made.
+func deferPropEventEnvelope(rt *rapid.T, seq uint64) *mailboxpb.Envelope {
+	body, err := anypb.New(&hellotestpb.HelloStartedEvent{
+		SessionId: strconv.FormatUint(seq, 10),
+	})
+	require.NoError(rt, err)
+
+	env := nonTxTestEnvelope(
+		mailboxpb.RpcMeta_KIND_EVENT, deferPropService, deferPropMethod,
+		seq,
+	)
+	env.Recipient = "client-1"
+	env.Body = body
+
+	return env
+}
+
+// drawDeferPropBatch draws a pulled window of mixed durable, hoisted and
+// waiter-backed envelopes with ascending event_seqs.
+func drawDeferPropBatch(rt *rapid.T) ([]*mailboxpb.Envelope,
+	map[uint64]deferPropKind) {
+
+	count := rapid.IntRange(1, 10).Draw(rt, "envelope_count")
+
+	envelopes := make([]*mailboxpb.Envelope, 0, count)
+	kinds := make(map[uint64]deferPropKind, count)
+
+	// Durable events are drawn twice as often as the other two kinds. They
+	// are the only ones a full mailbox can turn away, so a window that is
+	// mostly hoisted requests never reaches the deferral this is about.
+	kindWeights := []deferPropKind{
+		deferPropDurable, deferPropDurable, deferPropHoisted,
+		deferPropWaiter,
+	}
+
+	seq := uint64(0)
+	for range count {
+		seq += uint64(rapid.IntRange(1, 2).Draw(rt, "seq_gap"))
+
+		kind := rapid.SampledFrom(kindWeights).Draw(rt, "kind")
+		kinds[seq] = kind
+
+		switch kind {
+		case deferPropHoisted:
+			env := nonTxTestEnvelope(
+				mailboxpb.RpcMeta_KIND_REQUEST,
+				deferPropHoistedService, deferPropHoistedMethod,
+				seq,
+			)
+			env.Recipient = "client-1"
+			envelopes = append(envelopes, env)
+
+		case deferPropWaiter:
+			env := nonTxTestEnvelope(
+				mailboxpb.RpcMeta_KIND_RESPONSE,
+				deferPropUnaryService, deferPropUnaryMethod,
+				seq,
+			)
+			env.Recipient = "client-1"
+			env.Rpc.CorrelationId = string(deferPropCorrID(seq))
+			envelopes = append(envelopes, env)
+
+		case deferPropDurable:
+			envelopes = append(
+				envelopes, deferPropEventEnvelope(rt, seq),
+			)
+		}
+	}
+
+	return envelopes, kinds
+}
+
+// newDeferPropHarness builds the connector, spawns the gated target behind a
+// real mailbox of the given capacity, and registers a live waiter for every
+// waiter-backed response in the window.
+func newDeferPropHarness(rt *rapid.T, capacity int,
+	envelopes []*mailboxpb.Envelope,
+	kinds map[uint64]deferPropKind) *deferPropHarness {
+
+	h := &deferPropHarness{
+		system: actor.NewActorSystemWithConfig(actor.SystemConfig{
+			MailboxCapacity: capacity,
+		}),
+		store:     newWriterLockStore(),
+		behavior:  newGatedBehavior(),
+		envelopes: envelopes,
+		kinds:     kinds,
+		waiters: make(
+			map[uint64]actor.Future[*mailboxpb.Envelope],
+		),
+		durableAccepted:  make(map[uint64]bool),
+		durableTellCycle: make(map[uint64]int),
+		hoistedServed:    make(map[uint64]int),
+	}
+
+	// Register the target through the ordinary path, so it gets a genuine
+	// ChannelMailbox at the configured capacity rather than a test double:
+	// a mocked reference is exactly what would make this vacuous, because
+	// the backpressure being modelled lives in the mailbox.
+	key := actor.NewServiceKey[*helloStartedMsg, struct{}](deferPropService)
+	key.Spawn(h.system, "gated-target", h.behavior)
+
+	router := NewEventRouter(h.system)
+	AddRoute(router, EventRouteConfig[*helloStartedMsg, struct{}]{
+		Service: deferPropService,
+		Method:  deferPropMethod,
+		NewEvent: func() proto.Message {
+			return &hellotestpb.HelloStartedEvent{}
+		},
+		Key: key,
+		Adapt: func(p proto.Message) (*helloStartedMsg, error) {
+			m := &helloStartedMsg{}
+
+			return m, m.FromProto(p)
+		},
+	})
+
+	cfg := newTestConnectorConfig(newInMemoryMailbox(), nil)
+	cfg.MailboxProtocolVersion = 1
+	cfg.ArkProtocolVersion = 1
+	cfg.Store = h.store
+	cfg.Dispatchers = router.AsDispatcherMap()
+
+	durableRoute := mailboxrpc.ServiceMethod{
+		Service: deferPropService,
+		Method:  deferPropMethod,
+	}
+	cfg.Dispatchers[durableRoute] = h.observeDurable(
+		cfg.Dispatchers[durableRoute],
+	)
+
+	hoistedRoute := mailboxrpc.ServiceMethod{
+		Service: deferPropHoistedService,
+		Method:  deferPropHoistedMethod,
+	}
+	cfg.Dispatchers[hoistedRoute] = h.serveHoisted
+	cfg.NonTxRoutes = RouteSet{
+		hoistedRoute: {},
+	}
+
+	h.conn = NewServerConnectionActor(cfg)
+
+	for seq, kind := range kinds {
+		if kind != deferPropWaiter {
+			continue
+		}
+
+		h.waiters[seq] = h.conn.RegisterWaiter(deferPropCorrID(seq))
+	}
+
+	return h
+}
+
+// stop releases the target and shuts the actor system down.
+func (h *deferPropHarness) stop() {
+	// The gate is opened first: a parked receive turn would otherwise make
+	// the shutdown wait for the very target the run wedged.
+	h.behavior.open()
+
+	shutdownCtx, cancel := context.WithTimeout(
+		context.Background(), 5*time.Second,
+	)
+	defer cancel()
+
+	_ = h.system.Shutdown(shutdownCtx)
+}
+
+// observeDurable wraps the router's real dispatcher and records what it did.
+// The wrapper adds no behaviour of its own: the delivery, the mailbox and the
+// deferral all come from the production path.
+func (h *deferPropHarness) observeDurable(
+	inner EnvelopeDispatcher) EnvelopeDispatcher {
+
+	return func(ctx context.Context, env *mailboxpb.Envelope) error {
+		// Ask the fold's in-flight record what the real dispatcher is
+		// about to do. A seen envelope is one this folded dispatch
+		// already handed to the mailbox, so deliverToActor
+		// short-circuits and no second copy reaches the target. Reading
+		// it here is what lets the model tell a suppressed replay apart
+		// from a genuine hand-off — and a record that stopped
+		// suppressing would show up as a duplicate below rather than
+		// being quietly absorbed.
+		suppressed := deliveredOutsideTxFrom(ctx).seen(env.EventSeq)
+
+		if err := inner(ctx, env); err != nil {
+			return err
+		}
+
+		h.durableAccepted[env.EventSeq] = true
+
+		if suppressed {
+			return nil
+		}
+
+		if last, ok := h.durableTellCycle[env.EventSeq]; ok &&
+			last == h.cycle {
+
+			h.dupInFold = append(h.dupInFold, env.EventSeq)
+		}
+
+		h.durableTellCycle[env.EventSeq] = h.cycle
+		h.expectedLog = append(
+			h.expectedLog, strconv.FormatUint(env.EventSeq, 10),
+		)
+		h.expectedSeq = append(h.expectedSeq, env.EventSeq)
+		h.expectedCycle = append(h.expectedCycle, h.cycle)
+
+		return nil
+	}
+}
+
+// serveHoisted stands in for the mux bridge: it answers the operator over the
+// network and enqueues nothing, so a redrive that ran it twice would send a
+// second response to a request that has already been answered.
+func (h *deferPropHarness) serveHoisted(_ context.Context,
+	env *mailboxpb.Envelope) error {
+
+	if h.failHoisted {
+		return errDeferPropServe
+	}
+
+	h.hoistedServed[env.EventSeq]++
+
+	return nil
+}
+
+// handled reports whether the envelope at seq has reached its destination:
+// queued in the target's mailbox, answered over the network, or handed to its
+// in-memory waiter. This is the set the committed cursor is checked against.
+func (h *deferPropHarness) handled(seq uint64) bool {
+	switch h.kinds[seq] {
+	case deferPropHoisted:
+		return h.hoistedServed[seq] > 0
+
+	case deferPropWaiter:
+		return futureIsDone(h.waiters[seq])
+
+	case deferPropDurable:
+		return h.durableAccepted[seq]
+	}
+
+	return false
+}
+
+// futureIsDone reports whether a response waiter's future has already been
+// completed, without blocking on it. Await answers from its result cache
+// before it ever looks at the context, so a cancelled one turns the blocking
+// read into a poll.
+func futureIsDone(future actor.Future[*mailboxpb.Envelope]) bool {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	return future.Await(ctx).IsOk()
+}
+
+// snapshotHandled captures the handled set before a cycle runs, so the cycle's
+// own progress can be told apart from what earlier cycles had already done.
+func (h *deferPropHarness) snapshotHandled() map[uint64]bool {
+	snapshot := make(map[uint64]bool, len(h.envelopes))
+	for _, env := range h.envelopes {
+		snapshot[env.EventSeq] = h.handled(env.EventSeq)
+	}
+
+	return snapshot
+}
+
+// window returns the envelopes a pull at the current cursor would hand back,
+// along with the exclusive next cursor, matching what the mailbox computes.
+func (h *deferPropHarness) window(state AckState) ([]*mailboxpb.Envelope,
+	uint64) {
+
+	var (
+		batch  []*mailboxpb.Envelope
+		maxSeq uint64
+	)
+	for _, env := range h.envelopes {
+		if env.EventSeq < state.PullCursor {
+			continue
+		}
+
+		batch = append(batch, env)
+		maxSeq = env.EventSeq
+	}
+
+	if len(batch) == 0 {
+		return nil, state.PullCursor
+	}
+
+	return batch, maxSeq + 1
+}
+
+// drainTarget lets the wedged target empty its mailbox and then shuts the gate
+// again, so the next redrive starts against a mailbox with room. Waiting for
+// the target to catch up with the deliveries the fold made is what keeps the
+// toggle deterministic: every cycle starts with the target either fully
+// drained or holding exactly what earlier cycles gave it.
+func (h *deferPropHarness) drainTarget(rt *rapid.T) {
+	h.behavior.open()
+
+	want := len(h.expectedLog)
+	deadline := time.Now().Add(10 * time.Second)
+	for h.behavior.count() < want {
+		if time.Now().After(deadline) {
+			rt.Fatalf("target drained %d of %d deliveries",
+				h.behavior.count(), want)
+		}
+
+		time.Sleep(100 * time.Microsecond)
+	}
+
+	h.behavior.shut()
+}
+
+// runCycle runs one redrive of the pull window through the real folded
+// dispatch and checks the invariants the cycle has to preserve. It mirrors the
+// loop control ingressLoop applies around runFoldedDispatch — adopt the
+// advanced state on a deferral, hold the old one on a failure, clear the
+// deferral on success — and nothing else. It returns false when the window is
+// empty and there is nothing left to redrive.
+//
+// When chaos is set the cycle also injects the two faults a real one can meet:
+// a store that replays its transaction body after a retryable error, and a
+// hoisted serve whose round trip to the operator fails.
+func (h *deferPropHarness) runCycle(rt *rapid.T, state *AckState,
+	redrive *redriveState, chaos bool) bool {
+
+	batch, nextCursor := h.window(*state)
+	if len(batch) == 0 {
+		return false
+	}
+
+	h.cycle++
+	h.dupInFold = nil
+	h.failHoisted = false
+
+	replays := 0
+	if chaos {
+		if rapid.Bool().Draw(rt, "drain_target") {
+			h.drainTarget(rt)
+		}
+
+		replays = rapid.IntRange(0, 2).Draw(rt, "store_replays")
+		h.failHoisted = rapid.IntRange(0, 5).Draw(
+			rt, "serve_fails",
+		) == 0
+	}
+
+	store := &replayingStore{
+		writerLockStore: h.store,
+		replays:         replays,
+	}
+
+	before := h.snapshotHandled()
+	prev := *state
+
+	newState, err := h.conn.runFoldedDispatch(
+		context.Background(), store, batch, nextCursor, prev, redrive,
+	)
+
+	var deferral *deferredDispatchError
+	switch {
+	case errors.As(err, &deferral):
+		h.deferrals++
+
+		*state = newState
+		redrive.deferredSeq = deferral.eventSeq
+
+	case err != nil:
+		// A hoisted serve that failed returns before the fold, so the
+		// cursor stays where it was and the batch is re-pulled whole.
+		if newState != prev {
+			rt.Fatalf("failed dispatch moved the state: %+v -> %+v",
+				prev, newState)
+		}
+
+	default:
+		*state = newState
+		redrive.deferredSeq = 0
+	}
+
+	h.checkCycle(rt, prev, *state, nextCursor, deferral, before)
+
+	return true
+}
+
+// checkCycle holds one redrive to the invariants that must survive any mixture
+// of deferral point, store replay and mailbox state.
+func (h *deferPropHarness) checkCycle(rt *rapid.T, prev, state AckState,
+	nextCursor uint64, deferral *deferredDispatchError,
+	before map[uint64]bool) {
+
+	// CURSOR SAFETY. The committed cursor is exclusive, so every envelope
+	// below it has been acknowledged; if one of those never reached its
+	// destination it is gone, and on this path that means a silently
+	// dropped round event. The handled set is built from what the real
+	// dispatchers returned, so this compares the cursor against the
+	// pipeline's own outcomes.
+	for _, env := range h.envelopes {
+		if env.EventSeq >= state.PullCursor {
+			continue
+		}
+
+		if !h.handled(env.EventSeq) {
+			rt.Fatalf("cursor %d acked unhandled event_seq %d "+
+				"(kind %d)", state.PullCursor, env.EventSeq,
+				h.kinds[env.EventSeq])
+		}
+	}
+
+	// A transaction body that ran more than once must not hand the same
+	// envelope to a bounded in-memory mailbox more than once: that
+	// delivery is not in the transaction and a rollback does not take it
+	// back.
+	if len(h.dupInFold) > 0 {
+		rt.Fatalf("event_seqs %v delivered twice inside one folded "+
+			"dispatch", h.dupInFold)
+	}
+
+	// The cursor is monotonic and never runs past the window the pull
+	// returned. A store that replayed its body cannot compound the
+	// advance, because the fold re-derives both outputs from the caller's
+	// state on every attempt.
+	if state.PullCursor < prev.PullCursor {
+		rt.Fatalf("cursor regressed: %d -> %d", prev.PullCursor,
+			state.PullCursor)
+	}
+	if state.PullCursor > nextCursor {
+		rt.Fatalf("cursor %d ran past the pulled window %d",
+			state.PullCursor, nextCursor)
+	}
+
+	// A hoisted request is answered over the network, so serving it twice
+	// sends the operator a second response to a request it has already had
+	// answered. Once per episode, however many redrives the episode takes.
+	for seq, served := range h.hoistedServed {
+		if served > 1 {
+			rt.Fatalf("hoisted event_seq %d served %d times", seq,
+				served)
+		}
+	}
+
+	if deferral == nil {
+		return
+	}
+
+	// The cursor a deferral commits is exactly what deferredCursor says it
+	// should be, which ties the fold to the pure function the property
+	// above pins.
+	want := deferredCursor(deferral.eventSeq, prev.PullCursor)
+	if state.PullCursor != want {
+		rt.Fatalf("deferred cycle committed %d, want %d",
+			state.PullCursor, want)
+	}
+
+	// A redrive that got part of the backlog through has to move the
+	// cursor. This is the signal the loop keys deferFailCount's reset on:
+	// without an advance to observe, a draining target is redriven at the
+	// backoff ceiling instead of promptly, and backpressure that has
+	// already cleared still fails rounds.
+	for _, env := range h.envelopes {
+		if env.EventSeq >= deferral.eventSeq || before[env.EventSeq] {
+			continue
+		}
+
+		if !h.handled(env.EventSeq) {
+			continue
+		}
+
+		if state.PullCursor <= prev.PullCursor {
+			rt.Fatalf("redrive handled event_seq %d but left the "+
+				"cursor at %d", env.EventSeq, state.PullCursor)
+		}
+	}
+}
+
+// TestFoldedDispatch_DeferralInvariants_Property drives the real folded
+// dispatch through randomized backpressure episodes and holds it to the
+// invariants a deferral must not break.
+//
+// The reason this is a property test rather than another example is the size
+// of the state space. An episode is a cross product of where in the batch the
+// deferral falls, how many times the store replays its transaction body, which
+// hoisted serves fail, and whether the target drained between redrives — and
+// the invariants are about what SURVIVES all of that, not about any one path
+// through it. The example tests in ingress_backpressure_test.go each pin one
+// point in that space; this pins the space.
+//
+// Everything under test is production code: a real actor system, a real
+// fixed-capacity mailbox, the real EventRouter dispatcher, and
+// runFoldedDispatch itself. The harness only observes what those returned and
+// compares the committed cursor against it.
+func TestFoldedDispatch_DeferralInvariants_Property(t *testing.T) {
+	t.Parallel()
+
+	// Deferrals are counted across the whole run so a change that stopped
+	// producing backpressure — a bigger default mailbox, a generator that
+	// drifted — cannot turn this into a test that passes by never
+	// exercising the path.
+	var deferrals int
+
+	rapid.Check(t, func(rt *rapid.T) {
+		envelopes, kinds := drawDeferPropBatch(rt)
+
+		// A small mailbox only makes the wedge cheap to reach: the
+		// backpressure it produces is capacity-independent, and
+		// production runs the same code at the default 100.
+		capacity := rapid.IntRange(1, 3).Draw(rt, "mailbox_capacity")
+
+		h := newDeferPropHarness(rt, capacity, envelopes, kinds)
+		defer h.stop()
+
+		var (
+			state   AckState
+			redrive redriveState
+		)
+
+		// Phase one is the episode: redrives against a target that is
+		// mostly wedged, with faults injected.
+		cycles := rapid.IntRange(0, 2*len(envelopes)+2).Draw(
+			rt, "chaos_cycles",
+		)
+		for range cycles {
+			if !h.runCycle(rt, &state, &redrive, true) {
+				break
+			}
+		}
+
+		// Phase two is the recovery: the target drains before every
+		// redrive and no faults are injected, so the backlog has to
+		// clear. Each cycle starts against an empty mailbox and
+		// therefore delivers at least one more envelope, which bounds
+		// the loop.
+		for range 2*len(envelopes) + 8 {
+			h.drainTarget(rt)
+
+			if !h.runCycle(rt, &state, &redrive, false) {
+				break
+			}
+		}
+
+		if batch, _ := h.window(state); len(batch) > 0 {
+			rt.Fatalf("%d envelopes still unprocessed at cursor %d",
+				len(batch), state.PullCursor)
+		}
+
+		// NO LOSS. Every envelope the window carried reached its
+		// destination once the mailboxes drained.
+		for _, env := range h.envelopes {
+			if !h.handled(env.EventSeq) {
+				rt.Fatalf("event_seq %d (kind %d) was "+
+					"never handled", env.EventSeq,
+					h.kinds[env.EventSeq])
+			}
+		}
+
+		// NO REPLAY. Each hoisted request was answered exactly once,
+		// however many redrives the episode took.
+		for seq, kind := range h.kinds {
+			if kind != deferPropHoisted {
+				continue
+			}
+
+			if h.hoistedServed[seq] != 1 {
+				rt.Fatalf("hoisted event_seq %d served "+
+					"%d times", seq, h.hoistedServed[seq])
+			}
+		}
+
+		// ORDERING. Within a cycle the fold hands envelopes over in
+		// event_seq order; a duplicate can only come from a later
+		// cycle re-driving a window whose cursor never moved.
+		for i := 1; i < len(h.expectedSeq); i++ {
+			if h.expectedCycle[i] != h.expectedCycle[i-1] {
+				continue
+			}
+
+			if h.expectedSeq[i] <= h.expectedSeq[i-1] {
+				rt.Fatalf("cycle %d delivered %d after %d",
+					h.expectedCycle[i], h.expectedSeq[i],
+					h.expectedSeq[i-1])
+			}
+		}
+
+		// The target's own lane is the ground truth for both ordering
+		// and duplication: it must hold exactly the deliveries the fold
+		// made, in the order the fold made them.
+		h.behavior.open()
+
+		deadline := time.Now().Add(10 * time.Second)
+		for h.behavior.count() < len(h.expectedLog) {
+			if time.Now().After(deadline) {
+				break
+			}
+
+			time.Sleep(100 * time.Microsecond)
+		}
+
+		if got := h.behavior.observed(); !slices.Equal(
+			got, h.expectedLog,
+		) {
+
+			rt.Fatalf("target processed %v, fold delivered %v", got,
+				h.expectedLog)
+		}
+
+		deferrals += h.deferrals
+	})
+
+	require.Positive(
+		t, deferrals, "no redrive was ever deferred, so the "+
+			"generated batches never wedged the target",
+	)
+}

--- a/serverconn/ingress_metrics.go
+++ b/serverconn/ingress_metrics.go
@@ -1,0 +1,31 @@
+package serverconn
+
+import (
+	"github.com/lightninglabs/wavelength/metrics"
+)
+
+// markIngressPoll stamps the ingress liveness gauge. It is called after every
+// Pull that returns, including the empty long-poll, because the question the
+// gauge answers is whether the single goroutine that consumes the server
+// mailbox is still going round its loop — not whether there happened to be
+// traffic.
+//
+// Nothing else in the process can answer that question. The connector's only
+// pre-existing timestamp is outbound-only, GetInfo's server_connected is set
+// once at startup and never cleared on a stall, and the ingress loop reacts to
+// errors but not to a wedge, which produces none.
+func markIngressPoll() {
+	metrics.ServerConnLastIngressPollTimestamp.SetToCurrentTime()
+}
+
+// markIngressEvent stamps the inbound-traffic gauge after a pulled batch has
+// been delivered and its cursor committed. Read against the poll gauge it
+// separates a client with nothing to do from one whose dispatch is not getting
+// through.
+//
+// A deferral that committed a delivered prefix stamps it too. Partial progress
+// IS events reaching their actors, and reporting a draining backlog as
+// "dispatch is not getting through" would dilute the one reading that means it.
+func markIngressEvent() {
+	metrics.ServerConnLastIngressEventTimestamp.SetToCurrentTime()
+}

--- a/serverconn/ingress_nontx_test.go
+++ b/serverconn/ingress_nontx_test.go
@@ -226,7 +226,7 @@ func TestRunFoldedDispatchServesRequestsOutsideTx(t *testing.T) {
 	}
 
 	newState, err := probe.conn.runFoldedDispatch(
-		t.Context(), store, envelopes, 3, AckState{},
+		t.Context(), store, envelopes, 3, AckState{}, &redriveState{},
 	)
 	require.NoError(t, err)
 
@@ -275,7 +275,7 @@ func TestRunFoldedDispatchRequestFailureHoldsCursor(t *testing.T) {
 
 	state := AckState{PullCursor: 1}
 	newState, err := probe.conn.runFoldedDispatch(
-		t.Context(), store, envelopes, 3, state,
+		t.Context(), store, envelopes, 3, state, &redriveState{},
 	)
 	require.ErrorIs(t, err, serveErr)
 
@@ -315,7 +315,7 @@ func TestRunFoldedDispatchValidatesBeforeAnyDelivery(t *testing.T) {
 
 	state := AckState{PullCursor: 1}
 	newState, err := probe.conn.runFoldedDispatch(
-		t.Context(), store, envelopes, 3, state,
+		t.Context(), store, envelopes, 3, state, &redriveState{},
 	)
 	require.Error(t, err)
 	require.True(t, probe.conn.checkPermanentStatus(t.Context(), err))
@@ -363,7 +363,7 @@ func TestDispatchBatchSkipsMislabeledNonTxKinds(t *testing.T) {
 	}
 
 	newState, err := probe.conn.runFoldedDispatch(
-		t.Context(), store, envelopes, 4, AckState{},
+		t.Context(), store, envelopes, 4, AckState{}, &redriveState{},
 	)
 	require.NoError(t, err)
 

--- a/serverconn/types.go
+++ b/serverconn/types.go
@@ -52,10 +52,16 @@ type AckState = mailboxconn.AckState
 const ackStateType = mailboxconn.CheckpointStateType
 
 // EnvelopeDispatcher routes an inbound envelope to the correct local actor.
-// A nil error means the envelope was durably committed to the target actor's
-// mailbox (i.e., DurableActor.Tell returned nil, confirming persistence).
-// The dispatcher is a closure configured at wiring time that captures a
-// ServiceKey reference for the target actor.
+// A nil error means the target accepted the envelope: durably committed to its
+// mailbox for a durable actor, or queued in a fixed-capacity in-memory mailbox
+// for an ordinary one. The dispatcher is a closure configured at wiring time
+// that captures a ServiceKey reference for the target actor.
+//
+// An error wrapping ErrDispatchDeferred is the one non-failure a dispatcher may
+// return: the target's in-memory mailbox had no room. The envelope is untouched
+// and unacknowledged, and the ingress loop re-pulls it after a backoff. A
+// dispatcher must never park waiting for room, because one goroutine dispatches
+// every inbound route in the process.
 type EnvelopeDispatcher func(
 	ctx context.Context, env *mailboxpb.Envelope,
 ) error
@@ -164,6 +170,17 @@ type ConnectorConfig struct {
 	// envelope is a KIND_REQUEST, so a durable event or response route
 	// can never be hoisted by accident. Any new route whose dispatcher
 	// performs IO rather than a durable enqueue MUST be listed here.
+	//
+	// The rule the mark encodes is "this dispatcher can block on something
+	// other than this transaction's own writes", not merely "this
+	// dispatcher does network IO". The narrower reading is what let a real
+	// wedge through: the round and incoming-VTXO dispatchers do no IO at
+	// all, but they used to deliver with a blocking send into a
+	// fixed-capacity in-memory mailbox, which pinned the writer for as long
+	// as the target took to drain — forever, when it had stopped. Those
+	// routes do not need the mark because they no longer block at all (see
+	// deliverToActor), but a future dispatcher that can wait on anything
+	// else does.
 	//
 	// The mark only ever errs in one direction. Leaving a route out costs
 	// the stall described above, which is what the code did before this

--- a/serverconn/version_stamp_test.go
+++ b/serverconn/version_stamp_test.go
@@ -449,7 +449,7 @@ func TestRunFoldedDispatchRejectsMismatchedEnvelope(t *testing.T) {
 			_, err := conn.runFoldedDispatch(
 				t.Context(), store,
 				[]*mailboxpb.Envelope{tc.env},
-				tc.env.EventSeq+1, AckState{},
+				tc.env.EventSeq+1, AckState{}, &redriveState{},
 			)
 			require.Error(t, err)
 			require.True(

--- a/waved/mailbox_nontx_routes_test.go
+++ b/waved/mailbox_nontx_routes_test.go
@@ -35,8 +35,13 @@ func TestNonTxRoutesResolveToMuxBridge(t *testing.T) {
 
 	dispatchers, nonTxRoutes := s.buildRPCDispatchers(nil)
 
-	// The event router's own map is the set of durable Tell dispatchers.
-	// Anything marked non-transactional must not be one of them.
+	// The event router's own map is the set of dispatchers that deliver
+	// into a local actor mailbox and therefore belong inside the folded
+	// write transaction. Not all of them are durable Tells any more — the
+	// round and incoming-VTXO routes hand off to a bounded in-memory
+	// mailbox instead — but every one of them still commits with the
+	// cursor, which is what makes marking any of them non-transactional
+	// wrong.
 	durable := s.buildEventRoutes().AsDispatcherMap()
 
 	require.NotEmpty(t, nonTxRoutes)


### PR DESCRIPTION
In this PR, we fix the wedge behind the recurring "ark client goes deaf to round events" incidents (lightninglabs/lightning-infra#3675, two production occurrences). The serverconn ingress loop delivered server events with a blocking, deadline-free `Tell` into fixed-capacity in-memory mailboxes, while holding the SQLite global write transaction. Once a target mailbox filled, the sole ingress goroutine parked forever with the writer pinned. WAL mode meant readers kept answering RPC, so the pod looked healthy while every write in the process was frozen, and the only log line on that path was at trace level. The client silently dropped out of every round it had joined ("all clients dropped at seal time" on the operator side) until someone restarted it.

This is the client-side sibling of lightninglabs/lumos#734: an actor's receive goroutine (or here, the loop feeding all of them) must never block indefinitely on a peer's bounded mailbox. It builds on the `TryTell` primitive from #1082.

## What changes

The ingress path now dispatches through a new `TellWithoutParking` primitive that picks the right send per resolved target: `TryTell` for a bounded in-memory mailbox, ordinary transactional `Tell` for a durable one. A full mailbox becomes a *deferral* instead of a park: the fold commits the cursor at the deferred envelope's own `event_seq` (everything below it is fully handled, the undelivered tail is never acked), and the pull loop is the redrive. Redriven batches are clamped and a served watermark prevents re-answering hoisted non-transactional requests every cycle. Backpressure gets its own backoff with a 500ms ceiling that resets on progress, so a drained backlog clears in seconds rather than at the transport-failure schedule's 30s. Since the store retries its transaction body on retryable errors, a per-dispatch record of out-of-transaction deliveries keeps those retries from re-sending messages that already landed in a mailbox.

Beyond the ingress path, we close the two other ways the audit found to park the round actor's receive loop: the round-to-wallet Ask cycle gets a bounded `askWallet` (both the enqueue and the Await, 30s default), and `FSM.CurrentState` gets a context-aware variant, with the scanning call sites sharing one deadline per scan instead of paying a per-FSM budget N times.

## Observability

Both incidents produced zero evidence, so visibility is half this PR. Deferrals now log at error level (once per episode, re-logged every 30s with episode counters) and increment `waved_serverconn_ingress_dispatch_deferred_total`; two new gauges split "the ingress loop is alive" (last poll) from "dispatch is landing events" (last event). The metrics README gains an alerting section that maps each expression to the failure it detects; the deferral rate is the primary wedge signal, since a deaf client keeps polling and poll staleness alone can never see this failure.

## What this does not claim

One residual is documented in `serverconn/doc.go` rather than fixed: all sixteen inbound routes share one strictly ordered cursor, so a stalled target still delays events for the other routes until it drains. What this PR removes is the writer pin and the silence. Decoupling the lanes (a per-target deferral queue with its own cursor) is follow-up work.

## Testing

The regression tests wire a real actor system, the real event router, and the existing writer-lock harness, and each fails on the pre-fix code in seconds, one per mechanism: the storm test observes the loop parked inside the write transaction (the exact production signature), the redrive test counts unbounded hoisted re-serves, the recovery test times the drain on production-shaped config (63s pre-fix, under 4s post), and the replay test counts duplicate in-memory deliveries under transaction retries.

On top of the example-based tests, two further layers pin the invariants. Property tests (rapid) drive the real fold, cursor arithmetic, and backoff across randomized batches, deferral points, and store-retry injections; each property was validated non-vacuous by mutating the production code and watching it fail. And the P model suite gains a machine for this pipeline with six spec monitors (no acked loss, no tx-scoped duplicate, bounded at-least-once, served-once-per-incarnation, writer never parks, eventual drain); each pre-fix bug is a one-field config toggle the checker catches, and crash/restart nondeterminism is part of the schedule space.

The diff went through an adversarial review pass, a verification pass, and a complexity-focused design review; all findings are addressed in-line or documented as residuals. The design review drove one API simplification: the delivery helper is two exported names (`TellWithoutParking` + `NonParkingTeller` returning `fn.Result[bool]`), with the capability-query surface deleted rather than exported.

See the individual commit messages for the incremental story.
