### PR TITLE
waved: authenticate outbound mailbox RPCs with the auth header

### DIFF
--- a/serverconn/mailbox_auth.go
+++ b/serverconn/mailbox_auth.go
@@ -43,8 +43,24 @@ const MailboxTLSBindTagStr = "mailbox-tls-bind"
 //
 //	senderCompressedPubKey || recipientMailboxID
 //
-// Including the recipient mailbox ID (the server's pubkey-derived ID)
-// prevents cross-server replay of the signature.
+// Including the recipient mailbox ID binds the signature to what it
+// addresses, but how much that buys depends on the caller, and only
+// Send gets the strong version:
+//
+//   - Send passes the compound operator:client recipient, which
+//     embeds the operator's pubkey-derived ID, so a Send signature is
+//     useless at any other operator.
+//   - Pull and AckUpTo pass the client's own plain mailbox ID
+//     (ingress.go, via ConnectorConfig.LocalMailboxID), which carries
+//     no operator component. That digest is identical at every
+//     operator, so one Pull/Ack signature authorizes that client's
+//     mailbox at every operator its identity key is known to. Identity
+//     keys are a deterministic derivation, so a wallet driving two
+//     operators presents the same credential to both.
+//
+// Do not read this function as preventing cross-server replay on its
+// own. Closing the Pull/Ack case means folding a server identity into
+// the digest, which is a wire change on both sides.
 func MailboxAuthMessage(senderPubKey *btcec.PublicKey,
 	recipientMailboxID string) []byte {
 

--- a/waved/outbound_clients.go
+++ b/waved/outbound_clients.go
@@ -110,8 +110,12 @@ func (s *Server) mailboxAuthSigner() serverconn.MailboxAuthSigner {
 // Memoizing is what makes signing per RPC affordable: the digest is
 // TaggedHash("mailbox-auth", identityPubKey || recipientMailboxID), so it does
 // not vary with the request, while signMailboxAuth costs a round-trip to
-// whichever wallet backend holds the key. The daemon addresses one recipient
-// mailbox in practice, so the map holds a single entry.
+// whichever wallet backend holds the key.
+//
+// The map holds two entries, not one. Send addresses the compound
+// operator:client mailbox, while Pull and AckUpTo address this client's own
+// plain mailbox ID, so the two arms sign different recipients and cache
+// separately. Keying on the recipient is what keeps them from colliding.
 func (s *Server) mailboxAuthSig(ctx context.Context,
 	recipientMailboxID string) (*schnorr.Signature, error) {
 

--- a/waved/outbound_clients.go
+++ b/waved/outbound_clients.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/lightninglabs/wavelength/arkrpc"
@@ -18,6 +19,12 @@ import (
 	"github.com/lightninglabs/wavelength/serverconn"
 	"google.golang.org/grpc"
 )
+
+// mailboxAuthSignTimeout bounds a single mailbox auth signing round trip to
+// the wallet backend. A mailbox RPC that cannot get its signature in this long
+// should fail on its own rather than hold the caller open, since the ingress
+// puller hands down a context with no deadline of its own.
+const mailboxAuthSignTimeout = 30 * time.Second
 
 // operatorClients holds the daemon-owned outbound clients used to talk to the
 // Ark operator directly and through the mailbox edge.
@@ -89,8 +96,13 @@ func (s *Server) connectOperatorClients() (*operatorClients, error) {
 }
 
 // mailboxAuthSigner returns the signer that stamps x-mailbox-auth-sig on
-// outbound mailbox RPCs. It reads the identity key lazily, per RPC, because
-// the mailbox edge is built before the wallet has derived one.
+// outbound mailbox RPCs.
+//
+// The identity key is read per RPC rather than captured at construction.
+// deriveIdentityKeyEarly runs before connectOperatorClients and fails the
+// startup path if it cannot derive, so the key is in fact already there by
+// the time the edge is built; reading it late costs nothing and keeps this
+// closure from pinning a descriptor that startup has not finished with.
 func (s *Server) mailboxAuthSigner() serverconn.MailboxAuthSigner {
 	return func(ctx context.Context, recipientMailboxID string) (string,
 		error) {
@@ -116,6 +128,16 @@ func (s *Server) mailboxAuthSigner() serverconn.MailboxAuthSigner {
 // operator:client mailbox, while Pull and AckUpTo address this client's own
 // plain mailbox ID, so the two arms sign different recipients and cache
 // separately. Keying on the recipient is what keeps them from colliding.
+//
+// The wallet call deliberately happens with the mutex released. Holding it
+// across the round trip would serialize the whole mailbox edge behind one
+// signature: sync.Mutex.Lock is not context-aware, so the egress workers and
+// the ingress puller would block on it with their own deadlines silently
+// ignored, and a wedged wallet would stall egress, ingress, heartbeat and ack
+// together with nothing in the logs to say why. Two callers racing the same
+// cold recipient may both sign, which is harmless — the digest is
+// deterministic, so they produce the same signature and the second store is a
+// no-op.
 func (s *Server) mailboxAuthSig(ctx context.Context,
 	recipientMailboxID string) (*schnorr.Signature, error) {
 
@@ -125,19 +147,30 @@ func (s *Server) mailboxAuthSig(ctx context.Context,
 	}
 
 	s.mailboxAuthSigsMu.Lock()
-	defer s.mailboxAuthSigsMu.Unlock()
+	sig, ok := s.mailboxAuthSigs[recipientMailboxID]
+	s.mailboxAuthSigsMu.Unlock()
 
-	if sig, ok := s.mailboxAuthSigs[recipientMailboxID]; ok {
+	if ok {
 		return sig, nil
 	}
 
-	sig, err := s.signMailboxAuth(ctx, recipientMailboxID)
+	// Bound the signing round trip rather than inheriting the caller's
+	// context. The ingress puller builds its context with no deadline at
+	// all, so a hung wallet would otherwise park this call forever, and
+	// the memo miss is on the path every Pull takes.
+	signCtx, cancel := context.WithTimeout(ctx, mailboxAuthSignTimeout)
+	defer cancel()
+
+	sig, err := s.signMailboxAuth(signCtx, recipientMailboxID)
 	if err != nil {
 		return nil, err
 	}
 
+	s.mailboxAuthSigsMu.Lock()
+	defer s.mailboxAuthSigsMu.Unlock()
+
 	if s.mailboxAuthSigs == nil {
-		s.mailboxAuthSigs = make(map[string]*schnorr.Signature, 1)
+		s.mailboxAuthSigs = make(map[string]*schnorr.Signature, 2)
 	}
 	s.mailboxAuthSigs[recipientMailboxID] = sig
 

--- a/waved/outbound_clients.go
+++ b/waved/outbound_clients.go
@@ -1,13 +1,16 @@
 package waved
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"os"
 	"strings"
 
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/lightninglabs/wavelength/arkrpc"
 	mailboxpb "github.com/lightninglabs/wavelength/mailbox/pb"
 	"github.com/lightninglabs/wavelength/rpc/restclient"
@@ -27,7 +30,16 @@ type operatorClients struct {
 
 // connectOperatorClients builds the outbound clients for the configured
 // operator transport.
+//
+// Both mailbox edges are wrapped so every Send, Pull and AckUpTo carries the
+// x-mailbox-auth-sig metadata header. The operator authorizes a mailbox RPC
+// either from the TLS client certificate bound to the caller's mailbox ID or
+// from that header, and an operator that terminates TLS at a proxy never sees
+// a client certificate. Signing unconditionally means the daemon works against
+// either posture without the operator's TLS choice leaking into client config.
 func (s *Server) connectOperatorClients() (*operatorClients, error) {
+	sign := s.mailboxAuthSigner()
+
 	switch s.cfg.Server.Transport {
 	case "", RPCTransportGRPC:
 		conn, err := s.dialServer()
@@ -36,9 +48,11 @@ func (s *Server) connectOperatorClients() (*operatorClients, error) {
 		}
 
 		return &operatorClients{
-			conn:    conn,
-			ark:     arkrpc.NewArkServiceClient(conn),
-			mailbox: mailboxpb.NewMailboxServiceClient(conn),
+			conn: conn,
+			ark:  arkrpc.NewArkServiceClient(conn),
+			mailbox: serverconn.NewAuthenticatedMailboxClient(
+				mailboxpb.NewMailboxServiceClient(conn), sign,
+			),
 			cleanup: conn.Close,
 		}, nil
 
@@ -59,8 +73,11 @@ func (s *Server) connectOperatorClients() (*operatorClients, error) {
 			ark: restclient.NewArkServiceClientFromClient(
 				transport,
 			),
-			mailbox: restclient.NewMailboxServiceClientFromClient(
-				transport,
+			mailbox: serverconn.NewAuthenticatedMailboxClient(
+				restclient.NewMailboxServiceClientFromClient(
+					transport,
+				),
+				sign,
 			),
 			cleanup: func() error { return nil },
 		}, nil
@@ -69,6 +86,58 @@ func (s *Server) connectOperatorClients() (*operatorClients, error) {
 		return nil, fmt.Errorf("unknown server transport %q",
 			s.cfg.Server.Transport)
 	}
+}
+
+// mailboxAuthSigner returns the signer that stamps x-mailbox-auth-sig on
+// outbound mailbox RPCs. It reads the identity key lazily, per RPC, because
+// the mailbox edge is built before the wallet has derived one.
+func (s *Server) mailboxAuthSigner() serverconn.MailboxAuthSigner {
+	return func(ctx context.Context, recipientMailboxID string) (string,
+		error) {
+
+		sig, err := s.mailboxAuthSig(ctx, recipientMailboxID)
+		if err != nil {
+			return "", err
+		}
+
+		return hex.EncodeToString(sig.Serialize()), nil
+	}
+}
+
+// mailboxAuthSig returns the mailbox auth signature for recipientMailboxID,
+// signing once per recipient and serving every later call from memory.
+//
+// Memoizing is what makes signing per RPC affordable: the digest is
+// TaggedHash("mailbox-auth", identityPubKey || recipientMailboxID), so it does
+// not vary with the request, while signMailboxAuth costs a round-trip to
+// whichever wallet backend holds the key. The daemon addresses one recipient
+// mailbox in practice, so the map holds a single entry.
+func (s *Server) mailboxAuthSig(ctx context.Context,
+	recipientMailboxID string) (*schnorr.Signature, error) {
+
+	if s.clientKeyDesc.PubKey == nil {
+		return nil, fmt.Errorf("identity key not yet derived; wallet " +
+			"not ready")
+	}
+
+	s.mailboxAuthSigsMu.Lock()
+	defer s.mailboxAuthSigsMu.Unlock()
+
+	if sig, ok := s.mailboxAuthSigs[recipientMailboxID]; ok {
+		return sig, nil
+	}
+
+	sig, err := s.signMailboxAuth(ctx, recipientMailboxID)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.mailboxAuthSigs == nil {
+		s.mailboxAuthSigs = make(map[string]*schnorr.Signature, 1)
+	}
+	s.mailboxAuthSigs[recipientMailboxID] = sig
+
+	return sig, nil
 }
 
 // serverClientTLSCerts returns the optional client certificate used by the

--- a/waved/outbound_clients.go
+++ b/waved/outbound_clients.go
@@ -124,10 +124,18 @@ func (s *Server) mailboxAuthSigner() serverconn.MailboxAuthSigner {
 // not vary with the request, while signMailboxAuth costs a round-trip to
 // whichever wallet backend holds the key.
 //
-// The map holds two entries, not one. Send addresses the compound
-// operator:client mailbox, while Pull and AckUpTo address this client's own
-// plain mailbox ID, so the two arms sign different recipients and cache
-// separately. Keying on the recipient is what keeps them from colliding.
+// There is one entry per distinct recipient, which is more than the operator
+// edge alone accounts for. That edge contributes two: Send addresses the
+// compound operator:client mailbox while Pull and AckUpTo address this
+// client's own plain mailbox ID, so the two arms sign different recipients and
+// must not collide. RPCServer.SignMailboxAuth also routes here, and the swap
+// edge behind it addresses a per-swap mailbox (client:payment_hash), so a
+// long-lived daemon accumulates one further entry per out-swap. Each is a
+// mailbox ID and a 64-byte signature and none is ever evicted, so the map
+// grows with swaps performed rather than staying at a fixed size. Bounding it
+// would need an eviction policy, which is not worth the machinery at the sizes
+// involved — but it is growth, not a constant, and a reader should know that
+// before assuming otherwise.
 //
 // The wallet call deliberately happens with the mutex released. Holding it
 // across the round trip would serialize the whole mailbox edge behind one

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -140,11 +140,9 @@ func (r *RPCServer) SignMailboxAuth(ctx context.Context,
 	if r == nil || r.server == nil {
 		return "", fmt.Errorf("daemon server unavailable")
 	}
-	if r.server.clientKeyDesc.PubKey == nil {
-		return "", fmt.Errorf("identity key not yet derived; wallet " +
-			"not ready")
-	}
 
+	// mailboxAuthSig makes the same "identity key not yet derived" check
+	// with the same error, so it is not repeated here.
 	sig, err := r.server.mailboxAuthSig(ctx, recipientMailboxID)
 	if err != nil {
 		return "", err

--- a/waved/rpc_server.go
+++ b/waved/rpc_server.go
@@ -130,6 +130,10 @@ func (r *RPCServer) SubLogger(tag string) btclog.Logger {
 // the daemon identity key bound to the recipient mailbox ID. Optional
 // subservers use this to authenticate mailbox RPCs without learning how the
 // daemon wallet backend stores or signs with the identity key.
+//
+// It goes through the memo rather than signing directly, so a subserver that
+// stamps every Send, Pull and AckUpTo costs one wallet round trip per
+// recipient rather than one per RPC.
 func (r *RPCServer) SignMailboxAuth(ctx context.Context,
 	recipientMailboxID string) (string, error) {
 
@@ -141,7 +145,7 @@ func (r *RPCServer) SignMailboxAuth(ctx context.Context,
 			"not ready")
 	}
 
-	sig, err := r.server.signMailboxAuth(ctx, recipientMailboxID)
+	sig, err := r.server.mailboxAuthSig(ctx, recipientMailboxID)
 	if err != nil {
 		return "", err
 	}

--- a/waved/server.go
+++ b/waved/server.go
@@ -2853,7 +2853,17 @@ func (s *Server) newMailboxEdge() mailboxpb.MailboxServiceClient {
 		return s.mailboxClient
 	}
 
-	base := mailboxpb.NewMailboxServiceClient(s.serverConn)
+	// A raw client here would reach the operator with no x-mailbox-auth-sig
+	// header, which is exactly what an operator running requiredirectauth
+	// rejects. connectOperatorClients already wraps the client it builds,
+	// and it runs before this on every production path, so this arm is
+	// latent today; wrapping it too means a future caller that reaches
+	// newMailboxEdge with no mailboxClient set cannot silently lose the
+	// header.
+	base := serverconn.NewAuthenticatedMailboxClient(
+		mailboxpb.NewMailboxServiceClient(s.serverConn),
+		s.mailboxAuthSigner(),
+	)
 	if s.cfg.MailboxEdgeFactory != nil {
 		return s.cfg.MailboxEdgeFactory(s.serverConn, base)
 	}

--- a/waved/server.go
+++ b/waved/server.go
@@ -3779,7 +3779,7 @@ func (s *Server) initRPCClients(ctx context.Context) {
 			err,
 		)
 	} else {
-		identityDesc, identitySigner, err := s.IndexerProofKey(
+		_, identitySigner, err := s.IndexerProofKey(
 			ctx, keychain.KeyLocator{
 				Family: identityKeyFamily,
 				Index:  0,
@@ -3792,7 +3792,14 @@ func (s *Server) initRPCClients(ctx context.Context) {
 				err,
 			)
 		} else {
-			s.clientKeyDesc = *identityDesc
+			// clientKeyDesc is deliberately not written here.
+			// deriveIdentityKeyEarly has already stored the
+			// descriptor for this exact locator, and it errors out
+			// rather than leaving the field unset, so this would
+			// only re-store the same value. It would also be a
+			// data race: StartEgress runs before this, and its
+			// workers now sign every outbound envelope, so they
+			// read clientKeyDesc while this goroutine writes it.
 			signer = NewFallbackSchnorrSigner(
 				NewOwnedReceiveScriptSigner(
 					packageStore, signerFactory,

--- a/waved/server.go
+++ b/waved/server.go
@@ -281,6 +281,17 @@ type Server struct {
 	// so response envelopes can include it without re-computing.
 	authSigHex string
 
+	// mailboxAuthSigsMu guards mailboxAuthSigs.
+	mailboxAuthSigsMu sync.Mutex
+
+	// mailboxAuthSigs memoizes the mailbox auth signature per
+	// recipient mailbox ID. The signed digest covers the identity
+	// key and the recipient and nothing else, so one signature
+	// stays valid for the life of the key; signing per RPC would
+	// put a wallet round-trip in front of every Pull on a
+	// long-poll loop.
+	mailboxAuthSigs map[string]*schnorr.Signature
+
 	// tlsLeafSPKI is the DER-encoded SubjectPublicKeyInfo of the
 	// P-256 client TLS leaf certificate this daemon dialed with.
 	// It is captured during dialServer and used to compute the
@@ -3947,8 +3958,10 @@ func (s *Server) connectAndBootstrapMailbox(ctx context.Context) error {
 	)
 
 	// Sign the Schnorr auth proving key ownership, bound to
-	// the compound recipient mailbox.
-	authSig, err := s.signMailboxAuth(ctx, remoteMailboxID)
+	// the compound recipient mailbox. This goes through the memo so
+	// the per-RPC signer installed on the mailbox edge serves the
+	// same signature from memory rather than signing a second time.
+	authSig, err := s.mailboxAuthSig(ctx, remoteMailboxID)
 	if err != nil {
 		return fmt.Errorf("sign mailbox auth: %w", err)
 	}

--- a/waved/server_outbound_clients_test.go
+++ b/waved/server_outbound_clients_test.go
@@ -353,6 +353,12 @@ func TestMailboxAuthSigMemo(t *testing.T) {
 	_, err = s.mailboxAuthSig(t.Context(), compound)
 	require.ErrorContains(t, err, "no wallet backend available")
 
+	// A failed sign caches nothing. Caching it would pin the failure for
+	// the life of the process, so every later RPC to that mailbox would
+	// fail without ever retrying the wallet.
+	require.Len(t, s.mailboxAuthSigs, 1)
+	require.NotContains(t, s.mailboxAuthSigs, compound)
+
 	// The miss must not have disturbed the entry that was already there.
 	got, err = s.mailboxAuthSig(t.Context(), plain)
 	require.NoError(t, err)

--- a/waved/server_outbound_clients_test.go
+++ b/waved/server_outbound_clients_test.go
@@ -1,15 +1,20 @@
 package waved
 
 import (
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/lightninglabs/wavelength/arkrpc"
 	mailboxpb "github.com/lightninglabs/wavelength/mailbox/pb"
 	"github.com/lightninglabs/wavelength/rpcauth"
+	"github.com/lightninglabs/wavelength/serverconn"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 	"gopkg.in/macaroon-bakery.v2/bakery"
@@ -38,6 +43,19 @@ func TestConnectOperatorClientsREST(t *testing.T) {
 	macHex, err := rpcauth.HexFromFile(macaroonPath)
 	require.NoError(t, err)
 
+	// Record the mailbox auth header the REST edge sent, guarded because
+	// the handler runs on the test server's goroutine.
+	var (
+		authSigMu  sync.Mutex
+		gotAuthSig string
+	)
+	pulledAuthSig := func() string {
+		authSigMu.Lock()
+		defer authSigMu.Unlock()
+
+		return gotAuthSig
+	}
+
 	server := httptest.NewServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -63,6 +81,12 @@ func TestConnectOperatorClientsREST(t *testing.T) {
 					)
 
 				case "/v1/mailbox/pull":
+					authSigMu.Lock()
+					gotAuthSig = r.Header.Get(
+						serverconn.AuthHeaderKey,
+					)
+					authSigMu.Unlock()
+
 					msg, marshalErr = protojson.Marshal(
 						&mailboxpb.PullResponse{},
 					)
@@ -81,6 +105,20 @@ func TestConnectOperatorClientsREST(t *testing.T) {
 	)
 	defer server.Close()
 
+	// The mailbox edge signs every call with the daemon identity key, so
+	// the fixture needs one. Priming the memo stands in for the wallet
+	// backend that would produce the signature in a running daemon.
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientMailbox := serverconn.CompoundMailboxID(
+		serverconn.PubKeyMailboxID(operatorKey.PubKey()),
+		serverconn.PubKeyMailboxID(clientKey.PubKey()),
+	)
+
+	authSig, err := serverconn.SignMailboxAuth(clientKey, clientMailbox)
+	require.NoError(t, err)
+
 	s := &Server{
 		cfg: &Config{
 			Server: &ServerConfig{
@@ -89,6 +127,12 @@ func TestConnectOperatorClientsREST(t *testing.T) {
 				Insecure:     true,
 				MacaroonPath: macaroonPath,
 			},
+		},
+		clientKeyDesc: keychain.KeyDescriptor{
+			PubKey: clientKey.PubKey(),
+		},
+		mailboxAuthSigs: map[string]*schnorr.Signature{
+			clientMailbox: authSig,
 		},
 	}
 
@@ -105,9 +149,18 @@ func TestConnectOperatorClientsREST(t *testing.T) {
 	require.Equal(t, operatorPubKey, info.Pubkey)
 
 	_, err = clients.mailbox.Pull(
-		t.Context(), &mailboxpb.PullRequest{},
+		t.Context(), &mailboxpb.PullRequest{
+			MailboxId: clientMailbox,
+		},
 	)
 	require.NoError(t, err)
+
+	// The operator authorizes Pull from this header when it has no client
+	// certificate to bind the caller to a mailbox, so the REST edge has to
+	// carry it rather than only the gRPC one.
+	require.Equal(
+		t, hex.EncodeToString(authSig.Serialize()), pulledAuthSig(),
+	)
 }
 
 // TestConnectOperatorClientsUnknownTransport rejects typoed config early.

--- a/waved/server_outbound_clients_test.go
+++ b/waved/server_outbound_clients_test.go
@@ -1,7 +1,9 @@
 package waved
 
 import (
+	"context"
 	"encoding/hex"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -16,6 +18,8 @@ import (
 	"github.com/lightninglabs/wavelength/serverconn"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 )
@@ -160,6 +164,115 @@ func TestConnectOperatorClientsREST(t *testing.T) {
 	// carry it rather than only the gRPC one.
 	require.Equal(
 		t, hex.EncodeToString(authSig.Serialize()), pulledAuthSig(),
+	)
+}
+
+// mailboxAuthCapture is a stub MailboxService that records the mailbox auth
+// metadata each inbound RPC carried, standing in for the operator's mailbox
+// edge. The mutex is load bearing: gRPC serves the handler on its own
+// goroutine, so the assertion below reads what the handler wrote.
+type mailboxAuthCapture struct {
+	mailboxpb.UnimplementedMailboxServiceServer
+
+	mu      sync.Mutex
+	authSig string
+}
+
+// Pull records the x-mailbox-auth-sig header the caller sent.
+func (m *mailboxAuthCapture) Pull(ctx context.Context,
+	_ *mailboxpb.PullRequest) (*mailboxpb.PullResponse, error) {
+
+	md, _ := metadata.FromIncomingContext(ctx)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if values := md.Get(serverconn.AuthHeaderKey); len(values) > 0 {
+		m.authSig = values[0]
+	}
+
+	return &mailboxpb.PullResponse{}, nil
+}
+
+// pulledAuthSig returns the header recorded by the last Pull.
+func (m *mailboxAuthCapture) pulledAuthSig() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.authSig
+}
+
+// TestConnectOperatorClientsGRPC verifies the gRPC mailbox edge stamps
+// x-mailbox-auth-sig on outbound RPCs, the same property the REST test asserts
+// for the gateway transport. An operator that terminates TLS at a proxy has no
+// client certificate to authorize Pull with, so the header is the only thing
+// standing between this daemon and a rejected mailbox RPC.
+func TestConnectOperatorClientsGRPC(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	capture := &mailboxAuthCapture{}
+	operator := grpc.NewServer()
+	mailboxpb.RegisterMailboxServiceServer(operator, capture)
+
+	go func() {
+		_ = operator.Serve(listener)
+	}()
+	t.Cleanup(operator.Stop)
+
+	// The mailbox edge signs every call with the daemon identity key, so
+	// the fixture needs one. Priming the memo stands in for the wallet
+	// backend that would produce the signature in a running daemon.
+	operatorKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	clientMailbox := serverconn.CompoundMailboxID(
+		serverconn.PubKeyMailboxID(operatorKey.PubKey()),
+		serverconn.PubKeyMailboxID(clientKey.PubKey()),
+	)
+
+	authSig, err := serverconn.SignMailboxAuth(clientKey, clientMailbox)
+	require.NoError(t, err)
+
+	s := &Server{
+		cfg: &Config{
+			Server: &ServerConfig{
+				Host:      listener.Addr().String(),
+				Transport: RPCTransportGRPC,
+				Insecure:  true,
+			},
+		},
+		clientKeyDesc: keychain.KeyDescriptor{
+			PubKey: clientKey.PubKey(),
+		},
+		mailboxAuthSigs: map[string]*schnorr.Signature{
+			clientMailbox: authSig,
+		},
+	}
+
+	clients, err := s.connectOperatorClients()
+	require.NoError(t, err)
+	require.NotNil(t, clients.ark)
+	require.NotNil(t, clients.mailbox)
+	t.Cleanup(func() {
+		require.NoError(t, clients.cleanup())
+	})
+
+	_, err = clients.mailbox.Pull(
+		t.Context(), &mailboxpb.PullRequest{
+			MailboxId: clientMailbox,
+		},
+	)
+	require.NoError(t, err)
+
+	require.Equal(
+		t, hex.EncodeToString(authSig.Serialize()),
+		capture.pulledAuthSig(),
 	)
 }
 

--- a/waved/server_outbound_clients_test.go
+++ b/waved/server_outbound_clients_test.go
@@ -116,8 +116,12 @@ func TestConnectOperatorClientsREST(t *testing.T) {
 	require.NoError(t, err)
 
 	clientMailbox := serverconn.CompoundMailboxID(
-		serverconn.PubKeyMailboxID(operatorKey.PubKey()),
-		serverconn.PubKeyMailboxID(clientKey.PubKey()),
+		serverconn.PubKeyMailboxID(
+			operatorKey.PubKey(),
+		),
+		serverconn.PubKeyMailboxID(
+			clientKey.PubKey(),
+		),
 	)
 
 	authSig, err := serverconn.SignMailboxAuth(clientKey, clientMailbox)
@@ -163,7 +167,11 @@ func TestConnectOperatorClientsREST(t *testing.T) {
 	// certificate to bind the caller to a mailbox, so the REST edge has to
 	// carry it rather than only the gRPC one.
 	require.Equal(
-		t, hex.EncodeToString(authSig.Serialize()), pulledAuthSig(),
+		t,
+		hex.EncodeToString(
+			authSig.Serialize(),
+		),
+		pulledAuthSig(),
 	)
 }
 
@@ -232,8 +240,12 @@ func TestConnectOperatorClientsGRPC(t *testing.T) {
 	require.NoError(t, err)
 
 	clientMailbox := serverconn.CompoundMailboxID(
-		serverconn.PubKeyMailboxID(operatorKey.PubKey()),
-		serverconn.PubKeyMailboxID(clientKey.PubKey()),
+		serverconn.PubKeyMailboxID(
+			operatorKey.PubKey(),
+		),
+		serverconn.PubKeyMailboxID(
+			clientKey.PubKey(),
+		),
 	)
 
 	authSig, err := serverconn.SignMailboxAuth(clientKey, clientMailbox)
@@ -271,7 +283,10 @@ func TestConnectOperatorClientsGRPC(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(
-		t, hex.EncodeToString(authSig.Serialize()),
+		t,
+		hex.EncodeToString(
+			authSig.Serialize(),
+		),
 		capture.pulledAuthSig(),
 	)
 }
@@ -291,4 +306,60 @@ func TestConnectOperatorClientsUnknownTransport(t *testing.T) {
 
 	_, err := s.connectOperatorClients()
 	require.ErrorContains(t, err, "unknown server transport")
+}
+
+// TestMailboxAuthSigMemo covers the memo behaviour the two wiring tests above
+// deliberately skip past. Both of those prime the map, so a memo hit is all
+// they ever exercise; this drives the miss as well, which is the path every
+// first Pull takes on a live daemon.
+//
+// There is no seam to inject a signer — signTaggedSchnorr dispatches on the
+// concrete wallet backends — so a miss is observed through the error a Server
+// with no backend returns. That is enough to prove which recipients hit and
+// which miss, which is the property the compound-vs-plain split rests on.
+func TestMailboxAuthSigMemo(t *testing.T) {
+	t.Parallel()
+
+	clientKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	const (
+		plain    = "02aa"
+		compound = "02bb:02aa"
+	)
+
+	primed, err := serverconn.SignMailboxAuth(clientKey, plain)
+	require.NoError(t, err)
+
+	s := &Server{
+		clientKeyDesc: keychain.KeyDescriptor{
+			PubKey: clientKey.PubKey(),
+		},
+		mailboxAuthSigs: map[string]*schnorr.Signature{
+			plain: primed,
+		},
+	}
+
+	// The primed recipient is served from memory. No wallet backend is
+	// configured, so reaching the signing path at all would error.
+	got, err := s.mailboxAuthSig(t.Context(), plain)
+	require.NoError(t, err)
+	require.Same(t, primed, got)
+
+	// A different recipient is a distinct digest and therefore a distinct
+	// entry: it misses and goes to the wallet rather than being answered
+	// with the first recipient's signature. Serving the wrong signature
+	// here would authorize the wrong mailbox at the operator.
+	_, err = s.mailboxAuthSig(t.Context(), compound)
+	require.ErrorContains(t, err, "no wallet backend available")
+
+	// The miss must not have disturbed the entry that was already there.
+	got, err = s.mailboxAuthSig(t.Context(), plain)
+	require.NoError(t, err)
+	require.Same(t, primed, got)
+
+	// An unset identity key is refused before any of that.
+	empty := &Server{}
+	_, err = empty.mailboxAuthSig(t.Context(), plain)
+	require.ErrorContains(t, err, "identity key not yet derived")
 }


### PR DESCRIPTION
## What this does

The operator authorizes a mailbox RPC one of two ways: from the TLS client
certificate bound to the caller's mailbox ID at registration, or from the
`x-mailbox-auth-sig` metadata header (`verifyMailboxMetadataAuth`). An operator
that terminates TLS at a load balancer never sees a client certificate, so the
header is the only path left, and lumos is adding the knob that requires it
(lightninglabs/lumos#780).

We send that header on exactly one transport today, and it is the wrong one.
`NewAuthenticatedMailboxClient` wraps the swap server edge in
`swapclientserver/service.go`, while the operator edge this daemon actually
talks Ark over is built raw in `connectOperatorClients`: the gRPC arm
(`outbound_clients.go:41`) and the REST arm (`:62`) both hand back an unwrapped
client, and `dialServer` installs only the metrics interceptors.

The signature we *do* compute (`server.go:3474`) goes into **envelope headers**,
which is the first-contact `Send` proof the server verifies in
`HandleUnknownClient` during registration. That is a different mechanism from
the per-RPC gRPC metadata the interceptor reads. `Pull` and `AckUpTo` carried
nothing.

This PR wraps both operator arms so every `Send`, `Pull` and `AckUpTo` carries
the header.

## Why sign unconditionally

Signing is not keyed off the operator's TLS posture. The server checks the
header first and still falls through to the certificate binding when no header
is present, so a client that always signs works against either deployment shape
without having to learn which one it is talking to. Making it conditional would
put the operator's TLS choice into client config for no gain.

## Why memoize

The digest is `TaggedHash("mailbox-auth", identityPubKey || recipientMailboxID)`
and covers nothing request-specific, so one signature stays valid for the life
of the key. `signMailboxAuth` costs a round trip to whichever wallet backend
holds that key, so signing per call would put a wallet round trip in front of
every `Pull` on a long-poll loop.

The runtime setup path now takes the same memo, so the two signatures it and the
edge would otherwise compute for the same recipient collapse to one. The daemon
addresses one recipient mailbox in practice, so the map holds a single entry.

## Sequencing

**This has to land and roll out before an operator sets
`mailbox.requiredirectauth`.** That knob rejects any mailbox RPC that no TLS
binding and no valid header authorizes, and `isMailboxRPC` covers all three
methods, so an operator who set it against a client built before this PR would
reject every mailbox call its own clients make. `mailbox.allowdirectauth` is the
staging step: it authenticates the clients that sign and changes nothing for the
ones that do not.

## Verification

- `go build ./waved/... ./serverconn/...`, `go vet ./waved/` — clean. (`go build
  ./...` reports `function main is undeclared in the main package` for the repo
  root both with and without this change; confirmed pre-existing by stashing.)
- `go test ./waved/ ./serverconn/ -count=1` — pass, and `-race` on the
  `TestConnectOperatorClients` cases.

`TestConnectOperatorClientsREST` needed updating: it called `Pull` with an empty
`PullRequest`, which the wrapper now rejects with "mailbox recipient is
required" before dialing. It now addresses a real compound mailbox, primes the
memo to stand in for the wallet backend, and additionally asserts the header
actually reached the server — so it covers the REST arm rather than only
proving the transport is wired.

## Context

- lightninglabs/lumos#780 — the daemon-side knob this makes usable
- lightninglabs/lightning-infra#3265 — the deployment topology behind it
