### PR TITLE
ci: attribute nightly doc sweep commits to the deploy bot

### DIFF
--- a/.github/workflows/doc-gardening-nightly.yml
+++ b/.github/workflows/doc-gardening-nightly.yml
@@ -150,6 +150,15 @@ jobs:
           # by keeping BOT_GITHUB_TOKEN a fine-grained PAT scoped to only
           # these repos; log readers are first-party. Accepted on that
           # basis.
+          # Suppress the `Co-Authored-By: Claude` trailer so sweep commits
+          # are attributed to the deploy bot alone. This must be done here
+          # rather than by telling the model not to write the trailer: the
+          # CLI appends it as a post-processing step AFTER the model writes
+          # the message file, so a prompt constraint cannot prevent it.
+          # Note this is the action's `settings` input, which takes inline
+          # JSON or a file path — there is no `--settings` CLI flag to pass
+          # through claude_args.
+          settings: '{"includeCoAuthoredBy": false}'
           show_full_output: "true"
           prompt: |
             You are running in a nightly GitHub Actions cron job. Your job

--- a/.github/workflows/doc-gardening-nightly.yml
+++ b/.github/workflows/doc-gardening-nightly.yml
@@ -105,10 +105,18 @@ jobs:
           # Bot identity for commits. Set via env vars instead of
           # `git config` so Claude doesn't need Bash(git config:*) in its
           # allowlist.
-          GIT_AUTHOR_NAME: wavelength-doc-bot
-          GIT_AUTHOR_EMAIL: bot@lightning.engineering
-          GIT_COMMITTER_NAME: wavelength-doc-bot
-          GIT_COMMITTER_EMAIL: bot@lightning.engineering
+          # Use the deploy bot's GitHub noreply address, not a vanity
+          # domain. GitHub attributes a commit to an account by matching
+          # the author email against that account's verified addresses, so
+          # `bot@lightning.engineering` matched nothing and every sweep
+          # commit rendered as an unlinked plain-text name with a default
+          # avatar. The `<id>+<login>@users.noreply.github.com` form is the
+          # account's canonical address and is what links the commit to
+          # lightninglabs-deploy.
+          GIT_AUTHOR_NAME: lightninglabs-deploy
+          GIT_AUTHOR_EMAIL: 58193817+lightninglabs-deploy@users.noreply.github.com
+          GIT_COMMITTER_NAME: lightninglabs-deploy
+          GIT_COMMITTER_EMAIL: 58193817+lightninglabs-deploy@users.noreply.github.com
           # Surface GitHub Actions context into Claude's env so the prompt
           # can interpolate via shell $VAR expansion instead of templating.
           REPO_NAME: ${{ github.repository }}
@@ -268,6 +276,13 @@ jobs:
             - Never push to `main` directly.
             - Never modify files outside this repo.
             - Never add reviewers or assignees to the PR.
+            - The commit message must be exactly the template above and
+              nothing else. Do not append a `Co-Authored-By:` trailer, a
+              `Generated with Claude Code` line, or any other attribution
+              footer, to either the commit message or the PR body. A
+              `Co-Authored-By` trailer makes GitHub render the sweep as
+              "lightninglabs-deploy and claude committed"; these commits
+              should be attributed to the deploy bot alone.
             - This sweep is docs-only. Never run `go build`, `go test`, or
               anything that compiles the tree — those drop stray binaries
               (`accounting`, etc.) into package dirs that then get swept


### PR DESCRIPTION
In this PR, we make the nightly doc sweep's commits show up as the deploy
bot, and only the deploy bot. Right now they render on GitHub as
"wavelength-doc-bot and claude committed", and each half of that string
has its own cause.

The author identity was never linked to any GitHub account. GitHub
attributes a commit by matching the author email against an account's
verified addresses, and we commit as `bot@lightning.engineering`, which
matches nothing. The API reports the author of every sweep commit as
literally unlinked, which is why it renders as bare text with a default
avatar rather than as `lightninglabs-deploy`. We switch to the account's
canonical `<id>+<login>@users.noreply.github.com` address, taken from
that account's own existing commits, which is the form GitHub resolves
back to the account.

The trailing "and claude" comes from a `Co-Authored-By` trailer on the
commit message. The prompt's message template never included one, and
worth flagging for anyone tempted by the obvious fix: telling the model
not to write the trailer does not work. The CLI appends it as a
post-processing step after the model writes the message file, so the
model's text is overridden no matter what it writes. The supported lever
is the action's `settings` input, set to `{"includeCoAuthoredBy": false}`,
which suppresses the trailer on both commits and PRs. Note that this is
an action input taking inline JSON or a file path, not a CLI flag; there
is no `--settings` to route through `claude_args`, so passing it that way
would have failed the step outright.

We keep the prompt constraint as documentation of intent, but the
`settings` input is what enforces it.

These two commits were written against #913 but landed after it merged,
so they come as a follow-up rather than as part of that PR. The sibling server-side change is lightninglabs/lumos#768.