### PR TITLE
round: verify and sign asset trees (M4 client)

### DIFF
--- a/lib/tree/asset_path_validation_test.go
+++ b/lib/tree/asset_path_validation_test.go
@@ -1,0 +1,165 @@
+package tree
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// assetPathFixture builds a two-leaf tree with an attached asset context,
+// the shape an asset round hands a client, and returns the owner key of
+// the first leaf.
+func assetPathFixture(t *testing.T) (*Tree, *btcec.PublicKey,
+	*btcec.PublicKey) {
+
+	t.Helper()
+
+	_, operatorKey := createTestKey(t)
+	_, owner1 := createTestKey(t)
+	_, owner2 := createTestKey(t)
+
+	// Composed asset leaf outputs are P2TR; any taproot script stands in
+	// for the composed key here since composition is proven at spend
+	// time, not path-validation time.
+	script1, err := txscript.PayToTaprootScript(owner1)
+	require.NoError(t, err)
+	script2, err := txscript.PayToTaprootScript(owner2)
+	require.NoError(t, err)
+
+	leaves := []LeafDescriptor{
+		{
+			PkScript:    script1,
+			Amount:      1_000,
+			CoSignerKey: owner1,
+		},
+		{
+			PkScript:    script2,
+			Amount:      2_000,
+			CoSignerKey: owner2,
+		},
+	}
+
+	built, err := NewTree(
+		wire.OutPoint{
+			Hash: chainhash.HashH([]byte("asset_batch")),
+		}, &wire.TxOut{
+			Value: 3_000,
+		},
+		leaves,
+		operatorKey,
+		make([]byte, 32),
+		2,
+	)
+	require.NoError(t, err)
+
+	assetCtx := NewAssetTreeContext()
+	assetCtx.SetAssetRef("group:deadbeef")
+	for _, leaf := range built.Root.GetLeafNodes() {
+		amount := uint64(200)
+		if ContainsCosigner(leaf.CoSigners, owner1) {
+			amount = 100
+		}
+		assetCtx.SetNodeAssetAmount(leaf, amount)
+	}
+	built.AssetContext = assetCtx
+
+	return built, owner1, operatorKey
+}
+
+// TestValidatePathForAsset covers the accept path and each rejected
+// corruption of an asset VTXO path.
+func TestValidatePathForAsset(t *testing.T) {
+	t.Parallel()
+
+	expectedLeaf := func(owner *btcec.PublicKey) LeafDescriptor {
+		return LeafDescriptor{Amount: 1_000, CoSignerKey: owner}
+	}
+
+	t.Run("valid asset path", func(t *testing.T) {
+		t.Parallel()
+
+		built, owner, operator := assetPathFixture(t)
+		clientTree, err := built.ValidatePathForAsset(
+			owner, expectedLeaf(owner), operator, "group:deadbeef",
+			100,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, clientTree)
+		require.NotNil(t, clientTree.AssetContext)
+	})
+
+	t.Run("missing asset context", func(t *testing.T) {
+		t.Parallel()
+
+		built, owner, operator := assetPathFixture(t)
+		built.AssetContext = nil
+		_, err := built.ValidatePathForAsset(
+			owner, expectedLeaf(owner), operator, "group:deadbeef",
+			100,
+		)
+		require.ErrorContains(t, err, "no asset context")
+	})
+
+	t.Run("asset ref mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		built, owner, operator := assetPathFixture(t)
+		_, err := built.ValidatePathForAsset(
+			owner, expectedLeaf(owner), operator, "group:feedface",
+			100,
+		)
+		require.ErrorContains(t, err, "requested asset")
+	})
+
+	t.Run("leaf asset amount mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		built, owner, operator := assetPathFixture(t)
+		_, err := built.ValidatePathForAsset(
+			owner, expectedLeaf(owner), operator, "group:deadbeef",
+			250,
+		)
+		require.ErrorContains(t, err, "leaf asset amount")
+	})
+
+	t.Run("bitcoin amount mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		built, owner, operator := assetPathFixture(t)
+		wrongLeaf := LeafDescriptor{Amount: 999, CoSignerKey: owner}
+		_, err := built.ValidatePathForAsset(
+			owner, wrongLeaf, operator, "group:deadbeef", 100,
+		)
+		require.ErrorContains(t, err, "VTXO output value")
+	})
+
+	t.Run("non-taproot leaf output", func(t *testing.T) {
+		t.Parallel()
+
+		built, owner, operator := assetPathFixture(t)
+		for _, leaf := range built.Root.GetLeafNodes() {
+			leaf.Outputs[0].PkScript = []byte("not_p2tr")
+		}
+		_, err := built.ValidatePathForAsset(
+			owner, expectedLeaf(owner), operator, "group:deadbeef",
+			100,
+		)
+		require.ErrorContains(t, err, "not P2TR")
+	})
+
+	t.Run("missing operator cosigner", func(t *testing.T) {
+		t.Parallel()
+
+		built, owner, _ := assetPathFixture(t)
+		_, foreign := createTestKey(t)
+		_, err := built.ValidatePathForAsset(
+			owner, expectedLeaf(owner), foreign, "group:deadbeef",
+			100,
+		)
+		require.ErrorContains(t, err, "operator key")
+	})
+}

--- a/lib/tree/tree.go
+++ b/lib/tree/tree.go
@@ -7,6 +7,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightningnetwork/lnd/input"
@@ -385,6 +386,92 @@ func (t *Tree) ValidatePath(signingKey *btcec.PublicKey,
 
 	// Confirm operator key is present as co-signer to enable collaborative
 	// spending path.
+	if !ContainsCosigner(leaf.CoSigners, operatorKey) {
+		return nil, fmt.Errorf("leaf does not include operator key " +
+			"in co-signers")
+	}
+
+	return clientTree, nil
+}
+
+// ValidatePathForAsset validates the tree path for an asset VTXO leaf.
+// Structural validation mirrors ValidatePath — one leaf per signing key,
+// anchor output shape, operator cosigner presence, exact Bitcoin amount —
+// but the leaf output script equality is replaced by asset-context
+// checks: the composed script commits the asset into the leaf's taproot
+// key, and recomputing it byte-for-byte requires the leaf proof material
+// that is only delivered when the VTXO is spent. What the client pins
+// here instead is the asset identity and the exact asset amount its
+// leaf's subtree carries.
+func (t *Tree) ValidatePathForAsset(signingKey *btcec.PublicKey,
+	expectedLeaf LeafDescriptor, operatorKey *btcec.PublicKey,
+	expectedAssetRef string, expectedAssetAmount uint64) (*Tree, error) {
+
+	if t == nil {
+		return nil, fmt.Errorf("tree is nil")
+	}
+	if signingKey == nil {
+		return nil, fmt.Errorf("signing key cannot be nil")
+	}
+	if expectedAssetRef == "" || expectedAssetAmount == 0 {
+		return nil, fmt.Errorf("asset ref and amount are required")
+	}
+	if t.AssetContext == nil {
+		return nil, fmt.Errorf("tree carries no asset context")
+	}
+	if t.AssetContext.AssetRef() != expectedAssetRef {
+		return nil, fmt.Errorf("tree asset %q != requested asset %q",
+			t.AssetContext.AssetRef(), expectedAssetRef)
+	}
+
+	// Extract and structurally verify the client's path.
+	clientTree, err := t.ExtractPathForCoSigners(signingKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract client path: %w", err)
+	}
+	if err := clientTree.Verify(); err != nil {
+		return nil, fmt.Errorf("extracted tree structure invalid: %w",
+			err)
+	}
+
+	leaves := clientTree.Root.GetLeafNodes()
+	if len(leaves) != 1 {
+		return nil, fmt.Errorf("expected exactly 1 leaf, got %d",
+			len(leaves))
+	}
+	leaf := leaves[0]
+
+	if len(leaf.Outputs) != NumLeafOutputs {
+		return nil, fmt.Errorf("leaf should have %d outputs, got %d",
+			NumLeafOutputs, len(leaf.Outputs))
+	}
+	vtxoOutput := leaf.Outputs[0]
+
+	// The composed output must at least be a taproot output; its key is
+	// re-derived and proven at spend time.
+	if !txscript.IsPayToTaproot(vtxoOutput.PkScript) {
+		return nil, fmt.Errorf("asset VTXO output is not P2TR")
+	}
+
+	if len(leaf.Outputs[1].PkScript) > 0 &&
+		leaf.Outputs[1].Value != 0 {
+		return nil, fmt.Errorf("anchor output should have value "+
+			"0, got %d", leaf.Outputs[1].Value)
+	}
+
+	// Exact Bitcoin amount, exact asset amount.
+	if vtxoOutput.Value != int64(expectedLeaf.Amount) {
+		return nil, fmt.Errorf("VTXO output value %d != expected %d",
+			vtxoOutput.Value, expectedLeaf.Amount)
+	}
+	if got := t.AssetContext.NodeAssetAmount(leaf); got !=
+		expectedAssetAmount {
+		return nil, fmt.Errorf("leaf asset amount %d != requested %d",
+			got, expectedAssetAmount)
+	}
+
+	// Confirm operator key is present as co-signer to enable
+	// collaborative spending.
 	if !ContainsCosigner(leaf.CoSigners, operatorKey) {
 		return nil, fmt.Errorf("leaf does not include operator key " +
 			"in co-signers")

--- a/lib/types/boarding.go
+++ b/lib/types/boarding.go
@@ -266,6 +266,16 @@ type VTXORequest struct {
 	// output is not eligible for the implicit-change exception.
 	FixedAmount bool
 
+	// AssetRef identifies the Taproot Asset this VTXO must carry (group
+	// key reference for grouped assets). Empty for Bitcoin-only VTXOs.
+	// Asset requests carry a fixed Amount and never act as the change
+	// output.
+	AssetRef string
+
+	// AssetAmount is the requested Taproot Asset amount. Non-zero
+	// exactly when AssetRef is set.
+	AssetAmount uint64
+
 	// PolicyTemplate is the semantic arkscript policy for the requested
 	// output. This is the authoritative join-round representation.
 	PolicyTemplate []byte

--- a/lib/types/codec.go
+++ b/lib/types/codec.go
@@ -52,6 +52,8 @@ const (
 	joinRoundAuthVTXOSigningKeyRecordType  tlv.Type = 3
 	joinRoundAuthVTXOIsChangeRecordType    tlv.Type = 4
 	joinRoundAuthVTXOFixedAmountRecordType tlv.Type = 5
+	joinRoundAuthVTXOAssetRefRecordType    tlv.Type = 6
+	joinRoundAuthVTXOAssetAmountRecordType tlv.Type = 7
 )
 
 const (
@@ -493,11 +495,13 @@ func decodeJoinAuthVTXORequests(raw []byte) ([]*VTXORequest, error) {
 // decodeJoinAuthVTXORequest parses one VTXO request entry.
 func decodeJoinAuthVTXORequest(raw []byte) (*VTXORequest, error) {
 	var (
-		amount     uint64
-		policy     []byte
-		signingKey []byte
-		isChange   uint8
-		fixedAmt   uint8
+		amount      uint64
+		policy      []byte
+		signingKey  []byte
+		isChange    uint8
+		fixedAmt    uint8
+		assetRef    []byte
+		assetAmount uint64
 	)
 
 	stream, err := tlv.NewStream(
@@ -515,6 +519,12 @@ func decodeJoinAuthVTXORequest(raw []byte) (*VTXORequest, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			joinRoundAuthVTXOFixedAmountRecordType, &fixedAmt,
+		),
+		tlv.MakePrimitiveRecord(
+			joinRoundAuthVTXOAssetRefRecordType, &assetRef,
+		),
+		tlv.MakePrimitiveRecord(
+			joinRoundAuthVTXOAssetAmountRecordType, &assetAmount,
 		),
 	)
 	if err != nil {
@@ -571,6 +581,8 @@ func decodeJoinAuthVTXORequest(raw []byte) (*VTXORequest, error) {
 		IsChange:       isChange != 0,
 		FixedAmount:    fixedAmt != 0,
 		PolicyTemplate: bytes.Clone(policy),
+		AssetRef:       string(assetRef),
+		AssetAmount:    assetAmount,
 		SigningKey: keychain.KeyDescriptor{
 			PubKey: signingPubKey,
 		},
@@ -954,6 +966,8 @@ func encodeJoinAuthVTXORequest(req *VTXORequest) ([]byte, error) {
 	if req.FixedAmount {
 		fixedAmt = 1
 	}
+	assetRef := []byte(req.AssetRef)
+	assetAmount := req.AssetAmount
 
 	records := []tlv.Record{
 		tlv.MakePrimitiveRecord(
@@ -971,6 +985,22 @@ func encodeJoinAuthVTXORequest(req *VTXORequest) ([]byte, error) {
 		tlv.MakePrimitiveRecord(
 			joinRoundAuthVTXOFixedAmountRecordType, &fixedAmt,
 		),
+	}
+
+	// Asset requests bind their asset identity and amount into the
+	// auth digest so the operator cannot alter either. Bitcoin-only
+	// requests keep the historical record set, preserving their
+	// digests.
+	if req.AssetRef != "" {
+		records = append(records,
+			tlv.MakePrimitiveRecord(
+				joinRoundAuthVTXOAssetRefRecordType, &assetRef,
+			),
+			tlv.MakePrimitiveRecord(
+				joinRoundAuthVTXOAssetAmountRecordType,
+				&assetAmount,
+			),
+		)
 	}
 
 	return encodeJoinAuthTLV(records)

--- a/round/actor.go
+++ b/round/actor.go
@@ -1625,13 +1625,15 @@ func buildBoardingIntentFromWallet(walletIntent *wallet.BoardingIntent) (
 func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 	msg *RegisterVTXORequestsRequest) fn.Result[actormsg.RoundActorResp] {
 
-	if len(msg.Amounts) == 0 {
+	if len(msg.Amounts) == 0 && len(msg.AssetRequests) == 0 {
 		return fn.Err[actormsg.RoundActorResp](
 			fmt.Errorf("VTXO request amounts are empty"),
 		)
 	}
 
-	requests := make([]types.VTXORequest, 0, len(msg.Amounts))
+	requests := make(
+		[]types.VTXORequest, 0, len(msg.Amounts)+len(msg.AssetRequests),
+	)
 	for i, amount := range msg.Amounts {
 		if amount <= 0 {
 			return fn.Err[actormsg.RoundActorResp](
@@ -1663,6 +1665,35 @@ func (a *RoundClientActor) handleVTXORequests(ctx context.Context,
 		// that marker centrally via designateChangeMarker over
 		// the fully-composed intent, so this loop leaves
 		// IsChange unset.
+
+		requests = append(requests, *req)
+	}
+
+	// Asset VTXO requests ride the same intent with the asset identity
+	// and amount attached; their Bitcoin amount is fixed so the seal
+	// quote can never shrink the carrier value, and they never act as
+	// the change output.
+	for i, assetReq := range msg.AssetRequests {
+		if assetReq.AmountSat <= 0 || assetReq.AssetAmount == 0 ||
+			assetReq.AssetRef == "" {
+			return fn.Err[actormsg.RoundActorResp](
+				fmt.Errorf("asset VTXO request %d is "+
+					"incomplete", i),
+			)
+		}
+
+		req, err := a.buildVTXORequest(
+			ctx, assetReq.AmountSat, types.VTXOOriginUnknown,
+		)
+		if err != nil {
+			return fn.Err[actormsg.RoundActorResp](
+				fmt.Errorf("build asset VTXO request %d: %w",
+					i, err),
+			)
+		}
+		req.AssetRef = assetReq.AssetRef
+		req.AssetAmount = assetReq.AssetAmount
+		req.FixedAmount = true
 
 		requests = append(requests, *req)
 	}

--- a/round/actor_messages.go
+++ b/round/actor_messages.go
@@ -210,6 +210,24 @@ type RegisterVTXORequestsRequest struct {
 	actor.BaseMessage
 
 	Amounts []btcutil.Amount
+
+	// AssetRequests are Taproot Asset VTXO requests: each asks the
+	// operator's asset round for a leaf carrying AssetAmount units
+	// anchored by AmountSat.
+	AssetRequests []AssetVTXORequest
+}
+
+// AssetVTXORequest asks for one asset VTXO in the next round.
+type AssetVTXORequest struct {
+	// AmountSat is the leaf output's Bitcoin carrier value.
+	AmountSat btcutil.Amount
+
+	// AssetRef identifies the requested asset (group reference for
+	// grouped assets).
+	AssetRef string
+
+	// AssetAmount is the requested asset amount.
+	AssetAmount uint64
 }
 
 // MessageType returns the message type name.

--- a/round/from_proto.go
+++ b/round/from_proto.go
@@ -563,6 +563,8 @@ func (m *JoinRoundRequest) FromProto(p proto.Message) error {
 			IsChange:       vr.IsChange,
 			FixedAmount:    vr.FixedAmount,
 			PolicyTemplate: bytes.Clone(vr.PolicyTemplate),
+			AssetRef:       vr.AssetRef,
+			AssetAmount:    vr.AssetAmount,
 		}
 
 		if len(vr.SigningKey) > 0 {

--- a/round/outbox_messages.go
+++ b/round/outbox_messages.go
@@ -325,6 +325,8 @@ func (m *JoinRoundRequest) ToProto() fn.Result[proto.Message] {
 			IsChange:        req.IsChange,
 			FixedAmount:     req.FixedAmount,
 			PolicyTemplate:  policyTemplate,
+			AssetRef:        req.AssetRef,
+			AssetAmount:     req.AssetAmount,
 		}
 		if req.SigningKey.PubKey != nil {
 			vr.SigningKey = req.SigningKey.PubKey.

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -628,12 +628,40 @@ func (s *PendingRoundAssembly) processEvent(ctx context.Context,
 			), nil
 		}
 
-		// Validate that outputs don't exceed inputs.
-		if totalOutput > totalInput {
+		// Validate that the fixed outputs don't exceed inputs. The
+		// designated change output's target is advisory under the
+		// seal-time fee handshake — the server stamps it with the
+		// residual (Σin − Σfixed − fee) at seal — so it must not
+		// count against the input budget here. The change marker is
+		// only stamped further below over the composed intent, so
+		// exclude the target designateChangeMarker will pick: the
+		// first non-fixed output.
+		fixedOutput := totalOutput
+		if len(s.VTXOs)+len(s.Leaves) > 1 {
+			changeIdx := -1
+			for i, vtxo := range s.VTXOs {
+				if vtxo.FixedAmount {
+					continue
+				}
+				if vtxo.IsChange {
+					changeIdx = i
+
+					break
+				}
+				if changeIdx == -1 {
+					changeIdx = i
+				}
+			}
+			if changeIdx != -1 {
+				fixedOutput -= s.VTXOs[changeIdx].Amount
+			}
+		}
+		if fixedOutput > totalInput {
 			return failWithNotification(
 				"outputs exceed inputs",
-				fmt.Errorf("total output (%d) exceeds total "+
-					"input (%d)", totalOutput, totalInput),
+				fmt.Errorf("total fixed output (%d) exceeds "+
+					"total input (%d)", fixedOutput,
+					totalInput),
 				true,
 				fn.None[RoundID](),
 			), nil
@@ -644,9 +672,9 @@ func (s *PendingRoundAssembly) processEvent(ctx context.Context,
 		// composition time: the binding fee arrives later via the
 		// JoinRoundQuote message and is checked in
 		// QuoteReceivedState against env.MaxOperatorFee. The
-		// balance invariant (outputs <= inputs) stays here as a
-		// sanity guard.
-		operatorFee := totalInput - totalOutput
+		// balance invariant (fixed outputs <= inputs) stays here as
+		// a sanity guard.
+		operatorFee := totalInput - fixedOutput
 
 		env.Log.InfoS(ctx, "Intent balance check passed",
 			btclog.Fmt("total_input", "%v", totalInput),

--- a/round/transitions.go
+++ b/round/transitions.go
@@ -2207,14 +2207,32 @@ func (s *CommitmentTxReceivedState) processEvent(ctx context.Context,
 			}
 
 			// Search through all VTXO trees to find the one
-			// containing this VTXO request.
+			// containing this VTXO request. Asset requests pin
+			// the leaf's asset identity and amount instead of
+			// the composed output script, which is only provable
+			// with the proof material delivered at spend time.
 			var clientTree *tree.Tree
 			var validateErr error
 			for _, vtxoTree := range s.VTXOTreePaths {
-				clientTree, validateErr = vtxoTree.ValidatePath(
-					vtxoReq.SigningKey.PubKey, expectedLeaf,
-					treeCosignKey,
-				)
+				if vtxoReq.AssetRef != "" {
+					clientTree, validateErr =
+						vtxoTree.ValidatePathForAsset(
+							vtxoReq.SigningKey.
+								PubKey,
+							expectedLeaf,
+							treeCosignKey,
+							vtxoReq.AssetRef,
+							vtxoReq.AssetAmount,
+						)
+				} else {
+					clientTree, validateErr =
+						vtxoTree.ValidatePath(
+							vtxoReq.SigningKey.
+								PubKey,
+							expectedLeaf,
+							treeCosignKey,
+						)
+				}
 				if validateErr == nil {
 					// Found the VTXO in this tree.
 					break
@@ -2521,6 +2539,15 @@ func (s *CommitmentTxValidatedState) processEvent(ctx context.Context,
 					signerKey[:], err)
 			}
 
+			// Asset trees vary the signing tweak per node; the
+			// lookup overrides the sweep root wherever the tree
+			// carries one.
+			var tweakLookup tree.TaprootTweakLookup
+			if clientTree.AssetContext != nil {
+				tweakLookup = clientTree.AssetContext.
+					TweakLookup()
+			}
+
 			sessionJobs = append(
 				sessionJobs, CreateSignerSessionJob{
 					SignerKey:          signerKey,
@@ -2529,6 +2556,7 @@ func (s *CommitmentTxValidatedState) processEvent(ctx context.Context,
 					SweepTapscriptRoot: sweepTweak,
 					PrevOuts:           prevOutFetcher,
 					Root:               root,
+					TweakLookup:        tweakLookup,
 				},
 			)
 		}
@@ -3983,9 +4011,21 @@ func verifyVTXOTreeRoot(commitmentTx *wire.MsgTx, commitmentTxID chainhash.Hash,
 	// output whose key is not the aggregate of the declared cosigners,
 	// leaving the co-signed tree unable to ever spend it. We recompute from
 	// the declared parameters rather than trusting Root.FinalKey, which is
-	// itself operator-supplied.
+	// itself operator-supplied. Asset trees tweak the batch output with
+	// the combined root (sweep leaf plus asset commitment), carried as
+	// the root node's signing tweak; the recompute proves the co-signed
+	// aggregate can spend the committed output either way.
+	rootTweak := vtxoTree.SweepTapscriptRoot
+	if vtxoTree.AssetContext != nil {
+		tweak := vtxoTree.AssetContext.SigningTweak(
+			vtxoTree.Root.Input,
+		)
+		if len(tweak) > 0 {
+			rootTweak = tweak
+		}
+	}
 	finalKey, err := tree.ComputeFinalKey(
-		vtxoTree.Root.CoSigners, vtxoTree.SweepTapscriptRoot,
+		vtxoTree.Root.CoSigners, rootTweak,
 	)
 	if err != nil {
 		return fmt.Errorf("recompute tree root key: %w", err)

--- a/round/vtxo_tree_binding_test.go
+++ b/round/vtxo_tree_binding_test.go
@@ -48,6 +48,46 @@ func TestValidateVTXOTreeBindingAccepts(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestValidateVTXOTreeBindingAssetRootTweak proves the binding recompute
+// honors an asset tree's combined root tweak: the committed batch output
+// keyed with the combined tweak passes, and a tampered tweak that no
+// longer reproduces the committed script is rejected.
+func TestValidateVTXOTreeBindingAssetRootTweak(t *testing.T) {
+	t.Parallel()
+
+	commitmentTx, vtxtTree, _ := newBoundVTXOFixture(t)
+
+	// Re-key the committed batch output with a combined tweak (sweep
+	// leaf plus asset commitment root), as an asset round does.
+	combined := chainhash.HashH([]byte("combined root tweak"))
+	finalKey, err := tree.ComputeFinalKey(
+		vtxtTree.Root.CoSigners, combined[:],
+	)
+	require.NoError(t, err)
+	script, err := txscript.PayToTaprootScript(finalKey)
+	require.NoError(t, err)
+
+	commitmentTx.TxOut[0].PkScript = script
+	vtxtTree.BatchOutput.PkScript = script
+
+	// The output mutation changed the commitment txid; rebind the root.
+	vtxtTree.BatchOutpoint.Hash = commitmentTx.TxHash()
+	vtxtTree.Root.Input = vtxtTree.BatchOutpoint
+
+	assetCtx := tree.NewAssetTreeContext()
+	assetCtx.SetSigningTweak(vtxtTree.Root.Input, combined[:])
+	vtxtTree.AssetContext = assetCtx
+
+	trees := map[int]*tree.Tree{0: vtxtTree}
+	require.NoError(t, validateVTXOTreeBinding(commitmentTx, trees))
+
+	// A tampered tweak no longer reproduces the committed script.
+	tampered := chainhash.HashH([]byte("tampered tweak"))
+	assetCtx.SetSigningTweak(vtxtTree.Root.Input, tampered[:])
+	err = validateVTXOTreeBinding(commitmentTx, trees)
+	require.ErrorContains(t, err, "recomputed from tree cosigners")
+}
+
 // TestValidateVTXOTreeBindingRejects walks each way an operator-supplied tree
 // can fail to bind to the commitment tx the client is about to sign into. Each
 // case starts from an honest fixture and corrupts exactly one aspect, proving

--- a/rpc/roundpb/round.pb.go
+++ b/rpc/roundpb/round.pb.go
@@ -1389,7 +1389,16 @@ type VTXORequest struct {
 	// exactly. When this is set on a single-output intent, the single-output
 	// implicit-change exception is disabled and the intent must include a
 	// separate fee-bearing change output if fees need to be paid.
-	FixedAmount   bool `protobuf:"varint,5,opt,name=fixed_amount,json=fixedAmount,proto3" json:"fixed_amount,omitempty"`
+	FixedAmount bool `protobuf:"varint,5,opt,name=fixed_amount,json=fixedAmount,proto3" json:"fixed_amount,omitempty"`
+	// asset_ref identifies the Taproot Asset the client requests this
+	// VTXO to carry (group key reference for grouped assets). Empty for
+	// Bitcoin-only VTXOs. Asset requests are only accepted by operators
+	// running asset rounds for the same asset; they carry a fixed
+	// target_amount_sat and never act as the change output.
+	AssetRef string `protobuf:"bytes,6,opt,name=asset_ref,json=assetRef,proto3" json:"asset_ref,omitempty"`
+	// asset_amount is the requested Taproot Asset amount. Required
+	// (non-zero) when asset_ref is set, zero otherwise.
+	AssetAmount   uint64 `protobuf:"varint,7,opt,name=asset_amount,json=assetAmount,proto3" json:"asset_amount,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1457,6 +1466,20 @@ func (x *VTXORequest) GetFixedAmount() bool {
 		return x.FixedAmount
 	}
 	return false
+}
+
+func (x *VTXORequest) GetAssetRef() string {
+	if x != nil {
+		return x.AssetRef
+	}
+	return ""
+}
+
+func (x *VTXORequest) GetAssetAmount() uint64 {
+	if x != nil {
+		return x.AssetAmount
+	}
+	return 0
 }
 
 // ForfeitRequest specifies a VTXO the client wants to forfeit.
@@ -2956,14 +2979,16 @@ const file_round_proto_rawDesc = "" +
 	"\x0fBoardingRequest\x12.\n" +
 	"\boutpoint\x18\x01 \x01(\v2\x12.round.v1.OutpointR\boutpoint\x12'\n" +
 	"\x0fpolicy_template\x18\x02 \x01(\fR\x0epolicyTemplate\x12\x19\n" +
-	"\btx_proof\x18\x03 \x01(\fR\atxProof\"\xc3\x01\n" +
+	"\btx_proof\x18\x03 \x01(\fR\atxProof\"\x83\x02\n" +
 	"\vVTXORequest\x12*\n" +
 	"\x11target_amount_sat\x18\x01 \x01(\x03R\x0ftargetAmountSat\x12'\n" +
 	"\x0fpolicy_template\x18\x02 \x01(\fR\x0epolicyTemplate\x12\x1f\n" +
 	"\vsigning_key\x18\x03 \x01(\fR\n" +
 	"signingKey\x12\x1b\n" +
 	"\tis_change\x18\x04 \x01(\bR\bisChange\x12!\n" +
-	"\ffixed_amount\x18\x05 \x01(\bR\vfixedAmount\"\x9f\x01\n" +
+	"\ffixed_amount\x18\x05 \x01(\bR\vfixedAmount\x12\x1b\n" +
+	"\tasset_ref\x18\x06 \x01(\tR\bassetRef\x12!\n" +
+	"\fasset_amount\x18\a \x01(\x04R\vassetAmount\"\x9f\x01\n" +
 	"\x0eForfeitRequest\x127\n" +
 	"\rvtxo_outpoint\x18\x01 \x01(\v2\x12.round.v1.OutpointR\fvtxoOutpoint\x12&\n" +
 	"\x0fauth_spend_path\x18\x02 \x01(\fR\rauthSpendPath\x12,\n" +

--- a/rpc/roundpb/round.proto
+++ b/rpc/roundpb/round.proto
@@ -405,6 +405,17 @@ message VTXORequest {
     // implicit-change exception is disabled and the intent must include a
     // separate fee-bearing change output if fees need to be paid.
     bool fixed_amount = 5;
+
+    // asset_ref identifies the Taproot Asset the client requests this
+    // VTXO to carry (group key reference for grouped assets). Empty for
+    // Bitcoin-only VTXOs. Asset requests are only accepted by operators
+    // running asset rounds for the same asset; they carry a fixed
+    // target_amount_sat and never act as the change output.
+    string asset_ref = 6;
+
+    // asset_amount is the requested Taproot Asset amount. Required
+    // (non-zero) when asset_ref is set, zero otherwise.
+    uint64 asset_amount = 7;
 }
 
 // ForfeitRequest specifies a VTXO the client wants to forfeit.

--- a/tapassets/tree_materializer.go
+++ b/tapassets/tree_materializer.go
@@ -248,9 +248,16 @@ func (m *TreeMaterializer) MaterializeNode(ctx context.Context, node *tree.Node,
 		params.Input, committed.packageBytes,
 	)
 
-	// Re-register the subtree total now that the node carries its input,
-	// so the amount stays resolvable on extracted or deserialized clones.
-	m.cfg.AssetContext.SetNodeAssetAmount(node, amount)
+	// Re-register the subtree total now that the node carries its
+	// input, so the amount stays resolvable on extracted or
+	// deserialized clones. The structure pass's node-keyed total is
+	// authoritative: the resolved input amount is zero for the root,
+	// whose amount the proof verifier authenticates at commit time,
+	// and writing that zero would clobber a single-leaf tree's only
+	// node.
+	m.cfg.AssetContext.SetNodeAssetAmount(
+		node, m.cfg.AssetContext.NodeAssetAmount(node),
+	)
 
 	return m.prepareChildren(
 		node, params.Input, source, committedTx, committed, outputSpecs,

--- a/waved/server_round_testhook.go
+++ b/waved/server_round_testhook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/lightninglabs/wavelength/round"
 )
 
@@ -42,6 +43,36 @@ func (s *Server) TriggerRoundRegistration(ctx context.Context) error {
 	result := future.Await(ctx)
 	if err := result.Err(); err != nil {
 		return fmt.Errorf("failed to trigger round registration: %w",
+			err)
+	}
+
+	return nil
+}
+
+// RegisterAssetVTXORequest registers one Taproot Asset VTXO request with
+// the client round actor: the next round intent asks the operator's asset
+// round for a leaf carrying assetAmount units anchored by amountSat. The
+// same context-detachment rationale as TriggerRoundRegistration applies.
+func (s *Server) RegisterAssetVTXORequest(ctx context.Context,
+	amountSat btcutil.Amount, assetRef string, assetAmount uint64) error {
+
+	if s.actorSystem == nil {
+		return fmt.Errorf("actor system not initialized")
+	}
+
+	askCtx := context.WithoutCancel(ctx)
+
+	roundRef := round.NewServiceKey().Ref(s.actorSystem)
+	future := roundRef.Ask(askCtx, &round.RegisterVTXORequestsRequest{
+		AssetRequests: []round.AssetVTXORequest{{
+			AmountSat:   amountSat,
+			AssetRef:    assetRef,
+			AssetAmount: assetAmount,
+		}},
+	})
+	result := future.Await(ctx)
+	if err := result.Err(); err != nil {
+		return fmt.Errorf("failed to register asset VTXO request: %w",
 			err)
 	}
 


### PR DESCRIPTION
Client half of Milestone 4 (asset round trees), stacked on #1091. Operator counterpart: lumos#761 — the joint acceptance runs green against real tapd there.

**What changes**

- `VTXORequest` gains `asset_ref`/`asset_amount` on the wire and in `lib/types`; the join-auth TLV binds both into the intent digest (appended only for asset requests, so Bitcoin-only digests are unchanged).
- The tree binding recompute (`verifyVTXOTreeRoot`) honors an asset tree's combined root tweak, proving the co-signed cosigner aggregate can spend the committed batch output; a tampered tweak is rejected.
- Asset requests validate through the new `tree.ValidatePathForAsset`: structural path validation and exact Bitcoin amounts as before, plus pinning of the leaf's asset identity and exact asset amount from the wire context. The composed leaf output script is deliberately not byte-verified here — that requires the leaf proof material which only arrives at spend time (Milestone 5).
- Client signing sessions pick up per-node tweaks via `TweakLookup` from the tree's asset context.
- `RegisterVTXORequestsRequest` accepts asset entries (deriving owner keys and policies like plain requests) and a waved test hook exposes it for integration harnesses.
- The intent pre-flight treats the designated change target as advisory (#270 semantics): the server stamps it with the residual at seal, so it no longer counts against the input budget — boarding plus a fixed asset VTXO request now composes.
- The tree materializer no longer clobbers a single-leaf tree's subtree total with the root's unauthenticated zero amount.
- Also folds main's mock-signer nonce fixes (#1090) beneath the ceremony commit.