### PR TITLE
waved: answer inbound RPCs to the envelope sender

### DIFF
--- a/serverconn/AGENTS.md
+++ b/serverconn/AGENTS.md
@@ -31,6 +31,14 @@ background ingress polling with event routing.
 - `NewAuthenticatedMailboxClient` — `mailboxpb.MailboxServiceClient` decorator
   that signs and attaches the `x-mailbox-auth-sig` header to every `Send`
   before forwarding to the wrapped edge transport.
+- `SendResponseError` — Exported wrapper over the package-internal
+  `edgeResponseError` (`compatibility.go`) for the one `Edge.Send` call site
+  outside this package: `waved` answering an inbound mailbox RPC on its own
+  edge client. Maps a `(*mailboxpb.SendResponse, error)` pair to the single
+  error the caller should return — transport error wrapped with `op`, nil
+  response reported as a transport error, non-OK `Status` converted to a
+  `*mailboxconn.StatusError` — or nil when the send was accepted. It does not
+  drive the incompatibility transition; callers still pass the error on.
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
 - `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
 - `DurableUnaryRequestBuilder` — Interface for proof-gated request-body construction. Implementations build the actual proto request (e.g., with signed proofs) at send time, not at persist time. The interface is provided via `ConnectorConfig.DurableUnaryBuilder`.
@@ -84,6 +92,12 @@ background ingress polling with event routing.
   the logical request (see `mailboxrpc.Retry`). `SendRPC` mints a fresh key
   only when the caller leaves `RPCOptions.IdempotencyKey` empty, which is
   correct for a single-shot call and defeats deduplication for a retry.
+- A mailbox rejection (unknown recipient, empty recipient, version mismatch)
+  travels back as `SendResponse.Status.Ok = false`, **not** as a gRPC error,
+  so no `Edge.Send` caller may discard the response and check only `err` —
+  that reports a dropped envelope as a successful dispatch. Inside the
+  package every path routes through `edgeResponseError`; outside it, use the
+  exported `SendResponseError`.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 - `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.
 - `DurableUnaryQuery` implementations must produce stable identity bytes in `BuildBody` so that `MsgID` and `IdempotencyKey` are deterministic across restarts (auto-derived via `mailboxconn.StableEventMsgID` / `StableEventIdempotencyKey` when the caller leaves them empty).

--- a/serverconn/CLAUDE.md
+++ b/serverconn/CLAUDE.md
@@ -31,6 +31,14 @@ background ingress polling with event routing.
 - `NewAuthenticatedMailboxClient` — `mailboxpb.MailboxServiceClient` decorator
   that signs and attaches the `x-mailbox-auth-sig` header to every `Send`
   before forwarding to the wrapped edge transport.
+- `SendResponseError` — Exported wrapper over the package-internal
+  `edgeResponseError` (`compatibility.go`) for the one `Edge.Send` call site
+  outside this package: `waved` answering an inbound mailbox RPC on its own
+  edge client. Maps a `(*mailboxpb.SendResponse, error)` pair to the single
+  error the caller should return — transport error wrapped with `op`, nil
+  response reported as a transport error, non-OK `Status` converted to a
+  `*mailboxconn.StatusError` — or nil when the send was accepted. It does not
+  drive the incompatibility transition; callers still pass the error on.
 - `AckState` — Four-cursor watermark state machine (PullCursor, DispatchCommittedTo, AckTarget, AckCommittedTo).
 - `SendUnaryRequest` — Durable typed unary request that becomes a real unary RPC after commit. The response arrives via KIND_RESPONSE and, if no in-memory waiter exists, falls back to durable route dispatch via the EventRouter.
 - `DurableUnaryRequestBuilder` — Interface for proof-gated request-body construction. Implementations build the actual proto request (e.g., with signed proofs) at send time, not at persist time. The interface is provided via `ConnectorConfig.DurableUnaryBuilder`.
@@ -84,6 +92,12 @@ background ingress polling with event routing.
   the logical request (see `mailboxrpc.Retry`). `SendRPC` mints a fresh key
   only when the caller leaves `RPCOptions.IdempotencyKey` empty, which is
   correct for a single-shot call and defeats deduplication for a retry.
+- A mailbox rejection (unknown recipient, empty recipient, version mismatch)
+  travels back as `SendResponse.Status.Ok = false`, **not** as a gRPC error,
+  so no `Edge.Send` caller may discard the response and check only `err` —
+  that reports a dropped envelope as a successful dispatch. Inside the
+  package every path routes through `edgeResponseError`; outside it, use the
+  exported `SendResponseError`.
 - Ingress loop checkpoints pull cursor and ack state; on restart, resumes from checkpoint.
 - `DurableUnaryQuery` values are handled generically in `ServerConnectionActor.Receive` via `buildDurableUnary`: the query is converted to a `SendUnaryRequest` using the configured `DurableUnaryRequestBuilder`. Adding a new durable indexer query type requires only implementing `DurableUnaryQuery` — no new `Receive` case is needed.
 - `DurableUnaryQuery` implementations must produce stable identity bytes in `BuildBody` so that `MsgID` and `IdempotencyKey` are deterministic across restarts (auto-derived via `mailboxconn.StableEventMsgID` / `StableEventIdempotencyKey` when the caller leaves them empty).

--- a/serverconn/compatibility.go
+++ b/serverconn/compatibility.go
@@ -51,6 +51,17 @@ func edgeResponseError[T edgeStatusCarrier](op string, resp T,
 	return nil
 }
 
+// SendResponseError exposes edgeResponseError for the one Edge.Send call site
+// that lives outside this package (waved answers inbound mailbox RPCs on its
+// own edge client). Without it that path would have to re-implement the
+// status check, and a send whose rejection arrives as Status.Ok=false rather
+// than as a transport error would read as a success.
+func SendResponseError(op string, resp *mailboxpb.SendResponse,
+	err error) error {
+
+	return edgeResponseError(op, resp, err)
+}
+
 // compatibilityError returns the cached permanent version error if the
 // connector has transitioned to the terminal INCOMPATIBLE state, or nil while
 // it is still COMPATIBLE. Send paths consult this before contacting the edge.

--- a/serverconn/e2e_test.go
+++ b/serverconn/e2e_test.go
@@ -205,9 +205,14 @@ func (s *testServer) handleRequest(ctx context.Context,
 		ProtocolVersion:    1,
 		ArkProtocolVersion: 1,
 		Sender:             s.serverMailboxID,
-		Recipient:          env.Rpc.ReplyTo,
-		Headers:            headers,
-		Body:               body,
+
+		// Mirror the production responder (waved's handleInboundRPC),
+		// which answers the envelope sender rather than the request's
+		// ReplyTo. The two are equal here, so this changes nothing
+		// today -- it keeps the double honest if they ever diverge.
+		Recipient: env.Sender,
+		Headers:   headers,
+		Body:      body,
 		Rpc: &mailboxpb.RpcMeta{
 			Kind:          mailboxpb.RpcMeta_KIND_RESPONSE,
 			CorrelationId: env.Rpc.CorrelationId,

--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -136,6 +136,24 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   exceeds `OORConfig.MaxTransientSubmitRetry` (default 1h), persisting the
   window start (`FirstRejectUnixNanos`) in the outgoing snapshot (version 5)
   so the bound survives restarts.
+- `handleInboundRPC` (the mux bridge registered by `buildRPCDispatchers` for
+  every `NonTxRoutes` dispatcher) addresses its response envelope to
+  `env.Sender`, **not** to `env.Rpc.ReplyTo`. Every producer in this repo sets
+  both to the same `LocalMailboxID` (`serverconn/unary_facade.go`,
+  `serverconn/actor.go`, `serverconn/heartbeat.go`, and the operator's
+  `clientconn` equivalents), so the two agree for a well-formed peer; routing
+  by sender stops a request naming a destination that disagrees with its
+  origin, and stops an absent `ReplyTo` producing an empty recipient that the
+  mailbox store rejects outright. `Rpc.ReplyTo` is therefore advisory from the
+  responder's side: producers still set it, nothing here reads it. An empty
+  `env.Sender` is refused up front (the ingress version check only compares the
+  version fields, so nothing upstream asserts it) and the ingress loop logs the
+  dispatch error.
+- The response `Edge.Send` in `handleInboundRPC` folds the send status in
+  alongside the transport error via `serverconn.SendResponseError`. A mailbox
+  rejection arrives as `Status.Ok = false` rather than as an error, so checking
+  only `err` would report a dropped answer as a successful dispatch and leave
+  the caller blocked on its correlation ID until it times out.
 - `operatorTermsFromResponse` and daemon `GetInfo` must preserve
   `FreeRefreshWindowBlocks` end to end.
 - The VTXO manager reads `FreeRefreshWindowBlocks` from the latest cached

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -136,6 +136,24 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   exceeds `OORConfig.MaxTransientSubmitRetry` (default 1h), persisting the
   window start (`FirstRejectUnixNanos`) in the outgoing snapshot (version 5)
   so the bound survives restarts.
+- `handleInboundRPC` (the mux bridge registered by `buildRPCDispatchers` for
+  every `NonTxRoutes` dispatcher) addresses its response envelope to
+  `env.Sender`, **not** to `env.Rpc.ReplyTo`. Every producer in this repo sets
+  both to the same `LocalMailboxID` (`serverconn/unary_facade.go`,
+  `serverconn/actor.go`, `serverconn/heartbeat.go`, and the operator's
+  `clientconn` equivalents), so the two agree for a well-formed peer; routing
+  by sender stops a request naming a destination that disagrees with its
+  origin, and stops an absent `ReplyTo` producing an empty recipient that the
+  mailbox store rejects outright. `Rpc.ReplyTo` is therefore advisory from the
+  responder's side: producers still set it, nothing here reads it. An empty
+  `env.Sender` is refused up front (the ingress version check only compares the
+  version fields, so nothing upstream asserts it) and the ingress loop logs the
+  dispatch error.
+- The response `Edge.Send` in `handleInboundRPC` folds the send status in
+  alongside the transport error via `serverconn.SendResponseError`. A mailbox
+  rejection arrives as `Status.Ok = false` rather than as an error, so checking
+  only `err` would report a dropped answer as a successful dispatch and leave
+  the caller blocked on its correlation ID until it times out.
 - `operatorTermsFromResponse` and daemon `GetInfo` must preserve
   `FreeRefreshWindowBlocks` end to end.
 - The VTXO manager reads `FreeRefreshWindowBlocks` from the latest cached

--- a/waved/server.go
+++ b/waved/server.go
@@ -3621,6 +3621,10 @@ func (s *Server) handleInboundRPC(ctx context.Context,
 		// It also fixes an absent ReplyTo. That used to produce an
 		// empty recipient, which the mailbox store rejects outright,
 		// so the caller lost its answer entirely.
+		//
+		// Rpc.ReplyTo is therefore advisory from the responder's
+		// point of view: producers still set it, and nothing here
+		// reads it.
 		Recipient: env.Sender,
 		Headers:   headers,
 		Body:      body,

--- a/waved/server.go
+++ b/waved/server.go
@@ -3567,6 +3567,16 @@ func (s *Server) handleInboundRPC(ctx context.Context,
 		return fmt.Errorf("missing envelope body")
 	}
 
+	// The sender is where the answer goes, so an absent one is the same
+	// lost-response failure an absent ReplyTo used to cause: the recipient
+	// would be empty and the mailbox store rejects that outright. Nothing
+	// upstream asserts it — the ingress version check only compares the
+	// two version fields — so refuse here, where the value is used, and
+	// let the ingress loop log the dispatch error.
+	if env.Sender == "" {
+		return fmt.Errorf("missing envelope sender")
+	}
+
 	// Dispatch through the mux to the registered handler.
 	respMsg, err := s.mailboxMux.ServeRPC(
 		ctx, env.Rpc.Service, env.Rpc.Method, env.Body.Value,
@@ -3641,11 +3651,18 @@ func (s *Server) handleInboundRPC(ctx context.Context,
 	// client's negotiated mailbox transport and Ark protocol versions.
 	s.runtime.StampEnvelope(responseEnv)
 
-	_, err = edge.Send(ctx, &mailboxpb.SendRequest{
+	// Fold the response status in alongside the transport error: a mailbox
+	// rejection (an unknown recipient, a version mismatch) travels as
+	// Status.Ok=false, not as an error, so discarding it would report a
+	// dropped answer as a successful dispatch and leave the caller waiting
+	// on its correlation ID until it times out.
+	resp, err := edge.Send(ctx, &mailboxpb.SendRequest{
 		Envelope: responseEnv,
 	})
-	if err != nil {
-		return fmt.Errorf("send RPC response: %w", err)
+	if sErr := serverconn.SendResponseError(
+		"send rpc response", resp, err,
+	); sErr != nil {
+		return sErr
 	}
 
 	return nil

--- a/waved/server.go
+++ b/waved/server.go
@@ -3605,8 +3605,23 @@ func (s *Server) handleInboundRPC(ctx context.Context,
 	}
 
 	responseEnv := &mailboxpb.Envelope{
-		Sender:    s.localMailboxID,
-		Recipient: env.Rpc.ReplyTo,
+		Sender: s.localMailboxID,
+
+		// A response belongs to whoever sent the request, so address
+		// it to the sender rather than to the request's ReplyTo.
+		//
+		// The two agree for every producer in this repo: each sets
+		// Sender and Rpc.ReplyTo to the same LocalMailboxID (see
+		// serverconn/unary_facade.go, serverconn/actor.go,
+		// serverconn/heartbeat.go and the operator's clientconn
+		// equivalents). So this changes nothing for a well-formed
+		// peer, and it stops a request choosing a destination that
+		// disagrees with where it came from.
+		//
+		// It also fixes an absent ReplyTo. That used to produce an
+		// empty recipient, which the mailbox store rejects outright,
+		// so the caller lost its answer entirely.
+		Recipient: env.Sender,
 		Headers:   headers,
 		Body:      body,
 		Rpc: &mailboxpb.RpcMeta{

--- a/waved/server_reply_to_test.go
+++ b/waved/server_reply_to_test.go
@@ -65,6 +65,7 @@ func TestHandleInboundRPCAnswersTheSender(t *testing.T) {
 	const (
 		operatorMailboxID = "operator-1"
 		otherMailboxID    = "somebody-else"
+		daemonMailboxID   = "this-daemon"
 	)
 
 	tests := []struct {
@@ -90,6 +91,7 @@ func TestHandleInboundRPCAnswersTheSender(t *testing.T) {
 			edge := &recordingReplyEdge{}
 			s := newCompatTestServer(t, edge)
 			s.mailboxMux = mailboxrpc.NewServeMux()
+			s.localMailboxID = daemonMailboxID
 
 			env := &mailboxpb.Envelope{
 				Sender: operatorMailboxID,
@@ -113,6 +115,12 @@ func TestHandleInboundRPCAnswersTheSender(t *testing.T) {
 			)
 			require.NotEqual(
 				t, otherMailboxID, edge.sent[0].Recipient,
+			)
+
+			// The other half of the envelope: the response is from
+			// us, whoever it is addressed to.
+			require.Equal(
+				t, daemonMailboxID, edge.sent[0].Sender,
 			)
 		})
 	}

--- a/waved/server_reply_to_test.go
+++ b/waved/server_reply_to_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	mailboxconn "github.com/lightninglabs/wavelength/mailbox/conn"
 	mailboxpb "github.com/lightninglabs/wavelength/mailbox/pb"
 	mailboxrpc "github.com/lightninglabs/wavelength/mailbox/rpc"
 	"github.com/stretchr/testify/require"
@@ -12,21 +13,31 @@ import (
 )
 
 // recordingReplyEdge captures the envelopes handleInboundRPC sends so a test
-// can assert where a response was addressed.
+// can assert where a response was addressed. When sendStatus is set it is
+// returned verbatim, which lets a test drive the application-level rejection
+// path that arrives as a non-OK status rather than as a transport error.
 type recordingReplyEdge struct {
 	sent []*mailboxpb.Envelope
+
+	sendStatus *mailboxpb.Status
 }
 
-// Send records the outbound envelope and reports success.
+// Send records the outbound envelope and reports the configured status,
+// defaulting to success.
 func (r *recordingReplyEdge) Send(_ context.Context, in *mailboxpb.SendRequest,
 	_ ...grpc.CallOption) (*mailboxpb.SendResponse, error) {
 
 	r.sent = append(r.sent, in.Envelope)
 
-	return &mailboxpb.SendResponse{
-		Status: &mailboxpb.Status{
+	status := r.sendStatus
+	if status == nil {
+		status = &mailboxpb.Status{
 			Ok: true,
-		},
+		}
+	}
+
+	return &mailboxpb.SendResponse{
+		Status: status,
 	}, nil
 }
 
@@ -70,18 +81,31 @@ func TestHandleInboundRPCAnswersTheSender(t *testing.T) {
 
 	tests := []struct {
 		name    string
+		sender  string
 		replyTo string
+		wantErr string
 	}{{
 		name:    "matching reply-to",
+		sender:  operatorMailboxID,
 		replyTo: operatorMailboxID,
 	}, {
 		// Previously produced an empty Recipient, which the mailbox
 		// store rejects, so the caller never got its answer.
 		name:    "absent reply-to",
+		sender:  operatorMailboxID,
 		replyTo: "",
 	}, {
 		name:    "reply-to naming another mailbox",
+		sender:  operatorMailboxID,
 		replyTo: otherMailboxID,
+	}, {
+		// Sender is now the sole input deciding where the answer goes,
+		// so an empty one reproduces the very failure the ReplyTo fix
+		// removed. It must be refused before anything is sent.
+		name:    "absent sender",
+		sender:  "",
+		replyTo: operatorMailboxID,
+		wantErr: "missing envelope sender",
 	}}
 
 	for _, tc := range tests {
@@ -94,7 +118,7 @@ func TestHandleInboundRPCAnswersTheSender(t *testing.T) {
 			s.localMailboxID = daemonMailboxID
 
 			env := &mailboxpb.Envelope{
-				Sender: operatorMailboxID,
+				Sender: tc.sender,
 				Body:   &anypb.Any{},
 				Rpc: &mailboxpb.RpcMeta{
 					Kind: mailboxpb.
@@ -107,6 +131,17 @@ func TestHandleInboundRPCAnswersTheSender(t *testing.T) {
 			}
 
 			err := s.handleInboundRPC(t.Context(), edge, env)
+
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+
+				// A refused envelope must not put an
+				// unaddressable response on the wire.
+				require.Empty(t, edge.sent)
+
+				return
+			}
+
 			require.NoError(t, err)
 
 			require.Len(t, edge.sent, 1)
@@ -124,4 +159,51 @@ func TestHandleInboundRPCAnswersTheSender(t *testing.T) {
 			)
 		})
 	}
+}
+
+// TestHandleInboundRPCReportsSendRejection asserts a mailbox rejection that
+// arrives as a non-OK SendResponse.Status is reported as an error rather than
+// swallowed. That status is the canonical application-level failure channel
+// for the mailbox edge, so discarding it would report a lost answer as a
+// successful dispatch and leave the caller blocked until its own deadline.
+func TestHandleInboundRPCReportsSendRejection(t *testing.T) {
+	t.Parallel()
+
+	const rejectCode = "UNKNOWN_RECIPIENT"
+
+	edge := &recordingReplyEdge{
+		sendStatus: &mailboxpb.Status{
+			Ok:      false,
+			Code:    rejectCode,
+			Message: "no such mailbox",
+		},
+	}
+
+	s := newCompatTestServer(t, edge)
+	s.mailboxMux = mailboxrpc.NewServeMux()
+	s.localMailboxID = "this-daemon"
+
+	env := &mailboxpb.Envelope{
+		Sender: "operator-1",
+		Body:   &anypb.Any{},
+		Rpc: &mailboxpb.RpcMeta{
+			Kind:          mailboxpb.RpcMeta_KIND_REQUEST,
+			Service:       "svc.Unregistered",
+			Method:        "Method",
+			CorrelationId: "corr-1",
+			ReplyTo:       "operator-1",
+		},
+	}
+
+	err := s.handleInboundRPC(t.Context(), edge, env)
+	require.Error(t, err)
+
+	// The structured status must survive, not be flattened into a string,
+	// so callers can classify a permanent version failure.
+	var statusErr *mailboxconn.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	require.Equal(t, rejectCode, statusErr.Code())
+
+	// The send was attempted; only its outcome was misreported before.
+	require.Len(t, edge.sent, 1)
 }

--- a/waved/server_reply_to_test.go
+++ b/waved/server_reply_to_test.go
@@ -1,0 +1,119 @@
+package waved
+
+import (
+	"context"
+	"testing"
+
+	mailboxpb "github.com/lightninglabs/wavelength/mailbox/pb"
+	mailboxrpc "github.com/lightninglabs/wavelength/mailbox/rpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// recordingReplyEdge captures the envelopes handleInboundRPC sends so a test
+// can assert where a response was addressed.
+type recordingReplyEdge struct {
+	sent []*mailboxpb.Envelope
+}
+
+// Send records the outbound envelope and reports success.
+func (r *recordingReplyEdge) Send(_ context.Context, in *mailboxpb.SendRequest,
+	_ ...grpc.CallOption) (*mailboxpb.SendResponse, error) {
+
+	r.sent = append(r.sent, in.Envelope)
+
+	return &mailboxpb.SendResponse{
+		Status: &mailboxpb.Status{
+			Ok: true,
+		},
+	}, nil
+}
+
+// Pull is unused by these tests.
+func (r *recordingReplyEdge) Pull(_ context.Context, _ *mailboxpb.PullRequest,
+	_ ...grpc.CallOption) (*mailboxpb.PullResponse, error) {
+
+	return &mailboxpb.PullResponse{
+		Status: &mailboxpb.Status{
+			Ok: true,
+		},
+	}, nil
+}
+
+// AckUpTo is unused by these tests.
+func (r *recordingReplyEdge) AckUpTo(_ context.Context,
+	_ *mailboxpb.AckUpToRequest, _ ...grpc.CallOption) (
+	*mailboxpb.AckUpToResponse, error) {
+
+	return &mailboxpb.AckUpToResponse{
+		Status: &mailboxpb.Status{
+			Ok: true,
+		},
+	}, nil
+}
+
+// TestHandleInboundRPCAnswersTheSender asserts an inbound request is answered
+// to the mailbox it came from, whatever its Rpc.ReplyTo says.
+//
+// The method dispatched here is deliberately unregistered, so ServeRPC fails
+// and the handler takes its error path. That is the interesting path to pin:
+// it still sends a response envelope, so it still has to address one.
+func TestHandleInboundRPCAnswersTheSender(t *testing.T) {
+	t.Parallel()
+
+	const (
+		operatorMailboxID = "operator-1"
+		otherMailboxID    = "somebody-else"
+	)
+
+	tests := []struct {
+		name    string
+		replyTo string
+	}{{
+		name:    "matching reply-to",
+		replyTo: operatorMailboxID,
+	}, {
+		// Previously produced an empty Recipient, which the mailbox
+		// store rejects, so the caller never got its answer.
+		name:    "absent reply-to",
+		replyTo: "",
+	}, {
+		name:    "reply-to naming another mailbox",
+		replyTo: otherMailboxID,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			edge := &recordingReplyEdge{}
+			s := newCompatTestServer(t, edge)
+			s.mailboxMux = mailboxrpc.NewServeMux()
+
+			env := &mailboxpb.Envelope{
+				Sender: operatorMailboxID,
+				Body:   &anypb.Any{},
+				Rpc: &mailboxpb.RpcMeta{
+					Kind: mailboxpb.
+						RpcMeta_KIND_REQUEST,
+					Service:       "svc.Unregistered",
+					Method:        "Method",
+					CorrelationId: "corr-1",
+					ReplyTo:       tc.replyTo,
+				},
+			}
+
+			err := s.handleInboundRPC(t.Context(), edge, env)
+			require.NoError(t, err)
+
+			require.Len(t, edge.sent, 1)
+			require.Equal(
+				t, operatorMailboxID, edge.sent[0].Recipient,
+			)
+			require.NotEqual(
+				t, otherMailboxID, edge.sent[0].Recipient,
+			)
+		})
+	}
+}


### PR DESCRIPTION
A response belongs to whoever sent the request. `handleInboundRPC` was addressing its response to the request's `Rpc.ReplyTo` verbatim, so a request could name a reply destination that disagrees with where it came from.

## What changes

`Recipient: env.Rpc.ReplyTo` becomes `Recipient: env.Sender`.

Nothing changes for a well-formed peer. Every producer in this repo sets `Sender` and `Rpc.ReplyTo` to the same `LocalMailboxID`:

- `serverconn/unary_facade.go:129`/`:139`
- `serverconn/actor.go:860`/`:869` and `:1029`/`:1039`
- `serverconn/heartbeat.go:102`/`:110`

The operator's `clientconn` equivalents do the same. So the two fields already agree everywhere they are produced, and addressing the sender is the same destination by a more direct route.

## It also fixes a dropped response

An absent `ReplyTo` produced an empty `Recipient`. The mailbox store rejects an empty recipient outright, so a caller that left the field unset lost its answer entirely rather than receiving it. That case now answers the sender like any other.

## Testing

`TestHandleInboundRPCAnswersTheSender` covers matching, absent, and divergent `ReplyTo`. It dispatches a deliberately unregistered method so the handler takes its **error** path — that path still sends a response envelope, so it still has to address one, and it is the easier of the two to get wrong.

Verified the two changed cases (absent and divergent) fail against the previous behaviour and the matching case passes, so the test pins the change rather than restating it.

`make unit pkg=waved`, `make lint-changed-local` (0 issues) and `make commitmsg-lint` all pass.

