### PR TITLE
roundpb: reject VTXO trees that share a child

### DIFF
--- a/arkrpc/AGENTS.md
+++ b/arkrpc/AGENTS.md
@@ -34,5 +34,17 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
 - **Never edit generated code** — regenerate via `make rpc`.
 - Conversion round-trip: `TreePathFromTree(t)` → `TreePathToTree(pb)` must
   reproduce the original tree (excluding derived `FinalKey` fields).
+- `TreePathToTree` sits on the untrusted indexer receive path
+  (`vtxo.AncestryFromRPC` → `AncestryPathToTree`), so it validates the
+  decoded shape rather than trusting it: pre-order child indices (no
+  cycles), single parent (no node named as a child twice), full
+  reachability from index 0 (one connected tree, not a forest), index
+  bounds, and a node cap (`DefaultMaxTreePathNodes`, overridable via
+  `WithMaxTreePathNodes`). Single-parent is the load-bearing one:
+  `Children` is a map, so one node can point every output at the same
+  next node, and `nodeMaxDepth` — which the receive path runs on this
+  tree to validate the claimed ancestry depth — has no memoization, so a
+  shared child multiplies its work by the number of paths reaching it.
+  These mirror `roundpb.TreeFromProto`; keep the two decoders in step.
 - Child iteration during flattening is sorted by output index for
   deterministic serialization.

--- a/arkrpc/CLAUDE.md
+++ b/arkrpc/CLAUDE.md
@@ -34,5 +34,17 @@ Proto source: `arkrpc/ark.proto`, `arkrpc/indexer.proto`.
 - **Never edit generated code** — regenerate via `make rpc`.
 - Conversion round-trip: `TreePathFromTree(t)` → `TreePathToTree(pb)` must
   reproduce the original tree (excluding derived `FinalKey` fields).
+- `TreePathToTree` sits on the untrusted indexer receive path
+  (`vtxo.AncestryFromRPC` → `AncestryPathToTree`), so it validates the
+  decoded shape rather than trusting it: pre-order child indices (no
+  cycles), single parent (no node named as a child twice), full
+  reachability from index 0 (one connected tree, not a forest), index
+  bounds, and a node cap (`DefaultMaxTreePathNodes`, overridable via
+  `WithMaxTreePathNodes`). Single-parent is the load-bearing one:
+  `Children` is a map, so one node can point every output at the same
+  next node, and `nodeMaxDepth` — which the receive path runs on this
+  tree to validate the claimed ancestry depth — has no memoization, so a
+  shared child multiplies its work by the number of paths reaching it.
+  These mirror `roundpb.TreeFromProto`; keep the two decoders in step.
 - Child iteration during flattening is sorted by output index for
   deterministic serialization.

--- a/arkrpc/tree_path_convert.go
+++ b/arkrpc/tree_path_convert.go
@@ -37,15 +37,65 @@ func TreePathFromTree(t *tree.Tree) (*TreePath, error) {
 	}, nil
 }
 
+// DefaultMaxTreePathNodes is the upper bound on the number of nodes
+// allowed in a TreePath decoded from an indexer response. A path is a
+// slice through a commitment tree, so it is far smaller than a whole
+// tree in practice; the bound is deliberately set to the same generous
+// figure roundpb.DefaultMaxTreeNodes uses for a full tree, so the two
+// decode boundaries agree and no shape that survives one is rejected by
+// the other purely on size.
+const DefaultMaxTreePathNodes = 50_000
+
+// TreePathToTreeOption is a functional option for TreePathToTree that
+// allows callers to override default validation parameters.
+type TreePathToTreeOption func(*treePathToTreeConfig)
+
+// treePathToTreeConfig holds configurable validation parameters for tree
+// path deserialization.
+type treePathToTreeConfig struct {
+	maxNodes int
+}
+
+// defaultTreePathToTreeConfig returns the default configuration.
+func defaultTreePathToTreeConfig() treePathToTreeConfig {
+	return treePathToTreeConfig{
+		maxNodes: DefaultMaxTreePathNodes,
+	}
+}
+
+// WithMaxTreePathNodes sets the maximum number of nodes allowed in a
+// deserialized TreePath. A value of 0 disables the limit.
+func WithMaxTreePathNodes(maxNodes int) TreePathToTreeOption {
+	return func(cfg *treePathToTreeConfig) {
+		cfg.maxNodes = maxNodes
+	}
+}
+
 // TreePathToTree converts a proto TreePath back to a tree.Tree by
 // reconstructing the recursive node structure from the flattened nodes.
-func TreePathToTree(tp *TreePath) (*tree.Tree, error) {
+//
+// This sits on the indexer receive path, which treats responses as
+// untrusted, so the reconstructed shape is validated to be exactly one
+// connected tree rather than merely an acyclic graph.
+func TreePathToTree(tp *TreePath,
+	opts ...TreePathToTreeOption) (*tree.Tree, error) {
+
 	if tp == nil {
 		return nil, nil
 	}
 
+	cfg := defaultTreePathToTreeConfig()
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	if len(tp.Nodes) == 0 {
 		return nil, fmt.Errorf("empty tree path nodes")
+	}
+
+	if cfg.maxNodes > 0 && len(tp.Nodes) > cfg.maxNodes {
+		return nil, fmt.Errorf("tree path has %d nodes, exceeds "+
+			"maximum %d", len(tp.Nodes), cfg.maxNodes)
 	}
 
 	// Convert all proto nodes to Go nodes.
@@ -58,7 +108,26 @@ func TreePathToTree(tp *TreePath) (*tree.Tree, error) {
 		goNodes[i] = node
 	}
 
-	// Wire up children references with pre-order invariant.
+	// Wire up children references. The pre-order invariant
+	// (childIdx > i) rules out cycles, but on its own it still
+	// admits a DAG: two parents at different indices can both name
+	// the same higher-indexed child and both satisfy it.
+	//
+	// That matters most here. Children is a map, so one node may
+	// point all of its outputs at the same next node, and every
+	// recursive walk over the result then re-visits the shared
+	// subtree once per path that reaches it. nodeMaxDepth, which the
+	// receive path runs on this very tree to validate the claimed
+	// ancestry depth, is exactly such a walk: it has no memoization,
+	// so a shared child turns a linear-sized message into
+	// exponentially many paths.
+	//
+	// parentOf records the parent that claimed each child, so a
+	// second claim can name both of them. The bounds check runs
+	// first so a wild index is reported as out of range rather than
+	// as a sharing violation.
+	parentOf := make(map[uint32]int, len(tp.Nodes))
+
 	for i, pn := range tp.Nodes {
 		for outIdx, childIdx := range pn.Children {
 			if childIdx <= uint32(i) {
@@ -72,6 +141,14 @@ func TreePathToTree(tp *TreePath) (*tree.Tree, error) {
 					"%d out of range", i, childIdx)
 			}
 
+			if prev, dup := parentOf[childIdx]; dup {
+				return nil, fmt.Errorf("node[%d] child index "+
+					"%d is already a child of node[%d]; "+
+					"tree must not share children", i,
+					childIdx, prev)
+			}
+			parentOf[childIdx] = i
+
 			if int(outIdx) >= len(goNodes[i].Outputs) {
 				return nil, fmt.Errorf("node[%d] child output "+
 					"index %d out of range (node has %d "+
@@ -81,6 +158,20 @@ func TreePathToTree(tp *TreePath) (*tree.Tree, error) {
 
 			goNodes[i].Children[outIdx] = goNodes[childIdx]
 		}
+	}
+
+	// Single-parent plus forward-edges describes a forest, not a
+	// tree: nothing above requires a node to be reachable from index
+	// 0. Every node other than the root must be claimed exactly
+	// once, so counting the claims pins the shape to one connected
+	// tree and rejects both padding with unreachable nodes and a
+	// second detached root carrying its own subtree.
+	// flattenTreePathNode always emits exactly this shape, so no
+	// well-formed producer is affected.
+	if len(parentOf) != len(tp.Nodes)-1 {
+		return nil, fmt.Errorf("tree path has %d nodes but only %d "+
+			"are claimed as children; unreachable nodes or "+
+			"multiple roots", len(tp.Nodes), len(parentOf))
 	}
 
 	batchOP, err := outpointFromProto(tp.BatchOutpoint)

--- a/arkrpc/tree_path_shape_test.go
+++ b/arkrpc/tree_path_shape_test.go
@@ -1,0 +1,297 @@
+package arkrpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// shapeTestOutputs is the number of outputs every synthetic node in this
+// file carries. Two is the smallest count that lets a node name two
+// distinct children, which is what the DAG shapes below need.
+const shapeTestOutputs = 2
+
+// shapeNode builds a minimal, structurally valid TreePathNode carrying
+// the given child wiring. Only the shape matters to these tests, so the
+// payload fields are filled with the cheapest values the decoder
+// accepts.
+func shapeNode(idx uint32, children map[uint32]uint32) *TreePathNode {
+	hash := chainhash.Hash{byte(idx + 1)}
+
+	outputs := make([]*TxOut, shapeTestOutputs)
+	for i := range outputs {
+		outputs[i] = &TxOut{
+			Value: 1000,
+			PkScript: []byte{
+				0x51,
+			},
+		}
+	}
+
+	return &TreePathNode{
+		Input: &OutPoint{
+			Txid: hash[:],
+			Vout: idx,
+		},
+		Outputs:  outputs,
+		Children: children,
+		Amount:   2000,
+	}
+}
+
+// shapePath wraps nodes into a TreePath with a valid batch outpoint and
+// output, so any error a test observes comes from the node wiring rather
+// than from the surrounding fields.
+func shapePath(nodes ...*TreePathNode) *TreePath {
+	hash := chainhash.Hash{0xba}
+
+	return &TreePath{
+		Nodes: nodes,
+		BatchOutpoint: &OutPoint{
+			Txid: hash[:],
+			Vout: 0,
+		},
+		BatchOutput: &TxOut{
+			Value: 2000,
+			PkScript: []byte{
+				0x51,
+			},
+		},
+	}
+}
+
+// TestTreePathToTreeRejectsSharedChild pins the single-parent invariant
+// on the indexer decode path. Forward references alone admit a DAG: two
+// parents at different indices can both name the same higher-indexed
+// child and both satisfy childIdx > i. That shape is the expensive one
+// here, because the receive path walks the decoded tree to validate the
+// claimed ancestry depth and that walk re-visits a shared subtree once
+// per path reaching it.
+func TestTreePathToTreeRejectsSharedChild(t *testing.T) {
+	t.Parallel()
+
+	// Root fans out to 1 and 2; both then name 3.
+	tp := shapePath(
+		shapeNode(
+			0, map[uint32]uint32{
+				0: 1,
+				1: 2,
+			},
+		),
+		shapeNode(
+			1, map[uint32]uint32{
+				0: 3,
+			},
+		),
+		shapeNode(
+			2, map[uint32]uint32{
+				0: 3,
+			},
+		),
+		shapeNode(3, nil),
+	)
+
+	got, err := TreePathToTree(tp)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "must not share children")
+	require.Nil(t, got)
+}
+
+// TestTreePathToTreeRejectsSharedChildViaSiblingOutputs covers the
+// cheapest form of the same shape: one node pointing several of its own
+// outputs at the same next node. Children is a map keyed by output
+// index, so this needs no second parent at all, and it is what turns a
+// depth-d chain into 2^d walk paths from only d nodes.
+func TestTreePathToTreeRejectsSharedChildViaSiblingOutputs(t *testing.T) {
+	t.Parallel()
+
+	tp := shapePath(
+		shapeNode(
+			0, map[uint32]uint32{
+				0: 1,
+				1: 1,
+			},
+		),
+		shapeNode(1, nil),
+	)
+
+	got, err := TreePathToTree(tp)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "must not share children")
+	require.Nil(t, got)
+}
+
+// TestTreePathToTreeRejectsUnreachableNodes covers the shapes that
+// single-parent plus forward-edges still admits: those describe a
+// forest, so a sender can pad a message with nodes no walk from the root
+// will ever reach, or attach a whole second root with its own subtree.
+func TestTreePathToTreeRejectsUnreachableNodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		nodes []*TreePathNode
+	}{{
+		// The root claims nothing, so node 1 is simply detached.
+		name: "orphan node",
+		nodes: []*TreePathNode{
+			shapeNode(0, nil),
+			shapeNode(1, nil),
+		},
+	}, {
+		// Node 1 is a second root carrying its own subtree.
+		name: "detached second root",
+		nodes: []*TreePathNode{
+			shapeNode(0, nil),
+			shapeNode(1, map[uint32]uint32{0: 2}),
+			shapeNode(2, nil),
+		},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := TreePathToTree(shapePath(tc.nodes...))
+			require.Error(t, err)
+			require.ErrorContains(
+				t, err, "unreachable nodes or multiple roots",
+			)
+			require.Nil(t, got)
+		})
+	}
+}
+
+// TestTreePathToTreeReportsWildIndexAsOutOfRange checks the diagnostic
+// ordering: an index past the end of the node slice must be named as
+// out of range even when it repeats, rather than being reported as a
+// sharing violation that sends a reader hunting for a tree-shape bug.
+func TestTreePathToTreeReportsWildIndexAsOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	tp := shapePath(
+		shapeNode(
+			0, map[uint32]uint32{
+				0: 999,
+				1: 999,
+			},
+		),
+		shapeNode(1, nil),
+	)
+
+	got, err := TreePathToTree(tp)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "out of range")
+	require.NotContains(t, err.Error(), "share children")
+	require.Nil(t, got)
+}
+
+// TestTreePathToTreeNodeCap covers the node bound. The decoder had none
+// at all, so a single response could carry an arbitrary number of nodes
+// to deserialize before any structural check ran.
+func TestTreePathToTreeNodeCap(t *testing.T) {
+	t.Parallel()
+
+	// A linear chain long enough to exceed the cap set below.
+	const chainLen = 8
+
+	nodes := make([]*TreePathNode, chainLen)
+	for i := range nodes {
+		var children map[uint32]uint32
+		if i < chainLen-1 {
+			children = map[uint32]uint32{0: uint32(i + 1)}
+		}
+		nodes[i] = shapeNode(uint32(i), children)
+	}
+	tp := shapePath(nodes...)
+
+	// Over the cap: refused before any node is deserialized.
+	got, err := TreePathToTree(tp, WithMaxTreePathNodes(chainLen-1))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "exceeds maximum")
+	require.Nil(t, got)
+
+	// At the cap, and with the cap disabled, the same chain decodes.
+	for _, maxNodes := range []int{chainLen, 0} {
+		t.Run(fmt.Sprintf("max=%d", maxNodes), func(t *testing.T) {
+			t.Parallel()
+
+			got, err := TreePathToTree(
+				tp, WithMaxTreePathNodes(maxNodes),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+		})
+	}
+}
+
+// TestTreePathToTreeAcceptsWellFormedTree guards against the new checks
+// rejecting anything a legitimate producer emits: a plain branching tree
+// where every node other than the root is claimed exactly once must
+// still decode, and the wiring must survive.
+func TestTreePathToTreeAcceptsWellFormedTree(t *testing.T) {
+	t.Parallel()
+
+	tp := shapePath(
+		shapeNode(
+			0, map[uint32]uint32{
+				0: 1,
+				1: 2,
+			},
+		),
+		shapeNode(
+			1, map[uint32]uint32{
+				0: 3,
+			},
+		),
+		shapeNode(2, nil),
+		shapeNode(3, nil),
+	)
+
+	got, err := TreePathToTree(tp)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Root.Children, 2)
+	require.Len(t, got.Root.Children[0].Children, 1)
+	require.Empty(t, got.Root.Children[1].Children)
+}
+
+// TestAncestryPathDepthWalkOnSharedChild pins the reason the check
+// belongs at this boundary rather than in each walker. nodeMaxDepth,
+// which the receive path runs on every decoded ancestry path, has no
+// memoization, so a shared child multiplies its work by the number of
+// paths reaching it. Refusing the shape at decode time means the walk
+// is never handed one.
+func TestAncestryPathDepthWalkOnSharedChild(t *testing.T) {
+	t.Parallel()
+
+	// A chain where every node points both of its outputs at the
+	// next one: linear in nodes, exponential in root-to-leaf paths.
+	const chainLen = 20
+
+	nodes := make([]*TreePathNode, chainLen)
+	for i := range nodes {
+		var children map[uint32]uint32
+		if i < chainLen-1 {
+			children = map[uint32]uint32{
+				0: uint32(i + 1),
+				1: uint32(i + 1),
+			}
+		}
+		nodes[i] = shapeNode(uint32(i), children)
+	}
+
+	hash := chainhash.Hash{0xac}
+	ap := &AncestryPath{
+		TreePath:       shapePath(nodes...),
+		CommitmentTxid: hash[:],
+		TreeDepth:      chainLen,
+	}
+
+	got, err := AncestryPathToTree(ap)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "must not share children")
+	require.Nil(t, got)
+}

--- a/arkrpc/treeconv/AGENTS.md
+++ b/arkrpc/treeconv/AGENTS.md
@@ -13,9 +13,10 @@ full `arkrpc` gRPC surface.
   to `arkrpc.TreePathFromTree`; converts a `lib/tree.Tree` to its proto
   wire representation using deterministic pre-order flattening with sorted
   child indices.
-- `TreePathToTree(tp *arkrpc.TreePath) (*tree.Tree, error)` — Delegates to
-  `arkrpc.TreePathToTree`; converts a proto `TreePath` back to a
-  `lib/tree.Tree`.
+- `TreePathToTree(tp *arkrpc.TreePath, opts ...arkrpc.TreePathToTreeOption)
+  (*tree.Tree, error)` — Delegates to `arkrpc.TreePathToTree`; converts a
+  proto `TreePath` back to a `lib/tree.Tree`, validating the decoded
+  shape. Options are forwarded verbatim.
 
 ## Relationships
 

--- a/arkrpc/treeconv/CLAUDE.md
+++ b/arkrpc/treeconv/CLAUDE.md
@@ -13,9 +13,10 @@ full `arkrpc` gRPC surface.
   to `arkrpc.TreePathFromTree`; converts a `lib/tree.Tree` to its proto
   wire representation using deterministic pre-order flattening with sorted
   child indices.
-- `TreePathToTree(tp *arkrpc.TreePath) (*tree.Tree, error)` — Delegates to
-  `arkrpc.TreePathToTree`; converts a proto `TreePath` back to a
-  `lib/tree.Tree`.
+- `TreePathToTree(tp *arkrpc.TreePath, opts ...arkrpc.TreePathToTreeOption)
+  (*tree.Tree, error)` — Delegates to `arkrpc.TreePathToTree`; converts a
+  proto `TreePath` back to a `lib/tree.Tree`, validating the decoded
+  shape. Options are forwarded verbatim.
 
 ## Relationships
 

--- a/arkrpc/treeconv/tree_path_convert.go
+++ b/arkrpc/treeconv/tree_path_convert.go
@@ -11,7 +11,11 @@ func TreePathFromTree(t *tree.Tree) (*arkrpc.TreePath, error) {
 	return arkrpc.TreePathFromTree(t)
 }
 
-// TreePathToTree converts a proto TreePath back into a tree.Tree.
-func TreePathToTree(tp *arkrpc.TreePath) (*tree.Tree, error) {
-	return arkrpc.TreePathToTree(tp)
+// TreePathToTree converts a proto TreePath back into a tree.Tree. The
+// options are forwarded verbatim so a caller on this narrow import path
+// can still override the decoder's validation bounds.
+func TreePathToTree(tp *arkrpc.TreePath,
+	opts ...arkrpc.TreePathToTreeOption) (*tree.Tree, error) {
+
+	return arkrpc.TreePathToTree(tp, opts...)
 }

--- a/rpc/roundpb/AGENTS.md
+++ b/rpc/roundpb/AGENTS.md
@@ -52,9 +52,14 @@ distinction.
 - Method name constants in `service.go` must match the proto service
   definition; mismatches silently drop events at the mailbox router.
 - `TreeFromProto` enforces a pre-order invariant (child index > parent
-  index) and bounds child/output indices; this is what prevents a
-  malicious server from encoding cycles or out-of-range references in a
-  `VTXOTree` and DoS-ing tree traversal. Do not relax these checks.
+  index), a **single-parent** invariant (no node may be named as a child
+  twice), and bounds on child/output indices; this is what prevents a
+  malicious server from encoding cycles, shared children, or
+  out-of-range references in a `VTXOTree` and DoS-ing tree traversal. Do
+  not relax these checks. The pre-order check alone does **not** imply
+  single-parent: two parents at indices 0 and 1 can both name child 5
+  and both satisfy `childIdx > i`, which decodes a DAG whose shared
+  subtree every recursive walk re-visits once per path reaching it.
 - `ValidateFlowVersion` must reject any `FlowVersion` other than the
   versions this build implements (currently only `FlowVersionV1`); never
   make it permissive by default.

--- a/rpc/roundpb/AGENTS.md
+++ b/rpc/roundpb/AGENTS.md
@@ -60,6 +60,16 @@ distinction.
   single-parent: two parents at indices 0 and 1 can both name child 5
   and both satisfy `childIdx > i`, which decodes a DAG whose shared
   subtree every recursive walk re-visits once per path reaching it.
+- `TreeFromProto` additionally requires every node other than the root
+  to be claimed exactly once, so the decoded shape is a single connected
+  tree rather than a forest. Without it a sender can pad a message up to
+  the node cap with nodes no walk from `Root` reaches, each of which is
+  still deserialized and run through `tree.ComputeFinalKey`.
+- The same three structural invariants plus a node cap
+  (`DefaultMaxTreePathNodes`) are enforced by `arkrpc.TreePathToTree`,
+  the sibling decoder on the untrusted indexer receive path. Keep the
+  two in step: a shape rejected by one and accepted by the other is a
+  gap, not a difference in trust level.
 - `ValidateFlowVersion` must reject any `FlowVersion` other than the
   versions this build implements (currently only `FlowVersionV1`); never
   make it permissive by default.

--- a/rpc/roundpb/CLAUDE.md
+++ b/rpc/roundpb/CLAUDE.md
@@ -52,9 +52,14 @@ distinction.
 - Method name constants in `service.go` must match the proto service
   definition; mismatches silently drop events at the mailbox router.
 - `TreeFromProto` enforces a pre-order invariant (child index > parent
-  index) and bounds child/output indices; this is what prevents a
-  malicious server from encoding cycles or out-of-range references in a
-  `VTXOTree` and DoS-ing tree traversal. Do not relax these checks.
+  index), a **single-parent** invariant (no node may be named as a child
+  twice), and bounds on child/output indices; this is what prevents a
+  malicious server from encoding cycles, shared children, or
+  out-of-range references in a `VTXOTree` and DoS-ing tree traversal. Do
+  not relax these checks. The pre-order check alone does **not** imply
+  single-parent: two parents at indices 0 and 1 can both name child 5
+  and both satisfy `childIdx > i`, which decodes a DAG whose shared
+  subtree every recursive walk re-visits once per path reaching it.
 - `ValidateFlowVersion` must reject any `FlowVersion` other than the
   versions this build implements (currently only `FlowVersionV1`); never
   make it permissive by default.

--- a/rpc/roundpb/CLAUDE.md
+++ b/rpc/roundpb/CLAUDE.md
@@ -60,6 +60,16 @@ distinction.
   single-parent: two parents at indices 0 and 1 can both name child 5
   and both satisfy `childIdx > i`, which decodes a DAG whose shared
   subtree every recursive walk re-visits once per path reaching it.
+- `TreeFromProto` additionally requires every node other than the root
+  to be claimed exactly once, so the decoded shape is a single connected
+  tree rather than a forest. Without it a sender can pad a message up to
+  the node cap with nodes no walk from `Root` reaches, each of which is
+  still deserialized and run through `tree.ComputeFinalKey`.
+- The same three structural invariants plus a node cap
+  (`DefaultMaxTreePathNodes`) are enforced by `arkrpc.TreePathToTree`,
+  the sibling decoder on the untrusted indexer receive path. Keep the
+  two in step: a shape rejected by one and accepted by the other is a
+  gap, not a difference in trust level.
 - `ValidateFlowVersion` must reject any `FlowVersion` other than the
   versions this build implements (currently only `FlowVersionV1`); never
   make it permissive by default.

--- a/rpc/roundpb/convert.go
+++ b/rpc/roundpb/convert.go
@@ -394,6 +394,11 @@ func TreeFromProto(pt *VTXOTree,
 	//    node's output count. Without this, downstream code that
 	//    accesses Outputs[outIdx] would panic.
 	//
+	// The bounds check runs before the single-parent check so a wild
+	// index is reported as out of range rather than as a sharing
+	// violation, and so parentOf never records an index that was
+	// never valid in the first place.
+	//
 	// parentOf records the parent that claimed each child, so a
 	// second claim can name both of them.
 	parentOf := make(map[uint32]int, len(pt.Nodes))
@@ -406,6 +411,11 @@ func TreeFromProto(pt *VTXOTree,
 					"back-reference)", i, childIdx)
 			}
 
+			if int(childIdx) >= len(goNodes) {
+				return nil, fmt.Errorf("node[%d] child index "+
+					"%d out of range", i, childIdx)
+			}
+
 			if prev, dup := parentOf[childIdx]; dup {
 				return nil, fmt.Errorf("node[%d] child index "+
 					"%d is already a child of node[%d]; "+
@@ -413,11 +423,6 @@ func TreeFromProto(pt *VTXOTree,
 					childIdx, prev)
 			}
 			parentOf[childIdx] = i
-
-			if int(childIdx) >= len(goNodes) {
-				return nil, fmt.Errorf("node[%d] child index "+
-					"%d out of range", i, childIdx)
-			}
 
 			if int(outIdx) >= len(goNodes[i].Outputs) {
 				return nil, fmt.Errorf("node[%d] child output "+
@@ -428,6 +433,25 @@ func TreeFromProto(pt *VTXOTree,
 
 			goNodes[i].Children[outIdx] = goNodes[childIdx]
 		}
+	}
+
+	// The three checks above give "every node has at most one
+	// parent", which describes a forest, not a tree: nothing so far
+	// requires a node to be reachable from index 0. A sender could
+	// therefore pad the message with nodes no walk from Root will
+	// ever reach, and every one of them would still be deserialized
+	// and, far more expensively, run through ComputeFinalKey below
+	// (a MuSig2 aggregation with a sort and a copy per node).
+	//
+	// Since every node other than the root must be claimed exactly
+	// once, counting the claims pins the decoded shape to a single
+	// connected tree rooted at index 0 and lets the loop below skip
+	// work nobody can reach. flattenNode always emits exactly this
+	// shape, so no well-formed producer is affected.
+	if len(parentOf) != len(pt.Nodes)-1 {
+		return nil, fmt.Errorf("tree has %d nodes but only %d are "+
+			"claimed as children; unreachable nodes or "+
+			"multiple roots", len(pt.Nodes), len(parentOf))
 	}
 
 	// Compute FinalKey for each node now that we have the

--- a/rpc/roundpb/convert.go
+++ b/rpc/roundpb/convert.go
@@ -372,18 +372,32 @@ func TreeFromProto(pt *VTXOTree,
 		goNodes[i] = node
 	}
 
-	// Wire up children references. We enforce two structural
+	// Wire up children references. We enforce three structural
 	// invariants:
 	//
 	// 1. Pre-order invariant: childIdx > i. Since flattenNode
 	//    serializes in pre-order, children always have higher
-	//    indices than parents. This prevents cycles (self-refs,
-	//    mutual refs, back-edges) and diamond DAGs (shared
-	//    children) in a single check.
+	//    indices than parents. This prevents cycles: self-refs,
+	//    mutual refs and back-edges.
 	//
-	// 2. Output index bounds: outIdx must be within the parent
+	// 2. Single parent: no node may be named as a child twice.
+	//    The pre-order check alone does NOT give this, contrary to
+	//    what this comment used to claim. Two parents at indices 0
+	//    and 1 can both name child 5 and both satisfy childIdx > i,
+	//    which decodes a DAG rather than a tree. Every recursive
+	//    walk over the result then re-visits the shared subtree once
+	//    per path that reaches it, so a decoder that accepts a
+	//    shared child hands the rest of the system exponential work
+	//    from a linear-sized message.
+	//
+	// 3. Output index bounds: outIdx must be within the parent
 	//    node's output count. Without this, downstream code that
 	//    accesses Outputs[outIdx] would panic.
+	//
+	// parentOf records the parent that claimed each child, so a
+	// second claim can name both of them.
+	parentOf := make(map[uint32]int, len(pt.Nodes))
+
 	for i, pn := range pt.Nodes {
 		for outIdx, childIdx := range pn.Children {
 			if childIdx <= uint32(i) {
@@ -391,6 +405,14 @@ func TreeFromProto(pt *VTXOTree,
 					"%d must be > parent index (cycle or "+
 					"back-reference)", i, childIdx)
 			}
+
+			if prev, dup := parentOf[childIdx]; dup {
+				return nil, fmt.Errorf("node[%d] child index "+
+					"%d is already a child of node[%d]; "+
+					"tree must not share children", i,
+					childIdx, prev)
+			}
+			parentOf[childIdx] = i
 
 			if int(childIdx) >= len(goNodes) {
 				return nil, fmt.Errorf("node[%d] child index "+

--- a/rpc/roundpb/convert_security_test.go
+++ b/rpc/roundpb/convert_security_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
-	treePkg "github.com/lightninglabs/wavelength/lib/tree"
 	"github.com/stretchr/testify/require"
 )
 
@@ -316,21 +315,21 @@ func TestTreeFromProtoDiamondDAG(t *testing.T) {
 		},
 	}
 
-	// TreeFromProto rejects diamond DAGs because the shared
-	// child (node 3) would be referenced by node 2 at index 3,
-	// but node 1 already claims it. The pre-order invariant
-	// prevents this since shared children violate the tree
-	// property.
+	// Nodes 1 and 2 both name node 3 as their child. Every forward
+	// reference is valid, so the pre-order invariant (childIdx > i)
+	// admits this shape: it catches cycles, not shared children.
+	// Detecting the diamond needs a record of which parent already
+	// claimed each child, which TreeFromProto now keeps.
 	//
-	// NOTE: The pre-order invariant (childIdx > i) alone allows
-	// this specific diamond shape since all forward references
-	// are valid. However, the diamond is still structurally
-	// accepted here. The pre-order check primarily prevents
-	// cycles; diamond detection would require tracking parent
-	// counts. This test documents the current behavior.
+	// This test used to assert the opposite and document the gap as
+	// accepted behaviour. It is the gap that mattered: what decodes
+	// here is a DAG, not a tree, and a recursive walk re-visits the
+	// shared subtree once per path reaching it, so a linear-sized
+	// message buys exponential work downstream.
 	tree, err := TreeFromProto(pt)
-	require.NoError(t, err)
-	require.NotNil(t, tree)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must not share children")
+	require.Nil(t, tree)
 }
 
 // =====================================================================
@@ -1066,41 +1065,25 @@ func TestTreeFromProtoDiamondDoubleVisit(t *testing.T) {
 		},
 	}
 
-	// NOTE: The pre-order invariant (childIdx > i) does not
-	// prevent all diamond DAGs -- only those with back-edges.
-	// This specific diamond shape uses only forward references
-	// and is still accepted. Diamond detection would require a
-	// parent-count tracker. This test documents the current
-	// behavior: the diamond is accepted but the shared child
-	// is visited twice during traversal.
+	// This shape is why the single-parent check exists. It uses
+	// only forward references, so the pre-order invariant
+	// (childIdx > i) admits it, and what decodes is a DAG whose
+	// shared child sits on two distinct root-to-node paths.
+	//
+	// This test used to accept the decode and then demonstrate the
+	// consequence: a depth-first walk reached the shared child once
+	// per path, so it counted two visits for one node. That is the
+	// amplification in miniature -- at depth d a chain of shared
+	// children turns a linear message into 2^d visits, and the walks
+	// that do this are spread across the codebase rather than
+	// gathered behind one guard.
+	//
+	// So the fix is at the decode boundary, and the assertion moves
+	// with it: the DAG never becomes a tree.Node graph at all, which
+	// is what makes every downstream walk safe without auditing each
+	// one for re-visit behaviour.
 	tree, err := TreeFromProto(pt)
-	require.NoError(t, err)
-	require.NotNil(t, tree)
-
-	// Count how many times each node pointer is visited during
-	// a manual depth-first traversal (simulating ForEach).
-	visitCount := make(map[*treePkg.Node]int)
-	var walk func(n *treePkg.Node)
-	walk = func(n *treePkg.Node) {
-		if n == nil {
-			return
-		}
-		visitCount[n]++
-		// Stop if we detect we already visited this node to
-		// prevent infinite recursion in the test.
-		if visitCount[n] > 1 {
-			return
-		}
-		for _, child := range n.Children {
-			walk(child)
-		}
-	}
-	walk(tree.Root)
-
-	// The shared child (goNodes[3]) is visited twice.
-	sharedChild := tree.Root.Children[0].Children[0]
-	require.Equal(
-		t, 2, visitCount[sharedChild],
-		"diamond: shared child visited twice",
-	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must not share children")
+	require.Nil(t, tree)
 }

--- a/rpc/roundpb/convert_security_test.go
+++ b/rpc/roundpb/convert_security_test.go
@@ -1087,3 +1087,161 @@ func TestTreeFromProtoDiamondDoubleVisit(t *testing.T) {
 	require.Contains(t, err.Error(), "must not share children")
 	require.Nil(t, tree)
 }
+
+// =====================================================================
+// FINDING-M2: Single-parent plus forward-edges still admits a forest.
+// Severity: LOW (bounded by the node cap, but linear waste per node)
+//
+// "Every node has at most one parent" describes a forest, not a tree:
+// nothing requires a node to be reachable from index 0. A sender could
+// therefore pad a message up to the node cap with nodes no walk from
+// Root will ever reach, and every one of them was still deserialized
+// and run through ComputeFinalKey, a MuSig2 aggregation with a sort and
+// a copy per node.
+// =====================================================================
+
+// shapeTreeNode builds a minimal TreeNode carrying the given child
+// wiring. Only the shape matters to the tests below, so the payload
+// fields hold the cheapest values the decoder accepts.
+func shapeTreeNode(idx uint32, children map[uint32]uint32) *TreeNode {
+	hash := chainhash.Hash{byte(idx + 1)}
+
+	// Two outputs is the smallest count that lets one node name two
+	// distinct children.
+	outputs := []*TxOut{{
+		Value: 500,
+		PkScript: []byte{
+			0x51,
+		},
+	}, {
+		Value: 500,
+		PkScript: []byte{
+			0x51,
+		},
+	}}
+
+	return &TreeNode{
+		Input: &Outpoint{
+			TxHash:      hash[:],
+			OutputIndex: idx,
+		},
+		Outputs:  outputs,
+		Children: children,
+		Amount:   1000,
+	}
+}
+
+// shapeVTXOTree wraps nodes into a VTXOTree with a valid batch outpoint
+// and output, so any error observed comes from the node wiring.
+func shapeVTXOTree(nodes ...*TreeNode) *VTXOTree {
+	hash := chainhash.Hash{0xba}
+
+	return &VTXOTree{
+		Nodes: nodes,
+		BatchOutpoint: &Outpoint{
+			TxHash:      hash[:],
+			OutputIndex: 0,
+		},
+		BatchOutput: &TxOut{
+			Value: 1000,
+			PkScript: []byte{
+				0x51,
+			},
+		},
+	}
+}
+
+// TestTreeFromProtoRejectsUnreachableNodes covers the two forest shapes
+// that pass every per-edge check: a node nobody claims, and a detached
+// second root carrying its own subtree.
+func TestTreeFromProtoRejectsUnreachableNodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		nodes []*TreeNode
+	}{{
+		// The root claims nothing, so node 1 is detached.
+		name: "orphan node",
+		nodes: []*TreeNode{
+			shapeTreeNode(0, nil),
+			shapeTreeNode(1, nil),
+		},
+	}, {
+		// Node 1 is a second root with its own subtree.
+		name: "detached second root",
+		nodes: []*TreeNode{
+			shapeTreeNode(0, nil),
+			shapeTreeNode(1, map[uint32]uint32{0: 2}),
+			shapeTreeNode(2, nil),
+		},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := TreeFromProto(shapeVTXOTree(tc.nodes...))
+			require.Error(t, err)
+			require.ErrorContains(
+				t, err, "unreachable nodes or multiple roots",
+			)
+			require.Nil(t, got)
+		})
+	}
+}
+
+// TestTreeFromProtoReportsWildIndexAsOutOfRange pins the diagnostic
+// ordering. A repeated out-of-range index used to be reported as a
+// sharing violation, which sends whoever is reading the log looking for
+// a tree-shape bug when the real problem is a wild index.
+func TestTreeFromProtoReportsWildIndexAsOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	pt := shapeVTXOTree(
+		shapeTreeNode(
+			0, map[uint32]uint32{
+				0: 999,
+				1: 999,
+			},
+		),
+		shapeTreeNode(1, nil),
+	)
+
+	got, err := TreeFromProto(pt)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "out of range")
+	require.NotContains(t, err.Error(), "share children")
+	require.Nil(t, got)
+}
+
+// TestTreeFromProtoAcceptsWellFormedTree guards against the reachability
+// check rejecting anything a legitimate producer emits: flattenNode
+// always yields one connected pre-order tree, so a plain branching shape
+// must still decode with its wiring intact.
+func TestTreeFromProtoAcceptsWellFormedTree(t *testing.T) {
+	t.Parallel()
+
+	pt := shapeVTXOTree(
+		shapeTreeNode(
+			0, map[uint32]uint32{
+				0: 1,
+				1: 2,
+			},
+		),
+		shapeTreeNode(
+			1, map[uint32]uint32{
+				0: 3,
+			},
+		),
+		shapeTreeNode(2, nil),
+		shapeTreeNode(3, nil),
+	)
+
+	got, err := TreeFromProto(pt)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Root.Children, 2)
+	require.Len(t, got.Root.Children[0].Children, 1)
+	require.Empty(t, got.Root.Children[1].Children)
+}


### PR DESCRIPTION
`TreeFromProto` validated three things about each child reference: the index is greater than its parent's, it is in range, and the output index is within the parent's output count. It never checked that a node is named as a child only **once**.

## The comment was the give-away

The existing comment claimed the pre-order check already covered this:

> *This prevents cycles (self-refs, mutual refs, back-edges) and **diamond DAGs (shared children)** in a single check.*

The first half is true, the second is not. `childIdx > i` rules out cycles, but two parents at indices 0 and 1 can both name child 5 and both satisfy it. What decodes is a DAG, not a tree.

## Why decode is the right place to fix it

The tree is walked recursively in many places. A shared child sits on more than one root-to-node path, so each walk re-visits its whole subtree once per path that reaches it — a chain of shared children turns a linear-sized message into exponential work.

Fixing it at the decode boundary means the DAG never becomes a `tree.Node` graph at all, which makes every downstream walk safe without auditing each one for re-visit behaviour. That is the argument for a single guard here over N guards spread across the consumers.

The check is a `parentOf` map recording which parent claimed each child, so a second claim can name both nodes in the error.

## The tests were already there, asserting the wrong thing

Two existing tests covered this shape and **asserted it was accepted**, documenting the gap as known:

- `TestTreeFromProtoDiamondDAG` — *"Diamond detection would require tracking parent counts. This test documents the current behavior."*
- `TestTreeFromProtoDiamondDoubleVisit` — went further and counted the consequence, asserting the shared child is visited **twice** in a depth-first walk.

Both now assert the decode is refused. The double-visit the second one demonstrated is the amplification in miniature, so inverting them is better than deleting them: the shape they describe is exactly what the guard exists to reject.

I also corrected the package `CLAUDE.md` invariant, which documented the pre-order check as covering this.

## Testing

`make unit pkg=rpc/roundpb` passes, as do `lib/tree` and `round` — the packages that consume the decoded tree. `make lint-changed-local` 0 issues, `make commitmsg-lint` OK.

