### PR TITLE
docs: nightly doc-gardening sweep 2026-08-10

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,6 +36,7 @@ package may import from a higher layer.
 | Package | Purpose |
 |---------|---------|
 | [`baselib`](baselib/) | Actor framework (`baselib/actor`) and protofsm state machine engine (`baselib/protofsm`) |
+| [`build`](build/) | Cross-cutting build metadata and logging infrastructure: deployment mode, build-tag-controlled log type/level, context logger propagation, subsystem logger factory, version string. Imports no repo package |
 | [`chainsource`](chainsource/) | `ChainBackend` interface: fee estimation, block/conf/spend notifications |
 | [`chainbackends`](chainbackends/) | LND-backed `ChainBackend` implementation plus lndclient adapters (`TxBroadcaster`, `PackageSubmitter`) |
 | [`chainbackends/lndsubmitter`](chainbackends/lndsubmitter/) | `chainbackends.PackageSubmitter` over lnd's WalletKit; the default LND package-relay submitter |
@@ -56,6 +57,7 @@ package may import from a higher layer.
 | [`serverconn`](serverconn/) | Unified server connector: durable egress, ingress polling, unary RPC facade |
 | [`serverconn/mailboxpull`](serverconn/mailboxpull/) | Shared exponential-backoff retry primitives for mailbox pull loops (used by serverconn ingress and SDK swap consumers) |
 | [`rpcauth`](rpcauth/) | Shared macaroon and TLS helpers securing gRPC/REST connections |
+| [`metrics`](metrics/) | Prometheus instrumentation namespaced under `waved_`: event-driven counter actor pool plus a scrape-time `SystemCollector` for live gauges, and an opt-in `/metrics` HTTP server |
 | [`internal/sqlbase`](internal/sqlbase/) | `walletdb`-compatible key/value backend over `database/sql` (js/wasm walletdb storage for `lwwallet` browser builds) |
 
 ### Layer 3: Application & Orchestration


### PR DESCRIPTION
Automated nightly documentation-graph sweep via `.claude/skills/doc-gardening`, anchored to the last merged nightly (`c3c87644`).

**Result:** one substantive change. No Go source changed since the baseline, so no per-package `CLAUDE.md`/`AGENTS.md` needed regeneration and all 106 mirror pairs are already byte-identical. The sweep did surface a one-way link in the doc graph: `build/` and `metrics/` each have a `CLAUDE.md` that backlinks to `ARCHITECTURE.md`, but neither package was ever listed in the layer tables. Both are added to the **Layer 2 (Infrastructure)** table, matching how `baselib` — also cross-cutting infrastructure imported by Layer 1 packages — is already placed.

Note that `make doc-check` does not catch this class of gap: it validates that packages *referenced by* `ARCHITECTURE.md` have a `CLAUDE.md`, not the reverse. The two table rows are the reviewable content here — please check that the Layer 2 placement and the one-line purposes (drawn from each package's own `CLAUDE.md`) read correctly.

Workflow run: https://github.com/lightninglabs/wavelength/actions

Please review the `ARCHITECTURE.md` diff; no `CLAUDE.md`/`AGENTS.md` files were modified in this sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
