### PR TITLE
swaps: authorize credit account requests

### DIFF
--- a/cmd/wavecli/waveclicommands/devrpc/registry_generated.go
+++ b/cmd/wavecli/waveclicommands/devrpc/registry_generated.go
@@ -339,6 +339,13 @@ func generatedRegistry() []serviceSpec {
 					Output:   "waverpc.SignOutSwapHtlcAckResponse",
 					Comments: "SignOutSwapHtlcAck signs the accepted terms of an out-swap vHTLC with\nthe daemon identity key.",
 				},
+				{
+					Name:     "SignCreditAccountAuthorization",
+					Aliases:  []string{"sign-credit-account-authorization"},
+					Input:    "waverpc.SignCreditAccountAuthorizationRequest",
+					Output:   "waverpc.SignCreditAccountAuthorizationResponse",
+					Comments: "SignCreditAccountAuthorization signs one canonical swap credit-account\nrequest digest with the daemon identity key.",
+				},
 			},
 		},
 		{

--- a/rpc/restclient/clients.go
+++ b/rpc/restclient/clients.go
@@ -446,6 +446,20 @@ func (c *DaemonServiceClient) SignOutSwapHtlcAck(ctx context.Context,
 	return out, err
 }
 
+// SignCreditAccountAuthorization signs one swap credit-account request.
+func (c *DaemonServiceClient) SignCreditAccountAuthorization(
+	ctx context.Context, in *waverpc.SignCreditAccountAuthorizationRequest,
+	_ ...grpc.CallOption) (*waverpc.SignCreditAccountAuthorizationResponse,
+	error) {
+
+	out := new(waverpc.SignCreditAccountAuthorizationResponse)
+	err := c.client.Post(
+		ctx, "/v1/daemon/sign-credit-account-authorization", in, out,
+	)
+
+	return out, err
+}
+
 // GetIndexedVTXOByPkScript looks up one indexed VTXO by pkScript.
 func (c *DaemonServiceClient) GetIndexedVTXOByPkScript(ctx context.Context,
 	in *waverpc.GetIndexedVTXOByPkScriptRequest, _ ...grpc.CallOption) (

--- a/sdk/ark/client.go
+++ b/sdk/ark/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/lightninglabs/wavelength/swaprpc"
 	"github.com/lightninglabs/wavelength/waverpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"google.golang.org/grpc"
@@ -520,6 +521,35 @@ func (c *Client) SignOutSwapHTLCAck(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("parse out-swap HTLC "+
 			"acknowledgement: %w", err)
+	}
+
+	return sig, nil
+}
+
+// SignCreditAccountAuth asks the daemon identity key to authorize one
+// canonical swap credit-account request.
+func (c *Client) SignCreditAccountAuth(ctx context.Context, accountKey []byte,
+	requestDigest [32]byte, expiresAtUnix int64,
+	nonce [swaprpc.CreditAccountNonceSize]byte) (*schnorr.Signature,
+	error) {
+
+	resp, err := c.daemon.SignCreditAccountAuthorization(
+		ctx, &waverpc.SignCreditAccountAuthorizationRequest{
+			AccountPubkey: accountKey,
+			RequestDigest: requestDigest[:],
+			ExpiresAtUnix: expiresAtUnix,
+			Nonce:         nonce[:],
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sign credit account authorization: %w",
+			err)
+	}
+
+	sig, err := schnorr.ParseSignature(resp.GetSignature())
+	if err != nil {
+		return nil, fmt.Errorf("parse credit account authorization: %w",
+			err)
 	}
 
 	return sig, nil

--- a/sdk/ark/client_test.go
+++ b/sdk/ark/client_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"math/big"
 	"net"
@@ -51,6 +52,7 @@ type fakeDaemonService struct {
 	lastIndexedOORReq  *waverpc.GetIndexedOORSessionByTxidRequest
 	lastSendOORReq     *waverpc.SendOORRequest
 	lastOutSwapAckReq  *waverpc.SignOutSwapHtlcAckRequest
+	lastCreditAuthReq  *waverpc.SignCreditAccountAuthorizationRequest
 }
 
 const (
@@ -502,6 +504,39 @@ func (f *fakeDaemonService) SignOutSwapHtlcAck(_ context.Context,
 	}
 
 	return &waverpc.SignOutSwapHtlcAckResponse{
+		Signature: sig.Serialize(),
+	}, nil
+}
+
+// SignCreditAccountAuthorization signs a canonical credit-account request
+// with the fake daemon identity key.
+func (f *fakeDaemonService) SignCreditAccountAuthorization(_ context.Context,
+	req *waverpc.SignCreditAccountAuthorizationRequest) (
+	*waverpc.SignCreditAccountAuthorizationResponse, error) {
+
+	f.mu.Lock()
+	f.lastCreditAuthReq = req
+	f.mu.Unlock()
+	if !bytes.Equal(
+		req.GetAccountPubkey(),
+		fakeIdentityPrivKey().PubKey().SerializeCompressed(),
+	) {
+		return nil, fmt.Errorf("credit account key does not match " +
+			"identity")
+	}
+
+	var requestDigest [32]byte
+	copy(requestDigest[:], req.GetRequestDigest())
+	digest := swaprpc.CreditAccountAuthDigest(
+		req.GetAccountPubkey(), requestDigest, req.GetExpiresAtUnix(),
+		req.GetNonce(),
+	)
+	sig, err := schnorr.Sign(fakeIdentityPrivKey(), digest[:])
+	if err != nil {
+		return nil, err
+	}
+
+	return &waverpc.SignCreditAccountAuthorizationResponse{
 		Signature: sig.Serialize(),
 	}, nil
 }
@@ -962,6 +997,39 @@ func TestDialRemotePolicyHelpers(t *testing.T) {
 	require.Equal(t, ackHash[:], ackReq.GetPaymentHash())
 	require.Equal(t, uint64(42_000), ackReq.GetAmountSat())
 	require.Equal(t, ackScript, ackReq.GetVhtlcPkScript())
+
+	creditRequestDigest := [32]byte{7, 8, 9}
+	creditNonce := [swaprpc.CreditAccountNonceSize]byte{10, 11, 12}
+	creditExpiry := time.Now().Add(time.Minute).Unix()
+	creditSig, err := client.SignCreditAccountAuth(
+		context.Background(),
+		fakeIdentityPrivKey().PubKey().SerializeCompressed(),
+		creditRequestDigest, creditExpiry, creditNonce,
+	)
+	require.NoError(t, err)
+	creditDigest := swaprpc.CreditAccountAuthDigest(
+		fakeIdentityPrivKey().PubKey().SerializeCompressed(),
+		creditRequestDigest, creditExpiry, creditNonce[:],
+	)
+	require.True(
+		t,
+		creditSig.Verify(
+			creditDigest[:], fakeIdentityPrivKey().PubKey(),
+		),
+	)
+
+	service.mu.Lock()
+	creditAuthReq := service.lastCreditAuthReq
+	service.mu.Unlock()
+	require.Equal(
+		t, creditRequestDigest[:], creditAuthReq.GetRequestDigest(),
+	)
+	require.Equal(
+		t, fakeIdentityPrivKey().PubKey().SerializeCompressed(),
+		creditAuthReq.GetAccountPubkey(),
+	)
+	require.Equal(t, creditExpiry, creditAuthReq.GetExpiresAtUnix())
+	require.Equal(t, creditNonce[:], creditAuthReq.GetNonce())
 
 	remotePriv, err := btcec.NewPrivateKey()
 	require.NoError(t, err)

--- a/sdk/swaps/credit_account_auth.go
+++ b/sdk/swaps/credit_account_auth.go
@@ -1,0 +1,72 @@
+package swaps
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightninglabs/wavelength/swaprpc"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	creditAccountAuthorizationTTL = time.Minute
+	creditAccountNonceSize        = swaprpc.CreditAccountNonceSize
+)
+
+// CreditAccountAuthorizationSigner signs one canonical account request with
+// the wallet identity key. The signer must reject accountKey unless it names
+// that identity key.
+type CreditAccountAuthorizationSigner func(context.Context, []byte, [32]byte,
+	int64, [creditAccountNonceSize]byte) (*schnorr.Signature, error)
+
+// authorizeCreditAccountRequest attaches a fresh, short-lived authorization
+// to one account-scoped request.
+func (g *GRPCSwapServerConn) authorizeCreditAccountRequest(ctx context.Context,
+	req proto.Message) error {
+
+	if g.creditAccountSigner == nil {
+		return fmt.Errorf("credit account authorization signer is " +
+			"required")
+	}
+
+	digest, accountKey, err := swaprpc.CreditAccountRequestDigest(req)
+	if err != nil {
+		return err
+	}
+
+	var nonce [creditAccountNonceSize]byte
+	if _, err := io.ReadFull(g.authRand, nonce[:]); err != nil {
+		return fmt.Errorf("generate credit account authorization "+
+			"nonce: %w", err)
+	}
+
+	expiresAt := g.authNow().Add(creditAccountAuthorizationTTL).Unix()
+	sig, err := g.creditAccountSigner(
+		ctx, accountKey, digest, expiresAt, nonce,
+	)
+	if err != nil {
+		return fmt.Errorf("sign credit account authorization: %w", err)
+	}
+	if sig == nil {
+		return fmt.Errorf("credit account authorization signature is " +
+			"required")
+	}
+
+	return swaprpc.SetCreditAccountAuthorization(
+		req, &swaprpc.CreditAccountAuthorization{
+			ExpiresAtUnix: expiresAt,
+			Nonce:         nonce[:],
+			Signature:     sig.Serialize(),
+		},
+	)
+}
+
+// defaultCreditAccountAuthRand returns the cryptographic random source used
+// for authorization nonces.
+func defaultCreditAccountAuthRand() io.Reader {
+	return rand.Reader
+}

--- a/sdk/swaps/grpc_conn.go
+++ b/sdk/swaps/grpc_conn.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"math"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
@@ -19,32 +21,66 @@ import (
 // GRPCSwapServerConn implements SwapServerConn using the shared generated
 // swaprpc client stubs.
 type GRPCSwapServerConn struct {
-	client swaprpc.SwapServiceClient
+	client              swaprpc.SwapServiceClient
+	creditAccountSigner CreditAccountAuthorizationSigner
+	authNow             func() time.Time
+	authRand            io.Reader
 }
 
 const wireCreditFundingLightningReceive = swaprpc.
 	CreditFundingSource_CREDIT_FUNDING_SOURCE_LIGHTNING_RECEIVE
 
 // NewGRPCSwapServerConn creates a gRPC-backed SwapServerConn from one connected
-// gRPC client connection.
-func NewGRPCSwapServerConn(conn grpc.ClientConnInterface) *GRPCSwapServerConn {
-	return &GRPCSwapServerConn{
-		client: swaprpc.NewSwapServiceClient(conn),
+// gRPC client connection. A signer is required for receive and credit-account
+// operations; send-only callers that do not use credits may omit it.
+func NewGRPCSwapServerConn(conn grpc.ClientConnInterface,
+	creditSigner ...CreditAccountAuthorizationSigner) *GRPCSwapServerConn {
+
+	serverConn := newSwapServerConn(swaprpc.NewSwapServiceClient(conn))
+	if len(creditSigner) > 0 {
+		serverConn.creditAccountSigner = creditSigner[0]
 	}
+
+	return serverConn
 }
 
-// NewRESTSwapServerConn creates a REST-backed SwapServerConn for one
-// grpc-gateway base address.
+// NewRESTSwapServerConn creates an unauthenticated REST-backed SwapServerConn
+// for one grpc-gateway base address. It supports send operations that do not
+// use credits; receive and credit-account operations require the authenticated
+// constructor.
 func NewRESTSwapServerConn(addr string,
 	opts ...restclient.Option) *GRPCSwapServerConn {
 
+	return newSwapServerConn(restclient.NewSwapServiceClient(addr, opts...))
+}
+
+// NewAuthenticatedRESTSwapServerConn creates a REST-backed SwapServerConn
+// that signs account-scoped credit requests.
+func NewAuthenticatedRESTSwapServerConn(addr string,
+	creditSigner CreditAccountAuthorizationSigner,
+	opts ...restclient.Option) *GRPCSwapServerConn {
+
+	serverConn := newSwapServerConn(
+		restclient.NewSwapServiceClient(addr, opts...),
+	)
+	serverConn.creditAccountSigner = creditSigner
+
+	return serverConn
+}
+
+// newSwapServerConn creates the shared transport wrapper with production
+// clock and entropy sources.
+func newSwapServerConn(client swaprpc.SwapServiceClient) *GRPCSwapServerConn {
 	return &GRPCSwapServerConn{
-		client: restclient.NewSwapServiceClient(addr, opts...),
+		client:   client,
+		authNow:  time.Now,
+		authRand: defaultCreditAccountAuthRand(),
 	}
 }
 
 // RequestChannelID asks the swap server for one route hint for a
-// Lightning-to-Ark receive flow.
+// Lightning-to-Ark receive flow. Receive routes are account-scoped and always
+// require a credit-account authorization signer.
 func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 	vhtlcPubkey *btcec.PublicKey, paymentHash lntypes.Hash,
 	amountSat btcutil.Amount, expirySeconds uint32,
@@ -57,18 +93,21 @@ func (g *GRPCSwapServerConn) RequestChannelID(ctx context.Context,
 		return nil, fmt.Errorf("receive amount must be positive")
 	}
 
-	resp, err := g.client.RequestChannelId(
-		ctx, &swaprpc.RequestChannelIdRequest{
-			ExpirySeconds: expirySeconds,
-			ClientVhtlcPubkey: vhtlcPubkey.
-				SerializeCompressed(),
-			PaymentHash: append(
-				[]byte(nil), paymentHash[:]...,
-			),
-			AmountSat:           uint64(amountSat),
-			SupportsInArkCredit: supportsInArkCredit,
-		},
-	)
+	req := &swaprpc.RequestChannelIdRequest{
+		ExpirySeconds: expirySeconds,
+		ClientVhtlcPubkey: vhtlcPubkey.
+			SerializeCompressed(),
+		PaymentHash: append(
+			[]byte(nil), paymentHash[:]...,
+		),
+		AmountSat:           uint64(amountSat),
+		SupportsInArkCredit: supportsInArkCredit,
+	}
+	if err := g.authorizeCreditAccountRequest(ctx, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := g.client.RequestChannelId(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("RequestChannelId RPC: %w", err)
 	}
@@ -159,16 +198,23 @@ func (g *GRPCSwapServerConn) CreateInSwapWithCredits(ctx context.Context,
 		return nil, fmt.Errorf("client vHTLC pubkey must be provided")
 	}
 
-	resp, err := g.client.CreateInSwap(
-		ctx, &swaprpc.CreateInSwapRequest{
-			Invoice:   invoice,
-			MaxFeeSat: maxFeeSat,
-			ClientVhtlcPubkey: clientVhtlcPubkey.
-				SerializeCompressed(),
-			AccountPubkey: append([]byte(nil), accountPubKey...),
-			MaxCreditSat:  maxCreditSat,
-		},
-	)
+	req := &swaprpc.CreateInSwapRequest{
+		Invoice:   invoice,
+		MaxFeeSat: maxFeeSat,
+		ClientVhtlcPubkey: clientVhtlcPubkey.
+			SerializeCompressed(),
+		AccountPubkey: append([]byte(nil), accountPubKey...),
+		MaxCreditSat:  maxCreditSat,
+	}
+	if len(accountPubKey) > 0 {
+		if err := g.authorizeCreditAccountRequest(
+			ctx, req,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	resp, err := g.client.CreateInSwap(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("CreateInSwap RPC: %w", err)
 	}
@@ -190,14 +236,21 @@ func (g *GRPCSwapServerConn) QuoteInSwapWithCredits(ctx context.Context,
 	invoice string, maxFeeSat uint64, accountPubKey []byte,
 	maxCreditSat uint64) (*InSwapQuote, error) {
 
-	resp, err := g.client.QuoteInSwap(
-		ctx, &swaprpc.QuoteInSwapRequest{
-			Invoice:       invoice,
-			MaxFeeSat:     maxFeeSat,
-			AccountPubkey: append([]byte(nil), accountPubKey...),
-			MaxCreditSat:  maxCreditSat,
-		},
-	)
+	req := &swaprpc.QuoteInSwapRequest{
+		Invoice:       invoice,
+		MaxFeeSat:     maxFeeSat,
+		AccountPubkey: append([]byte(nil), accountPubKey...),
+		MaxCreditSat:  maxCreditSat,
+	}
+	if len(accountPubKey) > 0 {
+		if err := g.authorizeCreditAccountRequest(
+			ctx, req,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	resp, err := g.client.QuoteInSwap(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("QuoteInSwap RPC: %w", err)
 	}
@@ -215,13 +268,18 @@ func (g *GRPCSwapServerConn) CreateCredit(ctx context.Context,
 		return nil, err
 	}
 
-	resp, err := g.client.CreateCredit(ctx, &swaprpc.CreateCreditRequest{
+	protoReq := &swaprpc.CreateCreditRequest{
 		AccountPubkey:  append([]byte(nil), accountPubKey...),
 		IdempotencyKey: req.IdempotencyKey,
 		Source:         source,
 		AmountSat:      req.AmountSat,
 		Memo:           req.Memo,
-	})
+	}
+	if err := g.authorizeCreditAccountRequest(ctx, protoReq); err != nil {
+		return nil, err
+	}
+
+	resp, err := g.client.CreateCredit(ctx, protoReq)
 	if err != nil {
 		return nil, fmt.Errorf("CreateCredit RPC: %w", err)
 	}
@@ -236,14 +294,19 @@ func (g *GRPCSwapServerConn) RedeemCredit(ctx context.Context,
 	accountPubKey []byte, req RedeemCreditRequest) (*CreditRedemption,
 	error) {
 
-	resp, err := g.client.RedeemCredit(ctx, &swaprpc.RedeemCreditRequest{
+	protoReq := &swaprpc.RedeemCreditRequest{
 		AccountPubkey:  append([]byte(nil), accountPubKey...),
 		IdempotencyKey: req.IdempotencyKey,
 		AmountSat:      req.AmountSat,
 		DestinationPubkey: append(
 			[]byte(nil), req.DestinationPubKey...,
 		),
-	})
+	}
+	if err := g.authorizeCreditAccountRequest(ctx, protoReq); err != nil {
+		return nil, err
+	}
+
+	resp, err := g.client.RedeemCredit(ctx, protoReq)
 	if err != nil {
 		return nil, fmt.Errorf("RedeemCredit RPC: %w", err)
 	}
@@ -268,10 +331,15 @@ func (g *GRPCSwapServerConn) RedeemCredit(ctx context.Context,
 func (g *GRPCSwapServerConn) ListCredits(ctx context.Context,
 	accountPubKey []byte, limit uint32) (*CreditSnapshot, error) {
 
-	resp, err := g.client.ListCredits(ctx, &swaprpc.ListCreditsRequest{
+	req := &swaprpc.ListCreditsRequest{
 		AccountPubkey: append([]byte(nil), accountPubKey...),
 		Limit:         limit,
-	})
+	}
+	if err := g.authorizeCreditAccountRequest(ctx, req); err != nil {
+		return nil, err
+	}
+
+	resp, err := g.client.ListCredits(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("ListCredits RPC: %w", err)
 	}

--- a/sdk/swaps/grpc_conn_test.go
+++ b/sdk/swaps/grpc_conn_test.go
@@ -1,11 +1,14 @@
 package swaps
 
 import (
+	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/lightninglabs/wavelength/swaprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
 	"github.com/stretchr/testify/require"
@@ -25,6 +28,7 @@ type testSwapServiceClient struct {
 	lastAckReq       *swaprpc.AcknowledgeOutSwapHtlcRequest
 	lastSignReq      *swaprpc.SignInSwapForfeitRequest
 	lastSubmitSigReq *swaprpc.SubmitOutSwapForfeitSignatureRequest
+	listCreditReqs   []*swaprpc.ListCreditsRequest
 }
 
 func (c *testSwapServiceClient) AuthorizeInSwapRefund(context.Context,
@@ -68,6 +72,16 @@ func (c *testSwapServiceClient) SubmitOutSwapForfeitSignature(_ context.Context,
 	return &swaprpc.SubmitOutSwapForfeitSignatureResponse{}, nil
 }
 
+// ListCredits records account-scoped requests for authorization assertions.
+func (c *testSwapServiceClient) ListCredits(_ context.Context,
+	req *swaprpc.ListCreditsRequest, _ ...grpc.CallOption) (
+	*swaprpc.ListCreditsResponse, error) {
+
+	c.listCreditReqs = append(c.listCreditReqs, req)
+
+	return &swaprpc.ListCreditsResponse{}, nil
+}
+
 func testForfeitSignaturePayload() *ForfeitSignaturePayload {
 	return &ForfeitSignaturePayload{
 		RequestID: []byte("request-id"),
@@ -87,6 +101,99 @@ func testForfeitSignaturePayload() *ForfeitSignaturePayload {
 		ConnectorPkScript:     []byte("connector-pk-script"),
 		ServerForfeitPkScript: []byte("server-forfeit-pk-script"),
 	}
+}
+
+// TestCreditAccountRPCRequiresSigner verifies an account-scoped request never
+// reaches the server when the transport has no wallet signer.
+func TestCreditAccountRPCRequiresSigner(t *testing.T) {
+	t.Parallel()
+
+	client := &testSwapServiceClient{}
+	conn := newSwapServerConn(client)
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	_, err = conn.ListCredits(t.Context(), []byte{2, 3, 4}, 10)
+	require.ErrorContains(
+		t, err, "credit account authorization signer is required",
+	)
+	require.Empty(t, client.listCreditReqs)
+
+	_, err = conn.RequestChannelID(
+		t.Context(), privKey.PubKey(), lntypes.Hash{1},
+		btcutil.Amount(1_000), 30, false,
+	)
+	require.ErrorContains(
+		t, err, "credit account authorization signer is required",
+	)
+}
+
+// TestCreditAccountRPCUsesFreshAuthorization verifies every account-scoped
+// call carries a valid signature with a new nonce.
+func TestCreditAccountRPCUsesFreshAuthorization(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	accountKey := privKey.PubKey().SerializeCompressed()
+	fixedNow := time.Unix(1_800_000_000, 0)
+	nonceBytes := append(
+		bytes.Repeat(
+			[]byte{1}, 32,
+		),
+		bytes.Repeat([]byte{2}, 32)...,
+	)
+
+	client := &testSwapServiceClient{}
+	conn := newSwapServerConn(client)
+	conn.authNow = func() time.Time {
+		return fixedNow
+	}
+	conn.authRand = bytes.NewReader(nonceBytes)
+	conn.creditAccountSigner = func(_ context.Context, gotAccountKey []byte,
+		requestDigest [32]byte, expiresAtUnix int64,
+		nonce [creditAccountNonceSize]byte) (*schnorr.Signature,
+		error) {
+
+		require.Equal(t, accountKey, gotAccountKey)
+		digest := swaprpc.CreditAccountAuthDigest(
+			accountKey, requestDigest, expiresAtUnix, nonce[:],
+		)
+
+		return schnorr.Sign(privKey, digest[:])
+	}
+
+	for range 2 {
+		_, err := conn.ListCredits(t.Context(), accountKey, 10)
+		require.NoError(t, err)
+	}
+	require.Len(t, client.listCreditReqs, 2)
+
+	for _, req := range client.listCreditReqs {
+		auth := req.GetAccountAuthorization()
+		require.NotNil(t, auth)
+		require.Equal(
+			t, fixedNow.Add(creditAccountAuthorizationTTL).Unix(),
+			auth.GetExpiresAtUnix(),
+		)
+
+		requestDigest, gotAccount, err :=
+			swaprpc.CreditAccountRequestDigest(req)
+		require.NoError(t, err)
+		require.Equal(t, accountKey, gotAccount)
+		digest := swaprpc.CreditAccountAuthDigest(
+			accountKey, requestDigest, auth.GetExpiresAtUnix(),
+			auth.GetNonce(),
+		)
+		sig, err := schnorr.ParseSignature(auth.GetSignature())
+		require.NoError(t, err)
+		require.True(t, sig.Verify(digest[:], privKey.PubKey()))
+	}
+	require.NotEqual(
+		t,
+		client.listCreditReqs[0].GetAccountAuthorization().GetNonce(),
+		client.listCreditReqs[1].GetAccountAuthorization().GetNonce(),
+	)
 }
 
 // TestRouteHintPathsFromProto verifies alternative route-hint paths convert

--- a/sdk/swaps/rest_conn_test.go
+++ b/sdk/swaps/rest_conn_test.go
@@ -1,11 +1,14 @@
 package swaps
 
 import (
+	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/lightninglabs/wavelength/swaprpc"
 	"github.com/lightningnetwork/lnd/lntypes"
@@ -34,6 +37,12 @@ func TestRESTSwapServerConnRequestChannelID(t *testing.T) {
 					t, "/v1/swap/request-channel-id",
 					r.URL.Path,
 				)
+				requestBody, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				var req swaprpc.RequestChannelIdRequest
+				err = protojson.Unmarshal(requestBody, &req)
+				require.NoError(t, err)
+				require.NotNil(t, req.GetAccountAuthorization())
 
 				routeHintPaths := []*swaprpc.RouteHintPath{{
 					Hops: []*swaprpc.RouteHint{
@@ -61,7 +70,23 @@ func TestRESTSwapServerConnRequestChannelID(t *testing.T) {
 	clientPriv, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
-	client := NewRESTSwapServerConn(server.URL)
+	signer := func(_ context.Context, accountKey []byte,
+		requestDigest [32]byte, expiresAtUnix int64,
+		nonce [swaprpc.CreditAccountNonceSize]byte) (*schnorr.Signature,
+		error) {
+
+		require.Equal(
+			t, clientPriv.PubKey().SerializeCompressed(),
+			accountKey,
+		)
+		digest := swaprpc.CreditAccountAuthDigest(
+			clientPriv.PubKey().SerializeCompressed(),
+			requestDigest, expiresAtUnix, nonce[:],
+		)
+
+		return schnorr.Sign(clientPriv, digest[:])
+	}
+	client := NewAuthenticatedRESTSwapServerConn(server.URL, signer)
 	quote, err := client.RequestChannelID(
 		t.Context(), clientPriv.PubKey(), lntypes.Hash{1},
 		btcutil.Amount(42_000), 30, true,

--- a/swapclientserver/service.go
+++ b/swapclientserver/service.go
@@ -408,7 +408,8 @@ func newSwapClientService(ctx context.Context, rpcServer *waved.RPCServer,
 	}
 
 	swapClients, err := newSwapServerClients(
-		cfg, swapAddr, rpcServer.SignMailboxAuth, clientCerts,
+		cfg, swapAddr, rpcServer.SignMailboxAuth,
+		rpcServer.SignCreditAccountAuth, clientCerts,
 	)
 	if err != nil {
 		_ = store.Close()
@@ -603,6 +604,7 @@ func installVTXOForfeitParticipantSigner(rpcServer *waved.RPCServer,
 // daemon-owned outbound transport.
 func newSwapServerClients(cfg *waved.SwapConfig, swapAddr string,
 	sign serverconn.MailboxAuthSigner,
+	creditSigner swaps.CreditAccountAuthorizationSigner,
 	clientCerts clientTLSCertProvider) (*swapServerClients, error) {
 
 	switch cfg.ServerTransport {
@@ -621,7 +623,9 @@ func newSwapServerClients(cfg *waved.SwapConfig, swapAddr string,
 		}
 
 		return &swapServerClients{
-			server: swaps.NewGRPCSwapServerConn(swapConn),
+			server: swaps.NewGRPCSwapServerConn(
+				swapConn, creditSigner,
+			),
 			mailbox: serverconn.NewAuthenticatedMailboxClient(
 				mailboxpb.NewMailboxServiceClient(swapConn),
 				sign,
@@ -639,7 +643,9 @@ func newSwapServerClients(cfg *waved.SwapConfig, swapAddr string,
 		transport := restclient.New(baseURL, opts...)
 
 		return &swapServerClients{
-			server: swaps.NewRESTSwapServerConn(baseURL, opts...),
+			server: swaps.NewAuthenticatedRESTSwapServerConn(
+				baseURL, creditSigner, opts...,
+			),
 			mailbox: serverconn.NewAuthenticatedMailboxClient(
 				restclient.NewMailboxServiceClientFromClient(
 					transport,

--- a/swapclientserver/service_test.go
+++ b/swapclientserver/service_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btclog/v2"
@@ -946,6 +947,8 @@ func TestNewSwapServerClientsREST(t *testing.T) {
 	)
 	defer server.Close()
 
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
 	clients, err := newSwapServerClients(&waved.SwapConfig{
 		ServerTransport: waved.RPCTransportREST,
 		ServerInsecure:  true,
@@ -953,14 +956,11 @@ func TestNewSwapServerClientsREST(t *testing.T) {
 		error) {
 
 		return "auth-" + recipient, nil
-	}, nil)
+	}, testCreditAccountSigner(t, clientPriv), nil)
 	require.NoError(t, err)
 	require.NotNil(t, clients.server)
 	require.NotNil(t, clients.mailbox)
 	require.NoError(t, clients.cleanup())
-
-	clientPriv, err := btcec.NewPrivateKey()
-	require.NoError(t, err)
 
 	hint, err := clients.server.RequestChannelID(
 		t.Context(), clientPriv.PubKey(), lntypes.Hash{1},
@@ -1002,7 +1002,7 @@ func TestNewSwapServerClientsUnknownTransport(t *testing.T) {
 
 	_, err := newSwapServerClients(&waved.SwapConfig{
 		ServerTransport: "webdav",
-	}, "localhost:10030", nil, nil)
+	}, "localhost:10030", nil, nil, nil)
 	require.ErrorContains(t, err, "unknown swap server transport")
 }
 
@@ -1048,6 +1048,8 @@ func TestSwapServerClientsWaitForLateGRPCServer(t *testing.T) {
 	t.Parallel()
 
 	addr := reserveLoopbackAddr(t)
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
 	clients, err := newSwapServerClients(
 		&waved.SwapConfig{
 			ServerTransport: waved.RPCTransportGRPC,
@@ -1055,7 +1057,7 @@ func TestSwapServerClientsWaitForLateGRPCServer(t *testing.T) {
 		},
 		addr, func(context.Context, string) (string, error) {
 			return "auth", nil
-		}, nil,
+		}, testCreditAccountSigner(t, clientPriv), nil,
 	)
 	require.NoError(t, err)
 	defer func() {
@@ -1104,6 +1106,30 @@ func TestSwapServerClientsWaitForLateGRPCServer(t *testing.T) {
 	}
 }
 
+// testCreditAccountSigner returns a deterministic account-request signer for
+// swap transport tests.
+func testCreditAccountSigner(t *testing.T,
+	privKey *btcec.PrivateKey) swaps.CreditAccountAuthorizationSigner {
+
+	t.Helper()
+
+	return func(_ context.Context, accountKey []byte,
+		requestDigest [32]byte, expiresAtUnix int64,
+		nonce [swaprpc.CreditAccountNonceSize]byte) (*schnorr.Signature,
+		error) {
+
+		require.Equal(
+			t, privKey.PubKey().SerializeCompressed(), accountKey,
+		)
+		digest := swaprpc.CreditAccountAuthDigest(
+			privKey.PubKey().SerializeCompressed(), requestDigest,
+			expiresAtUnix, nonce[:],
+		)
+
+		return schnorr.Sign(privKey, digest[:])
+	}
+}
+
 // TestSwapServerClientsBestEffortReadsFailFast verifies optional read-only
 // calls do not consume their parent wallet RPC's deadline while swapd is
 // unavailable.
@@ -1111,6 +1137,8 @@ func TestSwapServerClientsBestEffortReadsFailFast(t *testing.T) {
 	t.Parallel()
 
 	addr := reserveLoopbackAddr(t)
+	clientPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
 	clients, err := newSwapServerClients(
 		&waved.SwapConfig{
 			ServerTransport: waved.RPCTransportGRPC,
@@ -1118,7 +1146,7 @@ func TestSwapServerClientsBestEffortReadsFailFast(t *testing.T) {
 		},
 		addr, func(context.Context, string) (string, error) {
 			return "auth", nil
-		}, nil,
+		}, testCreditAccountSigner(t, clientPriv), nil,
 	)
 	require.NoError(t, err)
 	defer func() {
@@ -1134,7 +1162,9 @@ func TestSwapServerClientsBestEffortReadsFailFast(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
-	_, err = creditClient.ListCredits(ctx, []byte{1, 2, 3}, 10)
+	_, err = creditClient.ListCredits(
+		ctx, clientPriv.PubKey().SerializeCompressed(), 10,
+	)
 	require.Error(t, err)
 	require.Equal(t, codes.Unavailable, status.Code(err))
 	require.NoError(t, ctx.Err())

--- a/swaprpc/credit_account_auth.go
+++ b/swaprpc/credit_account_auth.go
@@ -1,0 +1,206 @@
+package swaprpc
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// CreditAccountRequestTag domain-separates canonical credit-account
+	// request digests from every other protocol message.
+	//nolint:gosec // Public protocol tag, not a credential.
+	CreditAccountRequestTag = "swap-credit-account-request-v1"
+
+	// CreditAccountAuthTag domain-separates credit-account authorization
+	// signatures from every other use of the wallet identity key.
+	//nolint:gosec // Public protocol tag, not a credential.
+	CreditAccountAuthTag = "swap-credit-account-auth-v1"
+
+	// CreditAccountNonceSize is the required authorization nonce length.
+	CreditAccountNonceSize = 32
+
+	// CreditAccountMaxAuthTTL bounds signed request validity even when a
+	// caller supplies a far-future expiry.
+	CreditAccountMaxAuthTTL = 5 * time.Minute
+)
+
+const (
+	requestChannelIDMethod = "/swaprpc.SwapService/RequestChannelId"
+	createInSwapMethod     = "/swaprpc.SwapService/CreateInSwap"
+	quoteInSwapMethod      = "/swaprpc.SwapService/QuoteInSwap"
+	accountCreateMethod    = "/swaprpc.SwapService/CreateCredit"
+	accountRedeemMethod    = "/swaprpc.SwapService/RedeemCredit"
+	accountListMethod      = "/swaprpc.SwapService/ListCredits"
+)
+
+// CreditAccountRequestDigest returns the canonical digest and account key for
+// an account-scoped swap request. The authorization field is cleared before
+// deterministic protobuf serialization so the signature never commits to
+// itself.
+func CreditAccountRequestDigest(req proto.Message) ([32]byte, []byte, error) {
+	method, accountKey, unsigned, err := unsignedCreditAccountRequest(req)
+	if err != nil {
+		return [32]byte{}, nil, err
+	}
+
+	encoded, err := proto.MarshalOptions{
+		Deterministic: true,
+	}.Marshal(
+		unsigned,
+	)
+	if err != nil {
+		return [32]byte{}, nil, fmt.Errorf("marshal credit account "+
+			"request: %w", err)
+	}
+
+	message := make([]byte, 0, len(method)+1+len(encoded))
+	message = append(message, method...)
+	message = append(message, 0)
+	message = append(message, encoded...)
+	digest := chainhash.TaggedHash([]byte(CreditAccountRequestTag), message)
+
+	return *digest, append([]byte(nil), accountKey...), nil
+}
+
+// CreditAccountAuthMessage returns the canonical message signed by a credit
+// account identity key for one request digest, expiry, and nonce.
+func CreditAccountAuthMessage(accountKey []byte, requestDigest [32]byte,
+	expiresAtUnix int64, nonce []byte) []byte {
+
+	message := make(
+		[]byte, 0, len(accountKey)+len(requestDigest)+8+len(nonce),
+	)
+	message = append(message, accountKey...)
+	message = append(message, requestDigest[:]...)
+	message = binary.BigEndian.AppendUint64(message, uint64(expiresAtUnix))
+	message = append(message, nonce...)
+
+	return message
+}
+
+// CreditAccountAuthDigest returns the BIP-340 tagged digest signed by a credit
+// account identity key.
+func CreditAccountAuthDigest(accountKey []byte, requestDigest [32]byte,
+	expiresAtUnix int64, nonce []byte) [32]byte {
+
+	message := CreditAccountAuthMessage(
+		accountKey, requestDigest, expiresAtUnix, nonce,
+	)
+	digest := chainhash.TaggedHash([]byte(CreditAccountAuthTag), message)
+
+	return *digest
+}
+
+// CreditAccountAuthorizationForRequest extracts an account authorization from
+// one supported request.
+func CreditAccountAuthorizationForRequest(req proto.Message) (
+	*CreditAccountAuthorization, error) {
+
+	switch typed := req.(type) {
+	case *RequestChannelIdRequest:
+		return typed.GetAccountAuthorization(), nil
+
+	case *CreateInSwapRequest:
+		return typed.GetAccountAuthorization(), nil
+
+	case *QuoteInSwapRequest:
+		return typed.GetAccountAuthorization(), nil
+
+	case *CreateCreditRequest:
+		return typed.GetAccountAuthorization(), nil
+
+	case *RedeemCreditRequest:
+		return typed.GetAccountAuthorization(), nil
+
+	case *ListCreditsRequest:
+		return typed.GetAccountAuthorization(), nil
+
+	default:
+		return nil, fmt.Errorf("unsupported credit account request %T",
+			req)
+	}
+}
+
+// SetCreditAccountAuthorization attaches an authorization to one supported
+// request.
+func SetCreditAccountAuthorization(req proto.Message,
+	auth *CreditAccountAuthorization) error {
+
+	switch typed := req.(type) {
+	case *RequestChannelIdRequest:
+		typed.AccountAuthorization = auth
+
+	case *CreateInSwapRequest:
+		typed.AccountAuthorization = auth
+
+	case *QuoteInSwapRequest:
+		typed.AccountAuthorization = auth
+
+	case *CreateCreditRequest:
+		typed.AccountAuthorization = auth
+
+	case *RedeemCreditRequest:
+		typed.AccountAuthorization = auth
+
+	case *ListCreditsRequest:
+		typed.AccountAuthorization = auth
+
+	default:
+		return fmt.Errorf("unsupported credit account request %T", req)
+	}
+
+	return nil
+}
+
+// unsignedCreditAccountRequest clones one supported request, clears its
+// authorization, and returns the method and account identity committed by the
+// signature.
+func unsignedCreditAccountRequest(req proto.Message) (string, []byte,
+	proto.Message, error) {
+
+	var (
+		method     string
+		accountKey []byte
+	)
+	switch typed := req.(type) {
+	case *RequestChannelIdRequest:
+		method = requestChannelIDMethod
+		accountKey = typed.GetClientVhtlcPubkey()
+
+	case *CreateInSwapRequest:
+		method = createInSwapMethod
+		accountKey = typed.GetAccountPubkey()
+
+	case *QuoteInSwapRequest:
+		method = quoteInSwapMethod
+		accountKey = typed.GetAccountPubkey()
+
+	case *CreateCreditRequest:
+		method = accountCreateMethod
+		accountKey = typed.GetAccountPubkey()
+
+	case *RedeemCreditRequest:
+		method = accountRedeemMethod
+		accountKey = typed.GetAccountPubkey()
+
+	case *ListCreditsRequest:
+		method = accountListMethod
+		accountKey = typed.GetAccountPubkey()
+
+	default:
+		return "", nil, nil, fmt.Errorf("unsupported credit account "+
+			"request %T", req)
+	}
+
+	unsigned := proto.Clone(req)
+	if err := SetCreditAccountAuthorization(unsigned, nil); err != nil {
+		return "", nil, nil, fmt.Errorf("clear credit account "+
+			"authorization: %w", err)
+	}
+
+	return method, accountKey, unsigned, nil
+}

--- a/swaprpc/credit_account_auth_test.go
+++ b/swaprpc/credit_account_auth_test.go
@@ -1,0 +1,144 @@
+package swaprpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestCreditAccountRequestDigestCommitsToRequest verifies each supported RPC
+// shape has a stable account binding and that changing its semantics changes
+// the signed digest.
+func TestCreditAccountRequestDigestCommitsToRequest(t *testing.T) {
+	t.Parallel()
+
+	accountKey := []byte{2, 3, 4}
+	tests := []struct {
+		name   string
+		req    proto.Message
+		mutate func(*testing.T, proto.Message)
+	}{
+		{
+			name: "request channel id",
+			req: &RequestChannelIdRequest{
+				ClientVhtlcPubkey: accountKey,
+				PaymentHash: []byte{
+					1,
+				},
+				AmountSat: 2,
+			},
+			mutate: func(t *testing.T, req proto.Message) {
+				typed, ok := req.(*RequestChannelIdRequest)
+				require.True(t, ok)
+				typed.AmountSat++
+			},
+		},
+		{
+			name: "create in swap",
+			req: &CreateInSwapRequest{
+				AccountPubkey: accountKey,
+				Invoice:       "invoice-a",
+			},
+			mutate: func(t *testing.T, req proto.Message) {
+				typed, ok := req.(*CreateInSwapRequest)
+				require.True(t, ok)
+				typed.Invoice = "invoice-b"
+			},
+		},
+		{
+			name: "quote in swap",
+			req: &QuoteInSwapRequest{
+				AccountPubkey: accountKey,
+				MaxCreditSat:  3,
+			},
+			mutate: func(t *testing.T, req proto.Message) {
+				typed, ok := req.(*QuoteInSwapRequest)
+				require.True(t, ok)
+				typed.MaxCreditSat++
+			},
+		},
+		{
+			name: "create credit",
+			req: &CreateCreditRequest{
+				AccountPubkey:  accountKey,
+				IdempotencyKey: "create-a",
+			},
+			mutate: func(t *testing.T, req proto.Message) {
+				typed, ok := req.(*CreateCreditRequest)
+				require.True(t, ok)
+				typed.IdempotencyKey = "create-b"
+			},
+		},
+		{
+			name: "redeem credit",
+			req: &RedeemCreditRequest{
+				AccountPubkey: accountKey,
+				DestinationPubkey: []byte{
+					5,
+				},
+			},
+			mutate: func(t *testing.T, req proto.Message) {
+				typed, ok := req.(*RedeemCreditRequest)
+				require.True(t, ok)
+				typed.DestinationPubkey = []byte{
+					6,
+				}
+			},
+		},
+		{
+			name: "list credits",
+			req: &ListCreditsRequest{
+				AccountPubkey: accountKey,
+				Limit:         10,
+			},
+			mutate: func(t *testing.T, req proto.Message) {
+				typed, ok := req.(*ListCreditsRequest)
+				require.True(t, ok)
+				typed.Limit++
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			originalDigest, gotAccount, err :=
+				CreditAccountRequestDigest(test.req)
+			require.NoError(t, err)
+			require.Equal(t, accountKey, gotAccount)
+
+			withAuth := proto.Clone(test.req)
+			err = SetCreditAccountAuthorization(
+				withAuth, &CreditAccountAuthorization{
+					ExpiresAtUnix: 1,
+					Nonce:         []byte{2},
+					Signature:     []byte{3},
+				},
+			)
+			require.NoError(t, err)
+			authorizedDigest, _, err :=
+				CreditAccountRequestDigest(withAuth)
+			require.NoError(t, err)
+			require.Equal(t, originalDigest, authorizedDigest)
+
+			mutated := proto.Clone(test.req)
+			test.mutate(t, mutated)
+			mutatedDigest, _, err :=
+				CreditAccountRequestDigest(mutated)
+			require.NoError(t, err)
+			require.NotEqual(t, originalDigest, mutatedDigest)
+		})
+	}
+}
+
+// TestCreditAccountRequestDigestRejectsUnknownRequest verifies callers cannot
+// accidentally authorize a request outside the explicit account RPC set.
+func TestCreditAccountRequestDigestRejectsUnknownRequest(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := CreditAccountRequestDigest(&RouteHint{})
+	require.ErrorContains(t, err, "unsupported credit account request")
+}

--- a/swaprpc/swap.pb.go
+++ b/swaprpc/swap.pb.go
@@ -292,8 +292,12 @@ type RequestChannelIdRequest struct {
 	// capability on the receive intent and only routes a credit-attach
 	// receive through the swap-server-funded in-ark leg when it is set.
 	SupportsInArkCredit bool `protobuf:"varint,5,opt,name=supports_in_ark_credit,json=supportsInArkCredit,proto3" json:"supports_in_ark_credit,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// account_authorization proves control of client_vhtlc_pubkey for this
+	// exact request. Swap servers require it before consulting or reserving
+	// account credits.
+	AccountAuthorization *CreditAccountAuthorization `protobuf:"bytes,6,opt,name=account_authorization,json=accountAuthorization,proto3" json:"account_authorization,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *RequestChannelIdRequest) Reset() {
@@ -359,6 +363,13 @@ func (x *RequestChannelIdRequest) GetSupportsInArkCredit() bool {
 		return x.SupportsInArkCredit
 	}
 	return false
+}
+
+func (x *RequestChannelIdRequest) GetAccountAuthorization() *CreditAccountAuthorization {
+	if x != nil {
+		return x.AccountAuthorization
+	}
+	return nil
 }
 
 // RequestChannelIdResponse returns the route hint paths for one receive
@@ -1214,9 +1225,12 @@ type CreateInSwapRequest struct {
 	AccountPubkey []byte `protobuf:"bytes,4,opt,name=account_pubkey,json=accountPubkey,proto3" json:"account_pubkey,omitempty"`
 	// max_credit_sat is the maximum credit amount the caller authorizes this
 	// payment to reserve. Zero means credit use is not allowed.
-	MaxCreditSat  uint64 `protobuf:"varint,5,opt,name=max_credit_sat,json=maxCreditSat,proto3" json:"max_credit_sat,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	MaxCreditSat uint64 `protobuf:"varint,5,opt,name=max_credit_sat,json=maxCreditSat,proto3" json:"max_credit_sat,omitempty"`
+	// account_authorization proves control of account_pubkey for this exact
+	// request whenever account_pubkey is set.
+	AccountAuthorization *CreditAccountAuthorization `protobuf:"bytes,6,opt,name=account_authorization,json=accountAuthorization,proto3" json:"account_authorization,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *CreateInSwapRequest) Reset() {
@@ -1282,6 +1296,13 @@ func (x *CreateInSwapRequest) GetMaxCreditSat() uint64 {
 		return x.MaxCreditSat
 	}
 	return 0
+}
+
+func (x *CreateInSwapRequest) GetAccountAuthorization() *CreditAccountAuthorization {
+	if x != nil {
+		return x.AccountAuthorization
+	}
+	return nil
 }
 
 // CreateInSwapResponse returns the negotiated parameters for one in-swap.
@@ -1418,9 +1439,12 @@ type QuoteInSwapRequest struct {
 	// max_credit_sat is the maximum credit amount the caller is willing to
 	// use. Zero means the quote reports whether credits are required but does
 	// not apply optional credits.
-	MaxCreditSat  uint64 `protobuf:"varint,4,opt,name=max_credit_sat,json=maxCreditSat,proto3" json:"max_credit_sat,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	MaxCreditSat uint64 `protobuf:"varint,4,opt,name=max_credit_sat,json=maxCreditSat,proto3" json:"max_credit_sat,omitempty"`
+	// account_authorization proves control of account_pubkey for this exact
+	// request whenever account_pubkey is set.
+	AccountAuthorization *CreditAccountAuthorization `protobuf:"bytes,5,opt,name=account_authorization,json=accountAuthorization,proto3" json:"account_authorization,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *QuoteInSwapRequest) Reset() {
@@ -1479,6 +1503,13 @@ func (x *QuoteInSwapRequest) GetMaxCreditSat() uint64 {
 		return x.MaxCreditSat
 	}
 	return 0
+}
+
+func (x *QuoteInSwapRequest) GetAccountAuthorization() *CreditAccountAuthorization {
+	if x != nil {
+		return x.AccountAuthorization
+	}
+	return nil
 }
 
 // QuoteInSwapResponse returns the non-binding preview for one invoice send.
@@ -1679,6 +1710,71 @@ func (x *CreditQuote) GetArkFundingSat() uint64 {
 	return 0
 }
 
+// CreditAccountAuthorization proves control of the credit account identity
+// key for one exact request. The server rejects expired and reused nonces.
+type CreditAccountAuthorization struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// expires_at_unix is the unix timestamp after which the proof is invalid.
+	ExpiresAtUnix int64 `protobuf:"varint,1,opt,name=expires_at_unix,json=expiresAtUnix,proto3" json:"expires_at_unix,omitempty"`
+	// nonce is a caller-generated 32-byte unique value.
+	Nonce []byte `protobuf:"bytes,2,opt,name=nonce,proto3" json:"nonce,omitempty"`
+	// signature is a 64-byte BIP-340 Schnorr signature by the account key.
+	Signature     []byte `protobuf:"bytes,3,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreditAccountAuthorization) Reset() {
+	*x = CreditAccountAuthorization{}
+	mi := &file_swap_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreditAccountAuthorization) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreditAccountAuthorization) ProtoMessage() {}
+
+func (x *CreditAccountAuthorization) ProtoReflect() protoreflect.Message {
+	mi := &file_swap_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreditAccountAuthorization.ProtoReflect.Descriptor instead.
+func (*CreditAccountAuthorization) Descriptor() ([]byte, []int) {
+	return file_swap_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *CreditAccountAuthorization) GetExpiresAtUnix() int64 {
+	if x != nil {
+		return x.ExpiresAtUnix
+	}
+	return 0
+}
+
+func (x *CreditAccountAuthorization) GetNonce() []byte {
+	if x != nil {
+		return x.Nonce
+	}
+	return nil
+}
+
+func (x *CreditAccountAuthorization) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
 type CreateCreditRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// account_pubkey identifies the wallet credit account.
@@ -1690,14 +1786,17 @@ type CreateCreditRequest struct {
 	AmountSat uint64 `protobuf:"varint,4,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
 	// memo is embedded into server-owned Lightning receive invoices when the
 	// source is LIGHTNING_RECEIVE.
-	Memo          string `protobuf:"bytes,5,opt,name=memo,proto3" json:"memo,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Memo string `protobuf:"bytes,5,opt,name=memo,proto3" json:"memo,omitempty"`
+	// account_authorization proves control of account_pubkey for this exact
+	// request.
+	AccountAuthorization *CreditAccountAuthorization `protobuf:"bytes,6,opt,name=account_authorization,json=accountAuthorization,proto3" json:"account_authorization,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *CreateCreditRequest) Reset() {
 	*x = CreateCreditRequest{}
-	mi := &file_swap_proto_msgTypes[16]
+	mi := &file_swap_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1709,7 +1808,7 @@ func (x *CreateCreditRequest) String() string {
 func (*CreateCreditRequest) ProtoMessage() {}
 
 func (x *CreateCreditRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[16]
+	mi := &file_swap_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1722,7 +1821,7 @@ func (x *CreateCreditRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCreditRequest.ProtoReflect.Descriptor instead.
 func (*CreateCreditRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{16}
+	return file_swap_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *CreateCreditRequest) GetAccountPubkey() []byte {
@@ -1760,6 +1859,13 @@ func (x *CreateCreditRequest) GetMemo() string {
 	return ""
 }
 
+func (x *CreateCreditRequest) GetAccountAuthorization() *CreditAccountAuthorization {
+	if x != nil {
+		return x.AccountAuthorization
+	}
+	return nil
+}
+
 type CreateCreditResponse struct {
 	state       protoimpl.MessageState `protogen:"open.v1"`
 	OperationId string                 `protobuf:"bytes,1,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"`
@@ -1780,7 +1886,7 @@ type CreateCreditResponse struct {
 
 func (x *CreateCreditResponse) Reset() {
 	*x = CreateCreditResponse{}
-	mi := &file_swap_proto_msgTypes[17]
+	mi := &file_swap_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1792,7 +1898,7 @@ func (x *CreateCreditResponse) String() string {
 func (*CreateCreditResponse) ProtoMessage() {}
 
 func (x *CreateCreditResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[17]
+	mi := &file_swap_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1805,7 +1911,7 @@ func (x *CreateCreditResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateCreditResponse.ProtoReflect.Descriptor instead.
 func (*CreateCreditResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{17}
+	return file_swap_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *CreateCreditResponse) GetOperationId() string {
@@ -1863,13 +1969,16 @@ type RedeemCreditRequest struct {
 	IdempotencyKey    string                 `protobuf:"bytes,2,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
 	AmountSat         uint64                 `protobuf:"varint,3,opt,name=amount_sat,json=amountSat,proto3" json:"amount_sat,omitempty"`
 	DestinationPubkey []byte                 `protobuf:"bytes,4,opt,name=destination_pubkey,json=destinationPubkey,proto3" json:"destination_pubkey,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// account_authorization proves control of account_pubkey for this exact
+	// request.
+	AccountAuthorization *CreditAccountAuthorization `protobuf:"bytes,5,opt,name=account_authorization,json=accountAuthorization,proto3" json:"account_authorization,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *RedeemCreditRequest) Reset() {
 	*x = RedeemCreditRequest{}
-	mi := &file_swap_proto_msgTypes[18]
+	mi := &file_swap_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1881,7 +1990,7 @@ func (x *RedeemCreditRequest) String() string {
 func (*RedeemCreditRequest) ProtoMessage() {}
 
 func (x *RedeemCreditRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[18]
+	mi := &file_swap_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1894,7 +2003,7 @@ func (x *RedeemCreditRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RedeemCreditRequest.ProtoReflect.Descriptor instead.
 func (*RedeemCreditRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{18}
+	return file_swap_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *RedeemCreditRequest) GetAccountPubkey() []byte {
@@ -1925,6 +2034,13 @@ func (x *RedeemCreditRequest) GetDestinationPubkey() []byte {
 	return nil
 }
 
+func (x *RedeemCreditRequest) GetAccountAuthorization() *CreditAccountAuthorization {
+	if x != nil {
+		return x.AccountAuthorization
+	}
+	return nil
+}
+
 type RedeemCreditResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	OperationId   string                 `protobuf:"bytes,1,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"`
@@ -1938,7 +2054,7 @@ type RedeemCreditResponse struct {
 
 func (x *RedeemCreditResponse) Reset() {
 	*x = RedeemCreditResponse{}
-	mi := &file_swap_proto_msgTypes[19]
+	mi := &file_swap_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1950,7 +2066,7 @@ func (x *RedeemCreditResponse) String() string {
 func (*RedeemCreditResponse) ProtoMessage() {}
 
 func (x *RedeemCreditResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[19]
+	mi := &file_swap_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1963,7 +2079,7 @@ func (x *RedeemCreditResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RedeemCreditResponse.ProtoReflect.Descriptor instead.
 func (*RedeemCreditResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{19}
+	return file_swap_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *RedeemCreditResponse) GetOperationId() string {
@@ -2005,13 +2121,16 @@ type ListCreditsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	AccountPubkey []byte                 `protobuf:"bytes,1,opt,name=account_pubkey,json=accountPubkey,proto3" json:"account_pubkey,omitempty"`
 	Limit         uint32                 `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// account_authorization proves control of account_pubkey for this exact
+	// request.
+	AccountAuthorization *CreditAccountAuthorization `protobuf:"bytes,3,opt,name=account_authorization,json=accountAuthorization,proto3" json:"account_authorization,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ListCreditsRequest) Reset() {
 	*x = ListCreditsRequest{}
-	mi := &file_swap_proto_msgTypes[20]
+	mi := &file_swap_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2023,7 +2142,7 @@ func (x *ListCreditsRequest) String() string {
 func (*ListCreditsRequest) ProtoMessage() {}
 
 func (x *ListCreditsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[20]
+	mi := &file_swap_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2036,7 +2155,7 @@ func (x *ListCreditsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCreditsRequest.ProtoReflect.Descriptor instead.
 func (*ListCreditsRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{20}
+	return file_swap_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ListCreditsRequest) GetAccountPubkey() []byte {
@@ -2053,6 +2172,13 @@ func (x *ListCreditsRequest) GetLimit() uint32 {
 	return 0
 }
 
+func (x *ListCreditsRequest) GetAccountAuthorization() *CreditAccountAuthorization {
+	if x != nil {
+		return x.AccountAuthorization
+	}
+	return nil
+}
+
 type ListCreditsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	FinalizedSat  uint64                 `protobuf:"varint,1,opt,name=finalized_sat,json=finalizedSat,proto3" json:"finalized_sat,omitempty"`
@@ -2066,7 +2192,7 @@ type ListCreditsResponse struct {
 
 func (x *ListCreditsResponse) Reset() {
 	*x = ListCreditsResponse{}
-	mi := &file_swap_proto_msgTypes[21]
+	mi := &file_swap_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2078,7 +2204,7 @@ func (x *ListCreditsResponse) String() string {
 func (*ListCreditsResponse) ProtoMessage() {}
 
 func (x *ListCreditsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[21]
+	mi := &file_swap_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2091,7 +2217,7 @@ func (x *ListCreditsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCreditsResponse.ProtoReflect.Descriptor instead.
 func (*ListCreditsResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{21}
+	return file_swap_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ListCreditsResponse) GetFinalizedSat() uint64 {
@@ -2149,7 +2275,7 @@ type CreditOperation struct {
 
 func (x *CreditOperation) Reset() {
 	*x = CreditOperation{}
-	mi := &file_swap_proto_msgTypes[22]
+	mi := &file_swap_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2161,7 +2287,7 @@ func (x *CreditOperation) String() string {
 func (*CreditOperation) ProtoMessage() {}
 
 func (x *CreditOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[22]
+	mi := &file_swap_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2174,7 +2300,7 @@ func (x *CreditOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreditOperation.ProtoReflect.Descriptor instead.
 func (*CreditOperation) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{22}
+	return file_swap_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CreditOperation) GetOperationId() string {
@@ -2274,7 +2400,7 @@ type CreditLedgerEntry struct {
 
 func (x *CreditLedgerEntry) Reset() {
 	*x = CreditLedgerEntry{}
-	mi := &file_swap_proto_msgTypes[23]
+	mi := &file_swap_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2286,7 +2412,7 @@ func (x *CreditLedgerEntry) String() string {
 func (*CreditLedgerEntry) ProtoMessage() {}
 
 func (x *CreditLedgerEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[23]
+	mi := &file_swap_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2299,7 +2425,7 @@ func (x *CreditLedgerEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreditLedgerEntry.ProtoReflect.Descriptor instead.
 func (*CreditLedgerEntry) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{23}
+	return file_swap_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *CreditLedgerEntry) GetEntryId() string {
@@ -2357,7 +2483,7 @@ type AuthorizeInSwapRefundRequest struct {
 
 func (x *AuthorizeInSwapRefundRequest) Reset() {
 	*x = AuthorizeInSwapRefundRequest{}
-	mi := &file_swap_proto_msgTypes[24]
+	mi := &file_swap_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2369,7 +2495,7 @@ func (x *AuthorizeInSwapRefundRequest) String() string {
 func (*AuthorizeInSwapRefundRequest) ProtoMessage() {}
 
 func (x *AuthorizeInSwapRefundRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[24]
+	mi := &file_swap_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2382,7 +2508,7 @@ func (x *AuthorizeInSwapRefundRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthorizeInSwapRefundRequest.ProtoReflect.Descriptor instead.
 func (*AuthorizeInSwapRefundRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{24}
+	return file_swap_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *AuthorizeInSwapRefundRequest) GetPaymentHash() []byte {
@@ -2440,7 +2566,7 @@ type AuthorizeInSwapRefundResponse struct {
 
 func (x *AuthorizeInSwapRefundResponse) Reset() {
 	*x = AuthorizeInSwapRefundResponse{}
-	mi := &file_swap_proto_msgTypes[25]
+	mi := &file_swap_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2452,7 +2578,7 @@ func (x *AuthorizeInSwapRefundResponse) String() string {
 func (*AuthorizeInSwapRefundResponse) ProtoMessage() {}
 
 func (x *AuthorizeInSwapRefundResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[25]
+	mi := &file_swap_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2465,7 +2591,7 @@ func (x *AuthorizeInSwapRefundResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthorizeInSwapRefundResponse.ProtoReflect.Descriptor instead.
 func (*AuthorizeInSwapRefundResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{25}
+	return file_swap_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *AuthorizeInSwapRefundResponse) GetSignature() *TaprootScriptSignature {
@@ -2516,7 +2642,7 @@ type ForfeitSignaturePayload struct {
 
 func (x *ForfeitSignaturePayload) Reset() {
 	*x = ForfeitSignaturePayload{}
-	mi := &file_swap_proto_msgTypes[26]
+	mi := &file_swap_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2528,7 +2654,7 @@ func (x *ForfeitSignaturePayload) String() string {
 func (*ForfeitSignaturePayload) ProtoMessage() {}
 
 func (x *ForfeitSignaturePayload) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[26]
+	mi := &file_swap_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2541,7 +2667,7 @@ func (x *ForfeitSignaturePayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForfeitSignaturePayload.ProtoReflect.Descriptor instead.
 func (*ForfeitSignaturePayload) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{26}
+	return file_swap_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ForfeitSignaturePayload) GetRequestId() []byte {
@@ -2642,7 +2768,7 @@ type ForfeitParticipantSignature struct {
 
 func (x *ForfeitParticipantSignature) Reset() {
 	*x = ForfeitParticipantSignature{}
-	mi := &file_swap_proto_msgTypes[27]
+	mi := &file_swap_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2654,7 +2780,7 @@ func (x *ForfeitParticipantSignature) String() string {
 func (*ForfeitParticipantSignature) ProtoMessage() {}
 
 func (x *ForfeitParticipantSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[27]
+	mi := &file_swap_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2667,7 +2793,7 @@ func (x *ForfeitParticipantSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ForfeitParticipantSignature.ProtoReflect.Descriptor instead.
 func (*ForfeitParticipantSignature) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{27}
+	return file_swap_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ForfeitParticipantSignature) GetPubkey() []byte {
@@ -2694,7 +2820,7 @@ type SignInSwapForfeitRequest struct {
 
 func (x *SignInSwapForfeitRequest) Reset() {
 	*x = SignInSwapForfeitRequest{}
-	mi := &file_swap_proto_msgTypes[28]
+	mi := &file_swap_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2706,7 +2832,7 @@ func (x *SignInSwapForfeitRequest) String() string {
 func (*SignInSwapForfeitRequest) ProtoMessage() {}
 
 func (x *SignInSwapForfeitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[28]
+	mi := &file_swap_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2719,7 +2845,7 @@ func (x *SignInSwapForfeitRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignInSwapForfeitRequest.ProtoReflect.Descriptor instead.
 func (*SignInSwapForfeitRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{28}
+	return file_swap_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *SignInSwapForfeitRequest) GetPayload() *ForfeitSignaturePayload {
@@ -2739,7 +2865,7 @@ type SignInSwapForfeitResponse struct {
 
 func (x *SignInSwapForfeitResponse) Reset() {
 	*x = SignInSwapForfeitResponse{}
-	mi := &file_swap_proto_msgTypes[29]
+	mi := &file_swap_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2751,7 +2877,7 @@ func (x *SignInSwapForfeitResponse) String() string {
 func (*SignInSwapForfeitResponse) ProtoMessage() {}
 
 func (x *SignInSwapForfeitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[29]
+	mi := &file_swap_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2764,7 +2890,7 @@ func (x *SignInSwapForfeitResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignInSwapForfeitResponse.ProtoReflect.Descriptor instead.
 func (*SignInSwapForfeitResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{29}
+	return file_swap_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *SignInSwapForfeitResponse) GetSignature() *ForfeitParticipantSignature {
@@ -2784,7 +2910,7 @@ type OutSwapForfeitSignatureRequest struct {
 
 func (x *OutSwapForfeitSignatureRequest) Reset() {
 	*x = OutSwapForfeitSignatureRequest{}
-	mi := &file_swap_proto_msgTypes[30]
+	mi := &file_swap_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2796,7 +2922,7 @@ func (x *OutSwapForfeitSignatureRequest) String() string {
 func (*OutSwapForfeitSignatureRequest) ProtoMessage() {}
 
 func (x *OutSwapForfeitSignatureRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[30]
+	mi := &file_swap_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2809,7 +2935,7 @@ func (x *OutSwapForfeitSignatureRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OutSwapForfeitSignatureRequest.ProtoReflect.Descriptor instead.
 func (*OutSwapForfeitSignatureRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{30}
+	return file_swap_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *OutSwapForfeitSignatureRequest) GetPayload() *ForfeitSignaturePayload {
@@ -2832,7 +2958,7 @@ type SubmitOutSwapForfeitSignatureRequest struct {
 
 func (x *SubmitOutSwapForfeitSignatureRequest) Reset() {
 	*x = SubmitOutSwapForfeitSignatureRequest{}
-	mi := &file_swap_proto_msgTypes[31]
+	mi := &file_swap_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2844,7 +2970,7 @@ func (x *SubmitOutSwapForfeitSignatureRequest) String() string {
 func (*SubmitOutSwapForfeitSignatureRequest) ProtoMessage() {}
 
 func (x *SubmitOutSwapForfeitSignatureRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[31]
+	mi := &file_swap_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2857,7 +2983,7 @@ func (x *SubmitOutSwapForfeitSignatureRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use SubmitOutSwapForfeitSignatureRequest.ProtoReflect.Descriptor instead.
 func (*SubmitOutSwapForfeitSignatureRequest) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{31}
+	return file_swap_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *SubmitOutSwapForfeitSignatureRequest) GetPayload() *ForfeitSignaturePayload {
@@ -2882,7 +3008,7 @@ type SubmitOutSwapForfeitSignatureResponse struct {
 
 func (x *SubmitOutSwapForfeitSignatureResponse) Reset() {
 	*x = SubmitOutSwapForfeitSignatureResponse{}
-	mi := &file_swap_proto_msgTypes[32]
+	mi := &file_swap_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2894,7 +3020,7 @@ func (x *SubmitOutSwapForfeitSignatureResponse) String() string {
 func (*SubmitOutSwapForfeitSignatureResponse) ProtoMessage() {}
 
 func (x *SubmitOutSwapForfeitSignatureResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[32]
+	mi := &file_swap_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2907,7 +3033,7 @@ func (x *SubmitOutSwapForfeitSignatureResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use SubmitOutSwapForfeitSignatureResponse.ProtoReflect.Descriptor instead.
 func (*SubmitOutSwapForfeitSignatureResponse) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{32}
+	return file_swap_proto_rawDescGZIP(), []int{33}
 }
 
 // TaprootScriptSignature carries one externally produced tapscript signature.
@@ -2929,7 +3055,7 @@ type TaprootScriptSignature struct {
 
 func (x *TaprootScriptSignature) Reset() {
 	*x = TaprootScriptSignature{}
-	mi := &file_swap_proto_msgTypes[33]
+	mi := &file_swap_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2941,7 +3067,7 @@ func (x *TaprootScriptSignature) String() string {
 func (*TaprootScriptSignature) ProtoMessage() {}
 
 func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
-	mi := &file_swap_proto_msgTypes[33]
+	mi := &file_swap_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2954,7 +3080,7 @@ func (x *TaprootScriptSignature) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaprootScriptSignature.ProtoReflect.Descriptor instead.
 func (*TaprootScriptSignature) Descriptor() ([]byte, []int) {
-	return file_swap_proto_rawDescGZIP(), []int{33}
+	return file_swap_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *TaprootScriptSignature) GetPubkey() []byte {
@@ -2990,14 +3116,15 @@ var File_swap_proto protoreflect.FileDescriptor
 const file_swap_proto_rawDesc = "" +
 	"\n" +
 	"\n" +
-	"swap.proto\x12\aswaprpc\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe7\x01\n" +
+	"swap.proto\x12\aswaprpc\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc1\x02\n" +
 	"\x17RequestChannelIdRequest\x12%\n" +
 	"\x0eexpiry_seconds\x18\x01 \x01(\rR\rexpirySeconds\x12.\n" +
 	"\x13client_vhtlc_pubkey\x18\x02 \x01(\fR\x11clientVhtlcPubkey\x12!\n" +
 	"\fpayment_hash\x18\x03 \x01(\fR\vpaymentHash\x12\x1d\n" +
 	"\n" +
 	"amount_sat\x18\x04 \x01(\x04R\tamountSat\x123\n" +
-	"\x16supports_in_ark_credit\x18\x05 \x01(\bR\x13supportsInArkCredit\"\xbf\x03\n" +
+	"\x16supports_in_ark_credit\x18\x05 \x01(\bR\x13supportsInArkCredit\x12X\n" +
+	"\x15account_authorization\x18\x06 \x01(\v2#.swaprpc.CreditAccountAuthorizationR\x14accountAuthorization\"\xbf\x03\n" +
 	"\x18RequestChannelIdResponse\x12$\n" +
 	"\x0epayer_fee_msat\x18\x02 \x01(\x04R\fpayerFeeMsat\x120\n" +
 	"\x14requested_amount_sat\x18\x03 \x01(\x04R\x12requestedAmountSat\x120\n" +
@@ -3056,13 +3183,14 @@ const file_swap_proto_rawDesc = "" +
 	"\x16unilateral_claim_delay\x18\x02 \x01(\rR\x14unilateralClaimDelay\x126\n" +
 	"\x17unilateral_refund_delay\x18\x03 \x01(\rR\x15unilateralRefundDelay\x12V\n" +
 	"(unilateral_refund_without_receiver_delay\x18\x04 \x01(\rR$unilateralRefundWithoutReceiverDelay\x12+\n" +
-	"\x11swapserver_pubkey\x18\x05 \x01(\fR\x10swapserverPubkey\"\xcc\x01\n" +
+	"\x11swapserver_pubkey\x18\x05 \x01(\fR\x10swapserverPubkey\"\xa6\x02\n" +
 	"\x13CreateInSwapRequest\x12\x18\n" +
 	"\ainvoice\x18\x01 \x01(\tR\ainvoice\x12\x1e\n" +
 	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\x12.\n" +
 	"\x13client_vhtlc_pubkey\x18\x03 \x01(\fR\x11clientVhtlcPubkey\x12%\n" +
 	"\x0eaccount_pubkey\x18\x04 \x01(\fR\raccountPubkey\x12$\n" +
-	"\x0emax_credit_sat\x18\x05 \x01(\x04R\fmaxCreditSat\"\x9a\x03\n" +
+	"\x0emax_credit_sat\x18\x05 \x01(\x04R\fmaxCreditSat\x12X\n" +
+	"\x15account_authorization\x18\x06 \x01(\v2#.swaprpc.CreditAccountAuthorizationR\x14accountAuthorization\"\x9a\x03\n" +
 	"\x14CreateInSwapResponse\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12\x1d\n" +
 	"\n" +
@@ -3073,12 +3201,13 @@ const file_swap_proto_rawDesc = "" +
 	"\x06expiry\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x06expiry\x12@\n" +
 	"\x0fsettlement_type\x18\a \x01(\x0e2\x17.swaprpc.SettlementTypeR\x0esettlementType\x127\n" +
 	"\fcredit_quote\x18\b \x01(\v2\x14.swaprpc.CreditQuoteR\vcreditQuote\x12\x1a\n" +
-	"\bpreimage\x18\t \x01(\fR\bpreimage\"\x9b\x01\n" +
+	"\bpreimage\x18\t \x01(\fR\bpreimage\"\xf5\x01\n" +
 	"\x12QuoteInSwapRequest\x12\x18\n" +
 	"\ainvoice\x18\x01 \x01(\tR\ainvoice\x12\x1e\n" +
 	"\vmax_fee_sat\x18\x02 \x01(\x04R\tmaxFeeSat\x12%\n" +
 	"\x0eaccount_pubkey\x18\x03 \x01(\fR\raccountPubkey\x12$\n" +
-	"\x0emax_credit_sat\x18\x04 \x01(\x04R\fmaxCreditSat\"\xf5\x02\n" +
+	"\x0emax_credit_sat\x18\x04 \x01(\x04R\fmaxCreditSat\x12X\n" +
+	"\x15account_authorization\x18\x05 \x01(\v2#.swaprpc.CreditAccountAuthorizationR\x14accountAuthorization\"\xf5\x02\n" +
 	"\x13QuoteInSwapResponse\x12!\n" +
 	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\x12,\n" +
 	"\x12invoice_amount_sat\x18\x02 \x01(\x04R\x10invoiceAmountSat\x12\x1d\n" +
@@ -3094,14 +3223,19 @@ const file_swap_proto_rawDesc = "" +
 	"\x12credit_applied_sat\x18\x02 \x01(\x04R\x10creditAppliedSat\x120\n" +
 	"\x14credit_shortfall_sat\x18\x03 \x01(\x04R\x12creditShortfallSat\x12(\n" +
 	"\x10credit_topup_sat\x18\x04 \x01(\x04R\x0ecreditTopupSat\x12&\n" +
-	"\x0fark_funding_sat\x18\x05 \x01(\x04R\rarkFundingSat\"\xce\x01\n" +
+	"\x0fark_funding_sat\x18\x05 \x01(\x04R\rarkFundingSat\"x\n" +
+	"\x1aCreditAccountAuthorization\x12&\n" +
+	"\x0fexpires_at_unix\x18\x01 \x01(\x03R\rexpiresAtUnix\x12\x14\n" +
+	"\x05nonce\x18\x02 \x01(\fR\x05nonce\x12\x1c\n" +
+	"\tsignature\x18\x03 \x01(\fR\tsignature\"\xa8\x02\n" +
 	"\x13CreateCreditRequest\x12%\n" +
 	"\x0eaccount_pubkey\x18\x01 \x01(\fR\raccountPubkey\x12'\n" +
 	"\x0fidempotency_key\x18\x02 \x01(\tR\x0eidempotencyKey\x124\n" +
 	"\x06source\x18\x03 \x01(\x0e2\x1c.swaprpc.CreditFundingSourceR\x06source\x12\x1d\n" +
 	"\n" +
 	"amount_sat\x18\x04 \x01(\x04R\tamountSat\x12\x12\n" +
-	"\x04memo\x18\x05 \x01(\tR\x04memo\"\xb4\x02\n" +
+	"\x04memo\x18\x05 \x01(\tR\x04memo\x12X\n" +
+	"\x15account_authorization\x18\x06 \x01(\v2#.swaprpc.CreditAccountAuthorizationR\x14accountAuthorization\"\xb4\x02\n" +
 	"\x14CreateCreditResponse\x12!\n" +
 	"\foperation_id\x18\x01 \x01(\tR\voperationId\x123\n" +
 	"\x05state\x18\x02 \x01(\x0e2\x1d.swaprpc.CreditOperationStateR\x05state\x12\x18\n" +
@@ -3111,13 +3245,14 @@ const file_swap_proto_rawDesc = "" +
 	"amount_sat\x18\x05 \x01(\x04R\tamountSat\x12-\n" +
 	"\x12destination_pubkey\x18\a \x01(\fR\x11destinationPubkey\x129\n" +
 	"\n" +
-	"expires_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\"\xb3\x01\n" +
+	"expires_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\"\x8d\x02\n" +
 	"\x13RedeemCreditRequest\x12%\n" +
 	"\x0eaccount_pubkey\x18\x01 \x01(\fR\raccountPubkey\x12'\n" +
 	"\x0fidempotency_key\x18\x02 \x01(\tR\x0eidempotencyKey\x12\x1d\n" +
 	"\n" +
 	"amount_sat\x18\x03 \x01(\x04R\tamountSat\x12-\n" +
-	"\x12destination_pubkey\x18\x04 \x01(\fR\x11destinationPubkey\"\xd1\x01\n" +
+	"\x12destination_pubkey\x18\x04 \x01(\fR\x11destinationPubkey\x12X\n" +
+	"\x15account_authorization\x18\x05 \x01(\v2#.swaprpc.CreditAccountAuthorizationR\x14accountAuthorization\"\xd1\x01\n" +
 	"\x14RedeemCreditResponse\x12!\n" +
 	"\foperation_id\x18\x01 \x01(\tR\voperationId\x123\n" +
 	"\x05state\x18\x02 \x01(\x0e2\x1d.swaprpc.CreditOperationStateR\x05state\x12\x1f\n" +
@@ -3125,10 +3260,11 @@ const file_swap_proto_rawDesc = "" +
 	"debitedSat\x12!\n" +
 	"\fredeemed_sat\x18\x04 \x01(\x04R\vredeemedSat\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x05 \x01(\tR\tsessionId\"Q\n" +
+	"session_id\x18\x05 \x01(\tR\tsessionId\"\xab\x01\n" +
 	"\x12ListCreditsRequest\x12%\n" +
 	"\x0eaccount_pubkey\x18\x01 \x01(\fR\raccountPubkey\x12\x14\n" +
-	"\x05limit\x18\x02 \x01(\rR\x05limit\"\xff\x01\n" +
+	"\x05limit\x18\x02 \x01(\rR\x05limit\x12X\n" +
+	"\x15account_authorization\x18\x03 \x01(\v2#.swaprpc.CreditAccountAuthorizationR\x14accountAuthorization\"\xff\x01\n" +
 	"\x13ListCreditsResponse\x12#\n" +
 	"\rfinalized_sat\x18\x01 \x01(\x04R\ffinalizedSat\x12!\n" +
 	"\freserved_sat\x18\x02 \x01(\x04R\vreservedSat\x12#\n" +
@@ -3262,7 +3398,7 @@ func file_swap_proto_rawDescGZIP() []byte {
 }
 
 var file_swap_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_swap_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
 var file_swap_proto_goTypes = []any{
 	(SettlementType)(0),                           // 0: swaprpc.SettlementType
 	(CreditFundingSource)(0),                      // 1: swaprpc.CreditFundingSource
@@ -3284,86 +3420,93 @@ var file_swap_proto_goTypes = []any{
 	(*QuoteInSwapRequest)(nil),                    // 17: swaprpc.QuoteInSwapRequest
 	(*QuoteInSwapResponse)(nil),                   // 18: swaprpc.QuoteInSwapResponse
 	(*CreditQuote)(nil),                           // 19: swaprpc.CreditQuote
-	(*CreateCreditRequest)(nil),                   // 20: swaprpc.CreateCreditRequest
-	(*CreateCreditResponse)(nil),                  // 21: swaprpc.CreateCreditResponse
-	(*RedeemCreditRequest)(nil),                   // 22: swaprpc.RedeemCreditRequest
-	(*RedeemCreditResponse)(nil),                  // 23: swaprpc.RedeemCreditResponse
-	(*ListCreditsRequest)(nil),                    // 24: swaprpc.ListCreditsRequest
-	(*ListCreditsResponse)(nil),                   // 25: swaprpc.ListCreditsResponse
-	(*CreditOperation)(nil),                       // 26: swaprpc.CreditOperation
-	(*CreditLedgerEntry)(nil),                     // 27: swaprpc.CreditLedgerEntry
-	(*AuthorizeInSwapRefundRequest)(nil),          // 28: swaprpc.AuthorizeInSwapRefundRequest
-	(*AuthorizeInSwapRefundResponse)(nil),         // 29: swaprpc.AuthorizeInSwapRefundResponse
-	(*ForfeitSignaturePayload)(nil),               // 30: swaprpc.ForfeitSignaturePayload
-	(*ForfeitParticipantSignature)(nil),           // 31: swaprpc.ForfeitParticipantSignature
-	(*SignInSwapForfeitRequest)(nil),              // 32: swaprpc.SignInSwapForfeitRequest
-	(*SignInSwapForfeitResponse)(nil),             // 33: swaprpc.SignInSwapForfeitResponse
-	(*OutSwapForfeitSignatureRequest)(nil),        // 34: swaprpc.OutSwapForfeitSignatureRequest
-	(*SubmitOutSwapForfeitSignatureRequest)(nil),  // 35: swaprpc.SubmitOutSwapForfeitSignatureRequest
-	(*SubmitOutSwapForfeitSignatureResponse)(nil), // 36: swaprpc.SubmitOutSwapForfeitSignatureResponse
-	(*TaprootScriptSignature)(nil),                // 37: swaprpc.TaprootScriptSignature
-	(*timestamppb.Timestamp)(nil),                 // 38: google.protobuf.Timestamp
+	(*CreditAccountAuthorization)(nil),            // 20: swaprpc.CreditAccountAuthorization
+	(*CreateCreditRequest)(nil),                   // 21: swaprpc.CreateCreditRequest
+	(*CreateCreditResponse)(nil),                  // 22: swaprpc.CreateCreditResponse
+	(*RedeemCreditRequest)(nil),                   // 23: swaprpc.RedeemCreditRequest
+	(*RedeemCreditResponse)(nil),                  // 24: swaprpc.RedeemCreditResponse
+	(*ListCreditsRequest)(nil),                    // 25: swaprpc.ListCreditsRequest
+	(*ListCreditsResponse)(nil),                   // 26: swaprpc.ListCreditsResponse
+	(*CreditOperation)(nil),                       // 27: swaprpc.CreditOperation
+	(*CreditLedgerEntry)(nil),                     // 28: swaprpc.CreditLedgerEntry
+	(*AuthorizeInSwapRefundRequest)(nil),          // 29: swaprpc.AuthorizeInSwapRefundRequest
+	(*AuthorizeInSwapRefundResponse)(nil),         // 30: swaprpc.AuthorizeInSwapRefundResponse
+	(*ForfeitSignaturePayload)(nil),               // 31: swaprpc.ForfeitSignaturePayload
+	(*ForfeitParticipantSignature)(nil),           // 32: swaprpc.ForfeitParticipantSignature
+	(*SignInSwapForfeitRequest)(nil),              // 33: swaprpc.SignInSwapForfeitRequest
+	(*SignInSwapForfeitResponse)(nil),             // 34: swaprpc.SignInSwapForfeitResponse
+	(*OutSwapForfeitSignatureRequest)(nil),        // 35: swaprpc.OutSwapForfeitSignatureRequest
+	(*SubmitOutSwapForfeitSignatureRequest)(nil),  // 36: swaprpc.SubmitOutSwapForfeitSignatureRequest
+	(*SubmitOutSwapForfeitSignatureResponse)(nil), // 37: swaprpc.SubmitOutSwapForfeitSignatureResponse
+	(*TaprootScriptSignature)(nil),                // 38: swaprpc.TaprootScriptSignature
+	(*timestamppb.Timestamp)(nil),                 // 39: google.protobuf.Timestamp
 }
 var file_swap_proto_depIdxs = []int32{
-	0,  // 0: swaprpc.RequestChannelIdResponse.settlement_type:type_name -> swaprpc.SettlementType
-	13, // 1: swaprpc.RequestChannelIdResponse.route_hint_paths:type_name -> swaprpc.RouteHintPath
-	14, // 2: swaprpc.OutSwapHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	9,  // 3: swaprpc.OutSwapHtlcEvent.parts:type_name -> swaprpc.OutSwapHtlcPart
-	8,  // 4: swaprpc.SwapMailboxEvent.out_swap_htlc:type_name -> swaprpc.OutSwapHtlcEvent
-	11, // 5: swaprpc.SwapMailboxEvent.in_ark_htlc:type_name -> swaprpc.InArkHtlcEvent
-	34, // 6: swaprpc.SwapMailboxEvent.out_swap_forfeit_signature_request:type_name -> swaprpc.OutSwapForfeitSignatureRequest
-	14, // 7: swaprpc.InArkHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	12, // 8: swaprpc.RouteHintPath.hops:type_name -> swaprpc.RouteHint
-	14, // 9: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
-	38, // 10: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
-	0,  // 11: swaprpc.CreateInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
-	19, // 12: swaprpc.CreateInSwapResponse.credit_quote:type_name -> swaprpc.CreditQuote
-	0,  // 13: swaprpc.QuoteInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
-	38, // 14: swaprpc.QuoteInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
-	19, // 15: swaprpc.QuoteInSwapResponse.credit_quote:type_name -> swaprpc.CreditQuote
-	1,  // 16: swaprpc.CreateCreditRequest.source:type_name -> swaprpc.CreditFundingSource
-	3,  // 17: swaprpc.CreateCreditResponse.state:type_name -> swaprpc.CreditOperationState
-	38, // 18: swaprpc.CreateCreditResponse.expires_at:type_name -> google.protobuf.Timestamp
-	3,  // 19: swaprpc.RedeemCreditResponse.state:type_name -> swaprpc.CreditOperationState
-	26, // 20: swaprpc.ListCreditsResponse.operations:type_name -> swaprpc.CreditOperation
-	27, // 21: swaprpc.ListCreditsResponse.ledger_entries:type_name -> swaprpc.CreditLedgerEntry
-	2,  // 22: swaprpc.CreditOperation.type:type_name -> swaprpc.CreditOperationType
-	3,  // 23: swaprpc.CreditOperation.state:type_name -> swaprpc.CreditOperationState
-	38, // 24: swaprpc.CreditOperation.created_at:type_name -> google.protobuf.Timestamp
-	38, // 25: swaprpc.CreditOperation.updated_at:type_name -> google.protobuf.Timestamp
-	38, // 26: swaprpc.CreditOperation.completed_at:type_name -> google.protobuf.Timestamp
-	38, // 27: swaprpc.CreditLedgerEntry.created_at:type_name -> google.protobuf.Timestamp
-	37, // 28: swaprpc.AuthorizeInSwapRefundResponse.signature:type_name -> swaprpc.TaprootScriptSignature
-	30, // 29: swaprpc.SignInSwapForfeitRequest.payload:type_name -> swaprpc.ForfeitSignaturePayload
-	31, // 30: swaprpc.SignInSwapForfeitResponse.signature:type_name -> swaprpc.ForfeitParticipantSignature
-	30, // 31: swaprpc.OutSwapForfeitSignatureRequest.payload:type_name -> swaprpc.ForfeitSignaturePayload
-	30, // 32: swaprpc.SubmitOutSwapForfeitSignatureRequest.payload:type_name -> swaprpc.ForfeitSignaturePayload
-	31, // 33: swaprpc.SubmitOutSwapForfeitSignatureRequest.signature:type_name -> swaprpc.ForfeitParticipantSignature
-	4,  // 34: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
-	15, // 35: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
-	17, // 36: swaprpc.SwapService.QuoteInSwap:input_type -> swaprpc.QuoteInSwapRequest
-	20, // 37: swaprpc.SwapService.CreateCredit:input_type -> swaprpc.CreateCreditRequest
-	22, // 38: swaprpc.SwapService.RedeemCredit:input_type -> swaprpc.RedeemCreditRequest
-	24, // 39: swaprpc.SwapService.ListCredits:input_type -> swaprpc.ListCreditsRequest
-	28, // 40: swaprpc.SwapService.AuthorizeInSwapRefund:input_type -> swaprpc.AuthorizeInSwapRefundRequest
-	6,  // 41: swaprpc.SwapService.AcknowledgeOutSwapHtlc:input_type -> swaprpc.AcknowledgeOutSwapHtlcRequest
-	32, // 42: swaprpc.SwapService.SignInSwapForfeit:input_type -> swaprpc.SignInSwapForfeitRequest
-	35, // 43: swaprpc.SwapService.SubmitOutSwapForfeitSignature:input_type -> swaprpc.SubmitOutSwapForfeitSignatureRequest
-	5,  // 44: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
-	16, // 45: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
-	18, // 46: swaprpc.SwapService.QuoteInSwap:output_type -> swaprpc.QuoteInSwapResponse
-	21, // 47: swaprpc.SwapService.CreateCredit:output_type -> swaprpc.CreateCreditResponse
-	23, // 48: swaprpc.SwapService.RedeemCredit:output_type -> swaprpc.RedeemCreditResponse
-	25, // 49: swaprpc.SwapService.ListCredits:output_type -> swaprpc.ListCreditsResponse
-	29, // 50: swaprpc.SwapService.AuthorizeInSwapRefund:output_type -> swaprpc.AuthorizeInSwapRefundResponse
-	7,  // 51: swaprpc.SwapService.AcknowledgeOutSwapHtlc:output_type -> swaprpc.AcknowledgeOutSwapHtlcResponse
-	33, // 52: swaprpc.SwapService.SignInSwapForfeit:output_type -> swaprpc.SignInSwapForfeitResponse
-	36, // 53: swaprpc.SwapService.SubmitOutSwapForfeitSignature:output_type -> swaprpc.SubmitOutSwapForfeitSignatureResponse
-	44, // [44:54] is the sub-list for method output_type
-	34, // [34:44] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	20, // 0: swaprpc.RequestChannelIdRequest.account_authorization:type_name -> swaprpc.CreditAccountAuthorization
+	0,  // 1: swaprpc.RequestChannelIdResponse.settlement_type:type_name -> swaprpc.SettlementType
+	13, // 2: swaprpc.RequestChannelIdResponse.route_hint_paths:type_name -> swaprpc.RouteHintPath
+	14, // 3: swaprpc.OutSwapHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	9,  // 4: swaprpc.OutSwapHtlcEvent.parts:type_name -> swaprpc.OutSwapHtlcPart
+	8,  // 5: swaprpc.SwapMailboxEvent.out_swap_htlc:type_name -> swaprpc.OutSwapHtlcEvent
+	11, // 6: swaprpc.SwapMailboxEvent.in_ark_htlc:type_name -> swaprpc.InArkHtlcEvent
+	35, // 7: swaprpc.SwapMailboxEvent.out_swap_forfeit_signature_request:type_name -> swaprpc.OutSwapForfeitSignatureRequest
+	14, // 8: swaprpc.InArkHtlcEvent.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	12, // 9: swaprpc.RouteHintPath.hops:type_name -> swaprpc.RouteHint
+	20, // 10: swaprpc.CreateInSwapRequest.account_authorization:type_name -> swaprpc.CreditAccountAuthorization
+	14, // 11: swaprpc.CreateInSwapResponse.vhtlc_config:type_name -> swaprpc.VHTLCConfig
+	39, // 12: swaprpc.CreateInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
+	0,  // 13: swaprpc.CreateInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
+	19, // 14: swaprpc.CreateInSwapResponse.credit_quote:type_name -> swaprpc.CreditQuote
+	20, // 15: swaprpc.QuoteInSwapRequest.account_authorization:type_name -> swaprpc.CreditAccountAuthorization
+	0,  // 16: swaprpc.QuoteInSwapResponse.settlement_type:type_name -> swaprpc.SettlementType
+	39, // 17: swaprpc.QuoteInSwapResponse.expiry:type_name -> google.protobuf.Timestamp
+	19, // 18: swaprpc.QuoteInSwapResponse.credit_quote:type_name -> swaprpc.CreditQuote
+	1,  // 19: swaprpc.CreateCreditRequest.source:type_name -> swaprpc.CreditFundingSource
+	20, // 20: swaprpc.CreateCreditRequest.account_authorization:type_name -> swaprpc.CreditAccountAuthorization
+	3,  // 21: swaprpc.CreateCreditResponse.state:type_name -> swaprpc.CreditOperationState
+	39, // 22: swaprpc.CreateCreditResponse.expires_at:type_name -> google.protobuf.Timestamp
+	20, // 23: swaprpc.RedeemCreditRequest.account_authorization:type_name -> swaprpc.CreditAccountAuthorization
+	3,  // 24: swaprpc.RedeemCreditResponse.state:type_name -> swaprpc.CreditOperationState
+	20, // 25: swaprpc.ListCreditsRequest.account_authorization:type_name -> swaprpc.CreditAccountAuthorization
+	27, // 26: swaprpc.ListCreditsResponse.operations:type_name -> swaprpc.CreditOperation
+	28, // 27: swaprpc.ListCreditsResponse.ledger_entries:type_name -> swaprpc.CreditLedgerEntry
+	2,  // 28: swaprpc.CreditOperation.type:type_name -> swaprpc.CreditOperationType
+	3,  // 29: swaprpc.CreditOperation.state:type_name -> swaprpc.CreditOperationState
+	39, // 30: swaprpc.CreditOperation.created_at:type_name -> google.protobuf.Timestamp
+	39, // 31: swaprpc.CreditOperation.updated_at:type_name -> google.protobuf.Timestamp
+	39, // 32: swaprpc.CreditOperation.completed_at:type_name -> google.protobuf.Timestamp
+	39, // 33: swaprpc.CreditLedgerEntry.created_at:type_name -> google.protobuf.Timestamp
+	38, // 34: swaprpc.AuthorizeInSwapRefundResponse.signature:type_name -> swaprpc.TaprootScriptSignature
+	31, // 35: swaprpc.SignInSwapForfeitRequest.payload:type_name -> swaprpc.ForfeitSignaturePayload
+	32, // 36: swaprpc.SignInSwapForfeitResponse.signature:type_name -> swaprpc.ForfeitParticipantSignature
+	31, // 37: swaprpc.OutSwapForfeitSignatureRequest.payload:type_name -> swaprpc.ForfeitSignaturePayload
+	31, // 38: swaprpc.SubmitOutSwapForfeitSignatureRequest.payload:type_name -> swaprpc.ForfeitSignaturePayload
+	32, // 39: swaprpc.SubmitOutSwapForfeitSignatureRequest.signature:type_name -> swaprpc.ForfeitParticipantSignature
+	4,  // 40: swaprpc.SwapService.RequestChannelId:input_type -> swaprpc.RequestChannelIdRequest
+	15, // 41: swaprpc.SwapService.CreateInSwap:input_type -> swaprpc.CreateInSwapRequest
+	17, // 42: swaprpc.SwapService.QuoteInSwap:input_type -> swaprpc.QuoteInSwapRequest
+	21, // 43: swaprpc.SwapService.CreateCredit:input_type -> swaprpc.CreateCreditRequest
+	23, // 44: swaprpc.SwapService.RedeemCredit:input_type -> swaprpc.RedeemCreditRequest
+	25, // 45: swaprpc.SwapService.ListCredits:input_type -> swaprpc.ListCreditsRequest
+	29, // 46: swaprpc.SwapService.AuthorizeInSwapRefund:input_type -> swaprpc.AuthorizeInSwapRefundRequest
+	6,  // 47: swaprpc.SwapService.AcknowledgeOutSwapHtlc:input_type -> swaprpc.AcknowledgeOutSwapHtlcRequest
+	33, // 48: swaprpc.SwapService.SignInSwapForfeit:input_type -> swaprpc.SignInSwapForfeitRequest
+	36, // 49: swaprpc.SwapService.SubmitOutSwapForfeitSignature:input_type -> swaprpc.SubmitOutSwapForfeitSignatureRequest
+	5,  // 50: swaprpc.SwapService.RequestChannelId:output_type -> swaprpc.RequestChannelIdResponse
+	16, // 51: swaprpc.SwapService.CreateInSwap:output_type -> swaprpc.CreateInSwapResponse
+	18, // 52: swaprpc.SwapService.QuoteInSwap:output_type -> swaprpc.QuoteInSwapResponse
+	22, // 53: swaprpc.SwapService.CreateCredit:output_type -> swaprpc.CreateCreditResponse
+	24, // 54: swaprpc.SwapService.RedeemCredit:output_type -> swaprpc.RedeemCreditResponse
+	26, // 55: swaprpc.SwapService.ListCredits:output_type -> swaprpc.ListCreditsResponse
+	30, // 56: swaprpc.SwapService.AuthorizeInSwapRefund:output_type -> swaprpc.AuthorizeInSwapRefundResponse
+	7,  // 57: swaprpc.SwapService.AcknowledgeOutSwapHtlc:output_type -> swaprpc.AcknowledgeOutSwapHtlcResponse
+	34, // 58: swaprpc.SwapService.SignInSwapForfeit:output_type -> swaprpc.SignInSwapForfeitResponse
+	37, // 59: swaprpc.SwapService.SubmitOutSwapForfeitSignature:output_type -> swaprpc.SubmitOutSwapForfeitSignatureResponse
+	50, // [50:60] is the sub-list for method output_type
+	40, // [40:50] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_swap_proto_init() }
@@ -3382,7 +3525,7 @@ func file_swap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_swap_proto_rawDesc), len(file_swap_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   34,
+			NumMessages:   35,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/swaprpc/swap.proto
+++ b/swaprpc/swap.proto
@@ -138,6 +138,11 @@ message RequestChannelIdRequest {
     // capability on the receive intent and only routes a credit-attach
     // receive through the swap-server-funded in-ark leg when it is set.
     bool supports_in_ark_credit = 5;
+
+    // account_authorization proves control of client_vhtlc_pubkey for this
+    // exact request. Swap servers require it before consulting or reserving
+    // account credits.
+    CreditAccountAuthorization account_authorization = 6;
 }
 
 // RequestChannelIdResponse returns the route hint paths for one receive
@@ -375,6 +380,10 @@ message CreateInSwapRequest {
     // max_credit_sat is the maximum credit amount the caller authorizes this
     // payment to reserve. Zero means credit use is not allowed.
     uint64 max_credit_sat = 5;
+
+    // account_authorization proves control of account_pubkey for this exact
+    // request whenever account_pubkey is set.
+    CreditAccountAuthorization account_authorization = 6;
 }
 
 // CreateInSwapResponse returns the negotiated parameters for one in-swap.
@@ -426,6 +435,10 @@ message QuoteInSwapRequest {
     // use. Zero means the quote reports whether credits are required but does
     // not apply optional credits.
     uint64 max_credit_sat = 4;
+
+    // account_authorization proves control of account_pubkey for this exact
+    // request whenever account_pubkey is set.
+    CreditAccountAuthorization account_authorization = 5;
 }
 
 // QuoteInSwapResponse returns the non-binding preview for one invoice send.
@@ -480,6 +493,19 @@ message CreditQuote {
     uint64 ark_funding_sat = 5;
 }
 
+// CreditAccountAuthorization proves control of the credit account identity
+// key for one exact request. The server rejects expired and reused nonces.
+message CreditAccountAuthorization {
+    // expires_at_unix is the unix timestamp after which the proof is invalid.
+    int64 expires_at_unix = 1;
+
+    // nonce is a caller-generated 32-byte unique value.
+    bytes nonce = 2;
+
+    // signature is a 64-byte BIP-340 Schnorr signature by the account key.
+    bytes signature = 3;
+}
+
 message CreateCreditRequest {
     // account_pubkey identifies the wallet credit account.
     bytes account_pubkey = 1;
@@ -495,6 +521,10 @@ message CreateCreditRequest {
     // memo is embedded into server-owned Lightning receive invoices when the
     // source is LIGHTNING_RECEIVE.
     string memo = 5;
+
+    // account_authorization proves control of account_pubkey for this exact
+    // request.
+    CreditAccountAuthorization account_authorization = 6;
 }
 
 message CreateCreditResponse {
@@ -522,6 +552,10 @@ message RedeemCreditRequest {
     string idempotency_key = 2;
     uint64 amount_sat = 3;
     bytes destination_pubkey = 4;
+
+    // account_authorization proves control of account_pubkey for this exact
+    // request.
+    CreditAccountAuthorization account_authorization = 5;
 }
 
 message RedeemCreditResponse {
@@ -535,6 +569,10 @@ message RedeemCreditResponse {
 message ListCreditsRequest {
     bytes account_pubkey = 1;
     uint32 limit = 2;
+
+    // account_authorization proves control of account_pubkey for this exact
+    // request.
+    CreditAccountAuthorization account_authorization = 3;
 }
 
 message ListCreditsResponse {

--- a/waved/rpc_auth.go
+++ b/waved/rpc_auth.go
@@ -116,7 +116,10 @@ func newWavedRPCPermissions() map[string][]bakery.Op {
 		"NewReceiveScript", "ReceiveAuthKey", "SignReceiveAuthMessage",
 		"SignReceiveAuthMessageCompact", "ReceiveAuthECDH",
 	)
-	grant(daemon, entitySwap, "write", "SignOutSwapHtlcAck")
+	grant(
+		daemon, entitySwap, "write", "SignOutSwapHtlcAck",
+		"SignCreditAccountAuthorization",
+	)
 	grant(
 		daemon, entityOOR, "read", "GetIndexedOORSessionByTxid",
 		"ListOORSessions", "GetOORSession",

--- a/waved/rpc_wallet.go
+++ b/waved/rpc_wallet.go
@@ -1,6 +1,7 @@
 package waved
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"errors"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/lightninglabs/lndclient"
@@ -29,6 +31,9 @@ import (
 const identityKeyFamily = keychain.KeyFamilyNodeKey
 
 const receiveAuthKeyTag = "wavelength/swap/receive-auth/v1"
+
+var errCreditAccountIdentityMismatch = errors.New("credit account key does " +
+	"not match wallet identity")
 
 // ReceiveAuthKey returns the public key for the payment-scoped receive-auth
 // key while keeping the private scalar inside the daemon.
@@ -156,6 +161,111 @@ func (r *RPCServer) SignOutSwapHtlcAck(ctx context.Context,
 	return &waverpc.SignOutSwapHtlcAckResponse{
 		Signature: sig.Serialize(),
 	}, nil
+}
+
+// SignCreditAccountAuthorization signs one canonical swap credit-account
+// request with the daemon identity key.
+func (r *RPCServer) SignCreditAccountAuthorization(ctx context.Context,
+	req *waverpc.SignCreditAccountAuthorizationRequest) (
+	*waverpc.SignCreditAccountAuthorizationResponse, error) {
+
+	if len(req.GetRequestDigest()) != chainhash.HashSize {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"request_digest must be %d bytes", chainhash.HashSize)
+	}
+	if len(req.GetNonce()) != swaprpc.CreditAccountNonceSize {
+		return nil, status.Errorf(codes.InvalidArgument, "nonce must "+
+			"be %d bytes", swaprpc.CreditAccountNonceSize)
+	}
+	if len(req.GetAccountPubkey()) != btcec.PubKeyBytesLenCompressed {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"account_pubkey must be %d bytes",
+			btcec.PubKeyBytesLenCompressed)
+	}
+
+	var (
+		digest [chainhash.HashSize]byte
+		nonce  [swaprpc.CreditAccountNonceSize]byte
+	)
+	copy(digest[:], req.GetRequestDigest())
+	copy(nonce[:], req.GetNonce())
+	if err := validateCreditAccountAuthExpiry(
+		req.GetExpiresAtUnix(), time.Now(),
+	); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	sig, err := r.SignCreditAccountAuth(
+		ctx, req.GetAccountPubkey(), digest, req.GetExpiresAtUnix(),
+		nonce,
+	)
+	if err != nil {
+		if errors.Is(err, errCreditAccountIdentityMismatch) {
+			return nil, status.Error(
+				codes.InvalidArgument, err.Error(),
+			)
+		}
+
+		return nil, status.Errorf(codes.Internal, "sign credit "+
+			"account authorization: %v", err)
+	}
+
+	return &waverpc.SignCreditAccountAuthorizationResponse{
+		Signature: sig.Serialize(),
+	}, nil
+}
+
+// SignCreditAccountAuth signs one request digest for the internal swap client.
+func (r *RPCServer) SignCreditAccountAuth(ctx context.Context,
+	accountKey []byte, requestDigest [32]byte, expiresAtUnix int64,
+	nonce [swaprpc.CreditAccountNonceSize]byte) (*schnorr.Signature,
+	error) {
+
+	if r == nil || r.server == nil {
+		return nil, fmt.Errorf("daemon server unavailable")
+	}
+	if err := r.requireWalletReady(); err != nil {
+		return nil, err
+	}
+	if r.server.clientKeyDesc.PubKey == nil {
+		return nil, fmt.Errorf("identity key is not ready")
+	}
+	identityKey := r.server.clientKeyDesc.PubKey.SerializeCompressed()
+	if !bytes.Equal(accountKey, identityKey) {
+		return nil, errCreditAccountIdentityMismatch
+	}
+
+	if err := validateCreditAccountAuthExpiry(
+		expiresAtUnix, time.Now(),
+	); err != nil {
+		return nil, err
+	}
+
+	message := swaprpc.CreditAccountAuthMessage(
+		identityKey, requestDigest, expiresAtUnix, nonce[:],
+	)
+	sig, err := r.server.signTaggedSchnorr(
+		ctx, message, []byte(swaprpc.CreditAccountAuthTag),
+		"credit account authorization",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return sig, nil
+}
+
+// validateCreditAccountAuthExpiry bounds one requested authorization lifetime.
+func validateCreditAccountAuthExpiry(expiresAtUnix int64, now time.Time) error {
+	nowUnix := now.Unix()
+	if expiresAtUnix <= nowUnix {
+		return fmt.Errorf("authorization expiry must be in the future")
+	}
+	if expiresAtUnix > nowUnix+
+		int64(swaprpc.CreditAccountMaxAuthTTL/time.Second) {
+		return fmt.Errorf("authorization expiry exceeds maximum TTL")
+	}
+
+	return nil
 }
 
 // deriveReceiveAuthKey derives the receive-auth base using the same

--- a/waved/rpc_wallet_test.go
+++ b/waved/rpc_wallet_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
@@ -120,6 +121,132 @@ func TestSignOutSwapHtlcAckSignsTerms(t *testing.T) {
 		keyDesc.PubKey, paymentHash, amountSat, pkScript,
 	)
 	require.True(t, sig.Verify(digest[:], keyDesc.PubKey))
+}
+
+// TestSignCreditAccountAuthorizationValidatesEnvelope verifies malformed and
+// stale authorization inputs are rejected before signing.
+func TestSignCreditAccountAuthorizationValidatesEnvelope(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	tooFarExpiry := now.Add(
+		swaprpc.CreditAccountMaxAuthTTL + time.Minute,
+	).Unix()
+	tests := []struct {
+		name string
+		req  *waverpc.SignCreditAccountAuthorizationRequest
+	}{
+		{
+			name: "request digest",
+			req: &waverpc.SignCreditAccountAuthorizationRequest{
+				Nonce: make(
+					[]byte, swaprpc.CreditAccountNonceSize,
+				),
+				ExpiresAtUnix: now.Add(time.Minute).Unix(),
+			},
+		},
+		{
+			name: "nonce",
+			req: &waverpc.SignCreditAccountAuthorizationRequest{
+				RequestDigest: make([]byte, 32),
+				ExpiresAtUnix: now.Add(time.Minute).Unix(),
+			},
+		},
+		{
+			name: "expired",
+			req: &waverpc.SignCreditAccountAuthorizationRequest{
+				AccountPubkey: make(
+					[]byte, btcec.PubKeyBytesLenCompressed,
+				),
+				RequestDigest: make([]byte, 32),
+				Nonce: make(
+					[]byte, swaprpc.CreditAccountNonceSize,
+				),
+				ExpiresAtUnix: now.Add(-time.Minute).Unix(),
+			},
+		},
+		{
+			name: "too far",
+			req: &waverpc.SignCreditAccountAuthorizationRequest{
+				AccountPubkey: make(
+					[]byte, btcec.PubKeyBytesLenCompressed,
+				),
+				RequestDigest: make([]byte, 32),
+				Nonce: make(
+					[]byte, swaprpc.CreditAccountNonceSize,
+				),
+				ExpiresAtUnix: tooFarExpiry,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := (&RPCServer{}).SignCreditAccountAuthorization(
+				t.Context(),
+				test.req,
+			)
+			require.Equal(
+				t, codes.InvalidArgument, status.Code(err),
+			)
+		})
+	}
+}
+
+// TestSignCreditAccountAuthorizationSignsDigest verifies the daemon identity
+// key signs the canonical account authorization message.
+func TestSignCreditAccountAuthorizationSignsDigest(t *testing.T) {
+	t.Parallel()
+
+	wallet := newFundedLwWallet(t)
+	keyDesc, err := wallet.KeyRing().DeriveKey(keychain.KeyLocator{
+		Family: keychain.KeyFamilyNodeKey,
+		Index:  0,
+	})
+	require.NoError(t, err)
+	walletReady := make(chan struct{})
+	close(walletReady)
+	rpcServer := &RPCServer{server: &Server{
+		walletReady:   walletReady,
+		clientKeyDesc: keyDesc,
+		lwWallet:      fn.Some(wallet),
+	}}
+
+	requestDigest := [32]byte{1, 2, 3}
+	nonce := [swaprpc.CreditAccountNonceSize]byte{4, 5, 6}
+	expiresAt := time.Now().Add(time.Minute).Unix()
+	resp, err := rpcServer.SignCreditAccountAuthorization(
+		t.Context(), &waverpc.SignCreditAccountAuthorizationRequest{
+			AccountPubkey: keyDesc.PubKey.SerializeCompressed(),
+			RequestDigest: requestDigest[:],
+			ExpiresAtUnix: expiresAt,
+			Nonce:         nonce[:],
+		},
+	)
+	require.NoError(t, err)
+
+	sig, err := schnorr.ParseSignature(resp.GetSignature())
+	require.NoError(t, err)
+	digest := swaprpc.CreditAccountAuthDigest(
+		keyDesc.PubKey.SerializeCompressed(), requestDigest, expiresAt,
+		nonce[:],
+	)
+	require.True(t, sig.Verify(digest[:], keyDesc.PubKey))
+
+	otherKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	_, err = rpcServer.SignCreditAccountAuthorization(
+		t.Context(), &waverpc.SignCreditAccountAuthorizationRequest{
+			AccountPubkey: otherKey.PubKey().SerializeCompressed(),
+			RequestDigest: requestDigest[:],
+			ExpiresAtUnix: expiresAt,
+			Nonce:         nonce[:],
+		},
+	)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 // TestWrongPassphraseErrorMapping pins the wrong-password

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -10294,6 +10294,125 @@ func (x *SignOutSwapHtlcAckResponse) GetSignature() []byte {
 	return nil
 }
 
+type SignCreditAccountAuthorizationRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// request_digest is the canonical 32-byte swap credit request digest.
+	RequestDigest []byte `protobuf:"bytes,1,opt,name=request_digest,json=requestDigest,proto3" json:"request_digest,omitempty"`
+	// expires_at_unix is the unix timestamp committed by the authorization.
+	ExpiresAtUnix int64 `protobuf:"varint,2,opt,name=expires_at_unix,json=expiresAtUnix,proto3" json:"expires_at_unix,omitempty"`
+	// nonce is the caller-generated 32-byte unique value committed by the
+	// authorization.
+	Nonce []byte `protobuf:"bytes,3,opt,name=nonce,proto3" json:"nonce,omitempty"`
+	// account_pubkey is the compressed wallet identity key named by the
+	// account-scoped request. The daemon only signs for its own identity.
+	AccountPubkey []byte `protobuf:"bytes,4,opt,name=account_pubkey,json=accountPubkey,proto3" json:"account_pubkey,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignCreditAccountAuthorizationRequest) Reset() {
+	*x = SignCreditAccountAuthorizationRequest{}
+	mi := &file_daemon_proto_msgTypes[121]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignCreditAccountAuthorizationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignCreditAccountAuthorizationRequest) ProtoMessage() {}
+
+func (x *SignCreditAccountAuthorizationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[121]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignCreditAccountAuthorizationRequest.ProtoReflect.Descriptor instead.
+func (*SignCreditAccountAuthorizationRequest) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{121}
+}
+
+func (x *SignCreditAccountAuthorizationRequest) GetRequestDigest() []byte {
+	if x != nil {
+		return x.RequestDigest
+	}
+	return nil
+}
+
+func (x *SignCreditAccountAuthorizationRequest) GetExpiresAtUnix() int64 {
+	if x != nil {
+		return x.ExpiresAtUnix
+	}
+	return 0
+}
+
+func (x *SignCreditAccountAuthorizationRequest) GetNonce() []byte {
+	if x != nil {
+		return x.Nonce
+	}
+	return nil
+}
+
+func (x *SignCreditAccountAuthorizationRequest) GetAccountPubkey() []byte {
+	if x != nil {
+		return x.AccountPubkey
+	}
+	return nil
+}
+
+type SignCreditAccountAuthorizationResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// signature is the 64-byte BIP-340 Schnorr signature.
+	Signature     []byte `protobuf:"bytes,1,opt,name=signature,proto3" json:"signature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SignCreditAccountAuthorizationResponse) Reset() {
+	*x = SignCreditAccountAuthorizationResponse{}
+	mi := &file_daemon_proto_msgTypes[122]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SignCreditAccountAuthorizationResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SignCreditAccountAuthorizationResponse) ProtoMessage() {}
+
+func (x *SignCreditAccountAuthorizationResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_daemon_proto_msgTypes[122]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SignCreditAccountAuthorizationResponse.ProtoReflect.Descriptor instead.
+func (*SignCreditAccountAuthorizationResponse) Descriptor() ([]byte, []int) {
+	return file_daemon_proto_rawDescGZIP(), []int{122}
+}
+
+func (x *SignCreditAccountAuthorizationResponse) GetSignature() []byte {
+	if x != nil {
+		return x.Signature
+	}
+	return nil
+}
+
 var File_daemon_proto protoreflect.FileDescriptor
 
 const file_daemon_proto_rawDesc = "" +
@@ -10999,6 +11118,13 @@ const file_daemon_proto_rawDesc = "" +
 	"amount_sat\x18\x02 \x01(\x04R\tamountSat\x12&\n" +
 	"\x0fvhtlc_pk_script\x18\x03 \x01(\fR\rvhtlcPkScript\":\n" +
 	"\x1aSignOutSwapHtlcAckResponse\x12\x1c\n" +
+	"\tsignature\x18\x01 \x01(\fR\tsignature\"\xb3\x01\n" +
+	"%SignCreditAccountAuthorizationRequest\x12%\n" +
+	"\x0erequest_digest\x18\x01 \x01(\fR\rrequestDigest\x12&\n" +
+	"\x0fexpires_at_unix\x18\x02 \x01(\x03R\rexpiresAtUnix\x12\x14\n" +
+	"\x05nonce\x18\x03 \x01(\fR\x05nonce\x12%\n" +
+	"\x0eaccount_pubkey\x18\x04 \x01(\fR\raccountPubkey\"F\n" +
+	"&SignCreditAccountAuthorizationResponse\x12\x1c\n" +
 	"\tsignature\x18\x01 \x01(\fR\tsignature*\x8d\x01\n" +
 	"\vWalletState\x12\x1c\n" +
 	"\x18WALLET_STATE_UNSPECIFIED\x10\x00\x12\x15\n" +
@@ -11089,7 +11215,7 @@ const file_daemon_proto_rawDesc = "" +
 	"\x1eVHTLC_RECOVERY_STATE_COMPLETED\x10\t\x12\"\n" +
 	"\x1eVHTLC_RECOVERY_STATE_CANCELLED\x10\n" +
 	"\x12\x1f\n" +
-	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\xb1\x1f\n" +
+	"\x1bVHTLC_RECOVERY_STATE_FAILED\x10\v2\xb5 \n" +
 	"\rDaemonService\x12<\n" +
 	"\aGetInfo\x12\x17.waverpc.GetInfoRequest\x1a\x18.waverpc.GetInfoResponse\x12<\n" +
 	"\aGenSeed\x12\x17.waverpc.GenSeedRequest\x1a\x18.waverpc.GenSeedResponse\x12E\n" +
@@ -11142,7 +11268,8 @@ const file_daemon_proto_rawDesc = "" +
 	"\x13CancelVHTLCRecovery\x12#.waverpc.CancelVHTLCRecoveryRequest\x1a$.waverpc.CancelVHTLCRecoveryResponse\x12i\n" +
 	"\x16GetVHTLCRecoveryStatus\x12&.waverpc.GetVHTLCRecoveryStatusRequest\x1a'.waverpc.GetVHTLCRecoveryStatusResponse\x12`\n" +
 	"\x13ListVHTLCRecoveries\x12#.waverpc.ListVHTLCRecoveriesRequest\x1a$.waverpc.ListVHTLCRecoveriesResponse\x12]\n" +
-	"\x12SignOutSwapHtlcAck\x12\".waverpc.SignOutSwapHtlcAckRequest\x1a#.waverpc.SignOutSwapHtlcAckResponseB-Z+github.com/lightninglabs/wavelength/waverpcb\x06proto3"
+	"\x12SignOutSwapHtlcAck\x12\".waverpc.SignOutSwapHtlcAckRequest\x1a#.waverpc.SignOutSwapHtlcAckResponse\x12\x81\x01\n" +
+	"\x1eSignCreditAccountAuthorization\x12..waverpc.SignCreditAccountAuthorizationRequest\x1a/.waverpc.SignCreditAccountAuthorizationResponseB-Z+github.com/lightninglabs/wavelength/waverpcb\x06proto3"
 
 var (
 	file_daemon_proto_rawDescOnce sync.Once
@@ -11157,7 +11284,7 @@ func file_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
-var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 122)
+var file_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 124)
 var file_daemon_proto_goTypes = []any{
 	(WalletState)(0),                                               // 0: waverpc.WalletState
 	(VTXOStatus)(0),                                                // 1: waverpc.VTXOStatus
@@ -11291,7 +11418,9 @@ var file_daemon_proto_goTypes = []any{
 	(*VHTLCRecoveryStatus)(nil),                                    // 129: waverpc.VHTLCRecoveryStatus
 	(*SignOutSwapHtlcAckRequest)(nil),                              // 130: waverpc.SignOutSwapHtlcAckRequest
 	(*SignOutSwapHtlcAckResponse)(nil),                             // 131: waverpc.SignOutSwapHtlcAckResponse
-	nil,                                                            // 132: waverpc.LeaveVTXOsRequest.DestinationsEntry
+	(*SignCreditAccountAuthorizationRequest)(nil),                  // 132: waverpc.SignCreditAccountAuthorizationRequest
+	(*SignCreditAccountAuthorizationResponse)(nil),                 // 133: waverpc.SignCreditAccountAuthorizationResponse
+	nil, // 134: waverpc.LeaveVTXOsRequest.DestinationsEntry
 }
 var file_daemon_proto_depIdxs = []int32{
 	0,   // 0: waverpc.GetInfoResponse.wallet_state:type_name -> waverpc.WalletState
@@ -11328,7 +11457,7 @@ var file_daemon_proto_depIdxs = []int32{
 	72,  // 31: waverpc.SubmitForfeitParticipantSignaturesRequest.signatures:type_name -> waverpc.ForfeitParticipantSignature
 	60,  // 32: waverpc.LeaveVTXOsRequest.outpoints:type_name -> waverpc.OutpointSelection
 	75,  // 33: waverpc.LeaveVTXOsRequest.default_destination:type_name -> waverpc.LeaveDestination
-	132, // 34: waverpc.LeaveVTXOsRequest.destinations:type_name -> waverpc.LeaveVTXOsRequest.DestinationsEntry
+	134, // 34: waverpc.LeaveVTXOsRequest.destinations:type_name -> waverpc.LeaveVTXOsRequest.DestinationsEntry
 	75,  // 35: waverpc.SendOnChainRequest.destination:type_name -> waverpc.LeaveDestination
 	85,  // 36: waverpc.SweepBoardingUTXOsResponse.sweepable_outputs:type_name -> waverpc.BoardingSweepOutput
 	88,  // 37: waverpc.BoardingSweep.inputs:type_name -> waverpc.BoardingSweepInput
@@ -11409,54 +11538,56 @@ var file_daemon_proto_depIdxs = []int32{
 	125, // 112: waverpc.DaemonService.GetVHTLCRecoveryStatus:input_type -> waverpc.GetVHTLCRecoveryStatusRequest
 	127, // 113: waverpc.DaemonService.ListVHTLCRecoveries:input_type -> waverpc.ListVHTLCRecoveriesRequest
 	130, // 114: waverpc.DaemonService.SignOutSwapHtlcAck:input_type -> waverpc.SignOutSwapHtlcAckRequest
-	12,  // 115: waverpc.DaemonService.GetInfo:output_type -> waverpc.GetInfoResponse
-	15,  // 116: waverpc.DaemonService.GenSeed:output_type -> waverpc.GenSeedResponse
-	17,  // 117: waverpc.DaemonService.InitWallet:output_type -> waverpc.InitWalletResponse
-	19,  // 118: waverpc.DaemonService.UnlockWallet:output_type -> waverpc.UnlockWalletResponse
-	21,  // 119: waverpc.DaemonService.GetBalance:output_type -> waverpc.GetBalanceResponse
-	26,  // 120: waverpc.DaemonService.ListVTXOs:output_type -> waverpc.ListVTXOsResponse
-	28,  // 121: waverpc.DaemonService.NewAddress:output_type -> waverpc.NewAddressResponse
-	30,  // 122: waverpc.DaemonService.NewReceiveScript:output_type -> waverpc.NewReceiveScriptResponse
-	32,  // 123: waverpc.DaemonService.ReceiveAuthKey:output_type -> waverpc.ReceiveAuthKeyResponse
-	34,  // 124: waverpc.DaemonService.SignReceiveAuthMessage:output_type -> waverpc.SignReceiveAuthMessageResponse
-	36,  // 125: waverpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> waverpc.SignReceiveAuthMessageCompactResponse
-	38,  // 126: waverpc.DaemonService.ReceiveAuthECDH:output_type -> waverpc.ReceiveAuthECDHResponse
-	40,  // 127: waverpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> waverpc.GetIndexedVTXOByPkScriptResponse
-	42,  // 128: waverpc.DaemonService.GetVTXOExpiryInfo:output_type -> waverpc.GetVTXOExpiryInfoResponse
-	44,  // 129: waverpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> waverpc.GetIndexedOORSessionByTxidResponse
-	47,  // 130: waverpc.DaemonService.SendVTXO:output_type -> waverpc.SendVTXOResponse
-	51,  // 131: waverpc.DaemonService.SendOOR:output_type -> waverpc.SendOORResponse
-	54,  // 132: waverpc.DaemonService.PrepareOOR:output_type -> waverpc.PrepareOORResponse
-	56,  // 133: waverpc.DaemonService.SignOORCustomInput:output_type -> waverpc.SignOORCustomInputResponse
-	58,  // 134: waverpc.DaemonService.SignVTXOForfeit:output_type -> waverpc.SignVTXOForfeitResponse
-	62,  // 135: waverpc.DaemonService.RefreshVTXOs:output_type -> waverpc.RefreshVTXOsResponse
-	68,  // 136: waverpc.DaemonService.RefreshCustomVTXOs:output_type -> waverpc.RefreshCustomVTXOsResponse
-	71,  // 137: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:output_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsResponse
-	74,  // 138: waverpc.DaemonService.SubmitForfeitParticipantSignatures:output_type -> waverpc.SubmitForfeitParticipantSignaturesResponse
-	77,  // 139: waverpc.DaemonService.LeaveVTXOs:output_type -> waverpc.LeaveVTXOsResponse
-	79,  // 140: waverpc.DaemonService.SendOnChain:output_type -> waverpc.SendOnChainResponse
-	81,  // 141: waverpc.DaemonService.Board:output_type -> waverpc.BoardResponse
-	83,  // 142: waverpc.DaemonService.JoinNextRound:output_type -> waverpc.JoinNextRoundResponse
-	86,  // 143: waverpc.DaemonService.SweepBoardingUTXOs:output_type -> waverpc.SweepBoardingUTXOsResponse
-	90,  // 144: waverpc.DaemonService.ListBoardingSweeps:output_type -> waverpc.ListBoardingSweepsResponse
-	96,  // 145: waverpc.DaemonService.ListRounds:output_type -> waverpc.ListRoundsResponse
-	95,  // 146: waverpc.DaemonService.GetRound:output_type -> waverpc.GetRoundResponse
-	98,  // 147: waverpc.DaemonService.WatchRounds:output_type -> waverpc.WatchRoundsResponse
-	101, // 148: waverpc.DaemonService.ListOORSessions:output_type -> waverpc.ListOORSessionsResponse
-	103, // 149: waverpc.DaemonService.GetOORSession:output_type -> waverpc.GetOORSessionResponse
-	105, // 150: waverpc.DaemonService.EstimateFee:output_type -> waverpc.EstimateFeeResponse
-	108, // 151: waverpc.DaemonService.GetFeeHistory:output_type -> waverpc.GetFeeHistoryResponse
-	111, // 152: waverpc.DaemonService.ListTransactions:output_type -> waverpc.ListTransactionsResponse
-	113, // 153: waverpc.DaemonService.Unroll:output_type -> waverpc.UnrollResponse
-	118, // 154: waverpc.DaemonService.GetUnrollStatus:output_type -> waverpc.GetUnrollStatusResponse
-	120, // 155: waverpc.DaemonService.ArmVHTLCRecovery:output_type -> waverpc.ArmVHTLCRecoveryResponse
-	122, // 156: waverpc.DaemonService.EscalateVHTLCRecovery:output_type -> waverpc.EscalateVHTLCRecoveryResponse
-	124, // 157: waverpc.DaemonService.CancelVHTLCRecovery:output_type -> waverpc.CancelVHTLCRecoveryResponse
-	126, // 158: waverpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> waverpc.GetVHTLCRecoveryStatusResponse
-	128, // 159: waverpc.DaemonService.ListVHTLCRecoveries:output_type -> waverpc.ListVHTLCRecoveriesResponse
-	131, // 160: waverpc.DaemonService.SignOutSwapHtlcAck:output_type -> waverpc.SignOutSwapHtlcAckResponse
-	115, // [115:161] is the sub-list for method output_type
-	69,  // [69:115] is the sub-list for method input_type
+	132, // 115: waverpc.DaemonService.SignCreditAccountAuthorization:input_type -> waverpc.SignCreditAccountAuthorizationRequest
+	12,  // 116: waverpc.DaemonService.GetInfo:output_type -> waverpc.GetInfoResponse
+	15,  // 117: waverpc.DaemonService.GenSeed:output_type -> waverpc.GenSeedResponse
+	17,  // 118: waverpc.DaemonService.InitWallet:output_type -> waverpc.InitWalletResponse
+	19,  // 119: waverpc.DaemonService.UnlockWallet:output_type -> waverpc.UnlockWalletResponse
+	21,  // 120: waverpc.DaemonService.GetBalance:output_type -> waverpc.GetBalanceResponse
+	26,  // 121: waverpc.DaemonService.ListVTXOs:output_type -> waverpc.ListVTXOsResponse
+	28,  // 122: waverpc.DaemonService.NewAddress:output_type -> waverpc.NewAddressResponse
+	30,  // 123: waverpc.DaemonService.NewReceiveScript:output_type -> waverpc.NewReceiveScriptResponse
+	32,  // 124: waverpc.DaemonService.ReceiveAuthKey:output_type -> waverpc.ReceiveAuthKeyResponse
+	34,  // 125: waverpc.DaemonService.SignReceiveAuthMessage:output_type -> waverpc.SignReceiveAuthMessageResponse
+	36,  // 126: waverpc.DaemonService.SignReceiveAuthMessageCompact:output_type -> waverpc.SignReceiveAuthMessageCompactResponse
+	38,  // 127: waverpc.DaemonService.ReceiveAuthECDH:output_type -> waverpc.ReceiveAuthECDHResponse
+	40,  // 128: waverpc.DaemonService.GetIndexedVTXOByPkScript:output_type -> waverpc.GetIndexedVTXOByPkScriptResponse
+	42,  // 129: waverpc.DaemonService.GetVTXOExpiryInfo:output_type -> waverpc.GetVTXOExpiryInfoResponse
+	44,  // 130: waverpc.DaemonService.GetIndexedOORSessionByTxid:output_type -> waverpc.GetIndexedOORSessionByTxidResponse
+	47,  // 131: waverpc.DaemonService.SendVTXO:output_type -> waverpc.SendVTXOResponse
+	51,  // 132: waverpc.DaemonService.SendOOR:output_type -> waverpc.SendOORResponse
+	54,  // 133: waverpc.DaemonService.PrepareOOR:output_type -> waverpc.PrepareOORResponse
+	56,  // 134: waverpc.DaemonService.SignOORCustomInput:output_type -> waverpc.SignOORCustomInputResponse
+	58,  // 135: waverpc.DaemonService.SignVTXOForfeit:output_type -> waverpc.SignVTXOForfeitResponse
+	62,  // 136: waverpc.DaemonService.RefreshVTXOs:output_type -> waverpc.RefreshVTXOsResponse
+	68,  // 137: waverpc.DaemonService.RefreshCustomVTXOs:output_type -> waverpc.RefreshCustomVTXOsResponse
+	71,  // 138: waverpc.DaemonService.ListPendingForfeitParticipantSignatureRequests:output_type -> waverpc.ListPendingForfeitParticipantSignatureRequestsResponse
+	74,  // 139: waverpc.DaemonService.SubmitForfeitParticipantSignatures:output_type -> waverpc.SubmitForfeitParticipantSignaturesResponse
+	77,  // 140: waverpc.DaemonService.LeaveVTXOs:output_type -> waverpc.LeaveVTXOsResponse
+	79,  // 141: waverpc.DaemonService.SendOnChain:output_type -> waverpc.SendOnChainResponse
+	81,  // 142: waverpc.DaemonService.Board:output_type -> waverpc.BoardResponse
+	83,  // 143: waverpc.DaemonService.JoinNextRound:output_type -> waverpc.JoinNextRoundResponse
+	86,  // 144: waverpc.DaemonService.SweepBoardingUTXOs:output_type -> waverpc.SweepBoardingUTXOsResponse
+	90,  // 145: waverpc.DaemonService.ListBoardingSweeps:output_type -> waverpc.ListBoardingSweepsResponse
+	96,  // 146: waverpc.DaemonService.ListRounds:output_type -> waverpc.ListRoundsResponse
+	95,  // 147: waverpc.DaemonService.GetRound:output_type -> waverpc.GetRoundResponse
+	98,  // 148: waverpc.DaemonService.WatchRounds:output_type -> waverpc.WatchRoundsResponse
+	101, // 149: waverpc.DaemonService.ListOORSessions:output_type -> waverpc.ListOORSessionsResponse
+	103, // 150: waverpc.DaemonService.GetOORSession:output_type -> waverpc.GetOORSessionResponse
+	105, // 151: waverpc.DaemonService.EstimateFee:output_type -> waverpc.EstimateFeeResponse
+	108, // 152: waverpc.DaemonService.GetFeeHistory:output_type -> waverpc.GetFeeHistoryResponse
+	111, // 153: waverpc.DaemonService.ListTransactions:output_type -> waverpc.ListTransactionsResponse
+	113, // 154: waverpc.DaemonService.Unroll:output_type -> waverpc.UnrollResponse
+	118, // 155: waverpc.DaemonService.GetUnrollStatus:output_type -> waverpc.GetUnrollStatusResponse
+	120, // 156: waverpc.DaemonService.ArmVHTLCRecovery:output_type -> waverpc.ArmVHTLCRecoveryResponse
+	122, // 157: waverpc.DaemonService.EscalateVHTLCRecovery:output_type -> waverpc.EscalateVHTLCRecoveryResponse
+	124, // 158: waverpc.DaemonService.CancelVHTLCRecovery:output_type -> waverpc.CancelVHTLCRecoveryResponse
+	126, // 159: waverpc.DaemonService.GetVHTLCRecoveryStatus:output_type -> waverpc.GetVHTLCRecoveryStatusResponse
+	128, // 160: waverpc.DaemonService.ListVHTLCRecoveries:output_type -> waverpc.ListVHTLCRecoveriesResponse
+	131, // 161: waverpc.DaemonService.SignOutSwapHtlcAck:output_type -> waverpc.SignOutSwapHtlcAckResponse
+	133, // 162: waverpc.DaemonService.SignCreditAccountAuthorization:output_type -> waverpc.SignCreditAccountAuthorizationResponse
+	116, // [116:163] is the sub-list for method output_type
+	69,  // [69:116] is the sub-list for method input_type
 	69,  // [69:69] is the sub-list for extension type_name
 	69,  // [69:69] is the sub-list for extension extendee
 	0,   // [0:69] is the sub-list for field type_name
@@ -11499,7 +11630,7 @@ func file_daemon_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_daemon_proto_rawDesc), len(file_daemon_proto_rawDesc)),
 			NumEnums:      11,
-			NumMessages:   122,
+			NumMessages:   124,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/waverpc/daemon.pb.gw.go
+++ b/waverpc/daemon.pb.gw.go
@@ -1273,6 +1273,33 @@ func local_request_DaemonService_SignOutSwapHtlcAck_0(ctx context.Context, marsh
 	return msg, metadata, err
 }
 
+func request_DaemonService_SignCreditAccountAuthorization_0(ctx context.Context, marshaler runtime.Marshaler, client DaemonServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SignCreditAccountAuthorizationRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.SignCreditAccountAuthorization(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_DaemonService_SignCreditAccountAuthorization_0(ctx context.Context, marshaler runtime.Marshaler, server DaemonServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SignCreditAccountAuthorizationRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.SignCreditAccountAuthorization(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterDaemonServiceHandlerServer registers the http handlers for service DaemonService to "mux".
 // UnaryRPC     :call DaemonServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -2186,6 +2213,26 @@ func RegisterDaemonServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_SignOutSwapHtlcAck_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_SignCreditAccountAuthorization_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/waverpc.DaemonService/SignCreditAccountAuthorization", runtime.WithHTTPPathPattern("/v1/daemon/sign-credit-account-authorization"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_DaemonService_SignCreditAccountAuthorization_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_SignCreditAccountAuthorization_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	return nil
 }
@@ -3008,6 +3055,23 @@ func RegisterDaemonServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_DaemonService_SignOutSwapHtlcAck_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_DaemonService_SignCreditAccountAuthorization_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/waverpc.DaemonService/SignCreditAccountAuthorization", runtime.WithHTTPPathPattern("/v1/daemon/sign-credit-account-authorization"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_DaemonService_SignCreditAccountAuthorization_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_DaemonService_SignCreditAccountAuthorization_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -3058,6 +3122,7 @@ var (
 	pattern_DaemonService_GetVHTLCRecoveryStatus_0                         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "get-vhtlc-recovery-status"}, ""))
 	pattern_DaemonService_ListVHTLCRecoveries_0                            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "list-vhtlc-recoveries"}, ""))
 	pattern_DaemonService_SignOutSwapHtlcAck_0                             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "sign-out-swap-htlc-ack"}, ""))
+	pattern_DaemonService_SignCreditAccountAuthorization_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "daemon", "sign-credit-account-authorization"}, ""))
 )
 
 var (
@@ -3107,4 +3172,5 @@ var (
 	forward_DaemonService_GetVHTLCRecoveryStatus_0                         = runtime.ForwardResponseMessage
 	forward_DaemonService_ListVHTLCRecoveries_0                            = runtime.ForwardResponseMessage
 	forward_DaemonService_SignOutSwapHtlcAck_0                             = runtime.ForwardResponseMessage
+	forward_DaemonService_SignCreditAccountAuthorization_0                 = runtime.ForwardResponseMessage
 )

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -266,6 +266,11 @@ service DaemonService {
     // the daemon identity key.
     rpc SignOutSwapHtlcAck (SignOutSwapHtlcAckRequest)
         returns (SignOutSwapHtlcAckResponse);
+
+    // SignCreditAccountAuthorization signs one canonical swap credit-account
+    // request digest with the daemon identity key.
+    rpc SignCreditAccountAuthorization (SignCreditAccountAuthorizationRequest)
+        returns (SignCreditAccountAuthorizationResponse);
 }
 
 // WalletState mirrors the daemon's in-process wallet lifecycle enum:
@@ -2837,6 +2842,27 @@ message SignOutSwapHtlcAckRequest {
 }
 
 message SignOutSwapHtlcAckResponse {
+    // signature is the 64-byte BIP-340 Schnorr signature.
+    bytes signature = 1;
+}
+
+message SignCreditAccountAuthorizationRequest {
+    // request_digest is the canonical 32-byte swap credit request digest.
+    bytes request_digest = 1;
+
+    // expires_at_unix is the unix timestamp committed by the authorization.
+    int64 expires_at_unix = 2;
+
+    // nonce is the caller-generated 32-byte unique value committed by the
+    // authorization.
+    bytes nonce = 3;
+
+    // account_pubkey is the compressed wallet identity key named by the
+    // account-scoped request. The daemon only signs for its own identity.
+    bytes account_pubkey = 4;
+}
+
+message SignCreditAccountAuthorizationResponse {
     // signature is the 64-byte BIP-340 Schnorr signature.
     bytes signature = 1;
 }

--- a/waverpc/daemon.yaml
+++ b/waverpc/daemon.yaml
@@ -42,6 +42,9 @@ http:
     - selector: waverpc.DaemonService.SignOutSwapHtlcAck
       post: /v1/daemon/sign-out-swap-htlc-ack
       body: "*"
+    - selector: waverpc.DaemonService.SignCreditAccountAuthorization
+      post: /v1/daemon/sign-credit-account-authorization
+      body: "*"
     - selector: waverpc.DaemonService.GetIndexedVTXOByPkScript
       post: /v1/daemon/get-indexed-vtxo-by-pk-script
       body: "*"

--- a/waverpc/daemon_grpc.pb.go
+++ b/waverpc/daemon_grpc.pb.go
@@ -65,6 +65,7 @@ const (
 	DaemonService_GetVHTLCRecoveryStatus_FullMethodName                         = "/waverpc.DaemonService/GetVHTLCRecoveryStatus"
 	DaemonService_ListVHTLCRecoveries_FullMethodName                            = "/waverpc.DaemonService/ListVHTLCRecoveries"
 	DaemonService_SignOutSwapHtlcAck_FullMethodName                             = "/waverpc.DaemonService/SignOutSwapHtlcAck"
+	DaemonService_SignCreditAccountAuthorization_FullMethodName                 = "/waverpc.DaemonService/SignCreditAccountAuthorization"
 )
 
 // DaemonServiceClient is the client API for DaemonService service.
@@ -263,6 +264,9 @@ type DaemonServiceClient interface {
 	// SignOutSwapHtlcAck signs the accepted terms of an out-swap vHTLC with
 	// the daemon identity key.
 	SignOutSwapHtlcAck(ctx context.Context, in *SignOutSwapHtlcAckRequest, opts ...grpc.CallOption) (*SignOutSwapHtlcAckResponse, error)
+	// SignCreditAccountAuthorization signs one canonical swap credit-account
+	// request digest with the daemon identity key.
+	SignCreditAccountAuthorization(ctx context.Context, in *SignCreditAccountAuthorizationRequest, opts ...grpc.CallOption) (*SignCreditAccountAuthorizationResponse, error)
 }
 
 type daemonServiceClient struct {
@@ -742,6 +746,16 @@ func (c *daemonServiceClient) SignOutSwapHtlcAck(ctx context.Context, in *SignOu
 	return out, nil
 }
 
+func (c *daemonServiceClient) SignCreditAccountAuthorization(ctx context.Context, in *SignCreditAccountAuthorizationRequest, opts ...grpc.CallOption) (*SignCreditAccountAuthorizationResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SignCreditAccountAuthorizationResponse)
+	err := c.cc.Invoke(ctx, DaemonService_SignCreditAccountAuthorization_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // DaemonServiceServer is the server API for DaemonService service.
 // All implementations must embed UnimplementedDaemonServiceServer
 // for forward compatibility.
@@ -938,6 +952,9 @@ type DaemonServiceServer interface {
 	// SignOutSwapHtlcAck signs the accepted terms of an out-swap vHTLC with
 	// the daemon identity key.
 	SignOutSwapHtlcAck(context.Context, *SignOutSwapHtlcAckRequest) (*SignOutSwapHtlcAckResponse, error)
+	// SignCreditAccountAuthorization signs one canonical swap credit-account
+	// request digest with the daemon identity key.
+	SignCreditAccountAuthorization(context.Context, *SignCreditAccountAuthorizationRequest) (*SignCreditAccountAuthorizationResponse, error)
 	mustEmbedUnimplementedDaemonServiceServer()
 }
 
@@ -1085,6 +1102,9 @@ func (UnimplementedDaemonServiceServer) ListVHTLCRecoveries(context.Context, *Li
 }
 func (UnimplementedDaemonServiceServer) SignOutSwapHtlcAck(context.Context, *SignOutSwapHtlcAckRequest) (*SignOutSwapHtlcAckResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SignOutSwapHtlcAck not implemented")
+}
+func (UnimplementedDaemonServiceServer) SignCreditAccountAuthorization(context.Context, *SignCreditAccountAuthorizationRequest) (*SignCreditAccountAuthorizationResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SignCreditAccountAuthorization not implemented")
 }
 func (UnimplementedDaemonServiceServer) mustEmbedUnimplementedDaemonServiceServer() {}
 func (UnimplementedDaemonServiceServer) testEmbeddedByValue()                       {}
@@ -1928,6 +1948,24 @@ func _DaemonService_SignOutSwapHtlcAck_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_SignCreditAccountAuthorization_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SignCreditAccountAuthorizationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).SignCreditAccountAuthorization(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DaemonService_SignCreditAccountAuthorization_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).SignCreditAccountAuthorization(ctx, req.(*SignCreditAccountAuthorizationRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // DaemonService_ServiceDesc is the grpc.ServiceDesc for DaemonService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -2114,6 +2152,10 @@ var DaemonService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SignOutSwapHtlcAck",
 			Handler:    _DaemonService_SignOutSwapHtlcAck_Handler,
+		},
+		{
+			MethodName: "SignCreditAccountAuthorization",
+			Handler:    _DaemonService_SignCreditAccountAuthorization_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/waverpc/daemon_mailboxrpc.pb.go
+++ b/waverpc/daemon_mailboxrpc.pb.go
@@ -116,6 +116,8 @@ type DaemonServiceMailboxServer interface {
 	ListVHTLCRecoveries(ctx context.Context, req *ListVHTLCRecoveriesRequest) (*ListVHTLCRecoveriesResponse, error)
 	// SignOutSwapHtlcAck handles SignOutSwapHtlcAck.
 	SignOutSwapHtlcAck(ctx context.Context, req *SignOutSwapHtlcAckRequest) (*SignOutSwapHtlcAckResponse, error)
+	// SignCreditAccountAuthorization handles SignCreditAccountAuthorization.
+	SignCreditAccountAuthorization(ctx context.Context, req *SignCreditAccountAuthorizationRequest) (*SignCreditAccountAuthorizationResponse, error)
 }
 
 // RegisterDaemonServiceMailboxServer registers handlers for DaemonService.
@@ -579,6 +581,16 @@ func RegisterDaemonServiceMailboxServer(r rpc.Router, impl DaemonServiceMailboxS
 		}
 
 		return impl.SignOutSwapHtlcAck(ctx, req)
+	})
+	r.Handle("waverpc.DaemonService", "SignCreditAccountAuthorization", func() proto.Message {
+		return &SignCreditAccountAuthorizationRequest{}
+	}, func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+		req, ok := msg.(*SignCreditAccountAuthorizationRequest)
+		if !ok {
+			return nil, fmt.Errorf("unexpected request type: %T", msg)
+		}
+
+		return impl.SignCreditAccountAuthorization(ctx, req)
 	})
 }
 
@@ -1633,6 +1645,29 @@ func (c *DaemonServiceMailboxClient) SignOutSwapHtlcAck(ctx context.Context, req
 	}
 
 	resp := new(SignOutSwapHtlcAckResponse)
+	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// SignCreditAccountAuthorization calls the SignCreditAccountAuthorization RPC.
+func (c *DaemonServiceMailboxClient) SignCreditAccountAuthorization(ctx context.Context, req *SignCreditAccountAuthorizationRequest, opts ...rpc.RPCOptions) (*SignCreditAccountAuthorizationResponse, error) {
+	var opt rpc.RPCOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	result, err := c.C.SendRPC(ctx, rpc.ServiceMethod{
+		Service: "waverpc.DaemonService",
+		Method:  "SignCreditAccountAuthorization",
+	}, req, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := new(SignCreditAccountAuthorizationResponse)
 	if err := c.C.AwaitRPC(ctx, result.CorrelationID, resp); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What it does

- defines a canonical, method-bound proof for account-scoped credit requests
- signs short-lived request digests with the daemon identity key
- passes the account key named by each request into the signer and rejects any key that does not match the wallet identity
- attaches a fresh nonce and signature in both gRPC and REST swap transports
- rejects missing local signing support before a protected request leaves the client

## Protocol

The signature commits to the exact RPC method, deterministic request bytes, account public key, expiry, and a 32-byte random nonce. The authorization field is excluded from its own request digest. Proofs expire after one minute by default and signers reject expiries beyond five minutes.

The signer receives the account key extracted from the same canonical payload it signs. The daemon refuses to sign unless that key matches its identity key, preventing a caller from asking one wallet to authorize another wallet's account.

## Compatibility

Ordinary Ark-to-Lightning quote and create requests remain unsigned when no credit account is supplied. Lightning-to-Ark route requests are account-scoped because the route may inspect or reserve receive credit, so receive callers must use a connection configured with an identity signer. The exported constructors document this distinction.

## Testing

- `go test ./swaprpc ./sdk/swaps ./sdk/ark ./waved`
- `go test -tags=swapruntime ./swapclientserver`
- `make fmt-changed-check`
- `make lint-changed-local workers=4`
- `make commitmsg-lint range=origin/main..HEAD`

The changed-file lint pass runs all 71 configured linters and reports zero issues.
