### PR TITLE
Show all vtxos except forfeited and spent, add option to show all

### DIFF
--- a/cmd/wavecli/waveclicommands/cmd_vtxos.go
+++ b/cmd/wavecli/waveclicommands/cmd_vtxos.go
@@ -48,7 +48,9 @@ func newVTXOsListCmd() *cobra.Command {
 		Short: "List VTXOs",
 		Long: "Returns VTXOs known to the wallet, " +
 			"optionally filtered by status and " +
-			"minimum amount.",
+			"minimum amount. By default, forfeited and " +
+			"spent VTXOs are excluded; use --show-all to " +
+			"include them.",
 		RunE: vtxosList,
 	}
 
@@ -58,6 +60,11 @@ func newVTXOsListCmd() *cobra.Command {
 
 	cmd.Flags().Int64("min-amount", 0,
 		"minimum amount in sats")
+
+	cmd.Flags().Bool("show-all", false,
+		"show every VTXO regardless of status, including "+
+			"forfeited and spent ones; mutually exclusive "+
+			"with --status")
 
 	addListOutputFlags(cmd, "VTXO")
 
@@ -76,6 +83,12 @@ func vtxosList(cmd *cobra.Command, _ []string) error {
 	if err := parseRequest(cmd, req, func() error {
 		statusStr, _ := cmd.Flags().GetString("status")
 		minAmount, _ := cmd.Flags().GetInt64("min-amount")
+		showAll, _ := cmd.Flags().GetBool("show-all")
+
+		if showAll && statusStr != "" {
+			return fmt.Errorf("--show-all and --status are " +
+				"mutually exclusive")
+		}
 
 		if statusStr != "" {
 			statusFilter, ok := parseVTXOStatus(
@@ -97,6 +110,7 @@ func vtxosList(cmd *cobra.Command, _ []string) error {
 		}
 
 		req.MinAmountSat = minAmount
+		req.ShowAll = showAll
 
 		return nil
 	}); err != nil {

--- a/cmd/wavecli/waveclicommands/schema_registry.go
+++ b/cmd/wavecli/waveclicommands/schema_registry.go
@@ -855,6 +855,15 @@ func arkVTXOMethodRegistry() []schemaMethod {
 					Type:        "int64",
 					Description: "minimum amount in sats",
 				},
+				{
+					Name: "show-all",
+					Type: "bool",
+					Description: "show every VTXO " +
+						"regardless of status, " +
+						"including forfeited and " +
+						"spent ones; mutually " +
+						"exclusive with status",
+				},
 			}, listOutputParams()...),
 			RequestType:  "ListVTXOsRequest",
 			ResponseType: "ListVTXOsResponse",

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -141,6 +141,9 @@ type RoundStore interface {
 		arg sqlc.ListVTXOsExcludingStatusesParams) (
 		[]sqlc.ListVTXOsExcludingStatusesRow, error)
 
+	ListVTXOsAllStatuses(ctx context.Context) (
+		[]sqlc.ListVTXOsAllStatusesRow, error)
+
 	// ListVTXOSelectionCandidatesByStatus returns the lightweight
 	// (outpoint, amount, pkScript) projection coin selection runs on,
 	// avoiding the full descriptor decode on the per-payment hot path.

--- a/db/round_store.go
+++ b/db/round_store.go
@@ -137,6 +137,10 @@ type RoundStore interface {
 	ListVTXOsByStatus(ctx context.Context,
 		status int32) ([]sqlc.ListVTXOsByStatusRow, error)
 
+	ListVTXOsExcludingStatuses(ctx context.Context,
+		arg sqlc.ListVTXOsExcludingStatusesParams) (
+		[]sqlc.ListVTXOsExcludingStatusesRow, error)
+
 	// ListVTXOSelectionCandidatesByStatus returns the lightweight
 	// (outpoint, amount, pkScript) projection coin selection runs on,
 	// avoiding the full descriptor decode on the per-payment hot path.

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -328,6 +328,11 @@ type Querier interface {
 	// a forfeit_round_id, instead of aggregating every fee row in the ledger on
 	// every call.
 	ListVTXOsByStatus(ctx context.Context, status int32) ([]ListVTXOsByStatusRow, error)
+	// ListVTXOsExcludingStatuses returns all VTXOs except those with either of
+	// the two given statuses. Mirrors ListVTXOsByStatus's settlement join so
+	// terminal states (e.g. UnilateralExit) still surface forfeit-round
+	// settlement info.
+	ListVTXOsExcludingStatuses(ctx context.Context, arg ListVTXOsExcludingStatusesParams) ([]ListVTXOsExcludingStatusesRow, error)
 	ListWalletUTXOLog(ctx context.Context, arg ListWalletUTXOLogParams) ([]WalletUtxoLog, error)
 	ListWalletUTXOLogByBlock(ctx context.Context, blockHeight int32) ([]WalletUtxoLog, error)
 	ListWalletUTXOLogByClassification(ctx context.Context, arg ListWalletUTXOLogByClassificationParams) ([]WalletUtxoLog, error)

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -303,6 +303,12 @@ type Querier interface {
 	// full descriptors (pubkey parsing, taproot script reconstruction, policy
 	// template decode) and the batched ancestry-path query on the hot path.
 	ListVTXOSelectionCandidatesByStatus(ctx context.Context, status int32) ([]ListVTXOSelectionCandidatesByStatusRow, error)
+	// ListVTXOsAllStatuses returns every VTXO regardless of status. Mirrors
+	// ListVTXOsByStatus's settlement join so terminal states still surface
+	// forfeit-round settlement info. Named distinctly from the pre-existing
+	// unjoined ListAllVTXOs (round.sql), which round-side callers use for
+	// their own purposes.
+	ListVTXOsAllStatuses(ctx context.Context) ([]ListVTXOsAllStatusesRow, error)
 	ListVTXOsByRound(ctx context.Context, roundID string) ([]Vtxo, error)
 	// VTXO status and lifecycle queries.
 	// These queries support the vtxo.VTXOStore interface for VTXO lifecycle

--- a/db/sqlc/queries/vtxo.sql
+++ b/db/sqlc/queries/vtxo.sql
@@ -37,6 +37,25 @@ LEFT JOIN rounds ON vtxos.forfeit_round_id = rounds.round_id
 WHERE vtxos.status = $1
 ORDER BY vtxos.creation_time DESC;
 
+-- name: ListVTXOsExcludingStatuses :many
+-- ListVTXOsExcludingStatuses returns all VTXOs except those with either of
+-- the two given statuses. Mirrors ListVTXOsByStatus's settlement join so
+-- terminal states (e.g. UnilateralExit) still surface forfeit-round
+-- settlement info.
+SELECT sqlc.embed(vtxos),
+    rounds.commitment_txid AS settlement_txid,
+    rounds.confirmation_height AS settlement_height,
+    CAST(COALESCE((
+        SELECT SUM(le.amount_sat)
+        FROM ledger_entries AS le
+        WHERE le.round_uuid = vtxos.forfeit_round_id
+          AND le.event_type IN ('boarding_fee_paid', 'refresh_fee_paid')
+    ), 0) AS BIGINT) AS settlement_fee_sat
+FROM vtxos
+LEFT JOIN rounds ON vtxos.forfeit_round_id = rounds.round_id
+WHERE vtxos.status NOT IN ($1, $2)
+ORDER BY vtxos.creation_time DESC;
+
 -- name: ListVTXOSelectionCandidatesByStatus :many
 -- ListVTXOSelectionCandidatesByStatus returns the lightweight projection coin
 -- selection runs on: outpoint, amount, and pkScript. Selection happens on

--- a/db/sqlc/queries/vtxo.sql
+++ b/db/sqlc/queries/vtxo.sql
@@ -56,6 +56,25 @@ LEFT JOIN rounds ON vtxos.forfeit_round_id = rounds.round_id
 WHERE vtxos.status NOT IN ($1, $2)
 ORDER BY vtxos.creation_time DESC;
 
+-- name: ListVTXOsAllStatuses :many
+-- ListVTXOsAllStatuses returns every VTXO regardless of status. Mirrors
+-- ListVTXOsByStatus's settlement join so terminal states still surface
+-- forfeit-round settlement info. Named distinctly from the pre-existing
+-- unjoined ListAllVTXOs (round.sql), which round-side callers use for
+-- their own purposes.
+SELECT sqlc.embed(vtxos),
+    rounds.commitment_txid AS settlement_txid,
+    rounds.confirmation_height AS settlement_height,
+    CAST(COALESCE((
+        SELECT SUM(le.amount_sat)
+        FROM ledger_entries AS le
+        WHERE le.round_uuid = vtxos.forfeit_round_id
+          AND le.event_type IN ('boarding_fee_paid', 'refresh_fee_paid')
+    ), 0) AS BIGINT) AS settlement_fee_sat
+FROM vtxos
+LEFT JOIN rounds ON vtxos.forfeit_round_id = rounds.round_id
+ORDER BY vtxos.creation_time DESC;
+
 -- name: ListVTXOSelectionCandidatesByStatus :many
 -- ListVTXOSelectionCandidatesByStatus returns the lightweight projection coin
 -- selection runs on: outpoint, amount, and pkScript. Selection happens on

--- a/db/sqlc/vtxo.sql.go
+++ b/db/sqlc/vtxo.sql.go
@@ -297,6 +297,83 @@ func (q *Queries) ListVTXOSelectionCandidatesByStatus(ctx context.Context, statu
 	return items, nil
 }
 
+const ListVTXOsAllStatuses = `-- name: ListVTXOsAllStatuses :many
+SELECT vtxos.outpoint_hash, vtxos.outpoint_index, vtxos.round_id, vtxos.amount, vtxos.pk_script, vtxos.expiry, vtxos.policy_template, vtxos.client_key_id, vtxos.operator_pubkey, vtxos.batch_expiry, vtxos.created_height, vtxos.commitment_txid, vtxos.spent, vtxos.status, vtxos.forfeit_round_id, vtxos.forfeit_tx, vtxos.forfeit_txid, vtxos.replaced_by_hash, vtxos.replaced_by_index, vtxos.creation_time, vtxos.last_update_time, vtxos.chain_depth, vtxos.construction_version,
+    rounds.commitment_txid AS settlement_txid,
+    rounds.confirmation_height AS settlement_height,
+    CAST(COALESCE((
+        SELECT SUM(le.amount_sat)
+        FROM ledger_entries AS le
+        WHERE le.round_uuid = vtxos.forfeit_round_id
+          AND le.event_type IN ('boarding_fee_paid', 'refresh_fee_paid')
+    ), 0) AS BIGINT) AS settlement_fee_sat
+FROM vtxos
+LEFT JOIN rounds ON vtxos.forfeit_round_id = rounds.round_id
+ORDER BY vtxos.creation_time DESC
+`
+
+type ListVTXOsAllStatusesRow struct {
+	Vtxo             Vtxo
+	SettlementTxid   []byte
+	SettlementHeight sql.NullInt32
+	SettlementFeeSat int64
+}
+
+// ListVTXOsAllStatuses returns every VTXO regardless of status. Mirrors
+// ListVTXOsByStatus's settlement join so terminal states still surface
+// forfeit-round settlement info. Named distinctly from the pre-existing
+// unjoined ListAllVTXOs (round.sql), which round-side callers use for
+// their own purposes.
+func (q *Queries) ListVTXOsAllStatuses(ctx context.Context) ([]ListVTXOsAllStatusesRow, error) {
+	rows, err := q.db.QueryContext(ctx, ListVTXOsAllStatuses)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListVTXOsAllStatusesRow
+	for rows.Next() {
+		var i ListVTXOsAllStatusesRow
+		if err := rows.Scan(
+			&i.Vtxo.OutpointHash,
+			&i.Vtxo.OutpointIndex,
+			&i.Vtxo.RoundID,
+			&i.Vtxo.Amount,
+			&i.Vtxo.PkScript,
+			&i.Vtxo.Expiry,
+			&i.Vtxo.PolicyTemplate,
+			&i.Vtxo.ClientKeyID,
+			&i.Vtxo.OperatorPubkey,
+			&i.Vtxo.BatchExpiry,
+			&i.Vtxo.CreatedHeight,
+			&i.Vtxo.CommitmentTxid,
+			&i.Vtxo.Spent,
+			&i.Vtxo.Status,
+			&i.Vtxo.ForfeitRoundID,
+			&i.Vtxo.ForfeitTx,
+			&i.Vtxo.ForfeitTxid,
+			&i.Vtxo.ReplacedByHash,
+			&i.Vtxo.ReplacedByIndex,
+			&i.Vtxo.CreationTime,
+			&i.Vtxo.LastUpdateTime,
+			&i.Vtxo.ChainDepth,
+			&i.Vtxo.ConstructionVersion,
+			&i.SettlementTxid,
+			&i.SettlementHeight,
+			&i.SettlementFeeSat,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListVTXOsByStatus = `-- name: ListVTXOsByStatus :many
 
 SELECT vtxos.outpoint_hash, vtxos.outpoint_index, vtxos.round_id, vtxos.amount, vtxos.pk_script, vtxos.expiry, vtxos.policy_template, vtxos.client_key_id, vtxos.operator_pubkey, vtxos.batch_expiry, vtxos.created_height, vtxos.commitment_txid, vtxos.spent, vtxos.status, vtxos.forfeit_round_id, vtxos.forfeit_tx, vtxos.forfeit_txid, vtxos.replaced_by_hash, vtxos.replaced_by_index, vtxos.creation_time, vtxos.last_update_time, vtxos.chain_depth, vtxos.construction_version,

--- a/db/sqlc/vtxo.sql.go
+++ b/db/sqlc/vtxo.sql.go
@@ -394,6 +394,88 @@ func (q *Queries) ListVTXOsByStatus(ctx context.Context, status int32) ([]ListVT
 	return items, nil
 }
 
+const ListVTXOsExcludingStatuses = `-- name: ListVTXOsExcludingStatuses :many
+SELECT vtxos.outpoint_hash, vtxos.outpoint_index, vtxos.round_id, vtxos.amount, vtxos.pk_script, vtxos.expiry, vtxos.policy_template, vtxos.client_key_id, vtxos.operator_pubkey, vtxos.batch_expiry, vtxos.created_height, vtxos.commitment_txid, vtxos.spent, vtxos.status, vtxos.forfeit_round_id, vtxos.forfeit_tx, vtxos.forfeit_txid, vtxos.replaced_by_hash, vtxos.replaced_by_index, vtxos.creation_time, vtxos.last_update_time, vtxos.chain_depth, vtxos.construction_version,
+    rounds.commitment_txid AS settlement_txid,
+    rounds.confirmation_height AS settlement_height,
+    CAST(COALESCE((
+        SELECT SUM(le.amount_sat)
+        FROM ledger_entries AS le
+        WHERE le.round_uuid = vtxos.forfeit_round_id
+          AND le.event_type IN ('boarding_fee_paid', 'refresh_fee_paid')
+    ), 0) AS BIGINT) AS settlement_fee_sat
+FROM vtxos
+LEFT JOIN rounds ON vtxos.forfeit_round_id = rounds.round_id
+WHERE vtxos.status NOT IN ($1, $2)
+ORDER BY vtxos.creation_time DESC
+`
+
+type ListVTXOsExcludingStatusesParams struct {
+	Status   int32
+	Status_2 int32
+}
+
+type ListVTXOsExcludingStatusesRow struct {
+	Vtxo             Vtxo
+	SettlementTxid   []byte
+	SettlementHeight sql.NullInt32
+	SettlementFeeSat int64
+}
+
+// ListVTXOsExcludingStatuses returns all VTXOs except those with either of
+// the two given statuses. Mirrors ListVTXOsByStatus's settlement join so
+// terminal states (e.g. UnilateralExit) still surface forfeit-round
+// settlement info.
+func (q *Queries) ListVTXOsExcludingStatuses(ctx context.Context, arg ListVTXOsExcludingStatusesParams) ([]ListVTXOsExcludingStatusesRow, error) {
+	rows, err := q.db.QueryContext(ctx, ListVTXOsExcludingStatuses, arg.Status, arg.Status_2)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListVTXOsExcludingStatusesRow
+	for rows.Next() {
+		var i ListVTXOsExcludingStatusesRow
+		if err := rows.Scan(
+			&i.Vtxo.OutpointHash,
+			&i.Vtxo.OutpointIndex,
+			&i.Vtxo.RoundID,
+			&i.Vtxo.Amount,
+			&i.Vtxo.PkScript,
+			&i.Vtxo.Expiry,
+			&i.Vtxo.PolicyTemplate,
+			&i.Vtxo.ClientKeyID,
+			&i.Vtxo.OperatorPubkey,
+			&i.Vtxo.BatchExpiry,
+			&i.Vtxo.CreatedHeight,
+			&i.Vtxo.CommitmentTxid,
+			&i.Vtxo.Spent,
+			&i.Vtxo.Status,
+			&i.Vtxo.ForfeitRoundID,
+			&i.Vtxo.ForfeitTx,
+			&i.Vtxo.ForfeitTxid,
+			&i.Vtxo.ReplacedByHash,
+			&i.Vtxo.ReplacedByIndex,
+			&i.Vtxo.CreationTime,
+			&i.Vtxo.LastUpdateTime,
+			&i.Vtxo.ChainDepth,
+			&i.Vtxo.ConstructionVersion,
+			&i.SettlementTxid,
+			&i.SettlementHeight,
+			&i.SettlementFeeSat,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const MarkVTXOForfeited = `-- name: MarkVTXOForfeited :exec
 UPDATE vtxos
 SET status = 3, -- Forfeited

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -463,6 +463,48 @@ func (s *VTXOPersistenceStore) ListVTXOsByStatusLight(ctx context.Context,
 	return result, err
 }
 
+// ListVTXOsExcludingStatusesLight returns every VTXO except those with
+// either of the two given statuses, with a nil Ancestry on every entry. See
+// ListLiveVTXOsLight for why listing-only consumers skip the ancestry side
+// table.
+func (s *VTXOPersistenceStore) ListVTXOsExcludingStatusesLight(
+	ctx context.Context, status1, status2 vtxo.VTXOStatus) (
+	[]*vtxo.Descriptor, error) {
+
+	readTxOpts := ReadTxOption()
+
+	var result []*vtxo.Descriptor
+
+	err := s.db.ExecTx(ctx, readTxOpts, func(q RoundStore) error {
+		rows, err := q.ListVTXOsExcludingStatuses(
+			ctx, sqlc.ListVTXOsExcludingStatusesParams{
+				Status:   int32(status1),
+				Status_2: int32(status2),
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("list VTXOs excluding statuses: %w",
+				err)
+		}
+
+		// A non-nil empty index keeps rowToDescriptor on the preloaded
+		// (zero ancestry) path, matching rowsToDescriptorsNoAncestry.
+		noAncestry := map[wire.OutPoint][]vtxo.Ancestry{}
+		descs, err := s.excludingStatusRowsToDescriptors(
+			ctx, q, rows, noAncestry,
+		)
+		if err != nil {
+			return err
+		}
+
+		result = descs
+
+		return nil
+	})
+
+	return result, err
+}
+
 // byStatusRowsToDescriptors converts the joined by-status rows to descriptors
 // using the supplied (possibly empty) preloaded ancestry index, then stamps
 // the settlement txid/height carried by the LEFT JOIN onto rounds. The join
@@ -488,6 +530,38 @@ func (s *VTXOPersistenceStore) byStatusRowsToDescriptors(ctx context.Context,
 		// Settlement stays None.
 		// The txid, height, and round-level operator fee are attached
 		// together, as they all describe the same forfeit round.
+		if len(row.SettlementTxid) == chainhash.HashSize {
+			var settle vtxo.Settlement
+			copy(settle.TxID[:], row.SettlementTxid)
+			if row.SettlementHeight.Valid {
+				settle.Height = row.SettlementHeight.Int32
+			}
+			settle.FeeSat = row.SettlementFeeSat
+			desc.Settlement = fn.Some(settle)
+		}
+
+		descs = append(descs, desc)
+	}
+
+	return descs, nil
+}
+
+// excludingStatusRowsToDescriptors converts the joined excluding-statuses
+// rows to descriptors. It mirrors byStatusRowsToDescriptors, which it cannot
+// share directly since sqlc generates a distinct row type per query.
+func (s *VTXOPersistenceStore) excludingStatusRowsToDescriptors(
+	ctx context.Context, q RoundStore,
+	rows []sqlc.ListVTXOsExcludingStatusesRow,
+	preloaded map[wire.OutPoint][]vtxo.Ancestry) ([]*vtxo.Descriptor,
+	error) {
+
+	descs := make([]*vtxo.Descriptor, 0, len(rows))
+	for _, row := range rows {
+		desc, err := s.rowToDescriptor(ctx, q, row.Vtxo, preloaded)
+		if err != nil {
+			return nil, fmt.Errorf("convert VTXO: %w", err)
+		}
+
 		if len(row.SettlementTxid) == chainhash.HashSize {
 			var settle vtxo.Settlement
 			copy(settle.TxID[:], row.SettlementTxid)

--- a/db/vtxo_store.go
+++ b/db/vtxo_store.go
@@ -505,6 +505,40 @@ func (s *VTXOPersistenceStore) ListVTXOsExcludingStatusesLight(
 	return result, err
 }
 
+// ListVTXOsAllStatusesLight returns every VTXO regardless of status, with a
+// nil Ancestry on every entry. See ListLiveVTXOsLight for why listing-only
+// consumers skip the ancestry side table.
+func (s *VTXOPersistenceStore) ListVTXOsAllStatusesLight(ctx context.Context) (
+	[]*vtxo.Descriptor, error) {
+
+	readTxOpts := ReadTxOption()
+
+	var result []*vtxo.Descriptor
+
+	err := s.db.ExecTx(ctx, readTxOpts, func(q RoundStore) error {
+		rows, err := q.ListVTXOsAllStatuses(ctx)
+		if err != nil {
+			return fmt.Errorf("list all VTXOs: %w", err)
+		}
+
+		// A non-nil empty index keeps rowToDescriptor on the preloaded
+		// (zero ancestry) path, matching rowsToDescriptorsNoAncestry.
+		noAncestry := map[wire.OutPoint][]vtxo.Ancestry{}
+		descs, err := s.allStatusesRowsToDescriptors(
+			ctx, q, rows, noAncestry,
+		)
+		if err != nil {
+			return err
+		}
+
+		result = descs
+
+		return nil
+	})
+
+	return result, err
+}
+
 // byStatusRowsToDescriptors converts the joined by-status rows to descriptors
 // using the supplied (possibly empty) preloaded ancestry index, then stamps
 // the settlement txid/height carried by the LEFT JOIN onto rounds. The join
@@ -552,6 +586,37 @@ func (s *VTXOPersistenceStore) byStatusRowsToDescriptors(ctx context.Context,
 func (s *VTXOPersistenceStore) excludingStatusRowsToDescriptors(
 	ctx context.Context, q RoundStore,
 	rows []sqlc.ListVTXOsExcludingStatusesRow,
+	preloaded map[wire.OutPoint][]vtxo.Ancestry) ([]*vtxo.Descriptor,
+	error) {
+
+	descs := make([]*vtxo.Descriptor, 0, len(rows))
+	for _, row := range rows {
+		desc, err := s.rowToDescriptor(ctx, q, row.Vtxo, preloaded)
+		if err != nil {
+			return nil, fmt.Errorf("convert VTXO: %w", err)
+		}
+
+		if len(row.SettlementTxid) == chainhash.HashSize {
+			var settle vtxo.Settlement
+			copy(settle.TxID[:], row.SettlementTxid)
+			if row.SettlementHeight.Valid {
+				settle.Height = row.SettlementHeight.Int32
+			}
+			settle.FeeSat = row.SettlementFeeSat
+			desc.Settlement = fn.Some(settle)
+		}
+
+		descs = append(descs, desc)
+	}
+
+	return descs, nil
+}
+
+// allStatusesRowsToDescriptors converts the joined all-statuses rows to
+// descriptors. It mirrors byStatusRowsToDescriptors, which it cannot share
+// directly since sqlc generates a distinct row type per query.
+func (s *VTXOPersistenceStore) allStatusesRowsToDescriptors(ctx context.Context,
+	q RoundStore, rows []sqlc.ListVTXOsAllStatusesRow,
 	preloaded map[wire.OutPoint][]vtxo.Ancestry) ([]*vtxo.Descriptor,
 	error) {
 

--- a/db/vtxo_store_test.go
+++ b/db/vtxo_store_test.go
@@ -1278,6 +1278,64 @@ func TestVTXOPersistenceStoreListVTXOsByStatusSettlement(t *testing.T) {
 	require.Equal(t, refreshFeeSat+boardingFeeSat, settleLight.FeeSat)
 }
 
+// TestVTXOPersistenceStoreListVTXOsAllStatusesLight verifies that
+// ListVTXOsAllStatusesLight returns every VTXO regardless of status,
+// including the terminal statuses ListVTXOsExcludingStatusesLight omits.
+func TestVTXOPersistenceStoreListVTXOsAllStatusesLight(t *testing.T) {
+	t.Parallel()
+
+	vtxoStore, roundStore, _ := newVTXOStoreForTest(t)
+	ctx := t.Context()
+
+	roundID := testRoundIDDB("test-round-all-statuses")
+	testRound := createTestRound(t, roundID)
+	state := &round.InputSigSentState{
+		RoundID:     testRound.RoundID,
+		ClientTrees: make(map[round.SignerKey]*tree.Tree),
+	}
+	require.NoError(t, roundStore.CommitState(ctx, testRound, state))
+
+	live := createTestVTXODescriptor(t, roundID, 1)
+	forfeited := createTestVTXODescriptor(t, roundID, 2)
+	spent := createTestVTXODescriptor(t, roundID, 3)
+
+	require.NoError(t, vtxoStore.SaveVTXO(ctx, live))
+	require.NoError(t, vtxoStore.SaveVTXO(ctx, forfeited))
+	require.NoError(t, vtxoStore.SaveVTXO(ctx, spent))
+
+	require.NoError(
+		t, vtxoStore.UpdateVTXOStatus(
+			ctx, forfeited.Outpoint, vtxo.VTXOStatusForfeited,
+		),
+	)
+	require.NoError(
+		t, vtxoStore.UpdateVTXOStatus(
+			ctx, spent.Outpoint, vtxo.VTXOStatusSpent,
+		),
+	)
+
+	// The default listing excludes forfeited and spent.
+	excluding, err := vtxoStore.ListVTXOsExcludingStatusesLight(
+		ctx, vtxo.VTXOStatusForfeited, vtxo.VTXOStatusSpent,
+	)
+	require.NoError(t, err)
+	require.Len(t, excluding, 1)
+	require.Equal(t, live.Outpoint, excluding[0].Outpoint)
+
+	// show_all surfaces every VTXO, terminal or not.
+	all, err := vtxoStore.ListVTXOsAllStatusesLight(ctx)
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+
+	outpoints := make(map[wire.OutPoint]bool)
+	for _, v := range all {
+		outpoints[v.Outpoint] = true
+	}
+	require.True(t, outpoints[live.Outpoint])
+	require.True(t, outpoints[forfeited.Outpoint])
+	require.True(t, outpoints[spent.Outpoint])
+}
+
 // TestGroupAncestryRowsPreservesOrder is a unit test on the grouping
 // helper — distinct outpoints in the same row stream must produce
 // distinct map entries, and per-outpoint fragments must be appended

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -664,7 +664,7 @@ The VTXO inventory and onchain history are not part of the activity feed.
 Use the `ark` subtree for those:
 
 ```bash
-wavecli ark vtxos list          # live VTXO inventory
+wavecli ark vtxos list          # VTXO inventory (excludes forfeited, spent)
 wavecli ark listtransactions    # raw transaction / onchain history
 wavecli ark sweep list          # boarding-timeout sweep records
 ```

--- a/docs/daemon_cli_guide.md
+++ b/docs/daemon_cli_guide.md
@@ -419,12 +419,16 @@ List VTXOs known to the wallet with optional filters.
 |------|------|-------------|
 | `--status` | string | Filter: live, pending_forfeit, forfeiting, forfeited, spent, unilateral_exit, failed, spending |
 | `--min-amount` | int64 | Minimum amount in sats |
+| `--show-all` | bool | Show every VTXO regardless of status, including forfeited and spent ones; mutually exclusive with `--status` |
 | `--fields` | string | Comma-separated field names to include |
 | `--ndjson` | bool | Emit one JSON object per VTXO (newline-delimited) |
 
 ```bash
-# All VTXOs
+# VTXO inventory (excludes forfeited, spent)
 wavecli ark vtxos list
+
+# Every VTXO, including forfeited and spent
+wavecli ark vtxos list --show-all
 
 # Live VTXOs above 10k sats, only outpoint and amount
 wavecli ark vtxos list --status live --min-amount 10000 \

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -1225,16 +1225,24 @@ func roundStateLabel(s waverpc.RoundState) string {
 // ListVTXOs returns the set of VTXOs known to the wallet, optionally
 // filtered by status and minimum amount. When no status filter is given,
 // every VTXO except VTXO_STATUS_FORFEITED and VTXO_STATUS_SPENT is
-// returned. The VTXO_STATUS_PENDING_ROUND filter is special: it bypasses
-// the on-disk store and projects each upcoming VTXO from the live round
-// actor as a synthetic VTXO entry, giving callers a way to see the outputs
-// they have signed for but which have not yet been created by an on-chain
+// returned; show_all overrides that default to return every VTXO
+// regardless of status, and is mutually exclusive with status_filter. The
+// VTXO_STATUS_PENDING_ROUND filter is special: it bypasses the on-disk
+// store and projects each upcoming VTXO from the live round actor as a
+// synthetic VTXO entry, giving callers a way to see the outputs they have
+// signed for but which have not yet been created by an on-chain
 // commitment.
 func (r *RPCServer) ListVTXOs(ctx context.Context,
 	req *waverpc.ListVTXOsRequest) (*waverpc.ListVTXOsResponse, error) {
 
 	if err := r.requireWalletReady(); err != nil {
 		return nil, err
+	}
+
+	if req.ShowAll && req.StatusFilter !=
+		waverpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED {
+		return nil, status.Errorf(codes.InvalidArgument, "show_all "+
+			"and status_filter are mutually exclusive")
 	}
 
 	if req.StatusFilter ==
@@ -1247,18 +1255,22 @@ func (r *RPCServer) ListVTXOs(ctx context.Context,
 			"initialized")
 	}
 
-	// Fetch VTXOs from the store. When a specific status filter
-	// is provided, query the DB directly for that status so
-	// terminal states (spent, forfeited) are reachable. When
-	// unspecified, return every VTXO except forfeited and spent ones.
+	// Fetch VTXOs from the store. When a specific status filter is
+	// provided, query the DB directly for that status so terminal
+	// states (spent, forfeited) are reachable. When show_all is set,
+	// return every VTXO regardless of status. Otherwise, return every
+	// VTXO except forfeited and spent ones.
 	var (
 		dbVTXOs []*vtxo.Descriptor
 		err     error
 	)
 
-	if req.StatusFilter !=
-		waverpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED {
+	vtxoStore := r.server.vtxoStore
+	switch {
+	case req.ShowAll:
+		dbVTXOs, err = vtxoStore.ListVTXOsAllStatusesLight(ctx)
 
+	case req.StatusFilter != waverpc.VTXOStatus_VTXO_STATUS_UNSPECIFIED:
 		domainStatus, sErr := protoStatusToDomain(
 			req.StatusFilter,
 		)
@@ -1270,11 +1282,11 @@ func (r *RPCServer) ListVTXOs(ctx context.Context,
 		// The listing response never carries ancestry, so the light
 		// variants skip the ancestry side-table join (whose TLV tree
 		// fragments grow with OOR chain depth) entirely.
-		dbVTXOs, err = r.server.vtxoStore.ListVTXOsByStatusLight(
+		dbVTXOs, err = vtxoStore.ListVTXOsByStatusLight(
 			ctx, domainStatus,
 		)
-	} else {
-		vtxoStore := r.server.vtxoStore
+
+	default:
 		dbVTXOs, err = vtxoStore.ListVTXOsExcludingStatusesLight(
 			ctx, vtxo.VTXOStatusForfeited, vtxo.VTXOStatusSpent,
 		)

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -1223,11 +1223,13 @@ func roundStateLabel(s waverpc.RoundState) string {
 }
 
 // ListVTXOs returns the set of VTXOs known to the wallet, optionally
-// filtered by status and minimum amount. The VTXO_STATUS_PENDING_ROUND
-// filter is special: it bypasses the on-disk store and projects each
-// upcoming VTXO from the live round actor as a synthetic VTXO entry,
-// giving callers a way to see the outputs they have signed for but
-// which have not yet been created by an on-chain commitment.
+// filtered by status and minimum amount. When no status filter is given,
+// every VTXO except VTXO_STATUS_FORFEITED and VTXO_STATUS_SPENT is
+// returned. The VTXO_STATUS_PENDING_ROUND filter is special: it bypasses
+// the on-disk store and projects each upcoming VTXO from the live round
+// actor as a synthetic VTXO entry, giving callers a way to see the outputs
+// they have signed for but which have not yet been created by an on-chain
+// commitment.
 func (r *RPCServer) ListVTXOs(ctx context.Context,
 	req *waverpc.ListVTXOsRequest) (*waverpc.ListVTXOsResponse, error) {
 
@@ -1248,7 +1250,7 @@ func (r *RPCServer) ListVTXOs(ctx context.Context,
 	// Fetch VTXOs from the store. When a specific status filter
 	// is provided, query the DB directly for that status so
 	// terminal states (spent, forfeited) are reachable. When
-	// unspecified, return all non-terminal (live) VTXOs.
+	// unspecified, return every VTXO except forfeited and spent ones.
 	var (
 		dbVTXOs []*vtxo.Descriptor
 		err     error
@@ -1272,7 +1274,10 @@ func (r *RPCServer) ListVTXOs(ctx context.Context,
 			ctx, domainStatus,
 		)
 	} else {
-		dbVTXOs, err = r.server.vtxoStore.ListLiveVTXOsLight(ctx)
+		vtxoStore := r.server.vtxoStore
+		dbVTXOs, err = vtxoStore.ListVTXOsExcludingStatusesLight(
+			ctx, vtxo.VTXOStatusForfeited, vtxo.VTXOStatusSpent,
+		)
 	}
 
 	if err != nil {

--- a/waved/rpc_server_test.go
+++ b/waved/rpc_server_test.go
@@ -2,6 +2,7 @@ package waved
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"testing"
@@ -19,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/lightninglabs/wavelength/arkrpc"
 	"github.com/lightninglabs/wavelength/baselib/actor"
+	"github.com/lightninglabs/wavelength/db"
 	"github.com/lightninglabs/wavelength/lib/actormsg"
 	"github.com/lightninglabs/wavelength/lib/arkscript"
 	oortx "github.com/lightninglabs/wavelength/lib/tx/oor"
@@ -28,6 +30,7 @@ import (
 	"github.com/lightninglabs/wavelength/unroll"
 	"github.com/lightninglabs/wavelength/vtxo"
 	"github.com/lightninglabs/wavelength/waverpc"
+	"github.com/lightningnetwork/lnd/clock"
 	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
@@ -1481,6 +1484,81 @@ func TestListVTXOsPendingRoundSkipsConfirmedRounds(t *testing.T) {
 			"VTXO_STATUS_LIVE in the store; they must not "+
 			"double-report here",
 	)
+}
+
+// TestListVTXOsShowAll verifies that show_all returns every VTXO
+// regardless of status (including forfeited and spent, which the
+// default listing excludes), and that combining show_all with
+// status_filter is rejected as mutually exclusive.
+func TestListVTXOsShowAll(t *testing.T) {
+	t.Parallel()
+
+	sqlDB := db.NewTestDB(t)
+	roundDB := db.NewTransactionExecutor(
+		sqlDB.BaseDB,
+		func(tx *sql.Tx) db.RoundStore {
+			return sqlDB.WithTx(tx)
+		},
+		btclog.Disabled,
+	)
+	vtxoStore := db.NewVTXOPersistenceStore(
+		roundDB, clock.NewDefaultClock(),
+	)
+
+	liveDesc := newRefreshEstimateVTXO(t, 0x01, 10_000, 900)
+	forfeitedDesc := newRefreshEstimateVTXO(t, 0x02, 10_000, 900)
+	spentDesc := newRefreshEstimateVTXO(t, 0x03, 10_000, 900)
+
+	require.NoError(t, vtxoStore.SaveVTXO(t.Context(), liveDesc))
+	require.NoError(t, vtxoStore.SaveVTXO(t.Context(), forfeitedDesc))
+	require.NoError(t, vtxoStore.SaveVTXO(t.Context(), spentDesc))
+	require.NoError(
+		t,
+		vtxoStore.UpdateVTXOStatus(
+			t.Context(), forfeitedDesc.Outpoint,
+			vtxo.VTXOStatusForfeited,
+		),
+	)
+	require.NoError(
+		t,
+		vtxoStore.UpdateVTXOStatus(
+			t.Context(), spentDesc.Outpoint, vtxo.VTXOStatusSpent,
+		),
+	)
+
+	walletReady := make(chan struct{})
+	close(walletReady)
+	srv := &RPCServer{server: &Server{
+		walletReady: walletReady,
+		vtxoStore:   vtxoStore,
+	}}
+
+	defaultResp, err := srv.ListVTXOs(
+		t.Context(), &waverpc.ListVTXOsRequest{},
+	)
+	require.NoError(t, err)
+	require.Len(
+		t, defaultResp.Vtxos, 1,
+		"forfeited and spent should be excluded by default",
+	)
+
+	allResp, err := srv.ListVTXOs(
+		t.Context(), &waverpc.ListVTXOsRequest{
+			ShowAll: true,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(
+		t, allResp.Vtxos, 3,
+		"show_all must include forfeited and spent VTXOs",
+	)
+
+	_, err = srv.ListVTXOs(t.Context(), &waverpc.ListVTXOsRequest{
+		ShowAll:      true,
+		StatusFilter: waverpc.VTXOStatus_VTXO_STATUS_LIVE,
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 // TestQueryRoundStatesEarlyStateOmitsCommitmentTxid verifies that

--- a/waverpc/daemon.pb.go
+++ b/waverpc/daemon.pb.go
@@ -2145,7 +2145,9 @@ func (x *VTXOSettlement) GetFeeSat() int64 {
 type ListVTXOsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// status_filter restricts the response to VTXOs matching this status.
-	// If VTXO_STATUS_UNSPECIFIED (default), all statuses are returned.
+	// If VTXO_STATUS_UNSPECIFIED (default), every VTXO except
+	// VTXO_STATUS_FORFEITED and VTXO_STATUS_SPENT is returned; set show_all
+	// to include those too.
 	StatusFilter VTXOStatus `protobuf:"varint,1,opt,name=status_filter,json=statusFilter,proto3,enum=waverpc.VTXOStatus" json:"status_filter,omitempty"`
 	// min_amount_sat excludes VTXOs below this value.
 	MinAmountSat int64 `protobuf:"varint,2,opt,name=min_amount_sat,json=minAmountSat,proto3" json:"min_amount_sat,omitempty"`
@@ -2155,8 +2157,12 @@ type ListVTXOsRequest struct {
 	// consumers (balance views, coin selection) that never inspect the
 	// PSBTs. The default keeps the full response for compatibility.
 	ExcludeCheckpointPsbts bool `protobuf:"varint,3,opt,name=exclude_checkpoint_psbts,json=excludeCheckpointPsbts,proto3" json:"exclude_checkpoint_psbts,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// show_all returns every VTXO regardless of status, including
+	// VTXO_STATUS_FORFEITED and VTXO_STATUS_SPENT. Mutually exclusive with
+	// status_filter.
+	ShowAll       bool `protobuf:"varint,4,opt,name=show_all,json=showAll,proto3" json:"show_all,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ListVTXOsRequest) Reset() {
@@ -2206,6 +2212,13 @@ func (x *ListVTXOsRequest) GetMinAmountSat() int64 {
 func (x *ListVTXOsRequest) GetExcludeCheckpointPsbts() bool {
 	if x != nil {
 		return x.ExcludeCheckpointPsbts
+	}
+	return false
+}
+
+func (x *ListVTXOsRequest) GetShowAll() bool {
+	if x != nil {
+		return x.ShowAll
 	}
 	return false
 }
@@ -10402,11 +10415,12 @@ const file_daemon_proto_rawDesc = "" +
 	"\x0eVTXOSettlement\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x16\n" +
 	"\x06height\x18\x02 \x01(\x05R\x06height\x12\x17\n" +
-	"\afee_sat\x18\x03 \x01(\x03R\x06feeSat\"\xac\x01\n" +
+	"\afee_sat\x18\x03 \x01(\x03R\x06feeSat\"\xc7\x01\n" +
 	"\x10ListVTXOsRequest\x128\n" +
 	"\rstatus_filter\x18\x01 \x01(\x0e2\x13.waverpc.VTXOStatusR\fstatusFilter\x12$\n" +
 	"\x0emin_amount_sat\x18\x02 \x01(\x03R\fminAmountSat\x128\n" +
-	"\x18exclude_checkpoint_psbts\x18\x03 \x01(\bR\x16excludeCheckpointPsbts\"8\n" +
+	"\x18exclude_checkpoint_psbts\x18\x03 \x01(\bR\x16excludeCheckpointPsbts\x12\x19\n" +
+	"\bshow_all\x18\x04 \x01(\bR\ashowAll\"8\n" +
 	"\x11ListVTXOsResponse\x12#\n" +
 	"\x05vtxos\x18\x01 \x03(\v2\r.waverpc.VTXOR\x05vtxos\"\x13\n" +
 	"\x11NewAddressRequest\".\n" +

--- a/waverpc/daemon.proto
+++ b/waverpc/daemon.proto
@@ -750,7 +750,9 @@ message VTXOSettlement {
 
 message ListVTXOsRequest {
     // status_filter restricts the response to VTXOs matching this status.
-    // If VTXO_STATUS_UNSPECIFIED (default), all statuses are returned.
+    // If VTXO_STATUS_UNSPECIFIED (default), every VTXO except
+    // VTXO_STATUS_FORFEITED and VTXO_STATUS_SPENT is returned; set show_all
+    // to include those too.
     VTXOStatus status_filter = 1;
 
     // min_amount_sat excludes VTXOs below this value.
@@ -762,6 +764,11 @@ message ListVTXOsRequest {
     // consumers (balance views, coin selection) that never inspect the
     // PSBTs. The default keeps the full response for compatibility.
     bool exclude_checkpoint_psbts = 3;
+
+    // show_all returns every VTXO regardless of status, including
+    // VTXO_STATUS_FORFEITED and VTXO_STATUS_SPENT. Mutually exclusive with
+    // status_filter.
+    bool show_all = 4;
 }
 
 message ListVTXOsResponse {


### PR DESCRIPTION
This pull request addresses #1116 

As of now, `wavecli ark vtxos list` only shows live VTXOs. This means that any application building on that RPC call has to make repeated RPC calls to fetch all VTXOs, regarding of their status. By default, any VTXO that isn't `live` appears to be simply missing.

Available statuses include: `live`, `pending_forfeit`, `forfeiting`, `forfeited`, `spent`, `unilateral_exit`, `failed`, `spending`

In the first commit, we expand this to all VTXOs, except forfeited and spent VTXOs. I believe this best represents the VTXOs a user would care about.

In the second commit, we add a new `--show-all` flag that gives the user or application the option to query all VTXOs, regardless of their status, and then filter themselves.

Future work to consider:
- Allow multiple ` --status` flags to be passed
- Distinguish between successful/completed unilateral exit, and unilateral exit in progress
