### PR TITLE
build: bump version to v0.1.1

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -19,7 +19,7 @@ const (
 
 	// AppPreRelease defines the pre-release version suffix for this
 	// binary.
-	AppPreRelease = "rc3"
+	AppPreRelease = ""
 )
 
 var (


### PR DESCRIPTION
## What changed

- Remove the `rc3` prerelease suffix so Wavelength reports the final `v0.1.1` version.

## Why

The RC3 release candidate has completed validation, including its tag-triggered release workflows. This prepares the `v0.1.x` release branch for the final `v0.1.1` tag.

## Impact

`waved` and `wavecli` now report `0.1.1`. Existing release workflows already handle final `v[0-9]*` tags, so no workflow changes are needed.

## Validation

- `make fmt-changed`
- `go test ./build`
- `make build`
- `make lint-changed-local`
- `make commitmsg-lint range="origin/main..HEAD"`
- Confirmed both built binaries report `0.1.1`
- Confirmed the RC3 tag workflow completed successfully on attempt 2

Full CI will run on this PR.