### PR TITLE
waved: reuse cached identity in GetInfo

### DIFF
--- a/waved/AGENTS.md
+++ b/waved/AGENTS.md
@@ -12,8 +12,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
 
 - `Server` — main daemon. Owns the wallet, DB, chainsource actor, gRPC
   server, and `ActorSystem`. Caches `localMailboxID` (pubkey-derived),
-  `authSigHex` (Schnorr auth), and a single `clk` (`clock.Clock`) shared by
-  all sub-stores for deterministic time injection.
+  `authSigHex` (Schnorr auth), `clientKeyDesc` (the stable daemon identity
+  descriptor), and a single `clk` (`clock.Clock`) shared by all sub-stores
+  for deterministic time injection.
 - `RPCServer` — implements the gRPC `DaemonService`. Most write RPCs
   (`Board`, `SendVTXO`, `SendOOR`, `SweepBoardingUTXOs`, `SendOnChain`)
   validate input locally then `Ask` the relevant actor; `GetRound` and
@@ -159,6 +160,13 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   so the bound survives restarts.
 - `operatorTermsFromResponse` and daemon `GetInfo` must preserve
   `FreeRefreshWindowBlocks` end to end.
+- `deriveIdentityKeyEarly` publishes `clientKeyDesc` before mailbox bootstrap.
+  `GetInfo` reuses this descriptor instead of deriving the same key for every
+  status request because btcwallet-backed derivation opens a wallet database
+  write transaction. Before the descriptor is available, `GetInfo` keeps its
+  pre-initialization fallback. All descriptor reads and startup writes go
+  through `loadClientKeyDesc` and `storeClientKeyDesc` because `GetInfo` is
+  callable while startup is publishing the value.
 - The VTXO manager reads `FreeRefreshWindowBlocks` from the latest cached
   operator terms on each expiry check. It delays automatic refresh to the
   window boundary only when the local dynamic critical threshold plus retry

--- a/waved/CLAUDE.md
+++ b/waved/CLAUDE.md
@@ -12,8 +12,9 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
 
 - `Server` — main daemon. Owns the wallet, DB, chainsource actor, gRPC
   server, and `ActorSystem`. Caches `localMailboxID` (pubkey-derived),
-  `authSigHex` (Schnorr auth), and a single `clk` (`clock.Clock`) shared by
-  all sub-stores for deterministic time injection.
+  `authSigHex` (Schnorr auth), `clientKeyDesc` (the stable daemon identity
+  descriptor), and a single `clk` (`clock.Clock`) shared by all sub-stores
+  for deterministic time injection.
 - `RPCServer` — implements the gRPC `DaemonService`. Most write RPCs
   (`Board`, `SendVTXO`, `SendOOR`, `SweepBoardingUTXOs`, `SendOnChain`)
   validate input locally then `Ask` the relevant actor; `GetRound` and
@@ -159,6 +160,13 @@ For field-level detail, use `go doc github.com/lightninglabs/wavelength/waved.<S
   so the bound survives restarts.
 - `operatorTermsFromResponse` and daemon `GetInfo` must preserve
   `FreeRefreshWindowBlocks` end to end.
+- `deriveIdentityKeyEarly` publishes `clientKeyDesc` before mailbox bootstrap.
+  `GetInfo` reuses this descriptor instead of deriving the same key for every
+  status request because btcwallet-backed derivation opens a wallet database
+  write transaction. Before the descriptor is available, `GetInfo` keeps its
+  pre-initialization fallback. All descriptor reads and startup writes go
+  through `loadClientKeyDesc` and `storeClientKeyDesc` because `GetInfo` is
+  callable while startup is publishing the value.
 - The VTXO manager reads `FreeRefreshWindowBlocks` from the latest cached
   operator terms on each expiry check. It delays automatic refresh to the
   window boundary only when the local dynamic critical threshold plus retry

--- a/waved/outbound_clients.go
+++ b/waved/outbound_clients.go
@@ -149,7 +149,7 @@ func (s *Server) mailboxAuthSigner() serverconn.MailboxAuthSigner {
 func (s *Server) mailboxAuthSig(ctx context.Context,
 	recipientMailboxID string) (*schnorr.Signature, error) {
 
-	if s.clientKeyDesc.PubKey == nil {
+	if s.loadClientKeyDesc().PubKey == nil {
 		return nil, fmt.Errorf("identity key not yet derived; wallet " +
 			"not ready")
 	}
@@ -188,12 +188,13 @@ func (s *Server) mailboxAuthSig(ctx context.Context,
 // serverClientTLSCerts returns the optional client certificate used by the
 // operator to bind mailbox access to the daemon identity key.
 func (s *Server) serverClientTLSCerts() ([]tls.Certificate, error) {
-	if s.cfg.Server.Insecure || s.clientKeyDesc.PubKey == nil {
+	identityDesc := s.loadClientKeyDesc()
+	if s.cfg.Server.Insecure || identityDesc.PubKey == nil {
 		return nil, nil
 	}
 
 	clientCert, err := serverconn.GenerateClientTLSCert(
-		s.clientKeyDesc.PubKey,
+		identityDesc.PubKey,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("generate client TLS cert: %w", err)

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -212,13 +212,14 @@ func (r *RPCServer) ClientTLSCerts() ([]tls.Certificate, error) {
 		return nil, fmt.Errorf("daemon server unavailable")
 	}
 
-	if r.server.clientKeyDesc.PubKey == nil {
+	identityDesc := r.server.loadClientKeyDesc()
+	if identityDesc.PubKey == nil {
 		return nil, fmt.Errorf("identity key not yet derived; wallet " +
 			"not ready")
 	}
 
 	clientCert, err := serverconn.GenerateClientTLSCert(
-		r.server.clientKeyDesc.PubKey,
+		identityDesc.PubKey,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("generate client TLS cert: %w", err)
@@ -637,13 +638,26 @@ func (r *RPCServer) GetInfo(ctx context.Context, _ *waverpc.GetInfoRequest) (
 	// intentionally differs from the
 	// public node key above and must stay aligned with the indexer proof
 	// signer used for script-scoped VTXO queries.
-	identityPubkey, err := r.deriveIdentityPubkey(ctx)
-	if err != nil {
-		r.server.log.WarnS(ctx, "Unable to derive daemon identity key",
-			err,
-		)
+	identityDesc := r.server.loadClientKeyDesc()
+	if identityKey := identityDesc.PubKey; identityKey != nil {
+		// The daemon derives and stores this stable key before mailbox
+		// bootstrap. Avoid deriving it again on every status read:
+		// BtcWalletKeyRing.DeriveKey opens a walletdb write
+		// transaction, which can block an otherwise read-only GetInfo
+		// call behind an unrelated wallet writer.
+		resp.IdentityPubkey = fmt.Sprintf("%x",
+			identityKey.SerializeCompressed())
 	} else {
-		resp.IdentityPubkey = identityPubkey
+		identityPubkey, err := r.deriveIdentityPubkey(ctx)
+		if err != nil {
+			r.server.log.WarnS(
+				ctx,
+				"Unable to derive daemon identity key",
+				err,
+			)
+		} else {
+			resp.IdentityPubkey = identityPubkey
+		}
 	}
 
 	// Populate lwwallet fields if the lightweight wallet is active.
@@ -1800,8 +1814,9 @@ func (r *RPCServer) RefreshCustomVTXOs(ctx context.Context,
 		return nil, status.Errorf(codes.Unavailable, "fetch operator "+
 			"terms: %v", err)
 	}
+	identityDesc := r.server.loadClientKeyDesc()
 	if err := r.enrichCustomRefreshInputs(
-		ctx, inputs, r.server.clientKeyDesc, terms.PubKey,
+		ctx, inputs, identityDesc, terms.PubKey,
 	); err != nil {
 		return nil, err
 	}
@@ -3223,10 +3238,10 @@ func (r *RPCServer) SendOOR(ctx context.Context, req *waverpc.SendOORRequest) (
 		inputSelectDuration = time.Since(phaseStart)
 
 		phaseStart = time.Now()
+		identityDesc := r.server.loadClientKeyDesc()
 		selectedInputs, err = BuildCustomTransferInputs(
-			ctx, r.server.vtxoStore, req.CustomInputs,
-			r.server.clientKeyDesc, terms.PubKey,
-			terms.VTXOExitDelay,
+			ctx, r.server.vtxoStore, req.CustomInputs, identityDesc,
+			terms.PubKey, terms.VTXOExitDelay,
 		)
 		buildInputsDuration = time.Since(phaseStart)
 		if err != nil {
@@ -3541,9 +3556,10 @@ func (r *RPCServer) PrepareOOR(ctx context.Context,
 		return nil, err
 	}
 
+	identityDesc := r.server.loadClientKeyDesc()
 	selectedInputs, err := BuildCustomTransferInputs(
-		ctx, r.server.vtxoStore, req.GetCustomInputs(),
-		r.server.clientKeyDesc, terms.PubKey, terms.VTXOExitDelay,
+		ctx, r.server.vtxoStore, req.GetCustomInputs(), identityDesc,
+		terms.PubKey, terms.VTXOExitDelay,
 	)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "build custom "+
@@ -3675,10 +3691,11 @@ func (r *RPCServer) SignOORCustomInput(ctx context.Context,
 			"operator terms: %v", err)
 	}
 
+	identityDesc := r.server.loadClientKeyDesc()
 	inputs, err := BuildCustomTransferInputs(
 		ctx, r.server.vtxoStore,
-		[]*waverpc.CustomOORInput{req.GetCustomInput()},
-		r.server.clientKeyDesc, terms.PubKey, terms.VTXOExitDelay,
+		[]*waverpc.CustomOORInput{req.GetCustomInput()}, identityDesc,
+		terms.PubKey, terms.VTXOExitDelay,
 	)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "build custom "+
@@ -3832,7 +3849,8 @@ func (r *RPCServer) SignVTXOForfeit(ctx context.Context,
 		return nil, status.Errorf(codes.InvalidArgument, "resolve "+
 			"signing keys: %v", err)
 	}
-	if !containsSigningKey(signingKeys, r.server.clientKeyDesc.PubKey) {
+	identityDesc := r.server.loadClientKeyDesc()
+	if !containsSigningKey(signingKeys, identityDesc.PubKey) {
 		return nil, status.Errorf(codes.InvalidArgument, "daemon "+
 			"identity key is not required by spend path")
 	}
@@ -3887,7 +3905,7 @@ func (r *RPCServer) SignVTXOForfeit(ctx context.Context,
 
 	sigHashes := txscript.NewTxSigHashes(forfeitTx, prevFetcher)
 	signDesc := spendPath.SpendInfo.BuildSignDescriptor(
-		r.server.clientKeyDesc, vtxoOutput, sigHashes, prevFetcher,
+		identityDesc, vtxoOutput, sigHashes, prevFetcher,
 		arktx.ForfeitVTXOInputIndex,
 	)
 	sig, err := signer.SignOutputRaw(forfeitTx, signDesc)
@@ -3901,7 +3919,7 @@ func (r *RPCServer) SignVTXOForfeit(ctx context.Context,
 	}
 
 	return &waverpc.SignVTXOForfeitResponse{
-		Pubkey:    r.server.clientKeyDesc.PubKey.SerializeCompressed(),
+		Pubkey:    identityDesc.PubKey.SerializeCompressed(),
 		Signature: sig.Serialize(),
 	}, nil
 }

--- a/waved/rpc_server_test.go
+++ b/waved/rpc_server_test.go
@@ -986,6 +986,93 @@ func TestGetInfoIncludesServerInfo(t *testing.T) {
 	require.Equal(t, uint32(2), resp.ServerInfo.MinConfirmations)
 }
 
+// TestGetInfoUsesCachedIdentityKey verifies ordinary status reads do not
+// reopen key derivation after startup has already cached the stable daemon
+// identity. The wallet backend is deliberately absent: falling back to
+// deriveIdentityPubkey would fail and leave the response key empty.
+func TestGetInfoUsesCachedIdentityKey(t *testing.T) {
+	t.Parallel()
+
+	identityPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	server := &Server{
+		cfg: &Config{
+			Network: "regtest",
+			Wallet: &WalletConfig{
+				Type: WalletTypeLwwallet,
+			},
+		},
+		log: btclog.Disabled,
+	}
+	server.storeClientKeyDesc(keychain.KeyDescriptor{
+		PubKey: identityPriv.PubKey(),
+	})
+	r := &RPCServer{server: server}
+
+	resp, err := r.GetInfo(
+		context.Background(), &waverpc.GetInfoRequest{},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		fmt.Sprintf(
+			"%x", identityPriv.PubKey().SerializeCompressed(),
+		),
+		resp.IdentityPubkey,
+	)
+}
+
+// TestGetInfoSynchronizesCachedIdentityPublication verifies status requests
+// can read the cached identity while wallet startup publishes it. Repeatedly
+// publishing the same stable descriptor makes the startup/read overlap large
+// enough for the race detector to enforce the synchronization contract.
+func TestGetInfoSynchronizesCachedIdentityPublication(t *testing.T) {
+	t.Parallel()
+
+	identityPriv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	server := &Server{
+		cfg: &Config{
+			Network: "regtest",
+			Wallet: &WalletConfig{
+				Type: WalletTypeLwwallet,
+			},
+		},
+		log: btclog.Disabled,
+	}
+	identityDesc := keychain.KeyDescriptor{
+		PubKey: identityPriv.PubKey(),
+	}
+	server.storeClientKeyDesc(identityDesc)
+	r := &RPCServer{server: server}
+
+	const iterations = 1_000
+	start := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		<-start
+
+		for range iterations {
+			server.storeClientKeyDesc(identityDesc)
+		}
+	}()
+
+	close(start)
+	expectedKey := fmt.Sprintf("%x",
+		identityPriv.PubKey().SerializeCompressed())
+	for range iterations {
+		resp, err := r.GetInfo(
+			context.Background(), &waverpc.GetInfoRequest{},
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedKey, resp.IdentityPubkey)
+	}
+	<-done
+}
+
 // TestGetInfoFloorsMinVTXOAmountAtDust verifies GetInfo never exposes a
 // VTXO minimum below the cached dust limit.
 func TestGetInfoFloorsMinVTXOAmountAtDust(t *testing.T) {

--- a/waved/rpc_wallet.go
+++ b/waved/rpc_wallet.go
@@ -137,7 +137,8 @@ func (r *RPCServer) SignOutSwapHtlcAck(ctx context.Context,
 	if err := r.requireWalletReady(); err != nil {
 		return nil, err
 	}
-	if r.server.clientKeyDesc.PubKey == nil {
+	identityDesc := r.server.loadClientKeyDesc()
+	if identityDesc.PubKey == nil {
 		return nil, status.Error(
 			codes.FailedPrecondition, "identity key is not ready",
 		)
@@ -146,7 +147,7 @@ func (r *RPCServer) SignOutSwapHtlcAck(ctx context.Context,
 	var paymentHash lntypes.Hash
 	copy(paymentHash[:], req.GetPaymentHash())
 	msg := swaprpc.OutSwapHTLCAckMessage(
-		r.server.clientKeyDesc.PubKey, paymentHash, req.GetAmountSat(),
+		identityDesc.PubKey, paymentHash, req.GetAmountSat(),
 		req.GetVhtlcPkScript(),
 	)
 	sig, err := r.server.signTaggedSchnorr(
@@ -226,10 +227,11 @@ func (r *RPCServer) SignCreditAccountAuth(ctx context.Context,
 	if err := r.requireWalletReady(); err != nil {
 		return nil, err
 	}
-	if r.server.clientKeyDesc.PubKey == nil {
+	identityDesc := r.server.loadClientKeyDesc()
+	if identityDesc.PubKey == nil {
 		return nil, fmt.Errorf("identity key is not ready")
 	}
-	identityKey := r.server.clientKeyDesc.PubKey.SerializeCompressed()
+	identityKey := identityDesc.PubKey.SerializeCompressed()
 	if !bytes.Equal(accountKey, identityKey) {
 		return nil, errCreditAccountIdentityMismatch
 	}

--- a/waved/server.go
+++ b/waved/server.go
@@ -268,8 +268,14 @@ type Server struct {
 	// mode it is derived from the config's network string.
 	chainParams *chaincfg.Params
 
-	// clientKeyDesc is the client's identity key descriptor,
-	// derived during wallet initialization.
+	// clientKeyDescMu guards clientKeyDesc. GetInfo is callable while
+	// wallet startup derives the descriptor, so status reads and startup
+	// publication must synchronize even though all later consumers run
+	// after bootstrap.
+	clientKeyDescMu sync.RWMutex
+
+	// clientKeyDesc is the client's identity key descriptor, derived during
+	// wallet initialization.
 	clientKeyDesc keychain.KeyDescriptor
 
 	// localMailboxID caches the pubkey-derived mailbox ID for
@@ -476,6 +482,25 @@ func (s *Server) WalletLifecycleState() WalletState {
 // WalletType returns the configured wallet backend type string.
 func (s *Server) WalletType() string {
 	return s.cfg.Wallet.Type
+}
+
+// loadClientKeyDesc returns the identity descriptor most recently published
+// by wallet startup. The returned descriptor is a value copy whose public-key
+// pointer is immutable.
+func (s *Server) loadClientKeyDesc() keychain.KeyDescriptor {
+	s.clientKeyDescMu.RLock()
+	defer s.clientKeyDescMu.RUnlock()
+
+	return s.clientKeyDesc
+}
+
+// storeClientKeyDesc publishes the stable identity descriptor derived during
+// wallet startup so pre-ready status requests cannot race its initialization.
+func (s *Server) storeClientKeyDesc(desc keychain.KeyDescriptor) {
+	s.clientKeyDescMu.Lock()
+	defer s.clientKeyDescMu.Unlock()
+
+	s.clientKeyDesc = desc
 }
 
 // markWalletReady atomically stores WalletStateReady and closes the
@@ -3792,14 +3817,13 @@ func (s *Server) initRPCClients(ctx context.Context) {
 				err,
 			)
 		} else {
-			// clientKeyDesc is deliberately not written here.
+			// clientKeyDesc is deliberately not published here.
 			// deriveIdentityKeyEarly has already stored the
 			// descriptor for this exact locator, and it errors out
 			// rather than leaving the field unset, so this would
-			// only re-store the same value. It would also be a
-			// data race: StartEgress runs before this, and its
-			// workers now sign every outbound envelope, so they
-			// read clientKeyDesc while this goroutine writes it.
+			// only re-store the same value after StartEgress has
+			// begun using the descriptor to sign outbound
+			// envelopes.
 			signer = NewFallbackSchnorrSigner(
 				NewOwnedReceiveScriptSigner(
 					packageStore, signerFactory,
@@ -3811,9 +3835,8 @@ func (s *Server) initRPCClients(ctx context.Context) {
 
 	// The indexer principal is the client's pubkey-derived
 	// mailbox ID, used in proof-of-control signatures.
-	principal := serverconn.PubKeyMailboxID(
-		s.clientKeyDesc.PubKey,
-	)
+	identityDesc := s.loadClientKeyDesc()
+	principal := serverconn.PubKeyMailboxID(identityDesc.PubKey)
 
 	s.indexer = indexer.New(
 		s.runtime.Unary(), signer, indexerProofServerID, principal,
@@ -3966,9 +3989,8 @@ func (s *Server) connectAndBootstrapMailbox(ctx context.Context) error {
 	dispatchers, nonTxRoutes := s.buildRPCDispatchers(edge)
 
 	// Derive compound mailbox ID: operator:client.
-	s.localMailboxID = serverconn.PubKeyMailboxID(
-		s.clientKeyDesc.PubKey,
-	)
+	identityDesc := s.loadClientKeyDesc()
+	s.localMailboxID = serverconn.PubKeyMailboxID(identityDesc.PubKey)
 	operatorMBID := serverconn.PubKeyMailboxID(operatorPubKey)
 	remoteMailboxID := serverconn.CompoundMailboxID(
 		operatorMBID, s.localMailboxID,
@@ -4912,7 +4934,7 @@ func (s *Server) deriveIdentityKeyEarly(ctx context.Context) error {
 			return
 		}
 
-		s.clientKeyDesc = *desc
+		s.storeClientKeyDesc(*desc)
 		derived = true
 	})
 
@@ -4936,7 +4958,7 @@ func (s *Server) deriveIdentityKeyEarly(ctx context.Context) error {
 			return
 		}
 
-		s.clientKeyDesc = *desc
+		s.storeClientKeyDesc(*desc)
 		derived = true
 	})
 
@@ -4960,7 +4982,7 @@ func (s *Server) deriveIdentityKeyEarly(ctx context.Context) error {
 			return
 		}
 
-		s.clientKeyDesc = desc
+		s.storeClientKeyDesc(desc)
 		derived = true
 	})
 
@@ -4982,10 +5004,11 @@ func (s *Server) deriveIdentityKeyEarly(ctx context.Context) error {
 			"identity key")
 	}
 
+	identityDesc := s.loadClientKeyDesc()
 	s.log.InfoS(ctx, "Derived client identity key",
 		slog.String(
 			"mailbox_id", serverconn.PubKeyMailboxID(
-				s.clientKeyDesc.PubKey,
+				identityDesc.PubKey,
 			),
 		))
 
@@ -4999,8 +5022,9 @@ func (s *Server) deriveIdentityKeyEarly(ctx context.Context) error {
 func (s *Server) signMailboxAuth(ctx context.Context,
 	recipientMailboxID string) (*schnorr.Signature, error) {
 
+	identityDesc := s.loadClientKeyDesc()
 	msg := serverconn.MailboxAuthMessage(
-		s.clientKeyDesc.PubKey, recipientMailboxID,
+		identityDesc.PubKey, recipientMailboxID,
 	)
 	tag := []byte(serverconn.MailboxAuthTagStr)
 
@@ -5017,8 +5041,9 @@ func (s *Server) signMailboxAuth(ctx context.Context,
 func (s *Server) signMailboxTLSBind(ctx context.Context, tlsLeafSPKI []byte) (
 	*schnorr.Signature, error) {
 
+	identityDesc := s.loadClientKeyDesc()
 	msg := serverconn.MailboxTLSBindMessage(
-		s.clientKeyDesc.PubKey, tlsLeafSPKI,
+		identityDesc.PubKey, tlsLeafSPKI,
 	)
 	tag := []byte(serverconn.MailboxTLSBindTagStr)
 
@@ -5040,6 +5065,7 @@ func (s *Server) signTaggedSchnorr(ctx context.Context, msg, tag []byte,
 		sig *schnorr.Signature
 		err error
 	)
+	identityDesc := s.loadClientKeyDesc()
 
 	// In LND mode, use lnd's tagged Schnorr signing RPC. We pass the
 	// raw message and tag so LND computes the BIP-340 tagged hash
@@ -5047,7 +5073,7 @@ func (s *Server) signTaggedSchnorr(ctx context.Context, msg, tag []byte,
 	s.lnd.WhenSome(func(lndSvc *lndclient.GrpcLndServices) {
 		var rawSig []byte
 		rawSig, err = lndSvc.Signer.SignMessage(
-			ctx, msg, s.clientKeyDesc.KeyLocator,
+			ctx, msg, identityDesc.KeyLocator,
 			lndclient.SignSchnorr(nil), withSchnorrTag(tag),
 		)
 		if err != nil {
@@ -5098,8 +5124,9 @@ func (s *Server) signTaggedSchnorr(ctx context.Context, msg, tag []byte,
 func (s *Server) signTaggedSchnorrViaKeyRing(keyRing keychain.SecretKeyRing,
 	msg, tag []byte, opName string) (*schnorr.Signature, error) {
 
+	identityDesc := s.loadClientKeyDesc()
 	sig, err := keyRing.SignMessageSchnorr(
-		s.clientKeyDesc.KeyLocator, msg, false, nil, tag,
+		identityDesc.KeyLocator, msg, false, nil, tag,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("keyring sign %s: %w", opName, err)


### PR DESCRIPTION
## What changed

`GetInfo` now returns the daemon identity that startup already derived and
cached. It only derives the key itself when startup has not published the
cached value yet.

The cached descriptor is protected by a read/write lock because `GetInfo` can
run while wallet startup is publishing it. All production readers use the same
synchronized snapshot.

## Why

For btcwallet-backed wallets, deriving this key opens a wallet database write
transaction. Doing that for every status request could make a read-only
`GetInfo` call wait behind unrelated wallet work.

This matters to mobile clients because the receive readiness check calls
`GetInfo`. On a physical iPhone, the readiness stage dropped from a 20-second
timeout to 47.583 microseconds with this change.

The later timeout found in the receive authentication stage has a different
cause and is tracked in #1134. This PR remains a focused fix for status calls;
it does not claim to fix that separate wallet recovery stall.

## Safety

- The cached and fallback paths use the same stable key locator: identity key
  family, index 0.
- Requests made before publication keep the existing fallback behavior.
- The change does not alter mailbox identities, signatures, or wallet state.
- A race test covers identity publication while `GetInfo` is running.

Fixes #1132.

## Validation

- [x] `make fmt-changed-check base=origin/main`
- [x] `make tidy-module-check`
- [x] `make commitmsg-lint range='origin/main..HEAD'`
- [x] `make lint-changed-local base=origin/main`
- [x] `go test ./waved`
- [x] `go test -race ./waved`
- [x] `go test -tags='wavewalletrpc swapruntime' ./swapwallet`
- [x] Physical-device validation of the `GetInfo` readiness stage
