### PR TITLE
mobile: prevent wallet stalls on external I/O

### DIFF
--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -156,6 +156,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   3s cap).
 - SQLite `busy_timeout = 30 000 ms` under WAL mode tolerates
   multi-actor contention bursts.
+- Postgres test fixture slots bound Docker startup and migrations only. Helpers
+  release the slot before returning the initialized store; retaining it until
+  test cleanup can deadlock Go's parallel-test barrier.
 - `ledger_entries.entry_id` and `wallet_utxo_log.entry_id` use
   `INTEGER PRIMARY KEY AUTOINCREMENT` to prevent rowid reuse after
   deletion, preserving append-only ordering.

--- a/db/CLAUDE.md
+++ b/db/CLAUDE.md
@@ -156,6 +156,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/db.<Symb
   3s cap).
 - SQLite `busy_timeout = 30 000 ms` under WAL mode tolerates
   multi-actor contention bursts.
+- Postgres test fixture slots bound Docker startup and migrations only. Helpers
+  release the slot before returning the initialized store; retaining it until
+  test cleanup can deadlock Go's parallel-test barrier.
 - `ledger_entries.entry_id` and `wallet_utxo_log.entry_id` use
   `INTEGER PRIMARY KEY AUTOINCREMENT` to prevent rowid reuse after
   deletion, preserving append-only ordering.

--- a/db/postgres_fixture.go
+++ b/db/postgres_fixture.go
@@ -124,10 +124,12 @@ func NewTestPgFixture(t testing.TB, expiry time.Duration,
 	return fixture
 }
 
-// acquireTestPgFixtureSlot bounds active Postgres containers in parallel test
-// runs. The db package marks most tests parallel, and unbounded docker startup
-// can starve CI runners enough that stores observe partially initialized
-// schemas.
+// acquireTestPgFixtureSlot bounds concurrent Postgres fixture initialization.
+// The db package marks most tests parallel, and unbounded Docker startup and
+// migrations can starve CI runners enough that stores observe partially
+// initialized schemas. Callers release the slot once store initialization
+// returns; holding it for the full test lifetime can deadlock Go's parallel
+// test barrier.
 func acquireTestPgFixtureSlot() func() {
 	testPgFixtureSem <- struct{}{}
 
@@ -137,6 +139,15 @@ func acquireTestPgFixtureSlot() func() {
 		once.Do(func() {
 			<-testPgFixtureSem
 		})
+	}
+}
+
+// releaseFixtureInitSlot releases the fixture's initialization slot. The
+// closure is idempotent so teardown remains a safe fallback for callers that
+// fail before store initialization returns.
+func (f *TestPgFixture) releaseFixtureInitSlot() {
+	if f.releaseSlot != nil {
+		f.releaseSlot()
 	}
 }
 
@@ -160,9 +171,7 @@ func (f *TestPgFixture) GetConfig() *PostgresConfig {
 // TearDown stops the underlying docker container.
 func (f *TestPgFixture) TearDown(t testing.TB) {
 	err := f.pool.Purge(f.resource)
-	if f.releaseSlot != nil {
-		f.releaseSlot()
-	}
+	f.releaseFixtureInitSlot()
 	require.NoError(t, err, "Could not purge resource")
 }
 

--- a/db/postgres_test_helpers.go
+++ b/db/postgres_test_helpers.go
@@ -30,6 +30,7 @@ func NewTestPostgresDB(t testing.TB) *PostgresStore {
 	log := btclog.Disabled
 
 	sqlFixture := NewTestPgFixture(t, DefaultPostgresFixtureLifetime, true)
+	defer sqlFixture.releaseFixtureInitSlot()
 
 	// Cleanups run in reverse order. Register the fixture first so the
 	// store pool registered below is closed before its container is
@@ -62,6 +63,7 @@ func NewTestPostgresDBWithVersion(t testing.TB, version uint) *PostgresStore {
 	log := btclog.Disabled
 
 	sqlFixture := NewTestPgFixture(t, DefaultPostgresFixtureLifetime, true)
+	defer sqlFixture.releaseFixtureInitSlot()
 
 	// Cleanups run in reverse order. Register the fixture first so the
 	// store pool registered below is closed before its container is

--- a/db/postgres_test_helpers_test.go
+++ b/db/postgres_test_helpers_test.go
@@ -8,14 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNewTestPostgresDBClosesStore verifies that the common fixture helper
-// closes its connection pool before tearing down the Postgres container.
-func TestNewTestPostgresDBClosesStore(t *testing.T) {
+// TestNewTestPostgresDBLifecycle verifies that the common fixture helper
+// releases its initialization slot before returning and closes its connection
+// pool before tearing down the Postgres container.
+func TestNewTestPostgresDBLifecycle(t *testing.T) {
 	var store *PostgresStore
 
 	t.Run("fixture lifetime", func(t *testing.T) {
 		store = NewTestPostgresDB(t)
 		require.NoError(t, store.DB.Ping())
+		require.Empty(t, testPgFixtureSem)
 	})
 
 	require.NotNil(t, store)

--- a/db/test_postgres.go
+++ b/db/test_postgres.go
@@ -73,6 +73,7 @@ func NewTestDBHandleFromPath(t testing.TB, dbPath string) *PostgresStore {
 		sqlFixture = NewTestPgFixture(
 			t, DefaultPostgresFixtureLifetime, true,
 		)
+		defer sqlFixture.releaseFixtureInitSlot()
 
 		store, err := NewPostgresStore(sqlFixture.GetConfig(), log)
 		if err != nil {

--- a/docs/wavewalletdk_mobile.md
+++ b/docs/wavewalletdk_mobile.md
@@ -54,10 +54,10 @@ request is a small camelCase-tagged struct (`prfOutput`). Every other request
 decodes into the matching `wavewalletdk.*Request` DTO, so it follows the
 PascalCase rule. `Receive` additionally accepts `TimeoutSeconds`: zero or an
 omitted field selects a 20-second default, and values above five minutes are
-rejected. A binding-owned deadline returns an error beginning `receive timed
-out; outcome uncertain; reconcile Activity before retrying`. It does not prove
-that the receive session was not created. The host must reconcile the
-authoritative Activity view and recover any matching invoice before
+rejected. A binding-owned deadline or lifecycle cancellation returns an error
+beginning `receive outcome uncertain; reconcile Activity before retrying`. It
+does not prove that the receive session was not created. The host must reconcile
+the authoritative Activity view and recover any matching invoice before
 deliberately asking to create another one. Repeatable reads (`GetInfo`,
 `Balance`, `List`, `ExitStatus`, `ExitSummary`, `GetExitPlan`, `Status`, and the
 scalar balance/readiness helpers) use a 10-second binding-owned deadline because

--- a/docs/wavewalletdk_mobile.md
+++ b/docs/wavewalletdk_mobile.md
@@ -52,7 +52,14 @@ not snake_case. Host models must map those exact names (e.g. `@SerialName`
 (`data_dir`, `wallet_esplora_url`, …), and `OpenWalletFromPasskey`, whose
 request is a small camelCase-tagged struct (`prfOutput`). Every other request
 decodes into the matching `wavewalletdk.*Request` DTO, so it follows the
-PascalCase rule.
+PascalCase rule. `Receive` additionally accepts `TimeoutSeconds`: zero or an
+omitted field selects a 20-second default, and positive values are capped at
+five minutes. A deadline error does not prove that the receive session was not
+created. The host must reconcile the authoritative Activity view and recover
+any matching invoice before deliberately asking to create another one.
+Repeatable `Balance`, `List`, and `Status` reads use a 10-second binding-owned
+deadline because gomobile cannot carry a caller `context.Context`; these reads
+are safe for the host to request again after timeout.
 
 `StartExternalSeedWallet` is another explicit exception in the private binding
 ABI. Its startup envelope is snake_case (`config`, `seed_entropy`,
@@ -95,6 +102,13 @@ func Stop() error
   and in-flight RPCs / subscriptions unwind on shutdown.
 - The startup deadline bounds daemon readiness only. External-seed opening and
   recovery use the lifecycle context cancelled by `Stop`.
+- The portable Go binding cannot observe an iOS or Android application
+  lifecycle. A host that leaves the embedded daemon alive while its process is
+  suspended also leaves external gRPC connections frozen on their old network
+  path. After a real background/resume transition, call `Stop` and `Start`
+  (then unlock the same durable wallet) so external transports are re-dialled.
+  The lifecycle state machine prevents overlapping daemon instances; it does
+  not infer foreground state for the host.
 
 ### External seed wallets
 

--- a/docs/wavewalletdk_mobile.md
+++ b/docs/wavewalletdk_mobile.md
@@ -53,13 +53,16 @@ not snake_case. Host models must map those exact names (e.g. `@SerialName`
 request is a small camelCase-tagged struct (`prfOutput`). Every other request
 decodes into the matching `wavewalletdk.*Request` DTO, so it follows the
 PascalCase rule. `Receive` additionally accepts `TimeoutSeconds`: zero or an
-omitted field selects a 20-second default, and positive values are capped at
-five minutes. A deadline error does not prove that the receive session was not
-created. The host must reconcile the authoritative Activity view and recover
-any matching invoice before deliberately asking to create another one.
-Repeatable `Balance`, `List`, and `Status` reads use a 10-second binding-owned
-deadline because gomobile cannot carry a caller `context.Context`; these reads
-are safe for the host to request again after timeout.
+omitted field selects a 20-second default, and values above five minutes are
+rejected. A binding-owned deadline returns an error beginning `receive timed
+out; outcome uncertain; reconcile Activity before retrying`. It does not prove
+that the receive session was not created. The host must reconcile the
+authoritative Activity view and recover any matching invoice before
+deliberately asking to create another one. Repeatable reads (`GetInfo`,
+`Balance`, `List`, `ExitStatus`, `ExitSummary`, `GetExitPlan`, `Status`, and the
+scalar balance/readiness helpers) use a 10-second binding-owned deadline because
+gomobile cannot carry a caller `context.Context`; these reads are safe for the
+host to request again after timeout.
 
 `StartExternalSeedWallet` is another explicit exception in the private binding
 ABI. Its startup envelope is snake_case (`config`, `seed_entropy`,

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/btcsuite/btcd v0.26.0
 	github.com/btcsuite/btcd/btcec/v2 v2.5.0
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b
-	github.com/btcsuite/btcwallet v0.18.0
+	github.com/btcsuite/btcwallet v0.18.1-0.20260826052527-33c252f3b4d6
 	github.com/btcsuite/btcwallet/walletdb v1.6.0
 	github.com/btcsuite/btcwallet/wtxmgr v1.6.0
 	github.com/golang-migrate/migrate/v4 v4.19.1

--- a/go.sum
+++ b/go.sum
@@ -658,8 +658,8 @@ github.com/btcsuite/btclog v1.0.0 h1:sEkpKJMmfGiyZjADwEIgB1NSwMyfdD1FB8v6+w1T0Ns
 github.com/btcsuite/btclog v1.0.0/go.mod h1:w7xnGOhwT3lmrS4H3b/D1XAXxvh+tbhUm8xeHN2y3TQ=
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b h1:MQ+Q6sDy37V1wP1Yu79A5KqJutolqUGwA99UZWQDWZM=
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250728225537-6090e87c6c5b/go.mod h1:XItGUfVOxotJL8kkuk2Hj3EVow5KCugXl3wWfQ6K0AE=
-github.com/btcsuite/btcwallet v0.18.0 h1:VSRClNLT7NX0wmJEGALz3jOZRRjWPpUdp7VI1Akie1o=
-github.com/btcsuite/btcwallet v0.18.0/go.mod h1:1ZMc1EEskov+AKKv4kCMZqN8BwVh9rpXwEyxbeWy2A4=
+github.com/btcsuite/btcwallet v0.18.1-0.20260826052527-33c252f3b4d6 h1:A49O49JWTm2xaI3lWWtlYAQ8dpM3eMCu6JV52AWXOhQ=
+github.com/btcsuite/btcwallet v0.18.1-0.20260826052527-33c252f3b4d6/go.mod h1:1ZMc1EEskov+AKKv4kCMZqN8BwVh9rpXwEyxbeWy2A4=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.4.0 h1:oIkGj32YK1CvWaJGlVwZA1f+y/KVHkfrd2PoST0ZpQs=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.4.0/go.mod h1:sGrBjcqQ8UPexuRajFs72+o544CJn3Pavv/5H0VAWVk=
 github.com/btcsuite/btcwallet/wallet/txrules v1.3.0 h1:D5aGMwWIxdqek3xEJs4eOdMoh6iga2EI2xSlaXCdnNo=

--- a/sdk/wavewalletdk/mobile/AGENTS.md
+++ b/sdk/wavewalletdk/mobile/AGENTS.md
@@ -27,12 +27,17 @@ application-facing wallet API.
   `applyMobileConfig` into a `wavewalletdk.Config`; validated (non-negative
   durations/counts, `uint32`-safe recovery window) before merging onto
   `wavewalletdk.DefaultConfig()`.
+- `mobileReceiveRequest` — unexported wire DTO carrying the SDK's current
+  `AmountSat`/`Memo` fields plus the mobile-only `TimeoutSeconds`. It is
+  projected onto `wavewalletdk.ReceiveRequest` after deadline validation.
 - RPC verbs (`GetInfo`, `CreateWallet`, `UnlockWallet`, `Balance`, `Deposit`,
   `Receive`, `PrepareSend`, `SendPrepared`, `List`, `Exit`, `ExitStatus`,
   `ExitSummary`, `GetExitPlan`, `SweepWallet`, `Status`, `Subscribe`,
   `OpenWalletFromPasskey`) — each dereferences the singleton `wavewalletdk.Client`
   via `activeClient()`, decodes a JSON request into the matching
   `wavewalletdk.*Request`, and marshals the `wavewalletdk.*Result` response.
+  `Receive` is the exception: it decodes `mobileReceiveRequest` first so the
+  binding can own its request deadline without changing the SDK DTO.
 - Scalar conveniences (`ConfirmedBalanceSat`, `PendingInboundSat`,
   `WalletReady`, `IsRunning`) — avoid a JSON round trip for hot-path reads;
   `IsRunning` never blocks on an RPC.
@@ -57,6 +62,18 @@ application-facing wallet API.
   can succeed (e.g. after OS suspend/resume).
 - `startEmbedded` separates its daemon-readiness deadline from the lifecycle
   context used to open or recover the wallet. `Stop` cancels both.
+- gomobile cannot carry a caller `context.Context`, so this package owns
+  per-call deadlines. Repeatable reads (`GetInfo`, `Balance`, `List`,
+  `ExitStatus`, `ExitSummary`, `GetExitPlan`, `Status`, and the scalar
+  balance/readiness helpers) use `readContext`'s 10-second deadline. `Receive`
+  uses `TimeoutSeconds`, defaults to 20 seconds when zero or omitted, and
+  rejects negative values or values above five minutes.
+- A binding-owned `Receive` deadline is returned with the stable
+  `receiveTimeoutErrorPrefix`. The result is uncertain: the host must reconcile
+  Activity before deliberately requesting another invoice. Parent lifecycle
+  cancellation is left unchanged because it means the daemon is stopping.
+- Every bounded call context derives from the daemon-lifetime parent returned
+  by `activeClient`, so `Stop` still cancels in-flight calls immediately.
 - Startup through `startEmbedded` and `Subscription.Next` recover panics into
   a returned `error`; those are the entry points documented to survive a panic
   without crossing the gomobile boundary and killing the host process.
@@ -70,6 +87,8 @@ application-facing wallet API.
 
 ## Deep Docs
 
+- [docs/wavewalletdk_mobile.md](../../../docs/wavewalletdk_mobile.md) — Binding
+  ABI, JSON field casing, per-call deadlines, and host lifecycle rules.
 - [sdk/wavewalletdk/CLAUDE.md](../CLAUDE.md) — Wrapped SDK; see for full DTO and
   RPC method detail.
 - [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/wavewalletdk/mobile/AGENTS.md
+++ b/sdk/wavewalletdk/mobile/AGENTS.md
@@ -68,10 +68,10 @@ application-facing wallet API.
   balance/readiness helpers) use `readContext`'s 10-second deadline. `Receive`
   uses `TimeoutSeconds`, defaults to 20 seconds when zero or omitted, and
   rejects negative values or values above five minutes.
-- A binding-owned `Receive` deadline is returned with the stable
-  `receiveTimeoutErrorPrefix`. The result is uncertain: the host must reconcile
-  Activity before deliberately requesting another invoice. Parent lifecycle
-  cancellation is left unchanged because it means the daemon is stopping.
+- A `Receive` canceled by its binding-owned deadline or the parent lifecycle is
+  returned with the stable `receiveUncertainErrorPrefix`. The result is
+  uncertain: the host must reconcile Activity before deliberately requesting
+  another invoice.
 - Every bounded call context derives from the daemon-lifetime parent returned
   by `activeClient`, so `Stop` still cancels in-flight calls immediately.
 - Startup through `startEmbedded` and `Subscription.Next` recover panics into

--- a/sdk/wavewalletdk/mobile/CLAUDE.md
+++ b/sdk/wavewalletdk/mobile/CLAUDE.md
@@ -27,12 +27,17 @@ application-facing wallet API.
   `applyMobileConfig` into a `wavewalletdk.Config`; validated (non-negative
   durations/counts, `uint32`-safe recovery window) before merging onto
   `wavewalletdk.DefaultConfig()`.
+- `mobileReceiveRequest` — unexported wire DTO carrying the SDK's current
+  `AmountSat`/`Memo` fields plus the mobile-only `TimeoutSeconds`. It is
+  projected onto `wavewalletdk.ReceiveRequest` after deadline validation.
 - RPC verbs (`GetInfo`, `CreateWallet`, `UnlockWallet`, `Balance`, `Deposit`,
   `Receive`, `PrepareSend`, `SendPrepared`, `List`, `Exit`, `ExitStatus`,
   `ExitSummary`, `GetExitPlan`, `SweepWallet`, `Status`, `Subscribe`,
   `OpenWalletFromPasskey`) — each dereferences the singleton `wavewalletdk.Client`
   via `activeClient()`, decodes a JSON request into the matching
   `wavewalletdk.*Request`, and marshals the `wavewalletdk.*Result` response.
+  `Receive` is the exception: it decodes `mobileReceiveRequest` first so the
+  binding can own its request deadline without changing the SDK DTO.
 - Scalar conveniences (`ConfirmedBalanceSat`, `PendingInboundSat`,
   `WalletReady`, `IsRunning`) — avoid a JSON round trip for hot-path reads;
   `IsRunning` never blocks on an RPC.
@@ -57,6 +62,18 @@ application-facing wallet API.
   can succeed (e.g. after OS suspend/resume).
 - `startEmbedded` separates its daemon-readiness deadline from the lifecycle
   context used to open or recover the wallet. `Stop` cancels both.
+- gomobile cannot carry a caller `context.Context`, so this package owns
+  per-call deadlines. Repeatable reads (`GetInfo`, `Balance`, `List`,
+  `ExitStatus`, `ExitSummary`, `GetExitPlan`, `Status`, and the scalar
+  balance/readiness helpers) use `readContext`'s 10-second deadline. `Receive`
+  uses `TimeoutSeconds`, defaults to 20 seconds when zero or omitted, and
+  rejects negative values or values above five minutes.
+- A binding-owned `Receive` deadline is returned with the stable
+  `receiveTimeoutErrorPrefix`. The result is uncertain: the host must reconcile
+  Activity before deliberately requesting another invoice. Parent lifecycle
+  cancellation is left unchanged because it means the daemon is stopping.
+- Every bounded call context derives from the daemon-lifetime parent returned
+  by `activeClient`, so `Stop` still cancels in-flight calls immediately.
 - Startup through `startEmbedded` and `Subscription.Next` recover panics into
   a returned `error`; those are the entry points documented to survive a panic
   without crossing the gomobile boundary and killing the host process.
@@ -70,6 +87,8 @@ application-facing wallet API.
 
 ## Deep Docs
 
+- [docs/wavewalletdk_mobile.md](../../../docs/wavewalletdk_mobile.md) — Binding
+  ABI, JSON field casing, per-call deadlines, and host lifecycle rules.
 - [sdk/wavewalletdk/CLAUDE.md](../CLAUDE.md) — Wrapped SDK; see for full DTO and
   RPC method detail.
 - [ARCHITECTURE.md](../../../ARCHITECTURE.md) — System-wide package map.

--- a/sdk/wavewalletdk/mobile/CLAUDE.md
+++ b/sdk/wavewalletdk/mobile/CLAUDE.md
@@ -68,10 +68,10 @@ application-facing wallet API.
   balance/readiness helpers) use `readContext`'s 10-second deadline. `Receive`
   uses `TimeoutSeconds`, defaults to 20 seconds when zero or omitted, and
   rejects negative values or values above five minutes.
-- A binding-owned `Receive` deadline is returned with the stable
-  `receiveTimeoutErrorPrefix`. The result is uncertain: the host must reconcile
-  Activity before deliberately requesting another invoice. Parent lifecycle
-  cancellation is left unchanged because it means the daemon is stopping.
+- A `Receive` canceled by its binding-owned deadline or the parent lifecycle is
+  returned with the stable `receiveUncertainErrorPrefix`. The result is
+  uncertain: the host must reconcile Activity before deliberately requesting
+  another invoice.
 - Every bounded call context derives from the daemon-lifetime parent returned
   by `activeClient`, so `Stop` still cancels in-flight calls immediately.
 - Startup through `startEmbedded` and `Subscription.Next` recover panics into

--- a/sdk/wavewalletdk/mobile/convenience.go
+++ b/sdk/wavewalletdk/mobile/convenience.go
@@ -8,10 +8,12 @@ package mobile
 
 // ConfirmedBalanceSat returns the confirmed wallet balance in satoshis.
 func ConfirmedBalanceSat() (int64, error) {
-	client, ctx, err := activeClient()
+	client, parentCtx, err := activeClient()
 	if err != nil {
 		return 0, err
 	}
+	ctx, cancel := readContext(parentCtx)
+	defer cancel()
 
 	bal, err := client.Balance(ctx)
 	if err != nil {
@@ -23,10 +25,12 @@ func ConfirmedBalanceSat() (int64, error) {
 
 // PendingInboundSat returns the pending inbound balance in satoshis.
 func PendingInboundSat() (int64, error) {
-	client, ctx, err := activeClient()
+	client, parentCtx, err := activeClient()
 	if err != nil {
 		return 0, err
 	}
+	ctx, cancel := readContext(parentCtx)
+	defer cancel()
 
 	bal, err := client.Balance(ctx)
 	if err != nil {
@@ -39,10 +43,12 @@ func PendingInboundSat() (int64, error) {
 // WalletReady reports whether the daemon wallet is fully unlocked and ready to
 // sign. It is the scalar form of GetInfo().WalletState == ready.
 func WalletReady() (bool, error) {
-	client, ctx, err := activeClient()
+	client, parentCtx, err := activeClient()
 	if err != nil {
 		return false, err
 	}
+	ctx, cancel := readContext(parentCtx)
+	defer cancel()
 
 	info, err := client.GetInfo(ctx)
 	if err != nil {

--- a/sdk/wavewalletdk/mobile/mobile_test.go
+++ b/sdk/wavewalletdk/mobile/mobile_test.go
@@ -3,7 +3,9 @@
 package mobile
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -76,6 +78,37 @@ func TestReadContextHasDeadline(t *testing.T) {
 	remaining := time.Until(deadline)
 	if remaining <= 0 || remaining > defaultReadTimeout {
 		t.Fatalf("read deadline remaining = %v", remaining)
+	}
+}
+
+// TestReceiveErrorMarksUncertainTimeout verifies a binding-owned receive
+// deadline has a stable host-visible prefix and preserves the original cause.
+func TestReceiveErrorMarksUncertainTimeout(t *testing.T) {
+	parentCtx := context.Background()
+	callCtx, cancel := context.WithTimeout(parentCtx, 0)
+	defer cancel()
+
+	err := receiveError(parentCtx, callCtx, context.DeadlineExceeded)
+	if !strings.HasPrefix(err.Error(), receiveTimeoutErrorPrefix) {
+		t.Fatalf("receive error = %q", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("receive error lost deadline cause: %v", err)
+	}
+}
+
+// TestReceiveErrorPreservesLifecycleCancellation verifies Stop cancellation is
+// not mislabeled as a request deadline with an uncertain receive outcome.
+func TestReceiveErrorPreservesLifecycleCancellation(t *testing.T) {
+	parentCtx, cancelParent := context.WithCancel(context.Background())
+	callCtx, cancelCall := context.WithTimeout(parentCtx, time.Minute)
+	defer cancelCall()
+	cancelParent()
+	<-callCtx.Done()
+
+	want := errors.New("wallet stopped")
+	if got := receiveError(parentCtx, callCtx, want); got != want {
+		t.Fatalf("receive error = %v, want original %v", got, want)
 	}
 }
 

--- a/sdk/wavewalletdk/mobile/mobile_test.go
+++ b/sdk/wavewalletdk/mobile/mobile_test.go
@@ -7,9 +7,77 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lightninglabs/wavelength/sdk/wavewalletdk"
 )
+
+// TestDecodeReceiveRequestUsesBoundedDefault verifies older hosts that omit
+// TimeoutSeconds still receive a finite deadline without changing the SDK DTO.
+func TestDecodeReceiveRequestUsesBoundedDefault(t *testing.T) {
+	req, timeout, err := decodeReceiveRequest([]byte(
+		`{"AmountSat":21000,"Memo":"coffee"}`,
+	))
+	if err != nil {
+		t.Fatalf("decode receive request: %v", err)
+	}
+	if req.AmountSat != 21_000 || req.Memo != "coffee" {
+		t.Fatalf("unexpected receive request: %+v", req)
+	}
+	if timeout != defaultReceiveTimeout {
+		t.Fatalf("timeout = %v, want %v", timeout,
+			defaultReceiveTimeout)
+	}
+}
+
+// TestDecodeReceiveRequestAcceptsExplicitDeadline verifies a mobile host can
+// choose a shorter bounded foreground deadline for invoice creation.
+func TestDecodeReceiveRequestAcceptsExplicitDeadline(t *testing.T) {
+	_, timeout, err := decodeReceiveRequest([]byte(
+		`{"AmountSat":1000,"TimeoutSeconds":12}`,
+	))
+	if err != nil {
+		t.Fatalf("decode receive request: %v", err)
+	}
+	if timeout != 12*time.Second {
+		t.Fatalf("timeout = %v, want 12s", timeout)
+	}
+}
+
+// TestDecodeReceiveRequestRejectsInvalidDeadlines verifies malformed negative
+// or excessive values cannot restore an unbounded receive call.
+func TestDecodeReceiveRequestRejectsInvalidDeadlines(t *testing.T) {
+	for name, body := range map[string]string{
+		"negative":  `{"AmountSat":1000,"TimeoutSeconds":-1}`,
+		"excessive": `{"AmountSat":1000,"TimeoutSeconds":301}`,
+		"overflow":  `{"AmountSat":1000,"TimeoutSeconds":9223372036854775807}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := decodeReceiveRequest(
+				[]byte(body),
+			); err == nil {
+
+				t.Fatal("expected invalid timeout error")
+			}
+		})
+	}
+}
+
+// TestReadContextHasDeadline verifies repeatable mobile reads never inherit the
+// full daemon lifetime when a foreign host cannot provide context.Context.
+func TestReadContextHasDeadline(t *testing.T) {
+	ctx, cancel := readContext(t.Context())
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("read context has no deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 || remaining > defaultReadTimeout {
+		t.Fatalf("read deadline remaining = %v", remaining)
+	}
+}
 
 // TestParseConfigEmptyUsesDefaults verifies that an empty config string yields
 // the wavewalletdk defaults rather than a zero config.

--- a/sdk/wavewalletdk/mobile/mobile_test.go
+++ b/sdk/wavewalletdk/mobile/mobile_test.go
@@ -88,8 +88,8 @@ func TestReceiveErrorMarksUncertainTimeout(t *testing.T) {
 	callCtx, cancel := context.WithTimeout(parentCtx, 0)
 	defer cancel()
 
-	err := receiveError(parentCtx, callCtx, context.DeadlineExceeded)
-	if !strings.HasPrefix(err.Error(), receiveTimeoutErrorPrefix) {
+	err := receiveError(callCtx, context.DeadlineExceeded)
+	if !strings.HasPrefix(err.Error(), receiveUncertainErrorPrefix) {
 		t.Fatalf("receive error = %q", err)
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
@@ -97,9 +97,9 @@ func TestReceiveErrorMarksUncertainTimeout(t *testing.T) {
 	}
 }
 
-// TestReceiveErrorPreservesLifecycleCancellation verifies Stop cancellation is
-// not mislabeled as a request deadline with an uncertain receive outcome.
-func TestReceiveErrorPreservesLifecycleCancellation(t *testing.T) {
+// TestReceiveErrorMarksLifecycleCancellation verifies Stop cancellation has
+// the same reconcile-before-retry marker as a binding-owned deadline.
+func TestReceiveErrorMarksLifecycleCancellation(t *testing.T) {
 	parentCtx, cancelParent := context.WithCancel(context.Background())
 	callCtx, cancelCall := context.WithTimeout(parentCtx, time.Minute)
 	defer cancelCall()
@@ -107,8 +107,12 @@ func TestReceiveErrorPreservesLifecycleCancellation(t *testing.T) {
 	<-callCtx.Done()
 
 	want := errors.New("wallet stopped")
-	if got := receiveError(parentCtx, callCtx, want); got != want {
-		t.Fatalf("receive error = %v, want original %v", got, want)
+	got := receiveError(callCtx, want)
+	if !strings.HasPrefix(got.Error(), receiveUncertainErrorPrefix) {
+		t.Fatalf("receive error = %q", got)
+	}
+	if !errors.Is(got, want) {
+		t.Fatalf("receive error lost lifecycle cause: %v", got)
 	}
 }
 

--- a/sdk/wavewalletdk/mobile/wallet.go
+++ b/sdk/wavewalletdk/mobile/wallet.go
@@ -8,9 +8,76 @@ import (
 	"fmt"
 	"io"
 	"runtime/debug"
+	"time"
 
 	"github.com/lightninglabs/wavelength/sdk/wavewalletdk"
 )
+
+const (
+	// defaultReadTimeout bounds read-only wallet calls whose foreign host
+	// cannot supply context.Context through gomobile. Reads are safe to
+	// repeat after a timeout and must not inherit the daemon's entire
+	// lifetime.
+	defaultReadTimeout = 10 * time.Second
+
+	// defaultReceiveTimeout bounds invoice creation when a mobile host
+	// omits TimeoutSeconds. A timed-out request has an uncertain outcome:
+	// callers must reconcile Activity before deliberately creating another
+	// invoice.
+	defaultReceiveTimeout = 20 * time.Second
+
+	// maxReceiveTimeout prevents malformed host input from restoring the
+	// effectively unbounded behavior this mobile-only request field avoids.
+	maxReceiveTimeout = 5 * time.Minute
+)
+
+// readContext derives the bounded context used by safe, repeatable mobile
+// reads. The daemon-lifetime parent still cancels it immediately during Stop.
+func readContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, defaultReadTimeout)
+}
+
+// mobileReceiveRequest extends the SDK receive DTO with a mobile-only request
+// deadline. The extra JSON field is backwards-compatible with older bindings,
+// whose encoding/json decoder ignores it.
+type mobileReceiveRequest struct {
+	AmountSat      uint64
+	Memo           string
+	TimeoutSeconds int64
+}
+
+// decodeReceiveRequest validates the mobile-only deadline and converts the
+// wire request into the SDK DTO. Zero selects the bounded default so older
+// hosts gain a deadline when they update only the native framework.
+func decodeReceiveRequest(reqJSON []byte) (wavewalletdk.ReceiveRequest,
+	time.Duration, error) {
+
+	var mobileReq mobileReceiveRequest
+	if err := decode(reqJSON, &mobileReq); err != nil {
+		return wavewalletdk.ReceiveRequest{}, 0, err
+	}
+
+	timeout := defaultReceiveTimeout
+	if mobileReq.TimeoutSeconds < 0 {
+		return wavewalletdk.ReceiveRequest{}, 0,
+			fmt.Errorf("receive timeout seconds must not be " +
+				"negative")
+	}
+	maxTimeoutSeconds := int64(maxReceiveTimeout / time.Second)
+	if mobileReq.TimeoutSeconds > maxTimeoutSeconds {
+		return wavewalletdk.ReceiveRequest{}, 0, fmt.Errorf("receive "+
+			"timeout seconds %d exceeds maximum %d",
+			mobileReq.TimeoutSeconds, maxTimeoutSeconds)
+	}
+	if mobileReq.TimeoutSeconds > 0 {
+		timeout = time.Duration(mobileReq.TimeoutSeconds) * time.Second
+	}
+
+	return wavewalletdk.ReceiveRequest{
+		AmountSat: mobileReq.AmountSat,
+		Memo:      mobileReq.Memo,
+	}, timeout, nil
+}
 
 // GetInfo returns the daemon readiness snapshot as JSON (wavewalletdk.Info).
 func GetInfo() ([]byte, error) {
@@ -73,10 +140,12 @@ func UnlockWallet(reqJSON []byte) ([]byte, error) {
 
 // Balance returns the wallet balance summary as JSON (wavewalletdk.Balance).
 func Balance() ([]byte, error) {
-	client, ctx, err := activeClient()
+	client, parentCtx, err := activeClient()
 	if err != nil {
 		return nil, err
 	}
+	ctx, cancel := readContext(parentCtx)
+	defer cancel()
 
 	bal, err := client.Balance(ctx)
 	if err != nil {
@@ -107,18 +176,23 @@ func Deposit(reqJSON []byte) ([]byte, error) {
 	return marshal(res)
 }
 
-// Receive opens a Lightning invoice receive. reqJSON decodes to
-// wavewalletdk.ReceiveRequest; the response is wavewalletdk.ReceiveResult.
+// Receive opens a Lightning invoice receive. reqJSON accepts AmountSat, Memo,
+// and an optional mobile-only TimeoutSeconds; the response is
+// wavewalletdk.ReceiveResult. When the deadline expires, the outcome may be
+// uncertain, so the host must reconcile Activity before retrying deliberately.
 func Receive(reqJSON []byte) ([]byte, error) {
-	client, ctx, err := activeClient()
+	client, parentCtx, err := activeClient()
 	if err != nil {
 		return nil, err
 	}
 
-	var req wavewalletdk.ReceiveRequest
-	if err := decode(reqJSON, &req); err != nil {
+	req, timeout, err := decodeReceiveRequest(reqJSON)
+	if err != nil {
 		return nil, err
 	}
+
+	ctx, cancel := context.WithTimeout(parentCtx, timeout)
+	defer cancel()
 
 	res, err := client.Receive(ctx, req)
 	if err != nil {
@@ -175,10 +249,12 @@ func SendPrepared(reqJSON []byte) ([]byte, error) {
 // decodes to wavewalletdk.ListRequest; the response is the tagged-union
 // wavewalletdk.ListResult.
 func List(reqJSON []byte) ([]byte, error) {
-	client, ctx, err := activeClient()
+	client, parentCtx, err := activeClient()
 	if err != nil {
 		return nil, err
 	}
+	ctx, cancel := readContext(parentCtx)
+	defer cancel()
 
 	var req wavewalletdk.ListRequest
 	if err := decode(reqJSON, &req); err != nil {
@@ -305,10 +381,12 @@ func SweepWallet(reqJSON []byte) ([]byte, error) {
 // Status returns wallet readiness, balance, and pending counts as JSON
 // (wavewalletdk.Status).
 func Status() ([]byte, error) {
-	client, ctx, err := activeClient()
+	client, parentCtx, err := activeClient()
 	if err != nil {
 		return nil, err
 	}
+	ctx, cancel := readContext(parentCtx)
+	defer cancel()
 
 	status, err := client.Status(ctx)
 	if err != nil {

--- a/sdk/wavewalletdk/mobile/wallet.go
+++ b/sdk/wavewalletdk/mobile/wallet.go
@@ -29,12 +29,30 @@ const (
 	// maxReceiveTimeout prevents malformed host input from restoring the
 	// effectively unbounded behavior this mobile-only request field avoids.
 	maxReceiveTimeout = 5 * time.Minute
+
+	// receiveTimeoutErrorPrefix is stable binding ABI. It lets a foreign
+	// host distinguish an uncertain receive timeout from a rejected request
+	// without depending on transport-specific context error text.
+	receiveTimeoutErrorPrefix = "receive timed out; outcome uncertain; " +
+		"reconcile Activity before retrying"
 )
 
 // readContext derives the bounded context used by safe, repeatable mobile
 // reads. The daemon-lifetime parent still cancels it immediately during Stop.
 func readContext(parent context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(parent, defaultReadTimeout)
+}
+
+// receiveError preserves ordinary receive errors while marking a deadline
+// owned by this binding as an uncertain outcome. A parent cancellation means
+// the daemon is stopping, so it keeps the lifecycle error unchanged.
+func receiveError(parentCtx, callCtx context.Context, err error) error {
+	if err == nil || parentCtx.Err() != nil ||
+		callCtx.Err() != context.DeadlineExceeded {
+		return err
+	}
+
+	return fmt.Errorf("%s: %w", receiveTimeoutErrorPrefix, err)
 }
 
 // mobileReceiveRequest extends the SDK receive DTO with a mobile-only request
@@ -81,10 +99,12 @@ func decodeReceiveRequest(reqJSON []byte) (wavewalletdk.ReceiveRequest,
 
 // GetInfo returns the daemon readiness snapshot as JSON (wavewalletdk.Info).
 func GetInfo() ([]byte, error) {
-	client, ctx, err := activeClient()
+	client, parentCtx, err := activeClient()
 	if err != nil {
 		return nil, err
 	}
+	ctx, cancel := readContext(parentCtx)
+	defer cancel()
 
 	info, err := client.GetInfo(ctx)
 	if err != nil {
@@ -196,7 +216,7 @@ func Receive(reqJSON []byte) ([]byte, error) {
 
 	res, err := client.Receive(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, receiveError(parentCtx, ctx, err)
 	}
 
 	return marshal(res)
@@ -294,10 +314,12 @@ func Exit(reqJSON []byte) ([]byte, error) {
 // wavewalletdk.ExitStatusRequest; the response is
 // wavewalletdk.ExitStatusResult.
 func ExitStatus(reqJSON []byte) ([]byte, error) {
-	client, ctx, err := activeClient()
+	client, parentCtx, err := activeClient()
 	if err != nil {
 		return nil, err
 	}
+	ctx, cancel := readContext(parentCtx)
+	defer cancel()
 
 	var req wavewalletdk.ExitStatusRequest
 	if err := decode(reqJSON, &req); err != nil {
@@ -316,10 +338,12 @@ func ExitStatus(reqJSON []byte) ([]byte, error) {
 // decodes to wavewalletdk.ExitSummaryRequest (an empty object is fine); the
 // response is wavewalletdk.ExitSummaryResult.
 func ExitSummary(reqJSON []byte) ([]byte, error) {
-	client, ctx, err := activeClient()
+	client, parentCtx, err := activeClient()
 	if err != nil {
 		return nil, err
 	}
+	ctx, cancel := readContext(parentCtx)
+	defer cancel()
 
 	var req wavewalletdk.ExitSummaryRequest
 	if err := decode(reqJSON, &req); err != nil {
@@ -338,10 +362,12 @@ func ExitSummary(reqJSON []byte) ([]byte, error) {
 // decodes to wavewalletdk.GetExitPlanRequest; the response is
 // wavewalletdk.GetExitPlanResult.
 func GetExitPlan(reqJSON []byte) ([]byte, error) {
-	client, ctx, err := activeClient()
+	client, parentCtx, err := activeClient()
 	if err != nil {
 		return nil, err
 	}
+	ctx, cancel := readContext(parentCtx)
+	defer cancel()
 
 	var req wavewalletdk.GetExitPlanRequest
 	if err := decode(reqJSON, &req); err != nil {

--- a/sdk/wavewalletdk/mobile/wallet.go
+++ b/sdk/wavewalletdk/mobile/wallet.go
@@ -30,11 +30,11 @@ const (
 	// effectively unbounded behavior this mobile-only request field avoids.
 	maxReceiveTimeout = 5 * time.Minute
 
-	// receiveTimeoutErrorPrefix is stable binding ABI. It lets a foreign
-	// host distinguish an uncertain receive timeout from a rejected request
-	// without depending on transport-specific context error text.
-	receiveTimeoutErrorPrefix = "receive timed out; outcome uncertain; " +
-		"reconcile Activity before retrying"
+	// receiveUncertainErrorPrefix is stable binding ABI. It lets a foreign
+	// host distinguish a canceled receive with an uncertain outcome from a
+	// rejected request without depending on context-specific error text.
+	receiveUncertainErrorPrefix = "receive outcome uncertain; reconcile " +
+		"Activity before retrying"
 )
 
 // readContext derives the bounded context used by safe, repeatable mobile
@@ -43,16 +43,14 @@ func readContext(parent context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(parent, defaultReadTimeout)
 }
 
-// receiveError preserves ordinary receive errors while marking a deadline
-// owned by this binding as an uncertain outcome. A parent cancellation means
-// the daemon is stopping, so it keeps the lifecycle error unchanged.
-func receiveError(parentCtx, callCtx context.Context, err error) error {
-	if err == nil || parentCtx.Err() != nil ||
-		callCtx.Err() != context.DeadlineExceeded {
+// receiveError preserves ordinary receive errors while marking cancellation by
+// either the binding-owned deadline or Stop as an uncertain outcome.
+func receiveError(callCtx context.Context, err error) error {
+	if err == nil || callCtx.Err() == nil {
 		return err
 	}
 
-	return fmt.Errorf("%s: %w", receiveTimeoutErrorPrefix, err)
+	return fmt.Errorf("%s: %w", receiveUncertainErrorPrefix, err)
 }
 
 // mobileReceiveRequest extends the SDK receive DTO with a mobile-only request
@@ -216,7 +214,7 @@ func Receive(reqJSON []byte) ([]byte, error) {
 
 	res, err := client.Receive(ctx, req)
 	if err != nil {
-		return nil, receiveError(parentCtx, ctx, err)
+		return nil, receiveError(ctx, err)
 	}
 
 	return marshal(res)

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -204,6 +204,9 @@ default builds avoid the swap executor's dependency graph.
   mid-leave. Confirmed-but-not-yet-boarded UTXOs must NOT inflate
   `confirmed_sat` (issue #502), and adopted-but-not-yet-live VTXOs
   must stay pending inbound until commitment confirmation (issue #542).
+  Optional remote credit enrichment has its own short deadline and degrades to
+  the local satoshi snapshot when unavailable; a stalled credit connection
+  must never hold an otherwise valid wallet refresh open indefinitely.
 
 ## Deep Docs
 

--- a/swapwallet/AGENTS.md
+++ b/swapwallet/AGENTS.md
@@ -205,8 +205,9 @@ default builds avoid the swap executor's dependency graph.
   `confirmed_sat` (issue #502), and adopted-but-not-yet-live VTXOs
   must stay pending inbound until commitment confirmation (issue #542).
   Optional remote credit enrichment has its own short deadline and degrades to
-  the local satoshi snapshot when unavailable; a stalled credit connection
-  must never hold an otherwise valid wallet refresh open indefinitely.
+  the local satoshi snapshot with a warning when unavailable; a stalled credit
+  connection must never hold an otherwise valid wallet refresh open
+  indefinitely.
 
 ## Deep Docs
 

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -204,6 +204,9 @@ default builds avoid the swap executor's dependency graph.
   mid-leave. Confirmed-but-not-yet-boarded UTXOs must NOT inflate
   `confirmed_sat` (issue #502), and adopted-but-not-yet-live VTXOs
   must stay pending inbound until commitment confirmation (issue #542).
+  Optional remote credit enrichment has its own short deadline and degrades to
+  the local satoshi snapshot when unavailable; a stalled credit connection
+  must never hold an otherwise valid wallet refresh open indefinitely.
 
 ## Deep Docs
 

--- a/swapwallet/CLAUDE.md
+++ b/swapwallet/CLAUDE.md
@@ -205,8 +205,9 @@ default builds avoid the swap executor's dependency graph.
   `confirmed_sat` (issue #502), and adopted-but-not-yet-live VTXOs
   must stay pending inbound until commitment confirmation (issue #542).
   Optional remote credit enrichment has its own short deadline and degrades to
-  the local satoshi snapshot when unavailable; a stalled credit connection
-  must never hold an otherwise valid wallet refresh open indefinitely.
+  the local satoshi snapshot with a warning when unavailable; a stalled credit
+  connection must never hold an otherwise valid wallet refresh open
+  indefinitely.
 
 ## Deep Docs
 

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -627,6 +627,12 @@ func (s *Service) fetchBalance(ctx context.Context) (
 		},
 	)
 	if err != nil {
+		s.deps.resolveLog().WarnS(
+			ctx,
+			"Credit balance enrichment skipped",
+			err,
+		)
+
 		return resp, nil
 	}
 

--- a/swapwallet/service.go
+++ b/swapwallet/service.go
@@ -5,12 +5,18 @@ package swapwallet
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/lightninglabs/wavelength/rpc/swapclientrpc"
 	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
 	"github.com/lightninglabs/wavelength/waverpc"
 	"google.golang.org/protobuf/encoding/protojson"
 )
+
+// defaultCreditReadTimeout bounds optional remote credit enrichment during a
+// balance read. The local satoshi balance remains useful when this call times
+// out, so refresh paths must not wait on remote connectivity indefinitely.
+const defaultCreditReadTimeout = 2 * time.Second
 
 // Service implements the daemon-side WalletService gRPC handler. It is a
 // thin facade: every method translates the proto request into typed internal
@@ -24,6 +30,8 @@ type Service struct {
 	router  *router
 	recv    *receiver
 	history *history
+
+	creditReadTimeout time.Duration
 }
 
 // newService builds the Service handle given its composed dependencies and
@@ -32,11 +40,12 @@ type Service struct {
 // pure wiring.
 func newService(deps *Deps, runtime *Runtime) *Service {
 	return &Service{
-		deps:    deps,
-		runtime: runtime,
-		router:  newRouter(deps, runtime),
-		recv:    newReceiver(deps, runtime),
-		history: newHistory(deps, runtime),
+		deps:              deps,
+		runtime:           runtime,
+		router:            newRouter(deps, runtime),
+		recv:              newReceiver(deps, runtime),
+		history:           newHistory(deps, runtime),
+		creditReadTimeout: defaultCreditReadTimeout,
 	}
 }
 
@@ -558,7 +567,9 @@ func gapResponse(cursor int64) *wavewalletrpc.SubscribeWalletResponse {
 }
 
 // fetchBalance is the shared helper that pulls the daemon's GetBalance and
-// projects its richer breakdown onto the flat wallet shape.
+// projects its richer breakdown onto the flat wallet shape. Optional credit
+// enrichment has its own short deadline; when it is unavailable, the method
+// still returns the authoritative local satoshi balance.
 func (s *Service) fetchBalance(ctx context.Context) (
 	*wavewalletrpc.BalanceResponse, error) {
 
@@ -605,8 +616,13 @@ func (s *Service) fetchBalance(ctx context.Context) (
 		return resp, nil
 	}
 
+	creditCtx, cancel := context.WithTimeout(
+		ctx, s.creditReadTimeout,
+	)
+	defer cancel()
+
 	credits, err := s.deps.SwapService.ListCredits(
-		ctx, &swapclientrpc.ListCreditsRequest{
+		creditCtx, &swapclientrpc.ListCreditsRequest{
 			Limit: 1,
 		},
 	)

--- a/swapwallet/service_test.go
+++ b/swapwallet/service_test.go
@@ -5,6 +5,7 @@ package swapwallet
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/lightninglabs/wavelength/rpc/swapclientrpc"
 	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
@@ -13,6 +14,23 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// blockingCreditService models an external credit endpoint whose transport
+// accepts a request but never responds until the caller's context expires.
+type blockingCreditService struct {
+	*fakeSwapService
+}
+
+// ListCredits pins the incident shape by waiting only for caller cancellation;
+// it must not hold the local wallet balance open beyond its enrichment bound.
+func (b *blockingCreditService) ListCredits(ctx context.Context,
+	_ *swapclientrpc.ListCreditsRequest) (
+	*swapclientrpc.ListCreditsResponse, error) {
+
+	<-ctx.Done()
+
+	return nil, ctx.Err()
+}
 
 // newServiceFixture builds a Service with fake deps so each gRPC handler
 // can be exercised without a real daemon.
@@ -321,6 +339,8 @@ func TestServiceBalanceSurfacesInFlightVTXOs(t *testing.T) {
 	}
 }
 
+// TestServiceBalanceIncludesCredits verifies a healthy remote credit snapshot
+// enriches the authoritative local satoshi balance without replacing it.
 func TestServiceBalanceIncludesCredits(t *testing.T) {
 	t.Parallel()
 
@@ -342,6 +362,48 @@ func TestServiceBalanceIncludesCredits(t *testing.T) {
 	require.Equal(t, uint64(6_789), resp.GetCreditReservedSat())
 	require.Equal(t, 1, swap.listCreditsCalls)
 	require.Equal(t, uint32(1), swap.listCreditsLast.GetLimit())
+}
+
+// TestServiceBalanceDegradesWhenCreditsAreUnavailable verifies optional remote
+// credit enrichment cannot turn an otherwise valid local balance snapshot into
+// a refresh error. A later refresh may fill in the omitted credit fields.
+func TestServiceBalanceDegradesWhenCreditsAreUnavailable(t *testing.T) {
+	t.Parallel()
+
+	svc, swap, rpc := newServiceFixture(t)
+	rpc.getBalanceResp = &waverpc.GetBalanceResponse{
+		VtxoBalanceSat: 75_000,
+	}
+	swap.listCreditsErr = context.DeadlineExceeded
+
+	resp, err := svc.Balance(
+		t.Context(), &wavewalletrpc.BalanceRequest{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(75_000), resp.GetConfirmedSat())
+	require.Zero(t, resp.GetCreditAvailableSat())
+	require.Zero(t, resp.GetCreditReservedSat())
+}
+
+// TestServiceBalanceBoundsStalledCreditRead verifies a transport that never
+// answers cannot suppress the daemon-local balance snapshot indefinitely.
+func TestServiceBalanceBoundsStalledCreditRead(t *testing.T) {
+	svc, swap, rpc := newServiceFixture(t)
+	rpc.getBalanceResp = &waverpc.GetBalanceResponse{
+		VtxoBalanceSat: 75_000,
+	}
+	svc.deps.SwapService = &blockingCreditService{
+		fakeSwapService: swap,
+	}
+	svc.creditReadTimeout = 10 * time.Millisecond
+
+	started := time.Now()
+	resp, err := svc.Balance(
+		t.Context(), &wavewalletrpc.BalanceRequest{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(75_000), resp.GetConfirmedSat())
+	require.Less(t, time.Since(started), time.Second)
 }
 
 // TestServiceBalanceKeepsAdoptedBoardingPending pins issue #542: after a

--- a/swapwallet/service_test.go
+++ b/swapwallet/service_test.go
@@ -3,10 +3,12 @@
 package swapwallet
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btclog/v2"
 	"github.com/lightninglabs/wavelength/rpc/swapclientrpc"
 	"github.com/lightninglabs/wavelength/rpc/wavewalletrpc"
 	"github.com/lightninglabs/wavelength/waverpc"
@@ -371,6 +373,12 @@ func TestServiceBalanceDegradesWhenCreditsAreUnavailable(t *testing.T) {
 	t.Parallel()
 
 	svc, swap, rpc := newServiceFixture(t)
+	var logBuf bytes.Buffer
+	svc.deps.Log = btclog.NewSLogger(
+		btclog.NewDefaultHandler(
+			&logBuf, btclog.WithNoTimestamp(),
+		),
+	)
 	rpc.getBalanceResp = &waverpc.GetBalanceResponse{
 		VtxoBalanceSat: 75_000,
 	}
@@ -383,6 +391,11 @@ func TestServiceBalanceDegradesWhenCreditsAreUnavailable(t *testing.T) {
 	require.Equal(t, int64(75_000), resp.GetConfirmedSat())
 	require.Zero(t, resp.GetCreditAvailableSat())
 	require.Zero(t, resp.GetCreditReservedSat())
+	require.Contains(
+		t, logBuf.String(),
+		"Credit balance enrichment skipped",
+	)
+	require.Contains(t, logBuf.String(), context.DeadlineExceeded.Error())
 }
 
 // TestServiceBalanceBoundsStalledCreditRead verifies a transport that never


### PR DESCRIPTION
## The problem

Mobile hosts call the embedded Wavelength wallet through gomobile, which cannot carry a caller `context.Context`. If iOS or Android suspends the process while an external connection is using an old network path, wallet reads and Lightning invoice creation can wait for the embedded daemon's full lifetime instead of returning control to the app.

Wallet recovery can cause a second stall. btcwallet v0.18.0 keeps its database writer open while the chain backend filters recovery blocks. The lightweight backend may perform remote I/O during that call, so unrelated wallet operations can wait behind a slow recovery request.

Read calls are safe to repeat. Invoice creation is different: a deadline or lifecycle cancellation may race durable receive-session creation, so cancellation does not prove that no invoice exists.

## The fix

- Give repeatable mobile reads a 10-second deadline. This covers `GetInfo`, `Balance`, `List`, `ExitStatus`, `ExitSummary`, `GetExitPlan`, `Status`, and the scalar convenience helpers.
- Give mobile `Receive` an optional `TimeoutSeconds` field. Older hosts receive a 20-second default. Values above five minutes are rejected.
- Mark deadline and lifecycle cancellation of `Receive` as an uncertain outcome with a stable reconcile-before-retry error prefix.
- Return the authoritative local satoshi balance when optional remote credit enrichment exceeds its own two-second deadline, and log that the enrichment was skipped.
- Update btcwallet to the merged recovery implementation from [btcsuite/btcwallet#1318](https://github.com/btcsuite/btcwallet/pull/1318). It performs chain-backend filtering without an open wallet transaction, then atomically persists discoveries and the batch sync marker.
- Document that the host must stop and restart the embedded wallet after a real background/foreground transition so external transports are re-dialled.
- Release the Postgres test-fixture slot after container startup and store migration. This keeps the resource-sensitive initialization boundary at four concurrent fixtures without holding slots through each test lifetime.

## Safety rule

The host may retry timed-out reads. It must not blindly retry a canceled `Receive`; it must first reconcile the authoritative Activity view and recover any matching invoice.

Recovery keeps address-index operations serialized and commits each completed batch atomically, while unrelated database writers remain available during remote filter I/O.

## What does not change

- The Go SDK request type and server RPC schema do not change.
- Existing mobile hosts may omit `TimeoutSeconds`.
- A healthy credit endpoint still enriches the local balance with credit fields.
- The mobile binding still cannot observe the application lifecycle. The host owns background/foreground recovery.

## Tests

- `make lint-changed-local`
- `make tidy-module-check`
- `make unit-swapruntime`
- `go test -tags='mobile wavewalletrpc swapruntime' ./sdk/wavewalletdk/mobile`
- `go test -tags='wavewalletrpc swapruntime' ./swapwallet -run '^TestServiceBalance' -count=1`
- `go test -tags=test_postgres ./waved -count=1 -timeout=30m`
- `go test -tags=test_postgres ./db -count=1 -timeout=30m`
- `make mobile-ios`

The tests cover default and explicit mobile deadlines, invalid deadline values, repeatable read deadlines, uncertain `Receive` cancellation, healthy credit enrichment, credit timeout fallback and logging, and the Postgres fixture-slot lifecycle. The full wallet-runtime suite and iOS xcframework build pass against the updated btcwallet dependency.

Exact-head CI passes all 20 required checks, including Postgres unit and system tests, race tests, SQLite tests, lint, static checks, and every cross-build.

## Compatibility and rollout

`TimeoutSeconds` is additive at the mobile JSON boundary. Older Wavelength bindings ignore the extra field. Updated bindings apply the bounded default even when an older host omits it.

The btcwallet fix is pinned to `v0.18.1-0.20260826052527-33c252f3b4d6`, the Go pseudo-version for merged commit `33c252f3b4d6`. No btcwallet v0.18.1 tag exists yet.

After this PR merges, publish a Wavelength release containing both changes. [wavelength-mobile#6](https://github.com/lightninglabs/wavelength-mobile/pull/6) can then consume and validate the release xcframework.
