### PR TITLE
waved: Reserve exact managed OOR inputs

### DIFF
--- a/lib/actormsg/vtxo_admission.go
+++ b/lib/actormsg/vtxo_admission.go
@@ -20,10 +20,9 @@ import (
 // (wallet → vtxo → round → wallet).
 
 // SelectAndReserveSpendRequest asks the VTXO manager to select VTXOs covering
-// a target amount and atomically reserve them for an OOR spend. The manager
-// runs largest-first coin selection, then Asks each selected VTXO actor to
-// process SpendReserveEvent. If any reservation fails, already-reserved
-// VTXOs are rolled back.
+// a target amount, or use explicitly named managed VTXOs, and reserve them for
+// an OOR spend. If any reservation fails, already-reserved VTXOs are rolled
+// back.
 type SelectAndReserveSpendRequest struct {
 	actor.BaseMessage
 
@@ -34,6 +33,11 @@ type SelectAndReserveSpendRequest struct {
 	// MinChangeAmount, when positive, asks selection to avoid a
 	// non-zero residual below this amount. Exact spends are still valid.
 	MinChangeAmount btcutil.Amount
+
+	// Outpoints, when non-empty, identifies the exact managed VTXOs to
+	// reserve instead of running coin selection. The requested order is
+	// preserved in the response.
+	Outpoints []wire.OutPoint
 }
 
 // VTXOManagerMsg implements VTXOManagerMsg marker interface.

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -1888,6 +1888,7 @@ func (m *Manager) spawnVTXOActor(ctx context.Context, vtxo *Descriptor) (
 type reserveParams struct {
 	targetAmount    btcutil.Amount
 	minChangeAmount btcutil.Amount
+	exactOutpoints  []wire.OutPoint
 	reserveEvent    actormsg.VTXOActorMsg
 	rollback        func(ctx context.Context, ops []wire.OutPoint)
 	ask             func(context.Context, VTXOActorRef,
@@ -1904,11 +1905,9 @@ type reserveParams struct {
 	detached bool
 }
 
-// selectAndReserveVTXOs performs largest-first coin selection and
-// atomically reserves each selected VTXO by sending reserveEvent to
-// its actor. On partial failure the rollback function is called for
-// already-reserved outpoints. Returns the selected VTXO details and
-// total amount on success.
+// selectAndReserveVTXOs selects the requested liquidity and reserves each VTXO
+// by sending reserveEvent to its actor. On partial failure the rollback
+// function is called for already-reserved outpoints.
 func (m *Manager) selectAndReserveVTXOs(ctx context.Context, p reserveParams) (
 	[]SelectedVTXO, btcutil.Amount, error) {
 
@@ -1954,34 +1953,10 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context, p reserveParams) (
 		})
 	}
 
-	// Run largest-first selection through the shared selector. Map its
-	// typed outcomes back onto the manager's liquidity diagnostics: a
-	// dust-change rejection is reported verbatim, while any shortfall
-	// (including an empty candidate set) is refined into the
-	// locked-vs-absent distinction.
-	res, err := coinselect.LargestFirst(
-		candidates, func(d *Descriptor) btcutil.Amount {
-			return d.Amount
-		}, coinselect.Request{
-			Target:    p.targetAmount,
-			MinChange: p.minChangeAmount,
-		},
-	)
-	switch {
-	case errors.Is(err, coinselect.ErrChangeBelowMin):
-		change := res.Total - p.targetAmount
-
-		return nil, 0, fmt.Errorf("change %d is below minimum change "+
-			"amount %d", change, p.minChangeAmount)
-
-	case errors.Is(err, coinselect.ErrSelectionShortfall),
-		errors.Is(err, coinselect.ErrNoCandidates):
-		return nil, 0, m.insufficientLiquidityError(ctx, candidates, p)
-
-	case err != nil:
+	selected, err := m.selectReservationCandidates(ctx, candidates, p)
+	if err != nil {
 		return nil, 0, err
 	}
-	selected := res.Selected
 
 	// Reserve each selected VTXO via its actor. Track successfully
 	// reserved outpoints so we can roll back on partial failure.
@@ -2075,6 +2050,97 @@ func (m *Manager) selectAndReserveVTXOs(ctx context.Context, p reserveParams) (
 	return selectedVTXOs, totalSelected, nil
 }
 
+// selectReservationCandidates returns either the caller's exact managed
+// VTXOs or a largest-first selection that covers the requested amount.
+func (m *Manager) selectReservationCandidates(ctx context.Context,
+	candidates []*Descriptor, p reserveParams) ([]*Descriptor, error) {
+
+	if len(p.exactOutpoints) > 0 {
+		return m.selectExactReservationCandidates(candidates, p)
+	}
+
+	// Run largest-first selection through the shared selector. Map its
+	// typed outcomes back onto the manager's liquidity diagnostics: a
+	// dust-change rejection is reported verbatim, while any shortfall
+	// (including an empty candidate set) is refined into the
+	// locked-vs-absent distinction.
+	res, err := coinselect.LargestFirst(
+		candidates, func(d *Descriptor) btcutil.Amount {
+			return d.Amount
+		}, coinselect.Request{
+			Target:    p.targetAmount,
+			MinChange: p.minChangeAmount,
+		},
+	)
+	switch {
+	case errors.Is(err, coinselect.ErrChangeBelowMin):
+		change := res.Total - p.targetAmount
+
+		return nil, fmt.Errorf("change %d is below minimum change "+
+			"amount %d", change, p.minChangeAmount)
+
+	case errors.Is(err, coinselect.ErrSelectionShortfall),
+		errors.Is(err, coinselect.ErrNoCandidates):
+		return nil, m.insufficientLiquidityError(ctx, candidates, p)
+
+	case err != nil:
+		return nil, err
+	}
+
+	return res.Selected, nil
+}
+
+// selectExactReservationCandidates validates and returns exact managed inputs
+// without substituting other wallet liquidity.
+func (m *Manager) selectExactReservationCandidates(candidates []*Descriptor,
+	p reserveParams) ([]*Descriptor, error) {
+
+	byOutpoint := make(map[wire.OutPoint]*Descriptor, len(candidates))
+	for _, candidate := range candidates {
+		byOutpoint[candidate.Outpoint] = candidate
+	}
+
+	selected := make([]*Descriptor, 0, len(p.exactOutpoints))
+	seen := make(map[wire.OutPoint]struct{}, len(p.exactOutpoints))
+	var total btcutil.Amount
+	for _, op := range p.exactOutpoints {
+		if _, ok := seen[op]; ok {
+			return nil, fmt.Errorf("duplicate exact spend "+
+				"outpoint %s", op)
+		}
+		seen[op] = struct{}{}
+
+		if m.isReserved(op) {
+			return nil, fmt.Errorf("%w: exact spend outpoint %s "+
+				"is already reserved", ErrVTXOLiquidityLocked,
+				op)
+		}
+
+		candidate, ok := byOutpoint[op]
+		if !ok {
+			return nil, fmt.Errorf("%w: exact spend outpoint %s "+
+				"is not live", ErrInsufficientSpendableFunds,
+				op)
+		}
+
+		selected = append(selected, candidate)
+		total += candidate.Amount
+	}
+
+	if total < p.targetAmount {
+		return nil, fmt.Errorf("%w: exact inputs total %d, need %d",
+			ErrInsufficientSpendableFunds, total, p.targetAmount)
+	}
+
+	change := total - p.targetAmount
+	if change > 0 && change < p.minChangeAmount {
+		return nil, fmt.Errorf("change %d is below minimum change "+
+			"amount %d", change, p.minChangeAmount)
+	}
+
+	return selected, nil
+}
+
 // insufficientLiquidityError distinguishes a true spendable-funds shortfall
 // from liquidity that is present but unavailable because another operation has
 // already moved it out of LiveState.
@@ -2111,16 +2177,15 @@ func (m *Manager) insufficientLiquidityError(ctx context.Context,
 		ErrInsufficientSpendableFunds, p.targetAmount, liveTotal)
 }
 
-// handleSelectAndReserveSpend selects VTXOs covering the target amount using
-// largest-first coin selection, then atomically reserves them for an OOR
-// spend by Asking each VTXO actor to process SpendReserveEvent. If any
-// reservation fails, already-reserved VTXOs are rolled back.
+// handleSelectAndReserveSpend selects or resolves exact VTXOs and reserves
+// them for an OOR spend by sending each actor SpendReserveEvent.
 func (m *Manager) handleSelectAndReserveSpend(ctx context.Context,
 	req *SelectAndReserveSpendRequest) fn.Result[ManagerResp] {
 
 	vtxos, total, err := m.selectAndReserveVTXOs(ctx, reserveParams{
 		targetAmount:    req.TargetAmount,
 		minChangeAmount: req.MinChangeAmount,
+		exactOutpoints:  req.Outpoints,
 		reserveEvent:    &SpendReserveEvent{},
 		rollback:        m.rollbackSpend,
 		ask:             m.askVTXOActor,

--- a/vtxo/manager.go
+++ b/vtxo/manager.go
@@ -2056,7 +2056,7 @@ func (m *Manager) selectReservationCandidates(ctx context.Context,
 	candidates []*Descriptor, p reserveParams) ([]*Descriptor, error) {
 
 	if len(p.exactOutpoints) > 0 {
-		return m.selectExactReservationCandidates(candidates, p)
+		return m.selectExactReservationCandidates(ctx, candidates, p)
 	}
 
 	// Run largest-first selection through the shared selector. Map its
@@ -2092,8 +2092,8 @@ func (m *Manager) selectReservationCandidates(ctx context.Context,
 
 // selectExactReservationCandidates validates and returns exact managed inputs
 // without substituting other wallet liquidity.
-func (m *Manager) selectExactReservationCandidates(candidates []*Descriptor,
-	p reserveParams) ([]*Descriptor, error) {
+func (m *Manager) selectExactReservationCandidates(ctx context.Context,
+	candidates []*Descriptor, p reserveParams) ([]*Descriptor, error) {
 
 	byOutpoint := make(map[wire.OutPoint]*Descriptor, len(candidates))
 	for _, candidate := range candidates {
@@ -2118,9 +2118,7 @@ func (m *Manager) selectExactReservationCandidates(candidates []*Descriptor,
 
 		candidate, ok := byOutpoint[op]
 		if !ok {
-			return nil, fmt.Errorf("%w: exact spend outpoint %s "+
-				"is not live", ErrInsufficientSpendableFunds,
-				op)
+			return nil, m.exactSpendUnavailableError(ctx, op)
 		}
 
 		selected = append(selected, candidate)
@@ -2139,6 +2137,41 @@ func (m *Manager) selectExactReservationCandidates(candidates []*Descriptor,
 	}
 
 	return selected, nil
+}
+
+// exactSpendUnavailableError distinguishes a temporarily locked exact input
+// from one that is terminal, expired, or unknown. The live selection
+// projection cannot make that distinction because it excludes every non-live
+// status before exact-input matching.
+func (m *Manager) exactSpendUnavailableError(ctx context.Context,
+	op wire.OutPoint) error {
+
+	desc, err := m.cfg.Store.GetVTXO(ctx, op)
+	switch {
+	case errors.Is(err, ErrVTXONotFound), desc == nil && err == nil:
+		return fmt.Errorf("%w: exact spend outpoint %s is unknown",
+			ErrInsufficientSpendableFunds, op)
+
+	case err != nil:
+		return fmt.Errorf("look up exact spend outpoint %s: %w", op,
+			err)
+	}
+
+	switch desc.Status {
+	case VTXOStatusLive, VTXOStatusPendingForfeit,
+		VTXOStatusForfeiting, VTXOStatusSpending:
+		return fmt.Errorf("%w: exact spend outpoint %s has status %s",
+			ErrVTXOLiquidityLocked, op, desc.Status)
+
+	case VTXOStatusForfeited, VTXOStatusSpent,
+		VTXOStatusUnilateralExit, VTXOStatusFailed,
+		VTXOStatusExpired:
+		return fmt.Errorf("%w: exact spend outpoint %s has status %s",
+			ErrInsufficientSpendableFunds, op, desc.Status)
+	}
+
+	return fmt.Errorf("%w: exact spend outpoint %s has unknown status %d",
+		ErrInsufficientSpendableFunds, op, desc.Status)
 }
 
 // insufficientLiquidityError distinguishes a true spendable-funds shortfall

--- a/vtxo/manager_admission_test.go
+++ b/vtxo/manager_admission_test.go
@@ -882,6 +882,73 @@ func TestSelectAndReserveSpendSuccess(t *testing.T) {
 	require.True(t, ok, "expected SpendingState, got %T", ref.state)
 }
 
+// TestSelectAndReserveSpendExactOutpoints verifies an exact-input request
+// reserves only the named managed VTXOs, preserves their order, and permits an
+// exact spend even when each input is individually below the change floor.
+func TestSelectAndReserveSpendExactOutpoints(t *testing.T) {
+	t.Parallel()
+
+	large := makeDescriptor(t, 50_000, 0)
+	small1 := makeDescriptor(t, 744, 1)
+	small2 := makeDescriptor(t, 744, 2)
+
+	mgr, store := newTestManager(t, []*Descriptor{
+		large, small1, small2,
+	})
+	store.On(
+		"ListVTXOsByStatus", t.Context(), VTXOStatusLive,
+	).Return([]*Descriptor{large, small1, small2}, nil)
+
+	result := mgr.Receive(t.Context(), &SelectAndReserveSpendRequest{
+		TargetAmount:    1488,
+		MinChangeAmount: 1000,
+		Outpoints: []wire.OutPoint{
+			small2.Outpoint, small1.Outpoint,
+		},
+	})
+	resp, err := result.Unpack()
+	require.NoError(t, err)
+
+	spendResp, ok := resp.(*SelectAndReserveSpendResponse)
+	require.True(t, ok)
+	require.Equal(t, btcutil.Amount(1488), spendResp.TotalSelected)
+	require.Len(t, spendResp.SelectedVTXOs, 2)
+	require.Equal(t, []wire.OutPoint{
+		small2.Outpoint, small1.Outpoint,
+	}, []wire.OutPoint{
+		spendResp.SelectedVTXOs[0].Outpoint,
+		spendResp.SelectedVTXOs[1].Outpoint,
+	})
+
+	for _, op := range []wire.OutPoint{
+		small1.Outpoint, small2.Outpoint,
+	} {
+		ref, ok := mgr.actors[op].(*mockVTXOActorRef)
+		require.True(t, ok)
+		require.IsType(t, &SpendingState{}, ref.state)
+	}
+
+	largeRef, ok := mgr.actors[large.Outpoint].(*mockVTXOActorRef)
+	require.True(t, ok)
+	require.IsType(t, &LiveState{}, largeRef.state)
+
+	result = mgr.Receive(t.Context(), &CompleteSpendRequest{
+		Outpoints: []wire.OutPoint{
+			small2.Outpoint, small1.Outpoint,
+		},
+	})
+	_, err = result.Unpack()
+	require.NoError(t, err)
+
+	for _, op := range []wire.OutPoint{
+		small1.Outpoint, small2.Outpoint,
+	} {
+		ref, ok := mgr.actors[op].(*mockVTXOActorRef)
+		require.True(t, ok)
+		require.IsType(t, &SpentState{}, ref.state)
+	}
+}
+
 // TestSelectAndReserveRespawnGuards verifies the self-heal path for a
 // live-in-DB but actorless selection candidate fails closed: a store miss
 // and a non-live row both surface as reservation errors instead of spawning

--- a/vtxo/manager_admission_test.go
+++ b/vtxo/manager_admission_test.go
@@ -949,6 +949,50 @@ func TestSelectAndReserveSpendExactOutpoints(t *testing.T) {
 	}
 }
 
+// TestSelectAndReserveSpendExactLockedOutpoint verifies an exact input that
+// fell out of the live projection because its durable status is locked remains
+// a retryable liquidity error after the manager's in-memory marks are lost.
+func TestSelectAndReserveSpendExactLockedOutpoint(t *testing.T) {
+	t.Parallel()
+
+	for _, lockedStatus := range []VTXOStatus{
+		VTXOStatusPendingForfeit,
+		VTXOStatusForfeiting,
+		VTXOStatusSpending,
+	} {
+		t.Run(lockedStatus.String(), func(t *testing.T) {
+			t.Parallel()
+
+			locked := makeDescriptor(t, 50_000, 0)
+			locked.Status = lockedStatus
+
+			mgr, store := newTestManager(t, nil)
+			store.On(
+				"ListVTXOsByStatus", t.Context(),
+				VTXOStatusLive,
+			).Return([]*Descriptor{}, nil)
+			store.On(
+				"GetVTXO", t.Context(), locked.Outpoint,
+			).Return(locked, nil)
+
+			result := mgr.Receive(
+				t.Context(), &SelectAndReserveSpendRequest{
+					TargetAmount: 40_000,
+					Outpoints: []wire.OutPoint{
+						locked.Outpoint,
+					},
+				},
+			)
+			_, err := result.Unpack()
+			require.ErrorIs(t, err, ErrVTXOLiquidityLocked)
+			require.NotErrorIs(
+				t, err, ErrInsufficientSpendableFunds,
+			)
+			require.ErrorContains(t, err, lockedStatus.String())
+		})
+	}
+}
+
 // TestSelectAndReserveRespawnGuards verifies the self-heal path for a
 // live-in-DB but actorless selection candidate fails closed: a store miss
 // and a non-live row both surface as reservation errors instead of spawning

--- a/wallet/messages.go
+++ b/wallet/messages.go
@@ -547,10 +547,9 @@ func (m *DropCustomRefreshVTXOsResponse) MessageType() string {
 func (m *DropCustomRefreshVTXOsResponse) walletRespSealed() {}
 
 // SelectAndLockVTXOsRequest asks the wallet actor to select VTXOs covering a
-// target amount and atomically lock them to prevent double-spends. The locked
-// VTXOs are returned as descriptors that the caller can use to build OOR
-// transfer inputs. If the transfer fails, the caller should send an
-// UnlockVTXOsRequest to release the locks.
+// target amount, or use explicitly named managed VTXOs, and atomically lock
+// them to prevent double-spends. If the transfer fails, the caller should send
+// an UnlockVTXOsRequest to release the locks.
 type SelectAndLockVTXOsRequest struct {
 	actor.BaseMessage
 
@@ -561,6 +560,11 @@ type SelectAndLockVTXOsRequest struct {
 	// MinChangeAmount, when positive, asks selection to avoid a
 	// non-zero residual below this amount. Exact spends are still valid.
 	MinChangeAmount btcutil.Amount
+
+	// Outpoints, when non-empty, identifies the exact managed VTXOs to
+	// lock instead of running coin selection. The requested order is
+	// preserved in the response.
+	Outpoints []wire.OutPoint
 }
 
 // MessageType returns the message type identifier for logging and debugging.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2660,9 +2660,8 @@ func (a *Ark) releaseManagerForfeit(ctx context.Context,
 	}
 }
 
-// handleSelectAndLockVTXOs forwards a spend selection request to the VTXO
-// manager. The manager runs largest-first coin selection and atomically
-// reserves VTXOs for OOR spending by transitioning them to SpendingState.
+// handleSelectAndLockVTXOs forwards a spend selection or exact-input request
+// to the VTXO manager, which reserves the inputs in SpendingState.
 func (a *Ark) handleSelectAndLockVTXOs(ctx context.Context,
 	req *SelectAndLockVTXOsRequest) fn.Result[WalletResp] {
 
@@ -2674,6 +2673,7 @@ func (a *Ark) handleSelectAndLockVTXOs(ctx context.Context,
 		ctx, &actormsg.SelectAndReserveSpendRequest{
 			TargetAmount:    req.TargetAmount,
 			MinChangeAmount: req.MinChangeAmount,
+			Outpoints:       req.Outpoints,
 		},
 	)
 	if err != nil {

--- a/wallet/wallet_admission_test.go
+++ b/wallet/wallet_admission_test.go
@@ -275,6 +275,9 @@ func TestSelectAndLockVTXOs(t *testing.T) {
 	req := &SelectAndLockVTXOsRequest{
 		TargetAmount:    70000,
 		MinChangeAmount: 1000,
+		Outpoints: []wire.OutPoint{
+			testOutpoint(1), testOutpoint(0),
+		},
 	}
 	result := w.Receive(t.Context(), req)
 	require.True(t, result.IsOk(), "expected ok, got: %v",
@@ -291,6 +294,7 @@ func TestSelectAndLockVTXOs(t *testing.T) {
 		resp.SelectedVTXOs[0].Amount)
 	require.Equal(t, btcutil.Amount(70000), mgr.selectReq.TargetAmount)
 	require.Equal(t, btcutil.Amount(1000), mgr.selectReq.MinChangeAmount)
+	require.Equal(t, req.Outpoints, mgr.selectReq.Outpoints)
 }
 
 // TestSelectAndLockVTXOsInsufficientFunds verifies that the wallet surfaces

--- a/waved/rpc_oor_idempotency_test.go
+++ b/waved/rpc_oor_idempotency_test.go
@@ -407,6 +407,157 @@ func TestSendOORSubmitsMultipleRecipients(t *testing.T) {
 	require.Empty(t, testWallet.unlockBatches())
 }
 
+// TestSendOORReservesExactManagedCustomInputs verifies that outpoint-only
+// custom inputs use the wallet's durable spend reservation path while still
+// selecting precisely the caller-named VTXOs.
+func TestSendOORReservesExactManagedCustomInputs(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	recipientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	const (
+		inputAmount = btcutil.Amount(744)
+		amountSat   = int64(2 * inputAmount)
+		exitDelay   = uint32(10)
+	)
+
+	vtxoStore, _, _ := newSendOORTestStores(t)
+	input1, _ := newSendOORTestVTXO(
+		t, operatorKey.PubKey(), 0x61, inputAmount,
+	)
+	input2, _ := newSendOORTestVTXO(
+		t, operatorKey.PubKey(), 0x62, inputAmount,
+	)
+	require.NoError(t, vtxoStore.SaveVTXO(ctx, input1))
+	require.NoError(t, vtxoStore.SaveVTXO(ctx, input2))
+
+	testWallet := &sendOORTestWallet{
+		selections: [][]wallet.SelectedVTXO{{
+			selectedVTXOFromDescriptor(input2),
+			selectedVTXOFromDescriptor(input1),
+		}},
+	}
+
+	system := actor.NewActorSystem()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), 5*time.Second,
+		)
+		defer cancel()
+
+		require.NoError(t, system.Shutdown(shutdownCtx))
+	})
+
+	walletKey := actor.NewServiceKey[
+		wallet.WalletMsg, wallet.WalletResp,
+	](
+		"send-oor-exact-test-wallet",
+	)
+	walletRef := walletKey.Spawn(
+		system, "send-oor-exact-test-wallet", testWallet,
+	)
+
+	sessionHash := chainhash.HashH([]byte("send-oor-exact-session"))
+	oorActor := &capturingSendOORActor{
+		response: &oor.StartTransferResponse{
+			SessionID: oor.SessionID(sessionHash),
+		},
+	}
+	oorKey := oor.NewServiceKey()
+	oorKey.Spawn(system, "send-oor-exact-test-actor", oorActor)
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+
+	server := &Server{
+		cfg:         &Config{},
+		log:         btclog.Disabled,
+		walletReady: walletReady,
+		chainParams: &chaincfg.RegressionNetParams,
+		serverConn: newBufconnClient(t, &fakeArkService{
+			getInfoResponse: &arkrpc.GetInfoResponse{
+				Pubkey: operatorKey.
+					PubKey().
+					SerializeCompressed(),
+				VtxoExitDelay: exitDelay,
+				DustLimit:     1000,
+			},
+		}),
+		actorSystem: system,
+		vtxoStore:   vtxoStore,
+		walletRef:   fn.Some(walletRef),
+	}
+
+	recipient := sendOORPolicyRecipient(
+		t, recipientKey.PubKey(), operatorKey.PubKey(), exitDelay,
+		amountSat,
+	)
+	requestedOutpoints := []wire.OutPoint{
+		input2.Outpoint, input1.Outpoint,
+	}
+
+	resp, err := NewRPCServer(server).SendOOR(
+		ctx, &waverpc.SendOORRequest{
+			Recipients: []*waverpc.Output{recipient},
+			CustomInputs: []*waverpc.CustomOORInput{
+				{Outpoint: requestedOutpoints[0].String()},
+				{Outpoint: requestedOutpoints[1].String()},
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "submitted", resp.GetStatus())
+
+	selectReqs := testWallet.selectionRequests()
+	require.Len(t, selectReqs, 1)
+	require.Equal(t, btcutil.Amount(amountSat),
+		selectReqs[0].TargetAmount)
+	require.Equal(t, btcutil.Amount(1000),
+		selectReqs[0].MinChangeAmount)
+	require.Equal(t, requestedOutpoints, selectReqs[0].Outpoints)
+
+	requests := oorActor.capturedRequests()
+	require.Len(t, requests, 1)
+	require.Len(t, requests[0].Inputs, 2)
+	require.Equal(
+		t, requestedOutpoints[0], requests[0].Inputs[0].VTXO.Outpoint,
+	)
+	require.Equal(
+		t, requestedOutpoints[1], requests[0].Inputs[1].VTXO.Outpoint,
+	)
+}
+
+// TestClassifyCustomOORInputsRejectsMixedModes verifies a request cannot
+// silently bypass durable wallet reservation by mixing a managed outpoint with
+// an explicitly described custom-policy input.
+func TestClassifyCustomOORInputsRejectsMixedModes(t *testing.T) {
+	t.Parallel()
+
+	op1 := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("managed-custom-input")),
+		Index: 1,
+	}
+	op2 := wire.OutPoint{
+		Hash:  chainhash.HashH([]byte("explicit-custom-input")),
+		Index: 2,
+	}
+
+	_, _, err := classifyCustomOORInputs([]*waverpc.CustomOORInput{
+		{Outpoint: op1.String()},
+		{
+			Outpoint:  op2.String(),
+			AmountSat: 1000,
+		},
+	})
+	require.ErrorContains(t, err, "cannot mix outpoint-only managed")
+}
+
 // TestSendOORRejectsTooManyRecipients verifies the daemon rejects oversized
 // OOR fanout before resolving scripts or selecting wallet inputs. The OOR
 // actor also has request-size limits, but the RPC layer does enough per

--- a/waved/rpc_oor_idempotency_test.go
+++ b/waved/rpc_oor_idempotency_test.go
@@ -408,8 +408,8 @@ func TestSendOORSubmitsMultipleRecipients(t *testing.T) {
 }
 
 // TestSendOORReservesExactManagedCustomInputs verifies that outpoint-only
-// custom inputs use the wallet's durable spend reservation path while still
-// selecting precisely the caller-named VTXOs.
+// custom inputs use the wallet's durable spend reservation path, select
+// precisely the caller-named VTXOs, and retain ordinary recipient fanout.
 func TestSendOORReservesExactManagedCustomInputs(t *testing.T) {
 	t.Parallel()
 
@@ -418,13 +418,18 @@ func TestSendOORReservesExactManagedCustomInputs(t *testing.T) {
 	operatorKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
-	recipientKey, err := btcec.NewPrivateKey()
+	recipientKeyA, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	recipientKeyB, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
 	const (
-		inputAmount = btcutil.Amount(744)
-		amountSat   = int64(2 * inputAmount)
-		exitDelay   = uint32(10)
+		inputAmount     = btcutil.Amount(744)
+		recipientAmount = int64(inputAmount)
+		totalAmount     = 2 * inputAmount
+		floor           = btcutil.Amount(700)
+		exitDelay       = uint32(10)
 	)
 
 	vtxoStore, _, _ := newSendOORTestStores(t)
@@ -486,7 +491,7 @@ func TestSendOORReservesExactManagedCustomInputs(t *testing.T) {
 					PubKey().
 					SerializeCompressed(),
 				VtxoExitDelay: exitDelay,
-				DustLimit:     1000,
+				DustLimit:     int64(floor),
 			},
 		}),
 		actorSystem: system,
@@ -494,9 +499,13 @@ func TestSendOORReservesExactManagedCustomInputs(t *testing.T) {
 		walletRef:   fn.Some(walletRef),
 	}
 
-	recipient := sendOORPolicyRecipient(
-		t, recipientKey.PubKey(), operatorKey.PubKey(), exitDelay,
-		amountSat,
+	recipientA := sendOORPolicyRecipient(
+		t, recipientKeyA.PubKey(), operatorKey.PubKey(), exitDelay,
+		recipientAmount,
+	)
+	recipientB := sendOORPolicyRecipient(
+		t, recipientKeyB.PubKey(), operatorKey.PubKey(), exitDelay,
+		recipientAmount,
 	)
 	requestedOutpoints := []wire.OutPoint{
 		input2.Outpoint, input1.Outpoint,
@@ -504,7 +513,9 @@ func TestSendOORReservesExactManagedCustomInputs(t *testing.T) {
 
 	resp, err := NewRPCServer(server).SendOOR(
 		ctx, &waverpc.SendOORRequest{
-			Recipients: []*waverpc.Output{recipient},
+			Recipients: []*waverpc.Output{
+				recipientA, recipientB,
+			},
 			CustomInputs: []*waverpc.CustomOORInput{
 				{Outpoint: requestedOutpoints[0].String()},
 				{Outpoint: requestedOutpoints[1].String()},
@@ -513,18 +524,18 @@ func TestSendOORReservesExactManagedCustomInputs(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, "submitted", resp.GetStatus())
+	require.Len(t, resp.GetRecipientOutpoints(), 2)
 
 	selectReqs := testWallet.selectionRequests()
 	require.Len(t, selectReqs, 1)
-	require.Equal(t, btcutil.Amount(amountSat),
-		selectReqs[0].TargetAmount)
-	require.Equal(t, btcutil.Amount(1000),
-		selectReqs[0].MinChangeAmount)
+	require.Equal(t, totalAmount, selectReqs[0].TargetAmount)
+	require.Equal(t, floor, selectReqs[0].MinChangeAmount)
 	require.Equal(t, requestedOutpoints, selectReqs[0].Outpoints)
 
 	requests := oorActor.capturedRequests()
 	require.Len(t, requests, 1)
 	require.Len(t, requests[0].Inputs, 2)
+	require.Len(t, requests[0].Recipients, 2)
 	require.Equal(
 		t, requestedOutpoints[0], requests[0].Inputs[0].VTXO.Outpoint,
 	)
@@ -634,12 +645,12 @@ func TestSendOORRejectsDuplicateRecipientOutputs(t *testing.T) {
 	require.ErrorContains(t, err, "recipient 1 duplicates recipient 0")
 }
 
-// TestSendOORRejectsCustomInputsWithMultipleRecipients verifies the daemon
-// keeps custom-input sends single-recipient. Custom inputs carry per-input
-// signing material for specialized spend paths, so widening them should happen
-// as a separate protocol change rather than accidentally piggybacking on
-// wallet-selected fanout.
-func TestSendOORRejectsCustomInputsWithMultipleRecipients(t *testing.T) {
+// TestSendOORRejectsExplicitCustomInputsWithMultipleRecipients verifies the
+// daemon keeps custom-spend sends single-recipient. These inputs carry
+// per-input signing material, unlike outpoint-only managed exact inputs.
+func TestSendOORRejectsExplicitCustomInputsWithMultipleRecipients(
+	t *testing.T) {
+
 	t.Parallel()
 
 	operatorKey, err := btcec.NewPrivateKey()
@@ -683,6 +694,12 @@ func TestSendOORRejectsCustomInputsWithMultipleRecipients(t *testing.T) {
 		t, recipientKeyB.PubKey(), operatorKey.PubKey(), exitDelay,
 		amountSat,
 	)
+	customOutpoint := wire.OutPoint{
+		Hash: chainhash.HashH(
+			[]byte("explicit-custom-multi-recipient"),
+		),
+		Index: 0,
+	}
 
 	_, err = NewRPCServer(server).SendOOR(
 		t.Context(), &waverpc.SendOORRequest{
@@ -692,13 +709,14 @@ func TestSendOORRejectsCustomInputsWithMultipleRecipients(t *testing.T) {
 			},
 			DryRun: true,
 			CustomInputs: []*waverpc.CustomOORInput{{
-				Outpoint: "00:0",
+				Outpoint:  customOutpoint.String(),
+				AmountSat: amountSat,
 			}},
 		},
 	)
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 	require.ErrorContains(
-		t, err, "custom inputs require exactly one recipient",
+		t, err, "explicit custom inputs require exactly one recipient",
 	)
 }
 

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -262,6 +262,61 @@ func (r *RPCServer) reserveCustomInputs(outpoints []wire.OutPoint) (func(),
 	return release, nil
 }
 
+// classifyCustomOORInputs parses custom input outpoints and distinguishes
+// exact managed wallet inputs from explicitly described custom spend paths.
+func classifyCustomOORInputs(inputs []*waverpc.CustomOORInput) ([]wire.OutPoint,
+	bool, error) {
+
+	if len(inputs) == 0 {
+		return nil, false, nil
+	}
+
+	outpoints := make([]wire.OutPoint, 0, len(inputs))
+	seen := make(map[wire.OutPoint]struct{}, len(inputs))
+	var (
+		hasManaged bool
+		hasCustom  bool
+	)
+
+	for i, input := range inputs {
+		if input == nil {
+			return nil, false, fmt.Errorf("custom input %d is nil",
+				i)
+		}
+
+		op, err := parseOutpointString(input.GetOutpoint())
+		if err != nil {
+			return nil, false, fmt.Errorf("parse custom input "+
+				"outpoint %q: %w", input.GetOutpoint(), err)
+		}
+		if _, ok := seen[op]; ok {
+			return nil, false, fmt.Errorf("duplicate custom input "+
+				"outpoint %s", op)
+		}
+		seen[op] = struct{}{}
+		outpoints = append(outpoints, op)
+
+		explicit := len(input.GetVtxoPolicyTemplate()) > 0 ||
+			len(input.GetSpendPath()) > 0 ||
+			input.GetAmountSat() != 0 ||
+			len(input.GetPkScript()) > 0 ||
+			len(input.GetExternalSignatures()) > 0
+		if explicit {
+			hasCustom = true
+		} else {
+			hasManaged = true
+		}
+	}
+
+	if hasManaged && hasCustom {
+		return nil, false, fmt.Errorf("cannot mix outpoint-only " +
+			"managed inputs with explicitly described custom " +
+			"inputs")
+	}
+
+	return outpoints, hasManaged, nil
+}
+
 type oorChangeRecipientBuilder func(context.Context,
 	btcutil.Amount) (oortx.RecipientOutput, error)
 
@@ -3064,6 +3119,13 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 			"inputs require exactly one recipient")
 	}
 
+	customOutpoints, exactManagedInputs, err := classifyCustomOORInputs(
+		req.CustomInputs,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
 	// For dry_run, return a preview before selecting wallet inputs or
 	// submitting to the actor. The operator is still queried above so the
 	// preview enforces the current dust limit.
@@ -3100,10 +3162,10 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		releaseCustomInputs bool
 	)
 
-	if len(req.CustomInputs) > 0 {
+	if len(req.CustomInputs) > 0 && !exactManagedInputs {
 		phaseStart = time.Now()
-		// Custom inputs provided — bypass wallet selection and
-		// build TransferInputs from the specified VTXOs.
+		// Explicit custom inputs bypass wallet selection and build
+		// TransferInputs from the supplied policy and spend data.
 		//
 		// Custom inputs typically refer to non-standard VTXOs
 		// (e.g. vHTLC claim outpoints) that live outside the
@@ -3119,20 +3181,6 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		// already been accepted and the caller only stopped waiting for
 		// its response. In that case the release is deferred until the
 		// actor future actually completes.
-		customOutpoints := make(
-			[]wire.OutPoint, 0, len(req.CustomInputs),
-		)
-		for _, ci := range req.CustomInputs {
-			op, err := parseOutpointString(ci.Outpoint)
-			if err != nil {
-				return nil, status.Errorf(codes.InvalidArgument,
-					"parse custom input outpoint %q: %v",
-					ci.Outpoint, err)
-			}
-
-			customOutpoints = append(customOutpoints, op)
-		}
-
 		release, err := r.reserveCustomInputs(customOutpoints)
 		if err != nil {
 			return nil, status.Errorf(codes.Aborted, "custom "+
@@ -3163,13 +3211,18 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 			return nil, err
 		}
 	} else {
-		// Standard path: select and lock VTXOs from wallet.
+		// The standard path lets the wallet select inputs.
+		// Outpoint-only custom inputs use the same durable reservation
+		// path, but name the exact managed VTXOs that must be selected.
 		phaseStart = time.Now()
 		wRef := r.server.walletRef.UnsafeFromSome()
 
 		selectReq := &wallet.SelectAndLockVTXOsRequest{
 			TargetAmount:    targetAmt,
 			MinChangeAmount: terms.MinVTXOAmountFloor(),
+		}
+		if exactManagedInputs {
+			selectReq.Outpoints = customOutpoints
 		}
 		selectFuture := wRef.Ask(ctx, selectReq)
 		selectResult := selectFuture.Await(ctx)

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -3114,16 +3114,17 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		return nil, err
 	}
 
-	if len(req.CustomInputs) > 0 && len(oorRecipients) != 1 {
-		return nil, status.Errorf(codes.InvalidArgument, "custom "+
-			"inputs require exactly one recipient")
-	}
-
 	customOutpoints, exactManagedInputs, err := classifyCustomOORInputs(
 		req.CustomInputs,
 	)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	if len(req.CustomInputs) > 0 && !exactManagedInputs &&
+		len(oorRecipients) != 1 {
+		return nil, status.Errorf(codes.InvalidArgument, "explicit "+
+			"custom inputs require exactly one recipient")
 	}
 
 	// For dry_run, return a preview before selecting wallet inputs or


### PR DESCRIPTION
## Problem

Outpoint-only `custom_inputs` resolve local VTXO descriptors, but previously bypassed the wallet manager reservation path. The OOR transfer could succeed and then fail during local completion because `SpendCompletedEvent` was delivered to a VTXO that was still in `LiveState`.

This also prevented a safe one-off consolidation of the sub-minimum VTXOs described in lightninglabs/lumos#735.

## Fix

- Treat an all-outpoint-only `custom_inputs` list as exact managed wallet inputs.
- Reserve those exact outpoints through the existing durable `SpendingState` path; do not substitute other wallet liquidity.
- Keep explicitly described custom-policy inputs on their existing path.
- Reject mixed managed/custom input modes and duplicate outpoints before submission.
- Preserve input order, ordinary recipient fanout, and the existing target/change-floor validation.
- Report durably locked exact inputs as retryable liquidity after restart.

No protobuf or CLI surface change is required; the existing full JSON request is sufficient.

## Compatibility notes

- Outpoint-only inputs now intentionally require live, locally managed VTXOs. Callers spending non-standard inputs must provide their explicit policy/spend description.
- Custom-input shape and outpoint validation now runs during `dry_run` instead of returning a preview for malformed input.
- An over-funded exact-input set may still create wallet change when the residual meets the operator floor, matching the ordinary wallet-selected OOR path.

## Tests

- Regression coverage for an exact 744 + 744 sat input set, including `SpendingState` reservation and successful transition to `SpentState`.
- RPC coverage proving exact managed inputs retain multi-recipient fanout and use the requested outpoints.
- Restart-shape coverage proving durable `Spending`, `PendingForfeit`, and `Forfeiting` inputs return retryable liquidity errors.
- Wallet forwarding, explicit-custom fanout rejection, and mixed-mode rejection coverage.
- `go test ./vtxo ./wallet ./waved -count=1`
- `make lint-changed-local`
- `make fmt-changed-check`
- `make tidy-module-check`