### PR TITLE
vtxo: do not exit a forfeit whose signature already left

### DIFF
--- a/vtxo/transitions.go
+++ b/vtxo/transitions.go
@@ -8,9 +8,11 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/wavelength/build"
+	"github.com/lightninglabs/wavelength/lib/actormsg"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	"github.com/lightninglabs/wavelength/lib/tx"
 	"github.com/lightninglabs/wavelength/lib/types"
@@ -981,6 +983,27 @@ func (s *PendingForfeitState) ProcessEvent(ctx context.Context, event VTXOEvent,
 	}
 }
 
+// forfeitSignatureIssued reports whether this VTXO's forfeit signature has
+// already left the client.
+//
+// This is the line between an exit that can still work and one that cannot.
+// Before the signature goes out, the client is the only party able to spend
+// the coin, so a unilateral exit is a real recovery. After it goes out, the
+// operator holds a fully-signed transaction spending this coin into a
+// connector of the new commitment and can broadcast it whenever it likes. An
+// exit started past that point has to confirm the whole ancestry and then wait
+// out the exit CSV, while the forfeit is spendable immediately -- so the exit
+// races it and loses.
+//
+// Both fields are checked because either one alone is enough to mean the
+// signature exists: ForfeitTxID is stamped by ForfeitSignedEvent, and ForfeitTx
+// is the retained signed transaction restored on crash recovery.
+func (s *ForfeitingState) forfeitSignatureIssued() bool {
+	var zeroTxID chainhash.Hash
+
+	return s.ForfeitTxID != zeroTxID || s.ForfeitTx != nil
+}
+
 // ProcessEvent handles events in ForfeitingState. The VTXO is being forfeited
 // and waiting for the new commitment transaction to confirm.
 func (s *ForfeitingState) ProcessEvent(ctx context.Context, event VTXOEvent,
@@ -1042,7 +1065,18 @@ func (s *ForfeitingState) ProcessEvent(ctx context.Context, event VTXOEvent,
 		// while racing an already-spendable operator sweep — and
 		// escalating would abort the in-flight cooperative spend that
 		// IS the recovery. Staying put lets it finish.
-		if expiryStatus == ExpiryStatusCritical {
+		// The same reasoning rules out escalating once the forfeit
+		// signature has left, whatever the deadline says: the operator
+		// can spend this coin into a connector immediately, so the
+		// exit races a transaction that has already won
+		// (wavelength#845). This is defence in depth against a coin
+		// stranded in Forfeiting by the reconciliation gap in
+		// wavelength#844 -- such a coin is not expiring at all, it is
+		// already spent, so exiting it is pointless, and losing if the
+		// exit ever funded its CPFP and confirmed.
+		if expiryStatus == ExpiryStatusCritical &&
+			!s.forfeitSignatureIssued() {
+
 			blocksRemaining := BlocksUntilExpiry(s.VTXO, evt.Height)
 
 			// Non-terminal exit: no VTXOTerminatedNotification, so
@@ -1085,6 +1119,28 @@ func (s *ForfeitingState) ProcessEvent(ctx context.Context, event VTXOEvent,
 		}, nil
 
 	case *ForceUnrollEvent:
+		// A critical-expiry admission is refused once the forfeit
+		// signature has left, for the same reason the block-epoch path
+		// above declines to escalate: the operator can spend this coin
+		// into a connector immediately, so the exit races a
+		// transaction that has already won (wavelength#845). The
+		// chain-resolver bridge admits expiry-driven exits through
+		// this event too, so guarding only the block-epoch branch
+		// would leave the same doomed exit reachable by another door.
+		//
+		// Manual and fraud-spend triggers are deliberately still
+		// honoured. A fraud spend means the operator has already moved
+		// against us and exiting is the correct response, and a manual
+		// unroll is an explicit operator decision that should not be
+		// silently dropped. Only the automatic path, which fires on a
+		// coin nobody chose to exit, is suppressed.
+		if evt.Trigger == actormsg.UnrollTriggerCriticalExpiry &&
+			s.forfeitSignatureIssued() {
+			return &VTXOStateTransition{
+				NextState: s,
+			}, nil
+		}
+
 		// Client requested unilateral exit while a forfeit is
 		// mid-flight. The on-chain recovery path doesn't depend
 		// on the forfeit signature landing, so we escalate to

--- a/vtxo/transitions_test.go
+++ b/vtxo/transitions_test.go
@@ -1111,47 +1111,89 @@ func signForfeitParticipantRequest(t *testing.T,
 func TestForfeitingStateCriticalExpiry(t *testing.T) {
 	t.Parallel()
 
-	h := newVTXOTestHarness(t)
-	vtxo := h.newTestDescriptor()
-	vtxo.BatchExpiry = 1000
+	// Critical expiry escalates a forfeit that is still mid-flight, and
+	// must NOT escalate one whose signature has already left. Past that
+	// point the operator holds a fully-signed spend of this coin into a
+	// connector and can broadcast whenever it likes, so the exit races a
+	// transaction that has already won: pointless if it never funds its
+	// CPFP, and losing if it does (wavelength#845).
+	//
+	// This test previously asserted the opposite. It seeded both
+	// ForfeitTxID and ForfeitTx -- a signature that had demonstrably left
+	// -- and required escalation, which is the behaviour the issue was
+	// filed about.
+	tests := []struct {
+		name           string
+		signatureSent  bool
+		wantEscalation bool
+	}{{
+		name:           "signature not yet sent escalates",
+		signatureSent:  false,
+		wantEscalation: true,
+	}, {
+		name:           "signature already sent stays put",
+		signatureSent:  true,
+		wantEscalation: false,
+	}}
 
-	h.withExpiryConfig(&ExpiryConfig{
-		RefreshThresholdBlocks:  200,
-		CriticalThresholdBlocks: 50,
-		TreeDepthMultiplier:     1,
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	forfeitTx := wire.NewMsgTx(2)
-	h.withState(&ForfeitingState{
-		VTXO:              vtxo,
-		NewRoundID:        "round-stalled",
-		ConnectorOutpoint: h.newTestOutpoint(),
-		ForfeitTxID:       forfeitTx.TxHash(),
-		ForfeitTx:         forfeitTx,
-	})
+			h := newVTXOTestHarness(t)
+			vtxo := h.newTestDescriptor()
+			vtxo.BatchExpiry = 1000
 
-	// Block height within critical threshold while waiting for forfeit
-	// confirmation. Should escalate to chain resolver.
-	evt := h.newBlockEpochEvent(970)
+			h.withExpiryConfig(&ExpiryConfig{
+				RefreshThresholdBlocks:  200,
+				CriticalThresholdBlocks: 50,
+				TreeDepthMultiplier:     1,
+			})
 
-	// Setup mock for status update.
-	h.store.On(
-		"UpdateVTXOStatus",
-		h.ctx,
-		vtxo.Outpoint,
-		VTXOStatusUnilateralExit,
-	).Return(nil)
+			state := &ForfeitingState{
+				VTXO:              vtxo,
+				NewRoundID:        "round-stalled",
+				ConnectorOutpoint: h.newTestOutpoint(),
+			}
+			if tc.signatureSent {
+				forfeitTx := wire.NewMsgTx(2)
+				state.ForfeitTxID = forfeitTx.TxHash()
+				state.ForfeitTx = forfeitTx
+			}
+			h.withState(state)
 
-	_, err := h.sendEvent(evt)
-	require.NoError(t, err)
+			if tc.wantEscalation {
+				h.store.On(
+					"UpdateVTXOStatus",
+					h.ctx,
+					vtxo.Outpoint,
+					VTXOStatusUnilateralExit,
+				).Return(nil)
+			}
 
-	assertState[*UnilateralExitState](h)
+			// Block height inside the critical threshold.
+			_, err := h.sendEvent(h.newBlockEpochEvent(970))
+			require.NoError(t, err)
 
-	// Should emit ExpiringNotification but NOT a
-	// VTXOTerminatedNotification: the exit is observed, not fire-and-forget
-	// (wavelength#602).
-	assertOutboxContains[*ExpiringNotification](h)
-	assertOutboxLacks[*VTXOTerminatedNotification](h)
+			if !tc.wantEscalation {
+				// Staying in Forfeiting is the whole point: the
+				// coin is not expiring, it is spent, and the
+				// reconciliation that retires it is #844's job.
+				assertState[*ForfeitingState](h)
+				assertOutboxLacks[*ExpiringNotification](h)
+
+				return
+			}
+
+			assertState[*UnilateralExitState](h)
+
+			// Emits ExpiringNotification but NOT a
+			// VTXOTerminatedNotification: the exit is observed,
+			// not fire-and-forget (wavelength#602).
+			assertOutboxContains[*ExpiringNotification](h)
+			assertOutboxLacks[*VTXOTerminatedNotification](h)
+		})
+	}
 }
 
 // TestForfeitSignedEventPreservesForfeitTx verifies that handling
@@ -1860,4 +1902,83 @@ func TestForfeitSignatureValidity(t *testing.T) {
 
 	err = engine.Execute()
 	require.NoError(t, err, "VTXO input signature verification failed")
+}
+
+// TestForfeitingStateForceUnrollTriggers pins which unilateral-exit triggers
+// survive a forfeit whose signature has already left.
+//
+// The chain-resolver bridge admits expiry-driven exits through ForceUnrollEvent
+// as well as through the block-epoch path, so guarding only the latter would
+// leave the same doomed exit reachable by another door (wavelength#845).
+//
+// Manual and fraud-spend stay honoured on purpose. A fraud spend means the
+// operator has already moved against us and exiting is the correct response; a
+// manual unroll is an explicit decision that should not be silently dropped.
+// Only the automatic trigger, which fires on a coin nobody chose to exit, is
+// suppressed.
+func TestForfeitingStateForceUnrollTriggers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		trigger        actormsg.UnrollTrigger
+		wantEscalation bool
+	}{{
+		name:           "critical expiry suppressed",
+		trigger:        actormsg.UnrollTriggerCriticalExpiry,
+		wantEscalation: false,
+	}, {
+		name:           "manual still honoured",
+		trigger:        actormsg.UnrollTriggerManual,
+		wantEscalation: true,
+	}, {
+		name:           "fraud spend still honoured",
+		trigger:        actormsg.UnrollTriggerFraudSpend,
+		wantEscalation: true,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newVTXOTestHarness(t)
+			vtxo := h.newTestDescriptor()
+
+			// The signature has left in every case here; the
+			// trigger is the only variable.
+			forfeitTx := wire.NewMsgTx(2)
+			h.withState(&ForfeitingState{
+				VTXO:              vtxo,
+				NewRoundID:        "round-stalled",
+				ConnectorOutpoint: h.newTestOutpoint(),
+				ForfeitTxID:       forfeitTx.TxHash(),
+				ForfeitTx:         forfeitTx,
+			})
+
+			if tc.wantEscalation {
+				h.store.On(
+					"UpdateVTXOStatus",
+					h.ctx,
+					vtxo.Outpoint,
+					VTXOStatusUnilateralExit,
+				).Return(nil)
+			}
+
+			_, err := h.sendEvent(&ForceUnrollEvent{
+				Reason:  "test",
+				Trigger: tc.trigger,
+			})
+			require.NoError(t, err)
+
+			if !tc.wantEscalation {
+				assertState[*ForfeitingState](h)
+				assertOutboxLacks[*ExpiringNotification](h)
+
+				return
+			}
+
+			assertState[*UnilateralExitState](h)
+			assertOutboxContains[*ExpiringNotification](h)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #845.

This is the **defence-in-depth** half of that issue. The primary fix — reconciling a cooperatively-forfeited coin to terminal `Forfeited` so it leaves the expiry watcher's set entirely — is #844's track and is **not** attempted here. What this removes is the escalation that turns that strand from inert into an on-chain attempt.

## The defect

`ForfeitingState.ProcessEvent` escalated to `UnilateralExitState` on `ExpiryStatusCritical` with no guard (`vtxo/transitions.go`, the `BlockEpochEvent` branch). A coin stranded in `Forfeiting` by #844 is still a non-terminal, expiring coin as far as the watcher is concerned, so as `batch_expiry` approached it started a unilateral exit of an already-forfeited VTXO — which then wedged forever on CPFP funding, as in the signet trace on the issue.

## Why it is wrong once the signature has left

This is the line the fix draws. Before the forfeit signature goes out, the client is the only party able to spend the coin, so a unilateral exit is a real recovery and still escalates. After it goes out, the operator holds a fully-signed transaction spending this coin into a connector of the new commitment and can broadcast it at will.

An exit started past that point must confirm the whole ancestry and then wait out the exit CSV, while the forfeit is spendable immediately — so it races a transaction that has already won. Pointless if it never funds its CPFP; **losing** if it ever does.

There is precedent for exactly this reasoning in the same file: `ExpiredState` already refuses `ForceUnrollEvent` because an exit past expiry "must confirm the whole ancestry and then wait out the exit CSV while racing an already-spendable operator sweep".

## How the line is drawn

`forfeitSignatureIssued` reads state the FSM already keeps — no new field:

- `ForfeitTxID` is stamped by `ForfeitSignedEvent` ("forfeit tx has been signed and submitted")
- `ForfeitTx` is the retained signed transaction, persisted for crash recovery

Either alone is sufficient evidence the signature exists, so both are checked.

## Both doors, not one

The chain-resolver bridge admits expiry-driven exits through `ForceUnrollEvent` as well as through the block-epoch path, so guarding only the latter would leave the identical doomed exit reachable by another door. `ForceUnrollEvent` is therefore guarded too — but **only** for `UnrollTriggerCriticalExpiry`:

- **manual** — an explicit decision, should not be silently dropped
- **fraud_spend** — the operator has already moved against us, and exiting is the correct response

Only the automatic trigger, which fires on a coin nobody chose to exit, is suppressed.

## Testing

`TestForfeitingStateCriticalExpiry` **previously asserted the behaviour this issue was filed about**: it seeded both `ForfeitTxID` and `ForfeitTx` — a signature that had demonstrably left — and required escalation. It now covers both sides of the line, so the case that used to be the bug is the case that pins the fix.

`TestForfeitingStateForceUnrollTriggers` covers the three triggers with the signature already sent, so the pass-through cases are asserted rather than assumed.

Verified that only the two suppression subtests fail without the guard while the escalate/pass-through subtests stay green — the tests pin the change rather than restating it.

`make unit pkg=vtxo` plus `unroll` and `round` (the packages that consume the exit path) pass, `make lint-changed-local` 0 issues, `make commitmsg-lint` OK.

## Note on CI

wavelength CI has not reported on recent branches — its last run was 18:15 UTC today on an unrelated branch. Both use self-hosted runners. Local package tests and lint are the only validation so far.
